### PR TITLE
fix(memory): date indexed segments by when the content happened (LUM-3419)

### DIFF
--- a/assistant/src/__tests__/add-message-indexed-at-sent-time.test.ts
+++ b/assistant/src/__tests__/add-message-indexed-at-sent-time.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Memory segments are dated by when the content happened, not by when the row
+ * was written.
+ *
+ * `metadata.sentAt` carries the event time whenever persistence lags the
+ * event. The segment `created_at` reaches the embedding payload and is what
+ * graph search date-range filters on, so a row that reports a stale send time
+ * must not be recalled as if it had happened at write time.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { eq } from "drizzle-orm";
+
+mock.module("../persistence/embeddings/qdrant-client.js", () => ({
+  getQdrantClient: () => ({
+    searchWithFilter: async () => [],
+    hybridSearch: async () => [],
+    upsertPoints: async () => {},
+    deletePoints: async () => {},
+  }),
+  initQdrantClient: () => {},
+  resolveQdrantUrl: () => "http://127.0.0.1:6333",
+}));
+
+import { addMessage } from "../persistence/conversation-crud.js";
+import { getDb, getMemoryDb } from "../persistence/db-connection.js";
+import { initializeDb } from "../persistence/db-init.js";
+import {
+  conversations,
+  memorySegments,
+  messages,
+} from "../persistence/schema/index.js";
+import { setConfig } from "./helpers/set-config.js";
+
+setConfig("memory", { extraction: { useLLM: false } });
+
+await initializeDb();
+getMemoryDb();
+
+const CONVERSATION_ID = "conv-indexed-at-sent-time";
+
+const LONG_TEXT =
+  "Alice prefers VS Code over Vim for large projects and ships at the end " +
+  "of the day. She keeps the deploy runbook in the team wiki and reviews " +
+  "the rollout checklist before every release so nothing is missed.";
+
+function resetTables(): void {
+  const db = getDb();
+  getMemoryDb()!.run("DELETE FROM memory_segments");
+  db.run("DELETE FROM messages");
+  db.run("DELETE FROM conversations");
+
+  const now = Date.now();
+  db.insert(conversations)
+    .values({
+      id: CONVERSATION_ID,
+      title: null,
+      createdAt: now,
+      updatedAt: now,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalEstimatedCost: 0,
+      contextSummary: null,
+      contextCompactedMessageCount: 0,
+      contextCompactedAt: null,
+    })
+    .run();
+}
+
+function segmentTimestampsFor(messageId: string): number[] {
+  return getMemoryDb()!
+    .select({ createdAt: memorySegments.createdAt })
+    .from(memorySegments)
+    .where(eq(memorySegments.messageId, messageId))
+    .all()
+    .map((row) => row.createdAt);
+}
+
+function rowCreatedAt(messageId: string): number {
+  return getDb()
+    .select({ createdAt: messages.createdAt })
+    .from(messages)
+    .where(eq(messages.id, messageId))
+    .get()!.createdAt;
+}
+
+function blocks(text: string): string {
+  return JSON.stringify([{ type: "text", text }]);
+}
+
+beforeEach(() => {
+  resetTables();
+});
+
+describe("memory segment dating", () => {
+  test("segments are dated by sentAt when the row reports one", async () => {
+    const sentAt = Date.UTC(2026, 6, 8, 9, 15);
+    const saved = await addMessage(CONVERSATION_ID, "user", blocks(LONG_TEXT), {
+      metadata: { sentAt },
+    });
+
+    const timestamps = segmentTimestampsFor(saved.id);
+    expect(timestamps.length).toBeGreaterThan(0);
+    for (const ts of timestamps) {
+      expect(ts).toBe(sentAt);
+    }
+    // The gap is the point: without it this would pass on a segment that
+    // simply echoed the write time.
+    expect(rowCreatedAt(saved.id)).toBeGreaterThan(sentAt);
+  });
+
+  test("segments fall back to the row's own time when no sentAt is present", async () => {
+    const saved = await addMessage(CONVERSATION_ID, "user", blocks(LONG_TEXT));
+
+    const timestamps = segmentTimestampsFor(saved.id);
+    expect(timestamps.length).toBeGreaterThan(0);
+    for (const ts of timestamps) {
+      expect(ts).toBe(rowCreatedAt(saved.id));
+    }
+  });
+});

