### PR TITLE
fix(cli): default `vellum tunnel` to a provider that works

### DIFF
--- a/cli/src/__tests__/tunnel.test.ts
+++ b/cli/src/__tests__/tunnel.test.ts
@@ -627,6 +627,22 @@ describe("tunnel edge targeting", () => {
     expect(logs).toContain("serves webhooks only");
   });
 
+  test("a bare invocation defaults to the tailscale provider", async () => {
+    const entry = makeLocalEntry();
+    writeLockfile(entry);
+    process.argv = ["bun", "vellum", "tunnel"];
+
+    await runTunnelCapturingLogs();
+
+    expect(runTailscaleTunnelMock).toHaveBeenCalledWith({
+      port: EDGE_PORT,
+      assistantId: "assistant-1",
+      workspaceDir: join(entry.resources!.instanceDir, ".vellum", "workspace"),
+    });
+    expect(runNgrokTunnelMock).not.toHaveBeenCalled();
+    expect(runCloudflareTunnelMock).not.toHaveBeenCalled();
+  });
+
   test("missing nginx aborts before any provider spawn", async () => {
     process.argv = ["bun", "vellum", "tunnel", "--provider", "ngrok"];
     ensureTunnelEdgeMock.mockRejectedValue(
@@ -797,8 +813,8 @@ describe("tunnel edge targeting", () => {
   });
 
   test("a not-yet-implemented provider error carries the stale-CLI hint", async () => {
-    // The default `vellum` provider has no runtime yet, so it exercises the
-    // not-yet-implemented path without any network call.
+    // `vellum` stays valid-but-unimplemented, so it hits this path rather
+    // than the unknown-provider one.
     process.argv = ["bun", "vellum", "tunnel", "--provider", "vellum"];
 
     let err: Error | undefined;

--- a/cli/src/commands/tunnel.ts
+++ b/cli/src/commands/tunnel.ts
@@ -25,7 +25,7 @@ import { parseGatewayPortFromEntryUrls } from "./nginx-ingress.js";
 const VALID_PROVIDERS = ["vellum", "ngrok", "cloudflare", "tailscale"] as const;
 type TunnelProvider = (typeof VALID_PROVIDERS)[number];
 
-const DEFAULT_PROVIDER: TunnelProvider = "vellum";
+const DEFAULT_PROVIDER: TunnelProvider = "tailscale";
 
 interface TunnelArgs {
   assistantName: string | null;
@@ -88,7 +88,7 @@ function parseArgs(): TunnelArgs {
       console.log("");
       console.log("Providers:");
       console.log(
-        "  vellum       Managed tunnel via Vellum Cloud (default; requires account)",
+        "  vellum       Managed tunnel via Vellum Cloud (not yet available)",
       );
       console.log(
         "  ngrok        ngrok tunnel — install: brew install ngrok/ngrok/ngrok",
@@ -100,7 +100,7 @@ function parseArgs(): TunnelArgs {
         "               No Cloudflare account required for quick tunnels.",
       );
       console.log(
-        "  tailscale    Tailscale serve — install: brew install tailscale, then `tailscale up`",
+        "  tailscale    Tailscale serve (default) — install: brew install tailscale, then `tailscale up`",
       );
       console.log(
         "               Reachable only from your own tailnet (private; LetsEncrypt cert).",

--- a/cli/src/commands/tunnel.ts
+++ b/cli/src/commands/tunnel.ts
@@ -58,6 +58,13 @@ function parseArgs(): TunnelArgs {
       );
       console.log("");
       console.log(
+        "The default tailscale provider is reachable only from your own tailnet.",
+      );
+      console.log(
+        "Public webhook ingress needs --provider ngrok or --provider cloudflare.",
+      );
+      console.log("");
+      console.log(
         "The tunnel always fronts the local nginx edge, which is started automatically.",
       );
       console.log(
@@ -100,7 +107,7 @@ function parseArgs(): TunnelArgs {
         "               No Cloudflare account required for quick tunnels.",
       );
       console.log(
-        "  tailscale    Tailscale serve (default) — install: brew install tailscale, then `tailscale up`",
+        "  tailscale    Tailscale serve (default). Install: brew install tailscale, then `tailscale up`",
       );
       console.log(
         "               Reachable only from your own tailnet (private; LetsEncrypt cert).",

--- a/cli/src/lib/tailscale-tunnel.ts
+++ b/cli/src/lib/tailscale-tunnel.ts
@@ -256,6 +256,9 @@ export async function runTailscaleTunnel(
   console.log(
     "This URL is reachable only from devices signed in to your tailnet.",
   );
+  console.log(
+    "For public webhook ingress, use --provider ngrok or --provider cloudflare.",
+  );
   console.log("");
   console.log(
     "The serve runs in the background (tailscaled) and persists after this",


### PR DESCRIPTION
## Summary

- `DEFAULT_PROVIDER` was `vellum`, an unimplemented provider, so a bare `vellum tunnel` — the command the docs and the Pair-a-device card point people at — always threw `Tunnel provider 'vellum' is not yet implemented`. Default to `tailscale` instead, which actually runs.
- `--help` no longer advertises the managed provider as the default: the `vellum` line now reads "(not yet available)" and the `(default)` marker moves to `tailscale` (the options line derives it from `DEFAULT_PROVIDER`).
- `vellum` stays in `VALID_PROVIDERS`, so an explicit `--provider vellum` still gives the clear not-yet-implemented error rather than an unknown-provider one. Added a test that a bare invocation runs the Tailscale tunnel.

Part of plan: tunnel-status-pairing.md (PR 3 of 9)