### PR TITLE
refactor(providers): stop persisting auth.type — derive from the provider column

### DIFF
--- a/assistant/src/__tests__/config-loader-backfill.test.ts
+++ b/assistant/src/__tests__/config-loader-backfill.test.ts
@@ -66,6 +66,7 @@ import {
 } from "../config/loader.js";
 import { seedInferenceProfiles } from "../config/seed-inference-profiles.js";
 import type { DrizzleDb } from "../persistence/db-connection.js";
+import { getSqliteFrom } from "../persistence/db-connection.js";
 import { migrateCreateProviderConnections } from "../persistence/migrations/243-provider-connections.js";
 import { migrateProviderConnectionStatusLabel } from "../persistence/migrations/244-provider-connection-status-label.js";
 import { migrateProviderConnectionBaseUrlAndModels } from "../persistence/migrations/250-provider-connection-base-url-and-models.js";
@@ -1704,10 +1705,18 @@ describe("seedInferenceProfiles BYOK-mode default profiles", () => {
     expect(raw.llm.profiles.balanced.provider_connection).toBe(
       "anthropic-personal",
     );
-    // Connections exist (status is no longer a connection-level concept).
-    expect(getConnection(db, "anthropic-managed")).not.toBeNull();
-    expect(getConnection(db, "openai-managed")).not.toBeNull();
-    expect(getConnection(db, "gemini-managed")).not.toBeNull();
+    // The seed leaves the legacy migration-243 rows in place. They sit in
+    // their pre-361 shape here (concrete provider, platform auth), which the
+    // loaders drop as underivable; on a real install migration 361 rewrites
+    // them to provider "vellum" before anything reads them. Assert on the raw
+    // rows, not the loader.
+    const rawRowExists = (name: string): boolean =>
+      getSqliteFrom(db)
+        .query(`SELECT 1 FROM provider_connections WHERE name = ?`)
+        .get(name) !== null;
+    expect(rawRowExists("anthropic-managed")).toBe(true);
+    expect(rawRowExists("openai-managed")).toBe(true);
+    expect(rawRowExists("gemini-managed")).toBe(true);
   });
 
   test("non-hatch off-platform boot writes no managed entries and never auto-disables the defaults", () => {

--- a/assistant/src/__tests__/workspace-migration-144-convert-stranded-subscription-openai-profiles.test.ts
+++ b/assistant/src/__tests__/workspace-migration-144-convert-stranded-subscription-openai-profiles.test.ts
@@ -41,7 +41,9 @@ function readConfig(): Record<string, unknown> {
 interface SeedRow {
   name: string;
   provider: string;
-  authType: string;
+  authType?: string;
+  /** Raw auth object; wins over authType when present. */
+  auth?: object;
 }
 
 function seedConnections(rows: SeedRow[]): void {
@@ -54,14 +56,19 @@ function seedConnections(rows: SeedRow[]): void {
   for (const row of rows) {
     db.run(
       `INSERT INTO provider_connections (name, provider, auth) VALUES (?, ?, ?)`,
-      [row.name, row.provider, JSON.stringify({ type: row.authType })],
+      [
+        row.name,
+        row.provider,
+        JSON.stringify(row.auth ?? { type: row.authType }),
+      ],
     );
   }
   db.close();
 }
 
-// Both on-disk shapes of the canonical row: before DB migration 366 flips
-// the provider column, and after.
+// The on-disk shapes of the canonical row: before DB migration 366 flips
+// the provider column, after it, and after DB migration 367 strips the
+// stored auth type down to the payload.
 const SUBSCRIPTION_PRE_366: SeedRow = {
   name: "chatgpt-subscription",
   provider: "openai",
@@ -71,6 +78,11 @@ const SUBSCRIPTION_POST_366: SeedRow = {
   name: "chatgpt-subscription",
   provider: "chatgpt",
   authType: "oauth_subscription",
+};
+const SUBSCRIPTION_POST_367: SeedRow = {
+  name: "chatgpt-subscription",
+  provider: "chatgpt",
+  auth: { credential: "credential/chatgpt/access_token" },
 };
 const OPENAI_KEY_ROW: SeedRow = {
   name: "openai-personal",
@@ -128,6 +140,7 @@ describe("144-convert-stranded-subscription-openai-profiles migration", () => {
   test.each([
     ["pre-366 row shape", SUBSCRIPTION_PRE_366],
     ["post-366 row shape", SUBSCRIPTION_POST_366],
+    ["post-367 typeless row shape", SUBSCRIPTION_POST_367],
   ] as const)(
     "converts unpinned openai fragments in a subscription-only workspace (%s)",
     (_label, subscriptionRow) => {

--- a/assistant/src/persistence/migrations/367-strip-stored-auth-type.test.ts
+++ b/assistant/src/persistence/migrations/367-strip-stored-auth-type.test.ts
@@ -1,0 +1,127 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+
+import { drizzle } from "drizzle-orm/bun-sqlite";
+
+import * as schema from "../schema.js";
+import { migrateStripStoredAuthType } from "./367-strip-stored-auth-type.js";
+
+function createTestDb() {
+  const sqlite = new Database(":memory:");
+  sqlite.exec(/*sql*/ `
+    CREATE TABLE provider_connections (
+      name        TEXT PRIMARY KEY,
+      provider    TEXT NOT NULL,
+      auth        TEXT NOT NULL,
+      label       TEXT,
+      base_url    TEXT,
+      models      TEXT,
+      created_at  INTEGER NOT NULL,
+      updated_at  INTEGER NOT NULL
+    );
+  `);
+  return { sqlite, db: drizzle(sqlite, { schema }) };
+}
+
+function insertRow(
+  sqlite: Database,
+  name: string,
+  provider: string,
+  auth: string,
+): void {
+  sqlite
+    .query(
+      /*sql*/ `INSERT INTO provider_connections (name, provider, auth, created_at, updated_at)
+       VALUES (?, ?, ?, 1, 1)`,
+    )
+    .run(name, provider, auth);
+}
+
+function readAuth(sqlite: Database, name: string): string | undefined {
+  const row = sqlite
+    .query(`SELECT auth FROM provider_connections WHERE name = ?`)
+    .get(name) as { auth: string } | null;
+  return row?.auth;
+}
+
+describe("migration 367: strip stored auth type", () => {
+  test("strips the type key from every auth kind, keeping the credential payload", () => {
+    const { sqlite, db } = createTestDb();
+    insertRow(
+      sqlite,
+      "anthropic-personal",
+      "anthropic",
+      '{"type":"api_key","credential":"credential/anthropic/api_key"}',
+    );
+    insertRow(sqlite, "vellum", "vellum", '{"type":"platform"}');
+    insertRow(sqlite, "ollama-personal", "ollama", '{"type":"none"}');
+    insertRow(
+      sqlite,
+      "chatgpt-subscription",
+      "chatgpt",
+      '{"type":"oauth_subscription","credential":"credential/chatgpt/access_token"}',
+    );
+
+    migrateStripStoredAuthType(db);
+
+    expect(JSON.parse(readAuth(sqlite, "anthropic-personal")!)).toEqual({
+      credential: "credential/anthropic/api_key",
+    });
+    expect(JSON.parse(readAuth(sqlite, "vellum")!)).toEqual({});
+    expect(JSON.parse(readAuth(sqlite, "ollama-personal")!)).toEqual({});
+    expect(JSON.parse(readAuth(sqlite, "chatgpt-subscription")!)).toEqual({
+      credential: "credential/chatgpt/access_token",
+    });
+  });
+
+  test("leaves already-typeless rows untouched", () => {
+    const { sqlite, db } = createTestDb();
+    insertRow(
+      sqlite,
+      "openrouter-personal",
+      "openrouter",
+      '{"credential":"credential/openrouter/api_key"}',
+    );
+    insertRow(sqlite, "vellum", "vellum", "{}");
+
+    migrateStripStoredAuthType(db);
+
+    expect(readAuth(sqlite, "openrouter-personal")).toBe(
+      '{"credential":"credential/openrouter/api_key"}',
+    );
+    expect(readAuth(sqlite, "vellum")).toBe("{}");
+  });
+
+  test("skips unparseable auth", () => {
+    const { sqlite, db } = createTestDb();
+    insertRow(sqlite, "broken", "openai", "not json");
+
+    migrateStripStoredAuthType(db);
+
+    expect(readAuth(sqlite, "broken")).toBe("not json");
+  });
+
+  test("is idempotent", () => {
+    const { sqlite, db } = createTestDb();
+    insertRow(
+      sqlite,
+      "anthropic-personal",
+      "anthropic",
+      '{"type":"api_key","credential":"vault/anthropic"}',
+    );
+
+    migrateStripStoredAuthType(db);
+    const afterFirst = readAuth(sqlite, "anthropic-personal");
+    migrateStripStoredAuthType(db);
+
+    expect(readAuth(sqlite, "anthropic-personal")).toBe(afterFirst);
+    expect(JSON.parse(afterFirst!)).toEqual({ credential: "vault/anthropic" });
+  });
+
+  test("no-ops without the table", () => {
+    const bare = new Database(":memory:");
+    expect(() =>
+      migrateStripStoredAuthType(drizzle(bare, { schema })),
+    ).not.toThrow();
+  });
+});

--- a/assistant/src/persistence/migrations/367-strip-stored-auth-type.test.ts
+++ b/assistant/src/persistence/migrations/367-strip-stored-auth-type.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, test } from "bun:test";
 import { drizzle } from "drizzle-orm/bun-sqlite";
 
 import * as schema from "../schema.js";
+import { migrationSteps } from "../steps.js";
 import { migrateStripStoredAuthType } from "./367-strip-stored-auth-type.js";
 
 function createTestDb() {
@@ -123,5 +124,23 @@ describe("migration 367: strip stored auth type", () => {
     expect(() =>
       migrateStripStoredAuthType(drizzle(bare, { schema })),
     ).not.toThrow();
+  });
+
+  test("declares the migrations whose predicates read the stored type as dependencies", () => {
+    // 361 and 366 match rows by the auth `type` key this step strips. The
+    // runner isolates per-step failures, so without these dependencies a
+    // multi-release upgrade could checkpoint the strip while 361 or 366
+    // threw, and their retry would no-op against the typeless rows.
+    const step = migrationSteps.find(
+      (s) => typeof s !== "function" && s.name === "migrateStripStoredAuthType",
+    );
+    expect(step).toBeTruthy();
+    if (step && typeof step !== "function") {
+      expect(step.dependsOn).toEqual([
+        "migrateCreateProviderConnections",
+        "migrateNormalizeManagedConnectionRows",
+        "migrateChatgptSubscriptionRowIdentity",
+      ]);
+    }
   });
 });

--- a/assistant/src/persistence/migrations/367-strip-stored-auth-type.ts
+++ b/assistant/src/persistence/migrations/367-strip-stored-auth-type.ts
@@ -1,0 +1,54 @@
+import { type DrizzleDb, getSqliteFrom } from "../db-connection.js";
+
+/**
+ * Rewrite `provider_connections.auth` to payload-only JSON: `{"credential":
+ * ...}` for keyed auth, `{}` otherwise. The auth type is derived from the
+ * provider column on read (vellum is the platform route, chatgpt the
+ * subscription route, keyless providers run keyless unless a credential is
+ * stored, everything else keys), so a stored `type` key is inert and only
+ * the credential payload needs to persist.
+ *
+ * Rows whose auth column is not parseable JSON are left alone (the DB
+ * loaders already treat them as invalid). Idempotent: a stripped row has no
+ * `type` key and no longer matches, and the table-exists guard covers
+ * databases from before migration 243.
+ */
+export function migrateStripStoredAuthType(database: DrizzleDb): void {
+  const raw = getSqliteFrom(database);
+
+  const tableExists = raw
+    .query(
+      `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'provider_connections'`,
+    )
+    .get();
+  if (!tableExists) {
+    return;
+  }
+
+  const rows = raw
+    .query(`SELECT name, auth FROM provider_connections`)
+    .all() as Array<{ name: string; auth: string }>;
+
+  const now = Date.now();
+  for (const row of rows) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(row.auth);
+    } catch {
+      continue;
+    }
+    if (parsed === null || typeof parsed !== "object" || !("type" in parsed)) {
+      continue;
+    }
+    const credential = (parsed as { credential?: unknown }).credential;
+    const stripped =
+      typeof credential === "string" && credential.length > 0
+        ? { credential }
+        : {};
+    raw
+      .prepare(
+        `UPDATE provider_connections SET auth = ?, updated_at = ? WHERE name = ?`,
+      )
+      .run(JSON.stringify(stripped), now, row.name);
+  }
+}

--- a/assistant/src/persistence/steps.ts
+++ b/assistant/src/persistence/steps.ts
@@ -474,6 +474,7 @@ import { migrateBackfillScheduleInferenceProfile } from "./migrations/363-backfi
 import { migrateAddScheduleSourceKey } from "./migrations/364-add-schedule-source-key.js";
 import { migrateAddConversationForkStrategy } from "./migrations/365-add-conversation-fork-strategy.js";
 import { migrateChatgptSubscriptionRowIdentity } from "./migrations/366-chatgpt-subscription-row-identity.js";
+import { migrateStripStoredAuthType } from "./migrations/367-strip-stored-auth-type.js";
 import type { MigrationStep } from "./migrations/run-migrations.js";
 
 export const migrationSteps: MigrationStep[] = [
@@ -1577,6 +1578,14 @@ export const migrationSteps: MigrationStep[] = [
   {
     name: "migrateChatgptSubscriptionRowIdentity",
     run: migrateChatgptSubscriptionRowIdentity,
+    // The table-exists guard treats a missing table as nothing-to-do, so the
+    // creating migration must be checkpointed first or a repair flow could
+    // permanently checkpoint the no-op.
+    dependsOn: ["migrateCreateProviderConnections"],
+  },
+  {
+    name: "migrateStripStoredAuthType",
+    run: migrateStripStoredAuthType,
     // The table-exists guard treats a missing table as nothing-to-do, so the
     // creating migration must be checkpointed first or a repair flow could
     // permanently checkpoint the no-op.

--- a/assistant/src/persistence/steps.ts
+++ b/assistant/src/persistence/steps.ts
@@ -1588,7 +1588,16 @@ export const migrationSteps: MigrationStep[] = [
     run: migrateStripStoredAuthType,
     // The table-exists guard treats a missing table as nothing-to-do, so the
     // creating migration must be checkpointed first or a repair flow could
-    // permanently checkpoint the no-op.
-    dependsOn: ["migrateCreateProviderConnections"],
+    // permanently checkpoint the no-op. Migrations 361 and 366 must also be
+    // checkpointed first: their predicates key on the stored auth `type`,
+    // which this step strips. The runner isolates per-step failures, so
+    // without the dependency a single upgrade running all three could
+    // checkpoint the strip while 361 or 366 threw, and their retry would
+    // no-op against typeless rows, stranding the row unreconciled.
+    dependsOn: [
+      "migrateCreateProviderConnections",
+      "migrateNormalizeManagedConnectionRows",
+      "migrateChatgptSubscriptionRowIdentity",
+    ],
   },
 ];

--- a/assistant/src/providers/__tests__/inference.test.ts
+++ b/assistant/src/providers/__tests__/inference.test.ts
@@ -97,6 +97,35 @@ describe("migrateCreateProviderConnections", () => {
 // ---------------------------------------------------------------------------
 
 describe("Connection CRUD", () => {
+  test("create, update, and seed persist payload-only auth (no type key)", () => {
+    const { db, raw } = setupDb();
+    const storedAuth = (name: string): Record<string, unknown> => {
+      const row = raw
+        .query(`SELECT auth FROM provider_connections WHERE name = ?`)
+        .get(name) as { auth: string };
+      return JSON.parse(row.auth) as Record<string, unknown>;
+    };
+
+    createConnection(db, {
+      name: "stored-shape",
+      provider: "anthropic",
+      auth: { type: "api_key", credential: "credential/anthropic/api_key" },
+    });
+    expect(storedAuth("stored-shape")).toEqual({
+      credential: "credential/anthropic/api_key",
+    });
+
+    updateConnection(db, "stored-shape", {
+      auth: { type: "api_key", credential: "credential/anthropic/other_key" },
+    });
+    expect(storedAuth("stored-shape")).toEqual({
+      credential: "credential/anthropic/other_key",
+    });
+
+    seedCanonicalConnections(db);
+    expect(storedAuth("vellum")).toEqual({});
+  });
+
   test("createConnection — happy path", () => {
     const { db } = setupDb();
     const result = createConnection(db, {
@@ -132,12 +161,12 @@ describe("Connection CRUD", () => {
     createConnection(db, {
       name: "dup-conn",
       provider: "openai",
-      auth: { type: "platform" },
+      auth: { type: "api_key", credential: "credential/openai/api_key" },
     });
     const result = createConnection(db, {
       name: "dup-conn",
       provider: "openai",
-      auth: { type: "platform" },
+      auth: { type: "api_key", credential: "credential/openai/api_key" },
     });
     expect(result.ok).toBe(false);
     if (result.ok) {
@@ -167,7 +196,7 @@ describe("Connection CRUD", () => {
     createConnection(db, {
       name: "updatable",
       provider: "anthropic",
-      auth: { type: "platform" },
+      auth: { type: "api_key", credential: "credential/anthropic/old_key" },
     });
     const result = updateConnection(db, "updatable", {
       auth: { type: "api_key", credential: "credential/anthropic/api_key" },
@@ -182,7 +211,7 @@ describe("Connection CRUD", () => {
   });
 
   test("updateConnection: provider correction rides an auth rewrite", () => {
-    // The ChatGPT sign-in flow stamps provider "openai" when it writes
+    // The ChatGPT sign-in flow stamps provider "chatgpt" when it writes
     // subscription auth, so a claiming row with another provider cannot
     // strand the fresh token behind derived platform auth.
     const { db } = setupDb();
@@ -196,11 +225,11 @@ describe("Connection CRUD", () => {
         type: "oauth_subscription",
         credential: "credential/chatgpt/access_token",
       },
-      provider: "openai",
+      provider: "chatgpt",
     });
     expect(result.ok).toBe(true);
     const fetched = getConnection(db, "chatgpt-subscription");
-    expect(fetched?.provider).toBe("openai");
+    expect(fetched?.provider).toBe("chatgpt");
     expect(fetched?.auth.type).toBe("oauth_subscription");
   });
 
@@ -236,7 +265,7 @@ describe("Connection CRUD", () => {
     createConnection(db, {
       name: "to-delete",
       provider: "gemini",
-      auth: { type: "platform" },
+      auth: { type: "api_key", credential: "credential/gemini/api_key" },
     });
     const result = deleteConnection(db, "to-delete");
     expect(result.ok).toBe(true);
@@ -258,7 +287,7 @@ describe("Connection CRUD", () => {
     createConnection(db, {
       name: "referenced",
       provider: "anthropic",
-      auth: { type: "platform" },
+      auth: { type: "api_key", credential: "credential/anthropic/api_key" },
     });
     const result = deleteConnection(db, "referenced", {
       force: false,
@@ -280,7 +309,7 @@ describe("Connection CRUD", () => {
     createConnection(db, {
       name: "force-delete",
       provider: "anthropic",
-      auth: { type: "platform" },
+      auth: { type: "api_key", credential: "credential/anthropic/api_key" },
     });
     const result = deleteConnection(db, "force-delete", {
       force: true,
@@ -337,12 +366,12 @@ describe("Mix-and-match: two profiles, same provider, different connections", ()
   test("getConnection returns the right auth for each connection name", () => {
     const { db } = setupDb();
 
-    // Two connections for the same provider with distinct auth resolve
-    // independently: one platform-auth, one personal api_key.
+    // Two connections for the same provider with distinct credentials
+    // resolve independently.
     createConnection(db, {
-      name: "anthropic-platform",
+      name: "anthropic-work",
       provider: "anthropic",
-      auth: { type: "platform" },
+      auth: { type: "api_key", credential: "credential/anthropic/work_key" },
     });
     createConnection(db, {
       name: "anthropic-personal",
@@ -350,23 +379,22 @@ describe("Mix-and-match: two profiles, same provider, different connections", ()
       auth: { type: "api_key", credential: "credential/anthropic/api_key" },
     });
 
-    expect(getConnection(db, "anthropic-platform")?.auth.type).toBe("platform");
-    expect(getConnection(db, "anthropic-personal")?.auth.type).toBe("api_key");
-
     // Both connections exist for the same provider.
     const anthropicConns = listConnections(db, { provider: "anthropic" });
     const names = anthropicConns.map((c) => c.name);
-    expect(names).toContain("anthropic-platform");
+    expect(names).toContain("anthropic-work");
     expect(names).toContain("anthropic-personal");
 
-    // Auth is distinct per connection.
-    const platform = anthropicConns.find(
-      (c) => c.name === "anthropic-platform",
-    );
-    const personal = anthropicConns.find(
-      (c) => c.name === "anthropic-personal",
-    );
-    expect(platform?.auth.type).toBe("platform");
-    expect(personal?.auth.type).toBe("api_key");
+    // The credential is distinct per connection.
+    const work = getConnection(db, "anthropic-work");
+    const personal = getConnection(db, "anthropic-personal");
+    expect(work?.auth).toEqual({
+      type: "api_key",
+      credential: "credential/anthropic/work_key",
+    });
+    expect(personal?.auth).toEqual({
+      type: "api_key",
+      credential: "credential/anthropic/api_key",
+    });
   });
 });

--- a/assistant/src/providers/__tests__/vellum-connection-routing.test.ts
+++ b/assistant/src/providers/__tests__/vellum-connection-routing.test.ts
@@ -9,9 +9,9 @@ import { migrateProviderConnectionStatusLabel } from "../../persistence/migratio
 import { migrateProviderConnectionBaseUrlAndModels } from "../../persistence/migrations/250-provider-connection-base-url-and-models.js";
 import * as schema from "../../persistence/schema/index.js";
 import { createAdapterFromConnection } from "../inference/adapter-factory.js";
-import type { Auth, ProviderConnection } from "../inference/auth.js";
+import type { ProviderConnection } from "../inference/auth.js";
 import type { ResolvedAuth } from "../inference/auth.js";
-import { effectiveConnectionAuth } from "../inference/auth.js";
+import { deriveStoredAuth } from "../inference/auth.js";
 import {
   createConnection,
   getConnection,
@@ -78,38 +78,49 @@ describe("vellum connection routing", () => {
   });
 });
 
-describe("effectiveConnectionAuth", () => {
-  test("a vellum row dispatches on platform auth regardless of the stored variant", () => {
-    for (const stored of [
-      { type: "api_key", credential: "vault/x" },
-      { type: "none" },
-      { type: "platform" },
-    ] as Auth[]) {
-      expect(
-        effectiveConnectionAuth({ provider: "vellum", auth: stored }),
-      ).toEqual({ type: "platform" });
-    }
+describe("deriveStoredAuth", () => {
+  test("a vellum row dispatches on platform auth regardless of the stored payload", () => {
+    expect(deriveStoredAuth("vellum")).toEqual({ type: "platform" });
+    expect(deriveStoredAuth("vellum", "vault/x")).toEqual({
+      type: "platform",
+    });
   });
 
-  test("payload-carrying rows keep their stored auth verbatim", () => {
-    const keyed: Auth = { type: "api_key", credential: "vault/anthropic" };
+  test("a chatgpt row is the subscription route; without a token it is invalid", () => {
     expect(
-      effectiveConnectionAuth({ provider: "anthropic", auth: keyed }),
-    ).toBe(keyed);
-    const subscription: Auth = { type: "oauth_subscription" } as Auth;
-    expect(
-      effectiveConnectionAuth({ provider: "openai", auth: subscription }),
-    ).toBe(subscription);
+      deriveStoredAuth("chatgpt", "credential/chatgpt/access_token"),
+    ).toEqual({
+      type: "oauth_subscription",
+      credential: "credential/chatgpt/access_token",
+    });
+    expect(deriveStoredAuth("chatgpt")).toBeNull();
+  });
+
+  test("keyed providers require a credential", () => {
+    expect(deriveStoredAuth("anthropic", "vault/anthropic")).toEqual({
+      type: "api_key",
+      credential: "vault/anthropic",
+    });
+    expect(deriveStoredAuth("anthropic")).toBeNull();
   });
 
   test("a deliberately keyed keyless provider keeps its key", () => {
     // Keyless means no key REQUIRED, not no key possible: the ollama adapter
-    // accepts one, so stored api_key auth on an ollama row is payload and
+    // accepts one, so a stored credential on an ollama row is payload and
     // must never be derived away.
-    const keyed: Auth = { type: "api_key", credential: "vault/ollama" };
-    expect(effectiveConnectionAuth({ provider: "ollama", auth: keyed })).toBe(
-      keyed,
-    );
+    expect(deriveStoredAuth("ollama", "vault/ollama")).toEqual({
+      type: "api_key",
+      credential: "vault/ollama",
+    });
+    expect(deriveStoredAuth("ollama")).toEqual({ type: "none" });
+  });
+
+  test("openai-compatible endpoints are dual-mode on credential presence", () => {
+    expect(deriveStoredAuth("openai-compatible", "vault/custom")).toEqual({
+      type: "api_key",
+      credential: "vault/custom",
+    });
+    expect(deriveStoredAuth("openai-compatible")).toEqual({ type: "none" });
   });
 });
 

--- a/assistant/src/providers/inference/__tests__/connection-availability-keyless.test.ts
+++ b/assistant/src/providers/inference/__tests__/connection-availability-keyless.test.ts
@@ -1,8 +1,9 @@
 /**
  * Availability for keyless connections: none-auth is `ok` exactly where
  * dispatch succeeds — keyless catalog providers (ollama) and dual-mode
- * openai-compatible endpoints — and `unsupported_auth` for keyed catalog
- * providers, mirroring `createAdapterFromConnection`.
+ * openai-compatible endpoints. A credential-less row on a keyed catalog
+ * provider derives no auth at all, so the loaders drop it and availability
+ * reports the connection missing.
  */
 
 import { beforeEach, describe, expect, test } from "bun:test";
@@ -63,7 +64,30 @@ describe("computeConnectionAvailability — none auth", () => {
     expect(availability.status).toBe("ok");
   });
 
-  test("keyed catalog providers stay unsupported_auth", async () => {
+  test("payload-only rows derive none auth and are ok", async () => {
+    seedConnection({
+      name: "local-llm",
+      provider: "openai-compatible",
+      auth: {},
+    });
+    seedConnection({
+      name: "ollama-personal",
+      provider: "ollama",
+      auth: {},
+    });
+    expect(
+      (await computeConnectionAvailability("openai-compatible", "local-llm"))
+        .status,
+    ).toBe("ok");
+    expect(
+      (await computeConnectionAvailability("ollama", "ollama-personal")).status,
+    ).toBe("ok");
+  });
+
+  test("a credential-less row on a keyed catalog provider is invalid and drops", async () => {
+    // No auth type derives for a keyed provider without a credential, so the
+    // DB loaders treat the row as invalid and availability reports the
+    // connection missing.
     seedConnection({
       name: "anthropic-personal",
       provider: "anthropic",
@@ -73,6 +97,6 @@ describe("computeConnectionAvailability — none auth", () => {
       "anthropic",
       "anthropic-personal",
     );
-    expect(availability.status).toBe("unsupported_auth");
+    expect(availability.status).toBe("missing_connection");
   });
 });

--- a/assistant/src/providers/inference/__tests__/connections-label.test.ts
+++ b/assistant/src/providers/inference/__tests__/connections-label.test.ts
@@ -40,7 +40,7 @@ describe("connection CRUD label defaults", () => {
     const result = createConnection(db, {
       name: "my-conn",
       provider: "anthropic",
-      auth: { type: "platform" },
+      auth: { type: "api_key", credential: "credential/anthropic/api_key" },
     });
     expect(result.ok).toBe(true);
     if (result.ok) {
@@ -53,7 +53,7 @@ describe("connection CRUD label defaults", () => {
     const result = createConnection(db, {
       name: "labeled-conn",
       provider: "openai",
-      auth: { type: "platform" },
+      auth: { type: "api_key", credential: "credential/openai/api_key" },
       label: "My OpenAI",
     });
     expect(result.ok).toBe(true);
@@ -67,7 +67,7 @@ describe("connection CRUD label defaults", () => {
     createConnection(db, {
       name: "get-me",
       provider: "gemini",
-      auth: { type: "platform" },
+      auth: { type: "api_key", credential: "credential/gemini/api_key" },
       label: "Gemini Pro",
     });
 
@@ -81,12 +81,12 @@ describe("connection CRUD label defaults", () => {
     createConnection(db, {
       name: "clear-label",
       provider: "openai",
-      auth: { type: "platform" },
+      auth: { type: "api_key", credential: "credential/openai/api_key" },
       label: "Old Label",
     });
 
     const result = updateConnection(db, "clear-label", {
-      auth: { type: "platform" },
+      auth: { type: "api_key", credential: "credential/openai/api_key" },
       label: null,
     });
     expect(result.ok).toBe(true);

--- a/assistant/src/providers/inference/adapter-factory.ts
+++ b/assistant/src/providers/inference/adapter-factory.ts
@@ -38,7 +38,6 @@ import { isVellumManagedConnection } from "../vellum-model-routing.js";
 import { VercelAIGatewayProvider } from "../vercel-ai-gateway/client.js";
 import type { ResolvedAuth } from "./auth.js";
 import type { ProviderConnection } from "./auth.js";
-import { effectiveConnectionAuth } from "./auth.js";
 import { resolveAuth } from "./resolve-auth.js";
 
 /** Unified construction opts. Adapters ignore fields they don't consume. */
@@ -265,11 +264,9 @@ export function createAdapterFromConnection(
   function makeCredentialRefresher(): () => Promise<Provider | null> {
     let lastAuth = JSON.stringify(resolvedAuth);
     return async (): Promise<Provider | null> => {
-      const refreshedAuth = await resolveAuth(
-        effectiveConnectionAuth(connection),
-        provider,
-        { baseUrl: connection.baseUrl },
-      );
+      const refreshedAuth = await resolveAuth(connection.auth, provider, {
+        baseUrl: connection.baseUrl,
+      });
       if (!refreshedAuth.ok) {
         return null;
       }
@@ -288,17 +285,17 @@ export function createAdapterFromConnection(
   // would leak internal Vellum metadata, so gate on the managed connection
   // identity, the only route that flows through our proxy.
   const isManagedProxy = isVellumManagedConnection(connection);
-  const effectiveAuth = effectiveConnectionAuth(connection);
+  const authType = connection.auth.type;
   return new UsageTrackingProvider(
     new RetryProvider(adapter, {
       forwardUsageAttributionHeaders: isManagedProxy,
       credentialSource: isManagedProxy
         ? "vellum-managed"
-        : effectiveAuth.type === "api_key"
+        : authType === "api_key"
           ? "byok"
-          : effectiveAuth.type === "oauth_subscription"
+          : authType === "oauth_subscription"
             ? "oauth-subscription"
-            : effectiveAuth.type === "none"
+            : authType === "none"
               ? "no-auth"
               : undefined,
       connectionName: connection.name,
@@ -344,8 +341,7 @@ function buildConnectionAdapter(
       : undefined;
 
   const codexSubscription =
-    effectiveConnectionAuth(connection).type === "oauth_subscription" &&
-    provider === "openai";
+    connection.auth.type === "oauth_subscription" && provider === "openai";
 
   const adapter = buildProviderAdapter(provider, {
     apiKey,

--- a/assistant/src/providers/inference/auth.ts
+++ b/assistant/src/providers/inference/auth.ts
@@ -73,19 +73,36 @@ export function deriveAuthForProvider(
 }
 
 /**
- * The auth a connection dispatches with. The stored auth object is
- * authoritative only where it carries a payload (an api_key credential ref,
- * the oauth_subscription marker, a deliberately keyed keyless provider);
- * the vellum provider IS the managed route, so its auth derives from the
- * provider and the stored value can never mislead dispatch.
+ * Derive the typed auth of a stored `provider_connections` row from its
+ * provider column and the credential payload. The stored auth JSON carries
+ * only the payload (`{credential?}`); the type is implied by the provider:
+ * `vellum` IS the managed route (platform), `chatgpt` IS the subscription
+ * route (oauth_subscription), keyless catalog providers (`setupMode:
+ * "keyless"`, e.g. ollama) and openai-compatible endpoints run keyless
+ * unless deliberately keyed (e.g. a remote Ollama behind an authenticating
+ * proxy), and every other provider authenticates by API key. Returns null
+ * when no derivation can dispatch the row (a keyed provider with no
+ * credential, a chatgpt row with no token); callers drop such rows as
+ * invalid.
+ *
+ * `service_account` is not derivable: nothing writes it, the wire AuthSchema
+ * still accepts it, and the runtime rejects it at dispatch (resolve-auth.ts).
  */
-export function effectiveConnectionAuth(connection: {
-  provider: string;
-  auth: Auth;
-}): Auth {
-  return connection.provider === VELLUM_MANAGED_PROVIDER
-    ? { type: "platform" }
-    : connection.auth;
+export function deriveStoredAuth(
+  provider: string,
+  credential?: string,
+): Auth | null {
+  if (provider === VELLUM_MANAGED_PROVIDER) {
+    return { type: "platform" };
+  }
+  if (provider === "chatgpt") {
+    return credential ? { type: "oauth_subscription", credential } : null;
+  }
+  const entry = PROVIDER_CATALOG.find((p) => p.id === provider);
+  if (entry?.setupMode === "keyless" || provider === "openai-compatible") {
+    return credential ? { type: "api_key", credential } : { type: "none" };
+  }
+  return credential ? { type: "api_key", credential } : null;
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/providers/inference/connections.ts
+++ b/assistant/src/providers/inference/connections.ts
@@ -15,11 +15,11 @@ import {
 export { VELLUM_MANAGED_CONNECTION_NAME };
 import {
   type Auth,
-  AuthSchema,
   type ConnectionModel,
   ConnectionModelSchema,
   type ConnectionProvider,
   ConnectionProviderSchema,
+  deriveStoredAuth,
   type ProviderConnection,
   PROVIDERS_REQUIRING_BASE_URL_AND_MODELS,
   VALID_CONNECTION_PROVIDERS,
@@ -49,20 +49,36 @@ function isManagedRow(row: {
 // ---------------------------------------------------------------------------
 
 /**
- * Parse an auth value (stored JSON or caller input), normalizing any
- * credential reference to the vault-key form. Normalizing on read as well as
- * write heals rows that were stored with the secrets-API wire name (e.g.
- * `openrouter:api_key`) without a migration.
+ * Parse an auth value (stored JSON or caller input) into the typed Auth for
+ * a row of the given provider. Only the credential payload is read; the auth
+ * type is derived from the provider (`deriveStoredAuth`), so a legacy `type`
+ * key in stored JSON is inert. Credential references are normalized to the
+ * vault-key form on read as well as write, healing rows stored with the
+ * secrets-API wire name (e.g. `openrouter:api_key`) without a migration.
+ * Returns null for an underivable value; callers treat the row as invalid.
  */
-function parseAuth(raw: unknown): Auth | null {
-  const parsed = AuthSchema.safeParse(raw);
-  if (!parsed.success) {
+function parseAuth(raw: unknown, provider: string): Auth | null {
+  if (raw === null || typeof raw !== "object") {
     return null;
   }
-  const auth = parsed.data;
-  return "credential" in auth
-    ? { ...auth, credential: normalizeCredentialRef(auth.credential) }
-    : auth;
+  const credential = (raw as { credential?: unknown }).credential;
+  if (credential === undefined) {
+    return deriveStoredAuth(provider);
+  }
+  if (typeof credential !== "string" || credential.length === 0) {
+    return null;
+  }
+  return deriveStoredAuth(provider, normalizeCredentialRef(credential));
+}
+
+/**
+ * Payload-only JSON persisted in the auth column. The auth type is derived
+ * from the provider column on read, so it is never stored.
+ */
+function toStoredAuth(auth: Auth): string {
+  return JSON.stringify(
+    "credential" in auth ? { credential: auth.credential } : {},
+  );
 }
 
 function parseModelsColumn(raw: string | null): ConnectionModel[] | null {
@@ -94,7 +110,7 @@ export function listConnections(
     : db.select().from(providerConnections).all();
 
   return rows.flatMap((row) => {
-    const auth = parseAuth(JSON.parse(row.auth));
+    const auth = parseAuth(JSON.parse(row.auth), row.provider);
     if (!auth) {
       return [];
     }
@@ -129,7 +145,7 @@ export function getConnection(
   if (!row) {
     return null;
   }
-  const auth = parseAuth(JSON.parse(row.auth));
+  const auth = parseAuth(JSON.parse(row.auth), row.provider);
   if (!auth) {
     return null;
   }
@@ -209,7 +225,7 @@ export function createConnection(
   // Safe cast: VALID_CONNECTION_PROVIDERS.includes() guards above.
   const provider = input.provider as ConnectionProvider;
 
-  const auth = parseAuth(input.auth);
+  const auth = parseAuth(input.auth, provider);
   if (!auth) {
     return { ok: false, error: { code: "invalid_auth" } };
   }
@@ -241,7 +257,7 @@ export function createConnection(
     .values({
       name: input.name,
       provider,
-      auth: JSON.stringify(auth),
+      auth: toStoredAuth(auth),
       label,
       baseUrl,
       models: models === null ? null : JSON.stringify(models),
@@ -282,11 +298,6 @@ export function updateConnection(
     return { ok: false, error: { code: "not_found" } };
   }
 
-  const auth = parseAuth(input.auth);
-  if (!auth) {
-    return { ok: false, error: { code: "invalid_auth" } };
-  }
-
   if (
     input.provider !== undefined &&
     !VALID_CONNECTION_PROVIDERS.includes(input.provider as never)
@@ -297,6 +308,11 @@ export function updateConnection(
     };
   }
   const nextProvider = input.provider ?? existing.provider;
+
+  const auth = parseAuth(input.auth, nextProvider);
+  if (!auth) {
+    return { ok: false, error: { code: "invalid_auth" } };
+  }
 
   const nextBaseUrl =
     input.baseUrl !== undefined ? input.baseUrl : existing.baseUrl;
@@ -320,7 +336,7 @@ export function updateConnection(
     label?: string | null;
     baseUrl?: string | null;
     models?: string | null;
-  } = { auth: JSON.stringify(auth), updatedAt: now };
+  } = { auth: toStoredAuth(auth), updatedAt: now };
   if (input.provider !== undefined) {
     setClause.provider = input.provider;
   }
@@ -515,7 +531,7 @@ export function seedCanonicalConnections(db: DrizzleDb): void {
       .values({
         name,
         provider,
-        auth: JSON.stringify(auth),
+        auth: toStoredAuth(auth),
         label,
         createdAt: now,
         updatedAt: now,
@@ -524,7 +540,7 @@ export function seedCanonicalConnections(db: DrizzleDb): void {
         target: providerConnections.name,
         set: {
           provider,
-          auth: JSON.stringify(auth),
+          auth: toStoredAuth(auth),
           updatedAt: now,
         },
       })

--- a/assistant/src/providers/registry.ts
+++ b/assistant/src/providers/registry.ts
@@ -17,10 +17,7 @@ import {
 // Per-connection provider cache (mix-and-match support)
 // ---------------------------------------------------------------------------
 import type { ProviderConnection } from "./inference/auth.js";
-import {
-  effectiveConnectionAuth,
-  ROUTING_IDENTITY_PROVIDERS,
-} from "./inference/auth.js";
+import { ROUTING_IDENTITY_PROVIDERS } from "./inference/auth.js";
 import { resolveAuth } from "./inference/resolve-auth.js";
 import { isModelInCatalog, PROVIDER_CATALOG } from "./model-catalog.js";
 import { getProviderDefaultModel } from "./model-intents.js";
@@ -336,11 +333,9 @@ export async function resolveProviderFromConnection(
   // re-read from the store below, so a key rotated since the entry was cached
   // is picked up here rather than served stale forever.
 
-  const authResult = await resolveAuth(
-    effectiveConnectionAuth(connection),
-    effectiveProvider,
-    { baseUrl: connection.baseUrl },
-  );
+  const authResult = await resolveAuth(connection.auth, effectiveProvider, {
+    baseUrl: connection.baseUrl,
+  });
   if (!authResult.ok) {
     const err = authResult.error;
     if (err.code === "not_implemented") {

--- a/assistant/src/runtime/routes/__tests__/connection-routes-vs-cli-parity.test.ts
+++ b/assistant/src/runtime/routes/__tests__/connection-routes-vs-cli-parity.test.ts
@@ -12,6 +12,8 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 
 // ── Real imports ──────────────────────────────────────────────────────────────
+import { eq } from "drizzle-orm";
+
 import { getDb } from "../../../persistence/db-connection.js";
 import { initializeDb } from "../../../persistence/db-init.js";
 import { providerConnections } from "../../../persistence/schema/inference.js";
@@ -51,6 +53,19 @@ function normalizeTimestamps<T extends object>(
   return rest as Omit<T, "createdAt" | "updatedAt">;
 }
 
+/** The raw stored auth column, which must be payload-only (no `type` key). */
+function rawStoredAuth(name: string): Record<string, unknown> {
+  const row = getDb()
+    .select({ auth: providerConnections.auth })
+    .from(providerConnections)
+    .where(eq(providerConnections.name, name))
+    .get();
+  if (!row) {
+    throw new Error(`No stored row named ${name}`);
+  }
+  return JSON.parse(row.auth) as Record<string, unknown>;
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 beforeEach(() => {
@@ -73,6 +88,9 @@ describe("CLI vs HTTP route parity", () => {
     }
     const cliRow = getConnection(getDb(), payload.name);
     expect(cliRow).not.toBeNull();
+    expect(rawStoredAuth(payload.name)).toEqual({
+      credential: payload.auth.credential,
+    });
 
     // Clean up CLI row before HTTP create so names don't collide.
     clearConnections();
@@ -91,6 +109,9 @@ describe("CLI vs HTTP route parity", () => {
     expect(httpResult.name).toBe(payload.name);
     const httpRow = getConnection(getDb(), payload.name);
     expect(httpRow).not.toBeNull();
+    expect(rawStoredAuth(payload.name)).toEqual({
+      credential: payload.auth.credential,
+    });
 
     // ── Compare ───────────────────────────────────────────────────────────────
     // Both rows should have identical non-timestamp fields.
@@ -110,6 +131,7 @@ describe("CLI vs HTTP route parity", () => {
       throw new Error("CLI create failed");
     }
     const cliRow = getConnection(getDb(), payload.name);
+    expect(rawStoredAuth(payload.name)).toEqual({});
 
     clearConnections();
 
@@ -121,6 +143,7 @@ describe("CLI vs HTTP route parity", () => {
       },
     });
     const httpRow = getConnection(getDb(), payload.name);
+    expect(rawStoredAuth(payload.name)).toEqual({});
 
     expect(normalizeTimestamps(httpRow!)).toEqual(normalizeTimestamps(cliRow!));
   });
@@ -138,6 +161,7 @@ describe("CLI vs HTTP route parity", () => {
       throw new Error("CLI create failed");
     }
     const cliRow = getConnection(getDb(), payload.name);
+    expect(rawStoredAuth(payload.name)).toEqual({});
 
     clearConnections();
 
@@ -149,6 +173,7 @@ describe("CLI vs HTTP route parity", () => {
       },
     });
     const httpRow = getConnection(getDb(), payload.name);
+    expect(rawStoredAuth(payload.name)).toEqual({});
 
     expect(normalizeTimestamps(httpRow!)).toEqual(normalizeTimestamps(cliRow!));
   });

--- a/assistant/src/runtime/routes/__tests__/default-provider-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/default-provider-routes.test.ts
@@ -179,7 +179,10 @@ describe("GET config/llm/default-provider", () => {
     expect(availability(result).status).toBe("ok");
   });
 
-  test("platform-auth connection for a non-managed provider → unsupported_auth even when signed in", async () => {
+  test("credential-less row on a keyed provider is invalid → missing_connection even when signed in", async () => {
+    // A stored platform payload on a non-managed provider carries no
+    // credential, so no auth type derives for the row and the loaders drop
+    // it as invalid (migration 361 rewrites such rows to provider vellum).
     seedConnection({
       name: "openrouter-personal",
       provider: "openrouter",
@@ -189,8 +192,7 @@ describe("GET config/llm/default-provider", () => {
     setConfig("llm", { defaultProvider: { provider: "openrouter" } });
 
     const result = await get();
-    expect(availability(result).status).toBe("unsupported_auth");
-    expect(availability(result).message).toContain("platform auth");
+    expect(availability(result).status).toBe("missing_connection");
   });
 
   test("BYOK with stored key → ok, convention-resolved connection", async () => {
@@ -310,7 +312,7 @@ describe("GET config/llm/default-provider", () => {
     expect(availability(result).status).toBe("provider_mismatch");
   });
 
-  test("none-auth connection on a keyed provider → unsupported_auth", async () => {
+  test("none-auth row on a keyed provider is invalid → missing_connection", async () => {
     seedConnection({
       name: "openai-personal",
       provider: "openai",
@@ -319,8 +321,7 @@ describe("GET config/llm/default-provider", () => {
     setConfig("llm", { defaultProvider: { provider: "openai" } });
 
     const result = await get();
-    expect(availability(result).status).toBe("unsupported_auth");
-    expect(availability(result).message).toContain("API key");
+    expect(availability(result).status).toBe("missing_connection");
   });
 
   test("explicit connectionName for a different provider → provider_mismatch even with credentials", async () => {
@@ -377,7 +378,11 @@ describe("GET config/llm/default-provider", () => {
     expect(availability(result).message).toContain("Vellum-managed");
   });
 
-  test("service_account connection → unsupported_auth even with a stored credential", async () => {
+  test("a legacy service_account row reads as api_key on its stored credential", async () => {
+    // The auth type derives from the provider, so the stored
+    // `service_account` marker is inert: the row carries a credential and a
+    // keyed provider, which derives api_key. Availability then reports on
+    // that credential.
     seedConnection({
       name: "gemini-personal",
       provider: "gemini",
@@ -390,21 +395,7 @@ describe("GET config/llm/default-provider", () => {
     setConfig("llm", { defaultProvider: { provider: "gemini" } });
 
     const result = await get();
-    expect(availability(result).status).toBe("unsupported_auth");
-    expect(availability(result).message).toContain("service-account");
-  });
-
-  test("platform-auth connection follows managed-proxy state", async () => {
-    seedConnection({
-      name: "anthropic-personal",
-      provider: "anthropic",
-      auth: { type: "platform" },
-    });
-    setConfig("llm", { defaultProvider: { provider: "anthropic" } });
-
-    expect(availability(await get()).status).toBe("vellum_unauthenticated");
-    managedProxyEnabled = true;
-    expect(availability(await get()).status).toBe("ok");
+    expect(availability(result).status).toBe("ok");
   });
 });
 

--- a/assistant/src/runtime/routes/__tests__/inference-profiles-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/inference-profiles-routes.test.ts
@@ -577,7 +577,9 @@ describe("DELETE inference/profiles/:name protection", () => {
 
 describe("POST inference/profiles create conflict", () => {
   test("409s when a profile with the name already exists", async () => {
-    seedConnection("anthropic-personal", "anthropic");
+    seedConnection("anthropic-personal", "anthropic", {
+      credential: "credential/anthropic/api_key",
+    });
     setConfig("llm", {
       profiles: { existing: { source: "user", provider: "anthropic" } },
     });

--- a/assistant/src/runtime/routes/__tests__/inference-provider-connection-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/inference-provider-connection-routes.test.ts
@@ -94,35 +94,40 @@ describe("GET inference/provider-connections (list)", () => {
   });
 
   test("returns all connections when no filter", async () => {
+    // A legacy row with a stored auth type and a payload-only row both load;
+    // the stored type is inert and the echo derives from the provider.
     seedConnection({
       name: "conn-a",
       provider: "anthropic",
-      auth: { type: "platform" },
+      auth: { type: "api_key", credential: "credential/anthropic/api_key" },
     });
     seedConnection({
       name: "conn-b",
       provider: "openai",
-      auth: { type: "none" },
+      auth: { credential: "credential/openai/api_key" },
     });
 
     const result = (await call(
       findHandler("inference_provider_connections_list"),
       {},
-    )) as { connections: Array<{ name: string }> };
+    )) as { connections: Array<{ name: string; auth: { type: string } }> };
     const names = result.connections.map((c) => c.name).sort();
     expect(names).toEqual(["conn-a", "conn-b"]);
+    for (const conn of result.connections) {
+      expect(conn.auth.type).toBe("api_key");
+    }
   });
 
   test("filters by ?provider= query param", async () => {
     seedConnection({
       name: "ant-1",
       provider: "anthropic",
-      auth: { type: "platform" },
+      auth: { credential: "credential/anthropic/api_key" },
     });
     seedConnection({
       name: "oai-1",
       provider: "openai",
-      auth: { type: "platform" },
+      auth: { credential: "credential/openai/api_key" },
     });
 
     const result = (await call(
@@ -138,7 +143,7 @@ describe("GET inference/provider-connections (list)", () => {
     seedConnection({
       name: "ant-1",
       provider: "anthropic",
-      auth: { type: "platform" },
+      auth: { credential: "credential/anthropic/api_key" },
     });
 
     const result = (await call(
@@ -156,7 +161,7 @@ describe("GET inference/provider-connections/:name (single)", () => {
     seedConnection({
       name: "my-conn",
       provider: "anthropic",
-      auth: { type: "platform" },
+      auth: { type: "api_key", credential: "credential/anthropic/api_key" },
     });
 
     const result = (await call(
@@ -165,7 +170,45 @@ describe("GET inference/provider-connections/:name (single)", () => {
     )) as { name: string; provider: string; auth: object };
     expect(result.name).toBe("my-conn");
     expect(result.provider).toBe("anthropic");
-    expect(result.auth).toEqual({ type: "platform" });
+    expect(result.auth).toEqual({
+      type: "api_key",
+      credential: "credential/anthropic/api_key",
+    });
+  });
+
+  test("derives the typed echo for payload-only rows of every kind", async () => {
+    seedConnection({ name: "vellum", provider: "vellum", auth: {} });
+    seedConnection({
+      name: "chatgpt-subscription",
+      provider: "chatgpt",
+      auth: { credential: "credential/chatgpt/access_token" },
+    });
+    seedConnection({ name: "ollama-local", provider: "ollama", auth: {} });
+    seedConnection({
+      name: "ollama-remote",
+      provider: "ollama",
+      auth: { credential: "credential/ollama/api_key" },
+    });
+
+    const get = findHandler("inference_provider_connections_get");
+    const expected: Record<string, object> = {
+      vellum: { type: "platform" },
+      "chatgpt-subscription": {
+        type: "oauth_subscription",
+        credential: "credential/chatgpt/access_token",
+      },
+      "ollama-local": { type: "none" },
+      "ollama-remote": {
+        type: "api_key",
+        credential: "credential/ollama/api_key",
+      },
+    };
+    for (const [name, auth] of Object.entries(expected)) {
+      const result = (await call(get, { pathParams: { name } })) as {
+        auth: object;
+      };
+      expect(result.auth).toEqual(auth);
+    }
   });
 
   test("throws 404 when connection not found", async () => {
@@ -701,7 +744,7 @@ describe("PATCH inference/provider-connections/:name (update)", () => {
     seedConnection({
       name: "upd-conn",
       provider: "anthropic",
-      auth: { type: "platform" },
+      auth: { type: "api_key", credential: "vault/old-key" },
     });
 
     const result = (await call(
@@ -743,42 +786,59 @@ describe("PATCH inference/provider-connections/:name (update)", () => {
     expect((err as BadRequestError).message).toContain("platform");
   });
 
-  // A persisted row whose provider and auth disagree stays editable: both the
-  // web editor and the CLI resend the stored auth on every edit, so the guard
-  // keys on an actual auth change rather than on the field being present.
-  test("allows editing a legacy mismatched row when the client resends the stored auth", async () => {
+  // The web editor and the CLI resend the stored auth on every edit, so a
+  // label-only PATCH that round-trips the derived echo must compare
+  // fingerprint-equal to the stored auth and never trip the pairing guard.
+  // Pinned against both stored shapes: a legacy row that still carries a
+  // `type` key and a payload-only row.
+  test("a label-only PATCH resending the echoed auth succeeds on a legacy typed row", async () => {
     seedConnection({
-      name: "legacy-managed-openai",
-      provider: "openai",
-      auth: { type: "platform" },
+      name: "legacy-typed",
+      provider: "anthropic",
+      auth: { type: "api_key", credential: "credential/anthropic/api_key" },
     });
+
+    const echoed = (await call(
+      findHandler("inference_provider_connections_get"),
+      { pathParams: { name: "legacy-typed" } },
+    )) as { auth: object };
 
     const result = (await call(
       findHandler("inference_provider_connections_update"),
       {
-        pathParams: { name: "legacy-managed-openai" },
-        body: { auth: { type: "platform" }, label: "Legacy" },
+        pathParams: { name: "legacy-typed" },
+        body: { auth: echoed.auth, label: "Renamed" },
       },
     )) as { label: string | null; auth: object };
-    expect(result.label).toBe("Legacy");
-    expect(result.auth).toEqual({ type: "platform" });
+    expect(result.label).toBe("Renamed");
+    expect(result.auth).toEqual(echoed.auth);
   });
 
-  test("allows editing a legacy mismatched row when auth is omitted", async () => {
+  test("a label-only PATCH resending the echoed auth succeeds on a payload-only row", async () => {
     seedConnection({
-      name: "legacy-managed-gemini",
-      provider: "gemini",
-      auth: { type: "platform" },
+      name: "typeless-row",
+      provider: "anthropic",
+      auth: { credential: "credential/anthropic/api_key" },
+    });
+
+    const echoed = (await call(
+      findHandler("inference_provider_connections_get"),
+      { pathParams: { name: "typeless-row" } },
+    )) as { auth: object };
+    expect(echoed.auth).toEqual({
+      type: "api_key",
+      credential: "credential/anthropic/api_key",
     });
 
     const result = (await call(
       findHandler("inference_provider_connections_update"),
       {
-        pathParams: { name: "legacy-managed-gemini" },
-        body: { label: "Legacy" },
+        pathParams: { name: "typeless-row" },
+        body: { auth: echoed.auth, label: "Renamed" },
       },
-    )) as { label: string | null };
-    expect(result.label).toBe("Legacy");
+    )) as { label: string | null; auth: object };
+    expect(result.label).toBe("Renamed");
+    expect(result.auth).toEqual(echoed.auth);
   });
 
   // The guard must not trap a legacy row in its mismatched state: an auth
@@ -829,31 +889,11 @@ describe("PATCH inference/provider-connections/:name (update)", () => {
     expect(result.provider).toBe("openai");
   });
 
-  test("allows repairing a legacy mismatched row with a valid auth change", async () => {
-    seedConnection({
-      name: "legacy-managed-anthropic",
-      provider: "anthropic",
-      auth: { type: "platform" },
-    });
-
-    const result = (await call(
-      findHandler("inference_provider_connections_update"),
-      {
-        pathParams: { name: "legacy-managed-anthropic" },
-        body: { auth: { type: "api_key", credential: "vault/anthropic/key" } },
-      },
-    )) as { auth: object };
-    expect(result.auth).toEqual({
-      type: "api_key",
-      credential: "vault/anthropic/key",
-    });
-  });
-
   test("throws 400 when auth schema is invalid", async () => {
     seedConnection({
       name: "bad-auth",
       provider: "openai",
-      auth: { type: "platform" },
+      auth: { type: "api_key", credential: "vault/openai/key" },
     });
 
     await expect(
@@ -867,7 +907,7 @@ describe("PATCH inference/provider-connections/:name (update)", () => {
   test("keeps stored auth when both auth and credential are omitted", async () => {
     seedConnection({
       name: "label-only",
-      provider: "openai",
+      provider: "chatgpt",
       auth: { type: "oauth_subscription", credential: "vault/chatgpt/token" },
     });
 
@@ -888,7 +928,7 @@ describe("PATCH inference/provider-connections/:name (update)", () => {
   test("throws 400 on credential-only PATCH of an oauth_subscription connection", async () => {
     seedConnection({
       name: "chatgpt-subscription",
-      provider: "openai",
+      provider: "chatgpt",
       auth: { type: "oauth_subscription", credential: "vault/chatgpt/token" },
     });
 
@@ -925,7 +965,7 @@ describe("DELETE inference/provider-connections/:name (delete)", () => {
     seedConnection({
       name: "del-me",
       provider: "gemini",
-      auth: { type: "platform" },
+      auth: { type: "api_key", credential: "credential/gemini/api_key" },
     });
 
     const result = (await call(
@@ -954,7 +994,7 @@ describe("DELETE inference/provider-connections/:name (delete)", () => {
     seedConnection({
       name: "ref-conn",
       provider: "anthropic",
-      auth: { type: "platform" },
+      auth: { type: "api_key", credential: "credential/anthropic/api_key" },
     });
     setConfig("llm", {
       profiles: {
@@ -993,7 +1033,7 @@ describe("DELETE inference/provider-connections/:name (delete)", () => {
     seedConnection({
       name: "shared-conn",
       provider: "anthropic",
-      auth: { type: "none" },
+      auth: { type: "api_key", credential: "credential/anthropic/api_key" },
     });
     setConfig("llm", {
       profiles: {
@@ -1019,7 +1059,7 @@ describe("DELETE guards the llm.defaultProvider reference", () => {
     seedConnection({
       name: "anthropic-personal",
       provider: "anthropic",
-      auth: { type: "platform" },
+      auth: { type: "api_key", credential: "credential/anthropic/api_key" },
     });
     setConfig("llm", { defaultProvider: { provider: "anthropic" } });
 
@@ -1039,7 +1079,7 @@ describe("DELETE guards the llm.defaultProvider reference", () => {
     seedConnection({
       name: "my-conn",
       provider: "openai",
-      auth: { type: "platform" },
+      auth: { type: "api_key", credential: "credential/openai/api_key" },
     });
     setConfig("llm", {
       defaultProvider: { provider: "openai", connectionName: "my-conn" },
@@ -1059,7 +1099,7 @@ describe("DELETE guards the llm.defaultProvider reference", () => {
     seedConnection({
       name: "anthropic-work",
       provider: "anthropic",
-      auth: { type: "platform" },
+      auth: { type: "api_key", credential: "credential/anthropic/api_key" },
     });
     setConfig("llm", { defaultProvider: { provider: "anthropic" } });
 
@@ -1080,7 +1120,7 @@ describe("DELETE guards the llm.defaultProvider reference", () => {
     seedConnection({
       name: "anthropic-work",
       provider: "anthropic",
-      auth: { type: "platform" },
+      auth: { type: "api_key", credential: "credential/anthropic/api_key" },
     });
     setConfig("llm", {
       defaultProvider: {
@@ -1102,7 +1142,7 @@ describe("DELETE guards the llm.defaultProvider reference", () => {
     seedConnection({
       name: "anthropic-work",
       provider: "anthropic",
-      auth: { type: "platform" },
+      auth: { type: "api_key", credential: "credential/anthropic/api_key" },
     });
     seedConnection({
       name: "anthropic-managed",
@@ -1126,12 +1166,12 @@ describe("DELETE guards the llm.defaultProvider reference", () => {
     seedConnection({
       name: "anthropic-personal",
       provider: "anthropic",
-      auth: { type: "platform" },
+      auth: { type: "api_key", credential: "credential/anthropic/api_key" },
     });
     seedConnection({
       name: "anthropic-other",
       provider: "anthropic",
-      auth: { type: "platform" },
+      auth: { type: "api_key", credential: "credential/anthropic/api_key" },
     });
     setConfig("llm", { defaultProvider: { provider: "anthropic" } });
 
@@ -1146,7 +1186,7 @@ describe("DELETE guards the llm.defaultProvider reference", () => {
     seedConnection({
       name: "openai-conn",
       provider: "openai",
-      auth: { type: "platform" },
+      auth: { type: "api_key", credential: "credential/openai/api_key" },
     });
     setConfig("llm", { defaultProvider: { provider: "anthropic" } });
 
@@ -1161,7 +1201,7 @@ describe("DELETE guards the llm.defaultProvider reference", () => {
     seedConnection({
       name: "openai-conn",
       provider: "openai",
-      auth: { type: "platform" },
+      auth: { type: "api_key", credential: "credential/openai/api_key" },
     });
     // No "anthropic" rows exist at all — an already-dangling default is a
     // legal state; the guard must no-op rather than crash on an empty list.
@@ -1178,7 +1218,7 @@ describe("DELETE guards the llm.defaultProvider reference", () => {
     seedConnection({
       name: "some-conn",
       provider: "openai",
-      auth: { type: "platform" },
+      auth: { type: "api_key", credential: "credential/openai/api_key" },
     });
     setConfig("llm", {});
 
@@ -1193,7 +1233,7 @@ describe("DELETE guards the llm.defaultProvider reference", () => {
     seedConnection({
       name: "some-conn",
       provider: "openai",
-      auth: { type: "platform" },
+      auth: { type: "api_key", credential: "credential/openai/api_key" },
     });
     const parsed = LLMSchema.parse({
       defaultProvider: { provider: "not-a-provider" },

--- a/assistant/src/runtime/routes/__tests__/inference-provider-connection-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/inference-provider-connection-routes.test.ts
@@ -314,6 +314,24 @@ describe("POST inference/provider-connections (create)", () => {
     }
   });
 
+  test("rejects service_account auth with 400", async () => {
+    // Schema-accepted on the wire, but the payload-only store would read it
+    // back as api_key and dispatch the service-account blob as a bearer key.
+    const err = await call(
+      findHandler("inference_provider_connections_create"),
+      {
+        body: {
+          name: "sa-gemini",
+          provider: "gemini",
+          auth: { type: "service_account", credential: "credential/gemini/sa" },
+        },
+      },
+    ).catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(BadRequestError);
+    expect((err as BadRequestError).message).toContain("service_account");
+  });
+
   test("rejects subscription auth on a non-chatgpt provider", async () => {
     const err = await call(
       findHandler("inference_provider_connections_create"),
@@ -765,6 +783,27 @@ describe("PATCH inference/provider-connections/:name (update)", () => {
         body: { auth: { type: "platform" } },
       }),
     ).rejects.toBeInstanceOf(NotFoundError);
+  });
+
+  test("rejects switching to service_account auth with 400", async () => {
+    seedConnection({
+      name: "sa-target",
+      provider: "gemini",
+      auth: { type: "api_key", credential: "credential/gemini/api_key" },
+    });
+
+    const err = await call(
+      findHandler("inference_provider_connections_update"),
+      {
+        pathParams: { name: "sa-target" },
+        body: {
+          auth: { type: "service_account", credential: "credential/gemini/sa" },
+        },
+      },
+    ).catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(BadRequestError);
+    expect((err as BadRequestError).message).toContain("service_account");
   });
 
   test("rejects switching a real provider's connection to platform auth", async () => {

--- a/assistant/src/runtime/routes/inference-provider-connection-routes.ts
+++ b/assistant/src/runtime/routes/inference-provider-connection-routes.ts
@@ -206,6 +206,17 @@ function deriveConnectionAuth(provider: string, credential: unknown): Auth {
  * reverse.
  */
 function assertAuthMatchesProvider(provider: string, auth: Auth): void {
+  // The wire schema accepts service_account, but the store persists only the
+  // credential payload and derives the type from the provider on read, so a
+  // service_account write would come back as api_key auth and dispatch the
+  // service-account blob as a bearer key. Reject at the write boundary.
+  // Stored rows never echo service_account, so a resend of stored auth can
+  // never hit this.
+  if (auth.type === "service_account") {
+    throw new BadRequestError(
+      `Auth type "service_account" is not supported yet. Use "api_key" auth with a vault credential.`,
+    );
+  }
   const managedAuth = auth.type === "platform";
   const managedProvider = provider === VELLUM_MANAGED_PROVIDER;
   if (managedAuth !== managedProvider) {

--- a/assistant/src/workspace/migrations/144-convert-stranded-subscription-openai-profiles.ts
+++ b/assistant/src/workspace/migrations/144-convert-stranded-subscription-openai-profiles.ts
@@ -21,9 +21,9 @@ const log = getLogger("migration-144");
  *
  * Conversion requires proof from the workspace DB that the fragment is
  * genuinely stranded: the canonical subscription row exists (matched by
- * name + oauth_subscription auth, valid for both the pre- and post-366 row
- * shapes) and no `provider: "openai"` row exists (an API-key row means
- * openai fragments still resolve). An absent DB or table converts nothing;
+ * name + subscription identity, valid for every historical row shape; see
+ * `isSubscriptionRow`) and no `provider: "openai"` row exists (an API-key
+ * row means openai fragments still resolve). An absent DB or table converts nothing;
  * an open or query failure on an existing DB propagates so the runner
  * records a failed checkpoint and retries on a later boot.
  *
@@ -181,21 +181,12 @@ function isSubscriptionOnlyWorkspace(workspaceDir: string): boolean {
     }
 
     const subscription = db
-      .query(`SELECT auth FROM provider_connections WHERE name = ?`)
-      .get(SUBSCRIPTION_CONNECTION_NAME) as { auth: string } | null;
-    if (!subscription) {
-      return false;
-    }
-    try {
-      const parsed: unknown = JSON.parse(subscription.auth);
-      const authType =
-        parsed !== null && typeof parsed === "object"
-          ? (parsed as { type?: unknown }).type
-          : undefined;
-      if (authType !== "oauth_subscription") {
-        return false;
-      }
-    } catch {
+      .query(`SELECT provider, auth FROM provider_connections WHERE name = ?`)
+      .get(SUBSCRIPTION_CONNECTION_NAME) as {
+      provider: string;
+      auth: string;
+    } | null;
+    if (!subscription || !isSubscriptionRow(subscription)) {
       return false;
     }
 
@@ -217,6 +208,46 @@ function isSubscriptionOnlyWorkspace(workspaceDir: string): boolean {
   } finally {
     db.close();
   }
+}
+
+/**
+ * Whether the canonical row is genuinely the subscription route, recognized
+ * across every on-disk shape it has had:
+ *   - pre-DB-366: provider "openai", auth carries `type: "oauth_subscription"`
+ *   - post-DB-366: provider "chatgpt" (the row IS the subscription route)
+ *   - post-DB-367: payload-only auth (`type` stripped) whose credential is
+ *     the chatgpt access-token slot
+ *
+ * The post-367 arms were widened into this historical migration after DB
+ * migration 367 shipped: DB migrations run before workspace migrations at
+ * boot, so a workspace jumping several releases sees the stripped shape on
+ * the very boot this migration first runs. The edit is pure
+ * detection-widening: installs that already checkpointed this migration
+ * never re-run it, and rows in the old typed shape are judged exactly as
+ * before. A claiming row with key auth matches no arm and stays
+ * unrecognized, as before.
+ */
+function isSubscriptionRow(row: { provider: string; auth: string }): boolean {
+  if (row.provider === "chatgpt") {
+    return true;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(row.auth);
+  } catch {
+    return false;
+  }
+  if (parsed === null || typeof parsed !== "object") {
+    return false;
+  }
+  const { type, credential } = parsed as {
+    type?: unknown;
+    credential?: unknown;
+  };
+  if (type === "oauth_subscription") {
+    return true;
+  }
+  return type === undefined && credential === "credential/chatgpt/access_token";
 }
 
 /**


### PR DESCRIPTION
## Summary
- Stored provider_connections auth shrinks to payload-only ({credential} / {}); type is derived on read from the provider column (redundant since migrations 361/366)
- DB migration 367 strips type from existing rows; wire contract untouched — responses still emit a typed echo and the auth fingerprint stays stable across edits
- effectiveConnectionAuth's vellum special-case is subsumed by the derivation

Part of plan: conn-removal-13b-step4-demolition.md (PR 4 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41021" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->