### PR TITLE
feat(assistant): watch session manager with narration-triggered cadence

### DIFF
--- a/assistant/src/watch/__tests__/watch-session-manager.test.ts
+++ b/assistant/src/watch/__tests__/watch-session-manager.test.ts
@@ -1,0 +1,318 @@
+import { randomUUID } from "node:crypto";
+import { beforeEach, describe, expect, jest, test } from "bun:test";
+
+import { getConversation } from "../../persistence/conversation-crud.js";
+import { initializeDb } from "../../persistence/db-init.js";
+import type { HostObservation } from "../../runtime/host-observe.js";
+import { WatchSessionManager } from "../watch-session-manager.js";
+import { renderWatchTimeline } from "../watch-timeline.js";
+
+await initializeDb();
+
+const PRINCIPAL_ID = "principal-watch-test";
+
+/** A 1x1 JPEG, the shape the host hands over on every observe. */
+const SCREENSHOT_BASE64 =
+  "/9j/4AAQSkZJRgABAQEAYABgAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCAABAAEDASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwD3+iiigD//2Q==";
+
+/** An ordinary observation: the accessibility tree carried the screen. */
+function richObservation(): HostObservation {
+  return {
+    ok: true,
+    axTree: "Window: Editor\n[1] Button Save",
+    axDiff:
+      'CHANGES SINCE LAST ACTION:\n~ Changed: [1] Save - value: "a" to "b"',
+    screenshot: SCREENSHOT_BASE64,
+  };
+}
+
+/** The shape the helper returns when accessibility found no focused window. */
+function treelessObservation(): HostObservation {
+  return { ok: true, screenshot: SCREENSHOT_BASE64 };
+}
+
+/** The sentinel `AXTreeDiff` writes when the window was replaced wholesale. */
+function navigatedObservation(): HostObservation {
+  return {
+    ok: true,
+    axTree: "Window: Browser\n[1] Link Home",
+    axDiff:
+      "CHANGES SINCE LAST ACTION:\nPage navigated - UI changed substantially (40 of 50 elements differ). Refer to the current screen state below.",
+    screenshot: SCREENSHOT_BASE64,
+  };
+}
+
+let nowMs = 1_000_000;
+
+/**
+ * A manager wired to a scripted screen reader and the test's own clock, so a
+ * session's cadence is a function of the timeline the test writes rather than
+ * of how long the test took to run.
+ */
+function newManager(
+  respond: (call: number) => HostObservation = () => richObservation(),
+) {
+  const calls: number[] = [];
+  const manager = new WatchSessionManager({
+    now: () => nowMs,
+    observe: async () => {
+      calls.push(nowMs);
+      return respond(calls.length);
+    },
+  });
+  return { manager, calls };
+}
+
+function start(manager: WatchSessionManager) {
+  const result = manager.start({ sourceActorPrincipalId: PRINCIPAL_ID });
+  if (result.status !== "started") {
+    throw new Error(`Expected a started session, got ${result.status}`);
+  }
+  return result;
+}
+
+/**
+ * Let every already-resolved promise in an observation's chain settle. Fake
+ * timers stop the clock but not the microtask queue, so the work an expired
+ * timer kicks off lands here.
+ */
+async function settle(): Promise<void> {
+  for (let i = 0; i < 20; i += 1) {
+    await Promise.resolve();
+  }
+}
+
+/** Advance the session's clock and the timers armed against it together. */
+async function elapse(ms: number): Promise<void> {
+  nowMs += ms;
+  jest.advanceTimersByTime(ms);
+  await settle();
+}
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  nowMs = 1_000_000;
+});
+
+describe("watch session manager", () => {
+  test("runs in a background conversation so the thread stays out of the sidebar", () => {
+    const { manager } = newManager();
+    const started = start(manager);
+
+    expect(getConversation(started.conversationId)?.conversationType).toBe(
+      "background",
+    );
+    expect(manager.isActive()).toBe(true);
+    expect(manager.isActive(started.conversationId)).toBe(true);
+    expect(manager.isActive(randomUUID())).toBe(false);
+
+    manager.stop();
+  });
+
+  test("refuses a second session while one is running", () => {
+    const { manager } = newManager();
+    const started = start(manager);
+
+    const second = manager.start({ sourceActorPrincipalId: PRINCIPAL_ID });
+    expect(second).toEqual({
+      status: "busy",
+      sessionId: started.sessionId,
+      conversationId: started.conversationId,
+    });
+
+    manager.stop();
+    expect(manager.start({ sourceActorPrincipalId: PRINCIPAL_ID }).status).toBe(
+      "started",
+    );
+    manager.stop();
+  });
+
+  test("fails closed without an actor principal to observe for", () => {
+    const { manager, calls } = newManager();
+
+    const result = manager.start({
+      sourceActorPrincipalId: undefined as unknown as string,
+    });
+
+    expect(result.status).toBe("failed");
+    expect(manager.isActive()).toBe(false);
+    expect(calls).toHaveLength(0);
+  });
+
+  test("refuses a conversation id whose row does not exist", () => {
+    const { manager } = newManager();
+
+    const result = manager.start({
+      sourceActorPrincipalId: PRINCIPAL_ID,
+      conversationId: randomUUID(),
+    });
+
+    expect(result.status).toBe("failed");
+    expect(manager.isActive()).toBe(false);
+  });
+
+  test("collapses a burst of narration finals into one observation", async () => {
+    const { manager, calls } = newManager();
+    start(manager);
+
+    for (let i = 0; i < 5; i += 1) {
+      await manager.handleNarrationFinal(`burst ${i}`);
+      await elapse(400);
+    }
+
+    expect(calls).toHaveLength(1);
+
+    // The gap reopens once the minimum interval has passed.
+    await elapse(4_000);
+    await manager.handleNarrationFinal("after the floor");
+    expect(calls).toHaveLength(2);
+
+    manager.stop();
+  });
+
+  test("observes four times across a 60s session of ten narration finals", async () => {
+    const { manager, calls } = newManager();
+    const started = start(manager);
+
+    // Three clusters of three finals plus a closing one, the shape of someone
+    // describing a step, working through it, then describing the next.
+    const finalsAtMs = [
+      0, 500, 1_000, 20_000, 20_500, 21_000, 40_000, 40_500, 41_000, 59_000,
+    ];
+    let elapsedMs = 0;
+    for (const atMs of finalsAtMs) {
+      await elapse(atMs - elapsedMs);
+      elapsedMs = atMs;
+      await manager.handleNarrationFinal(`step at ${atMs}`);
+    }
+
+    expect(calls).toHaveLength(4);
+
+    const summary = manager.stop();
+    expect(summary).not.toBeNull();
+    expect(summary?.sessionId).toBe(started.sessionId);
+    expect(summary?.conversationId).toBe(started.conversationId);
+    expect(summary?.entryCount).toBe(finalsAtMs.length + calls.length);
+    expect(summary?.durationMs).toBe(59_000);
+  });
+
+  test("keeps observing through a silent stretch of work", async () => {
+    const { manager, calls } = newManager();
+    const started = start(manager);
+
+    // Not a word spoken for a minute and a half.
+    await elapse(30_000);
+    expect(calls).toHaveLength(1);
+    await elapse(30_000);
+    expect(calls).toHaveLength(2);
+    await elapse(30_000);
+    expect(calls).toHaveLength(3);
+
+    const rendered = renderWatchTimeline(started.sessionId);
+    expect(rendered.totalEntries).toBe(3);
+
+    manager.stop();
+  });
+
+  test("survives repeated observation failures and still hands back a handle", async () => {
+    const { manager, calls } = newManager((call) =>
+      call <= 3
+        ? {
+            ok: false,
+            reason: "No connected client supports screen observation",
+          }
+        : richObservation(),
+    );
+    const started = start(manager);
+
+    for (let i = 0; i < 4; i += 1) {
+      await manager.handleNarrationFinal(`narration ${i}`);
+      await elapse(6_000);
+    }
+
+    expect(calls).toHaveLength(4);
+    const summary = manager.stop();
+    // Four narrations landed; only the fourth observation had anything to file.
+    expect(summary?.entryCount).toBe(5);
+    expect(renderWatchTimeline(started.sessionId).totalEntries).toBe(5);
+  });
+
+  test("stop is idempotent and ends the cadence", async () => {
+    const { manager, calls } = newManager();
+    start(manager);
+
+    await manager.handleNarrationFinal("something worth watching");
+    expect(calls).toHaveLength(1);
+
+    const first = manager.stop();
+    expect(first).not.toBeNull();
+    expect(manager.stop()).toBeNull();
+    expect(manager.isActive()).toBe(false);
+    expect(manager.activeSessionId).toBeNull();
+
+    // Neither narration nor the idle ceiling reaches a stopped session.
+    await manager.handleNarrationFinal("nobody is listening");
+    await elapse(90_000);
+    expect(calls).toHaveLength(1);
+  });
+
+  test("never runs two observations at once, and drops one that lands after the session ended", async () => {
+    const releases: ((observation: HostObservation) => void)[] = [];
+    const manager = new WatchSessionManager({
+      now: () => nowMs,
+      observe: () =>
+        new Promise<HostObservation>((resolve) => {
+          releases.push(resolve);
+        }),
+    });
+    const started = start(manager);
+
+    const first = manager.handleNarrationFinal("mid-observation");
+    await settle();
+    expect(releases).toHaveLength(1);
+
+    // The floor has passed but the first read has not come back, so this final
+    // records what was said and waits rather than stacking a second request.
+    await elapse(6_000);
+    const second = manager.handleNarrationFinal("still talking");
+    await settle();
+    expect(releases).toHaveLength(1);
+
+    const summary = manager.stop();
+    expect(summary?.entryCount).toBe(2);
+
+    for (const release of releases) {
+      release(richObservation());
+    }
+    await Promise.all([first, second]);
+    await settle();
+
+    expect(renderWatchTimeline(started.sessionId).totalEntries).toBe(2);
+  });
+
+  describe("screenshot escalation", () => {
+    async function observeOnce(respond: () => HostObservation) {
+      const { manager } = newManager(respond);
+      const started = start(manager);
+      await manager.handleNarrationFinal("look at this");
+      manager.stop();
+      return renderWatchTimeline(started.sessionId);
+    }
+
+    test("keeps no frame when the accessibility tree carried the screen", async () => {
+      const rendered = await observeOnce(richObservation);
+      expect(rendered.totalEntries).toBe(2);
+      expect(rendered.screenshotEntryIds).toHaveLength(0);
+    });
+
+    test("keeps a frame when the observation has no accessibility tree", async () => {
+      const rendered = await observeOnce(treelessObservation);
+      expect(rendered.screenshotEntryIds).toHaveLength(1);
+    });
+
+    test("keeps a frame when the diff reports a whole-window replacement", async () => {
+      const rendered = await observeOnce(navigatedObservation);
+      expect(rendered.screenshotEntryIds).toHaveLength(1);
+    });
+  });
+});

