### PR TITLE
fix(plugins): run shutdown when a plugin is disabled

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -24097,10 +24097,11 @@ paths:
       summary: Disable a plugin
       description:
         Disable a plugin in this workspace by dropping a `.disabled` sentinel, mirroring the CLI's `assistant
-        plugins disable <name>`. The change is honored live at read time by every tool / injector / hook gate — no
-        restart required. Broadcasts a `sync_changed` invalidation carrying the `plugins:list` tag so other clients
-        refetch `GET /v1/plugins`. An already-disabled plugin returns 409; a user plugin with no directory returns 404
-        (default plugins are stubbed on demand via the `default-` prefix); a malformed name returns 400.
+        plugins disable <name>`. Awaits the same source reconcile enable uses so the plugin's shutdown hook runs (a live
+        gRPC subscribe or poll worker is dropped before this route returns). Tools, injectors, and hook gates also honor
+        the sentinel at read time. Broadcasts a `sync_changed` invalidation carrying the `plugins:list` tag so other
+        clients refetch `GET /v1/plugins`. An already-disabled plugin returns 409; a user plugin with no directory
+        returns 404 (default plugins are stubbed on demand via the `default-` prefix); a malformed name returns 400.
       tags:
         - plugins
       parameters:

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -24097,11 +24097,11 @@ paths:
       summary: Disable a plugin
       description:
         Disable a plugin in this workspace by dropping a `.disabled` sentinel, mirroring the CLI's `assistant
-        plugins disable <name>`. Awaits the same source reconcile enable uses so the plugin's shutdown hook runs (a live
-        gRPC subscribe or poll worker is dropped before this route returns). Tools, injectors, and hook gates also honor
-        the sentinel at read time. Broadcasts a `sync_changed` invalidation carrying the `plugins:list` tag so other
-        clients refetch `GET /v1/plugins`. An already-disabled plugin returns 409; a user plugin with no directory
-        returns 404 (default plugins are stubbed on demand via the `default-` prefix); a malformed name returns 400.
+        plugins disable <name>`. Awaits the same source reconcile enable uses so the plugin's shutdown hook runs. Tools,
+        injectors, and hook gates also honor the sentinel at read time. Broadcasts a `sync_changed` invalidation
+        carrying the `plugins:list` tag so other clients refetch `GET /v1/plugins`. An already-disabled plugin returns
+        409; a user plugin with no directory returns 404 (default plugins are stubbed on demand via the `default-`
+        prefix); a malformed name returns 400.
       tags:
         - plugins
       parameters:

--- a/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
@@ -319,9 +319,9 @@ mock.module("../../../cli/lib/toggle-plugin.js", () => ({
   enablePlugin: enablePluginSpy,
 }));
 
