### PR TITLE
fix(web): paint the composer pills from the last launch instead of popping in

### DIFF
--- a/clients/web/src/domains/chat/components/composer-settings-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/composer-settings-menu.test.tsx
@@ -55,19 +55,25 @@ mock.module("@vellumai/design-library/components/toast", () => ({
 }));
 
 // --- threshold-api (mount-time access-level fetches) -------------------------
-// A `mock()` rather than a plain stub so the boot-seed cases can hold the
-// global-thresholds fetch open and observe what the pill renders meanwhile.
+// Mocks rather than plain stubs: the boot-seed cases hold the global-thresholds
+// fetch open to observe what the pill renders meanwhile, and assert that a
+// press in that window reaches no mutation. `"low"` is a real `RiskThreshold`
+// and maps to the Conservative preset, which is the label the rest of the file
+// expects the access trigger to settle on.
 const getGlobalThresholdsMock = mock(
   async (_assistantId: string): Promise<{ interactive: unknown }> => ({
-    interactive: 50,
+    interactive: "low",
   }),
 );
+const setGlobalThresholdsMock = mock(async (..._args: unknown[]) => {});
+const setConversationOverrideMock = mock(async (..._args: unknown[]) => {});
+const deleteConversationOverrideMock = mock(async (..._args: unknown[]) => {});
 mock.module("@/lib/threshold-api", () => ({
   getGlobalThresholds: getGlobalThresholdsMock,
   getConversationOverride: async () => null,
-  setConversationOverride: async () => {},
-  deleteConversationOverride: async () => {},
-  setGlobalThresholds: async () => {},
+  setConversationOverride: setConversationOverrideMock,
+  deleteConversationOverride: deleteConversationOverrideMock,
+  setGlobalThresholds: setGlobalThresholdsMock,
 }));
 
 // --- profile quick-add controller (top-level) --------------------------------
@@ -277,6 +283,7 @@ import { ComposerCompactProvider } from "@/domains/chat/components/chat-composer
 import { ComposerSettingsMenu } from "@/domains/chat/components/composer-settings-menu";
 // Real store (not mocked) — the component reads the draft conversation id and
 // the pending-profile stash from it.
+import { loadComposerPillSnapshot } from "@/domains/chat/utils/composer-pill-storage";
 import { useConversationStore } from "@/stores/conversation-store";
 import { ApiError } from "@/utils/api-errors";
 import { clearUserScopedOverrides } from "@/utils/typed-storage";
