### PR TITLE
feat(web): let the avatar wave go around a phone screen, not beside it

### DIFF
--- a/clients/web/src/components/auth-welcome-screen.tsx
+++ b/clients/web/src/components/auth-welcome-screen.tsx
@@ -47,7 +47,7 @@ export function WelcomeScreenShell({
   fillsViewport?: boolean;
 }) {
   const content = (
-    <OnboardingLayout showAvatarWave animateAvatarWaveIn={animateAvatarWaveIn}>
+    <OnboardingLayout avatarWave="around" animateAvatarWaveIn={animateAvatarWaveIn}>
       <div className="mx-auto flex min-h-full w-full max-w-xl flex-col items-center px-6 pb-40 text-[var(--content-default)] md:pb-0">
         <div className="flex flex-1 flex-col items-center justify-center">
           {children}

--- a/clients/web/src/components/auth-welcome-screen.tsx
+++ b/clients/web/src/components/auth-welcome-screen.tsx
@@ -167,8 +167,16 @@ export function AuthWelcomeScreen({
         </p>
       )}
 
+      {/*
+        A failed handoff is the one thing that grows this column, and the wrap
+        composition has about a button's worth of room under it on a 640-tall
+        phone before the returning crowd. Spend the gap above the buttons on
+        the message rather than adding to the column: the error sits next to
+        what it is about either way, and the buttons stay clear of the crowd
+        through a message long enough to wrap three times.
+      */}
       <div
-        className="mt-15 flex w-full max-w-sm flex-col gap-3"
+        className={`${error ? "mt-4" : "mt-15"} flex w-full max-w-sm flex-col gap-3`}
         style={{ animation: "fadeInUp 0.5s ease-out 0.5s both" }}
       >
         <Button

--- a/clients/web/src/components/avatar-wave.tsx
+++ b/clients/web/src/components/avatar-wave.tsx
@@ -69,30 +69,35 @@ const COLUMN_RIBBON: RibbonPoint[] = [
 /**
  * The wrap ribbon is the same crowd on a screen with no column to spare: it
  * goes around the content instead of beside it. A thread of small characters
- * arcs over the heading, turns down past its outer edge, leaves the screen
- * entirely, and comes back in below the buttons, where it broadens into the
- * crowd that fills the rest of the screen.
+ * drops in through the top edge near the left, turns and sweeps right over
+ * the heading, carries on down past its outer edge and off the screen, then
+ * comes back in below the buttons, where it broadens into the crowd that
+ * fills the rest of the screen.
  *
  * The loop between `fx: 1.0` and the re-entry is drawn but never seen. It
  * exists so the thread that leaves and the crowd that returns are one
  * continuous path with a continuous size ramp, rather than two pieces that
  * happen to line up at the edge.
  *
- * The two clearances the arc and the crowd have to hold are the heading's
- * top and the second button's bottom. Both sit at fractions of the screen
- * that barely move across phone sizes (the content column is a fixed stack
- * of text and controls centred in what the bottom padding leaves it), so the
- * relative points hold the composition on every one of them. See
- * {@link RelativeRibbonPoint} for why this ribbon is authored that way and
- * the column one is not.
+ * The two clearances the thread and the crowd have to hold are the heading's
+ * top and the second button's bottom. A step's column is a fixed stack of
+ * text and controls centred in what the bottom padding leaves it, so it
+ * keeps its height as the screen shortens and takes a larger fraction of it:
+ * the shortest screen the wrap runs on is the one that binds, and both
+ * clearances are tuned against a 640-tall phone rather than an 844-tall one.
+ * See {@link RelativeRibbonPoint} for why this ribbon is authored against
+ * the screen and the column one is not.
  */
 const WRAP_RIBBON: RelativeRibbonPoint[] = [
-  { fx: -0.2, fy: 0.17, fw: 0.052, fs: 0.0118 },
-  { fx: 0.02, fy: 0.104, fw: 0.06, fs: 0.0136 },
-  { fx: 0.27, fy: 0.06, fw: 0.07, fs: 0.0158 },
-  { fx: 0.55, fy: 0.058, fw: 0.08, fs: 0.018 },
-  { fx: 0.83, fy: 0.096, fw: 0.095, fs: 0.0216 },
-  { fx: 1.03, fy: 0.17, fw: 0.114, fs: 0.026 },
+  { fx: 0.11, fy: -0.15, fw: 0.05, fs: 0.0112 },
+  { fx: 0.115, fy: -0.06, fw: 0.055, fs: 0.0126 },
+  { fx: 0.14, fy: 0.012, fw: 0.062, fs: 0.0142 },
+  { fx: 0.21, fy: 0.055, fw: 0.07, fs: 0.016 },
+  { fx: 0.34, fy: 0.072, fw: 0.077, fs: 0.0178 },
+  { fx: 0.51, fy: 0.072, fw: 0.084, fs: 0.0195 },
+  { fx: 0.7, fy: 0.08, fw: 0.091, fs: 0.0212 },
+  { fx: 0.89, fy: 0.112, fw: 0.1, fs: 0.023 },
+  { fx: 1.05, fy: 0.174, fw: 0.114, fs: 0.026 },
   { fx: 1.15, fy: 0.28, fw: 0.142, fs: 0.0316 },
   { fx: 1.19, fy: 0.4, fw: 0.18, fs: 0.0392 },
   { fx: 1.14, fy: 0.55, fw: 0.228, fs: 0.0476 },

--- a/clients/web/src/components/avatar-wave.tsx
+++ b/clients/web/src/components/avatar-wave.tsx
@@ -3,6 +3,8 @@ import { useEffect, useRef } from "react";
 import {
   buildRibbonWave,
   mulberry32,
+  resolveRibbon,
+  type RelativeRibbonPoint,
   type RibbonPoint,
 } from "@/utils/avatar-wave-ribbon";
 import type { CharacterComponents } from "@/types/avatar";
@@ -20,8 +22,8 @@ import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-component
  */
 
 /**
- * Design-space box the ribbon is authored in. The canvas scales this to
- * cover its container, so the crowd keeps its shape at any panel size.
+ * Design-space box the column ribbon is authored in. The canvas scales this
+ * to cover its container, so the crowd keeps its shape at any panel size.
  */
 const DESIGN_W = 620;
 const DESIGN_H = 900;
@@ -32,7 +34,7 @@ const SEED = 20260807;
 const MAX_AVATAR_SIZE = 165;
 
 /**
- * The ribbon enters cut off by the top edge as a thin thread of small
+ * The column ribbon enters cut off by the top edge as a thin thread of small
  * characters, switches back across the panel three times, and broadens into
  * a full crowd that pours off the bottom.
  *
@@ -47,7 +49,7 @@ const MAX_AVATAR_SIZE = 165;
  * so the broad rows bleed off the outer edge rather than being sliced by
  * the inner one.
  */
-const RIBBON: RibbonPoint[] = [
+const COLUMN_RIBBON: RibbonPoint[] = [
   { x: 330, y: -70, w: 26, s: 13 },
   { x: 420, y: 20, w: 40, s: 18 },
   { x: 482, y: 115, w: 62, s: 25 },
@@ -62,6 +64,47 @@ const RIBBON: RibbonPoint[] = [
   { x: 360, y: 912, w: 700, s: 132 },
   { x: 380, y: 1002, w: 760, s: 140 },
 ];
+
+/**
+ * The wrap ribbon is the same crowd on a screen with no column to spare: it
+ * goes around the content instead of beside it. A thread of small characters
+ * arcs over the heading, turns down past its outer edge, leaves the screen
+ * entirely, and comes back in below the buttons, where it broadens into the
+ * crowd that fills the rest of the screen.
+ *
+ * The loop between `fx: 1.0` and the re-entry is drawn but never seen. It
+ * exists so the thread that leaves and the crowd that returns are one
+ * continuous path with a continuous size ramp, rather than two pieces that
+ * happen to line up at the edge.
+ *
+ * The two clearances the arc and the crowd have to hold are the heading's
+ * top and the second button's bottom. Both sit at fractions of the screen
+ * that barely move across phone sizes (the content column is a fixed stack
+ * of text and controls centred in what the bottom padding leaves it), so the
+ * relative points hold the composition on every one of them. See
+ * {@link RelativeRibbonPoint} for why this ribbon is authored that way and
+ * the column one is not.
+ */
+const WRAP_RIBBON: RelativeRibbonPoint[] = [
+  { fx: -0.2, fy: 0.17, fw: 0.052, fs: 0.0118 },
+  { fx: 0.02, fy: 0.104, fw: 0.06, fs: 0.0136 },
+  { fx: 0.27, fy: 0.06, fw: 0.07, fs: 0.0158 },
+  { fx: 0.55, fy: 0.058, fw: 0.08, fs: 0.018 },
+  { fx: 0.83, fy: 0.096, fw: 0.095, fs: 0.0216 },
+  { fx: 1.03, fy: 0.17, fw: 0.114, fs: 0.026 },
+  { fx: 1.15, fy: 0.28, fw: 0.142, fs: 0.0316 },
+  { fx: 1.19, fy: 0.4, fw: 0.18, fs: 0.0392 },
+  { fx: 1.14, fy: 0.55, fw: 0.228, fs: 0.0476 },
+  { fx: 0.98, fy: 0.702, fw: 0.325, fs: 0.0586 },
+  { fx: 0.74, fy: 0.796, fw: 0.51, fs: 0.0724 },
+  { fx: 0.58, fy: 0.866, fw: 0.84, fs: 0.0874 },
+  { fx: 0.52, fy: 0.93, fw: 1.16, fs: 0.1004 },
+  { fx: 0.5, fy: 0.998, fw: 1.48, fs: 0.1124 },
+  { fx: 0.5, fy: 1.07, fw: 1.8, fs: 0.1224 },
+];
+
+/** {@link MAX_AVATAR_SIZE}'s counterpart, against the screen height. */
+const WRAP_MAX_AVATAR_FRACTION = 0.135;
 
 const REPEL_RADIUS = 170;
 const REPEL_PUSH = 70;
@@ -202,6 +245,15 @@ function renderSprite(
  */
 let hasPlayedEntrance = false;
 
+/**
+ * Which composition the crowd is laid out in.
+ *
+ * `column` fills a panel beside the content: the split the welcome screen
+ * takes once there is room for one. `wrap` fills the whole screen behind the
+ * content, going around it, which is what a phone gets instead of the split.
+ */
+export type AvatarWaveVariant = "column" | "wrap";
+
 interface AvatarWaveProps {
   className?: string;
   /**
@@ -211,9 +263,14 @@ interface AvatarWaveProps {
    * already come past one.
    */
   entrance?: boolean;
+  variant?: AvatarWaveVariant;
 }
 
-export function AvatarWave({ className = "", entrance = false }: AvatarWaveProps) {
+export function AvatarWave({
+  className = "",
+  entrance = false,
+  variant = "column",
+}: AvatarWaveProps) {
   const components = useBundledAvatarComponents();
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
 
@@ -280,18 +337,28 @@ export function AvatarWave({ className = "", entrance = false }: AvatarWaveProps
       canvas.height = Math.round(height * dpr);
       ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
 
-      // Cover the panel so the ribbon always reaches every edge. Covering
+      // The wrap ribbon is authored against the canvas, so resolving it
+      // already lands in canvas pixels and the design-box transform below is
+      // the identity. The column one is authored in a fixed design box and
+      // covers the panel so the ribbon always reaches every edge. Covering
       // means the design is at least as wide as the panel, so there is
       // always horizontal overflow to place. Pin it to the inner edge and
       // let all of that overflow run off the outer one: this panel sits
       // flush against the side of the window, so overflow there leaves the
       // screen, while overflow at the inner edge would slice the crowd in
       // half along the boundary with the content beside it.
+      const wrap = variant === "wrap";
       const offsetX = 0;
-      const scale = Math.max(width / DESIGN_W, height / DESIGN_H);
-      const offsetY = (height - DESIGN_H * scale) / 2;
+      const scale = wrap ? 1 : Math.max(width / DESIGN_W, height / DESIGN_H);
+      const offsetY = wrap ? 0 : (height - DESIGN_H * scale) / 2;
 
-      const placements = buildRibbonWave(RIBBON, SEED, MAX_AVATAR_SIZE);
+      const placements = wrap
+        ? buildRibbonWave(
+            resolveRibbon(WRAP_RIBBON, width, height),
+            SEED,
+            height * WRAP_MAX_AVATAR_FRACTION,
+          )
+        : buildRibbonWave(COLUMN_RIBBON, SEED, MAX_AVATAR_SIZE);
 
       // Normalize the size-weighted stagger to a fixed total so the crowd
       // always finishes arriving at the same moment, however many characters
@@ -574,7 +641,7 @@ export function AvatarWave({ className = "", entrance = false }: AvatarWaveProps
       window.removeEventListener("touchend", onLeave);
       window.removeEventListener("touchcancel", onLeave);
     };
-  }, [components, entrance]);
+  }, [components, entrance, variant]);
 
   return (
     <canvas

--- a/clients/web/src/components/avatar-wave.tsx
+++ b/clients/web/src/components/avatar-wave.tsx
@@ -4,6 +4,7 @@ import {
   buildRibbonWave,
   mulberry32,
   resolveRibbon,
+  ribbonSizingHeight,
   type RelativeRibbonPoint,
   type RibbonPoint,
 } from "@/utils/avatar-wave-ribbon";
@@ -103,8 +104,23 @@ const WRAP_RIBBON: RelativeRibbonPoint[] = [
   { fx: 0.5, fy: 1.07, fw: 1.8, fs: 0.1224 },
 ];
 
-/** {@link MAX_AVATAR_SIZE}'s counterpart, against the screen height. */
+/**
+ * {@link MAX_AVATAR_SIZE}'s counterpart, against the same height the ribbon
+ * sizes its avatars from. Reading it off the raw height instead would undo
+ * {@link ribbonSizingHeight} on exactly the boxes it exists for: the cap
+ * would clip the scaled-up avatars back down, and the crowd would go back to
+ * packing itself several times over.
+ */
 const WRAP_MAX_AVATAR_FRACTION = 0.135;
+
+/**
+ * Shortest box the wrap composition is offered on. It holds the top fifth
+ * for the thread and the bottom third for the crowd, so a shorter box has
+ * nowhere left to put the content between them, and the heading ends up
+ * under the thread whatever the step. Below this the layout falls back to
+ * the creature footer.
+ */
+export const WRAP_WAVE_MIN_HEIGHT_QUERY = "(min-height: 600px)";
 
 const REPEL_RADIUS = 170;
 const REPEL_PUSH = 70;
@@ -356,7 +372,7 @@ export function AvatarWave({
         ? buildRibbonWave(
             resolveRibbon(WRAP_RIBBON, width, height),
             SEED,
-            height * WRAP_MAX_AVATAR_FRACTION,
+            ribbonSizingHeight(width, height) * WRAP_MAX_AVATAR_FRACTION,
           )
         : buildRibbonWave(COLUMN_RIBBON, SEED, MAX_AVATAR_SIZE);
 

--- a/clients/web/src/components/avatar-wave.tsx
+++ b/clients/web/src/components/avatar-wave.tsx
@@ -108,8 +108,8 @@ const WRAP_RIBBON: RelativeRibbonPoint[] = [
  * {@link MAX_AVATAR_SIZE}'s counterpart, against the same height the ribbon
  * sizes its avatars from. Reading it off the raw height instead would undo
  * {@link ribbonSizingHeight} on exactly the boxes it exists for: the cap
- * would clip the scaled-up avatars back down, and the crowd would go back to
- * packing itself several times over.
+ * would clip the scaled-up avatars back down, leaving the crowd to pack
+ * itself several times over.
  */
 const WRAP_MAX_AVATAR_FRACTION = 0.135;
 

--- a/clients/web/src/components/onboarding-layout.test.tsx
+++ b/clients/web/src/components/onboarding-layout.test.tsx
@@ -3,10 +3,16 @@ import { cleanup, render, screen } from "@testing-library/react";
 
 let mobile = false;
 let electron = false;
+let tallEnough = true;
 
 mock.module("@/hooks/use-is-mobile", () => ({
   useIsMobile: () => mobile,
   MOBILE_MEDIA_QUERY: "(max-width: 767px)",
+}));
+mock.module("@/hooks/use-media-query", () => ({
+  // The layout asks exactly one media query of its own: the wrap
+  // composition's minimum height.
+  useMediaQuery: () => tallEnough,
 }));
 mock.module("@/runtime/is-electron", () => ({
   isElectron: () => electron,
@@ -17,6 +23,7 @@ mock.module("./avatar-wave", () => ({
   AvatarWave: ({ variant = "column" }: { variant?: string }) => (
     <div data-testid={`wave-${variant}`} />
   ),
+  WRAP_WAVE_MIN_HEIGHT_QUERY: "(min-height: 600px)",
 }));
 mock.module("./creature-footer", () => ({
   CreatureFooter: () => <div data-testid="creature-footer" />,
@@ -28,6 +35,7 @@ afterEach(() => {
   cleanup();
   mobile = false;
   electron = false;
+  tallEnough = true;
 });
 
 const renderLayout = (
@@ -73,6 +81,25 @@ describe("OnboardingLayout avatar wave placement", () => {
     expect(screen.getByTestId("wave-wrap")).toBeTruthy();
     expect(screen.queryByTestId("wave-column")).toBeNull();
     expect(screen.queryByTestId("creature-footer")).toBeNull();
+  });
+
+  test("falls `around` back to the footer on a viewport too short to wrap", () => {
+    // A phone in landscape: narrow enough to have no column to spare, too
+    // short to hold a thread above the content and a crowd below it.
+    mobile = true;
+    tallEnough = false;
+    renderLayout("around");
+    expect(screen.queryByTestId("wave-wrap")).toBeNull();
+    expect(screen.queryByTestId("wave-column")).toBeNull();
+    expect(screen.getByTestId("creature-footer")).toBeTruthy();
+  });
+
+  test("keeps a short viewport off the wrap wave, not off the column one", () => {
+    // Height only gates the wrap composition; a short desktop window still
+    // has a column beside the content.
+    tallEnough = false;
+    renderLayout("around");
+    expect(screen.getByTestId("wave-column")).toBeTruthy();
   });
 
   test("keeps the desktop shell on the footer either way", () => {

--- a/clients/web/src/components/onboarding-layout.test.tsx
+++ b/clients/web/src/components/onboarding-layout.test.tsx
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, render, screen } from "@testing-library/react";
+
+let mobile = false;
+let electron = false;
+
+mock.module("@/hooks/use-is-mobile", () => ({
+  useIsMobile: () => mobile,
+  MOBILE_MEDIA_QUERY: "(max-width: 767px)",
+}));
+mock.module("@/runtime/is-electron", () => ({
+  isElectron: () => electron,
+}));
+// The wave is a canvas simulation; the layout's job is only deciding whether
+// and in which composition one mounts, so stand in for it with a marker.
+mock.module("./avatar-wave", () => ({
+  AvatarWave: ({ variant = "column" }: { variant?: string }) => (
+    <div data-testid={`wave-${variant}`} />
+  ),
+}));
+mock.module("./creature-footer", () => ({
+  CreatureFooter: () => <div data-testid="creature-footer" />,
+}));
+
+const { OnboardingLayout } = await import("./onboarding-layout");
+
+afterEach(() => {
+  cleanup();
+  mobile = false;
+  electron = false;
+});
+
+const renderLayout = (
+  avatarWave: "none" | "beside" | "around" | undefined = undefined,
+) =>
+  render(
+    <OnboardingLayout avatarWave={avatarWave}>
+      <p>step</p>
+    </OnboardingLayout>,
+  );
+
+describe("OnboardingLayout avatar wave placement", () => {
+  test("shows only the creature footer with no wave asked for", () => {
+    renderLayout();
+    expect(screen.queryByTestId("wave-column")).toBeNull();
+    expect(screen.queryByTestId("wave-wrap")).toBeNull();
+    expect(screen.getByTestId("creature-footer")).toBeTruthy();
+  });
+
+  test("seats `beside` in its own column above the breakpoint", () => {
+    renderLayout("beside");
+    expect(screen.getByTestId("wave-column")).toBeTruthy();
+    expect(screen.queryByTestId("creature-footer")).toBeNull();
+  });
+
+  test("falls `beside` back to the footer on a narrow viewport", () => {
+    mobile = true;
+    renderLayout("beside");
+    expect(screen.queryByTestId("wave-column")).toBeNull();
+    expect(screen.queryByTestId("wave-wrap")).toBeNull();
+    expect(screen.getByTestId("creature-footer")).toBeTruthy();
+  });
+
+  test("gives `around` the same column above the breakpoint", () => {
+    renderLayout("around");
+    expect(screen.getByTestId("wave-column")).toBeTruthy();
+    expect(screen.queryByTestId("wave-wrap")).toBeNull();
+  });
+
+  test("wraps `around` the content on a narrow viewport, in place of the footer", () => {
+    mobile = true;
+    renderLayout("around");
+    expect(screen.getByTestId("wave-wrap")).toBeTruthy();
+    expect(screen.queryByTestId("wave-column")).toBeNull();
+    expect(screen.queryByTestId("creature-footer")).toBeNull();
+  });
+
+  test("keeps the desktop shell on the footer either way", () => {
+    electron = true;
+    for (const placement of ["beside", "around"] as const) {
+      renderLayout(placement);
+      expect(screen.queryByTestId("wave-column")).toBeNull();
+      expect(screen.queryByTestId("wave-wrap")).toBeNull();
+      expect(screen.getByTestId("creature-footer")).toBeTruthy();
+      cleanup();
+    }
+  });
+
+  test("isolates the layout so the wrapped wave can sit behind the content", () => {
+    mobile = true;
+    const { container } = renderLayout("around");
+    // Without a stacking context here the wave's negative z-index would drop
+    // it behind this element's own background and paint nothing at all.
+    expect(container.firstElementChild?.className).toContain("isolate");
+  });
+});

--- a/clients/web/src/components/onboarding-layout.tsx
+++ b/clients/web/src/components/onboarding-layout.tsx
@@ -2,8 +2,9 @@ import { useState, type ReactNode } from "react";
 
 import { PortalContainerProvider } from "@vellumai/design-library/utils/portal-container";
 import { useIsMobile } from "@/hooks/use-is-mobile";
+import { useMediaQuery } from "@/hooks/use-media-query";
 import { isElectron } from "@/runtime/is-electron";
-import { AvatarWave } from "./avatar-wave";
+import { AvatarWave, WRAP_WAVE_MIN_HEIGHT_QUERY } from "./avatar-wave";
 import { CreatureFooter } from "./creature-footer";
 
 /** See {@link OnboardingLayout}'s `avatarWave` prop. */
@@ -75,12 +76,17 @@ export function OnboardingLayout({
   // `hidden md:block` class) keeps the wave's canvas and its animation loop
   // from mounting at all on the layout that would not show them.
   const isMobile = useIsMobile();
+  // A viewport can be narrow enough to have no column to spare and still be
+  // too short to wrap: a phone in landscape, or a small window. See
+  // `WRAP_WAVE_MIN_HEIGHT_QUERY`. Those fall through to the footer.
+  const isTallEnoughToWrap = useMediaQuery(WRAP_WAVE_MIN_HEIGHT_QUERY);
   // The desktop shell runs its own compact, top-aligned onboarding flow in a
   // window that has neither half a screen to give to decoration nor the
   // centred column the wrap composition goes around, so it keeps the footer.
   const electron = isElectron();
   const columnWave = avatarWave !== "none" && !isMobile && !electron;
-  const wrapWave = avatarWave === "around" && isMobile && !electron;
+  const wrapWave =
+    avatarWave === "around" && isMobile && isTallEnoughToWrap && !electron;
 
   const content = (
     <div className="flex-1 overflow-y-auto">

--- a/clients/web/src/components/onboarding-layout.tsx
+++ b/clients/web/src/components/onboarding-layout.tsx
@@ -53,11 +53,19 @@ export function OnboardingLayout({
    * wave around the content instead: a thread arcing over the heading, off
    * the edge, and back in under the buttons as the crowd.
    *
-   * `around` spends the top fifth of a narrow screen on that thread and the
-   * bottom third on the crowd, so it is only for steps whose content is a
-   * short centred column. A step that fills more than what is left over runs
-   * its heading straight through the thread and its last control into the
-   * crowd; those keep `beside`.
+   * `around` asks two things of a step, and a step that fails either keeps
+   * `beside`:
+   *
+   * Its content has to be a short centred column. The thread takes the top
+   * fifth and the crowd comes back in on the right at about 0.59 of the
+   * height, sloping down to 0.85 at the left, so a full-width control below
+   * roughly 0.58 lands in the crowd and a heading above 0.2 lands under the
+   * thread. Narrow centred content can sit lower, since the crowd has not
+   * reached the middle yet.
+   *
+   * Its content also has to be bounded. A step rendering a list it does not
+   * cap has no height to check: it fits until a user with enough assistants
+   * arrives, and then it scrolls its cards through both.
    */
   avatarWave?: AvatarWavePlacement;
   /**

--- a/clients/web/src/components/onboarding-layout.tsx
+++ b/clients/web/src/components/onboarding-layout.tsx
@@ -6,6 +6,9 @@ import { isElectron } from "@/runtime/is-electron";
 import { AvatarWave } from "./avatar-wave";
 import { CreatureFooter } from "./creature-footer";
 
+/** See {@link OnboardingLayout}'s `avatarWave` prop. */
+export type AvatarWavePlacement = "none" | "beside" | "around";
+
 /**
  * Shared chrome for the pre-app screens — the onboarding funnel and the
  * welcome screen both front doors show (`/assistant/welcome` and
@@ -28,7 +31,7 @@ import { CreatureFooter } from "./creature-footer";
 export function OnboardingLayout({
   children,
   showCreatureFooter = true,
-  showAvatarWave = false,
+  avatarWave = "none",
   animateAvatarWaveIn = false,
 }: {
   children: ReactNode;
@@ -39,18 +42,29 @@ export function OnboardingLayout({
    */
   showCreatureFooter?: boolean;
   /**
-   * Whether to seat the content beside the live avatar wave. The wave needs
-   * a column of its own, so it is only offered from the `md` breakpoint up;
-   * narrower viewports keep the single-column layout and the creature footer
-   * rather than surrendering half the screen to decoration.
+   * Where the live avatar wave goes. Either setting stands in for the
+   * creature footer wherever it actually renders.
+   *
+   * `beside` seats it in a column next to the content from the `md`
+   * breakpoint up, and leaves narrower viewports the footer. The wave needs
+   * a column of its own, and surrendering half a phone screen to decoration
+   * is not one. `around` does the same above `md` and, below it, wraps the
+   * wave around the content instead: a thread arcing over the heading, off
+   * the edge, and back in under the buttons as the crowd.
+   *
+   * `around` spends the top fifth of a narrow screen on that thread and the
+   * bottom third on the crowd, so it is only for steps whose content is a
+   * short centred column. A step that fills more than what is left over runs
+   * its heading straight through the thread and its last control into the
+   * crowd; those keep `beside`.
    */
-  showAvatarWave?: boolean;
+  avatarWave?: AvatarWavePlacement;
   /**
    * Ask the wave to play its entrance rather than appear settled. Reserved
    * for the screen a visit starts on: the wave spans a run of screens that
    * each mount their own copy, and pouring it in again at every step reads
-   * as the page restarting. Ignored without `showAvatarWave`, and the wave
-   * itself plays the entrance at most once per session.
+   * as the page restarting. Ignored without a wave, and the wave itself
+   * plays the entrance at most once per session.
    */
   animateAvatarWaveIn?: boolean;
 }) {
@@ -62,9 +76,11 @@ export function OnboardingLayout({
   // from mounting at all on the layout that would not show them.
   const isMobile = useIsMobile();
   // The desktop shell runs its own compact, top-aligned onboarding flow in a
-  // window narrow enough that surrendering half of it to decoration would
-  // crowd the step content.
-  const withWave = showAvatarWave && !isMobile && !isElectron();
+  // window that has neither half a screen to give to decoration nor the
+  // centred column the wrap composition goes around, so it keeps the footer.
+  const electron = isElectron();
+  const columnWave = avatarWave !== "none" && !isMobile && !electron;
+  const wrapWave = avatarWave === "around" && isMobile && !electron;
 
   const content = (
     <div className="flex-1 overflow-y-auto">
@@ -75,8 +91,23 @@ export function OnboardingLayout({
   );
 
   return (
-    <div className="relative flex h-full flex-col bg-[var(--surface-base)]">
-      {withWave ? (
+    // `isolate` is what puts the wrap wave behind the content: without a
+    // stacking context here, its negative z-index would drop it behind this
+    // element's own background and paint nothing at all.
+    <div className="relative isolate flex h-full flex-col bg-[var(--surface-base)]">
+      {wrapWave && (
+        <AvatarWave
+          variant="wrap"
+          entrance={animateAvatarWaveIn}
+          // `fixed`, for the reason `CreatureFooter` is: this layout sits
+          // inside `RootLayout`'s safe-area padding, and an `absolute` wave
+          // would stop short of the physical bottom edge, cutting the crowd
+          // off above a strip of bare surface on iOS. The crowd is authored
+          // to pour off the bottom, so it has to reach one.
+          className="fixed inset-0 -z-10"
+        />
+      )}
+      {columnWave ? (
         <div className="flex min-h-0 flex-1">
           {content}
           <div className="relative w-[46%] lg:w-1/2">
@@ -86,7 +117,7 @@ export function OnboardingLayout({
       ) : (
         content
       )}
-      {showCreatureFooter && !withWave && <CreatureFooter />}
+      {showCreatureFooter && !columnWave && !wrapWave && <CreatureFooter />}
       <div ref={setPortalContainer} />
     </div>
   );

--- a/clients/web/src/components/onboarding-layout.tsx
+++ b/clients/web/src/components/onboarding-layout.tsx
@@ -56,12 +56,16 @@ export function OnboardingLayout({
    * `around` asks two things of a step, and a step that fails either keeps
    * `beside`:
    *
-   * Its content has to be a short centred column. The thread takes the top
-   * fifth and the crowd comes back in on the right at about 0.59 of the
-   * height, sloping down to 0.85 at the left, so a full-width control below
-   * roughly 0.58 lands in the crowd and a heading above 0.2 lands under the
-   * thread. Narrow centred content can sit lower, since the crowd has not
-   * reached the middle yet.
+   * Its content has to clear the wave at the shortest screen the wrap runs
+   * on, which is a 640-tall phone, not a 844-tall one. The step's column is
+   * a fixed stack of controls centred in what the padding leaves it, so it
+   * keeps its height as the screen shrinks and spreads across more of it:
+   * measure there or the check passes on a screen that was never the
+   * problem. The thread takes the top fifth, and the crowd comes back in on
+   * the right at about 0.59 of the height, sloping down to 0.85 at the left,
+   * so a full-width control below roughly 0.58 lands in the crowd and a
+   * heading above 0.2 lands under the thread. Narrow centred content can sit
+   * lower, where the crowd has not reached the middle yet.
    *
    * Its content also has to be bounded. A step rendering a list it does not
    * cap has no height to check: it fits until a user with enough assistants

--- a/clients/web/src/domains/onboarding/pages/api-key-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/api-key-screen.tsx
@@ -92,7 +92,7 @@ export function ApiKeyScreen() {
   };
 
   return (
-    <OnboardingLayout showAvatarWave>
+    <OnboardingLayout avatarWave="beside">
       <div
         className={`mx-auto flex w-full max-w-xl flex-col items-center ${electron ? "min-h-full px-8 pt-21 pb-4 electron-prechat-type" : "px-6 py-16"} text-[var(--content-default)]`}
       >

--- a/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -765,7 +765,7 @@ export function HatchingScreen() {
 
   if (error) {
     return (
-      <OnboardingLayout showAvatarWave>
+      <OnboardingLayout avatarWave="around">
         <div
           role="alert"
           className={`mx-auto flex w-full max-w-xl flex-col items-center ${electron ? "min-h-full px-8 pt-21 pb-28 electron-prechat-type" : "min-h-screen justify-center px-6 pb-40 md:min-h-full md:pb-6"} text-center text-[var(--content-default)]`}
@@ -876,7 +876,7 @@ export function HatchingScreen() {
   }
 
   return (
-    <OnboardingLayout showAvatarWave>
+    <OnboardingLayout avatarWave="around">
       {/* Electron layout: title pinned 84px from the window top (the shared
           step-title position), the creature centered in the leftover space via
           auto margins, and the progress section near the bottom — pb-28 keeps

--- a/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -765,7 +765,7 @@ export function HatchingScreen() {
 
   if (error) {
     return (
-      <OnboardingLayout avatarWave="around">
+      <OnboardingLayout avatarWave="beside">
         <div
           role="alert"
           className={`mx-auto flex w-full max-w-xl flex-col items-center ${electron ? "min-h-full px-8 pt-21 pb-28 electron-prechat-type" : "min-h-screen justify-center px-6 pb-40 md:min-h-full md:pb-6"} text-center text-[var(--content-default)]`}
@@ -876,7 +876,7 @@ export function HatchingScreen() {
   }
 
   return (
-    <OnboardingLayout avatarWave="around">
+    <OnboardingLayout avatarWave="beside">
       {/* Electron layout: title pinned 84px from the window top (the shared
           step-title position), the creature centered in the leftover space via
           auto margins, and the progress section near the bottom — pb-28 keeps

--- a/clients/web/src/domains/onboarding/pages/hosting-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/hosting-screen.tsx
@@ -120,7 +120,7 @@ export function HostingScreen() {
   };
 
   return (
-    <OnboardingLayout avatarWave="around">
+    <OnboardingLayout avatarWave="beside">
       <div
         className={`mx-auto flex w-full max-w-xl flex-col items-center ${electron ? "min-h-full px-8 pt-21 pb-4 electron-prechat-type" : "min-h-screen px-6 pb-40 pt-6 md:min-h-full md:pb-6"} text-[var(--content-default)]`}
       >

--- a/clients/web/src/domains/onboarding/pages/hosting-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/hosting-screen.tsx
@@ -120,7 +120,7 @@ export function HostingScreen() {
   };
 
   return (
-    <OnboardingLayout showAvatarWave>
+    <OnboardingLayout avatarWave="around">
       <div
         className={`mx-auto flex w-full max-w-xl flex-col items-center ${electron ? "min-h-full px-8 pt-21 pb-4 electron-prechat-type" : "min-h-screen px-6 pb-40 pt-6 md:min-h-full md:pb-6"} text-[var(--content-default)]`}
       >

--- a/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
@@ -166,7 +166,7 @@ export function PrivacyScreen() {
   ]);
 
   return (
-    <OnboardingLayout showAvatarWave>
+    <OnboardingLayout avatarWave="beside">
       <div
         className={`mx-auto flex w-full max-w-xl flex-col items-center ${electron ? "min-h-full px-8 pt-21 pb-4 electron-prechat-type" : "px-6 py-16"} text-[var(--content-default)]`}
       >

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
@@ -724,7 +724,7 @@ export function SelectAssistantScreen() {
   }
 
   return (
-    <OnboardingLayout showAvatarWave>
+    <OnboardingLayout avatarWave="around">
       <div
         className={`mx-auto flex w-full max-w-xl flex-col items-center ${electron ? "min-h-full px-8 pt-21 pb-4 electron-prechat-type" : "min-h-screen px-6 pb-40 pt-6 md:min-h-full md:pb-6"} text-[var(--content-default)]`}
       >
@@ -966,7 +966,7 @@ export function SelectAssistantScreen() {
 function ConnectingHold() {
   const { t } = useTranslation("onboarding");
   return (
-    <OnboardingLayout showAvatarWave>
+    <OnboardingLayout avatarWave="around">
       <div className="mx-auto flex min-h-screen w-full max-w-xl flex-col items-center justify-center px-6 text-[var(--content-default)]">
         <p className="text-body-medium-lighter text-[var(--content-tertiary)]">
           {t("selectAssistantScreen.connectingToAssistant")}

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
@@ -724,7 +724,7 @@ export function SelectAssistantScreen() {
   }
 
   return (
-    <OnboardingLayout avatarWave="around">
+    <OnboardingLayout avatarWave="beside">
       <div
         className={`mx-auto flex w-full max-w-xl flex-col items-center ${electron ? "min-h-full px-8 pt-21 pb-4 electron-prechat-type" : "min-h-screen px-6 pb-40 pt-6 md:min-h-full md:pb-6"} text-[var(--content-default)]`}
       >
@@ -966,7 +966,7 @@ export function SelectAssistantScreen() {
 function ConnectingHold() {
   const { t } = useTranslation("onboarding");
   return (
-    <OnboardingLayout avatarWave="around">
+    <OnboardingLayout avatarWave="beside">
       <div className="mx-auto flex min-h-screen w-full max-w-xl flex-col items-center justify-center px-6 text-[var(--content-default)]">
         <p className="text-body-medium-lighter text-[var(--content-tertiary)]">
           {t("selectAssistantScreen.connectingToAssistant")}

--- a/clients/web/src/domains/onboarding/pages/start-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/start-screen.tsx
@@ -26,7 +26,7 @@ export function StartScreen() {
   const navigate = useNavigate();
 
   return (
-    <OnboardingLayout showAvatarWave>
+    <OnboardingLayout avatarWave="around">
       <div className="mx-auto flex min-h-screen w-full max-w-xl flex-col items-center px-6 pb-40 md:min-h-full md:pb-6 text-[var(--content-default)]">
         <div className="flex flex-1 flex-col items-center justify-center">
           <h1

--- a/clients/web/src/utils/avatar-wave-ribbon.test.ts
+++ b/clients/web/src/utils/avatar-wave-ribbon.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from "bun:test";
 import {
   buildRibbonWave,
   mulberry32,
+  resolveRibbon,
+  type RelativeRibbonPoint,
   type RibbonPoint,
 } from "@/utils/avatar-wave-ribbon";
 
@@ -10,6 +12,12 @@ const RIBBON: RibbonPoint[] = [
   { x: 0, y: 0, w: 100, s: 40 },
   { x: 100, y: 200, w: 160, s: 80 },
   { x: 40, y: 400, w: 200, s: 120 },
+];
+
+const RELATIVE: RelativeRibbonPoint[] = [
+  { fx: 0.25, fy: 0.1, fw: 0.2, fs: 0.02 },
+  { fx: 1.2, fy: 0.5, fw: 0.6, fs: 0.06 },
+  { fx: 0.5, fy: 1.1, fw: 1.5, fs: 0.12 },
 ];
 
 describe("mulberry32", () => {
@@ -93,5 +101,46 @@ describe("buildRibbonWave", () => {
     ];
     const items = buildRibbonWave(degenerate, 2);
     expect(items.length).toBeGreaterThan(0);
+  });
+});
+
+describe("resolveRibbon", () => {
+  it("measures x against the width and y against the height", () => {
+    const resolved = resolveRibbon(RELATIVE, 400, 800);
+    const rounded = resolved.map((p) => ({
+      x: Math.round(p.x),
+      y: Math.round(p.y),
+      w: Math.round(p.w),
+      s: Math.round(p.s),
+    }));
+    expect(rounded).toEqual([
+      { x: 100, y: 80, w: 80, s: 16 },
+      { x: 480, y: 400, w: 240, s: 48 },
+      { x: 200, y: 880, w: 600, s: 96 },
+    ]);
+  });
+
+  it("keeps an off-screen point off screen at any aspect ratio", () => {
+    // The wrap ribbon's excursion is the one part of the composition that
+    // must never come back on screen: it is what makes the thread read as
+    // leaving and returning rather than doubling back inside the frame.
+    for (const [w, h] of [
+      [320, 1000],
+      [390, 844],
+      [767, 500],
+    ]) {
+      const resolved = resolveRibbon(RELATIVE, w!, h!);
+      expect(resolved[1]!.x).toBeGreaterThan(w!);
+    }
+  });
+
+  it("spans the box with a ribbon wider than it", () => {
+    const [, , tail] = resolveRibbon(RELATIVE, 390, 844);
+    expect(tail!.x - tail!.w / 2).toBeLessThan(0);
+    expect(tail!.x + tail!.w / 2).toBeGreaterThan(390);
+  });
+
+  it("returns an empty ribbon unchanged", () => {
+    expect(resolveRibbon([], 390, 844)).toEqual([]);
   });
 });

--- a/clients/web/src/utils/avatar-wave-ribbon.test.ts
+++ b/clients/web/src/utils/avatar-wave-ribbon.test.ts
@@ -4,6 +4,7 @@ import {
   buildRibbonWave,
   mulberry32,
   resolveRibbon,
+  ribbonSizingHeight,
   type RelativeRibbonPoint,
   type RibbonPoint,
 } from "@/utils/avatar-wave-ribbon";
@@ -142,5 +143,54 @@ describe("resolveRibbon", () => {
 
   it("returns an empty ribbon unchanged", () => {
     expect(resolveRibbon([], 390, 844)).toEqual([]);
+  });
+
+  it("sizes a wide box's avatars off the held height, not its own", () => {
+    const [head] = resolveRibbon(RELATIVE, 800, 400);
+    // 800 * 1.3 = 1040, so the avatars are sized as if the box were that
+    // tall rather than shrinking to fit 400.
+    expect(head!.s).toBeCloseTo(0.02 * 1040, 5);
+    // Position is untouched: only the size basis is held.
+    expect(head!.y).toBeCloseTo(0.1 * 400, 5);
+  });
+});
+
+describe("ribbonSizingHeight", () => {
+  it("is the box's own height on every portrait phone", () => {
+    for (const [w, h] of [
+      [320, 568],
+      [375, 667],
+      [390, 844],
+      [430, 932],
+    ]) {
+      expect(ribbonSizingHeight(w!, h!)).toBe(h!);
+    }
+  });
+
+  it("holds a box that is wide for its height to its aspect", () => {
+    expect(ribbonSizingHeight(667, 375)).toBeCloseTo(667 * 1.3, 5);
+    expect(ribbonSizingHeight(767, 600)).toBeCloseTo(767 * 1.3, 5);
+  });
+
+  it("keeps the crowd's cost flat across aspect ratios", () => {
+    // Sizing avatars off the raw height packs the same ribbon by area: a box
+    // wide for its height fills it with several times as many, far smaller
+    // avatars, every one of which is simulated and drawn on every frame.
+    // Landscape used to reach ~1,100 against ~140 in portrait.
+    const count = (w: number, h: number) =>
+      buildRibbonWave(
+        resolveRibbon(RELATIVE, w, h),
+        1,
+        ribbonSizingHeight(w, h) * 0.135,
+      ).length;
+    const portrait = count(390, 844);
+    for (const [w, h] of [
+      [667, 375],
+      [767, 400],
+      [767, 600],
+      [720, 750],
+    ]) {
+      expect(count(w!, h!)).toBeLessThan(portrait * 4);
+    }
   });
 });

--- a/clients/web/src/utils/avatar-wave-ribbon.test.ts
+++ b/clients/web/src/utils/avatar-wave-ribbon.test.ts
@@ -173,10 +173,9 @@ describe("ribbonSizingHeight", () => {
   });
 
   it("keeps the crowd's cost flat across aspect ratios", () => {
-    // Sizing avatars off the raw height packs the same ribbon by area: a box
-    // wide for its height fills it with several times as many, far smaller
-    // avatars, every one of which is simulated and drawn on every frame.
-    // Landscape used to reach ~1,100 against ~140 in portrait.
+    // Avatar count goes as the box's area over its size squared, and every
+    // avatar is simulated and drawn on every frame, so a box wide for its
+    // height has to scale its avatars up rather than pack in more of them.
     const count = (w: number, h: number) =>
       buildRibbonWave(
         resolveRibbon(RELATIVE, w, h),

--- a/clients/web/src/utils/avatar-wave-ribbon.ts
+++ b/clients/web/src/utils/avatar-wave-ribbon.ts
@@ -27,6 +27,51 @@ export interface WaveItem {
   rotate: number;
 }
 
+/**
+ * Centerline control point authored relative to the box the ribbon fills,
+ * rather than in a fixed design box scaled to cover it.
+ *
+ * A ribbon that has to hold a composition against the content on top of it
+ * (clearing a heading, returning below a pair of buttons) can't be authored
+ * once and scaled: covering a shorter viewport pushes the head off the top,
+ * and containing a wider one pulls the loop's excursion back on screen, which
+ * is the one part that has to stay off it. Expressing each point against the
+ * box keeps both ends anchored at any aspect ratio.
+ *
+ * The two axes are deliberately measured against different sides. `fx`/`fw`
+ * are widths, so the crowd spans the box and the loop leaves it whichever way
+ * the box is proportioned; `fy`/`fs` are heights, so the avatars keep their
+ * size relative to the run of screen they have to fill.
+ */
+export interface RelativeRibbonPoint {
+  /** Centerline x, as a fraction of the box width. Outside 0–1 is off screen. */
+  fx: number;
+  /** Centerline y, as a fraction of the box height. */
+  fy: number;
+  /** Ribbon width, as a fraction of the box width. */
+  fw: number;
+  /** Avatar size here, as a fraction of the box height. */
+  fs: number;
+}
+
+/**
+ * Resolve a relative ribbon against a box, in pixels. The result feeds
+ * {@link buildRibbonWave} directly, so the placements come back in the same
+ * pixels and need no further scaling.
+ */
+export function resolveRibbon(
+  points: RelativeRibbonPoint[],
+  width: number,
+  height: number,
+): RibbonPoint[] {
+  return points.map((p) => ({
+    x: p.fx * width,
+    y: p.fy * height,
+    w: p.fw * width,
+    s: p.fs * height,
+  }));
+}
+
 /** mulberry32 — small deterministic PRNG for layout jitter. */
 export function mulberry32(seed: number): () => number {
   let state = seed;

--- a/clients/web/src/utils/avatar-wave-ribbon.ts
+++ b/clients/web/src/utils/avatar-wave-ribbon.ts
@@ -44,14 +44,39 @@ export interface WaveItem {
  * size relative to the run of screen they have to fill.
  */
 export interface RelativeRibbonPoint {
-  /** Centerline x, as a fraction of the box width. Outside 0–1 is off screen. */
+  /** Centerline x, as a fraction of the box width. Outside 0-1 is off screen. */
   fx: number;
   /** Centerline y, as a fraction of the box height. */
   fy: number;
   /** Ribbon width, as a fraction of the box width. */
   fw: number;
-  /** Avatar size here, as a fraction of the box height. */
+  /** Avatar size here, as a fraction of {@link ribbonSizingHeight}. */
   fs: number;
+}
+
+/**
+ * Least ratio of height to width a relative ribbon will size its avatars
+ * against. Portrait phones run from about 1.7 to 2.2, so this only bites on
+ * a box far wider than the composition was authored for.
+ */
+const MIN_SIZE_ASPECT = 1.3;
+
+/**
+ * The height a relative ribbon sizes its avatars against, which is the box's
+ * own height until the box gets wide for its height.
+ *
+ * Size follows the height because that is the axis the composition is
+ * authored against, but a row holds `w / s` avatars and `w` follows the
+ * width, so the count in one row goes as width over height and the number of
+ * rows goes as height over size. Together the whole crowd grows with the
+ * box's area over its size squared: hand the same ribbon a box twice as wide
+ * for its height and it packs several times the avatars, each one smaller,
+ * and every one of them is simulated and drawn again on every frame. Holding
+ * the sizing height to the box's aspect scales a wide box's avatars up
+ * instead of multiplying them, which keeps the crowd's cost flat.
+ */
+export function ribbonSizingHeight(width: number, height: number): number {
+  return Math.max(height, width * MIN_SIZE_ASPECT);
 }
 
 /**
@@ -64,11 +89,12 @@ export function resolveRibbon(
   width: number,
   height: number,
 ): RibbonPoint[] {
+  const sizingHeight = ribbonSizingHeight(width, height);
   return points.map((p) => ({
     x: p.fx * width,
     y: p.fy * height,
     w: p.fw * width,
-    s: p.fs * height,
+    s: p.fs * sizingHeight,
   }));
 }
 


### PR DESCRIPTION
## What

On a narrow viewport the avatar wave had no column to spare, so it fell back to the flat `login-background-characters.svg` strip and the welcome screen sat in a lot of empty space. This gives phones the same live crowd in a composition that fits the screen instead of a column: a thread of small characters arcs over the heading, turns down past its outer edge, leaves the screen, and comes back in below the buttons as the crowd that fills the rest.

**The desktop layout is untouched.** Both wave settings behave identically from the `md` breakpoint up; they differ only in what a phone gets.

## Why the wrap ribbon is authored differently

The column ribbon lives in a fixed 620x900 design box that gets cover-scaled into its panel. That cannot work here, and the failure is two-sided: covering a shorter phone pushes the arc off the top, while containing a wider one pulls the off-screen loop back into frame, and that excursion is the one part of the composition that has to stay out of frame.

So `resolveRibbon()` measures the two axes against different sides of the box. `fx`/`fw` go against the width, so the crowd spans the screen and the loop leaves it whichever way the screen is proportioned; `fy`/`fs` go against the height, so the avatars keep their size relative to the run of screen they fill.

That governs where things sit, but not how many there are, and the two come apart. A row holds `w / s` avatars and `w` follows the width, so the crowd grows with the box's area over its size squared: a box wide for its height packs the same ribbon several times over, each avatar smaller, and `AvatarWave` simulates and draws every one of them per frame. A phone in landscape at 667x375 reached ~1,100 placements against 139 at 390x844. `ribbonSizingHeight()` holds the height that sizing reads to the box's aspect (min 1.3), so a wide box scales its avatars up instead of multiplying them. The cap on avatar size reads that same held height, since taking it off the raw height would clip the scaled-up avatars back down and undo the fix on exactly the boxes it exists for. Peak count across 320-767 x 320-1024 drops from 1,886 to 353, and every portrait phone aspect is untouched (phones run 1.7 to 2.2).

## Which screens get it

`OnboardingLayout`'s `showAvatarWave` boolean becomes `avatarWave: "none" | "beside" | "around"`.

`around` asks two things of a step. Its content must be a short centred column: the thread takes the top fifth, and the crowd re-enters on the right at 0.59 of the height sloping down to 0.85 at the left, so a full-width control below ~0.58 lands in the crowd. Its content must also be **bounded**, since a step rendering an uncapped list has no height to check.

| Screen | Placement | Why |
| --- | --- | --- |
| `/account/login`, `/assistant/welcome` | `around` | clears the edge at 360x640 and up |
| start | `around` | fixed content, clears the edge at 360x640 |
| hosting | `beside` | arc crosses the heading at 360x640 |
| hatching | `beside` | full-width progress bar at ~0.605, inside the crowd |
| select-assistant | `beside` | `visibleAssistants` / `originEntries` uncapped |
| privacy, api-key | `beside` | always taller than the composition leaves |

A viewport can also be narrow enough to have no column and still too short to wrap. Below `(min-height: 600px)` the wrap falls through to the footer: a landscape phone has nowhere to put content between the thread and the crowd whatever its density. The Electron shell keeps the footer on every step, unchanged.

## Notes

- The wrap wave is `fixed inset-0 -z-10` for the same reason `CreatureFooter` is `fixed`: the layout sits inside `RootLayout`'s safe-area padding, and an `absolute` wave would stop short of the physical bottom edge, cutting the crowd off above a strip of bare surface on iOS. `isolate` on the layout root is what lets the negative z-index land behind the content instead of behind the root's own background.
- The native iOS login path renders `NativeSplash` (wordmark + static strip), a separate surface, and is untouched.

## Testing

Rendered against a dev server at **375x667, 390x844, 430x932, 667x375 landscape and 1280x900**. The desktop column composition is identical to before; landscape falls back to the footer; the rejected screens were each checked with the wave on before being put back on it.

- `bunx tsc --noEmit`, `bun run lint` (0 errors), `bun run build` all clean
- `onboarding-layout.test.tsx` covers the three-way placement rule, the min-height gate, and the Electron fallback
- `avatar-wave-ribbon.test.ts` covers `ribbonSizingHeight`, the off-screen excursion at three aspect ratios, and a density bound as a regression guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)