### PR TITLE
fix(voice): acknowledge the task rather than ask for a moment to think

### DIFF
--- a/assistant/src/calls/__tests__/voice-triage-escalate.test.ts
+++ b/assistant/src/calls/__tests__/voice-triage-escalate.test.ts
@@ -180,12 +180,23 @@ describe("front-door decision rule", () => {
     // The escalated leg can run for a minute of tools and reasoning, and it
     // runs near-silent. A phrase promising "one second" sets an expectation
     // that the silence then breaks, so the sentence has to accept the task,
-    // name the work, and imply a result is coming back.
+    // name the work, and imply a reply is coming back.
     expect(rule.toLowerCase()).toContain("accepts the task");
     expect(rule.toLowerCase()).toContain("names what you are going to do");
     expect(rule.toLowerCase()).toContain(
-      "promise a result instead of asking for a moment to think",
+      "promise a response instead of asking for a moment to think",
     );
+  });
+
+  test("forbids promising the task is already finished", () => {
+    // The escalated leg is allowed to come back with a question it genuinely
+    // needs answered, or with a tool failure. An acknowledgement that
+    // promised completion is contradicted by the next thing the caller
+    // hears, so the rule has to ask for a promise of contact, not success.
+    expect(rule.toLowerCase()).toContain(
+      "never promise the task is already finished",
+    );
+    expect(rule.toLowerCase()).toContain("ask the caller for a missing detail");
   });
 
   test("hold completeness is judged in the caller's language", () => {
@@ -289,6 +300,43 @@ describe("fallbackEscalationBridgeFor", () => {
     );
   });
 
+  test("no localized bridge promises the task will be finished", () => {
+    // The escalated leg may come back with a clarifying question or a tool
+    // failure, so every canned bridge promises contact and none promises
+    // success. There is no language-agnostic way to assert that, so this is
+    // a regression guard rather than a proof: each language lists the
+    // completion-conditional phrasings ("when it's done", "wenn es fertig
+    // ist") that an earlier revision of this table used and that a rewrite
+    // is most likely to reach for again. A language may only be added to
+    // the bridge table once it has an entry here, which forces the question
+    // to be asked for the new copy too.
+    const completionPhrasings: Readonly<Record<string, readonly string[]>> = {
+      en: ["when it's done", "when it's sent", "once it's done"],
+      es: ["cuando esté listo", "cuando termine", "cuando lo tenga"],
+      fr: ["dès que c'est prêt", "quand c'est prêt", "une fois terminé"],
+      de: ["wenn es fertig ist", "sobald es fertig ist", "wenn ich fertig bin"],
+      hi: ["पूरा होते ही", "हो जाने पर", "पूरा हो जाए"],
+      ru: ["когда будет готово", "как только будет готово", "когда закончу"],
+      pt: [
+        "quando estiver pronto",
+        "assim que estiver pronto",
+        "quando acabar",
+      ],
+      ja: ["終わりましたら", "完了しましたら", "終わり次第"],
+      it: ["quando è pronto", "quando ho finito", "appena è pronto"],
+      nl: ["als het klaar is", "zodra het klaar is", "als ik klaar ben"],
+    };
+    for (const [language, bridge] of Object.entries(
+      FALLBACK_ESCALATION_BRIDGE_BY_LANGUAGE,
+    )) {
+      const phrasings = completionPhrasings[language];
+      expect(phrasings).toBeDefined();
+      for (const phrasing of phrasings!) {
+        expect(bridge.toLowerCase()).not.toContain(phrasing.toLowerCase());
+      }
+    }
+  });
+
   test("falls back to English for unknown or absent languages", () => {
     expect(fallbackEscalationBridgeFor()).toBe(FALLBACK_ESCALATION_BRIDGE);
     expect(fallbackEscalationBridgeFor("ko")).toBe(FALLBACK_ESCALATION_BRIDGE);
@@ -358,7 +406,7 @@ describe("isEscalationBridgeComplete", () => {
     // terminator, never by buffering to the char cap; the canned bridges are
     // the canonical sample of each language's ender. The cap-identity check
     // is also what keeps each canned bridge to ONE sentence: capping cuts at
-    // the first terminator, so a second sentence (the "I'll let you know"
+    // the first terminator, so a second sentence (the "I'll get back to you"
     // half of the promise) would be truncated away before it was spoken.
     for (const bridge of Object.values(
       FALLBACK_ESCALATION_BRIDGE_BY_LANGUAGE,
@@ -454,6 +502,7 @@ describe("escalation continuation content", () => {
     // for the pause instead of delivering the result.
     const content = ESCALATION_CONTINUATION_CONTENT.toLowerCase();
     expect(content).toContain("accept the task");
+    expect(content).toContain("come back to them");
     expect(content).toContain("heard nothing");
     expect(content).toContain("do not repeat");
   });

--- a/assistant/src/calls/__tests__/voice-triage-escalate.test.ts
+++ b/assistant/src/calls/__tests__/voice-triage-escalate.test.ts
@@ -16,6 +16,7 @@ import {
   HOLD_VERDICT_TOKEN,
   isEscalationBridgeComplete,
   MAX_ESCALATION_BRIDGE_CHARS,
+  MIN_SPOKEN_BRIDGE_CHARS,
   needsFallbackBridge,
   spokenBridgeText,
 } from "../voice-triage-escalate.js";
@@ -25,9 +26,9 @@ describe("frontDoorCapabilityDigest", () => {
     const digest = frontDoorCapabilityDigest(["calendar_read", "web_search"]);
     expect(digest).toContain("calendar_read, web_search");
     expect(digest.toLowerCase()).toContain("escalate");
-    // The digest teaches routing, and the bridge phrase should name the
+    // The digest teaches routing, and the spoken sentence should name the
     // action rather than the model refusing or guessing.
-    expect(digest.toLowerCase()).toContain("holding phrase");
+    expect(digest.toLowerCase()).toContain("name the action");
   });
 
   test("is empty when no tool names are available (registry-less contexts)", () => {
@@ -170,9 +171,21 @@ describe("front-door decision rule", () => {
     );
   });
 
-  test("demands a single-sentence holding phrase on escalation", () => {
-    expect(rule.toLowerCase()).toContain("one short natural holding phrase");
+  test("demands a single-sentence acknowledgement on escalation", () => {
+    expect(rule.toLowerCase()).toContain("one short natural sentence");
     expect(rule.toLowerCase()).toContain("stop after that single sentence");
+  });
+
+  test("asks for an acknowledgement, not a request for thinking time", () => {
+    // The escalated leg can run for a minute of tools and reasoning, and it
+    // runs near-silent. A phrase promising "one second" sets an expectation
+    // that the silence then breaks, so the sentence has to accept the task,
+    // name the work, and imply a result is coming back.
+    expect(rule.toLowerCase()).toContain("accepts the task");
+    expect(rule.toLowerCase()).toContain("names what you are going to do");
+    expect(rule.toLowerCase()).toContain(
+      "promise a result instead of asking for a moment to think",
+    );
   });
 
   test("hold completeness is judged in the caller's language", () => {
@@ -193,9 +206,9 @@ describe("front-door decision rule", () => {
     expect(rule).toContain("Answer in the language the caller is speaking.");
   });
 
-  test("the escalation holding phrase demands the caller's language", () => {
+  test("the escalation acknowledgement demands the caller's language", () => {
     // The bridge examples are English; without an explicit requirement a
-    // Spanish turn that needs a tool gets an English holding phrase before
+    // Spanish turn that needs a tool gets an English acknowledgement before
     // the localized answer. The examples stay, labeled as English only.
     expect(rule).toContain("spoken in the language the caller is speaking");
     expect(rule).toContain("those examples are English only");
@@ -235,7 +248,7 @@ describe("escalated continuation rule", () => {
     );
   });
 
-  test("bans re-announcing the holding phrase (bridge-echo regression)", () => {
+  test("bans re-announcing the acknowledgement (bridge-echo regression)", () => {
     // Regression: after the bridge "Let me check your calendar", the quality
     // model opened with "Let me check what calendar connections…" — a
     // re-announcement echo. The rule must ban paraphrase/re-announce openers,
@@ -256,11 +269,14 @@ describe("fallbackEscalationBridgeFor", () => {
     }
   });
 
-  test("every bridge fits the session-side cap", () => {
+  test("every bridge fits between the spoken threshold and the cap", () => {
     for (const bridge of Object.values(
       FALLBACK_ESCALATION_BRIDGE_BY_LANGUAGE,
     )) {
       expect(bridge.length).toBeLessThanOrEqual(MAX_ESCALATION_BRIDGE_CHARS);
+      // Above the spoken threshold, so escalating with no bridge of the
+      // model's own still gives the caller real audio rather than nothing.
+      expect(bridge.trim().length).toBeGreaterThan(MIN_SPOKEN_BRIDGE_CHARS);
     }
   });
 
@@ -340,7 +356,10 @@ describe("isEscalationBridgeComplete", () => {
   test("every localized fallback bridge ends in a recognized terminator", () => {
     // A model-spoken bridge in any roster language must hand off at its
     // terminator, never by buffering to the char cap; the canned bridges are
-    // the canonical sample of each language's ender.
+    // the canonical sample of each language's ender. The cap-identity check
+    // is also what keeps each canned bridge to ONE sentence: capping cuts at
+    // the first terminator, so a second sentence (the "I'll let you know"
+    // half of the promise) would be truncated away before it was spoken.
     for (const bridge of Object.values(
       FALLBACK_ESCALATION_BRIDGE_BY_LANGUAGE,
     )) {
@@ -374,15 +393,15 @@ describe("spokenBridgeText", () => {
 });
 
 describe("needsFallbackBridge", () => {
-  test("false when the model spoke a real holding phrase after the verdict", () => {
+  test("false when the model spoke a real acknowledgement after the verdict", () => {
     expect(
       needsFallbackBridge(
-        `${ESCALATE_VERDICT_TOKEN} Let me think about that for a second.`,
+        `${ESCALATE_VERDICT_TOKEN} I'll check your calendar and let you know.`,
       ),
     ).toBe(false);
   });
 
-  test("true for a bare escalate verdict with no holding phrase", () => {
+  test("true for a bare escalate verdict with no acknowledgement", () => {
     expect(needsFallbackBridge(ESCALATE_VERDICT_TOKEN)).toBe(true);
   });
 });
@@ -426,6 +445,17 @@ describe("escalation continuation content", () => {
   test("is an echo-suppressed synthetic prompt (parenthesized, non-user-speech)", () => {
     expect(ESCALATION_CONTINUATION_CONTENT.startsWith("(")).toBe(true);
     expect(ESCALATION_CONTINUATION_CONTENT.endsWith(")")).toBe(true);
+  });
+
+  test("states the real premise: task accepted, silence since", () => {
+    // The escalated leg is not resuming from "give me a second to think":
+    // the caller was told the work was underway and has heard nothing since.
+    // Getting the premise wrong is what produces an answer that apologizes
+    // for the pause instead of delivering the result.
+    const content = ESCALATION_CONTINUATION_CONTENT.toLowerCase();
+    expect(content).toContain("accept the task");
+    expect(content).toContain("heard nothing");
+    expect(content).toContain("do not repeat");
   });
 });
 

--- a/assistant/src/calls/__tests__/voice-triage-escalate.test.ts
+++ b/assistant/src/calls/__tests__/voice-triage-escalate.test.ts
@@ -305,11 +305,10 @@ describe("fallbackEscalationBridgeFor", () => {
     // failure, so every canned bridge promises contact and none promises
     // success. There is no language-agnostic way to assert that, so this is
     // a regression guard rather than a proof: each language lists the
-    // completion-conditional phrasings ("when it's done", "wenn es fertig
-    // ist") that an earlier revision of this table used and that a rewrite
-    // is most likely to reach for again. A language may only be added to
-    // the bridge table once it has an entry here, which forces the question
-    // to be asked for the new copy too.
+    // completion-conditional phrasings a rewrite is most likely to reach
+    // for. A language may only be added to the bridge table once it has an
+    // entry here, which forces the question to be asked for the new copy
+    // too.
     const completionPhrasings: Readonly<Record<string, readonly string[]>> = {
       en: ["when it's done", "when it's sent", "once it's done"],
       es: ["cuando esté listo", "cuando termine", "cuando lo tenga"],

--- a/assistant/src/calls/voice-triage-escalate.ts
+++ b/assistant/src/calls/voice-triage-escalate.ts
@@ -10,10 +10,10 @@
  *     acknowledgement: the turn is too tricky, so the acknowledgement is
  *     spoken (capped at a single sentence) while the turn re-runs on the
  *     call-site default profile, the model an un-routed voice turn would
- *     have used. It accepts the task and promises a report back rather than
- *     asking for a pause: the escalated leg can spend a minute on tools and
- *     reasoning, and the acknowledgement is what makes that stretch read as
- *     work in progress instead of a stall.
+ *     have used. It accepts the task and promises to come back to the caller
+ *     rather than asking for a pause: the escalated leg can spend a minute on
+ *     tools and reasoning, and the acknowledgement is what makes that stretch
+ *     read as work in progress instead of a stall.
  *   - Anything else: the output IS the answer, streamed straight to TTS
  *     (low first-token latency -> the caller hears audio fast).
  *
@@ -58,19 +58,25 @@ export type VoiceRoutingLeg = "front-door" | "escalated";
  * across the hand-off. When the model does speak its own bridge, that natural
  * text is used instead and this is not injected.
  *
- * It accepts the task and promises a report back rather than asking for a
- * second to think. A promised pause fits only the work a strong model finishes
- * in a breath; an escalated leg can spend a minute on tools and reasoning, and
- * that minute is near-silent by design. "A second" followed by ninety seconds
- * of quiet reads as a stall or a dropped call, so the acknowledgement is what
- * licenses the silence behind it.
+ * It accepts the task and promises to come back to the caller rather than
+ * asking for a second to think. A promised pause fits only the work a strong
+ * model finishes in a breath; an escalated leg can spend a minute on tools and
+ * reasoning, and that minute is near-silent by design. "A second" followed by
+ * ninety seconds of quiet reads as a stall or a dropped call, so the
+ * acknowledgement is what licenses the silence behind it.
+ *
+ * What it promises is contact, never success. The escalated leg is allowed to
+ * come back with a question it genuinely needs answered, or with a tool
+ * failure, so an acknowledgement that declared the task finished would be
+ * contradicted by the very next thing the caller hears ("I'll let you know
+ * when it's sent", then "what should the email say?").
  *
  * Exactly one sentence, here and in every localized spelling below:
  * {@link capEscalationBridge} cuts at the first sentence terminator, so a
  * second sentence would be truncated away unspoken.
  */
 export const FALLBACK_ESCALATION_BRIDGE =
-  "I'm on it, and I'll let you know when it's done.";
+  "I'm on it, and I'll get back to you.";
 
 /**
  * Per-language spellings of the fallback escalation bridge, keyed by
@@ -78,23 +84,24 @@ export const FALLBACK_ESCALATION_BRIDGE =
  * (DEEPGRAM_MULTI_LANGUAGE_CODES in providers/speech-to-text/deepgram.ts).
  * These are spoken audio; the English constant above also serves as the
  * prompt exemplar and stays the default. Every entry carries the same meaning
- * as the English one (task accepted, result to follow) in one sentence, and
- * sticks to verb forms that do not pin a gender on the assistant (the
- * gendered first-person past/future of Hindi and Russian is the trap here).
+ * as the English one (task accepted, a reply to follow) in one sentence, none
+ * of them claiming the task will be finished, and each sticks to verb forms
+ * that do not pin a gender on the assistant (the gendered first-person
+ * past/future of Hindi and Russian is the trap here).
  */
 export const FALLBACK_ESCALATION_BRIDGE_BY_LANGUAGE: Readonly<
   Record<string, string>
 > = {
   en: FALLBACK_ESCALATION_BRIDGE,
-  es: "Ya me encargo de eso y te aviso cuando esté listo.",
-  fr: "Je m'en occupe et je vous préviens dès que c'est prêt.",
-  de: "Ich kümmere mich darum und sage dir Bescheid, wenn es fertig ist.",
-  hi: "इस पर काम शुरू कर दिया है, पूरा होते ही आपको बता दिया जाएगा।",
-  ru: "Уже занимаюсь этим и сообщу, когда будет готово.",
-  pt: "Já estou cuidando disso e aviso quando estiver pronto.",
-  ja: "承知しました、終わりましたらお知らせします。",
-  it: "Ci penso io e ti faccio sapere quando è pronto.",
-  nl: "Ik ga ermee aan de slag en laat het je weten als het klaar is.",
+  es: "Ya me encargo de eso y te aviso.",
+  fr: "Je m'en occupe et je reviens vers vous.",
+  de: "Ich kümmere mich darum und melde mich bei dir.",
+  hi: "इस पर काम शुरू कर दिया है, आपको जल्द ही बता दिया जाएगा।",
+  ru: "Уже занимаюсь этим и дам вам знать.",
+  pt: "Já estou cuidando disso e te aviso.",
+  ja: "承知しました、後ほどお知らせします。",
+  it: "Ci penso io e ti faccio sapere.",
+  nl: "Ik ga ermee aan de slag en laat het je weten.",
 };
 
 /**
@@ -348,7 +355,7 @@ export function createFrontDoorStreamGate(
  * just above it.
  */
 export const ESCALATION_CONTINUATION_CONTENT =
-  "(The caller heard you accept the task, and has heard nothing from you since. Give them your full, careful answer to their previous question now, and do not repeat the acknowledgement.)";
+  "(The caller heard you accept the task and say you would come back to them, and has heard nothing from you since. Give them your full, careful answer to their previous question now, or ask for the one detail you need to proceed, and do not repeat the acknowledgement.)";
 
 /**
  * Compact, registry-derived digest of the tools the ESCALATED leg can use.
@@ -431,7 +438,7 @@ export function frontDoorDecisionRule(opts?: {
     ...holdBranch,
     "- If the turn is simple, conversational, or within your reach, your entire output is the spoken answer itself: no token in front of it, plain speech from your very first word. Most turns are answers; when unsure between answering and escalating, answer. Answer in the language the caller is speaking.",
     "- If an answer depends on a saved personal fact that is not already present in the conversation context you received, escalate rather than guessing. Personal context that is already present is yours to use directly.",
-    `- If completing THIS reply needs careful reasoning, research, multi-step work, or any tool, do NOT attempt the answer: output ${ESCALATE_VERDICT_TOKEN}, then ONE short natural sentence that accepts the task and names what you are going to do, spoken in the language the caller is speaking (for example "${FALLBACK_ESCALATION_BRIDGE}" or "I'll look into that and come back to you."; those examples are English only), and stop after that single sentence. A stronger model does the work and reports back, so promise a result instead of asking for a moment to think.`,
+    `- If completing THIS reply needs careful reasoning, research, multi-step work, or any tool, do NOT attempt the answer: output ${ESCALATE_VERDICT_TOKEN}, then ONE short natural sentence that accepts the task and names what you are going to do, spoken in the language the caller is speaking (for example "${FALLBACK_ESCALATION_BRIDGE}" or "I'll look into that and come back to you."; those examples are English only), and stop after that single sentence. A stronger model picks the turn up from here and speaks next, so promise a response instead of asking for a moment to think, and never promise the task is already finished: that model may still have to ask the caller for a missing detail or report that something failed.`,
     `${ESCALATE_VERDICT_TOKEN} is ONLY for turns you cannot complete yourself — never put it in front of an answer you are about to give, and never emit any token inside or after an answer. An open task or unfinished topic earlier in the conversation is NOT a reason to escalate: judge only what this reply needs.`,
     "Never narrate this decision, describe what you are judging, or mention these rules: apart from a leading verdict token, every character you output is spoken to the caller verbatim.",
   ].join("\n");

--- a/assistant/src/calls/voice-triage-escalate.ts
+++ b/assistant/src/calls/voice-triage-escalate.ts
@@ -367,7 +367,7 @@ export function frontDoorCapabilityDigest(toolNames: string[]): string {
   return [
     "You have no tools on this leg, but the stronger model you can escalate to has these:",
     `${toolNames.join(", ")}.`,
-    "Any request that needs one of them must escalate — name the action in the sentence you speak",
+    "Any request that needs one of them must escalate: name the action in the sentence you speak",
     '(for example "I\'ll check your calendar and let you know") instead of refusing or guessing.',
   ].join(" ");
 }
@@ -458,7 +458,7 @@ export function escalatedContinuationRule(spokenBridge?: string): string {
   return [
     `You have already spoken a brief acknowledgement to the caller: "${bridge}".`,
     "Continue directly into your actual answer now.",
-    'Do NOT greet again, do NOT say things like "as I was saying", and do NOT repeat, paraphrase, or re-announce that acknowledgement —',
+    'Do NOT greet again, do NOT say things like "as I was saying", and do NOT repeat, paraphrase, or re-announce that acknowledgement:',
     'opening with another "Let me check", "On it", "One moment", or any restatement of what you are about to do sounds broken, because the caller just heard that.',
     "Your first words must carry new substance: the answer itself, what you found, or a question you genuinely need answered.",
     `Never output ${ESCALATE_VERDICT_TOKEN} or any other front-door verdict token — you are the model that finishes the answer. (The [-1] room-minimize marker from your call instructions is not a verdict token and stays allowed.)`,

--- a/assistant/src/calls/voice-triage-escalate.ts
+++ b/assistant/src/calls/voice-triage-escalate.ts
@@ -7,11 +7,13 @@
  *   - `[0]` ({@link HOLD_VERDICT_TOKEN}, unified front-door only): the
  *     caller is mid-thought — the leg is discarded and listening continues.
  *   - `[1]` ({@link ESCALATE_VERDICT_TOKEN}) followed by ONE short natural
- *     holding phrase: the turn is too tricky — the phrase is spoken (capped
- *     at a single sentence) while the turn re-runs on the call-site default
- *     profile, the model an un-routed voice turn would have used. Because
- *     the holding phrase is spoken, the caller never hears the stronger
- *     model's think-time as silence.
+ *     acknowledgement: the turn is too tricky, so the acknowledgement is
+ *     spoken (capped at a single sentence) while the turn re-runs on the
+ *     call-site default profile, the model an un-routed voice turn would
+ *     have used. It accepts the task and promises a report back rather than
+ *     asking for a pause: the escalated leg can spend a minute on tools and
+ *     reasoning, and the acknowledgement is what makes that stretch read as
+ *     work in progress instead of a stall.
  *   - Anything else: the output IS the answer, streamed straight to TTS
  *     (low first-token latency -> the caller hears audio fast).
  *
@@ -51,34 +53,48 @@ export { ESCALATE_VERDICT_TOKEN, HOLD_VERDICT_TOKEN };
 export type VoiceRoutingLeg = "front-door" | "escalated";
 
 /**
- * Spoken when the front-door model escalates without a meaningful holding
- * phrase of its own — guarantees the caller never hears dead air across the
- * hand-off. When the model does speak its own bridge, that natural text is
- * used instead and this is not injected.
+ * Spoken when the front-door model escalates without a meaningful
+ * acknowledgement of its own - guarantees the caller never hears dead air
+ * across the hand-off. When the model does speak its own bridge, that natural
+ * text is used instead and this is not injected.
+ *
+ * It accepts the task and promises a report back rather than asking for a
+ * second to think. A promised pause fits only the work a strong model finishes
+ * in a breath; an escalated leg can spend a minute on tools and reasoning, and
+ * that minute is near-silent by design. "A second" followed by ninety seconds
+ * of quiet reads as a stall or a dropped call, so the acknowledgement is what
+ * licenses the silence behind it.
+ *
+ * Exactly one sentence, here and in every localized spelling below:
+ * {@link capEscalationBridge} cuts at the first sentence terminator, so a
+ * second sentence would be truncated away unspoken.
  */
 export const FALLBACK_ESCALATION_BRIDGE =
-  "Let me think about that for a second.";
+  "I'm on it, and I'll let you know when it's done.";
 
 /**
  * Per-language spellings of the fallback escalation bridge, keyed by
  * lowercased BCP 47 base subtag, covering the Deepgram code-switching roster
  * (DEEPGRAM_MULTI_LANGUAGE_CODES in providers/speech-to-text/deepgram.ts).
  * These are spoken audio; the English constant above also serves as the
- * prompt exemplar and stays the default.
+ * prompt exemplar and stays the default. Every entry carries the same meaning
+ * as the English one (task accepted, result to follow) in one sentence, and
+ * sticks to verb forms that do not pin a gender on the assistant (the
+ * gendered first-person past/future of Hindi and Russian is the trap here).
  */
 export const FALLBACK_ESCALATION_BRIDGE_BY_LANGUAGE: Readonly<
   Record<string, string>
 > = {
   en: FALLBACK_ESCALATION_BRIDGE,
-  es: "Déjame pensarlo un segundo.",
-  fr: "Laissez-moi y réfléchir un instant.",
-  de: "Lass mich kurz darüber nachdenken.",
-  hi: "मुझे एक पल सोचने दीजिए।",
-  ru: "Дайте мне секунду подумать.",
-  pt: "Deixe-me pensar nisso um segundo.",
-  ja: "少し考えさせてください。",
-  it: "Fammi pensare un attimo.",
-  nl: "Laat me daar even over nadenken.",
+  es: "Ya me encargo de eso y te aviso cuando esté listo.",
+  fr: "Je m'en occupe et je vous préviens dès que c'est prêt.",
+  de: "Ich kümmere mich darum und sage dir Bescheid, wenn es fertig ist.",
+  hi: "इस पर काम शुरू कर दिया है, पूरा होते ही आपको बता दिया जाएगा।",
+  ru: "Уже занимаюсь этим и сообщу, когда будет готово.",
+  pt: "Já estou cuidando disso e aviso quando estiver pronto.",
+  ja: "承知しました、終わりましたらお知らせします。",
+  it: "Ci penso io e ti faccio sapere quando è pronto.",
+  nl: "Ik ga ermee aan de slag en laat het je weten als het klaar is.",
 };
 
 /**
@@ -332,14 +348,15 @@ export function createFrontDoorStreamGate(
  * just above it.
  */
 export const ESCALATION_CONTINUATION_CONTENT =
-  "(You just told the caller you needed a moment to think. Now give them your full, careful answer to their previous question — do not repeat the holding phrase.)";
+  "(The caller heard you accept the task, and has heard nothing from you since. Give them your full, careful answer to their previous question now, and do not repeat the acknowledgement.)";
 
 /**
  * Compact, registry-derived digest of the tools the ESCALATED leg can use.
  * The front-door leg runs toolless, so without this it has no way to know
  * what the assistant can actually do — and its failure mode is refusing or
  * fabricating instead of escalating. The digest teaches routing (and lets
- * the holding phrase name the action) without carrying executable schemas.
+ * the spoken acknowledgement name the action) without carrying executable
+ * schemas.
  * Empty input (registry unavailable) yields an empty digest; the decision
  * rule still works, it just can't enumerate capabilities.
  */
@@ -350,8 +367,8 @@ export function frontDoorCapabilityDigest(toolNames: string[]): string {
   return [
     "You have no tools on this leg, but the stronger model you can escalate to has these:",
     `${toolNames.join(", ")}.`,
-    "Any request that needs one of them must escalate — name the action in your holding phrase",
-    '(for example "Let me check your calendar") instead of refusing or guessing.',
+    "Any request that needs one of them must escalate — name the action in the sentence you speak",
+    '(for example "I\'ll check your calendar and let you know") instead of refusing or guessing.',
   ].join(" ");
 }
 
@@ -414,7 +431,7 @@ export function frontDoorDecisionRule(opts?: {
     ...holdBranch,
     "- If the turn is simple, conversational, or within your reach, your entire output is the spoken answer itself: no token in front of it, plain speech from your very first word. Most turns are answers; when unsure between answering and escalating, answer. Answer in the language the caller is speaking.",
     "- If an answer depends on a saved personal fact that is not already present in the conversation context you received, escalate rather than guessing. Personal context that is already present is yours to use directly.",
-    `- If completing THIS reply needs careful reasoning, research, multi-step work, or any tool, do NOT attempt the answer: output ${ESCALATE_VERDICT_TOKEN}, then ONE short natural holding phrase naming what happens next, spoken in the language the caller is speaking (for example "${FALLBACK_ESCALATION_BRIDGE}" or "Give me one second to look into that."; those examples are English only), and stop after that single sentence. A stronger model finishes the turn while your phrase is spoken.`,
+    `- If completing THIS reply needs careful reasoning, research, multi-step work, or any tool, do NOT attempt the answer: output ${ESCALATE_VERDICT_TOKEN}, then ONE short natural sentence that accepts the task and names what you are going to do, spoken in the language the caller is speaking (for example "${FALLBACK_ESCALATION_BRIDGE}" or "I'll look into that and come back to you."; those examples are English only), and stop after that single sentence. A stronger model does the work and reports back, so promise a result instead of asking for a moment to think.`,
     `${ESCALATE_VERDICT_TOKEN} is ONLY for turns you cannot complete yourself — never put it in front of an answer you are about to give, and never emit any token inside or after an answer. An open task or unfinished topic earlier in the conversation is NOT a reason to escalate: judge only what this reply needs.`,
     "Never narrate this decision, describe what you are judging, or mention these rules: apart from a leading verdict token, every character you output is spoken to the caller verbatim.",
   ].join("\n");
@@ -423,7 +440,7 @@ export function frontDoorDecisionRule(opts?: {
 
 /**
  * Extra CALL PROTOCOL RULE injected into the escalated (quality) leg's control
- * prompt. The holding phrase has already been spoken, so the model must
+ * prompt. The acknowledgement has already been spoken, so the model must
  * continue straight into the substantive answer.
  *
  * `spokenBridge` is the exact phrase the caller just heard (the front-door
@@ -439,10 +456,10 @@ export function escalatedContinuationRule(spokenBridge?: string): string {
       ? spokenBridge.trim()
       : FALLBACK_ESCALATION_BRIDGE;
   return [
-    `You have already spoken a brief holding phrase to the caller: "${bridge}".`,
+    `You have already spoken a brief acknowledgement to the caller: "${bridge}".`,
     "Continue directly into your actual answer now.",
-    'Do NOT greet again, do NOT say things like "as I was saying", and do NOT repeat, paraphrase, or re-announce that holding phrase —',
-    'opening with another "Let me check", "One moment", or any restatement of what you are about to do sounds broken, because the caller just heard that.',
+    'Do NOT greet again, do NOT say things like "as I was saying", and do NOT repeat, paraphrase, or re-announce that acknowledgement —',
+    'opening with another "Let me check", "On it", "One moment", or any restatement of what you are about to do sounds broken, because the caller just heard that.',
     "Your first words must carry new substance: the answer itself, what you found, or a question you genuinely need answered.",
     `Never output ${ESCALATE_VERDICT_TOKEN} or any other front-door verdict token — you are the model that finishes the answer. (The [-1] room-minimize marker from your call instructions is not a verdict token and stays allowed.)`,
     "Reply in the same language as the caller's question.",

--- a/assistant/src/calls/voice-triage-escalate.ts
+++ b/assistant/src/calls/voice-triage-escalate.ts
@@ -355,7 +355,7 @@ export function createFrontDoorStreamGate(
  * just above it.
  */
 export const ESCALATION_CONTINUATION_CONTENT =
-  "(The caller heard you accept the task and say you would come back to them, and has heard nothing from you since. Give them your full, careful answer to their previous question now, or ask for the one detail you need to proceed, and do not repeat the acknowledgement.)";
+  "(The caller heard you accept the task and say you would come back to them, and has heard nothing from you since. Give them your full, careful answer to their previous question now, or ask for every detail you still need, in one go rather than one at a time, and do not repeat the acknowledgement.)";
 
 /**
  * Compact, registry-derived digest of the tools the ESCALATED leg can use.


### PR DESCRIPTION
## Summary
- Reword the escalation bridge so it acknowledges the task and promises a report back, instead of promising a pause measured in seconds.
- Update the front-door prompt rule and the escalated leg's continuation note to match, keeping every structural constraint intact.
- The bridge now licenses the silence that follows on a long working turn.

Part of plan: voice-speak-final-answer-only.md (PR 4 of 6)