### PR TITLE
feat(voice): render a working-cue tone as PCM

### DIFF
--- a/assistant/src/live-voice/__tests__/working-cue.test.ts
+++ b/assistant/src/live-voice/__tests__/working-cue.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Tests for the working-cue renderer: the framing contract (mono s16le at the
+ * requested rate), and the acoustic properties that decide whether the cue
+ * reads as a hold tone or as a glitch. The anti-click, no-clipping, and
+ * no-DC-offset assertions are the substance here: none of them is visible by
+ * reading the output, and all three are audible immediately if they break.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  DEFAULT_WORKING_CUE_SHAPE,
+  renderWorkingCuePcm,
+  type WorkingCueShape,
+} from "../working-cue.js";
+
+// Sample rates a client can ask for on the start frame: the STT-typical rate,
+// the TTS-typical one, and full-band.
+const SAMPLE_RATES = [16_000, 24_000, 48_000];
+
+// Mirrors FADE_FRACTION in the module under test. Duplicated rather than
+// exported because the tests assert the *shape* of the envelope, and reading
+// the production constant would let a bad value pass by agreeing with itself.
+const FADE_FRACTION = 0.15;
+
+const INT16_PEAK = 32_767;
+
+function samplesOf(pcm: Buffer): number[] {
+  const samples: number[] = [];
+  for (let offset = 0; offset < pcm.byteLength; offset += 2) {
+    samples.push(pcm.readInt16LE(offset));
+  }
+  return samples;
+}
+
+function expectedFrameCount(
+  sampleRate: number,
+  shape: WorkingCueShape,
+): number {
+  return Math.round((sampleRate * shape.durationMs) / 1_000);
+}
+
+describe("renderWorkingCuePcm", () => {
+  test.each(SAMPLE_RATES)(
+    "at %i Hz emits one s16le frame per sample of the requested duration",
+    (sampleRate) => {
+      const pcm = renderWorkingCuePcm(sampleRate, DEFAULT_WORKING_CUE_SHAPE);
+      const frames = expectedFrameCount(sampleRate, DEFAULT_WORKING_CUE_SHAPE);
+
+      expect(frames).toBeGreaterThan(0);
+      // Mono, 2 bytes per sample, no container header of any kind: the echo
+      // reference reads these bytes as bare PCM at the session rate.
+      expect(pcm.byteLength).toBe(frames * 2);
+    },
+  );
+
+  test.each(SAMPLE_RATES)(
+    "at %i Hz starts and ends at silence so neither edge clicks",
+    (sampleRate) => {
+      const samples = samplesOf(
+        renderWorkingCuePcm(sampleRate, DEFAULT_WORKING_CUE_SHAPE),
+      );
+
+      expect(samples[0]).toBe(0);
+      expect(samples[samples.length - 1]).toBe(0);
+
+      // Zero endpoints alone would also be satisfied by a waveform that leaps
+      // to full amplitude on the second sample, which clicks just as loudly.
+      // The ramp has to be gradual, so the first and last millisecond stay far
+      // below the peak.
+      const oneMs = Math.round(sampleRate / 1_000);
+      const ceiling = 0.05 * DEFAULT_WORKING_CUE_SHAPE.gain * INT16_PEAK;
+      for (let frame = 0; frame < oneMs; frame++) {
+        expect(Math.abs(samples[frame]!)).toBeLessThan(ceiling);
+        expect(Math.abs(samples[samples.length - 1 - frame]!)).toBeLessThan(
+          ceiling,
+        );
+      }
+    },
+  );
+
+  test.each(SAMPLE_RATES)(
+    "at %i Hz never exceeds the requested gain",
+    (sampleRate) => {
+      const samples = samplesOf(
+        renderWorkingCuePcm(sampleRate, DEFAULT_WORKING_CUE_SHAPE),
+      );
+      const peak = Math.round(DEFAULT_WORKING_CUE_SHAPE.gain * INT16_PEAK);
+
+      for (const sample of samples) {
+        expect(Math.abs(sample)).toBeLessThanOrEqual(peak);
+      }
+    },
+  );
+
+  test.each(SAMPLE_RATES)(
+    "at %i Hz reaches full amplitude inside the sustain",
+    (sampleRate) => {
+      const samples = samplesOf(
+        renderWorkingCuePcm(sampleRate, DEFAULT_WORKING_CUE_SHAPE),
+      );
+      const peak = Math.round(DEFAULT_WORKING_CUE_SHAPE.gain * INT16_PEAK);
+
+      let loudest = 0;
+      let loudestFrame = -1;
+      samples.forEach((sample, frame) => {
+        if (Math.abs(sample) > loudest) {
+          loudest = Math.abs(sample);
+          loudestFrame = frame;
+        }
+      });
+
+      // The envelope must open all the way, otherwise the cue is quieter than
+      // the configured gain and the fades are eating the whole tone.
+      expect(loudest).toBeGreaterThanOrEqual(0.99 * peak);
+
+      const fadeFrames = Math.floor(samples.length * FADE_FRACTION);
+      expect(loudestFrame).toBeGreaterThanOrEqual(fadeFrames);
+      expect(loudestFrame).toBeLessThan(samples.length - fadeFrames);
+    },
+  );
+
+  test.each(SAMPLE_RATES)("at %i Hz carries no DC offset", (sampleRate) => {
+    const samples = samplesOf(
+      renderWorkingCuePcm(sampleRate, DEFAULT_WORKING_CUE_SHAPE),
+    );
+    const peak = Math.round(DEFAULT_WORKING_CUE_SHAPE.gain * INT16_PEAK);
+    const mean = samples.reduce((a, b) => a + b, 0) / samples.length;
+
+    // A nonzero mean is inaudible on its own but shifts the echo reference off
+    // centre and eats headroom on whatever mixes the cue with speech.
+    expect(Math.abs(mean)).toBeLessThan(peak / 1_000);
+  });
+
+  test("is deterministic for a given rate and shape", () => {
+    const first = renderWorkingCuePcm(24_000, DEFAULT_WORKING_CUE_SHAPE);
+    const second = renderWorkingCuePcm(24_000, DEFAULT_WORKING_CUE_SHAPE);
+
+    expect(first.equals(second)).toBe(true);
+  });
+
+  test("honours a shape other than the default", () => {
+    const shape: WorkingCueShape = {
+      frequencyHz: 440,
+      durationMs: 100,
+      gain: 0.02,
+    };
+    const samples = samplesOf(renderWorkingCuePcm(24_000, shape));
+
+    expect(samples).toHaveLength(expectedFrameCount(24_000, shape));
+    for (const sample of samples) {
+      expect(Math.abs(sample)).toBeLessThanOrEqual(
+        Math.round(shape.gain * INT16_PEAK),
+      );
+    }
+  });
+
+  test("clamps an out-of-range gain instead of overflowing int16", () => {
+    // Gain becomes a config value, so a bad one has to render quietly wrong
+    // rather than throw partway through the buffer.
+    const samples = samplesOf(
+      renderWorkingCuePcm(24_000, { ...DEFAULT_WORKING_CUE_SHAPE, gain: 4 }),
+    );
+
+    for (const sample of samples) {
+      expect(Math.abs(sample)).toBeLessThanOrEqual(INT16_PEAK);
+    }
+  });
+
+  test("renders nothing for a zero-length cue", () => {
+    const pcm = renderWorkingCuePcm(24_000, {
+      ...DEFAULT_WORKING_CUE_SHAPE,
+      durationMs: 0,
+    });
+
+    expect(pcm.byteLength).toBe(0);
+  });
+
+  test("a cue too short to hold both fades still opens and closes at zero", () => {
+    // Two frames leaves one for the attack and one for the release, so the
+    // envelope has to degrade to all-fade rather than overlapping itself.
+    const samples = samplesOf(
+      renderWorkingCuePcm(24_000, {
+        ...DEFAULT_WORKING_CUE_SHAPE,
+        durationMs: 2 / 24,
+      }),
+    );
+
+    expect(samples).toHaveLength(2);
+    expect(samples[0]).toBe(0);
+    expect(samples[1]).toBe(0);
+  });
+});
+
+describe("DEFAULT_WORKING_CUE_SHAPE", () => {
+  test("stays a soft hum well under speech level", () => {
+    // Guards the intent of the defaults rather than the exact numbers, which
+    // are meant to be retuned by ear.
+    expect(DEFAULT_WORKING_CUE_SHAPE.gain).toBeGreaterThan(0);
+    expect(DEFAULT_WORKING_CUE_SHAPE.gain).toBeLessThan(0.2);
+    expect(DEFAULT_WORKING_CUE_SHAPE.frequencyHz).toBeGreaterThan(80);
+    expect(DEFAULT_WORKING_CUE_SHAPE.frequencyHz).toBeLessThan(1_000);
+    expect(DEFAULT_WORKING_CUE_SHAPE.durationMs).toBeGreaterThan(0);
+    expect(DEFAULT_WORKING_CUE_SHAPE.durationMs).toBeLessThan(1_000);
+  });
+});

