### PR TITLE
refactor(voice): let live-voice TTS segments be held and cancelled per job

### DIFF
--- a/assistant/src/live-voice/__tests__/live-voice-tts-session.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-tts-session.test.ts
@@ -185,7 +185,9 @@ interface ControlledSynthesis {
 // A TTS streamer whose per-call completion is driven by the test: chunks are
 // injected via `calls[n].options.onAudioChunk` and the provider promise
 // settles on `finish`/`fail`. `events` records call starts and settles so
-// synthesis overlap can be asserted deterministically.
+// synthesis overlap can be asserted deterministically. Aborting a call does
+// not settle it, which is also how a provider that is slow to tear down on
+// abort behaves.
 function createControlledTtsStreamer(): {
   streamTtsAudio: LiveVoiceTtsStreamer;
   calls: ControlledSynthesis[];
@@ -218,16 +220,27 @@ interface HeldJobView {
   readonly text: string;
 }
 
+// The slice of the session's private turn state these tests read.
+interface TurnView {
+  readonly token: symbol;
+  readonly ttsBuffer: string;
+}
+
 // Held segments have no production caller yet, so the tests drive the private
 // hold/promote/retract surface directly against the turn that
 // `startReleasedTurn` left active.
 function heldTtsController(session: LiveVoiceSession): {
   enqueue: (text: string) => void;
   promote: (select: (job: HeldJobView) => boolean) => number;
-  retract: (select: (job: HeldJobView) => boolean) => number;
+  retract: (
+    select: (job: HeldJobView) => boolean,
+    options?: { discardPendingTail?: boolean },
+  ) => number;
+  pendingTail: () => string;
+  audioIdle: () => boolean;
 } {
   const internals = session as unknown as {
-    activeAssistantTurn: { token: symbol } | null;
+    activeAssistantTurn: TurnView | null;
     enqueueTtsSegment: (
       token: symbol,
       segment: string,
@@ -240,16 +253,22 @@ function heldTtsController(session: LiveVoiceSession): {
     retractHeldTtsSegments: (
       token: symbol,
       select: (job: HeldJobView) => boolean,
+      options?: { discardPendingTail?: boolean },
     ) => number;
+    turnAudioIdle: (turn: TurnView) => boolean;
   };
-  const token = internals.activeAssistantTurn?.token;
-  if (!token) {
+  const turn = internals.activeAssistantTurn;
+  if (!turn) {
     throw new Error("No active assistant turn to hold TTS segments on");
   }
+  const { token } = turn;
   return {
     enqueue: (text) => internals.enqueueTtsSegment(token, text, { held: true }),
     promote: (select) => internals.promoteHeldTtsSegments(token, select),
-    retract: (select) => internals.retractHeldTtsSegments(token, select),
+    retract: (select, options) =>
+      internals.retractHeldTtsSegments(token, select, options),
+    pendingTail: () => turn.ttsBuffer,
+    audioIdle: () => internals.turnAudioIdle(turn),
   };
 }
 
@@ -259,6 +278,9 @@ const THIRD_HELD_SENTENCE = "A third held sentence waits even further back.";
 const FIRST_SENTENCE = "This is the first spoken sentence.";
 const SECOND_SENTENCE = "Here comes the second spoken sentence.";
 const THIRD_SENTENCE = "And now a third spoken sentence arrives.";
+// No terminal punctuation, so it stays in the turn's buffer as an
+// un-segmented tail instead of forming a job.
+const PENDING_TAIL = "an unfinished clause with no boundary yet";
 
 describe("LiveVoiceSession TTS", () => {
   test("starts streaming TTS audio before the assistant message completes at a segment boundary", async () => {
@@ -972,5 +994,118 @@ describe("LiveVoiceSession TTS", () => {
       type: "tts_done",
       turnId: "live-turn-1",
     });
+  });
+
+  test("a retracted segment holds its synthesis slot until the aborted stream settles", async () => {
+    let callbacks: VoiceTurnCallbacks | undefined;
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      callbacks = options.callbacks;
+      return { turnId: "bridge-turn-1", abort: mock() };
+    });
+    const { streamTtsAudio, calls, events } = createControlledTtsStreamer();
+    const { frames, session } = createSessionHarness({
+      startVoiceTurn,
+      streamTtsAudio,
+    });
+
+    await startReleasedTurn(session);
+    callbacks?.assistant_text_delta?.(makeTextDelta(FIRST_SENTENCE));
+    const held = heldTtsController(session);
+    held.enqueue(HELD_SENTENCE);
+    callbacks?.assistant_text_delta?.(makeTextDelta(SECOND_SENTENCE));
+
+    // Both slots are open, so the third segment is waiting on one.
+    expect(events).toEqual([
+      `start:${FIRST_SENTENCE}`,
+      `start:${HELD_SENTENCE}`,
+    ]);
+
+    // This provider ignores the abort, so the retracted stream is still open
+    // and its slot is still taken.
+    expect(held.retract((job) => job.text === HELD_SENTENCE)).toBe(1);
+    await flushAsyncCallbacks();
+    expect(events).toEqual([
+      `start:${FIRST_SENTENCE}`,
+      `start:${HELD_SENTENCE}`,
+    ]);
+
+    // Only the stream's own teardown releases it.
+    calls[1]?.finish();
+    await waitFor(() => events.includes(`start:${SECOND_SENTENCE}`));
+
+    calls[0]?.options.onAudioChunk(makeTtsChunk("audio:first-1"));
+    calls[0]?.finish();
+    calls[2]?.options.onAudioChunk(makeTtsChunk("audio:second-1"));
+    calls[2]?.finish();
+    callbacks?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    expect(ttsAudioPayloads(frames)).toEqual([
+      b64("audio:first-1"),
+      b64("audio:second-1"),
+    ]);
+  });
+
+  test("a held segment blocks audio idle and a retracted one does not", async () => {
+    let callbacks: VoiceTurnCallbacks | undefined;
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      callbacks = options.callbacks;
+      return { turnId: "bridge-turn-1", abort: mock() };
+    });
+    const { streamTtsAudio } = createControlledTtsStreamer();
+    const { frames, session } = createSessionHarness({
+      startVoiceTurn,
+      streamTtsAudio,
+    });
+
+    await startReleasedTurn(session);
+    const held = heldTtsController(session);
+    expect(held.audioIdle()).toBe(true);
+
+    // Held audio is seconds from being spoken, so the turn is quiet, not idle.
+    held.enqueue(HELD_SENTENCE);
+    expect(held.audioIdle()).toBe(false);
+
+    // Retraction makes it unhearable immediately, even though the provider is
+    // still sitting on the aborted stream and the job has not settled.
+    expect(held.retract(() => true)).toBe(1);
+    expect(held.audioIdle()).toBe(true);
+
+    callbacks?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+    expect(ttsAudioPayloads(frames)).toEqual([]);
+  });
+
+  test("retraction discards the pending tail only when the caller owns it", async () => {
+    let callbacks: VoiceTurnCallbacks | undefined;
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      callbacks = options.callbacks;
+      return { turnId: "bridge-turn-1", abort: mock() };
+    });
+    const { streamTtsAudio, calls } = createControlledTtsStreamer();
+    const { frames, session } = createSessionHarness({
+      startVoiceTurn,
+      streamTtsAudio,
+    });
+
+    await startReleasedTurn(session);
+    const held = heldTtsController(session);
+    held.enqueue(HELD_SENTENCE);
+    callbacks?.assistant_text_delta?.(makeTextDelta(PENDING_TAIL));
+    expect(held.pendingTail()).toBe(PENDING_TAIL);
+
+    // A selective retraction that matches nothing owns no speech, so the
+    // buffered tail survives it.
+    expect(held.retract((job) => job.text === SECOND_SENTENCE)).toBe(0);
+    expect(held.pendingTail()).toBe(PENDING_TAIL);
+
+    // A caller retracting its whole block says so, and the tail goes with it.
+    expect(held.retract(() => true, { discardPendingTail: true })).toBe(1);
+    expect(held.pendingTail()).toBe("");
+
+    calls[0]?.finish();
+    callbacks?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+    expect(ttsAudioPayloads(frames)).toEqual([]);
   });
 });

