### PR TITLE
feat(web): skip research onboarding in non-production

### DIFF
--- a/clients/web/src/domains/onboarding/onboarding-destination.test.ts
+++ b/clients/web/src/domains/onboarding/onboarding-destination.test.ts
@@ -1,7 +1,26 @@
 import { describe, expect, test } from "bun:test";
 
-import { onboardingDestinationAfterConsent } from "@/domains/onboarding/onboarding-destination";
+import {
+  SKIP_RESEARCH_PARAM,
+  canSkipOnboardingResearch,
+  onboardingDestinationAfterConsent,
+  shouldSkipResearchAfterHatch,
+  withSkipResearch,
+} from "@/domains/onboarding/onboarding-destination";
 import { routes } from "@/utils/routes";
+
+describe("canSkipOnboardingResearch", () => {
+  test("allows skip on local, dev, staging, and unset", () => {
+    expect(canSkipOnboardingResearch(undefined)).toBe(true);
+    expect(canSkipOnboardingResearch("local")).toBe(true);
+    expect(canSkipOnboardingResearch("dev")).toBe(true);
+    expect(canSkipOnboardingResearch("staging")).toBe(true);
+  });
+
+  test("blocks skip on production", () => {
+    expect(canSkipOnboardingResearch("production")).toBe(false);
+  });
+});
 
 describe("onboardingDestinationAfterConsent", () => {
   test("platform/Vellum-Cloud routes straight to the research flow", () => {
@@ -16,5 +35,101 @@ describe("onboardingDestinationAfterConsent", () => {
     expect(
       onboardingDestinationAfterConsent({ isLocalHatch: true }),
     ).toBe(routes.onboarding.hatching);
+  });
+
+  test("skip-to-chat routes platform onboarding to hatching so the assistant is provisioned", () => {
+    expect(
+      onboardingDestinationAfterConsent({
+        isLocalHatch: false,
+        skipResearch: true,
+        env: "staging",
+      }),
+    ).toBe(routes.onboarding.hatching);
+  });
+
+  test("skip-to-chat keeps local hosting on hatching", () => {
+    expect(
+      onboardingDestinationAfterConsent({
+        isLocalHatch: true,
+        skipResearch: true,
+        env: "dev",
+      }),
+    ).toBe(routes.onboarding.hatching);
+  });
+
+  test("production ignores skip-to-chat and keeps the research destination", () => {
+    expect(
+      onboardingDestinationAfterConsent({
+        isLocalHatch: false,
+        skipResearch: true,
+        env: "production",
+      }),
+    ).toBe(routes.onboarding.research);
+  });
+});
+
+describe("withSkipResearch", () => {
+  test("adds skip_research and rewrites a research URL onto hatching", () => {
+    expect(
+      withSkipResearch(
+        `${routes.onboarding.research}?hosting=managed`,
+        "staging",
+      ),
+    ).toBe(
+      `${routes.onboarding.hatching}?hosting=managed&${SKIP_RESEARCH_PARAM}=1`,
+    );
+  });
+
+  test("adds skip_research to an already-hatching destination", () => {
+    expect(
+      withSkipResearch(`${routes.onboarding.hatching}?hosting=local`, "dev"),
+    ).toBe(
+      `${routes.onboarding.hatching}?hosting=local&${SKIP_RESEARCH_PARAM}=1`,
+    );
+  });
+
+  test("adds skip_research to a paid hatch return without dropping post_checkout", () => {
+    expect(
+      withSkipResearch(
+        `${routes.onboarding.hatching}?hosting=vellum-cloud&post_checkout=1`,
+        "staging",
+      ),
+    ).toBe(
+      `${routes.onboarding.hatching}?hosting=vellum-cloud&post_checkout=1&${SKIP_RESEARCH_PARAM}=1`,
+    );
+  });
+
+  test("production leaves the destination unchanged", () => {
+    const destination = `${routes.onboarding.research}?hosting=managed`;
+    expect(withSkipResearch(destination, "production")).toBe(destination);
+  });
+});
+
+describe("shouldSkipResearchAfterHatch", () => {
+  test("true only when skip_research=1 is present", () => {
+    expect(
+      shouldSkipResearchAfterHatch(
+        new URLSearchParams("skip_research=1"),
+        "staging",
+      ),
+    ).toBe(true);
+    expect(
+      shouldSkipResearchAfterHatch(new URLSearchParams(), "staging"),
+    ).toBe(false);
+    expect(
+      shouldSkipResearchAfterHatch(
+        new URLSearchParams("skip_research=0"),
+        "staging",
+      ),
+    ).toBe(false);
+  });
+
+  test("production ignores skip_research even when the param is set", () => {
+    expect(
+      shouldSkipResearchAfterHatch(
+        new URLSearchParams("skip_research=1"),
+        "production",
+      ),
+    ).toBe(false);
   });
 });

--- a/clients/web/src/domains/onboarding/onboarding-destination.ts
+++ b/clients/web/src/domains/onboarding/onboarding-destination.ts
@@ -1,6 +1,65 @@
 import { routes } from "@/utils/routes";
 
 /**
+ * Query param that asks the hatch screen to hand off to chat instead of the
+ * research/personality funnel. Set only by the non-production "Skip to chat"
+ * control on the privacy screen (and carried through checkout / paid-return
+ * resumptions of that click). Production builds ignore it.
+ */
+export const SKIP_RESEARCH_PARAM = "skip_research";
+
+/**
+ * Whether this build may skip the research/personality funnel after consent.
+ * True everywhere except a production `VITE_SENTRY_ENVIRONMENT` so local, dev,
+ * and staging can drop into chat without walking the research steps.
+ */
+export function canSkipOnboardingResearch(
+  env: string | undefined = import.meta.env.VITE_SENTRY_ENVIRONMENT,
+): boolean {
+  return env !== "production";
+}
+
+/**
+ * Whether a hatch completion should skip research and enter chat. Requires both
+ * the skip query param and a non-production build, so a crafted production URL
+ * cannot bypass the funnel.
+ */
+export function shouldSkipResearchAfterHatch(
+  searchParams: Pick<URLSearchParams, "get">,
+  env: string | undefined = import.meta.env.VITE_SENTRY_ENVIRONMENT,
+): boolean {
+  return (
+    canSkipOnboardingResearch(env) &&
+    searchParams.get(SKIP_RESEARCH_PARAM) === "1"
+  );
+}
+
+/**
+ * Mark a post-consent destination so the hatch screen hands off to chat
+ * instead of research. No-op on production builds.
+ *
+ * Research URLs are rewritten to hatching: skip has no form to fill, so the
+ * foreground hatch screen is the provisioner.
+ */
+export function withSkipResearch(
+  destination: string,
+  env: string | undefined = import.meta.env.VITE_SENTRY_ENVIRONMENT,
+): string {
+  if (!canSkipOnboardingResearch(env)) {
+    return destination;
+  }
+  const qIdx = destination.indexOf("?");
+  const path = qIdx < 0 ? destination : destination.slice(0, qIdx);
+  const params = new URLSearchParams(
+    qIdx < 0 ? "" : destination.slice(qIdx + 1),
+  );
+  params.set(SKIP_RESEARCH_PARAM, "1");
+  const nextPath =
+    path === routes.onboarding.research ? routes.onboarding.hatching : path;
+  return `${nextPath}?${params.toString()}`;
+}
+
+/**
  * Decide where the standard onboarding flow goes after the user accepts
  * consent on the privacy screen.
  *
@@ -14,13 +73,27 @@ import { routes } from "@/utils/routes";
  *   gateway readyz → provider key) runs; the hatching screen then redirects into
  *   the research flow, which adopts that just-hatched assistant. Skipping
  *   hatching here would leave the research flow with no assistant to adopt.
+ * - **Skip to chat** (non-production) → hatching as well. There is no research
+ *   form, so the hatch screen provisions, then hands off to chat.
  */
 export function onboardingDestinationAfterConsent({
   isLocalHatch,
+  skipResearch = false,
+  env = import.meta.env.VITE_SENTRY_ENVIRONMENT,
 }: {
   /** A local-hosting onboarding that must run the foreground local hatch. */
   isLocalHatch: boolean;
+  /**
+   * Non-production shortcut past the research/personality funnel. Ignored on
+   * production builds.
+   */
+  skipResearch?: boolean;
+  /** Build environment; defaults to `VITE_SENTRY_ENVIRONMENT`. */
+  env?: string;
 }): string {
+  if (skipResearch && canSkipOnboardingResearch(env)) {
+    return routes.onboarding.hatching;
+  }
   return isLocalHatch
     ? routes.onboarding.hatching
     : routes.onboarding.research;

--- a/clients/web/src/domains/onboarding/pages/hatching-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/hatching-screen.test.tsx
@@ -416,6 +416,7 @@ mock.module("@/utils/avatar-svg-compositor", () => ({
 
 mock.module("@/utils/routes", () => ({
   routes: {
+    assistant: "/assistant",
     onboarding: {
       research: "/onboarding/research",
       hosting: "/onboarding/hosting",
@@ -532,6 +533,28 @@ describe("HatchingScreen — post-payment provisioning wait", () => {
     });
     // Not a Pro subscription: the resize phase is never entered.
     expect(screen.queryByText(RESIZE_LABEL)).toBeNull();
+  });
+
+  test("skip_research hands off to chat instead of the research funnel", async () => {
+    const env = import.meta.env as Record<string, string | undefined>;
+    const previousEnv = env.VITE_SENTRY_ENVIRONMENT;
+    env.VITE_SENTRY_ENVIRONMENT = "staging";
+    searchParams = new URLSearchParams("skip_research=1");
+    subscriptionPlanId = "base";
+    onboardingData = { max_machine_tier: null, selected_storage_gib: null };
+
+    try {
+      render(<HatchingScreen />);
+
+      await waitFor(() => expect(navigateMock).toHaveBeenCalled(), {
+        timeout: 5000,
+      });
+      expect(navigateMock).toHaveBeenCalledWith("/assistant?onboarding=1", {
+        replace: true,
+      });
+    } finally {
+      env.VITE_SENTRY_ENVIRONMENT = previousEnv;
+    }
   });
 
   test("a base plan whose targets fetch fails still completes, never trapping", async () => {

--- a/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/hatching-screen.tsx
@@ -28,6 +28,7 @@ import {
   ProviderKeyRejectedError,
 } from "@/domains/onboarding/provider-key";
 import { onboardingProvider } from "@/domains/onboarding/provider-catalog";
+import { shouldSkipResearchAfterHatch } from "@/domains/onboarding/onboarding-destination";
 import { ATTRIBUTED_PLUGIN_PARAM } from "@/domains/onboarding/plugin-attribution";
 import {
   awaitPurchasedProvisioning,
@@ -299,6 +300,14 @@ export function HatchingScreen() {
         void (async () => {
           await lifecycleService.checkAssistant();
           if (cancelled) {
+            return;
+          }
+          // Non-production skip-to-chat: the assistant is live, so drop into
+          // the workspace instead of the research/personality funnel.
+          if (shouldSkipResearchAfterHatch(searchParams)) {
+            void navigate(`${routes.assistant}?onboarding=1`, {
+              replace: true,
+            });
             return;
           }
           // A local hatch feeds the research/personality flow. The assistant is

--- a/clients/web/src/domains/onboarding/pages/privacy-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/privacy-screen.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 
+import { SKIP_RESEARCH_PARAM } from "@/domains/onboarding/onboarding-destination";
 import { routes } from "@/utils/routes";
 
 // react-router: capture navigate() targets and drive the ?preview flag.
@@ -115,6 +116,10 @@ const { PrivacyScreen } =
 
 function clickStart(): void {
   fireEvent.click(screen.getByText("Start"));
+}
+
+function clickSkipToChat(): void {
+  fireEvent.click(screen.getByText("Skip to chat"));
 }
 
 /** The query of the single URL `navigate()` was called with. */
@@ -533,6 +538,89 @@ describe("PrivacyScreen — Start navigation", () => {
     const target = navigateMock.mock.calls[0]?.[0] as string;
     expect(target.startsWith(`${routes.checkout}?`)).toBe(true);
     expect(navigatedQuery().get("package")).toBe("super");
+  });
+});
+
+describe("PrivacyScreen — Skip to chat", () => {
+  const env = import.meta.env as Record<string, string | undefined>;
+  let previousEnv: string | undefined;
+
+  beforeEach(() => {
+    previousEnv = env.VITE_SENTRY_ENVIRONMENT;
+    env.VITE_SENTRY_ENVIRONMENT = "staging";
+    navigateMock.mockClear();
+    saveConsentMock.mockClear();
+    emitFunnelStepCompletedMock.mockClear();
+    nativePlatform = false;
+    localMode = false;
+    checkoutIntentValue = null;
+    takeoverValue = "enabled";
+  });
+  afterEach(() => {
+    env.VITE_SENTRY_ENVIRONMENT = previousEnv;
+    cleanup();
+    nativePlatform = false;
+    localMode = false;
+    checkoutIntentValue = null;
+    takeoverValue = "enabled";
+  });
+
+  test("saves consent and hatches, skipping the research funnel", () => {
+    searchParamsValue = new URLSearchParams("hosting=managed");
+    render(<PrivacyScreen />);
+
+    clickSkipToChat();
+
+    expect(saveConsentMock).toHaveBeenCalledTimes(1);
+    expect(navigateMock).toHaveBeenCalledTimes(1);
+    const target = navigateMock.mock.calls[0]?.[0] as string;
+    expect(target.startsWith(routes.onboarding.hatching)).toBe(true);
+    expect(target).toContain("hosting=managed");
+    expect(target).toContain(`${SKIP_RESEARCH_PARAM}=1`);
+    expect(navigateMock.mock.calls[0]?.[1]).toEqual({ replace: true });
+  });
+
+  test("preview mode no-ops on Skip to chat without persisting consent", () => {
+    searchParamsValue = new URLSearchParams("preview=true");
+    render(<PrivacyScreen />);
+
+    clickSkipToChat();
+
+    expect(navigateMock).not.toHaveBeenCalled();
+    expect(saveConsentMock).not.toHaveBeenCalled();
+  });
+
+  test("carries skip_research onto a paid hatch return", () => {
+    const paidHatch = `${routes.onboarding.hatching}?hosting=vellum-cloud&post_checkout=1`;
+    searchParamsValue = new URLSearchParams({ returnTo: paidHatch });
+    render(<PrivacyScreen />);
+
+    clickSkipToChat();
+
+    expect(saveConsentMock).toHaveBeenCalledTimes(1);
+    const target = navigateMock.mock.calls[0]?.[0] as string;
+    expect(target.startsWith(routes.onboarding.hatching)).toBe(true);
+    expect(target).toContain("post_checkout=1");
+    expect(target).toContain(`${SKIP_RESEARCH_PARAM}=1`);
+  });
+
+  test("checkout continuation carries the skip-to-chat hatch URL", () => {
+    checkoutIntentValue = {
+      kind: "package",
+      packageKey: "super",
+      savedAt: Date.now(),
+      resumeAfterOnboarding: true,
+    };
+    searchParamsValue = new URLSearchParams("hosting=managed");
+    render(<PrivacyScreen />);
+
+    clickSkipToChat();
+
+    const target = navigateMock.mock.calls[0]?.[0] as string;
+    expect(target.startsWith(`${routes.checkout}?`)).toBe(true);
+    expect(navigatedQuery().get("continue")).toBe(
+      `${routes.onboarding.hatching}?hosting=managed&${SKIP_RESEARCH_PARAM}=1`,
+    );
   });
 });
 

--- a/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
@@ -12,7 +12,11 @@ import {
   getOnboardingFunnelSessionId,
   ONBOARDING_FUNNEL_STEPS,
 } from "@/domains/onboarding/funnel-events";
-import { onboardingDestinationAfterConsent } from "@/domains/onboarding/onboarding-destination";
+import {
+  canSkipOnboardingResearch,
+  onboardingDestinationAfterConsent,
+  withSkipResearch,
+} from "@/domains/onboarding/onboarding-destination";
 import { SETUP_NAVIGATE } from "@/domains/onboarding/onboarding-navigation";
 import { ATTRIBUTED_PLUGIN_PARAM } from "@/domains/onboarding/plugin-attribution";
 import { useMarketingPricingTakeover } from "@/hooks/use-marketing-pricing-takeover";
@@ -65,12 +69,14 @@ export function PrivacyScreen() {
   const setTosAccepted = isPreview ? noop : setTosAcceptedReal;
   const setPrivacyConsent = isPreview ? noop : setPrivacyConsentReal;
 
-  const onStart = useCallback(() => {
+  const showSkipToChat = canSkipOnboardingResearch();
+
+  const onAdvance = useCallback((skipResearch: boolean) => {
     if (isPreview) {
       // Developer "Replay Onboarding": preview mode does not advance to any
       // side-effecting onboarding route. Hatching is excluded from the preview
       // route allowlist in onboardingCompletedMiddleware (it has real side
-      // effects), so Start is a no-op here.
+      // effects), so Start and Skip to chat are no-ops here.
       return;
     }
 
@@ -92,7 +98,10 @@ export function PrivacyScreen() {
       searchParams.get("returnTo"),
     );
     if (paidHatchReturnTo) {
-      void navigate(paidHatchReturnTo, SETUP_NAVIGATE);
+      void navigate(
+        skipResearch ? withSkipResearch(paidHatchReturnTo) : paidHatchReturnTo,
+        SETUP_NAVIGATE,
+      );
       return;
     }
 
@@ -111,13 +120,18 @@ export function PrivacyScreen() {
     // A local-hosting onboarding (hosting=local/docker in a local-mode build)
     // must run the foreground local hatch first, so it goes to `hatching`, which
     // then redirects into the research flow. Vellum-Cloud goes straight to
-    // research (managed background hatch).
+    // research (managed background hatch). Skip-to-chat also uses hatching:
+    // there is no research form, so the hatch screen provisions then hands off
+    // to chat.
     const isLocalHatch =
       isLocalClient() && hostingParam !== null && hostingParam !== "vellum-cloud";
     const destination = onboardingDestinationAfterConsent({
       isLocalHatch,
+      skipResearch,
     });
-    const onboardingNext = `${destination}${qs ? `?${qs}` : ""}`;
+    const onboardingNext = skipResearch
+      ? withSkipResearch(`${destination}${qs ? `?${qs}` : ""}`)
+      : `${destination}${qs ? `?${qs}` : ""}`;
 
     // A pricing-CTA signup stashes its chosen plan (see navigation-resolver
     // post-auth). With consent now recorded, resume checkout so payment happens
@@ -127,8 +141,9 @@ export function PrivacyScreen() {
     // it's ignored here and left untouched for its own flow — onboarding proceeds
     // normally. The checkout route owns the marked stash's lifecycle from here —
     // re-stashing on a Stripe redirect, clearing it on an already-Pro no_op — so
-    // this screen just hands off. Resuming only from this explicit Start click —
-    // never a render effect — keeps consent and checkout from looping.
+    // this screen just hands off. Resuming only from this explicit click
+    // (Start or Skip to chat), never a render effect, keeps consent and
+    // checkout from looping.
     // A positively-off `marketing-pricing-takeover` drops the dead selection and
     // continues onboarding: handing off would bounce through a gated checkout
     // route and out of the funnel before research runs. An unresolved flag still
@@ -225,11 +240,23 @@ export function PrivacyScreen() {
             size="regular"
             fullWidth
             disabled={!tosAccepted || !privacyConsent}
-            onClick={onStart}
+            onClick={() => onAdvance(false)}
             className={electron ? undefined : "h-11 text-base"}
           >
             {t("actions.start")}
           </Button>
+          {showSkipToChat && (
+            <Button
+              variant="outlined"
+              size="regular"
+              fullWidth
+              disabled={!tosAccepted || !privacyConsent}
+              onClick={() => onAdvance(true)}
+              className={electron ? undefined : "h-11 text-base"}
+            >
+              {t("privacyScreen.skipToChat")}
+            </Button>
+          )}
           {/*
            * Back's destination is mode-specific, but always stays inside the SPA
            * (react-router `navigate`, never a full-document nav). In local mode

--- a/clients/web/src/i18n/locales/en/onboarding.json
+++ b/clients/web/src/i18n/locales/en/onboarding.json
@@ -27,9 +27,10 @@
   "startScreen": {
     "createAssistant": "Create your assistant"
   },
-  "privacyScreen": {
+    "privacyScreen": {
     "title": "Before You Start",
-    "body": "Choose your privacy preferences. You can update these anytime in the Settings."
+    "body": "Choose your privacy preferences. You can update these anytime in the Settings.",
+    "skipToChat": "Skip to chat"
   },
   "hostingScreen": {
     "title": "Hosting",

--- a/clients/web/src/i18n/locales/es/onboarding.json
+++ b/clients/web/src/i18n/locales/es/onboarding.json
@@ -27,9 +27,10 @@
   "startScreen": {
     "createAssistant": "Crear tu asistente"
   },
-  "privacyScreen": {
+    "privacyScreen": {
     "title": "Antes de empezar",
-    "body": "Elige tus preferencias de privacidad. Puedes cambiarlas cuando quieras en los ajustes."
+    "body": "Elige tus preferencias de privacidad. Puedes cambiarlas cuando quieras en los ajustes.",
+    "skipToChat": "Ir al chat"
   },
   "hostingScreen": {
     "title": "Alojamiento",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan

In local, dev, and staging, provide a way to skip the research/personality funnel after accepting privacy policy and terms, and land directly in chat.

Production is unchanged. Start still walks the full research onboarding so those environments can still test the funnel.

Skip still hatches the assistant (foreground hatching screen), then navigates to chat. Checkout continuation and paid-hatch returns carry the skip marker so a pricing signup that skipped research still provisions, then enters chat.

## Test plan

- `cd clients/web && bun test src/domains/onboarding/onboarding-destination.test.ts`
- `cd clients/web && bun test src/domains/onboarding/pages/privacy-screen.test.tsx`
- `cd clients/web && bun test src/domains/onboarding/pages/hatching-screen.test.tsx` (includes skip_research handoff)
- `cd clients/web && bun test src/i18n/catalogs.test.ts`

## Risk

Low. The Skip to chat button only renders when `VITE_SENTRY_ENVIRONMENT` is not `production`. Production also ignores a crafted `skip_research=1` query param.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0c026cbd-b38b-4823-b71c-aec6c8721b9a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c026cbd-b38b-4823-b71c-aec6c8721b9a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

