### PR TITLE
feat(windows): draw the app menu bar in the title bar

### DIFF
--- a/clients/web/src/components/window-drag-region.test.tsx
+++ b/clients/web/src/components/window-drag-region.test.tsx
@@ -11,7 +11,10 @@ mock.module("@/runtime/is-electron", () => ({
 
 mock.module("@/stores/title-bar-store", () => ({
   useTitleBarStore: {
-    use: { inlineTitleBarActive: () => inlineTitleBarActiveMock },
+    use: {
+      inlineTitleBarActive: () => inlineTitleBarActiveMock,
+      windowsMenuBarSuppressed: () => false,
+    },
   },
 }));
 

--- a/clients/web/src/components/window-drag-region.tsx
+++ b/clients/web/src/components/window-drag-region.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 
+import { WindowsMenuBar } from "@/components/windows-menu-bar";
 import { WINDOWS_TITLE_BAR_CONTROL_CLEARANCE_PX } from "@/runtime/electron-window-chrome";
 import { isPopoutWindow } from "@/runtime/popout-window";
 import { detectElectronHostOS } from "@/runtime/platform-detection";
@@ -49,17 +50,24 @@ export function WindowDragRegion() {
     return null;
   }
 
+  // On Windows the strip doubles as the menu-bar host: routes without the
+  // inline chat title bar (settings, logs, onboarding) would otherwise have
+  // no File/Edit/View menus at all, since the hidden native frame hides the
+  // OS menu bar too. The strip already swallows pointer events in this band,
+  // so the buttons claim no space that was interactive before.
   return (
     <div
-      aria-hidden="true"
+      aria-hidden={hostOS === "windows" ? undefined : "true"}
       className={`fixed left-0 top-0 z-[100] h-7 [-webkit-app-region:drag] ${
-        hostOS === "windows" ? "" : "right-0"
+        hostOS === "windows" ? "flex items-center pl-1" : "right-0"
       }`}
       style={
         hostOS === "windows"
           ? { right: WINDOWS_TITLE_BAR_CONTROL_CLEARANCE_PX }
           : undefined
       }
-    />
+    >
+      {hostOS === "windows" ? <WindowsMenuBar /> : null}
+    </div>
   );
 }

--- a/clients/web/src/components/windows-menu-bar.tsx
+++ b/clients/web/src/components/windows-menu-bar.tsx
@@ -1,0 +1,77 @@
+import { Button } from "@vellumai/design-library";
+import { useEffect, useState } from "react";
+
+import { getMenuBarTitles, popupMenuBarMenu } from "@/runtime/menu";
+
+/**
+ * In-title-bar menu bar for the Windows desktop shell.
+ *
+ * The Windows main window hides the native frame (`titleBarStyle: "hidden"`),
+ * which hides the OS menu bar with it. This draws the top-level menu titles
+ * as flat buttons in the renderer's title bar; clicking one asks the main
+ * process to pop the real native submenu just below the button, so items,
+ * accelerators, and enabled states stay owned by the shell's one menu
+ * template (`clients/windows/src/main/menu.ts`).
+ *
+ * Self-gating: renders nothing until the shell reports its menu titles.
+ * Off Electron, on macOS (whose menu bar the system draws), and on shells
+ * that predate the popup bridge, the titles query resolves empty and the
+ * bar stays unmounted.
+ */
+export function WindowsMenuBar() {
+  const [titles, setTitles] = useState<string[]>([]);
+  const [openTitle, setOpenTitle] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void getMenuBarTitles().then((fetched) => {
+      if (!cancelled) {
+        setTitles(fetched);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (titles.length === 0) {
+    return null;
+  }
+
+  const openMenu = (title: string, button: HTMLElement) => {
+    const rect = button.getBoundingClientRect();
+    setOpenTitle(title);
+    void popupMenuBarMenu(
+      title,
+      Math.round(rect.left),
+      Math.round(rect.bottom),
+    ).finally(() => {
+      // The popup call resolves when the native menu closes; only the menu
+      // that is still marked open clears the highlight, so a click that
+      // opened another title meanwhile keeps its own state.
+      setOpenTitle((current) => (current === title ? null : current));
+    });
+  };
+
+  return (
+    <div role="menubar" className="flex items-center">
+      {titles.map((title) => (
+        <Button
+          key={title}
+          role="menuitem"
+          aria-haspopup="menu"
+          aria-expanded={openTitle === title}
+          variant="ghost"
+          size="compact"
+          active={openTitle === title}
+          className="[--vbtn-fg:var(--content-secondary)]"
+          onClick={(event) => {
+            openMenu(title, event.currentTarget);
+          }}
+        >
+          {title}
+        </Button>
+      ))}
+    </div>
+  );
+}

--- a/clients/web/src/components/windows-menu-bar.tsx
+++ b/clients/web/src/components/windows-menu-bar.tsx
@@ -1,7 +1,17 @@
 import { Button } from "@vellumai/design-library";
 import { useEffect, useState } from "react";
 
-import { getMenuBarTitles, popupMenuBarMenu } from "@/runtime/menu";
+import { useTranslation } from "@/i18n";
+import {
+  getMenuBarEntries,
+  popupMenuBarMenu,
+  type MenuBarEntry,
+} from "@/runtime/menu";
+
+// Edit and Window carry only stock role items (undo/copy/minimize...) whose
+// shortcuts everyone knows; hiding them keeps the bar short. Their items stay
+// reachable through the (hidden) application menu's accelerators.
+const HIDDEN_MENU_IDS = new Set(["edit", "window"]);
 
 /**
  * In-title-bar menu bar for the Windows desktop shell.
@@ -13,20 +23,25 @@ import { getMenuBarTitles, popupMenuBarMenu } from "@/runtime/menu";
  * accelerators, and enabled states stay owned by the shell's one menu
  * template (`clients/windows/src/main/menu.ts`).
  *
- * Self-gating: renders nothing until the shell reports its menu titles.
- * Off Electron, on macOS (whose menu bar the system draws), and on shells
- * that predate the popup bridge, the titles query resolves empty and the
- * bar stays unmounted.
+ * Mounted in both title-bar surfaces: `ChatLayoutHeader` (the inline title
+ * bar on chat routes) and `WindowDragRegion` (the fallback strip everywhere
+ * else), so the menus survive navigation to routes without the chat layout.
+ *
+ * Self-gating: renders nothing until the shell reports its menus. Off
+ * Electron, on macOS (whose menu bar the system draws), and on shells that
+ * predate the popup bridge, the query resolves empty and the bar stays
+ * unmounted.
  */
 export function WindowsMenuBar() {
-  const [titles, setTitles] = useState<string[]>([]);
-  const [openTitle, setOpenTitle] = useState<string | null>(null);
+  const { t } = useTranslation();
+  const [entries, setEntries] = useState<MenuBarEntry[]>([]);
+  const [openId, setOpenId] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
-    void getMenuBarTitles().then((fetched) => {
+    void getMenuBarEntries().then((fetched) => {
       if (!cancelled) {
-        setTitles(fetched);
+        setEntries(fetched.filter((entry) => !HIDDEN_MENU_IDS.has(entry.id)));
       }
     });
     return () => {
@@ -34,42 +49,55 @@ export function WindowsMenuBar() {
     };
   }, []);
 
-  if (titles.length === 0) {
+  if (entries.length === 0) {
     return null;
   }
 
-  const openMenu = (title: string, button: HTMLElement) => {
+  // The shell reports stable menu ids; the visible label comes from the
+  // catalog. An id the catalog doesn't know yet (a newer shell) falls back
+  // to the shell's own label rather than disappearing.
+  const labels: Record<string, string | undefined> = {
+    file: t("windowsMenuBar.file"),
+    view: t("windowsMenuBar.view"),
+    developer: t("windowsMenuBar.developer"),
+    help: t("windowsMenuBar.help"),
+  };
+
+  const openMenu = (id: string, button: HTMLElement) => {
     const rect = button.getBoundingClientRect();
-    setOpenTitle(title);
+    setOpenId(id);
     void popupMenuBarMenu(
-      title,
+      id,
       Math.round(rect.left),
       Math.round(rect.bottom),
     ).finally(() => {
       // The popup call resolves when the native menu closes; only the menu
       // that is still marked open clears the highlight, so a click that
-      // opened another title meanwhile keeps its own state.
-      setOpenTitle((current) => (current === title ? null : current));
+      // opened another menu meanwhile keeps its own state.
+      setOpenId((current) => (current === id ? null : current));
     });
   };
 
   return (
     <div role="menubar" className="flex items-center">
-      {titles.map((title) => (
+      {entries.map((entry) => (
         <Button
-          key={title}
+          key={entry.id}
           role="menuitem"
           aria-haspopup="menu"
-          aria-expanded={openTitle === title}
+          aria-expanded={openId === entry.id}
           variant="ghost"
-          size="compact"
-          active={openTitle === title}
-          className="[--vbtn-fg:var(--content-secondary)]"
+          active={openId === entry.id}
+          // Regular size for the text scale of the neighboring header
+          // buttons, slimmed to menu-bar proportions; tertiary content
+          // color keeps the labels quiet in every theme. no-drag: both
+          // mounts sit inside a window-drag surface.
+          className="h-6 px-2 [--vbtn-fg:var(--content-tertiary)] [-webkit-app-region:no-drag]"
           onClick={(event) => {
-            openMenu(title, event.currentTarget);
+            openMenu(entry.id, event.currentTarget);
           }}
         >
-          {title}
+          {labels[entry.id] ?? entry.label}
         </Button>
       ))}
     </div>

--- a/clients/web/src/components/windows-menu-bar.tsx
+++ b/clients/web/src/components/windows-menu-bar.tsx
@@ -7,6 +7,7 @@ import {
   popupMenuBarMenu,
   type MenuBarEntry,
 } from "@/runtime/menu";
+import { useTitleBarStore } from "@/stores/title-bar-store";
 
 // Edit and Window carry only stock role items (undo/copy/minimize...) whose
 // shortcuts everyone knows; hiding them keeps the bar short. Their items stay
@@ -26,6 +27,8 @@ const HIDDEN_MENU_IDS = new Set(["edit", "window"]);
  * Mounted in both title-bar surfaces: `ChatLayoutHeader` (the inline title
  * bar on chat routes) and `WindowDragRegion` (the fallback strip everywhere
  * else), so the menus survive navigation to routes without the chat layout.
+ * Full-screen shells with their own chrome (settings) suppress it through
+ * the title-bar store.
  *
  * Self-gating: renders nothing until the shell reports its menus. Off
  * Electron, on macOS (whose menu bar the system draws), and on shells that
@@ -34,6 +37,7 @@ const HIDDEN_MENU_IDS = new Set(["edit", "window"]);
  */
 export function WindowsMenuBar() {
   const { t } = useTranslation();
+  const suppressed = useTitleBarStore.use.windowsMenuBarSuppressed();
   const [entries, setEntries] = useState<MenuBarEntry[]>([]);
   const [openId, setOpenId] = useState<string | null>(null);
 
@@ -49,7 +53,7 @@ export function WindowsMenuBar() {
     };
   }, []);
 
-  if (entries.length === 0) {
+  if (suppressed || entries.length === 0) {
     return null;
   }
 

--- a/clients/web/src/components/windows-menu-bar.tsx
+++ b/clients/web/src/components/windows-menu-bar.tsx
@@ -89,10 +89,11 @@ export function WindowsMenuBar() {
           variant="ghost"
           active={openId === entry.id}
           // Regular size for the text scale of the neighboring header
-          // buttons, slimmed to menu-bar proportions; tertiary content
-          // color keeps the labels quiet in every theme. no-drag: both
+          // buttons, slimmed to menu-bar proportions. The labels recede
+          // into the chrome: quiet in light, disabled-ramp in dark/velvet
+          // (a shade dimmer than quiet resolves there). no-drag: both
           // mounts sit inside a window-drag surface.
-          className="h-6 px-2 [--vbtn-fg:var(--content-tertiary)] [-webkit-app-region:no-drag]"
+          className="h-6 px-2 [--vbtn-fg:var(--content-quiet)] dark:[--vbtn-fg:var(--content-disabled)] [-webkit-app-region:no-drag]"
           onClick={(event) => {
             openMenu(entry.id, event.currentTarget);
           }}

--- a/clients/web/src/domains/chat/chat-layout-header.test.tsx
+++ b/clients/web/src/domains/chat/chat-layout-header.test.tsx
@@ -28,7 +28,10 @@ mock.module("@/stores/command-palette-store", () => ({
 const setInlineTitleBarActiveSpy = mock((_active: boolean) => {});
 mock.module("@/stores/title-bar-store", () => ({
   useTitleBarStore: {
-    use: { setInlineTitleBarActive: () => setInlineTitleBarActiveSpy },
+    use: {
+      setInlineTitleBarActive: () => setInlineTitleBarActiveSpy,
+      windowsMenuBarSuppressed: () => false,
+    },
   },
 }));
 

--- a/clients/web/src/domains/chat/chat-layout-header.tsx
+++ b/clients/web/src/domains/chat/chat-layout-header.tsx
@@ -225,11 +225,14 @@ export function ChatLayoutHeader({
               className={!canGoForward ? "opacity-35" : undefined}
               onClick={onGoForward}
             />
-            {/* Self-gates to the Windows shell (renders nothing elsewhere),
-                so no `electronHostOS` branch here. */}
-            <WindowsMenuBar />
           </>
         ) : null}
+        {/* Outside the isMobile branch: while this header is mounted the
+            fallback strip yields, so a narrow (zoomed) Windows window would
+            otherwise lose the menus entirely. Self-gates to the Windows
+            shell (renders nothing elsewhere), so no `electronHostOS`
+            branch here. */}
+        <WindowsMenuBar />
       </div>
 
       <div

--- a/clients/web/src/domains/chat/chat-layout-header.tsx
+++ b/clients/web/src/domains/chat/chat-layout-header.tsx
@@ -8,6 +8,7 @@ import {
 } from "lucide-react";
 import { useCallback, useEffect, type ReactNode } from "react";
 
+import { WindowsMenuBar } from "@/components/windows-menu-bar";
 import { NATIVE_MOBILE_BARE_ICON_BUTTON } from "@/domains/chat/utils/native-mobile-button-constants";
 import { WINDOWS_TITLE_BAR_CONTROL_CLEARANCE_PX } from "@/runtime/electron-window-chrome";
 import {
@@ -135,7 +136,10 @@ export function ChatLayoutHeader({
   // neutral band across the top. Off native mobile, and on any route that
   // publishes nothing, this resolves to the usual neutral chrome.
   const pageSurface = usePageSurfaceStore.use.surface();
-  const headerBackground = resolveShellBackground(pageSurface, isNativeMobile());
+  const headerBackground = resolveShellBackground(
+    pageSurface,
+    isNativeMobile(),
+  );
 
   return (
     <header
@@ -221,6 +225,9 @@ export function ChatLayoutHeader({
               className={!canGoForward ? "opacity-35" : undefined}
               onClick={onGoForward}
             />
+            {/* Self-gates to the Windows shell (renders nothing elsewhere),
+                so no `electronHostOS` branch here. */}
+            <WindowsMenuBar />
           </>
         ) : null}
       </div>

--- a/clients/web/src/domains/settings/settings-layout.tsx
+++ b/clients/web/src/domains/settings/settings-layout.tsx
@@ -1,5 +1,5 @@
 import { LogIn, LogOut } from "lucide-react";
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { Outlet, useLocation, useNavigate } from "react-router";
 
 import { useOnboardingLogin } from "@/hooks/use-onboarding-login";
@@ -11,6 +11,7 @@ import { useIsNativeAndroid } from "@/runtime/platform-detection";
 import { useHasPlatformSession } from "@/stores/auth-store";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+import { useTitleBarStore } from "@/stores/title-bar-store";
 import { routes } from "@/utils/routes";
 import { SETTINGS_SIDEBAR } from "@/utils/settings-navigation";
 import { SidebarShell } from "@/components/sidebar-shell";
@@ -25,6 +26,15 @@ import { SidebarTree, type SidebarItem } from "@/components/sidebar-tree";
 export function SettingsLayout() {
   const settingsDeveloperNav =
     useAssistantFeatureFlagStore.use.settingsDeveloperNav();
+  // Settings brings its own full-screen chrome; the Windows in-title-bar
+  // menu bar yields while it's up (inert off the Windows shell, where the
+  // menu bar doesn't render anyway).
+  const setWindowsMenuBarSuppressed =
+    useTitleBarStore.use.setWindowsMenuBarSuppressed();
+  useEffect(() => {
+    setWindowsMenuBarSuppressed(true);
+    return () => setWindowsMenuBarSuppressed(false);
+  }, [setWindowsMenuBarSuppressed]);
   const isNativeAndroid = useIsNativeAndroid();
   const activeAssistantId = useResolvedAssistantsStore.use.activeAssistantId();
   // The Bookmarks and Credentials tabs need routes that only newer assistants

--- a/clients/web/src/i18n/locales/en/common.json
+++ b/clients/web/src/i18n/locales/en/common.json
@@ -18,5 +18,11 @@
   },
   "sectionActionsButton": {
     "ariaLabel": "{name} actions"
+  },
+  "windowsMenuBar": {
+    "file": "File",
+    "view": "View",
+    "developer": "Developer",
+    "help": "Help"
   }
 }

--- a/clients/web/src/i18n/locales/es/common.json
+++ b/clients/web/src/i18n/locales/es/common.json
@@ -18,5 +18,11 @@
   },
   "sectionActionsButton": {
     "ariaLabel": "Acciones de {name}"
+  },
+  "windowsMenuBar": {
+    "file": "Archivo",
+    "view": "Ver",
+    "developer": "Desarrollador",
+    "help": "Ayuda"
   }
 }

--- a/clients/web/src/runtime/is-electron.ts
+++ b/clients/web/src/runtime/is-electron.ts
@@ -200,6 +200,8 @@ declare global {
       };
       menu: {
         setPlatformSession(has: boolean): Promise<void>;
+        titles?(): Promise<string[]>;
+        popup?(title: string, x: number, y: number): Promise<void>;
       };
       localMode: {
         hatch(
@@ -332,7 +334,9 @@ declare global {
         update(content: VoiceActivityContent): void;
         end(): void;
         control(control: VoiceActivityControl): void;
-        onControl(callback: (control: VoiceActivityControl) => void): () => void;
+        onControl(
+          callback: (control: VoiceActivityControl) => void,
+        ): () => void;
       };
       companion?: {
         getState(): Promise<CompanionSurfaceState | null>;

--- a/clients/web/src/runtime/is-electron.ts
+++ b/clients/web/src/runtime/is-electron.ts
@@ -200,8 +200,8 @@ declare global {
       };
       menu: {
         setPlatformSession(has: boolean): Promise<void>;
-        titles?(): Promise<string[]>;
-        popup?(title: string, x: number, y: number): Promise<void>;
+        titles?(): Promise<Array<{ id: string; label: string }>>;
+        popup?(id: string, x: number, y: number): Promise<void>;
       };
       localMode: {
         hatch(

--- a/clients/web/src/runtime/menu.ts
+++ b/clients/web/src/runtime/menu.ts
@@ -6,3 +6,30 @@ export async function setMenuPlatformSession(has: boolean): Promise<void> {
   }
   await window.vellum?.menu.setPlatformSession(has);
 }
+
+/**
+ * Titles of the native application menus, for the Windows in-title-bar menu
+ * bar. Empty off Electron, on macOS (the system draws its menu bar), and on
+ * shells that predate the menu popup bridge.
+ */
+export async function getMenuBarTitles(): Promise<string[]> {
+  if (!isElectron()) {
+    return [];
+  }
+  return (await window.vellum?.menu.titles?.()) ?? [];
+}
+
+/**
+ * Pop the native menu named `title` at (`x`, `y`), in CSS pixels relative to
+ * the window. Resolves when the menu closes.
+ */
+export async function popupMenuBarMenu(
+  title: string,
+  x: number,
+  y: number,
+): Promise<void> {
+  if (!isElectron()) {
+    return;
+  }
+  await window.vellum?.menu.popup?.(title, x, y);
+}

--- a/clients/web/src/runtime/menu.ts
+++ b/clients/web/src/runtime/menu.ts
@@ -7,12 +7,18 @@ export async function setMenuPlatformSession(has: boolean): Promise<void> {
   await window.vellum?.menu.setPlatformSession(has);
 }
 
+/** One top-level native menu: a stable id plus the shell's own label. */
+export interface MenuBarEntry {
+  id: string;
+  label: string;
+}
+
 /**
- * Titles of the native application menus, for the Windows in-title-bar menu
- * bar. Empty off Electron, on macOS (the system draws its menu bar), and on
+ * The native application menus, for the Windows in-title-bar menu bar.
+ * Empty off Electron, on macOS (the system draws its menu bar), and on
  * shells that predate the menu popup bridge.
  */
-export async function getMenuBarTitles(): Promise<string[]> {
+export async function getMenuBarEntries(): Promise<MenuBarEntry[]> {
   if (!isElectron()) {
     return [];
   }
@@ -20,16 +26,16 @@ export async function getMenuBarTitles(): Promise<string[]> {
 }
 
 /**
- * Pop the native menu named `title` at (`x`, `y`), in CSS pixels relative to
- * the window. Resolves when the menu closes.
+ * Pop the native menu with the given id at (`x`, `y`), in CSS pixels
+ * relative to the window. Resolves when the menu closes.
  */
 export async function popupMenuBarMenu(
-  title: string,
+  id: string,
   x: number,
   y: number,
 ): Promise<void> {
   if (!isElectron()) {
     return;
   }
-  await window.vellum?.menu.popup?.(title, x, y);
+  await window.vellum?.menu.popup?.(id, x, y);
 }

--- a/clients/web/src/stores/title-bar-store.ts
+++ b/clients/web/src/stores/title-bar-store.ts
@@ -25,17 +25,25 @@ import { createSelectors } from "@/utils/create-selectors";
 
 interface TitleBarState {
   inlineTitleBarActive: boolean;
+  /** Set by full-screen shells (settings) that don't want the Windows
+   *  in-title-bar menu bar over their own chrome; `WindowsMenuBar` yields
+   *  while it's set. */
+  windowsMenuBarSuppressed: boolean;
 }
 
 interface TitleBarActions {
   setInlineTitleBarActive: (active: boolean) => void;
+  setWindowsMenuBarSuppressed: (suppressed: boolean) => void;
 }
 
 type TitleBarStore = TitleBarState & TitleBarActions;
 
 const useTitleBarStoreBase = create<TitleBarStore>((set) => ({
   inlineTitleBarActive: false,
+  windowsMenuBarSuppressed: false,
   setInlineTitleBarActive: (active) => set({ inlineTitleBarActive: active }),
+  setWindowsMenuBarSuppressed: (suppressed) =>
+    set({ windowsMenuBarSuppressed: suppressed }),
 }));
 
 export const useTitleBarStore = createSelectors(useTitleBarStoreBase);

--- a/clients/windows/src/main/menu.test.ts
+++ b/clients/windows/src/main/menu.test.ts
@@ -72,13 +72,19 @@ describe("installWindowsMenu", () => {
     openAbout: () => undefined,
   });
 
-  test("reports the top-level menu titles", () => {
+  test("reports the top-level menu ids and labels", () => {
     const titles = handlers.get("vellum:menu:titles")?.([], {});
-    expect(titles).toEqual(["File", "Edit", "View", "Window", "Help"]);
+    expect(titles).toEqual([
+      { id: "file", label: "File" },
+      { id: "edit", label: "Edit" },
+      { id: "view", label: "View" },
+      { id: "window", label: "Window" },
+      { id: "help", label: "Help" },
+    ]);
   });
 
   test("pops the requested submenu at zoom-scaled coordinates", async () => {
-    await handlers.get("vellum:menu:popup")?.(["Edit", 100, 44], {
+    await handlers.get("vellum:menu:popup")?.(["edit", 100, 44], {
       sender: { getZoomFactor: () => 1.25 },
     });
     expect(popups).toHaveLength(1);
@@ -89,8 +95,8 @@ describe("installWindowsMenu", () => {
     expect(items.some((item) => item.role === "undo")).toBe(true);
   });
 
-  test("ignores popups for unknown titles", async () => {
-    await handlers.get("vellum:menu:popup")?.(["Nope", 0, 0], {
+  test("ignores popups for unknown ids", async () => {
+    await handlers.get("vellum:menu:popup")?.(["nope", 0, 0], {
       sender: { getZoomFactor: () => 1 },
     });
     expect(popups).toHaveLength(1);

--- a/clients/windows/src/main/menu.test.ts
+++ b/clients/windows/src/main/menu.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, mock, test } from "bun:test";
 
 const sent: unknown[] = [];
+const popups: Array<{
+  template: unknown;
+  options: { x: number; y: number; window: unknown };
+}> = [];
 
 mock.module("electron", () => ({
   app: { isPackaged: true, name: "Vellum" },
@@ -9,15 +13,27 @@ mock.module("electron", () => ({
       webContents: { send: (...args: unknown[]) => sent.push(args) },
     }),
     getAllWindows: () => [],
+    fromWebContents: () => ({ isDestroyed: () => false }),
   },
   Menu: {
-    buildFromTemplate: (template: unknown) => template,
+    buildFromTemplate: (template: unknown) => ({
+      template,
+      popup: (options: {
+        x: number;
+        y: number;
+        window: unknown;
+        callback: () => void;
+      }) => {
+        popups.push({ template, options });
+        options.callback();
+      },
+    }),
     setApplicationMenu: () => undefined,
   },
   shell: { openExternal: () => Promise.resolve() },
 }));
 
-const { buildWindowsMenu } = await import("./menu");
+const { buildWindowsMenu, installWindowsMenu } = await import("./menu");
 
 const submenu = (label: string): Array<Record<string, unknown>> => {
   const item = buildWindowsMenu({ openAbout: () => undefined }).find(
@@ -43,5 +59,40 @@ describe("buildWindowsMenu", () => {
     );
     (item?.click as (() => void) | undefined)?.();
     expect(sent).toEqual([["vellum:command", { kind: "newConversation" }]]);
+  });
+});
+
+describe("installWindowsMenu", () => {
+  type Handler = (args: unknown[], event: unknown) => unknown;
+  const handlers = new Map<string, Handler>();
+  installWindowsMenu({
+    handle: ((channel: string, _schema: unknown, fn: Handler) => {
+      handlers.set(channel, fn);
+    }) as never,
+    openAbout: () => undefined,
+  });
+
+  test("reports the top-level menu titles", () => {
+    const titles = handlers.get("vellum:menu:titles")?.([], {});
+    expect(titles).toEqual(["File", "Edit", "View", "Window", "Help"]);
+  });
+
+  test("pops the requested submenu at zoom-scaled coordinates", async () => {
+    await handlers.get("vellum:menu:popup")?.(["Edit", 100, 44], {
+      sender: { getZoomFactor: () => 1.25 },
+    });
+    expect(popups).toHaveLength(1);
+    expect(popups[0]?.options.x).toBe(125);
+    expect(popups[0]?.options.y).toBe(55);
+    expect(popups[0]?.options.window).toBeDefined();
+    const items = popups[0]?.template as Array<Record<string, unknown>>;
+    expect(items.some((item) => item.role === "undo")).toBe(true);
+  });
+
+  test("ignores popups for unknown titles", async () => {
+    await handlers.get("vellum:menu:popup")?.(["Nope", 0, 0], {
+      sender: { getZoomFactor: () => 1 },
+    });
+    expect(popups).toHaveLength(1);
   });
 });

--- a/clients/windows/src/main/menu.ts
+++ b/clients/windows/src/main/menu.ts
@@ -1,4 +1,10 @@
-import { Menu, app, shell, type MenuItemConstructorOptions } from "electron";
+import {
+  BrowserWindow,
+  Menu,
+  app,
+  shell,
+  type MenuItemConstructorOptions,
+} from "electron";
 import { z } from "zod";
 
 import {
@@ -85,9 +91,7 @@ export const buildWindowsMenu = ({
       { type: "separator" },
       { role: "reload" },
       { role: "forceReload" },
-      ...(!app.isPackaged
-        ? [{ role: "toggleDevTools" as const }]
-        : []),
+      ...(!app.isPackaged ? [{ role: "toggleDevTools" as const }] : []),
       { type: "separator" },
       { role: "resetZoom" },
       { role: "zoomIn" },
@@ -157,6 +161,37 @@ export const installWindowsMenu = (options: WindowsMenuOptions): void => {
         hasPlatformSession = has;
         apply();
       }
+    },
+  );
+  // The main window hides the native frame (`titleBarStyle: "hidden"`), which
+  // hides the OS menu bar with it. The renderer draws the top-level titles in
+  // its title bar and pops the real native submenus here, so items,
+  // accelerators, and enabled states keep the one template above as owner.
+  options.handle("vellum:menu:titles", z.tuple([]), () =>
+    buildWindowsMenu(options).map((item) => String(item.label)),
+  );
+  options.handle(
+    "vellum:menu:popup",
+    z.tuple([z.string(), z.number(), z.number()]),
+    ([title, x, y], event) => {
+      const submenu = buildWindowsMenu(options).find(
+        (item) => item.label === title,
+      )?.submenu;
+      const win = BrowserWindow.fromWebContents(event.sender);
+      if (!Array.isArray(submenu) || !win || win.isDestroyed()) {
+        return;
+      }
+      // The renderer reports CSS pixels; popup() takes DIPs, which differ
+      // from CSS pixels by the page zoom.
+      const zoom = event.sender.getZoomFactor();
+      return new Promise<void>((resolve) => {
+        Menu.buildFromTemplate(submenu).popup({
+          window: win,
+          x: Math.round(x * zoom),
+          y: Math.round(y * zoom),
+          callback: resolve,
+        });
+      });
     },
   );
   onHotkeyOverridesChange(apply);

--- a/clients/windows/src/main/menu.ts
+++ b/clients/windows/src/main/menu.ts
@@ -41,6 +41,7 @@ export const buildWindowsMenu = ({
   installCli,
 }: Omit<WindowsMenuOptions, "handle">): MenuItemConstructorOptions[] => [
   {
+    id: "file",
     label: "File",
     submenu: [
       commandItem("New Conversation", { kind: "newConversation" }),
@@ -69,6 +70,7 @@ export const buildWindowsMenu = ({
     ],
   },
   {
+    id: "edit",
     label: "Edit",
     submenu: [
       { role: "undo" },
@@ -83,6 +85,7 @@ export const buildWindowsMenu = ({
     ],
   },
   {
+    id: "view",
     label: "View",
     submenu: [
       commandItem("Toggle Sidebar", { kind: "sidebarToggle" }),
@@ -101,6 +104,7 @@ export const buildWindowsMenu = ({
     ],
   },
   {
+    id: "window",
     label: "Window",
     submenu: [
       { role: "minimize" },
@@ -112,6 +116,7 @@ export const buildWindowsMenu = ({
   ...(!app.isPackaged
     ? [
         {
+          id: "developer",
           label: "Developer",
           submenu: [
             commandItem("Choose Assistant...", { kind: "chooseAssistant" }),
@@ -124,6 +129,7 @@ export const buildWindowsMenu = ({
       ]
     : []),
   {
+    id: "help",
     label: "Help",
     submenu: [
       ...(app.isPackaged
@@ -165,17 +171,21 @@ export const installWindowsMenu = (options: WindowsMenuOptions): void => {
   );
   // The main window hides the native frame (`titleBarStyle: "hidden"`), which
   // hides the OS menu bar with it. The renderer draws the top-level titles in
-  // its title bar and pops the real native submenus here, so items,
-  // accelerators, and enabled states keep the one template above as owner.
+  // its title bar (localizing them by id) and pops the real native submenus
+  // here, so items, accelerators, and enabled states keep the one template
+  // above as owner.
   options.handle("vellum:menu:titles", z.tuple([]), () =>
-    buildWindowsMenu(options).map((item) => String(item.label)),
+    buildWindowsMenu(options).map((item) => ({
+      id: String(item.id),
+      label: String(item.label),
+    })),
   );
   options.handle(
     "vellum:menu:popup",
     z.tuple([z.string(), z.number(), z.number()]),
-    ([title, x, y], event) => {
+    ([id, x, y], event) => {
       const submenu = buildWindowsMenu(options).find(
-        (item) => item.label === title,
+        (item) => item.id === id,
       )?.submenu;
       const win = BrowserWindow.fromWebContents(event.sender);
       if (!Array.isArray(submenu) || !win || win.isDestroyed()) {

--- a/clients/windows/src/main/menu.ts
+++ b/clients/windows/src/main/menu.ts
@@ -14,6 +14,11 @@ import {
   type VellumCommand,
 } from "@vellumai/electron-desktop/commands";
 import type { IpcHandle } from "@vellumai/electron-desktop/ipc";
+import {
+  MENU_POPUP,
+  MENU_SET_PLATFORM_SESSION,
+  MENU_TITLES,
+} from "@vellumai/ipc-contract";
 
 interface WindowsMenuOptions {
   handle: IpcHandle;
@@ -160,7 +165,7 @@ export const installWindowsMenu = (options: WindowsMenuOptions): void => {
   };
 
   options.handle(
-    "vellum:menu:setPlatformSession",
+    MENU_SET_PLATFORM_SESSION,
     z.tuple([z.boolean()]),
     ([has]) => {
       if (hasPlatformSession !== has) {
@@ -174,14 +179,14 @@ export const installWindowsMenu = (options: WindowsMenuOptions): void => {
   // its title bar (localizing them by id) and pops the real native submenus
   // here, so items, accelerators, and enabled states keep the one template
   // above as owner.
-  options.handle("vellum:menu:titles", z.tuple([]), () =>
+  options.handle(MENU_TITLES, z.tuple([]), () =>
     buildWindowsMenu(options).map((item) => ({
       id: String(item.id),
       label: String(item.label),
     })),
   );
   options.handle(
-    "vellum:menu:popup",
+    MENU_POPUP,
     z.tuple([z.string(), z.number(), z.number()]),
     ([id, x, y], event) => {
       const submenu = buildWindowsMenu(options).find(

--- a/clients/windows/src/preload/features/commands.ts
+++ b/clients/windows/src/preload/features/commands.ts
@@ -18,9 +18,11 @@ const commandsFeature: CapabilityModule<
           has,
         ) as Promise<void>,
       titles: () =>
-        ipcRenderer.invoke("vellum:menu:titles") as Promise<string[]>,
-      popup: (title, x, y) =>
-        ipcRenderer.invoke("vellum:menu:popup", title, x, y) as Promise<void>,
+        ipcRenderer.invoke("vellum:menu:titles") as Promise<
+          Array<{ id: string; label: string }>
+        >,
+      popup: (id, x, y) =>
+        ipcRenderer.invoke("vellum:menu:popup", id, x, y) as Promise<void>,
     });
   },
 };

--- a/clients/windows/src/preload/features/commands.ts
+++ b/clients/windows/src/preload/features/commands.ts
@@ -13,7 +13,14 @@ const commandsFeature: CapabilityModule<
   install: (registry) => {
     registry.contribute("menu", {
       setPlatformSession: (has) =>
-        ipcRenderer.invoke("vellum:menu:setPlatformSession", has) as Promise<void>,
+        ipcRenderer.invoke(
+          "vellum:menu:setPlatformSession",
+          has,
+        ) as Promise<void>,
+      titles: () =>
+        ipcRenderer.invoke("vellum:menu:titles") as Promise<string[]>,
+      popup: (title, x, y) =>
+        ipcRenderer.invoke("vellum:menu:popup", title, x, y) as Promise<void>,
     });
   },
 };

--- a/clients/windows/src/preload/features/commands.ts
+++ b/clients/windows/src/preload/features/commands.ts
@@ -4,7 +4,12 @@ import type {
   BridgeCapabilityRegistry,
   CapabilityModule,
 } from "@vellumai/electron-desktop/capability-registry";
-import type { VellumBridge } from "@vellumai/ipc-contract";
+import {
+  MENU_POPUP,
+  MENU_SET_PLATFORM_SESSION,
+  MENU_TITLES,
+  type VellumBridge,
+} from "@vellumai/ipc-contract";
 
 const commandsFeature: CapabilityModule<
   BridgeCapabilityRegistry<VellumBridge>
@@ -13,16 +18,13 @@ const commandsFeature: CapabilityModule<
   install: (registry) => {
     registry.contribute("menu", {
       setPlatformSession: (has) =>
-        ipcRenderer.invoke(
-          "vellum:menu:setPlatformSession",
-          has,
-        ) as Promise<void>,
+        ipcRenderer.invoke(MENU_SET_PLATFORM_SESSION, has) as Promise<void>,
       titles: () =>
-        ipcRenderer.invoke("vellum:menu:titles") as Promise<
+        ipcRenderer.invoke(MENU_TITLES) as Promise<
           Array<{ id: string; label: string }>
         >,
       popup: (id, x, y) =>
-        ipcRenderer.invoke("vellum:menu:popup", id, x, y) as Promise<void>,
+        ipcRenderer.invoke(MENU_POPUP, id, x, y) as Promise<void>,
     });
   },
 };

--- a/packages/ipc-contract/src/bridge.ts
+++ b/packages/ipc-contract/src/bridge.ts
@@ -282,17 +282,18 @@ export interface VellumBridge {
   menu: {
     setPlatformSession(has: boolean): Promise<void>;
     /**
-     * Titles of the top-level application menus. Windows only: the shell
-     * hides the native frame (and the menu bar with it), so the renderer
-     * draws the titles in its own title bar.
+     * The top-level application menus: stable ids plus the shell's own
+     * labels. Windows only: the shell hides the native frame (and the menu
+     * bar with it), so the renderer draws the titles in its own title bar,
+     * mapping the ids to localized labels.
      */
-    titles?(): Promise<string[]>;
+    titles?(): Promise<Array<{ id: string; label: string }>>;
     /**
-     * Pop the native submenu named `title` at (`x`, `y`), in CSS pixels
+     * Pop the native submenu with the given id at (`x`, `y`), in CSS pixels
      * relative to the window's web contents. Resolves when the menu closes.
      * Windows only, paired with `titles`.
      */
-    popup?(title: string, x: number, y: number): Promise<void>;
+    popup?(id: string, x: number, y: number): Promise<void>;
   };
   mainWindow: {
     ensureVisible(): Promise<void>;

--- a/packages/ipc-contract/src/bridge.ts
+++ b/packages/ipc-contract/src/bridge.ts
@@ -170,7 +170,9 @@ export interface VellumBridge {
        * PCM — the offline transcript authority. Result arrives via
        * `onTranscribed`.
        */
-      transcribe?(audio: ArrayBuffer): Promise<{ ok: boolean; reason?: string }>;
+      transcribe?(
+        audio: ArrayBuffer,
+      ): Promise<{ ok: boolean; reason?: string }>;
       onTranscribed?(
         callback: (event: DictationPartialEvent) => void,
       ): () => void;
@@ -279,6 +281,18 @@ export interface VellumBridge {
   };
   menu: {
     setPlatformSession(has: boolean): Promise<void>;
+    /**
+     * Titles of the top-level application menus. Windows only: the shell
+     * hides the native frame (and the menu bar with it), so the renderer
+     * draws the titles in its own title bar.
+     */
+    titles?(): Promise<string[]>;
+    /**
+     * Pop the native submenu named `title` at (`x`, `y`), in CSS pixels
+     * relative to the window's web contents. Resolves when the menu closes.
+     * Windows only, paired with `titles`.
+     */
+    popup?(title: string, x: number, y: number): Promise<void>;
   };
   mainWindow: {
     ensureVisible(): Promise<void>;

--- a/packages/ipc-contract/src/channels.ts
+++ b/packages/ipc-contract/src/channels.ts
@@ -89,6 +89,8 @@ export const LOCAL_MODE_GUARDIAN_TOKEN = "vellum:localMode:guardianToken";
 
 // Menu
 export const MENU_SET_PLATFORM_SESSION = "vellum:menu:setPlatformSession";
+export const MENU_TITLES = "vellum:menu:titles";
+export const MENU_POPUP = "vellum:menu:popup";
 
 // Main window
 export const MAIN_WINDOW_ENSURE_VISIBLE = "vellum:mainWindow:ensureVisible";


### PR DESCRIPTION
## Summary
- The Windows shell runs `titleBarStyle: "hidden"`, so the native menu bar (File/Edit/View/Window/Help defined in `clients/windows/src/main/menu.ts`) was never visible; the titles are now drawn as flat ghost buttons in the chat header title bar, next to the back/forward controls, matching how the Codex Windows app does it.
- Clicking a title asks main to pop the real native submenu just below the button (`vellum:menu:titles` / `vellum:menu:popup`), so items, accelerators, and enabled states keep the existing menu template as the single owner; coordinates are zoom-scaled from CSS px to DIPs.
- The renderer component self-gates: the titles query resolves empty off Electron, on macOS, and on older shells that predate the bridge, so nothing renders there.

## Original prompt
The Windows app was missing the File/Edit/View/Window/Help menus entirely, since the custom title bar hides the OS menu bar. The ask was to find a home for them that doesn't look out of place, using the Codex Windows app as the reference: flat menu labels rendered inline in the custom title-bar row that pop native menus, rather than restoring the default OS-drawn menu bar.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40960" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->