### PR TITLE
fix(slack): report backfilled history at its original send time (LUM-3419)

### DIFF
--- a/assistant/src/__tests__/dm-backfill.test.ts
+++ b/assistant/src/__tests__/dm-backfill.test.ts
@@ -180,6 +180,8 @@ function readPersistedSlackRows(): Array<{
   provenanceSourceChannel: string | undefined;
   provenanceGuardianExternalUserId: string | undefined;
   provenanceRequesterIdentifier: string | undefined;
+  sentAt: number | undefined;
+  createdAt: number;
 }> {
   const db = getDb();
   return db
@@ -187,6 +189,7 @@ function readPersistedSlackRows(): Array<{
       role: messages.role,
       content: messages.content,
       metadata: messages.metadata,
+      createdAt: messages.createdAt,
     })
     .from(messages)
     .all()
@@ -231,6 +234,9 @@ function readPersistedSlackRows(): Array<{
           typeof envelope.provenanceRequesterIdentifier === "string"
             ? envelope.provenanceRequesterIdentifier
             : undefined,
+        sentAt:
+          typeof envelope.sentAt === "number" ? envelope.sentAt : undefined,
+        createdAt: row.createdAt,
       };
     });
 }
@@ -586,6 +592,32 @@ describe("PR 23 — Slack DM cold-start backfill", () => {
     expect(rows.length).toBe(3);
     const texts = rows.map((r) => r.content).sort();
     expect(texts).toEqual(["older A", "older B", "older D"]);
+  });
+
+  test("backfilled rows carry the original send time as sentAt", async () => {
+    // History serialization prefers `sentAt` for the display timestamp, so a
+    // row without it reads as having arrived when the import ran.
+    const sentAt = Date.UTC(2026, 6, 8, 9, 15);
+    backfillDmMock.mockImplementation(async () => [
+      makeBackfilledMessage({
+        id: String(sentAt / 1000),
+        text: "six weeks old",
+        timestamp: sentAt,
+      }),
+    ]);
+
+    await handleChannelInbound(
+      buildDmRequest("live new DM"),
+      noopProcessMessage,
+      TEST_BEARER_TOKEN,
+    );
+
+    const [row] = readPersistedSlackRows();
+    expect(row).toBeDefined();
+    expect(row.sentAt).toBe(sentAt);
+    // The row is still written now; only the reported send time is historical.
+    // Asserting the gap is what proves `sentAt` is not just echoing createdAt.
+    expect(row.createdAt).toBeGreaterThan(sentAt);
   });
 
   test("backfill refuses history rows carrying a secret, keeping the rest", async () => {

--- a/assistant/src/persistence/conversation-crud.ts
+++ b/assistant/src/persistence/conversation-crud.ts
@@ -259,6 +259,14 @@ const backgroundToolCompletionMetadataSchema = z.object({
 
 export const messageMetadataSchema = z
   .object({
+    /**
+     * Epoch ms the content actually happened, when that differs from when
+     * the row was written. Set wherever persistence lags the event: a queued
+     * turn draining, or channel history imported long after the fact.
+     * History serialization prefers it over `createdAt` for the display
+     * timestamp.
+     */
+    sentAt: z.number().optional(),
     userMessageChannel: channelIdSchema.optional(),
     assistantMessageChannel: channelIdSchema.optional(),
     userMessageInterface: interfaceIdSchema.optional(),

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -1236,12 +1236,10 @@ export async function handleListMessages({
 
       const alignedContentOrder = aligned.rewriteContentOrder(contentOrder);
 
-      // Use sentAt (actual event time) for the display timestamp when available,
-      // falling back to createdAt (persistence time). Clients use this display
-      // timestamp as their pagination cursor after memory-pressure trimming,
-      // while server-side pagination filters on createdAt. The mismatch is
-      // benign: it may return slightly extra data on a page boundary but never
-      // loses messages.
+      // Use sentAt (actual event time) for the display timestamp when
+      // available, falling back to createdAt (persistence time). Pagination
+      // is unaffected: the cursor is `oldestTimestamp`, built from
+      // `createdAt` on both ends.
       const displayTimestamp = m.sentAt ?? m.createdAt;
       return {
         id: m.id ?? "",

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -1760,9 +1760,19 @@ async function persistBackfilledSlackMessage(params: {
 
   const rawText = message.text ?? "";
 
+  // `sentAt` is when the message was sent; the row's `createdAt` is when the
+  // import wrote it. History serialization prefers `sentAt` for the display
+  // timestamp, so setting it is what keeps weeks-old history from reading as
+  // having just arrived. The Slack adapter already derives this from the
+  // message ts, so no parsing happens here.
+  const sentAt = Number.isFinite(message.timestamp)
+    ? message.timestamp
+    : undefined;
+
   const persisted = await addMessage(params.conversationId, role, rawText, {
     metadata: {
       slackMeta: writeSlackMetadata(slackMeta),
+      ...(sentAt !== undefined ? { sentAt } : {}),
       provenanceTrustClass: isGuardian ? "guardian" : "unknown",
       provenanceSourceChannel: "slack",
       ...(params.guardianExternalUserId

--- a/clients/web/src/domains/chat/components/message-hover-actions/message-hover-actions.test.tsx
+++ b/clients/web/src/domains/chat/components/message-hover-actions/message-hover-actions.test.tsx
@@ -5,29 +5,6 @@ import { MessageHoverActions } from "@/domains/chat/components/message-hover-act
 import type { DisplayMessage } from "@/domains/chat/types/types";
 import { textBody } from "@/domains/chat/utils/message-test-helpers";
 
-/**
- * The day portion the component renders for an epoch, computed with its own
- * `Intl` options so assertions hold in any locale. Only the choice of epoch
- * is under test.
- */
-function renderedDay(epoch: number): string {
-  return new Date(epoch).toLocaleDateString(undefined, {
-    month: "short",
-    day: "numeric",
-  });
-}
-
-const DAY_MS = 24 * 60 * 60 * 1000;
-
-/**
- * Epochs are taken relative to now because the component collapses today's
- * date to "Today". A fixed calendar date would assert the dated form on every
- * run except the one where it happens to be today.
- */
-function daysAgo(days: number): number {
-  return Date.now() - days * DAY_MS;
-}
-
 describe("MessageHoverActions", () => {
   test("renders the timestamp even when no actions are available", () => {
     const message: DisplayMessage = {
@@ -42,88 +19,6 @@ describe("MessageHoverActions", () => {
 
     expect(html).toContain("title=");
     expect(html).toContain("select-none");
-  });
-
-  test("dates a Slack row from its origin ts, not the row's write time", () => {
-    const sentAt = daysAgo(60);
-    const message: DisplayMessage = {
-      id: "m-backfilled",
-      role: "user",
-      timestamp: Date.now(),
-      slackMessage: {
-        channelId: "D0BFXBJE1QV",
-        channelTs: String(sentAt / 1000),
-      },
-      ...textBody("older message"),
-    };
-    const html = renderToStaticMarkup(
-      <MessageHoverActions message={message} />,
-    );
-
-    expect(html).toContain(renderedDay(sentAt));
-    expect(html).not.toContain("Today");
-  });
-
-  test("falls back to the row's own timestamp when no Slack ts is present", () => {
-    const rowWrittenAt = daysAgo(30);
-    const message: DisplayMessage = {
-      id: "m-plain",
-      role: "user",
-      timestamp: rowWrittenAt,
-      ...textBody("hello"),
-    };
-    const html = renderToStaticMarkup(
-      <MessageHoverActions message={message} />,
-    );
-
-    expect(html).toContain(renderedDay(rowWrittenAt));
-  });
-
-  test("dates a reaction from its arrival, not the message it reacts to", () => {
-    // A reaction row carries the reacted message's ts in `channelTs`, not
-    // its own arrival.
-    const reactedAt = daysAgo(60);
-    const reactedTs = String(reactedAt / 1000);
-    const arrivedAt = daysAgo(30);
-    const message: DisplayMessage = {
-      id: "m-reaction",
-      role: "user",
-      timestamp: arrivedAt,
-      slackMessage: {
-        channelId: "D0BFXBJE1QV",
-        channelTs: reactedTs,
-        eventKind: "reaction",
-        reaction: { emoji: "eyes", op: "added", targetChannelTs: reactedTs },
-      },
-      ...textBody("[reaction]"),
-    };
-    const html = renderToStaticMarkup(
-      <MessageHoverActions message={message} />,
-    );
-
-    expect(html).toContain(renderedDay(arrivedAt));
-    expect(html).not.toContain(renderedDay(reactedAt));
-  });
-
-  test("ignores a malformed Slack ts rather than inventing an origin time", () => {
-    // `parseFloat` accepts a numeric prefix, so a partial parse would render
-    // a fabricated date instead of falling back to the row's own timestamp.
-    const rowWrittenAt = daysAgo(30);
-    const message: DisplayMessage = {
-      id: "m-malformed",
-      role: "user",
-      timestamp: rowWrittenAt,
-      slackMessage: {
-        channelId: "D0BFXBJE1QV",
-        channelTs: "1783514100.123junk",
-      },
-      ...textBody("older message"),
-    };
-    const html = renderToStaticMarkup(
-      <MessageHoverActions message={message} />,
-    );
-
-    expect(html).toContain(renderedDay(rowWrittenAt));
   });
 
   test("renders inspect action for user messages when provided", () => {

--- a/clients/web/src/domains/chat/components/message-hover-actions/message-hover-actions.tsx
+++ b/clients/web/src/domains/chat/components/message-hover-actions/message-hover-actions.tsx
@@ -71,33 +71,6 @@ function formatDetailedTimestamp(epoch: number): string {
   });
 }
 
-/** Slack ts: `<unix-seconds>` with optional `.<microseconds>`. */
-const SLACK_TS_PATTERN = /^\d+(?:\.\d+)?$/;
-
-/**
- * Epoch ms a Slack message was sent, read from its origin `channelTs`.
- *
- * Rows hydrated by Slack history backfill are written at import time, so
- * `createdAt` records the import rather than the message; `channelTs` is the
- * only record of when it was sent. For a live Slack row the two agree.
- *
- * Reaction rows are excluded: their `channelTs` is the ts of the message
- * being reacted to, so the row's own timestamp is what dates the reaction.
- */
-function slackOriginTimestamp(message: DisplayMessage): number | undefined {
-  const slack = message.slackMessage;
-  if (!slack || slack.eventKind === "reaction") {
-    return undefined;
-  }
-  // Full-string match: `parseFloat` alone accepts a numeric prefix, which
-  // would turn a malformed ts into a fabricated origin time.
-  if (!SLACK_TS_PATTERN.test(slack.channelTs)) {
-    return undefined;
-  }
-  const ms = Number.parseFloat(slack.channelTs) * 1000;
-  return Number.isFinite(ms) ? ms : undefined;
-}
-
 /**
  * Latest activity timestamp for a message: the max of the message's own
  * timestamp and any tool-call start/completion times, so the displayed time
@@ -148,8 +121,7 @@ export function MessageHoverActions({
   // copy payload and mirrors the daemon's `joinWithSpacing`.
   const content = useMemo(() => messagePlainText(message), [message]);
   const timestamp = useMemo(
-    () =>
-      slackOriginTimestamp(message) ?? latestMessageActivityTimestamp(message),
+    () => latestMessageActivityTimestamp(message),
     [message],
   );
 


### PR DESCRIPTION
## TL;DR

Slack history backfill wrote imported messages without a send time, so weeks-old history reported the moment the import ran. The daemon already has a field for exactly this; setting it fixes every client at once and lets a client-side workaround come back out.

Context: LUM-3419. Replaces #41040, and supersedes #41017.

## The mechanism that already existed

History serialization prefers `metadata.sentAt` over the row's `createdAt` for the display timestamp:

```
const displayTimestamp = m.sentAt ?? m.createdAt;
```

That is the established answer to "this row was written later than the thing it describes" — the queue-drain path sets it whenever persistence is delayed. Backfill is the extreme case and simply never set it.

The send time needs no derivation: the Slack adapter already puts it on `Message.timestamp`, parsed from the message ts. `sentAt` is now declared on `messageMetadataSchema` too, rather than surviving on `.passthrough()`, since a third writer depends on it.

## What changes for the user

| | Before | After |
| --- | --- | --- |
| Timestamp on a backfilled Slack message | When the import ran | When it was sent |
| Same, on macOS / iOS / any other client | When the import ran | When it was sent |
| Live Slack message | Arrival time | Unchanged |
| Transcript ordering, `lastMessageAt` | By `createdAt` | Unchanged |

`createdAt` still records when the row was written. Only the reported send time changes.

## Why the client-side helper comes out

#41017 solved this in the web client by recomputing the time from `slackMeta.channelTs`. That was the wrong layer: it fixed one client, and it had to carry a hand-maintained ts regex plus a reaction special-case, because `channelTs` on a reaction row is the ts of the message being *reacted to*. With `sentAt` set, the daemon answers the question once for everyone, and reaction rows fall back to their arrival time by construction.

Both web files are byte-identical to their pre-#41017 state.

An earlier revision of this change kept the derivation as a backwards-compat gate so un-upgraded installs would not lose it. That was dropped deliberately. `clients/web/docs/BACKWARDS_COMPAT.md` describes gates for when "a new endpoint, wire field, or event shape will break against an older assistant" — here nothing breaks, a hover tooltip shows the import date, and that is what those users saw before #41017 shipped. Permanent registry machinery carrying a regex and a reaction special-case is not proportionate to a tooltip.

## The stale comment

The comment beside `displayTimestamp` claimed clients use it as a pagination cursor while the server filters on `createdAt`, calling the mismatch benign. That path does not exist: web's cursor is `oldestTimestamp`, which the server builds from `rawMessages[0].createdAt`, and `beforeTimestamp` appears in no other client. It is corrected in place rather than promoted into this description, where it would become load-bearing folklore.

The principle behind it is still the real reason to care: **the benign-ness of a `sentAt` / `createdAt` mismatch scales with the skew.** That comment was written for seconds of queue drain. Backfill makes it weeks.

## Testing

`dm-backfill.test.ts` asserts a backfilled row carries the original send time as `sentAt` **and** that `createdAt` is strictly later. The gap is the point: asserting the value alone would pass on a row that echoed the write time.

Typecheck, lint, and prettier pass. The test suite was not run locally by design; CI at this exact HEAD is the authority.

## Deliberately not here

- **No correction pass for existing rows.** Forward-only. On the dogfood install this is 125 skewed rows out of 1,889 — not a population worth a migration. Those rows keep reporting their import time.
- **Nothing about memory indexing.** An earlier PR (#41041) proposed dating memory segments the same way. It is closed: its only reader of segment `created_at` sits behind a v1 memory gate that nobody is on, while conversation summarization filters `gt(memorySegments.createdAt, lastCoveredAt)` on every tier, so backdating would silently drop imported content from future summaries. Net-negative, so it is not being pursued.
- **The scale of the import itself.** Binding a conversation still imports up to 50 prior messages in one write, and the verification code from the original report is still reproducible. Both are open on LUM-3419.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41047" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->