### PR TITLE
feat(cli): remember the last tunnel's provider and URL across teardown

### DIFF
--- a/assistant/src/__tests__/sanitize-config-for-transfer.test.ts
+++ b/assistant/src/__tests__/sanitize-config-for-transfer.test.ts
@@ -9,6 +9,11 @@ describe("sanitizeConfigForTransfer", () => {
         publicBaseUrl: "https://example.com",
         enabled: true,
         publicBaseUrlManagedBy: "velay",
+        lastTunnel: {
+          provider: "ngrok",
+          publicBaseUrl: "https://source.ngrok.app",
+        },
+        assistantId: "source-assistant",
         webhook: { path: "/hook" },
       },
       daemon: { port: 3000, logLevel: "debug" },
@@ -33,6 +38,8 @@ describe("sanitizeConfigForTransfer", () => {
     expect(result.ingress.publicBaseUrl).toBe("");
     expect(result.ingress.enabled).toBeUndefined();
     expect(result.ingress.publicBaseUrlManagedBy).toBeUndefined();
+    expect(result.ingress.lastTunnel).toBeUndefined();
+    expect(result.ingress.assistantId).toBeUndefined();
     expect(result.daemon).toBeUndefined();
     expect(result.skills.load.extraDirs).toEqual([]);
     expect(result.hostBrowser).toEqual({
@@ -143,6 +150,29 @@ describe("sanitizeConfigForTransfer", () => {
         publicBaseUrl: "https://velay-public.example.test",
         enabled: true,
         publicBaseUrlManagedBy: "velay",
+        webhook: { path: "/webhook" },
+      },
+    };
+
+    const result = JSON.parse(sanitizeConfigForTransfer(JSON.stringify(input)));
+
+    expect(result.ingress).toEqual({
+      publicBaseUrl: "",
+      webhook: { path: "/webhook" },
+    });
+  });
+
+  test("strips the remembered tunnel and the assistant it fronted", () => {
+    // Both records describe the source host's tunnel; a destination that
+    // inherited them would report the old deployment's tunnel as its own.
+    const input = {
+      ingress: {
+        publicBaseUrl: "https://source.ngrok.app",
+        lastTunnel: {
+          provider: "ngrok",
+          publicBaseUrl: "https://source.ngrok.app",
+        },
+        assistantId: "source-assistant",
         webhook: { path: "/webhook" },
       },
     };

--- a/assistant/src/config/sanitize-for-transfer.ts
+++ b/assistant/src/config/sanitize-for-transfer.ts
@@ -6,6 +6,8 @@
  * - `ingress.publicBaseUrl` → set to `""`
  * - `ingress.enabled` → deleted
  * - `ingress.publicBaseUrlManagedBy` → deleted
+ * - `ingress.lastTunnel` → deleted
+ * - `ingress.assistantId` → deleted
  * - `telegram.registeredWebhookUrl` → deleted
  * - `daemon` → deleted entirely
  * - `skills.load.extraDirs` → set to `[]`
@@ -44,6 +46,10 @@ export function sanitizeConfigForTransfer(configJson: string): string {
     ingress.publicBaseUrl = "";
     delete ingress.enabled;
     delete ingress.publicBaseUrlManagedBy;
+    // The remembered tunnel and the assistant it fronted belong to the source
+    // host; carrying them over makes tunnel-status UIs name the old deployment.
+    delete ingress.lastTunnel;
+    delete ingress.assistantId;
   }
 
   // Strip the recorded Telegram webhook URL. It records where *this*

--- a/cli/src/__tests__/ingress-config.test.ts
+++ b/cli/src/__tests__/ingress-config.test.ts
@@ -7,7 +7,12 @@ import { join } from "node:path";
 const testDir = mkdtempSync(join(tmpdir(), "ingress-config-test-"));
 process.env.VELLUM_LOCKFILE_DIR = testDir;
 
-import { clearIngressUrl, saveIngressUrl } from "../lib/ingress-config.js";
+import {
+  clearIngressUrl,
+  loadLastTunnel,
+  loadRecordedAssistantId,
+  saveIngressUrl,
+} from "../lib/ingress-config.js";
 
 function writeLockfile(entry: Record<string, unknown>): void {
   writeFileSync(
@@ -99,5 +104,101 @@ describe("ingress lockfile mirroring", () => {
       saveIngressUrl(ws, "https://tunnel.example.ts.net", "no-such-assistant");
     }).not.toThrow();
     expect(readLockfileEntry().ingressUrl).toBeUndefined();
+  });
+});
+
+describe("last-tunnel record", () => {
+  function readIngress(ws: string) {
+    const config = JSON.parse(readFileSync(join(ws, "config.json"), "utf-8"));
+    return config.ingress;
+  }
+
+  test("saveIngressUrl records the provider, URL, and assistant ID", () => {
+    const ws = makeWorkspace();
+
+    saveIngressUrl(
+      ws,
+      "https://a.trycloudflare.com",
+      "ingress-test",
+      "cloudflare",
+    );
+
+    const ingress = readIngress(ws);
+    expect(ingress.publicBaseUrl).toBe("https://a.trycloudflare.com");
+    expect(ingress.lastTunnel).toEqual({
+      provider: "cloudflare",
+      publicBaseUrl: "https://a.trycloudflare.com",
+    });
+    expect(ingress.assistantId).toBe("ingress-test");
+    expect(loadLastTunnel(ws)).toEqual({
+      provider: "cloudflare",
+      publicBaseUrl: "https://a.trycloudflare.com",
+    });
+    expect(loadRecordedAssistantId(ws)).toBe("ingress-test");
+  });
+
+  test("clearIngressUrl drops the URL but keeps the tunnel and assistant records", () => {
+    const ws = makeWorkspace();
+    saveIngressUrl(
+      ws,
+      "https://tunnel.example.ts.net",
+      "ingress-test",
+      "tailscale",
+    );
+
+    clearIngressUrl(ws);
+
+    expect(readIngress(ws).publicBaseUrl).toBeUndefined();
+    expect(loadLastTunnel(ws)).toEqual({
+      provider: "tailscale",
+      publicBaseUrl: "https://tunnel.example.ts.net",
+    });
+    expect(loadRecordedAssistantId(ws)).toBe("ingress-test");
+  });
+
+  test("saving without a provider leaves an existing lastTunnel untouched", () => {
+    const ws = makeWorkspace();
+    saveIngressUrl(ws, "https://one.ngrok.app", undefined, "ngrok");
+
+    saveIngressUrl(ws, "https://two.ngrok.app");
+
+    expect(readIngress(ws).publicBaseUrl).toBe("https://two.ngrok.app");
+    expect(loadLastTunnel(ws)).toEqual({
+      provider: "ngrok",
+      publicBaseUrl: "https://one.ngrok.app",
+    });
+  });
+
+  test("loadLastTunnel returns null for missing, unknown, or empty records", () => {
+    const missing = makeWorkspace();
+    expect(loadLastTunnel(missing)).toBeNull();
+    expect(loadRecordedAssistantId(missing)).toBeNull();
+
+    saveIngressUrl(missing, "https://one.ngrok.app");
+    expect(loadLastTunnel(missing)).toBeNull();
+    expect(loadRecordedAssistantId(missing)).toBeNull();
+
+    const unknown = makeWorkspace();
+    writeFileSync(
+      join(unknown, "config.json"),
+      JSON.stringify({
+        ingress: {
+          lastTunnel: {
+            provider: "wireguard",
+            publicBaseUrl: "https://x.test",
+          },
+        },
+      }),
+    );
+    expect(loadLastTunnel(unknown)).toBeNull();
+
+    const emptyUrl = makeWorkspace();
+    writeFileSync(
+      join(emptyUrl, "config.json"),
+      JSON.stringify({
+        ingress: { lastTunnel: { provider: "ngrok", publicBaseUrl: "  " } },
+      }),
+    );
+    expect(loadLastTunnel(emptyUrl)).toBeNull();
   });
 });

--- a/cli/src/__tests__/ingress-config.test.ts
+++ b/cli/src/__tests__/ingress-config.test.ts
@@ -12,6 +12,7 @@ import {
   loadLastTunnel,
   loadRecordedAssistantId,
   saveIngressUrl,
+  TUNNEL_PROVIDERS,
 } from "../lib/ingress-config.js";
 
 function writeLockfile(entry: Record<string, unknown>): void {
@@ -200,5 +201,16 @@ describe("last-tunnel record", () => {
       }),
     );
     expect(loadLastTunnel(emptyUrl)).toBeNull();
+  });
+
+  test("every provider in the shared registry round-trips", () => {
+    for (const provider of TUNNEL_PROVIDERS) {
+      const ws = makeWorkspace();
+      saveIngressUrl(ws, `https://${provider}.test`, undefined, provider);
+      expect(loadLastTunnel(ws)).toEqual({
+        provider,
+        publicBaseUrl: `https://${provider}.test`,
+      });
+    }
   });
 });