-// Spy on the plugin-schedule reconcile the disable handler pokes. The handler
-// imports it lazily at call time, so this mock intercepts the dynamic import
-// and keeps the reconciler's persistence graph out of the test.
+// Spy on the plugin-schedule reconcile so a toggle cannot silently go back
+// to poking it from the route. Enable and disable both await the source
+// reconcile, which converges schedules itself.
 const reconcilePluginSchedulesSpy = mock(() => Promise.resolve());
 
 mock.module("../../../schedule/plugin-schedule-reconciler.js", () => ({

--- a/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/plugins-routes.test.ts
@@ -2597,27 +2597,10 @@ async function invokeEnable(
   return (await enableHandler(args)) as { ok: boolean };
 }
 
-function invokeDisable(args: RouteHandlerArgs = {}): { ok: boolean } {
-  return disableHandler(args) as { ok: boolean };
-}
-
-/**
- * Wait for a toggle handler's fire-and-forget reconcile poke to land. The poke
- * runs off the microtask queue (the disable path also resolves a lazy
- * `import()` first), so the assertion cannot run on the handler's synchronous
- * return.
- */
-async function waitForReconcile(
-  spy: { mock: { calls: unknown[] } },
-  label: string,
-): Promise<void> {
-  for (let i = 0; i < 50; i++) {
-    if (spy.mock.calls.length > 0) {
-      return;
-    }
-    await new Promise((resolve) => setTimeout(resolve, 2));
-  }
-  throw new Error(`${label} was never triggered`);
+async function invokeDisable(
+  args: RouteHandlerArgs = {},
+): Promise<{ ok: boolean }> {
+  return (await disableHandler(args)) as { ok: boolean };
 }
 
 /** Assert the spy received exactly one sync_changed carrying `plugins:list`. */
@@ -2745,42 +2728,38 @@ describe("POST /v1/plugins/:name/disable", () => {
     reconcilePluginSourcesNowSpy.mockClear();
   });
 
-  test("reconciles plugin-declared schedules so the plugin's rows disarm now", async () => {
+  test("awaits the source reconcile so shutdown runs before the route returns", async () => {
     disablePluginSpy.mockImplementation((name) =>
       toggleResult(name, "disable"),
     );
 
-    invokeDisable({ pathParams: { name: "simple-memory" } });
+    await invokeDisable({ pathParams: { name: "simple-memory" } });
 
-    // Without this poke the rows stay armed until the reconciler's next
-    // backstop sweep. Disable stays on the schedule poke: the sentinel filters
-    // the plugin out at read time, and a source reconcile here would run its
-    // shutdown hooks.
-    await waitForReconcile(
-      reconcilePluginSchedulesSpy,
-      "plugin schedule reconcile",
-    );
-    expect(reconcilePluginSourcesNowSpy).not.toHaveBeenCalled();
+    // The sentinel hides tools at read time, but `init` already opened
+    // in-process work (a live subscribe, a poll worker). The source
+    // reconcile is what runs `shutdown`. It converges schedules itself, so
+    // the route does not poke them separately.
+    expect(reconcilePluginSourcesNowSpy).toHaveBeenCalledTimes(1);
+    expect(reconcilePluginSchedulesSpy).not.toHaveBeenCalled();
   });
 
-  test("a failed toggle does not poke the schedule reconcile", async () => {
+  test("a failed toggle does not run the source reconcile", async () => {
     disablePluginSpy.mockImplementation((name) => {
       throw new PluginDirectoryNotFoundError(name);
     });
 
-    expect(() => invokeDisable({ pathParams: { name: "ghost" } })).toThrow(
-      NotFoundError,
-    );
-    await new Promise((resolve) => setTimeout(resolve, 10));
-    expect(reconcilePluginSchedulesSpy).not.toHaveBeenCalled();
+    await expect(
+      invokeDisable({ pathParams: { name: "ghost" } }),
+    ).rejects.toThrow(NotFoundError);
+    expect(reconcilePluginSourcesNowSpy).not.toHaveBeenCalled();
   });
 
-  test("disables the plugin and broadcasts sync_changed(plugins:list)", () => {
+  test("disables the plugin and broadcasts sync_changed(plugins:list)", async () => {
     disablePluginSpy.mockImplementation((name) =>
       toggleResult(name, "disable"),
     );
 
-    const result = invokeDisable({ pathParams: { name: "simple-memory" } });
+    const result = await invokeDisable({ pathParams: { name: "simple-memory" } });
 
     expect(result).toEqual({ ok: true });
     expect(disablePluginSpy.mock.calls[0]?.[0]).toBe("simple-memory");
@@ -2789,12 +2768,12 @@ describe("POST /v1/plugins/:name/disable", () => {
     expectPluginsListBroadcast();
   });
 
-  test("threads x-vellum-client-id into the published event's originClientId", () => {
+  test("threads x-vellum-client-id into the published event's originClientId", async () => {
     disablePluginSpy.mockImplementation((name) =>
       toggleResult(name, "disable"),
     );
 
-    invokeDisable({
+    await invokeDisable({
       pathParams: { name: "simple-memory" },
       headers: { "x-vellum-client-id": "client-xyz" },
     });
@@ -2806,35 +2785,35 @@ describe("POST /v1/plugins/:name/disable", () => {
     });
   });
 
-  test("PluginAlreadyInStateException → ConflictError (409), no broadcast", () => {
+  test("PluginAlreadyInStateException → ConflictError (409), no broadcast", async () => {
     disablePluginSpy.mockImplementation((name) => {
       throw new PluginAlreadyInStateException(name, "disable");
     });
 
-    expect(() =>
+    await expect(
       invokeDisable({ pathParams: { name: "simple-memory" } }),
-    ).toThrow(ConflictError);
+    ).rejects.toThrow(ConflictError);
     expect(broadcastMessageSpy).not.toHaveBeenCalled();
   });
 
-  test("PluginDirectoryNotFoundError → NotFoundError (404)", () => {
+  test("PluginDirectoryNotFoundError → NotFoundError (404)", async () => {
     disablePluginSpy.mockImplementation((name) => {
       throw new PluginDirectoryNotFoundError(name);
     });
 
-    expect(() => invokeDisable({ pathParams: { name: "ghost" } })).toThrow(
-      NotFoundError,
-    );
+    await expect(
+      invokeDisable({ pathParams: { name: "ghost" } }),
+    ).rejects.toThrow(NotFoundError);
   });
 
-  test("InvalidPluginNameError → BadRequestError (400)", () => {
+  test("InvalidPluginNameError → BadRequestError (400)", async () => {
     disablePluginSpy.mockImplementation(() => {
       throw new ToggleInvalidPluginNameError("../escape");
     });
 
-    expect(() => invokeDisable({ pathParams: { name: "../escape" } })).toThrow(
-      BadRequestError,
-    );
+    await expect(
+      invokeDisable({ pathParams: { name: "../escape" } }),
+    ).rejects.toThrow(BadRequestError);
   });
 });
 

--- a/assistant/src/runtime/routes/plugins-routes.ts
+++ b/assistant/src/runtime/routes/plugins-routes.ts
@@ -1642,29 +1642,6 @@ function mapTogglePluginError(err: unknown): RouteError {
 }
 
 /**
- * Converge plugin-declared schedules against the sentinel this route just
- * wrote, so a disabled plugin's rows disarm now rather than at the
- * reconciler's next backstop sweep.
- *
- * Fire-and-forget: the toggle itself already succeeded on disk, so a reconcile
- * failure must not turn it into a route error. Imported lazily, matching the
- * plugin source reconcile's own hook, to keep the schedule and notification
- * modules out of this route module's static graph. The scheduler applies the
- * sentinel at fire time as well, so a slow or failed pass here delays the row
- * bookkeeping without letting a disabled plugin run.
- */
-function reconcilePluginSchedulesInBackground(): void {
-  void import("../../schedule/plugin-schedule-reconciler.js")
-    .then(({ reconcilePluginSchedules }) => reconcilePluginSchedules())
-    .catch((err: unknown) => {
-      log.error(
-        { err },
-        "plugin schedule reconcile after a plugin toggle failed",
-      );
-    });
-}
-
-/**
  * Toggle a plugin's `.disabled` sentinel through the shared toggle-plugin lib,
  * then publish a generic `sync_changed(plugins:list)` so every client refetches
  * `GET /v1/plugins`. Enable and disable emit the SAME invalidation — the tag
@@ -2153,7 +2130,7 @@ export const ROUTES: RouteDefinition[] = [
     },
     summary: "Disable a plugin",
     description:
-      "Disable a plugin in this workspace by dropping a `.disabled` sentinel, mirroring the CLI's `assistant plugins disable <name>`. Awaits the same source reconcile enable uses so the plugin's shutdown hook runs (a live gRPC subscribe or poll worker is dropped before this route returns). Tools, injectors, and hook gates also honor the sentinel at read time. Broadcasts a `sync_changed` invalidation carrying the `plugins:list` tag so other clients refetch `GET /v1/plugins`. An already-disabled plugin returns 409; a user plugin with no directory returns 404 (default plugins are stubbed on demand via the `default-` prefix); a malformed name returns 400.",
+      "Disable a plugin in this workspace by dropping a `.disabled` sentinel, mirroring the CLI's `assistant plugins disable <name>`. Awaits the same source reconcile enable uses so the plugin's shutdown hook runs. Tools, injectors, and hook gates also honor the sentinel at read time. Broadcasts a `sync_changed` invalidation carrying the `plugins:list` tag so other clients refetch `GET /v1/plugins`. An already-disabled plugin returns 409; a user plugin with no directory returns 404 (default plugins are stubbed on demand via the `default-` prefix); a malformed name returns 400.",
     tags: ["plugins"],
     pathParams: [
       {

--- a/assistant/src/runtime/routes/plugins-routes.ts
+++ b/assistant/src/runtime/routes/plugins-routes.ts
@@ -1694,15 +1694,22 @@ async function handleEnablePlugin({
   return { ok: true };
 }
 
-function handleDisablePlugin({ pathParams = {}, headers }: RouteHandlerArgs) {
+async function handleDisablePlugin({
+  pathParams = {},
+  headers,
+}: RouteHandlerArgs) {
   try {
     disablePlugin(pathParams.name ?? "");
-    publishPluginsChanged(getOriginClientId(headers));
-    reconcilePluginSchedulesInBackground();
-    return { ok: true };
   } catch (err) {
     throw mapTogglePluginError(err);
   }
+  // Same poke enable uses. The sentinel hides tools and hooks at read time,
+  // but a plugin that already ran `init` still owns in-process work (a live
+  // gRPC subscribe, a poll worker). The source reconcile is what runs
+  // `shutdown` and drops that work before this route returns.
+  await reconcilePluginSourcesNow();
+  publishPluginsChanged(getOriginClientId(headers));
+  return { ok: true };
 }
 
 // ---------------------------------------------------------------------------
@@ -2146,7 +2153,7 @@ export const ROUTES: RouteDefinition[] = [
     },
     summary: "Disable a plugin",
     description:
-      "Disable a plugin in this workspace by dropping a `.disabled` sentinel, mirroring the CLI's `assistant plugins disable <name>`. The change is honored live at read time by every tool / injector / hook gate — no restart required. Broadcasts a `sync_changed` invalidation carrying the `plugins:list` tag so other clients refetch `GET /v1/plugins`. An already-disabled plugin returns 409; a user plugin with no directory returns 404 (default plugins are stubbed on demand via the `default-` prefix); a malformed name returns 400.",
+      "Disable a plugin in this workspace by dropping a `.disabled` sentinel, mirroring the CLI's `assistant plugins disable <name>`. Awaits the same source reconcile enable uses so the plugin's shutdown hook runs (a live gRPC subscribe or poll worker is dropped before this route returns). Tools, injectors, and hook gates also honor the sentinel at read time. Broadcasts a `sync_changed` invalidation carrying the `plugins:list` tag so other clients refetch `GET /v1/plugins`. An already-disabled plugin returns 409; a user plugin with no directory returns 404 (default plugins are stubbed on demand via the `default-` prefix); a malformed name returns 400.",
     tags: ["plugins"],
     pathParams: [
       {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Disabling the iMessage plugin left Photon's live gRPC subscribe up. The plugin's `shutdown` hook already stopped ingress and closed the provider, but `POST /v1/plugins/:name/disable` never ran it.

Enable already awaited `reconcilePluginSourcesNow()`. Disable only wrote `.disabled` and poked schedules, with a comment that a source reconcile would run shutdown. That is the missing call.

## What changed

- `handleDisablePlugin` awaits the same source reconcile enable uses, then broadcasts
- Failed toggles still skip reconcile
- OpenAPI description updated (review: drop the gRPC/poll-worker parenthetical)
- Removed the unused `reconcilePluginSchedulesInBackground` helper that lint flagged after disable switched to source reconcile

The `.disabled` sentinel still hides tools and hooks at read time. The reconcile is what tears down work `init` already started.

CLI `assistant plugins disable` still only writes the sentinel (same as CLI enable). A disable from the settings UI hits this route.

## Test plan

`cd assistant && bun test src/runtime/routes/__tests__/plugins-routes.test.ts`

Companion plugin PR: iMessage now awaits the live subscribe close inside `shutdown`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-09030aa5-c6fd-4408-be6c-0f9fb7d2e9a8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-09030aa5-c6fd-4408-be6c-0f9fb7d2e9a8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

