### PR TITLE
feat(web): confirm saved cards synchronously in billing

### DIFF
--- a/clients/web/openapi-schemas/platform.yaml
+++ b/clients/web/openapi-schemas/platform.yaml
@@ -4272,6 +4272,58 @@ paths:
           description: ''
       x-vellum-api-clients:
       - platform
+  /v1/organizations/billing/auto-top-up/confirm-setup-intent/:
+    post:
+      operationId: organizations_billing_auto_top_up_confirm_setup_intent_create
+      description: |-
+        Persist the payment method from a just-confirmed SetupIntent.
+
+        Call this immediately after Stripe's client-side ``confirmSetup``
+        resolves so the saved card is readable on the very next GET, instead of
+        waiting on the ``setup_intent.succeeded`` webhook. The webhook remains
+        the durable fallback; whichever lands second is a no-op.
+
+        Returns the same payload as ``GET .../auto-top-up/``.
+
+        The caller's id is never trusted on its own: the SetupIntent is re-read
+        from Stripe and must be tagged ``metadata.auto_top_up=true``, carry this
+        org's ``metadata.organization_id``, sit on this org's Stripe customer,
+        and be ``succeeded`` with a payment method attached.
+      parameters:
+      - in: header
+        name: Vellum-Organization-Id
+        schema:
+          type: string
+          format: uuid
+        description: Required if using Cookie-based or X-Session-Token authentication
+          methods.
+      tags:
+      - organizations
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AutoTopUpConfirmSetupIntentRequestRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/AutoTopUpConfirmSetupIntentRequestRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/AutoTopUpConfirmSetupIntentRequestRequest'
+        required: true
+      security:
+      - VellumAPIKey: []
+      - cookieAuth: []
+      - XSessionTokenAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AutoTopUpConfigResponse'
+          description: ''
+      x-vellum-api-clients:
+      - platform
   /v1/organizations/billing/auto-top-up/disable/:
     post:
       operationId: organizations_billing_auto_top_up_disable_create
@@ -6478,6 +6530,18 @@ components:
       - stripe_payment_method_updated_at
       - stubbed
       - threshold_usd
+    AutoTopUpConfirmSetupIntentRequestRequest:
+      type: object
+      description: POST /…/auto-top-up/confirm-setup-intent/ request body.
+      properties:
+        setup_intent_id:
+          type: string
+          minLength: 1
+          description: Stripe SetupIntent id returned by the client-side confirmSetup
+            call.
+          maxLength: 255
+      required:
+      - setup_intent_id
     AutoTopUpDisableResponse:
       type: object
       properties:

--- a/clients/web/src/domains/settings/components/auto-top-up-card.tsx
+++ b/clients/web/src/domains/settings/components/auto-top-up-card.tsx
@@ -25,7 +25,7 @@ import {
   type AutoTopUpFormValues,
 } from "@/domains/settings/components/auto-top-up-form";
 import { AutoTopUpPaymentMethodModal } from "@/domains/settings/components/auto-top-up-payment-method-modal";
-import { usePaymentMethodSavedPoll } from "@/domains/settings/hooks/use-payment-method-saved-poll";
+import { usePaymentMethodSavedSync } from "@/domains/settings/hooks/use-payment-method-saved-poll";
 import { extractDrfFieldErrors } from "@/domains/settings/utils/drf-errors";
 import { useTranslation } from "@/i18n";
 
