### PR TITLE
feat(assistant): add a tunnel reachability probe

### DIFF
--- a/assistant/src/inbound/__tests__/tunnel-probe.test.ts
+++ b/assistant/src/inbound/__tests__/tunnel-probe.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Tests for the tunnel reachability probe.
+ *
+ * Two properties carry the feature. First, healthy means the whole chain is
+ * live, so an edge whose nginx answers while the gateway behind it does not
+ * must read `unreachable`. Second, `foreign` is an accusation ("this URL now
+ * fronts someone else's assistant"), so it is reserved for a positive
+ * mismatch of two known ids and every skew case reads `healthy`.
+ *
+ * Every case injects `fetchImpl`, so nothing here touches the network.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { probeTunnel } from "../tunnel-probe.js";
+
+const BASE = "https://edge.example";
+
+type Route = { status?: number; body?: string };
+
+/** `typeof fetch` carries extras (e.g. `preconnect`) a stub has no use for. */
+function asFetch(
+  stub: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>,
+): typeof fetch {
+  return stub as unknown as typeof fetch;
+}
+
+/** Serves canned responses per path, and records the URLs it was asked for. */
+function stubFetch(routes: { healthz?: Route; config?: Route }): {
+  fetchImpl: typeof fetch;
+  urls: string[];
+} {
+  const urls: string[] = [];
+  const fetchImpl = asFetch(async (input) => {
+    const url = String(input);
+    urls.push(url);
+    const route = url.endsWith("/healthz")
+      ? (routes.healthz ?? { status: 200, body: "ok" })
+      : (routes.config ?? { status: 200, body: "{}" });
+    return new Response(route.body ?? "", { status: route.status ?? 200 });
+  });
+  return { fetchImpl, urls };
+}
+
+function configBody(config: Record<string, unknown>): Route {
+  return { status: 200, body: JSON.stringify(config) };
+}
+
+describe("probeTunnel", () => {
+  test("probes both the gateway path and the served config", async () => {
+    const { fetchImpl, urls } = stubFetch({});
+    await probeTunnel({ publicBaseUrl: `${BASE}/`, fetchImpl });
+    expect(urls.sort()).toEqual([
+      `${BASE}/assistant/__config`,
+      `${BASE}/healthz`,
+    ]);
+  });
+
+  test("healthy when the served id matches the recorded one", async () => {
+    const { fetchImpl } = stubFetch({
+      config: configBody({ assistantId: "asst_1", assistantName: "Ada" }),
+    });
+    await expect(
+      probeTunnel({
+        publicBaseUrl: BASE,
+        expectedAssistantId: "asst_1",
+        fetchImpl,
+      }),
+    ).resolves.toEqual({
+      kind: "healthy",
+      assistantId: "asst_1",
+      assistantName: "Ada",
+    });
+  });
+
+  test("healthy when the edge serves no id (edge predates the id)", async () => {
+    const { fetchImpl } = stubFetch({
+      config: configBody({ assistantName: "Ada" }),
+    });
+    await expect(
+      probeTunnel({
+        publicBaseUrl: BASE,
+        expectedAssistantId: "asst_1",
+        fetchImpl,
+      }),
+    ).resolves.toEqual({
+      kind: "healthy",
+      assistantId: undefined,
+      assistantName: "Ada",
+    });
+  });
+
+  test("healthy when no id was recorded, even though the edge serves one", async () => {
+    const { fetchImpl } = stubFetch({
+      config: configBody({ assistantId: "asst_2", assistantName: "Grace" }),
+    });
+    await expect(
+      probeTunnel({ publicBaseUrl: BASE, fetchImpl }),
+    ).resolves.toEqual({
+      kind: "healthy",
+      assistantId: "asst_2",
+      assistantName: "Grace",
+    });
+  });
+
+  test("foreign when two known ids differ", async () => {
+    const { fetchImpl } = stubFetch({
+      config: configBody({ assistantId: "asst_2", assistantName: "Grace" }),
+    });
+    await expect(
+      probeTunnel({
+        publicBaseUrl: BASE,
+        expectedAssistantId: "asst_1",
+        fetchImpl,
+      }),
+    ).resolves.toEqual({
+      kind: "foreign",
+      assistantId: "asst_2",
+      assistantName: "Grace",
+    });
+  });
+
+  test("healthy when the config body is not JSON", async () => {
+    const { fetchImpl } = stubFetch({
+      config: { status: 200, body: "<html>nope</html>" },
+    });
+    await expect(
+      probeTunnel({
+        publicBaseUrl: BASE,
+        expectedAssistantId: "asst_1",
+        fetchImpl,
+      }),
+    ).resolves.toEqual({
+      kind: "healthy",
+      assistantId: undefined,
+      assistantName: undefined,
+    });
+  });
+
+  test("unreachable when the request rejects", async () => {
+    const fetchImpl = asFetch(async () => {
+      throw new TypeError("Unable to connect");
+    });
+    await expect(
+      probeTunnel({ publicBaseUrl: BASE, fetchImpl }),
+    ).resolves.toEqual({ kind: "unreachable", detail: "Unable to connect" });
+  });
+
+  test("unreachable when nginx answers but the gateway is down", async () => {
+    const { fetchImpl } = stubFetch({
+      healthz: { status: 502, body: "bad gateway" },
+      config: configBody({ assistantId: "asst_1" }),
+    });
+    await expect(
+      probeTunnel({
+        publicBaseUrl: BASE,
+        expectedAssistantId: "asst_1",
+        fetchImpl,
+      }),
+    ).resolves.toEqual({ kind: "unreachable", detail: "HTTP 502" });
+  });
+
+  test("unreachable when the probe times out", async () => {
+    const fetchImpl = asFetch(
+      (_input, init) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(init.signal?.reason);
+          });
+        }),
+    );
+    await expect(
+      probeTunnel({ publicBaseUrl: BASE, timeoutMs: 5, fetchImpl }),
+    ).resolves.toEqual({ kind: "unreachable", detail: "timeout" });
+  });
+
+  test("keeps the probed URL out of the failure detail", async () => {
+    const fetchImpl = asFetch(async (input) => {
+      throw new TypeError(`Failed to parse URL from ${String(input)}`);
+    });
+    const result = await probeTunnel({ publicBaseUrl: BASE, fetchImpl });
+    expect(result.kind).toEqual("unreachable");
+    expect(result).toHaveProperty("detail");
+    expect((result as { detail: string }).detail).not.toContain(BASE);
+  });
+
+  test("unreachable when there is no URL to probe", async () => {
+    const { fetchImpl, urls } = stubFetch({});
+    const result = await probeTunnel({ publicBaseUrl: "   ", fetchImpl });
+    expect(result).toEqual({
+      kind: "unreachable",
+      detail: "no public base URL",
+    });
+    expect(urls).toEqual([]);
+  });
+});

