### PR TITLE
feat(web): Watch action and watching phase on the companion surface

### DIFF
--- a/clients/web/src/components/companion-surface.stories.tsx
+++ b/clients/web/src/components/companion-surface.stories.tsx
@@ -189,6 +189,11 @@ export const Hover: Story = {
  * The phase and the flag are both set because they answer different questions.
  * Turn `watching` off and the pill stays open on a row nothing is running
  * behind, which is what the phase alone means.
+ *
+ * Watch is the one control on this surface that is genuinely on or off, so it
+ * is the one that reports a pressed state. Everything else the surface says
+ * about a running session is a colour, and a colour reaches nobody who is
+ * reading the page rather than looking at it.
  */
 export const Watching: Story = {
   args: { phase: "watching", watching: true, hovered: false },

--- a/clients/web/src/components/companion-surface.stories.tsx
+++ b/clients/web/src/components/companion-surface.stories.tsx
@@ -93,6 +93,7 @@ const meta: Meta<StoryArgs> = {
     },
     accentHex: { control: "color" },
     glow: { control: "boolean" },
+    watching: { control: "boolean" },
   },
   args: {
     phase: "resting",
@@ -161,9 +162,7 @@ export const TypingWhileWorking: Story = {
     phase: "typing",
     working: true,
     assistantName: "Ziggy",
-    turns: [
-      { role: "user", text: "what is on my calendar tomorrow?" },
-    ],
+    turns: [{ role: "user", text: "what is on my calendar tomorrow?" }],
   },
 };
 
@@ -186,9 +185,44 @@ export const Hover: Story = {
  * stays open with no hand on it, Watch is held down, and the ring burns amber
  * rather than the assistant's own colour, so the running session is legible
  * from across the desk.
+ *
+ * The phase and the flag are both set because they answer different questions.
+ * Turn `watching` off and the pill stays open on a row nothing is running
+ * behind, which is what the phase alone means.
  */
 export const Watching: Story = {
-  args: { phase: "watching", hovered: false },
+  args: { phase: "watching", watching: true, hovered: false },
+};
+
+/**
+ * The same session, with the user mid-sentence in the composer.
+ *
+ * The phase the pill draws is `typing`, which outranks `watching`, and the
+ * indicator survives it: the ring is the session's, not the phase's. This is
+ * also the hardest geometry it has to hold, since the card is the one state
+ * that is not a pill.
+ *
+ * **Turn `watching` off to see what an indicator drawn from the phase would
+ * do.** The card goes dark while the screen is still being read.
+ */
+export const TypingWhileWatching: Story = {
+  args: {
+    phase: "typing",
+    watching: true,
+    assistantName: "Ziggy",
+    turns: [{ role: "user", text: "what changed in this file?" }],
+  },
+};
+
+/**
+ * The same session again, with a call running over it.
+ *
+ * Two things are live and the surface has one edge to say so with, so the
+ * capture takes it: the creature already carries the turn in its own pose,
+ * and a call is a thing the user started and can hear.
+ */
+export const InCallWhileWatching: Story = {
+  args: { phase: "call", watching: true, call: DEMO_CALL },
 };
 
 /** Expanded mid-call: the session's own controls, at pill scale. */

--- a/clients/web/src/components/companion-surface.stories.tsx
+++ b/clients/web/src/components/companion-surface.stories.tsx
@@ -202,8 +202,15 @@ export const Watching: Story = {
  * also the hardest geometry it has to hold, since the card is the one state
  * that is not a pill.
  *
+ * The way out survives with it, in the composer's own trailing controls: the
+ * idle row that carries Watch is not drawn here, and a ring the user can see
+ * and cannot act on is a worse bargain than no ring at all. It sits on this row
+ * rather than a row of its own because the card is already within ten points of
+ * the height main sized the canvas for.
+ *
  * **Turn `watching` off to see what an indicator drawn from the phase would
- * do.** The card goes dark while the screen is still being read.
+ * do.** The card goes dark, and the control goes with it, while the screen is
+ * still being read.
  */
 export const TypingWhileWatching: Story = {
   args: {
@@ -220,6 +227,10 @@ export const TypingWhileWatching: Story = {
  * Two things are live and the surface has one edge to say so with, so the
  * capture takes it: the creature already carries the turn in its own pose,
  * and a call is a thing the user started and can hear.
+ *
+ * The widest row the surface draws outside the card: the activity line and five
+ * controls, with the stop beside what the session is doing rather than beside
+ * End, since two stops in a row is a misclick that ends the wrong one.
  */
 export const InCallWhileWatching: Story = {
   args: { phase: "call", watching: true, call: DEMO_CALL },

--- a/clients/web/src/components/companion-surface.stories.tsx
+++ b/clients/web/src/components/companion-surface.stories.tsx
@@ -77,7 +77,7 @@ const meta: Meta<StoryArgs> = {
   argTypes: {
     phase: {
       control: "inline-radio",
-      options: ["resting", "hover", "call", "typing"],
+      options: ["resting", "hover", "watching", "call", "typing"],
     },
     backdrop: {
       control: "inline-radio",
@@ -177,6 +177,18 @@ export const TypingWhileWorking: Story = {
  */
 export const Hover: Story = {
   args: { phase: "hover", hovered: true },
+};
+
+/**
+ * A session reading the screen, with the pointer nowhere near the surface.
+ *
+ * `hovered` is off on purpose: this is the state the phase exists for. The pill
+ * stays open with no hand on it, Watch is held down, and the ring burns amber
+ * rather than the assistant's own colour, so the running session is legible
+ * from across the desk.
+ */
+export const Watching: Story = {
+  args: { phase: "watching", hovered: false },
 };
 
 /** Expanded mid-call: the session's own controls, at pill scale. */

--- a/clients/web/src/components/companion-surface.test.tsx
+++ b/clients/web/src/components/companion-surface.test.tsx
@@ -1,7 +1,7 @@
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
 import { afterEach, describe, expect, test } from "bun:test";
 
-import { CompanionSurface } from "./companion-surface";
+import { CompanionSurface, FALLBACK_WIDTHS } from "./companion-surface";
 
 afterEach(cleanup);
 
@@ -84,6 +84,26 @@ describe("the companion surface's working ring", () => {
       />,
     );
     expect(ringOf(container)).not.toBeNull();
+  });
+
+  /**
+   * A session reading the screen lights the same ring, in a colour of its own.
+   * The ring is the whole of what says a capture is running while the pointer
+   * is elsewhere, so it is worth a test that it is lit and one that it is not
+   * wearing the assistant's colour, which already means something else.
+   */
+  test("lights for a watch session", () => {
+    const { container } = render(<CompanionSurface phase="watching" />);
+    expect(ringOf(container)).not.toBeNull();
+  });
+
+  test("burns a watch session in the capture colour, not the assistant's", () => {
+    const { container } = render(
+      <CompanionSurface phase="watching" accentHex="#ff8800" />,
+    );
+    expect(
+      ringOf(container)?.style.getPropertyValue("--companion-ring-accent"),
+    ).toBe("#ff9f45");
   });
 
   test("stays dark while a call is waiting on the user", () => {
@@ -246,5 +266,101 @@ describe("the companion surface's anchor in the canvas", () => {
       expect(surfaceOf(container).style.transform).toBe("translateY(-50%)");
       cleanup();
     }
+  });
+});
+
+/**
+ * Watch, the third way in, and the session it toggles.
+ *
+ * One control for both edges: the surface draws a single button and the side
+ * holding the session decides which edge a press is, so what a test can hold is
+ * that the press is reported and that a running session is drawn as one.
+ */
+describe("the companion surface's Watch action", () => {
+  const watchOf = (container: HTMLElement): HTMLButtonElement => {
+    const found = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Watch"]',
+    );
+    if (!found) {
+      throw new Error("Expected Watch to render");
+    }
+    return found;
+  };
+
+  test("sits on the idle pill beside Talk and Type", () => {
+    const { container } = render(<CompanionSurface phase="hover" />);
+    expect(watchOf(container).textContent).toBe("Watch");
+  });
+
+  test("reports the press", () => {
+    let presses = 0;
+    const { container } = render(
+      <CompanionSurface
+        phase="hover"
+        onWatch={() => {
+          presses += 1;
+        }}
+      />,
+    );
+    fireEvent.click(watchOf(container));
+    expect(presses).toBe(1);
+  });
+
+  /**
+   * `classList` rather than a substring, because every control carries
+   * `hover:bg-white/15` and a substring match would pass on the hover rule
+   * alone.
+   */
+  test("reads as held down while the session runs", () => {
+    const { container } = render(<CompanionSurface phase="watching" />);
+    expect(watchOf(container).classList.contains("bg-white/15")).toBe(true);
+  });
+
+  test("reads as idle while no session runs", () => {
+    const { container } = render(<CompanionSurface phase="hover" />);
+    expect(watchOf(container).classList.contains("bg-white/15")).toBe(false);
+  });
+});
+
+/**
+ * The pill stays open for as long as the session does, hand or no hand.
+ *
+ * A capture that hid itself the moment the pointer left would be one the user
+ * can neither see nor reach the control that ends it. The collapsed body is
+ * `inert`, so its absence is the pill being genuinely open rather than merely
+ * drawn.
+ */
+describe("the pill a watch session holds open", () => {
+  test("stays open with the pointer nowhere near it", () => {
+    const { container } = render(
+      <CompanionSurface phase="watching" hovered={false} />,
+    );
+    expect(container.querySelector("[inert]")).toBeNull();
+  });
+
+  test("is shut at rest, which is what makes that a claim", () => {
+    const { container } = render(<CompanionSurface phase="resting" />);
+    expect(container.querySelector("[inert]")).not.toBeNull();
+  });
+});
+
+/**
+ * The ceiling the Electron canvas is sized to.
+ *
+ * `companion-window.ts` sizes its window once, for the widest state this
+ * surface has, and never resizes it: a canvas that grew with the phase would
+ * move the window under the pointer mid-press. So a phase wider than the
+ * ceiling is not a wide pill, it is a clipped one, and the fix is on the other
+ * side of the bridge.
+ */
+describe("the companion surface's width ceiling", () => {
+  /** `BASE_MAX_PILL_WIDTH` in `clients/macos/src/main/companion-window.ts`. */
+  const CANVAS_CEILING = 360;
+
+  test("holds for every phase", () => {
+    const over = Object.entries(FALLBACK_WIDTHS).filter(
+      ([, width]) => width > CANVAS_CEILING,
+    );
+    expect(over).toEqual([]);
   });
 });

--- a/clients/web/src/components/companion-surface.test.tsx
+++ b/clients/web/src/components/companion-surface.test.tsx
@@ -342,6 +342,22 @@ describe("the companion surface's Watch action", () => {
   });
 
   /**
+   * A reader gets none of what this PR spends on the state: not the amber ring,
+   * not the held-down background. The pressed state is the whole of what
+   * reaches them, so it is what says a session is running and that the press
+   * they are on will end it.
+   */
+  test("reports its pressed state while the session runs", () => {
+    const { container } = render(<CompanionSurface phase="hover" watching />);
+    expect(watchOf(container).getAttribute("aria-pressed")).toBe("true");
+  });
+
+  test("reports the state it is actually in while nothing runs", () => {
+    const { container } = render(<CompanionSurface phase="hover" />);
+    expect(watchOf(container).getAttribute("aria-pressed")).toBe("false");
+  });
+
+  /**
    * `classList` rather than a substring, because every control carries
    * `hover:bg-white/15` and a substring match would pass on the hover rule
    * alone.
@@ -548,5 +564,74 @@ describe("the companion surface's capture indicator across phases", () => {
       <CompanionSurface phase="call" call={LISTENING_CALL} />,
     );
     expect(ringOf(container)).toBeNull();
+  });
+});
+
+/**
+ * What the surface claims to be a toggle, which is one control.
+ *
+ * `active` draws a control as though a pointer were on it, which the demo reel
+ * stages on Talk and Type to show a hand reaching for one. That is a look, and
+ * a look reported as a pressed state would tell a reader that Talk is switched
+ * on because a clip wanted it lit. Watch is the only control here that is
+ * genuinely on or off, so it is the only one that says so.
+ */
+describe("the companion surface's pressed states", () => {
+  const buttonsOf = (container: HTMLElement): HTMLButtonElement[] =>
+    Array.from(container.querySelectorAll<HTMLButtonElement>("button"));
+
+  const named = (container: HTMLElement, label: string): HTMLButtonElement => {
+    const found = container.querySelector<HTMLButtonElement>(
+      `button[aria-label="${label}"]`,
+    );
+    if (!found) {
+      throw new Error(`Expected ${label} to render`);
+    }
+    return found;
+  };
+
+  test("leaves the spotlit control unpressed, since a highlight is not a state", () => {
+    for (const spotlight of ["talk", "type"] as const) {
+      const { container } = render(
+        <CompanionSurface phase="hover" spotlight={spotlight} />,
+      );
+      expect(named(container, "Talk").getAttribute("aria-pressed")).toBeNull();
+      expect(named(container, "Type").getAttribute("aria-pressed")).toBeNull();
+      cleanup();
+    }
+  });
+
+  /**
+   * The look and the announced state come from one input on Watch, so a
+   * spotlight that drew a control held down without saying so is exactly the
+   * split this separation exists to keep.
+   */
+  test("still draws the spotlit control held down", () => {
+    const { container } = render(
+      <CompanionSurface phase="hover" spotlight="talk" />,
+    );
+    expect(named(container, "Talk").classList.contains("bg-white/15")).toBe(
+      true,
+    );
+  });
+
+  test("claims no pressed state anywhere on the call row", () => {
+    const { container } = render(
+      <CompanionSurface phase="call" watching call={LISTENING_CALL} />,
+    );
+    for (const button of buttonsOf(container)) {
+      expect(button.getAttribute("aria-pressed")).toBeNull();
+    }
+  });
+
+  /**
+   * The stop control goes one way and exists only while there is a session to
+   * end, so it is an action. Its name is what tells a reader that something is
+   * being watched and that this is the way out of it.
+   */
+  test("leaves the stop control an action rather than a toggle", () => {
+    const { container } = render(<CompanionSurface phase="typing" watching />);
+    const stop = named(container, "Stop watching");
+    expect(stop.getAttribute("aria-pressed")).toBeNull();
   });
 });

--- a/clients/web/src/components/companion-surface.test.tsx
+++ b/clients/web/src/components/companion-surface.test.tsx
@@ -93,17 +93,50 @@ describe("the companion surface's working ring", () => {
    * wearing the assistant's colour, which already means something else.
    */
   test("lights for a watch session", () => {
-    const { container } = render(<CompanionSurface phase="watching" />);
+    const { container } = render(
+      <CompanionSurface phase="watching" watching />,
+    );
     expect(ringOf(container)).not.toBeNull();
   });
 
   test("burns a watch session in the capture colour, not the assistant's", () => {
     const { container } = render(
-      <CompanionSurface phase="watching" accentHex="#ff8800" />,
+      <CompanionSurface phase="watching" watching accentHex="#ff8800" />,
     );
     expect(
       ringOf(container)?.style.getPropertyValue("--companion-ring-accent"),
     ).toBe("#ff9f45");
+  });
+
+  /**
+   * The capture keeps the colour when a turn is running under it. The creature
+   * carries the turn in its own pose, and a capture drawn in a colour that also
+   * means "a reply is streaming" is one the user has no reason to read as a
+   * capture.
+   */
+  test("keeps the capture colour while a turn runs under the session", () => {
+    const { container } = render(
+      <CompanionSurface
+        phase="watching"
+        watching
+        working
+        accentHex="#ff8800"
+      />,
+    );
+    expect(
+      ringOf(container)?.style.getPropertyValue("--companion-ring-accent"),
+    ).toBe("#ff9f45");
+  });
+
+  /**
+   * The phase is what the pill is showing and the flag is what is running, so
+   * the phase on its own is not a capture. This is the guard on that: an
+   * indicator that read the phase would be lit here, and would be dark in the
+   * two phases below that outrank it.
+   */
+  test("stays dark for the phase alone, which is not a running session", () => {
+    const { container } = render(<CompanionSurface phase="watching" />);
+    expect(ringOf(container)).toBeNull();
   });
 
   test("stays dark while a call is waiting on the user", () => {
@@ -312,13 +345,25 @@ describe("the companion surface's Watch action", () => {
    * alone.
    */
   test("reads as held down while the session runs", () => {
-    const { container } = render(<CompanionSurface phase="watching" />);
+    const { container } = render(
+      <CompanionSurface phase="watching" watching />,
+    );
     expect(watchOf(container).classList.contains("bg-white/15")).toBe(true);
   });
 
   test("reads as idle while no session runs", () => {
     const { container } = render(<CompanionSurface phase="hover" />);
     expect(watchOf(container).classList.contains("bg-white/15")).toBe(false);
+  });
+
+  /**
+   * The flag, not the phase, the same input the ring reads. The two are drawn
+   * in different places and must never be able to disagree about whether a
+   * session is running.
+   */
+  test("reads as held down on the idle pill while the session runs", () => {
+    const { container } = render(<CompanionSurface phase="hover" watching />);
+    expect(watchOf(container).classList.contains("bg-white/15")).toBe(true);
   });
 });
 
@@ -362,5 +407,56 @@ describe("the companion surface's width ceiling", () => {
       ([, width]) => width > CANVAS_CEILING,
     );
     expect(over).toEqual([]);
+  });
+});
+
+/**
+ * The indicator outlives the phase.
+ *
+ * `watching` ranks below `typing` and `call`, so a session that is still
+ * reading the screen is drawn under a phase that is not its own for as long as
+ * the user is mid-sentence or on a call. Those are the phases where an
+ * indicator derived from the phase would go dark, and going dark over a live
+ * capture is the failure this surface exists to prevent.
+ */
+describe("the companion surface's capture indicator across phases", () => {
+  const LISTENING_CALL = {
+    phase: "listening",
+    label: "Listening",
+    accentHex: "#5eead4",
+    muted: false,
+    outputMuted: false,
+    detail: "",
+    approvalRequestId: "",
+    assistantName: "Ziggy",
+  } as const;
+
+  test("survives the composer, which outranks the watching phase", () => {
+    const { container } = render(<CompanionSurface phase="typing" watching />);
+    expect(ringOf(container)).not.toBeNull();
+  });
+
+  test("survives a call, which outranks it too", () => {
+    const { container } = render(
+      <CompanionSurface phase="call" watching call={LISTENING_CALL} />,
+    );
+    expect(ringOf(container)).not.toBeNull();
+  });
+
+  test("follows the card's corner radius while the user types", () => {
+    const { container } = render(<CompanionSurface phase="typing" watching />);
+    expect(ringOf(container)?.className).toContain("rounded-[24px]");
+  });
+
+  test("is absent in the composer with no session running", () => {
+    const { container } = render(<CompanionSurface phase="typing" />);
+    expect(ringOf(container)).toBeNull();
+  });
+
+  test("is absent in a call with no session running", () => {
+    const { container } = render(
+      <CompanionSurface phase="call" call={LISTENING_CALL} />,
+    );
+    expect(ringOf(container)).toBeNull();
   });
 });

--- a/clients/web/src/components/companion-surface.test.tsx
+++ b/clients/web/src/components/companion-surface.test.tsx
@@ -1,9 +1,23 @@
 import { cleanup, fireEvent, render } from "@testing-library/react";
 import { afterEach, describe, expect, test } from "bun:test";
 
+import type { VoiceActivityState } from "@vellumai/ipc-contract";
+
 import { CompanionSurface, FALLBACK_WIDTHS } from "./companion-surface";
 
 afterEach(cleanup);
+
+/** The ordinary middle of a call: unmuted, listening, nothing to decide. */
+const LISTENING_CALL: VoiceActivityState = {
+  phase: "listening",
+  label: "Listening",
+  accentHex: "#5eead4",
+  muted: false,
+  outputMuted: false,
+  detail: "",
+  approvalRequestId: "",
+  assistantName: "Ziggy",
+};
 
 /**
  * The working ring: the surface's answer to "is it doing anything", drawn so it
@@ -141,19 +155,7 @@ describe("the companion surface's working ring", () => {
 
   test("stays dark while a call is waiting on the user", () => {
     const { container } = render(
-      <CompanionSurface
-        phase="call"
-        call={{
-          phase: "listening",
-          label: "Listening",
-          accentHex: "#5eead4",
-          muted: false,
-          outputMuted: false,
-          detail: "",
-          approvalRequestId: "",
-          assistantName: "Ziggy",
-        }}
-      />,
+      <CompanionSurface phase="call" call={LISTENING_CALL} />,
     );
     expect(ringOf(container)).toBeNull();
   });
@@ -390,6 +392,86 @@ describe("the pill a watch session holds open", () => {
 });
 
 /**
+ * The way out of a session, which has to reach as far as the indicator does.
+ *
+ * `watching` ranks below `typing` and `call`, so the idle row that carries
+ * Watch is not drawn in either of them while the ring still is. An indicator
+ * the user can see and cannot act on is a worse bargain than no indicator at
+ * all: it names something happening to them and withholds the means to end it.
+ * So both of those phases carry a stop control of their own, on the same
+ * `onWatch` the idle row presses.
+ */
+describe("the companion surface's stop control", () => {
+  const stopOf = (container: HTMLElement): HTMLButtonElement | null =>
+    container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Stop watching"]',
+    );
+
+  const required = (container: HTMLElement): HTMLButtonElement => {
+    const found = stopOf(container);
+    if (!found) {
+      throw new Error("Expected the stop control to render");
+    }
+    return found;
+  };
+
+  test("rides the composer while the user types", () => {
+    const { container } = render(<CompanionSurface phase="typing" watching />);
+    expect(stopOf(container)).not.toBeNull();
+  });
+
+  test("ends the session from the composer", () => {
+    let presses = 0;
+    const { container } = render(
+      <CompanionSurface
+        phase="typing"
+        watching
+        onWatch={() => {
+          presses += 1;
+        }}
+      />,
+    );
+    fireEvent.click(required(container));
+    expect(presses).toBe(1);
+  });
+
+  test("rides the call row too", () => {
+    const { container } = render(
+      <CompanionSurface phase="call" watching call={LISTENING_CALL} />,
+    );
+    expect(stopOf(container)).not.toBeNull();
+  });
+
+  test("ends the session from the call row", () => {
+    let presses = 0;
+    const { container } = render(
+      <CompanionSurface
+        phase="call"
+        watching
+        call={LISTENING_CALL}
+        onWatch={() => {
+          presses += 1;
+        }}
+      />,
+    );
+    fireEvent.click(required(container));
+    expect(presses).toBe(1);
+  });
+
+  test("is absent from the composer with no session to stop", () => {
+    const { container } = render(<CompanionSurface phase="typing" />);
+    expect(stopOf(container)).toBeNull();
+  });
+
+  test("is absent from the call row with no session to stop", () => {
+    const { container } = render(
+      <CompanionSurface phase="call" call={LISTENING_CALL} />,
+    );
+    expect(stopOf(container)).toBeNull();
+  });
+});
+
+/**
  * The ceiling the Electron canvas is sized to.
  *
  * `companion-window.ts` sizes its window once, for the widest state this
@@ -408,6 +490,25 @@ describe("the companion surface's width ceiling", () => {
     );
     expect(over).toEqual([]);
   });
+
+  /**
+   * The call row is the one the stop control grew, so the bound above is only
+   * worth anything if the entry it checks is the width of the row *with* the
+   * control on it. Five controls is what that row draws, and the card cannot
+   * grow the same way: it is a fixed width, and the composer's field gives up
+   * the space out of its own.
+   */
+  test("sizes the call entry for the row that carries the stop control", () => {
+    const { container } = render(
+      <CompanionSurface phase="call" watching call={LISTENING_CALL} />,
+    );
+    expect(container.querySelectorAll("button")).toHaveLength(4);
+    expect(FALLBACK_WIDTHS.call).toBeGreaterThan(FALLBACK_WIDTHS.hover);
+  });
+
+  test("leaves the card exactly at the ceiling it was already at", () => {
+    expect(FALLBACK_WIDTHS.typing).toBe(CANVAS_CEILING);
+  });
 });
 
 /**
@@ -420,17 +521,6 @@ describe("the companion surface's width ceiling", () => {
  * capture is the failure this surface exists to prevent.
  */
 describe("the companion surface's capture indicator across phases", () => {
-  const LISTENING_CALL = {
-    phase: "listening",
-    label: "Listening",
-    accentHex: "#5eead4",
-    muted: false,
-    outputMuted: false,
-    detail: "",
-    approvalRequestId: "",
-    assistantName: "Ziggy",
-  } as const;
-
   test("survives the composer, which outranks the watching phase", () => {
     const { container } = render(<CompanionSurface phase="typing" watching />);
     expect(ringOf(container)).not.toBeNull();

--- a/clients/web/src/components/companion-surface.tsx
+++ b/clients/web/src/components/companion-surface.tsx
@@ -3,6 +3,7 @@ import {
   AudioLines,
   Check,
   Eye,
+  EyeOff,
   Keyboard,
   Mic,
   MicOff,
@@ -204,7 +205,9 @@ export const FALLBACK_WIDTHS: Record<CompanionSurfacePhase, number> = {
   // The same row of controls hover draws, since the session is run from it
   // rather than from a row of its own.
   watching: 272,
-  call: 296,
+  // The row with the stop control on it, which is the widest a call draws: a
+  // watch session adds a fifth control to the four the call already has.
+  call: 332,
   typing: 360,
 };
 
@@ -623,8 +626,10 @@ export function CompanionSurface({
         {typing ? (
           <Composer
             assistantName={assistantName}
+            watching={watching}
             onSubmit={onSubmit}
             onCancel={onCancelTyping}
+            onWatch={onWatch}
           />
         ) : (
           <div
@@ -644,7 +649,12 @@ export function CompanionSurface({
             }}
           >
             {phase === "call" ? (
-              <CallBody call={call} onControl={onControl} />
+              <CallBody
+                call={call}
+                watching={watching}
+                onControl={onControl}
+                onWatch={onWatch}
+              />
             ) : (
               <IdleBody
                 spotlight={spotlight}
@@ -732,15 +742,28 @@ function RecentTurns({ turns }: { turns: CompanionTurn[] }) {
  * pressing Type changes what the pill contains without changing what the pill
  * is: empty, focused, or full of text, it is the same elongated single line as
  * the voice states. Growth happens above it, never to it.
+ *
+ * **It carries the stop control while a watch session runs**, because the card
+ * is the one state with no control row of its own and the ring around it says
+ * the screen is being read in every state. An indicator the user can see and
+ * cannot act on is a worse bargain than no indicator: it names something
+ * happening to them and withholds the means to end it. The row is where it fits
+ * without cost, since the card is a fixed {@link CARD_WIDTH} and the field
+ * takes the space out of its own flexible width rather than out of the card's,
+ * and a row added above would push the card past the canvas main sized for it.
  */
 function Composer({
   assistantName,
+  watching,
   onSubmit,
   onCancel,
+  onWatch,
 }: {
   assistantName: string;
+  watching: boolean;
   onSubmit?: (message: string) => void;
   onCancel?: () => void;
+  onWatch?: () => void;
 }) {
   // The draft is the composer's own and never leaves except as a submitted
   // message. Holding it in the page instead would re-render the whole surface,
@@ -795,6 +818,7 @@ function Composer({
         }}
         className="min-w-0 flex-1 bg-transparent text-[12px] text-white/85 placeholder:text-white/40 focus:outline-none"
       />
+      {watching && <StopWatchingButton onWatch={onWatch} />}
       {/* **The way out, and the way on, in one control.** With nothing typed
           there is nothing to send, so the trailing control is the way back to
           the pill; the moment there are words it becomes the way to send them.
@@ -984,15 +1008,25 @@ function IdleBody({
  */
 function CallBody({
   call,
+  watching,
   onControl,
+  onWatch,
 }: {
   call?: VoiceActivityState;
+  watching: boolean;
   onControl?: (action: VoiceActivityControlAction, requestId?: string) => void;
+  onWatch?: () => void;
 }) {
   // The confirmation takes the row rather than crowding into it. The turn is
   // stopped until it is answered, so it is the only thing here worth pressing,
   // and a pill that tried to carry five controls would make each of them a
   // smaller target than the decision deserves.
+  //
+  // The watch session's stop control is among what it excludes. The row already
+  // measures within a couple of points of the canvas ceiling, and what a canvas
+  // too narrow does is clip its trailing control, so adding one here risks
+  // clipping Deny. A blocked turn is reading nothing while it waits, and
+  // answering it lands back on the row that carries the stop.
   if (call !== undefined && call.approvalRequestId !== "") {
     return (
       <ApprovalBody
@@ -1021,6 +1055,10 @@ function CallBody({
       <span className="ml-1 max-w-[120px] shrink-0 truncate text-[12px] text-white/85">
         {line}
       </span>
+      {/* Beside what the session is doing rather than beside the end control:
+          two stops next to each other is a misclick that ends the wrong thing,
+          and only one of the two is irreversible. */}
+      {watching && <StopWatchingButton onWatch={onWatch} />}
       <PillButton
         icon={
           muted ? <MicOff className="size-4" /> : <Mic className="size-4" />
@@ -1105,6 +1143,25 @@ function ApprovalBody({
         }}
       />
     </>
+  );
+}
+
+/**
+ * End the watch session, on whichever row the user is looking at.
+ *
+ * One component for the two that draw it, because the label is the whole of
+ * what this control says. It carries no words, so an accessible name that
+ * drifted between the composer and the call row would be two different controls
+ * to anyone reading the surface rather than looking at it, and this is the
+ * control a user reaches for precisely when they want the reading to stop.
+ */
+function StopWatchingButton({ onWatch }: { onWatch?: () => void }) {
+  return (
+    <PillButton
+      icon={<EyeOff className="size-4" />}
+      label="Stop watching"
+      onClick={onWatch}
+    />
   );
 }
 

--- a/clients/web/src/components/companion-surface.tsx
+++ b/clients/web/src/components/companion-surface.tsx
@@ -972,12 +972,15 @@ function IdleBody({
         onClick={onType}
       />
       {/* Held down for as long as the session runs, so the row says which
-          control is holding the pill open and which press ends it. */}
+          control is holding the pill open and which press ends it. `pressed`
+          rather than `active`, because this one is a state and not a look: a
+          reader is told a session is running, where everything else this
+          surface does about it is a colour they never receive. */}
       <PillButton
         icon={<Eye className="size-4" />}
         label="Watch"
         showLabel
-        active={watching}
+        pressed={watching}
         onClick={onWatch}
       />
     </>
@@ -1154,6 +1157,11 @@ function ApprovalBody({
  * drifted between the composer and the call row would be two different controls
  * to anyone reading the surface rather than looking at it, and this is the
  * control a user reaches for precisely when they want the reading to stop.
+ *
+ * An action rather than a toggle, and so no pressed state: it goes one way, and
+ * it is drawn only while there is a session for it to end. Its name is what
+ * tells a reader both of those things at once, since a control offering to stop
+ * the watching is only there when something is being watched.
  */
 function StopWatchingButton({ onWatch }: { onWatch?: () => void }) {
   return (
@@ -1171,6 +1179,16 @@ function StopWatchingButton({ onWatch }: { onWatch?: () => void }) {
  * `label` is always the accessible name; it is only drawn when the pill has
  * room for words, which is why the call's controls are icon-only without being
  * unlabelled.
+ *
+ * **`active` and `pressed` are two props because they are two different
+ * claims.** `active` is a look: the demo reel draws a control as though a
+ * pointer were on it, and a highlight staged for a recording is not a state the
+ * control is in. `pressed` is the control's own on or off, which is a state,
+ * and reporting a highlight as one would tell a reader that Talk is switched on
+ * because a clip wanted it lit.
+ *
+ * `pressed` draws the same held-down look, so the state a looking user reads
+ * off the background and the state a reader is told cannot come apart.
  */
 function PillButton({
   icon,
@@ -1178,20 +1196,32 @@ function PillButton({
   tone,
   showLabel = false,
   active = false,
+  pressed,
   onClick,
 }: {
   icon: ReactNode;
   label: string;
   tone?: "positive" | "negative";
   showLabel?: boolean;
-  /** Held down, for a control whose surface is currently open. */
+  /** Drawn as though the pointer were on it. A look, not a state. */
   active?: boolean;
+  /**
+   * On or off, for a control that genuinely toggles.
+   *
+   * Undefined for everything that does not, which is most of this surface: a
+   * button reporting a state it does not have is one assistive technology
+   * describes wrongly. Where it is set it carries the whole of that state to a
+   * reader, since the ring and the held-down background are both things only a
+   * looking user gets.
+   */
+  pressed?: boolean;
   onClick?: () => void;
 }) {
   return (
     <button
       type="button"
       aria-label={label}
+      aria-pressed={pressed}
       title={label}
       onClick={onClick}
       // A press on a control is not the start of a drag. Without this the
@@ -1200,7 +1230,7 @@ function PillButton({
         event.stopPropagation();
       }}
       className={`flex h-7 shrink-0 items-center gap-1.5 rounded-full px-2 text-[12px] transition-colors hover:bg-white/15 ${
-        active ? "bg-white/15" : ""
+        active || pressed === true ? "bg-white/15" : ""
       } ${
         tone === "negative"
           ? "text-[#ff6b6b]"

--- a/clients/web/src/components/companion-surface.tsx
+++ b/clients/web/src/components/companion-surface.tsx
@@ -2,6 +2,7 @@ import {
   ArrowUp,
   AudioLines,
   Check,
+  Eye,
   Keyboard,
   Mic,
   MicOff,
@@ -40,11 +41,11 @@ import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
  * position (`left: 50%` plus the avatar's own half-width) rather than a
  * transform, and only `width` animates.
  *
- * **Growth needs clearance on the side it runs into**, `width - 44` of it: 144px
- * expanded and 316px in a call. A circle parked against the right edge does not
- * have it, and unclamped the body would run straight off the display with the
- * controls the user was reaching for. So the surface flips and grows the other
- * way instead, the way a menu does, through {@link growth}.
+ * **Growth needs clearance on the side it runs into**, `width - 44` of it:
+ * 228px expanded and 316px at its widest. A circle parked against the right
+ * edge does not have it, and unclamped the body would run straight off the
+ * display with the controls the user was reaching for. So the surface flips and
+ * grows the other way instead, the way a menu does, through {@link growth}.
  *
  * **Presentational only.** Phase comes from the caller, so this renders
  * identically in Storybook and in the Electron panel. Hover is a phase rather
@@ -75,6 +76,19 @@ import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
 export type CompanionSurfacePhase =
   | "resting"
   | "hover"
+  /**
+   * Watching: a session reading the screen is running.
+   *
+   * Holds the pill open regardless of the pointer, the way `call` does, and
+   * for a sharper reason. A screen reader that hides itself when the pointer
+   * leaves is one the user cannot see, and a capture nobody can see is one
+   * nobody can stop.
+   *
+   * It ranks below `typing` and `call` and above `hover`: a half-typed
+   * sentence and a live call are both something the user is in the middle of,
+   * and a watch session runs on its own either way.
+   */
+  | "watching"
   | "call"
   /**
    * Typing: the pill becomes a card carrying a condensed read of the
@@ -122,6 +136,16 @@ const DEFAULT_ACCENT = "#5eead4";
  */
 const ASSISTANT_TURN_PHASES = new Set(["transcribing", "thinking", "speaking"]);
 
+/**
+ * The colour a watch session lights the ring in.
+ *
+ * Fixed rather than the assistant's own accent, because the ring in the accent
+ * already means "a turn is running" and a screen being read is a different fact
+ * about the machine. Amber is the tone the host burns for a live capture, so
+ * the surface agrees with the menu bar above it.
+ */
+const WATCHING_RING_ACCENT = "#ff9f45";
+
 // The avatar is a fixed 44px disc in every state; only the body around it
 // changes. That is what makes this one surface expanding rather than three
 // surfaces that happen to share a colour, and it is the property to protect as
@@ -164,10 +188,20 @@ const INNER_GAP = 8;
  * Measuring is also what makes the surface survive its own roadmap. Once
  * plugins contribute actions (LUM-3097) no hardcoded number can be correct, and
  * these become nothing but the value for the first frame.
+ *
+ * **Every entry stays at or under 360**, which is `BASE_MAX_PILL_WIDTH` in
+ * `companion-window.ts`. The window is a fixed canvas sized once for the widest
+ * state the surface has, so the ceiling is the host's rather than this file's:
+ * a state that wanted more would be clipped by the window, and buying the room
+ * back means resizing the canvas, which is the thing a fixed canvas exists to
+ * avoid.
  */
-const FALLBACK_WIDTHS: Record<CompanionSurfacePhase, number> = {
+export const FALLBACK_WIDTHS: Record<CompanionSurfacePhase, number> = {
   resting: AVATAR_BOX,
-  hover: 188,
+  hover: 272,
+  // The same row of controls hover draws, since the session is run from it
+  // rather than from a row of its own.
+  watching: 272,
   call: 296,
   typing: 360,
 };
@@ -241,9 +275,9 @@ export interface CompanionSurfaceProps {
    * Whether the pointer is on the surface, which the creature answers by
    * widening its eyes.
    *
-   * Passed rather than derived from `phase`, because a call holds the pill open
-   * regardless of the pointer and the mascot should still notice a hand
-   * arriving over it mid-call.
+   * Passed rather than derived from `phase`, because a call and a watch session
+   * both hold the pill open regardless of the pointer and the mascot should
+   * still notice a hand arriving over it either way.
    */
   hovered?: boolean;
   /**
@@ -301,6 +335,14 @@ export interface CompanionSurfaceProps {
    * Electron host the same press also has to lend the window the keyboard.
    */
   onType?: () => void;
+  /**
+   * Start or stop the session that reads the screen, which is what Watch does.
+   *
+   * One press for both edges, the way the contract's `toggleWatch` is: the
+   * surface draws a single control, and the side holding the session is the
+   * only one that knows which edge a press is.
+   */
+  onWatch?: () => void;
   /**
    * Send what was typed. The text is the composer's own until it leaves, so
    * this is the only thing the caller ever sees of it.
@@ -373,6 +415,7 @@ export function CompanionSurface({
   spotlight,
   onTalk,
   onType,
+  onWatch,
   onSubmit,
   onCancelTyping,
   onAvatarClick,
@@ -382,6 +425,7 @@ export function CompanionSurface({
 }: CompanionSurfaceProps) {
   const expanded = phase !== "resting";
   const typing = phase === "typing";
+  const watching = phase === "watching";
 
   /**
    * Whether the assistant is working, from whichever side is in a position to
@@ -515,17 +559,26 @@ export function CompanionSurface({
         style={{ opacity: expanded ? 1 : 0 }}
         aria-hidden
       />
-      {/* The turn itself, as a light travelling around the surface's edge.
+      {/* Something running, as a light travelling around the surface's edge.
           Drawn over the body so it reads as the surface's own border in every
           state, and outside it by a hair so it never crowds the avatar at rest,
           which is the state it has to be legible in: the whole point is being
-          readable from the corner of an eye while the user works elsewhere. */}
-      {assistantWorking && (
+          readable from the corner of an eye while the user works elsewhere.
+
+          A turn burns it in the assistant's colour, a watch session in amber.
+          The session wins when both are true: the creature already carries the
+          turn in its own pose, and a capture running with nothing drawn over it
+          is the worse of the two failures. */}
+      {(assistantWorking || watching) && (
         <span
           className={`companion-working-ring pointer-events-none absolute -inset-0.5 ${
             typing ? "rounded-[24px]" : "rounded-full"
           }`}
-          style={{ ["--companion-ring-accent" as string]: accentHex }}
+          style={{
+            ["--companion-ring-accent" as string]: watching
+              ? WATCHING_RING_ACCENT
+              : accentHex,
+          }}
           aria-hidden
         />
       )}
@@ -571,7 +624,13 @@ export function CompanionSurface({
             {phase === "call" ? (
               <CallBody call={call} onControl={onControl} />
             ) : (
-              <IdleBody spotlight={spotlight} onTalk={onTalk} onType={onType} />
+              <IdleBody
+                spotlight={spotlight}
+                watching={watching}
+                onTalk={onTalk}
+                onType={onType}
+                onWatch={onWatch}
+              />
             )}
           </div>
         )}
@@ -828,20 +887,27 @@ function Avatar({
 }
 
 /**
- * Expanded, with the app idle: the two ways in.
+ * Expanded, with the app idle: the ways in.
  *
- * "Talk" and "Type" rather than "Talk" and "Ask", because they are two halves
- * of one choice about how to say something, and a verb pair reads as that where
- * a verb and a question word do not.
+ * Verbs throughout. "Talk" and "Type" rather than "Talk" and "Ask", because
+ * they are two halves of one choice about how to say something, and a verb pair
+ * reads as that where a verb and a question word do not. "Watch" is the third,
+ * and the one where the assistant does the looking rather than the user the
+ * saying.
  */
 function IdleBody({
   spotlight,
+  watching = false,
   onTalk,
   onType,
+  onWatch,
 }: {
   spotlight?: "talk" | "type";
+  /** Whether the session Watch starts is already running. */
+  watching?: boolean;
   onTalk?: () => void;
   onType?: () => void;
+  onWatch?: () => void;
 }) {
   return (
     <>
@@ -858,6 +924,15 @@ function IdleBody({
         showLabel
         active={spotlight === "type"}
         onClick={onType}
+      />
+      {/* Held down for as long as the session runs, so the row says which
+          control is holding the pill open and which press ends it. */}
+      <PillButton
+        icon={<Eye className="size-4" />}
+        label="Watch"
+        showLabel
+        active={watching}
+        onClick={onWatch}
       />
     </>
   );

--- a/clients/web/src/components/companion-surface.tsx
+++ b/clients/web/src/components/companion-surface.tsx
@@ -77,16 +77,18 @@ export type CompanionSurfacePhase =
   | "resting"
   | "hover"
   /**
-   * Watching: a session reading the screen is running.
+   * Watching: the pill held open by a session reading the screen.
    *
-   * Holds the pill open regardless of the pointer, the way `call` does, and
-   * for a sharper reason. A screen reader that hides itself when the pointer
-   * leaves is one the user cannot see, and a capture nobody can see is one
-   * nobody can stop.
+   * Open regardless of the pointer, the way `call` is, and for a sharper
+   * reason. A screen reader that hides itself when the pointer leaves is one
+   * the user cannot see, and a capture nobody can see is one nobody can stop.
    *
    * It ranks below `typing` and `call` and above `hover`: a half-typed
-   * sentence and a live call are both something the user is in the middle of,
-   * and a watch session runs on its own either way.
+   * sentence and a live call are both something the user is in the middle of.
+   * Being outranked costs the session nothing, because this phase is only what
+   * the pill is showing. Whether the screen is being read is
+   * {@link CompanionSurfaceProps.watching}, and that is what the indicator
+   * reads.
    */
   | "watching"
   | "call"
@@ -377,6 +379,24 @@ export interface CompanionSurfaceProps {
    */
   working?: boolean;
   /**
+   * Whether a session reading the screen is running.
+   *
+   * Its own input rather than `phase === "watching"`, and this is the one place
+   * on the surface where that separation is not a matter of taste. The phase
+   * says what the pill is showing; this says whether the screen is being read,
+   * and they are different questions. A phase is outranked by a half-typed
+   * sentence and by a live call, so an indicator drawn from one would go dark
+   * the moment the user typed or took a call, which is the same capture the
+   * user cannot see with a different trigger. The ring belongs to the session,
+   * not to whatever the surface happens to be drawing over it.
+   *
+   * Absence is not a session, the way `CompanionSurfaceState.watching` has it:
+   * every state that is not a positive answer has to read as nothing running,
+   * because the alternative is a consent signal over a machine nobody is
+   * capturing.
+   */
+  watching?: boolean;
+  /**
    * The running session, when `phase` is `call`.
    *
    * Absent renders the call state from fixed sample values, which is what the
@@ -420,12 +440,12 @@ export function CompanionSurface({
   onCancelTyping,
   onAvatarClick,
   working = false,
+  watching = false,
   call,
   onControl,
 }: CompanionSurfaceProps) {
   const expanded = phase !== "resting";
   const typing = phase === "typing";
-  const watching = phase === "watching";
 
   /**
    * Whether the assistant is working, from whichever side is in a position to
@@ -565,10 +585,12 @@ export function CompanionSurface({
           which is the state it has to be legible in: the whole point is being
           readable from the corner of an eye while the user works elsewhere.
 
-          A turn burns it in the assistant's colour, a watch session in amber.
-          The session wins when both are true: the creature already carries the
-          turn in its own pose, and a capture running with nothing drawn over it
-          is the worse of the two failures. */}
+          A turn burns it in the assistant's colour, a watch session in amber,
+          and the session's ring is drawn in every phase rather than only the
+          one named after it. The session also takes the colour when both are
+          true: the creature already carries the turn in its own pose, and a
+          capture running with nothing drawn over it is the worse of the two
+          failures. */}
       {(assistantWorking || watching) && (
         <span
           className={`companion-working-ring pointer-events-none absolute -inset-0.5 ${


### PR DESCRIPTION
## Summary

- **Watch**, an `Eye` `PillButton` on the idle row wired to a new `onWatch` prop, toggles the session that reads the screen.
- A `watching` phase holds the pill open regardless of the pointer, the way `call` does. It ranks below `typing` and `call` and above `hover`.
- A `watching?: boolean` prop, separate from the phase, drives the capture indicator. The phase says what the pill is showing; the flag says whether the screen is being read. The amber ring lights whenever the flag is true, in **every** phase, so a live capture never goes dark because the user started a sentence or took a call. Amber wins over the assistant's accent when a turn runs underneath: the creature already carries the turn in its own pose.
- **The stop action reaches as far as the indicator.** `typing` and `call` do not draw the idle row, so each carries its own icon-only `Stop watching` control on the same `onWatch`: in the composer's trailing cluster, and on the call row beside the activity line.
- **The state reaches a reader, not just a looker.** `PillButton` gains a `pressed` prop, distinct from the cosmetic `active`, which carries `aria-pressed` and draws the held-down look from one input. Watch is the only control on the surface that is genuinely on or off, so it is the only one that claims a pressed state.
- `FALLBACK_WIDTHS` is exported and a test asserts every entry stays at or under 360, which is `BASE_MAX_PILL_WIDTH` in `clients/macos/src/main/companion-window.ts`. Neither the canvas width nor its height changes.

## Widths and heights

| phase | width | headroom under 360 |
|---|---|---|
| resting | 44 | 316 |
| hover / watching | 272 | 88 |
| call (with the stop control) | 332 | 28 |
| typing | 360 (fixed `CARD_WIDTH`) | 0 |

The call row with the stop control measures 44 + (124 line + 4 x 32 controls + 16 gaps) + 8 = **320**; the 332 entry carries 12pt of slack. The card is unchanged in both dimensions: fixed 360 wide with the composer's field giving up the 32pt out of its own `flex-1`, and 280 tall against the 290 `BASE_MAX_CARD_HEIGHT` the canvas is sized for.

**The approval row is a deliberate exception.** It measures ~318 and the control would put it at ~354 against a hard 360 clip; what a too-narrow canvas clips is the trailing control, which there is Deny. A blocked turn is reading nothing while it waits, and answering it lands back on the row that carries the stop. Documented at the early return in `CallBody`.

## Accessibility

`active` was carrying two unrelated claims: a demo-reel highlight on Talk and Type, and a real toggle state on Watch. Wiring `aria-pressed` off it would have announced Talk as switched on because a recording wanted it lit. `pressed` is the separate prop, undefined everywhere that does not genuinely toggle, and it draws the held-down background itself so the state a reader is told and the state a looking user sees cannot come apart. `StopWatchingButton` stays an action with no pressed state: it goes one way and is drawn only while there is a session to end.

## For PR 8

```tsx
<CompanionSurface
  phase={...}            // "watching" when nothing outranks it
  watching={state.watching === true}
  onWatch={...}          // toggleWatch
/>
```

`watching` is not derived from the phase inside the component, and must not be: the phase is outranked by `typing` and `call`, and neither the indicator nor the stop control is.

Part of plan: learning-by-watching.md (PR 5 of 10)