@@ -116,7 +116,7 @@ export function AutoTopUpCard() {
   const disableMutation = useMutation(
     organizationsBillingAutoTopUpDisableCreateMutation(),
   );
-  const pollPaymentMethodSaved = usePaymentMethodSavedPoll();
+  const syncPaymentMethodSaved = usePaymentMethodSavedSync();
 
   const [searchParams, setSearchParams] = useSearchParams();
   const cardRef = useRef<HTMLDivElement>(null);
@@ -430,11 +430,13 @@ export function AutoTopUpCard() {
 
   /**
    * Called after `AutoTopUpPaymentMethodModal` confirms a card was saved.
-   * Once the poll confirms the PM is fresh, drop the no-PM gate and, if the
+   * Once the config reflects the fresh PM, drop the no-PM gate and, if the
    * user got here via the toggle, advance straight into the configure form.
+   * The gate effect above may already have run off the seeded cache; both
+   * paths land on the same state.
    */
-  const handlePmSaved = async () => {
-    await pollPaymentMethodSaved();
+  const handlePmSaved = async (args: { setupIntentId: string | null }) => {
+    await syncPaymentMethodSaved(args);
     setShowAddPm(false);
     if (pendingEnable) {
       enterFormMode();

--- a/clients/web/src/domains/settings/components/auto-top-up-payment-method-modal.test.tsx
+++ b/clients/web/src/domains/settings/components/auto-top-up-payment-method-modal.test.tsx
@@ -104,7 +104,11 @@ afterAll(() => {
 // ---------------------------------------------------------------------------
 
 /** Wait for the SetupIntent mutation to resolve and the card form to mount. */
-async function renderModalWithForm(): Promise<ReturnType<typeof render>> {
+async function renderModalWithForm(
+  onSavedOptimistic: (args: {
+    setupIntentId: string | null;
+  }) => void = () => {},
+): Promise<ReturnType<typeof render>> {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
@@ -113,7 +117,7 @@ async function renderModalWithForm(): Promise<ReturnType<typeof render>> {
       <AutoTopUpPaymentMethodModal
         open
         onClose={() => {}}
-        onSavedOptimistic={() => {}}
+        onSavedOptimistic={onSavedOptimistic}
       />
     </QueryClientProvider>,
   );
@@ -211,5 +215,26 @@ describe("AutoTopUpPaymentMethodModal billing address", () => {
     expect(
       (call.confirmParams as Record<string, unknown>).payment_method_data,
     ).toBeUndefined();
+  });
+
+  test("reports the SetupIntent id derived from the client secret on save", async () => {
+    const savedArgs: Array<{ setupIntentId: string | null }> = [];
+    const { getByTestId } = await renderModalWithForm((args) => {
+      savedArgs.push(args);
+    });
+    fireOnReady(paymentElementProps);
+    fireOnReady(addressElementProps);
+
+    fireEvent.submit(
+      getByTestId("auto-top-up-pm-save-button").closest("form")!,
+    );
+
+    await waitFor(() => {
+      if (savedArgs.length === 0) {
+        throw new Error("onSavedOptimistic not called");
+      }
+    });
+    // The mocked client_secret is `seti_123_secret_456`.
+    expect(savedArgs[0]).toEqual({ setupIntentId: "seti_123" });
   });
 });

--- a/clients/web/src/domains/settings/components/auto-top-up-payment-method-modal.tsx
+++ b/clients/web/src/domains/settings/components/auto-top-up-payment-method-modal.tsx
@@ -42,15 +42,35 @@ export interface AutoTopUpPaymentMethodModalProps {
   open: boolean;
   onClose: () => void;
   /**
-   * Called after `confirmSetup` succeeds. Owners use this to invalidate the
-   * auto-top-up config query so the saved-PM line and `has_payment_method`
-   * gate reflect the new card immediately.
+   * Called after `confirmSetup` succeeds, carrying the id of the SetupIntent
+   * that was just confirmed (null when it cannot be derived). Owners use this
+   * to refresh the auto-top-up config so the saved-PM line and
+   * `has_payment_method` gate reflect the new card immediately.
    *
    * May return a Promise; the modal awaits it before calling `onClose()` so
    * the parent re-renders against fresh data instead of briefly showing
    * stale payment-method copy after a successful save.
    */
-  onSavedOptimistic: () => void | Promise<void>;
+  onSavedOptimistic: (args: {
+    setupIntentId: string | null;
+  }) => void | Promise<void>;
+}
+
+/**
+ * A SetupIntent client secret is `<setup intent id>_secret_<random>`, so the
+ * id is everything before the `_secret` marker.
+ */
+function setupIntentIdFromClientSecret(
+  clientSecret: string | null,
+): string | null {
+  if (!clientSecret) {
+    return null;
+  }
+  const marker = clientSecret.indexOf("_secret");
+  if (marker <= 0) {
+    return null;
+  }
+  return clientSecret.slice(0, marker);
 }
 
 /**
@@ -74,7 +94,7 @@ export interface AutoTopUpPaymentMethodModalProps {
  *     in-page when the PM doesn't need 3DS, and otherwise redirects to
  *     `window.location.href` (so the user lands back on the current
  *     settings page).
- *  5. On success, toast + `onSavedOptimistic()` + `onClose()`.
+ *  5. On success, toast + `onSavedOptimistic({ setupIntentId })` + `onClose()`.
  */
 export function AutoTopUpPaymentMethodModal({
   open,
@@ -167,7 +187,9 @@ export function AutoTopUpPaymentMethodModal({
                   // the next render reads fresh auto-top-up data. Without
                   // the await, `onClose()` fires immediately and the user
                   // briefly sees stale PM copy.
-                  await onSavedOptimistic();
+                  await onSavedOptimistic({
+                    setupIntentId: setupIntentIdFromClientSecret(clientSecret),
+                  });
                   onClose();
                 }}
                 onCancel={onClose}

--- a/clients/web/src/domains/settings/components/auto-top-up-payment-method-modal.tsx
+++ b/clients/web/src/domains/settings/components/auto-top-up-payment-method-modal.tsx
@@ -94,7 +94,8 @@ function setupIntentIdFromClientSecret(
  *     in-page when the PM doesn't need 3DS, and otherwise redirects to
  *     `window.location.href` (so the user lands back on the current
  *     settings page).
- *  5. On success, toast + `onSavedOptimistic({ setupIntentId })` + `onClose()`.
+ *  5. On success, `onSavedOptimistic({ setupIntentId })`, then toast +
+ *     `onClose()` once the saved card has settled.
  */
 export function AutoTopUpPaymentMethodModal({
   open,
@@ -182,14 +183,14 @@ export function AutoTopUpPaymentMethodModal({
             >
               <SetupCardForm
                 onSuccess={async () => {
-                  toast.success("Payment method saved.");
-                  // Await the parent's optimistic refetch before closing so
-                  // the next render reads fresh auto-top-up data. Without
-                  // the await, `onClose()` fires immediately and the user
-                  // briefly sees stale PM copy.
+                  // Await the parent's follow-up before toasting or closing:
+                  // the toast must not claim success while the saved card is
+                  // still settling, and closing early would briefly show
+                  // stale PM copy.
                   await onSavedOptimistic({
                     setupIntentId: setupIntentIdFromClientSecret(clientSecret),
                   });
+                  toast.success("Payment method saved.");
                   onClose();
                 }}
                 onCancel={onClose}

--- a/clients/web/src/domains/settings/components/payment-methods-card.tsx
+++ b/clients/web/src/domains/settings/components/payment-methods-card.tsx
@@ -16,7 +16,7 @@ import { Notice } from "@vellumai/design-library/components/notice";
 import { AutoTopUpPaymentMethodModal } from "@/domains/settings/components/auto-top-up-payment-method-modal";
 import { BillingSectionHeader } from "@/domains/settings/components/billing-section-header";
 import { PaymentMethodRow } from "@/domains/settings/components/payment-method-row";
-import { usePaymentMethodSavedPoll } from "@/domains/settings/hooks/use-payment-method-saved-poll";
+import { usePaymentMethodSavedSync } from "@/domains/settings/hooks/use-payment-method-saved-poll";
 import { useTranslation } from "@/i18n";
 
 /**
@@ -31,7 +31,7 @@ export function PaymentMethodsCard() {
   const removeMutation = useMutation(
     organizationsBillingAutoTopUpRemovePaymentMethodCreateMutation(),
   );
-  const pollPaymentMethodSaved = usePaymentMethodSavedPoll();
+  const syncPaymentMethodSaved = usePaymentMethodSavedSync();
 
   const [pmModalOpen, setPmModalOpen] = useState(false);
   const [confirmingRemove, setConfirmingRemove] = useState(false);
@@ -163,7 +163,7 @@ export function PaymentMethodsCard() {
       <AutoTopUpPaymentMethodModal
         open={pmModalOpen}
         onClose={() => setPmModalOpen(false)}
-        onSavedOptimistic={pollPaymentMethodSaved}
+        onSavedOptimistic={syncPaymentMethodSaved}
       />
     </Card>
   );

--- a/clients/web/src/domains/settings/hooks/use-payment-method-saved-poll.test.tsx
+++ b/clients/web/src/domains/settings/hooks/use-payment-method-saved-poll.test.tsx
@@ -1,9 +1,15 @@
 /**
- * Tests for usePaymentMethodSavedPoll: the returned callback resolves as soon
- * as the refetched config reports a payment method whose
+ * Tests for the payment-method-saved follow-ups.
+ *
+ * usePaymentMethodSavedPoll: the returned callback resolves as soon as the
+ * refetched config reports a payment method whose
  * `stripe_payment_method_updated_at` advanced past the pre-call cache value,
  * and keeps polling while the marker is unchanged (webhook not landed yet).
  * The 20s timeout path is not exercised here; it would need real time.
+ *
+ * usePaymentMethodSavedSync: confirms the SetupIntent server-side and seeds
+ * the config cache from the response, falling back to the poll when the
+ * confirm call fails or no SetupIntent id was derivable.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -16,6 +22,9 @@ import type { AutoTopUpConfigResponse } from "@/generated/api/types.gen";
 
 let retrieveResponses: AutoTopUpConfigResponse[] = [];
 let retrieveCalls = 0;
+let confirmCalls: Array<Record<string, unknown>> = [];
+let confirmResponse: AutoTopUpConfigResponse | null = null;
+let confirmShouldFail = false;
 
 mock.module("@/generated/api/sdk.gen", () => ({
   ...sdkGen,
@@ -25,13 +34,21 @@ mock.module("@/generated/api/sdk.gen", () => ({
     retrieveCalls += 1;
     return Promise.resolve({ data: next, response: { ok: true } });
   },
+  organizationsBillingAutoTopUpConfirmSetupIntentCreate: (
+    opts: Record<string, unknown>,
+  ) => {
+    confirmCalls.push(opts);
+    if (confirmShouldFail) {
+      return Promise.reject(new Error("confirm failed"));
+    }
+    return Promise.resolve({ data: confirmResponse, response: { ok: true } });
+  },
 }));
 
 import { organizationsBillingAutoTopUpRetrieveQueryKey } from "@/generated/api/@tanstack/react-query.gen";
 
-const { usePaymentMethodSavedPoll } = await import(
-  "./use-payment-method-saved-poll"
-);
+const { usePaymentMethodSavedPoll, usePaymentMethodSavedSync } =
+  await import("./use-payment-method-saved-poll");
 const { DISABLED_CONFIG } = await import("../components/auto-top-up-card");
 
 function makeConfig(
@@ -45,20 +62,44 @@ function makeConfig(
   };
 }
 
-function setup(cached: AutoTopUpConfigResponse) {
+function makeClient(cached: AutoTopUpConfigResponse): QueryClient {
   const client = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
   });
   client.setQueryData(organizationsBillingAutoTopUpRetrieveQueryKey(), cached);
-  const wrapper = ({ children }: { children: ReactNode }) => (
+  return client;
+}
+
+function makeWrapper(client: QueryClient) {
+  return ({ children }: { children: ReactNode }) => (
     <QueryClientProvider client={client}>{children}</QueryClientProvider>
   );
-  return renderHook(() => usePaymentMethodSavedPoll(), { wrapper });
+}
+
+function setup(cached: AutoTopUpConfigResponse) {
+  const client = makeClient(cached);
+  return renderHook(() => usePaymentMethodSavedPoll(), {
+    wrapper: makeWrapper(client),
+  });
+}
+
+function setupSync(cached: AutoTopUpConfigResponse) {
+  const client = makeClient(cached);
+  const rendered = renderHook(() => usePaymentMethodSavedSync(), {
+    wrapper: makeWrapper(client),
+  });
+  return { ...rendered, client };
 }
 
 beforeEach(() => {
   retrieveResponses = [];
   retrieveCalls = 0;
+  confirmCalls = [];
+  confirmResponse = null;
+  confirmShouldFail = false;
 });
 
 describe("usePaymentMethodSavedPoll", () => {
@@ -91,6 +132,52 @@ describe("usePaymentMethodSavedPoll", () => {
 
     await result.current();
 
+    expect(retrieveCalls).toBe(1);
+  });
+});
+
+describe("usePaymentMethodSavedSync", () => {
+  test("seeds the config cache from the confirm response without polling", async () => {
+    const confirmed = {
+      ...makeConfig("2026-08-19T00:00:01Z", true),
+      payment_method_brand: "visa",
+      payment_method_last4: "4242",
+    };
+    confirmResponse = confirmed;
+    const { result, client } = setupSync(makeConfig(null, false));
+
+    await result.current({ setupIntentId: "seti_abc" });
+
+    expect(confirmCalls.length).toBe(1);
+    expect(
+      (confirmCalls[0] as { body: { setup_intent_id: string } }).body,
+    ).toEqual({ setup_intent_id: "seti_abc" });
+    expect(retrieveCalls).toBe(0);
+    expect(
+      client.getQueryData<AutoTopUpConfigResponse>(
+        organizationsBillingAutoTopUpRetrieveQueryKey(),
+      ),
+    ).toEqual(confirmed);
+  });
+
+  test("falls back to the poll when the confirm call fails", async () => {
+    confirmShouldFail = true;
+    retrieveResponses = [makeConfig("2026-08-19T00:00:01Z", true)];
+    const { result } = setupSync(makeConfig("2026-08-19T00:00:00Z", true));
+
+    await result.current({ setupIntentId: "seti_abc" });
+
+    expect(confirmCalls.length).toBe(1);
+    expect(retrieveCalls).toBe(1);
+  });
+
+  test("polls without confirming when no SetupIntent id was derivable", async () => {
+    retrieveResponses = [makeConfig("2026-08-19T00:00:01Z", true)];
+    const { result } = setupSync(makeConfig("2026-08-19T00:00:00Z", true));
+
+    await result.current({ setupIntentId: null });
+
+    expect(confirmCalls.length).toBe(0);
     expect(retrieveCalls).toBe(1);
   });
 });

--- a/clients/web/src/domains/settings/hooks/use-payment-method-saved-poll.ts
+++ b/clients/web/src/domains/settings/hooks/use-payment-method-saved-poll.ts
@@ -67,9 +67,9 @@ export function usePaymentMethodSavedPoll(): () => Promise<void> {
  * last4 filled in, so seeding the cache from it makes the saved card visible
  * without waiting on the `setup_intent.succeeded` webhook.
  *
- * The poll stays as the fallback: servers that predate the endpoint (older
- * self-hosted deployments) reject the call, and a transient failure still
- * leaves the webhook as the durable writer.
+ * The poll stays as the fallback: when the confirm call fails for any reason
+ * (the endpoint is unavailable on this server, or the request errors), the
+ * webhook remains the durable writer and the poll waits for its write.
  */
 export function usePaymentMethodSavedSync(): (args: {
   setupIntentId: string | null;

--- a/clients/web/src/domains/settings/hooks/use-payment-method-saved-poll.ts
+++ b/clients/web/src/domains/settings/hooks/use-payment-method-saved-poll.ts
@@ -1,8 +1,10 @@
-import { useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import {
+  organizationsBillingAutoTopUpConfirmSetupIntentCreateMutation,
   organizationsBillingAutoTopUpRetrieveOptions,
   organizationsBillingAutoTopUpRetrieveQueryKey,
+  organizationsBillingAutoTopUpRetrieveSetQueryData,
 } from "@/generated/api/@tanstack/react-query.gen";
 import type { AutoTopUpConfigResponse } from "@/generated/api/types.gen";
 
@@ -56,5 +58,44 @@ export function usePaymentMethodSavedPoll(): () => Promise<void> {
         setTimeout(resolve, PM_SAVED_POLL_INTERVAL_MS),
       );
     }
+  };
+}
+
+/**
+ * Confirm-first version of the follow-up above. The confirm endpoint persists
+ * the card and returns the same payload as the config GET, with brand and
+ * last4 filled in, so seeding the cache from it makes the saved card visible
+ * without waiting on the `setup_intent.succeeded` webhook.
+ *
+ * The poll stays as the fallback: servers that predate the endpoint (older
+ * self-hosted deployments) reject the call, and a transient failure still
+ * leaves the webhook as the durable writer.
+ */
+export function usePaymentMethodSavedSync(): (args: {
+  setupIntentId: string | null;
+}) => Promise<void> {
+  const queryClient = useQueryClient();
+  const pollPaymentMethodSaved = usePaymentMethodSavedPoll();
+  const { mutateAsync: confirmSetupIntent } = useMutation(
+    organizationsBillingAutoTopUpConfirmSetupIntentCreateMutation(),
+  );
+
+  return async ({ setupIntentId }) => {
+    if (setupIntentId != null) {
+      try {
+        const config = await confirmSetupIntent({
+          body: { setup_intent_id: setupIntentId },
+        });
+        organizationsBillingAutoTopUpRetrieveSetQueryData(
+          queryClient,
+          undefined,
+          config,
+        );
+        return;
+      } catch {
+        // fall through to the poll below
+      }
+    }
+    await pollPaymentMethodSaved();
   };
 }


### PR DESCRIPTION
## Summary

Saving a card in Settings > Billing only became visible once Stripe's `setup_intent.succeeded` webhook landed server-side. Until then the client polled the auto-top-up config GET every 1.5s for up to 20s (`usePaymentMethodSavedPoll`), so a freshly saved card took seconds to show up in the Payment Methods section and to release the auto-reload no-card gate.

This wires the client to the new synchronous confirm endpoint. Right after Stripe's `confirmSetup` resolves, the client posts the SetupIntent id to `POST /v1/organizations/billing/auto-top-up/confirm-setup-intent/`, which persists the card and returns the same payload as the config GET with `payment_method_brand` / `payment_method_last4` filled in. That response seeds the config query cache directly, so no poll and no follow-up refetch are needed.

The poll stays as the fallback. Any confirm failure (older server without the endpoint, validation error, Stripe outage) or an underivable SetupIntent id falls through to the existing 20s poll, where the webhook remains the durable writer.

## Changes

- `openapi-schemas/platform.yaml`: grafted the new path object and the `AutoTopUpConfirmSetupIntentRequestRequest` schema (the response reuses the existing `AutoTopUpConfigResponse`).
- `auto-top-up-payment-method-modal.tsx`: `onSavedOptimistic` now takes `{ setupIntentId }`. The id is derived from the SetupIntent client secret the modal already holds (everything before the `_secret` marker), null when underivable.
- `use-payment-method-saved-poll.ts`: new `usePaymentMethodSavedSync()` confirms first and seeds the cache via `organizationsBillingAutoTopUpRetrieveSetQueryData`, reusing `usePaymentMethodSavedPoll()` internally as the fallback. The poll hook is unchanged and still exported.
- `payment-methods-card.tsx` / `auto-top-up-card.tsx`: both consumers now pass the sync callback. In `AutoTopUpCard` the existing PM-appears gate effect may fire first off the seeded cache; that path is idempotent with `handlePmSaved`.

No new user-facing copy and no visual changes.

## Testing

- `bun test src/domains/settings/hooks/use-payment-method-saved-poll.test.tsx` (6 pass) covers confirm success seeding the cache with zero poll retrieves, confirm failure falling back to the poll, and a null SetupIntent id skipping confirm entirely.
- `bun test src/domains/settings/components/auto-top-up-payment-method-modal.test.tsx` (5 pass) adds an assertion that the derived id reaches `onSavedOptimistic`.
- `bun test src/domains/settings/components/payment-methods-card.test.tsx` (7 pass), `bun test src/domains/settings/components/auto-top-up-card.test.tsx` (19 pass).
- `bunx tsc --noEmit` clean; `bun run lint` 0 errors (17 pre-existing warnings elsewhere).

## Rollout

Platform PR vellum-ai/vellum-assistant-platform#9944 must merge and deploy first. Until then (and against older self-hosted servers) the confirm call fails and the client falls back to the existing 20s poll, so nothing breaks. Spec grafted from that PR's head (dbb9b16); re-sync specs after it merges if drift matters.

Stacked under #40935.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
