### PR TITLE
Fix the ACP Connect Claude Code card self-dismiss split-brain

### DIFF
--- a/assistant/src/__tests__/credential-broker-server-use.test.ts
+++ b/assistant/src/__tests__/credential-broker-server-use.test.ts
@@ -44,9 +44,24 @@ import { setSecureKeyAsync } from "../security/secure-keys.js";
 import { CredentialBroker } from "../tools/credentials/broker.js";
 import {
   _setMetadataPath,
+  type CredentialMetadata,
   upsertCredentialMetadata,
 } from "../tools/credentials/metadata-store.js";
 import { serverUseDenialReason } from "../tools/credentials/tool-policy.js";
+
+/** The shared policy's verdict for a state the broker must also deny. */
+function sharedDenialReason(
+  metadata: CredentialMetadata,
+  toolName: string,
+  service: string,
+  field: string,
+): string {
+  const reason = serverUseDenialReason(metadata, toolName, service, field);
+  if (!reason) {
+    throw new Error("expected a denial reason from the shared policy");
+  }
+  return reason;
+}
 
 // ---------------------------------------------------------------------------
 // Tests — serverUse (publish_page / unpublish_page regression)
@@ -519,9 +534,10 @@ describe("CredentialBroker.serverUseById", () => {
     if (result.success) {
       throw new Error("expected denial");
     }
-    expect(result.reason).toContain("not allowed");
-    expect(result.reason).toContain("unauthorized_tool");
-    expect(result.reason).toContain("media_proxy");
+    // The broker passes the shared server-use policy's verdict through verbatim.
+    expect(result.reason).toBe(
+      sharedDenialReason(meta, "unauthorized_tool", "fal", "api_key"),
+    );
   });
 
   test("returns not found for unknown credential ID", async () => {
@@ -554,8 +570,10 @@ describe("CredentialBroker.serverUseById", () => {
     if (result.success) {
       throw new Error("expected denial");
     }
-    expect(result.reason).toContain("domain restrictions");
-    expect(result.reason).toContain("cannot be used server-side");
+    // The broker passes the shared server-use policy's verdict through verbatim.
+    expect(result.reason).toBe(
+      sharedDenialReason(meta, "media_proxy", "github", "oauth_token"),
+    );
   });
 
   test("returns empty injection templates when credential has none", async () => {
@@ -625,60 +643,5 @@ describe("CredentialBroker.serverUseById", () => {
       throw new Error("expected denial");
     }
     expect(result.reason).toContain("no stored value");
-  });
-
-  test("tool denial reason matches the shared server-use policy exactly", async () => {
-    const meta = upsertCredentialMetadata("fal", "api_key", {
-      allowedTools: ["media_proxy"],
-    });
-    await setSecureKeyAsync(credentialKey("fal", "api_key"), "fal-secret-key");
-
-    const result = await broker.serverUseById({
-      credentialId: meta.credentialId,
-      requestingTool: "unauthorized_tool",
-    });
-
-    expect(result.success).toBe(false);
-    if (result.success) {
-      throw new Error("expected denial");
-    }
-    const expected = serverUseDenialReason(
-      meta,
-      "unauthorized_tool",
-      "fal",
-      "api_key",
-    );
-    if (!expected) {
-      throw new Error("expected a denial reason from the shared policy");
-    }
-    expect(result.reason).toBe(expected);
-  });
-
-  test("domain denial reason matches the shared server-use policy exactly", async () => {
-    const meta = upsertCredentialMetadata("github", "oauth_token", {
-      allowedTools: ["media_proxy"],
-      allowedDomains: ["github.com"],
-    });
-    await setSecureKeyAsync(credentialKey("github", "oauth_token"), "gho_test");
-
-    const result = await broker.serverUseById({
-      credentialId: meta.credentialId,
-      requestingTool: "media_proxy",
-    });
-
-    expect(result.success).toBe(false);
-    if (result.success) {
-      throw new Error("expected denial");
-    }
-    const expected = serverUseDenialReason(
-      meta,
-      "media_proxy",
-      "github",
-      "oauth_token",
-    );
-    if (!expected) {
-      throw new Error("expected a denial reason from the shared policy");
-    }
-    expect(result.reason).toBe(expected);
   });
 });

--- a/assistant/src/__tests__/credential-broker-server-use.test.ts
+++ b/assistant/src/__tests__/credential-broker-server-use.test.ts
@@ -46,6 +46,7 @@ import {
   _setMetadataPath,
   upsertCredentialMetadata,
 } from "../tools/credentials/metadata-store.js";
+import { serverUseDenialReason } from "../tools/credentials/tool-policy.js";
 
 // ---------------------------------------------------------------------------
 // Tests — serverUse (publish_page / unpublish_page regression)
@@ -624,5 +625,60 @@ describe("CredentialBroker.serverUseById", () => {
       throw new Error("expected denial");
     }
     expect(result.reason).toContain("no stored value");
+  });
+
+  test("tool denial reason matches the shared server-use policy exactly", async () => {
+    const meta = upsertCredentialMetadata("fal", "api_key", {
+      allowedTools: ["media_proxy"],
+    });
+    await setSecureKeyAsync(credentialKey("fal", "api_key"), "fal-secret-key");
+
+    const result = await broker.serverUseById({
+      credentialId: meta.credentialId,
+      requestingTool: "unauthorized_tool",
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      throw new Error("expected denial");
+    }
+    const expected = serverUseDenialReason(
+      meta,
+      "unauthorized_tool",
+      "fal",
+      "api_key",
+    );
+    if (!expected) {
+      throw new Error("expected a denial reason from the shared policy");
+    }
+    expect(result.reason).toBe(expected);
+  });
+
+  test("domain denial reason matches the shared server-use policy exactly", async () => {
+    const meta = upsertCredentialMetadata("github", "oauth_token", {
+      allowedTools: ["media_proxy"],
+      allowedDomains: ["github.com"],
+    });
+    await setSecureKeyAsync(credentialKey("github", "oauth_token"), "gho_test");
+
+    const result = await broker.serverUseById({
+      credentialId: meta.credentialId,
+      requestingTool: "media_proxy",
+    });
+
+    expect(result.success).toBe(false);
+    if (result.success) {
+      throw new Error("expected denial");
+    }
+    const expected = serverUseDenialReason(
+      meta,
+      "media_proxy",
+      "github",
+      "oauth_token",
+    );
+    if (!expected) {
+      throw new Error("expected a denial reason from the shared policy");
+    }
+    expect(result.reason).toBe(expected);
   });
 });

--- a/assistant/src/__tests__/tool-policy.test.ts
+++ b/assistant/src/__tests__/tool-policy.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "bun:test";
 
-import { isToolAllowed } from "../tools/credentials/tool-policy.js";
+import type { CredentialMetadata } from "../tools/credentials/metadata-store.js";
+import {
+  BROWSER_FILL_CAPABILITY,
+  isToolAllowed,
+  serverUseDenialReason,
+} from "../tools/credentials/tool-policy.js";
 
 describe("isToolAllowed", () => {
   // ── Allow cases ─────────────────────────────────────────────────────
@@ -70,5 +75,96 @@ describe("isToolAllowed", () => {
     expect(
       isToolAllowed("Browser_Fill_Credential", ["browser_fill_credential"]),
     ).toBe(false);
+  });
+});
+
+describe("serverUseDenialReason", () => {
+  function metadata(
+    overrides: Partial<CredentialMetadata> = {},
+  ): CredentialMetadata {
+    return {
+      credentialId: "cred-1",
+      service: "acp",
+      field: "claude_oauth_token",
+      allowedTools: ["acp_spawn"],
+      allowedDomains: [],
+      createdAt: 0,
+      updatedAt: 0,
+      ...overrides,
+    };
+  }
+
+  test("denies when metadata is missing", () => {
+    expect(
+      serverUseDenialReason(
+        undefined,
+        "acp_spawn",
+        "acp",
+        "claude_oauth_token",
+      ),
+    ).toBe("No credential found for acp/claude_oauth_token");
+  });
+
+  test("denies fail-closed when allowedTools is empty", () => {
+    const reason = serverUseDenialReason(
+      metadata({ allowedTools: [] }),
+      "acp_spawn",
+      "acp",
+      "claude_oauth_token",
+    );
+    expect(reason).toContain(
+      'Tool "acp_spawn" is not allowed to use credential acp/claude_oauth_token.',
+    );
+    expect(reason).toContain("No tools are currently allowed");
+  });
+
+  test("denies when allowedTools omits the requesting tool", () => {
+    const reason = serverUseDenialReason(
+      metadata({ allowedTools: ["bash", "web_fetch"] }),
+      "acp_spawn",
+      "acp",
+      "claude_oauth_token",
+    );
+    expect(reason).toContain(
+      'Tool "acp_spawn" is not allowed to use credential acp/claude_oauth_token.',
+    );
+    expect(reason).toContain("Allowed tools: bash, web_fetch.");
+  });
+
+  test("allows when a legacy alias canonicalizes to the requesting tool", () => {
+    expect(
+      serverUseDenialReason(
+        metadata({ allowedTools: ["browser_fill_credential"] }),
+        BROWSER_FILL_CAPABILITY,
+        "acp",
+        "claude_oauth_token",
+      ),
+    ).toBeUndefined();
+  });
+
+  test("denies a domain-restricted credential", () => {
+    expect(
+      serverUseDenialReason(
+        metadata({ allowedDomains: ["example.com", "example.org"] }),
+        "acp_spawn",
+        "acp",
+        "claude_oauth_token",
+      ),
+    ).toBe(
+      "Credential acp/claude_oauth_token has domain restrictions " +
+        "(example.com, example.org) and cannot be used server-side. " +
+        "Remove domain restrictions or use a separate credential without domain policy.",
+    );
+  });
+
+  test("allows fully-permitted metadata", () => {
+    expect(
+      serverUseDenialReason(
+        metadata(),
+        "acp_spawn",
+        "acp",
+        "claude_oauth_token",
+      ),
+    ).toBeUndefined();
   });
 });

