### PR TITLE
test(web): restore the anchor-less seed guard's regression tests

### DIFF
--- a/clients/web/src/domains/chat/chat-session-store-base.test.ts
+++ b/clients/web/src/domains/chat/chat-session-store-base.test.ts
@@ -116,6 +116,68 @@ describe("chat-session-store — snapshot + optimistic", () => {
     expect(store().snapshot).toBe(snap); // wholesale, no partial replay
   });
 
+  test("seedSnapshot drops an anchor-less fetch once the live view has folded stream events", () => {
+    // Fresh-conversation first turn: the daemon's partial-persist debounce
+    // hasn't flushed yet, so a mid-turn /messages fetch returns `seq: null`.
+    // Taking it wholesale would wipe the streamed prefix (the "vanishing
+    // prefix" flicker); the live view must be kept instead.
+    store().seedSnapshot(CONV, snapshot([], null)); // initial seed, nothing folded yet
+    store().applyEnvelopeToSnapshot(textDelta(6, CONV, "a1", "Hey"));
+    store().applyEnvelopeToSnapshot(textDelta(7, CONV, "a1", " yourself."));
+
+    store().seedSnapshot(CONV, snapshot([], null)); // anchor-less mid-turn refetch
+
+    expect(
+      store().snapshot?.messages.find((m) => m.id === "a1")?.textSegments,
+    ).toEqual(["Hey yourself."]);
+    expect(store().snapshot?.seq).toBe(7);
+  });
+
+  test("seedSnapshot still accepts an anchor-less fetch while nothing has been folded", () => {
+    store().seedSnapshot(CONV, snapshot([], null));
+    const snap = snapshot([textRow("a1", "persisted")], null);
+    // Live view exists but has no seq, so the fetch wins.
+    store().seedSnapshot(CONV, snap);
+    expect(store().snapshot).toBe(snap);
+  });
+
+  test("anchor-less refetch mid-stream no longer drops the streamed prefix (flicker repro)", () => {
+    // Regression shape from the field: deltas fold live; an anchor-less
+    // refetch lands mid-word; more deltas follow; the turn-end anchored
+    // reseed adopts the canonical row. The transcript must show the full text
+    // at every step after the refetch, never a suffix-only bubble.
+    store().seedSnapshot(
+      CONV,
+      snapshot([{ ...textRow("u1", "hey"), role: "user" }], null),
+    );
+    store().applyEnvelopeToSnapshot(textDelta(6, CONV, "a1", "Hey"));
+    store().applyEnvelopeToSnapshot(textDelta(7, CONV, "a1", " yourself."));
+
+    // Mid-turn refetch: server still has only the user row, no anchor.
+    store().seedSnapshot(
+      CONV,
+      snapshot([{ ...textRow("u1", "hey"), role: "user" }], null),
+    );
+    store().applyEnvelopeToSnapshot(textDelta(8, CONV, "a1", " You're up."));
+
+    const live = store().snapshot?.messages.find((m) => m.id === "a1");
+    expect(live?.textSegments).toEqual(["Hey yourself. You're up."]);
+
+    // Turn-end reseed carries the persisted row and a real anchor.
+    store().seedSnapshot(
+      CONV,
+      snapshot(
+        [
+          { ...textRow("u1", "hey"), role: "user" },
+          textRow("a1", "Hey yourself. You're up."),
+        ],
+        8,
+      ),
+    );
+    const final = store().snapshot?.messages.find((m) => m.id === "a1");
+    expect(final?.textSegments).toEqual(["Hey yourself. You're up."]);
+  });
+
   test("seedSnapshot drops a stale-anchored fetch the ring can't bridge (send flicker)", () => {
     // The logged incident: the live view seeded at seq 100, then folded the
     // send's user_message_echo (seq 500 — other conversations' events advanced


### PR DESCRIPTION
## TL;DR

Restores three tests the v0.10.5 release merge-back deleted. Tests only, no source change. The guard they cover is still in the code and has been uncovered for about seven weeks.

## What was lost

`seedSnapshot` has two regression guards. The anchor-less one drops a `/messages` fetch that comes back with `seq: null` once the live view has folded stream events, because taking it wholesale wipes the streamed prefix. That is the mid-turn "vanishing prefix" flicker.

Release v0.10.5 deleted the three tests covering it:

* `seedSnapshot drops an anchor-less fetch once the live view has folded stream events`
* `seedSnapshot still accepts an anchor-less fetch while nothing has been folded`
* `anchor-less refetch mid-stream no longer drops the streamed prefix (flicker repro)`

The third is a repro of a bug seen in the field.

## Why nobody noticed

Three reasons this stayed invisible, all worth knowing for the next one:

1. **The guard survived.** Only the tests went, so nothing broke and nothing failed.
2. **Its twin is still tested.** The suite kept `seedSnapshot drops a stale-anchored fetch the ring can't bridge (send flicker)`, the anchored counterpart. Skimming the file, the area looks covered.
3. **The file kept growing.** 323 lines before the release, 265 after, 494 today. Later work refilled the line count with different tests, so size or coverage deltas would not flag it.

## Still valid, checked not assumed

The tests are seven weeks old, so rather than trusting them:

* The anchor-less guard is intact at `chat-session-store.ts:365`, with a comment explaining the flicker and a `history_seed_skipped_anchorless` diagnostic. The behaviour is deliberate and current.
* Every helper the tests use is unchanged: `snapshot(messages, seq)`, `textRow`, `textDelta`, `store()`, `applyEnvelopeToSnapshot`.
* The current suite has no other coverage of the anchor-less branch, so this is a real gap rather than a duplicate.

## Sensitivity check

A restored test that cannot fail is worse than none, so each was checked against the guard being removed:

| Test | If the early return is deleted |
| -- | -- |
| drops an anchor-less fetch | fetch taken wholesale, live view wiped, `textSegments` undefined, fails |
| still accepts while nothing folded | passes either way by design: it holds the guard to its bounds, so the fix cannot over-fire |
| flicker repro | live view wiped mid-stream, suffix-only bubble, fails |

## Before / after

| | Before | After |
| -- | -- | -- |
| Anchor-less guard behaviour | unchanged | unchanged |
| Coverage of that branch | none | three tests, including the field repro |
| Removing the guard by accident | silent | two tests fail |

## Context

One of a set of restorations of work that release merge-backs reverted off `main`. The mechanism is ATL-1306: the merge-back resolves conflicts with `git rebase -X theirs`, silently discarding `main`'s side, then merges with `[skip ci]` and `--admin`. This one is the clearest illustration of why a red build is the wrong detector: nothing broke, the code was fine, only the thing that would catch a future break went missing.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41062" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->