### PR TITLE
fix(web): drop the drop shadow from the drawer's Preferences pill

### DIFF
--- a/clients/web/src/domains/chat/components/preferences-menu.tsx
+++ b/clients/web/src/domains/chat/components/preferences-menu.tsx
@@ -83,12 +83,12 @@ export function PreferencesMenu({
 
   const trigger =
     triggerVariant === "pill" ? (
-      /* Solid surface + shadow: the pill floats over the scrolling
-         conversation list, so it can't be transparent like `ghost`. */
+      /* Solid surface: the pill floats over the scrolling conversation list,
+         so it can't be transparent like `ghost`. */
       <Button
         variant="ghost"
         leftIcon={<CircleUser />}
-        className="min-h-[var(--side-menu-tile-size,36px)] min-w-0 rounded-full border border-[var(--border-base)] bg-[var(--surface-lift)] px-3 shadow-[var(--shadow-lg)]"
+        className="min-h-[var(--side-menu-tile-size,36px)] min-w-0 rounded-full border border-[var(--border-base)] bg-[var(--surface-lift)] px-3"
       >
         {/* `truncate` is belt-and-braces: the label is a fixed short string,
             but the pill shares its row with New Chat and must never grow


### PR DESCRIPTION
## Summary

Removes `shadow-[var(--shadow-lg)]` from the `triggerVariant="pill"` Preferences button in the mobile drawer overlay. The solid surface and border already lift the pill off the conversation list scrolling behind it, so the shadow only added depth the design does not want. The comment above the button keeps the surviving rationale (solid surface, not `ghost` transparency) and drops the shadow mention.

The neighboring New Chat pill in `side-menu-overlay-bottom-column.tsx` intentionally keeps its shadow for now, pending a separate decision, so it is untouched here.

## Verification

- `bun scripts/run-tests.ts src/domains/chat/components/preferences-menu.test.tsx` from `clients/web`: 1 passed, 0 failed
- `bunx eslint src/domains/chat/components/preferences-menu.tsx`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)