### PR TITLE
refactor(config): defaultProvider drops connectionName — convention resolution only

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -4831,9 +4831,9 @@ paths:
       operationId: config_llm_defaultprovider_get
       summary: Get the default provider and its availability
       description:
-        Returns `llm.defaultProvider`, the connection name it resolves to, and whether that connection is currently
-        usable (connection exists, credential stored, Vellum authenticated). Availability is informational — a broken
-        default is a valid persisted state that surfaces explainable errors at resolution time.
+        Returns `llm.defaultProvider`, the connection name it conventionally resolves to, and whether that
+        connection is currently usable (connection exists, credential stored, Vellum authenticated). Availability is
+        informational — a broken default is a valid persisted state that surfaces explainable errors at resolution time.
       tags:
         - config
       responses:
@@ -4848,8 +4848,8 @@ paths:
       summary: Set the default provider
       description:
         Replaces `llm.defaultProvider`. Strict-validates the body (unlike the generic config write paths, which
-        silently drop invalid values). Does not require the referenced connection to exist — a dangling name is allowed
-        by design and reported via the availability status.
+        silently drop invalid values). Does not require the conventionally resolved connection to exist — a dangling
+        name is allowed by design and reported via the availability status.
       tags:
         - config
       requestBody:
@@ -4875,9 +4875,6 @@ paths:
                     - atlascloud
                     - baseten
                     - poolside
-                connectionName:
-                  type: string
-                  minLength: 1
               required:
                 - provider
       responses:
@@ -34867,9 +34864,6 @@ components:
                     - atlascloud
                     - baseten
                     - poolside
-                connectionName:
-                  type: string
-                  minLength: 1
               required:
                 - provider
               additionalProperties: false
@@ -35246,8 +35240,6 @@ components:
                 - baseten
                 - poolside
             - type: "null"
-        connectionName:
-          type: string
         resolvedConnectionName:
           anyOf:
             - type: string

--- a/assistant/src/__tests__/default-provider-ensure.test.ts
+++ b/assistant/src/__tests__/default-provider-ensure.test.ts
@@ -190,18 +190,11 @@ describe("ensureDefaultProvider", () => {
     expect(llm().defaultProvider).toEqual({ provider: "gemini" });
   });
 
