### PR TITLE
feat(catalog): export the Codex subscription allowlist in the provider catalog JSON

### DIFF
--- a/assistant/scripts/sync-llm-catalog.ts
+++ b/assistant/scripts/sync-llm-catalog.ts
@@ -29,6 +29,7 @@ import {
   PROVIDER_CATALOG,
   type ProviderCatalogEntry,
 } from "../src/providers/model-catalog.js";
+import { CODEX_SUBSCRIPTION_MODEL_IDS } from "../src/providers/openai/codex-models.js";
 
 const ROOT = resolve(import.meta.dir, "../..");
 const OUTPUT_PATHS = [join(ROOT, "meta/llm-provider-catalog.json")] as const;
@@ -117,6 +118,12 @@ function projectProvider(entry: ProviderCatalogEntry): Record<string, unknown> {
   }
   projected.defaultModel = entry.defaultModel;
   projected.models = entry.models.map(projectModel);
+  // Which of this provider's models the ChatGPT Codex subscription endpoint
+  // serves — exported so out-of-repo consumers (e.g. the platform's
+  // model-liveness probe) read the allowlist instead of mirroring it.
+  if (entry.id === "openai") {
+    projected.codexSubscriptionModels = [...CODEX_SUBSCRIPTION_MODEL_IDS];
+  }
   // NOTE: `apiKeyUrl` intentionally omitted — clients use
   // `credentialsGuide.url` instead. Daemon callers still read it from
   // PROVIDER_CATALOG directly.

--- a/assistant/scripts/sync-llm-catalog.ts
+++ b/assistant/scripts/sync-llm-catalog.ts
@@ -119,7 +119,7 @@ function projectProvider(entry: ProviderCatalogEntry): Record<string, unknown> {
   projected.defaultModel = entry.defaultModel;
   projected.models = entry.models.map(projectModel);
   // Which of this provider's models the ChatGPT Codex subscription endpoint
-  // serves — exported so out-of-repo consumers (e.g. the platform's
+  // serves, exported so out-of-repo consumers (e.g. the platform's
   // model-liveness probe) read the allowlist instead of mirroring it.
   if (entry.id === "openai") {
     projected.codexSubscriptionModels = [...CODEX_SUBSCRIPTION_MODEL_IDS];

--- a/assistant/src/__tests__/llm-catalog-parity.test.ts
+++ b/assistant/src/__tests__/llm-catalog-parity.test.ts
@@ -7,6 +7,7 @@ import {
   isModelInCatalog,
   PROVIDER_CATALOG,
 } from "../providers/model-catalog.js";
+import { CODEX_SUBSCRIPTION_MODEL_IDS } from "../providers/openai/codex-models.js";
 import { PLATFORM_PROVIDER_META } from "../providers/platform-proxy/constants.js";
 import { resolvePricing, resolvePricingForUsage } from "../util/pricing.js";
 
@@ -81,6 +82,7 @@ interface ClientCatalogEntry {
   supportsPlatformAuth?: boolean;
   defaultModel: string;
   models: ClientCatalogModel[];
+  codexSubscriptionModels?: string[];
 }
 
 interface ClientCatalog {
@@ -220,6 +222,15 @@ describe("LLM catalog parity: daemon vs client", () => {
         `defaultModel "${entry.defaultModel}" not in models for provider "${entry.id}"`,
       ).toBe(true);
     }
+  });
+
+  test("openai entry's codexSubscriptionModels matches the daemon allowlist", () => {
+    const json = loadClientCatalog();
+    const openai = json.providers.find((p) => p.id === "openai");
+    expect(openai).toBeDefined();
+    expect(new Set(openai?.codexSubscriptionModels)).toEqual(
+      new Set(CODEX_SUBSCRIPTION_MODEL_IDS),
+    );
   });
 
   test("cache pricing rates are positive when defined", () => {

--- a/clients/web/src/assistant/llm-model-catalog.test.ts
+++ b/clients/web/src/assistant/llm-model-catalog.test.ts
@@ -52,6 +52,7 @@ interface MetaCatalogProvider {
   supportsPlatformAuth?: boolean;
   defaultModel: string;
   models: MetaCatalogModel[];
+  codexSubscriptionModels?: string[];
 }
 
 interface MetaCatalog {
@@ -118,6 +119,13 @@ describe("parity with meta/llm-provider-catalog.json", () => {
   const webProviderIds = (
     Object.keys(MODELS_BY_PROVIDER) as LlmProviderId[]
   ).filter((id) => id !== "openai-compatible");
+
+  test("CODEX_SUBSCRIPTION_MODEL_IDS matches the meta catalog's export", () => {
+    const openai = metaProvidersById.get("openai");
+    expect(new Set(openai?.codexSubscriptionModels)).toEqual(
+      new Set(CODEX_SUBSCRIPTION_MODEL_IDS),
+    );
+  });
 
   test("vellum is a picker-only entry: absent from the catalogs by design", () => {
     // The Vellum entry is the managed routing identity, not a provider with

--- a/meta/llm-provider-catalog.json
+++ b/meta/llm-provider-catalog.json
@@ -434,6 +434,14 @@
             "cacheReadPer1mTokens": 0.01
           }
         }
+      ],
+      "codexSubscriptionModels": [
+        "gpt-5.6-sol",
+        "gpt-5.6-terra",
+        "gpt-5.6-luna",
+        "gpt-5.5",
+        "gpt-5.4",
+        "gpt-5.4-mini"
       ]
     },
     {


### PR DESCRIPTION
## Summary
- Stamp a `codexSubscriptionModels` field on the openai entry of `meta/llm-provider-catalog.json`, generated from `CODEX_SUBSCRIPTION_MODEL_IDS` so the allowlist keeps one source of truth.
- Add parity tests on both the daemon and web sides asserting the exported field matches their respective allowlist constants, so allowlist edits can't drift from the published catalog.

## Original prompt
A user hit silent breakage when a ChatGPT/Codex subscription can't serve models our defaults reference. The plan is to extend the platform's model-liveness probe (which already fetches this catalog JSON from main) to also probe the Codex subscription endpoint, so a busted subscription model pages us before users notice. That probe needs to know which models constitute the subscription promise — this PR publishes the allowlist into the catalog JSON it already consumes; the probe leg itself lands in a platform PR.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40941" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->