### PR TITLE
feat(gateway): cross-check the Discord schemas against the official API types

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -373,6 +373,7 @@
         "@grammyjs/types": "4.0.0",
         "@slack/types": "2.22.0",
         "@types/bun": "1.3.9",
+        "discord-api-types": "0.38.53",
         "eslint": "10.0.0",
         "fast-check": "4.7.0",
         "knip": "5.83.1",
@@ -2272,6 +2273,8 @@
     "diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
 
     "dir-compare": ["dir-compare@4.2.0", "", { "dependencies": { "minimatch": "^3.0.5", "p-limit": "^3.1.0 " } }, "sha512-2xMCmOoMrdQIPHdsTawECdNPwlVFB9zGcz3kuhmBO6U3oU+UQjsue0i8ayLKpgBcm+hcXPMVSGUN9d+pvJ6+VQ=="],
+
+    "discord-api-types": ["discord-api-types@0.38.53", "", {}, "sha512-HL1zz/UuZ+bbJjA/X8Kbxx9gk8v9rJAbTeWRNYKmIdjwJ7EovjlHgoJTxcLpATfNJ+AonOtMdy3Y5MVIJAAd/A=="],
 
     "dmg-builder": ["dmg-builder@26.8.1", "", { "dependencies": { "app-builder-lib": "26.8.1", "builder-util": "26.8.1", "fs-extra": "^10.1.0", "iconv-lite": "^0.6.2", "js-yaml": "^4.1.0" }, "optionalDependencies": { "dmg-license": "^1.0.11" } }, "sha512-glMJgnTreo8CFINujtAhCgN96QAqApDMZ8Vl1r8f0QT8QprvC1UCltV4CcWj20YoIyLZx6IUskaJZ0NV8fokcg=="],
 

--- a/gateway/package.json
+++ b/gateway/package.json
@@ -55,6 +55,7 @@
     "@grammyjs/types": "4.0.0",
     "@slack/types": "2.22.0",
     "@types/bun": "1.3.9",
+    "discord-api-types": "0.38.53",
     "eslint": "10.0.0",
     "fast-check": "4.7.0",
     "knip": "5.83.1",

--- a/gateway/src/discord/message-schemas.ts
+++ b/gateway/src/discord/message-schemas.ts
@@ -19,7 +19,20 @@
  * https://docs.discord.com/developers/events/gateway-events
  */
 
+import type {
+  APIThreadChannel,
+  GatewayHelloData,
+  GatewayMessageCreateDispatchData,
+  GatewayReadyDispatchData,
+  GatewayReceivePayload,
+} from "discord-api-types/v10";
 import { z } from "zod";
+
+import type {
+  Expect,
+  ModeledKeysAreOfficial,
+  OfficialValueSatisfiesOurs,
+} from "../webhook-crosscheck.js";
 
 const optionalString = () => z.string().optional().catch(undefined);
 const optionalNumber = () => z.number().optional().catch(undefined);
@@ -126,3 +139,63 @@ export const DiscordMessageCreateSchema = z.object({
     .catch(undefined),
 });
 export type DiscordMessageCreate = z.infer<typeof DiscordMessageCreateSchema>;
+
+// ---------------------------------------------------------------------------
+// Compile-time cross-check against the official Discord API types.
+//
+// `discord-api-types` is a types-only dev dependency: it contributes nothing at
+// runtime (the `import type` above is erased from the build) and the schemas
+// above stay the sole runtime validators. Its only job is to make TypeScript
+// prove, via the shared `webhook-crosscheck` helpers, that a drift from the
+// real Gateway shape fails `tsc` instead of silently mis-parsing a live frame.
+//
+// This matters more here than on the other channels, because two of the fields
+// below fail CLOSED on a malformed value: `guild_id` decides whether a message
+// is a DM, and `author.bot` is the one classifier standing between the
+// admission gate and a bot reply loop. A field-name typo in either would parse
+// to the tolerant branch forever and never announce itself.
+type DiscordMessageAuthor = NonNullable<
+  z.infer<typeof DiscordMessageCreateSchema>["author"]
+>;
+
+type _DiscordApiCrossChecks = [
+  Expect<
+    ModeledKeysAreOfficial<
+      z.infer<typeof DiscordGatewayPayloadSchema>,
+      GatewayReceivePayload
+    >
+  >,
+  Expect<
+    ModeledKeysAreOfficial<z.infer<typeof DiscordHelloSchema>, GatewayHelloData>
+  >,
+  Expect<
+    OfficialValueSatisfiesOurs<
+      z.infer<typeof DiscordHelloSchema>,
+      GatewayHelloData
+    >
+  >,
+  Expect<
+    ModeledKeysAreOfficial<
+      z.infer<typeof DiscordReadySchema>,
+      GatewayReadyDispatchData
+    >
+  >,
+  Expect<
+    ModeledKeysAreOfficial<
+      z.infer<typeof DiscordThreadSchema>,
+      APIThreadChannel
+    >
+  >,
+  Expect<
+    ModeledKeysAreOfficial<
+      z.infer<typeof DiscordMessageCreateSchema>,
+      GatewayMessageCreateDispatchData
+    >
+  >,
+  Expect<
+    ModeledKeysAreOfficial<
+      DiscordMessageAuthor,
+      GatewayMessageCreateDispatchData["author"]
+    >
+  >,
+];


### PR DESCRIPTION
## TL;DR

Discord was the only channel with no official type package. It now has the same compile-time cross-check Slack and Telegram already use. 77 lines, no runtime change.

Part of LUM-3356, and the last item before the `send` narrowing.

## Why Discord specifically

Slack pairs its tolerant ingress schemas with a check against `@slack/types`; Telegram against `@grammyjs/types`. Both are types-only dev dependencies whose import is erased from the build, and in both cases the zod schemas stay the sole runtime validators. Discord had nothing, on the newest and least-exercised channel.

`discord-api-types` is the de facto standard (what discord.js is built on), MIT, pinned exact.

## Why this is worth more here than on the other two

Two fields in `discord/message-schemas.ts` fail **closed** on a malformed value, and both are load-bearing for admission:

* `guild_id` is the only thing that marks a message as a DM, and a DM is admitted without an allow-list entry and without a mention.
* `author.bot` is the one classifier standing between the admission gate and a bot reply loop.

A field-name typo in either does not throw. It parses to the tolerant branch forever, silently, and the comments in that file already explain how much rides on them. This is the check that makes such a typo fail the build.

**Verified it actually catches that**, rather than assuming: renaming `guild_id` to `guilld_id` fails `tsc` with a violated `Expect`, and restoring it goes clean. A cross-check that passes vacuously would be worse than none.

## One thing the check caught immediately

Pointing the thread schema at `APIChannel` failed, correctly. `APIChannel` is a union over every channel kind and a DM channel has no `parent_id`, so the modelled key is not a key on every member. A thread is `APIThreadChannel`, which is what the check now uses.

## Why it is safe

The import is `import type` only and erased at build. No runtime behaviour changes, no schema changes, no new validation. Gateway and assistant both typecheck clean; lint and the pinned prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41012" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->