### PR TITLE
fix(cli): support Windows auth and Tailscale

### DIFF
--- a/assistant/src/cli/commands/__tests__/inference-providers.test.ts
+++ b/assistant/src/cli/commands/__tests__/inference-providers.test.ts
@@ -91,13 +91,19 @@ afterEach(() => {
 
 async function run(
   args: string[],
-): Promise<{ stdout: string; exitCode: number }> {
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
   const originalWrite = process.stdout.write.bind(process.stdout);
+  const originalErrorWrite = process.stderr.write.bind(process.stderr);
   const chunks: string[] = [];
+  const errorChunks: string[] = [];
   process.stdout.write = ((chunk: unknown) => {
     chunks.push(typeof chunk === "string" ? chunk : String(chunk));
     return true;
   }) as typeof process.stdout.write;
+  process.stderr.write = ((chunk: unknown) => {
+    errorChunks.push(typeof chunk === "string" ? chunk : String(chunk));
+    return true;
+  }) as typeof process.stderr.write;
 
   const prevExit = process.exitCode;
   process.exitCode = 0;
@@ -112,11 +118,13 @@ async function run(
     // swallow commander exits
   } finally {
     process.stdout.write = originalWrite;
+    process.stderr.write = originalErrorWrite;
   }
   const stdout = chunks.join("");
+  const stderr = errorChunks.join("");
   const exitCode = (process.exitCode as number) ?? 0;
   process.exitCode = prevExit;
-  return { stdout, exitCode };
+  return { stdout, stderr, exitCode };
 }
 
 describe("providers create — derived auth", () => {
@@ -519,10 +527,18 @@ describe("deprecated providers connections alias", () => {
 });
 
 describe("providers login-chatgpt", () => {
-  test("delivers the authorization URL through the host browser signal", async () => {
-    const { exitCode } = await run(["providers", "login-chatgpt", "--json"]);
+  test("delivers the authorization URL through the host browser signal and stderr", async () => {
+    const { stdout, stderr, exitCode } = await run([
+      "providers",
+      "login-chatgpt",
+      "--json",
+    ]);
 
     expect(exitCode).toBe(0);
+    expect(JSON.parse(stdout)).toMatchObject({ ok: true });
+    expect(stderr).toContain(
+      "https://auth.openai.com/oauth/authorize?state=test",
+    );
     expect(openedUrls).toEqual([
       "https://auth.openai.com/oauth/authorize?state=test",
     ]);

--- a/assistant/src/cli/commands/__tests__/inference-providers.test.ts
+++ b/assistant/src/cli/commands/__tests__/inference-providers.test.ts
@@ -11,6 +11,8 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { Command } from "commander";
 
 let ipcCalls: { method: string; params?: any }[] = [];
+let openedUrls: string[] = [];
+let storedSecrets: Array<{ key: string; value: string }> = [];
 let mockIpcResult: { ok: boolean; result?: unknown; error?: string } = {
   ok: true,
   result: {},
@@ -28,6 +30,35 @@ mock.module("../../../util/logger.js", () => ({
     new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
   getCliLogger: () =>
     new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+}));
+
+mock.module("../../lib/open-browser.js", () => ({
+  openInHostBrowser: (url: string) => {
+    openedUrls.push(url);
+  },
+}));
+
+mock.module("../../../security/oauth2.js", () => ({
+  startOAuth2Flow: async (
+    _config: unknown,
+    callbacks: { openUrl: (url: string) => void },
+  ) => {
+    callbacks.openUrl("https://auth.openai.com/oauth/authorize?state=test");
+    return {
+      tokens: {
+        accessToken: "test-access-token",
+        refreshToken: "test-refresh-token",
+        expiresIn: 3600,
+      },
+    };
+  },
+}));
+
+mock.module("../../../security/secure-keys.js", () => ({
+  setSecureKeyAsync: async (key: string, value: string) => {
+    storedSecrets.push({ key, value });
+    return true;
+  },
 }));
 
 const { attachProvidersSubcommand } = await import("../inference-providers.js");
@@ -48,6 +79,8 @@ function lastIpcCall(): { method: string; params?: any } | null {
 
 beforeEach(() => {
   ipcCalls = [];
+  openedUrls = [];
+  storedSecrets = [];
   mockIpcResult = { ok: true, result: CONNECTION_RESULT };
   process.exitCode = 0;
 });
@@ -482,5 +515,21 @@ describe("deprecated providers connections alias", () => {
     const { stdout } = await run(["providers", "connections", "list"]);
     expect(lastIpcCall()?.method).toBe("inference_provider_connections_list");
     expect(stdout).toContain("No providers found.");
+  });
+});
+
+describe("providers login-chatgpt", () => {
+  test("delivers the authorization URL through the host browser signal", async () => {
+    const { exitCode } = await run(["providers", "login-chatgpt", "--json"]);
+
+    expect(exitCode).toBe(0);
+    expect(openedUrls).toEqual([
+      "https://auth.openai.com/oauth/authorize?state=test",
+    ]);
+    expect(storedSecrets).toContainEqual({
+      key: "credential/chatgpt/access_token",
+      value: "test-access-token",
+    });
+    expect(lastIpcCall()?.method).toBe("inference_provider_connections_update");
   });
 });

--- a/assistant/src/cli/commands/__tests__/inference-providers.test.ts
+++ b/assistant/src/cli/commands/__tests__/inference-providers.test.ts
@@ -527,7 +527,7 @@ describe("deprecated providers connections alias", () => {
 });
 
 describe("providers login-chatgpt", () => {
-  test("delivers the authorization URL through the host browser signal and stderr", async () => {
+  test("delivers the authorization URL through the browser helper and stderr", async () => {
     const { stdout, stderr, exitCode } = await run([
       "providers",
       "login-chatgpt",

--- a/assistant/src/cli/commands/inference-providers.ts
+++ b/assistant/src/cli/commands/inference-providers.ts
@@ -23,6 +23,7 @@ import { cliIpcCall } from "../../ipc/cli-client.js";
 import type { OAuth2Config } from "../../security/oauth2.js";
 import { subcommand } from "../lib/cli-command-help.js";
 import { writeCliError } from "../lib/cli-output.js";
+import { openInHostBrowser } from "../lib/open-browser.js";
 import { attachDefaultProviderSubcommand } from "./inference-providers-default.js";
 
 // ---------------------------------------------------------------------------
@@ -456,12 +457,21 @@ function attachLoginChatgptSubcommand(providers: Command): void {
           import("../../security/secure-keys.js"),
         ]);
         // Step 1: Run browser-based PKCE OAuth flow
-        process.stdout.write("Opening browser for ChatGPT authentication...\n");
+        if (!opts.json) {
+          process.stdout.write(
+            "Opening browser for ChatGPT authentication...\n",
+          );
+        }
         const result = await startOAuth2Flow(
           OPENAI_CODEX_OAUTH_CONFIG,
           {
             openUrl: (url) => {
-              Bun.spawn(["open", url]);
+              openInHostBrowser(url);
+              if (!opts.json) {
+                process.stdout.write(
+                  `If the browser did not open, visit:\n${url}\n`,
+                );
+              }
             },
           },
           {

--- a/assistant/src/cli/commands/inference-providers.ts
+++ b/assistant/src/cli/commands/inference-providers.ts
@@ -467,11 +467,9 @@ function attachLoginChatgptSubcommand(providers: Command): void {
           {
             openUrl: (url) => {
               openInHostBrowser(url);
-              if (!opts.json) {
-                process.stdout.write(
-                  `If the browser did not open, visit:\n${url}\n`,
-                );
-              }
+              const fallbackMessage = `If the browser did not open, visit:\n${url}\n`;
+              const output = opts.json ? process.stderr : process.stdout;
+              output.write(fallbackMessage);
             },
           },
           {

--- a/assistant/src/cli/lib/open-browser.test.ts
+++ b/assistant/src/cli/lib/open-browser.test.ts
@@ -1,0 +1,67 @@
+import type { ChildProcess, spawn } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+
+import { openInHostBrowser } from "./open-browser.js";
+
+describe("openInHostBrowser", () => {
+  test("launches the default browser directly on macOS", () => {
+    const calls: Array<{
+      command: string;
+      args: readonly string[];
+      options: unknown;
+    }> = [];
+    let unrefCalled = false;
+    const child = new EventEmitter() as ChildProcess;
+    child.unref = () => {
+      unrefCalled = true;
+      return child;
+    };
+    const spawnImpl = ((
+      command: string,
+      args: readonly string[],
+      options: unknown,
+    ) => {
+      calls.push({ command, args, options });
+      return child;
+    }) as typeof spawn;
+
+    openInHostBrowser("https://example.com/auth", {
+      platform: "darwin",
+      spawnImpl,
+    });
+
+    expect(calls).toEqual([
+      {
+        command: "open",
+        args: ["https://example.com/auth"],
+        options: { detached: true, stdio: "ignore" },
+      },
+    ]);
+    expect(unrefCalled).toBe(true);
+  });
+
+  test("emits a host-client signal on Windows", () => {
+    const workspaceDir = mkdtempSync(join(tmpdir(), "open-browser-test-"));
+    try {
+      openInHostBrowser("https://example.com/auth", {
+        platform: "win32",
+        workspaceDir,
+      });
+
+      expect(
+        JSON.parse(
+          readFileSync(join(workspaceDir, "signals", "emit-event"), "utf8"),
+        ),
+      ).toEqual({
+        type: "open_url",
+        url: "https://example.com/auth",
+      });
+    } finally {
+      rmSync(workspaceDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/assistant/src/cli/lib/open-browser.ts
+++ b/assistant/src/cli/lib/open-browser.ts
@@ -1,9 +1,8 @@
 /**
  * CLI-side helper that opens a URL on the user's host machine.
  *
- * Writes an `open_url` event to the `signals/emit-event` file so that the
- * assistant's ConfigWatcher picks it up and publishes it to connected
- * clients (e.g. the Swift macOS app) via the assistant event hub.
+ * On macOS, launches the default browser directly. Other platforms write an
+ * `open_url` event so a connected host client can open the URL.
  *
  * CLI-initiated emit — no conversation context available, so the inner
  * message has no `conversationId`. That's fine: `OpenUrlEventSchema`
@@ -13,6 +12,7 @@
  * Uses only `node:` imports so it's safe for `ipc`-tagged CLI commands.
  */
 
+import { spawn } from "node:child_process";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
@@ -27,9 +27,28 @@ function getWorkspaceDir(): string {
   );
 }
 
-export function openInHostBrowser(url: string): void {
+export function openInHostBrowser(
+  url: string,
+  deps: {
+    platform?: NodeJS.Platform;
+    spawnImpl?: typeof spawn;
+    workspaceDir?: string;
+  } = {},
+): void {
+  if ((deps.platform ?? process.platform) === "darwin") {
+    const child = (deps.spawnImpl ?? spawn)("open", [url], {
+      detached: true,
+      stdio: "ignore",
+    });
+    child.on("error", () => {
+      // The caller prints a fallback URL.
+    });
+    child.unref();
+    return;
+  }
+
   try {
-    const signalsDir = join(getWorkspaceDir(), "signals");
+    const signalsDir = join(deps.workspaceDir ?? getWorkspaceDir(), "signals");
     mkdirSync(signalsDir, { recursive: true });
     writeFileSync(
       join(signalsDir, "emit-event"),

--- a/cli/src/__tests__/provider-secrets.test.ts
+++ b/cli/src/__tests__/provider-secrets.test.ts
@@ -49,6 +49,7 @@ class FakePromptInput extends EventEmitter {
   private paused = false;
   pauseCount = 0;
   rawModes: boolean[] = [];
+  events: string[] = [];
 
   isPaused(): boolean {
     return this.paused;
@@ -68,6 +69,7 @@ class FakePromptInput extends EventEmitter {
   setRawMode(value: boolean): this {
     this.isRaw = value;
     this.rawModes.push(value);
+    this.events.push(`raw:${value}`);
     return this;
   }
 }
@@ -228,6 +230,7 @@ describe("provider secret helpers", () => {
     let outputText = "";
     const output = {
       write: (text: string) => {
+        input.events.push(`write:${text}`);
         outputText += text;
         return true;
       },
@@ -243,7 +246,38 @@ describe("provider secret helpers", () => {
     expect(input.pauseCount).toBe(1);
     expect(input.listenerCount("data")).toBe(0);
     expect(input.rawModes).toEqual([true, false]);
+    expect(input.events[0]).toBe("raw:true");
+    expect(input.events[1]).toBe("write:Enter key: ");
     expect(outputText).toBe("Enter key: \n");
+  });
+
+  test("refuses to read a secret when hidden input is unavailable", async () => {
+    const input = new FakePromptInput();
+    input.isTTY = false;
+
+    await expect(
+      promptSecret("Enter key: ", {
+        input: input as unknown as NodeJS.ReadStream,
+      }),
+    ).rejects.toThrow("requires an interactive terminal");
+    expect(input.listenerCount("data")).toBe(0);
+  });
+
+  test("restores terminal mode when the prompt cannot be written", async () => {
+    const input = new FakePromptInput();
+    const output = {
+      write: () => {
+        throw new Error("output unavailable");
+      },
+    };
+
+    await expect(
+      promptSecret("Enter key: ", {
+        input: input as unknown as NodeJS.ReadStream,
+        output: output as unknown as NodeJS.WriteStream,
+      }),
+    ).rejects.toThrow("output unavailable");
+    expect(input.rawModes).toEqual([true, false]);
   });
 
   test("returns a missing-key result in non-interactive shells", async () => {

--- a/cli/src/__tests__/tailscale-tunnel.test.ts
+++ b/cli/src/__tests__/tailscale-tunnel.test.ts
@@ -4,6 +4,8 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import {
+  getTailscaleBinaryCandidates,
+  getTailscaleInstallMessage,
   normalizeDnsName,
   resolveServeHostname,
   shouldClearIngressUrl,
@@ -12,6 +14,27 @@ import {
   type TailscaleCommandResult,
   type TailscaleDeps,
 } from "../lib/tailscale-tunnel.js";
+
+describe("Tailscale discovery", () => {
+  test("checks PATH and standard Windows install locations", () => {
+    expect(
+      getTailscaleBinaryCandidates("win32", {
+        ProgramFiles: "C:\\Program Files",
+        LOCALAPPDATA: "C:\\Users\\Example\\AppData\\Local",
+      }),
+    ).toEqual([
+      "tailscale.exe",
+      "C:\\Program Files\\Tailscale\\tailscale.exe",
+      "C:\\Users\\Example\\AppData\\Local\\Tailscale\\tailscale.exe",
+    ]);
+  });
+
+  test("provides Windows installation guidance", () => {
+    expect(getTailscaleInstallMessage("win32")).toContain(
+      "winget install Tailscale.Tailscale",
+    );
+  });
+});
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 

--- a/cli/src/commands/tunnel.ts
+++ b/cli/src/commands/tunnel.ts
@@ -100,7 +100,7 @@ function parseArgs(): TunnelArgs {
         "               No Cloudflare account required for quick tunnels.",
       );
       console.log(
-        "  tailscale    Tailscale serve — install: brew install tailscale, then `tailscale up`",
+        "  tailscale    Tailscale serve - install: https://tailscale.com/download, then run `tailscale up`",
       );
       console.log(
         "               Reachable only from your own tailnet (private; LetsEncrypt cert).",

--- a/cli/src/lib/provider-secrets.ts
+++ b/cli/src/lib/provider-secrets.ts
@@ -1,5 +1,3 @@
-import { spawnSync } from "node:child_process";
-
 import { LLM_PROVIDER_ENV_VAR_NAMES } from "../shared/provider-env-vars.js";
 
 export type LlmProviderId = keyof typeof LLM_PROVIDER_ENV_VAR_NAMES;
@@ -356,24 +354,31 @@ export async function promptSecret(
   const input = streams.input ?? process.stdin;
   const output = streams.output ?? process.stdout;
 
-  const restoreEcho = disableTerminalEcho(input);
-  output.write(prompt);
+  if (!input.isTTY || typeof input.setRawMode !== "function") {
+    throw new Error("Hidden secret input requires an interactive terminal.");
+  }
+
+  const wasRaw = input.isRaw;
+  let rawModeEnabled = false;
+  try {
+    input.setRawMode(true);
+    rawModeEnabled = true;
+    output.write(prompt);
+  } catch (error) {
+    if (rawModeEnabled) {
+      input.setRawMode(wasRaw ?? false);
+    }
+    throw error;
+  }
 
   return new Promise((resolve, reject) => {
-    const wasRaw = input.isRaw;
-    if (input.isTTY) {
-      input.setRawMode(true);
-    }
     input.resume();
 
     let value = "";
 
     const cleanup = (): void => {
       input.removeListener("data", onData);
-      if (input.isTTY) {
-        input.setRawMode(wasRaw ?? false);
-      }
-      restoreEcho();
+      input.setRawMode(wasRaw ?? false);
       input.pause();
     };
 
@@ -416,39 +421,6 @@ export async function promptSecret(
 
     input.on("data", onData);
   });
-}
-
-function disableTerminalEcho(input: NodeJS.ReadStream): () => void {
-  if (input !== process.stdin || !input.isTTY || process.platform === "win32") {
-    return () => {};
-  }
-
-  const currentState = spawnSync("stty", ["-g"], {
-    encoding: "utf8",
-    stdio: ["inherit", "pipe", "ignore"],
-  });
-  const state = currentState.stdout.trim();
-  if (currentState.status !== 0 || state.length === 0) {
-    return () => {};
-  }
-
-  const disabled = spawnSync("stty", ["-echo"], {
-    stdio: ["inherit", "ignore", "ignore"],
-  });
-  if (disabled.status !== 0) {
-    return () => {};
-  }
-
-  let restored = false;
-  return () => {
-    if (restored) {
-      return;
-    }
-    restored = true;
-    spawnSync("stty", [state], {
-      stdio: ["inherit", "ignore", "ignore"],
-    });
-  };
 }
 
 export async function ensureProviderApiKey(

--- a/cli/src/lib/tailscale-tunnel.ts
+++ b/cli/src/lib/tailscale-tunnel.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from "node:child_process";
+import { win32 } from "node:path";
 
 import { GATEWAY_PORT } from "./constants.js";
 import {
@@ -9,24 +10,56 @@ import {
 
 // ── Tailscale CLI discovery + invocation ────────────────────────────────────
 
-/**
- * Common macOS locations for the tailscale CLI when it is not on PATH: the
- * Homebrew bin and the CLI bundled inside the Mac App Store / standalone app.
- */
-const TAILSCALE_FALLBACK_PATHS = [
+const MACOS_TAILSCALE_FALLBACK_PATHS = [
   "/opt/homebrew/bin/tailscale",
   "/Applications/Tailscale.app/Contents/MacOS/Tailscale",
 ];
 
-const TAILSCALE_NOT_INSTALLED_MESSAGE = [
-  "Tailscale is not installed or could not be found.",
-  "",
-  "Install Tailscale:",
-  "  macOS:  brew install tailscale   (or install the Tailscale app)",
-  "  Linux:  https://tailscale.com/download/linux",
-  "",
-  "Then start it and sign in: `tailscale up`.",
-].join("\n");
+export function getTailscaleBinaryCandidates(
+  hostPlatform: NodeJS.Platform = process.platform,
+  env: NodeJS.ProcessEnv = process.env,
+): string[] {
+  if (hostPlatform === "darwin") {
+    return ["tailscale", ...MACOS_TAILSCALE_FALLBACK_PATHS];
+  }
+  if (hostPlatform !== "win32") {
+    return ["tailscale"];
+  }
+
+  const installRoots = [
+    env.ProgramW6432,
+    env.ProgramFiles,
+    env["ProgramFiles(x86)"],
+    env.LOCALAPPDATA,
+  ].filter((value): value is string => Boolean(value));
+  return [
+    "tailscale.exe",
+    ...new Set(
+      installRoots.map((root) =>
+        win32.join(root, "Tailscale", "tailscale.exe"),
+      ),
+    ),
+  ];
+}
+
+export function getTailscaleInstallMessage(
+  hostPlatform: NodeJS.Platform = process.platform,
+): string {
+  const platformInstructions =
+    hostPlatform === "win32"
+      ? "  Windows: winget install Tailscale.Tailscale"
+      : hostPlatform === "darwin"
+        ? "  macOS:  brew install tailscale   (or install the Tailscale app)"
+        : "  Linux:  https://tailscale.com/download/linux";
+  return [
+    "Tailscale is not installed or could not be found.",
+    "",
+    "Install Tailscale:",
+    platformInstructions,
+    "",
+    "Then start it and sign in: `tailscale up`.",
+  ].join("\n");
+}
 
 export interface TailscaleCommandResult {
   status: number | null;
@@ -47,7 +80,7 @@ export interface TailscaleDeps {
 }
 
 function realFindBinary(): string | null {
-  for (const candidate of ["tailscale", ...TAILSCALE_FALLBACK_PATHS]) {
+  for (const candidate of getTailscaleBinaryCandidates()) {
     const res = spawnSync(candidate, ["version"], {
       encoding: "utf-8",
       timeout: 5_000,
@@ -189,7 +222,7 @@ export async function startTailscaleServe(
 ): Promise<TailscaleServeInfo> {
   const binary = deps.findBinary();
   if (!binary) {
-    throw new Error(TAILSCALE_NOT_INSTALLED_MESSAGE);
+    throw new Error(getTailscaleInstallMessage());
   }
 
   const statusResult = deps.run(binary, ["status", "--json"]);


### PR DESCRIPTION
## Summary

- preserve native macOS ChatGPT OAuth browser opening while routing other hosts through the existing host-browser signal, with a manual fallback URL
- make provider secret entry use cross-platform raw TTY mode before prompting, with fail-closed cleanup
- discover Tailscale in standard Windows install locations and provide platform-aware install guidance

## Original prompt

Complete the Windows parity portion of item 5.14 for ChatGPT OAuth browser opening, non-echoing secret input, and Tailscale discovery. Docker auto-install and the POSIX assistant wrapper may remain unsupported, while the implemented paths should include focused tests and avoid duplicate browser-opening logic.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41083" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
