### PR TITLE
docs(channels): correct two comments that describe code as it is not

### DIFF
--- a/assistant/src/daemon/trust-context.ts
+++ b/assistant/src/daemon/trust-context.ts
@@ -113,9 +113,9 @@ export function mapChatTypeToConversationType(
     // it for the axis rather than inventing a native-looking word.
     case "dm":
       return "dm";
-    // "mpim" is Slack's multi-party DM. The gateway normalizer currently
-    // collapses mpim into "channel", so this arm matches nothing from Slack
-    // today; it pins the correct mapping for the raw Slack vocabulary.
+    // "mpim" is Slack's multi-party DM, forwarded under its own name rather
+    // than reported as "im": a room with several people in it takes the
+    // tighter `private` cell and the group-chat etiquette, not the `dm` one.
     case "mpim":
     case "group": // Telegram group
     case "supergroup": // Telegram supergroup

--- a/assistant/src/messaging/providers/index.ts
+++ b/assistant/src/messaging/providers/index.ts
@@ -161,9 +161,8 @@ export function isDirectDelivery(callbackUrl: string): boolean {
  * Deliver a channel reply directly to the provider API, bypassing the gateway
  * HTTP proxy. Callers MUST check `isDirectDelivery()` first.
  *
- * Sub-operations (reaction, thread status) route to the transport's optional
- * method when both the payload field and the method are present; otherwise
- * the reply is delivered as text / approval / attachments.
+ * Delivers the reply itself: text, approval card, attachments. Every other
+ * operation a transport supports is reached through its own entry point.
  */
 export async function deliverDirect(
   callbackUrl: string,


### PR DESCRIPTION
## TL;DR

Two comments assert things the code does not do. Comments only, no behavior change.

## What was wrong

**`mapChatTypeToConversationType`** said the gateway "currently collapses mpim into `channel`, so this arm matches nothing from Slack today". `message-normalizer.ts` forwards `chatType: "mpim"` under its own name and explains why: a multi-party room needs the group-chat etiquette and the tighter `private` permission cell, and reporting `im` would select the looser `dm` one. The arm the comment describes as dead is the live path for every Slack group DM.

**`deliverDirect`** said sub-operations route to a transport's optional method when the matching payload field is set. #41039 and #41020 gave each operation its own entry point, so it now goes straight to `deliver` and routes nothing.

## Why it matters

Both were read while working out where a guardian's approval prompt can be addressed in #41037. The first one was believed over the normalizer and produced a factually wrong claim in that PR's review thread, which had to be corrected in public. A comment that contradicts its own code is worse than no comment: it is trusted precisely when someone is reasoning carefully.

## Safety

No executable lines change. `tsc` and lint pass.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41069" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->