### PR TITLE
Keep the keyboard-free viewport reference honest across window resizes

### DIFF
--- a/clients/web/src/hooks/use-visible-viewport.test.ts
+++ b/clients/web/src/hooks/use-visible-viewport.test.ts
@@ -16,7 +16,8 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { act, cleanup, renderHook } from "@testing-library/react";
 
-let announceKeyboardHeight: ((keyboardHeight: number) => void) | null = null;
+let announceKeyboardHeight:
+  ((keyboardHeight: number, visible: boolean) => void) | null = null;
 // Whether the stubbed shell reports a keyboard source, as one with the plugin
 // linked does and one built before it never does.
 let stubReportsKeyboardSource = true;
@@ -88,10 +89,14 @@ function setInnerHeight(height: number): void {
   });
 }
 
-/** Announce a keyboard height the way the native shell does. */
-function announce(keyboardHeight: number): void {
+/**
+ * Announce a keyboard height the way the native shell does. Visibility is
+ * carried separately from the height, since the bridge sanitizes a malformed
+ * show payload to `0` and a keyboard coming up still means one is coming up.
+ */
+function announce(keyboardHeight: number, visible = keyboardHeight > 0): void {
   act(() => {
-    announceKeyboardHeight!(keyboardHeight);
+    announceKeyboardHeight!(keyboardHeight, visible);
   });
 }
 
@@ -587,6 +592,21 @@ describe("window resizes", () => {
     resizeWindowTo(REFERENCE_HEIGHT);
 
     expect(readVisibleViewport()?.keyboardHeight).toBe(0);
+  });
+
+  test("keeps the reference when a show announces a malformed height", () => {
+    // The bridge coerces a malformed payload to `0`. The keyboard is still
+    // coming up, so the frame resize behind it is not the window shrinking.
+    renderHook(() => useVisibleViewport());
+    announce(0, true);
+
+    resizeWindowTo(RESIZED_HEIGHT);
+
+    // The reference stands, so the shrunken frame still reads as a keyboard
+    // rather than as the window's new height.
+    expect(readVisibleViewport()?.keyboardHeight).toBe(
+      REFERENCE_HEIGHT - RESIZED_HEIGHT,
+    );
   });
 
   test("ignores a window that grew, which the reference already tracks", () => {

--- a/clients/web/src/hooks/use-visible-viewport.test.ts
+++ b/clients/web/src/hooks/use-visible-viewport.test.ts
@@ -17,12 +17,26 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { act, cleanup, renderHook } from "@testing-library/react";
 
 let announceKeyboardHeight: ((keyboardHeight: number) => void) | null = null;
+// Whether the stubbed shell reports a keyboard source, as one with the plugin
+// linked does and one built before it never does.
+let stubReportsKeyboardSource = true;
+// Held so a test can let registration land after the fact, the way a lazy
+// plugin import does.
+let reportKeyboardSource: (() => void) | null = null;
 
 const subscribeNativeKeyboardHeight = mock(
-  (onHeightChange: (keyboardHeight: number) => void) => {
+  (
+    onHeightChange: (keyboardHeight: number) => void,
+    onSourceReady?: () => void,
+  ) => {
     announceKeyboardHeight = onHeightChange;
+    reportKeyboardSource = onSourceReady ?? null;
+    if (stubReportsKeyboardSource) {
+      onSourceReady?.();
+    }
     return () => {
       announceKeyboardHeight = null;
+      reportKeyboardSource = null;
     };
   },
 );
@@ -88,6 +102,7 @@ beforeEach(() => {
     value: () => ({ matches: isPortraitStub }) as MediaQueryList,
   });
   isPortraitStub = true;
+  stubReportsKeyboardSource = true;
   setInnerHeight(REFERENCE_HEIGHT);
   subscribeNativeKeyboardHeight.mockClear();
   stubViewport();
@@ -427,5 +442,164 @@ describe("useVisibleViewport", () => {
     const remounted = renderHook(() => useVisibleViewport());
     announce(KEYBOARD_HEIGHT);
     expect(remounted.result.current?.keyboardHeight).toBe(KEYBOARD_HEIGHT);
+  });
+});
+
+describe("window resizes", () => {
+  const RESIZED_HEIGHT = REFERENCE_HEIGHT - 260;
+
+  /** Shrink the window and its viewport the way a window resize does. */
+  function resizeWindowTo(height: number): void {
+    setInnerHeight(height);
+    stubViewport({ height });
+    act(() => {
+      window.dispatchEvent(new Event("resize"));
+    });
+  }
+
+  test("rebases the reference onto a window a resize made shorter", () => {
+    // GIVEN a mounted consumer with no keyboard up
+    renderHook(() => useVisibleViewport());
+
+    // WHEN a same-orientation resize (an iPad Stage Manager drag, a split-view
+    // divider) shrinks the window past the keyboard threshold
+    resizeWindowTo(RESIZED_HEIGHT);
+
+    // THEN the shorter window is the new keyboard-free reference, rather than a
+    // keyboard that never goes away and arms the swipe-down dismiss gesture
+    // over the whole surface
+    const viewport = readVisibleViewport();
+    expect(viewport?.keyboardHeight).toBe(0);
+    expect(viewport?.height).toBe(RESIZED_HEIGHT);
+  });
+
+  test("leaves the reference alone for the frame resize a keyboard announced", () => {
+    // GIVEN a shell that resizes its own web view frame for the keyboard, which
+    // it announces first
+    renderHook(() => useVisibleViewport());
+    announce(KEYBOARD_HEIGHT);
+
+    // WHEN that deferred resize lands, shrinking the window with it
+    resizeWindowTo(REFERENCE_HEIGHT - KEYBOARD_HEIGHT);
+
+    // THEN the keyboard-free reference survives it, so the shell keeps sizing
+    // for the keyboard the user is looking at
+    expect(readVisibleViewport()?.keyboardHeight).toBe(KEYBOARD_HEIGHT);
+  });
+
+  test("rebases with the composer focused when no keyboard was announced", () => {
+    // GIVEN a composer holding focus with nothing announced, which is what a
+    // hardware keyboard on a tablet looks like: focus with no soft keyboard
+    renderHook(() => useVisibleViewport());
+    const composer = document.createElement("textarea");
+    document.body.appendChild(composer);
+    composer.focus();
+
+    // WHEN split view shortens the window under it
+    resizeWindowTo(RESIZED_HEIGHT);
+
+    // THEN focus is not mistaken for a keyboard, so the shorter window still
+    // becomes the reference and the gesture stays disarmed
+    const viewport = readVisibleViewport();
+    expect(viewport?.keyboardHeight).toBe(0);
+    expect(viewport?.height).toBe(RESIZED_HEIGHT);
+    composer.remove();
+  });
+
+  test("leaves the reference alone once the keyboard is announced away again", () => {
+    // GIVEN a shell whose keyboard opened and closed, so it has announced
+    // before but reports nothing up now
+    renderHook(() => useVisibleViewport());
+    announce(KEYBOARD_HEIGHT);
+    announce(0);
+
+    // WHEN a later keyboard shrinks the frame with its own announcement
+    announce(KEYBOARD_HEIGHT);
+    resizeWindowTo(REFERENCE_HEIGHT - KEYBOARD_HEIGHT);
+
+    // THEN the reference still survives it
+    expect(readVisibleViewport()?.keyboardHeight).toBe(KEYBOARD_HEIGHT);
+  });
+
+  test("keeps the reference on a shell that reports no keyboard source", () => {
+    // GIVEN a shell built before `@capacitor/keyboard`, which the deployed web
+    // bundle still runs in, so nothing will ever announce its keyboard
+    stubReportsKeyboardSource = false;
+    renderHook(() => useVisibleViewport());
+
+    // WHEN that shell resizes its own web view for the soft keyboard
+    resizeWindowTo(REFERENCE_HEIGHT - KEYBOARD_HEIGHT);
+
+    // THEN the reference survives, because rebasing here would swallow the
+    // keyboard and leave the composer behind it
+    expect(readVisibleViewport()?.keyboardHeight).toBe(KEYBOARD_HEIGHT);
+  });
+
+  test("holds the reference when the source reports in, which proves nothing", () => {
+    // GIVEN a shell whose plugin listeners are still registering, which is a
+    // lazy import away on every boot, and a frame that shrank in that window
+    stubReportsKeyboardSource = false;
+    renderHook(() => useVisibleViewport());
+    resizeWindowTo(RESIZED_HEIGHT);
+
+    // WHEN the source reports in, the one moment that cannot tell a shrinking
+    // window from a keyboard that opened before anything could announce it
+    act(() => {
+      reportKeyboardSource!();
+    });
+
+    // THEN the reference stands. Rebasing here onto a keyboard-sized frame
+    // would report no keyboard for as long as the keyboard is up; standing
+    // still only reports one that is not there, and that corrects itself.
+    expect(readVisibleViewport()?.keyboardHeight).toBe(
+      REFERENCE_HEIGHT - RESIZED_HEIGHT,
+    );
+  });
+
+  test("settles that shrink on the next resize, once the source is known", () => {
+    // GIVEN the same deferred shrink, with the source now reported
+    stubReportsKeyboardSource = false;
+    renderHook(() => useVisibleViewport());
+    resizeWindowTo(RESIZED_HEIGHT);
+    act(() => {
+      reportKeyboardSource!();
+    });
+
+    // WHEN any further resize arrives, which a window drag emits continuously
+    resizeWindowTo(RESIZED_HEIGHT);
+
+    // THEN the reference follows the window down and the phantom keyboard goes
+    const viewport = readVisibleViewport();
+    expect(viewport?.keyboardHeight).toBe(0);
+    expect(viewport?.height).toBe(RESIZED_HEIGHT);
+  });
+
+  test("grows back to a window returning to full height", () => {
+    // The other way the too-tall reference resolves itself, with no resize
+    // needed while the source is still registering.
+    stubReportsKeyboardSource = false;
+    renderHook(() => useVisibleViewport());
+    resizeWindowTo(RESIZED_HEIGHT);
+    act(() => {
+      reportKeyboardSource!();
+    });
+
+    resizeWindowTo(REFERENCE_HEIGHT);
+
+    expect(readVisibleViewport()?.keyboardHeight).toBe(0);
+  });
+
+  test("ignores a window that grew, which the reference already tracks", () => {
+    // GIVEN a window shortened by a resize
+    renderHook(() => useVisibleViewport());
+    resizeWindowTo(RESIZED_HEIGHT);
+
+    // WHEN it is pulled back out
+    resizeWindowTo(REFERENCE_HEIGHT);
+
+    // THEN the taller window is the reference again and no keyboard is reported
+    const viewport = readVisibleViewport();
+    expect(viewport?.keyboardHeight).toBe(0);
+    expect(viewport?.height).toBe(REFERENCE_HEIGHT);
   });
 });

--- a/clients/web/src/hooks/use-visible-viewport.test.ts
+++ b/clients/web/src/hooks/use-visible-viewport.test.ts
@@ -46,6 +46,14 @@ mock.module("@/runtime/native-keyboard", () => ({
   subscribeNativeKeyboardHeight,
 }));
 
+// Whether the stub stands in for a shell whose frame the keyboard resizes. Only
+// there is a shrink ambiguous, so only there does the reference wait for an
+// announcement before trusting that no keyboard is up.
+let stubIsNativeMobile = false;
+mock.module("@/runtime/platform-detection", () => ({
+  isNativeMobile: () => stubIsNativeMobile,
+}));
+
 const { holdVisibleViewport, readVisibleViewport, useVisibleViewport } =
   await import("@/hooks/use-visible-viewport");
 
@@ -101,6 +109,7 @@ function announce(keyboardHeight: number, visible = keyboardHeight > 0): void {
 }
 
 beforeEach(() => {
+  stubIsNativeMobile = false;
   Object.defineProperty(window, "matchMedia", {
     configurable: true,
     writable: true,
@@ -607,6 +616,46 @@ describe("window resizes", () => {
     expect(readVisibleViewport()?.keyboardHeight).toBe(
       REFERENCE_HEIGHT - RESIZED_HEIGHT,
     );
+  });
+
+  test("waits for an announcement on a shell before trusting a quiet keyboard", () => {
+    // A keyboard raised while the plugin listeners were registering announces
+    // nothing, so silence here is not proof that the frame shrank for the
+    // window. The deferred frame resize must not be taken as the window's own.
+    stubIsNativeMobile = true;
+    renderHook(() => useVisibleViewport());
+
+    resizeWindowTo(RESIZED_HEIGHT);
+
+    expect(readVisibleViewport()?.keyboardHeight).toBe(
+      REFERENCE_HEIGHT - RESIZED_HEIGHT,
+    );
+  });
+
+  test("rebases on a shell once an announcement has been heard", () => {
+    // A hide is an answer, where silence was not. From here a shrink is the
+    // window's own and the reference follows it.
+    stubIsNativeMobile = true;
+    renderHook(() => useVisibleViewport());
+    announce(0, false);
+
+    resizeWindowTo(RESIZED_HEIGHT);
+
+    const viewport = readVisibleViewport();
+    expect(viewport?.keyboardHeight).toBe(0);
+    expect(viewport?.height).toBe(RESIZED_HEIGHT);
+  });
+
+  test("rebases in a browser with no announcement, having nothing to wait for", () => {
+    // A browser keyboard leaves `window.innerHeight` alone, so every shrink
+    // there is the window's own and there is no ambiguity to resolve.
+    renderHook(() => useVisibleViewport());
+
+    resizeWindowTo(RESIZED_HEIGHT);
+
+    const viewport = readVisibleViewport();
+    expect(viewport?.keyboardHeight).toBe(0);
+    expect(viewport?.height).toBe(RESIZED_HEIGHT);
   });
 
   test("ignores a window that grew, which the reference already tracks", () => {

--- a/clients/web/src/hooks/use-visible-viewport.ts
+++ b/clients/web/src/hooks/use-visible-viewport.ts
@@ -48,7 +48,9 @@ export interface VisibleViewport {
 // detection works correctly across both runtimes.
 //
 // Orientation changes are tracked so the reference resets when the viewport
-// dimensions change due to rotation rather than a keyboard event.
+// dimensions change due to rotation rather than a keyboard event, and
+// `rebaseReferenceForWindowResize` does the same for a window that a resize
+// made shorter without rotating.
 let referenceInnerHeight =
   typeof window !== "undefined" ? window.innerHeight : 0;
 
@@ -73,6 +75,23 @@ let anticipatedKeyboardHeight = 0;
 // frame resize is the event anticipation waits for, and the viewport moving off
 // this height is what that event looks like from here.
 let anticipationViewportHeight = 0;
+
+// Whether the last thing the shell announced was a keyboard coming up. The
+// shells that resize their web view frame for the keyboard are the ones where
+// that resize is otherwise indistinguishable from the window itself getting
+// shorter, and they are exactly the shells that announce (see the
+// `isNativeMobile` gate on `subscribeNativeKeyboardHeight`), so the
+// announcement is what separates the two. Stays `false` in a browser, where the
+// keyboard leaves `window.innerHeight` alone and there is nothing to separate.
+let nativeKeyboardVisible = false;
+
+// Whether a soft keyboard in this runtime would reach us at all: the plugin
+// listeners registered, or there is no shell whose frame a keyboard resizes.
+// A shell built before `@capacitor/keyboard`, or one whose registration
+// rejected, leaves this `false`, and its own frame resizes must not be read as
+// the window getting shorter. The web bundle is deployed ahead of installed
+// shells, so that shell is a version we still run in.
+let keyboardSourceReady = false;
 
 // The viewport reading pinned across a native picker session, or `null` when
 // nothing is holding it. iOS presents a document/photo picker by taking first
@@ -145,9 +164,17 @@ function addViewportUpdater(update: () => void): () => void {
       (keyboardHeight) => {
         anticipatedKeyboardHeight = keyboardHeight;
         anticipationViewportHeight = window.visualViewport?.height ?? 0;
+        nativeKeyboardVisible = keyboardHeight > 0;
         for (const notify of viewportUpdaters) {
           notify();
         }
+      },
+      () => {
+        // Only the flag. A resize that landed while these listeners were
+        // registering is deliberately left alone: see `rebaseReferenceForWindowResize`
+        // for why this moment cannot tell a shrinking window from a keyboard
+        // that opened before there was anything to announce it.
+        keyboardSourceReady = true;
       },
     );
   }
@@ -160,7 +187,61 @@ function addViewportUpdater(update: () => void): () => void {
     unsubscribeNativeKeyboard?.();
     unsubscribeNativeKeyboard = null;
     anticipatedKeyboardHeight = 0;
+    nativeKeyboardVisible = false;
+    keyboardSourceReady = false;
   };
+}
+
+/**
+ * Rebase the keyboard-free reference onto a window that has genuinely become
+ * shorter.
+ *
+ * `referenceInnerHeight` otherwise only ever grows, so a same-orientation
+ * window resize (an iPad Stage Manager drag, a split-view divider, a desktop
+ * window pulled shorter) leaves it standing at a height the window no longer
+ * has, and every reading from then on reports the difference as a keyboard that
+ * never goes away.
+ *
+ * A real keyboard is the one shrink to leave alone, and the announcement is the
+ * whole test: a shell that resizes its frame for the keyboard says so first,
+ * and a browser, which never announces, does not shrink the window for a
+ * keyboard in the first place. Focus is deliberately not consulted, since a
+ * hardware keyboard holds the composer focused with nothing on screen.
+ *
+ * That test only holds while there is something to announce with, so a runtime
+ * that has not reported a keyboard source keeps its reference: on a shell built
+ * before the plugin, rebasing would swallow the keyboard's own frame resize and
+ * leave the composer behind it.
+ *
+ * Driven by the `window` resize listener alone. Never on a plain viewport read:
+ * that would rebase onto a frame the keyboard still owns, since a dismissal
+ * announces its `0` and notifies consumers before the frame grows back. And
+ * never when the keyboard source reports in, even though a resize that landed
+ * during registration was skipped for want of that answer: at that moment
+ * nothing separates a window that shrank from a keyboard that opened before
+ * there was anything to announce it. Focus does not separate them, a hardware
+ * keyboard holds a field focused with nothing on screen, and the plugin offers
+ * no way to ask whether the keyboard is up right now.
+ *
+ * Leaving it alone is the safe half of that ambiguity. A reference left too
+ * tall reports a keyboard that is not there, which arms a dismissal gesture
+ * whose whole effect is blurring a focused field, and it corrects itself on the
+ * next resize or as soon as a read sees the window at its full height. A
+ * reference rebased onto a keyboard-sized frame reports no keyboard at all and
+ * stays wrong for as long as the keyboard is up.
+ *
+ * Reports whether the reference moved, which the resize listener ignores today
+ * and a future caller may not.
+ */
+function rebaseReferenceForWindowResize(): boolean {
+  if (window.innerHeight >= referenceInnerHeight) {
+    return false;
+  }
+  if (!keyboardSourceReady || nativeKeyboardVisible) {
+    return false;
+  }
+  referenceInnerHeight = window.innerHeight;
+  return true;
 }
 
 /**
@@ -291,18 +372,24 @@ export function useVisibleViewport(): VisibleViewport | null {
     }
     const vv = window.visualViewport;
     const update = () => setState(readVisibleViewport());
+    // The rebase rides the window's own resize rather than every viewport
+    // read; see `rebaseReferenceForWindowResize`.
+    const handleWindowResize = () => {
+      rebaseReferenceForWindowResize();
+      update();
+    };
     update();
     // `resize` fires on width/height/scale changes; `scroll` fires on
     // offsetTop/offsetLeft changes. Both must be observed — iOS commonly
     // fires one without the other during a single keyboard transition.
     vv.addEventListener("resize", update);
     vv.addEventListener("scroll", update);
-    window.addEventListener("resize", update);
+    window.addEventListener("resize", handleWindowResize);
     const removeUpdater = addViewportUpdater(update);
     return () => {
       vv.removeEventListener("resize", update);
       vv.removeEventListener("scroll", update);
-      window.removeEventListener("resize", update);
+      window.removeEventListener("resize", handleWindowResize);
       removeUpdater();
     };
   }, []);

--- a/clients/web/src/hooks/use-visible-viewport.ts
+++ b/clients/web/src/hooks/use-visible-viewport.ts
@@ -161,10 +161,14 @@ function addViewportUpdater(update: () => void): () => void {
   viewportUpdaters.add(update);
   if (!unsubscribeNativeKeyboard) {
     unsubscribeNativeKeyboard = subscribeNativeKeyboardHeight(
-      (keyboardHeight) => {
+      (keyboardHeight, visible) => {
         anticipatedKeyboardHeight = keyboardHeight;
         anticipationViewportHeight = window.visualViewport?.height ?? 0;
-        nativeKeyboardVisible = keyboardHeight > 0;
+        // Which event fired, not what it measured. A malformed show payload is
+        // coerced to `0` at the bridge, and reading visibility off that number
+        // would call a keyboard coming up a dismissal, then let the frame
+        // resize behind it pass for the window getting shorter.
+        nativeKeyboardVisible = visible;
         for (const notify of viewportUpdaters) {
           notify();
         }

--- a/clients/web/src/hooks/use-visible-viewport.ts
+++ b/clients/web/src/hooks/use-visible-viewport.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 
 import { subscribeNativeKeyboardHeight } from "@/runtime/native-keyboard";
+import { isNativeMobile } from "@/runtime/platform-detection";
 
 /**
  * Threshold (in px) below which an `innerHeight − visualViewport.height` delta
@@ -93,6 +94,16 @@ let nativeKeyboardVisible = false;
 // shells, so that shell is a version we still run in.
 let keyboardSourceReady = false;
 
+// Whether an announcement has actually arrived. `nativeKeyboardVisible` starts
+// `false`, which before the first announcement means "nothing heard yet" and
+// not "no keyboard": a keyboard raised while the plugin listeners were still
+// registering shows up here as silence. On a shell whose frame the keyboard
+// resizes, that silence is indistinguishable from the window getting shorter,
+// so the reference waits for one announcement before it trusts a `false`.
+// A browser needs no such wait, since its keyboard leaves `window.innerHeight`
+// alone and every shrink there is the window's own.
+let sawKeyboardAnnouncement = false;
+
 // The viewport reading pinned across a native picker session, or `null` when
 // nothing is holding it. iOS presents a document/photo picker by taking first
 // responder off the web view, which dismisses the soft keyboard, and the
@@ -169,6 +180,7 @@ function addViewportUpdater(update: () => void): () => void {
         // would call a keyboard coming up a dismissal, then let the frame
         // resize behind it pass for the window getting shorter.
         nativeKeyboardVisible = visible;
+        sawKeyboardAnnouncement = true;
         for (const notify of viewportUpdaters) {
           notify();
         }
@@ -192,6 +204,7 @@ function addViewportUpdater(update: () => void): () => void {
     unsubscribeNativeKeyboard = null;
     anticipatedKeyboardHeight = 0;
     nativeKeyboardVisible = false;
+    sawKeyboardAnnouncement = false;
     keyboardSourceReady = false;
   };
 }
@@ -242,6 +255,12 @@ function rebaseReferenceForWindowResize(): boolean {
     return false;
   }
   if (!keyboardSourceReady || nativeKeyboardVisible) {
+    return false;
+  }
+  // On a shell that resizes its frame for the keyboard, a `false` that no
+  // announcement has confirmed is silence rather than an answer, and the
+  // keyboard raised during registration is exactly the case that produces it.
+  if (isNativeMobile() && !sawKeyboardAnnouncement) {
     return false;
   }
   referenceInnerHeight = window.innerHeight;

--- a/clients/web/src/runtime/native-keyboard.test.ts
+++ b/clients/web/src/runtime/native-keyboard.test.ts
@@ -1,17 +1,21 @@
 /**
  * Unit tests for `initNativeKeyboard` and `subscribeNativeKeyboardHeight`.
  *
- * These pin the platform gate, the backwards-compat contract (shells without
- * the linked `@capacitor/keyboard` plugin reject the call and retain the
- * accessory bar, and boot must not surface that as an error), and the
- * defensive height read that keeps a malformed payload from reaching layout.
+ * These pin the platform gates (including the Android half of `hide()`, which
+ * the swipe-down dismiss gesture depends on), the backwards-compat contract
+ * (shells without the linked `@capacitor/keyboard` plugin reject the call and
+ * retain the accessory bar, and boot must not surface that as an error), and
+ * the defensive height read that keeps a malformed payload from reaching
+ * layout.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 let mockIsNativeIOS = false;
+let mockIsNativeAndroid = false;
 mock.module("@/runtime/platform-detection", () => ({
   isNativeIOS: () => mockIsNativeIOS,
+  isNativeMobile: () => mockIsNativeIOS || mockIsNativeAndroid,
 }));
 
 mock.module("@/runtime/native-auth", () => ({
@@ -43,8 +47,10 @@ const addListener = mock((eventName: string, handler: unknown) => {
   return Promise.resolve({ remove: removeHide });
 });
 
+const hide = mock(async () => {});
+
 mock.module("@capacitor/keyboard", () => ({
-  Keyboard: { setAccessoryBarVisible, addListener },
+  Keyboard: { setAccessoryBarVisible, addListener, hide },
 }));
 
 // Warm the module cache so the source's lazy `import("@capacitor/keyboard")`
@@ -64,8 +70,10 @@ async function flushMicrotasks(rounds = 4): Promise<void> {
 
 beforeEach(() => {
   mockIsNativeIOS = false;
+  mockIsNativeAndroid = false;
   showHandler = null;
   hideHandler = null;
+  hide.mockClear();
   setAccessoryBarVisible.mockClear();
   addListener.mockClear();
   removeShow.mockClear();
@@ -141,7 +149,23 @@ describe("subscribeNativeKeyboardHeight", () => {
     unsubscribe();
   });
 
-  test("attaches nothing outside the native iOS shell", async () => {
+  test("listens on the native Android shell too", async () => {
+    // The Android web view frame resizes for the IME the same way, so the
+    // announcement is what tells `use-visible-viewport` that shrink apart from
+    // the window itself getting shorter.
+    mockIsNativeIOS = false;
+    mockIsNativeAndroid = true;
+    const onHeightChange = mock((_height: number) => {});
+    const unsubscribe = subscribeNativeKeyboardHeight(onHeightChange);
+    await flushMicrotasks();
+
+    showHandler!({ keyboardHeight: 336 });
+
+    expect(onHeightChange).toHaveBeenCalledWith(336);
+    unsubscribe();
+  });
+
+  test("attaches nothing outside the native shells", async () => {
     mockIsNativeIOS = false;
     const onHeightChange = mock((_height: number) => {});
     const unsubscribe = subscribeNativeKeyboardHeight(onHeightChange);
@@ -152,6 +176,45 @@ describe("subscribeNativeKeyboardHeight", () => {
     expect(() => {
       unsubscribe();
     }).not.toThrow();
+  });
+
+  test("reports the keyboard source once both listeners register", async () => {
+    const onSourceReady = mock(() => {});
+    const unsubscribe = subscribeNativeKeyboardHeight(() => {}, onSourceReady);
+
+    // Registration is a lazy plugin import, so nothing is settled yet
+    expect(onSourceReady).not.toHaveBeenCalled();
+    await flushMicrotasks();
+
+    expect(onSourceReady).toHaveBeenCalledTimes(1);
+    unsubscribe();
+  });
+
+  test("reports no keyboard source when registration rejects", async () => {
+    // A shell built before the plugin, which the deployed web bundle still runs
+    // in, rejects the import and must not look like a shell that announces.
+    addListener.mockImplementationOnce(() =>
+      Promise.reject(new Error("plugin missing")),
+    );
+    addListener.mockImplementationOnce(() =>
+      Promise.reject(new Error("plugin missing")),
+    );
+    const onSourceReady = mock(() => {});
+    const unsubscribe = subscribeNativeKeyboardHeight(() => {}, onSourceReady);
+    await flushMicrotasks();
+
+    expect(onSourceReady).not.toHaveBeenCalled();
+    unsubscribe();
+  });
+
+  test("reports the keyboard source straight away in a browser", async () => {
+    // No frame for a keyboard to resize, so nothing has to announce one.
+    mockIsNativeIOS = false;
+    const onSourceReady = mock(() => {});
+    const unsubscribe = subscribeNativeKeyboardHeight(() => {}, onSourceReady);
+
+    expect(onSourceReady).toHaveBeenCalledTimes(1);
+    unsubscribe();
   });
 
   test("unsubscribe removes both plugin listeners", async () => {

--- a/clients/web/src/runtime/native-keyboard.test.ts
+++ b/clients/web/src/runtime/native-keyboard.test.ts
@@ -110,31 +110,31 @@ describe("subscribeNativeKeyboardHeight", () => {
   });
 
   test("reports the height the plugin announces on keyboardWillShow", async () => {
-    const onHeightChange = mock((_height: number) => {});
+    const onHeightChange = mock((_height: number, _visible?: boolean) => {});
     const unsubscribe = subscribeNativeKeyboardHeight(onHeightChange);
     await flushMicrotasks();
 
     showHandler!({ keyboardHeight: 336 });
 
     expect(onHeightChange).toHaveBeenCalledTimes(1);
-    expect(onHeightChange).toHaveBeenCalledWith(336);
+    expect(onHeightChange).toHaveBeenCalledWith(336, true);
     unsubscribe();
   });
 
   test("reports 0 on keyboardWillHide", async () => {
-    const onHeightChange = mock((_height: number) => {});
+    const onHeightChange = mock((_height: number, _visible?: boolean) => {});
     const unsubscribe = subscribeNativeKeyboardHeight(onHeightChange);
     await flushMicrotasks();
 
     hideHandler!();
 
     expect(onHeightChange).toHaveBeenCalledTimes(1);
-    expect(onHeightChange).toHaveBeenCalledWith(0);
+    expect(onHeightChange).toHaveBeenCalledWith(0, false);
     unsubscribe();
   });
 
   test("falls back to 0 for a malformed payload", async () => {
-    const onHeightChange = mock((_height: number) => {});
+    const onHeightChange = mock((_height: number, _visible?: boolean) => {});
     const unsubscribe = subscribeNativeKeyboardHeight(onHeightChange);
     await flushMicrotasks();
 
@@ -144,7 +144,7 @@ describe("subscribeNativeKeyboardHeight", () => {
 
     expect(onHeightChange).toHaveBeenCalledTimes(3);
     for (const call of onHeightChange.mock.calls) {
-      expect(call).toEqual([0]);
+      expect(call).toEqual([0, true]);
     }
     unsubscribe();
   });
@@ -155,19 +155,19 @@ describe("subscribeNativeKeyboardHeight", () => {
     // the window itself getting shorter.
     mockIsNativeIOS = false;
     mockIsNativeAndroid = true;
-    const onHeightChange = mock((_height: number) => {});
+    const onHeightChange = mock((_height: number, _visible?: boolean) => {});
     const unsubscribe = subscribeNativeKeyboardHeight(onHeightChange);
     await flushMicrotasks();
 
     showHandler!({ keyboardHeight: 336 });
 
-    expect(onHeightChange).toHaveBeenCalledWith(336);
+    expect(onHeightChange).toHaveBeenCalledWith(336, true);
     unsubscribe();
   });
 
   test("attaches nothing outside the native shells", async () => {
     mockIsNativeIOS = false;
-    const onHeightChange = mock((_height: number) => {});
+    const onHeightChange = mock((_height: number, _visible?: boolean) => {});
     const unsubscribe = subscribeNativeKeyboardHeight(onHeightChange);
     await flushMicrotasks();
 
@@ -187,6 +187,39 @@ describe("subscribeNativeKeyboardHeight", () => {
     await flushMicrotasks();
 
     expect(onSourceReady).toHaveBeenCalledTimes(1);
+    unsubscribe();
+  });
+
+  test("suppresses readiness for a registration the caller already left", async () => {
+    // Unsubscribing during the lazy import means the listeners are being
+    // removed as they land. Reporting a source then restores the shared flag
+    // after the teardown that cleared it.
+    const onSourceReady = mock(() => {});
+    const unsubscribe = subscribeNativeKeyboardHeight(() => {}, onSourceReady);
+
+    unsubscribe();
+    await flushMicrotasks();
+
+    expect(onSourceReady).not.toHaveBeenCalled();
+  });
+
+  test("reports a show and a hide by which event fired, not by its height", async () => {
+    // The height is sanitized at the bridge, so a malformed show arrives as
+    // `0`. Visibility has to survive that, or the frame resize behind it reads
+    // as the window getting shorter.
+    const onHeightChange = mock((_height: number, _visible: boolean) => {});
+    const unsubscribe = subscribeNativeKeyboardHeight(onHeightChange);
+    await flushMicrotasks();
+
+    showHandler!({ keyboardHeight: 336 });
+    showHandler!({ keyboardHeight: "tall" });
+    hideHandler!();
+
+    expect(onHeightChange.mock.calls).toEqual([
+      [336, true],
+      [0, true],
+      [0, false],
+    ]);
     unsubscribe();
   });
 
@@ -218,7 +251,7 @@ describe("subscribeNativeKeyboardHeight", () => {
   });
 
   test("unsubscribe removes both plugin listeners", async () => {
-    const onHeightChange = mock((_height: number) => {});
+    const onHeightChange = mock((_height: number, _visible?: boolean) => {});
     const unsubscribe = subscribeNativeKeyboardHeight(onHeightChange);
     await flushMicrotasks();
 

--- a/clients/web/src/runtime/native-keyboard.ts
+++ b/clients/web/src/runtime/native-keyboard.ts
@@ -1,5 +1,5 @@
 import { subscribeCapacitorListener } from "@/runtime/capacitor-listener";
-import { isNativeIOS } from "@/runtime/platform-detection";
+import { isNativeIOS, isNativeMobile } from "@/runtime/platform-detection";
 
 /**
  * Declare at the JS layer that the iOS keyboard input accessory bar (prev/next
@@ -69,25 +69,41 @@ function readKeyboardHeight(reported: unknown): number {
 }
 
 /**
- * Subscribe to the iOS keyboard height as the keyboard animation starts.
+ * Subscribe to the native keyboard height as the keyboard animation starts.
  *
  * `keyboardWillShow` fires synchronously inside the plugin's native
  * `onKeyboardWillShow`, ahead of the web view frame resize the plugin defers
  * (see `docs/CAPACITOR.md` § "Linking a plugin runs its native `load()`"), so
  * reading the height here is what lets layout follow the keyboard as it
  * animates rather than a beat after it lands. `keyboardWillHide` carries no
- * payload and means height `0`.
+ * payload and means height `0`. Android announces the same pair off its window
+ * insets, in CSS pixels (`Keyboard.java` divides the IME height by the display
+ * density), so both shells report a height layout can use directly.
  *
- * Off the native iOS shell there is no keyboard to hear from, so the gate
- * returns a no-op unsubscribe and the plugin is never imported.
+ * The gate is `isNativeMobile()` because the shells that announce a keyboard
+ * are exactly the shells whose web view frame the keyboard resizes, and
+ * `use-visible-viewport.ts` has no other way to tell that resize apart from the
+ * window itself getting shorter. In a browser the keyboard leaves
+ * `window.innerHeight` alone, so there is nothing to hear from and the gate
+ * returns a no-op unsubscribe with the plugin never imported.
  *
  * Show and hide are one source, so they share a single subscription: one plugin
  * import, and one warning if this shell has no keyboard plugin to give.
+ *
+ * `onSourceReady` fires once it is settled that a soft keyboard here would
+ * reach the caller: after the plugin listeners register on a native shell, and
+ * straight away in a browser, where a keyboard has no frame to resize and so
+ * needs no announcement to be recognised. A native shell whose registration
+ * never lands (built before the plugin, or rejected) never fires it, which is
+ * how `use-visible-viewport.ts` knows not to read that shell's frame resizes as
+ * the window itself getting shorter.
  */
 export function subscribeNativeKeyboardHeight(
   onHeightChange: (keyboardHeight: number) => void,
+  onSourceReady?: () => void,
 ): () => void {
-  if (!isNativeIOS()) {
+  if (!isNativeMobile()) {
+    onSourceReady?.();
     return () => {};
   }
 
@@ -101,6 +117,7 @@ export function subscribeNativeKeyboardHeight(
         onHeightChange(0);
       }),
     ]);
+    onSourceReady?.();
     return {
       remove: async () => {
         await Promise.all([show.remove(), hide.remove()]);

--- a/clients/web/src/runtime/native-keyboard.ts
+++ b/clients/web/src/runtime/native-keyboard.ts
@@ -90,16 +90,25 @@ function readKeyboardHeight(reported: unknown): number {
  * Show and hide are one source, so they share a single subscription: one plugin
  * import, and one warning if this shell has no keyboard plugin to give.
  *
+ * `visible` says which of the two events fired, and is reported separately from
+ * the height because the height is sanitized: `readKeyboardHeight` coerces a
+ * malformed payload to `0`, and a show that arrives malformed still means a
+ * keyboard is coming up. Reading visibility off the number instead would call
+ * that a dismissal and let the frame resize behind it pass for the window
+ * getting shorter.
+ *
  * `onSourceReady` fires once it is settled that a soft keyboard here would
  * reach the caller: after the plugin listeners register on a native shell, and
  * straight away in a browser, where a keyboard has no frame to resize and so
  * needs no announcement to be recognised. A native shell whose registration
  * never lands (built before the plugin, or rejected) never fires it, which is
  * how `use-visible-viewport.ts` knows not to read that shell's frame resizes as
- * the window itself getting shorter.
+ * the window itself getting shorter. Nor does a registration the caller
+ * unsubscribed from while it was still in flight: the readiness it would report
+ * belongs to listeners that are already being removed.
  */
 export function subscribeNativeKeyboardHeight(
-  onHeightChange: (keyboardHeight: number) => void,
+  onHeightChange: (keyboardHeight: number, visible: boolean) => void,
   onSourceReady?: () => void,
 ): () => void {
   if (!isNativeMobile()) {
@@ -107,21 +116,32 @@ export function subscribeNativeKeyboardHeight(
     return () => {};
   }
 
-  return subscribeCapacitorListener("native_keyboard_height", async () => {
-    const { Keyboard } = await import("@capacitor/keyboard");
-    const [show, hide] = await Promise.all([
-      Keyboard.addListener("keyboardWillShow", (info) => {
-        onHeightChange(readKeyboardHeight(info.keyboardHeight));
-      }),
-      Keyboard.addListener("keyboardWillHide", () => {
-        onHeightChange(0);
-      }),
-    ]);
-    onSourceReady?.();
-    return {
-      remove: async () => {
-        await Promise.all([show.remove(), hide.remove()]);
-      },
-    };
-  });
+  let cancelled = false;
+  const unsubscribe = subscribeCapacitorListener(
+    "native_keyboard_height",
+    async () => {
+      const { Keyboard } = await import("@capacitor/keyboard");
+      const [show, hide] = await Promise.all([
+        Keyboard.addListener("keyboardWillShow", (info) => {
+          onHeightChange(readKeyboardHeight(info.keyboardHeight), true);
+        }),
+        Keyboard.addListener("keyboardWillHide", () => {
+          onHeightChange(0, false);
+        }),
+      ]);
+      if (!cancelled) {
+        onSourceReady?.();
+      }
+      return {
+        remove: async () => {
+          await Promise.all([show.remove(), hide.remove()]);
+        },
+      };
+    },
+  );
+
+  return () => {
+    cancelled = true;
+    unsubscribe();
+  };
 }


### PR DESCRIPTION
Split out of #40931, where these bugs were found. They **predate that PR** and reach every consumer of `use-visible-viewport.ts` (the app shell's height, the composer stack's keyboard collapse, mobile overlay sizing), not just the swipe gesture that exposed them.

## The bug

`referenceInnerHeight` is the height a keyboard gets measured against, and it only ever grew. A same-orientation window resize therefore left it standing at a height the window no longer has, and every reading from then on reported the difference as a keyboard that never goes away.

Reachable today on `main`:
- an iPad Stage Manager drag
- a split-view divider
- a desktop window pulled shorter

## The rule

The one shrink to leave alone is a real keyboard, and **the announcement is the whole test**. A shell that resizes its web view frame for the keyboard says so first (`@capacitor/keyboard`, `resize: native`), and a browser, which never announces, does not shrink `window.innerHeight` for a keyboard in the first place.

**Focus is deliberately not consulted.** A hardware keyboard holds a field focused with nothing on screen, so focus proves nothing either way. This is worth stating because it is the tempting wrong answer.

That test only holds where there is something to announce with, so a runtime that has not reported a keyboard source keeps its reference. On a shell built before the plugin, or one whose registration rejected, rebasing would swallow the keyboard's own frame resize and leave the composer stranded behind it. `subscribeNativeKeyboardHeight` now reports that readiness, and widens to `isNativeMobile()` so the Android shell announces too.

## The case this deliberately does not handle

The rebase runs on the `window` resize listener **alone**. It does not run when the keyboard source reports in, even though a resize that landed during registration was skipped for want of that answer.

At that moment nothing separates a window that shrank from a keyboard that opened before there was anything to announce it. Focus does not separate them, and the plugin offers no way to ask whether the keyboard is up right now. So the callback does not decide.

Holding still is the safe half of that ambiguity, and the asymmetry is the argument:

| Guess | Result | Recovery |
|---|---|---|
| Reference left too tall | Reports a keyboard that is not there | Next resize, or the next read that sees the window at full height |
| Reference rebased onto a keyboard frame | Reports **no** keyboard | Not until the keyboard closes |

The residual case is a single discrete resize that never repeats, inside the few milliseconds of a lazy import. A window drag emits resizes continuously, so the follow-up normally lands within milliseconds.

## Testing

`use-visible-viewport.test.ts` gains 9 cases covering: the same-orientation shrink, a shell with no keyboard source keeping its reference, an announced keyboard being left alone, the reference holding through source readiness, the next resize settling the deferred shrink, and a window returning to full height clearing it. `native-keyboard.test.ts` gains the readiness-callback contract, including a registration that rejects and the browser path that reports straight away.

26 and 13 tests respectively, both green in isolation. `eslint` and `tsc --noEmit` clean.

## Known gap, stated plainly

**A rotation taken while the keyboard is up still resets the reference to the keyboard-shrunken height**, so the keyboard reads as `0` until the next transition. That is pre-existing on `main` and is **not** fixed here; it was raised on #40931 and is the obvious next thing to pick up in this file. I left it out rather than grow this PR the way it grew the last one.

**Not verified on a device.** Every case here is reasoned from the code and driven through stubbed viewport globals in tests. Stage Manager, split view, and the Android announce path all want a real device before this is trusted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