--- a/assistant/src/acp/__tests__/acp-claude-oauth.test.ts
+++ b/assistant/src/acp/__tests__/acp-claude-oauth.test.ts
@@ -171,11 +171,7 @@ describe("parseManualClaudeCode", () => {
 // ---------------------------------------------------------------------------
 
 describe("storeAcpClaudeToken", () => {
-  test("writes the token and force-grants the acp_spawn policy (repairs a denied policy)", async () => {
-    upsertCredentialMetadata(ACP_SERVICE, OAUTH_FIELD, {
-      allowedTools: ["other_tool"],
-    });
-
+  test("writes the token to the acp/claude_oauth_token vault field", async () => {
     await storeAcpClaudeToken("sk-ant-oat-token");
 
     expect(setSecureKeyAsync).toHaveBeenCalledTimes(1);
@@ -183,52 +179,14 @@ describe("storeAcpClaudeToken", () => {
       "credential/acp/claude_oauth_token",
       "sk-ant-oat-token",
     );
-    // grant (union), not merely ensure (preserve) — so an explicit Connect
-    // repairs a credential whose allowedTools omitted acp_spawn.
-    expect(oauthMetadata()?.allowedTools).toEqual([
-      "other_tool",
-      ACP_SPAWN_TOOL,
-    ]);
-  });
-
-  test("clears a domain restriction the broker would refuse server-side", async () => {
-    upsertCredentialMetadata(ACP_SERVICE, OAUTH_FIELD, {
-      allowedTools: [ACP_SPAWN_TOOL],
-      allowedDomains: ["api.anthropic.com"],
-    });
-
-    await storeAcpClaudeToken("sk-ant-oat-token");
-
-    expect(oauthMetadata()?.allowedDomains).toEqual([]);
-    expect(oauthMetadata()?.allowedTools).toEqual([ACP_SPAWN_TOOL]);
-  });
-
-  test("leaves an already-unrestricted credential's domains alone", async () => {
-    upsertCredentialMetadata(ACP_SERVICE, OAUTH_FIELD, {
-      allowedTools: ["other_tool"],
-    });
-
-    await storeAcpClaudeToken("sk-ant-oat-token");
-
-    expect(oauthMetadata()?.allowedDomains).toEqual([]);
-    expect(oauthMetadata()?.allowedTools).toEqual([
-      "other_tool",
-      ACP_SPAWN_TOOL,
-    ]);
-  });
-
-  test("creates the standard record when there is no prior metadata", async () => {
-    await storeAcpClaudeToken("sk-ant-oat-token");
-
-    expect(oauthMetadata()?.allowedTools).toEqual([ACP_SPAWN_TOOL]);
-    expect(oauthMetadata()?.allowedDomains).toEqual([]);
   });
 
   test("takes a domain-restricted credential from not-connected to connected", async () => {
     // Invariant: when the vault holds a usable token whose domain policy
     // makes the spawn read fail, the status check keeps the Connect card
     // offered, and completing Connect repairs the policy so the retry after
-    // a successful sign-in succeeds.
+    // a successful sign-in succeeds. The per-shape repair details are covered
+    // by the repairAcpSpawnPolicy suite in prepare-agent-env.test.ts.
     upsertCredentialMetadata(ACP_SERVICE, OAUTH_FIELD, {
       allowedTools: [ACP_SPAWN_TOOL],
       allowedDomains: ["api.anthropic.com"],
@@ -281,29 +239,13 @@ describe("hasAcpClaudeToken", () => {
     expect(await hasAcpClaudeToken()).toBe(false);
   });
 
-  test("reports true with no metadata at all (the spawn would create it)", async () => {
-    getReturn = "sk-ant-oat-token";
-    expect(await hasAcpClaudeToken()).toBe(true);
-  });
-
   test("reports true for metadata with an empty allowedTools (the spawn would grant acp_spawn)", async () => {
+    // One allow-state case: the full policy matrix is guarded by the parity
+    // suite in prepare-agent-env.test.ts and the tool-policy unit tests.
     upsertCredentialMetadata(ACP_SERVICE, OAUTH_FIELD, { allowedTools: [] });
     getReturn = "sk-ant-oat-token";
 
     expect(await hasAcpClaudeToken()).toBe(true);
-  });
-
-  test("reports false when the spawn policy can't read the token (denied allowedTools)", async () => {
-    // A valid OAuth token is stored, but an explicit `allowedTools` that omits
-    // `acp_spawn` means the broker denies the spawn read. Reporting "connected"
-    // would self-dismiss the card and trap the user in a missing-token loop, so
-    // it stays not-connected to keep the repair CTA visible.
-    upsertCredentialMetadata(ACP_SERVICE, OAUTH_FIELD, {
-      allowedTools: ["other_tool"],
-    });
-    getReturn = "sk-ant-oat-token";
-
-    expect(await hasAcpClaudeToken()).toBe(false);
   });
 
   test("reports false for a domain-restricted credential the broker refuses server-side", async () => {

--- a/assistant/src/acp/__tests__/acp-claude-oauth.test.ts
+++ b/assistant/src/acp/__tests__/acp-claude-oauth.test.ts
@@ -36,6 +36,9 @@ mock.module("../../security/secure-keys.js", () => ({
 const { _setMetadataPath, getCredentialMetadata, upsertCredentialMetadata } =
   await import("../../tools/credentials/metadata-store.js");
 
+const { acpSpawnCredentialDenialReason } =
+  await import("../prepare-agent-env.js");
+
 const {
   CLAUDE_OAUTH_CONFIG,
   CLAUDE_MANUAL_REDIRECT_URI,
@@ -186,6 +189,57 @@ describe("storeAcpClaudeToken", () => {
       "other_tool",
       ACP_SPAWN_TOOL,
     ]);
+  });
+
+  test("clears a domain restriction the broker would refuse server-side", async () => {
+    upsertCredentialMetadata(ACP_SERVICE, OAUTH_FIELD, {
+      allowedTools: [ACP_SPAWN_TOOL],
+      allowedDomains: ["api.anthropic.com"],
+    });
+
+    await storeAcpClaudeToken("sk-ant-oat-token");
+
+    expect(oauthMetadata()?.allowedDomains).toEqual([]);
+    expect(oauthMetadata()?.allowedTools).toEqual([ACP_SPAWN_TOOL]);
+  });
+
+  test("leaves an already-unrestricted credential's domains alone", async () => {
+    upsertCredentialMetadata(ACP_SERVICE, OAUTH_FIELD, {
+      allowedTools: ["other_tool"],
+    });
+
+    await storeAcpClaudeToken("sk-ant-oat-token");
+
+    expect(oauthMetadata()?.allowedDomains).toEqual([]);
+    expect(oauthMetadata()?.allowedTools).toEqual([
+      "other_tool",
+      ACP_SPAWN_TOOL,
+    ]);
+  });
+
+  test("creates the standard record when there is no prior metadata", async () => {
+    await storeAcpClaudeToken("sk-ant-oat-token");
+
+    expect(oauthMetadata()?.allowedTools).toEqual([ACP_SPAWN_TOOL]);
+    expect(oauthMetadata()?.allowedDomains).toEqual([]);
+  });
+
+  test("takes a domain-restricted credential from not-connected to connected", async () => {
+    // Invariant: when the vault holds a usable token whose domain policy
+    // makes the spawn read fail, the status check keeps the Connect card
+    // offered, and completing Connect repairs the policy so the retry after
+    // a successful sign-in succeeds.
+    upsertCredentialMetadata(ACP_SERVICE, OAUTH_FIELD, {
+      allowedTools: [ACP_SPAWN_TOOL],
+      allowedDomains: ["api.anthropic.com"],
+    });
+    getReturn = "sk-ant-oat-token";
+    expect(await hasAcpClaudeToken()).toBe(false);
+
+    await storeAcpClaudeToken("sk-ant-oat-token");
+
+    expect(await hasAcpClaudeToken()).toBe(true);
+    expect(acpSpawnCredentialDenialReason(OAUTH_FIELD)).toBeUndefined();
   });
 
   test("throws when the secure store rejects the write", async () => {

--- a/assistant/src/acp/__tests__/acp-claude-oauth.test.ts
+++ b/assistant/src/acp/__tests__/acp-claude-oauth.test.ts
@@ -1,13 +1,21 @@
 /**
  * Tests for the Claude OAuth config + capture/store helpers.
  *
- * The store helper reaches into secure-keys and the ACP credential policy, so
- * we mock both (wired BEFORE importing the module under test via dynamic
- * import) and assert the vault write targets `credential/acp/claude_oauth_token`
- * and throws when the backend rejects the write.
+ * The store helper reaches into secure-keys, so we mock that (wired BEFORE
+ * importing the module under test via dynamic import) and assert the vault
+ * write targets `credential/acp/claude_oauth_token` and throws when the backend
+ * rejects the write.
+ *
+ * The ACP credential policy is NOT mocked: `hasAcpClaudeToken` has to answer
+ * exactly what the spawn-time broker read would, so it is exercised against the
+ * real metadata store (pointed at a temp dir) and the real policy evaluation.
  */
 
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { randomBytes } from "node:crypto";
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 // ---------------------------------------------------------------------------
 // Mocks — wired BEFORE importing the module via dynamic import.
@@ -19,20 +27,14 @@ const setSecureKeyAsync = mock(
   async (_account: string, _value: string) => storeReturn,
 );
 const getSecureKeyAsync = mock(async (_account: string) => getReturn);
-const grantAcpSpawnPolicy = mock(
-  (_field: string, _usageDescription: string) => {},
-);
-let spawnCanRead = true;
-const acpSpawnCanReadCredential = mock((_field: string) => spawnCanRead);
 
 mock.module("../../security/secure-keys.js", () => ({
   setSecureKeyAsync,
   getSecureKeyAsync,
 }));
-mock.module("../prepare-agent-env.js", () => ({
-  grantAcpSpawnPolicy,
-  acpSpawnCanReadCredential,
-}));
+
+const { _setMetadataPath, getCredentialMetadata, upsertCredentialMetadata } =
+  await import("../../tools/credentials/metadata-store.js");
 
 const {
   CLAUDE_OAUTH_CONFIG,
@@ -43,14 +45,31 @@ const {
   hasAcpClaudeToken,
 } = await import("../acp-claude-oauth.js");
 
+const ACP_SERVICE = "acp";
+const OAUTH_FIELD = "claude_oauth_token";
+const ACP_SPAWN_TOOL = "acp_spawn";
+
+const TEST_DIR = join(
+  tmpdir(),
+  `vellum-acp-claude-oauth-test-${randomBytes(4).toString("hex")}`,
+);
+
+function oauthMetadata() {
+  return getCredentialMetadata(ACP_SERVICE, OAUTH_FIELD);
+}
+
 beforeEach(() => {
+  mkdirSync(TEST_DIR, { recursive: true });
+  _setMetadataPath(join(TEST_DIR, "metadata.json"));
   storeReturn = true;
   getReturn = undefined;
-  spawnCanRead = true;
   setSecureKeyAsync.mockClear();
   getSecureKeyAsync.mockClear();
-  grantAcpSpawnPolicy.mockClear();
-  acpSpawnCanReadCredential.mockClear();
+});
+
+afterEach(() => {
+  _setMetadataPath(null);
+  rmSync(TEST_DIR, { recursive: true, force: true });
 });
 
 // ---------------------------------------------------------------------------
@@ -150,6 +169,10 @@ describe("parseManualClaudeCode", () => {
 
 describe("storeAcpClaudeToken", () => {
   test("writes the token and force-grants the acp_spawn policy (repairs a denied policy)", async () => {
+    upsertCredentialMetadata(ACP_SERVICE, OAUTH_FIELD, {
+      allowedTools: ["other_tool"],
+    });
+
     await storeAcpClaudeToken("sk-ant-oat-token");
 
     expect(setSecureKeyAsync).toHaveBeenCalledTimes(1);
@@ -159,8 +182,10 @@ describe("storeAcpClaudeToken", () => {
     );
     // grant (union), not merely ensure (preserve) — so an explicit Connect
     // repairs a credential whose allowedTools omitted acp_spawn.
-    expect(grantAcpSpawnPolicy).toHaveBeenCalledTimes(1);
-    expect(grantAcpSpawnPolicy.mock.calls[0][0]).toBe("claude_oauth_token");
+    expect(oauthMetadata()?.allowedTools).toEqual([
+      "other_tool",
+      ACP_SPAWN_TOOL,
+    ]);
   });
 
   test("throws when the secure store rejects the write", async () => {
@@ -169,7 +194,7 @@ describe("storeAcpClaudeToken", () => {
     await expect(storeAcpClaudeToken("sk-ant-oat-token")).rejects.toThrow(
       /Failed to store/,
     );
-    expect(grantAcpSpawnPolicy).not.toHaveBeenCalled();
+    expect(oauthMetadata()).toBeUndefined();
   });
 });
 
@@ -202,13 +227,60 @@ describe("hasAcpClaudeToken", () => {
     expect(await hasAcpClaudeToken()).toBe(false);
   });
 
+  test("reports true with no metadata at all (the spawn would create it)", async () => {
+    getReturn = "sk-ant-oat-token";
+    expect(await hasAcpClaudeToken()).toBe(true);
+  });
+
+  test("reports true for metadata with an empty allowedTools (the spawn would grant acp_spawn)", async () => {
+    upsertCredentialMetadata(ACP_SERVICE, OAUTH_FIELD, { allowedTools: [] });
+    getReturn = "sk-ant-oat-token";
+
+    expect(await hasAcpClaudeToken()).toBe(true);
+  });
+
   test("reports false when the spawn policy can't read the token (denied allowedTools)", async () => {
     // A valid OAuth token is stored, but an explicit `allowedTools` that omits
     // `acp_spawn` means the broker denies the spawn read. Reporting "connected"
     // would self-dismiss the card and trap the user in a missing-token loop, so
     // it stays not-connected to keep the repair CTA visible.
+    upsertCredentialMetadata(ACP_SERVICE, OAUTH_FIELD, {
+      allowedTools: ["other_tool"],
+    });
     getReturn = "sk-ant-oat-token";
-    spawnCanRead = false;
+
     expect(await hasAcpClaudeToken()).toBe(false);
+  });
+
+  test("reports false for a domain-restricted credential the broker refuses server-side", async () => {
+    // acp_spawn is allowed, but a non-empty allowedDomains scopes the credential
+    // to browser fills, so every spawn read is denied. The status check has to
+    // see that too, otherwise the Connect card self-dismisses while acp_spawn
+    // keeps failing with the missing-token marker.
+    upsertCredentialMetadata(ACP_SERVICE, OAUTH_FIELD, {
+      allowedTools: [ACP_SPAWN_TOOL],
+      allowedDomains: ["api.anthropic.com"],
+    });
+    getReturn = "sk-ant-oat-token";
+
+    expect(await hasAcpClaudeToken()).toBe(false);
+  });
+
+  test("writes nothing to the metadata store (the status route is a GET)", async () => {
+    upsertCredentialMetadata(ACP_SERVICE, OAUTH_FIELD, { allowedTools: [] });
+    getReturn = "sk-ant-oat-token";
+    const before = oauthMetadata();
+
+    await hasAcpClaudeToken();
+
+    expect(oauthMetadata()).toEqual(before);
+  });
+
+  test("creates no metadata when there is none to begin with", async () => {
+    getReturn = "sk-ant-oat-token";
+
+    await hasAcpClaudeToken();
+
+    expect(oauthMetadata()).toBeUndefined();
   });
 });

--- a/assistant/src/acp/__tests__/prepare-agent-env.test.ts
+++ b/assistant/src/acp/__tests__/prepare-agent-env.test.ts
@@ -10,15 +10,21 @@
  * exercised for real here: the metadata store and the encrypted secure-key
  * store are pointed at a temp dir, so the tool and domain policy these tests
  * observe is the same policy production evaluates.
+ *
+ * The module logger is the one exception. `mock.module` does not hoist above
+ * static imports, so the module under test is imported dynamically AFTER the
+ * mock is installed: that makes `prepare-agent-env.js` the only module holding
+ * the spy logger, so every warn the spy records came from `prepareAgentEnv`.
  */
 
 import { randomBytes } from "node:crypto";
 import { mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 import { setStorePathForTesting } from "../../__tests__/encrypted-store-test-helpers.js";
+import { createMockLoggerModule } from "../../__tests__/helpers/mock-logger.js";
 import { FailedDependencyError } from "../../runtime/routes/errors.js";
 import { credentialKey } from "../../security/credential-key.js";
 import {
@@ -33,13 +39,29 @@ import {
   upsertCredentialMetadata,
 } from "../../tools/credentials/metadata-store.js";
 import { ACP_OAUTH_TOKEN_FIELD, ACP_SERVICE } from "../acp-credentials.js";
-import {
+
+const mockLogWarn = mock((_fields: unknown, _msg: string) => {});
+
+mock.module("../../util/logger.js", () =>
+  createMockLoggerModule({
+    getLogger: () => ({
+      warn: mockLogWarn,
+      info: () => {},
+      error: () => {},
+      debug: () => {},
+      trace: () => {},
+      fatal: () => {},
+    }),
+  }),
+);
+
+const {
   ACP_CLAUDE_OAUTH_MISSING_CODE,
   acpSpawnCredentialDenialReason,
   ensureAcpCredentialPolicy,
   grantAcpSpawnPolicy,
   prepareAgentEnv,
-} from "../prepare-agent-env.js";
+} = await import("../prepare-agent-env.js");
 
 const ACP_SPAWN_TOOL = "acp_spawn";
 
@@ -53,6 +75,7 @@ beforeEach(() => {
   setStorePathForTesting(join(TEST_DIR, "keys.enc"));
   _resetBackend();
   _setMetadataPath(join(TEST_DIR, "metadata.json"));
+  mockLogWarn.mockClear();
 });
 
 afterEach(() => {
@@ -76,6 +99,22 @@ function seedVaultToken(token: string): Promise<void> {
 
 function oauthMetadata() {
   return getCredentialMetadata(ACP_SERVICE, ACP_OAUTH_TOKEN_FIELD);
+}
+
+/**
+ * Structured fields of the single injection-miss warn the module emitted.
+ * Exactly one line per failed spawn: it is the operator's only record of WHY
+ * the token was missing, and a duplicate would double-count in log searches.
+ */
+function soleInjectionMissWarnFields(): Record<string, unknown> {
+  expect(mockLogWarn).toHaveBeenCalledTimes(1);
+  const [fields, message] = mockLogWarn.mock.calls[0] as [
+    Record<string, unknown>,
+    string,
+  ];
+  expect(message).toBe("Claude OAuth token not injected for acp_spawn");
+  expect(fields.field).toBe(ACP_OAUTH_TOKEN_FIELD);
+  return fields;
 }
 
 describe("prepareAgentEnv — claude-agent-acp gating", () => {
@@ -198,6 +237,66 @@ describe("prepareAgentEnv — claude-agent-acp gating", () => {
     // card actually renders above the model's reply, so "below" is always wrong.
     expect(message).toContain('never say "below"');
     expect(message).toContain('"above"');
+    // Pins the seam between the opening and the shared guidance: an absent
+    // value keeps the "which is not set" wording verbatim.
+    expect(message).toContain(
+      'which is not set. The app shows the user an inline "Connect Claude Code" card.',
+    );
+
+    // The operator-facing half: the broker's own reason, classified.
+    const fields = soleInjectionMissWarnFields();
+    expect(fields.missReason).toContain("no stored value");
+    expect(fields.policyBlocked).toBe(false);
+    expect(fields.apiKeyShaped).toBe(false);
+  });
+
+  test("a policy-denied read logs the broker reason and reports the policy block", async () => {
+    // Invariant: a policy-denied read must be reported as a policy block, not
+    // as an absent value. The two states have different repair stories, and
+    // the message must never assert that a value is stored (policy is checked
+    // before the value, so metadata alone can trigger this branch).
+    upsertCredentialMetadata(ACP_SERVICE, ACP_OAUTH_TOKEN_FIELD, {
+      allowedTools: ["bash"],
+    });
+    await seedVaultToken("sk-ant-oat01-policy-blocked");
+
+    let caught: unknown;
+    try {
+      await prepareAgentEnv({ command: "claude-agent-acp", args: [] });
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(FailedDependencyError);
+    // Same wire contract: old clients keep rendering the same Connect card.
+    expect((caught as FailedDependencyError).details).toEqual({
+      code: ACP_CLAUDE_OAUTH_MISSING_CODE,
+    });
+    const message = (caught as Error).message;
+    expect(message).toContain("cannot read the Claude OAuth token");
+    expect(message).toContain("blocks the acp_spawn read");
+    expect(message).toContain("CLAUDE_CODE_OAUTH_TOKEN");
+    expect(message).toContain("signs in again and repairs that policy");
+    // Policy is checked before the value, so the message must never assert
+    // that a value is actually stored.
+    expect(message).not.toContain("has a stored");
+    expect(message).not.toContain("which is not set");
+    // The guidance steering the model away from CLI/token-paste workarounds is
+    // shared with the missing-value variant, so it must survive here too.
+    expect(message).toContain("ONE short sentence");
+    expect(message).toContain("Do NOT");
+    expect(message).toContain("claude setup-token");
+    expect(message).toContain("do NOT retry the spawn yourself");
+    expect(message).toContain("assistant credentials prompt");
+
+    const fields = soleInjectionMissWarnFields();
+    expect(fields.missReason).toContain(
+      'Tool "acp_spawn" is not allowed to use credential acp/claude_oauth_token',
+    );
+    expect(fields.policyBlocked).toBe(true);
+    expect(fields.apiKeyShaped).toBe(false);
+    // The denial reason is a policy verdict, never the credential itself.
+    expect(JSON.stringify(fields)).not.toContain("sk-ant-oat01-policy-blocked");
   });
 
   test("does NOT attach the marker when a token is present (happy path unchanged)", async () => {
@@ -229,6 +328,20 @@ describe("prepareAgentEnv — claude-agent-acp gating", () => {
     expect((caught as FailedDependencyError).details).toEqual({
       code: ACP_CLAUDE_OAUTH_MISSING_CODE,
     });
+    // Connect genuinely repairs this by storing a fresh OAuth token, so the
+    // message stays the missing-token one rather than the policy-blocked one.
+    expect((caught as Error).message).toContain(
+      'which is not set. The app shows the user an inline "Connect Claude Code" card.',
+    );
+
+    // The log is where the api-key shape is recorded; the value never is.
+    const fields = soleInjectionMissWarnFields();
+    expect(fields.apiKeyShaped).toBe(true);
+    expect(fields.policyBlocked).toBe(false);
+    expect(fields.missReason).toBeUndefined();
+    expect(JSON.stringify(fields)).not.toContain(
+      "sk-ant-api03-legacy-bad-value",
+    );
   });
 
   test("routes an API key supplied via agent.env (config override) to the missing-token path", async () => {

--- a/assistant/src/acp/__tests__/prepare-agent-env.test.ts
+++ b/assistant/src/acp/__tests__/prepare-agent-env.test.ts
@@ -1,128 +1,86 @@
 /**
- * Tests for `prepareAgentEnv` — the shared helper that injects required env
+ * Tests for `prepareAgentEnv`, the shared helper that injects required env
  * vars onto an `AcpAgentConfig` and preflights that they're set.
  *
  * The route-level test in `runtime/routes/acp-routes.test.ts` covers the same
  * behavior through the HTTP handler; these tests pin the helper in isolation
  * so the contract is clear and a future refactor can't silently break it.
  *
- * Credential reads go through the credential broker (`serverUse`), so we
- * mock the broker and metadata store rather than the raw secure-keys backend.
+ * Credential reads go through the credential broker (`serverUse`), which is
+ * exercised for real here: the metadata store and the encrypted secure-key
+ * store are pointed at a temp dir, so the tool and domain policy these tests
+ * observe is the same policy production evaluates.
  */
 
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { randomBytes } from "node:crypto";
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
+import { setStorePathForTesting } from "../../__tests__/encrypted-store-test-helpers.js";
 import { FailedDependencyError } from "../../runtime/routes/errors.js";
+import { credentialKey } from "../../security/credential-key.js";
+import {
+  _resetBackend,
+  setSecureKeyAsync,
+} from "../../security/secure-keys.js";
+import { credentialBroker } from "../../tools/credentials/broker.js";
+import {
+  _setMetadataPath,
+  deleteCredentialMetadata,
+  getCredentialMetadata,
+  upsertCredentialMetadata,
+} from "../../tools/credentials/metadata-store.js";
+import { ACP_OAUTH_TOKEN_FIELD, ACP_SERVICE } from "../acp-credentials.js";
+import {
+  ACP_CLAUDE_OAUTH_MISSING_CODE,
+  acpSpawnCredentialDenialReason,
+  ensureAcpCredentialPolicy,
+  grantAcpSpawnPolicy,
+  prepareAgentEnv,
+} from "../prepare-agent-env.js";
 
-// ---------------------------------------------------------------------------
-// Stubs — wired BEFORE importing the helper via dynamic import.
-// ---------------------------------------------------------------------------
+const ACP_SPAWN_TOOL = "acp_spawn";
 
-/** Simulates the credential metadata store. */
-const metadataStore = new Map<
-  string,
-  { allowedTools: string[]; usageDescription?: string }
->();
-
-mock.module("../../tools/credentials/metadata-store.js", () => ({
-  getCredentialMetadata: (service: string, field: string) => {
-    const key = `${service}/${field}`;
-    const entry = metadataStore.get(key);
-    if (!entry) {
-      return undefined;
-    }
-    return {
-      credentialId: `cred-${key}`,
-      service,
-      field,
-      allowedTools: entry.allowedTools,
-      allowedDomains: [],
-      usageDescription: entry.usageDescription,
-      createdAt: 0,
-      updatedAt: 0,
-    };
-  },
-  upsertCredentialMetadata: (
-    service: string,
-    field: string,
-    policy?: { allowedTools?: string[]; usageDescription?: string },
-  ) => {
-    const key = `${service}/${field}`;
-    const existing = metadataStore.get(key);
-    metadataStore.set(key, {
-      allowedTools: policy?.allowedTools ?? existing?.allowedTools ?? [],
-      usageDescription: policy?.usageDescription ?? existing?.usageDescription,
-    });
-    return {
-      credentialId: `cred-${key}`,
-      service,
-      field,
-      allowedTools: metadataStore.get(key)!.allowedTools,
-      allowedDomains: [],
-      createdAt: 0,
-      updatedAt: 0,
-    };
-  },
-}));
-
-/**
- * Simulates the credential broker's serverUse method. The vault stores
- * plaintext values keyed by `service/field`; the broker enforces tool
- * policy via the metadata store before passing the value to the callback.
- */
-const vaultStore = new Map<string, string>();
-
-mock.module("../../tools/credentials/broker.js", () => ({
-  credentialBroker: {
-    serverUse: async <T>(request: {
-      service: string;
-      field: string;
-      toolName: string;
-      execute: (value: string) => Promise<T>;
-    }) => {
-      const key = `${request.service}/${request.field}`;
-      const meta = metadataStore.get(key);
-      if (!meta) {
-        return { success: false, reason: `No credential found for ${key}` };
-      }
-      if (!meta.allowedTools.includes(request.toolName)) {
-        return {
-          success: false,
-          reason: `Tool "${request.toolName}" not allowed`,
-        };
-      }
-      const value = vaultStore.get(key);
-      if (!value) {
-        return {
-          success: false,
-          reason: `No stored value for ${key}`,
-        };
-      }
-      const result = await request.execute(value);
-      return { success: true, result };
-    },
-  },
-}));
-
-const { prepareAgentEnv, ACP_CLAUDE_OAUTH_MISSING_CODE, grantAcpSpawnPolicy } =
-  await import("../prepare-agent-env.js");
+const TEST_DIR = join(
+  tmpdir(),
+  `vellum-prepare-agent-env-test-${randomBytes(4).toString("hex")}`,
+);
 
 beforeEach(() => {
-  metadataStore.clear();
-  vaultStore.clear();
+  mkdirSync(TEST_DIR, { recursive: true });
+  setStorePathForTesting(join(TEST_DIR, "keys.enc"));
+  _resetBackend();
+  _setMetadataPath(join(TEST_DIR, "metadata.json"));
+});
+
+afterEach(() => {
+  _setMetadataPath(null);
+  setStorePathForTesting(null);
+  _resetBackend();
+  rmSync(TEST_DIR, { recursive: true, force: true });
 });
 
 // ---------------------------------------------------------------------------
-// Helper to seed a vault entry (simulates `assistant credentials set`).
+// Helpers to seed the vault + metadata (simulates `assistant credentials set`).
 // ---------------------------------------------------------------------------
 
-function seedVaultToken(token: string): void {
-  vaultStore.set("acp/claude_oauth_token", token);
+async function seedVaultValue(field: string, value: string): Promise<void> {
+  await setSecureKeyAsync(credentialKey(ACP_SERVICE, field), value);
+}
+
+function seedVaultToken(token: string): Promise<void> {
+  return seedVaultValue(ACP_OAUTH_TOKEN_FIELD, token);
+}
+
+function oauthMetadata() {
+  return getCredentialMetadata(ACP_SERVICE, ACP_OAUTH_TOKEN_FIELD);
 }
 
 describe("prepareAgentEnv — claude-agent-acp gating", () => {
   test("injects CLAUDE_CODE_OAUTH_TOKEN from the vault via the broker when agent.env has no override", async () => {
-    seedVaultToken("vault-AAA");
+    await seedVaultToken("vault-AAA");
 
     const prepared = await prepareAgentEnv({
       command: "claude-agent-acp",
@@ -133,39 +91,35 @@ describe("prepareAgentEnv — claude-agent-acp gating", () => {
   });
 
   test("auto-registers metadata with acp_spawn in allowedTools when none exists", async () => {
-    seedVaultToken("vault-auto-meta");
+    await seedVaultToken("vault-auto-meta");
 
     await prepareAgentEnv({ command: "claude-agent-acp", args: [] });
 
-    const meta = metadataStore.get("acp/claude_oauth_token");
-    expect(meta).toBeDefined();
-    expect(meta!.allowedTools).toContain("acp_spawn");
+    expect(oauthMetadata()?.allowedTools).toContain(ACP_SPAWN_TOOL);
   });
 
   test("adds acp_spawn to metadata with empty allowedTools (default provisioning path)", async () => {
-    metadataStore.set("acp/claude_oauth_token", {
+    upsertCredentialMetadata(ACP_SERVICE, ACP_OAUTH_TOKEN_FIELD, {
       allowedTools: [],
     });
-    seedVaultToken("vault-augment");
+    await seedVaultToken("vault-augment");
 
     await prepareAgentEnv({ command: "claude-agent-acp", args: [] });
 
-    const meta = metadataStore.get("acp/claude_oauth_token");
-    expect(meta!.allowedTools).toContain("acp_spawn");
+    expect(oauthMetadata()?.allowedTools).toContain(ACP_SPAWN_TOOL);
   });
 
   test("respects explicit tool policy that excludes acp_spawn", async () => {
-    metadataStore.set("acp/claude_oauth_token", {
+    upsertCredentialMetadata(ACP_SERVICE, ACP_OAUTH_TOKEN_FIELD, {
       allowedTools: ["other_tool"],
     });
-    seedVaultToken("vault-restricted");
+    await seedVaultToken("vault-restricted");
 
     await expect(
       prepareAgentEnv({ command: "claude-agent-acp", args: [] }),
     ).rejects.toThrow("CLAUDE_CODE_OAUTH_TOKEN");
 
-    const meta = metadataStore.get("acp/claude_oauth_token");
-    expect(meta!.allowedTools).toEqual(["other_tool"]);
+    expect(oauthMetadata()?.allowedTools).toEqual(["other_tool"]);
   });
 
   test("accepts CLAUDE_CODE_OAUTH_TOKEN from agent.env (config.json override) with no vault entry", async () => {
@@ -179,7 +133,7 @@ describe("prepareAgentEnv — claude-agent-acp gating", () => {
   });
 
   test("agent.env override wins over the vault entry (precedence pin)", async () => {
-    seedVaultToken("vault-CCC");
+    await seedVaultToken("vault-CCC");
 
     const prepared = await prepareAgentEnv({
       command: "claude-agent-acp",
@@ -191,7 +145,7 @@ describe("prepareAgentEnv — claude-agent-acp gating", () => {
   });
 
   test("preserves unrelated env vars on agent.env when injecting from the vault", async () => {
-    seedVaultToken("vault-EEE");
+    await seedVaultToken("vault-EEE");
 
     const prepared = await prepareAgentEnv({
       command: "claude-agent-acp",
@@ -247,7 +201,7 @@ describe("prepareAgentEnv — claude-agent-acp gating", () => {
   });
 
   test("does NOT attach the marker when a token is present (happy path unchanged)", async () => {
-    seedVaultToken("vault-marker-absent");
+    await seedVaultToken("vault-marker-absent");
 
     const prepared = await prepareAgentEnv({
       command: "claude-agent-acp",
@@ -262,7 +216,7 @@ describe("prepareAgentEnv — claude-agent-acp gating", () => {
     // format guard existed must not spawn with a doomed credential (a 401 with
     // no repair). The presence check alone would pass, so the injected value is
     // classified and an API key is treated as missing → the Connect card fires.
-    seedVaultToken("sk-ant-api03-legacy-bad-value");
+    await seedVaultToken("sk-ant-api03-legacy-bad-value");
 
     let caught: unknown;
     try {
@@ -304,7 +258,7 @@ describe("prepareAgentEnv — claude-agent-acp gating", () => {
     // be used and the Connect card would re-fire forever. The bad override is
     // dropped BEFORE the read, so the vault OAuth token is picked up and spawn
     // proceeds instead of looping.
-    seedVaultToken("sk-ant-oat01-freshly-connected");
+    await seedVaultToken("sk-ant-oat01-freshly-connected");
 
     const prepared = await prepareAgentEnv({
       command: "claude-agent-acp",
@@ -318,7 +272,7 @@ describe("prepareAgentEnv — claude-agent-acp gating", () => {
   });
 
   test("keeps a valid OAuth token (sk-ant-oat…) usable (not misclassified)", async () => {
-    seedVaultToken("sk-ant-oat01-good-token");
+    await seedVaultToken("sk-ant-oat01-good-token");
 
     const prepared = await prepareAgentEnv({
       command: "claude-agent-acp",
@@ -331,7 +285,7 @@ describe("prepareAgentEnv — claude-agent-acp gating", () => {
   });
 
   test("gates on the resolved command BASENAME (alias to /custom/path/claude-agent-acp still gets the token)", async () => {
-    seedVaultToken("vault-FFF");
+    await seedVaultToken("vault-FFF");
 
     const prepared = await prepareAgentEnv({
       command: "/opt/bin/claude-agent-acp",
@@ -342,7 +296,7 @@ describe("prepareAgentEnv — claude-agent-acp gating", () => {
   });
 
   test("does NOT mutate the caller's agentConfig", async () => {
-    seedVaultToken("vault-GGG");
+    await seedVaultToken("vault-GGG");
     const original = {
       command: "claude-agent-acp",
       args: [],
@@ -360,16 +314,16 @@ describe("prepareAgentEnv — claude-agent-acp gating", () => {
 });
 
 describe("prepareAgentEnv - codex-acp gating", () => {
-  function seedVaultOpenaiKey(key: string): void {
-    vaultStore.set("acp/openai_api_key", key);
+  function seedVaultOpenaiKey(key: string): Promise<void> {
+    return seedVaultValue("openai_api_key", key);
   }
 
-  function seedVaultCodexKey(key: string): void {
-    vaultStore.set("acp/codex_api_key", key);
+  function seedVaultCodexKey(key: string): Promise<void> {
+    return seedVaultValue("codex_api_key", key);
   }
 
   test("injects OPENAI_API_KEY from the vault via the broker when agent.env has no override", async () => {
-    seedVaultOpenaiKey("vault-fake-openai-AAA");
+    await seedVaultOpenaiKey("vault-fake-openai-AAA");
 
     const prepared = await prepareAgentEnv({
       command: "codex-acp",
@@ -382,7 +336,7 @@ describe("prepareAgentEnv - codex-acp gating", () => {
   test("agent.env override wins over the vault entry and skips the broker (precedence pin)", async () => {
     // Seed a vault value but no metadata: if the override path consulted the
     // broker anyway, ensureAcpCredentialPolicy would create metadata here.
-    seedVaultOpenaiKey("vault-fake-openai-BBB");
+    await seedVaultOpenaiKey("vault-fake-openai-BBB");
 
     const prepared = await prepareAgentEnv({
       command: "codex-acp",
@@ -391,7 +345,9 @@ describe("prepareAgentEnv - codex-acp gating", () => {
     });
 
     expect(prepared.env?.OPENAI_API_KEY).toBe("config-fake-openai-CCC");
-    expect(metadataStore.has("acp/openai_api_key")).toBe(false);
+    expect(
+      getCredentialMetadata(ACP_SERVICE, "openai_api_key"),
+    ).toBeUndefined();
   });
 
   test("a vault miss for both fields does NOT throw and spawns with env unchanged (keys are optional)", async () => {
@@ -407,7 +363,7 @@ describe("prepareAgentEnv - codex-acp gating", () => {
   });
 
   test("injects CODEX_API_KEY independently of OPENAI_API_KEY", async () => {
-    seedVaultCodexKey("vault-fake-codex-DDD");
+    await seedVaultCodexKey("vault-fake-codex-DDD");
 
     const prepared = await prepareAgentEnv({
       command: "codex-acp",
@@ -419,8 +375,8 @@ describe("prepareAgentEnv - codex-acp gating", () => {
   });
 
   test("injects both keys when both vault fields are present", async () => {
-    seedVaultOpenaiKey("vault-fake-openai-EEE");
-    seedVaultCodexKey("vault-fake-codex-FFF");
+    await seedVaultOpenaiKey("vault-fake-openai-EEE");
+    await seedVaultCodexKey("vault-fake-codex-FFF");
 
     const prepared = await prepareAgentEnv({
       command: "codex-acp",
@@ -432,7 +388,7 @@ describe("prepareAgentEnv - codex-acp gating", () => {
   });
 
   test("gates on the resolved command BASENAME (custom agent id with full path still gets injection)", async () => {
-    seedVaultOpenaiKey("vault-fake-openai-GGG");
+    await seedVaultOpenaiKey("vault-fake-openai-GGG");
 
     const prepared = await prepareAgentEnv({
       command: "/data/.bun/bin/codex-acp",
@@ -445,7 +401,7 @@ describe("prepareAgentEnv - codex-acp gating", () => {
 
 describe("prepareAgentEnv — non-claude commands", () => {
   test("returns the config unchanged for an unrecognized command basename", async () => {
-    seedVaultToken("vault-HHH");
+    await seedVaultToken("vault-HHH");
 
     const prepared = await prepareAgentEnv({
       command: "some-future-adapter",
@@ -459,36 +415,144 @@ describe("prepareAgentEnv — non-claude commands", () => {
 
 describe("grantAcpSpawnPolicy — force-grant (union)", () => {
   test("creates metadata with acp_spawn when none exists", () => {
-    grantAcpSpawnPolicy("claude_oauth_token", "desc");
-    expect(metadataStore.get("acp/claude_oauth_token")!.allowedTools).toEqual([
-      "acp_spawn",
-    ]);
+    grantAcpSpawnPolicy(ACP_OAUTH_TOKEN_FIELD, "desc");
+    expect(oauthMetadata()?.allowedTools).toEqual([ACP_SPAWN_TOOL]);
   });
 
   test("unions acp_spawn into an explicit policy that omitted it (repair)", () => {
-    metadataStore.set("acp/claude_oauth_token", {
+    upsertCredentialMetadata(ACP_SERVICE, ACP_OAUTH_TOKEN_FIELD, {
       allowedTools: ["other_tool"],
     });
 
-    grantAcpSpawnPolicy("claude_oauth_token", "desc");
+    grantAcpSpawnPolicy(ACP_OAUTH_TOKEN_FIELD, "desc");
 
     // Unlike ensureAcpCredentialPolicy (which preserves), grant adds acp_spawn.
-    expect(metadataStore.get("acp/claude_oauth_token")!.allowedTools).toEqual([
+    expect(oauthMetadata()?.allowedTools).toEqual([
       "other_tool",
-      "acp_spawn",
+      ACP_SPAWN_TOOL,
     ]);
   });
 
   test("leaves an allowedTools that already includes acp_spawn unchanged", () => {
-    metadataStore.set("acp/claude_oauth_token", {
-      allowedTools: ["acp_spawn", "other_tool"],
+    upsertCredentialMetadata(ACP_SERVICE, ACP_OAUTH_TOKEN_FIELD, {
+      allowedTools: [ACP_SPAWN_TOOL, "other_tool"],
     });
 
-    grantAcpSpawnPolicy("claude_oauth_token", "desc");
+    grantAcpSpawnPolicy(ACP_OAUTH_TOKEN_FIELD, "desc");
 
-    expect(metadataStore.get("acp/claude_oauth_token")!.allowedTools).toEqual([
-      "acp_spawn",
+    expect(oauthMetadata()?.allowedTools).toEqual([
+      ACP_SPAWN_TOOL,
       "other_tool",
     ]);
   });
+});
+
+/**
+ * Drift guard for the Connect Claude status predicate.
+ *
+ * `acpSpawnCredentialDenialReason` answers "would the spawn's broker read of
+ * this credential succeed?" without performing it, because the status route is
+ * a side-effect-free GET. Every state below is run twice: once through the
+ * predicate, and once through the real spawn sequence
+ * (`ensureAcpCredentialPolicy` then `credentialBroker.serverUse`). The two must
+ * agree down to the denial string; this suite fails whenever they diverge.
+ *
+ * The predicate reads only the persisted value via `getSecureKeyAsync` and
+ * never calls `serverUse`, so it can never consume a one-time transient
+ * credential the way a real broker read would.
+ */
+describe("acpSpawnCredentialDenialReason parity with the real spawn read", () => {
+  const STATES: { name: string; seed: () => void }[] = [
+    { name: "no metadata at all", seed: () => {} },
+    {
+      name: "empty allowedTools",
+      seed: () => {
+        upsertCredentialMetadata(ACP_SERVICE, ACP_OAUTH_TOKEN_FIELD, {
+          allowedTools: [],
+        });
+      },
+    },
+    {
+      name: "allowedTools listing acp_spawn",
+      seed: () => {
+        upsertCredentialMetadata(ACP_SERVICE, ACP_OAUTH_TOKEN_FIELD, {
+          allowedTools: [ACP_SPAWN_TOOL],
+        });
+      },
+    },
+    {
+      name: "allowedTools listing another tool",
+      seed: () => {
+        upsertCredentialMetadata(ACP_SERVICE, ACP_OAUTH_TOKEN_FIELD, {
+          allowedTools: ["bash"],
+        });
+      },
+    },
+    {
+      // The alias map in tool-policy.ts has no entry canonicalizing to
+      // acp_spawn, so this covers alias resolution generically: a legacy alias
+      // that canonicalizes to some OTHER capability must still deny.
+      name: "allowedTools listing a legacy alias for another capability",
+      seed: () => {
+        upsertCredentialMetadata(ACP_SERVICE, ACP_OAUTH_TOKEN_FIELD, {
+          allowedTools: ["browser_fill_credential"],
+        });
+      },
+    },
+    {
+      name: "acp_spawn allowed but domain-restricted",
+      seed: () => {
+        upsertCredentialMetadata(ACP_SERVICE, ACP_OAUTH_TOKEN_FIELD, {
+          allowedTools: [ACP_SPAWN_TOOL],
+          allowedDomains: ["api.anthropic.com"],
+        });
+      },
+    },
+    {
+      // The ensure-repair grants acp_spawn but must not drop the domain policy,
+      // so the projection has to preserve the rest of the record.
+      name: "empty allowedTools and domain-restricted",
+      seed: () => {
+        upsertCredentialMetadata(ACP_SERVICE, ACP_OAUTH_TOKEN_FIELD, {
+          allowedTools: [],
+          allowedDomains: ["api.anthropic.com"],
+        });
+      },
+    },
+    {
+      name: "acp_spawn allowed with an explicitly empty allowedDomains",
+      seed: () => {
+        upsertCredentialMetadata(ACP_SERVICE, ACP_OAUTH_TOKEN_FIELD, {
+          allowedTools: [ACP_SPAWN_TOOL],
+          allowedDomains: [],
+        });
+      },
+    },
+  ];
+
+  for (const state of STATES) {
+    test(`predicts the spawn read for: ${state.name}`, async () => {
+      await seedVaultToken("sk-ant-oat01-parity");
+
+      state.seed();
+      const beforePrediction = oauthMetadata();
+      const predicted = acpSpawnCredentialDenialReason(ACP_OAUTH_TOKEN_FIELD);
+      // The status route is a GET: predicting must not touch the store.
+      expect(oauthMetadata()).toEqual(beforePrediction);
+
+      // ensureAcpCredentialPolicy mutates the store, so the actual run starts
+      // from a fresh copy of the same state rather than the predicted one.
+      deleteCredentialMetadata(ACP_SERVICE, ACP_OAUTH_TOKEN_FIELD);
+      state.seed();
+      ensureAcpCredentialPolicy(ACP_OAUTH_TOKEN_FIELD, "desc");
+      const result = await credentialBroker.serverUse<void>({
+        service: ACP_SERVICE,
+        field: ACP_OAUTH_TOKEN_FIELD,
+        toolName: ACP_SPAWN_TOOL,
+        execute: async () => {},
+      });
+
+      expect(predicted).toBe(result.success ? undefined : result.reason);
+    });
+  }
 });

--- a/assistant/src/acp/__tests__/prepare-agent-env.test.ts
+++ b/assistant/src/acp/__tests__/prepare-agent-env.test.ts
@@ -59,8 +59,8 @@ const {
   ACP_CLAUDE_OAUTH_MISSING_CODE,
   acpSpawnCredentialDenialReason,
   ensureAcpCredentialPolicy,
-  grantAcpSpawnPolicy,
   prepareAgentEnv,
+  repairAcpSpawnPolicy,
 } = await import("../prepare-agent-env.js");
 
 const ACP_SPAWN_TOOL = "acp_spawn";
@@ -526,37 +526,83 @@ describe("prepareAgentEnv — non-claude commands", () => {
   });
 });
 
-describe("grantAcpSpawnPolicy — force-grant (union)", () => {
-  test("creates metadata with acp_spawn when none exists", () => {
-    grantAcpSpawnPolicy(ACP_OAUTH_TOKEN_FIELD, "desc");
+/**
+ * The Connect flow's repair, which `storeAcpClaudeToken` performs after writing
+ * the token. Every metadata shape the broker can deny on is covered here, so
+ * `acp-claude-oauth.test.ts` only has to pin the end-to-end wiring.
+ */
+describe("repairAcpSpawnPolicy - the Connect repair", () => {
+  test("creates a record with acp_spawn, the usage description, and no domain restriction when none exists", () => {
+    repairAcpSpawnPolicy(ACP_OAUTH_TOKEN_FIELD, "desc");
+
+    expect(oauthMetadata()?.allowedTools).toEqual([ACP_SPAWN_TOOL]);
+    expect(oauthMetadata()?.allowedDomains).toEqual([]);
+    expect(oauthMetadata()?.usageDescription).toBe("desc");
+  });
+
+  test("adds acp_spawn to an empty allowedTools (default provisioning path)", () => {
+    upsertCredentialMetadata(ACP_SERVICE, ACP_OAUTH_TOKEN_FIELD, {
+      allowedTools: [],
+    });
+
+    repairAcpSpawnPolicy(ACP_OAUTH_TOKEN_FIELD, "desc");
+
     expect(oauthMetadata()?.allowedTools).toEqual([ACP_SPAWN_TOOL]);
   });
 
-  test("unions acp_spawn into an explicit policy that omitted it (repair)", () => {
+  test("unions acp_spawn into an explicit policy that omitted it", () => {
     upsertCredentialMetadata(ACP_SERVICE, ACP_OAUTH_TOKEN_FIELD, {
       allowedTools: ["other_tool"],
     });
 
-    grantAcpSpawnPolicy(ACP_OAUTH_TOKEN_FIELD, "desc");
+    repairAcpSpawnPolicy(ACP_OAUTH_TOKEN_FIELD, "desc");
 
-    // Unlike ensureAcpCredentialPolicy (which preserves), grant adds acp_spawn.
+    // Unlike ensureAcpCredentialPolicy (which preserves), the repair widens.
     expect(oauthMetadata()?.allowedTools).toEqual([
       "other_tool",
       ACP_SPAWN_TOOL,
     ]);
   });
 
-  test("leaves an allowedTools that already includes acp_spawn unchanged", () => {
+  test("clears a domain restriction the broker refuses server-side, keeping the tools", () => {
+    upsertCredentialMetadata(ACP_SERVICE, ACP_OAUTH_TOKEN_FIELD, {
+      allowedTools: [ACP_SPAWN_TOOL],
+      allowedDomains: ["api.anthropic.com"],
+    });
+
+    repairAcpSpawnPolicy(ACP_OAUTH_TOKEN_FIELD, "desc");
+
+    expect(oauthMetadata()?.allowedDomains).toEqual([]);
+    expect(oauthMetadata()?.allowedTools).toEqual([ACP_SPAWN_TOOL]);
+  });
+
+  test("repairs both halves of a denied policy in one pass", () => {
+    upsertCredentialMetadata(ACP_SERVICE, ACP_OAUTH_TOKEN_FIELD, {
+      allowedTools: ["other_tool"],
+      allowedDomains: ["api.anthropic.com"],
+    });
+
+    repairAcpSpawnPolicy(ACP_OAUTH_TOKEN_FIELD, "desc");
+
+    expect(oauthMetadata()?.allowedTools).toEqual([
+      "other_tool",
+      ACP_SPAWN_TOOL,
+    ]);
+    expect(oauthMetadata()?.allowedDomains).toEqual([]);
+  });
+
+  test("writes nothing when the stored policy already satisfies both halves", async () => {
     upsertCredentialMetadata(ACP_SERVICE, ACP_OAUTH_TOKEN_FIELD, {
       allowedTools: [ACP_SPAWN_TOOL, "other_tool"],
     });
+    const before = oauthMetadata();
+    // Every upsert stamps `updatedAt` with the current millisecond, so waiting
+    // here makes an unconditional write show up as a changed record.
+    await Bun.sleep(5);
 
-    grantAcpSpawnPolicy(ACP_OAUTH_TOKEN_FIELD, "desc");
+    repairAcpSpawnPolicy(ACP_OAUTH_TOKEN_FIELD, "desc");
 
-    expect(oauthMetadata()?.allowedTools).toEqual([
-      ACP_SPAWN_TOOL,
-      "other_tool",
-    ]);
+    expect(oauthMetadata()).toEqual(before);
   });
 });
 

--- a/assistant/src/acp/acp-claude-oauth.ts
+++ b/assistant/src/acp/acp-claude-oauth.ts
@@ -17,6 +17,10 @@ import {
   getSecureKeyAsync,
   setSecureKeyAsync,
 } from "../security/secure-keys.js";
+import {
+  getCredentialMetadata,
+  upsertCredentialMetadata,
+} from "../tools/credentials/metadata-store.js";
 import { getLogger } from "../util/logger.js";
 import {
   ACP_OAUTH_TOKEN_FIELD,
@@ -112,8 +116,9 @@ export function parseManualClaudeCode(input: string): {
 
 /**
  * Store a captured Claude OAuth token in the `acp/claude_oauth_token` vault
- * field and provision the `acp_spawn` read policy so the broker can inject it
- * at spawn time. Throws when the backing store rejects the write.
+ * field and provision the policy the broker applies at spawn time: grant the
+ * `acp_spawn` read and lift any domain restriction. Throws when the backing
+ * store rejects the write.
  */
 export async function storeAcpClaudeToken(token: string): Promise<void> {
   const stored = await setSecureKeyAsync(
@@ -131,6 +136,16 @@ export async function storeAcpClaudeToken(token: string): Promise<void> {
     ACP_OAUTH_TOKEN_FIELD,
     "Claude OAuth token for ACP agent authentication",
   );
+  // Same deliberate opt-in, applied to the other half of the policy the broker
+  // checks. This field is OAuth-only and server-use-only, and the broker refuses
+  // a domain-restricted credential server-side, so a lingering restriction would
+  // keep every spawn failing even after a successful connect.
+  const meta = getCredentialMetadata(ACP_SERVICE, ACP_OAUTH_TOKEN_FIELD);
+  if ((meta?.allowedDomains ?? []).length > 0) {
+    upsertCredentialMetadata(ACP_SERVICE, ACP_OAUTH_TOKEN_FIELD, {
+      allowedDomains: [],
+    });
+  }
 }
 
 /**

--- a/assistant/src/acp/acp-claude-oauth.ts
+++ b/assistant/src/acp/acp-claude-oauth.ts
@@ -17,15 +17,18 @@ import {
   getSecureKeyAsync,
   setSecureKeyAsync,
 } from "../security/secure-keys.js";
+import { getLogger } from "../util/logger.js";
 import {
   ACP_OAUTH_TOKEN_FIELD,
   ACP_SERVICE,
   classifyAnthropicToken,
 } from "./acp-credentials.js";
 import {
-  acpSpawnCanReadCredential,
+  acpSpawnCredentialDenialReason,
   grantAcpSpawnPolicy,
 } from "./prepare-agent-env.js";
+
+const log = getLogger("acp:claude-oauth");
 
 /**
  * Verified Claude Code public OAuth client. PKCE-only (no client secret);
@@ -142,20 +145,32 @@ export async function storeAcpClaudeToken(token: string): Promise<void> {
  * spawn, so keeping Connect offered (rather than self-dismissing) lets the user
  * repair the bad entry by connecting a real OAuth token.
  *
- * Likewise, a token the `acp_spawn` policy can't read (an explicit
- * `allowedTools` that omits `acp_spawn`) is NOT connected: the vault holds a
- * value but the spawn's broker read is denied, so self-dismissing the card would
- * hide the only repair CTA while every spawn keeps failing. Keep the card up in
- * that denied-policy case too.
+ * Likewise, a token the spawn's broker read would be denied (an explicit
+ * `allowedTools` that omits `acp_spawn`, or a domain-restricted policy) is NOT
+ * connected: the vault holds a value but every spawn fails, so self-dismissing
+ * the card would hide the only repair CTA. That half of the answer is delegated
+ * to `acpSpawnCredentialDenialReason`, which evaluates the exact policy the
+ * spawn-time broker read applies, so "connected" means precisely "the spawn
+ * would get this token". The token-shape guard stays here instead: the broker
+ * knows nothing about Anthropic token formats.
  */
 export async function hasAcpClaudeToken(): Promise<boolean> {
   const token = await getSecureKeyAsync(
     credentialKey(ACP_SERVICE, ACP_OAUTH_TOKEN_FIELD),
   );
-  return (
-    token != null &&
-    token.length > 0 &&
-    classifyAnthropicToken(token) !== "api_key" &&
-    acpSpawnCanReadCredential(ACP_OAUTH_TOKEN_FIELD)
-  );
+  if (token == null || token.length === 0) {
+    return false;
+  }
+  if (classifyAnthropicToken(token) === "api_key") {
+    return false;
+  }
+  const denialReason = acpSpawnCredentialDenialReason(ACP_OAUTH_TOKEN_FIELD);
+  if (denialReason !== undefined) {
+    log.debug(
+      { field: ACP_OAUTH_TOKEN_FIELD, reason: denialReason },
+      "Connect Claude status: token present but spawn read would be denied",
+    );
+    return false;
+  }
+  return true;
 }

--- a/assistant/src/acp/acp-claude-oauth.ts
+++ b/assistant/src/acp/acp-claude-oauth.ts
@@ -17,10 +17,6 @@ import {
   getSecureKeyAsync,
   setSecureKeyAsync,
 } from "../security/secure-keys.js";
-import {
-  getCredentialMetadata,
-  upsertCredentialMetadata,
-} from "../tools/credentials/metadata-store.js";
 import { getLogger } from "../util/logger.js";
 import {
   ACP_OAUTH_TOKEN_FIELD,
@@ -28,8 +24,9 @@ import {
   classifyAnthropicToken,
 } from "./acp-credentials.js";
 import {
+  ACP_CLAUDE_OAUTH_USAGE_DESCRIPTION,
   acpSpawnCredentialDenialReason,
-  grantAcpSpawnPolicy,
+  repairAcpSpawnPolicy,
 } from "./prepare-agent-env.js";
 
 const log = getLogger("acp:claude-oauth");
@@ -128,24 +125,14 @@ export async function storeAcpClaudeToken(token: string): Promise<void> {
   if (!stored) {
     throw new Error("Failed to store Claude OAuth token in secure storage.");
   }
-  // Force-grant acp_spawn (union) rather than merely ensure it: an explicit
-  // Connect is a deliberate opt-in to ACP, so this repairs a credential whose
-  // explicit allowedTools omitted acp_spawn — otherwise the broker keeps denying
-  // the spawn read and the Connect card dead-loops on every auto-continue.
-  grantAcpSpawnPolicy(
+  // Repair rather than merely ensure the policy: an explicit Connect is a
+  // deliberate opt-in to ACP, so this widens a credential the broker would
+  // otherwise keep denying the spawn read on, which would dead-loop the Connect
+  // card on every auto-continue.
+  repairAcpSpawnPolicy(
     ACP_OAUTH_TOKEN_FIELD,
-    "Claude OAuth token for ACP agent authentication",
+    ACP_CLAUDE_OAUTH_USAGE_DESCRIPTION,
   );
-  // Same deliberate opt-in, applied to the other half of the policy the broker
-  // checks. This field is OAuth-only and server-use-only, and the broker refuses
-  // a domain-restricted credential server-side, so a lingering restriction would
-  // keep every spawn failing even after a successful connect.
-  const meta = getCredentialMetadata(ACP_SERVICE, ACP_OAUTH_TOKEN_FIELD);
-  if ((meta?.allowedDomains ?? []).length > 0) {
-    upsertCredentialMetadata(ACP_SERVICE, ACP_OAUTH_TOKEN_FIELD, {
-      allowedDomains: [],
-    });
-  }
 }
 
 /**

--- a/assistant/src/acp/prepare-agent-env.ts
+++ b/assistant/src/acp/prepare-agent-env.ts
@@ -287,25 +287,57 @@ export async function prepareAgentEnv(
     };
 
     dropApiKeyOauthToken();
+    let missReason: string | undefined;
     if (!env.CLAUDE_CODE_OAUTH_TOKEN) {
-      await injectCredential(
+      missReason = await injectCredential(
         env,
         ACP_OAUTH_TOKEN_FIELD,
         "CLAUDE_CODE_OAUTH_TOKEN",
         "Claude OAuth token for ACP agent authentication",
       );
     }
+    // Any api-key-shaped value still standing here came from the vault read:
+    // the config override was already dropped above, and the read only runs
+    // when the override left the var unset.
+    const storedValueIsApiKeyShaped =
+      env.CLAUDE_CODE_OAUTH_TOKEN !== undefined &&
+      classifyAnthropicToken(env.CLAUDE_CODE_OAUTH_TOKEN) === "api_key";
     dropApiKeyOauthToken();
     if (!env.CLAUDE_CODE_OAUTH_TOKEN) {
+      // The operator's record of WHY the spawn has no token. `missReason` is
+      // the broker's own reason string and the rest are policy verdicts, so no
+      // field can carry the credential value.
+      const policyDenialReason = acpSpawnCredentialDenialReason(
+        ACP_OAUTH_TOKEN_FIELD,
+      );
+      log.warn(
+        {
+          field: ACP_OAUTH_TOKEN_FIELD,
+          missReason,
+          policyBlocked: policyDenialReason !== undefined,
+          apiKeyShaped: storedValueIsApiKeyShaped,
+        },
+        "Claude OAuth token not injected for acp_spawn",
+      );
       // Carry the stable marker as structured `details` so the client renders
       // the inline "Connect Claude Code" card. The message itself is the tool
       // result the model reads at the failure moment, so it directs the model
       // AT that card and away from CLI/token-paste workarounds — otherwise the
       // model relays a `claude setup-token` / paste-a-token flow that the card
       // exists to replace. The CLI command stays only as a headless fallback.
+      // A policy-blocked read is a different repair story from an absent value,
+      // so the opening states which one happened. The guidance after it is
+      // shared: the Connect card fixes both.
+      const opening = policyDenialReason
+        ? "claude-agent-acp cannot read the Claude OAuth token: the credential " +
+          "policy on acp/claude_oauth_token blocks the acp_spawn read, so " +
+          "CLAUDE_CODE_OAUTH_TOKEN is not set for the spawn. Clicking Connect " +
+          "signs in again and repairs that policy. "
+        : "claude-agent-acp needs a Claude OAuth token (CLAUDE_CODE_OAUTH_TOKEN), " +
+          "which is not set. ";
       throw new FailedDependencyError(
-        "claude-agent-acp needs a Claude OAuth token (CLAUDE_CODE_OAUTH_TOKEN), " +
-          'which is not set. The app shows the user an inline "Connect Claude ' +
+        opening +
+          'The app shows the user an inline "Connect Claude ' +
           'Code" card. Reply with ONE short sentence: ask them to click Connect ' +
           "in that card to sign in, and tell them you'll continue automatically " +
           "once they're connected. Do NOT say where the card is — never say " +

--- a/assistant/src/acp/prepare-agent-env.ts
+++ b/assistant/src/acp/prepare-agent-env.ts
@@ -25,9 +25,11 @@ import { basename } from "node:path";
 import { FailedDependencyError } from "../runtime/routes/errors.js";
 import { credentialBroker } from "../tools/credentials/broker.js";
 import {
+  type CredentialMetadata,
   getCredentialMetadata,
   upsertCredentialMetadata,
 } from "../tools/credentials/metadata-store.js";
+import { serverUseDenialReason } from "../tools/credentials/tool-policy.js";
 import { getLogger } from "../util/logger.js";
 import {
   ACP_OAUTH_TOKEN_FIELD,
@@ -51,34 +53,67 @@ const ACP_SPAWN_TOOL = "acp_spawn";
 export const ACP_CLAUDE_OAUTH_MISSING_CODE = "acp_claude_oauth_missing";
 
 /**
- * Ensure an `acp/<field>` credential has metadata that allows the
- * `acp_spawn` tool to read it, but only for legacy/unmanaged cases:
+ * The metadata an `acp/<field>` credential has once the `acp_spawn` read policy
+ * is ensured, given what is stored now. This is the single definition of that
+ * decision: {@link ensureAcpCredentialPolicy} persists the result and
+ * {@link acpSpawnCredentialDenialReason} evaluates it without writing.
  *
- * - No metadata at all: create with `allowedTools: ["acp_spawn"]`.
- * - Metadata exists with an empty `allowedTools`: default provisioning
- *   path (user ran `credentials set` without `--allowed-tools`), add it.
- * - Metadata exists with a non-empty `allowedTools`: explicit policy set
- *   by the user/admin. Respect it even if `acp_spawn` is absent; the
- *   broker will deny the read and the caller decides whether that's fatal.
+ * The policy is only repaired for legacy/unmanaged cases:
+ *
+ * - No metadata at all: a record with `allowedTools: ["acp_spawn"]` and the
+ *   caller's `usageDescription`.
+ * - Metadata with an empty `allowedTools`: default provisioning path (user ran
+ *   `credentials set` without `--allowed-tools`), so `acp_spawn` is added.
+ * - Metadata with a non-empty `allowedTools`: explicit policy set by the
+ *   user/admin, returned as the very same object so callers can tell by
+ *   identity that there is nothing to persist. It stands even when `acp_spawn`
+ *   is absent; the broker denies the read and the caller decides whether that's
+ *   fatal.
+ *
+ * Everything else on an existing record, `allowedDomains` included, is
+ * preserved.
+ */
+function projectEnsuredAcpPolicy(
+  meta: CredentialMetadata | undefined,
+  field: string,
+  usageDescription?: string,
+): CredentialMetadata {
+  if (!meta) {
+    return {
+      credentialId: "",
+      service: ACP_SERVICE,
+      field,
+      allowedTools: [ACP_SPAWN_TOOL],
+      allowedDomains: [],
+      usageDescription,
+      createdAt: 0,
+      updatedAt: 0,
+    };
+  }
+  if ((meta.allowedTools ?? []).length === 0) {
+    return { ...meta, allowedTools: [ACP_SPAWN_TOOL] };
+  }
+  return meta;
+}
+
+/**
+ * Bring the stored metadata for `acp/<field>` up to the policy
+ * {@link projectEnsuredAcpPolicy} describes, writing only the fields that
+ * projection decides and only when it differs from what is stored.
  */
 export function ensureAcpCredentialPolicy(
   field: string,
   usageDescription: string,
 ): void {
   const meta = getCredentialMetadata(ACP_SERVICE, field);
-  if (!meta) {
-    upsertCredentialMetadata(ACP_SERVICE, field, {
-      allowedTools: [ACP_SPAWN_TOOL],
-      usageDescription,
-    });
+  const ensured = projectEnsuredAcpPolicy(meta, field, usageDescription);
+  if (ensured === meta) {
     return;
   }
-  const tools = meta.allowedTools ?? [];
-  if (tools.length === 0) {
-    upsertCredentialMetadata(ACP_SERVICE, field, {
-      allowedTools: [ACP_SPAWN_TOOL],
-    });
-  }
+  upsertCredentialMetadata(ACP_SERVICE, field, {
+    allowedTools: ensured.allowedTools,
+    usageDescription: ensured.usageDescription,
+  });
 }
 
 /**
@@ -110,21 +145,30 @@ export function grantAcpSpawnPolicy(
 }
 
 /**
- * Whether the `acp_spawn` broker read for `acp/<field>` would actually be
- * permitted, mirroring {@link ensureAcpCredentialPolicy}'s grant rules: a
- * missing or empty `allowedTools` is auto-granted `acp_spawn` at spawn time, so
- * it can read; a non-empty explicit policy is respected as-is, so it can read
- * only when it lists `acp_spawn`. Lets a connected-status check avoid reporting
- * "connected" for a token the spawn is policy-denied from reading (which would
- * otherwise hide the repair CTA and trap the user in a missing-token loop).
+ * Why the `acp_spawn` broker read for `acp/<field>` would be denied, or
+ * `undefined` when it would be permitted. Lets a connected-status check avoid
+ * reporting "connected" for a token the spawn is policy-denied from reading
+ * (which would otherwise hide the repair CTA and trap the user in a
+ * missing-token loop).
+ *
+ * The verdict comes from `serverUseDenialReason`, the single policy source the
+ * broker itself consults, so the status check and the spawn read can never
+ * disagree. The stored metadata is first run through
+ * {@link projectEnsuredAcpPolicy}, the same repair the spawn persists, computed
+ * in memory and never written: this runs on a side-effect-free GET route, so it
+ * has to predict what the spawn's ensure-then-read sequence would do rather
+ * than perform it.
  */
-export function acpSpawnCanReadCredential(field: string): boolean {
+export function acpSpawnCredentialDenialReason(
+  field: string,
+): string | undefined {
   const meta = getCredentialMetadata(ACP_SERVICE, field);
-  if (!meta) {
-    return true;
-  }
-  const tools = meta.allowedTools ?? [];
-  return tools.length === 0 || tools.includes(ACP_SPAWN_TOOL);
+  return serverUseDenialReason(
+    projectEnsuredAcpPolicy(meta, field),
+    ACP_SPAWN_TOOL,
+    ACP_SERVICE,
+    field,
+  );
 }
 
 /**

--- a/assistant/src/acp/prepare-agent-env.ts
+++ b/assistant/src/acp/prepare-agent-env.ts
@@ -43,12 +43,20 @@ const log = getLogger("acp:prepare-agent-env");
 const ACP_SPAWN_TOOL = "acp_spawn";
 
 /**
+ * `usageDescription` recorded on `acp/claude_oauth_token` when a record is
+ * created, shared by the spawn-time ensure and the Connect repair so the two
+ * paths can't describe the same credential differently.
+ */
+export const ACP_CLAUDE_OAUTH_USAGE_DESCRIPTION =
+  "Claude OAuth token for ACP agent authentication";
+
+/**
  * Stable, machine-readable marker carried on the `FailedDependencyError.details`
  * when a `claude-agent-acp` spawn is missing `CLAUDE_CODE_OAUTH_TOKEN`. Threaded
  * through the tool result / error payload as a structured field so clients can
  * offer the inline "Connect Claude Code" flow instead of re-parsing the human
  * message string. Kept in lockstep with the web literal in
- * `clients/web/src/domains/chat/transcript/acp-connect-affordance.tsx`.
+ * `clients/web/src/domains/chat/utils/acp-connect.ts`.
  */
 export const ACP_CLAUDE_OAUTH_MISSING_CODE = "acp_claude_oauth_missing";
 
@@ -117,31 +125,38 @@ export function ensureAcpCredentialPolicy(
 }
 
 /**
- * Force-grant the `acp_spawn` read policy on `acp/<field>`, unioning it into any
- * existing `allowedTools`. Unlike {@link ensureAcpCredentialPolicy} (which
- * PRESERVES an explicit non-empty policy so a passive spawn can't silently widen
- * it), this is for the EXPLICIT Connect flow: a user connecting Claude is a
- * deliberate opt-in to `acp_spawn`, so granting it makes the CTA actually repair
- * a policy-denied credential instead of dead-looping the missing-token card.
+ * Make `acp/<field>` readable by the spawn: union `acp_spawn` into any existing
+ * `allowedTools` and drop any domain restriction, in ONE write and only when the
+ * stored record fails either half. This is the whole repair the Connect flow
+ * performs, so a new dimension of {@link serverUseDenialReason} is repaired in
+ * exactly one place.
+ *
+ * Unlike {@link ensureAcpCredentialPolicy} (which PRESERVES an explicit non-empty
+ * policy so a passive spawn can't silently widen it), this is for the EXPLICIT
+ * Connect flow: a user connecting Claude is a deliberate opt-in to `acp_spawn`,
+ * so granting it makes the CTA actually repair a policy-denied credential instead
+ * of dead-looping the missing-token card. Domains are cleared under the same
+ * opt-in: this field is OAuth-only and server-use-only, and the broker refuses a
+ * domain-restricted credential server-side, so a lingering restriction would keep
+ * every spawn failing even after a successful connect.
  */
-export function grantAcpSpawnPolicy(
+export function repairAcpSpawnPolicy(
   field: string,
   usageDescription: string,
 ): void {
   const meta = getCredentialMetadata(ACP_SERVICE, field);
-  if (!meta) {
-    upsertCredentialMetadata(ACP_SERVICE, field, {
-      allowedTools: [ACP_SPAWN_TOOL],
-      usageDescription,
-    });
+  const tools = meta?.allowedTools ?? [];
+  const spawnAllowed = tools.includes(ACP_SPAWN_TOOL);
+  const domainUnrestricted = (meta?.allowedDomains ?? []).length === 0;
+  if (meta && spawnAllowed && domainUnrestricted) {
     return;
   }
-  const tools = meta.allowedTools ?? [];
-  if (!tools.includes(ACP_SPAWN_TOOL)) {
-    upsertCredentialMetadata(ACP_SERVICE, field, {
-      allowedTools: [...tools, ACP_SPAWN_TOOL],
-    });
-  }
+  upsertCredentialMetadata(ACP_SERVICE, field, {
+    allowedTools: spawnAllowed ? tools : [...tools, ACP_SPAWN_TOOL],
+    allowedDomains: [],
+    // Only a fresh record takes the description; an existing one keeps its own.
+    ...(meta ? {} : { usageDescription }),
+  });
 }
 
 /**
@@ -293,7 +308,7 @@ export async function prepareAgentEnv(
         env,
         ACP_OAUTH_TOKEN_FIELD,
         "CLAUDE_CODE_OAUTH_TOKEN",
-        "Claude OAuth token for ACP agent authentication",
+        ACP_CLAUDE_OAUTH_USAGE_DESCRIPTION,
       );
     }
     // Any api-key-shaped value still standing here came from the vault read:

--- a/assistant/src/tools/credentials/broker.ts
+++ b/assistant/src/tools/credentials/broker.ts
@@ -18,36 +18,16 @@ import type {
 import { isDomainAllowed } from "./domain-policy.js";
 import { getCredentialMetadata } from "./metadata-store.js";
 import { resolveById } from "./resolve.js";
-import { isToolAllowed } from "./tool-policy.js";
+import {
+  isToolAllowed,
+  serverUseDenialReason,
+  toolNotAllowedReason,
+} from "./tool-policy.js";
 
 const log = getLogger("credential-broker");
 
 /** Tokens expire after 5 minutes to limit the window for using stale/revoked credentials. */
 const TOKEN_TTL_MS = 5 * 60 * 1000;
-
-/**
- * Remediation for a credential whose allowed_tools list is empty. Points at
- * `credentials prompt` (not inline `credentials set`, which agent shells
- * refuse): the secure prompt re-collects the value and sets allowed_tools.
- */
-const NO_TOOLS_ALLOWED_REMEDIATION =
-  "No tools are currently allowed - grant access via `assistant credentials prompt --service <service> --field <field> --label <label> --allowed-tools <tools>` (re-collects the value securely and sets allowed_tools).";
-
-/** Denial reason for a tool that is not in a credential's allowed_tools list. */
-function toolNotAllowedReason(
-  toolName: string,
-  service: string,
-  field: string,
-  allowedTools: string[] | undefined,
-): string {
-  const tools = allowedTools ?? [];
-  return (
-    `Tool "${toolName}" is not allowed to use credential ${service}/${field}. ` +
-    (tools.length === 0
-      ? NO_TOOLS_ALLOWED_REMEDIATION
-      : `Allowed tools: ${tools.join(", ")}.`)
-  );
-}
 
 /**
  * Credential broker that issues single-use tokens for policy-checked credential access.
@@ -292,36 +272,14 @@ export class CredentialBroker {
     request: ServerUseRequest<T>,
   ): Promise<ServerUseResult<T>> {
     const metadata = getCredentialMetadata(request.service, request.field);
-    if (!metadata) {
-      return {
-        success: false,
-        reason: `No credential found for ${request.service}/${request.field}`,
-      };
-    }
-
-    if (!isToolAllowed(request.toolName, metadata.allowedTools)) {
-      return {
-        success: false,
-        reason: toolNotAllowedReason(
-          request.toolName,
-          request.service,
-          request.field,
-          metadata.allowedTools,
-        ),
-      };
-    }
-
-    // Domain policy enforcement - credentials with domain restrictions are
-    // scoped to browser use on those domains and cannot be used server-side.
-    const serverDomains = metadata.allowedDomains ?? [];
-    if (serverDomains.length > 0) {
-      return {
-        success: false,
-        reason:
-          `Credential ${request.service}/${request.field} has domain restrictions ` +
-          `(${serverDomains.join(", ")}) and cannot be used server-side. ` +
-          "Remove domain restrictions or use a separate credential without domain policy.",
-      };
+    const denialReason = serverUseDenialReason(
+      metadata,
+      request.toolName,
+      request.service,
+      request.field,
+    );
+    if (denialReason) {
+      return { success: false, reason: denialReason };
     }
 
     const storageKey = credentialKey(request.service, request.field);
@@ -381,30 +339,17 @@ export class CredentialBroker {
 
     const { metadata } = resolved;
 
-    // Tool policy enforcement
-    if (!isToolAllowed(request.requestingTool, metadata.allowedTools)) {
-      return {
-        success: false,
-        reason: toolNotAllowedReason(
-          request.requestingTool,
-          metadata.service,
-          metadata.field,
-          metadata.allowedTools,
-        ),
-      };
-    }
-
-    // Domain policy enforcement - credentials with domain restrictions are
-    // scoped to browser use on those domains and cannot be used server-side.
-    const domains = metadata.allowedDomains ?? [];
-    if (domains.length > 0) {
-      return {
-        success: false,
-        reason:
-          `Credential ${metadata.service}/${metadata.field} has domain restrictions ` +
-          `(${domains.join(", ")}) and cannot be used server-side. ` +
-          "Remove domain restrictions or use a separate credential without domain policy.",
-      };
+    // Shared server-use policy: the ID lookup above is the only by-ID-specific
+    // gate, so tool and domain enforcement come from the same helper serverUse
+    // uses.
+    const denialReason = serverUseDenialReason(
+      metadata,
+      request.requestingTool,
+      metadata.service,
+      metadata.field,
+    );
+    if (denialReason) {
+      return { success: false, reason: denialReason };
     }
 
     // Fail-closed: verify the secret value actually exists in secure storage.

--- a/assistant/src/tools/credentials/tool-policy.ts
+++ b/assistant/src/tools/credentials/tool-policy.ts
@@ -5,6 +5,8 @@
  * based on the credential's allowed tools list.
  */
 
+import type { CredentialMetadata } from "./metadata-store.js";
+
 /**
  * Canonical capability key for browser-based credential fills.
  *
@@ -63,4 +65,69 @@ export function isToolAllowed(
   return allowedTools.some(
     (allowed) => resolveCanonical(allowed) === canonical,
   );
+}
+
+/**
+ * Remediation for a credential whose allowed_tools list is empty. Points at
+ * `credentials prompt` (not inline `credentials set`, which agent shells
+ * refuse): the secure prompt re-collects the value and sets allowed_tools.
+ */
+const NO_TOOLS_ALLOWED_REMEDIATION =
+  "No tools are currently allowed - grant access via `assistant credentials prompt --service <service> --field <field> --label <label> --allowed-tools <tools>` (re-collects the value securely and sets allowed_tools).";
+
+/** Denial reason for a tool that is not in a credential's allowed_tools list. */
+export function toolNotAllowedReason(
+  toolName: string,
+  service: string,
+  field: string,
+  allowedTools: string[] | undefined,
+): string {
+  const tools = allowedTools ?? [];
+  return (
+    `Tool "${toolName}" is not allowed to use credential ${service}/${field}. ` +
+    (tools.length === 0
+      ? NO_TOOLS_ALLOWED_REMEDIATION
+      : `Allowed tools: ${tools.join(", ")}.`)
+  );
+}
+
+/**
+ * Evaluate the policy that gates server-side use of a credential.
+ *
+ * Pure: it inspects only the metadata it is handed, performs no store reads,
+ * and has no side effects. Returns the denial reason, or `undefined` when the
+ * tool may read the credential server-side.
+ *
+ * Domain-restricted credentials are scoped to browser fills on those domains,
+ * so they are refused here even when the tool itself is allowed.
+ */
+export function serverUseDenialReason(
+  metadata: CredentialMetadata | undefined,
+  toolName: string,
+  service: string,
+  field: string,
+): string | undefined {
+  if (!metadata) {
+    return `No credential found for ${service}/${field}`;
+  }
+
+  if (!isToolAllowed(toolName, metadata.allowedTools)) {
+    return toolNotAllowedReason(
+      toolName,
+      service,
+      field,
+      metadata.allowedTools,
+    );
+  }
+
+  const serverDomains = metadata.allowedDomains ?? [];
+  if (serverDomains.length > 0) {
+    return (
+      `Credential ${service}/${field} has domain restrictions ` +
+      `(${serverDomains.join(", ")}) and cannot be used server-side. ` +
+      "Remove domain restrictions or use a separate credential without domain policy."
+    );
+  }
+
+  return undefined;
 }

--- a/clients/web/src/domains/chat/hooks/use-chat-debug-registration.ts
+++ b/clients/web/src/domains/chat/hooks/use-chat-debug-registration.ts
@@ -80,6 +80,13 @@ export function useChatDebugRegistration({
         isSubmittingQuestion: state.isSubmittingQuestion,
         isQuestionCardDismissed: state.isQuestionCardDismissed,
         inlineConfirmationToolCallId: state.inlineConfirmationToolCallId,
+        pendingAcpConnect: state.pendingAcpConnect,
+        // The store holds a Set, which JSON-serializes to `{}` in the feedback
+        // bundle; sort so repeated captures read the same.
+        dismissedAcpConnectToolUseIds: [
+          ...state.dismissedAcpConnectToolUseIds,
+        ].sort(),
+        pendingAcpContinue: state.pendingAcpContinue,
       };
     },
     getScrollPagination: () => {

--- a/clients/web/src/domains/chat/transcript/acp-connect-affordance.test.tsx
+++ b/clients/web/src/domains/chat/transcript/acp-connect-affordance.test.tsx
@@ -5,13 +5,15 @@
  * Covers the version gate and the live-status self-heal: the affordance renders
  * its Connect button when the daemon supports Connect, renders nothing (falling
  * back to the plain error rendering) against a daemon too old to serve the
- * routes, and retires itself when Claude is already connected. Which failed tool
+ * routes, and retires itself when Claude is already connected (leaving a
+ * diagnostic breadcrumb behind). Which failed tool
  * call raises the prompt — and its reseed survival — is covered in
  * `acp-connect-prompt.test.ts`.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import {
+  act,
   cleanup,
   fireEvent,
   render,
@@ -87,7 +89,29 @@ mock.module("@vellumai/design-library/components/typography", () => ({
   ),
 }));
 
+const actualDiagnostics = await import("@/lib/diagnostics");
+const recordedLifecycleDiagnostics: Array<{
+  kind: string;
+  details: Record<string, unknown>;
+}> = [];
+mock.module("@/lib/diagnostics", () => ({
+  ...actualDiagnostics,
+  recordLifecycleDiagnostic: (
+    kind: string,
+    details: Record<string, unknown> = {},
+  ) => {
+    recordedLifecycleDiagnostics.push({ kind, details });
+  },
+}));
+
 const { AcpConnectAffordance } = await import("./acp-connect-affordance");
+
+/** Let the resolved `isClaudeConnected` promise settle inside React's act. */
+async function flushConnectedCheck() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
 
 beforeEach(() => {
   supported = true;
@@ -95,7 +119,12 @@ beforeEach(() => {
   popupBlocked = false;
   startMode = "loopback";
   exchangeShouldFail = false;
-  useInteractionStore.getState().clearAcpContinue();
+  recordedLifecycleDiagnostics.length = 0;
+  useInteractionStore.setState({
+    pendingAcpConnect: null,
+    dismissedAcpConnectToolUseIds: new Set<string>(),
+    pendingAcpContinue: false,
+  });
 });
 
 afterEach(() => {
@@ -140,6 +169,58 @@ describe("AcpConnectAffordance", () => {
     await waitFor(() => {
       expect(screen.queryByTestId("acp-connect-affordance")).toBeNull();
     });
+  });
+
+  test("records a lifecycle diagnostic for every self-heal dismissal", async () => {
+    alreadyConnected = true;
+    useInteractionStore
+      .getState()
+      .showAcpConnect({ toolUseId: "toolu-acp-1", reason: "missing" });
+
+    render(<AcpConnectAffordance assistantId="assistant-123" />);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("acp-connect-affordance")).toBeNull();
+    });
+    // The card vanishing is invisible in a feedback bundle without this
+    // breadcrumb, so it must carry who/which-call/why, and it lands in the
+    // durable ring that streaming volume cannot evict.
+    expect(recordedLifecycleDiagnostics).toEqual([
+      {
+        kind: "acp_connect_self_heal_dismiss",
+        details: {
+          assistantId: "assistant-123",
+          toolUseId: "toolu-acp-1",
+          reason: "missing",
+        },
+      },
+    ]);
+  });
+
+  test("records nothing for an auth_required prompt, which skips the connected check", async () => {
+    alreadyConnected = true;
+    useInteractionStore
+      .getState()
+      .showAcpConnect({ toolUseId: "toolu-acp-1", reason: "auth_required" });
+
+    render(<AcpConnectAffordance assistantId="assistant-123" />);
+    await flushConnectedCheck();
+
+    expect(screen.getByTestId("acp-connect-affordance")).not.toBeNull();
+    expect(recordedLifecycleDiagnostics).toEqual([]);
+  });
+
+  test("records nothing when the connected check answers false", async () => {
+    alreadyConnected = false;
+    useInteractionStore
+      .getState()
+      .showAcpConnect({ toolUseId: "toolu-acp-1", reason: "missing" });
+
+    render(<AcpConnectAffordance assistantId="assistant-123" />);
+    await flushConnectedCheck();
+
+    expect(screen.getByTestId("acp-connect-affordance")).not.toBeNull();
+    expect(recordedLifecycleDiagnostics).toEqual([]);
   });
 
   test("opens the sign-in tab and advances to awaiting-capture", async () => {

--- a/clients/web/src/domains/chat/transcript/acp-connect-affordance.tsx
+++ b/clients/web/src/domains/chat/transcript/acp-connect-affordance.tsx
@@ -105,8 +105,9 @@ function AcpConnectAffordanceInner({ assistantId }: { assistantId: string }) {
     // Leave a breadcrumb: the card flashing and vanishing is otherwise silent,
     // and a self-heal dismissal next to a fresh missing-token failure is the
     // signature of a status/spawn predicate mismatch. It goes in the durable
-    // lifecycle ring because streaming floods the high-volume ring, which held
-    // only minutes of history in the bundle that motivated this breadcrumb.
+    // lifecycle ring because streaming floods the high-volume ring, which then
+    // evicts within minutes, and the breadcrumb has to survive until a feedback
+    // bundle is captured.
     const store = useInteractionStore.getState();
     recordLifecycleDiagnostic("acp_connect_self_heal_dismiss", {
       assistantId,

--- a/clients/web/src/domains/chat/transcript/acp-connect-affordance.tsx
+++ b/clients/web/src/domains/chat/transcript/acp-connect-affordance.tsx
@@ -11,6 +11,7 @@ import {
   type UseConnectClaudeResult,
 } from "@/hooks/use-connect-claude";
 import { useSupportsAcpConnect } from "@/lib/backwards-compat/use-supports-acp-connect";
+import { recordLifecycleDiagnostic } from "@/lib/diagnostics";
 import { isElectron } from "@/runtime/is-electron";
 
 // ---------------------------------------------------------------------------
@@ -98,10 +99,22 @@ function AcpConnectAffordanceInner({ assistantId }: { assistantId: string }) {
   }, [assistantId, reason]);
 
   useEffect(() => {
-    if (alreadyConnected && connection.phase === "idle") {
-      useInteractionStore.getState().dismissAcpConnect();
+    if (!alreadyConnected || connection.phase !== "idle") {
+      return;
     }
-  }, [alreadyConnected, connection.phase]);
+    // Leave a breadcrumb: the card flashing and vanishing is otherwise silent,
+    // and a self-heal dismissal next to a fresh missing-token failure is the
+    // signature of a status/spawn predicate mismatch. It goes in the durable
+    // lifecycle ring because streaming floods the high-volume ring, which held
+    // only minutes of history in the bundle that motivated this breadcrumb.
+    const store = useInteractionStore.getState();
+    recordLifecycleDiagnostic("acp_connect_self_heal_dismiss", {
+      assistantId,
+      toolUseId: store.pendingAcpConnect?.toolUseId ?? null,
+      reason: store.pendingAcpConnect?.reason ?? "missing",
+    });
+    store.dismissAcpConnect();
+  }, [alreadyConnected, assistantId, connection.phase]);
 
   // When the in-card connect flow completes, signal the chat view to
   // auto-continue the failed task (via a hidden "retry" send) so the user

--- a/clients/web/src/domains/chat/utils/debug-api.test.ts
+++ b/clients/web/src/domains/chat/utils/debug-api.test.ts
@@ -75,6 +75,9 @@ const DEFAULT_PENDING_INTERACTIONS: PendingInteractionsSnapshot = {
   isSubmittingQuestion: false,
   isQuestionCardDismissed: false,
   inlineConfirmationToolCallId: null,
+  pendingAcpConnect: null,
+  dismissedAcpConnectToolUseIds: [],
+  pendingAcpContinue: false,
 };
 
 interface MakeRefsOverrides extends Partial<ChatDebugRefs> {
@@ -810,6 +813,50 @@ describe("createChatDebugApi.listPendingInteractions", () => {
     expect(captured.pendingConfirmation?.input).toBe(input);
     expect(input).toEqual({ api_key: "sk-live-secret-value" });
     expect(snapshot.pendingConfirmation?.input).not.toBe(input);
+  });
+
+  test("forwards the ACP Connect card state", () => {
+    const api = createChatDebugApi(
+      makeRefs({
+        pendingInteractions: {
+          pendingAcpConnect: {
+            toolUseId: "toolu-acp-1",
+            reason: "auth_required",
+          },
+          dismissedAcpConnectToolUseIds: ["toolu-acp-0", "toolu-acp-2"],
+          pendingAcpContinue: true,
+        },
+      }),
+    );
+    const snapshot = api.listPendingInteractions();
+    expect(snapshot.pendingAcpConnect).toEqual({
+      toolUseId: "toolu-acp-1",
+      reason: "auth_required",
+    });
+    expect(snapshot.dismissedAcpConnectToolUseIds).toEqual([
+      "toolu-acp-0",
+      "toolu-acp-2",
+    ]);
+    expect(snapshot.pendingAcpContinue).toBe(true);
+  });
+
+  test("keeps the ACP Connect card state when a confirmation is redacted", () => {
+    const api = createChatDebugApi(
+      makeRefs({
+        pendingInteractions: {
+          pendingConfirmation: {
+            requestId: "req-confirm-1",
+            input: { api_key: "sk-live-secret-value" },
+          },
+          pendingAcpConnect: { toolUseId: "toolu-acp-1" },
+        },
+      }),
+    );
+    const snapshot = api.listPendingInteractions();
+    expect(snapshot.pendingConfirmation?.input).toEqual({
+      api_key: "[redacted]",
+    });
+    expect(snapshot.pendingAcpConnect?.toolUseId).toBe("toolu-acp-1");
   });
 
   test("leaves a confirmation without input untouched", () => {

--- a/clients/web/src/domains/chat/utils/debug-api.ts
+++ b/clients/web/src/domains/chat/utils/debug-api.ts
@@ -33,6 +33,7 @@ import {
 import { fetchConversationMessages as defaultFetchConversationMessages } from "@/domains/chat/api/messages";
 import { useStreamStore } from "@/domains/chat/stream-store";
 import type {
+  PendingAcpConnectState,
   PendingConfirmationState,
   PendingContactRequestState,
   PendingQuestionState,
@@ -151,6 +152,16 @@ export interface PendingInteractionsSnapshot {
   /** Tool-call id paired with the currently-rendered inline confirmation,
    *  or `null` when no inline confirmation is active. */
   inlineConfirmationToolCallId: string | null;
+  /** The inline "Connect Claude Code" prompt currently raised by a failed
+   *  `acp_spawn`, or `null` when no Connect card is showing. */
+  pendingAcpConnect: PendingAcpConnectState | null;
+  /** Tool-call ids whose Connect card was dismissed in this session, sorted
+   *  so the dump is stable across captures. A dismissed id suppresses the
+   *  card even when the same failure is replayed by a resync. */
+  dismissedAcpConnectToolUseIds: string[];
+  /** True while a completed connect flow is waiting for the chat view to
+   *  fire its hidden continuation send. */
+  pendingAcpContinue: boolean;
 }
 
 /**
@@ -833,7 +844,7 @@ export function createChatDebugApi(refs: ChatDebugRefs): ChatDebugApi {
       "  .serverMessages()          [experimental] fetch /v1/history and return the server snapshot response (messages + seq)",
       "                              (diff against getClientMessages() manually in the console)",
       "  .listPendingInteractions() frontend-tracked pending prompts (secret/confirmation/",
-      "                              contact-request/question) and submission flags",
+      "                              contact-request/question/acp-connect) and submission flags",
       "  .getScrollState()          scroll geometry + pagination — why can't I scroll up?",
       "                              .diagnosis gives a human-readable summary",
       "  .getDiagnostics(prefix?)   main diagnostics ring (per-delta SSE / drop gates / history applies),",


### PR DESCRIPTION
## Summary
Fixes the invisible "Connect Claude Code" card loop: the spawn path (broker policy) and the card's self-heal check (`hasAcpClaudeToken`) evaluated the stored ACP Claude OAuth credential with different predicates, so a domain-restricted credential failed every `acp_spawn` with the missing-token card while the status route answered `connected: true`, dismissing the card within one round-trip. The status check now evaluates the exact spawn-time broker policy (with a parity drift-guard test), the spawn failure reports WHY injection missed instead of always claiming "not set", the Connect flow repairs a policy-blocked credential (tools grant + domain clear in one write), and the card's state and self-heal dismissals are now visible in feedback bundles.

## Self-review result
GAPS FOUND round 1 (3 findings: split repair, test redundancy, stale comments) — fixed in #40998; round 2 re-review PASS on all four passes.

## PRs merged into feature branch
- #40993: Extract serverUse policy evaluation into a pure tool-policy helper
- #40994: Record ACP Connect card state in the chat debug dump and diagnose self-heal dismissals
- #40995: Make the Connect Claude status check evaluate the exact spawn-time broker policy
- #40996: Clear allowedDomains on the ACP Claude OAuth credential when Connect stores a token
- #40997: Thread the ACP credential injection miss reason into logs and the spawn failure message

### Fix PRs
- #40998: consolidate Connect policy repair into repairAcpSpawnPolicy; trim redundant tests; correct stale comments

Part of plan: acp-connect-split-brain.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)