### PR TITLE
refactor(web): say which surface sits in each pane

### DIFF
--- a/clients/web/src/stores/pane-surfaces.test.ts
+++ b/clients/web/src/stores/pane-surfaces.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  paneSurfaces,
+  showsSecondary,
+  type PaneSurfaceFields,
+} from "@/stores/pane-surfaces";
+import { viewerPanePresentation } from "@/stores/pane-presentation";
+import type { MainView } from "@/stores/viewer-store";
+
+const MAIN_VIEWS: readonly MainView[] = [
+  "chat",
+  "app",
+  "app-editing",
+  "document",
+];
+const BOOLS = [false, true] as const;
+
+function fieldsFor(
+  mainView: MainView,
+  hasApp: boolean,
+  hasBound: boolean,
+  isAppMinimized: boolean,
+): PaneSurfaceFields {
+  return {
+    mainView,
+    appId: hasApp ? "app-1" : null,
+    conversationId: "conv-active",
+    boundConversationId: hasBound ? "conv-bound" : null,
+    isAppMinimized,
+  };
+}
+
+describe("paneSurfaces agrees with the arrangement", () => {
+  for (const mainView of MAIN_VIEWS) {
+    for (const hasApp of BOOLS) {
+      for (const hasBound of BOOLS) {
+        for (const isAppMinimized of BOOLS) {
+          const label = `${mainView}, app=${hasApp}, bound=${hasBound}, minimized=${isAppMinimized}`;
+
+          it(`${label}: a secondary exists exactly when the arrangement is not single`, () => {
+            const fields = fieldsFor(
+              mainView,
+              hasApp,
+              hasBound,
+              isAppMinimized,
+            );
+            const arrangement = viewerPanePresentation({
+              mainView,
+              hasApp,
+              hasBoundConversation: hasBound,
+              isAppMinimized,
+            });
+
+            expect(paneSurfaces(fields).secondary !== null).toBe(
+              arrangement !== "single",
+            );
+          });
+        }
+      }
+    }
+  }
+});
+
+describe("paneSurfaces", () => {
+  it("gives the conversation the workspace when no app is open", () => {
+    const { primary, secondary } = paneSurfaces(
+      fieldsFor("chat", false, false, false),
+    );
+    expect(primary).toEqual({ kind: "conversation", id: "conv-active" });
+    expect(secondary).toBeNull();
+  });
+
+  it("puts the app first and the conversation beside it", () => {
+    const { primary, secondary } = paneSurfaces(
+      fieldsFor("app-editing", true, true, false),
+    );
+    expect(primary).toEqual({ kind: "app", id: "app-1" });
+    expect(secondary).toEqual({ kind: "conversation", id: "conv-bound" });
+  });
+
+  it("inverts the pair when the app is parked to its strip", () => {
+    const { primary, secondary } = paneSurfaces(
+      fieldsFor("app", true, false, true),
+    );
+    expect(primary).toEqual({ kind: "conversation", id: "conv-active" });
+    expect(secondary).toEqual({ kind: "app", id: "app-1" });
+  });
+
+  it("keeps the collapsed conversation while the app fills the width", () => {
+    const { primary, secondary } = paneSurfaces(
+      fieldsFor("app", true, true, false),
+    );
+    expect(primary).toEqual({ kind: "app", id: "app-1" });
+    expect(secondary).toEqual({ kind: "conversation", id: "conv-bound" });
+  });
+
+  it("holds no secondary for an app opened with nothing beside it", () => {
+    expect(paneSurfaces(fieldsFor("app", true, false, false)).secondary).toBe(
+      null,
+    );
+  });
+
+  it("carries no surface at all before a conversation is selected", () => {
+    expect(
+      paneSurfaces({
+        mainView: "chat",
+        appId: null,
+        conversationId: null,
+        boundConversationId: null,
+        isAppMinimized: false,
+      }),
+    ).toEqual({ primary: null, secondary: null });
+  });
+});
+
+describe("showsSecondary", () => {
+  it("shows it beside and below, and holds it collapsed at full width", () => {
+    expect(showsSecondary("side")).toBe(true);
+    expect(showsSecondary("bottom")).toBe(true);
+    expect(showsSecondary("full")).toBe(false);
+    expect(showsSecondary("single")).toBe(false);
+  });
+});

