### PR TITLE
chore(web): drop unused type aliases

### DIFF
--- a/clients/web/src/components/collapsible-nav-section.tsx
+++ b/clients/web/src/components/collapsible-nav-section.tsx
@@ -162,7 +162,7 @@ export interface CollapsibleNavSectionDrag {
   dropEdge: "before" | "after" | null;
 }
 
-export interface CollapsibleNavSectionSectionProps extends Omit<
+interface CollapsibleNavSectionSectionProps extends Omit<
   CollapsibleItemProps,
   "children"
 > {
@@ -530,5 +530,3 @@ export const CollapsibleNavSection = {
   Root: CollapsibleNavSectionRoot,
   Section: CollapsibleNavSectionSection,
 };
-
-export type CollapsibleNavSectionRootProps = CollapsibleRootProps;

--- a/clients/web/src/types/app-types.ts
+++ b/clients/web/src/types/app-types.ts
@@ -1,11 +1,6 @@
-import type {
-  AppsByIdOpenPostResponse,
-  AppsGetResponse,
-} from "@/generated/daemon/types.gen";
+import type { AppsGetResponse } from "@/generated/daemon/types.gen";
 
 export type AppSummary = AppsGetResponse["apps"][number];
-
-export type AppOpenResponse = AppsByIdOpenPostResponse;
 
 /**
  * Whether an app is read-only over the daemon's mutation surface. The daemon


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan
Find a small, real cleanup in `vellum-assistant` to verify this Cloud Agent environment end to end (branch, commit, push, PR).

`AppOpenResponse` and `CollapsibleNavSectionRootProps` were leftover aliases with no remaining callers. Section props were only used inside the collapsible nav module.

## Summary
- Remove unused `AppOpenResponse` from `app-types.ts` (and the unused generated import it required).
- Remove unused `CollapsibleNavSectionRootProps`.
- Keep `CollapsibleNavSectionSectionProps` module-private.

## Test Plan
- Repo-wide search confirmed no remaining `AppOpenResponse` or `CollapsibleNavSectionRootProps` callers.
- [x] `cd clients/web && bun test src/types/app-types.test.ts src/components/collapsible-nav-section.test.tsx` (19 pass)
- [x] `cd clients/web && bunx tsc --noEmit` (clean)
- [x] `cd clients/web && bun run lint -- src/types/app-types.ts src/components/collapsible-nav-section.tsx` (clean)

## Risk
Low. Dead-code removal only. No behavior change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f2a0ccac-fd80-4459-90cb-e4855e861182?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f2a0ccac-fd80-4459-90cb-e4855e861182&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

