### PR TITLE
fix(web): apply the reconcile's ordering rule to every branch

### DIFF
--- a/clients/web/src/domains/chat/hooks/use-conversation-history-pending-question.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-conversation-history-pending-question.test.tsx
@@ -372,6 +372,31 @@ describe("ask_question restore on a committed snapshot", () => {
     expect(useInteractionStore.getState().pendingQuestion).toBeNull();
   });
 
+  test("does not re-raise from the marker when the slot moved mid-read", async () => {
+    // GIVEN a legacy assistant (no `pendingQuestion` key, so the marker is the
+    // only source) and a snapshot still carrying the marker for `req-1`
+    deferredCalls = [];
+    renderHistory();
+    await waitFor(() => {
+      expect(deferredCalls?.length).toBe(1);
+    });
+
+    // WHEN that prompt arrives and settles while the read is in flight
+    useInteractionStore
+      .getState()
+      .showQuestion({ requestId: "req-1", entries: ENTRIES });
+    useInteractionStore.getState().dismissQuestionIfMatches("req-1");
+
+    // AND the read lands with no opinion, sending the marker fallback down its
+    // own branch
+    deferredCalls?.[0]?.({ pendingConfirmation: null, pendingSecret: null });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // THEN the settled prompt is not restored from the marker either. The
+    // ordering rule holds for every branch, not only the registry's answer.
+    expect(useInteractionStore.getState().pendingQuestion).toBeNull();
+  });
+
   test("ignores a read that a newer one has already overtaken", async () => {
     // GIVEN two reconciles whose reads are both in flight, which happens when
     // two snapshots commit close together (a turn-end reseed landing on top of

--- a/clients/web/src/domains/chat/hooks/use-conversation-history.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-history.ts
@@ -157,6 +157,14 @@ function applyReportedQuestion(params: {
   const { reported, revisionBefore, messages } = params;
   const interactionStore = useInteractionStore.getState();
 
+  // Whatever this read has to say, it describes the slot as it was when the
+  // request went out. If the slot has moved since, something newer than this
+  // response already owns it, and that is true of the marker fallback as much
+  // as of the registry's answer.
+  if (interactionStore.questionRevision !== revisionBefore) {
+    return;
+  }
+
   if (reported === undefined) {
     const wirePendingQuestion = extractWirePendingQuestion(messages);
     if (wirePendingQuestion && !interactionStore.pendingQuestion) {
@@ -165,9 +173,6 @@ function applyReportedQuestion(params: {
     return;
   }
 
-  if (interactionStore.questionRevision !== revisionBefore) {
-    return;
-  }
   const current = interactionStore.pendingQuestion;
 
   const action = decidePendingQuestion({ reported, current });
@@ -199,12 +204,16 @@ export function useConversationHistory({
   });
 
   /**
-   * Bumped once per committed-snapshot reconcile so a read that is overtaken
-   * by a newer one applies nothing. The card-identity guard below cannot cover
-   * this: two reads issued before either lands both capture the same
-   * `questionBeforeFetch`, so an older response arriving last still matches and
-   * would re-raise a prompt the newer read already saw resolved. Ordering is
-   * not a property of the responses, so it has to be tracked here.
+   * Bumped once per committed-snapshot reconcile, so a read that a later
+   * reconcile has overtaken applies nothing.
+   *
+   * This is the ordering half of the pair that keeps a stale registry read from
+   * moving the card. It answers "is my read still the current one", which the
+   * question slot's revision cannot: two reads issued before either lands
+   * observe the same slot, so the older response looks just as current as the
+   * newer one when it arrives last. The revision answers the other half, "has
+   * the slot moved since I was issued", which ordering cannot see. Neither
+   * subsumes the other.
    */
   const reconcileGenerationRef = useRef(0);
 


### PR DESCRIPTION
## TL;DR

Two review findings from #40969 that arrived after it merged. The revision guard sat below the marker fallback, so the legacy branch could still re-raise a settled prompt, and the generation docstring still named the guard and the variable that PR replaced.

## Ordering rule applied to every branch

`applyReportedQuestion` checked the revision only on the registry branch. The `reported === undefined` path (an assistant too old to report questions, where the cached `/messages` marker is the only source) returned first, guarded solely by `!pendingQuestion`.

That leaves the legacy path exposed to the exact sequence #40969 fixed for the registry path: a prompt that arrives and settles inside the await returns the slot to `null`, the marker is still in the cached page, and the settled prompt is raised again.

The check is now hoisted above both branches. What it says is not specific to where the answer came from: if the slot moved since the request went out, something newer than this response owns it, and this response has nothing to add.

Narrower than the bug #40969 fixed, since it only reaches assistants that predate `pendingQuestion` on the pending-interactions response, but it costs one line to close and the value was already in scope.

## Docstring

The `reconcileGenerationRef` docstring described the guard pair in terms of a "card-identity guard" capturing `questionBeforeFetch`. Both names went away in #40969. Rewritten to state what the two guards each answer, in the present tense and without reference to what changed, per the repo's comment rule.

## Why it is safe

- Hoisting only ever causes an earlier return. Every case that applied before still applies, minus the ones where the slot had already moved, which is the defect.
- Bailing means doing nothing; the next committed snapshot reconciles again.
- No wire, contract, or daemon change. Confined to one file plus its test.

## Testing

Local test runs are blocked in this environment, so these run first in CI. A regression test drives the legacy branch specifically: a read parked in flight, the marker's prompt raised and settled inside that window, then a response carrying no opinion. It fails with the check below the branch, since the marker restore never consults the revision there.

The existing coverage from #40969 (registry-branch ABA, overtaken read, and the rest) is unchanged and still green.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40972" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->