### PR TITLE
feat: placement writes answer with the row they stored (LUM-2409)

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -9365,8 +9365,207 @@ paths:
                 properties:
                   ok:
                     type: boolean
+                  conversations:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: string
+                        title:
+                          type: string
+                        createdAt:
+                          type: number
+                        updatedAt:
+                          type: number
+                        lastMessageAt:
+                          anyOf:
+                            - type: number
+                            - type: "null"
+                        conversationType:
+                          type: string
+                          enum:
+                            - standard
+                            - background
+                            - scheduled
+                        source:
+                          type: string
+                        scheduleJobId:
+                          type: string
+                        channelBinding:
+                          type: object
+                          properties:
+                            sourceChannel:
+                              type: string
+                            externalChatId:
+                              type: string
+                            externalChatName:
+                              type: string
+                            externalThreadId:
+                              type: string
+                            externalUserId:
+                              anyOf:
+                                - type: string
+                                - type: "null"
+                            displayName:
+                              anyOf:
+                                - type: string
+                                - type: "null"
+                            username:
+                              anyOf:
+                                - type: string
+                                - type: "null"
+                            slackThread:
+                              type: object
+                              properties:
+                                channelId:
+                                  type: string
+                                threadTs:
+                                  type: string
+                                link:
+                                  type: object
+                                  properties:
+                                    appUrl:
+                                      type: string
+                                    webUrl:
+                                      type: string
+                                  additionalProperties: false
+                              required:
+                                - channelId
+                                - threadTs
+                              additionalProperties: false
+                            slackChannel:
+                              type: object
+                              properties:
+                                channelId:
+                                  type: string
+                                name:
+                                  type: string
+                                link:
+                                  type: object
+                                  properties:
+                                    webUrl:
+                                      type: string
+                                  required:
+                                    - webUrl
+                                  additionalProperties: false
+                              required:
+                                - channelId
+                              additionalProperties: false
+                            sourceLink:
+                              type: object
+                              properties:
+                                appUrl:
+                                  type: string
+                                webUrl:
+                                  type: string
+                              additionalProperties: false
+                          required:
+                            - sourceChannel
+                            - externalChatId
+                            - externalUserId
+                            - displayName
+                            - username
+                          additionalProperties: false
+                        conversationOriginChannel:
+                          anyOf:
+                            - type: string
+                              enum:
+                                - telegram
+                                - phone
+                                - vellum
+                                - whatsapp
+                                - slack
+                                - email
+                                - platform
+                                - a2a
+                                - discord
+                                - plugin
+                            - type: "null"
+                        assistantAttention:
+                          type: object
+                          properties:
+                            hasUnseenLatestAssistantMessage:
+                              type: boolean
+                            latestAssistantMessageAt:
+                              type: number
+                            lastSeenAssistantMessageAt:
+                              type: number
+                            lastSeenConfidence:
+                              type: string
+                              enum:
+                                - explicit
+                                - inferred
+                            lastSeenSignalType:
+                              type: string
+                              enum:
+                                - macos_notification_view
+                                - macos_conversation_opened
+                                - ios_conversation_opened
+                                - web_bulk_mark_read
+                                - telegram_inbound_message
+                                - telegram_callback
+                                - slack_inbound_message
+                                - slack_callback
+                          required:
+                            - hasUnseenLatestAssistantMessage
+                          additionalProperties: false
+                        isPinned:
+                          type: boolean
+                          const: true
+                        displayOrder:
+                          anyOf:
+                            - type: number
+                            - type: "null"
+                        groupId:
+                          anyOf:
+                            - type: string
+                            - type: "null"
+                        forkParent:
+                          type: object
+                          properties:
+                            conversationId:
+                              type: string
+                            messageId:
+                              type: string
+                            title:
+                              type: string
+                          required:
+                            - conversationId
+                            - messageId
+                            - title
+                          additionalProperties: false
+                        historyOrphaned:
+                          type: boolean
+                          const: true
+                        archivedAt:
+                          type: number
+                        surfacedAt:
+                          type: number
+                        inferenceProfile:
+                          type: string
+                        enabledPlugins:
+                          anyOf:
+                            - type: array
+                              items:
+                                type: string
+                            - type: "null"
+                        isProcessing:
+                          type: boolean
+                      required:
+                        - id
+                        - title
+                        - createdAt
+                        - updatedAt
+                        - lastMessageAt
+                        - conversationType
+                        - source
+                        - groupId
+                        - isProcessing
+                      additionalProperties: false
                 required:
                   - ok
