### PR TITLE
fix: companion size and coachmark, approvals raise the app, and Fn stops being a default

### DIFF
--- a/clients/macos/src/main/companion-window.test.ts
+++ b/clients/macos/src/main/companion-window.test.ts
@@ -294,13 +294,13 @@ describe("introOnAdvance", () => {
   test("walks to the next beat", () => {
     expect(introOnAdvance("meet", "next")).toBe("talk");
     expect(introOnAdvance("talk", "next")).toBe("type");
-    expect(introOnAdvance("type", "next")).toBe("tray");
+    expect(introOnAdvance("type", "next")).toBe("menu");
   });
 
   // Past the last beat there is no next one, and `null` is what main reads as
   // the run being over and worth recording.
   test("falls off the end of the last beat", () => {
-    expect(introOnAdvance("tray", "next")).toBe(null);
+    expect(introOnAdvance("menu", "next")).toBe(null);
   });
 
   test("dismiss ends the run from any beat", () => {

--- a/clients/macos/src/main/companion-window.ts
+++ b/clients/macos/src/main/companion-window.ts
@@ -760,14 +760,23 @@ export const installCompanionWindow = (): void => {
     }
     const current = readCompanionSize();
     const menu = Menu.buildFromTemplate([
-      ...COMPANION_SIZES.map((size) => ({
-        label: COMPANION_SIZE_LABELS[size],
-        type: "radio" as const,
-        checked: current === size,
-        click: () => {
-          setCompanionSurfaceSize(size);
-        },
-      })),
+      {
+        // The sizes sit under a heading rather than flat at the top level.
+        // Flat, the first thing a right-click offered was four words that only
+        // read as sizes once you had noticed they were sizes, and the one item
+        // that was not a size sat at the end of the same list. A named submenu
+        // says what the four are before it shows them, and leaves the top level
+        // short enough to read at a glance.
+        label: "Size",
+        submenu: COMPANION_SIZES.map((size) => ({
+          label: COMPANION_SIZE_LABELS[size],
+          type: "radio" as const,
+          checked: current === size,
+          click: () => {
+            setCompanionSurfaceSize(size);
+          },
+        })),
+      },
       { type: "separator" as const },
       {
         // Named for what it does to the thing under the cursor. The tray's item

--- a/clients/web/eslint.config.mjs
+++ b/clients/web/eslint.config.mjs
@@ -190,6 +190,7 @@ const authBoundaryAllowedPaths = [
  * noise, which is how these rules die.
  */
 const i18nEnforcedPaths = [
+  "src/components/companion-intro.tsx",
   "src/components/not-found.tsx",
   "src/components/section-actions-button.tsx",
   "src/domains/chat/components/allow-options-menu.tsx",

--- a/clients/web/src/components/companion-intro.tsx
+++ b/clients/web/src/components/companion-intro.tsx
@@ -8,6 +8,8 @@ import type {
 } from "@vellumai/ipc-contract";
 import type { CSSProperties, Ref } from "react";
 
+import { useTranslation } from "@/i18n";
+
 import type {
   CompanionSurfaceCardGrowth,
   CompanionSurfaceGrowth,
@@ -58,37 +60,47 @@ const AVATAR_BOX = 44;
  */
 const CARD_WIDTH = 244;
 
-interface IntroCopy {
-  title: string;
-  body: string;
-}
-
 /**
- * What each beat says.
+ * Where each beat's two lines live, by beat.
  *
  * Two short lines and no more. This is a panel floating over the app the user
  * was actually using, so every extra sentence is a sentence read at the expense
  * of the thing being pointed at, and the controls being introduced already
  * carry their own labels.
+ *
+ * A literal key per beat rather than a template built from the beat name: the
+ * catalogs type `t()`, and a key assembled at runtime types as `string` and
+ * checks against nothing, which is how a renamed beat becomes a card printing
+ * its own key path at someone.
+ *
+ * **`talk` and `type` quote the pill.** Their titles are the labels on the two
+ * controls the beat spotlights, so they are not free copy: when the surface
+ * itself is translated (`companion-surface.tsx` is still English throughout),
+ * these two titles move with the labels, in the same edit and to the same
+ * words. A card reading "Hablar" beside a button reading "Talk" points at
+ * nothing.
  */
-export const INTRO_COPY: Record<CompanionIntroBeat, IntroCopy> = {
+const INTRO_COPY_KEYS = {
   meet: {
-    title: "This is me",
-    body: "I stay on your desktop, even when Vellum isn’t visible.",
+    title: "companionIntro.meet.title",
+    body: "companionIntro.meet.body",
   },
   talk: {
-    title: "Talk",
-    body: "Start a voice conversation.",
+    title: "companionIntro.talk.title",
+    body: "companionIntro.talk.body",
   },
   type: {
-    title: "Type",
-    body: "Send a message from here and read the reply here too.",
+    title: "companionIntro.type.title",
+    body: "companionIntro.type.body",
   },
   menu: {
-    title: "Right-click me",
-    body: "That’s where you hide me or change my size.",
+    title: "companionIntro.menu.title",
+    body: "companionIntro.menu.body",
   },
-};
+} as const satisfies Record<
+  CompanionIntroBeat,
+  { title: string; body: string }
+>;
 
 /**
  * Which control the pill should draw as though the pointer were on it.
@@ -153,9 +165,10 @@ export function CompanionIntro({
   cardRef,
   onAdvance,
 }: CompanionIntroProps) {
+  const { t } = useTranslation();
   const index = COMPANION_INTRO_BEATS.indexOf(beat);
   const isLast = index === COMPANION_INTRO_BEATS.length - 1;
-  const copy = INTRO_COPY[beat];
+  const copy = INTRO_COPY_KEYS[beat];
 
   // The pill's own horizontal anchoring, repeated rather than shared, because
   // the card is a sibling of the pill and not inside it: it must not inherit
@@ -189,7 +202,7 @@ export function CompanionIntro({
       // pointer, so claiming a dialog's semantics would promise keyboard
       // behaviour this panel cannot deliver.
       role="group"
-      aria-label="Introducing your companion"
+      aria-label={t("companionIntro.ariaLabel")}
       className="absolute flex flex-col gap-2 rounded-2xl border border-white/10 bg-[#17181b]/95 px-3.5 py-3 shadow-lg shadow-black/40"
       style={{ width: CARD_WIDTH, ...placement, ...anchor }}
       // The card is not a drag handle. Everything else on this surface is, and
@@ -200,9 +213,9 @@ export function CompanionIntro({
       }}
     >
       <p className="text-[13px] leading-tight font-medium text-white">
-        {copy.title}
+        {t(copy.title)}
       </p>
-      <p className="text-[12px] leading-[1.45] text-white/70">{copy.body}</p>
+      <p className="text-[12px] leading-[1.45] text-white/70">{t(copy.body)}</p>
       <div className="flex items-center justify-between pt-0.5">
         {/* Where the run is, as dots rather than "2 of 3". The count is not
             information anyone acts on; that it is nearly over is. */}
@@ -231,7 +244,7 @@ export function CompanionIntro({
               className="h-7 rounded-full px-2.5 text-[12px] text-white/55 transition-colors hover:bg-white/10 hover:text-white/80"
               onClick={() => onAdvance?.("dismiss")}
             >
-              Skip
+              {t("companionIntro.skip")}
             </button>
           )}
           <button
@@ -239,7 +252,7 @@ export function CompanionIntro({
             className="h-7 rounded-full bg-white/15 px-3 text-[12px] text-white transition-colors hover:bg-white/25"
             onClick={() => onAdvance?.("next")}
           >
-            {isLast ? "Got it" : "Next"}
+            {isLast ? t("companionIntro.done") : t("companionIntro.next")}
           </button>
         </div>
       </div>

--- a/clients/web/src/components/companion-intro.tsx
+++ b/clients/web/src/components/companion-intro.tsx
@@ -223,7 +223,12 @@ export function CompanionIntro({
         event.stopPropagation();
       }}
     >
-      <p className="text-[13px] leading-tight font-medium text-white">
+      {/* Clamped, because the only variable in this card is a name the user
+          chose and there is no length it has to be. The card's width is fixed
+          and its height is borrowed from the canvas the typing card reserves,
+          so a title free to wrap is a title free to grow the card past what it
+          was drawn into. Two lines holds every name worth reading. */}
+      <p className="line-clamp-2 text-[13px] leading-tight font-medium text-white">
         {/* The first beat is the introduction proper, so it is the one that
             says the name. Two keys rather than one with an empty argument: a
             sentence built around a name that is not there reads as a bug, and

--- a/clients/web/src/components/companion-intro.tsx
+++ b/clients/web/src/components/companion-intro.tsx
@@ -84,9 +84,9 @@ export const INTRO_COPY: Record<CompanionIntroBeat, IntroCopy> = {
     title: "Type",
     body: "Send a message from here and read the reply here too.",
   },
-  tray: {
-    title: "Hide me anytime",
-    body: "Disable “Show Companion” in the menu bar.",
+  menu: {
+    title: "Right-click me",
+    body: "That’s where you hide me or change my size.",
   },
 };
 
@@ -94,9 +94,9 @@ export const INTRO_COPY: Record<CompanionIntroBeat, IntroCopy> = {
  * Which control the pill should draw as though the pointer were on it.
  *
  * Only the beats that name a control on the pill have one. `meet` is about the
- * creature, and `tray` is about the menu bar, which is not on the surface at
- * all. Shared with the page and the stories so a beat cannot be introduced in
- * one place and spotlighted in another.
+ * creature, and `menu` is about a right-click on it, which no control on the
+ * pill stands for. Shared with the page and the stories so a beat cannot be
+ * introduced in one place and spotlighted in another.
  */
 export const introSpotlight = (
   beat: CompanionIntroBeat | null,

--- a/clients/web/src/components/companion-intro.tsx
+++ b/clients/web/src/components/companion-intro.tsx
@@ -145,6 +145,16 @@ export interface CompanionIntroProps {
   /** The assistant's avatar colour, for the progress dots. */
   accentHex?: string;
   /**
+   * The assistant's own name, for the first beat.
+   *
+   * The creature introduces itself by name because it has one, and the surface
+   * is the one place it appears without the app around it to say whose it is.
+   * Undefined until the app's window has published a name, which is a real
+   * state on a cold launch, and the beat falls back to naming no one rather
+   * than to a gap in the sentence.
+   */
+  assistantName?: string;
+  /**
    * The card's own element, for the host to hit-test the pointer against.
    *
    * The companion's window is click-through except where it is told otherwise,
@@ -162,6 +172,7 @@ export function CompanionIntro({
   growth = "right",
   cardGrowth = "up",
   accentHex,
+  assistantName,
   cardRef,
   onAdvance,
 }: CompanionIntroProps) {
@@ -213,7 +224,14 @@ export function CompanionIntro({
       }}
     >
       <p className="text-[13px] leading-tight font-medium text-white">
-        {t(copy.title)}
+        {/* The first beat is the introduction proper, so it is the one that
+            says the name. Two keys rather than one with an empty argument: a
+            sentence built around a name that is not there reads as a bug, and
+            the unnamed version is a different sentence rather than the same one
+            with a hole in it. */}
+        {beat === "meet" && assistantName !== undefined
+          ? t("companionIntro.meet.titleNamed", { name: assistantName })
+          : t(copy.title)}
       </p>
       <p className="text-[12px] leading-[1.45] text-white/70">{t(copy.body)}</p>
       <div className="flex items-center justify-between pt-0.5">

--- a/clients/web/src/components/companion-surface-page.test.tsx
+++ b/clients/web/src/components/companion-surface-page.test.tsx
@@ -31,6 +31,7 @@ const resetState = () => {
   STATE.working = false;
   STATE.call = null;
   STATE.intro = null;
+  STATE.assistantName = "Ziggy";
 };
 
 /**
@@ -315,6 +316,22 @@ describe("the companion's introduction", () => {
 
   test("draws the beat main is holding", async () => {
     STATE.intro = "meet";
+    const { container } = render(<CompanionSurfacePage />);
+    const card = await pinCard(container);
+    // The creature introduces itself by name. The surface is the one place it
+    // appears with none of the app around it to say whose it is.
+    expect(card.textContent).toContain("Ziggy here!");
+  });
+
+  /**
+   * A cold launch reaches the surface before the app's window has published a
+   * name, and the first beat is the one most likely to be on screen when it
+   * does. The unnamed version is a different sentence rather than the same one
+   * with a hole where the name goes.
+   */
+  test("introduces the creature unnamed until a name arrives", async () => {
+    STATE.intro = "meet";
+    STATE.assistantName = "";
     const { container } = render(<CompanionSurfacePage />);
     const card = await pinCard(container);
     expect(card.textContent).toContain("This is me");

--- a/clients/web/src/components/companion-surface-page.test.tsx
+++ b/clients/web/src/components/companion-surface-page.test.tsx
@@ -320,7 +320,7 @@ describe("the companion's introduction", () => {
     const card = await pinCard(container);
     // The creature introduces itself by name. The surface is the one place it
     // appears with none of the app around it to say whose it is.
-    expect(card.textContent).toContain("Ziggy here!");
+    expect(card.textContent).toContain("I’m Ziggy");
   });
 
   /**

--- a/clients/web/src/components/companion-surface-page.test.tsx
+++ b/clients/web/src/components/companion-surface-page.test.tsx
@@ -386,7 +386,7 @@ describe("the companion's introduction", () => {
    * presses meant for whatever the user was working in.
    */
   test("gives the desktop back when the run ends under the pointer", async () => {
-    STATE.intro = "tray";
+    STATE.intro = "menu";
     const { container } = render(<CompanionSurfacePage />);
     await pinPill(container);
     await pinCard(container);

--- a/clients/web/src/components/companion-surface-page.tsx
+++ b/clients/web/src/components/companion-surface-page.tsx
@@ -434,6 +434,11 @@ export function CompanionSurfacePage() {
                 growth={growth}
                 cardGrowth={cardGrowth}
                 accentHex={accentHex}
+                // Same undefined-not-empty rule as the composer's placeholder
+                // above: the first beat introduces the creature by name, and
+                // before the app's window has published one there is no name to
+                // introduce it by.
+                assistantName={assistantName === "" ? undefined : assistantName}
                 cardRef={introRef}
                 onAdvance={advanceCompanionIntro}
               />

--- a/clients/web/src/domains/chat/utils/stream-handlers/interaction-handlers.test.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/interaction-handlers.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, beforeEach } from "bun:test";
+import { afterEach, describe, expect, it, beforeEach, mock } from "bun:test";
 
 import { useChatSessionStore } from "@/domains/chat/chat-session-store";
 import { useInteractionStore } from "@/domains/chat/interaction-store";
@@ -6,12 +6,27 @@ import type { DisplayMessage } from "@/domains/chat/types/types";
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
 import { textBody } from "@/domains/chat/utils/message-test-helpers";
 import { makeCtx } from "@/domains/chat/utils/stream-handlers/test-helpers";
-import {
+
+/**
+ * The host capability the confirmation handler reaches for, stubbed so the
+ * raise is observable. Off Electron the real one no-ops, which would make
+ * "raises the window" and "does nothing at all" the same passing test.
+ *
+ * Declared before the handlers are imported, so the module under test binds to
+ * the stub: same shape as `start-voice-request.test.ts`, the other caller of
+ * this seam.
+ */
+const ensureMainWindowVisibleMock = mock(() => Promise.resolve());
+mock.module("@/runtime/main-window", () => ({
+  ensureMainWindowVisible: ensureMainWindowVisibleMock,
+}));
+
+const {
   handleSecretRequest,
   handleConfirmationRequest,
   handleContactRequest,
   handleInteractionResolved,
-} from "@/domains/chat/utils/stream-handlers/interaction-handlers";
+} = await import("@/domains/chat/utils/stream-handlers/interaction-handlers");
 
 function seedSnapshot(messages: DisplayMessage[]): void {
   useChatSessionStore.setState({
@@ -32,6 +47,7 @@ function runningToolCall(id: string): ChatMessageToolCall {
 beforeEach(() => {
   useInteractionStore.getState().resetAll();
   useChatSessionStore.getState().deleteConfirmationToolCall("cr-1");
+  ensureMainWindowVisibleMock.mockClear();
 });
 
 afterEach(() => {
@@ -146,6 +162,53 @@ describe("handleConfirmationRequest", () => {
       useInteractionStore.getState().inlineConfirmationToolCallId,
     ).toBeNull();
     expect(ctx.setConfirmationToolCall).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The card that answers a confirmation is drawn in the app's window, and the
+   * turn that raised it need not have been started there: a message typed on
+   * the companion, or a scheduled run, leaves the window behind whatever the
+   * user is working in, and a request nobody can see is a run that has stopped
+   * for no visible reason.
+   */
+  it("brings the app forward so the request can be answered", () => {
+    handleConfirmationRequest(
+      {
+        type: "confirmation_request",
+        requestId: "cr-1",
+        toolName: "bash",
+        input: { command: "rm -rf ." },
+        riskLevel: "high",
+        allowlistOptions: [],
+        scopeOptions: [],
+      },
+      makeCtx(),
+    );
+
+    expect(ensureMainWindowVisibleMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+/**
+ * The other prompts are deliberately not raises. A secret is asked for at the
+ * point the user set up an integration, and a contact request is a field on a
+ * card that is already on screen, so neither is the assistant stopped on a
+ * question the user cannot see.
+ */
+describe("prompts that do not raise the window", () => {
+  it("leaves the window where it is for a secret request", () => {
+    handleSecretRequest(
+      {
+        type: "secret_request",
+        requestId: "sr-1",
+        service: "openai",
+        field: "api_key",
+        label: "API Key",
+      },
+      makeCtx(),
+    );
+
+    expect(ensureMainWindowVisibleMock).not.toHaveBeenCalled();
   });
 });
 

--- a/clients/web/src/domains/chat/utils/stream-handlers/interaction-handlers.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/interaction-handlers.ts
@@ -11,6 +11,7 @@ import type {
   SecretRequestEvent,
 } from "@vellumai/assistant-api";
 import { normalizeQuestionRequest } from "@/domains/chat/api/event-types";
+import { ensureMainWindowVisible } from "@/runtime/main-window";
 
 export function handleSecretRequest(
   event: SecretRequestEvent,
@@ -49,6 +50,22 @@ export function handleConfirmationRequest(
     toolUseId: event.toolUseId,
   };
   useInteractionStore.getState().showConfirmation(confData);
+
+  // **And the window comes forward.** A confirmation is the one thing the
+  // assistant cannot get past on its own, and the card that answers it is drawn
+  // in the app's window. A turn started from the companion, or by a schedule,
+  // or from anywhere else while the user is working in another app, leaves that
+  // window behind whatever is in front of it, so the run stops on a question
+  // nobody can see and the assistant reads as having gone quiet.
+  //
+  // Off Electron this is a no-op (`main-window` wraps a host capability the web
+  // and iOS builds do not have), and a window already frontmost is raised to
+  // where it already is. Fire and forget: nothing below waits on it.
+  //
+  // The better end state is answering the request on the companion itself,
+  // which is not this: the surface holds no interaction store and no way to
+  // send a decision, only the words of a message and the tail of a reply.
+  void ensureMainWindowVisible();
 
   // The reducer folds the inline confirmation marker onto the tool-call row in
   // the snapshot. Here we only need the matched tool-call id for the

--- a/clients/web/src/domains/chat/voice/use-voice-mode-hotkey.test.tsx
+++ b/clients/web/src/domains/chat/voice/use-voice-mode-hotkey.test.tsx
@@ -42,6 +42,7 @@ const {
   keyboardDefaultActivator,
   writeVoiceModeActivator,
 } = await import("@/utils/voice-mode-activation");
+const { FN_PTT_ACTIVATOR } = await import("@/utils/ptt-activator");
 const { useVoiceModeHotkey } =
   await import("@/domains/chat/voice/use-voice-mode-hotkey");
 
@@ -180,7 +181,22 @@ describe("useVoiceModeHotkey", () => {
       fnSupported = true;
     });
 
+    /**
+     * Fn only ever fires because the user went to Settings and chose it. It is
+     * not the default and cannot become one: the Globe key belongs to the OS
+     * (Start Dictation, on a lot of machines) and to whatever the user has it
+     * doing, so an install that took it would be one press doing two things.
+     */
+    test("does nothing until it has been chosen in settings", () => {
+      renderVoiceModeHotkey();
+
+      emitHotkeyEvent?.({ kind: "fnPushToTalk", state: "down" });
+
+      expect(startVoiceFromSurface).not.toHaveBeenCalled();
+    });
+
     test("toggles on the down edge and ignores the release", () => {
+      writeVoiceModeActivator(FN_PTT_ACTIVATOR);
       renderVoiceModeHotkey();
 
       emitHotkeyEvent?.({ kind: "fnPushToTalk", state: "down" });

--- a/clients/web/src/i18n/locales/en/common.json
+++ b/clients/web/src/i18n/locales/en/common.json
@@ -2,6 +2,28 @@
   "addCreditsModal": {
     "configureAutoReload": "Configure Auto-Reload"
   },
+  "companionIntro": {
+    "ariaLabel": "Introducing your companion",
+    "meet": {
+      "title": "This is me",
+      "body": "I stay on your desktop, even when Vellum isn’t visible."
+    },
+    "talk": {
+      "title": "Talk",
+      "body": "Start a voice conversation."
+    },
+    "type": {
+      "title": "Type",
+      "body": "Send a message from here and read the reply here too."
+    },
+    "menu": {
+      "title": "Right-click me",
+      "body": "That’s where you hide me or change my size."
+    },
+    "skip": "Skip",
+    "next": "Next",
+    "done": "Got it"
+  },
   "notFound": {
     "badge": "Error 404",
     "title": "Page not found",

--- a/clients/web/src/i18n/locales/en/common.json
+++ b/clients/web/src/i18n/locales/en/common.json
@@ -6,7 +6,7 @@
     "ariaLabel": "Introducing your companion",
     "meet": {
       "title": "This is me",
-      "titleNamed": "{name} here!",
+      "titleNamed": "I’m {name}",
       "body": "I stay on your desktop, even when Vellum isn’t visible."
     },
     "talk": {

--- a/clients/web/src/i18n/locales/en/common.json
+++ b/clients/web/src/i18n/locales/en/common.json
@@ -6,6 +6,7 @@
     "ariaLabel": "Introducing your companion",
     "meet": {
       "title": "This is me",
+      "titleNamed": "{name} here!",
       "body": "I stay on your desktop, even when Vellum isn’t visible."
     },
     "talk": {

--- a/clients/web/src/i18n/locales/es/common.json
+++ b/clients/web/src/i18n/locales/es/common.json
@@ -2,6 +2,28 @@
   "addCreditsModal": {
     "configureAutoReload": "Configurar la recarga automática"
   },
+  "companionIntro": {
+    "ariaLabel": "Te presento a tu compañero",
+    "meet": {
+      "title": "Este soy yo",
+      "body": "Me quedo en tu escritorio, aunque Vellum no esté a la vista."
+    },
+    "talk": {
+      "title": "Talk",
+      "body": "Inicia una conversación por voz."
+    },
+    "type": {
+      "title": "Type",
+      "body": "Envía un mensaje desde aquí y lee la respuesta aquí también."
+    },
+    "menu": {
+      "title": "Haz clic derecho sobre mí",
+      "body": "Ahí puedes ocultarme o cambiar mi tamaño."
+    },
+    "skip": "Omitir",
+    "next": "Siguiente",
+    "done": "Entendido"
+  },
   "notFound": {
     "badge": "Error 404",
     "title": "Página no encontrada",

--- a/clients/web/src/i18n/locales/es/common.json
+++ b/clients/web/src/i18n/locales/es/common.json
@@ -6,7 +6,7 @@
     "ariaLabel": "Te presento a tu compañero",
     "meet": {
       "title": "Este soy yo",
-      "titleNamed": "¡{name} al habla!",
+      "titleNamed": "Soy {name}",
       "body": "Me quedo en tu escritorio, aunque Vellum no esté a la vista."
     },
     "talk": {

--- a/clients/web/src/i18n/locales/es/common.json
+++ b/clients/web/src/i18n/locales/es/common.json
@@ -6,6 +6,7 @@
     "ariaLabel": "Te presento a tu compañero",
     "meet": {
       "title": "Este soy yo",
+      "titleNamed": "¡{name} al habla!",
       "body": "Me quedo en tu escritorio, aunque Vellum no esté a la vista."
     },
     "talk": {

--- a/clients/web/src/utils/voice-mode-activation.test.ts
+++ b/clients/web/src/utils/voice-mode-activation.test.ts
@@ -45,7 +45,15 @@ describe("readVoiceModeActivator", () => {
     expect(readVoiceModeActivator(false)).toEqual(keyboardDefaultActivator());
   });
 
-  test("defaults to Fn where the host can see it", () => {
+  test("binds nothing on a Fn-capable host until the user picks a key", () => {
+    // The release blocker this answers: Fn used to be the out-of-the-box
+    // binding, so a fresh install claimed the Globe key from whatever the OS
+    // had it doing (Start Dictation, on a lot of machines) without ever asking.
+    expect(readVoiceModeActivator(true)).toEqual({ kind: "off" });
+  });
+
+  test("honours Fn once the user has chosen it", () => {
+    writeVoiceModeActivator(FN_PTT_ACTIVATOR);
     expect(readVoiceModeActivator(true)).toEqual(FN_PTT_ACTIVATOR);
   });
 
@@ -64,7 +72,7 @@ describe("readVoiceModeActivator", () => {
     expect(readVoiceModeActivator(false)).toEqual({ kind: "off" });
   });
 
-  test("falls back to the default rather than off for an unusable stored value", () => {
+  test("falls back to the host default for an unusable stored value", () => {
     // A bare modifier can reach storage from the push-to-talk era or a hand
     // edit. Falling back to "off" would leave voice unreachable by keyboard
     // with the settings toggle still reading as on.
@@ -90,7 +98,7 @@ describe("defaultVoiceModeActivator", () => {
     ).toBeGreaterThan(0);
   });
 
-  test("prefers Fn when the host offers it", () => {
-    expect(defaultVoiceModeActivator(true)).toEqual(FN_PTT_ACTIVATOR);
+  test("never hands out Fn, which is the user's key to give", () => {
+    expect(defaultVoiceModeActivator(true)).toEqual({ kind: "off" });
   });
 });

--- a/clients/web/src/utils/voice-mode-activation.ts
+++ b/clients/web/src/utils/voice-mode-activation.ts
@@ -4,7 +4,6 @@ import {
 } from "@/runtime/platform-detection";
 import { getLocalSetting, setLocalSetting } from "@/utils/local-settings";
 import {
-  FN_PTT_ACTIVATOR,
   type PTTActivator,
   eventActivatesPTT,
   isFnPushToTalkActivator,
@@ -51,11 +50,28 @@ export function keyboardDefaultActivator(): VoiceModeActivator {
   };
 }
 
-/** The out-of-the-box binding: Fn where the host can see it, else the chord. */
+/**
+ * The out-of-the-box binding: the chord where it is live, and nothing at all
+ * on a host that can see Fn.
+ *
+ * **Fn is never a default.** It is one key on the user's keyboard, it is not
+ * ours, and macOS already gives it away: the Globe key runs whatever "Press 🌐
+ * key to" is set to, which on a lot of machines is Start Dictation. Claiming it
+ * the moment the app is installed means one press doing two things, only one of
+ * which the user asked for, and the app that took it is the one that never
+ * asked. It also puts an Input Monitoring prompt in front of someone who has
+ * not gone looking for a shortcut. Choosing Fn in Settings is what binds it.
+ *
+ * A host that can see Fn is the macOS desktop app, where the chord rail is the
+ * global Talk shortcut and that ships unbound for its own reasons
+ * (`GLOBAL_SHORTCUT_DEFAULTS`). So nothing is bound there until the user says
+ * what should be, which is the honest answer rather than a chord this host
+ * would not listen for anyway.
+ */
 export function defaultVoiceModeActivator(
   fnAvailable: boolean,
 ): VoiceModeActivator {
-  return fnAvailable ? FN_PTT_ACTIVATOR : keyboardDefaultActivator();
+  return fnAvailable ? { kind: "off" } : keyboardDefaultActivator();
 }
 
 /**
@@ -83,10 +99,13 @@ export function isValidVoiceModeActivator(
 }
 
 /**
- * The stored binding, or the default when nothing is stored. A stored value
- * that binds nothing usable (a modifier-only leftover, or a Fn binding read
- * on a host that cannot see Fn) falls back to the default rather than to
- * "off", so voice mode never becomes unreachable by keyboard.
+ * The stored binding, or the host default when nothing usable is stored: a
+ * modifier-only leftover from the push-to-talk era, or a hand edit, reads as
+ * nothing stored rather than as a binding.
+ *
+ * A stored Fn binding read on a host that cannot see Fn is the one substitution
+ * rather than a fall back to the default: the user did ask for a shortcut, and
+ * the chord is the same request expressed in something this host can hear.
  */
 export function readVoiceModeActivator(
   fnAvailable: boolean,

--- a/packages/electron-desktop/src/companion-menu.ts
+++ b/packages/electron-desktop/src/companion-menu.ts
@@ -18,4 +18,5 @@ export const COMPANION_SIZE_LABELS: Record<CompanionSize, string> = {
   medium: "Medium",
   large: "Large",
   huge: "Huge",
+  ridiculous: "Ridiculous",
 };

--- a/packages/electron-desktop/src/tray-model.test.ts
+++ b/packages/electron-desktop/src/tray-model.test.ts
@@ -608,6 +608,7 @@ describe("companion toggle", () => {
       "Medium",
       "Large",
       "Huge",
+      "Ridiculous",
     ]);
   });
 

--- a/packages/ipc-contract/src/types.ts
+++ b/packages/ipc-contract/src/types.ts
@@ -658,13 +658,22 @@ export type CompanionCardGrowth = (typeof COMPANION_CARD_GROWTHS)[number];
  * Named rather than free, because the avatar's box is not a style: it is the
  * geometry both sides of the bridge agree on, and everything derives from it:
  * the pill's reach, the card's height, and the canvas sized to hold the largest
- * state. A continuous scale would be a layout nobody had ever looked at; four
- * steps are four layouts, each checkable in Storybook.
+ * state. A continuous scale would be a layout nobody had ever looked at; five
+ * steps are five layouts, each checkable in Storybook.
  *
  * `medium` is the default. `small` is the size the surface's layout is authored
- * at, which every other step scales from.
+ * at, which every other step scales from. `ridiculous` is the joke at the end
+ * of the scale, and it is a real step rather than a gag drawn some other way:
+ * every length on the surface is stated in `small`, so the largest step costs
+ * one number here and is drawn by the same code as the other four.
  */
-export const COMPANION_SIZES = ["small", "medium", "large", "huge"] as const;
+export const COMPANION_SIZES = [
+  "small",
+  "medium",
+  "large",
+  "huge",
+  "ridiculous",
+] as const;
 
 export type CompanionSize = (typeof COMPANION_SIZES)[number];
 
@@ -674,6 +683,12 @@ export const COMPANION_SIZE_BOXES: Record<CompanionSize, number> = {
   medium: 66,
   large: 88,
   huge: 110,
+  // Five times the authored size, which puts the canvas well past the width of
+  // any display it will be shown on. That is allowed: a canvas may hang off the
+  // left and right freely, and the card flips to growing downward when the
+  // display is too short for it, so the oversize step lands on paths the other
+  // four already take near an edge.
+  ridiculous: 220,
 };
 
 /**

--- a/packages/ipc-contract/src/types.ts
+++ b/packages/ipc-contract/src/types.ts
@@ -661,7 +661,7 @@ export type CompanionCardGrowth = (typeof COMPANION_CARD_GROWTHS)[number];
  * state. A continuous scale would be a layout nobody had ever looked at; four
  * steps are four layouts, each checkable in Storybook.
  *
- * `large` is the default. `small` is the size the surface's layout is authored
+ * `medium` is the default. `small` is the size the surface's layout is authored
  * at, which every other step scales from.
  */
 export const COMPANION_SIZES = ["small", "medium", "large", "huge"] as const;
@@ -676,8 +676,18 @@ export const COMPANION_SIZE_BOXES: Record<CompanionSize, number> = {
   huge: 110,
 };
 
-/** What the surface is drawn at when nothing has been chosen. */
-export const DEFAULT_COMPANION_SIZE: CompanionSize = "large";
+/**
+ * What the surface is drawn at when nothing has been chosen.
+ *
+ * The second step rather than the third. The companion arrives on the desktop
+ * without anyone having asked for it, over whatever the user was already
+ * working in, so it arrives at the size of an uninvited guest: big enough to be
+ * recognised as the creature it is, small enough that nobody has to move it
+ * before they can carry on. The steps above are for the users who then want it
+ * bigger, and the introduction's last beat is where they are told to find
+ * them (see {@link COMPANION_INTRO_BEATS}).
+ */
+export const DEFAULT_COMPANION_SIZE: CompanionSize = "medium";
 
 /**
  * The avatar's box the companion's layout is authored at, and the size every
@@ -785,14 +795,15 @@ export interface CompanionContext {
  *
  * A list rather than a count, because each beat names the control it sits over
  * and the renderer spotlights that control by name. Two of them have no
- * control to spotlight: `meet` is the avatar itself, and `tray` is about the
- * menu bar, which is the one part of this the surface cannot point at.
+ * control to spotlight: `meet` is the avatar itself, and `menu` is about a
+ * press rather than a control drawn on the pill.
  *
- * `tray` is last and is the answer to "how do I make this go away". A surface
- * that sits above every other window has to say where its own off switch is,
- * and it is the only thing here the user cannot find by looking at the pill.
+ * `menu` is last and is the answer to "how do I make this go away" and "how do
+ * I make it a different size". A surface that sits above every other window has
+ * to say where its own off switch is, and the right-click menu it points at is
+ * the only part of this the user cannot find by looking at the pill.
  */
-export const COMPANION_INTRO_BEATS = ["meet", "talk", "type", "tray"] as const;
+export const COMPANION_INTRO_BEATS = ["meet", "talk", "type", "menu"] as const;
 
 export type CompanionIntroBeat = (typeof COMPANION_INTRO_BEATS)[number];
 


### PR DESCRIPTION
Four changes for the release. The first three are the companion surface, all about the same fact: it lives out on the desktop, over whatever the user is actually working in. The fourth is the Fn key, which is the same problem one layer down: the app helping itself to something that was not offered.

### It arrives at `medium`, not `large`

`DEFAULT_COMPANION_SIZE` is the size an uninvited guest turns up at, and `large` is an 88pt disc landing on top of whatever the user was already working in. `medium` (66pt) is still unmistakably the creature, and small enough that nobody has to move it before carrying on. The steps above it are still there for anyone who wants them.

Only the default moves. A stored `companionSize` is read back unchanged, so users who already picked a size keep it.

### The last beat points at the right-click menu

The beat said:

> **Hide me anytime** — Disable "Show Companion" in the menu bar.

which was the only way to hide the surface when the beat was written, and is no longer. The surface's own right-click menu both hides it and resizes it, and it is a press on the thing the user is already looking at rather than a hunt through a tray icon that says nothing about it. It now says:

> **Right-click me** — That's where you hide me or change my size.

That also answers the resize question, which the tray wording never did, and which is the other thing a user wants from a floating avatar.

The beat's id follows the copy: `tray` becomes `menu`, since a beat called `tray` that says "right-click me" has to be read twice. Nothing persists the id (only the one-shot `companionIntroSeen` flag is stored), so the rename is local to the contract and its four callers.

### A permission request brings the app forward

A confirmation is the one thing the assistant cannot get past on its own, and the card that answers it is drawn in the app's window. A message typed on the companion is sent from a surface floating over the user's editor, so the request lands in a window that is behind something else and the assistant reads as having gone quiet when it is in fact waiting.

`handleConfirmationRequest` now calls `ensureMainWindowVisible()` — the same seam the live-voice first-run card uses, for the same reason. No-op off Electron; a window already frontmost is raised to where it already is.

Only confirmations. A secret is asked for at the point the user set up the integration, and a contact request is a field on a card already in front of them, so neither is the assistant stopped on a question nobody can see. There's a test pinning that boundary.

**This is the "for now" version.** The end state is answering the request on the companion's own text conversation, and it is closer than it looks: the surface already draws Allow / Deny and sends `approveRequest` / `denyRequest` with the request id (`ApprovalBody` in `companion-surface.tsx`), but only inside a live-voice session, off the `voiceActivity` payload that also feeds the iOS Live Activity. A typed turn has no call, so `CallBody` never renders and the confirmation has no route to the surface. What is missing is publishing the pending confirmation into the companion's own context, not the decision rail, which exists.

### The `ridiculous` size, and the menu leads with Size

`ridiculous` (220pt, five times the authored size) was written during a merge on `alex-nork/learning-by-watching` (`80248c1c75`) rather than as a commit of its own, so neither parent carried it and no PR contained it — which is why it missed `v0.11.5-staging.1`. Lifted here as the same four lines plus the tray test's label list.

The surface's right-click menu now groups the sizes under a `Size` submenu, with `Hide Companion` below the separator. Flat, the first thing a right-click offered was four words that read as sizes only once you noticed they were sizes, with the one item that is not a size at the end of the same list.

### Fn is no longer bound to Talk out of the box

Fn was the default binding for Talk on macOS, so a fresh install claimed the Globe key with no step where the user agreed to it. "Press 🌐 key to" is a system setting, and where it is set to Start Dictation one press ran the OS's dictation and our voice mode together. Registering Fn is also what triggers the Input Monitoring prompt, which landed on people who had never gone looking for a shortcut.

`defaultVoiceModeActivator` now answers `off` on a Fn-capable host. Choosing Fn in Settings → Voice binds it; a user who already chose it keeps it, since only the implicit default is gone. With nothing chosen, the helper's Fn listener is never registered at all, so the key is left alone.

**On the "Fn triggers push-to-talk too" half of the report:** it doesn't, in this branch or on `main`. Fn drives voice mode and nothing else — the push-to-talk binding it is named after went away when voice mode took the key over (#40864), and dictation has had no keyboard binding since (`eventActivatesPTT` returns false for `function`, and `use-voice-mode-hotkey` is the only subscriber to the helper's hotkey channel). What survives is the naming: `hotkey.fnPushToTalk` on the wire, `FN_PTT_ACTIVATOR`, `supportsFnPushToTalk`, which is a plausible way to arrive at that conclusion from the code or the logs. Renaming it is a sweep across the helper, main, the bridge, and the renderer, so it is not in here with a release pending. Happy to do it as a follow-up.

### Testing

- `clients/macos`: `bun test src/main/companion-window.test.ts` (43 pass)
- `clients/web`: `bun test src/components/companion-surface-page.test.tsx` (19 pass)
- `packages/electron-desktop`: `bun test src/tray-model.test.ts`, `bun test src/window-state.test.ts` (35 + 32 pass)
- `clients/web`: `bun test src/domains/chat/utils/stream-handlers/interaction-handlers.test.ts` (14 pass; verified the new test fails with the raise removed)
- `clients/web`: `bun test src/utils/voice-mode-activation.test.ts` (12 pass), `src/domains/chat/voice/use-voice-mode-hotkey.test.tsx` (16 pass), `src/domains/settings/pages/voice-page.test.tsx` (18 pass), plus the voice-input/PTT-bridge suites
- `clients/macos`: `bun test src/main/hotkey-helper.test.ts` (25 pass), `src/main/companion-window.test.ts` (43 pass)
- `packages/electron-desktop`: `bun test src/tray-model.test.ts` (35 pass, incl. the size list) and `src/window-state.test.ts` (32 pass)
- `clients/web`: `bun test src/i18n/catalogs.test.ts` (66 pass) and `src/components/companion-surface-page.test.tsx` after the i18n conversion — the page test asserts the card's visible text, so a missing catalog entry would surface as a printed key path
- `bun run typecheck` in `clients/web` and `clients/macos`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyZzDvPWxhN9riyWQDCtLr