-  test("repairs an empty connectionName via the resolution chain", async () => {
+  test("a legacy connectionName does not invalidate the value — no repair, no rewrite", async () => {
+    // The retired pin is an unknown key now: it strips at parse (so the
+    // value is schema-valid) and self-heals on the next strict write; the
+    // ensure pass leaves the raw file alone.
     process.env.IS_PLATFORM = "1";
-    writeConfig({
-      llm: { defaultProvider: { provider: "anthropic", connectionName: "" } },
-    });
-
-    await ensureDefaultProvider(workspaceDir);
-
-    expect(llm().defaultProvider).toEqual({ provider: "vellum" });
-  });
-
-  test("a valid object with a connectionName is left untouched", async () => {
     writeConfig({
       llm: {
         defaultProvider: {

--- a/assistant/src/cli/commands/inference-providers-default.ts
+++ b/assistant/src/cli/commands/inference-providers-default.ts
@@ -13,7 +13,6 @@ import { writeCliError, writeLine } from "../lib/cli-output.js";
 
 interface DefaultProviderStatus {
   provider: string | null;
-  connectionName?: string;
   resolvedConnectionName: string | null;
   availability: { status: string; message?: string };
 }
@@ -39,10 +38,7 @@ function printStatus(status: DefaultProviderStatus, json?: boolean): void {
 
 export function attachDefaultProviderSubcommand(providers: Command): void {
   subcommand(providers, "default").action(
-    async (
-      name: string | undefined,
-      opts: { connection?: string; json?: boolean },
-    ) => {
+    async (name: string | undefined, opts: { json?: boolean }) => {
       if (name === undefined) {
         const ipcResult = await cliIpcCall<DefaultProviderStatus>(
           "llm_default_provider_get",
@@ -56,13 +52,9 @@ export function attachDefaultProviderSubcommand(providers: Command): void {
         return;
       }
 
-      const body: Record<string, unknown> = { provider: name };
-      if (opts.connection !== undefined) {
-        body.connectionName = opts.connection;
-      }
       const ipcResult = await cliIpcCall<DefaultProviderStatus>(
         "llm_default_provider_put",
-        { body },
+        { body: { provider: name } },
       );
       if (!ipcResult.ok) {
         writeCliError(ipcResult.error ?? "Unknown error", opts.json);

--- a/assistant/src/cli/commands/inference.help.ts
+++ b/assistant/src/cli/commands/inference.help.ts
@@ -294,8 +294,7 @@ a profile that uses it:
             },
             {
               flags: "--base-url <url>",
-              description:
-                "Endpoint base URL (openai-compatible or ollama)",
+              description: "Endpoint base URL (openai-compatible or ollama)",
             },
           ],
         },
@@ -395,22 +394,17 @@ matching \`assistant inference providers <verb>\` command.`,
           description: "Read or set the default provider (prints availability)",
           options: [
             {
-              flags: "--connection <name>",
-              description: "Pin a specific provider entry when setting",
-            },
-            {
               flags: "--json",
               description: "Output as machine-readable JSON",
             },
           ],
           helpText: `
 With no argument, prints the default provider and whether it is usable.
-With a provider name, sets it (optionally pinning a connection).
+With a provider name, sets it.
 
 Examples:
   $ assistant inference providers default
-  $ assistant inference providers default anthropic
-  $ assistant inference providers default anthropic --connection anthropic-personal`,
+  $ assistant inference providers default anthropic`,
         },
       ],
     },

--- a/assistant/src/config/__tests__/default-profile-catalog.test.ts
+++ b/assistant/src/config/__tests__/default-profile-catalog.test.ts
@@ -317,10 +317,7 @@ describe("schema validation", () => {
 });
 
 describe("resolveDefaultProfileForProvider", () => {
-  const dp = (
-    provider: DefaultProviderConfig["provider"],
-    connectionName?: string,
-  ) => ({ provider, ...(connectionName ? { connectionName } : {}) });
+  const dp = (provider: DefaultProviderConfig["provider"]) => ({ provider });
 
   test("every matrix column materializes every default profile key", () => {
     for (const provider of DEFAULT_PROFILE_PROVIDERS) {
@@ -435,16 +432,6 @@ describe("resolveDefaultProfileForProvider", () => {
     expect(entry?.model).toBe(
       CODE_DEFAULT_PROFILE_ENTRIES.balanced.model as string,
     );
-  });
-
-  test("an explicit connectionName wins over the convention", () => {
-    const entry = resolveDefaultProfileForProvider(
-      undefined,
-      "balanced",
-      dp("openai", "work-openai"),
-    );
-    expect(entry?.provider).toBe("openai");
-    expect(entry?.provider_connection).toBe("work-openai");
   });
 
   test("a user-source workspace entry shadows the provider-resolved default", () => {

--- a/assistant/src/config/__tests__/default-provider.test.ts
+++ b/assistant/src/config/__tests__/default-provider.test.ts
@@ -54,14 +54,17 @@ describe("LLMSchema.defaultProvider", () => {
     ).not.toThrow();
   });
 
-  test("accepts a provider pinned to a connection", () => {
+  // No migration for the retired `connectionName` pin: the key strips at
+  // parse and `setDefaultProvider`'s strict parse rewrites the stripped
+  // shape on the next write.
+  test("a legacy connectionName pin strips at parse and resolves by convention", () => {
     const parsed = LLMSchema.parse({
       defaultProvider: { provider: "vellum", connectionName: "x" },
     });
-    expect(parsed.defaultProvider).toEqual({
-      provider: "vellum",
-      connectionName: "x",
-    });
+    expect(parsed.defaultProvider).toEqual({ provider: "vellum" });
+    expect(resolveDefaultConnectionName(parsed.defaultProvider!)).toBe(
+      VELLUM_MANAGED_CONNECTION_NAME,
+    );
   });
 
   // The strict write-side schema; the `.catch` only applies when reading
@@ -69,15 +72,6 @@ describe("LLMSchema.defaultProvider", () => {
   test("rejects an unknown provider", () => {
     expect(() =>
       DefaultProviderSchema.parse({ provider: "not-a-provider" }),
-    ).toThrow();
-  });
-
-  test("rejects an empty connectionName", () => {
-    expect(() =>
-      DefaultProviderSchema.parse({
-        provider: "anthropic",
-        connectionName: "",
-      }),
     ).toThrow();
   });
 
@@ -93,12 +87,12 @@ describe("LLMSchema.defaultProvider", () => {
   });
 
   // Guards the loader-recovery hazard described at `DefaultProviderField`:
-  // a nested failure must never strand a `{ connectionName }` fragment.
+  // a nested failure must never strand a partial fragment.
   test("an invalid defaultProvider is dropped atomically", () => {
     const result = LLMSchema.safeParse({
       profiles: { "my-profile": {} },
       activeProfile: "my-profile",
-      defaultProvider: { provider: "not-a-provider", connectionName: "x" },
+      defaultProvider: { provider: "not-a-provider" },
     });
     expect(result.success).toBe(true);
     if (!result.success) {
@@ -142,15 +136,6 @@ describe("LLMSchema.defaultProvider", () => {
 });
 
 describe("resolveDefaultConnectionName", () => {
-  test("an explicit pin wins", () => {
-    expect(
-      resolveDefaultConnectionName({
-        provider: "anthropic",
-        connectionName: "my-connection",
-      }),
-    ).toBe("my-connection");
-  });
-
   test("vellum resolves to the managed connection name", () => {
     expect(resolveDefaultConnectionName({ provider: "vellum" })).toBe(
       VELLUM_MANAGED_CONNECTION_NAME,
@@ -180,15 +165,6 @@ describe("resolveDefaultConnectionName", () => {
       "openrouter-personal",
     );
   });
-
-  test("an explicit pin wins even for vellum", () => {
-    expect(
-      resolveDefaultConnectionName({
-        provider: "vellum",
-        connectionName: "pinned",
-      }),
-    ).toBe("pinned");
-  });
 });
 
 describe("getDefaultProvider / setDefaultProvider", () => {
@@ -209,19 +185,13 @@ describe("getDefaultProvider / setDefaultProvider", () => {
   });
 
   test("set/get round-trip through the raw config", () => {
-    setDefaultProvider({ provider: "openai", connectionName: "openai-work" });
+    setDefaultProvider({ provider: "openai" });
 
-    expect(getDefaultProvider()).toEqual({
-      provider: "openai",
-      connectionName: "openai-work",
-    });
+    expect(getDefaultProvider()).toEqual({ provider: "openai" });
 
     const raw = loadRawConfig();
     const llm = raw.llm as Record<string, unknown>;
-    expect(llm.defaultProvider).toEqual({
-      provider: "openai",
-      connectionName: "openai-work",
-    });
+    expect(llm.defaultProvider).toEqual({ provider: "openai" });
   });
 
   test("setDefaultProvider validates the provider before writing", () => {

--- a/assistant/src/config/default-provider-resolution.ts
+++ b/assistant/src/config/default-provider-resolution.ts
@@ -18,15 +18,12 @@ export function getDefaultProviderFromConfig(
 }
 
 /**
- * Pure by design — no connection-existence check. A dangling name (explicit
- * or conventional) is allowed; see `DefaultProviderSchema`.
+ * Pure by design — no connection-existence check. A dangling conventional
+ * name is allowed; see `DefaultProviderSchema`.
  */
 export function resolveDefaultConnectionName(
   dp: DefaultProviderConfig,
 ): string {
-  if (dp.connectionName) {
-    return dp.connectionName;
-  }
   if (dp.provider === "vellum") {
     return VELLUM_MANAGED_CONNECTION_NAME;
   }

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -640,29 +640,32 @@ type LLMCallSiteConfig = z.infer<typeof LLMCallSiteConfig>;
 // ---------------------------------------------------------------------------
 
 /**
- * Pins which provider backs the workspace's default inference identity.
- * When `connectionName` is absent, `resolveDefaultConnectionName`
- * (`../default-provider.js`) supplies the convention.
+ * Names which provider backs the workspace's default inference identity.
+ * The backing connection is always resolved by convention
+ * (`resolveDefaultConnectionName` in `../default-provider.js`).
  *
  * No connection-existence validation on purpose: schema validation is
- * pure/sync and cannot see the sqlite `provider_connections` table, so a
- * dangling `connectionName` is allowed here and surfaced as an explainable
- * resolution error at read time.
+ * pure/sync and cannot see the sqlite `provider_connections` table, so the
+ * conventionally resolved connection may be dangling — that surfaces as an
+ * explainable resolution error at read time.
+ *
+ * Unknown keys (including the retired `connectionName` pin) strip at parse;
+ * `setDefaultProvider`'s strict parse rewrites the stripped shape on the
+ * next write, so no migration is needed.
  */
 export const DefaultProviderSchema = z.object({
   provider: DefaultProviderEnum,
-  connectionName: z.string().min(1).optional(),
 });
 export type DefaultProviderConfig = z.infer<typeof DefaultProviderSchema>;
 
 /**
  * The `.catch(undefined)` drops an invalid value atomically at parse time.
  * Without it, the loader's recovery pass (which deletes the exact key at each
- * issue path) could strand a fragment like `{ connectionName }` that fails
- * the re-parse and escalates a one-field typo into a full config-defaults
- * fallback. A `z.unknown().transform(...)` wrapper would also fix that, but
- * hides the object shape from `getSchemaAtPath` / `z.toJSONSchema`; the catch
- * value must be static because `z.toJSONSchema` rejects callbacks.
+ * issue path) could strand a fragment that fails the re-parse and escalate a
+ * one-field typo into a full config-defaults fallback. A
+ * `z.unknown().transform(...)` wrapper would also fix that, but hides the
+ * object shape from `getSchemaAtPath` / `z.toJSONSchema`; the catch value
+ * must be static because `z.toJSONSchema` rejects callbacks.
  * Writes stay loud: `setDefaultProvider` parses the strict schema directly.
  */
 const DefaultProviderField = DefaultProviderSchema.optional().catch(undefined);

--- a/assistant/src/plugin-api/vision-support.test.ts
+++ b/assistant/src/plugin-api/vision-support.test.ts
@@ -14,8 +14,7 @@ interface MockProfileEntry {
 }
 
 let mockProfiles: Record<string, MockProfileEntry> = {};
-let mockDefaultProvider: { provider: string; connectionName?: string } | null =
-  null;
+let mockDefaultProvider: { provider: string } | null = null;
 
 // Real model catalog — don't mock it, the test exercises real catalog lookups.
 const { doesSupportVision } = await import("./vision-support.js");
@@ -52,7 +51,7 @@ function applyConfig(): void {
 
 function setMockConfig(
   profiles: Record<string, MockProfileEntry>,
-  defaultProvider?: { provider: string; connectionName?: string },
+  defaultProvider?: { provider: string },
 ) {
   mockProfiles = profiles;
   mockDefaultProvider = defaultProvider ?? null;

--- a/assistant/src/runtime/routes/__tests__/default-provider-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/default-provider-routes.test.ts
@@ -211,9 +211,9 @@ describe("GET config/llm/default-provider", () => {
     expect(availability(result)).toEqual({ status: "ok" });
   });
 
-  test("explicit connectionName wins over convention", async () => {
+  test("a legacy stored connectionName pin strips at parse — convention wins", async () => {
     seedConnection({
-      name: "work-openai",
+      name: "openai-personal",
       provider: "openai",
       auth: { type: "api_key", credential: "credential/openai/api_key" },
     });
@@ -226,8 +226,8 @@ describe("GET config/llm/default-provider", () => {
     });
 
     const result = await get();
-    expect(result.connectionName).toBe("work-openai");
-    expect(result.resolvedConnectionName).toBe("work-openai");
+    expect(result.connectionName).toBeUndefined();
+    expect(result.resolvedConnectionName).toBe("openai-personal");
     expect(availability(result)).toEqual({ status: "ok" });
   });
 
@@ -282,34 +282,6 @@ describe("GET config/llm/default-provider", () => {
     expect(availability(result).message).toContain("unreachable");
   });
 
-  test("vellum with a dangling explicit connectionName → missing_connection", async () => {
-    setConfig("llm", {
-      defaultProvider: { provider: "vellum", connectionName: "ghost" },
-    });
-    const result = await get();
-    expect(availability(result).status).toBe("missing_connection");
-  });
-
-  test("vellum pinned to another provider's connection → provider_mismatch", async () => {
-    seedConnection({
-      name: "anthropic-personal",
-      provider: "anthropic",
-      auth: { type: "api_key", credential: "credential/anthropic/api_key" },
-    });
-    secureKeyResults["credential/anthropic/api_key"] = {
-      value: "sk-ant",
-      unreachable: false,
-    };
-    setConfig("llm", {
-      defaultProvider: {
-        provider: "vellum",
-        connectionName: "anthropic-personal",
-      },
-    });
-    const result = await get();
-    expect(availability(result).status).toBe("provider_mismatch");
-  });
-
   test("none-auth connection on a keyed provider → unsupported_auth", async () => {
     seedConnection({
       name: "openai-personal",
@@ -321,60 +293,6 @@ describe("GET config/llm/default-provider", () => {
     const result = await get();
     expect(availability(result).status).toBe("unsupported_auth");
     expect(availability(result).message).toContain("API key");
-  });
-
-  test("explicit connectionName for a different provider → provider_mismatch even with credentials", async () => {
-    seedConnection({
-      name: "anthropic-personal",
-      provider: "anthropic",
-      auth: { type: "api_key", credential: "credential/anthropic/api_key" },
-    });
-    secureKeyResults["credential/anthropic/api_key"] = {
-      value: "sk-ant",
-      unreachable: false,
-    };
-    setConfig("llm", {
-      defaultProvider: {
-        provider: "openai",
-        connectionName: "anthropic-personal",
-      },
-    });
-
-    const result = await get();
-    expect(availability(result).status).toBe("provider_mismatch");
-    expect(availability(result).message).toContain('"anthropic"');
-    expect(availability(result).message).toContain('"openai"');
-  });
-
-  test("vellum-managed connection pinned for a managed-routable provider follows platform auth", async () => {
-    seedConnection({
-      name: "vellum",
-      provider: "vellum",
-      auth: { type: "platform" },
-    });
-    setConfig("llm", {
-      defaultProvider: { provider: "anthropic", connectionName: "vellum" },
-    });
-
-    expect(availability(await get()).status).toBe("vellum_unauthenticated");
-    managedProxyEnabled = true;
-    expect(availability(await get()).status).toBe("ok");
-  });
-
-  test("vellum-managed connection pinned for a non-managed provider → provider_mismatch", async () => {
-    seedConnection({
-      name: "vellum",
-      provider: "vellum",
-      auth: { type: "platform" },
-    });
-    managedProxyEnabled = true;
-    setConfig("llm", {
-      defaultProvider: { provider: "openrouter", connectionName: "vellum" },
-    });
-
-    const result = await get();
-    expect(availability(result).status).toBe("provider_mismatch");
-    expect(availability(result).message).toContain("Vellum-managed");
   });
 
   test("service_account connection → unsupported_auth even with a stored credential", async () => {
@@ -457,12 +375,9 @@ describe("PUT config/llm/default-provider", () => {
     expect(availability(result)).toEqual({ status: "ok" });
   });
 
-  test("persists an explicit connectionName", async () => {
+  test("a legacy connectionName in the body is stripped, not rejected", async () => {
     await put({ provider: "openai", connectionName: "work-openai" });
-    expect(persistedDefaultProvider()).toEqual({
-      provider: "openai",
-      connectionName: "work-openai",
-    });
+    expect(persistedDefaultProvider()).toEqual({ provider: "openai" });
   });
 
   test("dangling connection is accepted and reported via availability", async () => {
@@ -472,42 +387,6 @@ describe("PUT config/llm/default-provider", () => {
     >;
     expect(persistedDefaultProvider()).toEqual({ provider: "gemini" });
     expect(availability(result).status).toBe("missing_connection");
-  });
-
-  test("a noncanonical pin on a routing identity → 400 naming the canonical row", async () => {
-    for (const [provider, canonical] of [
-      ["chatgpt", "chatgpt-subscription"],
-      ["vellum", "vellum"],
-    ] as const) {
-      const err = await put({
-        provider,
-        connectionName: "some-other-row",
-      }).catch((e: unknown) => e);
-      expect(String(err)).toContain(canonical);
-    }
-  });
-
-  test("the canonical pin on a routing identity is accepted", async () => {
-    seedConnection({
-      name: "chatgpt-subscription",
-      provider: "chatgpt",
-      auth: {
-        type: "oauth_subscription",
-        credential: "credential/chatgpt/access_token",
-      },
-    });
-    secureKeyResults["credential/chatgpt/access_token"] = {
-      value: "token",
-      unreachable: false,
-    };
-
-    const result = (await put({
-      provider: "chatgpt",
-      connectionName: "chatgpt-subscription",
-    })) as Record<string, unknown>;
-
-    expect(result.resolvedConnectionName).toBe("chatgpt-subscription");
-    expect(availability(result)).toEqual({ status: "ok" });
   });
 
   test("invalid provider → 400 naming the allowed providers", async () => {

--- a/assistant/src/runtime/routes/__tests__/inference-provider-connection-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/inference-provider-connection-routes.test.ts
@@ -1035,9 +1035,16 @@ describe("DELETE guards the llm.defaultProvider reference", () => {
     });
   });
 
-  test("throws 409 deleting the default's explicit connectionName", async () => {
+  test("a legacy stored connectionName pin does not protect its row", async () => {
+    // The retired pin strips at parse; only the convention-resolved name and
+    // the last-connection fallback guard deletes.
     seedConnection({
       name: "my-conn",
+      provider: "openai",
+      auth: { type: "platform" },
+    });
+    seedConnection({
+      name: "openai-work",
       provider: "openai",
       auth: { type: "platform" },
     });
@@ -1045,11 +1052,11 @@ describe("DELETE guards the llm.defaultProvider reference", () => {
       defaultProvider: { provider: "openai", connectionName: "my-conn" },
     });
 
-    await expect(
-      call(findHandler("inference_provider_connections_delete"), {
-        pathParams: { name: "my-conn" },
-      }),
-    ).rejects.toBeInstanceOf(ConflictError);
+    const result = await call(
+      findHandler("inference_provider_connections_delete"),
+      { pathParams: { name: "my-conn" } },
+    );
+    expect(result).toEqual({ ok: true });
   });
 
   test("throws 409 deleting the last connection for the default provider when the convention name is dangling", async () => {
@@ -1072,28 +1079,6 @@ describe("DELETE guards the llm.defaultProvider reference", () => {
     expect((err as ConflictError).details).toEqual({
       referencedBy: ["llm.defaultProvider"],
     });
-  });
-
-  test("succeeds deleting an unrelated last same-provider connection when the default pins an explicit connectionName", async () => {
-    // The explicit pin is what the default references; "anthropic-work" is
-    // unrelated even though it is the only anthropic row.
-    seedConnection({
-      name: "anthropic-work",
-      provider: "anthropic",
-      auth: { type: "platform" },
-    });
-    setConfig("llm", {
-      defaultProvider: {
-        provider: "anthropic",
-        connectionName: "anthropic-personal",
-      },
-    });
-
-    const result = await call(
-      findHandler("inference_provider_connections_delete"),
-      { pathParams: { name: "anthropic-work" } },
-    );
-    expect(result).toEqual({ ok: true });
   });
 
   test("throws 409 deleting the last visible connection when a hidden legacy row shares the provider", async () => {

--- a/assistant/src/runtime/routes/default-provider-routes.ts
+++ b/assistant/src/runtime/routes/default-provider-routes.ts
@@ -9,9 +9,10 @@
  * silently dropped on the next reparse instead of rejected. This route
  * strict-parses and fails loudly.
  *
- * Availability is reported, never enforced: a dangling connection name is a
- * valid persisted state by design (see `DefaultProviderSchema`), and the GET
- * names what is broken and how to fix it.
+ * Availability is reported, never enforced: a dangling conventional
+ * connection is a valid persisted state by design (see
+ * `DefaultProviderSchema`), and the GET names what is broken and how to fix
+ * it.
  */
 import { z } from "zod";
 
@@ -25,7 +26,6 @@ import {
   DEFAULT_PROVIDER_CHOICES,
   DefaultProviderSchema,
 } from "../../config/schemas/llm.js";
-import { ROUTING_IDENTITY_PROVIDERS } from "../../providers/inference/auth.js";
 import {
   computeConnectionAvailability,
   CONNECTION_AVAILABILITY_STATUSES,
@@ -47,9 +47,7 @@ const defaultProviderStatusSchema = z
     provider: z
       .enum(DEFAULT_PROVIDER_CHOICES as [string, ...string[]])
       .nullable(),
-    /** Explicit connection pin, when the persisted value carries one. */
-    connectionName: z.string().optional(),
-    /** The connection the default resolves to (explicit pin or convention). */
+    /** The connection the default resolves to by convention. */
     resolvedConnectionName: z.string().nullable(),
     availability: availabilitySchema,
   })
@@ -74,7 +72,6 @@ async function handleGetDefaultProvider(): Promise<DefaultProviderStatus> {
   const resolvedConnectionName = resolveDefaultConnectionName(dp);
   return {
     provider: dp.provider,
-    ...(dp.connectionName ? { connectionName: dp.connectionName } : {}),
     resolvedConnectionName,
     availability: await computeConnectionAvailability(
       dp.provider,
@@ -91,22 +88,8 @@ async function handlePutDefaultProvider({
     throw new BadRequestError(
       `Invalid default provider. "provider" must be one of: ${DEFAULT_PROVIDER_CHOICES.join(
         ", ",
-      )}; "connectionName" is optional and must be a non-empty string.`,
+      )}.`,
     );
-  }
-  // Routing identities dispatch through their canonical row regardless of
-  // any stored pin (`resolveRoutingIdentity`), so a noncanonical
-  // connectionName would be judged by availability and the deletion guards
-  // while inference uses a different row. Reject it here rather than
-  // persisting a pin that status and dispatch disagree about.
-  const { provider, connectionName } = result.data;
-  if (connectionName != null && ROUTING_IDENTITY_PROVIDERS.has(provider)) {
-    const canonical = resolveDefaultConnectionName({ provider });
-    if (connectionName !== canonical) {
-      throw new BadRequestError(
-        `Provider "${provider}" always dispatches through its canonical connection "${canonical}". Omit "connectionName" or pass "${canonical}".`,
-      );
-    }
   }
   setDefaultProvider(result.data);
   return handleGetDefaultProvider();
@@ -124,7 +107,7 @@ export const ROUTES: RouteDefinition[] = [
     handler: handleGetDefaultProvider,
     summary: "Get the default provider and its availability",
     description:
-      "Returns `llm.defaultProvider`, the connection name it resolves to, and whether that connection is currently usable (connection exists, credential stored, Vellum authenticated). Availability is informational — a broken default is a valid persisted state that surfaces explainable errors at resolution time.",
+      "Returns `llm.defaultProvider`, the connection name it conventionally resolves to, and whether that connection is currently usable (connection exists, credential stored, Vellum authenticated). Availability is informational — a broken default is a valid persisted state that surfaces explainable errors at resolution time.",
     tags: ["config"],
     responseBody: defaultProviderStatusSchema,
   },
@@ -139,7 +122,7 @@ export const ROUTES: RouteDefinition[] = [
     handler: handlePutDefaultProvider,
     summary: "Set the default provider",
     description:
-      "Replaces `llm.defaultProvider`. Strict-validates the body (unlike the generic config write paths, which silently drop invalid values). Does not require the referenced connection to exist — a dangling name is allowed by design and reported via the availability status.",
+      "Replaces `llm.defaultProvider`. Strict-validates the body (unlike the generic config write paths, which silently drop invalid values). Does not require the conventionally resolved connection to exist — a dangling name is allowed by design and reported via the availability status.",
     tags: ["config"],
     requestBody: DefaultProviderSchema,
     responseBody: defaultProviderStatusSchema,

--- a/assistant/src/runtime/routes/inference-provider-connection-routes.ts
+++ b/assistant/src/runtime/routes/inference-provider-connection-routes.ts
@@ -583,16 +583,13 @@ async function handleDeleteConnection({ pathParams = {} }: RouteHandlerArgs) {
 
   const config = getConfigReadOnly();
 
-  // llm.defaultProvider: guards both the resolved connection name (explicit
-  // `connectionName` or the `<provider>-personal` convention) and the case
-  // where the convention name is dangling but this is the last remaining
-  // connection for the default's provider — resolution treats a dangling
-  // default as an explainable error; this guard keeps UI deletes from
-  // orphaning it silently. The last-connection fallback only applies to
-  // convention resolution: an explicit `connectionName` pins exactly one row
-  // (protected above), so unrelated same-provider rows stay deletable. Legacy
-  // managed rows are excluded from the count for the same reason the list
-  // route hides them — they aren't user-manageable connections.
+  // llm.defaultProvider: guards both the convention-resolved connection name
+  // and the case where the convention name is dangling but this is the last
+  // remaining connection for the default's provider — resolution treats a
+  // dangling default as an explainable error; this guard keeps UI deletes
+  // from orphaning it silently. Legacy managed rows are excluded from the
+  // count for the same reason the list route hides them — they aren't
+  // user-manageable connections.
   const dp = getDefaultProviderFromConfig(config);
   // A `vellum` default resolves to the canonical name, so this guard would
   // otherwise block deleting a row that merely claims that name. Deleting it
@@ -606,7 +603,6 @@ async function handleDeleteConnection({ pathParams = {} }: RouteHandlerArgs) {
       );
     }
     if (
-      !dp.connectionName &&
       existing.provider === dp.provider &&
       listConnections(getDb(), { provider: dp.provider }).filter(
         (c) => !LEGACY_MANAGED_CONNECTION_NAMES.has(c.name),

--- a/assistant/src/workspace/default-provider-ensure.ts
+++ b/assistant/src/workspace/default-provider-ensure.ts
@@ -30,9 +30,9 @@ import { getProviderKeyAsync } from "../security/secure-keys.js";
 //
 // Idempotent: never overwrites an existing *valid* `llm.defaultProvider`
 // value (an invalid persisted object is dropped by LLMSchema's catch at
-// parse, so replacing it is repair, not overwrite), and never writes
-// `connectionName` — convention resolution
-// (`resolveDefaultConnectionName`) owns the name.
+// parse, so replacing it is repair, not overwrite). The value is
+// provider-only; convention resolution (`resolveDefaultConnectionName`)
+// owns the backing connection name.
 //
 // The legacy `llm.default.provider` field is only honored as BYOK intent
 // when it is unambiguous: `LLMConfigBase.provider` defaults to "anthropic"

--- a/clients/web/src/domains/settings/ai/provider-row-meta.test.ts
+++ b/clients/web/src/domains/settings/ai/provider-row-meta.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import { getModelsForProvider } from "@/assistant/llm-model-catalog";
 import { CODEX_SUBSCRIPTION_MODEL_IDS } from "@/domains/settings/ai/codex-subscription-models";
 import {
+  isDefaultConventionTarget,
   isDefaultProviderId,
   providerRowMeta,
 } from "@/domains/settings/ai/provider-row-meta";
@@ -19,6 +20,31 @@ function connection(auth: ProviderConnection["auth"]): ProviderConnection {
 describe("default-provider eligibility", () => {
   test("the chatgpt identity row can be set as default", () => {
     expect(isDefaultProviderId("chatgpt")).toBe(true);
+  });
+});
+
+describe("isDefaultConventionTarget", () => {
+  const row = (name: string, provider: string) =>
+    ({ name, provider }) as ProviderConnection;
+
+  test("mirrors the daemon's convention resolution per provider", () => {
+    expect(isDefaultConventionTarget(row("vellum", "vellum"))).toBe(true);
+    expect(
+      isDefaultConventionTarget(row("chatgpt-subscription", "chatgpt")),
+    ).toBe(true);
+    expect(
+      isDefaultConventionTarget(row("anthropic-personal", "anthropic")),
+    ).toBe(true);
+  });
+
+  test("suffix-named duplicates and noncanonical rows are not targets", () => {
+    expect(
+      isDefaultConventionTarget(row("anthropic-personal-2", "anthropic")),
+    ).toBe(false);
+    expect(isDefaultConventionTarget(row("my-vellum", "vellum"))).toBe(false);
+    expect(isDefaultConventionTarget(row("chatgpt-personal", "chatgpt"))).toBe(
+      false,
+    );
   });
 });
 

--- a/clients/web/src/domains/settings/ai/provider-row-meta.ts
+++ b/clients/web/src/domains/settings/ai/provider-row-meta.ts
@@ -36,6 +36,24 @@ export function isDefaultProviderId(
 }
 
 /**
+ * Whether this row is the one convention resolution would select as the
+ * default for its provider (mirrors the daemon's
+ * `resolveDefaultConnectionName`). The default-provider PUT carries only the
+ * provider, so offering "Set as default" on any other row (e.g. a
+ * suffix-named duplicate like `anthropic-personal-2`) would silently target
+ * the convention row instead of the clicked one.
+ */
+export function isDefaultConventionTarget(conn: ProviderConnection): boolean {
+  if (conn.provider === VELLUM_CONNECTION_PROVIDER) {
+    return conn.name === VELLUM_CONNECTION_PROVIDER;
+  }
+  if (conn.provider === CHATGPT_CONNECTION_PROVIDER) {
+    return conn.name === "chatgpt-subscription";
+  }
+  return conn.name === `${conn.provider}-personal`;
+}
+
+/**
  * Endpoint meta for a custom (openai-compatible) provider: the endpoint
  * host plus what it serves, e.g. "api.x.ai · 2 models" or
  * "127.0.0.1:1234 · keyless".

--- a/clients/web/src/domains/settings/ai/provider-row.tsx
+++ b/clients/web/src/domains/settings/ai/provider-row.tsx
@@ -7,6 +7,7 @@ import { Tag } from "@vellumai/design-library/components/tag";
 
 import { providerConnectionDisplayName } from "@/domains/settings/ai/provider-editor-constants";
 import {
+  isDefaultConventionTarget,
   isDefaultProviderId,
   providerRowMeta,
 } from "@/domains/settings/ai/provider-row-meta";
@@ -49,7 +50,12 @@ export function ProviderRow({
   const { t } = useTranslation("settings");
   const isManaged = connection.isManaged ?? false;
   const displayName = providerConnectionDisplayName(connection);
-  const eligibleForDefault = isDefaultProviderId(connection.provider);
+  // Convention-target only: the set-default PUT carries just the provider,
+  // so on any other row the daemon would pick the convention row while the
+  // UI reported success against the clicked one.
+  const eligibleForDefault =
+    isDefaultProviderId(connection.provider) &&
+    isDefaultConventionTarget(connection);
   const meta = providerRowMeta(connection);
 
   const showSetDefault =
@@ -76,10 +82,7 @@ export function ProviderRow({
       trailing={
         <>
           {isManaged ? (
-            <Tag
-              tone="neutral"
-              title={t("providerRow.managedTagTitle")}
-            >
+            <Tag tone="neutral" title={t("providerRow.managedTagTitle")}>
               {t("providerRow.managedTag")}
             </Tag>
           ) : null}
@@ -117,7 +120,10 @@ export function ProviderRow({
                   </Menu.Item>
                 ) : null}
                 {showSetDefault ? (
-                  <Menu.Item disabled={isSettingDefault} onSelect={onSetDefault}>
+                  <Menu.Item
+                    disabled={isSettingDefault}
+                    onSelect={onSetDefault}
+                  >
                     {t("providerRow.setAsDefault")}
                   </Menu.Item>
                 ) : null}

--- a/clients/web/src/domains/settings/ai/providers-section.test.tsx
+++ b/clients/web/src/domains/settings/ai/providers-section.test.tsx
@@ -81,12 +81,10 @@ mock.module("@/generated/daemon/sdk.gen", () => ({
   },
 }));
 
-const { ProvidersSection } = await import(
-  "@/domains/settings/ai/providers-section"
-);
-const { useAssistantIdentityStore } = await import(
-  "@/stores/assistant-identity-store"
-);
+const { ProvidersSection } =
+  await import("@/domains/settings/ai/providers-section");
+const { useAssistantIdentityStore } =
+  await import("@/stores/assistant-identity-store");
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -275,6 +273,29 @@ describe("ProvidersSection - kebab actions", () => {
     await waitFor(() => {
       expect(putBodies).toEqual([{ provider: "anthropic" }]);
     });
+  });
+
+  test("a non-convention row offers no Set as default", async () => {
+    // The PUT body carries only the provider, so on a suffix-named
+    // duplicate the daemon would set the convention row instead of the
+    // clicked one — the affordance is hidden there.
+    connectionsState = [
+      ...connectionsState,
+      connection({
+        name: "anthropic-personal-2",
+        provider: "anthropic",
+        label: "Anthropic (work)",
+      }),
+    ];
+    renderSection();
+    await waitFor(() => {
+      expect(rows().length).toBe(4);
+    });
+    const menu = await openKebab("Anthropic (work)");
+    const items = menuItems(menu);
+    expect(items).not.toContain("Set as default");
+    expect(items).toContain("Edit");
+    expect(items).toContain("Delete");
   });
 
   test("an ineligible provider offers no Set as default", async () => {

--- a/clients/web/src/domains/settings/ai/providers-section.test.tsx
+++ b/clients/web/src/domains/settings/ai/providers-section.test.tsx
@@ -3,7 +3,8 @@
  * Model card.
  *
  * The Default chip tracks the resolved default connection and its kebab
- * hides Delete; Set as default PUTs the explicit provider + connectionName;
+ * hides Delete; Set as default PUTs the row's provider (the daemon resolves
+ * the connection by convention);
  * assistants without the default-provider routes get no marker UI and no
  * status query; the managed Vellum row pins first with a Managed chip and
  * no edit affordance; delete guards (409) surface as user-facing toasts.
@@ -31,7 +32,7 @@ let defaultProviderState: DefaultProviderStatus = {
   availability: { status: "missing_default" },
 };
 let defaultProviderGetCalls = 0;
-let putBodies: Array<{ provider: string; connectionName?: string }> = [];
+let putBodies: Array<{ provider: string }> = [];
 let deleteCalls: string[] = [];
 let deleteStatus = 200;
 let toastErrors: string[] = [];
@@ -63,7 +64,7 @@ mock.module("@/generated/daemon/sdk.gen", () => ({
     return { data: defaultProviderState };
   },
   configLlmDefaultproviderPut: async (options?: {
-    body?: { provider: string; connectionName?: string };
+    body?: { provider: string };
   }) => {
     if (options?.body) {
       putBodies.push(options.body);
@@ -259,7 +260,7 @@ describe("ProvidersSection - rows and chips", () => {
 });
 
 describe("ProvidersSection - kebab actions", () => {
-  test("Set as default PUTs the explicit provider + connectionName", async () => {
+  test("Set as default PUTs the row's provider only", async () => {
     defaultProviderState = {
       provider: "vellum",
       resolvedConnectionName: "vellum",
@@ -272,9 +273,7 @@ describe("ProvidersSection - kebab actions", () => {
     const menu = await openKebab("Anthropic");
     clickMenuItem(menu, "Set as default");
     await waitFor(() => {
-      expect(putBodies).toEqual([
-        { provider: "anthropic", connectionName: "anthropic-personal" },
-      ]);
+      expect(putBodies).toEqual([{ provider: "anthropic" }]);
     });
   });
 

--- a/clients/web/src/domains/settings/ai/use-provider-actions.ts
+++ b/clients/web/src/domains/settings/ai/use-provider-actions.ts
@@ -4,7 +4,10 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { toast } from "@vellumai/design-library/components/toast";
 
-import { isDefaultProviderId } from "@/domains/settings/ai/provider-row-meta";
+import {
+  isDefaultConventionTarget,
+  isDefaultProviderId,
+} from "@/domains/settings/ai/provider-row-meta";
 import { t } from "@/i18n";
 import {
   configGetQueryKey,
@@ -62,7 +65,13 @@ export function useProviderActions(
   });
 
   function setDefault(conn: ProviderConnection) {
-    if (!isDefaultProviderId(conn.provider)) {
+    // Convention-target check mirrors the row's affordance gate: the PUT
+    // body carries only the provider, so on any other row the daemon would
+    // set the convention row, not this one.
+    if (
+      !isDefaultProviderId(conn.provider) ||
+      !isDefaultConventionTarget(conn)
+    ) {
       return;
     }
     pendingDefaultNameRef.current = conn.name;

--- a/clients/web/src/domains/settings/ai/use-provider-actions.ts
+++ b/clients/web/src/domains/settings/ai/use-provider-actions.ts
@@ -1,3 +1,5 @@
+import { useRef } from "react";
+
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { toast } from "@vellumai/design-library/components/toast";
@@ -35,6 +37,10 @@ export function useProviderActions(
 ): ProviderActions {
   const queryClient = useQueryClient();
   const pathOpts = { path: { assistant_id: assistantId } };
+  // The PUT body carries only the provider (the daemon resolves the backing
+  // connection by convention), so the row the pending mutation targets is
+  // tracked here for `isSettingDefault`.
+  const pendingDefaultNameRef = useRef<string | null>(null);
 
   const setDefaultMutation = useMutation({
     ...configLlmDefaultproviderPutMutation(),
@@ -59,16 +65,16 @@ export function useProviderActions(
     if (!isDefaultProviderId(conn.provider)) {
       return;
     }
+    pendingDefaultNameRef.current = conn.name;
     setDefaultMutation.mutate({
       path: { assistant_id: assistantId },
-      body: { provider: conn.provider, connectionName: conn.name },
+      body: { provider: conn.provider },
     });
   }
 
   function isSettingDefault(name: string): boolean {
     return (
-      setDefaultMutation.isPending &&
-      setDefaultMutation.variables?.body?.connectionName === name
+      setDefaultMutation.isPending && pendingDefaultNameRef.current === name
     );
   }
 

--- a/clients/web/src/lib/billing/byok-credit-route.test.ts
+++ b/clients/web/src/lib/billing/byok-credit-route.test.ts
@@ -612,12 +612,10 @@ describe("stale managed default stubs", () => {
         llm: {
           activeProfile: "balanced",
           profiles: { balanced: STALE_BALANCED },
-          defaultProvider: {
-            provider: "anthropic",
-            connectionName: "my-anthropic",
-          },
+          defaultProvider: { provider: "anthropic" },
         },
         connections: [BYOK_ANTHROPIC],
+        defaultProviderResolvedConnection: "my-anthropic",
       }),
     ).toBe(false);
   });
@@ -666,13 +664,11 @@ describe("anchor fallbacks", () => {
       classify({
         llm: {
           default: { provider: "vellum", model: "claude" },
-          defaultProvider: {
-            provider: "anthropic",
-            connectionName: "my-anthropic",
-          },
+          defaultProvider: { provider: "anthropic" },
         },
         connections: [BYOK_ANTHROPIC],
         defaultProviderAvailability: "ok",
+        defaultProviderResolvedConnection: "my-anthropic",
       }),
     ).toBe(false);
     expect(
@@ -680,7 +676,7 @@ describe("anchor fallbacks", () => {
     ).toBeNull();
   });
 
-  test("an unset connectionName binds through the resolved conventional connection", () => {
+  test("the anchor binds through the resolved conventional connection", () => {
     // The daemon stamps `resolveDefaultConnectionName` onto default bodies;
     // without it the anchor would misread as unbound and a coexisting
     // platform-auth row for the provider would classify the route managed.
@@ -696,16 +692,14 @@ describe("anchor fallbacks", () => {
 
   test("defaultProvider proves BYOK only with an ok availability", () => {
     const llm: LlmConfig = {
-      defaultProvider: {
-        provider: "anthropic",
-        connectionName: "my-anthropic",
-      },
+      defaultProvider: { provider: "anthropic" },
     };
     expect(
       classify({
         llm,
         connections: [BYOK_ANTHROPIC],
         defaultProviderAvailability: "ok",
+        defaultProviderResolvedConnection: "my-anthropic",
       }),
     ).toBe(false);
     expect(
@@ -713,6 +707,7 @@ describe("anchor fallbacks", () => {
         llm,
         connections: [BYOK_ANTHROPIC],
         defaultProviderAvailability: "missing_credential",
+        defaultProviderResolvedConnection: "my-anthropic",
       }),
     ).toBeNull();
   });

--- a/clients/web/src/lib/billing/byok-credit-route.ts
+++ b/clients/web/src/lib/billing/byok-credit-route.ts
@@ -38,8 +38,7 @@ export interface ChatRouteEvidence {
   defaultProviderAvailability?: DefaultProviderAvailabilityStatus;
   /**
    * The connection the default-provider route conventionally resolves to
-   * when `connectionName` is unset (`resolvedConnectionName` from the same
-   * status response).
+   * (`resolvedConnectionName` from the same status response).
    */
   defaultProviderResolvedConnection?: string | null;
   /** The active conversation's `inferenceProfile` pin, when the caller has one. */
@@ -310,11 +309,13 @@ export function defaultChatRouteBurnsManagedCredits(
 }
 
 /**
- * The billing route of the `llm.defaultProvider` anchor: the explicit
- * `connectionName` when set, else the conventionally resolved connection the
- * daemon stamps onto default bodies (`resolvedConnectionName` from the
- * default-provider status), so an unset name doesn't misread as unbound
- * dispatch. Null when no default provider is configured.
+ * The billing route of the `llm.defaultProvider` anchor: the conventionally
+ * resolved connection the daemon stamps onto default bodies
+ * (`resolvedConnectionName` from the default-provider status), so an unset
+ * name doesn't misread as unbound dispatch. Old daemons may still emit an
+ * explicit `connectionName` pin in this evidence; it is ignored — their pins
+ * were canonical-or-conventional anyway. Null when no default provider is
+ * configured.
  */
 function defaultProviderRouteEntry(
   evidence: ChatRouteEvidence,
@@ -326,9 +327,7 @@ function defaultProviderRouteEntry(
   return {
     provider: defaultProvider.provider,
     provider_connection:
-      defaultProvider.connectionName ??
-      evidence.defaultProviderResolvedConnection ??
-      undefined,
+      evidence.defaultProviderResolvedConnection ?? undefined,
   };
 }
 


### PR DESCRIPTION
## Summary
- Deletes connectionName from DefaultProviderSchema; resolveDefaultConnectionName becomes pure convention
- GET/PUT default-provider and the CLI --connection flag drop the pin; web stops sending connectionName
- No migration: stored keys strip at parse and self-heal on next write (accepted tiny-cohort fallback, see plan)

Part of plan: conn-removal-13b-step4-demolition.md (PR 3 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41019" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->