### PR TITLE
Make the Connect Claude status check evaluate the exact spawn-time broker policy

### DIFF
--- a/assistant/src/acp/__tests__/acp-claude-oauth.test.ts
+++ b/assistant/src/acp/__tests__/acp-claude-oauth.test.ts
@@ -1,13 +1,21 @@
 /**
  * Tests for the Claude OAuth config + capture/store helpers.
  *
- * The store helper reaches into secure-keys and the ACP credential policy, so
- * we mock both (wired BEFORE importing the module under test via dynamic
- * import) and assert the vault write targets `credential/acp/claude_oauth_token`
- * and throws when the backend rejects the write.
+ * The store helper reaches into secure-keys, so we mock that (wired BEFORE
+ * importing the module under test via dynamic import) and assert the vault
+ * write targets `credential/acp/claude_oauth_token` and throws when the backend
+ * rejects the write.
+ *
+ * The ACP credential policy is NOT mocked: `hasAcpClaudeToken` has to answer
+ * exactly what the spawn-time broker read would, so it is exercised against the
+ * real metadata store (pointed at a temp dir) and the real policy evaluation.
  */
 
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { randomBytes } from "node:crypto";
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 // ---------------------------------------------------------------------------
 // Mocks — wired BEFORE importing the module via dynamic import.
@@ -19,20 +27,14 @@ const setSecureKeyAsync = mock(
   async (_account: string, _value: string) => storeReturn,
 );
 const getSecureKeyAsync = mock(async (_account: string) => getReturn);
-const grantAcpSpawnPolicy = mock(
-  (_field: string, _usageDescription: string) => {},
-);
-let spawnCanRead = true;
-const acpSpawnCanReadCredential = mock((_field: string) => spawnCanRead);
 
 mock.module("../../security/secure-keys.js", () => ({
   setSecureKeyAsync,
   getSecureKeyAsync,
 }));
