### PR TITLE
feat(web): add the tunnel status row component

### DIFF
--- a/clients/web/src/domains/settings/pair-device/tunnel-status-row.test.tsx
+++ b/clients/web/src/domains/settings/pair-device/tunnel-status-row.test.tsx
@@ -1,0 +1,144 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import { TunnelStatusRow, type TunnelStatusView } from "./tunnel-status-row";
+
+const PUBLIC_URL = "https://foo.ts.net";
+const REFRESH_LABEL = "Check the tunnel again";
+
+function renderRow(
+  status: TunnelStatusView,
+  { isRefreshing = false }: { isRefreshing?: boolean } = {},
+) {
+  const calls: number[] = [];
+  const result = render(
+    <TunnelStatusRow
+      status={status}
+      onRefresh={() => calls.push(1)}
+      isRefreshing={isRefreshing}
+    />,
+  );
+  return { calls, result };
+}
+
+function refreshButton(): HTMLButtonElement {
+  return screen.getByRole("button", { name: REFRESH_LABEL });
+}
+
+afterEach(cleanup);
+
+describe("TunnelStatusRow", () => {
+  test("renders nothing while the tunnel was never configured", () => {
+    const { result } = renderRow({ kind: "unconfigured" });
+    expect(result.container.innerHTML).toBe("");
+  });
+
+  test("names the probe in flight and disables the refresh", () => {
+    renderRow({ kind: "checking" });
+
+    expect(
+      screen.getByText("Checking whether the tunnel is reachable…"),
+    ).toBeDefined();
+    expect(refreshButton().disabled).toBe(true);
+  });
+
+  test("reports a healthy tunnel with its address and check age", () => {
+    renderRow({
+      kind: "healthy",
+      publicBaseUrl: PUBLIC_URL,
+      checkedAt: new Date(Date.now() - 5_000).toISOString(),
+    });
+
+    expect(
+      screen.getByText("The tunnel is running and reachable."),
+    ).toBeDefined();
+    expect(screen.getByText(PUBLIC_URL)).toBeDefined();
+    expect(screen.getByText("Checked 5 seconds ago")).toBeDefined();
+  });
+
+  test("reports an unreachable address", () => {
+    renderRow({
+      kind: "unreachable",
+      publicBaseUrl: PUBLIC_URL,
+      checkedAt: new Date().toISOString(),
+    });
+
+    expect(
+      screen.getByText("This address is not answering right now."),
+    ).toBeDefined();
+    expect(screen.getByText(PUBLIC_URL)).toBeDefined();
+  });
+
+  test("names the assistant a foreign edge is serving", () => {
+    renderRow({
+      kind: "foreign",
+      publicBaseUrl: PUBLIC_URL,
+      checkedAt: new Date().toISOString(),
+      servingAssistantName: "Jarvis",
+    });
+
+    expect(
+      screen.getByText(
+        "This address is serving Jarvis right now, not this assistant.",
+      ),
+    ).toBeDefined();
+  });
+
+  test("falls back to an unnamed foreign edge", () => {
+    renderRow({
+      kind: "foreign",
+      publicBaseUrl: PUBLIC_URL,
+      checkedAt: new Date().toISOString(),
+    });
+
+    expect(
+      screen.getByText(
+        "This address is serving a different assistant right now.",
+      ),
+    ).toBeDefined();
+  });
+
+  test("prints the provider's restart command when the tunnel is stopped", () => {
+    renderRow({
+      kind: "stopped",
+      provider: "cloudflare",
+      publicBaseUrl: PUBLIC_URL,
+    });
+
+    expect(
+      screen.getByText(
+        "The tunnel is stopped, so other devices cannot reach this assistant.",
+      ),
+    ).toBeDefined();
+    expect(
+      screen.getByText("vellum tunnel --provider cloudflare"),
+    ).toBeDefined();
+    expect(screen.getByText(PUBLIC_URL)).toBeDefined();
+  });
+
+  test("refreshing calls back to the owner", () => {
+    const { calls } = renderRow({
+      kind: "healthy",
+      publicBaseUrl: PUBLIC_URL,
+      checkedAt: new Date().toISOString(),
+    });
+
+    fireEvent.click(refreshButton());
+
+    expect(calls.length).toBe(1);
+  });
+
+  test("disables the refresh while a refetch is in flight", () => {
+    renderRow(
+      {
+        kind: "unreachable",
+        publicBaseUrl: PUBLIC_URL,
+        checkedAt: new Date().toISOString(),
+      },
+      { isRefreshing: true },
+    );
+
+    expect(refreshButton().disabled).toBe(true);
+  });
+});

