### PR TITLE
feat(web): carry watch sessions over velay on managed assistants

### DIFF
--- a/assistant/src/runtime/routes/__tests__/watch-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/watch-routes.test.ts
@@ -145,6 +145,41 @@ describe("watch stream session", () => {
     reopenWatchIngressForTest();
   });
 
+  test("observes on speech onset and acknowledges nothing", async () => {
+    // A controllable clock, so the test can step past the observation floor
+    // without waiting it out in real time.
+    let nowMs = 0;
+    const observeCalls: (string | undefined)[] = [];
+    const manager = new WatchSessionManager({
+      now: () => nowMs,
+      observe: async (options) => {
+        observeCalls.push(options.sourceActorPrincipalId);
+        return observation();
+      },
+    });
+    const { ws, transcriber, session } = newSession({ manager });
+    await session.start();
+    await Bun.sleep(5);
+
+    // The session's opening observation. Step past the floor it just spent so
+    // the onset below is free to read the screen rather than being collapsed
+    // into it.
+    expect(observeCalls).toHaveLength(1);
+    nowMs += 6_000;
+
+    transcriber!.emit({ type: "turn-start" });
+    await Bun.sleep(5);
+
+    expect(observeCalls).toHaveLength(2);
+    // No `entry`: onset carries no text, and the final that follows is what
+    // files the narration. Acknowledging here would report an entry the
+    // timeline does not have.
+    expect(ws.types()).toEqual(["ready"]);
+
+    session.handleMessage(JSON.stringify({ type: "stop" }));
+    transcriber!.emit({ type: "closed" });
+  });
+
   test("starts, records narration, and stops", async () => {
     const { manager, observeCalls } = newManager();
     const { ws, transcriber, session } = newSession({ manager });

--- a/assistant/src/runtime/routes/watch-routes.ts
+++ b/assistant/src/runtime/routes/watch-routes.ts
@@ -447,6 +447,18 @@ export class WatchStreamSession {
       return;
     }
 
+    if (event.type === "turn-start") {
+      // Onset, not text. Observing here catches the screen the user is about
+      // to describe rather than the one their sentence left behind; the
+      // narration itself is filed by the `final` below. Fire and forget for
+      // the same reason as that one, and no `entry` frame is sent because
+      // nothing was appended.
+      void this.manager.handleNarrationStart().catch((err: unknown) => {
+        log.warn({ err }, "Watch narration-start observation threw");
+      });
+      return;
+    }
+
     if (event.type === "final") {
       const text = event.text.trim();
       if (!text) {

--- a/assistant/src/watch/__tests__/watch-session-manager.test.ts
+++ b/assistant/src/watch/__tests__/watch-session-manager.test.ts
@@ -186,6 +186,75 @@ describe("watch session manager", () => {
     manager.stop();
   });
 
+  test("observes the screen the session opens on", async () => {
+    const { manager, calls } = newManager();
+    const started = start(manager);
+
+    // Before a word is spoken. A demonstration starts with the user already
+    // somewhere, and where that is decides whether the first narrated step is
+    // navigating there or working there.
+    expect(calls).toHaveLength(1);
+    await settle();
+    expect(renderWatchTimeline(started.sessionId).totalEntries).toBe(1);
+
+    manager.stop();
+  });
+
+  test("observes on speech onset rather than waiting for the sentence to land", async () => {
+    const { manager, calls } = newManager();
+    start(manager);
+    await settle();
+    await elapse(6_000);
+
+    await manager.handleNarrationStart();
+
+    expect(calls).toHaveLength(2);
+
+    manager.stop();
+  });
+
+  test("files no entry for speech onset, since the final files the narration", async () => {
+    const { manager } = newManager();
+    const started = start(manager);
+    await settle();
+    await elapse(6_000);
+
+    await manager.handleNarrationStart();
+    await manager.handleNarrationFinal("now I drag it to the Trash");
+
+    // The opening observation, the onset's observation, and one narration.
+    // An entry at onset would make a second, emptier record of one utterance.
+    const summary = manager.stop();
+    expect(summary?.entryCount).toBe(3);
+    expect(renderWatchTimeline(started.sessionId).totalEntries).toBe(3);
+  });
+
+  test("holds speech onset to the same floor as a final", async () => {
+    const { manager, calls } = newManager();
+    start(manager);
+    await settle();
+
+    // Onset lands inside the interval the opening observation just spent.
+    await elapse(1_000);
+    await manager.handleNarrationStart();
+    expect(calls).toHaveLength(1);
+
+    await elapse(4_000);
+    await manager.handleNarrationStart();
+    expect(calls).toHaveLength(2);
+
+    manager.stop();
+  });
+
+  test("ignores speech onset when no session is running", async () => {
+    const { manager, calls } = newManager();
+
+    await manager.handleNarrationStart();
+
+    expect(calls).toHaveLength(0);
+    expect(manager.isActive()).toBe(false);
+  });
+
   test("observes four times across a 60s session of ten narration finals", async () => {
     const { manager, calls } = newManager();
     const started = start(manager);
@@ -216,16 +285,22 @@ describe("watch session manager", () => {
     const { manager, calls } = newManager();
     const started = start(manager);
 
-    // Not a word spoken for a minute and a half.
-    await elapse(30_000);
+    // The opening observation goes out with the session, before a word is
+    // spoken, so the ceiling's own ticks are the ones after it. Settled first
+    // because the ceiling is armed when a read finishes, not when it is sent.
     expect(calls).toHaveLength(1);
-    await elapse(30_000);
+    await settle();
+
+    // Not a word spoken for the next three quarters of a minute.
+    await elapse(15_000);
     expect(calls).toHaveLength(2);
-    await elapse(30_000);
+    await elapse(15_000);
     expect(calls).toHaveLength(3);
+    await elapse(15_000);
+    expect(calls).toHaveLength(4);
 
     const rendered = renderWatchTimeline(started.sessionId);
-    expect(rendered.totalEntries).toBe(3);
+    expect(rendered.totalEntries).toBe(4);
 
     manager.stop();
   });
@@ -303,18 +378,20 @@ describe("watch session manager", () => {
     const { manager, releases } = newDeferredManager();
     start(manager);
 
-    // Silence, so the ceiling is what dispatches the read.
-    await elapse(30_000);
+    // The session's opening read, dispatched with the session itself. Nothing
+    // arms the ceiling while it is outstanding, so silence adds no second one.
+    expect(releases).toHaveLength(1);
+    await elapse(8_000);
     expect(releases).toHaveLength(1);
 
     // The host takes 8s to answer, most of the 10s the session allows it.
-    await elapse(8_000);
     releases[0](richObservation());
     await settle();
 
-    // The next read is due 30s after the one that went out, so 22s from here.
-    // A fresh interval measured from the answer would put it 8s later.
-    await elapse(21_999);
+    // That read went out at t=0, so its successor is due at t=15s: 7s from
+    // here, not the full 15s a fresh interval measured from the answer would
+    // give it.
+    await elapse(6_999);
     expect(releases).toHaveLength(1);
     await elapse(1);
     expect(releases).toHaveLength(2);
@@ -332,7 +409,7 @@ describe("watch session manager", () => {
 
     // The ceiling comes due while that read is still out. It stacks no second
     // request, and the deadline it belongs to is already spent.
-    await elapse(30_000);
+    await elapse(15_000);
     expect(releases).toHaveLength(1);
 
     releases[0](richObservation());

--- a/assistant/src/watch/watch-session-manager.ts
+++ b/assistant/src/watch/watch-session-manager.ts
@@ -38,20 +38,27 @@ const log = getLogger("watch-session-manager");
 /**
  * Shortest gap between two observations.
  *
- * Observation is triggered by narration, not by a poll. A speech final is the
- * moment the user just said what they were doing, which is exactly the moment
- * their screen is worth recording. A poll is both wasteful and lossy: most
- * ticks land mid-gesture on a screen nobody described, and the change that
- * matters lands between two of them. The subscription that would make polling
+ * Observation is triggered by narration, not by a poll. Speech is the moment
+ * the user is saying what they are doing, which is exactly the moment their
+ * screen is worth recording. A poll is both wasteful and lossy: most ticks
+ * land mid-gesture on a screen nobody described, and the change that matters
+ * lands between two of them. The subscription that would make polling
  * unnecessary does not exist either: the mac helper's `cu.perform` is strictly
  * request/response (`HostCuExecutor.swift`), with no channel for the host to
  * push an accessibility change of its own.
  *
- * Someone talking through a task produces a final every second or two, and
- * every observation costs a full accessibility enumeration plus a JPEG over
- * the wire. Five seconds collapses a burst of finals into one record while
- * staying shorter than any UI step a person pauses to narrate, so no step
- * passes unobserved.
+ * Every observation costs a full accessibility enumeration plus a JPEG over
+ * the wire, so this floor collapses a burst of triggers into one record while
+ * staying shorter than any UI step a person pauses to narrate.
+ *
+ * Measured on real sessions, narration arrives roughly every fifteen seconds
+ * rather than every second or two: people narrate in bursts and fall silent
+ * while they do the thing they just described. So this floor is rarely the
+ * binding constraint, and raising the rate it permits buys nothing. Coverage
+ * comes from how many triggers fire, not from how fast they are allowed to —
+ * which is what the onset trigger
+ * ({@link WatchSessionManager.handleNarrationStart}) and the opening
+ * observation in {@link WatchSessionManager.start} are for.
  */
 const MIN_OBSERVE_INTERVAL_MS = 5_000;
 
@@ -67,8 +74,16 @@ const MIN_OBSERVE_INTERVAL_MS = 5_000;
  * observation was dispatched, so the wait a slow read spends counts against the
  * ceiling rather than adding to it. It fires only in a stretch where narration
  * produced none, and a talkative session never reaches it.
+ *
+ * Sized against how far apart narration actually lands, which measurement puts
+ * at roughly fifteen seconds. Matching the two means a silent stretch is
+ * covered at about the rate a narrated one is. Set much longer and this stops
+ * being a backstop and becomes the dominant trigger, which is worse than it
+ * sounds: the gap it leaves falls at the *start* of a session, where the user
+ * is opening the thing they are about to demonstrate and the retrospective
+ * has no other account of where they began.
  */
-const MAX_OBSERVE_INTERVAL_MS = 30_000;
+const MAX_OBSERVE_INTERVAL_MS = 15_000;
 
 /**
  * How long one observation may take before the session gives up on it.
@@ -257,13 +272,49 @@ export class WatchSessionManager {
       idleTimer: null,
     };
     this.session = session;
-    this.scheduleIdleObservation(session);
+    // Read the screen the demonstration begins from, rather than waiting for
+    // the first trigger. The opening state is the cheapest context there is
+    // and the most expensive to be missing: a demonstration starts with the
+    // user already somewhere, and a retrospective that never saw where cannot
+    // tell whether the first step was navigating there or working there —
+    // it reports the ambiguity instead of the task.
+    //
+    // Fire and forget, like the idle timer's own dispatch: `observeNow` owns
+    // its failures, and a start must not wait on a screen read. It also arms
+    // the ceiling on the way out through `scheduleIdleObservation`, which is
+    // why nothing arms it here.
+    void this.observeNow(session);
 
     return {
       status: "started",
       sessionId: session.sessionId,
       conversationId,
     };
+  }
+
+  /**
+   * Observe because the user has started speaking, if the cadence allows it.
+   * The entry point the streaming transcript calls on `turn-start`.
+   *
+   * Speech onset beats the final by however long the sentence takes, and the
+   * screen it lands on is the one being described rather than the one after.
+   * A person says "now I drag it to the Trash" and then drags it, so the final
+   * arrives with the gesture already finished: the state that explains the
+   * words is the one that was on screen when they began.
+   *
+   * Files no entry of its own. There is no text yet at onset, and the final
+   * that follows appends the narration; an entry here would be a second,
+   * emptier record of one utterance.
+   */
+  async handleNarrationStart(): Promise<void> {
+    const session = this.session;
+    if (session === null) {
+      return;
+    }
+    if (this.now() - session.lastObserveAtMs < MIN_OBSERVE_INTERVAL_MS) {
+      return;
+    }
+    await this.observeNow(session);
   }
 
   /**

--- a/clients/web/src/domains/chat/voice/live-voice/connection.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/connection.test.ts
@@ -2,7 +2,7 @@
  * Tests for the live-voice WS connection + token-exchange client.
  *
  * Two surfaces under test:
- *   - `mintLiveVoiceToken` — must POST `/v1/auth/live-voice-token/` through
+ *   - `mintVelayWsToken` — must POST `/v1/auth/live-voice-token/` through
  *     the credentialed platform `client` (which attaches session cookie +
  *     CSRF + org header via the interceptor). We spy on `client.post` rather
  *     than `mock.module`-ing the whole SDK, matching the pattern in
@@ -22,14 +22,14 @@ import {
   buildSelfHostedLiveVoiceWsUrl,
   getVelayWsScheme,
   isPairedGatewayIngress,
-  LiveVoiceTokenError,
-  mintLiveVoiceToken,
+  VelayWsTokenError,
+  mintVelayWsToken,
   PairedVoiceUnavailableError,
   resolveLiveVoiceWsUrl,
 } from "./connection";
 
 // ---------------------------------------------------------------------------
-// mintLiveVoiceToken
+// mintVelayWsToken
 // ---------------------------------------------------------------------------
 
 type CapturedPostOptions = {
@@ -62,9 +62,9 @@ afterEach(() => {
   window.__VELLUM_CONFIG__ = undefined;
 });
 
-describe("mintLiveVoiceToken", () => {
+describe("mintVelayWsToken", () => {
   test("POSTs the documented mint endpoint with the assistantId body", async () => {
-    await mintLiveVoiceToken("assistant-1");
+    await mintVelayWsToken("assistant-1");
 
     expect(captured).not.toBeNull();
     expect(captured!.url).toBe("/v1/auth/live-voice-token/");
@@ -72,14 +72,14 @@ describe("mintLiveVoiceToken", () => {
   });
 
   test("returns { token, expiresAt } from the response", async () => {
-    const result = await mintLiveVoiceToken("assistant-1");
+    const result = await mintVelayWsToken("assistant-1");
     expect(result).toEqual({
       token: "tok-abc",
       expiresAt: "2026-06-01T00:05:00Z",
     });
   });
 
-  test("throws LiveVoiceTokenError with the HTTP status on non-OK", async () => {
+  test("throws VelayWsTokenError with the HTTP status on non-OK", async () => {
     nextPostResult = {
       data: null,
       error: { detail: "forbidden" },
@@ -87,15 +87,15 @@ describe("mintLiveVoiceToken", () => {
     };
 
     try {
-      await mintLiveVoiceToken("assistant-1");
-      throw new Error("expected mintLiveVoiceToken to throw");
+      await mintVelayWsToken("assistant-1");
+      throw new Error("expected mintVelayWsToken to throw");
     } catch (err) {
-      expect(err).toBeInstanceOf(LiveVoiceTokenError);
-      expect((err as LiveVoiceTokenError).status).toBe(403);
+      expect(err).toBeInstanceOf(VelayWsTokenError);
+      expect((err as VelayWsTokenError).status).toBe(403);
     }
   });
 
-  test("throws LiveVoiceTokenError(0) when the body is malformed", async () => {
+  test("throws VelayWsTokenError(0) when the body is malformed", async () => {
     nextPostResult = {
       data: { token: "tok-abc" }, // missing expiresAt
       error: null,
@@ -103,11 +103,11 @@ describe("mintLiveVoiceToken", () => {
     };
 
     try {
-      await mintLiveVoiceToken("assistant-1");
-      throw new Error("expected mintLiveVoiceToken to throw");
+      await mintVelayWsToken("assistant-1");
+      throw new Error("expected mintVelayWsToken to throw");
     } catch (err) {
-      expect(err).toBeInstanceOf(LiveVoiceTokenError);
-      expect((err as LiveVoiceTokenError).status).toBe(0);
+      expect(err).toBeInstanceOf(VelayWsTokenError);
+      expect((err as VelayWsTokenError).status).toBe(0);
     }
   });
 });
@@ -346,7 +346,7 @@ describe("resolveLiveVoiceWsUrl", () => {
 
     await expect(
       resolveLiveVoiceWsUrl({ assistantId: "assistant-1" }),
-    ).rejects.toBeInstanceOf(LiveVoiceTokenError);
+    ).rejects.toBeInstanceOf(VelayWsTokenError);
     expect(captured).toBeNull();
   });
 

--- a/clients/web/src/domains/chat/voice/live-voice/connection.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/connection.ts
@@ -36,6 +36,19 @@
  * We call the generated platform SDK function `authLiveVoiceTokenCreate`, which
  * routes through the platform `client` — that interceptor attaches the session
  * cookie + CSRF + `Vellum-Organization-Id`.
+ *
+ * ---------------------------------------------------------------------------
+ * Shared with more than live voice
+ * ---------------------------------------------------------------------------
+ *
+ * The transport pieces here are route-agnostic and have a second caller:
+ * {@link buildSelfHostedGatewayWsUrl}, {@link buildVelayWsUrl}, and
+ * {@link mintVelayWsToken} are what a watch session dials through as well
+ * (`domains/chat/watch/watch-controller.ts`). Only the `…LiveVoiceWsUrl`
+ * wrappers and {@link resolveLiveVoiceWsUrl} are live voice's own. The file
+ * keeps its name and its home because live voice is where the rules were
+ * worked out and is still their principal user; the alternative is a second
+ * module that restates them and drifts.
  */
 
 import { velayHostForPlatformHost } from "@vellumai/service-contracts/ingress";
@@ -55,12 +68,12 @@ import { assertHasResponse } from "@/utils/api-errors";
  */
 const DEFAULT_VELAY_HOST = "velay.vellum.ai";
 
-export class LiveVoiceTokenError extends Error {
+export class VelayWsTokenError extends Error {
   readonly status: number;
 
   constructor(status: number, message: string) {
     super(message);
-    this.name = "LiveVoiceTokenError";
+    this.name = "VelayWsTokenError";
     this.status = status;
   }
 }
@@ -70,7 +83,7 @@ export class LiveVoiceTokenError extends Error {
  * the body is unverified on the wire — narrow defensively rather than trusting
  * the generic.
  */
-function isLiveVoiceToken(value: unknown): value is LiveVoiceTokenResponse {
+function isVelayWsToken(value: unknown): value is LiveVoiceTokenResponse {
   if (!value || typeof value !== "object") {
     return false;
   }
@@ -79,28 +92,38 @@ function isLiveVoiceToken(value: unknown): value is LiveVoiceTokenResponse {
 }
 
 /**
- * Mint a short-lived, org+assistant-scoped live-voice WS token.
+ * Mint a short-lived, user+org+assistant-scoped velay WS token.
  *
  * POSTs `/v1/auth/live-voice-token/` through the credentialed platform client
  * so the session cookie, CSRF token, and `Vellum-Organization-Id` ride along
  * automatically (see the module doc comment for the contract).
+ *
+ * Named for velay rather than for live voice because the token is not a
+ * live-voice token in substance: the platform stores it as an opaque random
+ * string against a scope of `{user_id, organization_id, assistant_id}` and
+ * nothing else (`django/app/auth/live_voice_token.py`). There is no route in
+ * the scope, so the same token authorizes any velay WebSocket route that
+ * requires per-user validation, and a second one now does
+ * (`/v1/watch/stream`). Only the endpoint's URL still carries the original
+ * name, which is a wire compatibility detail rather than a claim about what
+ * the token is good for.
  */
-export async function mintLiveVoiceToken(
+export async function mintVelayWsToken(
   assistantId: string,
 ): Promise<LiveVoiceTokenResponse> {
   const { data, error, response } = await authLiveVoiceTokenCreate({
     body: { assistantId },
     throwOnError: false,
   });
-  assertHasResponse(response, error, "Failed to mint live-voice token");
+  assertHasResponse(response, error, "Failed to mint velay WS token");
   if (!response.ok) {
-    throw new LiveVoiceTokenError(
+    throw new VelayWsTokenError(
       response.status,
-      `Live-voice token request failed (HTTP ${response.status})`,
+      `Velay WS token request failed (HTTP ${response.status})`,
     );
   }
-  if (!isLiveVoiceToken(data)) {
-    throw new LiveVoiceTokenError(0, "Live-voice token response was malformed");
+  if (!isVelayWsToken(data)) {
+    throw new VelayWsTokenError(0, "Velay WS token response was malformed");
   }
   return data;
 }
@@ -158,19 +181,63 @@ export interface BuildLiveVoiceWsUrlArgs {
   assistantId: string;
   /** Optional conversation to attach the live-voice session to. */
   conversationId?: string;
-  /** Short-lived token from {@link mintLiveVoiceToken}. */
+  /** Short-lived token from {@link mintVelayWsToken}. */
   token: string;
 }
 
+export interface BuildVelayWsUrlArgs {
+  assistantId: string;
+  /** Gateway route to open, e.g. `/v1/live-voice` or `/v1/watch/stream`. */
+  routePath: string;
+  /** Short-lived token from {@link mintVelayWsToken}. */
+  token: string;
+  /** Extra query params to append after `token` (e.g. `conversationId`). */
+  params?: Record<string, string>;
+}
+
 /**
- * Build the velay live-voice WebSocket URL for the cloud path:
+ * Build a velay WebSocket URL for the cloud path:
  *
- *   wss://<velayHost>/<assistantId>/v1/live-voice?token=<token>[&conversationId=<id>]
+ *   wss://<velayHost>/<assistantId><routePath>?token=<token>[&…]
  *
- * The scheme is `wss` for the real velay host and `ws` when `VITE_VELAY_HOST`
- * points at a loopback (local `vel up` velay) — see {@link getVelayWsScheme}.
- * The token is URL-encoded. `conversationId` is appended as an additional
- * query param only when provided.
+ * The cloud counterpart of {@link buildSelfHostedGatewayWsUrl}, and shared by
+ * every velay WS the browser opens for the same reason that one is shared: the
+ * transport rules belong in one place rather than once per route.
+ *
+ * - **The `/<assistantId>` prefix selects the tunnel.** velay strips it to
+ *   recover the upstream path, which is what it matches its allowlist and its
+ *   per-user token validation against.
+ * - **The scheme** is `wss` for the real velay host and `ws` when
+ *   `VITE_VELAY_HOST` points at a loopback (local `vel up` velay) — see
+ *   {@link getVelayWsScheme}.
+ * - **The token is a minted velay token**, not the actor edge JWT the
+ *   self-hosted builder uses. velay consumes it on the upgrade and injects the
+ *   authenticated user/org downstream; the gateway reads that attestation
+ *   rather than the query param.
+ * - **Extra params are forwarded upstream** by velay, which is how the gateway
+ *   sees `conversationId` on live voice and `mimeType`/`sampleRate` on watch.
+ *
+ * Values are URL-encoded by `URLSearchParams`.
+ */
+export function buildVelayWsUrl({
+  assistantId,
+  routePath,
+  token,
+  params,
+}: BuildVelayWsUrlArgs): string {
+  const host = getVelayHost();
+  const scheme = getVelayWsScheme(host);
+  const url = new URL(`${scheme}://${host}/${assistantId}${routePath}`);
+  url.searchParams.set("token", token);
+  for (const [key, value] of Object.entries(params ?? {})) {
+    url.searchParams.set(key, value);
+  }
+  return url.toString();
+}
+
+/**
+ * Build the velay live-voice WebSocket URL for the cloud path. Thin wrapper
+ * over {@link buildVelayWsUrl} for the `/v1/live-voice` route.
  *
  * This is the cloud builder. The self-hosted/local path uses
  * {@link buildSelfHostedLiveVoiceWsUrl}; {@link resolveLiveVoiceWsUrl} chooses
@@ -181,14 +248,12 @@ export function buildLiveVoiceWsUrl({
   conversationId,
   token,
 }: BuildLiveVoiceWsUrlArgs): string {
-  const host = getVelayHost();
-  const scheme = getVelayWsScheme(host);
-  const url = new URL(`${scheme}://${host}/${assistantId}/v1/live-voice`);
-  url.searchParams.set("token", token);
-  if (conversationId) {
-    url.searchParams.set("conversationId", conversationId);
-  }
-  return url.toString();
+  return buildVelayWsUrl({
+    assistantId,
+    routePath: "/v1/live-voice",
+    token,
+    params: conversationId ? { conversationId } : undefined,
+  });
 }
 
 export interface BuildSelfHostedLiveVoiceWsUrlArgs {
@@ -344,7 +409,7 @@ export interface ResolveLiveVoiceWsUrlArgs {
  *
  * - **Self-hosted / local** — when {@link getSelfHostedIngressUrl} is primed,
  *   connect straight to the user's gateway with the actor edge JWT. No velay
- *   token-exchange happens. Throws {@link LiveVoiceTokenError} if the ingress is
+ *   token-exchange happens. Throws {@link VelayWsTokenError} if the ingress is
  *   known but the actor token hasn't been provisioned yet (a brief post-hatch
  *   window), so the caller surfaces a connection failure rather than dialling an
  *   unauthenticated socket. A paired ingress throws
@@ -364,7 +429,7 @@ export async function resolveLiveVoiceWsUrl({
     }
     const token = getSelfHostedActorToken();
     if (!token) {
-      throw new LiveVoiceTokenError(
+      throw new VelayWsTokenError(
         0,
         "Self-hosted live voice has no actor token yet; the gateway isn't ready.",
       );
@@ -372,6 +437,6 @@ export async function resolveLiveVoiceWsUrl({
     return buildSelfHostedLiveVoiceWsUrl({ ingressUrl, conversationId, token });
   }
 
-  const { token } = await mintLiveVoiceToken(assistantId);
+  const { token } = await mintVelayWsToken(assistantId);
   return buildLiveVoiceWsUrl({ assistantId, conversationId, token });
 }

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-client.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-client.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for the browser live-voice WebSocket client.
  *
- * `mintLiveVoiceToken` is mocked at module scope so no real HTTP/SDK call
+ * `mintVelayWsToken` is mocked at module scope so no real HTTP/SDK call
  * happens; `buildLiveVoiceWsUrl` is kept real so we exercise the genuine
  * connection.ts URL builder (no hardcoded host in the client). The WebSocket is
  * a hand-rolled fake injected via the client's `webSocketFactory` option — no

--- a/clients/web/src/domains/chat/watch/watch-controller.test.ts
+++ b/clients/web/src/domains/chat/watch/watch-controller.test.ts
@@ -38,6 +38,40 @@ mock.module("@/domains/chat/voice/live-voice/pcm-capture", () => ({
 }));
 
 /**
+ * The velay token mint, stood in for so the managed path can be exercised
+ * without an HTTP round trip.
+ *
+ * Only the mint is replaced. Everything else in the connection module — both
+ * URL builders, the paired-ingress predicate, the error types — stays real, so
+ * the URLs these tests assert on are the ones the app would actually dial
+ * rather than a fake's idea of them.
+ */
+const realConnection = await import(
+  "@/domains/chat/voice/live-voice/connection"
+);
+
+/** Assistant ids the mint was called for, in order. */
+let mintCalls: string[] = [];
+/** Set to null to make the platform refuse the mint. */
+let mintedToken: string | null = "velay-token";
+/** Held open by a test that needs a press to land mid-mint. */
+let mintGate: Promise<void> | null = null;
+
+mock.module("@/domains/chat/voice/live-voice/connection", () => ({
+  ...realConnection,
+  mintVelayWsToken: async (assistantId: string) => {
+    mintCalls.push(assistantId);
+    if (mintGate) {
+      await mintGate;
+    }
+    if (mintedToken === null) {
+      throw new realConnection.VelayWsTokenError(403, "mint refused");
+    }
+    return { token: mintedToken, expiresAt: "2026-01-01T00:00:00Z" };
+  },
+}));
+
+/**
  * The active-assistant store, stood in for so the test can see the session's
  * subscription come and go. A leaked listener is invisible against the real
  * store (teardown is idempotent, so a stale one fires harmlessly and
@@ -298,6 +332,9 @@ beforeEach(() => {
   ingressUrl = "http://localhost:8500";
   actorToken = "actor-jwt";
   pcmSupported = true;
+  mintCalls = [];
+  mintedToken = "velay-token";
+  mintGate = null;
   sockets = [];
   capture = createCaptureFake();
   useLiveVoiceStore.setState({ state: "idle" });
@@ -415,15 +452,6 @@ describe("toggling a watch session", () => {
     expect(useWatchStore.getState().watching).toBe(true);
   });
 
-  test("opens nothing without a self-hosted ingress to reach", async () => {
-    ingressUrl = null;
-
-    await toggle();
-
-    expect(sockets).toHaveLength(0);
-    expect(useWatchStore.getState().watching).toBe(false);
-  });
-
   test("opens nothing without an actor token to authenticate with", async () => {
     actorToken = null;
 
@@ -440,6 +468,119 @@ describe("toggling a watch session", () => {
 
     expect(sockets).toHaveLength(0);
     expect(useWatchStore.getState().watching).toBe(false);
+  });
+});
+
+/**
+ * The managed transport, which is the one most users are on.
+ *
+ * A managed assistant has no ingress of its own to dial, so the session goes
+ * through velay with a minted token instead — the same route, reached the
+ * other way. The gateway admits only the guardian on either path, so what
+ * these cases pin is that the press reaches a socket at all, and that a start
+ * which cannot get a token leaves nothing behind.
+ */
+describe("a watch session on a managed assistant", () => {
+  /**
+   * Resolve once the mint has actually been entered, so a case that means to
+   * interrupt it interrupts it rather than something earlier.
+   */
+  const whenMintInFlight = async (): Promise<void> => {
+    // Real timer turns, not microtasks: a start can be held behind the
+    // previous session's drain, which is a `setTimeout`, so a microtask-only
+    // spin would give up before the mint was ever reached.
+    for (let i = 0; i < 200 && mintCalls.length === 0; i += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 1));
+    }
+    if (mintCalls.length === 0) {
+      throw new Error("Expected the mint to have been entered");
+    }
+  };
+
+  /** No self-hosted ingress is what makes an assistant managed here. */
+  const managed = (): void => {
+    ingressUrl = null;
+    actorToken = null;
+  };
+
+  test("mints a velay token and dials velay with it", async () => {
+    managed();
+
+    await startRunning();
+
+    expect(mintCalls).toEqual([ASSISTANT_ID]);
+    const url = new URL(socket().url);
+    expect(url.protocol).toBe("wss:");
+    expect(url.host).toBe("velay.vellum.ai");
+    // The `/<assistantId>` prefix is what selects the tunnel; velay strips it
+    // to recover the upstream path it matches its allowlist against.
+    expect(url.pathname).toBe(`/${ASSISTANT_ID}/v1/watch/stream`);
+    expect(url.searchParams.get("token")).toBe("velay-token");
+    expect(url.searchParams.get("mimeType")).toBe("audio/pcm");
+    expect(url.searchParams.get("sampleRate")).toBe("16000");
+    expect(useWatchStore.getState().watching).toBe(true);
+  });
+
+  test("opens nothing when the platform refuses the mint", async () => {
+    managed();
+    mintedToken = null;
+
+    await toggle();
+
+    expect(sockets).toHaveLength(0);
+    expect(useWatchStore.getState().watching).toBe(false);
+  });
+
+  test("leaves the slot free for a later press when the mint is refused", async () => {
+    managed();
+    mintedToken = null;
+    await toggle();
+
+    // A refused start that kept the slot would swallow the next press as a
+    // stop, and the user would have to press twice to get anywhere.
+    mintedToken = "velay-token";
+    await startRunning();
+
+    expect(useWatchStore.getState().watching).toBe(true);
+  });
+
+  test("a stop pressed while the token is being minted opens nothing", async () => {
+    managed();
+    let releaseMint = (): void => {};
+    mintGate = new Promise<void>((resolve) => {
+      releaseMint = resolve;
+    });
+
+    const starting = toggle();
+    // The press lands while the mint is in flight, which is the window the
+    // registered attempt exists to cover. Waited for rather than assumed: a
+    // stop that arrived before the mint began would exercise the version-gate
+    // cancellation instead and pass for the wrong reason.
+    await whenMintInFlight();
+    stopWatch();
+    releaseMint();
+    await starting;
+
+    expect(sockets).toHaveLength(0);
+    expect(useWatchStore.getState().watching).toBe(false);
+  });
+
+  test("a stop mid-mint does not wedge the next press", async () => {
+    managed();
+    let releaseMint = (): void => {};
+    mintGate = new Promise<void>((resolve) => {
+      releaseMint = resolve;
+    });
+    const starting = toggle();
+    await whenMintInFlight();
+    stopWatch();
+    releaseMint();
+    await starting;
+
+    mintGate = null;
+    await startRunning();
+
+    expect(useWatchStore.getState().watching).toBe(true);
   });
 });
 

--- a/clients/web/src/domains/chat/watch/watch-controller.ts
+++ b/clients/web/src/domains/chat/watch/watch-controller.ts
@@ -53,19 +53,28 @@
  * still flowing to the previous assistant's socket while the surface draws the
  * new one's name beside a flag that reads as the new one's.
  *
- * Transport is the dictation stream's, through `buildSelfHostedGatewayWsUrl`:
- * straight to the user's gateway ingress with the actor edge JWT in `?token=`,
- * since browser WebSockets cannot set an `Authorization` header. See
- * `voice/dictation-stream.ts` for the whole rule set, including the local
- * `/assistant/__gateway/<port>` bypass. Off a self-hosted ingress there is no
- * socket to open and the toggle is a no-op.
+ * **Transport is live voice's, both halves of it.** `resolveWatchStreamWsUrl`
+ * chooses by deployment kind the way `resolveLiveVoiceWsUrl` does: a
+ * self-hosted assistant is dialled straight at the user's gateway ingress with
+ * the actor edge JWT in `?token=` (browser WebSockets cannot set an
+ * `Authorization` header), and a managed one is dialled through velay with a
+ * short-lived minted token. See `live-voice/connection.ts` for the whole rule
+ * set, including the local `/assistant/__gateway/<port>` bypass.
+ *
+ * A paired assistant remains the one deployment with no transport at all: its
+ * proxy is HTTP-only and there is no loopback to fall back to, so the toggle
+ * is a no-op there and says so.
  */
 
 import { create } from "zustand";
 
 import {
   buildSelfHostedGatewayWsUrl,
+  buildVelayWsUrl,
   isPairedGatewayIngress,
+  mintVelayWsToken,
+  PairedVoiceUnavailableError,
+  VelayWsTokenError,
 } from "@/domains/chat/voice/live-voice/connection";
 import {
   isLiveVoiceSessionActive,
@@ -191,8 +200,21 @@ let session: WatchSession | null = null;
  */
 let drainRelease: Promise<void> | null = null;
 
+/** The route both transports open, on the gateway either way. */
+const WATCH_STREAM_ROUTE = "/v1/watch/stream";
+
 /**
- * Build the watch stream WebSocket URL:
+ * Query params the gateway requires on the upgrade. `mimeType` is mandatory
+ * (`watch-stream-websocket.ts` refuses an upgrade without it); both are
+ * forwarded upstream unchanged on the velay path.
+ */
+const WATCH_STREAM_PARAMS: Record<string, string> = {
+  mimeType: LIVE_VOICE_AUDIO_FORMAT.mimeType,
+  sampleRate: String(LIVE_VOICE_AUDIO_FORMAT.sampleRate),
+};
+
+/**
+ * Build the self-hosted watch stream WebSocket URL:
  *
  *   ws(s)://<ingressHost>/v1/watch/stream?token=…&mimeType=audio/pcm&sampleRate=16000
  *
@@ -209,12 +231,61 @@ export function buildWatchStreamWsUrl({
 }): string {
   return buildSelfHostedGatewayWsUrl({
     ingressUrl,
-    routePath: "/v1/watch/stream",
+    routePath: WATCH_STREAM_ROUTE,
     token,
-    params: {
-      mimeType: LIVE_VOICE_AUDIO_FORMAT.mimeType,
-      sampleRate: String(LIVE_VOICE_AUDIO_FORMAT.sampleRate),
-    },
+    params: WATCH_STREAM_PARAMS,
+  });
+}
+
+/**
+ * Resolve the watch stream WebSocket URL for `assistantId`, choosing the
+ * transport by deployment kind exactly as {@link resolveLiveVoiceWsUrl} does.
+ *
+ * - **Self-hosted / local** — dial the user's own gateway ingress with the
+ *   actor edge JWT. No token is minted; the gateway validates the JWT and
+ *   checks its principal against the guardian binding.
+ * - **Managed / cloud** — mint a short-lived velay token and dial velay, which
+ *   validates and consumes it, then injects the authenticated user and org as
+ *   `X-Velay-*` headers. The gateway takes its managed branch on those and
+ *   cross-checks the caller against the stored `platform_user_id`
+ *   (`gateway/src/http/routes/guardian-pin.ts`), so the guardian-only rule is
+ *   the same rule on both paths, proven two different ways.
+ *
+ * Throws rather than returning null, so a start that cannot resolve a URL is
+ * distinguishable from one this environment simply does not support:
+ *
+ * - {@link PairedVoiceUnavailableError} for a paired ingress, whose proxy is
+ *   HTTP-only with no loopback to fall back to. Still genuinely unsupported.
+ * - {@link VelayWsTokenError} when the ingress is known but its actor token
+ *   has not been provisioned yet (a brief post-hatch window), and for a mint
+ *   that the platform refuses.
+ *
+ * Exported for unit tests.
+ */
+export async function resolveWatchStreamWsUrl(
+  assistantId: string,
+): Promise<string> {
+  const ingressUrl = getSelfHostedIngressUrl();
+  if (ingressUrl) {
+    if (isPairedGatewayIngress(ingressUrl)) {
+      throw new PairedVoiceUnavailableError();
+    }
+    const token = getSelfHostedActorToken();
+    if (!token) {
+      throw new VelayWsTokenError(
+        0,
+        "Self-hosted watch has no actor token yet; the gateway isn't ready.",
+      );
+    }
+    return buildWatchStreamWsUrl({ ingressUrl, token });
+  }
+
+  const { token } = await mintVelayWsToken(assistantId);
+  return buildVelayWsUrl({
+    assistantId,
+    routePath: WATCH_STREAM_ROUTE,
+    token,
+    params: WATCH_STREAM_PARAMS,
   });
 }
 
@@ -228,28 +299,24 @@ export function buildWatchStreamWsUrl({
  * registered while still pending, which is what keeps the stop edge working
  * before `ready`.
  *
- * Does nothing when this environment has nothing to open: no self-hosted
- * ingress or actor token, no AudioWorklet, a paired gateway whose proxy is
- * HTTP-only. Every one of those is a normal deployment rather than a failure,
- * so the toggle leaves the surface where it was rather than reporting an error
- * the user cannot act on.
+ * Takes an already-resolved `wsUrl` and stays synchronous, which is the point:
+ * resolving it is a network call on the managed path, and everything this
+ * function does after the first line has to happen in one uninterrupted
+ * stretch for the registration order above to mean anything. The await lives
+ * in {@link toggleWatch}, where a press that lands during it is already
+ * cancellable.
+ *
+ * Does nothing when this environment has no AudioWorklet, which is a normal
+ * browser rather than a failure, so the toggle leaves the surface where it was
+ * rather than reporting an error the user cannot act on.
  */
 function openSession(
   ownerAssistantId: string,
+  wsUrl: string,
   options: WatchControllerOptions,
 ): void {
-  const ingressUrl = getSelfHostedIngressUrl();
-  const token = getSelfHostedActorToken();
-  if (!ingressUrl || !token || !isPcmCaptureSupported()) {
-    console.info(
-      "watch-controller: skipping (no self-hosted ingress/token or no AudioWorklet)",
-    );
-    return;
-  }
-  if (isPairedGatewayIngress(ingressUrl)) {
-    console.info(
-      "watch-controller: skipping (watch sessions aren't available for paired assistants yet)",
-    );
+  if (!isPcmCaptureSupported()) {
+    console.info("watch-controller: skipping (no AudioWorklet)");
     return;
   }
 
@@ -258,7 +325,7 @@ function openSession(
 
   let ws: WebSocket;
   try {
-    ws = webSocketFactory(buildWatchStreamWsUrl({ ingressUrl, token }));
+    ws = webSocketFactory(wsUrl);
   } catch {
     return;
   }
@@ -697,6 +764,21 @@ export async function toggleWatch(
   };
   session = attempt;
 
+  /**
+   * Give up the slot without cancelling, for a start that ends on its own
+   * terms rather than by a press: an unsupported assistant, a transport that
+   * will not resolve, a re-read that no longer holds. Also how the slot is
+   * handed to `openSession` on the way through.
+   *
+   * Guarded on identity rather than assigning null outright, so a start that
+   * lost the slot to a newer one cannot clear the newer one's registration.
+   */
+  const releaseAttempt = (): void => {
+    if (session === attempt) {
+      session = null;
+    }
+  };
+
   // Resolve the version rather than reading the gate's conservative
   // unknown-is-false, which a press landing before the identity fetch would
   // otherwise hit and refuse an assistant that does support watching. See
@@ -719,25 +801,56 @@ export async function toggleWatch(
       return;
     }
   }
-  // Nothing else can have replaced the slot: every other entry point goes
-  // through the registered `stop` above, which sets `cancelled`. Released here
-  // so `openSession` can register the real session in it.
-  session = null;
   if (!supported) {
+    releaseAttempt();
     console.info(
       "watch-controller: skipping (this assistant has no watch stream to open)",
     );
     return;
   }
-  // Re-read across the await. A call can have started, and the active
-  // assistant can have moved out from under the gate that just passed.
+  /**
+   * The transport, resolved last and while the attempt still holds the slot.
+   *
+   * On a managed assistant this mints a single-use velay token, which is a
+   * round trip to the platform and the one genuinely new wait on this path.
+   * It is deliberately the last thing before the dial: the token lives 60
+   * seconds, and resolving it ahead of the drain wait above would spend part
+   * of that life waiting on the previous session.
+   *
+   * A throw here is not the same as an unsupported environment — a paired
+   * ingress, an unprovisioned actor token, a refused mint — but the press has
+   * nowhere to go in any of those cases, so all of them leave the surface
+   * where it was and say why in the log.
+   */
+  let wsUrl: string;
+  try {
+    wsUrl = await resolveWatchStreamWsUrl(assistantId);
+  } catch (err) {
+    releaseAttempt();
+    console.info("watch-controller: skipping (no watch transport)", err);
+    return;
+  }
+  if (cancelled) {
+    return;
+  }
+  // Re-read across the awaits. A call can have started, and the active
+  // assistant can have moved out from under the gate that just passed. Taken
+  // after the transport resolves rather than before, so the check that decides
+  // is the one nearest the dial; the cost is a minted token spent on a start
+  // that is then discarded, and a single-use token nobody presents just
+  // expires.
   if (
     isLiveVoiceSessionActive(useLiveVoiceStore.getState().state) ||
     useResolvedAssistantsStore.getState().activeAssistantId !== assistantId
   ) {
+    releaseAttempt();
     return;
   }
-  openSession(assistantId, options);
+  // Nothing else can have replaced the slot: every other entry point goes
+  // through the registered `stop` above, which sets `cancelled`. Released here
+  // so `openSession` can register the real session in it.
+  releaseAttempt();
+  openSession(assistantId, wsUrl, options);
 }
 
 /**

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -2152,12 +2152,11 @@ async function main() {
       return undefined as unknown as Response;
     }
 
-    // Self-hosted only in this version, and deliberately NOT in
-    // `VELAY_ALLOWED_PATHS`: the client refuses to open a session over a
-    // paired ingress, and a session needs a locally connected `host_cu`
-    // desktop client to observe anything. Adding the allowlist entry opens a
-    // managed route that still cannot carry a session, and nothing fails to
-    // say so. See the note in `velay/allowed-paths.ts`.
+    // Reachable both ways: directly on a self-hosted ingress with an actor
+    // edge JWT, and through the velay tunnel on a managed assistant, which is
+    // why it is in `VELAY_ALLOWED_PATHS`. The handler authorizes each shape on
+    // its own terms and admits only the guardian either way. A paired
+    // assistant has no transport at all and never reaches here.
     if (url.pathname === "/v1/watch/stream") {
       const upgradeResult = await handleWatchStreamWs(req, server);
       if (upgradeResult !== undefined) {

--- a/gateway/src/velay/allowed-paths.test.ts
+++ b/gateway/src/velay/allowed-paths.test.ts
@@ -5,7 +5,10 @@ import {
   VELAY_ALLOWED_PATHS_HEADER,
   VELAY_ALLOWED_PATHS_HEADER_VALUE,
 } from "./allowed-paths.js";
-import { isAllowedVelayWebSocketPath } from "./bridge-utils.js";
+import {
+  isAllowedVelayWebSocketPath,
+  VELAY_ALLOWED_WEBSOCKET_EXACT_PATHS,
+} from "./bridge-utils.js";
 
 describe("VELAY_ALLOWED_PATHS", () => {
   it("matches the platform-side header name (must stay in sync with vellum-assistant-platform RegistrationAllowedPathsHeader)", () => {
@@ -102,6 +105,20 @@ describe("VELAY_ALLOWED_PATHS", () => {
  * been noticed was a test like this one.
  */
 describe("the registration allowlist and the bridge's WebSocket allowlist", () => {
+  const compiled = () => VELAY_ALLOWED_PATHS.map((p) => new RegExp(p));
+
+  /**
+   * Every tunnelled WebSocket route, curated rather than derived.
+   *
+   * There is no single source to derive it from: the registration list is
+   * RE2 regex strings velay compiles platform-side, and the bridge's is exact
+   * paths sharing a predicate with the HTTP prefixes. Nothing in either
+   * records which entries are WebSocket routes, so that fact lives here.
+   *
+   * Which leaves one hole this file cannot close by itself: a new WebSocket
+   * route added to both allowlists but not to this list is simply unchecked.
+   * If you are adding one, add it here too.
+   */
   const WEBSOCKET_ROUTES = [
     "/v1/live-voice",
     "/v1/stt/stream",
@@ -109,27 +126,35 @@ describe("the registration allowlist and the bridge's WebSocket allowlist", () =
   ];
 
   it("admits every tunnelled WebSocket route at both layers", () => {
-    const compiled = VELAY_ALLOWED_PATHS.map((p) => new RegExp(p));
     for (const path of WEBSOCKET_ROUTES) {
       expect({
         path,
-        registration: compiled.some((re) => re.test(path)),
+        registration: compiled().some((re) => re.test(path)),
         bridge: isAllowedVelayWebSocketPath(path),
       }).toEqual({ path, registration: true, bridge: true });
     }
   });
 
-  it("does not admit a WebSocket route at the bridge that velay would refuse", () => {
-    // The reverse omission is quieter still: the bridge would dial happily and
-    // velay would 404 the upgrade before the frame ever arrived.
-    const compiled = VELAY_ALLOWED_PATHS.map((p) => new RegExp(p));
+  it("admits nothing at the bridge that velay would refuse anyway", () => {
+    // Derived from the bridge's own list rather than curated, so this half
+    // needs no maintenance. The reverse omission is quieter than the one
+    // above: the bridge would dial happily and velay would 404 the upgrade
+    // before the frame ever reached it.
+    for (const path of VELAY_ALLOWED_WEBSOCKET_EXACT_PATHS) {
+      expect({
+        path,
+        registration: compiled().some((re) => re.test(path)),
+      }).toEqual({ path, registration: true });
+    }
+  });
+
+  it("admits no near miss of a tunnelled route at either layer", () => {
     for (const path of ["/v1/watch", "/v1/watch/stream/extra", "/v1/speech"]) {
-      if (isAllowedVelayWebSocketPath(path)) {
-        expect({
-          path,
-          registration: compiled.some((re) => re.test(path)),
-        }).toEqual({ path, registration: true });
-      }
+      expect({
+        path,
+        registration: compiled().some((re) => re.test(path)),
+        bridge: isAllowedVelayWebSocketPath(path),
+      }).toEqual({ path, registration: false, bridge: false });
     }
   });
 });

--- a/gateway/src/velay/allowed-paths.test.ts
+++ b/gateway/src/velay/allowed-paths.test.ts
@@ -54,18 +54,15 @@ describe("VELAY_ALLOWED_PATHS", () => {
       "/v1/audio/some-uuid.mp3": true,
       "/v1/live-voice": true,
       "/v1/stt/stream": true,
+      // Watch sessions on a managed assistant ride the tunnel, the same shape
+      // as live voice: velay validates the browser's minted token on this path
+      // and injects the attested caller, and the gateway's handler admits only
+      // the guardian on it. Self-hosted assistants bypass velay entirely.
+      "/v1/watch/stream": true,
       "/assistant/credentials/enter": true,
       "/v1/credential-requests/peek": true,
       "/v1/credential-requests/submit": true,
       // Negative samples — paths that must NOT be tunnel-public.
-      //
-      // `/v1/watch/stream` is here because its absence is a decision rather
-      // than an oversight. Watch is self-hosted only: the client refuses a
-      // paired ingress and a session needs a local desktop client, so the
-      // allowlist entry would open a managed route that still cannot carry a
-      // session. This line is what turns adding it from a silent no-op into a
-      // failure that names the reason.
-      "/v1/watch/stream": false,
       "/v1/credential-requests": false,
       "/v1/credential-requests/other": false,
       "/assistant/credentials": false,

--- a/gateway/src/velay/allowed-paths.test.ts
+++ b/gateway/src/velay/allowed-paths.test.ts
@@ -5,6 +5,7 @@ import {
   VELAY_ALLOWED_PATHS_HEADER,
   VELAY_ALLOWED_PATHS_HEADER_VALUE,
 } from "./allowed-paths.js";
+import { isAllowedVelayWebSocketPath } from "./bridge-utils.js";
 
 describe("VELAY_ALLOWED_PATHS", () => {
   it("matches the platform-side header name (must stay in sync with vellum-assistant-platform RegistrationAllowedPathsHeader)", () => {
@@ -79,6 +80,56 @@ describe("VELAY_ALLOWED_PATHS", () => {
     for (const [path, expected] of Object.entries(samples)) {
       const matched = compiled.some((re) => re.test(path));
       expect({ path, matched }).toEqual({ path, matched: expected });
+    }
+  });
+});
+
+/**
+ * The two allowlists a tunnelled WebSocket has to clear, checked against each
+ * other.
+ *
+ * `VELAY_ALLOWED_PATHS` is declared to velay at registration and enforced
+ * platform-side; `VELAY_ALLOWED_WEBSOCKET_EXACT_PATHS` in `bridge-utils.ts` is
+ * the local second layer, enforced when the bridge dials the gateway's own
+ * loopback listener. A route needs both, and their comments have always said
+ * to keep them in sync, but nothing checked it.
+ *
+ * That gap is not theoretical: `/v1/watch/stream` was added to the
+ * registration list alone, and every managed watch session died at the bridge.
+ * The bridge answers a path it does not recognize with a `websocket_open_error`
+ * frame and no log, velay reports it as an opaque `tunnel_error`, and the
+ * gateway records nothing at all — so the one place the omission could have
+ * been noticed was a test like this one.
+ */
+describe("the registration allowlist and the bridge's WebSocket allowlist", () => {
+  const WEBSOCKET_ROUTES = [
+    "/v1/live-voice",
+    "/v1/stt/stream",
+    "/v1/watch/stream",
+  ];
+
+  it("admits every tunnelled WebSocket route at both layers", () => {
+    const compiled = VELAY_ALLOWED_PATHS.map((p) => new RegExp(p));
+    for (const path of WEBSOCKET_ROUTES) {
+      expect({
+        path,
+        registration: compiled.some((re) => re.test(path)),
+        bridge: isAllowedVelayWebSocketPath(path),
+      }).toEqual({ path, registration: true, bridge: true });
+    }
+  });
+
+  it("does not admit a WebSocket route at the bridge that velay would refuse", () => {
+    // The reverse omission is quieter still: the bridge would dial happily and
+    // velay would 404 the upgrade before the frame ever arrived.
+    const compiled = VELAY_ALLOWED_PATHS.map((p) => new RegExp(p));
+    for (const path of ["/v1/watch", "/v1/watch/stream/extra", "/v1/speech"]) {
+      if (isAllowedVelayWebSocketPath(path)) {
+        expect({
+          path,
+          registration: compiled.some((re) => re.test(path)),
+        }).toEqual({ path, registration: true });
+      }
     }
   });
 });

--- a/gateway/src/velay/allowed-paths.ts
+++ b/gateway/src/velay/allowed-paths.ts
@@ -29,17 +29,26 @@
  *     unauthenticated API calls; the single-use token travels in the POST
  *     body and is validated by the gateway handlers.
  *
- * **`/v1/watch/stream` is deliberately absent, and adding it does not make
- * Watch work in managed deployments.** Watch is self-hosted only in this
- * version. The client refuses to open a session over a paired ingress at all
+ *   - `^/v1/watch/stream` — exact match for the browser watch-session
+ *     WebSocket, which carries a session's narration audio.
+ *
+ * `/v1/watch/stream` was deliberately absent until the client could use it.
+ * The note that stood here argued the entry was premature on its own, and it
+ * was right: an allowlist pattern with no client that dials the route opens a
+ * public managed route which still cannot carry a session, and nothing fails
+ * to say so. That is no longer the case. `resolveWatchStreamWsUrl` picks the
+ * velay transport for a managed assistant, and velay validates the minted
+ * token on this path the way it does live voice's, so the entry is now the
+ * last step of the work rather than the first.
+ *
+ * One claim in that note was wrong and is worth not repeating: it read as
+ * though a managed assistant could not have a locally connected `host_cu`
+ * desktop client. Managed assistants reach the user's machine through the
+ * desktop host proxy, which is how computer use already works for them. What
+ * genuinely has no transport is a *paired* assistant, whose gateway proxy is
+ * HTTP-only, and the client still refuses those outright
  * (`isPairedGatewayIngress` in
- * `clients/web/src/domains/chat/voice/live-voice/connection.ts`), and a
- * session has nothing to observe without a locally connected `host_cu`
- * desktop client on the other end. So a pattern added here changes nothing a
- * user can see: it opens a public managed route that still cannot carry a
- * session, and it does so silently, because no test fails and no client
- * behavior changes. Making Watch managed is client and product work, and the
- * routing entry is the last step of it rather than the first.
+ * `clients/web/src/domains/chat/voice/live-voice/connection.ts`).
  *
  * If you add a new public route to `gateway/src/index.ts` that must be
  * reachable through the Velay tunnel (i.e. anything an external provider
@@ -52,9 +61,7 @@ export const VELAY_ALLOWED_PATHS: readonly string[] = Object.freeze([
   "^/v1/audio/",
   "^/v1/live-voice$",
   "^/v1/stt/stream$",
-  // No `^/v1/watch/stream$` here on purpose. See the note above: the client
-  // refuses a paired ingress and a session needs a local desktop client, so
-  // this line would open a managed route that still cannot carry a session.
+  "^/v1/watch/stream$",
   "^/assistant/credentials/enter$",
   "^/v1/credential-requests/(peek|submit)$",
 ]);

--- a/gateway/src/velay/bridge-utils.ts
+++ b/gateway/src/velay/bridge-utils.ts
@@ -18,7 +18,12 @@ const VELAY_ALLOWED_HTTP_EXACT_PATHS = [
   "/v1/credential-requests/peek",
   "/v1/credential-requests/submit",
 ] as const;
-const VELAY_ALLOWED_WEBSOCKET_EXACT_PATHS = [
+/**
+ * Exported so `allowed-paths.test.ts` can check this list against the
+ * registration allowlist it has to agree with. See the guard there for why the
+ * two are checked rather than trusted.
+ */
+export const VELAY_ALLOWED_WEBSOCKET_EXACT_PATHS = [
   "/v1/live-voice",
   "/v1/stt/stream",
   "/v1/watch/stream",

--- a/gateway/src/velay/bridge-utils.ts
+++ b/gateway/src/velay/bridge-utils.ts
@@ -21,9 +21,7 @@ const VELAY_ALLOWED_HTTP_EXACT_PATHS = [
 const VELAY_ALLOWED_WEBSOCKET_EXACT_PATHS = [
   "/v1/live-voice",
   "/v1/stt/stream",
-  // `/v1/watch/stream` is deliberately not here either. See the note in
-  // allowed-paths.ts before adding it: Watch is self-hosted only, and the
-  // entry alone does not make it work in managed deployments.
+  "/v1/watch/stream",
 ] as const;
 
 /**


### PR DESCRIPTION
Watch only dialled a self-hosted gateway ingress, so on a managed assistant `getSelfHostedIngressUrl()` is null and `openSession` returns early. The press does nothing, silently — for the deployment most users are on, and for the whole local `vel up` environment, which is how this surfaced.

Live voice already solved this. `resolveWatchStreamWsUrl` now branches by deployment kind the way `resolveLiveVoiceWsUrl` does: self-hosted keeps the direct dial with the actor edge JWT, managed mints a short-lived velay token and dials velay.

## What did not have to change

The gateway's watch handler already accepted both shapes and pins either to the guardian — the velay-attested branch cross-checks `platform_user_id`, the actor-JWT branch checks the guardian binding. That was the guardian-pin PR. So the only gateway change here is the allowlist entry that lets the tunnel reach the route.

The platform mint needs no change either: the token is opaque and scoped to `{user_id, organization_id, assistant_id}` with no route in the scope, so it already authorizes this route.

## Notes for review

- **`openSession` stays synchronous** and takes a resolved URL. Resolving is a network call on the managed path, and the registration order inside `openSession` only means anything if it runs uninterrupted. The await lives in `toggleWatch`, inside the window the registered attempt already makes cancellable — so a stop pressed mid-mint still lands. Two tests cover that window, and they assert the mint was actually entered rather than assuming it (the first version of them passed for the wrong reason).
- **The re-read moved after the mint** rather than before, so the check that decides is the one nearest the dial. The cost is a token occasionally minted for a start that is then discarded; a single-use token nobody presents just expires.
- **Renames:** `mintLiveVoiceToken` → `mintVelayWsToken` and `LiveVoiceTokenError` → `VelayWsTokenError`. Both were contained in one module, so the rename does not ripple. A generic `buildVelayWsUrl` now mirrors the generic `buildSelfHostedGatewayWsUrl` that was already there, and `buildLiveVoiceWsUrl` is a thin wrapper over it.
- **The allowlist note is rewritten, not deleted.** It argued the entry was premature on its own and it was right; that is no longer true. One claim in it is corrected: managed assistants do reach the user's machine through the desktop host proxy, so the "needs a local desktop client" argument never separated managed from self-hosted. Paired assistants are what genuinely have no transport, and are still refused.

## Depends on

The velay side (per-user `?token=` validation currently hardcoded to `/v1/live-voice`) lands separately in `vellum-assistant-platform`. Until that merges, a managed dial is rejected at the tunnel. Self-hosted is unaffected either way.

Reference: JARVIS-1604, blocking the JARVIS-1557 feature merge so watch can be tested on a managed assistant first.