### PR TITLE
feat(live-voice): record why a silent session produced nothing (JARVIS-1603)

### DIFF
--- a/assistant/src/live-voice/__tests__/live-voice-session-telemetry.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-session-telemetry.test.ts
@@ -147,9 +147,12 @@ describe("live-voice session telemetry", () => {
 
     await session.close("client_end");
 
+    // These sessions reach `ready` and are closed without ever sending audio,
+    // so they are silent by construction and the reason says which layer
+    // stopped short — see `telemetry/live-voice-funnel.ts`.
     expect(recordLiveVoiceSessionEnded).toHaveBeenCalledWith({
       sessionId: "session-123",
-      screen: "ended_client_end",
+      screen: "ended_client_end:silent_no_audio",
       outcome: "completed",
     });
   });
@@ -164,7 +167,7 @@ describe("live-voice session telemetry", () => {
     // the reason on `screen` is what distinguishes a drop from a hangup.
     expect(recordLiveVoiceSessionEnded).toHaveBeenCalledWith({
       sessionId: "session-123",
-      screen: "ended_websocket_close",
+      screen: "ended_websocket_close:silent_no_audio",
       outcome: "completed",
     });
   });

--- a/assistant/src/live-voice/__tests__/live-voice-session-telemetry.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-session-telemetry.test.ts
@@ -149,7 +149,7 @@ describe("live-voice session telemetry", () => {
 
     // These sessions reach `ready` and are closed without ever sending audio,
     // so they are silent by construction and the reason says which layer
-    // stopped short — see `telemetry/live-voice-funnel.ts`.
+    // stopped short. See `telemetry/live-voice-funnel.ts`.
     expect(recordLiveVoiceSessionEnded).toHaveBeenCalledWith({
       sessionId: "session-123",
       screen: "ended_client_end:silent_no_audio",

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -71,7 +71,10 @@ import type {
   SttStreamServerEvent,
 } from "../stt/types.js";
 import { getSubagentManager } from "../subagent/index.js";
-import { liveVoiceEndScreen } from "../telemetry/live-voice-funnel.js";
+import {
+  liveVoiceEndScreen,
+  liveVoiceSilenceReason,
+} from "../telemetry/live-voice-funnel.js";
 import { getToolOwner } from "../tools/registry.js";
 import {
   createReasoningTagFilter,
@@ -1126,6 +1129,20 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
    * session that never failed.
    */
   private failureCode: LiveVoiceProtocolErrorCode | null = null;
+  /**
+   * How far a session that never produced a turn actually got. Latched rather
+   * than derived at close, because every one of these is a transient the
+   * teardown has already destroyed by then: `state` has moved on, the current
+   * utterance is gone, and the turn detector is disposed.
+   *
+   * A quarter of sessions end with no turn at all, and these three booleans are
+   * what separate a microphone that never opened from one that was muted from a
+   * user who simply left. See `telemetry/live-voice-funnel.ts`.
+   */
+  private reachedActive = false;
+  private receivedAudio = false;
+  private detectedSpeech = false;
+  private dispatchedTurn = false;
   // Non-null iff the start frame requested turnDetection "server_vad".
   private readonly turnDetector: MediaTurnDetector | null;
   // Base energy gate for server-VAD speech classification. During estimated
@@ -1419,6 +1436,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     // through the pending/pre-roll paths and flushes on arm. An arm failure
     // surfaces as a non-recoverable error frame instead of a start rejection.
     this.state = "active";
+    this.reachedActive = true;
     void this.armUtterance().catch(() => {});
     this.metrics.markReady();
     await this.sendFrame({
@@ -1522,9 +1540,22 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     // `recorded_at` minus the started row's, so it must be written before the
     // teardown below, which awaits a pending continuation and can run long.
     const failed = this.state === "failed";
+    // Only a session that never dispatched a turn gets a silence reason; for
+    // every other session the question is meaningless.
+    const silenceReason = this.dispatchedTurn
+      ? null
+      : liveVoiceSilenceReason({
+          reachedActive: this.reachedActive,
+          receivedAudio: this.receivedAudio,
+          detectedSpeech: this.detectedSpeech,
+        });
     recordLiveVoiceSessionEnded({
       sessionId: this.context.sessionId,
-      screen: liveVoiceEndScreen(reason, failed ? this.failureCode : null),
+      screen: liveVoiceEndScreen(
+        reason,
+        failed ? this.failureCode : null,
+        silenceReason,
+      ),
       outcome: failed ? "failed" : "completed",
     });
 
@@ -1831,6 +1862,11 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   }
 
   private async handleAudio(chunk: Buffer): Promise<void> {
+    // Both transports funnel through here, and this runs before any of the
+    // early returns below — the question it answers is "did the microphone ever
+    // open", which a chunk arriving at all settles regardless of what the
+    // session then does with it.
+    this.receivedAudio = true;
     if (this.turnDetector) {
       await this.handleServerVadAudio(this.turnDetector, chunk);
       return;
@@ -1849,6 +1885,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     // The chunk belongs to an utterance the user is still holding the button
     // for, whether or not the transcriber has produced any text for it yet.
     utterance.manualAudioCaptured = true;
+    // Manual sessions have no VAD, so the user holding the talk button is
+    // the only speech signal available. Without this every abandoned manual
+    // session would be misfiled as `no_turn` instead of `no_speech`.
+    this.detectedSpeech = true;
     this.collectUserAudio(utterance, chunk);
     if (utterance.phase === "pending") {
       // The transcriber is still arming (session start overlaps the STT
@@ -1968,6 +2008,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     // resets it.
     if (hasSpeech || this.vadPreRollHasSpeech) {
       utterance.speechRouted = true;
+      this.detectedSpeech = true;
     }
     for (const preRollChunk of this.takeVadPreRoll()) {
       await this.routeVadAudio(utterance, preRollChunk);
@@ -2221,6 +2262,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     }
     if (preRollHadSpeech) {
       utterance.speechRouted = true;
+      this.detectedSpeech = true;
     }
   }
 
@@ -4725,6 +4767,14 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     };
 
     try {
+      // Latched before the await, not after: this flag only decides whether the
+      // end event carries a silence classification, and the dashboard decides
+      // silence from persisted turn rows instead. Setting it after would let a
+      // dispatch that persisted a turn and then threw stamp "this session was
+      // silent" onto a session that has turns — a contradictory row. Setting it
+      // before can at worst leave a silent session unexplained, which is a gap
+      // rather than a false statement.
+      this.dispatchedTurn = true;
       const handle = await this.startVoiceTurn({
         conversationId: this.conversationId,
         voiceSessionId: this.context.sessionId,

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -1863,7 +1863,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
 
   private async handleAudio(chunk: Buffer): Promise<void> {
     // Both transports funnel through here, and this runs before any of the
-    // early returns below — the question it answers is "did the microphone ever
+    // early returns below. The question it answers is "did the microphone ever
     // open", which a chunk arriving at all settles regardless of what the
     // session then does with it.
     this.receivedAudio = true;
@@ -4771,7 +4771,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       // end event carries a silence classification, and the dashboard decides
       // silence from persisted turn rows instead. Setting it after would let a
       // dispatch that persisted a turn and then threw stamp "this session was
-      // silent" onto a session that has turns — a contradictory row. Setting it
+      // silent" onto a session that has turns, a contradictory row. Setting it
       // before can at worst leave a silent session unexplained, which is a gap
       // rather than a false statement.
       this.dispatchedTurn = true;

--- a/assistant/src/telemetry/__tests__/live-voice-funnel.test.ts
+++ b/assistant/src/telemetry/__tests__/live-voice-funnel.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  liveVoiceEndScreen,
+  liveVoiceSilenceReason,
+} from "../live-voice-funnel.js";
+
+describe("liveVoiceSilenceReason", () => {
+  it("blames the transport when the session never went active", () => {
+    // Nothing after `ready` can be held against a session that never got
+    // there — the user had no chance to speak.
+    expect(
+      liveVoiceSilenceReason({
+        reachedActive: false,
+        receivedAudio: false,
+        detectedSpeech: false,
+      }),
+    ).toBe("no_ready");
+  });
+
+  it("blames the transport even if stray audio arrived first", () => {
+    // Audio can land before the preflight resolves. The session still never
+    // became usable, and reporting that as a microphone problem would send
+    // someone looking in the wrong layer.
+    expect(
+      liveVoiceSilenceReason({
+        reachedActive: false,
+        receivedAudio: true,
+        detectedSpeech: true,
+      }),
+    ).toBe("no_ready");
+  });
+
+  it("reports a microphone that never opened", () => {
+    expect(
+      liveVoiceSilenceReason({
+        reachedActive: true,
+        receivedAudio: false,
+        detectedSpeech: false,
+      }),
+    ).toBe("no_audio");
+  });
+
+  it("separates a mic that opened but carried no speech", () => {
+    // The distinction that makes this taxonomy worth having: a denied
+    // permission and a muted mic both produce a silent session, and only this
+    // pair of flags tells them apart.
+    expect(
+      liveVoiceSilenceReason({
+        reachedActive: true,
+        receivedAudio: true,
+        detectedSpeech: false,
+      }),
+    ).toBe("no_speech");
+  });
+
+  it("reports speech that never became a turn", () => {
+    expect(
+      liveVoiceSilenceReason({
+        reachedActive: true,
+        receivedAudio: true,
+        detectedSpeech: true,
+      }),
+    ).toBe("no_turn");
+  });
+});
+
+describe("liveVoiceEndScreen", () => {
+  it("carries the close reason alone when nothing else applies", () => {
+    expect(liveVoiceEndScreen("client_end")).toBe("ended_client_end");
+  });
+
+  it("carries a failure code in the detail slot", () => {
+    expect(liveVoiceEndScreen("error", "invalid_field")).toBe(
+      "ended_error:invalid_field",
+    );
+  });
+
+  it("carries a silence reason when the session merely produced nothing", () => {
+    expect(liveVoiceEndScreen("client_end", null, "no_audio")).toBe(
+      "ended_client_end:silent_no_audio",
+    );
+  });
+
+  it("prefers the failure code when a session both failed and was silent", () => {
+    // A session that died on an error is explained by the error; its silence
+    // is a consequence, not a second finding.
+    expect(liveVoiceEndScreen("error", "invalid_field", "no_audio")).toBe(
+      "ended_error:invalid_field",
+    );
+  });
+
+  it("keeps every combination inside the wire field's 64-char bound", () => {
+    // `screen` is capped at 64 chars by the ingest serializer and an over-long
+    // value is dropped silently, taking the whole row with it.
+    const longest = liveVoiceEndScreen("transport_closed", null, "no_speech");
+    expect(longest.length).toBeLessThanOrEqual(64);
+  });
+
+  it("prefixes the silence value so it reads correctly in a mislabelled column", () => {
+    // It shares the detail slot with failure codes, and the admin dashboard
+    // renders that slot under a "failure code" header until it learns the
+    // difference. The prefix keeps the value honest meanwhile.
+    expect(liveVoiceEndScreen("client_end", null, "no_turn")).toContain(
+      "silent_",
+    );
+  });
+});

--- a/assistant/src/telemetry/__tests__/live-voice-funnel.test.ts
+++ b/assistant/src/telemetry/__tests__/live-voice-funnel.test.ts
@@ -8,7 +8,7 @@ import {
 describe("liveVoiceSilenceReason", () => {
   it("blames the transport when the session never went active", () => {
     // Nothing after `ready` can be held against a session that never got
-    // there — the user had no chance to speak.
+    // there: the user had no chance to speak.
     expect(
       liveVoiceSilenceReason({
         reachedActive: false,

--- a/assistant/src/telemetry/live-voice-funnel.ts
+++ b/assistant/src/telemetry/live-voice-funnel.ts
@@ -58,18 +58,86 @@ export type LiveVoiceStepName =
 export type LiveVoiceSessionOutcome = "completed" | "failed";
 
 /**
- * The `screen` dimension for an ended session: how it closed, plus the
- * protocol error code when a failure is what closed it.
+ * How far a session that produced NO turn actually got.
  *
- * Both halves are the daemon's own vocabulary verbatim
- * (`LiveVoiceSessionCloseReason`, `LiveVoiceProtocolErrorCode`) rather than a
- * mapping, so a rename on either side surfaces here as a compile error instead
- * of a silently-empty dashboard facet. The longest pair this can produce is
- * well inside the wire field's 64-char bound.
+ * A quarter of live-voice sessions end without a single turn, at a median of a
+ * few seconds. That is the closest thing the telemetry has to a "voice didn't
+ * work for me" rate, and until now it was unactionable: the rows said only that
+ * the session connected and closed, which cannot separate a denied microphone
+ * from a muted one from someone deliberately backing out. Those have completely
+ * different fixes.
+ *
+ * The four values are ordered by how far the session got, and each one narrows
+ * the cause to a different layer:
+ *
+ * - `no_ready`  never reached `active` — died in the credential preflight or
+ *               the transport, before the user could have said anything.
+ * - `no_audio`  reached `active` but not one audio chunk ever arrived — the
+ *               microphone never opened. Permission denial looks like this.
+ * - `no_speech` audio arrived but the detector never classified any of it as
+ *               speech — a muted or dead mic, or a genuinely silent user.
+ * - `no_turn`   speech was detected but no turn was ever dispatched — the
+ *               utterance was abandoned, aborted, or failed to arm.
+ */
+export type LiveVoiceSilenceReason =
+  | "no_ready"
+  | "no_audio"
+  | "no_speech"
+  | "no_turn";
+
+/**
+ * Classify a zero-turn session from what the session observed. Call only when
+ * the session really produced no turn — every branch here asserts silence, so a
+ * session that did dispatch a turn would be mislabelled by the last one.
+ */
+export function liveVoiceSilenceReason(signals: {
+  reachedActive: boolean;
+  receivedAudio: boolean;
+  detectedSpeech: boolean;
+}): LiveVoiceSilenceReason {
+  if (!signals.reachedActive) {
+    return "no_ready";
+  }
+  if (!signals.receivedAudio) {
+    return "no_audio";
+  }
+  if (!signals.detectedSpeech) {
+    return "no_speech";
+  }
+  return "no_turn";
+}
+
+/**
+ * The `screen` dimension for an ended session: how it closed, plus a detail
+ * half — the protocol error code when a failure closed it, or the silence
+ * classification when the session produced no turn at all.
+ *
+ * Every part is the daemon's own vocabulary verbatim
+ * (`LiveVoiceSessionCloseReason`, `LiveVoiceProtocolErrorCode`,
+ * {@link LiveVoiceSilenceReason}) rather than a mapping, so a rename on any of
+ * them surfaces here as a compile error instead of a silently-empty dashboard
+ * facet. The longest combination this can produce is well inside the wire
+ * field's 64-char bound.
+ *
+ * A failure code wins over a silence reason when both apply: a session that
+ * died on an error is explained by the error, and the silence is a consequence
+ * of it rather than a separate finding.
+ *
+ * The silence value carries a `silent_` prefix on purpose. It shares the detail
+ * slot with failure codes, and the admin dashboard currently renders that slot
+ * in a column labelled "failure code" — so the value has to read correctly even
+ * where the column header is wrong, until that panel learns the difference.
  */
 export function liveVoiceEndScreen(
   reason: LiveVoiceSessionCloseReason,
   failureCode?: LiveVoiceProtocolErrorCode | null,
+  silenceReason?: LiveVoiceSilenceReason | null,
 ): string {
-  return failureCode ? `ended_${reason}:${failureCode}` : `ended_${reason}`;
+  if (failureCode) {
+    return `ended_${reason}:${failureCode}`;
+  }
+  if (silenceReason) {
+    return `ended_${reason}:silent_${silenceReason}`;
+  }
+  return `ended_${reason}`;
 }

--- a/assistant/src/telemetry/live-voice-funnel.ts
+++ b/assistant/src/telemetry/live-voice-funnel.ts
@@ -62,21 +62,20 @@ export type LiveVoiceSessionOutcome = "completed" | "failed";
  *
  * A quarter of live-voice sessions end without a single turn, at a median of a
  * few seconds. That is the closest thing the telemetry has to a "voice didn't
- * work for me" rate, and until now it was unactionable: the rows said only that
- * the session connected and closed, which cannot separate a denied microphone
- * from a muted one from someone deliberately backing out. Those have completely
- * different fixes.
+ * work for me" rate, and a bare connect/close row cannot separate a denied
+ * microphone from a muted one from someone deliberately backing out. Those have
+ * completely different fixes, so the reason is what makes the rate actionable.
  *
  * The four values are ordered by how far the session got, and each one narrows
  * the cause to a different layer:
  *
- * - `no_ready`  never reached `active` — died in the credential preflight or
+ * - `no_ready`  never reached `active`: died in the credential preflight or
  *               the transport, before the user could have said anything.
- * - `no_audio`  reached `active` but not one audio chunk ever arrived — the
+ * - `no_audio`  reached `active` but not one audio chunk ever arrived, so the
  *               microphone never opened. Permission denial looks like this.
  * - `no_speech` audio arrived but the detector never classified any of it as
- *               speech — a muted or dead mic, or a genuinely silent user.
- * - `no_turn`   speech was detected but no turn was ever dispatched — the
+ *               speech: a muted or dead mic, or a genuinely silent user.
+ * - `no_turn`   speech was detected but no turn was ever dispatched, so the
  *               utterance was abandoned, aborted, or failed to arm.
  */
 export type LiveVoiceSilenceReason =
@@ -87,7 +86,7 @@ export type LiveVoiceSilenceReason =
 
 /**
  * Classify a zero-turn session from what the session observed. Call only when
- * the session really produced no turn — every branch here asserts silence, so a
+ * the session really produced no turn: every branch here asserts silence, so a
  * session that did dispatch a turn would be mislabelled by the last one.
  */
 export function liveVoiceSilenceReason(signals: {
@@ -109,8 +108,8 @@ export function liveVoiceSilenceReason(signals: {
 
 /**
  * The `screen` dimension for an ended session: how it closed, plus a detail
- * half — the protocol error code when a failure closed it, or the silence
- * classification when the session produced no turn at all.
+ * half. That detail is the protocol error code when a failure closed it, or the
+ * silence classification when the session produced no turn at all.
  *
  * Every part is the daemon's own vocabulary verbatim
  * (`LiveVoiceSessionCloseReason`, `LiveVoiceProtocolErrorCode`,
@@ -125,7 +124,7 @@ export function liveVoiceSilenceReason(signals: {
  *
  * The silence value carries a `silent_` prefix on purpose. It shares the detail
  * slot with failure codes, and the admin dashboard currently renders that slot
- * in a column labelled "failure code" — so the value has to read correctly even
+ * in a column labelled "failure code", so the value has to read correctly even
  * where the column header is wrong, until that panel learns the difference.
  */
 export function liveVoiceEndScreen(


### PR DESCRIPTION
Closes JARVIS-1603.

A quarter of live-voice sessions end without a single turn, at a median of a few seconds — 25.3% of sessions, and 23% of everyone who opens voice. It's the largest number on the voice dashboard and the closest thing we have to a "voice didn't work for me" rate.

It was also unactionable. The rows said only that the session connected and closed, so a **denied microphone, a muted one, and someone deliberately backing out all looked identical** — and those have completely different fixes.

## The taxonomy

Zero-turn sessions now carry a classification in the `screen` detail slot that failure codes already use, so **this needs no platform work** — no serializer, no wire sync.

| Value | Means | Points at |
|---|---|---|
| `no_ready` | Never reached `active` | Preflight / transport |
| `no_audio` | Active, but not one chunk arrived | Mic never opened — permission denial looks like this |
| `no_speech` | Audio arrived, never classified as speech | Muted/dead mic, or a genuinely silent user |
| `no_turn` | Speech detected, no turn dispatched | Utterance abandoned, aborted, or failed to arm |

## Three decisions worth reviewing

**Signals are latched as they happen, not read at close.** Each is a transient the teardown has already destroyed by then — `state` has moved on, the utterance is gone, the detector is disposed.

**Manual sessions latch speech from the talk button.** They have no VAD, so without this every abandoned manual session would misfile as `no_turn` rather than `no_speech`.

**The dispatch flag is set *before* the turn await, deliberately.** It only decides whether to stamp a reason, and the dashboard decides silence from persisted turn rows. Setting it after would let a dispatch that persisted a turn and then threw stamp "this session was silent" onto a session that has turns. A gap beats a contradiction.

A failure code still wins the slot over a silence reason — a session that died on an error is explained by the error, and its silence is a consequence. The silence value carries a `silent_` prefix because the admin panel currently renders that slot under a "failure code" header; the prefix keeps it honest until the follow-up teaches that panel the difference.

## Verification

- 11 new tests on the classifier and the `screen` encoding, including the 64-char wire bound (an over-long `screen` is dropped silently, taking the row with it).
- Two existing telemetry tests asserted the old bare `screen` for fixture sessions that never send audio. Those sessions are silent by construction, so they now assert the classified value — the change is intended, not a regression.
- `bun test src/live-voice/` and `src/telemetry/`: **17 failures, all pre-existing.** Verified by running the same suite on an untouched checkout, which fails identically (218 pass/17 fail there vs 229/17 here — the 11 extra passes are this PR's).
- `tsc --noEmit` and `eslint` clean.

Follow-up: surface the split on `/admin/voice` once rows exist, and relabel that detail column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)