### PR TITLE
fix(web): bare top nav search icon, circled sidebar close on native mobile

### DIFF
--- a/clients/web/src/domains/chat/chat-layout-header.tsx
+++ b/clients/web/src/domains/chat/chat-layout-header.tsx
@@ -9,6 +9,7 @@ import {
 import { useCallback, useEffect, type ReactNode } from "react";
 
 import { WindowsMenuBar } from "@/components/windows-menu-bar";
+import { NATIVE_MOBILE_BARE_ICON_BUTTON } from "@/domains/chat/utils/native-mobile-button-constants";
 import { WINDOWS_TITLE_BAR_CONTROL_CLEARANCE_PX } from "@/runtime/electron-window-chrome";
 import {
   detectElectronHostOS,
@@ -114,6 +115,7 @@ export function ChatLayoutHeader({
       iconOnly={<Search />}
       aria-label="Search (Ctrl+K)"
       tooltip="Search (Ctrl+K)"
+      className={NATIVE_MOBILE_BARE_ICON_BUTTON}
       onClick={handleSearchClick}
     />
   ) : null;

--- a/clients/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -530,7 +530,7 @@ export function AssistantSideMenu({
                   variant="ghost"
                   iconOnly={<X />}
                   aria-label="Close navigation"
-                  className={`pointer-events-auto ${NATIVE_MOBILE_BARE_ICON_BUTTON}`}
+                  className="pointer-events-auto"
                   onClick={() => onClose?.()}
                 />
                 <SearchButton />


### PR DESCRIPTION
Summary:
On the iOS/Android Capacitor shells, the top nav search button reverts to a bare glyph (no circular pill) and the sidebar overlay's close button regains the design library's circular pill. Both are call-site-only changes using the existing NATIVE_MOBILE_BARE_ICON_BUTTON constant; desktop web and Electron are unaffected.

Changes:
- Apply NATIVE_MOBILE_BARE_ICON_BUTTON to the mobile header search button so it renders icon-only on the native shells (40x40 touch target preserved)
- Drop NATIVE_MOBILE_BARE_ICON_BUTTON from the side menu overlay close button so it gets the circular touch-mobile pill back (pointer-events-auto retained)

Testing:
- chat-layout-header.test.tsx (7/7) and assistant-side-menu.test.tsx (69/69) pass; typecheck and eslint clean
- Full bun run test:ci: 1015/1019 files pass; the 4 failures are pre-existing host-environment-sensitive tests unrelated to this diff (timezone label, Electron host detection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)