### PR TITLE
fix: support native Windows runtime portability

### DIFF
--- a/assistant/package.json
+++ b/assistant/package.json
@@ -72,6 +72,7 @@
     "remark-parse": "11.0.0",
     "rrule": "2.8.1",
     "semver": "7.8.0",
+    "sharp": "0.34.5",
     "stemmer": "2.0.1",
     "tar-stream": "3.1.7",
     "tldts": "7.0.25",

--- a/assistant/src/__tests__/attachments-store-heic-normalize.test.ts
+++ b/assistant/src/__tests__/attachments-store-heic-normalize.test.ts
@@ -4,7 +4,7 @@
  * register and assistant-outbound paths keep content verbatim.
  *
  * The converter module is mocked (keyed on the declared mime type) so these
- * tests run identically with and without macOS sips; real conversion is
+ * tests run independently of the installed image encoder; real conversion is
  * covered in image-conversion.test.ts. mock.module is process-global — keep
  * these cases in this file.
  */

--- a/assistant/src/__tests__/image-conversion.test.ts
+++ b/assistant/src/__tests__/image-conversion.test.ts
@@ -1,9 +1,8 @@
 /**
- * Tests for the shared sips-backed image converter.
+ * Tests for the shared cross-platform image converter.
  *
  * Pure logic (ftyp sniffing, filename rewriting, passthrough behavior) runs
- * everywhere; actual conversion requires macOS `sips`, so those cases are
- * gated on darwin.
+ * everywhere; macOS-specific HEIC fixture generation is gated on Darwin.
  */
 
 import { createHash } from "node:crypto";
@@ -151,6 +150,19 @@ describe("isCompleteJpeg", () => {
   });
 });
 