+                  - conversations
                 additionalProperties: false
   /v1/conversations/search:
     get:

--- a/assistant/src/runtime/routes/__tests__/conversation-management-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-management-routes.test.ts
@@ -103,6 +103,10 @@ const createHandler = findHandler(
   CONVERSATION_MANAGEMENT_ROUTES,
   "createConversation",
 );
+const reorderHandler = findHandler(
+  CONVERSATION_MANAGEMENT_ROUTES,
+  "reorderConversations",
+);
 const putHandler = findHandler(
   CONVERSATION_MANAGEMENT_ROUTES,
   "setConversationInferenceProfile",
@@ -520,5 +524,73 @@ describe("DELETE /v1/conversations/:id (deleteConversation)", () => {
 
     expect(getDb().select().from(conversations).all()).toHaveLength(0);
     expect(getSchedule(job.id)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /v1/conversations/reorder
+// ---------------------------------------------------------------------------
+
+/**
+ * The response is the point of these: this write does not simply apply its
+ * input, so a client that predicted the outcome from its own request would
+ * place the row in a section the next refetch takes it back out of. What the
+ * endpoint answers with has to be what the database now holds.
+ */
+describe("reorderConversations", () => {
+  beforeEach(() => {
+    clearConversations();
+  });
+
+  test("answers with the group as stored, not as requested", async () => {
+    const convId = crypto.randomUUID();
+    seedConversation(convId);
+
+    // An id naming no group: the write sanitizes it to the ungrouped bucket
+    // rather than failing, which is exactly the case a client cannot predict.
+    const result = (await reorderHandler({
+      body: { updates: [{ conversationId: convId, groupId: "no-such-group" }] },
+    })) as {
+      ok: boolean;
+      conversations: Array<{ id: string; groupId: string | null }>;
+    };
+
+    expect(result.ok).toBe(true);
+    expect(result.conversations).toHaveLength(1);
+    expect(result.conversations[0]!.id).toBe(convId);
+    expect(result.conversations[0]!.groupId).toBe("system:all");
+  });
+
+  test("answers with the pin state the write derived", async () => {
+    const convId = crypto.randomUUID();
+    seedConversation(convId);
+
+    const result = (await reorderHandler({
+      body: {
+        updates: [
+          { conversationId: convId, isPinned: true, groupId: "system:pinned" },
+        ],
+      },
+    })) as {
+      conversations: Array<{ groupId: string | null; isPinned?: true }>;
+    };
+
+    expect(result.conversations[0]!.groupId).toBe("system:pinned");
+    expect(result.conversations[0]!.isPinned).toBe(true);
+  });
+
+  test("an id naming no conversation is absent rather than represented", async () => {
+    const result = (await reorderHandler({
+      body: {
+        updates: [
+          { conversationId: crypto.randomUUID(), groupId: "system:all" },
+        ],
+      },
+    })) as { ok: boolean; conversations: unknown[] };
+
+    // The write is still reported as accepted: the batch is best-effort per
+    // row, and the empty list says this response speaks for no row.
+    expect(result.ok).toBe(true);
+    expect(result.conversations).toEqual([]);
   });
 });

--- a/assistant/src/runtime/routes/conversation-management-routes.ts
+++ b/assistant/src/runtime/routes/conversation-management-routes.ts
@@ -73,7 +73,10 @@ import { getLogger } from "../../util/logger.js";
 import { broadcastMessage } from "../assistant-event-hub.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import { resolveActorPrincipalIdForLocalGuardian } from "../local-actor-identity.js";
-import { buildConversationDetailResponse } from "../services/conversation-serializer.js";
+import {
+  buildConversationDetailResponse,
+  buildConversationSummaries,
+} from "../services/conversation-serializer.js";
 import {
   publishConversationEnabledPluginsChanged,
   publishConversationListAndMetadataChanged,
@@ -857,6 +860,9 @@ function handleReorderConversations({ body = {}, headers }: RouteHandlerArgs) {
   if (!Array.isArray(updates)) {
     throw new BadRequestError("Missing updates array");
   }
+  const conversationIds = updates.map(
+    (u) => resolveConversationId(u.conversationId) ?? u.conversationId,
+  );
   batchSetConversationPlacement(
     updates.map((u) => ({
       id: u.conversationId,
@@ -869,7 +875,17 @@ function handleReorderConversations({ body = {}, headers }: RouteHandlerArgs) {
     updates.map((u) => u.conversationId),
     headers?.["x-vellum-client-id"]?.trim() || undefined,
   );
-  return { ok: true };
+  /* Answer with the rows as stored rather than as requested. This write is
+     not a pure application of its input: an unknown or deleted group id
+     falls back to `system:all`, and `surfaced_at` is stamped or cleared by
+     rule, so a client that assumed its own input would place the row in a
+     section the next refetch takes it back out of. Read after write, in the
+     same request, is the only answer that cannot disagree with the database.
+  */
+  return {
+    ok: true,
+    conversations: buildConversationSummaries(conversationIds),
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -1321,7 +1337,13 @@ export const ROUTES: RouteDefinition[] = [
         }),
       ),
     }),
-    responseBody: z.object({ ok: z.boolean() }),
+    responseBody: z.object({
+      ok: z.boolean(),
+      /* The rows as stored, so a client can place them instead of predicting
+         where this write put them. Ids that name no conversation are absent
+         rather than represented. */
+      conversations: z.array(conversationSummarySchema),
+    }),
     handler: handleReorderConversations,
   },
 ];

--- a/assistant/src/runtime/services/conversation-serializer.ts
+++ b/assistant/src/runtime/services/conversation-serializer.ts
@@ -243,6 +243,52 @@ export function serializeConversationSummary(params: {
 }
 
 /**
+ * Serialize several conversations in one pass, for the writes that answer
+ * with the rows they changed.
+ *
+ * The batched form of {@link buildConversationDetailResponse}: the three
+ * per-row lookups (bindings, attention state, display meta) are issued once
+ * for the whole set rather than once per row, so answering a bulk placement
+ * costs a fixed number of queries plus one row read each.
+ *
+ * Ids naming no conversation are dropped, as are the legacy `private` rows,
+ * for the reason given on {@link buildConversationDetailResponse}: a row no
+ * listing will ever show must not reach a client through a write response
+ * either. A caller cannot tell those two cases apart from the result, which
+ * is deliberate. The response says where rows are now, and a row that is not
+ * in it is one this answer says nothing about.
+ */
+export function buildConversationSummaries(
+  conversationIds: readonly string[],
+): Array<ReturnType<typeof serializeConversationSummary>> {
+  const conversations = conversationIds
+    .map((id) => getConversation(id))
+    .filter(
+      (conversation): conversation is NonNullable<typeof conversation> =>
+        conversation != null && conversation.conversationType !== "private",
+    );
+  if (conversations.length === 0) {
+    return [];
+  }
+  const ids = conversations.map((conversation) => conversation.id);
+  const bindings = getBindingsForConversations(ids);
+  const attentionStates = getAttentionStateByConversationIds(ids);
+  const displayMeta = getDisplayMetaForConversations(ids);
+  const parentCache = new Map<string, ConversationRow | null>();
+
+  return conversations.map((conversation) =>
+    serializeConversationSummary({
+      conversation,
+      binding: bindings.get(conversation.id),
+      attentionState: attentionStates.get(conversation.id),
+      displayMeta: displayMeta.get(conversation.id),
+      parentCache,
+      isProcessing: isConversationProcessing(conversation.id),
+    }),
+  );
+}
+
+/**
  * Build a full conversation detail response from a conversation ID.
  * Returns null if the conversation doesn't exist, or if it is a legacy
  * `private` row: every listing hides those by type (see

--- a/assistant/src/runtime/services/conversation-serializer.ts
+++ b/assistant/src/runtime/services/conversation-serializer.ts
@@ -251,12 +251,13 @@ export function serializeConversationSummary(params: {
  * for the whole set rather than once per row, so answering a bulk placement
  * costs a fixed number of queries plus one row read each.
  *
- * Ids naming no conversation are dropped, as are the legacy `private` rows,
- * for the reason given on {@link buildConversationDetailResponse}: a row no
- * listing will ever show must not reach a client through a write response
- * either. A caller cannot tell those two cases apart from the result, which
- * is deliberate. The response says where rows are now, and a row that is not
- * in it is one this answer says nothing about.
+ * Ids naming no conversation are dropped, as are the legacy `private` rows:
+ * every listing hides those by type (see `standardListingVisibilitySql`) and
+ * migration cleanup deletes them, while the wire type collapses the value to
+ * `standard`, so serving one would let a client holding a stale id resurrect
+ * a row it can never see listed. A caller cannot tell the two cases apart
+ * from the result, which is deliberate. The response says where rows are now,
+ * and a row that is not in it is one this answer says nothing about.
  */
 export function buildConversationSummaries(
   conversationIds: readonly string[],
@@ -290,36 +291,18 @@ export function buildConversationSummaries(
 
 /**
  * Build a full conversation detail response from a conversation ID.
- * Returns null if the conversation doesn't exist, or if it is a legacy
- * `private` row: every listing hides those by type (see
- * `standardListingVisibilitySql`) and migration cleanup deletes them, and the
- * wire type collapses the value to `standard`, so serving one by id would let
- * a client that only holds a stale id (a persisted last-viewed conversation)
- * resurrect a row it can never see listed.
+ *
+ * The one-row shape of {@link buildConversationSummaries}, and it delegates
+ * rather than repeating the hydration: a summary field or a visibility rule
+ * added to one path has to reach the other, and two copies of the pipeline
+ * are how they stop agreeing.
+ *
+ * Returns null when the conversation does not exist, and for the same reason
+ * when it is a legacy `private` row.
  */
 export function buildConversationDetailResponse(
   conversationId: string,
 ): { conversation: ReturnType<typeof serializeConversationSummary> } | null {
-  const conversation = getConversation(conversationId);
-  if (!conversation || conversation.conversationType === "private") {
-    return null;
-  }
-
-  const bindings = getBindingsForConversations([conversation.id]);
-  const attentionStates = getAttentionStateByConversationIds([conversation.id]);
-  const displayMeta = getDisplayMetaForConversations([conversation.id]);
-  const parentCache = new Map<string, ConversationRow | null>();
-
-  return {
-    conversation: serializeConversationSummary({
-      conversation,
-      binding: bindings.get(conversation.id),
-      attentionState: attentionStates.get(conversation.id),
-      displayMeta: displayMeta.get(conversation.id),
-      parentCache,
-      // Checks in-memory flag first (hot path), falls back to the
-      // persisted `processing_started_at` column for cold conversations.
-      isProcessing: isConversationProcessing(conversation.id),
-    }),
-  };
+  const [conversation] = buildConversationSummaries([conversationId]);
+  return conversation ? { conversation } : null;
 }

--- a/clients/web/src/domains/chat/hooks/use-conversation-actions-placement.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-conversation-actions-placement.test.tsx
@@ -28,11 +28,20 @@ import {
   type ConversationListFilter,
 } from "@/utils/conversation-list-keys";
 import { listPage } from "@/utils/conversation-list.test-helper";
+import type { RawConversationSummary } from "@/utils/conversation-transforms";
 
-type ReorderImpl = (opts: unknown) => Promise<{
-  data: undefined;
+/**
+ * The reorder response carries the rows as the daemon stored them. `data` is
+ * `undefined` against a daemon that predates that field, which is the shape
+ * most of these tests use: it exercises the path where the client has only
+ * its own optimistic placement to go on.
+ */
+type ReorderResponse = {
+  data: { ok: boolean; conversations: RawConversationSummary[] } | undefined;
   response: { ok: boolean };
-}>;
+};
+
+type ReorderImpl = (opts: unknown) => Promise<ReorderResponse>;
 
 let reorderImpl: ReorderImpl = async () => ({
   data: undefined,
@@ -125,6 +134,29 @@ function copies(client: QueryClient, conversationId: string): number {
       idsIn(client, filter).filter((id) => id === conversationId).length,
     0,
   );
+}
+
+/**
+ * A row in the daemon's wire shape, for the responses that carry one. Only
+ * the fields a placement reads are interesting; the rest are the required
+ * shape.
+ */
+function wireRow(
+  overrides: Partial<RawConversationSummary> = {},
+): RawConversationSummary {
+  return {
+    id: "c1",
+    title: "Conversation",
+    createdAt: 1_000,
+    updatedAt: 1_000,
+    lastMessageAt: 1_000,
+    conversationType: "standard",
+    source: "user",
+    groupId: "system:all",
+    conversationOriginChannel: "slack",
+    isProcessing: false,
+    ...overrides,
+  };
 }
 
 function deferred<T>() {
@@ -390,5 +422,98 @@ describe("pin/unpin placement", () => {
       client.getQueryState(conversationListQueryKey(ASSISTANT_ID))
         ?.isInvalidated,
     ).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The response is authoritative
+// ---------------------------------------------------------------------------
+
+/**
+ * The optimistic write predicts where the daemon will put the row, and the
+ * prediction can be wrong in ways no client can detect: a group id naming no
+ * group is stored as `system:all`, and `surfaced_at` is stamped or cleared by
+ * rule. So the write answers with the rows it stored, and applying that answer
+ * is what converges the caches within the round trip.
+ */
+describe("placement response", () => {
+  const CUSTOM: ConversationListFilter = { groupId: "group-uuid" };
+
+  test("the row ends where the daemon stored it, not where the move asked", async () => {
+    /* Filing into a group that no longer exists. The daemon redirects it to
+       the ungrouped bucket, and without applying the response the row would
+       keep rendering in a group it is not in. */
+    reorderImpl = async () => ({
+      data: { ok: true, conversations: [wireRow({ groupId: "system:all" })] },
+      response: { ok: true },
+    });
+    const { result, client } = setup([
+      [SLACK, [SLACK_ROW]],
+      [CUSTOM, []],
+    ]);
+
+    await act(async () => {
+      result.current.handleMoveToGroup(SLACK_ROW, "group-uuid");
+    });
+
+    await waitFor(() => {
+      expect(idsIn(client, SLACK)).toEqual(["c1"]);
+    });
+    expect(idsIn(client, CUSTOM)).toEqual([]);
+    expect(copies(client, "c1")).toBe(1);
+  });
+
+  test("a superseded move does not apply its answer over the newer one", async () => {
+    /* Same rule as the rollback: the response describes a placement the user
+       has already left, so applying it would move the row back out of the
+       section they last chose. */
+    const first = deferred<ReorderResponse>();
+    let call = 0;
+    reorderImpl = () => {
+      call += 1;
+      return call === 1
+        ? first.promise
+        : Promise.resolve({
+            data: {
+              ok: true,
+              conversations: [wireRow({ groupId: "system:all" })],
+            },
+            response: { ok: true },
+          });
+    };
+    const { result, client } = setup([
+      [SLACK, [SLACK_ROW]],
+      [CUSTOM, []],
+    ]);
+
+    // Move A into the custom group, still in flight.
+    await act(async () => {
+      result.current.handleMoveToGroup(SLACK_ROW, "group-uuid");
+    });
+    // Move B returns it to the ungrouped bucket, and settles.
+    await act(async () => {
+      result.current.handleMoveToGroup(
+        { ...SLACK_ROW, groupId: "group-uuid" },
+        "system:all",
+      );
+    });
+    await waitFor(() => {
+      expect(idsIn(client, SLACK)).toEqual(["c1"]);
+    });
+
+    // A's answer lands late, naming the group the user has since left.
+    await act(async () => {
+      first.resolve({
+        data: {
+          ok: true,
+          conversations: [wireRow({ groupId: "group-uuid" })],
+        },
+        response: { ok: true },
+      });
+    });
+
+    expect(idsIn(client, SLACK)).toEqual(["c1"]);
+    expect(idsIn(client, CUSTOM)).toEqual([]);
+    expect(copies(client, "c1")).toBe(1);
   });
 });

--- a/clients/web/src/domains/chat/hooks/use-conversation-actions.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-actions.ts
@@ -393,10 +393,10 @@ export function useConversationActions({
         },
         throwOnError: true,
       });
-      /* The rows as the daemon stored them. Absent against one that predates
-         this field, which needs no version gate: no rows means nothing to
-         apply, and the settle reconciles from the optimistic placement's own
-         keys exactly as it did before. */
+      /* The rows as the daemon stored them. A daemon that does not serve this
+         field answers with none, which needs no version gate: no rows means
+         nothing to apply, and the settle reconciles from the optimistic
+         placement's own section keys. */
       return (data?.conversations ?? []).map(toConversation);
     },
     onMutate: async ({
@@ -452,11 +452,21 @@ export function useConversationActions({
         return;
       }
       for (const row of rows) {
+        /* The placement fields only. The response is authoritative about
+           where this write put the row, and a snapshot of everything else:
+           the daemon read those values before answering, so a rename, a
+           landing message, or a seen-state change between that read and this
+           patch would be reverted by applying them. Placement is the one part
+           of the row this request is the reason for. */
         for (const queryKey of patchConversation(
           queryClient,
           aid,
           row.conversationId,
-          row,
+          {
+            groupId: row.groupId,
+            isPinned: row.isPinned,
+            surfacedAt: row.surfacedAt,
+          },
         )) {
           placement.sectionKeys.set(hashKey(queryKey), queryKey);
         }

--- a/clients/web/src/domains/chat/hooks/use-conversation-actions.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-actions.ts
@@ -39,6 +39,7 @@ import { captureError } from "@/lib/sentry/capture-error";
 import { haptic } from "@/utils/haptics";
 
 import type { Conversation } from "@/types/conversation-types";
+import { toConversation } from "@/utils/conversation-transforms";
 import { useRenameRequestStore } from "@/domains/chat/rename-request-store";
 import {
   findNextConversationId,
@@ -374,7 +375,7 @@ export function useConversationActions({
   });
 
   const moveToGroupMutation = useMutation<
-    void,
+    Conversation[],
     Error,
     MoveToGroupVars,
     PlacementContext
@@ -385,13 +386,18 @@ export function useConversationActions({
       groupId,
       isPinned,
     }) => {
-      await conversationsReorderPost({
+      const { data } = await conversationsReorderPost({
         path: { assistant_id: aid },
         body: {
           updates: [{ conversationId, isPinned, groupId }],
         },
         throwOnError: true,
       });
+      /* The rows as the daemon stored them. Absent against one that predates
+         this field, which needs no version gate: no rows means nothing to
+         apply, and the settle reconciles from the optimistic placement's own
+         keys exactly as it did before. */
+      return (data?.conversations ?? []).map(toConversation);
     },
     onMutate: async ({
       assistantId: aid,
@@ -423,9 +429,37 @@ export function useConversationActions({
       });
       return { token };
     },
-    onSuccess: (_data, { conversationId, isPinned }) => {
+    /* The optimistic write predicted where this row would land; this is where
+       the prediction is replaced by the answer. The two differ whenever the
+       daemon did not simply apply the request: an unknown or deleted group id
+       is stored as `system:all`, and `surfaced_at` is stamped or cleared by
+       rule. Applying the returned row converges the caches within this one
+       round trip instead of leaving a plausible wrong placement standing
+       until something unrelated refetches. */
+    onSuccess: (
+      rows,
+      { assistantId: aid, conversationId, isPinned },
+      context,
+    ) => {
       if (!isPinned) {
         prePinGroupIdsRef.current.delete(conversationId);
+      }
+      const placement = placementsRef.current.get(conversationId);
+      /* Superseded moves do not apply their answer, for the reason their
+         rollback does not run: the user has moved the row again, and this
+         response describes a placement they have already left. */
+      if (!context || placement?.token !== context.token) {
+        return;
+      }
+      for (const row of rows) {
+        for (const queryKey of patchConversation(
+          queryClient,
+          aid,
+          row.conversationId,
+          row,
+        )) {
+          placement.sectionKeys.set(hashKey(queryKey), queryKey);
+        }
       }
     },
     onError: (


### PR DESCRIPTION
> Stacked on #40953. Review that one first; this branch contains its commits and the base retargets to `main` when it merges.

## TL;DR

`POST /v1/conversations/reorder` knew exactly where it put the row and answered `{ok: true}`. So the client predicted the placement, and when the prediction was wrong it stayed wrong until something unrelated refetched. The write now answers with the rows as stored, and the client applies them.

The concrete bug that fixes: file a conversation into a group that no longer exists, and the daemon stores it as ungrouped while the sidebar keeps rendering it inside that group.

## Why the client was predicting at all

`batchSetConversationPlacement` does not simply apply its input:

- an unknown or deleted `groupId` is rewritten to `system:all`
- `surfaced_at` is stamped for a background or scheduled row filed somewhere the user reads, and cleared on a demotion

Neither is visible from the request, so the client reimplemented both rules to guess the outcome. A read-after-write in the same request is the only answer that cannot disagree with the database.

## What this does not do

It does not delete the client's twins of those rules, and I want to be plain about that because an earlier version of the plan claimed it would.

The twins are what optimistic placement *is*. The row has to move on click, which means the client must decide there and then which section holds it. Deleting the prediction puts the row back in its old section for a round trip, which is the bug LUM-3195 fixed.

What changes is their authority: a prediction is now always corrected by the server's answer within the same round trip, instead of standing indefinitely. That is what makes the remaining duplication safe rather than load-bearing, and it is the documented precondition for windowing the foreground list.

## What changes for you

| Situation | Before | After |
| --- | --- | --- |
| Move a conversation into a group that was deleted elsewhere | Renders inside that group until an unrelated refetch | Lands in Chats, where the daemon actually put it |
| Pin a background or scheduled run | Visible if the client's `surfaced_at` guess matched the daemon's | Visible because the daemon said so |
| Any ordinary move or pin | Row moves on click | Unchanged, still moves on click |
| Connected to an older daemon | | Unchanged: no rows in the response means nothing to apply |

## Why this is safe

- **Additive on the wire.** A new field on a 200 response. Other clients (macOS, iOS) ignore it.
- **Self-detecting fallback, no version gate.** `data?.conversations ?? []` is empty against a daemon without the field, so the settle reconciles from the optimistic keys exactly as before. There is no second code path to keep alive, and no `MIN_VERSION` to retire later.
- **Superseded moves do not apply their answer**, under the same token check that already governs their rollback, so a late response cannot move a row out of the section the user last chose. Pinned by a test.
- **The optimistic paint is untouched**, so nothing about how a move feels changes.
- Ids naming no conversation are absent from the response rather than represented, so a caller cannot mistake "I have nothing to say about this row" for "this row is gone".

## Tests

Daemon: the response reports the stored group after the daemon redirects an unknown id, reports the derived pin state, and omits an id that names no conversation.

Client: a move whose response disagrees with the request ends where the response says; a superseded move's late answer does not move the row.

Local `bun test` is blocked by a hook in this environment, so these run in CI rather than here. Typecheck and lint are clean on both sides.

## Follow-ups, deliberately not here

The other placement writes (`surface`, `archive`, `unarchive`) still answer without their rows. They settle with a full prefix invalidation, so they converge already, just more expensively. Worth converting when one of them is next touched rather than as a sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40964" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->