-mock.module("../prepare-agent-env.js", () => ({
-  grantAcpSpawnPolicy,
-  acpSpawnCanReadCredential,
-}));
+
+const { _setMetadataPath, getCredentialMetadata, upsertCredentialMetadata } =
+  await import("../../tools/credentials/metadata-store.js");
 
 const {
   CLAUDE_OAUTH_CONFIG,
@@ -43,14 +45,31 @@ const {
   hasAcpClaudeToken,
 } = await import("../acp-claude-oauth.js");
 
+const ACP_SERVICE = "acp";
+const OAUTH_FIELD = "claude_oauth_token";
+const ACP_SPAWN_TOOL = "acp_spawn";
+
+const TEST_DIR = join(
+  tmpdir(),
+  `vellum-acp-claude-oauth-test-${randomBytes(4).toString("hex")}`,
+);
+
+function oauthMetadata() {
+  return getCredentialMetadata(ACP_SERVICE, OAUTH_FIELD);
+}
+
 beforeEach(() => {
+  mkdirSync(TEST_DIR, { recursive: true });
+  _setMetadataPath(join(TEST_DIR, "metadata.json"));
   storeReturn = true;
   getReturn = undefined;
-  spawnCanRead = true;
   setSecureKeyAsync.mockClear();
   getSecureKeyAsync.mockClear();
-  grantAcpSpawnPolicy.mockClear();
-  acpSpawnCanReadCredential.mockClear();
+});
+
+afterEach(() => {
+  _setMetadataPath(null);
+  rmSync(TEST_DIR, { recursive: true, force: true });
 });
 
 // ---------------------------------------------------------------------------
@@ -150,6 +169,10 @@ describe("parseManualClaudeCode", () => {
 
 describe("storeAcpClaudeToken", () => {
   test("writes the token and force-grants the acp_spawn policy (repairs a denied policy)", async () => {
+    upsertCredentialMetadata(ACP_SERVICE, OAUTH_FIELD, {
+      allowedTools: ["other_tool"],
+    });
+
     await storeAcpClaudeToken("sk-ant-oat-token");
 
     expect(setSecureKeyAsync).toHaveBeenCalledTimes(1);
@@ -159,8 +182,10 @@ describe("storeAcpClaudeToken", () => {
     );
     // grant (union), not merely ensure (preserve) — so an explicit Connect
     // repairs a credential whose allowedTools omitted acp_spawn.
-    expect(grantAcpSpawnPolicy).toHaveBeenCalledTimes(1);
-    expect(grantAcpSpawnPolicy.mock.calls[0][0]).toBe("claude_oauth_token");
+    expect(oauthMetadata()?.allowedTools).toEqual([
+      "other_tool",
+      ACP_SPAWN_TOOL,
+    ]);
   });
 
   test("throws when the secure store rejects the write", async () => {
@@ -169,7 +194,7 @@ describe("storeAcpClaudeToken", () => {
     await expect(storeAcpClaudeToken("sk-ant-oat-token")).rejects.toThrow(
       /Failed to store/,
     );
-    expect(grantAcpSpawnPolicy).not.toHaveBeenCalled();
+    expect(oauthMetadata()).toBeUndefined();
   });
 });
 
@@ -202,13 +227,60 @@ describe("hasAcpClaudeToken", () => {
     expect(await hasAcpClaudeToken()).toBe(false);
   });
 
+  test("reports true with no metadata at all (the spawn would create it)", async () => {
+    getReturn = "sk-ant-oat-token";
+    expect(await hasAcpClaudeToken()).toBe(true);
+  });
+
+  test("reports true for metadata with an empty allowedTools (the spawn would grant acp_spawn)", async () => {
+    upsertCredentialMetadata(ACP_SERVICE, OAUTH_FIELD, { allowedTools: [] });
+    getReturn = "sk-ant-oat-token";
+
+    expect(await hasAcpClaudeToken()).toBe(true);
+  });
+
   test("reports false when the spawn policy can't read the token (denied allowedTools)", async () => {
     // A valid OAuth token is stored, but an explicit `allowedTools` that omits
     // `acp_spawn` means the broker denies the spawn read. Reporting "connected"
     // would self-dismiss the card and trap the user in a missing-token loop, so
     // it stays not-connected to keep the repair CTA visible.
+    upsertCredentialMetadata(ACP_SERVICE, OAUTH_FIELD, {
+      allowedTools: ["other_tool"],
+    });
     getReturn = "sk-ant-oat-token";
-    spawnCanRead = false;
+
     expect(await hasAcpClaudeToken()).toBe(false);
+  });
+
+  test("reports false for a domain-restricted credential the broker refuses server-side", async () => {
+    // acp_spawn is allowed, but a non-empty allowedDomains scopes the credential
+    // to browser fills, so every spawn read is denied. The status check has to
+    // see that too, otherwise the Connect card self-dismisses while acp_spawn
+    // keeps failing with the missing-token marker.
+    upsertCredentialMetadata(ACP_SERVICE, OAUTH_FIELD, {
+      allowedTools: [ACP_SPAWN_TOOL],
+      allowedDomains: ["api.anthropic.com"],
+    });
+    getReturn = "sk-ant-oat-token";
+
+    expect(await hasAcpClaudeToken()).toBe(false);
+  });
+
+  test("writes nothing to the metadata store (the status route is a GET)", async () => {
+    upsertCredentialMetadata(ACP_SERVICE, OAUTH_FIELD, { allowedTools: [] });
+    getReturn = "sk-ant-oat-token";
+    const before = oauthMetadata();
+
+    await hasAcpClaudeToken();
+
+    expect(oauthMetadata()).toEqual(before);
+  });
+
+  test("creates no metadata when there is none to begin with", async () => {
+    getReturn = "sk-ant-oat-token";
+
+    await hasAcpClaudeToken();
+
+    expect(oauthMetadata()).toBeUndefined();
   });
 });

--- a/assistant/src/acp/__tests__/prepare-agent-env.test.ts
+++ b/assistant/src/acp/__tests__/prepare-agent-env.test.ts
@@ -1,128 +1,86 @@
 /**
- * Tests for `prepareAgentEnv` — the shared helper that injects required env
+ * Tests for `prepareAgentEnv`, the shared helper that injects required env
  * vars onto an `AcpAgentConfig` and preflights that they're set.
  *
  * The route-level test in `runtime/routes/acp-routes.test.ts` covers the same
  * behavior through the HTTP handler; these tests pin the helper in isolation
  * so the contract is clear and a future refactor can't silently break it.
  *
- * Credential reads go through the credential broker (`serverUse`), so we
- * mock the broker and metadata store rather than the raw secure-keys backend.
+ * Credential reads go through the credential broker (`serverUse`), which is
+ * exercised for real here: the metadata store and the encrypted secure-key
+ * store are pointed at a temp dir, so the tool and domain policy these tests
+ * observe is the same policy production evaluates.
  */
 
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { randomBytes } from "node:crypto";
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
+import { setStorePathForTesting } from "../../__tests__/encrypted-store-test-helpers.js";
 import { FailedDependencyError } from "../../runtime/routes/errors.js";
+import { credentialKey } from "../../security/credential-key.js";
+import {
+  _resetBackend,
+  setSecureKeyAsync,
+} from "../../security/secure-keys.js";
+import { credentialBroker } from "../../tools/credentials/broker.js";
+import {
+  _setMetadataPath,
+  deleteCredentialMetadata,
+  getCredentialMetadata,
+  upsertCredentialMetadata,
+} from "../../tools/credentials/metadata-store.js";
+import { ACP_OAUTH_TOKEN_FIELD, ACP_SERVICE } from "../acp-credentials.js";
+import {
+  ACP_CLAUDE_OAUTH_MISSING_CODE,
+  acpSpawnCredentialDenialReason,
+  ensureAcpCredentialPolicy,
+  grantAcpSpawnPolicy,
+  prepareAgentEnv,
+} from "../prepare-agent-env.js";
 
-// ---------------------------------------------------------------------------
-// Stubs — wired BEFORE importing the helper via dynamic import.
-// ---------------------------------------------------------------------------
+const ACP_SPAWN_TOOL = "acp_spawn";
 
-/** Simulates the credential metadata store. */
-const metadataStore = new Map<
-  string,
-  { allowedTools: string[]; usageDescription?: string }
->();
-
-mock.module("../../tools/credentials/metadata-store.js", () => ({
-  getCredentialMetadata: (service: string, field: string) => {
-    const key = `${service}/${field}`;
-    const entry = metadataStore.get(key);
-    if (!entry) {
-      return undefined;
-    }
-    return {
-      credentialId: `cred-${key}`,
-      service,
-      field,
-      allowedTools: entry.allowedTools,
-      allowedDomains: [],
-      usageDescription: entry.usageDescription,
-      createdAt: 0,
-      updatedAt: 0,
-    };
-  },
-  upsertCredentialMetadata: (
-    service: string,
-    field: string,
-    policy?: { allowedTools?: string[]; usageDescription?: string },
-  ) => {
-    const key = `${service}/${field}`;
-    const existing = metadataStore.get(key);
-    metadataStore.set(key, {
-      allowedTools: policy?.allowedTools ?? existing?.allowedTools ?? [],
-      usageDescription: policy?.usageDescription ?? existing?.usageDescription,
-    });
-    return {
-      credentialId: `cred-${key}`,
-      service,
-      field,
-      allowedTools: metadataStore.get(key)!.allowedTools,
-      allowedDomains: [],
-      createdAt: 0,
-      updatedAt: 0,
-    };
-  },
-}));
-
-/**
- * Simulates the credential broker's serverUse method. The vault stores
- * plaintext values keyed by `service/field`; the broker enforces tool
- * policy via the metadata store before passing the value to the callback.
- */
-const vaultStore = new Map<string, string>();
-
-mock.module("../../tools/credentials/broker.js", () => ({
-  credentialBroker: {
-    serverUse: async <T>(request: {
-      service: string;
-      field: string;
-      toolName: string;
-      execute: (value: string) => Promise<T>;
-    }) => {
-      const key = `${request.service}/${request.field}`;
-      const meta = metadataStore.get(key);
-      if (!meta) {
-        return { success: false, reason: `No credential found for ${key}` };
-      }
-      if (!meta.allowedTools.includes(request.toolName)) {
-        return {
-          success: false,
-          reason: `Tool "${request.toolName}" not allowed`,
-        };
-      }
-      const value = vaultStore.get(key);
-      if (!value) {
-        return {
-          success: false,
-          reason: `No stored value for ${key}`,
-        };
-      }
-      const result = await request.execute(value);
-      return { success: true, result };
-    },
-  },
-}));
-
-const { prepareAgentEnv, ACP_CLAUDE_OAUTH_MISSING_CODE, grantAcpSpawnPolicy } =
-  await import("../prepare-agent-env.js");
+const TEST_DIR = join(
+  tmpdir(),
+  `vellum-prepare-agent-env-test-${randomBytes(4).toString("hex")}`,
+);
 
 beforeEach(() => {
-  metadataStore.clear();
-  vaultStore.clear();
+  mkdirSync(TEST_DIR, { recursive: true });
+  setStorePathForTesting(join(TEST_DIR, "keys.enc"));
+  _resetBackend();
+  _setMetadataPath(join(TEST_DIR, "metadata.json"));
+});
+
+afterEach(() => {
+  _setMetadataPath(null);
+  setStorePathForTesting(null);
+  _resetBackend();
+  rmSync(TEST_DIR, { recursive: true, force: true });
 });
 
 // ---------------------------------------------------------------------------
-// Helper to seed a vault entry (simulates `assistant credentials set`).
+// Helpers to seed the vault + metadata (simulates `assistant credentials set`).
 // ---------------------------------------------------------------------------
 
-function seedVaultToken(token: string): void {
-  vaultStore.set("acp/claude_oauth_token", token);
+async function seedVaultValue(field: string, value: string): Promise<void> {
+  await setSecureKeyAsync(credentialKey(ACP_SERVICE, field), value);
+}
+
+function seedVaultToken(token: string): Promise<void> {
+  return seedVaultValue(ACP_OAUTH_TOKEN_FIELD, token);
+}
+
+function oauthMetadata() {
+  return getCredentialMetadata(ACP_SERVICE, ACP_OAUTH_TOKEN_FIELD);
 }
 
 describe("prepareAgentEnv — claude-agent-acp gating", () => {
   test("injects CLAUDE_CODE_OAUTH_TOKEN from the vault via the broker when agent.env has no override", async () => {
-    seedVaultToken("vault-AAA");
+    await seedVaultToken("vault-AAA");
 
     const prepared = await prepareAgentEnv({
       command: "claude-agent-acp",
@@ -133,39 +91,35 @@ describe("prepareAgentEnv — claude-agent-acp gating", () => {
   });
 
   test("auto-registers metadata with acp_spawn in allowedTools when none exists", async () => {
-    seedVaultToken("vault-auto-meta");
+    await seedVaultToken("vault-auto-meta");
 
     await prepareAgentEnv({ command: "claude-agent-acp", args: [] });
 
-    const meta = metadataStore.get("acp/claude_oauth_token");
-    expect(meta).toBeDefined();
-    expect(meta!.allowedTools).toContain("acp_spawn");
+    expect(oauthMetadata()?.allowedTools).toContain(ACP_SPAWN_TOOL);
   });
 
   test("adds acp_spawn to metadata with empty allowedTools (default provisioning path)", async () => {
-    metadataStore.set("acp/claude_oauth_token", {
+    upsertCredentialMetadata(ACP_SERVICE, ACP_OAUTH_TOKEN_FIELD, {
       allowedTools: [],
     });
-    seedVaultToken("vault-augment");
+    await seedVaultToken("vault-augment");
 
     await prepareAgentEnv({ command: "claude-agent-acp", args: [] });
 
-    const meta = metadataStore.get("acp/claude_oauth_token");
-    expect(meta!.allowedTools).toContain("acp_spawn");
+    expect(oauthMetadata()?.allowedTools).toContain(ACP_SPAWN_TOOL);
   });
 
   test("respects explicit tool policy that excludes acp_spawn", async () => {
-    metadataStore.set("acp/claude_oauth_token", {
+    upsertCredentialMetadata(ACP_SERVICE, ACP_OAUTH_TOKEN_FIELD, {
       allowedTools: ["other_tool"],
     });
-    seedVaultToken("vault-restricted");
+    await seedVaultToken("vault-restricted");
 
     await expect(
       prepareAgentEnv({ command: "claude-agent-acp", args: [] }),
     ).rejects.toThrow("CLAUDE_CODE_OAUTH_TOKEN");
 
-    const meta = metadataStore.get("acp/claude_oauth_token");
-    expect(meta!.allowedTools).toEqual(["other_tool"]);
+    expect(oauthMetadata()?.allowedTools).toEqual(["other_tool"]);
   });
 
   test("accepts CLAUDE_CODE_OAUTH_TOKEN from agent.env (config.json override) with no vault entry", async () => {
@@ -179,7 +133,7 @@ describe("prepareAgentEnv — claude-agent-acp gating", () => {
   });
 
   test("agent.env override wins over the vault entry (precedence pin)", async () => {
-    seedVaultToken("vault-CCC");
+    await seedVaultToken("vault-CCC");
 
     const prepared = await prepareAgentEnv({
       command: "claude-agent-acp",
@@ -191,7 +145,7 @@ describe("prepareAgentEnv — claude-agent-acp gating", () => {
   });
 
   test("preserves unrelated env vars on agent.env when injecting from the vault", async () => {
-    seedVaultToken("vault-EEE");
+    await seedVaultToken("vault-EEE");
 
     const prepared = await prepareAgentEnv({
       command: "claude-agent-acp",
@@ -247,7 +201,7 @@ describe("prepareAgentEnv — claude-agent-acp gating", () => {
   });
 
   test("does NOT attach the marker when a token is present (happy path unchanged)", async () => {
-    seedVaultToken("vault-marker-absent");
+    await seedVaultToken("vault-marker-absent");
 
     const prepared = await prepareAgentEnv({
       command: "claude-agent-acp",
@@ -262,7 +216,7 @@ describe("prepareAgentEnv — claude-agent-acp gating", () => {
     // format guard existed must not spawn with a doomed credential (a 401 with
     // no repair). The presence check alone would pass, so the injected value is
     // classified and an API key is treated as missing → the Connect card fires.
-    seedVaultToken("sk-ant-api03-legacy-bad-value");
+    await seedVaultToken("sk-ant-api03-legacy-bad-value");
 
     let caught: unknown;
     try {
@@ -304,7 +258,7 @@ describe("prepareAgentEnv — claude-agent-acp gating", () => {
     // be used and the Connect card would re-fire forever. The bad override is
     // dropped BEFORE the read, so the vault OAuth token is picked up and spawn
     // proceeds instead of looping.
-    seedVaultToken("sk-ant-oat01-freshly-connected");
+    await seedVaultToken("sk-ant-oat01-freshly-connected");
 
     const prepared = await prepareAgentEnv({
       command: "claude-agent-acp",
@@ -318,7 +272,7 @@ describe("prepareAgentEnv — claude-agent-acp gating", () => {
   });
 
   test("keeps a valid OAuth token (sk-ant-oat…) usable (not misclassified)", async () => {
-    seedVaultToken("sk-ant-oat01-good-token");
+    await seedVaultToken("sk-ant-oat01-good-token");
 
     const prepared = await prepareAgentEnv({
       command: "claude-agent-acp",
@@ -331,7 +285,7 @@ describe("prepareAgentEnv — claude-agent-acp gating", () => {
   });
 
   test("gates on the resolved command BASENAME (alias to /custom/path/claude-agent-acp still gets the token)", async () => {
-    seedVaultToken("vault-FFF");
+    await seedVaultToken("vault-FFF");
 
     const prepared = await prepareAgentEnv({
       command: "/opt/bin/claude-agent-acp",
@@ -342,7 +296,7 @@ describe("prepareAgentEnv — claude-agent-acp gating", () => {
   });
 
   test("does NOT mutate the caller's agentConfig", async () => {
-    seedVaultToken("vault-GGG");
+    await seedVaultToken("vault-GGG");
     const original = {
       command: "claude-agent-acp",
       args: [],
@@ -360,16 +314,16 @@ describe("prepareAgentEnv — claude-agent-acp gating", () => {
 });
 
 describe("prepareAgentEnv - codex-acp gating", () => {
-  function seedVaultOpenaiKey(key: string): void {
-    vaultStore.set("acp/openai_api_key", key);
+  function seedVaultOpenaiKey(key: string): Promise<void> {
+    return seedVaultValue("openai_api_key", key);
   }
 
-  function seedVaultCodexKey(key: string): void {
-    vaultStore.set("acp/codex_api_key", key);
+  function seedVaultCodexKey(key: string): Promise<void> {
+    return seedVaultValue("codex_api_key", key);
   }
 
   test("injects OPENAI_API_KEY from the vault via the broker when agent.env has no override", async () => {
-    seedVaultOpenaiKey("vault-fake-openai-AAA");
+    await seedVaultOpenaiKey("vault-fake-openai-AAA");
 
     const prepared = await prepareAgentEnv({
       command: "codex-acp",
@@ -382,7 +336,7 @@ describe("prepareAgentEnv - codex-acp gating", () => {
   test("agent.env override wins over the vault entry and skips the broker (precedence pin)", async () => {
     // Seed a vault value but no metadata: if the override path consulted the
     // broker anyway, ensureAcpCredentialPolicy would create metadata here.
-    seedVaultOpenaiKey("vault-fake-openai-BBB");
+    await seedVaultOpenaiKey("vault-fake-openai-BBB");
 
     const prepared = await prepareAgentEnv({
       command: "codex-acp",
@@ -391,7 +345,9 @@ describe("prepareAgentEnv - codex-acp gating", () => {
     });
 
     expect(prepared.env?.OPENAI_API_KEY).toBe("config-fake-openai-CCC");
-    expect(metadataStore.has("acp/openai_api_key")).toBe(false);
+    expect(
+      getCredentialMetadata(ACP_SERVICE, "openai_api_key"),
+    ).toBeUndefined();
   });
 
   test("a vault miss for both fields does NOT throw and spawns with env unchanged (keys are optional)", async () => {
@@ -407,7 +363,7 @@ describe("prepareAgentEnv - codex-acp gating", () => {
   });
 
   test("injects CODEX_API_KEY independently of OPENAI_API_KEY", async () => {
-    seedVaultCodexKey("vault-fake-codex-DDD");
+    await seedVaultCodexKey("vault-fake-codex-DDD");
 
     const prepared = await prepareAgentEnv({
       command: "codex-acp",
@@ -419,8 +375,8 @@ describe("prepareAgentEnv - codex-acp gating", () => {
   });
 
   test("injects both keys when both vault fields are present", async () => {
-    seedVaultOpenaiKey("vault-fake-openai-EEE");
-    seedVaultCodexKey("vault-fake-codex-FFF");
+    await seedVaultOpenaiKey("vault-fake-openai-EEE");
+    await seedVaultCodexKey("vault-fake-codex-FFF");
 
     const prepared = await prepareAgentEnv({
       command: "codex-acp",
@@ -432,7 +388,7 @@ describe("prepareAgentEnv - codex-acp gating", () => {
   });
 
   test("gates on the resolved command BASENAME (custom agent id with full path still gets injection)", async () => {
-    seedVaultOpenaiKey("vault-fake-openai-GGG");
+    await seedVaultOpenaiKey("vault-fake-openai-GGG");
 
     const prepared = await prepareAgentEnv({
       command: "/data/.bun/bin/codex-acp",
@@ -445,7 +401,7 @@ describe("prepareAgentEnv - codex-acp gating", () => {
 
 describe("prepareAgentEnv — non-claude commands", () => {
   test("returns the config unchanged for an unrecognized command basename", async () => {
-    seedVaultToken("vault-HHH");
+    await seedVaultToken("vault-HHH");
 
     const prepared = await prepareAgentEnv({
       command: "some-future-adapter",
@@ -459,36 +415,146 @@ describe("prepareAgentEnv — non-claude commands", () => {
 
 describe("grantAcpSpawnPolicy — force-grant (union)", () => {
   test("creates metadata with acp_spawn when none exists", () => {
-    grantAcpSpawnPolicy("claude_oauth_token", "desc");
-    expect(metadataStore.get("acp/claude_oauth_token")!.allowedTools).toEqual([
-      "acp_spawn",
-    ]);
+    grantAcpSpawnPolicy(ACP_OAUTH_TOKEN_FIELD, "desc");
+    expect(oauthMetadata()?.allowedTools).toEqual([ACP_SPAWN_TOOL]);
   });
 
   test("unions acp_spawn into an explicit policy that omitted it (repair)", () => {
-    metadataStore.set("acp/claude_oauth_token", {
+    upsertCredentialMetadata(ACP_SERVICE, ACP_OAUTH_TOKEN_FIELD, {
       allowedTools: ["other_tool"],
     });
 
-    grantAcpSpawnPolicy("claude_oauth_token", "desc");
+    grantAcpSpawnPolicy(ACP_OAUTH_TOKEN_FIELD, "desc");
 
     // Unlike ensureAcpCredentialPolicy (which preserves), grant adds acp_spawn.
-    expect(metadataStore.get("acp/claude_oauth_token")!.allowedTools).toEqual([
+    expect(oauthMetadata()?.allowedTools).toEqual([
       "other_tool",
-      "acp_spawn",
+      ACP_SPAWN_TOOL,
     ]);
   });
 
   test("leaves an allowedTools that already includes acp_spawn unchanged", () => {
-    metadataStore.set("acp/claude_oauth_token", {
-      allowedTools: ["acp_spawn", "other_tool"],
+    upsertCredentialMetadata(ACP_SERVICE, ACP_OAUTH_TOKEN_FIELD, {
+      allowedTools: [ACP_SPAWN_TOOL, "other_tool"],
     });
 
-    grantAcpSpawnPolicy("claude_oauth_token", "desc");
+    grantAcpSpawnPolicy(ACP_OAUTH_TOKEN_FIELD, "desc");
 
-    expect(metadataStore.get("acp/claude_oauth_token")!.allowedTools).toEqual([
-      "acp_spawn",
+    expect(oauthMetadata()?.allowedTools).toEqual([
+      ACP_SPAWN_TOOL,
       "other_tool",
     ]);
   });
+});
+
+/**
+ * Drift guard for the Connect Claude status predicate.
+ *
+ * `acpSpawnCredentialDenialReason` answers "would the spawn's broker read of
+ * this credential succeed?" without performing it, because the status route is
+ * a side-effect-free GET. Every state below is run twice: once through the
+ * predicate, and once through the real spawn sequence
+ * (`ensureAcpCredentialPolicy` then `credentialBroker.serverUse`). The two must
+ * agree down to the denial string, so this test fails the moment either side's
+ * policy logic changes without the other, which is exactly how the status route
+ * and the spawn path drifted apart before.
+ *
+ * The predicate reads only the persisted value via `getSecureKeyAsync` and
+ * never calls `serverUse`, so it can never consume a one-time transient
+ * credential the way a real broker read would.
+ */
+describe("acpSpawnCredentialDenialReason parity with the real spawn read", () => {
+  const STATES: { name: string; seed: () => void }[] = [
+    { name: "no metadata at all", seed: () => {} },
+    {
+      name: "empty allowedTools",
+      seed: () => {
+        upsertCredentialMetadata(ACP_SERVICE, ACP_OAUTH_TOKEN_FIELD, {
+          allowedTools: [],
+        });
+      },
+    },
+    {
+      name: "allowedTools listing acp_spawn",
+      seed: () => {
+        upsertCredentialMetadata(ACP_SERVICE, ACP_OAUTH_TOKEN_FIELD, {
+          allowedTools: [ACP_SPAWN_TOOL],
+        });
+      },
+    },
+    {
+      name: "allowedTools listing another tool",
+      seed: () => {
+        upsertCredentialMetadata(ACP_SERVICE, ACP_OAUTH_TOKEN_FIELD, {
+          allowedTools: ["bash"],
+        });
+      },
+    },
+    {
+      // The alias map in tool-policy.ts has no entry canonicalizing to
+      // acp_spawn, so this covers alias resolution generically: a legacy alias
+      // that canonicalizes to some OTHER capability must still deny.
+      name: "allowedTools listing a legacy alias for another capability",
+      seed: () => {
+        upsertCredentialMetadata(ACP_SERVICE, ACP_OAUTH_TOKEN_FIELD, {
+          allowedTools: ["browser_fill_credential"],
+        });
+      },
+    },
+    {
+      name: "acp_spawn allowed but domain-restricted",
+      seed: () => {
+        upsertCredentialMetadata(ACP_SERVICE, ACP_OAUTH_TOKEN_FIELD, {
+          allowedTools: [ACP_SPAWN_TOOL],
+          allowedDomains: ["api.anthropic.com"],
+        });
+      },
+    },
+    {
+      // The ensure-repair grants acp_spawn but must not drop the domain policy,
+      // so the projection has to preserve the rest of the record.
+      name: "empty allowedTools and domain-restricted",
+      seed: () => {
+        upsertCredentialMetadata(ACP_SERVICE, ACP_OAUTH_TOKEN_FIELD, {
+          allowedTools: [],
+          allowedDomains: ["api.anthropic.com"],
+        });
+      },
+    },
+    {
+      name: "acp_spawn allowed with an explicitly empty allowedDomains",
+      seed: () => {
+        upsertCredentialMetadata(ACP_SERVICE, ACP_OAUTH_TOKEN_FIELD, {
+          allowedTools: [ACP_SPAWN_TOOL],
+          allowedDomains: [],
+        });
+      },
+    },
+  ];
+
+  for (const state of STATES) {
+    test(`predicts the spawn read for: ${state.name}`, async () => {
+      await seedVaultToken("sk-ant-oat01-parity");
+
+      state.seed();
+      const beforePrediction = oauthMetadata();
+      const predicted = acpSpawnCredentialDenialReason(ACP_OAUTH_TOKEN_FIELD);
+      // The status route is a GET: predicting must not touch the store.
+      expect(oauthMetadata()).toEqual(beforePrediction);
+
+      // ensureAcpCredentialPolicy mutates the store, so the actual run starts
+      // from a fresh copy of the same state rather than the predicted one.
+      deleteCredentialMetadata(ACP_SERVICE, ACP_OAUTH_TOKEN_FIELD);
+      state.seed();
+      ensureAcpCredentialPolicy(ACP_OAUTH_TOKEN_FIELD, "desc");
+      const result = await credentialBroker.serverUse<void>({
+        service: ACP_SERVICE,
+        field: ACP_OAUTH_TOKEN_FIELD,
+        toolName: ACP_SPAWN_TOOL,
+        execute: async () => {},
+      });
+
+      expect(predicted).toBe(result.success ? undefined : result.reason);
+    });
+  }
 });

--- a/assistant/src/acp/__tests__/prepare-agent-env.test.ts
+++ b/assistant/src/acp/__tests__/prepare-agent-env.test.ts
@@ -455,9 +455,7 @@ describe("grantAcpSpawnPolicy — force-grant (union)", () => {
  * a side-effect-free GET. Every state below is run twice: once through the
  * predicate, and once through the real spawn sequence
  * (`ensureAcpCredentialPolicy` then `credentialBroker.serverUse`). The two must
- * agree down to the denial string, so this test fails the moment either side's
- * policy logic changes without the other, which is exactly how the status route
- * and the spawn path drifted apart before.
+ * agree down to the denial string; this suite fails whenever they diverge.
  *
  * The predicate reads only the persisted value via `getSecureKeyAsync` and
  * never calls `serverUse`, so it can never consume a one-time transient

--- a/assistant/src/acp/acp-claude-oauth.ts
+++ b/assistant/src/acp/acp-claude-oauth.ts
@@ -17,15 +17,18 @@ import {
   getSecureKeyAsync,
   setSecureKeyAsync,
 } from "../security/secure-keys.js";
+import { getLogger } from "../util/logger.js";
 import {
   ACP_OAUTH_TOKEN_FIELD,
   ACP_SERVICE,
   classifyAnthropicToken,
 } from "./acp-credentials.js";
 import {
-  acpSpawnCanReadCredential,
+  acpSpawnCredentialDenialReason,
   grantAcpSpawnPolicy,
 } from "./prepare-agent-env.js";
+
+const log = getLogger("acp:claude-oauth");
 
 /**
  * Verified Claude Code public OAuth client. PKCE-only (no client secret);
@@ -142,20 +145,32 @@ export async function storeAcpClaudeToken(token: string): Promise<void> {
  * spawn, so keeping Connect offered (rather than self-dismissing) lets the user
  * repair the bad entry by connecting a real OAuth token.
  *
- * Likewise, a token the `acp_spawn` policy can't read (an explicit
- * `allowedTools` that omits `acp_spawn`) is NOT connected: the vault holds a
- * value but the spawn's broker read is denied, so self-dismissing the card would
- * hide the only repair CTA while every spawn keeps failing. Keep the card up in
- * that denied-policy case too.
+ * Likewise, a token the spawn's broker read would be denied (an explicit
+ * `allowedTools` that omits `acp_spawn`, or a domain-restricted policy) is NOT
+ * connected: the vault holds a value but every spawn fails, so self-dismissing
+ * the card would hide the only repair CTA. That half of the answer is delegated
+ * to `acpSpawnCredentialDenialReason`, which evaluates the exact policy the
+ * spawn-time broker read applies, so "connected" means precisely "the spawn
+ * would get this token". The token-shape guard stays here instead: the broker
+ * knows nothing about Anthropic token formats.
  */
 export async function hasAcpClaudeToken(): Promise<boolean> {
   const token = await getSecureKeyAsync(
     credentialKey(ACP_SERVICE, ACP_OAUTH_TOKEN_FIELD),
   );
-  return (
-    token != null &&
-    token.length > 0 &&
-    classifyAnthropicToken(token) !== "api_key" &&
-    acpSpawnCanReadCredential(ACP_OAUTH_TOKEN_FIELD)
-  );
+  if (token == null || token.length === 0) {
+    return false;
+  }
+  if (classifyAnthropicToken(token) === "api_key") {
+    return false;
+  }
+  const denialReason = acpSpawnCredentialDenialReason(ACP_OAUTH_TOKEN_FIELD);
+  if (denialReason !== undefined) {
+    log.debug(
+      { field: ACP_OAUTH_TOKEN_FIELD, reason: denialReason },
+      "Connect Claude status: token present but spawn read would be denied",
+    );
+    return false;
+  }
+  return true;
 }

--- a/assistant/src/acp/prepare-agent-env.ts
+++ b/assistant/src/acp/prepare-agent-env.ts
@@ -53,34 +53,67 @@ const ACP_SPAWN_TOOL = "acp_spawn";
 export const ACP_CLAUDE_OAUTH_MISSING_CODE = "acp_claude_oauth_missing";
 
 /**
- * Ensure an `acp/<field>` credential has metadata that allows the
- * `acp_spawn` tool to read it, but only for legacy/unmanaged cases:
+ * The metadata an `acp/<field>` credential has once the `acp_spawn` read policy
+ * is ensured, given what is stored now. This is the single definition of that
+ * decision: {@link ensureAcpCredentialPolicy} persists the result and
+ * {@link acpSpawnCredentialDenialReason} evaluates it without writing.
  *
- * - No metadata at all: create with `allowedTools: ["acp_spawn"]`.
- * - Metadata exists with an empty `allowedTools`: default provisioning
- *   path (user ran `credentials set` without `--allowed-tools`), add it.
- * - Metadata exists with a non-empty `allowedTools`: explicit policy set
- *   by the user/admin. Respect it even if `acp_spawn` is absent; the
- *   broker will deny the read and the caller decides whether that's fatal.
+ * The policy is only repaired for legacy/unmanaged cases:
+ *
+ * - No metadata at all: a record with `allowedTools: ["acp_spawn"]` and the
+ *   caller's `usageDescription`.
+ * - Metadata with an empty `allowedTools`: default provisioning path (user ran
+ *   `credentials set` without `--allowed-tools`), so `acp_spawn` is added.
+ * - Metadata with a non-empty `allowedTools`: explicit policy set by the
+ *   user/admin, returned as the very same object so callers can tell by
+ *   identity that there is nothing to persist. It stands even when `acp_spawn`
+ *   is absent; the broker denies the read and the caller decides whether that's
+ *   fatal.
+ *
+ * Everything else on an existing record, `allowedDomains` included, is
+ * preserved.
+ */
+function projectEnsuredAcpPolicy(
+  meta: CredentialMetadata | undefined,
+  field: string,
+  usageDescription?: string,
+): CredentialMetadata {
+  if (!meta) {
+    return {
+      credentialId: "",
+      service: ACP_SERVICE,
+      field,
+      allowedTools: [ACP_SPAWN_TOOL],
+      allowedDomains: [],
+      usageDescription,
+      createdAt: 0,
+      updatedAt: 0,
+    };
+  }
+  if ((meta.allowedTools ?? []).length === 0) {
+    return { ...meta, allowedTools: [ACP_SPAWN_TOOL] };
+  }
+  return meta;
+}
+
+/**
+ * Bring the stored metadata for `acp/<field>` up to the policy
+ * {@link projectEnsuredAcpPolicy} describes, writing only the fields that
+ * projection decides and only when it differs from what is stored.
  */
 export function ensureAcpCredentialPolicy(
   field: string,
   usageDescription: string,
 ): void {
   const meta = getCredentialMetadata(ACP_SERVICE, field);
-  if (!meta) {
-    upsertCredentialMetadata(ACP_SERVICE, field, {
-      allowedTools: [ACP_SPAWN_TOOL],
-      usageDescription,
-    });
+  const ensured = projectEnsuredAcpPolicy(meta, field, usageDescription);
+  if (ensured === meta) {
     return;
   }
-  const tools = meta.allowedTools ?? [];
-  if (tools.length === 0) {
-    upsertCredentialMetadata(ACP_SERVICE, field, {
-      allowedTools: [ACP_SPAWN_TOOL],
-    });
-  }
+  upsertCredentialMetadata(ACP_SERVICE, field, {
+    allowedTools: ensured.allowedTools,
+    usageDescription: ensured.usageDescription,
+  });
 }
 
 /**
@@ -120,13 +153,11 @@ export function grantAcpSpawnPolicy(
  *
  * The verdict comes from `serverUseDenialReason`, the single policy source the
  * broker itself consults, so the status check and the spawn read can never
- * disagree. The stored metadata is first projected through the repair
- * {@link ensureAcpCredentialPolicy} performs at spawn time (missing metadata,
- * or metadata whose `allowedTools` is empty, is granted `acp_spawn`; everything
- * else on the record, `allowedDomains` included, is preserved). That projection
- * is computed in memory and never written: this runs on a side-effect-free GET
- * route, so it has to predict what the spawn's ensure-then-read sequence would
- * do rather than perform it.
+ * disagree. The stored metadata is first run through
+ * {@link projectEnsuredAcpPolicy}, the same repair the spawn persists, computed
+ * in memory and never written: this runs on a side-effect-free GET route, so it
+ * has to predict what the spawn's ensure-then-read sequence would do rather
+ * than perform it.
  */
 export function acpSpawnCredentialDenialReason(
   field: string,
@@ -138,28 +169,6 @@ export function acpSpawnCredentialDenialReason(
     ACP_SERVICE,
     field,
   );
-}
-
-/** The metadata {@link ensureAcpCredentialPolicy} would leave behind, unwritten. */
-function projectEnsuredAcpPolicy(
-  meta: CredentialMetadata | undefined,
-  field: string,
-): CredentialMetadata {
-  if (!meta) {
-    return {
-      credentialId: "",
-      service: ACP_SERVICE,
-      field,
-      allowedTools: [ACP_SPAWN_TOOL],
-      allowedDomains: [],
-      createdAt: 0,
-      updatedAt: 0,
-    };
-  }
-  if ((meta.allowedTools ?? []).length === 0) {
-    return { ...meta, allowedTools: [ACP_SPAWN_TOOL] };
-  }
-  return meta;
 }
 
 /**

--- a/assistant/src/acp/prepare-agent-env.ts
+++ b/assistant/src/acp/prepare-agent-env.ts
@@ -25,9 +25,11 @@ import { basename } from "node:path";
 import { FailedDependencyError } from "../runtime/routes/errors.js";
 import { credentialBroker } from "../tools/credentials/broker.js";
 import {
+  type CredentialMetadata,
   getCredentialMetadata,
   upsertCredentialMetadata,
 } from "../tools/credentials/metadata-store.js";
+import { serverUseDenialReason } from "../tools/credentials/tool-policy.js";
 import { getLogger } from "../util/logger.js";
 import {
   ACP_OAUTH_TOKEN_FIELD,
@@ -110,21 +112,54 @@ export function grantAcpSpawnPolicy(
 }
 
 /**
- * Whether the `acp_spawn` broker read for `acp/<field>` would actually be
- * permitted, mirroring {@link ensureAcpCredentialPolicy}'s grant rules: a
- * missing or empty `allowedTools` is auto-granted `acp_spawn` at spawn time, so
- * it can read; a non-empty explicit policy is respected as-is, so it can read
- * only when it lists `acp_spawn`. Lets a connected-status check avoid reporting
- * "connected" for a token the spawn is policy-denied from reading (which would
- * otherwise hide the repair CTA and trap the user in a missing-token loop).
+ * Why the `acp_spawn` broker read for `acp/<field>` would be denied, or
+ * `undefined` when it would be permitted. Lets a connected-status check avoid
+ * reporting "connected" for a token the spawn is policy-denied from reading
+ * (which would otherwise hide the repair CTA and trap the user in a
+ * missing-token loop).
+ *
+ * The verdict comes from `serverUseDenialReason`, the single policy source the
+ * broker itself consults, so the status check and the spawn read can never
+ * disagree. The stored metadata is first projected through the repair
+ * {@link ensureAcpCredentialPolicy} performs at spawn time (missing metadata,
+ * or metadata whose `allowedTools` is empty, is granted `acp_spawn`; everything
+ * else on the record, `allowedDomains` included, is preserved). That projection
+ * is computed in memory and never written: this runs on a side-effect-free GET
+ * route, so it has to predict what the spawn's ensure-then-read sequence would
+ * do rather than perform it.
  */
-export function acpSpawnCanReadCredential(field: string): boolean {
+export function acpSpawnCredentialDenialReason(
+  field: string,
+): string | undefined {
   const meta = getCredentialMetadata(ACP_SERVICE, field);
+  return serverUseDenialReason(
+    projectEnsuredAcpPolicy(meta, field),
+    ACP_SPAWN_TOOL,
+    ACP_SERVICE,
+    field,
+  );
+}
+
+/** The metadata {@link ensureAcpCredentialPolicy} would leave behind, unwritten. */
+function projectEnsuredAcpPolicy(
+  meta: CredentialMetadata | undefined,
+  field: string,
+): CredentialMetadata {
   if (!meta) {
-    return true;
+    return {
+      credentialId: "",
+      service: ACP_SERVICE,
+      field,
+      allowedTools: [ACP_SPAWN_TOOL],
+      allowedDomains: [],
+      createdAt: 0,
+      updatedAt: 0,
+    };
   }
-  const tools = meta.allowedTools ?? [];
-  return tools.length === 0 || tools.includes(ACP_SPAWN_TOOL);
+  if ((meta.allowedTools ?? []).length === 0) {
+    return { ...meta, allowedTools: [ACP_SPAWN_TOOL] };
+  }
+  return meta;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Replaces acpSpawnCanReadCredential with acpSpawnCredentialDenialReason: an as-if-ensured projection of the credential metadata evaluated through the shared serverUseDenialReason broker policy
- hasAcpClaudeToken now answers exactly whether the spawn-time broker read would succeed, closing the domain-restricted split-brain that made the Connect Claude card self-dismiss invisibly
- Adds a parity drift-guard test running the status predicate against the real ensure+serverUse spawn sequence over a metadata matrix

Part of plan: acp-connect-split-brain.md (PR 2 of 5)