### PR TITLE
feat(web): drive the Pair-a-device card from live tunnel status

### DIFF
--- a/clients/web/src/domains/settings/pair-device/pair-device-card.test.tsx
+++ b/clients/web/src/domains/settings/pair-device/pair-device-card.test.tsx
@@ -58,11 +58,18 @@ mock.module("@/hooks/use-is-org-ready", () => ({
 let probeResponse: IntegrationsIngressStatusGetResponse = {
   state: "unconfigured",
 };
-const probeMock = mock(async () => ({
-  data: probeResponse,
-  error: undefined,
-  response: new Response(null, { status: 200 }),
-}));
+/** Set by a test to make the probe fail the way a dead daemon would. */
+let probeFailure: Error | null = null;
+const probeMock = mock(async () => {
+  if (probeFailure) {
+    throw probeFailure;
+  }
+  return {
+    data: probeResponse,
+    error: undefined,
+    response: new Response(null, { status: 200 }),
+  };
+});
 
 /* Spread over the real module rather than replacing it: the generated SDK is a
    single barrel that the query-options barrel also pulls from, and a bare
@@ -255,6 +262,7 @@ beforeEach(() => {
   resetFetchLog();
   localStorage.clear();
   probeResponse = { state: "unconfigured" };
+  probeFailure = null;
   probeMock.mockClear();
   useResolvedAssistantsStore.getState().setActiveAssistantId(ASSISTANT_ID);
   // Tests that exercise the status row opt into a version that serves it.
@@ -756,6 +764,21 @@ describe("PairDeviceCard: tunnel status", () => {
     expect(screen.getByText(/comes from/)).toBeTruthy();
   });
 
+  test("keeps the first-run notice for the daemon's own unconfigured verdict", async () => {
+    // The daemon is the authority once it answers: a recorded URL it no longer
+    // reports is stale, so it does not suppress the notice or fill the field.
+    selectedAssistant = {
+      assistantId: ASSISTANT_ID,
+      cloud: "local",
+      ingressUrl: RECORDED_INGRESS_URL,
+    };
+    probeResponse = { state: "unconfigured" };
+    renderCard();
+
+    expect(await screen.findByText("Open a tunnel first")).toBeTruthy();
+    expect(urlField().value).toBe("");
+  });
+
   test("keeps a typed URL when the probe answers", async () => {
     probeResponse = healthyStatus();
     renderCard();
@@ -763,6 +786,53 @@ describe("PairDeviceCard: tunnel status", () => {
 
     await screen.findByText("The tunnel is running and reachable.");
     expect(urlField().value).toBe(PUBLIC_URL);
+  });
+});
+
+// A probe that never came back tells the card nothing, so it degrades to the
+// pre-probe behavior rather than to a blank card the gate-off path would never
+// have produced.
+describe("PairDeviceCard: when the tunnel probe gives up", () => {
+  beforeEach(() => {
+    enableTunnelStatus();
+    probeFailure = new Error("connection refused");
+  });
+
+  test("falls back to the recorded ingress URL, notice and all", async () => {
+    selectedAssistant = {
+      assistantId: ASSISTANT_ID,
+      cloud: "local",
+      ingressUrl: RECORDED_INGRESS_URL,
+    };
+    renderCard();
+
+    await waitFor(() => expect(urlField().value).toBe(RECORDED_INGRESS_URL));
+    expect(
+      (
+        screen.getByRole("button", {
+          name: "Generate pairing QR",
+        }) as HTMLButtonElement
+      ).disabled,
+    ).toBe(false);
+    expect(screen.queryByText("Open a tunnel first")).toBeNull();
+    // Nothing to report and nothing to re-check from: the row stays silent.
+    expect(
+      screen.queryByRole("button", { name: "Check the tunnel again" }),
+    ).toBeNull();
+  });
+
+  test("falls back to the field-derived empty state with nothing recorded", async () => {
+    renderCard();
+
+    expect(await screen.findByText("Open a tunnel first")).toBeTruthy();
+    expect(urlField().value).toBe("");
+    expect(
+      (
+        screen.getByRole("button", {
+          name: "Generate pairing QR",
+        }) as HTMLButtonElement
+      ).disabled,
+    ).toBe(true);
   });
 });
 

--- a/clients/web/src/domains/settings/pair-device/pair-device-card.test.tsx
+++ b/clients/web/src/domains/settings/pair-device/pair-device-card.test.tsx
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   act,
   cleanup,
@@ -9,6 +10,8 @@ import {
   waitFor,
 } from "@testing-library/react";
 
+import type { IntegrationsIngressStatusGetResponse } from "@/generated/daemon/types.gen";
+import { publish, __resetForTesting as resetEventBus } from "@/lib/event-bus";
 import type { LocalListDevicesResult } from "@/runtime/local-mode-host";
 
 let gatewayPath: string | undefined = "/assistant/__gateway/20100";
@@ -48,6 +51,29 @@ mock.module("@/lib/sentry/capture-error", () => ({
   captureError: () => {},
 }));
 
+mock.module("@/hooks/use-is-org-ready", () => ({
+  useIsOrgReady: () => true,
+}));
+
+let probeResponse: IntegrationsIngressStatusGetResponse = {
+  state: "unconfigured",
+};
+const probeMock = mock(async () => ({
+  data: probeResponse,
+  error: undefined,
+  response: new Response(null, { status: 200 }),
+}));
+
+/* Spread over the real module rather than replacing it: the generated SDK is a
+   single barrel that the query-options barrel also pulls from, and a bare
+   object drops every export this file does not name. */
+const realDaemonSdk = await import("@/generated/daemon/sdk.gen");
+
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  ...realDaemonSdk,
+  integrationsIngressStatusGet: probeMock,
+}));
+
 let listDevicesResult: LocalListDevicesResult = {
   ok: false,
   error: "unavailable",
@@ -66,6 +92,15 @@ mock.module(
 );
 
 const { PairDeviceCard } = await import("./pair-device-card");
+const { MIN_VERSION: INGRESS_STATUS_MIN_VERSION } = await import(
+  "@/lib/backwards-compat/ingress-status-gate"
+);
+const { useAssistantIdentityStore } = await import(
+  "@/stores/assistant-identity-store"
+);
+const { useResolvedAssistantsStore } = await import(
+  "@/stores/resolved-assistants-store"
+);
 const {
   createTimerHarness,
   fetchLog,
@@ -79,6 +114,42 @@ const {
 
 const PUBLIC_URL = "https://foo.ts.net";
 const PAIR_URL = "https://foo.ts.net/assistant/pair#device_code=DEV-123";
+const ASSISTANT_ID = "self";
+/** Below the ingress-status floor, so the probe stays out of reach. */
+const VERSION_WITHOUT_INGRESS_STATUS = "0.11.5";
+const TUNNEL_URL = "https://tunnel.example.ts.net";
+const RECORDED_INGRESS_URL = "https://recorded.example.ts.net";
+
+/** Move the active assistant onto a version whose daemon serves the probe. */
+function enableTunnelStatus() {
+  useAssistantIdentityStore
+    .getState()
+    .setIdentity("Test", INGRESS_STATUS_MIN_VERSION, ASSISTANT_ID);
+}
+
+function healthyStatus(publicBaseUrl = TUNNEL_URL) {
+  return {
+    state: "healthy" as const,
+    publicBaseUrl,
+    checkedAt: new Date().toISOString(),
+  };
+}
+
+/** Render inside a fresh query client, which the tunnel-status probe needs. */
+function renderCard() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <PairDeviceCard />
+    </QueryClientProvider>,
+  );
+}
+
+function urlField(): HTMLInputElement {
+  return screen.getByLabelText("Public URL") as HTMLInputElement;
+}
 
 function futureIso(): string {
   return new Date(Date.now() + 10 * 60_000).toISOString();
@@ -183,6 +254,13 @@ beforeEach(() => {
   listDevicesCalls = 0;
   resetFetchLog();
   localStorage.clear();
+  probeResponse = { state: "unconfigured" };
+  probeMock.mockClear();
+  useResolvedAssistantsStore.getState().setActiveAssistantId(ASSISTANT_ID);
+  // Tests that exercise the status row opt into a version that serves it.
+  useAssistantIdentityStore
+    .getState()
+    .setIdentity("Test", VERSION_WITHOUT_INGRESS_STATUS, ASSISTANT_ID);
   // A rendered card polls the pending-request list on mount, so every test
   // needs the route answered; minting stays unexpected unless overridden.
   installFetch(unexpectedMint);
@@ -191,18 +269,21 @@ beforeEach(() => {
 afterEach(() => {
   cleanup();
   restoreFetch();
+  resetEventBus();
+  useResolvedAssistantsStore.getState().setActiveAssistantId(null);
+  useAssistantIdentityStore.getState().clearIdentity();
 });
 
 describe("PairDeviceCard", () => {
   test("renders nothing when there is no local gateway (remote/platform mode)", () => {
     gatewayPath = undefined;
-    const { container } = render(<PairDeviceCard />);
+    const { container } = renderCard();
     expect(container.firstChild).toBeNull();
     expect(screen.queryByText("Pair a device")).toBeNull();
   });
 
   test("renders the section in local mode", () => {
-    render(<PairDeviceCard />);
+    renderCard();
     expect(screen.getByText("Pair a device")).toBeTruthy();
     expect(screen.getByLabelText("Public URL")).toBeTruthy();
     expect(
@@ -212,7 +293,7 @@ describe("PairDeviceCard", () => {
 
   test("renders nothing against an assistant without the pairing routes", () => {
     supportsPairingRoutes = false;
-    const { container } = render(<PairDeviceCard />);
+    const { container } = renderCard();
     expect(container.firstChild).toBeNull();
     expect(screen.queryByText("Pair a device")).toBeNull();
   });
@@ -220,14 +301,14 @@ describe("PairDeviceCard", () => {
   test("renders nothing when web-remote-ingress is off", () => {
     // The client flag only controls the card's visibility.
     webRemoteIngressOn = false;
-    const { container } = render(<PairDeviceCard />);
+    const { container } = renderCard();
     expect(container.firstChild).toBeNull();
     expect(screen.queryByText("Pair a device")).toBeNull();
   });
 
   test("mints + approves, then shows the QR and pair URL", async () => {
     installFetch(() => jsonResponse(challengeBody()));
-    render(<PairDeviceCard />);
+    renderCard();
     typeUrl(PUBLIC_URL);
     fireEvent.click(
       screen.getByRole("button", { name: "Generate pairing QR" }),
@@ -256,7 +337,7 @@ describe("PairDeviceCard", () => {
         403,
       ),
     );
-    render(<PairDeviceCard />);
+    renderCard();
     typeUrl(PUBLIC_URL);
     fireEvent.click(
       screen.getByRole("button", { name: "Generate pairing QR" }),
@@ -270,7 +351,7 @@ describe("PairDeviceCard", () => {
 
   test("blocks a loopback URL client-side without a network call", () => {
     installFetch(() => jsonResponse(challengeBody()));
-    render(<PairDeviceCard />);
+    renderCard();
     typeUrl("http://localhost:3000");
     fireEvent.click(
       screen.getByRole("button", { name: "Generate pairing QR" }),
@@ -290,7 +371,7 @@ describe("PairDeviceCard", () => {
       cloud: "local",
       ingressUrl: "https://tunnel.example.ts.net",
     };
-    render(<PairDeviceCard />);
+    renderCard();
 
     const input = screen.getByLabelText("Public URL") as HTMLInputElement;
     expect(input.value).toBe("https://tunnel.example.ts.net");
@@ -301,7 +382,7 @@ describe("PairDeviceCard", () => {
   });
 
   test("shows honest no-tunnel guidance when no ingress URL and no stored value", () => {
-    render(<PairDeviceCard />);
+    renderCard();
 
     expect(screen.getByText("Open a tunnel first")).toBeTruthy();
     expect(screen.getByText("vellum tunnel --provider tailscale")).toBeTruthy();
@@ -316,7 +397,7 @@ describe("PairDeviceCard", () => {
 
   test("rejects a tunnel-provider website URL (Tailscale admin invite) with a service-website message", () => {
     installFetch(() => jsonResponse(challengeBody()));
-    render(<PairDeviceCard />);
+    renderCard();
     typeUrl("https://login.tailscale.com/admin/invite/abc123");
     fireEvent.click(
       screen.getByRole("button", { name: "Generate pairing QR" }),
@@ -337,7 +418,7 @@ describe("PairDeviceCard", () => {
       cloud: "local",
       name: "My Assistant",
     };
-    render(<PairDeviceCard />);
+    renderCard();
 
     expect(
       screen.getByText(
@@ -359,7 +440,7 @@ describe("PairDeviceCard", () => {
         },
       ],
     };
-    render(<PairDeviceCard />);
+    renderCard();
 
     expect(
       await screen.findByRole("button", { name: "Paired devices (1)" }),
@@ -381,7 +462,7 @@ describe("PairDeviceCard", () => {
         },
       ],
     };
-    render(<PairDeviceCard />);
+    renderCard();
 
     expect(screen.getByText("Pair a device")).toBeTruthy();
     // The mount-time pending-request poll settles; the device list is never
@@ -396,7 +477,7 @@ describe("PairDeviceCard", () => {
   });
 
   test("falls back to generic copy when the assistant has no name", () => {
-    render(<PairDeviceCard />);
+    renderCard();
 
     expect(
       screen.getByText(
@@ -416,7 +497,7 @@ describe("PairDeviceCard: pending pairing requests", () => {
   }
 
   test("hides the approval section while no request is pending", async () => {
-    render(<PairDeviceCard />);
+    renderCard();
 
     // The list was polled and came back empty.
     await waitFor(() =>
@@ -432,7 +513,7 @@ describe("PairDeviceCard: pending pairing requests", () => {
       onPendingRequests: () =>
         jsonResponse({ error: { message: "gateway unreachable" } }, 500),
     });
-    render(<PairDeviceCard />);
+    renderCard();
 
     await waitFor(() =>
       expect(screen.getByText("gateway unreachable")).toBeTruthy(),
@@ -446,7 +527,7 @@ describe("PairDeviceCard: pending pairing requests", () => {
 
   test("renders a pending request's user code and requester metadata", async () => {
     installPendingFetch();
-    render(<PairDeviceCard />);
+    renderCard();
 
     await waitFor(() => expect(screen.getByText("QRST-7890")).toBeTruthy());
     expect(screen.getByText("Pairing requests")).toBeTruthy();
@@ -475,7 +556,7 @@ describe("PairDeviceCard: pending pairing requests", () => {
     timerHarness.install();
     try {
       await act(async () => {
-        render(<PairDeviceCard />);
+        renderCard();
       });
       expect(screen.getByText(/Requested 2 minutes ago/)).toBeTruthy();
 
@@ -497,7 +578,7 @@ describe("PairDeviceCard: pending pairing requests", () => {
 
   test("Approve posts the request id and removes the row", async () => {
     installPendingFetch();
-    render(<PairDeviceCard />);
+    renderCard();
     await waitFor(() => expect(screen.getByText("QRST-7890")).toBeTruthy());
 
     fireEvent.click(screen.getByRole("button", { name: "Approve" }));
@@ -510,7 +591,7 @@ describe("PairDeviceCard: pending pairing requests", () => {
 
   test("approving a pending request refetches the paired-device list", async () => {
     installPendingFetch();
-    render(<PairDeviceCard />);
+    renderCard();
     await waitFor(() => expect(screen.getByText("QRST-7890")).toBeTruthy());
     const callsBeforeApprove = listDevicesCalls;
 
@@ -523,7 +604,7 @@ describe("PairDeviceCard: pending pairing requests", () => {
 
   test("Deny posts the request id and removes the row", async () => {
     installPendingFetch();
-    render(<PairDeviceCard />);
+    renderCard();
     await waitFor(() => expect(screen.getByText("QRST-7890")).toBeTruthy());
 
     fireEvent.click(screen.getByRole("button", { name: "Deny" }));
@@ -539,7 +620,7 @@ describe("PairDeviceCard: pending pairing requests", () => {
     installPendingFetch({
       onRequestAction: () => new Promise<Response>(() => {}),
     });
-    render(<PairDeviceCard />);
+    renderCard();
     await waitFor(() => expect(screen.getByText("QRST-7890")).toBeTruthy());
 
     fireEvent.click(screen.getByRole("button", { name: "Approve" }));
@@ -573,7 +654,7 @@ describe("PairDeviceCard: pending pairing requests", () => {
           ],
         }),
     });
-    render(<PairDeviceCard />);
+    renderCard();
 
     await waitFor(() => expect(screen.getByText("QRST-7890")).toBeTruthy());
     expect(
@@ -587,7 +668,7 @@ describe("PairDeviceCard: pending pairing requests", () => {
       onPendingRequests: () =>
         jsonResponse({ requests: [pendingRequestBody({ viaEdgeProxy: true })] }),
     });
-    render(<PairDeviceCard />);
+    renderCard();
 
     await waitFor(() => expect(screen.getByText("QRST-7890")).toBeTruthy());
     expect(
@@ -598,7 +679,7 @@ describe("PairDeviceCard: pending pairing requests", () => {
   test("stays hidden with the card when there is no local gateway", () => {
     gatewayPath = undefined;
     installPendingFetch();
-    const { container } = render(<PairDeviceCard />);
+    const { container } = renderCard();
 
     expect(container.firstChild).toBeNull();
     expect(screen.queryByText("Pairing requests")).toBeNull();
@@ -609,10 +690,113 @@ describe("PairDeviceCard: pending pairing requests", () => {
   test("stays hidden with the card when web-remote-ingress is off", () => {
     webRemoteIngressOn = false;
     installPendingFetch();
-    const { container } = render(<PairDeviceCard />);
+    const { container } = renderCard();
 
     expect(container.firstChild).toBeNull();
     expect(screen.queryByText("Pairing requests")).toBeNull();
     expect(fetchLog).toHaveLength(0);
+  });
+});
+
+describe("PairDeviceCard: tunnel status", () => {
+  beforeEach(() => {
+    enableTunnelStatus();
+  });
+
+  test("shows the status row for a healthy tunnel, without the first-run notice", async () => {
+    probeResponse = healthyStatus();
+    renderCard();
+
+    expect(
+      await screen.findByText("The tunnel is running and reachable."),
+    ).toBeTruthy();
+    expect(screen.getByText(TUNNEL_URL)).toBeTruthy();
+    expect(screen.queryByText("Open a tunnel first")).toBeNull();
+  });
+
+  test("shows the first-run notice only once the daemon reports no tunnel", async () => {
+    probeResponse = { state: "unconfigured" };
+    renderCard();
+
+    // The in-flight probe is not an empty state, so the row speaks first.
+    expect(
+      screen.getByText("Checking whether the tunnel is reachable…"),
+    ).toBeTruthy();
+    expect(screen.queryByText("Open a tunnel first")).toBeNull();
+
+    expect(await screen.findByText("Open a tunnel first")).toBeTruthy();
+    expect(screen.getByText("vellum tunnel --provider tailscale")).toBeTruthy();
+    expect(
+      screen.queryByRole("button", { name: "Check the tunnel again" }),
+    ).toBeNull();
+  });
+
+  test("re-checks the tunnel when the app resumes", async () => {
+    probeResponse = healthyStatus();
+    renderCard();
+    await screen.findByText("The tunnel is running and reachable.");
+    expect(probeMock).toHaveBeenCalledTimes(1);
+
+    act(() => publish("app.resume", { signal: "visibility" }));
+
+    await waitFor(() => expect(probeMock).toHaveBeenCalledTimes(2));
+  });
+
+  test("prefills the URL field from the daemon's address, not the recorded one", async () => {
+    selectedAssistant = {
+      assistantId: ASSISTANT_ID,
+      cloud: "local",
+      ingressUrl: RECORDED_INGRESS_URL,
+    };
+    probeResponse = healthyStatus();
+    renderCard();
+
+    await waitFor(() => expect(urlField().value).toBe(TUNNEL_URL));
+    // The helper text still credits `vellum tunnel` for the address.
+    expect(screen.getByText(/comes from/)).toBeTruthy();
+  });
+
+  test("keeps a typed URL when the probe answers", async () => {
+    probeResponse = healthyStatus();
+    renderCard();
+    typeUrl(PUBLIC_URL);
+
+    await screen.findByText("The tunnel is running and reachable.");
+    expect(urlField().value).toBe(PUBLIC_URL);
+  });
+});
+
+describe("PairDeviceCard: without the ingress-status route", () => {
+  test("never probes and keeps the recorded ingress URL as the prefill", async () => {
+    selectedAssistant = {
+      assistantId: ASSISTANT_ID,
+      cloud: "local",
+      ingressUrl: RECORDED_INGRESS_URL,
+    };
+    probeResponse = healthyStatus();
+    renderCard();
+
+    expect(urlField().value).toBe(RECORDED_INGRESS_URL);
+    expect(
+      screen.queryByRole("button", { name: "Check the tunnel again" }),
+    ).toBeNull();
+    // A recorded URL is the pre-probe evidence of a tunnel, so no first-run
+    // notice even though the probe never reported one.
+    expect(screen.queryByText("Open a tunnel first")).toBeNull();
+
+    act(() => publish("app.resume", { signal: "visibility" }));
+    await waitFor(() =>
+      expect(
+        fetchLog.some((r) => r.url.endsWith("/v1/remote-web/pairing-requests")),
+      ).toBe(true),
+    );
+    expect(probeMock).not.toHaveBeenCalled();
+  });
+
+  test("keeps the field-derived first-run notice with nothing recorded", () => {
+    renderCard();
+
+    expect(screen.getByText("Open a tunnel first")).toBeTruthy();
+    expect(probeMock).not.toHaveBeenCalled();
   });
 });

--- a/clients/web/src/domains/settings/pair-device/pair-device-card.tsx
+++ b/clients/web/src/domains/settings/pair-device/pair-device-card.tsx
@@ -5,9 +5,12 @@ import { Input } from "@vellumai/design-library/components/input";
 import { Notice } from "@vellumai/design-library/components/notice";
 import { cn } from "@vellumai/design-library/utils/cn";
 
+import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
 import { DetailCard } from "@/components/detail-card";
+import { useBusSubscription } from "@/hooks/use-bus-subscription";
 import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
 import { Trans, useTranslation } from "@/i18n";
+import { useSupportsIngressStatus } from "@/lib/backwards-compat/ingress-status-gate";
 import { useSupportsRemoteWebPairing } from "@/lib/backwards-compat/remote-web-pairing-gate";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 
@@ -15,7 +18,9 @@ import { resolvePairDeviceTarget } from "./pair-device-client";
 import { PairDeviceReady } from "./pair-device-ready";
 import { PairedDevicesSection } from "./paired-devices-section";
 import { PendingPairingRequests } from "./pending-pairing-requests";
+import { statusPublicBaseUrl, TunnelStatusRow } from "./tunnel-status-row";
 import { usePairDevice } from "./use-pair-device";
+import { useTunnelStatus } from "./use-tunnel-status";
 
 /** Names a provider explicitly: the CLI's `vellum` default is not implemented. */
 const TUNNEL_COMMAND = "vellum tunnel --provider tailscale";
@@ -33,6 +38,13 @@ const CODE_CLASS =
  * hosts the approval list for pairing requests minted elsewhere
  * ({@link PendingPairingRequests}).
  *
+ * What the tunnel is doing comes from the daemon-side probe
+ * ({@link useTunnelStatus}), which drives the status row, the URL field's
+ * prefill and the first-run notice, and re-runs on the `app.resume` foreground
+ * edge. Against an assistant below {@link useSupportsIngressStatus}'s floor the
+ * probe never runs, so the card falls back to the assistant's recorded ingress
+ * URL and infers the empty state from the field.
+ *
  * Rendered only in desktop/local mode against an on-machine gateway (the gate
  * lives in {@link resolvePairDeviceTarget}) whose assistant version serves the
  * pairing routes ({@link useSupportsRemoteWebPairing}). The client-scoped
@@ -47,7 +59,24 @@ export function PairDeviceCard() {
   const supported = useSupportsRemoteWebPairing();
   const webRemoteIngressOn = useClientFeatureFlagStore.use.webRemoteIngress();
   const pairedDevicesUIOn = useClientFeatureFlagStore.use.pairedDevicesUI();
-  const pair = usePairDevice(target?.base ?? null, target?.ingressUrl ?? null);
+  const assistantId = useActiveAssistantId();
+  // Read alongside the probe so the card can tell "the daemon reports no
+  // tunnel" from "this assistant cannot be asked", which the status view
+  // spells the same way.
+  const probesTunnel = useSupportsIngressStatus(assistantId);
+  const surfaceEnabled = supported && webRemoteIngressOn;
+  const tunnel = useTunnelStatus(surfaceEnabled && target !== null);
+  // The user starts the tunnel in a terminal and tabs back, so the foreground
+  // edge is the re-check that matters most.
+  useBusSubscription("app.resume", () => {
+    tunnel.refresh();
+  });
+  const pair = usePairDevice(
+    target?.base ?? null,
+    probesTunnel
+      ? statusPublicBaseUrl(tunnel.status)
+      : (target?.ingressUrl ?? null),
+  );
   // Bumped when the pending-request flow pairs a device, so the device list
   // below refetches without waiting for a live-code poll.
   const [devicesRevalidateKey, setDevicesRevalidateKey] = useState(0);
@@ -55,7 +84,7 @@ export function PairDeviceCard() {
     errorMessage: t("pairDeviceCard.copyError"),
   });
 
-  if (!target || !supported || !webRemoteIngressOn) {
+  if (!target || !surfaceEnabled) {
     return null;
   }
 
@@ -65,10 +94,13 @@ export function PairDeviceCard() {
   const isMinting = phase.kind === "minting";
   const isReady = phase.kind === "ready";
   const prefilledFromTunnel = pair.prefillSource === "tunnel";
-  // Honest empty state: no recorded tunnel URL, no stored value, field still
-  // empty. Advanced users can still type an address into the field below.
-  const showNoTunnelGuidance =
-    pair.prefillSource === "none" && pair.publicBaseUrl.trim() === "";
+  // Honest empty state: the daemon's verdict where the probe runs, and where
+  // it cannot, the field-derived inference (no reported URL, no stored value,
+  // field still empty). Advanced users can still type an address into the
+  // field below either way.
+  const showNoTunnelGuidance = probesTunnel
+    ? tunnel.status.kind === "unconfigured"
+    : pair.prefillSource === "none" && pair.publicBaseUrl.trim() === "";
   const buttonLabel = isMinting
     ? t("pairDeviceCard.generateButtonMinting")
     : isReady
@@ -107,6 +139,11 @@ export function PairDeviceCard() {
             </div>
           </Notice>
         )}
+        <TunnelStatusRow
+          status={tunnel.status}
+          onRefresh={tunnel.refresh}
+          isRefreshing={tunnel.isRefreshing}
+        />
         <div className="flex flex-col gap-3">
           <Input
             label={t("pairDeviceCard.publicUrlLabel")}

--- a/clients/web/src/domains/settings/pair-device/pair-device-card.tsx
+++ b/clients/web/src/domains/settings/pair-device/pair-device-card.tsx
@@ -41,9 +41,10 @@ const CODE_CLASS =
  * What the tunnel is doing comes from the daemon-side probe
  * ({@link useTunnelStatus}), which drives the status row, the URL field's
  * prefill and the first-run notice, and re-runs on the `app.resume` foreground
- * edge. Against an assistant below {@link useSupportsIngressStatus}'s floor the
- * probe never runs, so the card falls back to the assistant's recorded ingress
- * URL and infers the empty state from the field.
+ * edge. Where that probe has no verdict, because the assistant sits below
+ * {@link useSupportsIngressStatus}'s floor or because the query gave up, the
+ * card falls back to the assistant's recorded ingress URL and infers the
+ * empty state from the field.
  *
  * Rendered only in desktop/local mode against an on-machine gateway (the gate
  * lives in {@link resolvePairDeviceTarget}) whose assistant version serves the
@@ -60,12 +61,13 @@ export function PairDeviceCard() {
   const webRemoteIngressOn = useClientFeatureFlagStore.use.webRemoteIngress();
   const pairedDevicesUIOn = useClientFeatureFlagStore.use.pairedDevicesUI();
   const assistantId = useActiveAssistantId();
-  // Read alongside the probe so the card can tell "the daemon reports no
-  // tunnel" from "this assistant cannot be asked", which the status view
-  // spells the same way.
   const probesTunnel = useSupportsIngressStatus(assistantId);
   const surfaceEnabled = supported && webRemoteIngressOn;
   const tunnel = useTunnelStatus(surfaceEnabled && target !== null);
+  // Whether the daemon's verdict is the card's source of truth right now. An
+  // assistant that cannot be asked, and a probe that came back with nothing,
+  // both leave the card on its pre-probe behavior below.
+  const probeAnswered = probesTunnel && tunnel.status.kind !== "unavailable";
   // The user starts the tunnel in a terminal and tabs back, so the foreground
   // edge is the re-check that matters most.
   useBusSubscription("app.resume", () => {
@@ -73,7 +75,7 @@ export function PairDeviceCard() {
   });
   const pair = usePairDevice(
     target?.base ?? null,
-    probesTunnel
+    probeAnswered
       ? statusPublicBaseUrl(tunnel.status)
       : (target?.ingressUrl ?? null),
   );
@@ -94,11 +96,11 @@ export function PairDeviceCard() {
   const isMinting = phase.kind === "minting";
   const isReady = phase.kind === "ready";
   const prefilledFromTunnel = pair.prefillSource === "tunnel";
-  // Honest empty state: the daemon's verdict where the probe runs, and where
-  // it cannot, the field-derived inference (no reported URL, no stored value,
-  // field still empty). Advanced users can still type an address into the
-  // field below either way.
-  const showNoTunnelGuidance = probesTunnel
+  // Honest empty state: the daemon's verdict where the probe answers, and
+  // where it does not, the field-derived inference (no reported URL, no
+  // stored value, field still empty). Advanced users can still type an
+  // address into the field below either way.
+  const showNoTunnelGuidance = probeAnswered
     ? tunnel.status.kind === "unconfigured"
     : pair.prefillSource === "none" && pair.publicBaseUrl.trim() === "";
   const buttonLabel = isMinting

--- a/clients/web/src/domains/settings/pair-device/tunnel-status-row.test.tsx
+++ b/clients/web/src/domains/settings/pair-device/tunnel-status-row.test.tsx
@@ -34,6 +34,11 @@ describe("TunnelStatusRow", () => {
     expect(result.container.innerHTML).toBe("");
   });
 
+  test("renders nothing when the probe has no verdict to report", () => {
+    const { result } = renderRow({ kind: "unavailable" });
+    expect(result.container.innerHTML).toBe("");
+  });
+
   test("names the probe in flight and disables the refresh", () => {
     renderRow({ kind: "checking" });
 

--- a/clients/web/src/domains/settings/pair-device/tunnel-status-row.tsx
+++ b/clients/web/src/domains/settings/pair-device/tunnel-status-row.tsx
@@ -25,6 +25,11 @@ export type TunnelStatusView =
 /** Every state the row actually draws; `unconfigured` renders nothing. */
 type RenderedTunnelStatus = Exclude<TunnelStatusView, { kind: "unconfigured" }>;
 
+/** The public address a status reports, or `null` in the states carrying none. */
+export function statusPublicBaseUrl(status: TunnelStatusView): string | null {
+  return "publicBaseUrl" in status ? status.publicBaseUrl : null;
+}
+
 interface TunnelStatusRowProps {
   status: TunnelStatusView;
   /** Re-runs the daemon-side probe. The row owns no fetching of its own. */
@@ -68,7 +73,7 @@ export function TunnelStatusRow({
 
   const busy = status.kind === "checking" || isRefreshing;
   const checkedAt = "checkedAt" in status ? status.checkedAt : null;
-  const publicBaseUrl = "publicBaseUrl" in status ? status.publicBaseUrl : null;
+  const publicBaseUrl = statusPublicBaseUrl(status);
 
   return (
     <div className="flex items-start gap-2.5 rounded-lg border border-[var(--border-element)] px-3 py-2.5">

--- a/clients/web/src/domains/settings/pair-device/tunnel-status-row.tsx
+++ b/clients/web/src/domains/settings/pair-device/tunnel-status-row.tsx
@@ -12,6 +12,8 @@ import { formatRelativeTime } from "@/lib/relative-time";
 export type TunnelStatusView =
   | { kind: "checking" }
   | { kind: "unconfigured" }
+  /** No verdict to report: the probe never ran, or it gave up. */
+  | { kind: "unavailable" }
   | { kind: "stopped"; provider: string; publicBaseUrl: string }
   | { kind: "healthy"; publicBaseUrl: string; checkedAt: string }
   | { kind: "unreachable"; publicBaseUrl: string; checkedAt: string }
@@ -22,8 +24,11 @@ export type TunnelStatusView =
       servingAssistantName?: string;
     };
 
-/** Every state the row actually draws; `unconfigured` renders nothing. */
-type RenderedTunnelStatus = Exclude<TunnelStatusView, { kind: "unconfigured" }>;
+/** Every state the row actually draws; the card covers the other two itself. */
+type RenderedTunnelStatus = Exclude<
+  TunnelStatusView,
+  { kind: "unconfigured" | "unavailable" }
+>;
 
 /** The public address a status reports, or `null` in the states carrying none. */
 export function statusPublicBaseUrl(status: TunnelStatusView): string | null {
@@ -57,8 +62,8 @@ function restartCommand(provider: string): string {
  *
  * Pure by design: props in, markup out. Fetching, the `app.resume` re-check
  * and any polling belong to the card above it, per `docs/EVENT_BUS.md`.
- * Renders nothing for `unconfigured`, which the card covers with its
- * first-run notice.
+ * Renders nothing for `unconfigured` or `unavailable`: with no tunnel and
+ * with no verdict there is nothing to report, and the card speaks instead.
  */
 export function TunnelStatusRow({
   status,
@@ -67,7 +72,7 @@ export function TunnelStatusRow({
 }: TunnelStatusRowProps) {
   const { t } = useTranslation("settings");
 
-  if (status.kind === "unconfigured") {
+  if (status.kind === "unconfigured" || status.kind === "unavailable") {
     return null;
   }
 

--- a/clients/web/src/domains/settings/pair-device/use-pair-device.ts
+++ b/clients/web/src/domains/settings/pair-device/use-pair-device.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { t } from "@/i18n";
 import { captureError } from "@/lib/sentry/capture-error";
@@ -21,15 +21,15 @@ const PUBLIC_BASE_URL_STORAGE_KEY = "vellum:pair-device:public-base-url";
 export type PairDevicePrefillSource = "tunnel" | "stored" | "none";
 
 /**
- * Resolve the URL field's initial value and its provenance. Priority: the
- * assistant's `vellum tunnel`-recorded ingress URL, then the last URL that
- * successfully minted a code, then empty.
+ * Resolve the URL field's prefill and its provenance. Priority: the public
+ * address the daemon reports for this assistant's tunnel, then the last URL
+ * that successfully minted a code, then empty.
  */
-function resolvePrefill(recordedIngressUrl: string | null): {
+function resolvePrefill(tunnelPublicBaseUrl: string | null): {
   url: string;
   source: PairDevicePrefillSource;
 } {
-  const tunnel = recordedIngressUrl?.trim();
+  const tunnel = tunnelPublicBaseUrl?.trim();
   if (tunnel) {
     return { url: tunnel, source: "tunnel" };
   }
@@ -50,7 +50,7 @@ export interface PairDeviceController {
   /** The public URL to advertise, editable and prefilled from the tunnel/last success. */
   publicBaseUrl: string;
   setPublicBaseUrl: (value: string) => void;
-  /** Where {@link publicBaseUrl}'s initial value came from. */
+  /** Where the field's prefilled value came from. */
   prefillSource: PairDevicePrefillSource;
   /** Client-side validation message for the URL field, or `null`. */
   inputError: string | null;
@@ -68,15 +68,21 @@ export interface PairDeviceController {
  * request against the host's loopback gateway, and a 1s expiry countdown while a
  * code is live. `base` is the resolved local-gateway base URL, or `null` when
  * pairing isn't available from here (the hook then no-ops).
- * `recordedIngressUrl` is the assistant's `vellum tunnel`-recorded public URL,
- * used to prefill the field.
+ * `tunnelPublicBaseUrl` is the public address reported for this assistant's
+ * tunnel, used to prefill the field.
  */
 export function usePairDevice(
   base: string | null,
-  recordedIngressUrl: string | null,
+  tunnelPublicBaseUrl: string | null,
 ): PairDeviceController {
-  const [prefill] = useState(() => resolvePrefill(recordedIngressUrl));
-  const [publicBaseUrl, setPublicBaseUrlState] = useState(prefill.url);
+  const prefill = useMemo(
+    () => resolvePrefill(tunnelPublicBaseUrl),
+    [tunnelPublicBaseUrl],
+  );
+  // The reported address arrives after the first render, so the field tracks
+  // the prefill until the user types; from then on their value is what shows.
+  const [editedUrl, setEditedUrl] = useState<string | null>(null);
+  const publicBaseUrl = editedUrl ?? prefill.url;
   const [inputError, setInputError] = useState<string | null>(null);
   const [phase, setPhase] = useState<PairDevicePhase>({ kind: "idle" });
   const [nowMs, setNowMs] = useState(() => Date.now());
@@ -99,7 +105,7 @@ export function usePairDevice(
   }, [phase]);
 
   const setPublicBaseUrl = useCallback((value: string) => {
-    setPublicBaseUrlState(value);
+    setEditedUrl(value);
     setInputError(null);
   }, []);
 

--- a/clients/web/src/domains/settings/pair-device/use-tunnel-status.test.ts
+++ b/clients/web/src/domains/settings/pair-device/use-tunnel-status.test.ts
@@ -28,11 +28,23 @@ mock.module("@/hooks/use-is-org-ready", () => ({
   useIsOrgReady: () => orgReady,
 }));
 
-const probeMock = mock(async () => ({
-  data: { state: "healthy", publicBaseUrl: PUBLIC_URL, checkedAt: CHECKED_AT },
-  error: undefined,
-  response: new Response(null, { status: 200 }),
-}));
+/** Set by a test to make the probe fail the way a dead daemon would. */
+let probeFailure: Error | null = null;
+
+const probeMock = mock(async () => {
+  if (probeFailure) {
+    throw probeFailure;
+  }
+  return {
+    data: {
+      state: "healthy",
+      publicBaseUrl: PUBLIC_URL,
+      checkedAt: CHECKED_AT,
+    },
+    error: undefined,
+    response: new Response(null, { status: 200 }),
+  };
+});
 
 /* Spread over the real module rather than replacing it: the generated SDK is a
    single barrel that the query-options barrel also pulls from, and a bare
@@ -73,6 +85,7 @@ async function settle() {
 
 beforeEach(() => {
   orgReady = true;
+  probeFailure = null;
   probeMock.mockClear();
   useResolvedAssistantsStore.getState().setActiveAssistantId(ASSISTANT_ID);
   useAssistantIdentityStore
@@ -91,8 +104,10 @@ describe("toStatusView", () => {
     expect(toStatusView(undefined, true)).toEqual({ kind: "checking" });
   });
 
-  test("reports unconfigured with no answer and nothing in flight", () => {
-    expect(toStatusView(undefined, false)).toEqual({ kind: "unconfigured" });
+  // Only the daemon says "no tunnel"; an answer the card never got is a
+  // different thing, and the card restores its pre-probe fallbacks for it.
+  test("reports unavailable with no answer and nothing in flight", () => {
+    expect(toStatusView(undefined, false)).toEqual({ kind: "unavailable" });
   });
 
   test("maps unconfigured", () => {
@@ -117,11 +132,12 @@ describe("toStatusView", () => {
     });
   });
 
-  test("degrades a stopped verdict with no record to unconfigured", () => {
+  test("degrades a stopped verdict with no record to unavailable", () => {
     // A stopped row exists to name the command that restarts the tunnel; with
-    // no provider there is nothing to tell the user, so draw nothing.
+    // no provider there is nothing to tell the user, and nothing usable came
+    // back either, so the card keeps its own fallbacks.
     expect(toStatusView({ state: "stopped" }, false)).toEqual({
-      kind: "unconfigured",
+      kind: "unavailable",
     });
   });
 
@@ -205,7 +221,7 @@ describe("useTunnelStatus", () => {
     const { result, client } = renderStatus();
 
     expect(probeFetchStatus(client)).toBe("idle");
-    expect(result.current.status).toEqual({ kind: "unconfigured" });
+    expect(result.current.status).toEqual({ kind: "unavailable" });
     expect(result.current.isRefreshing).toBe(false);
   });
 
@@ -241,6 +257,16 @@ describe("useTunnelStatus", () => {
     expect(probeFetchStatus(client)).toBe("fetching");
     expect(result.current.status).toEqual({ kind: "checking" });
     expect(result.current.isRefreshing).toBe(true);
+  });
+
+  test("reports unavailable once the probe gives up", async () => {
+    probeFailure = new Error("connection refused");
+    const { result } = renderStatus();
+
+    await waitFor(() =>
+      expect(result.current.status).toEqual({ kind: "unavailable" }),
+    );
+    expect(result.current.isRefreshing).toBe(false);
   });
 });
 

--- a/clients/web/src/domains/settings/pair-device/use-tunnel-status.ts
+++ b/clients/web/src/domains/settings/pair-device/use-tunnel-status.ts
@@ -72,16 +72,19 @@ export function useTunnelStatus(enabled: boolean): TunnelStatusController {
  * state) while the view is a union, so this narrows on `state` and drops the
  * fields that state does not populate.
  *
- * Degrades to `unconfigured` (which the row draws as nothing) whenever the
- * response cannot support a row: no answer yet with nothing in flight, or a
- * `stopped` verdict whose `lastTunnel` record is missing.
+ * Only the daemon's own verdict becomes `unconfigured`. Everything the probe
+ * cannot answer degrades to `unavailable` instead: no response with nothing
+ * in flight (the probe is gated off, or the query exhausted its retries), or
+ * a `stopped` verdict whose `lastTunnel` record is missing. The row draws
+ * both as nothing, but the card reads `unavailable` as "the probe told us
+ * nothing" and keeps its pre-probe fallbacks.
  */
 export function toStatusView(
   response: IntegrationsIngressStatusGetResponse | undefined,
   isFetching: boolean,
 ): TunnelStatusView {
   if (!response) {
-    return isFetching ? { kind: "checking" } : { kind: "unconfigured" };
+    return isFetching ? { kind: "checking" } : { kind: "unavailable" };
   }
 
   // Both are set by the daemon for every probed state; the wire marks them
@@ -99,7 +102,7 @@ export function toStatusView(
             provider: response.lastTunnel.provider,
             publicBaseUrl: response.lastTunnel.publicBaseUrl,
           }
-        : { kind: "unconfigured" };
+        : { kind: "unavailable" };
     case "healthy":
       return { kind: "healthy", publicBaseUrl, checkedAt };
     case "unreachable":


### PR DESCRIPTION
## Summary

- The Pair-a-device card now reads the daemon-side tunnel probe: it renders the status row above the URL field, re-checks on the `app.resume` foreground edge (bus, no per-component visibility listener), and shows the first-run "Open a tunnel first" notice only when the daemon actually reports `unconfigured`.
- The URL field prefills from the daemon-reported public address instead of the platform's `ingress_url` (refreshed only on `vellum login`), still falling back to the last URL that minted a code. The field follows that prefill until the user types.
- Below the ingress-status version floor the probe never runs, so the card reads the gate directly and keeps today's behavior end to end: recorded ingress URL for the prefill, field-derived empty state, no status row, no probe.

Part of plan: tunnel-status-pairing.md (PR 8 of 9)