### PR TITLE
feat(gateway): guardian-pinned watch stream proxy on a shared audio-stream base

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -23,6 +23,7 @@ This file is the cross-system architecture index. Detailed designs live in domai
 | Docker volume architecture                  | [Docker Volume Architecture](#docker-volume-architecture) (this file)                              |
 | Web search failure normalization            | [Web Search Failure Normalization](#web-search-failure-normalization) (this file)                  |
 | Workflow orchestration engine               | [Workflow Orchestration Engine](#workflow-orchestration-engine) (this file)                        |
+| Watch sessions                              | [Watch Sessions](#watch-sessions) (this file)                                                      |
 | Workflow authoring guide                    | [`assistant/docs/workflows.md`](assistant/docs/workflows.md)                                       |
 | Workflow manual testing runbook             | [`assistant/docs/workflows-testing.md`](assistant/docs/workflows-testing.md)                       |
 | Service communication matrix                | [`docs/service-communication-matrix.md`](docs/service-communication-matrix.md)                     |
@@ -704,6 +705,47 @@ graph TB
 - **Routes** (read/abort/resume surfaces): `GET /v1/workflows`, `GET /v1/workflows/runs`, `GET /v1/workflows/runs/:id`, `POST /v1/workflows/runs/:id/abort`, `POST /v1/workflows/runs/:id/resume` (the resume route refuses a side-effecting run in normal posture and proceeds at full access).
 - **CLI**: `vellum workflows list | runs | show <id> | abort <id> | resume <id>`.
 - **Config** (`workflows.*`): `maxAgentsPerRun` (500), `maxConcurrentLeaves` (6), `maxConcurrentRuns` (3), `journalRetentionDays` (30).
+
+## Watch Sessions
+
+A watch session records what the user narrates while they work and reads their screen around it. The microphone and the socket live in the browser (`clients/web/src/domains/chat/watch/watch-controller.ts`); the cadence, the observations, and the timeline live in the daemon (`assistant/src/watch/watch-session-manager.ts`). The client draws nothing during a session: frames going the other way are lifecycle only, and the retrospective is a conversational turn after the socket is gone.
+
+One session at a time, on both sides. The client holds a single module-level slot and the daemon a single manager slot, because both are driven by the one microphone the machine has. The client refuses a start while a live-voice call is running, refuses one against an assistant that predates the route (`clients/web/src/lib/backwards-compat/watch-sessions.ts`), binds the session to the assistant it was started for, and ends it when that assistant stops being the active one, when the layout unmounts, or on sign-out.
+
+**Transport.** The browser opens `wss://<ingress>/v1/watch/stream?token=<edge JWT>&mimeType=audio/pcm&sampleRate=16000` and streams 16 kHz mono PCM16LE as binary frames, the same capture pipeline live voice and streaming dictation use. The token rides the query string because browser WebSockets cannot set an `Authorization` header. Self-hosted ingress only: the paired-gateway proxy is HTTP-only, so no upgrade exists there.
+
+**A socket is not a session.** The gateway accepts the downstream upgrade before it dials the runtime, so a local `open` proves only that a proxy answered. The runtime's `ready` frame (carrying `sessionId` and `conversationId`) is the first word that a session exists, and it is what starts both the microphone and the `watching` flag the companion draws its capture indicator from. Until then the session is pending and the surface shows nothing. A bounded wait covers a gateway that accepts and then never hears from the runtime; a close, an `error`, or that timeout before `ready` is a failed start rather than a stopped session, so it tears down and the flag never moves.
+
+**Auth posture.** The gateway (`gateway/src/http/routes/watch-stream-websocket.ts`) validates the edge JWT, rejects a revoked actor token, and requires an actor principal, refusing service tokens on this client-facing path. It then **pins the upgrade to the bound guardian**, as live voice does and for a sharper reason: the daemon resolves whose screen to observe from the guardian binding rather than from the request, and the proxy replaces the caller's identity with a service token upstream, so a non-guardian actor admitted here would open a session bound to the guardian and observing the guardian's screen with the daemon unable to tell. Both arrival paths are pinned (`gateway/src/http/routes/guardian-pin.ts`, shared with live voice): a velay-attested managed caller is cross-checked against the stored `platform_user_id`, and an actor edge JWT against the guardian binding. It then dials a *fresh* upstream socket to the daemon bearing only a short-lived gateway service token, never anything the client supplied, and pumps frames between the two. The daemon resolves the acting principal from its own guardian binding, restricts the upgrade to private-network peers and origins, and picks the host client to observe from that actor's own `host_cu` clients. The token gate and the frame pump are shared with `/v1/stt/stream` (`gateway/src/http/routes/runtime-audio-stream.ts`) so the two client-facing audio proxies cannot drift apart on who may open one. The guardian pin is deliberately not part of that shared gate: dictation is the user's own words going to a transcriber and back, is not a guardian-only surface, and keeps accepting any valid actor.
+
+```mermaid
+graph LR
+    SURFACE["Companion surface<br/>(Watch press)"]
+    MAIN["Electron main<br/>vellum:companion:toggleWatch"]
+    CTRL["watch-controller.ts<br/>one slot · version gate<br/>assistant binding"]
+    MIC["LiveVoiceAudioCapture<br/>16 kHz mono PCM16LE"]
+    GW["Gateway /v1/watch/stream<br/>edge JWT + actor principal<br/>pinned to the bound guardian"]
+    RT["Daemon /v1/watch/stream<br/>private peer + service token"]
+    MGR["WatchSessionManager<br/>narration cadence"]
+    OBS["observeHostScreen<br/>host_cu · same actor"]
+    TL["watch timeline<br/>(no-turn messages)"]
+    MIRROR["use-companion-mirror<br/>publishes watching"]
+
+    SURFACE --> MAIN
+    MAIN -->|"toggleWatch command"| CTRL
+    CTRL --> MIC
+    MIC -->|"binary audio frames"| GW
+    CTRL -->|"WS upgrade"| GW
+    GW -->|"fresh upstream WS<br/>service token only"| RT
+    RT --> MGR
+    MGR -->|"speech finals"| TL
+    MGR --> OBS
+    OBS -->|"AX tree + screenshot"| TL
+    RT -->|"ready (starts mic + flag)<br/>entry / error / closed"| CTRL
+    CTRL --> MIRROR
+    MIRROR -->|"watching flag"| MAIN
+    MAIN --> SURFACE
+```
 
 ## Maintenance Rule
 

--- a/gateway/src/__tests__/stt-stream-websocket.test.ts
+++ b/gateway/src/__tests__/stt-stream-websocket.test.ts
@@ -2,11 +2,23 @@ import { describe, test, expect, mock } from "bun:test";
 import type { GatewayConfig } from "../config.js";
 import { initSigningKey, mintToken } from "../auth/token-service.js";
 import { CURRENT_POLICY_EPOCH } from "../auth/policy.js";
-import {
-  createSttStreamWebsocketHandler,
-  getSttStreamWebsocketHandlers,
-  type SttStreamSocketData,
-} from "../http/routes/stt-stream-websocket.js";
+
+// Dictation is NOT a guardian-only surface. The binding lookup is mocked to a
+// principal that no token below matches, so any consultation of it would
+// refuse every case in this file. Mocked before the module under test is
+// imported, the way the guardian-only handlers' tests do it.
+const mockFindVellumGuardian = mock(
+  async (): Promise<{ principalId: string } | null> => ({
+    principalId: "somebody-who-is-not-the-caller",
+  }),
+);
+mock.module("../auth/guardian-bootstrap.js", () => ({
+  findVellumGuardian: () => mockFindVellumGuardian(),
+}));
+
+const { createSttStreamWebsocketHandler, getSttStreamWebsocketHandlers } =
+  await import("../http/routes/stt-stream-websocket.js");
+import type { SttStreamSocketData } from "../http/routes/stt-stream-websocket.js";
 
 const TEST_SIGNING_KEY = Buffer.from("test-signing-key-at-least-32-bytes-long");
 initSigningKey(TEST_SIGNING_KEY);
@@ -385,5 +397,59 @@ describe("getSttStreamWebsocketHandlers", () => {
     handlers.close(ws as never, 1000, "normal");
 
     expect(fakeUpstream.close).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * The regression guard for the watch stream's guardian pin.
+ *
+ * `/v1/watch/stream` opts into `guardian-pin` because it reads the owner's
+ * screen. Dictation is the user's own words going to a transcriber and back,
+ * so it takes any valid actor, and the shared authorization the two routes
+ * share must not quietly acquire the pin on this one's behalf.
+ *
+ * The mock at the top of this file binds the guardian to a principal none of
+ * these tokens carry, so a pin appearing here would turn every upgrade into a
+ * 403 and this describe into a wall of failures.
+ */
+describe("dictation is not a guardian-only surface", () => {
+  test("admits an actor who is not the bound guardian", async () => {
+    const handler = createSttStreamWebsocketHandler(makeConfig());
+    const req = new Request(
+      `http://localhost:7830/v1/stt/stream?token=${mintEdgeToken("some-other-actor")}&mimeType=audio/webm`,
+      { headers: { upgrade: "websocket" } },
+    );
+    const server = makeFakeServer();
+
+    expect(handler(req, server)).toBeUndefined();
+    expect(server.upgrade).toHaveBeenCalledTimes(1);
+  });
+
+  test("never consults the guardian binding at all", async () => {
+    const handler = createSttStreamWebsocketHandler(makeConfig());
+    const req = new Request(
+      `http://localhost:7830/v1/stt/stream?token=${mintEdgeToken("some-other-actor")}&mimeType=audio/webm`,
+      { headers: { upgrade: "websocket" } },
+    );
+
+    handler(req, makeFakeServer());
+
+    expect(mockFindVellumGuardian).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The upgrade handler stays synchronous. Awaiting a binding lookup is what
+   * would make it async, so the signature is itself evidence of the posture.
+   */
+  test("stays a synchronous upgrade handler", () => {
+    const handler = createSttStreamWebsocketHandler(makeConfig());
+    const req = new Request(
+      `http://localhost:7830/v1/stt/stream?token=${mintEdgeToken()}&mimeType=audio/webm`,
+      { headers: { upgrade: "websocket" } },
+    );
+
+    const result = handler(req, makeFakeServer());
+
+    expect(result).not.toBeInstanceOf(Promise);
   });
 });

--- a/gateway/src/__tests__/watch-stream-websocket.test.ts
+++ b/gateway/src/__tests__/watch-stream-websocket.test.ts
@@ -1,0 +1,603 @@
+import { afterEach, beforeEach, describe, test, expect, mock } from "bun:test";
+import type { GatewayConfig } from "../config.js";
+import { initSigningKey, mintToken } from "../auth/token-service.js";
+import { CURRENT_POLICY_EPOCH } from "../auth/policy.js";
+import { setVelayBridgeAuthHeader } from "../velay/bridge-auth.js";
+import type { WatchStreamSocketData } from "../http/routes/watch-stream-websocket.js";
+
+/** The bound guardian's actor principal, which `mintEdgeToken` defaults to. */
+const GUARDIAN_PRINCIPAL = "test-user";
+
+/** The bound guardian's platform user id, for the velay-attested path. */
+const VELAY_USER_ID = "11111111-1111-1111-1111-111111111111";
+
+// Watch is a guardian-only surface, so the upgrade pins the caller to the
+// binding. Both lookups are mocked BEFORE the module under test is imported,
+// the way `live-voice-websocket.test.ts` does it, so the pin is testable
+// without gateway DB state.
+let mockFindVellumGuardian = mock(
+  async (): Promise<{ principalId: string } | null> => ({
+    principalId: GUARDIAN_PRINCIPAL,
+  }),
+);
+mock.module("../auth/guardian-bootstrap.js", () => ({
+  findVellumGuardian: () => mockFindVellumGuardian(),
+}));
+
+let mockReadCredential = mock(
+  async (_key: string): Promise<string | undefined> => VELAY_USER_ID,
+);
+mock.module("../credential-reader.js", () => ({
+  readCredential: (key: string) => mockReadCredential(key),
+}));
+
+const { createWatchStreamWebsocketHandler, getWatchStreamWebsocketHandlers } =
+  await import("../http/routes/watch-stream-websocket.js");
+
+const TEST_SIGNING_KEY = Buffer.from("test-signing-key-at-least-32-bytes-long");
+initSigningKey(TEST_SIGNING_KEY);
+
+/** Mint a valid actor edge JWT for watch stream auth. */
+function mintEdgeToken(actorPrincipalId: string = "test-user"): string {
+  return mintToken({
+    aud: "vellum-gateway",
+    sub: `actor:test-assistant:${actorPrincipalId}`,
+    scope_profile: "actor_client_v1",
+    policy_epoch: CURRENT_POLICY_EPOCH,
+    ttlSeconds: 300,
+  });
+}
+
+/** Mint a service-style token (no actor principal). */
+function mintServiceEdgeToken(): string {
+  return mintToken({
+    aud: "vellum-gateway",
+    sub: "svc:gateway:self",
+    scope_profile: "gateway_service_v1",
+    policy_epoch: CURRENT_POLICY_EPOCH,
+    ttlSeconds: 300,
+  });
+}
+
+function makeConfig(overrides: Partial<GatewayConfig> = {}): GatewayConfig {
+  return {
+    assistantRuntimeBaseUrl: "http://localhost:7821",
+    routingEntries: [],
+    port: 7830,
+    runtimeProxyRequireAuth: true,
+    shutdownDrainMs: 5000,
+    runtimeTimeoutMs: 30000,
+    runtimeMaxRetries: 2,
+    runtimeInitialBackoffMs: 500,
+    maxWebhookPayloadBytes: 1048576,
+    logFile: { dir: undefined, retentionDays: 30 },
+    maxAttachmentBytes: {
+      telegram: 50 * 1024 * 1024,
+      slack: 100 * 1024 * 1024,
+      whatsapp: 16 * 1024 * 1024,
+      default: 50 * 1024 * 1024,
+    },
+    maxAttachmentConcurrency: 3,
+    gatewayInternalBaseUrl: "http://127.0.0.1:7830",
+    trustProxy: false,
+    ...overrides,
+  } as GatewayConfig;
+}
+
+function makeFakeServer(upgradeResult: boolean = true) {
+  return {
+    requestIP: mock(() => ({
+      address: "127.0.0.1",
+      family: "IPv4",
+      port: 54000,
+    })),
+    upgrade: mock(() => upgradeResult),
+  } as unknown as import("bun").Server<unknown>;
+}
+
+/** The socket data the handler asked Bun to attach to the upgraded socket. */
+function upgradedData(
+  server: import("bun").Server<unknown>,
+): WatchStreamSocketData {
+  const call = (server.upgrade as ReturnType<typeof mock>).mock
+    .calls[0] as unknown[];
+  return (call[1] as { data: WatchStreamSocketData }).data;
+}
+
+// ---------------------------------------------------------------------------
+// createWatchStreamWebsocketHandler: upgrade handler tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  mockFindVellumGuardian = mock(async () => ({
+    principalId: GUARDIAN_PRINCIPAL,
+  }));
+  mockReadCredential = mock(async (_key: string) => VELAY_USER_ID);
+});
+
+afterEach(() => {
+  delete process.env.IS_PLATFORM;
+});
+
+describe("createWatchStreamWebsocketHandler", () => {
+  const TEST_TOKEN = mintEdgeToken();
+
+  test("upgrades when the token query parameter is valid", async () => {
+    const handler = createWatchStreamWebsocketHandler(makeConfig());
+    const req = new Request(
+      `http://localhost:7830/v1/watch/stream?token=${TEST_TOKEN}&mimeType=audio/pcm&sampleRate=16000`,
+      { headers: { upgrade: "websocket" } },
+    );
+    const server = makeFakeServer();
+    const res = await handler(req, server);
+
+    expect(res).toBeUndefined();
+    expect(server.upgrade).toHaveBeenCalledTimes(1);
+    expect(upgradedData(server)).toMatchObject({
+      wsType: "watch-stream",
+      mimeType: "audio/pcm",
+      sampleRate: 16000,
+    });
+  });
+
+  test("upgrades when the Authorization header is valid", async () => {
+    const handler = createWatchStreamWebsocketHandler(makeConfig());
+    const req = new Request(
+      "http://localhost:7830/v1/watch/stream?mimeType=audio/pcm",
+      {
+        headers: {
+          upgrade: "websocket",
+          authorization: `Bearer ${TEST_TOKEN}`,
+        },
+      },
+    );
+    const server = makeFakeServer();
+
+    expect(await handler(req, server)).toBeUndefined();
+    expect(server.upgrade).toHaveBeenCalledTimes(1);
+  });
+
+  test("carries an explicit conversation and host client through", async () => {
+    const handler = createWatchStreamWebsocketHandler(makeConfig());
+    const req = new Request(
+      `http://localhost:7830/v1/watch/stream?token=${TEST_TOKEN}&mimeType=audio/pcm&conversationId=conv-1&clientId=host-1`,
+      { headers: { upgrade: "websocket" } },
+    );
+    const server = makeFakeServer();
+    await handler(req, server);
+
+    expect(upgradedData(server)).toMatchObject({
+      conversationId: "conv-1",
+      clientId: "host-1",
+    });
+  });
+
+  /**
+   * A session with no conversation named is the companion surface's Watch,
+   * which starts a session rather than joining a thread. Blank has to read the
+   * same as absent, or the runtime would be handed an empty id to file against.
+   */
+  test("reads blank optional parameters as absent", async () => {
+    const handler = createWatchStreamWebsocketHandler(makeConfig());
+    const req = new Request(
+      `http://localhost:7830/v1/watch/stream?token=${TEST_TOKEN}&mimeType=audio/pcm&conversationId=%20&clientId=`,
+      { headers: { upgrade: "websocket" } },
+    );
+    const server = makeFakeServer();
+    await handler(req, server);
+
+    const data = upgradedData(server);
+    expect(data.conversationId).toBeUndefined();
+    expect(data.clientId).toBeUndefined();
+  });
+
+  test("returns 401 when no token is provided", async () => {
+    const handler = createWatchStreamWebsocketHandler(makeConfig());
+    const req = new Request(
+      "http://localhost:7830/v1/watch/stream?mimeType=audio/pcm",
+      { headers: { upgrade: "websocket" } },
+    );
+    const server = makeFakeServer();
+    const res = await handler(req, server);
+
+    expect(res!.status).toBe(401);
+    expect(server.upgrade).not.toHaveBeenCalled();
+  });
+
+  test("returns 401 when the token is invalid", async () => {
+    const handler = createWatchStreamWebsocketHandler(makeConfig());
+    const req = new Request(
+      "http://localhost:7830/v1/watch/stream?token=bad-token&mimeType=audio/pcm",
+      { headers: { upgrade: "websocket" } },
+    );
+    const server = makeFakeServer();
+    const res = await handler(req, server);
+
+    expect(res!.status).toBe(401);
+    expect(server.upgrade).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The client-facing half of the proxy takes actors and nothing else. A
+   * service credential reaching it would open a user's microphone stream on a
+   * token minted for machine to machine traffic.
+   */
+  test("returns 401 for a service token, which has no actor principal", async () => {
+    const handler = createWatchStreamWebsocketHandler(makeConfig());
+    const req = new Request(
+      `http://localhost:7830/v1/watch/stream?token=${mintServiceEdgeToken()}&mimeType=audio/pcm`,
+      { headers: { upgrade: "websocket" } },
+    );
+    const server = makeFakeServer();
+    const res = await handler(req, server);
+
+    expect(res!.status).toBe(401);
+    expect(server.upgrade).not.toHaveBeenCalled();
+  });
+
+  test("returns 400 when mimeType is missing", async () => {
+    const handler = createWatchStreamWebsocketHandler(makeConfig());
+    const req = new Request(
+      `http://localhost:7830/v1/watch/stream?token=${TEST_TOKEN}`,
+      { headers: { upgrade: "websocket" } },
+    );
+    const server = makeFakeServer();
+    const res = await handler(req, server);
+
+    expect(res!.status).toBe(400);
+    expect(server.upgrade).not.toHaveBeenCalled();
+  });
+
+  test("returns 426 when the request is not a WebSocket upgrade", async () => {
+    const handler = createWatchStreamWebsocketHandler(makeConfig());
+    const req = new Request(
+      `http://localhost:7830/v1/watch/stream?token=${TEST_TOKEN}&mimeType=audio/pcm`,
+    );
+    const server = makeFakeServer();
+    const res = await handler(req, server);
+
+    expect(res!.status).toBe(426);
+  });
+
+  test("returns 500 when the Bun upgrade fails", async () => {
+    const handler = createWatchStreamWebsocketHandler(makeConfig());
+    const req = new Request(
+      `http://localhost:7830/v1/watch/stream?token=${TEST_TOKEN}&mimeType=audio/pcm`,
+      { headers: { upgrade: "websocket" } },
+    );
+    const server = makeFakeServer(false);
+    const res = await handler(req, server);
+
+    expect(res!.status).toBe(500);
+  });
+
+  test("allows an unauthenticated upgrade when auth is disabled (dev bypass)", async () => {
+    const handler = createWatchStreamWebsocketHandler(
+      makeConfig({ runtimeProxyRequireAuth: false }),
+    );
+    const req = new Request(
+      "http://localhost:7830/v1/watch/stream?mimeType=audio/pcm",
+      { headers: { upgrade: "websocket" } },
+    );
+    const server = makeFakeServer();
+
+    expect(await handler(req, server)).toBeUndefined();
+    expect(server.upgrade).toHaveBeenCalledTimes(1);
+  });
+
+  test("still requires mimeType when auth is disabled", async () => {
+    const handler = createWatchStreamWebsocketHandler(
+      makeConfig({ runtimeProxyRequireAuth: false }),
+    );
+    const req = new Request("http://localhost:7830/v1/watch/stream", {
+      headers: { upgrade: "websocket" },
+    });
+    const server = makeFakeServer();
+    const res = await handler(req, server);
+
+    expect(res!.status).toBe(400);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The guardian pin
+// ---------------------------------------------------------------------------
+
+/**
+ * Watch reads the owner's screen, and the daemon resolves whose screen from
+ * the guardian binding rather than from the request. A non-guardian actor who
+ * gets past this upgrade therefore does not observe their own screen: they
+ * observe the guardian's. The proxy also replaces the caller's identity with a
+ * service token upstream, so the daemon cannot tell the difference. This
+ * upgrade is the only place that actor can be refused.
+ */
+describe("createWatchStreamWebsocketHandler: the guardian pin", () => {
+  const upgrade = async (token: string) => {
+    const handler = createWatchStreamWebsocketHandler(makeConfig());
+    const req = new Request(
+      `http://localhost:7830/v1/watch/stream?token=${token}&mimeType=audio/pcm`,
+      { headers: { upgrade: "websocket" } },
+    );
+    const server = makeFakeServer();
+    return { res: await handler(req, server), server };
+  };
+
+  test("admits the bound guardian", async () => {
+    const { res, server } = await upgrade(mintEdgeToken(GUARDIAN_PRINCIPAL));
+
+    expect(res).toBeUndefined();
+    expect(server.upgrade).toHaveBeenCalledTimes(1);
+  });
+
+  /** The finding: a valid token that belongs to somebody else. */
+  test("refuses a valid actor token that is not the bound guardian", async () => {
+    const { res, server } = await upgrade(mintEdgeToken("someone-else"));
+
+    expect(res!.status).toBe(403);
+    expect(server.upgrade).not.toHaveBeenCalled();
+  });
+
+  test("refuses when no guardian binding exists", async () => {
+    mockFindVellumGuardian = mock(async () => null);
+
+    const { res, server } = await upgrade(mintEdgeToken(GUARDIAN_PRINCIPAL));
+
+    expect(res!.status).toBe(403);
+    expect(server.upgrade).not.toHaveBeenCalled();
+  });
+
+  /**
+   * A lookup that throws leaves the answer unknown. Reporting that as
+   * "forbidden" would misread a database problem as a permission one.
+   */
+  test("answers 503 when the binding lookup fails", async () => {
+    mockFindVellumGuardian = mock(async () => {
+      throw new Error("db down");
+    });
+
+    const { res, server } = await upgrade(mintEdgeToken(GUARDIAN_PRINCIPAL));
+
+    expect(res!.status).toBe(503);
+    expect(server.upgrade).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * The managed path, where velay validated the browser's token and injected the
+ * caller. The attestation proves the caller is *a* platform user who traversed
+ * velay, not that they are this assistant's guardian, so it is cross-checked
+ * against the stored `platform_user_id`.
+ */
+describe("createWatchStreamWebsocketHandler: velay-attested managed auth", () => {
+  const VELAY_ORG_ID = "22222222-2222-2222-2222-222222222222";
+
+  const managedUpgrade = async ({
+    userId = VELAY_USER_ID,
+    actor = "user",
+    orgId = VELAY_ORG_ID as string | null,
+    bridgeProof = true,
+    token,
+    managed = true,
+  }: {
+    userId?: string;
+    actor?: string;
+    orgId?: string | null;
+    bridgeProof?: boolean;
+    token?: string;
+    managed?: boolean;
+  }) => {
+    if (managed) {
+      process.env.IS_PLATFORM = "true";
+    } else {
+      delete process.env.IS_PLATFORM;
+    }
+    const headers = new Headers({
+      upgrade: "websocket",
+      "x-velay-user-id": userId,
+      "x-velay-actor": actor,
+    });
+    if (orgId !== null) {
+      headers.set("x-velay-org-id", orgId);
+    }
+    if (bridgeProof) {
+      setVelayBridgeAuthHeader(headers);
+    }
+    const handler = createWatchStreamWebsocketHandler(makeConfig());
+    const query = token ? `&token=${token}` : "";
+    const req = new Request(
+      `http://localhost:7830/v1/watch/stream?mimeType=audio/pcm${query}`,
+      { headers },
+    );
+    const server = makeFakeServer();
+    return { res: await handler(req, server), server };
+  };
+
+  test("admits an attested caller who is the bound guardian", async () => {
+    const { res, server } = await managedUpgrade({});
+
+    expect(res).toBeUndefined();
+    expect(server.upgrade).toHaveBeenCalledTimes(1);
+  });
+
+  test("refuses an attested caller who is not the bound guardian", async () => {
+    mockReadCredential = mock(
+      async () => "99999999-9999-9999-9999-999999999999",
+    );
+
+    const { res, server } = await managedUpgrade({});
+
+    expect(res!.status).toBe(403);
+    expect(server.upgrade).not.toHaveBeenCalled();
+  });
+
+  test("refuses when this assistant has no platform user stored", async () => {
+    mockReadCredential = mock(async () => undefined);
+
+    const { res } = await managedUpgrade({});
+
+    expect(res!.status).toBe(403);
+  });
+
+  test("answers 503 when the platform user lookup fails", async () => {
+    mockReadCredential = mock(async () => {
+      throw new Error("credential store down");
+    });
+
+    const { res } = await managedUpgrade({});
+
+    expect(res!.status).toBe(503);
+  });
+
+  /**
+   * A direct request to a reachable gateway can spoof the header names. It
+   * cannot know the process-local bridge proof, which is what says the request
+   * really arrived through this gateway's own loopback bridge.
+   */
+  test("ignores spoofed velay headers with no bridge proof", async () => {
+    const { res, server } = await managedUpgrade({ bridgeProof: false });
+
+    expect(res!.status).toBe(401);
+    expect(server.upgrade).not.toHaveBeenCalled();
+  });
+
+  test("falls through to the token path on an incomplete attestation", async () => {
+    const { res, server } = await managedUpgrade({
+      orgId: null,
+      token: mintEdgeToken(GUARDIAN_PRINCIPAL),
+    });
+
+    expect(res).toBeUndefined();
+    expect(server.upgrade).toHaveBeenCalledTimes(1);
+  });
+
+  /** Falling through must not fall past the pin. */
+  test("still pins the token path in managed mode", async () => {
+    const { res } = await managedUpgrade({
+      actor: "service",
+      token: mintEdgeToken("someone-else"),
+    });
+
+    expect(res!.status).toBe(403);
+  });
+
+  test("does not trust velay headers outside managed mode", async () => {
+    const { res, server } = await managedUpgrade({ managed: false });
+
+    expect(res!.status).toBe(401);
+    expect(server.upgrade).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getWatchStreamWebsocketHandlers: WS lifecycle tests
+// ---------------------------------------------------------------------------
+
+describe("getWatchStreamWebsocketHandlers", () => {
+  function createFakeDownstreamWs(data: Partial<WatchStreamSocketData> = {}) {
+    const sent: (string | Uint8Array)[] = [];
+    const closes: { code: number; reason: string }[] = [];
+    const fullData: WatchStreamSocketData = {
+      wsType: "watch-stream",
+      config: makeConfig(),
+      mimeType: "audio/pcm",
+      sampleRate: 16000,
+      ...data,
+    };
+    return {
+      data: fullData,
+      sent,
+      closes,
+      send: mock((msg: string | Uint8Array) => {
+        sent.push(msg);
+      }),
+      close: mock((code?: number, reason?: string) => {
+        closes.push({ code: code ?? 1000, reason: reason ?? "" });
+      }),
+    };
+  }
+
+  test("open initializes the pending message buffer", async () => {
+    const handlers = getWatchStreamWebsocketHandlers();
+    const ws = createFakeDownstreamWs();
+
+    // Dialing upstream fails in a test process; the buffer is set up first.
+    try {
+      handlers.open(ws as never);
+    } catch {
+      // The WebSocket constructor may throw here.
+    }
+
+    expect(ws.data.pendingMessages).toBeDefined();
+  });
+
+  /**
+   * The client starts sending the moment its own socket opens, which is before
+   * this proxy has an upstream to send to. The first fraction of a second of
+   * narration is exactly the part a transcriber needs.
+   */
+  test("message buffers frames that arrive before upstream connects", async () => {
+    const handlers = getWatchStreamWebsocketHandlers();
+    const ws = createFakeDownstreamWs();
+    ws.data.pendingMessages = [];
+
+    handlers.message(ws as never, "narration-frame");
+
+    expect(ws.data.pendingMessages).toContain("narration-frame");
+  });
+
+  test("message closes the socket rather than buffering without bound", async () => {
+    const handlers = getWatchStreamWebsocketHandlers();
+    const ws = createFakeDownstreamWs();
+    ws.data.pendingMessages = new Array(100).fill("x");
+
+    handlers.message(ws as never, "overflow-frame");
+
+    expect(ws.close).toHaveBeenCalledWith(1008, "Buffer overflow");
+  });
+
+  test("message forwards straight through once upstream is open", async () => {
+    const handlers = getWatchStreamWebsocketHandlers();
+    const ws = createFakeDownstreamWs();
+    ws.data.pendingMessages = [];
+    const upstream = {
+      readyState: WebSocket.OPEN,
+      send: mock(() => {}),
+    };
+    ws.data.upstream = upstream as unknown as WebSocket;
+
+    handlers.message(ws as never, "narration-frame");
+
+    expect(upstream.send).toHaveBeenCalledWith("narration-frame");
+    expect(ws.data.pendingMessages).toEqual([]);
+  });
+
+  test("close releases the buffer and closes upstream with the same code", async () => {
+    const handlers = getWatchStreamWebsocketHandlers();
+    const ws = createFakeDownstreamWs();
+    ws.data.pendingMessages = ["some-data"];
+    const upstream = {
+      readyState: WebSocket.OPEN,
+      close: mock(() => {}),
+    };
+    ws.data.upstream = upstream as unknown as WebSocket;
+
+    handlers.close(ws as never, 1000, "normal");
+
+    expect(ws.data.pendingMessages).toBeUndefined();
+    expect(upstream.close).toHaveBeenCalledWith(1000, "normal");
+  });
+
+  test("close is safe when upstream is already gone", async () => {
+    const handlers = getWatchStreamWebsocketHandlers();
+    const ws = createFakeDownstreamWs();
+    const upstream = {
+      readyState: WebSocket.CLOSED,
+      close: mock(() => {}),
+    };
+    ws.data.upstream = upstream as unknown as WebSocket;
+
+    handlers.close(ws as never, 1000, "normal");
+
+    expect(upstream.close).not.toHaveBeenCalled();
+  });
+});

--- a/gateway/src/http/routes/guardian-pin.ts
+++ b/gateway/src/http/routes/guardian-pin.ts
@@ -1,0 +1,137 @@
+/**
+ * Pinning a WebSocket upgrade to this assistant's bound guardian.
+ *
+ * Some surfaces are the owner's own and nobody else's. Live voice runs in the
+ * owner's client and the daemon stamps each turn with the guardian's trust
+ * context; a watch session reads the owner's screen and the daemon resolves
+ * whose screen from the guardian binding rather than from the request. Both
+ * proxies replace the caller's identity with `mintServiceToken()` on the way
+ * upstream, so the daemon cannot tell one actor from another: whatever the
+ * gateway admits is what the daemon treats as the owner. The pin is therefore
+ * the only place a non-guardian actor can be stopped.
+ *
+ * A valid actor edge JWT is not enough on its own. It proves the caller is an
+ * actor on this assistant, not that they are the actor the surface belongs to.
+ *
+ * Two callers, two shapes, because there are two ways a caller arrives:
+ *
+ * - **Managed / cloud.** Velay validates the browser's token, strips any
+ *   client-supplied copies of the `X-Velay-*` headers, and injects the
+ *   authenticated caller. That attestation proves the caller is *a* platform
+ *   user who traversed velay, so it is cross-checked against the stored
+ *   `platform_user_id` by {@link requireManagedGuardian}.
+ * - **Self-hosted and everything else.** The caller presents an actor edge JWT
+ *   and its principal is compared against the binding by
+ *   {@link requireBoundGuardian}.
+ *
+ * Not every audio proxy wants this. `/v1/stt/stream` carries dictation, which
+ * is not a guardian-only surface and accepts any valid actor, which is why the
+ * pin is something a route opts into rather than something the shared
+ * authorization applies to everything.
+ */
+
+import type { Logger } from "pino";
+
+import { findVellumGuardian } from "../../auth/guardian-bootstrap.js";
+import { credentialKey } from "../../credential-key.js";
+import { readCredential } from "../../credential-reader.js";
+
+const VELAY_USER_ID_HEADER = "x-velay-user-id";
+const VELAY_ORG_ID_HEADER = "x-velay-org-id";
+const VELAY_ACTOR_HEADER = "x-velay-actor";
+
+/**
+ * True when the gateway runs in managed/cloud mode (vembda + velay ingress).
+ * Mirrors the `IS_PLATFORM` check used by the gateway's HTTP edge auth
+ * (`src/http/middleware/auth.ts`) and feature-flag resolver.
+ */
+export function isPlatformManaged(): boolean {
+  const v = process.env.IS_PLATFORM?.trim().toLowerCase();
+  return v === "1" || v === "true";
+}
+
+/** Velay-attested managed caller context, extracted from injected headers. */
+export type VelayAttestedContext = {
+  userId: string;
+  orgId: string;
+};
+
+/**
+ * Extract a velay-attested managed caller context from the upgrade request.
+ *
+ * Returns null when the request does not carry a complete, well-formed velay
+ * attestation (`X-Velay-User-Id` + `X-Velay-Org-Id` both present, with
+ * `X-Velay-Actor: user`). Callers MUST only trust the result in managed mode,
+ * and only alongside the process-local bridge proof: a direct request to a
+ * reachable gateway can spoof the header names but not the proof value.
+ */
+export function extractVelayAttestedContext(
+  req: Request,
+): VelayAttestedContext | null {
+  const userId = req.headers.get(VELAY_USER_ID_HEADER)?.trim();
+  const orgId = req.headers.get(VELAY_ORG_ID_HEADER)?.trim();
+  const actor = req.headers.get(VELAY_ACTOR_HEADER)?.trim().toLowerCase();
+
+  if (!userId || !orgId || actor !== "user") {
+    return null;
+  }
+  return { userId, orgId };
+}
+
+/**
+ * Managed-mode guardian check: cross-check a velay-attested caller's platform
+ * user id against the stored `platform_user_id` credential, the same guard the
+ * edge-auth middleware applies to guardian routes under the platform bypass.
+ *
+ * Returns null when the caller is the guardian, else a 403/503 Response.
+ */
+export async function requireManagedGuardian(
+  velayUserId: string,
+  log: Logger,
+): Promise<Response | null> {
+  let storedUserId: string | undefined;
+  try {
+    storedUserId = await readCredential(
+      credentialKey("vellum", "platform_user_id"),
+    );
+  } catch (err) {
+    log.error({ err }, "guardian pin: platform_user_id lookup failed");
+    return new Response("Service Unavailable", { status: 503 });
+  }
+  if (!storedUserId) {
+    log.warn("guardian pin: no platform_user_id stored on this assistant");
+    return new Response("Forbidden", { status: 403 });
+  }
+  if (storedUserId !== velayUserId) {
+    log.warn("guardian pin: velay caller is not the bound guardian");
+    return new Response("Forbidden", { status: 403 });
+  }
+  return null;
+}
+
+/**
+ * Actor-JWT guardian check: compare an already-validated actor principal
+ * against this assistant's guardian binding.
+ *
+ * Returns null when the caller is the guardian, else a 403/503 Response. A
+ * lookup that throws is 503 rather than 403: the answer is unknown, and
+ * failing closed with "forbidden" would misreport a database problem as a
+ * permission one.
+ */
+export async function requireBoundGuardian(
+  actorPrincipalId: string,
+  log: Logger,
+): Promise<Response | null> {
+  let guardian: { principalId: string } | null;
+  try {
+    guardian = await findVellumGuardian();
+  } catch (err) {
+    log.error({ err }, "guardian pin: findVellumGuardian failed");
+    return new Response("Service Unavailable", { status: 503 });
+  }
+  if (!guardian || guardian.principalId !== actorPrincipalId) {
+    log.warn("guardian pin: caller is not the bound guardian");
+    return new Response("Forbidden", { status: 403 });
+  }
+  return null;
+}

--- a/gateway/src/http/routes/live-voice-websocket.ts
+++ b/gateway/src/http/routes/live-voice-websocket.ts
@@ -5,68 +5,25 @@ import {
   mintServiceToken,
 } from "../../auth/token-exchange.js";
 import { isActorTokenRevoked } from "../../auth/actor-token-revocation.js";
-import { findVellumGuardian } from "../../auth/guardian-bootstrap.js";
 import { parseSub } from "../../auth/subject.js";
 import type { GatewayConfig } from "../../config.js";
-import { credentialKey } from "../../credential-key.js";
-import { readCredential } from "../../credential-reader.js";
 import { getLogger } from "../../logger.js";
 import { requestHasVelayBridgeAuth } from "../../velay/bridge-auth.js";
+import {
+  extractVelayAttestedContext,
+  isPlatformManaged,
+  requireBoundGuardian,
+  requireManagedGuardian,
+} from "./guardian-pin.js";
 
 const log = getLogger("live-voice-ws");
 
 // Cap buffered messages to prevent unbounded memory growth if upstream stalls
 const MAX_PENDING_MESSAGES = 100;
 
-// ---------------------------------------------------------------------------
-// Velay-attested managed auth headers
-// ---------------------------------------------------------------------------
-//
-// In managed/cloud deployments, velay validates the browser's live-voice
-// wsToken, strips any client-supplied copies of these headers, and injects the
-// authenticated caller context into the tunnel frame. The gateway only trusts
-// that context when the loopback WebSocket open also carries the process-local
-// bridge proof injected by this gateway's VelayWebSocketBridge; IS_PLATFORM
-// alone is not a per-request proof that the caller traversed velay.
-const VELAY_USER_ID_HEADER = "x-velay-user-id";
-const VELAY_ORG_ID_HEADER = "x-velay-org-id";
-const VELAY_ACTOR_HEADER = "x-velay-actor";
-
-/**
- * True when the gateway runs in managed/cloud mode (vembda + velay ingress).
- * Mirrors the `IS_PLATFORM` check used by the gateway's HTTP edge auth
- * (`src/http/middleware/auth.ts`) and feature-flag resolver.
- */
-function isPlatformManaged(): boolean {
-  const v = process.env.IS_PLATFORM?.trim().toLowerCase();
-  return v === "1" || v === "true";
-}
-
-/** Velay-attested managed caller context, extracted from injected headers. */
-type VelayAttestedContext = {
-  userId: string;
-  orgId: string;
-};
-
-/**
- * Extract a velay-attested managed caller context from the upgrade request.
- *
- * Returns null when the request does not carry a complete, well-formed velay
- * attestation (`X-Velay-User-Id` + `X-Velay-Org-Id` both present, with
- * `X-Velay-Actor: user`). Callers MUST only trust the result in managed mode.
- */
-function extractVelayAttestedContext(
-  req: Request,
-): VelayAttestedContext | null {
-  const userId = req.headers.get(VELAY_USER_ID_HEADER)?.trim();
-  const orgId = req.headers.get(VELAY_ORG_ID_HEADER)?.trim();
-  const actor = req.headers.get(VELAY_ACTOR_HEADER)?.trim().toLowerCase();
-
-  if (!userId || !orgId || actor !== "user") {
-    return null;
-  }
-  return { userId, orgId };
-}
+// The velay attestation helpers and both guardian checks live in
+// `guardian-pin.js`, shared with the watch stream so the two guardian-only
+// surfaces cannot drift into two ideas of who owns them.
 
 export type LiveVoiceSocketData = {
   wsType: "live-voice";
@@ -133,7 +90,10 @@ async function checkLiveVoiceAuth(
         // edge-auth middleware applies to guardian routes under the managed
         // bypass). Without it, any velay-authorized org user reaching this
         // assistant would be stamped guardian downstream.
-        const guardianError = await requireManagedGuardian(velayContext.userId);
+        const guardianError = await requireManagedGuardian(
+          velayContext.userId,
+          log,
+        );
         if (guardianError) return guardianError;
         log.info(
           { userId: velayContext.userId, orgId: velayContext.orgId },
@@ -189,52 +149,11 @@ async function checkLiveVoiceAuth(
 
   // Live voice is a guardian-only surface: the room runs in the owner's own
   // client, and the daemon stamps each voice turn with the guardian's trust
-  // context on that basis — so pin the upgrade to the bound guardian, the same
+  // context on that basis, so pin the upgrade to the bound guardian, the same
   // check the guardian edge-auth middleware applies to guardian-only HTTP
   // routes. Any valid-but-non-guardian actor token is rejected here rather
-  // than reaching the daemon with an identity the voice path can't represent.
-  let guardian: { principalId: string } | null;
-  try {
-    guardian = await findVellumGuardian();
-  } catch (err) {
-    log.error({ err }, "Live voice WS: findVellumGuardian failed");
-    return new Response("Service Unavailable", { status: 503 });
-  }
-  if (!guardian || guardian.principalId !== parsed.actorPrincipalId) {
-    log.warn("Live voice WS: rejected — caller is not the bound guardian");
-    return new Response("Forbidden", { status: 403 });
-  }
-
-  return null;
-}
-
-/**
- * Managed-mode guardian check: cross-check a velay-attested caller's platform
- * user id against the stored `platform_user_id` credential — the same guard the
- * edge-auth middleware applies to guardian routes under the platform bypass.
- * Returns null when the caller is the guardian, else a 403/503 Response.
- */
-async function requireManagedGuardian(
-  velayUserId: string,
-): Promise<Response | null> {
-  let storedUserId: string | undefined;
-  try {
-    storedUserId = await readCredential(
-      credentialKey("vellum", "platform_user_id"),
-    );
-  } catch (err) {
-    log.error({ err }, "Live voice WS: platform_user_id lookup failed");
-    return new Response("Service Unavailable", { status: 503 });
-  }
-  if (!storedUserId) {
-    log.warn("Live voice WS: no platform_user_id stored on this assistant");
-    return new Response("Forbidden", { status: 403 });
-  }
-  if (storedUserId !== velayUserId) {
-    log.warn("Live voice WS: velay caller is not the bound guardian");
-    return new Response("Forbidden", { status: 403 });
-  }
-  return null;
+  // than reaching the daemon with an identity the voice path cannot represent.
+  return requireBoundGuardian(parsed.actorPrincipalId, log);
 }
 
 /**

--- a/gateway/src/http/routes/runtime-audio-stream.ts
+++ b/gateway/src/http/routes/runtime-audio-stream.ts
@@ -11,13 +11,20 @@
  * upstream path and which query parameters travel with it, which is why those
  * are the arguments here.
  *
- * **The auth posture is the point, and it is deliberately not configurable.**
- * The downstream half requires an actor edge JWT and refuses service tokens,
- * so a service credential cannot be replayed into a client-facing socket. The
- * upstream half carries only {@link mintServiceToken}, never anything the
+ * **What the shared gate settles, and what it deliberately leaves open.** It
+ * settles that the caller is *an* actor on this assistant: a valid edge JWT,
+ * not revoked, carrying an actor principal, so a service credential cannot be
+ * replayed into a client-facing socket. It does not settle whether that actor
+ * is the one a particular surface belongs to, which is a question only the
+ * route can answer. `/v1/watch/stream` answers it with `guardian-pin.ts`;
+ * `/v1/stt/stream` answers that any actor will do. Adding the pin here would
+ * take dictation with it.
+ *
+ * The upstream half carries only {@link mintServiceToken}, never anything the
  * client supplied: the runtime is unreachable from the public internet and
  * resolves the acting principal from its own guardian rather than from a
- * header this proxy could be talked into forwarding.
+ * header this proxy could be talked into forwarding. That is also why the pin
+ * matters, since it leaves the daemon unable to tell one caller from another.
  */
 
 import type { Logger } from "pino";

--- a/gateway/src/http/routes/runtime-audio-stream.ts
+++ b/gateway/src/http/routes/runtime-audio-stream.ts
@@ -1,0 +1,269 @@
+/**
+ * The two halves every runtime audio-stream WebSocket proxy is made of: the
+ * gate that decides whether a client may open one, and the pump that carries
+ * frames between that client and the runtime.
+ *
+ * The gateway has more than one of these. `/v1/stt/stream` carries dictation
+ * audio and `/v1/watch/stream` carries a watch session's narration, and as
+ * proxies they are the same object: authenticate the downstream actor, dial a
+ * fresh upstream socket with a short-lived service token, and pass frames
+ * through in both directions until either end goes away. What differs is the
+ * upstream path and which query parameters travel with it, which is why those
+ * are the arguments here.
+ *
+ * **The auth posture is the point, and it is deliberately not configurable.**
+ * The downstream half requires an actor edge JWT and refuses service tokens,
+ * so a service credential cannot be replayed into a client-facing socket. The
+ * upstream half carries only {@link mintServiceToken}, never anything the
+ * client supplied: the runtime is unreachable from the public internet and
+ * resolves the acting principal from its own guardian rather than from a
+ * header this proxy could be talked into forwarding.
+ */
+
+import type { Logger } from "pino";
+
+import { buildWsUpstreamUrl } from "@vellumai/assistant-client";
+
+import {
+  validateEdgeToken,
+  mintServiceToken,
+} from "../../auth/token-exchange.js";
+import { isActorTokenRevoked } from "../../auth/actor-token-revocation.js";
+import { parseSub } from "../../auth/subject.js";
+import type { GatewayConfig } from "../../config.js";
+
+/**
+ * Cap on frames held while the upstream socket is still connecting, so a
+ * stalled runtime cannot grow this proxy's memory without bound.
+ */
+const MAX_PENDING_MESSAGES = 100;
+
+/** The state every audio-stream proxy socket carries, whatever it streams. */
+export interface RuntimeAudioStreamState {
+  config: GatewayConfig;
+  upstream?: WebSocket;
+  pendingMessages?: (string | ArrayBuffer | Uint8Array)[];
+}
+
+/**
+ * The outcome of the shared authorization: proceed, carrying whatever identity
+ * it established, or send this response back instead.
+ *
+ * A response rather than a thrown error so the caller stays a plain upgrade
+ * handler, which is the shape `Bun.serve` wants.
+ *
+ * `actorPrincipalId` is null only on the dev bypass, where no token was
+ * validated and there is no principal to report. A route that pins the upgrade
+ * to an identity has to decide what to do about that for itself; this module
+ * takes no position, because the bypass exists precisely to run without one.
+ */
+export type RuntimeAudioStreamAuth =
+  | { ok: true; actorPrincipalId: string | null }
+  | { ok: false; response: Response };
+
+/**
+ * Whether a client may open one of these sockets.
+ *
+ * Establishes that the caller is *an* actor on this assistant and nothing
+ * more. Whether they are the actor a particular surface belongs to is a
+ * separate question, deliberately left to the route: see `guardian-pin.ts`,
+ * which `/v1/watch/stream` opts into and `/v1/stt/stream` does not.
+ */
+export function authorizeRuntimeAudioStream(
+  req: Request,
+  config: GatewayConfig,
+  log: Logger,
+): RuntimeAudioStreamAuth {
+  if (req.headers.get("upgrade")?.toLowerCase() !== "websocket") {
+    return {
+      ok: false,
+      response: new Response("Upgrade Required", { status: 426 }),
+    };
+  }
+
+  // The dev bypass, which turns off runtime proxy auth globally. The upgrade
+  // still has to be a well-formed one, so only token validation is skipped.
+  if (!config.runtimeProxyRequireAuth) {
+    return { ok: true, actorPrincipalId: null };
+  }
+
+  const authHeader = req.headers.get("authorization");
+  const queryToken = new URL(req.url).searchParams.get("token");
+  const rawToken = authHeader
+    ? authHeader.toLowerCase().startsWith("bearer ")
+      ? authHeader.slice(7)
+      : null
+    : queryToken;
+
+  if (!rawToken) {
+    log.warn("audio stream WS: no token provided");
+    return {
+      ok: false,
+      response: new Response("Unauthorized", { status: 401 }),
+    };
+  }
+
+  const result = validateEdgeToken(rawToken);
+  if (!result.ok) {
+    log.warn({ reason: result.reason }, "audio stream WS: auth failed");
+    return {
+      ok: false,
+      response: new Response("Unauthorized", { status: 401 }),
+    };
+  }
+
+  if (isActorTokenRevoked(rawToken, result.claims)) {
+    log.warn("audio stream WS: rejected, actor token revoked");
+    return {
+      ok: false,
+      response: new Response("Unauthorized", { status: 401 }),
+    };
+  }
+
+  // An actor principal and nothing else. These are client-facing paths, and a
+  // service token reaching one would let a credential minted for machine to
+  // machine traffic open a user's microphone stream.
+  const parsed = parseSub(result.claims.sub);
+  if (
+    !parsed.ok ||
+    parsed.principalType !== "actor" ||
+    !parsed.actorPrincipalId
+  ) {
+    log.warn(
+      {
+        reason: parsed.ok ? "missing_actor_principal" : parsed.reason,
+        sub: result.claims.sub,
+      },
+      "audio stream WS: denied token without actor principal",
+    );
+    return {
+      ok: false,
+      response: new Response("Unauthorized", { status: 401 }),
+    };
+  }
+
+  return { ok: true, actorPrincipalId: parsed.actorPrincipalId };
+}
+
+export interface RuntimeAudioStreamHandlerOptions<
+  T extends RuntimeAudioStreamState,
+> {
+  /** Runtime path this proxy dials, e.g. `/v1/stt/stream`. */
+  upstreamPath: string;
+  log: Logger;
+  /** What this stream is called in log messages, e.g. `"STT stream"`. */
+  label: string;
+  /** Query parameters carried upstream, built from the socket's own state. */
+  upstreamParams: (data: T) => Record<string, string>;
+  /** Extra fields worth logging alongside every message about this socket. */
+  logContext?: (data: T) => Record<string, unknown>;
+}
+
+/**
+ * The `Bun.serve` WebSocket handlers that pump frames between a client and the
+ * runtime.
+ *
+ * Frames that arrive before the upstream socket is open are buffered rather
+ * than dropped: the client starts sending audio the moment its own socket
+ * opens, and the first fraction of a second of speech is exactly the part a
+ * transcriber needs most.
+ */
+export function createRuntimeAudioStreamHandlers<
+  T extends RuntimeAudioStreamState,
+>({
+  upstreamPath,
+  log,
+  label,
+  upstreamParams,
+  logContext = () => ({}),
+}: RuntimeAudioStreamHandlerOptions<T>) {
+  return {
+    open(ws: import("bun").ServerWebSocket<T>) {
+      const context = logContext(ws.data);
+      ws.data.pendingMessages = [];
+
+      const { url: upstreamUrl, logSafeUrl: logSafeUpstreamUrl } =
+        buildWsUpstreamUrl({
+          baseUrl: ws.data.config.assistantRuntimeBaseUrl,
+          path: upstreamPath,
+          serviceToken: mintServiceToken(),
+          extraParams: upstreamParams(ws.data),
+        });
+
+      log.info(
+        { upstreamUrl: logSafeUpstreamUrl, ...context },
+        `Opening upstream ${label} WS to runtime`,
+      );
+
+      const upstream = new WebSocket(upstreamUrl);
+      ws.data.upstream = upstream;
+
+      upstream.addEventListener("open", () => {
+        log.info(context, `Upstream ${label} WS connected`);
+        const pending = ws.data.pendingMessages;
+        if (pending) {
+          for (const msg of pending) {
+            upstream.send(msg);
+          }
+          ws.data.pendingMessages = undefined;
+        }
+      });
+
+      upstream.addEventListener("message", (event) => {
+        // Runtime events back to the client.
+        const data =
+          typeof event.data === "string"
+            ? event.data
+            : new Uint8Array(event.data as ArrayBuffer);
+        ws.send(data);
+      });
+
+      upstream.addEventListener("close", (event) => {
+        log.info(
+          { code: event.code, ...context },
+          `Upstream ${label} WS closed`,
+        );
+        ws.close(event.code, event.reason);
+      });
+
+      upstream.addEventListener("error", (event) => {
+        log.error({ error: event, ...context }, `Upstream ${label} WS error`);
+        ws.close(1011, "Upstream error");
+      });
+    },
+
+    message(
+      ws: import("bun").ServerWebSocket<T>,
+      message: string | ArrayBuffer | Uint8Array,
+    ) {
+      // Client audio frames on to the runtime.
+      const upstream = ws.data.upstream;
+      if (upstream && upstream.readyState === WebSocket.OPEN) {
+        upstream.send(message);
+        return;
+      }
+      if (ws.data.pendingMessages) {
+        if (ws.data.pendingMessages.length >= MAX_PENDING_MESSAGES) {
+          log.warn(`${label} pending message buffer overflow, closing`);
+          ws.close(1008, "Buffer overflow");
+          return;
+        }
+        ws.data.pendingMessages.push(message);
+      }
+    },
+
+    close(ws: import("bun").ServerWebSocket<T>, code: number, reason: string) {
+      const context = logContext(ws.data);
+      log.info({ code, reason, ...context }, `${label} downstream WS closed`);
+      ws.data.pendingMessages = undefined;
+      const upstream = ws.data.upstream;
+      if (
+        upstream &&
+        (upstream.readyState === WebSocket.OPEN ||
+          upstream.readyState === WebSocket.CONNECTING)
+      ) {
+        upstream.close(code, reason);
+      }
+    },
+  };
+}

--- a/gateway/src/http/routes/stt-stream-websocket.ts
+++ b/gateway/src/http/routes/stt-stream-websocket.ts
@@ -1,22 +1,25 @@
-import { buildWsUpstreamUrl } from "@vellumai/assistant-client";
+/**
+ * `/v1/stt/stream`: the client's dictation audio, proxied to the runtime's
+ * streaming transcriber.
+ *
+ * The auth gate and the frame pump are `runtime-audio-stream.ts`'s, shared
+ * with the watch stream next door, so the two client-facing audio proxies
+ * cannot drift into two ideas of who may open one. What is this route's own is
+ * the query it accepts and carries upstream.
+ */
 
 import {
-  validateEdgeToken,
-  mintServiceToken,
-} from "../../auth/token-exchange.js";
-import { isActorTokenRevoked } from "../../auth/actor-token-revocation.js";
-import { parseSub } from "../../auth/subject.js";
+  authorizeRuntimeAudioStream,
+  createRuntimeAudioStreamHandlers,
+  type RuntimeAudioStreamState,
+} from "./runtime-audio-stream.js";
 import type { GatewayConfig } from "../../config.js";
 import { getLogger } from "../../logger.js";
 
 const log = getLogger("stt-stream-ws");
 
-// Cap buffered messages to prevent unbounded memory growth if upstream stalls
-const MAX_PENDING_MESSAGES = 100;
-
-export type SttStreamSocketData = {
+export type SttStreamSocketData = RuntimeAudioStreamState & {
   wsType: "stt-stream";
-  config: GatewayConfig;
   /**
    * Optional provider identifier for the STT streaming session (e.g.
    * "deepgram", "google-gemini"). The runtime is config-authoritative —
@@ -30,8 +33,6 @@ export type SttStreamSocketData = {
   mimeType: string;
   /** Sample rate in Hz, when applicable. */
   sampleRate?: number;
-  upstream?: WebSocket;
-  pendingMessages?: (string | ArrayBuffer | Uint8Array)[];
 };
 
 /**
@@ -49,97 +50,19 @@ export function createSttStreamWebsocketHandler(config: GatewayConfig) {
     req: Request,
     server: import("bun").Server<unknown>,
   ): Response | undefined {
-    if (req.headers.get("upgrade")?.toLowerCase() !== "websocket") {
-      return new Response("Upgrade Required", { status: 426 });
-    }
-
-    const url = new URL(req.url);
-
-    // ── Auth ──
-    // STT streaming is an authenticated, assistant-scoped path. The
-    // client must present a valid edge JWT (actor principal). There is
-    // no auth-bypass mode — fail closed.
-    if (!config.runtimeProxyRequireAuth) {
-      // When runtime proxy auth is globally disabled (dev bypass), we
-      // still allow the upgrade but skip token validation.
-      const provider = url.searchParams.get("provider") ?? undefined;
-      const mimeType = url.searchParams.get("mimeType");
-
-      if (!mimeType) {
-        return new Response("Missing required query parameter: mimeType", {
-          status: 400,
-        });
-      }
-
-      const sampleRateRaw = url.searchParams.get("sampleRate");
-      const sampleRate = sampleRateRaw
-        ? parseInt(sampleRateRaw, 10)
-        : undefined;
-
-      const upgraded = server.upgrade(req, {
-        data: {
-          wsType: "stt-stream",
-          config,
-          provider,
-          mimeType,
-          sampleRate,
-        } satisfies SttStreamSocketData,
-      });
-
-      if (!upgraded) {
-        return new Response("WebSocket upgrade failed", { status: 500 });
-      }
-      return undefined;
-    }
-
-    const authHeader = req.headers.get("authorization");
-    const queryToken = url.searchParams.get("token");
-    const rawToken = authHeader
-      ? authHeader.toLowerCase().startsWith("bearer ")
-        ? authHeader.slice(7)
-        : null
-      : queryToken;
-
-    if (!rawToken) {
-      log.warn("STT stream WS: no token provided");
-      return new Response("Unauthorized", { status: 401 });
-    }
-
-    const result = validateEdgeToken(rawToken);
-    if (!result.ok) {
-      log.warn(
-        { reason: result.reason },
-        "STT stream WS: authentication failed",
-      );
-      return new Response("Unauthorized", { status: 401 });
-    }
-
-    if (isActorTokenRevoked(rawToken, result.claims)) {
-      log.warn("STT stream WS: rejected — actor token revoked");
-      return new Response("Unauthorized", { status: 401 });
-    }
-
-    // Require an actor principal — service tokens are not allowed on
-    // this client-facing path.
-    const parsed = parseSub(result.claims.sub);
-    if (
-      !parsed.ok ||
-      parsed.principalType !== "actor" ||
-      !parsed.actorPrincipalId
-    ) {
-      log.warn(
-        {
-          reason: parsed.ok ? "missing_actor_principal" : parsed.reason,
-          sub: result.claims.sub,
-        },
-        "STT stream WS: denied token without actor principal",
-      );
-      return new Response("Unauthorized", { status: 401 });
+    // Any valid actor, deliberately. Dictation is the user's own words going
+    // to a transcriber and back; it is not a guardian-only surface, and the
+    // watch stream's `guardian-pin` check is exactly what this route does not
+    // want.
+    const auth = authorizeRuntimeAudioStream(req, config, log);
+    if (!auth.ok) {
+      return auth.response;
     }
 
     // ── Query parameters ──
     // mimeType is required; provider is optional compatibility metadata
     // (the runtime resolves the transcriber from config, not from the query).
+    const url = new URL(req.url);
     const provider = url.searchParams.get("provider") ?? undefined;
     const mimeType = url.searchParams.get("mimeType");
 
@@ -176,105 +99,24 @@ export function createSttStreamWebsocketHandler(config: GatewayConfig) {
  * frames to the runtime's /v1/stt/stream endpoint.
  */
 export function getSttStreamWebsocketHandlers() {
-  return {
-    open(ws: import("bun").ServerWebSocket<SttStreamSocketData>) {
-      const { config, provider, mimeType, sampleRate } = ws.data;
-
-      // Initialize message buffer for frames arriving before upstream connects
-      ws.data.pendingMessages = [];
-
-      const extraParams: Record<string, string> = { mimeType };
+  return createRuntimeAudioStreamHandlers<SttStreamSocketData>({
+    upstreamPath: "/v1/stt/stream",
+    log,
+    label: "STT stream",
+    upstreamParams: ({ provider, mimeType, sampleRate }) => {
+      const params: Record<string, string> = { mimeType };
       if (provider) {
-        extraParams.provider = provider;
+        params.provider = provider;
       }
       if (sampleRate !== undefined) {
-        extraParams.sampleRate = String(sampleRate);
+        params.sampleRate = String(sampleRate);
       }
-      const { url: upstreamUrl, logSafeUrl: logSafeUpstreamUrl } =
-        buildWsUpstreamUrl({
-          baseUrl: config.assistantRuntimeBaseUrl,
-          path: "/v1/stt/stream",
-          serviceToken: mintServiceToken(),
-          extraParams,
-        });
-
-      log.info(
-        { upstreamUrl: logSafeUpstreamUrl, provider, mimeType, sampleRate },
-        "Opening upstream STT stream WS to runtime",
-      );
-
-      const upstream = new WebSocket(upstreamUrl);
-      ws.data.upstream = upstream;
-
-      upstream.addEventListener("open", () => {
-        log.info({ provider }, "Upstream STT stream WS connected");
-        const pending = ws.data.pendingMessages;
-        if (pending) {
-          for (const msg of pending) {
-            upstream.send(msg);
-          }
-          ws.data.pendingMessages = undefined;
-        }
-      });
-
-      upstream.addEventListener("message", (event) => {
-        // Forward runtime transcription events -> client
-        const data =
-          typeof event.data === "string"
-            ? event.data
-            : new Uint8Array(event.data as ArrayBuffer);
-        ws.send(data);
-      });
-
-      upstream.addEventListener("close", (event) => {
-        log.info(
-          { code: event.code, provider },
-          "Upstream STT stream WS closed",
-        );
-        ws.close(event.code, event.reason);
-      });
-
-      upstream.addEventListener("error", (event) => {
-        log.error({ error: event, provider }, "Upstream STT stream WS error");
-        ws.close(1011, "Upstream error");
-      });
+      return params;
     },
-
-    message(
-      ws: import("bun").ServerWebSocket<SttStreamSocketData>,
-      message: string | ArrayBuffer | Uint8Array,
-    ) {
-      // Forward client audio frames -> runtime
-      const upstream = ws.data.upstream;
-      if (upstream && upstream.readyState === WebSocket.OPEN) {
-        upstream.send(message);
-      } else if (ws.data.pendingMessages) {
-        if (ws.data.pendingMessages.length >= MAX_PENDING_MESSAGES) {
-          log.warn(
-            "STT stream pending message buffer overflow — closing connection",
-          );
-          ws.close(1008, "Buffer overflow");
-          return;
-        }
-        ws.data.pendingMessages.push(message);
-      }
-    },
-
-    close(
-      ws: import("bun").ServerWebSocket<SttStreamSocketData>,
-      code: number,
-      reason: string,
-    ) {
-      const { upstream, provider } = ws.data;
-      log.info({ code, reason, provider }, "STT stream downstream WS closed");
-      ws.data.pendingMessages = undefined;
-      if (
-        upstream &&
-        (upstream.readyState === WebSocket.OPEN ||
-          upstream.readyState === WebSocket.CONNECTING)
-      ) {
-        upstream.close(code, reason);
-      }
-    },
-  };
+    logContext: ({ provider, mimeType, sampleRate }) => ({
+      provider,
+      mimeType,
+      sampleRate,
+    }),
+  });
 }

--- a/gateway/src/http/routes/stt-stream-websocket.ts
+++ b/gateway/src/http/routes/stt-stream-websocket.ts
@@ -2,10 +2,15 @@
  * `/v1/stt/stream`: the client's dictation audio, proxied to the runtime's
  * streaming transcriber.
  *
- * The auth gate and the frame pump are `runtime-audio-stream.ts`'s, shared
+ * The token gate and the frame pump are `runtime-audio-stream.ts`'s, shared
  * with the watch stream next door, so the two client-facing audio proxies
- * cannot drift into two ideas of who may open one. What is this route's own is
- * the query it accepts and carries upstream.
+ * cannot drift on what a valid caller looks like. Where they deliberately do
+ * differ is who may open one: watch is guardian-only and pins the upgrade to
+ * the binding, and dictation takes any valid actor, which is why that pin is a
+ * route opt-in rather than part of the shared gate.
+ *
+ * The rest of what is this route's own is the query it accepts and carries
+ * upstream.
  */
 
 import {

--- a/gateway/src/http/routes/watch-stream-websocket.ts
+++ b/gateway/src/http/routes/watch-stream-websocket.ts
@@ -1,0 +1,195 @@
+/**
+ * `/v1/watch/stream`: a watch session's narration, proxied to the runtime.
+ *
+ * The client half of a watch session is a microphone and this socket
+ * (`clients/web/src/domains/chat/watch/watch-controller.ts`); the runtime half
+ * turns the narration into a timeline and decides when to read the user's
+ * screen (`assistant/src/runtime/routes/watch-routes.ts`). Neither can reach
+ * the other directly: the runtime is unreachable from outside the private
+ * network, so this is the hop that makes the feature work from a browser at
+ * all.
+ *
+ * The auth gate and the frame pump are `runtime-audio-stream.ts`'s, shared
+ * with `/v1/stt/stream`. The two carry different audio to different ends of
+ * the runtime and are the same proxy, so they are one implementation with two
+ * queries rather than two implementations that agree today.
+ */
+
+import {
+  authorizeRuntimeAudioStream,
+  createRuntimeAudioStreamHandlers,
+  type RuntimeAudioStreamState,
+} from "./runtime-audio-stream.js";
+import {
+  extractVelayAttestedContext,
+  isPlatformManaged,
+  requireBoundGuardian,
+  requireManagedGuardian,
+} from "./guardian-pin.js";
+import type { GatewayConfig } from "../../config.js";
+import { getLogger } from "../../logger.js";
+import { requestHasVelayBridgeAuth } from "../../velay/bridge-auth.js";
+
+const log = getLogger("watch-stream-ws");
+
+export type WatchStreamSocketData = RuntimeAudioStreamState & {
+  wsType: "watch-stream";
+  /** MIME type of the narration audio (`audio/pcm` from the web capture). */
+  mimeType: string;
+  /** Sample rate in Hz, when applicable. */
+  sampleRate?: number;
+  /**
+   * Conversation the session's timeline is filed against, when the client
+   * names one. Absent lets the runtime mint a conversation for the session,
+   * which is what the companion surface's Watch does: it starts a session
+   * rather than joining a thread.
+   */
+  conversationId?: string;
+  /**
+   * Host client whose screen the session reads, when the client names one.
+   * Absent lets the runtime resolve the actor's own host, which is the only
+   * choice on a machine with one.
+   */
+  clientId?: string;
+};
+
+/**
+ * Create the upgrade handler for `/v1/watch/stream`.
+ *
+ * Authenticates the downstream caller here and dials upstream with a
+ * short-lived service token, which is what lets the runtime resolve the acting
+ * principal from its own guardian rather than from anything the client sent.
+ *
+ * **Guardian-only, the way live voice is, and for a sharper reason.** The
+ * daemon resolves whose screen to observe from the guardian binding and never
+ * from the request, so a session opened by any other actor is still bound to
+ * the guardian and still reads the guardian's screen. The proxy also replaces
+ * the caller's identity with a service token upstream, leaving the daemon no
+ * way to tell one actor from another. This upgrade is therefore the only place
+ * a non-guardian actor can be refused, so it is refused here.
+ */
+export function createWatchStreamWebsocketHandler(config: GatewayConfig) {
+  return async function handleUpgrade(
+    req: Request,
+    server: import("bun").Server<unknown>,
+  ): Promise<Response | undefined> {
+    if (req.headers.get("upgrade")?.toLowerCase() !== "websocket") {
+      return new Response("Upgrade Required", { status: 426 });
+    }
+
+    // Managed/cloud path, taken before the token path exactly as live voice
+    // takes it: velay validated the browser's token and injected the caller,
+    // and the bridge proof is what says this request really came through the
+    // gateway's own loopback bridge rather than from someone who guessed the
+    // header names. An incomplete attestation falls through, so a managed
+    // deployment still accepts a valid actor edge JWT.
+    let managedGuardian = false;
+    if (isPlatformManaged() && config.runtimeProxyRequireAuth) {
+      const velayContext = extractVelayAttestedContext(req);
+      if (velayContext) {
+        if (requestHasVelayBridgeAuth(req)) {
+          const guardianError = await requireManagedGuardian(
+            velayContext.userId,
+            log,
+          );
+          if (guardianError) {
+            return guardianError;
+          }
+          log.info(
+            { userId: velayContext.userId, orgId: velayContext.orgId },
+            "Watch stream WS: authenticated via velay-attested managed context",
+          );
+          managedGuardian = true;
+        } else {
+          log.warn(
+            "Watch stream WS: ignoring velay context without bridge proof",
+          );
+        }
+      }
+    }
+
+    // The token path, and its half of the pin. Skipped entirely when velay
+    // already attested this caller as the guardian: there is no edge JWT on
+    // that path to validate, and requiring one would reject the managed
+    // callers the attestation exists to admit.
+    if (!managedGuardian) {
+      const auth = authorizeRuntimeAudioStream(req, config, log);
+      if (!auth.ok) {
+        return auth.response;
+      }
+      // A null principal is the dev bypass, which validated no token and has
+      // nothing to compare. That bypass turns runtime proxy auth off
+      // wholesale, and this is not the place to reintroduce it.
+      if (auth.actorPrincipalId !== null) {
+        const guardianError = await requireBoundGuardian(
+          auth.actorPrincipalId,
+          log,
+        );
+        if (guardianError) {
+          return guardianError;
+        }
+      }
+    }
+
+    const url = new URL(req.url);
+    const mimeType = url.searchParams.get("mimeType");
+    if (!mimeType) {
+      return new Response("Missing required query parameter: mimeType", {
+        status: 400,
+      });
+    }
+
+    const sampleRateRaw = url.searchParams.get("sampleRate");
+    const sampleRate = sampleRateRaw ? parseInt(sampleRateRaw, 10) : undefined;
+    const conversationId =
+      url.searchParams.get("conversationId")?.trim() || undefined;
+    const clientId = url.searchParams.get("clientId")?.trim() || undefined;
+
+    const upgraded = server.upgrade(req, {
+      data: {
+        wsType: "watch-stream",
+        config,
+        mimeType,
+        sampleRate,
+        conversationId,
+        clientId,
+      } satisfies WatchStreamSocketData,
+    });
+
+    if (!upgraded) {
+      return new Response("WebSocket upgrade failed", { status: 500 });
+    }
+
+    return undefined;
+  };
+}
+
+/**
+ * WebSocket handlers for Bun.serve() that pump narration audio to the
+ * runtime's `/v1/watch/stream` and its lifecycle frames back.
+ */
+export function getWatchStreamWebsocketHandlers() {
+  return createRuntimeAudioStreamHandlers<WatchStreamSocketData>({
+    upstreamPath: "/v1/watch/stream",
+    log,
+    label: "watch stream",
+    upstreamParams: ({ mimeType, sampleRate, conversationId, clientId }) => {
+      const params: Record<string, string> = { mimeType };
+      if (sampleRate !== undefined) {
+        params.sampleRate = String(sampleRate);
+      }
+      if (conversationId) {
+        params.conversationId = conversationId;
+      }
+      if (clientId) {
+        params.clientId = clientId;
+      }
+      return params;
+    },
+    logContext: ({ mimeType, sampleRate, conversationId }) => ({
+      mimeType,
+      sampleRate,
+      conversationId,
+    }),
+  });
+}

--- a/gateway/src/http/routes/watch-stream-websocket.ts
+++ b/gateway/src/http/routes/watch-stream-websocket.ts
@@ -9,10 +9,14 @@
  * network, so this is the hop that makes the feature work from a browser at
  * all.
  *
- * The auth gate and the frame pump are `runtime-audio-stream.ts`'s, shared
- * with `/v1/stt/stream`. The two carry different audio to different ends of
- * the runtime and are the same proxy, so they are one implementation with two
- * queries rather than two implementations that agree today.
+ * The token gate and the frame pump are `runtime-audio-stream.ts`'s, shared
+ * with `/v1/stt/stream`: the two carry different audio to different ends of
+ * the runtime and are otherwise the same proxy, so they are one implementation
+ * with two queries rather than two implementations that agree today.
+ *
+ * What is this route's own is who may open it. Watch is guardian-only and
+ * dictation is not, so the pin below is layered here rather than added to the
+ * shared gate, where it would take dictation with it.
  */
 
 import {
@@ -73,6 +77,9 @@ export function createWatchStreamWebsocketHandler(config: GatewayConfig) {
     req: Request,
     server: import("bun").Server<unknown>,
   ): Promise<Response | undefined> {
+    // Checked here as well as in the shared gate, because the managed path
+    // below skips that gate entirely: without this, a managed caller sending a
+    // plain request would fall through to `server.upgrade` and get a 500.
     if (req.headers.get("upgrade")?.toLowerCase() !== "websocket") {
       return new Response("Upgrade Required", { status: 426 });
     }

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -2160,7 +2160,9 @@ async function main() {
     // say so. See the note in `velay/allowed-paths.ts`.
     if (url.pathname === "/v1/watch/stream") {
       const upgradeResult = await handleWatchStreamWs(req, server);
-      if (upgradeResult !== undefined) return upgradeResult;
+      if (upgradeResult !== undefined) {
+        return upgradeResult;
+      }
       return undefined as unknown as Response;
     }
 

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -2152,6 +2152,12 @@ async function main() {
       return undefined as unknown as Response;
     }
 
+    // Self-hosted only in this version, and deliberately NOT in
+    // `VELAY_ALLOWED_PATHS`: the client refuses to open a session over a
+    // paired ingress, and a session needs a locally connected `host_cu`
+    // desktop client to observe anything. Adding the allowlist entry opens a
+    // managed route that still cannot carry a session, and nothing fails to
+    // say so. See the note in `velay/allowed-paths.ts`.
     if (url.pathname === "/v1/watch/stream") {
       const upgradeResult = await handleWatchStreamWs(req, server);
       if (upgradeResult !== undefined) return upgradeResult;

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -50,6 +50,11 @@ import {
   type SttStreamSocketData,
 } from "./http/routes/stt-stream-websocket.js";
 import {
+  createWatchStreamWebsocketHandler,
+  getWatchStreamWebsocketHandlers,
+  type WatchStreamSocketData,
+} from "./http/routes/watch-stream-websocket.js";
+import {
   createSpeechRelayUpgradeHandler,
   getSpeechRelayWebsocketHandlers,
   type SpeechRelaySocketData,
@@ -306,6 +311,14 @@ function isSttStreamSocketData(data: unknown): data is SttStreamSocketData {
   );
 }
 
+function isWatchStreamSocketData(data: unknown): data is WatchStreamSocketData {
+  return (
+    !!data &&
+    typeof data === "object" &&
+    (data as { wsType?: unknown }).wsType === "watch-stream"
+  );
+}
+
 function isLiveVoiceSocketData(data: unknown): data is LiveVoiceSocketData {
   return (
     !!data &&
@@ -535,6 +548,7 @@ async function main() {
     credentials: credentialCache,
   });
   const handleSttStreamWs = createSttStreamWebsocketHandler(config);
+  const handleWatchStreamWs = createWatchStreamWebsocketHandler(config);
   const handleLiveVoiceWs = createLiveVoiceWebsocketHandler(config);
   const handleSpeechRelaySttWs = createSpeechRelayUpgradeHandler(
     config,
@@ -549,6 +563,7 @@ async function main() {
   const twilioMediaStreamWebsocketHandlers = getMediaStreamWebsocketHandlers();
   const pluginWebhookWebsocketHandlers = getPluginWebhookWebsocketHandlers();
   const sttStreamWebsocketHandlers = getSttStreamWebsocketHandlers();
+  const watchStreamWebsocketHandlers = getWatchStreamWebsocketHandlers();
   const liveVoiceWebsocketHandlers = getLiveVoiceWebsocketHandlers();
   const speechRelayWebsocketHandlers = getSpeechRelayWebsocketHandlers();
   const { handler: handleWhatsAppWebhook, dedupCache: whatsappDedupCache } =
@@ -1857,6 +1872,10 @@ async function main() {
           sttStreamWebsocketHandlers.open(ws as never);
           return;
         }
+        if (isWatchStreamSocketData(ws.data)) {
+          watchStreamWebsocketHandlers.open(ws as never);
+          return;
+        }
         if (isLiveVoiceSocketData(ws.data)) {
           liveVoiceWebsocketHandlers.open(ws as never);
           return;
@@ -1880,6 +1899,10 @@ async function main() {
           sttStreamWebsocketHandlers.message(ws as never, message);
           return;
         }
+        if (isWatchStreamSocketData(ws.data)) {
+          watchStreamWebsocketHandlers.message(ws as never, message);
+          return;
+        }
         if (isLiveVoiceSocketData(ws.data)) {
           liveVoiceWebsocketHandlers.message(ws as never, message);
           return;
@@ -1901,6 +1924,10 @@ async function main() {
         }
         if (isSttStreamSocketData(ws.data)) {
           sttStreamWebsocketHandlers.close(ws as never, code, reason);
+          return;
+        }
+        if (isWatchStreamSocketData(ws.data)) {
+          watchStreamWebsocketHandlers.close(ws as never, code, reason);
           return;
         }
         if (isLiveVoiceSocketData(ws.data)) {
@@ -2121,6 +2148,12 @@ async function main() {
 
     if (url.pathname === "/v1/stt/stream") {
       const upgradeResult = handleSttStreamWs(req, server);
+      if (upgradeResult !== undefined) return upgradeResult;
+      return undefined as unknown as Response;
+    }
+
+    if (url.pathname === "/v1/watch/stream") {
+      const upgradeResult = await handleWatchStreamWs(req, server);
       if (upgradeResult !== undefined) return upgradeResult;
       return undefined as unknown as Response;
     }

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -1040,6 +1040,95 @@ export function buildSchema(): Record<string, unknown> {
           },
         },
       },
+      "/v1/watch/stream": {
+        get: {
+          summary: "Watch stream WebSocket",
+          description:
+            "Accepts a WebSocket upgrade for a watch session's narration audio. Authenticates the client using an edge JWT (actor principal) and proxies frames bidirectionally to the assistant runtime's /v1/watch/stream endpoint using a gateway service token. Requires the mimeType query parameter. Client frames are audio; runtime frames are session lifecycle only (ready, entry, error, closed), never transcript text.",
+          operationId: "watchStreamWebsocket",
+          security: [{ BearerAuth: [] }],
+          parameters: [
+            {
+              name: "mimeType",
+              in: "query",
+              required: true,
+              schema: { type: "string" },
+              description:
+                "MIME type of the narration audio being streamed (e.g. 'audio/pcm').",
+            },
+            {
+              name: "sampleRate",
+              in: "query",
+              required: false,
+              schema: { type: "integer" },
+              description: "Audio sample rate in Hz, when applicable.",
+            },
+            {
+              name: "conversationId",
+              in: "query",
+              required: false,
+              schema: { type: "string" },
+              description:
+                "Conversation the session's timeline is filed against. Absent lets the runtime mint one for the session.",
+            },
+            {
+              name: "clientId",
+              in: "query",
+              required: false,
+              schema: { type: "string" },
+              description:
+                "Host client whose screen the session reads. Absent lets the runtime resolve the actor's own host.",
+            },
+            {
+              name: "token",
+              in: "query",
+              required: false,
+              schema: { type: "string" },
+              description:
+                "Edge JWT for authentication (alternative to Authorization header, since browser WebSocket upgrades cannot set custom headers).",
+            },
+          ],
+          responses: {
+            "101": {
+              description:
+                "WebSocket upgrade successful - bidirectional watch stream frame proxying begins.",
+            },
+            "400": {
+              description: "Missing required query parameter (mimeType)",
+              content: {
+                "text/plain": {
+                  schema: { type: "string" },
+                },
+              },
+            },
+            "401": {
+              description: "Unauthorized - missing or invalid token",
+              content: {
+                "text/plain": {
+                  schema: { type: "string" },
+                },
+              },
+            },
+            "426": {
+              description:
+                "Upgrade Required - request is not a WebSocket upgrade",
+              content: {
+                "text/plain": {
+                  schema: { type: "string" },
+                },
+              },
+            },
+            "500": {
+              description: "WebSocket upgrade failed",
+              content: {
+                "text/plain": {
+                  schema: { type: "string" },
+                },
+              },
+            },
+          },
+        },
+      },
       "/v1/live-voice": {
         get: {
           summary: "Live voice WebSocket",

--- a/gateway/src/velay/allowed-paths.test.ts
+++ b/gateway/src/velay/allowed-paths.test.ts
@@ -58,6 +58,14 @@ describe("VELAY_ALLOWED_PATHS", () => {
       "/v1/credential-requests/peek": true,
       "/v1/credential-requests/submit": true,
       // Negative samples — paths that must NOT be tunnel-public.
+      //
+      // `/v1/watch/stream` is here because its absence is a decision rather
+      // than an oversight. Watch is self-hosted only: the client refuses a
+      // paired ingress and a session needs a local desktop client, so the
+      // allowlist entry would open a managed route that still cannot carry a
+      // session. This line is what turns adding it from a silent no-op into a
+      // failure that names the reason.
+      "/v1/watch/stream": false,
       "/v1/credential-requests": false,
       "/v1/credential-requests/other": false,
       "/assistant/credentials": false,

--- a/gateway/src/velay/allowed-paths.ts
+++ b/gateway/src/velay/allowed-paths.ts
@@ -29,6 +29,18 @@
  *     unauthenticated API calls; the single-use token travels in the POST
  *     body and is validated by the gateway handlers.
  *
+ * **`/v1/watch/stream` is deliberately absent, and adding it does not make
+ * Watch work in managed deployments.** Watch is self-hosted only in this
+ * version. The client refuses to open a session over a paired ingress at all
+ * (`isPairedGatewayIngress` in
+ * `clients/web/src/domains/chat/voice/live-voice/connection.ts`), and a
+ * session has nothing to observe without a locally connected `host_cu`
+ * desktop client on the other end. So a pattern added here changes nothing a
+ * user can see: it opens a public managed route that still cannot carry a
+ * session, and it does so silently, because no test fails and no client
+ * behavior changes. Making Watch managed is client and product work, and the
+ * routing entry is the last step of it rather than the first.
+ *
  * If you add a new public route to `gateway/src/index.ts` that must be
  * reachable through the Velay tunnel (i.e. anything an external provider
  * calls or any unauthenticated callback endpoint), add a matching pattern
@@ -40,6 +52,9 @@ export const VELAY_ALLOWED_PATHS: readonly string[] = Object.freeze([
   "^/v1/audio/",
   "^/v1/live-voice$",
   "^/v1/stt/stream$",
+  // No `^/v1/watch/stream$` here on purpose. See the note above: the client
+  // refuses a paired ingress and a session needs a local desktop client, so
+  // this line would open a managed route that still cannot carry a session.
   "^/assistant/credentials/enter$",
   "^/v1/credential-requests/(peek|submit)$",
 ]);

--- a/gateway/src/velay/bridge-utils.ts
+++ b/gateway/src/velay/bridge-utils.ts
@@ -21,6 +21,9 @@ const VELAY_ALLOWED_HTTP_EXACT_PATHS = [
 const VELAY_ALLOWED_WEBSOCKET_EXACT_PATHS = [
   "/v1/live-voice",
   "/v1/stt/stream",
+  // `/v1/watch/stream` is deliberately not here either. See the note in
+  // allowed-paths.ts before adding it: Watch is self-hosted only, and the
+  // entry alone does not make it work in managed deployments.
 ] as const;
 
 /**


### PR DESCRIPTION
## The security shape, first

`/v1/watch/stream` is **guardian-only**, and this PR is mostly about why.

The daemon resolves whose screen a watch session observes from the guardian binding, never from the request. This proxy replaces the caller's identity with `mintServiceToken()` on the way upstream, so the daemon cannot tell one caller from another. Put together: **a non-guardian actor admitted at this upgrade opens a session bound to the guardian, observing the guardian's screen, and nothing downstream can notice.** The upgrade is the only place to refuse them, so it does, on both arrival paths:

- **Managed / cloud** — a velay-attested caller is cross-checked against the stored `platform_user_id`, and only when the request also carries the process-local bridge proof. Header names can be guessed; the proof value cannot.
- **Self-hosted and everything else** — a validated actor edge JWT is compared against the guardian binding.

A lookup that throws answers 503, not 403: the answer is unknown, and reporting that as a permission failure would misdiagnose a database problem.

## STT must not have it, and that is structural

Dictation is the user's own words going to a transcriber and back. It is not a guardian-only surface and keeps accepting any valid actor. So the pin is a **route opt-in**, not part of the shared gate: `authorizeRuntimeAudioStream` returns the parsed principal and applies nothing itself, and `stt-stream-websocket.ts` stays a *synchronous* handler that never consults the binding. Three regression tests guard exactly that, with `findVellumGuardian` mocked to a principal no token in the file matches, so any consultation would turn every STT case into a 403.

## Live voice was ported onto the shared helper

`guardian-pin.ts` is the extraction of the rule `live-voice-websocket.ts` already implemented; live voice now imports it and its private copies are deleted. Copying ~90 lines of security logic into a second file is how two guardian checks drift apart. **Its 33 tests pass unchanged**, sequence and status codes identical, which is the evidence that the port is behavior-preserving.

## The rest

- `runtime-audio-stream.ts` holds what the two audio proxies genuinely share: the token gate and the frame pump (upstream dial with a service token, 100-frame pending buffer, bidirectional pumping, close/error propagation), parameterized by upstream path, label, and query.
- `watch-stream-websocket.ts` forwards `mimeType` (required), `sampleRate`, `conversationId`, `clientId`, matching PR 7's upgrade handler.
- Registered in `gateway/src/index.ts`; documented in `gateway/src/schema.ts` (served live, and `openapi.json` is generated from `ROUTES` so it needed no regeneration) and in `ARCHITECTURE.md`.
- `/v1/watch/stream` is deliberately **not** added to the velay allowlists: the watch client refuses a paired ingress and never mints a velay token, so tunnelling it would widen the public surface for a path that cannot work.

## Review history

Split out of **#40985**, which keeps the web client, the version gate, and the Electron bridge. The guardian finding was raised on #40985 before the split, so the review thread for this code starts there. The two compile independently: the client dials this route by URL and imports nothing from `gateway/`, so merge order does not matter.

## Testing

watch 30, STT 22, **live-voice 33 unchanged**, speech-relay 25, twilio-media 28, plugin-webhook 32, velay allowed-paths 4, schema 5, route-schema-guard 7. Typecheck and eslint clean.

Sabotage-verified: removing the actor-path pin fails 4; removing the managed check fails 3; giving STT the pin fails 10.

Part of plan: learning-by-watching.md (PR 8 of 10)