--- a/clients/web/src/domains/settings/pair-device/tunnel-status-row.tsx
+++ b/clients/web/src/domains/settings/pair-device/tunnel-status-row.tsx
@@ -1,0 +1,149 @@
+import { Button } from "@vellumai/design-library/components/button";
+import { RefreshCw } from "lucide-react";
+
+import { currentLocale, Trans, type TFunction, useTranslation } from "@/i18n";
+import { formatRelativeTime } from "@/lib/relative-time";
+
+/**
+ * What the Pair-a-device card knows about the tunnel right now. Local to this
+ * component rather than the generated SDK type: the row is presentation, and
+ * the hook that talks to the daemon maps the wire response onto it.
+ */
+export type TunnelStatusView =
+  | { kind: "checking" }
+  | { kind: "unconfigured" }
+  | { kind: "stopped"; provider: string; publicBaseUrl: string }
+  | { kind: "healthy"; publicBaseUrl: string; checkedAt: string }
+  | { kind: "unreachable"; publicBaseUrl: string; checkedAt: string }
+  | {
+      kind: "foreign";
+      publicBaseUrl: string;
+      checkedAt: string;
+      servingAssistantName?: string;
+    };
+
+/** Every state the row actually draws; `unconfigured` renders nothing. */
+type RenderedTunnelStatus = Exclude<TunnelStatusView, { kind: "unconfigured" }>;
+
+interface TunnelStatusRowProps {
+  status: TunnelStatusView;
+  /** Re-runs the daemon-side probe. The row owns no fetching of its own. */
+  onRefresh: () => void;
+  isRefreshing: boolean;
+}
+
+const DOT_COLOR: Record<RenderedTunnelStatus["kind"], string> = {
+  checking: "var(--content-tertiary)",
+  stopped: "var(--content-tertiary)",
+  healthy: "var(--system-positive-strong)",
+  unreachable: "var(--system-mid-strong)",
+  foreign: "var(--system-negative-strong)",
+};
+
+/** The command that restarts the tunnel the stopped record came from. */
+function restartCommand(provider: string): string {
+  return `vellum tunnel --provider ${provider}`;
+}
+
+/**
+ * One compact line reporting whether this assistant's public address is
+ * actually serving it: a tone dot, a sentence, the address, when it was last
+ * checked, and a manual re-check.
+ *
+ * Pure by design: props in, markup out. Fetching, the `app.resume` re-check
+ * and any polling belong to the card above it, per `docs/EVENT_BUS.md`.
+ * Renders nothing for `unconfigured`, which the card covers with its
+ * first-run notice.
+ */
+export function TunnelStatusRow({
+  status,
+  onRefresh,
+  isRefreshing,
+}: TunnelStatusRowProps) {
+  const { t } = useTranslation("settings");
+
+  if (status.kind === "unconfigured") {
+    return null;
+  }
+
+  const busy = status.kind === "checking" || isRefreshing;
+  const checkedAt = "checkedAt" in status ? status.checkedAt : null;
+  const publicBaseUrl = "publicBaseUrl" in status ? status.publicBaseUrl : null;
+
+  return (
+    <div className="flex items-start gap-2.5 rounded-lg border border-[var(--border-element)] px-3 py-2.5">
+      <span
+        aria-hidden
+        className="mt-1.5 inline-block h-2 w-2 shrink-0 rounded-full"
+        style={{ backgroundColor: DOT_COLOR[status.kind] }}
+      />
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        <p className="text-body-small-default text-[var(--content-default)]">
+          {statusSentence(status, t)}
+        </p>
+        {status.kind === "stopped" && (
+          <p className="text-body-small-default text-[var(--content-tertiary)]">
+            <Trans
+              i18nKey="tunnelStatusRow.stoppedRestart"
+              ns="settings"
+              values={{ command: restartCommand(status.provider) }}
+              components={{
+                code: (
+                  <code className="rounded-md bg-[var(--surface-active)] px-1.5 py-0.5 text-[color:var(--content-primary)]" />
+                ),
+              }}
+            />
+          </p>
+        )}
+        {publicBaseUrl && (
+          <p
+            className="truncate text-body-small-default text-[var(--content-tertiary)]"
+            title={publicBaseUrl}
+          >
+            {publicBaseUrl}
+          </p>
+        )}
+        {checkedAt && (
+          <p className="text-body-small-default text-[var(--content-tertiary)]">
+            {t("tunnelStatusRow.checkedAt", {
+              when: formatRelativeTime(new Date(checkedAt).getTime(), {
+                locale: currentLocale(),
+              }),
+            })}
+          </p>
+        )}
+      </div>
+      <Button
+        variant="ghost"
+        size="compact"
+        iconOnly={<RefreshCw className={busy ? "animate-spin" : undefined} />}
+        aria-label={t("tunnelStatusRow.refreshLabel")}
+        disabled={busy}
+        onClick={onRefresh}
+      />
+    </div>
+  );
+}
+
+/** Keys are written out per state so the catalog's orphan check can see them. */
+function statusSentence(
+  status: RenderedTunnelStatus,
+  t: TFunction<"settings">,
+): string {
+  switch (status.kind) {
+    case "checking":
+      return t("tunnelStatusRow.checkingStatus");
+    case "stopped":
+      return t("tunnelStatusRow.stoppedStatus");
+    case "healthy":
+      return t("tunnelStatusRow.healthyStatus");
+    case "unreachable":
+      return t("tunnelStatusRow.unreachableStatus");
+    case "foreign":
+      return status.servingAssistantName
+        ? t("tunnelStatusRow.foreignStatusNamed", {
+            name: status.servingAssistantName,
+          })
+        : t("tunnelStatusRow.foreignStatus");
+  }
+}

