### PR TITLE
feat(gateway): webhook route registry IPC handlers and daemon client

### DIFF
--- a/assistant/src/ipc/gateway-client.ts
+++ b/assistant/src/ipc/gateway-client.ts
@@ -20,6 +20,7 @@ import {
   IpcCallError,
   PersistentIpcClient as PackagePersistentIpcClient,
 } from "@vellumai/gateway-client/ipc-client";
+import { z } from "zod";
 
 import { getLogger } from "../util/logger.js";
 import { abortableSleep, computeRetryDelay } from "../util/retry.js";
@@ -143,6 +144,84 @@ export async function ipcGetVelayStatus(): Promise<VelayTunnelStatus | null> {
     connected: obj.connected,
     publicUrl: typeof obj.publicUrl === "string" ? obj.publicUrl : null,
   };
+}
+
+// ---------------------------------------------------------------------------
+// Webhook ingress route registry
+// ---------------------------------------------------------------------------
+
+const WebhookIngressRouteSchema = z.object({
+  path: z.string(),
+  type: z.string(),
+  source: z.string().nullable(),
+  match: z.literal("exact"),
+  createdAt: z.number(),
+  lastRegisteredAt: z.number(),
+});
+
+const RegisterWebhookRouteResultSchema = z.union([
+  z.object({ disabled: z.literal(true) }),
+  z.object({ disabled: z.literal(false), route: WebhookIngressRouteSchema }),
+]);
+
+export type WebhookIngressRoute = z.infer<typeof WebhookIngressRouteSchema>;
+export type RegisterWebhookRouteResult = z.infer<
+  typeof RegisterWebhookRouteResultSchema
+>;
+
+export interface RegisterWebhookRouteInput {
+  /** Exact subpath, leading slash included, under `/webhooks/`. */
+  path: string;
+  type: string;
+  source?: string | null;
+}
+
+/**
+ * Claim a webhook subpath on the gateway.
+ *
+ * A `disabled` result means the gateway is not serving its own webhooks, so
+ * the caller should fall back to platform callback registration. Returns
+ * `null` when the gateway is unreachable or rejected the path.
+ */
+export async function ipcRegisterWebhookRoute(
+  input: RegisterWebhookRouteInput,
+): Promise<RegisterWebhookRouteResult | null> {
+  const result = await ipcCall("register_webhook_route", { ...input });
+  const parsed = RegisterWebhookRouteResultSchema.safeParse(result);
+  if (!parsed.success) {
+    log.warn(
+      { result, path: input.path },
+      "ipcRegisterWebhookRoute: unusable gateway response",
+    );
+    return null;
+  }
+  return parsed.data;
+}
+
+/**
+ * Drop a webhook subpath from the gateway registry. Resolves to whether a
+ * route was removed, or `null` when the gateway is unreachable.
+ */
+export async function ipcUnregisterWebhookRoute(
+  path: string,
+): Promise<boolean | null> {
+  const result = await ipcCall("unregister_webhook_route", { path });
+  const parsed = z.object({ removed: z.boolean() }).safeParse(result);
+  return parsed.success ? parsed.data.removed : null;
+}
+
+/**
+ * List every webhook subpath the gateway currently answers, or `null` when
+ * the gateway is unreachable.
+ */
+export async function ipcListWebhookRoutes(): Promise<
+  WebhookIngressRoute[] | null
+> {
+  const result = await ipcCall("list_webhook_routes");
+  const parsed = z
+    .object({ routes: z.array(WebhookIngressRouteSchema) })
+    .safeParse(result);
+  return parsed.success ? parsed.data.routes : null;
 }
 
 // classify_risk is an idempotent, side-effect-free read, so a transient gateway