--- a/clients/web/src/stores/pane-surfaces.ts
+++ b/clients/web/src/stores/pane-surfaces.ts
@@ -1,0 +1,90 @@
+/**
+ * Which surface sits in each pane.
+ *
+ * A surface is a kind and the id of the thing it shows. The workspace holds a
+ * primary, which has the room, and at most one secondary, which shares it or
+ * waits collapsed beside it.
+ *
+ * Which surface takes which pane is not fixed by kind. An app beside a
+ * conversation has the room and the conversation shares it; an app parked to
+ * its strip has given the room to the conversation and waits there itself. The
+ * pair below says which is which, so no caller has to work it out from the
+ * arrangement.
+ */
+
+import {
+  isAppMainView,
+  type PanePresentation,
+} from "@/stores/pane-presentation";
+import type { MainView } from "@/stores/viewer-store";
+
+export type PaneSurface =
+  | { kind: "conversation"; id: string }
+  | { kind: "app"; id: string };
+
+export interface PaneSurfaces {
+  primary: PaneSurface | null;
+  secondary: PaneSurface | null;
+}
+
+export interface PaneSurfaceFields {
+  mainView: MainView;
+  /** The app the viewer holds, if any. */
+  appId: string | null;
+  /** The conversation the workspace is loaded on. */
+  conversationId: string | null;
+  /** The conversation bound to the pane beside the app. */
+  boundConversationId: string | null;
+  isAppMinimized: boolean;
+}
+
+/**
+ * Read the stored fields as the pair of surfaces they describe.
+ *
+ * With no app, the conversation has the workspace to itself and there is no
+ * secondary. With one, the arrangement decides the order: parked to its strip
+ * the app is the secondary, and in every other arrangement it is the primary
+ * and the conversation is what shares or waits.
+ */
+export function paneSurfaces({
+  mainView,
+  appId,
+  conversationId,
+  boundConversationId,
+  isAppMinimized,
+}: PaneSurfaceFields): PaneSurfaces {
+  const conversation: PaneSurface | null =
+    conversationId === null
+      ? null
+      : { kind: "conversation", id: conversationId };
+
+  if (appId === null || !isAppMainView(mainView)) {
+    return { primary: conversation, secondary: null };
+  }
+
+  const app: PaneSurface = { kind: "app", id: appId };
+  const bound: PaneSurface | null =
+    boundConversationId === null
+      ? null
+      : { kind: "conversation", id: boundConversationId };
+
+  // Side by side is read before the strip, matching the arrangement. The
+  // fields can hold both at once, and an app cannot be beside a conversation
+  // and parked below it, so one of them has to be the answer.
+  if (mainView === "app-editing") {
+    return { primary: app, secondary: bound };
+  }
+  if (isAppMinimized) {
+    return { primary: conversation, secondary: app };
+  }
+  return { primary: app, secondary: bound };
+}
+
+/**
+ * Whether an arrangement shows the secondary, as opposed to holding it
+ * collapsed. `"full"` keeps its secondary and shows one surface, which is the
+ * difference between a pane a click away and one that is gone.
+ */
+export function showsSecondary(presentation: PanePresentation): boolean {
+  return presentation === "side" || presentation === "bottom";
+}


### PR DESCRIPTION
## TL;DR

Says which surface sits in each pane, as a kind and an id, tied to the arrangement by one asserted invariant. Follows #40958 and #40966.

Design: [Panes and Surfaces](https://claude.ai/code/artifact/04da3094-7ead-4ea7-9fa4-0ee8733851f0)

## Why this and not the component

The obvious next step looked like extracting the split into a pane component. Reading the two branches said otherwise: in the side-by-side layout the chat renders on the left and the app on the right, while the full-width branch shows the app alone. So which pane is "primary" genuinely differs between them, and a component built now would take prop names this change immediately renames.

Which surface takes which pane is not fixed by kind. An app beside a conversation has the room while the conversation shares it; an app parked to its strip has given the room away and waits there itself. `paneSurfaces` says that once so no reader has to infer it from the arrangement.

## The invariant

A secondary exists exactly when the arrangement is not `"single"`, asserted against `viewerPanePresentation` across every combination the stored fields can hold. That is what keeps the two derivations from drifting as readers move over.

## What establishing it found

A state the fields can express and the arrangement cannot: `mainView === "app-editing"` with the app minimized, side by side and parked at once. An app cannot be beside a conversation and below it, so side by side is read first, matching the arrangement.

This is the third time this same pair has produced a contradiction while modelling: the fields can hold combinations the layout has no picture for, which is the argument for the migration restated as a defect.

## Scope

Nothing reads `paneSurfaces` yet, and the module before it gained its readers in #40966, so this is not a second inert module by the same reasoning: it lands with the invariant that makes it safe to adopt, and its first readers come with the pane component in the next change. If that does not follow, this should be reverted rather than left.

## Verification

`tsc --noEmit`, `eslint`, and the pinned Prettier are clean. Local test runs are blocked in this repo, so both the invariant and every named case were transcribed and enumerated outside the suite before pushing.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40974" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->