### PR TITLE
Stamp a semantic network_error reason on SDK transport failures

### DIFF
--- a/assistant/src/__tests__/openai-provider.test.ts
+++ b/assistant/src/__tests__/openai-provider.test.ts
@@ -82,9 +82,27 @@ class FakeAPIError extends Error {
   }
 }
 
+// Simulate the SDK's transport-failure and caller-abort subclasses; the
+// error normalizer distinguishes them by class, so the mock must define both
+// for suites that share this process.
+class FakeAPIConnectionError extends FakeAPIError {
+  constructor() {
+    super(undefined as unknown as number, "Connection error.");
+    this.name = "APIConnectionError";
+  }
+}
+class FakeAPIUserAbortError extends FakeAPIError {
+  constructor() {
+    super(undefined as unknown as number, "Request was aborted.");
+    this.name = "APIUserAbortError";
+  }
+}
+
 mock.module("openai", () => ({
   default: class MockOpenAI {
     static APIError = FakeAPIError;
+    static APIConnectionError = FakeAPIConnectionError;
+    static APIUserAbortError = FakeAPIUserAbortError;
     constructor(opts: Record<string, unknown>) {
       lastConstructorOptions = opts;
     }

--- a/assistant/src/__tests__/openai-responses-provider.test.ts
+++ b/assistant/src/__tests__/openai-responses-provider.test.ts
@@ -50,9 +50,27 @@ class FakeAPIError extends Error {
   }
 }
 
+// Simulate the SDK's transport-failure and caller-abort subclasses; the
+// error normalizer distinguishes them by class, so the mock must define both
+// for suites that share this process.
+class FakeAPIConnectionError extends FakeAPIError {
+  constructor() {
+    super(undefined as unknown as number, "Connection error.");
+    this.name = "APIConnectionError";
+  }
+}
+class FakeAPIUserAbortError extends FakeAPIError {
+  constructor() {
+    super(undefined as unknown as number, "Request was aborted.");
+    this.name = "APIUserAbortError";
+  }
+}
+
 mock.module("openai", () => ({
   default: class MockOpenAI {
     static APIError = FakeAPIError;
+    static APIConnectionError = FakeAPIConnectionError;
+    static APIUserAbortError = FakeAPIUserAbortError;
     constructor(opts: Record<string, unknown>) {
       lastConstructorOptions = opts;
     }

--- a/assistant/src/daemon/conversation-error.ts
+++ b/assistant/src/daemon/conversation-error.ts
@@ -635,8 +635,7 @@ function reasonToClassification(
     // Two producers share this reason: SDK transport failures that never got
     // a response (OpenAI APIConnectionError), and Gemini responses whose empty
     // body reveals a proxy/egress filter intercepting the request. The copy
-    // covers both; the category renames the old Gemini-only
-    // "provider_network_proxy_intercepted".
+    // must stay broad enough for both.
     case "network_error":
       return {
         code: "PROVIDER_NETWORK",

--- a/assistant/src/daemon/conversation-error.ts
+++ b/assistant/src/daemon/conversation-error.ts
@@ -632,13 +632,18 @@ function reasonToClassification(
       return contextTooLargeClassification();
     case "vision_unsupported":
       return visionNotSupportedClassification();
+    // Two producers share this reason: SDK transport failures that never got
+    // a response (OpenAI APIConnectionError), and Gemini responses whose empty
+    // body reveals a proxy/egress filter intercepting the request. The copy
+    // covers both; the category renames the old Gemini-only
+    // "provider_network_proxy_intercepted".
     case "network_error":
       return {
         code: "PROVIDER_NETWORK",
         userMessage:
-          "The provider returned an empty response with no body — this typically indicates a network proxy or egress filter intercepting the request, not a genuine provider error. Check your network configuration.",
+          "The request could not reach the provider: the connection failed before a real response arrived. Check that the endpoint is reachable and that no proxy or egress filter is intercepting the request, then try again.",
         retryable: true,
-        errorCategory: "provider_network_proxy_intercepted",
+        errorCategory: "provider_network_error",
       };
     case "model_not_found":
       return {

--- a/assistant/src/providers/__tests__/retry-network-error.test.ts
+++ b/assistant/src/providers/__tests__/retry-network-error.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, mock, test } from "bun:test";
+
+import * as retryUtil from "../../util/retry.js";
+
+// Instant sleep so backoff delays don't slow the suite; everything else is
+// the real module.
+mock.module("../../util/retry.js", () => ({
+  ...retryUtil,
+  sleep: async () => {},
+}));
+
+const { RetryProvider } = await import("../retry.js");
+const { ProviderError } = await import("../../util/errors.js");
+
+import type { Message, Provider, ProviderResponse } from "../types.js";
+
+const OK_RESPONSE = {
+  content: [{ type: "text", text: "ok" }],
+  model: "test-model",
+  usage: { inputTokens: 1, outputTokens: 1 },
+} as unknown as ProviderResponse;
+
+const MESSAGES: Message[] = [
+  { role: "user", content: [{ type: "text", text: "hi" }] },
+];
+
+/** Inner provider that throws the queued errors in order, then succeeds. */
+function flakyProvider(errors: unknown[]): {
+  provider: Provider;
+  calls: () => number;
+} {
+  let calls = 0;
+  const queue = [...errors];
+  const provider: Provider = {
+    name: "openai-compatible",
+    sendMessage: async () => {
+      calls += 1;
+      const next = queue.shift();
+      if (next !== undefined) {
+        throw next;
+      }
+      return OK_RESPONSE;
+    },
+  };
+  return { provider, calls: () => calls };
+}
+
+describe("RetryProvider network_error handling", () => {
+  test("retries a transport failure stamped with reason network_error", async () => {
+    const { provider, calls } = flakyProvider([
+      new ProviderError(
+        "OpenAI-compatible API error (unknown status): Connection error.",
+        "openai-compatible",
+        undefined,
+        { reason: "network_error" },
+      ),
+    ]);
+    const result = await new RetryProvider(provider).sendMessage(MESSAGES);
+    expect(result).toBe(OK_RESPONSE);
+    expect(calls()).toBe(2);
+  });
+
+  test("still does not retry a statusless reason-less abort-shaped error", async () => {
+    // OpenAI catch-sites do not distinguish inner stream deadlines from
+    // transport aborts, so their "Request was aborted." must stay
+    // non-retryable (see RETRYABLE_TRANSPORT_ABORT_PATTERNS).
+    const abortShaped = () =>
+      new ProviderError(
+        "OpenAI API error (unknown status): Request was aborted.",
+        "openai",
+        undefined,
+      );
+    const { provider, calls } = flakyProvider([
+      abortShaped(),
+      abortShaped(),
+      abortShaped(),
+      abortShaped(),
+    ]);
+    await expect(
+      new RetryProvider(provider).sendMessage(MESSAGES),
+    ).rejects.toThrow("Request was aborted");
+    expect(calls()).toBe(1);
+  });
+});

--- a/assistant/src/providers/openai/__tests__/api-error-normalization.test.ts
+++ b/assistant/src/providers/openai/__tests__/api-error-normalization.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import type OpenAI from "openai";
+import OpenAI from "openai";
 
 import type { NormalizedOpenAIAPIError } from "../api-error-normalization.js";
 import {
@@ -42,6 +42,22 @@ describe("normalizeOpenAIAPIError", () => {
     expect(formatNormalizedOpenAIAPIError("Together AI", 400, n)).toBe(
       "Together AI API error (400): Model 'MiniMax-M3' is not yet supported on Vellum.",
     );
+  });
+
+  test("stamps network_error for SDK connection failures", () => {
+    const cause = Object.assign(new Error("connect ECONNREFUSED 127.0.0.1:9"), {
+      code: "ECONNREFUSED",
+    });
+    const n = normalizeOpenAIAPIError(new OpenAI.APIConnectionError({ cause }));
+    expect(n.reason).toBe("network_error");
+  });
+
+  test("does not stamp network_error for user aborts", () => {
+    // APIUserAbortError covers caller cancellation and inner stream
+    // deadlines; classifying it as transient would make retry re-run
+    // 30-minute deadline failures.
+    const n = normalizeOpenAIAPIError(new OpenAI.APIUserAbortError());
+    expect(n.reason).not.toBe("network_error");
   });
 
   test("extracts OpenAI-shaped error metadata", () => {

--- a/assistant/src/providers/openai/__tests__/connection-error-wrap.test.ts
+++ b/assistant/src/providers/openai/__tests__/connection-error-wrap.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+
+import OpenAI from "openai";
+
+import { ProviderError } from "../../../util/errors.js";
+import { OpenAIChatCompletionsProvider } from "../chat-completions-provider.js";
+
+function providerThatThrows(error: unknown): OpenAIChatCompletionsProvider {
+  const provider = new OpenAIChatCompletionsProvider("test-key", "test-model", {
+    baseURL: "http://127.0.0.1:1/v1",
+    providerName: "openai-compatible",
+    providerLabel: "OpenAI-compatible",
+  });
+  (provider as unknown as { client: unknown }).client = {
+    chat: {
+      completions: {
+        create: async () => {
+          throw error;
+        },
+      },
+    },
+  };
+  return provider;
+}
+
+describe("connection-error wrapping", () => {
+  test("wraps APIConnectionError with reason network_error and the original as cause", async () => {
+    const cause = Object.assign(new Error("connect ECONNREFUSED"), {
+      code: "ECONNREFUSED",
+    });
+    const sdkError = new OpenAI.APIConnectionError({ cause });
+    const thrown = await providerThatThrows(sdkError)
+      .sendMessage([{ role: "user", content: [{ type: "text", text: "hi" }] }])
+      .then(
+        () => null,
+        (e: unknown) => e,
+      );
+    expect(thrown).toBeInstanceOf(ProviderError);
+    const providerError = thrown as ProviderError;
+    expect(providerError.reason).toBe("network_error");
+    expect(providerError.statusCode).toBeUndefined();
+    expect(providerError.cause).toBe(sdkError);
+  });
+});

--- a/assistant/src/providers/openai/api-error-normalization.ts
+++ b/assistant/src/providers/openai/api-error-normalization.ts
@@ -1,4 +1,4 @@
-import type OpenAI from "openai";
+import OpenAI from "openai";
 
 import type { ProviderErrorReason } from "../../util/errors.js";
 import {
@@ -238,7 +238,16 @@ export function normalizeOpenAIAPIError(
   if (rawBody) {
     out.rawBody = rawBody;
   }
-  out.reason = deriveReason(out, error.status);
+  // Transport failures never reached the server, so there is no status or
+  // body for deriveReason to read; the SDK's error class is the only signal.
+  // APIUserAbortError (caller cancellation, inner stream deadline) is a
+  // sibling class, not a subclass, so it deliberately does NOT match here:
+  // classifying it as a transient network error would make the retry loop
+  // re-run 30-minute deadline failures.
+  out.reason =
+    error instanceof OpenAI.APIConnectionError
+      ? "network_error"
+      : deriveReason(out, error.status);
   return out;
 }
 

--- a/assistant/src/providers/openai/api-error-normalization.ts
+++ b/assistant/src/providers/openai/api-error-normalization.ts
@@ -243,9 +243,14 @@ export function normalizeOpenAIAPIError(
   // APIUserAbortError (caller cancellation, inner stream deadline) is a
   // sibling class, not a subclass, so it deliberately does NOT match here:
   // classifying it as a transient network error would make the retry loop
-  // re-run 30-minute deadline failures.
+  // re-run 30-minute deadline failures. Guarded because test doubles of the
+  // openai module may not define the class.
+  const connectionErrorClass = OpenAI.APIConnectionError as
+    | typeof OpenAI.APIConnectionError
+    | undefined;
   out.reason =
-    error instanceof OpenAI.APIConnectionError
+    typeof connectionErrorClass === "function" &&
+    error instanceof connectionErrorClass
       ? "network_error"
       : deriveReason(out, error.status);
   return out;

--- a/assistant/src/providers/openai/chat-completions-provider.ts
+++ b/assistant/src/providers/openai/chat-completions-provider.ts
@@ -709,8 +709,7 @@ export class OpenAIChatCompletionsProvider implements Provider {
         if (toolChoice !== undefined) {
           const thinkingOn = isThinkingEnabledOnWire(params);
           const skipAutoDefault = thinkingOn && toolChoice === "auto";
-          const skipAllChoices =
-            thinkingOn && this.omitToolChoiceWhenReasoning;
+          const skipAllChoices = thinkingOn && this.omitToolChoiceWhenReasoning;
           if (!skipAutoDefault && !skipAllChoices) {
             params.tool_choice = toolChoice;
           }
@@ -1147,7 +1146,10 @@ export class OpenAIChatCompletionsProvider implements Provider {
           );
         }
         const retryAfterMs = extractRetryAfterMs(error.headers);
+        // `cause` keeps the SDK error's errno-bearing chain reachable for
+        // network-shape classification (`isRetryableNetworkError` walks it).
         const errorOptions: {
+          cause?: unknown;
           retryAfterMs?: number;
           abortReason?: unknown;
           apiErrorCode?: string;
@@ -1156,7 +1158,7 @@ export class OpenAIChatCompletionsProvider implements Provider {
           requestId?: string;
           rawBody?: string;
           reason?: ProviderErrorReason;
-        } = {};
+        } = { cause: error };
         if (retryAfterMs !== undefined) {
           errorOptions.retryAfterMs = retryAfterMs;
         }
@@ -1185,7 +1187,7 @@ export class OpenAIChatCompletionsProvider implements Provider {
           formattedMessage,
           this.name,
           error.status,
-          Object.keys(errorOptions).length > 0 ? errorOptions : undefined,
+          errorOptions,
         );
       }
       throw new ProviderError(

--- a/assistant/src/providers/openai/responses-provider.ts
+++ b/assistant/src/providers/openai/responses-provider.ts
@@ -680,7 +680,10 @@ export class OpenAIResponsesProvider implements Provider {
           });
         }
         const retryAfterMs = extractRetryAfterMs(error.headers);
+        // `cause` keeps the SDK error's errno-bearing chain reachable for
+        // network-shape classification (`isRetryableNetworkError` walks it).
         const errorOptions: {
+          cause?: unknown;
           retryAfterMs?: number;
           abortReason?: unknown;
           apiErrorCode?: string;
@@ -689,7 +692,7 @@ export class OpenAIResponsesProvider implements Provider {
           requestId?: string;
           rawBody?: string;
           reason?: ProviderErrorReason;
-        } = {};
+        } = { cause: error };
         if (retryAfterMs !== undefined) {
           errorOptions.retryAfterMs = retryAfterMs;
         }
@@ -718,7 +721,7 @@ export class OpenAIResponsesProvider implements Provider {
           formattedMessage,
           this.name,
           error.status,
-          Object.keys(errorOptions).length > 0 ? errorOptions : undefined,
+          errorOptions,
         );
       }
       throw new ProviderError(

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -246,14 +246,11 @@ const RETRYABLE_PROVIDER_ERROR_REASONS = new Set<ProviderErrorReason>([
   "rate_limited",
   "overloaded",
   "server_error",
-  // Stamped for SDK transport failures that never reached the server
-  // (OpenAI APIConnectionError, Gemini proxy interception). Deliberate
-  // behavior change alongside the stamping: previously these fell through to
-  // `isRetryableNetworkError`, which missed them because the ProviderError
-  // wrap dropped the errno-bearing cause chain, so they were silently
-  // non-retryable. Deadline/cancellation shapes never carry this reason
-  // (they surface as APIUserAbortError / abortReason and short-circuit
-  // above), so this cannot re-retry 30-minute stream deadline failures.
+  // Transport failures that never reached the server (SDK connection
+  // errors, Gemini proxy interception). Deadline and cancellation shapes
+  // never carry this reason — they surface as reason-less aborts and
+  // short-circuit in isRetryableError before the reason check — so a
+  // 30-minute stream deadline failure is never retried through it.
   "network_error",
 ]);
 

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -246,6 +246,15 @@ const RETRYABLE_PROVIDER_ERROR_REASONS = new Set<ProviderErrorReason>([
   "rate_limited",
   "overloaded",
   "server_error",
+  // Stamped for SDK transport failures that never reached the server
+  // (OpenAI APIConnectionError, Gemini proxy interception). Deliberate
+  // behavior change alongside the stamping: previously these fell through to
+  // `isRetryableNetworkError`, which missed them because the ProviderError
+  // wrap dropped the errno-bearing cause chain, so they were silently
+  // non-retryable. Deadline/cancellation shapes never carry this reason
+  // (they surface as APIUserAbortError / abortReason and short-circuit
+  // above), so this cannot re-retry 30-minute stream deadline failures.
+  "network_error",
 ]);
 
 function isRetryableStreamError(error: unknown): boolean {


### PR DESCRIPTION
## Summary
- `normalizeOpenAIAPIError` now stamps `reason: "network_error"` when the error is the SDK's `APIConnectionError` (a transport failure that never reached the server, so there is no status or body for `deriveReason` to read). `APIUserAbortError` is deliberately NOT matched: it covers caller cancellation and inner stream deadlines, and classifying it as transient would make retry re-run 30-minute deadline failures. Both OpenAI-compat adapters (chat-completions + responses, so every subclass provider) also keep the original SDK error as `cause`, restoring the errno-bearing chain for network-shape classification.
- `network_error` joins `RETRYABLE_PROVIDER_ERROR_REASONS`. This is the one deliberate behavior change: previously these failures fell through to `isRetryableNetworkError`, which missed them because the wrap dropped the cause chain, so genuine connection blips were never retried on the OpenAI-compat path. Abort/deadline shapes never carry the reason, so the anchored transport-abort pattern rules in retry.ts keep their guarantees; a regression test locks the statusless reason-less "Request was aborted." shape as non-retryable.
- The `network_error` classification copy in conversation-error.ts is generalized: it previously described only its single Gemini producer (empty-body proxy interception) and would have mislabeled plain connection failures; its telemetry category is renamed `provider_network_proxy_intercepted` to `provider_network_error` accordingly.

## Original prompt
Follow-up from the PR #41015 QA round: an unreachable upstream surfaced in the profile save probe as blame "unknown" because the SDK's connection errors carry no semantic reason, and the fix there was a probe-local pattern match. The ask was to do the deeper version as its own change: stamp the reason at the adapter level so every consumer benefits, with explicit care for the dispatch/retry error path shared by live chat, keeping the original error as cause, and proving via tests that abort/deadline failures do not become retryable. The probe-local fallback in #41015 becomes removable once both PRs merge; it is untouched here to keep the two independent.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41053" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->