### PR TITLE
fix(web): put a conversation you can see beside an app, or a new one

### DIFF
--- a/clients/web/src/domains/chat/app-viewer-actions.test.ts
+++ b/clients/web/src/domains/chat/app-viewer-actions.test.ts
@@ -132,13 +132,21 @@ describe("handleAppViewerAction — set_view", () => {
     expect(useViewerStore.getState().mainView).toBe("app");
   });
 
-  it("'split' is a no-op with no active conversation", () => {
+  it("'split' with no conversation starts one to put beside the app", () => {
     useConversationStore.setState({ activeConversationId: null });
     useViewerStore.setState({ mainView: "app", openedAppState: SAMPLE_APP });
+    const ctx = makeCtx(false);
 
-    handleAppViewerAction(makeCtx(false), "set_view", { view: "split" });
+    handleAppViewerAction(ctx, "set_view", { view: "split" });
 
-    expect(useViewerStore.getState().mainView).toBe("app");
+    const conversation = useConversationStore.getState();
+    const newId = conversation.activeConversationId;
+    expect(newId).toBeTruthy();
+    expect(conversation.draftConversationIds.has(newId!)).toBe(true);
+    expect(conversation.editingConversationId).toBe(newId);
+    expect(useViewerStore.getState().mainView).toBe("app-editing");
+    const [url] = ctx.navigate.mock.calls[0];
+    expect(url).toContain(`/assistant/conversations/${newId}`);
   });
 });
 

--- a/clients/web/src/domains/chat/app-viewer-actions.ts
+++ b/clients/web/src/domains/chat/app-viewer-actions.ts
@@ -19,7 +19,8 @@
  * - `set_view` ({ view }) — moves the app panel: `"split"` (side by side with
  *   chat), `"full"` (full-width), or `"chat"` (close the app). Side-by-side has
  *   no mobile layout, so `"split"` is ignored on mobile (the app keeps its
- *   full-screen overlay).
+ *   full-screen overlay). On a wide viewport it uses the open conversation,
+ *   and starts one when none is open.
  *
  * Stateless and framework-agnostic: stores are read via `getState()` and
  * navigation / viewport arrive through `ctx`, so this is unit-testable.
@@ -63,6 +64,19 @@ function relayPrompt(
   );
 }
 
