### PR TITLE
feat(voice): forward tool_use_preview_start to voice turn callbacks

### DIFF
--- a/assistant/src/calls/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/calls/__tests__/voice-session-bridge.test.ts
@@ -1472,10 +1472,11 @@ describe("startVoiceTurn race-loss state restore", () => {
 });
 
 describe("startVoiceTurn tool-event forwarding", () => {
-  // The agent loop's tool_use_start / tool_result events reach the voice
-  // callbacks so the session can track per-turn tool activity. The bridge is
-  // the single truncation point for tool results — the raw result can be
-  // huge and must never travel further into the voice layer.
+  // The agent loop's tool_use_preview_start / tool_use_start / tool_result
+  // events reach the voice callbacks so the session can track per-turn tool
+  // activity. The bridge is the single truncation point for tool results —
+  // the raw result can be huge and must never travel further into the voice
+  // layer.
 
   /** Scripts runAgentLoop to emit the given agent-loop events in order. */
   function makeEventEmittingConversation(events: unknown[]) {
@@ -1598,8 +1599,95 @@ describe("startVoiceTurn tool-event forwarding", () => {
     ]);
   });
 
+  test("tool_use_preview_start delivers the tool name and id", async () => {
+    makeEventEmittingConversation([
+      {
+        type: "tool_use_preview_start",
+        toolName: "web_search",
+        toolUseId: "toolu-1",
+      },
+    ]);
+
+    const previews: Array<{ toolName: string; toolUseId: string }> = [];
+    await startVoiceTurn({
+      ...makeTurnOptions(),
+      callbacks: {
+        tool_use_preview_start: (toolName, toolUseId) =>
+          previews.push({ toolName, toolUseId }),
+      },
+    });
+    await flushMicrotasks();
+
+    expect(previews).toEqual([
+      { toolName: "web_search", toolUseId: "toolu-1" },
+    ]);
+  });
+
+  test("a turn with no tool calls never fires tool_use_preview_start", async () => {
+    makeEventEmittingConversation([
+      { type: "assistant_text_delta", text: "hello" },
+    ]);
+
+    const previews: string[] = [];
+    await startVoiceTurn({
+      ...makeTurnOptions(),
+      callbacks: {
+        tool_use_preview_start: (toolName) => previews.push(toolName),
+      },
+    });
+    await flushMicrotasks();
+
+    expect(previews).toEqual([]);
+  });
+
+  test("the preview and the definitive start are independent callbacks", async () => {
+    // The preview is a structural signal only. Activity display keys off
+    // tool_use_start, so that callback must still fire with its full detail
+    // regardless of whether a consumer observes the preview.
+    makeEventEmittingConversation([
+      {
+        type: "tool_use_preview_start",
+        toolName: "web_search",
+        toolUseId: "toolu-1",
+      },
+      {
+        type: "tool_use_start",
+        toolName: "web_search",
+        input: { query: "weather" },
+        toolUseId: "toolu-1",
+      },
+    ]);
+
+    const fired: string[] = [];
+    const starts: Array<{ toolName: string; detail?: unknown }> = [];
+    await startVoiceTurn({
+      ...makeTurnOptions(),
+      callbacks: {
+        tool_use_preview_start: () => fired.push("preview"),
+        tool_use_start: (toolName, detail) => {
+          fired.push("start");
+          starts.push({ toolName, detail });
+        },
+      },
+    });
+    await flushMicrotasks();
+
+    expect(fired).toEqual(["preview", "start"]);
+    expect(starts).toEqual([
+      {
+        toolName: "web_search",
+        detail: { toolUseId: "toolu-1", input: { query: "weather" } },
+      },
+    ]);
+  });
+
   test("a callbacks object without the tool-event members doesn't throw", async () => {
     makeEventEmittingConversation([
+      {
+        type: "tool_use_preview_start",
+        toolName: "web_search",
+        toolUseId: "toolu-1",
+      },
       {
         type: "tool_use_start",
         toolName: "web_search",

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -250,6 +250,18 @@ export interface VoiceTurnCallbacks {
     toolName: string,
     detail?: { toolUseId?: string; input?: Record<string, unknown> },
   ) => void;
+  /**
+   * Fired when the provider OPENS a tool-use content block, before its input
+   * JSON streams - earlier and weaker than `tool_use_start`, which waits for a
+   * definitive, parsed call.
+   *
+   * Consumers must not use this to display or act on a tool: the call may
+   * never materialize. It is a structural signal about the RESPONSE, not the
+   * tool - once a tool-use block opens, the text block before it is closed, so
+   * any text streamed since the last block boundary was working commentary
+   * rather than the turn's answer.
+   */
+  tool_use_preview_start?: (toolName: string, toolUseId: string) => void;
   /** Fired when a tool invocation finishes. */
   tool_result?: (event: VoiceToolResultEvent) => void;
 }
@@ -1700,6 +1712,16 @@ export async function startVoiceTurn(
             eventSink.onError(msg.userMessage);
           } else if (msg.type === "tool_use_start") {
             eventSink.onToolUse(msg.toolName, msg.input, msg.toolUseId);
+          } else if (msg.type === "tool_use_preview_start") {
+            // Routed through `opts.callbacks` rather than `eventSink`: the
+            // sink is the phone-shaped surface, and this is a live-voice-only
+            // structural signal about the response. Activity display stays on
+            // the definitive `tool_use_start`, which is the only tool event a
+            // consumer may show or act on.
+            opts.callbacks?.tool_use_preview_start?.(
+              msg.toolName,
+              msg.toolUseId,
+            );
           } else if (msg.type === "tool_result") {
             eventSink.onToolResult({
               toolName: msg.toolName,
@@ -1711,8 +1733,6 @@ export async function startVoiceTurn(
               ),
             });
           }
-          // Note: tool_use_preview_start is intentionally not handled here.
-          // Voice only reacts to the definitive tool_use_start event.
         },
         // Front-door legs resolve through their own call site, whose shipped
         // default pins the latency-class verdict model (see


### PR DESCRIPTION
## Summary
- Add an optional `tool_use_preview_start` callback to `VoiceTurnCallbacks`, fired when the provider opens a tool-use content block.
- Forward the event from the agent loop through `opts.callbacks`; activity display still keys off the definitive `tool_use_start`.
- Behavior-neutral: no consumer sets the callback yet.

Part of plan: voice-speak-final-answer-only.md (PR 1 of 6)