--- a/clients/web/src/i18n/locales/en/settings.json
+++ b/clients/web/src/i18n/locales/en/settings.json
@@ -938,6 +938,17 @@
     "subtitle": "Configure how your assistant speaks",
     "title": "Text-to-Speech"
   },
+  "tunnelStatusRow": {
+    "checkedAt": "Checked {when}",
+    "checkingStatus": "Checking whether the tunnel is reachable…",
+    "foreignStatus": "This address is serving a different assistant right now.",
+    "foreignStatusNamed": "This address is serving {name} right now, not this assistant.",
+    "healthyStatus": "The tunnel is running and reachable.",
+    "refreshLabel": "Check the tunnel again",
+    "stoppedRestart": "Run <code>{command}</code> in a terminal on this computer to start it again.",
+    "stoppedStatus": "The tunnel is stopped, so other devices cannot reach this assistant.",
+    "unreachableStatus": "This address is not answering right now."
+  },
   "upgradeCancelPage": {
     "billingUnavailable": "Billing isn't available for the current assistant state.",
     "platformLoginNotice": "Log in to the Vellum platform to manage billing and usage.",

--- a/clients/web/src/i18n/locales/es/settings.json
+++ b/clients/web/src/i18n/locales/es/settings.json
@@ -938,6 +938,17 @@
     "subtitle": "Configura cómo habla tu asistente",
     "title": "Texto a voz"
   },
+  "tunnelStatusRow": {
+    "checkedAt": "Comprobado {when}",
+    "checkingStatus": "Comprobando si el túnel es accesible…",
+    "foreignStatus": "Esta dirección está sirviendo a otro asistente ahora mismo.",
+    "foreignStatusNamed": "Esta dirección está sirviendo a {name} ahora mismo, no a este asistente.",
+    "healthyStatus": "El túnel está en marcha y es accesible.",
+    "refreshLabel": "Comprobar el túnel de nuevo",
+    "stoppedRestart": "Ejecuta <code>{command}</code> en una terminal de este equipo para volver a iniciarlo.",
+    "stoppedStatus": "El túnel está detenido, por lo que otros dispositivos no pueden alcanzar este asistente.",
+    "unreachableStatus": "Esta dirección no responde ahora mismo."
+  },
   "upgradeCancelPage": {
     "billingUnavailable": "La facturación no está disponible para el estado actual del asistente.",
     "platformLoginNotice": "Inicie sesión en la plataforma Vellum para administrar facturación y uso.",


### PR DESCRIPTION
## Summary

- Adds `TunnelStatusRow`, a pure presentational row for the Pair-a-device card: a tone dot, one complete status sentence, the public address, a relative "Checked ..." stamp, and a manual re-check button. Props in, markup out: no queries, no timers, no bus subscriptions.
- Exports a local `TunnelStatusView` union (checking / unconfigured / stopped / healthy / unreachable / foreign) so the row lands before the daemon route exists; PR 7 maps the wire response onto it. `unconfigured` renders nothing, since the card keeps owning the first-run notice from #41092.
- Catalog copy under `tunnelStatusRow.*` in `en` and `es`. The stopped state's restart hint goes through `<Trans>` with a `<code>` placeholder rather than concatenating a fragment with an element, and the check age is formatted with the shared `Intl.RelativeTimeFormat` helper (`lib/relative-time`).

Design library note: there is no `IconButton` primitive, so the refresh affordance is `Button` with `iconOnly` (lucide `RefreshCw`), which is the documented icon-only shape. It is disabled and its icon spins while `checking` or `isRefreshing`.

Part of plan: tunnel-status-pairing.md (PR 6 of 9)