### PR TITLE
fix(web): clear a stuck thinking indicator seeded without the flag

### DIFF
--- a/clients/web/src/domains/chat/hooks/use-message-reconciliation.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-message-reconciliation.test.tsx
@@ -154,6 +154,22 @@ describe("useMessageReconciliation — server processing flag drives reseed", ()
     expect(invalidateSpy).not.toHaveBeenCalled();
   });
 
+  test("reseeds when the snapshot never received an authoritative flag (undefined sentinel)", async () => {
+    // The rolling snapshot was seeded without the `processing` field, so
+    // `nextProcessingState` pinned it to the `undefined` sentinel and no delta
+    // fold can ever lift it, leaving the close-gate starved on a non-`false`
+    // value. A modern daemon reporting idle must still trigger the reseed that
+    // plants an authoritative `false`.
+    seedSnapshotProcessing(undefined);
+    seedServerFetch(false);
+    const { result, invalidateSpy } = renderReconciliation();
+
+    const outcome = await result.current.reconcileActiveConversation();
+
+    expect(outcome.changed).toBe(false);
+    expect(invalidateSpy).toHaveBeenCalledTimes(1);
+  });
+
   test("does not reseed when the snapshot already reflects the idle turn", async () => {
     // Turn already idle locally — no stale spinner to clear, so no refetch.
     seedSnapshotProcessing(false);

--- a/clients/web/src/domains/chat/hooks/use-message-reconciliation.ts
+++ b/clients/web/src/domains/chat/hooks/use-message-reconciliation.ts
@@ -164,13 +164,26 @@ export function useMessageReconciliation({
       // terminal event (`message_complete` / `assistant_activity_state(idle)`)
       // was dropped on a disconnect. Propagating it lets the existing
       // authoritative CLOSE-gate in `shouldShowThinkingIndicator` /
-      // `isAssistantBusy` (`snapshotProcessing === false`) settle the turn —
-      // no client-side stuck-turn heuristic. `undefined` (older daemons) does
-      // nothing, preserving prior behavior.
+      // `isAssistantBusy` (`snapshotProcessing === false`) settle the turn,
+      // with no client-side stuck-turn heuristic.
+      //
+      // The local flag is non-`false` in two ways, and both need the reseed:
+      //   - `true`: a delta folded it on, but the terminal event that would
+      //     fold it back off never arrived.
+      //   - `undefined`: the version sentinel. `nextProcessingState` returns
+      //     `undefined` forever once the snapshot seed lacked the field, so no
+      //     amount of delta folding lifts it to a boolean and the close-gate
+      //     stays starved on a non-`false` value. A reseed is the only way to
+      //     plant an authoritative `false`.
+      //
+      // An older daemon cannot reach here: it never sends a defined
+      // `processing`, so `serverProcessing === false` is already false and the
+      // guard stays shut. The `undefined` this admits is the local sentinel,
+      // not an old daemon.
       const localSnapshotProcessing =
         useChatSessionStore.getState().snapshot?.processing;
       const serverClearedProcessing =
-        serverProcessing === false && localSnapshotProcessing === true;
+        serverProcessing === false && localSnapshotProcessing !== false;
 
       // Refresh the single source — history flows into the query cache and the
       // transcript (its union with the live turn) re-renders. No client-side


### PR DESCRIPTION
## TL;DR

A stuck "Thinking…" indicator that can only be cleared by refreshing the page. Fixed once in `92d4e2cbe8`, reverted by the v0.10.5 release merge-back, and still reverted today. This restores the fix, its test, and corrects the comment that made the broken version look deliberate.

## The bug

`shouldShowThinkingIndicator` closes a turn authoritatively when `snapshotProcessing === false`. If the flag is `undefined` the gate never closes and the indicator falls through to phase-driven behaviour, so a turn whose terminal SSE event was dropped on a disconnect keeps showing dots.

`undefined` is not a transient state. `nextProcessingState` opens with `if (current === undefined) return undefined`, so once a snapshot is seeded without the field it is pinned there for the life of that snapshot. No amount of delta folding lifts it to a boolean.

The one path that can rescue it is the reconciliation reseed, which plants an authoritative `false`. Its guard on `main` reads:

```ts
serverProcessing === false && localSnapshotProcessing === true;
```

`=== true` never matches `undefined`, so the only exit is closed for exactly the state that needs it.

`main` already says so, in a docstring in `use-conversation-history-seed-processing.test.tsx`:

> a snapshot seeded without it is pinned to the `undefined` sentinel for its whole life, leaving a stuck "Thinking…" indicator unrecoverable without a page refresh

## Why the broken version looks right

The comment currently above the guard says `undefined` means older daemons, and that ignoring it preserves prior behaviour. That reasoning is wrong, and it is the reason the narrowing survived.

There are two different `undefined`s and the comment conflates them:

* **The server's.** `serverProcessing` comes from `snapshot?.processing` on the fetched page. An older daemon never sends the field, so `serverProcessing === false` is already false and the guard shuts one clause earlier. Old daemons cannot reach this branch at all.
* **The local snapshot's.** That is the sentinel, and it happens on a current daemon.

So widening to `!== false` costs old daemons nothing, because they never get here. This PR rewrites that comment to say which `undefined` is which, so the next person does not narrow it again for the same plausible reason.

## Not a blind re-apply

The original fix is two months old, so each premise it depends on was re-checked against `main` rather than assumed:

| Premise | State on `main` |
| -- | -- |
| Close-gate still keyed on `snapshotProcessing === false` | yes, `turn-selectors.ts:90` |
| `undefined` still leaves that gate open | yes, and the comment there says so |
| The sentinel still pins `undefined` forever | yes, `rolling-snapshot.ts:275` |
| A reseed still plants an authoritative `false` | yes, unchanged |
| Old daemons still cannot reach the widened branch | yes, `serverProcessing` is the server's own flag |

One caveat worth a reviewer's eye: #37346 retired the reconciliation poll *timer* above the events-tail floor. `reconcileFromServerDetailed` still runs from `reconcile-on-reopen`, which is the dropped-terminal-event-on-disconnect path this targets, so the fix still sits where it is needed. Confirmation from someone who owns the transcript code would be welcome.

## Before / after

| | Before | After |
| -- | -- | -- |
| Snapshot seeded with `processing: true`, terminal event dropped | reseed clears it | unchanged |
| Snapshot seeded without `processing`, server reports idle | dots stay until refresh | reseed plants `false`, turn closes |
| Older daemon, no `processing` field sent | guard shut | unchanged, still shut |

## Tests

Restores `reseeds when the snapshot never received an authoritative flag (undefined sentinel)`, deleted by the same release. Its helpers (`seedSnapshotProcessing`, `seedServerFetch`, `renderReconciliation`) all still exist unchanged, so it applies as it was. Checked that no existing test asserts the narrow behaviour, so nothing in the suite contradicts this.

## Context

One of a set of restorations of work that release merge-backs reverted off `main`. The mechanism is ATL-1306: the merge-back resolves conflicts with `git rebase -X theirs`, silently discarding `main`'s side, then merges with `[skip ci]` and `--admin`. This is the only one of the set that changes behaviour.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41061" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->