### PR TITLE
feat(inbound): register webhook routes locally and mint Velay URLs on platform pods

### DIFF
--- a/assistant/src/__tests__/platform-callback-registration.test.ts
+++ b/assistant/src/__tests__/platform-callback-registration.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
+import type { RegisterWebhookRouteIpcParams } from "@vellumai/gateway-client";
+
+import type { IpcRegisterWebhookRouteResult } from "../ipc/gateway-client.js";
 import { credentialKey } from "../security/credential-key.js";
 
 let mockIsPlatform = true;
@@ -7,6 +10,22 @@ let mockVelayWebhooksEnabled = false;
 let mockPlatformBaseUrl = "";
 let mockPlatformAssistantId = "";
 let mockSecureKeys: Record<string, string> = {};
+
+const REGISTERED_ROUTE = {
+  path: "/webhooks/twilio/voice",
+  type: "twilio_voice",
+  source: null,
+  match: "exact" as const,
+  createdAt: 1,
+  lastRegisteredAt: 1,
+};
+
+let mockRegisterWebhookRouteResult: IpcRegisterWebhookRouteResult = {
+  ok: true,
+  disabled: false,
+  route: REGISTERED_ROUTE,
+};
+let ipcRegisterCalls: RegisterWebhookRouteIpcParams[] = [];
 
 // Bun shares mocked modules across test files in a combined run, so each mock
 // spreads the real module and overrides only what this file drives. Replacing
@@ -29,6 +48,15 @@ mock.module("../config/env.js", () => ({
   ...actualEnv,
   getPlatformBaseUrl: () => mockPlatformBaseUrl,
   getPlatformAssistantId: () => mockPlatformAssistantId,
+}));
+
+const actualGatewayClient = await import("../ipc/gateway-client.js");
+mock.module("../ipc/gateway-client.js", () => ({
+  ...actualGatewayClient,
+  ipcRegisterWebhookRoute: async (input: RegisterWebhookRouteIpcParams) => {
+    ipcRegisterCalls.push(input);
+    return mockRegisterWebhookRouteResult;
+  },
 }));
 
 const actualSecureKeys = await import("../security/secure-keys.js");