+describe("convertImageToJpeg", () => {
+  test("converts PNG input with the cross-platform encoder", async () => {
+    const converted = await convertImageToJpeg(PNG_1PX_BYTES, {
+      resizeToPx: { width: 2, height: 2 },
+      quality: 82,
+    });
+
+    expect(converted).not.toBeNull();
+    expect(isCompleteJpeg(converted!)).toBe(true);
+    expect(hasValidJpegStructure(converted!)).toBe(true);
+  });
+});
+
 // Mirrors the converter's cache-key derivation so the test can plant a
 // poisoned entry at the exact path a conversion will consult.
 function cacheKeyFor(bytes: Uint8Array, quality: number): string {
@@ -256,7 +268,7 @@ describe("normalizeImageBytes passthrough", () => {
   });
 
   test("HEIF header with undecodable payload passes through", async () => {
-    // sips fails (or is absent off-macOS) → the original bytes are kept.
+    // The malformed container cannot be decoded, so the bytes are kept.
     const fake = fakeHeifHeaderBytes();
     const result = await normalizeImageBytes("image/heic", fake);
     expect(result.converted).toBe(false);

--- a/assistant/src/__tests__/image-conversion.test.ts
+++ b/assistant/src/__tests__/image-conversion.test.ts
@@ -161,6 +161,28 @@ describe("convertImageToJpeg", () => {
     expect(isCompleteJpeg(converted!)).toBe(true);
     expect(hasValidJpegStructure(converted!)).toBe(true);
   });
+
+  test("applies EXIF orientation before encoding", async () => {
+    const { default: sharp } = await import("sharp");
+    const source = await sharp({
+      create: {
+        width: 2,
+        height: 1,
+        channels: 3,
+        background: { r: 255, g: 0, b: 0 },
+      },
+    })
+      .jpeg()
+      .withMetadata({ orientation: 6 })
+      .toBuffer();
+
+    const converted = await convertImageToJpeg(source, { quality: 83 });
+    expect(converted).not.toBeNull();
+    const metadata = await sharp(converted!).metadata();
+    expect(metadata.width).toBe(1);
+    expect(metadata.height).toBe(2);
+    expect(metadata.orientation).toBeUndefined();
+  });
 });
 
 // Mirrors the converter's cache-key derivation so the test can plant a

--- a/assistant/src/__tests__/persist-unsendable-image-downscale.test.ts
+++ b/assistant/src/__tests__/persist-unsendable-image-downscale.test.ts
@@ -2,18 +2,16 @@
  * Regression test for the durable-downscale path of the image-too-large
  * recovery (JARVIS-1041 review follow-up).
  *
- * When an oversized stored image *can* be shrunk on this host (the common macOS
- * path where `sips` is available), `persistUnsendableImageDowngrades` must write
- * the downscaled bytes back to the DB — not leave the original in place. The
+ * When an oversized stored image can be shrunk,
+ * `persistUnsendableImageDowngrades` must write the downscaled bytes back to
+ * the DB, not leave the original in place. The
  * latest tool-result media is intentionally kept in context, so leaving the
  * full-size block would rehydrate and re-reject on every later turn instead of
  * durably self-healing the conversation.
  *
- * `optimizeImageForTransport` needs `sips` and a decodable image to actually
- * downscale, which is not portable to CI, so it is mocked here to simulate a
- * successful shrink. The mock is process-global, so this case lives in its own
- * file (the test runner isolates each file in its own process) to avoid
- * disturbing the no-op-resize cases in persist-unsendable-image.test.ts.
+ * The encoder is mocked here to isolate the durable persistence behavior from
+ * image decoding. The mock is process-global, so this case lives in its own
+ * file to avoid disturbing the no-op resize cases.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";

--- a/assistant/src/__tests__/persist-unsendable-image.test.ts
+++ b/assistant/src/__tests__/persist-unsendable-image.test.ts
@@ -43,9 +43,9 @@ function resetTables(): void {
 /**
  * Build a minimal PNG whose IHDR declares the given dimensions. Only the
  * 8-byte signature and the width/height fields (read by `parseImageDimensions`)
- * need to be correct; the rest is padding. `optimizeImageForTransport` cannot
- * downscale this off macOS (no `sips`), so it stays a no-op — exactly the
- * host condition that produces an unsendable stored image.
+ * need to be correct; the rest is padding. The image is not decodable, so
+ * `optimizeImageForTransport` leaves it unchanged and produces the unsendable
+ * stored-image condition.
  */
 function makePngBase64(width: number, height: number, padBytes = 0): string {
   const header = Buffer.from(

--- a/assistant/src/__tests__/terminal-tools.test.ts
+++ b/assistant/src/__tests__/terminal-tools.test.ts
@@ -47,6 +47,7 @@ import {
   KATA_INJECTED_ENV_VARS,
   KATA_SAFE_ENV_VARS,
   SAFE_ENV_VARS,
+  WINDOWS_SAFE_ENV_VARS,
 } from "../tools/terminal/safe-env.js";
 import { shellTool } from "../tools/terminal/shell.js";
 
@@ -194,6 +195,7 @@ describe("buildSanitizedEnv", () => {
       ...KATA_SAFE_ENV_VARS,
       ...KATA_INJECTED_ENV_VARS,
       ...ALWAYS_INJECTED_ENV_VARS,
+      ...WINDOWS_SAFE_ENV_VARS,
     ];
     for (const key of keys) {
       expect(safeKeys).toContain(key);

--- a/assistant/src/bundler/app-compiler.ts
+++ b/assistant/src/bundler/app-compiler.ts
@@ -11,7 +11,7 @@
 
 import { existsSync, rmSync } from "node:fs";
 import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
-import { dirname, join, resolve } from "node:path";
+import { delimiter, dirname, join, resolve } from "node:path";
 
 import { getLogger } from "../util/logger.js";
 import { ensureCompilerTools } from "./compiler-tools.js";
@@ -469,7 +469,7 @@ export async function runCompile(
   const cacheNodeModules = join(getCacheDir(), "node_modules");
   const nodePath = [preactParent, cacheNodeModules]
     .filter((p) => existsSync(p))
-    .join(":");
+    .join(delimiter);
 
   // Shell out to esbuild CLI
   const args = [

--- a/assistant/src/bundler/compiler-tools.test.ts
+++ b/assistant/src/bundler/compiler-tools.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+
+import { resolveEsbuildPlatform } from "./compiler-tools.js";
+
+describe("resolveEsbuildPlatform", () => {
+  test("selects Windows executables", () => {
+    expect(resolveEsbuildPlatform("win32", "x64")).toEqual({
+      packageName: "win32-x64",
+      binaryPathParts: ["esbuild.exe"],
+    });
+    expect(resolveEsbuildPlatform("win32", "arm64")).toEqual({
+      packageName: "win32-arm64",
+      binaryPathParts: ["esbuild.exe"],
+    });
+  });
+
+  test("keeps POSIX binaries under bin", () => {
+    expect(resolveEsbuildPlatform("darwin", "arm64")).toEqual({
+      packageName: "darwin-arm64",
+      binaryPathParts: ["bin", "esbuild"],
+    });
+    expect(resolveEsbuildPlatform("linux", "x64")).toEqual({
+      packageName: "linux-x64",
+      binaryPathParts: ["bin", "esbuild"],
+    });
+  });
+
+  test("rejects unsupported targets", () => {
+    expect(() => resolveEsbuildPlatform("freebsd", "x64")).toThrow(
+      "Unsupported esbuild platform: freebsd",
+    );
+    expect(() => resolveEsbuildPlatform("win32", "ia32")).toThrow(
+      "Unsupported esbuild architecture: ia32",
+    );
+  });
+});

--- a/assistant/src/bundler/compiler-tools.ts
+++ b/assistant/src/bundler/compiler-tools.ts
@@ -16,7 +16,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { arch, platform } from "node:os";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 
 import { getLogger } from "../util/logger.js";
 import { getWorkspaceDir } from "../util/platform.js";
@@ -42,6 +42,37 @@ interface VersionManifest {
   platform: string;
   arch: string;
   installedAt: string;
+}
+
+interface EsbuildPlatform {
+  packageName: string;
+  binaryPathParts: string[];
+}
+
+export function resolveEsbuildPlatform(
+  os: NodeJS.Platform,
+  cpu: string,
+): EsbuildPlatform {
+  if (cpu !== "arm64" && cpu !== "x64") {
+    throw new Error(`Unsupported esbuild architecture: ${cpu}`);
+  }
+  if (os === "darwin" || os === "linux") {
+    return {
+      packageName: `${os}-${cpu}`,
+      binaryPathParts: ["bin", "esbuild"],
+    };
+  }
+  if (os === "win32") {
+    return {
+      packageName: `win32-${cpu}`,
+      binaryPathParts: ["esbuild.exe"],
+    };
+  }
+  throw new Error(`Unsupported esbuild platform: ${os}`);
+}
+
+function installedEsbuildName(os: NodeJS.Platform): string {
+  return os === "win32" ? "esbuild.exe" : "esbuild";
 }
 
 function getToolsDir(): string {
@@ -171,8 +202,11 @@ function isReady(baseDir: string): boolean {
   if (!manifest || manifest.toolsVersion !== TOOLS_VERSION) {
     return false;
   }
+  if (manifest.platform !== platform() || manifest.arch !== arch()) {
+    return false;
+  }
   return (
-    existsSync(join(baseDir, "bin", "esbuild")) &&
+    existsSync(join(baseDir, "bin", installedEsbuildName(platform()))) &&
     existsSync(join(baseDir, "node_modules", "preact"))
   );
 }
@@ -193,7 +227,7 @@ export async function ensureCompilerTools(): Promise<CompilerTools> {
   }
 
   return {
-    esbuildBin: join(baseDir, "bin", "esbuild"),
+    esbuildBin: join(baseDir, "bin", installedEsbuildName(platform())),
     preactDir: join(baseDir, "node_modules", "preact"),
   };
 }
@@ -247,22 +281,17 @@ async function install(baseDir: string): Promise<void> {
   mkdirSync(tmpDir, { recursive: true });
 
   try {
-    // Determine esbuild platform package name
-    const esbuildPlatform =
-      os === "darwin"
-        ? cpu === "arm64"
-          ? "darwin-arm64"
-          : "darwin-x64"
-        : cpu === "arm64"
-          ? "linux-arm64"
-          : "linux-x64";
+    const esbuildPlatform = resolveEsbuildPlatform(os, cpu);
 
     // Download esbuild binary + preact in parallel
     await Promise.all([
       downloadAndExtract(
-        `@esbuild/${esbuildPlatform}`,
+        `@esbuild/${esbuildPlatform.packageName}`,
         ESBUILD_VERSION,
-        npmTarballUrl(`@esbuild/${esbuildPlatform}`, ESBUILD_VERSION),
+        npmTarballUrl(
+          `@esbuild/${esbuildPlatform.packageName}`,
+          ESBUILD_VERSION,
+        ),
         join(tmpDir, "esbuild-pkg"),
       ),
       downloadAndExtract(
@@ -274,12 +303,19 @@ async function install(baseDir: string): Promise<void> {
     ]);
 
     // Move esbuild binary to bin/
-    const esbuildBinSrc = join(tmpDir, "esbuild-pkg", "bin", "esbuild");
+    const esbuildBinSrc = join(
+      tmpDir,
+      "esbuild-pkg",
+      ...esbuildPlatform.binaryPathParts,
+    );
     const binDir = join(tmpDir, "bin");
     mkdirSync(binDir, { recursive: true });
     const { renameSync } = await import("node:fs");
-    renameSync(esbuildBinSrc, join(binDir, "esbuild"));
-    chmodSync(join(binDir, "esbuild"), 0o755);
+    const esbuildBin = join(binDir, installedEsbuildName(os));
+    renameSync(esbuildBinSrc, esbuildBin);
+    if (os !== "win32") {
+      chmodSync(esbuildBin, 0o755);
+    }
     rmSync(join(tmpDir, "esbuild-pkg"), { recursive: true, force: true });
 
     // Write version manifest
@@ -299,7 +335,7 @@ async function install(baseDir: string): Promise<void> {
     // Atomic swap: clear old install, move new files in
     const { readdirSync } = await import("node:fs");
     for (const entry of readdirSync(baseDir)) {
-      if (entry.startsWith(".") || entry === tmpDir.split("/").pop()) {
+      if (entry.startsWith(".") || entry === basename(tmpDir)) {
         continue;
       }
       rmSync(join(baseDir, entry), { recursive: true, force: true });

--- a/assistant/src/plugins/defaults/image-recovery/recover.ts
+++ b/assistant/src/plugins/defaults/image-recovery/recover.ts
@@ -66,8 +66,8 @@ export const UNSENDABLE_IMAGE_NOTE =
  * bytes untouched. An unsendable image that can be resized is rewritten to
  * its resized form (downscaled when oversized, upscaled to the minimum floor
  * when undersized); one that cannot be resized on this host (resize is a
- * no-op, e.g. `sips` is absent off macOS or the format is unsupported) is
- * replaced with a text note.
+ * no-op because the encoder cannot decode the format) is replaced with a text
+ * note.
  *
  * Shared by the in-memory recovery transform and the durable persist pass so
  * both apply the identical rule. Persisting the resized form is what lets a

--- a/assistant/src/providers/media-resolve.ts
+++ b/assistant/src/providers/media-resolve.ts
@@ -79,9 +79,8 @@ export function isUnsendableImageSource(source: MediaSource): boolean {
  * `image/heic` and `image/heif` directly
  * (https://ai.google.dev/gemini-api/docs/image-understanding), while
  * OpenAI-compatible and Anthropic endpoints answer HTTP 400 for the whole
- * request. HEIF bytes reach a provider whenever transcoding was unavailable
- * (`convertImageToJpeg` is backed by macOS `sips`), so a Linux-hosted assistant
- * on Gemini depends on them passing through.
+ * request. HEIF bytes reach a provider whenever transcoding cannot decode the
+ * input, so Gemini depends on them passing through.
  */
 export interface MediaResolveOptions {
   acceptsHeif?: boolean;

--- a/assistant/src/schedule/run-script.ts
+++ b/assistant/src/schedule/run-script.ts
@@ -1,4 +1,8 @@
 import { buildSanitizedEnv } from "../tools/terminal/safe-env.js";
+import {
+  buildShellInvocation,
+  terminateProcessTree,
+} from "../util/host-process.js";
 import { getLogger } from "../util/logger.js";
 import { getWorkspaceDir } from "../util/platform.js";
 
@@ -34,14 +38,13 @@ export interface ScriptResult {
 /**
  * Run a shell command and capture its output.
  *
- * Uses Bun.spawn with /bin/sh so the command string supports pipes,
- * redirects, and shell builtins. Output is truncated to
- * {@link MAX_OUTPUT_BYTES} to keep schedule_runs rows bounded.
+ * Uses the platform shell so the command string supports pipes, redirects,
+ * and shell builtins. Windows uses PowerShell and POSIX hosts use Bash. Output
+ * is truncated to {@link MAX_OUTPUT_BYTES} to keep schedule_runs rows bounded.
  *
- * The command runs in its own process group, and the whole group is killed
- * on timeout and swept after exit, so background children cannot outlive the
- * run. A child that daemonizes itself with setsid leaves the group and
- * deliberately survives.
+ * The command runs in its own process group or Windows process tree. The tree
+ * is terminated on timeout and swept after exit so background children cannot
+ * outlive the run.
  */
 export async function runScript(
   command: string,
@@ -57,7 +60,8 @@ export async function runScript(
 
   log.info({ command, cwd, timeoutMs }, "Running script");
 
-  const proc = Bun.spawn(["sh", "-c", command], {
+  const shell = buildShellInvocation(command);
+  const proc = Bun.spawn([shell.command, ...shell.args], {
     cwd,
     detached: true,
     stdout: "pipe",
@@ -82,7 +86,7 @@ export async function runScript(
   const timeoutPromise = new Promise<never>((_, reject) => {
     const timer = setTimeout(() => {
       timedOut = true;
-      killProcessGroup(proc.pid);
+      terminateProcessTree(proc);
       reject(new Error(`Script timed out after ${timeoutMs}ms`));
     }, timeoutMs);
     timer.unref();
@@ -116,7 +120,7 @@ export async function runScript(
   // Sweep anything the script left running. This reaps orphaned background
   // children and closes their copies of the pipe fds so the stream reads
   // below can reach EOF.
-  killProcessGroup(proc.pid);
+  terminateProcessTree(proc);
 
   const [stdoutStr, stderrStr] = await drainStreams(
     stdoutCollector,
@@ -131,19 +135,6 @@ export async function runScript(
   );
 
   return { exitCode, stdout, stderr };
-}
-
-/**
- * SIGKILL every process in the script's process group. The group is often
- * already empty, in which case the signal fails with ESRCH and there is
- * nothing to reap.
- */
-function killProcessGroup(pid: number): void {
-  try {
-    process.kill(-pid, "SIGKILL");
-  } catch {
-    // Process group may have already exited.
-  }
 }
 
 interface StreamCollector {

--- a/assistant/src/skills/inline-command-runner.ts
+++ b/assistant/src/skills/inline-command-runner.ts
@@ -25,6 +25,10 @@ import { spawn } from "node:child_process";
 
 import { buildSanitizedEnv } from "../tools/terminal/safe-env.js";
 import { stripAnsiSequences } from "../util/ansi.js";
+import {
+  buildShellInvocation,
+  terminateProcessTree,
+} from "../util/host-process.js";
 import { getLogger } from "../util/logger.js";
 
 const log = getLogger("inline-command-runner");
@@ -99,7 +103,7 @@ export async function runInlineCommand(
   const timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const maxChars = options?.maxOutputChars ?? MAX_OUTPUT_CHARS;
 
-  const wrapped = { command: "bash", args: ["-c", "--", command] };
+  const wrapped = buildShellInvocation(command);
 
   // Build a minimal, sanitized environment. Explicitly exclude gateway URL,
   // workspace dir, and data dir since inline commands have no business calling
@@ -135,7 +139,7 @@ export async function runInlineCommand(
 
     const timer = setTimeout(() => {
       timedOut = true;
-      child.kill("SIGKILL");
+      terminateProcessTree(child);
     }, timeoutMs);
 
     child.stdout!.on("data", (data: Buffer) => {

--- a/assistant/src/tools/host-terminal/host-shell.ts
+++ b/assistant/src/tools/host-terminal/host-shell.ts
@@ -9,7 +9,7 @@
 import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
-import { isAbsolute } from "node:path";
+import { isAbsolute, join } from "node:path";
 
 import { z } from "zod";
 
@@ -24,6 +24,11 @@ import {
 } from "../../runtime/assistant-event-hub.js";
 import { conversationRevealNonce } from "../../runtime/reveal-nonce.js";
 import { redactSecrets } from "../../security/secret-scanner.js";
+import {
+  buildShellInvocation,
+  prependUniquePathEntries,
+  terminateProcessTree,
+} from "../../util/host-process.js";
 import { getLogger } from "../../util/logger.js";
 import type { CompletedBackgroundTool } from "../background-tool-registry.js";
 import {
@@ -67,15 +72,10 @@ const HOST_BASH_PROXY_ENV_KEYS = [
 function buildHostShellEnv(): Record<string, string> {
   const env = buildSanitizedEnv();
   // Ensure ~/.local/bin and ~/.bun/bin are in PATH so `vellum` and `bun` are
-  // always reachable, even when the daemon is launched from a macOS app
-  // bundle that inherits a minimal PATH.
+  // reachable when a desktop app launches the assistant with a minimal PATH.
   const home = homedir();
-  const extraDirs = [`${home}/.local/bin`, `${home}/.bun/bin`];
-  const currentPath = env.PATH ?? "";
-  const missing = extraDirs.filter((d) => !currentPath.split(":").includes(d));
-  if (missing.length > 0) {
-    env.PATH = [...missing, currentPath].filter(Boolean).join(":");
-  }
+  const extraDirs = [join(home, ".local", "bin"), join(home, ".bun", "bin")];
+  env.PATH = prependUniquePathEntries(env.PATH, extraDirs);
   return env;
 }
 
@@ -466,7 +466,8 @@ export const hostShellTool = {
       const bgId = generateBackgroundToolId();
       const startedAt = Date.now();
 
-      const child = spawn("bash", ["-c", "--", command], {
+      const wrapped = buildShellInvocation(command);
+      const child = spawn(wrapped.command, wrapped.args, {
         cwd: workingDir,
         env: hostEnv,
         stdio: ["ignore", "pipe", "pipe"],
@@ -480,21 +481,7 @@ export const hostShellTool = {
       // event reports "cancelled" rather than "failed".
       let aborted = false;
 
-      const killTree = () => {
-        if (child.pid != null) {
-          try {
-            process.kill(-child.pid, "SIGKILL");
-            return;
-          } catch {
-            // Process group may have already exited — fall through.
-          }
-        }
-        try {
-          child.kill("SIGKILL");
-        } catch {
-          // Child may have already exited.
-        }
-      };
+      const killTree = () => terminateProcessTree(child);
 
       const timer = setTimeout(() => {
         timedOut = true;
@@ -666,31 +653,15 @@ export const hostShellTool = {
       const stderrChunks: Buffer[] = [];
       let timedOut = false;
 
-      const child = spawn("bash", ["-c", "--", command], {
+      const wrapped = buildShellInvocation(command);
+      const child = spawn(wrapped.command, wrapped.args, {
         cwd: workingDir,
         env: hostEnv,
         stdio: ["ignore", "pipe", "pipe"],
         detached: true,
       });
 
-      // Kill the entire process tree. Tries the process group first
-      // (negative PID), then falls back to killing the direct child if the
-      // PID is unavailable or the group kill fails.
-      const killTree = () => {
-        if (child.pid != null) {
-          try {
-            process.kill(-child.pid, "SIGKILL");
-            return;
-          } catch {
-            // Process group may have already exited — fall through.
-          }
-        }
-        try {
-          child.kill("SIGKILL");
-        } catch {
-          // Child may have already exited.
-        }
-      };
+      const killTree = () => terminateProcessTree(child);
 
       const timer = setTimeout(() => {
         timedOut = true;

--- a/assistant/src/tools/shared/filesystem/image-read.ts
+++ b/assistant/src/tools/shared/filesystem/image-read.ts
@@ -76,7 +76,7 @@ async function buildImageToolResult(
   }
 
   // Detect actual format from magic bytes - never trust the file extension
-  // alone, since sips converts to JPEG and files can be misnamed.
+  // alone, since conversion produces JPEG and files can be misnamed.
   const detectedType = detectMediaType(buffer);
   if (!detectedType) {
     return {

--- a/assistant/src/tools/skills/sandbox-runner.ts
+++ b/assistant/src/tools/skills/sandbox-runner.ts
@@ -5,6 +5,10 @@ import { join, resolve } from "node:path";
 
 import { conversationRevealNonce } from "../../runtime/reveal-nonce.js";
 import { computeSkillVersionHash } from "../../skills/version-hash.js";
+import {
+  buildShellInvocation,
+  terminateProcessTree,
+} from "../../util/host-process.js";
 import { safeStringSlice } from "../../util/unicode.js";
 import { buildSanitizedEnv } from "../terminal/safe-env.js";
 import type { ToolContext, ToolExecutionResult } from "../types.js";
@@ -139,7 +143,7 @@ function spawnRunner(
     let timedOut = false;
 
     const bunRunCmd = "bun run __skill_runner.ts";
-    const wrapped = { command: "bash", args: ["-c", "--", bunRunCmd] };
+    const wrapped = buildShellInvocation(bunRunCmd);
 
     const env = buildSanitizedEnv();
     env.__SKILL_INPUT_JSON = JSON.stringify(input);
@@ -161,28 +165,16 @@ function spawnRunner(
 
     const timer = setTimeout(() => {
       timedOut = true;
-      try {
-        process.kill(-child.pid!, "SIGKILL");
-      } catch {
-        // Process group may have already exited.
-      }
+      terminateProcessTree(child);
     }, timeoutMs);
 
     // Cooperative cancellation via AbortSignal
     const onAbort = () => {
-      try {
-        process.kill(-child.pid!, "SIGKILL");
-      } catch {
-        // Process group may have already exited.
-      }
+      terminateProcessTree(child);
     };
     if (context.signal) {
       if (context.signal.aborted) {
-        try {
-          process.kill(-child.pid!, "SIGKILL");
-        } catch {
-          // Process group may have already exited.
-        }
+        terminateProcessTree(child);
       } else {
         context.signal.addEventListener("abort", onAbort, { once: true });
       }

--- a/assistant/src/tools/terminal/__tests__/safe-env.test.ts
+++ b/assistant/src/tools/terminal/__tests__/safe-env.test.ts
@@ -83,4 +83,18 @@ describe("safe-env Windows forwarding", () => {
       }
     }
   });
+
+  test("matches Windows environment names case-insensitively", () => {
+    const windowsEnv = buildSanitizedEnv("win32", {
+      Path: "C:\\Windows\\System32;C:\\Program Files\\Vellum",
+      systemroot: "C:\\Windows",
+      ComSpec: "C:\\Windows\\System32\\cmd.exe",
+    });
+
+    expect(windowsEnv.PATH).toBe(
+      "C:\\Windows\\System32;C:\\Program Files\\Vellum",
+    );
+    expect(windowsEnv.SystemRoot).toBe("C:\\Windows");
+    expect(windowsEnv.COMSPEC).toBe("C:\\Windows\\System32\\cmd.exe");
+  });
 });

--- a/assistant/src/tools/terminal/__tests__/safe-env.test.ts
+++ b/assistant/src/tools/terminal/__tests__/safe-env.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, test } from "bun:test";
 
-import { buildSanitizedEnv, SAFE_ENV_VARS } from "../safe-env.js";
+import {
+  buildSanitizedEnv,
+  SAFE_ENV_VARS,
+  WINDOWS_SAFE_ENV_VARS,
+} from "../safe-env.js";
 
 describe("safe-env Qdrant forwarding", () => {
   const priorPort = process.env.QDRANT_HTTP_PORT;
@@ -33,5 +37,50 @@ describe("safe-env Qdrant forwarding", () => {
     process.env.QDRANT_URL = "http://external:6333";
     const env = buildSanitizedEnv();
     expect(env.QDRANT_URL).toBeUndefined();
+  });
+});
+
+describe("safe-env Windows forwarding", () => {
+  test("forwards runtime paths only to Windows children", () => {
+    const keys = [
+      "SystemRoot",
+      "COMSPEC",
+      "USERPROFILE",
+      "LOCALAPPDATA",
+      "PATHEXT",
+    ] as const;
+    const previous = Object.fromEntries(
+      keys.map((key) => [key, process.env[key]]),
+    );
+
+    try {
+      process.env.SystemRoot = "C:\\Windows";
+      process.env.COMSPEC = "C:\\Windows\\System32\\cmd.exe";
+      process.env.USERPROFILE = "C:\\Users\\Alice";
+      process.env.LOCALAPPDATA = "C:\\Users\\Alice\\AppData\\Local";
+      process.env.PATHEXT = ".COM;.EXE;.BAT;.CMD";
+
+      expect(WINDOWS_SAFE_ENV_VARS).toContain("SystemRoot");
+      const windowsEnv = buildSanitizedEnv("win32");
+      expect(windowsEnv.SystemRoot).toBe("C:\\Windows");
+      expect(windowsEnv.COMSPEC).toBe("C:\\Windows\\System32\\cmd.exe");
+      expect(windowsEnv.USERPROFILE).toBe("C:\\Users\\Alice");
+      expect(windowsEnv.LOCALAPPDATA).toBe("C:\\Users\\Alice\\AppData\\Local");
+      expect(windowsEnv.PATHEXT).toBe(".COM;.EXE;.BAT;.CMD");
+
+      const posixEnv = buildSanitizedEnv("linux");
+      expect(posixEnv.SystemRoot).toBeUndefined();
+      expect(posixEnv.COMSPEC).toBeUndefined();
+      expect(posixEnv.USERPROFILE).toBeUndefined();
+    } finally {
+      for (const key of keys) {
+        const value = previous[key];
+        if (value == null) {
+          delete process.env[key];
+        } else {
+          process.env[key] = value;
+        }
+      }
+    }
   });
 });

--- a/assistant/src/tools/terminal/safe-env.ts
+++ b/assistant/src/tools/terminal/safe-env.ts
@@ -192,18 +192,29 @@ function appendUniquePathEntries(
 
 export function buildSanitizedEnv(
   hostPlatform: NodeJS.Platform = process.platform,
+  sourceEnv: NodeJS.ProcessEnv = process.env,
 ): Record<string, string> {
   const env: Record<string, string> = {};
-  const isKataRuntime = isKataFamilyRuntime(process.env.VELLUM_SANDBOX_RUNTIME);
+  const isKataRuntime = isKataFamilyRuntime(sourceEnv.VELLUM_SANDBOX_RUNTIME);
   const platformVars =
     hostPlatform === "win32" ? WINDOWS_SAFE_ENV_VARS : ([] as const);
   const safeEnvVars = isKataRuntime
     ? [...SAFE_ENV_VARS, ...platformVars, ...KATA_SAFE_ENV_VARS]
     : [...SAFE_ENV_VARS, ...platformVars];
 
+  const windowsEnv =
+    hostPlatform === "win32"
+      ? new Map(
+          Object.entries(sourceEnv).map(([key, value]) => [
+            key.toLowerCase(),
+            value,
+          ]),
+        )
+      : null;
   for (const key of safeEnvVars) {
-    if (process.env[key] != null) {
-      env[key] = process.env[key]!;
+    const value = windowsEnv?.get(key.toLowerCase()) ?? sourceEnv[key];
+    if (value != null) {
+      env[key] = value;
     }
   }
   if (isKataRuntime) {

--- a/assistant/src/tools/terminal/safe-env.ts
+++ b/assistant/src/tools/terminal/safe-env.ts
@@ -7,6 +7,8 @@
  */
 import { readdirSync } from "node:fs";
 
+import { pathListDelimiter } from "@vellumai/environments/shell";
+
 import { getGatewayInternalBaseUrl } from "../../config/env.js";
 import { getDataDir, getWorkspaceDir } from "../../util/platform.js";
 
@@ -74,6 +76,18 @@ export const SAFE_ENV_VARS = [
   "VELLUM_MINIKUBE_STORAGE_SIZE",
   "VELLUM_BACKUP_DIR",
   "VELLUM_BACKUP_KEY_PATH",
+] as const;
+
+export const WINDOWS_SAFE_ENV_VARS = [
+  "SystemRoot",
+  "COMSPEC",
+  "USERPROFILE",
+  "APPDATA",
+  "LOCALAPPDATA",
+  "TEMP",
+  "TMP",
+  "PATHEXT",
+  "SystemDrive",
 ] as const;
 
 export const KATA_SAFE_ENV_VARS = [
@@ -165,22 +179,27 @@ export const ALWAYS_INJECTED_ENV_VARS = [
 function appendUniquePathEntries(
   value: string | undefined,
   entries: readonly string[],
+  separator = pathListDelimiter(),
 ): string {
-  const parts = value ? value.split(":").filter(Boolean) : [];
+  const parts = value ? value.split(separator).filter(Boolean) : [];
   for (const entry of entries) {
     if (!parts.includes(entry)) {
       parts.push(entry);
     }
   }
-  return parts.join(":");
+  return parts.join(separator);
 }
 
-export function buildSanitizedEnv(): Record<string, string> {
+export function buildSanitizedEnv(
+  hostPlatform: NodeJS.Platform = process.platform,
+): Record<string, string> {
   const env: Record<string, string> = {};
   const isKataRuntime = isKataFamilyRuntime(process.env.VELLUM_SANDBOX_RUNTIME);
+  const platformVars =
+    hostPlatform === "win32" ? WINDOWS_SAFE_ENV_VARS : ([] as const);
   const safeEnvVars = isKataRuntime
-    ? [...SAFE_ENV_VARS, ...KATA_SAFE_ENV_VARS]
-    : SAFE_ENV_VARS;
+    ? [...SAFE_ENV_VARS, ...platformVars, ...KATA_SAFE_ENV_VARS]
+    : [...SAFE_ENV_VARS, ...platformVars];
 
   for (const key of safeEnvVars) {
     if (process.env[key] != null) {
@@ -207,7 +226,7 @@ export function buildSanitizedEnv(): Record<string, string> {
       env.BUN_INSTALL = `${env.HOME}/.bun`;
       env.PATH = appendUniquePathEntries(
         `${env.PYTHONUSERBASE}/bin:${env.BUN_INSTALL}/bin`,
-        env.PATH.split(":").filter(Boolean),
+        env.PATH.split(pathListDelimiter()).filter(Boolean),
       );
     }
   }

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -1,4 +1,3 @@
-import type { ChildProcess } from "node:child_process";
 import { spawn } from "node:child_process";
 
 import { z } from "zod";
@@ -10,6 +9,10 @@ import { wakeAgentForOpportunity } from "../../runtime/agent-wake.js";
 import { broadcastMessage } from "../../runtime/assistant-event-hub.js";
 import { conversationRevealNonce } from "../../runtime/reveal-nonce.js";
 import { redactSecrets } from "../../security/secret-scanner.js";
+import {
+  buildShellInvocation,
+  terminateProcessTree,
+} from "../../util/host-process.js";
 import { getLogger } from "../../util/logger.js";
 import { getDataDir } from "../../util/platform.js";
 import type { CompletedBackgroundTool } from "../background-tool-registry.js";
@@ -296,7 +299,7 @@ export const shellTool = {
       Object.assign(env, proxyEnv);
     }
 
-    const wrapped = { command: "bash", args: ["-c", "--", command] };
+    const wrapped = buildShellInvocation(command);
 
     // -----------------------------------------------------------------------
     // Background mode: spawn and return immediately. The process output is
@@ -644,12 +647,11 @@ export const shellTool = {
 
 /**
  * Structured teardown log. Pairs with the `"Executing shell command"`
- * start log: every shell invocation now produces a start/exit pair so
+ * start log: every shell invocation produces a start/exit pair so
  * orphan-leak post-mortems can correlate command + exitCode + signal +
  * timedOut + duration without spelunking through prose hints. The
- * `signal === "SIGKILL"` + `timedOut === true` combination is the
- * fingerprint left by the timeout watcher SIGKILLing the process group
- * — i.e. the moment that creates the orphans.
+ * `signal === "SIGKILL"` + `timedOut === true` combination identifies a
+ * timeout-driven process termination.
  */
 function logShellExit(args: {
   toolName: string;
@@ -681,19 +683,10 @@ function logShellExit(args: {
 }
 
 /**
- * Kill the entire process tree of a child process. Tries the process group
- * first (negative PID), then falls back to killing the direct child if the
- * PID is unavailable or the group kill fails.
- *
- * Emits a structured `warn` log on every invocation: this is the
- * ground-truth event that creates orphaned subprocesses (the SIGKILL hits
- * the entire group, so the immediate bash child has no chance to reap its
- * grandchildren; under bun-as-PID-1 they accumulate as `<defunct>`).
- * `reason` lets the next zombie report point at a specific call site (the
- * timeout watcher in the foreground/background branches, or an abort).
+ * Terminate the process tree and record the call site for timeout diagnostics.
  */
 function buildKillTree(
-  child: ChildProcess,
+  child: ReturnType<typeof spawn>,
   context: {
     toolName: string;
     conversationId: string;
@@ -704,7 +697,7 @@ function buildKillTree(
   },
 ): (reason: "timeout" | "abort" | "spawn_error") => void {
   return (reason) => {
-    const groupPid = child.pid ?? null;
+    const processPid = child.pid ?? null;
     log.warn(
       {
         toolName: context.toolName,
@@ -712,23 +705,11 @@ function buildKillTree(
         command: redactSecrets(context.command),
         durationMs: Date.now() - context.startedAt,
         reason,
-        groupPid,
+        processPid,
         invocationId: context.invocationId,
       },
-      "Shell process group SIGKILL'd — orphans expected to reparent to PID 1",
+      "Shell process tree termination requested",
     );
-    if (groupPid != null) {
-      try {
-        process.kill(-groupPid, "SIGKILL");
-        return;
-      } catch {
-        // Process group may have already exited — fall through.
-      }
-    }
-    try {
-      child.kill("SIGKILL");
-    } catch {
-      // Child may have already exited.
-    }
+    terminateProcessTree(child);
   };
 }

--- a/assistant/src/tools/terminal/shell.ts
+++ b/assistant/src/tools/terminal/shell.ts
@@ -697,7 +697,7 @@ function buildKillTree(
   },
 ): (reason: "timeout" | "abort" | "spawn_error") => void {
   return (reason) => {
-    const processPid = child.pid ?? null;
+    const groupPid = child.pid ?? null;
     log.warn(
       {
         toolName: context.toolName,
@@ -705,10 +705,10 @@ function buildKillTree(
         command: redactSecrets(context.command),
         durationMs: Date.now() - context.startedAt,
         reason,
-        processPid,
+        groupPid,
         invocationId: context.invocationId,
       },
-      "Shell process tree termination requested",
+      "Shell process group SIGKILL'd",
     );
     terminateProcessTree(child);
   };

--- a/assistant/src/util/host-process.test.ts
+++ b/assistant/src/util/host-process.test.ts
@@ -1,0 +1,17 @@
+import { expect, mock, test } from "bun:test";
+
+import { terminateProcessTree } from "./host-process.js";
+
+test("Windows process trees use taskkill and fall back to the direct child", () => {
+  const kill = mock(() => true);
+  let taskkillPid: number | undefined;
+
+  terminateProcessTree({ pid: 1234, kill }, "win32", (pid, onFailure) => {
+    taskkillPid = pid;
+    onFailure();
+  });
+
+  expect(taskkillPid).toBe(1234);
+  expect(kill).toHaveBeenCalledTimes(1);
+  expect(kill).toHaveBeenCalledWith();
+});

--- a/assistant/src/util/host-process.ts
+++ b/assistant/src/util/host-process.ts
@@ -1,0 +1,75 @@
+import { spawn } from "node:child_process";
+
+export {
+  buildShellInvocation,
+  pathListDelimiter,
+  prependUniquePathEntries,
+} from "@vellumai/environments/shell";
+
+export interface KillableProcess {
+  pid?: number;
+  kill: unknown;
+}
+
+type WindowsTreeTerminator = (pid: number, onFailure: () => void) => void;
+
+export function terminateProcessTree(
+  child: KillableProcess,
+  hostPlatform: NodeJS.Platform = process.platform,
+  terminateWindowsTree: WindowsTreeTerminator = runTaskkill,
+): void {
+  if (child.pid == null) {
+    killDirectChild(child, hostPlatform);
+    return;
+  }
+
+  if (hostPlatform === "win32") {
+    let fellBack = false;
+    const fallback = () => {
+      if (!fellBack) {
+        fellBack = true;
+        killDirectChild(child, hostPlatform);
+      }
+    };
+    terminateWindowsTree(child.pid, fallback);
+    return;
+  }
+
+  try {
+    process.kill(-child.pid, "SIGKILL");
+  } catch {
+    killDirectChild(child, hostPlatform);
+  }
+}
+
+function runTaskkill(pid: number, onFailure: () => void): void {
+  const killer = spawn("taskkill.exe", ["/PID", String(pid), "/T", "/F"], {
+    stdio: "ignore",
+    windowsHide: true,
+  });
+  killer.once("error", onFailure);
+  killer.once("close", (code) => {
+    if (code !== 0) {
+      onFailure();
+    }
+  });
+}
+
+function killDirectChild(
+  child: KillableProcess,
+  hostPlatform: NodeJS.Platform,
+): void {
+  if (typeof child.kill !== "function") {
+    return;
+  }
+  try {
+    const kill = child.kill as (signal?: NodeJS.Signals | number) => unknown;
+    if (hostPlatform === "win32") {
+      kill.call(child);
+    } else {
+      kill.call(child, "SIGKILL");
+    }
+  } catch {
+    // The process may have already exited.
+  }
+}

--- a/assistant/src/util/image-conversion.ts
+++ b/assistant/src/util/image-conversion.ts
@@ -295,7 +295,7 @@ async function runSharp(
 ): Promise<Buffer | null> {
   try {
     const { default: sharp } = await import("sharp");
-    let pipeline = sharp(inputBytes, { failOn: "error" });
+    let pipeline = sharp(inputBytes, { failOn: "error" }).autoOrient();
     if (options.resizeToPx != null) {
       pipeline = pipeline.resize(
         options.resizeToPx.width,

--- a/assistant/src/util/image-conversion.ts
+++ b/assistant/src/util/image-conversion.ts
@@ -1,5 +1,5 @@
 /**
- * JPEG conversion for images, backed by macOS `sips`.
+ * JPEG conversion for images, backed by sharp with a macOS `sips` fallback.
  *
  * Two consumers share this converter:
  *   - transport optimization (`agent/image-optimize.ts`) downscales large
@@ -7,10 +7,8 @@
  *   - storage normalization (attachment ingress + history hydration) converts
  *     HEIF/HEIC — which Chromium-based clients cannot decode — to JPEG.
  *
- * Conversion runs `sips` (a macOS builtin); on other platforms or on any
- * failure it returns null and callers keep the original bytes. Results are
- * cached on disk keyed by content hash + conversion options, so repeated
- * conversions of the same image (or daemon restarts) skip the sips call.
+ * Results are cached on disk keyed by content hash + conversion options, so
+ * repeated conversions of the same image skip the encoder call.
  */
 
 import { createHash } from "node:crypto";
@@ -291,9 +289,41 @@ async function runSips(
   }
 }
 
+async function runSharp(
+  inputBytes: Uint8Array,
+  options: ConvertToJpegOptions,
+): Promise<Buffer | null> {
+  try {
+    const { default: sharp } = await import("sharp");
+    let pipeline = sharp(inputBytes, { failOn: "error" });
+    if (options.resizeToPx != null) {
+      pipeline = pipeline.resize(
+        options.resizeToPx.width,
+        options.resizeToPx.height,
+        { fit: "fill" },
+      );
+    } else if (options.maxDimensionPx != null) {
+      pipeline = pipeline.resize(
+        options.maxDimensionPx,
+        options.maxDimensionPx,
+        {
+          fit: "inside",
+          withoutEnlargement: true,
+        },
+      );
+    }
+    const out = await pipeline
+      .jpeg({ quality: options.quality ?? DEFAULT_JPEG_QUALITY })
+      .toBuffer();
+    return isCompleteJpeg(out) ? out : null;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Convert an image to JPEG, optionally downscaling. Returns null when
- * conversion is unavailable (non-macOS) or fails; callers keep the original.
+ * conversion is unavailable or fails; callers keep the original.
  */
 export async function convertImageToJpeg(
   bytes: Uint8Array,
@@ -313,7 +343,9 @@ export async function convertImageToJpeg(
     return cached;
   }
 
-  const converted = await runSips(bytes, options);
+  const converted =
+    (await runSharp(bytes, options)) ??
+    (process.platform === "darwin" ? await runSips(bytes, options) : null);
   if (!converted) {
     return null;
   }

--- a/assistant/src/util/spawn.ts
+++ b/assistant/src/util/spawn.ts
@@ -2,6 +2,8 @@
  * Shared spawn-with-timeout helper used by media-processing and transcribe tools.
  */
 
+import { delimiter } from "node:path";
+
 /** Full video preprocessing: mpdecimate analysis, frame extraction, palette analysis. Longest operation. */
 export const FFMPEG_PREPROCESS_TIMEOUT_MS = 600_000;
 
@@ -29,9 +31,14 @@ export function spawnWithTimeout(
       stderr: "pipe",
       env: {
         ...process.env,
-        PATH: [process.env.PATH, "/opt/homebrew/bin", "/usr/local/bin"]
+        PATH: [
+          process.env.PATH,
+          ...(process.platform === "darwin"
+            ? ["/opt/homebrew/bin", "/usr/local/bin"]
+            : []),
+        ]
           .filter(Boolean)
-          .join(":"),
+          .join(delimiter),
       },
     });
     const timer = setTimeout(() => {

--- a/bun.lock
+++ b/bun.lock
@@ -49,6 +49,7 @@
         "remark-parse": "11.0.0",
         "rrule": "2.8.1",
         "semver": "7.8.0",
+        "sharp": "0.34.5",
         "stemmer": "2.0.1",
         "tar-stream": "3.1.7",
         "tldts": "7.0.25",

--- a/clients/windows/scripts/package-runtime-packages.test.ts
+++ b/clients/windows/scripts/package-runtime-packages.test.ts
@@ -1,18 +1,44 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { expect, test } from "bun:test";
 
 import { findPackageDir } from "./package-runtime-packages";
 
 test("locates native sharp packages through their exported binary", () => {
-  const repoRoot = path.resolve(import.meta.dir, "..", "..", "..");
-  const platform = process.platform === "win32" ? "win32" : process.platform;
-  const packageName = `sharp-${platform}-${process.arch}`;
-  const sharpPackageDir = findPackageDir(
-    "sharp",
-    path.join(repoRoot, "assistant"),
+  const basedir = mkdtempSync(path.join(tmpdir(), "sharp-package-resolution-"));
+  const packageName = "@img/sharp-win32-x64";
+  const packageDir = path.join(
+    basedir,
+    "node_modules",
+    "@img",
+    "sharp-win32-x64",
+  );
+  mkdirSync(path.join(packageDir, "lib"), { recursive: true });
+  writeFileSync(
+    path.join(packageDir, "package.json"),
+    JSON.stringify({
+      name: packageName,
+      exports: { "./sharp.node": "./lib/sharp-win32-x64.node" },
+    }),
+  );
+  writeFileSync(
+    path.join(packageDir, "lib", "sharp-win32-x64.node"),
+    "fixture",
   );
 
-  expect(
-    findPackageDir(`@img/${packageName}/sharp.node`, sharpPackageDir),
-  ).toEndWith(path.join("@img", packageName));
+  try {
+    expect(() => Bun.resolveSync(packageName, basedir)).toThrow();
+    expect(findPackageDir(`${packageName}/sharp.node`, basedir)).toBe(
+      realpathSync(packageDir),
+    );
+  } finally {
+    rmSync(basedir, { recursive: true, force: true });
+  }
 });

--- a/clients/windows/scripts/package-runtime-packages.test.ts
+++ b/clients/windows/scripts/package-runtime-packages.test.ts
@@ -1,0 +1,18 @@
+import path from "node:path";
+import { expect, test } from "bun:test";
+
+import { findPackageDir } from "./package-runtime-packages";
+
+test("locates native sharp packages through their exported binary", () => {
+  const repoRoot = path.resolve(import.meta.dir, "..", "..", "..");
+  const platform = process.platform === "win32" ? "win32" : process.platform;
+  const packageName = `sharp-${platform}-${process.arch}`;
+  const sharpPackageDir = findPackageDir(
+    "sharp",
+    path.join(repoRoot, "assistant"),
+  );
+
+  expect(
+    findPackageDir(`@img/${packageName}/sharp.node`, sharpPackageDir),
+  ).toEndWith(path.join("@img", packageName));
+});

--- a/clients/windows/scripts/package-runtime-packages.ts
+++ b/clients/windows/scripts/package-runtime-packages.ts
@@ -1,0 +1,16 @@
+import { existsSync, realpathSync } from "node:fs";
+import path from "node:path";
+
+export function findPackageDir(specifier: string, basedir: string): string {
+  let current = path.dirname(Bun.resolveSync(specifier, basedir));
+  for (;;) {
+    if (existsSync(path.join(current, "package.json"))) {
+      return realpathSync(current);
+    }
+    const parent = path.dirname(current);
+    if (parent === current) {
+      throw new Error(`Could not locate package directory for ${specifier}.`);
+    }
+    current = parent;
+  }
+}

--- a/clients/windows/scripts/package-runtime.ts
+++ b/clients/windows/scripts/package-runtime.ts
@@ -1,15 +1,9 @@
-import {
-  copyFileSync,
-  cpSync,
-  existsSync,
-  mkdirSync,
-  realpathSync,
-  rmSync,
-} from "node:fs";
+import { copyFileSync, cpSync, mkdirSync, rmSync } from "node:fs";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 
 import { resolveBuildCommitSha } from "./build-metadata";
+import { findPackageDir } from "./package-runtime-packages";
 
 interface RuntimeTarget {
   readonly name: string;
@@ -154,33 +148,42 @@ for (const { name, entry, externals, defines } of targets) {
   }
 }
 
-function findPackageDir(specifier: string): string {
-  let current = path.dirname(Bun.resolveSync(specifier, repoRoot));
-  for (;;) {
-    if (existsSync(path.join(current, "package.json"))) {
-      return realpathSync(current);
-    }
-    const parent = path.dirname(current);
-    if (parent === current) {
-      throw new Error(`Could not locate package directory for ${specifier}.`);
-    }
-    current = parent;
-  }
-}
-
+const nativeSharpPackage = `@img/sharp-win32-${targetArch}`;
+const assistantPackageDir = path.join(repoRoot, "assistant");
+const sharpPackageDir = findPackageDir("sharp", assistantPackageDir);
 const runtimePackages = [
-  "sharp",
-  "@img/colour",
-  `@img/sharp-win32-${targetArch}`,
-  "detect-libc",
-  "semver",
+  {
+    packageName: "sharp",
+    resolveSpecifier: "sharp",
+    basedir: assistantPackageDir,
+  },
+  {
+    packageName: "@img/colour",
+    resolveSpecifier: "@img/colour",
+    basedir: sharpPackageDir,
+  },
+  {
+    packageName: nativeSharpPackage,
+    resolveSpecifier: `${nativeSharpPackage}/sharp.node`,
+    basedir: sharpPackageDir,
+  },
+  {
+    packageName: "detect-libc",
+    resolveSpecifier: "detect-libc",
+    basedir: sharpPackageDir,
+  },
+  {
+    packageName: "semver",
+    resolveSpecifier: "semver",
+    basedir: sharpPackageDir,
+  },
 ] as const;
 const runtimeNodeModules = path.join(outputDir, "node_modules");
 mkdirSync(runtimeNodeModules, { recursive: true });
-for (const specifier of runtimePackages) {
+for (const { packageName, resolveSpecifier, basedir } of runtimePackages) {
   cpSync(
-    findPackageDir(specifier),
-    path.join(runtimeNodeModules, ...specifier.split("/")),
+    findPackageDir(resolveSpecifier, basedir),
+    path.join(runtimeNodeModules, ...packageName.split("/")),
     { recursive: true },
   );
 }

--- a/clients/windows/scripts/package-runtime.ts
+++ b/clients/windows/scripts/package-runtime.ts
@@ -1,4 +1,11 @@
-import { copyFileSync, cpSync, mkdirSync, rmSync } from "node:fs";
+import {
+  copyFileSync,
+  cpSync,
+  existsSync,
+  mkdirSync,
+  realpathSync,
+  rmSync,
+} from "node:fs";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 
@@ -60,6 +67,13 @@ const assistantDefines = {
   "process.env.APP_VERSION": JSON.stringify(assistantVersion),
   "process.env.COMMIT_SHA": JSON.stringify(commitSha),
 };
+const assistantExternals = [
+  "chromium-bidi/*",
+  "sharp",
+  "@img/*",
+  "detect-libc",
+  "semver",
+] as const;
 const targets: readonly RuntimeTarget[] = [
   {
     name: "vellum.exe",
@@ -69,13 +83,13 @@ const targets: readonly RuntimeTarget[] = [
   {
     name: "assistant.exe",
     entry: "assistant/src/windows-compiled-entry.ts",
-    externals: ["chromium-bidi/*"],
+    externals: assistantExternals,
     defines: assistantDefines,
   },
   {
     name: "vellum-daemon.exe",
     entry: "assistant/src/daemon/windows-compiled-entry.ts",
-    externals: ["chromium-bidi/*"],
+    externals: assistantExternals,
     defines: assistantDefines,
   },
   {
@@ -101,7 +115,7 @@ const targets: readonly RuntimeTarget[] = [
   {
     name: "vellum-worker.exe",
     entry: "assistant/src/windows-compiled-worker-entry.ts",
-    externals: ["chromium-bidi/*"],
+    externals: assistantExternals,
     defines: assistantDefines,
   },
   {
@@ -139,6 +153,38 @@ for (const { name, entry, externals, defines } of targets) {
     throw new Error(`Failed to compile ${name} (exit ${build.status}).`);
   }
 }
+
+function findPackageDir(specifier: string): string {
+  let current = path.dirname(Bun.resolveSync(specifier, repoRoot));
+  for (;;) {
+    if (existsSync(path.join(current, "package.json"))) {
+      return realpathSync(current);
+    }
+    const parent = path.dirname(current);
+    if (parent === current) {
+      throw new Error(`Could not locate package directory for ${specifier}.`);
+    }
+    current = parent;
+  }
+}
+
+const runtimePackages = [
+  "sharp",
+  "@img/colour",
+  `@img/sharp-win32-${targetArch}`,
+  "detect-libc",
+  "semver",
+] as const;
+const runtimeNodeModules = path.join(outputDir, "node_modules");
+mkdirSync(runtimeNodeModules, { recursive: true });
+for (const specifier of runtimePackages) {
+  cpSync(
+    findPackageDir(specifier),
+    path.join(runtimeNodeModules, ...specifier.split("/")),
+    { recursive: true },
+  );
+}
+
 const versionCheck = spawnSync(
   path.join(outputDir, "assistant.exe"),
   ["--version"],

--- a/clients/windows/src/main/executors/host-bash-adapter.ts
+++ b/clients/windows/src/main/executors/host-bash-adapter.ts
@@ -13,21 +13,7 @@ import {
   createHostShellExecutor,
   type HostShellSpec,
 } from "@vellumai/electron-desktop/host-proxy/executors/host-shell-executor";
-
-/** Windows PowerShell ships with every supported Windows version. */
-const POWERSHELL_EXECUTABLE = "powershell.exe";
-
-/**
- * Windows PowerShell writes redirected stdout/stderr using
- * [Console]::OutputEncoding (the OEM code page by default), while the shared
- * executor decodes the pipes as UTF-8, so output encoding is forced to UTF-8
- * before the user command runs. The try/catch guards hosts where the console
- * handle rejects the setter; $OutputEncoding covers text piped into native
- * commands.
- */
-const UTF8_OUTPUT_PREAMBLE =
-  "try { [Console]::OutputEncoding = [System.Text.Encoding]::UTF8 } catch {}; " +
-  "$OutputEncoding = [System.Text.Encoding]::UTF8; ";
+import { buildShellInvocation } from "@vellumai/environments/shell";
 
 /**
  * -NoProfile and -NonInteractive keep execution deterministic and prompt
@@ -35,19 +21,12 @@ const UTF8_OUTPUT_PREAMBLE =
  * and Unicode survive Windows command-line re-parsing untouched.
  */
 const createPowerShellSpec = (
-  executable: string = POWERSHELL_EXECUTABLE,
+  executable = "powershell.exe",
 ): HostShellSpec => ({
-  buildSpawn: (command) => ({
-    file: executable,
-    args: [
-      "-NoProfile",
-      "-NonInteractive",
-      "-ExecutionPolicy",
-      "Bypass",
-      "-EncodedCommand",
-      Buffer.from(UTF8_OUTPUT_PREAMBLE + command, "utf16le").toString("base64"),
-    ],
-  }),
+  buildSpawn: (command) => {
+    const invocation = buildShellInvocation(command, "win32", executable);
+    return { file: invocation.command, args: invocation.args };
+  },
 });
 
 export const createWindowsHostBashExecutor = (

--- a/packages/environments/package.json
+++ b/packages/environments/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
-    "./seeds": "./src/seeds.ts"
+    "./seeds": "./src/seeds.ts",
+    "./shell": "./src/shell.ts"
   },
   "scripts": {
     "typecheck": "bunx tsc --noEmit",

--- a/packages/environments/src/shell.test.ts
+++ b/packages/environments/src/shell.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  buildShellInvocation,
+  pathListDelimiter,
+  prependUniquePathEntries,
+} from "./shell.js";
+
+describe("buildShellInvocation", () => {
+  test("uses Bash on POSIX hosts", () => {
+    expect(buildShellInvocation("printf hello", "linux")).toEqual({
+      command: "bash",
+      args: ["-c", "--", "printf hello"],
+    });
+  });
+
+  test("uses encoded non-interactive PowerShell on Windows", () => {
+    const invocation = buildShellInvocation(
+      "Write-Output 'hello 世界'",
+      "win32",
+    );
+
+    expect(invocation.command).toBe("powershell.exe");
+    expect(invocation.args.slice(0, -1)).toEqual([
+      "-NoProfile",
+      "-NonInteractive",
+      "-ExecutionPolicy",
+      "Bypass",
+      "-EncodedCommand",
+    ]);
+    const encoded = invocation.args.at(-1)!;
+    const decoded = Buffer.from(encoded, "base64").toString("utf16le");
+    expect(decoded).toContain("[Console]::OutputEncoding");
+    expect(decoded).toEndWith("Write-Output 'hello 世界'");
+  });
+});
+
+describe("path list handling", () => {
+  test("uses the platform delimiter", () => {
+    expect(pathListDelimiter("win32")).toBe(";");
+    expect(pathListDelimiter("linux")).toBe(":");
+  });
+
+  test("prepends Windows paths without splitting drive letters", () => {
+    expect(
+      prependUniquePathEntries(
+        "C:\\Windows\\System32;C:\\Tools",
+        ["C:\\Tools", "C:\\Users\\Alice\\.bun\\bin"],
+        "win32",
+      ),
+    ).toBe("C:\\Users\\Alice\\.bun\\bin;C:\\Windows\\System32;C:\\Tools");
+  });
+});

--- a/packages/environments/src/shell.test.ts
+++ b/packages/environments/src/shell.test.ts
@@ -31,7 +31,10 @@ describe("buildShellInvocation", () => {
     const encoded = invocation.args.at(-1)!;
     const decoded = Buffer.from(encoded, "base64").toString("utf16le");
     expect(decoded).toContain("[Console]::OutputEncoding");
-    expect(decoded).toEndWith("Write-Output 'hello 世界'");
+    expect(decoded).toContain("$global:LASTEXITCODE = 0");
+    expect(decoded).toContain("Write-Output 'hello 世界'");
+    expect(decoded).toContain("exit $__vellumNativeExitCode");
+    expect(decoded).toEndWith("exit 0");
   });
 });
 

--- a/packages/environments/src/shell.ts
+++ b/packages/environments/src/shell.ts
@@ -1,0 +1,54 @@
+import { delimiter } from "node:path";
+
+export interface ShellInvocation {
+  command: string;
+  args: string[];
+}
+
+const WINDOWS_UTF8_PREAMBLE =
+  "try { [Console]::OutputEncoding = [System.Text.Encoding]::UTF8 } catch {}; " +
+  "$OutputEncoding = [System.Text.Encoding]::UTF8; ";
+
+export function buildShellInvocation(
+  command: string,
+  hostPlatform: NodeJS.Platform = process.platform,
+  windowsExecutable = "powershell.exe",
+): ShellInvocation {
+  if (hostPlatform === "win32") {
+    return {
+      command: windowsExecutable,
+      args: [
+        "-NoProfile",
+        "-NonInteractive",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-EncodedCommand",
+        Buffer.from(WINDOWS_UTF8_PREAMBLE + command, "utf16le").toString(
+          "base64",
+        ),
+      ],
+    };
+  }
+  return { command: "bash", args: ["-c", "--", command] };
+}
+
+export function pathListDelimiter(
+  hostPlatform: NodeJS.Platform = process.platform,
+): string {
+  return hostPlatform === process.platform
+    ? delimiter
+    : hostPlatform === "win32"
+      ? ";"
+      : ":";
+}
+
+export function prependUniquePathEntries(
+  value: string | undefined,
+  entries: readonly string[],
+  hostPlatform: NodeJS.Platform = process.platform,
+): string {
+  const separator = pathListDelimiter(hostPlatform);
+  const current = value?.split(separator).filter(Boolean) ?? [];
+  const missing = entries.filter((entry) => !current.includes(entry));
+  return [...missing, ...current].join(separator);
+}

--- a/packages/environments/src/shell.ts
+++ b/packages/environments/src/shell.ts
@@ -7,7 +7,17 @@ export interface ShellInvocation {
 
 const WINDOWS_UTF8_PREAMBLE =
   "try { [Console]::OutputEncoding = [System.Text.Encoding]::UTF8 } catch {}; " +
-  "$OutputEncoding = [System.Text.Encoding]::UTF8; ";
+  "$OutputEncoding = [System.Text.Encoding]::UTF8; " +
+  "$global:LASTEXITCODE = 0;";
+
+const WINDOWS_EXIT_STATUS_SUFFIX = `
+$__vellumCommandSucceeded = $?
+$__vellumNativeExitCode = $LASTEXITCODE
+if (-not $__vellumCommandSucceeded) {
+  if ($__vellumNativeExitCode -ne 0) { exit $__vellumNativeExitCode }
+  exit 1
+}
+exit 0`;
 
 export function buildShellInvocation(
   command: string,
@@ -23,9 +33,10 @@ export function buildShellInvocation(
         "-ExecutionPolicy",
         "Bypass",
         "-EncodedCommand",
-        Buffer.from(WINDOWS_UTF8_PREAMBLE + command, "utf16le").toString(
-          "base64",
-        ),
+        Buffer.from(
+          `${WINDOWS_UTF8_PREAMBLE}\n${command}${WINDOWS_EXIT_STATUS_SUFFIX}`,
+          "utf16le",
+        ).toString("base64"),
       ],
     };
   }


### PR DESCRIPTION
## Summary

- Run native Windows shell commands through encoded non-interactive PowerShell while preserving Bash behavior on POSIX hosts.
- Forward required Windows environment paths, use platform PATH delimiters, terminate Windows process trees, and select the correct esbuild binary.
- Convert images cross-platform with sharp and package its native Windows runtime dependencies.

## Original prompt

Implement Windows parity items 5.1 through 5.6 as a separate do workflow. The requested work covers the native shell strategy, sanitized environment, PATH handling, process-tree termination, esbuild target selection, and cross-platform image conversion while preserving existing POSIX behavior.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41080" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->