### PR TITLE
fix(web): date a Slack row from its origin ts, not its write time (LUM-3419)

### DIFF
--- a/clients/web/src/domains/chat/components/message-hover-actions/message-hover-actions.test.tsx
+++ b/clients/web/src/domains/chat/components/message-hover-actions/message-hover-actions.test.tsx
@@ -21,6 +21,52 @@ describe("MessageHoverActions", () => {
     expect(html).toContain("select-none");
   });
 
+  test("dates a Slack row from its origin ts, not the row's write time", () => {
+    // A backfilled row is written when the import runs, so `timestamp` is
+    // today while the message itself is weeks old. The tooltip must follow
+    // the Slack ts or old history reads as having just arrived.
+    const sentAt = Date.UTC(2026, 6, 8, 9, 15);
+    const message: DisplayMessage = {
+      id: "m-backfilled",
+      role: "user",
+      timestamp: Date.UTC(2026, 7, 20, 12, 32),
+      slackMessage: {
+        channelId: "D0BFXBJE1QV",
+        channelTs: String(sentAt / 1000),
+      },
+      ...textBody("older message"),
+    };
+    const html = renderToStaticMarkup(
+      <MessageHoverActions message={message} />,
+    );
+
+    // Computed with the component's own options so the assertion holds in
+    // any locale; only the source of the epoch is under test.
+    const expectedDay = new Date(sentAt).toLocaleDateString(undefined, {
+      month: "short",
+      day: "numeric",
+    });
+    expect(html).toContain(expectedDay);
+    expect(html).not.toContain("Today");
+  });
+
+  test("falls back to the row's own timestamp when no Slack ts is present", () => {
+    const message: DisplayMessage = {
+      id: "m-plain",
+      role: "user",
+      timestamp: Date.UTC(2026, 6, 8, 9, 15),
+      ...textBody("hello"),
+    };
+    const html = renderToStaticMarkup(
+      <MessageHoverActions message={message} />,
+    );
+
+    const expectedDay = new Date(
+      Date.UTC(2026, 6, 8, 9, 15),
+    ).toLocaleDateString(undefined, { month: "short", day: "numeric" });
+    expect(html).toContain(expectedDay);
+  });
+
   test("renders inspect action for user messages when provided", () => {
     const message: DisplayMessage = {
       id: "m2",

--- a/clients/web/src/domains/chat/components/message-hover-actions/message-hover-actions.test.tsx
+++ b/clients/web/src/domains/chat/components/message-hover-actions/message-hover-actions.test.tsx
@@ -5,6 +5,18 @@ import { MessageHoverActions } from "@/domains/chat/components/message-hover-act
 import type { DisplayMessage } from "@/domains/chat/types/types";
 import { textBody } from "@/domains/chat/utils/message-test-helpers";
 
+/**
+ * The day portion the component renders for an epoch, computed with its own
+ * `Intl` options so assertions hold in any locale. Only the choice of epoch
+ * is under test.
+ */
+function renderedDay(epoch: number): string {
+  return new Date(epoch).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  });
+}
+
 describe("MessageHoverActions", () => {
   test("renders the timestamp even when no actions are available", () => {
     const message: DisplayMessage = {
@@ -22,9 +34,6 @@ describe("MessageHoverActions", () => {
   });
 
   test("dates a Slack row from its origin ts, not the row's write time", () => {
-    // A backfilled row is written when the import runs, so `timestamp` is
-    // today while the message itself is weeks old. The tooltip must follow
-    // the Slack ts or old history reads as having just arrived.
     const sentAt = Date.UTC(2026, 6, 8, 9, 15);
     const message: DisplayMessage = {
       id: "m-backfilled",
@@ -40,49 +49,39 @@ describe("MessageHoverActions", () => {
       <MessageHoverActions message={message} />,
     );
 
-    // Computed with the component's own options so the assertion holds in
-    // any locale; only the source of the epoch is under test.
-    const expectedDay = new Date(sentAt).toLocaleDateString(undefined, {
-      month: "short",
-      day: "numeric",
-    });
-    expect(html).toContain(expectedDay);
+    expect(html).toContain(renderedDay(sentAt));
     expect(html).not.toContain("Today");
   });
 
   test("falls back to the row's own timestamp when no Slack ts is present", () => {
+    const rowWrittenAt = Date.UTC(2026, 6, 8, 9, 15);
     const message: DisplayMessage = {
       id: "m-plain",
       role: "user",
-      timestamp: Date.UTC(2026, 6, 8, 9, 15),
+      timestamp: rowWrittenAt,
       ...textBody("hello"),
     };
     const html = renderToStaticMarkup(
       <MessageHoverActions message={message} />,
     );
 
-    const expectedDay = new Date(
-      Date.UTC(2026, 6, 8, 9, 15),
-    ).toLocaleDateString(undefined, { month: "short", day: "numeric" });
-    expect(html).toContain(expectedDay);
+    expect(html).toContain(renderedDay(rowWrittenAt));
   });
 
   test("dates a reaction from its arrival, not the message it reacts to", () => {
-    // A reaction row carries the reacted message's ts in `channelTs`, so
-    // reading it would date a reaction added today by a six-week-old message.
+    // A reaction row carries the reacted message's ts in `channelTs`, not
+    // its own arrival.
+    const reactedAt = Date.UTC(2026, 6, 8, 9, 15);
+    const reactedTs = String(reactedAt / 1000);
     const message: DisplayMessage = {
       id: "m-reaction",
       role: "user",
       timestamp: Date.UTC(2026, 7, 20, 12, 32),
       slackMessage: {
         channelId: "D0BFXBJE1QV",
-        channelTs: String(Date.UTC(2026, 6, 8, 9, 15) / 1000),
+        channelTs: reactedTs,
         eventKind: "reaction",
-        reaction: {
-          emoji: "eyes",
-          op: "added",
-          targetChannelTs: String(Date.UTC(2026, 6, 8, 9, 15) / 1000),
-        },
+        reaction: { emoji: "eyes", op: "added", targetChannelTs: reactedTs },
       },
       ...textBody("[reaction]"),
     };
@@ -90,11 +89,7 @@ describe("MessageHoverActions", () => {
       <MessageHoverActions message={message} />,
     );
 
-    const reactedDay = new Date(Date.UTC(2026, 6, 8, 9, 15)).toLocaleDateString(
-      undefined,
-      { month: "short", day: "numeric" },
-    );
-    expect(html).not.toContain(reactedDay);
+    expect(html).not.toContain(renderedDay(reactedAt));
   });
 
   test("ignores a malformed Slack ts rather than inventing an origin time", () => {
@@ -115,11 +110,7 @@ describe("MessageHoverActions", () => {
       <MessageHoverActions message={message} />,
     );
 
-    const expectedDay = new Date(rowWrittenAt).toLocaleDateString(undefined, {
-      month: "short",
-      day: "numeric",
-    });
-    expect(html).toContain(expectedDay);
+    expect(html).toContain(renderedDay(rowWrittenAt));
   });
 
   test("renders inspect action for user messages when provided", () => {

--- a/clients/web/src/domains/chat/components/message-hover-actions/message-hover-actions.test.tsx
+++ b/clients/web/src/domains/chat/components/message-hover-actions/message-hover-actions.test.tsx
@@ -67,6 +67,61 @@ describe("MessageHoverActions", () => {
     expect(html).toContain(expectedDay);
   });
 
+  test("dates a reaction from its arrival, not the message it reacts to", () => {
+    // A reaction row carries the reacted message's ts in `channelTs`, so
+    // reading it would date a reaction added today by a six-week-old message.
+    const message: DisplayMessage = {
+      id: "m-reaction",
+      role: "user",
+      timestamp: Date.UTC(2026, 7, 20, 12, 32),
+      slackMessage: {
+        channelId: "D0BFXBJE1QV",
+        channelTs: String(Date.UTC(2026, 6, 8, 9, 15) / 1000),
+        eventKind: "reaction",
+        reaction: {
+          emoji: "eyes",
+          op: "added",
+          targetChannelTs: String(Date.UTC(2026, 6, 8, 9, 15) / 1000),
+        },
+      },
+      ...textBody("[reaction]"),
+    };
+    const html = renderToStaticMarkup(
+      <MessageHoverActions message={message} />,
+    );
+
+    const reactedDay = new Date(Date.UTC(2026, 6, 8, 9, 15)).toLocaleDateString(
+      undefined,
+      { month: "short", day: "numeric" },
+    );
+    expect(html).not.toContain(reactedDay);
+  });
+
+  test("ignores a malformed Slack ts rather than inventing an origin time", () => {
+    // `parseFloat` accepts a numeric prefix, so a partial parse would render
+    // a fabricated date instead of falling back to the row's own timestamp.
+    const rowWrittenAt = Date.UTC(2026, 7, 20, 12, 32);
+    const message: DisplayMessage = {
+      id: "m-malformed",
+      role: "user",
+      timestamp: rowWrittenAt,
+      slackMessage: {
+        channelId: "D0BFXBJE1QV",
+        channelTs: "1783514100.123junk",
+      },
+      ...textBody("older message"),
+    };
+    const html = renderToStaticMarkup(
+      <MessageHoverActions message={message} />,
+    );
+
+    const expectedDay = new Date(rowWrittenAt).toLocaleDateString(undefined, {
+      month: "short",
+      day: "numeric",
+    });
+    expect(html).toContain(expectedDay);
+  });
+
   test("renders inspect action for user messages when provided", () => {
     const message: DisplayMessage = {
       id: "m2",

--- a/clients/web/src/domains/chat/components/message-hover-actions/message-hover-actions.test.tsx
+++ b/clients/web/src/domains/chat/components/message-hover-actions/message-hover-actions.test.tsx
@@ -17,6 +17,17 @@ function renderedDay(epoch: number): string {
   });
 }
 
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Epochs are taken relative to now because the component collapses today's
+ * date to "Today". A fixed calendar date would assert the dated form on every
+ * run except the one where it happens to be today.
+ */
+function daysAgo(days: number): number {
+  return Date.now() - days * DAY_MS;
+}
+
 describe("MessageHoverActions", () => {
   test("renders the timestamp even when no actions are available", () => {
     const message: DisplayMessage = {
@@ -34,11 +45,11 @@ describe("MessageHoverActions", () => {
   });
 
   test("dates a Slack row from its origin ts, not the row's write time", () => {
-    const sentAt = Date.UTC(2026, 6, 8, 9, 15);
+    const sentAt = daysAgo(60);
     const message: DisplayMessage = {
       id: "m-backfilled",
       role: "user",
-      timestamp: Date.UTC(2026, 7, 20, 12, 32),
+      timestamp: Date.now(),
       slackMessage: {
         channelId: "D0BFXBJE1QV",
         channelTs: String(sentAt / 1000),
@@ -54,7 +65,7 @@ describe("MessageHoverActions", () => {
   });
 
   test("falls back to the row's own timestamp when no Slack ts is present", () => {
-    const rowWrittenAt = Date.UTC(2026, 6, 8, 9, 15);
+    const rowWrittenAt = daysAgo(30);
     const message: DisplayMessage = {
       id: "m-plain",
       role: "user",
@@ -71,12 +82,13 @@ describe("MessageHoverActions", () => {
   test("dates a reaction from its arrival, not the message it reacts to", () => {
     // A reaction row carries the reacted message's ts in `channelTs`, not
     // its own arrival.
-    const reactedAt = Date.UTC(2026, 6, 8, 9, 15);
+    const reactedAt = daysAgo(60);
     const reactedTs = String(reactedAt / 1000);
+    const arrivedAt = daysAgo(30);
     const message: DisplayMessage = {
       id: "m-reaction",
       role: "user",
-      timestamp: Date.UTC(2026, 7, 20, 12, 32),
+      timestamp: arrivedAt,
       slackMessage: {
         channelId: "D0BFXBJE1QV",
         channelTs: reactedTs,
@@ -89,13 +101,14 @@ describe("MessageHoverActions", () => {
       <MessageHoverActions message={message} />,
     );
 
+    expect(html).toContain(renderedDay(arrivedAt));
     expect(html).not.toContain(renderedDay(reactedAt));
   });
 
   test("ignores a malformed Slack ts rather than inventing an origin time", () => {
     // `parseFloat` accepts a numeric prefix, so a partial parse would render
     // a fabricated date instead of falling back to the row's own timestamp.
-    const rowWrittenAt = Date.UTC(2026, 7, 20, 12, 32);
+    const rowWrittenAt = daysAgo(30);
     const message: DisplayMessage = {
       id: "m-malformed",
       role: "user",

--- a/clients/web/src/domains/chat/components/message-hover-actions/message-hover-actions.tsx
+++ b/clients/web/src/domains/chat/components/message-hover-actions/message-hover-actions.tsx
@@ -71,30 +71,38 @@ function formatDetailedTimestamp(epoch: number): string {
   });
 }
 
+/** Slack ts: `<unix-seconds>` with optional `.<microseconds>`. */
+const SLACK_TS = /^\d+(?:\.\d+)?$/;
+
+/**
+ * Epoch ms a Slack message was sent, read from its origin `channelTs`.
+ *
+ * Rows hydrated by Slack history backfill are written at import time, so
+ * `createdAt` records the import rather than the message; `channelTs` is the
+ * only record of when it was sent. For a live Slack row the two agree.
+ *
+ * Reaction rows are excluded: their `channelTs` is the ts of the message
+ * being reacted to, so the row's own timestamp is what dates the reaction.
+ */
+function slackOriginTimestamp(message: DisplayMessage): number | undefined {
+  const slack = message.slackMessage;
+  if (!slack || slack.eventKind === "reaction") {
+    return undefined;
+  }
+  // Full-string match: `parseFloat` alone accepts a numeric prefix, which
+  // would turn a malformed ts into a fabricated origin time.
+  if (!SLACK_TS.test(slack.channelTs)) {
+    return undefined;
+  }
+  const ms = Number.parseFloat(slack.channelTs) * 1000;
+  return Number.isFinite(ms) ? ms : undefined;
+}
+
 /**
  * Latest activity timestamp for a message: the max of the message's own
  * timestamp and any tool-call start/completion times, so the displayed time
  * reflects when the row last did something rather than when it was created.
  */
-/**
- * Epoch ms a Slack row actually happened, read from its origin `channelTs`
- * (`"<unix-seconds>.<microseconds>"`).
- *
- * Rows hydrated by Slack history backfill are written when the import runs,
- * so their `createdAt` records the import rather than the message: a
- * six-week-old line otherwise renders as "Today". `channelTs` is the only
- * record of when the message was really sent, and for a live Slack row it
- * agrees with `createdAt` anyway.
- */
-function slackOriginTimestamp(message: DisplayMessage): number | undefined {
-  const channelTs = message.slackMessage?.channelTs;
-  if (channelTs == null) {
-    return undefined;
-  }
-  const seconds = Number.parseFloat(channelTs);
-  return Number.isFinite(seconds) ? seconds * 1000 : undefined;
-}
-
 function latestMessageActivityTimestamp(
   message: DisplayMessage,
 ): number | undefined {

--- a/clients/web/src/domains/chat/components/message-hover-actions/message-hover-actions.tsx
+++ b/clients/web/src/domains/chat/components/message-hover-actions/message-hover-actions.tsx
@@ -76,6 +76,25 @@ function formatDetailedTimestamp(epoch: number): string {
  * timestamp and any tool-call start/completion times, so the displayed time
  * reflects when the row last did something rather than when it was created.
  */
+/**
+ * Epoch ms a Slack row actually happened, read from its origin `channelTs`
+ * (`"<unix-seconds>.<microseconds>"`).
+ *
+ * Rows hydrated by Slack history backfill are written when the import runs,
+ * so their `createdAt` records the import rather than the message: a
+ * six-week-old line otherwise renders as "Today". `channelTs` is the only
+ * record of when the message was really sent, and for a live Slack row it
+ * agrees with `createdAt` anyway.
+ */
+function slackOriginTimestamp(message: DisplayMessage): number | undefined {
+  const channelTs = message.slackMessage?.channelTs;
+  if (channelTs == null) {
+    return undefined;
+  }
+  const seconds = Number.parseFloat(channelTs);
+  return Number.isFinite(seconds) ? seconds * 1000 : undefined;
+}
+
 function latestMessageActivityTimestamp(
   message: DisplayMessage,
 ): number | undefined {
@@ -121,7 +140,8 @@ export function MessageHoverActions({
   // copy payload and mirrors the daemon's `joinWithSpacing`.
   const content = useMemo(() => messagePlainText(message), [message]);
   const timestamp = useMemo(
-    () => latestMessageActivityTimestamp(message),
+    () =>
+      slackOriginTimestamp(message) ?? latestMessageActivityTimestamp(message),
     [message],
   );
 

--- a/clients/web/src/domains/chat/components/message-hover-actions/message-hover-actions.tsx
+++ b/clients/web/src/domains/chat/components/message-hover-actions/message-hover-actions.tsx
@@ -72,7 +72,7 @@ function formatDetailedTimestamp(epoch: number): string {
 }
 
 /** Slack ts: `<unix-seconds>` with optional `.<microseconds>`. */
-const SLACK_TS = /^\d+(?:\.\d+)?$/;
+const SLACK_TS_PATTERN = /^\d+(?:\.\d+)?$/;
 
 /**
  * Epoch ms a Slack message was sent, read from its origin `channelTs`.
@@ -91,7 +91,7 @@ function slackOriginTimestamp(message: DisplayMessage): number | undefined {
   }
   // Full-string match: `parseFloat` alone accepts a numeric prefix, which
   // would turn a malformed ts into a fabricated origin time.
-  if (!SLACK_TS.test(slack.channelTs)) {
+  if (!SLACK_TS_PATTERN.test(slack.channelTs)) {
     return undefined;
   }
   const ms = Number.parseFloat(slack.channelTs) * 1000;


### PR DESCRIPTION
## TL;DR

Hovering a Slack message showed when the row was written, not when the message was sent. For history pulled in by Slack backfill those differ by weeks, so a Jul 8 message hovered as "Today". Read the Slack ts the row already carries.

Context: LUM-3419. Display-only, and independent of where that ticket lands.

## The gap

Slack DM cold-start backfill writes history rows at import time, so `createdAt` records the import rather than the message. `channelTs` on `slackMessage` is the only record of when the message was actually sent, and the tooltip never consulted it.

The daemon side already gets this right: the Slack transcript renderer sorts and stamps by `channelTs`, and backfill inserts oldest-first for stable ordering. This was the one surface still reading the write time.

## What changes for the user

| | Before | After |
| --- | --- | --- |
| Hover a backfilled Slack message from Jul 8 | "Today, 12:32" | "Jul 8, 9:15" |
| Hover a live Slack message | Its arrival time | Unchanged (the two agree) |
| Hover a non-Slack message | Its own timestamp | Unchanged |
| Message order in the transcript | By `createdAt` | Unchanged |

## Why it is safe

- Purely a display read. No persisted field changes, and `createdAt` still drives ordering, `lastMessageAt`, sync, and every other consumer.
- Scoped to rows that carry `slackMessage.channelTs`; everything else takes the existing path unchanged.
- Falls back to the row's own timestamp when the ts is absent or unparseable, so a malformed value degrades to today's behaviour rather than rendering an invalid date.
- For a live Slack row `channelTs` and `createdAt` agree, so in practice only backfilled history moves.

## Testing

Two cases in `message-hover-actions.test.tsx`: a row whose `timestamp` is today and whose `channelTs` is six weeks earlier renders the older date and not "Today"; a row with no Slack metadata still renders its own timestamp. Expected strings are computed with the component's own `Intl` options so the assertions hold in any locale, leaving only the choice of epoch under test.

Typecheck, lint, and prettier pass locally. The test suite was not run locally by design; CI at this exact HEAD is the test authority.

## Related

The secret-gate half of LUM-3419 is #41016, deliberately separate: different package, different risk, no shared code.

Not doing: backdating `created_at` on backfilled rows. It would need a new write path and would scramble `lastMessageAt` and conversation ordering to fix a tooltip.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41017" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->