--- a/assistant/src/live-voice/__tests__/live-voice-tts-session.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-tts-session.test.ts
@@ -212,6 +212,50 @@ function createControlledTtsStreamer(): {
   return { streamTtsAudio, calls, events };
 }
 
+// The slice of a TtsSegmentJob a held-segment selector can see. Kept
+// structural so the test does not need the session's private job type.
+interface HeldJobView {
+  readonly text: string;
+}
+
+// Held segments have no production caller yet, so the tests drive the private
+// hold/promote/retract surface directly against the turn that
+// `startReleasedTurn` left active.
+function heldTtsController(session: LiveVoiceSession): {
+  enqueue: (text: string) => void;
+  promote: (select: (job: HeldJobView) => boolean) => number;
+  retract: (select: (job: HeldJobView) => boolean) => number;
+} {
+  const internals = session as unknown as {
+    activeAssistantTurn: { token: symbol } | null;
+    enqueueTtsSegment: (
+      token: symbol,
+      segment: string,
+      options?: { held?: boolean },
+    ) => void;
+    promoteHeldTtsSegments: (
+      token: symbol,
+      select: (job: HeldJobView) => boolean,
+    ) => number;
+    retractHeldTtsSegments: (
+      token: symbol,
+      select: (job: HeldJobView) => boolean,
+    ) => number;
+  };
+  const token = internals.activeAssistantTurn?.token;
+  if (!token) {
+    throw new Error("No active assistant turn to hold TTS segments on");
+  }
+  return {
+    enqueue: (text) => internals.enqueueTtsSegment(token, text, { held: true }),
+    promote: (select) => internals.promoteHeldTtsSegments(token, select),
+    retract: (select) => internals.retractHeldTtsSegments(token, select),
+  };
+}
+
+const HELD_SENTENCE = "The held answer is ready to speak.";
+const OTHER_HELD_SENTENCE = "A second held sentence waits behind it.";
+const THIRD_HELD_SENTENCE = "A third held sentence waits even further back.";
 const FIRST_SENTENCE = "This is the first spoken sentence.";
 const SECOND_SENTENCE = "Here comes the second spoken sentence.";
 const THIRD_SENTENCE = "And now a third spoken sentence arrives.";
