### PR TITLE
Plan tile polish: usage chip row + no Free Forever under obscure-credits

### DIFF
--- a/clients/web/src/domains/settings/billing/plan-spec.test.ts
+++ b/clients/web/src/domains/settings/billing/plan-spec.test.ts
@@ -29,6 +29,16 @@ describe("freePlanSpecs", () => {
     ]);
     expect(specs.map((s) => s.icon)).toEqual([Computer, HardDrive, Coins]);
   });
+
+  test("gives the credits chip a row of its own", () => {
+    // The machine and storage chips are short enough to share a row; the
+    // credits chip is a phrase, so the wrapped layout drops it onto its own.
+    expect(freePlanSpecs().map((s) => s.ownRow)).toEqual([
+      undefined,
+      undefined,
+      true,
+    ]);
+  });
 });
 
 describe("packageSpecs", () => {
@@ -76,6 +86,31 @@ describe("packageSpecs", () => {
       "Assistant email and subdomain",
     ]);
     expect(specs[3].icon).toBe(Mail);
+  });
+
+  test("gives the credits chip and every extra a row of its own", () => {
+    const specs = packageSpecs({
+      key: "super",
+      machine_size: "medium",
+      credits_usd: 45,
+      storage_gib: 30,
+    } as ProPackage);
+    // Machine and storage share the wrapping row; the credits phrase and the
+    // email/subdomain extra each take a full row below it.
+    expect(specs.map((s) => s.ownRow)).toEqual([
+      undefined,
+      undefined,
+      true,
+      true,
+    ]);
+  });
+
+  test("keeps the credits chip on its own row under the obscured label", () => {
+    const specs = packageSpecs(
+      { key: "mighty", credits_usd: 25, storage_gib: 10 } as ProPackage,
+      { obscuredUsageLabel: "Mighty usage, reset monthly" },
+    );
+    expect(specs[2].ownRow).toBe(true);
   });
 
   test("falls back to $0 when credits_usd is null", () => {

--- a/clients/web/src/domains/settings/billing/plan-spec.ts
+++ b/clients/web/src/domains/settings/billing/plan-spec.ts
@@ -32,6 +32,13 @@ export interface PlanSpec {
   label: string;
   /** Render the chip as a wrap-capable pill for long summary labels. */
   multiline?: boolean;
+  /**
+   * Give the chip a full-width row of its own instead of letting it flow in the
+   * wrapping row beside the short chips. Read only by the wrapped layout
+   * (`PlanTile`'s `specsWrap`); the vertical stack gives every chip its own row
+   * already.
+   */
+  ownRow?: boolean;
 }
 
 /**
@@ -63,6 +70,10 @@ export interface PackageSpecsOptions {
  * then any static extras from the tier copy (today only the email/subdomain
  * row on Super and Ultra; a new extra inherits the Mail icon until it needs
  * its own mapping).
+ *
+ * The machine and storage chips are short enough to sit side by side; the
+ * credits chip and the extras are sentences, so they take a row each wherever
+ * the chips are laid out as a wrapping row.
  */
 export function packageSpecs(
   pkg: ProPackage,
@@ -80,8 +91,9 @@ export function packageSpecs(
       label:
         opts?.obscuredUsageLabel ??
         `${formatDollars(credits * 100)} in credits included`,
+      ownRow: true,
     },
-    ...extras.map((label) => ({ icon: Mail, label })),
+    ...extras.map((label) => ({ icon: Mail, label, ownRow: true })),
   ];
 }
 
@@ -93,7 +105,7 @@ export function freePlanSpecs(): PlanSpec[] {
   return [
     { icon: Computer, label: `${STANDARD_MACHINE_LABEL} Machine` },
     { icon: HardDrive, label: `${FREE_STORAGE_GIB} GB Storage` },
-    { icon: Coins, label: "Pay as you go credits" },
+    { icon: Coins, label: "Pay as you go credits", ownRow: true },
   ];
 }
 

--- a/clients/web/src/domains/settings/billing/plan-tile.stories.tsx
+++ b/clients/web/src/domains/settings/billing/plan-tile.stories.tsx
@@ -180,9 +180,10 @@ export const CurrentPaid: Story = {
 
 /**
  * The same tile with the `obscure-credits` flag on: the credits chip names the
- * package's usage allowance instead of a dollar bundle, the chips wrap into a
- * row, and the price footer gives way to the Usage Balance bar. Props only, so
- * the ratio here is a fixture rather than a live usage read.
+ * package's usage allowance instead of a dollar bundle, the machine and storage
+ * chips wrap into a row with that longer chip on its own beneath them, and the
+ * price footer gives way to the Usage Balance bar. Props only, so the ratio here
+ * is a fixture rather than a live usage read.
  */
 export const CurrentObscuredCredits: Story = {
   args: {

--- a/clients/web/src/domains/settings/billing/plan-tile.stories.tsx
+++ b/clients/web/src/domains/settings/billing/plan-tile.stories.tsx
@@ -147,6 +147,20 @@ export const CurrentFree: Story = {
 };
 
 /**
+ * The same free tile with the `obscure-credits` flag on and a usage grant to
+ * chart: the Usage Balance bar takes the footer over from "Free Forever", so
+ * the tile never states its allowance twice. A free account that was never
+ * granted any usage has no bar, and keeps the price row above.
+ */
+export const CurrentFreeObscuredCredits: Story = {
+  args: {
+    ...CurrentFree.args,
+    specsWrap: true,
+    footer: <UsageBalancePanel ratio={0.68} resetsAt={null} />,
+  },
+};
+
+/**
  * A subscriber's current-plan tile, on the catalog's Mighty package. The
  * footer price is the fixture's own `total_price_cents` run through the shared
  * `priceLabelFromCents` formatter, so it stays honest if the package is

--- a/clients/web/src/domains/settings/billing/plan-tile.test.tsx
+++ b/clients/web/src/domains/settings/billing/plan-tile.test.tsx
@@ -1,17 +1,18 @@
 /**
  * Tests for PlanTile: the shared tile of the billing "Plan" section. Verifies
  * it renders the tag, the 48px avatar slot, the name (forwarding `nameTestId`),
- * the spec-chip stack and the footer slot; drops the chip stack for null and
- * empty `specs` and the footer wrapper when no footer is passed; stamps a
- * nested `data-theme` scope only when `theme` is set; and forwards `testId`
- * and `className` to the root.
+ * the spec-chip stack and the footer slot; splits the wrapped layout into the
+ * wrapping row and the chips that asked for a row of their own; drops the chip
+ * stack for null and empty `specs` and the footer wrapper when no footer is
+ * passed; stamps a nested `data-theme` scope only when `theme` is set; and
+ * forwards `testId` and `className` to the root.
  *
  * The lazy `PlanTierAvatar` compositor bundle is mocked away so the avatar
  * renders its deterministic same-size placeholder (mirrors
  * plan-spec-card.test.tsx).
  */
 
-import { Coins, Computer, HardDrive } from "lucide-react";
+import { Coins, Computer, HardDrive, Mail } from "lucide-react";
 
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, render } from "@testing-library/react";
@@ -30,6 +31,14 @@ const SPECS: PlanSpec[] = [
   { icon: Computer, label: "Small Machine" },
   { icon: HardDrive, label: "10 GB Storage" },
   { icon: Coins, label: "$25 in credits included" },
+];
+
+/** The production shape under `obscure-credits`: two short chips, two rows. */
+const OWN_ROW_SPECS: PlanSpec[] = [
+  { icon: Computer, label: "Small Machine" },
+  { icon: HardDrive, label: "10 GB Storage" },
+  { icon: Coins, label: "Mighty usage, reset monthly", ownRow: true },
+  { icon: Mail, label: "Assistant email and subdomain", ownRow: true },
 ];
 
 const TILE_TEST_ID = "plan-tile";
@@ -164,10 +173,83 @@ describe("PlanTile", () => {
       />,
     );
 
+    // No spec asks for its own row, so the whole set flows in the one wrap row.
     const container = getByTestId(TILE_TEST_ID).children[1] as HTMLElement;
-    expect(container.className).toContain("flex-row");
-    expect(container.className).toContain("flex-wrap");
-    expect(container.className).not.toContain("flex-col");
+    expect(container.className).toContain("flex-col");
+    expect(container.childElementCount).toBe(1);
+    const wrapRow = container.firstElementChild as HTMLElement;
+    expect(wrapRow.className).toContain("flex-row");
+    expect(wrapRow.className).toContain("flex-wrap");
+    expect(wrapRow.childElementCount).toBe(SPECS.length);
+  });
+
+  test("gives an ownRow spec a full row below the wrapping group", () => {
+    const { getByTestId, getByText } = render(
+      <PlanTile
+        testId={TILE_TEST_ID}
+        tierKey="mighty"
+        name="Mighty"
+        tag={<span>Current</span>}
+        specs={OWN_ROW_SPECS}
+        specsWrap
+      />,
+    );
+
+    const container = getByTestId(TILE_TEST_ID).children[1] as HTMLElement;
+    // The wrap row, then one block per own-row spec.
+    expect(container.childElementCount).toBe(3);
+    const wrapRow = container.firstElementChild as HTMLElement;
+    expect(wrapRow.className).toContain("flex-wrap");
+    expect(wrapRow.childElementCount).toBe(2);
+    expect(wrapRow.textContent).toContain("Small Machine");
+    expect(wrapRow.textContent).toContain("10 GB Storage");
+    expect(container.children[1]?.textContent).toBe(
+      "Mighty usage, reset monthly",
+    );
+    expect(container.children[2]?.textContent).toBe(
+      "Assistant email and subdomain",
+    );
+    // A full-width row can afford to wrap a long label inside the pill.
+    expect(getByText("Mighty usage, reset monthly").className).toContain(
+      "whitespace-normal",
+    );
+  });
+
+  test("renders no empty wrap group when every spec takes its own row", () => {
+    const { getByTestId } = render(
+      <PlanTile
+        testId={TILE_TEST_ID}
+        tierKey="mighty"
+        name="Mighty"
+        tag={<span>Current</span>}
+        specs={OWN_ROW_SPECS.filter((spec) => spec.ownRow)}
+        specsWrap
+      />,
+    );
+
+    const container = getByTestId(TILE_TEST_ID).children[1] as HTMLElement;
+    expect(container.childElementCount).toBe(2);
+    expect(container.firstElementChild?.className).not.toContain("flex-wrap");
+  });
+
+  test("ignores ownRow in the vertical stack", () => {
+    const { getByTestId, getByText } = render(
+      <PlanTile
+        testId={TILE_TEST_ID}
+        tierKey="mighty"
+        name="Mighty"
+        tag={<span>Current</span>}
+        specs={OWN_ROW_SPECS}
+      />,
+    );
+
+    // Every chip already has a row of its own, in the order it was given.
+    const container = getByTestId(TILE_TEST_ID).children[1] as HTMLElement;
+    expect(container.childElementCount).toBe(OWN_ROW_SPECS.length);
+    expect(container.className).toContain("flex-col");
+    expect(getByText("Mighty usage, reset monthly").className).toContain(
+      "whitespace-nowrap",
+    );
   });
 
   test("stamps a nested data-theme scope when theme is set", () => {

--- a/clients/web/src/domains/settings/billing/plan-tile.tsx
+++ b/clients/web/src/domains/settings/billing/plan-tile.tsx
@@ -22,7 +22,11 @@ export interface PlanTileProps {
   tag: ReactNode;
   /** Vertical spec-chip stack; omitted entirely when null or empty. */
   specs?: PlanSpec[] | null;
-  /** Lay the chips out as a wrapping row instead of a vertical stack. */
+  /**
+   * Lay the short chips out as a wrapping row instead of a vertical stack. Any
+   * spec flagged `ownRow` still gets a full-width row of its own below that
+   * group, which is where the long usage and extras labels go.
+   */
   specsWrap?: boolean;
   /** Bottom slot (price row or CTA), pinned to the tile's bottom edge. */
   footer?: ReactNode;
@@ -48,6 +52,8 @@ export function PlanTile({
   testId,
   className,
 }: PlanTileProps) {
+  const rowSpecs = specs?.filter((spec) => !spec.ownRow) ?? [];
+  const ownRowSpecs = specs?.filter((spec) => spec.ownRow) ?? [];
   return (
     <div
       data-theme={theme}
@@ -72,22 +78,43 @@ export function PlanTile({
         </div>
       </div>
       {specs?.length ? (
-        <div
-          className={
-            specsWrap
-              ? "flex flex-row flex-wrap items-start gap-1"
-              : "flex flex-col items-start gap-2"
-          }
-        >
-          {specs.map((spec) => (
-            <SpecChip
-              key={spec.label}
-              icon={spec.icon}
-              label={spec.label}
-              multiline={spec.multiline}
-            />
-          ))}
-        </div>
+        specsWrap ? (
+          <div className="flex flex-col items-start gap-1">
+            {rowSpecs.length ? (
+              <div className="flex flex-row flex-wrap items-start gap-1">
+                {rowSpecs.map((spec) => (
+                  <SpecChip
+                    key={spec.label}
+                    icon={spec.icon}
+                    label={spec.label}
+                    multiline={spec.multiline}
+                  />
+                ))}
+              </div>
+            ) : null}
+            {ownRowSpecs.map((spec) => (
+              // An own-row chip has the whole tile width, so let a long label
+              // wrap inside the pill rather than pushing past the tile.
+              <SpecChip
+                key={spec.label}
+                icon={spec.icon}
+                label={spec.label}
+                multiline
+              />
+            ))}
+          </div>
+        ) : (
+          <div className="flex flex-col items-start gap-2">
+            {specs.map((spec) => (
+              <SpecChip
+                key={spec.label}
+                icon={spec.icon}
+                label={spec.label}
+                multiline={spec.multiline}
+              />
+            ))}
+          </div>
+        )
       ) : null}
       {footer ? <div className="mt-auto w-full">{footer}</div> : null}
     </div>

--- a/clients/web/src/domains/settings/billing/usage-balance-panel.tsx
+++ b/clients/web/src/domains/settings/billing/usage-balance-panel.tsx
@@ -26,10 +26,9 @@ export interface UsageBalancePanelProps {
 }
 
 /**
- * The current-plan tile's footer while `obscure-credits` is on: how much of a
- * Pro package's included usage this cycle has spent, in place of the price
- * row, or how much of a free plan's granted usage credit it has used, above
- * one.
+ * The current-plan tile's footer while `obscure-credits` is on, in place of the
+ * price row: how much of a Pro package's included usage this cycle has spent,
+ * or how much of a free plan's granted usage credit it has used.
  */
 export function UsageBalancePanel({
   ratio,

--- a/clients/web/src/domains/settings/components/plan-card.test.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.test.tsx
@@ -1176,20 +1176,28 @@ describe("PlanCard with obscure-credits on", () => {
     expect(next.queryByText("$45 in credits included")).toBeNull();
   });
 
-  test("both tiles wrap their chips into a row", () => {
+  test("both tiles wrap their short chips into a row, usage below", () => {
     const { container } = renderCardInteractive(
       proMightySubscription(),
       plansWithSuper(),
       () => {},
     );
 
-    // Child 0 is the header row; child 1 is the chip container.
-    expect(
-      (currentTile(container).children[1] as HTMLElement).className,
-    ).toContain("flex-wrap");
-    expect(
-      (nextTile(container).children[1] as HTMLElement).className,
-    ).toContain("flex-wrap");
+    for (const [tile, usageLabel] of [
+      [currentTile(container), "Mighty usage, reset monthly"],
+      [nextTile(container), "Super usage, reset monthly"],
+    ] as const) {
+      // Child 0 is the header row; child 1 is the chip container.
+      const chips = tile.children[1] as HTMLElement;
+      const wrapRow = chips.firstElementChild as HTMLElement;
+      expect(wrapRow.className).toContain("flex-wrap");
+      expect(wrapRow.textContent).toContain("Machine");
+      expect(wrapRow.textContent).toContain("Storage");
+      expect(wrapRow.textContent).not.toContain(usageLabel);
+      // The usage chip is the first full-width row underneath (Super's email
+      // extra takes another below it).
+      expect(chips.children[1]?.textContent).toBe(usageLabel);
+    }
   });
 
   test("shows neither the bar nor the price when the usage read fails", async () => {

--- a/clients/web/src/domains/settings/components/plan-card.test.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.test.tsx
@@ -1354,10 +1354,10 @@ describe("PlanCard with obscure-credits on", () => {
     ).toBeNull();
   });
 
-  test("a free plan keeps its Free Forever footer and its own chips", () => {
+  test("a free plan with no grant falls back to Free Forever and its own chips", () => {
     // Nothing has reported a usage grant, so there is no denominator for the
-    // free tile's bar and no dollar figure to obscure either. Suppressing the
-    // footer here would leave the tile with an empty bottom slot.
+    // free tile's bar. Suppressing the footer here would leave the tile with an
+    // empty bottom slot, so the price row stays as the fallback.
     const { container } = renderCardInteractive(
       baseSubscription(),
       basePlansResponse(),
@@ -1375,9 +1375,9 @@ describe("PlanCard with obscure-credits on", () => {
     expect(usageTotalsCalls).toBe(0);
   });
 
-  test("a free plan stacks its usage-grant bar above Free Forever", async () => {
+  test("a free plan hides Free Forever once its usage-grant bar renders", async () => {
     // $3.40 of the $5.00 this account was granted, so the bar reads 68% and
-    // the price row it sits above is untouched.
+    // takes the footer over from the price row.
     totalUsageBalance = "5.00";
     availableUsageBalance = "1.60";
     const { container, findByTestId } = renderCardInteractive(
@@ -1392,9 +1392,8 @@ describe("PlanCard with obscure-credits on", () => {
     // A grant is not a cycle, so nothing resets.
     expect(panel.textContent).not.toContain("Resets");
     const current = within(currentTile(container));
-    expect(current.getByTestId("plan-card-price").textContent).toBe(
-      "Free Forever",
-    );
+    expect(current.queryByTestId("plan-card-price")).toBeNull();
+    expect(current.queryByText("Free Forever")).toBeNull();
     // The whole reading comes off the summary, so no usage window is read.
     expect(usageTotalsCalls).toBe(0);
   });

--- a/clients/web/src/domains/settings/components/plan-card.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.tsx
@@ -519,20 +519,13 @@ export function PlanCard({ onManage, onTierUpgraded }: PlanCardProps) {
       onAddCredits={() => setAddCreditsOpen(true)}
     />
   ) : null;
-  // A paid tile trades its price for the usage balance, so the two never state
-  // the same allowance twice. The free tile has no dollar figure to obscure,
-  // so "Free Forever" keeps its row and the bar over its usage grants stacks
-  // above it; an account that was never granted any has no bar to stack.
+  // A tile under the flag trades its price for the usage balance, so the two
+  // never state the same allowance twice. A free account that was never granted
+  // any usage has no bar to trade for, so "Free Forever" stays as its footer
+  // rather than leaving the tile with an empty bottom slot.
   let currentFooter: ReactNode = priceRow;
-  if (!isFreePlan && obscureCredits) {
+  if (obscureCredits && (!isFreePlan || usagePanel != null)) {
     currentFooter = usagePanel;
-  } else if (isFreePlan && usagePanel) {
-    currentFooter = (
-      <div className="flex w-full flex-col gap-2">
-        {usagePanel}
-        {priceRow}
-      </div>
-    );
   }
 
   return (


### PR DESCRIPTION
## Summary

Two small polish passes on the billing "Plan" section, both living entirely under the `obscure-credits` presentation, against mock [node 7830-130412](https://www.figma.com/design/cCGBcpVDbn22kj3OPU58W8?node-id=7830-130412):

1. **The obscured free tile drops "Free Forever".** The flag-on free tile stacked the Usage Balance bar above its price row, stating the same allowance twice. The bar now takes the footer over outright, the way the paid tile already did.
2. **The credits/usage chip gets its own row.** The mock lays the machine and storage chips out as a wrapping row with the long usage sentence ("Mighty usage, reset monthly") on a full-width row beneath. The wrapped layout now does the same.

Both changes are gated: with `obscure-credits` off, the vertical chip stack and the "Free Forever" footer render exactly as they do today. This was originally cut to stack on #41033, which has since merged, so it is based on `main`.

## Changes

- `plan-card.tsx`: the current tile's footer is the usage panel whenever the flag is on and there is a reading to draw. A free account that was never granted any usage has no bar to trade for, so "Free Forever" stays as the fallback rather than leaving the tile footerless on a platform that reports no grant.
- `plan-spec.ts`: `PlanSpec` gains an opt-in `ownRow`. `packageSpecs` sets it on the credits chip (both the dollar and the obscured usage label) and on the static extras; `freePlanSpecs` sets it on "Pay as you go credits".
- `plan-tile.tsx`: the `specsWrap` layout became a column of two groups: the non-`ownRow` chips in one `flex-row flex-wrap` group, then each `ownRow` chip as a full-width block below. Own-row chips render as `multiline` pills so a long label wraps inside the chip. The vertical stack ignores the field, since it gives every chip a row already.
- `usage-balance-panel.tsx`: docstring only, since the free tile no longer sits the bar above a price row.
- Stories: `CurrentObscuredCredits` shows the new two-group layout; added `CurrentFreeObscuredCredits` for the flag-on free tile.

## Testing

- `bun test` on each touched file: `plan-card.test.tsx` (46 pass), `plan-tile.test.tsx` (13 pass), `plan-spec.test.ts` (32 pass).
- `bunx tsc --noEmit`: clean. `bun run lint`: 0 errors (16 pre-existing warnings, all in untouched files).
- `bun run test:ci`: 1020 passed, 4 failed — `checkout-page`, `checkout-return-target`, `sentry-init`, `daily-reset-time`, all pre-existing on `main` and unrelated to this change.
- New coverage: plan-tile tests for the two-group structure, for the no-empty-wrap-group case when every chip takes its own row, and for `ownRow` being ignored in the vertical stack; plan-spec tests for the `ownRow` flags; the plan-card flag-on free case now asserts "Free Forever" disappears once the bar renders, with the no-grant fallback still asserted.

## Notes

- **Narrow widths / iOS**: measured in Storybook by driving the tile from 420px down to 200px of tile width. Nothing ever overflows (`scrollWidth === clientWidth` at every step). The wrap row breaks first (around 279px, roughly the tile width at a 375px viewport), and below about 240px the usage chip itself wraps to two lines inside its pill via the existing `SpecChip` `multiline` variant. No horizontal scroll at any width.
- Storybook-verified in a browser; **device QA on a real iPhone is still outstanding.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
