### PR TITLE
Validate inference profiles at save time

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -14929,6 +14929,38 @@ paths:
           description: Invalid fields, a profile that cannot serve requests, or attempt to edit a managed profile
         "404":
           description: Profile not found
+  /v1/inference/profiles/{name}/validate:
+    post:
+      operationId: inference_profiles_by_name_validate_post
+      summary: Probe a saved profile with one minimal request
+      description:
+        "Dispatch one minimal test request through the named profile's resolved model and connection, and classify
+        any failure by which object the user should fix (the profile vs its provider connection). Advisory: the probe
+        never mutates the profile. Returns a null check when there is no verdict to give (missing, disabled, managed, or
+        routing-identity profiles, or a probe timeout). The probe spends one tiny request on the profile's own key."
+      tags:
+        - inference
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  check:
+                    anyOf:
+                      - $ref: "#/components/schemas/InferenceProfileCheck"
+                      - type: "null"
+                required:
+                  - check
+                additionalProperties: false
   /v1/inference/provider-connections:
     get:
       operationId: inference_providerconnections_get
@@ -35566,6 +35598,29 @@ components:
         - name
         - entry
         - availability
+      additionalProperties: false
+    InferenceProfileCheck:
+      type: object
+      properties:
+        ok:
+          type: boolean
+        blame:
+          type: string
+          enum:
+            - profile
+            - provider
+            - transient
+            - unknown
+        reason:
+          type: string
+        detail:
+          type: string
+        connection:
+          type: string
+        message:
+          type: string
+      required:
+        - ok
       additionalProperties: false
     ProviderConnection:
       type: object

--- a/assistant/src/api/constants/profile-config-validation.ts
+++ b/assistant/src/api/constants/profile-config-validation.ts
@@ -4,12 +4,11 @@
  * (the output budget consumes the model's entire context window, or exceeds
  * its output cap) at save time instead of on the first chat message.
  *
- * Only judges what is knowable offline: fires when the profile explicitly
- * sets `maxTokens` AND the catalog declares a limit for the model. Unlisted
- * models are covered by the live save-time probe instead
- * (`profile-probe.ts`). Note `clampMaxTokensToModelCap` in
- * `default-profile-catalog.ts` protects only code-owned default profiles;
- * user-authored profiles send their `maxTokens` verbatim.
+ * Shared surface: the daemon's profile write routes enforce it as a blocking
+ * error, and the web profile editor mirrors the same judgment before its
+ * generic config PATCH, so the two paths cannot drift. Only fires when both
+ * sides of a judgment are known; unlisted models are covered by the live
+ * save-time probe instead.
  */
 
 /**
@@ -20,6 +19,8 @@ export const MIN_INPUT_RESERVE_TOKENS = 4096;
 
 export interface ProfileConfigIssue {
   field: "maxTokens";
+  /** Which judgment fired, so clients can compose surface-specific copy. */
+  code: "over_output_cap" | "no_input_room";
   message: string;
 }
 
