### PR TITLE
Probe custom inference endpoints at connection save time

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -14998,7 +14998,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ProviderConnection"
+                $ref: "#/components/schemas/SavedProviderConnection"
         "400":
           description: Invalid provider or auth schema
         "409":
@@ -15109,7 +15109,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ProviderConnection"
+                $ref: "#/components/schemas/SavedProviderConnection"
         "400":
           description: Invalid auth schema, or attempt to change auth on a managed connection
         "404":
@@ -35595,6 +35595,78 @@ components:
         - createdAt
         - updatedAt
         - isManaged
+      additionalProperties: false
+    SavedProviderConnection:
+      type: object
+      properties:
+        name:
+          type: string
+          minLength: 1
+        provider:
+          $ref: "#/components/schemas/ConnectionProvider"
+        auth:
+          $ref: "#/components/schemas/AuthOutput"
+        label:
+          anyOf:
+            - type: string
+              minLength: 1
+            - type: "null"
+        baseUrl:
+          anyOf:
+            - type: string
+              format: uri
+            - type: "null"
+        models:
+          anyOf:
+            - type: array
+              items:
+                $ref: "#/components/schemas/ConnectionModelOutput"
+            - type: "null"
+        createdAt:
+          type: integer
+          minimum: -9007199254740991
+          maximum: 9007199254740991
+        updatedAt:
+          type: integer
+          minimum: -9007199254740991
+          maximum: 9007199254740991
+        isManaged:
+          type: boolean
+        endpoint_check:
+          $ref: "#/components/schemas/EndpointCheck"
+      required:
+        - name
+        - provider
+        - auth
+        - label
+        - baseUrl
+        - models
+        - createdAt
+        - updatedAt
+        - isManaged
+      additionalProperties: false
+    EndpointCheck:
+      type: object
+      properties:
+        ok:
+          type: boolean
+        status:
+          type: integer
+          minimum: -9007199254740991
+          maximum: 9007199254740991
+        resolved_url:
+          type: string
+        error_class:
+          type: string
+          enum:
+            - http_error
+            - timeout
+            - network
+        hint:
+          type: string
+      required:
+        - ok
+        - resolved_url
       additionalProperties: false
     ProcessEntry:
       type: object

--- a/assistant/src/cli/commands/inference-providers.ts
+++ b/assistant/src/cli/commands/inference-providers.ts
@@ -41,6 +41,22 @@ interface ProviderConnection {
   baseUrl?: string | null;
   createdAt: string;
   updatedAt: string;
+  /** Save-time probe of a custom base URL; advisory, never blocks the save. */
+  endpoint_check?: {
+    ok: boolean;
+    status?: number;
+    resolved_url: string;
+    hint?: string;
+  };
+}
+
+/** Human-mode warning line for a failed save-time endpoint probe. */
+function formatEndpointCheckWarning(conn: ProviderConnection): string {
+  const check = conn.endpoint_check;
+  if (!check || check.ok) {
+    return "";
+  }
+  return `Warning: ${check.hint ?? `The endpoint returned HTTP ${check.status} for a test request.`} (probed ${check.resolved_url})\n`;
 }
 
 // ---------------------------------------------------------------------------
@@ -304,6 +320,7 @@ function attachCreateSubcommand(parent: Command): void {
         } else {
           process.stdout.write(
             `Added provider "${conn.name}" (provider=${conn.provider})\n` +
+              formatEndpointCheckWarning(conn) +
               `Verify it works: point a profile at "${conn.name}", then run: assistant inference send --profile <profile> "Reply with OK"\n`,
           );
         }
@@ -394,6 +411,7 @@ function attachUpdateSubcommand(parent: Command): void {
         } else {
           process.stdout.write(
             `Updated provider "${name}" (auth=${formatAuth(conn.auth)})\n` +
+              formatEndpointCheckWarning(conn) +
               `Verify it works: assistant inference send --profile <profile-using-this-provider> "Reply with OK"\n`,
           );
         }

