### PR TITLE
fix(web): hold the empty-state composer still while the page loads

### DIFF
--- a/clients/web/eslint.config.mjs
+++ b/clients/web/eslint.config.mjs
@@ -196,6 +196,7 @@ const i18nEnforcedPaths = [
   "src/domains/chat/components/chat-composer/add-to-chat-sheet.tsx",
   "src/domains/chat/components/conversation-actions-menu.tsx",
   "src/domains/chat/components/conversation-assets-pill.tsx",
+  "src/domains/chat/components/conversation-starter-dock.tsx",
   "src/domains/chat/components/group-actions-menu.tsx",
   "src/domains/chat/components/pinned-app-color-swatches.tsx",
   "src/domains/chat/components/sidebar-conversation-error.tsx",

--- a/clients/web/src/domains/chat/components/chat-body.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.test.tsx
@@ -541,18 +541,135 @@ describe("ChatBody - the docked empty state holds the composer still as its dock
       "[justify-content:safe_center]",
     );
   });
+
+  test("the first send does not remount the composer out from under the docked empty state", () => {
+    // The pin that matters most on iOS Safari: a composer that remounts on
+    // send loses focus and the keyboard drops (LUM-1506 / LUM-1516). The
+    // docked branch is the one every fresh chat now takes, so the
+    // empty-to-active transition has to be walked from there, not only the
+    // docked-to-undocked flip a starter arrival used to cause.
+    const { container, rerender } = render(
+      <ChatBody {...dockedWith(chipsSlot)} />,
+    );
+    const composer = container.querySelector('[data-testid="composer"]');
+    expect(composer).not.toBeNull();
+
+    rerender(<ChatBody {...baseProps()} />);
+
+    expect(container.querySelector('[data-slot="docked-starters"]')).toBeNull();
+    expect(container.querySelector('[data-testid="composer"]')).toBe(composer);
+  });
 });
 
