### PR TITLE
fix(config): let memory retrospectives use their model's real context window

### DIFF
--- a/assistant/src/__tests__/llm-resolver-override-or-default.test.ts
+++ b/assistant/src/__tests__/llm-resolver-override-or-default.test.ts
@@ -267,6 +267,24 @@ describe("shipped call-site tuning", () => {
     expect(resolved.contextWindow.maxInputTokens).toBe(1000000);
   });
 
+  test("the retrospective keeps its shipped budget through a repoint", () => {
+    const resolved = resolveCallSiteConfig(
+      "memoryRetrospective",
+      LLMSchema.parse({
+        profiles: { mine: completeCustom },
+        callSites: { memoryRetrospective: { profile: "mine" } },
+        ...anthropicDp,
+      }),
+    );
+    // A retrospective's input is larger than the source turn it reviews, so
+    // its ceiling is call-site-owned: a profile naming the generic default
+    // must not pull the call site back down to it.
+    expect(resolved.contextWindow.maxInputTokens).toBe(1000000);
+    expect(resolved.contextWindow.maxInputTokens).toBeGreaterThan(
+      schemaBase.contextWindow.maxInputTokens,
+    );
+  });
+
   test("an explicit workspace field beats the shipped one, field by field", () => {
     const resolved = resolveCallSiteConfig(
       "recall",

--- a/assistant/src/config/call-site-defaults.ts
+++ b/assistant/src/config/call-site-defaults.ts
@@ -74,7 +74,15 @@ export const CALL_SITE_DEFAULTS: Record<LLMCallSite, CallSiteDefaultConfig> = {
   filingAgent: { profile: "cost-optimized" },
   memoryExtraction: { profile: "cost-optimized" },
   memoryRetrieval: { profile: "cost-optimized" },
-  memoryRetrospective: { profile: "cost-optimized" },
+  // A retrospective sends the forked conversation plus its review
+  // instruction, dedup list, and the source's full tool surface, so its input
+  // is strictly larger than the turn the source last fit into the same
+  // budget. The resolver clamps this to the model's catalogued window, so an
+  // uncatalogued model keeps the conservative default.
+  memoryRetrospective: {
+    profile: "cost-optimized",
+    contextWindow: { maxInputTokens: 1000000 },
+  },
   memoryV2Migration: { profile: "cost-optimized" },
   memoryV2Sweep: { profile: "cost-optimized" },
   memoryV2Consolidation: { profile: "balanced" },


### PR DESCRIPTION
## TL;DR

Memory retrospectives were capped at a 200k context ceiling while the model they run on carries a 1.04M window. That cap is on the call site whose input is structurally the largest in the system, and when it is exceeded the run fails permanently with no recovery. This raises the ceiling for that one call site.

**This adds headroom, not a bound.** The retrospective payload is still unbounded. See "What this does not fix".

## Why the cap bites here specifically

A retrospective forks a conversation and sends that history plus its review instruction, the dedup list, and (deliberately, for provider cache parity) the source's full tool surface. Its input is therefore **strictly larger than the turn the source itself last fit**, against the same ceiling.

The arithmetic:

| | |
|---|---|
| Source compacts at `compactThreshold` 0.8 | runs to ~160k of its 200k budget |
| Retrospective inherits that tail | plus instruction, dedup list, tool surface, system prompt |
| Both measured against | the same 200k |
| Margin | ~40k, and that is the whole of it |

When the margin runs out there is no recovery on this path. Retrospectives pass `suppressAutoCompaction: true` (the fork is throwaway, so a summarization call on it is wasted spend), and every wake disables the in-loop budget gate and the overflow-recovery ladder because the wake's tail accounting holds external indexes into the returned history. The pre-run compaction gate is the only repair, and this call site opts out of it. The result is a deterministic `reason: "context_overflow"`, and because finalization is fail-closed the cursor never advances, so the same window is retried and fails identically forever.

## Why this is safe

- The resolver clamps with `Math.min(callSite, modelMaxInputTokens)`, so the model's catalogued window governs. An uncatalogued model (any custom-endpoint BYOK pin) falls back to 200k and is **unchanged**.
- 1000000 sits under the model's 1.04M total with room for the profile's 8192-token output budget.
- A model with a smaller real window still clamps down to it, so no pin can be pushed above what it supports.
- `isLongContextEnabled` is a derived reporting field with no non-test consumers, so nothing gates or reprices on it.
- The call-site `contextWindow` seam already exists in the type and is already used by `memoryRouter`. I verified the value independently rather than inheriting it from that precedent.

## What changes for you

| Before | After |
|---|---|
| Retrospectives on a long conversation fail silently and permanently; derived memory stops forming from that point on | They keep running until the conversation is roughly five times longer |
| The failure looks like a bug that started on Aug 10 | It is older than that (see below); only the recording of it started then |
| A BYOK custom-endpoint pin | Unchanged |

## What this does not fix, and why

**The unbounded payload.** Raising the ceiling five times over adds headroom; it does not add a bound. A long enough conversation reaches the same wall, later and more quietly. Fixing that means either bounding what the fork carries or letting it compact, and both are real design decisions about spend and fidelity that should not ride along on a config value. Deliberately left open.

**Not a regression from Aug 10.** Failures appeared to begin then, but the trigger was #39914 (fail-closed finalization), which made the worker honor a handler's returned outcome instead of completing every row unconditionally. `wake_failed` is a returned outcome, not a throw, so before that change these same failures recorded as `completed`. The class predates the queue data that shows it.

**Deferred, filed or filing separately:** no alerting on sustained retrospective failure (the highest-leverage gap here; this ran at a 15 to 77 percent daily failure rate for six weeks with nothing surfacing it), and the SQLite lock and timeout failure class, which is unrelated and already has an unused shipped mitigation in `forkStrategy: "reference"`.

## Testing

Typecheck and lint clean. Added a regression test asserting the ceiling is call-site-owned, so a profile repoint cannot silently pull it back down to the generic default. Full suite runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40926" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->