### PR TITLE
fix(web): skip privacy and research onboarding for established assistants

### DIFF
--- a/clients/web/src/domains/account/login-flow.test.ts
+++ b/clients/web/src/domains/account/login-flow.test.ts
@@ -7,7 +7,6 @@ import {
   requiresPlatformSession,
   resolvePostAuthDestination,
 } from "@/domains/account/login-flow";
-import { ONBOARDED_HATCH_AGE_MS } from "@/domains/onboarding/onboarded-assistant";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { routes } from "@/utils/routes";
 
@@ -65,7 +64,7 @@ describe("login flow routing", () => {
       assistants: [
         {
           id: "asst-1",
-          hatchedAt: new Date(Date.now() - ONBOARDED_HATCH_AGE_MS).toISOString(),
+          hatchedAt: new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString(),
           isLocal: false,
           isPlatformHosted: true,
           isPaired: false,

--- a/clients/web/src/domains/account/login-flow.test.ts
+++ b/clients/web/src/domains/account/login-flow.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import {
   buildProviderCallbackUrl,
@@ -7,9 +7,18 @@ import {
   requiresPlatformSession,
   resolvePostAuthDestination,
 } from "@/domains/account/login-flow";
+import { ONBOARDED_HATCH_AGE_MS } from "@/domains/onboarding/onboarded-assistant";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { routes } from "@/utils/routes";
 
 describe("login flow routing", () => {
+  beforeEach(() => {
+    useResolvedAssistantsStore.setState({ assistants: [] });
+  });
+  afterEach(() => {
+    useResolvedAssistantsStore.setState({ assistants: [] });
+  });
+
   test("marks signup provider callbacks with an auth intent", () => {
     expect(
       buildProviderCallbackUrl(routes.assistant, { authIntent: "signup" }),
@@ -47,6 +56,41 @@ describe("login flow routing", () => {
       }),
     ).toEqual({
       destination: routes.home,
+      requiresFullPageNavigation: false,
+    });
+  });
+
+  test("skips privacy and research when the assistant is already onboarded", () => {
+    useResolvedAssistantsStore.setState({
+      assistants: [
+        {
+          id: "asst-1",
+          hatchedAt: new Date(Date.now() - ONBOARDED_HATCH_AGE_MS).toISOString(),
+          isLocal: false,
+          isPlatformHosted: true,
+          isPaired: false,
+        },
+      ],
+    });
+
+    expect(
+      resolvePostAuthDestination({
+        returnTo: routes.assistant,
+        fallback: routes.assistant,
+        authIntent: "signup",
+      }),
+    ).toEqual({
+      destination: routes.assistant,
+      requiresFullPageNavigation: false,
+    });
+    expect(
+      resolvePostAuthDestination({
+        returnTo: routes.onboarding.research,
+        fallback: routes.assistant,
+        authIntent: "login",
+      }),
+    ).toEqual({
+      destination: routes.assistant,
       requiresFullPageNavigation: false,
     });
   });

--- a/clients/web/src/domains/account/pages/provider-callback-page.tsx
+++ b/clients/web/src/domains/account/pages/provider-callback-page.tsx
@@ -6,6 +6,7 @@ import { captureError } from "@/lib/sentry/capture-error";
 import { AccountHeading } from "@/components/account/account-form";
 import { AccountShell } from "@/components/account/account-shell";
 import { listAssistants } from "@/assistant/api";
+import { refreshPlatformAssistantsIfStale } from "@/assistant/platform-assistants-sync";
 import { getSession } from "@/lib/auth/allauth-client";
 import {
   readAuthCallbackIntent,
@@ -66,6 +67,9 @@ export function ProviderCallbackPage() {
         switch (outcome.kind) {
           case "authenticated": {
             await refreshSession();
+            // Wait for the assistants list so post-auth can skip privacy and
+            // research when the assistant is already onboarded.
+            await refreshPlatformAssistantsIfStale();
 
             if (isLocalClient()) {
               try {

--- a/clients/web/src/domains/account/pages/provider-signup-page.tsx
+++ b/clients/web/src/domains/account/pages/provider-signup-page.tsx
@@ -7,6 +7,7 @@ import {
   AccountInput,
 } from "@/components/account/account-form";
 import { useTranslation } from "@/i18n";
+import { refreshPlatformAssistantsIfStale } from "@/assistant/platform-assistants-sync";
 import { AccountShell } from "@/components/account/account-shell";
 import { SignupShell } from "@/domains/account/components/signup-shell";
 import {
@@ -83,6 +84,7 @@ export function ProviderSignupPage() {
     if (!result.ok) {
       if (isConflict(result)) {
         await refreshSession();
+        await refreshPlatformAssistantsIfStale();
         const conflict = resolvePostLoginDestination(
           returnTo,
           routes.account.root,
@@ -100,6 +102,7 @@ export function ProviderSignupPage() {
     }
 
     await refreshSession();
+    await refreshPlatformAssistantsIfStale();
     const post = resolvePostAuthDestination({
       returnTo,
       fallback: routes.account.root,

--- a/clients/web/src/domains/onboarding/onboarded-assistant.test.ts
+++ b/clients/web/src/domains/onboarding/onboarded-assistant.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  ONBOARDED_HATCH_AGE_MS,
+  hasOnboardedAssistant,
+  isHatchedOnboarded,
+} from "@/domains/onboarding/onboarded-assistant";
+
+const NOW = Date.parse("2026-08-21T12:00:00.000Z");
+
+describe("isHatchedOnboarded", () => {
+  test("treats a hatch at least a week old as onboarded", () => {
+    expect(
+      isHatchedOnboarded(
+        new Date(NOW - ONBOARDED_HATCH_AGE_MS).toISOString(),
+        NOW,
+      ),
+    ).toBe(true);
+    expect(
+      isHatchedOnboarded(
+        new Date(NOW - ONBOARDED_HATCH_AGE_MS - 1).toISOString(),
+        NOW,
+      ),
+    ).toBe(true);
+  });
+
+  test("treats a younger hatch as not yet onboarded", () => {
+    expect(
+      isHatchedOnboarded(
+        new Date(NOW - ONBOARDED_HATCH_AGE_MS + 1).toISOString(),
+        NOW,
+      ),
+    ).toBe(false);
+    expect(isHatchedOnboarded(new Date(NOW).toISOString(), NOW)).toBe(false);
+  });
+
+  test("ignores missing or unparseable hatch dates", () => {
+    expect(isHatchedOnboarded(undefined, NOW)).toBe(false);
+    expect(isHatchedOnboarded("", NOW)).toBe(false);
+    expect(isHatchedOnboarded("not-a-date", NOW)).toBe(false);
+  });
+});
+
+describe("hasOnboardedAssistant", () => {
+  test("is true when any assistant is past the hatch-age threshold", () => {
+    expect(
+      hasOnboardedAssistant(
+        [
+          { hatchedAt: new Date(NOW).toISOString() },
+          {
+            hatchedAt: new Date(NOW - ONBOARDED_HATCH_AGE_MS).toISOString(),
+          },
+        ],
+        NOW,
+      ),
+    ).toBe(true);
+  });
+
+  test("is false when every assistant is fresh or undated", () => {
+    expect(
+      hasOnboardedAssistant(
+        [
+          { hatchedAt: new Date(NOW - 3 * 24 * 60 * 60 * 1000).toISOString() },
+          {},
+        ],
+        NOW,
+      ),
+    ).toBe(false);
+    expect(hasOnboardedAssistant([], NOW)).toBe(false);
+  });
+});

--- a/clients/web/src/domains/onboarding/onboarded-assistant.ts
+++ b/clients/web/src/domains/onboarding/onboarded-assistant.ts
@@ -1,0 +1,33 @@
+/**
+ * Whether an existing assistant should skip first-run research onboarding.
+ *
+ * There is no durable "research completed" flag. Hatch age is the stored
+ * proxy: an assistant created at least a week ago has almost certainly
+ * finished onboarding, so login, signup, and the privacy screen should not
+ * send that user through `/onboarding/research` again.
+ */
+
+export const ONBOARDED_HATCH_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+export function isHatchedOnboarded(
+  hatchedAt: string | undefined,
+  nowMs: number = Date.now(),
+): boolean {
+  if (!hatchedAt) {
+    return false;
+  }
+  const hatchedMs = Date.parse(hatchedAt);
+  if (Number.isNaN(hatchedMs)) {
+    return false;
+  }
+  return nowMs - hatchedMs >= ONBOARDED_HATCH_AGE_MS;
+}
+
+export function hasOnboardedAssistant(
+  assistants: ReadonlyArray<{ hatchedAt?: string }>,
+  nowMs: number = Date.now(),
+): boolean {
+  return assistants.some((assistant) =>
+    isHatchedOnboarded(assistant.hatchedAt, nowMs),
+  );
+}

--- a/clients/web/src/domains/onboarding/onboarding-destination.test.ts
+++ b/clients/web/src/domains/onboarding/onboarding-destination.test.ts
@@ -66,6 +66,24 @@ describe("onboardingDestinationAfterConsent", () => {
       }),
     ).toBe(routes.onboarding.research);
   });
+
+  test("an already-onboarded assistant skips research on every build", () => {
+    expect(
+      onboardingDestinationAfterConsent({
+        isLocalHatch: false,
+        alreadyOnboarded: true,
+        env: "production",
+      }),
+    ).toBe(routes.assistant);
+    expect(
+      onboardingDestinationAfterConsent({
+        isLocalHatch: true,
+        skipResearch: true,
+        alreadyOnboarded: true,
+        env: "staging",
+      }),
+    ).toBe(routes.assistant);
+  });
 });
 
 describe("withSkipResearch", () => {

--- a/clients/web/src/domains/onboarding/onboarding-destination.ts
+++ b/clients/web/src/domains/onboarding/onboarding-destination.ts
@@ -73,12 +73,16 @@ export function withSkipResearch(
  *   gateway readyz → provider key) runs; the hatching screen then redirects into
  *   the research flow, which adopts that just-hatched assistant. Skipping
  *   hatching here would leave the research flow with no assistant to adopt.
+ * - **Already onboarded** (hatched at least a week ago) → `/assistant`. The
+ *   assistant is already provisioned and past research, including in
+ *   production.
  * - **Skip to chat** (non-production) → hatching as well. There is no research
  *   form, so the hatch screen provisions, then hands off to chat.
  */
 export function onboardingDestinationAfterConsent({
   isLocalHatch,
   skipResearch = false,
+  alreadyOnboarded = false,
   env = import.meta.env.VITE_SENTRY_ENVIRONMENT,
 }: {
   /** A local-hosting onboarding that must run the foreground local hatch. */
@@ -88,9 +92,17 @@ export function onboardingDestinationAfterConsent({
    * production builds.
    */
   skipResearch?: boolean;
+  /**
+   * The current assistant has already finished first-run onboarding. Skips
+   * research on every build, including production.
+   */
+  alreadyOnboarded?: boolean;
   /** Build environment; defaults to `VITE_SENTRY_ENVIRONMENT`. */
   env?: string;
 }): string {
+  if (alreadyOnboarded) {
+    return routes.assistant;
+  }
   if (skipResearch && canSkipOnboardingResearch(env)) {
     return routes.onboarding.hatching;
   }

--- a/clients/web/src/domains/onboarding/pages/privacy-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/privacy-screen.test.tsx
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 
 import { SKIP_RESEARCH_PARAM } from "@/domains/onboarding/onboarding-destination";
+import { ONBOARDED_HATCH_AGE_MS } from "@/domains/onboarding/onboarded-assistant";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { routes } from "@/utils/routes";
 
 // react-router: capture navigate() targets and drive the ?preview flag.
@@ -139,6 +141,7 @@ describe("PrivacyScreen — Start navigation", () => {
     localMode = false;
     checkoutIntentValue = null;
     takeoverValue = "enabled";
+    useResolvedAssistantsStore.setState({ assistants: [] });
   });
   afterEach(() => {
     cleanup();
@@ -146,6 +149,7 @@ describe("PrivacyScreen — Start navigation", () => {
     localMode = false;
     checkoutIntentValue = null;
     takeoverValue = "enabled";
+    useResolvedAssistantsStore.setState({ assistants: [] });
   });
 
   test("preview mode no-ops on Start without persisting consent", () => {
@@ -216,6 +220,28 @@ describe("PrivacyScreen — Start navigation", () => {
       userId: "user-1",
     });
     expect(navigateMock).toHaveBeenCalledWith(routes.onboarding.research, {
+      replace: true,
+    });
+  });
+
+  test("skips research when the assistant was hatched over a week ago", () => {
+    useResolvedAssistantsStore.setState({
+      assistants: [
+        {
+          id: "asst-1",
+          hatchedAt: new Date(Date.now() - ONBOARDED_HATCH_AGE_MS).toISOString(),
+          isLocal: false,
+          isPlatformHosted: true,
+          isPaired: false,
+        },
+      ],
+    });
+    searchParamsValue = new URLSearchParams();
+    render(<PrivacyScreen />);
+
+    clickStart();
+
+    expect(navigateMock).toHaveBeenCalledWith(routes.assistant, {
       replace: true,
     });
   });

--- a/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/privacy-screen.tsx
@@ -12,6 +12,7 @@ import {
   getOnboardingFunnelSessionId,
   ONBOARDING_FUNNEL_STEPS,
 } from "@/domains/onboarding/funnel-events";
+import { hasOnboardedAssistant } from "@/domains/onboarding/onboarded-assistant";
 import {
   canSkipOnboardingResearch,
   onboardingDestinationAfterConsent,
@@ -37,6 +38,7 @@ import {
 import { isElectron } from "@/runtime/is-electron";
 import { useIsNativePlatform } from "@/runtime/native-auth";
 import { useAuthStore, useHasPlatformSession } from "@/stores/auth-store";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { saveConsent } from "@/lib/consent/consent-persistence";
 import { useTranslation } from "@/i18n";
 import { PACKAGE_PARAM, routes } from "@/utils/routes";
@@ -125,9 +127,13 @@ export function PrivacyScreen() {
     // to chat.
     const isLocalHatch =
       isLocalClient() && hostingParam !== null && hostingParam !== "vellum-cloud";
+    const alreadyOnboarded = hasOnboardedAssistant(
+      useResolvedAssistantsStore.getState().assistants,
+    );
     const destination = onboardingDestinationAfterConsent({
       isLocalHatch,
       skipResearch,
+      alreadyOnboarded,
     });
     const onboardingNext = skipResearch
       ? withSkipResearch(`${destination}${qs ? `?${qs}` : ""}`)

--- a/clients/web/src/lib/navigation/build-state.test.ts
+++ b/clients/web/src/lib/navigation/build-state.test.ts
@@ -200,3 +200,39 @@ describe("buildNavigationState — hasPlatformHostedAssistant", () => {
     expect(buildNavigationState().hasPlatformHostedAssistant).toBe(false);
   });
 });
+
+describe("buildNavigationState — alreadyOnboarded", () => {
+  test("false when no assistant is a week old", () => {
+    useResolvedAssistantsStore.setState({
+      assistants: [
+        {
+          id: "asst-fresh",
+          hatchedAt: new Date().toISOString(),
+          isLocal: false,
+          isPlatformHosted: true,
+          isPaired: false,
+        },
+      ],
+    });
+
+    expect(buildNavigationState().alreadyOnboarded).toBe(false);
+  });
+
+  test("true when any assistant was hatched at least a week ago", () => {
+    useResolvedAssistantsStore.setState({
+      assistants: [
+        {
+          id: "asst-old",
+          hatchedAt: new Date(
+            Date.now() - 8 * 24 * 60 * 60 * 1000,
+          ).toISOString(),
+          isLocal: false,
+          isPlatformHosted: true,
+          isPaired: false,
+        },
+      ],
+    });
+
+    expect(buildNavigationState().alreadyOnboarded).toBe(true);
+  });
+});

--- a/clients/web/src/lib/navigation/build-state.ts
+++ b/clients/web/src/lib/navigation/build-state.ts
@@ -15,6 +15,7 @@ import {
   readConsentHydrated,
 } from "@/domains/onboarding/prefs";
 import { getActiveOrganizationIdForRequests } from "@/stores/organization-store";
+import { hasOnboardedAssistant } from "@/domains/onboarding/onboarded-assistant";
 import {
   assistantsValidForOrg,
   useResolvedAssistantsStore,
@@ -72,6 +73,7 @@ export function buildNavigationState(
     diagnosticsConsentCurrent: readDiagnosticsConsentCurrent(),
     consentHydrated: readConsentHydrated(),
     assistantsHydrated,
+    alreadyOnboarded: hasOnboardedAssistant(assistants),
     ...overrides,
   };
 }

--- a/clients/web/src/lib/navigation/navigation-resolver.test.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.test.ts
@@ -33,6 +33,7 @@ const base: NavigationState = {
   // the hydration-gating cases override these explicitly.
   consentHydrated: true,
   assistantsHydrated: true,
+  alreadyOnboarded: false,
 };
 
 function s(overrides: Partial<NavigationState>): NavigationState {
@@ -209,6 +210,33 @@ describe("resolveNavigation", () => {
       expect(guard(s({}), "/assistant/onboarding/privacy")).toEqual(ALLOW);
       expect(
         guard(s({ hasAssistants: false }), "/assistant/onboarding/privacy"),
+      ).toEqual(ALLOW);
+    });
+
+    test("bounces an already-onboarded user off first-run privacy", () => {
+      expect(
+        guard(s({ alreadyOnboarded: true }), "/assistant/onboarding/privacy"),
+      ).toEqual({ action: "redirect", to: "/assistant" });
+      expect(
+        guard(
+          s({ alreadyOnboarded: true, hasAssistants: false }),
+          "/assistant/onboarding/privacy?replay=1",
+        ),
+      ).toEqual({ action: "redirect", to: "/assistant" });
+    });
+
+    test("resumes a paid hatch when bouncing an already-onboarded user off privacy", () => {
+      expect(
+        guard(
+          s({ alreadyOnboarded: true }),
+          `/assistant/onboarding/privacy?returnTo=${encodeURIComponent(HATCHING_FUNNEL_URL)}`,
+        ),
+      ).toEqual({ action: "redirect", to: HATCHING_FUNNEL_URL });
+    });
+
+    test("keeps research reachable on demand for an already-onboarded user", () => {
+      expect(
+        guard(s({ alreadyOnboarded: true }), "/assistant/onboarding/research"),
       ).toEqual(ALLOW);
     });
 
@@ -1428,6 +1456,19 @@ describe("resolveNavigation", () => {
       ).toEqual(ALLOW);
     });
 
+    test("allows an already-onboarded assistant even without local consent flags", () => {
+      expect(
+        intercept(
+          s({
+            alreadyOnboarded: true,
+            tosAccepted: false,
+            privacyConsent: false,
+          }),
+          "/assistant",
+        ),
+      ).toEqual(ALLOW);
+    });
+
     test("stale toggles do not change onboarding-intercept (hasCompletedOnboarding only)", () => {
       expect(
         intercept(
@@ -1770,6 +1811,77 @@ describe("resolveNavigation", () => {
       expect(postAuth("login", "")).toEqual({
         action: "redirect",
         to: "/assistant",
+      });
+    });
+
+    test("signup skips privacy when the assistant is already onboarded", () => {
+      expect(
+        resolveNavigation(s({ alreadyOnboarded: true }), {
+          kind: "post-auth",
+          authIntent: "signup",
+          returnTo: "/assistant/home",
+          fallback: "/assistant",
+        }),
+      ).toEqual({ action: "redirect", to: "/assistant/home" });
+      expect(readCheckoutIntent()).toBeNull();
+    });
+
+    test("signup with a checkout deep link skips privacy when already onboarded", () => {
+      expect(
+        resolveNavigation(s({ alreadyOnboarded: true }), {
+          kind: "post-auth",
+          authIntent: "signup",
+          returnTo: "/assistant/checkout?package=super",
+          fallback: "/assistant",
+        }),
+      ).toEqual({
+        action: "redirect",
+        to: "/assistant/checkout?package=super",
+      });
+      expect(readCheckoutIntent()).toBeNull();
+    });
+
+    test("login keeps a paid hatch returnTo when already onboarded", () => {
+      expect(
+        resolveNavigation(s({ alreadyOnboarded: true }), {
+          kind: "post-auth",
+          authIntent: "login",
+          returnTo: HATCHING_FUNNEL_URL,
+          fallback: "/assistant",
+        }),
+      ).toEqual({ action: "redirect", to: HATCHING_FUNNEL_URL });
+    });
+
+    test("login skips a privacy or research returnTo when already onboarded", () => {
+      expect(
+        resolveNavigation(s({ alreadyOnboarded: true }), {
+          kind: "post-auth",
+          authIntent: "login",
+          returnTo: "/assistant/onboarding/privacy",
+          fallback: "/assistant",
+        }),
+      ).toEqual({ action: "redirect", to: "/assistant" });
+      expect(
+        resolveNavigation(s({ alreadyOnboarded: true }), {
+          kind: "post-auth",
+          authIntent: "login",
+          returnTo: "/assistant/onboarding/research?hosting=vellum-cloud",
+          fallback: "/assistant",
+        }),
+      ).toEqual({ action: "redirect", to: "/assistant" });
+    });
+
+    test("signup still goes to privacy for a freshly hatched assistant", () => {
+      expect(
+        resolveNavigation(s({ alreadyOnboarded: false, hasAssistants: true }), {
+          kind: "post-auth",
+          authIntent: "signup",
+          returnTo: "/assistant/home",
+          fallback: "/assistant",
+        }),
+      ).toEqual({
+        action: "redirect",
+        to: "/assistant/onboarding/privacy",
       });
     });
 

--- a/clients/web/src/lib/navigation/navigation-resolver.ts
+++ b/clients/web/src/lib/navigation/navigation-resolver.ts
@@ -48,6 +48,11 @@ export interface NavigationState {
   consentHydrationTimedOut?: boolean;
   /** Whether the resolved assistants list reflects at least one authoritative load. */
   assistantsHydrated: boolean;
+  /**
+   * Whether any resolved assistant is already past first-run onboarding.
+   * Hatch age is the stored proxy (see `hasOnboardedAssistant`).
+   */
+  alreadyOnboarded: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -287,7 +292,12 @@ export function resolveNavigation(
     case "hatch-gate":
       return resolveHatchGate(state);
     case "post-auth":
-      return resolvePostAuth(query.authIntent, query.returnTo, query.fallback);
+      return resolvePostAuth(
+        state,
+        query.authIntent,
+        query.returnTo,
+        query.fallback,
+      );
     case "post-retire":
       return resolvePostRetire(state);
   }
@@ -616,6 +626,25 @@ function allowSetupRoutes(
     return null;
   }
 
+  // An already-onboarded assistant should not re-enter first-run privacy.
+  // Research stays reachable on demand (replay); only the automatic privacy
+  // entry is bounced. A paid hatch riding on `returnTo` is resumed so a
+  // purchased resize is not dropped.
+  if (path === routes.onboarding.privacy && state.alreadyOnboarded) {
+    const qIdx = pathnameWithSearch.indexOf("?");
+    const returnTo =
+      qIdx >= 0
+        ? new URLSearchParams(pathnameWithSearch.slice(qIdx + 1)).get(
+            "returnTo",
+          )
+        : null;
+    const paidReturn = postCheckoutHatchReturnTo(returnTo);
+    if (paidReturn) {
+      return { action: "redirect", to: paidReturn };
+    }
+    return { action: "redirect", to: routes.assistant };
+  }
+
   return enforceFunnelConsent(state, path, pathnameWithSearch);
 }
 
@@ -801,7 +830,7 @@ function resolveOnboardingIntercept(
   if (state.isLocalClient && state.hasAssistants) {
     return { action: "allow" };
   }
-  if (hasCompletedOnboarding(state)) {
+  if (hasCompletedOnboarding(state) || state.alreadyOnboarded) {
     return { action: "allow" };
   }
 
@@ -862,12 +891,46 @@ function isImportFunnelDestination(destination: string): boolean {
   );
 }
 
+function isOnboardingResearchPath(destination: string): boolean {
+  const path = extractPathname(destination);
+  const qIdx = path.indexOf("?");
+  const pathname = qIdx < 0 ? path : path.slice(0, qIdx);
+  return (
+    pathname === routes.onboarding.privacy ||
+    pathname === routes.onboarding.research
+  );
+}
+
 function resolvePostAuth(
+  state: NavigationState,
   authIntent: "login" | "signup",
   returnTo: string | null,
   fallback: string,
 ): NavigationDecision {
   const destination = sanitizeReturnTo(returnTo, fallback);
+  // The import funnel replaces onboarding: a signup that started on /import
+  // lands back there instead of the consent screen.
+  if (authIntent === "signup" && isImportFunnelDestination(destination)) {
+    return { action: "redirect", to: destination };
+  }
+
+  // An already-onboarded assistant skips first-run privacy and research.
+  // Treat the auth as a login so a pricing-CTA checkout stash is not marked
+  // for the privacy screen to consume. A paid hatch return keeps its
+  // destination so a purchased resize is not dropped.
+  if (state.alreadyOnboarded) {
+    const skipTarget = postCheckoutHatchReturnTo(destination)
+      ? destination
+      : isOnboardingResearchPath(destination)
+        ? fallback
+        : destination;
+    resolveSignupCheckoutDestination({
+      intent: "login",
+      returnTo: skipTarget,
+    });
+    return { action: "redirect", to: skipTarget };
+  }
+
   // The shared resolver stashes a pricing-CTA checkout package across signup,
   // discards a stale stash for any non-checkout auth, and picks the
   // destination (privacy for signup, the sanitized `returnTo` for login).
@@ -875,11 +938,6 @@ function resolvePostAuth(
     intent: authIntent,
     returnTo: destination,
   });
-  // The import funnel replaces onboarding: a signup that started on /import
-  // lands back there instead of the consent screen.
-  if (authIntent === "signup" && isImportFunnelDestination(destination)) {
-    return { action: "redirect", to: destination };
-  }
   return { action: "redirect", to: resolved };
 }
 

--- a/clients/web/src/runtime/native-auth.test.ts
+++ b/clients/web/src/runtime/native-auth.test.ts
@@ -7,6 +7,10 @@ import {
 } from "@/lib/billing/checkout-intent";
 import { nativeAuthErrorDetail } from "@/domains/account/native-auth-error";
 
+import { ONBOARDED_HATCH_AGE_MS } from "@/domains/onboarding/onboarded-assistant";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+import { routes } from "@/utils/routes";
+
 import {
   clearStaleNativeCheckoutStash,
   resolveNativePostAuthDestination,
@@ -18,6 +22,11 @@ describe("resolveNativePostAuthDestination", () => {
     sessionStorage.clear();
     // Reset the module-level in-memory mirror so it can't leak across tests.
     clearCheckoutIntent();
+    useResolvedAssistantsStore.setState({ assistants: [] });
+  });
+
+  afterEach(() => {
+    useResolvedAssistantsStore.setState({ assistants: [] });
   });
 
   test("native signup via the checkout deep link stashes the package and still routes to privacy", () => {
@@ -82,6 +91,46 @@ describe("resolveNativePostAuthDestination", () => {
 
     expect(destination).toBe("/assistant/home");
     expect(readCheckoutIntent()).toBeNull();
+  });
+
+  test("native signup skips privacy when the assistant is already onboarded", () => {
+    useResolvedAssistantsStore.setState({
+      assistants: [
+        {
+          id: "asst-1",
+          hatchedAt: new Date(Date.now() - ONBOARDED_HATCH_AGE_MS).toISOString(),
+          isLocal: false,
+          isPlatformHosted: true,
+          isPaired: false,
+        },
+      ],
+    });
+
+    const destination = resolveNativePostAuthDestination(
+      "signup",
+      "/assistant/home",
+    );
+
+    expect(destination).toBe("/assistant/home");
+    expect(readCheckoutIntent()).toBeNull();
+  });
+
+  test("native login skips a research returnTo when the assistant is already onboarded", () => {
+    useResolvedAssistantsStore.setState({
+      assistants: [
+        {
+          id: "asst-1",
+          hatchedAt: new Date(Date.now() - ONBOARDED_HATCH_AGE_MS).toISOString(),
+          isLocal: false,
+          isPlatformHosted: true,
+          isPaired: false,
+        },
+      ],
+    });
+
+    expect(
+      resolveNativePostAuthDestination("login", routes.onboarding.research),
+    ).toBe(routes.assistant);
   });
 });
 

--- a/clients/web/src/runtime/native-auth.ts
+++ b/clients/web/src/runtime/native-auth.ts
@@ -8,6 +8,8 @@ import {
 import { sanitizeReturnTo } from "@/domains/account/return-to";
 import { getSession } from "@/lib/auth/allauth-client";
 import { resolveSignupCheckoutDestination } from "@/lib/billing/post-auth-checkout";
+import { buildNavigationState } from "@/lib/navigation/build-state";
+import { resolveNavigation } from "@/lib/navigation/navigation-resolver";
 import { isPlatformLocal, startLoopbackAuth } from "@/lib/auth/loopback-auth";
 import { isLocalClient } from "@/lib/local-mode";
 import { isElectron } from "@/runtime/is-electron";
@@ -284,26 +286,47 @@ export function getSessionTokenFromCookies(): string | null {
 /**
  * Post-auth destination for the native (Capacitor/Electron) flows. Delegates
  * the signup checkout-stash + destination decision to the shared
- * `resolveSignupCheckoutDestination`, which both this path and the web
- * `resolvePostAuth` path use: a signup routes through consent (privacy) first,
- * stashing any pricing-CTA checkout package so the consent screen resumes
- * checkout afterward, and any non-checkout auth discards a stale stash. A login
- * keeps its `returnTo` (the callers below sanitize and apply the fallback).
+ * `resolvePostAuth` path: a first-run signup routes through consent (privacy)
+ * first, stashing any pricing-CTA checkout package so the consent screen
+ * resumes checkout afterward. An already-onboarded assistant skips privacy and
+ * research. A login keeps its `returnTo` unless that target is the first-run
+ * funnel and the assistant is already onboarded.
  */
 export function resolveNativePostAuthDestination(
   intent: string | undefined,
   returnTo: string | null | undefined,
 ): string | null {
   const isSignup = intent === "signup";
-  const destination = resolveSignupCheckoutDestination({
-    intent: isSignup ? "signup" : "login",
-    returnTo: returnTo ?? "",
+  const state = buildNavigationState();
+  const decision = resolveNavigation(state, {
+    kind: "post-auth",
+    authIntent: isSignup ? "signup" : "login",
+    returnTo: returnTo ?? null,
+    fallback: routes.assistant,
   });
-  // A signup takes the shared destination (privacy, resuming checkout after
-  // consent). A login keeps its raw `returnTo` — the callers below sanitize
-  // and apply the fallback — while still discarding a stale stash via the
-  // shared resolver.
-  return isSignup ? destination : (returnTo ?? null);
+  if (isSignup) {
+    return decision.action === "redirect" ? decision.to : routes.assistant;
+  }
+  // A login keeps its raw `returnTo` — the callers below sanitize and apply
+  // the fallback — unless that target is first-run privacy/research and the
+  // assistant is already onboarded.
+  if (state.alreadyOnboarded && isFirstRunOnboardingReturnTo(returnTo)) {
+    return decision.action === "redirect" ? decision.to : routes.assistant;
+  }
+  return returnTo ?? null;
+}
+
+function isFirstRunOnboardingReturnTo(
+  returnTo: string | null | undefined,
+): boolean {
+  if (!returnTo) {
+    return false;
+  }
+  const pathname = returnTo.split(/[?#]/)[0] ?? returnTo;
+  return (
+    pathname === routes.onboarding.privacy ||
+    pathname === routes.onboarding.research
+  );
 }
 
 /**

--- a/clients/web/src/runtime/native-auth.ts
+++ b/clients/web/src/runtime/native-auth.ts
@@ -7,10 +7,10 @@ import {
 } from "@/domains/account/social-auth";
 import { sanitizeReturnTo } from "@/domains/account/return-to";
 import { getSession } from "@/lib/auth/allauth-client";
+import { hasOnboardedAssistant } from "@/domains/onboarding/onboarded-assistant";
 import { resolveSignupCheckoutDestination } from "@/lib/billing/post-auth-checkout";
-import { buildNavigationState } from "@/lib/navigation/build-state";
-import { resolveNavigation } from "@/lib/navigation/navigation-resolver";
 import { isPlatformLocal, startLoopbackAuth } from "@/lib/auth/loopback-auth";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { isLocalClient } from "@/lib/local-mode";
 import { isElectron } from "@/runtime/is-electron";
 import { setMenuPlatformSession } from "@/runtime/menu";
@@ -286,9 +286,8 @@ export function getSessionTokenFromCookies(): string | null {
 /**
  * Post-auth destination for the native (Capacitor/Electron) flows. Delegates
  * the signup checkout-stash + destination decision to the shared
- * `resolvePostAuth` path: a first-run signup routes through consent (privacy)
- * first, stashing any pricing-CTA checkout package so the consent screen
- * resumes checkout afterward. An already-onboarded assistant skips privacy and
+ * `resolveSignupCheckoutDestination`. A first-run signup routes through
+ * consent (privacy) first. An already-onboarded assistant skips privacy and
  * research. A login keeps its `returnTo` unless that target is the first-run
  * funnel and the assistant is already onboarded.
  */
@@ -297,23 +296,24 @@ export function resolveNativePostAuthDestination(
   returnTo: string | null | undefined,
 ): string | null {
   const isSignup = intent === "signup";
-  const state = buildNavigationState();
-  const decision = resolveNavigation(state, {
-    kind: "post-auth",
-    authIntent: isSignup ? "signup" : "login",
-    returnTo: returnTo ?? null,
-    fallback: routes.assistant,
+  const alreadyOnboarded = hasOnboardedAssistant(
+    useResolvedAssistantsStore.getState().assistants,
+  );
+  if (alreadyOnboarded) {
+    const skipTarget = isFirstRunOnboardingReturnTo(returnTo)
+      ? routes.assistant
+      : (returnTo ?? (isSignup ? routes.assistant : null));
+    resolveSignupCheckoutDestination({
+      intent: "login",
+      returnTo: skipTarget ?? "",
+    });
+    return skipTarget;
+  }
+  const destination = resolveSignupCheckoutDestination({
+    intent: isSignup ? "signup" : "login",
+    returnTo: returnTo ?? "",
   });
-  if (isSignup) {
-    return decision.action === "redirect" ? decision.to : routes.assistant;
-  }
-  // A login keeps its raw `returnTo` — the callers below sanitize and apply
-  // the fallback — unless that target is first-run privacy/research and the
-  // assistant is already onboarded.
-  if (state.alreadyOnboarded && isFirstRunOnboardingReturnTo(returnTo)) {
-    return decision.action === "redirect" ? decision.to : routes.assistant;
-  }
-  return returnTo ?? null;
+  return isSignup ? destination : (returnTo ?? null);
 }
 
 function isFirstRunOnboardingReturnTo(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan
Already-signed-up, already-onboarded users were still sent through `/assistant/onboarding/privacy` and `/assistant/onboarding/research` after completing signup or login. There is no durable "research completed" flag, so hatch age is the stored proxy: an assistant created at least a week ago is treated as already onboarded.

Both post-auth (signup and login) and the privacy screen skip first-run research when that signal is present. A brand-new or freshly hatched assistant still walks the funnel.

## Summary
- Treat any resolved assistant hatched at least 7 days ago as already onboarded.
- Signup/login no longer send those users to privacy or research. They keep `returnTo` (or `/assistant`).
- Visiting `/onboarding/privacy` bounces already-onboarded users to `/assistant`. Start on that screen also goes to chat instead of research.
- Paid hatch `returnTo` values are preserved so a purchased resize is not dropped.
- Completing signup/login waits for the platform assistants list before choosing a destination.

## Test plan
- `cd clients/web && bun test` on:
  - `src/domains/onboarding/onboarded-assistant.test.ts`
  - `src/lib/navigation/navigation-resolver.test.ts`
  - `src/lib/navigation/build-state.test.ts`
  - `src/domains/onboarding/onboarding-destination.test.ts`
  - `src/domains/onboarding/pages/privacy-screen.test.tsx`
  - `src/runtime/native-auth.test.ts`
  - `src/domains/account/login-flow.test.ts`
  - `src/lib/billing/post-auth-checkout.test.ts`
- 264 tests passed, including new cases for:
  - week-old hatch skips privacy/research on signup, login, and privacy Start
  - freshly hatched assistant still goes through privacy
  - paid hatch returnTo is kept

## Risk
- The week-old hatch proxy can skip research for a rare user who hatched more than a week ago and never finished research. That matches the requested heuristic.
- Research remains reachable on demand at `/assistant/onboarding/research` for replay.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-55c8b2de-88e4-47bc-9db7-a22c10ec671d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55c8b2de-88e4-47bc-9db7-a22c10ec671d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

