### PR TITLE
refactor(web): read the pane arrangement from one place

### DIFF
--- a/clients/web/src/domains/chat/components/chat-content-layout.tsx
+++ b/clients/web/src/domains/chat/components/chat-content-layout.tsx
@@ -26,6 +26,7 @@ import {
 import { handleAppViewerAction } from "@/domains/chat/app-viewer-actions";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { useConversationStore } from "@/stores/conversation-store";
+import { viewerPanePresentation } from "@/stores/pane-presentation";
 import { useDeployStore } from "@/stores/deploy-store";
 import { useViewerStore } from "@/stores/viewer-store";
 import { useSubagentStore } from "@/domains/chat/subagent-store";
@@ -92,6 +93,7 @@ const SkillDetailPanel = lazy(() =>
 export function ChatContentLayout(props: ChatMainPanelProps) {
   const mainView = useViewerStore.use.mainView();
   const openedAppState = useViewerStore.use.openedAppState();
+  const isAppMinimized = useViewerStore.use.isAppMinimized();
   const openedDocumentState = useViewerStore.use.openedDocumentState();
   const editingConversationId =
     useConversationStore.use.editingConversationId();
@@ -340,7 +342,15 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
   // -------------------------------------------------------------------------
 
   // App editing: resizable split with chat + app editor
-  if (mainView === "app-editing" && openedAppState && editingConversationId) {
+  if (
+    viewerPanePresentation({
+      mainView,
+      hasApp: !!openedAppState,
+      hasBoundConversation: !!editingConversationId,
+      isAppMinimized,
+    }) === "side" &&
+    openedAppState
+  ) {
     return (
       <ResizablePanel
         storageKey="appEditPanelWidth"

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -163,6 +163,7 @@ import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import { shouldMintNewChatDraft } from "@/domains/chat/utils/conversation-selection";
 import { isNativeMobile } from "@/runtime/platform-detection";
 import { useConversationStore } from "@/stores/conversation-store";
+import { viewerPanePresentation } from "@/stores/pane-presentation";
 import { useDoctorHandoffStore } from "@/stores/doctor-handoff-store";
 import { useLowBalanceBannerStore } from "@/stores/low-balance-banner-store";
 
@@ -1445,19 +1446,22 @@ export function ChatMainPanel({
   // -------------------------------------------------------------------------
   const editingConversationId =
     useConversationStore.use.editingConversationId();
-  const isSidePanel =
-    mainView === "app-editing" && !!openedAppState && !!editingConversationId;
+  const paneArrangement = viewerPanePresentation({
+    mainView,
+    hasApp: !!openedAppState,
+    hasBoundConversation: !!editingConversationId,
+    isAppMinimized,
+  });
+  const isSidePanel = paneArrangement === "side";
   const variant = isSidePanel ? "side-panel" : "main";
 
-  // Mobile-only: while the app overlay is minimized to its bottom strip, the
-  // strip covers the bottom of the chat. Reserve its height so the composer
-  // sits above it. The guard mirrors the strip's mount condition — the strip
-  // renders only while `mainView === "app"`, and navigation can leave
-  // `isAppMinimized`/`openedAppState` set after it unmounts. The strip peeks
-  // `--app-strip-h` above the safe area, and the chat shell already pads for
-  // the safe area itself, so only the strip height needs reserving.
+  // Mobile-only: while the app is parked to its bottom strip, the strip covers
+  // the bottom of the chat, so its height is reserved to keep the composer
+  // above it. The strip peeks `--app-strip-h` above the safe area, and the
+  // chat shell already pads for the safe area itself, so only the strip height
+  // needs reserving.
   const appStripBottomInset =
-    isMobile && mainView === "app" && isAppMinimized && openedAppState
+    isMobile && paneArrangement === "bottom"
       ? "var(--app-strip-h, 64px)"
       : undefined;
 

--- a/clients/web/src/domains/chat/utils/visible-app-context.ts
+++ b/clients/web/src/domains/chat/utils/visible-app-context.ts
@@ -13,6 +13,7 @@
  * reflected on the next send.
  */
 
+import { isAppMainView } from "@/stores/pane-presentation";
 import { useViewerStore } from "@/stores/viewer-store";
 
 /**
@@ -23,7 +24,7 @@ import { useViewerStore } from "@/stores/viewer-store";
  */
 export function getVisibleAppIdForSend(): string | undefined {
   const { mainView, openedAppState } = useViewerStore.getState();
-  if (mainView !== "app" && mainView !== "app-editing") {
+  if (!isAppMainView(mainView)) {
     return undefined;
   }
   return openedAppState?.appId;

--- a/clients/web/src/stores/pane-presentation.test.ts
+++ b/clients/web/src/stores/pane-presentation.test.ts
@@ -21,6 +21,7 @@ import {
   type PanePosition,
   type PanePresentation,
 } from "@/stores/pane-presentation";
+import type { MainView } from "@/stores/viewer-store";
 
 /** What a viewer sees, with arrangements that look alike collapsed together. */
 type Rendered = "one-surface" | "two-columns" | "stacked-strip";
@@ -183,12 +184,17 @@ describe("panePresentation", () => {
 describe("viewerPanePresentation reads the stored fields", () => {
   // The two combinations below are the reference: an arrangement is correct
   // when it agrees with them across every combination the fields can hold.
-  const MAIN_VIEWS = ["chat", "app", "app-editing", "document"];
+  const MAIN_VIEWS: readonly MainView[] = [
+    "chat",
+    "app",
+    "app-editing",
+    "document",
+  ];
   const BOOLS = [false, true];
 
   /** The field combination that means side by side. */
   function rendersSplit(
-    mainView: string,
+    mainView: MainView,
     hasApp: boolean,
     hasBoundConversation: boolean,
   ): boolean {
@@ -197,7 +203,7 @@ describe("viewerPanePresentation reads the stored fields", () => {
 
   /** The field combination that means the app is parked to its strip. */
   function rendersStrip(
-    mainView: string,
+    mainView: MainView,
     hasApp: boolean,
     isAppMinimized: boolean,
   ): boolean {
@@ -233,7 +239,8 @@ describe("viewerPanePresentation reads the stored fields", () => {
   }
 
   it("reports no secondary once the viewer has moved off the app", () => {
-    for (const mainView of ["chat", "document", "skill-detail"]) {
+    const offApp: readonly MainView[] = ["chat", "document", "skill-detail"];
+    for (const mainView of offApp) {
       expect(
         viewerPanePresentation({
           mainView,

--- a/clients/web/src/stores/pane-presentation.test.ts
+++ b/clients/web/src/stores/pane-presentation.test.ts
@@ -17,6 +17,7 @@ import { describe, expect, it } from "bun:test";
 
 import {
   panePresentation,
+  viewerPanePresentation,
   type PanePosition,
   type PanePresentation,
 } from "@/stores/pane-presentation";
@@ -176,5 +177,69 @@ describe("panePresentation", () => {
         isNarrow: true,
       }),
     ).toBe("full");
+  });
+});
+
+describe("viewerPanePresentation reads the stored fields", () => {
+  const MAIN_VIEWS = ["chat", "app", "app-editing", "document"];
+  const BOOLS = [false, true];
+
+  /** The side-by-side layout's own condition, before it read an arrangement. */
+  function rendersSplit(
+    mainView: string,
+    hasApp: boolean,
+    hasBoundConversation: boolean,
+  ): boolean {
+    return mainView === "app-editing" && hasApp && hasBoundConversation;
+  }
+
+  /** The strip's own condition, before it read an arrangement. */
+  function rendersStrip(
+    mainView: string,
+    hasApp: boolean,
+    isAppMinimized: boolean,
+  ): boolean {
+    return mainView === "app" && isAppMinimized && hasApp;
+  }
+
+  for (const mainView of MAIN_VIEWS) {
+    for (const hasApp of BOOLS) {
+      for (const hasBoundConversation of BOOLS) {
+        for (const isAppMinimized of BOOLS) {
+          const fields = {
+            mainView,
+            hasApp,
+            hasBoundConversation,
+            isAppMinimized,
+          };
+          const label = `${mainView}, app=${hasApp}, bound=${hasBoundConversation}, minimized=${isAppMinimized}`;
+
+          it(`${label}: side matches the split's condition`, () => {
+            expect(viewerPanePresentation(fields) === "side").toBe(
+              rendersSplit(mainView, hasApp, hasBoundConversation),
+            );
+          });
+
+          it(`${label}: bottom matches the strip's condition`, () => {
+            expect(viewerPanePresentation(fields) === "bottom").toBe(
+              rendersStrip(mainView, hasApp, isAppMinimized),
+            );
+          });
+        }
+      }
+    }
+  }
+
+  it("reports no secondary once the viewer has moved off the app", () => {
+    for (const mainView of ["chat", "document", "skill-detail"]) {
+      expect(
+        viewerPanePresentation({
+          mainView,
+          hasApp: true,
+          hasBoundConversation: true,
+          isAppMinimized: false,
+        }),
+      ).toBe("single");
+    }
   });
 });

--- a/clients/web/src/stores/pane-presentation.test.ts
+++ b/clients/web/src/stores/pane-presentation.test.ts
@@ -181,10 +181,12 @@ describe("panePresentation", () => {
 });
 
 describe("viewerPanePresentation reads the stored fields", () => {
+  // The two combinations below are the reference: an arrangement is correct
+  // when it agrees with them across every combination the fields can hold.
   const MAIN_VIEWS = ["chat", "app", "app-editing", "document"];
   const BOOLS = [false, true];
 
-  /** The side-by-side layout's own condition, before it read an arrangement. */
+  /** The field combination that means side by side. */
   function rendersSplit(
     mainView: string,
     hasApp: boolean,
@@ -193,7 +195,7 @@ describe("viewerPanePresentation reads the stored fields", () => {
     return mainView === "app-editing" && hasApp && hasBoundConversation;
   }
 
-  /** The strip's own condition, before it read an arrangement. */
+  /** The field combination that means the app is parked to its strip. */
   function rendersStrip(
     mainView: string,
     hasApp: boolean,

--- a/clients/web/src/stores/pane-presentation.ts
+++ b/clients/web/src/stores/pane-presentation.ts
@@ -45,6 +45,11 @@ export function panePresentation({
   return position;
 }
 
+/** Whether the viewer is showing an app, in any arrangement. */
+export function isAppMainView(mainView: MainView): boolean {
+  return mainView === "app" || mainView === "app-editing";
+}
+
 /** The fields the viewer stores about an app and the conversation beside it. */
 export interface ViewerPaneFields {
   mainView: MainView;
@@ -66,7 +71,7 @@ export function viewerPanePresentation({
   hasBoundConversation,
   isAppMinimized,
 }: ViewerPaneFields): PanePresentation {
-  if (!hasApp || (mainView !== "app" && mainView !== "app-editing")) {
+  if (!hasApp || !isAppMainView(mainView)) {
     return "single";
   }
   // Which surface is the secondary depends on the arrangement. Beside the

--- a/clients/web/src/stores/pane-presentation.ts
+++ b/clients/web/src/stores/pane-presentation.ts
@@ -54,3 +54,61 @@ export function panePresentation({
   }
   return position;
 }
+
+/**
+ * The fields the viewer stores about an app and the conversation beside it.
+ */
+export interface ViewerPaneFields {
+  /** The viewer's main view. */
+  mainView: string;
+  /** Whether an app is loaded into the viewer. */
+  hasApp: boolean;
+  /** Whether a conversation is bound to the pane beside the app. */
+  hasBoundConversation: boolean;
+  /** Whether the app is parked to its strip. */
+  isAppMinimized: boolean;
+}
+
+/**
+ * Read the stored fields as the arrangement they describe.
+ *
+ * The viewport is not consulted. The stored arrangement already reflects the
+ * room available when it was chosen, since every path into the side-by-side
+ * layout refuses a viewport with no space for two columns, so narrowing it
+ * again here would answer a question nobody asked. A position the user sets
+ * directly is a different matter, and {@link panePresentation} takes the
+ * viewport for that reason.
+ */
+export function viewerPanePresentation({
+  mainView,
+  hasApp,
+  hasBoundConversation,
+  isAppMinimized,
+}: ViewerPaneFields): PanePresentation {
+  if (!hasApp || (mainView !== "app" && mainView !== "app-editing")) {
+    return "single";
+  }
+  // Which surface is the secondary depends on the arrangement. Beside the
+  // app and behind it, the secondary is the conversation, so an unbound one
+  // means there is no second surface at all. Parked to the strip, the app is
+  // itself the secondary and the conversation has the surface.
+  if (mainView === "app-editing") {
+    return panePresentation({
+      hasSecondary: hasBoundConversation,
+      position: "side",
+      isNarrow: false,
+    });
+  }
+  if (isAppMinimized) {
+    return panePresentation({
+      hasSecondary: true,
+      position: "bottom",
+      isNarrow: false,
+    });
+  }
+  return panePresentation({
+    hasSecondary: hasBoundConversation,
+    position: "full",
+    isNarrow: false,
+  });
+}

--- a/clients/web/src/stores/pane-presentation.ts
+++ b/clients/web/src/stores/pane-presentation.ts
@@ -1,37 +1,28 @@
 /**
- * How the workspace arranges its two panes.
- *
- * Three facts decide it: whether a secondary surface is open, where the user
- * asked for it, and whether there is room for that answer. Deriving keeps
- * them independent, so opening, closing and moving a surface each change one
- * fact rather than re-deciding the arrangement, and no combination of them
- * can produce a layout nothing renders.
+ * How the workspace arranges its two panes: whether a secondary surface is
+ * open, where the user asked for it, and whether there is room for that.
  */
 
+import type { MainView } from "@/stores/viewer-store";
+
 /**
- * Where the user asked for the secondary pane.
- *
- * A preference rather than a consequence: a viewport with no room for
- * `"side"` presents `"bottom"` without overwriting it, so widening the window
- * answers what was asked for rather than making the user ask again.
+ * Where the user asked for the secondary pane. A viewport with no room for
+ * `"side"` presents `"bottom"` without overwriting it.
  */
 export type PanePosition = "side" | "bottom" | "full";
 
 /**
- * What the workspace shows.
- *
- * `"full"` and `"single"` are one picture and two states: a surface filling
- * the width, with a secondary collapsed behind it or with none at all. The
- * difference is what makes a collapsed pane one click from returning, and a
- * closed one gone.
+ * What the workspace shows. `"full"` and `"single"` are one picture and two
+ * states: a surface filling the width, with a secondary collapsed behind it
+ * or with none at all.
  */
 export type PanePresentation = "single" | "side" | "bottom" | "full";
 
 export interface PanePresentationInput {
-  /** Whether a secondary surface is open, visible or collapsed. */
+  /** Open, whether visible or collapsed. */
   hasSecondary: boolean;
   position: PanePosition;
-  /** Whether the viewport is too narrow to stand two panes side by side. */
+  /** Too narrow to stand two panes side by side. */
   isNarrow: boolean;
 }
 
@@ -46,38 +37,28 @@ export function panePresentation({
   if (position === "full") {
     return "full";
   }
-  // The one place the viewport has a say, and it narrows the answer rather
-  // than replacing it: `position` is untouched, so the same preference reads
-  // as `"side"` again once there is room.
+  // `position` is untouched, so the same preference reads as `"side"` again
+  // once there is room.
   if (isNarrow) {
     return "bottom";
   }
   return position;
 }
 
-/**
- * The fields the viewer stores about an app and the conversation beside it.
- */
+/** The fields the viewer stores about an app and the conversation beside it. */
 export interface ViewerPaneFields {
-  /** The viewer's main view. */
-  mainView: string;
-  /** Whether an app is loaded into the viewer. */
+  mainView: MainView;
   hasApp: boolean;
-  /** Whether a conversation is bound to the pane beside the app. */
   hasBoundConversation: boolean;
-  /** Whether the app is parked to its strip. */
   isAppMinimized: boolean;
 }
 
 /**
  * Read the stored fields as the arrangement they describe.
  *
- * The viewport is not consulted. The stored arrangement already reflects the
+ * The viewport is not consulted: a stored arrangement already reflects the
  * room available when it was chosen, since every path into the side-by-side
- * layout refuses a viewport with no space for two columns, so narrowing it
- * again here would answer a question nobody asked. A position the user sets
- * directly is a different matter, and {@link panePresentation} takes the
- * viewport for that reason.
+ * layout refuses a viewport with no space for two columns.
  */
 export function viewerPanePresentation({
   mainView,

--- a/clients/web/src/stores/viewer-store.ts
+++ b/clients/web/src/stores/viewer-store.ts
@@ -42,6 +42,7 @@ import { useUnseenDocumentChangesStore } from "@/domains/chat/unseen-document-ch
 
 import type { WebSearchResultItem } from "@/assistant/web-activity-types";
 import { createSelectors } from "@/utils/create-selectors";
+import { isAppMainView } from "@/stores/pane-presentation";
 
 /** Views that overlay the main content and track a "back" destination. */
 type OverlayView =
@@ -718,10 +719,7 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
 
   handleAppUnpinned: (appId) => {
     const state = get();
-    if (
-      state.activeAppId !== appId ||
-      (state.mainView !== "app" && state.mainView !== "app-editing")
-    ) {
+    if (state.activeAppId !== appId || !isAppMainView(state.mainView)) {
       return false;
     }
     get().closeApp();

--- a/clients/web/src/utils/conversation-navigation.ts
+++ b/clients/web/src/utils/conversation-navigation.ts
@@ -7,6 +7,7 @@ import { requestComposerFocus } from "@/domains/chat/composer-focus";
 import { useConversationStore } from "@/stores/conversation-store";
 import { useSubagentStore } from "@/domains/chat/subagent-store";
 import { useWorkflowStore } from "@/domains/chat/workflow-store";
+import { isAppMainView } from "@/stores/pane-presentation";
 import { useViewerStore } from "@/stores/viewer-store";
 import { createDraftConversationId } from "@/domains/chat/utils/conversation-selection";
 import { getSoundManager } from "@/lib/sounds/sound-manager";
@@ -46,7 +47,7 @@ export function keepOpenAppBesideConversation(conversationId: string): boolean {
     return false;
   }
   const viewer = useViewerStore.getState();
-  if (viewer.mainView !== "app" && viewer.mainView !== "app-editing") {
+  if (!isAppMainView(viewer.mainView)) {
     return false;
   }
   if (!viewer.activeAppId && !viewer.openedAppState) {


### PR DESCRIPTION
## TL;DR

The condition for the side-by-side layout was written out twice, identically, and the strip's condition was a third spelling of the same question. This gives that question one answer, and gives `panePresentation` its first readers. No behaviour change.

Follows #40958. Design: [Panes and Surfaces](https://claude.ai/code/artifact/04da3094-7ead-4ea7-9fa4-0ee8733851f0)

## What was duplicated

`chat-content-layout.tsx` and `chat-route-content.tsx` each spelled out `mainView === "app-editing" && openedAppState && editingConversationId`, and `chat-route-content` separately spelled out the strip as `mainView === "app" && isAppMinimized && openedAppState`. Every one of them restated which fields mean which arrangement, so changing that meaning meant finding all of them.

`viewerPanePresentation` answers it once, and the call sites ask rather than deduce.

## What writing it turned up

**Which surface is the secondary depends on the arrangement.** Beside the app and behind it, the secondary is the conversation, so an unbound one means there is no second surface. Parked to the strip, the app is itself the secondary and the conversation has the surface.

The first version of this used `isAppMinimized || hasBoundConversation` for "is there a secondary", which is wrong for `app-editing` with no bound conversation, and the equivalence table caught it before any render code was touched. That is the sort of thing three separate spellings of a predicate hide.

## Behaviour is unchanged, including where today's answer looks wrong

Today the split renders on any width once the fields say side-by-side; narrow the window while side by side and you get two cramped columns rather than a strip. `viewerPanePresentation` deliberately does not consult the viewport, so that keeps happening.

That is not an oversight. The stored arrangement already reflects the room available when it was chosen, because every path into the side-by-side layout refuses a viewport with no space for two columns. Re-narrowing a stored answer here would be a real behaviour change on window resize, and it belongs with the control that makes position a live preference, not with a refactor that claims to change nothing.

## Verification

Thirty-two combinations of the stored fields are walked against the exact conditions the two layouts used, asserting `"side"` matches the split's and `"bottom"` matches the strip's. `tsc --noEmit` and `eslint` clean, pinned Prettier clean.

Local test runs are blocked in this repo, so the table was also transcribed and enumerated outside the suite before pushing, after a failing table slipped into #40958 by being reasoned through rather than executed.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40966" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->