### PR TITLE
Clear allowedDomains on the ACP Claude OAuth credential when Connect stores a token

### DIFF
--- a/assistant/src/acp/__tests__/acp-claude-oauth.test.ts
+++ b/assistant/src/acp/__tests__/acp-claude-oauth.test.ts
@@ -36,6 +36,9 @@ mock.module("../../security/secure-keys.js", () => ({
 const { _setMetadataPath, getCredentialMetadata, upsertCredentialMetadata } =
   await import("../../tools/credentials/metadata-store.js");
 
+const { acpSpawnCredentialDenialReason } =
+  await import("../prepare-agent-env.js");
+
 const {
   CLAUDE_OAUTH_CONFIG,
   CLAUDE_MANUAL_REDIRECT_URI,
@@ -186,6 +189,57 @@ describe("storeAcpClaudeToken", () => {
       "other_tool",
       ACP_SPAWN_TOOL,
     ]);
+  });
+
+  test("clears a domain restriction the broker would refuse server-side", async () => {
+    upsertCredentialMetadata(ACP_SERVICE, OAUTH_FIELD, {
+      allowedTools: [ACP_SPAWN_TOOL],
+      allowedDomains: ["api.anthropic.com"],
+    });
+
+    await storeAcpClaudeToken("sk-ant-oat-token");
+
+    expect(oauthMetadata()?.allowedDomains).toEqual([]);
+    expect(oauthMetadata()?.allowedTools).toEqual([ACP_SPAWN_TOOL]);
+  });
+
+  test("leaves an already-unrestricted credential's domains alone", async () => {
+    upsertCredentialMetadata(ACP_SERVICE, OAUTH_FIELD, {
+      allowedTools: ["other_tool"],
+    });
+
+    await storeAcpClaudeToken("sk-ant-oat-token");
+
+    expect(oauthMetadata()?.allowedDomains).toEqual([]);
+    expect(oauthMetadata()?.allowedTools).toEqual([
+      "other_tool",
+      ACP_SPAWN_TOOL,
+    ]);
+  });
+
+  test("creates the standard record when there is no prior metadata", async () => {
+    await storeAcpClaudeToken("sk-ant-oat-token");
+
+    expect(oauthMetadata()?.allowedTools).toEqual([ACP_SPAWN_TOOL]);
+    expect(oauthMetadata()?.allowedDomains).toEqual([]);
+  });
+
+  test("takes a domain-restricted credential from not-connected to connected", async () => {
+    // The loop this closes: the vault holds a usable token, but the domain
+    // policy makes the spawn read fail, so the status check keeps the Connect
+    // card offered. Clicking Connect has to repair the policy, otherwise the
+    // retry after a successful sign-in fails exactly the same way.
+    upsertCredentialMetadata(ACP_SERVICE, OAUTH_FIELD, {
+      allowedTools: [ACP_SPAWN_TOOL],
+      allowedDomains: ["api.anthropic.com"],
+    });
+    getReturn = "sk-ant-oat-token";
+    expect(await hasAcpClaudeToken()).toBe(false);
+
+    await storeAcpClaudeToken("sk-ant-oat-token");
+
+    expect(await hasAcpClaudeToken()).toBe(true);
+    expect(acpSpawnCredentialDenialReason(OAUTH_FIELD)).toBeUndefined();
   });
 
   test("throws when the secure store rejects the write", async () => {

--- a/assistant/src/acp/__tests__/acp-claude-oauth.test.ts
+++ b/assistant/src/acp/__tests__/acp-claude-oauth.test.ts
@@ -225,10 +225,10 @@ describe("storeAcpClaudeToken", () => {
   });
 
   test("takes a domain-restricted credential from not-connected to connected", async () => {
-    // The loop this closes: the vault holds a usable token, but the domain
-    // policy makes the spawn read fail, so the status check keeps the Connect
-    // card offered. Clicking Connect has to repair the policy, otherwise the
-    // retry after a successful sign-in fails exactly the same way.
+    // Invariant: when the vault holds a usable token whose domain policy
+    // makes the spawn read fail, the status check keeps the Connect card
+    // offered, and completing Connect repairs the policy so the retry after
+    // a successful sign-in succeeds.
     upsertCredentialMetadata(ACP_SERVICE, OAUTH_FIELD, {
       allowedTools: [ACP_SPAWN_TOOL],
       allowedDomains: ["api.anthropic.com"],

--- a/assistant/src/acp/acp-claude-oauth.ts
+++ b/assistant/src/acp/acp-claude-oauth.ts
@@ -17,6 +17,10 @@ import {
   getSecureKeyAsync,
   setSecureKeyAsync,
 } from "../security/secure-keys.js";
+import {
+  getCredentialMetadata,
+  upsertCredentialMetadata,
+} from "../tools/credentials/metadata-store.js";
 import { getLogger } from "../util/logger.js";
 import {
   ACP_OAUTH_TOKEN_FIELD,
@@ -112,8 +116,9 @@ export function parseManualClaudeCode(input: string): {
 
 /**
  * Store a captured Claude OAuth token in the `acp/claude_oauth_token` vault
- * field and provision the `acp_spawn` read policy so the broker can inject it
- * at spawn time. Throws when the backing store rejects the write.
+ * field and provision the policy the broker applies at spawn time: grant the
+ * `acp_spawn` read and lift any domain restriction. Throws when the backing
+ * store rejects the write.
  */
 export async function storeAcpClaudeToken(token: string): Promise<void> {
   const stored = await setSecureKeyAsync(
@@ -131,6 +136,16 @@ export async function storeAcpClaudeToken(token: string): Promise<void> {
     ACP_OAUTH_TOKEN_FIELD,
     "Claude OAuth token for ACP agent authentication",
   );
+  // Same deliberate opt-in, applied to the other half of the policy the broker
+  // checks. This field is OAuth-only and server-use-only, and the broker refuses
+  // a domain-restricted credential server-side, so a lingering restriction would
+  // keep every spawn failing even after a successful connect.
+  const meta = getCredentialMetadata(ACP_SERVICE, ACP_OAUTH_TOKEN_FIELD);
+  if ((meta?.allowedDomains ?? []).length > 0) {
+    upsertCredentialMetadata(ACP_SERVICE, ACP_OAUTH_TOKEN_FIELD, {
+      allowedDomains: [],
+    });
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- storeAcpClaudeToken now clears a domain restriction on acp/claude_oauth_token alongside the existing acp_spawn force-grant, so an explicit Connect repairs a credential the broker would refuse server-side
- Adds an end-to-end test: domain-restricted record goes from not-connected to connected with no spawn denial after Connect

Part of plan: acp-connect-split-brain.md (PR 4 of 5)