### PR TITLE
feat(web): reorganize billing into Payment Methods, Credits, and Invoices

### DIFF
--- a/clients/web/openapi-schemas/platform.yaml
+++ b/clients/web/openapi-schemas/platform.yaml
@@ -4272,6 +4272,58 @@ paths:
           description: ''
       x-vellum-api-clients:
       - platform
+  /v1/organizations/billing/auto-top-up/confirm-setup-intent/:
+    post:
+      operationId: organizations_billing_auto_top_up_confirm_setup_intent_create
+      description: |-
+        Persist the payment method from a just-confirmed SetupIntent.
+
+        Call this immediately after Stripe's client-side ``confirmSetup``
+        resolves so the saved card is readable on the very next GET, instead of
+        waiting on the ``setup_intent.succeeded`` webhook. The webhook remains
+        the durable fallback; whichever lands second is a no-op.
+
+        Returns the same payload as ``GET .../auto-top-up/``.
+
+        The caller's id is never trusted on its own: the SetupIntent is re-read
+        from Stripe and must be tagged ``metadata.auto_top_up=true``, carry this
+        org's ``metadata.organization_id``, sit on this org's Stripe customer,
+        and be ``succeeded`` with a payment method attached.
+      parameters:
+      - in: header
+        name: Vellum-Organization-Id
+        schema:
+          type: string
+          format: uuid
+        description: Required if using Cookie-based or X-Session-Token authentication
+          methods.
+      tags:
+      - organizations
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AutoTopUpConfirmSetupIntentRequestRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/AutoTopUpConfirmSetupIntentRequestRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/AutoTopUpConfirmSetupIntentRequestRequest'
+        required: true
+      security:
+      - VellumAPIKey: []
+      - cookieAuth: []
+      - XSessionTokenAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AutoTopUpConfigResponse'
+          description: ''
+      x-vellum-api-clients:
+      - platform
   /v1/organizations/billing/auto-top-up/disable/:
     post:
       operationId: organizations_billing_auto_top_up_disable_create
@@ -6478,6 +6530,18 @@ components:
       - stripe_payment_method_updated_at
       - stubbed
       - threshold_usd
+    AutoTopUpConfirmSetupIntentRequestRequest:
+      type: object
+      description: POST /…/auto-top-up/confirm-setup-intent/ request body.
+      properties:
+        setup_intent_id:
+          type: string
+          minLength: 1
+          description: Stripe SetupIntent id returned by the client-side confirmSetup
+            call.
+          maxLength: 255
+      required:
+      - setup_intent_id
     AutoTopUpDisableResponse:
       type: object
       properties:

