### PR TITLE
fix(web): say "Muted" instead of "Listening" when the mic is off

### DIFF
--- a/clients/web/src/domains/chat/voice/live-voice/live-activity-push-registration.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-activity-push-registration.test.ts
@@ -109,6 +109,26 @@ describe("registerLiveActivityPushToken content state", () => {
     expect(lastUpsertArg?.body.muted).toBe(true);
   });
 
+  /**
+   * The platform composes each push by looking a phase up in this map, so a
+   * table built as if the mic were live would push "Listening…" over the local
+   * "Muted" on the first phase change after iOS suspends the web view, which
+   * is the only state the island is ever seen in.
+   */
+  test("bakes the mute state into the pushed label table", async () => {
+    await registerLiveActivityPushToken({ ...REGISTRATION, muted: true });
+
+    expect(lastUpsertArg?.body.labels.listening).toBe("Muted");
+    // The assistant's own phases are unaffected by a muted mic.
+    expect(lastUpsertArg?.body.labels.thinking).toBe("Thinking…");
+  });
+
+  test("pushes the listening label unmuted when the mic is live", async () => {
+    await registerLiveActivityPushToken({ ...REGISTRATION, muted: false });
+
+    expect(lastUpsertArg?.body.labels.listening).toBe("Listening…");
+  });
+
   // The stored row is what every background push composes from, so a slow
   // first request landing after a fast second one would leave the island
   // rendering the state the user moved away from.

--- a/clients/web/src/domains/chat/voice/live-voice/live-activity-push-registration.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-activity-push-registration.ts
@@ -51,8 +51,18 @@ import { createStorageAccessor } from "@/utils/typed-storage";
  * session cannot quietly ship without server-side copy. `idle` and `failed` are
  * filtered out for the same reason they have no `ContentState.Phase` case:
  * neither has an activity to address.
+ *
+ * `muted` is baked into the table rather than left at its steady state. The
+ * platform composes pushes by looking a phase up in this map, so a table built
+ * as if the mic were live would push "Listening…" over the local "Muted" on the
+ * first phase change after iOS suspends the web view, which is the only state
+ * the island is ever seen in. Mute is a registered field for exactly this
+ * reason and the caller re-registers when it moves, so every rebuild of this
+ * map already carries the current value. `reconnecting` and silent-`speaking`
+ * stay at their steady state: neither is registered, so the server genuinely
+ * cannot observe them.
  */
