### PR TITLE
fix: prevent corrupt image-conversion cache entries from wedging conversations

### DIFF
--- a/assistant/src/__tests__/compactor-retained-image-validation.test.ts
+++ b/assistant/src/__tests__/compactor-retained-image-validation.test.ts
@@ -4,7 +4,7 @@
  * Retained images are re-hydrated from the attachment store and re-optimized
  * at compaction time. If that pipeline yields bytes that no longer parse as an
  * image (e.g. a corrupt conversion-cache entry), embedding them would make the
- * provider reject EVERY subsequent turn with a 400 — the conversation wedges
+ * provider reject EVERY subsequent turn with a 400: the conversation wedges
  * until the block is manually removed. `buildRetainedImageBlocks` drops such
  * payloads instead.
  */
@@ -28,7 +28,7 @@ await initializeDb();
 const PNG_1X1_BASE64 =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==";
 
-// Declared image/png, but the bytes are not any known image format —
+// Declared image/png, but the bytes are not any known image format:
 // the stand-in for a corrupted payload surviving in the pipeline.
 const GARBAGE_BASE64 = Buffer.from("definitely not an image").toString(
   "base64",
@@ -95,11 +95,34 @@ describe("buildRetainedImageBlocks corrupt-bytes gate", () => {
       manifest,
     );
 
-    // The corrupt payload is dropped (not listed as manifest-missing — it
-    // resolved fine; its bytes were the problem) and the valid one survives.
+    // The corrupt payload is dropped (not listed as manifest-missing, since
+    // it resolved fine; its bytes were the problem) and the valid one
+    // survives.
     expect(resolved).toEqual(["good.png"]);
     expect(missing).toEqual([]);
     expect(blocks).toHaveLength(1);
+  });
+
+  test("a truncated JPEG (valid SOI header, no EOI) is dropped", async () => {
+    // A JPEG torn mid-write keeps its SOI header, so a format sniff alone
+    // accepts it; the gate must also require an EOI marker.
+    const tornJpeg = Buffer.concat([
+      Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]),
+      Buffer.from("JFIF\0"),
+      Buffer.alloc(64),
+    ]).toString("base64");
+    const conv = createConversation();
+    await addImageMessage(conv.id, "torn.jpg", tornJpeg);
+    const manifest = collectImageManifest(conv.id, "guardian");
+
+    const { blocks, resolved, missing } = await buildRetainedImageBlocks(
+      ["torn.jpg"],
+      manifest,
+    );
+
+    expect(resolved).toEqual([]);
+    expect(missing).toEqual([]);
+    expect(blocks).toHaveLength(0);
   });
 
   test("unresolvable filenames still land in missing", async () => {

--- a/assistant/src/__tests__/compactor-retained-image-validation.test.ts
+++ b/assistant/src/__tests__/compactor-retained-image-validation.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Compaction must never bake invalid image bytes into the rebuilt history.
+ *
+ * Retained images are re-hydrated from the attachment store and re-optimized
+ * at compaction time. If that pipeline yields bytes that no longer parse as an
+ * image (e.g. a corrupt conversion-cache entry), embedding them would make the
+ * provider reject EVERY subsequent turn with a 400 — the conversation wedges
+ * until the block is manually removed. `buildRetainedImageBlocks` drops such
+ * payloads instead.
+ */
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  buildRetainedImageBlocks,
+  collectImageManifest,
+} from "../context/compactor.js";
+import { attachInlineAttachmentToMessage } from "../persistence/attachments-store.js";
+import {
+  addMessage,
+  createConversation,
+} from "../persistence/conversation-crud.js";
+import { getDb } from "../persistence/db-connection.js";
+import { initializeDb } from "../persistence/db-init.js";
+
+await initializeDb();
+
+// 1x1 transparent PNG.
+const PNG_1X1_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==";
+
+// Declared image/png, but the bytes are not any known image format —
+// the stand-in for a corrupted payload surviving in the pipeline.
+const GARBAGE_BASE64 = Buffer.from("definitely not an image").toString(
+  "base64",
+);
+
+function resetTables(): void {
+  const db = getDb();
+  db.run("DELETE FROM message_attachments");
+  db.run("DELETE FROM attachments");
+  db.run("DELETE FROM messages");
+  db.run("DELETE FROM conversations");
+}
+
+async function addImageMessage(
+  conversationId: string,
+  filename: string,
+  dataBase64: string,
+): Promise<void> {
+  const inserted = await addMessage(
+    conversationId,
+    "user",
+    JSON.stringify([{ type: "text", text: filename }]),
+    {
+      metadata: { provenanceTrustClass: "guardian" },
+      skipIndexing: true,
+    },
+  );
+  await attachInlineAttachmentToMessage(
+    inserted.id,
+    0,
+    filename,
+    "image/png",
+    dataBase64,
+  );
+}
+
+describe("buildRetainedImageBlocks corrupt-bytes gate", () => {
+  beforeEach(resetTables);
+
+  test("valid image bytes are retained", async () => {
+    const conv = createConversation();
+    await addImageMessage(conv.id, "good.png", PNG_1X1_BASE64);
+    const manifest = collectImageManifest(conv.id, "guardian");
+
+    const { blocks, resolved, missing } = await buildRetainedImageBlocks(
+      ["good.png"],
+      manifest,
+    );
+
+    expect(resolved).toEqual(["good.png"]);
+    expect(missing).toEqual([]);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].source.type).toBe("base64");
+  });
+
+  test("bytes that do not parse as an image are dropped, not embedded", async () => {
+    const conv = createConversation();
+    await addImageMessage(conv.id, "corrupt.png", GARBAGE_BASE64);
+    await addImageMessage(conv.id, "good.png", PNG_1X1_BASE64);
+    const manifest = collectImageManifest(conv.id, "guardian");
+
+    const { blocks, resolved, missing } = await buildRetainedImageBlocks(
+      ["corrupt.png", "good.png"],
+      manifest,
+    );
+
+    // The corrupt payload is dropped (not listed as manifest-missing — it
+    // resolved fine; its bytes were the problem) and the valid one survives.
+    expect(resolved).toEqual(["good.png"]);
+    expect(missing).toEqual([]);
+    expect(blocks).toHaveLength(1);
+  });
+
+  test("unresolvable filenames still land in missing", async () => {
+    const conv = createConversation();
+    await addImageMessage(conv.id, "good.png", PNG_1X1_BASE64);
+    const manifest = collectImageManifest(conv.id, "guardian");
+
+    const { blocks, resolved, missing } = await buildRetainedImageBlocks(
+      ["never-uploaded.png", "good.png"],
+      manifest,
+    );
+
+    expect(missing).toEqual(["never-uploaded.png"]);
+    expect(resolved).toEqual(["good.png"]);
+    expect(blocks).toHaveLength(1);
+  });
+});

