### PR TITLE
fix: consolidate Connect policy repair into repairAcpSpawnPolicy

### DIFF
--- a/assistant/src/__tests__/credential-broker-server-use.test.ts
+++ b/assistant/src/__tests__/credential-broker-server-use.test.ts
@@ -44,9 +44,24 @@ import { setSecureKeyAsync } from "../security/secure-keys.js";
 import { CredentialBroker } from "../tools/credentials/broker.js";
 import {
   _setMetadataPath,
+  type CredentialMetadata,
   upsertCredentialMetadata,
 } from "../tools/credentials/metadata-store.js";
 import { serverUseDenialReason } from "../tools/credentials/tool-policy.js";
+
+/** The shared policy's verdict for a state the broker must also deny. */
+function sharedDenialReason(
+  metadata: CredentialMetadata,
+  toolName: string,
+  service: string,
+  field: string,
+): string {
+  const reason = serverUseDenialReason(metadata, toolName, service, field);
+  if (!reason) {
+    throw new Error("expected a denial reason from the shared policy");
+  }
+  return reason;
+}
 
 // ---------------------------------------------------------------------------
 // Tests — serverUse (publish_page / unpublish_page regression)
@@ -519,9 +534,10 @@ describe("CredentialBroker.serverUseById", () => {
     if (result.success) {
       throw new Error("expected denial");
     }
-    expect(result.reason).toContain("not allowed");
-    expect(result.reason).toContain("unauthorized_tool");
-    expect(result.reason).toContain("media_proxy");
+    // The broker passes the shared server-use policy's verdict through verbatim.
+    expect(result.reason).toBe(
+      sharedDenialReason(meta, "unauthorized_tool", "fal", "api_key"),
+    );
   });
 
   test("returns not found for unknown credential ID", async () => {
@@ -554,8 +570,10 @@ describe("CredentialBroker.serverUseById", () => {
     if (result.success) {
       throw new Error("expected denial");
     }
-    expect(result.reason).toContain("domain restrictions");
-    expect(result.reason).toContain("cannot be used server-side");
+    // The broker passes the shared server-use policy's verdict through verbatim.
+    expect(result.reason).toBe(
+      sharedDenialReason(meta, "media_proxy", "github", "oauth_token"),
+    );
   });
 
   test("returns empty injection templates when credential has none", async () => {
@@ -625,60 +643,5 @@ describe("CredentialBroker.serverUseById", () => {
       throw new Error("expected denial");
     }
     expect(result.reason).toContain("no stored value");
-  });
-
-  test("tool denial reason matches the shared server-use policy exactly", async () => {
-    const meta = upsertCredentialMetadata("fal", "api_key", {
-      allowedTools: ["media_proxy"],
-    });
-    await setSecureKeyAsync(credentialKey("fal", "api_key"), "fal-secret-key");
-
-    const result = await broker.serverUseById({
-      credentialId: meta.credentialId,
-      requestingTool: "unauthorized_tool",
-    });
-
-    expect(result.success).toBe(false);
-    if (result.success) {
-      throw new Error("expected denial");
-    }
-    const expected = serverUseDenialReason(
-      meta,
-      "unauthorized_tool",
-      "fal",
-      "api_key",
-    );
-    if (!expected) {
-      throw new Error("expected a denial reason from the shared policy");
-    }
-    expect(result.reason).toBe(expected);
-  });
-
-  test("domain denial reason matches the shared server-use policy exactly", async () => {
-    const meta = upsertCredentialMetadata("github", "oauth_token", {
-      allowedTools: ["media_proxy"],
-      allowedDomains: ["github.com"],
-    });
-    await setSecureKeyAsync(credentialKey("github", "oauth_token"), "gho_test");
-
-    const result = await broker.serverUseById({
-      credentialId: meta.credentialId,
-      requestingTool: "media_proxy",
-    });
-
-    expect(result.success).toBe(false);
-    if (result.success) {
-      throw new Error("expected denial");
-    }
-    const expected = serverUseDenialReason(
-      meta,
-      "media_proxy",
-      "github",
-      "oauth_token",
-    );
-    if (!expected) {
-      throw new Error("expected a denial reason from the shared policy");
-    }
-    expect(result.reason).toBe(expected);
   });
 });

--- a/assistant/src/acp/__tests__/acp-claude-oauth.test.ts
+++ b/assistant/src/acp/__tests__/acp-claude-oauth.test.ts
@@ -171,11 +171,7 @@ describe("parseManualClaudeCode", () => {
 // ---------------------------------------------------------------------------
 
 describe("storeAcpClaudeToken", () => {
-  test("writes the token and force-grants the acp_spawn policy (repairs a denied policy)", async () => {
-    upsertCredentialMetadata(ACP_SERVICE, OAUTH_FIELD, {
-      allowedTools: ["other_tool"],
-    });
-
+  test("writes the token to the acp/claude_oauth_token vault field", async () => {
     await storeAcpClaudeToken("sk-ant-oat-token");
 
     expect(setSecureKeyAsync).toHaveBeenCalledTimes(1);
@@ -183,52 +179,14 @@ describe("storeAcpClaudeToken", () => {
       "credential/acp/claude_oauth_token",
       "sk-ant-oat-token",
     );
-    // grant (union), not merely ensure (preserve) — so an explicit Connect
-    // repairs a credential whose allowedTools omitted acp_spawn.
-    expect(oauthMetadata()?.allowedTools).toEqual([
-      "other_tool",
-      ACP_SPAWN_TOOL,
-    ]);
-  });
-
-  test("clears a domain restriction the broker would refuse server-side", async () => {
-    upsertCredentialMetadata(ACP_SERVICE, OAUTH_FIELD, {
-      allowedTools: [ACP_SPAWN_TOOL],
-      allowedDomains: ["api.anthropic.com"],
-    });
-
-    await storeAcpClaudeToken("sk-ant-oat-token");
-
-    expect(oauthMetadata()?.allowedDomains).toEqual([]);
-    expect(oauthMetadata()?.allowedTools).toEqual([ACP_SPAWN_TOOL]);
-  });
-
-  test("leaves an already-unrestricted credential's domains alone", async () => {
-    upsertCredentialMetadata(ACP_SERVICE, OAUTH_FIELD, {
-      allowedTools: ["other_tool"],
-    });
-
-    await storeAcpClaudeToken("sk-ant-oat-token");
-
-    expect(oauthMetadata()?.allowedDomains).toEqual([]);
-    expect(oauthMetadata()?.allowedTools).toEqual([
-      "other_tool",
-      ACP_SPAWN_TOOL,
-    ]);
-  });
-
-  test("creates the standard record when there is no prior metadata", async () => {
-    await storeAcpClaudeToken("sk-ant-oat-token");
-
-    expect(oauthMetadata()?.allowedTools).toEqual([ACP_SPAWN_TOOL]);
-    expect(oauthMetadata()?.allowedDomains).toEqual([]);
   });
 
   test("takes a domain-restricted credential from not-connected to connected", async () => {
     // Invariant: when the vault holds a usable token whose domain policy
     // makes the spawn read fail, the status check keeps the Connect card
     // offered, and completing Connect repairs the policy so the retry after
-    // a successful sign-in succeeds.
+    // a successful sign-in succeeds. The per-shape repair details are covered
+    // by the repairAcpSpawnPolicy suite in prepare-agent-env.test.ts.
     upsertCredentialMetadata(ACP_SERVICE, OAUTH_FIELD, {
       allowedTools: [ACP_SPAWN_TOOL],
       allowedDomains: ["api.anthropic.com"],
@@ -281,29 +239,13 @@ describe("hasAcpClaudeToken", () => {
     expect(await hasAcpClaudeToken()).toBe(false);
   });
 
-  test("reports true with no metadata at all (the spawn would create it)", async () => {
-    getReturn = "sk-ant-oat-token";
-    expect(await hasAcpClaudeToken()).toBe(true);
-  });
-
   test("reports true for metadata with an empty allowedTools (the spawn would grant acp_spawn)", async () => {
+    // One allow-state case: the full policy matrix is guarded by the parity
+    // suite in prepare-agent-env.test.ts and the tool-policy unit tests.
     upsertCredentialMetadata(ACP_SERVICE, OAUTH_FIELD, { allowedTools: [] });
     getReturn = "sk-ant-oat-token";
 
     expect(await hasAcpClaudeToken()).toBe(true);
-  });
-
-  test("reports false when the spawn policy can't read the token (denied allowedTools)", async () => {
-    // A valid OAuth token is stored, but an explicit `allowedTools` that omits
-    // `acp_spawn` means the broker denies the spawn read. Reporting "connected"
-    // would self-dismiss the card and trap the user in a missing-token loop, so
-    // it stays not-connected to keep the repair CTA visible.
-    upsertCredentialMetadata(ACP_SERVICE, OAUTH_FIELD, {
-      allowedTools: ["other_tool"],
-    });
-    getReturn = "sk-ant-oat-token";
-
-    expect(await hasAcpClaudeToken()).toBe(false);
   });
 
   test("reports false for a domain-restricted credential the broker refuses server-side", async () => {

--- a/assistant/src/acp/__tests__/prepare-agent-env.test.ts
+++ b/assistant/src/acp/__tests__/prepare-agent-env.test.ts
@@ -59,8 +59,8 @@ const {
   ACP_CLAUDE_OAUTH_MISSING_CODE,
   acpSpawnCredentialDenialReason,
   ensureAcpCredentialPolicy,
-  grantAcpSpawnPolicy,
   prepareAgentEnv,
+  repairAcpSpawnPolicy,
 } = await import("../prepare-agent-env.js");
 
 const ACP_SPAWN_TOOL = "acp_spawn";
@@ -526,37 +526,83 @@ describe("prepareAgentEnv — non-claude commands", () => {
   });
 });
 
-describe("grantAcpSpawnPolicy — force-grant (union)", () => {
-  test("creates metadata with acp_spawn when none exists", () => {
-    grantAcpSpawnPolicy(ACP_OAUTH_TOKEN_FIELD, "desc");
+/**
+ * The Connect flow's repair, which `storeAcpClaudeToken` performs after writing
+ * the token. Every metadata shape the broker can deny on is covered here, so
+ * `acp-claude-oauth.test.ts` only has to pin the end-to-end wiring.
+ */
+describe("repairAcpSpawnPolicy - the Connect repair", () => {
+  test("creates a record with acp_spawn, the usage description, and no domain restriction when none exists", () => {
+    repairAcpSpawnPolicy(ACP_OAUTH_TOKEN_FIELD, "desc");
+
+    expect(oauthMetadata()?.allowedTools).toEqual([ACP_SPAWN_TOOL]);
+    expect(oauthMetadata()?.allowedDomains).toEqual([]);
+    expect(oauthMetadata()?.usageDescription).toBe("desc");
+  });
+
+  test("adds acp_spawn to an empty allowedTools (default provisioning path)", () => {
+    upsertCredentialMetadata(ACP_SERVICE, ACP_OAUTH_TOKEN_FIELD, {
+      allowedTools: [],
+    });
+
+    repairAcpSpawnPolicy(ACP_OAUTH_TOKEN_FIELD, "desc");
+
     expect(oauthMetadata()?.allowedTools).toEqual([ACP_SPAWN_TOOL]);
   });
 
-  test("unions acp_spawn into an explicit policy that omitted it (repair)", () => {
+  test("unions acp_spawn into an explicit policy that omitted it", () => {
     upsertCredentialMetadata(ACP_SERVICE, ACP_OAUTH_TOKEN_FIELD, {
       allowedTools: ["other_tool"],
     });
 
-    grantAcpSpawnPolicy(ACP_OAUTH_TOKEN_FIELD, "desc");
+    repairAcpSpawnPolicy(ACP_OAUTH_TOKEN_FIELD, "desc");
 
-    // Unlike ensureAcpCredentialPolicy (which preserves), grant adds acp_spawn.
+    // Unlike ensureAcpCredentialPolicy (which preserves), the repair widens.
     expect(oauthMetadata()?.allowedTools).toEqual([
       "other_tool",
       ACP_SPAWN_TOOL,
     ]);
   });
 
-  test("leaves an allowedTools that already includes acp_spawn unchanged", () => {
+  test("clears a domain restriction the broker refuses server-side, keeping the tools", () => {
+    upsertCredentialMetadata(ACP_SERVICE, ACP_OAUTH_TOKEN_FIELD, {
+      allowedTools: [ACP_SPAWN_TOOL],
+      allowedDomains: ["api.anthropic.com"],
+    });
+
+    repairAcpSpawnPolicy(ACP_OAUTH_TOKEN_FIELD, "desc");
+
+    expect(oauthMetadata()?.allowedDomains).toEqual([]);
+    expect(oauthMetadata()?.allowedTools).toEqual([ACP_SPAWN_TOOL]);
+  });
+
+  test("repairs both halves of a denied policy in one pass", () => {
+    upsertCredentialMetadata(ACP_SERVICE, ACP_OAUTH_TOKEN_FIELD, {
+      allowedTools: ["other_tool"],
+      allowedDomains: ["api.anthropic.com"],
+    });
+
+    repairAcpSpawnPolicy(ACP_OAUTH_TOKEN_FIELD, "desc");
+
+    expect(oauthMetadata()?.allowedTools).toEqual([
+      "other_tool",
+      ACP_SPAWN_TOOL,
+    ]);
+    expect(oauthMetadata()?.allowedDomains).toEqual([]);
+  });
+
+  test("writes nothing when the stored policy already satisfies both halves", async () => {
     upsertCredentialMetadata(ACP_SERVICE, ACP_OAUTH_TOKEN_FIELD, {
       allowedTools: [ACP_SPAWN_TOOL, "other_tool"],
     });
+    const before = oauthMetadata();
+    // Every upsert stamps `updatedAt` with the current millisecond, so waiting
+    // here makes an unconditional write show up as a changed record.
+    await Bun.sleep(5);
 
-    grantAcpSpawnPolicy(ACP_OAUTH_TOKEN_FIELD, "desc");
+    repairAcpSpawnPolicy(ACP_OAUTH_TOKEN_FIELD, "desc");
 
-    expect(oauthMetadata()?.allowedTools).toEqual([
-      ACP_SPAWN_TOOL,
-      "other_tool",
-    ]);
+    expect(oauthMetadata()).toEqual(before);
   });
 });
 

--- a/assistant/src/acp/acp-claude-oauth.ts
+++ b/assistant/src/acp/acp-claude-oauth.ts
@@ -17,10 +17,6 @@ import {
   getSecureKeyAsync,
   setSecureKeyAsync,
 } from "../security/secure-keys.js";
-import {
-  getCredentialMetadata,
-  upsertCredentialMetadata,
-} from "../tools/credentials/metadata-store.js";
 import { getLogger } from "../util/logger.js";
 import {
   ACP_OAUTH_TOKEN_FIELD,
@@ -28,8 +24,9 @@ import {
   classifyAnthropicToken,
 } from "./acp-credentials.js";
 import {
+  ACP_CLAUDE_OAUTH_USAGE_DESCRIPTION,
   acpSpawnCredentialDenialReason,
-  grantAcpSpawnPolicy,
+  repairAcpSpawnPolicy,
 } from "./prepare-agent-env.js";
 
 const log = getLogger("acp:claude-oauth");
@@ -128,24 +125,14 @@ export async function storeAcpClaudeToken(token: string): Promise<void> {
   if (!stored) {
     throw new Error("Failed to store Claude OAuth token in secure storage.");
   }
-  // Force-grant acp_spawn (union) rather than merely ensure it: an explicit
-  // Connect is a deliberate opt-in to ACP, so this repairs a credential whose
-  // explicit allowedTools omitted acp_spawn — otherwise the broker keeps denying
-  // the spawn read and the Connect card dead-loops on every auto-continue.
-  grantAcpSpawnPolicy(
+  // Repair rather than merely ensure the policy: an explicit Connect is a
+  // deliberate opt-in to ACP, so this widens a credential the broker would
+  // otherwise keep denying the spawn read on, which would dead-loop the Connect
+  // card on every auto-continue.
+  repairAcpSpawnPolicy(
     ACP_OAUTH_TOKEN_FIELD,
-    "Claude OAuth token for ACP agent authentication",
+    ACP_CLAUDE_OAUTH_USAGE_DESCRIPTION,
   );
-  // Same deliberate opt-in, applied to the other half of the policy the broker
-  // checks. This field is OAuth-only and server-use-only, and the broker refuses
-  // a domain-restricted credential server-side, so a lingering restriction would
-  // keep every spawn failing even after a successful connect.
-  const meta = getCredentialMetadata(ACP_SERVICE, ACP_OAUTH_TOKEN_FIELD);
-  if ((meta?.allowedDomains ?? []).length > 0) {
-    upsertCredentialMetadata(ACP_SERVICE, ACP_OAUTH_TOKEN_FIELD, {
-      allowedDomains: [],
-    });
-  }
 }
 
 /**

--- a/assistant/src/acp/prepare-agent-env.ts
+++ b/assistant/src/acp/prepare-agent-env.ts
@@ -43,12 +43,20 @@ const log = getLogger("acp:prepare-agent-env");
 const ACP_SPAWN_TOOL = "acp_spawn";
 
 /**
+ * `usageDescription` recorded on `acp/claude_oauth_token` when a record is
+ * created, shared by the spawn-time ensure and the Connect repair so the two
+ * paths can't describe the same credential differently.
+ */
+export const ACP_CLAUDE_OAUTH_USAGE_DESCRIPTION =
+  "Claude OAuth token for ACP agent authentication";
+
+/**
  * Stable, machine-readable marker carried on the `FailedDependencyError.details`
  * when a `claude-agent-acp` spawn is missing `CLAUDE_CODE_OAUTH_TOKEN`. Threaded
  * through the tool result / error payload as a structured field so clients can
  * offer the inline "Connect Claude Code" flow instead of re-parsing the human
  * message string. Kept in lockstep with the web literal in
- * `clients/web/src/domains/chat/transcript/acp-connect-affordance.tsx`.
+ * `clients/web/src/domains/chat/utils/acp-connect.ts`.
  */
 export const ACP_CLAUDE_OAUTH_MISSING_CODE = "acp_claude_oauth_missing";
 
@@ -117,31 +125,38 @@ export function ensureAcpCredentialPolicy(
 }
 
 /**
- * Force-grant the `acp_spawn` read policy on `acp/<field>`, unioning it into any
- * existing `allowedTools`. Unlike {@link ensureAcpCredentialPolicy} (which
- * PRESERVES an explicit non-empty policy so a passive spawn can't silently widen
- * it), this is for the EXPLICIT Connect flow: a user connecting Claude is a
- * deliberate opt-in to `acp_spawn`, so granting it makes the CTA actually repair
- * a policy-denied credential instead of dead-looping the missing-token card.
+ * Make `acp/<field>` readable by the spawn: union `acp_spawn` into any existing
+ * `allowedTools` and drop any domain restriction, in ONE write and only when the
+ * stored record fails either half. This is the whole repair the Connect flow
+ * performs, so a new dimension of {@link serverUseDenialReason} is repaired in
+ * exactly one place.
+ *
+ * Unlike {@link ensureAcpCredentialPolicy} (which PRESERVES an explicit non-empty
+ * policy so a passive spawn can't silently widen it), this is for the EXPLICIT
+ * Connect flow: a user connecting Claude is a deliberate opt-in to `acp_spawn`,
+ * so granting it makes the CTA actually repair a policy-denied credential instead
+ * of dead-looping the missing-token card. Domains are cleared under the same
+ * opt-in: this field is OAuth-only and server-use-only, and the broker refuses a
+ * domain-restricted credential server-side, so a lingering restriction would keep
+ * every spawn failing even after a successful connect.
  */
-export function grantAcpSpawnPolicy(
+export function repairAcpSpawnPolicy(
   field: string,
   usageDescription: string,
 ): void {
   const meta = getCredentialMetadata(ACP_SERVICE, field);
-  if (!meta) {
-    upsertCredentialMetadata(ACP_SERVICE, field, {
-      allowedTools: [ACP_SPAWN_TOOL],
-      usageDescription,
-    });
+  const tools = meta?.allowedTools ?? [];
+  const spawnAllowed = tools.includes(ACP_SPAWN_TOOL);
+  const domainUnrestricted = (meta?.allowedDomains ?? []).length === 0;
+  if (meta && spawnAllowed && domainUnrestricted) {
     return;
   }
-  const tools = meta.allowedTools ?? [];
-  if (!tools.includes(ACP_SPAWN_TOOL)) {
-    upsertCredentialMetadata(ACP_SERVICE, field, {
-      allowedTools: [...tools, ACP_SPAWN_TOOL],
-    });
-  }
+  upsertCredentialMetadata(ACP_SERVICE, field, {
+    allowedTools: spawnAllowed ? tools : [...tools, ACP_SPAWN_TOOL],
+    allowedDomains: [],
+    // Only a fresh record takes the description; an existing one keeps its own.
+    ...(meta ? {} : { usageDescription }),
+  });
 }
 
 /**
@@ -293,7 +308,7 @@ export async function prepareAgentEnv(
         env,
         ACP_OAUTH_TOKEN_FIELD,
         "CLAUDE_CODE_OAUTH_TOKEN",
-        "Claude OAuth token for ACP agent authentication",
+        ACP_CLAUDE_OAUTH_USAGE_DESCRIPTION,
       );
     }
     // Any api-key-shaped value still standing here came from the vault read:

--- a/clients/web/src/domains/chat/transcript/acp-connect-affordance.tsx
+++ b/clients/web/src/domains/chat/transcript/acp-connect-affordance.tsx
@@ -105,8 +105,9 @@ function AcpConnectAffordanceInner({ assistantId }: { assistantId: string }) {
     // Leave a breadcrumb: the card flashing and vanishing is otherwise silent,
     // and a self-heal dismissal next to a fresh missing-token failure is the
     // signature of a status/spawn predicate mismatch. It goes in the durable
-    // lifecycle ring because streaming floods the high-volume ring, which held
-    // only minutes of history in the bundle that motivated this breadcrumb.
+    // lifecycle ring because streaming floods the high-volume ring, which then
+    // evicts within minutes, and the breadcrumb has to survive until a feedback
+    // bundle is captured.
     const store = useInteractionStore.getState();
     recordLifecycleDiagnostic("acp_connect_self_heal_dismiss", {
       assistantId,


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan self-review for acp-connect-split-brain.md.

**Gap A:** the Connect repair was split (acp_spawn grant in prepare-agent-env.ts, domain-clear in acp-claude-oauth.ts); now one repairAcpSpawnPolicy with a single read and single conditional upsert
**Gap B:** folded tautological broker seam tests into existing denial tests; trimmed hasAcpClaudeToken's re-derived policy matrix
**Gap C:** corrected the stale wire-contract pointer comment and a history-narrating web comment