### PR TITLE
Record ACP Connect card state in the chat debug dump and diagnose self-heal dismissals

### DIFF
--- a/clients/web/src/domains/chat/hooks/use-chat-debug-registration.ts
+++ b/clients/web/src/domains/chat/hooks/use-chat-debug-registration.ts
@@ -80,6 +80,13 @@ export function useChatDebugRegistration({
         isSubmittingQuestion: state.isSubmittingQuestion,
         isQuestionCardDismissed: state.isQuestionCardDismissed,
         inlineConfirmationToolCallId: state.inlineConfirmationToolCallId,
+        pendingAcpConnect: state.pendingAcpConnect,
+        // The store holds a Set, which JSON-serializes to `{}` in the feedback
+        // bundle; sort so repeated captures read the same.
+        dismissedAcpConnectToolUseIds: [
+          ...state.dismissedAcpConnectToolUseIds,
+        ].sort(),
+        pendingAcpContinue: state.pendingAcpContinue,
       };
     },
     getScrollPagination: () => {

--- a/clients/web/src/domains/chat/transcript/acp-connect-affordance.test.tsx
+++ b/clients/web/src/domains/chat/transcript/acp-connect-affordance.test.tsx
@@ -5,13 +5,15 @@
  * Covers the version gate and the live-status self-heal: the affordance renders
  * its Connect button when the daemon supports Connect, renders nothing (falling
  * back to the plain error rendering) against a daemon too old to serve the
- * routes, and retires itself when Claude is already connected. Which failed tool
+ * routes, and retires itself when Claude is already connected (leaving a
+ * diagnostic breadcrumb behind). Which failed tool
  * call raises the prompt — and its reseed survival — is covered in
  * `acp-connect-prompt.test.ts`.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import {
+  act,
   cleanup,
   fireEvent,
   render,
@@ -87,7 +89,26 @@ mock.module("@vellumai/design-library/components/typography", () => ({
   ),
 }));
 
+const actualDiagnostics = await import("@/lib/diagnostics");
+const recordedDiagnostics: Array<{
+  kind: string;
+  details: Record<string, unknown>;
+}> = [];
+mock.module("@/lib/diagnostics", () => ({
+  ...actualDiagnostics,
+  recordDiagnostic: (kind: string, details: Record<string, unknown> = {}) => {
+    recordedDiagnostics.push({ kind, details });
+  },
+}));
+
 const { AcpConnectAffordance } = await import("./acp-connect-affordance");
+
+/** Let the resolved `isClaudeConnected` promise settle inside React's act. */
+async function flushConnectedCheck() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
 
 beforeEach(() => {
   supported = true;
@@ -95,7 +116,12 @@ beforeEach(() => {
   popupBlocked = false;
   startMode = "loopback";
   exchangeShouldFail = false;
-  useInteractionStore.getState().clearAcpContinue();
+  recordedDiagnostics.length = 0;
+  useInteractionStore.setState({
+    pendingAcpConnect: null,
+    dismissedAcpConnectToolUseIds: new Set<string>(),
+    pendingAcpContinue: false,
+  });
 });
 
 afterEach(() => {
@@ -140,6 +166,57 @@ describe("AcpConnectAffordance", () => {
     await waitFor(() => {
       expect(screen.queryByTestId("acp-connect-affordance")).toBeNull();
     });
+  });
+
+  test("records a diagnostic for every self-heal dismissal", async () => {
+    alreadyConnected = true;
+    useInteractionStore
+      .getState()
+      .showAcpConnect({ toolUseId: "toolu-acp-1", reason: "missing" });
+
+    render(<AcpConnectAffordance assistantId="assistant-123" />);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("acp-connect-affordance")).toBeNull();
+    });
+    // The card vanishing is invisible in a feedback bundle without this
+    // breadcrumb, so it must carry who/which-call/why.
+    expect(recordedDiagnostics).toEqual([
+      {
+        kind: "acp_connect_self_heal_dismiss",
+        details: {
+          assistantId: "assistant-123",
+          toolUseId: "toolu-acp-1",
+          reason: "missing",
+        },
+      },
+    ]);
+  });
+
+  test("records nothing for an auth_required prompt, which skips the connected check", async () => {
+    alreadyConnected = true;
+    useInteractionStore
+      .getState()
+      .showAcpConnect({ toolUseId: "toolu-acp-1", reason: "auth_required" });
+
+    render(<AcpConnectAffordance assistantId="assistant-123" />);
+    await flushConnectedCheck();
+
+    expect(screen.getByTestId("acp-connect-affordance")).not.toBeNull();
+    expect(recordedDiagnostics).toEqual([]);
+  });
+
+  test("records nothing when the connected check answers false", async () => {
+    alreadyConnected = false;
+    useInteractionStore
+      .getState()
+      .showAcpConnect({ toolUseId: "toolu-acp-1", reason: "missing" });
+
+    render(<AcpConnectAffordance assistantId="assistant-123" />);
+    await flushConnectedCheck();
+
+    expect(screen.getByTestId("acp-connect-affordance")).not.toBeNull();
+    expect(recordedDiagnostics).toEqual([]);
   });
 
   test("opens the sign-in tab and advances to awaiting-capture", async () => {

--- a/clients/web/src/domains/chat/transcript/acp-connect-affordance.test.tsx
+++ b/clients/web/src/domains/chat/transcript/acp-connect-affordance.test.tsx
@@ -90,14 +90,17 @@ mock.module("@vellumai/design-library/components/typography", () => ({
 }));
 
 const actualDiagnostics = await import("@/lib/diagnostics");
-const recordedDiagnostics: Array<{
+const recordedLifecycleDiagnostics: Array<{
   kind: string;
   details: Record<string, unknown>;
 }> = [];
 mock.module("@/lib/diagnostics", () => ({
   ...actualDiagnostics,
-  recordDiagnostic: (kind: string, details: Record<string, unknown> = {}) => {
-    recordedDiagnostics.push({ kind, details });
+  recordLifecycleDiagnostic: (
+    kind: string,
+    details: Record<string, unknown> = {},
+  ) => {
+    recordedLifecycleDiagnostics.push({ kind, details });
   },
 }));
 
@@ -116,7 +119,7 @@ beforeEach(() => {
   popupBlocked = false;
   startMode = "loopback";
   exchangeShouldFail = false;
-  recordedDiagnostics.length = 0;
+  recordedLifecycleDiagnostics.length = 0;
   useInteractionStore.setState({
     pendingAcpConnect: null,
     dismissedAcpConnectToolUseIds: new Set<string>(),
@@ -168,7 +171,7 @@ describe("AcpConnectAffordance", () => {
     });
   });
 
-  test("records a diagnostic for every self-heal dismissal", async () => {
+  test("records a lifecycle diagnostic for every self-heal dismissal", async () => {
     alreadyConnected = true;
     useInteractionStore
       .getState()
@@ -180,8 +183,9 @@ describe("AcpConnectAffordance", () => {
       expect(screen.queryByTestId("acp-connect-affordance")).toBeNull();
     });
     // The card vanishing is invisible in a feedback bundle without this
-    // breadcrumb, so it must carry who/which-call/why.
-    expect(recordedDiagnostics).toEqual([
+    // breadcrumb, so it must carry who/which-call/why, and it lands in the
+    // durable ring that streaming volume cannot evict.
+    expect(recordedLifecycleDiagnostics).toEqual([
       {
         kind: "acp_connect_self_heal_dismiss",
         details: {
@@ -203,7 +207,7 @@ describe("AcpConnectAffordance", () => {
     await flushConnectedCheck();
 
     expect(screen.getByTestId("acp-connect-affordance")).not.toBeNull();
-    expect(recordedDiagnostics).toEqual([]);
+    expect(recordedLifecycleDiagnostics).toEqual([]);
   });
 
   test("records nothing when the connected check answers false", async () => {
@@ -216,7 +220,7 @@ describe("AcpConnectAffordance", () => {
     await flushConnectedCheck();
 
     expect(screen.getByTestId("acp-connect-affordance")).not.toBeNull();
-    expect(recordedDiagnostics).toEqual([]);
+    expect(recordedLifecycleDiagnostics).toEqual([]);
   });
 
   test("opens the sign-in tab and advances to awaiting-capture", async () => {

--- a/clients/web/src/domains/chat/transcript/acp-connect-affordance.tsx
+++ b/clients/web/src/domains/chat/transcript/acp-connect-affordance.tsx
@@ -11,7 +11,7 @@ import {
   type UseConnectClaudeResult,
 } from "@/hooks/use-connect-claude";
 import { useSupportsAcpConnect } from "@/lib/backwards-compat/use-supports-acp-connect";
-import { recordDiagnostic } from "@/lib/diagnostics";
+import { recordLifecycleDiagnostic } from "@/lib/diagnostics";
 import { isElectron } from "@/runtime/is-electron";
 
 // ---------------------------------------------------------------------------
@@ -104,9 +104,11 @@ function AcpConnectAffordanceInner({ assistantId }: { assistantId: string }) {
     }
     // Leave a breadcrumb: the card flashing and vanishing is otherwise silent,
     // and a self-heal dismissal next to a fresh missing-token failure is the
-    // signature of a status/spawn predicate mismatch.
+    // signature of a status/spawn predicate mismatch. It goes in the durable
+    // lifecycle ring because streaming floods the high-volume ring, which held
+    // only minutes of history in the bundle that motivated this breadcrumb.
     const store = useInteractionStore.getState();
-    recordDiagnostic("acp_connect_self_heal_dismiss", {
+    recordLifecycleDiagnostic("acp_connect_self_heal_dismiss", {
       assistantId,
       toolUseId: store.pendingAcpConnect?.toolUseId ?? null,
       reason: store.pendingAcpConnect?.reason ?? "missing",

--- a/clients/web/src/domains/chat/transcript/acp-connect-affordance.tsx
+++ b/clients/web/src/domains/chat/transcript/acp-connect-affordance.tsx
@@ -11,6 +11,7 @@ import {
   type UseConnectClaudeResult,
 } from "@/hooks/use-connect-claude";
 import { useSupportsAcpConnect } from "@/lib/backwards-compat/use-supports-acp-connect";
+import { recordDiagnostic } from "@/lib/diagnostics";
 import { isElectron } from "@/runtime/is-electron";
 
 // ---------------------------------------------------------------------------
@@ -98,10 +99,20 @@ function AcpConnectAffordanceInner({ assistantId }: { assistantId: string }) {
   }, [assistantId, reason]);
 
   useEffect(() => {
-    if (alreadyConnected && connection.phase === "idle") {
-      useInteractionStore.getState().dismissAcpConnect();
+    if (!alreadyConnected || connection.phase !== "idle") {
+      return;
     }
-  }, [alreadyConnected, connection.phase]);
+    // Leave a breadcrumb: the card flashing and vanishing is otherwise silent,
+    // and a self-heal dismissal next to a fresh missing-token failure is the
+    // signature of a status/spawn predicate mismatch.
+    const store = useInteractionStore.getState();
+    recordDiagnostic("acp_connect_self_heal_dismiss", {
+      assistantId,
+      toolUseId: store.pendingAcpConnect?.toolUseId ?? null,
+      reason: store.pendingAcpConnect?.reason ?? "missing",
+    });
+    store.dismissAcpConnect();
+  }, [alreadyConnected, assistantId, connection.phase]);
 
   // When the in-card connect flow completes, signal the chat view to
   // auto-continue the failed task (via a hidden "retry" send) so the user

--- a/clients/web/src/domains/chat/utils/debug-api.test.ts
+++ b/clients/web/src/domains/chat/utils/debug-api.test.ts
@@ -75,6 +75,9 @@ const DEFAULT_PENDING_INTERACTIONS: PendingInteractionsSnapshot = {
   isSubmittingQuestion: false,
   isQuestionCardDismissed: false,
   inlineConfirmationToolCallId: null,
+  pendingAcpConnect: null,
+  dismissedAcpConnectToolUseIds: [],
+  pendingAcpContinue: false,
 };
 
 interface MakeRefsOverrides extends Partial<ChatDebugRefs> {
@@ -810,6 +813,50 @@ describe("createChatDebugApi.listPendingInteractions", () => {
     expect(captured.pendingConfirmation?.input).toBe(input);
     expect(input).toEqual({ api_key: "sk-live-secret-value" });
     expect(snapshot.pendingConfirmation?.input).not.toBe(input);
+  });
+
+  test("forwards the ACP Connect card state", () => {
+    const api = createChatDebugApi(
+      makeRefs({
+        pendingInteractions: {
+          pendingAcpConnect: {
+            toolUseId: "toolu-acp-1",
+            reason: "auth_required",
+          },
+          dismissedAcpConnectToolUseIds: ["toolu-acp-0", "toolu-acp-2"],
+          pendingAcpContinue: true,
+        },
+      }),
+    );
+    const snapshot = api.listPendingInteractions();
+    expect(snapshot.pendingAcpConnect).toEqual({
+      toolUseId: "toolu-acp-1",
+      reason: "auth_required",
+    });
+    expect(snapshot.dismissedAcpConnectToolUseIds).toEqual([
+      "toolu-acp-0",
+      "toolu-acp-2",
+    ]);
+    expect(snapshot.pendingAcpContinue).toBe(true);
+  });
+
+  test("keeps the ACP Connect card state when a confirmation is redacted", () => {
+    const api = createChatDebugApi(
+      makeRefs({
+        pendingInteractions: {
+          pendingConfirmation: {
+            requestId: "req-confirm-1",
+            input: { api_key: "sk-live-secret-value" },
+          },
+          pendingAcpConnect: { toolUseId: "toolu-acp-1" },
+        },
+      }),
+    );
+    const snapshot = api.listPendingInteractions();
+    expect(snapshot.pendingConfirmation?.input).toEqual({
+      api_key: "[redacted]",
+    });
+    expect(snapshot.pendingAcpConnect?.toolUseId).toBe("toolu-acp-1");
   });
 
   test("leaves a confirmation without input untouched", () => {

--- a/clients/web/src/domains/chat/utils/debug-api.ts
+++ b/clients/web/src/domains/chat/utils/debug-api.ts
@@ -33,6 +33,7 @@ import {
 import { fetchConversationMessages as defaultFetchConversationMessages } from "@/domains/chat/api/messages";
 import { useStreamStore } from "@/domains/chat/stream-store";
 import type {
+  PendingAcpConnectState,
   PendingConfirmationState,
   PendingContactRequestState,
   PendingQuestionState,
@@ -151,6 +152,16 @@ export interface PendingInteractionsSnapshot {
   /** Tool-call id paired with the currently-rendered inline confirmation,
    *  or `null` when no inline confirmation is active. */
   inlineConfirmationToolCallId: string | null;
+  /** The inline "Connect Claude Code" prompt currently raised by a failed
+   *  `acp_spawn`, or `null` when no Connect card is showing. */
+  pendingAcpConnect: PendingAcpConnectState | null;
+  /** Tool-call ids whose Connect card was dismissed in this session, sorted
+   *  so the dump is stable across captures. A dismissed id suppresses the
+   *  card even when the same failure is replayed by a resync. */
+  dismissedAcpConnectToolUseIds: string[];
+  /** True while a completed connect flow is waiting for the chat view to
+   *  fire its hidden continuation send. */
+  pendingAcpContinue: boolean;
 }
 
 /**
@@ -833,7 +844,7 @@ export function createChatDebugApi(refs: ChatDebugRefs): ChatDebugApi {
       "  .serverMessages()          [experimental] fetch /v1/history and return the server snapshot response (messages + seq)",
       "                              (diff against getClientMessages() manually in the console)",
       "  .listPendingInteractions() frontend-tracked pending prompts (secret/confirmation/",
-      "                              contact-request/question) and submission flags",
+      "                              contact-request/question/acp-connect) and submission flags",
       "  .getScrollState()          scroll geometry + pagination — why can't I scroll up?",
       "                              .diagnosis gives a human-readable summary",
       "  .getDiagnostics(prefix?)   main diagnostics ring (per-delta SSE / drop gates / history applies),",


### PR DESCRIPTION
## Summary
- Adds pendingAcpConnect, dismissedAcpConnectToolUseIds, and pendingAcpContinue to the chat debug interactions snapshot
- Records an acp_connect_self_heal_dismiss diagnostic whenever the Connect card retires itself after an already-connected check
- Extends affordance and debug-api tests

Part of plan: acp-connect-split-brain.md (PR 5 of 5)