### PR TITLE
feat(windows): add attended desktop presence

### DIFF
--- a/assistant/src/__tests__/client-os-metadata-persistence.test.ts
+++ b/assistant/src/__tests__/client-os-metadata-persistence.test.ts
@@ -65,7 +65,7 @@ import type {
 import type { MessagingConversationContext } from "../daemon/conversation-messaging.js";
 import { persistQueuedMessageBody } from "../daemon/conversation-messaging.js";
 import type { MessageQueue } from "../daemon/conversation-queue-manager.js";
-import { isMacOriginatedUserMessage } from "../persistence/conversation-types.js";
+import { isDesktopOriginatedUserMessage } from "../persistence/conversation-types.js";
 
 function createWebTurnContext(
   clientOs: string | undefined,
@@ -179,9 +179,9 @@ describe("client OS surface metadata persistence", () => {
  * `Conversation.clientOs` is a live field that only a transport-carrying
  * message refreshes, so a transport-less turn stamps whatever an earlier send
  * left there. `clientOsFromRequest` separates the two, and
- * {@link isMacOriginatedUserMessage} (the row-origin read behind the
+ * {@link isDesktopOriginatedUserMessage} (the row-origin read behind the
  * `chat.assistant_reply` presence gate) requires it before letting an attended
- * Mac suppress a push.
+ * desktop suppress a push.
  */
 describe("client OS per-row evidence marker", () => {
   beforeEach(() => {
@@ -198,7 +198,20 @@ describe("client OS per-row evidence marker", () => {
 
     expect(lastUserMetadata().client).toEqual({ os: "macos" });
     expect(lastUserMetadata().clientOsFromRequest).toBe(true);
-    expect(isMacOriginatedUserMessage(lastUserMetadata())).toBe(true);
+    expect(isDesktopOriginatedUserMessage(lastUserMetadata())).toBe(true);
+  });
+
+  test("recognizes a Windows app turn as desktop-originated", async () => {
+    const ctx = createWebTurnContext("windows");
+    await persistQueuedMessageBody(ctx, {
+      content: "hello",
+      requestId: "req-transport-os-windows",
+      requestClientOs: "windows",
+    });
+
+    expect(lastUserMetadata().client).toEqual({ os: "windows" });
+    expect(lastUserMetadata().clientOsFromRequest).toBe(true);
+    expect(isDesktopOriginatedUserMessage(lastUserMetadata())).toBe(true);
   });
 
   // Mirrors the Mac-originated case above: a plain browser tab reports
@@ -214,7 +227,7 @@ describe("client OS per-row evidence marker", () => {
 
     expect(lastUserMetadata().client).toEqual({ os: "web" });
     expect(lastUserMetadata().clientOsFromRequest).toBe(true);
-    expect(isMacOriginatedUserMessage(lastUserMetadata())).toBe(false);
+    expect(isDesktopOriginatedUserMessage(lastUserMetadata())).toBe(false);
   });
 
   test("marks an OS this row's own request headers reported", async () => {
@@ -226,14 +239,14 @@ describe("client OS per-row evidence marker", () => {
     });
 
     expect(lastUserMetadata().clientOsFromRequest).toBe(true);
-    expect(isMacOriginatedUserMessage(lastUserMetadata())).toBe(true);
+    expect(isDesktopOriginatedUserMessage(lastUserMetadata())).toBe(true);
   });
 
   // The bug shape: a button tapped on the phone reaches a conversation whose
   // last desktop send left `clientOs: "macos"` behind. The row still carries
   // the inherited OS for telemetry, but nothing says this turn came from the
   // Mac, so the reply push must survive.
-  test("leaves an inherited OS unmarked and not Mac-originated", async () => {
+  test("leaves an inherited OS unmarked and not desktop-originated", async () => {
     const ctx = createWebTurnContext("macos");
     await persistQueuedMessageBody(ctx, {
       content: "[User action on card surface: submit]",
@@ -242,7 +255,7 @@ describe("client OS per-row evidence marker", () => {
 
     expect(lastUserMetadata().client).toEqual({ os: "macos" });
     expect(lastUserMetadata().clientOsFromRequest).toBeUndefined();
-    expect(isMacOriginatedUserMessage(lastUserMetadata())).toBe(false);
+    expect(isDesktopOriginatedUserMessage(lastUserMetadata())).toBe(false);
   });
 
   // The marker vouches for the `client.os` that actually landed, not for
@@ -258,7 +271,7 @@ describe("client OS per-row evidence marker", () => {
 
     expect(lastUserMetadata().client).toEqual({ os: "macos" });
     expect(lastUserMetadata().clientOsFromRequest).toBeUndefined();
-    expect(isMacOriginatedUserMessage(lastUserMetadata())).toBe(false);
+    expect(isDesktopOriginatedUserMessage(lastUserMetadata())).toBe(false);
   });
 
   // The marker is derived from what this persist can see, so a bag value
@@ -273,7 +286,7 @@ describe("client OS per-row evidence marker", () => {
     });
 
     expect(lastUserMetadata().clientOsFromRequest).toBeUndefined();
-    expect(isMacOriginatedUserMessage(lastUserMetadata())).toBe(false);
+    expect(isDesktopOriginatedUserMessage(lastUserMetadata())).toBe(false);
   });
 
   test("leaves the marker off for a reported OS outside the vocabulary", async () => {

--- a/assistant/src/__tests__/conversation-seed-composer.test.ts
+++ b/assistant/src/__tests__/conversation-seed-composer.test.ts
@@ -71,6 +71,14 @@ describe("resolveVerbosity", () => {
     ).toBe("rich");
   });
 
+  test("explicit interfaceHint=windows overrides to rich", () => {
+    expect(
+      resolveVerbosity("telegram" as NotificationChannel, {
+        interfaceHint: "windows",
+      }),
+    ).toBe("rich");
+  });
+
   test("explicit interfaceHint=telegram overrides to compact", () => {
     expect(
       resolveVerbosity("vellum" as NotificationChannel, {

--- a/assistant/src/__tests__/conversation-slash-commands.test.ts
+++ b/assistant/src/__tests__/conversation-slash-commands.test.ts
@@ -49,6 +49,14 @@ describe("resolveSlash /commands interface-aware help", () => {
     ]);
   });
 
+  test("renders desktop command help for Windows", async () => {
+    const lines = await resolveCommandsLines(
+      makeSlashContext({ userMessageInterface: "windows" }),
+    );
+    expect(lines.some((line) => line.startsWith("/btw "))).toBe(true);
+    expect(lines.some((line) => line.startsWith("/fork "))).toBe(true);
+  });
+
   test("renders iOS command help with /fork", async () => {
     const lines = await resolveCommandsLines(
       makeSlashContext({ userMessageInterface: "ios" }),

--- a/assistant/src/__tests__/disk-pressure-policy.test.ts
+++ b/assistant/src/__tests__/disk-pressure-policy.test.ts
@@ -91,6 +91,12 @@ describe("classifyDiskPressureTurnPolicy", () => {
       expected: { action: "allow-cleanup-mode", reason: "local-owner" },
     },
     {
+      name: "locked Windows local owner without trust enters cleanup mode",
+      status: status({ acknowledged: true }),
+      metadata: { ...localOwnerTurn, sourceInterface: "windows" },
+      expected: { action: "allow-cleanup-mode", reason: "local-owner" },
+    },
+    {
       name: "locked guardian enters cleanup mode",
       status: status(),
       metadata: guardianTurn,

--- a/assistant/src/config/bundled-skills/schedule/SKILL.md
+++ b/assistant/src/config/bundled-skills/schedule/SKILL.md
@@ -158,7 +158,7 @@ Optionally pass `routing_hints` (a JSON object) to influence routing decisions (
   2. **`interface` fallback** — if `source_channel` is absent (common for guardian/direct users), map the `interface` value to a channel name:
      | `interface` value | Channel name |
      | --- | --- |
-     | `macos`, `ios` | `vellum` |
+     | `macos`, `windows`, `ios` | `vellum` |
      | `telegram` | `telegram` |
      | `slack` | `slack` |
      | `cli` | _(omit — no routable channel)_ |

--- a/assistant/src/daemon/conversation-slash.ts
+++ b/assistant/src/daemon/conversation-slash.ts
@@ -295,6 +295,11 @@ function resolveStatusCommand(context: SlashContext): SlashResolution {
 
 const CLEAN_HELP_LINE =
   "/clean — Strip injected runtime context and reset memory injection state (no summarization)";
+const FORK_CAPABLE_INTERFACES = new Set<InterfaceId>([
+  "macos",
+  "windows",
+  "ios",
+]);
 
 function resolveCommandsList(context?: SlashContext): string[] {
   const fallbackLines = [
@@ -315,21 +320,7 @@ function resolveCommandsList(context?: SlashContext): string[] {
     return fallbackLines;
   }
 
-  if (context.userMessageInterface === "macos") {
-    return [
-      "/commands — List all available commands",
-      "/compact — Force context compaction immediately",
-      CLEAN_HELP_LINE,
-      "/context — Show conversation context usage",
-      "/model — List or switch inference profile",
-      "/models — List all available models",
-      "/status — Show conversation status and context usage",
-      "/btw — Ask a side question while the assistant is working",
-      "/fork — Fork the current conversation into a new branch",
-    ];
-  }
-
-  if (context.userMessageInterface === "ios") {
+  if (FORK_CAPABLE_INTERFACES.has(context.userMessageInterface)) {
     return [
       "/commands — List all available commands",
       "/compact — Force context compaction immediately",

--- a/assistant/src/daemon/disk-pressure-policy.ts
+++ b/assistant/src/daemon/disk-pressure-policy.ts
@@ -57,7 +57,13 @@ const BACKGROUND_SOURCES = new Set([
   "schedule",
   "task",
 ]);
-const LOCAL_OWNER_INTERFACES = new Set(["macos", "web", "vellum", "cli"]);
+const LOCAL_OWNER_INTERFACES = new Set([
+  "macos",
+  "windows",
+  "web",
+  "vellum",
+  "cli",
+]);
 
 export function classifyDiskPressureTurnPolicy(
   status: DiskPressureStatus,

--- a/assistant/src/notifications/__tests__/assistant-reply-producer.test.ts
+++ b/assistant/src/notifications/__tests__/assistant-reply-producer.test.ts
@@ -200,6 +200,17 @@ function makeMacOriginatedMessage(): MessageRow {
   });
 }
 
+function makeWindowsOriginatedMessage(): MessageRow {
+  return makeMessage({
+    metadata: JSON.stringify({
+      userMessageChannel: "vellum",
+      userMessageInterface: "web",
+      client: { os: "windows" },
+      clientOsFromRequest: true,
+    }),
+  });
+}
+
 /**
  * A turn opened from a plain browser tab, as opposed to the Electron desktop
  * renderer sharing the same web bundle: `client.os` is `"web"` only when
@@ -347,7 +358,7 @@ describe("emitAssistantReplyNotification", () => {
       desktopAttended = true;
     });
 
-    test("marks the signal source-active while a Mac reports itself attended", async () => {
+    test("marks the signal source-active while a desktop reports itself attended", async () => {
       await run();
 
       expect(emitCalls).toHaveLength(1);
@@ -357,7 +368,16 @@ describe("emitAssistantReplyNotification", () => {
       expect(desktopPresenceArgs).toEqual([[]]);
     });
 
-    test("leaves the signal live when no Mac is attended", async () => {
+    test("marks a Windows-originated signal source-active while attended", async () => {
+      initiatingRow = makeWindowsOriginatedMessage();
+
+      await run();
+
+      expect(emitCalls).toHaveLength(1);
+      expect(emitCalls[0].attentionHints.visibleInSourceNow).toBe(true);
+    });
+
+    test("leaves the signal live when no desktop is attended", async () => {
       desktopAttended = false;
 
       await run();
@@ -386,10 +406,13 @@ describe("emitAssistantReplyNotification", () => {
       expect(warnCalls).toHaveLength(1);
     });
 
-    // An attended Mac only speaks for a turn the Mac itself opened: the user
-    // can send from the phone minutes after last touching the keyboard, which
+    // An attended desktop only speaks for a turn that desktop itself opened.
+    // The user can send from the phone minutes after last touching the keyboard,
     // is exactly the reply this producer exists to push.
-    const NON_MAC_ORIGIN_CASES: Array<{ name: string; metadata: unknown }> = [
+    const NON_DESKTOP_ORIGIN_CASES: Array<{
+      name: string;
+      metadata: unknown;
+    }> = [
       {
         name: "the iOS app",
         metadata: { client: { os: "ios" }, clientOsFromRequest: true },
@@ -412,7 +435,7 @@ describe("emitAssistantReplyNotification", () => {
       // `macos` the conversation's live client state kept from an earlier
       // desktop send. Without the marker that OS names an earlier turn, not
       // this one, and the push the user is waiting for on their phone would
-      // be dropped by the attended Mac.
+      // be dropped by the attended desktop.
       {
         name: "a row whose macOS OS was inherited, not reported",
         metadata: { userMessageInterface: "web", client: { os: "macos" } },
@@ -424,7 +447,7 @@ describe("emitAssistantReplyNotification", () => {
       },
     ];
 
-    for (const { name, metadata } of NON_MAC_ORIGIN_CASES) {
+    for (const { name, metadata } of NON_DESKTOP_ORIGIN_CASES) {
       test(`leaves the signal live for a turn opened from ${name}`, async () => {
         initiatingRow = makeMessage({ metadata: JSON.stringify(metadata) });
 

--- a/assistant/src/notifications/assistant-reply-producer.ts
+++ b/assistant/src/notifications/assistant-reply-producer.ts
@@ -23,7 +23,7 @@ import {
   parseMessageMetadata,
 } from "../persistence/conversation-crud.js";
 import {
-  isMacOriginatedUserMessage,
+  isDesktopOriginatedUserMessage,
   isReplyPushIneligibleUserMessage,
   resolveConversationKind,
 } from "../persistence/conversation-types.js";
@@ -122,7 +122,7 @@ function readSuppressionMarkers(
  *
  * No `actorPrincipalId`: the platform delivers this push to the assistant
  * owner's device tokens, and a pod has exactly one owner, so any attended
- * macOS client is that owner's.
+ * desktop client is that owner's.
  */
 function readDesktopAttended(rlog: pino.Logger): boolean {
   try {
@@ -246,12 +246,12 @@ export async function emitAssistantReplyNotification(params: {
     );
 
     // Read as close to the emit as possible: nothing short-circuits on it.
-    // Presence only speaks for a turn the Mac itself opened, on that row's own
-    // OS evidence. A turn sent from the phone still needs its push while the
-    // Mac sits idle within the desktop client's attendance window.
+    // Presence only speaks for a turn the desktop itself opened, on that row's
+    // own OS evidence. A turn sent from the phone still needs its push while the
+    // desktop sits idle within the attendance window.
     const desktopAttended =
       isAssistantFeatureFlagEnabled(DESKTOP_PRESENCE_FLAG) &&
-      isMacOriginatedUserMessage(initiatingMetadata) &&
+      isDesktopOriginatedUserMessage(initiatingMetadata) &&
       readDesktopAttended(rlog);
 
     // Conversation-scoped web presence applies regardless of which device
@@ -276,7 +276,7 @@ export async function emitAssistantReplyNotification(params: {
         // opting into v2.
         urgency: "medium",
         isAsyncBackground: false,
-        // Read weakly, as "at the surface this landed on": the attended Mac
+        // Read weakly, as "at the surface this landed on": the attended desktop
         // or focused web tab that opened the turn renders the reply in-app,
         // so a redundant push would only duplicate what's already on screen.
         visibleInSourceNow: desktopAttended || webFocused,

--- a/assistant/src/notifications/conversation-seed-composer.ts
+++ b/assistant/src/notifications/conversation-seed-composer.ts
@@ -3,7 +3,7 @@
  *
  * Generates richer seed content for notification conversations than the concise
  * title/body used in native notification popups. Verbosity adapts to the
- * delivery surface: vellum/macos gets flowing prose, telegram gets compact.
+ * delivery surface: Vellum desktop gets flowing prose, Telegram gets compact.
  *
  * Composes from `copy.title/body` rather than hardcoded English templates
  * so LLM-localized copy is preserved for non-English users.
@@ -25,7 +25,12 @@ const CHANNEL_DEFAULT_INTERFACE: Record<string, InterfaceId> = {
   telegram: "telegram",
 };
 
-const RICH_INTERFACES = new Set<InterfaceId>(["macos", "ios", "web"]);
+const RICH_INTERFACES = new Set<InterfaceId>([
+  "macos",
+  "windows",
+  "ios",
+  "web",
+]);
 
 /**
  * Resolve verbosity level from delivery channel + optional interface hint.

--- a/assistant/src/persistence/conversation-types.ts
+++ b/assistant/src/persistence/conversation-types.ts
@@ -228,21 +228,22 @@ export function isVoiceSessionUserMessage(
 }
 
 /**
- * True when the row that opened the turn was sent from the macOS app, on that
+ * True when the row that opened the turn was sent from a desktop app, on that
  * row's own evidence.
  *
  * Two markers, both required. The `client` bag's `os` entry is the only
  * per-platform attribution on a message: `userMessageInterface` is `"web"` for
- * the macOS app, the iOS app, and a desktop browser alike. `clientOsFromRequest`
- * says that `os` was reported by this row's request or transport rather than
- * inherited from the conversation's live client state, which names the surface
- * of an earlier turn: a button tapped on the phone against a conversation last
- * sent to from the Mac persists `os: "macos"` with no marker.
+ * the desktop apps, the iOS app, and a desktop browser alike.
+ * `clientOsFromRequest` says that `os` was reported by this row's request or
+ * transport rather than inherited from the conversation's live client state,
+ * which names the surface of an earlier turn. A button tapped on the phone
+ * against a conversation last sent to from desktop persists the old OS with no
+ * marker.
  *
  * Origin a row did not report itself is origin unknown. Callers gate
- * suppression on this, so unknown has to read as not-macOS.
+ * suppression on this, so unknown has to read as not-desktop.
  */
-export function isMacOriginatedUserMessage(
+export function isDesktopOriginatedUserMessage(
   metadata: Record<string, unknown> | undefined,
 ): boolean {
   if (metadata?.clientOsFromRequest !== true) {
@@ -252,7 +253,8 @@ export function isMacOriginatedUserMessage(
   if (typeof client !== "object" || client === null) {
     return false;
   }
-  return parseClientOs((client as Record<string, unknown>).os) === "macos";
+  const clientOs = parseClientOs((client as Record<string, unknown>).os);
+  return clientOs === "macos" || clientOs === "windows";
 }
 
 /**

--- a/assistant/src/runtime/__tests__/desktop-presence.test.ts
+++ b/assistant/src/runtime/__tests__/desktop-presence.test.ts
@@ -2,7 +2,7 @@
  * Tests for the desktop presence policy.
  *
  * The invariant under test is fail-open: only a fresh `active` report from a
- * `macos` client answers `true`. Every other shape (stale, idle, away, no
+ * desktop client answers `true`. Every other shape (stale, idle, away, no
  * presence, wrong interface, no clients, hub throw) answers `false` so the
  * push is sent. Scoping the read to an actor principal narrows what counts as
  * attendance, so it can only ever turn a `true` into a `false`.
@@ -42,6 +42,15 @@ afterEach(() => {
 describe("isDesktopAttended", () => {
   test("fresh active macos client is attended", () => {
     registerClient({ clientId: "mac-1", presence: "active" });
+    expect(isDesktopAttended()).toBe(true);
+  });
+
+  test("fresh active windows client is attended", () => {
+    registerClient({
+      clientId: "windows-1",
+      interfaceId: "windows",
+      presence: "active",
+    });
     expect(isDesktopAttended()).toBe(true);
   });
 
@@ -92,9 +101,13 @@ describe("isDesktopAttended", () => {
     }
   });
 
-  test("one active macos client among several is enough", () => {
+  test("one active desktop client among several is enough", () => {
     registerClient({ clientId: "mac-1", presence: "away" });
-    registerClient({ clientId: "mac-2", presence: "active" });
+    registerClient({
+      clientId: "windows-1",
+      interfaceId: "windows",
+      presence: "active",
+    });
     expect(isDesktopAttended()).toBe(true);
   });
 });
@@ -103,6 +116,16 @@ describe("isDesktopAttended scoped to an actor principal", () => {
   test("matching actor principal is attended", () => {
     registerClient({
       clientId: "mac-1",
+      presence: "active",
+      actorPrincipalId: "actor-a",
+    });
+    expect(isDesktopAttended({ actorPrincipalId: "actor-a" })).toBe(true);
+  });
+
+  test("matching actor principal on windows is attended", () => {
+    registerClient({
+      clientId: "windows-1",
+      interfaceId: "windows",
       presence: "active",
       actorPrincipalId: "actor-a",
     });
@@ -123,7 +146,7 @@ describe("isDesktopAttended scoped to an actor principal", () => {
     expect(isDesktopAttended({ actorPrincipalId: "actor-a" })).toBe(false);
   });
 
-  test("omitting the principal counts any attended macos client", () => {
+  test("omitting the principal counts any attended desktop client", () => {
     registerClient({
       clientId: "mac-1",
       presence: "active",

--- a/assistant/src/runtime/desktop-presence.ts
+++ b/assistant/src/runtime/desktop-presence.ts
@@ -2,12 +2,12 @@
  * Desktop presence policy.
  *
  * Answers exactly one question for notification producers: is the user
- * demonstrably at their Mac right now? Producers use the answer to skip a
+ * demonstrably at their desktop right now? Producers use the answer to skip a
  * push that the user would see on screen anyway.
  *
  * Fails open by design. Presence is in-memory, best-effort, and reported by
  * a client that can drop off at any time, so anything short of a fresh
- * `active` report from a `macos` client answers `false` and the push goes
+ * `active` report from a desktop client answers `false` and the push goes
  * out. A missed notification is strictly worse than a redundant one.
  */
 
@@ -15,16 +15,17 @@ import { getLogger } from "../util/logger.js";
 import { assistantEventHub } from "./assistant-event-hub.js";
 
 const log = getLogger("desktop-presence");
+const DESKTOP_INTERFACES = ["macos", "windows"] as const;
 
 /**
- * Bounds how long suppression can outlive the Mac going to sleep or dropping
+ * Bounds how long suppression can outlive the desktop sleeping or dropping
  * off, while still tolerating two dropped reports at the 30s report interval.
  */
 export const PRESENCE_STALE_AFTER_MS = 90_000;
 
 export interface DesktopAttendanceOptions {
   /**
-   * Only count macOS clients whose verified actor principal matches this id.
+   * Only count desktop clients whose verified actor principal matches this id.
    * A client that connected without a principal (legacy or service token)
    * never matches a supplied id.
    */
@@ -34,13 +35,13 @@ export interface DesktopAttendanceOptions {
 }
 
 /**
- * Whether some macOS client has reported `active` recently enough to trust.
- * Stale, absent, non-macOS, and error reads all answer `false`.
+ * Whether some desktop client has reported `active` recently enough to trust.
+ * Stale, absent, non-desktop, and error reads all answer `false`.
  *
  * Callers whose notification targets one recipient (guardian-scoped or
  * otherwise per-recipient pushes) must pass that recipient's
- * `actorPrincipalId`, or another user's attended Mac suppresses the push.
- * Omitting it treats any attended macOS client as attendance, which only
+ * `actorPrincipalId`, or another user's attended desktop suppresses the push.
+ * Omitting it treats any attended desktop client as attendance, which only
  * suits notifications with no single recipient.
  */
 export function isDesktopAttended(
@@ -48,19 +49,21 @@ export function isDesktopAttended(
 ): boolean {
   const { actorPrincipalId, now = new Date() } = options;
   try {
-    return assistantEventHub.listClientsByInterface("macos").some((client) => {
-      if (
-        actorPrincipalId !== undefined &&
-        client.actorPrincipalId !== actorPrincipalId
-      ) {
-        return false;
-      }
-      return (
-        client.presence?.state === "active" &&
-        now.getTime() - client.presence.reportedAt.getTime() <=
-          PRESENCE_STALE_AFTER_MS
-      );
-    });
+    return DESKTOP_INTERFACES.some((interfaceId) =>
+      assistantEventHub.listClientsByInterface(interfaceId).some((client) => {
+        if (
+          actorPrincipalId !== undefined &&
+          client.actorPrincipalId !== actorPrincipalId
+        ) {
+          return false;
+        }
+        return (
+          client.presence?.state === "active" &&
+          now.getTime() - client.presence.reportedAt.getTime() <=
+            PRESENCE_STALE_AFTER_MS
+        );
+      }),
+    );
   } catch (err) {
     // Returning false sends the push, which is the safe direction.
     log.warn({ err }, "desktop presence read failed; treating as unattended");

--- a/clients/docs/src/app/docs/_components/skills-reference-schedule-content.tsx
+++ b/clients/docs/src/app/docs/_components/skills-reference-schedule-content.tsx
@@ -122,6 +122,10 @@ export function SkillsReferenceScheduleContent() {
             </li>
             <li>Timezone-aware</li>
             <li>
+              Notify mode can prefer the Vellum app used to create the schedule on macOS, Windows,
+              or iOS when no source channel is available
+            </li>
+            <li>
               Each schedule is pinned to a model profile when it is created, so
               changing your default model later does not change what your
               existing schedules cost

--- a/clients/windows/src/main/features/host-proxy.ts
+++ b/clients/windows/src/main/features/host-proxy.ts
@@ -28,6 +28,7 @@ import {
 
 import { createWindowsHostProxyRuntime } from "../host-proxy-adapter";
 import log from "../logger";
+import { installPresenceMonitor } from "../presence";
 import { COMPUTER_USE_ACTION_EXECUTORS } from "./computer-use-actions";
 
 const hostProxy: CapabilityModule<DesktopCapabilityRegistry> = {
@@ -80,10 +81,7 @@ const installBridge = (capabilities: DesktopCapabilityRegistry): void => {
       onSessionTokenChange,
       getLockfile: getWatchedLockfile,
       onLockfileChange,
-      // Windows has no user-attention monitor yet. Reporting nothing is
-      // the fail-open direction: with no presence record on file the
-      // daemon lets mobile pushes through.
-      installPresenceMonitor: () => () => undefined,
+      installPresenceMonitor,
       getClientId: getDeviceId,
       computerUseExecutors: capabilities.get(COMPUTER_USE_ACTION_EXECUTORS),
       logger: log,

--- a/clients/windows/src/main/host-proxy-feature.test.ts
+++ b/clients/windows/src/main/host-proxy-feature.test.ts
@@ -13,6 +13,12 @@ mock.module("electron", () => ({
     },
   },
   BrowserWindow: { getAllWindows: () => [] },
+  powerMonitor: {
+    on: () => undefined,
+    off: () => undefined,
+    getSystemIdleTime: () => 0,
+    getSystemIdleState: () => "active",
+  },
   safeStorage: {
     isEncryptionAvailable: () => false,
     encryptString: (value: string) => Buffer.from(value),

--- a/clients/windows/src/main/presence.test.ts
+++ b/clients/windows/src/main/presence.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+type PowerListener = () => void;
+
+const listeners = new Map<string, Set<PowerListener>>();
+const powerOnMock = mock((event: string, listener: PowerListener) => {
+  const eventListeners = listeners.get(event) ?? new Set<PowerListener>();
+  eventListeners.add(listener);
+  listeners.set(event, eventListeners);
+});
+const powerOffMock = mock((event: string, listener: PowerListener) => {
+  listeners.get(event)?.delete(listener);
+});
+
+let idleSeconds = 0;
+let systemIdleState: "active" | "idle" | "locked" | "unknown" = "active";
+
+mock.module("electron", () => ({
+  powerMonitor: {
+    on: powerOnMock,
+    off: powerOffMock,
+    getSystemIdleTime: () => idleSeconds,
+    getSystemIdleState: () => systemIdleState,
+  },
+}));
+
+mock.module("electron-log/main", () => ({
+  default: {
+    initialize: () => undefined,
+    info: () => undefined,
+    warn: () => undefined,
+    error: () => undefined,
+    debug: () => undefined,
+    transports: {
+      file: {
+        maxSize: 0,
+        fileName: "",
+        format: "",
+        getFile: () => ({ path: "" }),
+      },
+    },
+  },
+}));
+
+const { IDLE_THRESHOLD_MS, installPresenceMonitor } = await import("./presence");
+
+const originalSetInterval = globalThis.setInterval;
+const originalClearInterval = globalThis.clearInterval;
+let poll: (() => void) | null = null;
+let teardown: (() => void) | null = null;
+
+const fire = (event: string): void => {
+  for (const listener of listeners.get(event) ?? []) {
+    listener();
+  }
+};
+
+beforeEach(() => {
+  listeners.clear();
+  idleSeconds = 0;
+  systemIdleState = "active";
+  poll = null;
+  globalThis.setInterval = ((callback: () => void) => {
+    poll = callback;
+    return 1 as unknown as ReturnType<typeof setInterval>;
+  }) as typeof setInterval;
+  globalThis.clearInterval = (() => undefined) as typeof clearInterval;
+});
+
+afterEach(() => {
+  teardown?.();
+  teardown = null;
+  globalThis.setInterval = originalSetInterval;
+  globalThis.clearInterval = originalClearInterval;
+});
+
+describe("Windows desktop presence", () => {
+  test("reports active immediately and refreshes the report", () => {
+    const reports: string[] = [];
+    teardown = installPresenceMonitor((state) => reports.push(state));
+
+    poll?.();
+
+    expect(reports).toEqual(["active", "active"]);
+  });
+
+  test("reports away while the screen is locked", () => {
+    const reports: string[] = [];
+    teardown = installPresenceMonitor((state) => reports.push(state));
+    reports.length = 0;
+
+    fire("lock-screen");
+    poll?.();
+
+    expect(reports).toEqual(["away", "away"]);
+  });
+
+  test("reports idle after the user-attention threshold", () => {
+    const reports: string[] = [];
+    teardown = installPresenceMonitor((state) => reports.push(state));
+    reports.length = 0;
+
+    idleSeconds = IDLE_THRESHOLD_MS / 1000;
+    poll?.();
+
+    expect(reports).toEqual(["idle"]);
+  });
+});

--- a/clients/windows/src/main/presence.ts
+++ b/clients/windows/src/main/presence.ts
@@ -1,12 +1,10 @@
 import {
   createDesktopPresenceMonitor,
   IDLE_THRESHOLD_MS,
-  POLL_INTERVAL_MS,
-  type PresenceState,
 } from "@vellumai/electron-desktop/desktop-presence-monitor";
 
 import log from "./logger";
 
-export { IDLE_THRESHOLD_MS, POLL_INTERVAL_MS, type PresenceState };
+export { IDLE_THRESHOLD_MS };
 
 export const installPresenceMonitor = createDesktopPresenceMonitor(log);

--- a/packages/electron-desktop/package.json
+++ b/packages/electron-desktop/package.json
@@ -22,6 +22,7 @@
     "./connectivity-probe": "./src/connectivity-probe.ts",
     "./csp": "./src/csp.ts",
     "./deep-links": "./src/deep-links.ts",
+    "./desktop-presence-monitor": "./src/desktop-presence-monitor.ts",
     "./device-id": "./src/device-id.ts",
     "./devtools": "./src/devtools.ts",
     "./diagnostics": "./src/diagnostics.ts",

--- a/packages/electron-desktop/src/desktop-presence-monitor.ts
+++ b/packages/electron-desktop/src/desktop-presence-monitor.ts
@@ -1,0 +1,137 @@
+import { powerMonitor } from "electron";
+
+export type PresenceState = "active" | "idle" | "away";
+
+export const IDLE_THRESHOLD_MS = 10 * 60_000;
+export const POLL_INTERVAL_MS = 30_000;
+
+const SYSTEM_IDLE_STATE_THRESHOLD_SECONDS = 60;
+
+type SystemIdleState = ReturnType<typeof powerMonitor.getSystemIdleState>;
+type PresencePowerEvent =
+  | "lock-screen"
+  | "unlock-screen"
+  | "suspend"
+  | "resume"
+  | "user-did-become-active"
+  | "user-did-resign-active";
+
+export interface DesktopPresenceLogger {
+  warn: (...args: unknown[]) => void;
+}
+
+export type InstallDesktopPresenceMonitor = (
+  onReport: (state: PresenceState) => void,
+) => () => void;
+
+export const createDesktopPresenceMonitor = (
+  logger: DesktopPresenceLogger,
+): InstallDesktopPresenceMonitor => {
+  let installed = false;
+
+  return (onReport): (() => void) => {
+    if (installed) {
+      logger.warn("[presence] monitor already installed, ignoring second install");
+      return (): void => {};
+    }
+
+    // Attendance follows system input and reachability, not app focus.
+    let locked = false;
+    let suspended = false;
+    let sessionActive = true;
+
+    const readSystemIdleState = (): SystemIdleState => {
+      try {
+        return powerMonitor.getSystemIdleState(
+          SYSTEM_IDLE_STATE_THRESHOLD_SECONDS,
+        );
+      } catch {
+        // An unproven state must never suppress a notification.
+        return "unknown";
+      }
+    };
+
+    const evaluate = (): PresenceState => {
+      const systemIdleState = readSystemIdleState();
+      if (
+        locked ||
+        suspended ||
+        !sessionActive ||
+        systemIdleState === "locked"
+      ) {
+        return "away";
+      }
+      if (systemIdleState === "unknown") {
+        return "idle";
+      }
+      try {
+        const idleMs = powerMonitor.getSystemIdleTime() * 1000;
+        return idleMs < IDLE_THRESHOLD_MS ? "active" : "idle";
+      } catch {
+        // A failed idle-time read is not evidence that the user is present.
+        return "idle";
+      }
+    };
+
+    const report = (): void => {
+      onReport(evaluate());
+    };
+
+    const attached: [PresencePowerEvent, () => void][] = [];
+    const emitter: NodeJS.EventEmitter = powerMonitor;
+
+    const detachAll = (): void => {
+      for (const [event, handler] of attached.splice(0)) {
+        emitter.off(event, handler);
+      }
+    };
+
+    const attach = (event: PresencePowerEvent, handler: () => void): void => {
+      emitter.on(event, handler);
+      attached.push([event, handler]);
+    };
+
+    try {
+      attach("lock-screen", () => {
+        locked = true;
+        report();
+      });
+      attach("unlock-screen", () => {
+        locked = false;
+        report();
+      });
+      attach("suspend", () => {
+        suspended = true;
+        report();
+      });
+      attach("resume", () => {
+        suspended = false;
+        report();
+      });
+      attach("user-did-become-active", () => {
+        sessionActive = true;
+        report();
+      });
+      attach("user-did-resign-active", () => {
+        sessionActive = false;
+        report();
+      });
+    } catch (err) {
+      // Never leave a half-installed monitor that could report stale presence.
+      detachAll();
+      throw err;
+    }
+
+    installed = true;
+    report();
+    // The assistant expires presence after 90 seconds, so unchanged state must
+    // be refreshed rather than reported only on transitions.
+    const timer = setInterval(report, POLL_INTERVAL_MS);
+
+    return (): void => {
+      installed = false;
+      clearInterval(timer);
+      detachAll();
+    };
+  };
+};

--- a/scripts/skill-docs-sync.manifest.json
+++ b/scripts/skill-docs-sync.manifest.json
@@ -47,7 +47,7 @@
     },
     "schedule": {
       "docsSlug": "schedule",
-      "sha256": "74891c880acb0c8d3a6ac5ba11ba05ee19adf46ce5a873e719875a066a7c6391"
+      "sha256": "536613209f592d138a42bd95c28e7bf619b327f1091807465012c2bf842b37e4"
     },
     "skill-management": {
       "docsSlug": "skill-management",


### PR DESCRIPTION
## Summary

- share the Electron idle, lock, suspend, and session presence monitor across macOS and Windows
- treat fresh Windows presence and Windows-originated turns as attended desktop activity for notification suppression
- align Windows with desktop-rich notification seeds, disk-pressure ownership, slash commands, and schedule routing

## Original prompt

Implement Windows presence reporting and the related desktop interface parity gaps. Windows should behave as an attended desktop across notification suppression and other interface-aware policies, with focused regression coverage.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41076" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->