### PR TITLE
refactor(channels): move Slack-only fields off the shared reply payload (LUM-3357)

### DIFF
--- a/assistant/src/__tests__/channel-inbound-disk-pressure.test.ts
+++ b/assistant/src/__tests__/channel-inbound-disk-pressure.test.ts
@@ -414,8 +414,7 @@ describe("channel inbound disk pressure gate", () => {
           chatId: "slack-channel-1",
           text: expectedRemoteBlockReply,
           assistantId: "self",
-          ephemeral: true,
-          user: "slack-user-1",
+          slack: { ephemeral: true, user: "slack-user-1" },
         },
       ],
     ]);

--- a/assistant/src/__tests__/channel-reply-delivery.test.ts
+++ b/assistant/src/__tests__/channel-reply-delivery.test.ts
@@ -789,9 +789,11 @@ describe("channel-reply-delivery", () => {
       chatId: "chat-live",
       attachments,
       assistantId: undefined,
-      ephemeral: undefined,
-      user: undefined,
-      messageTs: "1700000000.000055",
+      slack: {
+        ephemeral: undefined,
+        user: undefined,
+        messageTs: "1700000000.000055",
+      },
     });
     expect(seenTs).toEqual(["1700000000.000055"]);
   });

--- a/assistant/src/__tests__/channel-reply-delivery.test.ts
+++ b/assistant/src/__tests__/channel-reply-delivery.test.ts
@@ -3,6 +3,13 @@ import { beforeEach, describe, expect, it, mock } from "bun:test";
 import { resolveMessageContentBlocks } from "../persistence/message-content-file.js";
 import type { RuntimeAttachmentMetadata } from "../runtime/http-types.js";
 