@@ -735,6 +779,195 @@ describe("LiveVoiceSession TTS", () => {
     });
     expect(firstAudioIndex).toBeLessThan(errorIndex);
     expect(errorIndex).toBeLessThan(thirdAudioIndex);
+    expect(frames.at(-1)).toMatchObject({
+      type: "tts_done",
+      turnId: "live-turn-1",
+    });
+  });
+
+  test("a held segment synthesizes but forwards no audio until it is promoted", async () => {
+    let callbacks: VoiceTurnCallbacks | undefined;
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      callbacks = options.callbacks;
+      return { turnId: "bridge-turn-1", abort: mock() };
+    });
+    const { streamTtsAudio, calls, events } = createControlledTtsStreamer();
+    const { frames, session } = createSessionHarness({
+      startVoiceTurn,
+      streamTtsAudio,
+    });
+
+    await startReleasedTurn(session);
+    const held = heldTtsController(session);
+    held.enqueue(HELD_SENTENCE);
+
+    // Synthesis starts immediately: holding is about emission, not about
+    // deferring the provider round trip.
+    expect(events).toEqual([`start:${HELD_SENTENCE}`]);
+
+    calls[0]?.options.onAudioChunk(makeTtsChunk("audio:held-1"));
+    calls[0]?.finish();
+    await flushAsyncCallbacks();
+    expect(ttsAudioPayloads(frames)).toEqual([]);
+
+    expect(held.promote((job) => job.text === HELD_SENTENCE)).toBe(1);
+    await waitFor(() => ttsAudioPayloads(frames).length === 1);
+    expect(ttsAudioPayloads(frames)).toEqual([b64("audio:held-1")]);
+
+    callbacks?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+    expect(frames.at(-1)).toMatchObject({
+      type: "tts_done",
+      turnId: "live-turn-1",
+    });
+  });
+
+  test("a promoted held segment emits its buffered audio ahead of later segments", async () => {
+    let callbacks: VoiceTurnCallbacks | undefined;
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      callbacks = options.callbacks;
+      return { turnId: "bridge-turn-1", abort: mock() };
+    });
+    const { streamTtsAudio, calls } = createControlledTtsStreamer();
+    const { frames, session } = createSessionHarness({
+      startVoiceTurn,
+      streamTtsAudio,
+    });
+
+    await startReleasedTurn(session);
+    const held = heldTtsController(session);
+    held.enqueue(HELD_SENTENCE);
+    calls[0]?.options.onAudioChunk(makeTtsChunk("audio:held-1"));
+
+    // Promotion happens before the next segment is enqueued, so the held job
+    // is ahead of it on the emission chain.
+    expect(held.promote(() => true)).toBe(1);
+    callbacks?.assistant_text_delta?.(makeTextDelta(FIRST_SENTENCE));
+    expect(calls).toHaveLength(2);
+
+    // The later segment finishes first; ordering still follows the chain.
+    calls[1]?.options.onAudioChunk(makeTtsChunk("audio:later-1"));
+    calls[1]?.finish();
+    await flushAsyncCallbacks();
+    calls[0]?.options.onAudioChunk(makeTtsChunk("audio:held-2"));
+    calls[0]?.finish();
+    callbacks?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    expect(ttsAudioPayloads(frames)).toEqual([
+      b64("audio:held-1"),
+      b64("audio:held-2"),
+      b64("audio:later-1"),
+    ]);
+  });
+
+  test("a retracted held segment forwards nothing and aborts only its own synthesis", async () => {
+    let callbacks: VoiceTurnCallbacks | undefined;
+    const abort = mock();
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      callbacks = options.callbacks;
+      return { turnId: "bridge-turn-1", abort };
+    });
+    const { streamTtsAudio, calls } = createControlledTtsStreamer();
+    const { frames, session } = createSessionHarness({
+      startVoiceTurn,
+      streamTtsAudio,
+    });
+
+    await startReleasedTurn(session);
+    callbacks?.assistant_text_delta?.(makeTextDelta(FIRST_SENTENCE));
+    const held = heldTtsController(session);
+    held.enqueue(HELD_SENTENCE);
+    expect(calls).toHaveLength(2);
+    calls[1]?.options.onAudioChunk(makeTtsChunk("audio:held-1"));
+
+    expect(held.retract((job) => job.text === HELD_SENTENCE)).toBe(1);
+    expect(calls[1]?.options.signal?.aborted).toBe(true);
+    expect(calls[0]?.options.signal?.aborted).toBe(false);
+
+    // Late provider chunks on a retracted job are dropped rather than
+    // rebuffered, and the retraction never touched the live turn.
+    calls[1]?.options.onAudioChunk(makeTtsChunk("audio:held-2"));
+    calls[0]?.options.onAudioChunk(makeTtsChunk("audio:live-1"));
+    calls[0]?.finish();
+    callbacks?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    expect(abort).not.toHaveBeenCalled();
+    expect(ttsAudioPayloads(frames)).toEqual([b64("audio:live-1")]);
+    expect(frames.at(-1)).toMatchObject({
+      type: "tts_done",
+      turnId: "live-turn-1",
+    });
+  });
+
+  test("held segments occupy at most one synthesis slot", async () => {
+    let callbacks: VoiceTurnCallbacks | undefined;
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      callbacks = options.callbacks;
+      return { turnId: "bridge-turn-1", abort: mock() };
+    });
+    const { streamTtsAudio, calls, events } = createControlledTtsStreamer();
+    const { frames, session } = createSessionHarness({
+      startVoiceTurn,
+      streamTtsAudio,
+    });
+
+    await startReleasedTurn(session);
+    const held = heldTtsController(session);
+    held.enqueue(HELD_SENTENCE);
+    held.enqueue(OTHER_HELD_SENTENCE);
+    held.enqueue(THIRD_HELD_SENTENCE);
+
+    // A second open slot exists, but held jobs may not take it: the block may
+    // never be spoken, so only its first segment is worth synthesizing.
+    expect(events).toEqual([`start:${HELD_SENTENCE}`]);
+
+    // Promoting the first frees the held slot for the next one.
+    expect(held.promote((job) => job.text === HELD_SENTENCE)).toBe(1);
+    expect(events).toEqual([
+      `start:${HELD_SENTENCE}`,
+      `start:${OTHER_HELD_SENTENCE}`,
+    ]);
+
+    calls[0]?.options.onAudioChunk(makeTtsChunk("audio:held-1"));
+    calls[0]?.finish();
+    calls[1]?.finish();
+    expect(held.retract(() => true)).toBe(2);
+    callbacks?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    expect(ttsAudioPayloads(frames)).toEqual([b64("audio:held-1")]);
+  });
+
+  test("tts_done still fires on a turn holding one segment and retracting another", async () => {
+    let callbacks: VoiceTurnCallbacks | undefined;
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      callbacks = options.callbacks;
+      return { turnId: "bridge-turn-1", abort: mock() };
+    });
+    const { streamTtsAudio, calls } = createControlledTtsStreamer();
+    const { frames, session } = createSessionHarness({
+      startVoiceTurn,
+      streamTtsAudio,
+    });
+
+    await startReleasedTurn(session);
+    callbacks?.assistant_text_delta?.(makeTextDelta(FIRST_SENTENCE));
+    const held = heldTtsController(session);
+    held.enqueue(HELD_SENTENCE);
+    held.enqueue(OTHER_HELD_SENTENCE);
+
+    // One job stays held forever and one is retracted; neither is on the
+    // emission chain, so neither can stall the drain.
+    expect(held.retract((job) => job.text === OTHER_HELD_SENTENCE)).toBe(1);
+
+    calls[0]?.options.onAudioChunk(makeTtsChunk("audio:live-1"));
+    calls[0]?.finish();
+    callbacks?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    expect(ttsAudioPayloads(frames)).toEqual([b64("audio:live-1")]);
     expect(frames.at(-1)).toMatchObject({
       type: "tts_done",
       turnId: "live-turn-1",

--- a/assistant/src/live-voice/__tests__/live-voice-tts-session.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-tts-session.test.ts
@@ -996,6 +996,40 @@ describe("LiveVoiceSession TTS", () => {
     });
   });
 
