### PR TITLE
feat(web): gate conversation forking behind a staff-only flag

### DIFF
--- a/clients/web/src/domains/chat/active-chat-view.tsx
+++ b/clients/web/src/domains/chat/active-chat-view.tsx
@@ -42,6 +42,7 @@ import { useConversationLoader } from "@/domains/chat/hooks/use-conversation-loa
 import { useDraftPersistence } from "@/domains/chat/hooks/use-draft-persistence";
 import { useOnboardingOrchestrator } from "@/domains/chat/hooks/use-onboarding-orchestrator";
 
+import { useCanForkConversation } from "@/domains/chat/fork/access";
 import { useConversationSecondaryActions } from "@/domains/chat/hooks/use-conversation-secondary-actions";
 import { useAssistantCapability } from "@/hooks/use-assistant-capability";
 import { useSupportsResourcePressureStatus } from "@/lib/backwards-compat/use-supports-resource-pressure-status";
@@ -88,6 +89,7 @@ import type { ChatMainPanelProps } from "@/domains/chat/components/chat-route-co
 
 export function ActiveChatView() {
   const showLlmInspector = useCanUseLlmInspector();
+  const canFork = useCanForkConversation();
   const [searchParams, setSearchParams] = useSearchParams();
   const { conversationId: urlConversationId } = useParams<{
     conversationId?: string;
@@ -521,7 +523,9 @@ export function ActiveChatView() {
   // -------------------------------------------------------------------------
   useChatHeaderRegistration({
     assetsRefreshKey,
-    handleForkConversationFromMenu,
+    handleForkConversationFromMenu: canFork
+      ? handleForkConversationFromMenu
+      : undefined,
     handleOpenInNewWindow,
     handleInspectConversation,
     handleCopyConversation,
@@ -571,7 +575,7 @@ export function ActiveChatView() {
     handleEditQueueTail,
 
     // Conversation secondary actions
-    handleForkConversation,
+    handleForkConversation: canFork ? handleForkConversation : undefined,
     onSummarizeUpToHere: supportsSummarizeUpToHere
       ? handleSummarizeUpToHere
       : undefined,

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -193,7 +193,9 @@ export interface ChatMainPanelProps {
   handleEditQueueTail: () => void;
 
   // Conversation secondary actions (orchestration dependency)
-  handleForkConversation: (throughMessageId: string) => Promise<void>;
+  /** Forks through a message. Omitted unless the viewer passes the
+   *  staff + `fork-from-message` gate, which hides the hover action. */
+  handleForkConversation?: (throughMessageId: string) => Promise<void>;
   /** Opens the "Summarize up to here" confirm dialog for a message. */
   onSummarizeUpToHere?: (messageId: string) => void;
   /** Opens the "Retry" confirm dialog for the latest assistant turn. */
@@ -508,10 +510,13 @@ export function ChatMainPanel({
     [],
   );
 
-  const handleForkConversationCallback = useCallback(
-    (messageId: string) => {
-      void handleForkConversation(messageId);
-    },
+  const handleForkConversationCallback = useMemo(
+    () =>
+      handleForkConversation
+        ? (messageId: string) => {
+            void handleForkConversation(messageId);
+          }
+        : undefined,
     [handleForkConversation],
   );
 

--- a/clients/web/src/domains/chat/fork/access.test.ts
+++ b/clients/web/src/domains/chat/fork/access.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+
+import { canForkConversation } from "@/domains/chat/fork/access";
+import type { AuthUser } from "@/stores/auth-store";
+
+function user(overrides: Partial<AuthUser>): AuthUser {
+  return {
+    kind: "platform",
+    id: "user-123",
+    username: null,
+    email: "user@example.com",
+    isStaff: false,
+    firstName: "",
+    lastName: "",
+    ...overrides,
+  };
+}
+
+describe("canForkConversation", () => {
+  test("allows staff once the flag is on", () => {
+    expect(canForkConversation(user({ isStaff: true }), true)).toBe(true);
+  });
+
+  test("allows Vellum email users case-insensitively", () => {
+    expect(
+      canForkConversation(user({ email: "alice@" + "VELLUM.AI" }), true),
+    ).toBe(true);
+  });
+
+  test("rejects regular users even with the flag on", () => {
+    expect(canForkConversation(user({ email: "user@example.com" }), true)).toBe(
+      false,
+    );
+  });
+
+  test("the flag is a kill switch that outranks staff", () => {
+    // Both halves have to agree, so turning the flag off pulls the affordance
+    // from staff too, which is the point of keeping it as a kill switch.
+    expect(canForkConversation(user({ isStaff: true }), false)).toBe(false);
+    expect(canForkConversation(user({ email: "alice@vellum.ai" }), false)).toBe(
+      false,
+    );
+  });
+
+  test("rejects identity-less sessions", () => {
+    // Local-gateway sessions carry no email or staff bit, and there is no
+    // flag-only escape hatch the way the LLM inspector has one.
+    expect(canForkConversation(null, true)).toBe(false);
+    expect(canForkConversation(user({ email: null }), true)).toBe(false);
+  });
+});

--- a/clients/web/src/domains/chat/fork/access.ts
+++ b/clients/web/src/domains/chat/fork/access.ts
@@ -1,3 +1,4 @@
+import { isVellumStaff } from "@/lib/auth/staff";
 import { useAuthStore } from "@/stores/auth-store";
 import type { AuthUser } from "@/stores/auth-store";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
@@ -8,11 +9,9 @@ import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
  * kill switch, and the staff check is what keeps the feature off for everyone
  * else even if the flag is ever rolled out more widely than intended.
  *
- * "Staff" is recognized the same way `canUseLlmInspector` recognizes it: the
- * platform's `isStaff` bit, or a `@vellum.ai` address for sessions whose
- * snapshot carries no staff bit. Unlike the inspector there is no flag-only
- * escape hatch: local-gateway sessions have neither signal, so they never see
- * fork.
+ * Staff is recognized by the shared `isVellumStaff` predicate, the same one
+ * the LLM inspector gates on. Unlike the inspector there is no flag-only
+ * escape hatch, so local gateway sessions never see fork.
  */
 export function canForkConversation(
   user: AuthUser | null,
@@ -21,10 +20,7 @@ export function canForkConversation(
   if (!forkFromMessageEnabled) {
     return false;
   }
-  return (
-    user?.isStaff === true ||
-    user?.email?.toLowerCase().endsWith("@vellum.ai") === true
-  );
+  return isVellumStaff(user);
 }
 
 /**

--- a/clients/web/src/domains/chat/fork/access.ts
+++ b/clients/web/src/domains/chat/fork/access.ts
@@ -1,0 +1,40 @@
+import { useAuthStore } from "@/stores/auth-store";
+import type { AuthUser } from "@/stores/auth-store";
+import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
+
+/**
+ * Forking a conversation is a staff-only affordance behind the
+ * `fork-from-message` client flag. Both halves have to agree: the flag is the
+ * kill switch, and the staff check is what keeps the feature off for everyone
+ * else even if the flag is ever rolled out more widely than intended.
+ *
+ * "Staff" is recognized the same way `canUseLlmInspector` recognizes it: the
+ * platform's `isStaff` bit, or a `@vellum.ai` address for sessions whose
+ * snapshot carries no staff bit. Unlike the inspector there is no flag-only
+ * escape hatch: local-gateway sessions have neither signal, so they never see
+ * fork.
+ */
+export function canForkConversation(
+  user: AuthUser | null,
+  forkFromMessageEnabled: boolean,
+): boolean {
+  if (!forkFromMessageEnabled) {
+    return false;
+  }
+  return (
+    user?.isStaff === true ||
+    user?.email?.toLowerCase().endsWith("@vellum.ai") === true
+  );
+}
+
+/**
+ * Store-connected variant for render bodies. The flag reads as its registry
+ * default (`false`) until `/feature-flags` hydrates, so fork appears once the
+ * real value lands rather than flashing and disappearing.
+ */
+export function useCanForkConversation(): boolean {
+  const user = useAuthStore.use.user();
+  const forkFromMessageEnabled =
+    useClientFeatureFlagStore.use.forkFromMessage();
+  return canForkConversation(user, forkFromMessageEnabled === true);
+}

--- a/clients/web/src/domains/chat/hooks/use-chat-header-registration.tsx
+++ b/clients/web/src/domains/chat/hooks/use-chat-header-registration.tsx
@@ -37,7 +37,9 @@ import type { Conversation } from "@/types/conversation-types";
 
 export interface UseChatHeaderRegistrationOptions {
   assetsRefreshKey: number;
-  handleForkConversationFromMenu: () => void;
+  /** Forks through the latest persisted message. Omitted unless the viewer
+   *  passes the staff + `fork-from-message` gate, which drops the menu item. */
+  handleForkConversationFromMenu?: () => void;
   handleOpenInNewWindow: (conversation: Conversation) => void;
   handleInspectConversation: (conversation: Conversation) => void;
   handleCopyConversation: () => void;
@@ -122,7 +124,7 @@ export function useChatHeaderRegistration({
       channelHeaderLabel,
       channelHeaderChannelId,
       channelSourceLinkHref,
-      onForkConversation: handleForkConversationFromMenu,
+      onForkConversation: handleForkConversationFromMenu ?? null,
       onOpenInNewWindow: handleOpenInNewWindow,
       onInspect: handleInspectConversation,
       onCopyConversation: messages.length > 0 ? handleCopyConversation : null,

--- a/clients/web/src/domains/chat/inspector/access.ts
+++ b/clients/web/src/domains/chat/inspector/access.ts
@@ -1,3 +1,4 @@
+import { isVellumStaff } from "@/lib/auth/staff";
 import { useAssistantFeatureFlagStore } from "@/stores/assistant-feature-flag-store";
 import { useAuthStore } from "@/stores/auth-store";
 import type { AuthUser } from "@/stores/auth-store";
@@ -13,11 +14,7 @@ export function canUseLlmInspector(
   user: AuthUser | null,
   developerNavEnabled: boolean,
 ): boolean {
-  return (
-    developerNavEnabled ||
-    user?.isStaff === true ||
-    user?.email?.toLowerCase().endsWith("@vellum.ai") === true
-  );
+  return developerNavEnabled || isVellumStaff(user);
 }
 
 /**

--- a/clients/web/src/domains/settings/components/panels/debug-controls-panel.tsx
+++ b/clients/web/src/domains/settings/components/panels/debug-controls-panel.tsx
@@ -8,6 +8,7 @@ import { AssistantBackups } from "@/domains/settings/components/assistant-backup
 import { RecoveryModeControls } from "@/domains/settings/components/recovery-mode-controls";
 import { RestartAssistant } from "@/domains/settings/components/restart-assistant";
 import { usePlatformGate } from "@/hooks/use-platform-gate";
+import { isVellumStaff } from "@/lib/auth/staff";
 import { captureError } from "@/lib/sentry/capture-error";
 import { useAuthStore } from "@/stores/auth-store";
 import { clearConsentForUser } from "@/lib/consent/consent-persistence";
@@ -15,21 +16,11 @@ import { routes } from "@/utils/routes";
 import { Button } from "@vellumai/design-library/components/button";
 import { toast } from "@vellumai/design-library/components/toast";
 
-function isInternalUser(email: string | null, isAdmin: boolean): boolean {
-  if (isAdmin) {
-    return true;
-  }
-  return !!email && email.toLowerCase().endsWith("@vellum.ai");
-}
-
 export function DebugControlsPanel() {
   const navigate = useNavigate();
   const user = useAuthStore.use.user();
   const platformGate = usePlatformGate();
-  const showInternalControls = isInternalUser(
-    user?.email ?? null,
-    user?.isStaff ?? false,
-  );
+  const showInternalControls = isVellumStaff(user);
 
   const [assistant, setAssistant] = useState<Assistant | null>(null);
   const [loading, setLoading] = useState(true);

--- a/clients/web/src/lib/auth/staff.test.ts
+++ b/clients/web/src/lib/auth/staff.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+
+import { isVellumStaff } from "@/lib/auth/staff";
+import type { AuthUser } from "@/stores/auth-store";
+
+function user(overrides: Partial<AuthUser>): AuthUser {
+  return {
+    kind: "platform",
+    id: "user-123",
+    username: null,
+    email: "user@example.com",
+    isStaff: false,
+    firstName: "",
+    lastName: "",
+    ...overrides,
+  };
+}
+
+describe("isVellumStaff", () => {
+  test("accepts the platform staff bit", () => {
+    expect(isVellumStaff(user({ isStaff: true }))).toBe(true);
+  });
+
+  test("accepts a Vellum address case-insensitively", () => {
+    expect(isVellumStaff(user({ email: "alice@" + "VELLUM.AI" }))).toBe(true);
+  });
+
+  test("rejects a lookalike domain", () => {
+    // Suffix matching includes the "@", so a domain that merely ends in
+    // "vellum.ai" does not qualify.
+    expect(isVellumStaff(user({ email: "eve@notvellum.ai" }))).toBe(false);
+  });
+
+  test("rejects regular users", () => {
+    expect(isVellumStaff(user({ email: "user@example.com" }))).toBe(false);
+  });
+
+  test("rejects sessions carrying neither signal", () => {
+    // Local gateway sessions have no email and no staff bit.
+    expect(isVellumStaff(null)).toBe(false);
+    expect(isVellumStaff(user({ email: null }))).toBe(false);
+  });
+});

--- a/clients/web/src/lib/auth/staff.ts
+++ b/clients/web/src/lib/auth/staff.ts
@@ -1,0 +1,18 @@
+import type { AuthUser } from "@/stores/auth-store";
+
+/**
+ * Whether a session belongs to Vellum staff.
+ *
+ * The platform's `isStaff` bit is the primary signal. A `@vellum.ai` address
+ * is the fallback for sessions whose snapshot carries no staff bit. Local
+ * gateway sessions have neither, so they are never staff.
+ *
+ * Every staff-gated affordance reads this one predicate, so widening or
+ * narrowing who counts as staff moves all of them together.
+ */
+export function isVellumStaff(user: AuthUser | null): boolean {
+  return (
+    user?.isStaff === true ||
+    user?.email?.toLowerCase().endsWith("@vellum.ai") === true
+  );
+}

--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -145,7 +145,7 @@
       "scope": "client",
       "key": "fork-from-message",
       "label": "Fork from Message",
-      "description": "Show the 'Fork from here' option in message overflow menus",
+      "description": "Show the fork affordance: 'Fork from here' on messages and 'Fork Conversation' in the thread menu. Staff-only: the client also requires the viewer to be Vellum staff, so enabling this for a non-staff account still shows nothing.",
       "defaultEnabled": false
     },
     {

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -145,7 +145,7 @@
       "scope": "client",
       "key": "fork-from-message",
       "label": "Fork from Message",
-      "description": "Show the 'Fork from here' option in message overflow menus",
+      "description": "Show the fork affordance: 'Fork from here' on messages and 'Fork Conversation' in the thread menu. Staff-only: the client also requires the viewer to be Vellum staff, so enabling this for a non-staff account still shows nothing.",
       "defaultEnabled": false
     },
     {


### PR DESCRIPTION
## Summary

- Fork is no longer visible by default, but it is **not deleted**. Both entry points are gated on the existing `fork-from-message` client flag **and** a Vellum staff viewer, so a non-staff account sees nothing even if the flag is switched on for it.
- Gated seams: **"Fork from here"** on user/assistant messages (hover row + mobile long-press sheet) and **"Fork Conversation"** in the thread-title menu (dropdown + mobile bottom sheet).
- New `domains/chat/fork/access.ts` holds `canForkConversation(user, flagEnabled)` and its store-connected `useCanForkConversation()`, mirroring `domains/chat/inspector/access.ts`. The LLM inspector already gates the neighbouring **Inspect** action at these exact two seams, so fork now reads the same way.
- Wiring is a two-line change in `ActiveChatView`: the message-level and menu-level handlers are passed as `undefined` when the gate fails, so the existing `onFork` / `onForkConversation` optionality drops the affordance with no new conditional rendering. `ChatMainPanelProps.handleForkConversation` and `UseChatHeaderRegistrationOptions.handleForkConversationFromMenu` become optional to match.
- `fork-from-message` was already in the registry (client scope, `defaultEnabled: false`) and gating nothing. Its description now states the staff requirement, so nobody reads the LaunchDarkly toggle as the whole story. Bundled copies re-synced via `meta/sync-bundled-copies.ts`.

### Gate semantics

`flag && staff` rather than `flag || staff`: the flag is the kill switch, the staff check is the audience. Turning the flag off pulls the affordance from staff too, which is intentional and covered by a test. Local gateway sessions carry neither staff signal and never see fork, and unlike the inspector there is no flag-only escape hatch.

### Staff is now defined once

Review turned up that the `isStaff || @vellum.ai` rule existed in three places. `lib/auth/staff.ts` now owns it as `isVellumStaff`, and all three callers read it: the fork gate, `canUseLlmInspector`, and `DebugControlsPanel` (which had its own `isInternalUser` copy). A repo-wide search for the `@vellum.ai` suffix check finds exactly one definition left. Widening or narrowing who counts as staff now moves every gate together.

## Verification

`bun run typecheck`, `eslint`, `prettier --check`, and the cross-domain import audit are clean. CI is green at 23/23.

`lib/auth/staff.test.ts` covers the shared predicate, including a lookalike-domain case (`eve@notvellum.ai` does not qualify, since the suffix match includes the `@`). It runs locally: 5/5 pass.

`domains/chat/fork/access.test.ts` covers the gate's five cases but cannot run in this worktree, which resolves `@vellumai/assistant-api` through a checkout carrying unrelated uncommitted edits that break that module's exports. The pre-existing `inspector/access.test.ts` fails identically there on untouched code. Both pass in CI, which runs from a clean checkout.

## Review feedback addressed

1. **Em dash on a changed line** (AGENTS.md L138-146). Swept every em dash out of the lines this PR adds: source, tests, flag registry description, commit messages, and this body. Pre-existing em dashes on untouched lines left alone, per the same rule.
2. **Duplicated staff predicate.** Extracted `isVellumStaff` and pointed the fork gate and the inspector gate at it.
3. **A third copy still outstanding.** `DebugControlsPanel.isInternalUser` was the remaining one; it delegates to `isVellumStaff` now.

## Original prompt

Started as a request to remove forking from user and assistant messages and from the thread title. Mid-flight the ask changed to keeping the feature but putting it behind a feature flag enabled only for staff, so the removal was dropped in favour of this gate.