--- a/assistant/src/ipc/gateway-client.ts
+++ b/assistant/src/ipc/gateway-client.ts
@@ -14,13 +14,17 @@ import {
   type ClassifyRiskIpcParams,
   type ClassifyRiskIpcResponse,
   ClassifyRiskIpcResponseSchema,
+  ListWebhookRoutesIpcResponseSchema,
+  type RegisterWebhookRouteIpcParams,
+  RegisterWebhookRouteIpcResponseSchema,
+  UnregisterWebhookRouteIpcResponseSchema,
+  type WebhookIngressRoute,
 } from "@vellumai/gateway-client";
 import {
   ipcCall as packageIpcCall,
   IpcCallError,
   PersistentIpcClient as PackagePersistentIpcClient,
 } from "@vellumai/gateway-client/ipc-client";
-import { z } from "zod";
 
 import { getLogger } from "../util/logger.js";
 import { abortableSleep, computeRetryDelay } from "../util/retry.js";
@@ -150,78 +154,86 @@ export async function ipcGetVelayStatus(): Promise<VelayTunnelStatus | null> {
 // Webhook ingress route registry
 // ---------------------------------------------------------------------------
 
-const WebhookIngressRouteSchema = z.object({
-  path: z.string(),
-  type: z.string(),
-  source: z.string().nullable(),
-  match: z.literal("exact"),
-  createdAt: z.number(),
-  lastRegisteredAt: z.number(),
-});
+/**
+ * Why a webhook-route call failed.
+ *
+ * `no_response` means nothing came back. The one-shot IPC transport answers a
+ * missing gateway and a gateway-side refusal the same way, with no result, so
+ * both land here. `invalid_response` means the gateway answered but the answer
+ * does not match the shared contract, so the two sides have drifted.
+ */
+export type WebhookRouteIpcFailureReason = "no_response" | "invalid_response";
 
-const RegisterWebhookRouteResultSchema = z.union([
-  z.object({ disabled: z.literal(true) }),
-  z.object({ disabled: z.literal(false), route: WebhookIngressRouteSchema }),
-]);
+export type IpcRegisterWebhookRouteResult =
+  | { ok: true; disabled: true }
+  | { ok: true; disabled: false; route: WebhookIngressRoute }
+  | { ok: false; reason: WebhookRouteIpcFailureReason };
 
-export type WebhookIngressRoute = z.infer<typeof WebhookIngressRouteSchema>;
-export type RegisterWebhookRouteResult = z.infer<
-  typeof RegisterWebhookRouteResultSchema
->;
+export type IpcUnregisterWebhookRouteResult =
+  | { ok: true; removed: boolean }
+  | { ok: false; reason: WebhookRouteIpcFailureReason };
 
-export interface RegisterWebhookRouteInput {
-  /** Exact subpath, leading slash included, under `/webhooks/`. */
-  path: string;
-  type: string;
-  source?: string | null;
+export type IpcListWebhookRoutesResult =
+  | { ok: true; routes: WebhookIngressRoute[] }
+  | { ok: false; reason: WebhookRouteIpcFailureReason };
+
+function webhookRouteFailure(
+  method: string,
+  result: unknown,
+  detail: Record<string, unknown> = {},
+): { ok: false; reason: WebhookRouteIpcFailureReason } {
+  const reason: WebhookRouteIpcFailureReason =
+    result === undefined ? "no_response" : "invalid_response";
+  log.warn({ ...detail, result, reason }, `${method}: gateway call failed`);
+  return { ok: false, reason };
 }
 
 /**
  * Claim a webhook subpath on the gateway.
  *
- * A `disabled` result means the gateway is not serving its own webhooks, so
- * the caller should fall back to platform callback registration. Returns
- * `null` when the gateway is unreachable or rejected the path.
+ * A `disabled` result is a normal answer, not a failure: the gateway is not
+ * serving its own webhooks and the caller should fall back to platform
+ * callback registration. A failure carries the reason it failed so a caller
+ * that also falls back can log the two apart.
  */
 export async function ipcRegisterWebhookRoute(
-  input: RegisterWebhookRouteInput,
-): Promise<RegisterWebhookRouteResult | null> {
+  input: RegisterWebhookRouteIpcParams,
+): Promise<IpcRegisterWebhookRouteResult> {
   const result = await ipcCall("register_webhook_route", { ...input });
-  const parsed = RegisterWebhookRouteResultSchema.safeParse(result);
+  const parsed = RegisterWebhookRouteIpcResponseSchema.safeParse(result);
   if (!parsed.success) {
-    log.warn(
-      { result, path: input.path },
-      "ipcRegisterWebhookRoute: unusable gateway response",
-    );
-    return null;
+    return webhookRouteFailure("ipcRegisterWebhookRoute", result, {
+      path: input.path,
+    });
   }
-  return parsed.data;
+  return parsed.data.disabled
+    ? { ok: true, disabled: true }
+    : { ok: true, disabled: false, route: parsed.data.route };
 }
 
 /**
- * Drop a webhook subpath from the gateway registry. Resolves to whether a
- * route was removed, or `null` when the gateway is unreachable.
+ * Drop a webhook subpath from the gateway registry. A successful call reports
+ * whether a route was actually removed.
  */
 export async function ipcUnregisterWebhookRoute(
   path: string,
-): Promise<boolean | null> {
+): Promise<IpcUnregisterWebhookRouteResult> {
   const result = await ipcCall("unregister_webhook_route", { path });
-  const parsed = z.object({ removed: z.boolean() }).safeParse(result);
-  return parsed.success ? parsed.data.removed : null;
+  const parsed = UnregisterWebhookRouteIpcResponseSchema.safeParse(result);
+  if (!parsed.success) {
+    return webhookRouteFailure("ipcUnregisterWebhookRoute", result, { path });
+  }
+  return { ok: true, removed: parsed.data.removed };
 }
 
-/**
- * List every webhook subpath the gateway currently answers, or `null` when
- * the gateway is unreachable.
- */
-export async function ipcListWebhookRoutes(): Promise<
-  WebhookIngressRoute[] | null
-> {
+/** List every webhook subpath the gateway currently answers. */
+export async function ipcListWebhookRoutes(): Promise<IpcListWebhookRoutesResult> {
   const result = await ipcCall("list_webhook_routes");
-  const parsed = z
-    .object({ routes: z.array(WebhookIngressRouteSchema) })
-    .safeParse(result);
-  return parsed.success ? parsed.data.routes : null;
+  const parsed = ListWebhookRoutesIpcResponseSchema.safeParse(result);
+  if (!parsed.success) {
+    return webhookRouteFailure("ipcListWebhookRoutes", result);
+  }
+  return { ok: true, routes: parsed.data.routes };
 }
 
 // classify_risk is an idempotent, side-effect-free read, so a transient gateway

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -232,6 +232,7 @@ import { trustRulesRoutes } from "./ipc/trust-rules-handlers.js";
 
 import { riskClassificationRoutes } from "./ipc/risk-classification-handlers.js";
 import { createVelayRoutes } from "./ipc/velay-handlers.js";
+import { createWebhookRouteRoutes } from "./ipc/webhook-route-handlers.js";
 import { refreshRouteSchema } from "./ipc/route-schema-cache.js";
 import { AvatarChannelSyncer } from "./avatar-sync/avatar-channel-syncer.js";
 import { AvatarSyncWatcher } from "./avatar-sync/avatar-sync-watcher.js";
@@ -2921,6 +2922,7 @@ async function main() {
     ...createLogTailRoutes(config),
     ...trustRulesRoutes,
     ...createVelayRoutes(velayTunnelClient),
+    ...createWebhookRouteRoutes(),
     ...createCredentialRequestIpcRoutes(
       config,
       configFileCache,

--- a/gateway/src/ipc/webhook-route-handlers.test.ts
+++ b/gateway/src/ipc/webhook-route-handlers.test.ts
@@ -23,6 +23,12 @@ mock.module("../feature-flag-resolver.js", () => ({
 }));
 
 import {
+  ListWebhookRoutesIpcResponseSchema,
+  RegisterWebhookRouteIpcResponseSchema,
+  UnregisterWebhookRouteIpcResponseSchema,
+} from "@vellumai/gateway-client/gateway-ipc-contracts";
+
+import {
   getGatewayDb,
   initGatewayDb,
   resetGatewayDb,
@@ -118,6 +124,32 @@ describe("register_webhook_route", () => {
       register({ path: "/webhooks/../admin", type: "telegram" }),
     ).toThrow();
     expect(list()).toEqual({ routes: [] });
+  });
+});
+
+describe("shared IPC contract", () => {
+  it("answers every method in the shape the daemon parses", () => {
+    flagEnabled = false;
+    expect(
+      RegisterWebhookRouteIpcResponseSchema.safeParse(
+        register({ path: PATH, type: "telegram" }),
+      ).success,
+    ).toBe(true);
+
+    flagEnabled = true;
+    expect(
+      RegisterWebhookRouteIpcResponseSchema.safeParse(
+        register({ path: PATH, type: "telegram", source: "bot-1" }),
+      ).success,
+    ).toBe(true);
+    expect(ListWebhookRoutesIpcResponseSchema.safeParse(list()).success).toBe(
+      true,
+    );
+    expect(
+      UnregisterWebhookRouteIpcResponseSchema.safeParse(
+        unregister({ path: PATH }),
+      ).success,
+    ).toBe(true);
   });
 });
 

--- a/gateway/src/ipc/webhook-route-handlers.test.ts
+++ b/gateway/src/ipc/webhook-route-handlers.test.ts
@@ -1,0 +1,146 @@
+/**
+ * The registry is what decides whether an inbound webhook is answered, so the
+ * IPC surface has to refuse a claim while the flag is off, refuse a path the
+ * store would not store, and otherwise show back exactly what it wrote.
+ */
+
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+} from "bun:test";
+
+import "../__tests__/test-preload.js";
+
+let flagEnabled = true;
+
+mock.module("../feature-flag-resolver.js", () => ({
+  isFeatureFlagEnabled: (_key: string) => flagEnabled,
+}));
+
+import {
+  getGatewayDb,
+  initGatewayDb,
+  resetGatewayDb,
+} from "../db/connection.js";
+import { webhookIngressRoutes } from "../db/schema.js";
+import { createWebhookRouteRoutes } from "./webhook-route-handlers.js";
+
+const PATH = "/webhooks/telegram";
+
+const routes = createWebhookRouteRoutes();
+
+function route(method: string) {
+  const found = routes.find((r) => r.method === method);
+  if (!found) throw new Error(`No route registered for ${method}`);
+  return found;
+}
+
+const register = (params: Record<string, unknown>) =>
+  route("register_webhook_route").handler(params);
+const unregister = (params: Record<string, unknown>) =>
+  route("unregister_webhook_route").handler(params);
+const list = () => route("list_webhook_routes").handler();
+
+beforeAll(async () => {
+  resetGatewayDb();
+  await initGatewayDb();
+});
+
+afterAll(() => {
+  resetGatewayDb();
+});
+
+beforeEach(() => {
+  flagEnabled = true;
+  getGatewayDb().delete(webhookIngressRoutes).run();
+});
+
+describe("register_webhook_route", () => {
+  it("rejects params the store could never key on", () => {
+    const schema = route("register_webhook_route").schema;
+
+    expect(schema?.safeParse({ path: PATH, type: "telegram" }).success).toBe(
+      true,
+    );
+    expect(schema?.safeParse({ path: "", type: "telegram" }).success).toBe(
+      false,
+    );
+    expect(schema?.safeParse({ path: PATH, type: "" }).success).toBe(false);
+    expect(schema?.safeParse({ path: PATH }).success).toBe(false);
+  });
+
+  it("refuses without writing while the flag is off", () => {
+    flagEnabled = false;
+
+    expect(register({ path: PATH, type: "telegram" })).toEqual({
+      disabled: true,
+    });
+    expect(list()).toEqual({ routes: [] });
+  });
+
+  it("returns the stored row and shows it in the listing", () => {
+    const result = register({
+      path: PATH,
+      type: "telegram",
+      source: "bot-1",
+    }) as { disabled: false; route: unknown };
+
+    expect(result).toEqual({
+      disabled: false,
+      route: {
+        path: PATH,
+        type: "telegram",
+        source: "bot-1",
+        match: "exact",
+        createdAt: expect.any(Number),
+        lastRegisteredAt: expect.any(Number),
+      },
+    });
+    expect(list()).toEqual({ routes: [result.route] });
+  });
+
+  it("stores an unattributed route with a null source", () => {
+    register({ path: PATH, type: "telegram" });
+
+    expect(list()).toEqual({
+      routes: [expect.objectContaining({ source: null })],
+    });
+  });
+
+  it("throws on a path outside the webhook namespace", () => {
+    expect(() => register({ path: "/v1/admin", type: "telegram" })).toThrow();
+    expect(() =>
+      register({ path: "/webhooks/../admin", type: "telegram" }),
+    ).toThrow();
+    expect(list()).toEqual({ routes: [] });
+  });
+});
+
+describe("unregister_webhook_route", () => {
+  it("removes a registered route and reports it", () => {
+    register({ path: PATH, type: "telegram" });
+
+    expect(unregister({ path: PATH })).toEqual({ removed: true });
+    expect(list()).toEqual({ routes: [] });
+  });
+
+  it("reports a path it never held", () => {
+    expect(unregister({ path: PATH })).toEqual({ removed: false });
+  });
+
+  it("still revokes and lists while the flag is off", () => {
+    register({ path: PATH, type: "telegram" });
+    flagEnabled = false;
+
+    expect(list()).toEqual({
+      routes: [expect.objectContaining({ path: PATH })],
+    });
+    expect(unregister({ path: PATH })).toEqual({ removed: true });
+    expect(list()).toEqual({ routes: [] });
+  });
+});

--- a/gateway/src/ipc/webhook-route-handlers.ts
+++ b/gateway/src/ipc/webhook-route-handlers.ts
@@ -5,46 +5,35 @@
  * answers from outside. Only registration is gated on `velay-webhooks`;
  * revocation and inspection stay available so an operator can always see and
  * remove what was claimed while the flag was on.
+ *
+ * The request and response shapes are the shared contract in
+ * `@vellumai/gateway-client`, which the daemon reads the other end of.
  */
 
-import { z } from "zod";
+import {
+  type ListWebhookRoutesIpcResponse,
+  RegisterWebhookRouteIpcParamsSchema,
+  type RegisterWebhookRouteIpcResponse,
+  UnregisterWebhookRouteIpcParamsSchema,
+  type UnregisterWebhookRouteIpcResponse,
+} from "@vellumai/gateway-client/gateway-ipc-contracts";
 
 import {
   listWebhookIngressRoutes,
   registerWebhookIngressRoute,
   unregisterWebhookIngressRoute,
-  type WebhookIngressRoute,
 } from "../db/webhook-ingress-route-store.js";
 import { isFeatureFlagEnabled } from "../feature-flag-resolver.js";
 import { ipcRoute, type IpcRoute } from "./server.js";
 
 const VELAY_WEBHOOKS_FLAG_KEY = "velay-webhooks";
 
-const RegisterWebhookRouteSchema = z.object({
-  path: z.string().min(1),
-  type: z.string().min(1),
-  source: z.string().nullish(),
-});
-
-const UnregisterWebhookRouteSchema = z.object({
-  path: z.string().min(1),
-});
-
-/**
- * A refusal is a normal result rather than an error: the daemon reads
- * `disabled` as "this assistant is not serving its own webhooks" and falls
- * back to the platform's callback routes.
- */
-type RegisterWebhookRouteResult =
-  | { disabled: true }
-  | { disabled: false; route: WebhookIngressRoute };
-
 export function createWebhookRouteRoutes(): IpcRoute[] {
   return [
     ipcRoute({
       method: "register_webhook_route",
-      schema: RegisterWebhookRouteSchema,
-      handler: (params): RegisterWebhookRouteResult => {
+      schema: RegisterWebhookRouteIpcParamsSchema,
+      handler: (params): RegisterWebhookRouteIpcResponse => {
         if (!isFeatureFlagEnabled(VELAY_WEBHOOKS_FLAG_KEY)) {
           return { disabled: true };
         }
@@ -53,14 +42,16 @@ export function createWebhookRouteRoutes(): IpcRoute[] {
     }),
     ipcRoute({
       method: "unregister_webhook_route",
-      schema: UnregisterWebhookRouteSchema,
-      handler: (params) => ({
+      schema: UnregisterWebhookRouteIpcParamsSchema,
+      handler: (params): UnregisterWebhookRouteIpcResponse => ({
         removed: unregisterWebhookIngressRoute(params.path),
       }),
     }),
     {
       method: "list_webhook_routes",
-      handler: () => ({ routes: listWebhookIngressRoutes() }),
+      handler: (): ListWebhookRoutesIpcResponse => ({
+        routes: listWebhookIngressRoutes(),
+      }),
     },
   ];
 }

--- a/gateway/src/ipc/webhook-route-handlers.ts
+++ b/gateway/src/ipc/webhook-route-handlers.ts
@@ -1,0 +1,66 @@
+/**
+ * IPC route definitions for the webhook ingress route registry.
+ *
+ * Lets the daemon claim, drop, and inspect the exact subpaths this assistant
+ * answers from outside. Only registration is gated on `velay-webhooks`;
+ * revocation and inspection stay available so an operator can always see and
+ * remove what was claimed while the flag was on.
+ */
+
+import { z } from "zod";
+
+import {
+  listWebhookIngressRoutes,
+  registerWebhookIngressRoute,
+  unregisterWebhookIngressRoute,
+  type WebhookIngressRoute,
+} from "../db/webhook-ingress-route-store.js";
+import { isFeatureFlagEnabled } from "../feature-flag-resolver.js";
+import { ipcRoute, type IpcRoute } from "./server.js";
+
+const VELAY_WEBHOOKS_FLAG_KEY = "velay-webhooks";
+
+const RegisterWebhookRouteSchema = z.object({
+  path: z.string().min(1),
+  type: z.string().min(1),
+  source: z.string().nullish(),
+});
+
+const UnregisterWebhookRouteSchema = z.object({
+  path: z.string().min(1),
+});
+
+/**
+ * A refusal is a normal result rather than an error: the daemon reads
+ * `disabled` as "this assistant is not serving its own webhooks" and falls
+ * back to the platform's callback routes.
+ */
+type RegisterWebhookRouteResult =
+  | { disabled: true }
+  | { disabled: false; route: WebhookIngressRoute };
+
+export function createWebhookRouteRoutes(): IpcRoute[] {
+  return [
+    ipcRoute({
+      method: "register_webhook_route",
+      schema: RegisterWebhookRouteSchema,
+      handler: (params): RegisterWebhookRouteResult => {
+        if (!isFeatureFlagEnabled(VELAY_WEBHOOKS_FLAG_KEY)) {
+          return { disabled: true };
+        }
+        return { disabled: false, route: registerWebhookIngressRoute(params) };
+      },
+    }),
+    ipcRoute({
+      method: "unregister_webhook_route",
+      schema: UnregisterWebhookRouteSchema,
+      handler: (params) => ({
+        removed: unregisterWebhookIngressRoute(params.path),
+      }),
+    }),
+    {
+      method: "list_webhook_routes",
+      handler: () => ({ routes: listWebhookIngressRoutes() }),
+    },
+  ];
+}

--- a/packages/gateway-client/src/gateway-ipc-contracts.ts
+++ b/packages/gateway-client/src/gateway-ipc-contracts.ts
@@ -347,6 +347,72 @@ export type GetGuardianContactIpcResponse = z.infer<
   typeof GetGuardianContactIpcResponseSchema
 >;
 
+// ── webhook ingress routes ───────────────────────────────────────────────────
+// The gateway owns the registry of subpaths this assistant answers from
+// outside; the daemon claims, drops, and inspects them over IPC. Both sides
+// read these schemas so a change to the stored row has to travel through the
+// contract.
+
+export const WebhookIngressRouteSchema = z.object({
+  path: z.string(),
+  type: z.string(),
+  source: z.string().nullable(),
+  match: z.literal("exact"),
+  createdAt: z.number(),
+  lastRegisteredAt: z.number(),
+});
+
+export type WebhookIngressRoute = z.infer<typeof WebhookIngressRouteSchema>;
+
+export const RegisterWebhookRouteIpcParamsSchema = z.object({
+  /** Exact subpath, leading slash included, under `/webhooks/`. */
+  path: z.string().min(1),
+  type: z.string().min(1),
+  source: z.string().nullish(),
+});
+
+export type RegisterWebhookRouteIpcParams = z.infer<
+  typeof RegisterWebhookRouteIpcParamsSchema
+>;
+
+/**
+ * A refusal is a normal result rather than an error: the daemon reads
+ * `disabled` as "this assistant is not serving its own webhooks" and falls
+ * back to the platform's callback routes.
+ */
+export const RegisterWebhookRouteIpcResponseSchema = z.union([
+  z.object({ disabled: z.literal(true) }),
+  z.object({ disabled: z.literal(false), route: WebhookIngressRouteSchema }),
+]);
+
+export type RegisterWebhookRouteIpcResponse = z.infer<
+  typeof RegisterWebhookRouteIpcResponseSchema
+>;
+
+export const UnregisterWebhookRouteIpcParamsSchema = z.object({
+  path: z.string().min(1),
+});
+
+export type UnregisterWebhookRouteIpcParams = z.infer<
+  typeof UnregisterWebhookRouteIpcParamsSchema
+>;
+
+export const UnregisterWebhookRouteIpcResponseSchema = z.object({
+  removed: z.boolean(),
+});
+
+export type UnregisterWebhookRouteIpcResponse = z.infer<
+  typeof UnregisterWebhookRouteIpcResponseSchema
+>;
+
+export const ListWebhookRoutesIpcResponseSchema = z.object({
+  routes: z.array(WebhookIngressRouteSchema),
+});
+
+export type ListWebhookRoutesIpcResponse = z.infer<
+  typeof ListWebhookRoutesIpcResponseSchema
+>;
+
 // ── classify_risk ────────────────────────────────────────────────────────────
 // Risk classification is gateway-owned; the assistant sends one request per
 // tool invocation and reads the whole answer back. The gateway validates the


### PR DESCRIPTION
## Summary

- Adds `register_webhook_route` / `unregister_webhook_route` / `list_webhook_routes` IPC routes over the gateway webhook ingress route registry, wired into the gateway IPC server.
- Registration is gated on `velay-webhooks` and returns `{disabled: true}` when off so the daemon falls back to Django; revocation and listing always work.
- Adds typed daemon wrappers `ipcRegisterWebhookRoute`, `ipcUnregisterWebhookRoute`, `ipcListWebhookRoutes`.

Part of plan: webhook-consolidation-velay.md (PR 2 of 9)