### PR TITLE
feat(web-search): add fastCRW as BYOK search and fetch provider

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -19054,6 +19054,7 @@ paths:
                                           - tavily
                                           - keenable
                                           - firecrawl
+                                          - fastcrw
                                       resultCount:
                                         type: number
                                       durationMs:
@@ -19106,6 +19107,7 @@ paths:
                                         enum:
                                           - default
                                           - firecrawl
+                                          - fastcrw
                                       status:
                                         type: number
                                       contentType:
@@ -19563,6 +19565,7 @@ paths:
                                                   - tavily
                                                   - keenable
                                                   - firecrawl
+                                                  - fastcrw
                                               resultCount:
                                                 type: number
                                               durationMs:
@@ -19615,6 +19618,7 @@ paths:
                                                 enum:
                                                   - default
                                                   - firecrawl
+                                                  - fastcrw
                                               status:
                                                 type: number
                                               contentType:

--- a/assistant/scripts/sync-web-search-catalog.ts
+++ b/assistant/scripts/sync-web-search-catalog.ts
@@ -67,6 +67,12 @@ function projectProvider(
   if (entry.privacyPolicyUrl !== undefined) {
     projected.privacyPolicyUrl = entry.privacyPolicyUrl;
   }
+  if (entry.supportsApiBase !== undefined) {
+    projected.supportsApiBase = entry.supportsApiBase;
+  }
+  if (entry.defaultApiBase !== undefined) {
+    projected.defaultApiBase = entry.defaultApiBase;
+  }
   return projected;
 }
 

--- a/assistant/src/__tests__/web-search-catalog-parity.test.ts
+++ b/assistant/src/__tests__/web-search-catalog-parity.test.ts
@@ -29,6 +29,8 @@ interface JsonCatalogEntry {
   secretKey?: string;
   fallbackOrder?: number;
   privacyPolicyUrl?: string;
+  supportsApiBase?: boolean;
+  defaultApiBase?: string;
 }
 
 interface JsonCatalog {
@@ -74,6 +76,12 @@ function entryToPlain(
   }
   if (entry.privacyPolicyUrl !== undefined) {
     out.privacyPolicyUrl = entry.privacyPolicyUrl;
+  }
+  if (entry.supportsApiBase !== undefined) {
+    out.supportsApiBase = entry.supportsApiBase;
+  }
+  if (entry.defaultApiBase !== undefined) {
+    out.defaultApiBase = entry.defaultApiBase;
   }
   return out;
 }

--- a/assistant/src/api/events/tool-result.ts
+++ b/assistant/src/api/events/tool-result.ts
@@ -50,11 +50,16 @@ export const WebSearchProviderIdSchema = z.enum([
   "tavily",
   "keenable",
   "firecrawl",
+  "fastcrw",
 ]);
 
 export type WebSearchProviderId = z.infer<typeof WebSearchProviderIdSchema>;
 
-export const WebFetchProviderIdSchema = z.enum(["default", "firecrawl"]);
+export const WebFetchProviderIdSchema = z.enum([
+  "default",
+  "firecrawl",
+  "fastcrw",
+]);
 
 export type WebFetchProviderId = z.infer<typeof WebFetchProviderIdSchema>;
 

--- a/assistant/src/config/schemas/services.ts
+++ b/assistant/src/config/schemas/services.ts
@@ -76,6 +76,9 @@ const WebSearchServiceSchema = z.object({
   provider: z
     .enum(VALID_WEB_SEARCH_PROVIDERS)
     .default("inference-provider-native"),
+  // Origin for providers that support a custom API base (e.g. fastCRW).
+  // Empty / omitted uses the provider's cloud default.
+  apiBase: z.string().optional(),
 });
 
 /**
@@ -88,6 +91,9 @@ const WebFetchServiceSchema = z.object({
   // `firecrawl`) scrape via their hosted API and reuse the same stored key as
   // their web-search counterpart.
   provider: z.enum(VALID_WEB_FETCH_PROVIDERS).default("default"),
+  // Origin for providers that support a custom API base (e.g. fastCRW).
+  // Empty / omitted uses the provider's cloud default.
+  apiBase: z.string().optional(),
 });
 
 const GoogleOAuthServiceSchema = BaseServiceSchema.extend({

--- a/assistant/src/daemon/message-types/web-activity.ts
+++ b/assistant/src/daemon/message-types/web-activity.ts
@@ -11,10 +11,11 @@ export type WebSearchProviderId =
   | "perplexity"
   | "tavily"
   | "keenable"
-  | "firecrawl";
+  | "firecrawl"
+  | "fastcrw";
 
 /** Provider that backed a `web_fetch` call. `default` is the built-in fetcher. */
-export type WebFetchProviderId = "default" | "firecrawl";
+export type WebFetchProviderId = "default" | "firecrawl" | "fastcrw";
 
 export interface WebSearchResultItem {
   rank: number; // 1-indexed

--- a/assistant/src/providers/fetch-provider-catalog.ts
+++ b/assistant/src/providers/fetch-provider-catalog.ts
@@ -45,6 +45,14 @@ export interface FetchProviderCatalogEntry {
   /** Privacy-policy URL surfaced in marketing data-sharing docs.
    *  BYOK providers only. */
   readonly privacyPolicyUrl?: string;
+  /**
+   * When true, settings UIs show an optional API Base field. Empty /
+   * omitted base uses {@link defaultApiBase}.
+   */
+  readonly supportsApiBase?: boolean;
+  /** Cloud default origin when `supportsApiBase` is true and the user
+   *  leaves API Base empty. */
+  readonly defaultApiBase?: string;
 }
 
 export const FETCH_PROVIDER_CATALOG: readonly FetchProviderCatalogEntry[] = [
@@ -64,6 +72,17 @@ export const FETCH_PROVIDER_CATALOG: readonly FetchProviderCatalogEntry[] = [
     envVar: "FIRECRAWL_API_KEY",
     secretKey: "firecrawl",
     privacyPolicyUrl: "https://www.firecrawl.dev/privacy-policy",
+  },
+  {
+    id: "fastcrw",
+    displayName: "fastCRW",
+    kind: "byok",
+    apiKeyPrefix: "crw_live_...",
+    envVar: "FASTCRW_API_KEY",
+    secretKey: "fastcrw",
+    privacyPolicyUrl: "https://fastcrw.com/privacy",
+    supportsApiBase: true,
+    defaultApiBase: "https://api.fastcrw.com",
   },
 ];
 

--- a/assistant/src/providers/search-provider-catalog.ts
+++ b/assistant/src/providers/search-provider-catalog.ts
@@ -76,6 +76,14 @@ export interface SearchProviderCatalogEntry {
   /** Privacy-policy URL surfaced in marketing data-sharing docs.
    *  BYOK providers only. */
   readonly privacyPolicyUrl?: string;
+  /**
+   * When true, settings UIs show an optional API Base field. Empty /
+   * omitted base uses {@link defaultApiBase}.
+   */
+  readonly supportsApiBase?: boolean;
+  /** Cloud default origin when `supportsApiBase` is true and the user
+   *  leaves API Base empty. */
+  readonly defaultApiBase?: string;
 }
 
 export const SEARCH_PROVIDER_CATALOG: readonly SearchProviderCatalogEntry[] = [
@@ -142,6 +150,18 @@ export const SEARCH_PROVIDER_CATALOG: readonly SearchProviderCatalogEntry[] = [
     secretKey: "keenable",
     fallbackOrder: 5,
     privacyPolicyUrl: "https://keenable.ai/privacy",
+  },
+  {
+    id: "fastcrw",
+    displayName: "fastCRW",
+    kind: "byok",
+    apiKeyPrefix: "crw_live_...",
+    envVar: "FASTCRW_API_KEY",
+    secretKey: "fastcrw",
+    fallbackOrder: 6,
+    privacyPolicyUrl: "https://fastcrw.com/privacy",
+    supportsApiBase: true,
+    defaultApiBase: "https://api.fastcrw.com",
   },
 ];
 

--- a/assistant/src/tools/network/__tests__/firecrawl-compat.test.ts
+++ b/assistant/src/tools/network/__tests__/firecrawl-compat.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  extractFirecrawlCompatSearchResults,
+  resolveProviderApiUrl,
+  searchResultSnippet,
+} from "../firecrawl-compat.js";
+
+describe("resolveProviderApiUrl", () => {
+  test("uses the default base when apiBase is empty", () => {
+    expect(
+      resolveProviderApiUrl("", "/v1/search", "https://api.fastcrw.com"),
+    ).toBe("https://api.fastcrw.com/v1/search");
+    expect(
+      resolveProviderApiUrl(undefined, "/v1/scrape", "https://api.fastcrw.com"),
+    ).toBe("https://api.fastcrw.com/v1/scrape");
+  });
+
+  test("strips trailing slashes from a custom base", () => {
+    expect(
+      resolveProviderApiUrl(
+        "http://localhost:3000///",
+        "/v1/search",
+        "https://api.fastcrw.com",
+      ),
+    ).toBe("http://localhost:3000/v1/search");
+  });
+});
+
+describe("extractFirecrawlCompatSearchResults", () => {
+  test("reads grouped data.web", () => {
+    expect(
+      extractFirecrawlCompatSearchResults({
+        data: { web: [{ title: "A", url: "https://a.test" }] },
+      }),
+    ).toEqual([{ title: "A", url: "https://a.test" }]);
+  });
+
+  test("reads data.results as a flat array", () => {
+    expect(
+      extractFirecrawlCompatSearchResults({
+        data: { results: [{ title: "B", url: "https://b.test" }] },
+      }),
+    ).toEqual([{ title: "B", url: "https://b.test" }]);
+  });
+
+  test("reads self-hosted data.results.web when sources group by type", () => {
+    expect(
+      extractFirecrawlCompatSearchResults({
+        data: {
+          results: {
+            web: [{ title: "Self-host", url: "https://local.test" }],
+            news: [{ title: "News", url: "https://news.test" }],
+          },
+        },
+      }),
+    ).toEqual([{ title: "Self-host", url: "https://local.test" }]);
+  });
+
+  test("reads a flat data array", () => {
+    expect(
+      extractFirecrawlCompatSearchResults({
+        data: [{ title: "C", url: "https://c.test" }],
+      }),
+    ).toEqual([{ title: "C", url: "https://c.test" }]);
+  });
+});
+
+describe("searchResultSnippet", () => {
+  test("prefers description then snippet", () => {
+    expect(
+      searchResultSnippet({ description: "desc", snippet: "snip" }),
+    ).toBe("desc");
+    expect(searchResultSnippet({ snippet: "snip" })).toBe("snip");
+    expect(searchResultSnippet({})).toBeUndefined();
+  });
+});

