### PR TITLE
ci(windows): disable the Windows package smoke job

### DIFF
--- a/.github/workflows/ci-main-windows.yaml
+++ b/.github/workflows/ci-main-windows.yaml
@@ -18,7 +18,6 @@ on:
       - 'skills/**'
       - 'packages/**'
       - '.github/workflows/ci-main-windows.yaml'
-      - '.github/workflows/windows-package-smoke.yaml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -114,13 +113,9 @@ jobs:
       - name: Test and publish helper
         run: bun scripts/build-native-helper.ts --arch all --test
 
-  package-smoke:
-    name: Package Smoke (Windows)
-    uses: ./.github/workflows/windows-package-smoke.yaml
-
   checks:
     name: Type Check, Build & Test (Windows Electron)
-    needs: [typecheck, build, test, native, package-smoke]
+    needs: [typecheck, build, test, native]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -130,14 +125,12 @@ jobs:
           BUILD: ${{ needs.build.result }}
           TEST: ${{ needs.test.result }}
           NATIVE: ${{ needs.native.result }}
-          RUNTIME: ${{ needs.package-smoke.result }}
         run: |
           echo "Type Check: $TYPECHECK"
           echo "Build:      $BUILD"
           echo "Test:       $TEST"
           echo "Native:     $NATIVE"
-          echo "Package:    $RUNTIME"
-          for r in "$TYPECHECK" "$BUILD" "$TEST" "$NATIVE" "$RUNTIME"; do
+          for r in "$TYPECHECK" "$BUILD" "$TEST" "$NATIVE"; do
             if [ "$r" != "success" ]; then
               echo "::error::At least one windows electron CI job failed."
               exit 1

--- a/.github/workflows/pr-windows.yaml
+++ b/.github/workflows/pr-windows.yaml
@@ -18,7 +18,6 @@ on:
       - 'skills/**'
       - 'packages/**'
       - '.github/workflows/pr-windows.yaml'
-      - '.github/workflows/windows-package-smoke.yaml'
 
 concurrency:
   group: pr-windows-${{ github.event.pull_request.number }}
@@ -114,13 +113,9 @@ jobs:
       - name: Test and publish helper
         run: bun scripts/build-native-helper.ts --arch all --test
 
-  package-smoke:
-    name: Package Smoke (Windows)
-    uses: ./.github/workflows/windows-package-smoke.yaml
-
   checks:
     name: Type Check, Build & Test (Windows Electron)
-    needs: [typecheck, build, test, native, package-smoke]
+    needs: [typecheck, build, test, native]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -130,14 +125,12 @@ jobs:
           BUILD: ${{ needs.build.result }}
           TEST: ${{ needs.test.result }}
           NATIVE: ${{ needs.native.result }}
-          RUNTIME: ${{ needs.package-smoke.result }}
         run: |
           echo "Type Check: $TYPECHECK"
           echo "Build:      $BUILD"
           echo "Test:       $TEST"
           echo "Native:     $NATIVE"
-          echo "Package:    $RUNTIME"
-          for r in "$TYPECHECK" "$BUILD" "$TEST" "$NATIVE" "$RUNTIME"; do
+          for r in "$TYPECHECK" "$BUILD" "$TEST" "$NATIVE"; do
             if [ "$r" != "success" ]; then
               echo "::error::At least one windows electron CI job failed."
               exit 1

--- a/.github/workflows/windows-package-smoke.yaml
+++ b/.github/workflows/windows-package-smoke.yaml
@@ -1,7 +1,11 @@
 name: Windows Package Smoke
 
+# Not wired into PR/main CI: the NSIS silent install intermittently exits 5
+# on the hosted runners. Run by hand, or re-add the package-smoke job to
+# pr-windows.yaml / ci-main-windows.yaml once that is resolved.
 on:
   workflow_call: {}
+  workflow_dispatch: {}
 
 jobs:
   package:


### PR DESCRIPTION
## Summary
- Remove the `package-smoke` job from `pr-windows.yaml` and `ci-main-windows.yaml`, and drop it from the aggregate `checks` job's `needs` and result loop. `windows-package-smoke.yaml` stays in place (now also `workflow_dispatch`) so it can be run by hand or re-wired later.
- Why: the NSIS silent install step (`Vellum Local-Setup-<ver>-<arch>.exe /S /D=...`) intermittently exits with code 5 before the smoke checks even run, on both main and PRs. Examples: main run 32422937055 (x64), PR #40743 run 32424407603 (arm64). It blocks PRs that have nothing to do with Windows packaging.

## Why Windows CI runs on nearly every merge
Both Windows workflows trigger on a broad path filter: `package.json`, `bun.lock`, `patches/**`, `assistant/**`, `cli/**`, `credential-executor/**`, `gateway/**`, `clients/windows/**`, `clients/web/**`, `meta/feature-flags/**`, `skills/**`, `packages/**`. That is because the Windows package bundles the web renderer, the CLI runtime, the assistant daemon and gateway, so a change to any of those changes the packaged app. The filters are left as-is in this PR; narrowing them is a separate call (e.g. only the Electron typecheck/build/test need `clients/windows/**` + `packages/**`, while the packaging itself is the part that cares about the rest).

## Original prompt
While fixing CI on PR #40743, the x64 smoke failure turned out to be a real helper-path mismatch (fixed there), but the arm64 smoke then failed with the installer exiting 5, and the same exit-5 failure shows up on main. Maddie asked to just disable the Windows package smoke test in a separate PR via /do, based off main, and to explain why the Windows workflows run on merges that don't touch Windows code.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41066" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->