### PR TITLE
feat(discord): verify the user's identity during Discord setup

### DIFF
--- a/assistant/src/__tests__/guardian-verify-setup-skill-regression.test.ts
+++ b/assistant/src/__tests__/guardian-verify-setup-skill-regression.test.ts
@@ -1,8 +1,12 @@
 /**
  * Regression tests for the guardian-verify-setup skill.
  *
- * Ensures the voice verification flow includes proactive auto-check polling
- * so the user does not have to manually ask whether verification succeeded.
+ * The behaviour under guard is proactive auto-check polling: after a code is
+ * delivered, the skill must poll for completion rather than leaving the user
+ * to ask whether it worked. Originally that existed only for voice, and these
+ * tests pinned the voice section. The three per-channel polling sections were
+ * later merged into one parameterised section, so the assertions here pin the
+ * behaviour in its shared form and cover every channel that polls.
  */
 
 import { readFileSync } from "node:fs";
@@ -23,128 +27,154 @@ const SKILL_PATH = resolve(
 
 const skillContent = readFileSync(SKILL_PATH, "utf-8");
 
+/**
+ * The channels that poll. Telegram is deliberately absent: it confirms through
+ * its own bot-driven flow, so polling it reports nothing.
+ */
+const POLLED_CHANNELS = ["phone", "slack", "discord", "email"] as const;
+
+function section(from: string, to: string): string {
+  const body = skillContent.split(from)[1]?.split(to)[0];
+  // An empty slice would make every `toContain` below fail loudly rather than
+  // silently pass, which is the intent: a renamed heading must break this.
+  return body ?? "";
+}
+
+const pollingSection = () => section("## Auto-Check Polling", "## Step 6");
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
-describe("guardian-verify-setup skill — voice auto-followup", () => {
-  test("voice path in Step 3 references the auto-check polling loop", () => {
-    // The voice success instruction in Step 3 must direct the assistant to
-    // begin the polling loop rather than waiting for the user to report back.
-    expect(skillContent).toContain(
-      "immediately begin the voice auto-check polling loop",
+describe("guardian-verify-setup skill: proactive auto-check polling", () => {
+  test("the polling section exists", () => {
+    expect(skillContent).toContain("## Auto-Check Polling");
+  });
+
+  test("Step 3 sends every polled channel into the loop", () => {
+    const step3 = section("## Step 3", "## Step 4");
+    for (const channel of POLLED_CHANNELS) {
+      const bullet = step3
+        .split("\n")
+        .filter((line) =>
+          new RegExp(
+            `^\\s*-\\s+\\*\\*(Phone|Slack|Discord|Email)\\*\\*`,
+            "i",
+          ).test(line),
+        )
+        .find((line) => new RegExp(channel, "i").test(line));
+      expect(bullet, `Step 3 has no bullet for ${channel}`).toBeDefined();
+      expect(bullet).toContain("auto-check polling loop");
+    }
+  });
+
+  test("Step 4 resend sends every polled channel back into the loop", () => {
+    const resend = section("## Step 4", "## Step 5");
+    for (const channel of POLLED_CHANNELS) {
+      expect(
+        new RegExp(`\\*\\*${channel}\\*\\*`, "i").test(resend),
+        `Step 4 has no bullet for ${channel}`,
+      ).toBe(true);
+    }
+    expect(resend).toContain("auto-check polling loop");
+  });
+
+  test("the polling section names every polled channel and excludes Telegram", () => {
+    const body = pollingSection();
+    for (const channel of POLLED_CHANNELS) {
+      expect(body, `polling section omits ${channel}`).toContain(channel);
+    }
+    // Telegram may only appear as an exclusion, never as a channel to poll.
+    expect(body).toContain("Never Telegram");
+  });
+
+  test("the polling command is guarded against an unset channel", () => {
+    const body = pollingSection();
+    // The command is parameterised, so the channel has to be assigned in the
+    // same block. An unset CHANNEL would call the CLI with an empty value.
+    expect(body).toContain('CHANNEL=""');
+    expect(body).toContain('if [ -z "$CHANNEL" ]');
+    expect(body).toContain(
+      'channel-verification-sessions status --channel "$CHANNEL" --json',
     );
   });
 
-  test("voice path in Step 4 (resend) references the auto-check polling loop", () => {
-    // After a voice resend, the same auto-check behavior must kick in.
-    const resendSection =
-      skillContent.split("## Step 4")[1]?.split("## Step 5")[0] ?? "";
-    expect(resendSection).toContain("voice auto-check polling loop");
+  test("the polling section states an interval and a timeout per channel", () => {
+    const body = pollingSection();
+    expect(body).toContain("15s");
+    expect(body).toContain("20s");
+    expect(body).toContain("2 minutes");
+    expect(body).toContain("3 minutes");
   });
 
-  test("contains a Voice Auto-Check Polling section", () => {
-    expect(skillContent).toContain("## Voice Auto-Check Polling");
+  test("the polling section checks for bound: true", () => {
+    expect(pollingSection()).toContain("bound: true");
   });
 
-  test("polling section specifies the correct status command for voice", () => {
-    const pollingSection =
-      skillContent
-        .split("## Voice Auto-Check Polling")[1]
-        ?.split("## Step 6")[0] ?? "";
-    expect(pollingSection).toContain(
-      "assistant channel-verification-sessions status --channel phone --json",
-    );
+  test("success is reported proactively, not on request", () => {
+    const body = pollingSection();
+    expect(body).toContain("success message");
+    expect(body).toContain("Do NOT require the user to ask");
   });
 
-  test("polling section includes ~15 second interval", () => {
-    const pollingSection =
-      skillContent
-        .split("## Voice Auto-Check Polling")[1]
-        ?.split("## Step 6")[0] ?? "";
-    expect(pollingSection).toContain("~15 seconds");
+  test("timeout offers a resend rather than stopping silently", () => {
+    const body = pollingSection();
+    expect(body).toContain("timeout");
+    expect(body).toContain("resend");
   });
 
-  test("polling section includes 2-minute timeout", () => {
-    const pollingSection =
-      skillContent
-        .split("## Voice Auto-Check Polling")[1]
-        ?.split("## Step 6")[0] ?? "";
-    expect(pollingSection).toContain("2 minutes");
+  test("the rebind guard survives, with its false-success reasoning", () => {
+    const body = pollingSection();
+    expect(body).toContain("Rebind guard");
+    expect(body).toContain("verificationSessionId");
+    expect(body).toContain("Non-rebind flows");
   });
 
-  test("polling section checks for bound: true", () => {
-    const pollingSection =
-      skillContent
-        .split("## Voice Auto-Check Polling")[1]
-        ?.split("## Step 6")[0] ?? "";
-    expect(pollingSection).toContain("bound: true");
-  });
-
-  test("polling section includes proactive success confirmation", () => {
-    const pollingSection =
-      skillContent
-        .split("## Voice Auto-Check Polling")[1]
-        ?.split("## Step 6")[0] ?? "";
-    expect(pollingSection).toContain("proactive success message");
-  });
-
-  test("polling section includes timeout fallback with resend/restart offer", () => {
-    const pollingSection =
-      skillContent
-        .split("## Voice Auto-Check Polling")[1]
-        ?.split("## Step 6")[0] ?? "";
-    expect(pollingSection).toContain("timeout");
-    expect(pollingSection).toContain("resend");
-  });
-
-  test("polling section includes rebind guard against false-success from pre-existing binding", () => {
-    const pollingSection =
-      skillContent
-        .split("## Voice Auto-Check Polling")[1]
-        ?.split("## Step 6")[0] ?? "";
-    // Must mention rebind guard concept
-    expect(pollingSection).toContain("Rebind guard");
-    // Must instruct not to trust bound: true alone in a rebind flow
-    expect(pollingSection).toContain(
-      "do NOT treat `bound: true` alone as success",
-    );
-    // Must reference verificationSessionId as the mechanism to detect fresh binding
-    expect(pollingSection).toContain("verificationSessionId");
-    // Must clarify non-rebind flows are unaffected
-    expect(pollingSection).toContain("Non-rebind flows");
-  });
-
-  test("polling is voice-only — does not apply to Telegram", () => {
-    const pollingSection =
-      skillContent
-        .split("## Voice Auto-Check Polling")[1]
-        ?.split("## Step 6")[0] ?? "";
-    expect(pollingSection).toContain("voice-only");
-    expect(pollingSection).toContain("Do NOT poll for Telegram");
-  });
-
-  test('no instruction requires waiting for user to ask "did it work?"', () => {
-    // The skill should never instruct the assistant to wait for the user to
-    // confirm that voice verification worked. The auto-check polling loop
-    // makes this unnecessary.
-    const voiceAutoCheckSection =
-      skillContent
-        .split("## Voice Auto-Check Polling")[1]
-        ?.split("## Step 6")[0] ?? "";
-    expect(voiceAutoCheckSection).toContain("Do NOT require the user to ask");
-    // The voice bullet in Step 3 should not instruct the assistant to wait
-    // for the user to confirm or ask if it worked. Narrow to just the voice
-    // bullet line to avoid false positives from Telegram's "wait for the
-    // user to confirm they clicked the link" which is unrelated to voice.
-    const step3Section =
-      skillContent.split("## Step 3")[1]?.split("## Step 4")[0] ?? "";
-    const voiceBullet = step3Section
+  test("no polled channel's Step 3 bullet tells the assistant to wait", () => {
+    const step3 = section("## Step 3", "## Step 4");
+    // Narrowed to the polled bullets: Telegram's "wait for the user to confirm
+    // they clicked the link" is a real instruction for its own bootstrap flow.
+    const bullets = step3
       .split("\n")
-      .filter((line) => /^\s*-\s+\*\*Phone\*\*/.test(line))
-      .join("\n");
-    expect(voiceBullet).not.toHaveLength(0);
-    expect(voiceBullet).not.toContain("wait for the user to confirm");
-    expect(voiceBullet).not.toContain("ask the user if it worked");
+      .filter((line) =>
+        /^\s*-\s+\*\*(Phone|Slack|Discord|Email)\*\*/i.test(line),
+      );
+    expect(bullets.length).toBe(POLLED_CHANNELS.length);
+    for (const bullet of bullets) {
+      expect(bullet).not.toContain("wait for the user to confirm");
+      expect(bullet).not.toContain("ask the user if it worked");
+    }
+  });
+});
+
+describe("guardian-verify-setup skill: channel coverage", () => {
+  test("every channel the CLI accepts is offered in Step 1", () => {
+    const step1 = section("## Step 1", "## Step 2");
+    for (const channel of [...POLLED_CHANNELS, "telegram"]) {
+      expect(step1, `Step 1 does not offer ${channel}`).toContain(
+        `**${channel}**`,
+      );
+    }
+  });
+
+  test("Step 2 collects a destination for every channel", () => {
+    const step2 = section("## Step 2", "## Step 3");
+    for (const channel of ["Phone", "Telegram", "Slack", "Discord", "Email"]) {
+      expect(step2, `Step 2 has no destination for ${channel}`).toContain(
+        `**${channel}**`,
+      );
+    }
+  });
+
+  test("the status and revoke guards allow every supported channel", () => {
+    // These enumerate valid CHANNEL values. A channel missing here reads to
+    // the assistant as unsupported at exactly the point a user asks for it.
+    const guards = skillContent
+      .split("\n")
+      .filter((line) => line.includes("MUST set to one of"));
+    expect(guards.length).toBeGreaterThanOrEqual(2);
+    for (const guard of guards) {
+      expect(guard).toContain("discord");
+    }
   });
 });

--- a/assistant/src/cli/commands/channel-verification-sessions.help.ts
+++ b/assistant/src/cli/commands/channel-verification-sessions.help.ts
@@ -92,7 +92,8 @@ Examples:
       options: [
         {
           flags: "--channel <channel>",
-          description: "Channel type (telegram, phone). Defaults to telegram.",
+          description:
+            "Channel type (telegram, phone, slack, discord, email). Defaults to telegram.",
         },
       ],
       helpText: `

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -184,7 +184,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-08-07T01:16:55.000Z"
+      "updatedAt": "2026-08-20T22:06:50.000Z"
     },
     {
       "id": "doordash",
@@ -375,7 +375,7 @@
     {
       "id": "guardian-verify-setup",
       "name": "guardian-verify-setup",
-      "description": "Set up channel verification for phone, Telegram, Slack, or email channels via outbound verification flow",
+      "description": "Set up channel verification for phone, Telegram, Slack, Discord, or email channels via outbound verification flow",
       "metadata": {
         "emoji": "🔐",
         "vellum": {
@@ -392,7 +392,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-06-13T01:05:59.000Z"
+      "updatedAt": "2026-08-20T22:10:58.000Z"
     },
     {
       "id": "headless-claude-code",
@@ -1052,7 +1052,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-08-20T14:28:30.000Z"
+      "updatedAt": "2026-08-20T21:25:08.000Z"
     },
     {
       "id": "vellum-github-app-setup",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -392,7 +392,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-08-20T22:13:17.000Z"
+      "updatedAt": "2026-08-20T22:22:44.000Z"
     },
     {
       "id": "headless-claude-code",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -392,7 +392,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-08-20T22:10:58.000Z"
+      "updatedAt": "2026-08-20T22:13:17.000Z"
     },
     {
       "id": "headless-claude-code",

--- a/skills/discord-app-setup/SKILL.md
+++ b/skills/discord-app-setup/SKILL.md
@@ -133,7 +133,21 @@ Direct the user:
 
 Wait for the user to confirm the bot has joined the server before continuing.
 
-## Step 6: Report What Setup Delivered
+## Step 6: Verify the User's Discord Identity
+
+This binds the user's Discord account to their identity, so the bot knows who it is talking to and can address them by name rather than treating them as a stranger. Without it the channel is connected but recognises nobody, so do not skip it silently.
+
+It has to happen after Step 5: the code is delivered as a Discord DM, and Discord only permits a bot to DM someone it shares a server with.
+
+Load the **guardian-verify-setup** skill:
+
+- Call `skill_load` with `skill: "guardian-verify-setup"`.
+
+The channel is already `discord`. Do not re-ask which channel to verify.
+
+If the user wants to skip, continue to Step 7 and tell them they can verify later by saying _"verify me on Discord"_.
+
+## Step 7: Report What Setup Delivered
 
 Report exactly what is now true, and what is still required before the bot answers anything. Do **not** claim the bot is live: it appears online in the member list the moment it connects, which reads as "working" even while it ignores every message.
 
@@ -176,8 +190,9 @@ Two things still gate a reply after that, and are worth naming if the bot stays 
 - **Do NOT collect the bot token before Step 3.** The token is shown once and cannot be retrieved later, so it must be collected in the same turn the user generates it, with the secure prompt already open.
 - **Do NOT request the `Administrator` permission** on the OAuth invite URL. The default permission integer was chosen with the principle of least privilege — only request more if a downstream feature explicitly requires it, and document why.
 - **Do NOT enable any privileged intent.** The client identifies with `GUILDS`, `GUILD_MESSAGES`, and `DIRECT_MESSAGES` only, all three non-privileged, and nothing reads presence, member, or non-mention guild-message events. Enabling one grants access the software never uses and opts the app into Discord's privileged-intent review past 10,000 users.
-- **Do NOT claim the bot can reply once setup finishes.** It goes online, and looks working, while ignoring every message until a channel is on `discord.allowedChannelIds`. Always report that gap (Step 6).
+- **Do NOT claim the bot can reply once setup finishes.** It goes online, and looks working, while ignoring every message until a channel is on `discord.allowedChannelIds`. Always report that gap (Step 7).
 - **Do NOT instruct the user to set an Interactions Endpoint URL.** Gateway-connected bots receive interactions over the WebSocket — the HTTP endpoint is only needed for HTTP-only interaction handlers.
+- **Do NOT end setup without offering identity verification.** A connected bot that recognises nobody treats its own owner as a stranger. Step 6 is a skip the user declines explicitly, never one taken on their behalf.
 - **Do NOT persist the application ID, public key, or bot user metadata** anywhere outside the credential vault. They are derivable from the bot token on demand and persisting them risks staleness after a token reset.
 
 ## Disconnecting

--- a/skills/guardian-verify-setup/SKILL.md
+++ b/skills/guardian-verify-setup/SKILL.md
@@ -107,7 +107,7 @@ Based on the chosen channel, ask for the required destination:
 
   The bot will send a verification code via Slack DM once the member ID is resolved.
 
-- **Discord**: Ask for their Discord user ID, a numeric snowflake such as `216761906512297985`. To find it: **User Settings > Advanced > Developer Mode**, then right-click their own name in any channel or the member list and choose **Copy User ID**. A username or `@handle` will not work.
+- **Discord**: Ask for their Discord user ID, a numeric snowflake such as `900000000000000001`. To find it: **User Settings > Advanced > Developer Mode**, then right-click their own name in any channel or the member list and choose **Copy User ID**. A username or `@handle` will not work.
 
   The bot DMs the code to that user. Discord only permits that DM when the bot and the user share a server, so complete the invite step of `discord-app-setup` first, and note that a user who has turned off direct messages from server members cannot receive it.
 
@@ -205,9 +205,11 @@ Email is slower than chat, which is why it waits longer before giving up.
 **Polling procedure:**
 
 1. Wait one interval after delivering the code, to give the user time to receive it and reply.
-2. Check the binding status, with `CHANNEL` set to the channel being verified:
+2. Check the binding status. Each bash invocation starts fresh, so set `CHANNEL` in the same block as the command:
 
 ```bash
+CHANNEL=""  # ← MUST set to one of: phone, slack, discord, email
+if [ -z "$CHANNEL" ]; then echo "ERROR: CHANNEL not set"; exit 1; fi
 assistant channel-verification-sessions status --channel "$CHANNEL" --json
 ```
 

--- a/skills/guardian-verify-setup/SKILL.md
+++ b/skills/guardian-verify-setup/SKILL.md
@@ -235,12 +235,12 @@ When in a **rebind flow** (the session creation request included `"rebind": true
 After the user reports entering the code, verify the binding was created. Set `CHANNEL` to the channel currently being verified before running:
 
 ```bash
-CHANNEL=""  # ← MUST set to one of: phone, telegram, slack, email
+CHANNEL=""  # ← MUST set to one of: phone, telegram, slack, discord, email
 if [ -z "$CHANNEL" ]; then echo "ERROR: CHANNEL not set"; exit 1; fi
 assistant channel-verification-sessions status --channel "$CHANNEL" --json
 ```
 
-⚠️ CRITICAL — point of action: **`CHANNEL` must be set to the channel currently being verified (`phone`, `telegram`, `slack`, or `email`) before running.** The empty-string guard ensures a missed substitution fails safely rather than operating on the wrong channel.
+⚠️ CRITICAL — point of action: **`CHANNEL` must be set to the channel currently being verified (`phone`, `telegram`, `slack`, `discord`, or `email`) before running.** The empty-string guard ensures a missed substitution fails safely rather than operating on the wrong channel.
 
 If the response shows the channel is bound, confirm success: "Verification complete! Your [channel] identity is now verified."
 
@@ -251,12 +251,12 @@ If not yet bound, offer to resend (Step 4) or generate a new session (Step 3).
 If the user wants to remove themselves (or the current verified identity) from a channel, use the revoke endpoint. Set `CHANNEL` to the channel to unbind from before running:
 
 ```bash
-CHANNEL=""  # ← MUST set to one of: phone, telegram, slack, email
+CHANNEL=""  # ← MUST set to one of: phone, telegram, slack, discord, email
 if [ -z "$CHANNEL" ]; then echo "ERROR: CHANNEL not set"; exit 1; fi
 assistant channel-verification-sessions revoke --channel "$CHANNEL" --json
 ```
 
-⚠️ CRITICAL — point of action: **`CHANNEL` must be set to the channel to unbind (`phone`, `telegram`, `slack`, or `email`) before running.** The empty-string guard ensures a missed substitution fails safely rather than accidentally revoking the wrong channel.
+⚠️ CRITICAL — point of action: **`CHANNEL` must be set to the channel to unbind (`phone`, `telegram`, `slack`, `discord`, or `email`) before running.** The empty-string guard ensures a missed substitution fails safely rather than accidentally revoking the wrong channel.
 
 ### On success (`success: true`)
 

--- a/skills/guardian-verify-setup/SKILL.md
+++ b/skills/guardian-verify-setup/SKILL.md
@@ -15,13 +15,13 @@ metadata:
       - "If the user already specified a channel, do not re-ask"
 ---
 
-You are helping your user set up channel verification for a messaging channel (phone, Telegram, Slack, or email). This links their identity for verified message delivery on the chosen channel. Use the `assistant channel-verification-sessions` CLI for all verification operations.
+You are helping your user set up channel verification for a messaging channel (phone, Telegram, Slack, Discord, or email). This links their identity for verified message delivery on the chosen channel. Use the `assistant channel-verification-sessions` CLI for all verification operations.
 
 ## When to Use
 
 Load this skill when:
 
-- The user says "verify me", "verify my identity", "set up verification", "verify my [phone/telegram/slack/email]", or any equivalent identity-handshake intent.
+- The user says "verify me", "verify my identity", "set up verification", "verify my [phone/telegram/slack/discord/email]", or any equivalent identity-handshake intent.
 - Another skill is wiring up a channel and needs to bind the guardian's identity to it (e.g., `slack-app-setup` invokes this skill at the end of Slack setup so the user can prove ownership of the configured workspace).
 
 Do not load this skill for:

--- a/skills/guardian-verify-setup/SKILL.md
+++ b/skills/guardian-verify-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: guardian-verify-setup
-description: Set up channel verification for phone, Telegram, Slack, or email channels via outbound verification flow
+description: Set up channel verification for phone, Telegram, Slack, Discord, or email channels via outbound verification flow
 compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "🔐"
@@ -41,6 +41,7 @@ Ask the user which channel they want to verify:
 - **phone** -- verify a phone number for voice calls
 - **telegram** -- verify a Telegram account
 - **slack** -- verify a Slack account
+- **discord** -- verify a Discord account
 - **email** -- verify an email address
 
 **Skip the prompt and proceed directly with the named channel when:**
@@ -106,6 +107,10 @@ Based on the chosen channel, ask for the required destination:
 
   The bot will send a verification code via Slack DM once the member ID is resolved.
 
+- **Discord**: Ask for their Discord user ID, a numeric snowflake such as `216761906512297985`. To find it: **User Settings > Advanced > Developer Mode**, then right-click their own name in any channel or the member list and choose **Copy User ID**. A username or `@handle` will not work.
+
+  The bot DMs the code to that user. Discord only permits that DM when the bot and the user share a server, so complete the invite step of `discord-app-setup` first, and note that a user who has turned off direct messages from server members cannot receive it.
+
 ## Step 3: Start Outbound Verification
 
 Execute the outbound start request:
@@ -114,17 +119,18 @@ Execute the outbound start request:
 assistant channel-verification-sessions create --channel <channel> --destination "<destination>" --json
 ```
 
-Replace `<channel>` with `phone`, `telegram`, `slack`, or `email`, and `<destination>` with the phone number, Telegram destination, Slack user ID, or email address.
+Replace `<channel>` with `phone`, `telegram`, `slack`, `discord`, or `email`, and `<destination>` with the phone number, Telegram destination, Slack user ID, Discord user ID, or email address.
 
 ### On success (`success: true`)
 
 Report the exact next action based on the channel:
 
-- **Phone**: The response includes a `secret` field with the verification code. Tell the user the code BEFORE the call connects: "I'm calling [number] now. Your verification code is [secret]. When you answer the call, enter this code using your phone's keypad." The `create` command already initiates the voice call. Do NOT place a separate `call_start` call. **After delivering the code, immediately begin the voice auto-check polling loop** (see [Voice Auto-Check Polling](#voice-auto-check-polling) below).
+- **Phone**: The response includes a `secret` field with the verification code. Tell the user the code BEFORE the call connects: "I'm calling [number] now. Your verification code is [secret]. When you answer the call, enter this code using your phone's keypad." The `create` command already initiates the voice call. Do NOT place a separate `call_start` call. **After delivering the code, immediately begin the auto-check polling loop** (see [Auto-Check Polling](#auto-check-polling) below).
 - **Telegram with chat ID** (no `telegramBootstrapUrl` in response): The response includes a `secret` field. Show it in the current chat: "Your verification code is **[secret]**. I've also sent it to your Telegram. Open the Telegram bot chat and reply with that 6-digit code to complete verification." If the response does not contain a `secret` field, treat this as a control-plane error: tell the user something went wrong and ask them to retry from Step 3 or resend (Step 4).
 - **Telegram with handle** (`telegramBootstrapUrl` present in response): "Tap this deep-link first: [telegramBootstrapUrl]. After Telegram binds your identity, I'll send your verification code."
-- **Slack**: The response includes a `secret` field with the verification code. Show it in the current chat: "Your verification code is **[secret]**. I've also sent it to you as a Slack DM. Open the DM from the Vellum bot in Slack and reply with that 6-digit code to complete verification." The DM channel ID is captured automatically during this process for future message delivery. If the response does not contain a `secret` field, treat this as a control-plane error: tell the user something went wrong and ask them to retry from Step 3 or resend (Step 4). **After delivering the code, immediately begin the Slack auto-check polling loop** (see [Slack Auto-Check Polling](#slack-auto-check-polling) below).
-- **Email**: The response includes a `secret` field with the verification code. Show it in the current chat: "Your verification code is **[secret]**. I've also sent it to your email. Reply to the verification email with only the 6-digit code to complete verification." If the response does not contain a `secret` field, treat this as a control-plane error: tell the user something went wrong and ask them to retry from Step 3 or resend (Step 4). **After delivering the code, immediately begin the Email auto-check polling loop** (see [Email Auto-Check Polling](#email-auto-check-polling) below).
+- **Slack**: The response includes a `secret` field with the verification code. Show it in the current chat: "Your verification code is **[secret]**. I've also sent it to you as a Slack DM. Open the DM from the Vellum bot in Slack and reply with that 6-digit code to complete verification." The DM channel ID is captured automatically during this process for future message delivery. If the response does not contain a `secret` field, treat this as a control-plane error: tell the user something went wrong and ask them to retry from Step 3 or resend (Step 4). **After delivering the code, immediately begin the auto-check polling loop** (see [Auto-Check Polling](#auto-check-polling) below).
+- **Discord**: The response includes a `secret` field with the verification code. Show it in the current chat: "Your verification code is **[secret]**. I've also sent it to you as a Discord DM. Open the DM from the bot and reply with that 6-digit code to complete verification." If the response does not contain a `secret` field, treat this as a control-plane error: tell the user something went wrong and ask them to retry from Step 3 or resend (Step 4). **After delivering the code, begin the auto-check polling loop** (see [Auto-Check Polling](#auto-check-polling) below). The DM send is fire-and-forget, so a closed-DM or not-in-a-shared-server failure shows up as the poll timing out rather than as an error here.
+- **Email**: The response includes a `secret` field with the verification code. Show it in the current chat: "Your verification code is **[secret]**. I've also sent it to your email. Reply to the verification email with only the 6-digit code to complete verification." If the response does not contain a `secret` field, treat this as a control-plane error: tell the user something went wrong and ask them to retry from Step 3 or resend (Step 4). **After delivering the code, immediately begin the auto-check polling loop** (see [Auto-Check Polling](#auto-check-polling) below).
 
 After reporting the bootstrap URL for Telegram handle flows, wait for the user to confirm they clicked the link. Then check verification status (Step 6) to see if the bootstrap completed and a code was sent.
 
@@ -132,14 +138,14 @@ After reporting the bootstrap URL for Telegram handle flows, wait for the user t
 
 Handle each error code:
 
-| Error code            | Action                                                                                                                                                                                                                                                                                       |
-| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `missing_destination` | Ask the user to provide their phone number, Telegram destination, or Slack user ID.                                                                                                                                                                                                          |
-| `invalid_destination` | Tell the user the format is invalid. For phone: suggest E.164 format (+15551234567). For Telegram: explain that group chat IDs (negative numbers) are not supported. For Slack: explain that the value must be a Slack member ID (e.g. U01ABCDEF). For email: suggest a valid email address. |
-| `already_bound`       | Tell the user a verified identity is already bound for this channel. Ask if they want to replace it. If yes, re-run the create command with `--rebind` added.                                                                                                                                |
-| `rate_limited`        | Tell the user they have sent too many verification attempts to this destination. Ask them to wait and try again later.                                                                                                                                                                       |
-| `unsupported_channel` | Tell the user the channel is not supported. Only phone, telegram, slack, and email are valid.                                                                                                                                                                                                |
-| `no_bot_username`     | Telegram bot is not configured. Load and run the `telegram-setup` skill first.                                                                                                                                                                                                               |
+| Error code            | Action                                                                                                                                                                                                                                                                                                                                                                             |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `missing_destination` | Ask the user to provide their phone number, Telegram destination, Slack user ID, or Discord user ID.                                                                                                                                                                                                                                                                               |
+| `invalid_destination` | Tell the user the format is invalid. For phone: suggest E.164 format (+15551234567). For Telegram: explain that group chat IDs (negative numbers) are not supported. For Slack: explain that the value must be a Slack member ID (e.g. U01ABCDEF). For Discord: explain that the value must be a numeric user snowflake, not a username. For email: suggest a valid email address. |
+| `already_bound`       | Tell the user a verified identity is already bound for this channel. Ask if they want to replace it. If yes, re-run the create command with `--rebind` added.                                                                                                                                                                                                                      |
+| `rate_limited`        | Tell the user they have sent too many verification attempts to this destination. Ask them to wait and try again later.                                                                                                                                                                                                                                                             |
+| `unsupported_channel` | Tell the user the channel is not supported. Valid channels are phone, telegram, slack, discord, and email.                                                                                                                                                                                                                                                                         |
+| `no_bot_username`     | Telegram bot is not configured. Load and run the `telegram-setup` skill first.                                                                                                                                                                                                                                                                                                     |
 
 ## Step 4: Handle Resend
 
@@ -151,10 +157,11 @@ assistant channel-verification-sessions resend --channel <channel> --json
 
 On success, report the next action based on the channel:
 
-- **Phone**: The resend response includes a fresh `secret` field with a new verification code. Tell the user the new code BEFORE the call connects - just like the initial start flow: "I'm calling [number] again. Your new verification code is [secret]. When you answer the call, enter this code using your phone's keypad." The `resend` command already initiates the voice call. Do NOT place a separate `call_start` call. **After delivering the code, immediately begin the voice auto-check polling loop** (see [Voice Auto-Check Polling](#voice-auto-check-polling) below).
+- **Phone**: The resend response includes a fresh `secret` field with a new verification code. Tell the user the new code BEFORE the call connects - just like the initial start flow: "I'm calling [number] again. Your new verification code is [secret]. When you answer the call, enter this code using your phone's keypad." The `resend` command already initiates the voice call. Do NOT place a separate `call_start` call. **After delivering the code, immediately begin the auto-check polling loop** (see [Auto-Check Polling](#auto-check-polling) below).
 - **Telegram**: The resend response includes a fresh `secret` field. Show the new code in the current chat: "Your new verification code is **[secret]**. I've also sent it to your Telegram. Open the Telegram bot chat and reply with that 6-digit code to complete verification." If the response does not contain a `secret` field, treat this as a control-plane error: tell the user something went wrong and ask them to retry from Step 3.
-- **Slack**: The resend response includes a fresh `secret` field. Show the new code in the current chat: "Your new verification code is **[secret]**. I've also sent it to you as a Slack DM. Reply to the DM with that 6-digit code to complete verification. (resent)" If the response does not contain a `secret` field, treat this as a control-plane error: tell the user something went wrong and ask them to retry from Step 3. **After delivering the code, immediately begin the Slack auto-check polling loop** (see [Slack Auto-Check Polling](#slack-auto-check-polling) below).
-- **Email**: The resend response includes a fresh `secret` field. Show the new code in the current chat: "Your new verification code is **[secret]**. I've also sent it to your email. Reply to the verification email with only the 6-digit code to complete verification. (resent)" If the response does not contain a `secret` field, treat this as a control-plane error: tell the user something went wrong and ask them to retry from Step 3. **After delivering the code, immediately begin the Email auto-check polling loop** (see [Email Auto-Check Polling](#email-auto-check-polling) below).
+- **Slack**: The resend response includes a fresh `secret` field. Show the new code in the current chat: "Your new verification code is **[secret]**. I've also sent it to you as a Slack DM. Reply to the DM with that 6-digit code to complete verification. (resent)" If the response does not contain a `secret` field, treat this as a control-plane error: tell the user something went wrong and ask them to retry from Step 3. **After delivering the code, immediately begin the auto-check polling loop** (see [Auto-Check Polling](#auto-check-polling) below).
+- **Discord**: The resend response includes a fresh `secret` field. Show the new code in the current chat: "Your new verification code is **[secret]**. I've also sent it to you as a Discord DM. Reply to the DM with that 6-digit code to complete verification. (resent)" If the response does not contain a `secret` field, treat this as a control-plane error: tell the user something went wrong and ask them to retry from Step 3. **After delivering the code, begin the auto-check polling loop** (see [Auto-Check Polling](#auto-check-polling) below).
+- **Email**: The resend response includes a fresh `secret` field. Show the new code in the current chat: "Your new verification code is **[secret]**. I've also sent it to your email. Reply to the verification email with only the 6-digit code to complete verification. (resent)" If the response does not contain a `secret` field, treat this as a control-plane error: tell the user something went wrong and ask them to retry from Step 3. **After delivering the code, immediately begin the auto-check polling loop** (see [Auto-Check Polling](#auto-check-polling) below).
 
 ### Resend errors
 
@@ -178,26 +185,41 @@ assistant channel-verification-sessions cancel --channel <channel> --json
 
 Confirm cancellation to the user. On `no_active_session`, tell them there is nothing to cancel.
 
-## Voice Auto-Check Polling
+## Auto-Check Polling
 
-For **voice** verification only: after telling the user their code and instructing keypad entry (in Step 3 or Step 4), do NOT wait for the user to report back. Instead, proactively poll for completion so the user gets instant confirmation without having to ask "did it work?"
+After delivering the code (in Step 3 or Step 4), do NOT wait for the user to report back. Poll for completion so they get confirmation without having to ask "did it work?"
+
+**Applies to phone, Slack, Discord, and email. Never Telegram** -- Telegram confirms through its own bot-driven flow, so polling it reports nothing useful.
+
+Each channel differs only in timing and in the sentence you send on success:
+
+| Channel | Poll every | Give up after        | Success message                                                                                                                  |
+| ------- | ---------- | -------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| phone   | 15s        | 2 minutes (~8 polls) | "Voice verification complete! Your phone number is now verified."                                                                |
+| slack   | 15s        | 2 minutes (~8 polls) | "Slack verification complete! Your Slack account is now verified. The DM channel has been captured for future message delivery." |
+| discord | 15s        | 2 minutes (~8 polls) | "Discord verification complete! Your Discord account is now verified."                                                           |
+| email   | 20s        | 3 minutes (~9 polls) | "Email verification complete! Your email address is now verified."                                                               |
+
+Email is slower than chat, which is why it waits longer before giving up.
 
 **Polling procedure:**
 
-1. Wait ~15 seconds after delivering the code (to give the user time to answer the call and enter the code).
-2. Check the binding status via Vellum CLI:
+1. Wait one interval after delivering the code, to give the user time to receive it and reply.
+2. Check the binding status, with `CHANNEL` set to the channel being verified:
 
 ```bash
-assistant channel-verification-sessions status --channel phone --json
+assistant channel-verification-sessions status --channel "$CHANNEL" --json
 ```
 
-3. If the response shows `bound: true`: immediately send a proactive success message in the current chat - "Voice verification complete! Your phone number is now verified." Stop polling.
-4. If not yet bound: wait ~15 seconds and poll again.
-5. Continue polling for up to **2 minutes** (approximately 8 attempts).
-6. If the 2-minute timeout is reached without `bound: true`: proactively tell the user - "I've been checking for about 2 minutes but verification hasn't completed yet. The code may have expired or wasn't entered. Would you like me to resend a new code (Step 4) or start a new session (Step 3)?"
+3. If the response shows `bound: true` (subject to the rebind guard below): immediately send that channel's success message in the current chat and stop polling.
+4. If not yet bound: wait one more interval and poll again.
+5. Stop at the channel's timeout.
+6. On timeout, proactively tell the user: "I've been checking for a couple of minutes but verification hasn't completed yet. The code may have expired or wasn't entered. Would you like me to resend a new code (Step 4) or start a new session (Step 3)?"
+
+A timeout is also how a silent delivery failure surfaces. Code delivery is fire-and-forget, so a Discord user with DMs closed, or a Slack DM that could not be opened, produces a clean `create` response and then no arrival. Offer resend rather than asserting the code was received.
 
 **Rebind guard:**
-When in a **rebind flow** (i.e., the session creation request included `"rebind": true` because a binding already existed), do NOT treat `bound: true` alone as success. The pre-existing binding will show `bound: true` before the user has entered the new code, which would be a false positive. To guard against this:
+When in a **rebind flow** (the session creation request included `"rebind": true` because a binding already existed), do NOT treat `bound: true` alone as success. The pre-existing binding shows `bound: true` before the user has entered the new code, which would be a false positive. To guard against this:
 
 - Only report success when BOTH conditions are met: `bound: true` AND `verificationSessionId` is **absent** from the status response. The `verificationSessionId` field is present while a verification session is still active (pending). When the user enters the correct code, the session is consumed and `verificationSessionId` disappears from subsequent status responses. This proves the new outbound session was consumed and the binding is fresh.
 - If a poll shows `bound: true` but `verificationSessionId` is still present, the old binding is still active and the new code has not yet been consumed - continue polling.
@@ -205,65 +227,8 @@ When in a **rebind flow** (i.e., the session creation request included `"rebind"
 
 **Important polling rules:**
 
-- This polling loop is voice-only. Do NOT poll for Telegram channels (Telegram has its own bot-driven flow). For Slack, use the separate Slack Auto-Check Polling loop below.
 - Do NOT require the user to ask "did it work?" - the whole point is proactive confirmation.
 - If the user sends a message while polling is in progress, handle their message normally. If their message is about verification status, the next poll iteration will provide the answer.
-
-## Slack Auto-Check Polling
-
-For **Slack** verification: after telling the user their code and instructing them to reply in the Slack DM (in Step 3 or Step 4), proactively poll for completion so the user gets instant confirmation.
-
-**Polling procedure:**
-
-1. Wait ~15 seconds after delivering the code (to give the user time to open the Slack DM and reply with the code).
-2. Check the binding status via Vellum CLI:
-
-```bash
-assistant channel-verification-sessions status --channel slack --json
-```
-
-3. If the response shows `bound: true`: immediately send a proactive success message in the current chat - "Slack verification complete! Your Slack account is now verified. The DM channel has been captured for future message delivery." Stop polling.
-4. If not yet bound: wait ~15 seconds and poll again.
-5. Continue polling for up to **2 minutes** (approximately 8 attempts).
-6. If the 2-minute timeout is reached without `bound: true`: proactively tell the user - "I've been checking for about 2 minutes but verification hasn't completed yet. The code may have expired or wasn't entered. Would you like me to resend a new code (Step 4) or start a new session (Step 3)?"
-
-**Rebind guard:**
-When in a **rebind flow** (i.e., the session creation request included `"rebind": true` because a binding already existed), do NOT treat `bound: true` alone as success. The pre-existing binding will show `bound: true` before the user has entered the new code, which would be a false positive. To guard against this:
-
-- Only report success when BOTH conditions are met: `bound: true` AND `verificationSessionId` is **absent** from the status response. The `verificationSessionId` field is present while a verification session is still active (pending). When the user enters the correct code, the session is consumed and `verificationSessionId` disappears from subsequent status responses. This proves the new outbound session was consumed and the binding is fresh.
-- If a poll shows `bound: true` but `verificationSessionId` is still present, the old binding is still active and the new code has not yet been consumed - continue polling.
-- Non-rebind flows (fresh verification with no prior binding) are unaffected - the first `bound: true` is trustworthy because there was no prior binding to confuse the result.
-
-**Important polling rules:**
-
-- Do NOT require the user to ask "did it work?" - the whole point is proactive confirmation.
-- If the user sends a message while polling is in progress, handle their message normally.
-
-## Email Auto-Check Polling
-
-For **email** verification: after telling the user their code and instructing them to reply to the verification email (in Step 3 or Step 4), proactively poll for completion so the user gets instant confirmation.
-
-**Polling procedure:**
-
-1. Wait ~20 seconds after delivering the code (to give the user time to check their email and reply).
-2. Check the binding status via Vellum CLI:
-
-```bash
-assistant channel-verification-sessions status --channel email --json
-```
-
-3. If the response shows `bound: true`: immediately send a proactive success message in the current chat - "Email verification complete! Your email address is now verified." Stop polling.
-4. If not yet bound: wait ~20 seconds and poll again.
-5. Continue polling for up to **3 minutes** (approximately 9 attempts). Email is slower than chat, so a longer timeout is appropriate.
-6. If the 3-minute timeout is reached without `bound: true`: proactively tell the user - "I've been checking for about 3 minutes but verification hasn't completed yet. The code may have expired or the reply wasn't received. Would you like me to resend a new code (Step 4) or start a new session (Step 3)?"
-
-**Rebind guard:**
-When in a **rebind flow**, apply the same guard as Slack/voice: only report success when BOTH `bound: true` AND `verificationSessionId` is absent from the response.
-
-**Important polling rules:**
-
-- Do NOT require the user to ask "did it work?" - the whole point is proactive confirmation.
-- If the user sends a message while polling is in progress, handle their message normally.
 
 ## Step 6: Check Verification Status
 


### PR DESCRIPTION
## TL;DR

Discord setup finished with a connected bot that recognised nobody. The verification machinery for Discord was already built and working; nothing called it. This wires it up, and consolidates three copy-pasted polling sections on the way through, so it lands 19 lines shorter than it started.

## What a person sees

| | Before | After |
| -- | -- | -- |
| Finishing Discord setup | Bot connects, then treats its own owner as a stranger. No verification offered. | A verification step after the invite, same shape Slack and Telegram already have. |
| Saying "verify me on Discord" | Skill offers phone, Telegram, Slack, email. Discord is not on the list. | Discord is offered and works. |
| Resending a Discord code | No instruction for Discord; the step falls through. | Handled, like every other channel. |
| Code never arrives (DMs closed) | n/a | The poll times out after two minutes and offers a resend. |
| Slack, Telegram, phone, email | Unchanged | Unchanged |

## The gap was two skill files, not a build

Everything below already existed on `main`:

* `runtime/verification-outbound-actions.ts` has a complete `discord` entry: its own `missingDestination` and `rateLimited` copy, dedicated challenge and resend template keys, a `deliverVerificationDiscord` that opens the DM channel on the way through, and a `sessionIdentity` that deliberately records only the user snowflake because "the guild channel the requester was seen in is a room rather than a person, so binding to it would accept the code from anyone standing in it".
* The CLI accepts `--channel discord`.
* `getVerificationStatus` is channel-generic, so the polling loop reads Discord with no change.
* Identity recognition landed in LUM-3091.

Neither `guardian-verify-setup` nor `discord-app-setup` offered any of it.

## Why the polling sections were merged rather than extended

There were three near-identical auto-check polling sections, one each for voice, Slack and email. They differed in the poll interval, the timeout, and one success sentence. Everything else, including a fourteen-line rebind guard, was duplicated, and email had already given up and delegated its guard to Slack's copy.

Adding Discord meant either a fourth copy or one section with a per-channel table. The table is four rows and reads more clearly than the prose it replaces:

| Channel | Poll every | Give up after |
| -- | -- | -- |
| phone | 15s | 2 minutes |
| slack | 15s | 2 minutes |
| discord | 15s | 2 minutes |
| email | 20s | 3 minutes |

Behaviour is preserved exactly, including email's longer timeout and the rebind guard's reasoning.

## Why this is safe

**No code path changes.** The only source change is one help string. Everything else is skill markdown, which alters what the assistant is told to do during setup, not what the daemon does.

**It does not expose Discord.** Discord remains absent from `SETUP_CHANNEL_IDS`, `CHANNEL_METADATA`, the readiness probes and the invite transports, and stays in `ADMISSION_POLICY_HIDDEN_CHANNELS`. Surfacing it is LUM-3102 and is gated on a real-world run. This completes a setup path that already exists for anyone who runs the skill.

**Placement is forced by the platform, not preference.** Verification sits after the invite step because Discord only permits a bot to DM a user it shares a server with. The skill says so, so the ordering survives an edit.

**The failure mode is named rather than hidden.** Code delivery is fire-and-forget across every channel, by design, so a Discord user with DMs closed produces a clean `create` response and no arrival. That surfaces as the poll timing out and offering a resend, which is what the polling loop is for, and the skill now says this instead of asserting the code was received.

## Also fixed

The `status` subcommand's help listed only `telegram, phone` while its siblings listed all five channels. The handler resolves any channel, and the new polling loop reads it for Discord, so this was stale text rather than a limit.

## Deferred

`skill_load` is referenced by tool name, which `skills/AGENTS.md` generally discourages. Both `telegram-setup` and `slack-app-setup` already do this and there is no portable alternative for skill composition, so this matches its siblings rather than diverging in one file. Worth settling across all three at once if it matters.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41049" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->