### PR TITLE
Extract serverUse policy evaluation into a pure tool-policy helper

### DIFF
--- a/assistant/src/__tests__/credential-broker-server-use.test.ts
+++ b/assistant/src/__tests__/credential-broker-server-use.test.ts
@@ -46,6 +46,7 @@ import {
   _setMetadataPath,
   upsertCredentialMetadata,
 } from "../tools/credentials/metadata-store.js";
+import { serverUseDenialReason } from "../tools/credentials/tool-policy.js";
 
 // ---------------------------------------------------------------------------
 // Tests — serverUse (publish_page / unpublish_page regression)
@@ -624,5 +625,60 @@ describe("CredentialBroker.serverUseById", () => {
       throw new Error("expected denial");
     }
     expect(result.reason).toContain("no stored value");
+  });
+
+  test("tool denial reason matches the shared server-use policy exactly", async () => {
+    const meta = upsertCredentialMetadata("fal", "api_key", {
+      allowedTools: ["media_proxy"],
+    });
+    await setSecureKeyAsync(credentialKey("fal", "api_key"), "fal-secret-key");
+
+    const result = await broker.serverUseById({
+      credentialId: meta.credentialId,
+      requestingTool: "unauthorized_tool",
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      throw new Error("expected denial");
+    }
+    const expected = serverUseDenialReason(
+      meta,
+      "unauthorized_tool",
+      "fal",
+      "api_key",
+    );
+    if (!expected) {
+      throw new Error("expected a denial reason from the shared policy");
+    }
+    expect(result.reason).toBe(expected);
+  });
+
+  test("domain denial reason matches the shared server-use policy exactly", async () => {
+    const meta = upsertCredentialMetadata("github", "oauth_token", {
+      allowedTools: ["media_proxy"],
+      allowedDomains: ["github.com"],
+    });
+    await setSecureKeyAsync(credentialKey("github", "oauth_token"), "gho_test");
+
+    const result = await broker.serverUseById({
+      credentialId: meta.credentialId,
+      requestingTool: "media_proxy",
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      throw new Error("expected denial");
+    }
+    const expected = serverUseDenialReason(
+      meta,
+      "media_proxy",
+      "github",
+      "oauth_token",
+    );
+    if (!expected) {
+      throw new Error("expected a denial reason from the shared policy");
+    }
+    expect(result.reason).toBe(expected);
   });
 });

--- a/assistant/src/__tests__/tool-policy.test.ts
+++ b/assistant/src/__tests__/tool-policy.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "bun:test";
 
-import { isToolAllowed } from "../tools/credentials/tool-policy.js";
+import type { CredentialMetadata } from "../tools/credentials/metadata-store.js";
+import {
+  BROWSER_FILL_CAPABILITY,
+  isToolAllowed,
+  serverUseDenialReason,
+} from "../tools/credentials/tool-policy.js";
 
 describe("isToolAllowed", () => {
   // ── Allow cases ─────────────────────────────────────────────────────
@@ -70,5 +75,96 @@ describe("isToolAllowed", () => {
     expect(
       isToolAllowed("Browser_Fill_Credential", ["browser_fill_credential"]),
     ).toBe(false);
+  });
+});
+
+describe("serverUseDenialReason", () => {
+  function metadata(
+    overrides: Partial<CredentialMetadata> = {},
+  ): CredentialMetadata {
+    return {
+      credentialId: "cred-1",
+      service: "acp",
+      field: "claude_oauth_token",
+      allowedTools: ["acp_spawn"],
+      allowedDomains: [],
+      createdAt: 0,
+      updatedAt: 0,
+      ...overrides,
+    };
+  }
+
+  test("denies when metadata is missing", () => {
+    expect(
+      serverUseDenialReason(
+        undefined,
+        "acp_spawn",
+        "acp",
+        "claude_oauth_token",
+      ),
+    ).toBe("No credential found for acp/claude_oauth_token");
+  });
+
+  test("denies fail-closed when allowedTools is empty", () => {
+    const reason = serverUseDenialReason(
+      metadata({ allowedTools: [] }),
+      "acp_spawn",
+      "acp",
+      "claude_oauth_token",
+    );
+    expect(reason).toContain(
+      'Tool "acp_spawn" is not allowed to use credential acp/claude_oauth_token.',
+    );
+    expect(reason).toContain("No tools are currently allowed");
+  });
+
+  test("denies when allowedTools omits the requesting tool", () => {
+    const reason = serverUseDenialReason(
+      metadata({ allowedTools: ["bash", "web_fetch"] }),
+      "acp_spawn",
+      "acp",
+      "claude_oauth_token",
+    );
+    expect(reason).toContain(
+      'Tool "acp_spawn" is not allowed to use credential acp/claude_oauth_token.',
+    );
+    expect(reason).toContain("Allowed tools: bash, web_fetch.");
+  });
+
+  test("allows when a legacy alias canonicalizes to the requesting tool", () => {
+    expect(
+      serverUseDenialReason(
+        metadata({ allowedTools: ["browser_fill_credential"] }),
+        BROWSER_FILL_CAPABILITY,
+        "acp",
+        "claude_oauth_token",
+      ),
+    ).toBeUndefined();
+  });
+
+  test("denies a domain-restricted credential", () => {
+    expect(
+      serverUseDenialReason(
+        metadata({ allowedDomains: ["example.com", "example.org"] }),
+        "acp_spawn",
+        "acp",
+        "claude_oauth_token",
+      ),
+    ).toBe(
+      "Credential acp/claude_oauth_token has domain restrictions " +
+        "(example.com, example.org) and cannot be used server-side. " +
+        "Remove domain restrictions or use a separate credential without domain policy.",
+    );
+  });
+
+  test("allows fully-permitted metadata", () => {
+    expect(
+      serverUseDenialReason(
+        metadata(),
+        "acp_spawn",
+        "acp",
+        "claude_oauth_token",
+      ),
+    ).toBeUndefined();
   });
 });

