### PR TITLE
fix(cli): retrieve plugins/skills search for setup prompts

### DIFF
--- a/assistant/src/cli/__tests__/catalog-search-help.test.ts
+++ b/assistant/src/cli/__tests__/catalog-search-help.test.ts
@@ -36,15 +36,15 @@ describe("catalog search help for setup-intent retrieval", () => {
     expect(indexed.toLowerCase()).not.toContain("empty query");
   });
 
-  test("skills help indexes setup, superpowers, and web-search fallback", () => {
+  test("skills help indexes setup as the second stop before web search", () => {
     const indexed = buildCliCommandHelpContent(skillsHelp);
     const search = searchHelp(skillsHelp);
 
     expect(search.helpText).toBeDefined();
-    expect(indexed.toLowerCase()).toContain("superpowers");
+    expect(indexed).toContain("Second stop after plugin search");
     expect(indexed).toContain("Setup <app> for me");
     expect(indexed.toLowerCase()).toContain("before searching the web");
     expect(indexed).toContain("assistant skills search");
-    expect(indexed).toContain("assistant plugins search");
+    expect(indexed).toContain("try web search");
   });
 });

--- a/assistant/src/cli/__tests__/catalog-search-help.test.ts
+++ b/assistant/src/cli/__tests__/catalog-search-help.test.ts
@@ -1,11 +1,10 @@
 /**
- * Memory injection indexes CLI help via {@link buildCliCommandHelpContent}
- * (full help) and surfaces {@link buildCliCommandSummary} (top-level
- * description). Setup prompts like "Setup Natural for me" should retrieve
- * `plugins search` / `skills search` before the model falls back to web search.
+ * Memory injection indexes CLI help via {@link buildCliCommandHelpContent}.
+ * Setup prompts like "Setup <app> for me" should retrieve `plugins search` /
+ * `skills search` before the model falls back to web search.
  *
- * These assertions lock the retrieval phrases in the indexed blob and the
- * injected summary so a later wording change cannot silently drop them.
+ * These assertions lock the retrieval phrases in the indexed blob so a later
+ * wording change cannot silently drop them.
  */
 import { describe, expect, test } from "bun:test";
 
@@ -13,7 +12,9 @@ import { buildCliCommandHelpContent } from "../../plugins/defaults/memory/substr
 import { pluginsHelp } from "../commands/plugins.help.js";
 import { skillsHelp } from "../commands/skills.help.js";
 
