### PR TITLE
feat(web): gate internal thread actions on the feature flag alone

### DIFF
--- a/clients/web/src/domains/chat/inspector/inspect-page.test.tsx
+++ b/clients/web/src/domains/chat/inspector/inspect-page.test.tsx
@@ -209,8 +209,8 @@ beforeEach(() => {
   assistantStub = { assistantId: "asst-1" };
   authUserStub = { email: "dev@vellum.ai", isStaff: false };
   sessionInitializingStub = false;
-  // Hydrated, flag-off baseline: gating tests exercise the denial branch
-  // by default; flag tests opt in explicitly.
+  // Hydrated, flag-on baseline: most tests exercise the allowed branch;
+  // gating tests flip the flag keys off to reach the denial branch.
   internalActionsFlagStub = true;
   legacyForkFlagStub = false;
   flagsHydratedStub = true;
@@ -246,23 +246,24 @@ function makeLog(id: string, createdAt: number) {
 // ---------------------------------------------------------------------------
 
 describe("InspectPage — gating", () => {
-  test("blocks non-internal users before resolving inspector params", () => {
-    authUserStub = { email: "person@example.com", isStaff: false };
+  test("blocks sessions with both flag keys off before resolving inspector params", () => {
+    internalActionsFlagStub = false;
+    legacyForkFlagStub = false;
     paramsStub = { conversationId: "conv-abc" };
 
     const html = renderInspector();
 
-    expect(html).toContain("Inspector is available to Vellum staff");
+    expect(html).toContain(
+      "Inspector is available when the Internal Thread Actions",
+    );
     // header chrome shouldn't render
     expect(html).not.toContain("LLM Context Inspector");
   });
 
-  test("blocks identity-less sessions even with the flag on", () => {
-    // Local-gateway sessions have no email/staff bit, and the
-    // internal-thread-actions gate has no flag-only escape hatch.
+  test("allows identity-less sessions when the flag is on", () => {
+    // Local-gateway sessions carry no email or staff bit; the flag is the
+    // sole gate, so they qualify like any platform session.
     authUserStub = { email: null, isStaff: false };
-    internalActionsFlagStub = true;
-  legacyForkFlagStub = false;
     paramsStub = { conversationId: "conv-abc" };
     contextStub = {
       data: {
@@ -282,26 +283,18 @@ describe("InspectPage — gating", () => {
 
     const html = renderInspector();
 
-    expect(html).toContain("Inspector is available to Vellum staff");
-    expect(html).not.toContain("LLM Context Inspector");
-  });
-
-  test("the flag is a kill switch that outranks staff", () => {
-    authUserStub = { email: "dev@vellum.ai", isStaff: true };
-    internalActionsFlagStub = false;
-    legacyForkFlagStub = false;
-    paramsStub = { conversationId: "conv-abc" };
-
-    const html = renderInspector();
-
-    expect(html).toContain("Inspector is available to Vellum staff");
-    expect(html).not.toContain("LLM Context Inspector");
+    expect(html).not.toContain(
+      "Inspector is available when the Internal Thread Actions",
+    );
+    // Real CallRail emits one row per log; assert the page reached the
+    // loaded state, not the empty/loading/error branches.
+    expect(html).toContain("LLM Context Inspector");
+    expect(html).toContain("1 LLM call");
   });
 
   test("accepts the legacy fork-from-message key on its own", () => {
-    // The platform may serve this gate under either key, so a staff session
+    // The platform may serve this gate under either key, so a session
     // carrying only the legacy one still gets in.
-    authUserStub = { email: "dev@vellum.ai", isStaff: true };
     internalActionsFlagStub = false;
     legacyForkFlagStub = true;
     paramsStub = { conversationId: "conv-abc" };
@@ -323,48 +316,25 @@ describe("InspectPage — gating", () => {
 
     const html = renderInspector();
 
-    expect(html).not.toContain("Inspector is available to Vellum staff");
+    expect(html).not.toContain(
+      "Inspector is available when the Internal Thread Actions",
+    );
     expect(html).toContain("LLM Context Inspector");
   });
 
   test("treats the pre-hydration window as loading, not denial", () => {
-    // Until /feature-flags lands, the flag reads registry-default false —
-    // non-staff sessions must see the loading state, not a denial flash.
-    authUserStub = { email: "person@example.com", isStaff: false };
+    // Until /feature-flags lands, the flag reads its registry default of
+    // false, so sessions must see the loading state, not a denial flash.
+    internalActionsFlagStub = false;
+    legacyForkFlagStub = false;
     flagsHydratedStub = false;
 
     const html = renderInspector();
 
     expect(html).toContain("Loading…");
-    expect(html).not.toContain("Inspector is available to Vellum staff");
-  });
-
-  test("allows staff users even without a vellum.ai email", () => {
-    authUserStub = { email: "person@example.com", isStaff: true };
-    paramsStub = { conversationId: "conv-abc" };
-    contextStub = {
-      data: {
-        conversationId: "conv-int-1",
-        conversationKey: "conv-abc",
-        conversationKind: "user",
-        conversationTotalEstimatedCostUsd: null,
-        logs: [makeLog("log-1", 1)],
-        memoryRecall: null,
-        memoryV2Activation: null,
-      },
-      isLoading: false,
-      isError: false,
-      error: null,
-      refetch: () => {},
-    };
-
-    const html = renderInspector();
-
-    expect(html).not.toContain("Inspector is available to Vellum staff");
-    // Real CallRail emits one row per log — assert the page reached the
-    // loaded state, not the empty/loading/error branches.
-    expect(html).toContain("LLM Context Inspector");
-    expect(html).toContain("1 LLM call");
+    expect(html).not.toContain(
+      "Inspector is available when the Internal Thread Actions",
+    );
   });
 
   // (No "missing conversationId" branch — the dynamic segment is required

--- a/clients/web/src/domains/chat/inspector/inspect-page.tsx
+++ b/clients/web/src/domains/chat/inspector/inspect-page.tsx
@@ -84,8 +84,9 @@ export function InspectPage(): ReactNode {
   const { t: tChat } = useTranslation("chat");
   const canInspect = useCanUseInternalThreadActions();
   // The internal-thread-actions flag reads as registry-default `false` until
-  // the `/feature-flags` response lands, so a staff session would flash the
-  // denial on deep links. Treat the pre-hydration window as loading instead.
+  // the `/feature-flags` response lands, so an enabled session would flash
+  // the denial on deep links. Treat the pre-hydration window as loading
+  // instead.
   const flagsHydrated = useClientFeatureFlagStore.use.hydrated();
   const authLoading = useIsSessionInitializing();
   // React Router's :conversationId segment is the source of truth; the

--- a/clients/web/src/domains/chat/inspector/memory-router-playground-page.tsx
+++ b/clients/web/src/domains/chat/inspector/memory-router-playground-page.tsx
@@ -34,8 +34,8 @@ import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
  *
  * Gated by:
  *   1. The `memoryRouterPlayground` client feature flag (default off).
- *   2. The same staff/developer-flag gate that protects the LLM context
- *      inspector (/assistant/conversations/:conversationId/inspect).
+ *   2. The same internal-thread-actions flag gate that protects the LLM
+ *      context inspector (/assistant/conversations/:conversationId/inspect).
  */
 export function MemoryRouterPlaygroundPage(): ReactNode {
   const { t } = useTranslation("chat");

--- a/clients/web/src/i18n/locales/en/chat.json
+++ b/clients/web/src/i18n/locales/en/chat.json
@@ -248,7 +248,7 @@
     "title": "{name} actions"
   },
   "inspectPage": {
-    "accessDenied": "Inspector is available to Vellum staff, or when the settings-developer-nav developer flag is enabled.",
+    "accessDenied": "Inspector is available when the Internal Thread Actions feature flag is enabled.",
     "allMessages": "All messages",
     "back": "Back",
     "backToConversationAria": "Back to conversation",

--- a/clients/web/src/i18n/locales/es/chat.json
+++ b/clients/web/src/i18n/locales/es/chat.json
@@ -248,7 +248,7 @@
     "title": "Acciones de {name}"
   },
   "inspectPage": {
-    "accessDenied": "El inspector está disponible para el personal de Vellum o cuando la marca de desarrollador settings-developer-nav está habilitada.",
+    "accessDenied": "El inspector está disponible cuando la marca Internal Thread Actions está habilitada.",
     "allMessages": "Todos los mensajes",
     "back": "Volver",
     "backToConversationAria": "Volver a la conversación",

--- a/clients/web/src/lib/auth/internal-thread-actions.test.ts
+++ b/clients/web/src/lib/auth/internal-thread-actions.test.ts
@@ -1,59 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
 import { CLIENT_FLAG_DEFAULTS } from "@/lib/feature-flags/feature-flag-catalog";
-import { canUseInternalThreadActions } from "@/lib/auth/internal-thread-actions";
-import type { AuthUser } from "@/stores/auth-store";
-
-function user(overrides: Partial<AuthUser>): AuthUser {
-  return {
-    kind: "platform",
-    id: "user-123",
-    username: null,
-    email: "user@example.com",
-    isStaff: false,
-    firstName: "",
-    lastName: "",
-    ...overrides,
-  };
-}
-
-describe("canUseInternalThreadActions", () => {
-  test("allows staff once the flag is on", () => {
-    expect(canUseInternalThreadActions(user({ isStaff: true }), true)).toBe(
-      true,
-    );
-  });
-
-  test("allows Vellum email users case-insensitively", () => {
-    expect(
-      canUseInternalThreadActions(user({ email: "alice@" + "VELLUM.AI" }), true),
-    ).toBe(true);
-  });
-
-  test("rejects regular users even with the flag on", () => {
-    expect(
-      canUseInternalThreadActions(user({ email: "user@example.com" }), true),
-    ).toBe(false);
-  });
-
-  test("the flag is a kill switch that outranks staff", () => {
-    // Both halves have to agree, so turning the flag off pulls the affordances
-    // from staff too, which is the point of keeping it as a kill switch.
-    expect(canUseInternalThreadActions(user({ isStaff: true }), false)).toBe(
-      false,
-    );
-    expect(
-      canUseInternalThreadActions(user({ email: "alice@vellum.ai" }), false),
-    ).toBe(false);
-  });
-
-  test("rejects identity-less sessions", () => {
-    // Local-gateway sessions carry no email or staff bit, and unlike the old
-    // inspector gate there is no flag-only escape hatch.
-    expect(canUseInternalThreadActions(null, true)).toBe(false);
-    expect(canUseInternalThreadActions(user({ email: null }), true)).toBe(false);
-  });
-});
 
 describe("internal-thread-actions flag keys", () => {
   // `use-client-feature-flag-sync` drops any server key the registry does not

--- a/clients/web/src/lib/auth/internal-thread-actions.ts
+++ b/clients/web/src/lib/auth/internal-thread-actions.ts
@@ -1,38 +1,19 @@
-import { isVellumStaff } from "@/lib/auth/staff";
-import { useAuthStore } from "@/stores/auth-store";
-import type { AuthUser } from "@/stores/auth-store";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 
 /**
- * Whether the viewer may use the internal-only thread affordances: fork ('Fork
+ * Whether the viewer may use the internal thread affordances: fork ('Fork
  * from here' on a message, 'Fork Conversation' in the thread menu), 'Analyze
  * Conversation', 'Copy Full Conversation', 'Copy conversation ID', 'Open in
  * New Window', 'Refresh', message bookmarks, and the LLM inspector surfaces
  * behind them. They all read this one predicate, so widening or narrowing the
  * audience moves them together.
  *
- * Both halves have to agree: the `internal-thread-actions` client flag is the
- * kill switch, and the staff check keeps the affordances off for everyone else
- * even if the flag is ever rolled out more widely than intended.
- *
- * Staff is recognized by the shared `isVellumStaff` predicate. There is no
- * flag-only escape hatch, so local-gateway sessions, which carry no email and
- * no staff bit, never qualify.
- */
-export function canUseInternalThreadActions(
-  user: AuthUser | null,
-  internalThreadActionsEnabled: boolean,
-): boolean {
-  if (!internalThreadActionsEnabled) {
-    return false;
-  }
-  return isVellumStaff(user);
-}
-
-/**
- * Store-connected variant for render bodies. The flag reads as its registry
- * default (`false`) until `/feature-flags` hydrates, so these affordances
- * appear once the real value lands rather than flashing and disappearing.
+ * The `internal-thread-actions` client flag is the sole gate. It defaults
+ * off, so the affordances are opt-in for any session that enables it,
+ * including local-gateway sessions, which carry no platform identity. The
+ * flag reads as its registry default (`false`) until `/feature-flags`
+ * hydrates, so the affordances appear once the real value lands rather than
+ * flashing and disappearing.
  *
  * The platform serves this gate under either `internal-thread-actions` or the
  * legacy `fork-from-message` key, and either one grants access. Both are
@@ -41,13 +22,9 @@ export function canUseInternalThreadActions(
  * declare).
  */
 export function useCanUseInternalThreadActions(): boolean {
-  const user = useAuthStore.use.user();
   const internalThreadActionsEnabled =
     useClientFeatureFlagStore.use.internalThreadActions();
   const legacyForkFlagEnabled =
     useClientFeatureFlagStore.use.forkFromMessage();
-  return canUseInternalThreadActions(
-    user,
-    internalThreadActionsEnabled === true || legacyForkFlagEnabled === true,
-  );
+  return internalThreadActionsEnabled === true || legacyForkFlagEnabled === true;
 }

--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -145,7 +145,7 @@
       "scope": "client",
       "key": "internal-thread-actions",
       "label": "Internal Thread Actions",
-      "description": "Show the internal-only thread affordances: 'Fork from here' on messages, 'Fork Conversation', 'Analyze Conversation', and 'Copy conversation ID' in the thread menu, plus the LLM inspector surfaces. Staff-only: the client also requires the viewer to be Vellum staff, so enabling this for a non-staff account still shows nothing.",
+      "description": "Show the internal thread affordances: 'Fork from here' on messages, 'Fork Conversation', 'Analyze Conversation', and 'Copy conversation ID' in the thread menu, plus the LLM inspector surfaces. The flag is the sole gate: any session that enables it gets the affordances, including local sessions with no platform identity.",
       "defaultEnabled": false
     },
     {

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -145,7 +145,7 @@
       "scope": "client",
       "key": "internal-thread-actions",
       "label": "Internal Thread Actions",
-      "description": "Show the internal-only thread affordances: 'Fork from here' on messages, 'Fork Conversation', 'Analyze Conversation', and 'Copy conversation ID' in the thread menu, plus the LLM inspector surfaces. Staff-only: the client also requires the viewer to be Vellum staff, so enabling this for a non-staff account still shows nothing.",
+      "description": "Show the internal thread affordances: 'Fork from here' on messages, 'Fork Conversation', 'Analyze Conversation', and 'Copy conversation ID' in the thread menu, plus the LLM inspector surfaces. The flag is the sole gate: any session that enables it gets the affordances, including local sessions with no platform identity.",
       "defaultEnabled": false
     },
     {


### PR DESCRIPTION
## Summary

Removes the `isVellumStaff` half of the internal-thread-actions gate. The `internal-thread-actions` client flag (or its legacy `fork-from-message` key) is now the sole gate for the internal thread affordances: 'Fork from here' / 'Fork Conversation', 'Analyze Conversation', 'Copy conversation ID', message bookmarks, and the LLM inspector surfaces (including the memory-router playground, which additionally requires its own flag).

## Why

Local-gateway and paired sessions install a synthetic auth user (`GATEWAY_LOCAL_USER`) with no email and no staff bit, so the staff requirement made these affordances unreachable on local assistants even for sessions that explicitly enabled the flag. The staff check was client-side audience control, not a security boundary: the client is open source and the inspector only ever renders the viewer's own assistant's data. The flag defaults off in the registry, so the surfaces remain strictly opt-in.

## Changes

- `canUseInternalThreadActions(user, flag)` is deleted; `useCanUseInternalThreadActions()` reads the two flag keys directly.
- Inspector denial copy (en/es) rewritten; it still described the retired `settings-developer-nav` gate.
- Canonical registry description updated (`meta/feature-flags/feature-flag-registry.json`) and bundled copies re-synced via `bun run meta/sync-bundled-copies.ts`.
- Gating tests updated: denial now comes from the flags being off, and identity-less sessions are asserted to pass with the flag on.

Not touched: `isVellumStaff` itself and its other consumers (debug-controls panel, share-feedback modal, preferences menu) keep their staff gating.

## Test plan

- `bun test src/lib/auth/internal-thread-actions.test.ts` (2 pass)
- `bun test src/domains/chat/inspector/inspect-page.test.tsx` (13 pass)
- `bunx tsc --noEmit` clean in `clients/web`
- eslint clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)