--- a/assistant/src/tools/network/__tests__/web-fetch-fastcrw.test.ts
+++ b/assistant/src/tools/network/__tests__/web-fetch-fastcrw.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { setConfig } from "../../../__tests__/helpers/set-config.js";
+
+let mockFastcrwSecureKey: string | undefined;
+
+function seedWebFetch(provider: string, apiBase?: string): void {
+  const entry: Record<string, string> = { provider };
+  if (apiBase !== undefined) {
+    entry.apiBase = apiBase;
+  }
+  setConfig("services", { "web-fetch": entry });
+}
+
+mock.module("../../../security/secure-keys.js", () => ({
+  getProviderKeyAsync: async (provider: string) =>
+    provider === "fastcrw" ? mockFastcrwSecureKey : undefined,
+}));
+
+const realLogger = await import("../../../util/logger.js");
+mock.module("../../../util/logger.js", () => ({
+  ...realLogger,
+  getLogger: () =>
+    new Proxy({} as Record<string, unknown>, { get: () => () => {} }),
+}));
+
+mock.module("../../../permissions/types.js", () => ({
+  RiskLevel: { Low: "low", Medium: "medium", High: "high" },
+}));
+
+let mockResolveAddresses: string[] = [];
+const realUrlSafety = await import("../url-safety.js");
+mock.module("../url-safety.js", () => ({
+  ...realUrlSafety,
+  resolveHostAddresses: async () => mockResolveAddresses,
+}));
+
+const { executeFastcrwScrape, webFetchTool } = await import("../web-fetch.js");
+
+function scrapeResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("executeFastcrwScrape", () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    mockFastcrwSecureKey = undefined;
+    mockResolveAddresses = ["93.184.216.34"];
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("hits the cloud default /v1/scrape endpoint", async () => {
+    let capturedUrl = "";
+    let capturedHeaders: any = null;
+    globalThis.fetch = (async (url: string, init?: RequestInit) => {
+      capturedUrl = url;
+      capturedHeaders = new Headers(init?.headers);
+      return scrapeResponse({
+        success: true,
+        data: {
+          markdown: "# Hello\n\nFrom fastCRW.",
+          metadata: {
+            title: "Example",
+            url: "https://example.com/",
+            statusCode: 200,
+          },
+        },
+      });
+    }) as typeof fetch;
+
+    const result = await executeFastcrwScrape(
+      { url: "https://example.com" },
+      { apiKey: "crw_live_test" },
+    );
+
+    expect(result.isError).toBe(false);
+    expect(capturedUrl).toBe("https://api.fastcrw.com/v1/scrape");
+    expect(capturedHeaders?.get("authorization")).toBe("Bearer crw_live_test");
+    expect(result.activityMetadata?.webFetch?.provider).toBe("fastcrw");
+    expect(result.content).toContain("From fastCRW.");
+  });
+
+  test("uses a custom API base from config", async () => {
+    seedWebFetch("fastcrw", "http://localhost:3000/");
+    let capturedUrl = "";
+    globalThis.fetch = (async (url: string) => {
+      capturedUrl = url;
+      return scrapeResponse({
+        success: true,
+        data: { markdown: "local", metadata: { statusCode: 200 } },
+      });
+    }) as typeof fetch;
+
+    const result = await executeFastcrwScrape(
+      { url: "https://example.com" },
+      { apiKey: "" },
+    );
+
+    expect(result.isError).toBe(false);
+    expect(capturedUrl).toBe("http://localhost:3000/v1/scrape");
+  });
+});
+
+describe("webFetchTool fastCRW dispatch", () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  const execute = (input: Record<string, unknown>, ctx: any = {}) =>
+    webFetchTool.execute(input, ctx);
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    mockFastcrwSecureKey = "crw_live_test";
+    mockResolveAddresses = ["93.184.216.34"];
+  });
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("routes to fastCRW when provider=fastcrw and a key is set", async () => {
+    seedWebFetch("fastcrw");
+    let fastcrwHit = false;
+    globalThis.fetch = (async (url: string) => {
+      if (String(url).includes("api.fastcrw.com")) {
+        fastcrwHit = true;
+      }
+      return scrapeResponse({
+        success: true,
+        data: {
+          markdown: "ok",
+          metadata: { statusCode: 200, url: "https://example.com/" },
+        },
+      });
+    }) as typeof fetch;
+
+    const result = await execute({ url: "https://example.com" });
+    expect(fastcrwHit).toBe(true);
+    expect(result.activityMetadata?.webFetch?.provider).toBe("fastcrw");
+  });
+
+  test("routes to fastCRW without a key when a custom API base is set", async () => {
+    seedWebFetch("fastcrw", "http://127.0.0.1:3000");
+    mockFastcrwSecureKey = undefined;
+    let capturedUrl = "";
+    let capturedHeaders: any = null;
+    globalThis.fetch = (async (url: string, init?: RequestInit) => {
+      capturedUrl = String(url);
+      capturedHeaders = new Headers(init?.headers);
+      return scrapeResponse({
+        success: true,
+        data: {
+          markdown: "self-host",
+          metadata: { statusCode: 200, url: "https://example.com/" },
+        },
+      });
+    }) as typeof fetch;
+
+    const result = await execute({ url: "https://example.com" });
+    expect(capturedUrl).toBe("http://127.0.0.1:3000/v1/scrape");
+    expect(capturedHeaders?.get("authorization")).toBeNull();
+    expect(result.activityMetadata?.webFetch?.provider).toBe("fastcrw");
+  });
+});

--- a/assistant/src/tools/network/__tests__/web-search.test.ts
+++ b/assistant/src/tools/network/__tests__/web-search.test.ts
@@ -9,6 +9,7 @@ let mockPerplexitySecureKey: string | undefined;
 let mockTavilySecureKey: string | undefined;
 let mockFirecrawlSecureKey: string | undefined;
 let mockKeenableSecureKey: string | undefined;
