### PR TITLE
feat(plugins): add imessage to the marketplace catalog

### DIFF
--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -219,9 +219,9 @@
       "source": {
         "source": "github",
         "repo": "vellum-ai/imessage",
-        "ref": "cf65266908f370a4efe266d0cb4fd953efc13c05"
+        "ref": "069a8375e2a6ed069550866114a653218864bc91"
       },
-      "description": "iMessage and SMS channel for the Vellum assistant, backed by a Photon or Comms by Osis line.",
+      "description": "iMessage and SMS channel for the Vellum assistant, backed by a Photon line.",
       "category": "productivity",
       "homepage": "https://github.com/vellum-ai/imessage",
       "license": "MIT",

--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -215,6 +215,19 @@
       "icon": "📣"
     },
     {
+      "name": "imessage",
+      "source": {
+        "source": "github",
+        "repo": "vellum-ai/imessage",
+        "ref": "cf65266908f370a4efe266d0cb4fd953efc13c05"
+      },
+      "description": "iMessage and SMS channel for the Vellum assistant, backed by a Photon or Comms by Osis line.",
+      "category": "productivity",
+      "homepage": "https://github.com/vellum-ai/imessage",
+      "license": "MIT",
+      "icon": "📲"
+    },
+    {
       "name": "kitchen-companion",
       "source": {
         "source": "github",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
List the iMessage channel plugin in the curated marketplace catalog so it is discoverable via `assistant plugins search` and installable via `assistant plugins install imessage`.

Entry in `plugins/marketplace.json`:
- name: `imessage`
- source: `vellum-ai/imessage` at `069a8375e2a6ed069550866114a653218864bc91` (`main` as of #42, Comms coming soon)
- description from the plugin's `package.json`
- category: `productivity`
- license: MIT
- icon: 📲

`assistant/src/cli/lib/bundled-marketplace.json` is a generated, gitignored copy. CI regenerates it.

## Test plan

- `node scripts/check-marketplace-prefix.mjs`
- Manifest parses as JSON and includes the `imessage` entry with a full 40-char SHA
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-09030aa5-c6fd-4408-be6c-0f9fb7d2e9a8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-09030aa5-c6fd-4408-be6c-0f9fb7d2e9a8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

