### PR TITLE
docs(apps): a <form> in an app frame never submits, so say so

### DIFF
--- a/assistant/src/config/bundled-skills/app-builder/SKILL.md
+++ b/assistant/src/config/bundled-skills/app-builder/SKILL.md
@@ -325,9 +325,35 @@ To reach daemon capabilities, import from `@vellumai/plugin-api` — `publishEve
 
 - **Feedback for every action** — a toast or inline confirmation after creates, deletes, updates, errors. Build your own (e.g. toggle the `.v-toast` class with JS).
 - **Confirm destructive actions** — render your own confirmation (an inline "Are you sure?" or a modal) before deleting or resetting.
-- **Validate forms** before submit, show errors inline, disable submit during async.
+- **Validate forms** before submit, show errors inline, disable submit during async — but wire the submit with `onClick`, never a `<form>` (see below).
 - **Loading states** — skeleton or spinner, never a blank screen.
 - **Designed empty states** — `.v-empty-state` when there's no data.
+
+### `<form>` submission is blocked — use `onClick`
+
+The app frame runs under `sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox"`. There is no `allow-forms`, so the browser blocks every `<form>` submission and **the `onSubmit` handler never runs**. Nothing throws, nothing renders an error, and no test fails — the only trace is a console line the user never sees:
+
+```
+Blocked form submission to '' because the form's frame is sandboxed and the 'allow-forms' permission is not set.
+```
+
+A Save button written the ordinary way is therefore inert. Wire the action to the button's `onClick`, and put keyboard submit back with an Enter handler on the inputs — that is all the `<form>` was buying:
+
+```tsx
+<input
+  value={name}
+  onInput={(e) => setName(e.currentTarget.value)}
+  onKeyDown={(e) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      save();
+    }
+  }}
+/>
+<button type="button" onClick={save} disabled={busy}>Save</button>
+```
+
+Group the fields with a `<div>`, not a `<form>`. If you keep a `<form>` for semantics, give the button `type="button"` so it can never try to submit.
 
 ### Keep the assistant aware
 

--- a/skills/plugin-builder/references/apps.md
+++ b/skills/plugin-builder/references/apps.md
@@ -51,6 +51,32 @@ App discovery mirrors the plugin loader's own scan, so an app is visible on exac
 
 This reference covers how an app is packaged, compiled, and served as a plugin surface. The _authoring_ contract for the app itself — the design system and `--v-*` tokens, the widget library, responsive rules, the `window.vellum` bridge (`fetch`, `asset`, `subscribe`, `sendAction`), and how an app reaches backend data through routes — is owned by the **app-builder** skill, with design quality delegated to **frontend-design**. Build the app's UI by those skills, then drop the resulting `src/` under your plugin's `apps/`. A plugin that also ships `routes/` can back its app's data with its own namespaced HTTP routes (see [routes.md](routes.md)) — the app reaches them through `window.vellum.fetch` at `/x/plugins/<name>/…` (the wrapper prepends the `/v1` API prefix), **never the global `fetch`**, which fails from the app's sandboxed origin.
 
+### The sandbox an app runs in
+
+The host renders the app in an iframe sandboxed as `allow-scripts allow-popups allow-popups-to-escape-sandbox`. Those three tokens are the whole grant: scripts run, `window.open` works, and a popup escapes the sandbox — everything else the attribute gates is denied, including the same origin (which is why raw `fetch` fails above).
+
+The denial that bites hardest is `allow-forms`. **A `<form>` inside an app cannot submit: the browser blocks the submission and the `onSubmit` handler never runs.** There is no exception, no UI error, and no failing test — only a console line the user never sees:
+
+```
+Blocked form submission to '' because the form's frame is sandboxed and the 'allow-forms' permission is not set.
+```
+
+So an ordinary `<form onSubmit={save}>` with a `<button type="submit">` ships a Save button that does nothing. Wire the action to the button's `onClick` instead, and restore keyboard submit with an Enter handler on the inputs — that is what the form element was actually buying:
+
+```tsx
+<input
+  value={name}
+  onInput={(e) => setName(e.currentTarget.value)}
+  onKeyDown={(e) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      save();
+    }
+  }}
+/>
+<button type="button" onClick={save}>Save</button>
+```
+
 ## Anatomy of an app
 
 ```


### PR DESCRIPTION
## The failure

An app renders in an iframe the host sandboxes as:

```
sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox"
```

(`clients/web/src/components/app-viewer-container.tsx:22` for the workspace panel, and `clients/web/src/domains/chat/components/surfaces/dynamic-page-surface.tsx:241` for the chat surface.)

Note what is absent: **`allow-forms`**. So a `<form>` inside an app cannot submit. The browser blocks the submission outright and **the `onSubmit` handler never runs**. Nothing throws, nothing renders an error, no test fails. The only evidence is a console line the user will never see:

```
Blocked form submission to '' because the form's frame is sandboxed and the 'allow-forms' permission is not set.
```

An author writing ordinary React — `<form onSubmit={save}>` with a `<button type="submit">` — ships a Save button that does nothing at all.

**This was hit in practice.** It made every Save button in a setup wizard inert, and took a console inspection to diagnose, because there was no other symptom anywhere.

The docs made it worse, not better: `SKILL.md` already told authors to "**Validate forms** before submit, show errors inline, disable submit during async" — actively steering them into the broken pattern.

## The fix

Documentation only. No runtime code changed, and the sandbox attribute is untouched — the tokens are correct, they just were not written down anywhere an app author would look.

The working pattern is to put the action on the button's `onClick` and restore keyboard submit with an Enter handler on the inputs, since that is what the `<form>` element was actually buying.

## Where it goes

Two places, because two different audiences hit it:

- **`assistant/src/config/bundled-skills/app-builder/SKILL.md`** — the real owner. This skill holds the authoring contract, and its *Interaction standards* section was the thing recommending forms. A new subsection states the sandbox grant, the silent block, and the pattern; the existing forms bullet now points at it.
- **`skills/plugin-builder/references/apps.md`** — a plugin author reading only this file would never reach the app-builder skill. Its *frontend contract* section already carries the sibling caveat from the same sandbox (use `window.vellum.fetch`, "never the global `fetch`, which fails from the app's sandboxed origin"). The new note sits directly after it and also writes down the three sandbox tokens in one place, since `allow-popups` behaviour is already relied on by `clients/web/src/utils/sandbox-bridge.ts`.

No new skill, no new file.

## Note on ownership

`apps.md` describes the app-builder skill as external to this reference. It is not external to the repo — it lives at `assistant/src/config/bundled-skills/app-builder/`, not under `skills/`, which is why it does not turn up in a `skills/` search. It is the correct primary home for this, and that is where the fuller version of the note went.

## Verification

- `bun test src/__tests__/app-builder-skill-instructions.test.ts` — 3 pass.
- Prettier accepts both files (the pre-commit format hook passed).
- Reference implementation of the pattern: `Button` / `Field` with an `onEnter` prop, wired through a setup wizard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40920" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->