--- a/assistant/src/tools/credentials/broker.ts
+++ b/assistant/src/tools/credentials/broker.ts
@@ -339,30 +339,17 @@ export class CredentialBroker {
 
     const { metadata } = resolved;
 
-    // Tool policy enforcement
-    if (!isToolAllowed(request.requestingTool, metadata.allowedTools)) {
-      return {
-        success: false,
-        reason: toolNotAllowedReason(
-          request.requestingTool,
-          metadata.service,
-          metadata.field,
-          metadata.allowedTools,
-        ),
-      };
-    }
-
-    // Domain policy enforcement - credentials with domain restrictions are
-    // scoped to browser use on those domains and cannot be used server-side.
-    const domains = metadata.allowedDomains ?? [];
-    if (domains.length > 0) {
-      return {
-        success: false,
-        reason:
-          `Credential ${metadata.service}/${metadata.field} has domain restrictions ` +
-          `(${domains.join(", ")}) and cannot be used server-side. ` +
-          "Remove domain restrictions or use a separate credential without domain policy.",
-      };
+    // Shared server-use policy: the ID lookup above is the only by-ID-specific
+    // gate, so tool and domain enforcement come from the same helper serverUse
+    // uses.
+    const denialReason = serverUseDenialReason(
+      metadata,
+      request.requestingTool,
+      metadata.service,
+      metadata.field,
+    );
+    if (denialReason) {
+      return { success: false, reason: denialReason };
     }
 
     // Fail-closed: verify the secret value actually exists in secure storage.

--- a/assistant/src/tools/credentials/broker.ts
+++ b/assistant/src/tools/credentials/broker.ts
@@ -18,36 +18,16 @@ import type {
 import { isDomainAllowed } from "./domain-policy.js";
 import { getCredentialMetadata } from "./metadata-store.js";
 import { resolveById } from "./resolve.js";
-import { isToolAllowed } from "./tool-policy.js";
+import {
+  isToolAllowed,
+  serverUseDenialReason,
+  toolNotAllowedReason,
+} from "./tool-policy.js";
 
 const log = getLogger("credential-broker");
 
 /** Tokens expire after 5 minutes to limit the window for using stale/revoked credentials. */
 const TOKEN_TTL_MS = 5 * 60 * 1000;
-
-/**
- * Remediation for a credential whose allowed_tools list is empty. Points at
- * `credentials prompt` (not inline `credentials set`, which agent shells
- * refuse): the secure prompt re-collects the value and sets allowed_tools.
- */
-const NO_TOOLS_ALLOWED_REMEDIATION =
-  "No tools are currently allowed - grant access via `assistant credentials prompt --service <service> --field <field> --label <label> --allowed-tools <tools>` (re-collects the value securely and sets allowed_tools).";
-
-/** Denial reason for a tool that is not in a credential's allowed_tools list. */
-function toolNotAllowedReason(
-  toolName: string,
-  service: string,
-  field: string,
-  allowedTools: string[] | undefined,
-): string {
-  const tools = allowedTools ?? [];
-  return (
-    `Tool "${toolName}" is not allowed to use credential ${service}/${field}. ` +
-    (tools.length === 0
-      ? NO_TOOLS_ALLOWED_REMEDIATION
-      : `Allowed tools: ${tools.join(", ")}.`)
-  );
-}
 
 /**
  * Credential broker that issues single-use tokens for policy-checked credential access.
@@ -292,36 +272,14 @@ export class CredentialBroker {
     request: ServerUseRequest<T>,
   ): Promise<ServerUseResult<T>> {
     const metadata = getCredentialMetadata(request.service, request.field);
-    if (!metadata) {
-      return {
-        success: false,
-        reason: `No credential found for ${request.service}/${request.field}`,
-      };
-    }
-
-    if (!isToolAllowed(request.toolName, metadata.allowedTools)) {
-      return {
-        success: false,
-        reason: toolNotAllowedReason(
-          request.toolName,
-          request.service,
-          request.field,
-          metadata.allowedTools,
-        ),
-      };
-    }
-
-    // Domain policy enforcement - credentials with domain restrictions are
-    // scoped to browser use on those domains and cannot be used server-side.
-    const serverDomains = metadata.allowedDomains ?? [];
-    if (serverDomains.length > 0) {
-      return {
-        success: false,
-        reason:
-          `Credential ${request.service}/${request.field} has domain restrictions ` +
-          `(${serverDomains.join(", ")}) and cannot be used server-side. ` +
-          "Remove domain restrictions or use a separate credential without domain policy.",
-      };
+    const denialReason = serverUseDenialReason(
+      metadata,
+      request.toolName,
+      request.service,
+      request.field,
+    );
+    if (denialReason) {
+      return { success: false, reason: denialReason };
     }
 
     const storageKey = credentialKey(request.service, request.field);

--- a/assistant/src/tools/credentials/tool-policy.ts
+++ b/assistant/src/tools/credentials/tool-policy.ts
@@ -5,6 +5,8 @@
  * based on the credential's allowed tools list.
  */
 
+import type { CredentialMetadata } from "./metadata-store.js";
+
 /**
  * Canonical capability key for browser-based credential fills.
  *
@@ -63,4 +65,69 @@ export function isToolAllowed(
   return allowedTools.some(
     (allowed) => resolveCanonical(allowed) === canonical,
   );
+}
+
+/**
+ * Remediation for a credential whose allowed_tools list is empty. Points at
+ * `credentials prompt` (not inline `credentials set`, which agent shells
+ * refuse): the secure prompt re-collects the value and sets allowed_tools.
+ */
+const NO_TOOLS_ALLOWED_REMEDIATION =
+  "No tools are currently allowed - grant access via `assistant credentials prompt --service <service> --field <field> --label <label> --allowed-tools <tools>` (re-collects the value securely and sets allowed_tools).";
+
+/** Denial reason for a tool that is not in a credential's allowed_tools list. */
+export function toolNotAllowedReason(
+  toolName: string,
+  service: string,
+  field: string,
+  allowedTools: string[] | undefined,
+): string {
+  const tools = allowedTools ?? [];
+  return (
+    `Tool "${toolName}" is not allowed to use credential ${service}/${field}. ` +
+    (tools.length === 0
+      ? NO_TOOLS_ALLOWED_REMEDIATION
+      : `Allowed tools: ${tools.join(", ")}.`)
+  );
+}
+
+/**
+ * Evaluate the policy that gates server-side use of a credential.
+ *
+ * Pure: it inspects only the metadata it is handed, performs no store reads,
+ * and has no side effects. Returns the denial reason, or `undefined` when the
+ * tool may read the credential server-side.
+ *
+ * Domain-restricted credentials are scoped to browser fills on those domains,
+ * so they are refused here even when the tool itself is allowed.
+ */
+export function serverUseDenialReason(
+  metadata: CredentialMetadata | undefined,
+  toolName: string,
+  service: string,
+  field: string,
+): string | undefined {
+  if (!metadata) {
+    return `No credential found for ${service}/${field}`;
+  }
+
+  if (!isToolAllowed(toolName, metadata.allowedTools)) {
+    return toolNotAllowedReason(
+      toolName,
+      service,
+      field,
+      metadata.allowedTools,
+    );
+  }
+
+  const serverDomains = metadata.allowedDomains ?? [];
+  if (serverDomains.length > 0) {
+    return (
+      `Credential ${service}/${field} has domain restrictions ` +
+      `(${serverDomains.join(", ")}) and cannot be used server-side. ` +
+      "Remove domain restrictions or use a separate credential without domain policy."
+    );
+  }
+
+  return undefined;
 }


### PR DESCRIPTION
## Summary
- Extracts the three pre-read denial branches of credentialBroker.serverUse into a pure serverUseDenialReason helper in tool-policy.ts
- Zero behavior change; reason strings byte-identical
- Adds unit tests covering all denial branches including alias canonicalization

Part of plan: acp-connect-split-brain.md (PR 1 of 5)