### PR TITLE
refactor(web): drop the Pinned-resize constants nothing reads

### DIFF
--- a/clients/web/src/components/sidebar-nav-geometry.ts
+++ b/clients/web/src/components/sidebar-nav-geometry.ts
@@ -43,13 +43,6 @@ export const SIDEBAR_SECTION_INDENT = 0;
 export const SIDEBAR_SECTION_MAX_HEIGHT = 300;
 
 /**
- * Bounds for the Pinned section's user-adjustable height (dragging the rule
- * under the curated block). Min fits two desktop rows (30px each) plus their
- * 4px gap. Max stays a fixed constant rather than viewport-derived: the
- * sidebar body scrolls, so an oversized section degrades to body scrolling
- * the same way a long section list does today.
- */
-/**
  * The gap between any two stacked entries in the sidebar: the built-in nav's
  * pills, the section cards, and the scrollport that holds them.
  *
@@ -59,9 +52,6 @@ export const SIDEBAR_SECTION_MAX_HEIGHT = 300;
  * adjacent entries, and which container wins is not locally visible.
  */
 export const SIDEBAR_STACK_GAP = "gap-2";
-
-export const SIDEBAR_SECTION_RESIZE_MIN_HEIGHT = 64;
-export const SIDEBAR_SECTION_RESIZE_MAX_HEIGHT = 600;
 
 /**
  * Text treatment for a section title (Pinned, a custom group, Chats, a


### PR DESCRIPTION
## TL;DR

Deletes two exported constants with no readers and a docstring describing a feature that no longer exists. No behaviour change.

## What this is

`sidebar-nav-geometry.ts` still carries:

```ts
export const SIDEBAR_SECTION_RESIZE_MIN_HEIGHT = 64;
export const SIDEBAR_SECTION_RESIZE_MAX_HEIGHT = 600;
```

Neither has a single reader anywhere in the repo. They bounded the Pinned section's drag-to-resize from #39795, whose integration points the v0.11.1 release merge-back reverted off `main`. #39934 then deleted the orphaned modules three days later and these two exports survived the sweep.

Their docstring outlived them twice over. It describes "dragging the rule under the curated block", which is not a gesture the sidebar has, and an intervening edit left it sitting above `SIDEBAR_STACK_GAP` instead of the constants it documents. A reader today finds resize-bounds prose introducing a flexbox gap.

## Not the rail handle

Worth stating so this is not read as removing something live. The sidebar does have a drag-to-resize: the rail width handle in `assistant-side-menu.tsx:511`, which "sits in the rail's last 6px". That is untouched. What is gone is the separate Pinned *section height* drag, and these constants only ever bounded that.

## Verified before deleting

* `git grep SIDEBAR_SECTION_RESIZE` across the whole repo returns only the two definition lines.
* `SIDEBAR_SECTION_MAX_HEIGHT`, two lines above, is still imported by `assistant-side-menu.test.tsx` and is deliberately left alone. The similar names are why this is worth checking rather than pattern-matching.

## Before / after

| | Before | After |
| -- | -- | -- |
| Behaviour | unchanged | unchanged |
| Reading `sidebar-nav-geometry.ts` | a docstring for a gesture that does not exist, above the wrong constant | gone |
| Searching for the resize feature | two live-looking exports suggest it is still wired up | nothing to mislead |

## Context

Fallout from ATL-1306, where the release merge-back resolves conflicts with `git rebase -X theirs` and silently discards `main`'s side. The Pinned-resize feature is the clearest case in that issue: reverted silently, then tidied away as dead code, so no commit records a decision to remove it. This removes the last trace rather than restoring the feature, which is the deliberate call.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41067" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->