@@ -204,6 +232,12 @@ describe("resolveCallbackUrl resolution order", () => {
     mockSecureKeys = {};
     delete process.env.ASSISTANT_API_KEY;
     registerCalls = 0;
+    ipcRegisterCalls = [];
+    mockRegisterWebhookRouteResult = {
+      ok: true,
+      disabled: false,
+      route: REGISTERED_ROUTE,
+    };
     globalThis.fetch = mock(async () => {
       registerCalls++;
       return new Response(
@@ -232,9 +266,10 @@ describe("resolveCallbackUrl resolution order", () => {
       resolveCallbackUrl(noIngress, "webhooks/twilio/voice", "twilio_voice"),
     ).resolves.toBe(PLATFORM_URL);
     expect(registerCalls).toBe(1);
+    expect(ipcRegisterCalls).toEqual([]);
   });
 
-  test("velay-webhooks on: a pod with a published ingress URL uses it directly", async () => {
+  test("velay-webhooks on: a pod claims the subpath and uses the published URL", async () => {
     mockIsPlatform = true;
     mockVelayWebhooksEnabled = true;
     seedPlatformCredentials();
@@ -244,11 +279,54 @@ describe("resolveCallbackUrl resolution order", () => {
         () => "https://velay.example.com/assistant-1/webhooks/twilio/voice",
         "webhooks/twilio/voice",
         "twilio_voice",
+        { callSessionId: "conv-xyz" },
+        "+15555550142",
       ),
     ).resolves.toBe(
       "https://velay.example.com/assistant-1/webhooks/twilio/voice",
     );
     expect(registerCalls).toBe(0);
+    expect(ipcRegisterCalls).toEqual([
+      {
+        path: "/webhooks/twilio/voice",
+        type: "twilio_voice",
+        source: "+15555550142",
+      },
+    ]);
+  });
+
+  test("velay-webhooks on: a refused claim falls back to the platform", async () => {
+    mockIsPlatform = true;
+    mockVelayWebhooksEnabled = true;
+    mockRegisterWebhookRouteResult = { ok: true, disabled: true };
+    seedPlatformCredentials();
+
+    await expect(
+      resolveCallbackUrl(
+        () => "https://velay.example.com/assistant-1/webhooks/twilio/voice",
+        "webhooks/twilio/voice",
+        "twilio_voice",
+      ),
+    ).resolves.toBe(PLATFORM_URL);
+    expect(registerCalls).toBe(1);
+    expect(ipcRegisterCalls).toHaveLength(1);
+  });
+
+  test("velay-webhooks on: an unreachable gateway falls back to the platform", async () => {
+    mockIsPlatform = true;
+    mockVelayWebhooksEnabled = true;
+    mockRegisterWebhookRouteResult = { ok: false, reason: "no_response" };
+    seedPlatformCredentials();
+
+    await expect(
+      resolveCallbackUrl(
+        () => "https://velay.example.com/assistant-1/webhooks/twilio/voice",
+        "webhooks/twilio/voice",
+        "twilio_voice",
+      ),
+    ).resolves.toBe(PLATFORM_URL);
+    expect(registerCalls).toBe(1);
+    expect(ipcRegisterCalls).toHaveLength(1);
   });
 
   test("velay-webhooks on: a pod with no published URL still registers with the platform", async () => {
@@ -260,6 +338,7 @@ describe("resolveCallbackUrl resolution order", () => {
       resolveCallbackUrl(noIngress, "webhooks/twilio/voice", "twilio_voice"),
     ).resolves.toBe(PLATFORM_URL);
     expect(registerCalls).toBe(1);
+    expect(ipcRegisterCalls).toEqual([]);
   });
 
   test("velay-webhooks on: a pod with ingress disabled falls back instead of throwing", async () => {
@@ -275,6 +354,7 @@ describe("resolveCallbackUrl resolution order", () => {
       ),
     ).resolves.toBe(PLATFORM_URL);
     expect(registerCalls).toBe(1);
+    expect(ipcRegisterCalls).toEqual([]);
   });
 
   test("velay-webhooks on: self-hosted opt-out still surfaces", async () => {
@@ -289,6 +369,21 @@ describe("resolveCallbackUrl resolution order", () => {
       ),
     ).rejects.toThrow("Public ingress is disabled");
     expect(registerCalls).toBe(0);
+    expect(ipcRegisterCalls).toEqual([]);
+  });
+
+  test("velay-webhooks on: a self-hosted ingress URL is not claimed on the gateway", async () => {
+    mockVelayWebhooksEnabled = true;
+    seedPlatformCredentials();
+
+    await expect(
+      resolveCallbackUrl(
+        () => "https://tunnel.example.com/webhooks/twilio/voice",
+        "webhooks/twilio/voice",
+        "twilio_voice",
+      ),
+    ).resolves.toBe("https://tunnel.example.com/webhooks/twilio/voice");
+    expect(ipcRegisterCalls).toEqual([]);
   });
 
   test("a configured ingress wins over platform connectivity", async () => {
@@ -302,6 +397,7 @@ describe("resolveCallbackUrl resolution order", () => {
       ),
     ).resolves.toBe("https://tunnel.example.com/webhooks/twilio/voice");
     expect(registerCalls).toBe(0);
+    expect(ipcRegisterCalls).toEqual([]);
   });
 
   test("a platform-connected assistant with no ingress registers with the platform", async () => {

--- a/assistant/src/__tests__/plugin-api-webhook-url.test.ts
+++ b/assistant/src/__tests__/plugin-api-webhook-url.test.ts
@@ -10,6 +10,7 @@
 
 import { describe, expect, spyOn, test } from "bun:test";
 
+import * as loader from "../config/loader.js";
 import * as registration from "../inbound/platform-callback-registration.js";
 import { resolveWebhookUrl } from "../plugin-api/webhook-url.js";
 import { runInPluginContext } from "../plugins/plugin-execution-context.js";
@@ -141,6 +142,29 @@ describe("resolveWebhookUrl", () => {
       "webhooks/plugins/imessage/events-comms",
     );
     spy.mockRestore();
+  });
+
+  test("hands out an ingress URL under exactly the path it claimed", async () => {
+    // The Velay tunnel forwards the request path verbatim and the gateway
+    // admits it only when it matches a claimed path byte for byte. A trailing
+    // slash on this URL would be rejected before the gateway ever saw it.
+    const configSpy = spyOn(loader, "getConfig").mockReturnValue({
+      ingress: { publicBaseUrl: "https://velay.vellum.ai/assistant-abc" },
+    } as ReturnType<typeof loader.getConfig>);
+    const spy = spyOn(registration, "resolveCallbackUrl").mockImplementation(
+      async (directUrl) => directUrl(),
+    );
+
+    const url = await resolveWebhookUrl({
+      plugin: "imessage",
+      path: "events-photon",
+    });
+
+    const claimedPath = `/${spy.mock.calls[0]![1]}`;
+    expect(claimedPath).toBe("/webhooks/plugins/imessage/events-photon");
+    expect(new URL(url).pathname).toBe(`/assistant-abc${claimedPath}`);
+    spy.mockRestore();
+    configSpy.mockRestore();
   });
 
   test("leaves a URL carrying a query string alone", async () => {

--- a/assistant/src/cli/commands/__tests__/conversations-slack.test.ts
+++ b/assistant/src/cli/commands/__tests__/conversations-slack.test.ts
@@ -95,6 +95,18 @@ mock.module("../../../ipc/gateway-client.js", () => ({
   ipcGetFeatureFlags: async () => ({}),
   ipcGetVelayStatus: async () => null,
   ipcClassifyRisk: async () => ({ risk: "low" }),
+  ipcRegisterWebhookRoute: async () => ({
+    ok: false as const,
+    reason: "no_response" as const,
+  }),
+  ipcUnregisterWebhookRoute: async () => ({
+    ok: false as const,
+    reason: "no_response" as const,
+  }),
+  ipcListWebhookRoutes: async () => ({
+    ok: false as const,
+    reason: "no_response" as const,
+  }),
 }));
 
 mock.module("../../../messaging/providers/slack/send.js", () => ({

--- a/assistant/src/inbound/platform-callback-registration.ts
+++ b/assistant/src/inbound/platform-callback-registration.ts
@@ -18,6 +18,7 @@
 
 import { getPlatformAssistantId, getPlatformBaseUrl } from "../config/env.js";
 import { getIsPlatform } from "../config/env-registry.js";
+import { ipcRegisterWebhookRoute } from "../ipc/gateway-client.js";
 import { credentialKey } from "../security/credential-key.js";
 import { getSecureKeyAsync } from "../security/secure-keys.js";
 import { getLogger } from "../util/logger.js";
@@ -153,6 +154,47 @@ export async function registerCallbackRoute(
 }
 
 /**
+ * Claim a webhook subpath on the gateway so the Velay tunnel forwards it.
+ *
+ * The registry matches paths exactly, so query parameters a caller appends to
+ * the resolved URL play no part. Returns false when the gateway declines the
+ * claim or cannot be reached, leaving platform callback registration as the
+ * way to keep the webhook reachable.
+ *
+ * @param callbackPath - The path to claim, e.g. "webhooks/twilio/voice".
+ */
+export async function registerLocalWebhookRoute(
+  callbackPath: string,
+  type: string,
+  sourceIdentifier?: string,
+): Promise<boolean> {
+  const path = callbackPath.startsWith("/") ? callbackPath : `/${callbackPath}`;
+  const result = await ipcRegisterWebhookRoute({
+    path,
+    type,
+    source: sourceIdentifier,
+  });
+
+  if (!result.ok) {
+    log.warn(
+      { path, type, reason: result.reason },
+      "Gateway webhook route registration failed, falling back to the platform",
+    );
+    return false;
+  }
+  if (result.disabled) {
+    log.info(
+      { path, type },
+      "Gateway is not serving its own webhooks, falling back to the platform",
+    );
+    return false;
+  }
+
+  log.debug({ path, type }, "Gateway webhook route registered");
+  return true;
+}
+
+/**
  * Resolve a callback URL, registering with the platform when appropriate.
  *
  * Resolution order, matching `handleWebhooksRegister` in
@@ -165,7 +207,9 @@ export async function registerCallbackRoute(
  *      tunnel URL into `ingress.publicBaseUrl` — and fall back to platform
  *      registration on any failure, including an explicit
  *      `ingress.enabled: false`: a pod owner toggling that flag must not
- *      lose webhooks entirely.
+ *      lose webhooks entirely. The subpath is claimed on the gateway before
+ *      the tunnel URL is handed out, and a refused claim falls back the same
+ *      way.
  *   2. **A configured public ingress wins** for everyone else, so the direct
  *      supplier is tried first and its value returned when it resolves.
  *   3. **Platform-connected assistants with no ingress** register with the
@@ -204,9 +248,10 @@ export async function resolveCallbackUrl(
 ): Promise<string> {
   const isPlatform = getIsPlatform();
   if (!isPlatform || isVelayWebhooksEnabled()) {
+    let ingressUrl: string | undefined;
     let ingressError: unknown;
     try {
-      return directUrl();
+      ingressUrl = directUrl();
     } catch (err) {
       if (err instanceof PublicIngressDisabledError && !isPlatform) {
         throw err;
@@ -214,10 +259,19 @@ export async function resolveCallbackUrl(
       ingressError = err;
     }
 
-    // No ingress configured. Fall back to the platform gateway when this
-    // assistant is connected to the platform. Platform pods always are, so
-    // they skip the context probe and register directly.
-    if (!isPlatform) {
+    if (ingressUrl !== undefined) {
+      // A pod's tunnel only forwards subpaths the gateway has claimed, so the
+      // URL is handed out only once the claim succeeds.
+      if (
+        !isPlatform ||
+        (await registerLocalWebhookRoute(callbackPath, type, sourceIdentifier))
+      ) {
+        return ingressUrl;
+      }
+    } else if (!isPlatform) {
+      // No ingress configured. Fall back to the platform gateway when this
+      // assistant is connected to the platform. Platform pods always are, so
+      // they skip the context probe and register directly.
       const context = await resolvePlatformCallbackRegistrationContext();
       if (!context.enabled) {
         throw ingressError;

--- a/assistant/src/plugin-api/webhook-url.ts
+++ b/assistant/src/plugin-api/webhook-url.ts
@@ -90,12 +90,11 @@ function registrationType(plugin: string, route: string): string {
 }
 
 /**
- * Keep a trailing slash on a resolved callback URL.
+ * Keep a trailing slash on a managed callback URL.
  *
  * Django in front of managed callbacks canonicalizes onto `/`. A vendor given
  * the slashless spelling is 301'd, and clients that follow a 301 on POST
- * typically retry as GET and drop the body. The gateway serves both spellings
- * of a plugin webhook, so the slashed URL is the one to hand out.
+ * typically retry as GET and drop the body.
  *
  * Query-bearing URLs are left alone: this resolver passes no query
  * parameters, and appending there would cut into the query rather than the
@@ -142,12 +141,22 @@ export async function resolveWebhookUrl(
 
   const callbackPath = `${PLUGIN_WEBHOOK_PREFIX}/${plugin}/${path}`;
 
+  let ingressUrl: string | undefined;
   const resolved = await resolveCallbackUrl(
-    () => `${getPublicBaseUrl(getConfig())}/${callbackPath}`,
+    () => {
+      ingressUrl = `${getPublicBaseUrl(getConfig())}/${callbackPath}`;
+      return ingressUrl;
+    },
     callbackPath,
     registrationType(plugin, path),
     undefined,
     sourceIdentifier,
   );
-  return withTrailingSlash(resolved);
+
+  // An ingress URL reaches the gateway through the tunnel, which forwards the
+  // request path verbatim and admits it only when it matches a claimed path
+  // byte for byte. The claim above is made under the slashless spelling, so
+  // that is the spelling to hand out. Only a managed callback URL goes through
+  // Django, so only that one is given the trailing slash.
+  return resolved === ingressUrl ? resolved : withTrailingSlash(resolved);
 }

--- a/assistant/src/runtime/routes/__tests__/webhook-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/webhook-routes.test.ts
@@ -13,6 +13,8 @@ let config: Record<string, unknown> = {};
 let platformContextEnabled = false;
 let registerCallbackRouteError: Error | undefined;
 
+let localWebhookRouteRegistered = true;
+
 const registerCallbackRouteMock = mock(
   async (callbackPath: string, _type: string, _source?: string) => {
     if (registerCallbackRouteError) {
@@ -20,6 +22,11 @@ const registerCallbackRouteMock = mock(
     }
     return `https://gateway.vellum.ai/assistant-123/${callbackPath}`;
   },
+);
+
+const registerLocalWebhookRouteMock = mock(
+  async (_callbackPath: string, _type: string, _source?: string) =>
+    localWebhookRouteRegistered,
 );
 
 // Spread the real modules: these are broad barrels and replacing them wholesale
@@ -44,6 +51,7 @@ mock.module("../../../inbound/velay-webhooks-gate.js", () => ({
 
 mock.module("../../../inbound/platform-callback-registration.js", () => ({
   registerCallbackRoute: registerCallbackRouteMock,
+  registerLocalWebhookRoute: registerLocalWebhookRouteMock,
   resolvePlatformCallbackRegistrationContext: async () => ({
     isPlatform,
     platformBaseUrl: "https://api.vellum.ai",
@@ -70,7 +78,9 @@ describe("webhooks_register callback URL resolution", () => {
     config = {};
     platformContextEnabled = false;
     registerCallbackRouteError = undefined;
+    localWebhookRouteRegistered = true;
     registerCallbackRouteMock.mockClear();
+    registerLocalWebhookRouteMock.mockClear();
   });
 
   test("platform pods register with the platform gateway", async () => {
@@ -83,6 +93,7 @@ describe("webhooks_register callback URL resolution", () => {
       path: "webhooks/telegram",
       mode: "platform",
     });
+    expect(registerLocalWebhookRouteMock).not.toHaveBeenCalled();
   });
 
   // The bug: a local assistant that IS connected to the platform used to fall
@@ -103,7 +114,7 @@ describe("webhooks_register callback URL resolution", () => {
     );
   });
 
-  test("velay-webhooks on: a pod with a published ingress URL uses it directly", async () => {
+  test("velay-webhooks on: a pod claims the subpath and uses the published URL", async () => {
     isPlatform = true;
     velayWebhooksEnabled = true;
     platformContextEnabled = true;
@@ -111,13 +122,34 @@ describe("webhooks_register callback URL resolution", () => {
       ingress: { publicBaseUrl: "https://velay.vellum.ai/assistant-123" },
     };
 
-    expect(await register({ type: "telegram" })).toEqual({
+    expect(await register({ type: "telegram", source: "@my_bot" })).toEqual({
       callbackUrl: "https://velay.vellum.ai/assistant-123/webhooks/telegram",
       type: "telegram",
       path: "webhooks/telegram",
       mode: "self-hosted",
     });
+    expect(registerLocalWebhookRouteMock).toHaveBeenCalledWith(
+      "webhooks/telegram",
+      "telegram",
+      "@my_bot",
+    );
     expect(registerCallbackRouteMock).not.toHaveBeenCalled();
+  });
+
+  test("velay-webhooks on: a refused claim falls back to the platform", async () => {
+    isPlatform = true;
+    velayWebhooksEnabled = true;
+    platformContextEnabled = true;
+    localWebhookRouteRegistered = false;
+    config = {
+      ingress: { publicBaseUrl: "https://velay.vellum.ai/assistant-123" },
+    };
+
+    expect(await register({ type: "telegram" })).toMatchObject({
+      callbackUrl: "https://gateway.vellum.ai/assistant-123/webhooks/telegram",
+      mode: "platform",
+    });
+    expect(registerLocalWebhookRouteMock).toHaveBeenCalled();
   });
 
   test("velay-webhooks on: a pod with no published URL still registers with the platform", async () => {
@@ -129,6 +161,7 @@ describe("webhooks_register callback URL resolution", () => {
       callbackUrl: "https://gateway.vellum.ai/assistant-123/webhooks/telegram",
       mode: "platform",
     });
+    expect(registerLocalWebhookRouteMock).not.toHaveBeenCalled();
   });
 
   test("velay-webhooks on: a pod with ingress disabled falls back to the platform", async () => {
@@ -140,6 +173,7 @@ describe("webhooks_register callback URL resolution", () => {
     expect(await register({ type: "telegram" })).toMatchObject({
       mode: "platform",
     });
+    expect(registerLocalWebhookRouteMock).not.toHaveBeenCalled();
   });
 
   test("disconnected local assistant uses the configured publicBaseUrl", async () => {
@@ -152,6 +186,7 @@ describe("webhooks_register callback URL resolution", () => {
       mode: "self-hosted",
     });
     expect(registerCallbackRouteMock).not.toHaveBeenCalled();
+    expect(registerLocalWebhookRouteMock).not.toHaveBeenCalled();
   });
 
   test("disconnected local assistant with no ingress is still unprocessable", async () => {
@@ -171,6 +206,7 @@ describe("webhooks_register callback URL resolution", () => {
       mode: "self-hosted",
     });
     expect(registerCallbackRouteMock).not.toHaveBeenCalled();
+    expect(registerLocalWebhookRouteMock).not.toHaveBeenCalled();
   });
 
   // The gateway publishes the Velay tunnel URL into ingress.publicBaseUrl, so

--- a/assistant/src/runtime/routes/webhook-routes.ts
+++ b/assistant/src/runtime/routes/webhook-routes.ts
@@ -153,7 +153,7 @@ async function handleWebhooksRegister(
       try {
         baseUrl = getPublicBaseUrl(getConfig());
       } catch {
-        // No published tunnel URL yet (or ingress toggled off) — platform
+        // No published tunnel URL yet (or ingress toggled off), so platform
         // registration keeps webhooks working.
       }
       if (

--- a/assistant/src/runtime/routes/webhook-routes.ts
+++ b/assistant/src/runtime/routes/webhook-routes.ts
@@ -15,6 +15,7 @@ import { getIsPlatform } from "../../config/env-registry.js";
 import { getConfig } from "../../config/loader.js";
 import {
   registerCallbackRoute,
+  registerLocalWebhookRoute,
   resolvePlatformCallbackRegistrationContext,
 } from "../../inbound/platform-callback-registration.js";
 import {
@@ -115,7 +116,8 @@ async function registerWithPlatform(
  *      Velay-published `ingress.publicBaseUrl` wins and platform
  *      registration is the fallback for any failure to resolve it —
  *      including an explicit `ingress.enabled: false`, matching
- *      `resolveCallbackUrl`'s pod behavior.
+ *      `resolveCallbackUrl`'s pod behavior. The subpath is claimed on the
+ *      gateway first, and a refused claim falls back the same way.
  *   2. **A configured public ingress wins** for everyone else. That URL is
  *      either the user's own tunnel (ngrok, a custom domain) or the Velay
  *      tunnel URL the gateway publishes into `ingress.publicBaseUrl`, so a
@@ -147,17 +149,23 @@ async function handleWebhooksRegister(
 
   if (getIsPlatform()) {
     if (isVelayWebhooksEnabled()) {
+      let baseUrl: string | undefined;
       try {
-        const baseUrl = getPublicBaseUrl(getConfig());
+        baseUrl = getPublicBaseUrl(getConfig());
+      } catch {
+        // No published tunnel URL yet (or ingress toggled off) — platform
+        // registration keeps webhooks working.
+      }
+      if (
+        baseUrl !== undefined &&
+        (await registerLocalWebhookRoute(webhookPath, type, sourceIdentifier))
+      ) {
         return {
           callbackUrl: `${baseUrl}/${webhookPath}`,
           type,
           path: webhookPath,
           mode: "self-hosted",
         };
-      } catch {
-        // No published tunnel URL yet (or ingress toggled off) — platform
-        // registration keeps webhooks working.
       }
     }
     return registerWithPlatform(webhookPath, type, sourceIdentifier);


### PR DESCRIPTION
## Summary
- On a flag-on platform pod, the resolver and `webhooks/register` claim the exact subpath on the gateway over IPC before handing out the Velay ingress URL, so no Django callback route is created.
- A refused claim (gateway flag off) or an unreachable gateway falls back to platform registration; flag-off and self-hosted paths are unchanged.

Part of plan: webhook-consolidation-velay.md (PR 5 of 9)