### PR TITLE
fix(plugin-api): translate entry-name providers when resolving vision support

### DIFF
--- a/assistant/src/plugin-api/vision-support.test.ts
+++ b/assistant/src/plugin-api/vision-support.test.ts
@@ -2,7 +2,13 @@ import { beforeEach, describe, expect, test } from "bun:test";
 
 import { setConfig } from "../__tests__/helpers/set-config.js";
 import { getConfig } from "../config/loader.js";
+import { getDb } from "../persistence/db-connection.js";
+import { initializeDb } from "../persistence/db-init.js";
+import { providerConnections } from "../persistence/schema/inference.js";
 import type { ModelProfileInfo } from "./types.js";
+
+// Entry-name translation reads provider_connections rows through the real DB.
+await initializeDb();
 
 // ─── Fixture config ─────────────────────────────────────────────────────────
 
@@ -208,6 +214,82 @@ describe("doesSupportVision with a BYO default provider", () => {
       { provider: "anthropic" },
     );
     expect(doesSupportVision(profile("custom-text"))).toBe(false);
+  });
+});
+
+describe("doesSupportVision with connection entry-name providers", () => {
+  function seedConnection(opts: { name: string; provider: string }): void {
+    const now = Date.now();
+    getDb()
+      .insert(providerConnections)
+      .values({
+        name: opts.name,
+        provider: opts.provider,
+        auth: JSON.stringify({
+          type: "api_key",
+          credential: `${opts.provider}/api_key`,
+        }),
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+  }
+
+  beforeEach(() => {
+    getDb().delete(providerConnections).run();
+  });
+
+  test("judges an entry-name profile by its row's vendor (vision-capable)", () => {
+    seedConnection({ name: "openrouter-personal", provider: "openrouter" });
+    setMockConfig({
+      "personal-opus": {
+        provider: "openrouter-personal",
+        model: "anthropic/claude-opus-4.6",
+      },
+    });
+    expect(doesSupportVision(profile("personal-opus"))).toBe(true);
+  });
+
+  test("judges an entry-name profile by its row's vendor (text-only)", () => {
+    seedConnection({ name: "openrouter-personal", provider: "openrouter" });
+    setMockConfig({
+      "personal-deepseek": {
+        provider: "openrouter-personal",
+        model: "deepseek/deepseek-v4-pro",
+      },
+    });
+    expect(doesSupportVision(profile("personal-deepseek"))).toBe(false);
+  });
+
+  test("an entry name naming no row fails safe to false", () => {
+    setMockConfig({
+      dangling: {
+        provider: "ghost-connection",
+        model: "anthropic/claude-opus-4.6",
+      },
+    });
+    expect(doesSupportVision(profile("dangling"))).toBe(false);
+  });
+
+  test("mix arms with entry-name providers translate the same way", () => {
+    seedConnection({ name: "openrouter-personal", provider: "openrouter" });
+    setMockConfig({
+      "mix-profile": {
+        mix: [
+          { profile: "personal-deepseek", weight: 0.5 },
+          { profile: "personal-opus", weight: 0.5 },
+        ],
+      },
+      "personal-deepseek": {
+        provider: "openrouter-personal",
+        model: "deepseek/deepseek-v4-pro",
+      },
+      "personal-opus": {
+        provider: "openrouter-personal",
+        model: "anthropic/claude-opus-4.6",
+      },
+    });
+    expect(doesSupportVision(profile("mix-profile"))).toBe(true);
   });
 });
 

--- a/assistant/src/plugin-api/vision-support.ts
+++ b/assistant/src/plugin-api/vision-support.ts
@@ -10,7 +10,9 @@
  *   resolved through `llm.profiles` to an effective `(provider, model)`.
  *   Default profile keys resolve through `llm.defaultProvider`'s column of the
  *   intent × provider matrix, so the judged model is the one that actually
- *   runs on a BYO install.
+ *   runs on a BYO install. A profile whose provider names a connection entry
+ *   row (e.g. a `<vendor>-personal` binding) is judged by the row's
+ *   dispatchable vendor, sharing dispatch's entry-name translation.
  *
  * A bare string is tried as a model id first and then as a profile key, so the
  * two callers share one function. Resolution returns `false` when nothing
@@ -21,6 +23,7 @@
 
 import { resolveDefaultProfileForProvider } from "../config/default-profile-catalog.js";
 import { getConfig } from "../config/loader.js";
+import { resolveEntryProviderKind } from "../providers/connection-resolution.js";
 import { ROUTING_IDENTITY_PROVIDERS } from "../providers/inference/auth.js";
 import {
   getCatalogProviderForModel,
@@ -117,11 +120,20 @@ function resolveEntryVision(entry: {
 }): boolean | undefined {
   // Routing identities ("vellum"/"chatgpt") are not catalog providers; the
   // model's catalog owner is the capability source for them.
-  const provider =
+  const declared =
     entry.provider != null && ROUTING_IDENTITY_PROVIDERS.has(entry.provider)
       ? undefined
       : entry.provider;
   const model = entry.model;
+
+  // A provider naming a connection entry row (e.g. a "<vendor>-personal"
+  // binding) translates to the row's dispatchable kind, the same translation
+  // dispatch uses, so the catalog judges the vendor actually serving the
+  // profile. Vendor ids pass through untranslated.
+  const provider =
+    declared != null
+      ? (resolveEntryProviderKind(declared, model) ?? declared)
+      : undefined;
 
   // Infer provider from model when missing (mirrors the resolver's catalog
   // provider implication).


### PR DESCRIPTION
## Summary
- `resolveEntryVision` translates a profile provider that names a connection entry row (e.g. `openrouter-personal`) to the row's dispatchable vendor via `resolveEntryProviderKind`, the same translation dispatch and preflight use, before the `PROVIDER_CATALOG` lookup. Vendor ids and routing identities behave as before.
- Fixes the image-fallback plugin captioning images for vision-capable models: after workspace migration 145 folded `provider_connection` into `provider`, profiles carrying entry-name providers failed the catalog lookup, `doesSupportVision` failed closed to "text-only", and user-attached images were replaced with caption text (or a failure placeholder when the caption call itself failed) instead of being sent to the model.
- Adds real-DB regression tests covering entry-name translation: vision-capable and text-only models behind an entry row, an entry name with no row (fails safe), and mix arms.

## Original prompt
Diagnosed a live turn where a user-attached screenshot reached a Claude Opus 4.6 conversation as `[Image: auto-description failed (text-only model)]` even though the model supports image input natively. Root cause: the vision capability probe judged the profile's raw provider string against catalog vendor ids, which broke once migration 145 rewrote profile providers to connection entry names. The requested fix was to share dispatch's entry-name translation in `resolveEntryVision` so vision-capable models on entry-name profiles are no longer misclassified as text-only.