### PR TITLE
fix(companion): put the avatar back where the host aimed when the pill grows left (JARVIS-1582)

### DIFF
--- a/clients/web/src/components/companion-surface.test.tsx
+++ b/clients/web/src/components/companion-surface.test.tsx
@@ -259,8 +259,8 @@ describe("the companion surface's anchor in the canvas", () => {
  * avatar ends up against that edge.
  *
  * Anchoring without mirroring is the failure this covers. It draws the avatar
- * at the far end of the pill instead — up to a card's width from where main
- * believes it is — so the mascot teleports at the direction flip, the labels
+ * at the far end of the pill instead, up to a card's width from where main
+ * believes it is, so the mascot teleports at the direction flip, the labels
  * sweep under a held pointer, and the point main hands presses to lands on a
  * control that refuses them. The surface reads as dead (JARVIS-1582).
  */

--- a/clients/web/src/components/companion-surface.test.tsx
+++ b/clients/web/src/components/companion-surface.test.tsx
@@ -169,16 +169,16 @@ describe("the companion surface's custom avatar", () => {
  * main flip the direction near the top of a display without the renderer
  * learning the canvas's height (JARVIS-1548).
  */
-describe("the companion surface's anchor in the canvas", () => {
-  /** The pill itself, which is also the surface's drag handle. */
-  const surfaceOf = (container: HTMLElement): HTMLElement => {
-    const found = container.querySelector<HTMLElement>(".cursor-grab");
-    if (!found) {
-      throw new Error("Expected the surface to render");
-    }
-    return found;
-  };
+/** The pill itself, which is also the surface's drag handle. */
+const surfaceOf = (container: HTMLElement): HTMLElement => {
+  const found = container.querySelector<HTMLElement>(".cursor-grab");
+  if (!found) {
+    throw new Error("Expected the surface to render");
+  }
+  return found;
+};
 
+describe("the companion surface's anchor in the canvas", () => {
   test("hangs off the canvas's bottom edge while the card grows up", () => {
     const { container } = render(<CompanionSurface phase="resting" />);
     expect(surfaceOf(container).style.top).toBe("calc(100% - 46px)");
@@ -246,5 +246,117 @@ describe("the companion surface's anchor in the canvas", () => {
       expect(surfaceOf(container).style.transform).toBe("translateY(-50%)");
       cleanup();
     }
+  });
+});
+/**
+ * Growing leftward is two halves, and the surface is only in the right place
+ * when both happen.
+ *
+ * Main positions the window by the *avatar's* centre and measures every later
+ * drag, clamp and direction check from it. The renderer's half of that bargain
+ * is to draw the avatar on the point the host aimed at: the surface anchors by
+ * the edge the avatar is on, and the row the avatar sits in mirrors so the
+ * avatar ends up against that edge.
+ *
+ * Anchoring without mirroring is the failure this covers. It draws the avatar
+ * at the far end of the pill instead — up to a card's width from where main
+ * believes it is — so the mascot teleports at the direction flip, the labels
+ * sweep under a held pointer, and the point main hands presses to lands on a
+ * control that refuses them. The surface reads as dead (JARVIS-1582).
+ */
+describe("the companion surface growing leftward", () => {
+  /**
+   * The row the avatar is on, found through the avatar rather than by its own
+   * classes: it is the row's job to order the avatar, so the avatar is what
+   * says which row it is.
+   */
+  const avatarRowOf = (container: HTMLElement): HTMLElement => {
+    const avatar = container.querySelector<HTMLElement>(".size-11");
+    if (!avatar?.parentElement) {
+      throw new Error("Expected the avatar to render inside a row");
+    }
+    return avatar.parentElement;
+  };
+
+  test("mirrors the row the avatar is on", () => {
+    const { container } = render(
+      <CompanionSurface phase="hover" growth="left" />,
+    );
+    expect(avatarRowOf(container).className).toContain("flex-row-reverse");
+  });
+
+  test("leaves that row alone growing the ordinary way", () => {
+    const { container } = render(
+      <CompanionSurface phase="hover" growth="right" />,
+    );
+    expect(avatarRowOf(container).className).not.toContain("flex-row-reverse");
+  });
+
+  /**
+   * The card is anchored by the same edge as the pill and is eight times the
+   * avatar's width, so an unmirrored card puts the mascot further from where
+   * main is measuring than any other state.
+   */
+  test("mirrors the card's row too", () => {
+    const { container } = render(
+      <CompanionSurface phase="typing" growth="left" />,
+    );
+    expect(avatarRowOf(container).className).toContain("flex-row-reverse");
+  });
+
+  /**
+   * The other half. The row is `INNER_GAP` narrower than the pill, because that
+   * gap is trailing space past the last control, so the row has to sit against
+   * the anchored end and leave the slack at the other.
+   */
+  test("holds the row against the edge the pill is anchored by", () => {
+    const { container } = render(
+      <CompanionSurface phase="hover" growth="left" />,
+    );
+    expect(surfaceOf(container).className).toContain("flex-row-reverse");
+  });
+
+  test("anchors the pill by its right edge", () => {
+    const { container } = render(
+      <CompanionSurface phase="hover" growth="left" />,
+    );
+    expect(surfaceOf(container).style.right).toBe("50%");
+  });
+});
+
+/**
+ * The whole surface is a drag handle that happens to have words on it, so a
+ * press and a sweep across it is a drag and never a text selection. Without
+ * this, a drag that crosses the direction flip highlights "Talk" and "Type" on
+ * the way past, and the selection it leaves behind arms the browser's own
+ * text-drag against the next press (JARVIS-1582).
+ */
+describe("the companion surface's text selection", () => {
+  test("is off across the surface", () => {
+    const { container } = render(<CompanionSurface phase="hover" />);
+    expect(surfaceOf(container).className).toContain("select-none");
+  });
+
+  test("is back on for a reply, which is prose to copy", () => {
+    const { container } = render(
+      <CompanionSurface
+        phase="typing"
+        turns={[
+          { role: "assistant", text: "The 14:00 one moved to Thursday." },
+        ]}
+      />,
+    );
+    const turn = container.querySelector("p");
+    expect(turn?.textContent).toBe("The 14:00 one moved to Thursday.");
+    expect(turn?.closest(".select-text")).not.toBeNull();
+  });
+
+  test("is back on in the field, which needs a caret", () => {
+    const { container } = render(
+      <CompanionSurface phase="typing" growth="left" />,
+    );
+    expect(container.querySelector("input")?.className).toContain(
+      "select-text",
+    );
   });
 });

--- a/clients/web/src/components/companion-surface.tsx
+++ b/clients/web/src/components/companion-surface.tsx
@@ -539,14 +539,14 @@ export function CompanionSurface({
       )}
       {typing && turns.length > 0 && <RecentTurns turns={turns} />}
       {/* The avatar's own row, and the half of the mirroring that orders it.
-          The reversal belongs here rather than on the surface, which is where
-          it used to live: this row wraps the avatar and the body, so the
-          surface has a single in-flow child and reversing *that* orders
-          nothing. Left alone, growing leftward anchors the surface by its right
-          edge and then draws the avatar at the far end of it, putting the
-          mascot up to a card's width from the point the host positioned the
-          window by. Applied whether or not the composer is open, because the
-          card is anchored the same way and has further to be wrong. */}
+          This row is the surface's only in-flow child, so it is the one place
+          the reversal has any ordering to do: reversing the surface around it
+          moves the row within the box and leaves the avatar wherever the row
+          put it. The avatar has to land against the edge `placement` anchored
+          by, since that edge is derived from the point the host positioned the
+          window by. True of the card as much as the pill, and the card is
+          anchored the same way with a card's width to be wrong by, so this
+          holds whether or not the composer is open. */}
       <div
         className={`relative flex h-11 shrink-0 items-center ${
           growth === "left" ? "flex-row-reverse" : ""

--- a/clients/web/src/components/companion-surface.tsx
+++ b/clients/web/src/components/companion-surface.tsx
@@ -435,8 +435,13 @@ export function CompanionSurface({
   // eye and cursor would have no fixed target to aim at.
   //
   // Each direction therefore fixes the avatar's own edge to the centre and lets
-  // the body run the other way. Growing left also reverses the row, because the
-  // body has to end up on the avatar's left.
+  // the body run the other way: this anchors the surface by the edge the avatar
+  // is on, and the avatar's own row is mirrored below so the avatar ends up
+  // against that edge. Both halves are required. Anchoring by the right edge without
+  // mirroring puts the avatar at the far end of the pill, which is a different
+  // point from the one the host positioned the window by, and every drag,
+  // clamp and direction check main makes from then on is measured against a
+  // place the avatar is not.
   const placement: CSSProperties =
     growth === "left"
       ? { right: "50%", marginRight: -(AVATAR_BOX / 2) }
@@ -478,7 +483,7 @@ export function CompanionSurface({
     // press, so everything that is not a button can be grabbed, which at rest
     // means the avatar and when expanded means the pill around the controls.
     <div
-      className={`absolute cursor-grab transition-[width] duration-300 will-change-[width] active:cursor-grabbing ${
+      className={`absolute cursor-grab transition-[width] duration-300 select-none will-change-[width] active:cursor-grabbing ${
         typing
           ? // The composer row is the column's last child, so a card growing
             // downward reverses the column for the same reason a pill growing
@@ -488,9 +493,12 @@ export function CompanionSurface({
             `flex rounded-[22px] ${cardGrowth === "up" ? "flex-col" : "flex-col-reverse"}`
           : "flex h-11 items-center rounded-full"
       } ${
-        // The avatar is the row's first child, so growing leftward means
-        // reversing the row rather than repositioning it. The card is a column,
-        // so it never wants this.
+        // Alignment, not ordering. The row is `INNER_GAP` narrower than the
+        // pill, because that gap is trailing space past the last control, so
+        // the row has to sit against the end the avatar is anchored to and
+        // leave the slack at the other. Reversing a one-item row is how a
+        // `flex-start` box puts its item at the far end. The card is a column
+        // whose row is stretched to its full width, so it needs no help.
         growth === "left" && !typing ? "flex-row-reverse" : ""
       }`}
       style={style}
@@ -530,7 +538,20 @@ export function CompanionSurface({
         />
       )}
       {typing && turns.length > 0 && <RecentTurns turns={turns} />}
-      <div className="relative flex h-11 shrink-0 items-center">
+      {/* The avatar's own row, and the half of the mirroring that orders it.
+          The reversal belongs here rather than on the surface, which is where
+          it used to live: this row wraps the avatar and the body, so the
+          surface has a single in-flow child and reversing *that* orders
+          nothing. Left alone, growing leftward anchors the surface by its right
+          edge and then draws the avatar at the far end of it, putting the
+          mascot up to a card's width from the point the host positioned the
+          window by. Applied whether or not the composer is open, because the
+          card is anchored the same way and has further to be wrong. */}
+      <div
+        className={`relative flex h-11 shrink-0 items-center ${
+          growth === "left" ? "flex-row-reverse" : ""
+        }`}
+      >
         <Avatar
           glow={glow && !expanded}
           accentHex={accentHex}
@@ -608,7 +629,11 @@ function RecentTurns({ turns }: { turns: CompanionTurn[] }) {
   return (
     <div
       ref={scrollRef}
-      className="relative flex flex-col gap-1.5 overflow-y-auto px-3 pt-3 pb-1"
+      // Selectable, against the surface's `select-none`. That rule is there so
+      // a drag across the controls does not highlight their labels, and this is
+      // the one part of the surface that is prose rather than chrome: an answer
+      // the user may well want to copy out of.
+      className="relative flex flex-col gap-1.5 overflow-y-auto px-3 pt-3 pb-1 select-text"
       style={{ maxHeight: TURNS_MAX_HEIGHT }}
     >
       {/* Sides, as the transcript does it: the user's turn is a bubble pushed
@@ -712,7 +737,7 @@ function Composer({
         onMouseDown={(event) => {
           event.stopPropagation();
         }}
-        className="min-w-0 flex-1 bg-transparent text-[12px] text-white/85 placeholder:text-white/40 focus:outline-none"
+        className="min-w-0 flex-1 bg-transparent text-[12px] text-white/85 select-text placeholder:text-white/40 focus:outline-none"
       />
       {/* **The way out, and the way on, in one control.** With nothing typed
           there is nothing to send, so the trailing control is the way back to


### PR DESCRIPTION
Fixes JARVIS-1582.

Dragging the companion toward the right edge of the display made the surface teleport, highlight "Talk" and "Type", and stop responding to drags altogether.

## What was wrong

Growing leftward is two halves. The surface anchors by its **right** edge (`placement`), and the row the avatar sits in mirrors so the avatar ends up **against** that edge, on the point main positioned the window by.

Only the first half was still happening. `flex-row-reverse` was on the surface, and #40353 (the typing card) wrapped the avatar and the body in a row of their own, so the surface has a single in-flow child and reversing it orders nothing. The avatar was drawn at the far end of the pill instead.

Measured live over CDP against the dev app (724pt canvas, centre 362):

| growth | surface | avatar centre |
| --- | --- | --- |
| `right` | `[340, 384]` | **362** = canvas centre ✅ |
| `left` | `[204, 384]` | **234**, 128pt off ❌ |

In the card it is worse: `CARD_WIDTH - AVATAR_BOX` = 316pt.

Everything reported follows from that gap:

- The mascot teleports at the direction flip, and the labels sweep under a held pointer.
- Main's `avatarCentre()` is wrong from then on, so the clamp pinned the window at `winX=1344` while the drawn avatar was still ~150pt from the screen edge.
- The point main hands presses to now lands on the **Type** control, whose `onMouseDown` stops propagation. Instrumenting the bridge showed **zero** `moveBy` calls during those drags. That is the dead surface.

## The fix

The reversal moves onto the row that actually holds the avatar, and applies whether or not the composer is open, since the card is anchored the same way. The surface keeps its own reversal for what it was really doing: aligning that row against the anchored edge, since the row is `INNER_GAP` narrower than the pill.

The surface is also a drag handle with words on it, so it takes `select-none`. The reply and the composer's field opt back in, being prose to copy and a field that needs a caret.

## Tests

Five new tests in `companion-surface.test.tsx` fail on `main` and pass here; the two alignment tests pin the existing behaviour the fix leans on. No unit test covered the leftward layout before, only the `growth: "left"` Storybook story, which had been rendering it wrong since #40353.

## Deliberately not in scope

`growthFor` measures clearance against `maxPillWidth` (360), so the flip fires 316pt from the edge while the hover pill only needs ~180. It triggers mid-screen during ordinary drags. That is a main-side tuning question rather than this bug, and worth its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)