### PR TITLE
Register Windows host proxy clients

### DIFF
--- a/assistant/src/__tests__/events-client-registration.test.ts
+++ b/assistant/src/__tests__/events-client-registration.test.ts
@@ -54,6 +54,34 @@ describe("events client registration", () => {
     ac.abort();
   });
 
+  test("registers Windows with only its implemented host capabilities", () => {
+    const ac = new AbortController();
+    const hub = new AssistantEventHub();
+
+    handleSubscribeAssistantEvents(
+      {
+        headers: {
+          "x-vellum-client-id": "test-windows-001",
+          "x-vellum-interface-id": "windows",
+        },
+        abortSignal: ac.signal,
+      },
+      { hub },
+    );
+
+    const entry = hub.getClientById("test-windows-001");
+    expect(entry?.interfaceId).toBe("windows");
+    expect(entry?.capabilities).toEqual([
+      "host_bash",
+      "host_file",
+      "host_cu",
+      "host_browser",
+      "host_ui_snapshot",
+    ]);
+
+    ac.abort();
+  });
+
   test("skips registration when no headers are provided (backwards compat)", () => {
     const ac = new AbortController();
     const hub = new AssistantEventHub();

--- a/assistant/src/__tests__/host-proxy-interface.test.ts
+++ b/assistant/src/__tests__/host-proxy-interface.test.ts
@@ -16,6 +16,7 @@ import { isHostProxyTransport } from "../daemon/message-types/conversations.js";
 describe("supportsHostProxy (runtime)", () => {
   test("no-arg form returns true for host-proxy interfaces", () => {
     expect(supportsHostProxy("macos")).toBe(true);
+    expect(supportsHostProxy("windows")).toBe(true);
   });
 
   test("no-arg form returns false for interfaces without host-proxy support", () => {
@@ -42,11 +43,20 @@ describe("supportsHostProxy (runtime)", () => {
     expect(supportsHostProxy("chrome-extension", "host_cu")).toBe(false);
   });
 
-  test("capability form grants all four capabilities to macOS including host_browser", () => {
+  test("capability form grants representative host capabilities to macOS", () => {
     expect(supportsHostProxy("macos", "host_bash")).toBe(true);
     expect(supportsHostProxy("macos", "host_file")).toBe(true);
     expect(supportsHostProxy("macos", "host_cu")).toBe(true);
     expect(supportsHostProxy("macos", "host_browser")).toBe(true);
+  });
+
+  test("capability form withholds unimplemented Windows app control", () => {
+    expect(supportsHostProxy("windows", "host_bash")).toBe(true);
+    expect(supportsHostProxy("windows", "host_file")).toBe(true);
+    expect(supportsHostProxy("windows", "host_cu")).toBe(true);
+    expect(supportsHostProxy("windows", "host_browser")).toBe(true);
+    expect(supportsHostProxy("windows", "host_ui_snapshot")).toBe(true);
+    expect(supportsHostProxy("windows", "host_app_control")).toBe(false);
   });
 
   test("capability form rejects everything for non-host-proxy interfaces", () => {

--- a/assistant/src/channels/__tests__/types.test.ts
+++ b/assistant/src/channels/__tests__/types.test.ts
@@ -17,9 +17,10 @@ describe("INTERFACE_IDS", () => {
     ).toBe(true);
   });
 
-  test("still includes macos and other existing interfaces", () => {
+  test("includes desktop and existing interfaces", () => {
     for (const id of [
       "macos",
+      "windows",
       "ios",
       "cli",
       "telegram",
@@ -41,8 +42,9 @@ describe("INTERACTIVE_INTERFACES", () => {
     expect(INTERACTIVE_INTERFACES.has("chrome-extension" as never)).toBe(false);
   });
 
-  test("still includes macos", () => {
+  test("includes desktop clients", () => {
     expect(INTERACTIVE_INTERFACES.has("macos")).toBe(true);
+    expect(INTERACTIVE_INTERFACES.has("windows")).toBe(true);
   });
 });
 
@@ -51,8 +53,9 @@ describe("isInterfaceId", () => {
     expect(isInterfaceId("chrome-extension")).toBe(true);
   });
 
-  test("returns true for macos", () => {
+  test("returns true for desktop interfaces", () => {
     expect(isInterfaceId("macos")).toBe(true);
+    expect(isInterfaceId("windows")).toBe(true);
   });
 
   test("returns false for unknown interface", () => {
@@ -68,6 +71,7 @@ describe("parseInterfaceId", () => {
   test("returns canonical ID for valid interface", () => {
     expect(parseInterfaceId("web")).toBe("web");
     expect(parseInterfaceId("macos")).toBe("macos");
+    expect(parseInterfaceId("windows")).toBe("windows");
   });
 
   test("normalizes legacy 'vellum' alias to 'web'", () => {
@@ -101,6 +105,16 @@ describe("supportsHostProxy", () => {
 
   test("macos returns true for host_browser", () => {
     expect(supportsHostProxy("macos", "host_browser")).toBe(true);
+  });
+
+  test("windows exposes its implemented host capabilities", () => {
+    expect(supportsHostProxy("windows")).toBe(true);
+    expect(supportsHostProxy("windows", "host_bash")).toBe(true);
+    expect(supportsHostProxy("windows", "host_file")).toBe(true);
+    expect(supportsHostProxy("windows", "host_cu")).toBe(true);
+    expect(supportsHostProxy("windows", "host_browser")).toBe(true);
+    expect(supportsHostProxy("windows", "host_ui_snapshot")).toBe(true);
+    expect(supportsHostProxy("windows", "host_app_control")).toBe(false);
   });
 
   // ── chrome-extension: only host_browser. ──

--- a/assistant/src/channels/types.ts
+++ b/assistant/src/channels/types.ts
@@ -166,6 +166,7 @@ export const CHANNEL_METADATA: Partial<Record<ChannelId, ChannelInfo>> = {
 
 export const INTERFACE_IDS = [
   "macos",
+  "windows",
   "ios",
   "cli",
   "telegram",
@@ -264,6 +265,7 @@ export function parseClientOs(value: unknown): ClientOs | null {
  */
 export const INTERACTIVE_INTERFACES: ReadonlySet<InterfaceId> = new Set([
   "macos",
+  "windows",
   "ios",
   "cli",
   "web",
@@ -274,9 +276,9 @@ export function isInteractiveInterface(id: InterfaceId): boolean {
 }
 
 /**
- * Host proxy capabilities that an interface can support. The macOS client
- * supports all of them; the chrome-extension interface only supports
- * host_browser (via the Chrome DevTools Protocol proxy).
+ * Host proxy capabilities that an interface can support. macOS supports all
+ * of them, Windows withholds app control, and chrome-extension supports only
+ * host_browser through the Chrome DevTools Protocol proxy.
  */
 export const HOST_PROXY_CAPABILITIES = [
   "host_bash",
@@ -290,29 +292,28 @@ export const HOST_PROXY_CAPABILITIES = [
 export type HostProxyCapability = (typeof HOST_PROXY_CAPABILITIES)[number];
 
 /**
- * Interfaces that support the full desktop host-proxy set (every
- * `HostProxyCapability` value). This is the capability-level identity used
- * by the discriminated transport metadata union and by the
+ * Interfaces that support desktop host-proxy tools. This identity is used by
+ * the discriminated transport metadata union and by the
  * `supportsHostProxy(id)` type predicate.
  *
  * Extend this literal type AND the `supportsHostProxy` implementation
- * below in lock-step when adding a new host-capable client (e.g. a native
- * Linux or Windows desktop).
+ * below in lock-step when adding a new host-capable client such as native
+ * Linux.
  */
-export type HostProxyInterfaceId = "macos";
+export type HostProxyInterfaceId = "macos" | "windows";
 
 /**
  * Whether the interface supports a host proxy capability.
  *
  * The no-arg form `supportsHostProxy(id)` asks "is this interface a desktop
- * host-proxy client?" — it returns `true` only for macOS and is the type
+ * host-proxy client?" It returns `true` for native desktop clients and is the
  * predicate that narrows `InterfaceId` to `HostProxyInterfaceId`. It returns
  * `false` for chrome-extension because chrome-extension only supports
  * `host_browser`, and the no-arg form is the gate that legacy desktop-only
  * call sites use (e.g. preactivating computer-use, restoring host proxies
- * in the drain queue). Callers that want to check a single capability —
+ * in the drain queue). Callers that want to check a single capability,
  * for example, to decide whether to keep `hostBrowserProxy` available for
- * chrome-extension — should pass the capability explicitly:
+ * chrome-extension, should pass the capability explicitly:
  * `supportsHostProxy(id, "host_browser")`.
  */
 export function supportsHostProxy(id: InterfaceId): id is HostProxyInterfaceId;
@@ -330,6 +331,9 @@ export function supportsHostProxy(
   // through to cdp-inspect/local via the CDP factory's candidate chain.
   if (id === "macos") {
     return true;
+  }
+  if (id === "windows") {
+    return capability == null || capability !== "host_app_control";
   }
   if (id === "chrome-extension" && capability === "host_browser") {
     return true;

--- a/assistant/src/daemon/message-types/conversations.ts
+++ b/assistant/src/daemon/message-types/conversations.ts
@@ -48,18 +48,16 @@ interface BaseTransportMetadata {
 }
 
 /**
- * Transport metadata for interfaces that support the full desktop host-proxy
- * set (see `HostProxyInterfaceId` / `supportsHostProxy`). Carries the host
+ * Transport metadata for interfaces that support desktop host-proxy tools
+ * (see `HostProxyInterfaceId` / `supportsHostProxy`). Carries the host
  * environment fields the client reports so the `<workspace>` block renders
  * the user's actual machine rather than a containerized daemon's own OS.
  *
- * Today this variant is populated only by the macOS client, but the shape
- * is capability-keyed (not interface-name-keyed) so future host-capable
- * clients (e.g. a native Linux or Windows desktop) get the same treatment
- * automatically when added to `HostProxyInterfaceId`.
+ * The shape is capability-keyed so each native desktop client gets the same
+ * host-environment treatment through `HostProxyInterfaceId`.
  */
 export interface HostProxyTransportMetadata extends BaseTransportMetadata {
-  /** Interface identifier — restricted to interfaces that support host proxies. */
+  /** Interface identifier restricted to interfaces that support host proxies. */
   interfaceId: HostProxyInterfaceId;
   /** Home directory of the user on the host machine (e.g. `NSHomeDirectory()`). */
   hostHomeDir?: string;


### PR DESCRIPTION
## Summary
- Accept Windows desktop SSE clients and register their host shell, filesystem, computer-use, browser, and UI snapshot capabilities.
- Keep host app control unavailable until the Windows executor exists.
- Add regression coverage for Windows interface parsing and SSE capability registration.

## Original prompt
Make the Windows desktop dev build connect its host PowerShell and filesystem executors when using bun run dev:electron-local-web, without requiring each developer build to go through a workflow release.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40942" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->