### PR TITLE
feat(ipc-contract): watch phase, state, and toggle command

### DIFF
--- a/packages/electron-desktop/src/commands.ts
+++ b/packages/electron-desktop/src/commands.ts
@@ -93,6 +93,7 @@ export const DEFAULT_ACCELERATORS: Record<VellumCommandKind, string> = {
   quickInputSubmit: "",
   startVoice: "",
   companionSubmit: "",
+  toggleWatch: "",
   cancelDictation: "",
   replayOnboarding: "",
   replayHatchFailure: "",

--- a/packages/ipc-contract/src/channels.ts
+++ b/packages/ipc-contract/src/channels.ts
@@ -161,6 +161,7 @@ export const COMPANION_STATE_EVENT = "vellum:companion:state";
 export const COMPANION_SET_INTERACTIVE = "vellum:companion:setInteractive";
 export const COMPANION_MOVE_BY = "vellum:companion:moveBy";
 export const COMPANION_START_VOICE = "vellum:companion:startVoice";
+export const COMPANION_TOGGLE_WATCH = "vellum:companion:toggleWatch";
 export const COMPANION_ACTIVATE = "vellum:companion:activate";
 export const COMPANION_SET_COMPOSING = "vellum:companion:setComposing";
 export const COMPANION_SUBMIT = "vellum:companion:submit";

--- a/packages/ipc-contract/src/schemas.ts
+++ b/packages/ipc-contract/src/schemas.ts
@@ -109,4 +109,8 @@ export const companionContextSchema = z.object({
   // honest answer for a publisher that cannot report a turn is that it is not
   // reporting one.
   working: z.boolean().default(false),
+  // Defaulted for the same reason `working` is, and for one more: the toggle
+  // arrived after the context did, so every publisher that has not been taught
+  // to run a watch session yet is reporting truthfully by staying silent.
+  watching: z.boolean().default(false),
 });

--- a/packages/ipc-contract/src/schemas.ts
+++ b/packages/ipc-contract/src/schemas.ts
@@ -109,8 +109,7 @@ export const companionContextSchema = z.object({
   // honest answer for a publisher that cannot report a turn is that it is not
   // reporting one.
   working: z.boolean().default(false),
-  // Defaulted for the same reason `working` is, and for one more: the toggle
-  // arrived after the context did, so every publisher that has not been taught
-  // to run a watch session yet is reporting truthfully by staying silent.
+  // Defaulted for the same reason `working` is: a publisher that runs no watch
+  // session has nothing to report, and staying silent is its truthful answer.
   watching: z.boolean().default(false),
 });

--- a/packages/ipc-contract/src/types.ts
+++ b/packages/ipc-contract/src/types.ts
@@ -67,6 +67,21 @@ export type VellumCommand =
    */
   | { kind: "startVoice" }
   /**
+   * Turn a watch session on or off, the way the companion surface's Watch
+   * asks.
+   *
+   * One command for both edges rather than a start and a stop: the surface
+   * draws a single toggle, and the window that owns the session is the only
+   * side that knows which edge a press is. A press that lands while a session
+   * is running ends that session.
+   *
+   * Like `startVoice`, this does not raise the app. The user reached for a
+   * floating surface precisely because they are working somewhere else, and
+   * here that work is the subject: raising the app would cover the very thing
+   * the session exists to observe.
+   */
+  | { kind: "toggleWatch" }
+  /**
    * Send what the user typed on the companion surface, the way its Type option
    * asks.
    *
@@ -749,6 +764,15 @@ export interface CompanionContext {
    * on screen is no proof the turn behind it has ended.
    */
   working: boolean;
+  /**
+   * Whether a watch session is running, when the publisher knows.
+   *
+   * Optional here, and defaulted in `companionContextSchema`, because a
+   * publisher built before the toggle existed has nothing to report and the
+   * honest answer for it is that no session of its is running. Publishers that
+   * do run sessions always send it.
+   */
+  watching?: boolean;
 }
 
 /** What main tells the companion renderer. */
