### PR TITLE
fix(telegram): tell an unclaimed channel's first sender how to claim it

### DIFF
--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -900,6 +900,7 @@ export async function handleChannelInbound({
       verdict: inboundVerdict,
       guardianNotified,
       handshakeInProgress,
+      sourceChannel,
     });
     let replyDelivered = false;
     if (replyCallbackUrl) {

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.test.ts
@@ -496,6 +496,9 @@ describe("enforceIngressAcl — deny copy names the guardian from the verdict", 
         sourceMetadata: withVerdict({
           trustClass: "unknown",
           canonicalSenderId: "stranger-1",
+          // A guardian holds the channel but carries no display name. Without
+          // the binding this is an unclaimed channel, which has its own copy.
+          guardianExternalUserId: "guardian-1",
         }),
       }),
     );
@@ -534,6 +537,80 @@ describe("enforceIngressAcl — deny copy names the guardian from the verdict", 
     expect(dm).toBeDefined();
     expect((dm!.payload as { text: string }).text).toContain("Alice Guardian");
     expect(guardianDeliveryCalls.length).toBe(0);
+  });
+});
+
+describe("enforceIngressAcl: an unclaimed channel is told how to claim itself", () => {
+  test("no guardian of any kind on Telegram points the sender at /start", async () => {
+    const result = await enforceIngressAcl(
+      makeParams({
+        sourceMetadata: withVerdict({
+          trustClass: "unknown",
+          canonicalSenderId: "stranger-1",
+        }),
+      }),
+    );
+
+    expect(result.earlyResponse!.reason).toBe("not_a_member");
+    const reply = deliverReplyCalls.at(-1)!.payload as { text: string };
+    expect(reply.text).toContain("/start");
+    // The copy replaces the dead end rather than joining it.
+    expect(reply.text).not.toContain("tried talking to me");
+    // Read from the verdict: this path must stay free of the guardian
+    // delivery IPC it was built without.
+    expect(guardianDeliveryCalls.length).toBe(0);
+  });
+
+  test("a guardian known only by principal is not advertised as claimable", async () => {
+    await enforceIngressAcl(
+      makeParams({
+        sourceMetadata: withVerdict({
+          trustClass: "unknown",
+          canonicalSenderId: "stranger-1",
+          // No same-channel binding, so `guardianExternalUserId` is unset
+          // while a guardian plainly exists.
+          guardianPrincipalId: "principal-1",
+        }),
+      }),
+    );
+
+    const reply = deliverReplyCalls.at(-1)!.payload as { text: string };
+    expect(reply.text).not.toContain("/start");
+  });
+
+  test("a failed resolution is not read as an unclaimed channel", async () => {
+    await enforceIngressAcl(
+      makeParams({
+        sourceMetadata: withVerdict({
+          trustClass: "unknown",
+          canonicalSenderId: "stranger-1",
+          resolutionFailed: true,
+        }),
+      }),
+    );
+
+    const reply = deliverReplyCalls.at(-1)!.payload as { text: string };
+    expect(reply.text).not.toContain("/start");
+  });
+
+  test("a channel without self-claim is never pointed at /start", async () => {
+    await enforceIngressAcl(
+      makeParams({
+        sourceChannel: "slack",
+        canonicalSenderId: "U123STRANGER",
+        rawSenderId: "U123STRANGER",
+        sourceMetadata: withVerdict({
+          trustClass: "unknown",
+          canonicalSenderId: "U123STRANGER",
+        }),
+      }),
+    );
+
+    for (const call of deliverReplyCalls) {
+      expect(
+        String((call.payload as { text?: string }).text ?? ""),
+      ).not.toContain("/start");
+    }
   });
 });
 

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -39,6 +39,7 @@ import {
   verdictMemberFromVerdict,
   verdictUsability,
 } from "../../trust-verdict-consumer.js";
+import { channelSupportsGuardianSelfClaim } from "./guardian-activation-intercept.js";
 
 const log = getLogger("runtime-http");
 
