### PR TITLE
feat(gateway): advertise registered webhook routes to Velay and refresh on change

### DIFF
--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -204,7 +204,10 @@ import {
 import { SleepWakeDetector } from "./sleep-wake-detector.js";
 import { callTelegramApi } from "./telegram/api.js";
 import { fetchImpl } from "./fetch.js";
-import { arePlatformFeaturesEnabled } from "./feature-flag-resolver.js";
+import {
+  arePlatformFeaturesEnabled,
+  isFeatureFlagEnabled,
+} from "./feature-flag-resolver.js";
 import { isNewCommand, handleNewCommand } from "./webhook-pipeline.js";
 import { reconcileTelegramWebhook } from "./telegram/webhook-manager.js";
 import { registerEmailCallbackRoute } from "./email/register-callback.js";
@@ -238,7 +241,9 @@ import { AvatarSyncWatcher } from "./avatar-sync/avatar-sync-watcher.js";
 import { SlackAvatarSyncer } from "./avatar-sync/slack-avatar-syncer.js";
 import { initGatewayDb } from "./db/connection.js";
 import { cleanupExpiredInboundEvents } from "./db/inbound-dedup-store.js";
+import { onWebhookIngressRoutesChanged } from "./db/webhook-ingress-route-store.js";
 import { runPostAssistantReady } from "./post-assistant-ready.js";
+import { VELAY_WEBHOOKS_FLAG_KEY } from "./velay/allowed-paths.js";
 import {
   clearManagedPublicBaseUrl,
   createVelayTunnelClient,
@@ -390,6 +395,11 @@ async function main() {
   const velayTunnelClient = createVelayTunnelClient(config, {
     credentials: credentialCache,
     configFile: configFileCache,
+  });
+  // Velay only sees a webhook route on the next tunnel connect, so a registry
+  // write asks for one.
+  onWebhookIngressRoutesChanged(() => {
+    velayTunnelClient?.requestRulesRefresh("webhook-routes-changed");
   });
 
   // ── Avatar sync ──
@@ -2937,8 +2947,16 @@ async function main() {
     assistantRuntimeBaseUrl: config.assistantRuntimeBaseUrl,
   });
 
+  let velayWebhooksEnabled = isFeatureFlagEnabled(VELAY_WEBHOOKS_FLAG_KEY);
   emitFlagChanged = () => {
     ipcServer.emit("feature_flags_changed");
+    // The flag decides the shape of the advertised rules, so flipping it has
+    // to re-advertise rather than wait out the periodic tunnel refresh.
+    const enabled = isFeatureFlagEnabled(VELAY_WEBHOOKS_FLAG_KEY);
+    if (enabled !== velayWebhooksEnabled) {
+      velayWebhooksEnabled = enabled;
+      velayTunnelClient?.requestRulesRefresh("velay-webhooks-flag-changed");
+    }
   };
 
   const featureFlagWatcher = new FeatureFlagWatcher({

--- a/gateway/src/velay/allowed-paths.test.ts
+++ b/gateway/src/velay/allowed-paths.test.ts
@@ -1,10 +1,27 @@
-import { describe, expect, it } from "bun:test";
+import { beforeEach, describe, expect, it, mock } from "bun:test";
 
-import {
+let velayWebhooksEnabled = false;
+
+mock.module("../feature-flag-resolver.js", () => ({
+  isFeatureFlagEnabled: (flag: string) =>
+    flag === "velay-webhooks" ? velayWebhooksEnabled : false,
+}));
+
+const {
   VELAY_ALLOWED_PATHS,
   VELAY_ALLOWED_PATHS_HEADER,
   VELAY_ALLOWED_PATHS_HEADER_VALUE,
-} from "./allowed-paths.js";
+  VELAY_STATIC_ALLOWED_PATHS,
+  buildVelayAllowedPathsHeaderValue,
+} = await import("./allowed-paths.js");
+
+function decode(headerValue: string): string[] {
+  return JSON.parse(headerValue) as string[];
+}
+
+beforeEach(() => {
+  velayWebhooksEnabled = false;
+});
 
 describe("VELAY_ALLOWED_PATHS", () => {
   it("matches the platform-side header name (must stay in sync with vellum-assistant-platform RegistrationAllowedPathsHeader)", () => {
@@ -23,7 +40,17 @@ describe("VELAY_ALLOWED_PATHS", () => {
   it("contains only RE2-portable regex patterns (no JS-specific lookaround / backreferences) that compile in JavaScript too", () => {
     // We can't run Go RE2 here, but every pattern below is plain anchored
     // prefix/exact matching that's a strict subset of both engines.
-    for (const pattern of VELAY_ALLOWED_PATHS) {
+    velayWebhooksEnabled = true;
+    const patterns = [
+      ...VELAY_ALLOWED_PATHS,
+      ...decode(
+        buildVelayAllowedPathsHeaderValue([
+          "/webhooks/plugins/example/realtime",
+          "/webhooks/plugins/ex.am+ple/(realtime)",
+        ]),
+      ),
+    ];
+    for (const pattern of patterns) {
       expect(() => new RegExp(pattern)).not.toThrow();
       // RE2-incompatible features that should never appear: lookahead,
       // lookbehind, backreferences. A simple guard is enough — the platform
@@ -75,5 +102,61 @@ describe("VELAY_ALLOWED_PATHS", () => {
       const matched = compiled.some((re) => re.test(path));
       expect({ path, matched }).toEqual({ path, matched: expected });
     }
+  });
+});
+
+describe("buildVelayAllowedPathsHeaderValue", () => {
+  it("advertises the legacy list verbatim while the flag is off", () => {
+    expect(buildVelayAllowedPathsHeaderValue([])).toBe(
+      VELAY_ALLOWED_PATHS_HEADER_VALUE,
+    );
+    expect(buildVelayAllowedPathsHeaderValue(["/webhooks/telegram"])).toBe(
+      VELAY_ALLOWED_PATHS_HEADER_VALUE,
+    );
+  });
+
+  it("drops the webhook wildcard for the statics plus one exact rule per registered path", () => {
+    velayWebhooksEnabled = true;
+
+    const rules = decode(
+      buildVelayAllowedPathsHeaderValue([
+        "/webhooks/telegram",
+        "/webhooks/plugins/example/realtime",
+      ]),
+    );
+
+    expect(rules).toEqual([
+      ...VELAY_STATIC_ALLOWED_PATHS,
+      "^/webhooks/telegram$",
+      "^/webhooks/plugins/example/realtime$",
+    ]);
+    expect(rules).not.toContain("^/webhooks/");
+    // The Twilio subtree keeps its prefix rule because its paths carry call
+    // state the registry cannot hold.
+    expect(rules).toContain("^/webhooks/twilio/");
+  });
+
+  it("advertises only the statics when nothing is registered", () => {
+    velayWebhooksEnabled = true;
+
+    expect(decode(buildVelayAllowedPathsHeaderValue([]))).toEqual([
+      ...VELAY_STATIC_ALLOWED_PATHS,
+    ]);
+  });
+
+  it("escapes regex metacharacters so a generated rule matches only its own path", () => {
+    velayWebhooksEnabled = true;
+    const path = "/webhooks/plugins/a.b+c*d?e|f(g)h[i]j{k}^l$m\\n";
+
+    const rules = decode(buildVelayAllowedPathsHeaderValue([path]));
+    const generated = rules[rules.length - 1];
+    const compiled = new RegExp(generated);
+
+    expect(compiled.test(path)).toBe(true);
+    expect(compiled.test("/webhooks/plugins/aXbXcXdXeXfXgXhXiXjXkXlXmXn")).toBe(
+      false,
+    );
+    expect(compiled.test(`${path}/extra`)).toBe(false);
+    expect(compiled.test(`/prefix${path}`)).toBe(false);
   });
 });

--- a/gateway/src/velay/allowed-paths.ts
+++ b/gateway/src/velay/allowed-paths.ts
@@ -27,15 +27,15 @@ import { isFeatureFlagEnabled } from "../feature-flag-resolver.js";
 /**
  * Public routes outside the webhook namespace:
  *
- *   - `^/v1/audio/` — Twilio fetches generated audio URLs directly on the
+ *   - `^/v1/audio/`: Twilio fetches generated audio URLs directly on the
  *     public surface (see comment at `gateway/src/index.ts` audio route).
- *   - `^/v1/live-voice$` — the browser live-voice WebSocket (the Twilio
+ *   - `^/v1/live-voice$`: the browser live-voice WebSocket (the Twilio
  *     media-stream WebSocket rides the Twilio webhook prefix).
- *   - `^/v1/stt/stream$` — the public STT streaming WebSocket.
- *   - `^/assistant/credentials/enter$` — the gateway-served one-time
+ *   - `^/v1/stt/stream$`: the public STT streaming WebSocket.
+ *   - `^/assistant/credentials/enter$`: the gateway-served one-time
  *     credential entry page (self-contained HTML; the single-use token rides
  *     the URL fragment, which never reaches Velay or the gateway logs).
- *   - `^/v1/credential-requests/(peek|submit)$` — the entry page's
+ *   - `^/v1/credential-requests/(peek|submit)$`: the entry page's
  *     unauthenticated API calls; the single-use token travels in the POST
  *     body and is validated by the gateway handlers.
  */

--- a/gateway/src/velay/allowed-paths.ts
+++ b/gateway/src/velay/allowed-paths.ts
@@ -10,33 +10,36 @@
  *
  * Each entry is a Go RE2 regex string. Patterns are anchored at the start
  * (`^/...`) and either prefix-bound (trailing `/`) or exactly anchored (`$`)
- * depending on the route shape:
+ * depending on the route shape. Provider-side signature validation is
+ * performed by the per-route handlers in the gateway runtime, not by Velay.
  *
- *   - `^/webhooks/` — every webhook handler under `/webhooks/*` (Twilio voice,
- *     status, voice-verify, the media-stream WebSocket upgrade, Telegram,
- *     WhatsApp, email, Resend, Mailgun, OAuth callback).
- *     Provider-side signature validation is performed by the per-route
- *     handlers in the gateway runtime, not by Velay.
+ * If you add a new public route to `gateway/src/index.ts` that must be
+ * reachable through the Velay tunnel (i.e. anything an external provider
+ * calls or any unauthenticated callback endpoint), add a matching pattern
+ * here as well. Webhook routes instead go in the webhook ingress registry,
+ * which {@link buildVelayAllowedPathsHeaderValue} advertises row by row. The
+ * route-table guard test in `allowed-paths.test.ts` enforces symmetry between
+ * the allowlist and the gateway's actual public surface.
+ */
+
+import { isFeatureFlagEnabled } from "../feature-flag-resolver.js";
+
+/**
+ * Public routes outside the webhook namespace:
+ *
  *   - `^/v1/audio/` — Twilio fetches generated audio URLs directly on the
  *     public surface (see comment at `gateway/src/index.ts` audio route).
- *   - `^/v1/live-voice` — exact match for the browser live-voice WebSocket
- *     (the Twilio media-stream WebSocket rides `^/webhooks/`).
- *   - `^/v1/stt/stream` — exact match for the public STT streaming WebSocket.
+ *   - `^/v1/live-voice$` — the browser live-voice WebSocket (the Twilio
+ *     media-stream WebSocket rides the Twilio webhook prefix).
+ *   - `^/v1/stt/stream$` — the public STT streaming WebSocket.
  *   - `^/assistant/credentials/enter$` — the gateway-served one-time
  *     credential entry page (self-contained HTML; the single-use token rides
  *     the URL fragment, which never reaches Velay or the gateway logs).
  *   - `^/v1/credential-requests/(peek|submit)$` — the entry page's
  *     unauthenticated API calls; the single-use token travels in the POST
  *     body and is validated by the gateway handlers.
- *
- * If you add a new public route to `gateway/src/index.ts` that must be
- * reachable through the Velay tunnel (i.e. anything an external provider
- * calls or any unauthenticated callback endpoint), add a matching pattern
- * here as well. The route-table guard test in `allowed-paths.test.ts` enforces
- * symmetry between the allowlist and the gateway's actual public surface.
  */
-export const VELAY_ALLOWED_PATHS: readonly string[] = Object.freeze([
-  "^/webhooks/",
+const VELAY_NON_WEBHOOK_ALLOWED_PATHS: readonly string[] = Object.freeze([
   "^/v1/audio/",
   "^/v1/live-voice$",
   "^/v1/stt/stream$",
@@ -45,16 +48,75 @@ export const VELAY_ALLOWED_PATHS: readonly string[] = Object.freeze([
 ]);
 
 /**
+ * Twilio reaches the gateway on paths carrying call state in their segments
+ * (`/webhooks/twilio/media-stream/<callSessionId>/<token>`), which an
+ * exact-match registry row cannot express, so the whole Twilio subtree stays a
+ * prefix rule.
+ */
+const VELAY_TWILIO_WEBHOOKS_PATH = "^/webhooks/twilio/";
+
+/**
+ * Every handler under `/webhooks/*`: Twilio voice, status, voice-verify, the
+ * media-stream WebSocket upgrade, Telegram, WhatsApp, email, Resend, Mailgun,
+ * the OAuth callback, and plugin-declared webhooks.
+ */
+const VELAY_WEBHOOKS_WILDCARD_PATH = "^/webhooks/";
+
+/** The rules advertised while `velay-webhooks` is off. */
+export const VELAY_ALLOWED_PATHS: readonly string[] = Object.freeze([
+  VELAY_WEBHOOKS_WILDCARD_PATH,
+  ...VELAY_NON_WEBHOOK_ALLOWED_PATHS,
+]);
+
+/**
+ * The rules that hold whatever the webhook ingress registry contains.
+ * {@link buildVelayAllowedPathsHeaderValue} appends one exact-match rule per
+ * registered webhook path to these.
+ */
+export const VELAY_STATIC_ALLOWED_PATHS: readonly string[] = Object.freeze([
+  VELAY_TWILIO_WEBHOOKS_PATH,
+  ...VELAY_NON_WEBHOOK_ALLOWED_PATHS,
+]);
+
+/**
  * HTTP request header set on the WebSocket upgrade to declare the tunnel's
- * path allowlist to Velay. The value is `JSON.stringify(VELAY_ALLOWED_PATHS)`.
- * Mirrors `RegistrationAllowedPathsHeader` on the platform side.
+ * path allowlist to Velay. Mirrors `RegistrationAllowedPathsHeader` on the
+ * platform side.
  */
 export const VELAY_ALLOWED_PATHS_HEADER = "X-Vellum-Velay-Allowed-Paths";
 
-/**
- * Encoded header value to attach to the registration WS upgrade. Cached at
- * module load — the allowlist is static for the lifetime of the gateway
- * process.
- */
+/** Encoded header value advertised while `velay-webhooks` is off. */
 export const VELAY_ALLOWED_PATHS_HEADER_VALUE =
   JSON.stringify(VELAY_ALLOWED_PATHS);
+
+/**
+ * Gates whether the webhook namespace is advertised as one wildcard rule or as
+ * one exact rule per registered path.
+ */
+export const VELAY_WEBHOOKS_FLAG_KEY = "velay-webhooks";
+
+const RE2_METACHARACTERS = /[.*+?^${}()|[\]\\]/g;
+
+/** Escape `value` so it matches only itself under both RE2 and JavaScript. */
+function escapeForRe2(value: string): string {
+  return value.replace(RE2_METACHARACTERS, "\\$&");
+}
+
+/**
+ * The header value to advertise for a tunnel serving `registeredPaths`.
+ *
+ * With `velay-webhooks` off this is the wildcard allowlist. With it on the
+ * webhook namespace narrows to exactly the registered paths, so Velay drops
+ * anything else under `/webhooks/` before it reaches the gateway.
+ */
+export function buildVelayAllowedPathsHeaderValue(
+  registeredPaths: string[],
+): string {
+  if (!isFeatureFlagEnabled(VELAY_WEBHOOKS_FLAG_KEY)) {
+    return VELAY_ALLOWED_PATHS_HEADER_VALUE;
+  }
+  return JSON.stringify([
+    ...VELAY_STATIC_ALLOWED_PATHS,
+    ...registeredPaths.map((path) => `^${escapeForRe2(path)}$`),
+  ]);
+}

--- a/gateway/src/velay/client.test.ts
+++ b/gateway/src/velay/client.test.ts
@@ -13,7 +13,6 @@ import type { GatewayConfig } from "../config.js";
 import type { ConfigFileCache } from "../config-file-cache.js";
 import type { CredentialCache } from "../credential-cache.js";
 import { credentialKey } from "../credential-key.js";
-import { VELAY_ALLOWED_PATHS_HEADER_VALUE } from "./allowed-paths.js";
 import {
   FakeWebSocket,
   makeFakeWebSocketConstructor,
@@ -29,12 +28,29 @@ import {
 } from "./protocol.js";
 
 let workspaceDir = "";
+let registeredWebhookPaths: string[] = [];
+let velayWebhooksEnabled = false;
 
 mock.module("../credential-reader.js", () => ({
   getWorkspaceDir: () => workspaceDir,
   readCredential: async () => undefined,
 }));
 
+mock.module("../db/webhook-ingress-route-store.js", () => ({
+  listWebhookIngressRoutes: () =>
+    registeredWebhookPaths.map((path) => ({ path })),
+}));
+
+mock.module("../feature-flag-resolver.js", () => ({
+  isFeatureFlagEnabled: (flag: string) =>
+    flag === "velay-webhooks" ? velayWebhooksEnabled : false,
+}));
+
+const {
+  VELAY_ALLOWED_PATHS_HEADER_VALUE,
+  VELAY_STATIC_ALLOWED_PATHS,
+  buildVelayAllowedPathsHeaderValue,
+} = await import("./allowed-paths.js");
 const { VelayTunnelClient, createVelayTunnelClient, enablePublicIngress } =
   await import("./client.js");
 
@@ -212,6 +228,8 @@ async function flushPromises(): Promise<void> {
 
 beforeEach(() => {
   workspaceDir = mkdtempSync(join(tmpdir(), "velay-client-"));
+  registeredWebhookPaths = [];
+  velayWebhooksEnabled = false;
 });
 
 afterEach(() => {
@@ -1469,6 +1487,141 @@ describe("proactive tunnel refresh", () => {
     callbacks[0]();
     await flushPromises();
     expect(sockets[0].closes).toEqual([]);
+    await client.stop();
+  });
+});
+
+describe("advertised path rules", () => {
+  async function registerTunnel(sockets: FakeWebSocket[]): Promise<void> {
+    sockets[0].readyState = WS_OPEN;
+    sockets[0].emit("open");
+    sendFrame(sockets[0], {
+      type: VELAY_FRAME_TYPES.registered,
+      assistant_id: "asst-123",
+      public_url: "https://velay-public.example.test",
+    });
+    await flushPromises();
+  }
+
+  function headerValue(socket: FakeWebSocket): unknown {
+    return (socket.options as { headers: Record<string, string> } | undefined)
+      ?.headers["X-Vellum-Velay-Allowed-Paths"];
+  }
+
+  test("advertises the registered routes on connect while the flag is on", async () => {
+    velayWebhooksEnabled = true;
+    registeredWebhookPaths = ["/webhooks/telegram"];
+    const sockets: FakeWebSocket[] = [];
+    const client = makeClient({ sockets });
+
+    client.start();
+    await flushPromises();
+
+    expect(headerValue(sockets[0])).toBe(
+      buildVelayAllowedPathsHeaderValue(["/webhooks/telegram"]),
+    );
+    expect(JSON.parse(headerValue(sockets[0]) as string)).toEqual([
+      ...VELAY_STATIC_ALLOWED_PATHS,
+      "^/webhooks/telegram$",
+    ]);
+    await client.stop();
+  });
+
+  test("coalesces a burst of registry changes into one reconnect", async () => {
+    const sockets: FakeWebSocket[] = [];
+    const delays: number[] = [];
+    const callbacks: Array<() => void> = [];
+    const client = makeClient({
+      sockets,
+      reconnectDelays: delays,
+      timerCallbacks: callbacks,
+    });
+
+    client.start();
+    await flushPromises();
+    await registerTunnel(sockets);
+    expect(delays).toEqual([]);
+
+    client.requestRulesRefresh("first");
+    client.requestRulesRefresh("second");
+    client.requestRulesRefresh("third");
+    expect(delays).toEqual([5000]);
+
+    velayWebhooksEnabled = true;
+    registeredWebhookPaths = ["/webhooks/telegram"];
+    callbacks[0]();
+    await flushPromises();
+    expect(sockets[0].closes).toEqual([
+      { code: 1000, reason: "proactive tunnel refresh" },
+    ]);
+
+    // The reconnect carries the rules the burst asked for.
+    callbacks[1]();
+    await flushPromises();
+    expect(sockets).toHaveLength(2);
+    expect(JSON.parse(headerValue(sockets[1]) as string)).toEqual([
+      ...VELAY_STATIC_ALLOWED_PATHS,
+      "^/webhooks/telegram$",
+    ]);
+    await client.stop();
+  });
+
+  test("defers a rule refresh while the tunnel is busy, then refreshes once idle", async () => {
+    const sockets: FakeWebSocket[] = [];
+    const delays: number[] = [];
+    const callbacks: Array<() => void> = [];
+    const bridgeConnections = { count: 1 };
+    const bridgeIdle = { fire: () => {} };
+    const client = makeClient({
+      sockets,
+      reconnectDelays: delays,
+      timerCallbacks: callbacks,
+      bridgeConnections,
+      bridgeIdle,
+    });
+
+    client.start();
+    await flushPromises();
+    await registerTunnel(sockets);
+
+    client.requestRulesRefresh("webhook-routes-changed");
+    callbacks[0]();
+    await flushPromises();
+    expect(sockets[0].closes).toEqual([]);
+
+    bridgeConnections.count = 0;
+    bridgeIdle.fire();
+    await flushPromises();
+    expect(sockets[0].closes).toEqual([
+      { code: 1000, reason: "proactive tunnel refresh" },
+    ]);
+    await client.stop();
+  });
+
+  test("ignores a rule refresh while disconnected and advertises the rules on the next connect", async () => {
+    const sockets: FakeWebSocket[] = [];
+    const delays: number[] = [];
+    const callbacks: Array<() => void> = [];
+    const client = makeClient({
+      sockets,
+      reconnectDelays: delays,
+      timerCallbacks: callbacks,
+    });
+
+    client.requestRulesRefresh("before start");
+    expect(delays).toEqual([]);
+
+    velayWebhooksEnabled = true;
+    registeredWebhookPaths = ["/webhooks/plugins/example/realtime"];
+    client.start();
+    await flushPromises();
+    await registerTunnel(sockets);
+
+    expect(JSON.parse(headerValue(sockets[0]) as string)).toEqual([
+      ...VELAY_STATIC_ALLOWED_PATHS,
+      "^/webhooks/plugins/example/realtime$",
+    ]);
+    expect(delays).toEqual([]);
     await client.stop();
   });
 });

--- a/gateway/src/velay/client.test.ts
+++ b/gateway/src/velay/client.test.ts
@@ -39,6 +39,13 @@ mock.module("../credential-reader.js", () => ({
 mock.module("../db/webhook-ingress-route-store.js", () => ({
   listWebhookIngressRoutes: () =>
     registeredWebhookPaths.map((path) => ({ path })),
+  hasWebhookIngressRoute: (path: string) =>
+    registeredWebhookPaths.includes(path),
+  registerWebhookIngressRoute: () => {
+    throw new Error("not expected in these tests");
+  },
+  unregisterWebhookIngressRoute: () => false,
+  onWebhookIngressRoutesChanged: () => () => {},
 }));
 
 mock.module("../feature-flag-resolver.js", () => ({

--- a/gateway/src/velay/client.test.ts
+++ b/gateway/src/velay/client.test.ts
@@ -1492,10 +1492,10 @@ describe("proactive tunnel refresh", () => {
 });
 
 describe("advertised path rules", () => {
-  async function registerTunnel(sockets: FakeWebSocket[]): Promise<void> {
-    sockets[0].readyState = WS_OPEN;
-    sockets[0].emit("open");
-    sendFrame(sockets[0], {
+  async function registerTunnel(socket: FakeWebSocket): Promise<void> {
+    socket.readyState = WS_OPEN;
+    socket.emit("open");
+    sendFrame(socket, {
       type: VELAY_FRAME_TYPES.registered,
       assistant_id: "asst-123",
       public_url: "https://velay-public.example.test",
@@ -1539,7 +1539,7 @@ describe("advertised path rules", () => {
 
     client.start();
     await flushPromises();
-    await registerTunnel(sockets);
+    await registerTunnel(sockets[0]);
     expect(delays).toEqual([]);
 
     client.requestRulesRefresh("first");
@@ -1582,7 +1582,7 @@ describe("advertised path rules", () => {
 
     client.start();
     await flushPromises();
-    await registerTunnel(sockets);
+    await registerTunnel(sockets[0]);
 
     client.requestRulesRefresh("webhook-routes-changed");
     callbacks[0]();
@@ -1615,13 +1615,64 @@ describe("advertised path rules", () => {
     registeredWebhookPaths = ["/webhooks/plugins/example/realtime"];
     client.start();
     await flushPromises();
-    await registerTunnel(sockets);
+    await registerTunnel(sockets[0]);
 
     expect(JSON.parse(headerValue(sockets[0]) as string)).toEqual([
       ...VELAY_STATIC_ALLOWED_PATHS,
       "^/webhooks/plugins/example/realtime$",
     ]);
     expect(delays).toEqual([]);
+    await client.stop();
+  });
+
+  test("refreshes the reconnected tunnel when a reconnect races the debounce", async () => {
+    velayWebhooksEnabled = true;
+    registeredWebhookPaths = ["/webhooks/telegram"];
+    const sockets: FakeWebSocket[] = [];
+    const delays: number[] = [];
+    const callbacks: Array<() => void> = [];
+    const client = makeClient({
+      sockets,
+      reconnectDelays: delays,
+      timerCallbacks: callbacks,
+    });
+
+    client.start();
+    await flushPromises();
+    await registerTunnel(sockets[0]);
+
+    client.requestRulesRefresh("first change");
+    expect(delays).toEqual([5000]);
+
+    // The tunnel drops and reconnects before the debounce fires, so the
+    // replacement socket already advertises the first change.
+    sockets[0].readyState = WS_CLOSED;
+    sockets[0].emit("close", { code: 1006, reason: "" });
+    await flushPromises();
+    callbacks[1]();
+    await flushPromises();
+    expect(sockets).toHaveLength(2);
+    await registerTunnel(sockets[1]);
+
+    // A second change lands after the replacement connected, so only a
+    // refresh of that socket can advertise it.
+    registeredWebhookPaths = ["/webhooks/telegram", "/webhooks/stripe"];
+    client.requestRulesRefresh("second change");
+
+    callbacks[0]();
+    await flushPromises();
+    expect(sockets[1].closes).toEqual([
+      { code: 1000, reason: "proactive tunnel refresh" },
+    ]);
+
+    callbacks[callbacks.length - 1]();
+    await flushPromises();
+    expect(sockets).toHaveLength(3);
+    expect(JSON.parse(headerValue(sockets[2]) as string)).toEqual([
+      ...VELAY_STATIC_ALLOWED_PATHS,
+      "^/webhooks/telegram$",
+      "^/webhooks/stripe$",
+    ]);
     await client.stop();
   });
 });

--- a/gateway/src/velay/client.ts
+++ b/gateway/src/velay/client.ts
@@ -199,16 +199,19 @@ export class VelayTunnelClient {
    * Reconnect so Velay sees the current path rules. Only a live tunnel needs
    * this: the next connect reads the registry itself, so a client that is
    * stopped or disconnected already picks the change up. Deferred while the
-   * tunnel is busy, the same way the load-balancer refresh is.
+   * tunnel is busy, the same way the load-balancer refresh is. The socket to
+   * refresh is resolved when the debounce fires rather than captured when it
+   * is armed, so a reconnect during the debounce window still advertises the
+   * rules that landed after it connected.
    */
   requestRulesRefresh(reason: string): void {
-    const ws = this.ws;
-    if (!this.running || !ws || this.rulesRefreshTimer) {
+    if (!this.running || !this.ws || this.rulesRefreshTimer) {
       return;
     }
     this.rulesRefreshTimer = this.timerApi.setTimeout(() => {
       this.rulesRefreshTimer = null;
-      if (!this.running || this.ws !== ws) {
+      const ws = this.ws;
+      if (!this.running || !ws) {
         return;
       }
       if (this.isTunnelBusy()) {

--- a/gateway/src/velay/client.ts
+++ b/gateway/src/velay/client.ts
@@ -9,9 +9,10 @@ import { credentialKey } from "../credential-key.js";
 import { mutateConfigFile } from "../config-file-utils.js";
 import { getLogger } from "../logger.js";
 import { ExponentialBackoff } from "../util/exponential-backoff.js";
+import { listWebhookIngressRoutes } from "../db/webhook-ingress-route-store.js";
 import {
   VELAY_ALLOWED_PATHS_HEADER,
-  VELAY_ALLOWED_PATHS_HEADER_VALUE,
+  buildVelayAllowedPathsHeaderValue,
 } from "./allowed-paths.js";
 import { bridgeVelayHttpRequest } from "./http-bridge.js";
 import { closeWebSocket } from "./bridge-utils.js";
@@ -40,6 +41,9 @@ const HEARTBEAT_READ_TIMEOUT_MS = 60_000;
 // ever chopping an established call.
 const TUNNEL_REFRESH_AFTER_MS = 3_300_000;
 const TUNNEL_REFRESH_BUSY_RETRY_MS = 30_000;
+// A lifecycle that registers several webhook routes in a row should cost one
+// reconnect, not one per route, so rule refreshes coalesce over this window.
+const RULES_REFRESH_DEBOUNCE_MS = 5_000;
 
 export type WebSocketConstructorWithOptions = {
   new (
@@ -102,6 +106,7 @@ export class VelayTunnelClient {
   private heartbeatTimer: unknown = null;
   private readTimeoutTimer: unknown = null;
   private refreshTimer: unknown = null;
+  private rulesRefreshTimer: unknown = null;
   // Set when the refresh deadline passed while the tunnel was busy: the
   // refresh then fires as soon as the tunnel drains (last bridged
   // connection or in-flight HTTP request completes) instead of waiting for
@@ -190,6 +195,31 @@ export class VelayTunnelClient {
     this.connectForCredentialRefresh(reason);
   }
 
+  /**
+   * Reconnect so Velay sees the current path rules. Only a live tunnel needs
+   * this: the next connect reads the registry itself, so a client that is
+   * stopped or disconnected already picks the change up. Deferred while the
+   * tunnel is busy, the same way the load-balancer refresh is.
+   */
+  requestRulesRefresh(reason: string): void {
+    const ws = this.ws;
+    if (!this.running || !ws || this.rulesRefreshTimer) {
+      return;
+    }
+    this.rulesRefreshTimer = this.timerApi.setTimeout(() => {
+      this.rulesRefreshTimer = null;
+      if (!this.running || this.ws !== ws) {
+        return;
+      }
+      if (this.isTunnelBusy()) {
+        this.refreshDue = true;
+        return;
+      }
+      log.info({ reason }, "Reconnecting Velay tunnel to advertise new rules");
+      this.performTunnelRefresh(ws);
+    }, RULES_REFRESH_DEBOUNCE_MS);
+  }
+
   start(): void {
     if (this.running) return;
     this.running = true;
@@ -218,6 +248,10 @@ export class VelayTunnelClient {
     }
     this.clearHeartbeat();
     this.clearTunnelRefresh();
+    if (this.rulesRefreshTimer) {
+      this.timerApi.clearTimeout(this.rulesRefreshTimer);
+      this.rulesRefreshTimer = null;
+    }
     const ws = this.ws;
     this.ws = null;
     this.webSocketBridge.closeAll();
@@ -302,9 +336,13 @@ export class VelayTunnelClient {
         headers: {
           Authorization: `Api-Key ${apiKey}`,
           // Declares the path allowlist Velay enforces for inbound proxied
-          // traffic on this tunnel. See ./allowed-paths.ts for the route
-          // inventory and the platform-side enforcement (ATL-402).
-          [VELAY_ALLOWED_PATHS_HEADER]: VELAY_ALLOWED_PATHS_HEADER_VALUE,
+          // traffic on this tunnel. Read per attempt so a reconnect picks up
+          // webhook routes registered since the last one. See
+          // ./allowed-paths.ts for the route inventory and the platform-side
+          // enforcement (ATL-402).
+          [VELAY_ALLOWED_PATHS_HEADER]: buildVelayAllowedPathsHeaderValue(
+            listWebhookIngressRoutes().map((route) => route.path),
+          ),
         },
       });
       ws.binaryType = "arraybuffer";


### PR DESCRIPTION
## Summary

- Splits the Velay allowlist into static rules plus one anchored exact-match rule per registered webhook ingress route, built per connect attempt. With `velay-webhooks` off the advertised header is byte-identical to today's constant.
- Adds `VelayTunnelClient.requestRulesRefresh()`: a 5s-debounced reconnect that defers to the existing idle machinery while the tunnel is busy and no-ops when the tunnel is down.
- The gateway asks for that refresh on webhook registry changes and on a `velay-webhooks` flag flip.

Part of plan: webhook-consolidation-velay.md (PR 4 of 9)