### PR TITLE
feat(assistant): /v1/watch/stream websocket for narration capture

### DIFF
--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -94,7 +94,6 @@ import {
 } from "./routes/inference-profile-session-reaper.js";
 import {
   activeWatchStreamSessions,
-  resolveWatchActorPrincipalId,
   WatchStreamSession,
 } from "./routes/watch-routes.js";
 
@@ -183,8 +182,6 @@ interface WatchStreamWebSocketData {
   conversationId?: string;
   /** Desktop client to observe, when the actor has more than one connected. */
   clientId?: string;
-  /** Actor principal header, present only on a socket that skipped the gateway. */
-  actorPrincipalIdHeader?: string;
   /** The session ID for tracking in the active sessions registry. */
   sessionId: string;
   /** Bound at open time so the close handler tears down the exact session. */
@@ -359,8 +356,6 @@ export class RuntimeHttpServer {
                 ? { conversationId: watchData.conversationId }
                 : {}),
               ...(watchData.clientId ? { clientId: watchData.clientId } : {}),
-              resolveActorPrincipalId: () =>
-                resolveWatchActorPrincipalId(watchData.actorPrincipalIdHeader),
             });
             watchData.session = session;
             activeWatchStreamSessions.set(watchData.sessionId, session);
@@ -1061,8 +1056,6 @@ export class RuntimeHttpServer {
     const conversationId =
       wsUrl.searchParams.get("conversationId")?.trim() || undefined;
     const clientId = wsUrl.searchParams.get("clientId")?.trim() || undefined;
-    const actorPrincipalIdHeader =
-      req.headers.get("x-vellum-actor-principal-id")?.trim() || undefined;
 
     const upgraded = server.upgrade(req, {
       data: {
@@ -1071,7 +1064,6 @@ export class RuntimeHttpServer {
         sampleRate,
         conversationId,
         clientId,
-        actorPrincipalIdHeader,
         sessionId: crypto.randomUUID(),
       } satisfies WatchStreamWebSocketData,
     });

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -495,8 +495,8 @@ export class RuntimeHttpServer {
             const session = watchData.session;
             if (session) {
               session.handleClose(code, reason?.toString());
-              // Only drop our own session from the registry — a reconnect may
-              // have already replaced it under a new id.
+              // Only drop our own session from the registry, since a
+              // reconnect may have already replaced it under a new id.
               if (
                 activeWatchStreamSessions.get(watchData.sessionId) === session
               ) {
@@ -723,8 +723,9 @@ export class RuntimeHttpServer {
       return this.handleLiveVoiceUpgrade(req, server);
     }
 
-    // WebSocket upgrade for watch narration capture — same private-network
-    // restrictions and gateway-service token verification as STT streaming.
+    // WebSocket upgrade for watch narration capture, under the same
+    // private-network restrictions and gateway-service token verification as
+    // STT streaming.
     if (
       path === "/v1/watch/stream" &&
       req.headers.get("upgrade")?.toLowerCase() === "websocket"
@@ -1033,7 +1034,7 @@ export class RuntimeHttpServer {
     if (!isPrivateNetworkPeer(server, req) || !isPrivateNetworkOrigin(req)) {
       return httpError(
         "FORBIDDEN",
-        "Direct watch stream access disabled — only private network peers allowed",
+        "Direct watch stream access disabled: only private network peers allowed",
         403,
       );
     }
@@ -1070,7 +1071,7 @@ export class RuntimeHttpServer {
     if (!upgraded) {
       return new Response("WebSocket upgrade failed", { status: 500 });
     }
-    // Bun's WebSocket upgrade consumes the request — no Response is sent.
+    // Bun's WebSocket upgrade consumes the request, so no Response is sent.
     return undefined!;
   }
 

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -92,6 +92,11 @@ import {
   startInferenceProfileSessionReaper,
   stopInferenceProfileSessionReaper,
 } from "./routes/inference-profile-session-reaper.js";
+import {
+  activeWatchStreamSessions,
+  resolveWatchActorPrincipalId,
+  WatchStreamSession,
+} from "./routes/watch-routes.js";
 
 // Re-export for consumers
 export { isPrivateAddress } from "./middleware/auth.js";
@@ -165,6 +170,27 @@ interface LiveVoiceWebSocketData {
   wsType: "live-voice";
 }
 
+/**
+ * WebSocket data attached to `/v1/watch/stream` connections. The `wsType`
+ * discriminator routes frames to the watch session orchestrator instead of
+ * the other WebSocket handlers.
+ */
+interface WatchStreamWebSocketData {
+  wsType: "watch-stream";
+  mimeType: string;
+  sampleRate?: number;
+  /** Conversation the session's timeline is keyed on, when the client names one. */
+  conversationId?: string;
+  /** Desktop client to observe, when the actor has more than one connected. */
+  clientId?: string;
+  /** Actor principal header, present only on a socket that skipped the gateway. */
+  actorPrincipalIdHeader?: string;
+  /** The session ID for tracking in the active sessions registry. */
+  sessionId: string;
+  /** Bound at open time so the close handler tears down the exact session. */
+  session?: WatchStreamSession;
+}
+
 export class RuntimeHttpServer {
   private server: ReturnType<typeof Bun.serve> | null = null;
   private port: number;
@@ -203,7 +229,8 @@ export class RuntimeHttpServer {
     type AllWebSocketData =
       | MediaStreamWebSocketData
       | SttStreamWebSocketData
-      | LiveVoiceWebSocketData;
+      | LiveVoiceWebSocketData
+      | WatchStreamWebSocketData;
     this.server = Bun.serve<AllWebSocketData>({
       port: this.port,
       hostname: this.hostname,
@@ -314,6 +341,32 @@ export class RuntimeHttpServer {
             log.info("Live voice WebSocket opened");
             return;
           }
+          if (data.wsType === "watch-stream") {
+            const watchData = data;
+            log.info(
+              {
+                sessionId: watchData.sessionId,
+                mimeType: watchData.mimeType,
+              },
+              "Watch stream WebSocket opened",
+            );
+            const session = new WatchStreamSession(ws, {
+              mimeType: watchData.mimeType,
+              ...(watchData.sampleRate !== undefined
+                ? { sampleRate: watchData.sampleRate }
+                : {}),
+              ...(watchData.conversationId
+                ? { conversationId: watchData.conversationId }
+                : {}),
+              ...(watchData.clientId ? { clientId: watchData.clientId } : {}),
+              resolveActorPrincipalId: () =>
+                resolveWatchActorPrincipalId(watchData.actorPrincipalIdHeader),
+            });
+            watchData.session = session;
+            activeWatchStreamSessions.set(watchData.sessionId, session);
+            void session.start();
+            return;
+          }
           log.warn("WebSocket opened with unknown data type — closing");
           ws.close(1008, "Unknown WebSocket type");
         },
@@ -350,6 +403,18 @@ export class RuntimeHttpServer {
               ws as ServerWebSocket<LiveVoiceWebSocketData>,
             );
             void connection?.handleMessage(message);
+            return;
+          }
+          if (data.wsType === "watch-stream") {
+            const session = data.session;
+            if (!session) {
+              return;
+            }
+            if (typeof message === "string") {
+              session.handleMessage(message);
+            } else {
+              session.handleBinaryAudio(message);
+            }
             return;
           }
           log.warn("WebSocket message on unknown data type — closing");
@@ -420,6 +485,29 @@ export class RuntimeHttpServer {
               "Live voice WebSocket closed",
             );
             connection?.release();
+            return;
+          }
+          if (data.wsType === "watch-stream") {
+            const watchData = data;
+            log.info(
+              {
+                sessionId: watchData.sessionId,
+                code,
+                reason: reason?.toString(),
+              },
+              "Watch stream WebSocket closed",
+            );
+            const session = watchData.session;
+            if (session) {
+              session.handleClose(code, reason?.toString());
+              // Only drop our own session from the registry — a reconnect may
+              // have already replaced it under a new id.
+              if (
+                activeWatchStreamSessions.get(watchData.sessionId) === session
+              ) {
+                activeWatchStreamSessions.delete(watchData.sessionId);
+              }
+            }
             return;
           }
           log.warn(
@@ -542,6 +630,11 @@ export class RuntimeHttpServer {
       activeSttStreamSessions.delete(sessionId);
     }
 
+    for (const [sessionId, session] of activeWatchStreamSessions) {
+      session.destroy();
+      activeWatchStreamSessions.delete(sessionId);
+    }
+
     const liveVoiceManager = getLiveVoiceSessionManager();
     const liveVoiceSessionId = liveVoiceManager.activeSessionId;
     if (liveVoiceSessionId) {
@@ -633,6 +726,15 @@ export class RuntimeHttpServer {
       req.headers.get("upgrade")?.toLowerCase() === "websocket"
     ) {
       return this.handleLiveVoiceUpgrade(req, server);
+    }
+
+    // WebSocket upgrade for watch narration capture — same private-network
+    // restrictions and gateway-service token verification as STT streaming.
+    if (
+      path === "/v1/watch/stream" &&
+      req.headers.get("upgrade")?.toLowerCase() === "websocket"
+    ) {
+      return this.handleWatchStreamUpgrade(req, server);
     }
 
     // Twilio webhook endpoints — before auth check because Twilio
@@ -919,6 +1021,64 @@ export class RuntimeHttpServer {
     if (!upgraded) {
       return new Response("WebSocket upgrade failed", { status: 500 });
     }
+    return undefined!;
+  }
+
+  /**
+   * Handle WebSocket upgrade for `/v1/watch/stream`.
+   *
+   * Gated exactly as `/v1/stt/stream` is: private network peers and origins
+   * only, then a gateway service token. The gateway owns downstream client
+   * auth and dials this upstream on the client's behalf.
+   */
+  private handleWatchStreamUpgrade(
+    req: Request,
+    server: ReturnType<typeof Bun.serve>,
+  ): Response {
+    if (!isPrivateNetworkPeer(server, req) || !isPrivateNetworkOrigin(req)) {
+      return httpError(
+        "FORBIDDEN",
+        "Direct watch stream access disabled — only private network peers allowed",
+        403,
+      );
+    }
+
+    const tokenError = this.verifyGatewayServiceToken(req);
+    if (tokenError) {
+      return tokenError;
+    }
+
+    const wsUrl = new URL(req.url);
+    const mimeType = wsUrl.searchParams.get("mimeType");
+    if (!mimeType) {
+      return new Response("Missing required query parameter: mimeType", {
+        status: 400,
+      });
+    }
+
+    const sampleRateRaw = wsUrl.searchParams.get("sampleRate");
+    const sampleRate = sampleRateRaw ? parseInt(sampleRateRaw, 10) : undefined;
+    const conversationId =
+      wsUrl.searchParams.get("conversationId")?.trim() || undefined;
+    const clientId = wsUrl.searchParams.get("clientId")?.trim() || undefined;
+    const actorPrincipalIdHeader =
+      req.headers.get("x-vellum-actor-principal-id")?.trim() || undefined;
+
+    const upgraded = server.upgrade(req, {
+      data: {
+        wsType: "watch-stream",
+        mimeType,
+        sampleRate,
+        conversationId,
+        clientId,
+        actorPrincipalIdHeader,
+        sessionId: crypto.randomUUID(),
+      } satisfies WatchStreamWebSocketData,
+    });
+    if (!upgraded) {
+      return new Response("WebSocket upgrade failed", { status: 500 });
+    }
+    // Bun's WebSocket upgrade consumes the request — no Response is sent.
     return undefined!;
   }
 

--- a/assistant/src/runtime/routes/__tests__/watch-routes-guardian-cache.test.ts
+++ b/assistant/src/runtime/routes/__tests__/watch-routes-guardian-cache.test.ts
@@ -1,0 +1,136 @@
+/**
+ * A watch session's principal lookup against a stale guardian-delivery cache.
+ *
+ * The cache keeps a successful read that found no binding, and a gateway-side
+ * binding write does not invalidate it, so the read a session start depends on
+ * has to force a refresh or a first run fails for the cache's whole TTL. The
+ * guardian reader is mocked here rather than in the main watch-routes suite so
+ * the substitution stays inside this file.
+ */
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { GuardianDelivery } from "@vellumai/gateway-client";
+
+let cachedResult: GuardianDelivery[] | null = null;
+let freshResult: GuardianDelivery[] | null = null;
+let cachedCalls = 0;
+let freshCalls = 0;
+
+// Only the two read entry points are substituted; the rest of the reader's
+// surface stays real, because other modules in this graph import from it.
+const realReader =
+  await import("../../../contacts/guardian-delivery-reader.js");
+mock.module("../../../contacts/guardian-delivery-reader.js", () => ({
+  ...realReader,
+  getGuardianDelivery: () => {
+    cachedCalls++;
+    return Promise.resolve(cachedResult);
+  },
+  getGuardianDeliveryFresh: () => {
+    freshCalls++;
+    return Promise.resolve(freshResult);
+  },
+  peekCachedGuardianDelivery: () => undefined,
+}));
+
+const { initializeDb } = await import("../../../persistence/db-init.js");
+const { WatchSessionManager } =
+  await import("../../../watch/watch-session-manager.js");
+const { WatchStreamSession, resolveWatchActorPrincipalId } =
+  await import("../watch-routes.js");
+
+await initializeDb();
+
+afterAll(() => {
+  mock.restore();
+});
+
+/** The shape `guardianForChannel` matches on for the vellum binding. */
+function guardian(principalId: string): GuardianDelivery {
+  return {
+    principalId,
+    channelType: "vellum",
+    status: "active",
+  } as unknown as GuardianDelivery;
+}
+
+/** A socket that keeps the frame types the session sent it. */
+function newSocket() {
+  const types: string[] = [];
+  return {
+    types,
+    send: (data: string) => {
+      types.push((JSON.parse(data) as { type: string }).type);
+    },
+    close: () => {},
+  };
+}
+
+/** A transcriber that opens without reaching any provider. */
+function newTranscriber() {
+  return {
+    providerId: "deepgram" as const,
+    boundaryId: "daemon-streaming" as const,
+    start: async () => {},
+    sendAudio: () => {},
+    stop: () => {},
+  };
+}
+
+describe("watch principal lookup against a stale guardian cache", () => {
+  beforeEach(() => {
+    cachedCalls = 0;
+    freshCalls = 0;
+    cachedResult = [];
+    freshResult = [];
+  });
+
+  test("reads past an empty cached answer to the binding that now exists", async () => {
+    cachedResult = [];
+    freshResult = [guardian("guardian-just-bound")];
+
+    expect(await resolveWatchActorPrincipalId()).toBe("guardian-just-bound");
+    expect(freshCalls).toBe(1);
+    expect(cachedCalls).toBe(0);
+  });
+
+  test("a session started after the binding appears reaches ready", async () => {
+    // The cache still holds the empty answer from before the guardian was
+    // bound, which is the state a first run starts in.
+    cachedResult = [];
+    freshResult = [guardian("guardian-just-bound")];
+
+    const manager = new WatchSessionManager({
+      observe: async () => ({ ok: true, axTree: "Window: Editor" }),
+    });
+    const ws = newSocket();
+    const session = new WatchStreamSession(ws, {
+      mimeType: "audio/webm",
+      manager,
+      resolveTranscriber: async () => newTranscriber(),
+    });
+
+    await session.start();
+
+    expect(ws.types).toEqual(["ready"]);
+    expect(manager.isActive()).toBe(true);
+
+    session.destroy();
+  });
+
+  test("no binding at all still fails closed", async () => {
+    cachedResult = [];
+    freshResult = [];
+
+    const ws = newSocket();
+    const session = new WatchStreamSession(ws, {
+      mimeType: "audio/webm",
+      manager: new WatchSessionManager(),
+      resolveTranscriber: async () => newTranscriber(),
+    });
+
+    await session.start();
+
+    expect(ws.types).toEqual(["error", "closed"]);
+  });
+});

--- a/assistant/src/runtime/routes/__tests__/watch-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/watch-routes.test.ts
@@ -1,0 +1,290 @@
+import { describe, expect, test } from "bun:test";
+
+import { initializeDb } from "../../../persistence/db-init.js";
+import type {
+  StreamingTranscriber,
+  SttStreamServerEvent,
+} from "../../../stt/types.js";
+import { WatchSessionManager } from "../../../watch/watch-session-manager.js";
+import { renderWatchTimeline } from "../../../watch/watch-timeline.js";
+import type { HostObservation } from "../../host-observe.js";
+import {
+  type WatchStreamServerFrame,
+  WatchStreamSession,
+  type WatchStreamSocket,
+} from "../watch-routes.js";
+
+await initializeDb();
+
+const PRINCIPAL_ID = "principal-watch-stream-test";
+
+/** A socket that keeps every frame the session sent it. */
+class FakeSocket implements WatchStreamSocket {
+  readonly frames: WatchStreamServerFrame[] = [];
+  closeCode: number | null = null;
+  closeReason: string | null = null;
+
+  send(data: string): void {
+    this.frames.push(JSON.parse(data) as WatchStreamServerFrame);
+  }
+
+  close(code?: number, reason?: string): void {
+    this.closeCode = code ?? null;
+    this.closeReason = reason ?? null;
+  }
+
+  types(): string[] {
+    return this.frames.map((frame) => frame.type);
+  }
+
+  firstOfType<T extends WatchStreamServerFrame["type"]>(
+    type: T,
+  ): Extract<WatchStreamServerFrame, { type: T }> | undefined {
+    return this.frames.find((frame) => frame.type === type) as
+      | Extract<WatchStreamServerFrame, { type: T }>
+      | undefined;
+  }
+}
+
+/** A transcriber the test drives by hand. */
+class FakeTranscriber implements StreamingTranscriber {
+  readonly providerId = "deepgram" as const;
+  readonly boundaryId = "daemon-streaming" as const;
+  readonly audio: { bytes: Buffer; mimeType: string }[] = [];
+  stopCount = 0;
+  private onEvent: ((event: SttStreamServerEvent) => void) | null = null;
+
+  async start(onEvent: (event: SttStreamServerEvent) => void): Promise<void> {
+    this.onEvent = onEvent;
+  }
+
+  sendAudio(audio: Buffer, mimeType: string): void {
+    this.audio.push({ bytes: audio, mimeType });
+  }
+
+  stop(): void {
+    this.stopCount += 1;
+  }
+
+  emit(event: SttStreamServerEvent): void {
+    this.onEvent?.(event);
+  }
+}
+
+function observation(): HostObservation {
+  return {
+    ok: true,
+    axTree: "Window: Editor\n[1] Button Save",
+  };
+}
+
+/**
+ * A manager wired to a scripted screen reader, so a session's cadence is a
+ * function of what the test says the host answered rather than of a real
+ * desktop client.
+ */
+function newManager() {
+  const observeCalls: (string | undefined)[] = [];
+  const manager = new WatchSessionManager({
+    observe: async (options) => {
+      observeCalls.push(options.sourceActorPrincipalId);
+      return observation();
+    },
+  });
+  return { manager, observeCalls };
+}
+
+interface HarnessOverrides {
+  manager?: WatchSessionManager;
+  transcriber?: FakeTranscriber | null;
+  principalId?: string | undefined;
+  idleTimeoutMs?: number;
+}
+
+function newSession(overrides: HarnessOverrides = {}) {
+  const ws = new FakeSocket();
+  const transcriber =
+    overrides.transcriber === undefined
+      ? new FakeTranscriber()
+      : overrides.transcriber;
+  const manager = overrides.manager ?? newManager().manager;
+  const session = new WatchStreamSession(ws, {
+    mimeType: "audio/webm",
+    manager,
+    resolveTranscriber: async () => transcriber,
+    resolveActorPrincipalId: async () =>
+      "principalId" in overrides ? overrides.principalId : PRINCIPAL_ID,
+    ...(overrides.idleTimeoutMs !== undefined
+      ? { idleTimeoutMs: overrides.idleTimeoutMs }
+      : {}),
+  });
+  return { ws, transcriber, manager, session };
+}
+
+describe("watch stream session", () => {
+  test("starts, records narration, and stops", async () => {
+    const { manager, observeCalls } = newManager();
+    const { ws, transcriber, session } = newSession({ manager });
+    await session.start();
+
+    const ready = ws.firstOfType("ready");
+    expect(ready).toBeDefined();
+    expect(manager.isActive(ready!.conversationId)).toBe(true);
+
+    transcriber!.emit({ type: "final", text: "  opening the invoice  " });
+    // The narration lands synchronously; the screen read it triggers does not.
+    await Bun.sleep(5);
+
+    expect(ws.types()).toEqual(["ready", "entry"]);
+    expect(observeCalls).toEqual([PRINCIPAL_ID]);
+
+    const rendered = renderWatchTimeline(ready!.sessionId);
+    expect(rendered.totalEntries).toBe(2);
+    expect(rendered.text).toContain("opening the invoice");
+
+    session.handleMessage(JSON.stringify({ type: "stop" }));
+    expect(transcriber!.stopCount).toBe(1);
+    // The provider flushes and then reports its own close.
+    transcriber!.emit({ type: "closed" });
+
+    expect(ws.types()).toEqual(["ready", "entry", "closed"]);
+    expect(manager.isActive()).toBe(false);
+    expect(session.isClosed).toBe(true);
+  });
+
+  test("forwards binary and base64 audio frames to the transcriber", async () => {
+    const { ws, transcriber, session } = newSession();
+    await session.start();
+
+    session.handleBinaryAudio(Buffer.from([1, 2, 3]));
+    session.handleMessage(
+      JSON.stringify({
+        type: "audio",
+        audio: Buffer.from([4, 5]).toString("base64"),
+        mimeType: "audio/pcm",
+      }),
+    );
+
+    expect(transcriber!.audio).toHaveLength(2);
+    expect([...transcriber!.audio[0]!.bytes]).toEqual([1, 2, 3]);
+    expect(transcriber!.audio[0]!.mimeType).toBe("audio/webm");
+    expect([...transcriber!.audio[1]!.bytes]).toEqual([4, 5]);
+    expect(transcriber!.audio[1]!.mimeType).toBe("audio/pcm");
+    expect(ws.types()).toEqual(["ready"]);
+
+    session.destroy();
+  });
+
+  test("draws no transcript: partials produce no frames", async () => {
+    const { ws, transcriber, session } = newSession();
+    await session.start();
+
+    transcriber!.emit({ type: "partial", text: "half a sen" });
+    transcriber!.emit({ type: "turn-end", text: "half a sentence" });
+    transcriber!.emit({ type: "final", text: "   " });
+
+    expect(ws.types()).toEqual(["ready"]);
+
+    session.destroy();
+  });
+
+  test("an unresolvable actor principal fails without opening a session", async () => {
+    const { manager } = newManager();
+    const { ws, transcriber, session } = newSession({
+      manager,
+      principalId: undefined,
+    });
+    await session.start();
+
+    expect(ws.types()).toEqual(["error", "closed"]);
+    expect(ws.firstOfType("error")!.category).toBe("session-error");
+    expect(ws.closeCode).toBe(1008);
+    expect(manager.isActive()).toBe(false);
+    // The provider stream is never opened for a session that could observe
+    // nothing, so there is nothing to stop.
+    expect(transcriber!.stopCount).toBe(0);
+    expect(session.isClosed).toBe(true);
+  });
+
+  test("provider resolution failure yields a clean error then closed", async () => {
+    const { manager } = newManager();
+    const { ws, session } = newSession({ manager, transcriber: null });
+    await session.start();
+
+    expect(ws.types()).toEqual(["error", "closed"]);
+    expect(ws.firstOfType("error")!.category).toBe("provider-error");
+    expect(manager.isActive()).toBe(false);
+    expect(session.isClosed).toBe(true);
+  });
+
+  test("a second socket is turned away without disturbing the running session", async () => {
+    const { manager } = newManager();
+    const first = newSession({ manager });
+    await first.session.start();
+    const runningConversationId = first.ws.firstOfType("ready")!.conversationId;
+
+    const second = newSession({ manager });
+    await second.session.start();
+
+    expect(second.ws.types()).toEqual(["error", "closed"]);
+    expect(second.ws.firstOfType("error")!.message).toContain(
+      "already running",
+    );
+    // The loser's teardown must not release the winner's slot.
+    expect(manager.isActive(runningConversationId)).toBe(true);
+    expect(second.transcriber!.stopCount).toBe(1);
+
+    first.session.destroy();
+    expect(manager.isActive()).toBe(false);
+  });
+
+  test("an abandoned socket is torn down by the idle timeout", async () => {
+    const { manager } = newManager();
+    const { ws, transcriber, session } = newSession({
+      manager,
+      idleTimeoutMs: 20,
+    });
+    await session.start();
+    expect(manager.isActive()).toBe(true);
+
+    await Bun.sleep(60);
+
+    expect(ws.types()).toEqual(["ready", "error", "closed"]);
+    expect(ws.firstOfType("error")!.category).toBe("timeout");
+    expect(ws.closeCode).toBe(1000);
+    expect(transcriber!.stopCount).toBe(1);
+    expect(manager.isActive()).toBe(false);
+    expect(session.isClosed).toBe(true);
+  });
+
+  test("inbound audio keeps the idle timeout at bay", async () => {
+    const { manager } = newManager();
+    const { ws, session } = newSession({ manager, idleTimeoutMs: 40 });
+    await session.start();
+
+    for (let i = 0; i < 4; i += 1) {
+      await Bun.sleep(15);
+      session.handleBinaryAudio(Buffer.from([i]));
+    }
+
+    expect(ws.types()).toEqual(["ready"]);
+    expect(manager.isActive()).toBe(true);
+
+    session.destroy();
+  });
+
+  test("a dropped socket releases the session slot", async () => {
+    const { manager } = newManager();
+    const { transcriber, session } = newSession({ manager });
+    await session.start();
+
+    session.handleClose(1006, "abnormal closure");
+
+    expect(manager.isActive()).toBe(false);
+    expect(transcriber!.stopCount).toBe(1);
+
+    // A second close is a no-op rather than a second stop.
+    session.handleClose(1006, "abnormal closure");
+    expect(transcriber!.stopCount).toBe(1);
+  });
+});

--- a/assistant/src/runtime/routes/watch-routes.ts
+++ b/assistant/src/runtime/routes/watch-routes.ts
@@ -1,0 +1,585 @@
+/**
+ * The ingress for a watch session: `/v1/watch/stream`, a WebSocket carrying
+ * the user's narration while they work.
+ *
+ * The transport is the one `/v1/stt/stream` already established, and
+ * deliberately not a second story: binary frames or base64 `audio` events in,
+ * a `{ type: "stop" }` text frame to flush, and a `StreamingTranscriber`
+ * resolved by `resolveStreamingTranscriber()` so provider selection,
+ * credentials, and language live in exactly one place.
+ *
+ * What differs is everything downstream of a transcript. Dictation hands its
+ * text back to the client; a watch session hands each final to
+ * {@link WatchSessionManager}, which files it on the timeline and decides
+ * whether the screen is worth reading. So the frames going the other way are
+ * lifecycle only: `ready`, `entry`, `error`, `closed`. No `partial`, no
+ * transcript text, no assistant reply. The client draws nothing during a
+ * session and the assistant stays silent until the retrospective, which is a
+ * conversational turn that happens after the socket is gone.
+ *
+ * Route policy: the upgrade is gated exactly as `/v1/stt/stream` is, in
+ * `http-server.ts` — private-network peer and origin, then an `svc_gateway`
+ * service token. A WebSocket upgrade never reaches the shared `ROUTES` array,
+ * whose `policy` block the HTTP adapter evaluates per JSON request, so the
+ * gate is the upgrade handler's rather than a `RoutePolicy` value. The gateway
+ * authenticates the downstream actor before it dials upstream
+ * (`gateway/src/http/routes/stt-stream-websocket.ts` requires an actor
+ * principal and refuses service tokens on the client-facing half).
+ */
+
+import type {
+  StreamingTranscriber,
+  SttErrorCategory,
+  SttStreamServerEvent,
+} from "../../stt/types.js";
+import { getLogger } from "../../util/logger.js";
+import { WatchSessionManager } from "../../watch/watch-session-manager.js";
+
+const log = getLogger("watch-stream");
+
+/**
+ * How long a socket may go without an inbound frame before the session is torn
+ * down, matching `/v1/stt/stream`. A watch client streams capture continuously,
+ * so silence on the socket means the client is gone rather than that the user
+ * stopped talking, and a leaked session would hold the single manager slot
+ * against the next press of Watch.
+ */
+const IDLE_TIMEOUT_MS = 60_000;
+
+// ---------------------------------------------------------------------------
+// Frames
+// ---------------------------------------------------------------------------
+
+/**
+ * Why a session ended badly. Provider failures keep the category
+ * `resolveStreamingTranscriber`'s stack already assigns them; `session-error`
+ * covers the reasons that are the watch session's own, such as a second socket
+ * arriving while one is running.
+ */
+export type WatchStreamErrorCategory = SttErrorCategory | "session-error";
+
+/**
+ * What the daemon sends back. Lifecycle only.
+ *
+ * `entry` is an acknowledgement that narration reached the session, carrying
+ * no text: it is what lets a client show that capture is live without drawing
+ * a transcript nobody is meant to read mid-session.
+ */
+export type WatchStreamServerFrame =
+  | { readonly type: "ready"; sessionId: string; conversationId: string }
+  | { readonly type: "entry" }
+  | {
+      readonly type: "error";
+      category: WatchStreamErrorCategory;
+      message: string;
+    }
+  | { readonly type: "closed" };
+
+/**
+ * Minimal socket surface, so the session can be driven by a test double
+ * instead of Bun's `ServerWebSocket`.
+ */
+export interface WatchStreamSocket {
+  send(data: string): void;
+  close(code?: number, reason?: string): void;
+}
+
+// ---------------------------------------------------------------------------
+// Manager singleton
+// ---------------------------------------------------------------------------
+
+let sharedManager: WatchSessionManager | null = null;
+
+/**
+ * The process-wide watch session manager.
+ *
+ * One instance because the manager owns one slot: it is driven by the one
+ * microphone the machine has, and a second manager would let two sessions
+ * interleave unrelated timelines. Lazily created so importing this module
+ * costs nothing until a socket arrives.
+ */
+export function getWatchSessionManager(): WatchSessionManager {
+  sharedManager ??= new WatchSessionManager();
+  return sharedManager;
+}
+
+// ---------------------------------------------------------------------------
+// Session
+// ---------------------------------------------------------------------------
+
+type SessionState =
+  /** Constructed, waiting for the transcriber and the session slot. */
+  | "initializing"
+  /** Recording: audio frames are accepted and finals become narration. */
+  | "active"
+  /** The client sent `stop`; the provider is flushing its last finals. */
+  | "stopping"
+  /** Terminal. */
+  | "closed";
+
+export interface WatchStreamSessionOptions {
+  /** MIME type of the audio the client streams. */
+  readonly mimeType: string;
+  /** Sample rate in Hz, threaded to the provider that wants one. */
+  readonly sampleRate?: number;
+  /** Adopt an existing conversation rather than minting one for the session. */
+  readonly conversationId?: string;
+  /** The desktop client to observe, when the actor has more than one. */
+  readonly clientId?: string;
+  /** Override the idle window for testing. */
+  readonly idleTimeoutMs?: number;
+  /** The manager the session drives. Defaults to the process-wide one. */
+  readonly manager?: WatchSessionManager;
+  /**
+   * Opens the provider stream. Defaults to `resolveStreamingTranscriber`,
+   * imported lazily so a caller that injects its own never pulls the provider
+   * stack into the module graph.
+   */
+  readonly resolveTranscriber?: () => Promise<StreamingTranscriber | null>;
+  /** Resolves the actor the session observes for. */
+  readonly resolveActorPrincipalId?: () => Promise<string | undefined>;
+}
+
+/**
+ * One watch session, from socket open to teardown.
+ *
+ * Created by the WebSocket `open` handler in `http-server.ts` and destroyed on
+ * `stop`, client disconnect, idle timeout, or runtime shutdown. Whichever of
+ * those arrives first, the manager slot is released exactly once.
+ */
+export class WatchStreamSession {
+  private state: SessionState = "initializing";
+  private transcriber: StreamingTranscriber | null = null;
+  private idleTimer: ReturnType<typeof setTimeout> | null = null;
+  /**
+   * Whether this socket is the one holding the manager's slot. A socket that
+   * was turned away as busy must never stop the session that turned it away.
+   */
+  private ownsManagerSession = false;
+
+  private readonly ws: WatchStreamSocket;
+  private readonly options: WatchStreamSessionOptions;
+  private readonly manager: WatchSessionManager;
+  private readonly idleTimeoutMs: number;
+
+  constructor(ws: WatchStreamSocket, options: WatchStreamSessionOptions) {
+    this.ws = ws;
+    this.options = options;
+    this.manager = options.manager ?? getWatchSessionManager();
+    this.idleTimeoutMs = options.idleTimeoutMs ?? IDLE_TIMEOUT_MS;
+  }
+
+  /** Whether the session has reached its terminal state. */
+  get isClosed(): boolean {
+    return this.state === "closed";
+  }
+
+  // ── Startup ────────────────────────────────────────────────────────
+
+  /**
+   * Resolve the actor, open the provider stream, and claim the session slot.
+   *
+   * The actor comes first because it is the binding everything else depends
+   * on: `observeHostScreen` reaches only that actor's own desktop clients, and
+   * a session started without one could record nothing but failures. Failing
+   * here sends `error` then `closed` rather than opening a session that cannot
+   * see anything.
+   */
+  async start(): Promise<void> {
+    if (this.state !== "initializing") {
+      log.warn(
+        { state: this.state },
+        "Watch stream start in non-initial state",
+      );
+      return;
+    }
+
+    try {
+      const sourceActorPrincipalId = await this.resolveActorPrincipalId();
+      if (this.isClosed) {
+        return;
+      }
+      if (!sourceActorPrincipalId) {
+        this.failStart(
+          "session-error",
+          "Watch could not resolve the actor to observe for. Sign in on this device and try again.",
+          1008,
+        );
+        return;
+      }
+
+      const transcriber = await this.resolveTranscriber();
+
+      // The socket can close while either resolution is in flight. Read the
+      // terminal state through the getter so the compiler does not narrow it
+      // to the value it held before the await.
+      if (this.isClosed) {
+        stopQuietly(transcriber);
+        return;
+      }
+
+      if (!transcriber) {
+        this.failStart(
+          "provider-error",
+          "Watch needs a speech provider that supports streaming transcription.",
+          1000,
+        );
+        return;
+      }
+
+      this.transcriber = transcriber;
+      await transcriber.start((event) => {
+        this.handleTranscriberEvent(event);
+      });
+
+      if (this.isClosed) {
+        stopQuietly(transcriber);
+        this.transcriber = null;
+        return;
+      }
+
+      const started = this.manager.start({
+        sourceActorPrincipalId,
+        ...(this.options.conversationId
+          ? { conversationId: this.options.conversationId }
+          : {}),
+        ...(this.options.clientId ? { clientId: this.options.clientId } : {}),
+      });
+      if (started.status !== "started") {
+        this.failStart(
+          "session-error",
+          started.status === "busy"
+            ? "A watch session is already running."
+            : started.reason,
+          1000,
+        );
+        return;
+      }
+      this.ownsManagerSession = true;
+
+      this.state = "active";
+      this.resetIdleTimer();
+      this.sendFrame({
+        type: "ready",
+        sessionId: started.sessionId,
+        conversationId: started.conversationId,
+      });
+      log.info(
+        {
+          sessionId: started.sessionId,
+          conversationId: started.conversationId,
+          provider: transcriber.providerId,
+        },
+        "Watch stream session started",
+      );
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log.error({ error: message }, "Failed to start watch stream session");
+      this.failStart("provider-error", message, 1011);
+    }
+  }
+
+  // ── Inbound frames ─────────────────────────────────────────────────
+
+  /** Handle a text frame: a base64 `audio` event or `stop`. */
+  handleMessage(raw: string): void {
+    if (this.state === "closed") {
+      return;
+    }
+    this.resetIdleTimer();
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      log.debug("Watch stream: dropped non-JSON text frame");
+      return;
+    }
+    if (!parsed || typeof parsed !== "object") {
+      return;
+    }
+
+    const event = parsed as {
+      type?: string;
+      audio?: string;
+      mimeType?: string;
+    };
+    switch (event.type) {
+      case "audio": {
+        if (this.state !== "active" || typeof event.audio !== "string") {
+          return;
+        }
+        this.transcriber?.sendAudio(
+          Buffer.from(event.audio, "base64"),
+          event.mimeType ?? this.options.mimeType,
+        );
+        return;
+      }
+      case "stop": {
+        this.handleStop();
+        return;
+      }
+      default: {
+        log.debug({ type: event.type }, "Watch stream: dropped unknown event");
+        return;
+      }
+    }
+  }
+
+  /** Handle a binary frame: raw audio bytes. */
+  handleBinaryAudio(data: Buffer | ArrayBuffer | Uint8Array): void {
+    if (this.state !== "active") {
+      return;
+    }
+    this.resetIdleTimer();
+
+    const buffer = Buffer.isBuffer(data)
+      ? data
+      : Buffer.from(data instanceof ArrayBuffer ? new Uint8Array(data) : data);
+    this.transcriber?.sendAudio(buffer, this.options.mimeType);
+  }
+
+  /** The client disconnected, or the transport failed. */
+  handleClose(code: number, reason?: string): void {
+    if (this.state === "closed") {
+      return;
+    }
+    log.info({ code, reason }, "Watch stream WebSocket closed");
+    this.teardown();
+  }
+
+  /** Forcible teardown, for runtime shutdown. */
+  destroy(): void {
+    if (this.state === "closed") {
+      return;
+    }
+    log.info("Watch stream session destroyed");
+    this.teardown();
+  }
+
+  // ── Internals ──────────────────────────────────────────────────────
+
+  private async resolveActorPrincipalId(): Promise<string | undefined> {
+    if (this.options.resolveActorPrincipalId) {
+      return this.options.resolveActorPrincipalId();
+    }
+    return resolveWatchActorPrincipalId();
+  }
+
+  private async resolveTranscriber(): Promise<StreamingTranscriber | null> {
+    if (this.options.resolveTranscriber) {
+      return this.options.resolveTranscriber();
+    }
+    const { resolveStreamingTranscriber } =
+      await import("../../providers/speech-to-text/resolve.js");
+    return resolveStreamingTranscriber(
+      this.options.sampleRate !== undefined
+        ? { sampleRate: this.options.sampleRate }
+        : {},
+    );
+  }
+
+  /**
+   * Report why the session never opened, then close. The teardown between the
+   * two stops a transcriber that opened before the failing step, and emits the
+   * terminal `closed` frame.
+   */
+  private failStart(
+    category: WatchStreamErrorCategory,
+    message: string,
+    closeCode: number,
+  ): void {
+    this.sendFrame({ type: "error", category, message });
+    this.teardown();
+    this.closeSocket(closeCode, "watch session start failed");
+  }
+
+  /**
+   * The client finished narrating. The provider may still emit finals after
+   * `stop()`, so the session waits for the provider's `closed` rather than
+   * tearing down here.
+   */
+  private handleStop(): void {
+    if (this.state !== "active") {
+      return;
+    }
+    this.state = "stopping";
+    this.clearIdleTimer();
+
+    try {
+      this.transcriber?.stop();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log.error({ error: message }, "Error stopping the watch transcriber");
+      this.sendFrame({ type: "error", category: "provider-error", message });
+      this.teardown();
+      this.closeSocket(1011, "stop failed");
+    }
+  }
+
+  private handleTranscriberEvent(event: SttStreamServerEvent): void {
+    if (this.state === "closed") {
+      return;
+    }
+
+    if (event.type === "final") {
+      const text = event.text.trim();
+      if (!text) {
+        return;
+      }
+      // Fire and forget: the narration is filed synchronously inside
+      // `handleNarrationFinal`, and what remains is the screen read, which the
+      // manager already owns the failure handling for.
+      void this.manager.handleNarrationFinal(text).catch((err: unknown) => {
+        log.warn({ err }, "Watch narration append threw");
+      });
+      this.sendFrame({ type: "entry" });
+      return;
+    }
+
+    if (event.type === "error") {
+      this.sendFrame({
+        type: "error",
+        category: event.category,
+        message: event.message,
+      });
+      return;
+    }
+
+    if (event.type === "closed") {
+      this.teardown();
+      this.closeSocket(1000, "session complete");
+    }
+  }
+
+  // ── Idle timer ─────────────────────────────────────────────────────
+
+  private resetIdleTimer(): void {
+    this.clearIdleTimer();
+    if (this.state === "closed" || this.state === "stopping") {
+      return;
+    }
+
+    this.idleTimer = setTimeout(() => {
+      if (this.state === "closed") {
+        return;
+      }
+      log.warn("Watch stream session idle timeout");
+      this.sendFrame({
+        type: "error",
+        category: "timeout",
+        message: "The watch session timed out because the client went quiet.",
+      });
+      this.teardown();
+      this.closeSocket(1000, "idle timeout");
+    }, this.idleTimeoutMs);
+  }
+
+  private clearIdleTimer(): void {
+    if (this.idleTimer !== null) {
+      clearTimeout(this.idleTimer);
+      this.idleTimer = null;
+    }
+  }
+
+  // ── Teardown ───────────────────────────────────────────────────────
+
+  /**
+   * Release everything the session holds and send the terminal `closed` frame.
+   * Idempotent: the close handler, the idle timer, and the provider's own
+   * `closed` all land here, and only the first one does any work.
+   */
+  private teardown(): void {
+    if (this.state === "closed") {
+      return;
+    }
+    this.state = "closed";
+    this.clearIdleTimer();
+
+    if (this.transcriber) {
+      stopQuietly(this.transcriber);
+      this.transcriber = null;
+    }
+
+    if (this.ownsManagerSession) {
+      this.ownsManagerSession = false;
+      const summary = this.manager.stop();
+      if (summary) {
+        log.info(
+          {
+            sessionId: summary.sessionId,
+            conversationId: summary.conversationId,
+            entryCount: summary.entryCount,
+            durationMs: summary.durationMs,
+          },
+          "Watch session ended",
+        );
+      }
+    }
+
+    this.sendFrame({ type: "closed" });
+  }
+
+  private sendFrame(frame: WatchStreamServerFrame): void {
+    try {
+      this.ws.send(JSON.stringify(frame));
+    } catch (err) {
+      log.debug({ err }, "Watch stream: failed to send a frame");
+    }
+  }
+
+  private closeSocket(code: number, reason: string): void {
+    try {
+      this.ws.close(code, reason);
+    } catch {
+      // Already closed.
+    }
+  }
+}
+
+/** Stop a transcriber that may already be gone. */
+function stopQuietly(transcriber: StreamingTranscriber | null): void {
+  if (!transcriber) {
+    return;
+  }
+  try {
+    transcriber.stop();
+  } catch {
+    // Best effort.
+  }
+}
+
+/**
+ * The actor a watch session observes for.
+ *
+ * The gateway authenticates the downstream client and then dials the runtime
+ * on a fresh connection carrying only its service token, so the upgrade
+ * request arrives with no actor header of its own: the header path covers a
+ * client that reaches the daemon directly, and the guardian lookup covers the
+ * gateway-proxied socket, which the gateway pinned to the bound guardian
+ * before it dialled. Both go through the same resolution the host-proxy result
+ * routes use, so a session binds to the principal those routes would match a
+ * desktop client against.
+ */
+export async function resolveWatchActorPrincipalId(
+  actorPrincipalIdHeader?: string,
+): Promise<string | undefined> {
+  const {
+    findLocalGuardianPrincipalId,
+    resolveActorPrincipalIdForLocalGuardian,
+  } = await import("../local-actor-identity.js");
+  const fromHeader = await resolveActorPrincipalIdForLocalGuardian(
+    actorPrincipalIdHeader,
+  );
+  return fromHeader ?? (await findLocalGuardianPrincipalId());
+}
+
+// ---------------------------------------------------------------------------
+// Active session registry
+// ---------------------------------------------------------------------------
+
+/**
+ * Open watch sessions keyed by socket session id, so runtime shutdown can tear
+ * them all down deterministically. Mirrors `activeSttStreamSessions`.
+ */
+export const activeWatchStreamSessions = new Map<string, WatchStreamSession>();

--- a/assistant/src/runtime/routes/watch-routes.ts
+++ b/assistant/src/runtime/routes/watch-routes.ts
@@ -18,7 +18,7 @@
  * conversational turn that happens after the socket is gone.
  *
  * Route policy: the upgrade is gated exactly as `/v1/stt/stream` is, in
- * `http-server.ts` — private-network peer and origin, then an `svc_gateway`
+ * `http-server.ts`: private-network peer and origin, then an `svc_gateway`
  * service token. A WebSocket upgrade never reaches the shared `ROUTES` array,
  * whose `policy` block the HTTP adapter evaluates per JSON request, so the
  * gate is the upgrade handler's rather than a `RoutePolicy` value. The gateway
@@ -570,13 +570,22 @@ function stopQuietly(transcriber: StreamingTranscriber | null): void {
  * through to and the same one `live-voice-session.ts` stamps its turns with,
  * so a watch session observes the principal the host-proxy result routes match
  * a desktop client against.
+ *
+ * The read deliberately bypasses the guardian-delivery cache. That cache keeps
+ * a successful read that found no binding, and a gateway-side binding write
+ * does not invalidate it, so a guardian bound after the daemon cached an empty
+ * answer would leave every Watch press failing the unresolvable-principal path
+ * until the TTL lapsed. That is the order of events on a first run, and it
+ * fails looking like a broken feature rather than one that is not ready yet. A
+ * session starts only when a person asks for one, so a fresh read costs
+ * nothing worth weighing against that.
  */
 export async function resolveWatchActorPrincipalId(): Promise<
   string | undefined
 > {
   const { findLocalGuardianPrincipalId } =
     await import("../local-actor-identity.js");
-  return findLocalGuardianPrincipalId();
+  return findLocalGuardianPrincipalId({ forceRefresh: true });
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/runtime/routes/watch-routes.ts
+++ b/assistant/src/runtime/routes/watch-routes.ts
@@ -503,6 +503,10 @@ export class WatchStreamSession {
 
     if (this.ownsManagerSession) {
       this.ownsManagerSession = false;
+      // A screen read still in flight is dropped by the manager's `stopped`
+      // guard rather than awaited. Narration itself survives, because
+      // `handleNarrationFinal` files it synchronously before it observes, so
+      // what is lost is at most one trailing frame of a session that is over.
       const summary = this.manager.stop();
       if (summary) {
         log.info(
@@ -550,28 +554,29 @@ function stopQuietly(transcriber: StreamingTranscriber | null): void {
 }
 
 /**
- * The actor a watch session observes for.
+ * The actor a watch session observes for: the vellum guardian bound to this
+ * daemon, read from the gateway-owned binding.
  *
- * The gateway authenticates the downstream client and then dials the runtime
- * on a fresh connection carrying only its service token, so the upgrade
- * request arrives with no actor header of its own: the header path covers a
- * client that reaches the daemon directly, and the guardian lookup covers the
- * gateway-proxied socket, which the gateway pinned to the bound guardian
- * before it dialled. Both go through the same resolution the host-proxy result
- * routes use, so a session binds to the principal those routes would match a
- * desktop client against.
+ * The principal comes from that binding rather than from anything the request
+ * carries, because the request cannot carry a trustworthy one. The gateway
+ * authenticates the downstream client's edge JWT and then dials the runtime on
+ * a fresh socket bearing only its own service token
+ * (`gateway/src/http/routes/stt-stream-websocket.ts`), so an actor claim on
+ * the upgrade is never the gateway's word about who the client is. Honouring
+ * one would let any caller holding the service token bind a session, and the
+ * screen reads it drives, to somebody else's principal.
+ *
+ * It is the same binding `resolveActorPrincipalIdForLocalGuardian` falls
+ * through to and the same one `live-voice-session.ts` stamps its turns with,
+ * so a watch session observes the principal the host-proxy result routes match
+ * a desktop client against.
  */
-export async function resolveWatchActorPrincipalId(
-  actorPrincipalIdHeader?: string,
-): Promise<string | undefined> {
-  const {
-    findLocalGuardianPrincipalId,
-    resolveActorPrincipalIdForLocalGuardian,
-  } = await import("../local-actor-identity.js");
-  const fromHeader = await resolveActorPrincipalIdForLocalGuardian(
-    actorPrincipalIdHeader,
-  );
-  return fromHeader ?? (await findLocalGuardianPrincipalId());
+export async function resolveWatchActorPrincipalId(): Promise<
+  string | undefined
+> {
+  const { findLocalGuardianPrincipalId } =
+    await import("../local-actor-identity.js");
+  return findLocalGuardianPrincipalId();
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `/v1/watch/stream`, the production ingress for a watch session: the `/v1/stt/stream` transport (binary or base64 audio in, `{type:"stop"}` to flush) driving a `StreamingTranscriber` from `resolveStreamingTranscriber()`, with no second provider story.
- Drives `WatchSessionManager` for real: `start()` on open with a principal resolved from the request, `handleNarrationFinal()` on every STT final, `stop()` on close, idle timeout, or shutdown. Closes the "wire into production ingress" threads from PRs 3 and 4.
- Frames back to the client are lifecycle only (`ready`, `entry`, `error`, `closed`): no partials, no transcript text, no assistant reply.

Part of plan: learning-by-watching.md (PR 7 of 10)