### PR TITLE
docs(assistant): restore the Telegram webhook tier invariant

### DIFF
--- a/assistant/src/config/webhook-routing.ts
+++ b/assistant/src/config/webhook-routing.ts
@@ -83,6 +83,14 @@ function isIngressExplicitlyDisabled(): boolean {
  *
  * `allowManagedCallbacks` gates both platform tiers: channels that can only be
  * served by a self-hosted ingress pass `false` and never see them.
+ *
+ * The gateway's Telegram webhook reconciler implements this same resolution
+ * order when deciding what URL to hand Telegram's setWebhook
+ * (`resolveExpectedTelegramWebhookUrl` in
+ * `gateway/src/telegram/webhook-manager.ts`). The two must stay in agreement:
+ * a tier this derivation reports as configured but the reconciler declines
+ * leaves Telegram setup reporting success while no webhook is ever
+ * registered. Change the tiers in both places or not at all.
  */
 export async function hasWebhookRoutingConfigured(
   allowManagedCallbacks = false,


### PR DESCRIPTION
## TL;DR

Restores a docstring block that the v0.11.0 release merge-back reverted off `main`. Comment only, no behaviour change.

## What was lost

`hasWebhookRoutingConfigured` documents a four-tier resolution order for where inbound webhooks are routed. It used to end with a note that the gateway's Telegram reconciler implements the same order, and that the two must be changed together or not at all, because a tier the daemon reports as configured but the reconciler declines makes Telegram setup report success while `setWebhook` never runs.

Release v0.11.0 removed that block. The file has not been touched since, so it has been missing for about three weeks.

## Why it matters

The note is one half of a two-way pointer. The gateway side still carries its counterpart at `gateway/src/telegram/webhook-manager.ts:139`, which says the resolution order mirrors this file and the two must agree. With the daemon half gone, a rule binding two files was visible from only one of them, which is exactly the direction someone editing the tier list here would not look.

## Verified before restoring

Rather than re-applying the old text on faith:

- `resolveExpectedTelegramWebhookUrl` still exists at `gateway/src/telegram/webhook-manager.ts:139`.
- It still mirrors the same four tiers this derivation documents (platform pods, explicit ingress-disabled, configured public ingress, platform-connected fallback).
- The gateway's counterpart comment is still present and still points here.

So the invariant the note describes is still true.

## One deliberate difference

The original cited a Linear id. This restores the sentence without it, since it already names the failure it prevents and a docstring should state the gap rather than the ticket. Everything else is the text as it was.

## Before / after

| | Before | After |
| -- | -- | -- |
| Behaviour | unchanged | unchanged |
| Editing the daemon tier list | no sign the gateway must match | the docstring says so, as it did before v0.11.0 |
| Editing the gateway tier list | its comment points at a file with no matching note | both halves agree again |

## Context

Part of a set of small restorations of content that release merge-backs reverted off `main` and nobody re-landed. The mechanism is ATL-1306: the merge-back resolves conflicts with `git rebase -X theirs`, discarding `main`'s side silently, then merges with `[skip ci]` and `--admin`. Each restoration is a separate PR because they span different areas and reviewers.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41060" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->