### PR TITLE
refactor(channels): give the typing capability its own parameters (LUM-3358)

### DIFF
--- a/assistant/src/messaging/providers/__tests__/transport-dispatch.test.ts
+++ b/assistant/src/messaging/providers/__tests__/transport-dispatch.test.ts
@@ -57,8 +57,12 @@ mock.module("../../../util/logger.js", () => ({
   getLogger: () => ({ debug() {}, info() {}, warn() {}, error() {} }),
 }));
 
-const { deliverDirect, isDirectDelivery, getTransportForCallback } =
-  await import("../index.js");
+const {
+  deliverDirect,
+  sendChannelTyping,
+  isDirectDelivery,
+  getTransportForCallback,
+} = await import("../index.js");
 
 const BASE = "https://gateway.internal";
 
@@ -164,12 +168,11 @@ describe("Slack sub-operation selection", () => {
     expect(slack.sendSlackReply).not.toHaveBeenCalled();
   });
 
-  test("a typing payload to Slack falls through to deliver (no typing capability)", async () => {
-    await deliverDirect(
-      `${BASE}/deliver/slack`,
-      payload({ chatAction: "typing", text: "hi" }),
-    );
-    expect(slack.sendSlackReply).toHaveBeenCalledTimes(1);
+  test("sendChannelTyping resolves quietly for a channel with no typing capability", async () => {
+    const result = await sendChannelTyping(`${BASE}/deliver/slack`, "C1");
+
+    expect(result).toEqual({ ok: true });
+    expect(slack.sendSlackReply).not.toHaveBeenCalled();
   });
 
   test("slackStream routes to sendSlackStreamOp ahead of the text path", async () => {
@@ -202,11 +205,9 @@ describe("capability gating across channels", () => {
     expect(telegram.sendTelegramReply).toHaveBeenCalledTimes(1);
   });
 
-  test("typing to Telegram routes to its typing indicator", async () => {
-    await deliverDirect(
-      `${BASE}/deliver/telegram`,
-      payload({ chatAction: "typing" }),
-    );
+  test("sendChannelTyping reaches Telegram's typing indicator", async () => {
+    await sendChannelTyping(`${BASE}/deliver/telegram`, "123");
+
     expect(telegram.sendTelegramTypingIndicator).toHaveBeenCalledTimes(1);
   });
 
@@ -244,15 +245,10 @@ describe("capability gating across channels", () => {
     });
   });
 
-  test("a typing payload to Discord falls through to deliver (no sendTyping)", async () => {
-    // Only the Telegram heartbeat produces `chatAction: "typing"`, and it is
-    // gated on sourceChannel === "telegram", so Discord can never receive one.
-    // The transport implements no sendTyping, so this falls through.
-    await deliverDirect(
-      `${BASE}/deliver/discord`,
-      payload({ chatAction: "typing", text: "hi" }),
-    );
-    expect(discord.sendDiscordReply).toHaveBeenCalledTimes(1);
+  test("sendChannelTyping reaches Discord's typing indicator", async () => {
+    await sendChannelTyping(`${BASE}/deliver/discord`, "999");
+
+    expect(discord.sendDiscordTypingIndicator).toHaveBeenCalledTimes(1);
   });
 
   test("a Slack-only stream payload to Discord falls through to deliver", async () => {

--- a/assistant/src/messaging/providers/__tests__/transport-dispatch.test.ts
+++ b/assistant/src/messaging/providers/__tests__/transport-dispatch.test.ts
@@ -60,6 +60,7 @@ mock.module("../../../util/logger.js", () => ({
 const {
   deliverDirect,
   sendChannelTyping,
+  supportsChannelTyping,
   isDirectDelivery,
   getTransportForCallback,
 } = await import("../index.js");
@@ -203,6 +204,16 @@ describe("capability gating across channels", () => {
       }),
     );
     expect(telegram.sendTelegramReply).toHaveBeenCalledTimes(1);
+  });
+
+  test("the typing capability is read from the transport, not the channel name", () => {
+    // The heartbeat gate in background-dispatch asks this rather than testing
+    // `sourceChannel === "telegram"`, so a channel that implements the method
+    // starts showing an indicator without a caller being changed.
+    expect(supportsChannelTyping(`${BASE}/deliver/telegram`)).toBe(true);
+    expect(supportsChannelTyping(`${BASE}/deliver/discord`)).toBe(true);
+    expect(supportsChannelTyping(`${BASE}/deliver/slack`)).toBe(false);
+    expect(supportsChannelTyping(`${BASE}/deliver/whatsapp`)).toBe(false);
   });
 
   test("sendChannelTyping reaches Telegram's typing indicator", async () => {

--- a/assistant/src/messaging/providers/channel-transport.ts
+++ b/assistant/src/messaging/providers/channel-transport.ts
@@ -35,11 +35,14 @@ export interface ChannelTransport {
     payload: ChannelReplyPayload,
   ): Promise<ChannelDeliveryResult>;
 
-  /** Send a typing indicator. Routed when `payload.chatAction === "typing"`. */
-  sendTyping?(
-    ctx: CallbackContext,
-    payload: ChannelReplyPayload,
-  ): Promise<ChannelDeliveryResult>;
+  /**
+   * Show that the assistant is working, in whatever form the channel has.
+   *
+   * Takes the place and nothing else, because that is all it needs. A channel
+   * without the affordance omits the method, so implementing it is the whole
+   * of declaring the capability.
+   */
+  typing?(ctx: CallbackContext, chatId: string): Promise<ChannelDeliveryResult>;
 
   /** Add an emoji reaction. Routed when `payload.reaction` is set. */
   sendReaction?(

--- a/assistant/src/messaging/providers/discord/send.ts
+++ b/assistant/src/messaging/providers/discord/send.ts
@@ -210,3 +210,19 @@ export async function sendDiscordAttachments(
     totalCount: attachments.length,
   };
 }
+
+/**
+ * Show the Discord typing indicator in a channel.
+ *
+ * Discord expires it after about ten seconds, so a caller that wants it to
+ * persist re-sends on a timer rather than clearing it; there is no stop route.
+ */
+export async function sendDiscordTypingIndicator(
+  target: DiscordSendTarget,
+): Promise<void> {
+  await callDiscordApi(
+    "POST",
+    `/channels/${encodeURIComponent(target.channelId)}/typing`,
+    {},
+  );
+}

--- a/assistant/src/messaging/providers/discord/transport.ts
+++ b/assistant/src/messaging/providers/discord/transport.ts
@@ -7,7 +7,11 @@ import type {
 } from "../channel-transport.js";
 import { openDiscordDmChannel } from "./api.js";
 import type { DiscordSendTarget } from "./send.js";
-import { sendDiscordAttachments, sendDiscordReply } from "./send.js";
+import {
+  sendDiscordAttachments,
+  sendDiscordReply,
+  sendDiscordTypingIndicator,
+} from "./send.js";
 
 const log = getLogger("discord-transport");
 
@@ -42,6 +46,12 @@ async function sendTarget(
 
 export const discordTransport: ChannelTransport = {
   channel: "discord",
+
+  async typing(ctx, chatId) {
+    await sendDiscordTypingIndicator(await sendTarget(ctx, chatId));
+    log.debug({ chatId }, "Discord typing indicator delivered (direct)");
+    return { ok: true };
+  },
 
   async deliver(ctx, payload) {
     const { chatId, text, attachments, approval } = payload;

--- a/assistant/src/messaging/providers/index.ts
+++ b/assistant/src/messaging/providers/index.ts
@@ -52,6 +52,16 @@ export function getTransportForCallback(
  * ordinary case rather than a failure: the indicator is decoration, and a
  * channel that cannot show one is not degraded by its absence.
  */
+/**
+ * Whether the channel this callback addresses can show a working indicator.
+ *
+ * Asks the transport rather than the channel id, so a channel that gains the
+ * method starts being asked without a caller being told about it.
+ */
+export function supportsChannelTyping(callbackUrl: string): boolean {
+  return getTransportForCallback(callbackUrl)?.typing !== undefined;
+}
+
 export async function sendChannelTyping(
   callbackUrl: string,
   chatId: string,
@@ -92,9 +102,9 @@ export function isDirectDelivery(callbackUrl: string): boolean {
  * Deliver a channel reply directly to the provider API, bypassing the gateway
  * HTTP proxy. Callers MUST check `isDirectDelivery()` first.
  *
- * Sub-operations (reaction, thread status, typing) route to the transport's
- * optional method when both the payload field and the method are present;
- * otherwise the reply is delivered as text / approval / attachments.
+ * Sub-operations (reaction, thread status) route to the transport's optional
+ * method when both the payload field and the method are present; otherwise
+ * the reply is delivered as text / approval / attachments.
  */
 export async function deliverDirect(
   callbackUrl: string,

--- a/assistant/src/messaging/providers/index.ts
+++ b/assistant/src/messaging/providers/index.ts
@@ -45,6 +45,24 @@ export function getTransportForCallback(
   return channel ? TRANSPORTS[channel] : undefined;
 }
 
+/**
+ * Show that the assistant is working on the channel this callback addresses.
+ *
+ * Resolves to nothing when the channel has no such affordance, which is the
+ * ordinary case rather than a failure: the indicator is decoration, and a
+ * channel that cannot show one is not degraded by its absence.
+ */
+export async function sendChannelTyping(
+  callbackUrl: string,
+  chatId: string,
+): Promise<ChannelDeliveryResult> {
+  const transport = getTransportForCallback(callbackUrl);
+  if (!transport?.typing) {
+    return { ok: true };
+  }
+  return transport.typing(callbackContext(callbackUrl), chatId);
+}
+
 function callbackContext(callbackUrl: string): CallbackContext {
   const params: Record<string, string> = {};
   try {
@@ -98,9 +116,6 @@ export async function deliverDirect(
   }
   if (payload.assistantThreadStatus && transport.setThreadStatus) {
     return transport.setThreadStatus(ctx, payload);
-  }
-  if (payload.chatAction === "typing" && transport.sendTyping) {
-    return transport.sendTyping(ctx, payload);
   }
   return transport.deliver(ctx, payload);
 }

--- a/assistant/src/messaging/providers/telegram-bot/send.test.ts
+++ b/assistant/src/messaging/providers/telegram-bot/send.test.ts
@@ -272,10 +272,7 @@ describe("telegramTransport topic targeting", () => {
   });
 
   test("typing indicators target the topic", async () => {
-    await telegramTransport.sendTyping!(
-      topicCtx,
-      payload({ chatAction: "typing" }),
-    );
+    await telegramTransport.typing!(topicCtx, "123");
 
     expect(callTelegramBotApiMock).toHaveBeenCalledWith("sendChatAction", {
       chat_id: "123",
@@ -291,10 +288,7 @@ describe("telegramTransport topic targeting", () => {
     };
 
     await telegramTransport.deliver(bareCtx, payload({ useBlocks: false }));
-    await telegramTransport.sendTyping!(
-      bareCtx,
-      payload({ chatAction: "typing" }),
-    );
+    await telegramTransport.typing!(bareCtx, "123");
 
     expect(callTelegramBotApiMock).toHaveBeenCalledWith("sendMessage", {
       chat_id: "123",

--- a/assistant/src/messaging/providers/telegram-bot/transport.ts
+++ b/assistant/src/messaging/providers/telegram-bot/transport.ts
@@ -67,12 +67,9 @@ export const telegramTransport: ChannelTransport = {
     return { ok: true };
   },
 
-  async sendTyping(ctx, payload) {
-    await sendTelegramTypingIndicator(payload.chatId, threadOptions(ctx));
-    log.debug(
-      { chatId: payload.chatId },
-      "Telegram typing indicator delivered (direct)",
-    );
+  async typing(ctx, chatId) {
+    await sendTelegramTypingIndicator(chatId, threadOptions(ctx));
+    log.debug({ chatId }, "Telegram typing indicator delivered (direct)");
     return { ok: true };
   },
 };

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
@@ -20,6 +20,7 @@ import {
 } from "../../../contacts/guardian-delivery-reader.js";
 import { isConversationBusyError } from "../../../daemon/conversation-messaging.js";
 import type { TrustContext } from "../../../daemon/trust-context-types.js";
+import { sendChannelTyping } from "../../../messaging/providers/index.js";
 import {
   getSiblingStreamedReplyTs,
   linkMessage,
@@ -168,11 +169,7 @@ export function processChannelMessageInBackground(
       ? replyCallbackUrl
       : undefined;
     const stopTypingHeartbeat = typingCallbackUrl
-      ? startTelegramTypingHeartbeat(
-          typingCallbackUrl,
-          externalChatId,
-          assistantId,
-        )
+      ? startTelegramTypingHeartbeat(typingCallbackUrl, externalChatId)
       : undefined;
 
     const slackThinkingStatus = createSlackThinkingStatusController({
@@ -419,7 +416,6 @@ function shouldEmitTelegramTyping(
 function startTelegramTypingHeartbeat(
   callbackUrl: string,
   chatId: string,
-  assistantId?: string,
 ): () => void {
   let active = true;
   let inFlight = false;
@@ -429,11 +425,7 @@ function startTelegramTypingHeartbeat(
       return;
     }
     inFlight = true;
-    void deliverChannelReply(callbackUrl, {
-      chatId,
-      chatAction: "typing",
-      assistantId,
-    })
+    void sendChannelTyping(callbackUrl, chatId)
       .catch((err) => {
         log.debug(
           { err, chatId },

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
@@ -20,7 +20,10 @@ import {
 } from "../../../contacts/guardian-delivery-reader.js";
 import { isConversationBusyError } from "../../../daemon/conversation-messaging.js";
 import type { TrustContext } from "../../../daemon/trust-context-types.js";
-import { sendChannelTyping } from "../../../messaging/providers/index.js";
+import {
+  sendChannelTyping,
+  supportsChannelTyping,
+} from "../../../messaging/providers/index.js";
 import {
   getSiblingStreamedReplyTs,
   linkMessage,
@@ -162,15 +165,10 @@ export function processChannelMessageInBackground(
   // `channel-turn-admission.ts` for why channel turns defer rather than route
   // through the SSE-oriented conversation queue.
   void withChannelTurnAdmission(conversationId, async () => {
-    const typingCallbackUrl = shouldEmitTelegramTyping(
-      sourceChannel,
-      replyCallbackUrl,
-    )
-      ? replyCallbackUrl
-      : undefined;
-    const stopTypingHeartbeat = typingCallbackUrl
-      ? startTelegramTypingHeartbeat(typingCallbackUrl, externalChatId)
-      : undefined;
+    const stopTypingHeartbeat =
+      replyCallbackUrl && supportsChannelTyping(replyCallbackUrl)
+        ? startTypingHeartbeat(replyCallbackUrl, externalChatId)
+        : undefined;
 
     const slackThinkingStatus = createSlackThinkingStatusController({
       sourceChannel,
@@ -384,39 +382,23 @@ export function processChannelMessageInBackground(
 // ---------------------------------------------------------------------------
 
 /**
- * How often the typing status is re-sent while a turn runs.
+ * How often the working indicator is re-sent while a turn runs.
  *
- * `sendChatAction` sets a status that expires on its own after a few seconds,
- * and the Bot API offers no stop/start pair to hold one open, so showing
- * typing across a multi-second turn means re-sending on a timer. The interval
- * has to stay under that expiry or the indicator blinks off between beats;
- * anyone changing it should check the current window first.
+ * Every channel that has one expires it after a few seconds and offers no
+ * start/stop pair to hold it open, so showing it across a multi-second turn
+ * means re-sending on a timer. The interval has to stay under the shortest
+ * expiry of any channel that implements `typing`: Telegram is about five
+ * seconds, Discord about ten. Anyone changing it should check the current
+ * windows first.
  *
- * No explicit stop is needed on the delivery path: Telegram clears the status
- * as soon as the bot sends a message.
+ * No explicit stop is needed: both clear the indicator when the bot posts.
  *
  * https://core.telegram.org/bots/api#sendchataction
+ * https://discord.com/developers/docs/resources/channel#trigger-typing-indicator
  */
-const TELEGRAM_TYPING_INTERVAL_MS = 4_000;
+const TYPING_INTERVAL_MS = 4_000;
 
-function shouldEmitTelegramTyping(
-  sourceChannel: ChannelId,
-  replyCallbackUrl?: string,
-): boolean {
-  if (sourceChannel !== "telegram" || !replyCallbackUrl) {
-    return false;
-  }
-  try {
-    return new URL(replyCallbackUrl).pathname.endsWith("/deliver/telegram");
-  } catch {
-    return replyCallbackUrl.endsWith("/deliver/telegram");
-  }
-}
-
-function startTelegramTypingHeartbeat(
-  callbackUrl: string,
-  chatId: string,
-): () => void {
+function startTypingHeartbeat(callbackUrl: string, chatId: string): () => void {
   let active = true;
   let inFlight = false;
 
@@ -439,7 +421,7 @@ function startTelegramTypingHeartbeat(
 
   emitTyping();
 
-  const interval = setInterval(emitTyping, TELEGRAM_TYPING_INTERVAL_MS);
+  const interval = setInterval(emitTyping, TYPING_INTERVAL_MS);
   (interval as { unref?: () => void }).unref?.();
 
   return () => {

--- a/gateway/README.md
+++ b/gateway/README.md
@@ -134,14 +134,6 @@ The `/deliver/telegram` endpoint accepts an optional `approval` field in the req
 
 **Fallback behavior:** For non-rich channels that do not support inline keyboards, the runtime substitutes the `plainTextFallback` string for the structured `promptText` before calling the delivery endpoint. The fallback includes plain-text instructions so the user can respond via text. The `supportsInlineOptions` channel capability (`channelSupportsInlineOptions()`) in the runtime determines which format to use. Free-text responses are classified by the conversational approval engine.
 
-## Telegram Typing Indicator
-
-The `/deliver/telegram` endpoint also accepts an optional `chatAction` field for ephemeral Telegram chat actions. Current supported value:
-
-- `typing` — triggers Telegram `sendChatAction` with `action: "typing"` for the target `chatId`.
-
-This can be sent as an action-only payload (without `text` or `attachments`) when the runtime wants to show a typing indicator while an assistant response is still in progress.
-
 ## Public Ingress Routes
 
 The gateway serves as the single public ingress point for all external callbacks. The following routes are handled directly by the gateway before any proxy forwarding:

--- a/packages/gateway-client/src/http-delivery.ts
+++ b/packages/gateway-client/src/http-delivery.ts
@@ -131,7 +131,6 @@ function buildManagedOutboundRequestId(
       chatId: payload.chatId,
       text: normalizedText,
       assistantId: payload.assistantId ?? null,
-      chatAction: payload.chatAction ?? null,
       hasAttachments:
         Array.isArray(payload.attachments) && payload.attachments.length > 0,
       approvalRequestId: payload.approval?.requestId ?? null,
@@ -212,7 +211,6 @@ async function deliverManagedOutboundReply(
         chatId: payload.chatId,
         text: payload.text ?? null,
         assistantId: payload.assistantId ?? null,
-        chatAction: payload.chatAction ?? null,
         hasAttachments,
         sourceUpdateId: callback.sourceUpdateId ?? null,
       },
@@ -325,7 +323,12 @@ export async function deliverChannelReply(
 ): Promise<ChannelDeliveryResult> {
   const managedCallback = parseManagedOutboundCallback(callbackUrl);
   if (managedCallback) {
-    await deliverManagedOutboundReply(managedCallback, payload, bearerToken, log);
+    await deliverManagedOutboundReply(
+      managedCallback,
+      payload,
+      bearerToken,
+      log,
+    );
     return { ok: true };
   }
 
@@ -385,17 +388,7 @@ export async function deliverChannelReply(
     // Response may not be JSON for non-Slack channels; that's fine.
   }
 
-  if (payload.chatAction) {
-    log.debug(
-      { chatId: payload.chatId, callbackUrl, chatAction: payload.chatAction },
-      "Channel action delivered",
-    );
-  } else {
-    log.info(
-      { chatId: payload.chatId, callbackUrl },
-      "Channel reply delivered",
-    );
-  }
+  log.info({ chatId: payload.chatId, callbackUrl }, "Channel reply delivered");
 
   return result;
 }

--- a/packages/gateway-client/src/outbound-contract.ts
+++ b/packages/gateway-client/src/outbound-contract.ts
@@ -168,7 +168,6 @@ export const ChannelReplyPayloadSchema = z.object({
   assistantId: z.string().optional(),
   attachments: z.array(AttachmentMetadataSchema).optional(),
   approval: ApprovalUIMetadataSchema.optional(),
-  chatAction: z.literal("typing").optional(),
   /**
    * When true, deliver via `chat.postEphemeral` so only the target `user`
    * sees the message.


### PR DESCRIPTION
## TL;DR

The first capability narrowed to its own parameters, and Discord gains a typing indicator as a one-line consequence. Net 15 lines added across production code.

Part of LUM-3356. This is the pattern the remaining capabilities follow.

## The shape being fixed

`ChannelTransport` declares five capabilities as optional methods, and that part is right: a method a channel does not implement is a capability it does not have. That is already the hookable surface.

What was wrong is that all five methods took the **same reply payload**, so the payload had to be the union of every method's parameters, and the dispatcher picked between them by sniffing which optional field happened to be set:

```ts
if (payload.slackStream && transport.streamReply)  return transport.streamReply(ctx, payload);
if (payload.reaction && transport.sendReaction)    return transport.sendReaction(ctx, payload);
if (payload.chatAction === "typing" && ...)        return transport.sendTyping(ctx, payload);
return transport.deliver(ctx, payload);
```

That is why the payload reads as Slack-shaped: most of its fields are not Slack's, they are *other operations'* parameters. Nothing can be added to it without touching a type every channel shares.

## Why typing first

It is the smallest of the five and shows the whole problem in miniature. `chatAction` sat on the **daemon-to-gateway wire contract** purely so the daemon could route past it locally: the gateway has no reference to the field anywhere. A routing marker for one daemon-side operation was living in a contract shared with another service.

It now takes the place and nothing else:

```ts
typing?(ctx: CallbackContext, chatId: string): Promise<ChannelDeliveryResult>;
```

and is reached through `sendChannelTyping(callbackUrl, chatId)` rather than by constructing a reply that is not a reply. A channel without the affordance resolves quietly, because the indicator is decoration and its absence is not a degraded delivery.

## What changes for the user

| | Before | After |
| -- | -- | -- |
| Telegram | shows a typing indicator | unchanged |
| Discord | shows nothing while the assistant works | shows the typing indicator |
| Everything else | no indicator | unchanged |

Discord costs one transport method and a `POST /channels/{id}/typing` helper. That is the point of the narrowing: adding a capability to a channel stops being an edit to a shared type.

The heartbeat that drives it now asks `supportsChannelTyping(replyCallbackUrl)` rather than testing for Telegram. Review caught that the first version of this PR left the old channel-named gate in place, which made the Discord method unreachable and the table above wrong; the gate is now capability-driven and a regression test pins it that way.

## Why it is safe

`chatAction` leaves the shared contract, and the gateway never read it (`grep chatAction gateway/src` is empty). Nothing persists a reply payload, so no migration is involved. The one behavioural change is Discord gaining an indicator.

Also removed: the typing heartbeat threaded an `assistantId` it never used, which lint surfaced once the payload stopped carrying it.

## Next

`react`, `edit`, `stream` and `interactive` follow this shape, each pulled in by a channel that is missing that capability. `send` goes last, when four narrowings have shown what its parameters actually need to be.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
