### PR TITLE
fix(slack): apply the ingress secret gate to backfilled history (LUM-3419)

### DIFF
--- a/assistant/src/__tests__/dm-backfill.test.ts
+++ b/assistant/src/__tests__/dm-backfill.test.ts
@@ -589,8 +589,6 @@ describe("PR 23 — Slack DM cold-start backfill", () => {
   });
 
   test("backfill refuses history rows carrying a secret, keeping the rest", async () => {
-    // Live ingress refuses a body carrying a credential; replayed history
-    // carries the same bodies, so backfill refuses them on the same terms.
     const leakedKey = "AKIA3H7QWERTY9MNBVC2";
     backfillDmMock.mockImplementation(async () => [
       makeBackfilledMessage({
@@ -610,11 +608,9 @@ describe("PR 23 — Slack DM cold-start backfill", () => {
     );
 
     const rows = readPersistedSlackRows();
-    // The secret-bearing row is refused; the clean row still lands, so the
-    // gate rejects one message rather than abandoning the whole backfill.
     expect(rows.map((r) => r.content)).toEqual(["ordinary older chatter"]);
-    // The invariant that matters: the key must not survive anywhere in the
-    // stored transcript, in any encoding the row went through.
+    // `rawContent`, not `content`: the latter is unwrapped by the test
+    // helper, so only the raw column proves what reached storage.
     for (const row of rows) {
       expect(row.rawContent).not.toContain(leakedKey);
     }

--- a/assistant/src/__tests__/dm-backfill.test.ts
+++ b/assistant/src/__tests__/dm-backfill.test.ts
@@ -589,9 +589,8 @@ describe("PR 23 — Slack DM cold-start backfill", () => {
   });
 
   test("backfill refuses history rows carrying a secret, keeping the rest", async () => {
-    // A credential the sender posted weeks ago is still a credential when
-    // history is replayed. The live ingress path blocks this body outright,
-    // so the backfill path must not write it in through the side door.
+    // Live ingress refuses a body carrying a credential; replayed history
+    // carries the same bodies, so backfill refuses them on the same terms.
     const leakedKey = "AKIA3H7QWERTY9MNBVC2";
     backfillDmMock.mockImplementation(async () => [
       makeBackfilledMessage({

--- a/assistant/src/__tests__/dm-backfill.test.ts
+++ b/assistant/src/__tests__/dm-backfill.test.ts
@@ -587,4 +587,40 @@ describe("PR 23 — Slack DM cold-start backfill", () => {
     const texts = rows.map((r) => r.content).sort();
     expect(texts).toEqual(["older A", "older B", "older D"]);
   });
+
+  test("backfill refuses history rows carrying a secret, keeping the rest", async () => {
+    // A credential the sender posted weeks ago is still a credential when
+    // history is replayed. The live ingress path blocks this body outright,
+    // so the backfill path must not write it in through the side door.
+    const leakedKey = "AKIA3H7QWERTY9MNBVC2";
+    backfillDmMock.mockImplementation(async () => [
+      makeBackfilledMessage({
+        id: "1700000000.000001",
+        text: "ordinary older chatter",
+      }),
+      makeBackfilledMessage({
+        id: "1700000000.000002",
+        text: `here is the access key ${leakedKey} for the deploy`,
+      }),
+    ]);
+
+    await handleChannelInbound(
+      buildDmRequest("live new DM"),
+      noopProcessMessage,
+      TEST_BEARER_TOKEN,
+    );
+
+    const rows = readPersistedSlackRows();
+    // The secret-bearing row is refused; the clean row still lands, so the
+    // gate rejects one message rather than abandoning the whole backfill.
+    expect(rows.map((r) => r.content)).toEqual(["ordinary older chatter"]);
+    // The invariant that matters: the key must not survive anywhere in the
+    // stored transcript, in any encoding the row went through.
+    for (const row of rows) {
+      expect(row.rawContent).not.toContain(leakedKey);
+    }
+    expect(
+      rows.some((r) => r.slackMeta?.channelTs === "1700000000.000002"),
+    ).toBe(false);
+  });
 });

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -1692,11 +1692,10 @@ async function persistBackfilledSlackMessage(params: {
 }): Promise<boolean> {
   const { message } = params;
 
-  // Mirror the live ingress secret gate (`runSecretIngressCheck`). Backfill
-  // re-fetches message bodies straight from Slack history, so a body the live
-  // path would have refused is otherwise written verbatim the first time a
-  // channel binds, reproducing a credential the sender issued weeks earlier.
-  // Runs before any file hydration so a refused row costs no downloads.
+  // Backfill writes externally-authored bodies into a conversation, so it
+  // carries the same secret gate as live channel ingress
+  // (`runSecretIngressCheck`). Runs before file hydration, so a refused row
+  // costs no downloads.
   const secretScan = checkIngressForSecrets(message.text ?? "");
   if (secretScan.blocked) {
     log.warn(

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -1678,10 +1678,9 @@ function readStoredSlackThreadState(
  * Caller is responsible for dedup checks before invoking; this helper
  * performs no idempotency check itself.
  *
- * Returns false when the row was deliberately not written (secret detected),
- * so callers can keep their persisted counts honest. The channel ts should
- * still be marked seen either way: the message has been processed, and a
- * refused body must not be reconsidered on the next backfill pass.
+ * Returns false when the row was refused rather than written. Callers mark
+ * the channel ts seen either way, so a refused body is not reconsidered on
+ * the next pass.
  */
 async function persistBackfilledSlackMessage(params: {
   conversationId: string;

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -90,6 +90,7 @@ import {
 import { markProcessed } from "../../persistence/delivery-status.js";
 import { upsertBinding } from "../../persistence/external-conversation-store.js";
 import type { ContentBlock } from "../../providers/types.js";
+import { checkIngressForSecrets } from "../../security/secret-ingress.js";
 import { canonicalizeInboundIdentity } from "../../util/canonicalize-identity.js";
 import { getLogger } from "../../util/logger.js";
 import { truncate } from "../../util/truncate.js";
@@ -1676,6 +1677,11 @@ function readStoredSlackThreadState(
  * content.
  * Caller is responsible for dedup checks before invoking; this helper
  * performs no idempotency check itself.
+ *
+ * Returns false when the row was deliberately not written (secret detected),
+ * so callers can keep their persisted counts honest. The channel ts should
+ * still be marked seen either way: the message has been processed, and a
+ * refused body must not be reconsidered on the next backfill pass.
  */
 async function persistBackfilledSlackMessage(params: {
   conversationId: string;
@@ -1683,8 +1689,28 @@ async function persistBackfilledSlackMessage(params: {
   message: ProviderMessage;
   account?: string;
   guardianExternalUserId?: string;
-}): Promise<void> {
+}): Promise<boolean> {
   const { message } = params;
+
+  // Mirror the live ingress secret gate (`runSecretIngressCheck`). Backfill
+  // re-fetches message bodies straight from Slack history, so a body the live
+  // path would have refused is otherwise written verbatim the first time a
+  // channel binds, reproducing a credential the sender issued weeks earlier.
+  // Runs before any file hydration so a refused row costs no downloads.
+  const secretScan = checkIngressForSecrets(message.text ?? "");
+  if (secretScan.blocked) {
+    log.warn(
+      {
+        conversationId: params.conversationId,
+        channelId: params.channelId,
+        channelTs: message.id,
+        detectedTypes: secretScan.detectedTypes,
+      },
+      "Skipping backfilled Slack message: secret detected",
+    );
+    return false;
+  }
+
   const slackFilesWithUrls = readSlackFilesWithUrlsFromProviderMetadata(
     message.metadata,
   );
@@ -1761,7 +1787,7 @@ async function persistBackfilledSlackMessage(params: {
       f.mimetype.startsWith("image/"),
   );
   if (imageFiles.length === 0) {
-    return;
+    return true;
   }
 
   const hydratedAttachments = await withSlackBotToken(
@@ -1832,7 +1858,7 @@ async function persistBackfilledSlackMessage(params: {
       { conversationId: params.conversationId, channelTs: message.id },
       "No Slack token available for backfill image hydration; skipping",
     );
-    return;
+    return true;
   }
 
   if (hydratedAttachments.length > 0) {
@@ -1843,6 +1869,7 @@ async function persistBackfilledSlackMessage(params: {
       ),
     );
   }
+  return true;
 }
 
 async function buildBackfilledSlackContentBlocks(
@@ -2079,7 +2106,7 @@ async function runBackfillSlackDmIfCold(params: {
         continue;
       }
       try {
-        await persistBackfilledSlackMessage({
+        const stored = await persistBackfilledSlackMessage({
           conversationId: params.conversationId,
           channelId: params.channelId,
           message,
@@ -2089,7 +2116,9 @@ async function runBackfillSlackDmIfCold(params: {
             : {}),
         });
         seen.add(message.id);
-        written++;
+        if (stored) {
+          written++;
+        }
       } catch (perRowErr) {
         log.warn(
           {
@@ -2677,7 +2706,7 @@ export async function triggerSlackThreadBackfillIfNeeded(params: {
         continue;
       }
       try {
-        await persistBackfilledSlackMessage({
+        const stored = await persistBackfilledSlackMessage({
           conversationId,
           channelId,
           message,
@@ -2685,7 +2714,9 @@ export async function triggerSlackThreadBackfillIfNeeded(params: {
           ...(guardianExternalUserId ? { guardianExternalUserId } : {}),
         });
         threadState.storedChannelTs.add(message.id);
-        persisted++;
+        if (stored) {
+          persisted++;
+        }
       } catch (err) {
         log.warn(
           { err, conversationId, channelId, threadTs, channelTs: message.id },


### PR DESCRIPTION
## TL;DR

Slack history backfill wrote message bodies straight into a conversation without the secret check that channel ingress applies to every live message. A credential posted weeks ago was reproduced verbatim the first time a DM bound to a conversation. This puts the existing gate on the backfill path.

Context: LUM-3419. That ticket is still in triage and covers more ground than this PR; this change is independent of where it lands.

## The gap

Live channel ingress runs `checkIngressForSecrets` and drops the message when it hits (`inbound-message-handler.ts:1221`). `persistBackfilledSlackMessage` called `addMessage` with the raw body and ran no such check, so a body that ingress would refuse got written verbatim when the same body was re-fetched through Slack history.

`assistant/src/runtime/AGENTS.md` already states the invariant: hardening applied at channel ingress must be mirrored on the replay paths, or a replayed turn silently loses it. Backfill is a third writer of externally-authored bodies that was never brought under it.

## What changes for the user

| | Before | After |
| --- | --- | --- |
| Old message with a credential, replayed by backfill | Written verbatim into a conversation created today | Not written; the rest of the history still lands |
| Old message with no credential | Written | Unchanged |
| Live message with a credential | Already blocked at ingress | Unchanged |
| Conversation binding for a channel with history | Imports history | Unchanged, minus refused rows |

Nothing about which conversations get history, how much, or in what order changes. The only behaviour difference is which individual rows are refused.

## Why it is safe

- The gate sits in `persistBackfilledSlackMessage`, the shared insertion point both callers funnel through (DM cold-start and thread gap/delta), so both paths are covered by one change and any future backfill path inherits it rather than having to remember.
- It reuses `checkIngressForSecrets` rather than a second detector, so backfill honours the same `secretDetection.enabled` / `blockIngress` config as the live path. With detection off, behaviour is byte-identical to before.
- It runs before file hydration, so a refused row costs no Slack downloads.
- Refusing one row does not abandon the backfill; the surrounding loop continues, and the regression test asserts the clean row still lands.
- The channel ts is marked seen whether or not the row was written, so a refused body is not re-fetched and re-refused on every later pass. The helper returns whether it wrote so the callers' log counts stay honest.

## Testing

Added a case to `dm-backfill.test.ts`: backfill returns one clean message and one carrying an AWS key. It asserts the clean row lands, the secret-bearing ts is absent, and the key does not appear anywhere in stored row content. Both assertions flip without the fix.

Typecheck, lint, and prettier pass locally. The test suite was not run locally by design; CI at this exact HEAD is the test authority.

## Deliberately not in this PR

- **Hover timestamp.** Backfilled rows carry `created_at` of the import, so the web hover tooltip reads "Today" on a six-week-old message. Display-only, and a separate web fix.
- **Backdating `created_at`.** Rejected rather than deferred. It would need a new write path and would scramble `lastMessageAt` and conversation ordering to fix a tooltip.
- **The asymmetric-trust / 30-minute TTL angle** raised in LUM-3419. Unrelated to this seam and unfiled.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41016" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->