### PR TITLE
fix(web): draw one asset card per thread, not per response

### DIFF
--- a/clients/web/src/domains/chat/transcript/app-reopen-card.tsx
+++ b/clients/web/src/domains/chat/transcript/app-reopen-card.tsx
@@ -1,6 +1,8 @@
 /**
- * The card for an app the assistant created or changed during a turn, rendered
- * at the end of that turn's response.
+ * The card for an app the assistant first reached during a turn, rendered at
+ * the end of that turn's response. A later turn that changes the same app
+ * draws nothing: by then the app is in the conversation's assets, which the
+ * header pill lists (see `resolve-response-artifacts.ts`).
  *
  * The app twin of `DocumentReopenLink`, and it exists for the same reason: the
  * daemon emits a `dynamic_page` preview where `app_create` ran, which put a
@@ -67,10 +69,10 @@ function useAppSummary(
  * resolved, `null` once no list carries the app.
  *
  * The conversation-scoped list is asked first so the card reads the same cache
- * entry as the assets pill. A miss there is not an absence: the assistant can
- * edit any app it can reach, and an edit does not link the app to the
- * conversation it was made from, so an app reached from an older conversation
- * is missing from this one's list while still existing. The assistant-wide list
+ * entry as the assets pill. A miss there is not an absence: the daemon links an
+ * app to the conversation that created, changed, or opened it, but it links on
+ * the tool's post-execution hook, so a card rendering before that list is
+ * refetched reads a list the app has not landed in yet. The assistant-wide list
  * settles that, and only a miss in both hides the card.
  */
 function useAppDisplaySummary(

--- a/clients/web/src/domains/chat/transcript/document-reopen-link.tsx
+++ b/clients/web/src/domains/chat/transcript/document-reopen-link.tsx
@@ -1,11 +1,14 @@
 /**
- * The card for a document the assistant created or changed during a turn,
- * rendered at the end of that turn's response.
+ * The card for a document the assistant first reached during a turn, rendered
+ * at the end of that turn's response. A later turn that changes the same
+ * document draws nothing: by then the document is in the conversation's assets,
+ * where the header pill lists it and lights its unseen dot (see
+ * `resolve-response-artifacts.ts`).
  *
- * This is the single affordance a response owes each document it touched. The
+ * This is the single affordance a thread owes each document it touched. The
  * daemon also emits an inline `document_preview` surface where the tool ran,
- * but the transcript does not draw that one (see `resolve-response-documents.ts`
- * and `transcript-message-body.tsx`): one document produced two cards in the
+ * but the transcript does not draw that one (see `response-artifacts.ts` and
+ * `message-content.ts`): one document produced two cards in the
  * same response, at two different sizes, whenever a create was followed by an
  * edit.
  *

--- a/clients/web/src/domains/chat/transcript/resolve-response-artifacts.test.ts
+++ b/clients/web/src/domains/chat/transcript/resolve-response-artifacts.test.ts
@@ -243,7 +243,9 @@ describe("resolveResponseArtifacts", () => {
     ]);
   });
 
-  test("keeps a document previewed by a later response", () => {
+  test("leaves a later response that only previews the same document empty", () => {
+    // The document is in the conversation's assets from the create onwards, so
+    // reopening it is not news the transcript repeats.
     const items = [
       user("u1"),
       assistant("a1", [createCall("tc-1", "surf-notes")]),
@@ -251,8 +253,92 @@ describe("resolveResponseArtifacts", () => {
       assistant("a2", [], [previewBlock("surf-notes")]),
     ];
 
-    expect(resolveResponseArtifacts(items).get("a1")).toEqual([
-      doc("surf-notes"),
+    const byKey = resolveResponseArtifacts(items);
+
+    expect(byKey.get("a1")).toEqual([doc("surf-notes")]);
+    expect(byKey.has("a2")).toBe(false);
+  });
+
+  test("leaves a later response that edits the same document empty", () => {
+    const items = [
+      user("u1"),
+      assistant("a1", [createCall("tc-1", "surf-notes")]),
+      user("u2"),
+      assistant("a2", [updateCall("tc-2", "surf-notes")]),
+      user("u3"),
+      assistant("a3", [updateCall("tc-3", "surf-notes")]),
+    ];
+
+    const byKey = resolveResponseArtifacts(items);
+
+    expect([...byKey]).toEqual([["a1", [doc("surf-notes")]]]);
+  });
+
+  test("leaves a later response that updates the same app empty", () => {
+    const items = [
+      user("u1"),
+      assistant(
+        "a1",
+        [appCreateCall("tc-1", "app-7")],
+        [appPreviewBlock("app-7")],
+      ),
+      user("u2"),
+      assistant("a2", [appUpdateCall("tc-2", "app-7")]),
+    ];
+
+    const byKey = resolveResponseArtifacts(items);
+
+    expect([...byKey]).toEqual([["a1", [{ kind: "app", id: "app-7" }]]]);
+  });
+
+  test("keeps the card on the response that first reached the asset", () => {
+    // Nothing in this thread created the document; it was reached from an
+    // older conversation, so the response that first touches it here is the
+    // one that owes the card.
+    const items = [
+      user("u1"),
+      assistant("a1", [], [previewBlock("surf-notes")]),
+      user("u2"),
+      assistant("a2", [updateCall("tc-1", "surf-notes")]),
+    ];
+
+    const byKey = resolveResponseArtifacts(items);
+
+    expect([...byKey]).toEqual([["a1", [doc("surf-notes")]]]);
+  });
+
+  test("gives each asset its own first response", () => {
+    const items = [
+      user("u1"),
+      assistant("a1", [createCall("tc-1", "surf-notes")]),
+      user("u2"),
+      assistant("a2", [
+        updateCall("tc-2", "surf-notes"),
+        createCall("tc-3", "surf-plan"),
+      ]),
+    ];
+
+    const byKey = resolveResponseArtifacts(items);
+
+    expect(byKey.get("a1")).toEqual([doc("surf-notes")]);
+    expect(byKey.get("a2")).toEqual([doc("surf-plan")]);
+  });
+
+  test("does not let the in-flight response claim an asset it repeats", () => {
+    // The in-flight response is withheld, and a response that draws nothing
+    // must not consume the entry either. The create keeps it throughout.
+    const items = [
+      user("u1"),
+      assistant("a1", [createCall("tc-1", "surf-notes")]),
+      user("u2"),
+      assistant("a2", [updateCall("tc-2", "surf-notes")]),
+    ];
+
+    expect([...resolveResponseArtifacts(items, { turnActive: true })]).toEqual([
+      ["a1", [doc("surf-notes")]],
+    ]);
+    expect([...resolveResponseArtifacts(items)]).toEqual([
+      ["a1", [doc("surf-notes")]],
     ]);
   });
 
@@ -375,6 +461,88 @@ describe("resolveResponseArtifacts", () => {
 
     expect(byKey.get("a1")).toEqual([doc("surf-notes")]);
     expect(byKey.has("a2")).toBe(false);
+  });
+
+  test("does not let a system-card-only response claim an asset", () => {
+    // A response with no ordinary message has no card slot, so it cannot draw
+    // the asset it touched. Claiming it there would lose the card entirely.
+    const card = (key: string, toolCalls: ChatMessageToolCall[]) =>
+      ({
+        kind: "message",
+        key,
+        message: {
+          id: key,
+          role: "assistant",
+          isSystemCard: true,
+          toolCalls,
+          contentBlocks: toolCalls.map(
+            (toolCall) =>
+              ({ type: "tool_use", toolCall }) as ConversationContentBlock,
+          ),
+        },
+      }) as TranscriptItem;
+    const items = [
+      user("u1"),
+      card("a1", [createCall("tc-1", "surf-notes")]),
+      user("u2"),
+      assistant("a2", [updateCall("tc-2", "surf-notes")]),
+    ];
+
+    expect([...resolveResponseArtifacts(items)]).toEqual([
+      ["a2", [doc("surf-notes")]],
+    ]);
+  });
+
+  test("keeps a drawn card where it is when older history arrives", () => {
+    // The transcript loads its newest page first and prepends older ones, so
+    // an earlier touch can surface after the card is already drawn. Retracting
+    // it would remove height below the viewport, which the prepend's
+    // scrollHeight-delta correction reads as prepended content.
+    const conversationId = "conv-prepend";
+    const newestPage = [user("u2"), assistant("a2", [updateCall("tc-2", "s")])];
+    const withOlderPage = [
+      user("u1"),
+      assistant("a1", [createCall("tc-1", "s")]),
+      ...newestPage,
+    ];
+
+    expect([
+      ...resolveResponseArtifacts(newestPage, { conversationId }),
+    ]).toEqual([["a2", [doc("s")]]]);
+    expect([
+      ...resolveResponseArtifacts(withOlderPage, { conversationId }),
+    ]).toEqual([["a2", [doc("s")]]]);
+  });
+
+  test("awards the oldest touch when the held response has left the window", () => {
+    // A fork or a cleared history retires the anchor an award names, and an
+    // anchor nothing can draw must not keep the card from the responses that
+    // remain.
+    const conversationId = "conv-forked";
+    const before = [user("u1"), assistant("a1", [createCall("tc-1", "s")])];
+    const after = [user("u2"), assistant("a2", [updateCall("tc-2", "s")])];
+
+    resolveResponseArtifacts(before, { conversationId });
+
+    expect([...resolveResponseArtifacts(after, { conversationId })]).toEqual([
+      ["a2", [doc("s")]],
+    ]);
+  });
+
+  test("starts fresh awards for another conversation", () => {
+    const first = [user("u1"), assistant("a1", [createCall("tc-1", "s")])];
+    const second = [
+      user("u1"),
+      assistant("a1", [createCall("tc-1", "s")]),
+      user("u2"),
+      assistant("a2", [updateCall("tc-2", "s")]),
+    ];
+
+    resolveResponseArtifacts(first, { conversationId: "conv-a" });
+
+    expect([
+      ...resolveResponseArtifacts(second, { conversationId: "conv-b" }),
+    ]).toEqual([["a1", [doc("s")]]]);
   });
 
   test("reuses the previous array when a response resolves the same ids", () => {

--- a/clients/web/src/domains/chat/transcript/resolve-response-artifacts.ts
+++ b/clients/web/src/domains/chat/transcript/resolve-response-artifacts.ts
@@ -1,6 +1,6 @@
-// Assign the assets a response touched to the message that ends it, so a
-// response closes with one card per asset rather than repeating the same card
-// on every message that wrote to it.
+// Assign the assets a thread touched to the message that ends the response
+// that first reached each one, so a thread draws one card per asset rather
+// than repeating the same card on every response that writes to it.
 
 import type { DisplayMessage } from "@/domains/chat/types/types";
 import type {
@@ -71,6 +71,8 @@ function pointedArtifacts(message: DisplayMessage): ResponseArtifact[] {
  *
  * The seen set spans the whole response, so repeated edits of one asset
  * collapse into a single entry, whether they ran in one message or several.
+ * Collapsing across responses is the caller's, since which response keeps the
+ * entry is a question about the thread rather than about any one response.
  */
 function touchedArtifacts(response: MessageItem[]): ResponseArtifact[] {
   const seen = new Set<string>();
@@ -100,6 +102,55 @@ function touchedArtifacts(response: MessageItem[]): ResponseArtifact[] {
  */
 function canAnchorCards(item: MessageItem): boolean {
   return !item.message.isSystemCard;
+}
+
+/**
+ * The anchor each asset's card was awarded to, for the conversation currently
+ * on screen.
+ *
+ * The transcript loads its newest page first and prepends older ones, so the
+ * first response that touched an asset is not always known when the card is
+ * first drawn: an older page can arrive later carrying an earlier touch. An
+ * award already made outranks that late arrival, because retracting a card
+ * removes height from below the viewport, which the prepend's scroll
+ * correction (a `scrollHeight` delta, see `use-transcript-scroll.ts`) reads as
+ * prepended content and compensates for twice.
+ *
+ * One conversation at a time: switching conversations starts a fresh window
+ * (its own newest page) and so a fresh set of awards.
+ */
+let awardedAnchors: {
+  conversationId: string;
+  byArtifact: Map<string, string>;
+} | null = null;
+
+/**
+ * Forget every award.
+ *
+ * For tests. Nothing in the app needs it: awards are keyed by conversation, a
+ * message id belongs to one response for the life of that conversation, and an
+ * award naming a response no longer in the window is released on the next
+ * resolution. A test suite reusing ids like `a1` across cases has none of those
+ * guarantees, so it resets between them instead.
+ */
+export function resetResponseArtifactAwards(): void {
+  awardedAnchors = null;
+}
+
+/**
+ * The award map for `conversationId`, or `null` when the caller named no
+ * conversation and every resolution stands on its own.
+ */
+function awardsFor(
+  conversationId: string | null | undefined,
+): Map<string, string> | null {
+  if (conversationId == null) {
+    return null;
+  }
+  if (awardedAnchors?.conversationId !== conversationId) {
+    awardedAnchors = { conversationId, byArtifact: new Map() };
+  }
+  return awardedAnchors.byArtifact;
 }
 
 /** Previously returned artifacts, keyed by the message that anchored them. */
@@ -137,11 +188,102 @@ export interface ResolveResponseArtifactsOptions {
    * affordance is honest.
    */
   turnActive?: boolean;
+  /**
+   * The conversation being resolved, which scopes the awards that survive an
+   * older-page prepend. Omitted, every resolution stands on its own.
+   */
+  conversationId?: string | null;
+}
+
+/** One response's assets, and the message that can draw them. */
+interface DrawableResponse {
+  anchor: MessageItem;
+  artifacts: ResponseArtifact[];
 }
 
 /**
- * The assets each completed response touched, keyed by the transcript item key
- * of the message that ends that response.
+ * The responses that could draw a card, oldest first, each with the assets it
+ * touched.
+ *
+ * A response that cannot draw is left out rather than recorded as empty: the
+ * in-flight one, which is withheld until the turn settles, and one whose every
+ * message is a system card, which has no card slot. Neither claims an asset,
+ * so the next response to touch it still closes with the card.
+ */
+function drawableResponses(
+  items: TranscriptItem[],
+  turnActive: boolean,
+): DrawableResponse[] {
+  const responses = splitResponses(items);
+  const inFlightIndex = turnActive ? responses.length - 1 : -1;
+  const drawable: DrawableResponse[] = [];
+
+  responses.forEach((response, index) => {
+    if (index === inFlightIndex) {
+      return;
+    }
+    const anchor = response.findLast(canAnchorCards);
+    if (!anchor) {
+      return;
+    }
+    const artifacts = touchedArtifacts(response);
+    if (artifacts.length > 0) {
+      drawable.push({ anchor, artifacts });
+    }
+  });
+
+  return drawable;
+}
+
+/**
+ * The anchor that draws each asset's card: the oldest response that touched it,
+ * unless a card was already awarded to a response still present in this window,
+ * which keeps it.
+ *
+ * Recorded as it is decided, so the next resolution (one more page of history,
+ * one more settled turn) reaches the same answer for an asset already drawn.
+ */
+function anchorPerArtifact(
+  drawable: DrawableResponse[],
+  awards: Map<string, string> | null,
+): Map<string, string> {
+  const occurrences = new Map<string, string[]>();
+
+  for (const { anchor, artifacts } of drawable) {
+    for (const artifact of artifacts) {
+      const key = artifactKey(artifact);
+      const anchors = occurrences.get(key);
+      if (anchors) {
+        anchors.push(anchor.key);
+      } else {
+        occurrences.set(key, [anchor.key]);
+      }
+    }
+  }
+
+  const chosen = new Map<string, string>();
+  for (const [key, anchors] of occurrences) {
+    // An award whose response has left the window (a fork, a cleared history)
+    // names an anchor nothing can draw, so the oldest touch takes it back.
+    const held = awards?.get(key);
+    const anchorKey =
+      held != null && anchors.includes(held) ? held : anchors[0]!;
+    chosen.set(key, anchorKey);
+    awards?.set(key, anchorKey);
+  }
+
+  return chosen;
+}
+
+/**
+ * The assets each response closes with, keyed by the transcript item key of the
+ * message that ends that response.
+ *
+ * An asset earns one card in a thread, on the response that first reached it.
+ * Every later response that writes to, or reopens, the same asset draws
+ * nothing: it is in the conversation's assets by then (the header pill lists
+ * it, and a changed document lights its dot), so a second card would be a
+ * second way to say what the pill already says.
  *
  * Each id rides on its tool call's persisted `result` or its pointer surface's
  * persisted block, so a response reseeded from `/messages` resolves the same
@@ -154,24 +296,36 @@ export function resolveResponseArtifacts(
   items: TranscriptItem[],
   options?: ResolveResponseArtifactsOptions,
 ): Map<string, ResponseArtifact[]> {
-  const byItemKey = new Map<string, ResponseArtifact[]>();
-  const responses = splitResponses(items);
-  const inFlightIndex = options?.turnActive ? responses.length - 1 : -1;
+  const drawable = drawableResponses(items, options?.turnActive === true);
+  const anchorKeys = anchorPerArtifact(
+    drawable,
+    awardsFor(options?.conversationId),
+  );
 
-  responses.forEach((response, index) => {
-    if (index === inFlightIndex) {
-      return;
+  // Walked in response order, so a response closing with more than one asset
+  // keeps them in the order it touched them.
+  const collected = new Map<string, ResponseArtifact[]>();
+  for (const { anchor, artifacts } of drawable) {
+    for (const artifact of artifacts) {
+      if (anchorKeys.get(artifactKey(artifact)) !== anchor.key) {
+        continue;
+      }
+      const drawn = collected.get(anchor.key);
+      if (drawn) {
+        drawn.push(artifact);
+      } else {
+        collected.set(anchor.key, [artifact]);
+      }
     }
-    const anchor = response.findLast(canAnchorCards);
-    if (!anchor) {
-      return;
+  }
+
+  const byItemKey = new Map<string, ResponseArtifact[]>();
+  for (const { anchor } of drawable) {
+    const artifacts = collected.get(anchor.key);
+    if (artifacts) {
+      byItemKey.set(anchor.key, stableArtifacts(anchor.message, artifacts));
     }
-    const artifacts = touchedArtifacts(response);
-    if (artifacts.length === 0) {
-      return;
-    }
-    byItemKey.set(anchor.key, stableArtifacts(anchor.message, artifacts));
-  });
+  }
 
   return byItemKey;
 }

--- a/clients/web/src/domains/chat/transcript/response-artifacts.ts
+++ b/clients/web/src/domains/chat/transcript/response-artifacts.ts
@@ -6,10 +6,11 @@
  * surface the tool emits where it ran (a `document_preview`, or a
  * `dynamic_page` carrying `data.preview`, which renders an `AppCard` rather
  * than the expanded live app). The transcript draws neither in place. It
- * collects both into one card per asset at the end of the response, which is
- * what keeps a create-then-edit turn from producing two cards for one asset at
- * two different sizes, and what keeps a pointer surface from splitting the
- * "Earlier activity" run it lands in.
+ * collects both into one card per asset, at the end of the response that first
+ * reached it (`resolve-response-artifacts.ts`), which is what keeps a
+ * create-then-edit turn from producing two cards for one asset at two different
+ * sizes, and what keeps a pointer surface from splitting the "Earlier activity"
+ * run it lands in.
  *
  * A kind is registered here once, and the three consumers read the registry
  * rather than naming a tool or a surface type themselves:

--- a/clients/web/src/domains/chat/transcript/transcript.test.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript.test.tsx
@@ -72,6 +72,7 @@ import type { DisplayMessage } from "@/domains/chat/types/types";
 import type { TranscriptItem } from "@/domains/chat/transcript/types";
 
 import { Transcript } from "@/domains/chat/transcript/transcript";
+import { resetResponseArtifactAwards } from "@/domains/chat/transcript/resolve-response-artifacts";
 import { INITIAL_TURN_STATE, useTurnStore } from "@/domains/chat/turn-store";
 import { viewportAxesStub } from "@/hooks/viewport-axes.test-helper";
 
@@ -482,6 +483,9 @@ describe("Transcript changed-document reopen links", () => {
   afterEach(() => {
     cleanup();
     useTurnStore.setState(INITIAL_TURN_STATE);
+    // These cases share one conversation id and reuse message ids across
+    // cases, which the awards would otherwise carry from one to the next.
+    resetResponseArtifactAwards();
   });
 
   /** A settled `document_update` whose result carries the surface it wrote. */
@@ -626,6 +630,69 @@ describe("Transcript changed-document reopen links", () => {
     ]);
 
     expect(reopenSurfaceIds(container)).toEqual(["surf-notes", "surf-plan"]);
+  });
+
+  test("renders no second link when a later response edits the same document", () => {
+    // The document is in the conversation's assets from the first response
+    // onwards, and the assets pill is where it stays reachable.
+    const { container } = renderTranscript([
+      userMessage("u1", "update my notes"),
+      editingMessage("a1", [updateCall("tc-1", "surf-notes")]),
+      userMessage("u2", "one more edit"),
+      editingMessage("a2", [updateCall("tc-2", "surf-notes")]),
+    ]);
+
+    const links = container.querySelectorAll(
+      "[data-testid='document-reopen-link']",
+    );
+    expect(links.length).toBe(1);
+    expect(
+      links[0]!.closest("[data-message-id]")!.getAttribute("data-message-id"),
+    ).toBe("a1");
+  });
+
+  test("keeps the link where it is when an older page arrives above it", () => {
+    // The transcript prepends older pages, so the earliest response to touch a
+    // document can appear after its card is drawn. Moving the card then would
+    // change the height below the viewport, which the prepend's scroll
+    // correction reads as prepended content.
+    const conversationId = "conv-doc-paged";
+    const newestPage = [
+      userMessage("u2", "one more edit"),
+      editingMessage("a2", [updateCall("tc-2", "surf-notes")]),
+    ];
+    const render1 = render(
+      <Transcript
+        items={newestPage}
+        conversationId={conversationId}
+        assistantId="asst-doc"
+        onSurfaceAction={noop}
+        onOpenDocument={noop}
+      />,
+    );
+    expect(reopenSurfaceIds(render1.container)).toEqual(["surf-notes"]);
+
+    render1.rerender(
+      <Transcript
+        items={[
+          userMessage("u1", "start my notes"),
+          editingMessage("a1", [updateCall("tc-1", "surf-notes")]),
+          ...newestPage,
+        ]}
+        conversationId={conversationId}
+        assistantId="asst-doc"
+        onSurfaceAction={noop}
+        onOpenDocument={noop}
+      />,
+    );
+
+    const links = render1.container.querySelectorAll(
+      "[data-testid='document-reopen-link']",
+    );
+    expect(links.length).toBe(1);
+    expect(
+      links[0]!.closest("[data-message-id]")!.getAttribute("data-message-id"),
+    ).toBe("a2");
   });
 });
 