@@ -376,7 +383,12 @@ beforeEach(() => {
   conversationsByIdGetMock.mockClear();
   toastSuccess.mockClear();
   toastError.mockClear();
-  getGlobalThresholdsMock.mockImplementation(async () => ({ interactive: 50 }));
+  getGlobalThresholdsMock.mockImplementation(async () => ({
+    interactive: "low",
+  }));
+  setGlobalThresholdsMock.mockClear();
+  setConversationOverrideMock.mockClear();
+  deleteConversationOverrideMock.mockClear();
   useConversationStore.getState().reset();
   // The menu writes the settled pill labels here for the next launch, so a
   // mounted test leaves a seed behind that the next one would boot from.
@@ -1028,12 +1040,48 @@ describe("pills seeded from the last launch", () => {
     renderMenu();
 
     await waitFor(() => {
-      const stored = JSON.parse(
-        localStorage.getItem(PILL_SNAPSHOT_KEY) ?? "{}",
-      ) as { accessPresetId?: string; profileLabel?: string };
+      const stored = loadComposerPillSnapshot("assistant-1");
       expect(stored.accessPresetId).toBe("conservative");
       expect(stored.profileLabel).toBe("Smart");
     });
+  });
+
+  test("maps the server's threshold onto the preset it actually names", async () => {
+    // "medium" is Relaxed, and is also the gateway's own no-row default, so
+    // getting this mapping wrong is what the seed exists to avoid.
+    getGlobalThresholdsMock.mockImplementation(async () => ({
+      interactive: "medium",
+    }));
+
+    renderMenu();
+
+    await waitFor(() => {
+      expect(loadComposerPillSnapshot("assistant-1").accessPresetId).toBe(
+        "relaxed",
+      );
+    });
+    expect(
+      await screen.findByLabelText("Assistant access: Relaxed"),
+    ).toBeTruthy();
+  });
+
+  test("stores nothing for a threshold it can't name", async () => {
+    // Version skew between the gateway and the web app: an unrecognized
+    // threshold resolves to the conservative preset for display, and freezing
+    // that into the seed would boot every later launch on a stricter level than
+    // the server holds.
+    getGlobalThresholdsMock.mockImplementation(async () => ({
+      interactive: "paranoid",
+    }));
+
+    renderMenu();
+
+    await waitFor(() => {
+      expect(loadComposerPillSnapshot("assistant-1").profileLabel).toBe(
+        "Smart",
+      );
+    });
+    expect(loadComposerPillSnapshot("assistant-1").accessPresetId).toBeNull();
   });
 
   test("a conversation override is not what the next launch boots from", async () => {
@@ -1069,10 +1117,101 @@ describe("pills seeded from the last launch", () => {
       "Model profile: Quality",
     );
     expect(profileTrigger.textContent).toContain("Quality");
-    const stored = JSON.parse(
-      localStorage.getItem(PILL_SNAPSHOT_KEY) ?? "{}",
-    ) as { profileLabel?: string };
-    expect(stored.profileLabel).toBe("Smart");
+    expect(loadComposerPillSnapshot("assistant-1").profileLabel).toBe("Smart");
+  });
+
+  test("the seeded access pill is inert until the real value lands", async () => {
+    // `handleSelect` needs the global threshold to decide between setting an
+    // override and clearing one, so it refuses to act without it. A pill that
+    // looked live in that window would take a press, close its surface, and
+    // send nothing, which on a failed fetch never resolves itself.
+    seedPillSnapshot({ accessPresetId: "relaxed" });
+    hangGlobalThresholds();
+
+    renderMenu();
+
+    const accessTrigger = screen.getByLabelText(
+      "Assistant access: Relaxed",
+    ) as HTMLButtonElement;
+    expect(accessTrigger.textContent).toContain("Relaxed");
+    expect(accessTrigger.disabled).toBe(true);
+
+    // Reaching a row anyway (the compact hamburger opens one without passing
+    // through this trigger) must still not mutate anything.
+    const relaxedRow = screen
+      .getAllByTestId("panel-item")
+      .find((row) => row.textContent?.includes("Relaxed"));
+    await act(async () => {
+      fireEvent.click(relaxedRow!);
+    });
+
+    expect(setGlobalThresholdsMock).not.toHaveBeenCalled();
+    expect(setConversationOverrideMock).not.toHaveBeenCalled();
+    expect(deleteConversationOverrideMock).not.toHaveBeenCalled();
+
+    await settleMountFetches();
+  });
+
+  test("the access pill goes live once the fetch lands", async () => {
+    // The other half of the gate: the inert state has to end, or the seed has
+    // traded one broken control for another.
+    seedPillSnapshot({ accessPresetId: "relaxed" });
+
+    renderMenu();
+
+    await waitFor(() => {
+      const accessTrigger = screen.getByLabelText(
+        "Assistant access: Conservative",
+      ) as HTMLButtonElement;
+      expect(accessTrigger.disabled).toBe(false);
+    });
+
+    const relaxedRow = screen
+      .getAllByTestId("panel-item")
+      .find((row) => row.textContent?.includes("Relaxed"));
+    await act(async () => {
+      fireEvent.click(relaxedRow!);
+    });
+
+    await waitFor(() => {
+      expect(setConversationOverrideMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  test("the seeded profile pill offers nothing to select before config lands", async () => {
+    // The profile picker's selection handler bails while the config fetch is
+    // unsettled. Nothing is swallowed only because there is nothing to press:
+    // the seed names a label, it does not invent a list to pick from.
+    seedPillSnapshot({ profileLabel: "Balanced" });
+    configGetMock.mockImplementation(() => new Promise(() => {}));
+
+    renderMenu();
+
+    expect(screen.getByLabelText("Model profile: Balanced")).toBeTruthy();
+    expect(
+      screen
+        .queryAllByTestId("panel-item")
+        .filter((row) => row.textContent?.includes("Balanced")),
+    ).toHaveLength(0);
+    expect(inferenceprofilePut).not.toHaveBeenCalled();
+
+    await settleMountFetches();
+  });
+
+  test("a failed config fetch drops the seeded label instead of holding it", async () => {
+    // With no answer coming, the stale label would sit there for the life of
+    // the session claiming a selection the app cannot confirm.
+    seedPillSnapshot({ profileLabel: "Balanced" });
+    configGetMock.mockImplementation(async () => {
+      throw new ApiError(500, "daemon unreachable");
+    });
+
+    renderMenu();
+
+    expect(screen.getByLabelText("Model profile: Balanced")).toBeTruthy();
+
+    const profileTrigger = await screen.findByLabelText("Model profile");
+    expect(profileTrigger.textContent).toBe("");
   });
 
   test("first run, with nothing stored, still holds the pill's shape", async () => {
@@ -1247,6 +1386,28 @@ describe("compact composer collapse", () => {
     expect(trigger.getAttribute("title")).toBe(
       "Assistant access and model profile: Relaxed · Balanced",
     );
+
+    await settleMountFetches();
+  });
+
+  test("holds the seeded access rows inert until the real value lands", async () => {
+    // The hamburger reaches the access rows without passing through the pill
+    // that the split layout disables, so the rows carry the gate themselves.
+    seedPillSnapshot({ accessPresetId: "relaxed" });
+    hangGlobalThresholds();
+
+    renderMenu({ compact: true, props: { segments: "access" } });
+
+    const relaxedRow = screen
+      .getAllByTestId("menu-item")
+      .find((row) => row.textContent?.includes("Relaxed"));
+    expect((relaxedRow as HTMLButtonElement).disabled).toBe(true);
+
+    await act(async () => {
+      fireEvent.click(relaxedRow!);
+    });
+    expect(setGlobalThresholdsMock).not.toHaveBeenCalled();
+    expect(setConversationOverrideMock).not.toHaveBeenCalled();
 
     await settleMountFetches();
   });

--- a/clients/web/src/domains/chat/components/composer-settings-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/composer-settings-menu.test.tsx
@@ -1090,6 +1090,25 @@ describe("pills seeded from the last launch", () => {
     expect(loadComposerPillSnapshot("assistant-1").accessPresetId).toBeNull();
   });
 
+  test("an unrecognized answer clears the seed it contradicts", async () => {
+    // The stored preset is from the old vocabulary, so this build would keep
+    // repainting it on every cold launch while the server holds something it
+    // cannot name. A non-null answer with no matching preset invalidates the
+    // seed rather than leaving it to reconcile again every boot.
+    seedPillSnapshot({ accessPresetId: "relaxed", profileLabel: "Balanced" });
+    getGlobalThresholdsMock.mockImplementation(async () => ({
+      interactive: "paranoid",
+    }));
+
+    renderMenu();
+
+    await waitFor(() => {
+      const stored = loadComposerPillSnapshot("assistant-1");
+      expect(stored.accessPresetId).toBeNull();
+      expect(stored.profileLabel).toBe("Smart");
+    });
+  });
+
   test("a conversation override is not what the next launch boots from", async () => {
     // The seed stands in for every conversation the assistant opens, so it
     // tracks the global default rather than one thread's override.

--- a/clients/web/src/domains/chat/components/composer-settings-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/composer-settings-menu.test.tsx
@@ -55,8 +55,15 @@ mock.module("@vellumai/design-library/components/toast", () => ({
 }));
 
 // --- threshold-api (mount-time access-level fetches) -------------------------
+// A `mock()` rather than a plain stub so the boot-seed cases can hold the
+// global-thresholds fetch open and observe what the pill renders meanwhile.
+const getGlobalThresholdsMock = mock(
+  async (_assistantId: string): Promise<{ interactive: unknown }> => ({
+    interactive: 50,
+  }),
+);
 mock.module("@/lib/threshold-api", () => ({
-  getGlobalThresholds: async () => ({ interactive: 50 }),
+  getGlobalThresholds: getGlobalThresholdsMock,
   getConversationOverride: async () => null,
   setConversationOverride: async () => {},
   deleteConversationOverride: async () => {},
@@ -272,6 +279,32 @@ import { ComposerSettingsMenu } from "@/domains/chat/components/composer-setting
 // the pending-profile stash from it.
 import { useConversationStore } from "@/stores/conversation-store";
 import { ApiError } from "@/utils/api-errors";
+import { clearUserScopedOverrides } from "@/utils/typed-storage";
+
+/** The key the composer seeds its pills from on the next launch. */
+const PILL_SNAPSHOT_KEY = "vellum:composerPills:assistant-1";
+
+function seedPillSnapshot(snapshot: {
+  accessPresetId?: string;
+  profileLabel?: string;
+}) {
+  localStorage.setItem(PILL_SNAPSHOT_KEY, JSON.stringify(snapshot));
+}
+
+/** Hold the gateway's threshold fetch open for the length of a test. */
+function hangGlobalThresholds() {
+  getGlobalThresholdsMock.mockImplementation(() => new Promise(() => {}));
+}
+
+/**
+ * Let the fetches a first-frame assertion deliberately raced settle inside
+ * `act`, so their state updates land before the test tears the tree down.
+ */
+async function settleMountFetches() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
 
 /** The config payload most cases mount against: one profile, "Smart". */
 const SMART_CONFIG = {
@@ -343,12 +376,19 @@ beforeEach(() => {
   conversationsByIdGetMock.mockClear();
   toastSuccess.mockClear();
   toastError.mockClear();
+  getGlobalThresholdsMock.mockImplementation(async () => ({ interactive: 50 }));
   useConversationStore.getState().reset();
+  // The menu writes the settled pill labels here for the next launch, so a
+  // mounted test leaves a seed behind that the next one would boot from.
+  localStorage.clear();
+  clearUserScopedOverrides();
 });
 
 afterEach(() => {
   cleanup();
   useConversationStore.getState().reset();
+  localStorage.clear();
+  clearUserScopedOverrides();
 });
 
 describe("Model Profile quick-add", () => {
@@ -915,6 +955,174 @@ describe("mobile pill triggers", () => {
   });
 });
 
+describe("pills seeded from the last launch", () => {
+  beforeEach(() => {
+    isMobileRef.value = true;
+    isTouchMobileRef.value = true;
+    configGetMock.mockImplementation(async () => ({ data: SMART_CONFIG }));
+    conversationsByIdGetMock.mockImplementation(async () => ({
+      data: { conversation: { inferenceProfile: null } },
+    }));
+  });
+
+  test("paints both pills labelled on the very first render", async () => {
+    // Nothing has answered yet: the config fetch is daemon-proxied and slow on
+    // boot, and the thresholds fetch is held open here to stand for the same
+    // window. Both pills still have to be readable in the first frame.
+    seedPillSnapshot({ accessPresetId: "relaxed", profileLabel: "Balanced" });
+    hangGlobalThresholds();
+    configGetMock.mockImplementation(() => new Promise(() => {}));
+
+    renderMenu();
+
+    const accessTrigger = screen.getByLabelText("Assistant access: Relaxed");
+    expect(accessTrigger.textContent).toContain("Relaxed");
+    const profileTrigger = screen.getByLabelText("Model profile: Balanced");
+    expect(profileTrigger.textContent).toContain("Balanced");
+
+    await settleMountFetches();
+  });
+
+  test("reconciles to the server's answer without unmounting the pill", async () => {
+    // The seed is a display stand-in, so a stale label must give way silently
+    // once the real fetches land, in the same element the fade plays in.
+    seedPillSnapshot({ accessPresetId: "relaxed", profileLabel: "Balanced" });
+
+    renderMenu();
+
+    const profileTrigger = screen.getByLabelText("Model profile: Balanced");
+    expect(
+      screen.getByLabelText("Assistant access: Relaxed").textContent,
+    ).toContain("Relaxed");
+
+    await waitFor(() => {
+      expect(profileTrigger.textContent).toContain("Smart");
+    });
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText("Assistant access: Conservative"),
+      ).toBeTruthy();
+    });
+    // Same node throughout: the label swapped inside the pill rather than the
+    // pill being replaced.
+    expect(screen.getByLabelText("Model profile: Smart")).toBe(profileTrigger);
+  });
+
+  test("an unrecognized stored preset leaves the access pill hidden", async () => {
+    // The un-fetched fallback preset names a stricter level than the server's
+    // own default, so a seed that no longer maps to a preset has to fall back
+    // to showing nothing rather than to that fallback.
+    seedPillSnapshot({ accessPresetId: "wide-open", profileLabel: "Balanced" });
+    hangGlobalThresholds();
+    configGetMock.mockImplementation(() => new Promise(() => {}));
+
+    renderMenu();
+
+    expect(screen.queryByLabelText(/^Assistant access/)).toBeNull();
+    expect(screen.getByLabelText("Model profile: Balanced")).toBeTruthy();
+
+    await settleMountFetches();
+  });
+
+  test("records what each pill settled on for the next launch", async () => {
+    renderMenu();
+
+    await waitFor(() => {
+      const stored = JSON.parse(
+        localStorage.getItem(PILL_SNAPSHOT_KEY) ?? "{}",
+      ) as { accessPresetId?: string; profileLabel?: string };
+      expect(stored.accessPresetId).toBe("conservative");
+      expect(stored.profileLabel).toBe("Smart");
+    });
+  });
+
+  test("a conversation override is not what the next launch boots from", async () => {
+    // The seed stands in for every conversation the assistant opens, so it
+    // tracks the global default rather than one thread's override.
+    conversationsByIdGetMock.mockImplementation(async () => ({
+      data: { conversation: { inferenceProfile: "quality" } },
+    }));
+    configGetMock.mockImplementation(async () => ({
+      data: {
+        llm: {
+          profileOrder: ["smart", "quality"],
+          profiles: {
+            smart: {
+              label: "Smart",
+              provider: "anthropic",
+              model: "claude-fable-5",
+            },
+            quality: {
+              label: "Quality",
+              provider: "anthropic",
+              model: "claude-fable-5",
+            },
+          },
+          activeProfile: "smart",
+        },
+      },
+    }));
+
+    renderMenu();
+
+    const profileTrigger = await screen.findByLabelText(
+      "Model profile: Quality",
+    );
+    expect(profileTrigger.textContent).toContain("Quality");
+    const stored = JSON.parse(
+      localStorage.getItem(PILL_SNAPSHOT_KEY) ?? "{}",
+    ) as { profileLabel?: string };
+    expect(stored.profileLabel).toBe("Smart");
+  });
+
+  test("first run, with nothing stored, still holds the pill's shape", async () => {
+    hangGlobalThresholds();
+    configGetMock.mockImplementation(() => new Promise(() => {}));
+
+    renderMenu();
+
+    // No seed to show, so the access pill stays hidden rather than naming a
+    // level the server never returned.
+    expect(screen.queryByLabelText(/^Assistant access/)).toBeNull();
+    const profileTrigger = screen.getByLabelText("Model profile");
+    expect(profileTrigger.textContent).toBe("");
+    const pillClass = profileTrigger.getAttribute("class") ?? "";
+    expect(pillClass).toContain("h-8");
+    expect(pillClass).toContain("w-8");
+
+    await settleMountFetches();
+  });
+
+  test("the label fades into the pill the icon-only state already mounted", async () => {
+    // The genuine first run has no seed, so the label does arrive late. It has
+    // to land inside the same button, or there is nothing to transition.
+    const configSettle = deferred<{ data: unknown }>();
+    configGetMock.mockImplementation(() => configSettle.promise);
+
+    renderMenu();
+
+    const profileTrigger = screen.getByLabelText("Model profile");
+    expect(profileTrigger.textContent).toBe("");
+
+    await act(async () => {
+      configSettle.resolve({ data: SMART_CONFIG });
+      await configSettle.promise;
+    });
+
+    await waitFor(() => {
+      expect(profileTrigger.textContent).toContain("Smart");
+    });
+    expect(screen.getByLabelText("Model profile: Smart")).toBe(profileTrigger);
+    const labelSpan = profileTrigger.querySelector(
+      'span:not([aria-hidden="true"])',
+    );
+    expect(labelSpan?.getAttribute("class")).toContain("animate-[fadeIn_");
+    expect(labelSpan?.getAttribute("class")).toContain(
+      "motion-reduce:animate-none",
+    );
+  });
+});
+
 describe("open-state reporting across the quick-add and unmount", () => {
   test("stays open while the quick-add modal it launched is up", async () => {
     // The modal renders outside the composer, and opening it closes the sheet
@@ -1024,6 +1232,23 @@ describe("compact composer collapse", () => {
     await waitFor(() => {
       expect(onOpenChange).toHaveBeenLastCalledWith(false);
     });
+  });
+
+  test("summarizes the seeded pills before either fetch lands", async () => {
+    // The hamburger carries the same two values in its title, so it seeds from
+    // the same snapshot rather than announcing an empty selection on boot.
+    seedPillSnapshot({ accessPresetId: "relaxed", profileLabel: "Balanced" });
+    hangGlobalThresholds();
+    configGetMock.mockImplementation(() => new Promise(() => {}));
+
+    renderMenu({ compact: true, props: { segments: "access" } });
+
+    const trigger = screen.getByLabelText("Assistant access and model profile");
+    expect(trigger.getAttribute("title")).toBe(
+      "Assistant access and model profile: Relaxed · Balanced",
+    );
+
+    await settleMountFetches();
   });
 
   test("stays split when the composer is wide", async () => {

--- a/clients/web/src/domains/chat/components/composer-settings-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/composer-settings-menu.test.tsx
@@ -1109,6 +1109,35 @@ describe("pills seeded from the last launch", () => {
     });
   });
 
+  test("a successful config with no nameable profile clears that seed", async () => {
+    // The server answered: there is no active profile this build can label.
+    // Leaving the old label stored would repaint it on every cold launch, the
+    // profile-side twin of the unnameable-threshold case above.
+    seedPillSnapshot({ accessPresetId: "relaxed", profileLabel: "Balanced" });
+    configGetMock.mockImplementation(async () => ({
+      data: {
+        llm: {
+          profileOrder: ["smart"],
+          profiles: {
+            smart: {
+              label: "Smart",
+              provider: "anthropic",
+              model: "claude-fable-5",
+            },
+          },
+        },
+      },
+    }));
+
+    renderMenu();
+
+    await waitFor(() => {
+      const stored = loadComposerPillSnapshot("assistant-1");
+      expect(stored.profileLabel).toBeNull();
+      expect(stored.accessPresetId).toBe("conservative");
+    });
+  });
+
   test("a conversation override is not what the next launch boots from", async () => {
     // The seed stands in for every conversation the assistant opens, so it
     // tracks the global default rather than one thread's override.

--- a/clients/web/src/domains/chat/components/composer-settings-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/composer-settings-menu.test.tsx
@@ -65,12 +65,15 @@ const getGlobalThresholdsMock = mock(
     interactive: "low",
   }),
 );
+const getConversationOverrideMock = mock(
+  async (..._args: unknown[]): Promise<unknown> => null,
+);
 const setGlobalThresholdsMock = mock(async (..._args: unknown[]) => {});
 const setConversationOverrideMock = mock(async (..._args: unknown[]) => {});
 const deleteConversationOverrideMock = mock(async (..._args: unknown[]) => {});
 mock.module("@/lib/threshold-api", () => ({
   getGlobalThresholds: getGlobalThresholdsMock,
-  getConversationOverride: async () => null,
+  getConversationOverride: getConversationOverrideMock,
   setConversationOverride: setConversationOverrideMock,
   deleteConversationOverride: deleteConversationOverrideMock,
   setGlobalThresholds: setGlobalThresholdsMock,
@@ -388,6 +391,7 @@ beforeEach(() => {
   getGlobalThresholdsMock.mockImplementation(async () => ({
     interactive: "low",
   }));
+  getConversationOverrideMock.mockImplementation(async () => null);
   setGlobalThresholdsMock.mockClear();
   setConversationOverrideMock.mockClear();
   deleteConversationOverrideMock.mockClear();
@@ -1177,6 +1181,69 @@ describe("pills seeded from the last launch", () => {
 
     await waitFor(() => {
       expect(setConversationOverrideMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  test("an override arriving first shows its level but stays inert", async () => {
+    // The two threshold fetches are independent, and the per-conversation one
+    // can land first. It names the level to display, but `handleSelect` still
+    // needs the global value to choose between setting an override and
+    // clearing one, so the picker must not open on the override alone.
+    const globalSettle = deferred<{ interactive: string }>();
+    getGlobalThresholdsMock.mockImplementation(() => globalSettle.promise);
+    getConversationOverrideMock.mockImplementation(async () => "high");
+
+    renderMenu();
+
+    const accessTrigger = (await screen.findByLabelText(
+      "Assistant access: Full access",
+    )) as HTMLButtonElement;
+    expect(accessTrigger.textContent).toContain("Full access");
+    expect(accessTrigger.disabled).toBe(true);
+
+    const relaxedRow = screen
+      .getAllByTestId("panel-item")
+      .find((row) => row.textContent?.includes("Relaxed"));
+    await act(async () => {
+      fireEvent.click(relaxedRow!);
+    });
+    expect(setConversationOverrideMock).not.toHaveBeenCalled();
+    expect(deleteConversationOverrideMock).not.toHaveBeenCalled();
+    expect(setGlobalThresholdsMock).not.toHaveBeenCalled();
+
+    // The global value lands: the same pill goes live and the press it would
+    // have dropped now reaches the server.
+    await act(async () => {
+      globalSettle.resolve({ interactive: "low" });
+      await globalSettle.promise;
+    });
+    await waitFor(() => {
+      expect(accessTrigger.disabled).toBe(false);
+    });
+
+    await act(async () => {
+      fireEvent.click(relaxedRow!);
+    });
+    await waitFor(() => {
+      expect(setConversationOverrideMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  test("a failed thresholds fetch drops the seeded level instead of holding it", async () => {
+    // Mirrors the profile side: with no answer coming, a stored permission
+    // level would sit on the composer for the rest of the session claiming a
+    // setting the app cannot confirm.
+    seedPillSnapshot({ accessPresetId: "relaxed" });
+    getGlobalThresholdsMock.mockImplementation(async () => {
+      throw new ApiError(500, "gateway unreachable");
+    });
+
+    renderMenu();
+
+    expect(screen.getByLabelText("Assistant access: Relaxed")).toBeTruthy();
+
+    await waitFor(() => {
+      expect(screen.queryByLabelText(/^Assistant access/)).toBeNull();
     });
   });
 

--- a/clients/web/src/domains/chat/components/composer-settings-menu.tsx
+++ b/clients/web/src/domains/chat/components/composer-settings-menu.tsx
@@ -36,6 +36,7 @@ import { useComposerCompact } from "@/domains/chat/components/chat-composer/comp
 import { preventPressFocusTransfer } from "@/domains/chat/components/chat-composer/composer-mobile-chrome";
 import {
   clearComposerPillAccessPreset,
+  clearComposerPillProfileLabel,
   saveComposerPillAccessPreset,
   saveComposerPillProfileLabel,
   useComposerPillSnapshot,
@@ -602,11 +603,19 @@ export function ComposerSettingsMenu({
   }, [globalActiveProfile, orderedProfileEntries]);
 
   useEffect(() => {
+    // Before the config settles, a null label proves nothing and the seed
+    // stays. After a successful response it is the server's answer: no active
+    // profile, or one this map cannot name, invalidates whatever the seed
+    // held, the same way an unnameable threshold clears the access field.
+    if (!profilesLoaded) {
+      return;
+    }
     if (globalProfileLabel === null) {
+      clearComposerPillProfileLabel(assistantId);
       return;
     }
     saveComposerPillProfileLabel(assistantId, globalProfileLabel);
-  }, [assistantId, globalProfileLabel]);
+  }, [assistantId, profilesLoaded, globalProfileLabel]);
 
   // Quick-add is owned by the top-level ProfileQuickAddProvider (chat must not
   // import settings directly — see local/no-cross-domain-imports). The provider

--- a/clients/web/src/domains/chat/components/composer-settings-menu.tsx
+++ b/clients/web/src/domains/chat/components/composer-settings-menu.tsx
@@ -323,7 +323,9 @@ export function ComposerSettingsMenu({
 
   const handleSelect = useCallback(
     async (preset: ThresholdPreset) => {
-      // Don't act until the real global threshold has loaded.
+      // Don't act until the real global threshold has loaded. `accessLive`
+      // gates the surfaces on this same condition, so nothing reaches here
+      // while it holds; keep the two in step.
       if (serverGlobalInteractive === null) {
         return;
       }
@@ -675,19 +677,27 @@ export function ComposerSettingsMenu({
   // Access-level segment. Two gates, because displaying a level and changing
   // one need different things to have happened:
   //
-  // `accessLive` is the real value, which every mutation needs: `handleSelect`
-  // has to compare against the global threshold to decide between setting an
-  // override and clearing one, so it refuses to act without it.
-  // `accessSettled` also accepts a stored preset from a previous launch, which
-  // is enough to show a level the server actually returned. It is never enough
-  // to act on, so the trigger renders inert until the fetch lands rather than
-  // opening a surface whose selections would be dropped in silence.
+  // `accessLive` is the global threshold, and is the exact condition
+  // `handleSelect` refuses to act without: it compares against that value to
+  // decide between setting a per-conversation override and clearing one. A
+  // conversation override does not stand in for it, so an override that
+  // resolves first must not open the picker.
   //
-  // Neither accepts the `THRESHOLD_PRESETS[1]` fallback, which is stricter than
-  // the server's own default and so must never reach the screen.
+  // `accessSettled` accepts anything the server actually returned: the global
+  // value, an override for this conversation, or a preset stored on a previous
+  // launch. Enough to show a level, never enough to act on, so the trigger
+  // renders inert rather than taking presses it would drop in silence. The
+  // stored preset stops counting once the fetch has failed outright, so a
+  // level nothing can confirm doesn't sit there for the rest of the session.
+  //
+  // None of them accepts the `THRESHOLD_PRESETS[1]` fallback, which is stricter
+  // than the server's own default and so must never reach the screen.
   const AccessIcon = activePreset.icon;
-  const accessLive = globalThresholdsQuery.isSuccess || serverIsOverride;
-  const accessSettled = accessLive || seededPreset !== null;
+  const accessLive = serverGlobalInteractive !== null;
+  const accessSettled =
+    accessLive ||
+    serverIsOverride ||
+    (seededPreset !== null && !globalThresholdsQuery.isError);
   const showAccess = accessSettled && segments !== "profile";
   const showProfile = segments !== "access";
 

--- a/clients/web/src/domains/chat/components/composer-settings-menu.tsx
+++ b/clients/web/src/domains/chat/components/composer-settings-menu.tsx
@@ -35,6 +35,7 @@ import { conversationsByIdInferenceprofilePut } from "@/generated/daemon/sdk.gen
 import { useComposerCompact } from "@/domains/chat/components/chat-composer/composer-compact";
 import { preventPressFocusTransfer } from "@/domains/chat/components/chat-composer/composer-mobile-chrome";
 import {
+  clearComposerPillAccessPreset,
   saveComposerPillAccessPreset,
   saveComposerPillProfileLabel,
   useComposerPillSnapshot,
@@ -566,14 +567,21 @@ export function ComposerSettingsMenu({
   // values, not the per-conversation effective ones, so a conversation-scoped
   // override can't become the seed every other conversation opens with.
   useEffect(() => {
+    if (serverGlobalInteractive === null) {
+      return;
+    }
     // Only an exact match: `presetFromThreshold` answers with the conservative
     // preset for a threshold it doesn't recognize, and freezing that into the
     // seed would show a stricter level than the server holds for as long as the
-    // two sides disagree about the vocabulary.
+    // two sides disagree about the vocabulary. An answer this build cannot name
+    // also invalidates whatever the seed held: repainting the old preset on
+    // every launch is the same skew, one launch removed, so the field clears
+    // instead. A null answer proves nothing and leaves the seed alone.
     const preset = THRESHOLD_PRESETS.find(
       (p) => p.riskThreshold === serverGlobalInteractive,
     );
     if (!preset) {
+      clearComposerPillAccessPreset(assistantId);
       return;
     }
     saveComposerPillAccessPreset(assistantId, preset.id);

--- a/clients/web/src/domains/chat/components/composer-settings-menu.tsx
+++ b/clients/web/src/domains/chat/components/composer-settings-menu.tsx
@@ -520,36 +520,50 @@ export function ComposerSettingsMenu({
   // The label the trigger renders. Until the config fetch settles it stands in
   // with the last launch's, which is the assistant's own default profile and so
   // right for every conversation that doesn't override it; the rest reconcile
-  // silently when the fetch lands. Once config has answered, its label is the
-  // only one, so a profile that was renamed or removed can't linger.
+  // silently when the fetch lands. Once config has answered (or failed), its
+  // answer is the only one, so a profile that was renamed, removed, or is
+  // simply unreachable can't linger behind a label.
   const displayProfileLabel =
-    activeProfileLabel ?? (profilesLoaded ? null : pillSnapshot.profileLabel);
+    activeProfileLabel ??
+    (profilesLoaded || configQuery.isError ? null : pillSnapshot.profileLabel);
 
   // Record what each pill settled on for the next launch. Keyed off the global
   // values, not the per-conversation effective ones, so a conversation-scoped
   // override can't become the seed every other conversation opens with.
   useEffect(() => {
-    if (serverGlobalInteractive === null) {
+    // Only an exact match: `presetFromThreshold` answers with the conservative
+    // preset for a threshold it doesn't recognize, and freezing that into the
+    // seed would show a stricter level than the server holds for as long as the
+    // two sides disagree about the vocabulary.
+    const preset = THRESHOLD_PRESETS.find(
+      (p) => p.riskThreshold === serverGlobalInteractive,
+    );
+    if (!preset) {
       return;
     }
-    saveComposerPillAccessPreset(
-      assistantId,
-      presetFromThreshold(serverGlobalInteractive).id,
-    );
+    saveComposerPillAccessPreset(assistantId, preset.id);
   }, [assistantId, serverGlobalInteractive]);
 
-  useEffect(() => {
+  // Resolved here rather than in the effect below: `orderedProfileEntries` is a
+  // fresh array whenever the daemon omits `profileOrder`, and an effect keyed on
+  // it would hit storage on every render of a component the chat view mounts
+  // twice.
+  const globalProfileLabel = useMemo(() => {
     if (!globalActiveProfile) {
-      return;
+      return null;
     }
     const entry = orderedProfileEntries.find(
       (e) => e.name === globalActiveProfile,
     );
-    if (!entry) {
+    return entry ? profilePickerLabel(entry) : null;
+  }, [globalActiveProfile, orderedProfileEntries]);
+
+  useEffect(() => {
+    if (globalProfileLabel === null) {
       return;
     }
-    saveComposerPillProfileLabel(assistantId, profilePickerLabel(entry));
-  }, [assistantId, globalActiveProfile, orderedProfileEntries]);
+    saveComposerPillProfileLabel(assistantId, globalProfileLabel);
+  }, [assistantId, globalProfileLabel]);
 
   // Quick-add is owned by the top-level ProfileQuickAddProvider (chat must not
   // import settings directly — see local/no-cross-domain-imports). The provider
@@ -625,15 +639,22 @@ export function ComposerSettingsMenu({
   // Render
   // ---------------------------------------------------------------------------
 
-  // Access-level segment: gate on a settled fetch (or an active override) so the
-  // trigger never flashes the `THRESHOLD_PRESETS[1]` fallback before the real
-  // value loads. A stored preset from a previous launch counts as settled for
-  // display, since it is a value the server actually returned.
+  // Access-level segment. Two gates, because displaying a level and changing
+  // one need different things to have happened:
+  //
+  // `accessLive` is the real value, which every mutation needs: `handleSelect`
+  // has to compare against the global threshold to decide between setting an
+  // override and clearing one, so it refuses to act without it.
+  // `accessSettled` also accepts a stored preset from a previous launch, which
+  // is enough to show a level the server actually returned. It is never enough
+  // to act on, so the trigger renders inert until the fetch lands rather than
+  // opening a surface whose selections would be dropped in silence.
+  //
+  // Neither accepts the `THRESHOLD_PRESETS[1]` fallback, which is stricter than
+  // the server's own default and so must never reach the screen.
   const AccessIcon = activePreset.icon;
-  const accessSettled =
-    globalThresholdsQuery.isSuccess ||
-    serverIsOverride ||
-    seededPreset !== null;
+  const accessLive = globalThresholdsQuery.isSuccess || serverIsOverride;
+  const accessSettled = accessLive || seededPreset !== null;
   const showAccess = accessSettled && segments !== "profile";
   const showProfile = segments !== "access";
 
@@ -718,6 +739,16 @@ export function ComposerSettingsMenu({
   const pillIconClass =
     "flex size-5 shrink-0 items-center justify-center text-[var(--content-tertiary)] [&_svg]:size-5";
 
+  // A trigger showing a stored level before its fetch lands is inert, not
+  // spent: it names the level it holds at full contrast, and only stops
+  // answering presses. The Button's own disabled treatment dims the label to
+  // `--content-disabled`, which would make the thing it exists to show the
+  // hardest part of it to read, so both tones are restored here.
+  const inertTriggerClass =
+    "disabled:cursor-default disabled:[--vbtn-fg:var(--content-secondary)]";
+  const inertActionRowTriggerClass =
+    "disabled:cursor-default disabled:[--vbtn-fg:var(--content-tertiary)]";
+
   // Access trigger: the active preset's name beside its icon, as a floating
   // pill on mobile (Figma 7840-8819) and as an action-row button on desktop
   // (Figma 7471-25243).
@@ -727,7 +758,8 @@ export function ComposerSettingsMenu({
       variant="ghost"
       aria-label={accessLabel}
       title={accessLabel}
-      className={pillClass}
+      className={`${pillClass} ${inertTriggerClass}`}
+      disabled={!accessLive}
       // Touch only: the bottom sheet opens on the click that follows, so the
       // press has to leave the composer's focus alone until then.
       onMouseDown={isTouchMobile ? preventPressFocusTransfer : undefined}
@@ -743,7 +775,8 @@ export function ComposerSettingsMenu({
       leftIcon={<AccessIcon className="h-3.5 w-3.5 shrink-0" />}
       aria-label={accessLabel}
       title={accessLabel}
-      className={`${triggerClass} ${triggerLabelClass} shrink-0`}
+      className={`${triggerClass} ${triggerLabelClass} ${inertActionRowTriggerClass} shrink-0`}
+      disabled={!accessLive}
     >
       {activePreset.label}
     </Button>
@@ -825,6 +858,9 @@ export function ComposerSettingsMenu({
       <Menu.Item
         key={preset.id}
         onSelect={() => handleSelect(preset)}
+        // Inert for the same reason the trigger is: the compact hamburger
+        // reaches these rows without passing through it.
+        disabled={!accessLive}
         leftIcon={<PresetIcon className="h-3.5 w-3.5" />}
         className={
           isActive
@@ -888,9 +924,10 @@ export function ComposerSettingsMenu({
   if (compact) {
     // One trigger, one menu, both sections, so the row keeps its
     // attach | settings | mic | voice order and nothing collides. The access
-    // section waits on a settled fetch (same gate as `showAccess`) so it never
-    // flashes the fallback preset, but the trigger itself is always mounted:
-    // the profile section below it is reachable either way.
+    // section waits on a value the server returned (same gate as `showAccess`)
+    // so it never flashes the fallback preset, and its rows stay inert until
+    // the real one lands; the trigger itself is always mounted, so the profile
+    // section below it is reachable either way.
     const activeSummary = [
       accessSettled ? activePreset.label : null,
       displayProfileLabel,

--- a/clients/web/src/domains/chat/components/composer-settings-menu.tsx
+++ b/clients/web/src/domains/chat/components/composer-settings-menu.tsx
@@ -34,6 +34,11 @@ import {
 import { conversationsByIdInferenceprofilePut } from "@/generated/daemon/sdk.gen";
 import { useComposerCompact } from "@/domains/chat/components/chat-composer/composer-compact";
 import { preventPressFocusTransfer } from "@/domains/chat/components/chat-composer/composer-mobile-chrome";
+import {
+  saveComposerPillAccessPreset,
+  saveComposerPillProfileLabel,
+  useComposerPillSnapshot,
+} from "@/domains/chat/utils/composer-pill-storage";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { useTouchMobile } from "@/hooks/use-touch-mobile";
 import {
@@ -160,6 +165,17 @@ export function ComposerSettingsMenu({
     conversationProfileOverride ?? globalActiveProfile;
   const profilesLoaded = configQuery.isSuccess;
 
+  // What the pills displayed the last time these fetches settled, read during
+  // render so a relaunch paints both of them in the first frame. Display only:
+  // it never feeds a mutation. See `composer-pill-storage`.
+  const pillSnapshot = useComposerPillSnapshot(assistantId);
+  const seededPreset = useMemo(
+    () =>
+      THRESHOLD_PRESETS.find((p) => p.id === pillSnapshot.accessPresetId) ??
+      null,
+    [pillSnapshot.accessPresetId],
+  );
+
   const serverGlobalInteractive =
     globalThresholdsQuery.data?.interactive ?? null;
   const serverThresholdOverride = conversationThresholdQuery.data ?? null;
@@ -170,8 +186,10 @@ export function ComposerSettingsMenu({
     if (serverGlobalInteractive !== null) {
       return presetFromThreshold(serverGlobalInteractive);
     }
-    return THRESHOLD_PRESETS[1]!;
-  }, [serverThresholdOverride, serverGlobalInteractive]);
+    // `THRESHOLD_PRESETS[1]` is stricter than the server's own no-row default,
+    // so it is only ever a placeholder for a pill the gate below keeps hidden.
+    return seededPreset ?? THRESHOLD_PRESETS[1]!;
+  }, [serverThresholdOverride, serverGlobalInteractive, seededPreset]);
   const serverIsOverride = serverThresholdOverride !== null;
 
   // ---------------------------------------------------------------------------
@@ -499,6 +517,40 @@ export function ComposerSettingsMenu({
     return entry ? profilePickerLabel(entry) : null;
   }, [orderedProfileEntries, profileActiveKey]);
 
+  // The label the trigger renders. Until the config fetch settles it stands in
+  // with the last launch's, which is the assistant's own default profile and so
+  // right for every conversation that doesn't override it; the rest reconcile
+  // silently when the fetch lands. Once config has answered, its label is the
+  // only one, so a profile that was renamed or removed can't linger.
+  const displayProfileLabel =
+    activeProfileLabel ?? (profilesLoaded ? null : pillSnapshot.profileLabel);
+
+  // Record what each pill settled on for the next launch. Keyed off the global
+  // values, not the per-conversation effective ones, so a conversation-scoped
+  // override can't become the seed every other conversation opens with.
+  useEffect(() => {
+    if (serverGlobalInteractive === null) {
+      return;
+    }
+    saveComposerPillAccessPreset(
+      assistantId,
+      presetFromThreshold(serverGlobalInteractive).id,
+    );
+  }, [assistantId, serverGlobalInteractive]);
+
+  useEffect(() => {
+    if (!globalActiveProfile) {
+      return;
+    }
+    const entry = orderedProfileEntries.find(
+      (e) => e.name === globalActiveProfile,
+    );
+    if (!entry) {
+      return;
+    }
+    saveComposerPillProfileLabel(assistantId, profilePickerLabel(entry));
+  }, [assistantId, globalActiveProfile, orderedProfileEntries]);
+
   // Quick-add is owned by the top-level ProfileQuickAddProvider (chat must not
   // import settings directly — see local/no-cross-domain-imports). The provider
   // renders the ProfileEditorModal in create mode, persists the new profile,
@@ -575,9 +627,13 @@ export function ComposerSettingsMenu({
 
   // Access-level segment: gate on a settled fetch (or an active override) so the
   // trigger never flashes the `THRESHOLD_PRESETS[1]` fallback before the real
-  // value loads.
+  // value loads. A stored preset from a previous launch counts as settled for
+  // display, since it is a value the server actually returned.
   const AccessIcon = activePreset.icon;
-  const accessSettled = globalThresholdsQuery.isSuccess || serverIsOverride;
+  const accessSettled =
+    globalThresholdsQuery.isSuccess ||
+    serverIsOverride ||
+    seededPreset !== null;
   const showAccess = accessSettled && segments !== "profile";
   const showProfile = segments !== "access";
 
@@ -701,48 +757,38 @@ export function ComposerSettingsMenu({
   // `accessLabel`: an aria-label overrides the visible text, so it has to carry
   // the selection a labelled trigger shows, or the name says nothing about it
   // and voice control can't reach the control by what it reads.
-  const profileLabel = activeProfileLabel
-    ? `Model profile: ${activeProfileLabel}`
+  const profileLabel = displayProfileLabel
+    ? `Model profile: ${displayProfileLabel}`
     : "Model profile";
   // min-w-0 + truncate keeps a long label from pushing the composer's action
   // buttons off-screen on narrow viewports. leading-snug: text-body-small-default
   // is line-height:1, so truncate clips descenders (e.g. the "g" in profile
-  // names).
+  // names). The fade carries a first-run label into a trigger that started
+  // without one, so it arrives rather than pops.
   const profileLabelText = (
-    <span className="max-w-[10rem] truncate leading-snug">
-      {activeProfileLabel}
+    <span className="max-w-[10rem] animate-[fadeIn_var(--anim-fast)_var(--anim-ease-out)] truncate leading-snug motion-reduce:animate-none">
+      {displayProfileLabel}
     </span>
   );
+  // One Button across both states so the label arriving is a change inside a
+  // live element rather than a swap of one element for another: the fade below
+  // only plays because the pill it lands in is the same node.
   const profileTrigger = isMobile ? (
-    activeProfileLabel ? (
-      <Button
-        variant="ghost"
-        aria-label={profileLabel}
-        title={profileLabel}
-        className={pillClass}
-        // Match the access pill: hold the composer's focus for the sheet's
-        // click, and only on the touch presentation that opens that way.
-        onMouseDown={isTouchMobile ? preventPressFocusTransfer : undefined}
-      >
-        <span aria-hidden="true" className={pillIconClass}>
-          <Sparkles />
-        </span>
-        {profileLabelText}
-      </Button>
-    ) : (
-      <Button
-        variant="ghost"
-        aria-label={profileLabel}
-        title={profileLabel}
-        className={pillIconOnlyClass}
-        onMouseDown={isTouchMobile ? preventPressFocusTransfer : undefined}
-      >
-        <span aria-hidden="true" className={pillIconClass}>
-          <SlidersHorizontal />
-        </span>
-      </Button>
-    )
-  ) : activeProfileLabel ? (
+    <Button
+      variant="ghost"
+      aria-label={profileLabel}
+      title={profileLabel}
+      className={displayProfileLabel ? pillClass : pillIconOnlyClass}
+      // Match the access pill: hold the composer's focus for the sheet's
+      // click, and only on the touch presentation that opens that way.
+      onMouseDown={isTouchMobile ? preventPressFocusTransfer : undefined}
+    >
+      <span aria-hidden="true" className={pillIconClass}>
+        {displayProfileLabel ? <Sparkles /> : <SlidersHorizontal />}
+      </span>
+      {displayProfileLabel ? profileLabelText : null}
+    </Button>
+  ) : displayProfileLabel ? (
     <Button
       variant="ghost"
       leftIcon={<Sparkles className="h-3.5 w-3.5 shrink-0" />}
@@ -847,7 +893,7 @@ export function ComposerSettingsMenu({
     // the profile section below it is reachable either way.
     const activeSummary = [
       accessSettled ? activePreset.label : null,
-      activeProfileLabel,
+      displayProfileLabel,
     ]
       .filter(Boolean)
       .join(" · ");

--- a/clients/web/src/domains/chat/utils/composer-pill-storage.test.ts
+++ b/clients/web/src/domains/chat/utils/composer-pill-storage.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 
 import {
+  clearComposerPillAccessPreset,
   loadComposerPillSnapshot,
   saveComposerPillAccessPreset,
   saveComposerPillProfileLabel,
@@ -60,6 +61,24 @@ describe("composer pill snapshot storage", () => {
       accessPresetId: null,
       profileLabel: null,
     });
+  });
+
+  test("clearing the access preset keeps the profile label", () => {
+    saveComposerPillAccessPreset("asst-1", "relaxed");
+    saveComposerPillProfileLabel("asst-1", "Balanced");
+
+    clearComposerPillAccessPreset("asst-1");
+
+    expect(loadComposerPillSnapshot("asst-1")).toEqual({
+      accessPresetId: null,
+      profileLabel: "Balanced",
+    });
+  });
+
+  test("clearing an empty snapshot writes nothing", () => {
+    clearComposerPillAccessPreset("asst-1");
+
+    expect(localStorage.getItem(KEY("asst-1"))).toBeNull();
   });
 
   test("non-string fields are dropped, keeping the usable half", () => {

--- a/clients/web/src/domains/chat/utils/composer-pill-storage.test.ts
+++ b/clients/web/src/domains/chat/utils/composer-pill-storage.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 
 import {
   clearComposerPillAccessPreset,
+  clearComposerPillProfileLabel,
   loadComposerPillSnapshot,
   saveComposerPillAccessPreset,
   saveComposerPillProfileLabel,
@@ -79,6 +80,18 @@ describe("composer pill snapshot storage", () => {
     clearComposerPillAccessPreset("asst-1");
 
     expect(localStorage.getItem(KEY("asst-1"))).toBeNull();
+  });
+
+  test("clearing the profile label keeps the access preset", () => {
+    saveComposerPillAccessPreset("asst-1", "relaxed");
+    saveComposerPillProfileLabel("asst-1", "Balanced");
+
+    clearComposerPillProfileLabel("asst-1");
+
+    expect(loadComposerPillSnapshot("asst-1")).toEqual({
+      accessPresetId: "relaxed",
+      profileLabel: null,
+    });
   });
 
   test("non-string fields are dropped, keeping the usable half", () => {

--- a/clients/web/src/domains/chat/utils/composer-pill-storage.test.ts
+++ b/clients/web/src/domains/chat/utils/composer-pill-storage.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import {
+  loadComposerPillSnapshot,
+  saveComposerPillAccessPreset,
+  saveComposerPillProfileLabel,
+} from "@/domains/chat/utils/composer-pill-storage";
+import { clearUserScopedOverrides } from "@/utils/typed-storage";
+
+const KEY = (assistantId: string) => `vellum:composerPills:${assistantId}`;
+
+afterEach(() => {
+  localStorage.clear();
+  // Accessors are module singletons, so a value held after a rejected write
+  // outlives the test that set it. Logout clears these for the same reason.
+  clearUserScopedOverrides();
+});
+
+describe("composer pill snapshot storage", () => {
+  test("reads empty before anything is stored", () => {
+    expect(loadComposerPillSnapshot("asst-1")).toEqual({
+      accessPresetId: null,
+      profileLabel: null,
+    });
+  });
+
+  test("each field merges into the stored snapshot instead of replacing it", () => {
+    saveComposerPillAccessPreset("asst-1", "relaxed");
+    saveComposerPillProfileLabel("asst-1", "Balanced");
+
+    expect(loadComposerPillSnapshot("asst-1")).toEqual({
+      accessPresetId: "relaxed",
+      profileLabel: "Balanced",
+    });
+  });
+
+  test("scopes the snapshot per assistant", () => {
+    saveComposerPillProfileLabel("asst-1", "Balanced");
+
+    expect(loadComposerPillSnapshot("asst-2").profileLabel).toBeNull();
+  });
+
+  test("a later write replaces the field it owns", () => {
+    saveComposerPillProfileLabel("asst-1", "Balanced");
+    saveComposerPillProfileLabel("asst-1", "Quality");
+
+    expect(loadComposerPillSnapshot("asst-1").profileLabel).toBe("Quality");
+  });
+
+  test("writes under a user-scoped key so logout clears it", () => {
+    saveComposerPillAccessPreset("asst-1", "relaxed");
+
+    expect(localStorage.getItem(KEY("asst-1"))).toContain("relaxed");
+  });
+
+  test("a malformed payload reads as empty rather than throwing", () => {
+    localStorage.setItem(KEY("asst-1"), "{not json");
+
+    expect(loadComposerPillSnapshot("asst-1")).toEqual({
+      accessPresetId: null,
+      profileLabel: null,
+    });
+  });
+
+  test("non-string fields are dropped, keeping the usable half", () => {
+    localStorage.setItem(
+      KEY("asst-1"),
+      JSON.stringify({ accessPresetId: 7, profileLabel: "Balanced" }),
+    );
+
+    expect(loadComposerPillSnapshot("asst-1")).toEqual({
+      accessPresetId: null,
+      profileLabel: "Balanced",
+    });
+  });
+});

--- a/clients/web/src/domains/chat/utils/composer-pill-storage.ts
+++ b/clients/web/src/domains/chat/utils/composer-pill-storage.ts
@@ -1,0 +1,105 @@
+// Persist the labels the composer's settings pills last displayed, per
+// assistant, so a relaunch paints both of them in the first frame.
+//
+// The two pills are fed by fetches that land far apart on a cold boot: the
+// access preset comes from the gateway's own store (fast) while the model
+// profile comes from the daemon-proxied config (slow). The row therefore
+// assembles itself in visible steps, and the access pill has to stay hidden
+// until its fetch settles because the un-fetched fallback preset names a
+// stricter level than the server's real default.
+//
+// This is a deliberate, narrow exception to "server data has one owner: its
+// query cache" (see clients/web/AGENTS.md). The snapshot is display-only: it
+// names what the pills render before their queries settle, never what a
+// selection writes back, and the live query values still gate every mutation.
+// Same rationale as `context-window-storage.ts`: the desktop client keeps this
+// state alive in a long-lived view model, and a browser tab (or a WKWebView
+// that was evicted) has to rebuild it from storage instead.
+//
+// Keys are `vellum:`-prefixed and therefore user-scoped: the logout sweep in
+// `lib/auth/session-cleanup.ts` removes them. One value per assistant rather
+// than a per-conversation map, so there is nothing to trim.
+
+import { useMemo } from "react";
+
+import { createKeyedStorageAccessor } from "@/utils/typed-storage";
+
+export interface ComposerPillSnapshot {
+  /** `ThresholdPreset.id` the access pill last displayed. */
+  accessPresetId: string | null;
+  /** Display label the model-profile pill last displayed. */
+  profileLabel: string | null;
+}
+
+const EMPTY: ComposerPillSnapshot = {
+  accessPresetId: null,
+  profileLabel: null,
+};
+
+function parseSnapshot(raw: string): ComposerPillSnapshot | null {
+  const parsed: unknown = JSON.parse(raw);
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return null;
+  }
+  const record = parsed as Record<string, unknown>;
+  const accessPresetId =
+    typeof record.accessPresetId === "string" ? record.accessPresetId : null;
+  const profileLabel =
+    typeof record.profileLabel === "string" ? record.profileLabel : null;
+  if (accessPresetId === null && profileLabel === null) {
+    return null;
+  }
+  return { accessPresetId, profileLabel };
+}
+
+const storage = createKeyedStorageAccessor<ComposerPillSnapshot>({
+  keyFn: (assistantId) => `vellum:composerPills:${assistantId}`,
+  scope: "user",
+  parse: parseSnapshot,
+  serialize: JSON.stringify,
+  fallback: EMPTY,
+});
+
+/**
+ * Read one assistant's snapshot during render, so the first paint already
+ * carries the stored labels.
+ *
+ * Deliberately unsubscribed, unlike the accessor's own `useValue`: the snapshot
+ * is a boot seed, spent the moment the fetches it stands in for settle. A
+ * subscription would re-render every consumer on its own write-back, and would
+ * let a value written after the pill resolved replace a label the user is
+ * already reading.
+ */
+export function useComposerPillSnapshot(
+  assistantId: string,
+): ComposerPillSnapshot {
+  return useMemo(() => storage.load(assistantId), [assistantId]);
+}
+
+export function loadComposerPillSnapshot(
+  assistantId: string,
+): ComposerPillSnapshot {
+  return storage.load(assistantId);
+}
+
+export function saveComposerPillAccessPreset(
+  assistantId: string,
+  accessPresetId: string,
+): void {
+  const current = storage.load(assistantId);
+  if (current.accessPresetId === accessPresetId) {
+    return;
+  }
+  storage.save(assistantId, { ...current, accessPresetId });
+}
+
+export function saveComposerPillProfileLabel(
+  assistantId: string,
+  profileLabel: string,
+): void {
+  const current = storage.load(assistantId);
+  if (current.profileLabel === profileLabel) {
+    return;
+  }
+  storage.save(assistantId, { ...current, profileLabel });
+}

--- a/clients/web/src/domains/chat/utils/composer-pill-storage.ts
+++ b/clients/web/src/domains/chat/utils/composer-pill-storage.ts
@@ -106,6 +106,15 @@ export function clearComposerPillAccessPreset(assistantId: string): void {
   storage.save(assistantId, { ...current, accessPresetId: null });
 }
 
+/** {@link clearComposerPillAccessPreset}'s counterpart for the profile pill. */
+export function clearComposerPillProfileLabel(assistantId: string): void {
+  const current = storage.load(assistantId);
+  if (current.profileLabel === null) {
+    return;
+  }
+  storage.save(assistantId, { ...current, profileLabel: null });
+}
+
 export function saveComposerPillProfileLabel(
   assistantId: string,
   profileLabel: string,

--- a/clients/web/src/domains/chat/utils/composer-pill-storage.ts
+++ b/clients/web/src/domains/chat/utils/composer-pill-storage.ts
@@ -93,6 +93,19 @@ export function saveComposerPillAccessPreset(
   storage.save(assistantId, { ...current, accessPresetId });
 }
 
+/**
+ * Drop the stored access preset while leaving the profile label alone. For
+ * when the server's answer invalidates the seed without supplying a
+ * replacement this build can name.
+ */
+export function clearComposerPillAccessPreset(assistantId: string): void {
+  const current = storage.load(assistantId);
+  if (current.accessPresetId === null) {
+    return;
+  }
+  storage.save(assistantId, { ...current, accessPresetId: null });
+}
+
 export function saveComposerPillProfileLabel(
   assistantId: string,
   profileLabel: string,


### PR DESCRIPTION
## The problem

On a cold boot the composer's settings-pill row assembles itself in three
visible steps: a bare sliders icon, then the "Relaxed" access pill appearing
beside it, then the sliders glyph swapping for the labelled profile pill
("Balanced"). It reads as three separate pops rather than one row arriving.

Two things cause it:

1. **The two pills are fed by fetches that land far apart.** The access preset
   comes from `getGlobalThresholds`, which the gateway answers out of its own
   SQLite. The profile label comes from `GET /v1/assistants/{id}/config`, which
   is proxied through to the daemon and is slow on boot. The access pill is
   additionally gated on a settled fetch on purpose: the un-fetched fallback
   (`THRESHOLD_PRESETS[1]`, "Conservative") is stricter than the gateway's real
   no-row default (`interactive: "medium"` = "Relaxed"), so rendering it
   optimistically would show the user a level the server never returned.
2. **The mobile profile trigger was two different `<Button>` elements.** One
   for the labelled pill, one for the icon-only pill. The label arriving
   unmounted one and mounted the other, which is not something CSS can
   transition.

## What this does

**Seeds both pills from a persisted last-known snapshot.** New module
`clients/web/src/domains/chat/utils/composer-pill-storage.ts`, modelled on the
existing `context-window-storage.ts`, stores `{ accessPresetId, profileLabel }`
per assistant under a `vellum:`-prefixed (user-scoped) key. The composer writes
it when each query settles, and reads it during render so a launch after the
first paints both pills labelled in the first frame, reconciling silently when
the real fetches land.

**Restructures the mobile profile trigger onto one `<Button>`.** The glyph
swaps sliders → Sparkles and the label span fades in at `var(--anim-fast)`,
`motion-reduce:animate-none` respected. Element identity is preserved, so on a
genuine first run the label lands inside a pill that is already on screen. The
icon-only state keeps the labelled pill's height and shape as before, and the
`aria-label` still carries the current selection in both states.

**The compact hamburger branch is seeded too**, so its `title` summary names
both values on boot instead of announcing an empty selection.

### Displaying a level and changing one are separate gates

Seeding the access pill introduced a way to render a control that could not yet
act: `handleSelect` has to compare against the global threshold to decide
between setting a per-conversation override and clearing one, so it refuses to
act without it. A pill that looked live in that window would take a press,
close its surface, and send nothing, which on a failed fetch never resolves
itself. So there are two flags:

- `accessLive` (`serverGlobalInteractive !== null`) is the global threshold.
  Everything that mutates requires it. It is deliberately the *same expression*
  `handleSelect` guards on, so the two cannot drift, and a successful response
  that omitted the field can't slip through either.
- `accessSettled` (`accessLive || serverIsOverride || (seededPreset !== null &&
  !globalThresholdsQuery.isError)`) accepts anything the server actually
  returned, and is only ever enough to *display*.

A conversation override deliberately sits on the display side only. The two
threshold fetches are independent, so the override can land first; it names the
level to show, but it is not the value `handleSelect` computes against, so it
must not open the picker.

The trigger and the shared access menu rows render **inert** until the global
value lands (the rows carry the gate themselves because the compact hamburger
reaches them without passing through the trigger). The inert pill keeps full
contrast: the Button's own disabled treatment dims the label to
`--content-disabled`, which would make the level it exists to show the hardest
part of it to read, so that tone and the `not-allowed` cursor are overridden at
the call site.

Neither flag ever accepts the `THRESHOLD_PRESETS[1]` fallback, so the stricter
placeholder still never reaches the screen.

### The query-cache-ownership exception

`clients/web/AGENTS.md` says server data has one owner: its query cache. This is
a deliberate, narrow exception, documented in the module the same way
`context-window-storage.ts` documents its own. The snapshot is **display-only**:

- It names what the pills *render* before their queries answer. It never feeds
  `handleSelect` or `handleProfileSelect`, and the existing
  `serverGlobalInteractive === null` guard is untouched.
- It is read unsubscribed (a `useMemo` on `assistantId`, not the accessor's
  `useValue`). A boot seed is spent the moment the fetch it stands in for
  settles; a subscription would re-render every consumer on the component's own
  write-back and would let a late value replace a label already on screen.
- The menu rows, checkmarks and `profileActiveKey` stay purely server-derived.

### The stale-label tradeoff

The seed tracks the **global** values (the assistant's default profile, the
global interactive threshold), not the per-conversation effective ones. A
conversation-scoped override is therefore never what the next launch boots
from, which is the right call because the seed stands in for whichever
conversation opens first. The cost: opening a conversation that *does* carry an
override shows the global label for the length of the config fetch, then
reconciles. That is a correct-value-then-correct-value swap rather than the
wrong-value-then-hidden behavior the access gate exists to prevent.

Four further guards on staleness. Neither seed outlives the fetch it stands in
for:

- The profile seed is dropped as soon as the config query **succeeds or
  errors**, so a renamed profile, a deleted one, or an unreachable daemon
  cannot leave a label up that nothing can confirm.
- The access seed is dropped the same way once `globalThresholdsQuery` errors
  out of its retries, so a stale permission level does not sit on the composer
  for the rest of the session. The pill falls back to hidden.
- Only a threshold that names a preset outright is persisted.
  `presetFromThreshold` answers with the conservative preset for anything it
  does not recognize, so gateway/web version skew would otherwise freeze a
  stricter level into the seed.
- An `accessPresetId` that no longer maps to a `THRESHOLD_PRESETS` entry falls
  back to today's hidden-until-settled behavior.

### First run (nothing stored)

Unchanged from today, minus the pop: the access pill stays hidden until its
fetch settles, and the profile trigger renders as the icon-only pill holding
the row's geometry. When the config fetch lands, the label now fades into that
same pill instead of swapping the element out.

### Known limitations

- **The pill box widens in one frame while the label fades.** Element identity
  is preserved and the text arrives on a `--anim-fast` fade, but the pill's
  geometry goes from the fixed 32px icon-only box to auto width in a single
  layout pass, so the box itself still snaps. Transitioning to an `auto` width
  is not something CSS does, and the alternatives (measuring, or animating a
  `max-width` guess) are more machinery than this is worth. Device QA on an iOS
  boot is outstanding, and this is the thing to look at.
- **The desktop split profile trigger is out of scope.** It still branches
  between Button's `leftIcon` and `iconOnly` props, which are structurally
  different elements, so its genuine first-run swap is not transitioned. The
  seed removes the pop there on every launch after the first.

## Verification

```
cd clients/web
bun scripts/run-tests.ts src/domains/chat/components/composer-settings-menu.test.tsx
bun scripts/run-tests.ts src/domains/chat/utils/composer-pill-storage.test.ts
bun scripts/run-tests.ts src/utils/typed-storage.test.ts
bun scripts/run-tests.ts src/domains/chat/utils/sidebar-view-mode.test.tsx
bunx tsc --noEmit
bunx eslint <changed files>
```

All green. `composer-settings-menu.test.tsx` goes 30 → 48 tests. The threshold
fixtures now use real `RiskThreshold` values (`"low"` → Conservative, which is
the label the existing assertions already expected), so the write-back tests
assert a mapping rather than accidentally pinning the fallback.

New coverage:

- A cold mount with a cache paints both pills labelled on the **first** render.
- Silent reconcile when the queries land, asserting the profile pill is the
  *same node* before and after.
- The seeded access pill is inert until the real value lands: trigger
  `disabled`, and a row selection issues no `setGlobalThresholds` /
  `setConversationOverride` / `deleteConversationOverride`. Plus the other half,
  that it goes live once the fetch lands.
- The compact hamburger's access rows carry the same gate.
- A conversation override resolving before the global threshold: the pill shows
  the override's level but stays disabled and mutates nothing, then goes live
  and lands the press once the global value arrives.
- A failed thresholds fetch drops the seeded level and hides the pill.
- The seeded profile pill has nothing to select before config lands, and no
  inference-profile PUT is issued.
- A failed config fetch drops the seeded label back to the icon-only state.
- `"medium"` maps to Relaxed; an unrecognized threshold persists nothing.
- Unrecognized cached preset id → access pill hidden.
- First-run shape with nothing stored, and the label fading into the already
  mounted pill.

Every review-fix behavior was confirmed to fail against the implementation it
replaced before the fix was restored.

**Not covered by tests:** the animation itself, only the classes that drive it.

## Risk

Yellow. The change is contained to the composer settings menu and one new
storage module, but it touches a surface that renders on every chat view and
adds a localStorage write on every settled fetch (guarded so an unchanged value
writes nothing, and keyed off a memoized label so the write-back effect does
not re-run per render).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

