### PR TITLE
fix(web): guard the question reconcile on a revision, not on the card

### DIFF
--- a/clients/web/src/domains/chat/hooks/use-conversation-history-pending-question.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-conversation-history-pending-question.test.tsx
@@ -340,6 +340,38 @@ describe("ask_question restore on a committed snapshot", () => {
     });
   });
 
+  test("ignores a read whose prompt arrived and settled while it was in flight", async () => {
+    // GIVEN a reconcile whose read is still in flight, started while no card
+    // was on screen
+    currentMessages = [];
+    deferredCalls = [];
+    renderHistory();
+    await waitFor(() => {
+      expect(deferredCalls?.length).toBe(1);
+    });
+
+    // WHEN a prompt arrives and is then resolved inside that same window (the
+    // live `question_request` followed by its `interaction_resolved`, or a fast
+    // answer), returning the slot to the null it started from
+    useInteractionStore
+      .getState()
+      .showQuestion({ requestId: "req-fleeting", entries: ENTRIES });
+    useInteractionStore.getState().dismissQuestionIfMatches("req-fleeting");
+    expect(useInteractionStore.getState().pendingQuestion).toBeNull();
+
+    // AND the read lands, still carrying the prompt it saw mid-flight
+    deferredCalls?.[0]?.({
+      pendingQuestion: { requestId: "req-fleeting", entries: ENTRIES },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // THEN the settled prompt is not put back on screen. Comparing the card
+    // rather than a revision cannot catch this: the slot ends on the same
+    // `null` it began on, so the response looks like it landed on an untouched
+    // store.
+    expect(useInteractionStore.getState().pendingQuestion).toBeNull();
+  });
+
   test("ignores a read that a newer one has already overtaken", async () => {
     // GIVEN two reconciles whose reads are both in flight, which happens when
     // two snapshots commit close together (a turn-end reseed landing on top of

--- a/clients/web/src/domains/chat/hooks/use-conversation-history.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-history.ts
@@ -66,7 +66,6 @@ import {
 } from "@/domains/chat/utils/send-message-utils";
 import type { AssistantStateKind } from "@/domains/chat/types";
 import type { DisplayMessage } from "@/domains/chat/types/types";
-import type { PendingQuestionState } from "@/types/interaction-ui-types";
 import {
   getPendingInteractions,
   type ConversationPendingInteractions,
@@ -142,17 +141,20 @@ function surfaceContentEqual(a: unknown, b: unknown): boolean {
  * re-raises a prompt that was answered before the switch and nothing ever takes
  * it down again. See `pending-question.ts`.
  *
- * `before` is the card as it stood when the request was issued. Anything that
- * moved it since (a live `question_request`, the user's own submit) is strictly
+ * `revisionBefore` is the question slot's revision when the request was issued.
+ * Anything that moved the slot since (a live `question_request`, the user's own
+ * submit, a prompt that both arrived and settled inside the await) is strictly
  * newer than this response and keeps its claim; the next committed snapshot
- * reconciles again.
+ * reconciles again. This is a revision rather than the card itself because a
+ * prompt that comes and goes returns the slot to the same `null` it started
+ * from, which a value comparison reads as "nothing happened".
  */
 function applyReportedQuestion(params: {
   reported: ReportedQuestion;
-  before: PendingQuestionState | null;
+  revisionBefore: number;
   messages: DisplayMessage[];
 }): void {
-  const { reported, before, messages } = params;
+  const { reported, revisionBefore, messages } = params;
   const interactionStore = useInteractionStore.getState();
 
   if (reported === undefined) {
@@ -163,10 +165,10 @@ function applyReportedQuestion(params: {
     return;
   }
 
-  const current = interactionStore.pendingQuestion;
-  if (current !== before) {
+  if (interactionStore.questionRevision !== revisionBefore) {
     return;
   }
+  const current = interactionStore.pendingQuestion;
 
   const action = decidePendingQuestion({ reported, current });
   if (action.kind === "raise") {
@@ -465,7 +467,8 @@ export function useConversationHistory({
     const requestedConversationId = activeConversationId;
     // Read before the fetch so the question reconcile below can tell whether
     // anything moved underneath it while the request was in flight.
-    const questionBeforeFetch = useInteractionStore.getState().pendingQuestion;
+    const questionRevisionBeforeFetch =
+      useInteractionStore.getState().questionRevision;
     const generation = ++reconcileGenerationRef.current;
     void (async () => {
       // A read that never landed carries no opinion, exactly like an assistant
@@ -499,7 +502,7 @@ export function useConversationHistory({
       }
       applyReportedQuestion({
         reported: interactions?.pendingQuestion,
-        before: questionBeforeFetch,
+        revisionBefore: questionRevisionBeforeFetch,
         messages: pagination.messages,
       });
       if (!interactions) {
@@ -544,9 +547,9 @@ export function useConversationHistory({
             .removeAttentionConversationId(requestedConversationId);
         }
       } catch {
-        // Unchanged from before this reconcile existed: a payload the secret /
-        // confirmation parsers choke on leaves both prompts and the attention
-        // key as they are, rather than rejecting inside a void async block.
+        // A payload the secret or confirmation parsers choke on leaves both
+        // prompts and the attention key untouched, rather than rejecting
+        // inside a void async block.
       }
     })();
     // `pagination.*` other than `dataUpdatedAt` intentionally excluded: they all

--- a/clients/web/src/domains/chat/interaction-store.ts
+++ b/clients/web/src/domains/chat/interaction-store.ts
@@ -39,6 +39,16 @@ export interface InteractionState {
   contactRequestAccepted: boolean;
 
   pendingQuestion: PendingQuestionState | null;
+  /**
+   * Bumped on every change to {@link pendingQuestion}, so a reader that has to
+   * leave and come back can tell whether the slot moved while it was away.
+   * Comparing the value cannot answer that: a prompt that arrives and settles
+   * inside one await returns the slot to `null`, which is indistinguishable
+   * from never having changed, and a reconcile that trusted the comparison
+   * would raise the settled prompt back onto the screen. Monotonic, never
+   * reset, and meaningless in absolute terms; only differences matter.
+   */
+  questionRevision: number;
   isSubmittingQuestion: boolean;
   /** When true, the question card is hidden but `pendingQuestion` stays set
    *  so the composer free-text intercept still routes to `submitQuestionResponse`. */
@@ -158,6 +168,7 @@ const INITIAL_STATE: InteractionState = {
   contactRequestAccepted: false,
 
   pendingQuestion: null,
+  questionRevision: 0,
   isSubmittingQuestion: false,
   isQuestionCardDismissed: false,
 
@@ -278,33 +289,36 @@ const useInteractionStoreBase = create<InteractionStore>()((set, get) => ({
 
   // ----- Question -----
   showQuestion: (payload) =>
-    set({
+    set((state) => ({
       pendingQuestion: payload,
+      questionRevision: state.questionRevision + 1,
       isSubmittingQuestion: false,
       isQuestionCardDismissed: false,
-    }),
+    })),
 
   submitQuestionStart: () => set({ isSubmittingQuestion: true }),
 
   submitQuestionEnd: () => set({ isSubmittingQuestion: false }),
 
   dismissQuestion: () =>
-    set({
+    set((state) => ({
       pendingQuestion: null,
+      questionRevision: state.questionRevision + 1,
       isSubmittingQuestion: false,
       isQuestionCardDismissed: false,
-    }),
+    })),
 
   dismissQuestionIfMatches: (requestId) => {
     const { pendingQuestion } = get();
     if (!pendingQuestion || pendingQuestion.requestId !== requestId) {
       return;
     }
-    set({
+    set((state) => ({
       pendingQuestion: null,
+      questionRevision: state.questionRevision + 1,
       isSubmittingQuestion: false,
       isQuestionCardDismissed: false,
-    });
+    }));
   },
 
   dismissQuestionCard: () => set({ isQuestionCardDismissed: true }),
@@ -383,6 +397,11 @@ const useInteractionStoreBase = create<InteractionStore>()((set, get) => ({
     set((state) => ({
       ...INITIAL_STATE,
       pendingAcpConnect: state.pendingAcpConnect,
+      // A conversation switch drops the card, which is a change like any other:
+      // carry the counter forward and advance it rather than restarting from
+      // the initial zero. Restarting would let a read issued before the switch
+      // compare equal to the state after it.
+      questionRevision: state.questionRevision + 1,
     })),
 }));
 


### PR DESCRIPTION
## TL;DR

The in-flight guard #40923 added compares the question card against the value captured when the read was issued. That cannot see a prompt which both arrives and settles inside the await, so a stale response can put an answered prompt back on screen. Compare a revision instead.

Follow-up to #40923, reported by Codex on that PR three minutes before it merged.

## The bug

`applyReportedQuestion` bailed when `current !== before`. Both values are the card itself, so this sequence defeats it:

1. a reconcile starts with no card on screen, capturing `before = null`
2. mid-read a `question_request` arrives (`showQuestion`), and is then resolved, submitted, or dismissed (`dismissQuestionIfMatches`), returning the slot to `null`
3. the read lands still reporting that prompt
4. `current === before`, because both are `null`, so the guard passes
5. the settled prompt is raised again

The generation guard added in the same PR does not cover it: no newer reconcile started, so the generation still matches. It answers "did a newer read overtake me", which is a different question from "did the slot move underneath me".

Reachable whenever a question resolves quickly while a committed snapshot's read is in flight. The result is the exact symptom #40923 exists to remove.

## The fix

`questionRevision` on the interaction store, bumped by every mutator that changes `pendingQuestion` (`showQuestion`, `dismissQuestion`, `dismissQuestionIfMatches` when it matches). The reconcile captures it at issue time and bails if it moved.

`resetAll` advances the counter rather than restoring the initial zero. Resetting a monotonic counter would reintroduce the same defect across a conversation switch: a read issued before the switch would compare equal to the state after it.

Both guards stay, because they answer different questions:

| Guard | Answers |
| --- | --- |
| reconcile generation | has a newer reconcile overtaken this read? |
| question revision | has the question slot moved since this read was issued? |

## What changes for the user

| Situation | Before | After |
| --- | --- | --- |
| Answer a question while a snapshot read is in flight | The answered prompt can reappear, and answering it again does nothing (404) | Stays answered |
| Dismiss a card while a read is in flight | Same, reopened | Stays dismissed |
| Everything else | Unchanged | Unchanged |

This also closes the dismiss-window race listed as deferred on #40923: a local dismiss bumps the revision, so a read that predates it can no longer re-raise the card.

## Why it is safe

- The guard is strictly more conservative than the one it replaces. Every case that bailed before still bails; it additionally catches the ones where the value returned to where it started.
- Bailing means doing nothing. The next committed snapshot reconciles again, so a spurious bail costs one cycle, never a stranded card.
- Nothing on the write path changed, and the daemon is untouched.
- No wire or contract change.

## Testing

Local test runs are blocked in this environment, so these run first in CI. A regression test drives the exact sequence: a read parked in flight, a prompt raised and settled inside that window, then the stale response delivered. It fails against the value comparison, since the slot ends on the same `null` it began on.

The comment rewrite is the second Codex finding on the same review: a comment that described the diff ("Unchanged from before this reconcile existed") rather than the current behavior, which the repo's comment rule forbids.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40969" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->