+  test("turn completion sweeps a held segment the caller never resolved", async () => {
+    let callbacks: VoiceTurnCallbacks | undefined;
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      callbacks = options.callbacks;
+      return { turnId: "bridge-turn-1", abort: mock() };
+    });
+    const { streamTtsAudio, calls } = createControlledTtsStreamer();
+    const { frames, session } = createSessionHarness({
+      startVoiceTurn,
+      streamTtsAudio,
+    });
+
+    await startReleasedTurn(session);
+    callbacks?.assistant_text_delta?.(makeTextDelta(FIRST_SENTENCE));
+    const held = heldTtsController(session);
+    held.enqueue(HELD_SENTENCE);
+
+    const strandedCall = calls.find(
+      (call) => call.options.text === HELD_SENTENCE,
+    );
+    expect(strandedCall).toBeDefined();
+    expect(strandedCall?.options.signal?.aborted).toBe(false);
+
+    calls[0]?.options.onAudioChunk(makeTtsChunk("audio:live-1"));
+    calls[0]?.finish();
+    callbacks?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    // The stranded job's provider request is aborted rather than left running
+    // into the next turn, and its audio is never spoken.
+    expect(strandedCall?.options.signal?.aborted).toBe(true);
+    expect(ttsAudioPayloads(frames)).toEqual([b64("audio:live-1")]);
+  });
+
   test("a retracted segment holds its synthesis slot until the aborted stream settles", async () => {
     let callbacks: VoiceTurnCallbacks | undefined;
     const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -533,6 +533,16 @@ interface TtsSegmentJob {
   // Chunks received while prefetching, flushed in order on promotion.
   // Dropped with the turn on cancellation.
   bufferedChunks: LiveVoiceTtsAudioChunk[];
+  // Enqueued for synthesis but deliberately kept off the emission chain until
+  // the caller promotes it. A held job has forwarded no audio, so it is
+  // silently cancellable and must never count as audible activity.
+  held: boolean;
+  // Retracted before promotion: dropped from the emission chain with its
+  // provider stream aborted. Only ever set while `emitting` is false.
+  cancelled: boolean;
+  // Per-job synthesis abort, so retracting one segment leaves the turn's other
+  // segments alone (the turn controller aborts all of them).
+  readonly abort: AbortController;
   // Settles when the provider stream ends; rejects on synthesis failure.
   synthesis: Promise<void> | null;
   // Ordered tts_audio frame writes for this job.
@@ -5332,11 +5342,13 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
 
   // No assistant audio is pending or (estimatedly) still playing: nothing
   // buffered toward the next sentence, every queued TTS segment fully
-  // emitted, and the client-side playback-tail estimate expired.
+  // emitted, and the client-side playback-tail estimate expired. A held
+  // segment is synthesized but unspoken and may never be promoted, so it is
+  // silence as far as the user is concerned.
   private turnAudioIdle(turn: ActiveAssistantTurn): boolean {
     return (
       turn.ttsBuffer.length === 0 &&
-      turn.ttsJobs.every((job) => job.settled) &&
+      turn.ttsJobs.every((job) => job.settled || job.held) &&
       Date.now() >= this.assistantPlaybackTailUntilMs
     );
   }
@@ -5559,6 +5571,78 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     this.flushTtsBuffer(token, false);
   }
 
+  /**
+   * Move held segments onto the emission chain, in enqueue order. Their audio
+   * is already synthesized and buffered, so promotion is a buffer flush rather
+   * than a TTS round trip.
+   */
+  private promoteHeldTtsSegments(
+    token: symbol,
+    select: (job: TtsSegmentJob) => boolean,
+  ): number {
+    const activeTurn = this.activeAssistantTurn;
+    if (activeTurn?.token !== token) {
+      return 0;
+    }
+
+    // `ttsJobs` is in enqueue order, so chaining in filter order is what keeps
+    // a promoted block ahead of whatever is enqueued after it.
+    const promoted = activeTurn.ttsJobs.filter(
+      (job) => job.held && !job.cancelled && select(job),
+    );
+    for (const job of promoted) {
+      job.held = false;
+      activeTurn.ttsQueue = activeTurn.ttsQueue
+        .catch(() => {})
+        .then(() => this.emitTtsJob(token, job));
+    }
+    // Promotion frees the standing held-job slot, so a segment that was
+    // waiting behind the cap can start synthesizing now.
+    this.pumpTtsSynthesis(token);
+    return promoted.length;
+  }
+
+  /**
+   * Retract held segments that have not reached the client. Returns the number
+   * dropped.
+   *
+   * A job that is already `emitting` is left alone: spoken audio cannot be
+   * un-said and cutting a segment mid-phrase sounds broken. In this design no
+   * held job is ever emitting, so that guard is belt-and-braces.
+   */
+  private retractHeldTtsSegments(
+    token: symbol,
+    select: (job: TtsSegmentJob) => boolean,
+  ): number {
+    const activeTurn = this.activeAssistantTurn;
+    if (activeTurn?.token !== token) {
+      return 0;
+    }
+
+    const retracted = activeTurn.ttsJobs.filter(
+      (job) => job.held && !job.cancelled && !job.emitting && select(job),
+    );
+    for (const job of retracted) {
+      job.cancelled = true;
+      job.abort.abort(
+        createAbortReason("voice_session_aborted", "live-voice-tts-retract"),
+      );
+      job.bufferedChunks.length = 0;
+      // A retracted job never reaches emitTtsJob, so its synthesis slot has to
+      // be released here or it would stand open for the rest of the turn.
+      job.settled = true;
+    }
+
+    // Drop the retracted block's un-segmented tail too, whether or not any
+    // job had formed from it yet: text still short of a segment boundary
+    // belongs to the block being retracted, and a half-finished markdown or
+    // <think> construct left in the filter would bleed into the next block.
+    activeTurn.ttsBuffer = "";
+    activeTurn.ttsReasoningFilter.flush();
+    this.pumpTtsSynthesis(token);
+    return retracted.length;
+  }
+
   private completeTtsForTurn(token: symbol): void {
     const activeTurn = this.activeAssistantTurn;
     if (activeTurn?.token !== token) {
@@ -5666,7 +5750,14 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   private enqueueTtsSegment(
     token: symbol,
     segment: string,
-    options: { countsAsFirstSegment?: boolean; language?: string } = {},
+    options: {
+      countsAsFirstSegment?: boolean;
+      language?: string;
+      // Synthesize now, speak later (or never): the job is queued for the
+      // provider but stays off the emission chain until promoteHeldTtsSegments
+      // puts it there, or retractHeldTtsSegments drops it.
+      held?: boolean;
+    } = {},
   ): void {
     const activeTurn = this.activeAssistantTurn;
     if (activeTurn?.token !== token || !this.streamTtsAudio) {
@@ -5684,12 +5775,21 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       started: false,
       settled: false,
       emitting: false,
+      held: options.held ?? false,
+      cancelled: false,
+      abort: new AbortController(),
       bufferedChunks: [],
       synthesis: null,
       frames: Promise.resolve(),
     };
     activeTurn.ttsJobs.push(job);
     this.pumpTtsSynthesis(token);
+    if (job.held) {
+      // Synthesis has started; emission has not. Chaining the job onto
+      // ttsQueue is exactly what promotion does, so doing it here would
+      // defeat the hold.
+      return;
+    }
     activeTurn.ttsQueue = activeTurn.ttsQueue
       .catch(() => {})
       .then(() => this.emitTtsJob(token, job));
@@ -5715,7 +5815,23 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       activeTurn.ttsJobs.filter((job) => job.started && !job.settled).length <
       TTS_MAX_OPEN_SYNTHESIS_JOBS
     ) {
-      const job = activeTurn.ttsJobs.find((candidate) => !candidate.started);
+      // Held jobs get at most one of the open slots. Pre-synthesizing a held
+      // block's FIRST segment is what removes the TTS round trip from the
+      // answer's onset; later segments pipeline during that first segment's
+      // playback anyway, so synthesizing further ahead only risks paying for
+      // audio a tool call is about to cancel. A held job stays open until it
+      // is promoted or retracted, so the cap is a standing one.
+      const heldSlotTaken = activeTurn.ttsJobs.some(
+        (candidate) =>
+          candidate.held && candidate.started && !candidate.settled,
+      );
+      const job = activeTurn.ttsJobs.find(
+        (candidate) =>
+          !candidate.started &&
+          // A retracted job is dead: nothing will ever emit it.
+          !candidate.cancelled &&
+          (!candidate.held || !heldSlotTaken),
+      );
       if (!job) {
         return;
       }
@@ -5728,11 +5844,19 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         synthesis = streamTtsAudio({
           text: job.text,
           ...(language !== undefined ? { language } : {}),
-          signal: activeTurn.abortController.signal,
+          // Either the turn ending or this one segment being retracted stops
+          // the stream; the job's own controller is what lets a retraction
+          // leave the turn's other segments streaming.
+          signal: AbortSignal.any([
+            activeTurn.abortController.signal,
+            job.abort.signal,
+          ]),
           outputFormat: "pcm",
           sampleRate: this.context.startFrame.audio.sampleRate,
           onAudioChunk: (chunk) => {
-            if (!this.isForwardingTts(token)) {
+            // A retracted job keeps nothing: its buffer was already released
+            // and no promotion will ever flush it.
+            if (!this.isForwardingTts(token) || job.cancelled) {
               return;
             }
             if (job.emitting) {
@@ -5766,6 +5890,13 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       ) {
         // The turn is gone: release the prefetched audio immediately rather
         // than holding it until the turn object drops.
+        job.bufferedChunks.length = 0;
+        return;
+      }
+
+      if (job.cancelled) {
+        // Retracted while held: drop the prefetched audio without promoting
+        // it. Nothing was forwarded, so the client hears no seam.
         job.bufferedChunks.length = 0;
         return;
       }
@@ -5812,7 +5943,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     } finally {
       job.settled = true;
       const settledTurn = this.activeAssistantTurn;
-      if (settledTurn?.token === token) {
+      // A retracted job forwarded nothing, so it must not stand in for audio
+      // the user never heard and postpone the dead-air countdown.
+      if (settledTurn?.token === token && !job.cancelled) {
         // Anchor the dead-air countdown to the end of emission; the playback
         // -tail estimate covers any client-side buffer still draining.
         settledTurn.progress.lastAudibleAtMs = Date.now();

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -743,6 +743,10 @@ interface ActiveAssistantTurn {
   // the hand-off idempotent.
   escalationHandedOff: boolean;
   ttsBuffer: string;
+  // The turn is finalizing its TTS: every remaining enqueue is terminal by
+  // construction, so holds are ignored past this point (see
+  // enqueueTtsSegment) and stranded held jobs have already been swept.
+  ttsCompleting: boolean;
   // Strips inline <think> reasoning spans from the spoken stream. Stateful
   // per turn because spans and tags cross delta boundaries; display frames
   // keep the raw text.
@@ -4580,6 +4584,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       deltaEpoch: 0,
       escalationHandedOff: false,
       ttsBuffer: "",
+      ttsCompleting: false,
       ttsReasoningFilter: createReasoningTagFilter(),
       ttsSegmentEnqueued: false,
       ttsJobs: [],
@@ -5701,6 +5706,26 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     }
 
     this.clearFillerTimers(activeTurn);
+    // Sweep held jobs the caller never resolved. Every held block is supposed
+    // to end in a promotion (it was the answer) or a retraction (a tool call
+    // proved it was commentary), but a caller that misses an exit would
+    // otherwise leave a provider request running past the turn: the job is off
+    // ttsQueue, so completion never awaits it, and its synthesis slot would
+    // still be occupied when the next turn starts. Retract rather than promote,
+    // because unresolved held text is commentary far more often than it is an
+    // answer, and speaking it is the failure this hold exists to prevent.
+    const strandedHeldJobs = this.retractHeldTtsSegments(
+      token,
+      (job) => job.held,
+    );
+    if (strandedHeldJobs > 0) {
+      log.warn(
+        { turnId: activeTurn.turnId, strandedHeldJobs },
+        "Live voice turn completed with held segments the caller never resolved",
+      );
+    }
+    // Past this point every enqueue is terminal, so nothing new is held.
+    activeTurn.ttsCompleting = true;
     activeTurn.ttsBuffer += activeTurn.ttsReasoningFilter.flush();
     this.flushTtsBuffer(token, true);
     activeTurn.ttsQueue = activeTurn.ttsQueue
@@ -5820,13 +5845,19 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     if (options.countsAsFirstSegment ?? true) {
       activeTurn.ttsSegmentEnqueued = true;
     }
+    // A hold means "wait and see whether a tool call follows this text". Once
+    // the turn is completing, nothing can follow it, so a segment flushed here
+    // is terminal by construction and must never be held: holding it would
+    // strand the tail of the answer off the emission chain, where the leftover
+    // sweep below would then drop it.
+    const held = (options.held ?? false) && !activeTurn.ttsCompleting;
     const job: TtsSegmentJob = {
       text: segment,
       language: options.language,
       started: false,
       settled: false,
       emitting: false,
-      held: options.held ?? false,
+      held,
       cancelled: false,
       abort: new AbortController(),
       bufferedChunks: [],

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -525,7 +525,9 @@ interface TtsSegmentJob {
   readonly language: string | undefined;
   // The provider stream was started (the job holds an open-job slot).
   started: boolean;
-  // Emission finished; the slot is free for the next queued segment.
+  // The provider is done with this job, either because emission finished or
+  // because a retraction's abort tore the stream down. The synthesis slot is
+  // free for the next queued segment.
   settled: boolean;
   // The job owns the emission slot: provider chunks forward to the client
   // live instead of buffering.
@@ -534,11 +536,14 @@ interface TtsSegmentJob {
   // Dropped with the turn on cancellation.
   bufferedChunks: LiveVoiceTtsAudioChunk[];
   // Enqueued for synthesis but deliberately kept off the emission chain until
-  // the caller promotes it. A held job has forwarded no audio, so it is
-  // silently cancellable and must never count as audible activity.
+  // the caller promotes it. A held job has forwarded no audio, so it is still
+  // silently cancellable, but it does count as pending audio: promotion is all
+  // that stands between it and the caller's ears.
   held: boolean;
   // Retracted before promotion: dropped from the emission chain with its
-  // provider stream aborted. Only ever set while `emitting` is false.
+  // provider stream aborted. Only ever set while `emitting` is false. It goes
+  // true the instant the retraction lands, ahead of `settled`, because a job
+  // stops being audible before its aborted stream stops being open.
   cancelled: boolean;
   // Per-job synthesis abort, so retracting one segment leaves the turn's other
   // segments alone (the turn controller aborts all of them).
@@ -5341,14 +5346,22 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   }
 
   // No assistant audio is pending or (estimatedly) still playing: nothing
-  // buffered toward the next sentence, every queued TTS segment fully
-  // emitted, and the client-side playback-tail estimate expired. A held
-  // segment is synthesized but unspoken and may never be promoted, so it is
-  // silence as far as the user is concerned.
+  // buffered toward the next sentence, no queued TTS segment that can still be
+  // heard, and the client-side playback-tail estimate expired.
+  //
+  // A job sits on two independent axes. "Does it still occupy a provider
+  // synthesis slot" is `started && !settled`, and that is pumpTtsSynthesis's
+  // question, not this one. This is the other axis: "can it still produce
+  // audio the caller hears". A cancelled job never can, whatever its aborted
+  // stream is still doing, so it must not gate the idle tick: a provider that
+  // hangs on abort would otherwise mute narration for the rest of the turn. A
+  // held job is the opposite. It is heard the moment it is promoted, so a turn
+  // sitting on held segments is quiet rather than idle, and the tick must stay
+  // silent instead of talking over the answer that is about to land.
   private turnAudioIdle(turn: ActiveAssistantTurn): boolean {
     return (
       turn.ttsBuffer.length === 0 &&
-      turn.ttsJobs.every((job) => job.settled || job.held) &&
+      turn.ttsJobs.every((job) => job.settled || job.cancelled) &&
       Date.now() >= this.assistantPlaybackTailUntilMs
     );
   }
@@ -5572,9 +5585,18 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   }
 
   /**
-   * Move held segments onto the emission chain, in enqueue order. Their audio
-   * is already synthesized and buffered, so promotion is a buffer flush rather
-   * than a TTS round trip.
+   * Move held segments onto the emission chain. Their audio is already
+   * synthesized and buffered, so promotion is a buffer flush rather than a TTS
+   * round trip.
+   *
+   * Ordering contract: promoted jobs join the chain at promotion time, ordered
+   * among themselves by enqueue order, and land behind anything already queued.
+   * A held job deliberately does not reserve a position when it is enqueued.
+   * A reserved position would stall every later job behind a segment that may
+   * never be promoted at all, including the short "still working" tone whose
+   * entire purpose is to fill that hold, so the queue would go silent for
+   * exactly as long as the hold lasts. Keeping held jobs off the chain is what
+   * makes a hold quiet rather than blocking.
    */
   private promoteHeldTtsSegments(
     token: symbol,
@@ -5586,7 +5608,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     }
 
     // `ttsJobs` is in enqueue order, so chaining in filter order is what keeps
-    // a promoted block ahead of whatever is enqueued after it.
+    // the promoted block internally ordered.
     const promoted = activeTurn.ttsJobs.filter(
       (job) => job.held && !job.cancelled && select(job),
     );
@@ -5609,10 +5631,19 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
    * A job that is already `emitting` is left alone: spoken audio cannot be
    * un-said and cutting a segment mid-phrase sounds broken. In this design no
    * held job is ever emitting, so that guard is belt-and-braces.
+   *
+   * `discardPendingTail` declares that the caller also owns whatever sits in
+   * `ttsBuffer` below the next segment boundary, so a caller retracting a whole
+   * block sets it and a selective retraction does not. Ownership is stated
+   * rather than inferred: the buffer is turn-wide, the selector only sees jobs
+   * that have already formed, and a selective retraction has no way to tell
+   * whose text the un-segmented tail is. Guessing would silently delete speech
+   * the retraction never covered.
    */
   private retractHeldTtsSegments(
     token: symbol,
     select: (job: TtsSegmentJob) => boolean,
+    options: { discardPendingTail?: boolean } = {},
   ): number {
     const activeTurn = this.activeAssistantTurn;
     if (activeTurn?.token !== token) {
@@ -5628,19 +5659,39 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         createAbortReason("voice_session_aborted", "live-voice-tts-retract"),
       );
       job.bufferedChunks.length = 0;
-      // A retracted job never reaches emitTtsJob, so its synthesis slot has to
-      // be released here or it would stand open for the rest of the turn.
-      job.settled = true;
+      if (job.synthesis === null) {
+        // Never handed to the provider, so it occupies no synthesis slot.
+        job.settled = true;
+        continue;
+      }
+      // A retracted job never reaches emitTtsJob, so nothing else will settle
+      // it. The slot stays taken until the provider stream actually tears
+      // down: a provider that does not honour the abort promptly would
+      // otherwise have the next job start alongside it and put more than
+      // TTS_MAX_OPEN_SYNTHESIS_JOBS streams open at once.
+      void job.synthesis.then(
+        () => this.settleRetractedTtsJob(token, job),
+        () => this.settleRetractedTtsJob(token, job),
+      );
     }
 
-    // Drop the retracted block's un-segmented tail too, whether or not any
-    // job had formed from it yet: text still short of a segment boundary
-    // belongs to the block being retracted, and a half-finished markdown or
-    // <think> construct left in the filter would bleed into the next block.
-    activeTurn.ttsBuffer = "";
-    activeTurn.ttsReasoningFilter.flush();
+    if (options.discardPendingTail === true) {
+      // The block owns its un-segmented tail whether or not a job formed from
+      // it yet: text short of a segment boundary is still the block's, and a
+      // half-finished markdown or <think> construct left in the filter would
+      // bleed into the next block.
+      activeTurn.ttsBuffer = "";
+      activeTurn.ttsReasoningFilter.flush();
+    }
     this.pumpTtsSynthesis(token);
     return retracted.length;
+  }
+
+  // Releases a retracted job's synthesis slot once its aborted provider stream
+  // has torn down, and lets the next queued segment take it.
+  private settleRetractedTtsJob(token: symbol, job: TtsSegmentJob): void {
+    job.settled = true;
+    this.pumpTtsSynthesis(token);
   }
 
   private completeTtsForTurn(token: symbol): void {
@@ -5820,7 +5871,8 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       // answer's onset; later segments pipeline during that first segment's
       // playback anyway, so synthesizing further ahead only risks paying for
       // audio a tool call is about to cancel. A held job stays open until it
-      // is promoted or retracted, so the cap is a standing one.
+      // is promoted, or until a retraction's abort tears its stream down, so
+      // the cap is a standing one.
       const heldSlotTaken = activeTurn.ttsJobs.some(
         (candidate) =>
           candidate.held && candidate.started && !candidate.settled,


### PR DESCRIPTION
## Summary
- Add `held`, `cancelled`, and a per-job `AbortController` to `TtsSegmentJob`, so a segment can be synthesized without being emitted and cancelled before any audio reaches the client.
- Add `promoteHeldTtsSegments` and `retractHeldTtsSegments`; cap held jobs at one open synthesis slot.
- Behavior-neutral: no caller passes `held` yet.

Part of plan: voice-speak-final-answer-only.md (PR 2 of 6)