-function searchHelp(help: { subcommands?: Array<{ name: string }> }) {
+function searchHelp(
+  help: { subcommands?: Array<{ name: string; helpText?: string }> },
+): { name: string; helpText?: string } {
   const search = help.subcommands?.find((sub) => sub.name === "search");
   if (!search) {
     throw new Error("expected a search subcommand");
@@ -26,41 +27,24 @@ describe("catalog search help for setup-intent retrieval", () => {
     const indexed = buildCliCommandHelpContent(pluginsHelp);
     const search = searchHelp(pluginsHelp);
 
-    expect(pluginsHelp.description.toLowerCase()).toContain("superpowers");
-    expect(pluginsHelp.description.toLowerCase()).toContain("set up");
-    expect(pluginsHelp.description.toLowerCase()).toContain(
-      "before searching the web",
-    );
-
-    expect(search.description.toLowerCase()).toContain("superpowers");
-    expect(search.description.toLowerCase()).toContain("set up");
-    expect(search.description.toLowerCase()).toContain("web search");
-
-    expect(indexed).toContain("Setup Natural for me");
+    expect(search.helpText).toBeDefined();
     expect(indexed.toLowerCase()).toContain("superpowers");
+    expect(indexed).toContain("Setup <app> for me");
     expect(indexed.toLowerCase()).toContain("before searching the web");
-    expect(indexed).toContain("assistant plugins search natural");
+    expect(indexed).toContain("assistant plugins search");
     expect(indexed).toContain("assistant skills search");
+    expect(indexed.toLowerCase()).not.toContain("empty query");
   });
 
   test("skills help indexes setup, superpowers, and web-search fallback", () => {
     const indexed = buildCliCommandHelpContent(skillsHelp);
     const search = searchHelp(skillsHelp);
 
-    expect(skillsHelp.description.toLowerCase()).toContain("superpowers");
-    expect(skillsHelp.description.toLowerCase()).toContain("set up");
-    expect(skillsHelp.description.toLowerCase()).toContain(
-      "before searching the web",
-    );
-
-    expect(search.description.toLowerCase()).toContain("superpowers");
-    expect(search.description.toLowerCase()).toContain("set up");
-    expect(search.description.toLowerCase()).toContain("web search");
-
-    expect(indexed).toContain("Setup Natural for me");
+    expect(search.helpText).toBeDefined();
     expect(indexed.toLowerCase()).toContain("superpowers");
+    expect(indexed).toContain("Setup <app> for me");
     expect(indexed.toLowerCase()).toContain("before searching the web");
-    expect(indexed).toContain("assistant skills search natural");
+    expect(indexed).toContain("assistant skills search");
     expect(indexed).toContain("assistant plugins search");
   });
 });

--- a/assistant/src/cli/__tests__/catalog-search-help.test.ts
+++ b/assistant/src/cli/__tests__/catalog-search-help.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Memory injection indexes CLI help via {@link buildCliCommandHelpContent}
+ * (full help) and surfaces {@link buildCliCommandSummary} (top-level
+ * description). Setup prompts like "Setup Natural for me" should retrieve
+ * `plugins search` / `skills search` before the model falls back to web search.
+ *
+ * These assertions lock the retrieval phrases in the indexed blob and the
+ * injected summary so a later wording change cannot silently drop them.
+ */
+import { describe, expect, test } from "bun:test";
+
+import { buildCliCommandHelpContent } from "../../plugins/defaults/memory/substrate/cli-command-content.js";
+import { pluginsHelp } from "../commands/plugins.help.js";
+import { skillsHelp } from "../commands/skills.help.js";
+
+function searchHelp(help: { subcommands?: Array<{ name: string }> }) {
+  const search = help.subcommands?.find((sub) => sub.name === "search");
+  if (!search) {
+    throw new Error("expected a search subcommand");
+  }
+  return search;
+}
+
+describe("catalog search help for setup-intent retrieval", () => {
+  test("plugins help indexes setup, superpowers, and web-search fallback", () => {
+    const indexed = buildCliCommandHelpContent(pluginsHelp);
+    const search = searchHelp(pluginsHelp);
+
+    expect(pluginsHelp.description.toLowerCase()).toContain("superpowers");
+    expect(pluginsHelp.description.toLowerCase()).toContain("set up");
+    expect(pluginsHelp.description.toLowerCase()).toContain(
+      "before searching the web",
+    );
+
+    expect(search.description.toLowerCase()).toContain("superpowers");
+    expect(search.description.toLowerCase()).toContain("set up");
+    expect(search.description.toLowerCase()).toContain("web search");
+
+    expect(indexed).toContain("Setup Natural for me");
+    expect(indexed.toLowerCase()).toContain("superpowers");
+    expect(indexed.toLowerCase()).toContain("before searching the web");
+    expect(indexed).toContain("assistant plugins search natural");
+    expect(indexed).toContain("assistant skills search");
+  });
+
+  test("skills help indexes setup, superpowers, and web-search fallback", () => {
+    const indexed = buildCliCommandHelpContent(skillsHelp);
+    const search = searchHelp(skillsHelp);
+
+    expect(skillsHelp.description.toLowerCase()).toContain("superpowers");
+    expect(skillsHelp.description.toLowerCase()).toContain("set up");
+    expect(skillsHelp.description.toLowerCase()).toContain(
+      "before searching the web",
+    );
+
+    expect(search.description.toLowerCase()).toContain("superpowers");
+    expect(search.description.toLowerCase()).toContain("set up");
+    expect(search.description.toLowerCase()).toContain("web search");
+
+    expect(indexed).toContain("Setup Natural for me");
+    expect(indexed.toLowerCase()).toContain("superpowers");
+    expect(indexed.toLowerCase()).toContain("before searching the web");
+    expect(indexed).toContain("assistant skills search natural");
+    expect(indexed).toContain("assistant plugins search");
+  });
+});

--- a/assistant/src/cli/commands/plugins.help.ts
+++ b/assistant/src/cli/commands/plugins.help.ts
@@ -10,45 +10,12 @@ import {
 
 export const pluginsHelp: CliCommandHelp = {
   name: "plugins",
-  description:
-    "List, search, install, and manage plugins (superpowers). Search the marketplace when asked to set up, install, or connect a product or service, before searching the web",
+  description: "List, search, install, and manage plugins.",
   helpText: `
-Plugins are superpowers: installable extensions that add skills, tools, and
-integrations. When the user asks to set up, install, connect, or integrate a
-product, service, or app (for example "set up Natural for me"), run
-'assistant plugins search <name>' first. Query the product or plugin name,
-not the full sentence. Search the marketplace before searching the web.
-'list' shows what is already installed; 'search' queries the marketplace.
-
-Examples:
-  $ assistant plugins search natural
-  $ assistant plugins install example
-  $ assistant plugins install example --force
-  $ assistant plugins install https://github.com/owner/repo
-  $ assistant plugins install https://github.com/owner/repo/tree/main/sub/path --name my-plugin
-  $ assistant plugins install example --ref my-feature-branch
-  $ assistant plugins versions example
-  $ assistant plugins versions example --json
-  $ assistant plugins install example --pin <sha> --force
-  $ assistant plugins list
-  $ assistant plugins list --json
-  $ assistant plugins list --all
-  $ assistant plugins list --all --json
-  $ assistant plugins inspect example
-  $ assistant plugins inspect example --json
-  $ assistant plugins diff example
-  $ assistant plugins diff example --json
-  $ assistant plugins upgrade example
-  $ assistant plugins upgrade example --dry-run
-  $ assistant plugins upgrade example --strategy ours
-  $ assistant plugins upgrade example --strategy theirs
-  $ assistant plugins upgrade example --strategy assistant
-  $ assistant plugins search example
-  $ assistant plugins search "^example"
-  $ assistant plugins search example --json
-  $ assistant plugins uninstall example
-  $ assistant plugins enable example
-  $ assistant plugins disable example`,
+Plugins are superpowers: installable extensions that add skills, tools, integrations,
+and so much more from the Vellum Community. When the user asks to set up,
+install, connect, or integrate a product, service, or app, run
+'assistant plugins search <name>' first before searching the web.`,
   subcommands: [
     {
       name: "install",
@@ -176,7 +143,7 @@ Examples:
       name: "search",
       args: "<query>",
       description:
-        "Search the plugin marketplace (superpowers) for a product or service to set up, install, or connect. Prefer this over web search. Query is a case-insensitive regex against plugin names",
+        "Search the plugin marketplace. Query is a case-insensitive regex against plugin names",
       options: [
         {
           flags: "--json",
@@ -186,21 +153,19 @@ Examples:
       helpText: `
 When to use:
   First stop when the user asks to set up, install, connect, or integrate a
-  product, service, or app (for example "Setup Natural for me", "set up Slack",
-  "connect this service"). Search superpowers in the marketplace before
-  searching the web.
+  product, service, or app (for example "Setup <app> for me",
+  "connect this service"). Search here before searching the web.
 
 Arguments:
   query    Case-insensitive regex matched against plugin names, not the full
-           user sentence. Use the product or plugin name: natural, slack.
-           Empty query returns every entry. Anchors like ^example work.
+           user sentence. Use the product or plugin name. Anchors like
+           ^example work.
 
 If a match is found, install it with 'assistant plugins install <name>'.
 If nothing matches, try 'assistant skills search <query>', then web search.
 
 Examples:
-  $ assistant plugins search natural
-  $ assistant plugins search slack
+  $ assistant plugins search example
   $ assistant plugins search "^example"
   $ assistant plugins search example --json`,
     },

--- a/assistant/src/cli/commands/plugins.help.ts
+++ b/assistant/src/cli/commands/plugins.help.ts
@@ -11,9 +11,17 @@ import {
 export const pluginsHelp: CliCommandHelp = {
   name: "plugins",
   description:
-    "List, search, install, and manage external plugins (`list` shows what is installed, `search` queries the marketplace)",
+    "List, search, install, and manage plugins (superpowers). Search the marketplace when asked to set up, install, or connect a product or service, before searching the web",
   helpText: `
+Plugins are superpowers: installable extensions that add skills, tools, and
+integrations. When the user asks to set up, install, connect, or integrate a
+product, service, or app (for example "set up Natural for me"), run
+'assistant plugins search <name>' first. Query the product or plugin name,
+not the full sentence. Search the marketplace before searching the web.
+'list' shows what is already installed; 'search' queries the marketplace.
+
 Examples:
+  $ assistant plugins search natural
   $ assistant plugins install example
   $ assistant plugins install example --force
   $ assistant plugins install https://github.com/owner/repo
@@ -168,13 +176,33 @@ Examples:
       name: "search",
       args: "<query>",
       description:
-        "Search the plugins/marketplace.json catalog for plugin names matching <query> (case-insensitive regex)",
+        "Search the plugin marketplace (superpowers) for a product or service to set up, install, or connect. Prefer this over web search. Query is a case-insensitive regex against plugin names",
       options: [
         {
           flags: "--json",
           description: "Emit machine-readable JSON instead of a table",
         },
       ],
+      helpText: `
+When to use:
+  First stop when the user asks to set up, install, connect, or integrate a
+  product, service, or app (for example "Setup Natural for me", "set up Slack",
+  "connect this service"). Search superpowers in the marketplace before
+  searching the web.
+
+Arguments:
+  query    Case-insensitive regex matched against plugin names, not the full
+           user sentence. Use the product or plugin name: natural, slack.
+           Empty query returns every entry. Anchors like ^example work.
+
+If a match is found, install it with 'assistant plugins install <name>'.
+If nothing matches, try 'assistant skills search <query>', then web search.
+
+Examples:
+  $ assistant plugins search natural
+  $ assistant plugins search slack
+  $ assistant plugins search "^example"
+  $ assistant plugins search example --json`,
     },
     {
       name: "publish",

--- a/assistant/src/cli/commands/skills.help.ts
+++ b/assistant/src/cli/commands/skills.help.ts
@@ -4,16 +4,21 @@ import type { CliCommandHelp } from "../lib/cli-command-help.js";
 
 export const skillsHelp: CliCommandHelp = {
   name: "skills",
-  description: "Browse and install skills from the Vellum catalog",
+  description:
+    "Browse, search, and install skills (superpowers) from the Vellum catalog. Search the catalog when asked to set up or add a capability, before searching the web",
   helpText: `
-Manage skills from the Vellum catalog. Skills extend the assistant's
-capabilities with pre-built workflows and tools.
+Manage skills from the Vellum catalog. Skills are superpowers: pre-built
+workflows and tools that extend the assistant. When the user asks to set up,
+install, or add a capability (for example "set up Natural for me"), run
+'assistant skills search <query>' first. Query the product or capability
+name, not the full sentence. Search the catalog before searching the web.
 
 Examples:
   $ assistant skills list
   $ assistant skills list --json
   $ assistant skills inspect slack
   $ assistant skills inspect resend-setup --json
+  $ assistant skills search natural
   $ assistant skills search react
   $ assistant skills search react --limit 5 --json
   $ assistant skills install weather
@@ -60,7 +65,7 @@ Examples:
       name: "search",
       args: "<query>",
       description:
-        "Search the Vellum catalog, skills.sh, and clawhub community registries",
+        "Search the Vellum catalog, skills.sh, and clawhub for skills (superpowers) to set up or add a capability. Prefer this over web search",
       options: [
         {
           flags: "--limit <n>",
@@ -70,16 +75,27 @@ Examples:
         { flags: "--json", description: "Machine-readable JSON output" },
       ],
       helpText: `
+When to use:
+  First stop when the user asks to set up, install, or add a capability
+  (for example "Setup Natural for me", "add a skill for file management").
+  Search superpowers in the skills catalog before searching the web.
+
 Arguments:
   query    Free-text search term matched against skill names, descriptions,
-           and tags. Searches the Vellum catalog, the skills.sh community
+           and tags. Use the product or capability name, not the full user
+           sentence. Searches the Vellum catalog, the skills.sh community
            registry, and the clawhub registry.
 
 Displays results from all sources with clear labels. When a skill ID
 exists in both the Vellum catalog and a community registry, a conflict
 note is shown with guidance on which install command to use.
 
+If a catalog match is found, install it with 'assistant skills install <id>'.
+If a community match is found, add it with 'assistant skills add <source>'.
+If nothing matches, try 'assistant plugins search <query>', then web search.
+
 Examples:
+  $ assistant skills search natural
   $ assistant skills search react
   $ assistant skills search "file management" --limit 3
   $ assistant skills search deploy --json`,

--- a/assistant/src/cli/commands/skills.help.ts
+++ b/assistant/src/cli/commands/skills.help.ts
@@ -6,10 +6,8 @@ export const skillsHelp: CliCommandHelp = {
   name: "skills",
   description: "Browse and install skills from the Vellum catalog",
   helpText: `
-Manage skills from the Vellum catalog. Skills are superpowers: pre-built
-workflows and tools that extend the assistant. When the user asks to set up,
-install, or add a capability, run 'assistant skills search <query>' first
-before searching the web.`,
+Manage skills from the Vellum catalog. Skills are instructions of
+workflows and tools that teach the assistant when dynamically relevant.`,
   subcommands: [
     {
       name: "list",
@@ -60,8 +58,8 @@ Examples:
       ],
       helpText: `
 When to use:
-  First stop when the user asks to set up, install, or add a capability
-  (for example "Setup <app> for me", "add a skill for file management").
+  Second stop after plugin search when the user asks to set up, install, or
+  add a capability (for example "Setup <app> for me", "add a skill for file management").
   Search here before searching the web.
 
 Arguments:
@@ -76,7 +74,7 @@ note is shown with guidance on which install command to use.
 
 If a catalog match is found, install it with 'assistant skills install <id>'.
 If a community match is found, add it with 'assistant skills add <source>'.
-If nothing matches, try 'assistant plugins search <query>', then web search.
+If nothing matches, try web search.
 
 Examples:
   $ assistant skills search react

--- a/assistant/src/cli/commands/skills.help.ts
+++ b/assistant/src/cli/commands/skills.help.ts
@@ -4,28 +4,12 @@ import type { CliCommandHelp } from "../lib/cli-command-help.js";
 
 export const skillsHelp: CliCommandHelp = {
   name: "skills",
-  description:
-    "Browse, search, and install skills (superpowers) from the Vellum catalog. Search the catalog when asked to set up or add a capability, before searching the web",
+  description: "Browse and install skills from the Vellum catalog",
   helpText: `
 Manage skills from the Vellum catalog. Skills are superpowers: pre-built
 workflows and tools that extend the assistant. When the user asks to set up,
-install, or add a capability (for example "set up Natural for me"), run
-'assistant skills search <query>' first. Query the product or capability
-name, not the full sentence. Search the catalog before searching the web.
-
-Examples:
-  $ assistant skills list
-  $ assistant skills list --json
-  $ assistant skills inspect slack
-  $ assistant skills inspect resend-setup --json
-  $ assistant skills search natural
-  $ assistant skills search react
-  $ assistant skills search react --limit 5 --json
-  $ assistant skills install weather
-  $ assistant skills install weather --overwrite
-  $ assistant skills uninstall weather
-  $ assistant skills add vercel-labs/skills@find-skills
-  $ assistant skills add vercel-labs/skills/find-skills --overwrite`,
+install, or add a capability, run 'assistant skills search <query>' first
+before searching the web.`,
   subcommands: [
     {
       name: "list",
@@ -65,7 +49,7 @@ Examples:
       name: "search",
       args: "<query>",
       description:
-        "Search the Vellum catalog, skills.sh, and clawhub for skills (superpowers) to set up or add a capability. Prefer this over web search",
+        "Search the Vellum catalog, skills.sh, and clawhub community registries",
       options: [
         {
           flags: "--limit <n>",
@@ -77,8 +61,8 @@ Examples:
       helpText: `
 When to use:
   First stop when the user asks to set up, install, or add a capability
-  (for example "Setup Natural for me", "add a skill for file management").
-  Search superpowers in the skills catalog before searching the web.
+  (for example "Setup <app> for me", "add a skill for file management").
+  Search here before searching the web.
 
 Arguments:
   query    Free-text search term matched against skill names, descriptions,
@@ -95,7 +79,6 @@ If a community match is found, add it with 'assistant skills add <source>'.
 If nothing matches, try 'assistant plugins search <query>', then web search.
 
 Examples:
-  $ assistant skills search natural
   $ assistant skills search react
   $ assistant skills search "file management" --limit 3
   $ assistant skills search deploy --json`,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan
A user prompted their assistant with "Setup Natural for me". For those setup requests, the assistant should search superpowers (`plugins search`, then `skills search`) before falling back to web search. Memory injection indexes CLI `--help` (full text), so this change adds setup-intent phrasing to those commands so they get retrieved.

## Summary
- Keep setup-intent phrasing in `plugins` / `skills` `search` helpText so memory retrieval can hit catalog search before web search.
- Keep one-line descriptions short. Drop named plugins, parent-level example lists, and the unreachable empty-query note.
- Plugin search is the first stop for setup prompts. Skills search is the second stop, then web search. Skills are described as instructions, not superpowers.

## Test plan
- `cd assistant && bun test src/cli/__tests__/catalog-search-help.test.ts src/cli/__tests__/cli-command-help-coverage.test.ts` (3 pass)
- `cd assistant && bun test src/cli/commands/__tests__/skills.test.ts --grep "skills search"` (4 pass)
- `bunx eslint` on the changed files (clean)

## Risk
Low. Help text and a retrieval-phrase test only. Existing installs pick this up on the next CLI-command memory reseed.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-70178224-8407-4546-b1df-1f564c26c46b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-70178224-8407-4546-b1df-1f564c26c46b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