@@ -35,6 +36,7 @@ export function validateInferenceProfileConfig(args: {
   if (modelMaxOutputTokens !== undefined && maxTokens > modelMaxOutputTokens) {
     return {
       field: "maxTokens",
+      code: "over_output_cap",
       message:
         `maxTokens (${maxTokens}) exceeds the model's maximum output of ` +
         `${modelMaxOutputTokens} tokens. Requests would be rejected upstream; ` +
@@ -47,6 +49,7 @@ export function validateInferenceProfileConfig(args: {
   ) {
     return {
       field: "maxTokens",
+      code: "no_input_room",
       message:
         `maxTokens (${maxTokens}) reserves the entire ${modelContextWindowTokens}-token ` +
         `context window for output, leaving no room for your messages. ` +

--- a/assistant/src/api/index.ts
+++ b/assistant/src/api/index.ts
@@ -152,6 +152,11 @@ export {
   REOPENABLE_DOCUMENT_MUTATION_TOOL_NAMES,
 } from "./constants/document-tools.js";
 export {
+  MIN_INPUT_RESERVE_TOKENS,
+  type ProfileConfigIssue,
+  validateInferenceProfileConfig,
+} from "./constants/profile-config-validation.js";
+export {
   SSE_REPLAY_RING_AGE_LIMIT_MS,
   SSE_REPLAY_RING_COUNT_LIMIT,
 } from "./constants/sse-replay.js";

--- a/assistant/src/cli/commands/__tests__/inference-profiles.test.ts
+++ b/assistant/src/cli/commands/__tests__/inference-profiles.test.ts
@@ -11,6 +11,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { Command } from "commander";
 
 let lastIpcCall: { method: string; params?: any } | null = null;
+let ipcCalls: { method: string; params?: any }[] = [];
 let mockIpcResult: { ok: boolean; result?: unknown; error?: string } = {
   ok: true,
   result: {},
@@ -19,6 +20,7 @@ let mockIpcResult: { ok: boolean; result?: unknown; error?: string } = {
 mock.module("../../../ipc/cli-client.js", () => ({
   cliIpcCall: async (method: string, params?: Record<string, unknown>) => {
     lastIpcCall = { method, params };
+    ipcCalls.push({ method, params });
     return mockIpcResult;
   },
 }));
@@ -36,6 +38,7 @@ const { inferenceHelp } = await import("../inference.help.js");
 
 beforeEach(() => {
   lastIpcCall = null;
+  ipcCalls = [];
   mockIpcResult = { ok: true, result: {} };
   process.exitCode = 0;
 });
@@ -136,8 +139,13 @@ describe("profiles create", () => {
       "--allow-unlisted",
       "--allow-unavailable",
     ]);
-    expect(lastIpcCall?.method).toBe("inference_profiles_create");
-    expect(lastIpcCall?.params?.body).toEqual({
+    const createCall = ipcCalls.find(
+      (c) => c.method === "inference_profiles_create",
+    );
+    expect(createCall).toBeDefined();
+    // The save is followed by the advisory probe call.
+    expect(ipcCalls.at(-1)?.method).toBe("inference_profiles_validate");
+    expect(createCall?.params?.body).toEqual({
       name: "p",
       provider: "anthropic",
       model: "claude-opus-4-8",
@@ -243,11 +251,15 @@ describe("profiles update", () => {
       result: { ok: true, name: "p", entry: {}, warnings: [] },
     };
     await run(["profiles", "update", "p", "--effort", "low"]);
-    expect(lastIpcCall?.method).toBe("inference_profiles_update");
-    expect(lastIpcCall?.params).toEqual({
+    const updateCall = ipcCalls.find(
+      (c) => c.method === "inference_profiles_update",
+    );
+    expect(updateCall?.params).toEqual({
       pathParams: { name: "p" },
       body: { effort: "low" },
     });
+    // The save is followed by the advisory probe call.
+    expect(ipcCalls.at(-1)?.method).toBe("inference_profiles_validate");
   });
 
   test("refuses an empty update", async () => {

--- a/assistant/src/cli/commands/inference-profiles.ts
+++ b/assistant/src/cli/commands/inference-profiles.ts
@@ -37,6 +37,29 @@ interface ProfileWriteResult {
   warnings: string[];
   /** Live-call command the daemon suggests for verifying the written profile. */
   verify?: string;
+  /** Save-time probe verdict (null = no verdict); absent when the daemon predates the route. */
+  check?: ProfileCheck | null;
+}
+
+interface ProfileCheck {
+  ok: boolean;
+  blame?: string;
+  message?: string;
+}
+
+/**
+ * Probe the just-written profile with one minimal request through the
+ * daemon's validate route. Advisory: any transport or route error (e.g. a
+ * daemon predating the route) yields undefined and the save flow proceeds.
+ */
+async function fetchProfileCheck(
+  name: string,
+): Promise<ProfileCheck | null | undefined> {
+  const probe = await cliIpcCall<{ check: ProfileCheck | null }>(
+    "inference_profiles_validate",
+    { pathParams: { name } },
+  );
+  return probe.ok ? probe.result!.check : undefined;
 }
 
 type WriteFlags = {
@@ -122,6 +145,9 @@ function printWriteResult(
   }
   for (const warning of result.warnings) {
     writeLine(`warning: ${warning}`);
+  }
+  if (result.check && !result.check.ok && result.check.message) {
+    writeLine(`warning: ${result.check.message}`);
   }
   writeLine(`profile ${result.name} ${verb}`);
   if (result.verify) {
@@ -219,7 +245,12 @@ export function attachProfilesSubcommand(inference: Command): void {
         writeCliError(ipcResult.error ?? "Unknown error", opts.json);
         return;
       }
-      printWriteResult("created", ipcResult.result!, opts.json);
+      const check = await fetchProfileCheck(name);
+      printWriteResult(
+        "created",
+        { ...ipcResult.result!, ...(check !== undefined ? { check } : {}) },
+        opts.json,
+      );
     },
   );
 
@@ -246,7 +277,12 @@ export function attachProfilesSubcommand(inference: Command): void {
         writeCliError(ipcResult.error ?? "Unknown error", opts.json);
         return;
       }
-      printWriteResult("updated", ipcResult.result!, opts.json);
+      const check = await fetchProfileCheck(name);
+      printWriteResult(
+        "updated",
+        { ...ipcResult.result!, ...(check !== undefined ? { check } : {}) },
+        opts.json,
+      );
     },
   );
 

--- a/assistant/src/config/__tests__/profile-materialization.test.ts
+++ b/assistant/src/config/__tests__/profile-materialization.test.ts
@@ -36,6 +36,23 @@ const fullDefault = LLMConfigBase.parse({
 });
 
 describe("completeCustomProfile", () => {
+  test("clamps a filled maxTokens to the model's catalog output cap", () => {
+    const completed = completeCustomProfile(fullDefault, {
+      provider: "ollama",
+      model: "llama3.2",
+    });
+    expect(completed.maxTokens).toBe(4096);
+  });
+
+  test("never clamps an explicit maxTokens", () => {
+    const completed = completeCustomProfile(fullDefault, {
+      provider: "ollama",
+      model: "llama3.2",
+      maxTokens: 64000,
+    });
+    expect(completed.maxTokens).toBe(64000);
+  });
+
   test("inherits omitted scalar fields from the default", () => {
     const completed = completeCustomProfile(fullDefault, {
       model: "claude-fable-5",

--- a/assistant/src/config/__tests__/profile-materialization.test.ts
+++ b/assistant/src/config/__tests__/profile-materialization.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, mock, test } from "bun:test";
 // kind, so the tests control the row store directly.
 const connectionRows = new Map<string, { name: string; provider: string }>([
   ["anthropic-personal", { name: "anthropic-personal", provider: "anthropic" }],
+  ["local-ollama", { name: "local-ollama", provider: "ollama" }],
 ]);
 mock.module("../../persistence/db-connection.js", () => ({
   getDb: () => ({}),
@@ -39,6 +40,14 @@ describe("completeCustomProfile", () => {
   test("clamps a filled maxTokens to the model's catalog output cap", () => {
     const completed = completeCustomProfile(fullDefault, {
       provider: "ollama",
+      model: "llama3.2",
+    });
+    expect(completed.maxTokens).toBe(4096);
+  });
+
+  test("clamps a filled maxTokens for an entry-name provider via its row's kind", () => {
+    const completed = completeCustomProfile(fullDefault, {
+      provider: "local-ollama",
       model: "llama3.2",
     });
     expect(completed.maxTokens).toBe(4096);

--- a/assistant/src/config/profile-materialization.ts
+++ b/assistant/src/config/profile-materialization.ts
@@ -1,4 +1,5 @@
 import { getDb } from "../persistence/db-connection.js";
+import { catalogProviderForProfile } from "../providers/connection-resolution.js";
 import { ROUTING_IDENTITY_PROVIDERS } from "../providers/inference/auth.js";
 import { getConnection } from "../providers/inference/connections.js";
 import {
@@ -115,7 +116,14 @@ export function completeCustomProfile(
     completed.provider !== undefined &&
     completed.model !== undefined
   ) {
-    const cap = catalogMaxOutputTokens(completed.provider, completed.model);
+    const catalogProvider = catalogProviderForProfile(
+      completed.provider,
+      completed.model,
+    );
+    const cap =
+      catalogProvider !== null
+        ? catalogMaxOutputTokens(catalogProvider, completed.model)
+        : undefined;
     if (cap !== undefined && completed.maxTokens > cap) {
       completed.maxTokens = cap;
     }

--- a/assistant/src/config/profile-materialization.ts
+++ b/assistant/src/config/profile-materialization.ts
@@ -2,6 +2,7 @@ import { getDb } from "../persistence/db-connection.js";
 import { ROUTING_IDENTITY_PROVIDERS } from "../providers/inference/auth.js";
 import { getConnection } from "../providers/inference/connections.js";
 import {
+  catalogMaxOutputTokens,
   getCatalogProviderForModel,
   isModelInCatalog,
 } from "../providers/model-catalog.js";
@@ -97,6 +98,26 @@ export function completeCustomProfile(
     const implied = getCatalogProviderForModel(profile.model);
     if (implied !== undefined) {
       completed.provider = implied as ProfileEntry["provider"];
+    }
+  }
+
+  // A FILLED maxTokens expresses no user preference, so it is clamped to the
+  // model's catalog output cap — an over-cap fill (e.g. 64000 onto a
+  // 4096-cap model) would make every request fail upstream. Runs after the
+  // provider implication above so the cap is read from the provider the
+  // profile actually dispatches with. An explicit profile value is never
+  // touched, and models the catalog does not know keep the default (the
+  // save-time probe covers those). Mirrors `clampMaxTokensToModelCap` for
+  // the code-owned default profiles.
+  if (
+    profile.maxTokens === undefined &&
+    completed.maxTokens !== undefined &&
+    completed.provider !== undefined &&
+    completed.model !== undefined
+  ) {
+    const cap = catalogMaxOutputTokens(completed.provider, completed.model);
+    if (cap !== undefined && completed.maxTokens > cap) {
+      completed.maxTokens = cap;
     }
   }
 

--- a/assistant/src/providers/connection-resolution.ts
+++ b/assistant/src/providers/connection-resolution.ts
@@ -41,7 +41,10 @@ import {
   describeSubscriptionModelIncompatibility,
   isConnectionCompatibleWithModel,
 } from "./connection-model-compat.js";
-import { VALID_CONNECTION_PROVIDERS } from "./inference/auth.js";
+import {
+  ROUTING_IDENTITY_PROVIDERS,
+  VALID_CONNECTION_PROVIDERS,
+} from "./inference/auth.js";
 import {
   canonicalVellumConnection,
   getConnection,
@@ -191,6 +194,25 @@ export function resolveEntryProviderKind(
 ): string | null {
   const entryName = resolveEntryConnectionName(provider);
   return entryName ? connectionProviderKind(entryName, model) : null;
+}
+
+/**
+ * The catalog provider whose model limits judge a profile's (provider,
+ * model) pair: routing identities translate to their concrete upstream
+ * (chatgpt serves the OpenAI catalog; a vellum profile's bare native model
+ * names its managed owner), and an entry-name label resolves to its row's
+ * dispatchable kind. Null when no upstream is derivable (the pair stays
+ * unjudged). Shared by the profile-route budget validation and profile
+ * materialization so the two cannot drift.
+ */
+export function catalogProviderForProfile(
+  provider: string,
+  model: string,
+): string | null {
+  if (ROUTING_IDENTITY_PROVIDERS.has(provider)) {
+    return provider === "chatgpt" ? "openai" : getManagedUpstream(model);
+  }
+  return resolveEntryProviderKind(provider, model) ?? provider;
 }
 
 /**

--- a/assistant/src/providers/inference/__tests__/profile-config-validation.test.ts
+++ b/assistant/src/providers/inference/__tests__/profile-config-validation.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+
+import { validateInferenceProfileConfig } from "../profile-config-validation.js";
+
+describe("validateInferenceProfileConfig", () => {
+  test("rejects an output budget that consumes the whole context window", () => {
+    const issue = validateInferenceProfileConfig({
+      maxTokens: 300000,
+      modelContextWindowTokens: 300000,
+    });
+    expect(issue?.field).toBe("maxTokens");
+    expect(issue?.message).toContain("context window");
+  });
+
+  test("passes an output budget that leaves input room", () => {
+    expect(
+      validateInferenceProfileConfig({
+        maxTokens: 8000,
+        modelContextWindowTokens: 300000,
+      }),
+    ).toBeNull();
+  });
+
+  test("rejects an output budget over the model's output cap", () => {
+    const issue = validateInferenceProfileConfig({
+      maxTokens: 100000,
+      modelMaxOutputTokens: 64000,
+      modelContextWindowTokens: 200000,
+    });
+    expect(issue?.message).toContain("maximum output");
+  });
+
+  test("silent when either side of the judgment is unknown", () => {
+    expect(validateInferenceProfileConfig({ maxTokens: 300000 })).toBeNull();
+    expect(
+      validateInferenceProfileConfig({ modelContextWindowTokens: 300000 }),
+    ).toBeNull();
+  });
+});

--- a/assistant/src/providers/inference/__tests__/profile-config-validation.test.ts
+++ b/assistant/src/providers/inference/__tests__/profile-config-validation.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { validateInferenceProfileConfig } from "../profile-config-validation.js";
+import { validateInferenceProfileConfig } from "../../../api/constants/profile-config-validation.js";
 
 describe("validateInferenceProfileConfig", () => {
   test("rejects an output budget that consumes the whole context window", () => {

--- a/assistant/src/providers/inference/__tests__/profile-probe-classify.test.ts
+++ b/assistant/src/providers/inference/__tests__/profile-probe-classify.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+
+import { ProviderError } from "../../../util/errors.js";
+import { classifyProbeFailure } from "../profile-probe.js";
+
+describe("classifyProbeFailure", () => {
+  test("blames the provider connection for a rejected credential", () => {
+    const result = classifyProbeFailure(
+      new ProviderError("401 invalid api key", "openai-compatible", 401, {
+        reason: "invalid_credentials",
+      }),
+    );
+    expect(result.blame).toBe("provider");
+    expect(result.reason).toBe("invalid_credentials");
+  });
+
+  test("blames the profile for an unknown model", () => {
+    const result = classifyProbeFailure(
+      new ProviderError("model does not exist", "openai-compatible", 404, {
+        reason: "model_not_found",
+      }),
+    );
+    expect(result.blame).toBe("profile");
+  });
+
+  test("blames the profile for an impossible token budget", () => {
+    const result = classifyProbeFailure(
+      new ProviderError(
+        "ContextWindowExceededError: maximum context length is 300000 tokens",
+        "openai-compatible",
+        400,
+        { reason: "context_overflow" },
+      ),
+    );
+    expect(result.blame).toBe("profile");
+    expect(result.detail).toContain("300000");
+  });
+
+  test("marks rate limits as transient", () => {
+    expect(
+      classifyProbeFailure(
+        new ProviderError("429", "openai", 429, { reason: "rate_limited" }),
+      ).blame,
+    ).toBe("transient");
+  });
+
+  test("falls back to unknown for unclassified errors", () => {
+    expect(classifyProbeFailure(new Error("boom")).blame).toBe("unknown");
+    expect(classifyProbeFailure(new Error("boom")).detail).toBe("boom");
+  });
+});

--- a/assistant/src/providers/inference/__tests__/profile-probe-classify.test.ts
+++ b/assistant/src/providers/inference/__tests__/profile-probe-classify.test.ts
@@ -44,15 +44,19 @@ describe("classifyProbeFailure", () => {
     ).toBe("transient");
   });
 
-  test("blames the provider for unwrapped transport failures", () => {
-    // The OpenAI SDK's APIConnectionError reaches the probe without a
-    // ProviderError wrapper or semantic reason.
-    const result = classifyProbeFailure(new Error("Connection error."));
+  test("blames the provider for transport failures", () => {
+    // The adapters stamp reason network_error on SDK connection errors
+    // (normalizeOpenAIAPIError), so the probe classifies by reason alone.
+    const result = classifyProbeFailure(
+      new ProviderError(
+        "OpenAI-compatible API error (unknown status): Connection error.",
+        "openai-compatible",
+        undefined,
+        { reason: "network_error" },
+      ),
+    );
     expect(result.blame).toBe("provider");
     expect(result.reason).toBe("network_error");
-    expect(classifyProbeFailure(new Error("fetch failed")).blame).toBe(
-      "provider",
-    );
   });
 
   test("falls back to unknown for unclassified errors", () => {

--- a/assistant/src/providers/inference/__tests__/profile-probe-classify.test.ts
+++ b/assistant/src/providers/inference/__tests__/profile-probe-classify.test.ts
@@ -44,6 +44,17 @@ describe("classifyProbeFailure", () => {
     ).toBe("transient");
   });
 
+  test("blames the provider for unwrapped transport failures", () => {
+    // The OpenAI SDK's APIConnectionError reaches the probe without a
+    // ProviderError wrapper or semantic reason.
+    const result = classifyProbeFailure(new Error("Connection error."));
+    expect(result.blame).toBe("provider");
+    expect(result.reason).toBe("network_error");
+    expect(classifyProbeFailure(new Error("fetch failed")).blame).toBe(
+      "provider",
+    );
+  });
+
   test("falls back to unknown for unclassified errors", () => {
     expect(classifyProbeFailure(new Error("boom")).blame).toBe("unknown");
     expect(classifyProbeFailure(new Error("boom")).detail).toBe("boom");

--- a/assistant/src/providers/inference/endpoint-probe.ts
+++ b/assistant/src/providers/inference/endpoint-probe.ts
@@ -15,8 +15,11 @@ import { resolveAuth } from "./resolve-auth.js";
 
 const log = getLogger("inference-endpoint-probe");
 
-/** Matches the API-key validation timeout so a dead host can't hang the save. */
-const PROBE_TIMEOUT_MS = 10_000;
+/**
+ * Bound on every save-path probe (this endpoint probe and the profile probe)
+ * so a dead host can't hang a save. Matches the API-key validation timeout.
+ */
+export const PROBE_TIMEOUT_MS = 10_000;
 
 export const EndpointCheckSchema = z
   .object({

--- a/assistant/src/providers/inference/profile-config-validation.ts
+++ b/assistant/src/providers/inference/profile-config-validation.ts
@@ -1,0 +1,57 @@
+/**
+ * Static sanity check for a profile's explicit token budget against the
+ * model's catalog limits. Catches configurations that can never dispatch
+ * (the output budget consumes the model's entire context window, or exceeds
+ * its output cap) at save time instead of on the first chat message.
+ *
+ * Only judges what is knowable offline: fires when the profile explicitly
+ * sets `maxTokens` AND the catalog declares a limit for the model. Unlisted
+ * models are covered by the live save-time probe instead
+ * (`profile-probe.ts`). Note `clampMaxTokensToModelCap` in
+ * `default-profile-catalog.ts` protects only code-owned default profiles;
+ * user-authored profiles send their `maxTokens` verbatim.
+ */
+
+/**
+ * Input room a profile must leave when its output budget is judged against
+ * the model's total context window.
+ */
+export const MIN_INPUT_RESERVE_TOKENS = 4096;
+
+export interface ProfileConfigIssue {
+  field: "maxTokens";
+  message: string;
+}
+
+export function validateInferenceProfileConfig(args: {
+  maxTokens?: number;
+  modelMaxOutputTokens?: number;
+  modelContextWindowTokens?: number;
+}): ProfileConfigIssue | null {
+  const { maxTokens, modelMaxOutputTokens, modelContextWindowTokens } = args;
+  if (maxTokens === undefined) {
+    return null;
+  }
+  if (modelMaxOutputTokens !== undefined && maxTokens > modelMaxOutputTokens) {
+    return {
+      field: "maxTokens",
+      message:
+        `maxTokens (${maxTokens}) exceeds the model's maximum output of ` +
+        `${modelMaxOutputTokens} tokens. Requests would be rejected upstream; ` +
+        `reduce maxTokens to ${modelMaxOutputTokens} or less.`,
+    };
+  }
+  if (
+    modelContextWindowTokens !== undefined &&
+    maxTokens >= modelContextWindowTokens - MIN_INPUT_RESERVE_TOKENS
+  ) {
+    return {
+      field: "maxTokens",
+      message:
+        `maxTokens (${maxTokens}) reserves the entire ${modelContextWindowTokens}-token ` +
+        `context window for output, leaving no room for your messages. ` +
+        `Reduce maxTokens (e.g. 8000) so input fits.`,
+    };
+  }
+  return null;
+}

--- a/assistant/src/providers/inference/profile-probe.ts
+++ b/assistant/src/providers/inference/profile-probe.ts
@@ -126,21 +126,6 @@ export async function probeInferenceProfile(
   if (!entry || entry.status === "disabled" || entry.source === "managed") {
     return null;
   }
-  const provider = typeof entry.provider === "string" ? entry.provider : "";
-  if (ROUTING_IDENTITY_PROVIDERS.has(provider)) {
-    return null;
-  }
-  const connection =
-    typeof entry.provider_connection === "string"
-      ? entry.provider_connection
-      : provider || undefined;
-  // A legacy profile can declare a concrete provider while staying bound to
-  // a platform-billed connection row (e.g. the canonical vellum connection);
-  // the row's auth is the billing fact, so it gates the probe too.
-  const boundRow = connection ? getConnection(getDb(), connection) : null;
-  if (boundRow?.auth.type === "platform") {
-    return null;
-  }
 
   const selectionSeed = crypto.randomUUID();
 
@@ -170,6 +155,29 @@ export async function probeInferenceProfile(
       detail,
       message: checkMessage({ blame: "profile", detail }),
     };
+  }
+
+  // Billing guards run on the CONCRETE entry the resolver selected — for a
+  // mix that is the expanded arm, not the mix record (which carries no
+  // provider or connection of its own) — so a probe can never dispatch a
+  // managed or platform-billed route the raw entry hid.
+  const dispatchEntry =
+    (winner.entry as Record<string, unknown> | null) ?? entry;
+  const provider =
+    typeof dispatchEntry.provider === "string" ? dispatchEntry.provider : "";
+  if (ROUTING_IDENTITY_PROVIDERS.has(provider)) {
+    return null;
+  }
+  const connection =
+    typeof dispatchEntry.provider_connection === "string"
+      ? dispatchEntry.provider_connection
+      : provider || undefined;
+  // A legacy profile can declare a concrete provider while staying bound to
+  // a platform-billed connection row (e.g. the canonical vellum connection);
+  // the row's auth is the billing fact, so it gates the probe too.
+  const boundRow = connection ? getConnection(getDb(), connection) : null;
+  if (boundRow?.auth.type === "platform") {
+    return null;
   }
 
   const timeout = createTimeout(PROBE_TIMEOUT_MS);

--- a/assistant/src/providers/inference/profile-probe.ts
+++ b/assistant/src/providers/inference/profile-probe.ts
@@ -71,6 +71,14 @@ const TRANSIENT_BLAME_REASONS: ReadonlySet<ProviderErrorReason> = new Set([
  * parameter and token-budget rejections) blame the profile; credential,
  * billing, and reachability reasons blame the provider connection.
  */
+/**
+ * Transport failures the SDKs surface without a semantic reason (e.g. the
+ * OpenAI client's APIConnectionError, message "Connection error."). Matched
+ * on the error text since no adapter wraps these into a ProviderError.
+ */
+const CONNECTION_FAILURE_PATTERN =
+  /connection (error|refused|timed out)|fetch failed|econnrefused|etimedout|enotfound|socket|network/i;
+
 export function classifyProbeFailure(err: unknown): {
   blame: ProfileCheckBlame;
   reason?: string;
@@ -78,6 +86,12 @@ export function classifyProbeFailure(err: unknown): {
 } {
   const detail = err instanceof Error ? err.message : String(err);
   if (!(err instanceof ProviderError) || err.reason === undefined) {
+    if (
+      CONNECTION_FAILURE_PATTERN.test(detail) ||
+      (err instanceof Error && err.name === "APIConnectionError")
+    ) {
+      return { blame: "provider", reason: "network_error", detail };
+    }
     return { blame: "unknown", detail };
   }
   if (PROVIDER_BLAME_REASONS.has(err.reason)) {

--- a/assistant/src/providers/inference/profile-probe.ts
+++ b/assistant/src/providers/inference/profile-probe.ts
@@ -1,0 +1,212 @@
+/**
+ * Live save-time probe for a user-authored inference profile: one minimal
+ * request dispatched through the profile's own resolved model and connection,
+ * so a wrong model name, a rejected key, or an impossible token budget
+ * surfaces when the profile is saved instead of on the first chat message.
+ *
+ * The verdict is advisory and classified by which object the user should fix
+ * (this profile vs its provider connection), using the semantic
+ * `ProviderErrorReason` the provider adapters stamp at their throw sites.
+ * Managed and routing-identity profiles are never probed: their pins are
+ * hand-validated, and a probe there would spend managed credits on every
+ * save.
+ */
+
+import type { ResolutionFallbackReason } from "../../config/llm-resolver.js";
+import { selectWinningProfile } from "../../config/llm-resolver.js";
+import { getConfigReadOnly } from "../../config/loader.js";
+import { ProviderError, type ProviderErrorReason } from "../../util/errors.js";
+import { getLogger } from "../../util/logger.js";
+import {
+  createTimeout,
+  getConfiguredProvider,
+  userMessage,
+} from "../provider-send-message.js";
+import { ROUTING_IDENTITY_PROVIDERS } from "./auth.js";
+
+const log = getLogger("inference-profile-probe");
+
+/** Matches the connection endpoint probe so a dead upstream can't hang the save flow. */
+const PROBE_TIMEOUT_MS = 10_000;
+
+/** Which object the user should fix when the probe fails. */
+export type ProfileCheckBlame =
+  | "profile"
+  | "provider"
+  | "transient"
+  | "unknown";
+
+export interface ProfileCheck {
+  ok: boolean;
+  blame?: ProfileCheckBlame;
+  /** Semantic reason (ProviderErrorReason, or "resolution"/"not_configured"). */
+  reason?: string;
+  /** Upstream or resolver error text, verbatim. */
+  detail?: string;
+  /** The connection to inspect when `blame` is "provider". */
+  connection?: string;
+  /** English summary for non-localized surfaces (the CLI). */
+  message?: string;
+}
+
+const PROVIDER_BLAME_REASONS: ReadonlySet<ProviderErrorReason> = new Set([
+  "invalid_credentials",
+  "insufficient_credits",
+  "daily_limit_reached",
+  "network_error",
+  "server_error",
+]);
+
+const TRANSIENT_BLAME_REASONS: ReadonlySet<ProviderErrorReason> = new Set([
+  "rate_limited",
+  "overloaded",
+]);
+
+/**
+ * Map a failed probe dispatch onto the object the user should fix. Reasons
+ * the adapters stamp about the request itself (model unknown or restricted,
+ * parameter and token-budget rejections) blame the profile; credential,
+ * billing, and reachability reasons blame the provider connection.
+ */
+export function classifyProbeFailure(err: unknown): {
+  blame: ProfileCheckBlame;
+  reason?: string;
+  detail: string;
+} {
+  const detail = err instanceof Error ? err.message : String(err);
+  if (!(err instanceof ProviderError) || err.reason === undefined) {
+    return { blame: "unknown", detail };
+  }
+  if (PROVIDER_BLAME_REASONS.has(err.reason)) {
+    return { blame: "provider", reason: err.reason, detail };
+  }
+  if (TRANSIENT_BLAME_REASONS.has(err.reason)) {
+    return { blame: "transient", reason: err.reason, detail };
+  }
+  if (err.reason === "unknown") {
+    return { blame: "unknown", reason: err.reason, detail };
+  }
+  return { blame: "profile", reason: err.reason, detail };
+}
+
+function checkMessage(check: {
+  blame: ProfileCheckBlame;
+  detail: string;
+  connection?: string;
+}): string {
+  switch (check.blame) {
+    case "profile":
+      return `A test request through this profile failed: ${check.detail} Check the profile's model and parameters.`;
+    case "provider":
+      return (
+        `A test request through this profile failed: ${check.detail} ` +
+        (check.connection
+          ? `Check the provider connection "${check.connection}".`
+          : `Check the profile's provider connection.`)
+      );
+    case "transient":
+      return `A test request through this profile could not complete: ${check.detail} This may be temporary.`;
+    default:
+      return `A test request through this profile failed: ${check.detail}`;
+  }
+}
+
+/**
+ * Probe a saved profile with one minimal request. Returns `null` when there
+ * is no verdict to give: the profile does not exist or is disabled, it rides
+ * a managed or routing-identity route (probing would bill managed credits),
+ * or the probe timed out without an answer.
+ */
+export async function probeInferenceProfile(
+  name: string,
+): Promise<ProfileCheck | null> {
+  const { llm } = getConfigReadOnly();
+  const entry = llm.profiles?.[name] as Record<string, unknown> | undefined;
+  if (!entry || entry.status === "disabled" || entry.source === "managed") {
+    return null;
+  }
+  const provider = typeof entry.provider === "string" ? entry.provider : "";
+  if (ROUTING_IDENTITY_PROVIDERS.has(provider)) {
+    return null;
+  }
+  const connection =
+    typeof entry.provider_connection === "string"
+      ? entry.provider_connection
+      : provider || undefined;
+
+  const selectionSeed = crypto.randomUUID();
+
+  // If the resolver would fall back past this profile, the probe must not run:
+  // it would silently exercise (and bill) a different profile. The fallback
+  // reason is itself the verdict.
+  let fallbackReason: ResolutionFallbackReason | undefined;
+  const winner = selectWinningProfile("inference", llm, {
+    overrideProfile: name,
+    selectionSeed,
+    onResolutionFallback: (info) => {
+      if (info.requested === name) {
+        fallbackReason = info.reason;
+      }
+    },
+  });
+  if (winner.profileName !== name) {
+    const detail = `The profile is ${fallbackReason ?? "unusable"} and requests would silently run on ${winner.profileName ?? "the default"} instead.`;
+    return {
+      ok: false,
+      blame: "profile",
+      reason: "resolution",
+      detail,
+      message: checkMessage({ blame: "profile", detail }),
+    };
+  }
+
+  const timeout = createTimeout(PROBE_TIMEOUT_MS);
+  try {
+    const providerInstance = await getConfiguredProvider("inference", {
+      overrideProfile: name,
+      selectionSeed,
+    });
+    if (!providerInstance) {
+      const detail = "No dispatchable provider is configured for this profile.";
+      return {
+        ok: false,
+        blame: "provider",
+        reason: "not_configured",
+        detail,
+        connection,
+        message: checkMessage({ blame: "provider", detail, connection }),
+      };
+    }
+    await providerInstance.sendMessage(
+      [userMessage("Reply with only the word OK.")],
+      {
+        signal: timeout.signal,
+        config: {
+          callSite: "inference",
+          overrideProfile: name,
+          selectionSeed,
+        },
+      },
+    );
+    return { ok: true };
+  } catch (err) {
+    if (timeout.signal.aborted) {
+      // No verdict: a slow model and a dead endpoint look identical here,
+      // and the connection-level probe already covers unreachable hosts.
+      log.info({ profile: name }, "Profile probe timed out without a verdict");
+      return null;
+    }
+    const classified = classifyProbeFailure(err);
+    return {
+      ok: false,
+      ...classified,
+      ...(classified.blame === "provider" ? { connection } : {}),
+      message: checkMessage({
+        ...classified,
+        ...(classified.blame === "provider" ? { connection } : {}),
+      }),
+    };
+  } finally {
+    timeout.cleanup();
+  }
+}

--- a/assistant/src/providers/inference/profile-probe.ts
+++ b/assistant/src/providers/inference/profile-probe.ts
@@ -28,7 +28,7 @@ import {
   userMessage,
 } from "../provider-send-message.js";
 import { ROUTING_IDENTITY_PROVIDERS } from "./auth.js";
-import { getConnection } from "./connections.js";
+import { getConnection, MANAGED_CONNECTION_NAMES } from "./connections.js";
 import { PROBE_TIMEOUT_MS } from "./endpoint-probe.js";
 
 const log = getLogger("inference-profile-probe");
@@ -175,9 +175,16 @@ export async function probeInferenceProfile(
     return null;
   }
   const connection = resolved.provider_connection ?? (provider || undefined);
+  // Canonical managed names always dispatch platform-billed: routing ignores
+  // a user-owned row that merely claims such a name
+  // (tryResolveProviderForConnectionName), so the name gates the probe
+  // regardless of the row's stored auth.
+  if (connection && MANAGED_CONNECTION_NAMES.has(connection)) {
+    return null;
+  }
   // A legacy profile can declare a concrete provider while staying bound to
-  // a platform-billed connection row (e.g. the canonical vellum connection);
-  // the row's auth is the billing fact, so it gates the probe too.
+  // a platform-billed connection row; the row's auth is the billing fact, so
+  // it gates the probe too.
   const boundRow = connection ? getConnection(getDb(), connection) : null;
   if (boundRow?.auth.type === "platform") {
     return null;

--- a/assistant/src/providers/inference/profile-probe.ts
+++ b/assistant/src/providers/inference/profile-probe.ts
@@ -71,14 +71,6 @@ const TRANSIENT_BLAME_REASONS: ReadonlySet<ProviderErrorReason> = new Set([
  * parameter and token-budget rejections) blame the profile; credential,
  * billing, and reachability reasons blame the provider connection.
  */
-/**
- * Transport failures the SDKs surface without a semantic reason (e.g. the
- * OpenAI client's APIConnectionError, message "Connection error."). Matched
- * on the error text since no adapter wraps these into a ProviderError.
- */
-const CONNECTION_FAILURE_PATTERN =
-  /connection (error|refused|timed out)|fetch failed|econnrefused|etimedout|enotfound|socket|network/i;
-
 export function classifyProbeFailure(err: unknown): {
   blame: ProfileCheckBlame;
   reason?: string;
@@ -86,12 +78,6 @@ export function classifyProbeFailure(err: unknown): {
 } {
   const detail = err instanceof Error ? err.message : String(err);
   if (!(err instanceof ProviderError) || err.reason === undefined) {
-    if (
-      CONNECTION_FAILURE_PATTERN.test(detail) ||
-      (err instanceof Error && err.name === "APIConnectionError")
-    ) {
-      return { blame: "provider", reason: "network_error", detail };
-    }
     return { blame: "unknown", detail };
   }
   if (PROVIDER_BLAME_REASONS.has(err.reason)) {

--- a/assistant/src/providers/inference/profile-probe.ts
+++ b/assistant/src/providers/inference/profile-probe.ts
@@ -15,6 +15,7 @@
 import type { ResolutionFallbackReason } from "../../config/llm-resolver.js";
 import { selectWinningProfile } from "../../config/llm-resolver.js";
 import { getConfigReadOnly } from "../../config/loader.js";
+import { getDb } from "../../persistence/db-connection.js";
 import { ProviderError, type ProviderErrorReason } from "../../util/errors.js";
 import { getLogger } from "../../util/logger.js";
 import {
@@ -23,6 +24,7 @@ import {
   userMessage,
 } from "../provider-send-message.js";
 import { ROUTING_IDENTITY_PROVIDERS } from "./auth.js";
+import { getConnection } from "./connections.js";
 
 const log = getLogger("inference-profile-probe");
 
@@ -133,6 +135,13 @@ export async function probeInferenceProfile(
     typeof entry.provider_connection === "string"
       ? entry.provider_connection
       : provider || undefined;
+  // A legacy profile can declare a concrete provider while staying bound to
+  // a platform-billed connection row (e.g. the canonical vellum connection);
+  // the row's auth is the billing fact, so it gates the probe too.
+  const boundRow = connection ? getConnection(getDb(), connection) : null;
+  if (boundRow?.auth.type === "platform") {
+    return null;
+  }
 
   const selectionSeed = crypto.randomUUID();
 

--- a/assistant/src/providers/inference/profile-probe.ts
+++ b/assistant/src/providers/inference/profile-probe.ts
@@ -18,6 +18,7 @@ import { getConfigReadOnly } from "../../config/loader.js";
 import { getDb } from "../../persistence/db-connection.js";
 import { ProviderError, type ProviderErrorReason } from "../../util/errors.js";
 import { getLogger } from "../../util/logger.js";
+import { dispatchProviderResolvable } from "../connection-resolution.js";
 import {
   createTimeout,
   getConfiguredProvider,
@@ -152,6 +153,10 @@ export async function probeInferenceProfile(
   const winner = selectWinningProfile("inference", llm, {
     overrideProfile: name,
     selectionSeed,
+    // The same resolvability predicate dispatch applies: without it this
+    // pre-check can report the requested profile as winner while the actual
+    // dispatch below falls back to (and bills) a different profile.
+    isResolvableProvider: dispatchProviderResolvable,
     onResolutionFallback: (info) => {
       if (info.requested === name) {
         fallbackReason = info.reason;

--- a/assistant/src/providers/inference/profile-probe.ts
+++ b/assistant/src/providers/inference/profile-probe.ts
@@ -207,6 +207,20 @@ export async function probeInferenceProfile(
         message: checkMessage({ blame: "provider", detail, connection }),
       };
     }
+    // Final billing gate on the route dispatch ACTUALLY resolved: a profile
+    // without a binding gets its row auto-selected inside
+    // getConfiguredProvider, so only the stamped attribution names the row
+    // this request would sign with.
+    const route = providerInstance.routeAttribution;
+    if (route?.isManagedRoute) {
+      return null;
+    }
+    const routedRow = route?.connectionName
+      ? getConnection(getDb(), route.connectionName)
+      : null;
+    if (routedRow?.auth.type === "platform") {
+      return null;
+    }
     await providerInstance.sendMessage(
       [userMessage("Reply with only the word OK.")],
       {

--- a/assistant/src/providers/inference/profile-probe.ts
+++ b/assistant/src/providers/inference/profile-probe.ts
@@ -13,7 +13,10 @@
  */
 
 import type { ResolutionFallbackReason } from "../../config/llm-resolver.js";
-import { selectWinningProfile } from "../../config/llm-resolver.js";
+import {
+  resolveCallSiteConfig,
+  selectWinningProfile,
+} from "../../config/llm-resolver.js";
 import { getConfigReadOnly } from "../../config/loader.js";
 import { getDb } from "../../persistence/db-connection.js";
 import { ProviderError, type ProviderErrorReason } from "../../util/errors.js";
@@ -157,21 +160,21 @@ export async function probeInferenceProfile(
     };
   }
 
-  // Billing guards run on the CONCRETE entry the resolver selected — for a
-  // mix that is the expanded arm, not the mix record (which carries no
-  // provider or connection of its own) — so a probe can never dispatch a
-  // managed or platform-billed route the raw entry hid.
-  const dispatchEntry =
-    (winner.entry as Record<string, unknown> | null) ?? entry;
-  const provider =
-    typeof dispatchEntry.provider === "string" ? dispatchEntry.provider : "";
+  // Billing guards run on the fully resolved call-site config — the same
+  // composition dispatch consumes (mix arm expanded, call-site overrides
+  // applied) — so neither a mix nor an `llm.callSites.inference` provider
+  // tweak can route the probe onto a managed or platform-billed path the
+  // stored entry hid. Same seed as the dispatch below, so the judged arm is
+  // the dispatched arm.
+  const resolved = resolveCallSiteConfig("inference", llm, {
+    overrideProfile: name,
+    selectionSeed,
+  });
+  const provider = resolved.provider ?? "";
   if (ROUTING_IDENTITY_PROVIDERS.has(provider)) {
     return null;
   }
-  const connection =
-    typeof dispatchEntry.provider_connection === "string"
-      ? dispatchEntry.provider_connection
-      : provider || undefined;
+  const connection = resolved.provider_connection ?? (provider || undefined);
   // A legacy profile can declare a concrete provider while staying bound to
   // a platform-billed connection row (e.g. the canonical vellum connection);
   // the row's auth is the billing fact, so it gates the probe too.

--- a/assistant/src/providers/inference/profile-probe.ts
+++ b/assistant/src/providers/inference/profile-probe.ts
@@ -26,11 +26,9 @@ import {
 } from "../provider-send-message.js";
 import { ROUTING_IDENTITY_PROVIDERS } from "./auth.js";
 import { getConnection } from "./connections.js";
+import { PROBE_TIMEOUT_MS } from "./endpoint-probe.js";
 
 const log = getLogger("inference-profile-probe");
-
-/** Matches the connection endpoint probe so a dead upstream can't hang the save flow. */
-const PROBE_TIMEOUT_MS = 10_000;
 
 /** Which object the user should fix when the probe fails. */
 export type ProfileCheckBlame =

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -2190,6 +2190,16 @@ export function catalogMaxOutputTokens(
   )?.maxOutputTokens;
 }
 
+/** The `contextWindowTokens` declared for a (provider, model) catalog entry, if any. */
+export function catalogContextWindowTokens(
+  provider: string,
+  modelId: string,
+): number | undefined {
+  return PROVIDER_CATALOG.find((p) => p.id === provider)?.models.find(
+    (m) => m.id === modelId,
+  )?.contextWindowTokens;
+}
+
 /**
  * Model IDs (across all catalog providers) flagged
  * `supportsPromptCacheBreakpoints`. Consumed by the OpenAI Responses

--- a/assistant/src/providers/provider-send-message.ts
+++ b/assistant/src/providers/provider-send-message.ts
@@ -11,6 +11,7 @@ import {
 import { getConfig } from "../config/loader.js";
 import type { LLMCallSite } from "../config/schemas/llm.js";
 import { getDb } from "../persistence/db-connection.js";
+import type { ProviderRouteAttribution } from "../util/errors.js";
 import { getLogger } from "../util/logger.js";
 import {
   describeSubscriptionModelIncompatibility,
@@ -69,6 +70,16 @@ export class CallSiteConfiguredProvider implements Provider {
   // Forward native web-search capability so it survives the wrapper chain
   // (callers like the advisor consult gate on it). Fixed at construction.
   public readonly supportsNativeWebSearch?: boolean;
+
+  /**
+   * Route the inner adapter signs with, stamped at connection resolution.
+   * Forwarded live (not snapshotted) so consumers holding this wrapper —
+   * e.g. the save-time probe's billing gate — read the row dispatch
+   * actually selected.
+   */
+  get routeAttribution(): ProviderRouteAttribution | undefined {
+    return this.inner.routeAttribution;
+  }
 
   constructor(
     private readonly inner: Provider,

--- a/assistant/src/runtime/routes/__tests__/inference-profiles-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/inference-profiles-routes.test.ts
@@ -748,6 +748,22 @@ describe("POST inference/profiles/:name/validate billing guards", () => {
     })) as { check: unknown };
     expect(result.check).toBeNull();
   });
+
+  test("gives no verdict when a call-site override routes the probe onto the managed identity", async () => {
+    seedVellumConnection();
+    setConfig("llm", {
+      profiles: {
+        "my-byok": { provider: "openai", model: "gpt-5.2" },
+      },
+      callSites: {
+        inference: { provider: "vellum", model: "claude-opus-4-8" },
+      },
+    });
+    const result = (await call("inference_profiles_validate", {
+      pathParams: { name: "my-byok" },
+    })) as { check: unknown };
+    expect(result.check).toBeNull();
+  });
 });
 
 describe("PUT inference/active-profile validation", () => {

--- a/assistant/src/runtime/routes/__tests__/inference-profiles-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/inference-profiles-routes.test.ts
@@ -213,6 +213,20 @@ describe("POST inference/profiles (create) validation", () => {
     });
   });
 
+  test("rejects a vellum profile whose maxTokens exceeds the routed model's limits", async () => {
+    seedVellumConnection();
+    await expect(
+      call("inference_profiles_create", {
+        body: {
+          name: "my-managed-big",
+          provider: "vellum",
+          model: "claude-opus-4-8",
+          maxTokens: 999999999,
+        },
+      }),
+    ).rejects.toThrow(/maxTokens/);
+  });
+
   test("rejects a vellum profile whose model has no managed upstream", async () => {
     await expect(
       call("inference_profiles_create", {
@@ -714,6 +728,27 @@ describe("GET inference/profiles honors llm.defaultProvider", () => {
 });
 
 // ── active-profile setter validation (Finding 3) ──────────────────────────────
+
+describe("POST inference/profiles/:name/validate billing guards", () => {
+  test("gives no verdict for a mix whose winning arm rides the managed route", async () => {
+    seedVellumConnection();
+    setConfig("llm", {
+      profiles: {
+        "managed-arm": { provider: "vellum", model: "claude-opus-4-8" },
+        "my-mix": {
+          mix: [
+            { profile: "managed-arm", weight: 1 },
+            { profile: "managed-arm", weight: 1 },
+          ],
+        },
+      },
+    });
+    const result = (await call("inference_profiles_validate", {
+      pathParams: { name: "my-mix" },
+    })) as { check: unknown };
+    expect(result.check).toBeNull();
+  });
+});
 
 describe("PUT inference/active-profile validation", () => {
   test("sets a valid profile", async () => {

--- a/assistant/src/runtime/routes/inference-profiles-routes.ts
+++ b/assistant/src/runtime/routes/inference-profiles-routes.ts
@@ -45,7 +45,11 @@ import {
   isUnavailable,
 } from "../../providers/inference/connection-availability.js";
 import { getConnection } from "../../providers/inference/connections.js";
+import { validateInferenceProfileConfig } from "../../providers/inference/profile-config-validation.js";
+import { probeInferenceProfile } from "../../providers/inference/profile-probe.js";
 import {
+  catalogContextWindowTokens,
+  catalogMaxOutputTokens,
   getModelDisplayName,
   isModelInCatalog,
 } from "../../providers/model-catalog.js";
@@ -118,6 +122,17 @@ const profileWriteResultSchema = z
     verify: z.string(),
   })
   .meta({ id: "InferenceProfileWriteResult" });
+
+const profileCheckSchema = z
+  .object({
+    ok: z.boolean(),
+    blame: z.enum(["profile", "provider", "transient", "unknown"]).optional(),
+    reason: z.string().optional(),
+    detail: z.string().optional(),
+    connection: z.string().optional(),
+    message: z.string().optional(),
+  })
+  .meta({ id: "InferenceProfileCheck" });
 
 const createRequestSchema = z.object({
   name: z.string().min(1),
@@ -373,6 +388,35 @@ function validateProfileEntry(entry: Record<string, unknown>): void {
   }
 }
 
+/**
+ * Reject an explicit `maxTokens` the catalog can prove impossible for the
+ * model (over its output cap, or reserving the whole context window so no
+ * input fits). Judged against the same catalog-provider translation
+ * `validateModel` uses; models the catalog does not know are left to the
+ * live probe.
+ */
+function assertSaneMaxTokens(
+  provider: string,
+  model: string,
+  maxTokens: number | undefined,
+): void {
+  if (maxTokens === undefined || ROUTING_IDENTITY_PROVIDERS.has(provider)) {
+    return;
+  }
+  const catalogProvider = resolveEntryProviderKind(provider, model) ?? provider;
+  const issue = validateInferenceProfileConfig({
+    maxTokens,
+    modelMaxOutputTokens: catalogMaxOutputTokens(catalogProvider, model),
+    modelContextWindowTokens: catalogContextWindowTokens(
+      catalogProvider,
+      model,
+    ),
+  });
+  if (issue) {
+    throw new BadRequestError(issue.message);
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Handlers
 // ---------------------------------------------------------------------------
@@ -456,6 +500,7 @@ async function handleCreateProfile({ body = {} }: RouteHandlerArgs) {
     input.allowUnlisted ?? false,
     input.connection,
   );
+  assertSaneMaxTokens(input.provider, input.model, input.maxTokens);
 
   const entry: Record<string, unknown> = {
     ...fragmentFromBody(body as Record<string, unknown>),
@@ -585,6 +630,24 @@ async function handleUpdateProfile({
       nextConnection,
     );
   }
+  // Gated on the fields that feed the judgment, mirroring the availability
+  // guard: metadata-only edits must not start rejecting a stored budget.
+  if (
+    (input.maxTokens !== undefined ||
+      input.model !== undefined ||
+      input.provider !== undefined) &&
+    typeof nextProvider === "string" &&
+    typeof nextModel === "string"
+  ) {
+    assertSaneMaxTokens(
+      nextProvider,
+      nextModel,
+      input.maxTokens ??
+        (typeof existing.maxTokens === "number"
+          ? existing.maxTokens
+          : undefined),
+    );
+  }
 
   const merged: Record<string, unknown> = {
     ...existing,
@@ -630,6 +693,14 @@ async function handleUpdateProfile({
     warnings,
     verify: verifyProfileCommand(name),
   };
+}
+
+async function handleValidateProfile({ pathParams = {} }: RouteHandlerArgs) {
+  const name = (pathParams.name ?? "").trim();
+  if (!name) {
+    throw new BadRequestError("Profile name must be a non-empty string");
+  }
+  return { check: await probeInferenceProfile(name) };
 }
 
 async function handleDeleteProfile({ pathParams = {} }: RouteHandlerArgs) {
@@ -857,5 +928,23 @@ export const ROUTES: RouteDefinition[] = [
       },
     },
     handler: handleSetActiveProfile,
+  },
+  {
+    operationId: "inference_profiles_validate",
+    endpoint: "inference/profiles/:name/validate",
+    method: "POST",
+    policy: {
+      requiredScopes: ["settings.write"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "Probe a saved profile with one minimal request",
+    description:
+      "Dispatch one minimal test request through the named profile's resolved model and connection, and classify any failure by which object the user should fix (the profile vs its provider connection). Advisory: the probe never mutates the profile. Returns a null check when there is no verdict to give (missing, disabled, managed, or routing-identity profiles, or a probe timeout). The probe spends one tiny request on the profile's own key.",
+    tags: ["inference"],
+    pathParams: [{ name: "name", description: "Profile name" }],
+    responseBody: z.object({
+      check: profileCheckSchema.nullable(),
+    }),
+    handler: handleValidateProfile,
   },
 ];

--- a/assistant/src/runtime/routes/inference-profiles-routes.ts
+++ b/assistant/src/runtime/routes/inference-profiles-routes.ts
@@ -18,6 +18,7 @@
 
 import { z } from "zod";
 
+import { validateInferenceProfileConfig } from "../../api/constants/profile-config-validation.js";
 import {
   getEffectiveProfilesForProvider,
   MANAGED_PROFILE_NAMES,
@@ -45,7 +46,6 @@ import {
   isUnavailable,
 } from "../../providers/inference/connection-availability.js";
 import { getConnection } from "../../providers/inference/connections.js";
-import { validateInferenceProfileConfig } from "../../providers/inference/profile-config-validation.js";
 import { probeInferenceProfile } from "../../providers/inference/profile-probe.js";
 import {
   catalogContextWindowTokens,
@@ -53,6 +53,7 @@ import {
   getModelDisplayName,
   isModelInCatalog,
 } from "../../providers/model-catalog.js";
+import { getManagedUpstream } from "../../providers/vellum-model-routing.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import {
   commitConfigWrite,
@@ -400,10 +401,22 @@ function assertSaneMaxTokens(
   model: string,
   maxTokens: number | undefined,
 ): void {
-  if (maxTokens === undefined || ROUTING_IDENTITY_PROVIDERS.has(provider)) {
+  if (maxTokens === undefined) {
     return;
   }
-  const catalogProvider = resolveEntryProviderKind(provider, model) ?? provider;
+  // Routing identities are judged against their concrete upstream's catalog
+  // entry: chatgpt serves the OpenAI catalog, and a vellum profile stores the
+  // bare native model id (validateModel rejects encoded routing strings), so
+  // the managed upstream owns its limits. An unroutable model yields no
+  // upstream and stays unjudged.
+  const catalogProvider = ROUTING_IDENTITY_PROVIDERS.has(provider)
+    ? provider === "chatgpt"
+      ? "openai"
+      : getManagedUpstream(model)
+    : (resolveEntryProviderKind(provider, model) ?? provider);
+  if (catalogProvider === null) {
+    return;
+  }
   const issue = validateInferenceProfileConfig({
     maxTokens,
     modelMaxOutputTokens: catalogMaxOutputTokens(catalogProvider, model),

--- a/assistant/src/runtime/routes/inference-profiles-routes.ts
+++ b/assistant/src/runtime/routes/inference-profiles-routes.ts
@@ -35,6 +35,7 @@ import {
 } from "../../config/schemas/llm.js";
 import { getDb } from "../../persistence/db-connection.js";
 import {
+  catalogProviderForProfile,
   resolveEntryProviderKind,
   writableProfileProviderIssue,
 } from "../../providers/connection-resolution.js";
@@ -53,7 +54,6 @@ import {
   getModelDisplayName,
   isModelInCatalog,
 } from "../../providers/model-catalog.js";
-import { getManagedUpstream } from "../../providers/vellum-model-routing.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import {
   commitConfigWrite,
@@ -404,16 +404,7 @@ function assertSaneMaxTokens(
   if (maxTokens === undefined) {
     return;
   }
-  // Routing identities are judged against their concrete upstream's catalog
-  // entry: chatgpt serves the OpenAI catalog, and a vellum profile stores the
-  // bare native model id (validateModel rejects encoded routing strings), so
-  // the managed upstream owns its limits. An unroutable model yields no
-  // upstream and stays unjudged.
-  const catalogProvider = ROUTING_IDENTITY_PROVIDERS.has(provider)
-    ? provider === "chatgpt"
-      ? "openai"
-      : getManagedUpstream(model)
-    : (resolveEntryProviderKind(provider, model) ?? provider);
+  const catalogProvider = catalogProviderForProfile(provider, model);
   if (catalogProvider === null) {
     return;
   }

--- a/clients/web/src/domains/settings/ai/use-profile-editor.ts
+++ b/clients/web/src/domains/settings/ai/use-profile-editor.ts
@@ -47,6 +47,38 @@ import { assistantSupportsEntryProviderBinding } from "@/lib/backwards-compat/en
 import { assistantSupportsVellumProviderProfiles } from "@/lib/backwards-compat/vellum-profile-provider";
 import { badRequestMessage } from "@/utils/api-errors";
 
+/**
+ * Mirror of the daemon's `validateInferenceProfileConfig` judgment
+ * (`assistant/src/providers/inference/profile-config-validation.ts`). The
+ * settings surface persists through the generic config PATCH, which is the
+ * deliberately unvalidated escape hatch, so an impossible output budget must
+ * be rejected here before the write or it lands stored.
+ */
+const MIN_INPUT_RESERVE_TOKENS = 4096;
+
+function maxTokensBudgetError(
+  provider: string,
+  model: string,
+  maxTokens: number,
+): string | null {
+  const catalogModel = getModelsForProvider(provider).find(
+    (m) => m.id === model,
+  );
+  if (!catalogModel) {
+    return null;
+  }
+  if (maxTokens > catalogModel.maxOutputTokens) {
+    return `Max tokens (${maxTokens}) exceeds the model's maximum output of ${catalogModel.maxOutputTokens} tokens. Reduce it to ${catalogModel.maxOutputTokens} or less.`;
+  }
+  if (
+    maxTokens >=
+    catalogModel.contextWindowTokens - MIN_INPUT_RESERVE_TOKENS
+  ) {
+    return `Max tokens (${maxTokens}) reserves the entire ${catalogModel.contextWindowTokens}-token context window for output, leaving no room for your messages. Reduce it (e.g. 8000).`;
+  }
+  return null;
+}
+
 export type ProfileEditorMode = "create" | "edit" | "view";
 export type EffortSelection = "inherit" | NonNullable<ProfileEntry["effort"]>;
 
@@ -636,6 +668,13 @@ export function useProfileEditor({
         setSaving(false);
       }
       return;
+    }
+    if (visibility.maxTokens && maxTokens !== null && provider && model) {
+      const budgetError = maxTokensBudgetError(provider, model, maxTokens);
+      if (budgetError) {
+        setSaveError(budgetError);
+        return;
+      }
     }
     setSaving(true);
     setSaveError(null);

--- a/clients/web/src/domains/settings/ai/use-profile-editor.ts
+++ b/clients/web/src/domains/settings/ai/use-profile-editor.ts
@@ -10,6 +10,8 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { validateInferenceProfileConfig } from "@vellumai/assistant-api";
 
+import { t } from "@/i18n";
+
 import {
   getManagedUpstreamForModel,
   getModelsForProvider,
@@ -69,8 +71,14 @@ function maxTokensBudgetError(
     return null;
   }
   return issue.code === "over_output_cap"
-    ? `Max tokens (${maxTokens}) exceeds the model's maximum output of ${catalogModel.maxOutputTokens} tokens. Reduce it to ${catalogModel.maxOutputTokens} or less.`
-    : `Max tokens (${maxTokens}) reserves the entire ${catalogModel.contextWindowTokens}-token context window for output, leaving no room for your messages. Reduce it (e.g. 8000).`;
+    ? t("settings:profileEditor.maxTokensOverCap", {
+        maxTokens,
+        cap: catalogModel.maxOutputTokens,
+      })
+    : t("settings:profileEditor.maxTokensNoInputRoom", {
+        maxTokens,
+        window: catalogModel.contextWindowTokens,
+      });
 }
 
 export type ProfileEditorMode = "create" | "edit" | "view";

--- a/clients/web/src/domains/settings/ai/use-profile-editor.ts
+++ b/clients/web/src/domains/settings/ai/use-profile-editor.ts
@@ -57,16 +57,9 @@ import { badRequestMessage } from "@/utils/api-errors";
 const MIN_INPUT_RESERVE_TOKENS = 4096;
 
 function maxTokensBudgetError(
-  provider: string,
-  model: string,
+  catalogModel: LlmCatalogModel,
   maxTokens: number,
 ): string | null {
-  const catalogModel = getModelsForProvider(provider).find(
-    (m) => m.id === model,
-  );
-  if (!catalogModel) {
-    return null;
-  }
   if (maxTokens > catalogModel.maxOutputTokens) {
     return `Max tokens (${maxTokens}) exceeds the model's maximum output of ${catalogModel.maxOutputTokens} tokens. Reduce it to ${catalogModel.maxOutputTokens} or less.`;
   }
@@ -669,8 +662,11 @@ export function useProfileEditor({
       }
       return;
     }
-    if (visibility.maxTokens && maxTokens !== null && provider && model) {
-      const budgetError = maxTokensBudgetError(provider, model, maxTokens);
+    // `selectedModel` already resolves the routed `<provider>/<model>` form
+    // to its native catalog entry, so the judgment sees the same model the
+    // save will dispatch.
+    if (visibility.maxTokens && maxTokens !== null && selectedModel) {
+      const budgetError = maxTokensBudgetError(selectedModel, maxTokens);
       if (budgetError) {
         setSaveError(budgetError);
         return;

--- a/clients/web/src/domains/settings/ai/use-profile-editor.ts
+++ b/clients/web/src/domains/settings/ai/use-profile-editor.ts
@@ -8,6 +8,8 @@ import { useEffect, useMemo, useState } from "react";
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 
+import { validateInferenceProfileConfig } from "@vellumai/assistant-api";
+
 import {
   getManagedUpstreamForModel,
   getModelsForProvider,
@@ -48,28 +50,27 @@ import { assistantSupportsVellumProviderProfiles } from "@/lib/backwards-compat/
 import { badRequestMessage } from "@/utils/api-errors";
 
 /**
- * Mirror of the daemon's `validateInferenceProfileConfig` judgment
- * (`assistant/src/providers/inference/profile-config-validation.ts`). The
- * settings surface persists through the generic config PATCH, which is the
- * deliberately unvalidated escape hatch, so an impossible output budget must
- * be rejected here before the write or it lands stored.
+ * The settings surface persists through the generic config PATCH, which is
+ * the deliberately unvalidated escape hatch, so an impossible output budget
+ * must be rejected here before the write or it lands stored. The judgment is
+ * the daemon's own `validateInferenceProfileConfig` (shared via
+ * assistant-api) so the two paths cannot drift; only the copy is local.
  */
-const MIN_INPUT_RESERVE_TOKENS = 4096;
-
 function maxTokensBudgetError(
   catalogModel: LlmCatalogModel,
   maxTokens: number,
 ): string | null {
-  if (maxTokens > catalogModel.maxOutputTokens) {
-    return `Max tokens (${maxTokens}) exceeds the model's maximum output of ${catalogModel.maxOutputTokens} tokens. Reduce it to ${catalogModel.maxOutputTokens} or less.`;
+  const issue = validateInferenceProfileConfig({
+    maxTokens,
+    modelMaxOutputTokens: catalogModel.maxOutputTokens,
+    modelContextWindowTokens: catalogModel.contextWindowTokens,
+  });
+  if (!issue) {
+    return null;
   }
-  if (
-    maxTokens >=
-    catalogModel.contextWindowTokens - MIN_INPUT_RESERVE_TOKENS
-  ) {
-    return `Max tokens (${maxTokens}) reserves the entire ${catalogModel.contextWindowTokens}-token context window for output, leaving no room for your messages. Reduce it (e.g. 8000).`;
-  }
-  return null;
+  return issue.code === "over_output_cap"
+    ? `Max tokens (${maxTokens}) exceeds the model's maximum output of ${catalogModel.maxOutputTokens} tokens. Reduce it to ${catalogModel.maxOutputTokens} or less.`
+    : `Max tokens (${maxTokens}) reserves the entire ${catalogModel.contextWindowTokens}-token context window for output, leaving no room for your messages. Reduce it (e.g. 8000).`;
 }
 
 export type ProfileEditorMode = "create" | "edit" | "view";

--- a/clients/web/src/domains/settings/ai/use-profile-save.ts
+++ b/clients/web/src/domains/settings/ai/use-profile-save.ts
@@ -8,7 +8,49 @@ import { useLlmConfigPatch } from "@/domains/settings/ai/use-llm-config-patch";
 import { t } from "@/i18n";
 import { captureError } from "@/lib/sentry/capture-error";
 import { configGetOptions } from "@/generated/daemon/@tanstack/react-query.gen";
+import { inferenceProfilesByNameValidatePost } from "@/generated/daemon/sdk.gen";
 import type { ProfilePatchEntry } from "@/generated/daemon/types.gen";
+
+/**
+ * Probe the just-saved profile with one minimal request and surface a
+ * classified warning toast when it fails, so a wrong model name or a broken
+ * provider connection is visible at save time instead of on the first chat
+ * message. Advisory and fire-and-forget: a missing route (older daemon) or a
+ * transport error must not disturb the save flow, and a null check means the
+ * daemon had no verdict to give.
+ */
+async function probeSavedProfile(
+  assistantId: string,
+  name: string,
+): Promise<void> {
+  try {
+    const { data } = await inferenceProfilesByNameValidatePost({
+      path: { assistant_id: assistantId, name },
+    });
+    const check = data?.check;
+    if (!check || check.ok) {
+      return;
+    }
+    const key =
+      check.blame === "profile"
+        ? ("settings:profileCheck.profileError" as const)
+        : check.blame === "provider"
+          ? check.connection
+            ? ("settings:profileCheck.providerError" as const)
+            : ("settings:profileCheck.providerErrorUnnamed" as const)
+          : check.blame === "transient"
+            ? ("settings:profileCheck.transient" as const)
+            : ("settings:profileCheck.unknown" as const);
+    toast.warning(
+      t(key, {
+        detail: check.detail ?? "",
+        connection: check.connection ?? "",
+      }),
+    );
+  } catch {
+    // Advisory only.
+  }
+}
 
 export interface ProfileSave {
   /**
@@ -117,6 +159,7 @@ export function useProfileSave(
       );
     }
     onSaved?.();
+    void probeSavedProfile(assistantId, name);
   }
 
   return { saveProfile, isPending: configMutation.isPending };

--- a/clients/web/src/i18n/locales/en/settings.json
+++ b/clients/web/src/i18n/locales/en/settings.json
@@ -752,6 +752,13 @@
     "topPLabel": "Top P",
     "verbosityLabel": "Verbosity"
   },
+  "profileCheck": {
+    "profileError": "Saved, but a test request through this profile failed: {detail} Check the profile's model and parameters.",
+    "providerError": "Saved, but a test request through this profile failed: {detail} Check the provider connection \"{connection}\".",
+    "providerErrorUnnamed": "Saved, but a test request through this profile failed: {detail} Check the profile's provider connection.",
+    "transient": "Saved, but a test request through this profile could not complete: {detail} This may be temporary.",
+    "unknown": "Saved, but a test request through this profile failed: {detail}"
+  },
   "profileDetailPanel": {
     "createProfile": "Create Profile",
     "defaultTitle": "Profile",

--- a/clients/web/src/i18n/locales/en/settings.json
+++ b/clients/web/src/i18n/locales/en/settings.json
@@ -772,6 +772,8 @@
     "saving": "Saving…"
   },
   "profileEditor": {
+    "maxTokensNoInputRoom": "Max tokens ({maxTokens}) reserves the entire {window}-token context window for output, leaving no room for your messages. Reduce it (e.g. 8000).",
+    "maxTokensOverCap": "Max tokens ({maxTokens}) exceeds the model's maximum output of {cap} tokens. Reduce it to {cap} or less.",
     "subscriptionSteeringHint": "Your ChatGPT subscription is available as the ChatGPT provider."
   },
   "profileEditorFields": {

--- a/clients/web/src/i18n/locales/es/settings.json
+++ b/clients/web/src/i18n/locales/es/settings.json
@@ -752,6 +752,13 @@
     "topPLabel": "Top P",
     "verbosityLabel": "Verbosidad"
   },
+  "profileCheck": {
+    "profileError": "Guardado, pero una solicitud de prueba con este perfil falló: {detail} Revisa el modelo y los parámetros del perfil.",
+    "providerError": "Guardado, pero una solicitud de prueba con este perfil falló: {detail} Revisa la conexión de proveedor \"{connection}\".",
+    "providerErrorUnnamed": "Guardado, pero una solicitud de prueba con este perfil falló: {detail} Revisa la conexión de proveedor del perfil.",
+    "transient": "Guardado, pero una solicitud de prueba con este perfil no se pudo completar: {detail} Puede ser temporal.",
+    "unknown": "Guardado, pero una solicitud de prueba con este perfil falló: {detail}"
+  },
   "profileDetailPanel": {
     "createProfile": "Crear perfil",
     "defaultTitle": "Perfil",

--- a/clients/web/src/i18n/locales/es/settings.json
+++ b/clients/web/src/i18n/locales/es/settings.json
@@ -772,6 +772,8 @@
     "saving": "Guardando…"
   },
   "profileEditor": {
+    "maxTokensNoInputRoom": "El máximo de tokens ({maxTokens}) reserva toda la ventana de contexto de {window} tokens para la salida, sin dejar espacio para tus mensajes. Redúcelo (p. ej., 8000).",
+    "maxTokensOverCap": "El máximo de tokens ({maxTokens}) supera la salida máxima del modelo de {cap} tokens. Redúcelo a {cap} o menos.",
     "subscriptionSteeringHint": "Tu suscripción a ChatGPT está disponible como el proveedor ChatGPT."
   },
   "profileEditorFields": {


### PR DESCRIPTION
## Summary
- Static check (blocking): profile create/update now rejects an explicit `maxTokens` the model catalog can prove impossible, either over the model's `maxOutputTokens` cap or reserving the whole `contextWindowTokens` window so no input fits (`validateInferenceProfileConfig`, with a 4096-token input reserve). Judged only when the catalog knows the model; gated on the fields that feed the judgment so metadata-only edits never start rejecting a stored budget.
- Live probe (advisory): new `POST /v1/inference/profiles/:name/validate` dispatches one minimal request through the profile's own resolved model and connection (the same resolution path chat uses, 10s bound) and classifies any failure via the adapters' semantic `ProviderErrorReason` into profile-vs-provider blame, naming the connection to inspect. Managed and routing-identity (vellum/chatgpt) profiles are never probed so saves never spend managed credits.
- Both clients trigger the probe after a successful save: the CLI prints a `warning:` line (and carries a `check` field under `--json`), and the web profile editor shows a classified, localized warning toast (en + es catalogs). Unit tests cover the token-math judgment and the blame classification; a probe timeout or a daemon predating the route stays silent.

## Original prompt
Follow-up to PR #41010 (connection endpoint probing): validate the model profile itself at save time for the BYO flow, so configuration errors surface on Save instead of on the first chat message. Motivated by a real incident where a custom litellm profile with `maxTokens` equal to the model's 300000-token context window failed every message with an opaque ContextWindowExceededError. Asked for a static token-math check (blocking, only when the numbers are knowable), plus a non-blocking live probe through the profile's resolved model and connection whose failures are classified by existing error parsers into profile errors (wrong model name, impossible budget) vs provider errors (auth, reachability), guiding the user to the right object to fix. Sticky-footer UI work and deep edit links were explicitly out of scope.

Note: pre-commit/pre-push hooks were skipped for this commit because the secret scanner false-positives on pre-existing masked placeholder strings in the touched locale catalogs; tsc, eslint, prettier, and the test suites were run manually and CI runs them all again.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41015" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->