### PR TITLE
fix(web): stop giving `transcribing` a label of its own

### DIFF
--- a/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/voice-composer-bar.test.tsx
@@ -96,7 +96,8 @@ describe("VoiceComposerBar: state announcement", () => {
   const labels: Array<[LiveVoiceSessionState, string]> = [
     ["connecting", "Connecting…"],
     ["listening", "Listening…"],
-    ["transcribing", "Transcribing…"],
+    // Shares `thinking`'s wording on purpose (JARVIS-1559).
+    ["transcribing", "Thinking…"],
     ["thinking", "Thinking…"],
     ["speaking", "Speaking…"],
     ["ending", "Ending…"],

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.test.ts
@@ -16,6 +16,7 @@ import {
   isLiveVoiceMicLive,
   isLiveVoiceSessionActive,
   isLiveVoiceSessionOwnedBy,
+  LIVE_VOICE_STATE_LABELS,
   liveVoiceStateLabel,
   liveVoiceSurfaceLabel,
   minimizeVoiceRoom,
@@ -28,6 +29,7 @@ import {
   useLiveVoiceStore,
   type LiveVoiceSessionState,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
+import { toVoiceAvatarVisual } from "@/domains/chat/voice/voice-room/voice-avatar-state";
 
 beforeEach(() => {
   useLiveVoiceStore.getState().reset();
@@ -220,6 +222,27 @@ describe("liveVoiceStateLabel", () => {
   });
 });
 
+describe("LIVE_VOICE_STATE_LABELS", () => {
+  /**
+   * `toVoiceAvatarVisual` collapses `transcribing` into `thinking`, so a label
+   * of its own put two different words for one phase on screen at once: the
+   * avatar and eyes caption reading thinking, the label reading transcribing.
+   */
+  test("gives transcribing no wording of its own", () => {
+    expect(LIVE_VOICE_STATE_LABELS.transcribing).toBe(
+      LIVE_VOICE_STATE_LABELS.thinking,
+    );
+  });
+
+  /** The collapse is the label's, not the phase's: the state still exists. */
+  test("keeps transcribing a distinct session state", () => {
+    expect(toVoiceAvatarVisual("transcribing", false)).toBe(
+      toVoiceAvatarVisual("thinking", false),
+    );
+    expect(liveVoiceStateLabel("transcribing", false)).toBe("Thinking…");
+  });
+});
+
 describe("liveVoiceSurfaceLabel", () => {
   test("a speaking phase with no audio playing reads as thinking", () => {
     // `speaking` stays set across a mid-turn tool run (the ack was spoken and
@@ -270,7 +293,7 @@ describe("liveVoiceSurfaceLabel", () => {
       "Speaking…",
     );
     expect(liveVoiceSurfaceLabel("transcribing", false, false, true)).toBe(
-      "Transcribing…",
+      "Thinking…",
     );
   });
 

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
@@ -38,7 +38,10 @@ import { createSelectors } from "@/utils/create-selectors";
  * - `idle` — no session (or a finished one cleaned up).
  * - `connecting` — minting a token / opening the socket, before `ready`.
  * - `listening` — mic is capturing and streaming PCM to the server.
- * - `transcribing` — push-to-talk released; waiting on the final transcript.
+ * - `transcribing` — the user's utterance closed; waiting on the final
+ *   transcript. Set by server VAD's `utterance_end` in hands-free and by the
+ *   turn-boundary `ptt_release` frame in manual mode. Carries no wording of its
+ *   own; see {@link LIVE_VOICE_STATE_LABELS}.
  * - `thinking` — server is generating the assistant response.
  * - `speaking` — TTS audio is queued/playing.
  * - `ending` — graceful teardown in progress.
@@ -63,12 +66,26 @@ export type LiveVoiceSessionState =
  * streams into the thread transcript like text chat, so surfaces only carry a
  * small label. `idle`/`failed` map to an empty label — hosts unmount their
  * voice UI in those states.
+ *
+ * `transcribing` deliberately shares `thinking`'s wording rather than having
+ * its own (JARVIS-1559). {@link toVoiceAvatarVisual} already collapses the two,
+ * so a distinct label left the avatar animating thinking and the eyes caption
+ * reading "Thinking" while the label beside them said "Transcribing…", for a
+ * window that is usually under a second and that offers the user nothing to do
+ * with the distinction. Mapped here rather than in {@link liveVoiceSurfaceLabel}
+ * so the phase has no wording of its own on any surface: the session pill and
+ * the composer's voice bar read this table directly and would otherwise keep
+ * the split alive.
+ *
+ * The phase itself stays. It stamps end-of-speech latency and gates the
+ * `utterance_discarded` return to `listening`, so collapsing the *state* would
+ * break both.
  */
 export const LIVE_VOICE_STATE_LABELS: Record<LiveVoiceSessionState, string> = {
   idle: "",
   connecting: "Connecting…",
   listening: "Listening…",
-  transcribing: "Transcribing…",
+  transcribing: "Thinking…",
   thinking: "Thinking…",
   speaking: "Speaking…",
   ending: "Ending…",

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
@@ -38,10 +38,12 @@ import { createSelectors } from "@/utils/create-selectors";
  * - `idle` — no session (or a finished one cleaned up).
  * - `connecting` — minting a token / opening the socket, before `ready`.
  * - `listening` — mic is capturing and streaming PCM to the server.
- * - `transcribing` — the user's utterance closed; waiting on the final
+ * - `transcribing`: the user's utterance closed; waiting on the final
  *   transcript. Set by server VAD's `utterance_end` in hands-free and by the
- *   turn-boundary `ptt_release` frame in manual mode. Carries no wording of its
- *   own; see {@link LIVE_VOICE_STATE_LABELS}.
+ *   turn-boundary `ptt_release` frame in manual mode. Distinct from `thinking`
+ *   because it stamps end-of-speech latency and gates the
+ *   `utterance_discarded` return to `listening`, though the two share a label
+ *   (see {@link LIVE_VOICE_STATE_LABELS}).
  * - `thinking` — server is generating the assistant response.
  * - `speaking` — TTS audio is queued/playing.
  * - `ending` — graceful teardown in progress.
@@ -67,19 +69,13 @@ export type LiveVoiceSessionState =
  * small label. `idle`/`failed` map to an empty label — hosts unmount their
  * voice UI in those states.
  *
- * `transcribing` deliberately shares `thinking`'s wording rather than having
- * its own (JARVIS-1559). {@link toVoiceAvatarVisual} already collapses the two,
- * so a distinct label left the avatar animating thinking and the eyes caption
- * reading "Thinking" while the label beside them said "Transcribing…", for a
- * window that is usually under a second and that offers the user nothing to do
- * with the distinction. Mapped here rather than in {@link liveVoiceSurfaceLabel}
- * so the phase has no wording of its own on any surface: the session pill and
- * the composer's voice bar read this table directly and would otherwise keep
- * the split alive.
- *
- * The phase itself stays. It stamps end-of-speech latency and gates the
- * `utterance_discarded` return to `listening`, so collapsing the *state* would
- * break both.
+ * `transcribing` and `thinking` share one label (JARVIS-1559).
+ * `toVoiceAvatarVisual` collapses both phases to a single visual, so wording
+ * unique to `transcribing` puts two words for one phase on screen at once,
+ * across a window that is usually under a second and that offers the user
+ * nothing to act on. The pairing belongs in this table rather than in
+ * {@link liveVoiceSurfaceLabel}: the session pill and the composer's voice bar
+ * read the table directly, so it is the only layer every surface shares.
  */
 export const LIVE_VOICE_STATE_LABELS: Record<LiveVoiceSessionState, string> = {
   idle: "",


### PR DESCRIPTION
Closes JARVIS-1559. Follow-on from JARVIS-1554 / #40932.

`transcribing` was the only layer still insisting it was distinct from `thinking`. `toVoiceAvatarVisual` collapses the two (`voice-avatar-state.ts:49`), so while the phase was set the avatar animated thinking, the eyes caption said "Thinking", and the label beside them said "Transcribing…" — three layers, one phase, two words, for a window that is usually under a second and that gives the user nothing to act on.

It now shares `thinking`'s wording.

## Why the base table, not `liveVoiceSurfaceLabel`

The surface helper is the natural-looking place, and it is the wrong one. `voice-session-pill-host.tsx:182` and `voice-composer-bar.tsx:269` read `LIVE_VOICE_STATE_LABELS` directly, so remapping in the helper would have left the pill and the composer bar saying "Transcribing…" while the room said "Thinking…" — the same split, one layer down. Mapping in the table means the phase has no wording of its own on any surface, including the label map uploaded for server-composed APNs pushes.

## What is deliberately unchanged

- **The phase.** It stamps `speechEndedAtMs` for end-of-speech latency and gates the `utterance_discarded` return to `listening` (`use-live-voice.ts:826-843`). Collapsing the state would break both. This is a copy change, not a state-machine change.
- **Dictation.** `chat-composer.tsx:1120` (`voicePhase === "processing"`) also says "Transcribing", but that is the mic-button path, where transcription is a genuinely distinct visible step with the text landing in the composer after. Different feature, different surface, left alone.

## Verification

- 2 new tests: `transcribing` and `thinking` share a label, and the phase stays distinct at the state level (`toVoiceAvatarVisual` parity, `liveVoiceStateLabel` reads "Thinking…").
- Updated the two suites that asserted the old string (`live-voice-store.test.ts`, `voice-composer-bar.test.tsx:99`).
- Suites pass: store 56, composer bar 39, session pill 28, avatar state 21, voice room 98, use-live-voice 98, push registration 5, companion surface 22.
- `bun run typecheck` clean; lint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)