--- a/assistant/src/live-voice/working-cue.ts
+++ b/assistant/src/live-voice/working-cue.ts
@@ -1,0 +1,126 @@
+/**
+ * The working cue: a short, wordless tone that holds the floor while the
+ * assistant is busy on a tool-heavy turn.
+ *
+ * Words are the wrong instrument for that job. A spoken progress line makes a
+ * claim ("still working on it") that has to be true, has to be translated, and
+ * has to be re-said every few seconds before it starts sounding anxious. A
+ * tone claims nothing, needs no language, and reads as "the line is still
+ * open" the way a hold tone does on a phone call.
+ */
+
+/** The tunable dimensions of the cue. Every field is meant to be tried by ear. */
+export interface WorkingCueShape {
+  /** Fundamental in Hz. Low reads as a hum, high as a chime. */
+  frequencyHz: number;
+  /** Total length including fade in and out. */
+  durationMs: number;
+  /** Peak amplitude, 0..1. Well below speech so it sits under the call. */
+  gain: number;
+}
+
+/**
+ * Starting point for the cue, chosen to sound like a soft hum under the call
+ * rather than a notification demanding attention: low enough to sit beneath a
+ * speaking voice, short enough to read as punctuation, quiet enough that a
+ * listener notices the room is still occupied without listening *to* it.
+ *
+ * Every number here is a first guess, not a result. All three become config
+ * values, so treat them as defaults to override rather than as constants that
+ * carry meaning.
+ */
+export const DEFAULT_WORKING_CUE_SHAPE: WorkingCueShape = {
+  frequencyHz: 220,
+  durationMs: 260,
+  gain: 0.09,
+};
+
+/**
+ * Portion of the buffer given to the attack, and the same again to the
+ * release. A fifteenth-ish of a quarter-second is a few tens of milliseconds:
+ * long enough to remove the click (see below), short enough that the cue still
+ * has an audible body between the two ramps.
+ */
+const FADE_FRACTION = 0.15;
+
+/**
+ * Full-scale for signed 16-bit samples. 32767 rather than 32768 so a peak of
+ * exactly `gain` cannot round to -32768, which has no positive counterpart.
+ */
+const INT16_PEAK = 32767;
+
+/**
+ * Render the cue as mono signed 16-bit little-endian PCM at `sampleRate`.
+ *
+ * Rendered rather than shipped as an asset: the session's sample rate is
+ * whatever the client asked for on the start frame, so an asset would need
+ * resampling, and every parameter here is a number worth tuning by ear.
+ *
+ * Raw samples only, with no WAV or other container header. The bytes ride the
+ * same `tts_audio` frame path as synthesized speech, and the session's echo
+ * canceller feeds its reference from that path by treating the payload as
+ * bare `audio/pcm` at the session rate. A header would be interpreted as
+ * leading samples: audible as a tick, and worse, wrong in the echo reference.
+ */
+export function renderWorkingCuePcm(
+  sampleRate: number,
+  shape: WorkingCueShape,
+): Buffer {
+  const frameCount = Math.max(
+    0,
+    Math.round((sampleRate * shape.durationMs) / 1_000),
+  );
+  const pcm = Buffer.alloc(frameCount * 2);
+
+  // Both ramps have to fit, so a cue too short for the nominal fraction
+  // degrades to all attack and release rather than letting the two envelopes
+  // overlap. At least one fade frame whenever there is room for one: dropping
+  // the ramp on a very short cue would reintroduce exactly the click the
+  // envelope exists to remove.
+  const fadeFrames = Math.min(
+    Math.max(1, Math.floor(frameCount * FADE_FRACTION)),
+    Math.floor(frameCount / 2),
+  );
+  const radiansPerFrame = (2 * Math.PI * shape.frequencyHz) / sampleRate;
+  // Gain is clamped here rather than per sample: it arrives from config, and a
+  // value outside 0..1 would otherwise make `writeInt16LE` throw partway
+  // through the render on the first sample that overflows.
+  const peak = Math.min(1, Math.max(0, shape.gain)) * INT16_PEAK;
+
+  for (let frame = 0; frame < frameCount; frame++) {
+    const sample =
+      envelopeAt(frame, frameCount, fadeFrames) *
+      peak *
+      Math.sin(radiansPerFrame * frame);
+    pcm.writeInt16LE(Math.round(sample), frame * 2);
+  }
+
+  return pcm;
+}
+
+/**
+ * Raised-cosine attack and release, 0 at both edges and 1 across the sustain.
+ *
+ * This is required, not cosmetic. A sine that begins or ends at a nonzero
+ * amplitude is a step discontinuity, and a step is broadband: the listener
+ * hears a click. A click does not read as a cue that the assistant is working,
+ * it reads as a glitch in the call, which is the opposite of the reassurance
+ * the tone exists to give. The raised cosine is chosen over a linear ramp
+ * because its slope is also zero at the edges, so neither the amplitude nor
+ * its first derivative jumps.
+ */
+function envelopeAt(
+  frame: number,
+  frameCount: number,
+  fadeFrames: number,
+): number {
+  if (fadeFrames <= 0) {
+    return 1;
+  }
+  // Distance from whichever edge is nearer, so the release mirrors the attack.
+  const framesFromEdge = Math.min(frame, frameCount - 1 - frame);
+  if (framesFromEdge >= fadeFrames) {
+    return 1;
+  }
+  return 0.5 * (1 - Math.cos((Math.PI * framesFromEdge) / fadeFrames));
+}


### PR DESCRIPTION
## Summary
- Add `renderWorkingCuePcm`, a pure renderer producing a short mono s16le tone at an arbitrary sample rate, with raised-cosine fades so neither edge clicks.
- Export tunable default shape constants (frequency, duration, gain).
- Imported by nobody yet; a later PR plays it on the session idle tick.

Part of plan: voice-speak-final-answer-only.md (PR 5 of 6)