### PR TITLE
refactor(channels): name the rich-render request after the request

### DIFF
--- a/assistant/src/__tests__/channel-reply-delivery.test.ts
+++ b/assistant/src/__tests__/channel-reply-delivery.test.ts
@@ -266,7 +266,7 @@ describe("channel-reply-delivery", () => {
       payload: {
         chatId: "chat-1",
         text: "Before tool.",
-        useBlocks: true,
+        renderRichly: true,
         attachments: undefined,
         assistantId: "assistant-1",
       },
@@ -276,7 +276,7 @@ describe("channel-reply-delivery", () => {
       payload: {
         chatId: "chat-1",
         text: "After tool.",
-        useBlocks: true,
+        renderRichly: true,
         attachments,
         assistantId: "assistant-1",
       },
@@ -335,14 +335,14 @@ describe("channel-reply-delivery", () => {
     expect(deliveryCalls[0].payload).toEqual({
       chatId: "chat-3",
       text: "Before tool.",
-      useBlocks: true,
+      renderRichly: true,
       attachments: undefined,
       assistantId: "assistant-2",
     });
     expect(deliveryCalls[1].payload).toEqual({
       chatId: "chat-3",
       text: "After tool.",
-      useBlocks: true,
+      renderRichly: true,
       attachments: [
         {
           id: "att-2",

--- a/assistant/src/messaging/providers/channel-transport.ts
+++ b/assistant/src/messaging/providers/channel-transport.ts
@@ -42,7 +42,7 @@ export interface ThreadStatus {
  * An existing message to replace in place, and what to replace it with.
  *
  * `messageId` is the target in the channel's own id space, the same way
- * `chatId` is. `blocks` and `useBlocks` are the rendering inputs the edit
+ * `chatId` is. `blocks` and `renderRichly` are the rendering inputs the edit
  * carries, so a replacement renders the way the original did rather than
  * degrading to plain text.
  */
@@ -51,7 +51,7 @@ export interface EditTarget {
   readonly messageId: string;
   readonly text: string;
   readonly blocks?: readonly KnownBlock[];
-  readonly useBlocks?: boolean;
+  readonly renderRichly?: boolean;
 }
 
 /**

--- a/assistant/src/messaging/providers/slack/transport.ts
+++ b/assistant/src/messaging/providers/slack/transport.ts
@@ -25,7 +25,7 @@ export const slackTransport: ChannelTransport = {
       const result = await sendSlackReply(chatId, text, {
         threadTs,
         approval: payload.approval,
-        useBlocks: payload.useBlocks,
+        useBlocks: payload.renderRichly,
         audience: payload.audience,
       });
       sentTs = result.ts;
@@ -57,7 +57,7 @@ export const slackTransport: ChannelTransport = {
       target.chatId,
       target.messageId,
       target.text,
-      { blocks: target.blocks, useBlocks: target.useBlocks },
+      { blocks: target.blocks, useBlocks: target.renderRichly },
     );
     return { ok: true, ts: result.ts };
   },

--- a/assistant/src/messaging/providers/telegram-bot/send.test.ts
+++ b/assistant/src/messaging/providers/telegram-bot/send.test.ts
@@ -191,15 +191,15 @@ describe("telegramTransport.deliver routing", () => {
     } as ChannelReplyPayload;
   }
 
-  test("routes to the rich send when useBlocks is set", async () => {
-    await telegramTransport.deliver(ctx, payload({ useBlocks: true }));
+  test("routes to the rich send when a rich render is asked for", async () => {
+    await telegramTransport.deliver(ctx, payload({ renderRichly: true }));
 
     expect(callsTo("sendRichMessage")).toHaveLength(1);
     expect(callsTo("sendMessage")).toHaveLength(0);
   });
 
-  test("stays on the plain send when useBlocks is absent", async () => {
-    await telegramTransport.deliver(ctx, payload({ useBlocks: false }));
+  test("stays on the plain send when it is not", async () => {
+    await telegramTransport.deliver(ctx, payload({ renderRichly: false }));
 
     expect(callsTo("sendRichMessage")).toHaveLength(0);
     expect(callsTo("sendMessage")).toHaveLength(1);
@@ -208,7 +208,7 @@ describe("telegramTransport.deliver routing", () => {
   test("forwards approval metadata through the rich path", async () => {
     await telegramTransport.deliver(
       ctx,
-      payload({ useBlocks: true, approval } as Partial<ChannelReplyPayload>),
+      payload({ renderRichly: true, approval } as Partial<ChannelReplyPayload>),
     );
 
     expect(callTelegramBotApiMock).toHaveBeenCalledWith("sendRichMessage", {
@@ -238,7 +238,7 @@ describe("telegramTransport topic targeting", () => {
   }
 
   test("plain replies target the topic from the callback threadId param", async () => {
-    await telegramTransport.deliver(topicCtx, payload({ useBlocks: false }));
+    await telegramTransport.deliver(topicCtx, payload({ renderRichly: false }));
 
     expect(callTelegramBotApiMock).toHaveBeenCalledWith("sendMessage", {
       chat_id: "123",
@@ -248,7 +248,7 @@ describe("telegramTransport topic targeting", () => {
   });
 
   test("rich replies target the topic", async () => {
-    await telegramTransport.deliver(topicCtx, payload({ useBlocks: true }));
+    await telegramTransport.deliver(topicCtx, payload({ renderRichly: true }));
 
     expect(callTelegramBotApiMock).toHaveBeenCalledWith("sendRichMessage", {
       chat_id: "123",
@@ -262,7 +262,7 @@ describe("telegramTransport topic targeting", () => {
       throw new TelegramNonRetryableError("rejected", "rejected");
     });
 
-    await telegramTransport.deliver(topicCtx, payload({ useBlocks: true }));
+    await telegramTransport.deliver(topicCtx, payload({ renderRichly: true }));
 
     expect(callTelegramBotApiMock).toHaveBeenNthCalledWith(2, "sendMessage", {
       chat_id: "123",
@@ -287,7 +287,7 @@ describe("telegramTransport topic targeting", () => {
       params: {},
     };
 
-    await telegramTransport.deliver(bareCtx, payload({ useBlocks: false }));
+    await telegramTransport.deliver(bareCtx, payload({ renderRichly: false }));
     await telegramTransport.typing!(bareCtx, "123");
 
     expect(callTelegramBotApiMock).toHaveBeenCalledWith("sendMessage", {

--- a/assistant/src/messaging/providers/telegram-bot/transport.ts
+++ b/assistant/src/messaging/providers/telegram-bot/transport.ts
@@ -32,11 +32,11 @@ export const telegramTransport: ChannelTransport = {
     const opts = threadOptions(ctx);
 
     if (text) {
-      // `useBlocks` is the channel-neutral "render richly" intent set by the
+      // The delivery layer sets this on every segment; Telegram answers it
       // delivery layer; the Telegram adapter honors it by forwarding markdown
       // to `sendRichMessage`, degrading to plain text otherwise (and on any
       // rich-send rejection).
-      if (payload.useBlocks) {
+      if (payload.renderRichly) {
         await sendTelegramRichReply(chatId, text, approval, opts);
       } else {
         await sendTelegramReply(chatId, text, approval, opts);

--- a/assistant/src/runtime/channel-reply-delivery.ts
+++ b/assistant/src/runtime/channel-reply-delivery.ts
@@ -217,7 +217,7 @@ export async function deliverRenderedReplyViaCallback(
         chatId,
         messageId: editTarget,
         text: segmentText,
-        useBlocks: true,
+        renderRichly: true,
       });
       // An edit replaces the text of one message. Attachments are always new
       // messages, so they still have to be posted alongside it.
@@ -245,7 +245,7 @@ export async function deliverRenderedReplyViaCallback(
       result = await deliverChannelReply(callbackUrl, {
         chatId,
         text: segmentText,
-        useBlocks: true,
+        renderRichly: true,
         attachments: segmentAttachments,
         assistantId,
         audience,

--- a/packages/gateway-client/src/outbound-contract.ts
+++ b/packages/gateway-client/src/outbound-contract.ts
@@ -197,7 +197,7 @@ export const ChannelReplyPayloadSchema = z.object({
    * Each channel decides what that means, and one that cannot ignores it.
    * Slack is the only channel acting on it today, where it becomes Block Kit.
    */
-  useBlocks: z.boolean().optional(),
+  renderRichly: z.boolean().optional(),
 });
 
 export type ChannelReplyPayload = z.infer<typeof ChannelReplyPayloadSchema>;


### PR DESCRIPTION
## TL;DR

Rename `useBlocks` to `renderRichly` on the shared payload. Slack keeps `useBlocks` inside its own module, where it is the right word.

Follows #41082 under LUM-3356.

## Why the old name was wrong, in the code's own words

`telegram-bot/transport.ts` reads this field, and carried a comment to explain it:

> `useBlocks` is the channel-neutral "render richly" intent set by the delivery layer

A field whose name forces every non-Slack reader to restate what it means is misnamed. Block Kit is Slack's answer to the question; the field is the question.

## What a person sees

Nothing. A wire field is renamed and both sides move together.

## Why this is not a compatibility change

The gateway never reads it. Every consumer is daemon-side: the Slack transport, the Telegram transport, and the delivery layer that sets it. The field crosses the wire but nothing on the far side acts on it, so the rename has no other end to break.

## Where the boundary sits

| | Name | Why |
| -- | -- | -- |
| Shared payload, `EditTarget`, Telegram | `renderRichly` | The request. Any channel can answer it, and one that cannot ignores it. |
| Inside `providers/slack/` | `useBlocks` | Block Kit is Slack's answer, and its own module is where that word is accurate. |
| `slack/transport.ts` | both | The translation point, one line each for send and edit. |

That is the pattern this whole arc is built on, in a single field: Vellum names the operation, the channel decides what it becomes.

## Scope

Seven files, all mechanical, compiler-verified. Two producers, three consumers, two test files. Typechecked in both `assistant/` and `gateway/`, since the contract package has consumers on both sides.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41086" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->