+let mockFastcrwSecureKey: string | undefined;
 let mockManagedSearchProxyResult: any;
 let mockManagedSearchAvailable = true;
 let mockManagedSearchProxyCalls: Array<{
@@ -21,9 +22,18 @@ let mockManagedSearchProxyCalls: Array<{
  * Seed the web-search service into the workspace config. Pass `undefined`
  * for mode to write a post-migration-132 config carrying only `provider`.
  */
-function seedWebSearch(mode: string | undefined, provider: string): void {
+function seedWebSearch(
+  mode: string | undefined,
+  provider: string,
+  apiBase?: string,
+): void {
+  const entry: Record<string, string> =
+    mode === undefined ? { provider } : { mode, provider };
+  if (apiBase !== undefined) {
+    entry.apiBase = apiBase;
+  }
   setConfig("services", {
-    "web-search": mode === undefined ? { provider } : { mode, provider },
+    "web-search": entry,
   });
 }
 
@@ -43,6 +53,9 @@ mock.module("../../../security/secure-keys.js", () => ({
     }
     if (provider === "keenable") {
       return mockKeenableSecureKey;
+    }
+    if (provider === "fastcrw") {
+      return mockFastcrwSecureKey;
     }
     return undefined;
   },
@@ -87,6 +100,7 @@ describe("web_search tool", () => {
     mockTavilySecureKey = undefined;
     mockFirecrawlSecureKey = undefined;
     mockKeenableSecureKey = undefined;
+    mockFastcrwSecureKey = undefined;
     mockManagedSearchProxyCalls = [];
     mockManagedSearchAvailable = true;
     mockManagedSearchProxyResult = {
@@ -1045,6 +1059,87 @@ describe("web_search tool", () => {
     // Post-retry rate limits surface the friendly recoverable copy (ATL-727).
     expect(result.content).toBe(WEB_SEARCH_BACKEND_FAILURE_MESSAGE);
     expect(callCount).toBe(4);
+  });
+
+  // ---- fastCRW provider ---------------------------------------------------
+
+  test("executes fastCRW search against the cloud default base", async () => {
+    seedWebSearch("your-own", "fastcrw");
+    mockFastcrwSecureKey = "crw_live_test";
+    let capturedUrl = "";
+    globalThis.fetch = (async (url: string) => {
+      capturedUrl = url;
+      return new Response(
+        JSON.stringify({
+          success: true,
+          data: {
+            web: [
+              {
+                title: "fastCRW Result",
+                url: "https://example.com/crw",
+                description: "From fastCRW",
+              },
+            ],
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as any;
+
+    const result = await execute({ query: "rust scraper" });
+    expect(result.isError).toBe(false);
+    expect(capturedUrl).toBe("https://api.fastcrw.com/v1/search");
+    expect(result.content).toContain("fastCRW Result");
+    expect(result.activityMetadata?.webSearch?.provider).toBe("fastcrw");
+  });
+
+  test("fastCRW uses a custom API base and accepts flat data arrays", async () => {
+    seedWebSearch("your-own", "fastcrw", "http://localhost:3000/");
+    mockFastcrwSecureKey = "crw_live_test";
+    let capturedUrl = "";
+    globalThis.fetch = (async (url: string) => {
+      capturedUrl = url;
+      return new Response(
+        JSON.stringify({
+          success: true,
+          data: [
+            {
+              title: "Flat Result",
+              url: "https://example.com/flat",
+              snippet: "Portable flat shape",
+            },
+          ],
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as any;
+
+    const result = await execute({ query: "flat" });
+    expect(result.isError).toBe(false);
+    expect(capturedUrl).toBe("http://localhost:3000/v1/search");
+    expect(result.content).toContain("Flat Result");
+    expect(result.content).toContain("Portable flat shape");
+  });
+
+  test("fastCRW self-host with custom base runs without an API key", async () => {
+    seedWebSearch("your-own", "fastcrw", "http://127.0.0.1:3000");
+    mockFastcrwSecureKey = undefined;
+    let capturedHeaders: any = null;
+    globalThis.fetch = (async (_url: string, init?: RequestInit) => {
+      capturedHeaders = new Headers(init?.headers);
+      return new Response(
+        JSON.stringify({
+          success: true,
+          data: { results: [{ title: "Local", url: "https://local.test" }] },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as any;
+
+    const result = await execute({ query: "local" });
+    expect(result.isError).toBe(false);
+    expect(result.content).toContain("Local");
+    expect(capturedHeaders?.get("authorization")).toBeNull();
   });
 
   // ---- Provider fallback --------------------------------------------------

--- a/assistant/src/tools/network/firecrawl-compat.ts
+++ b/assistant/src/tools/network/firecrawl-compat.ts
@@ -1,0 +1,90 @@
+/**
+ * Shared helpers for Firecrawl-compatible scrape/search HTTP APIs
+ * (Firecrawl hosted `/v2/*` and fastCRW `/v1/*`).
+ */
+
+export const FASTCRW_DEFAULT_API_BASE = "https://api.fastcrw.com";
+
+/**
+ * Join an API origin with a path. Empty / whitespace `apiBase` uses
+ * `defaultBase`. Trailing slashes on the base are stripped.
+ */
+export function resolveProviderApiUrl(
+  apiBase: string | undefined,
+  path: string,
+  defaultBase: string,
+): string {
+  const trimmed = apiBase?.trim() ?? "";
+  const origin = (trimmed.length > 0 ? trimmed : defaultBase).replace(
+    /\/+$/,
+    "",
+  );
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  return `${origin}${normalizedPath}`;
+}
+
+export interface FirecrawlCompatSearchResult {
+  title?: string;
+  description?: string;
+  snippet?: string;
+  url?: string;
+  category?: string;
+}
+
+/**
+ * Portable read of Firecrawl / fastCRW search payloads:
+ * - grouped: `data.web` (Firecrawl `/v2/search`, hosted CRW with sources)
+ * - self-hosted with sources: `data.results.web` (object keyed by source)
+ * - self-hosted flat: `data.results` (array)
+ * - hosted flat: `data` is the array itself
+ */
+export function extractFirecrawlCompatSearchResults(
+  data: unknown,
+): FirecrawlCompatSearchResult[] {
+  if (!data || typeof data !== "object") {
+    return [];
+  }
+  const root = data as Record<string, unknown>;
+  const payload = root.data;
+
+  if (Array.isArray(payload)) {
+    return payload as FirecrawlCompatSearchResult[];
+  }
+
+  if (payload && typeof payload === "object") {
+    const nested = payload as Record<string, unknown>;
+    if (Array.isArray(nested.web)) {
+      return nested.web as FirecrawlCompatSearchResult[];
+    }
+    // Self-hosted CRW with sources:["web"] nests rows under data.results.web
+    // (an object keyed by source), not data.results as a flat array.
+    if (
+      nested.results &&
+      typeof nested.results === "object" &&
+      !Array.isArray(nested.results)
+    ) {
+      const resultsBySource = nested.results as Record<string, unknown>;
+      if (Array.isArray(resultsBySource.web)) {
+        return resultsBySource.web as FirecrawlCompatSearchResult[];
+      }
+      const firstSourceKey = Object.keys(resultsBySource).find((key) =>
+        Array.isArray(resultsBySource[key]),
+      );
+      if (firstSourceKey) {
+        return resultsBySource[firstSourceKey] as FirecrawlCompatSearchResult[];
+      }
+    }
+    if (Array.isArray(nested.results)) {
+      return nested.results as FirecrawlCompatSearchResult[];
+    }
+  }
+
+  return [];
+}
+
+export function searchResultSnippet(
+  result: FirecrawlCompatSearchResult,
+): string | undefined {
+  const text = result.description || result.snippet;
+  return text?.trim() || undefined;
+}

--- a/assistant/src/tools/network/web-fetch.ts
+++ b/assistant/src/tools/network/web-fetch.ts
@@ -29,6 +29,10 @@ import type {
 } from "../types.js";
 import { extractDomain } from "./domain-normalize.js";
 import {
+  FASTCRW_DEFAULT_API_BASE,
+  resolveProviderApiUrl,
+} from "./firecrawl-compat.js";
+import {
   buildHostHeader,
   isIPv4,
   isIPv6,
@@ -46,6 +50,7 @@ import {
 const log = getLogger("web-fetch");
 
 const FIRECRAWL_SCRAPE_API_URL = "https://api.firecrawl.dev/v2/scrape";
+const FASTCRW_SCRAPE_PATH = "/v1/scrape";
 
 const DEFAULT_TIMEOUT_SECONDS = 20;
 const MAX_TIMEOUT_SECONDS = 60;
@@ -1114,25 +1119,29 @@ interface FirecrawlScrapeResponse {
 
 function getWebFetchProvider(): WebFetchProviderId {
   const configured = getConfig().services["web-fetch"]?.provider ?? "default";
-  return configured === "firecrawl" ? "firecrawl" : "default";
+  if (configured === "firecrawl" || configured === "fastcrw") {
+    return configured;
+  }
+  return "default";
 }
 
 /**
- * Decide whether a request may be routed to the hosted Firecrawl provider.
+ * Decide whether a request may be routed to a hosted scrape provider
+ * (Firecrawl / fastCRW).
  *
- * Posting a URL to Firecrawl sends its path + query (which can hold secrets) to
- * a third party, so we apply the SAME safety gate as the built-in fetcher
- * BEFORE dispatching — not just the lexical host check:
- *   - only http(s) URLs (Firecrawl can't do other schemes anyway),
+ * Posting a URL to a hosted scraper sends its path + query (which can hold
+ * secrets) to a third party, so we apply the SAME safety gate as the built-in
+ * fetcher BEFORE dispatching — not just the lexical host check:
+ *   - only http(s) URLs (hosted scrapers can't do other schemes anyway),
  *   - never `allow_private_network` requests (those are intentionally local;
- *     Firecrawl can't reach them and the built-in path owns that mode),
+ *     hosted scrapers can't reach them and the built-in path owns that mode),
  *   - and a DNS resolution check so a public hostname that resolves to a
  *     private/blocked address (e.g. `internal.example` → 10.x.x.x) is NOT
- *     leaked to Firecrawl.
+ *     leaked to the hosted scraper.
  * Anything that fails falls back to the built-in fetcher, which enforces its
  * own SSRF rules and returns the appropriate error.
  */
-async function canRouteToFirecrawl(
+async function canRouteToHostedScraper(
   input: Record<string, unknown>,
 ): Promise<boolean> {
   if (input.allow_private_network === true) {
@@ -1163,10 +1172,11 @@ async function canRouteToFirecrawl(
   return true;
 }
 
-function firecrawlErrorResult(
+function hostedScrapeErrorResult(
   requestedUrl: string,
   startedAt: number,
   errorMessage: string,
+  provider: "firecrawl" | "fastcrw",
   status = 0,
 ): ToolExecutionResult {
   const domain = extractDomain(requestedUrl);
@@ -1177,7 +1187,7 @@ function firecrawlErrorResult(
       webFetch: {
         url: requestedUrl,
         finalUrl: requestedUrl,
-        provider: "firecrawl",
+        provider,
         status,
         byteCount: 0,
         charCount: 0,
@@ -1193,7 +1203,7 @@ function firecrawlErrorResult(
 }
 
 /**
- * Fetch a page via Firecrawl's hosted `/v2/scrape` endpoint, returning clean
+ * Fetch a page via a Firecrawl-compatible scrape endpoint, returning clean
  * markdown. Mirrors the built-in fetcher's output shape (same
  * {@link formatWebFetchOutput} and {@link WebFetchMetadata}) so the model and
  * client UIs can't tell which backend served the page apart from
@@ -1202,9 +1212,15 @@ function firecrawlErrorResult(
  * Exported for direct unit testing; the registered tool dispatches here via
  * {@link getWebFetchProvider}.
  */
-export async function executeFirecrawlScrape(
+export async function executeFirecrawlCompatScrape(
   input: Record<string, unknown>,
-  options: { apiKey: string; signal?: AbortSignal },
+  options: {
+    apiKey: string;
+    endpoint: string;
+    provider: "firecrawl" | "fastcrw";
+    displayName: string;
+    signal?: AbortSignal;
+  },
 ): Promise<ToolExecutionResult> {
   const startedAt = Date.now();
   const parsedUrl = parseUrl(input.url);
@@ -1215,22 +1231,24 @@ export async function executeFirecrawlScrape(
     : sanitizeUrlStringForOutput(targetUrl);
 
   if (!targetUrl) {
-    return firecrawlErrorResult(
+    return hostedScrapeErrorResult(
       safeRequestedUrl,
       startedAt,
       "url is required and must be a valid HTTP(S) URL",
+      options.provider,
     );
   }
 
-  // Never forward URL-embedded credentials (user:password@host) to the hosted
-  // Firecrawl API. The built-in fetcher turns them into a Basic-auth header to
-  // the target; Firecrawl can't, so reject rather than leak them to a third
-  // party.
+  // Never forward URL-embedded credentials (user:password@host) to a hosted
+  // scrape API. The built-in fetcher turns them into a Basic-auth header to
+  // the target; hosted scrapers can't, so reject rather than leak them to a
+  // third party.
   if (parsedUrl?.username || parsedUrl?.password) {
-    return firecrawlErrorResult(
+    return hostedScrapeErrorResult(
       safeRequestedUrl,
       startedAt,
-      "URLs with embedded credentials are not supported by the Firecrawl provider. Remove the user:password@ portion of the URL.",
+      `URLs with embedded credentials are not supported by the ${options.displayName} provider. Remove the user:password@ portion of the URL.`,
+      options.provider,
     );
   }
 
@@ -1255,16 +1273,21 @@ export async function executeFirecrawlScrape(
     timeout: timeoutSeconds * 1000,
   };
 
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "X-Client-Source": "vellum-assistant",
+  };
+  const trimmedKey = options.apiKey.trim();
+  if (trimmedKey.length > 0) {
+    headers.Authorization = `Bearer ${trimmedKey}`;
+  }
+
   for (let attempt = 0; attempt <= DEFAULT_MAX_RETRIES; attempt++) {
     let response: Response;
     try {
-      response = await fetch(FIRECRAWL_SCRAPE_API_URL, {
+      response = await fetch(options.endpoint, {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${options.apiKey}`,
-          "X-Client-Source": "vellum-assistant",
-        },
+        headers,
         body: JSON.stringify(requestBody),
         signal: options.signal,
       });
@@ -1273,17 +1296,19 @@ export async function executeFirecrawlScrape(
         options.signal?.aborted ||
         (err instanceof Error && err.name === "AbortError")
       ) {
-        return firecrawlErrorResult(
+        return hostedScrapeErrorResult(
           safeRequestedUrl,
           startedAt,
           "web fetch was cancelled",
+          options.provider,
         );
       }
       const msg = err instanceof Error ? err.message : String(err);
-      return firecrawlErrorResult(
+      return hostedScrapeErrorResult(
         safeRequestedUrl,
         startedAt,
-        `Firecrawl scrape failed: ${msg}`,
+        `${options.displayName} scrape failed: ${msg}`,
+        options.provider,
       );
     }
 
@@ -1292,24 +1317,26 @@ export async function executeFirecrawlScrape(
       try {
         json = (await response.json()) as FirecrawlScrapeResponse;
       } catch {
-        return firecrawlErrorResult(
+        return hostedScrapeErrorResult(
           safeRequestedUrl,
           startedAt,
-          "Firecrawl scrape returned an invalid JSON payload.",
+          `${options.displayName} scrape returned an invalid JSON payload.`,
+          options.provider,
           response.status,
         );
       }
       const data = json.data ?? {};
-      const fcMeta = data.metadata ?? {};
+      const scrapeMeta = data.metadata ?? {};
       // A 200 can still carry a payload-level failure (success:false, a
       // top-level error, or a per-page error in data.metadata). Surface it
       // instead of treating an empty body as a successful "no content" scrape.
-      const payloadError = json.error ?? fcMeta.error;
+      const payloadError = json.error ?? scrapeMeta.error;
       if (json.success === false || payloadError) {
-        return firecrawlErrorResult(
+        return hostedScrapeErrorResult(
           safeRequestedUrl,
           startedAt,
-          payloadError ?? "Firecrawl scrape failed.",
+          payloadError ?? `${options.displayName} scrape failed.`,
+          options.provider,
           response.status,
         );
       }
@@ -1322,15 +1349,15 @@ export async function executeFirecrawlScrape(
       const sliced = processed.slice(safeStart, safeEnd);
       const bytesRead = Buffer.byteLength(processed, "utf8");
 
-      const finalUrlRaw = fcMeta.url ?? fcMeta.sourceURL ?? targetUrl;
+      const finalUrlRaw = scrapeMeta.url ?? scrapeMeta.sourceURL ?? targetUrl;
       const finalUrl = sanitizeUrlStringForOutput(finalUrlRaw);
-      const status = fcMeta.statusCode ?? 200;
-      const contentType = fcMeta.contentType ?? "text/markdown";
+      const status = scrapeMeta.statusCode ?? 200;
+      const contentType = scrapeMeta.contentType ?? "text/markdown";
 
       const notices: string[] = [];
       const warning = data.warning ?? json.warning;
       if (warning) {
-        notices.push(`Firecrawl: ${warning}`);
+        notices.push(`${options.displayName}: ${warning}`);
       }
       if (safeEnd < processed.length) {
         notices.push(`Output truncated by max_chars=${maxChars}.`);
@@ -1352,8 +1379,8 @@ export async function executeFirecrawlScrape(
         startIndex: safeStart,
         endIndex: safeEnd,
         content: sliced,
-        title: fcMeta.title,
-        description: fcMeta.description,
+        title: scrapeMeta.title,
+        description: scrapeMeta.description,
         notices,
         raw: false,
         markdown: true,
@@ -1363,13 +1390,13 @@ export async function executeFirecrawlScrape(
       const meta: WebFetchMetadata = {
         url: safeRequestedUrl,
         finalUrl,
-        provider: "firecrawl",
+        provider: options.provider,
         status,
         contentType,
         byteCount: bytesRead,
         charCount: sliced.length,
         truncated: safeEnd < processed.length,
-        title: fcMeta.title,
+        title: scrapeMeta.title,
         domain: finalDomain,
         faviconUrl: faviconUrlForDomain(finalDomain),
         redirectCount: 0,
@@ -1387,10 +1414,11 @@ export async function executeFirecrawlScrape(
     const bodyText = await response.text();
 
     if (response.status === 401 || response.status === 403) {
-      return firecrawlErrorResult(
+      return hostedScrapeErrorResult(
         safeRequestedUrl,
         startedAt,
-        "Invalid or expired Firecrawl API key",
+        `Invalid or expired ${options.displayName} API key`,
+        options.provider,
         response.status,
       );
     }
@@ -1402,37 +1430,75 @@ export async function executeFirecrawlScrape(
         DEFAULT_BASE_DELAY_MS,
       );
       log.warn(
-        { attempt: attempt + 1, delayMs },
-        "Firecrawl scrape rate limited, retrying",
+        { attempt: attempt + 1, delayMs, provider: options.provider },
+        `${options.displayName} scrape rate limited, retrying`,
       );
       await sleep(delayMs);
       continue;
     }
 
     log.warn(
-      { status: response.status, body: safeStringSlice(bodyText, 0, 200) },
-      "Firecrawl scrape API error",
+      {
+        status: response.status,
+        body: safeStringSlice(bodyText, 0, 200),
+        provider: options.provider,
+      },
+      `${options.displayName} scrape API error`,
     );
     const errorMessage =
       response.status === 429
-        ? "Firecrawl scrape rate limit exceeded after retries. Try again shortly."
+        ? `${options.displayName} scrape rate limit exceeded after retries. Try again shortly.`
         : response.status === 402
-          ? "Firecrawl scrape failed: account balance/credits exhausted."
-          : `Firecrawl scrape API returned status ${response.status}`;
-    return firecrawlErrorResult(
+          ? `${options.displayName} scrape failed: account balance/credits exhausted.`
+          : `${options.displayName} scrape API returned status ${response.status}`;
+    return hostedScrapeErrorResult(
       safeRequestedUrl,
       startedAt,
       errorMessage,
+      options.provider,
       response.status,
     );
   }
 
-  return firecrawlErrorResult(
+  return hostedScrapeErrorResult(
     safeRequestedUrl,
     startedAt,
-    "Firecrawl scrape rate limit exceeded after retries. Try again shortly.",
+    `${options.displayName} scrape rate limit exceeded after retries. Try again shortly.`,
+    options.provider,
     429,
   );
+}
+
+export async function executeFirecrawlScrape(
+  input: Record<string, unknown>,
+  options: { apiKey: string; signal?: AbortSignal },
+): Promise<ToolExecutionResult> {
+  return executeFirecrawlCompatScrape(input, {
+    apiKey: options.apiKey,
+    endpoint: FIRECRAWL_SCRAPE_API_URL,
+    provider: "firecrawl",
+    displayName: "Firecrawl",
+    signal: options.signal,
+  });
+}
+
+export async function executeFastcrwScrape(
+  input: Record<string, unknown>,
+  options: { apiKey: string; signal?: AbortSignal },
+): Promise<ToolExecutionResult> {
+  const apiBase = getConfig().services["web-fetch"]?.apiBase;
+  const endpoint = resolveProviderApiUrl(
+    apiBase,
+    FASTCRW_SCRAPE_PATH,
+    FASTCRW_DEFAULT_API_BASE,
+  );
+  return executeFirecrawlCompatScrape(input, {
+    apiKey: options.apiKey,
+    endpoint,
+    provider: "fastcrw",
+    displayName: "fastCRW",
+    signal: options.signal,
+  });
 }
 
 export const webFetchTool = {
@@ -1482,19 +1548,33 @@ export const webFetchTool = {
     input: Record<string, unknown>,
     context: ToolContext,
   ): Promise<ToolExecutionResult> {
+    const fetchProvider = getWebFetchProvider();
     if (
-      getWebFetchProvider() === "firecrawl" &&
-      (await canRouteToFirecrawl(input))
+      (fetchProvider === "firecrawl" || fetchProvider === "fastcrw") &&
+      (await canRouteToHostedScraper(input))
     ) {
-      const apiKey = await getProviderKeyAsync("firecrawl");
-      if (apiKey) {
-        return executeFirecrawlScrape(input, {
+      const apiKey = (await getProviderKeyAsync(fetchProvider)) ?? "";
+      const webFetchApiBase = getConfig().services["web-fetch"]?.apiBase;
+      const allowsKeylessSelfHost =
+        fetchProvider === "fastcrw" &&
+        typeof webFetchApiBase === "string" &&
+        webFetchApiBase.trim().length > 0;
+
+      if (apiKey || allowsKeylessSelfHost) {
+        if (fetchProvider === "firecrawl") {
+          return executeFirecrawlScrape(input, {
+            apiKey,
+            signal: context.signal,
+          });
+        }
+        return executeFastcrwScrape(input, {
           apiKey,
           signal: context.signal,
         });
       }
       log.info(
-        "web_fetch provider is firecrawl but no API key is configured; falling back to the built-in fetcher",
+        { provider: fetchProvider },
+        "web_fetch BYOK provider has no API key configured; falling back to the built-in fetcher",
       );
       // Fall through to the built-in fetcher.
     }

--- a/assistant/src/tools/network/web-search.ts
+++ b/assistant/src/tools/network/web-search.ts
@@ -21,6 +21,13 @@ import type {
   ToolExecutionResult,
 } from "../types.js";
 import { extractDomain } from "./domain-normalize.js";
+import {
+  extractFirecrawlCompatSearchResults,
+  FASTCRW_DEFAULT_API_BASE,
+  type FirecrawlCompatSearchResult,
+  resolveProviderApiUrl,
+  searchResultSnippet,
+} from "./firecrawl-compat.js";
 import type { ManagedSearchProxyResult } from "./managed-search-proxy.js";
 import {
   classifyWebSearchFailure,
@@ -35,6 +42,7 @@ const BRAVE_API_URL = `https://api.search.brave.com${BRAVE_SEARCH_PATH}`;
 const PERPLEXITY_API_URL = "https://api.perplexity.ai/chat/completions";
 const TAVILY_API_URL = "https://api.tavily.com/search";
 const FIRECRAWL_API_URL = "https://api.firecrawl.dev/v2/search";
+const FASTCRW_SEARCH_PATH = "/v1/search";
 // Keenable is keyless by default: the public path needs no key (rate-limited);
 // a key switches to the authenticated path and lifts the cap.
 const KEENABLE_API_BASE_URL = "https://api.keenable.ai";
@@ -46,7 +54,8 @@ type WebSearchProvider =
   | "brave"
   | "tavily"
   | "firecrawl"
-  | "keenable";
+  | "keenable"
+  | "fastcrw";
 
 /**
  * Arguments passed to every {@link WebSearchAdapter}. The full superset is
@@ -123,25 +132,21 @@ interface TavilySearchResponse {
   results?: TavilySearchResult[];
 }
 
-interface FirecrawlSearchResult {
-  title?: string;
-  description?: string;
-  url?: string;
-  category?: string;
-}
-
 /**
- * Firecrawl `/v2/search` returns one array per requested source under `data`
- * (defaults to `web`). We request only `web`, so that is the array we read;
- * `news`/`images` are typed loosely since we never request them here.
+ * Firecrawl `/v2/search` and fastCRW `/v1/search` payloads. Result rows are
+ * read via {@link extractFirecrawlCompatSearchResults} (grouped `data.web`,
+ * self-hosted `data.results.web`, flat `data.results`, or array `data`).
  */
-interface FirecrawlSearchResponse {
+interface FirecrawlCompatSearchResponse {
   success?: boolean;
-  data?: {
-    web?: FirecrawlSearchResult[];
-    news?: FirecrawlSearchResult[];
-    images?: unknown[];
-  };
+  data?:
+    | FirecrawlCompatSearchResult[]
+    | {
+        web?: FirecrawlCompatSearchResult[];
+        results?: FirecrawlCompatSearchResult[];
+        news?: FirecrawlCompatSearchResult[];
+        images?: unknown[];
+      };
   warning?: string | null;
 }
 
@@ -278,11 +283,11 @@ function formatTavilyResults(
   return lines.join("\n");
 }
 
-function formatFirecrawlResults(
-  data: FirecrawlSearchResponse,
+function formatFirecrawlCompatResults(
+  data: FirecrawlCompatSearchResponse,
   query: string,
 ): string {
-  const results = data.data?.web ?? [];
+  const results = extractFirecrawlCompatSearchResults(data);
 
   if (results.length === 0) {
     return `No results found for "${query}".`;
@@ -297,8 +302,9 @@ function formatFirecrawlResults(
     if (r.url) {
       lines.push(`   URL: ${r.url}`);
     }
-    if (r.description) {
-      lines.push(`   ${r.description}`);
+    const snippet = searchResultSnippet(r);
+    if (snippet) {
+      lines.push(`   ${snippet}`);
     }
     lines.push("");
   }
@@ -442,12 +448,13 @@ function tavilyTimeRangeForFreshness(
   }
 }
 
-function buildFirecrawlMetadata(
-  data: FirecrawlSearchResponse,
+function buildFirecrawlCompatMetadata(
+  data: FirecrawlCompatSearchResponse,
   query: string,
   durationMs: number,
+  provider: "firecrawl" | "fastcrw",
 ): WebSearchMetadata {
-  const results = data.data?.web ?? [];
+  const results = extractFirecrawlCompatSearchResults(data);
   const items: WebSearchResultItem[] = results.map((r, i) => {
     const url = r.url ?? "";
     const domain = extractDomain(url);
@@ -457,12 +464,12 @@ function buildFirecrawlMetadata(
       url,
       domain,
       faviconUrl: faviconUrlForDomain(domain),
-      snippet: r.description,
+      snippet: searchResultSnippet(r),
     };
   });
   return {
     query,
-    provider: "firecrawl",
+    provider,
     resultCount: items.length,
     durationMs,
     results: items,
@@ -1080,12 +1087,17 @@ async function executeTavilySearch(
   );
 }
 
-async function executeFirecrawlSearch(
+async function executeFirecrawlCompatSearch(
   query: string,
   count: number,
   freshness: string | undefined,
   apiKey: string,
-  signal?: AbortSignal,
+  options: {
+    endpoint: string;
+    provider: "firecrawl" | "fastcrw";
+    displayName: string;
+    signal?: AbortSignal;
+  },
 ): Promise<ToolExecutionResult> {
   const tbs = firecrawlTbsForFreshness(freshness);
   const body: Record<string, unknown> = {
@@ -1098,36 +1110,51 @@ async function executeFirecrawlSearch(
   }
 
   const startedAt = Date.now();
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "X-Client-Source": "vellum-assistant",
+  };
+  const trimmedKey = apiKey.trim();
+  if (trimmedKey.length > 0) {
+    headers.Authorization = `Bearer ${trimmedKey}`;
+  }
 
   for (let attempt = 0; attempt <= DEFAULT_MAX_RETRIES; attempt++) {
     let response: Response;
     try {
-      response = await fetch(FIRECRAWL_API_URL, {
+      response = await fetch(options.endpoint, {
         method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${apiKey}`,
-          "X-Client-Source": "vellum-assistant",
-        },
+        headers,
         body: JSON.stringify(body),
-        signal,
+        signal: options.signal,
       });
     } catch (err) {
-      return networkFailureResult(query, "firecrawl", startedAt, err, signal);
+      return networkFailureResult(
+        query,
+        options.provider,
+        startedAt,
+        err,
+        options.signal,
+      );
     }
 
     if (response.ok) {
-      const data = (await response.json()) as FirecrawlSearchResponse;
+      const data = (await response.json()) as FirecrawlCompatSearchResponse;
       const durationMs = Date.now() - startedAt;
       return {
         content:
-          wrapUntrustedContent(formatFirecrawlResults(data, query), {
+          wrapUntrustedContent(formatFirecrawlCompatResults(data, query), {
             source: "search",
-            sourceDetail: "firecrawl",
+            sourceDetail: options.provider,
           }) + CITATION_INSTRUCTION,
         isError: false,
         activityMetadata: {
-          webSearch: buildFirecrawlMetadata(data, query, durationMs),
+          webSearch: buildFirecrawlCompatMetadata(
+            data,
+            query,
+            durationMs,
+            options.provider,
+          ),
         },
       };
     }
@@ -1137,9 +1164,9 @@ async function executeFirecrawlSearch(
     if (response.status === 401 || response.status === 403) {
       return errorResult(
         query,
-        "firecrawl",
+        options.provider,
         startedAt,
-        "Invalid or expired Firecrawl API key",
+        `Invalid or expired ${options.displayName} API key`,
       );
     }
 
@@ -1150,32 +1177,71 @@ async function executeFirecrawlSearch(
         DEFAULT_BASE_DELAY_MS,
       );
       log.warn(
-        { attempt: attempt + 1, delayMs },
-        "Firecrawl Search rate limited, retrying",
+        { attempt: attempt + 1, delayMs, provider: options.provider },
+        `${options.displayName} Search rate limited, retrying`,
       );
       await sleep(delayMs);
       continue;
     }
 
-    log.warn({ status: response.status }, "Firecrawl Search API error");
+    log.warn(
+      { status: response.status, provider: options.provider },
+      `${options.displayName} Search API error`,
+    );
     return backendFailureResult(
       query,
-      "firecrawl",
+      options.provider,
       startedAt,
       { statusCode: response.status, error: rawBodyDetail(bodyText) },
       response.status === 429
-        ? "Firecrawl Search rate limit exceeded after retries. Try again shortly."
-        : `Firecrawl Search API returned status ${response.status}`,
+        ? `${options.displayName} Search rate limit exceeded after retries. Try again shortly.`
+        : `${options.displayName} Search API returned status ${response.status}`,
     );
   }
 
   return backendFailureResult(
     query,
-    "firecrawl",
+    options.provider,
     startedAt,
     { statusCode: 429 },
-    "Firecrawl Search rate limit exceeded after retries. Try again shortly.",
+    `${options.displayName} Search rate limit exceeded after retries. Try again shortly.`,
   );
+}
+
+function executeFirecrawlSearch(
+  query: string,
+  count: number,
+  freshness: string | undefined,
+  apiKey: string,
+  signal?: AbortSignal,
+): Promise<ToolExecutionResult> {
+  return executeFirecrawlCompatSearch(query, count, freshness, apiKey, {
+    endpoint: FIRECRAWL_API_URL,
+    provider: "firecrawl",
+    displayName: "Firecrawl",
+    signal,
+  });
+}
+
+function executeFastcrwSearch(
+  query: string,
+  count: number,
+  freshness: string | undefined,
+  apiKey: string,
+  signal?: AbortSignal,
+): Promise<ToolExecutionResult> {
+  const apiBase = getConfig().services["web-search"]?.apiBase;
+  const endpoint = resolveProviderApiUrl(
+    apiBase,
+    FASTCRW_SEARCH_PATH,
+    FASTCRW_DEFAULT_API_BASE,
+  );
+  return executeFirecrawlCompatSearch(query, count, freshness, apiKey, {
+    endpoint,
+    provider: "fastcrw",
+    displayName: "fastCRW",
+    signal,
+  });
 }
 
 async function executeKeenableSearch(
@@ -1345,6 +1411,14 @@ const keenableSearchAdapter: WebSearchAdapter = {
     executeKeenableSearch(query, count, freshness, apiKey, signal),
 };
 
+const fastcrwSearchAdapter: WebSearchAdapter = {
+  id: "fastcrw",
+  providerKeyName: "fastcrw",
+  fallbackOrder: 6,
+  execute: ({ query, count, freshness, apiKey, signal }) =>
+    executeFastcrwSearch(query, count, freshness, apiKey, signal),
+};
+
 /**
  * All built-in web-search adapters keyed by provider id. The
  * `Record<WebSearchProvider, ...>` shape forces TypeScript to flag any
@@ -1356,6 +1430,7 @@ const WEB_SEARCH_ADAPTERS: Record<WebSearchProvider, WebSearchAdapter> = {
   tavily: tavilySearchAdapter,
   firecrawl: firecrawlSearchAdapter,
   keenable: keenableSearchAdapter,
+  fastcrw: fastcrwSearchAdapter,
 };
 
 /**
@@ -1387,7 +1462,7 @@ export const webSearchTool = {
       count: {
         type: "number",
         description:
-          "Number of results to return (1-20, default 10). Used with Brave, Tavily, Firecrawl, and Keenable providers.",
+          "Number of results to return (1-20, default 10). Used with Brave, Tavily, Firecrawl, Keenable, and fastCRW providers.",
       },
       offset: {
         type: "number",
@@ -1397,7 +1472,7 @@ export const webSearchTool = {
       freshness: {
         type: "string",
         description:
-          'Filter by recency: "pd" (past day), "pw" (past week), "pm" (past month), "py" (past year). Used with Brave, Tavily, Firecrawl, and Keenable providers.',
+          'Filter by recency: "pd" (past day), "pw" (past week), "pm" (past month), "py" (past year). Used with Brave, Tavily, Firecrawl, Keenable, and fastCRW providers.',
       },
     },
     required: ["query"],
@@ -1462,13 +1537,24 @@ export const webSearchTool = {
     let provider = getWebSearchProvider();
     let apiKey = await getApiKey(provider);
 
+    const webSearchApiBase = getConfig().services["web-search"]?.apiBase;
+    const fastcrwAllowsKeylessSelfHost =
+      provider === "fastcrw" &&
+      typeof webSearchApiBase === "string" &&
+      webSearchApiBase.trim().length > 0;
+
     // A keyless provider (e.g. Keenable) runs without a stored key, so skip the
     // missing-key fallback/error entirely and execute it as configured.
+    // fastCRW with a custom API Base may also run without a key (self-hosted).
     // Fallback: if a key-based provider has no key, try other BYOK search
     // providers in a stable order. This preserves existing installs that only
     // configured one search-provider key while still allowing new providers to
     // be selected explicitly.
-    if (!apiKey && !WEB_SEARCH_ADAPTERS[provider].keyless) {
+    if (
+      !apiKey &&
+      !WEB_SEARCH_ADAPTERS[provider].keyless &&
+      !fastcrwAllowsKeylessSelfHost
+    ) {
       for (const fallback of fallbackProvidersFor(provider)) {
         const fallbackKey = await getApiKey(fallback);
         if (!fallbackKey) {
@@ -1502,7 +1588,7 @@ export const webSearchTool = {
           query,
           provider,
           startedAt,
-          "No web search API key configured. Set it via `keys set perplexity <key>`, `keys set brave <key>`, `keys set tavily <key>`, or `keys set firecrawl <key>`, or configure it from the Settings page under API Keys. Or switch the web-search provider to Keenable, which works without a key.",
+          "No web search API key configured. Set it via `keys set perplexity <key>`, `keys set brave <key>`, `keys set tavily <key>`, `keys set firecrawl <key>`, or `keys set fastcrw <key>`, or configure it from the Settings page under API Keys. Or switch the web-search provider to Keenable, which works without a key.",
         );
       }
     }

--- a/cli/src/shared/provider-env-vars.ts
+++ b/cli/src/shared/provider-env-vars.ts
@@ -42,6 +42,7 @@ export const SEARCH_PROVIDER_ENV_VAR_NAMES: Record<string, string> = {
   tavily: "TAVILY_API_KEY",
   firecrawl: "FIRECRAWL_API_KEY",
   keenable: "KEENABLE_API_KEY",
+  fastcrw: "FASTCRW_API_KEY",
 };
 
 /**

--- a/clients/web/src/assistant/generated/web-fetch-provider-catalog.gen.ts
+++ b/clients/web/src/assistant/generated/web-fetch-provider-catalog.gen.ts
@@ -5,6 +5,7 @@
 export const WEB_FETCH_PROVIDER_IDS: readonly string[] = [
   "default",
   "firecrawl",
+  "fastcrw",
 ];
 
 /** Short display name used in picker UI. */
@@ -13,6 +14,7 @@ export const WEB_FETCH_PROVIDER_DISPLAY_NAMES: Readonly<
 > = {
   default: "Vellum",
   firecrawl: "Firecrawl",
+  fastcrw: "fastCRW",
 };
 
 /** Placeholder hint shown in the API-key input. BYOK providers only. */
@@ -20,19 +22,34 @@ export const WEB_FETCH_PROVIDER_KEY_PLACEHOLDERS: Readonly<
   Record<string, string>
 > = {
   firecrawl: "fc-...",
+  fastcrw: "crw_live_...",
 };
 
 /**
  * localStorage key used to persist each BYOK provider's user-supplied key.
- * Firecrawl intentionally shares the same key slot as web search — one stored
- * `firecrawl` credential powers both `web_search` and `web_fetch`.
+ * Firecrawl and fastCRW intentionally share the same key slot as web search —
+ * one stored credential powers both `web_search` and `web_fetch`.
  */
 export const WEB_FETCH_PROVIDER_KEY_STORAGE: Readonly<Record<string, string>> =
   {
     firecrawl: "vellum:ai:firecrawlKey",
+    fastcrw: "vellum:ai:fastcrwKey",
   };
 
 /** Provider ids that require a user-supplied API key. */
 export const WEB_FETCH_BYOK_PROVIDER_IDS: ReadonlySet<string> = new Set([
   "firecrawl",
+  "fastcrw",
 ]);
+
+/** Provider ids that show an optional API Base field in settings. */
+export const WEB_FETCH_API_BASE_PROVIDER_IDS: ReadonlySet<string> = new Set([
+  "fastcrw",
+]);
+
+/** Cloud default API origin when API Base is left empty. */
+export const WEB_FETCH_PROVIDER_DEFAULT_API_BASE: Readonly<
+  Record<string, string>
+> = {
+  fastcrw: "https://api.fastcrw.com",
+};

--- a/clients/web/src/assistant/generated/web-search-provider-catalog.gen.ts
+++ b/clients/web/src/assistant/generated/web-search-provider-catalog.gen.ts
@@ -9,6 +9,8 @@ export const WEB_SEARCH_PROVIDER_IDS: readonly string[] = [
   "brave",
   "tavily",
   "firecrawl",
+  "keenable",
+  "fastcrw",
 ];
 
 /** Short display name used in picker UI. */
@@ -21,6 +23,8 @@ export const WEB_SEARCH_PROVIDER_DISPLAY_NAMES: Readonly<
   brave: "Brave",
   tavily: "Tavily",
   firecrawl: "Firecrawl",
+  keenable: "Keenable",
+  fastcrw: "fastCRW",
 };
 
 /** Placeholder hint shown in the API-key input. BYOK providers only. */
@@ -31,6 +35,8 @@ export const WEB_SEARCH_PROVIDER_KEY_PLACEHOLDERS: Readonly<
   brave: "BSA...",
   tavily: "tvly-...",
   firecrawl: "fc-...",
+  keenable: "keen_... (optional)",
+  fastcrw: "crw_live_...",
 };
 
 /** localStorage key used to persist each BYOK provider's user-supplied key. */
@@ -40,6 +46,8 @@ export const WEB_SEARCH_PROVIDER_KEY_STORAGE: Readonly<Record<string, string>> =
     brave: "vellum:ai:braveKey",
     tavily: "vellum:ai:tavilyKey",
     firecrawl: "vellum:ai:firecrawlKey",
+    keenable: "vellum:ai:keenableKey",
+    fastcrw: "vellum:ai:fastcrwKey",
   };
 
 /** Provider ids that require a user-supplied API key. */
@@ -48,4 +56,25 @@ export const WEB_SEARCH_BYOK_PROVIDER_IDS: ReadonlySet<string> = new Set([
   "brave",
   "tavily",
   "firecrawl",
+  "keenable",
+  "fastcrw",
 ]);
+
+/**
+ * BYOK providers that also work without a stored key (key is optional).
+ * Save is not gated on a credential for these.
+ */
+export const WEB_SEARCH_KEYLESS_BYOK_PROVIDER_IDS: ReadonlySet<string> =
+  new Set(["keenable"]);
+
+/** Provider ids that show an optional API Base field in settings. */
+export const WEB_SEARCH_API_BASE_PROVIDER_IDS: ReadonlySet<string> = new Set([
+  "fastcrw",
+]);
+
+/** Cloud default API origin when API Base is left empty. */
+export const WEB_SEARCH_PROVIDER_DEFAULT_API_BASE: Readonly<
+  Record<string, string>
+> = {
+  fastcrw: "https://api.fastcrw.com",
+};

--- a/clients/web/src/assistant/web-activity-types.ts
+++ b/clients/web/src/assistant/web-activity-types.ts
@@ -6,9 +6,10 @@ export type WebSearchProviderId =
   | "perplexity"
   | "tavily"
   | "keenable"
-  | "firecrawl";
+  | "firecrawl"
+  | "fastcrw";
 
-export type WebFetchProviderId = "default" | "firecrawl";
+export type WebFetchProviderId = "default" | "firecrawl" | "fastcrw";
 
 export interface WebSearchResultItem {
   rank: number;

--- a/clients/web/src/domains/settings/ai/web-fetch-card.tsx
+++ b/clients/web/src/domains/settings/ai/web-fetch-card.tsx
@@ -2,7 +2,9 @@ import { Loader2 } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
 
 import {
+  WEB_FETCH_API_BASE_PROVIDER_IDS,
   WEB_FETCH_BYOK_PROVIDER_IDS,
+  WEB_FETCH_PROVIDER_DEFAULT_API_BASE,
   WEB_FETCH_PROVIDER_DISPLAY_NAMES,
   WEB_FETCH_PROVIDER_IDS,
   WEB_FETCH_PROVIDER_KEY_PLACEHOLDERS,
@@ -43,8 +45,8 @@ const DEFAULT_PROVIDER = "default";
 /**
  * Web Fetch service card. Unlike Web Search there is no managed proxy, so the
  * card is mode-less (`ByoServiceCard`): pick the built-in fetcher or a BYOK
- * provider (Firecrawl) that scrapes via its hosted API. Firecrawl reuses the
- * same stored credential as Web Search.
+ * provider that scrapes via its hosted API. BYOK providers reuse the same
+ * stored credential as Web Search.
  */
 export function WebFetchCard() {
   const { t } = useTranslation("settings");
@@ -79,12 +81,22 @@ export function WebFetchCard() {
     );
   }, [daemonConfig]);
 
+  const serverApiBase = useMemo((): string => {
+    const service = daemonConfig?.services?.["web-fetch"] as
+      | { apiBase?: string }
+      | undefined;
+    return service?.apiBase ?? "";
+  }, [daemonConfig]);
+
   const [saving, setSaving] = useState(false);
   const [webFetchProvider, setDraftWebFetchProvider] = useDraftOverride(
     serverWebFetchProvider,
   );
+  const [webFetchApiBase, setDraftWebFetchApiBase] =
+    useDraftOverride(serverApiBase);
   const [webFetchApiKey, setWebFetchApiKey] = useState("");
 
+  const showsApiBase = WEB_FETCH_API_BASE_PROVIDER_IDS.has(webFetchProvider);
   const requiresProviderCredential =
     WEB_FETCH_BYOK_PROVIDER_IDS.has(webFetchProvider);
   const { hasStoredCredential: webFetchHasStoredKey } =
@@ -97,9 +109,16 @@ export function WebFetchCard() {
 
   // --- Derived state ---
   const hasNewApiKey = webFetchApiKey.trim().length > 0;
-  const configChanged = webFetchProvider !== serverWebFetchProvider;
+  const trimmedApiBase = webFetchApiBase.trim();
+  const hasCustomApiBase = showsApiBase && trimmedApiBase.length > 0;
+  const configChanged =
+    webFetchProvider !== serverWebFetchProvider ||
+    (showsApiBase && trimmedApiBase !== serverApiBase.trim());
   const needsKeyBeforeSave =
-    requiresProviderCredential && !webFetchHasStoredKey && !hasNewApiKey;
+    requiresProviderCredential &&
+    !hasCustomApiBase &&
+    !webFetchHasStoredKey &&
+    !hasNewApiKey;
   const saveDisabled =
     saving || needsKeyBeforeSave || (!configChanged && !hasNewApiKey);
   const apiKeyPlaceholder = secretPlaceholder(
@@ -107,6 +126,8 @@ export function WebFetchCard() {
       t("webFetchCard.apiKeyPlaceholder"),
     webFetchHasStoredKey,
   );
+  const defaultApiBase =
+    WEB_FETCH_PROVIDER_DEFAULT_API_BASE[webFetchProvider] ?? "";
 
   const handleSave = useCallback(async () => {
     setSaving(true);
@@ -121,7 +142,10 @@ export function WebFetchCard() {
           path: { assistant_id: assistantId },
           body: {
             services: {
-              "web-fetch": { provider: webFetchProvider },
+              "web-fetch": {
+                provider: webFetchProvider,
+                ...(showsApiBase ? { apiBase: trimmedApiBase } : {}),
+              },
             },
           },
         })
@@ -164,6 +188,8 @@ export function WebFetchCard() {
     assistantId,
     webFetchApiKey,
     webFetchProvider,
+    showsApiBase,
+    trimmedApiBase,
     t,
   ]);
 
@@ -173,9 +199,10 @@ export function WebFetchCard() {
       removeLocalSetting(storageKey);
     }
     setWebFetchApiKey("");
+    setDraftWebFetchApiBase("");
     setDraftWebFetchProvider(DEFAULT_PROVIDER);
     setLocalSetting(LS_WEB_FETCH_PROVIDER, DEFAULT_PROVIDER);
-  }, [webFetchProvider, setDraftWebFetchProvider]);
+  }, [webFetchProvider, setDraftWebFetchProvider, setDraftWebFetchApiBase]);
 
   return (
     <ByoServiceCard
@@ -197,6 +224,28 @@ export function WebFetchCard() {
             }))}
           />
         </div>
+
+        {showsApiBase && (
+          <div className="space-y-1">
+            <Input
+              label={t("webFetchCard.apiBaseLabel")}
+              type="url"
+              value={webFetchApiBase}
+              onChange={(e) => setDraftWebFetchApiBase(e.target.value)}
+              placeholder={
+                defaultApiBase || t("webFetchCard.apiBasePlaceholder")
+              }
+              fullWidth
+            />
+            {defaultApiBase ? (
+              <p className="text-body-small-default text-[var(--content-tertiary)]">
+                {t("webFetchCard.apiBaseHint", {
+                  defaultBase: defaultApiBase,
+                })}
+              </p>
+            ) : null}
+          </div>
+        )}
 
         {requiresProviderCredential && (
           <Input

--- a/clients/web/src/domains/settings/ai/web-search-card.test.tsx
+++ b/clients/web/src/domains/settings/ai/web-search-card.test.tsx
@@ -169,6 +169,8 @@ describe("WebSearchCard — provider-only configuration", () => {
       "Brave",
       "Tavily",
       "Firecrawl",
+      "Keenable",
+      "fastCRW",
     ]);
   });
 
@@ -248,6 +250,41 @@ describe("WebSearchCard — provider-only configuration", () => {
     expect(configPatchCalls[0]!.body).toMatchObject({
       services: {
         "web-search": { provider: "firecrawl", mode: "your-own" },
+      },
+    });
+  });
+
+  test("fastCRW shows API Base and allows save without a key when base is custom", async () => {
+    renderCard();
+
+    fireEvent.click(providerTrigger());
+    selectOption("fastCRW");
+
+    expect(screen.getByText("API Base")).toBeTruthy();
+    const saveButton = screen.getByRole("button", {
+      name: "Save",
+    }) as HTMLButtonElement;
+    expect(saveButton.disabled).toBe(true);
+
+    const apiBaseInput = screen.getByPlaceholderText(
+      "https://api.fastcrw.com",
+    );
+    fireEvent.change(apiBaseInput, {
+      target: { value: "http://localhost:3000" },
+    });
+    expect(saveButton.disabled).toBe(false);
+
+    fireEvent.click(saveButton);
+
+    await waitFor(() => expect(configPatchCalls.length).toBe(1));
+    expect(provisionedKeys).toHaveLength(0);
+    expect(configPatchCalls[0]!.body).toMatchObject({
+      services: {
+        "web-search": {
+          provider: "fastcrw",
+          mode: "your-own",
+          apiBase: "http://localhost:3000",
+        },
       },
     });
   });

--- a/clients/web/src/domains/settings/ai/web-search-card.tsx
+++ b/clients/web/src/domains/settings/ai/web-search-card.tsx
@@ -2,7 +2,10 @@ import { Loader2 } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
 
 import {
+  WEB_SEARCH_API_BASE_PROVIDER_IDS,
   WEB_SEARCH_BYOK_PROVIDER_IDS,
+  WEB_SEARCH_KEYLESS_BYOK_PROVIDER_IDS,
+  WEB_SEARCH_PROVIDER_DEFAULT_API_BASE,
   WEB_SEARCH_PROVIDER_DISPLAY_NAMES,
   WEB_SEARCH_PROVIDER_IDS,
   WEB_SEARCH_PROVIDER_KEY_PLACEHOLDERS,
@@ -75,7 +78,8 @@ export function WebSearchCard() {
       );
     }
     const wsService = daemonConfig.services?.["web-search"] as
-      { provider?: string; mode?: string } | undefined;
+      | { provider?: string; mode?: string; apiBase?: string }
+      | undefined;
     // A config written by the legacy mode toggle marks managed via `mode`
     // while `provider` holds the BYOK restore value — the daemon routes it to
     // Vellum, so the card must render it as Vellum too. Provider Native is
@@ -91,15 +95,27 @@ export function WebSearchCard() {
     );
   }, [daemonConfig]);
 
+  const serverApiBase = useMemo((): string => {
+    const wsService = daemonConfig?.services?.["web-search"] as
+      | { apiBase?: string }
+      | undefined;
+    return wsService?.apiBase ?? "";
+  }, [daemonConfig]);
+
   const [saving, setSaving] = useState(false);
   const [webSearchProvider, setDraftWebSearchProvider] = useDraftOverride(
     serverWebSearchProvider,
   );
+  const [webSearchApiBase, setDraftWebSearchApiBase] =
+    useDraftOverride(serverApiBase);
 
   const [webSearchApiKey, setWebSearchApiKey] = useState("");
 
+  const showsApiBase = WEB_SEARCH_API_BASE_PROVIDER_IDS.has(webSearchProvider);
   const requiresProviderCredential =
     WEB_SEARCH_BYOK_PROVIDER_IDS.has(webSearchProvider);
+  const isKeylessByok =
+    WEB_SEARCH_KEYLESS_BYOK_PROVIDER_IDS.has(webSearchProvider);
   const { hasStoredCredential: webSearchHasStoredKey } =
     useStoredCredentialPresence({
       assistantId,
@@ -110,9 +126,17 @@ export function WebSearchCard() {
 
   // --- Derived state ---
   const hasNewApiKey = webSearchApiKey.trim().length > 0;
-  const configChanged = webSearchProvider !== serverWebSearchProvider;
+  const trimmedApiBase = webSearchApiBase.trim();
+  const hasCustomApiBase = showsApiBase && trimmedApiBase.length > 0;
+  const configChanged =
+    webSearchProvider !== serverWebSearchProvider ||
+    (showsApiBase && trimmedApiBase !== serverApiBase.trim());
   const needsKeyBeforeSave =
-    requiresProviderCredential && !webSearchHasStoredKey && !hasNewApiKey;
+    requiresProviderCredential &&
+    !isKeylessByok &&
+    !hasCustomApiBase &&
+    !webSearchHasStoredKey &&
+    !hasNewApiKey;
   const saveDisabled =
     saving || needsKeyBeforeSave || (!configChanged && !hasNewApiKey);
   const apiKeyPlaceholder = secretPlaceholder(
@@ -120,6 +144,8 @@ export function WebSearchCard() {
       t("webSearchCard.apiKeyPlaceholder"),
     webSearchHasStoredKey,
   );
+  const defaultApiBase =
+    WEB_SEARCH_PROVIDER_DEFAULT_API_BASE[webSearchProvider] ?? "";
 
   const handleSave = useCallback(async () => {
     setSaving(true);
@@ -140,12 +166,17 @@ export function WebSearchCard() {
       const webSearchService: {
         provider?: string;
         mode: "managed" | "your-own";
+        apiBase?: string;
       } =
         webSearchProvider === "vellum"
           ? supportsWebSearchVellumProvider()
             ? { provider: "vellum", mode: "managed" }
             : { mode: "managed" }
-          : { provider: webSearchProvider, mode: "your-own" };
+          : {
+              provider: webSearchProvider,
+              mode: "your-own",
+              ...(showsApiBase ? { apiBase: trimmedApiBase } : {}),
+            };
       await configMutation
         .mutateAsync({
           path: { assistant_id: assistantId },
@@ -195,6 +226,8 @@ export function WebSearchCard() {
     assistantId,
     webSearchApiKey,
     webSearchProvider,
+    showsApiBase,
+    trimmedApiBase,
     t,
   ]);
 
@@ -204,9 +237,14 @@ export function WebSearchCard() {
       removeLocalSetting(storageKey);
     }
     setWebSearchApiKey("");
+    setDraftWebSearchApiBase("");
     setDraftWebSearchProvider("inference-provider-native");
     setLocalSetting(LS_WEB_SEARCH_PROVIDER, "inference-provider-native");
-  }, [webSearchProvider, setDraftWebSearchProvider]);
+  }, [
+    webSearchProvider,
+    setDraftWebSearchProvider,
+    setDraftWebSearchApiBase,
+  ]);
 
   return (
     <ByoServiceCard
@@ -233,6 +271,28 @@ export function WebSearchCard() {
           <p className="text-body-medium-lighter text-[var(--content-tertiary)]">
             {t("webSearchCard.vellumNote")}
           </p>
+        )}
+
+        {showsApiBase && (
+          <div className="space-y-1">
+            <Input
+              label={t("webSearchCard.apiBaseLabel")}
+              type="url"
+              value={webSearchApiBase}
+              onChange={(e) => setDraftWebSearchApiBase(e.target.value)}
+              placeholder={
+                defaultApiBase || t("webSearchCard.apiBasePlaceholder")
+              }
+              fullWidth
+            />
+            {defaultApiBase ? (
+              <p className="text-body-small-default text-[var(--content-tertiary)]">
+                {t("webSearchCard.apiBaseHint", {
+                  defaultBase: defaultApiBase,
+                })}
+              </p>
+            ) : null}
+          </div>
         )}
 
         {requiresProviderCredential && (

--- a/clients/web/src/i18n/locales/en/settings.json
+++ b/clients/web/src/i18n/locales/en/settings.json
@@ -1077,6 +1077,9 @@
     "titleWithName": "{name}'s Voice"
   },
   "webFetchCard": {
+    "apiBaseHint": "Leave empty for the cloud default ({defaultBase}).",
+    "apiBaseLabel": "API Base",
+    "apiBasePlaceholder": "https://api.fastcrw.com",
     "apiKeyLabel": "API Key",
     "apiKeyPlaceholder": "Enter your API key",
     "configUpdateFailedToast": "Failed to update assistant configuration. Please try again.",
@@ -1087,6 +1090,9 @@
     "title": "Web Fetch"
   },
   "webSearchCard": {
+    "apiBaseHint": "Leave empty for the cloud default ({defaultBase}).",
+    "apiBaseLabel": "API Base",
+    "apiBasePlaceholder": "https://api.fastcrw.com",
     "apiKeyLabel": "API Key",
     "apiKeyPlaceholder": "Enter your API key",
     "configUpdateFailedToast": "Failed to update assistant configuration. Please try again.",

--- a/clients/web/src/i18n/locales/es/settings.json
+++ b/clients/web/src/i18n/locales/es/settings.json
@@ -1077,6 +1077,9 @@
     "titleWithName": "Voz de {name}"
   },
   "webFetchCard": {
+    "apiBaseHint": "Déjalo vacío para el valor predeterminado en la nube ({defaultBase}).",
+    "apiBaseLabel": "Base de la API",
+    "apiBasePlaceholder": "https://api.fastcrw.com",
     "apiKeyLabel": "Clave de API",
     "apiKeyPlaceholder": "Introduce tu clave de API",
     "configUpdateFailedToast": "No se pudo actualizar la configuración del asistente. Inténtalo de nuevo.",
@@ -1087,6 +1090,9 @@
     "title": "Obtención web"
   },
   "webSearchCard": {
+    "apiBaseHint": "Déjalo vacío para el valor predeterminado en la nube ({defaultBase}).",
+    "apiBaseLabel": "Base de la API",
+    "apiBasePlaceholder": "https://api.fastcrw.com",
     "apiKeyLabel": "Clave de API",
     "apiKeyPlaceholder": "Introduce tu clave de API",
     "configUpdateFailedToast": "No se pudo actualizar la configuración del asistente. Inténtalo de nuevo.",

--- a/meta/web-search-provider-catalog.json
+++ b/meta/web-search-provider-catalog.json
@@ -62,6 +62,18 @@
       "secretKey": "keenable",
       "fallbackOrder": 5,
       "privacyPolicyUrl": "https://keenable.ai/privacy"
+    },
+    {
+      "id": "fastcrw",
+      "displayName": "fastCRW",
+      "kind": "byok",
+      "apiKeyPrefix": "crw_live_...",
+      "envVar": "FASTCRW_API_KEY",
+      "secretKey": "fastcrw",
+      "fallbackOrder": 6,
+      "privacyPolicyUrl": "https://fastcrw.com/privacy",
+      "supportsApiBase": true,
+      "defaultApiBase": "https://api.fastcrw.com"
     }
   ]
 }


### PR DESCRIPTION
## Prompt / plan
Add fastCRW (`https://fastcrw.com/`) as a BYOK provider for `web_search` and `web_fetch`, following the Firecrawl settings pattern: shared CES credential, optional API Base (empty = `https://api.fastcrw.com`), and API Key.

Approach:
- Catalog entries for search + fetch (`fastcrw`, `supportsApiBase`, default base, shared `secretKey`)
- Optional `apiBase` on web-search / web-fetch service schemas; OpenAPI + generated web catalogs synced
- Shared Firecrawl-compat helpers for URL resolution and portable search payload parsing (`data.web`, flat `data.results`, self-hosted `data.results.web` when `sources: ["web"]`, array `data`)
- Settings UI: API Base + API Key for fastCRW on both Web Search and Web Fetch cards
- Keyless self-host when a custom API base is set and no key is stored

## Test plan
- [x] Unit: `firecrawl-compat`, `web-search` (fastCRW default + custom base + keyless self-host), `web-fetch-fastcrw`, catalog parity, CLI search env-var parity, `web-search-card`
- [x] Typecheck: assistant, CLI, clients/web
- [x] Lint on touched files (including import-sort fix in `web-search.ts`); assistant `lint:unused`
- [x] `bun run generate:openapi -- --check`; `bun run sync:web-search-catalog -- --check`
- [x] Manual against a local Vellum instance: default base URL and custom API Base both work for search/fetch