### PR TITLE
feat(cli): include the assistant id in the served remote-web edge config

### DIFF
--- a/cli/src/__tests__/nginx-ingress.test.ts
+++ b/cli/src/__tests__/nginx-ingress.test.ts
@@ -269,20 +269,22 @@ describe("buildIngressNginxConfig", () => {
     expect(remoteConf).toContain(
       'return 200 "{\\"mode\\":\\"remote-gateway\\",\\"apiBaseUrl\\":\\"/v1\\",\\"platformDisabled\\":true,\\"disablePlatform\\":true}";',
     );
+    expect(remoteConf).not.toContain("assistantId");
   });
 
-  test("stamps assistantName and hubUrl into the served config when provided", () => {
+  test("stamps assistantName, assistantId and hubUrl into the served config when provided", () => {
     const named = buildIngressNginxConfig({
       gatewayPort: 7830,
       listenPort: 7840,
       remoteWebIngress: {
         webDistDir: "/tmp/vellum web/dist",
         assistantName: "Homelab",
+        assistantId: "assistant-1",
         hubUrl: "https://www.vellum.ai/assistant",
       },
     });
     expect(named).toContain(
-      'return 200 "{\\"mode\\":\\"remote-gateway\\",\\"apiBaseUrl\\":\\"/v1\\",\\"platformDisabled\\":true,\\"disablePlatform\\":true,\\"assistantName\\":\\"Homelab\\",\\"hubUrl\\":\\"https://www.vellum.ai/assistant\\"}";',
+      'return 200 "{\\"mode\\":\\"remote-gateway\\",\\"apiBaseUrl\\":\\"/v1\\",\\"platformDisabled\\":true,\\"disablePlatform\\":true,\\"assistantName\\":\\"Homelab\\",\\"assistantId\\":\\"assistant-1\\",\\"hubUrl\\":\\"https://www.vellum.ai/assistant\\"}";',
     );
   });
 
@@ -723,17 +725,20 @@ const PRODUCTION_HUB_URL = "https://www.vellum.ai/assistant";
  * both the injected config shape and the hash format; assumes the
  * production-pinned environment. `template` tracks `EDGE_TEMPLATE_VERSION`.
  */
-function spaConfigHash(assistantName?: string): string {
+function spaConfigHash(
+  opts: { assistantName?: string; assistantId?: string } = {},
+): string {
   return createHash("sha256")
     .update(
       JSON.stringify({
-        template: 3,
+        template: 4,
         config: {
           mode: "remote-gateway",
           apiBaseUrl: "/v1",
           platformDisabled: true,
           disablePlatform: true,
-          ...(assistantName ? { assistantName } : {}),
+          ...(opts.assistantName ? { assistantName: opts.assistantName } : {}),
+          ...(opts.assistantId ? { assistantId: opts.assistantId } : {}),
           hubUrl: PRODUCTION_HUB_URL,
         },
       }),
@@ -1109,7 +1114,7 @@ describe("startRemoteWebIngress", () => {
       listenPort: 7845,
       includeWebApp: true,
       gatewayPort: 7830,
-      remoteWebConfigHash: spaConfigHash("My Homelab"),
+      remoteWebConfigHash: spaConfigHash({ assistantName: "My Homelab" }),
     });
     const edge = mockKillableNginx(pid);
 
@@ -1139,7 +1144,7 @@ describe("startRemoteWebIngress", () => {
       listenPort: 7845,
       includeWebApp: true,
       gatewayPort: 7830,
-      remoteWebConfigHash: spaConfigHash("Old Name"),
+      remoteWebConfigHash: spaConfigHash({ assistantName: "Old Name" }),
     });
     const edge = mockKillableNginx(pid);
 
@@ -1162,7 +1167,7 @@ describe("startRemoteWebIngress", () => {
       listenPort: 7845,
       includeWebApp: true,
       gatewayPort: 7830,
-      remoteWebConfigHash: spaConfigHash("New Name"),
+      remoteWebConfigHash: spaConfigHash({ assistantName: "New Name" }),
     });
   });
 
@@ -1248,7 +1253,7 @@ describe("startRemoteWebIngress", () => {
       listenPort: 7845,
       includeWebApp: true,
       gatewayPort: 7830,
-      remoteWebConfigHash: spaConfigHash("Old Name"),
+      remoteWebConfigHash: spaConfigHash({ assistantName: "Old Name" }),
     });
     mockUnkillableNginx(pid);
 
@@ -1573,7 +1578,7 @@ describe("ensureTunnelEdge", () => {
     }
   });
 
-  test("threads the lockfile display name into the served SPA config", async () => {
+  test("threads the lockfile display name and assistant id into the served SPA config", async () => {
     const ws = makeWorkspace();
     mockNginxInstalled();
     mockNginxSpawn();
@@ -1606,6 +1611,7 @@ describe("ensureTunnelEdge", () => {
       "utf-8",
     );
     expect(indexHtml).toContain('"assistantName":"Homelab"');
+    expect(indexHtml).toContain(`"assistantId":"${ASSISTANT_ID}"`);
     expect(indexHtml).toContain(`"hubUrl":"${PRODUCTION_HUB_URL}"`);
   });
 
@@ -1627,6 +1633,7 @@ describe("ensureTunnelEdge", () => {
       "utf-8",
     );
     expect(indexHtml).not.toContain("assistantName");
+    expect(indexHtml).toContain(`"assistantId":"${ASSISTANT_ID}"`);
     expect(indexHtml).toContain(`"hubUrl":"${PRODUCTION_HUB_URL}"`);
   });
 
@@ -1638,7 +1645,7 @@ describe("ensureTunnelEdge", () => {
       listenPort: 7845,
       includeWebApp: true,
       gatewayPort: 7830,
-      remoteWebConfigHash: spaConfigHash(),
+      remoteWebConfigHash: spaConfigHash({ assistantId: ASSISTANT_ID }),
     });
     const edge = mockKillableNginx(pid);
 
@@ -1715,7 +1722,10 @@ describe("ensureTunnelEdge", () => {
       listenPort: REQUESTED_PORT,
       includeWebApp: true,
       gatewayPort: 7830,
-      remoteWebConfigHash: spaConfigHash("Stale Name"),
+      remoteWebConfigHash: spaConfigHash({
+        assistantName: "Stale Name",
+        assistantId: ASSISTANT_ID,
+      }),
     });
     mockUnkillableNginx(pid);
 
@@ -1762,7 +1772,7 @@ describe("ensureTunnelEdge", () => {
       listenPort: 7845,
       includeWebApp: true,
       gatewayPort: 7900,
-      remoteWebConfigHash: spaConfigHash(),
+      remoteWebConfigHash: spaConfigHash({ assistantId: ASSISTANT_ID }),
     });
     mockUnkillableNginx(pid);
 
@@ -1788,7 +1798,7 @@ describe("ensureTunnelEdge", () => {
       listenPort: 7845,
       includeWebApp: true,
       gatewayPort: 7900,
-      remoteWebConfigHash: spaConfigHash(),
+      remoteWebConfigHash: spaConfigHash({ assistantId: ASSISTANT_ID }),
     });
     const edge = mockKillableNginx(pid);
 
@@ -1856,7 +1866,7 @@ describe("ensureTunnelEdge", () => {
       listenPort: REQUESTED_PORT,
       includeWebApp: true,
       gatewayPort: 7830,
-      remoteWebConfigHash: spaConfigHash(),
+      remoteWebConfigHash: spaConfigHash({ assistantId: ASSISTANT_ID }),
     });
   });
 
@@ -1906,6 +1916,7 @@ describe("ensureTunnelEdge", () => {
     });
     const conf = realFs.readFileSync(ingressConfPath(ws), "utf-8");
     expect(conf).toContain("location ^~ /assistant/ {");
+    expect(conf).not.toContain("assistantId");
   });
 
   test("missing nginx throws with install instructions", async () => {

--- a/cli/src/lib/nginx-ingress.ts
+++ b/cli/src/lib/nginx-ingress.ts
@@ -132,6 +132,10 @@ export interface RemoteWebIngressOptions {
   /** Serving assistant's display name, stamped into the served config so
    *  remote clients can label this origin. Absent in older served configs. */
   assistantName?: string;
+  /** Serving assistant's id, stamped into the served config so a caller can
+   *  confirm which assistant an edge is fronting. Absent in older served
+   *  configs. */
+  assistantId?: string;
   /** Cloud web SPA base the remote client can hand this origin to (see
    *  `cloudWebHubUrl`). Absent in older served configs. */
   hubUrl?: string;
@@ -147,7 +151,10 @@ export function cloudWebHubUrl(env: string | undefined): string {
 }
 
 function remoteWebIngressConfig(
-  opts: Pick<RemoteWebIngressOptions, "config" | "assistantName" | "hubUrl">,
+  opts: Pick<
+    RemoteWebIngressOptions,
+    "config" | "assistantName" | "assistantId" | "hubUrl"
+  >,
 ): Record<string, unknown> {
   return {
     mode: "remote-gateway",
@@ -155,6 +162,7 @@ function remoteWebIngressConfig(
     platformDisabled: true,
     disablePlatform: true,
     ...(opts.assistantName ? { assistantName: opts.assistantName } : {}),
+    ...(opts.assistantId ? { assistantId: opts.assistantId } : {}),
     ...(opts.hubUrl ? { hubUrl: opts.hubUrl } : {}),
     ...opts.config,
   };
@@ -165,7 +173,7 @@ function remoteWebIngressConfig(
  * fingerprint matches, so this must change whenever the generated index or
  * nginx template does.
  */
-const EDGE_TEMPLATE_VERSION = 3;
+const EDGE_TEMPLATE_VERSION = 4;
 
 /**
  * Stable fingerprint of the SPA config injected into the served index and
@@ -748,6 +756,12 @@ export async function startRemoteWebIngress(opts: {
    */
   assistantName?: string;
   /**
+   * Serving assistant's id, stamped into the served remote-web config
+   * (`__VELLUM_CONFIG__.assistantId`) so a caller probing this origin can
+   * confirm which assistant the edge fronts. Omitted when unknown.
+   */
+  assistantId?: string;
+  /**
    * Invoked once, after every preflight check passes and immediately before
    * nginx is spawned, so callers can emit their own "starting" progress line
    * with the resolved version/dist/port (webDistDir is null in webhooks-only
@@ -777,6 +791,7 @@ export async function startRemoteWebIngress(opts: {
     ? {
         hubUrl: cloudWebHubUrl(getCurrentEnvironment().name),
         ...(opts.assistantName ? { assistantName: opts.assistantName } : {}),
+        ...(opts.assistantId ? { assistantId: opts.assistantId } : {}),
       }
     : undefined;
   const requestedConfigHash = spaOptions
@@ -953,6 +968,7 @@ export async function ensureTunnelEdge(opts: {
     gatewayPort: opts.gatewayPort,
     includeWebApp: true,
     ...(assistantName ? { assistantName } : {}),
+    ...(opts.assistantId ? { assistantId: opts.assistantId } : {}),
     ...(opts.onStarting ? { onStarting: opts.onStarting } : {}),
   });
 


### PR DESCRIPTION
## Summary

- Stamp `assistantId` into the remote-web SPA config the nginx edge injects into the served index and returns from `GET /assistant/__config`, so a caller probing a tunnel's public URL can confirm which assistant the edge fronts. Threaded from `ensureTunnelEdge` (which already resolves the id) through `startRemoteWebIngress`; the key is omitted entirely when the id is unknown, so older served configs stay valid.
- Bump `EDGE_TEMPLATE_VERSION` 3 → 4. `remoteWebConfigFingerprint()` mixes the template version into the reuse/restart decision, so without the bump an edge started before this change would be reused and keep serving a config with no `assistantId`.
- Extend the nginx-ingress tests to assert the id is present when supplied and the key is absent when not; the `spaConfigHash` test helper now takes an options object instead of positional optionals.

Part of plan: tunnel-status-pairing.md (PR 2 of 9)