### PR TITLE
feat(gateway): webhook ingress route registry store

### DIFF
--- a/gateway/src/db/schema.ts
+++ b/gateway/src/db/schema.ts
@@ -673,6 +673,34 @@ export const pluginIngressApprovals = sqliteTable(
 );
 
 // ---------------------------------------------------------------------------
+// Webhook ingress routes (the subpaths this assistant accepts from outside)
+// ---------------------------------------------------------------------------
+
+/**
+ * The assistant's own allowlist of inbound webhook subpaths.
+ *
+ * A row is a claim that some live integration expects traffic on that exact
+ * path, so a path nothing registered can be refused before it reaches the
+ * route table or a per-route signature check.
+ */
+export const webhookIngressRoutes = sqliteTable("webhook_ingress_routes", {
+  // Origin-relative path with its leading slash, e.g. `/webhooks/telegram`.
+  path: text("path").primaryKey(),
+  // What kind of integration owns the path, e.g. `telegram` or `plugin`.
+  type: text("type").notNull(),
+  // The specific instance within that type, e.g. a plugin name. Null when
+  // the type alone identifies the owner.
+  source: text("source"),
+  // Only exact paths are matched today. The column exists so prefix or
+  // pattern rules can be added later without a schema change.
+  match: text("match").$type<"exact">().notNull().default("exact"),
+  createdAt: integer("created_at").notNull(),
+  // Refreshed on every re-registration, so a path nothing claims any more is
+  // visible as a stale row.
+  lastRegisteredAt: integer("last_registered_at").notNull(),
+});
+
+// ---------------------------------------------------------------------------
 // Inbound dedup (a vendor's retry must not become a second turn)
 // ---------------------------------------------------------------------------
 

