### PR TITLE
feat(assistant): add GET integrations/ingress/status

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -15468,6 +15468,61 @@ paths:
                   - localGatewayTarget
                   - success
                 additionalProperties: false
+  /v1/integrations/ingress/status:
+    get:
+      operationId: integrations_ingress_status_get
+      summary: Get ingress tunnel status
+      description:
+        Probe the configured public ingress URL and report whether a tunnel is serving this assistant.
+        `unconfigured` means no tunnel has ever been recorded (or the assistant is platform-hosted, which never uses
+        one), `stopped` means a tunnel ran before and `lastTunnel` names it, `healthy` means the URL answers and fronts
+        this assistant, `unreachable` means it does not answer, and `foreign` means it answers for a different
+        assistant.
+      tags:
+        - config
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  state:
+                    type: string
+                    enum:
+                      - unconfigured
+                      - stopped
+                      - healthy
+                      - unreachable
+                      - foreign
+                  publicBaseUrl:
+                    description: The probed URL. Set for healthy, unreachable, and foreign.
+                    type: string
+                  lastTunnel:
+                    description: The tunnel to restart. Set for stopped.
+                    type: object
+                    properties:
+                      provider:
+                        type: string
+                      publicBaseUrl:
+                        type: string
+                    required:
+                      - provider
+                      - publicBaseUrl
+                    additionalProperties: false
+                  servingAssistantName:
+                    description: Name the edge serves under. Set for foreign when it reports one.
+                    type: string
+                  detail:
+                    description: Short failure reason, free of the URL. Set for unreachable.
+                    type: string
+                  checkedAt:
+                    description: ISO-8601 instant the probe finished. Set whenever one ran.
+                    type: string
+                required:
+                  - state
+                additionalProperties: false
   /v1/integrations/oauth/start:
     post:
       operationId: integrations_oauth_start_post

--- a/assistant/src/daemon/handlers/__tests__/config-ingress-tunnel-records.test.ts
+++ b/assistant/src/daemon/handlers/__tests__/config-ingress-tunnel-records.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Unit tests for the ingress section of the workspace config, including the
+ * records `vellum tunnel` leaves behind. A hand-edited or half-written entry
+ * must yield a typed fallback or null, never a throw or an unusable address.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+let rawConfig: Record<string, unknown> = {};
+
+mock.module("../../../config/loader.js", () => ({
+  loadRawConfig: () => rawConfig,
+}));
+
+import {
+  getIngressConfigResult,
+  loadLastTunnelRecord,
+  loadRecordedAssistantId,
+} from "../config-ingress.js";
+
+const TUNNEL_URL = "https://assistant-1.example.ts.net";
+
+describe("workspace tunnel records", () => {
+  beforeEach(() => {
+    rawConfig = {};
+  });
+
+  test("reads a well-formed record", () => {
+    rawConfig = {
+      ingress: {
+        assistantId: "assistant-1",
+        lastTunnel: { provider: "tailscale", publicBaseUrl: TUNNEL_URL },
+      },
+    };
+
+    expect(loadLastTunnelRecord()).toEqual({
+      provider: "tailscale",
+      publicBaseUrl: TUNNEL_URL,
+    });
+    expect(loadRecordedAssistantId()).toBe("assistant-1");
+  });
+
+  test("returns null when the ingress section is absent", () => {
+    expect(loadLastTunnelRecord()).toBeNull();
+    expect(loadRecordedAssistantId()).toBeNull();
+  });
+
+  test("returns null when the ingress section is not an object", () => {
+    rawConfig = { ingress: "nonsense" };
+
+    expect(loadLastTunnelRecord()).toBeNull();
+    expect(loadRecordedAssistantId()).toBeNull();
+  });
+
+  test("returns null for a record missing either field", () => {
+    rawConfig = { ingress: { lastTunnel: { provider: "ngrok" } } };
+    expect(loadLastTunnelRecord()).toBeNull();
+
+    rawConfig = { ingress: { lastTunnel: { publicBaseUrl: TUNNEL_URL } } };
+    expect(loadLastTunnelRecord()).toBeNull();
+  });
+
+  test("returns null for a URL that is not absolute HTTP(S)", () => {
+    for (const publicBaseUrl of ["", "   ", "example.ts.net", "ftp://x.test"]) {
+      rawConfig = {
+        ingress: { lastTunnel: { provider: "ngrok", publicBaseUrl } },
+      };
+      expect(loadLastTunnelRecord()).toBeNull();
+    }
+  });
+
+  test("returns null for a blank recorded assistant id", () => {
+    rawConfig = { ingress: { assistantId: "   " } };
+
+    expect(loadRecordedAssistantId()).toBeNull();
+  });
+
+  test("falls back to typed defaults for a mistyped ingress section", () => {
+    rawConfig = { ingress: { publicBaseUrl: 42, enabled: "yes" } };
+
+    const config = getIngressConfigResult();
+
+    expect(config.publicBaseUrl).toBe("");
+    expect(config.enabled).toBe(false);
+  });
+});