--- a/assistant/src/providers/inference/__tests__/endpoint-probe.test.ts
+++ b/assistant/src/providers/inference/__tests__/endpoint-probe.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test";
+
+import { testInferenceConnection } from "../endpoint-probe.js";
+
+// Keyless auth so the probe never touches the vault; the fetch stub records
+// the request instead of dialing out.
+const CONNECTION = {
+  provider: "openai-compatible",
+  auth: { type: "none" } as const,
+  baseUrl: "https://integrate.api.nvidia.com",
+  models: [{ id: "meta/llama-3.1-8b-instruct" }],
+};
+
+function stubFetch(status: number, calls: { url: string; body: unknown }[]) {
+  return (async (url: RequestInfo | URL, init?: RequestInit) => {
+    calls.push({
+      url: String(url),
+      body: JSON.parse(String(init?.body)),
+    });
+    return new Response(status < 400 ? "{}" : "404 page not found", { status });
+  }) as typeof fetch;
+}
+
+describe("testInferenceConnection", () => {
+  test("reports ok:false with a base-path hint on 404", async () => {
+    const calls: { url: string; body: unknown }[] = [];
+    const result = await testInferenceConnection(
+      CONNECTION,
+      stubFetch(404, calls),
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      status: 404,
+      resolved_url: "https://integrate.api.nvidia.com/chat/completions",
+      error_class: "http_error",
+    });
+    expect(result?.hint).toContain("/v1");
+    expect(calls[0].body).toMatchObject({
+      model: "meta/llama-3.1-8b-instruct",
+      max_tokens: 1,
+    });
+  });
+
+  test("reports ok:true on 200 from a correct base URL", async () => {
+    const calls: { url: string; body: unknown }[] = [];
+    const result = await testInferenceConnection(
+      { ...CONNECTION, baseUrl: "https://integrate.api.nvidia.com/v1" },
+      stubFetch(200, calls),
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      status: 200,
+      resolved_url: "https://integrate.api.nvidia.com/v1/chat/completions",
+    });
+    expect(result?.hint).toBeUndefined();
+  });
+
+  test("hints at the credential on 401", async () => {
+    const result = await testInferenceConnection(
+      CONNECTION,
+      stubFetch(401, []),
+    );
+    expect(result).toMatchObject({ ok: false, status: 401 });
+    expect(result?.hint).toContain("API key");
+  });
+
+  test("reports a network error_class when the endpoint is unreachable", async () => {
+    const failingFetch = (async () => {
+      throw new Error("connection refused");
+    }) as unknown as typeof fetch;
+    const result = await testInferenceConnection(CONNECTION, failingFetch);
+    expect(result).toMatchObject({ ok: false, error_class: "network" });
+    expect(result?.hint).toContain("connection refused");
+  });
+
+  test("skips when there is no base URL or no model to probe with", async () => {
+    const neverFetch = (async () => {
+      throw new Error("should not be called");
+    }) as unknown as typeof fetch;
+    expect(
+      await testInferenceConnection(
+        { ...CONNECTION, baseUrl: null },
+        neverFetch,
+      ),
+    ).toBeNull();
+    expect(
+      await testInferenceConnection({ ...CONNECTION, models: [] }, neverFetch),
+    ).toBeNull();
+  });
+});

