### PR TITLE
fix(release): keep main when merge-back rebase hits conflicts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2592,18 +2592,17 @@ jobs:
             --head "$BRANCH")
 
           # Try the normal merge first. If it fails (e.g. due to cherry-picked
-          # commits causing conflicts), rebase onto main with `-X theirs` to
-          # auto-resolve textual conflicts in favor of the release branch and
-          # retry. The release branch is the source of truth for the version
-          # being shipped, so taking its side is the safe default.
+          # commits causing conflicts), rebase onto main with `-X ours` to
+          # auto-resolve textual conflicts in favor of main and retry. During a
+          # rebase, ours is the new base, so `-X ours` keeps main's side.
           if ! gh pr merge "$PR_URL" --squash --admin --delete-branch; then
-            echo "Merge failed — rebasing with -X theirs to resolve cherry-pick conflicts"
+            echo "Merge failed - rebasing with -X ours to keep main on conflicts"
 
             git config user.name "vellum-automation[bot]"
             git config user.email "192048195+vellum-automation[bot]@users.noreply.github.com"
 
             git fetch origin main
-            git rebase -X theirs origin/main
+            git rebase -X ours origin/main
 
             # Append [skip ci] so the force-push doesn't re-trigger this workflow
             git commit --allow-empty --amend -m "$(git log -1 --format=%B) [skip ci]"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan

[ATL-1306](https://linear.app/vellum/issue/ATL-1306/release-merge-back-auto-resolves-conflicts-with-x-theirs-silently): when `merge-release-branch` cannot squash-merge the release branch into `main`, the fallback rebases onto `main` and auto-resolves textual conflicts. That rebase used `-X theirs`. During a rebase, `theirs` is the commit being replayed (the release branch), so overlapping hunks discarded `main`.

v0.11.4 is the concrete case. `#40915` hit `Pull Request has merge conflicts`, rebased with `-X theirs`, and landed `785241af9f` with the release side of picker / i18n / read-toggle conflicts. `#40922` had to restore those files the next day. Version files in that merge did not conflict. `-X theirs` fired on application code.

This flips the fallback to `-X ours`. During a rebase, `ours` is the new base (`main`), so overlapping hunks keep `main`. Cleanly applicable release-only edits (the version bump when `main` did not touch the same lines) still apply.

Part of ATL-1306.

## Test plan

Replayed the v0.11.4 merge-back in throwaway worktrees: rebase `935834be9b` (release tip after `#40841`) onto `da8ab63cfa` (main just before the squash).

`-X theirs` (old fallback): leftover vs main is 15 files, +33/-275, matching `785241af9f`. Picker, read-toggle, and both `settings.json` catalogs differ from main.

`-X ours` (this PR): git drops the cherry-pick commit as "patch contents already upstream". Leftover vs main is 10 version/lockfile files, +19/-19. Picker, read-toggle, and `settings.json` match main byte-for-byte. `assistant/package.json` is still `0.11.4`.

## Risk

- Low operational risk: this job only runs on a production release merge-back after publish.
- If a version or lockfile line *does* conflict with a later `main` edit, the fallback now keeps `main`. A missed version bump would be visible in the squash diff and is preferable to silently reverting application code.
- `[skip ci]` and `--admin` on the resolved path are unchanged. This PR only flips which side wins.

## CLI verb checklist

Not applicable. Workflow-only change, no new IPC routes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bb1530a1-152a-4a82-885e-8bd7da42db64?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bb1530a1-152a-4a82-885e-8bd7da42db64&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