-function phaseLabels(): Record<string, string> {
+function phaseLabels(muted: boolean): Record<string, string> {
   const labels: Record<string, string> = {};
   const phases = (
     Object.keys(LIVE_VOICE_STATE_LABELS) as LiveVoiceSessionState[]
@@ -60,12 +70,8 @@ function phaseLabels(): Record<string, string> {
   for (const phase of phases) {
     // Read through the same helper the room and the mirror use rather than the
     // raw table, so a server-pushed label is the string the user would have
-    // seen locally, including the relabel rules, resolved for their steady
-    // state. `reconnecting`, silent-`speaking` and `muted` are conditions the
-    // server does not observe, so they resolve to their steady state here: a
-    // pushed `listening` reads as "Listening…" even if the mic is muted, which
-    // is the same limitation the other two carry on this path.
-    labels[phase] = liveVoiceSurfaceLabel(phase, false, true, false);
+    // seen locally, including the relabel rules.
+    labels[phase] = liveVoiceSurfaceLabel(phase, false, true, muted);
   }
   return labels;
 }
@@ -206,7 +212,7 @@ async function upsertToken({
         bundle_id: bundleId,
         apns_environment: apnsEnvironment,
         conversation_id: conversationId,
-        labels: phaseLabels(),
+        labels: phaseLabels(muted),
         accent_hex: accentHex,
         muted,
       },

--- a/clients/web/src/domains/chat/voice/live-voice/live-activity-push-registration.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-activity-push-registration.ts
@@ -60,10 +60,12 @@ function phaseLabels(): Record<string, string> {
   for (const phase of phases) {
     // Read through the same helper the room and the mirror use rather than the
     // raw table, so a server-pushed label is the string the user would have
-    // seen locally — including the relabel rules, resolved for their steady
-    // state. `reconnecting` and silent-`speaking` are transient conditions the
-    // server does not observe, so they resolve false here.
-    labels[phase] = liveVoiceSurfaceLabel(phase, false, true);
+    // seen locally, including the relabel rules, resolved for their steady
+    // state. `reconnecting`, silent-`speaking` and `muted` are conditions the
+    // server does not observe, so they resolve to their steady state here: a
+    // pushed `listening` reads as "Listening…" even if the mic is muted, which
+    // is the same limitation the other two carry on this path.
+    labels[phase] = liveVoiceSurfaceLabel(phase, false, true, false);
   }
   return labels;
 }

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.test.ts
@@ -222,18 +222,65 @@ describe("liveVoiceStateLabel", () => {
 
 describe("liveVoiceSurfaceLabel", () => {
   test("a speaking phase with no audio playing reads as thinking", () => {
-    // `speaking` stays set across a mid-turn tool run — the ack was spoken and
-    // the assistant is now silent — so every surface says "Thinking…".
-    expect(liveVoiceSurfaceLabel("speaking", false, false)).toBe("Thinking…");
-    expect(liveVoiceSurfaceLabel("speaking", false, true)).toBe("Speaking…");
+    // `speaking` stays set across a mid-turn tool run (the ack was spoken and
+    // the assistant is now silent) so every surface says "Thinking…".
+    expect(liveVoiceSurfaceLabel("speaking", false, false, false)).toBe(
+      "Thinking…",
+    );
+    expect(liveVoiceSurfaceLabel("speaking", false, true, false)).toBe(
+      "Speaking…",
+    );
   });
 
   test("carries the reconnecting relabel through unchanged", () => {
-    expect(liveVoiceSurfaceLabel("connecting", true, false)).toBe(
+    expect(liveVoiceSurfaceLabel("connecting", true, false, false)).toBe(
       "Reconnecting…",
     );
-    expect(liveVoiceSurfaceLabel("listening", false, false)).toBe(
+    expect(liveVoiceSurfaceLabel("listening", false, false, false)).toBe(
       "Listening…",
+    );
+  });
+
+  /**
+   * The session holds `listening` while the mic is muted, so an unremapped
+   * surface claims to be listening beside a mute button that says it is not.
+   */
+  test("a muted listening phase reads as muted", () => {
+    expect(liveVoiceSurfaceLabel("listening", false, false, true)).toBe(
+      "Muted",
+    );
+  });
+
+  /** A state rather than an activity, so no ellipsis where the phases have one. */
+  test("says muted without an ellipsis", () => {
+    expect(liveVoiceSurfaceLabel("listening", false, false, true)).not.toContain(
+      "\u2026",
+    );
+  });
+
+  /**
+   * Muting the microphone does not make the assistant stop thinking or
+   * speaking, so relabelling those would trade one false statement for another.
+   */
+  test("leaves the assistant's own phases alone while muted", () => {
+    expect(liveVoiceSurfaceLabel("thinking", false, false, true)).toBe(
+      "Thinking…",
+    );
+    expect(liveVoiceSurfaceLabel("speaking", false, true, true)).toBe(
+      "Speaking…",
+    );
+    expect(liveVoiceSurfaceLabel("transcribing", false, false, true)).toBe(
+      "Transcribing…",
+    );
+  });
+
+  /**
+   * Reconnecting is the more urgent fact: a muted mic matters less than a
+   * session that is not currently connected at all.
+   */
+  test("does not hide a reconnect behind the mute", () => {
+    expect(liveVoiceSurfaceLabel("connecting", true, false, true)).toBe(
+      "Reconnecting…",
     );
   });
 });

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
@@ -94,15 +94,24 @@ export function liveVoiceStateLabel(
 }
 
 /**
- * The label a *surface* shows for a session — {@link liveVoiceStateLabel} plus
- * the audio-aware `speaking` remap.
+ * The label a *surface* shows for a session: {@link liveVoiceStateLabel} plus
+ * the two remaps that keep the words true of what is actually happening.
  *
  * `speaking` stays set across a mid-turn tool run: the assistant spoke an ack,
  * then went silent while a tool runs. Announcing "Speaking…" while nothing is
  * audible is wrong for the room's caption, wrong for its screen-reader
  * announcement, and wrong for the Dynamic Island (JARVIS-1279). Every surface
- * that renders session activity calls this — the voice room and the iOS Live
- * Activity mirror — so the island always reads exactly what the room reads.
+ * that renders session activity calls this, the voice room and the iOS Live
+ * Activity mirror, so the island always reads exactly what the room reads.
+ *
+ * `listening` is the same problem through the microphone: the session holds
+ * that phase while the mic is muted, so the surface claims to be listening
+ * beside a mute button that says it is not. Muted is a state rather than an
+ * activity, so it takes no ellipsis where the phases do.
+ *
+ * Only `listening` is remapped. Muting the microphone does not make the
+ * assistant stop thinking or speaking, and relabelling those would trade one
+ * false statement for another.
  *
  * {@link liveVoiceStateLabel} stays the lower layer for callers that have no
  * audio signal to consult.
@@ -111,7 +120,11 @@ export function liveVoiceSurfaceLabel(
   state: LiveVoiceSessionState,
   reconnecting: boolean,
   assistantAudioActive: boolean,
+  muted: boolean,
 ): string {
+  if (state === "listening" && muted) {
+    return "Muted";
+  }
   return liveVoiceStateLabel(
     state === "speaking" && !assistantAudioActive ? "thinking" : state,
     reconnecting,

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-activity-mirror.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-activity-mirror.ts
@@ -95,14 +95,15 @@ function toActivityContent(
   }
   return {
     phase: session.state,
-    // The room's label, verbatim — the same `liveVoiceSurfaceLabel` call the
-    // room makes, including both its "Reconnecting…" relabel and its
-    // silent-`speaking` → "Thinking…" remap — so the island never has wording
-    // of its own to drift from.
+    // The room's label, verbatim: the same `liveVoiceSurfaceLabel` call the
+    // room makes, including its "Reconnecting…" relabel, its
+    // silent-`speaking` to "Thinking…" remap, and its muted-`listening` to
+    // "Muted" remap, so the island never has wording of its own to drift from.
     label: liveVoiceSurfaceLabel(
       session.state,
       session.reconnecting,
       session.assistantAudioActive,
+      session.muted,
     ),
     // The accent the avatar (and therefore the voice room) renders. `""` for
     // an avatar with no color to match: the native side canonicalizes

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -448,12 +448,15 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
   // The label + sr-only announcement must follow the same audio-aware mapping as
   // the visual: a silent mid-turn `speaking` (ack spoken, tool now running)
   // reads as "Thinking…", not "Speaking…", so screen-reader users aren't told
-  // the assistant is talking while it's actually silent (JARVIS-1279). Shared
-  // with the iOS Live Activity mirror, which shows this exact string.
+  // the assistant is talking while it's actually silent (JARVIS-1279), and a
+  // muted `listening` reads as "Muted", so they are not told it is hearing them
+  // while the mic is off. Shared with the iOS Live Activity mirror and the
+  // macOS companion, which show this exact string.
   const stateLabel = liveVoiceSurfaceLabel(
     state,
     reconnecting,
     assistantAudioActive,
+    muted,
   );
 
   // The state caption (e.g. "Listening…") shows only while the assistant
@@ -1106,7 +1109,10 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
       {/* Screen readers get session-state changes here; the avatar is the
           visual channel, so this stays off-screen. */}
       <div aria-live="polite" className="sr-only">
-        {muted ? `Muted — ${stateLabel}` : stateLabel}
+        {/* A muted `listening` already reads as "Muted", so prefixing it again
+            would announce "Muted — Muted". The assistant's own phases still
+            need the prefix: "Thinking…" alone would not say the mic is off. */}
+        {muted && state !== "listening" ? `Muted — ${stateLabel}` : stateLabel}
       </div>
     </motion.div>
   );

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -1112,7 +1112,7 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
         {/* A muted `listening` already reads as "Muted", so prefixing it again
             would announce "Muted — Muted". The assistant's own phases still
             need the prefix: "Thinking…" alone would not say the mic is off. */}
-        {muted && state !== "listening" ? `Muted — ${stateLabel}` : stateLabel}
+        {muted && state !== "listening" ? `Muted. ${stateLabel}` : stateLabel}
       </div>
     </motion.div>
   );

--- a/clients/web/src/runtime/native-live-activity.ts
+++ b/clients/web/src/runtime/native-live-activity.ts
@@ -52,7 +52,7 @@ export interface VoiceLiveActivityContent {
   phase: ActiveLiveVoiceSessionState;
   /**
    * User-facing activity copy. Pass
-   * `liveVoiceSurfaceLabel(state, reconnecting, assistantAudioActive)` so the
+   * `liveVoiceSurfaceLabel(state, reconnecting, assistantAudioActive, muted)` so the
    * island shows exactly what the voice room shows; the native side
    * deliberately owns no phase wording of its own.
    */


### PR DESCRIPTION
Closes JARVIS-1554.

Mute the mic mid-call and the companion pill went on reading "Listening" — the one thing on the surface that was plainly false, sitting right next to the mute button that said otherwise.

## The fix

The label is shared, so this fixes it at the source: `liveVoiceSurfaceLabel` now takes `muted` and remaps a muted `listening` to "Muted". The room, the Dynamic Island, and the companion pill agree by construction rather than by three surfaces each remembering to.

This is option 1 from the ticket. The alternative — writing "Muted" in `companion-surface.tsx` — is the one fix that violates the rule that file exists under: `CallBody` owns no phase copy, because that wording deploys continuously with the web bundle while the shell ships on release cadence. A surface that re-words its own phases is how the two come to disagree.

## Scope of the remap

- **Only `listening`.** Muting the mic does not make the assistant stop thinking or speaking; relabelling those would trade one false statement for another.
- **Reconnecting still wins.** A session that is not connected at all matters more than a muted mic.
- **No ellipsis.** Muted is a state, not an activity, where the phases are all `Listening…` / `Thinking…`.

## Knock-on

The room's screen-reader line already prefixed `Muted — ` onto the label, which with the remap would have announced **"Muted — Muted"**. It now keeps the prefix only for the phases that still need it — `Muted — Thinking…` still has to say the mic is off.

`live-activity-push-registration.ts` bakes the current mute state into the phase-label table it uploads. The first pass passed `muted: false` there on the reasoning that the server cannot observe mute — that was wrong, and Codex caught it: mute is a registered field on the token row precisely because the daemon cannot see it, and the mirror's `registeredKey` includes it, so a toggle already re-registers. Left as-is, the next APNs update after iOS suspended the web view would have pushed "Listening…" over the local "Muted", in the only state the island is ever seen in. `reconnecting` and silent-`speaking` do stay at their steady state: neither is registered, so for those the original reasoning holds.

## Verification

- `liveVoiceSurfaceLabel` covered by 5 new tests (muted remap, no ellipsis, assistant phases left alone, reconnect not hidden).
- 2 new tests pin the pushed label table to the registered mute state.
- 26 voice + companion test files pass, 0 fail — including `voice-room.test.tsx` (98) and `companion-surface.test.tsx` (22).
- `tsc --noEmit` clean; lint 0 errors.

## Deliberately not in this PR

Two adjacent surfaces have their own wording and are out of the ticket's "fed by the same payload" scope:

- `voice-session-pill-host.tsx:182` duplicates the remap (`muted ? "Muted" : LIVE_VOICE_STATE_LABELS[state]`) instead of calling the shared helper. Already muted-correct, so this is a de-duplication, not a bug.
- `voice-room-eyes.tsx:197` has a hardcoded `EYE_STATE_CAPTION` table that is not mute-aware. It is keyed on `VoiceAvatarVisual`, not the session label, and is usually hidden by the caption-emphasis default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

**Review round 1.** Two of three P1s applied in `81cfb54755` — the push-table mute bug above, and an em dash in the aria-live copy (now `Muted. ${stateLabel}`).

The third, moving `"Muted"` into the i18n catalog, is declined with reasoning [on the thread](https://github.com/vellum-ai/vellum-assistant/pull/40932#discussion_r3814168081): the six phase labels it sits beside in `LIVE_VOICE_STATE_LABELS` are all hardcoded English, so translating this one string alone would produce a half-localized surface. `src/domains/chat/voice/**` is not in `i18nEnforcedPaths`, and the config explicitly forbids widening a glob to silence an error. Converting the voice area is a separate cutover, made larger here by the label table being uploaded for server-composed APNs pushes.
