### PR TITLE
feat(cli): print a setup-skill hint after plugin install

### DIFF
--- a/assistant/src/cli/commands/__tests__/plugins.test.ts
+++ b/assistant/src/cli/commands/__tests__/plugins.test.ts
@@ -16,6 +16,8 @@
  *   - under --json the consent listing, the prompt, and the cancellation line
  *     all go to stderr, leaving stdout a pure JSON document
  *   - inspect renders the schedules surface block
+ *   - install prints a setup-skill hint when `skills/setup` or
+ *     `skills/<name>-setup` is present on the installed tree
  *
  * The installers are replaced by fakes that stage a fixture tree and run the
  * real `confirmStagedOrAbort` gate, so the command's consent callback is
@@ -76,6 +78,10 @@ let ipcResults: Array<{
 
 let inspectResult: PluginInspection | null = null;
 
+/** On-disk tree returned as the fake install `target` so post-install walks work. */
+let installTarget: string | null = null;
+const installTargetDirs: string[] = [];
+
 // ---------------------------------------------------------------------------
 // Mocks
 // ---------------------------------------------------------------------------
@@ -123,7 +129,7 @@ async function runFakeInstall(
   await stageAndConfirm(name, deps?.confirmStaged);
   return {
     name,
-    target: `/plugins/${name}`,
+    target: installTarget ?? `/plugins/${name}`,
     fileCount: 3,
     ref: "main",
     commit: "a".repeat(40),
@@ -253,6 +259,7 @@ beforeEach(() => {
   upgradePluginCalls = [];
   ipcResults = [];
   inspectResult = null;
+  installTarget = null;
   // Platform features on by default, so a plain name install takes the
   // platform-tarball branch.
   delete process.env.VELLUM_DISABLE_PLATFORM;
@@ -260,6 +267,10 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  for (const dir of installTargetDirs) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+  installTargetDirs.length = 0;
   if (savedDisablePlatform === undefined) {
     delete process.env.VELLUM_DISABLE_PLATFORM;
   } else {
@@ -346,6 +357,7 @@ describe("plugins install - declared-schedules consent", () => {
     expect(confirmCalls.length).toBe(0);
     expect(r.stdout).not.toContain("declares");
     expect(r.stdout).not.toContain("schedule");
+    expect(r.stdout).not.toContain("to help set up this plugin");
     expect(r.stdout).toContain('Installed plugin "example"');
     expect(r.exitCode).toBe(0);
   });
@@ -687,6 +699,50 @@ describe("plugins inspect - schedules surface", () => {
     const r = await runCommand(["plugins", "inspect", "example"]);
 
     expect(r.stdout).toContain("weekly  RRULE:FREQ=WEEKLY;BYDAY=MO  (execute)");
+    expect(r.exitCode).toBe(0);
+  });
+});
+
+describe("plugins install - setup skill hint", () => {
+  function writeSetupSkill(skillId: string): void {
+    const dir = mkdtempSync(join(tmpdir(), "plugins-cmd-target-"));
+    installTargetDirs.push(dir);
+    mkdirSync(join(dir, "skills", skillId), { recursive: true });
+    writeFileSync(
+      join(dir, "skills", skillId, "SKILL.md"),
+      "---\nname: setup\ndescription: Set up the plugin.\n---\n",
+    );
+    installTarget = dir;
+  }
+
+  test("points at skills/setup after a successful install", async () => {
+    writeSetupSkill("setup");
+
+    const r = await runCommand(["plugins", "install", "example"]);
+
+    expect(r.stdout).toContain('Installed plugin "example"');
+    expect(r.stdout).toContain(
+      "Load the setup skill to help set up this plugin",
+    );
+    expect(r.exitCode).toBe(0);
+  });
+
+  test("points at skills/<name>-setup when that is the shipped id", async () => {
+    writeSetupSkill("imessage-setup");
+
+    const r = await runCommand(["plugins", "install", "imessage"]);
+
+    expect(r.stdout).toContain(
+      "Load the imessage-setup skill to help set up this plugin",
+    );
+    expect(r.exitCode).toBe(0);
+  });
+
+  test("prints no setup hint when the plugin ships no setup skill", async () => {
+    const r = await runCommand(["plugins", "install", "example"]);
+
+    expect(r.stdout).toContain('Installed plugin "example"');
+    expect(r.stdout).not.toContain("to help set up this plugin");
     expect(r.exitCode).toBe(0);
   });
 });

--- a/assistant/src/cli/commands/plugins.help.ts
+++ b/assistant/src/cli/commands/plugins.help.ts
@@ -54,6 +54,10 @@ during the install, and the install asks for confirmation before finalizing:
 schedules run automatically in the background once the plugin is installed.
 Pass --force to skip the prompt (required for non-interactive installs).
 
+A plugin that ships a setup skill (`skills/setup/` or
+`skills/<name>-setup/`) prints a line after install telling the user to
+load that skill to finish setup.
+
 A GitHub URL (anything containing a slash) installs directly from that repo,
 bypassing the marketplace whitelist. Such a plugin is UNTRUSTED — it has not
 been reviewed and its hooks/tools run with full assistant access — so the

--- a/assistant/src/cli/commands/plugins.help.ts
+++ b/assistant/src/cli/commands/plugins.help.ts
@@ -54,8 +54,8 @@ during the install, and the install asks for confirmation before finalizing:
 schedules run automatically in the background once the plugin is installed.
 Pass --force to skip the prompt (required for non-interactive installs).
 
-A plugin that ships a setup skill (`skills/setup/` or
-`skills/<name>-setup/`) prints a line after install telling the user to
+A plugin that ships a setup skill (skills/setup/ or
+skills/<name>-setup/) prints a line after install telling the user to
 load that skill to finish setup.
 
 A GitHub URL (anything containing a slash) installs directly from that repo,

--- a/assistant/src/cli/commands/plugins.ts
+++ b/assistant/src/cli/commands/plugins.ts
@@ -301,6 +301,16 @@ export function registerPluginsCommand(program: Command): void {
             console.log(
               `Installed ${label} "${result.name}" (${result.fileCount} file${result.fileCount === 1 ? "" : "s"})${pinned} → ${result.target}`,
             );
+            const { skills } = libs.surfaces.detectPluginSurfaces(
+              result.target,
+            );
+            const setupSkill = libs.surfaces.findPluginSetupSkill(
+              result.name,
+              skills,
+            );
+            if (setupSkill !== undefined) {
+              console.log(libs.surfaces.formatPluginSetupHint(setupSkill));
+            }
           } catch (err) {
             if (err instanceof libs.installGitHub.PluginInstallDeclinedError) {
               // The consent gate already printed the outcome and set the exit

--- a/assistant/src/cli/lib/__tests__/plugin-surfaces.test.ts
+++ b/assistant/src/cli/lib/__tests__/plugin-surfaces.test.ts
@@ -17,7 +17,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
-import { detectPluginSurfaces } from "../plugin-surfaces.js";
+import {
+  detectPluginSurfaces,
+  findPluginSetupSkill,
+  formatPluginSetupHint,
+} from "../plugin-surfaces.js";
 
 let pluginDir: string;
 
@@ -186,5 +190,32 @@ describe("detectPluginSurfaces", () => {
     // WHEN its surfaces are detected
     // THEN none of them are listed
     expect(detectPluginSurfaces(pluginDir).schedules).toEqual([]);
+  });
+});
+
+describe("findPluginSetupSkill", () => {
+  test("prefers the generic setup id when both conventions are present", () => {
+    expect(
+      findPluginSetupSkill("imessage", ["setup", "imessage-setup", "other"]),
+    ).toBe("setup");
+  });
+
+  test("falls back to <plugin-name>-setup", () => {
+    expect(findPluginSetupSkill("imessage", ["imessage-setup"])).toBe(
+      "imessage-setup",
+    );
+  });
+
+  test("returns undefined when the plugin ships no setup skill", () => {
+    expect(findPluginSetupSkill("imessage", ["imessage-send"])).toBeUndefined();
+    expect(findPluginSetupSkill("imessage", [])).toBeUndefined();
+  });
+});
+
+describe("formatPluginSetupHint", () => {
+  test("names the skill in the install-command copy", () => {
+    expect(formatPluginSetupHint("imessage-setup")).toBe(
+      "Load the imessage-setup skill to help set up this plugin",
+    );
   });
 });

--- a/assistant/src/cli/lib/plugin-surfaces.ts
+++ b/assistant/src/cli/lib/plugin-surfaces.ts
@@ -217,6 +217,33 @@ function listSchedules(schedulesDir: string): PluginScheduleSurface[] {
 }
 
 /**
+ * Skill id a plugin ships for first-run setup, if any.
+ *
+ * Convention: `skills/setup/SKILL.md` or `skills/<plugin-name>-setup/SKILL.md`.
+ * The directory name is the id `skill_load` uses. `setup` wins when both exist
+ * so the generic name is the standard; `<plugin-name>-setup` covers plugins
+ * that already ship that form.
+ */
+export function findPluginSetupSkill(
+  pluginName: string,
+  skillIds: readonly string[],
+): string | undefined {
+  if (skillIds.includes("setup")) {
+    return "setup";
+  }
+  const named = `${pluginName}-setup`;
+  if (skillIds.includes(named)) {
+    return named;
+  }
+  return undefined;
+}
+
+/** Install-command copy pointing at a plugin's setup skill. */
+export function formatPluginSetupHint(skillId: string): string {
+  return `Load the ${skillId} skill to help set up this plugin`;
+}
+
+/**
  * Detect the {@link PluginSurfaces} an installed plugin contributes by walking
  * its install tree at `pluginDir`. Surface types with no contributions come
  * back as empty arrays; callers omit empty types from the rendered output.

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -876,3 +876,7 @@ inside the stub, run under a stripped environment and a timeout.
 - **Cooperative cancellation.** Long-running tools should check
   `ctx.signal?.aborted` or forward `ctx.signal` to `fetch` / `spawn`
   options.
+- **Setup skill.** A plugin that needs a first-run walkthrough ships
+  `skills/setup/SKILL.md` or `skills/<plugin-name>-setup/SKILL.md`.
+  `assistant plugins install` detects that directory and tells the user
+  to load the skill.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan

After a successful `assistant plugins install`, detect whether the installed plugin ships a first-run setup skill and print a standardized stdout hint.

Convention (any plugin):
- `skills/setup/SKILL.md` (preferred)
- or `skills/<plugin-name>-setup/SKILL.md`

Copy:

```
Load the <skill-id> skill to help set up this plugin
```

The skill id is the directory name (`skill_load` uses the same id), not frontmatter `name`.

## Test plan

- `cd assistant && bun test src/cli/lib/__tests__/plugin-surfaces.test.ts src/cli/commands/__tests__/plugins.test.ts`
- Covers generic `setup`, `<name>-setup` (e.g. `imessage-setup`), no hint when absent, and `setup` winning when both exist

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-09030aa5-c6fd-4408-be6c-0f9fb7d2e9a8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-09030aa5-c6fd-4408-be6c-0f9fb7d2e9a8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