--- a/assistant/src/__tests__/add-message-indexed-at-sent-time.test.ts
+++ b/assistant/src/__tests__/add-message-indexed-at-sent-time.test.ts
@@ -23,7 +23,10 @@ mock.module("../persistence/embeddings/qdrant-client.js", () => ({
   resolveQdrantUrl: () => "http://127.0.0.1:6333",
 }));
 
-import { addMessage } from "../persistence/conversation-crud.js";
+import {
+  addMessage,
+  messageOccurredAt,
+} from "../persistence/conversation-crud.js";
 import { getDb, getMemoryDb } from "../persistence/db-connection.js";
 import { initializeDb } from "../persistence/db-init.js";
 import {
@@ -118,5 +121,20 @@ describe("memory segment dating", () => {
     for (const ts of timestamps) {
       expect(ts).toBe(rowCreatedAt(saved.id));
     }
+  });
+});
+
+describe("messageOccurredAt", () => {
+  // Every `indexMessageNow` caller dates through this, so the seams cannot
+  // disagree about which week a message belongs to.
+  test("prefers sentAt over the row's own time", () => {
+    const sentAt = Date.UTC(2026, 6, 8, 9, 15);
+    expect(messageOccurredAt({ sentAt }, Date.UTC(2026, 7, 20))).toBe(sentAt);
+  });
+
+  test("falls back to the row's own time when sentAt is absent", () => {
+    const createdAt = Date.UTC(2026, 7, 20);
+    expect(messageOccurredAt({}, createdAt)).toBe(createdAt);
+    expect(messageOccurredAt(undefined, createdAt)).toBe(createdAt);
   });
 });

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -36,7 +36,8 @@ import {
   deleteMessageById,
   getConversation,
   getMessageById,
-  messageMetadataSchema,
+  messageOccurredAt,
+  parseMessageMetadata,
   provenanceFromTrustContext,
   recordConversationPersistedSeq,
   reserveMessage,
@@ -2056,26 +2057,11 @@ export async function finalizePendingToolResultRow(
   // a successful turn into a throw.
   const row = getMessageById(rowId, conversationId);
   if (row) {
-    let provenanceTrustClass:
-      | "guardian"
-      | "trusted_contact"
-      | "unverified_contact"
-      | "unknown"
-      | undefined;
-    let automated: boolean | undefined;
-    if (row.metadata) {
-      try {
-        const parsedMeta = messageMetadataSchema.safeParse(
-          JSON.parse(row.metadata),
-        );
-        if (parsedMeta.success) {
-          provenanceTrustClass = parsedMeta.data.provenanceTrustClass;
-          automated = parsedMeta.data.automated;
-        }
-      } catch {
-        // Malformed metadata JSON — index with undefined provenance fields.
-      }
-    }
+    // Malformed metadata yields `undefined`, so provenance fields are simply
+    // absent and the row dates by its own `createdAt`.
+    const rowMetadata = parseMessageMetadata(row.metadata ?? null);
+    const provenanceTrustClass = rowMetadata?.provenanceTrustClass;
+    const automated = rowMetadata?.automated;
     try {
       await indexMessageNow(
         {
@@ -2083,7 +2069,7 @@ export async function finalizePendingToolResultRow(
           conversationId,
           role: "user",
           content: contentJson,
-          createdAt: row.createdAt,
+          createdAt: messageOccurredAt(rowMetadata, row.createdAt),
           provenanceTrustClass,
           automated,
         },

--- a/assistant/src/daemon/conversation-turn-finalize.ts
+++ b/assistant/src/daemon/conversation-turn-finalize.ts
@@ -39,6 +39,7 @@ import {
   type ConversationRow,
   getConversation,
   getMessageById,
+  messageOccurredAt,
   parseMessageMetadata,
 } from "../persistence/conversation-crud.js";
 import { getResolvedConversationDirPath } from "../persistence/conversation-directories.js";
@@ -108,7 +109,7 @@ export function buildDeferredFinalizeEffect(params: {
           conversationId,
           role: "assistant",
           content: contentJson,
-          createdAt: finalizedRow.createdAt,
+          createdAt: messageOccurredAt(metadata, finalizedRow.createdAt),
           provenanceTrustClass: metadata?.provenanceTrustClass,
           automated: metadata?.automated,
         },

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -492,6 +492,20 @@ export function isStandaloneAssistantMessage(
  * typed fields (e.g. `provenanceTrustClass`, `automated`, `subagentNotification`)
  * instead of re-implementing it.
  */
+export function parseMessageMetadata(
+  metadataJson: string | null,
+): MessageMetadata | undefined {
+  if (!metadataJson) {
+    return undefined;
+  }
+  try {
+    const parsed = messageMetadataSchema.safeParse(JSON.parse(metadataJson));
+    return parsed.success ? parsed.data : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 /**
  * When a message's content happened, as distinct from when its row was
  * written. `sentAt` carries the event time wherever persistence lags the
@@ -508,20 +522,6 @@ export function messageOccurredAt(
   createdAt: number,
 ): number {
   return typeof metadata?.sentAt === "number" ? metadata.sentAt : createdAt;
-}
-
-export function parseMessageMetadata(
-  metadataJson: string | null,
-): MessageMetadata | undefined {
-  if (!metadataJson) {
-    return undefined;
-  }
-  try {
-    const parsed = messageMetadataSchema.safeParse(JSON.parse(metadataJson));
-    return parsed.success ? parsed.data : undefined;
-  } catch {
-    return undefined;
-  }
 }
 
 /**
@@ -2359,14 +2359,10 @@ export async function addMessage(
       const parsed = metadata
         ? messageMetadataSchema.safeParse(metadata)
         : null;
-      const provenanceTrustClass = parsed?.success
-        ? parsed.data.provenanceTrustClass
-        : undefined;
-      const automated = parsed?.success ? parsed.data.automated : undefined;
-      const occurredAt = messageOccurredAt(
-        parsed?.success ? parsed.data : undefined,
-        message.createdAt,
-      );
+      const parsedMetadata = parsed?.success ? parsed.data : undefined;
+      const provenanceTrustClass = parsedMetadata?.provenanceTrustClass;
+      const automated = parsedMetadata?.automated;
+      const occurredAt = messageOccurredAt(parsedMetadata, message.createdAt);
       await indexMessageNow(
         {
           messageId: message.id,

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -492,6 +492,24 @@ export function isStandaloneAssistantMessage(
  * typed fields (e.g. `provenanceTrustClass`, `automated`, `subagentNotification`)
  * instead of re-implementing it.
  */
+/**
+ * When a message's content happened, as distinct from when its row was
+ * written. `sentAt` carries the event time wherever persistence lags the
+ * event: seconds on a queued turn, weeks on imported channel history.
+ *
+ * Every `indexMessageNow` caller dates its segments through this, so a
+ * message lands on the same point in time whether it was indexed as it
+ * arrived or re-indexed later by a backfill job. Segment `created_at`
+ * reaches the embedding payload, which graph search range-filters on, so
+ * two seams disagreeing here would put one message in two different weeks.
+ */
+export function messageOccurredAt(
+  metadata: MessageMetadata | undefined,
+  createdAt: number,
+): number {
+  return typeof metadata?.sentAt === "number" ? metadata.sentAt : createdAt;
+}
+
 export function parseMessageMetadata(
   metadataJson: string | null,
 ): MessageMetadata | undefined {
@@ -2345,16 +2363,10 @@ export async function addMessage(
         ? parsed.data.provenanceTrustClass
         : undefined;
       const automated = parsed?.success ? parsed.data.automated : undefined;
-      // Index against when the content happened, not when the row was
-      // written. The two differ whenever persistence lags the event: by
-      // seconds on a queued turn, by weeks on imported channel history.
-      // The indexed timestamp reaches the embedding payload as `created_at`,
-      // which graph search date-range filters on, so a row carrying `sentAt`
-      // would otherwise be recalled as if it had happened at import time.
-      const occurredAt =
-        parsed?.success && typeof parsed.data.sentAt === "number"
-          ? parsed.data.sentAt
-          : message.createdAt;
+      const occurredAt = messageOccurredAt(
+        parsed?.success ? parsed.data : undefined,
+        message.createdAt,
+      );
       await indexMessageNow(
         {
           messageId: message.id,

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -259,6 +259,14 @@ const backgroundToolCompletionMetadataSchema = z.object({
 
 export const messageMetadataSchema = z
   .object({
+    /**
+     * Epoch ms the content actually happened, when that differs from when
+     * the row was written. Set wherever persistence lags the event: a queued
+     * turn draining, or channel history imported long after the fact.
+     * History serialization prefers it over `createdAt` for the display
+     * timestamp, and memory indexing dates segments by it.
+     */
+    sentAt: z.number().optional(),
     userMessageChannel: channelIdSchema.optional(),
     assistantMessageChannel: channelIdSchema.optional(),
     userMessageInterface: interfaceIdSchema.optional(),
@@ -2337,13 +2345,23 @@ export async function addMessage(
         ? parsed.data.provenanceTrustClass
         : undefined;
       const automated = parsed?.success ? parsed.data.automated : undefined;
+      // Index against when the content happened, not when the row was
+      // written. The two differ whenever persistence lags the event: by
+      // seconds on a queued turn, by weeks on imported channel history.
+      // The indexed timestamp reaches the embedding payload as `created_at`,
+      // which graph search date-range filters on, so a row carrying `sentAt`
+      // would otherwise be recalled as if it had happened at import time.
+      const occurredAt =
+        parsed?.success && typeof parsed.data.sentAt === "number"
+          ? parsed.data.sentAt
+          : message.createdAt;
       await indexMessageNow(
         {
           messageId: message.id,
           conversationId: message.conversationId,
           role: message.role,
           content: message.content,
-          createdAt: message.createdAt,
+          createdAt: occurredAt,
           provenanceTrustClass,
           automated,
         },

--- a/assistant/src/persistence/conversation-plugin-facade.ts
+++ b/assistant/src/persistence/conversation-plugin-facade.ts
@@ -81,6 +81,18 @@ export async function parseMessageMetadata(
   return fn(metadataJson);
 }
 
+/**
+ * When a message's content happened, as distinct from when its row was
+ * written. Falls back to the row's own time when no event time is recorded.
+ */
+export async function messageOccurredAt(
+  metadata: MessageMetadata | undefined,
+  createdAt: number,
+): Promise<number> {
+  const { messageOccurredAt: fn } = await import("./conversation-crud.js");
+  return fn(metadata, createdAt);
+}
+
 /** Merge the given keys into a message's metadata JSON. */
 export async function updateMessageMetadata(
   messageId: string,

--- a/assistant/src/plugin-api/index.ts
+++ b/assistant/src/plugin-api/index.ts
@@ -355,6 +355,7 @@ export {
   hasLexicalTokens,
   isConversationProcessing,
   listConversations,
+  messageOccurredAt,
   parseMessageMetadata,
   searchMessageIdsLexical,
   syncMessageToDisk,

--- a/assistant/src/plugins/defaults/memory/v1/job-handlers/backfill.ts
+++ b/assistant/src/plugins/defaults/memory/v1/job-handlers/backfill.ts
@@ -1,4 +1,4 @@
-import { parseMessageMetadata } from "@vellumai/plugin-api";
+import { messageOccurredAt, parseMessageMetadata } from "@vellumai/plugin-api";
 import { and, asc, eq, gt, or } from "drizzle-orm";
 
 import type { AssistantConfig } from "../../../../../config/types.js";
@@ -7,7 +7,6 @@ import {
   resetMessageCursorCheckpoint,
   writeMessageCursorCheckpoint,
 } from "../../../../../persistence/checkpoints.js";
-import { messageOccurredAt } from "../../../../../persistence/conversation-crud.js";
 import { getDb } from "../../../../../persistence/db-connection.js";
 import {
   enqueueMemoryJob,
@@ -64,7 +63,7 @@ export async function backfillJob(
           conversationId: message.conversationId,
           role: message.role,
           content: message.content,
-          createdAt: messageOccurredAt(meta, message.createdAt),
+          createdAt: await messageOccurredAt(meta, message.createdAt),
           provenanceTrustClass: meta?.provenanceTrustClass,
           automated: meta?.automated,
         },

--- a/assistant/src/plugins/defaults/memory/v1/job-handlers/backfill.ts
+++ b/assistant/src/plugins/defaults/memory/v1/job-handlers/backfill.ts
@@ -7,6 +7,7 @@ import {
   resetMessageCursorCheckpoint,
   writeMessageCursorCheckpoint,
 } from "../../../../../persistence/checkpoints.js";
+import { messageOccurredAt } from "../../../../../persistence/conversation-crud.js";
 import { getDb } from "../../../../../persistence/db-connection.js";
 import {
   enqueueMemoryJob,
@@ -63,7 +64,7 @@ export async function backfillJob(
           conversationId: message.conversationId,
           role: message.role,
           content: message.content,
-          createdAt: message.createdAt,
+          createdAt: messageOccurredAt(meta, message.createdAt),
           provenanceTrustClass: meta?.provenanceTrustClass,
           automated: meta?.automated,
         },


### PR DESCRIPTION
## TL;DR

Messages persisted long after the fact were indexed into memory as though they had just happened. That timestamp is filterable, so imported Slack history answered "what was said today" and went missing from the weeks it actually belonged to. Index by when the content happened instead.

Context: LUM-3419. Independent of #41040, which fixes the display side.

## The reader chain

The indexed timestamp is not inert. It travels:

1. `addMessage` passes the row's `createdAt` into `indexMessageNow`
2. `indexMessageNow` writes it to `memory_segments.created_at`
3. `v1/job-handlers/embedding.ts` puts it on the embedding payload as `created_at`
4. `v1/graph/graph-search.ts` builds Qdrant range filters on that key from a query's `dateRange`

So a row written weeks after its content happened is both a false positive for recent date ranges and a false negative for the range it belongs to.

Note there are two `graph-search.ts` files. The one carrying the date filter is `v1/graph/graph-search.ts`, the hybrid node search path reached from `context-search/sources/memory.ts`. The non-v1 file of the same name is embedding plumbing and has no filter.

## Depends on #41040

That PR is what writes `sentAt` onto backfilled Slack rows. Merge it first, or this one is inert for the Slack case. It is not inert generally: any row whose persistence lags its event, a queued turn included, was being indexed at write time.

## The fix

Index against `metadata.sentAt` when present, falling back to `createdAt`, through a single shared derivation.

`messageOccurredAt(metadata, createdAt)` lives beside `parseMessageMetadata` and every row-derived `indexMessageNow` caller goes through it: `addMessage`, the turn finalize, the tool-result finalize, and the v1 memory backfill job. That last one is why this is centralized rather than local to `addMessage`: it re-indexes existing rows, so leaving it on `createdAt` would date the same message differently depending on whether it was indexed as it arrived or re-indexed later.

`conversations-import-routes.ts` keeps passing the true event time from the imported payload directly; it never derives from row metadata, so routing it through this helper would be a regression.

The tool-result finalize also carried a hand-rolled copy of the metadata parse, which is now the canonical `parseMessageMetadata`.

`sentAt` already means exactly this: "when the content happened, as distinct from when the row was written." Using it rather than adding a parameter means no call site changes, and the queued-turn case is corrected in the same stroke, where the same bug exists at a skew of seconds instead of weeks.

`sentAt` is now declared on `messageMetadataSchema` instead of surviving on `.passthrough()`. It was already written by three call sites and read by history serialization; a field the persistence layer now depends on should be in the contract rather than an accident of schema looseness.

## What changes for the user

| | Before | After |
| --- | --- | --- |
| Recall of imported history by date | Dated at import time | Dated when sent |
| Recall of a queued turn | Dated at drain time | Dated when sent |
| Message with no `sentAt` | Dated at write time | Unchanged |
| Which messages get indexed | Unchanged | Unchanged |

This changes only the timestamp attached to a segment. Nothing changes about which content is indexed, how it is segmented, or trust gating.

## Testing

`add-message-indexed-at-sent-time.test.ts` asserts segments carry `sentAt` when the row reports one, **and** that the row's own `createdAt` is strictly later. The gap is what makes the test meaningful: asserting the value alone would pass on a segment that simply echoed the write time. Further cases cover the fallback and the shared derivation directly.

Typecheck, lint, and prettier pass. The test suite was not run locally by design; CI at this exact HEAD is the authority.

## Deliberately not here

- **No reindex of existing segments.** Forward-only. On the dogfood install the affected population is 125 skewed Slack rows out of 1,889, so a migration is not worth its risk.
- **Nothing about whether imported history belongs in memory at all.** Merely binding a channel currently ingests another party's DM archive into memory and search. That is a product question, not a dating bug, and it is not settled here.