@@ -55,6 +56,44 @@ function resolveGuardianLabel(verdict: TrustVerdict | undefined): string {
 }
 
 /**
+ * Whether this channel has no guardian at all and can be claimed with
+ * `/start`.
+ *
+ * Every guardian field is checked, not just the channel binding. The resolver
+ * can classify a guardian by principal with no binding on this channel, which
+ * leaves `guardianExternalUserId` unset while a guardian plainly exists. The
+ * activation stage would admit a `/start` in that state, so keying on the
+ * binding alone would advertise a claim over someone else's assistant.
+ *
+ * Read from the verdict rather than from a guardian-delivery lookup:
+ * `guardianExternalUserId` is stamped from the resolver's
+ * guardian-for-channel binding, which is resolved independently of the
+ * sender, so its absence means the channel is unheld. Taking it from the
+ * verdict keeps this path free of the guardian-delivery IPC it was
+ * deliberately built without.
+ *
+ * A failed resolution is not evidence of an unheld channel, so it degrades to
+ * the ordinary copy rather than advertising a `/start` the activation stage
+ * would then refuse.
+ */
+function isUnclaimedSelfClaimChannel(
+  sourceChannel: ChannelId,
+  verdict: TrustVerdict | undefined,
+): boolean {
+  if (!channelSupportsGuardianSelfClaim(sourceChannel)) {
+    return false;
+  }
+  if (verdict === undefined || verdict.resolutionFailed) {
+    return false;
+  }
+  return (
+    verdict.guardianExternalUserId === undefined &&
+    verdict.guardianPrincipalId === undefined &&
+    verdict.guardianDisplayName === undefined
+  );
+}
+
+/**
  * Compose the requester-facing reply for a denied inbound, keyed on the
  * access-request outcome. Single source for this copy — the not_a_member,
  * inactive-member, and admission-floor deny lanes all route through it.
@@ -63,6 +102,11 @@ function resolveGuardianLabel(verdict: TrustVerdict | undefined): string {
  *   code is live; tell the sender their next step. The code is DM'd directly
  *   to the requester on Slack but relayed via the guardian elsewhere, so the
  *   copy covers both.
+ * - Nobody holds the channel yet: both lanes below tell the sender to wait on
+ *   a guardian who does not exist, so name the step that does work instead.
+ *   Copy only, and grants nothing: `guardian-activation-intercept.ts` already
+ *   admits a bare `/start` from any sender while the channel is unclaimed, so
+ *   this describes that behaviour rather than widening it.
  * - Guardian notified: the standard "I'll let <guardian> know" copy.
  * - Otherwise: the plain not-approved copy.
  */