--- a/assistant/src/providers/inference/endpoint-probe.ts
+++ b/assistant/src/providers/inference/endpoint-probe.ts
@@ -1,0 +1,112 @@
+/**
+ * Save-time probe for connections with a custom base URL.
+ *
+ * A wrong base path (e.g. NVIDIA without `/v1`) otherwise stays invisible
+ * until the first chat turn fails with an opaque provider 404. The probe
+ * fires one minimal chat-completions request against the stored endpoint and
+ * reports the outcome as a non-blocking hint — the save always succeeds.
+ */
+
+import { z } from "zod";
+
+import { getLogger } from "../../util/logger.js";
+import type { Auth, ConnectionModel } from "./auth.js";
+import { resolveAuth } from "./resolve-auth.js";
+
+const log = getLogger("inference-endpoint-probe");
+
+/** Matches the API-key validation timeout so a dead host can't hang the save. */
+const PROBE_TIMEOUT_MS = 10_000;
+
+export const EndpointCheckSchema = z
+  .object({
+    ok: z.boolean(),
+    status: z.number().int().optional(),
+    resolved_url: z.string(),
+    error_class: z.enum(["http_error", "timeout", "network"]).optional(),
+    /** Human-readable warning, present when `ok` is false. */
+    hint: z.string().optional(),
+  })
+  .meta({ id: "EndpointCheck" });
+
+export type EndpointCheck = z.infer<typeof EndpointCheckSchema>;
+
+function hintForStatus(status: number): string {
+  if (status === 404) {
+    return "The endpoint returned 404 for a test request — check the base path for this provider (e.g. NVIDIA needs /v1, OpenRouter needs /api/v1). Some providers gate requests behind auth, so this may be a false alarm.";
+  }
+  if (status === 401 || status === 403) {
+    return `The endpoint rejected the credential for a test request (HTTP ${status}) — check the API key.`;
+  }
+  return `The endpoint returned HTTP ${status} for a test request.`;
+}
+
+/**
+ * Probe a connection's custom endpoint with a minimal chat-completions
+ * request (`max_tokens: 1`). Returns `null` when there is nothing to probe:
+ * no custom base URL, no model id to send, or auth that cannot be resolved
+ * (a missing credential surfaces through its own error path).
+ */
+export async function testInferenceConnection(
+  connection: {
+    provider: string;
+    auth: Auth;
+    baseUrl?: string | null;
+    models?: ConnectionModel[] | null;
+  },
+  fetchImpl: typeof fetch = fetch,
+): Promise<EndpointCheck | null> {
+  const model = connection.models?.[0]?.id;
+  if (!connection.baseUrl || !model) {
+    return null;
+  }
+
+  const resolved = await resolveAuth(connection.auth, connection.provider, {
+    baseUrl: connection.baseUrl,
+  });
+  if (!resolved.ok || resolved.resolved.kind === "runtime_proxy") {
+    return null;
+  }
+  const authHeaders =
+    resolved.resolved.kind === "header" ? resolved.resolved.headers : {};
+
+  const url = `${connection.baseUrl.replace(/\/+$/, "")}/chat/completions`;
+  try {
+    const res = await fetchImpl(url, {
+      method: "POST",
+      headers: { ...authHeaders, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model,
+        messages: [{ role: "user", content: "ping" }],
+        max_tokens: 1,
+        stream: false,
+      }),
+      signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+    });
+    void res.body?.cancel();
+    if (res.ok) {
+      return { ok: true, status: res.status, resolved_url: url };
+    }
+    return {
+      ok: false,
+      status: res.status,
+      resolved_url: url,
+      error_class: "http_error",
+      hint: hintForStatus(res.status),
+    };
+  } catch (err) {
+    const isTimeout = err instanceof Error && err.name === "TimeoutError";
+    log.info(
+      { url, error: err instanceof Error ? err.message : String(err) },
+      "Endpoint probe failed to reach the endpoint",
+    );
+    return {
+      ok: false,
+      resolved_url: url,
+      error_class: isTimeout ? "timeout" : "network",
+      hint: isTimeout
+        ? `The endpoint did not respond within ${PROBE_TIMEOUT_MS / 1000}s for a test request.`
+        : `Could not reach the endpoint for a test request: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}

--- a/assistant/src/providers/inference/endpoint-probe.ts
+++ b/assistant/src/providers/inference/endpoint-probe.ts
@@ -4,7 +4,7 @@
  * A wrong base path (e.g. NVIDIA without `/v1`) otherwise stays invisible
  * until the first chat turn fails with an opaque provider 404. The probe
  * fires one minimal chat-completions request against the stored endpoint and
- * reports the outcome as a non-blocking hint — the save always succeeds.
+ * reports the outcome as a non-blocking hint. The save always succeeds.
  */
 
 import { z } from "zod";
@@ -33,10 +33,10 @@ export type EndpointCheck = z.infer<typeof EndpointCheckSchema>;
 
 function hintForStatus(status: number): string {
   if (status === 404) {
-    return "The endpoint returned 404 for a test request — check the base path for this provider (e.g. NVIDIA needs /v1, OpenRouter needs /api/v1). Some providers gate requests behind auth, so this may be a false alarm.";
+    return "The endpoint returned 404 for a test request: check the base path for this provider (e.g. NVIDIA needs /v1, OpenRouter needs /api/v1). Some providers gate requests behind auth, so this may be a false alarm.";
   }
   if (status === 401 || status === 403) {
-    return `The endpoint rejected the credential for a test request (HTTP ${status}) — check the API key.`;
+    return `The endpoint rejected the credential for a test request (HTTP ${status}). Check the API key.`;
   }
   return `The endpoint returned HTTP ${status} for a test request.`;
 }

--- a/assistant/src/runtime/routes/__tests__/inference-provider-connection-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/inference-provider-connection-routes.test.ts
@@ -565,6 +565,26 @@ describe("POST inference/provider-connections (create)", () => {
     ).rejects.toThrow(/belongs to a built-in provider/);
   });
 
+  test("attaches a failed endpoint_check when the custom base URL is unreachable", async () => {
+    // Port 1 is never listening, so the probe fails fast with a network error.
+    const result = (await call(
+      findHandler("inference_provider_connections_create"),
+      {
+        body: {
+          name: "probe-dead-endpoint",
+          provider: "openai-compatible",
+          auth: { type: "none" },
+          base_url: "http://127.0.0.1:1",
+          models: [{ id: "my-model" }],
+        },
+      },
+    )) as { endpoint_check?: { ok: boolean; resolved_url: string } };
+    expect(result.endpoint_check).toMatchObject({
+      ok: false,
+      resolved_url: "http://127.0.0.1:1/chat/completions",
+    });
+  });
+
   test("derives none auth for openai-compatible without a credential", async () => {
     const result = (await call(
       findHandler("inference_provider_connections_create"),

--- a/assistant/src/runtime/routes/inference-provider-connection-routes.ts
+++ b/assistant/src/runtime/routes/inference-provider-connection-routes.ts
@@ -70,7 +70,7 @@ const providerConnectionResponseSchema = ProviderConnectionSchema;
 
 /**
  * Create/update responses carry the save-time endpoint probe result for
- * connections with a custom base URL. Advisory only — a failed probe never
+ * connections with a custom base URL. Advisory only: a failed probe never
  * fails the save (some endpoints legitimately reject unauthenticated or
  * minimal requests); clients render `hint` as a warning.
  */

--- a/assistant/src/runtime/routes/inference-provider-connection-routes.ts
+++ b/assistant/src/runtime/routes/inference-provider-connection-routes.ts
@@ -39,6 +39,10 @@ import {
   MANAGED_CONNECTION_NAMES,
   updateConnection,
 } from "../../providers/inference/connections.js";
+import {
+  EndpointCheckSchema,
+  testInferenceConnection,
+} from "../../providers/inference/endpoint-probe.js";
 import { PROVIDER_CATALOG } from "../../providers/model-catalog.js";
 import {
   isVellumManagedConnection,
@@ -63,6 +67,16 @@ const log = getLogger("routes/inference-provider-connections");
 // ---------------------------------------------------------------------------
 
 const providerConnectionResponseSchema = ProviderConnectionSchema;
+
+/**
+ * Create/update responses carry the save-time endpoint probe result for
+ * connections with a custom base URL. Advisory only — a failed probe never
+ * fails the save (some endpoints legitimately reject unauthenticated or
+ * minimal requests); clients render `hint` as a warning.
+ */
+const savedConnectionResponseSchema = ProviderConnectionSchema.extend({
+  endpoint_check: EndpointCheckSchema.optional(),
+}).meta({ id: "SavedProviderConnection" });
 
 // ---------------------------------------------------------------------------
 // Custom provider field parsing (openai-compatible base_url + models)
@@ -428,7 +442,10 @@ async function handleCreateConnection({ body = {} }: RouteHandlerArgs) {
     throw new BadRequestError("Invalid auth configuration.");
   }
 
-  return result.connection;
+  const endpointCheck = await testInferenceConnection(result.connection);
+  return endpointCheck
+    ? { ...result.connection, endpoint_check: endpointCheck }
+    : result.connection;
 }
 
 async function handleUpdateConnection({
@@ -547,7 +564,10 @@ async function handleUpdateConnection({
     throw new BadRequestError("Invalid auth configuration.");
   }
 
-  return result.connection;
+  const endpointCheck = await testInferenceConnection(result.connection);
+  return endpointCheck
+    ? { ...result.connection, endpoint_check: endpointCheck }
+    : result.connection;
 }
 
 async function handleDeleteConnection({ pathParams = {} }: RouteHandlerArgs) {
@@ -751,7 +771,7 @@ export const ROUTES: RouteDefinition[] = [
       base_url: z.string().url().nullable().optional(),
       models: z.array(ConnectionModelSchema).nullable().optional(),
     }),
-    responseBody: providerConnectionResponseSchema,
+    responseBody: savedConnectionResponseSchema,
     responseStatus: "201",
     additionalResponses: {
       "400": { description: "Invalid provider or auth schema" },
@@ -779,7 +799,7 @@ export const ROUTES: RouteDefinition[] = [
       base_url: z.string().url().nullable().optional(),
       models: z.array(ConnectionModelSchema).nullable().optional(),
     }),
-    responseBody: providerConnectionResponseSchema,
+    responseBody: savedConnectionResponseSchema,
     additionalResponses: {
       "400": {
         description:

--- a/clients/web/src/domains/settings/ai/provider-create-form.tsx
+++ b/clients/web/src/domains/settings/ai/provider-create-form.tsx
@@ -41,6 +41,7 @@ import {
   parseCredentialRef,
   providerAllowsCustomBaseUrl,
   validationErrorMessage,
+  warnOnFailedEndpointCheck,
 } from "@/domains/settings/ai/provider-editor-constants";
 import { useSelectableConnectionProviders } from "@/domains/settings/ai/provider-availability";
 import { secretPlaceholder } from "@/domains/settings/ai/secret-placeholder";
@@ -323,6 +324,7 @@ export function ProviderCreateForm({
       // Single success confirmation for both the standalone and inline
       // surfaces; failures above already surface inline via `error` (no toast).
       toast.success(t("providerCreateForm.providerConnectedToast"));
+      warnOnFailedEndpointCheck(created);
       onCreated(created);
     } catch {
       setError(t("providerCreateForm.failedSaveProvider"));

--- a/clients/web/src/domains/settings/ai/provider-create-form.tsx
+++ b/clients/web/src/domains/settings/ai/provider-create-form.tsx
@@ -324,7 +324,7 @@ export function ProviderCreateForm({
       // Single success confirmation for both the standalone and inline
       // surfaces; failures above already surface inline via `error` (no toast).
       toast.success(t("providerCreateForm.providerConnectedToast"));
-      warnOnFailedEndpointCheck(created);
+      warnOnFailedEndpointCheck(created, t);
       onCreated(created);
     } catch {
       setError(t("providerCreateForm.failedSaveProvider"));

--- a/clients/web/src/domains/settings/ai/provider-editor-constants.ts
+++ b/clients/web/src/domains/settings/ai/provider-editor-constants.ts
@@ -1,3 +1,5 @@
+import { toast } from "@vellumai/design-library/components/toast";
+
 import { PROVIDER_DISPLAY_NAMES } from "@/assistant/llm-model-catalog";
 import type {
   Auth,
@@ -108,6 +110,20 @@ export function validationErrorMessage(
   return typeof message === "string" && message.length > 0
     ? message
     : undefined;
+}
+
+/**
+ * Surface a failed save-time endpoint probe as a warning toast. The daemon's
+ * `hint` is advisory server copy (like validation-envelope messages above) —
+ * the save itself succeeded, so this never blocks the flow.
+ */
+export function warnOnFailedEndpointCheck(connection: {
+  endpoint_check?: { ok: boolean; hint?: string };
+}): void {
+  const check = connection.endpoint_check;
+  if (check && !check.ok && check.hint) {
+    toast.warning(check.hint);
+  }
 }
 
 export function providerConnectionDisplayName(

--- a/clients/web/src/domains/settings/ai/provider-editor-constants.ts
+++ b/clients/web/src/domains/settings/ai/provider-editor-constants.ts
@@ -1,6 +1,7 @@
 import { toast } from "@vellumai/design-library/components/toast";
 
 import { PROVIDER_DISPLAY_NAMES } from "@/assistant/llm-model-catalog";
+import type { TFunction } from "@/i18n";
 import type {
   Auth,
   ConnectionProvider,
@@ -113,17 +114,30 @@ export function validationErrorMessage(
 }
 
 /**
- * Surface a failed save-time endpoint probe as a warning toast. The daemon's
- * `hint` is advisory server copy (like validation-envelope messages above) —
- * the save itself succeeded, so this never blocks the flow.
+ * Surface a failed save-time endpoint probe as a warning toast, mapping the
+ * probe's structured status onto catalog copy (the daemon's English `hint` is
+ * for non-localized surfaces like the CLI). The save itself succeeded, so
+ * this never blocks the flow.
  */
-export function warnOnFailedEndpointCheck(connection: {
-  endpoint_check?: { ok: boolean; hint?: string };
-}): void {
+export function warnOnFailedEndpointCheck(
+  connection: {
+    endpoint_check?: { ok: boolean; status?: number };
+  },
+  t: TFunction<"settings">,
+): void {
   const check = connection.endpoint_check;
-  if (check && !check.ok && check.hint) {
-    toast.warning(check.hint);
+  if (!check || check.ok) {
+    return;
   }
+  const key =
+    check.status === 404
+      ? ("providerEndpointCheck.notFound" as const)
+      : check.status === 401 || check.status === 403
+        ? ("providerEndpointCheck.unauthorized" as const)
+        : check.status !== undefined
+          ? ("providerEndpointCheck.httpError" as const)
+          : ("providerEndpointCheck.unreachable" as const);
+  toast.warning(t(key, { status: check.status }));
 }
 
 export function providerConnectionDisplayName(

--- a/clients/web/src/domains/settings/ai/provider-editor-content.tsx
+++ b/clients/web/src/domains/settings/ai/provider-editor-content.tsx
@@ -37,6 +37,7 @@ import {
   providerAllowsCustomBaseUrl,
   providerConnectionDisplayName,
   validationErrorMessage,
+  warnOnFailedEndpointCheck,
 } from "@/domains/settings/ai/provider-editor-constants";
 import { secretPlaceholder } from "@/domains/settings/ai/secret-placeholder";
 import { useProviderCredentialsList } from "@/domains/settings/ai/use-provider-credentials-list";
@@ -289,6 +290,7 @@ export function ProviderEditorContent({
         setError(t("providerEditorContent.emptyServerResponse"));
         return;
       }
+      warnOnFailedEndpointCheck(updated);
       onSave(updated);
     } catch {
       setError(t("providerEditorContent.failedSaveProvider"));

--- a/clients/web/src/domains/settings/ai/provider-editor-content.tsx
+++ b/clients/web/src/domains/settings/ai/provider-editor-content.tsx
@@ -290,7 +290,7 @@ export function ProviderEditorContent({
         setError(t("providerEditorContent.emptyServerResponse"));
         return;
       }
-      warnOnFailedEndpointCheck(updated);
+      warnOnFailedEndpointCheck(updated, t);
       onSave(updated);
     } catch {
       setError(t("providerEditorContent.failedSaveProvider"));

--- a/clients/web/src/i18n/locales/en/settings.json
+++ b/clients/web/src/i18n/locales/en/settings.json
@@ -828,6 +828,12 @@
     "saveChanges": "Save Changes",
     "saving": "Saving…"
   },
+  "providerEndpointCheck": {
+    "httpError": "The endpoint returned HTTP {{status}} for a test request.",
+    "notFound": "The endpoint returned 404 for a test request: check the base path for this provider (e.g. NVIDIA needs /v1, OpenRouter needs /api/v1). Some providers gate requests behind auth, so this may be a false alarm.",
+    "unauthorized": "The endpoint rejected the credential for a test request (HTTP {{status}}). Check the API key.",
+    "unreachable": "Could not reach the endpoint for a test request. Check the URL."
+  },
   "providerRow": {
     "actionsAriaLabel": "Actions for {displayName}",
     "customTag": "Custom",

--- a/clients/web/src/i18n/locales/en/settings.json
+++ b/clients/web/src/i18n/locales/en/settings.json
@@ -829,9 +829,9 @@
     "saving": "Saving…"
   },
   "providerEndpointCheck": {
-    "httpError": "The endpoint returned HTTP {{status}} for a test request.",
+    "httpError": "The endpoint returned HTTP {status} for a test request.",
     "notFound": "The endpoint returned 404 for a test request: check the base path for this provider (e.g. NVIDIA needs /v1, OpenRouter needs /api/v1). Some providers gate requests behind auth, so this may be a false alarm.",
-    "unauthorized": "The endpoint rejected the credential for a test request (HTTP {{status}}). Check the API key.",
+    "unauthorized": "The endpoint rejected the credential for a test request (HTTP {status}). Check the API key.",
     "unreachable": "Could not reach the endpoint for a test request. Check the URL."
   },
   "providerRow": {

--- a/clients/web/src/i18n/locales/es/settings.json
+++ b/clients/web/src/i18n/locales/es/settings.json
@@ -828,6 +828,12 @@
     "saveChanges": "Guardar cambios",
     "saving": "Guardando…"
   },
+  "providerEndpointCheck": {
+    "httpError": "El endpoint devolvió HTTP {{status}} en una solicitud de prueba.",
+    "notFound": "El endpoint devolvió 404 en una solicitud de prueba: revisa la ruta base de este proveedor (p. ej., NVIDIA necesita /v1 y OpenRouter /api/v1). Algunos proveedores exigen autenticación, así que puede ser una falsa alarma.",
+    "unauthorized": "El endpoint rechazó la credencial en una solicitud de prueba (HTTP {{status}}). Revisa la clave de API.",
+    "unreachable": "No se pudo conectar con el endpoint en una solicitud de prueba. Revisa la URL."
+  },
   "providerRow": {
     "actionsAriaLabel": "Acciones para {displayName}",
     "customTag": "Personalizado",

--- a/clients/web/src/i18n/locales/es/settings.json
+++ b/clients/web/src/i18n/locales/es/settings.json
@@ -829,9 +829,9 @@
     "saving": "Guardando…"
   },
   "providerEndpointCheck": {
-    "httpError": "El endpoint devolvió HTTP {{status}} en una solicitud de prueba.",
+    "httpError": "El endpoint devolvió HTTP {status} en una solicitud de prueba.",
     "notFound": "El endpoint devolvió 404 en una solicitud de prueba: revisa la ruta base de este proveedor (p. ej., NVIDIA necesita /v1 y OpenRouter /api/v1). Algunos proveedores exigen autenticación, así que puede ser una falsa alarma.",
-    "unauthorized": "El endpoint rechazó la credencial en una solicitud de prueba (HTTP {{status}}). Revisa la clave de API.",
+    "unauthorized": "El endpoint rechazó la credencial en una solicitud de prueba (HTTP {status}). Revisa la clave de API.",
     "unreachable": "No se pudo conectar con el endpoint en una solicitud de prueba. Revisa la URL."
   },
   "providerRow": {


### PR DESCRIPTION
## Summary
- Add `testInferenceConnection` (`assistant/src/providers/inference/endpoint-probe.ts`): fires one minimal chat-completions request (`max_tokens: 1`, "ping") against a connection's custom base URL with its resolved auth, returning `{ ok, status, resolved_url, error_class?, hint? }`. It skips when there is no base URL, no model id, or unresolvable auth.
- The daemon's create/update provider-connection routes attach the result as an optional `endpoint_check` field on the response (new `SavedProviderConnection` schema), so every client gets it from the single choke point. A failed probe never blocks the save.
- The CLI (`inference providers create|update`) prints a `Warning:` line, and the web provider create/edit forms show a localized warning toast when the probe fails. A 404 now says to check the base path (NVIDIA needs `/v1`, OpenRouter `/api/v1`) at save time instead of surfacing as an opaque `ProviderError` on the first chat message.

## Original prompt
A user configured a custom NVIDIA connection with a base URL missing the `/v1` path and only discovered it through repeated opaque `OpenAI-compatible API error (404)` failures at chat time, after a long Doctor diagnosis session. Messaging providers already validate at save via `testConnection`, but inference connections stored the base URL without ever hitting it. The ask: probe the endpoint with a minimal completions request when an inference connection is saved (CLI and web), surface the outcome as a non-blocking save-time warning with a base-path hint on 404, and unit-test the helper for the 404 and 200 cases. Same validate-at-save-not-at-send principle as ATL-1262.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uze8ARqExMzShDUmZjJoQc