### PR TITLE
docs(web): name the theme surface that actually exists

### DIFF
--- a/clients/web/src/components/theme-toggle.tsx
+++ b/clients/web/src/components/theme-toggle.tsx
@@ -28,7 +28,7 @@ const VELVET_THEME_OPTION = {
 
 /**
  * Compact icon-only theme switcher for the sidebar preferences popover.
- * Mirrors the `AppearanceSection` in the Preferences modal — both share the
+ * Mirrors the `ThemePicker` on Settings → General. Both share the
  * `useThemePreference` hook so they stay in sync via the `watchDeviceSetting`
  * listener.
  *

--- a/clients/web/src/hooks/use-theme-preference.ts
+++ b/clients/web/src/hooks/use-theme-preference.ts
@@ -12,9 +12,9 @@ import { watchDeviceSetting } from "@/utils/device-settings";
 
 /**
  * Shared theme-preference state used by both the compact `ThemeToggle` in the
- * sidebar preferences popover and the `AppearanceSection` in the Preferences
- * modal. Keeps the two surfaces in sync (they read/write the same device
- * setting) without duplicating the effect chain.
+ * sidebar preferences popover and the `ThemePicker` on Settings → General.
+ * Keeps the two surfaces in sync (they read/write the same device setting)
+ * without duplicating the effect chain.
  *
  * @returns the current theme and a setter that persists + applies the choice.
  */


### PR DESCRIPTION
## TL;DR

Two docstrings name a React component that does not exist. Comment only.

## What happened

`useThemePreference` is shared by the sidebar's compact `ThemeToggle` and the settings-side theme UI, and its docstring names the second surface so the two stay findable from each other.

That name has been wrong since 2026-07-16:

| Version | Text | Correct? |
| -- | -- | -- |
| Before v0.10.10 | `AppearanceCard` on Settings → General | right place, name has since changed |
| v0.10.10 release merge-back reverted it to | `AppearanceSection` in the Preferences modal | wrong name and wrong place |
| Today on `main` | still the reverted text | no |

`AppearanceSection` was then deleted outright by #38365, whose title says it plainly: `drop orphaned AppearanceSection left by the v0.10.10 release merge`. So the revert left a reference to a component, and the follow-up cleanup deleted the component while leaving the reference.

## Not a restoration

Restoring the pre-revert text would swap one dangling reference for another, since `AppearanceCard` does not exist either. The hook's only settings-side consumer today is `ThemePicker`, rendered from `general-page.tsx`, which is Settings → General. Both docstrings now say that.

The second one (`theme-toggle.tsx`) carried the same stale name and is fixed in the same change, since a half-fix leaves the two surfaces pointing at each other through a component that isn't there.

## Before / after

| | Before | After |
| -- | -- | -- |
| Behaviour | unchanged | unchanged |
| Following the docstring from the hook | lands on a component that does not exist | lands on `ThemePicker` |
| Following it from `ThemeToggle` | same dead name | same fix |

## Context

Came out of the sweep behind ATL-1306, where the release merge-back resolves conflicts with `git rebase -X theirs` and silently discards `main`'s side. This one is worth noting as a shape rather than a severity: the revert alone was survivable, but the cleanup that followed it deleted the component and made the stale reference permanent. Same pattern as the sidebar-resize feature in that issue, where the tidy-up entrenched the loss.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41063" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->