@@ -795,6 +819,18 @@ export interface CompanionSurfaceState {
    * {@link CompanionContext.working}.
    */
   working: boolean;
+  /**
+   * Whether a watch session is running, from the toggle until it ends.
+   *
+   * Pushed by the window that owns the session for the same reason
+   * {@link CompanionSurfaceState.working} is: the session lives in the app's
+   * window and the surface is only where it was asked for. Held here rather
+   * than kept in the surface's own renderer for the same reason the turns are,
+   * and with more riding on it: the surface can reload mid-session, and a
+   * screen being read with nothing on screen saying so is a capture the user
+   * has no way to stop.
+   */
+  watching: boolean;
   /**
    * The character to render live, or `undefined` when there is none to
    * compose. See {@link CompanionCharacter}; `avatarBase64` is the fallback.

--- a/packages/ipc-contract/src/types.ts
+++ b/packages/ipc-contract/src/types.ts
@@ -68,7 +68,7 @@ export type VellumCommand =
   | { kind: "startVoice" }
   /**
    * Turn a watch session on or off, the way the companion surface's Watch
-   * asks.
+   * option asks.
    *
    * One command for both edges rather than a start and a stop: the surface
    * draws a single toggle, and the window that owns the session is the only
@@ -768,9 +768,9 @@ export interface CompanionContext {
    * Whether a watch session is running, when the publisher knows.
    *
    * Optional here, and defaulted in `companionContextSchema`, because a
-   * publisher built before the toggle existed has nothing to report and the
-   * honest answer for it is that no session of its is running. Publishers that
-   * do run sessions always send it.
+   * publisher that runs no watch session has nothing to report, and an omitted
+   * value reads as no session of its running. Publishers that do run sessions
+   * always send it.
    */
   watching?: boolean;
 }
@@ -832,11 +832,11 @@ export interface CompanionSurfaceState {
    *
    * Optional, and absence means not watching. Read it as `watching === true`
    * rather than for truthiness: every state that is not a positive answer is
-   * the answer "no session", including a surface whose main process predates
-   * this field. The same bargain `companion-window.ts` makes for the surface
-   * flag, and for the same reason -- not knowing has to read as not running,
-   * because the alternative is drawing a capture indicator over a machine that
-   * is not being captured.
+   * the answer "no session", including a state pushed by a main process that
+   * tracks no watch sessions. The same bargain `companion-window.ts` makes for
+   * the surface flag, and for the same reason: not knowing has to read as not
+   * running, because the alternative is drawing a capture indicator over a
+   * machine that is not being captured.
    */
   watching?: boolean;
   /**

--- a/packages/ipc-contract/src/types.ts
+++ b/packages/ipc-contract/src/types.ts
@@ -829,8 +829,16 @@ export interface CompanionSurfaceState {
    * and with more riding on it: the surface can reload mid-session, and a
    * screen being read with nothing on screen saying so is a capture the user
    * has no way to stop.
+   *
+   * Optional, and absence means not watching. Read it as `watching === true`
+   * rather than for truthiness: every state that is not a positive answer is
+   * the answer "no session", including a surface whose main process predates
+   * this field. The same bargain `companion-window.ts` makes for the surface
+   * flag, and for the same reason -- not knowing has to read as not running,
+   * because the alternative is drawing a capture indicator over a machine that
+   * is not being captured.
    */
-  watching: boolean;
+  watching?: boolean;
   /**
    * The character to render live, or `undefined` when there is none to
    * compose. See {@link CompanionCharacter}; `avatarBase64` is the fallback.


### PR DESCRIPTION
## Summary

- Add `watching` to `CompanionSurfaceState` (pushed by the window that owns the session, exactly like `working`) and a `{ kind: "toggleWatch" }` `VellumCommand` that, like `startVoice`, does not raise the app.
- Add the `COMPANION_TOGGLE_WATCH` channel constant beside `COMPANION_START_VOICE`, and a defaulted `watching` boolean on `companionContextSchema` so main validates it at the IPC boundary while existing publishers stay valid.
- One deviation worth a look: `CompanionContext` also gains an optional `watching?: boolean`, because this file's stated convention is that the type is canonical and the schema mirrors it, and a publisher could not send the field otherwise. Optional rather than required so no consumer needs updating until PR 8 starts publishing it.

Types only, no behavior change. `CompanionSurfacePhase` gains its `"watching"` member in PR 5, not here.

Part of plan: learning-by-watching.md (PR 2 of 10)