@@ -70,9 +114,13 @@ export function composeAccessDenialReply(params: {
   verdict: TrustVerdict | undefined;
   guardianNotified: boolean;
   handshakeInProgress: boolean;
+  sourceChannel: ChannelId;
 }): string {
   if (params.handshakeInProgress) {
     return `Your access request was approved! Reply here with the 6-digit verification code to finish connecting — if you don't have it, ask ${resolveGuardianLabel(params.verdict)} for it.`;
+  }
+  if (isUnclaimedSelfClaimChannel(params.sourceChannel, params.verdict)) {
+    return "I'm not connected to anyone yet. Send /start and I'll walk you through it.";
   }
   if (params.guardianNotified) {
     return `Hmm looks like you don't have access to talk to me. I'll let ${resolveGuardianLabel(params.verdict)} know you tried talking to me and get back to you.`;
@@ -587,6 +635,7 @@ export async function enforceIngressAcl(
           verdict,
           guardianNotified,
           handshakeInProgress,
+          sourceChannel,
         });
         let replyDelivered = false;
         if (replyCallbackUrl) {
@@ -837,6 +886,7 @@ export async function enforceIngressAcl(
             verdict,
             guardianNotified,
             handshakeInProgress,
+            sourceChannel,
           });
           let inactiveReplyDelivered = false;
           if (replyCallbackUrl) {

--- a/assistant/src/runtime/routes/inbound-stages/guardian-activation-intercept.ts
+++ b/assistant/src/runtime/routes/inbound-stages/guardian-activation-intercept.ts
@@ -64,6 +64,17 @@ function markProcessed(messageId: string): void {
   processedMessageIds.set(messageId, Date.now());
 }
 
+/**
+ * Whether a channel lets its first user claim it by sending a bare `/start`.
+ *
+ * Read both by the gate below and by the denial copy in `acl-enforcement.ts`,
+ * so the instruction given to a stranger cannot name a channel that would not
+ * honour it. Telegram is the only one today.
+ */
+export function channelSupportsGuardianSelfClaim(channel: ChannelId): boolean {
+  return channel === "telegram";
+}
+
 export async function handleGuardianActivationIntercept(
   params: GuardianActivationInterceptParams,
 ): Promise<Record<string, unknown> | null> {
@@ -93,8 +104,7 @@ export async function handleGuardianActivationIntercept(
     return null;
   }
 
-  // Only proceed for Telegram (can be extended later)
-  if (sourceChannel !== "telegram") {
+  if (!channelSupportsGuardianSelfClaim(sourceChannel)) {
     return null;
   }
 


### PR DESCRIPTION
## TL;DR

A stranger who messages a Telegram bot that nobody has claimed yet is told to wait on a guardian who does not exist. This replaces that dead end with the step that actually works: send `/start`.

Copy only. No access decision changes.

## What a person sees

| | Before | After |
| -- | -- | -- |
| First message to an unclaimed bot that is not `/start` | "Hmm looks like you don't have access to talk to me. I'll let my human know you tried talking to me and get back to you." Nobody is listening, so nothing follows. | "I'm not connected to anyone yet. Send /start and I'll walk you through it." |
| First message is a bare `/start` | Guardian verification begins | Unchanged |
| Any channel that has a guardian | Unchanged | Unchanged |
| Slack, Discord, and every other channel | Unchanged | Unchanged |

## Why this is safe

**It grants nothing.** `guardian-activation-intercept.ts` already admits a bare `/start` from any sender while the channel is unclaimed. The new reply describes that behaviour instead of leaving the sender at a dead end. Nobody can do anything after this change that they could not do before it.

**The predicate is deliberately conservative.** It fires only when the verdict carries no guardian signal of any kind. The resolver can classify a guardian by principal with no binding on the current channel, which leaves `guardianExternalUserId` unset while a guardian plainly exists; keying on the binding alone would have advertised a claim over someone else's assistant. All three guardian fields are checked.

**A failed resolution is not read as an unclaimed channel.** `resolutionFailed` degrades to the ordinary copy, so a gateway that could not answer never advertises a `/start` the activation stage would then refuse.

**No new IPC.** The existing tests assert zero guardian-delivery reads on this path, an invariant added when the guardian name moved onto the verdict. The first draft of this change reintroduced that lookup; it now reads `guardianExternalUserId` from the verdict, which the resolver stamps from a guardian-for-channel binding resolved independently of the sender. The invariant is asserted again in the new tests.

**The channel gate has one definition.** `channelSupportsGuardianSelfClaim` is exported from the activation stage and read by both it and the denial copy, so the instruction given to a stranger cannot name a channel that would not honour it.

## Tests

Four cases, including two sensitivity checks that the guards matter: a guardian known only by principal is not advertised as claimable, and a channel without self-claim is never pointed at `/start`.

One existing fixture changed. "absent guardianDisplayName degrades to the default reference" previously used a verdict with no guardian fields at all while asserting the "I'll let my human know" copy, which is the dead end this fixes. It now uses a bound guardian carrying no display name, which is the state that actually produces that degradation in production.

## Scope

This is the copy half of the identity-verification problem in JARVIS-1574. The underlying gap is that activation only triggers on a bare `/start`, and a stale binding from an earlier setup skips it entirely. Widening that trigger changes who can start a guardian claim, so it is deliberately not in this change and wants a reproduction against a real bot first.

Separately: JARVIS-1574's point 2, that readiness reports green on an indeterminate check, is wrong. `channel-readiness-service.ts` computes readiness with `c.passed && !c.indeterminate`. Corrected in a comment on that issue.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41043" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->