-describe("ChatBody - plain empty state bottom-anchors while the keyboard is open", () => {
-  // Before conversation starters arrive, the plain empty state renders the
-  // NON-docked branch with no startersSlot (server-side starter generation
-  // can take a while on a brand-new assistant). While the soft keyboard is
-  // open that branch must bottom-anchor the greeting + composer group just
-  // like the docked branch, so the composer docks to the keyboard edge in
-  // the zero-starters window and the docked/non-docked flip when starters
-  // arrive never moves the composer mid-typing. The app-editing side panel
-  // is the one non-docked state WITH a startersSlot (its inline chips), and
-  // it keeps its centered layout regardless of keyboard state.
+describe("ChatBody - an empty docked starters slot collapses in place", () => {
+  // A starter query that settles with nothing to show leaves the dock with
+  // no reason to hold space. Unmounting it would snap the group down and
+  // snap it back if a later answer arrives, so the dock collapses through
+  // the same transition the keyboard uses. The collapse wraps the docked
+  // COLUMN, not just the slot, so the column's own bottom padding goes with
+  // it: a collapse inside that padding leaves a 12px band behind, which for
+  // an assistant with no starters is a band that never goes away.
+  const startersSlot = <div data-testid="starters">STARTER_CHIPS</div>;
+
+  const dockWrapper = (container: HTMLElement) =>
+    container.querySelector<HTMLElement>('[data-slot="docked-starters"]');
+
+  afterEach(() => {
+    keyboardOpen = false;
+    cleanup();
+  });
+
+  test("collapses, fades, goes inert, and clips while keeping the slot mounted", () => {
+    const { container } = render(
+      <ChatBody
+        {...withEmptyState({
+          dockStartersToBottom: true,
+          startersDockCollapsed: true,
+          startersSlot,
+        })}
+      />,
+    );
+
+    const dock = dockWrapper(container);
+    expect(dock).not.toBeNull();
+    expect(container.innerHTML).toContain("STARTER_CHIPS");
+    expect(dock?.style.gridTemplateRows).toBe("0fr");
+    expect(dock?.className).toContain("opacity-0");
+    expect(dock?.className).toContain("pointer-events-none");
+    expect(dock?.hasAttribute("inert")).toBe(true);
+    expect(dock?.firstElementChild?.className).toContain("overflow-hidden");
+  });
+
+  test("the collapse encloses the docked column, padding and all", () => {
+    // Structural pin, since happy-dom performs no layout: the padded column
+    // must sit INSIDE the collapsing wrapper. Move it outside and the
+    // wrapper can only ever give back the slot's height, never the padding
+    // framing it.
+    const { container } = render(
+      <ChatBody
+        {...withEmptyState({
+          dockStartersToBottom: true,
+          startersDockCollapsed: true,
+          startersSlot,
+        })}
+      />,
+    );
+
+    const slot = container.querySelector('[data-testid="starters"]');
+    const column = slot?.closest(".pb-3");
+    expect(column).not.toBeNull();
+    expect(column?.closest('[data-slot="docked-starters"]')).toBe(
+      dockWrapper(container),
+    );
+  });
+
+  test("a later answer expands the same wrapper instead of mounting a new one", () => {
+    const collapsed = () =>
+      withEmptyState({
+        dockStartersToBottom: true,
+        startersDockCollapsed: true,
+        startersSlot,
+      });
+    const { container, rerender } = render(<ChatBody {...collapsed()} />);
+    const dock = dockWrapper(container);
+    expect(dock?.style.gridTemplateRows).toBe("0fr");
+
+    rerender(
+      <ChatBody
+        {...withEmptyState({ dockStartersToBottom: true, startersSlot })}
+      />,
+    );
+
+    expect(dockWrapper(container)).toBe(dock as HTMLElement);
+    expect(dock?.style.gridTemplateRows).toBe("1fr");
+    expect(dock?.hasAttribute("inert")).toBe(false);
+  });
+
+  test("an open keyboard collapses the dock whatever the slot says", () => {
+    keyboardOpen = true;
+    const { container } = render(
+      <ChatBody
+        {...withEmptyState({
+          dockStartersToBottom: true,
+          startersDockCollapsed: false,
+          startersSlot,
+        })}
+      />,
+    );
+
+    expect(dockWrapper(container)?.style.gridTemplateRows).toBe("0fr");
+  });
+});
+
+describe("ChatBody - the undocked empty state bottom-anchors while the keyboard is open", () => {
+  // An undocked empty state with nothing at all below the composer must
+  // bottom-anchor the greeting + composer group while the soft keyboard is
+  // up, so the composer reaches the keyboard edge instead of floating in the
+  // middle of the band above it. The app-editing side panel is the undocked
+  // state WITH a startersSlot (its inline chips), and it keeps its centered
+  // layout regardless of keyboard state. The flip between the two branches
+  // must not move the composer either, since a caller can pass a docked slot
+  // at any point in a render.
   const startersSlot = <div data-testid="starters">STARTER_CHIPS</div>;
 
   afterEach(() => {
@@ -560,7 +677,7 @@ describe("ChatBody - plain empty state bottom-anchors while the keyboard is open
     cleanup();
   });
 
-  test("keyboard open, zero starters: the group bottom-anchors instead of centering", () => {
+  test("keyboard open, nothing below the composer: the group bottom-anchors instead of centering", () => {
     keyboardOpen = true;
     const { container } = render(<ChatBody {...withEmptyState()} />);
 
@@ -568,7 +685,7 @@ describe("ChatBody - plain empty state bottom-anchors while the keyboard is open
     expect(container.innerHTML).not.toContain("[justify-content:safe_center]");
   });
 
-  test("starters arriving under an open keyboard keep the bottom anchor across the branch flip", () => {
+  test("a docked slot appearing under an open keyboard keeps the bottom anchor across the branch flip", () => {
     keyboardOpen = true;
     const { container, rerender } = render(<ChatBody {...withEmptyState()} />);
     expect(container.innerHTML).toContain("justify-end");

--- a/clients/web/src/domains/chat/components/chat-body.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.test.tsx
@@ -482,6 +482,67 @@ describe("ChatBody - docked starters hide while the keyboard is open", () => {
   });
 });
 
+describe("ChatBody - the docked empty state holds the composer still as its dock fills in", () => {
+  // The plain empty state passes a docked starters slot from the first frame,
+  // holding space for chips that have not loaded, and swaps the reserved
+  // content for real chips in place. Neither the composer nor the dock may
+  // remount across that swap, and an open keyboard must still bottom-anchor
+  // the group so the composer reaches the keyboard edge.
+  const reservedSlot = <div data-testid="starters">RESERVED_DOCK</div>;
+  const chipsSlot = <div data-testid="starters">STARTER_CHIPS</div>;
+
+  const dockedWith = (slot: ReactNode) =>
+    withEmptyState({ dockStartersToBottom: true, startersSlot: slot });
+
+  afterEach(() => {
+    keyboardOpen = false;
+    cleanup();
+  });
+
+  test("reserved dock, keyboard open: the group still bottom-anchors and the dock collapses", () => {
+    keyboardOpen = true;
+    const { container } = render(<ChatBody {...dockedWith(reservedSlot)} />);
+
+    expect(container.innerHTML).toContain("justify-end");
+    expect(container.innerHTML).not.toContain("[justify-content:safe_center]");
+    const dock = container.querySelector<HTMLElement>(
+      '[data-slot="docked-starters"]',
+    );
+    expect(dock?.style.gridTemplateRows).toBe("0fr");
+    expect(dock?.hasAttribute("inert")).toBe(true);
+  });
+
+  test("chips replacing the reserved content remount neither the composer nor the dock", () => {
+    const { container, rerender } = render(
+      <ChatBody {...dockedWith(reservedSlot)} />,
+    );
+    const composer = container.querySelector('[data-testid="composer"]');
+    const dock = container.querySelector('[data-slot="docked-starters"]');
+    expect(composer).not.toBeNull();
+    expect(dock).not.toBeNull();
+    expect(container.innerHTML).toContain("RESERVED_DOCK");
+
+    rerender(<ChatBody {...dockedWith(chipsSlot)} />);
+
+    expect(container.innerHTML).toContain("STARTER_CHIPS");
+    expect(container.querySelector('[data-testid="composer"]')).toBe(composer);
+    expect(container.querySelector('[data-slot="docked-starters"]')).toBe(dock);
+  });
+
+  test("the docked group centers at rest whether the dock holds chips or reserved space", () => {
+    const reserved = render(<ChatBody {...dockedWith(reservedSlot)} />);
+    expect(reserved.container.innerHTML).toContain(
+      "[justify-content:safe_center]",
+    );
+    cleanup();
+
+    const chips = render(<ChatBody {...dockedWith(chipsSlot)} />);
+    expect(chips.container.innerHTML).toContain(
+      "[justify-content:safe_center]",
+    );
+  });
+});
+
 describe("ChatBody - plain empty state bottom-anchors while the keyboard is open", () => {
   // Before conversation starters arrive, the plain empty state renders the
   // NON-docked branch with no startersSlot (server-side starter generation

--- a/clients/web/src/domains/chat/components/chat-body.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.tsx
@@ -184,6 +184,15 @@ export interface ChatBodyProps {
   dockStartersToBottom?: boolean;
 
   /**
+   * When true, the docked {@link startersSlot} keeps its place in the tree but
+   * collapses to nothing, through the same transition an open soft keyboard
+   * uses. The empty state sets it once its starter query has settled with no
+   * chips to show. The collapse wraps the whole docked column, padding
+   * included, so an empty dock gives back every pixel it was holding.
+   */
+  startersDockCollapsed?: boolean;
+
+  /**
    * Top-center floating row of active background-process overlays (subagents,
    * ACP runs, workflows, background tasks), shown independent of scroll
    * position. The caller builds this from the process registry and passes it
@@ -216,6 +225,7 @@ export function ChatBody({
   pluginPillsSlot,
   belowFoldSlot,
   dockStartersToBottom = false,
+  startersDockCollapsed = false,
   activeProcessOverlaysSlot,
 }: ChatBodyProps) {
   const isEmptyState = scrollAreaProps.showEmptyState;
@@ -294,22 +304,26 @@ export function ChatBody({
   }, [bannerRendered, registerVisibleBanner, unregisterVisibleBanner]);
 
   // Shared treatment for the below-composer extras (the starters dock and
-  // the plugin pills) while the soft keyboard is open: fade out and collapse
+  // the plugin pills) when something should stand down: fade out and collapse
   // the reserved height so the bottom-anchored composer reaches the keyboard
-  // edge. Each stays mounted so dismissing the keyboard restores it without
-  // a remount, and `inert` removes it from the tab order and the
-  // accessibility tree. The inner div clips only while the keyboard is
-  // open: the collapse needs the clip, but at rest it would shave the
-  // keyboard-focus rings that paint outside the cards and buttons inside
+  // edge, or so an empty dock gives its space back. Each stays mounted so the
+  // reason going away restores it without a remount, and `inert` removes it
+  // from the tab order and the accessibility tree. The inner div clips only
+  // while collapsed: the collapse needs the clip, but at rest it would shave
+  // the keyboard-focus rings that paint outside the cards and buttons inside
   // the slot.
-  const renderKeyboardCollapse = (dataSlot: string, children: ReactNode) => (
+  const renderCollapse = (
+    dataSlot: string,
+    collapsed: boolean,
+    children: ReactNode,
+  ) => (
     <div
       data-slot={dataSlot}
-      inert={keyboardOpen || undefined}
-      className={`grid transition-[grid-template-rows,opacity] duration-150${keyboardOpen ? " pointer-events-none opacity-0" : ""}`}
-      style={{ gridTemplateRows: keyboardOpen ? "0fr" : "1fr" }}
+      inert={collapsed || undefined}
+      className={`grid transition-[grid-template-rows,opacity] duration-150${collapsed ? " pointer-events-none opacity-0" : ""}`}
+      style={{ gridTemplateRows: collapsed ? "0fr" : "1fr" }}
     >
-      <div className={`min-h-0${keyboardOpen ? " overflow-hidden" : ""}`}>
+      <div className={`min-h-0${collapsed ? " overflow-hidden" : ""}`}>
         {children}
       </div>
     </div>
@@ -370,8 +384,9 @@ export function ChatBody({
         <StagedQuotesStrip />
         {composerSlot}
         {pluginPillsSlot &&
-          renderKeyboardCollapse(
+          renderCollapse(
             "new-chat-plugins",
+            keyboardOpen,
             <div className="mt-4">{pluginPillsSlot}</div>,
           )}
         {trailingStarters}
@@ -417,8 +432,9 @@ export function ChatBody({
         </div>
         {isDockedEmpty &&
           startersSlot &&
-          renderKeyboardCollapse(
+          renderCollapse(
             "docked-starters",
+            keyboardOpen || startersDockCollapsed,
             <ChatColumn className="pb-3">{startersSlot}</ChatColumn>,
           )}
       </div>

--- a/clients/web/src/domains/chat/components/chat-body.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.tsx
@@ -141,11 +141,13 @@ export interface ChatBodyProps {
   channelFooterSlot?: ReactNode;
 
   /**
-   * Optional conversation-starter chip grid rendered inside the max-width
-   * wrapper directly below the composer. Visible only on the empty state;
-   * the parent passes `undefined` once messages arrive. Rendered as a
-   * slot (like {@link bannerSlot}) so `ChatBody` stays agnostic of the
-   * starter data model.
+   * Optional conversation-starter content for the empty state: the bottom
+   * dock when {@link dockStartersToBottom} is set, otherwise a chip grid
+   * inside the max-width wrapper directly below the composer. The parent
+   * passes `undefined` once messages arrive. Rendered as a slot (like
+   * {@link bannerSlot}) so `ChatBody` stays agnostic of the starter data
+   * model, including whether the node it hands over is holding space for
+   * chips that have not loaded.
    */
   startersSlot?: ReactNode;
 
@@ -172,8 +174,9 @@ export interface ChatBodyProps {
    * When true (and on the empty state), the greeting + composer are centered
    * in the first viewport, {@link startersSlot} is docked to the bottom of
    * that viewport, and {@link belowFoldSlot} is placed below the fold. Used by
-   * the new-thread suggestions library. When false, the empty state keeps the
-   * default layout where the starters sit directly below the composer.
+   * the whole plain empty state (starter chips and the new-thread suggestions
+   * library alike). When false, the empty state uses the layout where the
+   * starters sit directly below the composer.
    * While the soft keyboard is open the greeting + composer anchor to the
    * bottom edge and the dock fades out and collapses its reserved height
    * (kept mounted so dismissing the keyboard restores it without a remount).
@@ -232,13 +235,13 @@ export function ChatBody({
       ? "relative flex min-h-0 flex-1 flex-col"
       : "relative flex h-full min-h-0 flex-col";
 
-  // While the soft keyboard is open and nothing renders below the composer
-  // (`startersSlot` absent: starters have not arrived yet), the plain
-  // non-docked empty state bottom-anchors instead of centering so the
-  // composer docks to the keyboard edge, and the flip to the docked branch
-  // when starters arrive keeps that alignment instead of jumping
-  // mid-typing. The app-editing side panel always passes inline starters,
-  // so it keeps its centered layout regardless of keyboard state.
+  // The undocked empty state bottom-anchors while the soft keyboard is open
+  // and nothing at all sits below the composer, so the composer reaches the
+  // keyboard edge; with content down there it stays centered and lets the
+  // scroll container handle the overflow. The predicate reads the slot
+  // itself rather than any "still loading" flag, because the slot is exactly
+  // what would occupy that space. The docked branch answers the same
+  // question on `groupClass` below, where its dock collapses instead.
   const nonDockedAlignmentClass =
     keyboardOpen && startersSlot == null
       ? "justify-end"

--- a/clients/web/src/domains/chat/components/chat-body.tsx
+++ b/clients/web/src/domains/chat/components/chat-body.tsx
@@ -311,7 +311,7 @@ export function ChatBody({
   // from the tab order and the accessibility tree. The inner div clips only
   // while collapsed: the collapse needs the clip, but at rest it would shave
   // the keyboard-focus rings that paint outside the cards and buttons inside
-  // the slot.
+  // the slot. Reduced motion gets the same end states without the tween.
   const renderCollapse = (
     dataSlot: string,
     collapsed: boolean,
@@ -320,7 +320,7 @@ export function ChatBody({
     <div
       data-slot={dataSlot}
       inert={collapsed || undefined}
-      className={`grid transition-[grid-template-rows,opacity] duration-150${collapsed ? " pointer-events-none opacity-0" : ""}`}
+      className={`grid transition-[grid-template-rows,opacity] duration-150 motion-reduce:transition-none${collapsed ? " pointer-events-none opacity-0" : ""}`}
       style={{ gridTemplateRows: collapsed ? "0fr" : "1fr" }}
     >
       <div className={`min-h-0${collapsed ? " overflow-hidden" : ""}`}>

--- a/clients/web/src/domains/chat/components/chat-empty-state.tsx
+++ b/clients/web/src/domains/chat/components/chat-empty-state.tsx
@@ -38,7 +38,12 @@ export function ChatEmptyState({
     // group with clear air above the composer (Figma: New-App 7471-25035).
     <div className="pt-8 pb-16">
       <div className="mx-auto w-full max-w-[var(--chat-max-width)] px-3 sm:px-6">
-        <div className="flex flex-col items-center justify-center">
+        {/* The slot reserves the headline's own line box at both type sizes,
+            so the busy indicator standing in for a greeting that has not
+            streamed yet occupies exactly the height the headline will, and
+            the centered greeting + composer group holds still through the
+            swap. */}
+        <div className="flex min-h-[34px] flex-col items-center justify-center md:min-h-[44px]">
           {isGenerating ? (
             <BusyIndicator size={10} />
           ) : (

--- a/clients/web/src/domains/chat/components/chat-route-content.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.test.tsx
@@ -48,7 +48,10 @@ mock.module("@/domains/chat/hooks/use-empty-state-greeting", () => ({
 }));
 
 mock.module("@/domains/chat/hooks/use-conversation-starters", () => ({
-  useConversationStarters: () => ({ starters: [] }),
+  useConversationStarters: () => ({
+    starters: [],
+    isAwaitingStarters: false,
+  }),
 }));
 
 const FEATURED: ThreadSuggestion = {

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -1166,6 +1166,7 @@ export function ChatMainPanel({
     startersSlot,
     belowFoldSlot,
     dockStartersToBottom,
+    startersDockCollapsed,
     renderAvatar,
     emptyStatePlaceholder,
     composerPeekSlot,
@@ -1492,6 +1493,7 @@ export function ChatMainPanel({
       startersSlot={startersSlot}
       belowFoldSlot={belowFoldSlot}
       dockStartersToBottom={dockStartersToBottom}
+      startersDockCollapsed={startersDockCollapsed}
       activeProcessOverlaysSlot={
         hasActiveProcess ? activeProcessOverlays : undefined
       }

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -53,6 +53,7 @@ import { TextSelectionPopover } from "@/domains/chat/components/text-selection-p
 import { useNativeQuoteReply } from "@/domains/chat/hooks/use-native-quote-reply";
 import { useQuoteReplyStore } from "@/domains/chat/quote-reply-store";
 import { isChannelConversation } from "@/domains/chat/utils/conversation-channel";
+import { resolveComposerPlaceholder } from "@/domains/chat/utils/composer-placeholder";
 import { isPopoutWindow } from "@/runtime/popout-window";
 
 import { useChatSessionStore } from "@/domains/chat/chat-session-store";
@@ -1281,17 +1282,19 @@ export function ChatMainPanel({
   const [profileSheetOpen, setProfileSheetOpen] = useState(false);
   const settingsSheetOpen = accessSheetOpen || profileSheetOpen;
 
-  // The narrow composer is one slim row with no room for a sentence, so it
-  // names the assistant it is addressed to instead. An assistant whose name
-  // has not loaded keeps the wider copy.
   const { t } = useTranslation("chat");
   const composerAssistantName = assistantName?.trim();
-  const mobilePlaceholder =
-    isMobile && composerAssistantName
-      ? t("chatComposer.askAssistantPlaceholder", {
-          assistantName: composerAssistantName,
-        })
-      : null;
+  const composerPlaceholder = resolveComposerPlaceholder({
+    isEmptyConversation,
+    emptyStatePlaceholder,
+    assistantPlaceholder:
+      isMobile && composerAssistantName
+        ? t("chatComposer.askAssistantPlaceholder", {
+            assistantName: composerAssistantName,
+          })
+        : null,
+    defaultPlaceholder: "What would you like to do?",
+  });
 
   // Explicit props (no spread bundle): the contract is visible here, and the
   // composer self-sources its own store state, so nothing high-frequency is
@@ -1299,12 +1302,7 @@ export function ChatMainPanel({
   const composerNode = (
     <ChatComposer
       cmdEnterMode={cmdEnterMode}
-      placeholder={
-        mobilePlaceholder ??
-        (isEmptyConversation
-          ? emptyStatePlaceholder
-          : "What would you like to do?")
-      }
+      placeholder={composerPlaceholder}
       onSubmit={handleFormSubmit}
       inputRef={inputRef}
       typingDisabled={typingDisabled}

--- a/clients/web/src/domains/chat/components/conversation-starter-chip.tsx
+++ b/clients/web/src/domains/chat/components/conversation-starter-chip.tsx
@@ -25,6 +25,14 @@ export interface ConversationStarterChipProps {
   "aria-label"?: string;
 }
 
+/**
+ * The chip's box: its size floor, insets, corner, and type. Shared with the
+ * dock's reserved placeholder so the space held for a chip and the chip that
+ * lands in it are measured from the same classes.
+ */
+export const CONVERSATION_STARTER_CHIP_BOX =
+  "min-h-[40px] sm:min-h-[44px] px-3 py-2 sm:px-4 sm:py-2.5 rounded-[12px] text-body-small-lighter sm:text-body-medium-lighter";
+
 export const ConversationStarterChip = forwardRef<
   HTMLButtonElement,
   ConversationStarterChipProps
@@ -43,11 +51,10 @@ export const ConversationStarterChip = forwardRef<
       className={cn(
         // Override Button's fixed h-8 / single-line / default body size.
         "h-auto whitespace-normal",
-        "min-h-[40px] sm:min-h-[44px]",
-        "px-3 py-2 sm:px-4 sm:py-2.5 rounded-[12px]",
-        // Theme body type in the secondary tone — reads like the app's
+        // Theme body type in the secondary tone: reads like the app's
         // buttons rather than heavy title text.
-        "text-body-small-lighter sm:text-body-medium-lighter text-center",
+        CONVERSATION_STARTER_CHIP_BOX,
+        "text-center",
         // Soft white card, no border (Figma 7471-25047).
         "bg-[var(--surface-lift)] [--vbtn-fg:var(--content-secondary)]",
       )}

--- a/clients/web/src/domains/chat/components/conversation-starter-chip.tsx
+++ b/clients/web/src/domains/chat/components/conversation-starter-chip.tsx
@@ -33,6 +33,16 @@ export interface ConversationStarterChipProps {
 export const CONVERSATION_STARTER_CHIP_BOX =
   "min-h-[40px] sm:min-h-[44px] px-3 py-2 sm:px-4 sm:py-2.5 rounded-[12px] text-body-small-lighter sm:text-body-medium-lighter";
 
+/**
+ * The label's line box. The body-type tokens pin `line-height` to 18px, which
+ * is tighter than the glyphs need: `line-clamp`'s overflow clipping cuts
+ * descenders (the "g" in "morning") without real line height. Shared with the
+ * dock's reserved placeholder for the same reason as
+ * {@link CONVERSATION_STARTER_CHIP_BOX}: two reserved lines and two rendered
+ * lines have to measure the same.
+ */
+export const CONVERSATION_STARTER_CHIP_LINE = "leading-normal";
+
 export const ConversationStarterChip = forwardRef<
   HTMLButtonElement,
   ConversationStarterChipProps
@@ -59,10 +69,9 @@ export const ConversationStarterChip = forwardRef<
         "bg-[var(--surface-lift)] [--vbtn-fg:var(--content-secondary)]",
       )}
     >
-      {/* leading-normal: the title-small token is line-height:1, and
-          line-clamp's overflow clipping would cut descenders (the "g" in
-          "morning") without real line height. */}
-      <span className="line-clamp-2 leading-normal">{label}</span>
+      <span className={`line-clamp-2 ${CONVERSATION_STARTER_CHIP_LINE}`}>
+        {label}
+      </span>
     </Button>
   );
 });

--- a/clients/web/src/domains/chat/components/conversation-starter-chip.tsx
+++ b/clients/web/src/domains/chat/components/conversation-starter-chip.tsx
@@ -26,12 +26,18 @@ export interface ConversationStarterChipProps {
 }
 
 /**
- * The chip's box: its size floor, insets, corner, and type. Shared with the
- * dock's reserved placeholder so the space held for a chip and the chip that
- * lands in it are measured from the same classes.
+ * The chip's box: its size floor, border, insets, corner, and type. Shared
+ * with the dock's reserved placeholder so the space held for a chip and the
+ * chip that lands in it are measured from the same classes.
+ *
+ * The border is stated here rather than left to `Button`, which sets a 1px
+ * one on its base and paints it transparent for `ghost`. A chip taller than
+ * its size floor (the two-line case the dock reserves for) is content plus
+ * padding plus that border, so a placeholder without it comes up 2px short
+ * per chip and the arriving chips push the dock open.
  */
 export const CONVERSATION_STARTER_CHIP_BOX =
-  "min-h-[40px] sm:min-h-[44px] px-3 py-2 sm:px-4 sm:py-2.5 rounded-[12px] text-body-small-lighter sm:text-body-medium-lighter";
+  "h-auto min-h-[40px] sm:min-h-[44px] border border-transparent px-3 py-2 sm:px-4 sm:py-2.5 rounded-[12px] text-body-small-lighter sm:text-body-medium-lighter";
 
 /**
  * The label's line box. The body-type tokens pin `line-height` to 18px, which
@@ -59,10 +65,11 @@ export const ConversationStarterChip = forwardRef<
       onClick={onSelect}
       aria-label={ariaLabel}
       className={cn(
-        // Override Button's fixed h-8 / single-line / default body size.
-        "h-auto whitespace-normal",
-        // Theme body type in the secondary tone: reads like the app's
-        // buttons rather than heavy title text.
+        // Override Button's single-line default.
+        "whitespace-normal",
+        // The box overrides Button's fixed height and default body size, and
+        // themes the type in the secondary tone: reads like the app's buttons
+        // rather than heavy title text.
         CONVERSATION_STARTER_CHIP_BOX,
         "text-center",
         // Soft white card, no border (Figma 7471-25047).

--- a/clients/web/src/domains/chat/components/conversation-starter-dock.test.tsx
+++ b/clients/web/src/domains/chat/components/conversation-starter-dock.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * Tests for the starters dock's reserved placeholder.
+ *
+ * The dock's whole job is that chips arrive without moving anything, and it
+ * does that by holding a placeholder the size of the chips that will land in
+ * it. That only works while the placeholder's border box and a real chip's
+ * border box are built from the same classes, and they are not built by the
+ * same code: the chip goes through the design library's `Button`, which
+ * contributes classes of its own. The pin below is on that seam.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, render } from "@testing-library/react";
+
+import { ConversationStarterChip } from "@/domains/chat/components/conversation-starter-chip";
+import { ConversationStarterDock } from "@/domains/chat/components/conversation-starter-dock";
+import type { ConversationStarter } from "@/domains/chat/utils/conversation-starters";
+
+const STARTER: ConversationStarter = {
+  id: "starter-1",
+  label: "Draft a plan for tomorrow morning",
+  prompt: "Draft a plan",
+  category: null,
+  batch: 0,
+};
+
+/**
+ * Classes that build a border box: its height floor, border, padding, corner,
+ * and the type that sets its content height. Anything outside this set (a
+ * background, a cursor, a transition) cannot change how tall the box is.
+ */
+const BOX_CLASS =
+  /^(sm:)?(h-|min-h-|max-h-|p[xytblrse]?-|border([0-9-]*)?$|rounded|text-body|leading-|box-)/;
+
+function boxClasses(element: Element | null | undefined): string[] {
+  const raw = element?.getAttribute("class") ?? "";
+  return raw
+    .split(/\s+/)
+    .filter((token) => token.length > 0 && BOX_CLASS.test(token))
+    .sort();
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ConversationStarterDock reserved placeholder", () => {
+  test("is built to the same border box as a real chip", () => {
+    // The regression: `Button` sets a 1px border on its base and paints it
+    // transparent for `ghost`, so a chip past its height floor (the two-line
+    // case the dock reserves for) is 2px taller than a placeholder that only
+    // copied the padding. Chips landing then pushed the dock open.
+    const chip = render(
+      <ConversationStarterChip label={STARTER.label} onSelect={() => {}} />,
+    );
+    const chipBox = boxClasses(chip.container.querySelector("button"));
+    cleanup();
+
+    const dock = render(
+      <ConversationStarterDock starters={[]} isReserving onSelect={() => {}} />,
+    );
+    const placeholder = dock.container.querySelector(
+      '[data-slot="conversation-starter-dock-reserve"] .grid > *',
+    );
+
+    expect(chipBox.length).toBeGreaterThan(0);
+    expect(boxClasses(placeholder)).toEqual(chipBox);
+  });
+
+  test("reserves one placeholder per chip the grid will show", () => {
+    const { container } = render(
+      <ConversationStarterDock starters={[]} isReserving onSelect={() => {}} />,
+    );
+
+    const reserve = container.querySelector(
+      '[data-slot="conversation-starter-dock-reserve"] .grid',
+    );
+    expect(reserve?.children.length).toBe(4);
+  });
+
+  test("the placeholder is hidden from assistive technology", () => {
+    const { container } = render(
+      <ConversationStarterDock starters={[]} isReserving onSelect={() => {}} />,
+    );
+
+    const reserve = container.querySelector(
+      '[data-slot="conversation-starter-dock-reserve"]',
+    );
+    expect(reserve?.getAttribute("aria-hidden")).toBe("true");
+    expect(reserve?.querySelector("button")).toBeNull();
+  });
+
+  test("draws nothing when it has neither chips nor a reserve", () => {
+    const { container } = render(
+      <ConversationStarterDock
+        starters={[]}
+        isReserving={false}
+        onSelect={() => {}}
+      />,
+    );
+
+    expect(container.innerHTML).toBe("");
+  });
+
+  test("keeps the reserve under chips that have landed", () => {
+    const { container } = render(
+      <ConversationStarterDock
+        starters={[STARTER]}
+        isReserving
+        onSelect={() => {}}
+      />,
+    );
+
+    expect(
+      container.querySelector(
+        '[data-slot="conversation-starter-dock-reserve"]',
+      ),
+    ).not.toBeNull();
+    expect(
+      container.querySelector(`[aria-label="Send: ${STARTER.label}"]`),
+    ).not.toBeNull();
+  });
+});

--- a/clients/web/src/domains/chat/components/conversation-starter-dock.tsx
+++ b/clients/web/src/domains/chat/components/conversation-starter-dock.tsx
@@ -1,21 +1,29 @@
 /**
  * The plain empty state's bottom dock for conversation-starter chips.
  *
- * The dock reserves its full height from the first frame, before the daemon
- * has answered, so the greeting + composer group centered above it lands at
- * its final position immediately and never shifts when chips appear. An
- * invisible grid of two-line chips sets that height; the real chips fade in
- * over it. A starter query that settles with nothing to show (none generated,
- * a transport failure, or an assistant that serves none) collapses the dock
- * through a grid-row transition rather than dropping it out of the layout.
+ * When the dock reserves, it holds the chips' full height from the first
+ * frame, before the daemon has answered, so the greeting + composer group
+ * centered above it lands at its final position and stays there. An invisible
+ * grid of two-line chips sets that height and stays mounted underneath the
+ * real chips as a sizing floor, so a short answer cannot shrink the dock
+ * either. Whether reserving is worth it is the caller's call: an assistant
+ * that produces no chips is better served by a dock that never takes the
+ * space at all (see `starters-availability-storage`).
  *
- * The fade is bound to the presence of chips rather than played on mount, so
- * a dock that mounts with cached chips renders them already in place and only
- * a genuine wait-then-arrive plays the reveal.
+ * The reveal is bound to the presence of chips rather than played on mount,
+ * so a dock that mounts with cached chips renders them already in place and
+ * only a genuine wait-then-arrive plays the fade.
+ *
+ * Collapsing an empty dock is `ChatBody`'s job, not this component's: the
+ * height to give back includes the padding of the column this renders into,
+ * which lives one level up.
  */
 
 import { ConversationStarterGrid } from "@/domains/chat/components/conversation-starter-grid";
-import { CONVERSATION_STARTER_CHIP_BOX } from "@/domains/chat/components/conversation-starter-chip";
+import {
+  CONVERSATION_STARTER_CHIP_BOX,
+  CONVERSATION_STARTER_CHIP_LINE,
+} from "@/domains/chat/components/conversation-starter-chip";
 import type { ConversationStarter } from "@/domains/chat/utils/conversation-starters";
 import { MAX_CONVERSATION_STARTER_CHIPS } from "@/domains/chat/utils/empty-state-constants";
 import { useTranslation } from "@/i18n";
@@ -34,76 +42,67 @@ const BLANK_LINE = "\u00a0";
 export interface ConversationStarterDockProps {
   /** Chips to render once the daemon has produced them. */
   starters: readonly ConversationStarter[];
-  /** True while the starter query may still deliver chips. */
-  isAwaiting: boolean;
+  /**
+   * True when the dock holds the chips' worst-case height whether or not any
+   * chip is in hand. False leaves the dock the size of whatever it has, which
+   * is nothing at all until chips land.
+   */
+  isReserving: boolean;
   /** Invoked with the full starter object when a chip is clicked. */
   onSelect: (starter: ConversationStarter) => void;
 }
 
 export function ConversationStarterDock({
   starters,
-  isAwaiting,
+  isReserving,
   onSelect,
 }: ConversationStarterDockProps) {
   const { t } = useTranslation("chat");
   const hasStarters = starters.length > 0;
-  const collapsed = !hasStarters && !isAwaiting;
   const revealClass = `${FADE} ${hasStarters ? "opacity-100" : "opacity-0"}`;
 
   return (
+    // Top corners only, and `-mb-3` swallows the enclosing column's bottom
+    // padding so the panel sits flush against the viewport's bottom edge.
     <div
       data-slot="conversation-starter-dock"
-      data-collapsed={collapsed || undefined}
-      inert={collapsed || undefined}
-      className={`grid transition-[grid-template-rows,opacity] duration-300 ease-out motion-reduce:transition-none${collapsed ? " opacity-0" : ""}`}
-      style={{ gridTemplateRows: collapsed ? "0fr" : "1fr" }}
+      className="-mb-3 rounded-t-2xl px-6 pt-5 pb-6"
     >
-      {/* The clip is only for the collapse: at rest it would shave the
-          keyboard-focus rings the chips paint outside their border box. */}
-      <div className={`min-h-0${collapsed ? " overflow-hidden" : ""}`}>
-        {/* Top corners only, and `-mb-3` swallows the dock wrapper's bottom
-            padding so the panel sits flush against the viewport's bottom
-            edge. */}
-        <div className="-mb-3 rounded-t-2xl px-6 pt-5 pb-6">
-          <p
-            aria-hidden={hasStarters ? undefined : "true"}
-            className={`mb-4 text-center text-body-medium-default text-[var(--content-tertiary)] ${revealClass}`}
+      <p
+        aria-hidden={hasStarters ? undefined : "true"}
+        className={`mb-4 text-center text-body-medium-default text-[var(--content-tertiary)] ${revealClass}`}
+      >
+        {t("conversationStarterDock.caption")}
+      </p>
+      <div className="grid">
+        {isReserving ? (
+          // Sizing floor: an invisible grid of two-line chips holds the dock
+          // at the tallest the real chips reach, in the same grid cell they
+          // land in, so neither their arrival nor their length moves anything
+          // above the dock.
+          <div
+            aria-hidden="true"
+            className="invisible col-start-1 row-start-1"
+            data-slot="conversation-starter-dock-reserve"
           >
-            {t("conversationStarterDock.caption")}
-          </p>
-          <div className="grid">
-            {/* Sizing floor: an invisible grid of two-line chips holds the
-                dock at the tallest the real chips reach, so chips arriving
-                one or two lines long move nothing above them. */}
-            <div
-              aria-hidden="true"
-              className="invisible col-start-1 row-start-1"
-              data-slot="conversation-starter-dock-reserve"
-            >
-              <div className="grid grid-cols-2 gap-4">
-                {PLACEHOLDER_SLOTS.map((slot) => (
-                  <div
-                    key={slot}
-                    className={`${CONVERSATION_STARTER_CHIP_BOX} bg-[var(--surface-lift)]`}
-                  >
-                    <span className="block leading-normal">
-                      {BLANK_LINE}
-                      <br />
-                      {BLANK_LINE}
-                    </span>
-                  </div>
-                ))}
-              </div>
-            </div>
-            <div
-              className={`col-start-1 row-start-1 self-start ${revealClass}`}
-            >
-              <ConversationStarterGrid
-                starters={starters}
-                onSelect={onSelect}
-              />
+            <div className="grid grid-cols-2 gap-4">
+              {PLACEHOLDER_SLOTS.map((slot) => (
+                <div
+                  key={slot}
+                  className={`${CONVERSATION_STARTER_CHIP_BOX} bg-[var(--surface-lift)]`}
+                >
+                  <span className={`block ${CONVERSATION_STARTER_CHIP_LINE}`}>
+                    {BLANK_LINE}
+                    <br />
+                    {BLANK_LINE}
+                  </span>
+                </div>
+              ))}
             </div>
           </div>
+        ) : null}
+        <div className={`col-start-1 row-start-1 self-start ${revealClass}`}>
+          <ConversationStarterGrid starters={starters} onSelect={onSelect} />
         </div>
       </div>
     </div>

--- a/clients/web/src/domains/chat/components/conversation-starter-dock.tsx
+++ b/clients/web/src/domains/chat/components/conversation-starter-dock.tsx
@@ -61,6 +61,14 @@ export function ConversationStarterDock({
   const hasStarters = starters.length > 0;
   const revealClass = `${FADE} ${hasStarters ? "opacity-100" : "opacity-0"}`;
 
+  // Neither chips nor a reserve leaves the panel's own framing as the only
+  // thing in it, which is dead space under whatever shares the slot (the
+  // credits card). `ChatBody` still mounts the wrapper around this, so a
+  // later answer expands into it rather than snapping in.
+  if (!hasStarters && !isReserving) {
+    return null;
+  }
+
   return (
     // Top corners only, and `-mb-3` swallows the enclosing column's bottom
     // padding so the panel sits flush against the viewport's bottom edge.

--- a/clients/web/src/domains/chat/components/conversation-starter-dock.tsx
+++ b/clients/web/src/domains/chat/components/conversation-starter-dock.tsx
@@ -1,0 +1,111 @@
+/**
+ * The plain empty state's bottom dock for conversation-starter chips.
+ *
+ * The dock reserves its full height from the first frame, before the daemon
+ * has answered, so the greeting + composer group centered above it lands at
+ * its final position immediately and never shifts when chips appear. An
+ * invisible grid of two-line chips sets that height; the real chips fade in
+ * over it. A starter query that settles with nothing to show (none generated,
+ * a transport failure, or an assistant that serves none) collapses the dock
+ * through a grid-row transition rather than dropping it out of the layout.
+ *
+ * The fade is bound to the presence of chips rather than played on mount, so
+ * a dock that mounts with cached chips renders them already in place and only
+ * a genuine wait-then-arrive plays the reveal.
+ */
+
+import { ConversationStarterGrid } from "@/domains/chat/components/conversation-starter-grid";
+import { CONVERSATION_STARTER_CHIP_BOX } from "@/domains/chat/components/conversation-starter-chip";
+import type { ConversationStarter } from "@/domains/chat/utils/conversation-starters";
+import { MAX_CONVERSATION_STARTER_CHIPS } from "@/domains/chat/utils/empty-state-constants";
+import { useTranslation } from "@/i18n";
+
+const FADE =
+  "transition-opacity duration-300 ease-out motion-reduce:transition-none";
+
+const PLACEHOLDER_SLOTS = Array.from(
+  { length: MAX_CONVERSATION_STARTER_CHIPS },
+  (_, index) => index,
+);
+
+/** Non-breaking space: two of them give the placeholder chip two line boxes. */
+const BLANK_LINE = "\u00a0";
+
+export interface ConversationStarterDockProps {
+  /** Chips to render once the daemon has produced them. */
+  starters: readonly ConversationStarter[];
+  /** True while the starter query may still deliver chips. */
+  isAwaiting: boolean;
+  /** Invoked with the full starter object when a chip is clicked. */
+  onSelect: (starter: ConversationStarter) => void;
+}
+
+export function ConversationStarterDock({
+  starters,
+  isAwaiting,
+  onSelect,
+}: ConversationStarterDockProps) {
+  const { t } = useTranslation("chat");
+  const hasStarters = starters.length > 0;
+  const collapsed = !hasStarters && !isAwaiting;
+  const revealClass = `${FADE} ${hasStarters ? "opacity-100" : "opacity-0"}`;
+
+  return (
+    <div
+      data-slot="conversation-starter-dock"
+      data-collapsed={collapsed || undefined}
+      inert={collapsed || undefined}
+      className={`grid transition-[grid-template-rows,opacity] duration-300 ease-out motion-reduce:transition-none${collapsed ? " opacity-0" : ""}`}
+      style={{ gridTemplateRows: collapsed ? "0fr" : "1fr" }}
+    >
+      {/* The clip is only for the collapse: at rest it would shave the
+          keyboard-focus rings the chips paint outside their border box. */}
+      <div className={`min-h-0${collapsed ? " overflow-hidden" : ""}`}>
+        {/* Top corners only, and `-mb-3` swallows the dock wrapper's bottom
+            padding so the panel sits flush against the viewport's bottom
+            edge. */}
+        <div className="-mb-3 rounded-t-2xl px-6 pt-5 pb-6">
+          <p
+            aria-hidden={hasStarters ? undefined : "true"}
+            className={`mb-4 text-center text-body-medium-default text-[var(--content-tertiary)] ${revealClass}`}
+          >
+            {t("conversationStarterDock.caption")}
+          </p>
+          <div className="grid">
+            {/* Sizing floor: an invisible grid of two-line chips holds the
+                dock at the tallest the real chips reach, so chips arriving
+                one or two lines long move nothing above them. */}
+            <div
+              aria-hidden="true"
+              className="invisible col-start-1 row-start-1"
+              data-slot="conversation-starter-dock-reserve"
+            >
+              <div className="grid grid-cols-2 gap-4">
+                {PLACEHOLDER_SLOTS.map((slot) => (
+                  <div
+                    key={slot}
+                    className={`${CONVERSATION_STARTER_CHIP_BOX} bg-[var(--surface-lift)]`}
+                  >
+                    <span className="block leading-normal">
+                      {BLANK_LINE}
+                      <br />
+                      {BLANK_LINE}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+            <div
+              className={`col-start-1 row-start-1 self-start ${revealClass}`}
+            >
+              <ConversationStarterGrid
+                starters={starters}
+                onSelect={onSelect}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/clients/web/src/domains/chat/hooks/use-chat-empty-state.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-chat-empty-state.test.tsx
@@ -42,9 +42,13 @@ const STARTER: ConversationStarter = {
 };
 
 const startersRef = { value: [STARTER] };
+const awaitingStartersRef = { value: false };
 
 mock.module("@/domains/chat/hooks/use-conversation-starters", () => ({
-  useConversationStarters: () => ({ starters: startersRef.value }),
+  useConversationStarters: () => ({
+    starters: startersRef.value,
+    isAwaitingStarters: awaitingStartersRef.value,
+  }),
 }));
 
 // The real card mounts platform gates, subscription queries, and a router
@@ -95,6 +99,7 @@ function baseParams(
 beforeEach(() => {
   flagRef.value = false;
   startersRef.value = [STARTER];
+  awaitingStartersRef.value = false;
   useLiveVoiceStore.getState().reset();
 });
 
@@ -202,6 +207,122 @@ describe("useChatEmptyState startersSlot", () => {
     expect(
       container.querySelector('[data-slot="suggestion-library"]'),
     ).toBeNull();
+  });
+});
+
+describe("useChatEmptyState starters dock", () => {
+  // The dock is what keeps the composer still while a fresh chat loads. It
+  // is docked and mounted from the first frame, before the daemon has
+  // answered, so the greeting + composer group above it never re-centers
+  // around starters arriving.
+  const dockOf = (container: HTMLElement) =>
+    container.querySelector<HTMLElement>(
+      '[data-slot="conversation-starter-dock"]',
+    );
+
+  test("docks from the first frame, before any starter has arrived", () => {
+    awaitingStartersRef.value = true;
+    startersRef.value = [];
+    const { result } = renderHook(() => useChatEmptyState(baseParams()));
+
+    expect(result.current.dockStartersToBottom).toBe(true);
+    expect(result.current.startersSlot).not.toBeUndefined();
+
+    const { container } = render(<>{result.current.startersSlot}</>);
+    const dock = dockOf(container);
+    expect(dock).not.toBeNull();
+    // Reserved, not collapsed: the space the chips will occupy is already
+    // held, so their arrival moves nothing above the dock.
+    expect(dock?.style.gridTemplateRows).toBe("1fr");
+    expect(dock?.hasAttribute("inert")).toBe(false);
+    expect(
+      container.querySelector(
+        '[data-slot="conversation-starter-dock-reserve"]',
+      ),
+    ).not.toBeNull();
+    // Nothing readable yet: the reserve is invisible space, not chips.
+    expect(
+      container.querySelector(`[aria-label="Send: ${STARTER.label}"]`),
+    ).toBeNull();
+  });
+
+  test("stays docked when no assistant id has resolved yet", () => {
+    // At boot the chat route can render before an assistant id lands. The
+    // starter query is idle there, and a dock that read that as "settled with
+    // nothing" would collapse for a frame and re-expand on the next.
+    awaitingStartersRef.value = false;
+    startersRef.value = [];
+    const { result } = renderHook(() =>
+      useChatEmptyState(baseParams({ assistantId: null })),
+    );
+
+    expect(result.current.dockStartersToBottom).toBe(true);
+    const { container } = render(<>{result.current.startersSlot}</>);
+    expect(dockOf(container)?.style.gridTemplateRows).toBe("1fr");
+  });
+
+  test("chips landing fill the reserved dock and become visible", () => {
+    const { result } = renderHook(() => useChatEmptyState(baseParams()));
+
+    const { container } = render(<>{result.current.startersSlot}</>);
+    const dock = dockOf(container);
+    expect(dock?.style.gridTemplateRows).toBe("1fr");
+    expect(
+      container.querySelector(`[aria-label="Send: ${STARTER.label}"]`),
+    ).not.toBeNull();
+    // The reserve stays mounted as the dock's sizing floor.
+    expect(
+      container.querySelector(
+        '[data-slot="conversation-starter-dock-reserve"]',
+      ),
+    ).not.toBeNull();
+    expect(container.innerHTML).toContain("opacity-100");
+  });
+
+  test("a starter query that settles empty collapses the dock instead of dropping it", () => {
+    // Self-hosted assistants and failed fetches land here. The dock stays in
+    // the tree and animates its height away, so the group above re-centers
+    // smoothly rather than snapping.
+    awaitingStartersRef.value = false;
+    startersRef.value = [];
+    const { result } = renderHook(() => useChatEmptyState(baseParams()));
+
+    expect(result.current.dockStartersToBottom).toBe(true);
+    const { container } = render(<>{result.current.startersSlot}</>);
+    const dock = dockOf(container);
+    expect(dock).not.toBeNull();
+    expect(dock?.style.gridTemplateRows).toBe("0fr");
+    expect(dock?.hasAttribute("inert")).toBe(true);
+  });
+
+  test("app editing keeps its chips inline and never docks", () => {
+    const { result } = renderHook(() =>
+      useChatEmptyState(
+        baseParams({
+          mainView: "app-editing",
+          openedAppState: { name: "My App" },
+        }),
+      ),
+    );
+
+    expect(result.current.dockStartersToBottom).toBe(false);
+    const { container } = render(<>{result.current.startersSlot}</>);
+    expect(dockOf(container)).toBeNull();
+  });
+
+  test("app editing renders no starters slot at all once the conversation has messages", () => {
+    const { result } = renderHook(() =>
+      useChatEmptyState(
+        baseParams({
+          isEmptyConversation: false,
+          mainView: "app-editing",
+          openedAppState: { name: "My App" },
+        }),
+      ),
+    );
+
+    expect(result.current.dockStartersToBottom).toBe(false);
+    expect(result.current.startersSlot).toBeUndefined();
   });
 });
 

--- a/clients/web/src/domains/chat/hooks/use-chat-empty-state.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-chat-empty-state.test.tsx
@@ -265,8 +265,11 @@ describe("useChatEmptyState starters dock", () => {
     expect(result.current.dockStartersToBottom).toBe(true);
     expect(result.current.startersDockCollapsed).toBe(true);
 
+    // The slot is still handed over, so `ChatBody` mounts the wrapper a
+    // later answer expands into. It just has nothing to draw.
+    expect(result.current.startersSlot).not.toBeUndefined();
     const { container } = render(<>{result.current.startersSlot}</>);
-    expect(dockOf(container)).not.toBeNull();
+    expect(dockOf(container)).toBeNull();
     expect(container.querySelector(RESERVE)).toBeNull();
   });
 
@@ -283,6 +286,23 @@ describe("useChatEmptyState starters dock", () => {
     expect(result.current.startersDockCollapsed).toBe(true);
     const { container } = render(<>{result.current.startersSlot}</>);
     expect(container.querySelector(RESERVE)).toBeNull();
+  });
+
+  test("the credits card does not sit above an empty panel", () => {
+    // The card shares the slot, so a dock with nothing to draw must draw
+    // nothing: its padding and caption would otherwise hang under the card
+    // as dead space.
+    startersRef.value = [];
+    startersStatusRef.value = "empty";
+    const { result } = renderHook(() =>
+      useChatEmptyState(baseParams({ showCreditsUpsell: true })),
+    );
+
+    const { container } = render(<>{result.current.startersSlot}</>);
+    expect(
+      container.querySelector('[data-slot="credits-upsell-card"]'),
+    ).not.toBeNull();
+    expect(dockOf(container)).toBeNull();
   });
 
   test("chips landing keep the reserve as the dock's sizing floor", () => {

--- a/clients/web/src/domains/chat/hooks/use-chat-empty-state.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-chat-empty-state.test.tsx
@@ -43,10 +43,14 @@ const STARTER: ConversationStarter = {
 
 const startersRef = { value: [STARTER] };
 const awaitingStartersRef = { value: false };
+const startersStatusRef: { value: "ready" | "empty" | "generating" } = {
+  value: "ready",
+};
 
 mock.module("@/domains/chat/hooks/use-conversation-starters", () => ({
   useConversationStarters: () => ({
     starters: startersRef.value,
+    status: startersStatusRef.value,
     isAwaitingStarters: awaitingStartersRef.value,
   }),
 }));
@@ -78,6 +82,10 @@ mock.module("@/domains/chat/hooks/use-thread-suggestions", () => ({
 import { useLiveVoiceStore } from "@/domains/chat/voice/live-voice/live-voice-store";
 import { useChatEmptyState } from "@/domains/chat/hooks/use-chat-empty-state";
 import type { UseChatEmptyStateParams } from "@/domains/chat/hooks/use-chat-empty-state";
+import {
+  loadAssistantProducesStarters,
+  recordAssistantProducesStarters,
+} from "@/domains/chat/utils/starters-availability-storage";
 
 function baseParams(
   overrides: Partial<UseChatEmptyStateParams> = {},
@@ -99,7 +107,9 @@ function baseParams(
 beforeEach(() => {
   flagRef.value = false;
   startersRef.value = [STARTER];
+  startersStatusRef.value = "ready";
   awaitingStartersRef.value = false;
+  localStorage.clear();
   useLiveVoiceStore.getState().reset();
 });
 
@@ -211,88 +221,120 @@ describe("useChatEmptyState startersSlot", () => {
 });
 
 describe("useChatEmptyState starters dock", () => {
-  // The dock is what keeps the composer still while a fresh chat loads. It
-  // is docked and mounted from the first frame, before the daemon has
-  // answered, so the greeting + composer group above it never re-centers
-  // around starters arriving.
+  // The dock is what keeps the composer still while a fresh chat loads: it is
+  // docked and mounted from the first frame, so the greeting + composer group
+  // above it never re-centers around starters arriving. Whether it also holds
+  // the chips' height up front is a separate decision, because holding space
+  // for an assistant that produces no chips only trades one movement for
+  // another. Only an assistant known to produce them reserves.
+  const RESERVE = '[data-slot="conversation-starter-dock-reserve"]';
+
   const dockOf = (container: HTMLElement) =>
     container.querySelector<HTMLElement>(
       '[data-slot="conversation-starter-dock"]',
     );
 
-  test("docks from the first frame, before any starter has arrived", () => {
+  test("a known producer reserves the chips' height before any of them arrives", () => {
+    recordAssistantProducesStarters("a1", true);
     awaitingStartersRef.value = true;
+    startersStatusRef.value = "generating";
     startersRef.value = [];
     const { result } = renderHook(() => useChatEmptyState(baseParams()));
 
     expect(result.current.dockStartersToBottom).toBe(true);
-    expect(result.current.startersSlot).not.toBeUndefined();
+    expect(result.current.startersDockCollapsed).toBe(false);
 
     const { container } = render(<>{result.current.startersSlot}</>);
-    const dock = dockOf(container);
-    expect(dock).not.toBeNull();
-    // Reserved, not collapsed: the space the chips will occupy is already
-    // held, so their arrival moves nothing above the dock.
-    expect(dock?.style.gridTemplateRows).toBe("1fr");
-    expect(dock?.hasAttribute("inert")).toBe(false);
-    expect(
-      container.querySelector(
-        '[data-slot="conversation-starter-dock-reserve"]',
-      ),
-    ).not.toBeNull();
+    expect(dockOf(container)).not.toBeNull();
+    expect(container.querySelector(RESERVE)).not.toBeNull();
     // Nothing readable yet: the reserve is invisible space, not chips.
     expect(
       container.querySelector(`[aria-label="Send: ${STARTER.label}"]`),
     ).toBeNull();
   });
 
-  test("stays docked when no assistant id has resolved yet", () => {
-    // At boot the chat route can render before an assistant id lands. The
-    // starter query is idle there, and a dock that read that as "settled with
-    // nothing" would collapse for a frame and re-expand on the next.
-    awaitingStartersRef.value = false;
+  test("an assistant nothing is known about reserves nothing and starts collapsed", () => {
+    // The fresh-install case. Reserving here would hold ~150px and then hand
+    // it back the moment the daemon answers with an empty list, sliding a
+    // screen that had no reason to move at all.
+    awaitingStartersRef.value = true;
+    startersStatusRef.value = "generating";
     startersRef.value = [];
-    const { result } = renderHook(() =>
-      useChatEmptyState(baseParams({ assistantId: null })),
-    );
-
-    expect(result.current.dockStartersToBottom).toBe(true);
-    const { container } = render(<>{result.current.startersSlot}</>);
-    expect(dockOf(container)?.style.gridTemplateRows).toBe("1fr");
-  });
-
-  test("chips landing fill the reserved dock and become visible", () => {
     const { result } = renderHook(() => useChatEmptyState(baseParams()));
 
+    expect(result.current.dockStartersToBottom).toBe(true);
+    expect(result.current.startersDockCollapsed).toBe(true);
+
     const { container } = render(<>{result.current.startersSlot}</>);
-    const dock = dockOf(container);
-    expect(dock?.style.gridTemplateRows).toBe("1fr");
+    expect(dockOf(container)).not.toBeNull();
+    expect(container.querySelector(RESERVE)).toBeNull();
+  });
+
+  test("the reserve ends when the wait does, whatever ended it", () => {
+    // The wait can end on a settled answer, a failed or paused fetch, or the
+    // deadline on a generation that never lands. Each arrives here the same
+    // way, and none of them may leave a known producer holding space forever.
+    recordAssistantProducesStarters("a1", true);
+    awaitingStartersRef.value = false;
+    startersStatusRef.value = "generating";
+    startersRef.value = [];
+    const { result } = renderHook(() => useChatEmptyState(baseParams()));
+
+    expect(result.current.startersDockCollapsed).toBe(true);
+    const { container } = render(<>{result.current.startersSlot}</>);
+    expect(container.querySelector(RESERVE)).toBeNull();
+  });
+
+  test("chips landing keep the reserve as the dock's sizing floor", () => {
+    // Dropping the floor the moment chips arrive would let a one-line answer
+    // shrink the dock, which moves the group just as surely as growing it.
+    recordAssistantProducesStarters("a1", true);
+    const { result } = renderHook(() => useChatEmptyState(baseParams()));
+
+    expect(result.current.startersDockCollapsed).toBe(false);
+    const { container } = render(<>{result.current.startersSlot}</>);
+    expect(container.querySelector(RESERVE)).not.toBeNull();
     expect(
       container.querySelector(`[aria-label="Send: ${STARTER.label}"]`),
-    ).not.toBeNull();
-    // The reserve stays mounted as the dock's sizing floor.
-    expect(
-      container.querySelector(
-        '[data-slot="conversation-starter-dock-reserve"]',
-      ),
     ).not.toBeNull();
     expect(container.innerHTML).toContain("opacity-100");
   });
 
-  test("a starter query that settles empty collapses the dock instead of dropping it", () => {
-    // Self-hosted assistants and failed fetches land here. The dock stays in
-    // the tree and animates its height away, so the group above re-centers
-    // smoothly rather than snapping.
-    awaitingStartersRef.value = false;
-    startersRef.value = [];
+  test("this launch's own answer does not add a floor under chips already drawn", () => {
+    // The first-ever answer on a brand-new assistant. Recording it must not
+    // feed straight back into the reserve: a floor appearing under chips that
+    // are already laid out pushes the group the floor exists to hold still.
+    // The chips open the dock instead, once, and the next launch reserves.
     const { result } = renderHook(() => useChatEmptyState(baseParams()));
 
-    expect(result.current.dockStartersToBottom).toBe(true);
+    expect(result.current.startersDockCollapsed).toBe(false);
     const { container } = render(<>{result.current.startersSlot}</>);
-    const dock = dockOf(container);
-    expect(dock).not.toBeNull();
-    expect(dock?.style.gridTemplateRows).toBe("0fr");
-    expect(dock?.hasAttribute("inert")).toBe(true);
+    expect(container.querySelector(RESERVE)).toBeNull();
+    expect(
+      container.querySelector(`[aria-label="Send: ${STARTER.label}"]`),
+    ).not.toBeNull();
+    expect(loadAssistantProducesStarters("a1")).toBe(true);
+  });
+
+  test("a settled answer with no chips is remembered too", () => {
+    recordAssistantProducesStarters("a1", true);
+    startersRef.value = [];
+    startersStatusRef.value = "empty";
+    renderHook(() => useChatEmptyState(baseParams()));
+
+    expect(loadAssistantProducesStarters("a1")).toBe(false);
+  });
+
+  test("an unsettled answer leaves the previous one alone", () => {
+    // A wedged generation, a failed fetch, and an offline pause all reach
+    // here with no chips and no terminal status. Forgetting on those would
+    // cost the next launch its reserve over a transient failure.
+    recordAssistantProducesStarters("a1", true);
+    startersRef.value = [];
+    startersStatusRef.value = "generating";
+    renderHook(() => useChatEmptyState(baseParams()));
+
+    expect(loadAssistantProducesStarters("a1")).toBe(true);
   });
 
   test("app editing keeps its chips inline and never docks", () => {
@@ -344,8 +386,13 @@ describe("useChatEmptyState credits upsell card", () => {
     ).not.toBeNull();
   });
 
-  test("showCreditsUpsell with no starters still renders the card alone", () => {
+  test("showCreditsUpsell with no starters still renders the card, riding the dock", () => {
+    // The card shares the starters slot, so with no chips to show it rides
+    // the bottom dock rather than sitting inline under the composer. The dock
+    // must therefore stay expanded: collapsing an empty dock would take the
+    // credit wall down with it.
     startersRef.value = [];
+    startersStatusRef.value = "empty";
     const { result } = renderHook(() =>
       useChatEmptyState(baseParams({ showCreditsUpsell: true })),
     );
@@ -354,6 +401,7 @@ describe("useChatEmptyState credits upsell card", () => {
     expect(
       container.querySelector('[data-slot="credits-upsell-card"]'),
     ).not.toBeNull();
+    expect(result.current.startersDockCollapsed).toBe(false);
   });
 
   test("no card when showCreditsUpsell is false (normal balance, loading, or gated-off billing query)", () => {

--- a/clients/web/src/domains/chat/hooks/use-chat-empty-state.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-chat-empty-state.test.tsx
@@ -47,12 +47,19 @@ const startersStatusRef: { value: "ready" | "empty" | "generating" } = {
   value: "ready",
 };
 
+// Honors the assistant id the way the real hook does: a null id is a
+// disabled query and answers idle. A stub that served starters regardless
+// hid the paths that never ask for them (the suggestions library, an
+// active conversation) behind chips they would never actually receive.
 mock.module("@/domains/chat/hooks/use-conversation-starters", () => ({
-  useConversationStarters: () => ({
-    starters: startersRef.value,
-    status: startersStatusRef.value,
-    isAwaitingStarters: awaitingStartersRef.value,
-  }),
+  useConversationStarters: (assistantId: string | null | undefined) =>
+    assistantId
+      ? {
+          starters: startersRef.value,
+          status: startersStatusRef.value,
+          isAwaitingStarters: awaitingStartersRef.value,
+        }
+      : { starters: [], status: "idle", isAwaitingStarters: false },
 }));
 
 // The real card mounts platform gates, subscription queries, and a router
@@ -355,6 +362,41 @@ describe("useChatEmptyState starters dock", () => {
     renderHook(() => useChatEmptyState(baseParams()));
 
     expect(loadAssistantProducesStarters("a1")).toBe(true);
+  });
+
+  test("the suggestions library is never collapsed by the chip dock's policy", () => {
+    // The library takes the same docked slot but fills it from its own data,
+    // and the starter query is disabled on that path, so it answers idle with
+    // no chips. Reading that as an empty dock collapsed the featured row out
+    // of sight on the whole flag-on empty state.
+    flagRef.value = true;
+    const { result } = renderHook(() =>
+      useChatEmptyState(baseParams({ onSelectSuggestion: () => {} })),
+    );
+
+    expect(result.current.dockStartersToBottom).toBe(true);
+    expect(result.current.startersDockCollapsed).toBe(false);
+
+    const { container } = render(<>{result.current.startersSlot}</>);
+    expect(
+      container.querySelector('[data-slot="suggestion-featured-row"]'),
+    ).not.toBeNull();
+    expect(dockOf(container)).toBeNull();
+  });
+
+  test("the library is not collapsed even for an assistant known to have no chips", () => {
+    // The discriminating case: the flag-off path for this assistant would
+    // collapse, so a gate that only checked the starter data would take the
+    // library down with it.
+    recordAssistantProducesStarters("a1", false);
+    startersRef.value = [];
+    startersStatusRef.value = "empty";
+    flagRef.value = true;
+    const { result } = renderHook(() =>
+      useChatEmptyState(baseParams({ onSelectSuggestion: () => {} })),
+    );
+
+    expect(result.current.startersDockCollapsed).toBe(false);
   });
 
   test("app editing keeps its chips inline and never docks", () => {

--- a/clients/web/src/domains/chat/hooks/use-chat-empty-state.tsx
+++ b/clients/web/src/domains/chat/hooks/use-chat-empty-state.tsx
@@ -8,7 +8,7 @@
  * the daemon.
  */
 
-import { type ReactNode, useMemo } from "react";
+import { type ReactNode, useEffect, useMemo } from "react";
 
 import { ChatAvatar } from "@/components/avatar/chat-avatar";
 import type { ChatEmptyStateProps } from "@/domains/chat/components/chat-empty-state";
@@ -32,6 +32,10 @@ import {
   buildEditAppStarters,
 } from "@/domains/chat/utils/edit-app-empty-state";
 import { pickRandomPlaceholder } from "@/domains/chat/utils/empty-state-constants";
+import {
+  recordAssistantProducesStarters,
+  useAssistantProducedStartersAtOpen,
+} from "@/domains/chat/utils/starters-availability-storage";
 import type { ConversationStarter } from "@/domains/chat/utils/conversation-starters";
 import type { ThreadSuggestion } from "@/domains/chat/suggestions/types";
 import type { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
@@ -89,6 +93,13 @@ export interface ChatEmptyStateResult {
    * composer.
    */
   dockStartersToBottom: boolean;
+  /**
+   * True when the docked starters have nothing to show and no reason to hold
+   * space: the query settled with no chips for an assistant that is not known
+   * to produce any. `ChatBody` keeps the dock mounted and collapses it, so a
+   * later answer expands it instead of snapping in.
+   */
+  startersDockCollapsed: boolean;
   renderAvatar: (() => ReactNode) | undefined;
   emptyStatePlaceholder: string;
   /**
@@ -175,16 +186,40 @@ export function useChatEmptyState({
   // polling for data that's never rendered. Also skip it whenever the
   // suggestions library is shown — the daemon GET enqueues starter generation
   // and polls every few seconds for chips the library path never renders.
-  const { starters: conversationStarters, isAwaitingStarters } =
-    useConversationStarters(
-      isEmptyConversation && !showSuggestionLibrary ? assistantId : null,
-    );
+  const startersAssistantId =
+    isEmptyConversation && !showSuggestionLibrary ? assistantId : null;
+  const {
+    starters: conversationStarters,
+    status: startersStatus,
+    isAwaitingStarters,
+  } = useConversationStarters(startersAssistantId);
 
-  // The dock holds its reserved height while chips may still arrive. Before
-  // an assistant id resolves there is no query to be pending, so treat that
-  // window as waiting too: the alternative collapses the dock for a frame
-  // and re-expands it the moment the id lands.
-  const startersAwaiting = assistantId == null || isAwaitingStarters;
+  // Whether this assistant produced chips the last time it answered. The
+  // dock's reserve has to be decided on the first paint, before this launch's
+  // query can say, and reserving for an assistant that turns out to have no
+  // chips is worse than not reserving at all: the dock takes the space and
+  // then gives it back, sliding a screen that would otherwise be still. An
+  // assistant nothing is known about therefore reserves nothing, and its
+  // first-ever chips open the dock instead of landing in it.
+  const assistantProducesStarters =
+    useAssistantProducedStartersAtOpen(assistantId);
+
+  // Remember every settled answer for the next launch. Chips in hand say yes
+  // whatever the daemon is doing next; only the daemon's own terminal
+  // statuses say no, so a failed, paused, or still-generating fetch leaves
+  // the previous answer alone rather than forgetting it.
+  useEffect(() => {
+    if (!startersAssistantId) {
+      return;
+    }
+    if (conversationStarters.length > 0) {
+      recordAssistantProducesStarters(startersAssistantId, true);
+      return;
+    }
+    if (startersStatus === "ready" || startersStatus === "empty") {
+      recordAssistantProducesStarters(startersAssistantId, false);
+    }
+  }, [startersAssistantId, startersStatus, conversationStarters.length]);
 
   const emptyStateProps: ChatEmptyStateProps = {
     greeting: editingApp
@@ -196,6 +231,26 @@ export function useChatEmptyState({
   const emptyStateStarters = editingApp
     ? buildEditAppStarters(editingApp)
     : conversationStarters;
+
+  // Reserve for an assistant known to produce chips, and keep the reserve up
+  // as its own sizing floor once they land so a short answer cannot shrink
+  // the dock either. Everything that can end the wait ends the reserve: chips
+  // arriving, the daemon settling on none, a failed or paused fetch, and the
+  // deadline on a generation that never lands.
+  const startersReserved =
+    isPlainEmptyState &&
+    assistantProducesStarters &&
+    (isAwaitingStarters || emptyStateStarters.length > 0);
+
+  // A dock with neither chips nor a reserve has nothing to show. It stays
+  // mounted and hands its height back through `ChatBody`'s collapse, which
+  // covers the docked column's own padding as well. The credits card rides
+  // this same slot, so a dock holding one is never empty.
+  const startersDockCollapsed =
+    isPlainEmptyState &&
+    !startersReserved &&
+    !showCreditsUpsell &&
+    emptyStateStarters.length === 0;
 
   let startersSlot: ReactNode | undefined;
   let belowFoldSlot: ReactNode | undefined;
@@ -230,12 +285,12 @@ export function useChatEmptyState({
   } else if (isPlainEmptyState) {
     // The chips dock to the bottom of the first viewport in a subtle panel
     // with a muted caption (the Figma's 1×3 row stays a 2×2 grid here). The
-    // dock mounts whether or not chips exist yet and owns its own reserve,
-    // reveal, and collapse.
+    // dock mounts whether or not chips exist yet, so the layout never waits
+    // on the daemon to know its shape.
     startersSlot = (
       <ConversationStarterDock
         starters={emptyStateStarters}
-        isAwaiting={startersAwaiting}
+        isReserving={startersReserved}
         onSelect={onSelectStarter}
       />
     );
@@ -304,6 +359,7 @@ export function useChatEmptyState({
     // composer's position waits on the daemon. Only the app-editing side
     // panel keeps them inline under the composer.
     dockStartersToBottom: showSuggestionLibrary || isPlainEmptyState,
+    startersDockCollapsed,
     renderAvatar,
     emptyStatePlaceholder,
     composerPeekSlot,

--- a/clients/web/src/domains/chat/hooks/use-chat-empty-state.tsx
+++ b/clients/web/src/domains/chat/hooks/use-chat-empty-state.tsx
@@ -232,13 +232,20 @@ export function useChatEmptyState({
     ? buildEditAppStarters(editingApp)
     : conversationStarters;
 
+  // Everything below is about the chip dock and only the chip dock. The
+  // suggestions library takes the same docked slot on the flag-on path and
+  // fills it from its own data, which the starters query is not even asked
+  // for there: reading that silence as an empty dock would collapse the
+  // library's featured row out of sight.
+  const showStarterDock = isPlainEmptyState && !showSuggestionLibrary;
+
   // Reserve for an assistant known to produce chips, and keep the reserve up
   // as its own sizing floor once they land so a short answer cannot shrink
   // the dock either. Everything that can end the wait ends the reserve: chips
   // arriving, the daemon settling on none, a failed or paused fetch, and the
   // deadline on a generation that never lands.
   const startersReserved =
-    isPlainEmptyState &&
+    showStarterDock &&
     assistantProducesStarters &&
     (isAwaitingStarters || emptyStateStarters.length > 0);
 
@@ -247,7 +254,7 @@ export function useChatEmptyState({
   // covers the docked column's own padding as well. The credits card rides
   // this same slot, so a dock holding one is never empty.
   const startersDockCollapsed =
-    isPlainEmptyState &&
+    showStarterDock &&
     !startersReserved &&
     !showCreditsUpsell &&
     emptyStateStarters.length === 0;
@@ -282,7 +289,7 @@ export function useChatEmptyState({
         />
       </div>
     );
-  } else if (isPlainEmptyState) {
+  } else if (showStarterDock) {
     // The chips dock to the bottom of the first viewport in a subtle panel
     // with a muted caption (the Figma's 1×3 row stays a 2×2 grid here). The
     // dock mounts whether or not chips exist yet, so the layout never waits

--- a/clients/web/src/domains/chat/hooks/use-chat-empty-state.tsx
+++ b/clients/web/src/domains/chat/hooks/use-chat-empty-state.tsx
@@ -14,6 +14,7 @@ import { ChatAvatar } from "@/components/avatar/chat-avatar";
 import type { ChatEmptyStateProps } from "@/domains/chat/components/chat-empty-state";
 import { ComposerPeek } from "@/domains/chat/components/composer-peek";
 import { CreditsUpsellCard } from "@/domains/chat/components/credits-upsell-card";
+import { ConversationStarterDock } from "@/domains/chat/components/conversation-starter-dock";
 import { ConversationStarterGrid } from "@/domains/chat/components/conversation-starter-grid";
 import {
   SuggestionFeaturedRow,
@@ -80,9 +81,12 @@ export interface ChatEmptyStateResult {
   belowFoldSlot: ReactNode | undefined;
   /**
    * When true, the empty state docks `startersSlot` to the bottom of the
-   * first viewport and centers the greeting + composer above it (the
-   * suggestions-library layout). Otherwise the starters sit directly below
-   * the composer (the conversation-starter chip layout).
+   * first viewport and centers the greeting + composer above it. True for
+   * the whole plain empty state (chips and suggestions library alike), from
+   * the first frame and regardless of whether starters have arrived, so the
+   * composer never moves as the page fills in. Only the app-editing side
+   * panel sits false and keeps its bespoke chips directly below the
+   * composer.
    */
   dockStartersToBottom: boolean;
   renderAvatar: (() => ReactNode) | undefined;
@@ -171,9 +175,16 @@ export function useChatEmptyState({
   // polling for data that's never rendered. Also skip it whenever the
   // suggestions library is shown — the daemon GET enqueues starter generation
   // and polls every few seconds for chips the library path never renders.
-  const { starters: conversationStarters } = useConversationStarters(
-    isEmptyConversation && !showSuggestionLibrary ? assistantId : null,
-  );
+  const { starters: conversationStarters, isAwaitingStarters } =
+    useConversationStarters(
+      isEmptyConversation && !showSuggestionLibrary ? assistantId : null,
+    );
+
+  // The dock holds its reserved height while chips may still arrive. Before
+  // an assistant id resolves there is no query to be pending, so treat that
+  // window as waiting too: the alternative collapses the dock for a frame
+  // and re-expands it the moment the id lands.
+  const startersAwaiting = assistantId == null || isAwaitingStarters;
 
   const emptyStateProps: ChatEmptyStateProps = {
     greeting: editingApp
@@ -200,37 +211,34 @@ export function useChatEmptyState({
     belowFoldSlot = (
       <SuggestionGroups groups={groups} onSelect={onSelectSuggestion} />
     );
-  } else if (isEmptyConversation && emptyStateStarters.length > 0) {
-    if (editingApp) {
-      // The app-editing side panel keeps its bespoke chips inline under
-      // the composer.
-      startersSlot = (
-        <div className="mt-4">
-          <ConversationStarterGrid
-            starters={emptyStateStarters}
-            onSelect={onSelectStarter}
-          />
-        </div>
-      );
-    } else {
-      // Plain empty state: the chips dock to the bottom of the first
-      // viewport in a subtle panel with a muted caption (Figma: New-App
-      // 7471-25035; the Figma's 1×3 row stays a 2×2 grid here). Top
-      // corners only, and `-mb-3` swallows the dock wrapper's bottom
-      // padding so the panel sits flush against the viewport's bottom
-      // edge.
-      startersSlot = (
-        <div className="-mb-3 rounded-t-2xl px-6 pt-5 pb-6">
-          <p className="mb-4 text-center text-body-medium-default text-[var(--content-tertiary)]">
-            Try some suggestions:
-          </p>
-          <ConversationStarterGrid
-            starters={emptyStateStarters}
-            onSelect={onSelectStarter}
-          />
-        </div>
-      );
-    }
+  } else if (
+    isEmptyConversation &&
+    editingApp &&
+    emptyStateStarters.length > 0
+  ) {
+    // The app-editing side panel keeps its bespoke chips inline under the
+    // composer. They are derived from the opened app, so they are ready on
+    // the first render and need no reserved space.
+    startersSlot = (
+      <div className="mt-4">
+        <ConversationStarterGrid
+          starters={emptyStateStarters}
+          onSelect={onSelectStarter}
+        />
+      </div>
+    );
+  } else if (isPlainEmptyState) {
+    // The chips dock to the bottom of the first viewport in a subtle panel
+    // with a muted caption (the Figma's 1×3 row stays a 2×2 grid here). The
+    // dock mounts whether or not chips exist yet and owns its own reserve,
+    // reveal, and collapse.
+    startersSlot = (
+      <ConversationStarterDock
+        starters={emptyStateStarters}
+        isAwaiting={startersAwaiting}
+        onSelect={onSelectStarter}
+      />
+    );
   }
 
   // Proactive credit wall for a fresh conversation: the card rides the
@@ -290,12 +298,12 @@ export function useChatEmptyState({
     emptyStateProps,
     startersSlot,
     belowFoldSlot,
-    // Both the suggestions library and the plain chip dock pin the
-    // starters to the bottom of the first viewport; only the app-editing
-    // side panel keeps them inline under the composer.
-    dockStartersToBottom:
-      showSuggestionLibrary ||
-      (isPlainEmptyState && emptyStateStarters.length > 0),
+    // Both the suggestions library and the plain chip dock pin the starters
+    // to the bottom of the first viewport, from the first frame: the layout
+    // does not depend on starters having arrived, so nothing about the
+    // composer's position waits on the daemon. Only the app-editing side
+    // panel keeps them inline under the composer.
+    dockStartersToBottom: showSuggestionLibrary || isPlainEmptyState,
     renderAvatar,
     emptyStatePlaceholder,
     composerPeekSlot,

--- a/clients/web/src/domains/chat/hooks/use-conversation-starters.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-conversation-starters.test.tsx
@@ -14,8 +14,9 @@
  *      provide).
  */
 
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import * as realRQ from "@tanstack/react-query";
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
 import { renderToStaticMarkup } from "react-dom/server";
 
 import type {
@@ -44,6 +45,7 @@ interface UseQueryStub {
   data: ConversationstartersGetResponse | undefined;
   isLoading: boolean;
   isError?: boolean;
+  fetchStatus?: "fetching" | "paused" | "idle";
   refetch: () => Promise<void>;
 }
 
@@ -376,5 +378,70 @@ describe("useConversationStarters isAwaitingStarters", () => {
 
   test("an idle query never waits", () => {
     expect(runHook(null).isAwaitingStarters).toBe(false);
+  });
+
+  test("stops waiting on a fetch the browser paused for being offline", () => {
+    // TanStack's default `networkMode` holds the request while offline: no
+    // load is reported and no error arrives, so `data` stays undefined and
+    // the status keeps falling back to "generating". Nothing else here would
+    // ever end that wait.
+    useQueryStub = {
+      data: undefined,
+      isLoading: false,
+      fetchStatus: "paused",
+      refetch: async () => {},
+    };
+
+    expect(runHook("asst-1").isAwaitingStarters).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Awaiting deadline: a generation that never lands must not pin the reserve
+// ---------------------------------------------------------------------------
+
+describe("useConversationStarters await deadline", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  test("stops waiting once the deadline passes on a generation that never lands", async () => {
+    // The daemon can keep answering "generating" indefinitely. Without a
+    // deadline the empty state's reserved dock holds its space for the life
+    // of the screen.
+    useQueryStub = {
+      data: { starters: [], total: 0, status: "generating" },
+      isLoading: false,
+      refetch: async () => {},
+    };
+
+    const { result } = renderHook(() =>
+      useConversationStarters("asst-1", { awaitDeadlineMs: 10 }),
+    );
+    expect(result.current.isAwaitingStarters).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.isAwaitingStarters).toBe(false);
+    });
+  });
+
+  test("the deadline restarts for a different assistant", async () => {
+    useQueryStub = {
+      data: { starters: [], total: 0, status: "generating" },
+      isLoading: false,
+      refetch: async () => {},
+    };
+
+    const { result, rerender } = renderHook(
+      ({ id }: { id: string }) =>
+        useConversationStarters(id, { awaitDeadlineMs: 30 }),
+      { initialProps: { id: "asst-1" } },
+    );
+    await waitFor(() => {
+      expect(result.current.isAwaitingStarters).toBe(false);
+    });
+
+    rerender({ id: "asst-2" });
+    expect(result.current.isAwaitingStarters).toBe(true);
   });
 });

--- a/clients/web/src/domains/chat/hooks/use-conversation-starters.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-conversation-starters.test.tsx
@@ -43,6 +43,7 @@ let lastCapturedOptions: CapturedQueryOptions | null = null;
 interface UseQueryStub {
   data: ConversationstartersGetResponse | undefined;
   isLoading: boolean;
+  isError?: boolean;
   refetch: () => Promise<void>;
 }
 
@@ -289,5 +290,91 @@ describe("useConversationStarters — projects query state to result", () => {
     await result.refetch();
 
     expect(refetchCalls).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Awaiting flag: drives the empty state's reserved starters dock
+// ---------------------------------------------------------------------------
+
+describe("useConversationStarters isAwaitingStarters", () => {
+  test("waits while the first fetch is in flight", () => {
+    useQueryStub = {
+      data: undefined,
+      isLoading: true,
+      refetch: async () => {},
+    };
+
+    expect(runHook("asst-1").isAwaitingStarters).toBe(true);
+  });
+
+  test("waits while the daemon reports it is still generating", () => {
+    useQueryStub = {
+      data: { starters: [], total: 0, status: "generating" },
+      isLoading: false,
+      refetch: async () => {},
+    };
+
+    expect(runHook("asst-1").isAwaitingStarters).toBe(true);
+  });
+
+  test("waits through a refresh that has nothing to show yet", () => {
+    useQueryStub = {
+      data: { starters: [], total: 0, status: "refreshing" },
+      isLoading: false,
+      refetch: async () => {},
+    };
+
+    expect(runHook("asst-1").isAwaitingStarters).toBe(true);
+  });
+
+  test("stops waiting once starters arrive, even mid-refresh", () => {
+    useQueryStub = {
+      data: {
+        starters: [
+          {
+            id: "s1",
+            label: "Plan a trip",
+            prompt: "Help me plan a trip",
+            category: null,
+            batch: 0,
+          },
+        ],
+        total: 1,
+        status: "refreshing",
+      },
+      isLoading: false,
+      refetch: async () => {},
+    };
+
+    expect(runHook("asst-1").isAwaitingStarters).toBe(false);
+  });
+
+  test("stops waiting when the daemon settles on having none", () => {
+    useQueryStub = {
+      data: { starters: [], total: 0, status: "ready" },
+      isLoading: false,
+      refetch: async () => {},
+    };
+
+    expect(runHook("asst-1").isAwaitingStarters).toBe(false);
+  });
+
+  test("stops waiting on a failed fetch, which reports no status of its own", () => {
+    // A failed query leaves `data` undefined, so the status falls back to
+    // "generating". Without the error check the dock would hold space for
+    // chips that are never coming.
+    useQueryStub = {
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      refetch: async () => {},
+    };
+
+    expect(runHook("asst-1").isAwaitingStarters).toBe(false);
+  });
+
+  test("an idle query never waits", () => {
+    expect(runHook(null).isAwaitingStarters).toBe(false);
   });
 });

--- a/clients/web/src/domains/chat/hooks/use-conversation-starters.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-conversation-starters.test.tsx
@@ -15,8 +15,9 @@
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { useEffect } from "react";
 import * as realRQ from "@tanstack/react-query";
-import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { cleanup, render, renderHook, waitFor } from "@testing-library/react";
 import { renderToStaticMarkup } from "react-dom/server";
 
 import type {
@@ -442,6 +443,61 @@ describe("useConversationStarters await deadline", () => {
     });
 
     rerender({ id: "asst-2" });
+    expect(result.current.isAwaitingStarters).toBe(true);
+  });
+
+  test("a switch away from an expired assistant never commits an expired frame", async () => {
+    // `rerender` flushes effects before returning, so asserting on the final
+    // value cannot see a stale frame. The probe records every COMMITTED frame
+    // instead: a post-commit reset paints one expired frame first, which
+    // collapses the reserved dock and re-expands it mid-transition.
+    useQueryStub = {
+      data: { starters: [], total: 0, status: "generating" },
+      isLoading: false,
+      refetch: async () => {},
+    };
+
+    const committed: boolean[] = [];
+    function Probe({ id }: { id: string }) {
+      const { isAwaitingStarters } = useConversationStarters(id, {
+        awaitDeadlineMs: 10,
+      });
+      useEffect(() => {
+        committed.push(isAwaitingStarters);
+      });
+      return null;
+    }
+
+    const { rerender } = render(<Probe id="asst-1" />);
+    await waitFor(() => {
+      expect(committed.at(-1)).toBe(false);
+    });
+
+    committed.length = 0;
+    rerender(<Probe id="asst-2" />);
+
+    expect(committed.length).toBeGreaterThan(0);
+    expect(committed.every((frame) => frame === true)).toBe(true);
+  });
+
+  test("re-enabling the same assistant restarts the deadline", async () => {
+    useQueryStub = {
+      data: { starters: [], total: 0, status: "generating" },
+      isLoading: false,
+      refetch: async () => {},
+    };
+
+    const { result, rerender } = renderHook(
+      ({ id }: { id: string | null }) =>
+        useConversationStarters(id, { awaitDeadlineMs: 10 }),
+      { initialProps: { id: "asst-1" as string | null } },
+    );
+    await waitFor(() => {
+      expect(result.current.isAwaitingStarters).toBe(false);
+    });
+
+    rerender({ id: null });
+    rerender({ id: "asst-1" });
     expect(result.current.isAwaitingStarters).toBe(true);
   });
 });

--- a/clients/web/src/domains/chat/hooks/use-conversation-starters.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-starters.ts
@@ -98,14 +98,35 @@ export function useConversationStarters(
     refetchInterval: (q) => shouldPoll(q.state.data?.status),
   });
 
-  const [awaitExpired, setAwaitExpired] = useState(false);
+  // Expiry is keyed to the enabled query's identity and read synchronously,
+  // so the first committed render after an assistant switch or a re-enable
+  // can never wear the previous query's expired answer. A post-commit reset
+  // would paint one frame with that stale answer, and for an assistant known
+  // to produce starters that frame collapses the reserved dock and re-expands
+  // it, moving the composer during the transition the reserve exists to hold
+  // still. Same render-phase adjustment as `useAssistantProducedStartersAtOpen`.
+  const awaitKey = enabled ? (assistantId ?? null) : null;
+  const [awaitState, setAwaitState] = useState<{
+    key: string | null;
+    expired: boolean;
+  }>(() => ({ key: awaitKey, expired: false }));
+  if (awaitState.key !== awaitKey) {
+    setAwaitState({ key: awaitKey, expired: false });
+  }
+  const awaitExpired = awaitState.key === awaitKey && awaitState.expired;
+
   useEffect(() => {
     if (!enabled) {
       return;
     }
-    setAwaitExpired(false);
+    const key = assistantId ?? null;
     const timer = setTimeout(() => {
-      setAwaitExpired(true);
+      setAwaitState((current) => {
+        if (current.key !== key || current.expired) {
+          return current;
+        }
+        return { key, expired: true };
+      });
     }, awaitDeadlineMs);
     return () => {
       clearTimeout(timer);

--- a/clients/web/src/domains/chat/hooks/use-conversation-starters.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-starters.ts
@@ -7,6 +7,7 @@
  * idle result without making a network call.
  */
 
+import { useEffect, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 
 import { conversationstartersGetOptions } from "@/generated/daemon/@tanstack/react-query.gen";
@@ -20,6 +21,15 @@ import { MAX_CONVERSATION_STARTER_CHIPS } from "@/domains/chat/utils/empty-state
 
 const STALE_TIME_MS = 60_000;
 const POLL_INTERVAL_MS = 3_000;
+
+/**
+ * How long {@link UseConversationStartersResult.isAwaitingStarters} is willing
+ * to answer "chips may still arrive" while the daemon keeps reporting that it
+ * is generating them. A generation that never lands would otherwise pin the
+ * empty state's reserved dock open for the life of the screen, so the wait
+ * gets a deadline and the layout always resolves.
+ */
+export const STARTERS_AWAIT_DEADLINE_MS = 10_000;
 
 const DEFAULT_OFFSET = 0;
 
@@ -37,15 +47,24 @@ export interface UseConversationStartersResult {
   status: ConversationStartersStatus | "idle";
   isLoading: boolean;
   /**
-   * True while there is nothing to render yet and chips may still arrive:
-   * the first fetch is in flight, or the daemon reports it is still
-   * generating them. False once chips land, once the daemon settles on
-   * having none, on a failed fetch, and whenever the query is idle. The
-   * empty state's starter dock holds its reserved height while this is
-   * true and collapses when it goes false with no chips.
+   * True while there is nothing to render yet and chips are worth waiting
+   * for: the first fetch is in flight, or the daemon reports it is still
+   * generating them and the wait is inside
+   * {@link STARTERS_AWAIT_DEADLINE_MS}.
+   *
+   * False once chips land, once the daemon settles on having none, on a
+   * failed fetch, on a fetch the browser has paused for being offline, past
+   * the deadline, and whenever the query is idle. Every one of those is a
+   * state the answer can get stuck in, and the empty state's starter dock
+   * holds reserved height while this is true, so it must always resolve.
    */
   isAwaitingStarters: boolean;
   refetch: () => Promise<void>;
+}
+
+export interface UseConversationStartersOptions {
+  /** Override for {@link STARTERS_AWAIT_DEADLINE_MS}. */
+  awaitDeadlineMs?: number;
 }
 
 const NOOP_REFETCH = async (): Promise<void> => {};
@@ -60,8 +79,11 @@ const IDLE_RESULT: UseConversationStartersResult = {
 
 export function useConversationStarters(
   assistantId: string | null | undefined,
+  options?: UseConversationStartersOptions,
 ): UseConversationStartersResult {
   const enabled = Boolean(assistantId);
+  const awaitDeadlineMs =
+    options?.awaitDeadlineMs ?? STARTERS_AWAIT_DEADLINE_MS;
 
   const query = useQuery({
     ...conversationstartersGetOptions({
@@ -76,12 +98,31 @@ export function useConversationStarters(
     refetchInterval: (q) => shouldPoll(q.state.data?.status),
   });
 
+  const [awaitExpired, setAwaitExpired] = useState(false);
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+    setAwaitExpired(false);
+    const timer = setTimeout(() => {
+      setAwaitExpired(true);
+    }, awaitDeadlineMs);
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [enabled, assistantId, awaitDeadlineMs]);
+
   if (!enabled) {
     return IDLE_RESULT;
   }
 
   const starters = query.data?.starters ?? [];
   const status = query.data?.status ?? "generating";
+  // A paused fetch is the offline case: TanStack's default `networkMode`
+  // holds the request without ever reporting a load or an error, so the
+  // status stays on its pre-answer fallback and nothing else here would
+  // ever end the wait.
+  const paused = query.fetchStatus === "paused";
 
   return {
     starters,
@@ -90,6 +131,8 @@ export function useConversationStarters(
     isAwaitingStarters:
       starters.length === 0 &&
       !query.isError &&
+      !paused &&
+      !awaitExpired &&
       (query.isLoading || status === "generating" || status === "refreshing"),
     refetch: async () => {
       await query.refetch();

--- a/clients/web/src/domains/chat/hooks/use-conversation-starters.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-starters.ts
@@ -36,6 +36,15 @@ export interface UseConversationStartersResult {
   starters: ConversationStarter[];
   status: ConversationStartersStatus | "idle";
   isLoading: boolean;
+  /**
+   * True while there is nothing to render yet and chips may still arrive:
+   * the first fetch is in flight, or the daemon reports it is still
+   * generating them. False once chips land, once the daemon settles on
+   * having none, on a failed fetch, and whenever the query is idle. The
+   * empty state's starter dock holds its reserved height while this is
+   * true and collapses when it goes false with no chips.
+   */
+  isAwaitingStarters: boolean;
   refetch: () => Promise<void>;
 }
 
@@ -45,6 +54,7 @@ const IDLE_RESULT: UseConversationStartersResult = {
   starters: [],
   status: "idle",
   isLoading: false,
+  isAwaitingStarters: false,
   refetch: NOOP_REFETCH,
 };
 
@@ -70,10 +80,17 @@ export function useConversationStarters(
     return IDLE_RESULT;
   }
 
+  const starters = query.data?.starters ?? [];
+  const status = query.data?.status ?? "generating";
+
   return {
-    starters: query.data?.starters ?? [],
-    status: query.data?.status ?? "generating",
+    starters,
+    status,
     isLoading: query.isLoading,
+    isAwaitingStarters:
+      starters.length === 0 &&
+      !query.isError &&
+      (query.isLoading || status === "generating" || status === "refreshing"),
     refetch: async () => {
       await query.refetch();
     },

--- a/clients/web/src/domains/chat/utils/composer-placeholder.test.ts
+++ b/clients/web/src/domains/chat/utils/composer-placeholder.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Tests for the composer's placeholder policy.
+ *
+ * The regression these pin is the empty state changing its own copy while
+ * it loads: the assistant name lands after the first paint, and letting it
+ * rewrite the placeholder swaps the prompt under the reader mid-load.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { resolveComposerPlaceholder } from "@/domains/chat/utils/composer-placeholder";
+
+const EMPTY = "What should we tackle?";
+const NAMED = "Ask Luna";
+const DEFAULT = "What would you like to do?";
+
+function resolve(
+  overrides: Partial<Parameters<typeof resolveComposerPlaceholder>[0]> = {},
+) {
+  return resolveComposerPlaceholder({
+    isEmptyConversation: true,
+    emptyStatePlaceholder: EMPTY,
+    assistantPlaceholder: null,
+    defaultPlaceholder: DEFAULT,
+    ...overrides,
+  });
+}
+
+describe("resolveComposerPlaceholder", () => {
+  test("a fresh conversation shows the neutral prompt", () => {
+    expect(resolve()).toBe(EMPTY);
+  });
+
+  test("the assistant name arriving does not rewrite a fresh conversation's prompt", () => {
+    // The name resolves from a query that settles after the first paint. The
+    // same input before and after it lands must produce the same copy.
+    expect(resolve({ assistantPlaceholder: null })).toBe(EMPTY);
+    expect(resolve({ assistantPlaceholder: NAMED })).toBe(EMPTY);
+  });
+
+  test("an active conversation on a narrow composer names the assistant", () => {
+    expect(
+      resolve({ isEmptyConversation: false, assistantPlaceholder: NAMED }),
+    ).toBe(NAMED);
+  });
+
+  test("an active conversation without a name keeps the wider copy", () => {
+    expect(
+      resolve({ isEmptyConversation: false, assistantPlaceholder: null }),
+    ).toBe(DEFAULT);
+  });
+});

--- a/clients/web/src/domains/chat/utils/composer-placeholder.ts
+++ b/clients/web/src/domains/chat/utils/composer-placeholder.ts
@@ -1,0 +1,39 @@
+/**
+ * Which placeholder the chat composer shows.
+ *
+ * A fresh conversation keeps its neutral prompt at every width. The
+ * assistant's name reaches the page from a query that settles after the
+ * first paint, so letting it rewrite the placeholder would change the copy
+ * under the reader's eyes while the rest of the empty state is still filling
+ * in, which reads as the page loading rather than as one screen arriving.
+ *
+ * Once the conversation has messages, a narrow composer is one slim row with
+ * no space for a sentence, so it names the assistant it is addressed to
+ * instead. An assistant whose name has not loaded keeps the wider copy.
+ */
+
+export interface ComposerPlaceholderInput {
+  /** True on a conversation with no messages yet. */
+  isEmptyConversation: boolean;
+  /** The neutral prompt drawn for a fresh conversation. */
+  emptyStatePlaceholder: string;
+  /**
+   * Copy naming the assistant, or `null` when the composer is not narrow
+   * enough to need it or the name has not loaded.
+   */
+  assistantPlaceholder: string | null;
+  /** Copy for an active conversation with no assistant name to show. */
+  defaultPlaceholder: string;
+}
+
+export function resolveComposerPlaceholder({
+  isEmptyConversation,
+  emptyStatePlaceholder,
+  assistantPlaceholder,
+  defaultPlaceholder,
+}: ComposerPlaceholderInput): string {
+  if (isEmptyConversation) {
+    return emptyStatePlaceholder;
+  }
+  return assistantPlaceholder ?? defaultPlaceholder;
+}

--- a/clients/web/src/domains/chat/utils/starters-availability-storage.ts
+++ b/clients/web/src/domains/chat/utils/starters-availability-storage.ts
@@ -1,0 +1,74 @@
+/**
+ * Per-assistant record of whether the daemon has ever answered with
+ * conversation starters.
+ *
+ * The empty state's dock reserves the chips' height before they load so their
+ * arrival moves nothing above them. That trade only pays off for an assistant
+ * that actually produces chips: reserving for one that produces none holds
+ * ~150px and then gives it back, sliding the greeting and composer down a
+ * screen that would otherwise have been perfectly still. The flag is the
+ * positive signal that the reserve is worth taking, and it is persisted
+ * because the question has to be answered on the first paint, before the
+ * query it describes has replied.
+ *
+ * Display-only. A stale answer costs one animated dock open or close, never
+ * correctness, so it is written on every settled answer and never migrated.
+ */
+
+import { useState } from "react";
+
+import { createKeyedStorageAccessor } from "@/utils/typed-storage";
+
+const storage = createKeyedStorageAccessor<boolean>({
+  keyFn: (assistantId) => `vellum:startersSeen:${assistantId}`,
+  scope: "user",
+  parse: (raw) => raw === "true",
+  serialize: (value) => (value ? "true" : "false"),
+  fallback: false,
+});
+
+/**
+ * Whether this assistant produced starters the last time one of its settled
+ * answers was seen. False for an assistant nothing is known about yet, which
+ * is the answer that keeps a fresh install motionless.
+ */
+export function loadAssistantProducesStarters(
+  assistantId: string | null | undefined,
+): boolean {
+  return storage.load(assistantId ?? "");
+}
+
+/**
+ * {@link loadAssistantProducesStarters} as it stood when this assistant's
+ * empty state opened.
+ *
+ * Deliberately a snapshot rather than a subscription. The empty state is the
+ * only writer, so a subscription would only ever deliver this launch's own
+ * answer back to it, and a reserve that appears on that news arrives after
+ * the chips it was supposed to be holding space for: it would push the group
+ * that the reserve exists to keep still. The answer that matters was
+ * already on disk before the screen was drawn.
+ */
+export function useAssistantProducedStartersAtOpen(
+  assistantId: string | null | undefined,
+): boolean {
+  const id = assistantId ?? "";
+  const [snapshot, setSnapshot] = useState(() => ({
+    id,
+    value: storage.load(id),
+  }));
+  if (snapshot.id !== id) {
+    const next = { id, value: storage.load(id) };
+    setSnapshot(next);
+    return next.value;
+  }
+  return snapshot.value;
+}
+
+/** Record a settled answer from the starters query. */
+export function recordAssistantProducesStarters(
+  assistantId: string,
+  producesStarters: boolean,
+): void {
+  storage.save(assistantId, producesStarters);
+}

--- a/clients/web/src/i18n/locales/en/chat.json
+++ b/clients/web/src/i18n/locales/en/chat.json
@@ -193,6 +193,9 @@
     "heading": "Assets",
     "label": "{count, plural, one {# asset} other {# assets}}"
   },
+  "conversationStarterDock": {
+    "caption": "Try some suggestions:"
+  },
   "copyButton": {
     "copied": "Copied",
     "copyFailed": "Could not copy to the clipboard."

--- a/clients/web/src/i18n/locales/es/chat.json
+++ b/clients/web/src/i18n/locales/es/chat.json
@@ -193,6 +193,9 @@
     "heading": "Recursos",
     "label": "{count, plural, one {# recurso} other {# recursos}}"
   },
+  "conversationStarterDock": {
+    "caption": "Prueba algunas sugerencias:"
+  },
   "copyButton": {
     "copied": "Copiado",
     "copyFailed": "No se pudo copiar al portapapeles."


### PR DESCRIPTION
On iOS, opening the app to a new chat played out in visible steps: a
centered dot, then the greeting and a bottom dock of starter chips
appearing together while the composer teleported up about 75px, then the
placeholder rewriting itself from the empty-state prompt to
"Ask {assistantName}", then the avatar arriving last. Every one of those
was a layout that waited on a network answer before it knew its shape.

This holds the shape still and lets only the content arrive.

## What changes

**The plain empty state always docks.** `dockStartersToBottom` was
`showSuggestionLibrary || (isPlainEmptyState && starters.length > 0)`, so
one query resolution flipped the layout branch: which wrapper centered
the group, whether the group carried `flex-1`, and whether a ~150px dock
existed below it. That flip is the composer jump. It is now
`showSuggestionLibrary || isPlainEmptyState`, decided on the first render
and never revisited. The app-editing side panel is untouched and keeps
its inline chips under the composer.

**The dock reserves its own height, for assistants that will fill it.**
New `ConversationStarterDock` mounts on the plain empty state whether or
not chips exist. When it reserves, it holds the space with an invisible
grid of two-line chips measured from the chip's own box and line-box
classes (now shared as `CONVERSATION_STARTER_CHIP_BOX` and
`CONVERSATION_STARTER_CHIP_LINE`, so the reserve cannot drift from the
thing it reserves for), and the real chips render into that same grid
cell with the reserve still under them, so a short answer cannot shrink
the dock either.

Reserving is gated on a positive signal, because holding space for an
assistant that produces no chips only trades one movement for another: a
fresh install answers `{starters: [], status: "empty"}`, and an
ungated reserve would take ~150px on first paint and hand it straight
back. A per-assistant flag (localStorage via the typed-storage keyed
accessor, `scope: "user"`, display-only) records every settled answer.
Net behavior:

| Assistant | First paint | On the answer |
| --- | --- | --- |
| Had chips last launch | dock reserved | chips fade in, nothing moves |
| Fresh install, no chips | dock collapsed | nothing moves |
| Brand new, first-ever chips | dock collapsed | dock opens once, reserves from then on |

The flag is read as a snapshot, not a subscription: this hook is the only
writer, and a floor that appeared on this launch's own answer would land
under chips already drawn and push the group it exists to hold still.

**The reveal is a transition, not an entrance.** Chips fade in by binding
opacity to their own presence on a persistent element, so the animation
runs on the loading-to-loaded change and not on mount. A dock that mounts
with cached starters (the 60s `staleTime` case, i.e. most navigations to
a new chat) draws them already in place. `motion-reduce` opts out of
every transition added here.

**The wait always ends.** `useConversationStarters` grew an
`isAwaitingStarters` flag to answer "could chips still arrive?", and it
had two states it could hang in forever, each of which pinned the reserve
open: a fetch the browser paused for being offline (TanStack's default
`networkMode` reports no load and no error, leaving `data` undefined and
the status falling back to `generating`), and a generation the daemon
never lands. Paused fetches now end the wait, and a
`STARTERS_AWAIT_DEADLINE_MS` deadline bounds the generating case.
Everything that ends the wait ends the reserve.

**Collapsing an empty dock is `ChatBody`'s job.** The collapse wraps the
whole docked column rather than the slot inside it, so the column's own
`pb-3` collapses with it. A collapse nested inside that padding cannot
reach it: the negative margin that cancels the padding at rest cannot
pull a parent's used height below zero, so it leaves a 12px band behind,
and for an assistant with no starters that band never goes away. Same
`0fr/1fr` grid-row idiom the soft keyboard already uses, now shared by
both reasons.

**The greeting slot reserves its line box.** The slot renders a 10px busy
indicator until the first greeting token streams in, then a 28/36px serif
headline. A min-height equal to the headline's line box at both type
sizes keeps the swap from re-centering the group.

**The placeholder no longer swaps mid-load.** *Behavior change:* on phone
widths a brand-new chat keeps its own empty-state prompt and no longer
switches to "Ask {assistantName}" when the identity query settles. Active
conversations keep the named copy, where it is not competing with a
loading screen. The decision moved into `resolveComposerPlaceholder` so
the policy has one home and a test.

**Avatar prefetch: not needed.** `useAssistantAvatar(assistantId)` is
already mounted at app boot in `root-layout.tsx` (it feeds the favicon,
the `--avatar-accent` var, the iOS Live Activity, and the Electron dock
icon), so its queries start well before the chat route renders and no
prefetch was added. `ComposerPeek` was not touched. Worth knowing for a
follow-up: the avatar query key includes the avatar-state-manifest
capability, which is derived from the assistant version, so the key flips
once the version resolves and the query refetches. That, not a late
mount, is the most likely remaining cause of a late avatar.

## Behavior changes worth knowing

Three, beyond the placeholder above.

**The credits upsell card rides the bottom dock in the zero-starter
state.** The card has always shared the starters slot, and that slot is
now the dock, so on a fresh chat with no chips the credit wall sits at
the bottom of the viewport instead of inline under the composer, and it
collapses with the dock while the soft keyboard is open. A dock holding
the card is never treated as empty, so it will not collapse out from
under it, and a dock with neither chips nor a reserve draws nothing at
all rather than hanging its padding and caption under the card as dead
space. Both have tests.

**The mobile placeholder now changes at first send rather than
mid-load.** The empty state keeps its neutral prompt and an active
conversation says "Ask {name}", so sending the first message swaps the
copy. That swap is visible, and it is the accepted trade: it happens on a
deliberate action, at a moment the whole screen is already changing,
rather than unprompted while the page is still filling in.

**The reserve holds four two-line slots, which is the worst case.** An
assistant that returns two chips, or four short ones, leaves some dead
band at the bottom of the dock, and a chip that somehow reached three
lines would still move the group. Reserve-for-worst-case cannot avoid
this without measuring, which is the machinery this component exists to
not have. Flagged for device QA.

## Guardrails honored

- `composerSlot` renders at `outer > inner > group > stack` in every
  branch, empty or active, docked or undocked. Only its siblings changed.
  Tests assert the composer DOM node survives both the
  reserved-to-chips swap and the empty-to-active transition on the docked
  branch, which is the branch every fresh chat now takes (LUM-1506 /
  LUM-1516).
- The keyboard-open bottom anchor survives on both branches. The docked
  branch answers it on `groupClass` (and collapses its dock), which is
  the branch the plain empty state now always takes. The undocked
  branch's `startersSlot == null` predicate is unchanged and still reads
  actual content presence: the always-mounted dock is only ever passed
  alongside `dockStartersToBottom`, so it never reaches that branch. The
  stale comment saying the predicate means "starters have not arrived
  yet" is rewritten to say what it actually asks.
- No entrance replays on navigation: transitions on persistent elements,
  never keyframes on mount. `chat-composer.tsx` was not modified.
- The raw `"Try some suggestions:"` string moved to
  `chat:conversationStarterDock.caption` in the `en` and `es` catalogs,
  and the new component is added to `i18nEnforcedPaths`.
- `prefers-reduced-motion` opt-out on every new transition.
- Design-library tokens only, no raw hex.

## Verification

```
cd clients/web
bun scripts/run-tests.ts src/domains/chat/components/chat-body.test.tsx \
  src/domains/chat/components/chat-route-content.test.tsx \
  src/domains/chat/hooks/use-chat-empty-state.test.tsx \
  src/domains/chat/hooks/use-conversation-starters.test.tsx \
  src/domains/chat/utils/composer-placeholder.test.ts \
  src/i18n/catalogs.test.ts \
  src/utils/typed-storage.test.ts
bunx tsc --noEmit
bunx eslint <changed files>
```

All seven files pass in isolation; typecheck and lint are clean.

Regressions cover: a known producer reserving before any chip arrives; an
unknown assistant reserving nothing and starting collapsed; the reserve
ending whenever the wait ends, however it ended; chips keeping the
reserve as a sizing floor; this launch's own answer not adding a floor
under chips already drawn; settled answers being remembered in both
directions and unsettled ones leaving the previous answer alone; the
offline pause and the deadline each ending the wait; the collapse
enclosing the docked column rather than the slot; a later answer
expanding the same wrapper instead of mounting a new one; app editing
staying inline and passing no slot once its conversation has messages;
the keyboard-open bottom anchor with a reserved dock; the composer node
surviving both the content swap and the first send; the credits card
riding a dock that stays open for it and never sitting above an empty
panel; and the placeholder staying put when the assistant name lands on
an empty conversation.

## Manual QA still outstanding

Device QA on iOS has not been done. Worth watching on a real boot: the
composer's position from first paint to settled on an assistant that has
chips, the fresh-install path staying motionless, the chips fading rather
than popping, and the keyboard-open composer still reaching the keyboard
edge.

One known residual: the greeting streams token by token, so a headline
that wraps to a second line mid-stream still reflows the group. Reserving
two lines up front would leave a gap under every one-line greeting, so
this change reserves one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