--- a/assistant/src/__tests__/image-conversion.test.ts
+++ b/assistant/src/__tests__/image-conversion.test.ts
@@ -14,7 +14,7 @@ import { beforeAll, describe, expect, test } from "bun:test";
 
 import {
   convertImageToJpeg,
-  hasJpegEoi,
+  hasValidJpegStructure,
   isCompleteJpeg,
   isHeifImage,
   jpegFilenameFor,
@@ -158,21 +158,74 @@ function cacheKeyFor(bytes: Uint8Array, quality: number): string {
   return `${hash}-full-q${quality}`;
 }
 
-describe("hasJpegEoi", () => {
+// Minimal structurally valid JPEG: SOI, APP0 (len 4, 2 payload bytes),
+// SOS (len 3, 1 payload byte), entropy data with a stuffed FF, then EOI.
+function minimalJpeg(extra: {
+  trailing?: Uint8Array;
+  dropEoi?: boolean;
+}): Buffer {
+  const parts: Uint8Array[] = [
+    Buffer.from([0xff, 0xd8]), // SOI
+    Buffer.from([0xff, 0xe0, 0x00, 0x04, 0x4a, 0x46]), // APP0
+    Buffer.from([0xff, 0xda, 0x00, 0x03, 0x01]), // SOS header
+    Buffer.from([0x12, 0xff, 0x00, 0x34]), // entropy data with stuffed FF
+  ];
+  if (!extra.dropEoi) {
+    parts.push(Buffer.from([0xff, 0xd9])); // EOI
+  }
+  if (extra.trailing) {
+    parts.push(extra.trailing);
+  }
+  return Buffer.concat(parts);
+}
+
+describe("hasValidJpegStructure", () => {
   test("accepts a JPEG with trailing bytes after the EOI marker", () => {
-    // Some encoders append padding or metadata past the EOI; the lenient
-    // check tolerates it where isCompleteJpeg's exact tail framing does not.
-    const padded = Buffer.from([
-      0xff, 0xd8, 0xff, 0xe0, 0xff, 0xd9, 0x00, 0x00,
-    ]);
-    expect(hasJpegEoi(padded)).toBe(true);
+    // Some encoders append padding or metadata past the EOI; the structural
+    // walk tolerates it where isCompleteJpeg's exact tail framing does not.
+    const padded = minimalJpeg({ trailing: Buffer.from([0x00, 0x00]) });
+    expect(hasValidJpegStructure(padded)).toBe(true);
     expect(isCompleteJpeg(padded)).toBe(false);
   });
 
+  test("accepts restart markers inside entropy-coded data", () => {
+    const withRst = Buffer.concat([
+      Buffer.from([0xff, 0xd8]),
+      Buffer.from([0xff, 0xda, 0x00, 0x03, 0x01]),
+      Buffer.from([0x12, 0xff, 0xd0, 0x34]), // RST0 continues the scan
+      Buffer.from([0xff, 0xd9]),
+    ]);
+    expect(hasValidJpegStructure(withRst)).toBe(true);
+  });
+
+  test("rejects a truncated JPEG whose metadata segment contains FF D9", () => {
+    // An EXIF-style APP1 payload can embed a complete thumbnail JPEG, so an
+    // FF D9 pair appears inside the segment while the main image is torn. A
+    // raw byte search would accept this; the marker walk skips the segment
+    // payload and reports the truncation.
+    const tornWithThumbnail = Buffer.concat([
+      Buffer.from([0xff, 0xd8]), // SOI
+      Buffer.from([0xff, 0xe1, 0x00, 0x08]), // APP1, length 8
+      Buffer.from([0x45, 0x78, 0xff, 0xd9, 0x00, 0x00]), // payload with FF D9
+      Buffer.from([0xff, 0xda, 0x00, 0x03, 0x01, 0x12, 0x34]), // torn scan
+    ]);
+    expect(hasValidJpegStructure(tornWithThumbnail)).toBe(false);
+  });
+
   test("rejects truncated JPEGs and non-JPEG payloads", () => {
-    expect(hasJpegEoi(Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00]))).toBe(false);
-    expect(hasJpegEoi(Buffer.alloc(0))).toBe(false);
-    expect(hasJpegEoi(PNG_1PX_BYTES)).toBe(false);
+    expect(hasValidJpegStructure(minimalJpeg({ dropEoi: true }))).toBe(false);
+    expect(
+      hasValidJpegStructure(Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00])),
+    ).toBe(false);
+    expect(hasValidJpegStructure(Buffer.alloc(0))).toBe(false);
+    expect(hasValidJpegStructure(PNG_1PX_BYTES)).toBe(false);
+  });
+
+  test("rejects a segment length that runs past the buffer", () => {
+    // A declared length larger than the remaining bytes is truncation, not a
+    // reason to scan beyond the buffer.
+    const overrun = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0xff, 0xff, 0x00]);
+    expect(hasValidJpegStructure(overrun)).toBe(false);
   });
 });
 
