### PR TITLE
refactor(web): call-site overrides pick a model only

### DIFF
--- a/clients/web/src/assistant/llm-model-catalog.ts
+++ b/clients/web/src/assistant/llm-model-catalog.ts
@@ -1006,7 +1006,7 @@ export const VELLUM_SERVED_PROVIDERS = [
  * Union of the given providers' catalogs, deduplicated by display label as
  * well as id: two upstreams can host the same model under different ids
  * (e.g. MiniMax M3 on Fireworks and Together), and provider-agnostic pickers
- * render labels only — duplicate labels would be indistinguishable options.
+ * render labels only, so duplicate labels would be indistinguishable options.
  * First provider in the given order wins.
  */
 function dedupedModelUnion(

--- a/clients/web/src/assistant/llm-model-catalog.ts
+++ b/clients/web/src/assistant/llm-model-catalog.ts
@@ -1003,21 +1003,20 @@ export const VELLUM_SERVED_PROVIDERS = [
 ] as const;
 
 /**
- * The Vellum entry's model list: the union of the managed-routable providers'
- * catalogs, deduplicated by id in VELLUM_SERVED_PROVIDERS order. Users pick
- * "Vellum" + a model; which upstream serves it is an implementation detail.
+ * Union of the given providers' catalogs, deduplicated by display label as
+ * well as id: two upstreams can host the same model under different ids
+ * (e.g. MiniMax M3 on Fireworks and Together), and provider-agnostic pickers
+ * render labels only — duplicate labels would be indistinguishable options.
+ * First provider in the given order wins.
  */
-const VELLUM_MODELS: readonly LlmCatalogModel[] = (() => {
+function dedupedModelUnion(
+  providers: readonly LlmProviderId[],
+): readonly LlmCatalogModel[] {
   const seenIds = new Set<string>();
   const seenLabels = new Set<string>();
   const union: LlmCatalogModel[] = [];
-  for (const provider of VELLUM_SERVED_PROVIDERS) {
+  for (const provider of providers) {
     for (const model of MODELS_BY_PROVIDER[provider]) {
-      // Dedupe by display label as well as id: two upstreams can host the
-      // same model under different ids (e.g. MiniMax M3 on Fireworks and
-      // Together), and the provider-agnostic picker renders labels only —
-      // duplicate labels would be indistinguishable options. First provider
-      // in VELLUM_SERVED_PROVIDERS order wins.
       if (seenIds.has(model.id) || seenLabels.has(model.displayName)) {
         continue;
       }
@@ -1027,7 +1026,19 @@ const VELLUM_MODELS: readonly LlmCatalogModel[] = (() => {
     }
   }
   return union;
-})();
+}
+
+/**
+ * The Vellum entry's model list: the union of the managed-routable providers'
+ * catalogs. Users pick "Vellum" + a model; which upstream serves it is an
+ * implementation detail.
+ */
+const VELLUM_MODELS = dedupedModelUnion(VELLUM_SERVED_PROVIDERS);
+
+/** Every catalog model across all providers. */
+export const ALL_CATALOG_MODELS = dedupedModelUnion(
+  Object.keys(MODELS_BY_PROVIDER) as LlmProviderId[],
+);
 
 /**
  * The managed upstream that serves a model picked under the Vellum entry —

--- a/clients/web/src/domains/onboarding/provider-key.test.ts
+++ b/clients/web/src/domains/onboarding/provider-key.test.ts
@@ -186,7 +186,6 @@ describe("pending provider key", () => {
       body: {
         provider: "ollama",
         model: "mistral",
-        provider_connection: "ollama",
         source: "user",
         label: "Ollama",
         maxTokens: 4096,
@@ -243,7 +242,6 @@ describe("pending provider key", () => {
       body: {
         provider: "openai-compatible",
         model: "model-a",
-        provider_connection: "openai-compatible",
         source: "user",
         label: "OpenAI-compatible",
         maxTokens: 16_000,
@@ -297,7 +295,6 @@ describe("pending provider key", () => {
       body: {
         provider: "anthropic",
         model: "claude-sonnet-4-6",
-        provider_connection: "anthropic",
         source: "user",
         label: "Balanced",
         description: "Good balance of quality, cost, and speed",

--- a/clients/web/src/domains/onboarding/provider-key.ts
+++ b/clients/web/src/domains/onboarding/provider-key.ts
@@ -240,7 +240,6 @@ function buildCustomProviderProfile(
   const profile: ProfileEntry = {
     provider,
     model,
-    provider_connection: provider,
     source: "user",
     label: providerEntry?.displayName ?? provider,
     maxTokens: modelEntry?.maxOutputTokens ?? 16_000,

--- a/clients/web/src/domains/settings/ai/bulk-override-swap-modal.tsx
+++ b/clients/web/src/domains/settings/ai/bulk-override-swap-modal.tsx
@@ -85,8 +85,8 @@ export function BulkOverrideSwapModal({
     [requireOwnProviderAndModel],
   );
 
-  // What each action currently runs on. Sites with a provider/model
-  // ("Custom") pin reference no profile and stay out.
+  // What each action currently runs on. Sites with a model ("Custom") pin
+  // reference no profile and stay out.
   const effectiveByCallSite = useMemo(() => {
     const map = new Map<string, CallSiteEffectiveProfile>();
     for (const cs of callSites) {

--- a/clients/web/src/domains/settings/ai/call-site-helpers.test.ts
+++ b/clients/web/src/domains/settings/ai/call-site-helpers.test.ts
@@ -28,13 +28,16 @@ describe("isDraftActive", () => {
   });
 
   test("returns false when all picker fields are null", () => {
-    expect(isDraftActive({ profile: null, model: null })).toBe(false);
+    expect(isDraftActive({ profile: null, provider: null, model: null })).toBe(
+      false,
+    );
   });
 
-  test("a legacy provider-only entry reads as inactive", () => {
-    // Drafts pick a model only; a stale provider field persisted by an
-    // older daemon does not activate the row.
-    expect(isDraftActive({ provider: "openai" })).toBe(false);
+  test("a legacy provider-only entry reads as active", () => {
+    // Drafts can no longer set a provider, but old daemons still route on a
+    // persisted pin: the row must show as modified and stay clearable
+    // rather than hiding a live routing change.
+    expect(isDraftActive({ provider: "openai" })).toBe(true);
   });
 });
 
@@ -81,9 +84,15 @@ describe("effectiveCallSiteProfile", () => {
     ).toEqual({ profile: "balanced", via: "default" });
   });
 
-  test("a model pin references no profile", () => {
+  test("a model or legacy provider pin references no profile", () => {
     expect(
       effectiveCallSiteProfile({ defaultProfile: "slow" }, { model: "gpt-4o" }),
+    ).toBe(null);
+    expect(
+      effectiveCallSiteProfile(
+        { defaultProfile: "slow" },
+        { provider: "openai" },
+      ),
     ).toBe(null);
     expect(
       effectiveCallSiteProfile(
@@ -134,11 +143,22 @@ describe("draftsEqual", () => {
     ).toBe(false);
   });
 
+  test("clearing a legacy provider pin reads as a change", () => {
+    // Repairing a legacy pin can leave the model identical; the provider
+    // difference alone must make the row dirty so the clearing save fires.
+    expect(
+      draftsEqual(
+        { provider: "openai", model: "gpt-4o" },
+        { profile: null, model: "gpt-4o" },
+      ),
+    ).toBe(false);
+  });
+
   test("null and undefined fields are treated as equivalent", () => {
     expect(
       draftsEqual(
-        { profile: "fast", model: null },
-        { profile: "fast", model: undefined },
+        { profile: "fast", provider: null, model: null },
+        { profile: "fast", provider: undefined, model: undefined },
       ),
     ).toBe(true);
   });

--- a/clients/web/src/domains/settings/ai/call-site-helpers.test.ts
+++ b/clients/web/src/domains/settings/ai/call-site-helpers.test.ts
@@ -22,16 +22,19 @@ describe("isDraftActive", () => {
     expect(isDraftActive({})).toBe(false);
   });
 
-  test("returns true when any field is set", () => {
+  test("returns true when a picker field is set", () => {
     expect(isDraftActive({ profile: "fast" })).toBe(true);
-    expect(isDraftActive({ provider: "openai" })).toBe(true);
     expect(isDraftActive({ model: "gpt-4o" })).toBe(true);
   });
 
-  test("returns false when all fields are null", () => {
-    expect(isDraftActive({ profile: null, provider: null, model: null })).toBe(
-      false,
-    );
+  test("returns false when all picker fields are null", () => {
+    expect(isDraftActive({ profile: null, model: null })).toBe(false);
+  });
+
+  test("a legacy provider-only entry reads as inactive", () => {
+    // Drafts pick a model only; a stale provider field persisted by an
+    // older daemon does not activate the row.
+    expect(isDraftActive({ provider: "openai" })).toBe(false);
   });
 });
 
@@ -78,15 +81,9 @@ describe("effectiveCallSiteProfile", () => {
     ).toEqual({ profile: "balanced", via: "default" });
   });
 
-  test("a provider or model pin references no profile", () => {
+  test("a model pin references no profile", () => {
     expect(
       effectiveCallSiteProfile({ defaultProfile: "slow" }, { model: "gpt-4o" }),
-    ).toBe(null);
-    expect(
-      effectiveCallSiteProfile(
-        { defaultProfile: "slow" },
-        { provider: "openai" },
-      ),
     ).toBe(null);
     expect(
       effectiveCallSiteProfile(
@@ -121,7 +118,6 @@ describe("draftsEqual", () => {
   test("identical active drafts are equal", () => {
     const a: CallSiteOverrideDraft = {
       profile: "fast",
-      provider: "openai",
       model: "gpt-4o",
     };
     expect(draftsEqual(a, { ...a })).toBe(true);
@@ -130,11 +126,9 @@ describe("draftsEqual", () => {
   test("differing fields are detected", () => {
     const base: CallSiteOverrideDraft = {
       profile: "fast",
-      provider: "openai",
       model: "gpt-4o",
     };
     expect(draftsEqual(base, { ...base, profile: "slow" })).toBe(false);
-    expect(draftsEqual(base, { ...base, provider: "anthropic" })).toBe(false);
     expect(
       draftsEqual(base, { ...base, model: "claude-sonnet-4-20250514" }),
     ).toBe(false);
@@ -143,8 +137,8 @@ describe("draftsEqual", () => {
   test("null and undefined fields are treated as equivalent", () => {
     expect(
       draftsEqual(
-        { profile: "fast", provider: null, model: null },
-        { profile: "fast", provider: undefined, model: undefined },
+        { profile: "fast", model: null },
+        { profile: "fast", model: undefined },
       ),
     ).toBe(true);
   });

--- a/clients/web/src/domains/settings/ai/call-site-helpers.ts
+++ b/clients/web/src/domains/settings/ai/call-site-helpers.ts
@@ -19,7 +19,7 @@ export function isDraftActive(
   if (!d) {
     return false;
   }
-  return !!(d.profile || d.provider || d.model);
+  return !!(d.profile || d.model);
 }
 
 /**
@@ -33,8 +33,8 @@ export function isDraftActive(
  * else entirely.
  *
  * `via` is therefore derived by asking whether the winner is the pin, rather
- * than assuming a pin wins. Returns null for provider/model ("Custom") pins,
- * which reference no profile at all.
+ * than assuming a pin wins. Returns null for model ("Custom") pins, which
+ * reference no profile at all.
  */
 export interface CallSiteEffectiveProfile {
   profile: string;
@@ -51,7 +51,7 @@ export function effectiveCallSiteProfile(
   callSite: CallSiteDefaults,
   override: CallSiteOverrideDraft | null | undefined,
 ): CallSiteEffectiveProfile | null {
-  if (override?.provider || override?.model) {
+  if (override?.model) {
     return null;
   }
   // `shippedDefaultProfile` covers the profileless case, where the winner is
@@ -81,7 +81,6 @@ export function draftsEqual(
   }
   return (
     (a?.profile ?? null) === (b?.profile ?? null) &&
-    (a?.provider ?? null) === (b?.provider ?? null) &&
     (a?.model ?? null) === (b?.model ?? null)
   );
 }

--- a/clients/web/src/domains/settings/ai/call-site-helpers.ts
+++ b/clients/web/src/domains/settings/ai/call-site-helpers.ts
@@ -19,7 +19,12 @@ export function isDraftActive(
   if (!d) {
     return false;
   }
-  return !!(d.profile || d.model);
+  // The legacy `provider` field is read-tolerated but never set: older
+  // daemons still route on a persisted provider pin, so hiding such an
+  // entry would show an unmodified row while dispatch is still changed.
+  // The row stays visible and clearable; every write path sends
+  // `provider: null`.
+  return !!(d.profile || d.model) || d.provider != null;
 }
 
 /**
@@ -34,7 +39,8 @@ export function isDraftActive(
  *
  * `via` is therefore derived by asking whether the winner is the pin, rather
  * than assuming a pin wins. Returns null for model ("Custom") pins, which
- * reference no profile at all.
+ * reference no profile at all; a legacy provider pin counts too, since old
+ * daemons still route on it.
  */
 export interface CallSiteEffectiveProfile {
   profile: string;
@@ -51,7 +57,7 @@ export function effectiveCallSiteProfile(
   callSite: CallSiteDefaults,
   override: CallSiteOverrideDraft | null | undefined,
 ): CallSiteEffectiveProfile | null {
-  if (override?.model) {
+  if (override?.model || override?.provider != null) {
     return null;
   }
   // `shippedDefaultProfile` covers the profileless case, where the winner is
@@ -81,6 +87,10 @@ export function draftsEqual(
   }
   return (
     (a?.profile ?? null) === (b?.profile ?? null) &&
+    // Legacy provider pins compare too, so replacing one with a model-only
+    // pin of the same model still reads as a change worth saving (the save
+    // is what clears the pin).
+    (a?.provider ?? null) === (b?.provider ?? null) &&
     (a?.model ?? null) === (b?.model ?? null)
   );
 }

--- a/clients/web/src/domains/settings/ai/call-site-overrides-row.test.tsx
+++ b/clients/web/src/domains/settings/ai/call-site-overrides-row.test.tsx
@@ -1,32 +1,30 @@
 /**
- * A pinned provider this assistant cannot select must still be shown as the
- * pin, not swapped for a selectable one.
- *
- * Displaying a fallback while storing something else would be wrong on its
- * own, and `Select` gives it teeth: it reports changes rather than clicks, so
- * re-picking the shown provider is a no-op and the mismatch survives into a
- * save of the wrong provider.
+ * The custom-pin editor is a model choice only: the route comes from the
+ * site's winning profile, so the model list is scoped by that route's
+ * provider kind and no provider is ever written into a draft.
  */
 
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 
 import { cleanup, fireEvent, render } from "@testing-library/react";
 
-let selfHosted = false;
-
-mock.module("@/hooks/use-platform-gate", () => ({
-  usePlatformGate: () => "full",
-  useActiveAssistantIsSelfHosted: () => selfHosted,
-}));
-
-const { CallSiteOverrideRow } =
-  await import("@/domains/settings/ai/call-site-overrides-row");
+import { getDefaultModelForProvider } from "@/assistant/llm-model-catalog";
+import { CUSTOM_SENTINEL } from "@/domains/settings/ai/call-site-helpers";
+import { CallSiteOverrideRow } from "@/domains/settings/ai/call-site-overrides-row";
 
 const drafts: unknown[] = [];
 
+const PROFILE_OPTIONS = [
+  { value: "balanced", label: "Balanced" },
+  { value: CUSTOM_SENTINEL, label: "Custom" },
+];
+
 function renderRow(
   draft: Record<string, unknown> | null,
-  connections?: Record<string, unknown>[],
+  options?: {
+    winningProvider?: string;
+    connections?: Record<string, unknown>[];
+  },
 ) {
   return render(
     <CallSiteOverrideRow
@@ -34,8 +32,9 @@ function renderRow(
       displayName="Workflow Leaf"
       defaultProfileLabel="Balanced"
       draft={draft as never}
-      profileOptions={[{ value: "balanced", label: "Balanced" }] as never}
-      connections={connections as never}
+      profileOptions={PROFILE_OPTIONS as never}
+      winningProvider={options?.winningProvider}
+      connections={options?.connections as never}
       onDraftChange={(_id, next) => {
         drafts.push(next);
       }}
@@ -44,25 +43,22 @@ function renderRow(
   );
 }
 
-function triggerLabels(): string[] {
+function triggers(): HTMLElement[] {
   return Array.from(
     document.querySelectorAll<HTMLElement>('button[role="combobox"]'),
-  ).map((t) => t.textContent?.trim() ?? "");
+  );
 }
 
-/**
- * The row renders three pickers in order: profile, provider, model. Index,
- * not text, because the provider trigger's text is the thing under test.
- */
-function providerTrigger(): HTMLElement {
-  const triggers = document.querySelectorAll<HTMLElement>(
-    'button[role="combobox"]',
-  );
-  const el = triggers[1];
+function triggerLabels(): string[] {
+  return triggers().map((t) => t.textContent?.trim() ?? "");
+}
+
+/** The row renders two pickers in order: profile, model. */
+function modelTrigger(): HTMLElement {
+  const all = triggers();
+  const el = all[1];
   if (!el) {
-    throw new Error(
-      `expected a provider trigger, saw ${triggers.length} comboboxes`,
-    );
+    throw new Error(`expected a model trigger, saw ${all.length} comboboxes`);
   }
   return el;
 }
@@ -76,77 +72,96 @@ function optionLabels(): string[] {
 afterEach(() => {
   cleanup();
   drafts.length = 0;
-  selfHosted = false;
 });
 
-describe("CallSiteOverrideRow provider picker", () => {
-  test("a pin this assistant cannot select is shown as itself, marked unavailable", () => {
-    // `ollama` is local-only, so a platform-hosted assistant cannot pick it.
-    renderRow({ provider: "ollama", model: "llama3" });
+describe("CallSiteOverrideRow custom pin", () => {
+  test("a custom draft renders the profile and model pickers only", () => {
+    renderRow({ model: "claude-fable-5" }, { winningProvider: "anthropic" });
 
-    const labels = triggerLabels();
-    expect(labels.some((l) => l.includes("Ollama"))).toBe(true);
-    // The bug this guards: showing a provider the draft does not hold.
-    expect(labels.some((l) => l.includes("Anthropic"))).toBe(false);
+    expect(triggers().length).toBe(2);
   });
 
-  test("the unavailable pin is offered so the user has a way out", () => {
-    renderRow({ provider: "ollama", model: "llama3" });
+  test("picking Custom sends a model-only draft", () => {
+    renderRow({ profile: "balanced" }, { winningProvider: "anthropic" });
 
-    fireEvent.click(providerTrigger());
-
-    expect(optionLabels().some((l) => l.includes("(unavailable)"))).toBe(true);
-  });
-
-  test("picking a real provider over an unavailable pin saves that provider", () => {
-    // The repair path. Under the old fallback display this was impossible:
-    // the trigger already showed Anthropic, so choosing Anthropic was a
-    // no-op and the stale `ollama` was saved.
-    renderRow({ provider: "ollama", model: "llama3" });
-
-    fireEvent.click(providerTrigger());
-    const anthropic = Array.from(
+    const profileTrigger = triggers()[0]!;
+    fireEvent.click(profileTrigger);
+    const custom = Array.from(
       document.querySelectorAll<HTMLElement>('[role="option"]'),
-    ).find((o) => o.textContent?.trim() === "Anthropic");
-    expect(anthropic).toBeTruthy();
-    fireEvent.click(anthropic!);
+    ).find((o) => o.textContent?.trim() === "Custom");
+    expect(custom).toBeTruthy();
+    fireEvent.click(custom!);
 
-    expect(drafts.length).toBeGreaterThan(0);
-    expect(drafts.at(-1)).toMatchObject({ provider: "anthropic" });
+    expect(drafts.at(-1)).toEqual({
+      profile: null,
+      model: getDefaultModelForProvider("anthropic"),
+    });
   });
 
-  test("a selectable pin is not marked unavailable", () => {
-    renderRow({ provider: "anthropic", model: "claude-opus-5" });
+  test("picking a model keeps the draft model-only", () => {
+    renderRow({ model: "claude-fable-5" }, { winningProvider: "anthropic" });
 
-    fireEvent.click(providerTrigger());
+    fireEvent.click(modelTrigger());
+    const option = Array.from(
+      document.querySelectorAll<HTMLElement>('[role="option"]'),
+    ).find((o) => o.textContent?.trim() === "Claude Opus 5");
+    expect(option).toBeTruthy();
+    fireEvent.click(option!);
 
-    expect(optionLabels().some((l) => l.includes("(unavailable)"))).toBe(false);
-  });
-
-  test("on a self-hosted assistant ollama is a normal option", () => {
-    selfHosted = true;
-    renderRow({ provider: "ollama", model: "llama3" });
-
-    fireEvent.click(providerTrigger());
-
-    expect(optionLabels().some((l) => l.includes("(unavailable)"))).toBe(false);
-    expect(optionLabels().some((l) => l.includes("Ollama"))).toBe(true);
+    expect(drafts.at(-1)).toEqual({ model: "claude-opus-5" });
   });
 });
 
-/** The row renders three pickers in order: profile, provider, model. */
-function modelTrigger(): HTMLElement {
-  const triggers = document.querySelectorAll<HTMLElement>(
-    'button[role="combobox"]',
-  );
-  const el = triggers[2];
-  if (!el) {
-    throw new Error(
-      `expected a model trigger, saw ${triggers.length} comboboxes`,
-    );
-  }
-  return el;
-}
+describe("CallSiteOverrideRow model scoping by the winning route", () => {
+  test("a BYOK winner scopes the list to its provider's catalog", () => {
+    renderRow({ model: "claude-fable-5" }, { winningProvider: "anthropic" });
+
+    fireEvent.click(modelTrigger());
+
+    const labels = optionLabels();
+    expect(labels.some((l) => l.includes("Claude Fable 5"))).toBe(true);
+    expect(labels.some((l) => l.includes("GPT-5.6 Luna"))).toBe(false);
+  });
+
+  test("a vellum winner offers the managed model union", () => {
+    renderRow({ model: "claude-fable-5" }, { winningProvider: "vellum" });
+
+    fireEvent.click(modelTrigger());
+
+    const labels = optionLabels();
+    expect(labels.some((l) => l.includes("Claude Fable 5"))).toBe(true);
+    expect(labels.some((l) => l.includes("GPT-5.6 Luna"))).toBe(true);
+  });
+
+  test("an indeterminate winner falls back to the full catalog union", () => {
+    // The daemon validates servability on save, so offering everything is
+    // safe; hiding models would strand a user whose winner the client
+    // cannot resolve.
+    renderRow({ model: "claude-fable-5" });
+
+    fireEvent.click(modelTrigger());
+
+    const labels = optionLabels();
+    expect(labels.some((l) => l.includes("Claude Fable 5"))).toBe(true);
+    expect(labels.some((l) => l.includes("GPT-5.6 Luna"))).toBe(true);
+    expect(labels.some((l) => l.includes("Llama 3.2"))).toBe(true);
+  });
+
+  test("a stored pin outside the offered set stays visible as unavailable", () => {
+    // The trigger shows the stored pin instead of rendering blank while the
+    // out-of-route value is still saved.
+    renderRow({ model: "gpt-5.4-nano" }, { winningProvider: "anthropic" });
+
+    expect(
+      triggerLabels().some((l) => l.includes("GPT-5.4 Nano (unavailable)")),
+    ).toBe(true);
+
+    fireEvent.click(modelTrigger());
+    expect(
+      optionLabels().some((l) => l.includes("GPT-5.4 Nano (unavailable)")),
+    ).toBe(true);
+  });
+});
 
 const SUBSCRIPTION_CONNECTION = {
   name: "chatgpt-subscription",
@@ -167,17 +182,12 @@ const SUBSCRIPTION_CONNECTION_366 = {
   auth: { type: "oauth_subscription", credential: "credential/chatgpt" },
 };
 
-const VELLUM_CONNECTION = {
-  name: "vellum",
-  provider: "vellum",
-  auth: { type: "platform" },
-};
-
 describe("CallSiteOverrideRow model picker under a ChatGPT subscription", () => {
   test("only Codex-servable models are offered when every openai connection is a subscription", () => {
-    renderRow({ provider: "openai", model: "gpt-5.6-luna" }, [
-      SUBSCRIPTION_CONNECTION,
-    ]);
+    renderRow(
+      { model: "gpt-5.6-luna" },
+      { winningProvider: "openai", connections: [SUBSCRIPTION_CONNECTION] },
+    );
 
     fireEvent.click(modelTrigger());
 
@@ -188,116 +198,54 @@ describe("CallSiteOverrideRow model picker under a ChatGPT subscription", () => 
     expect(labels.some((l) => l.includes("Nano"))).toBe(false);
   });
 
-  test("a migrated subscription row (provider chatgpt) does not gate the openai picker", () => {
-    // Post-366 semantics: dispatch matches connections by exact provider, so
-    // the subscription cannot serve an openai override. The subscription is
-    // offered as its own ChatGPT provider entry instead.
-    renderRow({ provider: "openai", model: "gpt-5.6-luna" }, [
-      SUBSCRIPTION_CONNECTION_366,
-    ]);
+  test("a migrated subscription row (provider chatgpt) does not gate an openai winner", () => {
+    // Post-366 semantics: dispatch matches connections by exact provider,
+    // so the subscription cannot serve an openai route.
+    renderRow(
+      { model: "gpt-5.6-luna" },
+      { winningProvider: "openai", connections: [SUBSCRIPTION_CONNECTION_366] },
+    );
 
     fireEvent.click(modelTrigger());
 
     expect(optionLabels().some((l) => l.includes("Nano"))).toBe(true);
   });
 
-  test("the subscription row adds ChatGPT to the provider picker", () => {
-    renderRow({ provider: "openai", model: "gpt-5.6-luna" }, [
-      SUBSCRIPTION_CONNECTION_366,
-    ]);
-
-    fireEvent.click(providerTrigger());
-
-    expect(optionLabels().some((l) => l.includes("ChatGPT Subscription"))).toBe(
-      true,
+  test("a chatgpt winner offers the Codex model list", () => {
+    renderRow(
+      { model: "gpt-5.6-terra" },
+      {
+        winningProvider: "chatgpt",
+        connections: [SUBSCRIPTION_CONNECTION_366],
+      },
     );
-  });
-
-  test("without the subscription row ChatGPT is not offered", () => {
-    renderRow({ provider: "openai", model: "gpt-5.6-luna" }, [
-      API_KEY_CONNECTION,
-    ]);
-
-    fireEvent.click(providerTrigger());
-
-    expect(optionLabels().some((l) => l.includes("ChatGPT Subscription"))).toBe(
-      false,
-    );
-  });
-
-  test("a chatgpt draft renders as itself with the Codex model list", () => {
-    renderRow({ provider: "chatgpt", model: "gpt-5.6-terra" }, [
-      SUBSCRIPTION_CONNECTION_366,
-    ]);
-
-    expect(
-      triggerLabels().some((l) => l.includes("ChatGPT Subscription")),
-    ).toBe(true);
 
     fireEvent.click(modelTrigger());
+
     const labels = optionLabels();
     expect(labels.some((l) => l.includes("GPT-5.6 Terra"))).toBe(true);
     expect(labels.some((l) => l.includes("Nano"))).toBe(false);
   });
 
-  test("a chatgpt draft without the subscription renders as an unavailable pin", () => {
-    renderRow({ provider: "chatgpt", model: "gpt-5.6-terra" }, [
-      API_KEY_CONNECTION,
-    ]);
-
-    fireEvent.click(providerTrigger());
-
-    expect(
-      optionLabels().some((l) =>
-        l.includes("ChatGPT Subscription (unavailable)"),
-      ),
-    ).toBe(true);
-  });
-
-  test("a vellum-managed connection lifts the restriction (openai routes through the managed proxy)", () => {
-    renderRow({ provider: "openai", model: "gpt-5.6-luna" }, [
-      SUBSCRIPTION_CONNECTION_366,
-      VELLUM_CONNECTION,
-    ]);
+  test("an api-key connection restores the full openai catalog", () => {
+    renderRow(
+      { model: "gpt-5.6-luna" },
+      {
+        winningProvider: "openai",
+        connections: [SUBSCRIPTION_CONNECTION, API_KEY_CONNECTION],
+      },
+    );
 
     fireEvent.click(modelTrigger());
 
     expect(optionLabels().some((l) => l.includes("Nano"))).toBe(true);
   });
 
-  test("an api-key connection restores the full catalog", () => {
-    renderRow({ provider: "openai", model: "gpt-5.6-luna" }, [
-      SUBSCRIPTION_CONNECTION,
-      API_KEY_CONNECTION,
-    ]);
+  test("absent connection data leaves the winner's catalog unfiltered", () => {
+    renderRow({ model: "gpt-5.6-luna" }, { winningProvider: "openai" });
 
     fireEvent.click(modelTrigger());
 
     expect(optionLabels().some((l) => l.includes("Nano"))).toBe(true);
-  });
-
-  test("absent connection data leaves the catalog unfiltered", () => {
-    renderRow({ provider: "openai", model: "gpt-5.6-luna" });
-
-    fireEvent.click(modelTrigger());
-
-    expect(optionLabels().some((l) => l.includes("Nano"))).toBe(true);
-  });
-
-  test("a stored pin outside the filtered set stays visible as unavailable", () => {
-    renderRow({ provider: "openai", model: "gpt-5.4-nano" }, [
-      SUBSCRIPTION_CONNECTION,
-    ]);
-
-    // The trigger shows the stored pin instead of rendering blank while the
-    // incompatible value is still saved.
-    expect(
-      triggerLabels().some((l) => l.includes("GPT-5.4 Nano (unavailable)")),
-    ).toBe(true);
-
-    fireEvent.click(modelTrigger());
-    expect(
-      optionLabels().some((l) => l.includes("GPT-5.4 Nano (unavailable)")),
-    ).toBe(true);
   });
 });

--- a/clients/web/src/domains/settings/ai/call-site-overrides-row.test.tsx
+++ b/clients/web/src/domains/settings/ai/call-site-overrides-row.test.tsx
@@ -147,6 +147,44 @@ describe("CallSiteOverrideRow model scoping by the winning route", () => {
     expect(labels.some((l) => l.includes("Llama 3.2"))).toBe(true);
   });
 
+  test("an empty-catalog winner falls back to the full union", () => {
+    // litellm serves models from its connection, so its catalog column is
+    // empty; scoping to it would leave nothing to pick.
+    renderRow({ model: "claude-fable-5" }, { winningProvider: "litellm" });
+
+    fireEvent.click(modelTrigger());
+
+    const labels = optionLabels();
+    expect(labels.some((l) => l.includes("Claude Fable 5"))).toBe(true);
+    expect(labels.some((l) => l.includes("GPT-5.6 Luna"))).toBe(true);
+  });
+
+  test("picking Custom under an empty-catalog winner seeds a real model", () => {
+    // A model-less seed would read as an inactive draft.
+    renderRow({ profile: "balanced" }, { winningProvider: "litellm" });
+
+    const profileTrigger = triggers()[0]!;
+    fireEvent.click(profileTrigger);
+    const custom = Array.from(
+      document.querySelectorAll<HTMLElement>('[role="option"]'),
+    ).find((o) => o.textContent?.trim() === "Custom");
+    fireEvent.click(custom!);
+
+    const draft = drafts.at(-1) as { model?: string };
+    expect(typeof draft.model).toBe("string");
+    expect(draft.model!.length).toBeGreaterThan(0);
+  });
+
+  test("a legacy provider-only draft renders as an active Custom row", () => {
+    // Old daemons still route on a persisted provider pin: the row shows as
+    // modified with the Custom picker (picking a model is the repair path).
+    renderRow({ provider: "ollama" }, { winningProvider: "anthropic" });
+
+    const all = triggers();
+    expect(all.length).toBe(2);
+    expect(all[0]!.textContent).toContain("Custom");
+  });
+
   test("a stored pin outside the offered set stays visible as unavailable", () => {
     // The trigger shows the stored pin instead of rendering blank while the
     // out-of-route value is still saved.

--- a/clients/web/src/domains/settings/ai/call-site-overrides-row.tsx
+++ b/clients/web/src/domains/settings/ai/call-site-overrides-row.tsx
@@ -80,7 +80,9 @@ export function CallSiteOverrideRow({
     if (!draft || !overrideOn) {
       return "";
     }
-    if (draft.model) {
+    // A legacy provider-only pin renders as Custom: picking a model is its
+    // repair path (the save clears the provider).
+    if (draft.model || draft.provider != null) {
       return CUSTOM_SENTINEL;
     }
     return draft.profile ?? "";
@@ -97,11 +99,16 @@ export function CallSiteOverrideRow({
         connectionServesProvider(c.provider, winningProvider),
       )
     : [];
-  const availableModels = !winningProvider
+  const scopedModels = !winningProvider
     ? ALL_CATALOG_MODELS
     : restrictsToSubscriptionModels(winningProvider, "", connectionsForProvider)
       ? codexServableModels(winningProvider)
       : getModelsForProvider(winningProvider);
+  // A winner with an empty catalog (litellm, openai-compatible: models live
+  // on the connection) would leave nothing to pick; fall back to the full
+  // union and let the daemon validate on save.
+  const availableModels =
+    scopedModels.length > 0 ? scopedModels : ALL_CATALOG_MODELS;
   const modelOptions = availableModels.map((m) => ({
     value: m.id,
     label: m.displayName,
@@ -124,11 +131,14 @@ export function CallSiteOverrideRow({
 
   function handleProfilePickerChange(val: string) {
     if (val === CUSTOM_SENTINEL) {
+      // `||` chains so an empty-string catalog default (empty-catalog
+      // providers) falls through; a model-less seed would read as an
+      // inactive draft.
       const defaultModel =
         (winningProvider
           ? getDefaultModelForProvider(winningProvider)
-          : undefined) ??
-        availableModels[0]?.id ??
+          : undefined) ||
+        availableModels[0]?.id ||
         "";
       onDraftChange(id, { profile: null, model: defaultModel });
     } else if (val === "") {

--- a/clients/web/src/domains/settings/ai/call-site-overrides-row.tsx
+++ b/clients/web/src/domains/settings/ai/call-site-overrides-row.tsx
@@ -4,20 +4,15 @@ import { Toggle } from "@vellumai/design-library/components/toggle";
 import { useTranslation } from "@/i18n";
 
 import {
+  ALL_CATALOG_MODELS,
   getDefaultModelForProvider,
   getModelsForProvider,
-  PROVIDER_DISPLAY_NAMES,
 } from "@/assistant/llm-model-catalog";
 import type {
   CallSiteOverrideDraft,
   ProviderConnection,
 } from "@/generated/daemon/types.gen";
 
-import {
-  CHATGPT_CONNECTION_PROVIDER,
-  INFERENCE_PROVIDERS,
-  isInferenceProvider,
-} from "@/domains/settings/ai/constants";
 import {
   CUSTOM_SENTINEL,
   isDraftActive,
@@ -26,10 +21,7 @@ import {
   codexServableModels,
   restrictsToSubscriptionModels,
 } from "@/domains/settings/ai/codex-subscription-models";
-import {
-  connectionServesProvider,
-  useSelectableInferenceProviders,
-} from "@/domains/settings/ai/provider-availability";
+import { connectionServesProvider } from "@/domains/settings/ai/provider-availability";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -40,9 +32,6 @@ interface ProfileOption {
   label: string;
 }
 
-type PickableProvider =
-  (typeof INFERENCE_PROVIDERS)[number] | typeof CHATGPT_CONNECTION_PROVIDER;
-
 export interface CallSiteOverrideRowProps {
   id: string;
   displayName: string;
@@ -51,10 +40,17 @@ export interface CallSiteOverrideRowProps {
   draft: CallSiteOverrideDraft | null;
   profileOptions: ProfileOption[];
   /**
+   * Provider kind of the site's winning route, scoping the custom-pin model
+   * picker to what that route can serve. Absent when the winner is
+   * indeterminate client-side; the picker then offers the full catalog union
+   * and the daemon validates servability on save.
+   */
+  winningProvider?: string;
+  /**
    * All provider connections, used to limit the model picker to what the
    * matching connections can dispatch (a ChatGPT subscription serves only
    * the Codex model set). Absent when the caller has no connection data;
-   * the picker then offers the full catalog.
+   * the picker then offers the winning provider's full catalog.
    */
   connections?: ProviderConnection[];
   onDraftChange: (id: string, draft: CallSiteOverrideDraft | null) => void;
@@ -72,6 +68,7 @@ export function CallSiteOverrideRow({
   defaultProfileLabel,
   draft,
   profileOptions,
+  winningProvider,
   connections,
   onDraftChange,
   onToggle,
@@ -83,128 +80,62 @@ export function CallSiteOverrideRow({
     if (!draft || !overrideOn) {
       return "";
     }
-    if (draft.provider || draft.model) {
+    if (draft.model) {
       return CUSTOM_SENTINEL;
     }
     return draft.profile ?? "";
   })();
 
   const isCustom = profileVal === CUSTOM_SENTINEL;
-  const selectableInferenceProviders = useSelectableInferenceProviders();
-  // The chatgpt identity joins the picker when the workspace holds the
-  // subscription row (provider "chatgpt"; only daemons that understand the
-  // identity return that shape). Migration 144 also writes chatgpt drafts,
-  // so the row must represent the value even without the subscription: the
-  // unavailable-pin branch below covers that.
-  const hasSubscription = (connections ?? []).some(
-    (c) => c.provider === CHATGPT_CONNECTION_PROVIDER,
-  );
-  const pickableProviders: PickableProvider[] = [
-    ...selectableInferenceProviders,
-    ...(hasSubscription ? ([CHATGPT_CONNECTION_PROVIDER] as const) : []),
-  ];
-  const defaultProvider =
-    selectableInferenceProviders[0] ?? INFERENCE_PROVIDERS[0];
-  // Show what is actually pinned, even when this assistant cannot select it
-  // (an `ollama` pin on a platform-hosted assistant, say). Substituting a
-  // selectable provider for display would show one thing while saving
-  // another, and picking the shown value could not repair it: it is already
-  // the value, so the change never fires.
-  //
-  // `LlmProvider` is wider than the picker's domain (it also carries the
-  // `openai-compatible` and `vellum` routing sentinels), so a pin outside
-  // the pickable set still falls back rather than being offered as a row
-  // the picker cannot represent. The `chatgpt` identity is pickable and
-  // renders as itself.
-  const draftProvider = draft?.provider;
-  const storedProvider: PickableProvider | undefined = isInferenceProvider(
-    draftProvider,
-  )
-    ? draftProvider
-    : draftProvider === CHATGPT_CONNECTION_PROVIDER
-      ? CHATGPT_CONNECTION_PROVIDER
-      : undefined;
-  const storedProviderIsSelectable =
-    storedProvider !== undefined &&
-    pickableProviders.some((p) => p === storedProvider);
-  const currentProvider = storedProvider ?? defaultProvider;
-  // A call-site override pins no connection, so dispatch auto-resolves one.
-  // When every connection that can serve the provider is a ChatGPT
-  // subscription (stored as provider "chatgpt" once daemon migration 366 has
-  // run), only Codex models can resolve; offering the rest would save a pin
-  // that fails on every request.
-  const connectionsForProvider = (connections ?? []).filter((c) =>
-    connectionServesProvider(c.provider, currentProvider),
-  );
-  const availableModels = restrictsToSubscriptionModels(
-    currentProvider,
-    "",
-    connectionsForProvider,
-  )
-    ? codexServableModels(currentProvider)
-    : getModelsForProvider(currentProvider);
+  // A call-site pin names no connection, so dispatch resolves one from the
+  // winning route. When every connection that can serve the winning provider
+  // is a ChatGPT subscription (the pre-migration-366 row shape), only Codex
+  // models can resolve; offering the rest would save a pin that fails on
+  // every request.
+  const connectionsForProvider = winningProvider
+    ? (connections ?? []).filter((c) =>
+        connectionServesProvider(c.provider, winningProvider),
+      )
+    : [];
+  const availableModels = !winningProvider
+    ? ALL_CATALOG_MODELS
+    : restrictsToSubscriptionModels(winningProvider, "", connectionsForProvider)
+      ? codexServableModels(winningProvider)
+      : getModelsForProvider(winningProvider);
   const modelOptions = availableModels.map((m) => ({
     value: m.id,
     label: m.displayName,
   }));
   // A stored pin outside the offered set stays visible as itself, marked
   // unavailable: hiding it would render a blank trigger while the pin is
-  // still saved (mirrors the provider picker's unavailable-pin handling).
+  // still saved.
   const storedModel = typeof draft?.model === "string" ? draft.model : "";
   if (storedModel && !availableModels.some((m) => m.id === storedModel)) {
-    const displayName =
-      getModelsForProvider(currentProvider).find((m) => m.id === storedModel)
-        ?.displayName ?? storedModel;
+    const modelDisplayName =
+      ALL_CATALOG_MODELS.find((m) => m.id === storedModel)?.displayName ??
+      storedModel;
     modelOptions.push({
       value: storedModel,
-      label: t("callSiteOverridesRow.unavailableOption", { name: displayName }),
+      label: t("callSiteOverridesRow.unavailableOption", {
+        name: modelDisplayName,
+      }),
     });
   }
-  const hasModelError = !!draft?.provider && !draft?.model;
-  const providerOptions: { value: PickableProvider; label: string }[] = [
-    ...pickableProviders.map((p) => ({
-      value: p,
-      label: PROVIDER_DISPLAY_NAMES[p] ?? p,
-    })),
-    // Keeps the trigger honest and gives the user a way out: the row
-    // renders its real pin, and choosing any other provider is a genuine
-    // change that fires.
-    ...(storedProvider && !storedProviderIsSelectable
-      ? [
-          {
-            value: storedProvider,
-            label: t("callSiteOverridesRow.unavailableOption", {
-              name:
-                PROVIDER_DISPLAY_NAMES[storedProvider] ?? storedProvider,
-            }),
-          },
-        ]
-      : []),
-  ];
 
   function handleProfilePickerChange(val: string) {
     if (val === CUSTOM_SENTINEL) {
-      const defaultModel = getDefaultModelForProvider(defaultProvider) ?? "";
-      onDraftChange(id, {
-        profile: null,
-        provider: defaultProvider,
-        model: defaultModel,
-      });
+      const defaultModel =
+        (winningProvider
+          ? getDefaultModelForProvider(winningProvider)
+          : undefined) ??
+        availableModels[0]?.id ??
+        "";
+      onDraftChange(id, { profile: null, model: defaultModel });
     } else if (val === "") {
       onDraftChange(id, null);
     } else {
-      onDraftChange(id, { profile: val, provider: null, model: null });
+      onDraftChange(id, { profile: val, model: null });
     }
-  }
-
-  function handleProviderChange(provider: PickableProvider) {
-    const defaultModel = getDefaultModelForProvider(provider) ?? "";
-    onDraftChange(id, {
-      ...(draft ?? {}),
-      profile: null,
-      provider,
-      model: defaultModel,
-    });
   }
 
   function handleModelChange(model: string) {
@@ -255,36 +186,17 @@ export function CallSiteOverrideRow({
         </div>
       )}
 
-      {/* Custom provider + model pickers */}
+      {/* Custom model picker: the route comes from the winning profile */}
       {overrideOn && isCustom && (
-        <div className="mt-3 space-y-2 border-t border-[var(--border-base)] pt-3">
-          <div className="flex gap-2">
-            <div className="flex-1">
-              <label className="mb-1 block text-body-small-default text-[var(--content-tertiary)]">
-                {t("callSiteOverridesRow.providerLabel")}
-              </label>
-              <Select
-                value={currentProvider ?? ""}
-                onChange={handleProviderChange}
-                options={providerOptions}
-              />
-            </div>
-            <div className="flex-1">
-              <label className="mb-1 block text-body-small-default text-[var(--content-tertiary)]">
-                {t("callSiteOverridesRow.modelLabel")}
-              </label>
-              <Select
-                value={draft?.model ?? ""}
-                onChange={handleModelChange}
-                options={modelOptions}
-              />
-            </div>
-          </div>
-          {hasModelError && (
-            <p className="text-body-small-default text-[var(--system-negative-strong)]">
-              {t("callSiteOverridesRow.pickModelError")}
-            </p>
-          )}
+        <div className="mt-3 border-t border-[var(--border-base)] pt-3">
+          <label className="mb-1 block text-body-small-default text-[var(--content-tertiary)]">
+            {t("callSiteOverridesRow.modelLabel")}
+          </label>
+          <Select
+            value={draft?.model ?? ""}
+            onChange={handleModelChange}
+            options={modelOptions}
+          />
         </div>
       )}
     </div>

--- a/clients/web/src/domains/settings/ai/codex-subscription-models.ts
+++ b/clients/web/src/domains/settings/ai/codex-subscription-models.ts
@@ -2,16 +2,13 @@ import {
   CODEX_SUBSCRIPTION_MODEL_IDS,
   getModelsForProvider,
 } from "@/assistant/llm-model-catalog";
-import type {
-  ConnectionProvider,
-  ProviderConnection,
-} from "@/generated/daemon/types.gen";
+import type { ProviderConnection } from "@/generated/daemon/types.gen";
 
 export { CODEX_SUBSCRIPTION_MODEL_IDS };
 
 /** The provider's catalog models a ChatGPT subscription can dispatch. */
 export function codexServableModels(
-  provider: ConnectionProvider,
+  provider: string,
 ): ReturnType<typeof getModelsForProvider> {
   return getModelsForProvider(provider).filter((m) =>
     CODEX_SUBSCRIPTION_MODEL_IDS.has(m.id),
@@ -33,7 +30,7 @@ export function codexServableModels(
  * Codex-only model list itself.
  */
 export function restrictsToSubscriptionModels(
-  provider: ConnectionProvider | "",
+  provider: string,
   providerConnection: string,
   availableConnectionsForProvider: ProviderConnection[],
 ): boolean {

--- a/clients/web/src/domains/settings/ai/language-model-card.tsx
+++ b/clients/web/src/domains/settings/ai/language-model-card.tsx
@@ -73,7 +73,10 @@ export function LanguageModelCard({
 
   const callSites = config?.llm?.callSites ?? {};
   const overrideCount = Object.entries(callSites).filter(
-    ([id, s]) => id !== "mainAgent" && (s?.profile != null || s?.model != null),
+    // Legacy provider-only pins count: old daemons still route on them.
+    ([id, s]) =>
+      id !== "mainAgent" &&
+      (s?.profile != null || s?.model != null || s?.provider != null),
   ).length;
 
   return (

--- a/clients/web/src/domains/settings/ai/language-model-card.tsx
+++ b/clients/web/src/domains/settings/ai/language-model-card.tsx
@@ -73,78 +73,72 @@ export function LanguageModelCard({
 
   const callSites = config?.llm?.callSites ?? {};
   const overrideCount = Object.entries(callSites).filter(
-    ([id, s]) =>
-      id !== "mainAgent" &&
-      (s?.profile != null || s?.provider != null || s?.model != null),
+    ([id, s]) => id !== "mainAgent" && (s?.profile != null || s?.model != null),
   ).length;
 
   return (
     <ByoServiceCard
-        title={t("languageModelCard.title")}
-        subtitle={t("languageModelCard.subtitle")}
-      >
-        <div className="space-y-2">
-          {availability && availability.status !== "ok" && (
-            // The server owns the explainable wording - render its message
-            // verbatim. `unknown` is transient (credential store unreachable),
-            // everything else is a config problem the user must fix.
-            <Notice
-              tone={availability.status === "unknown" ? "warning" : "error"}
-            >
-              {availability.message ??
-                t("languageModelCard.defaultProviderUnavailable")}
-            </Notice>
-          )}
+      title={t("languageModelCard.title")}
+      subtitle={t("languageModelCard.subtitle")}
+    >
+      <div className="space-y-2">
+        {availability && availability.status !== "ok" && (
+          // The server owns the explainable wording - render its message
+          // verbatim. `unknown` is transient (credential store unreachable),
+          // everything else is a config problem the user must fix.
+          <Notice
+            tone={availability.status === "unknown" ? "warning" : "error"}
+          >
+            {availability.message ??
+              t("languageModelCard.defaultProviderUnavailable")}
+          </Notice>
+        )}
 
-          {assistantId && (
-            <ProfilesSection
-              assistantId={assistantId}
-              config={config}
-              connections={connections}
-              selectedProfileName={
-                panel?.kind === "profile" ? panel.name : null
+        {assistantId && (
+          <ProfilesSection
+            assistantId={assistantId}
+            config={config}
+            connections={connections}
+            selectedProfileName={panel?.kind === "profile" ? panel.name : null}
+            onOpenProfile={(name) => onOpenPanel({ kind: "profile", name })}
+            onCreateProfile={() => onOpenPanel({ kind: "create-profile" })}
+            onProfileDeleted={(name) => {
+              if (panel?.kind === "profile" && panel.name === name) {
+                onClosePanel();
               }
-              onOpenProfile={(name) => onOpenPanel({ kind: "profile", name })}
-              onCreateProfile={() => onOpenPanel({ kind: "create-profile" })}
-              onProfileDeleted={(name) => {
-                if (panel?.kind === "profile" && panel.name === name) {
-                  onClosePanel();
-                }
-              }}
-            />
-          )}
-
-          {assistantId && (
-            <ProvidersSection
-              assistantId={assistantId}
-              selectedConnectionName={
-                panel?.kind === "provider" ? panel.name : null
-              }
-              onOpenConnection={(name) =>
-                onOpenPanel({ kind: "provider", name })
-              }
-              onAddProvider={() => onOpenPanel({ kind: "add-provider" })}
-              onConnectionDeleted={(name) => {
-                if (panel?.kind === "provider" && panel.name === name) {
-                  onClosePanel();
-                }
-              }}
-            />
-          )}
-
-          <LanguageModelSection
-            title={t("languageModelCard.overridesTitle")}
-            count={overrideCount}
-            action={
-              <Button
-                variant="outlined"
-                onClick={() => onOpenPanel({ kind: "overrides" })}
-              >
-                {t("languageModelCard.manage")}
-              </Button>
-            }
+            }}
           />
-        </div>
+        )}
+
+        {assistantId && (
+          <ProvidersSection
+            assistantId={assistantId}
+            selectedConnectionName={
+              panel?.kind === "provider" ? panel.name : null
+            }
+            onOpenConnection={(name) => onOpenPanel({ kind: "provider", name })}
+            onAddProvider={() => onOpenPanel({ kind: "add-provider" })}
+            onConnectionDeleted={(name) => {
+              if (panel?.kind === "provider" && panel.name === name) {
+                onClosePanel();
+              }
+            }}
+          />
+        )}
+
+        <LanguageModelSection
+          title={t("languageModelCard.overridesTitle")}
+          count={overrideCount}
+          action={
+            <Button
+              variant="outlined"
+              onClick={() => onOpenPanel({ kind: "overrides" })}
+            >
+              {t("languageModelCard.manage")}
+            </Button>
+          }
+        />
+      </div>
     </ByoServiceCard>
   );
 }

--- a/clients/web/src/domains/settings/ai/overrides-call-site-list.tsx
+++ b/clients/web/src/domains/settings/ai/overrides-call-site-list.tsx
@@ -37,6 +37,12 @@ export interface OverridesCallSiteListProps {
     selectedProfile: string | null,
   ) => ProfileOption[];
   profileLabelFor: (name: string) => string;
+  /**
+   * Provider of a named profile from the loaded config, or undefined when
+   * the profile (or its provider) is unknown. Scopes each row's custom
+   * model picker to its winning route.
+   */
+  providerForProfile: (name: string) => string | undefined;
   advisorMatchesSearch: boolean;
   /** Passed through to each row's model picker; see CallSiteOverrideRowProps. */
   connections?: ProviderConnection[];
@@ -57,6 +63,7 @@ export function OverridesCallSiteList({
   drafts,
   buildProfileOptionsForRow,
   profileLabelFor,
+  providerForProfile,
   advisorMatchesSearch,
   connections,
   onDraftChange,
@@ -88,7 +95,7 @@ export function OverridesCallSiteList({
                   if (!d || !isDraftActive(d)) {
                     return "";
                   }
-                  if (d.provider || d.model) {
+                  if (d.model) {
                     return CUSTOM_SENTINEL;
                   }
                   return d.profile ?? "";
@@ -102,6 +109,16 @@ export function OverridesCallSiteList({
                 const defaultProfileLabel = defaultKey
                   ? profileLabelFor(defaultKey)
                   : null;
+                // A custom pin dispatches on the winning profile's route (a
+                // model pin references no profile, so `defaultProfile` names
+                // the chain's winner even under one). Undefined when neither
+                // catalog field resolves to a known provider; the row then
+                // offers the full model union and the daemon validates.
+                const winnerName =
+                  cs.defaultProfile ?? cs.shippedDefaultProfile;
+                const winningProvider = winnerName
+                  ? providerForProfile(winnerName)
+                  : undefined;
 
                 return (
                   <CallSiteOverrideRow
@@ -116,6 +133,7 @@ export function OverridesCallSiteList({
                         ? null
                         : profileVal,
                     )}
+                    winningProvider={winningProvider}
                     connections={connections}
                     onDraftChange={onDraftChange}
                     onToggle={onToggle}

--- a/clients/web/src/domains/settings/ai/overrides-call-site-list.tsx
+++ b/clients/web/src/domains/settings/ai/overrides-call-site-list.tsx
@@ -35,6 +35,7 @@ export interface OverridesCallSiteListProps {
   drafts: CallSiteDraftMap;
   buildProfileOptionsForRow: (
     selectedProfile: string | null,
+    includeCustom: boolean,
   ) => ProfileOption[];
   profileLabelFor: (name: string) => string;
   /**
@@ -43,6 +44,11 @@ export interface OverridesCallSiteListProps {
    * model picker to its winning route.
    */
   providerForProfile: (name: string) => string | undefined;
+  /**
+   * Whether a named profile is a mix. A mix winner has no single provider
+   * kind, so its rows do not offer new Custom pins.
+   */
+  isMixProfile: (name: string) => boolean;
   advisorMatchesSearch: boolean;
   /** Passed through to each row's model picker; see CallSiteOverrideRowProps. */
   connections?: ProviderConnection[];
@@ -64,6 +70,7 @@ export function OverridesCallSiteList({
   buildProfileOptionsForRow,
   profileLabelFor,
   providerForProfile,
+  isMixProfile,
   advisorMatchesSearch,
   connections,
   onDraftChange,
@@ -95,7 +102,7 @@ export function OverridesCallSiteList({
                   if (!d || !isDraftActive(d)) {
                     return "";
                   }
-                  if (d.model) {
+                  if (d.model || d.provider != null) {
                     return CUSTOM_SENTINEL;
                   }
                   return d.profile ?? "";
@@ -116,9 +123,19 @@ export function OverridesCallSiteList({
                 // offers the full model union and the daemon validates.
                 const winnerName =
                   cs.defaultProfile ?? cs.shippedDefaultProfile;
-                const winningProvider = winnerName
-                  ? providerForProfile(winnerName)
-                  : undefined;
+                const winnerIsMix =
+                  winnerName != null && isMixProfile(winnerName);
+                const winningProvider =
+                  winnerName != null && !winnerIsMix
+                    ? providerForProfile(winnerName)
+                    : undefined;
+                // A mix winner offers no NEW Custom pins (which arm serves
+                // a conversation is seeded per conversation, so no single
+                // model list is honest). An existing custom pin stays
+                // representable: hiding its option would blank the trigger
+                // while the pin is still saved.
+                const includeCustom =
+                  !winnerIsMix || profileVal === CUSTOM_SENTINEL;
 
                 return (
                   <CallSiteOverrideRow
@@ -132,6 +149,7 @@ export function OverridesCallSiteList({
                       profileVal === "" || profileVal === CUSTOM_SENTINEL
                         ? null
                         : profileVal,
+                      includeCustom,
                     )}
                     winningProvider={winningProvider}
                     connections={connections}

--- a/clients/web/src/domains/settings/ai/overrides-detail-panel.test.tsx
+++ b/clients/web/src/domains/settings/ai/overrides-detail-panel.test.tsx
@@ -91,9 +91,8 @@ mock.module("@/generated/daemon/sdk.gen", () => ({
   },
 }));
 
-const { OverridesDetailPanel } = await import(
-  "@/domains/settings/ai/overrides-detail-panel"
-);
+const { OverridesDetailPanel } =
+  await import("@/domains/settings/ai/overrides-detail-panel");
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -443,15 +442,14 @@ describe("OverridesDetailPanel - bulk change", () => {
   };
 
   test("disabled when no action carries a profile", async () => {
-    // The fixture catalog has no default profiles, and a provider/model
-    // pin renders as "Custom" and references no profile, so nothing is
-    // swappable.
+    // The fixture catalog has no default profiles, and a model pin renders
+    // as "Custom" and references no profile, so nothing is swappable.
     const CUSTOM_ONLY_CONFIG = {
       ...CONFIG,
       llm: {
         ...CONFIG.llm,
         callSites: {
-          workflowLeaf: { provider: "anthropic", model: "claude-fable-5" },
+          workflowLeaf: { model: "claude-fable-5" },
         },
       },
     };

--- a/clients/web/src/domains/settings/ai/overrides-detail-panel.test.tsx
+++ b/clients/web/src/domains/settings/ai/overrides-detail-panel.test.tsx
@@ -541,3 +541,104 @@ describe("OverridesDetailPanel - bulk change", () => {
     expect(getButton("Bulk change").disabled).toBe(true);
   });
 });
+
+describe("OverridesDetailPanel - Custom under a mix winner", () => {
+  // A mix winner has no single provider kind (the serving arm is seeded per
+  // conversation), so no model list is honest and the row must not offer a
+  // new Custom pin.
+  const MIX_CONFIG = {
+    ...CONFIG,
+    llm: {
+      ...CONFIG.llm,
+      profiles: {
+        ...CONFIG.llm.profiles,
+        blend: {
+          label: "Blend",
+          mix: [
+            { profile: "my-byok", weight: 1 },
+            { profile: "quality", weight: 1 },
+          ],
+        },
+      },
+      profileOrder: ["my-byok", "quality", "blend"],
+    },
+  };
+
+  const MIX_CATALOG = {
+    domains: [{ id: "agentLoop", displayName: "Agent Loop" }],
+    callSites: [
+      {
+        id: "workflowLeaf",
+        displayName: "Workflow Leaf",
+        description: "Runs an ephemeral leaf agent.",
+        domain: "agentLoop",
+        defaultProfile: "blend",
+      },
+    ],
+  };
+
+  function renderWith(config: unknown, catalog: unknown) {
+    servedConfig = config;
+    servedCatalog = catalog;
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: 0 } },
+    });
+    client.setQueryData([{ _id: "configLlmCallsitesGet" }], catalog);
+    client.setQueryData([{ _id: "configGet" }], config);
+    return render(
+      createElement(
+        QueryClientProvider,
+        { client },
+        createElement(OverridesDetailPanel, {
+          assistantId: "asst-1",
+          onClose: () => {},
+        }),
+      ),
+    );
+  }
+
+  function toggleOnAndOpenRowPicker() {
+    const toggle = Array.from(
+      document.querySelectorAll<HTMLElement>('[role="switch"]'),
+    ).find((el) =>
+      (el.getAttribute("aria-label") ?? "").includes("Workflow Leaf"),
+    );
+    if (!toggle) {
+      throw new Error("expected the Workflow Leaf toggle");
+    }
+    fireEvent.click(toggle);
+    // The advisor combobox renders first; the row's picker is the last one.
+    const combos = Array.from(
+      document.querySelectorAll<HTMLElement>('button[role="combobox"]'),
+    );
+    const rowTrigger = combos.at(-1);
+    if (!rowTrigger) {
+      throw new Error("expected the row's profile picker");
+    }
+    fireEvent.click(rowTrigger);
+    return Array.from(
+      document.querySelectorAll<HTMLElement>('[role="option"]'),
+    ).map((o) => o.textContent?.trim() ?? "");
+  }
+
+  test("a mix winner's row offers profiles but no Custom option", async () => {
+    renderWith(MIX_CONFIG, MIX_CATALOG);
+    await waitFor(() => {
+      expect(renderedText()).toContain("Workflow Leaf");
+    });
+
+    const options = toggleOnAndOpenRowPicker();
+    expect(options.some((l) => l.includes("My BYOK"))).toBe(true);
+    expect(options.some((l) => l === "Custom")).toBe(false);
+  });
+
+  test("a non-mix winner's row still offers Custom", async () => {
+    renderWith(CONFIG, CATALOG);
+    await waitFor(() => {
+      expect(renderedText()).toContain("Workflow Leaf");
+    });
+
+    const options = toggleOnAndOpenRowPicker();
+    expect(options.some((l) => l === "Custom")).toBe(true);
+  });
+});

--- a/clients/web/src/domains/settings/ai/overrides-detail-panel.tsx
+++ b/clients/web/src/domains/settings/ai/overrides-detail-panel.tsx
@@ -185,6 +185,14 @@ export function OverridesDetailPanel({
     [profiles],
   );
 
+  // A mix profile has no single provider kind: the arm is seeded per
+  // conversation, so a model pin's servability cannot be judged client-side
+  // and rows with a mix winner do not offer the Custom option.
+  const isMixProfile = useCallback(
+    (name: string) => (profiles[name]?.mix?.length ?? 0) > 0,
+    [profiles],
+  );
+
   // An entry only reaches a picker while undispatchable when it is the
   // current selection. It carries the same warning affordance the Profiles
   // row uses, rather than a word appended to its name.
@@ -237,15 +245,17 @@ export function OverridesDetailPanel({
   const hasAnyPersistedOverride = useMemo(
     () =>
       Object.entries(persistedOverrides).some(
+        // Legacy provider-only pins count: old daemons still route on
+        // them, and Reset is the affordance that clears them.
         ([id, s]) =>
           gatedCallSiteIdSet.has(id) &&
-          (s?.profile != null || s?.model != null),
+          (s?.profile != null || s?.model != null || s?.provider != null),
       ),
     [persistedOverrides, gatedCallSiteIdSet],
   );
 
   const buildProfileOptionsForRow = useCallback(
-    (selectedProfile: string | null) => {
+    (selectedProfile: string | null, includeCustom: boolean) => {
       const visible = visibleProfilesForPicker(
         orderedProfiles,
         [selectedProfile],
@@ -253,10 +263,14 @@ export function OverridesDetailPanel({
       );
       return [
         ...visible.map(toProfileOption),
-        {
-          value: CUSTOM_SENTINEL,
-          label: t("overridesDetailPanel.customProfileOption"),
-        },
+        ...(includeCustom
+          ? [
+              {
+                value: CUSTOM_SENTINEL,
+                label: t("overridesDetailPanel.customProfileOption"),
+              },
+            ]
+          : []),
       ];
     },
     [orderedProfiles, toProfileOption, dispatchOptions, t],
@@ -529,6 +543,7 @@ export function OverridesDetailPanel({
             buildProfileOptionsForRow={buildProfileOptionsForRow}
             profileLabelFor={profileLabelFor}
             providerForProfile={providerForProfile}
+            isMixProfile={isMixProfile}
             advisorMatchesSearch={advisorMatchesSearch}
             connections={connectionsData?.connections}
             onDraftChange={setDraft}

--- a/clients/web/src/domains/settings/ai/overrides-detail-panel.tsx
+++ b/clients/web/src/domains/settings/ai/overrides-detail-panel.tsx
@@ -35,6 +35,7 @@ import {
 } from "@/generated/daemon/@tanstack/react-query.gen";
 import { useLlmConfigPatch } from "@/domains/settings/ai/use-llm-config-patch";
 import { useSupportsCompleteProfileSnapshots } from "@/lib/backwards-compat/complete-profile-snapshots";
+import { badRequestMessage } from "@/utils/api-errors";
 import { captureError } from "@/lib/sentry/capture-error";
 import { useTranslation } from "@/i18n";
 import { DetailShell } from "@/components/detail-shell";
@@ -146,7 +147,6 @@ export function OverridesDetailPanel({
     advisorDirty,
     callSiteDraftsDirty,
     hasUnsavedDrafts,
-    hasValidationError,
     setDraft,
     setAdvisor,
     clearEdits,
@@ -171,6 +171,18 @@ export function OverridesDetailPanel({
   const profileLabelFor = useCallback(
     (name: string) => profileDisplayLabel(orderedProfiles, name),
     [orderedProfiles],
+  );
+
+  // Scopes each row's custom model picker to its winning route. Code-owned
+  // default profiles have no stored body, but the config GET wire view
+  // materializes their effective provider (`overlayEffectiveProfilesForWire`
+  // daemon-side), so this resolves for them too.
+  const providerForProfile = useCallback(
+    (name: string) => {
+      const provider = profiles[name]?.provider;
+      return typeof provider === "string" ? provider : undefined;
+    },
+    [profiles],
   );
 
   // An entry only reaches a picker while undispatchable when it is the
@@ -227,7 +239,7 @@ export function OverridesDetailPanel({
       Object.entries(persistedOverrides).some(
         ([id, s]) =>
           gatedCallSiteIdSet.has(id) &&
-          (s?.profile != null || s?.provider != null || s?.model != null),
+          (s?.profile != null || s?.model != null),
       ),
     [persistedOverrides, gatedCallSiteIdSet],
   );
@@ -241,7 +253,10 @@ export function OverridesDetailPanel({
       );
       return [
         ...visible.map(toProfileOption),
-        { value: CUSTOM_SENTINEL, label: t("overridesDetailPanel.customProfileOption") },
+        {
+          value: CUSTOM_SENTINEL,
+          label: t("overridesDetailPanel.customProfileOption"),
+        },
       ];
     },
     [orderedProfiles, toProfileOption, dispatchOptions, t],
@@ -279,7 +294,10 @@ export function OverridesDetailPanel({
     );
     if (unknownSites.length > 0) {
       groups.push({
-        domain: { id: "other", displayName: t("overridesDetailPanel.otherDomain") },
+        domain: {
+          id: "other",
+          displayName: t("overridesDetailPanel.otherDomain"),
+        },
         sites: unknownSites,
       });
     }
@@ -305,10 +323,12 @@ export function OverridesDetailPanel({
       if (seedProfile) {
         setDraft(id, { profile: seedProfile });
       } else {
+        // No dispatchable profile to seed with, so the row starts as a
+        // custom model pin; the daemon validates servability on save.
         const defaultProvider =
           selectableInferenceProviders[0] ?? INFERENCE_PROVIDERS[0];
         const defaultModel = getDefaultModelForProvider(defaultProvider) ?? "";
-        setDraft(id, { provider: defaultProvider, model: defaultModel });
+        setDraft(id, { model: defaultModel });
       }
     },
     [
@@ -345,8 +365,14 @@ export function OverridesDetailPanel({
       onClose();
       toast.success(t("overridesDetailPanel.overridesSavedToast"));
     } catch (error) {
-      toast.error(t("overridesDetailPanel.saveFailedToast"));
-      captureError(error, { context: "call_site_overrides_save" });
+      // A 400 is the daemon's verdict on the pins themselves (e.g. a model
+      // the site's winning route cannot serve). Show it verbatim and skip
+      // Sentry: it's a config problem the user can fix, not an app fault.
+      const serverMessage = badRequestMessage(error);
+      toast.error(serverMessage ?? t("overridesDetailPanel.saveFailedToast"));
+      if (!serverMessage) {
+        captureError(error, { context: "call_site_overrides_save" });
+      }
     } finally {
       setSaving(false);
     }
@@ -399,7 +425,7 @@ export function OverridesDetailPanel({
       <Button
         variant="primary"
         onClick={() => void handleSave()}
-        disabled={!hasUnsavedDrafts || hasValidationError || saving}
+        disabled={!hasUnsavedDrafts || saving}
       >
         {saving ? (
           <Loader2 className="h-4 w-4 animate-spin" />
@@ -502,6 +528,7 @@ export function OverridesDetailPanel({
             drafts={drafts}
             buildProfileOptionsForRow={buildProfileOptionsForRow}
             profileLabelFor={profileLabelFor}
+            providerForProfile={providerForProfile}
             advisorMatchesSearch={advisorMatchesSearch}
             connections={connectionsData?.connections}
             onDraftChange={setDraft}

--- a/clients/web/src/domains/settings/ai/use-override-drafts.test.ts
+++ b/clients/web/src/domains/settings/ai/use-override-drafts.test.ts
@@ -43,6 +43,27 @@ describe("buildCallSiteSavePatch", () => {
     });
   });
 
+  test("an untouched legacy provider-only row is omitted, not rewritten", () => {
+    // The row reads as active (old daemons still route on the pin), but the
+    // serialized entry carries no provider: rewriting it without a user
+    // edit would silently clear the pin.
+    const drafts: CallSiteDraftMap = { heartbeatAgent: { provider: "openai" } };
+    const patch = buildCallSiteSavePatch(drafts, {});
+    expect("heartbeatAgent" in patch).toBe(false);
+  });
+
+  test("an edited legacy row serializes with the explicit provider clear", () => {
+    const edited: CallSiteDraftMap = {
+      heartbeatAgent: { provider: "openai", model: "gpt-4o" },
+    };
+    const patch = buildCallSiteSavePatch(edited, edited);
+    expect(patch.heartbeatAgent).toEqual({
+      profile: null,
+      provider: null,
+      model: "gpt-4o",
+    });
+  });
+
   test("a row switched off this session serializes to null", () => {
     const drafts: CallSiteDraftMap = { heartbeatAgent: null };
     const draftEdits: CallSiteDraftMap = { heartbeatAgent: null };

--- a/clients/web/src/domains/settings/ai/use-override-drafts.test.ts
+++ b/clients/web/src/domains/settings/ai/use-override-drafts.test.ts
@@ -19,7 +19,7 @@ import {
 // ---------------------------------------------------------------------------
 
 describe("buildCallSiteSavePatch", () => {
-  test("an active profile draft sends the picker triple with explicit nulls", () => {
+  test("an active profile draft sends the picker fields with explicit nulls", () => {
     const drafts: CallSiteDraftMap = { workflowLeaf: { profile: "quality" } };
     const patch = buildCallSiteSavePatch(drafts, {});
     expect(patch.workflowLeaf).toEqual({
@@ -29,14 +29,16 @@ describe("buildCallSiteSavePatch", () => {
     });
   });
 
-  test("an active custom draft sends provider and model with a null profile", () => {
+  test("an active custom draft sends the model with a null profile and provider", () => {
+    // `provider: null` is an explicit clear: it scrubs a stale provider pin
+    // persisted by an older daemon.
     const drafts: CallSiteDraftMap = {
-      workflowLeaf: { provider: "openai", model: "gpt-4o" },
+      workflowLeaf: { model: "gpt-4o" },
     };
     const patch = buildCallSiteSavePatch(drafts, {});
     expect(patch.workflowLeaf).toEqual({
       profile: null,
-      provider: "openai",
+      provider: null,
       model: "gpt-4o",
     });
   });

--- a/clients/web/src/domains/settings/ai/use-override-drafts.ts
+++ b/clients/web/src/domains/settings/ai/use-override-drafts.ts
@@ -76,6 +76,13 @@ export function buildCallSiteSavePatch(
   for (const id of Object.keys(drafts)) {
     const d = drafts[id] ?? null;
     if (isDraftActive(d)) {
+      // A row active only through a legacy provider pin is omitted unless
+      // the user edited it: the serialized entry carries no provider, so
+      // rewriting an untouched row would silently clear a pin an old
+      // daemon still routes on.
+      if (!(id in draftEdits) && !d?.profile && !d?.model) {
+        continue;
+      }
       patch[id] = {
         profile: d?.profile ?? null,
         // Drafts carry no provider. The literal null is an explicit clear:

--- a/clients/web/src/domains/settings/ai/use-override-drafts.ts
+++ b/clients/web/src/domains/settings/ai/use-override-drafts.ts
@@ -34,7 +34,6 @@ export interface OverrideDrafts {
   advisorDirty: boolean;
   callSiteDraftsDirty: boolean;
   hasUnsavedDrafts: boolean;
-  hasValidationError: boolean;
   setDraft: (id: string, draft: CallSiteOverrideDraft | null) => void;
   setAdvisor: (profile: string) => void;
   /**
@@ -64,13 +63,13 @@ export function buildCallSiteSavePatch(
   // config loader), so an omitted key keeps its persisted value and a
   // `null` deletes the whole entry. Three cases follow from that:
   //
-  //  - active draft: send the picker triple. Nulling provider/model
+  //  - active draft: send the picker pair. Nulling the unused field
   //    clears a stale pin; any tuning the entry carries is untouched
   //    because it isn't mentioned.
   //  - the user switched this row off: send `null` and delete it. That
   //    is what off means.
   //  - inactive and untouched: omit it. `isDraftActive` only reads the
-  //    picker triple, so an entry holding nothing but tuning reads as
+  //    picker fields, so an entry holding nothing but tuning reads as
   //    off; sending `null` for it would delete settings the user never
   //    asked to remove.
   const patch: CallSiteDraftMap = {};
@@ -79,7 +78,10 @@ export function buildCallSiteSavePatch(
     if (isDraftActive(d)) {
       patch[id] = {
         profile: d?.profile ?? null,
-        provider: d?.provider ?? null,
+        // Drafts carry no provider. The literal null is an explicit clear:
+        // it scrubs a stale provider pin persisted by an older daemon, and
+        // daemons without the field accept and ignore the key.
+        provider: null,
         model: d?.model ?? null,
       };
     } else if (id in draftEdits && draftEdits[id] === null) {
@@ -170,14 +172,6 @@ export function useOverrideDrafts({
 
   const hasUnsavedDrafts = advisorDirty || callSiteDraftsDirty;
 
-  const hasValidationError = useMemo(
-    () =>
-      Object.values(drafts).some(
-        (d) => isDraftActive(d) && !!d?.provider && !d?.model,
-      ),
-    [drafts],
-  );
-
   const setDraft = useCallback(
     (id: string, draft: CallSiteOverrideDraft | null) => {
       setDraftEdits((prev) => ({ ...prev, [id]: draft }));
@@ -210,7 +204,6 @@ export function useOverrideDrafts({
     advisorDirty,
     callSiteDraftsDirty,
     hasUnsavedDrafts,
-    hasValidationError,
     setDraft,
     setAdvisor,
     clearEdits,

--- a/clients/web/src/domains/settings/components/model-profile-row.tsx
+++ b/clients/web/src/domains/settings/components/model-profile-row.tsx
@@ -30,7 +30,7 @@ function callSiteOverrideLabel(
   if (override == null) {
     return undefined;
   }
-  if (override.provider != null || override.model != null) {
+  if (override.model != null) {
     return CUSTOM_CALL_SITE_MODEL_LABEL;
   }
   const profile = override.profile?.trim();

--- a/clients/web/src/domains/settings/components/model-profile-row.tsx
+++ b/clients/web/src/domains/settings/components/model-profile-row.tsx
@@ -30,7 +30,9 @@ function callSiteOverrideLabel(
   if (override == null) {
     return undefined;
   }
-  if (override.model != null) {
+  // Legacy provider-only pins read as custom too: old daemons still route
+  // on them, so the label must not claim the default profile.
+  if (override.model != null || override.provider != null) {
     return CUSTOM_CALL_SITE_MODEL_LABEL;
   }
   const profile = override.profile?.trim();

--- a/clients/web/src/i18n/locales/en/settings.json
+++ b/clients/web/src/i18n/locales/en/settings.json
@@ -80,8 +80,6 @@
     "defaultProfileSuffix": "· Default: {label}",
     "modelLabel": "Model",
     "overrideAriaLabel": "Override {displayName}",
-    "pickModelError": "Pick a model",
-    "providerLabel": "Provider",
     "unavailableOption": "{name} (unavailable)"
   },
   "chatgptOauthSection": {

--- a/clients/web/src/i18n/locales/es/settings.json
+++ b/clients/web/src/i18n/locales/es/settings.json
@@ -80,8 +80,6 @@
     "defaultProfileSuffix": "· Predeterminado: {label}",
     "modelLabel": "Modelo",
     "overrideAriaLabel": "Anular {displayName}",
-    "pickModelError": "Elige un modelo",
-    "providerLabel": "Proveedor",
     "unavailableOption": "{name} (no disponible)"
   },
   "chatgptOauthSection": {

--- a/clients/web/src/lib/billing/byok-credit-route.test.ts
+++ b/clients/web/src/lib/billing/byok-credit-route.test.ts
@@ -456,7 +456,9 @@ describe("mix rungs (per-conversation seeded pick)", () => {
   });
 });
 
-describe("mainAgent call-site model tweak", () => {
+describe("mainAgent call-site tweak composition (pre-migration-147 daemons)", () => {
+  // Real catalog ids: the composition's serves-model check reads the client
+  // model catalog, so fake ids would always look foreign.
   const ANTHROPIC_MODEL = MODELS_BY_PROVIDER.anthropic[0]?.id ?? "";
   const OPENAI_MODEL = MODELS_BY_PROVIDER.openai[0]?.id ?? "";
 
@@ -474,29 +476,93 @@ describe("mainAgent call-site model tweak", () => {
     },
   });
 
-  test("a model tweak rides the winner's route and keeps its verdict", () => {
-    // A call-site pin picks a model only; it dispatches on the winner's
-    // route (the daemon rejects a model that route cannot serve), so the
-    // billing verdict and its availability proof both carry.
-    for (const model of [ANTHROPIC_MODEL, OPENAI_MODEL]) {
-      expect(
-        classify({
-          llm: BYOK_WINNER_LLM({ mainAgent: { model } }),
-          connections: [BYOK_ANTHROPIC],
-        }),
-      ).toBe(false);
-    }
+  test("a model tweak served by the winner's provider keeps the BYOK verdict", () => {
+    expect(
+      classify({
+        llm: BYOK_WINNER_LLM({ mainAgent: { model: ANTHROPIC_MODEL } }),
+        connections: [BYOK_ANTHROPIC],
+      }),
+    ).toBe(false);
   });
 
-  test("a legacy provider field on the entry is not consulted", () => {
-    // Older daemons persisted provider pins; the classification reads only
-    // the winner's own route.
+  test("a model tweak owned by another provider voids the BYOK proof", () => {
+    // Pre-147 daemons stamp the model's catalog owner and drop the winner's
+    // binding, so the availability proof no longer attests the dispatch
+    // route and the verdict degrades to unknown (banners up). Post-147
+    // daemons cannot hold this shape (foreign pins 400 at write time and
+    // migration 147 strips persisted ones), so over-warning is confined to
+    // lagging daemons.
+    expect(
+      classify({
+        llm: BYOK_WINNER_LLM({ mainAgent: { model: OPENAI_MODEL } }),
+        connections: [BYOK_ANTHROPIC],
+      }),
+    ).toBeNull();
+  });
+
+  test("a foreign model tweak classifies by the implied provider's connections", () => {
+    // Unbound implied dispatch consults the implied provider's connections:
+    // a platform-auth openai connection makes the route managed, while an
+    // api-key one leaves a BYOK-looking route whose proof was voided.
+    expect(
+      classify({
+        llm: BYOK_WINNER_LLM({ mainAgent: { model: OPENAI_MODEL } }),
+        connections: [
+          BYOK_ANTHROPIC,
+          conn({
+            name: "managed-openai",
+            provider: "openai",
+            auth: { type: "platform" },
+          }),
+        ],
+      }),
+    ).toBe(true);
+    expect(
+      classify({
+        llm: BYOK_WINNER_LLM({ mainAgent: { model: OPENAI_MODEL } }),
+        connections: [
+          BYOK_ANTHROPIC,
+          conn({ name: "my-openai", provider: "openai" }),
+        ],
+      }),
+    ).toBeNull();
+  });
+
+  test("an explicit provider tweak voids the BYOK proof but keeps a managed binding decisive", () => {
     expect(
       classify({
         llm: BYOK_WINNER_LLM({ mainAgent: { provider: "openai" } }),
         connections: [BYOK_ANTHROPIC],
       }),
-    ).toBe(false);
+    ).toBeNull();
+    expect(
+      classify({
+        llm: {
+          activeProfile: "p",
+          callSites: { mainAgent: { provider: "openai" } },
+          profiles: {
+            p: {
+              provider: "anthropic",
+              model: ANTHROPIC_MODEL,
+              provider_connection: "managed-anthropic",
+            },
+          },
+        },
+        connections: [PLATFORM_ANTHROPIC],
+      }),
+    ).toBe(true);
+  });
+
+  test("a vellum winner keeps managed routing under a concrete provider tweak", () => {
+    expect(
+      classify({
+        llm: {
+          activeProfile: "p",
+          callSites: { mainAgent: { provider: "anthropic" } },
+          profiles: { p: { provider: "vellum", model: ANTHROPIC_MODEL } },
+        },
+      }),
+    ).toBe(true);
   });
 });
 

--- a/clients/web/src/lib/billing/byok-credit-route.test.ts
+++ b/clients/web/src/lib/billing/byok-credit-route.test.ts
@@ -456,9 +456,7 @@ describe("mix rungs (per-conversation seeded pick)", () => {
   });
 });
 
-describe("mainAgent call-site tweak composition", () => {
-  // Real catalog ids: the composition's serves-model check reads the client
-  // model catalog, so fake ids would always look foreign.
+describe("mainAgent call-site model tweak", () => {
   const ANTHROPIC_MODEL = MODELS_BY_PROVIDER.anthropic[0]?.id ?? "";
   const OPENAI_MODEL = MODELS_BY_PROVIDER.openai[0]?.id ?? "";
 
@@ -476,90 +474,29 @@ describe("mainAgent call-site tweak composition", () => {
     },
   });
 
-  test("a model tweak served by the winner's provider keeps the BYOK verdict", () => {
-    expect(
-      classify({
-        llm: BYOK_WINNER_LLM({ mainAgent: { model: ANTHROPIC_MODEL } }),
-        connections: [BYOK_ANTHROPIC],
-      }),
-    ).toBe(false);
+  test("a model tweak rides the winner's route and keeps its verdict", () => {
+    // A call-site pin picks a model only; it dispatches on the winner's
+    // route (the daemon rejects a model that route cannot serve), so the
+    // billing verdict and its availability proof both carry.
+    for (const model of [ANTHROPIC_MODEL, OPENAI_MODEL]) {
+      expect(
+        classify({
+          llm: BYOK_WINNER_LLM({ mainAgent: { model } }),
+          connections: [BYOK_ANTHROPIC],
+        }),
+      ).toBe(false);
+    }
   });
 
-  test("a model tweak owned by another provider voids the BYOK proof", () => {
-    // The daemon stamps the model's catalog owner and drops the winner's
-    // binding, so the availability proof no longer attests the dispatch
-    // route and the verdict degrades to unknown (banners up).
-    expect(
-      classify({
-        llm: BYOK_WINNER_LLM({ mainAgent: { model: OPENAI_MODEL } }),
-        connections: [BYOK_ANTHROPIC],
-      }),
-    ).toBeNull();
-  });
-
-  test("a foreign model tweak classifies by the implied provider's connections", () => {
-    // Unbound implied dispatch consults the implied provider's connections:
-    // a platform-auth openai connection makes the route managed, while an
-    // api-key one leaves a BYOK-looking route whose proof was voided.
-    expect(
-      classify({
-        llm: BYOK_WINNER_LLM({ mainAgent: { model: OPENAI_MODEL } }),
-        connections: [
-          BYOK_ANTHROPIC,
-          conn({
-            name: "managed-openai",
-            provider: "openai",
-            auth: { type: "platform" },
-          }),
-        ],
-      }),
-    ).toBe(true);
-    expect(
-      classify({
-        llm: BYOK_WINNER_LLM({ mainAgent: { model: OPENAI_MODEL } }),
-        connections: [
-          BYOK_ANTHROPIC,
-          conn({ name: "my-openai", provider: "openai" }),
-        ],
-      }),
-    ).toBeNull();
-  });
-
-  test("an explicit provider tweak voids the BYOK proof but keeps a managed binding decisive", () => {
+  test("a legacy provider field on the entry is not consulted", () => {
+    // Older daemons persisted provider pins; the classification reads only
+    // the winner's own route.
     expect(
       classify({
         llm: BYOK_WINNER_LLM({ mainAgent: { provider: "openai" } }),
         connections: [BYOK_ANTHROPIC],
       }),
-    ).toBeNull();
-    expect(
-      classify({
-        llm: {
-          activeProfile: "p",
-          callSites: { mainAgent: { provider: "openai" } },
-          profiles: {
-            p: {
-              provider: "anthropic",
-              model: ANTHROPIC_MODEL,
-              provider_connection: "managed-anthropic",
-            },
-          },
-        },
-        connections: [PLATFORM_ANTHROPIC],
-      }),
-    ).toBe(true);
-  });
-
-  test("a vellum winner keeps managed routing under a concrete provider tweak", () => {
-    expect(
-      classify({
-        llm: {
-          activeProfile: "p",
-          callSites: { mainAgent: { provider: "anthropic" } },
-          profiles: { p: { provider: "vellum", model: ANTHROPIC_MODEL } },
-        },
-      }),
-    ).toBe(true);
+    ).toBe(false);
   });
 });
 

--- a/clients/web/src/lib/billing/byok-credit-route.ts
+++ b/clients/web/src/lib/billing/byok-credit-route.ts
@@ -1,3 +1,8 @@
+import {
+  getModelsForProvider,
+  MODELS_BY_PROVIDER,
+  VELLUM_SERVED_PROVIDERS,
+} from "@/assistant/llm-model-catalog";
 import type {
   ConfigGetResponse,
   DefaultProviderStatus,
@@ -117,6 +122,95 @@ function classifyEntry(
   return burns;
 }
 
+const MANAGED_ROUTABLE = new Set<string>(VELLUM_SERVED_PROVIDERS);
+
+/** The provider whose catalog owns a model id, mirroring the daemon's lookup. */
+function catalogProviderForModel(model: string): string | undefined {
+  for (const [provider, models] of Object.entries(MODELS_BY_PROVIDER)) {
+    if (models.some((m) => m.id === model)) {
+      return provider;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * The billing route after the workspace `llm.callSites.mainAgent` tweak is
+ * layered over the winning fragment. Mirrors pre-migration-147 daemons,
+ * whose resolver still rewrites the route: an explicit tweak provider
+ * replaces the winner's while keeping its binding; a tweak model the
+ * winner's provider does not serve stamps the model's catalog owner and
+ * drops the binding (the provider-agnostic managed connection survives);
+ * and a vellum winner re-gains the managed connection under a concrete
+ * managed-routable provider. Post-147 daemons refuse foreign pins at write
+ * time and migration 147 strips persisted ones, so there this composition
+ * is a no-op; it is deleted together with the telemetry-gated legacy shims.
+ *
+ * Returns the composed route plus whether composition altered it (callers
+ * void the winner's availability proof for altered routes, since the proof
+ * attests a binding the composed route no longer dispatches on), or `null`
+ * when the client catalog cannot settle the serves-model question.
+ */
+function composedMainAgentRoute(
+  entry: CreditRouteEntry,
+  llm: LlmConfig,
+): { route: CreditRouteEntry; altered: boolean } | null {
+  const tweak = llm?.callSites?.mainAgent;
+  // typeof-narrowed so the read stays valid when the generated draft type
+  // no longer declares the legacy provider field.
+  const tweakProvider =
+    typeof tweak?.provider === "string" ? tweak.provider : undefined;
+  const tweakModel = tweak?.model ?? undefined;
+  let route = entry;
+  let altered = false;
+  if (tweakProvider) {
+    if (tweakProvider !== entry.provider) {
+      route = {
+        provider: tweakProvider,
+        provider_connection: entry.provider_connection,
+      };
+      altered = true;
+    }
+  } else if (tweakModel) {
+    if (!entry.provider) {
+      // The daemon implies from its code-default provider here, which the
+      // client does not know.
+      return null;
+    }
+    const winnerModels = getModelsForProvider(entry.provider);
+    if (winnerModels.length === 0) {
+      // Unknown or routing-identity provider: serves-model can't be settled.
+      return null;
+    }
+    if (!winnerModels.some((m) => m.id === tweakModel)) {
+      const implied = catalogProviderForModel(tweakModel);
+      if (implied && implied !== entry.provider) {
+        const managedConnectionSurvives =
+          entry.provider_connection === "vellum" &&
+          MANAGED_ROUTABLE.has(implied);
+        route = {
+          provider: implied,
+          ...(managedConnectionSurvives
+            ? { provider_connection: "vellum" }
+            : {}),
+        };
+        altered = true;
+      }
+    }
+  }
+  if (
+    entry.provider === "vellum" &&
+    route.provider &&
+    route.provider !== "vellum" &&
+    !route.provider_connection &&
+    MANAGED_ROUTABLE.has(route.provider)
+  ) {
+    route = { ...route, provider_connection: "vellum" };
+    altered = true;
+  }
+  return { route, altered };
+}
+
 /**
  * Whether the assistant's default chat route spends managed Vellum credits.
  *
@@ -129,10 +223,9 @@ function classifyEntry(
  * unusable rungs. A mix rung follows the daemon's per-conversation seeded
  * pick: each usable arm classifies on its own route, and an unusable arm
  * stands for the seeds that fall through to the rest of the chain, so the
- * mix classifies as the tri-state any() of both. Every winner classifies on
- * its own route: a workspace `llm.callSites.mainAgent` model tweak rides
- * the winner's route unchanged (the daemon validates the model is servable
- * there), so it never moves the billing verdict.
+ * mix classifies as the tri-state any() of both. Every winner is classified
+ * as dispatched, with the workspace mainAgent call-site tweak composed over
+ * it (see {@link composedMainAgentRoute}).
  *
  * `null` (never a BYOK verdict) whenever the evidence can't settle the
  * question; callers fail open to showing the banners. That includes the
@@ -162,11 +255,7 @@ export function defaultChatRouteBurnsManagedCredits(
     if (!entry) {
       return null;
     }
-    return classifyEntry(
-      entry,
-      evidence.connections,
-      profileAvailability.get(name),
-    );
+    return classifyDispatched(entry, evidence, profileAvailability.get(name));
   };
 
   const classifyFromRung = (index: number): boolean | null => {
@@ -256,10 +345,33 @@ function classifyStaleDefaultStub(evidence: ChatRouteEvidence): boolean | null {
   if (!entry) {
     return true;
   }
-  return classifyEntry(
+  return classifyDispatched(
     entry,
-    evidence.connections,
+    evidence,
     evidence.defaultProviderAvailability,
+  );
+}
+
+/**
+ * Classify what the mainAgent call site actually dispatches: the winning
+ * fragment with the workspace call-site tweak composed over it. The winner's
+ * availability proof only carries when composition left the route unchanged;
+ * an altered route dispatches on something the proof never attested, so its
+ * BYOK verdicts degrade to unknown while managed verdicts stand.
+ */
+function classifyDispatched(
+  entry: CreditRouteEntry,
+  evidence: ChatRouteEvidence,
+  availability: DefaultProviderAvailabilityStatus | undefined,
+): boolean | null {
+  const composed = composedMainAgentRoute(entry, evidence.llm);
+  if (composed === null) {
+    return null;
+  }
+  return classifyEntry(
+    composed.route,
+    evidence.connections,
+    composed.altered ? undefined : availability,
   );
 }
 
@@ -275,9 +387,9 @@ function classifyAnchor(evidence: ChatRouteEvidence): boolean | null {
   if (!entry) {
     return null;
   }
-  return classifyEntry(
+  return classifyDispatched(
     entry,
-    evidence.connections,
+    evidence,
     evidence.defaultProviderAvailability,
   );
 }

--- a/clients/web/src/lib/billing/byok-credit-route.ts
+++ b/clients/web/src/lib/billing/byok-credit-route.ts
@@ -1,8 +1,3 @@
-import {
-  getModelsForProvider,
-  MODELS_BY_PROVIDER,
-  VELLUM_SERVED_PROVIDERS,
-} from "@/assistant/llm-model-catalog";
 import type {
   ConfigGetResponse,
   DefaultProviderStatus,
@@ -122,92 +117,6 @@ function classifyEntry(
   return burns;
 }
 
-const MANAGED_ROUTABLE = new Set<string>(VELLUM_SERVED_PROVIDERS);
-
-/** The provider whose catalog owns a model id, mirroring the daemon's lookup. */
-function catalogProviderForModel(model: string): string | undefined {
-  for (const [provider, models] of Object.entries(MODELS_BY_PROVIDER)) {
-    if (models.some((m) => m.id === model)) {
-      return provider;
-    }
-  }
-  return undefined;
-}
-
-/**
- * The billing route after the daemon layers the workspace
- * `llm.callSites.mainAgent` tweak over the winning fragment
- * (`resolveOverrideOrDefault` in assistant/src/config/llm-resolver.ts): an
- * explicit tweak provider replaces the winner's while keeping its binding; a
- * tweak model the winner's provider does not serve stamps the model's
- * catalog owner and drops the binding (the provider-agnostic managed
- * connection survives); and a vellum winner re-gains the managed connection
- * under a concrete managed-routable provider. The shipped mainAgent
- * call-site default carries only a profile intent, so the workspace entry is
- * the only route-affecting tweak source.
- *
- * Returns the composed route plus whether composition altered it (callers
- * void the winner's availability proof for altered routes, since the proof
- * attests a binding the composed route no longer dispatches on), or `null`
- * when the client catalog cannot settle the serves-model question.
- */
-function composedMainAgentRoute(
-  entry: CreditRouteEntry,
-  llm: LlmConfig,
-): { route: CreditRouteEntry; altered: boolean } | null {
-  const tweak = llm?.callSites?.mainAgent;
-  const tweakProvider = tweak?.provider ?? undefined;
-  const tweakModel = tweak?.model ?? undefined;
-  let route = entry;
-  let altered = false;
-  if (tweakProvider) {
-    if (tweakProvider !== entry.provider) {
-      route = {
-        provider: tweakProvider,
-        provider_connection: entry.provider_connection,
-      };
-      altered = true;
-    }
-  } else if (tweakModel) {
-    if (!entry.provider) {
-      // The daemon implies from its code-default provider here, which the
-      // client does not know.
-      return null;
-    }
-    const winnerModels = getModelsForProvider(entry.provider);
-    if (winnerModels.length === 0) {
-      // Unknown or routing-identity provider: serves-model can't be settled.
-      return null;
-    }
-    if (!winnerModels.some((m) => m.id === tweakModel)) {
-      const implied = catalogProviderForModel(tweakModel);
-      if (implied && implied !== entry.provider) {
-        const managedConnectionSurvives =
-          entry.provider_connection === "vellum" &&
-          MANAGED_ROUTABLE.has(implied);
-        route = {
-          provider: implied,
-          ...(managedConnectionSurvives
-            ? { provider_connection: "vellum" }
-            : {}),
-        };
-        altered = true;
-      }
-    }
-  }
-  if (
-    entry.provider === "vellum" &&
-    route.provider &&
-    route.provider !== "vellum" &&
-    !route.provider_connection &&
-    MANAGED_ROUTABLE.has(route.provider)
-  ) {
-    route = { ...route, provider_connection: "vellum" };
-    altered = true;
-  }
-  return { route, altered };
-}
-
 /**
  * Whether the assistant's default chat route spends managed Vellum credits.
  *
@@ -220,9 +129,10 @@ function composedMainAgentRoute(
  * unusable rungs. A mix rung follows the daemon's per-conversation seeded
  * pick: each usable arm classifies on its own route, and an unusable arm
  * stands for the seeds that fall through to the rest of the chain, so the
- * mix classifies as the tri-state any() of both. Every winner is classified
- * as dispatched, with the workspace mainAgent call-site tweak composed over
- * it (see {@link composedMainAgentRoute}).
+ * mix classifies as the tri-state any() of both. Every winner classifies on
+ * its own route: a workspace `llm.callSites.mainAgent` model tweak rides
+ * the winner's route unchanged (the daemon validates the model is servable
+ * there), so it never moves the billing verdict.
  *
  * `null` (never a BYOK verdict) whenever the evidence can't settle the
  * question; callers fail open to showing the banners. That includes the
@@ -252,7 +162,11 @@ export function defaultChatRouteBurnsManagedCredits(
     if (!entry) {
       return null;
     }
-    return classifyDispatched(entry, evidence, profileAvailability.get(name));
+    return classifyEntry(
+      entry,
+      evidence.connections,
+      profileAvailability.get(name),
+    );
   };
 
   const classifyFromRung = (index: number): boolean | null => {
@@ -342,33 +256,10 @@ function classifyStaleDefaultStub(evidence: ChatRouteEvidence): boolean | null {
   if (!entry) {
     return true;
   }
-  return classifyDispatched(
-    entry,
-    evidence,
-    evidence.defaultProviderAvailability,
-  );
-}
-
-/**
- * Classify what the mainAgent call site actually dispatches: the winning
- * fragment with the workspace call-site tweak composed over it. The winner's
- * availability proof only carries when composition left the route unchanged;
- * an altered route dispatches on something the proof never attested, so its
- * BYOK verdicts degrade to unknown while managed verdicts stand.
- */
-function classifyDispatched(
-  entry: CreditRouteEntry,
-  evidence: ChatRouteEvidence,
-  availability: DefaultProviderAvailabilityStatus | undefined,
-): boolean | null {
-  const composed = composedMainAgentRoute(entry, evidence.llm);
-  if (composed === null) {
-    return null;
-  }
   return classifyEntry(
-    composed.route,
+    entry,
     evidence.connections,
-    composed.altered ? undefined : availability,
+    evidence.defaultProviderAvailability,
   );
 }
 
@@ -384,9 +275,9 @@ function classifyAnchor(evidence: ChatRouteEvidence): boolean | null {
   if (!entry) {
     return null;
   }
-  return classifyDispatched(
+  return classifyEntry(
     entry,
-    evidence,
+    evidence.connections,
     evidence.defaultProviderAvailability,
   );
 }


### PR DESCRIPTION
## Summary
- Overrides UI drops the provider picker: a custom pin is a model choice; the route comes from the winning profile
- Save patch sends provider: null as an explicit clear (compatible with old and new daemons, no version gate)
- byok-credit-route drops the implied-provider mirror; onboarding stops sending provider_connection

Part of plan: conn-removal-13b-step4-demolition.md (PR 5 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41022" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->