--- a/clients/web/src/components/add-credits-modal.test.tsx
+++ b/clients/web/src/components/add-credits-modal.test.tsx
@@ -167,7 +167,7 @@ describe("AddCreditsModal", () => {
     renderModal();
 
     const link = screen.getByRole("link", {
-      name: /Configure Automatic Top-Ups/,
+      name: /Configure Auto-Reload/,
     });
     expect(link.getAttribute("href")).toBe(
       routes.settings.usageBillingConfigureTopUps,

--- a/clients/web/src/components/add-credits-modal.tsx
+++ b/clients/web/src/components/add-credits-modal.tsx
@@ -193,7 +193,7 @@ function AddCreditsModalContent({ open, onOpenChange }: AddCreditsModalProps) {
               className="flex items-center gap-1 text-body-small-default text-[var(--content-tertiary)] hover:text-[var(--content-secondary)]"
               onClick={() => onOpenChange(false)}
             >
-              Configure Automatic Top-Ups
+              Configure Auto-Reload
               <ChevronRight className="size-4" />
             </Link>
 

--- a/clients/web/src/components/add-credits-modal.tsx
+++ b/clients/web/src/components/add-credits-modal.tsx
@@ -9,6 +9,7 @@ import {
   organizationsBillingTopUpsCheckoutSessionCreateMutation,
 } from "@/generated/api/@tanstack/react-query.gen";
 import { useBusSubscription } from "@/hooks/use-bus-subscription";
+import { useTranslation } from "@/i18n";
 import { ANDROID_BILLING_MESSAGE } from "@/lib/billing/android-consumption-only";
 import { checkoutReturnTarget } from "@/lib/billing/checkout-return-target";
 import { openUrl, openUrlFinishedListener } from "@/runtime/browser";
@@ -63,6 +64,7 @@ interface AddCreditsModalProps {
 }
 
 function AddCreditsModalContent({ open, onOpenChange }: AddCreditsModalProps) {
+  const { t } = useTranslation();
   const { pathname } = useLocation();
   const [searchParams] = useSearchParams();
   const returnPath = searchParams.toString()
@@ -193,7 +195,7 @@ function AddCreditsModalContent({ open, onOpenChange }: AddCreditsModalProps) {
               className="flex items-center gap-1 text-body-small-default text-[var(--content-tertiary)] hover:text-[var(--content-secondary)]"
               onClick={() => onOpenChange(false)}
             >
-              Configure Auto-Reload
+              {t("addCreditsModal.configureAutoReload")}
               <ChevronRight className="size-4" />
             </Link>
 

--- a/clients/web/src/domains/settings/billing/billing-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/billing-page.test.tsx
@@ -148,6 +148,9 @@ mock.module("@/domains/settings/components/grace-period-banner", () => ({
 mock.module("@/domains/settings/components/invoices-table", () => ({
   InvoicesTable: () => null,
 }));
+mock.module("@/domains/settings/components/payment-methods-card", () => ({
+  PaymentMethodsCard: () => null,
+}));
 mock.module("@/domains/settings/components/plan-card", () => ({
   PlanCard: ({ onTierUpgraded }: { onTierUpgraded?: () => void }) => (
     <button data-testid="plan-card-tier-upgraded" onClick={onTierUpgraded} />

--- a/clients/web/src/domains/settings/billing/billing-page.tsx
+++ b/clients/web/src/domains/settings/billing/billing-page.tsx
@@ -20,6 +20,7 @@ import { BillingPortalReturnHandler } from "@/domains/settings/components/billin
 import { BillingUsagePanel } from "@/domains/settings/components/billing-usage/billing-usage-panel";
 import { GracePeriodBanner } from "@/domains/settings/components/grace-period-banner";
 import { InvoicesTable } from "@/domains/settings/components/invoices-table";
+import { PaymentMethodsCard } from "@/domains/settings/components/payment-methods-card";
 import { PlanCard } from "@/domains/settings/components/plan-card";
 import { useAssistantDomains } from "@/domains/settings/billing/pro-onboarding/use-assistant-domains";
 import {
@@ -305,6 +306,9 @@ function BillingTabContent() {
         onOpenChange={onBonusOpenChange}
         amountUsd={amountUsd}
       />
+      <Suspense fallback={null}>
+        <PaymentMethodsCard />
+      </Suspense>
       <Suspense fallback={null}>
         <BillingPanel />
       </Suspense>

--- a/clients/web/src/domains/settings/components/auto-top-up-card.test.tsx
+++ b/clients/web/src/domains/settings/components/auto-top-up-card.test.tsx
@@ -16,9 +16,8 @@
  *  - Arriving with `?configure_top_up=1` replays the toggle-on path (reveal the
  *    form, or the add-card gate with no PM), no-ops while enabled, and never
  *    fires an update mutation.
- *  - The enable form announces the default daily credit limit only when the org
- *    has none, and a successful enable invalidates the daily-limit and billing
- *    summary queries so the daily-limit card picks up the applied default.
+ *  - A successful enable invalidates the daily-limit and billing summary
+ *    queries so the daily-limit card picks up the server-applied default.
  *
  * Strategy: the render-only cases pre-populate the React Query cache so the
  * card's `useQuery` resolves synchronously — `renderToStaticMarkup` is
@@ -559,47 +558,6 @@ describe("AutoTopUpCard configure_top_up deeplink", () => {
 });
 
 describe("AutoTopUpCard default daily credit limit", () => {
-  const NOTE = '[data-testid="auto-top-up-default-daily-limit-note"]';
-
-  test("announces the applied default when enabling with no daily limit", () => {
-    const { container, getByLabelText } = render(wrap(DISABLED_WITH_CARD));
-
-    fireEvent.click(getByLabelText("Enable auto-reload"));
-
-    const note = container.querySelector(NOTE);
-    expect(note).not.toBeNull();
-    expect(note?.textContent).toContain(
-      "A default daily credit limit of $25 per day will be applied.",
-    );
-  });
-
-  test("stays quiet when the org already has a daily limit", () => {
-    dailyLimitResponse = {
-      daily_credit_limit_usd: "40.00",
-      current_day_spent_usd: "0.00",
-      day_bucket: "2026-07-20",
-      daily_limit_snoozed: false,
-      daily_limit_snoozed_day_bucket: null,
-    };
-    const { container, getByLabelText } = render(wrap(DISABLED_WITH_CARD));
-
-    fireEvent.click(getByLabelText("Enable auto-reload"));
-
-    expect(
-      container.querySelector('[data-testid="auto-top-up-save-button"]'),
-    ).not.toBeNull();
-    expect(container.querySelector(NOTE)).toBeNull();
-  });
-
-  test("stays quiet when adjusting an already-enabled config", () => {
-    retrieveResponse = { ...ENABLED_WITH_CARD };
-    const { container, getByTestId } = render(wrap(ENABLED_WITH_CARD));
-
-    fireEvent.click(getByTestId("auto-top-up-edit-button"));
-
-    expect(container.querySelector(NOTE)).toBeNull();
-  });
-
   test("invalidates the daily-limit and summary queries after a successful enable", async () => {
     const client = makeClient(DISABLED_WITH_CARD);
     const invalidated: string[] = [];

--- a/clients/web/src/domains/settings/components/auto-top-up-card.test.tsx
+++ b/clients/web/src/domains/settings/components/auto-top-up-card.test.tsx
@@ -353,6 +353,105 @@ describe("AutoTopUpCard enable gate", () => {
     expect(form()).toBeNull();
   });
 
+  test("a card saved via the Payment Methods section continues a pending enable into the form", async () => {
+    const config: AutoTopUpConfigResponse = {
+      ...DISABLED_CONFIG,
+      enabled: false,
+      has_payment_method: false,
+      disabled_due_to_repeated_failures: false,
+    };
+    const client = makeClient(config);
+    const { container, getByLabelText } = render(wrap(config, "/", client));
+
+    // Let the mount-time background refetch settle so it cannot overwrite the
+    // card-appeared write below.
+    await waitFor(() => {
+      if (client.isFetching() > 0) {
+        throw new Error("config refetch still in flight");
+      }
+    });
+
+    // Toggle on with no card: the add-card gate shows, no form.
+    fireEvent.click(getByLabelText("Enable auto-reload"));
+    expect(
+      container.querySelector('[data-testid="auto-top-up-save-button"]'),
+    ).toBeNull();
+
+    // Simulate the card arriving through the Payment Methods section: its
+    // poll refreshes the shared config query.
+    const withCard: AutoTopUpConfigResponse = {
+      ...DISABLED_CONFIG,
+      enabled: false,
+      has_payment_method: true,
+      payment_method_brand: "visa",
+      payment_method_last4: "4242",
+      stripe_payment_method_updated_at: "2026-08-19T00:00:00Z",
+    };
+    retrieveResponse = withCard;
+    client.setQueryData(
+      organizationsBillingAutoTopUpRetrieveQueryKey(),
+      withCard,
+    );
+
+    // The pending enable continues into the configure form; the toggle stays
+    // visually on (still pendingEnable until Save persists).
+    await waitFor(() => {
+      if (
+        !container.querySelector('[data-testid="auto-top-up-save-button"]')
+      ) {
+        throw new Error("form did not open after the card appeared");
+      }
+    });
+    expect(
+      getByLabelText("Enable auto-reload").getAttribute("aria-checked"),
+    ).toBe("true");
+  });
+
+  test("clearing the declines cutoff with a fresh card continues a pending enable into the form", async () => {
+    // Toggle-on while cut off gates the flow even though the declined card is
+    // on file. Once a fresh card lands (backend clears the flag), the pending
+    // enable continues into the form.
+    const cutOff: AutoTopUpConfigResponse = {
+      ...DISABLED_CONFIG,
+      enabled: false,
+      has_payment_method: true,
+      disabled_due_to_repeated_failures: true,
+    };
+    retrieveResponse = { ...cutOff };
+    const client = makeClient(cutOff);
+    const { container, getByLabelText } = render(wrap(cutOff, "/", client));
+
+    await waitFor(() => {
+      if (client.isFetching() > 0) {
+        throw new Error("config refetch still in flight");
+      }
+    });
+
+    fireEvent.click(getByLabelText("Enable auto-reload"));
+    expect(
+      container.querySelector('[data-testid="auto-top-up-save-button"]'),
+    ).toBeNull();
+
+    const freshCard: AutoTopUpConfigResponse = {
+      ...cutOff,
+      disabled_due_to_repeated_failures: false,
+      stripe_payment_method_updated_at: "2026-08-19T00:00:00Z",
+    };
+    retrieveResponse = freshCard;
+    client.setQueryData(
+      organizationsBillingAutoTopUpRetrieveQueryKey(),
+      freshCard,
+    );
+
+    await waitFor(() => {
+      if (
+        !container.querySelector('[data-testid="auto-top-up-save-button"]')
+      ) {
+        throw new Error("form did not open after the cutoff cleared");
+      }
+    });
+  });
+
   test("the no-payment-method banner shows the connect-card notice without the ACTION placeholder", () => {
     // The banner renders the connect-a-card copy and only a dismiss control —
     // never the Figma component's empty actions-slot "ACTION" placeholder.

--- a/clients/web/src/domains/settings/components/auto-top-up-card.test.tsx
+++ b/clients/web/src/domains/settings/components/auto-top-up-card.test.tsx
@@ -1,11 +1,13 @@
 /**
  * Tests for the AutoTopUpCard enabled-state layout, the repeated-decline
  * cutoff notice, and the `configure_top_up` deeplink:
- *  - The enabled view renders the payment-method row above two summary chips
- *    (spend rule + monthly-cap progress) and Adjust swaps the chips for the
- *    inline form.
- *  - Removing the saved card opens a destructive confirm; confirming calls the
- *    remove endpoint and drives the config to disabled / no card.
+ *  - The enabled view renders two summary chips (spend rule + monthly-cap
+ *    progress) and Adjust swaps the chips for the inline form. Card
+ *    management lives in `PaymentMethodsCard`, so no payment-method row
+ *    renders here.
+ *  - When the shared config's payment method goes away (removed in the
+ *    Payment Methods section), the card exits the Adjust form and drops the
+ *    add-card gate.
  *  - When the backend reports `disabled_due_to_repeated_failures` on a disabled
  *    config, the card renders a tailored warning; a normally-disabled config
  *    renders no such notice; the notice is suppressed when `enabled`.
@@ -22,9 +24,8 @@
  * card's `useQuery` resolves synchronously — `renderToStaticMarkup` is
  * single-pass, so a pending query would otherwise report `isLoading`. The
  * interaction cases use @testing-library/react (happy-dom via the test
- * preload). The remove flow mocks the SDK boundary so the mutation and the
- * follow-up GET are deterministic. Every render is wrapped in a MemoryRouter
- * because the card reads `useSearchParams`.
+ * preload). Every render is wrapped in a MemoryRouter because the card reads
+ * `useSearchParams`.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -39,39 +40,12 @@ import type {
   DailyCreditLimitResponse,
 } from "@/generated/api/types.gen";
 
-let removeCalls: Array<Record<string, unknown>> = [];
 let updateCalls: Array<Record<string, unknown>> = [];
-let removeShouldFail = false;
 let retrieveResponse: AutoTopUpConfigResponse;
 let dailyLimitResponse: DailyCreditLimitResponse;
 
 mock.module("@/generated/api/sdk.gen", () => ({
   ...sdkGen,
-  organizationsBillingAutoTopUpRemovePaymentMethodCreate: (
-    opts: Record<string, unknown>,
-  ) => {
-    removeCalls.push(opts);
-    if (removeShouldFail) {
-      return Promise.reject(new Error("remove failed"));
-    }
-    // The endpoint clears the PM and disables auto-reload server-side, so the
-    // next GET reflects that.
-    retrieveResponse = {
-      ...retrieveResponse,
-      enabled: false,
-      has_payment_method: false,
-      payment_method_brand: null,
-      payment_method_last4: null,
-    };
-    return Promise.resolve({
-      data: {
-        enabled: false,
-        stubbed: false,
-        message: "Payment method removed",
-      },
-      response: { ok: true },
-    });
-  },
   // Record any auto-top-up update (the PUT that persists a config). The
   // `configure_top_up` deeplink must never trigger this on mount.
   organizationsBillingAutoTopUpUpdate: (opts: Record<string, unknown>) => {
@@ -152,9 +126,7 @@ const DISABLED_WITH_CARD: AutoTopUpConfigResponse = {
 };
 
 beforeEach(() => {
-  removeCalls = [];
   updateCalls = [];
-  removeShouldFail = false;
   retrieveResponse = { ...DISABLED_CONFIG };
   dailyLimitResponse = {
     daily_credit_limit_usd: null,
@@ -191,225 +163,60 @@ describe("AutoTopUpCard enabled-state layout", () => {
     ).toBeNull();
   });
 
-  test("renders the payment-method row above the summary chips", () => {
+  test("does not render the payment-method row (card management lives in Payment Methods)", () => {
     const html = renderCard(ENABLED_WITH_CARD);
 
-    expect(html).toContain("payment-method-row");
-    expect(html).toContain("Visa");
-    expect(html).toContain("Ending in 4242");
-    // The row's Update/Remove controls belong to it.
-    expect(html).toContain("payment-method-update");
-    expect(html).toContain("payment-method-remove");
-
-    // The row is rendered before the summary chips.
-    expect(html.indexOf("payment-method-row")).toBeLessThan(
-      html.indexOf("auto-top-up-summary"),
-    );
+    expect(html).not.toContain("payment-method-row");
+    expect(html).toContain("auto-top-up-summary");
   });
 });
 
-describe("AutoTopUpCard remove card", () => {
-  test("confirming Remove calls the endpoint and disables Extra Usage", async () => {
+describe("AutoTopUpCard payment-method removal reaction", () => {
+  test("losing the payment method while adjusting exits the form and turns the toggle off", async () => {
     retrieveResponse = { ...ENABLED_WITH_CARD };
-    const { container, getByLabelText } = render(wrap(ENABLED_WITH_CARD));
-
-    // Precondition: the card is on file and Extra Usage is on.
-    expect(
-      container.querySelector('[data-testid="payment-method-row"]'),
-    ).not.toBeNull();
-
-    // Remove opens a destructive confirm that warns it turns off Extra Usage.
-    fireEvent.click(
-      container.querySelector('[data-testid="payment-method-remove"]')!,
-    );
-    const confirmButton = await waitFor(() => {
-      const btn = document.querySelector<HTMLButtonElement>(
-        "[data-confirm-dialog-confirm]",
-      );
-      if (!btn) {
-        throw new Error("confirm dialog not open");
-      }
-      return btn;
-    });
-    expect(document.body.textContent).toContain("Remove payment method?");
-    expect(document.body.textContent).toContain("turn off Extra Usage");
-    expect(removeCalls.length).toBe(0);
-
-    fireEvent.click(confirmButton);
-
-    await waitFor(() => {
-      if (removeCalls.length === 0) {
-        throw new Error("remove endpoint not called");
-      }
-    });
-
-    // The card drops to the disabled / no-card state: toggle off, no PM row.
-    await waitFor(() => {
-      const toggle = getByLabelText("Enable Extra Usage");
-      if (toggle.getAttribute("aria-checked") !== "false") {
-        throw new Error("still enabled");
-      }
-      if (container.querySelector('[data-testid="payment-method-row"]')) {
-        throw new Error("payment-method row still present");
-      }
-    });
-    expect(
-      container.querySelector('[data-testid="auto-top-up-summary"]'),
-    ).toBeNull();
-    expect(
-      container.querySelector('[data-testid="auto-top-up-remove-error"]'),
-    ).toBeNull();
-  });
-
-  test("removing while in Adjust form mode exits the form and disables Extra Usage", async () => {
-    retrieveResponse = { ...ENABLED_WITH_CARD };
+    const client = makeClient(ENABLED_WITH_CARD);
     const { container, getByLabelText, getByTestId } = render(
-      wrap(ENABLED_WITH_CARD),
+      wrap(ENABLED_WITH_CARD, "/", client),
     );
 
-    // Enter Adjust form mode: the inline form (Save) mounts.
+    // Let the mount-time background refetch settle first, so its (stale)
+    // result cannot land after the removal write below and mask the
+    // transition.
+    await waitFor(() => {
+      if (client.isFetching() > 0) {
+        throw new Error("config refetch still in flight");
+      }
+    });
+
     fireEvent.click(getByTestId("auto-top-up-edit-button"));
     expect(
       container.querySelector('[data-testid="auto-top-up-save-button"]'),
     ).not.toBeNull();
 
-    // Remove the saved card and confirm.
-    fireEvent.click(
-      container.querySelector('[data-testid="payment-method-remove"]')!,
+    // Simulate `PaymentMethodsCard` removing the card: its optimistic write
+    // drives the shared config cache to the disabled / no-PM state, and any
+    // follow-up GET agrees.
+    const removedConfig: AutoTopUpConfigResponse = {
+      ...ENABLED_WITH_CARD,
+      enabled: false,
+      has_payment_method: false,
+      payment_method_brand: null,
+      payment_method_last4: null,
+    };
+    retrieveResponse = removedConfig;
+    client.setQueryData(
+      organizationsBillingAutoTopUpRetrieveQueryKey(),
+      removedConfig,
     );
-    const confirmButton = await waitFor(() => {
-      const btn = document.querySelector<HTMLButtonElement>(
-        "[data-confirm-dialog-confirm]",
-      );
-      if (!btn) {
-        throw new Error("confirm dialog not open");
-      }
-      return btn;
-    });
-    fireEvent.click(confirmButton);
 
     await waitFor(() => {
-      if (removeCalls.length === 0) {
-        throw new Error("remove endpoint not called");
-      }
-    });
-
-    // Form mode exited (no Save) and the card is disabled / no card.
-    await waitFor(() => {
-      const toggle = getByLabelText("Enable Extra Usage");
-      if (toggle.getAttribute("aria-checked") !== "false") {
-        throw new Error("still enabled");
-      }
       if (container.querySelector('[data-testid="auto-top-up-save-button"]')) {
         throw new Error("form still mounted after removal");
       }
-      if (container.querySelector('[data-testid="payment-method-row"]')) {
-        throw new Error("payment-method row still present");
-      }
-    });
-  });
-
-  test("a failed removal closes the confirm dialog and surfaces the error notice", async () => {
-    removeShouldFail = true;
-    retrieveResponse = { ...ENABLED_WITH_CARD };
-    const { container } = render(wrap(ENABLED_WITH_CARD));
-
-    fireEvent.click(
-      container.querySelector('[data-testid="payment-method-remove"]')!,
-    );
-    const confirmButton = await waitFor(() => {
-      const btn = document.querySelector<HTMLButtonElement>(
-        "[data-confirm-dialog-confirm]",
-      );
-      if (!btn) {
-        throw new Error("confirm dialog not open");
-      }
-      return btn;
-    });
-    fireEvent.click(confirmButton);
-
-    await waitFor(() => {
-      if (removeCalls.length === 0) {
-        throw new Error("remove endpoint not called");
-      }
-    });
-
-    // On failure the dialog closes (so the notice isn't hidden behind the
-    // overlay) and the card row stays put for a retry.
-    await waitFor(() => {
-      if (document.querySelector("[data-confirm-dialog-confirm]")) {
-        throw new Error("confirm dialog still open");
-      }
-      if (
-        !container.querySelector('[data-testid="auto-top-up-remove-error"]')
-      ) {
-        throw new Error("remove error notice not shown");
-      }
     });
     expect(
-      container.querySelector('[data-testid="payment-method-row"]'),
-    ).not.toBeNull();
-  });
-});
-
-describe("AutoTopUpCard disabled with a saved card", () => {
-  test("renders the payment-method row (Update/Remove) while Extra Usage is off", () => {
-    const html = renderCard(DISABLED_WITH_CARD);
-
-    // The saved card and its controls stay reachable even though Extra Usage
-    // is off, so the user can still update or remove the card.
-    expect(html).toContain("payment-method-row");
-    expect(html).toContain("payment-method-update");
-    expect(html).toContain("Update Card");
-    expect(html).toContain("payment-method-remove");
-    expect(html).toContain("Remove");
-    // The enabled-only summary chips stay hidden while off.
-    expect(html).not.toContain("auto-top-up-summary");
-  });
-
-  test("confirming Remove from the disabled state calls the endpoint and clears the card", async () => {
-    retrieveResponse = { ...DISABLED_WITH_CARD };
-    const { container, getByLabelText } = render(wrap(DISABLED_WITH_CARD));
-
-    // Precondition: Extra Usage is off but the card row is on file.
-    expect(
-      getByLabelText("Enable Extra Usage").getAttribute("aria-checked"),
+      getByLabelText("Enable auto-reload").getAttribute("aria-checked"),
     ).toBe("false");
-    expect(
-      container.querySelector('[data-testid="payment-method-row"]'),
-    ).not.toBeNull();
-
-    fireEvent.click(
-      container.querySelector('[data-testid="payment-method-remove"]')!,
-    );
-    const confirmButton = await waitFor(() => {
-      const btn = document.querySelector<HTMLButtonElement>(
-        "[data-confirm-dialog-confirm]",
-      );
-      if (!btn) {
-        throw new Error("confirm dialog not open");
-      }
-      return btn;
-    });
-    expect(removeCalls.length).toBe(0);
-
-    fireEvent.click(confirmButton);
-
-    await waitFor(() => {
-      if (removeCalls.length === 0) {
-        throw new Error("remove endpoint not called");
-      }
-    });
-
-    // The card row drops once the PM is cleared.
-    await waitFor(() => {
-      if (container.querySelector('[data-testid="payment-method-row"]')) {
-        throw new Error("payment-method row still present");
-      }
-    });
-    expect(
-      container.querySelector('[data-testid="auto-top-up-remove-error"]'),
-    ).toBeNull();
   });
 });
 
@@ -486,7 +293,7 @@ describe("AutoTopUpCard enable gate", () => {
     // The form is not present before the click.
     expect(form()).toBeNull();
 
-    fireEvent.click(getByLabelText("Enable Extra Usage"));
+    fireEvent.click(getByLabelText("Enable auto-reload"));
 
     // The enable gate tripped: still no form, and the cutoff notice persists.
     expect(form()).toBeNull();
@@ -511,7 +318,7 @@ describe("AutoTopUpCard enable gate", () => {
 
     expect(form()).toBeNull();
 
-    fireEvent.click(getByLabelText("Enable Extra Usage"));
+    fireEvent.click(getByLabelText("Enable auto-reload"));
 
     expect(form()).not.toBeNull();
   });
@@ -532,7 +339,7 @@ describe("AutoTopUpCard enable gate", () => {
       container.querySelector('[data-testid="auto-top-up-save-button"]');
     const addPmButton = () =>
       container.querySelector('[data-testid="auto-top-up-add-pm-button"]');
-    const toggle = getByLabelText("Enable Extra Usage");
+    const toggle = getByLabelText("Enable auto-reload");
 
     // The add-a-card button stays mounted inside the collapse-animation
     // wrapper, so it is always in the DOM; the toggle starting unchecked is
@@ -558,10 +365,10 @@ describe("AutoTopUpCard enable gate", () => {
 
     const { container, getByLabelText } = render(wrap(config));
 
-    fireEvent.click(getByLabelText("Enable Extra Usage"));
+    fireEvent.click(getByLabelText("Enable auto-reload"));
 
     expect(container.textContent).toContain(
-      "Extra usage requires you to connect a credit card.",
+      "Auto-reload requires you to connect a credit card.",
     );
     expect(container.textContent).not.toContain("ACTION");
   });
@@ -583,7 +390,7 @@ describe("AutoTopUpCard configure_top_up deeplink", () => {
     // The toggle-on path ran: the toggle flipped and the configure form opened,
     // exactly as clicking the toggle would — with no update mutation.
     expect(
-      getByLabelText("Enable Extra Usage").getAttribute("aria-checked"),
+      getByLabelText("Enable auto-reload").getAttribute("aria-checked"),
     ).toBe("true");
     expect(
       container.querySelector('[data-testid="auto-top-up-save-button"]'),
@@ -605,7 +412,7 @@ describe("AutoTopUpCard configure_top_up deeplink", () => {
 
     // No PM on file → the add-card gate is shown instead of the form.
     expect(
-      getByLabelText("Enable Extra Usage").getAttribute("aria-checked"),
+      getByLabelText("Enable auto-reload").getAttribute("aria-checked"),
     ).toBe("true");
     expect(
       container.querySelector('[data-testid="auto-top-up-add-pm-button"]'),
@@ -643,7 +450,7 @@ describe("AutoTopUpCard configure_top_up deeplink", () => {
     const { container, getByLabelText } = render(wrap(config, "/"));
 
     expect(
-      getByLabelText("Enable Extra Usage").getAttribute("aria-checked"),
+      getByLabelText("Enable auto-reload").getAttribute("aria-checked"),
     ).toBe("false");
     expect(
       container.querySelector('[data-testid="auto-top-up-save-button"]'),
@@ -658,7 +465,7 @@ describe("AutoTopUpCard default daily credit limit", () => {
   test("announces the applied default when enabling with no daily limit", () => {
     const { container, getByLabelText } = render(wrap(DISABLED_WITH_CARD));
 
-    fireEvent.click(getByLabelText("Enable Extra Usage"));
+    fireEvent.click(getByLabelText("Enable auto-reload"));
 
     const note = container.querySelector(NOTE);
     expect(note).not.toBeNull();
@@ -677,7 +484,7 @@ describe("AutoTopUpCard default daily credit limit", () => {
     };
     const { container, getByLabelText } = render(wrap(DISABLED_WITH_CARD));
 
-    fireEvent.click(getByLabelText("Enable Extra Usage"));
+    fireEvent.click(getByLabelText("Enable auto-reload"));
 
     expect(
       container.querySelector('[data-testid="auto-top-up-save-button"]'),
@@ -707,7 +514,7 @@ describe("AutoTopUpCard default daily credit limit", () => {
       wrap(DISABLED_WITH_CARD, "/", client),
     );
 
-    fireEvent.click(getByLabelText("Enable Extra Usage"));
+    fireEvent.click(getByLabelText("Enable auto-reload"));
     fireEvent.click(getByTestId("auto-top-up-save-button"));
 
     await waitFor(() => {

--- a/clients/web/src/domains/settings/components/auto-top-up-card.tsx
+++ b/clients/web/src/domains/settings/components/auto-top-up-card.tsx
@@ -28,6 +28,7 @@ import {
 import { AutoTopUpPaymentMethodModal } from "@/domains/settings/components/auto-top-up-payment-method-modal";
 import { usePaymentMethodSavedPoll } from "@/domains/settings/hooks/use-payment-method-saved-poll";
 import { extractDrfFieldErrors } from "@/domains/settings/utils/drf-errors";
+import { useTranslation } from "@/i18n";
 
 type Mode = "view" | "form";
 
@@ -107,6 +108,7 @@ function SummaryChip({
  *   amount, monthly cap) + Save.
  */
 export function AutoTopUpCard() {
+  const { t } = useTranslation("settings");
   const queryClient = useQueryClient();
   const configQuery = useQuery(organizationsBillingAutoTopUpRetrieveOptions());
   // Drives the "we'll apply the default daily limit" note in the enable form:
@@ -132,17 +134,6 @@ export function AutoTopUpCard() {
   const [showAddPm, setShowAddPm] = useState(false);
   const [bannerDismissed, setBannerDismissed] = useState(false);
   const [pmModalOpen, setPmModalOpen] = useState(false);
-
-  // Auto-dismiss the no-PM gate once a PM appears (e.g. after the user saves
-  // one via `AutoTopUpPaymentMethodModal` below). Declared before the
-  // early-return branches to satisfy rules-of-hooks; reads through
-  // `configQuery.data` since `config` isn't bound until after the
-  // loading/error guards below.
-  useEffect(() => {
-    if (showAddPm && configQuery.data?.has_payment_method) {
-      setShowAddPm(false);
-    }
-  }, [showAddPm, configQuery.data?.has_payment_method]);
 
   // Removing the card (in `PaymentMethodsCard`) disables auto-reload
   // server-side, so when the shared config's PM goes away, leave the add-card
@@ -196,6 +187,32 @@ export function AutoTopUpCard() {
     enterFormMode();
   };
 
+  // Auto-dismiss the no-PM gate once a USABLE PM appears (saved via this
+  // card's modal below, via the Payment Methods section, or discovered by a
+  // background refetch). When the enable flow is still pending and the server
+  // config is still disabled, continue into the configure form: without this,
+  // a card saved from the other section would strand an on-looking toggle
+  // with no form and no persisted enable. "Usable" excludes the
+  // repeated-declines cutoff, where the declined card is still on file but
+  // re-enabling with it must stay gated; the backend clears the flag once a
+  // fresh PM is attached, and that transition is what fires this. Declared
+  // before the early-return branches to satisfy rules-of-hooks; reads through
+  // `configQuery.data` since `config` isn't bound until after the
+  // loading/error guards below.
+  const gateHasPaymentMethod = configQuery.data?.has_payment_method === true;
+  const gateEnabled = configQuery.data?.enabled === true;
+  const gateCutOff =
+    configQuery.data?.disabled_due_to_repeated_failures === true;
+  useEffect(() => {
+    if (showAddPm && gateHasPaymentMethod && !gateCutOff) {
+      setShowAddPm(false);
+      if (pendingEnable && !gateEnabled) {
+        enterFormMode();
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- `enterFormMode` is recreated per render; the guards above make re-runs no-ops
+  }, [showAddPm, pendingEnable, gateHasPaymentMethod, gateEnabled, gateCutOff]);
+
   // Arriving with `?configure_top_up=1` (deeplinked from the Add Credits
   // modal) replays the toggle-on path once, then strips the param. Never
   // mutates the server; persistence still requires Save. Must sit before the
@@ -237,7 +254,7 @@ export function AutoTopUpCard() {
   if (configQuery.isError || !configQuery.data) {
     return (
       <div data-testid="auto-top-up-card">
-        <Notice tone="error">Failed to load auto-reload configuration.</Notice>
+        <Notice tone="error">{t("autoTopUpCard.loadError")}</Notice>
       </div>
     );
   }
@@ -452,7 +469,7 @@ export function AutoTopUpCard() {
         <Toggle
           checked={toggleChecked}
           onChange={handleToggleChange}
-          label="Enable auto-reload"
+          label={t("autoTopUpCard.toggleLabel")}
         />
       </div>
 
@@ -538,7 +555,7 @@ export function AutoTopUpCard() {
                     variant="body-medium-default"
                     className="truncate text-[var(--system-mid-strong)]"
                   >
-                    Auto-reload requires you to connect a credit card.
+                    {t("autoTopUpCard.connectCardBanner")}
                   </Typography>
                 </div>
                 <button
@@ -573,7 +590,7 @@ export function AutoTopUpCard() {
           className="mt-4"
           data-testid="auto-top-up-update-error"
         >
-          Failed to save auto-reload settings. Please try again.
+          {t("autoTopUpCard.updateError")}
         </Notice>
       )}
 
@@ -583,7 +600,7 @@ export function AutoTopUpCard() {
           className="mt-4"
           data-testid="auto-top-up-disable-error"
         >
-          Failed to disable auto-reload. Please try again.
+          {t("autoTopUpCard.disableError")}
         </Notice>
       )}
 

--- a/clients/web/src/domains/settings/components/auto-top-up-card.tsx
+++ b/clients/web/src/domains/settings/components/auto-top-up-card.tsx
@@ -25,7 +25,7 @@ import {
   type AutoTopUpFormValues,
 } from "@/domains/settings/components/auto-top-up-form";
 import { AutoTopUpPaymentMethodModal } from "@/domains/settings/components/auto-top-up-payment-method-modal";
-import { usePaymentMethodSavedPoll } from "@/domains/settings/hooks/use-payment-method-saved-poll";
+import { usePaymentMethodSavedSync } from "@/domains/settings/hooks/use-payment-method-saved-poll";
 import { extractDrfFieldErrors } from "@/domains/settings/utils/drf-errors";
 import { useTranslation } from "@/i18n";
 
@@ -116,7 +116,7 @@ export function AutoTopUpCard() {
   const disableMutation = useMutation(
     organizationsBillingAutoTopUpDisableCreateMutation(),
   );
-  const pollPaymentMethodSaved = usePaymentMethodSavedPoll();
+  const syncPaymentMethodSaved = usePaymentMethodSavedSync();
 
   const [searchParams, setSearchParams] = useSearchParams();
   const cardRef = useRef<HTMLDivElement>(null);
@@ -430,11 +430,13 @@ export function AutoTopUpCard() {
 
   /**
    * Called after `AutoTopUpPaymentMethodModal` confirms a card was saved.
-   * Once the poll confirms the PM is fresh, drop the no-PM gate and, if the
+   * Once the config reflects the fresh PM, drop the no-PM gate and, if the
    * user got here via the toggle, advance straight into the configure form.
+   * The gate effect above may already have run off the seeded cache; both
+   * paths land on the same state.
    */
-  const handlePmSaved = async () => {
-    await pollPaymentMethodSaved();
+  const handlePmSaved = async (args: { setupIntentId: string | null }) => {
+    await syncPaymentMethodSaved(args);
     setShowAddPm(false);
     if (pendingEnable) {
       enterFormMode();

--- a/clients/web/src/domains/settings/components/auto-top-up-card.tsx
+++ b/clients/web/src/domains/settings/components/auto-top-up-card.tsx
@@ -9,7 +9,6 @@ import {
   organizationsBillingAutoTopUpRetrieveQueryKey,
   organizationsBillingAutoTopUpRetrieveSetQueryData,
   organizationsBillingAutoTopUpUpdateMutation,
-  organizationsBillingDailyCreditLimitRetrieveOptions,
   organizationsBillingDailyCreditLimitRetrieveQueryKey,
   organizationsBillingSummaryRetrieveQueryKey,
 } from "@/generated/api/@tanstack/react-query.gen";
@@ -111,12 +110,6 @@ export function AutoTopUpCard() {
   const { t } = useTranslation("settings");
   const queryClient = useQueryClient();
   const configQuery = useQuery(organizationsBillingAutoTopUpRetrieveOptions());
-  // Drives the "we'll apply the default daily limit" note in the enable form:
-  // the backend applies its default limit when auto top-up is turned on and the
-  // org has none.
-  const dailyLimitQuery = useQuery(
-    organizationsBillingDailyCreditLimitRetrieveOptions(),
-  );
   const updateMutation = useMutation(
     organizationsBillingAutoTopUpUpdateMutation(),
   );
@@ -457,11 +450,6 @@ export function AutoTopUpCard() {
     updateMutation.isError && Object.keys(fieldErrors).length === 0;
 
   const toggleChecked = enabled || pendingEnable;
-  // Only claim the default will be applied once the daily-limit config has
-  // loaded and reports no limit; a loading or failed query stays quiet.
-  const dailyLimitMissing =
-    dailyLimitQuery.data != null &&
-    dailyLimitQuery.data.daily_credit_limit_usd == null;
 
   return (
     <div ref={cardRef} data-testid="auto-top-up-card">
@@ -617,17 +605,9 @@ export function AutoTopUpCard() {
           }
           submitting={updateMutation.isPending}
           serverErrors={fieldErrors}
-          showDefaultDailyLimitNote={!enabled && dailyLimitMissing}
           onCancel={exitFormMode}
           onSave={handleSave}
         />
-      )}
-
-      {(enabled || isFormMode) && (
-        <Notice tone="info" className="mt-4">
-          If you&apos;re too close to your monthly limit, the auto-reload will
-          only top up to that limit.
-        </Notice>
       )}
 
       <AutoTopUpDisableConfirm

--- a/clients/web/src/domains/settings/components/auto-top-up-card.tsx
+++ b/clients/web/src/domains/settings/components/auto-top-up-card.tsx
@@ -5,7 +5,6 @@ import { useSearchParams } from "react-router";
 
 import {
   organizationsBillingAutoTopUpDisableCreateMutation,
-  organizationsBillingAutoTopUpRemovePaymentMethodCreateMutation,
   organizationsBillingAutoTopUpRetrieveOptions,
   organizationsBillingAutoTopUpRetrieveQueryKey,
   organizationsBillingAutoTopUpRetrieveSetQueryData,
@@ -16,7 +15,6 @@ import {
 } from "@/generated/api/@tanstack/react-query.gen";
 import type { AutoTopUpConfigResponse } from "@/generated/api/types.gen";
 import { Button } from "@vellumai/design-library/components/button";
-import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialog";
 import { Notice } from "@vellumai/design-library/components/notice";
 import { Toggle } from "@vellumai/design-library/components/toggle";
 import { Typography } from "@vellumai/design-library/components/typography";
@@ -28,7 +26,7 @@ import {
   type AutoTopUpFormValues,
 } from "@/domains/settings/components/auto-top-up-form";
 import { AutoTopUpPaymentMethodModal } from "@/domains/settings/components/auto-top-up-payment-method-modal";
-import { PaymentMethodRow } from "@/domains/settings/components/payment-method-row";
+import { usePaymentMethodSavedPoll } from "@/domains/settings/hooks/use-payment-method-saved-poll";
 import { extractDrfFieldErrors } from "@/domains/settings/utils/drf-errors";
 
 type Mode = "view" | "form";
@@ -93,10 +91,10 @@ function SummaryChip({
 }
 
 /**
- * Settings → Billing auto-reload section. Embedded directly inside the
- * Credit Balance card by `BillingPanel.tsx` (no outer Card wrapper of its
- * own). Toggle controls enable/disable; Adjust enters configure mode. This
- * card also owns saving a new payment method (via
+ * Settings → Billing auto-reload rows. Embedded directly inside the Credits
+ * card by `BillingPanel.tsx` (no outer Card wrapper of its own). Toggle
+ * controls enable/disable; Adjust enters configure mode. Card management
+ * lives in `PaymentMethodsCard`, but this card still owns saving a card (via
  * `AutoTopUpPaymentMethodModal`) for the no-PM gate below.
  *
  * - Off: just the toggle.
@@ -123,9 +121,7 @@ export function AutoTopUpCard() {
   const disableMutation = useMutation(
     organizationsBillingAutoTopUpDisableCreateMutation(),
   );
-  const removeMutation = useMutation(
-    organizationsBillingAutoTopUpRemovePaymentMethodCreateMutation(),
-  );
+  const pollPaymentMethodSaved = usePaymentMethodSavedPoll();
 
   const [searchParams, setSearchParams] = useSearchParams();
   const cardRef = useRef<HTMLDivElement>(null);
@@ -133,7 +129,6 @@ export function AutoTopUpCard() {
   const [mode, setMode] = useState<Mode>("view");
   const [pendingEnable, setPendingEnable] = useState(false);
   const [confirmingDisable, setConfirmingDisable] = useState(false);
-  const [confirmingRemove, setConfirmingRemove] = useState(false);
   const [showAddPm, setShowAddPm] = useState(false);
   const [bannerDismissed, setBannerDismissed] = useState(false);
   const [pmModalOpen, setPmModalOpen] = useState(false);
@@ -148,6 +143,22 @@ export function AutoTopUpCard() {
       setShowAddPm(false);
     }
   }, [showAddPm, configQuery.data?.has_payment_method]);
+
+  // Removing the card (in `PaymentMethodsCard`) disables auto-reload
+  // server-side, so when the shared config's PM goes away, leave the add-card
+  // gate and the Adjust form to keep the OFF toggle and a saveable form from
+  // coexisting. Transition-gated so the poll-timeout path (`false → false`)
+  // can't misfire.
+  const hadPaymentMethodRef = useRef(false);
+  const hasPaymentMethod = configQuery.data?.has_payment_method === true;
+  useEffect(() => {
+    if (hadPaymentMethodRef.current && !hasPaymentMethod) {
+      setShowAddPm(false);
+      setMode("view");
+      setPendingEnable(false);
+    }
+    hadPaymentMethodRef.current = hasPaymentMethod;
+  }, [hasPaymentMethod]);
 
   /**
    * Transition into form mode. Resets any prior mutation errors so stale
@@ -164,7 +175,7 @@ export function AutoTopUpCard() {
   };
 
   /**
-   * Shared "turn Extra Usage on from disabled" flow, used by both the toggle
+   * Shared "turn auto-reload on from disabled" flow, used by both the toggle
    * (`handleToggleChange`) and the `?configure_top_up=1` deeplink effect: with
    * no usable PM (none on file, or auto-reload paused after repeated declines)
    * reveal the add-card gate, otherwise open the configure form. Never persists
@@ -226,7 +237,7 @@ export function AutoTopUpCard() {
   if (configQuery.isError || !configQuery.data) {
     return (
       <div data-testid="auto-top-up-card">
-        <Notice tone="error">Failed to load auto top-up configuration.</Notice>
+        <Notice tone="error">Failed to load auto-reload configuration.</Notice>
       </div>
     );
   }
@@ -352,9 +363,9 @@ export function AutoTopUpCard() {
               // endpoint flips `enabled=False` but does NOT clear
               // `stripe_payment_method_id` or its updated_at marker — so
               // dropping the marker here would corrupt the polling snapshot
-              // in `handlePmSaved` below: it reads `priorMarker` from this
-              // same cache, then polls until the backend's marker advances
-              // past it. If we seed `null` after disable, the user's next
+              // in `usePaymentMethodSavedPoll`: it reads `priorMarker` from
+              // this same cache, then polls until the backend's marker
+              // advances past it. If we seed `null` after disable, the next
               // "Add a Credit Card" click takes a priorMarker=null
               // snapshot, the first poll reads the backend's still-set
               // timestamp, and the poll exits immediately with stale data.
@@ -373,45 +384,7 @@ export function AutoTopUpCard() {
   };
 
   /**
-   * The remove endpoint clears the PM AND flips `enabled=False` server-side,
-   * so the optimistic write lands on the disabled/no-PM state — matching what
-   * the follow-up GET returns, with no separate disable call needed.
-   */
-  const handleConfirmRemove = () => {
-    removeMutation.mutate(
-      {},
-      {
-        onSuccess: () => {
-          organizationsBillingAutoTopUpRetrieveSetQueryData(
-            queryClient,
-            undefined,
-            {
-              ...config,
-              enabled: false,
-              has_payment_method: false,
-              payment_method_brand: null,
-              payment_method_last4: null,
-            },
-          );
-          void queryClient.invalidateQueries({
-            queryKey: organizationsBillingAutoTopUpRetrieveQueryKey(),
-          });
-          setConfirmingRemove(false);
-          // Removal disables auto-reload, so leave the Adjust form (if open)
-          // to keep the OFF toggle and a saveable form from coexisting.
-          exitFormMode();
-        },
-        // Close the dialog on failure so the error notice isn't hidden behind
-        // the overlay; the card row stays put for a retry.
-        onError: () => {
-          setConfirmingRemove(false);
-        },
-      },
-    );
-  };
-
-  /**
-   * Click handler for the "Enable Extra Usage" toggle. The toggle itself is
+   * Click handler for the "Enable auto-reload" toggle. The toggle itself is
    * never disabled — turning it on always flips visually to reflect intent
    * (`pendingEnable`), even when a payment method still needs to be added.
    *
@@ -447,45 +420,11 @@ export function AutoTopUpCard() {
 
   /**
    * Called after `AutoTopUpPaymentMethodModal` confirms a card was saved.
-   * The `setup_intent.succeeded` webhook persists `stripe_payment_method_id`
-   * asynchronously, so a single invalidate+refetch can race the webhook and
-   * leave the cache stale. Poll until `stripe_payment_method_updated_at`
-   * actually advances past its pre-save value, with a timeout so this never
-   * spins forever if the webhook never lands. Once the PM is confirmed
-   * fresh, drop the no-PM gate and — if the user got here via the toggle —
-   * advance straight into the configure form.
+   * Once the poll confirms the PM is fresh, drop the no-PM gate and, if the
+   * user got here via the toggle, advance straight into the configure form.
    */
   const handlePmSaved = async () => {
-    const POLL_INTERVAL_MS = 1500;
-    const MAX_POLL_MS = 20_000;
-    const start = Date.now();
-    const priorMarker = config.stripe_payment_method_updated_at ?? null;
-
-    try {
-      await queryClient.invalidateQueries({
-        queryKey: organizationsBillingAutoTopUpRetrieveQueryKey(),
-      });
-    } catch {
-      // fall through to polling below
-    }
-
-    while (Date.now() - start < MAX_POLL_MS) {
-      try {
-        const refetched = await queryClient.fetchQuery(
-          organizationsBillingAutoTopUpRetrieveOptions(),
-        );
-        if (
-          refetched.has_payment_method &&
-          refetched.stripe_payment_method_updated_at !== priorMarker
-        ) {
-          break;
-        }
-      } catch {
-        // sleep and retry
-      }
-      await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
-    }
-
+    await pollPaymentMethodSaved();
     setShowAddPm(false);
     if (pendingEnable) {
       enterFormMode();
@@ -513,21 +452,9 @@ export function AutoTopUpCard() {
         <Toggle
           checked={toggleChecked}
           onChange={handleToggleChange}
-          label="Enable Extra Usage"
+          label="Enable auto-reload"
         />
       </div>
-
-      {config.has_payment_method && (
-        <div className="mt-3">
-          <PaymentMethodRow
-            brand={config.payment_method_brand}
-            last4={config.payment_method_last4}
-            onUpdateCard={() => setPmModalOpen(true)}
-            onRemove={() => setConfirmingRemove(true)}
-            removing={removeMutation.isPending}
-          />
-        </div>
-      )}
 
       {enabled && !isFormMode && (
         <div className="mt-3 flex w-full items-center gap-2">
@@ -611,7 +538,7 @@ export function AutoTopUpCard() {
                     variant="body-medium-default"
                     className="truncate text-[var(--system-mid-strong)]"
                   >
-                    Extra usage requires you to connect a credit card.
+                    Auto-reload requires you to connect a credit card.
                   </Typography>
                 </div>
                 <button
@@ -646,7 +573,7 @@ export function AutoTopUpCard() {
           className="mt-4"
           data-testid="auto-top-up-update-error"
         >
-          Failed to save automatic top-ups. Please try again.
+          Failed to save auto-reload settings. Please try again.
         </Notice>
       )}
 
@@ -656,17 +583,7 @@ export function AutoTopUpCard() {
           className="mt-4"
           data-testid="auto-top-up-disable-error"
         >
-          Failed to disable automatic top-ups. Please try again.
-        </Notice>
-      )}
-
-      {removeMutation.isError && (
-        <Notice
-          tone="error"
-          className="mt-4"
-          data-testid="auto-top-up-remove-error"
-        >
-          Failed to remove the payment method. Please try again.
+          Failed to disable auto-reload. Please try again.
         </Notice>
       )}
 
@@ -701,18 +618,6 @@ export function AutoTopUpCard() {
         confirming={disableMutation.isPending}
         onCancel={dismissDisableConfirm}
         onConfirm={handleConfirmDisable}
-      />
-
-      <ConfirmDialog
-        open={confirmingRemove}
-        title="Remove payment method?"
-        message="Removing your card will turn off Extra Usage."
-        confirmLabel={removeMutation.isPending ? "Removing…" : "Remove"}
-        isPending={removeMutation.isPending}
-        cancelLabel="Keep card"
-        destructive
-        onConfirm={handleConfirmRemove}
-        onCancel={() => setConfirmingRemove(false)}
       />
 
       <AutoTopUpPaymentMethodModal

--- a/clients/web/src/domains/settings/components/auto-top-up-disable-confirm.tsx
+++ b/clients/web/src/domains/settings/components/auto-top-up-disable-confirm.tsx
@@ -1,5 +1,7 @@
 import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialog";
 
+import { useTranslation } from "@/i18n";
+
 export interface AutoTopUpDisableConfirmProps {
   open: boolean;
   confirming: boolean;
@@ -18,11 +20,12 @@ export function AutoTopUpDisableConfirm({
   onCancel,
   onConfirm,
 }: AutoTopUpDisableConfirmProps) {
+  const { t } = useTranslation("settings");
   return (
     <ConfirmDialog
       open={open}
-      title="Disable auto-reload?"
-      message="Auto-reload will stop. Any saved payment method stays on file."
+      title={t("autoTopUpDisableConfirm.title")}
+      message={t("autoTopUpDisableConfirm.message")}
       confirmLabel={confirming ? "Disabling…" : "Disable"}
       cancelLabel="Keep enabled"
       destructive

--- a/clients/web/src/domains/settings/components/auto-top-up-disable-confirm.tsx
+++ b/clients/web/src/domains/settings/components/auto-top-up-disable-confirm.tsx
@@ -8,7 +8,7 @@ export interface AutoTopUpDisableConfirmProps {
 }
 
 /**
- * Reconfirm dialog for the destructive "Disable automatic top-ups" action.
+ * Reconfirm dialog for the destructive "Disable auto-reload" action.
  * Single-sentence body — fits the `ConfirmDialog` primitive exactly. If the
  * copy ever needs structure (bullets, etc.), swap to `Modal.*` directly.
  */
@@ -21,8 +21,8 @@ export function AutoTopUpDisableConfirm({
   return (
     <ConfirmDialog
       open={open}
-      title="Disable automatic top-ups?"
-      message="Auto top-ups will stop. Any saved payment method stays on file."
+      title="Disable auto-reload?"
+      message="Auto-reload will stop. Any saved payment method stays on file."
       confirmLabel={confirming ? "Disabling…" : "Disable"}
       cancelLabel="Keep enabled"
       destructive

--- a/clients/web/src/domains/settings/components/auto-top-up-form.tsx
+++ b/clients/web/src/domains/settings/components/auto-top-up-form.tsx
@@ -4,6 +4,8 @@ import { Button } from "@vellumai/design-library/components/button";
 import { Input } from "@vellumai/design-library/components/input";
 import { Notice } from "@vellumai/design-library/components/notice";
 
+import { useTranslation } from "@/i18n";
+
 export interface AutoTopUpFormValues {
   threshold_usd: string;
   amount_usd: string;
@@ -127,6 +129,7 @@ export function AutoTopUpForm({
   onSave,
   onCancel,
 }: AutoTopUpFormProps) {
+  const { t } = useTranslation("settings");
   const [values, setValues] = useState<AutoTopUpFormValues>(initialValues);
   const [touched, setTouched] = useState<
     Record<keyof AutoTopUpFormValues, boolean>
@@ -223,7 +226,7 @@ export function AutoTopUpForm({
             type="number"
             step="1"
             label="Monthly spending cap"
-            helperText="Pauses auto-reload for the rest of the month once spending reaches this amount. Manual purchases also count toward the total. Leave empty for no limit."
+            helperText={t("autoTopUpForm.capHelper")}
             value={values.monthly_cap_usd}
             onChange={onChange("monthly_cap_usd")}
             onBlur={onBlur("monthly_cap_usd")}
@@ -260,8 +263,9 @@ export function AutoTopUpForm({
           className="mt-3"
           data-testid="auto-top-up-default-daily-limit-note"
         >
-          A default daily credit limit of ${DEFAULT_DAILY_CREDIT_LIMIT_USD} per
-          day will be applied. You can adjust it under Daily Credit Limit.
+          {t("autoTopUpForm.defaultDailyLimitNote", {
+            amount: `$${DEFAULT_DAILY_CREDIT_LIMIT_USD}`,
+          })}
         </Notice>
       )}
     </div>

--- a/clients/web/src/domains/settings/components/auto-top-up-form.tsx
+++ b/clients/web/src/domains/settings/components/auto-top-up-form.tsx
@@ -223,7 +223,7 @@ export function AutoTopUpForm({
             type="number"
             step="1"
             label="Monthly spending cap"
-            helperText="Pauses auto top-ups for the rest of the month once spending reaches this amount. Manual purchases also count toward the total. Leave empty for no limit."
+            helperText="Pauses auto-reload for the rest of the month once spending reaches this amount. Manual purchases also count toward the total. Leave empty for no limit."
             value={values.monthly_cap_usd}
             onChange={onChange("monthly_cap_usd")}
             onBlur={onBlur("monthly_cap_usd")}
@@ -261,7 +261,7 @@ export function AutoTopUpForm({
           data-testid="auto-top-up-default-daily-limit-note"
         >
           A default daily credit limit of ${DEFAULT_DAILY_CREDIT_LIMIT_USD} per
-          day will be applied. You can adjust it under Daily credit limit.
+          day will be applied. You can adjust it under Daily Credit Limit.
         </Notice>
       )}
     </div>

--- a/clients/web/src/domains/settings/components/auto-top-up-form.tsx
+++ b/clients/web/src/domains/settings/components/auto-top-up-form.tsx
@@ -2,9 +2,6 @@ import { useState, type ChangeEvent } from "react";
 
 import { Button } from "@vellumai/design-library/components/button";
 import { Input } from "@vellumai/design-library/components/input";
-import { Notice } from "@vellumai/design-library/components/notice";
-
-import { useTranslation } from "@/i18n";
 
 export interface AutoTopUpFormValues {
   threshold_usd: string;
@@ -16,17 +13,9 @@ export interface AutoTopUpFormProps {
   initialValues?: AutoTopUpFormValues;
   submitting: boolean;
   serverErrors: Record<string, string>;
-  /**
-   * Announce that saving will apply the default daily credit limit. Set while
-   * the user is turning auto top-up on and the org has no daily limit yet.
-   */
-  showDefaultDailyLimitNote?: boolean;
   onSave: (values: AutoTopUpFormValues) => void;
   onCancel: () => void;
 }
-
-/** Mirrors the backend `BILLING_DEFAULT_DAILY_CREDIT_LIMIT_USD` default. */
-const DEFAULT_DAILY_CREDIT_LIMIT_USD = 25;
 
 export type AutoTopUpFormErrors = Partial<
   Record<keyof AutoTopUpFormValues, string>
@@ -125,11 +114,9 @@ export function AutoTopUpForm({
   initialValues = DEFAULTS,
   submitting,
   serverErrors,
-  showDefaultDailyLimitNote = false,
   onSave,
   onCancel,
 }: AutoTopUpFormProps) {
-  const { t } = useTranslation("settings");
   const [values, setValues] = useState<AutoTopUpFormValues>(initialValues);
   const [touched, setTouched] = useState<
     Record<keyof AutoTopUpFormValues, boolean>
@@ -226,7 +213,6 @@ export function AutoTopUpForm({
             type="number"
             step="1"
             label="Monthly spending cap"
-            helperText={t("autoTopUpForm.capHelper")}
             value={values.monthly_cap_usd}
             onChange={onChange("monthly_cap_usd")}
             onBlur={onBlur("monthly_cap_usd")}
@@ -256,18 +242,6 @@ export function AutoTopUpForm({
           </Button>
         </div>
       </div>
-
-      {showDefaultDailyLimitNote && (
-        <Notice
-          tone="info"
-          className="mt-3"
-          data-testid="auto-top-up-default-daily-limit-note"
-        >
-          {t("autoTopUpForm.defaultDailyLimitNote", {
-            amount: `$${DEFAULT_DAILY_CREDIT_LIMIT_USD}`,
-          })}
-        </Notice>
-      )}
     </div>
   );
 }

--- a/clients/web/src/domains/settings/components/auto-top-up-form.tsx
+++ b/clients/web/src/domains/settings/components/auto-top-up-form.tsx
@@ -181,8 +181,8 @@ export function AutoTopUpForm({
 
   return (
     <div className="mt-4">
-      <div className="flex flex-wrap items-start gap-3">
-        <div className="min-w-[10rem] flex-1">
+      <div className="flex flex-wrap items-start gap-2">
+        <div className="w-full max-w-full sm:w-[200px]">
           <Input
             type="number"
             step="1"
@@ -195,7 +195,7 @@ export function AutoTopUpForm({
             fullWidth
           />
         </div>
-        <div className="min-w-[10rem] flex-1">
+        <div className="w-full max-w-full sm:w-[200px]">
           <Input
             type="number"
             step="1"
@@ -208,7 +208,7 @@ export function AutoTopUpForm({
             fullWidth
           />
         </div>
-        <div className="min-w-[10rem] flex-1">
+        <div className="w-full max-w-full sm:w-[200px]">
           <Input
             type="number"
             step="1"

--- a/clients/web/src/domains/settings/components/auto-top-up-payment-method-modal.test.tsx
+++ b/clients/web/src/domains/settings/components/auto-top-up-payment-method-modal.test.tsx
@@ -104,7 +104,11 @@ afterAll(() => {
 // ---------------------------------------------------------------------------
 
 /** Wait for the SetupIntent mutation to resolve and the card form to mount. */
-async function renderModalWithForm(): Promise<ReturnType<typeof render>> {
+async function renderModalWithForm(
+  onSavedOptimistic: (args: {
+    setupIntentId: string | null;
+  }) => void = () => {},
+): Promise<ReturnType<typeof render>> {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
@@ -113,7 +117,7 @@ async function renderModalWithForm(): Promise<ReturnType<typeof render>> {
       <AutoTopUpPaymentMethodModal
         open
         onClose={() => {}}
-        onSavedOptimistic={() => {}}
+        onSavedOptimistic={onSavedOptimistic}
       />
     </QueryClientProvider>,
   );
@@ -211,5 +215,26 @@ describe("AutoTopUpPaymentMethodModal billing address", () => {
     expect(
       (call.confirmParams as Record<string, unknown>).payment_method_data,
     ).toBeUndefined();
+  });
+
+  test("reports the SetupIntent id derived from the client secret on save", async () => {
+    const savedArgs: Array<{ setupIntentId: string | null }> = [];
+    const { getByTestId } = await renderModalWithForm((args) => {
+      savedArgs.push(args);
+    });
+    fireOnReady(paymentElementProps);
+    fireOnReady(addressElementProps);
+
+    fireEvent.submit(
+      getByTestId("auto-top-up-pm-save-button").closest("form")!,
+    );
+
+    await waitFor(() => {
+      if (savedArgs.length === 0) {
+        throw new Error("onSavedOptimistic not called");
+      }
+    });
+    // The mocked client_secret is `seti_123_secret_456`.
+    expect(savedArgs[0]).toEqual({ setupIntentId: "seti_123" });
   });
 });

--- a/clients/web/src/domains/settings/components/auto-top-up-payment-method-modal.tsx
+++ b/clients/web/src/domains/settings/components/auto-top-up-payment-method-modal.tsx
@@ -42,15 +42,35 @@ export interface AutoTopUpPaymentMethodModalProps {
   open: boolean;
   onClose: () => void;
   /**
-   * Called after `confirmSetup` succeeds. Owners use this to invalidate the
-   * auto-top-up config query so the saved-PM line and `has_payment_method`
-   * gate reflect the new card immediately.
+   * Called after `confirmSetup` succeeds, carrying the id of the SetupIntent
+   * that was just confirmed (null when it cannot be derived). Owners use this
+   * to refresh the auto-top-up config so the saved-PM line and
+   * `has_payment_method` gate reflect the new card immediately.
    *
    * May return a Promise; the modal awaits it before calling `onClose()` so
    * the parent re-renders against fresh data instead of briefly showing
    * stale payment-method copy after a successful save.
    */
-  onSavedOptimistic: () => void | Promise<void>;
+  onSavedOptimistic: (args: {
+    setupIntentId: string | null;
+  }) => void | Promise<void>;
+}
+
+/**
+ * A SetupIntent client secret is `<setup intent id>_secret_<random>`, so the
+ * id is everything before the `_secret` marker.
+ */
+function setupIntentIdFromClientSecret(
+  clientSecret: string | null,
+): string | null {
+  if (!clientSecret) {
+    return null;
+  }
+  const marker = clientSecret.indexOf("_secret");
+  if (marker <= 0) {
+    return null;
+  }
+  return clientSecret.slice(0, marker);
 }
 
 /**
@@ -74,7 +94,8 @@ export interface AutoTopUpPaymentMethodModalProps {
  *     in-page when the PM doesn't need 3DS, and otherwise redirects to
  *     `window.location.href` (so the user lands back on the current
  *     settings page).
- *  5. On success, toast + `onSavedOptimistic()` + `onClose()`.
+ *  5. On success, `onSavedOptimistic({ setupIntentId })`, then toast +
+ *     `onClose()` once the saved card has settled.
  */
 export function AutoTopUpPaymentMethodModal({
   open,
@@ -162,12 +183,14 @@ export function AutoTopUpPaymentMethodModal({
             >
               <SetupCardForm
                 onSuccess={async () => {
+                  // Await the parent's follow-up before toasting or closing:
+                  // the toast must not claim success while the saved card is
+                  // still settling, and closing early would briefly show
+                  // stale PM copy.
+                  await onSavedOptimistic({
+                    setupIntentId: setupIntentIdFromClientSecret(clientSecret),
+                  });
                   toast.success("Payment method saved.");
-                  // Await the parent's optimistic refetch before closing so
-                  // the next render reads fresh auto-top-up data. Without
-                  // the await, `onClose()` fires immediately and the user
-                  // briefly sees stale PM copy.
-                  await onSavedOptimistic();
                   onClose();
                 }}
                 onCancel={onClose}

--- a/clients/web/src/domains/settings/components/billing-panel.tsx
+++ b/clients/web/src/domains/settings/components/billing-panel.tsx
@@ -15,6 +15,7 @@ import { Card } from "@vellumai/design-library/components/card";
 import { Notice } from "@vellumai/design-library/components/notice";
 import { StatSquare } from "@vellumai/design-library/components/stat-square";
 import { Toggle } from "@vellumai/design-library/components/toggle";
+import { useTranslation } from "@/i18n";
 import { BillingSectionHeader } from "./billing-section-header";
 import {
   DAILY_CREDIT_LIMIT_ANCHOR_ID,
@@ -43,6 +44,7 @@ function formatCreditsShort(value: string): string {
 }
 
 export function BillingPanel() {
+  const { t } = useTranslation("settings");
   const queryClient = useQueryClient();
 
   const { data, isLoading, isError } = useQuery(
@@ -106,8 +108,8 @@ export function BillingPanel() {
 
   const creditsHeader = (
     <BillingSectionHeader
-      title="Credits"
-      subtitle="Quick overview of your balances and other things"
+      title={t("billingPanel.title")}
+      subtitle={t("billingPanel.subtitle")}
       actions={
         <>
           <Button
@@ -116,7 +118,7 @@ export function BillingPanel() {
             onClick={() => setReferralOpen(true)}
             data-testid="earn-credits-button"
           >
-            Earn Free Credits
+            {t("billingPanel.earnCreditsButton")}
           </Button>
           <Button
             variant="primary"
@@ -124,7 +126,7 @@ export function BillingPanel() {
             disabled={isLoading || !summary}
             data-testid="add-credits-button"
           >
-            Add Credits
+            {t("billingPanel.addCreditsButton")}
           </Button>
         </>
       }
@@ -145,7 +147,7 @@ export function BillingPanel() {
         <StatSquare
           icon={<Coins className="h-4 w-4" aria-hidden />}
           value={<span data-testid="effective-balance">{display}</span>}
-          label="Credits"
+          label={t("billingPanel.balanceLabel")}
           tone={effectiveNeg ? "negative" : "default"}
         />
       </div>
@@ -211,7 +213,7 @@ export function BillingPanel() {
             <Toggle
               checked={lowBalanceExpanded}
               onChange={setLowBalanceExpanded}
-              label="Custom Low Balance Alert"
+              label={t("billingPanel.lowBalanceToggle")}
             />
             {lowBalanceExpanded && <LowBalanceAlertCard />}
           </div>

--- a/clients/web/src/domains/settings/components/billing-panel.tsx
+++ b/clients/web/src/domains/settings/components/billing-panel.tsx
@@ -15,7 +15,7 @@ import { Card } from "@vellumai/design-library/components/card";
 import { Notice } from "@vellumai/design-library/components/notice";
 import { StatSquare } from "@vellumai/design-library/components/stat-square";
 import { Toggle } from "@vellumai/design-library/components/toggle";
-import { Typography } from "@vellumai/design-library/components/typography";
+import { BillingSectionHeader } from "./billing-section-header";
 import {
   DAILY_CREDIT_LIMIT_ANCHOR_ID,
   DailyCreditLimitCard,
@@ -104,43 +104,31 @@ export function BillingPanel() {
     bootstrapMutate,
   ]);
 
-  const creditBalanceHeader = (
-    <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
-      <div className="min-w-0">
-        <Typography
-          as="h2"
-          variant="title-medium"
-          className="text-[var(--content-emphasised)]"
-        >
-          Credit Balance
-        </Typography>
-        <Typography
-          as="p"
-          variant="body-medium-default"
-          className="mt-2 text-[var(--content-tertiary)]"
-        >
-          Quick overview of your balances and other things
-        </Typography>
-      </div>
-      <div className="flex items-center gap-2">
-        <Button
-          variant="outlined"
-          leftIcon={<Coins className="h-4 w-4" aria-hidden />}
-          onClick={() => setReferralOpen(true)}
-          data-testid="earn-credits-button"
-        >
-          Earn Free Credits
-        </Button>
-        <Button
-          variant="primary"
-          onClick={() => setAddCreditsOpen(true)}
-          disabled={isLoading || !summary}
-          data-testid="add-credits-button"
-        >
-          Add Credits
-        </Button>
-      </div>
-    </div>
+  const creditsHeader = (
+    <BillingSectionHeader
+      title="Credits"
+      subtitle="Quick overview of your balances and other things"
+      actions={
+        <>
+          <Button
+            variant="outlined"
+            leftIcon={<Coins className="h-4 w-4" aria-hidden />}
+            onClick={() => setReferralOpen(true)}
+            data-testid="earn-credits-button"
+          >
+            Earn Free Credits
+          </Button>
+          <Button
+            variant="primary"
+            onClick={() => setAddCreditsOpen(true)}
+            disabled={isLoading || !summary}
+            data-testid="add-credits-button"
+          >
+            Add Credits
+          </Button>
+        </>
+      }
+    />
   );
 
   const renderBalanceBox = (): ReactNode => {
@@ -148,16 +136,16 @@ export function BillingPanel() {
       return null;
     }
     const effectiveNeg = parseFloat(summary.effective_balance) < 0;
+    const formatted = formatCreditsShort(summary.effective_balance);
+    const display = formatted.startsWith("-")
+      ? `-$${formatted.slice(1)}`
+      : `$${formatted}`;
     return (
       <div className="mt-4">
         <StatSquare
           icon={<Coins className="h-4 w-4" aria-hidden />}
-          value={
-            <span data-testid="effective-balance">
-              {formatCreditsShort(summary.effective_balance)}
-            </span>
-          }
-          label="Balance"
+          value={<span data-testid="effective-balance">{display}</span>}
+          label="Credits"
           tone={effectiveNeg ? "negative" : "default"}
         />
       </div>
@@ -207,19 +195,9 @@ export function BillingPanel() {
   return (
     <>
       <Card padding="md">
-        {creditBalanceHeader}
+        {creditsHeader}
         {renderBalanceBody()}
         <div className="mt-6">
-          <div className="flex flex-col gap-4">
-            <Toggle
-              checked={lowBalanceExpanded}
-              onChange={setLowBalanceExpanded}
-              label="Custom low balance alert"
-            />
-            {lowBalanceExpanded && <LowBalanceAlertCard />}
-          </div>
-        </div>
-        <div className="mt-6 border-t border-[var(--border-base)] pt-6">
           <AutoTopUpCard />
         </div>
         <div
@@ -227,6 +205,16 @@ export function BillingPanel() {
           className="mt-6 scroll-mt-4 border-t border-[var(--border-base)] pt-6"
         >
           <DailyCreditLimitCard />
+        </div>
+        <div className="mt-6 border-t border-[var(--border-base)] pt-6">
+          <div className="flex flex-col gap-4">
+            <Toggle
+              checked={lowBalanceExpanded}
+              onChange={setLowBalanceExpanded}
+              label="Custom Low Balance Alert"
+            />
+            {lowBalanceExpanded && <LowBalanceAlertCard />}
+          </div>
         </div>
       </Card>
 

--- a/clients/web/src/domains/settings/components/billing-section-header.stories.tsx
+++ b/clients/web/src/domains/settings/components/billing-section-header.stories.tsx
@@ -1,0 +1,50 @@
+/**
+ * Shared header for the billing settings sections (Payment Methods, Credits,
+ * Invoices). The stories mirror the three production call sites: title only,
+ * title + subtitle, and the full form with an actions cluster.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Coins } from "lucide-react";
+
+import { Button } from "@vellumai/design-library/components/button";
+
+import { BillingSectionHeader } from "@/domains/settings/components/billing-section-header";
+
+const meta = {
+  title: "Settings/Billing/BillingSectionHeader",
+  component: BillingSectionHeader,
+  parameters: { layout: "padded" },
+} satisfies Meta<typeof BillingSectionHeader>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const TitleOnly: Story = {
+  args: { title: "Invoices" },
+};
+
+export const WithSubtitle: Story = {
+  args: {
+    title: "Payment Methods",
+    subtitle: "Payment methods linked to your account.",
+  },
+};
+
+export const WithActions: Story = {
+  args: {
+    title: "Credits",
+    subtitle: "Quick overview of your balances and other things",
+    actions: (
+      <>
+        <Button
+          variant="outlined"
+          leftIcon={<Coins className="h-4 w-4" aria-hidden />}
+        >
+          Earn Free Credits
+        </Button>
+        <Button variant="primary">Add Credits</Button>
+      </>
+    ),
+  },
+};

--- a/clients/web/src/domains/settings/components/billing-section-header.tsx
+++ b/clients/web/src/domains/settings/components/billing-section-header.tsx
@@ -1,0 +1,46 @@
+import type { ReactNode } from "react";
+
+import { Typography } from "@vellumai/design-library/components/typography";
+
+export interface BillingSectionHeaderProps {
+  title: string;
+  subtitle?: string;
+  actions?: ReactNode;
+}
+
+/**
+ * Shared header for the billing settings sections (Payment Methods, Credits,
+ * Invoices): title + optional subtitle on the left, action buttons on the
+ * right, stacking vertically on narrow viewports.
+ */
+export function BillingSectionHeader({
+  title,
+  subtitle,
+  actions,
+}: BillingSectionHeaderProps) {
+  return (
+    <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
+      <div className="min-w-0">
+        <Typography
+          as="h2"
+          variant="title-medium"
+          className="text-[var(--content-emphasised)]"
+        >
+          {title}
+        </Typography>
+        {subtitle != null && (
+          <Typography
+            as="p"
+            variant="body-medium-default"
+            className="mt-2 text-[var(--content-tertiary)]"
+          >
+            {subtitle}
+          </Typography>
+        )}
+      </div>
+      {actions != null && (
+        <div className="flex shrink-0 items-center gap-2">{actions}</div>
+      )}
+    </div>
+  );
+}

--- a/clients/web/src/domains/settings/components/daily-credit-limit-card.test.tsx
+++ b/clients/web/src/domains/settings/components/daily-credit-limit-card.test.tsx
@@ -402,7 +402,7 @@ describe("DailyCreditLimitCard auto top-up dependency", () => {
     const toggle = getByRole("switch") as HTMLButtonElement;
     expect(toggle.disabled).toBe(true);
     expect(getByTestId("daily-credit-limit-required-note").textContent).toBe(
-      "A daily credit limit is required while automatic top-ups are enabled.",
+      "A daily credit limit is required while auto-reload is enabled.",
     );
 
     // The guard holds even if the click lands (e.g. a programmatic change):

--- a/clients/web/src/domains/settings/components/daily-credit-limit-card.tsx
+++ b/clients/web/src/domains/settings/components/daily-credit-limit-card.tsx
@@ -228,7 +228,7 @@ export function DailyCreditLimitCard() {
           disabled={
             updateMutation.isPending || (hasLimit && requiredByAutoTopUp)
           }
-          label="Set a daily credit limit"
+          label="Daily Credit Limit"
         />
 
         {requiredByAutoTopUp && (
@@ -236,8 +236,7 @@ export function DailyCreditLimitCard() {
             className="text-body-small-default text-[var(--content-tertiary)]"
             data-testid="daily-credit-limit-required-note"
           >
-            A daily credit limit is required while automatic top-ups are
-            enabled.
+            A daily credit limit is required while auto-reload is enabled.
           </p>
         )}
 

--- a/clients/web/src/domains/settings/components/daily-credit-limit-card.tsx
+++ b/clients/web/src/domains/settings/components/daily-credit-limit-card.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/generated/api/@tanstack/react-query.gen";
 import { useResumeDailyLimit } from "@/hooks/use-daily-limit-skip";
 import { useScrollToAnchor } from "@/hooks/use-scroll-to-anchor";
+import { useTranslation } from "@/i18n";
 import { dailyResetTimePhrase } from "@/utils/daily-reset-time";
 import { formatUsd } from "@/utils/format-usd";
 import { Button } from "@vellumai/design-library/components/button";
@@ -65,6 +66,7 @@ export function validateDailyLimit(raw: string): string | undefined {
  * both so the summary's `daily_limit_reached`/`daily_spend_usd` stay in sync.
  */
 export function DailyCreditLimitCard() {
+  const { t } = useTranslation("settings");
   const queryClient = useQueryClient();
   const limitQuery = useQuery(
     organizationsBillingDailyCreditLimitRetrieveOptions(),
@@ -228,7 +230,7 @@ export function DailyCreditLimitCard() {
           disabled={
             updateMutation.isPending || (hasLimit && requiredByAutoTopUp)
           }
-          label="Daily Credit Limit"
+          label={t("dailyCreditLimitCard.toggleLabel")}
         />
 
         {requiredByAutoTopUp && (
@@ -236,7 +238,7 @@ export function DailyCreditLimitCard() {
             className="text-body-small-default text-[var(--content-tertiary)]"
             data-testid="daily-credit-limit-required-note"
           >
-            A daily credit limit is required while auto-reload is enabled.
+            {t("dailyCreditLimitCard.requiredNote")}
           </p>
         )}
 

--- a/clients/web/src/domains/settings/components/daily-credit-limit-card.tsx
+++ b/clients/web/src/domains/settings/components/daily-credit-limit-card.tsx
@@ -327,11 +327,6 @@ export function DailyCreditLimitCard() {
         )}
       </div>
 
-      <p className="mt-3 text-body-small-default text-[var(--content-tertiary)]">
-        Applies to Vellum credit spend only. Usage billed to your own provider
-        API keys isn&apos;t limited. Resets daily at {resetPhrase}.
-      </p>
-
       {saveError != null && (
         <Notice
           tone="error"

--- a/clients/web/src/domains/settings/components/invoices-table.test.tsx
+++ b/clients/web/src/domains/settings/components/invoices-table.test.tsx
@@ -131,9 +131,8 @@ describe("InvoicesTable collapse", () => {
     const { getByText, getByTestId, queryByTestId } = renderTable();
 
     getByText("Invoices");
-    getByText("Your billing history.");
     expect(getByTestId("invoices-toggle").textContent).toContain(
-      "Show invoices",
+      "Show Invoices",
     );
     expect(queryByTestId("invoices-table")).toBeNull();
     expect(queryByTestId("invoices-download-all")).toBeNull();
@@ -146,7 +145,7 @@ describe("InvoicesTable collapse", () => {
     expect(listRetrieveCalls.length).toBe(1);
     expect(getAllByTestId("invoice-row").length).toBe(2);
     expect(getByTestId("invoices-toggle").textContent).toContain(
-      "Hide invoices",
+      "Hide Invoices",
     );
     getByTestId("invoices-download-all");
 
@@ -154,7 +153,7 @@ describe("InvoicesTable collapse", () => {
     expect(queryByTestId("invoices-table")).toBeNull();
     expect(queryByTestId("invoices-download-all")).toBeNull();
     expect(getByTestId("invoices-toggle").textContent).toContain(
-      "Show invoices",
+      "Show Invoices",
     );
   });
 

--- a/clients/web/src/domains/settings/components/invoices-table.tsx
+++ b/clients/web/src/domains/settings/components/invoices-table.tsx
@@ -26,6 +26,8 @@ import { toast } from "@vellumai/design-library/components/toast";
 import { Typography } from "@vellumai/design-library/components/typography";
 import { stripeScaleDigits } from "@vellumai/service-contracts/stripe-currency";
 
+import { BillingSectionHeader } from "./billing-section-header";
+
 const EMPTY_RESPONSE: InvoiceListResponse = { invoices: [], has_more: false };
 
 const INITIAL_VISIBLE = 4;
@@ -205,72 +207,60 @@ export function InvoicesTable() {
   return (
     <Card padding="md">
       <div className="flex flex-col gap-4">
-        <div className="flex items-start justify-between gap-4">
-          <div>
-            <Typography
-              as="h2"
-              variant="title-medium"
-              className="text-[var(--content-default)]"
-            >
-              Invoices
-            </Typography>
-            <Typography
-              as="p"
-              variant="body-small-default"
-              className="mt-2 text-[var(--content-tertiary)]"
-            >
-              Your billing history.
-            </Typography>
-          </div>
-          <div className="flex shrink-0 items-center gap-2">
-            {expanded && invoices.length > 0 && (
+        <BillingSectionHeader
+          title="Invoices"
+          actions={
+            <>
+              {expanded && invoices.length > 0 && (
+                <Button
+                  variant="outlined"
+                  leftIcon={
+                    isDownloadingAll ? (
+                      <Loader2 className="animate-spin" />
+                    ) : (
+                      <Download className="h-4 w-4" />
+                    )
+                  }
+                  onClick={downloadAllInvoices}
+                  disabled={isDownloadingAll}
+                  data-testid="invoices-download-all"
+                >
+                  Download all
+                </Button>
+              )}
               <Button
                 variant="outlined"
-                leftIcon={
-                  isDownloadingAll ? (
-                    <Loader2 className="animate-spin" />
+                rightIcon={
+                  expanded ? (
+                    <ChevronUp className="h-4 w-4" />
                   ) : (
-                    <Download className="h-4 w-4" />
+                    <ChevronDown className="h-4 w-4" />
                   )
                 }
-                onClick={downloadAllInvoices}
-                disabled={isDownloadingAll}
-                data-testid="invoices-download-all"
+                onClick={() => {
+                  // Collapsing abandons a failed page load; re-expanding
+                  // refetches, so a stale banner would sit over fresh data.
+                  // The bump also stops in-flight page fetches from writing
+                  // pageLoadFailed after this reset, and cancelling on collapse
+                  // keeps an abandoned page fetch from failing after re-expand
+                  // and resurrecting the banner via isFetchNextPageError.
+                  loadAttemptRef.current += 1;
+                  setPageLoadFailed(false);
+                  if (expanded) {
+                    void queryClient.cancelQueries({
+                      queryKey:
+                        organizationsBillingInvoicesRetrieveInfiniteQueryKey(),
+                    });
+                  }
+                  setExpanded((v) => !v);
+                }}
+                data-testid="invoices-toggle"
               >
-                Download all
+                {expanded ? "Hide Invoices" : "Show Invoices"}
               </Button>
-            )}
-            <Button
-              variant="outlined"
-              leftIcon={
-                expanded ? (
-                  <ChevronUp className="h-4 w-4" />
-                ) : (
-                  <ChevronDown className="h-4 w-4" />
-                )
-              }
-              onClick={() => {
-                // Collapsing abandons a failed page load; re-expanding
-                // refetches, so a stale banner would sit over fresh data.
-                // The bump also stops in-flight page fetches from writing
-                // pageLoadFailed after this reset, and cancelling on collapse
-                // keeps an abandoned page fetch from failing after re-expand
-                // and resurrecting the banner via isFetchNextPageError.
-                loadAttemptRef.current += 1;
-                setPageLoadFailed(false);
-                if (expanded) {
-                  void queryClient.cancelQueries({
-                    queryKey: organizationsBillingInvoicesRetrieveInfiniteQueryKey(),
-                  });
-                }
-                setExpanded((v) => !v);
-              }}
-              data-testid="invoices-toggle"
-            >
-              {expanded ? "Hide invoices" : "Show invoices"}
-            </Button>
-          </div>
-        </div>
+            </>
+          }
+        />
 
         {!expanded ? null : invoicesQuery.isLoading ? (
           <div className="flex items-center gap-2 py-6 text-[var(--content-tertiary)]">

--- a/clients/web/src/domains/settings/components/invoices-table.tsx
+++ b/clients/web/src/domains/settings/components/invoices-table.tsx
@@ -26,6 +26,7 @@ import { toast } from "@vellumai/design-library/components/toast";
 import { Typography } from "@vellumai/design-library/components/typography";
 import { stripeScaleDigits } from "@vellumai/service-contracts/stripe-currency";
 
+import { useTranslation } from "@/i18n";
 import { BillingSectionHeader } from "./billing-section-header";
 
 const EMPTY_RESPONSE: InvoiceListResponse = { invoices: [], has_more: false };
@@ -89,6 +90,7 @@ function downloadPdf(url: string): void {
 }
 
 export function InvoicesTable() {
+  const { t } = useTranslation("settings");
   const [expanded, setExpanded] = useState(false);
   const [showAll, setShowAll] = useState(false);
   const [isDownloadingAll, setIsDownloadingAll] = useState(false);
@@ -208,7 +210,7 @@ export function InvoicesTable() {
     <Card padding="md">
       <div className="flex flex-col gap-4">
         <BillingSectionHeader
-          title="Invoices"
+          title={t("invoicesTable.title")}
           actions={
             <>
               {expanded && invoices.length > 0 && (
@@ -256,7 +258,9 @@ export function InvoicesTable() {
                 }}
                 data-testid="invoices-toggle"
               >
-                {expanded ? "Hide Invoices" : "Show Invoices"}
+                {expanded
+                  ? t("invoicesTable.hideButton")
+                  : t("invoicesTable.showButton")}
               </Button>
             </>
           }

--- a/clients/web/src/domains/settings/components/payment-method-row.tsx
+++ b/clients/web/src/domains/settings/components/payment-method-row.tsx
@@ -23,14 +23,14 @@ export function PaymentMethodRow({
   return (
     <div
       data-testid="payment-method-row"
-      className="flex items-center justify-between gap-2 rounded-lg bg-[var(--surface-base)] pl-3 pr-2 py-1.5"
+      className="flex items-center justify-between gap-2 rounded-lg border border-[var(--border-base)] pl-3 pr-2 py-1.5"
     >
       <div className="flex min-w-0 items-center gap-2">
         <CreditCard
           aria-hidden
           className="h-4 w-4 shrink-0 text-[var(--content-default)]"
         />
-        <div className="min-w-0">
+        <div className="flex min-w-0 items-baseline gap-2">
           <Typography
             as="p"
             variant="body-medium-default"
@@ -51,7 +51,7 @@ export function PaymentMethodRow({
       </div>
       <div className="flex shrink-0 items-center gap-2">
         <Button
-          variant="outlined"
+          variant="ghost"
           onClick={onUpdateCard}
           data-testid="payment-method-update"
         >

--- a/clients/web/src/domains/settings/components/payment-method-row.tsx
+++ b/clients/web/src/domains/settings/components/payment-method-row.tsx
@@ -30,11 +30,13 @@ export function PaymentMethodRow({
           aria-hidden
           className="h-4 w-4 shrink-0 text-[var(--content-default)]"
         />
+        {/* leading-snug: the type tokens are line-height:1 and truncate's
+            overflow clipping would cut descenders without real line height. */}
         <div className="flex min-w-0 items-baseline gap-2">
           <Typography
             as="p"
             variant="body-medium-default"
-            className="truncate text-[var(--content-default)]"
+            className="truncate leading-snug text-[var(--content-default)]"
           >
             {brand ? brandLabel(brand) : "Saved card"}
           </Typography>
@@ -42,7 +44,7 @@ export function PaymentMethodRow({
             <Typography
               as="p"
               variant="body-small-default"
-              className="truncate text-[var(--content-tertiary)]"
+              className="truncate leading-snug text-[var(--content-tertiary)]"
             >
               Ending in {last4}
             </Typography>

--- a/clients/web/src/domains/settings/components/payment-methods-card.test.tsx
+++ b/clients/web/src/domains/settings/components/payment-methods-card.test.tsx
@@ -1,0 +1,267 @@
+/**
+ * Tests for the PaymentMethodsCard section:
+ *  - Renders the payment-method row (brand, last4, Update/Remove) whenever a
+ *    card is on file (including while auto-reload is off) and a muted empty
+ *    state otherwise.
+ *  - "Add Payment Method" and "Update Card" open the Stripe setup modal
+ *    (stubbed here; the modal has its own tests).
+ *  - Removing the saved card opens a destructive confirm warning it turns off
+ *    auto-reload; confirming calls the remove endpoint and drives the config
+ *    to disabled / no card. A failed removal closes the dialog and surfaces
+ *    the error notice.
+ *
+ * Strategy: pre-populate the React Query cache so `useQuery` resolves
+ * synchronously; mock the SDK boundary so the remove mutation and the
+ * follow-up GET are deterministic.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+
+import * as sdkGen from "@/generated/api/sdk.gen";
+import type { AutoTopUpConfigResponse } from "@/generated/api/types.gen";
+
+let removeCalls: Array<Record<string, unknown>> = [];
+let removeShouldFail = false;
+let retrieveResponse: AutoTopUpConfigResponse;
+
+mock.module("@/generated/api/sdk.gen", () => ({
+  ...sdkGen,
+  organizationsBillingAutoTopUpRemovePaymentMethodCreate: (
+    opts: Record<string, unknown>,
+  ) => {
+    removeCalls.push(opts);
+    if (removeShouldFail) {
+      return Promise.reject(new Error("remove failed"));
+    }
+    // The endpoint clears the PM and disables auto-reload server-side, so the
+    // next GET reflects that.
+    retrieveResponse = {
+      ...retrieveResponse,
+      enabled: false,
+      has_payment_method: false,
+      payment_method_brand: null,
+      payment_method_last4: null,
+    };
+    return Promise.resolve({
+      data: {
+        enabled: false,
+        stubbed: false,
+        message: "Payment method removed",
+      },
+      response: { ok: true },
+    });
+  },
+  organizationsBillingAutoTopUpRetrieve: () =>
+    Promise.resolve({ data: retrieveResponse, response: { ok: true } }),
+}));
+
+// Stub the Stripe setup modal: these tests only assert it is opened/closed.
+mock.module(
+  "@/domains/settings/components/auto-top-up-payment-method-modal",
+  () => ({
+    AutoTopUpPaymentMethodModal: ({ open }: { open: boolean }) =>
+      open ? <div data-testid="pm-modal-stub" /> : null,
+  }),
+);
+
+import { organizationsBillingAutoTopUpRetrieveQueryKey } from "@/generated/api/@tanstack/react-query.gen";
+
+const { PaymentMethodsCard } = await import("./payment-methods-card");
+const { DISABLED_CONFIG } = await import("./auto-top-up-card");
+
+const ENABLED_WITH_CARD: AutoTopUpConfigResponse = {
+  ...DISABLED_CONFIG,
+  enabled: true,
+  threshold_usd: "50.00",
+  amount_usd: "200.00",
+  has_payment_method: true,
+  payment_method_brand: "visa",
+  payment_method_last4: "4242",
+};
+
+const DISABLED_WITH_CARD: AutoTopUpConfigResponse = {
+  ...DISABLED_CONFIG,
+  enabled: false,
+  has_payment_method: true,
+  payment_method_brand: "visa",
+  payment_method_last4: "4242",
+};
+
+function wrap(config: AutoTopUpConfigResponse) {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  client.setQueryData(organizationsBillingAutoTopUpRetrieveQueryKey(), config);
+  return (
+    <QueryClientProvider client={client}>
+      <PaymentMethodsCard />
+    </QueryClientProvider>
+  );
+}
+
+async function openRemoveConfirm(container: HTMLElement) {
+  fireEvent.click(
+    container.querySelector('[data-testid="payment-method-remove"]')!,
+  );
+  return waitFor(() => {
+    const btn = document.querySelector<HTMLButtonElement>(
+      "[data-confirm-dialog-confirm]",
+    );
+    if (!btn) {
+      throw new Error("confirm dialog not open");
+    }
+    return btn;
+  });
+}
+
+beforeEach(() => {
+  removeCalls = [];
+  removeShouldFail = false;
+  retrieveResponse = { ...DISABLED_CONFIG };
+});
+
+afterEach(cleanup);
+
+describe("PaymentMethodsCard row and empty state", () => {
+  test("renders the saved card row with Update/Remove", () => {
+    retrieveResponse = { ...ENABLED_WITH_CARD };
+    const { container } = render(wrap(ENABLED_WITH_CARD));
+
+    const row = container.querySelector('[data-testid="payment-method-row"]');
+    expect(row).not.toBeNull();
+    expect(row?.textContent).toContain("Visa");
+    expect(row?.textContent).toContain("Ending in 4242");
+    expect(
+      container.querySelector('[data-testid="payment-method-update"]'),
+    ).not.toBeNull();
+    expect(
+      container.querySelector('[data-testid="payment-method-remove"]'),
+    ).not.toBeNull();
+  });
+
+  test("keeps the card row reachable while auto-reload is off", () => {
+    retrieveResponse = { ...DISABLED_WITH_CARD };
+    const { container } = render(wrap(DISABLED_WITH_CARD));
+
+    expect(
+      container.querySelector('[data-testid="payment-method-row"]'),
+    ).not.toBeNull();
+    expect(
+      container.querySelector('[data-testid="payment-methods-empty"]'),
+    ).toBeNull();
+  });
+
+  test("renders the muted empty state when no card is on file", () => {
+    const { container, getByTestId } = render(wrap(DISABLED_CONFIG));
+
+    expect(getByTestId("payment-methods-empty").textContent).toContain(
+      "No payment method on file",
+    );
+    expect(
+      container.querySelector('[data-testid="payment-method-row"]'),
+    ).toBeNull();
+  });
+});
+
+describe("PaymentMethodsCard modal wiring", () => {
+  test("Add Payment Method opens the setup modal", () => {
+    const { container, getByTestId } = render(wrap(DISABLED_CONFIG));
+
+    expect(
+      container.querySelector('[data-testid="pm-modal-stub"]'),
+    ).toBeNull();
+
+    fireEvent.click(getByTestId("payment-methods-add"));
+
+    expect(
+      container.querySelector('[data-testid="pm-modal-stub"]'),
+    ).not.toBeNull();
+  });
+
+  test("Update Card opens the setup modal", () => {
+    retrieveResponse = { ...DISABLED_WITH_CARD };
+    const { container, getByTestId } = render(wrap(DISABLED_WITH_CARD));
+
+    fireEvent.click(getByTestId("payment-method-update"));
+
+    expect(
+      container.querySelector('[data-testid="pm-modal-stub"]'),
+    ).not.toBeNull();
+  });
+});
+
+describe("PaymentMethodsCard remove card", () => {
+  test("confirming Remove calls the endpoint and clears the card", async () => {
+    retrieveResponse = { ...ENABLED_WITH_CARD };
+    const { container } = render(wrap(ENABLED_WITH_CARD));
+
+    expect(
+      container.querySelector('[data-testid="payment-method-row"]'),
+    ).not.toBeNull();
+
+    // Remove opens a destructive confirm that warns it turns off auto-reload.
+    const confirmButton = await openRemoveConfirm(container);
+    expect(document.body.textContent).toContain("Remove payment method?");
+    expect(document.body.textContent).toContain("turn off auto-reload");
+    expect(removeCalls.length).toBe(0);
+
+    fireEvent.click(confirmButton);
+
+    await waitFor(() => {
+      if (removeCalls.length === 0) {
+        throw new Error("remove endpoint not called");
+      }
+    });
+
+    // The section drops to the empty state; no error notice.
+    await waitFor(() => {
+      if (container.querySelector('[data-testid="payment-method-row"]')) {
+        throw new Error("payment-method row still present");
+      }
+      if (
+        !container.querySelector('[data-testid="payment-methods-empty"]')
+      ) {
+        throw new Error("empty state not shown");
+      }
+    });
+    expect(
+      container.querySelector('[data-testid="auto-top-up-remove-error"]'),
+    ).toBeNull();
+  });
+
+  test("a failed removal closes the confirm dialog and surfaces the error notice", async () => {
+    removeShouldFail = true;
+    retrieveResponse = { ...ENABLED_WITH_CARD };
+    const { container } = render(wrap(ENABLED_WITH_CARD));
+
+    const confirmButton = await openRemoveConfirm(container);
+    fireEvent.click(confirmButton);
+
+    await waitFor(() => {
+      if (removeCalls.length === 0) {
+        throw new Error("remove endpoint not called");
+      }
+    });
+
+    // On failure the dialog closes (so the notice isn't hidden behind the
+    // overlay) and the card row stays put for a retry.
+    await waitFor(() => {
+      if (document.querySelector("[data-confirm-dialog-confirm]")) {
+        throw new Error("confirm dialog still open");
+      }
+      if (
+        !container.querySelector('[data-testid="auto-top-up-remove-error"]')
+      ) {
+        throw new Error("remove error notice not shown");
+      }
+    });
+    expect(
+      container.querySelector('[data-testid="payment-method-row"]'),
+    ).not.toBeNull();
+  });
+});

--- a/clients/web/src/domains/settings/components/payment-methods-card.tsx
+++ b/clients/web/src/domains/settings/components/payment-methods-card.tsx
@@ -95,12 +95,11 @@ export function PaymentMethodsCard() {
     }
     if (!config.has_payment_method) {
       return (
-        <p
-          className="mt-4 text-body-medium-lighter text-[var(--content-tertiary)]"
-          data-testid="payment-methods-empty"
-        >
-          {t("paymentMethodsCard.empty")}
-        </p>
+        <div className="mt-4">
+          <Notice tone="neutral" data-testid="payment-methods-empty">
+            {t("paymentMethodsCard.empty")}
+          </Notice>
+        </div>
       );
     }
     return (

--- a/clients/web/src/domains/settings/components/payment-methods-card.tsx
+++ b/clients/web/src/domains/settings/components/payment-methods-card.tsx
@@ -17,6 +17,7 @@ import { AutoTopUpPaymentMethodModal } from "@/domains/settings/components/auto-
 import { BillingSectionHeader } from "@/domains/settings/components/billing-section-header";
 import { PaymentMethodRow } from "@/domains/settings/components/payment-method-row";
 import { usePaymentMethodSavedPoll } from "@/domains/settings/hooks/use-payment-method-saved-poll";
+import { useTranslation } from "@/i18n";
 
 /**
  * Settings → Billing "Payment Methods" section. Card management lives here;
@@ -24,6 +25,7 @@ import { usePaymentMethodSavedPoll } from "@/domains/settings/hooks/use-payment-
  * section), which reacts to removals via the shared config query.
  */
 export function PaymentMethodsCard() {
+  const { t } = useTranslation("settings");
   const queryClient = useQueryClient();
   const configQuery = useQuery(organizationsBillingAutoTopUpRetrieveOptions());
   const removeMutation = useMutation(
@@ -80,14 +82,14 @@ export function PaymentMethodsCard() {
     if (configQuery.isLoading) {
       return (
         <p className="mt-4 text-body-medium-lighter text-[var(--content-tertiary)]">
-          Loading…
+          {t("paymentMethodsCard.loading")}
         </p>
       );
     }
     if (configQuery.isError || config == null) {
       return (
         <div className="mt-4">
-          <Notice tone="error">Failed to load payment methods.</Notice>
+          <Notice tone="error">{t("paymentMethodsCard.loadError")}</Notice>
         </div>
       );
     }
@@ -97,7 +99,7 @@ export function PaymentMethodsCard() {
           className="mt-4 text-body-medium-lighter text-[var(--content-tertiary)]"
           data-testid="payment-methods-empty"
         >
-          No payment method on file
+          {t("paymentMethodsCard.empty")}
         </p>
       );
     }
@@ -117,15 +119,15 @@ export function PaymentMethodsCard() {
   return (
     <Card padding="md" data-testid="payment-methods-card">
       <BillingSectionHeader
-        title="Payment Methods"
-        subtitle="Payment methods linked to your account."
+        title={t("paymentMethodsCard.title")}
+        subtitle={t("paymentMethodsCard.subtitle")}
         actions={
           <Button
             variant="outlined"
             onClick={() => setPmModalOpen(true)}
             data-testid="payment-methods-add"
           >
-            Add Payment Method
+            {t("paymentMethodsCard.addButton")}
           </Button>
         }
       />
@@ -138,17 +140,21 @@ export function PaymentMethodsCard() {
           className="mt-4"
           data-testid="auto-top-up-remove-error"
         >
-          Failed to remove the payment method. Please try again.
+          {t("paymentMethodsCard.removeError")}
         </Notice>
       )}
 
       <ConfirmDialog
         open={confirmingRemove}
-        title="Remove payment method?"
-        message="Removing your card will turn off auto-reload."
-        confirmLabel={removeMutation.isPending ? "Removing…" : "Remove"}
+        title={t("paymentMethodsCard.removeConfirmTitle")}
+        message={t("paymentMethodsCard.removeConfirmMessage")}
+        confirmLabel={
+          removeMutation.isPending
+            ? t("paymentMethodsCard.removeConfirmPending")
+            : t("paymentMethodsCard.removeConfirmConfirm")
+        }
         isPending={removeMutation.isPending}
-        cancelLabel="Keep card"
+        cancelLabel={t("paymentMethodsCard.removeConfirmCancel")}
         destructive
         onConfirm={handleConfirmRemove}
         onCancel={() => setConfirmingRemove(false)}

--- a/clients/web/src/domains/settings/components/payment-methods-card.tsx
+++ b/clients/web/src/domains/settings/components/payment-methods-card.tsx
@@ -16,7 +16,7 @@ import { Notice } from "@vellumai/design-library/components/notice";
 import { AutoTopUpPaymentMethodModal } from "@/domains/settings/components/auto-top-up-payment-method-modal";
 import { BillingSectionHeader } from "@/domains/settings/components/billing-section-header";
 import { PaymentMethodRow } from "@/domains/settings/components/payment-method-row";
-import { usePaymentMethodSavedPoll } from "@/domains/settings/hooks/use-payment-method-saved-poll";
+import { usePaymentMethodSavedSync } from "@/domains/settings/hooks/use-payment-method-saved-poll";
 import { useTranslation } from "@/i18n";
 
 /**
@@ -31,7 +31,7 @@ export function PaymentMethodsCard() {
   const removeMutation = useMutation(
     organizationsBillingAutoTopUpRemovePaymentMethodCreateMutation(),
   );
-  const pollPaymentMethodSaved = usePaymentMethodSavedPoll();
+  const syncPaymentMethodSaved = usePaymentMethodSavedSync();
 
   const [pmModalOpen, setPmModalOpen] = useState(false);
   const [confirmingRemove, setConfirmingRemove] = useState(false);
@@ -162,7 +162,7 @@ export function PaymentMethodsCard() {
       <AutoTopUpPaymentMethodModal
         open={pmModalOpen}
         onClose={() => setPmModalOpen(false)}
-        onSavedOptimistic={pollPaymentMethodSaved}
+        onSavedOptimistic={syncPaymentMethodSaved}
       />
     </Card>
   );

--- a/clients/web/src/domains/settings/components/payment-methods-card.tsx
+++ b/clients/web/src/domains/settings/components/payment-methods-card.tsx
@@ -96,7 +96,7 @@ export function PaymentMethodsCard() {
     if (!config.has_payment_method) {
       return (
         <div className="mt-4">
-          <Notice tone="neutral" data-testid="payment-methods-empty">
+          <Notice tone="info" data-testid="payment-methods-empty">
             {t("paymentMethodsCard.empty")}
           </Notice>
         </div>

--- a/clients/web/src/domains/settings/components/payment-methods-card.tsx
+++ b/clients/web/src/domains/settings/components/payment-methods-card.tsx
@@ -1,0 +1,164 @@
+import { useState } from "react";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import {
+  organizationsBillingAutoTopUpRemovePaymentMethodCreateMutation,
+  organizationsBillingAutoTopUpRetrieveOptions,
+  organizationsBillingAutoTopUpRetrieveQueryKey,
+  organizationsBillingAutoTopUpRetrieveSetQueryData,
+} from "@/generated/api/@tanstack/react-query.gen";
+import { Button } from "@vellumai/design-library/components/button";
+import { Card } from "@vellumai/design-library/components/card";
+import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialog";
+import { Notice } from "@vellumai/design-library/components/notice";
+
+import { AutoTopUpPaymentMethodModal } from "@/domains/settings/components/auto-top-up-payment-method-modal";
+import { BillingSectionHeader } from "@/domains/settings/components/billing-section-header";
+import { PaymentMethodRow } from "@/domains/settings/components/payment-method-row";
+import { usePaymentMethodSavedPoll } from "@/domains/settings/hooks/use-payment-method-saved-poll";
+
+/**
+ * Settings → Billing "Payment Methods" section. Card management lives here;
+ * the auto-reload toggle and its config stay in `AutoTopUpCard` (Credits
+ * section), which reacts to removals via the shared config query.
+ */
+export function PaymentMethodsCard() {
+  const queryClient = useQueryClient();
+  const configQuery = useQuery(organizationsBillingAutoTopUpRetrieveOptions());
+  const removeMutation = useMutation(
+    organizationsBillingAutoTopUpRemovePaymentMethodCreateMutation(),
+  );
+  const pollPaymentMethodSaved = usePaymentMethodSavedPoll();
+
+  const [pmModalOpen, setPmModalOpen] = useState(false);
+  const [confirmingRemove, setConfirmingRemove] = useState(false);
+
+  const config = configQuery.data;
+
+  /**
+   * The remove endpoint clears the PM AND flips `enabled=False` server-side,
+   * so the optimistic write lands on the disabled/no-PM state, matching what
+   * the follow-up GET returns, with no separate disable call needed.
+   * `AutoTopUpCard` closes its Adjust form via the `has_payment_method`
+   * transition this write produces.
+   */
+  const handleConfirmRemove = () => {
+    if (config == null) {
+      return;
+    }
+    removeMutation.mutate(
+      {},
+      {
+        onSuccess: () => {
+          organizationsBillingAutoTopUpRetrieveSetQueryData(
+            queryClient,
+            undefined,
+            {
+              ...config,
+              enabled: false,
+              has_payment_method: false,
+              payment_method_brand: null,
+              payment_method_last4: null,
+            },
+          );
+          void queryClient.invalidateQueries({
+            queryKey: organizationsBillingAutoTopUpRetrieveQueryKey(),
+          });
+          setConfirmingRemove(false);
+        },
+        // Close the dialog on failure so the error notice isn't hidden behind
+        // the overlay; the card row stays put for a retry.
+        onError: () => {
+          setConfirmingRemove(false);
+        },
+      },
+    );
+  };
+
+  const renderBody = () => {
+    if (configQuery.isLoading) {
+      return (
+        <p className="mt-4 text-body-medium-lighter text-[var(--content-tertiary)]">
+          Loading…
+        </p>
+      );
+    }
+    if (configQuery.isError || config == null) {
+      return (
+        <div className="mt-4">
+          <Notice tone="error">Failed to load payment methods.</Notice>
+        </div>
+      );
+    }
+    if (!config.has_payment_method) {
+      return (
+        <p
+          className="mt-4 text-body-medium-lighter text-[var(--content-tertiary)]"
+          data-testid="payment-methods-empty"
+        >
+          No payment method on file
+        </p>
+      );
+    }
+    return (
+      <div className="mt-4">
+        <PaymentMethodRow
+          brand={config.payment_method_brand}
+          last4={config.payment_method_last4}
+          onUpdateCard={() => setPmModalOpen(true)}
+          onRemove={() => setConfirmingRemove(true)}
+          removing={removeMutation.isPending}
+        />
+      </div>
+    );
+  };
+
+  return (
+    <Card padding="md" data-testid="payment-methods-card">
+      <BillingSectionHeader
+        title="Payment Methods"
+        subtitle="Payment methods linked to your account."
+        actions={
+          <Button
+            variant="outlined"
+            onClick={() => setPmModalOpen(true)}
+            data-testid="payment-methods-add"
+          >
+            Add Payment Method
+          </Button>
+        }
+      />
+
+      {renderBody()}
+
+      {removeMutation.isError && (
+        <Notice
+          tone="error"
+          className="mt-4"
+          data-testid="auto-top-up-remove-error"
+        >
+          Failed to remove the payment method. Please try again.
+        </Notice>
+      )}
+
+      <ConfirmDialog
+        open={confirmingRemove}
+        title="Remove payment method?"
+        message="Removing your card will turn off auto-reload."
+        confirmLabel={removeMutation.isPending ? "Removing…" : "Remove"}
+        isPending={removeMutation.isPending}
+        cancelLabel="Keep card"
+        destructive
+        onConfirm={handleConfirmRemove}
+        onCancel={() => setConfirmingRemove(false)}
+      />
+
+      <AutoTopUpPaymentMethodModal
+        open={pmModalOpen}
+        onClose={() => setPmModalOpen(false)}
+        onSavedOptimistic={pollPaymentMethodSaved}
+      />
+    </Card>
+  );
+}

--- a/clients/web/src/domains/settings/hooks/use-payment-method-saved-poll.test.tsx
+++ b/clients/web/src/domains/settings/hooks/use-payment-method-saved-poll.test.tsx
@@ -1,9 +1,15 @@
 /**
- * Tests for usePaymentMethodSavedPoll: the returned callback resolves as soon
- * as the refetched config reports a payment method whose
+ * Tests for the payment-method-saved follow-ups.
+ *
+ * usePaymentMethodSavedPoll: the returned callback resolves as soon as the
+ * refetched config reports a payment method whose
  * `stripe_payment_method_updated_at` advanced past the pre-call cache value,
  * and keeps polling while the marker is unchanged (webhook not landed yet).
  * The 20s timeout path is not exercised here; it would need real time.
+ *
+ * usePaymentMethodSavedSync: confirms the SetupIntent server-side and seeds
+ * the config cache from the response, falling back to the poll when the
+ * confirm call fails or no SetupIntent id was derivable.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -16,6 +22,9 @@ import type { AutoTopUpConfigResponse } from "@/generated/api/types.gen";
 
 let retrieveResponses: AutoTopUpConfigResponse[] = [];
 let retrieveCalls = 0;
+let confirmCalls: Array<Record<string, unknown>> = [];
+let confirmResponse: AutoTopUpConfigResponse | null = null;
+let confirmShouldFail = false;
 
 mock.module("@/generated/api/sdk.gen", () => ({
   ...sdkGen,
@@ -25,13 +34,21 @@ mock.module("@/generated/api/sdk.gen", () => ({
     retrieveCalls += 1;
     return Promise.resolve({ data: next, response: { ok: true } });
   },
+  organizationsBillingAutoTopUpConfirmSetupIntentCreate: (
+    opts: Record<string, unknown>,
+  ) => {
+    confirmCalls.push(opts);
+    if (confirmShouldFail) {
+      return Promise.reject(new Error("confirm failed"));
+    }
+    return Promise.resolve({ data: confirmResponse, response: { ok: true } });
+  },
 }));
 
 import { organizationsBillingAutoTopUpRetrieveQueryKey } from "@/generated/api/@tanstack/react-query.gen";
 
-const { usePaymentMethodSavedPoll } = await import(
-  "./use-payment-method-saved-poll"
-);
+const { usePaymentMethodSavedPoll, usePaymentMethodSavedSync } =
+  await import("./use-payment-method-saved-poll");
 const { DISABLED_CONFIG } = await import("../components/auto-top-up-card");
 
 function makeConfig(
@@ -45,20 +62,44 @@ function makeConfig(
   };
 }
 
-function setup(cached: AutoTopUpConfigResponse) {
+function makeClient(cached: AutoTopUpConfigResponse): QueryClient {
   const client = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
   });
   client.setQueryData(organizationsBillingAutoTopUpRetrieveQueryKey(), cached);
-  const wrapper = ({ children }: { children: ReactNode }) => (
+  return client;
+}
+
+function makeWrapper(client: QueryClient) {
+  return ({ children }: { children: ReactNode }) => (
     <QueryClientProvider client={client}>{children}</QueryClientProvider>
   );
-  return renderHook(() => usePaymentMethodSavedPoll(), { wrapper });
+}
+
+function setup(cached: AutoTopUpConfigResponse) {
+  const client = makeClient(cached);
+  return renderHook(() => usePaymentMethodSavedPoll(), {
+    wrapper: makeWrapper(client),
+  });
+}
+
+function setupSync(cached: AutoTopUpConfigResponse) {
+  const client = makeClient(cached);
+  const rendered = renderHook(() => usePaymentMethodSavedSync(), {
+    wrapper: makeWrapper(client),
+  });
+  return { ...rendered, client };
 }
 
 beforeEach(() => {
   retrieveResponses = [];
   retrieveCalls = 0;
+  confirmCalls = [];
+  confirmResponse = null;
+  confirmShouldFail = false;
 });
 
 describe("usePaymentMethodSavedPoll", () => {
@@ -91,6 +132,52 @@ describe("usePaymentMethodSavedPoll", () => {
 
     await result.current();
 
+    expect(retrieveCalls).toBe(1);
+  });
+});
+
+describe("usePaymentMethodSavedSync", () => {
+  test("seeds the config cache from the confirm response without polling", async () => {
+    const confirmed = {
+      ...makeConfig("2026-08-19T00:00:01Z", true),
+      payment_method_brand: "visa",
+      payment_method_last4: "4242",
+    };
+    confirmResponse = confirmed;
+    const { result, client } = setupSync(makeConfig(null, false));
+
+    await result.current({ setupIntentId: "seti_abc" });
+
+    expect(confirmCalls.length).toBe(1);
+    expect(
+      (confirmCalls[0] as { body: { setup_intent_id: string } }).body,
+    ).toEqual({ setup_intent_id: "seti_abc" });
+    expect(retrieveCalls).toBe(0);
+    expect(
+      client.getQueryData<AutoTopUpConfigResponse>(
+        organizationsBillingAutoTopUpRetrieveQueryKey(),
+      ),
+    ).toEqual(confirmed);
+  });
+
+  test("falls back to the poll when the confirm call fails", async () => {
+    confirmShouldFail = true;
+    retrieveResponses = [makeConfig("2026-08-19T00:00:01Z", true)];
+    const { result } = setupSync(makeConfig("2026-08-19T00:00:00Z", true));
+
+    await result.current({ setupIntentId: "seti_abc" });
+
+    expect(confirmCalls.length).toBe(1);
+    expect(retrieveCalls).toBe(1);
+  });
+
+  test("polls without confirming when no SetupIntent id was derivable", async () => {
+    retrieveResponses = [makeConfig("2026-08-19T00:00:01Z", true)];
+    const { result } = setupSync(makeConfig("2026-08-19T00:00:00Z", true));
+
+    await result.current({ setupIntentId: null });
+
+    expect(confirmCalls.length).toBe(0);
     expect(retrieveCalls).toBe(1);
   });
 });

--- a/clients/web/src/domains/settings/hooks/use-payment-method-saved-poll.test.tsx
+++ b/clients/web/src/domains/settings/hooks/use-payment-method-saved-poll.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * Tests for usePaymentMethodSavedPoll: the returned callback resolves as soon
+ * as the refetched config reports a payment method whose
+ * `stripe_payment_method_updated_at` advanced past the pre-call cache value,
+ * and keeps polling while the marker is unchanged (webhook not landed yet).
+ * The 20s timeout path is not exercised here; it would need real time.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+import * as sdkGen from "@/generated/api/sdk.gen";
+import type { AutoTopUpConfigResponse } from "@/generated/api/types.gen";
+
+let retrieveResponses: AutoTopUpConfigResponse[] = [];
+let retrieveCalls = 0;
+
+mock.module("@/generated/api/sdk.gen", () => ({
+  ...sdkGen,
+  organizationsBillingAutoTopUpRetrieve: () => {
+    const next =
+      retrieveResponses[Math.min(retrieveCalls, retrieveResponses.length - 1)];
+    retrieveCalls += 1;
+    return Promise.resolve({ data: next, response: { ok: true } });
+  },
+}));
+
+import { organizationsBillingAutoTopUpRetrieveQueryKey } from "@/generated/api/@tanstack/react-query.gen";
+
+const { usePaymentMethodSavedPoll } = await import(
+  "./use-payment-method-saved-poll"
+);
+const { DISABLED_CONFIG } = await import("../components/auto-top-up-card");
+
+function makeConfig(
+  marker: string | null,
+  hasPm: boolean,
+): AutoTopUpConfigResponse {
+  return {
+    ...DISABLED_CONFIG,
+    has_payment_method: hasPm,
+    stripe_payment_method_updated_at: marker,
+  };
+}
+
+function setup(cached: AutoTopUpConfigResponse) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  client.setQueryData(organizationsBillingAutoTopUpRetrieveQueryKey(), cached);
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+  return renderHook(() => usePaymentMethodSavedPoll(), { wrapper });
+}
+
+beforeEach(() => {
+  retrieveResponses = [];
+  retrieveCalls = 0;
+});
+
+describe("usePaymentMethodSavedPoll", () => {
+  test("resolves once the marker advances past the pre-call cache value", async () => {
+    retrieveResponses = [makeConfig("2026-08-19T00:00:01Z", true)];
+    const { result } = setup(makeConfig("2026-08-19T00:00:00Z", true));
+
+    await result.current();
+
+    expect(retrieveCalls).toBe(1);
+  });
+
+  test("keeps polling while the marker is unchanged", async () => {
+    // First refetch still carries the stale marker (webhook not landed);
+    // the second carries the fresh one.
+    retrieveResponses = [
+      makeConfig("2026-08-19T00:00:00Z", true),
+      makeConfig("2026-08-19T00:00:01Z", true),
+    ];
+    const { result } = setup(makeConfig("2026-08-19T00:00:00Z", true));
+
+    await result.current();
+
+    expect(retrieveCalls).toBe(2);
+  }, 10_000);
+
+  test("treats a first-ever card (null prior marker) as fresh", async () => {
+    retrieveResponses = [makeConfig("2026-08-19T00:00:01Z", true)];
+    const { result } = setup(makeConfig(null, false));
+
+    await result.current();
+
+    expect(retrieveCalls).toBe(1);
+  });
+});

--- a/clients/web/src/domains/settings/hooks/use-payment-method-saved-poll.ts
+++ b/clients/web/src/domains/settings/hooks/use-payment-method-saved-poll.ts
@@ -1,0 +1,60 @@
+import { useQueryClient } from "@tanstack/react-query";
+
+import {
+  organizationsBillingAutoTopUpRetrieveOptions,
+  organizationsBillingAutoTopUpRetrieveQueryKey,
+} from "@/generated/api/@tanstack/react-query.gen";
+import type { AutoTopUpConfigResponse } from "@/generated/api/types.gen";
+
+export const PM_SAVED_POLL_INTERVAL_MS = 1500;
+export const PM_SAVED_MAX_POLL_MS = 20_000;
+
+/**
+ * Returns the follow-up for `AutoTopUpPaymentMethodModal`'s
+ * `onSavedOptimistic`: the `setup_intent.succeeded` webhook persists
+ * `stripe_payment_method_id` asynchronously, so a single invalidate+refetch
+ * can race the webhook and leave the cache stale. Poll until
+ * `stripe_payment_method_updated_at` actually advances past its pre-save
+ * value, with a timeout so this never spins forever if the webhook never
+ * lands. Always resolves.
+ */
+export function usePaymentMethodSavedPoll(): () => Promise<void> {
+  const queryClient = useQueryClient();
+
+  return async () => {
+    // Snapshot the marker before invalidating so the comparison below is
+    // against the pre-save value.
+    const priorMarker =
+      queryClient.getQueryData<AutoTopUpConfigResponse>(
+        organizationsBillingAutoTopUpRetrieveQueryKey(),
+      )?.stripe_payment_method_updated_at ?? null;
+    const start = Date.now();
+
+    try {
+      await queryClient.invalidateQueries({
+        queryKey: organizationsBillingAutoTopUpRetrieveQueryKey(),
+      });
+    } catch {
+      // fall through to polling below
+    }
+
+    while (Date.now() - start < PM_SAVED_MAX_POLL_MS) {
+      try {
+        const refetched = await queryClient.fetchQuery(
+          organizationsBillingAutoTopUpRetrieveOptions(),
+        );
+        if (
+          refetched.has_payment_method &&
+          refetched.stripe_payment_method_updated_at !== priorMarker
+        ) {
+          break;
+        }
+      } catch {
+        // sleep and retry
+      }
+      await new Promise((resolve) =>
+        setTimeout(resolve, PM_SAVED_POLL_INTERVAL_MS),
+      );
+    }
+  };
+}

--- a/clients/web/src/domains/settings/hooks/use-payment-method-saved-poll.ts
+++ b/clients/web/src/domains/settings/hooks/use-payment-method-saved-poll.ts
@@ -1,8 +1,10 @@
-import { useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import {
+  organizationsBillingAutoTopUpConfirmSetupIntentCreateMutation,
   organizationsBillingAutoTopUpRetrieveOptions,
   organizationsBillingAutoTopUpRetrieveQueryKey,
+  organizationsBillingAutoTopUpRetrieveSetQueryData,
 } from "@/generated/api/@tanstack/react-query.gen";
 import type { AutoTopUpConfigResponse } from "@/generated/api/types.gen";
 
@@ -56,5 +58,44 @@ export function usePaymentMethodSavedPoll(): () => Promise<void> {
         setTimeout(resolve, PM_SAVED_POLL_INTERVAL_MS),
       );
     }
+  };
+}
+
+/**
+ * Confirm-first version of the follow-up above. The confirm endpoint persists
+ * the card and returns the same payload as the config GET, with brand and
+ * last4 filled in, so seeding the cache from it makes the saved card visible
+ * without waiting on the `setup_intent.succeeded` webhook.
+ *
+ * The poll stays as the fallback: when the confirm call fails for any reason
+ * (the endpoint is unavailable on this server, or the request errors), the
+ * webhook remains the durable writer and the poll waits for its write.
+ */
+export function usePaymentMethodSavedSync(): (args: {
+  setupIntentId: string | null;
+}) => Promise<void> {
+  const queryClient = useQueryClient();
+  const pollPaymentMethodSaved = usePaymentMethodSavedPoll();
+  const { mutateAsync: confirmSetupIntent } = useMutation(
+    organizationsBillingAutoTopUpConfirmSetupIntentCreateMutation(),
+  );
+
+  return async ({ setupIntentId }) => {
+    if (setupIntentId != null) {
+      try {
+        const config = await confirmSetupIntent({
+          body: { setup_intent_id: setupIntentId },
+        });
+        organizationsBillingAutoTopUpRetrieveSetQueryData(
+          queryClient,
+          undefined,
+          config,
+        );
+        return;
+      } catch {
+        // fall through to the poll below
+      }
+    }
+    await pollPaymentMethodSaved();
   };
 }

--- a/clients/web/src/i18n/locales/en/common.json
+++ b/clients/web/src/i18n/locales/en/common.json
@@ -1,4 +1,7 @@
 {
+  "addCreditsModal": {
+    "configureAutoReload": "Configure Auto-Reload"
+  },
   "notFound": {
     "badge": "Error 404",
     "title": "Page not found",

--- a/clients/web/src/i18n/locales/en/settings.json
+++ b/clients/web/src/i18n/locales/en/settings.json
@@ -7,6 +7,21 @@
   "aiProviderPicker": {
     "defaultEntryMeta": "Default"
   },
+  "autoTopUpCard": {
+    "connectCardBanner": "Auto-reload requires you to connect a credit card.",
+    "disableError": "Failed to disable auto-reload. Please try again.",
+    "loadError": "Failed to load auto-reload configuration.",
+    "toggleLabel": "Enable auto-reload",
+    "updateError": "Failed to save auto-reload settings. Please try again."
+  },
+  "autoTopUpDisableConfirm": {
+    "message": "Auto-reload will stop. Any saved payment method stays on file.",
+    "title": "Disable auto-reload?"
+  },
+  "autoTopUpForm": {
+    "capHelper": "Pauses auto-reload for the rest of the month once spending reaches this amount. Manual purchases also count toward the total. Leave empty for no limit.",
+    "defaultDailyLimitNote": "A default daily credit limit of {amount} per day will be applied. You can adjust it under Daily Credit Limit."
+  },
   "billingOnboardingModal": {
     "backgroundConfirmContinue": "Continue",
     "backgroundConfirmKeepWaiting": "Keep waiting",
@@ -21,6 +36,14 @@
     "loadingBilling": "Loading billing…",
     "platformLoginNotice": "Log in to the Vellum platform to manage billing and usage.",
     "usageTab": "Usage"
+  },
+  "billingPanel": {
+    "addCreditsButton": "Add Credits",
+    "balanceLabel": "Credits",
+    "earnCreditsButton": "Earn Free Credits",
+    "lowBalanceToggle": "Custom Low Balance Alert",
+    "subtitle": "Quick overview of your balances and other things",
+    "title": "Credits"
   },
   "billingStatusHandler": {
     "successToast": "Payment received! Your credit balance will update shortly.",
@@ -165,6 +188,10 @@
     "genericDescriptor": "Select custom CPU power, Ram and Storage. Or just throw in some tokens.",
     "prompt": "Need something more tailored to your needs?",
     "title": "Custom Plan"
+  },
+  "dailyCreditLimitCard": {
+    "requiredNote": "A daily credit limit is required while auto-reload is enabled.",
+    "toggleLabel": "Daily Credit Limit"
   },
   "developerPage": {
     "sectionsAriaLabel": "Developer sections",
@@ -326,6 +353,11 @@
     "tabMcp": "MCP",
     "tabOAuth": "OAuth",
     "tipBanner": "<tip>Tip:</tip> You can enable integrations by mentioning them in chat."
+  },
+  "invoicesTable": {
+    "hideButton": "Hide Invoices",
+    "showButton": "Show Invoices",
+    "title": "Invoices"
   },
   "languageModelCard": {
     "defaultProviderUnavailable": "Your default provider is not available.",
@@ -561,6 +593,20 @@
     "revokeButton": "Revoke",
     "thisMachine": "This machine",
     "title": "Paired devices ({count})"
+  },
+  "paymentMethodsCard": {
+    "addButton": "Add Payment Method",
+    "empty": "No payment method on file",
+    "loadError": "Failed to load payment methods.",
+    "loading": "Loading…",
+    "removeConfirmCancel": "Keep card",
+    "removeConfirmConfirm": "Remove",
+    "removeConfirmMessage": "Removing your card will turn off auto-reload.",
+    "removeConfirmPending": "Removing…",
+    "removeConfirmTitle": "Remove payment method?",
+    "removeError": "Failed to remove the payment method. Please try again.",
+    "subtitle": "Payment methods linked to your account.",
+    "title": "Payment Methods"
   },
   "pendingPairingRequests": {
     "approveButton": "Approve",

--- a/clients/web/src/i18n/locales/en/settings.json
+++ b/clients/web/src/i18n/locales/en/settings.json
@@ -592,7 +592,7 @@
   },
   "paymentMethodsCard": {
     "addButton": "Add Payment Method",
-    "empty": "No payment method on file",
+    "empty": "No payment method on file. Add one to use auto-reload.",
     "loadError": "Failed to load payment methods.",
     "loading": "Loading…",
     "removeConfirmCancel": "Keep card",

--- a/clients/web/src/i18n/locales/en/settings.json
+++ b/clients/web/src/i18n/locales/en/settings.json
@@ -18,10 +18,6 @@
     "message": "Auto-reload will stop. Any saved payment method stays on file.",
     "title": "Disable auto-reload?"
   },
-  "autoTopUpForm": {
-    "capHelper": "Pauses auto-reload for the rest of the month once spending reaches this amount. Manual purchases also count toward the total. Leave empty for no limit.",
-    "defaultDailyLimitNote": "A default daily credit limit of {amount} per day will be applied. You can adjust it under Daily Credit Limit."
-  },
   "billingOnboardingModal": {
     "backgroundConfirmContinue": "Continue",
     "backgroundConfirmKeepWaiting": "Keep waiting",

--- a/clients/web/src/i18n/locales/es/common.json
+++ b/clients/web/src/i18n/locales/es/common.json
@@ -1,4 +1,7 @@
 {
+  "addCreditsModal": {
+    "configureAutoReload": "Configurar la recarga automática"
+  },
   "notFound": {
     "badge": "Error 404",
     "title": "Página no encontrada",

--- a/clients/web/src/i18n/locales/es/settings.json
+++ b/clients/web/src/i18n/locales/es/settings.json
@@ -18,10 +18,6 @@
     "message": "La recarga automática se detendrá. Los métodos de pago guardados se conservarán.",
     "title": "¿Desactivar la recarga automática?"
   },
-  "autoTopUpForm": {
-    "capHelper": "Pausa la recarga automática durante el resto del mes cuando el gasto alcanza este importe. Las compras manuales también cuentan para el total. Déjalo vacío para no fijar límite.",
-    "defaultDailyLimitNote": "Se aplicará un límite diario de créditos predeterminado de {amount} al día. Puedes ajustarlo en Límite diario de créditos."
-  },
   "billingOnboardingModal": {
     "backgroundConfirmContinue": "Continuar",
     "backgroundConfirmKeepWaiting": "Seguir esperando",

--- a/clients/web/src/i18n/locales/es/settings.json
+++ b/clients/web/src/i18n/locales/es/settings.json
@@ -7,6 +7,21 @@
   "aiProviderPicker": {
     "defaultEntryMeta": "Predeterminado"
   },
+  "autoTopUpCard": {
+    "connectCardBanner": "La recarga automática requiere vincular una tarjeta de crédito.",
+    "disableError": "No se pudo desactivar la recarga automática. Inténtalo de nuevo.",
+    "loadError": "No se pudo cargar la configuración de la recarga automática.",
+    "toggleLabel": "Activar recarga automática",
+    "updateError": "No se pudo guardar la configuración de la recarga automática. Inténtalo de nuevo."
+  },
+  "autoTopUpDisableConfirm": {
+    "message": "La recarga automática se detendrá. Los métodos de pago guardados se conservarán.",
+    "title": "¿Desactivar la recarga automática?"
+  },
+  "autoTopUpForm": {
+    "capHelper": "Pausa la recarga automática durante el resto del mes cuando el gasto alcanza este importe. Las compras manuales también cuentan para el total. Déjalo vacío para no fijar límite.",
+    "defaultDailyLimitNote": "Se aplicará un límite diario de créditos predeterminado de {amount} al día. Puedes ajustarlo en Límite diario de créditos."
+  },
   "billingOnboardingModal": {
     "backgroundConfirmContinue": "Continuar",
     "backgroundConfirmKeepWaiting": "Seguir esperando",
@@ -21,6 +36,14 @@
     "loadingBilling": "Cargando facturación…",
     "platformLoginNotice": "Inicia sesión en la plataforma Vellum para administrar la facturación y el uso.",
     "usageTab": "Uso"
+  },
+  "billingPanel": {
+    "addCreditsButton": "Añadir créditos",
+    "balanceLabel": "Créditos",
+    "earnCreditsButton": "Gana créditos gratis",
+    "lowBalanceToggle": "Alerta personalizada de saldo bajo",
+    "subtitle": "Resumen rápido de tus saldos y otros datos",
+    "title": "Créditos"
   },
   "billingStatusHandler": {
     "successToast": "¡Pago recibido! Tu saldo de créditos se actualizará en breve.",
@@ -165,6 +188,10 @@
     "genericDescriptor": "Selecciona potencia de CPU, RAM y almacenamiento personalizados. O añade algunos tokens.",
     "prompt": "¿Necesitas algo más adaptado a tus necesidades?",
     "title": "Plan personalizado"
+  },
+  "dailyCreditLimitCard": {
+    "requiredNote": "Se requiere un límite diario de créditos mientras la recarga automática está activada.",
+    "toggleLabel": "Límite diario de créditos"
   },
   "developerPage": {
     "sectionsAriaLabel": "Secciones de desarrollador",
@@ -326,6 +353,11 @@
     "tabMcp": "MCP",
     "tabOAuth": "OAuth",
     "tipBanner": "<tip>Consejo:</tip> Puedes habilitar integraciones mencionándolas en el chat."
+  },
+  "invoicesTable": {
+    "hideButton": "Ocultar facturas",
+    "showButton": "Mostrar facturas",
+    "title": "Facturas"
   },
   "languageModelCard": {
     "defaultProviderUnavailable": "Tu proveedor predeterminado no está disponible.",
@@ -561,6 +593,20 @@
     "revokeButton": "Revocar",
     "thisMachine": "Este equipo",
     "title": "Dispositivos vinculados ({count})"
+  },
+  "paymentMethodsCard": {
+    "addButton": "Añadir método de pago",
+    "empty": "No hay ningún método de pago guardado",
+    "loadError": "No se pudieron cargar los métodos de pago.",
+    "loading": "Cargando…",
+    "removeConfirmCancel": "Conservar tarjeta",
+    "removeConfirmConfirm": "Eliminar",
+    "removeConfirmMessage": "Al eliminar tu tarjeta se desactivará la recarga automática.",
+    "removeConfirmPending": "Eliminando…",
+    "removeConfirmTitle": "¿Eliminar el método de pago?",
+    "removeError": "No se pudo eliminar el método de pago. Inténtalo de nuevo.",
+    "subtitle": "Métodos de pago vinculados a tu cuenta.",
+    "title": "Métodos de pago"
   },
   "pendingPairingRequests": {
     "approveButton": "Aprobar",

--- a/clients/web/src/i18n/locales/es/settings.json
+++ b/clients/web/src/i18n/locales/es/settings.json
@@ -592,7 +592,7 @@
   },
   "paymentMethodsCard": {
     "addButton": "Añadir método de pago",
-    "empty": "No hay ningún método de pago guardado",
+    "empty": "No hay ningún método de pago guardado. Añade uno para usar la recarga automática.",
     "loadError": "No se pudieron cargar los métodos de pago.",
     "loading": "Cargando…",
     "removeConfirmCancel": "Conservar tarjeta",


### PR DESCRIPTION
## Summary

Reorganizes the lower half of the billing settings tab to match the new Figma mocks: the Credit Balance + Invoices area becomes three sections (Payment Methods, Credits, Invoices), and "Enable Extra Usage" is rebranded auto-reload. UI-only: every button keeps its existing mutation, query keys, testids, and deeplinks.

## Changes

- **Payment Methods (new section)**: card row with Update Card (unchanged action) and Remove (kept for functionality parity; confirm copy now says it turns off auto-reload), "Add Payment Method" header CTA opening the same Stripe SetupIntent modal, and a muted "No payment method on file" empty state.
- **Credits (was Credit Balance)**: balance banner shows a $-prefixed value labeled "Credits" (no "Resets" text by request); rows reordered to auto-reload → Daily Credit Limit → Custom Low Balance Alert; toggle renamed "Enable auto-reload".
- **Invoices**: subtitle dropped; toggle button restyled to "Show Invoices"/"Hide Invoices" with a right chevron; collapse/fetch/pagination untouched.
- **Plumbing**: `PaymentMethodRow` and the remove flow moved out of `AutoTopUpCard` into the new `PaymentMethodsCard`; the post-save webhook poll extracted to a shared `usePaymentMethodSavedPoll` hook; a `has_payment_method` true→false transition effect closes the Adjust form when the card is removed from the other section; shared `BillingSectionHeader` extracted from the three duplicated headers.
- **Copy rebrand**: remaining "Extra Usage"/"Automatic Top-Ups" strings become auto-reload wording (disable confirm, Add Credits modal link, daily-limit required note, form helper text).

## Testing

- All affected suites pass file-by-file (auto-top-up-card, new payment-methods-card, new poll-hook test, payment-method-row, PM modal, invoices-table, daily-credit-limit, low-balance-alert, add-credits-modal, billing-page).
- Full `bun run test:ci`: 988/992 files pass; the 4 failures (checkout-page, checkout-return-target, sentry-init, daily-reset-time) reproduce with this change stashed, i.e. pre-existing on main in this environment.
- `tsc --noEmit` and `bun run lint` clean.
- Not yet browser-verified; manual QA worth doing: no-card enable flow (toggle → banner → add card → form auto-opens), remove-card flipping the Credits toggle off, `?configure_top_up=1` and `#daily-credit-limit` deeplinks.

## Notes and risks

- The riskiest part is the enable-flow split (poll + `pendingEnable` continuation now spans two sections); it is covered by the moved and added tests.
- No server/API changes; single-revert rollback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)