### PR TITLE
refactor(channels): drop the reply payload's unused Block Kit field

### DIFF
--- a/assistant/src/messaging/providers/slack/transport.ts
+++ b/assistant/src/messaging/providers/slack/transport.ts
@@ -17,14 +17,13 @@ export const slackTransport: ChannelTransport = {
   channel: "slack",
 
   async deliver(ctx, payload) {
-    const { chatId, text, attachments, blocks } = payload;
+    const { chatId, text, attachments } = payload;
     const threadTs = ctx.params.threadTs;
 
     let sentTs: string | undefined;
     if (text) {
       const result = await sendSlackReply(chatId, text, {
         threadTs,
-        blocks,
         approval: payload.approval,
         useBlocks: payload.useBlocks,
         audience: payload.audience,

--- a/assistant/src/runtime/slack-reply-session.ts
+++ b/assistant/src/runtime/slack-reply-session.ts
@@ -196,8 +196,8 @@ export function createSlackReplySession(params: {
   ): string | undefined =>
     tasks ? JSON.stringify({ title, tasks }) : undefined;
 
-  // Typed from where these go, a streamed reply's closing blocks, rather than
-  // from the reply payload, which carries no blocks of its own.
+  // Typed from the stream operation these are passed to, so the element type
+  // follows that contract rather than drifting from it.
   const imageBlocks = (
     text: string,
   ): Extract<SlackStreamOp, { action: "stop" }>["blocks"] => {

--- a/assistant/src/runtime/slack-reply-session.ts
+++ b/assistant/src/runtime/slack-reply-session.ts
@@ -1,4 +1,4 @@
-import type { SlackStreamTask } from "@vellumai/gateway-client";
+import type { SlackStreamOp, SlackStreamTask } from "@vellumai/gateway-client";
 
 import type { AssistantEvent } from "../api/index.js";
 import {
@@ -15,7 +15,6 @@ import { SLACK_STREAM_MARKDOWN_LIMIT } from "../messaging/providers/slack/api.js
 import { renderSlackBlocks } from "../messaging/providers/slack/render.js";
 import { getLogger } from "../util/logger.js";
 import { needsBoundarySpace } from "../util/text-spacing.js";
-import { deliverChannelReply } from "./gateway-client.js";
 import {
   hasDeliverableAssistantText,
   NO_RESPONSE_INLINE_RE,
@@ -197,11 +196,11 @@ export function createSlackReplySession(params: {
   ): string | undefined =>
     tasks ? JSON.stringify({ title, tasks }) : undefined;
 
+  // Typed from where these go, a streamed reply's closing blocks, rather than
+  // from the reply payload, which carries no blocks of its own.
   const imageBlocks = (
     text: string,
-  ):
-    | NonNullable<Parameters<typeof deliverChannelReply>[1]["blocks"]>
-    | undefined => {
+  ): Extract<SlackStreamOp, { action: "stop" }>["blocks"] => {
     const blocks = renderSlackBlocks(text)?.filter(
       (block) => block.type === "image",
     );

--- a/packages/gateway-client/src/outbound-contract.ts
+++ b/packages/gateway-client/src/outbound-contract.ts
@@ -183,8 +183,6 @@ export type MessageAudience = z.infer<typeof MessageAudienceSchema>;
 export const ChannelReplyPayloadSchema = z.object({
   chatId: z.string(),
   text: z.string().optional(),
-  /** Pre-formatted Block Kit blocks for Slack delivery. */
-  blocks: z.array(z.custom<KnownBlock>()).optional(),
   assistantId: z.string().optional(),
   attachments: z.array(AttachmentMetadataSchema).optional(),
   approval: ApprovalUIMetadataSchema.optional(),

--- a/packages/gateway-client/src/outbound-contract.ts
+++ b/packages/gateway-client/src/outbound-contract.ts
@@ -192,7 +192,11 @@ export const ChannelReplyPayloadSchema = z.object({
    * loses its audience must not become a public one.
    */
   audience: MessageAudienceSchema.optional(),
-  /** When true, the daemon generates Block Kit blocks from the text before delivery. */
+  /**
+   * Asks the channel to render the text richly rather than as plain text.
+   * Each channel decides what that means, and one that cannot ignores it.
+   * Slack is the only channel acting on it today, where it becomes Block Kit.
+   */
   useBlocks: z.boolean().optional(),
 });
 


### PR DESCRIPTION
## TL;DR

`blocks` was the last Slack-shaped field on the shared reply payload, and nothing sets it. Delete it.

Follows #41072 under LUM-3356.

## Why it is dead

`blocks` carries pre-built Slack Block Kit. Its one real producer was the guardian approval status card, which moved to `EditTarget` in #41068 when editing became its own capability. The send-path copy has been inert since: declared in the contract, destructured and forwarded by the Slack transport, set by no producer in the daemon and none in the gateway.

Checked both sides of the wire before removing it, since a wire field with no daemon producer could still have a gateway one. It does not.

## What changes for a person

Nothing. A field nobody populates stops being declared.

## What removing it surfaced

`slack-reply-session` typed its image blocks like this:

```ts
NonNullable<Parameters<typeof deliverChannelReply>[1]["blocks"]>
```

Those blocks are not passed to `deliverChannelReply`. They go to `sendChannelStreamOp` as a streamed reply's closing blocks. The type was anchored to a field on an unrelated payload that happened to have the same name and shape, and the file imported `deliverChannelReply` **only** to borrow a type off it. Both now point at the stream operation, and the import is gone.

That is the kind of thing a dead field hides: it stays plausible as a type source long after it stops being a value.

## What stays, and why

`useBlocks` is not the same kind of field. It says "render this richly", each channel decides what that means, and `channel-reply-delivery` sets it on every segment of every reply on every channel. It is channel-agnostic intent, so it belongs on a shared payload. Removing it would be the actual Slack coupling, not the fix for it.

Its docstring did not say that, though. It described the field as generating Block Kit, which is one channel's answer to the question rather than the question, so a reader deciding whether a new channel should honour it was being told the contract in Slack's vocabulary. Rewritten here.

**The name is still Slack's word.** `useBlocks` describes the mechanism Slack happens to use, where the contract is closer to "render richly". Renaming it touches seven producers and the wire contract for no behaviour change, so it is named here rather than folded into a deletion.

## Where this leaves `send`

The shared payload is now `chatId`, `text`, `attachments`, `approval`, `assistantId`, `audience` and `useBlocks`. Every field is either universal or channel-agnostic intent. The operations that were hiding inside it, typing, reactions, thread status, streaming, editing and the one-reader audience, each have their own parameters and entry point.