@@ -250,6 +303,9 @@ describe.skipIf(process.platform !== "darwin")(
       const converted = await convertImageToJpeg(heicBytes);
       expect(converted).not.toBeNull();
       expect(startsWithJpegMagic(converted!)).toBe(true);
+      // A real encoder's output must pass the structural walk, or the
+      // compactor gate would drop every legitimately converted image.
+      expect(hasValidJpegStructure(converted!)).toBe(true);
     });
 
     test("conversion options produce distinct outputs (cache key isolation)", async () => {

--- a/assistant/src/__tests__/image-conversion.test.ts
+++ b/assistant/src/__tests__/image-conversion.test.ts
@@ -14,6 +14,7 @@ import { beforeAll, describe, expect, test } from "bun:test";
 
 import {
   convertImageToJpeg,
+  hasJpegEoi,
   isCompleteJpeg,
   isHeifImage,
   jpegFilenameFor,
@@ -142,7 +143,7 @@ describe("isCompleteJpeg", () => {
 
   test("rejects empty, truncated, and non-JPEG payloads", () => {
     expect(isCompleteJpeg(Buffer.alloc(0))).toBe(false);
-    // Valid head, torn tail — the poisoned-cache signature.
+    // Valid head, torn tail: the poisoned-cache signature.
     expect(isCompleteJpeg(Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00]))).toBe(
       false,
     );
@@ -156,6 +157,24 @@ function cacheKeyFor(bytes: Uint8Array, quality: number): string {
   const hash = createHash("sha256").update(bytes).digest("hex").slice(0, 16);
   return `${hash}-full-q${quality}`;
 }
+
+describe("hasJpegEoi", () => {
+  test("accepts a JPEG with trailing bytes after the EOI marker", () => {
+    // Some encoders append padding or metadata past the EOI; the lenient
+    // check tolerates it where isCompleteJpeg's exact tail framing does not.
+    const padded = Buffer.from([
+      0xff, 0xd8, 0xff, 0xe0, 0xff, 0xd9, 0x00, 0x00,
+    ]);
+    expect(hasJpegEoi(padded)).toBe(true);
+    expect(isCompleteJpeg(padded)).toBe(false);
+  });
+
+  test("rejects truncated JPEGs and non-JPEG payloads", () => {
+    expect(hasJpegEoi(Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00]))).toBe(false);
+    expect(hasJpegEoi(Buffer.alloc(0))).toBe(false);
+    expect(hasJpegEoi(PNG_1PX_BYTES)).toBe(false);
+  });
+});
 
 describe("normalizeImageBytes passthrough", () => {
   test("non-HEIF bytes pass through untouched", async () => {
@@ -263,9 +282,8 @@ describe.skipIf(process.platform !== "darwin")(
         cacheDir,
         `${cacheKeyFor(heicBytes, quality)}.jpg`,
       );
-      // A torn write: valid JPEG head, no EOI tail. Pre-fix, this came back
-      // verbatim as the "converted" image and poisoned every provider call
-      // that embedded it.
+      // A torn write: valid JPEG head, no EOI tail. readFromCache must
+      // discard it rather than return it as the converted image.
       writeFileSync(poisonedPath, Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00]));
 
       const converted = await convertImageToJpeg(heicBytes, { quality });

--- a/assistant/src/__tests__/image-conversion.test.ts
+++ b/assistant/src/__tests__/image-conversion.test.ts
@@ -159,7 +159,8 @@ function cacheKeyFor(bytes: Uint8Array, quality: number): string {
 }
 
 // Minimal structurally valid JPEG: SOI, APP0 (len 4, 2 payload bytes),
-// SOS (len 3, 1 payload byte), entropy data with a stuffed FF, then EOI.
+// SOF0 (len 5, 3 payload bytes), SOS (len 3, 1 payload byte), entropy data
+// with a stuffed FF, then EOI.
 function minimalJpeg(extra: {
   trailing?: Uint8Array;
   dropEoi?: boolean;
@@ -167,6 +168,7 @@ function minimalJpeg(extra: {
   const parts: Uint8Array[] = [
     Buffer.from([0xff, 0xd8]), // SOI
     Buffer.from([0xff, 0xe0, 0x00, 0x04, 0x4a, 0x46]), // APP0
+    Buffer.from([0xff, 0xc0, 0x00, 0x05, 0x08, 0x00, 0x01]), // SOF0
     Buffer.from([0xff, 0xda, 0x00, 0x03, 0x01]), // SOS header
     Buffer.from([0x12, 0xff, 0x00, 0x34]), // entropy data with stuffed FF
   ];
@@ -191,6 +193,7 @@ describe("hasValidJpegStructure", () => {
   test("accepts restart markers inside entropy-coded data", () => {
     const withRst = Buffer.concat([
       Buffer.from([0xff, 0xd8]),
+      Buffer.from([0xff, 0xc0, 0x00, 0x05, 0x08, 0x00, 0x01]), // SOF0
       Buffer.from([0xff, 0xda, 0x00, 0x03, 0x01]),
       Buffer.from([0x12, 0xff, 0xd0, 0x34]), // RST0 continues the scan
       Buffer.from([0xff, 0xd9]),
@@ -219,6 +222,21 @@ describe("hasValidJpegStructure", () => {
     ).toBe(false);
     expect(hasValidJpegStructure(Buffer.alloc(0))).toBe(false);
     expect(hasValidJpegStructure(PNG_1PX_BYTES)).toBe(false);
+  });
+
+  test("rejects a top-level EOI with no frame or scan", () => {
+    // Bare SOI+EOI is structurally walkable but carries no image data;
+    // providers reject it, so the gate must too.
+    expect(hasValidJpegStructure(Buffer.from([0xff, 0xd8, 0xff, 0xd9]))).toBe(
+      false,
+    );
+    // A scan without a frame header is equally undecodable.
+    const scanNoFrame = Buffer.concat([
+      Buffer.from([0xff, 0xd8]),
+      Buffer.from([0xff, 0xda, 0x00, 0x03, 0x01, 0x12]),
+      Buffer.from([0xff, 0xd9]),
+    ]);
+    expect(hasValidJpegStructure(scanNoFrame)).toBe(false);
   });
 
   test("rejects a segment length that runs past the buffer", () => {

--- a/assistant/src/__tests__/image-conversion.test.ts
+++ b/assistant/src/__tests__/image-conversion.test.ts
@@ -6,13 +6,15 @@
  * gated on darwin.
  */
 
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { beforeAll, describe, expect, test } from "bun:test";
 
 import {
   convertImageToJpeg,
+  isCompleteJpeg,
   isHeifImage,
   jpegFilenameFor,
   normalizeImageBase64,
@@ -131,6 +133,30 @@ describe("sniffImageMimeType", () => {
   });
 });
 
+describe("isCompleteJpeg", () => {
+  test("accepts SOI...EOI framed payloads", () => {
+    expect(
+      isCompleteJpeg(Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0xff, 0xd9])),
+    ).toBe(true);
+  });
+
+  test("rejects empty, truncated, and non-JPEG payloads", () => {
+    expect(isCompleteJpeg(Buffer.alloc(0))).toBe(false);
+    // Valid head, torn tail — the poisoned-cache signature.
+    expect(isCompleteJpeg(Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00]))).toBe(
+      false,
+    );
+    expect(isCompleteJpeg(PNG_1PX_BYTES)).toBe(false);
+  });
+});
+
+// Mirrors the converter's cache-key derivation so the test can plant a
+// poisoned entry at the exact path a conversion will consult.
+function cacheKeyFor(bytes: Uint8Array, quality: number): string {
+  const hash = createHash("sha256").update(bytes).digest("hex").slice(0, 16);
+  return `${hash}-full-q${quality}`;
+}
+
 describe("normalizeImageBytes passthrough", () => {
   test("non-HEIF bytes pass through untouched", async () => {
     const result = await normalizeImageBytes("image/png", PNG_1PX_BYTES);
@@ -226,6 +252,30 @@ describe.skipIf(process.platform !== "darwin")(
       expect(first).not.toBeNull();
       expect(second).not.toBeNull();
       expect(first!.equals(second!)).toBe(true);
+    });
+
+    test("a poisoned (truncated) cache entry is discarded, not returned", async () => {
+      // Distinct quality so this test owns its cache key.
+      const quality = 77;
+      const cacheDir = join(tmpdir(), "vellum-optimized-images");
+      mkdirSync(cacheDir, { recursive: true });
+      const poisonedPath = join(
+        cacheDir,
+        `${cacheKeyFor(heicBytes, quality)}.jpg`,
+      );
+      // A torn write: valid JPEG head, no EOI tail. Pre-fix, this came back
+      // verbatim as the "converted" image and poisoned every provider call
+      // that embedded it.
+      writeFileSync(poisonedPath, Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00]));
+
+      const converted = await convertImageToJpeg(heicBytes, { quality });
+      expect(converted).not.toBeNull();
+      expect(isCompleteJpeg(converted!)).toBe(true);
+
+      // The poisoned entry was replaced by the re-converted result.
+      expect(existsSync(poisonedPath)).toBe(true);
+      const { readFileSync } = await import("node:fs");
+      expect(isCompleteJpeg(readFileSync(poisonedPath))).toBe(true);
     });
 
     test("normalizeImageBytes converts to a JPEG master", async () => {

--- a/assistant/src/context/compactor.ts
+++ b/assistant/src/context/compactor.ts
@@ -39,10 +39,7 @@ import type {
 } from "../providers/types.js";
 import { type TrustClass } from "../runtime/actor-trust-resolver.js";
 import { resolveCapabilities } from "../runtime/capabilities.js";
-import {
-  sniffBase64ImageMimeType,
-  sniffImageMimeType,
-} from "../util/image-conversion.js";
+import { hasJpegEoi, sniffImageMimeType } from "../util/image-conversion.js";
 import { getLogger } from "../util/logger.js";
 import { preModelCallSanitize } from "./outbound-sanitize.js";
 import { stripInjectionsForCompaction } from "./strip-injections.js";
@@ -888,7 +885,7 @@ export async function buildRetainedImageBlocks(
       missing.push(name);
       continue;
     }
-    // Sniff the declared MIME from the stored bytes rather than the filename —
+    // Sniff the declared MIME from the stored bytes rather than the filename:
     // clients derive extensions from user input, and providers reject an image
     // whose bytes disagree with the declared media type.
     const sourceMime =
@@ -901,14 +898,21 @@ export async function buildRetainedImageBlocks(
       sourceMime,
     );
     // Last-line gate before the bytes are baked into the rebuilt history: a
-    // payload that no longer sniffs as a known image format (e.g. a corrupt
-    // conversion-cache entry) would be rejected by the provider with a 400 on
-    // EVERY subsequent turn, wedging the conversation. Dropping the image
-    // loses a retained picture; shipping it loses the conversation.
-    if (sniffBase64ImageMimeType(optimized.data) == null) {
+    // corrupt payload would be rejected by the provider with a 400 on EVERY
+    // subsequent turn, wedging the conversation. Dropping the image loses a
+    // retained picture; shipping it loses the conversation. Format sniffing
+    // alone is not enough for JPEG: a truncated JPEG (e.g. persisted from a
+    // torn conversion-cache read) keeps its SOI header, so JPEG payloads must
+    // also carry an EOI marker.
+    const optimizedBytes = Buffer.from(optimized.data, "base64");
+    const optimizedFormat = sniffImageMimeType(optimizedBytes);
+    const bytesAreValidImage =
+      optimizedFormat != null &&
+      (optimizedFormat !== "image/jpeg" || hasJpegEoi(optimizedBytes));
+    if (!bytesAreValidImage) {
       log.warn(
         { filename: name, attachmentId: entry.attachmentId },
-        "Retained image bytes are not a valid image after transport optimization — dropping",
+        "Retained image bytes are not a valid image after transport optimization; dropping",
       );
       continue;
     }

--- a/assistant/src/context/compactor.ts
+++ b/assistant/src/context/compactor.ts
@@ -39,7 +39,10 @@ import type {
 } from "../providers/types.js";
 import { type TrustClass } from "../runtime/actor-trust-resolver.js";
 import { resolveCapabilities } from "../runtime/capabilities.js";
-import { hasJpegEoi, sniffImageMimeType } from "../util/image-conversion.js";
+import {
+  hasValidJpegStructure,
+  sniffImageMimeType,
+} from "../util/image-conversion.js";
 import { getLogger } from "../util/logger.js";
 import { preModelCallSanitize } from "./outbound-sanitize.js";
 import { stripInjectionsForCompaction } from "./strip-injections.js";
@@ -903,12 +906,13 @@ export async function buildRetainedImageBlocks(
     // retained picture; shipping it loses the conversation. Format sniffing
     // alone is not enough for JPEG: a truncated JPEG (e.g. persisted from a
     // torn conversion-cache read) keeps its SOI header, so JPEG payloads must
-    // also carry an EOI marker.
+    // also walk to a terminal EOI marker.
     const optimizedBytes = Buffer.from(optimized.data, "base64");
     const optimizedFormat = sniffImageMimeType(optimizedBytes);
     const bytesAreValidImage =
       optimizedFormat != null &&
-      (optimizedFormat !== "image/jpeg" || hasJpegEoi(optimizedBytes));
+      (optimizedFormat !== "image/jpeg" ||
+        hasValidJpegStructure(optimizedBytes));
     if (!bytesAreValidImage) {
       log.warn(
         { filename: name, attachmentId: entry.attachmentId },

--- a/assistant/src/context/compactor.ts
+++ b/assistant/src/context/compactor.ts
@@ -39,6 +39,10 @@ import type {
 } from "../providers/types.js";
 import { type TrustClass } from "../runtime/actor-trust-resolver.js";
 import { resolveCapabilities } from "../runtime/capabilities.js";
+import {
+  sniffBase64ImageMimeType,
+  sniffImageMimeType,
+} from "../util/image-conversion.js";
 import { getLogger } from "../util/logger.js";
 import { preModelCallSanitize } from "./outbound-sanitize.js";
 import { stripInjectionsForCompaction } from "./strip-injections.js";
@@ -865,7 +869,8 @@ function resolveTailFloorIndex(messages: Message[], tailIndex: number): number {
 // Retained-image hydration
 // ---------------------------------------------------------------------------
 
-async function buildRetainedImageBlocks(
+/** Exported for unit testing (the corrupt-bytes drop gate). */
+export async function buildRetainedImageBlocks(
   filenames: string[],
   manifest: ManifestEntry[],
 ): Promise<{ blocks: ImageContent[]; resolved: string[]; missing: string[] }> {
@@ -883,7 +888,11 @@ async function buildRetainedImageBlocks(
       missing.push(name);
       continue;
     }
-    const sourceMime = guessMimeFromFilename(name);
+    // Sniff the declared MIME from the stored bytes rather than the filename —
+    // clients derive extensions from user input, and providers reject an image
+    // whose bytes disagree with the declared media type.
+    const sourceMime =
+      sniffImageMimeType(content) ?? guessMimeFromFilename(name);
     // Run the same downscale pass the agent uses when first sending an
     // image. Without this, attachments that exceed the provider's per-image
     // byte limit (Anthropic: 5 MB) crash the next turn after compaction.
@@ -891,6 +900,18 @@ async function buildRetainedImageBlocks(
       content.toString("base64"),
       sourceMime,
     );
+    // Last-line gate before the bytes are baked into the rebuilt history: a
+    // payload that no longer sniffs as a known image format (e.g. a corrupt
+    // conversion-cache entry) would be rejected by the provider with a 400 on
+    // EVERY subsequent turn, wedging the conversation. Dropping the image
+    // loses a retained picture; shipping it loses the conversation.
+    if (sniffBase64ImageMimeType(optimized.data) == null) {
+      log.warn(
+        { filename: name, attachmentId: entry.attachmentId },
+        "Retained image bytes are not a valid image after transport optimization — dropping",
+      );
+      continue;
+    }
     blocks.push({
       type: "image",
       source: {

--- a/assistant/src/util/image-conversion.ts
+++ b/assistant/src/util/image-conversion.ts
@@ -22,6 +22,7 @@ import {
   readdirSync,
   readFileSync,
   readSync,
+  renameSync,
   statSync,
   unlinkSync,
   writeFileSync,
@@ -42,26 +43,62 @@ function getCacheDir(): string {
   return join(tmpdir(), "vellum-optimized-images");
 }
 
+/**
+ * Structural completeness check for a JPEG payload: SOI marker (FF D8) at the
+ * head and EOI marker (FF D9) at the tail. Every cache entry and every sips
+ * output is a JPEG, so a payload failing this is truncated or empty — the
+ * signature of a torn cache write — and must never reach a provider, which
+ * rejects it with a 400 that wedges the conversation (the corrupt block is
+ * resent on every subsequent turn).
+ */
+export function isCompleteJpeg(bytes: Uint8Array): boolean {
+  return (
+    bytes.length >= 4 &&
+    bytes[0] === 0xff &&
+    bytes[1] === 0xd8 &&
+    bytes[bytes.length - 2] === 0xff &&
+    bytes[bytes.length - 1] === 0xd9
+  );
+}
+
 function readFromCache(key: string): Buffer | null {
+  const cachePath = join(getCacheDir(), `${key}.jpg`);
   try {
-    const cachePath = join(getCacheDir(), `${key}.jpg`);
     if (!existsSync(cachePath)) {
       return null;
     }
-    return readFileSync(cachePath) as Buffer;
+    const bytes = readFileSync(cachePath) as Buffer;
+    if (!isCompleteJpeg(bytes)) {
+      // Poisoned entry (torn write from a pre-atomic-rename version, disk
+      // full, etc.) — drop it so the caller re-converts and re-caches.
+      unlinkSync(cachePath);
+      return null;
+    }
+    return bytes;
   } catch {
     return null;
   }
 }
 
 function writeToCache(key: string, convertedBytes: Buffer): void {
+  const dir = getCacheDir();
+  // Write-then-rename so concurrent readers (the cache dir is shared across
+  // daemon processes) never observe a partially written entry; rename within
+  // the same directory is atomic. The pid+uuid suffix keeps concurrent
+  // writers of the same key off each other's temp file.
+  const tmpPath = join(dir, `${key}.${process.pid}-${uuid().slice(0, 8)}.tmp`);
   try {
-    const dir = getCacheDir();
     mkdirSync(dir, { recursive: true });
-    writeFileSync(join(dir, `${key}.jpg`), convertedBytes);
+    writeFileSync(tmpPath, convertedBytes);
+    renameSync(tmpPath, join(dir, `${key}.jpg`));
     evictIfNeeded(dir);
   } catch {
     // Cache write failure is non-fatal.
+    try {
+      unlinkSync(tmpPath);
+    } catch {
+      /* ignore */
+    }
   }
 }
 
@@ -141,7 +178,14 @@ async function runSips(
     if (proc.exitCode !== 0) {
       return null;
     }
-    return readFileSync(outPath) as Buffer;
+    const out = readFileSync(outPath) as Buffer;
+    // A zero-exit sips can still leave a truncated file (disk full, timeout
+    // kill racing the write). Returning it would poison the cache and every
+    // downstream provider call — treat it as a failed conversion instead.
+    if (!isCompleteJpeg(out)) {
+      return null;
+    }
+    return out;
   } catch {
     return null;
   } finally {

--- a/assistant/src/util/image-conversion.ts
+++ b/assistant/src/util/image-conversion.ts
@@ -46,8 +46,8 @@ function getCacheDir(): string {
 /**
  * Structural completeness check for a JPEG payload: SOI marker (FF D8) at the
  * head and EOI marker (FF D9) at the tail. Every cache entry and every sips
- * output is a JPEG, so a payload failing this is truncated or empty — the
- * signature of a torn cache write — and must never reach a provider, which
+ * output is a JPEG, so a payload failing this is truncated or empty (the
+ * signature of a torn cache write) and must never reach a provider, which
  * rejects it with a 400 that wedges the conversation (the corrupt block is
  * resent on every subsequent turn).
  */
@@ -61,6 +61,29 @@ export function isCompleteJpeg(bytes: Uint8Array): boolean {
   );
 }
 
+const JPEG_EOI = Buffer.from([0xff, 0xd9]);
+
+/**
+ * Lenient JPEG truncation check for payloads of arbitrary origin: the SOI
+ * header plus an EOI marker anywhere in the buffer. Unlike
+ * {@link isCompleteJpeg} (exact tail framing, for sips output and cache
+ * entries, which always end on EOI), this tolerates encoders that append
+ * padding or metadata after the EOI. A truncated JPEG contains no EOI at all:
+ * entropy-coded data byte-stuffs FF as FF 00, so FF D9 cannot appear inside
+ * it by accident.
+ */
+export function hasJpegEoi(bytes: Uint8Array): boolean {
+  return (
+    bytes.length >= 4 &&
+    bytes[0] === 0xff &&
+    bytes[1] === 0xd8 &&
+    Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength).includes(
+      JPEG_EOI,
+      2,
+    )
+  );
+}
+
 function readFromCache(key: string): Buffer | null {
   const cachePath = join(getCacheDir(), `${key}.jpg`);
   try {
@@ -69,8 +92,8 @@ function readFromCache(key: string): Buffer | null {
     }
     const bytes = readFileSync(cachePath) as Buffer;
     if (!isCompleteJpeg(bytes)) {
-      // Poisoned entry (torn write from a pre-atomic-rename version, disk
-      // full, etc.) — drop it so the caller re-converts and re-caches.
+      // Poisoned entry (torn write, disk full, etc.): drop it so the caller
+      // re-converts and re-caches.
       unlinkSync(cachePath);
       return null;
     }
@@ -181,7 +204,7 @@ async function runSips(
     const out = readFileSync(outPath) as Buffer;
     // A zero-exit sips can still leave a truncated file (disk full, timeout
     // kill racing the write). Returning it would poison the cache and every
-    // downstream provider call — treat it as a failed conversion instead.
+    // downstream provider call. Treat it as a failed conversion instead.
     if (!isCompleteJpeg(out)) {
       return null;
     }

--- a/assistant/src/util/image-conversion.ts
+++ b/assistant/src/util/image-conversion.ts
@@ -75,11 +75,17 @@ export function isCompleteJpeg(bytes: Uint8Array): boolean {
  * the top level of the marker stream counts. Entropy-coded scan data is
  * traversed byte-wise, where FF is stuffed as FF 00 and restart markers
  * (D0-D7) continue the scan, so a marker byte there is unambiguous.
+ *
+ * The EOI only counts after at least one frame header (SOF) and one scan
+ * (SOS) have been seen: a degenerate payload such as bare SOI+EOI carries no
+ * image data and providers reject it.
  */
 export function hasValidJpegStructure(bytes: Uint8Array): boolean {
   if (bytes.length < 4 || bytes[0] !== 0xff || bytes[1] !== 0xd8) {
     return false;
   }
+  let sawFrame = false;
+  let sawScan = false;
   let i = 2;
   while (i + 1 < bytes.length) {
     if (bytes[i] !== 0xff) {
@@ -96,7 +102,17 @@ export function hasValidJpegStructure(bytes: Uint8Array): boolean {
     const marker = bytes[j];
     i = j + 1;
     if (marker === 0xd9) {
-      return true;
+      return sawFrame && sawScan;
+    }
+    // SOF0-SOF15 occupy C0-CF, excluding DHT (C4), JPG (C8), and DAC (CC).
+    if (
+      marker >= 0xc0 &&
+      marker <= 0xcf &&
+      marker !== 0xc4 &&
+      marker !== 0xc8 &&
+      marker !== 0xcc
+    ) {
+      sawFrame = true;
     }
     // Standalone markers carry no length field: repeated SOI, TEM, RST0-7.
     if (
@@ -115,6 +131,7 @@ export function hasValidJpegStructure(bytes: Uint8Array): boolean {
     }
     i += segmentLength;
     if (marker === 0xda) {
+      sawScan = true;
       // SOS: entropy-coded data follows the header. Scan to the next real
       // marker; FF 00 (stuffed data byte) and FF D0-D7 (restart) stay inside
       // the scan.

--- a/assistant/src/util/image-conversion.ts
+++ b/assistant/src/util/image-conversion.ts
@@ -61,27 +61,76 @@ export function isCompleteJpeg(bytes: Uint8Array): boolean {
   );
 }
 
-const JPEG_EOI = Buffer.from([0xff, 0xd9]);
-
 /**
- * Lenient JPEG truncation check for payloads of arbitrary origin: the SOI
- * header plus an EOI marker anywhere in the buffer. Unlike
- * {@link isCompleteJpeg} (exact tail framing, for sips output and cache
- * entries, which always end on EOI), this tolerates encoders that append
- * padding or metadata after the EOI. A truncated JPEG contains no EOI at all:
- * entropy-coded data byte-stuffs FF as FF 00, so FF D9 cannot appear inside
- * it by accident.
+ * Structural JPEG truncation check for payloads of arbitrary origin: walk the
+ * marker segments from SOI and report whether a terminal EOI is reached.
+ * Unlike {@link isCompleteJpeg} (exact tail framing, for sips output and
+ * cache entries, which always end on EOI), this tolerates encoders that
+ * append padding or metadata after the EOI.
+ *
+ * A raw byte search for FF D9 is not enough: length-delimited APP/COM
+ * segments (an EXIF thumbnail is itself a complete embedded JPEG) may contain
+ * FF D9, so a truncated file with an intact metadata prefix would pass.
+ * Walking segment boundaries skips those payloads entirely; only an EOI at
+ * the top level of the marker stream counts. Entropy-coded scan data is
+ * traversed byte-wise, where FF is stuffed as FF 00 and restart markers
+ * (D0-D7) continue the scan, so a marker byte there is unambiguous.
  */
-export function hasJpegEoi(bytes: Uint8Array): boolean {
-  return (
-    bytes.length >= 4 &&
-    bytes[0] === 0xff &&
-    bytes[1] === 0xd8 &&
-    Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength).includes(
-      JPEG_EOI,
-      2,
-    )
-  );
+export function hasValidJpegStructure(bytes: Uint8Array): boolean {
+  if (bytes.length < 4 || bytes[0] !== 0xff || bytes[1] !== 0xd8) {
+    return false;
+  }
+  let i = 2;
+  while (i + 1 < bytes.length) {
+    if (bytes[i] !== 0xff) {
+      return false;
+    }
+    // FF fill bytes before a marker are legal padding.
+    let j = i + 1;
+    while (j < bytes.length && bytes[j] === 0xff) {
+      j++;
+    }
+    if (j >= bytes.length) {
+      return false;
+    }
+    const marker = bytes[j];
+    i = j + 1;
+    if (marker === 0xd9) {
+      return true;
+    }
+    // Standalone markers carry no length field: repeated SOI, TEM, RST0-7.
+    if (
+      marker === 0xd8 ||
+      marker === 0x01 ||
+      (marker >= 0xd0 && marker <= 0xd7)
+    ) {
+      continue;
+    }
+    if (i + 1 >= bytes.length) {
+      return false;
+    }
+    const segmentLength = (bytes[i] << 8) | bytes[i + 1];
+    if (segmentLength < 2) {
+      return false;
+    }
+    i += segmentLength;
+    if (marker === 0xda) {
+      // SOS: entropy-coded data follows the header. Scan to the next real
+      // marker; FF 00 (stuffed data byte) and FF D0-D7 (restart) stay inside
+      // the scan.
+      while (i + 1 < bytes.length) {
+        if (
+          bytes[i] === 0xff &&
+          bytes[i + 1] !== 0x00 &&
+          !(bytes[i + 1] >= 0xd0 && bytes[i + 1] <= 0xd7)
+        ) {
+          break;
+        }
+        i++;
+      }
+    }
+  }
+  return false;
 }
 
 function readFromCache(key: string): Buffer | null {


### PR DESCRIPTION
## Problem

After in-place compaction, retained images could be mangled, and the next provider call failed with OpenAI 400 `The image data you provided does not represent a valid image` — on every subsequent turn, wedging the conversation. Reported via doctor session `f7d30858-a346-4b97-bb85-d5435752c986` (feedback `01a015ec-a2cb-74b9-9061-cb73ef0ef293`).

Root cause: the shared sips JPEG conversion cache (`util/image-conversion.ts`) wrote entries with a plain non-atomic `writeFileSync` inside a swallowed `catch`, and `readFromCache` returned whatever bytes were on disk — a zero-length buffer included (`if (cached)` is truthy for any Buffer object, empty or not). A torn write (disk full, kill mid-write, concurrent reader in another daemon process — the cache dir in `tmpdir()` is cross-process) left a truncated JPEG that surfaced later, when compaction re-hydrated a retained image through `optimizeImageForTransport` and baked the corrupt bytes into the rebuilt in-memory history.

The original uploads on disk were always valid; only the conversion cache was poisoned, which is why the failure looked inexplicable from the attachment store.

## Fix (three layers)

1. **Atomic cache writes** — `writeToCache` writes to a temp file and `renameSync`s into place, so readers never observe a partial entry.
2. **Validate on the way out** — `readFromCache` checks JPEG framing (SOI `FF D8` head, EOI `FF D9` tail); a poisoned entry is deleted and re-converted. `runSips` applies the same check to fresh conversions so a truncated sips output never enters the cache.
3. **Last-line compactor gate** — `buildRetainedImageBlocks` sniffs the optimized bytes (`sniffBase64ImageMimeType`) before embedding them and drops any payload that no longer parses as a known image format, logging the drop. It also now sniffs the source MIME from the stored bytes instead of trusting the filename extension.

With 1–2, layer 3's drop path should be nearly unreachable; it exists so compaction can never brick a conversation even if a future path feeds it bad bytes (dropping one retained image loses a picture; shipping it loses the conversation).

## Not in this PR

The `image-2.png` / `image-3.png` "could not be resolved against attachments" log line from the same report is a separate, milder bug: disk-side filename de-collision (`-N` suffixes) diverges from the manifest's `originalFilename` keying, so retention references can miss or resolve to the wrong same-named attachment. Fixing that means keying the manifest by attachment id, which touches the compaction prompt contract — follow-up.

## Testing

- New: `compactor-retained-image-validation.test.ts` (corrupt bytes dropped, valid retained, missing-vs-corrupt accounting).
- New in `image-conversion.test.ts`: `isCompleteJpeg` unit cases; darwin-gated poisoned-cache-entry test proving a truncated entry is discarded and replaced by a re-conversion.
- `bunx tsc --noEmit`, `bun run lint` clean; all compactor/compaction/attachment/image test files pass under CI-style per-file isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wd7U2V2EeWTrLUuQz3qiJn
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/40987" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
