### PR TITLE
feat(watch): lead the retrospective with the ask

### DIFF
--- a/assistant/src/watch/__tests__/watch-retro.test.ts
+++ b/assistant/src/watch/__tests__/watch-retro.test.ts
@@ -234,9 +234,16 @@ describe("watch retrospective", () => {
     expect(prompt).toContain("what they would say to start this task");
     // And the report is not turned back into a questionnaire about itself.
     expect(prompt).toContain(
-      "Do not ask them to confirm something the recording already showed you.",
+      "do not ask them to confirm something the recording already showed you.",
     );
     expect(prompt).toContain("No preamble");
+    // A destructive step is confirmed however plainly it was recorded. The
+    // recording establishes what someone did once and nothing about whether
+    // they want it repeated unattended, so it is the one exception to the
+    // rule above.
+    expect(prompt).toContain(
+      "Always confirm any destructive or irreversible step, even one the recording showed plainly",
+    );
   });
 
   test("authors nothing until the user has confirmed", async () => {

--- a/assistant/src/watch/__tests__/watch-retro.test.ts
+++ b/assistant/src/watch/__tests__/watch-retro.test.ts
@@ -224,11 +224,19 @@ describe("watch retrospective", () => {
 
     const { prompt } = calls[0]!;
     expect(prompt).toContain("skill-management");
-    // The four points the alignment pass needs before it will scaffold.
-    expect(prompt).toContain("The task.");
-    expect(prompt).toContain("The phrase they would use");
-    expect(prompt).toContain("The steps, in order");
-    expect(prompt).toContain("What you are unsure about.");
+    // The ask leads, and the record follows it.
+    expect(prompt).toContain("What I need from you");
+    expect(prompt).toContain("What I saw");
+    expect(prompt.indexOf("What I need from you")).toBeLessThan(
+      prompt.indexOf("What I saw"),
+    );
+    // The one field the recording cannot supply is always asked for.
+    expect(prompt).toContain("what they would say to start this task");
+    // And the report is not turned back into a questionnaire about itself.
+    expect(prompt).toContain(
+      "Do not ask them to confirm something the recording already showed you.",
+    );
+    expect(prompt).toContain("No preamble");
   });
 
   test("authors nothing until the user has confirmed", async () => {
@@ -239,7 +247,7 @@ describe("watch retrospective", () => {
 
     const { prompt } = calls[0]!;
     expect(prompt).toContain(
-      "Do not author or scaffold a skill until they have confirmed",
+      "Do not author or scaffold a skill until the four points that step names are settled",
     );
     // The retro delegates authoring to the skill-management flow rather than
     // naming the tool that writes a skill, so nothing here can reach it.
@@ -500,7 +508,7 @@ describe("watch retrospective", () => {
     expect(payload).toBeGreaterThan(opened);
     expect(payload).toBeLessThan(closed);
     // The retrospective's own instructions sit outside it.
-    expect(prompt.indexOf("Report back to the user")).toBeGreaterThan(closed);
+    expect(prompt.indexOf("Write back to the user")).toBeGreaterThan(closed);
 
     // One real envelope, so nothing in the recording can pass for a second.
     expect(prompt.match(/<external_content/g)).toHaveLength(1);

--- a/assistant/src/watch/watch-retro.ts
+++ b/assistant/src/watch/watch-retro.ts
@@ -73,7 +73,7 @@ const RETRO_INSTRUCTIONS = `Write back to the user in two sections, in this orde
 
 First, "What I need from you". The questions you cannot answer from the recording, numbered, most consequential first. Each one concrete enough to answer in a sentence, and each one about something you are genuinely guessing at: a value you could not read, a choice whose rule you could not infer, a step you only saw the result of. Always ask what they would say to start this task, in their own words, because the recording cannot tell you that. Ask about the destructive step and the done condition if either is unclear. Do not ask them to confirm something the recording already showed you.
 
-Second, "What I saw". Your reading of the task from start to finish and what it is for, the steps in order, one line each and concrete enough to follow. This is the record your questions sit on top of, so state it rather than asking about it.
+Second, "What I saw". Open with one sentence naming the task and what it is for, on its own and not as a list item. Then the steps in order beneath it, one line each and concrete enough to follow, carrying no purpose of their own. This is the record your questions sit on top of, so state it rather than asking about it.
 
 Open on the first heading. No preamble, no announcing what you are about to do, no narrating which skills you are loading.
 

--- a/assistant/src/watch/watch-retro.ts
+++ b/assistant/src/watch/watch-retro.ts
@@ -68,10 +68,17 @@ const WATCH_RETRO_WAKE_SOURCE = "watch-retro";
  * field the recording cannot supply: the timeline holds what they did, never
  * what they would call it. The steps are usually not, because the recording is
  * exactly the evidence for those.
+ *
+ * A destructive step is the exception, and it is asked about however plainly it
+ * was seen. The recording establishes what someone did once; it establishes
+ * nothing about whether they want it done again without being asked, and the
+ * gap between those two is the whole risk of turning a demonstration into a
+ * skill. `skill-management` will not scaffold until that step is settled
+ * either, so an unasked one stalls the flow it was meant to feed.
  */
 const RETRO_INSTRUCTIONS = `Write back to the user in two sections, in this order, both as level-2 headings.
 
-First, "What I need from you". The questions you cannot answer from the recording, numbered, most consequential first. Each one concrete enough to answer in a sentence, and each one about something you are genuinely guessing at: a value you could not read, a choice whose rule you could not infer, a step you only saw the result of. Always ask what they would say to start this task, in their own words, because the recording cannot tell you that. Ask about the destructive step and the done condition if either is unclear. Do not ask them to confirm something the recording already showed you.
+First, "What I need from you". The questions you cannot answer from the recording, numbered, most consequential first. Each one concrete enough to answer in a sentence, and each one about something you are genuinely guessing at: a value you could not read, a choice whose rule you could not infer, a step you only saw the result of. Always ask what they would say to start this task, in their own words, because the recording cannot tell you that. Ask about the done condition if it is unclear. Always confirm any destructive or irreversible step, even one the recording showed plainly: watching someone do a thing once is not agreement to have it done again unattended, and this is the one place the rule below does not apply. Otherwise do not ask them to confirm something the recording already showed you.
 
 Second, "What I saw". Open with one sentence naming the task and what it is for, on its own and not as a list item. Then the steps in order beneath it, one line each and concrete enough to follow, carrying no purpose of their own. This is the record your questions sit on top of, so state it rather than asking about it.
 

--- a/assistant/src/watch/watch-retro.ts
+++ b/assistant/src/watch/watch-retro.ts
@@ -5,17 +5,17 @@
  * The session itself is silent. It records narration and screens into
  * `watch-timeline` and never speaks, which is what lets the user work without
  * being interrupted. The retro is where that stops: one turn, in the session's
- * own conversation, reporting the task, the phrase the user would use to ask
- * for it, the steps, and everything the recording left uncertain.
+ * own conversation, asking what the recording could not tell it and showing
+ * what it read.
  *
- * It reports and asks. It does not author a skill. What the timeline shows is
- * one performance of a task by someone who was talking while they worked, and
- * a procedure inferred from that is a guess until the person who did it says
- * otherwise: the trigger phrase especially, because the words a user reaches
- * for are not recoverable from watching them click. So the turn ends inside
- * the `skill-management` flow, whose first step is the alignment pass that
- * asks for exactly those things, rather than in a scaffolded file the user
- * never agreed to.
+ * It asks and reports, in that order. It does not author a skill. What the
+ * timeline shows is one performance of a task by someone who was talking while
+ * they worked, and a procedure inferred from that is a guess until the person
+ * who did it says otherwise: the trigger phrase especially, because the words
+ * a user reaches for are not recoverable from watching them click. So the turn
+ * ends inside the `skill-management` flow, whose first step will not scaffold
+ * until those points are settled, rather than in a file the user never agreed
+ * to.
  *
  * Dispatch is fire-and-forget from a socket teardown, so the retro owns its
  * own failures: a session that cannot run its retro has already recorded
@@ -49,21 +49,35 @@ const WATCH_RETRO_WAKE_SOURCE = "watch-retro";
 /**
  * What the retro asks for, and the order it asks in.
  *
- * The four points are the four the `skill-management` alignment pass needs
- * before it will scaffold anything, asked here while the session is still the
- * subject rather than after the user has been handed a skill to react to. The
- * trigger phrase is called out as the user's words because it is the one field
- * the recording cannot supply: the timeline holds what they did, never what
- * they would call it.
+ * **The ask comes first, and it is the shorter half.** What the user owes this
+ * turn is a handful of answers; everything else is the assistant showing its
+ * work. Leading with the report buries the one part that needs them under the
+ * part that does not, and a reader who has to reach the bottom to find the
+ * question has already been asked for more than the question was worth.
+ *
+ * **It asks about what it does not know, not about what it just wrote.** The
+ * `skill-management` skill will not scaffold until four points are settled:
+ * what the skill does, its trigger phrases, its major steps, and its
+ * destructive step and done condition. Its checkpoint is explicit that the
+ * ones to raise are the ones being guessed at. Re-asking all four regardless
+ * turns the report into a questionnaire about itself, where the user confirms
+ * a list of steps printed directly above the question asking whether those are
+ * the steps.
+ *
+ * The trigger phrase is always one of the open ones, because it is the single
+ * field the recording cannot supply: the timeline holds what they did, never
+ * what they would call it. The steps are usually not, because the recording is
+ * exactly the evidence for those.
  */
-const RETRO_INSTRUCTIONS = `Report back to the user, in your own words, in this order:
+const RETRO_INSTRUCTIONS = `Write back to the user in two sections, in this order, both as level-2 headings.
 
-1. The task. What they were doing from start to finish, and what it is for.
-2. The phrase they would use to ask you to do this for them, in their words rather than yours.
-3. The steps, in order, one line each and concrete enough to follow.
-4. What you are unsure about. Name every place the recording left you guessing: a value you could not read, a choice whose rule you could not infer, a step you only saw the result of.
+First, "What I need from you". The questions you cannot answer from the recording, numbered, most consequential first. Each one concrete enough to answer in a sentence, and each one about something you are genuinely guessing at: a value you could not read, a choice whose rule you could not infer, a step you only saw the result of. Always ask what they would say to start this task, in their own words, because the recording cannot tell you that. Ask about the destructive step and the done condition if either is unclear. Do not ask them to confirm something the recording already showed you.
 
-Then load the \`skill-management\` skill and follow it from its first step, which is the alignment pass that asks the user to confirm the task, the trigger phrases, and the steps. Do not author or scaffold a skill until they have confirmed all of it, and correct your reading against whatever they tell you. If they decide this is not worth keeping, say so and stop.`;
+Second, "What I saw". Your reading of the task from start to finish and what it is for, the steps in order, one line each and concrete enough to follow. This is the record your questions sit on top of, so state it rather than asking about it.
+
+Open on the first heading. No preamble, no announcing what you are about to do, no narrating which skills you are loading.
+
+Then load the \`skill-management\` skill and follow it, treating the answers to your questions as the alignment its first step calls for. Do not author or scaffold a skill until the four points that step names are settled. Correct your reading against whatever they tell you. If they decide this is not worth keeping, say so and stop.`;
 
 /**
  * Told to the model whenever the render was bounded, naming the bound that


### PR DESCRIPTION
A real retro from a real session was hard to read, and the reason was the document rather than its styling.

It opened with process narration, spent four sections showing its work, then asked the user to confirm three things printed directly above the question asking about them. Three of its four alignment points restated a section you could already see. The eight uncertainties it had just listed, the one part of the output only the recording could produce, were asked about nowhere. And the ask rendered as `###` against the report's `##`, so the only part needing the user was the smallest heading on the page, roughly 400 words in.

## The restatement was instructed

The handoff told the model to follow `skill-management` "from its first step, which is the alignment pass that asks the user to confirm the task, the trigger phrases, and the steps". That is a blanket re-ask. The skill's own checkpoint says something narrower: "If you are guessing at any of the four points above, ask first." Honoring that instead of overriding it removes most of the duplication by itself.

## What changed

Two sections at the same heading level, questions first and the reading second, plus an explicit instruction not to ask about anything the recording already showed, and no preamble.

The trigger phrase stays in the questions because it is the single field a recording cannot supply: the timeline holds what someone did, never what they would call it. The steps move out of them, because the recording is exactly the evidence for those.

`skill-management` is untouched. Its alignment step is correct where nothing precedes it, and only reads as redundant here because the retro has already written the answers above it.

## How to judge it

Run a watch session and read the output. A diff cannot tell you whether this is better, and the tests only pin the parts that are mechanically checkable: the section ordering, the always-open trigger-phrase question, the no-restatement rule, and that the instructions still sit outside the untrusted-content fence.

JARVIS-1610's card is held in draft behind this. Its marker plumbing and recognizer stay useful; what it renders changes once the document is worth rendering.

Reference: JARVIS-1616.