--- a/gateway/src/db/webhook-ingress-route-store.test.ts
+++ b/gateway/src/db/webhook-ingress-route-store.test.ts
@@ -106,6 +106,7 @@ describe("registerWebhookIngressRoute", () => {
     // carrying dots or dashes is a name, not a traversal.
     for (const path of [
       "/webhooks/plugins/a.b/hook",
+      "/webhooks/plugins/foo..bar/hook",
       "/webhooks/twilio/sms-inbound",
       `/webhooks/${"x".repeat(500)}`,
     ]) {
@@ -134,8 +135,11 @@ describe("registerWebhookIngressRoute", () => {
 
   it("refuses paths that would not survive a byte-for-byte comparison", () => {
     for (const path of [
+      "/webhooks/../admin",
       "/webhooks/../v1/guardian/init",
       "/webhooks/a/../../etc",
+      "/webhooks/..%2fadmin",
+      "/webhooks/%2e%2e/admin",
       "/webhooks/telegram?token=x",
       "/webhooks/telegram#frag",
       "/webhooks/telegram\\..\\etc",

--- a/gateway/src/db/webhook-ingress-route-store.test.ts
+++ b/gateway/src/db/webhook-ingress-route-store.test.ts
@@ -143,6 +143,8 @@ describe("registerWebhookIngressRoute", () => {
       "/webhooks/telegram?token=x",
       "/webhooks/telegram#frag",
       "/webhooks/telegram\\..\\etc",
+      "/webhooks/foo%5c..%5cadmin",
+      "/webhooks/foo%5Cbar",
       "/webhooks/tele gram",
       "/webhooks/telegram\n",
       "/webhooks/tele\tgram",

--- a/gateway/src/db/webhook-ingress-route-store.test.ts
+++ b/gateway/src/db/webhook-ingress-route-store.test.ts
@@ -1,0 +1,225 @@
+/**
+ * The registry decides which webhook paths this assistant answers at all, so
+ * what it stores has to survive a byte-for-byte comparison later: nothing that
+ * a URL parser would rewrite, nothing that escapes the webhook namespace, and
+ * no second opinion about a path already claimed.
+ */
+
+import { eq } from "drizzle-orm";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "bun:test";
+
+import "../__tests__/test-preload.js";
+import { getGatewayDb, initGatewayDb, resetGatewayDb } from "./connection.js";
+import { webhookIngressRoutes } from "./schema.js";
+import {
+  hasWebhookIngressRoute,
+  listWebhookIngressRoutes,
+  onWebhookIngressRoutesChanged,
+  registerWebhookIngressRoute,
+  unregisterWebhookIngressRoute,
+} from "./webhook-ingress-route-store.js";
+
+const PATH = "/webhooks/telegram";
+
+beforeAll(async () => {
+  resetGatewayDb();
+  await initGatewayDb();
+});
+
+afterAll(() => {
+  resetGatewayDb();
+});
+
+beforeEach(() => {
+  getGatewayDb().delete(webhookIngressRoutes).run();
+});
+
+describe("registerWebhookIngressRoute", () => {
+  it("round-trips a route through the database", () => {
+    registerWebhookIngressRoute({
+      path: PATH,
+      type: "telegram",
+      source: "bot-1",
+    });
+
+    expect(listWebhookIngressRoutes()).toEqual([
+      {
+        path: PATH,
+        type: "telegram",
+        source: "bot-1",
+        match: "exact",
+        createdAt: expect.any(Number),
+        lastRegisteredAt: expect.any(Number),
+      },
+    ]);
+  });
+
+  it("defaults an unattributed route's source to null", () => {
+    registerWebhookIngressRoute({ path: PATH, type: "telegram" });
+
+    expect(listWebhookIngressRoutes()[0]?.source).toBeNull();
+  });
+
+  it("keeps one row per path however often it is registered", () => {
+    registerWebhookIngressRoute({ path: PATH, type: "telegram" });
+    registerWebhookIngressRoute({ path: PATH, type: "telegram" });
+    registerWebhookIngressRoute({ path: PATH, type: "telegram" });
+
+    expect(listWebhookIngressRoutes()).toHaveLength(1);
+  });
+
+  it("refreshes the registration time and preserves the creation time", () => {
+    const created = registerWebhookIngressRoute({
+      path: PATH,
+      type: "telegram",
+    });
+    // Age the row so the refresh is visible regardless of clock resolution.
+    getGatewayDb()
+      .update(webhookIngressRoutes)
+      .set({ lastRegisteredAt: created.lastRegisteredAt - 60_000 })
+      .where(eq(webhookIngressRoutes.path, PATH))
+      .run();
+
+    registerWebhookIngressRoute({ path: PATH, type: "telegram" });
+
+    const [row] = listWebhookIngressRoutes();
+    expect(row?.createdAt).toBe(created.createdAt);
+    expect(row?.lastRegisteredAt).toBeGreaterThan(created.createdAt - 60_000);
+  });
+
+  it("lets a re-registration move the route's owner", () => {
+    registerWebhookIngressRoute({ path: PATH, type: "telegram", source: "a" });
+    registerWebhookIngressRoute({ path: PATH, type: "telegram", source: "b" });
+
+    expect(listWebhookIngressRoutes()[0]?.source).toBe("b");
+  });
+
+  it("accepts paths whose segments are opaque strings", () => {
+    // The registry never interprets what is after `/webhooks/`; a plugin id
+    // carrying dots or dashes is a name, not a traversal.
+    for (const path of [
+      "/webhooks/plugins/a.b/hook",
+      "/webhooks/twilio/sms-inbound",
+      `/webhooks/${"x".repeat(500)}`,
+    ]) {
+      expect(() =>
+        registerWebhookIngressRoute({ path, type: "plugin" }),
+      ).not.toThrow();
+      expect(hasWebhookIngressRoute(path)).toBe(true);
+    }
+  });
+
+  it("refuses anything outside the webhook namespace", () => {
+    for (const path of [
+      "/v1/audio/stream",
+      "/hooks/telegram",
+      "webhooks/telegram",
+      "//webhooks/telegram",
+      "/webhooks",
+      "",
+      "https://evil.example/webhooks/telegram",
+    ]) {
+      expect(() =>
+        registerWebhookIngressRoute({ path, type: "telegram" }),
+      ).toThrow();
+    }
+  });
+
+  it("refuses paths that would not survive a byte-for-byte comparison", () => {
+    for (const path of [
+      "/webhooks/../v1/guardian/init",
+      "/webhooks/a/../../etc",
+      "/webhooks/telegram?token=x",
+      "/webhooks/telegram#frag",
+      "/webhooks/telegram\\..\\etc",
+      "/webhooks/tele gram",
+      "/webhooks/telegram\n",
+      "/webhooks/tele\tgram",
+      `/webhooks/${"x".repeat(600)}`,
+    ]) {
+      expect(() =>
+        registerWebhookIngressRoute({ path, type: "telegram" }),
+      ).toThrow();
+    }
+    expect(listWebhookIngressRoutes()).toEqual([]);
+  });
+});
+
+describe("unregisterWebhookIngressRoute", () => {
+  it("removes the route and reports that it existed", () => {
+    registerWebhookIngressRoute({ path: PATH, type: "telegram" });
+
+    expect(unregisterWebhookIngressRoute(PATH)).toBe(true);
+    expect(listWebhookIngressRoutes()).toEqual([]);
+  });
+
+  it("reports a path it never held", () => {
+    expect(unregisterWebhookIngressRoute(PATH)).toBe(false);
+  });
+});
+
+describe("hasWebhookIngressRoute", () => {
+  it("answers only for the exact path", () => {
+    registerWebhookIngressRoute({ path: PATH, type: "telegram" });
+
+    expect(hasWebhookIngressRoute(PATH)).toBe(true);
+    expect(hasWebhookIngressRoute("/webhooks/telegram/extra")).toBe(false);
+    expect(hasWebhookIngressRoute("/webhooks/teleg")).toBe(false);
+    expect(hasWebhookIngressRoute("/webhooks/twilio")).toBe(false);
+  });
+});
+
+describe("onWebhookIngressRoutesChanged", () => {
+  it("fires when the set of routes changes", () => {
+    let fired = 0;
+    const unsubscribe = onWebhookIngressRoutesChanged(() => {
+      fired += 1;
+    });
+
+    registerWebhookIngressRoute({ path: PATH, type: "telegram" });
+    expect(fired).toBe(1);
+
+    unregisterWebhookIngressRoute(PATH);
+    expect(fired).toBe(2);
+
+    unsubscribe();
+  });
+
+  it("stays quiet when a re-registration changes nothing", () => {
+    registerWebhookIngressRoute({ path: PATH, type: "telegram", source: "a" });
+
+    let fired = 0;
+    const unsubscribe = onWebhookIngressRoutesChanged(() => {
+      fired += 1;
+    });
+
+    registerWebhookIngressRoute({ path: PATH, type: "telegram", source: "a" });
+    expect(fired).toBe(0);
+
+    registerWebhookIngressRoute({ path: PATH, type: "telegram", source: "b" });
+    expect(fired).toBe(1);
+
+    unsubscribe();
+  });
+
+  it("stays quiet when a removal finds nothing and after unsubscribing", () => {
+    let fired = 0;
+    const unsubscribe = onWebhookIngressRoutesChanged(() => {
+      fired += 1;
+    });
+
+    unregisterWebhookIngressRoute(PATH);
+    expect(fired).toBe(0);
+
+    unsubscribe();
+    registerWebhookIngressRoute({ path: PATH, type: "telegram" });
+    expect(fired).toBe(0);
+  });
+});

--- a/gateway/src/db/webhook-ingress-route-store.ts
+++ b/gateway/src/db/webhook-ingress-route-store.ts
@@ -38,6 +38,21 @@ function notifyChanged(): void {
 }
 
 /**
+ * Consecutive dots inside a segment are part of a name, so only a segment that
+ * is exactly `..` is traversal. The path is percent-decoded first because a
+ * consumer downstream may decode before it splits the path on slashes.
+ */
+function hasTraversalSegment(path: string): boolean {
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(path);
+  } catch {
+    return true;
+  }
+  return decoded.split("/").includes("..");
+}
+
+/**
  * Paths are stored verbatim and compared byte for byte, so the only shapes
  * refused are the ones that would not survive that: anything outside the
  * webhook namespace, anything a URL parser would rewrite, and traversal.
@@ -46,7 +61,7 @@ function isValidWebhookIngressPath(path: string): boolean {
   return (
     path.length <= MAX_WEBHOOK_PATH_LENGTH &&
     path.startsWith(WEBHOOK_PATH_PREFIX) &&
-    !path.includes("..") &&
+    !hasTraversalSegment(path) &&
     !/\s/.test(path) &&
     isSafeOriginRelativePath(path)
   );

--- a/gateway/src/db/webhook-ingress-route-store.ts
+++ b/gateway/src/db/webhook-ingress-route-store.ts
@@ -40,7 +40,9 @@ function notifyChanged(): void {
 /**
  * Consecutive dots inside a segment are part of a name, so only a segment that
  * is exactly `..` is traversal. The path is percent-decoded first because a
- * consumer downstream may decode before it splits the path on slashes.
+ * consumer downstream may decode before it splits the path on slashes. A
+ * decoded backslash is refused outright because a URL parser treats it as a
+ * separator, which would turn `/webhooks/foo%5c..%5cadmin` into `/webhooks/admin`.
  */
 function hasTraversalSegment(path: string): boolean {
   let decoded: string;
@@ -49,7 +51,7 @@ function hasTraversalSegment(path: string): boolean {
   } catch {
     return true;
   }
-  return decoded.split("/").includes("..");
+  return decoded.includes("\\") || decoded.split("/").includes("..");
 }
 
 /**

--- a/gateway/src/db/webhook-ingress-route-store.ts
+++ b/gateway/src/db/webhook-ingress-route-store.ts
@@ -1,0 +1,147 @@
+/** Store for the webhook subpaths this assistant accepts from outside. */
+
+import { eq } from "drizzle-orm";
+
+import { isSafeOriginRelativePath } from "../velay/bridge-utils.js";
+import { getGatewayDb } from "./connection.js";
+import { webhookIngressRoutes } from "./schema.js";
+
+export interface WebhookIngressRoute {
+  path: string;
+  type: string;
+  source: string | null;
+  match: "exact";
+  createdAt: number;
+  lastRegisteredAt: number;
+}
+
+const WEBHOOK_PATH_PREFIX = "/webhooks/";
+const MAX_WEBHOOK_PATH_LENGTH = 512;
+
+const changeListeners = new Set<() => void>();
+
+/**
+ * Register a callback that fires after every registration or removal.
+ * Returns an unsubscribe function.
+ */
+export function onWebhookIngressRoutesChanged(cb: () => void): () => void {
+  changeListeners.add(cb);
+  return () => {
+    changeListeners.delete(cb);
+  };
+}
+
+function notifyChanged(): void {
+  for (const cb of changeListeners) {
+    cb();
+  }
+}
+
+/**
+ * Paths are stored verbatim and compared byte for byte, so the only shapes
+ * refused are the ones that would not survive that: anything outside the
+ * webhook namespace, anything a URL parser would rewrite, and traversal.
+ */
+function isValidWebhookIngressPath(path: string): boolean {
+  return (
+    path.length <= MAX_WEBHOOK_PATH_LENGTH &&
+    path.startsWith(WEBHOOK_PATH_PREFIX) &&
+    !path.includes("..") &&
+    !/\s/.test(path) &&
+    isSafeOriginRelativePath(path)
+  );
+}
+
+export interface RegisterWebhookIngressRouteInput {
+  /** Exact subpath, leading slash included, under `/webhooks/`. */
+  path: string;
+  type: string;
+  source?: string | null;
+}
+
+/**
+ * Claim `path` for `type`. Registering the same path again refreshes its
+ * registration time and keeps the original `createdAt`.
+ */
+export function registerWebhookIngressRoute(
+  input: RegisterWebhookIngressRouteInput,
+): WebhookIngressRoute {
+  const { path } = input;
+  if (!isValidWebhookIngressPath(path)) {
+    throw new Error(`Invalid webhook ingress path: ${path}`);
+  }
+
+  const existing = readWebhookIngressRoute(path);
+  const now = Date.now();
+  const row: WebhookIngressRoute = {
+    path,
+    type: input.type,
+    source: input.source ?? null,
+    match: "exact",
+    createdAt: existing?.createdAt ?? now,
+    lastRegisteredAt: now,
+  };
+
+  getGatewayDb()
+    .insert(webhookIngressRoutes)
+    .values(row)
+    .onConflictDoUpdate({
+      target: webhookIngressRoutes.path,
+      set: {
+        type: row.type,
+        source: row.source,
+        lastRegisteredAt: row.lastRegisteredAt,
+      },
+    })
+    .run();
+
+  // Re-registering an unchanged row leaves the advertised path set identical,
+  // so subscribers have nothing to react to.
+  if (
+    existing === undefined ||
+    existing.type !== row.type ||
+    existing.source !== row.source
+  ) {
+    notifyChanged();
+  }
+  return row;
+}
+
+/** Drop `path`. Returns true when a row was removed. */
+export function unregisterWebhookIngressRoute(path: string): boolean {
+  if (!hasWebhookIngressRoute(path)) {
+    return false;
+  }
+  getGatewayDb()
+    .delete(webhookIngressRoutes)
+    .where(eq(webhookIngressRoutes.path, path))
+    .run();
+  notifyChanged();
+  return true;
+}
+
+/** Every registered route. */
+export function listWebhookIngressRoutes(): WebhookIngressRoute[] {
+  return getGatewayDb().select().from(webhookIngressRoutes).all();
+}
+
+/** Whether `path` is registered. On the bridge's per-request path. */
+export function hasWebhookIngressRoute(path: string): boolean {
+  return (
+    getGatewayDb()
+      .select({ path: webhookIngressRoutes.path })
+      .from(webhookIngressRoutes)
+      .where(eq(webhookIngressRoutes.path, path))
+      .get() !== undefined
+  );
+}
+
+function readWebhookIngressRoute(
+  path: string,
+): WebhookIngressRoute | undefined {
+  return getGatewayDb()
+    .select()
+    .from(webhookIngressRoutes)
+    .where(eq(webhookIngressRoutes.path, path))
+    .get();
+}


### PR DESCRIPTION
## Summary

- Adds a `webhook_ingress_routes` gateway table: exact `/webhooks/*` subpath as primary key, plus the owning type/source and registration timestamps.
- Adds `webhook-ingress-route-store.ts` with idempotent register, unregister, list, point lookup, and a change-listener registry.
- Nothing reads the store yet; registration and enforcement land in later PRs.

Part of plan: webhook-consolidation-velay.md (PR 1 of 9)