--- a/assistant/src/inbound/tunnel-probe.ts
+++ b/assistant/src/inbound/tunnel-probe.ts
@@ -1,0 +1,135 @@
+/**
+ * Reachability probe for the public URL a tunnel exposes.
+ *
+ * A tunnel's public URL is recorded in the workspace config, but a recorded
+ * URL says nothing about whether anything still answers on it: the tunnel
+ * process can die, the nginx edge can stay up while the gateway behind it is
+ * down, and a URL can end up fronting a different assistant entirely. The
+ * probe resolves that by asking the edge two questions at once:
+ *
+ *   - `GET /healthz` is proxied through nginx to the gateway, so a 2xx proves
+ *     the whole chain tunnel -> nginx -> gateway.
+ *   - `GET /assistant/__config` is a static nginx response carrying the
+ *     assistant's identity, so it proves which assistant the edge fronts.
+ *
+ * Both paths live in `cli/src/lib/nginx-ingress.ts` and neither is denylisted,
+ * so both are publicly reachable.
+ *
+ * The module takes a URL and an expected id and returns a verdict: it reads no
+ * config and knows nothing about workspace paths, which is what lets callers
+ * probe an arbitrary URL and lets tests run without network access.
+ */
+
+import { normalizePublicBaseUrl } from "@vellumai/service-contracts/ingress";
+
+import { isPlainObject } from "../util/object.js";
+
+/**
+ * Verdict for one probe.
+ *
+ * `foreign` means the edge positively identified itself as a different
+ * assistant. Any case where either id is unknown is `healthy`: a config
+ * served by a CLI that predates the id, or a URL recorded before the id was
+ * saved, is version skew, not someone else's assistant.
+ */
+export type TunnelProbeResult =
+  | { kind: "healthy"; assistantId?: string; assistantName?: string }
+  | { kind: "unreachable"; detail: string }
+  | { kind: "foreign"; assistantId?: string; assistantName?: string };
+
+const DEFAULT_TIMEOUT_MS = 4_000;
+
+/** Placeholder swapped in for the probed URL so `detail` stays URL-free. */
+const REDACTED_URL = "<url>";
+
+export async function probeTunnel(args: {
+  publicBaseUrl: string;
+  /** Id recorded when this URL was saved; omit to skip the identity check. */
+  expectedAssistantId?: string;
+  timeoutMs?: number;
+  fetchImpl?: typeof fetch;
+}): Promise<TunnelProbeResult> {
+  const base = normalizePublicBaseUrl(args.publicBaseUrl);
+  if (!base) {
+    return { kind: "unreachable", detail: "no public base URL" };
+  }
+
+  const fetchImpl = args.fetchImpl ?? globalThis.fetch.bind(globalThis);
+  const signal = AbortSignal.timeout(args.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+  const [health, config] = await Promise.allSettled([
+    fetchImpl(`${base}/healthz`, { signal }),
+    fetchImpl(`${base}/assistant/__config`, { signal }),
+  ]);
+
+  if (health.status === "rejected") {
+    return unreachable(describeError(health.reason), base);
+  }
+  if (config.status === "rejected") {
+    return unreachable(describeError(config.reason), base);
+  }
+  if (!health.value.ok) {
+    return unreachable(`HTTP ${health.value.status}`, base);
+  }
+  if (!config.value.ok) {
+    return unreachable(`HTTP ${config.value.status}`, base);
+  }
+
+  const served = await readServedConfig(config.value);
+  const expected = nonEmptyString(args.expectedAssistantId);
+  const isForeign =
+    expected !== undefined &&
+    served.assistantId !== undefined &&
+    served.assistantId !== expected;
+
+  return { kind: isForeign ? "foreign" : "healthy", ...served };
+}
+
+/**
+ * Fetch layers vary in how much of the request they echo into an error
+ * message, and the caller already knows which URL it asked about.
+ */
+function unreachable(detail: string, base: string): TunnelProbeResult {
+  return { kind: "unreachable", detail: detail.replaceAll(base, REDACTED_URL) };
+}
+
+function describeError(error: unknown): string {
+  if (isPlainObject(error)) {
+    if (error.name === "TimeoutError" || error.name === "AbortError") {
+      return "timeout";
+    }
+    const text = nonEmptyString(error.message);
+    if (text !== undefined) {
+      return text;
+    }
+  }
+  return String(error);
+}
+
+interface ServedEdgeConfig {
+  assistantId?: string;
+  assistantName?: string;
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+/**
+ * An edge answering with a body this cannot read is still an edge that is
+ * answering, so an unreadable config yields an unknown identity rather than a
+ * failure.
+ */
+async function readServedConfig(response: Response): Promise<ServedEdgeConfig> {
+  try {
+    const body: unknown = await response.json();
+    if (!isPlainObject(body)) {
+      return {};
+    }
+    return {
+      assistantId: nonEmptyString(body.assistantId),
+      assistantName: nonEmptyString(body.assistantName),
+    };
+  } catch {
+    return {};
+  }
+}


### PR DESCRIPTION
## Summary

- Add `assistant/src/inbound/tunnel-probe.ts`: a pure module that probes a tunnel's public URL by fetching `/healthz` (proxied to the gateway) and `/assistant/__config` (the edge's served identity) concurrently under a shared timeout, and returns `healthy` / `unreachable` / `foreign`.
- `foreign` is reported only on a positive mismatch of two known assistant ids; an id-less served config or a missing recorded id is version skew and reads `healthy`. A 502 from `/healthz` while the static config still answers reads `unreachable`, so an nginx-up/gateway-down edge is never called healthy.
- The module reads no config and knows no workspace paths (the route in PR 5 owns that), takes an injectable `fetchImpl`, never throws, and keeps the probed URL out of `detail`. 11 unit tests, no network access.

Part of plan: tunnel-status-pairing.md (PR 4 of 9)