--- a/assistant/src/daemon/handlers/config-ingress.ts
+++ b/assistant/src/daemon/handlers/config-ingress.ts
@@ -1,3 +1,5 @@
+import { normalizeHttpPublicBaseUrl } from "@vellumai/service-contracts/ingress";
+
 import { updatePhoneNumberWebhooks } from "../../calls/twilio-rest.js";
 import {
   getGatewayInternalBaseUrl,
@@ -12,10 +14,64 @@ import {
   getTwilioVoiceWebhookUrl,
   type IngressConfig,
 } from "../../inbound/public-ingress-urls.js";
+import { isPlainObject } from "../../util/object.js";
 import { log } from "./shared.js";
 
 export function computeGatewayTarget(): string {
   return getGatewayInternalBaseUrl();
+}
+
+/**
+ * The `ingress` section of the raw workspace config.
+ *
+ * `vellum tunnel` writes this section (`cli/src/lib/ingress-config.ts`), so
+ * the field names below are the contract between the two packages: the CLI is
+ * a separate build unit the assistant does not depend on, so the assistant
+ * reads the same keys rather than importing the CLI's readers.
+ */
+function readIngressSection(): Record<string, unknown> {
+  const ingress = loadRawConfig().ingress;
+  return isPlainObject(ingress) ? ingress : {};
+}
+
+function readNonEmptyString(value: unknown): string | null {
+  const trimmed = typeof value === "string" ? value.trim() : "";
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+/** The tunnel that most recently ran; the CLI keeps it across teardown. */
+export interface LastTunnelRecord {
+  /** Provider name as the CLI wrote it, opaque here. */
+  provider: string;
+  publicBaseUrl: string;
+}
+
+/** Read the last tunnel that ran, or null when it is absent or malformed. */
+export function loadLastTunnelRecord(): LastTunnelRecord | null {
+  const record = readIngressSection().lastTunnel;
+  if (!isPlainObject(record)) {
+    return null;
+  }
+  const provider = readNonEmptyString(record.provider);
+  const publicBaseUrl = readNonEmptyString(record.publicBaseUrl);
+  // A hand-edited config must not hand callers an unusable address, so the
+  // URL faces the same absolute HTTP(S) constraint the CLI applies to it.
+  if (
+    !provider ||
+    !publicBaseUrl ||
+    !normalizeHttpPublicBaseUrl(publicBaseUrl)
+  ) {
+    return null;
+  }
+  return { provider, publicBaseUrl };
+}
+
+/**
+ * Read the assistant id the last tunnel fronted, or null when absent. The
+ * daemon cannot derive it: it scopes itself as `self` internally.
+ */
+export function loadRecordedAssistantId(): string | null {
+  return readNonEmptyString(readIngressSection().assistantId);
 }
 
 /**
@@ -48,10 +104,12 @@ export function getIngressConfigResult(): {
     }
   }
 
-  const raw = loadRawConfig();
-  const ingress = (raw?.ingress ?? {}) as Record<string, unknown>;
-  const publicBaseUrl = (ingress.publicBaseUrl as string) ?? "";
-  const enabled = (ingress.enabled as boolean | undefined) ?? false;
+  const ingress = readIngressSection();
+  // Typed reads, not casts: a hand-edited config must not hand callers a
+  // value whose type contradicts this function's return type.
+  const publicBaseUrl =
+    typeof ingress.publicBaseUrl === "string" ? ingress.publicBaseUrl : "";
+  const enabled = ingress.enabled === true;
   return {
     enabled,
     publicBaseUrl,

--- a/assistant/src/runtime/routes/__tests__/ingress-status-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/ingress-status-routes.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Unit tests for the integrations_ingress_status route handler.
+ *
+ * The workspace config reads and the probe are both mocked, so the five
+ * states are exercised without a config file or network access.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { LastTunnelRecord } from "../../../daemon/handlers/config-ingress.js";
+import type { TunnelProbeResult } from "../../../inbound/tunnel-probe.js";
+import { ACTOR_PRINCIPALS } from "../../auth/route-policy.js";
+
+let ingressConfig = {
+  enabled: false,
+  publicBaseUrl: "",
+  localGatewayTarget: "http://127.0.0.1:4000",
+  managedCallbacks: false,
+  success: true,
+};
+let lastTunnel: LastTunnelRecord | null = null;
+let recordedAssistantId: string | null = null;
+let probeResult: TunnelProbeResult = { kind: "healthy" };
+
+const probeTunnelMock = mock(
+  async (_args: {
+    publicBaseUrl: string;
+    expectedAssistantId?: string;
+  }): Promise<TunnelProbeResult> => probeResult,
+);
+
+mock.module("../../../daemon/handlers/config-ingress.js", () => ({
+  getIngressConfigResult: () => ingressConfig,
+  loadLastTunnelRecord: () => lastTunnel,
+  loadRecordedAssistantId: () => recordedAssistantId,
+}));
+
+mock.module("../../../inbound/tunnel-probe.js", () => ({
+  probeTunnel: probeTunnelMock,
+}));
+
+import { ROUTES } from "../ingress-status-routes.js";
+
+const route = ROUTES.find(
+  (r) => r.operationId === "integrations_ingress_status",
+)!;
+
+const TUNNEL_URL = "https://assistant-1.example.ts.net";
+
+describe("integrations_ingress_status route", () => {
+  beforeEach(() => {
+    ingressConfig = {
+      enabled: false,
+      publicBaseUrl: "",
+      localGatewayTarget: "http://127.0.0.1:4000",
+      managedCallbacks: false,
+      success: true,
+    };
+    lastTunnel = null;
+    recordedAssistantId = null;
+    probeResult = { kind: "healthy" };
+    probeTunnelMock.mockClear();
+  });
+
+  test("is registered with the expected operationId, method, and endpoint", () => {
+    expect(route).toBeDefined();
+    expect(route.method).toBe("GET");
+    expect(route.endpoint).toBe("integrations/ingress/status");
+    expect(route.policy).toEqual({
+      requiredScopes: ["settings.read"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    });
+  });
+
+  test("reports unconfigured for a platform-hosted assistant", async () => {
+    ingressConfig = {
+      ...ingressConfig,
+      enabled: true,
+      publicBaseUrl: "https://platform.example.com/gateway/callbacks/a-1",
+      managedCallbacks: true,
+    };
+    lastTunnel = { provider: "tailscale", publicBaseUrl: TUNNEL_URL };
+
+    expect(await route.handler({})).toEqual({ state: "unconfigured" });
+    expect(probeTunnelMock).not.toHaveBeenCalled();
+  });
+
+  test("reports unconfigured with no URL and no recorded tunnel", async () => {
+    expect(await route.handler({})).toEqual({ state: "unconfigured" });
+    expect(probeTunnelMock).not.toHaveBeenCalled();
+  });
+
+  test("reports stopped with the recorded tunnel when the URL is gone", async () => {
+    lastTunnel = { provider: "tailscale", publicBaseUrl: TUNNEL_URL };
+
+    expect(await route.handler({})).toEqual({
+      state: "stopped",
+      lastTunnel: { provider: "tailscale", publicBaseUrl: TUNNEL_URL },
+    });
+    expect(probeTunnelMock).not.toHaveBeenCalled();
+  });
+
+  test("reports healthy with a timestamp when the probe succeeds", async () => {
+    ingressConfig = {
+      ...ingressConfig,
+      enabled: true,
+      publicBaseUrl: TUNNEL_URL,
+    };
+    recordedAssistantId = "assistant-1";
+
+    const result = (await route.handler({})) as Record<string, unknown>;
+
+    expect(result.state).toBe("healthy");
+    expect(result.publicBaseUrl).toBe(TUNNEL_URL);
+    expect(new Date(result.checkedAt as string).getTime()).not.toBeNaN();
+    expect(probeTunnelMock).toHaveBeenCalledWith({
+      publicBaseUrl: TUNNEL_URL,
+      expectedAssistantId: "assistant-1",
+    });
+  });
+
+  test("omits expectedAssistantId when no id was recorded", async () => {
+    ingressConfig = {
+      ...ingressConfig,
+      enabled: true,
+      publicBaseUrl: TUNNEL_URL,
+    };
+
+    await route.handler({});
+
+    expect(probeTunnelMock).toHaveBeenCalledWith({
+      publicBaseUrl: TUNNEL_URL,
+    });
+  });
+
+  test("reports unreachable with the probe's detail", async () => {
+    ingressConfig = {
+      ...ingressConfig,
+      enabled: true,
+      publicBaseUrl: TUNNEL_URL,
+    };
+    probeResult = { kind: "unreachable", detail: "HTTP 502" };
+
+    const result = (await route.handler({})) as Record<string, unknown>;
+
+    expect(result.state).toBe("unreachable");
+    expect(result.detail).toBe("HTTP 502");
+    expect(result.publicBaseUrl).toBe(TUNNEL_URL);
+    expect(result.checkedAt).toBeString();
+  });
+
+  test("reports foreign with the name the edge serves under", async () => {
+    ingressConfig = {
+      ...ingressConfig,
+      enabled: true,
+      publicBaseUrl: TUNNEL_URL,
+    };
+    recordedAssistantId = "assistant-1";
+    probeResult = {
+      kind: "foreign",
+      assistantId: "assistant-2",
+      assistantName: "Other Assistant",
+    };
+
+    const result = (await route.handler({})) as Record<string, unknown>;
+
+    expect(result.state).toBe("foreign");
+    expect(result.servingAssistantName).toBe("Other Assistant");
+    expect(result.publicBaseUrl).toBe(TUNNEL_URL);
+  });
+
+  test("omits servingAssistantName when the edge reports no name", async () => {
+    ingressConfig = {
+      ...ingressConfig,
+      enabled: true,
+      publicBaseUrl: TUNNEL_URL,
+    };
+    probeResult = { kind: "foreign", assistantId: "assistant-2" };
+
+    const result = (await route.handler({})) as Record<string, unknown>;
+
+    expect(result.state).toBe("foreign");
+    expect(result).not.toHaveProperty("servingAssistantName");
+  });
+
+  test("treats a whitespace-only URL as no URL", async () => {
+    ingressConfig = { ...ingressConfig, enabled: true, publicBaseUrl: "   " };
+
+    expect(await route.handler({})).toEqual({ state: "unconfigured" });
+    expect(probeTunnelMock).not.toHaveBeenCalled();
+  });
+});

--- a/assistant/src/runtime/routes/index.ts
+++ b/assistant/src/runtime/routes/index.ts
@@ -91,6 +91,7 @@ import { ROUTES as INFERENCE_PROFILE_SESSION_ROUTES } from "./inference-profile-
 import { ROUTES as INFERENCE_PROFILES_ROUTES } from "./inference-profiles-routes.js";
 import { ROUTES as INFERENCE_PROVIDER_CONNECTION_ROUTES } from "./inference-provider-connection-routes.js";
 import { ROUTES as INFERENCE_SEND_ROUTES } from "./inference-send-routes.js";
+import { ROUTES as INGRESS_STATUS_ROUTES } from "./ingress-status-routes.js";
 import { ROUTES as A2A_ROUTES } from "./integrations/a2a.js";
 import { ROUTES as SLACK_CHANNEL_CONFIG_ROUTES } from "./integrations/slack/channel.js";
 import { ROUTES as SLACK_CHANNELS_ROUTES } from "./integrations/slack/channels.js";
@@ -240,6 +241,7 @@ export const ROUTES: RouteDefinition[] = [
   ...INFERENCE_PROFILES_ROUTES,
   ...INFERENCE_PROVIDER_CONNECTION_ROUTES,
   ...INFERENCE_SEND_ROUTES,
+  ...INGRESS_STATUS_ROUTES,
   ...INTERNAL_OAUTH_ROUTES,
   ...INTERNAL_TELEMETRY_ROUTES,
   ...MCP_AUTH_ROUTES,

--- a/assistant/src/runtime/routes/ingress-status-routes.ts
+++ b/assistant/src/runtime/routes/ingress-status-routes.ts
@@ -1,0 +1,124 @@
+/**
+ * Ingress status route: is the assistant's public tunnel actually up?
+ *
+ * The recorded `ingress.publicBaseUrl` only says a tunnel was configured at
+ * some point. It stays behind in both directions: a killed tunnel leaves the
+ * URL in place, and an edge can survive while the gateway behind it dies or
+ * while it starts fronting a different assistant. This route resolves that by
+ * probing the URL live (`inbound/tunnel-probe.ts`) and reporting one of five
+ * states, so a client can tell the user what to do instead of guessing.
+ *
+ * Platform-hosted assistants receive webhooks through platform callback
+ * routing and never run `vellum tunnel`, so they report `unconfigured`
+ * rather than a tunnel state they cannot act on.
+ */
+import { z } from "zod";
+
+import {
+  getIngressConfigResult,
+  loadLastTunnelRecord,
+  loadRecordedAssistantId,
+} from "../../daemon/handlers/config-ingress.js";
+import { probeTunnel } from "../../inbound/tunnel-probe.js";
+import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
+import type { RouteDefinition } from "./types.js";
+
+// ── Schemas ─────────────────────────────────────────────────────────────
+
+/**
+ * Flat rather than a union on `state` so the generated client SDK stays a
+ * single type; which fields are populated follows from `state`.
+ */
+const IngressStatusResponseSchema = z.object({
+  state: z.enum([
+    "unconfigured",
+    "stopped",
+    "healthy",
+    "unreachable",
+    "foreign",
+  ]),
+  publicBaseUrl: z
+    .string()
+    .optional()
+    .describe("The probed URL. Set for healthy, unreachable, and foreign."),
+  lastTunnel: z
+    .object({ provider: z.string(), publicBaseUrl: z.string() })
+    .optional()
+    .describe("The tunnel to restart. Set for stopped."),
+  servingAssistantName: z
+    .string()
+    .optional()
+    .describe(
+      "Name the edge serves under. Set for foreign when it reports one.",
+    ),
+  detail: z
+    .string()
+    .optional()
+    .describe("Short failure reason, free of the URL. Set for unreachable."),
+  checkedAt: z
+    .string()
+    .optional()
+    .describe("ISO-8601 instant the probe finished. Set whenever one ran."),
+});
+type IngressStatusResponse = z.infer<typeof IngressStatusResponseSchema>;
+
+// ── Handlers ────────────────────────────────────────────────────────────
+
+async function handleIngressStatus(): Promise<IngressStatusResponse> {
+  const config = getIngressConfigResult();
+  if (config.managedCallbacks) {
+    return { state: "unconfigured" };
+  }
+
+  const publicBaseUrl = config.publicBaseUrl.trim();
+  if (!publicBaseUrl) {
+    const lastTunnel = loadLastTunnelRecord();
+    return lastTunnel
+      ? { state: "stopped", lastTunnel }
+      : { state: "unconfigured" };
+  }
+
+  // Omitted when unrecorded so the probe skips the identity check entirely
+  // rather than reading every served id as a mismatch.
+  const expectedAssistantId = loadRecordedAssistantId();
+  const result = await probeTunnel({
+    publicBaseUrl,
+    ...(expectedAssistantId ? { expectedAssistantId } : {}),
+  });
+  const checked = { publicBaseUrl, checkedAt: new Date().toISOString() };
+
+  switch (result.kind) {
+    case "healthy":
+      return { state: "healthy", ...checked };
+    case "unreachable":
+      return { state: "unreachable", ...checked, detail: result.detail };
+    case "foreign":
+      return {
+        state: "foreign",
+        ...checked,
+        ...(result.assistantName
+          ? { servingAssistantName: result.assistantName }
+          : {}),
+      };
+  }
+}
+
+// ── Route definitions ───────────────────────────────────────────────────
+
+export const ROUTES: RouteDefinition[] = [
+  {
+    operationId: "integrations_ingress_status",
+    endpoint: "integrations/ingress/status",
+    method: "GET",
+    policy: {
+      requiredScopes: ["settings.read"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "Get ingress tunnel status",
+    description:
+      "Probe the configured public ingress URL and report whether a tunnel is serving this assistant. `unconfigured` means no tunnel has ever been recorded (or the assistant is platform-hosted, which never uses one), `stopped` means a tunnel ran before and `lastTunnel` names it, `healthy` means the URL answers and fronts this assistant, `unreachable` means it does not answer, and `foreign` means it answers for a different assistant.",
+    tags: ["config"],
+    handler: handleIngressStatus,
+    responseBody: IngressStatusResponseSchema,
+  },
+];


### PR DESCRIPTION
## Summary

- Adds `GET /v1/integrations/ingress/status`, which probes the recorded public ingress URL and reports one of five states (`unconfigured`, `stopped`, `healthy`, `unreachable`, `foreign`) so the Pair-a-device card can stop inferring tunnel health from the platform's stale `ingress_url`.
- Adds assistant-side readers for the `ingress.lastTunnel` / `ingress.assistantId` records the CLI writes, alongside the existing ingress-config read in `config-ingress.ts`. The assistant package does not depend on `cli/`, so it reads the same workspace-config keys rather than importing the CLI's readers, and hardens `getIngressConfigResult()` to return typed fallbacks for a hand-edited config.
- Platform-hosted assistants report `unconfigured`: they never run `vellum tunnel`, so they must not be handed a tunnel state they cannot act on.

Part of plan: tunnel-status-pairing.md (PR 5 of 9)