--- a/clients/web/src/domains/chat/transcript/transcript.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript.tsx
@@ -213,16 +213,17 @@ export const Transcript = forwardRef<TranscriptHandle, TranscriptProps>(
       ? -1
       : partition.historyItems.findLastIndex((item) => item.kind === "message");
 
-    // A document a response changed earns one reopen link at the end of that
-    // response, not one per message that wrote to it. Resolved here because
-    // this is where the flat item list is read as turns; the in-flight response
-    // is withheld until the turn settles, `awaiting_user_input` included, so a
-    // paused turn never reads as finished.
+    // A document the thread changed earns one reopen link, at the end of the
+    // response that first reached it. Not one per message that wrote to it,
+    // and not another one each time a later response writes to it again.
+    // Resolved here because this is where the flat item list is read as turns;
+    // the in-flight response is withheld until the turn settles,
+    // `awaiting_user_input` included, so a paused turn never reads as finished.
     const turnPhase = useTurnStore.use.phase();
     const turnActive = isSending(turnPhase);
     const responseArtifactsByKey = useMemo(
-      () => resolveResponseArtifacts(items, { turnActive }),
-      [items, turnActive],
+      () => resolveResponseArtifacts(items, { turnActive, conversationId }),
+      [items, turnActive, conversationId],
     );
 
     useImperativeHandle(


### PR DESCRIPTION
## Prompt / plan

> When we build a new asset like app or document we should show the app card or the document card. But I don't want to show the document card for a document that is already part of the assets or an app that is already part of the assets for that thread. I feel as long as it's in the assets, we shouldn't continue to show additional UI elements over and over again.

**The rule adopted:** one card per asset per thread, on the response that first reaches it. Every later response that writes to or reopens the same asset draws nothing. The header assets pill is the durable affordance, and a changed document already lights its dot.

**Why not "suppress when it's in the assets list":** that test doesn't work. The daemon links an app to a conversation on create, update, refresh, *and* open (`tool-side-effects.ts`, `conversation-surfaces.ts`), so it's in the list the instant the tool runs, which would suppress the creation card too. Documents link only on create, so the same test behaves differently per kind. "First touch in this thread" is uniform across both, and still gives one card to an asset first reached from another thread.

## What changed

- **`resolve-response-artifacts.ts`**: dedupe widened from one response to the thread. Split into three steps: collect the responses that *can* draw, pick one anchor per asset, then walk responses in order to build each anchor's list, so a response closing with two assets keeps them in touch order.
- **Two responses deliberately don't claim an asset**, or the card would be lost rather than moved: the in-flight one (withheld until the turn settles) and one whose every message is a system card (no card slot).
- **Pagination guard**: a per-conversation award map. The transcript loads its newest page first and prepends older ones, so an earlier touch can surface *after* a card is drawn. The existing award wins. This isn't cosmetic: the prepend's scroll correction is a `scrollHeight` delta (`use-transcript-scroll.ts:282`), so a card vanishing below the viewport in the same render is read as prepended content and double-compensated. An award naming a response that has left the window (fork, cleared history) is released.
- **Comments**: the "per response" rule statements, and the stale claim in `app-reopen-card.tsx` that an edit doesn't link an app to its conversation (it does, via the tool post-execution hooks).

## Test plan

`cd clients/web && bun run test:ci src/domains/chat/transcript/*.test.ts src/domains/chat/transcript/*.test.tsx` gives **22 files passed, 0 failed**.

- `resolve-response-artifacts.test.ts` (26 tests, 9 new) covers the rule itself: later edit/preview of the same doc draws nothing, later `app_update` draws nothing, an asset first reached mid-thread still gets its card, the in-flight and system-card-only cases, the prepend guard, award release on fork, conversation isolation. One existing test is inverted, since it pinned the old repeat-card behavior.
- `transcript.test.tsx` (31 tests, 2 new) covers the render level, to catch a wiring regression the unit tests can't: a later response editing the same doc renders exactly one link on the first response's message, and an older page prepending doesn't move it.
- Added `resetResponseArtifactAwards()` for tests. Those cases share one conversation id and reuse message ids (`a1`, `a2`), so awards carried between them. That can't happen in the app, where message ids are unique per conversation and one id belongs to one response, but the suite needs the reset.

**Not yet manually QA'd in the running app.** Worth a look at one case in particular: an app edited in a later turn is now completely silent, because apps have no unseen-dot equivalent to documents. Extending the dot to apps off `app_files_changed` was considered and deliberately deferred.

**Pre-existing on `main`, not from this PR:** `bunx tsc --noEmit` reports 36 errors (a `SubscriptionResponse.current_period_start` spec drift), an identical count on a clean `origin/main`, none in `transcript/`. Separately, a single `bun test` over a large directory reports mass phantom failures against `@vellumai/design-library`; the per-file `test:ci` runner is green, which is why the command above is the one to use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)