### PR TITLE
fix(web): match the profile page header buttons and tiles to the mock

### DIFF
--- a/clients/web/src/domains/chat/chat-layout-header.tsx
+++ b/clients/web/src/domains/chat/chat-layout-header.tsx
@@ -9,7 +9,6 @@ import {
 import { useCallback, useEffect, type ReactNode } from "react";
 
 import { WindowsMenuBar } from "@/components/windows-menu-bar";
-import { NATIVE_MOBILE_BARE_ICON_BUTTON } from "@/domains/chat/utils/native-mobile-button-constants";
 import { WINDOWS_TITLE_BAR_CONTROL_CLEARANCE_PX } from "@/runtime/electron-window-chrome";
 import {
   detectElectronHostOS,
@@ -115,7 +114,6 @@ export function ChatLayoutHeader({
       iconOnly={<Search />}
       aria-label="Search (Ctrl+K)"
       tooltip="Search (Ctrl+K)"
-      className={NATIVE_MOBILE_BARE_ICON_BUTTON}
       onClick={handleSearchClick}
     />
   ) : null;
@@ -184,7 +182,6 @@ export function ChatLayoutHeader({
             aria-expanded={drawerOpen}
             aria-controls="chat-side-menu"
             tooltip="Open navigation"
-            className={NATIVE_MOBILE_BARE_ICON_BUTTON}
             onClick={toggleSidebar}
           />
         ) : (

--- a/clients/web/src/domains/intelligence/components/identity-overview.tsx
+++ b/clients/web/src/domains/intelligence/components/identity-overview.tsx
@@ -1051,8 +1051,13 @@ function OverviewBento({
                         : "text-[var(--content-secondary)]"
                     }`}
                   >
+                    {/* The mark's height follows its width, so the full frame
+                        at card width runs past 250px and the card swallows
+                        the tiles below it. The compact frame holds the band
+                        near 110px without shrinking the labels. */}
                     <PersonalitySignature
                       values={signature}
+                      compact
                       className="h-auto w-full"
                     />
                   </span>

--- a/clients/web/src/domains/intelligence/components/identity-overview.tsx
+++ b/clients/web/src/domains/intelligence/components/identity-overview.tsx
@@ -13,7 +13,7 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   Brain,
-  CalendarClock,
+  Calendar,
   ChevronRight,
   FolderOpen,
   LayoutGrid,
@@ -71,7 +71,7 @@ import { PersonalitySignature } from "./personality-signature";
 
 const SECTION_ICONS: Record<string, LucideIcon> = {
   personality: Sparkles,
-  schedules: CalendarClock,
+  schedules: Calendar,
   superpowers: Zap,
   memory: Brain,
   library: LayoutGrid,
@@ -995,7 +995,7 @@ function OverviewBento({
                 to={schedulesSection.to}
                 className="flex w-full cursor-pointer items-center gap-2 p-4 transition-all duration-150 hover:bg-[var(--card-hover)] active:scale-[0.98]"
               >
-                <CalendarClock
+                <Calendar
                   className="h-6 w-6 shrink-0 text-[var(--content-default)]"
                   aria-hidden
                 />

--- a/clients/web/src/domains/intelligence/components/identity-overview.tsx
+++ b/clients/web/src/domains/intelligence/components/identity-overview.tsx
@@ -480,8 +480,10 @@ function SectionCard({
         >
           {floodOverlay}
           <span className="relative flex h-10 w-10 shrink-0 items-center justify-center">
+            {/* The stacked tiles keep the 40px slot but sit a smaller glyph
+                in it, so the title leads the row rather than the icon. */}
             <Icon
-              className={`h-5 w-5 transition-colors duration-300 ${fgMuted}`}
+              className={`${compact ? "h-3.5 w-3.5" : "h-5 w-5"} transition-colors duration-300 ${fgMuted}`}
               aria-hidden
             />
           </span>

--- a/clients/web/src/domains/intelligence/components/personality-signature.tsx
+++ b/clients/web/src/domains/intelligence/components/personality-signature.tsx
@@ -27,23 +27,49 @@ import {
 } from "../identity-actions/personality-axes";
 
 const W = 340;
-/**
- * The frame is taller than the mark strictly needs so the signature fills its
- * card rather than floating in the middle of it — the extra height goes to
- * capsule travel and to the gap between the poles, not to dead margin. The
- * label baselines sit the same distance from the top and bottom edges, so a
- * frame that ends flush with the card leaves an even gap at both.
- */
-const H = 226;
-/** The neutral line: where a trait sits when neither pole has been chosen. */
-const MID = 113;
 const PAD_X = 46;
-/** Vertical travel from the neutral line to a pole. */
-const SPAN = 58;
-/** Baselines for the first line of each pole label. */
-const TOP_Y = 15;
-const BOTTOM_Y = 216;
 const LINE_H = 11.5;
+
+interface SignatureFrame {
+  /** viewBox height; the mark's aspect ratio, since the width is fixed. */
+  h: number;
+  /** The neutral line: where a trait sits when neither pole has been chosen. */
+  mid: number;
+  /** Vertical travel from the neutral line to a pole. */
+  span: number;
+  /** Baseline for the first line of a pole label above the rule. */
+  topY: number;
+  /** Baseline for the last line of a pole label below it. */
+  bottomY: number;
+}
+
+/**
+ * The default frame is taller than the mark strictly needs so the signature
+ * fills its card rather than floating in the middle of it: the extra height
+ * goes to capsule travel and to the gap between the poles, not to dead margin.
+ * The label baselines sit the same distance from the top and bottom edges, so
+ * a frame that ends flush with the card leaves an even gap at both.
+ */
+const FULL_FRAME: SignatureFrame = {
+  h: 226,
+  mid: 113,
+  span: 58,
+  topY: 15,
+  bottomY: 216,
+};
+
+/**
+ * Half the height, for a card that gives the mark a band rather than a panel.
+ * Only the vertical metrics shrink: the labels keep their size, so what the
+ * band gives up is capsule travel and not legibility.
+ */
+const COMPACT_FRAME: SignatureFrame = {
+  h: 108,
+  mid: 52,
+  span: 18,
+  topY: 12,
+  bottomY: 96,
+};
 /** Inside this much of neutral a trait reads as unset, not as a lean. */
 const DEAD_ZONE = 5;
 /** Capsule width; also the diameter an unset trait collapses to. */
@@ -61,8 +87,8 @@ function axisValue(values: Record<string, number>, id: string): number {
   return Math.max(0, Math.min(100, n));
 }
 
-function yFor(value: number): number {
-  return MID - ((value - 50) / 50) * SPAN;
+function yFor(value: number, frame: SignatureFrame): number {
+  return frame.mid - ((value - 50) / 50) * frame.span;
 }
 
 /** "Baby Boomer" needs two lines at this size; single words never wrap. */
@@ -73,6 +99,7 @@ function poleLines(label: string): string[] {
 interface PoleLabelProps {
   x: number;
   label: string;
+  frame: SignatureFrame;
   /** Above the rule the label grows downward; below it, upward. */
   above: boolean;
   /** This is the pole the trait was pushed toward. */
@@ -87,13 +114,14 @@ interface PoleLabelProps {
 function PoleLabel({
   x,
   label,
+  frame,
   above,
   leaning,
   neutral,
   magnitude,
 }: PoleLabelProps) {
   const rows = poleLines(label);
-  const y = above ? TOP_Y : BOTTOM_Y - (rows.length - 1) * LINE_H;
+  const y = above ? frame.topY : frame.bottomY - (rows.length - 1) * LINE_H;
   const strong = leaning && !neutral;
   const opacity = neutral
     ? NEUTRAL_LABEL_OPACITY
@@ -121,15 +149,19 @@ function PoleLabel({
 
 interface PersonalitySignatureProps {
   values: Record<string, number>;
+  /** Draw the mark in the short band rather than the full panel. */
+  compact?: boolean;
   className?: string;
 }
 
 export function PersonalitySignature({
   values,
+  compact = false,
   className,
 }: PersonalitySignatureProps) {
   const { t } = useTranslation("intelligence");
   const reduce = useReducedMotion();
+  const frame = compact ? COMPACT_FRAME : FULL_FRAME;
 
   const axes = PERSONALITY_AXES.map((axis) => {
     const value = axisValue(values, axis.id);
@@ -164,7 +196,7 @@ export function PersonalitySignature({
     return () => controls.stop();
   }, [reduce]);
 
-  const ys = axes.map((a) => yFor(50 + (a.value - 50) * grown));
+  const ys = axes.map((a) => yFor(50 + (a.value - 50) * grown, frame));
 
   const ariaLabel = axes
     .map(({ left, right, lean, neutral, magnitude }) => {
@@ -180,16 +212,16 @@ export function PersonalitySignature({
 
   return (
     <svg
-      viewBox={`0 0 ${W} ${H}`}
+      viewBox={`0 0 ${W} ${frame.h}`}
       role="img"
       aria-label={t("personalitySignature.ariaLabel", { summary: ariaLabel })}
       className={className}
     >
       <line
         x1={PAD_X - 14}
-        y1={MID}
+        y1={frame.mid}
         x2={W - PAD_X + 14}
-        y2={MID}
+        y2={frame.mid}
         stroke="currentColor"
         strokeOpacity={0.3}
         strokeWidth={1}
@@ -205,9 +237,9 @@ export function PersonalitySignature({
         <rect
           key={axis.id}
           x={XS[i]! - CAP_W / 2}
-          y={Math.min(MID, ys[i]!) - CAP_W / 2}
+          y={Math.min(frame.mid, ys[i]!) - CAP_W / 2}
           width={CAP_W}
-          height={Math.abs(ys[i]! - MID) + CAP_W}
+          height={Math.abs(ys[i]! - frame.mid) + CAP_W}
           rx={CAP_W / 2}
           fill="var(--card-accent)"
         />
@@ -218,6 +250,7 @@ export function PersonalitySignature({
           <PoleLabel
             x={XS[i]!}
             label={right}
+            frame={frame}
             above
             leaning={lean > 0}
             neutral={neutral}
@@ -226,6 +259,7 @@ export function PersonalitySignature({
           <PoleLabel
             x={XS[i]!}
             label={left}
+            frame={frame}
             above={false}
             leaning={lean < 0}
             neutral={neutral}

--- a/clients/web/src/domains/intelligence/identity-section-stat-labels.test.ts
+++ b/clients/web/src/domains/intelligence/identity-section-stat-labels.test.ts
@@ -37,9 +37,13 @@ const UNIT_LABEL_KEYS = [
 const COUNT_PHRASE_KEYS = [
   "identityOverview.memoryCount",
   "useIdentitySectionStats.activeCount",
+  "useIdentitySectionStats.appAndDocCount",
+  "useIdentitySectionStats.appCount",
   "useIdentitySectionStats.connectedCount",
   "useIdentitySectionStats.itemCount",
   "useIdentitySectionStats.personCount",
+  "useIdentitySectionStats.skillAndPluginCount",
+  "useIdentitySectionStats.skillCount",
 ] as const;
 
 /** Exercises the `one` and `other` categories and a multi-digit count. */

--- a/clients/web/src/domains/intelligence/use-identity-section-stats.ts
+++ b/clients/web/src/domains/intelligence/use-identity-section-stats.ts
@@ -159,41 +159,35 @@ export function useIdentitySectionStats(
           ? completeSliderValues(sliders.data ?? {})
           : undefined,
     },
-    // Skills and plugins share the merged My Superpowers card; the stat
-    // names both kinds (interpunct-separated) so a plugin never hides
-    // inside a bare count. The plugin half appears once its query resolves
-    // — on assistants without the plugin surface it never does, and the
-    // stat stays skills-only.
+    // Skills and plugins share the merged Superpowers card, and the tile
+    // states them as one total rather than two counts. Until the plugin
+    // query resolves, and forever on assistants without the plugin surface,
+    // that total would understate itself, so the stat stays skills-only.
     superpowers:
       skills.data !== undefined
         ? {
-            text: [
-              t("useIdentitySectionStats.skillCount", { count: skills.data }),
-              ...(plugins.data !== undefined
-                ? [
-                    t("useIdentitySectionStats.pluginCount", {
-                      count: plugins.data,
-                    }),
-                  ]
-                : []),
-            ].join(" · "),
+            text:
+              plugins.data !== undefined
+                ? t("useIdentitySectionStats.skillAndPluginCount", {
+                    count: skills.data + plugins.data,
+                  })
+                : t("useIdentitySectionStats.skillCount", {
+                    count: skills.data,
+                  }),
           }
         : undefined,
-    // Apps and documents share the Library card; like the superpowers stat,
-    // both kinds are named (interpunct-separated) once their reads resolve.
+    // Apps and documents share the Library card and read as one total, on
+    // the same terms as the superpowers stat above: apps alone until the
+    // document read resolves.
     library:
       apps.data !== undefined
         ? {
-            text: [
-              t("useIdentitySectionStats.appCount", { count: apps.data }),
-              ...(documents.data !== undefined
-                ? [
-                    t("useIdentitySectionStats.docCount", {
-                      count: documents.data,
-                    }),
-                  ]
-                : []),
-            ].join(" · "),
+            text:
+              documents.data !== undefined
+                ? t("useIdentitySectionStats.appAndDocCount", {
+                    count: apps.data + documents.data,
+                  })
+                : t("useIdentitySectionStats.appCount", { count: apps.data }),
           }
         : undefined,
     workspace:

--- a/clients/web/src/i18n/locales/en/intelligence.json
+++ b/clients/web/src/i18n/locales/en/intelligence.json
@@ -385,16 +385,16 @@
   "useIdentitySectionStats": {
     "activeCount": "{count, plural, one {# active} other {# active}}",
     "activeLabel": "{count, plural, one {active} other {active}}",
+    "appAndDocCount": "{count, plural, one {# app or doc} other {# apps & docs}}",
     "appCount": "{count, plural, one {# app} other {# apps}}",
     "connectedCount": "{count, plural, one {# connected} other {# connected}}",
     "connectedLabel": "{count, plural, one {connected} other {connected}}",
-    "docCount": "{count, plural, one {# doc} other {# docs}}",
     "itemCount": "{count, plural, one {# item} other {# items}}",
     "itemLabel": "{count, plural, one {item} other {items}}",
     "noSchedulesText": "Nothing scheduled yet",
     "personCount": "{count, plural, one {# person} other {# people}}",
     "personLabel": "{count, plural, one {person} other {people}}",
-    "pluginCount": "{count, plural, one {# plugin} other {# plugins}}",
+    "skillAndPluginCount": "{count, plural, one {# skill or plugin} other {# skills & plugins}}",
     "skillCount": "{count, plural, one {# skill} other {# skills}}"
   },
   "usePluginsList": {

--- a/clients/web/src/i18n/locales/en/intelligence.json
+++ b/clients/web/src/i18n/locales/en/intelligence.json
@@ -131,7 +131,7 @@
     },
     "superpowers": {
       "description": "What I can do",
-      "label": "My Superpowers"
+      "label": "Superpowers"
     },
     "workspace": {
       "description": "My files",

--- a/clients/web/src/i18n/locales/es/intelligence.json
+++ b/clients/web/src/i18n/locales/es/intelligence.json
@@ -385,16 +385,16 @@
   "useIdentitySectionStats": {
     "activeCount": "{count, plural, one {# activa} other {# activas}}",
     "activeLabel": "{count, plural, one {activa} other {activas}}",
+    "appAndDocCount": "{count, plural, one {# app o documento} other {# apps y documentos}}",
     "appCount": "{count, plural, one {# app} other {# apps}}",
     "connectedCount": "{count, plural, one {# conectado} other {# conectados}}",
     "connectedLabel": "{count, plural, one {conectado} other {conectados}}",
-    "docCount": "{count, plural, one {# documento} other {# documentos}}",
     "itemCount": "{count, plural, one {# elemento} other {# elementos}}",
     "itemLabel": "{count, plural, one {elemento} other {elementos}}",
     "noSchedulesText": "Todavía no hay nada programado",
     "personCount": "{count, plural, one {# persona} other {# personas}}",
     "personLabel": "{count, plural, one {persona} other {personas}}",
-    "pluginCount": "{count, plural, one {# plugin} other {# plugins}}",
+    "skillAndPluginCount": "{count, plural, one {# habilidad o plugin} other {# habilidades y plugins}}",
     "skillCount": "{count, plural, one {# habilidad} other {# habilidades}}"
   },
   "usePluginsList": {

--- a/clients/web/src/i18n/locales/es/intelligence.json
+++ b/clients/web/src/i18n/locales/es/intelligence.json
@@ -131,7 +131,7 @@
     },
     "superpowers": {
       "description": "Lo que puedo hacer",
-      "label": "Mis superpoderes"
+      "label": "Superpoderes"
     },
     "workspace": {
       "description": "Mis archivos",


### PR DESCRIPTION
The mobile assistant-profile page drifted from the design mock in a handful of small ways. Each is its own commit.

## Changes

**1. Header circles** (`chat-layout-header.tsx`)
The mobile search and hamburger buttons passed `NATIVE_MOBILE_BARE_ICON_BUTTON`, which strips the design library's touch-mobile circular fill from an icon-only ghost `Button`. The notification bell never opted out, so the three header controls rendered as two bare glyphs beside one filled circle. Dropping the override on both leaves them identical. The drawer's own uses of that constant (`assistant-side-menu.tsx`) are untouched, so the module stays.

**2. Tile title** (`intelligence.json`)
The overview grid tile read "My Superpowers", which truncates in the phone grid's two-column tile. The overview cards carry their own label key (`identitySections.superpowers.label`, consumed only by `buildIdentitySections`), so shortening it to "Superpowers" leaves the section page heading (`sections.superpowers`, still "My Superpowers") and every other surface alone. `es` updated to match.

**3. Combined stat subtitles** (`use-identity-section-stats.ts`, `intelligence.json`)
The Superpowers and Library tiles listed their two kinds separately ("38 skills · 2 plugins", "2 apps · 2 docs"), which reads as two facts and wraps on a phone. Both now state one total through a single ICU plural: "40 skills & plugins", "4 apps & docs". The second read is not always available (the plugin query never resolves on an assistant without the plugin surface), so the stat falls back to the leading kind alone rather than understating the total. Contacts ("2 people") and Channels ("1 connected") already matched the mock and are unchanged.

New keys `skillAndPluginCount` / `appAndDocCount` (en + es); the now-orphaned `pluginCount` / `docCount` are removed, which `catalogs.test.ts` requires. All four one-line count phrases are added to `identity-section-stat-labels.test.ts` so the "count stated exactly once" guard covers them.

**4. Tile glyphs** (`identity-overview.tsx`)
The stacked tiles drew a 20px glyph in their 40px slot; the mock has a small ~14px glyph in that same slot, in `var(--content-secondary)` (which `fgMuted` already resolves to). Scoped to the `compact` variant, per the existing note on `SectionCard` that the stacked tiles and the desktop bottom strip are specced separately.

**5. Schedules glyph** (`identity-overview.tsx`)
`CalendarClock` → lucide `Calendar`, in both the icon map and the stacked layout's inline Schedules row.

**6. Personality band** (`personality-signature.tsx`, `identity-overview.tsx`) — **separable**
The signature's height follows its width, so at phone card width the full 340×226 frame drew a panel over 250px tall and pushed the tiles below it off the first screen. Capping the rendered height instead would letterboxing-scale the whole mark and make the pole labels illegible (~5px), so this adds a second vertical frame: same width, same font size, ~108 tall, with the capsule travel shrunk to make room. The stacked Personality card passes `compact`; the bento card is unchanged.

**Drop this commit and the other five still stand.**

## Desktop-visible effects

- **(2)** and **(3)** also feed the desktop bento: its Superpowers card now reads "Superpowers" and its bottom-strip Superpowers/Library tiles show the combined totals.
- **(5)** applies everywhere the Schedules icon renders, bento included, so the section reads the same on every surface.
- **(1)**, **(4)** and **(6)** are mobile/stacked only.

## Verification

- `bun scripts/run-tests.ts` (each in isolation): `chat-layout-header.test.tsx`, `identity-section-stat-labels.test.ts`, `i18n/catalogs.test.ts`, `intelligence-layout.test.tsx`, `identity-sections.test.ts` — all pass.
- `bunx tsc --noEmit` — no errors in any touched file.
- `bunx eslint` + `bunx prettier --check` on all touched files — clean.
- Compact-frame geometry checked against a throwaway SSR render: `viewBox="0 0 340 108"`, rule at y=52, and both two-line pole labels ("Baby Boomer", "Sin filtro") clear the capsule band.

Not yet verified in a running app on a device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
