### PR TITLE
feat(gateway): tunnel bridge admits registered webhook routes

### DIFF
--- a/gateway/src/http/routes/channel-verification-session-proxy.test.ts
+++ b/gateway/src/http/routes/channel-verification-session-proxy.test.ts
@@ -20,7 +20,11 @@ mock.module("../../fetch.js", () => ({
   },
 }));
 
+// Spread the actual module so untouched exports (getLegacyRootDir, …) stay
+// importable by transitive dependencies of the modules under test.
+const actualPaths = await import("../../paths.js");
 mock.module("../../paths.js", () => ({
+  ...actualPaths,
   getGatewaySecurityDir: () => "/tmp/test-gateway-sec",
   getWorkspaceDir: () => "/tmp/test-workspace",
 }));

--- a/gateway/src/velay/bridge-utils.ts
+++ b/gateway/src/velay/bridge-utils.ts
@@ -2,17 +2,30 @@ import { Buffer } from "node:buffer";
 import type { OutgoingHttpHeaders } from "node:http";
 import { buildUpstreamUrl, stripHopByHop } from "@vellumai/assistant-client";
 
+import { hasWebhookIngressRoute } from "../db/webhook-ingress-route-store.js";
+import { isFeatureFlagEnabled } from "../feature-flag-resolver.js";
 import type { VelayHeaders } from "./protocol.js";
 
 const MAX_WEBSOCKET_CLOSE_REASON_BYTES = 123;
 
+const VELAY_WEBHOOKS_FLAG_KEY = "velay-webhooks";
+const WEBHOOK_PATH_PREFIX = "/webhooks/";
+
+/**
+ * Velay admission is decided across three layers. The webhook ingress route
+ * registry is authoritative for `/webhooks/*` once the `velay-webhooks` flag is
+ * on, so an assistant that registers nothing accepts nothing. The static
+ * prefixes and exact paths below are authoritative for every other route, and
+ * they still carry `/webhooks/twilio/` so Twilio keeps working until it
+ * registers its own routes. The rules in `allowed-paths.ts` are the coarse
+ * outer filter Velay applies platform-side and never widen what this bridge
+ * admits.
+ */
 const VELAY_ALLOWED_HTTP_PATH_PREFIXES = [
   "/webhooks/twilio/",
   "/v1/audio/",
 ] as const;
