### PR TITLE
fix(web-search): read Keenable page text from snippet, not description

### DIFF
--- a/assistant/src/tools/network/__tests__/web-search.test.ts
+++ b/assistant/src/tools/network/__tests__/web-search.test.ts
@@ -797,7 +797,8 @@ describe("web_search tool", () => {
             {
               title: "Keenable Result 1",
               url: "https://example.com/keenable-1",
-              description: "First Keenable result",
+              description: "",
+              snippet: "First Keenable result",
             },
           ],
         }),
@@ -812,6 +813,45 @@ describe("web_search tool", () => {
     expect(capturedHeaders.get("x-keenable-title")).toBe("Vellum Assistant");
     expect(result.content).toContain("Keenable Result 1");
     expect(result.content).toContain("https://example.com/keenable-1");
+  });
+
+  test("Keenable reads the page text from snippet, capped", async () => {
+    seedWebSearch("your-own", "keenable");
+    globalThis.fetch = (async () => {
+      return new Response(
+        JSON.stringify({
+          results: [
+            {
+              title: "Wrapped",
+              url: "https://example.com/wrapped",
+              description: "",
+              snippet: "line one\n\nline two",
+            },
+            {
+              title: "Long",
+              url: "https://example.com/long",
+              description: "",
+              snippet: "word ".repeat(400),
+            },
+            {
+              title: "Meta only",
+              url: "https://example.com/meta",
+              description: "only a meta description",
+            },
+          ],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as any;
+
+    const result = await execute({ query: "test" });
+    expect(result.content).toContain("line one line two");
+    expect(result.content).toContain("only a meta description");
+    const longLine = String(result.content)
+      .split("\n")
+      .find((line) => line.trim().startsWith("word"));
+    expect(longLine?.trim().length).toBeLessThanOrEqual(500);
+    expect(longLine?.trim().length).toBeGreaterThan(490);
   });
 
   test("Keenable uses the authenticated endpoint when a key is set", async () => {

--- a/assistant/src/tools/network/web-search.ts
+++ b/assistant/src/tools/network/web-search.ts
@@ -148,7 +148,10 @@ interface FirecrawlSearchResponse {
 interface KeenableSearchResult {
   title?: string;
   url?: string;
+  /** The page's meta description. Empty for most pages; see keenableSnippet. */
   description?: string;
+  /** The page text. This is what carries content on a Keenable result. */
+  snippet?: string;
   published_at?: string;
   acquired_at?: string;
 }
@@ -488,6 +491,20 @@ function firecrawlTbsForFreshness(
   }
 }
 
+/** Characters of page text kept per result. Keenable returns the whole page on
+ * every search result, an order of magnitude more than the other providers here
+ * return, so it is capped to keep one search from filling the context. */
+const KEENABLE_SNIPPET_MAX_LENGTH = 500;
+
+/** Keenable sends both `snippet` and `description` on every result: `snippet`
+ * carries the page text and `description` is the page's meta description, which
+ * is empty for most pages. `||` rather than `??`, since the empty description is
+ * present rather than nullish. */
+function keenableSnippet(result: KeenableSearchResult): string {
+  const text = result.snippet || result.description || "";
+  return text.replace(/\s+/g, " ").trim().slice(0, KEENABLE_SNIPPET_MAX_LENGTH);
+}
+
 function formatKeenableResults(
   data: KeenableSearchResponse,
   query: string,
@@ -505,8 +522,9 @@ function formatKeenableResults(
     if (r.url) {
       lines.push(`   URL: ${r.url}`);
     }
-    if (r.description) {
-      lines.push(`   ${r.description}`);
+    const snippet = keenableSnippet(r);
+    if (snippet) {
+      lines.push(`   ${snippet}`);
     }
     if (r.published_at) {
       lines.push(`   Published: ${r.published_at}`);
@@ -531,7 +549,7 @@ function buildKeenableMetadata(
       url,
       domain,
       faviconUrl: faviconUrlForDomain(domain),
-      snippet: r.description,
+      snippet: keenableSnippet(r),
     };
   });
   return {


### PR DESCRIPTION
## Prompt / plan

Fixing this Keenable result mapping across our integrations.

`formatKeenableResults` and `buildKeenableMetadata` read `r.description`, which Keenable leaves empty on most pages; the page text is in `snippet`. Both go through one helper now, using `||` rather than `??` (the empty description is present, not nullish), capped at 500 chars since Keenable returns whole pages.

## Test plan

The keenable fixture now has the real response shape, plus a case for the snippet, the fallback and the cap.