--- a/assistant/src/watch/__tests__/watch-session-manager.test.ts
+++ b/assistant/src/watch/__tests__/watch-session-manager.test.ts
@@ -63,6 +63,22 @@ function newManager(
   return { manager, calls };
 }
 
+/**
+ * A manager whose screen reads hang until the test releases them, so how long
+ * the host takes to answer is something the test states rather than waits for.
+ */
+function newDeferredManager() {
+  const releases: ((observation: HostObservation) => void)[] = [];
+  const manager = new WatchSessionManager({
+    now: () => nowMs,
+    observe: () =>
+      new Promise<HostObservation>((resolve) => {
+        releases.push(resolve);
+      }),
+  });
+  return { manager, releases };
+}
+
 function start(manager: WatchSessionManager) {
   const result = manager.start({ sourceActorPrincipalId: PRINCIPAL_ID });
   if (result.status !== "started") {
@@ -257,14 +273,7 @@ describe("watch session manager", () => {
   });
 
   test("never runs two observations at once, and drops one that lands after the session ended", async () => {
-    const releases: ((observation: HostObservation) => void)[] = [];
-    const manager = new WatchSessionManager({
-      now: () => nowMs,
-      observe: () =>
-        new Promise<HostObservation>((resolve) => {
-          releases.push(resolve);
-        }),
-    });
+    const { manager, releases } = newDeferredManager();
     const started = start(manager);
 
     const first = manager.handleNarrationFinal("mid-observation");
@@ -288,6 +297,51 @@ describe("watch session manager", () => {
     await settle();
 
     expect(renderWatchTimeline(started.sessionId).totalEntries).toBe(2);
+  });
+
+  test("a slow read spends the interval it belongs to rather than extending it", async () => {
+    const { manager, releases } = newDeferredManager();
+    start(manager);
+
+    // Silence, so the ceiling is what dispatches the read.
+    await elapse(30_000);
+    expect(releases).toHaveLength(1);
+
+    // The host takes 8s to answer, most of the 10s the session allows it.
+    await elapse(8_000);
+    releases[0](richObservation());
+    await settle();
+
+    // The next read is due 30s after the one that went out, so 22s from here.
+    // A fresh interval measured from the answer would put it 8s later.
+    await elapse(21_999);
+    expect(releases).toHaveLength(1);
+    await elapse(1);
+    expect(releases).toHaveLength(2);
+
+    manager.stop();
+  });
+
+  test("a ceiling tick that lands mid-read is deferred, not dropped", async () => {
+    const { manager, releases } = newDeferredManager();
+    start(manager);
+
+    const narration = manager.handleNarrationFinal("starting the long one");
+    await settle();
+    expect(releases).toHaveLength(1);
+
+    // The ceiling comes due while that read is still out. It stacks no second
+    // request, and the deadline it belongs to is already spent.
+    await elapse(30_000);
+    expect(releases).toHaveLength(1);
+
+    releases[0](richObservation());
+    await narration;
+    await settle();
+    await elapse(1);
+    expect(releases).toHaveLength(2);
+
+    manager.stop();
   });
 
   describe("screenshot escalation", () => {

--- a/assistant/src/watch/watch-session-manager.ts
+++ b/assistant/src/watch/watch-session-manager.ts
@@ -63,9 +63,10 @@ const MIN_OBSERVE_INTERVAL_MS = 5_000;
  * jumps from what they said before to what they said after with the work
  * itself missing. This is the ceiling on that gap.
  *
- * It is a ceiling and not a poll. It is rearmed from the last observation, so
- * it fires only in a stretch where narration produced none, and a talkative
- * session never reaches it.
+ * It is a ceiling and not a poll. The deadline runs from the moment the last
+ * observation was dispatched, so the wait a slow read spends counts against the
+ * ceiling rather than adding to it. It fires only in a stretch where narration
+ * produced none, and a talkative session never reaches it.
  */
 const MAX_OBSERVE_INTERVAL_MS = 30_000;
 
@@ -173,9 +174,10 @@ interface ActiveWatchSession {
   readonly startedAtMs: number;
   entryCount: number;
   /**
-   * When the last observation was dispatched. Negative infinity until the
-   * first one, so a session observes on its opening narration rather than
-   * spending its first interval blind.
+   * When the last observation was dispatched, the anchor both the rate limit
+   * and the idle ceiling measure from. Negative infinity until the first one,
+   * so a session observes on its opening narration rather than spending its
+   * first interval blind.
    */
   lastObserveAtMs: number;
   observing: boolean;
@@ -342,12 +344,19 @@ export class WatchSessionManager {
    * Read the screen once and file the result under the moment the request went
    * out.
    *
-   * The rate limit is anchored at dispatch rather than at completion, so a
-   * slow read does not shorten the gap before the next one, and a read still
-   * in flight turns away the finals that arrive during it.
+   * The rate limit and the idle ceiling are both anchored at dispatch rather
+   * than at completion, so a slow read neither shortens the gap before the next
+   * one nor pushes it out, and a read still in flight turns away the finals
+   * that arrive during it.
    */
   private async observeNow(session: ActiveWatchSession): Promise<void> {
-    if (session.stopped || session.observing) {
+    if (session.stopped) {
+      return;
+    }
+    if (session.observing) {
+      // The read in flight stands in for this one: it rearms the ceiling
+      // against its own dispatch when it settles, which is already due when the
+      // read outlasted the interval. The tick is deferred, not dropped.
       return;
     }
     session.observing = true;
@@ -399,18 +408,28 @@ export class WatchSessionManager {
   /**
    * Arm the ceiling on the gap between observations.
    *
-   * Rearmed after each observation rather than run as an interval, so it
-   * measures from the last thing recorded and never queues behind itself.
+   * The deadline is {@link MAX_OBSERVE_INTERVAL_MS} past the last dispatch, so
+   * rearming it after a slow read leaves only what remains of that interval and
+   * a read that outlasts the interval leaves nothing: the next observation goes
+   * out as soon as it settles. Rearmed rather than run as an interval, so it
+   * never queues behind itself.
    */
   private scheduleIdleObservation(session: ActiveWatchSession): void {
     this.clearIdleTimer(session);
     if (session.stopped) {
       return;
     }
+    // Before the first observation the ceiling runs from the session's start,
+    // the last moment its screen was accounted for.
+    const anchorMs = Math.max(session.lastObserveAtMs, session.startedAtMs);
+    const delayMs = Math.max(
+      0,
+      anchorMs + MAX_OBSERVE_INTERVAL_MS - this.now(),
+    );
     const timer = setTimeout(() => {
       session.idleTimer = null;
       void this.observeNow(session);
-    }, MAX_OBSERVE_INTERVAL_MS);
+    }, delayMs);
     // A watch session is not a reason to hold the process open.
     timer.unref?.();
     session.idleTimer = timer;

--- a/assistant/src/watch/watch-session-manager.ts
+++ b/assistant/src/watch/watch-session-manager.ts
@@ -1,0 +1,445 @@
+/**
+ * The live half of a watch session: the user narrates a task while they work,
+ * and this decides when to read their screen and what of it to keep.
+ *
+ * One session at a time, the way `live-voice-session-manager.ts` holds one
+ * call. Both are driven by a microphone the machine has exactly one of, and
+ * both own a slot rather than a set: a second session would compete for the
+ * same audio and interleave two unrelated timelines into one store.
+ *
+ * The manager owns three decisions the pieces below it deliberately do not
+ * make. When to observe, which is a cadence question and belongs to whoever
+ * hears the narration. Which observations are worth a stored frame, which
+ * `watch-timeline` refuses to infer because the payload it is handed always
+ * carries one. And when the session is over, which it answers with a handle
+ * rather than by acting: the retrospective is a conversational turn, and a
+ * session that ends because the daemon is shutting down has nowhere to run it.
+ */
+
+import { randomUUID } from "node:crypto";
+
+import {
+  createConversation,
+  getConversation,
+} from "../persistence/conversation-crud.js";
+import {
+  type HostObservationFields,
+  observeHostScreen,
+} from "../runtime/host-observe.js";
+import { getLogger } from "../util/logger.js";
+import {
+  appendNarration,
+  appendObservation,
+  type WatchAppendResult,
+} from "./watch-timeline.js";
+
+const log = getLogger("watch-session-manager");
+
+/**
+ * Shortest gap between two observations.
+ *
+ * Observation is triggered by narration, not by a poll. A speech final is the
+ * moment the user just said what they were doing, which is exactly the moment
+ * their screen is worth recording. A poll is both wasteful and lossy: most
+ * ticks land mid-gesture on a screen nobody described, and the change that
+ * matters lands between two of them. The subscription that would make polling
+ * unnecessary does not exist either: the mac helper's `cu.perform` is strictly
+ * request/response (`HostCuExecutor.swift`), with no channel for the host to
+ * push an accessibility change of its own.
+ *
+ * Someone talking through a task produces a final every second or two, and
+ * every observation costs a full accessibility enumeration plus a JPEG over
+ * the wire. Five seconds collapses a burst of finals into one record while
+ * staying shorter than any UI step a person pauses to narrate, so no step
+ * passes unobserved.
+ */
+const MIN_OBSERVE_INTERVAL_MS = 5_000;
+
+/**
+ * Longest a session goes without an observation.
+ *
+ * Narration is the trigger, so silent work would otherwise be invisible: the
+ * user drags a file, waits on a build, or reads for a minute, and the timeline
+ * jumps from what they said before to what they said after with the work
+ * itself missing. This is the ceiling on that gap.
+ *
+ * It is a ceiling and not a poll. It is rearmed from the last observation, so
+ * it fires only in a stretch where narration produced none, and a talkative
+ * session never reaches it.
+ */
+const MAX_OBSERVE_INTERVAL_MS = 30_000;
+
+/**
+ * How long one observation may take before the session gives up on it.
+ *
+ * Shorter than {@link MAX_OBSERVE_INTERVAL_MS} so a stalled request cannot
+ * outlive the cadence slot it belongs to. `observeHostScreen` defaults to 30s,
+ * which is a reasonable wait for a caller with a turn to block on it, and too
+ * long for one recording a screen that has since moved on.
+ */
+const OBSERVE_TIMEOUT_MS = 10_000;
+
+/**
+ * The sentence `AXTreeDiff` writes in place of a diff when the window it
+ * compared was replaced wholesale rather than edited (`AXTreeDiff.swift`).
+ */
+const WHOLE_WINDOW_REPLACEMENT_MARKER = "Page navigated";
+
+/** Title carried by a conversation a session mints for itself. */
+const WATCH_CONVERSATION_TITLE = "Watch session";
+
+// FROZEN: persisted `conversations.source` value. Never rename it.
+const WATCH_CONVERSATION_SOURCE = "watch";
+
+/**
+ * Whether an observation is worth a stored frame.
+ *
+ * Text first. An accessibility tree describes the screen in a form the
+ * retrospective reads directly and costs a fraction of a JPEG to keep. That
+ * the payload carries a screenshot is no signal at all: the mac helper
+ * captures one on every observe with no opt-out (`HostCuExecutor.swift`), so
+ * it is always true. Two shapes make the text thin enough that the pixels
+ * become the better record:
+ *
+ * - No tree. The helper fell back to a bare screenshot because accessibility
+ *   enumeration found no focused window, the ordinary result for an app that
+ *   exposes nothing. The frame is the only account of that moment there is.
+ * - A whole-window replacement. The window the diff was computed against is
+ *   gone, so what the user is looking at now is unrelated to anything already
+ *   in the timeline.
+ */
+function shouldAttachScreenshot(observation: HostObservationFields): boolean {
+  if (!observation.axTree) {
+    return true;
+  }
+  return observation.axDiff?.includes(WHOLE_WINDOW_REPLACEMENT_MARKER) === true;
+}
+
+/** What a finished session leaves behind for the retrospective to read. */
+export interface WatchSessionSummary {
+  readonly sessionId: string;
+  readonly conversationId: string;
+  /** Timeline entries the session persisted, narrations and observations. */
+  readonly entryCount: number;
+  readonly durationMs: number;
+}
+
+export interface WatchSessionStartOptions {
+  /**
+   * Principal id of the actor the session observes on behalf of, the same
+   * binding every `HostCuProxy` caller carries. `observeHostScreen` matches
+   * the target desktop client against it and fails closed without one.
+   */
+  readonly sourceActorPrincipalId: string;
+  /**
+   * Adopt an existing conversation instead of minting one. The row must
+   * already exist.
+   */
+  readonly conversationId?: string;
+  /**
+   * The desktop client to observe. Required when the actor has more than one
+   * connected, because default selection resolves their single `host_cu`
+   * client and returns an ambiguity error otherwise.
+   */
+  readonly clientId?: string;
+}
+
+export type WatchSessionStartResult =
+  | {
+      readonly status: "started";
+      readonly sessionId: string;
+      readonly conversationId: string;
+    }
+  | {
+      readonly status: "busy";
+      readonly sessionId: string;
+      readonly conversationId: string;
+    }
+  | { readonly status: "failed"; readonly reason: string };
+
+export interface WatchSessionManagerOptions {
+  /** Reads the screen. Defaults to {@link observeHostScreen}. */
+  readonly observe?: typeof observeHostScreen;
+  /** Clock the timeline's `atMs` offsets and the rate limit are measured on. */
+  readonly now?: () => number;
+  readonly createSessionId?: () => string;
+}
+
+interface ActiveWatchSession {
+  readonly sessionId: string;
+  readonly conversationId: string;
+  readonly sourceActorPrincipalId: string;
+  readonly clientId: string | undefined;
+  readonly startedAtMs: number;
+  entryCount: number;
+  /**
+   * When the last observation was dispatched. Negative infinity until the
+   * first one, so a session observes on its opening narration rather than
+   * spending its first interval blind.
+   */
+  lastObserveAtMs: number;
+  observing: boolean;
+  stopped: boolean;
+  idleTimer: ReturnType<typeof setTimeout> | null;
+}
+
+export class WatchSessionManager {
+  private readonly observe: typeof observeHostScreen;
+  private readonly now: () => number;
+  private readonly createSessionId: () => string;
+  private session: ActiveWatchSession | null = null;
+
+  constructor(options: WatchSessionManagerOptions = {}) {
+    this.observe = options.observe ?? observeHostScreen;
+    this.now = options.now ?? Date.now;
+    this.createSessionId = options.createSessionId ?? randomUUID;
+  }
+
+  /**
+   * Whether a session is running, optionally for one specific conversation.
+   * The toggle that starts and ends a session reads this to know which edge a
+   * press is.
+   */
+  isActive(conversationId?: string): boolean {
+    const session = this.session;
+    if (session === null) {
+      return false;
+    }
+    return (
+      conversationId === undefined || session.conversationId === conversationId
+    );
+  }
+
+  get activeSessionId(): string | null {
+    return this.session?.sessionId ?? null;
+  }
+
+  start(options: WatchSessionStartOptions): WatchSessionStartResult {
+    const existing = this.session;
+    if (existing !== null) {
+      return {
+        status: "busy",
+        sessionId: existing.sessionId,
+        conversationId: existing.conversationId,
+      };
+    }
+
+    // The same fail-closed stance `observeHostScreen` takes, applied before a
+    // session exists rather than once per observation: a session without an
+    // actor could reach no client and would record nothing but failures.
+    if (!options.sourceActorPrincipalId) {
+      return {
+        status: "failed",
+        reason: "A watch session requires the actor principal it observes for.",
+      };
+    }
+
+    const conversationId = this.resolveConversationId(options.conversationId);
+    if (conversationId === null) {
+      return {
+        status: "failed",
+        reason: `Conversation "${options.conversationId}" does not exist.`,
+      };
+    }
+
+    const session: ActiveWatchSession = {
+      sessionId: this.createSessionId(),
+      conversationId,
+      sourceActorPrincipalId: options.sourceActorPrincipalId,
+      clientId: options.clientId,
+      startedAtMs: this.now(),
+      entryCount: 0,
+      lastObserveAtMs: Number.NEGATIVE_INFINITY,
+      observing: false,
+      stopped: false,
+      idleTimer: null,
+    };
+    this.session = session;
+    this.scheduleIdleObservation(session);
+
+    return {
+      status: "started",
+      sessionId: session.sessionId,
+      conversationId,
+    };
+  }
+
+  /**
+   * Record what the user just said and observe the screen if the cadence
+   * allows it. The entry point the streaming transcript calls on every final.
+   */
+  async handleNarrationFinal(text: string): Promise<void> {
+    const session = this.session;
+    if (session === null) {
+      return;
+    }
+
+    const nowMs = this.now();
+    this.recordAppend(
+      session,
+      appendNarration(session.sessionId, {
+        conversationId: session.conversationId,
+        text,
+        atMs: nowMs - session.startedAtMs,
+      }),
+    );
+
+    if (nowMs - session.lastObserveAtMs < MIN_OBSERVE_INTERVAL_MS) {
+      return;
+    }
+    await this.observeNow(session);
+  }
+
+  /**
+   * End the session and hand back what it recorded.
+   *
+   * Returns null when nothing is running, so a second stop and a stop that
+   * races a client disconnect are both no-ops rather than a second handle for
+   * the same session.
+   */
+  stop(): WatchSessionSummary | null {
+    const session = this.session;
+    this.session = null;
+    if (session === null) {
+      return null;
+    }
+
+    session.stopped = true;
+    this.clearIdleTimer(session);
+
+    return {
+      sessionId: session.sessionId,
+      conversationId: session.conversationId,
+      entryCount: session.entryCount,
+      durationMs: Math.max(0, this.now() - session.startedAtMs),
+    };
+  }
+
+  /**
+   * The conversation a session's timeline is keyed on.
+   *
+   * `background` so the thread stays out of the sidebar while the session
+   * runs: nothing is said in it, no turn runs, and its only reader is the
+   * retrospective that comes after. A caller-supplied id is adopted only when
+   * its row already exists, so a session never mints a conversation under an
+   * id it was handed.
+   */
+  private resolveConversationId(
+    conversationId: string | undefined,
+  ): string | null {
+    if (conversationId !== undefined) {
+      return getConversation(conversationId) === null ? null : conversationId;
+    }
+    return createConversation({
+      title: WATCH_CONVERSATION_TITLE,
+      conversationType: "background",
+      source: WATCH_CONVERSATION_SOURCE,
+      origin: "vellum",
+    }).id;
+  }
+
+  /**
+   * Read the screen once and file the result under the moment the request went
+   * out.
+   *
+   * The rate limit is anchored at dispatch rather than at completion, so a
+   * slow read does not shorten the gap before the next one, and a read still
+   * in flight turns away the finals that arrive during it.
+   */
+  private async observeNow(session: ActiveWatchSession): Promise<void> {
+    if (session.stopped || session.observing) {
+      return;
+    }
+    session.observing = true;
+    session.lastObserveAtMs = this.now();
+    const atMs = session.lastObserveAtMs - session.startedAtMs;
+
+    try {
+      const observation = await this.observe({
+        sourceActorPrincipalId: session.sourceActorPrincipalId,
+        timeoutMs: OBSERVE_TIMEOUT_MS,
+        ...(session.clientId ? { clientId: session.clientId } : {}),
+      });
+      if (session.stopped) {
+        return;
+      }
+      if (!observation.ok) {
+        // A session outlives a screen it could not read. The desktop client
+        // may be busy, asleep, or briefly disconnected, and the narration
+        // still arriving is worth keeping either way.
+        log.debug(
+          { sessionId: session.sessionId, reason: observation.reason },
+          "Watch observation failed",
+        );
+        return;
+      }
+      this.recordAppend(
+        session,
+        appendObservation(session.sessionId, {
+          conversationId: session.conversationId,
+          observation,
+          atMs,
+          attachScreenshot: shouldAttachScreenshot(observation),
+        }),
+      );
+    } catch (err) {
+      // Nothing on this path is meant to throw, and the idle timer has no
+      // caller to hand a rejection to, so an unexpected one ends the
+      // observation rather than the process.
+      log.warn(
+        { err, sessionId: session.sessionId },
+        "Watch observation threw",
+      );
+    } finally {
+      session.observing = false;
+      this.scheduleIdleObservation(session);
+    }
+  }
+
+  /**
+   * Arm the ceiling on the gap between observations.
+   *
+   * Rearmed after each observation rather than run as an interval, so it
+   * measures from the last thing recorded and never queues behind itself.
+   */
+  private scheduleIdleObservation(session: ActiveWatchSession): void {
+    this.clearIdleTimer(session);
+    if (session.stopped) {
+      return;
+    }
+    const timer = setTimeout(() => {
+      session.idleTimer = null;
+      void this.observeNow(session);
+    }, MAX_OBSERVE_INTERVAL_MS);
+    // A watch session is not a reason to hold the process open.
+    timer.unref?.();
+    session.idleTimer = timer;
+  }
+
+  private clearIdleTimer(session: ActiveWatchSession): void {
+    if (session.idleTimer !== null) {
+      clearTimeout(session.idleTimer);
+      session.idleTimer = null;
+    }
+  }
+
+  /**
+   * Count an append that landed. A refused one is logged and the session
+   * carries on: the store turns away an entry whose conversation is gone and
+   * one whose observation carried nothing, and neither is a reason to stop
+   * watching.
+   */
+  private recordAppend(
+    session: ActiveWatchSession,
+    result: WatchAppendResult,
+  ): void {
+    if (result.ok) {
+      session.entryCount += 1;
+      return;
+    }
+    log.debug(
+      { sessionId: session.sessionId, reason: result.reason },
+      "Watch timeline refused an entry",
+    );
+  }
+}


### PR DESCRIPTION
## Summary

- One live watch session at a time, keyed by conversation, with `start`, `stop`, and `isActive`, modeled structurally on `live-voice-session-manager.ts`. A session mints a `background` conversation so the thread stays out of the sidebar while it runs, and `stop` returns a summary handle (session id, conversation id, entry count, duration) for the retrospective to consume rather than running one itself.
- Cadence is narration-triggered: each STT final observes the screen, floored at 5s so a burst of finals collapses into one record, and ceilinged at 30s so a silent stretch of work is still captured. Both constants carry the reasoning for rejecting a poll, including that the mac helper offers no AX-change subscription (`cu.perform` is strictly request/response).
- The manager owns the `attachScreenshot` decision and escalates only on a thin AX result: no `axTree`, or an `axDiff` carrying `AXTreeDiff`'s whole-window-replacement sentinel. That the payload carries a screenshot is no signal, since `HostCuExecutor.swift` captures one on every observe. A failed observation logs and the session continues.

Part of plan: learning-by-watching.md (PR 4 of 10)