+/** The Slack extras off a captured wire payload. */
+function slackExtrasOf(
+  payload: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  return payload.slack as Record<string, unknown> | undefined;
+}
+
 type DeliveryCall = {
   callbackUrl: string;
   payload: Record<string, unknown>;
@@ -800,10 +807,10 @@ describe("channel-reply-delivery", () => {
     });
 
     expect(deliveryCalls).toHaveLength(2);
-    expect(deliveryCalls[0].payload.ephemeral).toBe(true);
-    expect(deliveryCalls[0].payload.user).toBe("U456");
-    expect(deliveryCalls[1].payload.ephemeral).toBe(true);
-    expect(deliveryCalls[1].payload.user).toBe("U456");
+    expect(slackExtrasOf(deliveryCalls[0].payload)?.ephemeral).toBe(true);
+    expect(slackExtrasOf(deliveryCalls[0].payload)?.user).toBe("U456");
+    expect(slackExtrasOf(deliveryCalls[1].payload)?.ephemeral).toBe(true);
+    expect(slackExtrasOf(deliveryCalls[1].payload)?.user).toBe("U456");
   });
 
   it("does not include ephemeral fields when not set", async () => {
@@ -815,8 +822,8 @@ describe("channel-reply-delivery", () => {
     });
 
     expect(deliveryCalls).toHaveLength(1);
-    expect(deliveryCalls[0].payload.ephemeral).toBeUndefined();
-    expect(deliveryCalls[0].payload.user).toBeUndefined();
+    expect(slackExtrasOf(deliveryCalls[0].payload)?.ephemeral).toBeUndefined();
+    expect(slackExtrasOf(deliveryCalls[0].payload)?.user).toBeUndefined();
   });
 
   it("suppresses delivery when the only text segment is <no_response/>", async () => {

--- a/assistant/src/__tests__/channel-reply-delivery.test.ts
+++ b/assistant/src/__tests__/channel-reply-delivery.test.ts
@@ -2,13 +2,7 @@ import { beforeEach, describe, expect, it, mock } from "bun:test";
 
 import { resolveMessageContentBlocks } from "../persistence/message-content-file.js";
 import type { RuntimeAttachmentMetadata } from "../runtime/http-types.js";
-
-/** The Slack extras off a captured wire payload. */
-function slackExtrasOf(
-  payload: Record<string, unknown>,
-): Record<string, unknown> | undefined {
-  return payload.slack as Record<string, unknown> | undefined;
-}
+import { slackExtrasOf } from "./channel-reply-test-helpers.js";
 
 type DeliveryCall = {
   callbackUrl: string;

--- a/assistant/src/__tests__/channel-reply-test-helpers.ts
+++ b/assistant/src/__tests__/channel-reply-test-helpers.ts
@@ -1,0 +1,14 @@
+/**
+ * Helpers for suites that capture outbound channel replies.
+ *
+ * A captured payload is typed `Record<string, unknown>` rather than
+ * `ChannelReplyPayload`, so reaching a channel's own options needs a cast that
+ * is easy to spell differently in each suite.
+ */
+
+/** The Slack options off a captured wire payload. */
+export function slackExtrasOf(
+  payload: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  return payload.slack as Record<string, unknown> | undefined;
+}

--- a/assistant/src/__tests__/trusted-contact-inline-approval-integration.test.ts
+++ b/assistant/src/__tests__/trusted-contact-inline-approval-integration.test.ts
@@ -187,6 +187,13 @@ import type { ToolContext } from "../tools/types.js";
 import { seedContactChannel } from "./helpers/seed-contact-channel.js";
 import { setConfig } from "./helpers/set-config.js";
 
+/** The Slack extras off a captured wire payload. */
+function slackExtrasOf(
+  payload: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  return payload.slack as Record<string, unknown> | undefined;
+}
+
 await initializeDb();
 
 function resetTables(): void {
@@ -1232,7 +1239,9 @@ describe("(g) access_request resolver: requester code delivery", () => {
       "your access request was approved",
     );
     // The code DM is durable, never ephemeral.
-    expect(requesterCodeReply!.payload.ephemeral).toBeUndefined();
+    expect(
+      slackExtrasOf(requesterCodeReply!.payload)?.ephemeral,
+    ).toBeUndefined();
     // threadTs (the guardian's channel thread) is stripped for the DM.
     expect(requesterCodeReply!.url).not.toContain("threadTs");
 
@@ -1411,8 +1420,8 @@ describe("(g) access_request resolver: requester code delivery", () => {
     );
     expect(courier).toBeDefined();
     expect(courier!.payload.chatId).toBe("C_SHARED_CHANNEL");
-    expect(courier!.payload.ephemeral).toBe(true);
-    expect(courier!.payload.user).toBe(REQUESTER_UID);
+    expect(slackExtrasOf(courier!.payload)?.ephemeral).toBe(true);
+    expect(slackExtrasOf(courier!.payload)?.user).toBe(REQUESTER_UID);
   });
 
   test("guardian-facing reply uses the requester's display name, not the raw ID", async () => {

--- a/assistant/src/__tests__/trusted-contact-inline-approval-integration.test.ts
+++ b/assistant/src/__tests__/trusted-contact-inline-approval-integration.test.ts
@@ -184,15 +184,9 @@ import {
   waitForInlineGrant,
 } from "../tools/tool-approval-handler.js";
 import type { ToolContext } from "../tools/types.js";
+import { slackExtrasOf } from "./channel-reply-test-helpers.js";
 import { seedContactChannel } from "./helpers/seed-contact-channel.js";
 import { setConfig } from "./helpers/set-config.js";
-
-/** The Slack extras off a captured wire payload. */
-function slackExtrasOf(
-  payload: Record<string, unknown>,
-): Record<string, unknown> | undefined {
-  return payload.slack as Record<string, unknown> | undefined;
-}
 
 await initializeDb();
 

--- a/assistant/src/approvals/guardian-request-resolvers.ts
+++ b/assistant/src/approvals/guardian-request-resolvers.ts
@@ -16,6 +16,7 @@
  */
 
 import type { CreateOutboundSessionIpcResponse } from "@vellumai/gateway-client";
+import { ephemeralTo } from "@vellumai/gateway-client";
 
 import { answerCall } from "../calls/call-domain.js";
 import type {
@@ -198,8 +199,7 @@ function buildRequesterChannelNotice(params: {
     shouldUseEphemeral(params.channel, params.requesterChatId) &&
     params.requesterExternalUserId
   ) {
-    payload.ephemeral = true;
-    payload.user = params.requesterExternalUserId;
+    payload.slack = ephemeralTo(params.requesterExternalUserId, payload.slack);
   }
   return payload;
 }
@@ -1316,8 +1316,10 @@ const accessRequestResolver: GuardianRequestResolver = {
           ) &&
           ctx.actor.actorExternalUserId
         ) {
-          codePayload.ephemeral = true;
-          codePayload.user = ctx.actor.actorExternalUserId;
+          codePayload.slack = ephemeralTo(
+            ctx.actor.actorExternalUserId,
+            codePayload.slack,
+          );
         }
         await deliverChannelReply(
           guardianInBandContext.replyCallbackUrl,
@@ -1547,8 +1549,10 @@ const toolGrantRequestResolver: GuardianRequestResolver = {
             shouldUseEphemeral(request.sourceChannel ?? "", requesterChatId) &&
             request.requesterExternalUserId
           ) {
-            grantDenialPayload.ephemeral = true;
-            grantDenialPayload.user = request.requesterExternalUserId;
+            grantDenialPayload.slack = ephemeralTo(
+              request.requesterExternalUserId,
+              grantDenialPayload.slack,
+            );
           }
           await deliverChannelReply(
             channelDeliveryContext.replyCallbackUrl,
@@ -1646,8 +1650,10 @@ const toolGrantRequestResolver: GuardianRequestResolver = {
           shouldUseEphemeral(request.sourceChannel ?? "", requesterChatId) &&
           request.requesterExternalUserId
         ) {
-          grantApprovalPayload.ephemeral = true;
-          grantApprovalPayload.user = request.requesterExternalUserId;
+          grantApprovalPayload.slack = ephemeralTo(
+            request.requesterExternalUserId,
+            grantApprovalPayload.slack,
+          );
         }
         await deliverChannelReply(
           channelDeliveryContext.replyCallbackUrl,

--- a/assistant/src/messaging/providers/__tests__/transport-dispatch.test.ts
+++ b/assistant/src/messaging/providers/__tests__/transport-dispatch.test.ts
@@ -153,10 +153,12 @@ describe("Slack sub-operation selection", () => {
     await deliverDirect(
       `${BASE}/deliver/slack`,
       payload({
-        assistantThreadStatus: {
-          channel: "C1",
-          threadTs: "1700.5",
-          status: "is thinking",
+        slack: {
+          assistantThreadStatus: {
+            channel: "C1",
+            threadTs: "1700.5",
+            status: "is thinking",
+          },
         },
       }),
     );
@@ -177,7 +179,7 @@ describe("Slack sub-operation selection", () => {
       `${BASE}/deliver/slack?threadTs=1700.5`,
       payload({
         text: "ignored while streaming",
-        slackStream: { action: "start", threadTs: "1700.5" },
+        slack: { stream: { action: "start", threadTs: "1700.5" } },
       }),
     );
     expect(slack.sendSlackStreamOp).toHaveBeenCalledTimes(1);
@@ -260,7 +262,7 @@ describe("capability gating across channels", () => {
       `${BASE}/deliver/discord`,
       payload({
         text: "hi",
-        slackStream: { action: "start", threadTs: "1700.5" },
+        slack: { stream: { action: "start", threadTs: "1700.5" } },
       }),
     );
     expect(discord.sendDiscordReply).toHaveBeenCalledTimes(1);

--- a/assistant/src/messaging/providers/channel-transport.ts
+++ b/assistant/src/messaging/providers/channel-transport.ts
@@ -47,13 +47,13 @@ export interface ChannelTransport {
     payload: ChannelReplyPayload,
   ): Promise<ChannelDeliveryResult>;
 
-  /** Update an assistant-thread status surface. Routed when `payload.assistantThreadStatus` is set. */
+  /** Update an assistant-thread status surface. Routed when `payload.slack.assistantThreadStatus` is set. */
   setThreadStatus?(
     ctx: CallbackContext,
     payload: ChannelReplyPayload,
   ): Promise<ChannelDeliveryResult>;
 
-  /** Perform one streaming operation. Routed when `payload.slackStream` is set. */
+  /** Perform one streaming operation. Routed when `payload.slack.stream` is set. */
   streamReply?(
     ctx: CallbackContext,
     payload: ChannelReplyPayload,

--- a/assistant/src/messaging/providers/index.ts
+++ b/assistant/src/messaging/providers/index.ts
@@ -90,13 +90,13 @@ export async function deliverDirect(
   }
 
   const ctx = callbackContext(callbackUrl);
-  if (payload.slackStream && transport.streamReply) {
+  if (payload.slack?.stream && transport.streamReply) {
     return transport.streamReply(ctx, payload);
   }
   if (payload.reaction && transport.sendReaction) {
     return transport.sendReaction(ctx, payload);
   }
-  if (payload.assistantThreadStatus && transport.setThreadStatus) {
+  if (payload.slack?.assistantThreadStatus && transport.setThreadStatus) {
     return transport.setThreadStatus(ctx, payload);
   }
   if (payload.chatAction === "typing" && transport.sendTyping) {

--- a/assistant/src/messaging/providers/slack/transport.ts
+++ b/assistant/src/messaging/providers/slack/transport.ts
@@ -16,19 +16,20 @@ export const slackTransport: ChannelTransport = {
   channel: "slack",
 
   async deliver(ctx, payload) {
-    const { chatId, text, attachments, blocks } = payload;
+    const { chatId, text, attachments } = payload;
+    const slack = payload.slack;
     const threadTs = ctx.params.threadTs;
 
     let sentTs: string | undefined;
     if (text) {
       const result = await sendSlackReply(chatId, text, {
         threadTs,
-        blocks,
+        blocks: slack?.blocks,
         approval: payload.approval,
         useBlocks: payload.useBlocks,
-        ephemeral: payload.ephemeral,
-        user: payload.user,
-        messageTs: payload.messageTs,
+        ephemeral: slack?.ephemeral,
+        user: slack?.user,
+        messageTs: slack?.messageTs,
       });
       sentTs = result.ts;
     } else if (payload.approval) {
@@ -69,7 +70,7 @@ export const slackTransport: ChannelTransport = {
   },
 
   async setThreadStatus(_ctx, payload) {
-    const status = payload.assistantThreadStatus;
+    const status = payload.slack?.assistantThreadStatus;
     if (!status) {
       return { ok: true };
     }
@@ -83,7 +84,7 @@ export const slackTransport: ChannelTransport = {
   },
 
   async streamReply(_ctx, payload) {
-    const op = payload.slackStream;
+    const op = payload.slack?.stream;
     if (!op) {
       return { ok: true };
     }

--- a/assistant/src/runtime/channel-reply-delivery.ts
+++ b/assistant/src/runtime/channel-reply-delivery.ts
@@ -1,3 +1,5 @@
+import type { SlackReplyExtras } from "@vellumai/gateway-client";
+
 import { stripVellumLinks } from "../daemon/assistant-attachments.js";
 import type { RenderedHistoryContent } from "../daemon/handlers/shared.js";
 import { renderHistoryContent } from "../daemon/handlers/shared.js";
@@ -148,9 +150,9 @@ export async function deliverRenderedReplyViaCallback(
 
   // Slack's per-message coordinates. `undefined` when none apply, so a payload
   // for another channel carries no empty Slack object.
-  const slackExtras = (
+  const buildSlackExtras = (
     ts: string | undefined,
-  ): { ephemeral?: boolean; user?: string; messageTs?: string } | undefined =>
+  ): SlackReplyExtras | undefined =>
     ephemeral || user || ts ? { ephemeral, user, messageTs: ts } : undefined;
 
   const deliverableSegments = toDeliverableTextSegments(
@@ -174,7 +176,7 @@ export async function deliverRenderedReplyViaCallback(
           chatId,
           attachments: replyAttachments,
           assistantId,
-          slack: slackExtras(messageTs),
+          slack: buildSlackExtras(messageTs),
         },
       );
       if (result.ts) {
@@ -192,7 +194,7 @@ export async function deliverRenderedReplyViaCallback(
           chatId,
           attachments: replyAttachments,
           assistantId,
-          slack: slackExtras(messageTs),
+          slack: buildSlackExtras(messageTs),
         },
       );
       const deliveredTs = result.ts ?? messageTs;
@@ -223,7 +225,7 @@ export async function deliverRenderedReplyViaCallback(
         useBlocks: true,
         attachments: isLastSegment ? replyAttachments : undefined,
         assistantId,
-        slack: slackExtras(isFirstSegment ? currentMessageTs : undefined),
+        slack: buildSlackExtras(isFirstSegment ? currentMessageTs : undefined),
       },
     );
 

--- a/assistant/src/runtime/channel-reply-delivery.ts
+++ b/assistant/src/runtime/channel-reply-delivery.ts
@@ -146,6 +146,13 @@ export async function deliverRenderedReplyViaCallback(
     onMessageTs,
   } = params;
 
+  // Slack's per-message coordinates. `undefined` when none apply, so a payload
+  // for another channel carries no empty Slack object.
+  const slackExtras = (
+    ts: string | undefined,
+  ): { ephemeral?: boolean; user?: string; messageTs?: string } | undefined =>
+    ephemeral || user || ts ? { ephemeral, user, messageTs: ts } : undefined;
+
   const deliverableSegments = toDeliverableTextSegments(
     textSegments,
     fallbackText,
@@ -167,9 +174,7 @@ export async function deliverRenderedReplyViaCallback(
           chatId,
           attachments: replyAttachments,
           assistantId,
-          ephemeral,
-          user,
-          messageTs,
+          slack: slackExtras(messageTs),
         },
       );
       if (result.ts) {
@@ -187,9 +192,7 @@ export async function deliverRenderedReplyViaCallback(
           chatId,
           attachments: replyAttachments,
           assistantId,
-          ephemeral,
-          user,
-          messageTs,
+          slack: slackExtras(messageTs),
         },
       );
       const deliveredTs = result.ts ?? messageTs;
@@ -220,9 +223,7 @@ export async function deliverRenderedReplyViaCallback(
         useBlocks: true,
         attachments: isLastSegment ? replyAttachments : undefined,
         assistantId,
-        ephemeral,
-        user,
-        messageTs: isFirstSegment ? currentMessageTs : undefined,
+        slack: slackExtras(isFirstSegment ? currentMessageTs : undefined),
       },
     );
 

--- a/assistant/src/runtime/channel-retry-sweep.ts
+++ b/assistant/src/runtime/channel-retry-sweep.ts
@@ -2,6 +2,8 @@
  * Periodic retry sweep for failed channel inbound events.
  */
 
+import { ephemeralTo } from "@vellumai/gateway-client";
+
 import type { AssistantEvent } from "../api/index.js";
 import {
   type ChannelId,
@@ -334,8 +336,10 @@ export async function sweepFailedEvents(
           assistantId,
         };
         if (sourceChannel === "slack" && requesterExternalUserId) {
-          replyPayload.ephemeral = true;
-          replyPayload.user = requesterExternalUserId;
+          replyPayload.slack = ephemeralTo(
+            requesterExternalUserId,
+            replyPayload.slack,
+          );
         }
         try {
           await deliverChannelReply(replyCallbackUrl, replyPayload);

--- a/assistant/src/runtime/routes/approval-strategies/guardian-text-engine-strategy.ts
+++ b/assistant/src/runtime/routes/approval-strategies/guardian-text-engine-strategy.ts
@@ -3,6 +3,8 @@
  * the conversational approval engine when an approvalConversationGenerator is
  * available. Classifies natural language and responds conversationally.
  */
+import { ephemeralTo } from "@vellumai/gateway-client";
+
 import type { ChannelId } from "../../../channels/types.js";
 import { getLogger } from "../../../util/logger.js";
 import { runApprovalConversationTurn } from "../../approval-conversation-turn.js";
@@ -98,8 +100,10 @@ export async function handleGuardianTextEngineDecision(
       };
       const ephemeral = slackEphemeralUserId(sourceChannel, actorExternalId);
       if (ephemeral) {
-        keepPendingPayload.ephemeral = true;
-        keepPendingPayload.user = ephemeral;
+        keepPendingPayload.slack = ephemeralTo(
+          ephemeral,
+          keepPendingPayload.slack,
+        );
       }
       await deliverChannelReply(replyCallbackUrl, keepPendingPayload);
     } catch (err) {
@@ -133,8 +137,7 @@ export async function handleGuardianTextEngineDecision(
       };
       const ephemeral = slackEphemeralUserId(sourceChannel, actorExternalId);
       if (ephemeral) {
-        decisionPayload.ephemeral = true;
-        decisionPayload.user = ephemeral;
+        decisionPayload.slack = ephemeralTo(ephemeral, decisionPayload.slack);
       }
       await deliverChannelReply(replyCallbackUrl, decisionPayload);
     } catch (err) {

--- a/assistant/src/runtime/routes/guardian-approval-interception.ts
+++ b/assistant/src/runtime/routes/guardian-approval-interception.ts
@@ -6,6 +6,7 @@
  * the conversational engine in guardian-text-engine-strategy.ts.
  */
 import type { KnownBlock } from "@slack/types";
+import { ephemeralTo } from "@vellumai/gateway-client";
 
 import type { ChannelId } from "../../channels/types.js";
 import type { TrustContext } from "../../daemon/trust-context-types.js";
@@ -214,7 +215,7 @@ export async function handleApprovalInterception(
             chatId: conversationExternalId,
             text: "Sorry, I couldn't process that. Please try again.",
             assistantId,
-            ...(ephemeralUser ? { ephemeral: true, user: ephemeralUser } : {}),
+            ...(ephemeralUser ? { slack: ephemeralTo(ephemeralUser) } : {}),
           });
         } catch (err) {
           log.error(

--- a/assistant/src/runtime/routes/guardian-approval-interception.ts
+++ b/assistant/src/runtime/routes/guardian-approval-interception.ts
@@ -276,7 +276,7 @@ export async function handleApprovalInterception(
           deliverChannelReply(replyCallbackUrl, {
             chatId: conversationExternalId,
             text: `${statusEmoji} ${statusLabel}`,
-            messageTs: approvalMessageTs,
+            slack: { messageTs: approvalMessageTs },
             assistantId,
           }).catch((err) => {
             log.error(
@@ -398,8 +398,7 @@ function editStaleSlackApprovalMessage(params: {
   deliverChannelReply(params.replyCallbackUrl, {
     chatId: params.chatId,
     text: statusText,
-    blocks,
-    messageTs: params.messageTs,
+    slack: { blocks, messageTs: params.messageTs },
     assistantId: params.assistantId,
   }).catch((err) => {
     log.error(

--- a/assistant/src/runtime/routes/guardian-approval-reply-helpers.ts
+++ b/assistant/src/runtime/routes/guardian-approval-reply-helpers.ts
@@ -3,6 +3,7 @@
  * identity mismatch notices, reminders, etc.) that were duplicated across
  * guardian-approval-interception.ts.
  */
+import { ephemeralTo } from "@vellumai/gateway-client";
 import type pino from "pino";
 
 import type { ChannelId } from "../../channels/types.js";
@@ -75,8 +76,7 @@ async function composeAndDeliver(
     assistantId,
   };
   if (ephemeralUserId) {
-    payload.ephemeral = true;
-    payload.user = ephemeralUserId;
+    payload.slack = ephemeralTo(ephemeralUserId, payload.slack);
   }
   await deliverChannelReply(replyCallbackUrl, payload);
 }

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -6,6 +6,7 @@
  * messages reach this handler.
  */
 import type { SourceMetadata } from "@vellumai/gateway-client";
+import { ephemeralTo } from "@vellumai/gateway-client";
 import {
   ADMISSION_POLICY_DEFAULT,
   type AdmissionPolicy,
@@ -908,8 +909,10 @@ export async function handleChannelInbound({
         assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
       };
       if (sourceChannel === "slack" && (canonicalSenderId ?? rawSenderId)) {
-        replyPayload.ephemeral = true;
-        replyPayload.user = (canonicalSenderId ?? rawSenderId)!;
+        replyPayload.slack = ephemeralTo(
+          (canonicalSenderId ?? rawSenderId)!,
+          replyPayload.slack,
+        );
       }
       try {
         await deliverChannelReply(replyCallbackUrl, replyPayload);
@@ -970,8 +973,10 @@ export async function handleChannelInbound({
         assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
       };
       if (sourceChannel === "slack" && (canonicalSenderId ?? rawSenderId)) {
-        replyPayload.ephemeral = true;
-        replyPayload.user = (canonicalSenderId ?? rawSenderId)!;
+        replyPayload.slack = ephemeralTo(
+          (canonicalSenderId ?? rawSenderId)!,
+          replyPayload.slack,
+        );
       }
       try {
         await deliverChannelReply(replyCallbackUrl, replyPayload);
@@ -1196,7 +1201,7 @@ export async function handleChannelInbound({
         deliverChannelReply(replyCallbackUrl, {
           chatId: conversationExternalId,
           text: "This approval request has been resolved.",
-          messageTs: approvalMessageTs,
+          slack: { messageTs: approvalMessageTs },
           assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
         }).catch((err) => {
           log.error(

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -11,6 +11,7 @@ import type {
   SourceMetadata,
   TrustVerdict,
 } from "@vellumai/gateway-client";
+import { ephemeralTo } from "@vellumai/gateway-client";
 
 import type { VerificationSessionWire } from "../../../channels/gateway-verification-sessions.js";
 import {
@@ -597,8 +598,10 @@ export async function enforceIngressAcl(
           };
           // On Slack, send as ephemeral so only the requester sees the rejection
           if (sourceChannel === "slack" && (canonicalSenderId ?? rawSenderId)) {
-            replyPayload.ephemeral = true;
-            replyPayload.user = (canonicalSenderId ?? rawSenderId)!;
+            replyPayload.slack = ephemeralTo(
+              (canonicalSenderId ?? rawSenderId)!,
+              replyPayload.slack,
+            );
           }
           try {
             await deliverChannelReply(replyCallbackUrl, replyPayload);
@@ -852,8 +855,10 @@ export async function enforceIngressAcl(
               sourceChannel === "slack" &&
               (canonicalSenderId ?? rawSenderId)
             ) {
-              inactiveReplyPayload.ephemeral = true;
-              inactiveReplyPayload.user = (canonicalSenderId ?? rawSenderId)!;
+              inactiveReplyPayload.slack = ephemeralTo(
+                (canonicalSenderId ?? rawSenderId)!,
+                inactiveReplyPayload.slack,
+              );
             }
             try {
               await deliverChannelReply(replyCallbackUrl, inactiveReplyPayload);
@@ -892,8 +897,10 @@ export async function enforceIngressAcl(
             assistantId,
           };
           if (sourceChannel === "slack" && (canonicalSenderId ?? rawSenderId)) {
-            denyPayload.ephemeral = true;
-            denyPayload.user = (canonicalSenderId ?? rawSenderId)!;
+            denyPayload.slack = ephemeralTo(
+              (canonicalSenderId ?? rawSenderId)!,
+              denyPayload.slack,
+            );
           }
           try {
             await deliverChannelReply(replyCallbackUrl, denyPayload);

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.test.ts
@@ -123,6 +123,13 @@ import {
 } from "./background-dispatch.js";
 import { __resetChannelTurnAdmissionForTests } from "./channel-turn-admission.js";
 
+/** The Slack extras off a captured wire payload. */
+function slackExtrasOf(
+  payload: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  return payload.slack as Record<string, unknown> | undefined;
+}
+
 beforeEach(() => {
   __resetChannelTurnAdmissionForTests();
   clearConversations();
@@ -146,7 +153,10 @@ beforeEach(() => {
 
 const slackStreamOps = (): Array<Record<string, unknown>> =>
   deliveredChannelReplies
-    .map((entry) => entry.payload.slackStream as Record<string, unknown>)
+    .map(
+      (entry) =>
+        slackExtrasOf(entry.payload)?.stream as Record<string, unknown>,
+    )
     .filter(Boolean);
 
 describe("isBoundGuardianActor", () => {
@@ -966,14 +976,15 @@ describe("Slack thinking status timing", () => {
 
     const processMessage: MessageProcessor = async () => {
       expect(deliveredChannelReplies).toHaveLength(1);
-      expect(deliveredChannelReplies[0]!.payload.assistantThreadStatus).toEqual(
-        {
-          channel: channelId,
-          threadTs,
-          status: expect.any(String),
-          loadingMessages: ["Thinking\u2026"],
-        },
-      );
+      expect(
+        slackExtrasOf(deliveredChannelReplies[0]!.payload)
+          ?.assistantThreadStatus,
+      ).toEqual({
+        channel: channelId,
+        threadTs,
+        status: expect.any(String),
+        loadingMessages: ["Thinking\u2026"],
+      });
       const threadStatus = deliveredChannelReplies[0]!.payload
         .assistantThreadStatus as { status: string };
       expect(slackStatusLabels).toContain(threadStatus.status);
@@ -997,7 +1008,7 @@ describe("Slack thinking status timing", () => {
     await flush();
 
     const statuses = deliveredChannelReplies.map((entry) => {
-      const status = entry.payload.assistantThreadStatus as
+      const status = slackExtrasOf(entry.payload)?.assistantThreadStatus as
         | { status?: string }
         | undefined;
       return status?.status;
@@ -1083,7 +1094,7 @@ describe("Slack thinking status timing", () => {
     await flush();
 
     const statuses = deliveredChannelReplies.map((entry) => {
-      const status = entry.payload.assistantThreadStatus as
+      const status = slackExtrasOf(entry.payload)?.assistantThreadStatus as
         | { status?: string }
         | undefined;
       return status?.status;
@@ -1145,7 +1156,7 @@ describe("Slack thinking status timing", () => {
     await flush();
 
     const statuses = deliveredChannelReplies.map(
-      (entry) => entry.payload.assistantThreadStatus,
+      (entry) => slackExtrasOf(entry.payload)?.assistantThreadStatus,
     );
     expect(statuses).toEqual([
       {
@@ -1279,7 +1290,7 @@ describe("Slack thinking status timing", () => {
     await flush();
 
     const statuses = deliveredChannelReplies.map(
-      (entry) => entry.payload.assistantThreadStatus,
+      (entry) => slackExtrasOf(entry.payload)?.assistantThreadStatus,
     );
     expect(statuses).toEqual([
       {

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.test.ts
@@ -107,6 +107,7 @@ mock.module("../../channel-reply-delivery.js", () => ({
   },
 }));
 
+import { slackExtrasOf } from "../../../__tests__/channel-reply-test-helpers.js";
 import type { Conversation } from "../../../daemon/conversation.js";
 import { CONVERSATION_BUSY_MESSAGE } from "../../../daemon/conversation-messaging.js";
 import {
@@ -122,13 +123,6 @@ import {
   shouldStartSlackThinkingStatusImmediately,
 } from "./background-dispatch.js";
 import { __resetChannelTurnAdmissionForTests } from "./channel-turn-admission.js";
-
-/** The Slack extras off a captured wire payload. */
-function slackExtrasOf(
-  payload: Record<string, unknown>,
-): Record<string, unknown> | undefined {
-  return payload.slack as Record<string, unknown> | undefined;
-}
 
 beforeEach(() => {
   __resetChannelTurnAdmissionForTests();

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
@@ -716,11 +716,13 @@ function setSlackThinkingStatus(
   let statusPromise = deliverChannelReply(callbackUrl, {
     chatId,
     assistantId,
-    assistantThreadStatus: {
-      channel: chatId,
-      threadTs,
-      status: getRandomSlackThinkingStatus(),
-      ...(loadingMessages ? { loadingMessages } : {}),
+    slack: {
+      assistantThreadStatus: {
+        channel: chatId,
+        threadTs,
+        status: getRandomSlackThinkingStatus(),
+        ...(loadingMessages ? { loadingMessages } : {}),
+      },
     },
   }).catch((err) => {
     log.debug({ err, chatId, threadTs }, "Failed to set Slack thinking status");
@@ -734,13 +736,15 @@ function setSlackThinkingStatus(
       deliverChannelReply(callbackUrl, {
         chatId,
         assistantId,
-        assistantThreadStatus: {
-          channel: chatId,
-          threadTs,
-          status: getRandomSlackThinkingStatus(),
-          ...(nextLoadingMessages
-            ? { loadingMessages: nextLoadingMessages }
-            : {}),
+        slack: {
+          assistantThreadStatus: {
+            channel: chatId,
+            threadTs,
+            status: getRandomSlackThinkingStatus(),
+            ...(nextLoadingMessages
+              ? { loadingMessages: nextLoadingMessages }
+              : {}),
+          },
         },
       }).catch((err) => {
         log.debug(
@@ -761,10 +765,12 @@ function setSlackThinkingStatus(
       deliverChannelReply(callbackUrl, {
         chatId,
         assistantId,
-        assistantThreadStatus: {
-          channel: chatId,
-          threadTs,
-          status: "",
+        slack: {
+          assistantThreadStatus: {
+            channel: chatId,
+            threadTs,
+            status: "",
+          },
         },
       }).catch((err) => {
         log.debug(

--- a/assistant/src/runtime/routes/inbound-stages/guardian-reply-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/guardian-reply-intercept.ts
@@ -9,6 +9,8 @@
  * Extracted from inbound-message-handler.ts to keep the top-level handler
  * focused on orchestration.
  */
+import { ephemeralTo } from "@vellumai/gateway-client";
+
 import {
   listGuardianRequestsOrEmpty,
   listPendingRequestsByDestinationOrEmpty,
@@ -198,8 +200,10 @@ export async function handleGuardianReplyIntercept(
       // On Slack, send guardian management replies (disambiguation, pending
       // request lists, etc.) as ephemeral so only the guardian sees them.
       if (sourceChannel === "slack" && (canonicalSenderId ?? rawSenderId)) {
-        routerReplyPayload.ephemeral = true;
-        routerReplyPayload.user = (canonicalSenderId ?? rawSenderId)!;
+        routerReplyPayload.slack = ephemeralTo(
+          (canonicalSenderId ?? rawSenderId)!,
+          routerReplyPayload.slack,
+        );
       }
       try {
         await deliverChannelReply(replyCallbackUrl, routerReplyPayload);

--- a/assistant/src/runtime/slack-reply-session.test.ts
+++ b/assistant/src/runtime/slack-reply-session.test.ts
@@ -28,19 +28,13 @@ mock.module("./gateway-client.js", () => ({
   },
 }));
 
+import { slackExtrasOf } from "../__tests__/channel-reply-test-helpers.js";
 import type { AssistantEvent } from "../api/index.js";
 import { SLACK_STREAM_MARKDOWN_LIMIT } from "../messaging/providers/slack/api.js";
 import {
   createSlackReplySession,
   shouldStreamSlackReply,
 } from "./slack-reply-session.js";
-
-/** The Slack extras off a captured wire payload. */
-function slackExtrasOf(
-  payload: Record<string, unknown>,
-): Record<string, unknown> | undefined {
-  return payload.slack as Record<string, unknown> | undefined;
-}
 
 const CHANNEL = "D-STREAM";
 const THREAD_TS = "1700000000.000001";

--- a/assistant/src/runtime/slack-reply-session.test.ts
+++ b/assistant/src/runtime/slack-reply-session.test.ts
@@ -35,6 +35,13 @@ import {
   shouldStreamSlackReply,
 } from "./slack-reply-session.js";
 
+/** The Slack extras off a captured wire payload. */
+function slackExtrasOf(
+  payload: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  return payload.slack as Record<string, unknown> | undefined;
+}
+
 const CHANNEL = "D-STREAM";
 const THREAD_TS = "1700000000.000001";
 const CALLBACK_URL = `https://example.test/deliver/slack?channel=${CHANNEL}&threadTs=${THREAD_TS}`;
@@ -98,7 +105,9 @@ const tick = (ms: number): Promise<void> =>
 
 const slackStreamOps = (): Array<Record<string, unknown>> =>
   deliverCalls
-    .map((call) => call.payload.slackStream as Record<string, unknown>)
+    .map(
+      (call) => slackExtrasOf(call.payload)?.stream as Record<string, unknown>,
+    )
     .filter(Boolean);
 
 const streamedMarkdown = (): string =>
@@ -350,7 +359,7 @@ describe("createSlackReplySession", () => {
 
   test("falls back when stopStream throws after streaming text", async () => {
     deliverImpl = async (_url, payload) => {
-      const op = payload.slackStream as { action: string };
+      const op = slackExtrasOf(payload)?.stream as { action: string };
       if (op.action === "stop") {
         throw new Error("stop failed");
       }
@@ -483,7 +492,7 @@ describe("createSlackReplySession", () => {
 
   test("leaves progress to stop when the task-only append fails", async () => {
     deliverImpl = async (_url, payload) => {
-      const op = payload.slackStream as {
+      const op = slackExtrasOf(payload)?.stream as {
         action: string;
         markdownText?: string;
       };

--- a/assistant/src/runtime/slack-reply-session.ts
+++ b/assistant/src/runtime/slack-reply-session.ts
@@ -200,7 +200,11 @@ export function createSlackReplySession(params: {
   const imageBlocks = (
     text: string,
   ):
-    | NonNullable<Parameters<typeof deliverChannelReply>[1]["blocks"]>
+    | NonNullable<
+        NonNullable<
+          Parameters<typeof deliverChannelReply>[1]["slack"]
+        >["blocks"]
+      >
     | undefined => {
     const blocks = renderSlackBlocks(text)?.filter(
       (block) => block.type === "image",
@@ -225,20 +229,22 @@ export function createSlackReplySession(params: {
         const result = await deliverChannelReply(replyCallbackUrl, {
           chatId,
           assistantId,
-          slackStream: {
-            action: "start",
-            threadTs,
-            markdownText: firstChunk,
-            // The task display mode is fixed for the stream's lifetime at
-            // start, while a `task_progress` surface usually appears only
-            // after the first text flush has opened the stream. Plan mode
-            // only affects how task chunks render, so a stream that never
-            // carries tasks still reads as a plain message.
-            taskDisplayMode: "plan" as const,
-            ...(title ? { planTitle: title } : {}),
-            ...(tasks ? { tasks } : {}),
-            ...(recipientUserId ? { recipientUserId } : {}),
-            ...(recipientTeamId ? { recipientTeamId } : {}),
+          slack: {
+            stream: {
+              action: "start",
+              threadTs,
+              markdownText: firstChunk,
+              // The task display mode is fixed for the stream's lifetime at
+              // start, while a `task_progress` surface usually appears only
+              // after the first text flush has opened the stream. Plan mode
+              // only affects how task chunks render, so a stream that never
+              // carries tasks still reads as a plain message.
+              taskDisplayMode: "plan" as const,
+              ...(title ? { planTitle: title } : {}),
+              ...(tasks ? { tasks } : {}),
+              ...(recipientUserId ? { recipientUserId } : {}),
+              ...(recipientTeamId ? { recipientTeamId } : {}),
+            },
           },
         });
         if (result.ok && result.ts) {
@@ -290,12 +296,14 @@ export function createSlackReplySession(params: {
           await deliverChannelReply(replyCallbackUrl, {
             chatId,
             assistantId,
-            slackStream: {
-              action: "append",
-              streamTs,
-              markdownText: chunk,
-              ...(title ? { planTitle: title } : {}),
-              ...(tasks ? { tasks } : {}),
+            slack: {
+              stream: {
+                action: "append",
+                streamTs,
+                markdownText: chunk,
+                ...(title ? { planTitle: title } : {}),
+                ...(tasks ? { tasks } : {}),
+              },
             },
           });
           confirmedLength += chunk.length;
@@ -319,11 +327,13 @@ export function createSlackReplySession(params: {
           await deliverChannelReply(replyCallbackUrl, {
             chatId,
             assistantId,
-            slackStream: {
-              action: "append",
-              streamTs,
-              ...(title ? { planTitle: title } : {}),
-              tasks,
+            slack: {
+              stream: {
+                action: "append",
+                streamTs,
+                ...(title ? { planTitle: title } : {}),
+                tasks,
+              },
             },
           });
           deliveredProgressKey = key;
@@ -453,13 +463,15 @@ export function createSlackReplySession(params: {
           await deliverChannelReply(replyCallbackUrl, {
             chatId,
             assistantId,
-            slackStream: {
-              action: "stop",
-              streamTs,
-              ...(remaining.length > 0 ? { markdownText: remaining } : {}),
-              ...(blocks ? { blocks } : {}),
-              ...(title ? { planTitle: title } : {}),
-              ...(tasks ? { tasks } : {}),
+            slack: {
+              stream: {
+                action: "stop",
+                streamTs,
+                ...(remaining.length > 0 ? { markdownText: remaining } : {}),
+                ...(blocks ? { blocks } : {}),
+                ...(title ? { planTitle: title } : {}),
+                ...(tasks ? { tasks } : {}),
+              },
             },
           });
           confirmedLength = clean.length;

--- a/packages/gateway-client/src/index.ts
+++ b/packages/gateway-client/src/index.ts
@@ -27,9 +27,13 @@ export {
   ChannelDeliveryResultSchema,
   ChannelReplyPayloadSchema,
   PermissionRequestDetailsSchema,
+} from "./outbound-contract.js";
+export {
+  ephemeralTo,
+  SlackReplyExtrasSchema,
   SlackStreamOpSchema,
   SlackStreamTaskSchema,
-} from "./outbound-contract.js";
+} from "./slack-reply.js";
 
 export type {
   ApprovalActionOption,
@@ -38,9 +42,12 @@ export type {
   ChannelDeliveryResult,
   ChannelReplyPayload,
   PermissionRequestDetails,
+} from "./outbound-contract.js";
+export type {
+  SlackReplyExtras,
   SlackStreamOp,
   SlackStreamTask,
-} from "./outbound-contract.js";
+} from "./slack-reply.js";
 
 // Inbound contract (gateway → daemon) — Zod schemas + derived types
 export {

--- a/packages/gateway-client/src/outbound-contract.ts
+++ b/packages/gateway-client/src/outbound-contract.ts
@@ -10,8 +10,9 @@
  * to the target channel provider.
  */
 
-import type { KnownBlock } from "@slack/types";
 import { z } from "zod";
+
+import { SlackReplyExtrasSchema } from "./slack-reply.js";
 
 // ---------------------------------------------------------------------------
 // Attachment metadata
@@ -66,121 +67,30 @@ export const ApprovalUIMetadataSchema = z.object({
 export type ApprovalUIMetadata = z.infer<typeof ApprovalUIMetadataSchema>;
 
 // ---------------------------------------------------------------------------
-// Slack streaming operations
-// ---------------------------------------------------------------------------
-
-/**
- * One task card in a Slack streamed plan. Mirrors the `task_update` chunk of
- * the Slack streaming API: an ordered, status-bearing step the assistant is
- * working through. `title` is capped at 256 characters by Slack.
- *
- * @see https://docs.slack.dev/reference/methods/chat.appendStream/
- */
-export const SlackStreamTaskSchema = z.object({
-  id: z.string(),
-  title: z.string(),
-  status: z.enum(["pending", "in_progress", "complete", "error"]),
-  details: z.string().optional(),
-  output: z.string().optional(),
-});
-
-export type SlackStreamTask = z.infer<typeof SlackStreamTaskSchema>;
-
-/**
- * A single Slack streaming operation, mapping directly onto the
- * `chat.startStream` / `chat.appendStream` / `chat.stopStream` Web API methods.
- *
- * `start` opens a streamed reply on a thread and returns the stream `ts`;
- * `append` adds markdown (and optional task cards) to that stream; `stop`
- * finalizes it, optionally rendering rich Block Kit blocks below the streamed
- * body. Blocks are only accepted on `stop` — during the stream, Slack renders
- * the `markdownText` natively.
- *
- * @see https://docs.slack.dev/reference/methods/chat.startStream/
- * @see https://docs.slack.dev/reference/methods/chat.appendStream/
- * @see https://docs.slack.dev/reference/methods/chat.stopStream/
- */
-export const SlackStreamOpSchema = z
-  .discriminatedUnion("action", [
-    z.object({
-      action: z.literal("start"),
-      threadTs: z.string(),
-      markdownText: z.string().optional(),
-      taskDisplayMode: z.literal("plan").optional(),
-      /** Title of the plan block, serialized as a `plan_update` chunk. */
-      planTitle: z.string().optional(),
-      tasks: z.array(SlackStreamTaskSchema).optional(),
-      /**
-       * Slack user ID of the reader the stream targets. Required by
-       * `chat.startStream` when streaming into a channel; omitted for DMs.
-       */
-      recipientUserId: z.string().optional(),
-      /**
-       * Slack team ID the recipient belongs to. Required alongside
-       * `recipientUserId` when streaming into a channel; omitted for DMs.
-       */
-      recipientTeamId: z.string().optional(),
-    }),
-    z.object({
-      action: z.literal("append"),
-      streamTs: z.string(),
-      markdownText: z.string().optional(),
-      /** Title of the plan block, serialized as a `plan_update` chunk. */
-      planTitle: z.string().optional(),
-      tasks: z.array(SlackStreamTaskSchema).optional(),
-    }),
-    z.object({
-      action: z.literal("stop"),
-      streamTs: z.string(),
-      markdownText: z.string().optional(),
-      blocks: z.array(z.custom<KnownBlock>()).optional(),
-      /** Title of the plan block, serialized as a `plan_update` chunk. */
-      planTitle: z.string().optional(),
-      tasks: z.array(SlackStreamTaskSchema).optional(),
-    }),
-  ])
-  .superRefine((op, ctx) => {
-    // Slack requires either `markdown_text` or `chunks` on `start`/`append`; a
-    // task-only operation advances the plan block without new body text.
-    if (
-      (op.action === "start" || op.action === "append") &&
-      op.markdownText === undefined &&
-      op.tasks === undefined
-    ) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: `${op.action} requires markdownText or tasks`,
-      });
-    }
-  });
-
-export type SlackStreamOp = z.infer<typeof SlackStreamOpSchema>;
-
-// ---------------------------------------------------------------------------
 // Channel reply payload — the full outbound wire format
 // ---------------------------------------------------------------------------
 
 export const ChannelReplyPayloadSchema = z.object({
   chatId: z.string(),
   text: z.string().optional(),
-  /** Pre-formatted Block Kit blocks for Slack delivery. */
-  blocks: z.array(z.custom<KnownBlock>()).optional(),
   assistantId: z.string().optional(),
   attachments: z.array(AttachmentMetadataSchema).optional(),
   approval: ApprovalUIMetadataSchema.optional(),
   chatAction: z.literal("typing").optional(),
   /**
-   * When true, deliver via `chat.postEphemeral` so only the target `user`
-   * sees the message.
+   * Render the text richly rather than as plain text. Channel-neutral intent,
+   * not a Slack one: Slack reads it as Block Kit, Telegram as a rich-message
+   * send that degrades to plain text on rejection.
    */
-  ephemeral: z.boolean().optional(),
-  /** Slack user ID — required when `ephemeral` is true. */
-  user: z.string().optional(),
-  /** When provided, update an existing message instead of posting a new one. */
-  messageTs: z.string().optional(),
-  /** When true, the daemon generates Block Kit blocks from the text before delivery. */
   useBlocks: z.boolean().optional(),
-  /** When provided, add or remove an emoji reaction on a message. */
+  /**
+   * Add or remove an emoji reaction on a message.
+   *
+   * `messageTs` is Slack's identifier and is the reason this is not yet a
+   * channel-neutral field. It stays at the root because reactions are a
+   * capability several channels have, so the fix is a neutral message id
+   * rather than a move into the Slack extras.
+   */
   reaction: z
     .object({
       action: z.enum(["add", "remove"]),
@@ -188,18 +98,8 @@ export const ChannelReplyPayloadSchema = z.object({
       messageTs: z.string(),
     })
     .optional(),
-  /** When provided, set or clear the Slack Assistants API thread status. */
-  assistantThreadStatus: z
-    .object({
-      channel: z.string(),
-      threadTs: z.string(),
-      status: z.string(),
-      /** Serialized to Slack as `loading_messages`. */
-      loadingMessages: z.array(z.string()).optional(),
-    })
-    .optional(),
-  /** When provided, perform one Slack streaming operation (start/append/stop). */
-  slackStream: SlackStreamOpSchema.optional(),
+  /** What a Slack reply carries that no other channel does. */
+  slack: SlackReplyExtrasSchema.optional(),
 });
 
 export type ChannelReplyPayload = z.infer<typeof ChannelReplyPayloadSchema>;

--- a/packages/gateway-client/src/slack-reply.ts
+++ b/packages/gateway-client/src/slack-reply.ts
@@ -1,0 +1,150 @@
+/**
+ * Slack's additions to the outbound reply contract.
+ *
+ * Channel-specific options live in a per-channel object on
+ * {@link ChannelReplyPayload} rather than at its root, so the root stays the
+ * set of fields every channel genuinely has. `outbound-contract.ts` composes
+ * them in by name; a plugin-contributed channel would need that composition to
+ * become a registry.
+ */
+
+import type { KnownBlock } from "@slack/types";
+import { z } from "zod";
+
+/**
+ * One task card in a Slack streamed plan. Mirrors the `task_update` chunk of
+ * the Slack streaming API: an ordered, status-bearing step the assistant is
+ * working through. `title` is capped at 256 characters by Slack.
+ *
+ * @see https://docs.slack.dev/reference/methods/chat.appendStream/
+ */
+export const SlackStreamTaskSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  status: z.enum(["pending", "in_progress", "complete", "error"]),
+  details: z.string().optional(),
+  output: z.string().optional(),
+});
+
+export type SlackStreamTask = z.infer<typeof SlackStreamTaskSchema>;
+
+/**
+ * A single Slack streaming operation, mapping directly onto the
+ * `chat.startStream` / `chat.appendStream` / `chat.stopStream` Web API methods.
+ *
+ * `start` opens a streamed reply on a thread and returns the stream `ts`;
+ * `append` adds markdown (and optional task cards) to that stream; `stop`
+ * finalizes it, optionally rendering rich Block Kit blocks below the streamed
+ * body. Blocks are only accepted on `stop` because during the stream Slack
+ * renders the `markdownText` natively.
+ *
+ * @see https://docs.slack.dev/reference/methods/chat.startStream/
+ * @see https://docs.slack.dev/reference/methods/chat.appendStream/
+ * @see https://docs.slack.dev/reference/methods/chat.stopStream/
+ */
+export const SlackStreamOpSchema = z
+  .discriminatedUnion("action", [
+    z.object({
+      action: z.literal("start"),
+      threadTs: z.string(),
+      markdownText: z.string().optional(),
+      taskDisplayMode: z.literal("plan").optional(),
+      /** Title of the plan block, serialized as a `plan_update` chunk. */
+      planTitle: z.string().optional(),
+      tasks: z.array(SlackStreamTaskSchema).optional(),
+      /**
+       * Slack user ID of the reader the stream targets. Required by
+       * `chat.startStream` when streaming into a channel; omitted for DMs.
+       */
+      recipientUserId: z.string().optional(),
+      /**
+       * Slack team ID the recipient belongs to. Required alongside
+       * `recipientUserId` when streaming into a channel; omitted for DMs.
+       */
+      recipientTeamId: z.string().optional(),
+    }),
+    z.object({
+      action: z.literal("append"),
+      streamTs: z.string(),
+      markdownText: z.string().optional(),
+      /** Title of the plan block, serialized as a `plan_update` chunk. */
+      planTitle: z.string().optional(),
+      tasks: z.array(SlackStreamTaskSchema).optional(),
+    }),
+    z.object({
+      action: z.literal("stop"),
+      streamTs: z.string(),
+      markdownText: z.string().optional(),
+      blocks: z.array(z.custom<KnownBlock>()).optional(),
+      /** Title of the plan block, serialized as a `plan_update` chunk. */
+      planTitle: z.string().optional(),
+      tasks: z.array(SlackStreamTaskSchema).optional(),
+    }),
+  ])
+  .superRefine((op, ctx) => {
+    // Slack requires either `markdown_text` or `chunks` on `start`/`append`; a
+    // task-only operation advances the plan block without new body text.
+    if (
+      (op.action === "start" || op.action === "append") &&
+      op.markdownText === undefined &&
+      op.tasks === undefined
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `${op.action} requires markdownText or tasks`,
+      });
+    }
+  });
+
+export type SlackStreamOp = z.infer<typeof SlackStreamOpSchema>;
+
+/**
+ * What a Slack reply carries that no other channel does.
+ *
+ * `messageTs` is Slack's own message identifier, so updating an existing
+ * message is expressed here rather than generically: another channel's edit
+ * would key on its own id type, and a shared field would have to be a bare
+ * string meaning something different per channel.
+ */
+export const SlackReplyExtrasSchema = z.object({
+  /** Pre-formatted Block Kit blocks. */
+  blocks: z.array(z.custom<KnownBlock>()).optional(),
+  /**
+   * When true, deliver via `chat.postEphemeral` so only the target `user`
+   * sees the message.
+   */
+  ephemeral: z.boolean().optional(),
+  /** Slack user ID. Required when `ephemeral` is true. */
+  user: z.string().optional(),
+  /** When provided, update this existing message instead of posting a new one. */
+  messageTs: z.string().optional(),
+  /** When provided, set or clear the Slack Assistants API thread status. */
+  assistantThreadStatus: z
+    .object({
+      channel: z.string(),
+      threadTs: z.string(),
+      status: z.string(),
+      /** Serialized to Slack as `loading_messages`. */
+      loadingMessages: z.array(z.string()).optional(),
+    })
+    .optional(),
+  /** When provided, perform one streaming operation (start/append/stop). */
+  stream: SlackStreamOpSchema.optional(),
+});
+
+export type SlackReplyExtras = z.infer<typeof SlackReplyExtrasSchema>;
+
+/**
+ * Address a Slack reply to one reader, so only that person sees it.
+ *
+ * `chat.postEphemeral` needs both the flag and the user the message is visible
+ * to, and a payload carrying one without the other fails at delivery. Taking
+ * the user as a required argument is what makes that pair unrepresentable
+ * apart.
+ */
+export function ephemeralTo(
+  user: string,
+  extras?: SlackReplyExtras,
+): SlackReplyExtras {
+  return { ...extras, ephemeral: true, user };
+}


### PR DESCRIPTION
## TL;DR

`ChannelReplyPayload` is the contract every channel delivers through, and nine of its fifteen fields belonged to Slack alone. Six move to a `slack` key. No behaviour changes: fields move, none are added or removed.

Part of LUM-3356. This is phase 0 of five, and the phase's remaining work (an email transport, then absorbing the callback params) follows in separate PRs.

## Why

The shared contract was Slack wearing a generic name:

* It imported `KnownBlock` from `@slack/types`.
* `ChannelTransport.streamReply` is documented as routed "when `payload.slackStream` is set".
* Of the five transports, the four non-Slack ones use only `chatId`, `text`, `attachments`, `approval` and `useBlocks`. Slack uses seven fields nothing else touches.

The cost is that there is no way to express "Discord has threads and reactions but not Block Kit". A channel either speaks Slack or leaves two thirds of the payload unused, which is what makes adding a channel feel like a fork rather than an implementation.

## What moved, and what deliberately did not

| Field | Where it lives now | Why |
| -- | -- | -- |
| `blocks`, `ephemeral`, `user`, `messageTs`, `assistantThreadStatus`, `stream` | `slack` | Slack-only in concept and in shape |
| `useBlocks` | root, unchanged | Already channel-neutral. The Telegram transport documents it as the "render richly" intent and honours it by degrading to plain text |
| `reaction` | root, unchanged | Reactions are a capability several channels have. Its `messageTs` key is Slack's, and neutralising that is phase 1's job, not a move into the Slack extras |

`reaction` staying put is deliberate rather than an oversight: LUM-3346 is actively adding Telegram reaction ingestion, and moving the field under `slack` now would have to be undone.

`slackStream` is renamed `stream` inside the namespace, since the prefix is redundant there.

## `ephemeralTo`

Fourteen call sites did `payload.ephemeral = true; payload.user = x;` as a pair. `chat.postEphemeral` needs both, and a payload carrying one without the other fails at delivery. They now call a helper that takes the user as a required argument, so the two cannot be set apart.

## Why this is safe

**Nothing persists this shape.** The rule that would otherwise apply here is the repo's backwards-compatibility requirement to ship a migration alongside a data-shape change, so this was the thing to check rather than assume. `channel-retry-sweep.ts` rebuilds its reply payload from the stored inbound event rather than deserialising a stored `ChannelReplyPayload`; no other path stores one. No migration is needed.

Verified: assistant and gateway both typecheck clean, lint and the pinned prettier are clean. Tests run in CI.

## One question for review

`assistant/CLAUDE.md` states that the CLI and daemon always ship together, so no version-skew shims are needed on that boundary. Nothing states the same for **gateway and daemon**, which is the boundary this contract crosses. I have treated them as co-released because they ship in one release, but that is an assumption the docs do not confirm. If it is wrong, this wants a transitional accept-both window rather than a straight move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40950" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->