-// Exact-match HTTP paths (no trailing segments). Keep in sync with the
-// registration allowlist in allowed-paths.ts — Velay enforces that list
-// platform-side, and this bridge check is the local second layer.
+/** Exact-match HTTP paths (no trailing segments). */
 const VELAY_ALLOWED_HTTP_EXACT_PATHS = [
   "/assistant/credentials/enter",
   "/v1/credential-requests/peek",
@@ -34,6 +47,13 @@ const VELAY_ALLOWED_WEBSOCKET_EXACT_PATHS = [
 export const VELAY_FORWARDED_HEADER = "x-velay-forwarded" as const;
 
 export function isAllowedVelayHttpPath(path: string): boolean {
+  if (
+    path.startsWith(WEBHOOK_PATH_PREFIX) &&
+    isFeatureFlagEnabled(VELAY_WEBHOOKS_FLAG_KEY) &&
+    hasWebhookIngressRoute(path)
+  ) {
+    return true;
+  }
   return (
     VELAY_ALLOWED_HTTP_PATH_PREFIXES.some((prefix) =>
       path.startsWith(prefix),
@@ -44,6 +64,7 @@ export function isAllowedVelayHttpPath(path: string): boolean {
   );
 }
 
+/** A registered webhook route admits a WebSocket upgrade on that same path. */
 export function isAllowedVelayWebSocketPath(path: string): boolean {
   return (
     isAllowedVelayHttpPath(path) ||

--- a/gateway/src/velay/http-bridge.test.ts
+++ b/gateway/src/velay/http-bridge.test.ts
@@ -16,12 +16,26 @@ mock.module("../fetch.js", () => ({
   fetchImpl: (...args: Parameters<FetchFn>) => fetchMock(...args),
 }));
 
+let velayWebhooksFlagEnabled = false;
+let registeredWebhookPaths = new Set<string>();
+
+mock.module("../feature-flag-resolver.js", () => ({
+  isFeatureFlagEnabled: (key: string) =>
+    key === "velay-webhooks" ? velayWebhooksFlagEnabled : false,
+}));
+
+mock.module("../db/webhook-ingress-route-store.js", () => ({
+  hasWebhookIngressRoute: (path: string) => registeredWebhookPaths.has(path),
+}));
+
 const { bridgeVelayHttpRequest } = await import("./http-bridge.js");
 
 const TWILIO_EXAMPLE_PATH = "/webhooks/twilio/example";
 
 afterEach(() => {
   fetchMock = mock(async () => new Response());
+  velayWebhooksFlagEnabled = false;
+  registeredWebhookPaths = new Set();
 });
 
 function makeFrame(
@@ -291,5 +305,87 @@ describe("Velay HTTP bridge", () => {
 
     expect(captured).toHaveLength(1);
     expect(captured[0].get("x-velay-forwarded")).toBe("1");
+  });
+});
+
+describe("Velay HTTP bridge webhook ingress registry", () => {
+  const STATIC_PATHS = [
+    TWILIO_EXAMPLE_PATH,
+    "/v1/audio/550e8400-e29b-41d4-a716-446655440000",
+    "/assistant/credentials/enter",
+    "/v1/credential-requests/peek",
+    "/v1/credential-requests/submit",
+  ];
+
+  test("flag off: a registered webhook path is still rejected", async () => {
+    registeredWebhookPaths = new Set(["/webhooks/telegram"]);
+    fetchMock = mock(async () => {
+      throw new Error("should not fetch");
+    });
+
+    const response = await bridgeVelayHttpRequest(
+      makeFrame({ path: "/webhooks/telegram" }),
+      "http://127.0.0.1:7830",
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(response.status_code).toBe(502);
+  });
+
+  test("flag on: a registered webhook path is forwarded and its response relayed", async () => {
+    velayWebhooksFlagEnabled = true;
+    registeredWebhookPaths = new Set(["/webhooks/telegram"]);
+    const captured: string[] = [];
+    fetchMock = mock(async (input: string | URL | Request) => {
+      captured.push((input as Request).url);
+      return new Response("handled", { status: 202 });
+    });
+
+    const response = await bridgeVelayHttpRequest(
+      makeFrame({ path: "/webhooks/telegram" }),
+      "http://127.0.0.1:7830",
+    );
+
+    expect(captured).toEqual(["http://127.0.0.1:7830/webhooks/telegram"]);
+    expect(response.status_code).toBe(202);
+    expect(decodeBase64(response.body_base64)).toBe("handled");
+  });
+
+  test("flag on: an unregistered webhook path is rejected without contacting the loopback listener", async () => {
+    velayWebhooksFlagEnabled = true;
+    registeredWebhookPaths = new Set(["/webhooks/telegram"]);
+    fetchMock = mock(async () => {
+      throw new Error("should not fetch");
+    });
+
+    for (const path of [
+      "/webhooks/slack",
+      "/webhooks/telegram/extra",
+      "/webhooks/telegramX",
+    ]) {
+      const response = await bridgeVelayHttpRequest(
+        makeFrame({ path }),
+        "http://127.0.0.1:7830",
+      );
+      expect(response.status_code).toBe(502);
+    }
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("static allowlist paths are forwarded regardless of the flag", async () => {
+    for (const flagEnabled of [false, true]) {
+      velayWebhooksFlagEnabled = flagEnabled;
+      registeredWebhookPaths = new Set();
+
+      for (const path of STATIC_PATHS) {
+        fetchMock = mock(async () => new Response("ok", { status: 200 }));
+        const response = await bridgeVelayHttpRequest(
+          makeFrame({ path }),
+          "http://127.0.0.1:7830",
+        );
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        expect(response.status_code).toBe(200);
+      }
+    }
   });
 });


### PR DESCRIPTION
## Summary

- `isAllowedVelayHttpPath` now consults the webhook ingress route registry for `/webhooks/*` when the `velay-webhooks` flag is on, admitting only registered exact paths; everything else falls through to the existing static prefixes/exacts unchanged.
- Flag off, or an empty registry, is exactly today's admission. `/webhooks/twilio/` stays static for migration compat.
- WebSocket admission keeps delegating to the HTTP check, so a registered path also admits a WS upgrade on that same path.

Part of plan: webhook-consolidation-velay.md (PR 3 of 9)