--- a/cli/src/__tests__/ingress-config.test.ts
+++ b/cli/src/__tests__/ingress-config.test.ts
@@ -203,6 +203,24 @@ describe("last-tunnel record", () => {
     expect(loadLastTunnel(emptyUrl)).toBeNull();
   });
 
+  test("loadLastTunnel rejects a URL that is not absolute HTTP(S)", () => {
+    for (const publicBaseUrl of [
+      "not-a-url",
+      "one.ngrok.app",
+      "ftp://one.ngrok.app",
+      "https://one.ngrok.app?token=x",
+    ]) {
+      const ws = makeWorkspace();
+      writeFileSync(
+        join(ws, "config.json"),
+        JSON.stringify({
+          ingress: { lastTunnel: { provider: "ngrok", publicBaseUrl } },
+        }),
+      );
+      expect(loadLastTunnel(ws)).toBeNull();
+    }
+  });
+
   test("every provider in the shared registry round-trips", () => {
     for (const provider of TUNNEL_PROVIDERS) {
       const ws = makeWorkspace();

--- a/cli/src/__tests__/tunnel.test.ts
+++ b/cli/src/__tests__/tunnel.test.ts
@@ -891,6 +891,41 @@ describe("ngrok --domain spawn args", () => {
     }) as unknown as typeof globalThis.fetch;
   }
 
+  function readIngress(ws: string): Record<string, unknown> {
+    const config = JSON.parse(
+      readFileSync(join(ws, "config.json"), "utf-8"),
+    ) as {
+      ingress?: Record<string, unknown>;
+    };
+    return config.ingress ?? {};
+  }
+
+  /** Run `fn` against a throwaway lockfile holding one local entry. */
+  async function withLockfileFor<T>(
+    assistantId: string,
+    fn: () => Promise<T>,
+  ): Promise<T> {
+    const lockfileDir = mkdtempSync(join(tmpdir(), "vellum-ngrok-lockfile-"));
+    tempDirs.push(lockfileDir);
+    writeFileSync(
+      join(lockfileDir, ".vellum.lock.json"),
+      JSON.stringify({
+        activeAssistant: assistantId,
+        assistants: [
+          { assistantId, runtimeUrl: "http://127.0.0.1:7830", cloud: "local" },
+        ],
+      }),
+    );
+    const previous = process.env.VELLUM_LOCKFILE_DIR;
+    process.env.VELLUM_LOCKFILE_DIR = lockfileDir;
+    try {
+      return await fn();
+    } finally {
+      if (previous === undefined) delete process.env.VELLUM_LOCKFILE_DIR;
+      else process.env.VELLUM_LOCKFILE_DIR = previous;
+    }
+  }
+
   const unrelatedPortTunnel: StubTunnel = {
     public_url: "https://unrelated.ngrok.app",
     config: { addr: "localhost:65500" },
@@ -1072,6 +1107,54 @@ describe("ngrok --domain spawn args", () => {
     expect(config.ingress.publicBaseUrl).toBeUndefined();
     // …and the reserved domain stays saved as standing intent.
     expect(config.ingress.ngrok?.domain).toBe("foo.ngrok.app");
+  });
+
+  test("an adopted automatic tunnel records the assistant it fronts", async () => {
+    const ws = makeWorkspace({ telegram: { botUsername: "example_bot" } });
+    mockTunnelListFetch("https://adopted.ngrok.app", "localhost:7830");
+
+    const child = await withLockfileFor("adopt-assistant", () =>
+      realNgrok.maybeStartNgrokTunnel(7830, ws, "adopt-assistant"),
+    );
+
+    expect(child).toBeNull();
+    expect(readIngress(ws)).toMatchObject({
+      publicBaseUrl: "https://adopted.ngrok.app",
+      assistantId: "adopt-assistant",
+      lastTunnel: {
+        provider: "ngrok",
+        publicBaseUrl: "https://adopted.ngrok.app",
+      },
+    });
+  });
+
+  test("a spawned automatic tunnel records the assistant it fronts", async () => {
+    const ws = makeWorkspace({ telegram: { botUsername: "example_bot" } });
+    mockNgrokApiFetch([
+      { tunnels: [] },
+      {
+        tunnels: [
+          {
+            public_url: "https://spawned.ngrok.app",
+            config: { addr: "localhost:7830" },
+          },
+        ],
+      },
+    ]);
+
+    const child = await withLockfileFor("spawn-assistant", () =>
+      realNgrok.maybeStartNgrokTunnel(7830, ws, "spawn-assistant"),
+    );
+
+    expect(child).not.toBeNull();
+    expect(readIngress(ws)).toMatchObject({
+      publicBaseUrl: "https://spawned.ngrok.app",
+      assistantId: "spawn-assistant",
+      lastTunnel: {
+        provider: "ngrok",
+        publicBaseUrl: "https://spawned.ngrok.app",
+      },
+    });
   });
 
   test("maybeStartNgrokTunnel skips when an existing agent tunnels a different port", async () => {

--- a/cli/src/__tests__/tunnel.test.ts
+++ b/cli/src/__tests__/tunnel.test.ts
@@ -27,6 +27,7 @@ import * as ngrok from "../lib/ngrok.js";
 import * as nginxIngress from "../lib/nginx-ingress.js";
 import * as tailscaleTunnel from "../lib/tailscale-tunnel.js";
 import type { AssistantEntry } from "../lib/assistant-config.js";
+import { TUNNEL_PROVIDERS } from "../lib/ingress-config.js";
 
 const realCloudflareTunnel = { ...cloudflareTunnel };
 const realNgrok = { ...ngrok };
@@ -673,6 +674,23 @@ describe("tunnel edge targeting", () => {
     expect(errors).toContain("bun install -g vellum@latest");
     expect(runNgrokTunnelMock).not.toHaveBeenCalled();
     expect(runCloudflareTunnelMock).not.toHaveBeenCalled();
+  });
+
+  test("accepts every provider in the shared registry", async () => {
+    const logSpy = spyOn(console, "log").mockImplementation(() => {});
+    try {
+      for (const provider of TUNNEL_PROVIDERS) {
+        writeLockfile(makeLocalEntry());
+        process.argv = ["bun", "vellum", "tunnel", "--provider", provider];
+
+        const { exited, errors } = await runTunnelExpectingExit1();
+
+        expect(exited).toBe(false);
+        expect(errors).not.toContain("unknown tunnel provider");
+      }
+    } finally {
+      logSpy.mockRestore();
+    }
   });
 
   test("threads --domain through to runNgrokTunnel", async () => {

--- a/cli/src/__tests__/upgrade-local.test.ts
+++ b/cli/src/__tests__/upgrade-local.test.ts
@@ -418,6 +418,7 @@ describe("vellum upgrade local", () => {
     expect(maybeStartNgrokTunnelMock).toHaveBeenCalledWith(
       7830,
       join(tempDir, ".vellum", "workspace"),
+      "local-assistant",
     );
     expect(waitForReadyMock).toHaveBeenCalledWith("http://127.0.0.1:7830");
     expect(commitWorkspaceViaGatewayMock).toHaveBeenCalledWith(

--- a/cli/src/__tests__/wake.test.ts
+++ b/cli/src/__tests__/wake.test.ts
@@ -600,6 +600,7 @@ describe("vellum wake — tunnel edge restore", () => {
     expect(maybeStartNgrokTunnelMock).toHaveBeenCalledWith(
       7840,
       workspaceDirOf(tempDir),
+      "local-assistant",
     );
     expect(logSpy).toHaveBeenCalledWith("Wake complete.");
   });
@@ -617,6 +618,7 @@ describe("vellum wake — tunnel edge restore", () => {
     expect(maybeStartNgrokTunnelMock).toHaveBeenCalledWith(
       7840,
       workspaceDirOf(tempDir),
+      "local-assistant",
     );
     expect(logSpy).toHaveBeenCalledWith("Wake complete.");
   });
@@ -628,6 +630,7 @@ describe("vellum wake — tunnel edge restore", () => {
     expect(maybeStartNgrokTunnelMock).toHaveBeenCalledWith(
       7830,
       workspaceDirOf(tempDir),
+      "local-assistant",
     );
   });
 
@@ -640,6 +643,7 @@ describe("vellum wake — tunnel edge restore", () => {
     expect(maybeStartNgrokTunnelMock).toHaveBeenCalledWith(
       7830,
       workspaceDirOf(tempDir),
+      "local-assistant",
     );
   });
 
@@ -669,6 +673,7 @@ describe("vellum wake — tunnel edge restore", () => {
     expect(maybeStartNgrokTunnelMock).toHaveBeenCalledWith(
       7845,
       workspaceDirOf(tempDir),
+      "local-assistant",
     );
   });
 
@@ -689,6 +694,7 @@ describe("vellum wake — tunnel edge restore", () => {
     expect(maybeStartNgrokTunnelMock).toHaveBeenCalledWith(
       7840,
       workspaceDirOf(tempDir),
+      "local-assistant",
     );
   });
 
@@ -709,6 +715,7 @@ describe("vellum wake — tunnel edge restore", () => {
     expect(maybeStartNgrokTunnelMock).toHaveBeenCalledWith(
       7840,
       workspaceDirOf(tempDir),
+      "local-assistant",
     );
   });
 
@@ -746,6 +753,7 @@ describe("vellum wake — tunnel edge restore", () => {
     expect(maybeStartNgrokTunnelMock).toHaveBeenCalledWith(
       7830,
       workspaceDirOf(tempDir),
+      "local-assistant",
     );
     expect(logSpy).toHaveBeenCalledWith("Wake complete.");
   });
@@ -763,6 +771,7 @@ describe("vellum wake — tunnel edge restore", () => {
     expect(maybeStartNgrokTunnelMock).toHaveBeenCalledWith(
       7841,
       workspaceDirOf(tempDir),
+      "local-assistant",
     );
   });
 });

--- a/cli/src/commands/tunnel.ts
+++ b/cli/src/commands/tunnel.ts
@@ -11,6 +11,7 @@ import { runCloudflareTunnel } from "../lib/cloudflare-tunnel.js";
 import {
   getDefaultWorkspaceDir,
   saveNgrokDomain,
+  TUNNEL_PROVIDERS,
 } from "../lib/ingress-config.js";
 import {
   ensureTunnelEdge,
@@ -22,7 +23,10 @@ import { STALE_CLI_UPDATE_HINT } from "../lib/stale-cli-hint.js";
 import { runTailscaleTunnel } from "../lib/tailscale-tunnel.js";
 import { parseGatewayPortFromEntryUrls } from "./nginx-ingress.js";
 
-const VALID_PROVIDERS = ["vellum", "ngrok", "cloudflare", "tailscale"] as const;
+// `vellum` is the managed option this command owns; the local providers come
+// from the shared registry so validation here cannot drift from what the
+// workspace config accepts.
+const VALID_PROVIDERS = ["vellum", ...TUNNEL_PROVIDERS] as const;
 type TunnelProvider = (typeof VALID_PROVIDERS)[number];
 
 const DEFAULT_PROVIDER: TunnelProvider = "tailscale";

--- a/cli/src/lib/cloudflare-tunnel.ts
+++ b/cli/src/lib/cloudflare-tunnel.ts
@@ -219,7 +219,7 @@ export async function runCloudflareTunnel(
   console.log(`Forwarding to:     localhost:${port}`);
   console.log("");
 
-  saveIngressUrl(workspaceDir, publicUrl, opts.assistantId);
+  saveIngressUrl(workspaceDir, publicUrl, opts.assistantId, "cloudflare");
   console.log("Ingress URL saved to config.");
   console.log("");
   console.log("Press Ctrl+C to stop the tunnel and clear the ingress URL.");

--- a/cli/src/lib/ingress-config.ts
+++ b/cli/src/lib/ingress-config.ts
@@ -18,6 +18,24 @@ import {
  * no-`.vellum/`-reads boundary in cli/AGENTS.md.
  */
 
+export type TunnelProviderName = "ngrok" | "cloudflare" | "tailscale";
+
+const TUNNEL_PROVIDER_NAMES: readonly string[] = [
+  "ngrok",
+  "cloudflare",
+  "tailscale",
+];
+
+function isTunnelProviderName(value: unknown): value is TunnelProviderName {
+  return typeof value === "string" && TUNNEL_PROVIDER_NAMES.includes(value);
+}
+
+/** The tunnel that most recently ran, kept after teardown so UIs can name the command to restart. */
+export interface LastTunnelRecord {
+  provider: TunnelProviderName;
+  publicBaseUrl: string;
+}
+
 /** Default workspace dir: `$VELLUM_WORKSPACE_DIR` or `~/.vellum/workspace`. */
 export function getDefaultWorkspaceDir(): string {
   return (
@@ -38,6 +56,14 @@ export function loadRawConfig(workspaceDir: string): Record<string, unknown> {
     string,
     unknown
   >;
+}
+
+function loadIngressSection(
+  workspaceDir: string,
+): Record<string, unknown> | undefined {
+  return loadRawConfig(workspaceDir).ingress as
+    | Record<string, unknown>
+    | undefined;
 }
 
 /** Write the workspace `config.json`, creating parent directories as needed. */
@@ -68,21 +94,62 @@ function stampLockfileIngressUrl(
   saveAssistantEntry(entry);
 }
 
-/** Persist a public ingress URL to the workspace config and enable ingress. */
+/**
+ * Persist a public ingress URL to the workspace config and enable ingress.
+ * `provider`/`assistantId` also land under `ingress.lastTunnel` and
+ * `ingress.assistantId` — workspace-only records the daemon reads to report
+ * tunnel health, deliberately not mirrored onto the lockfile.
+ */
 export function saveIngressUrl(
   workspaceDir: string,
   publicUrl: string,
   assistantId?: string,
+  provider?: TunnelProviderName,
 ): void {
   const config = loadRawConfig(workspaceDir);
   const ingress = (config.ingress ?? {}) as Record<string, unknown>;
   ingress.publicBaseUrl = publicUrl;
   ingress.enabled = true;
+  if (provider) {
+    ingress.lastTunnel = {
+      provider,
+      publicBaseUrl: publicUrl,
+    } satisfies LastTunnelRecord;
+  }
+  // The daemon can't derive this: it uses 'self' internally.
+  if (assistantId) {
+    ingress.assistantId = assistantId;
+  }
   config.ingress = ingress;
   saveRawConfig(workspaceDir, config);
   if (assistantId) {
     stampLockfileIngressUrl(assistantId, publicUrl);
   }
+}
+
+/** Read the last tunnel that ran, or null when absent or malformed. */
+export function loadLastTunnel(workspaceDir: string): LastTunnelRecord | null {
+  const record = loadIngressSection(workspaceDir)?.lastTunnel as
+    | Record<string, unknown>
+    | undefined;
+  const provider = record?.provider;
+  const publicBaseUrl = record?.publicBaseUrl;
+  if (
+    !isTunnelProviderName(provider) ||
+    typeof publicBaseUrl !== "string" ||
+    !publicBaseUrl.trim()
+  ) {
+    return null;
+  }
+  return { provider, publicBaseUrl };
+}
+
+/** Read the assistant ID the last tunnel fronted, or null when absent. */
+export function loadRecordedAssistantId(workspaceDir: string): string | null {
+  const assistantId = loadIngressSection(workspaceDir)?.assistantId;
+  return typeof assistantId === "string" && assistantId.trim()
+    ? assistantId
+    : null;
 }
 
 /** Persist a reserved ngrok domain under `ingress.ngrok.domain`; null clears it. */
@@ -103,9 +170,9 @@ export function saveNgrokDomain(
 
 /** Read the reserved ngrok domain from the workspace config, if saved. */
 export function loadNgrokDomain(workspaceDir: string): string | null {
-  const config = loadRawConfig(workspaceDir);
-  const ingress = config.ingress as Record<string, unknown> | undefined;
-  const ngrok = ingress?.ngrok as Record<string, unknown> | undefined;
+  const ngrok = loadIngressSection(workspaceDir)?.ngrok as
+    | Record<string, unknown>
+    | undefined;
   const domain = ngrok?.domain;
   return typeof domain === "string" && domain.trim() ? domain : null;
 }
@@ -117,6 +184,8 @@ export function clearIngressUrl(
 ): void {
   const config = loadRawConfig(workspaceDir);
   const ingress = (config.ingress ?? {}) as Record<string, unknown>;
+  // `lastTunnel`/`assistantId` survive teardown on purpose — readers name the
+  // tunnel to restart once it is gone.
   delete ingress.publicBaseUrl;
   config.ingress = ingress;
   saveRawConfig(workspaceDir, config);

--- a/cli/src/lib/ingress-config.ts
+++ b/cli/src/lib/ingress-config.ts
@@ -18,16 +18,20 @@ import {
  * no-`.vellum/`-reads boundary in cli/AGENTS.md.
  */
 
-export type TunnelProviderName = "ngrok" | "cloudflare" | "tailscale";
+/**
+ * The local tunnel providers the CLI can start, in the order they are offered.
+ * Single source of truth: the provider type, the persisted-record validation
+ * below, and `vellum tunnel`'s accepted `--provider` values all derive from it.
+ */
+export const TUNNEL_PROVIDERS = ["ngrok", "cloudflare", "tailscale"] as const;
 
-const TUNNEL_PROVIDER_NAMES: readonly string[] = [
-  "ngrok",
-  "cloudflare",
-  "tailscale",
-];
+export type TunnelProviderName = (typeof TUNNEL_PROVIDERS)[number];
 
 function isTunnelProviderName(value: unknown): value is TunnelProviderName {
-  return typeof value === "string" && TUNNEL_PROVIDER_NAMES.includes(value);
+  return (
+    typeof value === "string" &&
+    (TUNNEL_PROVIDERS as readonly string[]).includes(value)
+  );
 }
 
 /** The tunnel that most recently ran, kept after teardown so UIs can name the command to restart. */
@@ -97,7 +101,7 @@ function stampLockfileIngressUrl(
 /**
  * Persist a public ingress URL to the workspace config and enable ingress.
  * `provider`/`assistantId` also land under `ingress.lastTunnel` and
- * `ingress.assistantId` — workspace-only records the daemon reads to report
+ * `ingress.assistantId`: workspace-only records the daemon reads to report
  * tunnel health, deliberately not mirrored onto the lockfile.
  */
 export function saveIngressUrl(
@@ -184,7 +188,7 @@ export function clearIngressUrl(
 ): void {
   const config = loadRawConfig(workspaceDir);
   const ingress = (config.ingress ?? {}) as Record<string, unknown>;
-  // `lastTunnel`/`assistantId` survive teardown on purpose — readers name the
+  // `lastTunnel`/`assistantId` survive teardown on purpose: readers name the
   // tunnel to restart once it is gone.
   delete ingress.publicBaseUrl;
   config.ingress = ingress;

--- a/cli/src/lib/ingress-config.ts
+++ b/cli/src/lib/ingress-config.ts
@@ -2,6 +2,8 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 
+import { normalizeHttpPublicBaseUrl } from "@vellumai/service-contracts/ingress";
+
 import {
   lookupAssistantByIdentifier,
   saveAssistantEntry,
@@ -138,14 +140,16 @@ export function loadLastTunnel(workspaceDir: string): LastTunnelRecord | null {
     | undefined;
   const provider = record?.provider;
   const publicBaseUrl = record?.publicBaseUrl;
+  // A hand-edited config must not hand callers an unusable address, so the URL
+  // faces the same absolute HTTP(S) constraint as every other public base URL.
   if (
     !isTunnelProviderName(provider) ||
     typeof publicBaseUrl !== "string" ||
-    !publicBaseUrl.trim()
+    !normalizeHttpPublicBaseUrl(publicBaseUrl)
   ) {
     return null;
   }
-  return { provider, publicBaseUrl };
+  return { provider, publicBaseUrl: publicBaseUrl.trim() };
 }
 
 /** Read the assistant ID the last tunnel fronted, or null when absent. */

--- a/cli/src/lib/ngrok.ts
+++ b/cli/src/lib/ngrok.ts
@@ -270,7 +270,7 @@ export async function maybeStartNgrokTunnel(
       return null;
     }
     console.log(`   Found existing ngrok tunnel: ${existingUrl}`);
-    saveIngressUrl(workspaceDir, existingUrl);
+    saveIngressUrl(workspaceDir, existingUrl, undefined, "ngrok");
     return null;
   }
   if (runningTunnels.length > 0) {
@@ -297,7 +297,7 @@ export async function maybeStartNgrokTunnel(
 
   try {
     const publicUrl = await waitForNgrokUrl(targetPort, savedDomain);
-    saveIngressUrl(workspaceDir, publicUrl);
+    saveIngressUrl(workspaceDir, publicUrl, undefined, "ngrok");
     console.log(`   Tunnel established: ${publicUrl}`);
 
     return ngrokProcess;
@@ -384,7 +384,7 @@ export async function runNgrokTunnel(
       process.exit(1);
     }
     console.log(`Found existing ngrok tunnel: ${existingUrl}`);
-    saveIngressUrl(workspaceDir, existingUrl, opts.assistantId);
+    saveIngressUrl(workspaceDir, existingUrl, opts.assistantId, "ngrok");
     if (opts.domain) {
       saveNgrokDomain(workspaceDir, opts.domain);
     }
@@ -468,7 +468,7 @@ export async function runNgrokTunnel(
 
   // The domain is standing intent, not tunnel state: cleanup clears the
   // ingress URL but leaves the domain saved for wake/daemon restores.
-  saveIngressUrl(workspaceDir, publicUrl, opts.assistantId);
+  saveIngressUrl(workspaceDir, publicUrl, opts.assistantId, "ngrok");
   if (opts.domain) {
     saveNgrokDomain(workspaceDir, opts.domain);
   }

--- a/cli/src/lib/ngrok.ts
+++ b/cli/src/lib/ngrok.ts
@@ -235,11 +235,15 @@ function hasNonNgrokIngressUrl(workspaceDir: string): boolean {
  * non-ngrok ingress URL is present. Designed to be called during daemon/gateway
  * startup. Non-fatal: if ngrok is unavailable or fails, startup continues.
  *
+ * `assistantId` is what the recorded tunnel fronts — without it an automatic
+ * start would leave `ingress.assistantId` absent or stale from an earlier run.
+ *
  * Returns the spawned ngrok child process (for PID tracking) or null.
  */
 export async function maybeStartNgrokTunnel(
   targetPort: number,
   workspaceDir: string,
+  assistantId?: string,
 ): Promise<ChildProcess | null> {
   // Managed/containerized deployments route webhooks through the platform's
   // callback proxy. ngrok is not needed and would not be reachable from the
@@ -270,7 +274,7 @@ export async function maybeStartNgrokTunnel(
       return null;
     }
     console.log(`   Found existing ngrok tunnel: ${existingUrl}`);
-    saveIngressUrl(workspaceDir, existingUrl, undefined, "ngrok");
+    saveIngressUrl(workspaceDir, existingUrl, assistantId, "ngrok");
     return null;
   }
   if (runningTunnels.length > 0) {
@@ -297,7 +301,7 @@ export async function maybeStartNgrokTunnel(
 
   try {
     const publicUrl = await waitForNgrokUrl(targetPort, savedDomain);
-    saveIngressUrl(workspaceDir, publicUrl, undefined, "ngrok");
+    saveIngressUrl(workspaceDir, publicUrl, assistantId, "ngrok");
     console.log(`   Tunnel established: ${publicUrl}`);
 
     return ngrokProcess;

--- a/cli/src/lib/ngrok.ts
+++ b/cli/src/lib/ngrok.ts
@@ -235,8 +235,8 @@ function hasNonNgrokIngressUrl(workspaceDir: string): boolean {
  * non-ngrok ingress URL is present. Designed to be called during daemon/gateway
  * startup. Non-fatal: if ngrok is unavailable or fails, startup continues.
  *
- * `assistantId` is what the recorded tunnel fronts — without it an automatic
- * start would leave `ingress.assistantId` absent or stale from an earlier run.
+ * `assistantId` records what the tunnel fronts. Without it, an automatic start
+ * would leave `ingress.assistantId` absent or stale from an earlier run.
  *
  * Returns the spawned ngrok child process (for PID tracking) or null.
  */

--- a/cli/src/lib/tailscale-tunnel.ts
+++ b/cli/src/lib/tailscale-tunnel.ts
@@ -213,7 +213,7 @@ export async function startTailscaleServe(
     throw new Error(serveFailureMessage(serveResult));
   }
 
-  saveIngressUrl(workspaceDir, publicUrl, opts.assistantId);
+  saveIngressUrl(workspaceDir, publicUrl, opts.assistantId, "tailscale");
 
   return { publicUrl, port, binary, workspaceDir };
 }

--- a/cli/src/lib/tunnel-edge.ts
+++ b/cli/src/lib/tunnel-edge.ts
@@ -102,5 +102,5 @@ export async function restoreTunnelEdgeAndAutoTunnel(
       );
     }
   }
-  return maybeStartNgrokTunnel(tunnelTargetPort, workspaceDir);
+  return maybeStartNgrokTunnel(tunnelTargetPort, workspaceDir, assistantId);
 }


### PR DESCRIPTION
## Summary

- `saveIngressUrl()` takes an optional `provider` and now records `ingress.lastTunnel = { provider, publicBaseUrl }` plus `ingress.assistantId` in the workspace config; both survive `clearIngressUrl()` so a reader can still name the tunnel to restart after teardown. The lockfile `ingressUrl` mirror is unchanged — `lastTunnel` is workspace-config-only state for the daemon.
- Adds `loadLastTunnel()` and `loadRecordedAssistantId()`, which validate the provider name and URL and return `null` rather than throwing on a hand-edited config.
- The tailscale, ngrok, and cloudflare modules each stamp their own provider name; unit tests cover save/clear/load and the malformed-record cases.

Part of plan: tunnel-status-pairing.md (PR 1 of 9)