+/**
+ * Select `conversationId` and land on it, keeping an open app beside it
+ * rather than dismissing the app for the chat.
+ */
+function goToConversation(
+  ctx: AppViewerActionContext,
+  conversationId: string,
+): void {
+  useConversationStore.getState().setActiveConversationId(conversationId);
+  keepOpenAppBesideConversation(conversationId);
+  ctx.navigate(routes.conversation(conversationId));
+}
+
 function openConversation(
   ctx: AppViewerActionContext,
   data?: Record<string, unknown>,
@@ -72,9 +86,7 @@ function openConversation(
   if (!conversationId) {
     return;
   }
-  useConversationStore.getState().setActiveConversationId(conversationId);
-  keepOpenAppBesideConversation(conversationId);
-  ctx.navigate(routes.conversation(conversationId));
+  goToConversation(ctx, conversationId);
 }
 
 function setView(
@@ -97,10 +109,14 @@ function setView(
       }
       const conversationId =
         useConversationStore.getState().activeConversationId;
-      if (!conversationId) {
+      if (conversationId) {
+        keepOpenAppBesideConversation(conversationId);
         return;
       }
-      keepOpenAppBesideConversation(conversationId);
+      // Split view is a chat beside the app, so it needs a conversation to
+      // put there. Starting one is what the request asks for; ignoring it
+      // leaves the app full-width with no way to talk about it.
+      goToConversation(ctx, createDraftConversationId());
       return;
     }
     default:

--- a/clients/web/src/domains/chat/app-viewer-actions.ts
+++ b/clients/web/src/domains/chat/app-viewer-actions.ts
@@ -114,8 +114,7 @@ function setView(
         return;
       }
       // Split view is a chat beside the app, so it needs a conversation to
-      // put there. Starting one is what the request asks for; ignoring it
-      // leaves the app full-width with no way to talk about it.
+      // put there.
       goToConversation(ctx, createDraftConversationId());
       return;
     }

--- a/clients/web/src/domains/chat/document-viewer-page.tsx
+++ b/clients/web/src/domains/chat/document-viewer-page.tsx
@@ -21,6 +21,7 @@ import {
   documentsByIdPdfGet,
 } from "@/generated/daemon/sdk.gen";
 import { useBusSubscription } from "@/hooks/use-bus-subscription";
+import { createDraftConversationId } from "@/domains/chat/utils/conversation-selection";
 import { useViewerStore } from "@/stores/viewer-store";
 import type { DocumentContent } from "@/types/document-types";
 import {
@@ -138,9 +139,7 @@ export function DocumentViewerPage() {
     const conversationId =
       doc.conversationId ||
       getEditChatConversationId(assistantId, surfaceId) ||
-      (typeof globalThis.crypto?.randomUUID === "function"
-        ? globalThis.crypto.randomUUID()
-        : `draft-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+      createDraftConversationId();
 
     setEditChatConversationId(assistantId, surfaceId, conversationId);
 

--- a/clients/web/src/domains/chat/hooks/use-draft-persistence.ts
+++ b/clients/web/src/domains/chat/hooks/use-draft-persistence.ts
@@ -14,8 +14,9 @@
  * - **Cold-load restore**: when a conversation first becomes active, restore its
  *   saved draft into an empty composer.
  *
- * Drafts are keyed by `activeConversationId`, which is reload-stable: new chats
- * carry a `draft-…` id in the URL and the id is re-derived from the URL on load.
+ * Drafts are keyed by `activeConversationId`, which is reload-stable because a
+ * new chat's client-minted key is in the URL and is re-derived from it on load.
+ * Nothing distinguishes that key by its shape.
  *
  * Self-contained — reads both stores directly, so it mounts once with no props.
  */

--- a/clients/web/src/hooks/use-edit-app.test.tsx
+++ b/clients/web/src/hooks/use-edit-app.test.tsx
@@ -17,6 +17,10 @@ import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { useConversationStore } from "@/stores/conversation-store";
 import { useViewerStore, type OpenedAppState } from "@/stores/viewer-store";
 import { routes } from "@/utils/routes";
+import {
+  getEditChatConversationId,
+  setEditChatConversationId,
+} from "@/utils/edit-chat-session";
 
 import { useEditApp } from "./use-edit-app";
 
@@ -42,6 +46,8 @@ const APP: OpenedAppState = {
   html: "<html></html>",
 };
 const CONV_ID = "conv-edit";
+const ASSISTANT_ID = "asst-1";
+const REMEMBERED_ID = "conv-remembered";
 const LIBRARY_PATH = "/assistant/library/app-42";
 const CONVERSATION_PATH = `/assistant/conversations/${CONV_ID}`;
 
@@ -94,7 +100,7 @@ beforeEach(() => {
     setEditingConversationId:
       setEditingConversationIdMock as unknown as typeof conversationSnapshot.setEditingConversationId,
   });
-  useResolvedAssistantsStore.setState({ activeAssistantId: "asst-1" });
+  useResolvedAssistantsStore.setState({ activeAssistantId: ASSISTANT_ID });
 });
 
 afterEach(() => {
@@ -155,6 +161,34 @@ describe("useEditApp", () => {
     expect(
       useConversationStore.getState().draftConversationIds.has(mintedId!),
     ).toBe(true);
+  });
+
+  test("with nothing on screen, returns to the thread this app was last edited in", () => {
+    // GIVEN this app has a remembered edit thread, and nothing is on screen
+    setEditChatConversationId(ASSISTANT_ID, APP.appId, REMEMBERED_ID);
+    useConversationStore.setState({ activeConversationId: null });
+    const { result } = renderHook(() => useEditApp(), { wrapper });
+
+    // WHEN the user clicks Edit
+    act(() => result.current(APP));
+
+    // THEN that thread is reused rather than a fresh one minted, so repeated
+    // Edit clicks on one app keep iterating in the same conversation
+    expect(setEditingConversationIdMock).toHaveBeenCalledWith(REMEMBERED_ID);
+  });
+
+  test("the conversation on screen wins over the remembered thread", () => {
+    // GIVEN a remembered thread for this app, and a different one on screen
+    setEditChatConversationId(ASSISTANT_ID, APP.appId, REMEMBERED_ID);
+    const { result } = renderHook(() => useEditApp(), { wrapper });
+
+    // WHEN the user clicks Edit
+    act(() => result.current(APP));
+
+    // THEN the visible conversation is bound, and becomes what the app
+    // remembers, so a later Edit with nothing on screen returns here
+    expect(setEditingConversationIdMock).toHaveBeenCalledWith(CONV_ID);
+    expect(getEditChatConversationId(ASSISTANT_ID, APP.appId)).toBe(CONV_ID);
   });
 
   test("on a mobile viewport, binds the edit conversation, navigates, and minimizes the app to the chat strip (no split)", () => {

--- a/clients/web/src/hooks/use-edit-app.test.tsx
+++ b/clients/web/src/hooks/use-edit-app.test.tsx
@@ -16,7 +16,6 @@ mock.module("@/hooks/use-is-mobile", () => ({
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { useConversationStore } from "@/stores/conversation-store";
 import { useViewerStore, type OpenedAppState } from "@/stores/viewer-store";
-import { setEditChatConversationId } from "@/utils/edit-chat-session";
 import { routes } from "@/utils/routes";
 
 import { useEditApp } from "./use-edit-app";
@@ -80,10 +79,6 @@ beforeEach(() => {
   setEditingConversationIdMock.mockReset();
   window.sessionStorage.clear();
 
-  // Seed the per-app edit conversation so the resolved id is deterministic
-  // (otherwise the hook mints a random UUID).
-  setEditChatConversationId("asst-1", APP.appId, CONV_ID);
-
   useViewerStore.setState({
     activeAppId: null,
     openedAppState: null,
@@ -93,7 +88,9 @@ beforeEach(() => {
     minimizeApp: minimizeAppMock,
   });
   useConversationStore.setState({
-    activeConversationId: null,
+    // The conversation on screen, which is what Edit puts beside the app.
+    activeConversationId: CONV_ID,
+    draftConversationIds: new Set(),
     setEditingConversationId:
       setEditingConversationIdMock as unknown as typeof conversationSnapshot.setEditingConversationId,
   });
@@ -140,6 +137,24 @@ describe("useEditApp", () => {
     // Desktop uses the split view, not the mobile minimized strip.
     expect(minimizeAppMock).not.toHaveBeenCalled();
     expect(currentPath()).toBe(routes.conversation(CONV_ID));
+  });
+
+  test("starts a conversation, registered as a draft, when none is selected", () => {
+    // GIVEN nothing is on screen to put beside the app
+    useConversationStore.setState({ activeConversationId: null });
+    const { result } = renderHook(() => useEditApp(), { wrapper });
+
+    // WHEN the user clicks Edit
+    act(() => result.current(APP));
+
+    // THEN a fresh key is bound, and it is registered as a draft so the pane
+    // paints an empty thread rather than waiting on history that is not there
+    const mintedId = setEditingConversationIdMock.mock.calls[0]?.[0];
+    expect(typeof mintedId).toBe("string");
+    expect(mintedId).not.toBe(CONV_ID);
+    expect(
+      useConversationStore.getState().draftConversationIds.has(mintedId!),
+    ).toBe(true);
   });
 
   test("on a mobile viewport, binds the edit conversation, navigates, and minimizes the app to the chat strip (no split)", () => {

--- a/clients/web/src/hooks/use-edit-app.ts
+++ b/clients/web/src/hooks/use-edit-app.ts
@@ -39,12 +39,10 @@ export function useEditApp(): (app: OpenedAppState) => void {
       if (!assistantId) {
         return;
       }
-      // The conversation already on screen, or a new one. A thread the user
-      // can see beats one resolved from somewhere they cannot: a remembered
-      // id is invisible, expires on its own, and puts them somewhere they did
-      // not ask for. A new one is registered as a draft like every other
-      // client-minted key, so the pane paints an empty thread rather than the
-      // skeleton it holds while real history loads.
+      // The conversation on screen, so the pane opens on something the user
+      // chose. A new one is registered as a draft like every client-minted
+      // key, which is what lets the pane paint an empty thread rather than
+      // wait on history it does not have.
       const convId =
         useConversationStore.getState().activeConversationId ??
         createDraftConversationId();

--- a/clients/web/src/hooks/use-edit-app.ts
+++ b/clients/web/src/hooks/use-edit-app.ts
@@ -6,6 +6,10 @@ import { useIsMobile } from "@/hooks/use-is-mobile";
 import { useConversationStore } from "@/stores/conversation-store";
 import { useViewerStore, type OpenedAppState } from "@/stores/viewer-store";
 import { createDraftConversationId } from "@/domains/chat/utils/conversation-selection";
+import {
+  getEditChatConversationId,
+  setEditChatConversationId,
+} from "@/utils/edit-chat-session";
 import { routes } from "@/utils/routes";
 
 /**
@@ -39,13 +43,17 @@ export function useEditApp(): (app: OpenedAppState) => void {
       if (!assistantId) {
         return;
       }
-      // The conversation on screen, so the pane opens on something the user
-      // chose. A new one is registered as a draft like every client-minted
-      // key, which is what lets the pane paint an empty thread rather than
-      // wait on history it does not have.
+      // The conversation on screen wins, so the pane opens on something the
+      // user chose. With nothing on screen, the per-app memo keeps repeated
+      // Edit clicks in one thread. A minted id is registered as a draft like
+      // every client-minted key, which is what lets the pane paint an empty
+      // thread rather than wait on history it does not have. Same order as
+      // the document surface in `document-viewer-page`.
       const convId =
         useConversationStore.getState().activeConversationId ??
+        getEditChatConversationId(assistantId, app.appId) ??
         createDraftConversationId();
+      setEditChatConversationId(assistantId, app.appId, convId);
 
       const viewer = useViewerStore.getState();
       if (viewer.activeAppId !== app.appId || !viewer.openedAppState) {

--- a/clients/web/src/hooks/use-edit-app.ts
+++ b/clients/web/src/hooks/use-edit-app.ts
@@ -5,10 +5,7 @@ import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { useConversationStore } from "@/stores/conversation-store";
 import { useViewerStore, type OpenedAppState } from "@/stores/viewer-store";
-import {
-  getEditChatConversationId,
-  setEditChatConversationId,
-} from "@/utils/edit-chat-session";
+import { createDraftConversationId } from "@/domains/chat/utils/conversation-selection";
 import { routes } from "@/utils/routes";
 
 /**
@@ -42,10 +39,15 @@ export function useEditApp(): (app: OpenedAppState) => void {
       if (!assistantId) {
         return;
       }
+      // The conversation already on screen, or a new one. A thread the user
+      // can see beats one resolved from somewhere they cannot: a remembered
+      // id is invisible, expires on its own, and puts them somewhere they did
+      // not ask for. A new one is registered as a draft like every other
+      // client-minted key, so the pane paints an empty thread rather than the
+      // skeleton it holds while real history loads.
       const convId =
-        getEditChatConversationId(assistantId, app.appId) ??
-        crypto.randomUUID();
-      setEditChatConversationId(assistantId, app.appId, convId);
+        useConversationStore.getState().activeConversationId ??
+        createDraftConversationId();
 
       const viewer = useViewerStore.getState();
       if (viewer.activeAppId !== app.appId || !viewer.openedAppState) {


### PR DESCRIPTION
## TL;DR

Three places decided which conversation goes beside a surface, and each got it wrong differently. Part of LUM-3423, but independent of the migration: none of this is deleted by the later stages.

## What was wrong

**Edit put you in a thread you cannot see.** It resolved a per-app conversation out of `sessionStorage`, keyed by assistant and app, expiring after four hours. So Edit lands you in a thread you did not choose and cannot see listed, and quietly a different one once the entry ages out. It now uses the conversation already on screen and starts one only when there is none, which is also the behaviour the pane design settles on.

**`set_view({ view: "split" })` was silence.** It returned early when nothing was selected, so an app asking for a chat beside itself got nothing. It starts one. The verb is a documented contract in the bundled app-builder skill and deployed apps call it, so this widens what it does rather than changing it.

**Two places minted a key nothing recorded.** Both the app path and the document viewer's feedback thread used a bare `crypto.randomUUID()`. Nothing registers that as a draft, so the transcript waits on history for a conversation that has none and paints a skeleton over what should be an empty thread. `createDraftConversationId` records it, which is the contract `use-send-message` already completes when the first message resolves the key.

## Behaviour change worth naming

Pressing Edit twice on the same app no longer returns you to a remembered thread. It uses whichever conversation is on screen. That is the point rather than a side effect: a remembered-but-invisible thread is the same class of thing as an app that is open but rendered by nothing, and the design settled on making selection and visibility the same fact.

## Scope

`edit-chat-session` stays. The document viewer keys it by surface for repeated feedback on one document, which is a different feature that this does not touch.

## Which conversation Edit opens

Three steps, in this order, matching what the document surface already does in `document-viewer-page`:

1. the conversation on screen, so the pane opens on something the user chose;
2. failing that, the per-app `edit-chat-session` memo, so repeated Edit clicks on one app keep iterating in one thread;
3. failing that, a freshly minted id, registered as a draft so the pane paints an empty thread instead of waiting on history that does not exist.

The defect was step 2 sitting above step 1: Edit resurrected a remembered thread over the conversation the user was looking at, and that thread could have expired out from under them. An earlier version of this branch deleted the memo outright, which fixed the ordering by removing a working behaviour, and left the document surface answering the same question a different way. Demoting it does the same job without either cost.
## Checked and not fixed

`useSurfaceOnOpen` looked like the same shape as the seen-state bug in #40978: mounted in `ChatLayout`, premised on "the user opened it", no visibility guard. It is not reachable. The conversation loader refuses to select background or scheduled runs implicitly, and `shouldSurfaceConversation` requires `surfacedAt == null`, so an unsurfaced run only becomes the selected conversation by being opened, which is exactly when surfacing it is right.

The other is Edit on the standalone Library route, raised in review. There `activeConversationId` can hold a conversation that is nowhere on screen, because that route never touches the workspace selection, so Edit prefers something invisible. Selection is the only signal this hook has, and separating it from visibility would mean a route check inside a deeply mounted hook, which is the shape removed from `useMarkSeenOnOpen` in #40978 by hoisting the route read to `ChatLayout`. There is no equivalent layout above `LibraryDetailPage`.

It closes in LUM-3424, when the route stops keeping its own state and leaving the workspace clears the panes. The selection is then empty on that route and the per-app memo answers instead, which is why this branch keeps that memo rather than deleting it. Noted on the ticket.

## Verification

`tsc --noEmit`, `eslint` and the pinned Prettier are clean. The eight decisions across the three call sites were enumerated outside the suite, since local test runs are blocked here. `use-edit-app`'s existing cases move from a seeded `sessionStorage` entry to a selected conversation, and gain the no-selection case.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41042" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

