### PR TITLE
feat(web): inline assistant switcher in the sidebar

### DIFF
--- a/clients/web/src/assistant/switch-service.test.ts
+++ b/clients/web/src/assistant/switch-service.test.ts
@@ -21,6 +21,7 @@ let selectedAssistant: { assistantId: string } | undefined = undefined;
 let removeFromLockfileResult: { ok: boolean; error?: string } = { ok: true };
 let connectPairedShouldThrow = false;
 let activeAssistantId: string | null = null;
+let localClient = false;
 
 // --- module mocks --- //
 
@@ -38,6 +39,7 @@ mock.module("@/lib/local-mode", () => ({
   getLockfileAssistant: (id: string) =>
     lockfileAssistants.find((a) => a.assistantId === id),
   getSelectedAssistant: () => selectedAssistant,
+  isLocalClient: () => localClient,
   isPairedAssistant: (a: { cloud?: string }) => a.cloud === "paired",
   loadLockfile: loadLockfileMock,
   removePairedAssistantFromLockfile: removePairedFromLockfileMock,
@@ -48,9 +50,15 @@ const connectPairedAssistantMock = mock(async (_id: string) => {
     throw new Error("guardian lease failed");
   }
 });
+const connectLocalAssistantMock = mock(async (_id: string) => {});
+const connectPlatformAssistantMock = mock(async (_id: string) => {});
 mock.module("@/stores/auth-store", () => ({
   useAuthStore: {
-    getState: () => ({ connectPairedAssistant: connectPairedAssistantMock }),
+    getState: () => ({
+      connectPairedAssistant: connectPairedAssistantMock,
+      connectLocalAssistant: connectLocalAssistantMock,
+      connectPlatformAssistant: connectPlatformAssistantMock,
+    }),
   },
 }));
 
@@ -77,9 +85,8 @@ mock.module("@/utils/routes", () => ({
   },
 }));
 
-const { removePairedAssistant, switchToAssistant } = await import(
-  "./switch-service"
-);
+const { removePairedAssistant, switchToAssistant, switchToResolvedAssistant } =
+  await import("./switch-service");
 
 beforeEach(() => {
   lockfileAssistants = [];
@@ -88,9 +95,12 @@ beforeEach(() => {
   removeFromLockfileResult = { ok: true };
   connectPairedShouldThrow = false;
   activeAssistantId = null;
+  localClient = false;
   removePairedFromLockfileMock.mockClear();
   loadLockfileMock.mockClear();
   connectPairedAssistantMock.mockClear();
+  connectLocalAssistantMock.mockClear();
+  connectPlatformAssistantMock.mockClear();
   setSelectedAssistantMock.mockClear();
   setActiveAssistantIdMock.mockClear();
 });
@@ -155,6 +165,81 @@ describe("switchToAssistant", () => {
     if (!outcome.ok) {
       expect(outcome.error).toBe("Failed to connect to the assistant.");
     }
+    expect(setSelectedAssistantMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("switchToResolvedAssistant", () => {
+  const resolved = (
+    overrides: Partial<
+      import("@/stores/resolved-assistants-store").ResolvedAssistant
+    > & { id: string },
+  ) => ({
+    isLocal: false,
+    isPlatformHosted: true,
+    isPaired: false,
+    ...overrides,
+  });
+
+  test("a paired entry connects through connectPairedAssistant", async () => {
+    await switchToResolvedAssistant(
+      resolved({
+        id: "pr1",
+        isPaired: true,
+        isLocal: false,
+        isPlatformHosted: false,
+      }),
+    );
+
+    expect(connectPairedAssistantMock).toHaveBeenCalledWith("pr1");
+    expect(connectLocalAssistantMock).not.toHaveBeenCalled();
+    expect(connectPlatformAssistantMock).not.toHaveBeenCalled();
+    expect(setSelectedAssistantMock).not.toHaveBeenCalled();
+  });
+
+  test("a local entry on a local client connects through connectLocalAssistant", async () => {
+    localClient = true;
+
+    await switchToResolvedAssistant(
+      resolved({ id: "lo1", isLocal: true, isPlatformHosted: false }),
+    );
+
+    expect(connectLocalAssistantMock).toHaveBeenCalledWith("lo1");
+    expect(connectPlatformAssistantMock).not.toHaveBeenCalled();
+    expect(setSelectedAssistantMock).not.toHaveBeenCalled();
+  });
+
+  test("a hub-listed local entry takes the platform path", async () => {
+    localClient = false;
+
+    await switchToResolvedAssistant(
+      resolved({ id: "lo2", isLocal: true, isPlatformHosted: false }),
+    );
+
+    expect(connectPlatformAssistantMock).toHaveBeenCalledWith("lo2");
+    expect(connectLocalAssistantMock).not.toHaveBeenCalled();
+  });
+
+  test("a platform-hosted entry takes the platform path", async () => {
+    await switchToResolvedAssistant(resolved({ id: "m1" }));
+
+    expect(connectPlatformAssistantMock).toHaveBeenCalledWith("m1");
+    expect(connectPairedAssistantMock).not.toHaveBeenCalled();
+  });
+
+  test("a failed connect rethrows for the caller to surface", async () => {
+    connectPairedShouldThrow = true;
+
+    await expect(
+      switchToResolvedAssistant(
+        resolved({
+          id: "pr1",
+          isPaired: true,
+          isLocal: false,
+          isPlatformHosted: false,
+        }),
+      ),
+    ).rejects.toThrow("guardian lease failed");
     expect(setSelectedAssistantMock).not.toHaveBeenCalled();
   });
 });

--- a/clients/web/src/assistant/switch-service.ts
+++ b/clients/web/src/assistant/switch-service.ts
@@ -2,12 +2,16 @@ import { setSelectedAssistant } from "@/assistant/selection";
 import {
   getLockfileAssistant,
   getSelectedAssistant,
+  isLocalClient,
   isPairedAssistant,
   loadLockfile,
   removePairedAssistantFromLockfile,
 } from "@/lib/local-mode";
 import { useAuthStore } from "@/stores/auth-store";
-import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+import {
+  useResolvedAssistantsStore,
+  type ResolvedAssistant,
+} from "@/stores/resolved-assistants-store";
 import { routes } from "@/utils/routes";
 
 /**
@@ -48,6 +52,34 @@ export async function switchToAssistant(
   }
   await setSelectedAssistant(assistantId);
   return { ok: true };
+}
+
+/**
+ * Switch to a resolved assistant through the connect entry its kind needs,
+ * mirroring the chooser screen's dispatch: a paired entry primes the
+ * host-authorized proxy, a local entry on a local client primes a gateway
+ * token for its gateway, and everything else (platform-hosted, or a
+ * hub-listed local entry reached through the platform) goes through the
+ * platform session path.
+ *
+ * Unlike {@link switchToAssistant}, which serves id-only host commands whose
+ * surfaces exclude local entries, this rethrows so UI callers can surface the
+ * failure. Every connect entry fails before the selection write, so a failed
+ * switch leaves the previous assistant intact.
+ */
+export async function switchToResolvedAssistant(
+  assistant: ResolvedAssistant,
+): Promise<void> {
+  const auth = useAuthStore.getState();
+  if (assistant.isPaired) {
+    await auth.connectPairedAssistant(assistant.id);
+    return;
+  }
+  if (assistant.isLocal && isLocalClient()) {
+    await auth.connectLocalAssistant(assistant.id);
+    return;
+  }
+  await auth.connectPlatformAssistant(assistant.id);
 }
 
 export type RemovePairedOutcome =

--- a/clients/web/src/assistant/use-switchable-assistants.test.tsx
+++ b/clients/web/src/assistant/use-switchable-assistants.test.tsx
@@ -11,17 +11,14 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, renderHook } from "@testing-library/react";
 
 let localClient = false;
+let remoteGatewayMode = false;
 mock.module("@/lib/local-mode", () => ({
   isLocalClient: () => localClient,
+  isRemoteGatewayMode: () => remoteGatewayMode,
   isLocalAssistant: (a: { cloud?: string }) =>
     a.cloud === "local" || a.cloud === "docker",
   isPairedAssistant: (a: { cloud?: string }) => a.cloud === "paired",
   isPlatformAssistant: (a: { cloud?: string }) => a.cloud === "vellum",
-}));
-
-let gatewayAuthMode = false;
-mock.module("@/lib/auth/gateway-session", () => ({
-  isGatewayAuthMode: () => gatewayAuthMode,
 }));
 
 let organizationId: string | null = "org-1";
@@ -68,7 +65,7 @@ function run() {
 
 beforeEach(() => {
   localClient = false;
-  gatewayAuthMode = false;
+  remoteGatewayMode = false;
   organizationId = "org-1";
   hasPlatformSession = true;
   seed([]);
@@ -104,8 +101,8 @@ describe("useSwitchableAssistants gate", () => {
     expect(run().canSwitch).toBe(true);
   });
 
-  test("gateway-auth mode closes it", () => {
-    gatewayAuthMode = true;
+  test("remote-gateway mode closes it", () => {
+    remoteGatewayMode = true;
     seed([platform("a1"), platform("a2")]);
 
     expect(run().canSwitch).toBe(false);

--- a/clients/web/src/assistant/use-switchable-assistants.test.tsx
+++ b/clients/web/src/assistant/use-switchable-assistants.test.tsx
@@ -1,0 +1,187 @@
+/**
+ * Tests for `useSwitchableAssistants`: the gate (flag pair + gateway-auth
+ * mode) and the list derivation (org validity, device reachability,
+ * per-kind accessibility, and the two-entry floor) the sidebar switcher
+ * renders from. The resolved-assistants and feature-flag stores are real;
+ * the environment probes around them are mocked per test.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { cleanup, renderHook } from "@testing-library/react";
+
+let localClient = false;
+mock.module("@/lib/local-mode", () => ({
+  isLocalClient: () => localClient,
+  isLocalAssistant: (a: { cloud?: string }) =>
+    a.cloud === "local" || a.cloud === "docker",
+  isPairedAssistant: (a: { cloud?: string }) => a.cloud === "paired",
+  isPlatformAssistant: (a: { cloud?: string }) => a.cloud === "vellum",
+}));
+
+let gatewayAuthMode = false;
+mock.module("@/lib/auth/gateway-session", () => ({
+  isGatewayAuthMode: () => gatewayAuthMode,
+}));
+
+let organizationId: string | null = "org-1";
+mock.module("@/stores/organization-store", () => ({
+  useRequestOrganizationId: () => organizationId,
+}));
+
+let hasPlatformSession = true;
+mock.module("@/stores/auth-store", () => ({
+  useHasPlatformSession: () => hasPlatformSession,
+}));
+
+const { useResolvedAssistantsStore } = await import(
+  "@/stores/resolved-assistants-store"
+);
+const { useClientFeatureFlagStore } = await import(
+  "@/stores/client-feature-flag-store"
+);
+const { useSwitchableAssistants } = await import(
+  "@/assistant/use-switchable-assistants"
+);
+
+import type { ResolvedAssistant } from "@/stores/resolved-assistants-store";
+
+const platform = (
+  id: string,
+  overrides: Partial<ResolvedAssistant> = {},
+): ResolvedAssistant => ({
+  id,
+  name: id,
+  isLocal: false,
+  isPlatformHosted: true,
+  isPaired: false,
+  ...overrides,
+});
+
+function seed(assistants: ResolvedAssistant[]): void {
+  useResolvedAssistantsStore.setState({ assistants, assistantsHydrated: true });
+}
+
+function run() {
+  return renderHook(() => useSwitchableAssistants()).result.current;
+}
+
+beforeEach(() => {
+  localClient = false;
+  gatewayAuthMode = false;
+  organizationId = "org-1";
+  hasPlatformSession = true;
+  seed([]);
+  useClientFeatureFlagStore.setState({
+    multiPlatformAssistant: false,
+    assistantSwitcher: true,
+  });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("useSwitchableAssistants gate", () => {
+  test("closed with both flags off, whatever the list holds", () => {
+    useClientFeatureFlagStore.setState({
+      multiPlatformAssistant: false,
+      assistantSwitcher: false,
+    });
+    seed([platform("a1"), platform("a2")]);
+
+    expect(run().canSwitch).toBe(false);
+  });
+
+  test("either flag alone opens it", () => {
+    seed([platform("a1"), platform("a2")]);
+    expect(run().canSwitch).toBe(true);
+
+    useClientFeatureFlagStore.setState({
+      multiPlatformAssistant: true,
+      assistantSwitcher: false,
+    });
+    expect(run().canSwitch).toBe(true);
+  });
+
+  test("gateway-auth mode closes it", () => {
+    gatewayAuthMode = true;
+    seed([platform("a1"), platform("a2")]);
+
+    expect(run().canSwitch).toBe(false);
+  });
+
+  test("a single switchable assistant is not enough", () => {
+    seed([platform("a1")]);
+
+    expect(run().canSwitch).toBe(false);
+  });
+});
+
+describe("useSwitchableAssistants list", () => {
+  test("cross-org platform entries are dropped", () => {
+    seed([
+      platform("a1", { organizationId: "org-1" }),
+      platform("a2", { organizationId: "org-2" }),
+    ]);
+
+    const { assistants, canSwitch } = run();
+    expect(assistants.map((a) => a.id)).toEqual(["a1"]);
+    expect(canSwitch).toBe(false);
+  });
+
+  test("an unreachable local registration is dropped", () => {
+    seed([
+      platform("a1"),
+      platform("lo1", {
+        isLocal: true,
+        isPlatformHosted: false,
+        cloud: undefined,
+        ingressUrl: null,
+      }),
+    ]);
+
+    expect(run().assistants.map((a) => a.id)).toEqual(["a1"]);
+  });
+
+  test("without a platform session only paired entries survive", () => {
+    hasPlatformSession = false;
+    seed([
+      platform("a1"),
+      platform("pr1", {
+        isPaired: true,
+        isPlatformHosted: false,
+        cloud: "paired",
+      }),
+    ]);
+
+    const { assistants, canSwitch } = run();
+    expect(assistants.map((a) => a.id)).toEqual(["pr1"]);
+    expect(canSwitch).toBe(false);
+  });
+
+  test("local entries count only on a local client, with no org required", () => {
+    hasPlatformSession = false;
+    organizationId = null;
+    const locals = [
+      platform("lo1", {
+        isLocal: true,
+        isPlatformHosted: false,
+        cloud: "local",
+      }),
+      platform("lo2", {
+        isLocal: true,
+        isPlatformHosted: false,
+        cloud: "local",
+      }),
+    ];
+    seed(locals);
+
+    expect(run().canSwitch).toBe(false);
+
+    localClient = true;
+    const { assistants, canSwitch } = run();
+    expect(assistants.map((a) => a.id)).toEqual(["lo1", "lo2"]);
+    expect(canSwitch).toBe(true);
+  });
+});

--- a/clients/web/src/assistant/use-switchable-assistants.ts
+++ b/clients/web/src/assistant/use-switchable-assistants.ts
@@ -1,0 +1,60 @@
+/**
+ * The assistants the sidebar's ambient switcher can offer, and whether the
+ * switcher affordance should render at all.
+ *
+ * The list mirrors the chooser screen's derivation: org-valid entries with a
+ * transport from this device, kept only where a switch can actually succeed
+ * (a paired entry is session-free, a local entry needs a local client, and
+ * everything else needs the platform session). The gate reuses the flag pair
+ * `useGatedSelectedAssistantId` honors, multi-platform-assistant or
+ * assistant-switcher, and closes in gateway-auth mode, where the selection is
+ * not this client's to change. Unlike that hook it does not require an org
+ * id: a flag-on local client with two local assistants must still switch,
+ * and `assistantsValidForOrg` passes org-less entries regardless.
+ */
+
+import { useMemo } from "react";
+
+import { isGatewayAuthMode } from "@/lib/auth/gateway-session";
+import { isLocalClient } from "@/lib/local-mode";
+import { useHasPlatformSession } from "@/stores/auth-store";
+import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
+import { useRequestOrganizationId } from "@/stores/organization-store";
+import {
+  assistantsValidForOrg,
+  isConnectableFromThisDevice,
+  useResolvedAssistantsStore,
+  type ResolvedAssistant,
+} from "@/stores/resolved-assistants-store";
+
+export interface SwitchableAssistants {
+  /** Org-valid, reachable, accessible entries, the active one included. */
+  assistants: ResolvedAssistant[];
+  /** Whether the switcher should render: gate open and two or more entries. */
+  canSwitch: boolean;
+}
+
+export function useSwitchableAssistants(): SwitchableAssistants {
+  const multiPlatformAssistant =
+    useClientFeatureFlagStore.use.multiPlatformAssistant();
+  const assistantSwitcher = useClientFeatureFlagStore.use.assistantSwitcher();
+  const organizationId = useRequestOrganizationId();
+  const allAssistants = useResolvedAssistantsStore.use.assistants();
+  const hasPlatformSession = useHasPlatformSession();
+  const localClient = isLocalClient();
+
+  const gateOpen =
+    (multiPlatformAssistant || assistantSwitcher) && !isGatewayAuthMode();
+
+  const assistants = useMemo(
+    () =>
+      assistantsValidForOrg(allAssistants, organizationId)
+        .filter(isConnectableFromThisDevice)
+        .filter(
+          (a) => a.isPaired || (a.isLocal && localClient) || hasPlatformSession,
+        ),
+    [allAssistants, organizationId, localClient, hasPlatformSession],
+  );
+
+  return { assistants, canSwitch: gateOpen && assistants.length >= 2 };
+}

--- a/clients/web/src/assistant/use-switchable-assistants.ts
+++ b/clients/web/src/assistant/use-switchable-assistants.ts
@@ -7,16 +7,19 @@
  * (a paired entry is session-free, a local entry needs a local client, and
  * everything else needs the platform session). The gate reuses the flag pair
  * `useGatedSelectedAssistantId` honors, multi-platform-assistant or
- * assistant-switcher, and closes in gateway-auth mode, where the selection is
- * not this client's to change. Unlike that hook it does not require an org
- * id: a flag-on local client with two local assistants must still switch,
- * and `assistantsValidForOrg` passes org-less entries regardless.
+ * assistant-switcher, but deliberately deviates from it twice: it closes
+ * only in remote-gateway mode (a served single-assistant session, where the
+ * selection is not this client's to change) rather than in every
+ * gateway-authenticated session, since a local or paired session holds a
+ * gateway token too and is exactly where local switching works; and it does
+ * not require an org id, since a flag-on local client with two local
+ * assistants must still switch and `assistantsValidForOrg` passes org-less
+ * entries regardless.
  */
 
 import { useMemo } from "react";
 
-import { isGatewayAuthMode } from "@/lib/auth/gateway-session";
-import { isLocalClient } from "@/lib/local-mode";
+import { isLocalClient, isRemoteGatewayMode } from "@/lib/local-mode";
 import { useHasPlatformSession } from "@/stores/auth-store";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import { useRequestOrganizationId } from "@/stores/organization-store";
@@ -44,7 +47,7 @@ export function useSwitchableAssistants(): SwitchableAssistants {
   const localClient = isLocalClient();
 
   const gateOpen =
-    (multiPlatformAssistant || assistantSwitcher) && !isGatewayAuthMode();
+    (multiPlatformAssistant || assistantSwitcher) && !isRemoteGatewayMode();
 
   const assistants = useMemo(
     () =>

--- a/clients/web/src/domains/chat/components/assistant-nav-item.test.tsx
+++ b/clients/web/src/domains/chat/components/assistant-nav-item.test.tsx
@@ -107,6 +107,57 @@ describe("AssistantNavItem leading slot", () => {
   });
 });
 
+describe("AssistantNavItem switcher slots", () => {
+  const TRAILING = createElement(
+    "span",
+    { "data-testid": "switcher-chevron" },
+    "v",
+  );
+  const EXPANSION = createElement(
+    "div",
+    { "data-testid": "switcher-card" },
+    "card",
+  );
+
+  function renderWithSlots(
+    props: Partial<Parameters<typeof AssistantNavItem>[0]> = {},
+  ): string {
+    return renderToStaticMarkup(
+      createElement(AssistantNavItem, {
+        assistantId: "a1",
+        label: "Haze II",
+        active: false,
+        onSelect: () => {},
+        onNewConversation: () => {},
+        ...props,
+      }),
+    );
+  }
+
+  test("a trailing action renders inside the expanded pill", () => {
+    const html = renderWithSlots({ trailingAction: TRAILING });
+    expect(html).toContain('data-testid="switcher-chevron"');
+  });
+
+  test("the collapsed tile has no slot for the trailing action", () => {
+    const html = renderWithSlots({ trailingAction: TRAILING, collapsed: true });
+    expect(html).not.toContain('data-testid="switcher-chevron"');
+  });
+
+  test("an expansion replaces the pill and keeps the New Chat row", () => {
+    const html = renderWithSlots({ expansion: EXPANSION });
+    expect(html).toContain('data-testid="switcher-card"');
+    expect(html).not.toContain('data-tour-id="assistant-page"');
+    expect(html).toContain(">New Chat<");
+  });
+
+  test("the collapsed tile ignores an expansion", () => {
+    const html = renderWithSlots({ expansion: EXPANSION, collapsed: true });
+    expect(html).not.toContain('data-testid="switcher-card"');
+    expect(html).toContain('data-tour-id="assistant-page"');
+  });
+});
+
 describe("AssistantNavItem New Chat shortcut tooltip", () => {
   function renderNewChat(collapsed = false): string {
     return renderToStaticMarkup(

--- a/clients/web/src/domains/chat/components/assistant-nav-item.test.tsx
+++ b/clients/web/src/domains/chat/components/assistant-nav-item.test.tsx
@@ -137,6 +137,12 @@ describe("AssistantNavItem switcher slots", () => {
   test("a trailing action renders inside the expanded pill", () => {
     const html = renderWithSlots({ trailingAction: TRAILING });
     expect(html).toContain('data-testid="switcher-chevron"');
+    expect(html).toContain("gap-[12px]");
+  });
+
+  test("without a trailing action the pill keeps its default gap", () => {
+    const html = renderWithSlots();
+    expect(html).not.toContain("gap-[12px]");
   });
 
   test("the collapsed tile has no slot for the trailing action", () => {

--- a/clients/web/src/domains/chat/components/assistant-nav-item.tsx
+++ b/clients/web/src/domains/chat/components/assistant-nav-item.tsx
@@ -30,7 +30,13 @@
 
 import { SIDEBAR_STACK_GAP } from "@/components/sidebar-nav-geometry";
 import { Brain, Plus } from "lucide-react";
-import { useEffect, useMemo, useState, type ReactElement } from "react";
+import {
+  useEffect,
+  useMemo,
+  useState,
+  type ReactElement,
+  type ReactNode,
+} from "react";
 import { motion, useAnimationControls, useReducedMotion } from "motion/react";
 
 import {
@@ -99,6 +105,18 @@ interface AssistantNavItemProps {
   onSelect?: () => void;
   /** Renders the "New Chat" row below the assistant row. */
   onNewConversation?: () => void;
+  /**
+   * Trailing control inside the expanded pill (the switcher's chevron). The
+   * collapsed rail's tile has no slot for it, and the tour suppresses it with
+   * the rest of the identity treatment.
+   */
+  trailingAction?: ReactNode;
+  /**
+   * Replaces the assistant row entirely (the switcher's expanded card),
+   * leaving the New Chat row in place beneath. Ignored on the collapsed rail
+   * and while the tour owns the nav.
+   */
+  expansion?: ReactNode;
 }
 
 export function AssistantNavItem({
@@ -108,6 +126,8 @@ export function AssistantNavItem({
   collapsed = false,
   onSelect,
   onNewConversation,
+  trailingAction,
+  expansion,
 }: AssistantNavItemProps) {
   const { components, traits, customImageUrl } =
     useAssistantAvatar(assistantId);
@@ -308,6 +328,14 @@ export function AssistantNavItem({
      rather than a boolean, so each render site has the value it needs. */
   const uploadedAvatarUrl = navTourActive ? null : customImageUrl;
 
+  /* The switcher's affordances follow the identity treatment: the collapsed
+     tile has no slot for a trailing control, and the tour's drained nav must
+     not carry a live switcher. */
+  const pillTrailingAction =
+    !collapsed && !navTourActive ? trailingAction : undefined;
+  const activeExpansion =
+    !collapsed && !navTourActive ? (expansion ?? null) : null;
+
   const avatarImage =
     uploadedAvatarUrl !== null ? (
       <span
@@ -383,15 +411,18 @@ export function AssistantNavItem({
              the pill wears its plain surface. Same component and same
              geometry as the tinted one below: the colour is the only
              difference between them. */
-          <PanelItem
-            shape="pill"
-            icon={Brain}
-            leadingSlot={avatarImage ?? undefined}
-            label={label}
-            active={active}
-            onSelect={onSelect}
-            data-tour-id="assistant-page"
-          />
+          (activeExpansion ?? (
+            <PanelItem
+              shape="pill"
+              icon={Brain}
+              leadingSlot={avatarImage ?? undefined}
+              label={label}
+              active={active}
+              onSelect={onSelect}
+              trailingAction={pillTrailingAction}
+              data-tour-id="assistant-page"
+            />
+          ))
         )}
         {newConversationRow}
       </div>
@@ -526,6 +557,7 @@ export function AssistantNavItem({
         label={label}
         active={active}
         onSelect={onSelect}
+        trailingAction={pillTrailingAction}
         data-tour-id="assistant-page"
       />
     </span>
@@ -533,7 +565,7 @@ export function AssistantNavItem({
 
   return (
     <div className={cn("flex flex-col", SIDEBAR_STACK_GAP)}>
-      {assistantRow}
+      {activeExpansion ?? assistantRow}
       {newConversationRow}
     </div>
   );

--- a/clients/web/src/domains/chat/components/assistant-nav-item.tsx
+++ b/clients/web/src/domains/chat/components/assistant-nav-item.tsx
@@ -335,6 +335,7 @@ export function AssistantNavItem({
     !collapsed && !navTourActive ? trailingAction : undefined;
   const activeExpansion =
     !collapsed && !navTourActive ? (expansion ?? null) : null;
+  const pillGapClass = pillTrailingAction ? "gap-[12px]" : undefined;
 
   const avatarImage =
     uploadedAvatarUrl !== null ? (
@@ -420,6 +421,7 @@ export function AssistantNavItem({
               active={active}
               onSelect={onSelect}
               trailingAction={pillTrailingAction}
+              className={pillGapClass}
               data-tour-id="assistant-page"
             />
           ))
@@ -558,6 +560,7 @@ export function AssistantNavItem({
         active={active}
         onSelect={onSelect}
         trailingAction={pillTrailingAction}
+        className={pillGapClass}
         data-tour-id="assistant-page"
       />
     </span>

--- a/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
@@ -18,6 +18,7 @@ import { act, cleanup, render, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
+import * as reactRouter from "react-router";
 
 import {
   SIDEBAR_SECTION_MAX_HEIGHT,
@@ -27,6 +28,14 @@ import {
 mock.module("@/hooks/use-is-mobile", () => ({
   useIsMobile: () => false,
   MOBILE_MEDIA_QUERY: "(max-width: 767px)",
+}));
+
+/* `AssistantSwitcher` (inside `SideMenuBuiltInNav`) navigates after a
+   successful switch, and its hook runs on every sidebar render; these tests
+   mount no router, so hand it a no-op. */
+mock.module("react-router", () => ({
+  ...reactRouter,
+  useNavigate: () => () => {},
 }));
 
 // The sidebar owns its Background/Scheduled lazy queries; stub both so static

--- a/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
@@ -30,12 +30,13 @@ mock.module("@/hooks/use-is-mobile", () => ({
   MOBILE_MEDIA_QUERY: "(max-width: 767px)",
 }));
 
-/* `AssistantSwitcher` (inside `SideMenuBuiltInNav`) navigates after a
-   successful switch, and its hook runs on every sidebar render; these tests
-   mount no router, so hand it a no-op. */
+/* `AssistantSwitcher` (inside `SideMenuBuiltInNav`) reads the route and
+   navigates after a successful switch, and its hooks run on every sidebar
+   render; these tests mount no router, so hand it no-ops. */
 mock.module("react-router", () => ({
   ...reactRouter,
   useNavigate: () => () => {},
+  useLocation: () => ({ pathname: "/assistant", search: "", hash: "" }),
 }));
 
 // The sidebar owns its Background/Scheduled lazy queries; stub both so static

--- a/clients/web/src/domains/chat/components/assistant-switcher-row.tsx
+++ b/clients/web/src/domains/chat/components/assistant-switcher-row.tsx
@@ -24,6 +24,13 @@ interface AssistantSwitcherRowProps {
   disabled?: boolean;
   /** A switch to this row is in flight; shows a spinner beside the name. */
   switching?: boolean;
+  /**
+   * This assistant's own avatar-state-manifest capability, resolved from
+   * ITS version: a sibling can run an older runtime than the active
+   * assistant the default gate reads. `undefined` keeps the active gate
+   * (the current row).
+   */
+  supportsAvatarManifest?: boolean;
   trailingAction?: ReactNode;
   onSelect: () => void;
 }
@@ -34,12 +41,15 @@ export function AssistantSwitcherRow({
   isCurrent = false,
   disabled = false,
   switching = false,
+  supportsAvatarManifest,
   trailingAction,
   onSelect,
 }: AssistantSwitcherRowProps) {
   const { t } = useTranslation("chat");
-  const { components, traits, customImageUrl } =
-    useAssistantAvatar(assistantId);
+  const { components, traits, customImageUrl } = useAssistantAvatar(
+    assistantId,
+    { supportsManifest: supportsAvatarManifest },
+  );
 
   const label = isCurrent ? (
     <span className="flex min-w-0 items-center gap-2">

--- a/clients/web/src/domains/chat/components/assistant-switcher-row.tsx
+++ b/clients/web/src/domains/chat/components/assistant-switcher-row.tsx
@@ -1,0 +1,89 @@
+/**
+ * One assistant in the switcher's expanded card (Figma 7984:9239): the full
+ * avatar beside the name, with the current entry carrying a positive check
+ * inline after its label and the card's collapse control in its trailing
+ * slot. Presentational: the switcher decides what selecting a row does.
+ */
+
+import { Check, Loader2 } from "lucide-react";
+import type { ReactNode } from "react";
+import { useTranslation } from "react-i18next";
+
+import { PanelItem, type CustomPropertyStyle } from "@vellumai/design-library";
+
+import { ChatAvatar } from "@/components/avatar/chat-avatar";
+import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
+
+/* The 32px avatar outgrows the icon the row's default gap was tuned for. */
+const ROW_STYLE: CustomPropertyStyle = { "--panel-item-gap": "8px" };
+
+interface AssistantSwitcherRowProps {
+  assistantId: string | null;
+  name: string;
+  isCurrent?: boolean;
+  disabled?: boolean;
+  /** A switch to this row is in flight; shows a spinner beside the name. */
+  switching?: boolean;
+  trailingAction?: ReactNode;
+  onSelect: () => void;
+}
+
+export function AssistantSwitcherRow({
+  assistantId,
+  name,
+  isCurrent = false,
+  disabled = false,
+  switching = false,
+  trailingAction,
+  onSelect,
+}: AssistantSwitcherRowProps) {
+  const { t } = useTranslation("chat");
+  const { components, traits, customImageUrl } =
+    useAssistantAvatar(assistantId);
+
+  const label = isCurrent ? (
+    <span className="flex min-w-0 items-center gap-2">
+      <span className="truncate">{name}</span>
+      <Check
+        aria-hidden
+        className="size-4 shrink-0 text-[var(--system-positive-strong)]"
+      />
+    </span>
+  ) : (
+    name
+  );
+
+  return (
+    <PanelItem
+      shape="row"
+      className="h-auto rounded-[12px] text-[var(--content-default)]"
+      leadingSlot={
+        <ChatAvatar
+          components={components}
+          traits={traits}
+          customImageUrl={customImageUrl}
+          size={32}
+        />
+      }
+      label={label}
+      aria-label={
+        isCurrent
+          ? t("assistantSwitcher.currentAssistant", { name })
+          : t("assistantSwitcher.switchTo", { name })
+      }
+      onSelect={onSelect}
+      disabled={disabled}
+      badgeBare
+      badge={
+        switching ? (
+          <Loader2
+            aria-hidden
+            className="size-4 animate-spin text-[var(--content-tertiary)]"
+          />
+        ) : undefined
+      }
+      trailingAction={trailingAction}
+      style={ROW_STYLE}
+    />
+  );
+}

--- a/clients/web/src/domains/chat/components/assistant-switcher-row.tsx
+++ b/clients/web/src/domains/chat/components/assistant-switcher-row.tsx
@@ -31,6 +31,13 @@ interface AssistantSwitcherRowProps {
    * (the current row).
    */
   supportsAvatarManifest?: boolean;
+  /**
+   * Whether this assistant's avatar can be fetched at all: a sibling
+   * behind a transport that cannot be addressed independently must not be
+   * asked, or the single active connection answers with the wrong
+   * assistant's avatar. `false` renders the fallback avatar.
+   */
+  avatarEnabled?: boolean;
   trailingAction?: ReactNode;
   onSelect: () => void;
 }
@@ -42,13 +49,14 @@ export function AssistantSwitcherRow({
   disabled = false,
   switching = false,
   supportsAvatarManifest,
+  avatarEnabled = true,
   trailingAction,
   onSelect,
 }: AssistantSwitcherRowProps) {
   const { t } = useTranslation("chat");
   const { components, traits, customImageUrl } = useAssistantAvatar(
     assistantId,
-    { supportsManifest: supportsAvatarManifest },
+    { supportsManifest: supportsAvatarManifest, enabled: avatarEnabled },
   );
 
   const label = isCurrent ? (

--- a/clients/web/src/domains/chat/components/assistant-switcher.stories.tsx
+++ b/clients/web/src/domains/chat/components/assistant-switcher.stories.tsx
@@ -6,7 +6,7 @@
  * assistants, the assistant-switcher flag, a live platform session, and a
  * query cache carrying one character avatar per entry; a story that seeds a
  * single assistant shows the affordance-free pill the short list collapses
- * to. The names mirror the mock so the states can be compared against it.
+ * to.
  */
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -30,15 +30,15 @@ function platformAssistant(id: string, name: string): ResolvedAssistant {
 }
 
 const ASSISTANTS: ResolvedAssistant[] = [
-  platformAssistant("asst-mel", "Mel Gibson"),
-  platformAssistant("asst-jimmy", "Jimmy Buckets"),
-  platformAssistant("asst-shqurte", "Shqurte Fejza"),
+  platformAssistant("asst-1", "Alice"),
+  platformAssistant("asst-2", "Bob"),
+  platformAssistant("asst-3", "Carol"),
 ];
 
 const TRAITS: Record<string, CharacterTraits> = {
-  "asst-mel": { bodyShape: "blob", eyeStyle: "curious", color: "teal" },
-  "asst-jimmy": { bodyShape: "star", eyeStyle: "goofy", color: "green" },
-  "asst-shqurte": { bodyShape: "burst", eyeStyle: "surprised", color: "pink" },
+  "asst-1": { bodyShape: "blob", eyeStyle: "curious", color: "teal" },
+  "asst-2": { bodyShape: "star", eyeStyle: "goofy", color: "green" },
+  "asst-3": { bodyShape: "burst", eyeStyle: "surprised", color: "pink" },
 };
 
 /* One client for every story: the seeds are per-assistant-id and the stories
@@ -65,7 +65,7 @@ function seedStores(assistants: ResolvedAssistant[]): void {
   useResolvedAssistantsStore.setState({
     assistants,
     assistantsHydrated: true,
-    activeAssistantId: "asst-mel",
+    activeAssistantId: "asst-1",
   });
   useClientFeatureFlagStore.setState({ assistantSwitcher: true });
   /* `useSwitchableAssistants` only counts platform entries where a platform
@@ -77,8 +77,8 @@ const meta: Meta<typeof AssistantSwitcher> = {
   title: "Chat/AssistantSwitcher",
   component: AssistantSwitcher,
   args: {
-    assistantId: "asst-mel",
-    label: "Mel Gibson",
+    assistantId: "asst-1",
+    label: "Alice",
     active: false,
     collapsed: false,
     onSelect: () => {},

--- a/clients/web/src/domains/chat/components/assistant-switcher.stories.tsx
+++ b/clients/web/src/domains/chat/components/assistant-switcher.stories.tsx
@@ -1,0 +1,120 @@
+/**
+ * Visual reference for the sidebar's assistant switcher (Figma 7984:9239).
+ *
+ * The switcher derives everything from stores: the switchable list, the flag
+ * gate, and each row's avatar. Every story therefore seeds the resolved
+ * assistants, the assistant-switcher flag, a live platform session, and a
+ * query cache carrying one character avatar per entry; a story that seeds a
+ * single assistant shows the affordance-free pill the short list collapses
+ * to. The names mirror the mock so the states can be compared against it.
+ */
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactElement } from "react";
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { AssistantSwitcher } from "@/domains/chat/components/assistant-switcher";
+import { avatarQueryKey, type AvatarData } from "@/hooks/use-assistant-avatar";
+import { useAuthStore } from "@/stores/auth-store";
+import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
+import {
+  useResolvedAssistantsStore,
+  type ResolvedAssistant,
+} from "@/stores/resolved-assistants-store";
+import type { CharacterTraits } from "@/types/avatar";
+import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
+
+function platformAssistant(id: string, name: string): ResolvedAssistant {
+  return { id, name, isLocal: false, isPlatformHosted: true, isPaired: false };
+}
+
+const ASSISTANTS: ResolvedAssistant[] = [
+  platformAssistant("asst-mel", "Mel Gibson"),
+  platformAssistant("asst-jimmy", "Jimmy Buckets"),
+  platformAssistant("asst-shqurte", "Shqurte Fejza"),
+];
+
+const TRAITS: Record<string, CharacterTraits> = {
+  "asst-mel": { bodyShape: "blob", eyeStyle: "curious", color: "teal" },
+  "asst-jimmy": { bodyShape: "star", eyeStyle: "goofy", color: "green" },
+  "asst-shqurte": { bodyShape: "burst", eyeStyle: "surprised", color: "pink" },
+};
+
+/* One client for every story: the seeds are per-assistant-id and the stories
+   share the ids. Both spellings of the key carry each avatar, since the hook
+   appends its manifest-support flag and a story cannot know which way that
+   resolves. */
+const AVATAR_CLIENT = (() => {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+  });
+  for (const [id, traits] of Object.entries(TRAITS)) {
+    for (const supportsManifest of [true, false]) {
+      client.setQueryData([...avatarQueryKey(id), supportsManifest], {
+        components: BUNDLED_COMPONENTS,
+        traits,
+        customImageUrl: null,
+      } satisfies AvatarData);
+    }
+  }
+  return client;
+})();
+
+function seedStores(assistants: ResolvedAssistant[]): void {
+  useResolvedAssistantsStore.setState({
+    assistants,
+    assistantsHydrated: true,
+    activeAssistantId: "asst-mel",
+  });
+  useClientFeatureFlagStore.setState({ assistantSwitcher: true });
+  /* `useSwitchableAssistants` only counts platform entries where a platform
+     session is live; a story has no session of its own. */
+  useAuthStore.setState({ platformSession: "present" });
+}
+
+const meta: Meta<typeof AssistantSwitcher> = {
+  title: "Chat/AssistantSwitcher",
+  component: AssistantSwitcher,
+  args: {
+    assistantId: "asst-mel",
+    label: "Mel Gibson",
+    active: false,
+    collapsed: false,
+    onSelect: () => {},
+    onNewConversation: () => {},
+  },
+  decorators: [
+    (Story: () => ReactElement) => {
+      seedStores(ASSISTANTS);
+      return (
+        <QueryClientProvider client={AVATAR_CLIENT}>
+          <div className="w-[280px] rounded-2xl bg-[var(--surface-base)] p-3">
+            <Story />
+          </div>
+        </QueryClientProvider>
+      );
+    },
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof AssistantSwitcher>;
+
+/** The resting pill with the switcher's chevron beside the name. */
+export const Default: Story = {};
+
+/** The expanded card: the current entry checked, the rest one tap away. */
+export const Expanded: Story = {
+  args: { defaultExpanded: true },
+};
+
+/** A single switchable assistant renders the plain pill, chevron-free. */
+export const SingleAssistant: Story = {
+  decorators: [
+    (Story: () => ReactElement) => {
+      seedStores(ASSISTANTS.slice(0, 1));
+      return <Story />;
+    },
+  ],
+};

--- a/clients/web/src/domains/chat/components/assistant-switcher.test.tsx
+++ b/clients/web/src/domains/chat/components/assistant-switcher.test.tsx
@@ -30,9 +30,15 @@ const OTHER: ResolvedAssistant = {
 };
 
 const navigateMock = mock((_to: string, _opts?: { replace?: boolean }) => {});
+const LOCATION = {
+  pathname: "/assistant/conversations/conv-old",
+  search: "",
+  hash: "",
+};
 mock.module("react-router", () => ({
   ...reactRouter,
   useNavigate: () => navigateMock,
+  useLocation: () => LOCATION,
 }));
 
 let switchable: { assistants: ResolvedAssistant[]; canSwitch: boolean } = {
@@ -200,9 +206,42 @@ describe("AssistantSwitcher expanded card", () => {
     expect(useConversationStore.getState().activeConversationId).toBe(
       "conv-old",
     );
+    /* The route the switch was attempted from comes back, not a
+       conversation URL invented from the store id. */
     expect(navigateMock.mock.calls.at(-1)).toEqual([
-      routes.conversation("conv-old"),
+      LOCATION.pathname,
       { replace: true },
     ]);
+  });
+
+  test("a mid-switch assistant publication still hands focus to the chevron", async () => {
+    let resolveSwitch: () => void = () => {};
+    switchMock.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSwitch = resolve;
+        }),
+    );
+    const { getByLabelText, queryByLabelText, rerender } = renderSwitcher();
+
+    fireEvent.click(getByLabelText("Switch assistant"));
+    fireEvent.click(getByLabelText("Switch to Bob"));
+
+    /* The selection publishes before the connect resolves: the new active
+       assistant re-renders the switcher and auto-collapses the card. */
+    rerender(
+      <AssistantSwitcher
+        assistantId="a2"
+        label="Bob"
+        active={false}
+        onSelect={() => {}}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(queryByLabelText("Hide assistants")).toBeNull();
+      expect(document.activeElement).toBe(getByLabelText("Switch assistant"));
+    });
+    resolveSwitch();
   });
 });

--- a/clients/web/src/domains/chat/components/assistant-switcher.test.tsx
+++ b/clients/web/src/domains/chat/components/assistant-switcher.test.tsx
@@ -1,0 +1,159 @@
+/**
+ * Tests for `AssistantSwitcher`: the chevron's visibility matrix (gate,
+ * entry count, collapsed rail), the expanded card's contents, and what a
+ * row selection does on success and on failure. The switchable list and the
+ * switch call are mocked; the identity pill renders for real around them.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+
+import type { ResolvedAssistant } from "@/stores/resolved-assistants-store";
+
+const CURRENT: ResolvedAssistant = {
+  id: "a1",
+  name: "Mel Gibson",
+  isLocal: false,
+  isPlatformHosted: true,
+  isPaired: false,
+};
+const OTHER: ResolvedAssistant = {
+  id: "a2",
+  name: "Jimmy Buckets",
+  isLocal: false,
+  isPlatformHosted: true,
+  isPaired: false,
+};
+
+let switchable: { assistants: ResolvedAssistant[]; canSwitch: boolean } = {
+  assistants: [],
+  canSwitch: false,
+};
+mock.module("@/assistant/use-switchable-assistants", () => ({
+  useSwitchableAssistants: () => switchable,
+}));
+
+const switchMock = mock(async (_assistant: ResolvedAssistant) => {});
+mock.module("@/assistant/switch-service", () => ({
+  switchToResolvedAssistant: switchMock,
+}));
+
+const captureErrorMock = mock(
+  (_error: unknown, _context?: Record<string, unknown>) => {},
+);
+mock.module("@/lib/sentry/capture-error", () => ({
+  captureError: captureErrorMock,
+}));
+
+mock.module("@/hooks/use-assistant-avatar", () => ({
+  useAssistantAvatar: () => ({
+    components: null,
+    traits: null,
+    customImageUrl: null,
+    isLoading: false,
+    invalidate: () => {},
+  }),
+}));
+
+const { AssistantSwitcher } = await import(
+  "@/domains/chat/components/assistant-switcher"
+);
+
+function renderSwitcher(
+  props: Partial<Parameters<typeof AssistantSwitcher>[0]> = {},
+) {
+  return render(
+    <AssistantSwitcher
+      assistantId="a1"
+      label="Mel Gibson"
+      active={false}
+      onSelect={() => {}}
+      {...props}
+    />,
+  );
+}
+
+beforeEach(() => {
+  switchable = { assistants: [CURRENT, OTHER], canSwitch: true };
+  switchMock.mockClear();
+  switchMock.mockImplementation(async () => {});
+  captureErrorMock.mockClear();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("AssistantSwitcher chevron visibility", () => {
+  test("no chevron when the gate is closed or the list is short", () => {
+    switchable = { assistants: [CURRENT], canSwitch: false };
+    const { queryByLabelText, getByText } = renderSwitcher();
+
+    expect(queryByLabelText("Switch assistant")).toBeNull();
+    expect(getByText("Mel Gibson")).toBeTruthy();
+  });
+
+  test("no chevron on the collapsed rail", () => {
+    const { queryByLabelText } = renderSwitcher({ collapsed: true });
+
+    expect(queryByLabelText("Switch assistant")).toBeNull();
+  });
+
+  test("two switchable assistants put the chevron on the pill", () => {
+    const { getByLabelText } = renderSwitcher();
+
+    const chevron = getByLabelText("Switch assistant");
+    expect(chevron.getAttribute("aria-expanded")).toBe("false");
+  });
+});
+
+describe("AssistantSwitcher expanded card", () => {
+  test("the chevron expands the card with the current entry checked and the rest listed", () => {
+    const { getByLabelText, getByText } = renderSwitcher();
+
+    fireEvent.click(getByLabelText("Switch assistant"));
+
+    expect(getByLabelText("Mel Gibson, current assistant")).toBeTruthy();
+    expect(getByText("Jimmy Buckets")).toBeTruthy();
+    const collapse = getByLabelText("Hide assistants");
+    expect(collapse.getAttribute("aria-expanded")).toBe("true");
+  });
+
+  test("the collapse control folds the card back to the pill", () => {
+    const { getByLabelText, queryByText } = renderSwitcher();
+
+    fireEvent.click(getByLabelText("Switch assistant"));
+    fireEvent.click(getByLabelText("Hide assistants"));
+
+    expect(queryByText("Jimmy Buckets")).toBeNull();
+  });
+
+  test("selecting a row switches and collapses on success", async () => {
+    const { getByLabelText, queryByText } = renderSwitcher();
+
+    fireEvent.click(getByLabelText("Switch assistant"));
+    fireEvent.click(getByLabelText("Switch to Jimmy Buckets"));
+
+    expect(switchMock).toHaveBeenCalledTimes(1);
+    expect(switchMock.mock.calls[0]?.[0]).toEqual(OTHER);
+    await waitFor(() => {
+      expect(queryByText("Jimmy Buckets")).toBeNull();
+    });
+  });
+
+  test("a failed switch reports, stays expanded for a retry", async () => {
+    switchMock.mockImplementation(async () => {
+      throw new Error("boom");
+    });
+    const { getByLabelText, getByText } = renderSwitcher();
+
+    fireEvent.click(getByLabelText("Switch assistant"));
+    fireEvent.click(getByLabelText("Switch to Jimmy Buckets"));
+
+    await waitFor(() => {
+      expect(captureErrorMock).toHaveBeenCalledTimes(1);
+    });
+    expect(getByText("Jimmy Buckets")).toBeTruthy();
+  });
+});

--- a/clients/web/src/domains/chat/components/assistant-switcher.test.tsx
+++ b/clients/web/src/domains/chat/components/assistant-switcher.test.tsx
@@ -223,14 +223,19 @@ describe("AssistantSwitcher expanded card", () => {
     fireEvent.click(getByLabelText("Switch assistant"));
     fireEvent.click(getByLabelText("Switch to Bob"));
 
-    expect(switchMock).toHaveBeenCalledTimes(1);
-    expect(switchMock.mock.calls[0]?.[0]).toEqual(OTHER);
-    expect(storeIdAtSwitch).toBeNull();
+    /* The synchronous half: store and route reset land before any await,
+       and the connect does not start until the navigation settles. */
+    expect(useConversationStore.getState().activeConversationId).toBeNull();
     expect(navigateMock.mock.calls[0]).toEqual([
       routes.assistant,
       { replace: true },
     ]);
+    expect(switchMock).not.toHaveBeenCalled();
+
     await flushSwitch();
+    expect(switchMock).toHaveBeenCalledTimes(1);
+    expect(switchMock.mock.calls[0]?.[0]).toEqual(OTHER);
+    expect(storeIdAtSwitch).toBeNull();
     expect(queryByText("Bob")).toBeNull();
     expect(useConversationStore.getState().activeConversationId).toBeNull();
   });

--- a/clients/web/src/domains/chat/components/assistant-switcher.test.tsx
+++ b/clients/web/src/domains/chat/components/assistant-switcher.test.tsx
@@ -7,7 +7,7 @@
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
-import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render } from "@testing-library/react";
 import * as reactRouter from "react-router";
 
 import { useConversationStore } from "@/stores/conversation-store";
@@ -122,6 +122,17 @@ afterEach(() => {
   cleanup();
 });
 
+/* Flush the switch handler's post-await continuation and the React commits
+   it queues. Deterministic where a polling waitFor is not: under CI load
+   the poll raced bun's per-test timeout and bled assertions into the next
+   test. */
+async function flushSwitch(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
 describe("AssistantSwitcher chevron visibility", () => {
   test("no chevron when the gate is closed or the list is short", () => {
     switchable = { assistants: [CURRENT], canSwitch: false };
@@ -170,15 +181,31 @@ describe("AssistantSwitcher expanded card", () => {
     const { getByLabelText } = renderSwitcher();
 
     fireEvent.click(getByLabelText("Switch assistant"));
-    const collapse = getByLabelText("Hide assistants");
-    await waitFor(() => {
-      expect(document.activeElement).toBe(collapse);
-    });
+    await flushSwitch();
+    expect(document.activeElement).toBe(getByLabelText("Hide assistants"));
 
-    fireEvent.click(collapse);
-    await waitFor(() => {
-      expect(document.activeElement).toBe(getByLabelText("Switch assistant"));
+    fireEvent.click(getByLabelText("Hide assistants"));
+    await flushSwitch();
+    expect(document.activeElement).toBe(getByLabelText("Switch assistant"));
+  });
+
+  test("a successful switch reports completion; a failed one does not", async () => {
+    const onSwitched = mock(() => {});
+    const { getByLabelText } = renderSwitcher({ onSwitched });
+
+    fireEvent.click(getByLabelText("Switch assistant"));
+    fireEvent.click(getByLabelText("Switch to Bob"));
+    await flushSwitch();
+    expect(onSwitched).toHaveBeenCalledTimes(1);
+
+    switchMock.mockImplementation(async () => {
+      throw new Error("boom");
     });
+    fireEvent.click(getByLabelText("Switch assistant"));
+    fireEvent.click(getByLabelText("Switch to Bob"));
+    await flushSwitch();
+    expect(captureErrorMock).toHaveBeenCalledTimes(1);
+    expect(onSwitched).toHaveBeenCalledTimes(1);
   });
 
   test("selecting a row resets the conversation before the connect, then collapses", async () => {
@@ -203,9 +230,8 @@ describe("AssistantSwitcher expanded card", () => {
       routes.assistant,
       { replace: true },
     ]);
-    await waitFor(() => {
-      expect(queryByText("Bob")).toBeNull();
-    });
+    await flushSwitch();
+    expect(queryByText("Bob")).toBeNull();
     expect(useConversationStore.getState().activeConversationId).toBeNull();
   });
 
@@ -219,9 +245,8 @@ describe("AssistantSwitcher expanded card", () => {
     fireEvent.click(getByLabelText("Switch assistant"));
     fireEvent.click(getByLabelText("Switch to Bob"));
 
-    await waitFor(() => {
-      expect(captureErrorMock).toHaveBeenCalledTimes(1);
-    });
+    await flushSwitch();
+    expect(captureErrorMock).toHaveBeenCalledTimes(1);
     expect(getByText("Bob")).toBeTruthy();
     expect(useConversationStore.getState().activeConversationId).toBe(
       "conv-old",
@@ -327,10 +352,11 @@ describe("AssistantSwitcher expanded card", () => {
       />,
     );
 
-    await waitFor(() => {
-      expect(queryByLabelText("Hide assistants")).toBeNull();
-      expect(document.activeElement).toBe(getByLabelText("Switch assistant"));
-    });
+    await flushSwitch();
+    expect(queryByLabelText("Hide assistants")).toBeNull();
+    expect(document.activeElement).toBe(getByLabelText("Switch assistant"));
+
     resolveSwitch();
+    await flushSwitch();
   });
 });

--- a/clients/web/src/domains/chat/components/assistant-switcher.test.tsx
+++ b/clients/web/src/domains/chat/components/assistant-switcher.test.tsx
@@ -8,23 +8,32 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import * as reactRouter from "react-router";
 
+import { useConversationStore } from "@/stores/conversation-store";
 import type { ResolvedAssistant } from "@/stores/resolved-assistants-store";
+import { routes } from "@/utils/routes";
 
 const CURRENT: ResolvedAssistant = {
   id: "a1",
-  name: "Mel Gibson",
+  name: "Alice",
   isLocal: false,
   isPlatformHosted: true,
   isPaired: false,
 };
 const OTHER: ResolvedAssistant = {
   id: "a2",
-  name: "Jimmy Buckets",
+  name: "Bob",
   isLocal: false,
   isPlatformHosted: true,
   isPaired: false,
 };
+
+const navigateMock = mock((_to: string, _opts?: { replace?: boolean }) => {});
+mock.module("react-router", () => ({
+  ...reactRouter,
+  useNavigate: () => navigateMock,
+}));
 
 let switchable: { assistants: ResolvedAssistant[]; canSwitch: boolean } = {
   assistants: [],
@@ -66,7 +75,7 @@ function renderSwitcher(
   return render(
     <AssistantSwitcher
       assistantId="a1"
-      label="Mel Gibson"
+      label="Alice"
       active={false}
       onSelect={() => {}}
       {...props}
@@ -79,6 +88,8 @@ beforeEach(() => {
   switchMock.mockClear();
   switchMock.mockImplementation(async () => {});
   captureErrorMock.mockClear();
+  navigateMock.mockClear();
+  useConversationStore.setState({ activeConversationId: null });
 });
 
 afterEach(() => {
@@ -91,7 +102,7 @@ describe("AssistantSwitcher chevron visibility", () => {
     const { queryByLabelText, getByText } = renderSwitcher();
 
     expect(queryByLabelText("Switch assistant")).toBeNull();
-    expect(getByText("Mel Gibson")).toBeTruthy();
+    expect(getByText("Alice")).toBeTruthy();
   });
 
   test("no chevron on the collapsed rail", () => {
@@ -114,8 +125,8 @@ describe("AssistantSwitcher expanded card", () => {
 
     fireEvent.click(getByLabelText("Switch assistant"));
 
-    expect(getByLabelText("Mel Gibson, current assistant")).toBeTruthy();
-    expect(getByText("Jimmy Buckets")).toBeTruthy();
+    expect(getByLabelText("Alice, current assistant")).toBeTruthy();
+    expect(getByText("Bob")).toBeTruthy();
     const collapse = getByLabelText("Hide assistants");
     expect(collapse.getAttribute("aria-expanded")).toBe("true");
   });
@@ -126,34 +137,47 @@ describe("AssistantSwitcher expanded card", () => {
     fireEvent.click(getByLabelText("Switch assistant"));
     fireEvent.click(getByLabelText("Hide assistants"));
 
-    expect(queryByText("Jimmy Buckets")).toBeNull();
+    expect(queryByText("Bob")).toBeNull();
   });
 
-  test("selecting a row switches and collapses on success", async () => {
+  test("selecting a row switches, collapses, and lands on the assistant route", async () => {
+    useConversationStore.setState({ activeConversationId: "conv-old" });
     const { getByLabelText, queryByText } = renderSwitcher();
 
     fireEvent.click(getByLabelText("Switch assistant"));
-    fireEvent.click(getByLabelText("Switch to Jimmy Buckets"));
+    fireEvent.click(getByLabelText("Switch to Bob"));
 
     expect(switchMock).toHaveBeenCalledTimes(1);
     expect(switchMock.mock.calls[0]?.[0]).toEqual(OTHER);
     await waitFor(() => {
-      expect(queryByText("Jimmy Buckets")).toBeNull();
+      expect(queryByText("Bob")).toBeNull();
+    });
+    /* The old assistant's conversation must not survive the switch: the
+       loader would otherwise request it from, and persist it against, the
+       new assistant (URL ids outrank everything, across assistants). */
+    expect(useConversationStore.getState().activeConversationId).toBeNull();
+    expect(navigateMock).toHaveBeenCalledWith(routes.assistant, {
+      replace: true,
     });
   });
 
-  test("a failed switch reports, stays expanded for a retry", async () => {
+  test("a failed switch reports, stays expanded, and stays put", async () => {
     switchMock.mockImplementation(async () => {
       throw new Error("boom");
     });
+    useConversationStore.setState({ activeConversationId: "conv-old" });
     const { getByLabelText, getByText } = renderSwitcher();
 
     fireEvent.click(getByLabelText("Switch assistant"));
-    fireEvent.click(getByLabelText("Switch to Jimmy Buckets"));
+    fireEvent.click(getByLabelText("Switch to Bob"));
 
     await waitFor(() => {
       expect(captureErrorMock).toHaveBeenCalledTimes(1);
     });
-    expect(getByText("Jimmy Buckets")).toBeTruthy();
+    expect(getByText("Bob")).toBeTruthy();
+    expect(useConversationStore.getState().activeConversationId).toBe(
+      "conv-old",
+    );
+    expect(navigateMock).not.toHaveBeenCalled();
   });
 });

--- a/clients/web/src/domains/chat/components/assistant-switcher.test.tsx
+++ b/clients/web/src/domains/chat/components/assistant-switcher.test.tsx
@@ -62,13 +62,21 @@ mock.module("@/lib/sentry/capture-error", () => ({
   captureError: captureErrorMock,
 }));
 
+let selfHostedIngressUrl: string | null = null;
+mock.module("@/lib/self-hosted/connection", () => ({
+  getSelfHostedIngressUrl: () => selfHostedIngressUrl,
+}));
+
 const avatarCalls: Array<
-  [string | null, { supportsManifest?: boolean } | undefined]
+  [
+    string | null,
+    { supportsManifest?: boolean; enabled?: boolean } | undefined,
+  ]
 > = [];
 mock.module("@/hooks/use-assistant-avatar", () => ({
   useAssistantAvatar: (
     id: string | null,
-    options?: { supportsManifest?: boolean },
+    options?: { supportsManifest?: boolean; enabled?: boolean },
   ) => {
     avatarCalls.push([id, options]);
     return {
@@ -106,6 +114,7 @@ beforeEach(() => {
   captureErrorMock.mockClear();
   navigateMock.mockClear();
   avatarCalls.length = 0;
+  selfHostedIngressUrl = null;
   useConversationStore.setState({ activeConversationId: null });
 });
 
@@ -257,6 +266,40 @@ describe("AssistantSwitcher expanded card", () => {
         ([id, o]) =>
           id === "a1" && o !== undefined && o.supportsManifest === undefined,
       ),
+    ).toBe(true);
+  });
+
+  test("sibling avatars fetch only through an addressable transport", () => {
+    const PAIRED: ResolvedAssistant = {
+      id: "a4",
+      name: "Dana",
+      isLocal: false,
+      isPlatformHosted: false,
+      isPaired: true,
+    };
+    switchable = { assistants: [CURRENT, OTHER, PAIRED], canSwitch: true };
+    const first = renderSwitcher();
+
+    fireEvent.click(first.getByLabelText("Switch assistant"));
+
+    /* A platform sibling routes by the id in the path; a paired sibling
+       has no per-id platform route and keeps the fallback avatar. */
+    expect(
+      avatarCalls.some(([id, o]) => id === "a2" && o?.enabled === true),
+    ).toBe(true);
+    expect(
+      avatarCalls.some(([id, o]) => id === "a4" && o?.enabled === false),
+    ).toBe(true);
+    first.unmount();
+
+    /* With a self-hosted ingress active, every daemon request is rewritten
+       to that one gateway: no sibling is addressable. */
+    selfHostedIngressUrl = "https://gateway.example.com/ingress";
+    avatarCalls.length = 0;
+    const second = renderSwitcher();
+    fireEvent.click(second.getByLabelText("Switch assistant"));
+    expect(
+      avatarCalls.some(([id, o]) => id === "a2" && o?.enabled === false),
     ).toBe(true);
   });
 

--- a/clients/web/src/domains/chat/components/assistant-switcher.test.tsx
+++ b/clients/web/src/domains/chat/components/assistant-switcher.test.tsx
@@ -27,6 +27,7 @@ const OTHER: ResolvedAssistant = {
   isLocal: false,
   isPlatformHosted: true,
   isPaired: false,
+  runtimeVersion: "0.9.0",
 };
 
 const navigateMock = mock((_to: string, _opts?: { replace?: boolean }) => {});
@@ -61,14 +62,23 @@ mock.module("@/lib/sentry/capture-error", () => ({
   captureError: captureErrorMock,
 }));
 
+const avatarCalls: Array<
+  [string | null, { supportsManifest?: boolean } | undefined]
+> = [];
 mock.module("@/hooks/use-assistant-avatar", () => ({
-  useAssistantAvatar: () => ({
-    components: null,
-    traits: null,
-    customImageUrl: null,
-    isLoading: false,
-    invalidate: () => {},
-  }),
+  useAssistantAvatar: (
+    id: string | null,
+    options?: { supportsManifest?: boolean },
+  ) => {
+    avatarCalls.push([id, options]);
+    return {
+      components: null,
+      traits: null,
+      customImageUrl: null,
+      isLoading: false,
+      invalidate: () => {},
+    };
+  },
 }));
 
 const { AssistantSwitcher } = await import(
@@ -95,6 +105,7 @@ beforeEach(() => {
   switchMock.mockImplementation(async () => {});
   captureErrorMock.mockClear();
   navigateMock.mockClear();
+  avatarCalls.length = 0;
   useConversationStore.setState({ activeConversationId: null });
 });
 
@@ -212,6 +223,41 @@ describe("AssistantSwitcher expanded card", () => {
       LOCATION.pathname,
       { replace: true },
     ]);
+  });
+
+  test("sibling avatars gate by the sibling's own runtime version", () => {
+    const OLD_SIBLING: ResolvedAssistant = {
+      id: "a3",
+      name: "Carol",
+      isLocal: false,
+      isPlatformHosted: true,
+      isPaired: false,
+      runtimeVersion: "0.5.0",
+    };
+    switchable = {
+      assistants: [CURRENT, OTHER, OLD_SIBLING],
+      canSwitch: true,
+    };
+    const { getByLabelText } = renderSwitcher();
+
+    fireEvent.click(getByLabelText("Switch assistant"));
+
+    /* Bob's 0.9.0 runtime serves the manifest; Carol's 0.5.0 predates it.
+       The current row carries no override, deferring to the active gate. */
+    expect(
+      avatarCalls.some(([id, o]) => id === "a2" && o?.supportsManifest === true),
+    ).toBe(true);
+    expect(
+      avatarCalls.some(
+        ([id, o]) => id === "a3" && o?.supportsManifest === false,
+      ),
+    ).toBe(true);
+    expect(
+      avatarCalls.some(
+        ([id, o]) =>
+          id === "a1" && o !== undefined && o.supportsManifest === undefined,
+      ),
+    ).toBe(true);
   });
 
   test("a mid-switch assistant publication still hands focus to the chevron", async () => {

--- a/clients/web/src/domains/chat/components/assistant-switcher.test.tsx
+++ b/clients/web/src/domains/chat/components/assistant-switcher.test.tsx
@@ -140,6 +140,21 @@ describe("AssistantSwitcher expanded card", () => {
     expect(queryByText("Bob")).toBeNull();
   });
 
+  test("toggling re-anchors keyboard focus on the counterpart chevron", async () => {
+    const { getByLabelText } = renderSwitcher();
+
+    fireEvent.click(getByLabelText("Switch assistant"));
+    const collapse = getByLabelText("Hide assistants");
+    await waitFor(() => {
+      expect(document.activeElement).toBe(collapse);
+    });
+
+    fireEvent.click(collapse);
+    await waitFor(() => {
+      expect(document.activeElement).toBe(getByLabelText("Switch assistant"));
+    });
+  });
+
   test("selecting a row resets the conversation before the connect, then collapses", async () => {
     useConversationStore.setState({ activeConversationId: "conv-old" });
     /* The reset must precede the connect: the selection publishes before

--- a/clients/web/src/domains/chat/components/assistant-switcher.test.tsx
+++ b/clients/web/src/domains/chat/components/assistant-switcher.test.tsx
@@ -140,8 +140,16 @@ describe("AssistantSwitcher expanded card", () => {
     expect(queryByText("Bob")).toBeNull();
   });
 
-  test("selecting a row switches, collapses, and lands on the assistant route", async () => {
+  test("selecting a row resets the conversation before the connect, then collapses", async () => {
     useConversationStore.setState({ activeConversationId: "conv-old" });
+    /* The reset must precede the connect: the selection publishes before
+       the connect promise resolves, and the loader would apply, and
+       persist, a still-mounted old conversation against the new
+       assistant. */
+    let storeIdAtSwitch: string | null = "unset";
+    switchMock.mockImplementation(async () => {
+      storeIdAtSwitch = useConversationStore.getState().activeConversationId;
+    });
     const { getByLabelText, queryByText } = renderSwitcher();
 
     fireEvent.click(getByLabelText("Switch assistant"));
@@ -149,19 +157,18 @@ describe("AssistantSwitcher expanded card", () => {
 
     expect(switchMock).toHaveBeenCalledTimes(1);
     expect(switchMock.mock.calls[0]?.[0]).toEqual(OTHER);
+    expect(storeIdAtSwitch).toBeNull();
+    expect(navigateMock.mock.calls[0]).toEqual([
+      routes.assistant,
+      { replace: true },
+    ]);
     await waitFor(() => {
       expect(queryByText("Bob")).toBeNull();
     });
-    /* The old assistant's conversation must not survive the switch: the
-       loader would otherwise request it from, and persist it against, the
-       new assistant (URL ids outrank everything, across assistants). */
     expect(useConversationStore.getState().activeConversationId).toBeNull();
-    expect(navigateMock).toHaveBeenCalledWith(routes.assistant, {
-      replace: true,
-    });
   });
 
-  test("a failed switch reports, stays expanded, and stays put", async () => {
+  test("a failed switch reports, stays expanded, and restores the conversation", async () => {
     switchMock.mockImplementation(async () => {
       throw new Error("boom");
     });
@@ -178,6 +185,9 @@ describe("AssistantSwitcher expanded card", () => {
     expect(useConversationStore.getState().activeConversationId).toBe(
       "conv-old",
     );
-    expect(navigateMock).not.toHaveBeenCalled();
+    expect(navigateMock.mock.calls.at(-1)).toEqual([
+      routes.conversation("conv-old"),
+      { replace: true },
+    ]);
   });
 });

--- a/clients/web/src/domains/chat/components/assistant-switcher.tsx
+++ b/clients/web/src/domains/chat/components/assistant-switcher.tsx
@@ -24,6 +24,7 @@ import { switchToResolvedAssistant } from "@/assistant/switch-service";
 import { useSwitchableAssistants } from "@/assistant/use-switchable-assistants";
 import { AssistantNavItem } from "@/domains/chat/components/assistant-nav-item";
 import { AssistantSwitcherRow } from "@/domains/chat/components/assistant-switcher-row";
+import { versionSupportsAvatarStateManifest } from "@/lib/backwards-compat/avatar-state-manifest";
 import { captureError } from "@/lib/sentry/capture-error";
 import { useConversationStore } from "@/stores/conversation-store";
 import type { ResolvedAssistant } from "@/stores/resolved-assistants-store";
@@ -218,6 +219,12 @@ export function AssistantSwitcher({
               name={assistant.name || t("assistantSwitcher.unnamedAssistant")}
               disabled={switching}
               switching={switchingId === assistant.id}
+              /* A sibling's avatar loads through ITS runtime's capability,
+                 not the active assistant's: the default gate would ask a
+                 pre-manifest sibling for /avatar/state it doesn't serve. */
+              supportsAvatarManifest={versionSupportsAvatarStateManifest(
+                assistant.runtimeVersion ?? assistant.currentReleaseVersion,
+              )}
               onSelect={() => void handleSwitch(assistant)}
             />
           ))}

--- a/clients/web/src/domains/chat/components/assistant-switcher.tsx
+++ b/clients/web/src/domains/chat/components/assistant-switcher.tsx
@@ -16,7 +16,7 @@ import { ChevronDown, ChevronUp } from "lucide-react";
 import { useEffect, useId, useRef, useState } from "react";
 import { motion, useReducedMotion } from "motion/react";
 import { useTranslation } from "react-i18next";
-import { useNavigate } from "react-router";
+import { useLocation, useNavigate } from "react-router";
 
 import { cn, toast } from "@vellumai/design-library";
 
@@ -53,10 +53,35 @@ export function AssistantSwitcher({
   const reduce = useReducedMotion();
   const listId = useId();
   const navigate = useNavigate();
+  const location = useLocation();
+
+  /* Toggling swaps the tree holding the focused chevron (pill vs card),
+     which unmounts it and drops keyboard focus on the document. Every
+     user-driven toggle bumps this request, and the effect re-anchors focus
+     on whichever chevron the commit mounted. A counter rather than a flag
+     keyed on `expanded`: the collapse racing a mid-switch publication (the
+     auto-collapse below) leaves `expanded` unchanged by the time the
+     success path runs, and a flag would then wait, stale, to steal focus
+     from an unrelated background collapse. */
+  const chevronRef = useRef<HTMLButtonElement | null>(null);
+  const [chevronFocusRequest, setChevronFocusRequest] = useState(0);
+  const requestChevronFocus = () => {
+    setChevronFocusRequest((count) => count + 1);
+  };
+  useEffect(() => {
+    if (chevronFocusRequest === 0) {
+      return;
+    }
+    chevronRef.current?.focus();
+  }, [chevronFocusRequest]);
 
   /* A completed switch, a shrinking list, and the rail collapsing all fold
      the card away: the pill (or the rail's tile) is the only resting state.
-     Skipped on mount so `defaultExpanded` survives its first render. */
+     Skipped on mount so `defaultExpanded` survives its first render. When
+     the fold is the target assistant publishing mid-switch it carries the
+     focus handoff a user toggle gets; a background fold never steals
+     focus. */
+  const switchingIdRef = useRef<string | null>(null);
   const mounted = useRef(false);
   useEffect(() => {
     if (!mounted.current) {
@@ -64,27 +89,10 @@ export function AssistantSwitcher({
       return;
     }
     setExpanded(false);
-  }, [assistantId, canSwitch, collapsed]);
-
-  /* Toggling swaps the tree holding the focused chevron (pill vs card),
-     which unmounts it and drops keyboard focus on the document. Re-anchor
-     focus on the counterpart chevron after a user-initiated toggle; the
-     auto-collapse effect above must never steal focus, so it leaves the
-     flag unset. */
-  const chevronRef = useRef<HTMLButtonElement | null>(null);
-  const focusChevronAfterToggle = useRef(false);
-  useEffect(() => {
-    if (!focusChevronAfterToggle.current) {
-      return;
+    if (switchingIdRef.current !== null) {
+      requestChevronFocus();
     }
-    focusChevronAfterToggle.current = false;
-    chevronRef.current?.focus();
-  }, [expanded]);
-
-  const setExpandedWithFocus = (next: boolean) => {
-    focusChevronAfterToggle.current = true;
-    setExpanded(next);
-  };
+  }, [assistantId, canSwitch, collapsed]);
 
   if (!canSwitch || collapsed) {
     return <AssistantNavItem {...props} />;
@@ -98,6 +106,7 @@ export function AssistantSwitcher({
       return;
     }
     setSwitchingId(assistant.id);
+    switchingIdRef.current = assistant.id;
     /* Leave the old assistant's conversation behind BEFORE the connect, not
        after it resolves: every connect path publishes the selection before
        its promise finishes, and the loader gives an explicit URL
@@ -109,11 +118,13 @@ export function AssistantSwitcher({
        chooser screen navigates to. */
     const previousConversationId =
       useConversationStore.getState().activeConversationId;
+    const previousPath = `${location.pathname}${location.search}${location.hash}`;
     useConversationStore.getState().setActiveConversationId(null);
     void navigate(routes.assistant, { replace: true });
     try {
       await switchToResolvedAssistant(assistant);
-      setExpandedWithFocus(false);
+      setExpanded(false);
+      requestChevronFocus();
       /* The old assistant's loader may have landed somewhere while the
          connect was in flight; sweep again so the new assistant resolves
          its own landing from a clean slate. */
@@ -122,20 +133,21 @@ export function AssistantSwitcher({
         void navigate(routes.assistant, { replace: true });
       }
     } catch (error) {
-      /* A failed connect leaves the previous assistant selected; put its
-         conversation back too. */
+      /* A failed connect leaves the previous assistant selected; put back
+         whatever route the switch was attempted from (a conversation, the
+         identity page, documents), not a conversation URL invented from the
+         store id, which persists across non-chat routes. */
       if (previousConversationId !== null) {
         useConversationStore
           .getState()
           .setActiveConversationId(previousConversationId);
-        void navigate(routes.conversation(previousConversationId), {
-          replace: true,
-        });
       }
+      void navigate(previousPath, { replace: true });
       captureError(error, { context: "assistantSwitcher.switch" });
       toast.error(t("assistantSwitcher.switchFailed"));
     } finally {
       setSwitchingId(null);
+      switchingIdRef.current = null;
     }
   };
 
@@ -146,7 +158,10 @@ export function AssistantSwitcher({
     <button
       ref={chevronRef}
       type="button"
-      onClick={() => setExpandedWithFocus(!expanded)}
+      onClick={() => {
+        setExpanded(!expanded);
+        requestChevronFocus();
+      }}
       aria-expanded={expanded}
       aria-controls={expanded ? listId : undefined}
       aria-label={
@@ -181,7 +196,10 @@ export function AssistantSwitcher({
         name={label}
         isCurrent
         disabled={switching}
-        onSelect={() => setExpandedWithFocus(false)}
+        onSelect={() => {
+          setExpanded(false);
+          requestChevronFocus();
+        }}
         trailingAction={chevronButton}
       />
       <motion.div

--- a/clients/web/src/domains/chat/components/assistant-switcher.tsx
+++ b/clients/web/src/domains/chat/components/assistant-switcher.tsx
@@ -26,6 +26,7 @@ import { AssistantNavItem } from "@/domains/chat/components/assistant-nav-item";
 import { AssistantSwitcherRow } from "@/domains/chat/components/assistant-switcher-row";
 import { versionSupportsAvatarStateManifest } from "@/lib/backwards-compat/avatar-state-manifest";
 import { captureError } from "@/lib/sentry/capture-error";
+import { getSelfHostedIngressUrl } from "@/lib/self-hosted/connection";
 import { useConversationStore } from "@/stores/conversation-store";
 import type { ResolvedAssistant } from "@/stores/resolved-assistants-store";
 import { routes } from "@/utils/routes";
@@ -187,6 +188,17 @@ export function AssistantSwitcher({
     </button>
   );
 
+  /* A sibling's avatar is only fetchable where the request can actually be
+     addressed to it: through the platform proxy, which routes by the id in
+     the path. With a self-hosted ingress active, the interceptor rewrites
+     every daemon request to that single gateway whatever id the path
+     carries, and it would answer with the ACTIVE assistant's avatar; a
+     local or paired sibling has no per-id platform route either. Those
+     rows keep the fallback avatar instead of showing a wrong one. */
+  const selfHostedActive = getSelfHostedIngressUrl() !== null;
+  const canFetchSiblingAvatar = (sibling: ResolvedAssistant) =>
+    sibling.isPlatformHosted && !selfHostedActive;
+
   const expansion = expanded ? (
     <div
       id={listId}
@@ -225,6 +237,7 @@ export function AssistantSwitcher({
               supportsAvatarManifest={versionSupportsAvatarStateManifest(
                 assistant.runtimeVersion ?? assistant.currentReleaseVersion,
               )}
+              avatarEnabled={canFetchSiblingAvatar(assistant)}
               onSelect={() => void handleSwitch(assistant)}
             />
           ))}

--- a/clients/web/src/domains/chat/components/assistant-switcher.tsx
+++ b/clients/web/src/domains/chat/components/assistant-switcher.tsx
@@ -130,8 +130,13 @@ export function AssistantSwitcher({
       useConversationStore.getState().activeConversationId;
     const previousPath = `${location.pathname}${location.search}${location.hash}`;
     useConversationStore.getState().setActiveConversationId(null);
-    void navigate(routes.assistant, { replace: true });
     try {
+      /* Awaited, not fired: the data router commits the URL change
+         asynchronously, and the connect must not start (and publish the
+         new selection) while the old conversation id is still mounted in
+         the route. Inside the try so an aborted navigation takes the same
+         restore path a failed connect does. */
+      await navigate(routes.assistant, { replace: true });
       await switchToResolvedAssistant(assistant);
       setExpanded(false);
       requestChevronFocus();

--- a/clients/web/src/domains/chat/components/assistant-switcher.tsx
+++ b/clients/web/src/domains/chat/components/assistant-switcher.tsx
@@ -1,0 +1,163 @@
+/**
+ * The sidebar's ambient assistant switcher (Figma 7984:9239). The identity
+ * pill gains a circular chevron when more than one assistant is reachable,
+ * and the chevron expands the pill in place into a lifted card listing every
+ * switchable assistant: the current one checked, the rest one tap from
+ * becoming the selection. Selecting switches through the kind-aware connect
+ * path and collapses back to the pill, which retints to the new assistant
+ * once the lifecycle republishes; the content area's assistant gate carries
+ * the loading state, so the sidebar stays put.
+ *
+ * With fewer than two switchable assistants, a closed flag gate, or the
+ * collapsed rail, it renders the plain `AssistantNavItem` untouched.
+ */
+
+import { ChevronDown, ChevronUp } from "lucide-react";
+import { useEffect, useId, useRef, useState } from "react";
+import { motion, useReducedMotion } from "motion/react";
+import { useTranslation } from "react-i18next";
+
+import { cn, toast } from "@vellumai/design-library";
+
+import { switchToResolvedAssistant } from "@/assistant/switch-service";
+import { useSwitchableAssistants } from "@/assistant/use-switchable-assistants";
+import { AssistantNavItem } from "@/domains/chat/components/assistant-nav-item";
+import { AssistantSwitcherRow } from "@/domains/chat/components/assistant-switcher-row";
+import { captureError } from "@/lib/sentry/capture-error";
+import type { ResolvedAssistant } from "@/stores/resolved-assistants-store";
+
+interface AssistantSwitcherProps {
+  assistantId: string | null;
+  label: string;
+  active: boolean;
+  collapsed?: boolean;
+  onSelect?: () => void;
+  /** Renders the "New Chat" row below the assistant row. */
+  onNewConversation?: () => void;
+  /** Mounts with the card open. Stories only; the app always starts closed. */
+  defaultExpanded?: boolean;
+}
+
+export function AssistantSwitcher({
+  defaultExpanded = false,
+  ...props
+}: AssistantSwitcherProps) {
+  const { assistantId, label, collapsed = false } = props;
+  const { t } = useTranslation("chat");
+  const { assistants, canSwitch } = useSwitchableAssistants();
+  const [expanded, setExpanded] = useState(defaultExpanded);
+  const [switchingId, setSwitchingId] = useState<string | null>(null);
+  const reduce = useReducedMotion();
+  const listId = useId();
+
+  /* A completed switch, a shrinking list, and the rail collapsing all fold
+     the card away: the pill (or the rail's tile) is the only resting state.
+     Skipped on mount so `defaultExpanded` survives its first render. */
+  const mounted = useRef(false);
+  useEffect(() => {
+    if (!mounted.current) {
+      mounted.current = true;
+      return;
+    }
+    setExpanded(false);
+  }, [assistantId, canSwitch, collapsed]);
+
+  if (!canSwitch || collapsed) {
+    return <AssistantNavItem {...props} />;
+  }
+
+  const others = assistants.filter((a) => a.id !== assistantId);
+  const switching = switchingId !== null;
+
+  const handleSwitch = async (assistant: ResolvedAssistant) => {
+    if (switching) {
+      return;
+    }
+    setSwitchingId(assistant.id);
+    try {
+      await switchToResolvedAssistant(assistant);
+      setExpanded(false);
+    } catch (error) {
+      captureError(error, { context: "assistantSwitcher.switch" });
+      toast.error(t("assistantSwitcher.switchFailed"));
+    } finally {
+      setSwitchingId(null);
+    }
+  };
+
+  /* White at a fifth over the pill's tint (and over the card's lift), via
+     currentColor so it stays legible on the light avatar hues whose pills
+     flip to a dark foreground. */
+  const chevronButton = (
+    <button
+      type="button"
+      onClick={() => setExpanded((value) => !value)}
+      aria-expanded={expanded}
+      aria-controls={expanded ? listId : undefined}
+      aria-label={
+        expanded
+          ? t("assistantSwitcher.collapse")
+          : t("assistantSwitcher.expand")
+      }
+      className={cn(
+        /* Touch keeps the mock's 36px target; the negative margin stops it
+           from growing the pill past the height its other children set. */
+        "flex size-6 shrink-0 cursor-pointer items-center justify-center rounded-full max-md:-my-2 max-md:size-9",
+        "bg-[color-mix(in_srgb,currentColor_20%,transparent)]",
+        "[@media(hover:hover)]:hover:bg-[color-mix(in_srgb,currentColor_30%,transparent)]",
+        "outline-none keyboard-focus:ring-2 keyboard-focus:ring-[var(--ring)]",
+      )}
+    >
+      {expanded ? (
+        <ChevronUp aria-hidden className="size-4" />
+      ) : (
+        <ChevronDown aria-hidden className="size-4" />
+      )}
+    </button>
+  );
+
+  const expansion = expanded ? (
+    <div
+      id={listId}
+      className="flex flex-col rounded-[18px] bg-[var(--surface-lift)] p-[6px]"
+    >
+      <AssistantSwitcherRow
+        assistantId={assistantId}
+        name={label}
+        isCurrent
+        disabled={switching}
+        onSelect={() => setExpanded(false)}
+        trailingAction={chevronButton}
+      />
+      <motion.div
+        className="overflow-hidden"
+        initial={reduce ? false : { height: 0, opacity: 0 }}
+        animate={{ height: "auto", opacity: 1 }}
+        transition={
+          reduce ? { duration: 0 } : { duration: 0.2, ease: "easeOut" }
+        }
+      >
+        <div className="flex flex-col">
+          {others.map((assistant) => (
+            <AssistantSwitcherRow
+              key={assistant.id}
+              assistantId={assistant.id}
+              name={assistant.name || t("assistantSwitcher.unnamedAssistant")}
+              disabled={switching}
+              switching={switchingId === assistant.id}
+              onSelect={() => void handleSwitch(assistant)}
+            />
+          ))}
+        </div>
+      </motion.div>
+    </div>
+  ) : null;
+
+  return (
+    <AssistantNavItem
+      {...props}
+      trailingAction={chevronButton}
+      expansion={expansion}
+    />
+  );
+}

--- a/clients/web/src/domains/chat/components/assistant-switcher.tsx
+++ b/clients/web/src/domains/chat/components/assistant-switcher.tsx
@@ -39,12 +39,20 @@ interface AssistantSwitcherProps {
   onSelect?: () => void;
   /** Renders the "New Chat" row below the assistant row. */
   onNewConversation?: () => void;
+  /**
+   * Called after a successful switch. The overlay drawer passes its close
+   * callback here so the switch reveals the new assistant, the way every
+   * other drawer row dismisses on selection; a failed switch keeps the
+   * drawer (and the card) open for a retry.
+   */
+  onSwitched?: () => void;
   /** Mounts with the card open. Stories only; the app always starts closed. */
   defaultExpanded?: boolean;
 }
 
 export function AssistantSwitcher({
   defaultExpanded = false,
+  onSwitched,
   ...props
 }: AssistantSwitcherProps) {
   const { assistantId, label, collapsed = false } = props;
@@ -134,6 +142,7 @@ export function AssistantSwitcher({
         useConversationStore.getState().setActiveConversationId(null);
         void navigate(routes.assistant, { replace: true });
       }
+      onSwitched?.();
     } catch (error) {
       /* A failed connect leaves the previous assistant selected; put back
          whatever route the switch was attempted from (a conversation, the

--- a/clients/web/src/domains/chat/components/assistant-switcher.tsx
+++ b/clients/web/src/domains/chat/components/assistant-switcher.tsx
@@ -78,19 +78,40 @@ export function AssistantSwitcher({
       return;
     }
     setSwitchingId(assistant.id);
+    /* Leave the old assistant's conversation behind BEFORE the connect, not
+       after it resolves: every connect path publishes the selection before
+       its promise finishes, and the loader gives an explicit URL
+       conversation id top priority even across an assistant switch, so a
+       reset deferred to the await races the loader applying, and
+       persisting, the old assistant's conversation against the new one.
+       Landing on the assistant route lets the loader resolve the new
+       assistant's own last-viewed conversation, the same landing the
+       chooser screen navigates to. */
+    const previousConversationId =
+      useConversationStore.getState().activeConversationId;
+    useConversationStore.getState().setActiveConversationId(null);
+    void navigate(routes.assistant, { replace: true });
     try {
       await switchToResolvedAssistant(assistant);
       setExpanded(false);
-      /* Leave the old assistant's conversation behind: the loader gives an
-         explicit URL conversation id top priority even across an assistant
-         switch, so an id left in the route (or the store, which the async
-         landing fallback defers to) would be requested from, and persisted
-         against, the new assistant. Landing on the assistant route lets the
-         loader resolve the new assistant's own last-viewed conversation,
-         the same landing the chooser screen navigates to. */
-      useConversationStore.getState().setActiveConversationId(null);
-      void navigate(routes.assistant, { replace: true });
+      /* The old assistant's loader may have landed somewhere while the
+         connect was in flight; sweep again so the new assistant resolves
+         its own landing from a clean slate. */
+      if (useConversationStore.getState().activeConversationId !== null) {
+        useConversationStore.getState().setActiveConversationId(null);
+        void navigate(routes.assistant, { replace: true });
+      }
     } catch (error) {
+      /* A failed connect leaves the previous assistant selected; put its
+         conversation back too. */
+      if (previousConversationId !== null) {
+        useConversationStore
+          .getState()
+          .setActiveConversationId(previousConversationId);
+        void navigate(routes.conversation(previousConversationId), {
+          replace: true,
+        });
+      }
       captureError(error, { context: "assistantSwitcher.switch" });
       toast.error(t("assistantSwitcher.switchFailed"));
     } finally {

--- a/clients/web/src/domains/chat/components/assistant-switcher.tsx
+++ b/clients/web/src/domains/chat/components/assistant-switcher.tsx
@@ -16,6 +16,7 @@ import { ChevronDown, ChevronUp } from "lucide-react";
 import { useEffect, useId, useRef, useState } from "react";
 import { motion, useReducedMotion } from "motion/react";
 import { useTranslation } from "react-i18next";
+import { useNavigate } from "react-router";
 
 import { cn, toast } from "@vellumai/design-library";
 
@@ -24,7 +25,9 @@ import { useSwitchableAssistants } from "@/assistant/use-switchable-assistants";
 import { AssistantNavItem } from "@/domains/chat/components/assistant-nav-item";
 import { AssistantSwitcherRow } from "@/domains/chat/components/assistant-switcher-row";
 import { captureError } from "@/lib/sentry/capture-error";
+import { useConversationStore } from "@/stores/conversation-store";
 import type { ResolvedAssistant } from "@/stores/resolved-assistants-store";
+import { routes } from "@/utils/routes";
 
 interface AssistantSwitcherProps {
   assistantId: string | null;
@@ -49,6 +52,7 @@ export function AssistantSwitcher({
   const [switchingId, setSwitchingId] = useState<string | null>(null);
   const reduce = useReducedMotion();
   const listId = useId();
+  const navigate = useNavigate();
 
   /* A completed switch, a shrinking list, and the rail collapsing all fold
      the card away: the pill (or the rail's tile) is the only resting state.
@@ -77,6 +81,15 @@ export function AssistantSwitcher({
     try {
       await switchToResolvedAssistant(assistant);
       setExpanded(false);
+      /* Leave the old assistant's conversation behind: the loader gives an
+         explicit URL conversation id top priority even across an assistant
+         switch, so an id left in the route (or the store, which the async
+         landing fallback defers to) would be requested from, and persisted
+         against, the new assistant. Landing on the assistant route lets the
+         loader resolve the new assistant's own last-viewed conversation,
+         the same landing the chooser screen navigates to. */
+      useConversationStore.getState().setActiveConversationId(null);
+      void navigate(routes.assistant, { replace: true });
     } catch (error) {
       captureError(error, { context: "assistantSwitcher.switch" });
       toast.error(t("assistantSwitcher.switchFailed"));

--- a/clients/web/src/domains/chat/components/assistant-switcher.tsx
+++ b/clients/web/src/domains/chat/components/assistant-switcher.tsx
@@ -66,6 +66,26 @@ export function AssistantSwitcher({
     setExpanded(false);
   }, [assistantId, canSwitch, collapsed]);
 
+  /* Toggling swaps the tree holding the focused chevron (pill vs card),
+     which unmounts it and drops keyboard focus on the document. Re-anchor
+     focus on the counterpart chevron after a user-initiated toggle; the
+     auto-collapse effect above must never steal focus, so it leaves the
+     flag unset. */
+  const chevronRef = useRef<HTMLButtonElement | null>(null);
+  const focusChevronAfterToggle = useRef(false);
+  useEffect(() => {
+    if (!focusChevronAfterToggle.current) {
+      return;
+    }
+    focusChevronAfterToggle.current = false;
+    chevronRef.current?.focus();
+  }, [expanded]);
+
+  const setExpandedWithFocus = (next: boolean) => {
+    focusChevronAfterToggle.current = true;
+    setExpanded(next);
+  };
+
   if (!canSwitch || collapsed) {
     return <AssistantNavItem {...props} />;
   }
@@ -93,7 +113,7 @@ export function AssistantSwitcher({
     void navigate(routes.assistant, { replace: true });
     try {
       await switchToResolvedAssistant(assistant);
-      setExpanded(false);
+      setExpandedWithFocus(false);
       /* The old assistant's loader may have landed somewhere while the
          connect was in flight; sweep again so the new assistant resolves
          its own landing from a clean slate. */
@@ -124,8 +144,9 @@ export function AssistantSwitcher({
      flip to a dark foreground. */
   const chevronButton = (
     <button
+      ref={chevronRef}
       type="button"
-      onClick={() => setExpanded((value) => !value)}
+      onClick={() => setExpandedWithFocus(!expanded)}
       aria-expanded={expanded}
       aria-controls={expanded ? listId : undefined}
       aria-label={
@@ -160,7 +181,7 @@ export function AssistantSwitcher({
         name={label}
         isCurrent
         disabled={switching}
-        onSelect={() => setExpanded(false)}
+        onSelect={() => setExpandedWithFocus(false)}
         trailingAction={chevronButton}
       />
       <motion.div

--- a/clients/web/src/domains/chat/components/side-menu-built-in-nav.tsx
+++ b/clients/web/src/domains/chat/components/side-menu-built-in-nav.tsx
@@ -82,6 +82,7 @@ export function SideMenuBuiltInNav({
                 }
               : undefined
           }
+          onSwitched={onClose}
         />
       </div>
       {pinnedApps.length > 0 ? (

--- a/clients/web/src/domains/chat/components/side-menu-built-in-nav.tsx
+++ b/clients/web/src/domains/chat/components/side-menu-built-in-nav.tsx
@@ -1,5 +1,5 @@
 import { SIDEBAR_STACK_GAP } from "@/components/sidebar-nav-geometry";
-import { AssistantNavItem } from "@/domains/chat/components/assistant-nav-item";
+import { AssistantSwitcher } from "@/domains/chat/components/assistant-switcher";
 import { PinnedAppNavItem } from "@/domains/chat/components/pinned-app-nav-item";
 import { usePinnedAppsStore } from "@/stores/pinned-apps-store";
 import { cn } from "@vellumai/design-library";
@@ -61,7 +61,7 @@ export function SideMenuBuiltInNav({
           overlay drawer skips the New Chat row: its floating New Chat
           pill already owns that action in the thumb zone. */}
       <div>
-        <AssistantNavItem
+        <AssistantSwitcher
           assistantId={assistantId}
           label={assistantName || "Your Assistant"}
           active={isIntelligenceActive}

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
@@ -14,7 +14,10 @@ import { refreshPlatformAssistantsIfStale } from "@/assistant/platform-assistant
 import { resolveSelectedAssistantId } from "@/assistant/selection";
 import { retireAssistant } from "@/assistant/retire-service";
 import { isCurrentOrigin, switchToOrigin } from "@/assistant/switch-origin";
-import { removePairedAssistant } from "@/assistant/switch-service";
+import {
+  removePairedAssistant,
+  switchToResolvedAssistant,
+} from "@/assistant/switch-service";
 import { RemoveFromDeviceDialog } from "@/components/remove-from-device-dialog";
 import {
   clearGatewayToken,
@@ -45,7 +48,7 @@ import {
   nativeSwitchToOrigin,
   nativeVellumCloudOrigin,
 } from "@/runtime/self-hosted-servers";
-import { useAuthStore, useHasPlatformSession } from "@/stores/auth-store";
+import { useHasPlatformSession } from "@/stores/auth-store";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import { useConnectDialogStore } from "@/stores/connect-dialog-store";
 import { useOrganizationStore } from "@/stores/organization-store";
@@ -411,15 +414,7 @@ export function SelectAssistantScreen() {
     setConnecting(true);
     setError(null);
     try {
-      if (assistant.isPaired) {
-        await useAuthStore.getState().connectPairedAssistant(assistant.id);
-      } else if (assistant.isLocal && localClient) {
-        await useAuthStore.getState().connectLocalAssistant(assistant.id);
-      } else {
-        // A hub-listed local entry has no lockfile behind it; the platform
-        // path reaches it (lifecycle projects self-hosted via `ingress_url`).
-        await useAuthStore.getState().connectPlatformAssistant(assistant.id);
-      }
+      await switchToResolvedAssistant(assistant);
       void navigate(routes.assistant, { replace: true });
     } catch (err) {
       console.error("selectAssistant.handleConnect failed", err);

--- a/clients/web/src/hooks/use-assistant-avatar.ts
+++ b/clients/web/src/hooks/use-assistant-avatar.ts
@@ -25,6 +25,19 @@ export interface AvatarData {
 
 const activeBlobUrls = new Map<string, string>();
 
+export interface AssistantAvatarOptions {
+  /**
+   * Per-assistant override for the avatar-state-manifest capability. The
+   * default gate reads the ACTIVE assistant's version, which is wrong for
+   * a sibling assistant on another runtime: a pre-manifest sibling would
+   * be asked for `/avatar/state` it doesn't serve and its avatar would
+   * collapse to the fallback. List surfaces resolve the sibling's own
+   * version (`versionSupportsAvatarStateManifest`) and pass it here;
+   * `undefined` keeps the active-assistant gate.
+   */
+  supportsManifest?: boolean;
+}
+
 /**
  * Resolve the avatar render mode from the authoritative `/avatar/state`
  * manifest (assistants on `MIN_VERSION`+). Throws on a null state so React
@@ -90,9 +103,13 @@ async function fetchAvatarViaLegacyFiles(
  * key so the avatar re-fetches through the correct path the moment the
  * assistant version resolves.
  */
-export function useAssistantAvatar(assistantId: string | null) {
+export function useAssistantAvatar(
+  assistantId: string | null,
+  options?: AssistantAvatarOptions,
+) {
   const queryClient = useQueryClient();
-  const supportsManifest = useSupportsAvatarStateManifest();
+  const activeSupportsManifest = useSupportsAvatarStateManifest();
+  const supportsManifest = options?.supportsManifest ?? activeSupportsManifest;
 
   const { data, isLoading } = useQuery<AvatarData>({
     queryKey: [...avatarQueryKey(assistantId ?? ""), supportsManifest],

--- a/clients/web/src/hooks/use-assistant-avatar.ts
+++ b/clients/web/src/hooks/use-assistant-avatar.ts
@@ -36,6 +36,15 @@ export interface AssistantAvatarOptions {
    * `undefined` keeps the active-assistant gate.
    */
   supportsManifest?: boolean;
+  /**
+   * Skip the fetch entirely (`false`) and hand consumers the null avatar.
+   * For sibling assistants whose transport cannot be addressed
+   * independently: with a self-hosted ingress active, every daemon request
+   * is rewritten to that single gateway whatever assistant id the path
+   * carries, so a sibling fetch would return the ACTIVE assistant's
+   * avatar. Defaults to `true`.
+   */
+  enabled?: boolean;
 }
 
 /**
@@ -142,7 +151,7 @@ export function useAssistantAvatar(
 
       return { components, traits, customImageUrl: imageUrl };
     },
-    enabled: Boolean(assistantId),
+    enabled: Boolean(assistantId) && (options?.enabled ?? true),
     staleTime: Infinity,
     structuralSharing: false,
     // Retry transient failures (character-components or avatar-state) once

--- a/clients/web/src/i18n/locales/en/chat.json
+++ b/clients/web/src/i18n/locales/en/chat.json
@@ -24,6 +24,14 @@
   "assistantSideMenu": {
     "bulkActionMembersFailed": "Couldn't load every conversation in this section. Try again."
   },
+  "assistantSwitcher": {
+    "collapse": "Hide assistants",
+    "currentAssistant": "{name}, current assistant",
+    "expand": "Switch assistant",
+    "switchFailed": "Couldn't switch assistants. Try again.",
+    "switchTo": "Switch to {name}",
+    "unnamedAssistant": "Unnamed assistant"
+  },
   "cacheBreakpointMapCard": {
     "description": "Where the {count, plural, one {# cache breakpoint} other {# cache breakpoints}} fell across this request's prefix, and which segments were read versus re-created.",
     "estimatedTokens": "≈ {count} tokens",

--- a/clients/web/src/i18n/locales/es/chat.json
+++ b/clients/web/src/i18n/locales/es/chat.json
@@ -24,6 +24,14 @@
   "assistantSideMenu": {
     "bulkActionMembersFailed": "No se pudieron cargar todas las conversaciones de esta sección. Inténtalo de nuevo."
   },
+  "assistantSwitcher": {
+    "collapse": "Ocultar asistentes",
+    "currentAssistant": "{name}, asistente actual",
+    "expand": "Cambiar de asistente",
+    "switchFailed": "No se pudo cambiar de asistente. Inténtalo de nuevo.",
+    "switchTo": "Cambiar a {name}",
+    "unnamedAssistant": "Asistente sin nombre"
+  },
   "cacheBreakpointMapCard": {
     "description": "Dónde {count, plural, one {cayó # punto de corte de caché} other {cayeron # puntos de corte de caché}} en el prefijo de esta solicitud, y qué segmentos se leyeron frente a los que se volvieron a crear.",
     "estimatedTokens": "≈ {count} tokens",

--- a/clients/web/src/lib/backwards-compat/avatar-state-manifest.ts
+++ b/clients/web/src/lib/backwards-compat/avatar-state-manifest.ts
@@ -25,10 +25,27 @@
 import {
   assistantSupports,
   useAssistantSupports,
+  versionSupports,
   whenAssistantVersionKnown,
 } from "./utils";
 
 export const MIN_VERSION = "0.8.7";
+
+/**
+ * Per-assistant variant of {@link supportsAvatarStateManifest} for list
+ * surfaces that render avatars of assistants OTHER than the active one
+ * (the sidebar switcher). The active-assistant gate would ask a
+ * pre-manifest sibling for `/avatar/state` it doesn't serve; callers
+ * resolve the sibling's own version and gate on that instead. A
+ * null/unknown version answers `false`, matching the active gate's
+ * conservative default: the legacy read path is understood by every
+ * supported assistant.
+ */
+export function versionSupportsAvatarStateManifest(
+  version: string | null | undefined,
+): boolean {
+  return versionSupports(version, MIN_VERSION);
+}
 
 /**
  * Returns `true` when the active assistant exposes the avatar state


### PR DESCRIPTION
## Summary

Implements the assistant switcher from the [Figma mock](https://www.figma.com/design/cCGBcpVDbn22kj3OPU58W8/New-App?node-id=7984-9239) for users with multiple assistants:

- The sidebar's identity pill gains a circular chevron when 2+ assistants are switchable; with a single assistant (or a closed gate) the pill renders exactly as today, chevron-free, per the mock's annotation.
- Clicking the chevron expands the pill **in place** (sidebar content pushes down, not a popover) into a `--surface-lift` card: the current assistant row (32px avatar, name, green check, chevron-up) with the other assistants listed below.
- Selecting one switches assistants and collapses back to the pill, which retints to the new assistant's avatar accent once the lifecycle republishes. Failure toasts, keeps the previous assistant (all connect entries fail before the selection write), and stays expanded for retry.

## Implementation notes

- **Gate**: `multiPlatformAssistant || assistantSwitcher` (the same pair `useGatedSelectedAssistantId` honors) AND not gateway-auth mode AND >= 2 switchable entries — new hook `useSwitchableAssistants()`. Both flags default off, so this ships dark.
- **List derivation** mirrors the chooser screen: `assistantsValidForOrg` + `isConnectableFromThisDevice` + per-kind accessibility (paired always; local only on a local client; everything else needs the platform session). No hard org-id requirement, so a flag-on local client with two local assistants can still switch.
- **Switch dispatch**: new `switchToResolvedAssistant()` routes paired -> `connectPairedAssistant`, local-on-local-client -> `connectLocalAssistant`, else `connectPlatformAssistant`. The tray's `switchToAssistant()` is deliberately NOT reused: it bare-writes non-paired ids, which `selection.ts` forbids for local assistants (the tray gets away with it only by excluding local entries).
- **`AssistantNavItem`** gains two additive props: `trailingAction` (threaded to `PanelItem`'s hover-revealed trailing slot) and `expansion` (replaces the pill with the card, New Chat row stays outside). With both absent the output is byte-identical to today, so the collapsed rail, tour mode, and gate-closed paths cannot regress.
- Check color is `--system-positive-strong` (the mock's #309C50). Note: `assistant-picker.tsx` references `--system-positive-default`, which does not exist in tokens.css — not fixed here.
- All copy through i18n (`en`/`es` chat namespaces).

## Deliberate scope cuts

- Collapsed desktop rail unchanged: no mock exists and the circular tile has no room for a chevron or inline expansion; the expanded rail is one click away.
- No "New Assistant…" entry in the card (not in the mock; the tray keeps its own).
- Desktop chevron is hover-revealed (inherited `PanelItem` trailing-action behavior; always visible on touch, pinned while expanded). If design wants it permanently visible, that needs a small `PanelItem` opt-out prop.

## Testing

- 41 tests across 4 files: three-way switch dispatch (incl. rejection propagation), gate/list derivation matrix, chevron visibility matrix, expand/collapse, switch success/failure behavior, and nav-item slot regression guards.
- `bunx tsc --noEmit` and eslint clean; `bun run test:ci` failures (4 files) verified pre-existing on `main` via stash round-trip.
- Storybook stories (Default / Expanded / SingleAssistant) QA'd in-browser via Playwright against all three mock states.
- **Outstanding**: live QA on a dev build with 2+ real assistants — switch cascade end-to-end, switching while viewing the old assistant's conversation, avatar fetches for non-active local/paired siblings (fails soft to the "V" fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)