### PR TITLE
feat(gateway): expose GET /v1/velay/status HTTP route

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -25071,30 +25071,6 @@ paths:
                 required:
                   - processes
                 additionalProperties: false
-  /v1/velay/status:
-    get:
-      operationId: velay_status_get
-      summary: Velay tunnel status
-      description: "Returns the current state of the Velay tunnel connection: whether it is connected and its public URL when available. Returns { connected: false, publicUrl: null } when Velay is not configured."
-      tags:
-        - system
-      responses:
-        "200":
-          description: Successful response
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  connected:
-                    type: boolean
-                  publicUrl:
-                    type: string
-                    nullable: true
-                required:
-                  - connected
-                  - publicUrl
-                additionalProperties: false
   /v1/question-response:
     post:
       operationId: questionresponse_post

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -25071,6 +25071,30 @@ paths:
                 required:
                   - processes
                 additionalProperties: false
+  /v1/velay/status:
+    get:
+      operationId: velay_status_get
+      summary: Velay tunnel status
+      description: "Returns the current state of the Velay tunnel connection: whether it is connected and its public URL when available. Returns { connected: false, publicUrl: null } when Velay is not configured."
+      tags:
+        - system
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  connected:
+                    type: boolean
+                  publicUrl:
+                    type: string
+                    nullable: true
+                required:
+                  - connected
+                  - publicUrl
+                additionalProperties: false
   /v1/question-response:
     post:
       operationId: questionresponse_post

--- a/gateway/src/http/routes/velay-status.ts
+++ b/gateway/src/http/routes/velay-status.ts
@@ -1,0 +1,29 @@
+/**
+ * Velay tunnel status endpoint (GET /v1/velay/status).
+ *
+ * Exposes the in-process VelayTunnelClient state over HTTP so web clients
+ * and the CLI can query tunnel connectivity without a custom IPC call.
+ * Returns { connected: false, publicUrl: null } when Velay is not configured
+ * (VELAY_BASE_URL not set).
+ */
+
+import type { VelayTunnelClient } from "../../velay/client.js";
+
+export interface VelayStatusResponse {
+  connected: boolean;
+  publicUrl: string | null;
+}
+
+export function createVelayStatusHandler(
+  velayTunnelClient: VelayTunnelClient | undefined,
+) {
+  function handleVelayStatus(): Response {
+    const status: VelayStatusResponse = velayTunnelClient?.getStatus() ?? {
+      connected: false,
+      publicUrl: null,
+    };
+    return Response.json(status);
+  }
+
+  return { handleVelayStatus };
+}

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -109,6 +109,7 @@ import { createOAuthAppsProxyHandler } from "./http/routes/oauth-apps-proxy.js";
 import { createOAuthProvidersProxyHandler } from "./http/routes/oauth-providers-proxy.js";
 import { createChannelReadinessProxyHandler } from "./http/routes/channel-readiness-proxy.js";
 import { createPsHandler } from "./http/routes/ps.js";
+import { createVelayStatusHandler } from "./http/routes/velay-status.js";
 import { createRuntimeHealthProxyHandler } from "./http/routes/runtime-health-proxy.js";
 import { createUpgradeBroadcastProxyHandler } from "./http/routes/upgrade-broadcast-proxy.js";
 import {
@@ -593,6 +594,7 @@ async function main() {
   const oauthProvidersProxy = createOAuthProvidersProxyHandler(config);
   const channelReadinessProxy = createChannelReadinessProxyHandler(config);
   const psHandler = createPsHandler(config);
+  const velayStatusHandler = createVelayStatusHandler(velayTunnelClient);
   const runtimeHealthProxy = createRuntimeHealthProxyHandler(config);
   const upgradeBroadcastProxy = createUpgradeBroadcastProxyHandler(config);
   const migrationExportProxy = createMigrationExportProxyHandler(config);
@@ -798,6 +800,14 @@ async function main() {
       method: "GET",
       auth: "edge",
       handler: () => psHandler.handlePs(),
+    },
+
+    // ── Velay tunnel status ──
+    {
+      path: "/v1/velay/status",
+      method: "GET",
+      auth: "edge",
+      handler: () => velayStatusHandler.handleVelayStatus(),
     },
 
     // ── Brain graph ──

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -809,6 +809,15 @@ async function main() {
       auth: "edge",
       handler: () => velayStatusHandler.handleVelayStatus(),
     },
+    // Assistant-scoped mirror: self-hosted clients emit /v1/assistants/<id>/velay/status
+    // and rewriteForSelfHostedIngress preserves that path, so a flat-only route
+    // would fall through to the runtime proxy and 404. The assistant id is discarded.
+    {
+      path: /^\/v1\/assistants\/[^/]+\/velay\/status\/?$/,
+      method: "GET",
+      auth: "edge-scoped",
+      handler: () => velayStatusHandler.handleVelayStatus(),
+    },
 
     // ── Brain graph ──
     {

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -190,6 +190,36 @@ export function buildSchema(): Record<string, unknown> {
           },
         },
       },
+      "/v1/velay/status": {
+        get: {
+          summary: "Velay tunnel status",
+          description:
+            "Returns the current state of the Velay tunnel connection: whether it is connected and its public URL when available. Returns { connected: false, publicUrl: null } when Velay is not configured (VELAY_BASE_URL not set).",
+          operationId: "velayStatus",
+          security: [{ BearerAuth: [] }],
+          responses: {
+            "200": {
+              description: "Velay tunnel status returned",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      connected: { type: "boolean" },
+                      publicUrl: { type: "string", nullable: true },
+                    },
+                    required: ["connected", "publicUrl"],
+                    additionalProperties: false,
+                  },
+                },
+              },
+            },
+            "401": {
+              description: "Unauthorized — missing or invalid bearer token",
+            },
+          },
+        },
+      },
       "/v1/brain-graph": {
         get: {
           summary: "Brain graph data",


### PR DESCRIPTION
The get_velay_status IPC handler already returned tunnel connectivity state but had no HTTP surface, leaving web clients and the CLI unable to query tunnel status without a custom IPC call.

Adds gateway/src/http/routes/velay-status.ts with createVelayStatusHandler, wires it at GET /v1/velay/status (auth: "edge") following the same pattern as /v1/ps, and documents the endpoint in openapi.yaml. Returns { connected: false, publicUrl: null } when Velay is not configured.

<!-- PR title format: type(scope): description -->
<!-- Examples: feat(slack): add user token support, fix(cli): handle missing config, docs(architecture): update API table -->

## Prompt / plan
<!-- What prompt or plan was used to generate this code? Link to a plan file, paste the prompt, or describe the approach. -->

## Test plan
<!-- How was this change verified? e.g. unit tests, manual testing, CI checks -->

## CLI verb checklist
<!-- For PRs that add a new IPC route under assistant/src/runtime/routes/: -->
<!-- - [ ] Does this route need an `assistant` CLI verb? If yes, add a thin -->
<!--       wrapper in assistant/src/cli/commands/ via registerCommand (same -->
<!--       PR or a follow-up). -->
<!-- - [ ] If no, leave a one-line note explaining why (e.g. internal-only, -->
<!--       composed by another command). -->
<!-- Delete this section if your PR does not add any new routes. -->
