### PR TITLE
fix(windows): make the dictation overlay Stop button clickable

### DIFF
--- a/clients/macos/src/preload/index.ts
+++ b/clients/macos/src/preload/index.ts
@@ -6,14 +6,9 @@ import {
 } from "electron";
 
 import { createLocalModeBridge } from "@vellumai/electron-desktop/local-mode-bridge";
-import {
-  createFileOpenPreloadBridge,
-} from "@vellumai/electron-desktop/file-open-preload";
+import { createFileOpenPreloadBridge } from "@vellumai/electron-desktop/file-open-preload";
 
-import type {
-  Lockfile,
-  LockfileWriteResult,
-} from "@vellumai/local-mode";
+import type { Lockfile, LockfileWriteResult } from "@vellumai/local-mode";
 import type {
   AppVersionInfo,
   AssistantStatus,
@@ -22,6 +17,7 @@ import type {
   CompanionSurfaceState,
   ConnectivityState,
   DeepLink,
+  DictationOverlayHitRegion,
   DictationOverlayMessage,
   DictationOverlayState,
   DictationPartialEvent,
@@ -121,9 +117,7 @@ const bridge: VellumBridge = {
         text,
       ) as Promise<TextInsertionResult>,
     openAutomationSettings: (): Promise<void> =>
-      ipcRenderer.invoke(
-        "vellum:text:openAutomationSettings",
-      ) as Promise<void>,
+      ipcRenderer.invoke("vellum:text:openAutomationSettings") as Promise<void>,
   },
   auth: {
     startOAuth: (options: {
@@ -174,8 +168,7 @@ const bridge: VellumBridge = {
     },
   },
   helper: {
-    ping: () =>
-      ipcRenderer.invoke("vellum:helper:ping") as Promise<"pong">,
+    ping: () => ipcRenderer.invoke("vellum:helper:ping") as Promise<"pong">,
     getState: () =>
       ipcRenderer.invoke("vellum:helper:state:get") as Promise<HelperState>,
     restart: () =>
@@ -223,9 +216,7 @@ const bridge: VellumBridge = {
         ipcRenderer.send("vellum:helper:dictation:audio", chunk);
       },
       onPartial: subscribeDictationEvent("vellum:helper:dictation:partial"),
-      onFinalized: subscribeDictationEvent(
-        "vellum:helper:dictation:finalized",
-      ),
+      onFinalized: subscribeDictationEvent("vellum:helper:dictation:finalized"),
       transcribe: (
         audio: ArrayBuffer,
       ): Promise<{ ok: boolean; reason?: string }> =>
@@ -311,7 +302,10 @@ const bridge: VellumBridge = {
   localMode: createLocalModeBridge(ipcRenderer),
   menu: {
     setPlatformSession: (has: boolean): Promise<void> =>
-      ipcRenderer.invoke("vellum:menu:setPlatformSession", has) as Promise<void>,
+      ipcRenderer.invoke(
+        "vellum:menu:setPlatformSession",
+        has,
+      ) as Promise<void>,
   },
   mainWindow: {
     ensureVisible: (): Promise<void> =>
@@ -341,22 +335,20 @@ const bridge: VellumBridge = {
       ipcRenderer.invoke(FEEDBACK_DIAGNOSTICS) as Promise<
         Record<string, unknown>
       >,
-    logs: () =>
-      ipcRenderer.invoke(FEEDBACK_LOGS) as Promise<string>,
+    logs: () => ipcRenderer.invoke(FEEDBACK_LOGS) as Promise<string>,
   },
   connectivity: {
     onState: (callback) => {
-      const handler = (
-        _event: IpcRendererEvent,
-        state: ConnectivityState,
-      ) => {
+      const handler = (_event: IpcRendererEvent, state: ConnectivityState) => {
         callback(state);
       };
       ipcRenderer.on("vellum:connectivity:state", handler);
       // Emit the current state so late subscribers (window loaded after
       // the first probe) don't wait for the next state transition.
       void (
-        ipcRenderer.invoke("vellum:connectivity:get") as Promise<ConnectivityState>
+        ipcRenderer.invoke(
+          "vellum:connectivity:get",
+        ) as Promise<ConnectivityState>
       ).then(callback);
       return () => {
         ipcRenderer.off("vellum:connectivity:state", handler);
@@ -378,10 +370,10 @@ const bridge: VellumBridge = {
     show: (
       payload: ShowNotificationPayload,
     ): Promise<{ success: boolean; errorMessage?: string }> =>
-      ipcRenderer.invoke(
-        "vellum:notifications:show",
-        payload,
-      ) as Promise<{ success: boolean; errorMessage?: string }>,
+      ipcRenderer.invoke("vellum:notifications:show", payload) as Promise<{
+        success: boolean;
+        errorMessage?: string;
+      }>,
     onAction: (callback) => {
       const handler = (
         _event: IpcRendererEvent,
@@ -456,6 +448,9 @@ const bridge: VellumBridge = {
     setInteractive: (interactive: boolean): void => {
       ipcRenderer.send("vellum:dictationOverlay:setInteractive", interactive);
     },
+    setHitRegion: (region: DictationOverlayHitRegion | null): void => {
+      ipcRenderer.send("vellum:dictationOverlay:setHitRegion", region);
+    },
   },
   voiceActivity: {
     start: (state: VoiceActivityStart): void => {
@@ -516,11 +511,7 @@ const bridge: VellumBridge = {
       ipcRenderer.send("vellum:companion:setComposing", composing);
     },
     submit: (message: string, startsConversation: boolean): void => {
-      ipcRenderer.send(
-        "vellum:companion:submit",
-        message,
-        startsConversation,
-      );
+      ipcRenderer.send("vellum:companion:submit", message, startsConversation);
     },
     setContext: (context: CompanionContext): void => {
       ipcRenderer.send("vellum:companion:setContext", context);

--- a/clients/macos/src/preload/index.ts
+++ b/clients/macos/src/preload/index.ts
@@ -6,9 +6,14 @@ import {
 } from "electron";
 
 import { createLocalModeBridge } from "@vellumai/electron-desktop/local-mode-bridge";
-import { createFileOpenPreloadBridge } from "@vellumai/electron-desktop/file-open-preload";
+import {
+  createFileOpenPreloadBridge,
+} from "@vellumai/electron-desktop/file-open-preload";
 
-import type { Lockfile, LockfileWriteResult } from "@vellumai/local-mode";
+import type {
+  Lockfile,
+  LockfileWriteResult,
+} from "@vellumai/local-mode";
 import type {
   AppVersionInfo,
   AssistantStatus,
@@ -117,7 +122,9 @@ const bridge: VellumBridge = {
         text,
       ) as Promise<TextInsertionResult>,
     openAutomationSettings: (): Promise<void> =>
-      ipcRenderer.invoke("vellum:text:openAutomationSettings") as Promise<void>,
+      ipcRenderer.invoke(
+        "vellum:text:openAutomationSettings",
+      ) as Promise<void>,
   },
   auth: {
     startOAuth: (options: {
@@ -168,7 +175,8 @@ const bridge: VellumBridge = {
     },
   },
   helper: {
-    ping: () => ipcRenderer.invoke("vellum:helper:ping") as Promise<"pong">,
+    ping: () =>
+      ipcRenderer.invoke("vellum:helper:ping") as Promise<"pong">,
     getState: () =>
       ipcRenderer.invoke("vellum:helper:state:get") as Promise<HelperState>,
     restart: () =>
@@ -216,7 +224,9 @@ const bridge: VellumBridge = {
         ipcRenderer.send("vellum:helper:dictation:audio", chunk);
       },
       onPartial: subscribeDictationEvent("vellum:helper:dictation:partial"),
-      onFinalized: subscribeDictationEvent("vellum:helper:dictation:finalized"),
+      onFinalized: subscribeDictationEvent(
+        "vellum:helper:dictation:finalized",
+      ),
       transcribe: (
         audio: ArrayBuffer,
       ): Promise<{ ok: boolean; reason?: string }> =>
@@ -302,10 +312,7 @@ const bridge: VellumBridge = {
   localMode: createLocalModeBridge(ipcRenderer),
   menu: {
     setPlatformSession: (has: boolean): Promise<void> =>
-      ipcRenderer.invoke(
-        "vellum:menu:setPlatformSession",
-        has,
-      ) as Promise<void>,
+      ipcRenderer.invoke("vellum:menu:setPlatformSession", has) as Promise<void>,
   },
   mainWindow: {
     ensureVisible: (): Promise<void> =>
@@ -335,20 +342,22 @@ const bridge: VellumBridge = {
       ipcRenderer.invoke(FEEDBACK_DIAGNOSTICS) as Promise<
         Record<string, unknown>
       >,
-    logs: () => ipcRenderer.invoke(FEEDBACK_LOGS) as Promise<string>,
+    logs: () =>
+      ipcRenderer.invoke(FEEDBACK_LOGS) as Promise<string>,
   },
   connectivity: {
     onState: (callback) => {
-      const handler = (_event: IpcRendererEvent, state: ConnectivityState) => {
+      const handler = (
+        _event: IpcRendererEvent,
+        state: ConnectivityState,
+      ) => {
         callback(state);
       };
       ipcRenderer.on("vellum:connectivity:state", handler);
       // Emit the current state so late subscribers (window loaded after
       // the first probe) don't wait for the next state transition.
       void (
-        ipcRenderer.invoke(
-          "vellum:connectivity:get",
-        ) as Promise<ConnectivityState>
+        ipcRenderer.invoke("vellum:connectivity:get") as Promise<ConnectivityState>
       ).then(callback);
       return () => {
         ipcRenderer.off("vellum:connectivity:state", handler);
@@ -370,10 +379,10 @@ const bridge: VellumBridge = {
     show: (
       payload: ShowNotificationPayload,
     ): Promise<{ success: boolean; errorMessage?: string }> =>
-      ipcRenderer.invoke("vellum:notifications:show", payload) as Promise<{
-        success: boolean;
-        errorMessage?: string;
-      }>,
+      ipcRenderer.invoke(
+        "vellum:notifications:show",
+        payload,
+      ) as Promise<{ success: boolean; errorMessage?: string }>,
     onAction: (callback) => {
       const handler = (
         _event: IpcRendererEvent,
@@ -511,7 +520,11 @@ const bridge: VellumBridge = {
       ipcRenderer.send("vellum:companion:setComposing", composing);
     },
     submit: (message: string, startsConversation: boolean): void => {
-      ipcRenderer.send("vellum:companion:submit", message, startsConversation);
+      ipcRenderer.send(
+        "vellum:companion:submit",
+        message,
+        startsConversation,
+      );
     },
     setContext: (context: CompanionContext): void => {
       ipcRenderer.send("vellum:companion:setContext", context);

--- a/clients/web/src/components/dictation-overlay-page.test.tsx
+++ b/clients/web/src/components/dictation-overlay-page.test.tsx
@@ -6,12 +6,17 @@ import type { DictationOverlayState } from "@/runtime/is-electron";
 let currentState: DictationOverlayState | null = null;
 const requestStopMock = mock(() => undefined);
 const setInteractiveMock = mock((_interactive: boolean) => undefined);
+const setHitRegionMock = mock(
+  (_region: { x: number; y: number; width: number; height: number } | null) =>
+    undefined,
+);
 
 mock.module("@/runtime/dictation-overlay", () => ({
   getDictationOverlayState: async () => currentState,
   subscribeToDictationOverlayState: () => () => undefined,
   requestDictationOverlayStop: requestStopMock,
   setDictationOverlayInteractive: setInteractiveMock,
+  setDictationOverlayHitRegion: setHitRegionMock,
 }));
 
 const { DictationOverlayPage } = await import("./dictation-overlay-page");
@@ -21,6 +26,7 @@ afterEach(() => {
   currentState = null;
   requestStopMock.mockClear();
   setInteractiveMock.mockClear();
+  setHitRegionMock.mockClear();
 });
 
 describe("DictationOverlayPage", () => {
@@ -89,6 +95,23 @@ describe("DictationOverlayPage", () => {
 
     expect(setInteractiveMock.mock.calls).toContainEqual([true]);
     expect(setInteractiveMock.mock.calls.at(-1)).toEqual([false]);
+  });
+
+  test("reports the stop control's hit region while recording and clears it on teardown", async () => {
+    currentState = {
+      kind: "recording",
+      transcription: "",
+      audioLevel: 0.5,
+    };
+
+    const { getByLabelText, unmount } = render(<DictationOverlayPage />);
+    await waitFor(() => getByLabelText("Stop recording"));
+
+    expect(setHitRegionMock).toHaveBeenCalled();
+    expect(setHitRegionMock.mock.calls.at(-1)?.[0]).not.toBeNull();
+
+    unmount();
+    expect(setHitRegionMock.mock.calls.at(-1)).toEqual([null]);
   });
 
   test("does not render the stop control after recording ends", async () => {

--- a/clients/web/src/components/dictation-overlay-page.test.tsx
+++ b/clients/web/src/components/dictation-overlay-page.test.tsx
@@ -114,6 +114,59 @@ describe("DictationOverlayPage", () => {
     expect(setHitRegionMock.mock.calls.at(-1)).toEqual([null]);
   });
 
+  test("re-measures the hit region when the layout changes mid-recording", async () => {
+    currentState = {
+      kind: "recording",
+      transcription: "",
+      audioLevel: 0.5,
+    };
+
+    const observerCallbacks: Array<() => void> = [];
+    const originalResizeObserver = globalThis.ResizeObserver;
+    globalThis.ResizeObserver = class {
+      constructor(callback: ResizeObserverCallback) {
+        observerCallbacks.push(() =>
+          callback([], this as unknown as ResizeObserver),
+        );
+      }
+
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as typeof ResizeObserver;
+
+    try {
+      const { getByLabelText } = render(<DictationOverlayPage />);
+      const stopButton = await waitFor(() => getByLabelText("Stop recording"));
+      expect(observerCallbacks.length).toBeGreaterThan(0);
+
+      stopButton.getBoundingClientRect = () =>
+        ({
+          left: 44,
+          right: 64,
+          top: 8,
+          bottom: 28,
+          x: 44,
+          y: 8,
+          width: 20,
+          height: 20,
+          toJSON: () => ({}),
+        }) as DOMRect;
+      for (const fire of observerCallbacks) {
+        fire();
+      }
+
+      expect(setHitRegionMock.mock.calls.at(-1)?.[0]).toEqual({
+        x: 44,
+        y: 8,
+        width: 20,
+        height: 20,
+      });
+    } finally {
+      globalThis.ResizeObserver = originalResizeObserver;
+    }
+  });
+
   test("does not render the stop control after recording ends", async () => {
     currentState = { kind: "processing" };
 

--- a/clients/web/src/components/dictation-overlay-page.tsx
+++ b/clients/web/src/components/dictation-overlay-page.tsx
@@ -65,8 +65,9 @@ export function DictationOverlayPage() {
 
   // Tell main where the Stop control sits so it can hit-test the cursor
   // itself on platforms where forwarded mouse moves never reach this
-  // click-through window (Windows). The pill's top row is static for the
-  // whole recording state, so one measurement per session is enough.
+  // click-through window (Windows). View > Zoom relayouts the page
+  // mid-recording and moves the button, so watch the viewport and the
+  // button and re-report on every change.
   useEffect(() => {
     if (state?.kind !== "recording") {
       return;
@@ -75,14 +76,21 @@ export function DictationOverlayPage() {
     if (!button) {
       return;
     }
-    const rect = button.getBoundingClientRect();
-    setDictationOverlayHitRegion({
-      x: rect.left,
-      y: rect.top,
-      width: rect.width,
-      height: rect.height,
-    });
+    const report = () => {
+      const rect = button.getBoundingClientRect();
+      setDictationOverlayHitRegion({
+        x: rect.left,
+        y: rect.top,
+        width: rect.width,
+        height: rect.height,
+      });
+    };
+    report();
+    const observer = new ResizeObserver(report);
+    observer.observe(document.documentElement);
+    observer.observe(button);
     return () => {
+      observer.disconnect();
       setDictationOverlayHitRegion(null);
     };
   }, [state?.kind]);

--- a/clients/web/src/components/dictation-overlay-page.tsx
+++ b/clients/web/src/components/dictation-overlay-page.tsx
@@ -10,6 +10,7 @@ import {
 import {
   getDictationOverlayState,
   requestDictationOverlayStop,
+  setDictationOverlayHitRegion,
   setDictationOverlayInteractive,
   subscribeToDictationOverlayState,
 } from "@/runtime/dictation-overlay";
@@ -60,6 +61,30 @@ export function DictationOverlayPage() {
     }
     interactiveRef.current = false;
     setDictationOverlayInteractive(false);
+  }, [state?.kind]);
+
+  // Tell main where the Stop control sits so it can hit-test the cursor
+  // itself on platforms where forwarded mouse moves never reach this
+  // click-through window (Windows). The pill's top row is static for the
+  // whole recording state, so one measurement per session is enough.
+  useEffect(() => {
+    if (state?.kind !== "recording") {
+      return;
+    }
+    const button = stopButtonRef.current;
+    if (!button) {
+      return;
+    }
+    const rect = button.getBoundingClientRect();
+    setDictationOverlayHitRegion({
+      x: rect.left,
+      y: rect.top,
+      width: rect.width,
+      height: rect.height,
+    });
+    return () => {
+      setDictationOverlayHitRegion(null);
+    };
   }, [state?.kind]);
 
   if (!state) {

--- a/clients/web/src/runtime/dictation-overlay.ts
+++ b/clients/web/src/runtime/dictation-overlay.ts
@@ -14,6 +14,7 @@
 
 import {
   isElectron,
+  type DictationOverlayHitRegion,
   type DictationOverlayMessage,
   type DictationOverlayState,
 } from "@/runtime/is-electron";
@@ -76,4 +77,19 @@ export function setDictationOverlayInteractive(interactive: boolean): void {
     return;
   }
   window.vellum?.dictationOverlay?.setInteractive?.(interactive);
+}
+
+/**
+ * Report where the Stop control sits (window-relative CSS pixels), or null
+ * when there is none. Main hit-tests the cursor against it on platforms
+ * where forwarded mouse moves never reach the click-through overlay
+ * (Windows). No-ops on shells that predate the channel.
+ */
+export function setDictationOverlayHitRegion(
+  region: DictationOverlayHitRegion | null,
+): void {
+  if (!isElectron()) {
+    return;
+  }
+  window.vellum?.dictationOverlay?.setHitRegion?.(region);
 }

--- a/clients/web/src/runtime/is-electron.ts
+++ b/clients/web/src/runtime/is-electron.ts
@@ -26,6 +26,7 @@ import type {
   CompanionSurfaceState,
   ConnectivityState,
   DeepLink,
+  DictationOverlayHitRegion,
   DictationOverlayMessage,
   DictationOverlayState,
   DictationPartialEvent,
@@ -75,6 +76,7 @@ export type {
   CompanionSurfaceState,
   ConnectivityState,
   DeepLink,
+  DictationOverlayHitRegion,
   DictationOverlayMessage,
   DictationOverlayState,
   DictationPartialEvent,
@@ -305,6 +307,7 @@ declare global {
         requestStop(): void;
         onStopRequested(callback: () => void): () => void;
         setInteractive(interactive: boolean): void;
+        setHitRegion?(region: DictationOverlayHitRegion | null): void;
       };
       notifications?: {
         show(
@@ -332,7 +335,9 @@ declare global {
         update(content: VoiceActivityContent): void;
         end(): void;
         control(control: VoiceActivityControl): void;
-        onControl(callback: (control: VoiceActivityControl) => void): () => void;
+        onControl(
+          callback: (control: VoiceActivityControl) => void,
+        ): () => void;
       };
       companion?: {
         getState(): Promise<CompanionSurfaceState | null>;

--- a/clients/windows/src/main/app-config.ts
+++ b/clients/windows/src/main/app-config.ts
@@ -47,6 +47,20 @@ export const RENDERER_BASE_PROD = `${APP_PROTOCOL}://${APP_HOST}/assistant`;
 export const getDevRendererBase = (): string =>
   (process.env.VELLUM_DEV_URL ?? DEV_SERVER_FALLBACK_URL).replace(/\/+$/, "");
 
+/**
+ * Renderer-base URL for the current process, for auxiliary windows and
+ * any other surface that must land on the same origin as the main window.
+ * Follows `usesAppProtocolRenderer`, not `isPackaged` alone: with
+ * `VELLUM_LOCAL_RENDERER` the main window is served over `app://` while
+ * `VELLUM_DEV_URL` points at the remote platform, and loading that remote
+ * URL would hand a window a foreign origin that the IPC sender guard
+ * rejects.
+ */
+export const getRendererBase = (isPackaged: boolean): string =>
+  usesAppProtocolRenderer(isPackaged)
+    ? RENDERER_BASE_PROD
+    : getDevRendererBase();
+
 /** Whether this process loads the renderer through the app protocol. */
 export const usesAppProtocolRenderer = (isPackaged: boolean): boolean =>
   isPackaged || process.env.VELLUM_LOCAL_RENDERER === "true";

--- a/clients/windows/src/main/auxiliary-windows.test.ts
+++ b/clients/windows/src/main/auxiliary-windows.test.ts
@@ -41,6 +41,7 @@ const makeWindow = () => {
       isDestroyed: () => destroyed,
       on: () => undefined,
       send: mock(() => undefined),
+      getZoomFactor: () => 1,
     },
     close: mock(() => emit("closed")),
     emit,

--- a/clients/windows/src/main/auxiliary-windows.test.ts
+++ b/clients/windows/src/main/auxiliary-windows.test.ts
@@ -1,4 +1,12 @@
-import { afterEach, beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
 
 import type { CreateWindowOptions } from "@vellumai/electron-desktop/windows";
 
@@ -33,6 +41,7 @@ const makeWindow = () => {
       isDestroyed: () => destroyed,
       on: () => undefined,
       send: mock(() => undefined),
+      sendInputEvent: mock(() => undefined),
     },
     close: mock(() => emit("closed")),
     emit,
@@ -70,7 +79,9 @@ mock.module("electron", () => ({
   app: { isPackaged: false },
   BrowserWindow: class {
     static getAllWindows() {
-      return created.map(({ window }) => window).filter((win) => !win.isDestroyed());
+      return created
+        .map(({ window }) => window)
+        .filter((win) => !win.isDestroyed());
     }
 
     static getFocusedWindow() {
@@ -108,7 +119,8 @@ mock.module("./main-window", () => ({
 }));
 mock.module("./logger", () => ({ default: { warn: logWarn } }));
 
-const { default: auxiliaryWindowsModule } = await import("./features/auxiliary-windows");
+const { default: auxiliaryWindowsModule } =
+  await import("./features/auxiliary-windows");
 beforeAll(() => {
   auxiliaryWindowsModule.install({} as never);
 });
@@ -149,7 +161,9 @@ describe("Windows auxiliary windows", () => {
       y: 324,
       alwaysOnTop: true,
     });
-    expect(window.loadURL).toHaveBeenCalledWith("http://localhost:5173/assistant/quick-input");
+    expect(window.loadURL).toHaveBeenCalledWith(
+      "http://localhost:5173/assistant/quick-input",
+    );
     window.emit("blur");
     expect(window.isDestroyed()).toBe(true);
   });
@@ -168,8 +182,30 @@ describe("Windows auxiliary windows", () => {
     expect(window.loadURL).toHaveBeenCalledWith(
       "http://localhost:5173/assistant/floating/dictation-overlay",
     );
-    onListeners.get("vellum:dictationOverlay:setState")?.([{ kind: "dismiss" }]);
+    onListeners.get("vellum:dictationOverlay:setState")?.([
+      { kind: "dismiss" },
+    ]);
     expect(window.isDestroyed()).toBe(true);
+  });
+
+  test("polls the cursor and synthesizes hover moves into the click-through overlay", async () => {
+    // Native forward:true mouse-move delivery is unreliable on Windows
+    // (electron/electron#33281); the overlay must receive synthetic moves so
+    // its Stop button hit-test can run. The mocked cursor sits at the
+    // window's origin, i.e. inside the overlay canvas.
+    onListeners.get("vellum:dictationOverlay:setState")?.([
+      { kind: "recording", transcription: "" },
+    ]);
+    const { window } = created[0]!;
+    await new Promise((resolve) => setTimeout(resolve, 120));
+    expect(window.webContents.sendInputEvent).toHaveBeenCalledWith({
+      type: "mouseMove",
+      x: 0,
+      y: 0,
+    });
+    onListeners.get("vellum:dictationOverlay:setState")?.([
+      { kind: "dismiss" },
+    ]);
   });
 
   test("repositions transient windows after a display change", () => {

--- a/clients/windows/src/main/auxiliary-windows.test.ts
+++ b/clients/windows/src/main/auxiliary-windows.test.ts
@@ -41,7 +41,6 @@ const makeWindow = () => {
       isDestroyed: () => destroyed,
       on: () => undefined,
       send: mock(() => undefined),
-      sendInputEvent: mock(() => undefined),
     },
     close: mock(() => emit("closed")),
     emit,
@@ -188,21 +187,21 @@ describe("Windows auxiliary windows", () => {
     expect(window.isDestroyed()).toBe(true);
   });
 
-  test("polls the cursor and synthesizes hover moves into the click-through overlay", async () => {
+  test("polls the cursor against the reported Stop region and unlocks clicks", async () => {
     // Native forward:true mouse-move delivery is unreliable on Windows
-    // (electron/electron#33281); the overlay must receive synthetic moves so
-    // its Stop button hit-test can run. The mocked cursor sits at the
-    // window's origin, i.e. inside the overlay canvas.
+    // (electron/electron#33281), so main hit-tests the cursor against the
+    // Stop region the overlay page reports. The mocked cursor sits at the
+    // window's origin; a region covering it must flip the window
+    // interactive.
     onListeners.get("vellum:dictationOverlay:setState")?.([
       { kind: "recording", transcription: "" },
     ]);
+    onListeners.get("vellum:dictationOverlay:setHitRegion")?.([
+      { x: 0, y: 0, width: 24, height: 24 },
+    ]);
     const { window } = created[0]!;
     await new Promise((resolve) => setTimeout(resolve, 120));
-    expect(window.webContents.sendInputEvent).toHaveBeenCalledWith({
-      type: "mouseMove",
-      x: 0,
-      y: 0,
-    });
+    expect(window.setIgnoreMouseEvents).toHaveBeenCalledWith(false);
     onListeners.get("vellum:dictationOverlay:setState")?.([
       { kind: "dismiss" },
     ]);

--- a/clients/windows/src/main/auxiliary-windows.test.ts
+++ b/clients/windows/src/main/auxiliary-windows.test.ts
@@ -210,6 +210,25 @@ describe("Windows auxiliary windows", () => {
     ]);
   });
 
+  test("loads auxiliary windows from the app origin in local-renderer dev", () => {
+    // VELLUM_LOCAL_RENDERER serves the main window over app:// while
+    // VELLUM_DEV_URL names the remote platform; auxiliary windows must
+    // follow the main window or the IPC sender guard rejects them.
+    process.env.VELLUM_LOCAL_RENDERER = "true";
+    process.env.VELLUM_DEV_URL = "https://dev-assistant.example.com/assistant";
+    try {
+      onListeners.get("vellum:dictationOverlay:setState")?.([
+        { kind: "recording", transcription: "" },
+      ]);
+      expect(created[0]!.window.loadURL).toHaveBeenCalledWith(
+        "app://vellum.ai/assistant/floating/dictation-overlay",
+      );
+    } finally {
+      delete process.env.VELLUM_LOCAL_RENDERER;
+      delete process.env.VELLUM_DEV_URL;
+    }
+  });
+
   test("repositions transient windows after a display change", () => {
     handleListeners.get("vellum:commandPalette:open")?.([]);
     shortcutListeners.get("Control+Shift+/")?.();

--- a/clients/windows/src/main/auxiliary-windows.test.ts
+++ b/clients/windows/src/main/auxiliary-windows.test.ts
@@ -117,7 +117,9 @@ mock.module("./main-window", () => ({
   dispatchToMain,
   ensureVisible,
 }));
-mock.module("./logger", () => ({ default: { warn: logWarn } }));
+mock.module("./logger", () => ({
+  default: { info: () => undefined, warn: logWarn },
+}));
 
 const { default: auxiliaryWindowsModule } =
   await import("./features/auxiliary-windows");

--- a/clients/windows/src/main/features/auxiliary-windows.ts
+++ b/clients/windows/src/main/features/auxiliary-windows.ts
@@ -61,7 +61,15 @@ const module: CapabilityModule<DesktopCapabilityRegistry> = {
       platform: "win32",
       resolveRoute,
     });
-    configureDictationOverlayWindow({ closeOnHide: true, handle, on });
+    // Native mouse-move forwarding for the click-through overlay is
+    // unreliable on Windows (electron/electron#33281); poll instead so the
+    // Stop button can be hovered and clicked.
+    configureDictationOverlayWindow({
+      closeOnHide: true,
+      pollCursorForHover: true,
+      handle,
+      on,
+    });
     configurePopoutWindows({ createWindow, handle, resolveRoute });
 
     installCommandPaletteWindow();

--- a/clients/windows/src/main/features/auxiliary-windows.ts
+++ b/clients/windows/src/main/features/auxiliary-windows.ts
@@ -61,12 +61,13 @@ const module: CapabilityModule<DesktopCapabilityRegistry> = {
       platform: "win32",
       resolveRoute,
     });
-    // Native mouse-move forwarding for the click-through overlay is
-    // unreliable on Windows (electron/electron#33281); poll instead so the
-    // Stop button can be hovered and clicked.
+    // Native mouse-move forwarding for the click-through overlay is broken
+    // on Windows (see `pollCursorForHover`); poll instead so the Stop button
+    // can be hovered and clicked.
     configureDictationOverlayWindow({
       closeOnHide: true,
       pollCursorForHover: true,
+      log: (message) => log.info(message),
       handle,
       on,
     });

--- a/clients/windows/src/main/features/auxiliary-windows.ts
+++ b/clients/windows/src/main/features/auxiliary-windows.ts
@@ -29,14 +29,14 @@ import {
   toggleQuickInput,
 } from "@vellumai/electron-desktop/quick-input-window";
 
-import { RENDERER_BASE_PROD, getDevRendererBase } from "../app-config";
+import { getRendererBase } from "../app-config";
 import { handle, on } from "../ipc.client";
 import log from "../logger";
 import { current, dispatchToMain, ensureVisible } from "../main-window";
 import { createWindow } from "../windows.client";
 
 const resolveRoute = createWindowRouteResolver(() =>
-  app.isPackaged ? RENDERER_BASE_PROD : getDevRendererBase(),
+  getRendererBase(app.isPackaged),
 );
 
 const module: CapabilityModule<DesktopCapabilityRegistry> = {

--- a/clients/windows/src/main/features/bundles.ts
+++ b/clients/windows/src/main/features/bundles.ts
@@ -17,7 +17,7 @@ import type {
 } from "@vellumai/electron-desktop/capability-registry";
 import { onFileOpen } from "@vellumai/electron-desktop/file-open";
 
-import { RENDERER_BASE_PROD, getDevRendererBase } from "../app-config";
+import { getRendererBase } from "../app-config";
 import { handle, on } from "../ipc.client";
 
 const bundles: CapabilityModule<DesktopCapabilityRegistry> = {
@@ -31,8 +31,7 @@ const bundles: CapabilityModule<DesktopCapabilityRegistry> = {
     configureBundlePlatform({
       ...host,
       bundlesRoot: () => path.join(app.getPath("userData"), BUNDLES_DIR_NAME),
-      rendererBase: () =>
-        app.isPackaged ? RENDERER_BASE_PROD : getDevRendererBase(),
+      rendererBase: () => getRendererBase(app.isPackaged),
       ipc: { handle, on },
     });
     installBundleFlow();

--- a/clients/windows/src/main/features/commands.ts
+++ b/clients/windows/src/main/features/commands.ts
@@ -18,7 +18,7 @@ import { installHotkeysIpc } from "@vellumai/electron-desktop/hotkeys";
 import { installImageContextMenu } from "@vellumai/electron-desktop/image-context-menu";
 import { installTextContextMenu } from "@vellumai/electron-desktop/text-context-menu";
 
-import { getDevRendererBase, RENDERER_BASE_PROD } from "../app-config";
+import { getRendererBase } from "../app-config";
 import { handle } from "../ipc.client";
 import log from "../logger";
 import { ensureVisible } from "../main-window";
@@ -34,8 +34,7 @@ const commandsFeature: CapabilityModule<DesktopCapabilityRegistry> = {
     }
 
     configureAboutRuntime({
-      rendererBase: () =>
-        app.isPackaged ? RENDERER_BASE_PROD : getDevRendererBase(),
+      rendererBase: () => getRendererBase(app.isPackaged),
     });
     installAbout({ handle });
 

--- a/clients/windows/src/main/host-proxy-adapter.ts
+++ b/clients/windows/src/main/host-proxy-adapter.ts
@@ -11,7 +11,7 @@ import { hostFileExecutor } from "@vellumai/electron-desktop/host-proxy/executor
 import { hostTransferExecutor } from "@vellumai/electron-desktop/host-proxy/executors/host-transfer-executor";
 import { createHostUiSnapshotExecutor } from "@vellumai/electron-desktop/host-proxy/executors/host-ui-snapshot-executor";
 
-import { getDevRendererBase, RENDERER_BASE_PROD } from "./app-config";
+import { getRendererBase } from "./app-config";
 import { hostBashExecutor } from "./executors/host-bash-adapter";
 
 import type { ComputerUseActionExecutors } from "./features/computer-use-actions";
@@ -52,8 +52,7 @@ export const createWindowsHostProxyRuntime = (
       host_transfer: hostTransferExecutor,
       host_browser: browserExecutor,
       host_ui_snapshot: createHostUiSnapshotExecutor({
-        resolveRendererBase: () =>
-          app.isPackaged ? RENDERER_BASE_PROD : getDevRendererBase(),
+        resolveRendererBase: () => getRendererBase(app.isPackaged),
       }),
       ...(computerUseExecutors
         ? { host_cu: computerUseExecutors.host_cu }

--- a/clients/windows/src/preload/features/auxiliary-windows.ts
+++ b/clients/windows/src/preload/features/auxiliary-windows.ts
@@ -10,6 +10,7 @@ import {
   COMMAND_PALETTE_SELECT,
   DICTATION_OVERLAY_GET_STATE,
   DICTATION_OVERLAY_REQUEST_STOP,
+  DICTATION_OVERLAY_SET_HIT_REGION,
   DICTATION_OVERLAY_SET_INTERACTIVE,
   DICTATION_OVERLAY_SET_STATE,
   DICTATION_OVERLAY_STATE_EVENT,
@@ -38,7 +39,10 @@ const module: CapabilityModule<BridgeCapabilityRegistry<VellumBridge>> = {
         ipcRenderer.send(DICTATION_OVERLAY_SET_STATE, state);
       },
       onState: (callback) => {
-        const listener = (_event: IpcRendererEvent, state: DictationOverlayState): void => {
+        const listener = (
+          _event: IpcRendererEvent,
+          state: DictationOverlayState,
+        ): void => {
           callback(state);
         };
         ipcRenderer.on(DICTATION_OVERLAY_STATE_EVENT, listener);
@@ -61,6 +65,9 @@ const module: CapabilityModule<BridgeCapabilityRegistry<VellumBridge>> = {
       },
       setInteractive: (interactive) => {
         ipcRenderer.send(DICTATION_OVERLAY_SET_INTERACTIVE, interactive);
+      },
+      setHitRegion: (region) => {
+        ipcRenderer.send(DICTATION_OVERLAY_SET_HIT_REGION, region);
       },
     });
     registry.contribute("popout", {

--- a/packages/electron-desktop/src/dictation-overlay-window.test.ts
+++ b/packages/electron-desktop/src/dictation-overlay-window.test.ts
@@ -5,35 +5,37 @@ mock.module("electron", () => ({
   screen: { getCursorScreenPoint: () => ({ x: 0, y: 0 }) },
 }));
 
-const { CURSOR_HOVER_POLL_MS, createCursorHoverForwarder } =
+const { CURSOR_HOVER_POLL_MS, createCursorHoverPoller } =
   await import("./dictation-overlay-window");
 
 type Rect = { x: number; y: number; width: number; height: number };
 
 const OVERLAY_BOUNDS: Rect = { x: 100, y: 50, width: 480, height: 160 };
+// The Stop control, window-relative: x 400..420, y 20..40 on screen
+// 500..520 x 70..90.
+const STOP_REGION: Rect = { x: 400, y: 20, width: 20, height: 20 };
 
 const createHarness = () => {
   const state = {
     cursor: { x: 0, y: 0 },
     bounds: OVERLAY_BOUNDS as Rect | null,
+    region: STOP_REGION as Rect | null,
     interactive: false,
-    moves: [] as Array<{ x: number; y: number }>,
-    leaves: 0,
+    toggles: [] as boolean[],
     intervals: 0,
     intervalMs: null as number | null,
     cleared: 0,
   };
   let tick: (() => void) | null = null;
 
-  const forwarder = createCursorHoverForwarder({
+  const poller = createCursorHoverPoller({
     getCursor: () => state.cursor,
     getOverlayBounds: () => state.bounds,
+    getHitRegion: () => state.region,
     isInteractive: () => state.interactive,
-    sendMouseMove: (point) => {
-      state.moves.push(point);
-    },
-    sendMouseLeave: () => {
-      state.leaves += 1;
+    setInteractive: (interactive) => {
+      state.interactive = interactive;
+      state.toggles.push(interactive);
     },
     setInterval: (callback, ms) => {
       state.intervals += 1;
@@ -47,89 +49,79 @@ const createHarness = () => {
     },
   });
 
-  return { forwarder, state, tick: () => tick?.() };
+  return { poller, state, tick: () => tick?.() };
 };
 
-describe("createCursorHoverForwarder", () => {
-  test("forwards window-relative moves while the cursor is inside the overlay", () => {
+describe("createCursorHoverPoller", () => {
+  test("makes the overlay interactive only while the cursor is over the Stop region", () => {
     const h = createHarness();
-    h.forwarder.start();
+    h.poller.start();
     expect(h.state.intervalMs).toBe(CURSOR_HOVER_POLL_MS);
 
-    h.state.cursor = { x: 120, y: 60 };
+    h.state.cursor = { x: 110, y: 60 };
     h.tick();
-    h.state.cursor = { x: 579, y: 209 };
-    h.tick();
+    expect(h.state.toggles).toEqual([]);
 
-    expect(h.state.moves).toEqual([
-      { x: 20, y: 10 },
-      { x: 479, y: 159 },
-    ]);
-    expect(h.state.leaves).toBe(0);
+    h.state.cursor = { x: 510, y: 80 };
+    h.tick();
+    expect(h.state.toggles).toEqual([true]);
+
+    h.state.cursor = { x: 530, y: 80 };
+    h.tick();
+    expect(h.state.toggles).toEqual([true, false]);
   });
 
-  test("sends a single leave when the cursor exits the overlay", () => {
+  test("does not re-toggle while the hover state is unchanged", () => {
     const h = createHarness();
-    h.forwarder.start();
+    h.poller.start();
 
-    h.state.cursor = { x: 120, y: 60 };
+    h.state.cursor = { x: 510, y: 80 };
     h.tick();
-    h.state.cursor = { x: 700, y: 60 };
     h.tick();
     h.tick();
 
-    expect(h.state.moves).toHaveLength(1);
-    expect(h.state.leaves).toBe(1);
+    expect(h.state.toggles).toEqual([true]);
   });
 
-  test("does not re-deliver moves while the cursor is stationary", () => {
+  test("stays click-through while no Stop region is reported", () => {
     const h = createHarness();
-    h.forwarder.start();
+    h.state.region = null;
+    h.poller.start();
 
-    h.state.cursor = { x: 120, y: 60 };
-    h.tick();
-    h.tick();
-    h.state.cursor = { x: 121, y: 60 };
+    h.state.cursor = { x: 510, y: 80 };
     h.tick();
 
-    expect(h.state.moves).toEqual([
-      { x: 20, y: 10 },
-      { x: 21, y: 10 },
-    ]);
+    expect(h.state.toggles).toEqual([]);
   });
 
-  test("stays quiet while the cursor has never entered the overlay", () => {
+  test("drops interactivity when the region is cleared under the cursor", () => {
     const h = createHarness();
-    h.forwarder.start();
+    h.poller.start();
 
-    h.state.cursor = { x: 0, y: 0 };
+    h.state.cursor = { x: 510, y: 80 };
     h.tick();
+    h.state.region = null;
     h.tick();
 
-    expect(h.state.moves).toHaveLength(0);
-    expect(h.state.leaves).toBe(0);
+    expect(h.state.toggles).toEqual([true, false]);
   });
 
-  test("pauses while interactive, then leaves once the pointer moves away", () => {
+  test("respects interactivity the renderer set on its own", () => {
     const h = createHarness();
-    h.forwarder.start();
+    h.poller.start();
 
-    h.state.cursor = { x: 120, y: 60 };
-    h.tick();
+    // Real mouse events reached the page and it asked for interactivity;
+    // a cursor inside the region must not produce a redundant toggle.
     h.state.interactive = true;
+    h.state.cursor = { x: 510, y: 80 };
     h.tick();
-    expect(h.state.moves).toHaveLength(1);
 
-    // The page drops interactivity after the pointer has already left.
-    h.state.interactive = false;
-    h.state.cursor = { x: 700, y: 60 };
-    h.tick();
-    expect(h.state.leaves).toBe(1);
+    expect(h.state.toggles).toEqual([]);
   });
 
   test("stops itself once the overlay window is gone", () => {
     const h = createHarness();
-    h.forwarder.start();
+    h.poller.start();
 
     h.state.bounds = null;
     h.tick();
@@ -139,13 +131,13 @@ describe("createCursorHoverForwarder", () => {
 
   test("start is idempotent and stop clears the timer", () => {
     const h = createHarness();
-    h.forwarder.start();
-    h.forwarder.start();
+    h.poller.start();
+    h.poller.start();
     expect(h.state.intervals).toBe(1);
 
-    h.forwarder.stop();
+    h.poller.stop();
     expect(h.state.cleared).toBe(1);
-    h.forwarder.start();
+    h.poller.start();
     expect(h.state.intervals).toBe(2);
   });
 });

--- a/packages/electron-desktop/src/dictation-overlay-window.test.ts
+++ b/packages/electron-desktop/src/dictation-overlay-window.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, mock, test } from "bun:test";
+
+mock.module("electron", () => ({
+  BrowserWindow: class {},
+  screen: { getCursorScreenPoint: () => ({ x: 0, y: 0 }) },
+}));
+
+const { CURSOR_HOVER_POLL_MS, createCursorHoverForwarder } =
+  await import("./dictation-overlay-window");
+
+type Rect = { x: number; y: number; width: number; height: number };
+
+const OVERLAY_BOUNDS: Rect = { x: 100, y: 50, width: 480, height: 160 };
+
+const createHarness = () => {
+  const state = {
+    cursor: { x: 0, y: 0 },
+    bounds: OVERLAY_BOUNDS as Rect | null,
+    interactive: false,
+    moves: [] as Array<{ x: number; y: number }>,
+    leaves: 0,
+    intervals: 0,
+    intervalMs: null as number | null,
+    cleared: 0,
+  };
+  let tick: (() => void) | null = null;
+
+  const forwarder = createCursorHoverForwarder({
+    getCursor: () => state.cursor,
+    getOverlayBounds: () => state.bounds,
+    isInteractive: () => state.interactive,
+    sendMouseMove: (point) => {
+      state.moves.push(point);
+    },
+    sendMouseLeave: () => {
+      state.leaves += 1;
+    },
+    setInterval: (callback, ms) => {
+      state.intervals += 1;
+      state.intervalMs = ms;
+      tick = callback;
+      return state.intervals;
+    },
+    clearInterval: () => {
+      state.cleared += 1;
+      tick = null;
+    },
+  });
+
+  return { forwarder, state, tick: () => tick?.() };
+};
+
+describe("createCursorHoverForwarder", () => {
+  test("forwards window-relative moves while the cursor is inside the overlay", () => {
+    const h = createHarness();
+    h.forwarder.start();
+    expect(h.state.intervalMs).toBe(CURSOR_HOVER_POLL_MS);
+
+    h.state.cursor = { x: 120, y: 60 };
+    h.tick();
+    h.state.cursor = { x: 579, y: 209 };
+    h.tick();
+
+    expect(h.state.moves).toEqual([
+      { x: 20, y: 10 },
+      { x: 479, y: 159 },
+    ]);
+    expect(h.state.leaves).toBe(0);
+  });
+
+  test("sends a single leave when the cursor exits the overlay", () => {
+    const h = createHarness();
+    h.forwarder.start();
+
+    h.state.cursor = { x: 120, y: 60 };
+    h.tick();
+    h.state.cursor = { x: 700, y: 60 };
+    h.tick();
+    h.tick();
+
+    expect(h.state.moves).toHaveLength(1);
+    expect(h.state.leaves).toBe(1);
+  });
+
+  test("does not re-deliver moves while the cursor is stationary", () => {
+    const h = createHarness();
+    h.forwarder.start();
+
+    h.state.cursor = { x: 120, y: 60 };
+    h.tick();
+    h.tick();
+    h.state.cursor = { x: 121, y: 60 };
+    h.tick();
+
+    expect(h.state.moves).toEqual([
+      { x: 20, y: 10 },
+      { x: 21, y: 10 },
+    ]);
+  });
+
+  test("stays quiet while the cursor has never entered the overlay", () => {
+    const h = createHarness();
+    h.forwarder.start();
+
+    h.state.cursor = { x: 0, y: 0 };
+    h.tick();
+    h.tick();
+
+    expect(h.state.moves).toHaveLength(0);
+    expect(h.state.leaves).toBe(0);
+  });
+
+  test("pauses while interactive, then leaves once the pointer moves away", () => {
+    const h = createHarness();
+    h.forwarder.start();
+
+    h.state.cursor = { x: 120, y: 60 };
+    h.tick();
+    h.state.interactive = true;
+    h.tick();
+    expect(h.state.moves).toHaveLength(1);
+
+    // The page drops interactivity after the pointer has already left.
+    h.state.interactive = false;
+    h.state.cursor = { x: 700, y: 60 };
+    h.tick();
+    expect(h.state.leaves).toBe(1);
+  });
+
+  test("stops itself once the overlay window is gone", () => {
+    const h = createHarness();
+    h.forwarder.start();
+
+    h.state.bounds = null;
+    h.tick();
+
+    expect(h.state.cleared).toBe(1);
+  });
+
+  test("start is idempotent and stop clears the timer", () => {
+    const h = createHarness();
+    h.forwarder.start();
+    h.forwarder.start();
+    expect(h.state.intervals).toBe(1);
+
+    h.forwarder.stop();
+    expect(h.state.cleared).toBe(1);
+    h.forwarder.start();
+    expect(h.state.intervals).toBe(2);
+  });
+});

--- a/packages/electron-desktop/src/dictation-overlay-window.test.ts
+++ b/packages/electron-desktop/src/dictation-overlay-window.test.ts
@@ -20,6 +20,7 @@ const createHarness = () => {
     cursor: { x: 0, y: 0 },
     bounds: OVERLAY_BOUNDS as Rect | null,
     region: STOP_REGION as Rect | null,
+    zoom: 1,
     interactive: false,
     toggles: [] as boolean[],
     intervals: 0,
@@ -32,6 +33,7 @@ const createHarness = () => {
     getCursor: () => state.cursor,
     getOverlayBounds: () => state.bounds,
     getHitRegion: () => state.region,
+    getZoomFactor: () => state.zoom,
     isInteractive: () => state.interactive,
     setInteractive: (interactive) => {
       state.interactive = interactive;
@@ -80,6 +82,22 @@ describe("createCursorHoverPoller", () => {
     h.tick();
     h.tick();
 
+    expect(h.state.toggles).toEqual([true]);
+  });
+
+  test("scales the CSS-pixel region by the page zoom factor", () => {
+    const h = createHarness();
+    h.state.zoom = 2;
+    h.poller.start();
+
+    // At zoom 2 the region's DIP footprint is 900..940 x 90..130; the
+    // unzoomed position must no longer hit.
+    h.state.cursor = { x: 510, y: 80 };
+    h.tick();
+    expect(h.state.toggles).toEqual([]);
+
+    h.state.cursor = { x: 920, y: 110 };
+    h.tick();
     expect(h.state.toggles).toEqual([true]);
   });
 

--- a/packages/electron-desktop/src/dictation-overlay-window.ts
+++ b/packages/electron-desktop/src/dictation-overlay-window.ts
@@ -4,10 +4,12 @@ import { z } from "zod";
 import {
   DICTATION_OVERLAY_GET_STATE,
   DICTATION_OVERLAY_REQUEST_STOP,
+  DICTATION_OVERLAY_SET_HIT_REGION,
   DICTATION_OVERLAY_SET_INTERACTIVE,
   DICTATION_OVERLAY_SET_STATE,
   DICTATION_OVERLAY_STATE_EVENT,
   DICTATION_OVERLAY_STOP_REQUESTED,
+  type DictationOverlayHitRegion,
   type DictationOverlayMessage,
   type DictationOverlayState,
 } from "@vellumai/ipc-contract";
@@ -67,19 +69,26 @@ export const DONE_HIDE_MS = 800;
 /** How long error states stay up — mirrors the recording store's 3 s. */
 export const ERROR_HIDE_MS = 3000;
 
-export type { DictationOverlayMessage, DictationOverlayState };
+export type {
+  DictationOverlayHitRegion,
+  DictationOverlayMessage,
+  DictationOverlayState,
+};
 
 export interface DictationOverlayWindowDependencies {
   closeOnHide?: boolean;
   /**
-   * Poll the cursor from main and synthesize hover events into the overlay
-   * renderer. Windows workaround: Electron's native mouse-move forwarding
+   * Poll the cursor from main and hit-test it against the renderer-reported
+   * Stop region. Windows workaround: Electron's native mouse-move forwarding
    * for click-through windows (`setIgnoreMouseEvents(true, { forward:
    * true })`) relies on a low-level mouse hook that stops delivering while
-   * a non-Electron window has focus (electron/electron#33281) — exactly the
-   * push-to-talk posture. Without the moves the page never sees the pointer
-   * reach the Stop button, never asks to become interactive, and the click
-   * falls through to the app behind.
+   * a non-Electron window has focus (electron/electron#33281), which is
+   * exactly the push-to-talk posture. Without the moves the page never sees
+   * the pointer reach the Stop button, never asks to become interactive,
+   * and the click falls through to the app behind. Synthesizing the moves
+   * via `webContents.sendInputEvent` is no fix either: it requires the
+   * window to be focused, and this window is deliberately unfocusable. So
+   * main does the hover hit-test itself and toggles interactivity directly.
    */
   pollCursorForHover?: boolean;
   handle: IpcHandle;
@@ -103,6 +112,13 @@ const dictationOverlayMessageSchema = z.discriminatedUnion("kind", [
   z.object({ kind: z.literal("error"), message: z.string() }),
   z.object({ kind: z.literal("dismiss") }),
 ]);
+
+const dictationOverlayHitRegionSchema = z.object({
+  x: z.number(),
+  y: z.number(),
+  width: z.number().min(0),
+  height: z.number().min(0),
+});
 
 export type DictationOverlayDeps = {
   showOverlay: () => void;
@@ -174,7 +190,7 @@ export const createDictationOverlayController = (
 
 export const CURSOR_HOVER_POLL_MS = 50;
 
-export type CursorHoverForwarderDeps = {
+export type CursorHoverPollerDeps = {
   getCursor: () => { x: number; y: number };
   /** Overlay window bounds in screen coordinates, or null once it is gone. */
   getOverlayBounds: () => {
@@ -183,36 +199,32 @@ export type CursorHoverForwarderDeps = {
     width: number;
     height: number;
   } | null;
+  /** The Stop control's rect in window-relative CSS pixels, if reported. */
+  getHitRegion: () => DictationOverlayHitRegion | null;
   isInteractive: () => boolean;
-  /** Synthesize a mouse move at window-relative coordinates. */
-  sendMouseMove: (point: { x: number; y: number }) => void;
-  sendMouseLeave: () => void;
+  setInteractive: (interactive: boolean) => void;
   setInterval: (callback: () => void, ms: number) => unknown;
   clearInterval: (handle: unknown) => void;
 };
 
 /**
  * Stand-in for Electron's broken mouse-move forwarding on Windows (see
- * `pollCursorForHover`): while the overlay is click-through, watch the
- * cursor and synthesize the moves the native hook should have delivered,
- * plus one leave event when the cursor exits. The page's own hit-test then
- * decides interactivity exactly as it does on macOS. Paused while the
- * overlay is interactive — real input reaches the page then.
+ * `pollCursorForHover`): while the overlay is up, watch the cursor and
+ * hit-test it against the Stop region the renderer reported, toggling the
+ * window's interactivity from main. The renderer cannot run this hit-test
+ * itself there: the forwarded mouse moves never arrive, and synthesized
+ * input events are ignored by unfocused windows.
  */
-export const createCursorHoverForwarder = (
-  deps: CursorHoverForwarderDeps,
+export const createCursorHoverPoller = (
+  deps: CursorHoverPollerDeps,
 ): { start: () => void; stop: () => void } => {
   let timer: unknown = null;
-  let wasInside = false;
-  let lastMove: { x: number; y: number } | null = null;
 
   const stop = (): void => {
     if (timer !== null) {
       deps.clearInterval(timer);
       timer = null;
     }
-    wasInside = false;
-    lastMove = null;
   };
 
   const tick = (): void => {
@@ -221,42 +233,30 @@ export const createCursorHoverForwarder = (
       stop();
       return;
     }
-    if (deps.isInteractive()) {
-      // The pointer is over the Stop control; when the page drops
-      // interactivity again the next tick resumes from "inside" so an
-      // immediate exit still produces a leave event.
-      wasInside = true;
-      lastMove = null;
-      return;
+    const region = deps.getHitRegion();
+    let inside = false;
+    if (region) {
+      const cursor = deps.getCursor();
+      const left = bounds.x + region.x;
+      const top = bounds.y + region.y;
+      inside =
+        cursor.x >= left &&
+        cursor.x < left + region.width &&
+        cursor.y >= top &&
+        cursor.y < top + region.height;
     }
-    const cursor = deps.getCursor();
-    const inside =
-      cursor.x >= bounds.x &&
-      cursor.x < bounds.x + bounds.width &&
-      cursor.y >= bounds.y &&
-      cursor.y < bounds.y + bounds.height;
-    if (inside) {
-      const move = { x: cursor.x - bounds.x, y: cursor.y - bounds.y };
-      // A stationary cursor needs no re-delivery.
-      if (move.x !== lastMove?.x || move.y !== lastMove?.y) {
-        deps.sendMouseMove(move);
-      }
-      lastMove = move;
-    } else {
-      if (wasInside) {
-        deps.sendMouseLeave();
-      }
-      lastMove = null;
+    // Only toggle on change; the renderer's own setInteractive messages
+    // (real mouse events, once the window is interactive) stay in charge
+    // between ticks.
+    if (inside !== deps.isInteractive()) {
+      deps.setInteractive(inside);
     }
-    wasInside = inside;
   };
 
   const start = (): void => {
     if (timer !== null) {
       return;
     }
-    wasInside = false;
-    lastMove = null;
     timer = deps.setInterval(tick, CURSOR_HOVER_POLL_MS);
   };
 
@@ -290,6 +290,7 @@ const broadcastStopRequested = (): void => {
 };
 
 let overlayInteractive = false;
+let overlayHitRegion: DictationOverlayHitRegion | null = null;
 
 const setOverlayInteractive = (interactive: boolean): void => {
   const win = getFloatingWindow(OVERLAY_KIND);
@@ -304,24 +305,12 @@ const setOverlayInteractive = (interactive: boolean): void => {
   }
 };
 
-const hoverForwarder = createCursorHoverForwarder({
+const hoverPoller = createCursorHoverPoller({
   getCursor: () => screen.getCursorScreenPoint(),
   getOverlayBounds: () => getFloatingWindow(OVERLAY_KIND)?.getBounds() ?? null,
+  getHitRegion: () => overlayHitRegion,
   isInteractive: () => overlayInteractive,
-  sendMouseMove: ({ x, y }) => {
-    getFloatingWindow(OVERLAY_KIND)?.webContents.sendInputEvent({
-      type: "mouseMove",
-      x,
-      y,
-    });
-  },
-  sendMouseLeave: () => {
-    getFloatingWindow(OVERLAY_KIND)?.webContents.sendInputEvent({
-      type: "mouseLeave",
-      x: 0,
-      y: 0,
-    });
-  },
+  setInteractive: setOverlayInteractive,
   setInterval: (callback, ms) => setInterval(callback, ms),
   clearInterval: (handle) =>
     clearInterval(handle as ReturnType<typeof setInterval>),
@@ -376,14 +365,16 @@ const showOverlay = (): void => {
   // A (re)shown window starts click-through regardless of what the last
   // session left behind.
   overlayInteractive = false;
+  overlayHitRegion = null;
   if (configuration.get().pollCursorForHover) {
-    hoverForwarder.start();
+    hoverPoller.start();
   }
 };
 
 const hideOverlay = (): void => {
   latestState = null;
-  hoverForwarder.stop();
+  overlayHitRegion = null;
+  hoverPoller.stop();
   const win = getFloatingWindow(OVERLAY_KIND);
   if (win) {
     setOverlayInteractive(false);
@@ -448,6 +439,14 @@ export const installDictationOverlay = (
     z.tuple([z.boolean()]),
     ([interactive]) => {
       setOverlayInteractive(interactive);
+    },
+  );
+
+  on(
+    DICTATION_OVERLAY_SET_HIT_REGION,
+    z.tuple([dictationOverlayHitRegionSchema.nullable()]),
+    ([region]) => {
+      overlayHitRegion = region;
     },
   );
 

--- a/packages/electron-desktop/src/dictation-overlay-window.ts
+++ b/packages/electron-desktop/src/dictation-overlay-window.ts
@@ -71,13 +71,25 @@ export type { DictationOverlayMessage, DictationOverlayState };
 
 export interface DictationOverlayWindowDependencies {
   closeOnHide?: boolean;
+  /**
+   * Poll the cursor from main and synthesize hover events into the overlay
+   * renderer. Windows workaround: Electron's native mouse-move forwarding
+   * for click-through windows (`setIgnoreMouseEvents(true, { forward:
+   * true })`) relies on a low-level mouse hook that stops delivering while
+   * a non-Electron window has focus (electron/electron#33281) — exactly the
+   * push-to-talk posture. Without the moves the page never sees the pointer
+   * reach the Stop button, never asks to become interactive, and the click
+   * falls through to the app behind.
+   */
+  pollCursorForHover?: boolean;
   handle: IpcHandle;
   on: IpcOn;
 }
 
-const configuration = createModuleConfiguration<DictationOverlayWindowDependencies>(
-  "Dictation overlay window module",
-);
+const configuration =
+  createModuleConfiguration<DictationOverlayWindowDependencies>(
+    "Dictation overlay window module",
+  );
 export const configureDictationOverlayWindow = configuration.configure;
 
 const dictationOverlayMessageSchema = z.discriminatedUnion("kind", [
@@ -160,6 +172,97 @@ export const createDictationOverlayController = (
   return { handleMessage };
 };
 
+export const CURSOR_HOVER_POLL_MS = 50;
+
+export type CursorHoverForwarderDeps = {
+  getCursor: () => { x: number; y: number };
+  /** Overlay window bounds in screen coordinates, or null once it is gone. */
+  getOverlayBounds: () => {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  } | null;
+  isInteractive: () => boolean;
+  /** Synthesize a mouse move at window-relative coordinates. */
+  sendMouseMove: (point: { x: number; y: number }) => void;
+  sendMouseLeave: () => void;
+  setInterval: (callback: () => void, ms: number) => unknown;
+  clearInterval: (handle: unknown) => void;
+};
+
+/**
+ * Stand-in for Electron's broken mouse-move forwarding on Windows (see
+ * `pollCursorForHover`): while the overlay is click-through, watch the
+ * cursor and synthesize the moves the native hook should have delivered,
+ * plus one leave event when the cursor exits. The page's own hit-test then
+ * decides interactivity exactly as it does on macOS. Paused while the
+ * overlay is interactive — real input reaches the page then.
+ */
+export const createCursorHoverForwarder = (
+  deps: CursorHoverForwarderDeps,
+): { start: () => void; stop: () => void } => {
+  let timer: unknown = null;
+  let wasInside = false;
+  let lastMove: { x: number; y: number } | null = null;
+
+  const stop = (): void => {
+    if (timer !== null) {
+      deps.clearInterval(timer);
+      timer = null;
+    }
+    wasInside = false;
+    lastMove = null;
+  };
+
+  const tick = (): void => {
+    const bounds = deps.getOverlayBounds();
+    if (!bounds) {
+      stop();
+      return;
+    }
+    if (deps.isInteractive()) {
+      // The pointer is over the Stop control; when the page drops
+      // interactivity again the next tick resumes from "inside" so an
+      // immediate exit still produces a leave event.
+      wasInside = true;
+      lastMove = null;
+      return;
+    }
+    const cursor = deps.getCursor();
+    const inside =
+      cursor.x >= bounds.x &&
+      cursor.x < bounds.x + bounds.width &&
+      cursor.y >= bounds.y &&
+      cursor.y < bounds.y + bounds.height;
+    if (inside) {
+      const move = { x: cursor.x - bounds.x, y: cursor.y - bounds.y };
+      // A stationary cursor needs no re-delivery.
+      if (move.x !== lastMove?.x || move.y !== lastMove?.y) {
+        deps.sendMouseMove(move);
+      }
+      lastMove = move;
+    } else {
+      if (wasInside) {
+        deps.sendMouseLeave();
+      }
+      lastMove = null;
+    }
+    wasInside = inside;
+  };
+
+  const start = (): void => {
+    if (timer !== null) {
+      return;
+    }
+    wasInside = false;
+    lastMove = null;
+    timer = deps.setInterval(tick, CURSOR_HOVER_POLL_MS);
+  };
+
+  return { start, stop };
+};
+
 // ---------------------------------------------------------------------------
 // Window plumbing
 // ---------------------------------------------------------------------------
@@ -186,17 +289,43 @@ const broadcastStopRequested = (): void => {
   }
 };
 
+let overlayInteractive = false;
+
 const setOverlayInteractive = (interactive: boolean): void => {
   const win = getFloatingWindow(OVERLAY_KIND);
   if (!win || win.isDestroyed()) {
     return;
   }
+  overlayInteractive = interactive;
   if (interactive) {
     win.setIgnoreMouseEvents(false);
   } else {
     win.setIgnoreMouseEvents(true, { forward: true });
   }
 };
+
+const hoverForwarder = createCursorHoverForwarder({
+  getCursor: () => screen.getCursorScreenPoint(),
+  getOverlayBounds: () => getFloatingWindow(OVERLAY_KIND)?.getBounds() ?? null,
+  isInteractive: () => overlayInteractive,
+  sendMouseMove: ({ x, y }) => {
+    getFloatingWindow(OVERLAY_KIND)?.webContents.sendInputEvent({
+      type: "mouseMove",
+      x,
+      y,
+    });
+  },
+  sendMouseLeave: () => {
+    getFloatingWindow(OVERLAY_KIND)?.webContents.sendInputEvent({
+      type: "mouseLeave",
+      x: 0,
+      y: 0,
+    });
+  },
+  setInterval: (callback, ms) => setInterval(callback, ms),
+  clearInterval: (handle) =>
+    clearInterval(handle as ReturnType<typeof setInterval>),
+});
 
 export const positionDictationOverlayInWorkArea = (workArea: {
   x: number;
@@ -244,10 +373,17 @@ const showOverlay = (): void => {
   // `createFloatingWindow` uses `showInactive()` when `focusOnShow` is false;
   // never activate the app or steal focus from the dictation target.
   ensureOverlayWindow();
+  // A (re)shown window starts click-through regardless of what the last
+  // session left behind.
+  overlayInteractive = false;
+  if (configuration.get().pollCursorForHover) {
+    hoverForwarder.start();
+  }
 };
 
 const hideOverlay = (): void => {
   latestState = null;
+  hoverForwarder.stop();
   const win = getFloatingWindow(OVERLAY_KIND);
   if (win) {
     setOverlayInteractive(false);

--- a/packages/electron-desktop/src/dictation-overlay-window.ts
+++ b/packages/electron-desktop/src/dictation-overlay-window.ts
@@ -79,18 +79,20 @@ export interface DictationOverlayWindowDependencies {
   closeOnHide?: boolean;
   /**
    * Poll the cursor from main and hit-test it against the renderer-reported
-   * Stop region. Windows workaround: Electron's native mouse-move forwarding
-   * for click-through windows (`setIgnoreMouseEvents(true, { forward:
-   * true })`) relies on a low-level mouse hook that stops delivering while
-   * a non-Electron window has focus (electron/electron#33281), which is
-   * exactly the push-to-talk posture. Without the moves the page never sees
-   * the pointer reach the Stop button, never asks to become interactive,
-   * and the click falls through to the app behind. Synthesizing the moves
-   * via `webContents.sendInputEvent` is no fix either: it requires the
-   * window to be focused, and this window is deliberately unfocusable. So
-   * main does the hover hit-test itself and toggles interactivity directly.
+   * Stop region, toggling interactivity directly. Windows workaround:
+   * Electron forwards mouse moves to a click-through window
+   * (`setIgnoreMouseEvents(true, { forward: true })`) through a low-level
+   * hook that posts to a child HWND cached once at window creation and
+   * never refreshed (electron/electron#15376, #49982; fix pending in
+   * #52633), and the hook is blind while an elevated window is in front
+   * (#33281). Either way the page never sees the pointer reach the Stop
+   * button, never asks to become interactive, and the click falls through
+   * to the app behind. `webContents.sendInputEvent` is no fix: it requires
+   * a focused window, and this one is deliberately unfocusable.
    */
   pollCursorForHover?: boolean;
+  /** Diagnostic sink for overlay lifecycle and hit-test decisions. */
+  log?: (message: string) => void;
   handle: IpcHandle;
   on: IpcOn;
 }
@@ -300,10 +302,17 @@ const broadcastStopRequested = (): void => {
 let overlayInteractive = false;
 let overlayHitRegion: DictationOverlayHitRegion | null = null;
 
+const debug = (message: string): void => {
+  configuration.get().log?.(`[dictation-overlay] ${message}`);
+};
+
 const setOverlayInteractive = (interactive: boolean): void => {
   const win = getFloatingWindow(OVERLAY_KIND);
   if (!win || win.isDestroyed()) {
     return;
+  }
+  if (interactive !== overlayInteractive) {
+    debug(`interactive=${interactive}`);
   }
   overlayInteractive = interactive;
   if (interactive) {
@@ -320,7 +329,13 @@ const hoverPoller = createCursorHoverPoller({
   getZoomFactor: () =>
     getFloatingWindow(OVERLAY_KIND)?.webContents.getZoomFactor() ?? 1,
   isInteractive: () => overlayInteractive,
-  setInteractive: setOverlayInteractive,
+  setInteractive: (interactive) => {
+    const win = getFloatingWindow(OVERLAY_KIND);
+    debug(
+      `poll -> ${interactive}: cursor=${JSON.stringify(screen.getCursorScreenPoint())} bounds=${JSON.stringify(win?.getBounds() ?? null)} region=${JSON.stringify(overlayHitRegion)} zoom=${win?.webContents.getZoomFactor() ?? 1}`,
+    );
+    setOverlayInteractive(interactive);
+  },
   setInterval: (callback, ms) => setInterval(callback, ms),
   clearInterval: (handle) =>
     clearInterval(handle as ReturnType<typeof setInterval>),
@@ -376,12 +391,15 @@ const showOverlay = (): void => {
   // session left behind.
   overlayInteractive = false;
   overlayHitRegion = null;
-  if (configuration.get().pollCursorForHover) {
+  const poll = Boolean(configuration.get().pollCursorForHover);
+  debug(`show (pollCursorForHover=${poll})`);
+  if (poll) {
     hoverPoller.start();
   }
 };
 
 const hideOverlay = (): void => {
+  debug("hide");
   latestState = null;
   overlayHitRegion = null;
   hoverPoller.stop();
@@ -441,6 +459,7 @@ export const installDictationOverlay = (
   );
 
   on(DICTATION_OVERLAY_REQUEST_STOP, z.tuple([]), () => {
+    debug("stop requested by the overlay page; broadcasting");
     broadcastStopRequested();
   });
 
@@ -456,6 +475,7 @@ export const installDictationOverlay = (
     DICTATION_OVERLAY_SET_HIT_REGION,
     z.tuple([dictationOverlayHitRegionSchema.nullable()]),
     ([region]) => {
+      debug(`hit region ${region ? JSON.stringify(region) : "cleared"}`);
       overlayHitRegion = region;
     },
   );

--- a/packages/electron-desktop/src/dictation-overlay-window.ts
+++ b/packages/electron-desktop/src/dictation-overlay-window.ts
@@ -201,6 +201,13 @@ export type CursorHoverPollerDeps = {
   } | null;
   /** The Stop control's rect in window-relative CSS pixels, if reported. */
   getHitRegion: () => DictationOverlayHitRegion | null;
+  /**
+   * The overlay page's zoom factor. Window bounds and the cursor are in
+   * DIPs while the reported region is in CSS pixels; the two only match at
+   * zoom 1, and Chromium persists per-origin zoom, so a zoomed main window
+   * carries over to the overlay route.
+   */
+  getZoomFactor: () => number;
   isInteractive: () => boolean;
   setInteractive: (interactive: boolean) => void;
   setInterval: (callback: () => void, ms: number) => unknown;
@@ -237,13 +244,14 @@ export const createCursorHoverPoller = (
     let inside = false;
     if (region) {
       const cursor = deps.getCursor();
-      const left = bounds.x + region.x;
-      const top = bounds.y + region.y;
+      const zoom = deps.getZoomFactor();
+      const left = bounds.x + region.x * zoom;
+      const top = bounds.y + region.y * zoom;
       inside =
         cursor.x >= left &&
-        cursor.x < left + region.width &&
+        cursor.x < left + region.width * zoom &&
         cursor.y >= top &&
-        cursor.y < top + region.height;
+        cursor.y < top + region.height * zoom;
     }
     // Only toggle on change; the renderer's own setInteractive messages
     // (real mouse events, once the window is interactive) stay in charge
@@ -309,6 +317,8 @@ const hoverPoller = createCursorHoverPoller({
   getCursor: () => screen.getCursorScreenPoint(),
   getOverlayBounds: () => getFloatingWindow(OVERLAY_KIND)?.getBounds() ?? null,
   getHitRegion: () => overlayHitRegion,
+  getZoomFactor: () =>
+    getFloatingWindow(OVERLAY_KIND)?.webContents.getZoomFactor() ?? 1,
   isInteractive: () => overlayInteractive,
   setInteractive: setOverlayInteractive,
   setInterval: (callback, ms) => setInterval(callback, ms),

--- a/packages/ipc-contract/src/bridge.ts
+++ b/packages/ipc-contract/src/bridge.ts
@@ -23,6 +23,7 @@ import type {
   CompanionSurfaceState,
   ConnectivityState,
   DeepLink,
+  DictationOverlayHitRegion,
   DictationOverlayMessage,
   DictationOverlayState,
   DictationPartialEvent,
@@ -170,7 +171,9 @@ export interface VellumBridge {
        * PCM — the offline transcript authority. Result arrives via
        * `onTranscribed`.
        */
-      transcribe?(audio: ArrayBuffer): Promise<{ ok: boolean; reason?: string }>;
+      transcribe?(
+        audio: ArrayBuffer,
+      ): Promise<{ ok: boolean; reason?: string }>;
       onTranscribed?(
         callback: (event: DictationPartialEvent) => void,
       ): () => void;
@@ -352,6 +355,13 @@ export interface VellumBridge {
     requestStop(): void;
     onStopRequested(callback: () => void): () => void;
     setInteractive(interactive: boolean): void;
+    /**
+     * Report where the Stop control sits (window-relative CSS pixels), or
+     * null when there is none. Lets main hit-test the cursor itself on
+     * platforms where forwarded mouse moves never reach the click-through
+     * overlay.
+     */
+    setHitRegion(region: DictationOverlayHitRegion | null): void;
   };
   /**
    * The running live-voice session, as the desktop shows it. Two renderers use

--- a/packages/ipc-contract/src/channels.ts
+++ b/packages/ipc-contract/src/channels.ts
@@ -148,6 +148,8 @@ export const DICTATION_OVERLAY_STOP_REQUESTED =
   "vellum:dictationOverlay:stopRequested";
 export const DICTATION_OVERLAY_SET_INTERACTIVE =
   "vellum:dictationOverlay:setInteractive";
+export const DICTATION_OVERLAY_SET_HIT_REGION =
+  "vellum:dictationOverlay:setHitRegion";
 
 // Voice activity: the running live-voice session, as the companion surface
 // renders it. The session's window publishes; the surface's window presses.

--- a/packages/ipc-contract/src/types.ts
+++ b/packages/ipc-contract/src/types.ts
@@ -279,6 +279,19 @@ export type DictationOverlayState =
 export type DictationOverlayMessage =
   DictationOverlayState | { kind: "dismiss" };
 
+/**
+ * Where the overlay's Stop control sits, in window-relative CSS pixels.
+ * The overlay renderer reports it so main can hit-test the cursor against
+ * it on platforms where forwarded mouse moves never reach a click-through
+ * window.
+ */
+export type DictationOverlayHitRegion = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
 // ---------------------------------------------------------------------------
 // Voice activity (the floating live-voice session surface)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

On the Windows client the dictation overlay's Stop button could not be clicked: the click fell through to whatever was behind the pill.

## Root causes (two, both Windows only)

1. **Auxiliary windows loaded from the wrong origin in local-renderer dev.** With `VELLUM_LOCAL_RENDERER=true` (`bun run dev:electron-local-web`) the main window is served over `app://vellum.ai` while `VELLUM_DEV_URL` names the remote platform. The overlay, quick input, command palette, popouts, about window, bundle flow, and host UI snapshot resolved their renderer base from `app.isPackaged` alone, so they loaded the remote URL: the deployed web build, under a foreign origin. The IPC sender guard rejected everything those windows sent (`getState`, `setInteractive`, `requestStop`, ...), visible in the dev log as `Rejected vellum:dictationOverlay:getState: sender is not the app renderer`. Fixed by routing all of them through `getRendererBase()`, which follows `usesAppProtocolRenderer` like the main window and the origin guard do. Regression test added.
2. **Mouse-move forwarding for the click-through overlay is unreliable on Windows.** Electron forwards moves to a click-through window (`setIgnoreMouseEvents(true, { forward: true })`) through a low-level hook that posts to a child HWND cached once at window creation and never refreshed (electron/electron#15376, #49982; upstream fix pending in #52633), and the hook is blind while an elevated window is in front (#33281). The page never sees the pointer reach Stop, never asks to become interactive, and the click falls through. `webContents.sendInputEvent` cannot substitute: it requires a focused window and the overlay is deliberately unfocusable. Fixed by having the overlay page report the Stop button's rect (`vellum:dictationOverlay:setHitRegion`, re-measured on layout/zoom changes) and letting main poll the cursor every 50 ms, hit-test it against `bounds + rect * zoomFactor`, and toggle interactivity itself. Enabled only by the Windows client (`pollCursorForHover`).

## Diagnostics

Main logs `[dictation-overlay]` lines for show/hide, each reported hit region, each interactivity toggle (cursor, bounds, region, zoom), and stop requests, so a failing click can be traced from the dev terminal or `vellum.log`.

## macOS

No behavior change. The Mac preload gains the additive `setHitRegion` bridge; the Mac main process stores the region and never reads it (no poll); the page's ResizeObserver is inert there.

## Testing

- Unit tests for the cursor poller, the Windows wiring (poll flips `setIgnoreMouseEvents(false)` over the reported region; auxiliary windows load `app://` in local-renderer dev), and the overlay page (reports, re-measures, clears the region).
- Needs a manual smoke test on Windows: dictate into another app, hover and click Stop; repeat after View > Zoom and on a secondary display.
