### PR TITLE
refactor(channels): give the reaction capability its own parameters (LUM-3358)

### DIFF
--- a/assistant/src/messaging/providers/__tests__/transport-dispatch.test.ts
+++ b/assistant/src/messaging/providers/__tests__/transport-dispatch.test.ts
@@ -57,8 +57,13 @@ mock.module("../../../util/logger.js", () => ({
   getLogger: () => ({ debug() {}, info() {}, warn() {}, error() {} }),
 }));
 
-const { deliverDirect, isDirectDelivery, getTransportForCallback } =
-  await import("../index.js");
+const {
+  deliverDirect,
+  sendChannelReaction,
+  supportsChannelReaction,
+  isDirectDelivery,
+  getTransportForCallback,
+} = await import("../index.js");
 
 const BASE = "https://gateway.internal";
 
@@ -134,17 +139,14 @@ describe("Slack sub-operation selection", () => {
     expect(opts.threadTs).toBe("1700.9");
   });
 
-  test("reaction routes to sendSlackReaction, not the text path", async () => {
-    await deliverDirect(
-      `${BASE}/deliver/slack`,
-      payload({
-        reaction: {
-          action: "add",
-          name: "white_check_mark",
-          messageTs: "1700.5",
-        },
-      }),
-    );
+  test("sendChannelReaction reaches Slack without touching the text path", async () => {
+    await sendChannelReaction(`${BASE}/deliver/slack`, {
+      chatId: "C1",
+      messageId: "1700.5",
+      emoji: "white_check_mark",
+      action: "add",
+    });
+
     expect(slack.sendSlackReaction).toHaveBeenCalledTimes(1);
     expect(slack.sendSlackReply).not.toHaveBeenCalled();
   });
@@ -191,15 +193,23 @@ describe("Slack sub-operation selection", () => {
 });
 
 describe("capability gating across channels", () => {
-  test("a reaction payload to Telegram falls through to deliver (no sendReaction)", async () => {
-    await deliverDirect(
-      `${BASE}/deliver/telegram`,
-      payload({
-        text: "hi",
-        reaction: { action: "add", name: "x", messageTs: "1" },
-      }),
-    );
-    expect(telegram.sendTelegramReply).toHaveBeenCalledTimes(1);
+  test("the reaction capability is read from the transport, not the channel name", async () => {
+    // Slack is the only channel that implements it, because the only producer
+    // is Slack's own acknowledgement fallback. A channel that implements the
+    // method starts being asked without a caller changing.
+    expect(supportsChannelReaction(`${BASE}/deliver/slack`)).toBe(true);
+    expect(supportsChannelReaction(`${BASE}/deliver/telegram`)).toBe(false);
+
+    const target = {
+      chatId: "C1",
+      messageId: "1",
+      emoji: "eyes",
+      action: "add",
+    } as const;
+    expect(
+      await sendChannelReaction(`${BASE}/deliver/telegram`, target),
+    ).toEqual({ ok: true });
+    expect(telegram.sendTelegramReply).not.toHaveBeenCalled();
   });
 
   test("typing to Telegram routes to its typing indicator", async () => {

--- a/assistant/src/messaging/providers/channel-transport.ts
+++ b/assistant/src/messaging/providers/channel-transport.ts
@@ -15,6 +15,15 @@ export interface CallbackContext {
   readonly params: Readonly<Record<string, string>>;
 }
 
+/** The message an emoji reaction lands on, and what to do there. */
+export interface ReactionTarget {
+  readonly chatId: string;
+  /** The target message, in the channel's own id space. */
+  readonly messageId: string;
+  readonly emoji: string;
+  readonly action: "add" | "remove";
+}
+
 /**
  * Direct outbound delivery for one channel, wrapping the channel's provider-API
  * send functions behind a uniform surface. Transports are registered statically
@@ -41,10 +50,17 @@ export interface ChannelTransport {
     payload: ChannelReplyPayload,
   ): Promise<ChannelDeliveryResult>;
 
-  /** Add an emoji reaction. Routed when `payload.reaction` is set. */
-  sendReaction?(
+  /**
+   * Add or remove one of the assistant's own emoji reactions on a message.
+   *
+   * `messageId` is the target's id in the channel's own space, the same way
+   * `chatId` is: Slack spells it as a timestamp, Discord and Telegram as ids.
+   * Nothing outside the channel reads it, so nothing outside needs a shared
+   * spelling for it.
+   */
+  react?(
     ctx: CallbackContext,
-    payload: ChannelReplyPayload,
+    target: ReactionTarget,
   ): Promise<ChannelDeliveryResult>;
 
   /** Update an assistant-thread status surface. Routed when `payload.assistantThreadStatus` is set. */

--- a/assistant/src/messaging/providers/index.ts
+++ b/assistant/src/messaging/providers/index.ts
@@ -16,7 +16,11 @@ import type {
 import { a2aTransport } from "./a2a/transport.js";
 import type { DirectDeliveryChannel } from "./callback-routing.js";
 import { channelForCallback } from "./callback-routing.js";
-import type { CallbackContext, ChannelTransport } from "./channel-transport.js";
+import type {
+  CallbackContext,
+  ChannelTransport,
+  ReactionTarget,
+} from "./channel-transport.js";
 import { discordTransport } from "./discord/transport.js";
 import { slackTransport } from "./slack/transport.js";
 import { telegramTransport } from "./telegram-bot/transport.js";
@@ -43,6 +47,29 @@ export function getTransportForCallback(
 ): ChannelTransport | undefined {
   const channel = channelForCallback(callbackUrl);
   return channel ? TRANSPORTS[channel] : undefined;
+}
+
+/** Whether the channel this callback addresses can carry emoji reactions. */
+export function supportsChannelReaction(callbackUrl: string): boolean {
+  return getTransportForCallback(callbackUrl)?.react !== undefined;
+}
+
+/**
+ * Add or remove one of the assistant's own reactions on a message.
+ *
+ * Resolves to nothing when the channel has none, the same as typing: a
+ * reaction is an acknowledgement, and a channel that cannot show one is not a
+ * failed delivery.
+ */
+export async function sendChannelReaction(
+  callbackUrl: string,
+  target: ReactionTarget,
+): Promise<ChannelDeliveryResult> {
+  const transport = getTransportForCallback(callbackUrl);
+  if (!transport?.react) {
+    return { ok: true };
+  }
+  return transport.react(callbackContext(callbackUrl), target);
 }
 
 function callbackContext(callbackUrl: string): CallbackContext {
@@ -92,9 +119,6 @@ export async function deliverDirect(
   const ctx = callbackContext(callbackUrl);
   if (payload.slackStream && transport.streamReply) {
     return transport.streamReply(ctx, payload);
-  }
-  if (payload.reaction && transport.sendReaction) {
-    return transport.sendReaction(ctx, payload);
   }
   if (payload.assistantThreadStatus && transport.setThreadStatus) {
     return transport.setThreadStatus(ctx, payload);

--- a/assistant/src/messaging/providers/slack/transport.ts
+++ b/assistant/src/messaging/providers/slack/transport.ts
@@ -54,16 +54,12 @@ export const slackTransport: ChannelTransport = {
     return { ok: true, ts: sentTs };
   },
 
-  async sendReaction(_ctx, payload) {
-    const reaction = payload.reaction;
-    if (!reaction) {
-      return { ok: true };
-    }
+  async react(_ctx, target) {
     await sendSlackReaction(
-      payload.chatId,
-      reaction.name,
-      reaction.messageTs,
-      reaction.action,
+      target.chatId,
+      target.emoji,
+      target.messageId,
+      target.action,
     );
     return { ok: true };
   },

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
@@ -20,6 +20,7 @@ import {
 } from "../../../contacts/guardian-delivery-reader.js";
 import { isConversationBusyError } from "../../../daemon/conversation-messaging.js";
 import type { TrustContext } from "../../../daemon/trust-context-types.js";
+import { sendChannelReaction } from "../../../messaging/providers/index.js";
 import {
   getSiblingStreamedReplyTs,
   linkMessage,
@@ -668,15 +669,13 @@ function setSlackThinkingStatus(
       };
     }
 
-    const addPromise = deliverChannelReply(callbackUrl, {
+    const addPromise = sendChannelReaction(callbackUrl, {
       chatId,
-      assistantId,
-      reaction: { action: "add", name: "eyes", messageTs },
+      messageId: messageTs,
+      emoji: "eyes",
+      action: "add",
     }).catch((err) => {
-      log.debug(
-        { err, chatId, messageTs },
-        "Failed to add Slack eyes reaction",
-      );
+      log.debug({ err, chatId, messageTs }, "Failed to add eyes reaction");
     });
 
     const clearReaction = (): void => {
@@ -686,14 +685,15 @@ function setSlackThinkingStatus(
       cleared = true;
       clearTimeout(safetyTimer);
       void addPromise.then(() =>
-        deliverChannelReply(callbackUrl, {
+        sendChannelReaction(callbackUrl, {
           chatId,
-          assistantId,
-          reaction: { action: "remove", name: "eyes", messageTs },
+          messageId: messageTs,
+          emoji: "eyes",
+          action: "remove",
         }).catch((err) => {
           log.debug(
             { err, chatId, messageTs },
-            "Failed to remove Slack eyes reaction",
+            "Failed to remove eyes reaction",
           );
         }),
       );

--- a/packages/gateway-client/src/outbound-contract.ts
+++ b/packages/gateway-client/src/outbound-contract.ts
@@ -180,14 +180,6 @@ export const ChannelReplyPayloadSchema = z.object({
   messageTs: z.string().optional(),
   /** When true, the daemon generates Block Kit blocks from the text before delivery. */
   useBlocks: z.boolean().optional(),
-  /** When provided, add or remove an emoji reaction on a message. */
-  reaction: z
-    .object({
-      action: z.enum(["add", "remove"]),
-      name: z.string(),
-      messageTs: z.string(),
-    })
-    .optional(),
   /** When provided, set or clear the Slack Assistants API thread status. */
   assistantThreadStatus: z
     .object({


### PR DESCRIPTION
## TL;DR

The second capability narrowed to its own parameters. **No new channel gains reactions, deliberately**, and the reason is the interesting part.

Part of LUM-3356. Follows PR #40959 (typing).

## The change

```ts
react?(ctx: CallbackContext, target: ReactionTarget): Promise<ChannelDeliveryResult>;

interface ReactionTarget {
  chatId: string;
  messageId: string;   // the target, in the channel's own id space
  emoji: string;
  action: "add" | "remove";
}
```

Reached through `sendChannelReaction(callbackUrl, target)` instead of setting a `reaction` field on a reply payload and having the dispatcher notice. `reaction` leaves the daemon-to-gateway contract, where it was a routing marker the gateway never read, the same as `chatAction` in #40959.

`messageId` is deliberately channel-native. `chatId` already is, nothing outside the channel reads either, and inventing a shared spelling for a Slack timestamp, a Discord snowflake and a Telegram integer would be a vocabulary nobody consumes.

## Why Telegram and Discord do not gain reactions here

I built both, then removed them, which is worth explaining rather than hiding.

The only producer of an outbound reaction is the eyes acknowledgement in `createSlackThinkingStatusController`, and that controller returns early unless the channel is Slack. Adding Telegram and Discord implementations without changing that gate ships code no caller reaches, which is precisely what review caught on #40959.

Generalizing the gate is the obvious next thought and is wrong here. **The eyes reaction exists because Slack has no typing indicator.** Telegram has one, and Discord gained one in #40959. Extending the fallback to channels that already show a working indicator would give them two.

So reactions have no cross-channel producer today, and the honest position is that the capability is now narrow enough that adding a channel is a few lines whenever a producer wants one. Both stay `available` on the [capability map](https://claude.ai/code/artifact/7979ce72-7aeb-4bf2-946e-1b030d846fc9) rather than moving to `built`.

## What changes for the user

Nothing. This is a refactor with no behavioural change: Slack still adds and clears the eyes reaction exactly as before, and no other channel gained or lost anything.

## Why it is safe

`reaction` leaves the shared contract and the gateway never read it (`grep reaction gateway/src` finds only inbound handling). Nothing persists a reply payload. Both producers migrated in the same change, so nothing is left setting a field that no longer routes.

Verified: assistant and gateway typecheck, lint and the pinned prettier all clean. Tests in CI.

## Next

`edit`, `stream` and `interactive` remain, each pulled in by a channel that needs it. `send` last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40965" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->