### PR TITLE
Drop the mobile composer caption, and close the drawer on a leftward swipe

### DIFF
--- a/clients/web/docs/PLATFORM_ADAPTATION.md
+++ b/clients/web/docs/PLATFORM_ADAPTATION.md
@@ -305,6 +305,13 @@ the left half of a mobile viewport opens the navigation drawer. A row there keep
 on the **trailing** edge, or the two gestures resolve to the drawer and the row's leading action is
 unreachable in practice.
 
+Inside the open drawer the contested edge flips: a leftward drag closes it
+([`useSwipeCloseDrawer`](../src/hooks/use-swipe-close-drawer.ts)). Rows keep both edges there,
+because that gesture stands down over anything marked `data-slot="swipe-action-row"`, which
+[`SwipeActionReveal`](../src/components/swipe-action-reveal.tsx) sets on the branch that arms its own
+handlers. A panel gesture layered over rows needs the same opt-out, or it takes drags the rows were
+built to answer.
+
 ---
 
 ## Should iOS and Android differ?

--- a/clients/web/src/components/swipe-action-reveal.tsx
+++ b/clients/web/src/components/swipe-action-reveal.tsx
@@ -145,6 +145,11 @@ export const SwipeActionReveal = forwardRef<
   return (
     <div
       ref={ref}
+      // Marks a row that owns horizontal drags, so an enclosing panel gesture
+      // can stand down over it. The mobile drawer's swipe-to-close reads this
+      // to leave a row's own swipe actions alone. Only the armed branch carries
+      // it: with no actions there is nothing to yield to.
+      data-slot="swipe-action-row"
       className={cn("relative overflow-hidden", className)}
       // Spread injected props first so our swipe-specific touch handlers
       // take precedence if there is ever a key collision.

--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -48,6 +48,7 @@ import {
   EDGE_SWIPE_SLIDE_MS,
 } from "@/hooks/edge-swipe-motion";
 import { useEdgeSwipeDrawer } from "@/hooks/use-edge-swipe-drawer";
+import { useSwipeCloseDrawer } from "@/hooks/use-swipe-close-drawer";
 import { useCommandPaletteStore } from "@/stores/command-palette-store";
 import { useMobileDrawerStore } from "@/stores/mobile-drawer-store";
 import { useEdgeSwipeArbiterStore } from "@/stores/edge-swipe-arbiter-store";
@@ -589,6 +590,15 @@ export function ChatLayout({
     onSettle: () => setDrawerDragging(false),
   });
 
+  // Swipe-to-close, the counterpart to the swipe that opened it. Armed only
+  // while the drawer is open, so it and the opening gesture never see the same
+  // touch, and stood down while a swipe-action row is revealed: swiping that
+  // row back toward centre must close the row, not the drawer.
+  const closeSwipe = useSwipeCloseDrawer({
+    enabled: drawerVisible && openRowCount === 0,
+    onClose: closeDrawer,
+  });
+
   const activeConversationId = useConversationStore.use.activeConversationId();
   const processingConversationIds =
     useConversationStore.use.processingConversationIds();
@@ -1105,9 +1115,25 @@ export function ChatLayout({
               className="fixed inset-0"
               style={{
                 zIndex: 40,
-                transform: drawerOpen ? "translateX(0)" : "translateX(-100%)",
-                transition: `transform ${EDGE_SWIPE_SLIDE_MS}ms ${EDGE_SWIPE_EASING}`,
+                // The close drag rides on the open resting transform, so the
+                // panel tracks the finger from where it sits. Releasing short
+                // returns it here under the standard transition; releasing past
+                // the threshold flips `drawerOpen`, and the same transition
+                // carries it the rest of the way out.
+                transform: drawerOpen
+                  ? `translateX(${closeSwipe.dragOffset}px)`
+                  : "translateX(-100%)",
+                transition: closeSwipe.isDragging
+                  ? "none"
+                  : `transform ${EDGE_SWIPE_SLIDE_MS}ms ${EDGE_SWIPE_EASING}`,
+                // Vertical panning stays native for the menu's scrollport while
+                // the horizontal axis belongs to this gesture.
+                touchAction: "pan-y",
               }}
+              onTouchStart={closeSwipe.onTouchStart}
+              onTouchMove={closeSwipe.onTouchMove}
+              onTouchEnd={closeSwipe.onTouchEnd}
+              onTouchCancel={closeSwipe.onTouchCancel}
               role="dialog"
               aria-modal="true"
               aria-label="Navigation"

--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -47,15 +47,13 @@ import {
   EDGE_SWIPE_EASING,
   EDGE_SWIPE_SLIDE_MS,
 } from "@/hooks/edge-swipe-motion";
-import { useEdgeSwipeDrawer } from "@/hooks/use-edge-swipe-drawer";
-import { useSwipeCloseDrawer } from "@/hooks/use-swipe-close-drawer";
 import { useCommandPaletteStore } from "@/stores/command-palette-store";
 import { useMobileDrawerStore } from "@/stores/mobile-drawer-store";
-import { useEdgeSwipeArbiterStore } from "@/stores/edge-swipe-arbiter-store";
 
 import { useActiveConversation } from "@/domains/chat/hooks/use-active-conversation";
 import { useAttentionTracking } from "@/domains/chat/hooks/use-attention-tracking";
 import { useChatLayoutDrawer } from "@/domains/chat/hooks/use-chat-layout-drawer";
+import { useChatLayoutDrawerGestures } from "@/domains/chat/hooks/use-chat-layout-drawer-gestures";
 import { useChatLayoutShortcuts } from "@/domains/chat/hooks/use-chat-layout-shortcuts";
 import { useConversationActions } from "@/domains/chat/hooks/use-conversation-actions";
 import { useConversationGroupActions } from "@/domains/chat/hooks/use-conversation-group-actions";
@@ -449,15 +447,10 @@ export function ChatLayout({
 
   const isMobile = useIsMobile();
   const [drawerOpen, setDrawerOpen] = useState<boolean>(false);
-  // True while a left-edge swipe is dragging the drawer in from off-screen but
-  // has not yet committed open; keeps the panel mounted so its transform can
-  // track the finger before `drawerOpen` flips.
-  const [drawerDragging, setDrawerDragging] = useState<boolean>(false);
 
   useEffect(() => {
     if (!isMobile) {
       setDrawerOpen(false);
-      setDrawerDragging(false);
     }
   }, [isMobile]);
 
@@ -498,23 +491,6 @@ export function ChatLayout({
   const voiceRoomVisible = useIsVoiceRoomVisible();
 
   const drawerVisible = isMobile && drawerOpen;
-
-  // Publish for surfaces that render outside this tree and would otherwise
-  // paint over the drawer; see `mobile-drawer-store`. Mirrors the same
-  // condition the drawer itself mounts on, so the two can't disagree.
-  //
-  // Layout effect, not passive: a passive effect runs after the browser can
-  // paint, so the drawer's first frame would go up with the store still
-  // reporting false and the peek still portaled over it. Publishing before
-  // paint means the two never disagree on screen.
-  const drawerPresented = drawerVisible || drawerDragging;
-  const setDrawerPresented = useMobileDrawerStore.use.setPresented();
-  useLayoutEffect(() => {
-    setDrawerPresented(drawerPresented);
-    return () => {
-      setDrawerPresented(false);
-    };
-  }, [drawerPresented, setDrawerPresented]);
 
   const toggleSidebar = useCallback(() => {
     // The tour forces the rail expanded; a toggle would only flip the
@@ -561,43 +537,41 @@ export function ChatLayout({
     onClose: closeDrawer,
   });
 
-  // Swipe-to-open-menu: track the drawer in from the left edge, committing open
-  // past threshold. Suppressed whenever a back-swipe owner is active (a pushed
-  // page under this layout) so a single left-edge swipe resolves to exactly one
-  // action — back-navigation on detail pages, open-menu at the stack root.
-  // Also suppressed while a swipe-action row is revealed anywhere under the
-  // layout (e.g. a library card showing Pin/Delete): swiping the open row back
-  // toward centre must close it, matching the iOS table-row model where the
-  // open row owns the gesture and the enclosing container yields.
-  const backSwipeOwnerCount = useEdgeSwipeArbiterStore.use.backOwnerCount();
-  const openRowCount = useEdgeSwipeArbiterStore.use.openRowCount();
-  useEdgeSwipeDrawer({
+  // Swipe-to-open from the left edge and swipe-to-close on the panel, plus the
+  // presence the closing slide needs. See the hook for where each gesture
+  // yields and why the panel outlives `drawerOpen`.
+  const drawerGestures = useChatLayoutDrawerGestures({
     panelRef: drawerRef,
-    enabled:
-      isMobile &&
-      !drawerOpen &&
-      backSwipeOwnerCount === 0 &&
-      openRowCount === 0,
-    onDragStart: () => setDrawerDragging(true),
+    isMobile,
+    open: drawerOpen,
     onOpen: () => {
       // Same as the button path: swiping the drawer in over a focused
       // composer must blur it so iOS dismisses the soft keyboard, otherwise
       // the drawer slides in behind a raised keyboard and looks stuck.
       (document.activeElement as HTMLElement | null)?.blur();
       setDrawerOpen(true);
-      setDrawerDragging(false);
     },
-    onSettle: () => setDrawerDragging(false),
-  });
-
-  // Swipe-to-close, the counterpart to the swipe that opened it. Armed only
-  // while the drawer is open, so it and the opening gesture never see the same
-  // touch, and stood down while a swipe-action row is revealed: swiping that
-  // row back toward centre must close the row, not the drawer.
-  const closeSwipe = useSwipeCloseDrawer({
-    enabled: drawerVisible && openRowCount === 0,
     onClose: closeDrawer,
   });
+
+  // Publish for surfaces that render outside this tree and would otherwise
+  // paint over the drawer; see `mobile-drawer-store`. Mirrors the same
+  // condition the drawer itself mounts on, so the two can't disagree: the
+  // panel is still on screen through its closing slide, so the peek stays
+  // parked until the slide ends.
+  //
+  // Layout effect, not passive: a passive effect runs after the browser can
+  // paint, so the drawer's first frame would go up with the store still
+  // reporting false and the peek still portaled over it. Publishing before
+  // paint means the two never disagree on screen.
+  const drawerPresented = isMobile && drawerGestures.present;
+  const setDrawerPresented = useMobileDrawerStore.use.setPresented();
+  useLayoutEffect(() => {
+    setDrawerPresented(drawerPresented);
+    return () => {
+      setDrawerPresented(false);
+    };
+  }, [drawerPresented, setDrawerPresented]);
 
   const activeConversationId = useConversationStore.use.activeConversationId();
   const processingConversationIds =
@@ -1109,7 +1083,7 @@ export function ChatLayout({
               `<main>`'s box instead of the viewport, and sealed below the
               room by its parent's tier: the menu button read as dead. Out
               here its z-40 sorts against the room directly. */}
-          {drawerVisible || drawerDragging ? (
+          {drawerGestures.present ? (
             <div
               ref={drawerRef}
               className="fixed inset-0"
@@ -1121,19 +1095,19 @@ export function ChatLayout({
                 // the threshold flips `drawerOpen`, and the same transition
                 // carries it the rest of the way out.
                 transform: drawerOpen
-                  ? `translateX(${closeSwipe.dragOffset}px)`
+                  ? `translateX(${drawerGestures.dragOffset}px)`
                   : "translateX(-100%)",
-                transition: closeSwipe.isDragging
+                transition: drawerGestures.isDragging
                   ? "none"
                   : `transform ${EDGE_SWIPE_SLIDE_MS}ms ${EDGE_SWIPE_EASING}`,
                 // Vertical panning stays native for the menu's scrollport while
                 // the horizontal axis belongs to this gesture.
                 touchAction: "pan-y",
               }}
-              onTouchStart={closeSwipe.onTouchStart}
-              onTouchMove={closeSwipe.onTouchMove}
-              onTouchEnd={closeSwipe.onTouchEnd}
-              onTouchCancel={closeSwipe.onTouchCancel}
+              onTouchStart={drawerGestures.onTouchStart}
+              onTouchMove={drawerGestures.onTouchMove}
+              onTouchEnd={drawerGestures.onTouchEnd}
+              onTouchCancel={drawerGestures.onTouchCancel}
               role="dialog"
               aria-modal="true"
               aria-label="Navigation"

--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -1093,7 +1093,8 @@ export function ChatLayout({
                 // panel tracks the finger from where it sits. Releasing short
                 // returns it here under the standard transition; releasing past
                 // the threshold flips `drawerOpen`, and the same transition
-                // carries it the rest of the way out.
+                // carries it the rest of the way out while the panel stays
+                // mounted for the slide.
                 transform: drawerOpen
                   ? `translateX(${drawerGestures.dragOffset}px)`
                   : "translateX(-100%)",
@@ -1103,6 +1104,10 @@ export function ChatLayout({
                 // Vertical panning stays native for the menu's scrollport while
                 // the horizontal axis belongs to this gesture.
                 touchAction: "pan-y",
+                // A panel on its way out still covers the viewport for the
+                // length of the slide. Let taps through to the page it is
+                // uncovering rather than swallowing them.
+                pointerEvents: drawerGestures.exiting ? "none" : undefined,
               }}
               onTouchStart={drawerGestures.onTouchStart}
               onTouchMove={drawerGestures.onTouchMove}

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -843,10 +843,6 @@ function pillsRow(container: HTMLElement) {
   return container.querySelector('[data-slot="composer-settings-pills"]');
 }
 
-function disclaimer(container: HTMLElement) {
-  return container.querySelector('[data-slot="composer-disclaimer"]');
-}
-
 /** The wrapper around the card, which publishes the banner flag. */
 function composerShell(container: HTMLElement) {
   return container.querySelector('[data-slot="chat-composer-shell"]');
@@ -1310,18 +1306,6 @@ describe("ChatComposer: mobile settings pills row", () => {
     expect(row?.className).toContain("flex");
   });
 
-  test("an app shell still rests the caption under the card", () => {
-    // GIVEN an untouched phone composer in a Capacitor shell
-    mockIsNativeMobile = true;
-    const { container } = renderPhoneComposer(SETTINGS_SLOTS);
-
-    // THEN both stand: the caption keeps its own at-rest rule, so a resting
-    // composer in a shell carries the row above the card and the caption below
-    // it at the same time
-    expect(disclaimer(container)?.hasAttribute("hidden")).toBe(false);
-    expect(pillsRow(container)?.hasAttribute("hidden")).toBe(false);
-  });
-
   test("focusing the composer raises the row above the card, access first", () => {
     // GIVEN a phone composer
     const { container } = renderPhoneComposer(SETTINGS_SLOTS);
@@ -1387,7 +1371,6 @@ describe("ChatComposer: mobile settings pills row", () => {
     // THEN the row stays up rather than collapsing behind the picker, the same
     // way the sheet used to hold it
     expect(pillsRow(container)?.hasAttribute("hidden")).toBe(false);
-    expect(disclaimer(container)?.hasAttribute("hidden")).toBe(true);
 
     // AND the picker closing gives the composer back to its own focus
     fireEvent(fileInput(container)!, new Event("cancel"));
@@ -1554,106 +1537,6 @@ describe("ChatComposer: a banner standing over the card", () => {
     expect(composerShell(container)?.hasAttribute("data-banner-above")).toBe(
       false,
     );
-  });
-});
-
-// ---------------------------------------------------------------------------
-// The resting caption below the card, the pills row's opposite number
-// ---------------------------------------------------------------------------
-
-describe("ChatComposer: the mobile external-models caption", () => {
-  const DISCLAIMER = "Vellum uses external AI models and can make mistakes";
-
-  test("an unfocused phone composer stands the caption under the card", () => {
-    // GIVEN a phone composer nobody has tapped into
-    const { container } = renderPhoneComposer(SETTINGS_SLOTS);
-
-    // THEN the caption is shown, below the card and outside it
-    const caption = disclaimer(container);
-    expect(caption?.textContent).toBe(DISCLAIMER);
-    expect(caption?.hasAttribute("hidden")).toBe(false);
-    expect(caption?.closest("form")).toBeNull();
-    const html = container.innerHTML;
-    expect(html.indexOf("<form")).toBeLessThan(
-      html.indexOf('data-slot="composer-disclaimer"'),
-    );
-  });
-
-  test("focusing the composer takes the caption away, as the keyboard covers it", () => {
-    // GIVEN a phone composer
-    const { container } = renderPhoneComposer(SETTINGS_SLOTS);
-
-    // WHEN it takes focus
-    fireEvent.focusIn(textareaOf(container));
-
-    // THEN the caption is hidden, still mounted, exactly as the pills row it
-    // trades places with
-    const caption = disclaimer(container);
-    expect(caption?.hasAttribute("hidden")).toBe(true);
-    expect(pillsRow(container)?.hasAttribute("hidden")).toBe(false);
-  });
-
-  test("an open settings sheet keeps the caption away with focus gone", () => {
-    // GIVEN a phone composer whose access sheet is open
-    const { container } = renderPhoneComposer({
-      ...SETTINGS_SLOTS,
-      settingsSheetOpen: true,
-    });
-    const textarea = textareaOf(container);
-    fireEvent.focusIn(textarea);
-
-    // WHEN the sheet takes focus out of the composer
-    fireEvent.focusOut(textarea, { relatedTarget: null });
-
-    // THEN the caption stays away rather than surfacing under the scrim
-    expect(disclaimer(container)?.hasAttribute("hidden")).toBe(true);
-  });
-
-  test("a picker the sheet opened holds the caption away", () => {
-    // The sheet closes itself before opening one and the picker takes the web
-    // view's first responder, so neither the composer's focus nor the sheet's
-    // own flag is still true. What the sheet reports is the only thing left
-    // holding the layout, and a native pick lasts until every file has been
-    // read across the bridge.
-    mockNativePickersAvailable = true;
-    const { container, getByText } = renderPhoneComposer(SETTINGS_SLOTS);
-
-    fireEvent.click(getByText("sheet-picker-up"));
-
-    expect(disclaimer(container)?.hasAttribute("hidden")).toBe(true);
-  });
-
-  test("blurring back to the body brings the caption back", () => {
-    // GIVEN a focused phone composer
-    const { container } = renderPhoneComposer(SETTINGS_SLOTS);
-    const textarea = textareaOf(container);
-    fireEvent.focusIn(textarea);
-
-    // WHEN focus leaves with nowhere to land, as the iOS keyboard dismiss does
-    fireEvent.focusOut(textarea, { relatedTarget: null });
-
-    // THEN the composer is at rest again and the caption is back
-    expect(disclaimer(container)?.hasAttribute("hidden")).toBe(false);
-  });
-
-  test("desktop renders no caption, focused or not", () => {
-    // GIVEN a desktop composer
-    viewport.set({ narrow: false, coarsePointer: false });
-    const { container } = renderComposerView(SETTINGS_SLOTS);
-
-    // THEN nothing hangs under the card, and focus does not add it
-    expect(disclaimer(container)).toBeNull();
-    fireEvent.focusIn(textareaOf(container));
-    expect(disclaimer(container)).toBeNull();
-  });
-
-  test("a variant with no settings slots renders no caption (app-editing panel)", () => {
-    // GIVEN a phone composer that was passed neither settings slot
-    viewport.set({ narrow: true, coarsePointer: true });
-    const { container } = renderComposerView();
-
-    // THEN the panel's composer carries no caption of its own
-    expect(disclaimer(container)).toBeNull();
   });
 });
 
@@ -2152,8 +2035,8 @@ describe("ChatComposer: the mobile send slot", () => {
 describe("ChatComposer: the mobile row holds focus through a press", () => {
   // WebKit blurs the textarea on a press without focusing the pressed button.
   // The mobile composer is gated on that focus, so the pills row above the card
-  // and the disclaimer under it both swap in the same commit and the row's 40px
-  // controls move out from under the finger before the tap's click lands. Each
+  // swaps away and the row's 40px controls move out from under the finger
+  // before the tap's click lands. Each
   // control cancels the compatibility `mousedown`, the event the focus transfer
   // rides on, and leaves `pointerdown` alone, since WebKit drops the whole rest
   // of the sequence when that one is cancelled. See `docs/CAPACITOR.md`.
@@ -2171,7 +2054,6 @@ describe("ChatComposer: the mobile row holds focus through a press", () => {
     // AND the row is still up when the click arrives, so the plus is still
     // under the finger
     expect(pillsRow(container)?.hasAttribute("hidden")).toBe(false);
-    expect(disclaimer(container)?.hasAttribute("hidden")).toBe(true);
 
     // AND the click opens what it always opened
     let opened = 0;

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -901,12 +901,6 @@ export function ChatComposer({
     isMobileMainComposer &&
     !hasBannerAboveCard &&
     (isNativeMobileShell || composerInUse);
-  // The caption is the row's opposite number: it stands under the card at rest
-  // and steps aside the moment anything takes the bottom of the screen, which
-  // is where the keyboard and every sheet cover it anyway. In the shells,
-  // where the pills row stands throughout, the two share the resting composer
-  // rather than trading places.
-  const disclaimerVisible = isMobileMainComposer && !composerInUse;
   // The entrance belongs to the row that arrives with the keyboard. A row that
   // stands throughout has no arrival to animate, and the same animation there
   // replays on every mount, settling the composer on each navigation.
@@ -1661,21 +1655,6 @@ export function ChatComposer({
               )}
             </Popover.Content>
           </Popover.Root>
-          {isMobileMainComposer && (
-            // Mounted for as long as the composer is and toggled with `hidden`,
-            // the same treatment the pills row above the card gets: one caption
-            // that comes and goes rather than a node that mounts and unmounts
-            // under the card the composer is anchored to. Inside the shell, so
-            // focus judged against the shell is unaffected, and below the form,
-            // which is the box `composer-peek` measures.
-            <p
-              data-slot="composer-disclaimer"
-              hidden={!disclaimerVisible}
-              className="mt-2 px-4 text-center text-[10px] leading-3 text-[var(--content-tertiary)]"
-            >
-              {t("chatComposer.disclaimer")}
-            </p>
-          )}
           {/* Beside the form, not inside it: a hidden file input stays mounted
               while a native picker is up, and has no business in the form the
               composer submits. Mounted whatever the row is showing, so a width

--- a/clients/web/src/domains/chat/components/chat-composer/composer-mobile-chrome.ts
+++ b/clients/web/src/domains/chat/components/chat-composer/composer-mobile-chrome.ts
@@ -40,10 +40,10 @@ export const MOBILE_GHOST_WASH_CLASS =
  *
  * WebKit blurs the textarea on a press without focusing the pressed button, and
  * the mobile composer is gated on that focus: the pills row above the card goes
- * away and the disclaimer under it comes back in the same commit, all before the
- * tap's `click` is dispatched. A pill vanishes outright; the action row's 40px
- * controls shift far enough that the press lands off whichever one the finger
- * started on. Either way the tap does nothing but drop the keyboard.
+ * away before the tap's `click` is dispatched. A pill vanishes outright; the
+ * action row's 40px controls shift far enough that the press lands off
+ * whichever one the finger started on. Either way the tap does nothing but drop
+ * the keyboard.
  *
  * `mousedown` is the press to cancel, not `pointerdown`. WebKit drops the whole
  * compatibility sequence when `pointerdown` is cancelled, `click` included.

--- a/clients/web/src/domains/chat/hooks/use-chat-layout-drawer-gestures.test.ts
+++ b/clients/web/src/domains/chat/hooks/use-chat-layout-drawer-gestures.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Tests for `useChatLayoutDrawerGestures`, which arbitrates the mobile
+ * drawer's two swipe gestures and owns how long the panel stays mounted.
+ *
+ * The opening gesture is mocked so its `enabled` can be read directly, the
+ * pattern `sidebar-shell.test.tsx` established. The closing gesture runs for
+ * real, driven through synthesized touch events like
+ * `use-swipe-close-drawer.test.ts`.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { act, renderHook } from "@testing-library/react";
+
+import type { UseEdgeSwipeDrawerArgs } from "@/hooks/use-edge-swipe-drawer";
+import { useEdgeSwipeArbiterStore } from "@/stores/edge-swipe-arbiter-store";
+
+let openSwipeArgs: UseEdgeSwipeDrawerArgs | null = null;
+
+mock.module("@/hooks/use-edge-swipe-drawer", () => ({
+  useEdgeSwipeDrawer: (args: UseEdgeSwipeDrawerArgs) => {
+    openSwipeArgs = args;
+  },
+}));
+
+const { useChatLayoutDrawerGestures } = await import(
+  "./use-chat-layout-drawer-gestures"
+);
+
+interface FakeTouch {
+  identifier: number;
+  clientX: number;
+  clientY: number;
+}
+
+function makeTouchEvent(
+  touches: FakeTouch[],
+  changedTouches: FakeTouch[] = [],
+): React.TouchEvent {
+  return {
+    touches: touches as unknown as TouchList,
+    changedTouches: changedTouches as unknown as TouchList,
+    targetTouches: touches as unknown as TouchList,
+    preventDefault: () => {},
+    stopPropagation: () => {},
+    target: null,
+  } as unknown as React.TouchEvent;
+}
+
+function coarsePointer(matches: boolean) {
+  return ((query: string) => ({
+    matches: matches && query.includes("coarse"),
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia;
+}
+
+function renderGestures(onClose: () => void, initialOpen = true) {
+  const panel = document.createElement("div");
+  document.body.appendChild(panel);
+  const panelRef = { current: panel as HTMLElement | null };
+  const view = renderHook(
+    ({ open }: { open: boolean }) =>
+      useChatLayoutDrawerGestures({
+        panelRef,
+        isMobile: true,
+        open,
+        onOpen: () => {},
+        onClose,
+      }),
+    { initialProps: { open: initialOpen } },
+  );
+  return { ...view, panel };
+}
+
+/** Drag the panel `dx` px and release, the way a finger would. */
+function swipe(
+  result: { current: ReturnType<typeof useChatLayoutDrawerGestures> },
+  dx: number,
+) {
+  const start = { identifier: 1, clientX: 300, clientY: 400 };
+  const end = { identifier: 1, clientX: 300 + dx, clientY: 400 };
+  act(() => {
+    result.current.onTouchStart(makeTouchEvent([start]));
+  });
+  act(() => {
+    result.current.onTouchMove(makeTouchEvent([end]));
+  });
+  act(() => {
+    result.current.onTouchEnd(makeTouchEvent([], [end]));
+  });
+}
+
+beforeEach(() => {
+  window.matchMedia = coarsePointer(true);
+  useEdgeSwipeArbiterStore.setState({ backOwnerCount: 0, openRowCount: 0 });
+});
+
+afterEach(() => {
+  window.matchMedia = coarsePointer(false);
+  useEdgeSwipeArbiterStore.setState({ backOwnerCount: 0, openRowCount: 0 });
+  openSwipeArgs = null;
+  document.body.replaceChildren();
+});
+
+describe("revealed-row arbitration", () => {
+  test("disarms the opening swipe, which listens across the whole route", () => {
+    // GIVEN a drawer that is closed
+    renderGestures(() => {}, false);
+    expect(openSwipeArgs?.enabled).toBe(true);
+
+    // WHEN a row is revealed somewhere on the route behind it
+    act(() => {
+      useEdgeSwipeArbiterStore.getState().registerOpenRow();
+    });
+
+    // THEN the left-edge swipe stands down: it listens on `document`, so it
+    // would otherwise steal the swipe that closes the revealed row.
+    expect(openSwipeArgs?.enabled).toBe(false);
+  });
+
+  test("leaves the closing swipe armed, which only sees its own panel", () => {
+    // GIVEN an open drawer with a row revealed on the route behind it, e.g. a
+    // library card left showing its actions before the drawer was opened
+    const onClose = mock(() => {});
+    const { result } = renderGestures(onClose);
+    act(() => {
+      useEdgeSwipeArbiterStore.getState().registerOpenRow();
+    });
+
+    // WHEN a leftward swipe lands on the drawer itself
+    swipe(result, -120);
+
+    // THEN it still closes: a row revealed behind the drawer says nothing
+    // about a touch that landed on the drawer. Rows inside it are handled at
+    // the target instead, by `useSwipeCloseDrawer`'s own marker check.
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("presence", () => {
+  test("mounts the panel for an opening drag before it commits", () => {
+    // GIVEN a closed drawer
+    const { result } = renderGestures(() => {}, false);
+    expect(result.current.present).toBe(false);
+
+    // WHEN a left-edge swipe starts tracking it in
+    act(() => {
+      openSwipeArgs?.onDragStart();
+    });
+
+    // THEN the panel mounts so the drag has something to move
+    expect(result.current.present).toBe(true);
+
+    // AND a swipe that never commits takes it back out
+    act(() => {
+      openSwipeArgs?.onSettle();
+    });
+    expect(result.current.present).toBe(false);
+  });
+});

--- a/clients/web/src/domains/chat/hooks/use-chat-layout-drawer-gestures.test.ts
+++ b/clients/web/src/domains/chat/hooks/use-chat-layout-drawer-gestures.test.ts
@@ -26,6 +26,9 @@ const { useChatLayoutDrawerGestures } = await import(
   "./use-chat-layout-drawer-gestures"
 );
 
+/** Longer than the slide plus its fallback slack (200ms + 50ms). */
+const PAST_FALLBACK_MS = 340;
+
 interface FakeTouch {
   identifier: number;
   clientX: number;
@@ -142,7 +145,86 @@ describe("revealed-row arbitration", () => {
   });
 });
 
-describe("presence", () => {
+describe("closing slide", () => {
+  test("keeps the panel mounted until the slide ends", () => {
+    // GIVEN an open drawer
+    const { result, rerender, panel } = renderGestures(() => {});
+    expect(result.current.present).toBe(true);
+
+    // WHEN it closes
+    act(() => {
+      rerender({ open: false });
+    });
+
+    // THEN the panel stays in the DOM so the closing transform has something
+    // to run on, and stops taking taps meant for the page it uncovers
+    expect(result.current.present).toBe(true);
+    expect(result.current.exiting).toBe(true);
+
+    // AND it goes away once the slide finishes
+    act(() => {
+      panel.dispatchEvent(new Event("transitionend"));
+    });
+    expect(result.current.present).toBe(false);
+  });
+
+  test("ignores a transition ending on a descendant", () => {
+    // GIVEN a closing drawer
+    const { result, rerender, panel } = renderGestures(() => {});
+    const child = document.createElement("button");
+    panel.appendChild(child);
+    act(() => {
+      rerender({ open: false });
+    });
+
+    // WHEN something inside the menu finishes a transition of its own
+    act(() => {
+      child.dispatchEvent(new Event("transitionend", { bubbles: true }));
+    });
+
+    // THEN the panel is still sliding: only its own transition ends the slide
+    expect(result.current.present).toBe(true);
+  });
+
+  test("gives up on the slide when no transition runs", async () => {
+    // GIVEN a closing drawer whose transition never fires, e.g. reduced motion
+    // or a backgrounded tab
+    const { result, rerender } = renderGestures(() => {});
+    act(() => {
+      rerender({ open: false });
+    });
+
+    // WHEN the slide's window elapses with no `transitionend`
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, PAST_FALLBACK_MS));
+    });
+
+    // THEN the panel unmounts anyway rather than being stranded on screen
+    expect(result.current.present).toBe(false);
+  });
+
+  test("keeps a reopened drawer, cancelling the slide", async () => {
+    // GIVEN a drawer that started closing
+    const { result, rerender } = renderGestures(() => {});
+    act(() => {
+      rerender({ open: false });
+    });
+
+    // WHEN it reopens before the slide ends
+    act(() => {
+      rerender({ open: true });
+    });
+
+    // THEN it is open, not exiting, and the abandoned slide's fallback cannot
+    // unmount it out from under the user
+    expect(result.current.present).toBe(true);
+    expect(result.current.exiting).toBe(false);
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, PAST_FALLBACK_MS));
+    });
+    expect(result.current.present).toBe(true);
+  });
+
   test("mounts the panel for an opening drag before it commits", () => {
     // GIVEN a closed drawer
     const { result } = renderGestures(() => {}, false);

--- a/clients/web/src/domains/chat/hooks/use-chat-layout-drawer-gestures.ts
+++ b/clients/web/src/domains/chat/hooks/use-chat-layout-drawer-gestures.ts
@@ -5,6 +5,10 @@ import {
   type TouchEvent as ReactTouchEvent,
 } from "react";
 
+import {
+  EDGE_SWIPE_FALLBACK_SLACK_MS,
+  EDGE_SWIPE_SLIDE_MS,
+} from "@/hooks/edge-swipe-motion";
 import { useEdgeSwipeDrawer } from "@/hooks/use-edge-swipe-drawer";
 import { useSwipeCloseDrawer } from "@/hooks/use-swipe-close-drawer";
 import { useEdgeSwipeArbiterStore } from "@/stores/edge-swipe-arbiter-store";
@@ -23,8 +27,10 @@ interface UseChatLayoutDrawerGesturesArgs {
 }
 
 interface UseChatLayoutDrawerGesturesResult {
-  /** Whether the panel belongs in the DOM: open, or being dragged in. */
+  /** Whether the panel belongs in the DOM: open, dragging in, or exiting. */
   present: boolean;
+  /** True while the panel is mounted only to finish its closing slide. */
+  exiting: boolean;
   /** Live leftward drag offset (px) of the closing gesture, never positive. */
   dragOffset: number;
   /** True while a closing drag runs, so the caller drops its transition. */
@@ -56,6 +62,14 @@ interface UseChatLayoutDrawerGesturesResult {
  * its own horizontal drag. Route-wide arbitration would be wrong here, because
  * a row revealed on the page *behind* the drawer says nothing about a touch
  * landing on the drawer.
+ *
+ * ## Presence
+ *
+ * `present` outlives `open`. Unmounting the panel the moment the drawer closes
+ * takes the closing transform off screen with it, so the panel vanishes instead
+ * of sliding out. It stays mounted until the slide finishes, resolved by
+ * `transitionend` with a timeout fallback for the case where no transition runs
+ * at all (reduced motion, a zero-duration override, a backgrounded tab).
  */
 export function useChatLayoutDrawerGestures({
   panelRef,
@@ -70,6 +84,15 @@ export function useChatLayoutDrawerGestures({
   // has not yet committed open; keeps it mounted so its transform can track the
   // finger before `open` flips.
   const [dragging, setDragging] = useState(false);
+
+  // Mounted-ness, which lags `visible` on the way out so the closing slide has
+  // something to run on. Raised during render, because a commit that mounts the
+  // panel one render late would start it at its resting transform and skip the
+  // opening slide entirely.
+  const [rendered, setRendered] = useState(visible);
+  if (visible && !rendered) {
+    setRendered(true);
+  }
 
   const backSwipeOwnerCount = useEdgeSwipeArbiterStore.use.backOwnerCount();
   const openRowCount = useEdgeSwipeArbiterStore.use.openRowCount();
@@ -89,13 +112,46 @@ export function useChatLayoutDrawerGestures({
   const closeSwipe = useSwipeCloseDrawer({ enabled: visible, onClose });
 
   useEffect(() => {
+    if (visible || !rendered) {
+      return;
+    }
+    const el = panelRef.current;
+    if (!el) {
+      setRendered(false);
+      return;
+    }
+    let settled = false;
+    const finish = (event?: Event) => {
+      // Descendants of the panel run transitions of their own, and those
+      // bubble. Only the panel's own slide ends this.
+      if (settled || (event && event.target !== el)) {
+        return;
+      }
+      settled = true;
+      el.removeEventListener("transitionend", finish);
+      setRendered(false);
+    };
+    el.addEventListener("transitionend", finish);
+    const fallback = setTimeout(
+      finish,
+      EDGE_SWIPE_SLIDE_MS + EDGE_SWIPE_FALLBACK_SLACK_MS,
+    );
+    return () => {
+      settled = true;
+      el.removeEventListener("transitionend", finish);
+      clearTimeout(fallback);
+    };
+  }, [visible, rendered, panelRef]);
+
+  useEffect(() => {
     if (!isMobile) {
       setDragging(false);
     }
   }, [isMobile]);
 
   return {
-    present: visible || dragging,
+    present: rendered || dragging,
+    exiting: rendered && !visible,
     dragOffset: closeSwipe.dragOffset,
     isDragging: closeSwipe.isDragging,
     onTouchStart: closeSwipe.onTouchStart,

--- a/clients/web/src/domains/chat/hooks/use-chat-layout-drawer-gestures.ts
+++ b/clients/web/src/domains/chat/hooks/use-chat-layout-drawer-gestures.ts
@@ -1,0 +1,106 @@
+import {
+  useEffect,
+  useState,
+  type RefObject,
+  type TouchEvent as ReactTouchEvent,
+} from "react";
+
+import { useEdgeSwipeDrawer } from "@/hooks/use-edge-swipe-drawer";
+import { useSwipeCloseDrawer } from "@/hooks/use-swipe-close-drawer";
+import { useEdgeSwipeArbiterStore } from "@/stores/edge-swipe-arbiter-store";
+
+interface UseChatLayoutDrawerGesturesArgs {
+  /** Ref to the sliding panel, whose `translateX` both gestures move. */
+  panelRef: RefObject<HTMLElement | null>;
+  /** Whether the mobile layout is in play; the drawer exists nowhere else. */
+  isMobile: boolean;
+  /** Whether the drawer is open. */
+  open: boolean;
+  /** Fired when a left-edge swipe commits open. */
+  onOpen: () => void;
+  /** Fired when a leftward swipe on the panel commits closed. */
+  onClose: () => void;
+}
+
+interface UseChatLayoutDrawerGesturesResult {
+  /** Whether the panel belongs in the DOM: open, or being dragged in. */
+  present: boolean;
+  /** Live leftward drag offset (px) of the closing gesture, never positive. */
+  dragOffset: number;
+  /** True while a closing drag runs, so the caller drops its transition. */
+  isDragging: boolean;
+  onTouchStart: (e: ReactTouchEvent) => void;
+  onTouchMove: (e: ReactTouchEvent) => void;
+  onTouchEnd: (e: ReactTouchEvent) => void;
+  onTouchCancel: () => void;
+}
+
+/**
+ * The mobile drawer's two swipe gestures and the presence state they need.
+ *
+ * Swipe-to-open (`useEdgeSwipeDrawer`) tracks the panel in from the left edge
+ * while the drawer is closed; swipe-to-close (`useSwipeCloseDrawer`) tracks it
+ * back out while it is open. The two are never armed at the same time, so a
+ * single touch resolves to exactly one of them.
+ *
+ * ## Where each gesture yields
+ *
+ * The opening gesture listens on `document` across the whole route and arms
+ * over a wide band of the viewport, so it has to yield to anything more
+ * specific that a left-edge swipe could mean: a back-swipe owner (a pushed page
+ * under this layout) and a revealed swipe-action row anywhere on the route,
+ * both counted by the shared arbiter store.
+ *
+ * The closing gesture arms on the panel's own touch handlers, so it yields at
+ * the target instead: `useSwipeCloseDrawer` stands down over a row that owns
+ * its own horizontal drag. Route-wide arbitration would be wrong here, because
+ * a row revealed on the page *behind* the drawer says nothing about a touch
+ * landing on the drawer.
+ */
+export function useChatLayoutDrawerGestures({
+  panelRef,
+  isMobile,
+  open,
+  onOpen,
+  onClose,
+}: UseChatLayoutDrawerGesturesArgs): UseChatLayoutDrawerGesturesResult {
+  const visible = isMobile && open;
+
+  // True while a left-edge swipe is dragging the panel in from off-screen but
+  // has not yet committed open; keeps it mounted so its transform can track the
+  // finger before `open` flips.
+  const [dragging, setDragging] = useState(false);
+
+  const backSwipeOwnerCount = useEdgeSwipeArbiterStore.use.backOwnerCount();
+  const openRowCount = useEdgeSwipeArbiterStore.use.openRowCount();
+
+  useEdgeSwipeDrawer({
+    panelRef,
+    enabled:
+      isMobile && !open && backSwipeOwnerCount === 0 && openRowCount === 0,
+    onDragStart: () => setDragging(true),
+    onOpen: () => {
+      onOpen();
+      setDragging(false);
+    },
+    onSettle: () => setDragging(false),
+  });
+
+  const closeSwipe = useSwipeCloseDrawer({ enabled: visible, onClose });
+
+  useEffect(() => {
+    if (!isMobile) {
+      setDragging(false);
+    }
+  }, [isMobile]);
+
+  return {
+    present: visible || dragging,
+    dragOffset: closeSwipe.dragOffset,
+    isDragging: closeSwipe.isDragging,
+    onTouchStart: closeSwipe.onTouchStart,
+    onTouchMove: closeSwipe.onTouchMove,
+    onTouchEnd: closeSwipe.onTouchEnd,
+    onTouchCancel: closeSwipe.onTouchCancel,
+  };
+}

--- a/clients/web/src/hooks/use-swipe-close-drawer.test.ts
+++ b/clients/web/src/hooks/use-swipe-close-drawer.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Tests for `useSwipeCloseDrawer`, the mobile drawer's swipe-to-close.
+ *
+ * The pure helpers are covered directly; the hook itself is driven through
+ * `renderHook` with synthesized React touch events, the harness
+ * `use-swipe-horizontal.test.ts` established for the engine underneath.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { renderHook, act } from "@testing-library/react";
+
+import {
+  closingOffset,
+  startsOnSwipeActionRow,
+  useSwipeCloseDrawer,
+} from "@/hooks/use-swipe-close-drawer";
+
+interface FakeTouch {
+  identifier: number;
+  clientX: number;
+  clientY: number;
+}
+
+function makeTouchList(touches: FakeTouch[]): TouchList {
+  return touches as unknown as TouchList;
+}
+
+function makeTouchEvent(
+  type: "touchstart" | "touchmove" | "touchend",
+  touches: FakeTouch[],
+  changedTouches: FakeTouch[] = [],
+  target: EventTarget | null = null,
+): React.TouchEvent {
+  return {
+    type,
+    touches: makeTouchList(touches),
+    changedTouches: makeTouchList(changedTouches),
+    targetTouches: makeTouchList(touches),
+    preventDefault: () => {},
+    stopPropagation: () => {},
+    nativeEvent: {} as TouchEvent,
+    bubbles: false,
+    cancelable: false,
+    currentTarget: null,
+    defaultPrevented: false,
+    eventPhase: 0,
+    isDefaultPrevented: () => false,
+    isPropagationStopped: () => false,
+    isTrusted: false,
+    persist: () => {},
+    timeStamp: 0,
+    target,
+  } as unknown as React.TouchEvent;
+}
+
+function coarsePointer(matches: boolean) {
+  return ((query: string) => ({
+    matches: matches && query.includes("coarse"),
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia;
+}
+
+beforeEach(() => {
+  window.matchMedia = coarsePointer(true);
+});
+
+afterEach(() => {
+  window.matchMedia = coarsePointer(false);
+  document.body.replaceChildren();
+});
+
+describe("startsOnSwipeActionRow", () => {
+  test("is true on a marked row and its descendants", () => {
+    const row = document.createElement("div");
+    row.setAttribute("data-slot", "swipe-action-row");
+    const label = document.createElement("span");
+    row.appendChild(label);
+    document.body.appendChild(row);
+
+    expect(startsOnSwipeActionRow(row)).toBe(true);
+    expect(startsOnSwipeActionRow(label)).toBe(true);
+  });
+
+  test("is false on the rest of the drawer", () => {
+    // The header, the assistant cluster, section headings and the space below
+    // the list are all fair game for the close gesture.
+    const header = document.createElement("header");
+    document.body.appendChild(header);
+
+    expect(startsOnSwipeActionRow(header)).toBe(false);
+    expect(startsOnSwipeActionRow(null)).toBe(false);
+    expect(startsOnSwipeActionRow(document)).toBe(false);
+  });
+});
+
+describe("closingOffset", () => {
+  test("passes leftward travel through", () => {
+    expect(closingOffset(-40)).toBe(-40);
+    expect(closingOffset(-120)).toBe(-120);
+  });
+
+  test("clamps rightward travel, so the panel keeps its left edge", () => {
+    expect(closingOffset(40)).toBe(0);
+    expect(closingOffset(0)).toBe(0);
+  });
+});
+
+describe("useSwipeCloseDrawer", () => {
+  function drag(
+    result: { current: ReturnType<typeof useSwipeCloseDrawer> },
+    dx: number,
+    target: EventTarget | null = null,
+  ) {
+    const start = { identifier: 1, clientX: 300, clientY: 400 };
+    const end = { identifier: 1, clientX: 300 + dx, clientY: 400 };
+    act(() => {
+      result.current.onTouchStart(
+        makeTouchEvent("touchstart", [start], [], target),
+      );
+    });
+    act(() => {
+      result.current.onTouchMove(
+        makeTouchEvent("touchmove", [end], [], target),
+      );
+    });
+    act(() => {
+      result.current.onTouchEnd(makeTouchEvent("touchend", [], [end], target));
+    });
+  }
+
+  test("closes on a leftward swipe past the threshold", () => {
+    const onClose = mock(() => {});
+    const { result } = renderHook(() =>
+      useSwipeCloseDrawer({ enabled: true, onClose }),
+    );
+
+    drag(result, -120);
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test("leaves a short drag alone, so the panel springs back", () => {
+    const onClose = mock(() => {});
+    const { result } = renderHook(() =>
+      useSwipeCloseDrawer({ enabled: true, onClose }),
+    );
+
+    drag(result, -20);
+
+    expect(onClose).not.toHaveBeenCalled();
+    expect(result.current.dragOffset).toBe(0);
+  });
+
+  test("ignores a rightward swipe, which has nowhere to go", () => {
+    const onClose = mock(() => {});
+    const { result } = renderHook(() =>
+      useSwipeCloseDrawer({ enabled: true, onClose }),
+    );
+
+    drag(result, 120);
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  test("yields a drag that began on a row with its own swipe actions", () => {
+    // Archive lives on that row's leftward swipe. The drawer standing down here
+    // is what keeps it reachable.
+    const onClose = mock(() => {});
+    const row = document.createElement("div");
+    row.setAttribute("data-slot", "swipe-action-row");
+    const label = document.createElement("span");
+    row.appendChild(label);
+    document.body.appendChild(row);
+    const { result } = renderHook(() =>
+      useSwipeCloseDrawer({ enabled: true, onClose }),
+    );
+
+    drag(result, -120, label);
+
+    expect(onClose).not.toHaveBeenCalled();
+    expect(result.current.dragOffset).toBe(0);
+  });
+
+  test("takes the same drag when it began off a row", () => {
+    const onClose = mock(() => {});
+    const heading = document.createElement("h2");
+    document.body.appendChild(heading);
+    const { result } = renderHook(() =>
+      useSwipeCloseDrawer({ enabled: true, onClose }),
+    );
+
+    drag(result, -120, heading);
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test("stays inert while disabled, i.e. the drawer is closed", () => {
+    const onClose = mock(() => {});
+    const { result } = renderHook(() =>
+      useSwipeCloseDrawer({ enabled: false, onClose }),
+    );
+
+    drag(result, -120);
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/clients/web/src/hooks/use-swipe-close-drawer.ts
+++ b/clients/web/src/hooks/use-swipe-close-drawer.ts
@@ -1,0 +1,103 @@
+import { useCallback, type TouchEvent as ReactTouchEvent } from "react";
+
+import { useSwipeHorizontal } from "@/hooks/use-swipe-horizontal";
+
+/**
+ * Rows that own a horizontal drag for their own swipe actions. A conversation
+ * row reveals Archive on a leftward swipe and Pin on a rightward one, and a
+ * pinned app pill reveals Unpin; both sit inside the drawer, so the panel
+ * gesture has to leave them alone or the two fight over every drag.
+ *
+ * `SwipeActionReveal` marks only its armed branch, so a row rendered without
+ * actions (or on a fine pointer) claims nothing and the panel keeps the drag.
+ */
+const SWIPE_ACTION_ROW_SELECTOR = '[data-slot="swipe-action-row"]';
+
+/**
+ * Whether a touch beginning here belongs to a row's own swipe actions rather
+ * than to the enclosing panel.
+ */
+export function startsOnSwipeActionRow(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) {
+    return false;
+  }
+  return target.closest(SWIPE_ACTION_ROW_SELECTOR) !== null;
+}
+
+/**
+ * Clamp the live drag to the closing direction.
+ *
+ * The engine tracks both ways on its axis, but this panel rests against the
+ * left edge with nowhere to go rightward: following a rightward drag would peel
+ * it off that edge and expose the page behind it. Leftward travel passes
+ * through, so the panel keeps tracking the finger toward the close.
+ */
+export function closingOffset(dragOffset: number): number {
+  return Math.min(0, dragOffset);
+}
+
+interface UseSwipeCloseDrawerArgs {
+  /** Whether the gesture is armed, i.e. the drawer is open. */
+  enabled: boolean;
+  /** Fired when a leftward swipe passes the commit threshold. */
+  onClose: () => void;
+}
+
+interface UseSwipeCloseDrawerResult {
+  /** Live leftward drag offset (px), never positive. 0 at rest. */
+  dragOffset: number;
+  /** True while a drag is in progress, so the caller can drop its transition. */
+  isDragging: boolean;
+  onTouchStart: (e: ReactTouchEvent) => void;
+  onTouchMove: (e: ReactTouchEvent) => void;
+  onTouchEnd: (e: ReactTouchEvent) => void;
+  onTouchCancel: () => void;
+}
+
+/**
+ * Swipe-to-close for the mobile navigation drawer, the counterpart to
+ * `useEdgeSwipeDrawer`'s swipe-to-open.
+ *
+ * The two never overlap: the opening gesture is armed only while the drawer is
+ * closed and hands the panel's transform back to React once it settles, and
+ * this one is armed only while it is open. That is also why this is built on
+ * `useSwipeHorizontal` rather than the opening gesture's engine, which listens
+ * on `document`, arms only in the left half of the viewport, and rejects
+ * leftward travel outright. Element handlers are what let a row inside the
+ * drawer take a drag that started on it.
+ *
+ * A drag beginning on a row with its own swipe actions is left to that row: the
+ * gesture never arms, so Archive and Pin behave inside the drawer exactly as
+ * they do outside it. Everywhere else on the sheet, the header, the assistant
+ * cluster, section headings, the gaps between cards and the space below the
+ * list, a leftward swipe closes.
+ */
+export function useSwipeCloseDrawer({
+  enabled,
+  onClose,
+}: UseSwipeCloseDrawerArgs): UseSwipeCloseDrawerResult {
+  const swipe = useSwipeHorizontal({
+    enabled,
+    onSwipeLeft: onClose,
+  });
+
+  const { onTouchStart } = swipe;
+  const handleTouchStart = useCallback(
+    (event: ReactTouchEvent) => {
+      if (startsOnSwipeActionRow(event.target)) {
+        return;
+      }
+      onTouchStart(event);
+    },
+    [onTouchStart],
+  );
+
+  return {
+    dragOffset: closingOffset(swipe.dragOffset),
+    isDragging: swipe.isDragging,
+    onTouchStart: handleTouchStart,
+    onTouchMove: swipe.onTouchMove,
+    onTouchEnd: swipe.onTouchEnd,
+    onTouchCancel: swipe.onTouchCancel,
+  };
+}

--- a/clients/web/src/i18n/locales/en/chat.json
+++ b/clients/web/src/i18n/locales/en/chat.json
@@ -117,8 +117,7 @@
   },
   "chatComposer": {
     "addToChat": "Add to chat",
-    "askAssistantPlaceholder": "Ask {assistantName}",
-    "disclaimer": "Vellum uses external AI models and can make mistakes"
+    "askAssistantPlaceholder": "Ask {assistantName}"
   },
   "compactionTab": {
     "compactedMessages": "{count} compacted",

--- a/clients/web/src/i18n/locales/es/chat.json
+++ b/clients/web/src/i18n/locales/es/chat.json
@@ -117,8 +117,7 @@
   },
   "chatComposer": {
     "addToChat": "Añadir al chat",
-    "askAssistantPlaceholder": "Pregunta a {assistantName}",
-    "disclaimer": "Vellum usa modelos de IA externos y puede cometer errores"
+    "askAssistantPlaceholder": "Pregunta a {assistantName}"
   },
   "compactionTab": {
     "compactedMessages": "{count} compactados",


### PR DESCRIPTION
Two independent mobile changes.

## 1. The external-models caption is gone

"Vellum uses external AI models and can make mistakes" stood under the card whenever the mobile composer was at rest.

One thing to correct from the request: **mobile was the only surface that ever carried it.** There is no desktop render site and never was, so this is an outright removal rather than bringing mobile in line with somewhere else. The whole feature was one `<p>` behind `isMobileMainComposer`, added in the mobile composer redesign (#40675).

**Worth a human decision, not a silent delete:** with this gone the product carries no "can make mistakes" caption on any surface. A repo-wide grep confirms zero other render sites. If that disclaimer is wanted for product or legal reasons, this is the PR to say so on.

The i18n key goes with the render site, in both `en` and `es`. `catalogs.test.ts` fails both ways otherwise: it treats a key nothing reads as an orphan, and an `es` key with no `en` counterpart as a mismatch.

Two comments described the caption as the pills row's "opposite number" (one on `preventPressFocusTransfer`, one over the press-handling tests). Both now describe the WebKit press failure in terms of the pills row alone, which is what remains and what was always the dominant contributor to that shift.

## 2. A leftward swipe closes the drawer

Swiping in from the left edge opened the navigation drawer, but nothing took it back: the only exits were the close button, Escape, and picking something.

`useSwipeCloseDrawer` is the counterpart to `useEdgeSwipeDrawer`. It is armed only while the drawer is open and the opening gesture only while it is closed, so the two never see the same touch and never contend for the panel's transform.

It is built on `useSwipeHorizontal`, not on the opening gesture's engine. That engine listens on `document`, arms only in the left half of the viewport, and rejects leftward travel in both `decideDirection` and `isCommitted`; making it bidirectional would touch every call site and every assertion in `use-edge-swipe.test.ts`. Element handlers are also the point here, because they are what let a row keep a drag that started on it. `side-list-drawer.tsx` already closes the same way.

### The conflict, and how it is resolved

This is the part worth reviewing closely. Conversation rows inside the drawer reveal **Archive on a leftward swipe**, and pinned app pills reveal **Unpin**. They commit at **36px** against this gesture's **80px**, so a panel gesture layered over them would win nothing and break both: the row would follow the finger while the drawer also closed.

Per product decision on this PR, **rows keep their swipe actions**. `SwipeActionReveal` now marks its armed branch with `data-slot="swipe-action-row"`, and the close gesture never arms over one. Only the armed branch is marked, so a row with no actions (or on a fine pointer) claims nothing and the drawer keeps the drag.

That means the close gesture covers the header, the assistant cluster, section headings, the gaps between cards, and the space below the list, but **not the chat rows themselves**. That is deliberate. The alternative was taking Archive off the rows, which was considered and rejected.

Arbitration is split by how each gesture arms, which review corrected. The **opening** gesture listens on `document` across the whole route, so it yields route-wide: to a back-swipe owner, and to any revealed row (`openRowCount`). The **closing** gesture arms on the panel's own touch handlers, so it yields at the target and nowhere else. Gating it on the same route-wide counter killed it outright whenever a card was left revealed on a background route, which nothing in the drawer would ever close. Both wirings now sit in `useChatLayoutDrawerGestures` so the two rules read next to each other.

The panel tracks the finger from its open position, clamped to the closing direction so a rightward drag cannot peel it off the left edge. On commit the resting transition carries it the rest of the way.

### Closing it now animates at all

Also from review: the panel mounted on `drawerOpen`, so closing took the element out of the DOM in the same commit that gave it `translateX(-100%)`. The closing transform never rendered and the drawer blinked out. That predates this PR (the button, Escape and select-a-conversation paths all closed that way); tracking the finger just makes it conspicuous, and the claim above about the transition carrying it out was simply untrue until now.

Presence moves onto its own state that lags `drawerOpen` on the way out, ended by `transitionend` on the panel with the same timeout fallback `useEdgeSwipeDrawer` uses for the opening slide. It is raised during render, not from an effect, or a panel mounting a commit late would start at its resting transform and skip the opening slide. A panel on its way out still covers the viewport, so it drops pointer events for the length of the slide rather than swallowing taps meant for the page it is uncovering.

`docs/PLATFORM_ADAPTATION.md` said trailing was the safe edge under `ChatLayout` precisely because the drawer owned rightward swipes. That is now only half true, so the section documents the flipped edge inside the open drawer and the opt-out a panel gesture needs.

## Testing

- `use-swipe-close-drawer.test.ts` (new, 10 tests): the row-yield rule, the clamp, commit past threshold, spring-back under it, rightward ignored, inert while closed. **I verified the row-yield case fails without the skip** (1 of 10 fails), so it pins the actual conflict rather than passing either way.
- `use-chat-layout-drawer-gestures.test.ts` (new, 7 tests): the split arbitration (a revealed row disarms the opening swipe and leaves the closing one armed) and the closing slide (mounted until `transitionend`, a descendant's transition ignored, the fallback, a reopen cancelling it). Both review fixes were checked by reverting them: re-gating the close on `openRowCount` fails the arbitration case, and unmounting on `drawerOpen` fails the two slide cases.
- `chat-composer.test.tsx` (145) and `catalogs.test.ts` (66) green after the caption removal; the caption's own `describe` block and helper are deleted, two lingering assertions dropped.
- `use-edge-swipe`, `use-swipe-horizontal`, `swipe-action-reveal`, `edge-swipe-arbiter-store` all green in isolation (the runner isolates per file; multi-file local runs leak mocks).
- `eslint` and `tsc --noEmit` clean on the changed files.

**Not verified on a device.** The gesture's feel is the open question: whether the 80px commit reads right for a full-viewport panel, and whether the row exclusion is discoverable in practice or just feels like the swipe intermittently not working over the list. That last one is the real risk and it needs a phone to judge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

