### PR TITLE
fix(windows): report permission applicability

### DIFF
--- a/clients/web/src/components/system-permissions-card.test.tsx
+++ b/clients/web/src/components/system-permissions-card.test.tsx
@@ -142,13 +142,23 @@ describe("SystemPermissionsCard", () => {
 
     expect(screen.queryByRole("switch", { name: "Accessibility" })).toBeNull();
     expect(
-      screen.queryByRole("switch", { name: "Screen Recording" }),
-    ).toBeNull();
+      screen.getByRole("switch", { name: "Screen Recording" }),
+    ).toBeTruthy();
     expect(screen.getByRole("switch", { name: "Microphone" })).toBeTruthy();
     expect(
       screen.getByText(/show Windows notifications for approvals/),
     ).toBeTruthy();
     expect(screen.queryByText(/macOS alerts/)).toBeNull();
+  });
+
+  test("hides permissions reported as not applicable", () => {
+    state = makeState({ screen: "not-applicable" });
+
+    render(<SystemPermissionsCard />);
+
+    expect(
+      screen.queryByRole("switch", { name: "Screen Recording" }),
+    ).toBeNull();
   });
 
   test("updates the Dock badge setting without requesting a macOS permission", async () => {

--- a/clients/web/src/components/system-permissions-card.tsx
+++ b/clients/web/src/components/system-permissions-card.tsx
@@ -30,10 +30,7 @@ interface SystemPermissionRowMeta {
   sourceKind: SystemPermissionKind;
   label: string;
   description: string;
-  /**
-   * Windows-specific description. Absent means the permission has no
-   * Windows equivalent and the row is hidden on a Windows host.
-   */
+  availableOnWindows?: boolean;
   windowsDescription?: string;
 }
 
@@ -68,6 +65,7 @@ const SYSTEM_PERMISSION_ROWS: SystemPermissionRowMeta[] = [
     label: "Screen Recording",
     description:
       "Allows your assistant to capture screen context during computer-use tasks.",
+    availableOnWindows: true,
   },
   {
     id: "microphone",
@@ -76,8 +74,7 @@ const SYSTEM_PERMISSION_ROWS: SystemPermissionRowMeta[] = [
     label: "Microphone",
     description:
       "Allows your assistant to capture audio for voice input and recordings.",
-    windowsDescription:
-      "Allows your assistant to capture audio for voice input and recordings.",
+    availableOnWindows: true,
   },
   {
     id: "speechRecognition",
@@ -86,6 +83,7 @@ const SYSTEM_PERMISSION_ROWS: SystemPermissionRowMeta[] = [
     label: "Speech Recognition",
     description:
       "Allows your assistant to transcribe your speech into text on-device.",
+    availableOnWindows: true,
     windowsDescription:
       "Allows your assistant to transcribe your speech into text with Windows speech recognition.",
   },
@@ -96,6 +94,7 @@ const SYSTEM_PERMISSION_ROWS: SystemPermissionRowMeta[] = [
     label: "Notifications",
     description:
       "Allows your assistant to send macOS alerts for approvals, messages, and task updates.",
+    availableOnWindows: true,
     windowsDescription:
       "Allows your assistant to show Windows notifications for approvals, messages, and task updates.",
   },
@@ -217,7 +216,7 @@ export function SystemPermissionsCard({
   const visibleSystemRows = useMemo(
     () =>
       SYSTEM_PERMISSION_ROWS.filter(
-        (meta) => !isWindowsHost || meta.windowsDescription,
+        (meta) => !isWindowsHost || meta.availableOnWindows,
       ),
     [isWindowsHost],
   );
@@ -233,7 +232,7 @@ export function SystemPermissionsCard({
 
     for (const meta of visibleSystemRows) {
       const item = state[meta.sourceKind];
-      if (item) {
+      if (item && item.status !== "not-applicable") {
         rows.set(meta.id, { meta, item });
       }
     }

--- a/clients/windows/src/main/features/permissions.ts
+++ b/clients/windows/src/main/features/permissions.ts
@@ -79,7 +79,7 @@ const kindSchema = z.enum(SYSTEM_PERMISSION_KINDS);
 // Settings deep links for the kinds a Windows user can actually change;
 // absent kinds have no Windows permission concept or remediation surface.
 const SETTINGS_URIS: Partial<Record<SystemPermissionKind, string>> = {
-  screen: "ms-settings:privacy-graphicscapture",
+  screen: "ms-settings:privacy-graphicscaptureprogrammatic",
   microphone: "ms-settings:privacy-microphone",
   speechRecognition: "ms-settings:privacy-speech",
   notifications: "ms-settings:notifications",

--- a/clients/windows/src/main/features/permissions.ts
+++ b/clients/windows/src/main/features/permissions.ts
@@ -79,12 +79,19 @@ const kindSchema = z.enum(SYSTEM_PERMISSION_KINDS);
 // Settings deep links for the kinds a Windows user can actually change;
 // absent kinds have no Windows permission concept or remediation surface.
 const SETTINGS_URIS: Partial<Record<SystemPermissionKind, string>> = {
+  screen: "ms-settings:privacy-graphicscapture",
   microphone: "ms-settings:privacy-microphone",
   speechRecognition: "ms-settings:privacy-speech",
   notifications: "ms-settings:notifications",
 };
 
 const PRIVACY_SETTINGS_URI = "ms-settings:privacy";
+
+const NOT_APPLICABLE_KINDS = new Set<SystemPermissionKind>([
+  "accessibility",
+  "inputMonitoring",
+  "automation",
+]);
 
 const mapMediaStatus = (status: string): SystemPermissionStatus =>
   SYSTEM_PERMISSION_STATUSES.includes(status as SystemPermissionStatus)
@@ -164,11 +171,12 @@ class WindowsPermissionsService {
   }
 
   private fallbackStatus(kind: SystemPermissionKind): SystemPermissionStatus {
+    if (NOT_APPLICABLE_KINDS.has(kind)) {
+      return "not-applicable";
+    }
     if (kind === "microphone" || kind === "screen") {
       return mapMediaStatus(systemPreferences.getMediaAccessStatus(kind));
     }
-    // Either not a Windows concept or readable only through the helper;
-    // never fabricate a granted state.
     return "unknown";
   }
 

--- a/clients/windows/src/main/features/permissions.ts
+++ b/clients/windows/src/main/features/permissions.ts
@@ -174,7 +174,7 @@ class WindowsPermissionsService {
     if (NOT_APPLICABLE_KINDS.has(kind)) {
       return "not-applicable";
     }
-    if (kind === "microphone" || kind === "screen") {
+    if (kind === "microphone") {
       return mapMediaStatus(systemPreferences.getMediaAccessStatus(kind));
     }
     return "unknown";

--- a/clients/windows/src/main/permissions-feature.test.ts
+++ b/clients/windows/src/main/permissions-feature.test.ts
@@ -1,10 +1,15 @@
 import { beforeEach, expect, mock, test } from "bun:test";
 
-import { PERMISSIONS_GET_STATE, TEXT_INSERT } from "@vellumai/ipc-contract";
+import {
+  PERMISSIONS_GET_STATE,
+  PERMISSIONS_OPEN_SETTINGS,
+  TEXT_INSERT,
+} from "@vellumai/ipc-contract";
 
 type Handler = (args: unknown[]) => unknown;
 
 const handlers = new Map<string, Handler>();
+const openExternal = mock(async () => undefined);
 const helperCall = mock(async (method: string) => {
   if (method === "permissions.state") {
     return {
@@ -23,7 +28,7 @@ mock.module("electron", () => ({
     relaunch: mock(() => undefined),
   },
   BrowserWindow: { getAllWindows: () => [], getFocusedWindow: () => null },
-  shell: { openExternal: mock(async () => undefined) },
+  shell: { openExternal },
   systemPreferences: { getMediaAccessStatus: () => "unknown" },
 }));
 mock.module("./ipc.client", () => ({
@@ -42,6 +47,7 @@ const { default: permissionsFeature } = await import("./features/permissions");
 beforeEach(() => {
   handlers.clear();
   helperCall.mockClear();
+  openExternal.mockClear();
   permissionsFeature.install({} as never);
 });
 
@@ -59,4 +65,24 @@ test("uses the Windows helper for permission states and text insertion", async (
 
   expect(helperCall).toHaveBeenCalledWith("permissions.state");
   expect(helperCall).toHaveBeenCalledWith("text.insert", { text: "hello" });
+});
+
+test("reports Windows-only applicability and opens screen capture settings", async () => {
+  await expect(handlers.get(PERMISSIONS_GET_STATE)!([])).resolves.toMatchObject(
+    {
+      accessibility: { status: "not-applicable" },
+      screen: {
+        status: "unknown",
+        canOpenSettings: true,
+      },
+      inputMonitoring: { status: "not-applicable" },
+      automation: { status: "not-applicable" },
+    },
+  );
+
+  await handlers.get(PERMISSIONS_OPEN_SETTINGS)!(["screen"]);
+
+  expect(openExternal).toHaveBeenCalledWith(
+    "ms-settings:privacy-graphicscapture",
+  );
 });

--- a/clients/windows/src/main/permissions-feature.test.ts
+++ b/clients/windows/src/main/permissions-feature.test.ts
@@ -83,6 +83,6 @@ test("reports Windows-only applicability and opens screen capture settings", asy
   await handlers.get(PERMISSIONS_OPEN_SETTINGS)!(["screen"]);
 
   expect(openExternal).toHaveBeenCalledWith(
-    "ms-settings:privacy-graphicscapture",
+    "ms-settings:privacy-graphicscaptureprogrammatic",
   );
 });

--- a/clients/windows/src/main/permissions-feature.test.ts
+++ b/clients/windows/src/main/permissions-feature.test.ts
@@ -29,7 +29,7 @@ mock.module("electron", () => ({
   },
   BrowserWindow: { getAllWindows: () => [], getFocusedWindow: () => null },
   shell: { openExternal },
-  systemPreferences: { getMediaAccessStatus: () => "unknown" },
+  systemPreferences: { getMediaAccessStatus: () => "granted" },
 }));
 mock.module("./ipc.client", () => ({
   handle: (channel: string, _schema: unknown, handler: Handler) => {

--- a/packages/ipc-contract/src/types.ts
+++ b/packages/ipc-contract/src/types.ts
@@ -158,6 +158,7 @@ export type SystemPermissionKind = (typeof SYSTEM_PERMISSION_KINDS)[number];
 
 export const SYSTEM_PERMISSION_STATUSES = [
   "unknown",
+  "not-applicable",
   "restricted",
   "denied",
   "not-determined",


### PR DESCRIPTION
## Summary
- Model non-applicable system permission states explicitly across the desktop IPC contract.
- Report macOS-only permissions as not applicable on Windows and hide those rows in the renderer.
- Surface Screen Recording on Windows with a direct link to the graphics capture privacy settings page.

## Original prompt
Complete the Windows permission parity work by reporting permissions that do not apply on Windows accurately and adding the screen capture Settings URI. Preserve the renderer-driven microphone permission prompt and avoid introducing a fake helper capture.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41087" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->