### PR TITLE
fix(cli): restore large local .vbundle backups via staged path

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -21083,8 +21083,9 @@ paths:
       summary: Import a .vbundle archive
       description:
         Commit a .vbundle archive import to disk — destructive. Accepts the bundle as raw bytes
-        (application/octet-stream), multipart/form-data, or a JSON body with `{ url }` carrying a signed URL the daemon
-        fetches.
+        (application/octet-stream), multipart/form-data, a JSON body with `{ url }` carrying a signed URL the daemon
+        fetches, or a JSON body with `{ path }` pointing at a file staged under the workspace `.restore-staging`
+        directory.
       tags:
         - migrations
       requestBody:
@@ -21095,11 +21096,13 @@ paths:
               type: object
               properties:
                 url:
+                  description: A signed GCS URL pointing to the .vbundle archive (JSON body path only).
                   type: string
                   format: uri
-                  description: A signed GCS URL pointing to the .vbundle archive (JSON body path only).
-              required:
-                - url
+                path:
+                  description: Workspace-relative or absolute path to a staged .vbundle under .restore-staging (JSON body path only).
+                  type: string
+                  minLength: 1
       responses:
         "200":
           description: Successful response
@@ -21182,9 +21185,23 @@ paths:
     post:
       operationId: migrations_importpreflight_post
       summary: Dry-run import analysis
-      description: Validate a .vbundle archive and return a report of what would change on import without modifying data.
+      description:
+        Validate a .vbundle archive and return a report of what would change on import without modifying data.
+        Accepts raw bytes, multipart form data, or JSON `{ path }` pointing at a file staged under the workspace
+        `.restore-staging` directory.
       tags:
         - migrations
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                path:
+                  description: Workspace-relative or absolute path to a staged .vbundle under .restore-staging (JSON body path only).
+                  type: string
+                  minLength: 1
       responses:
         "200":
           description: Successful response

--- a/assistant/src/__tests__/migration-import-from-path.test.ts
+++ b/assistant/src/__tests__/migration-import-from-path.test.ts
@@ -1,0 +1,349 @@
+/**
+ * HTTP tests for JSON `{ path }` on POST /v1/migrations/import and
+ * POST /v1/migrations/import-preflight.
+ *
+ * The daemon only opens a regular `.vbundle` that realpath-resolves
+ * under `${workspace}/.restore-staging/`.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+
+mock.module("../permissions/trust-store.js", () => ({
+  getAllRules: () => [],
+  isStarterBundleAccepted: () => false,
+  clearCache: () => {},
+}));
+
+mock.module("../config/env.js", () => ({
+  isHttpAuthDisabled: () => true,
+  hasUngatedHttpAuthDisabled: () => false,
+  getGatewayInternalBaseUrl: () => "http://127.0.0.1:7830",
+  getGatewayPort: () => 7830,
+  getRuntimeHttpPort: () => 7821,
+  getRuntimeHttpHost: () => "127.0.0.1",
+  getRuntimeGatewayOriginSecret: () => undefined,
+  getIngressPublicBaseUrl: () => undefined,
+  setIngressPublicBaseUrl: () => {},
+}));
+
+import { defaultV1Options } from "../runtime/migrations/__tests__/v1-test-helpers.js";
+import { RESTORE_STAGING_DIRNAME } from "../runtime/migrations/staged-import-path.js";
+import { buildVBundle } from "../runtime/migrations/vbundle-builder.js";
+import {
+  handleMigrationImport,
+  handleMigrationImportPreflight,
+} from "../runtime/routes/migration-routes.js";
+import { callHandler } from "./helpers/call-route-handler.js";
+
+const originalWorkspaceDir = process.env.VELLUM_WORKSPACE_DIR;
+
+function freshWorkspaceRoot(): string {
+  const parent = realpathSync(
+    mkdtempSync(join(tmpdir(), "migration-import-from-path-")),
+  );
+  const workspaceDir = join(parent, "workspace");
+  mkdirSync(workspaceDir, { recursive: true });
+  return workspaceDir;
+}
+
+function setWorkspaceDir(dir: string): void {
+  process.env.VELLUM_WORKSPACE_DIR = dir;
+}
+
+function makeSmallValidBundle(): Uint8Array {
+  const { archive } = buildVBundle({
+    files: [
+      {
+        path: "workspace/data/db/assistant.db",
+        data: new TextEncoder().encode("SQLite format 3\0"),
+      },
+      {
+        path: "workspace/config.json",
+        data: new TextEncoder().encode(
+          JSON.stringify({ provider: "anthropic", model: "test-model" }),
+        ),
+      },
+    ],
+    ...defaultV1Options(),
+  });
+  return archive;
+}
+
+function stageBundle(workspaceDir: string, archive: Uint8Array): string {
+  const staging = join(workspaceDir, RESTORE_STAGING_DIRNAME);
+  mkdirSync(staging, { recursive: true });
+  const filename = "backup.vbundle";
+  writeFileSync(join(staging, filename), archive);
+  return `${RESTORE_STAGING_DIRNAME}/${filename}`;
+}
+
+interface ImportCommitResponse {
+  success: boolean;
+  summary: {
+    total_files: number;
+    files_created: number;
+    files_overwritten: number;
+    files_skipped: number;
+    backups_created: number;
+  };
+  files: Array<{ path: string }>;
+  manifest: Record<string, unknown>;
+}
+
+interface PreflightResponse {
+  can_import: boolean;
+  summary?: {
+    files_to_create: number;
+    files_to_overwrite: number;
+    files_unchanged: number;
+    total_files: number;
+  };
+  validation?: { is_valid: false; errors: Array<{ code: string }> };
+}
+
+interface BadRequestResponse {
+  error: { code: string; message: string };
+}
+
+let testWorkspaceRoot: string;
+let testParent: string;
+
+beforeEach(() => {
+  testWorkspaceRoot = freshWorkspaceRoot();
+  testParent = join(testWorkspaceRoot, "..");
+  setWorkspaceDir(testWorkspaceRoot);
+});
+
+afterEach(() => {
+  try {
+    rmSync(testParent, { recursive: true, force: true });
+  } catch {
+    /* best effort */
+  }
+});
+
+afterAll(() => {
+  if (originalWorkspaceDir !== undefined) {
+    process.env.VELLUM_WORKSPACE_DIR = originalWorkspaceDir;
+  } else {
+    delete process.env.VELLUM_WORKSPACE_DIR;
+  }
+});
+
+describe("handleMigrationImport — JSON {path} body", () => {
+  test("happy path: streams a staged .vbundle and imports it", async () => {
+    const relativePath = stageBundle(
+      testWorkspaceRoot,
+      makeSmallValidBundle(),
+    );
+
+    const req = new Request("http://localhost/v1/migrations/import", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ path: relativePath }),
+    });
+
+    const res = await callHandler(handleMigrationImport, req);
+    const body = (await res.json()) as ImportCommitResponse;
+
+    expect(res.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(body.summary.total_files).toBeGreaterThan(0);
+    expect(body.files.length).toBeGreaterThan(0);
+    expect(existsSync(join(testWorkspaceRoot, "data", "db", "assistant.db"))).toBe(
+      true,
+    );
+    expect(existsSync(join(testWorkspaceRoot, "config.json"))).toBe(true);
+  });
+
+  test("absolute path inside staging is accepted", async () => {
+    const relativePath = stageBundle(
+      testWorkspaceRoot,
+      makeSmallValidBundle(),
+    );
+    const absolutePath = join(testWorkspaceRoot, relativePath);
+
+    const req = new Request("http://localhost/v1/migrations/import", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ path: absolutePath }),
+    });
+
+    const res = await callHandler(handleMigrationImport, req);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as ImportCommitResponse;
+    expect(body.success).toBe(true);
+  });
+
+  test("both url and path returns 400", async () => {
+    const req = new Request("http://localhost/v1/migrations/import", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        url: "https://storage.googleapis.com/b/o?X-Goog-Signature=x",
+        path: `${RESTORE_STAGING_DIRNAME}/backup.vbundle`,
+      }),
+    });
+
+    const res = await callHandler(handleMigrationImport, req);
+    const body = (await res.json()) as BadRequestResponse;
+
+    expect(res.status).toBe(400);
+    expect(body.error.code).toBe("BAD_REQUEST");
+    expect(body.error.message).toContain("exactly one");
+  });
+
+  test("missing staged file returns 400", async () => {
+    const req = new Request("http://localhost/v1/migrations/import", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        path: `${RESTORE_STAGING_DIRNAME}/missing.vbundle`,
+      }),
+    });
+
+    const res = await callHandler(handleMigrationImport, req);
+    const body = (await res.json()) as BadRequestResponse;
+
+    expect(res.status).toBe(400);
+    expect(body.error.code).toBe("BAD_REQUEST");
+    expect(body.error.message.toLowerCase()).toContain("not found");
+  });
+
+  test("traversal out of staging returns 400", async () => {
+    writeFileSync(join(testWorkspaceRoot, "secret.vbundle"), "nope");
+
+    const req = new Request("http://localhost/v1/migrations/import", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        path: `${RESTORE_STAGING_DIRNAME}/../secret.vbundle`,
+      }),
+    });
+
+    const res = await callHandler(handleMigrationImport, req);
+    const body = (await res.json()) as BadRequestResponse;
+
+    expect(res.status).toBe(400);
+    expect(body.error.code).toBe("BAD_REQUEST");
+    expect(body.error.message.toLowerCase()).toContain("staging");
+  });
+
+  test("path outside the workspace returns 400", async () => {
+    const outside = join(testParent, "outside.vbundle");
+    writeFileSync(outside, "nope");
+
+    const req = new Request("http://localhost/v1/migrations/import", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ path: outside }),
+    });
+
+    const res = await callHandler(handleMigrationImport, req);
+    const body = (await res.json()) as BadRequestResponse;
+
+    expect(res.status).toBe(400);
+    expect(body.error.code).toBe("BAD_REQUEST");
+    expect(body.error.message.toLowerCase()).toContain("staging");
+  });
+
+  test("symlink in staging returns 400", async () => {
+    const relativePath = stageBundle(
+      testWorkspaceRoot,
+      makeSmallValidBundle(),
+    );
+    const target = join(testWorkspaceRoot, relativePath);
+    const link = join(testWorkspaceRoot, RESTORE_STAGING_DIRNAME, "alias.vbundle");
+    symlinkSync(target, link);
+
+    const req = new Request("http://localhost/v1/migrations/import", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        path: `${RESTORE_STAGING_DIRNAME}/alias.vbundle`,
+      }),
+    });
+
+    const res = await callHandler(handleMigrationImport, req);
+    const body = (await res.json()) as BadRequestResponse;
+
+    expect(res.status).toBe(400);
+    expect(body.error.code).toBe("BAD_REQUEST");
+    expect(body.error.message.toLowerCase()).toContain("symlink");
+  });
+});
+
+describe("handleMigrationImportPreflight — JSON {path} body", () => {
+  test("happy path: analyzes a staged .vbundle without writing files", async () => {
+    const relativePath = stageBundle(
+      testWorkspaceRoot,
+      makeSmallValidBundle(),
+    );
+
+    const req = new Request("http://localhost/v1/migrations/import-preflight", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ path: relativePath }),
+    });
+
+    const res = await callHandler(handleMigrationImportPreflight, req);
+    const body = (await res.json()) as PreflightResponse;
+
+    expect(res.status).toBe(200);
+    expect(body.can_import).toBe(true);
+    expect(body.summary?.total_files).toBeGreaterThan(0);
+    expect(existsSync(join(testWorkspaceRoot, "config.json"))).toBe(false);
+  });
+
+  test("empty path returns 400", async () => {
+    const req = new Request("http://localhost/v1/migrations/import-preflight", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ path: "" }),
+    });
+
+    const res = await callHandler(handleMigrationImportPreflight, req);
+    const body = (await res.json()) as BadRequestResponse;
+
+    expect(res.status).toBe(400);
+    expect(body.error.code).toBe("BAD_REQUEST");
+  });
+
+  test("non-.vbundle staging file returns 400", async () => {
+    const staging = join(testWorkspaceRoot, RESTORE_STAGING_DIRNAME);
+    mkdirSync(staging, { recursive: true });
+    writeFileSync(join(staging, "notes.txt"), "nope");
+
+    const req = new Request("http://localhost/v1/migrations/import-preflight", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ path: `${RESTORE_STAGING_DIRNAME}/notes.txt` }),
+    });
+
+    const res = await callHandler(handleMigrationImportPreflight, req);
+    const body = (await res.json()) as BadRequestResponse;
+
+    expect(res.status).toBe(400);
+    expect(body.error.code).toBe("BAD_REQUEST");
+    expect(body.error.message.toLowerCase()).toContain(".vbundle");
+  });
+});

--- a/assistant/src/runtime/migrations/__tests__/staged-import-path.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/staged-import-path.test.ts
@@ -10,8 +10,8 @@ import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
 
 import {
-  RESTORE_STAGING_DIRNAME,
   resolveStagedImportPath,
+  RESTORE_STAGING_DIRNAME,
   StagedImportPathError,
 } from "../staged-import-path.js";
 

--- a/assistant/src/runtime/migrations/__tests__/staged-import-path.test.ts
+++ b/assistant/src/runtime/migrations/__tests__/staged-import-path.test.ts
@@ -1,0 +1,104 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+
+import {
+  RESTORE_STAGING_DIRNAME,
+  resolveStagedImportPath,
+  StagedImportPathError,
+} from "../staged-import-path.js";
+
+function stagingWorkspace(): { workspace: string; staging: string } {
+  const workspace = realpathSync(mkdtempSync(join(tmpdir(), "staged-import-")));
+  const staging = join(workspace, RESTORE_STAGING_DIRNAME);
+  mkdirSync(staging, { recursive: true });
+  return { workspace, staging };
+}
+
+describe("resolveStagedImportPath", () => {
+  test("resolves a relative path inside the staging directory", () => {
+    const { workspace, staging } = stagingWorkspace();
+    const file = join(staging, "backup.vbundle");
+    writeFileSync(file, "bundle");
+
+    expect(
+      resolveStagedImportPath(`${RESTORE_STAGING_DIRNAME}/backup.vbundle`, workspace),
+    ).toBe(realpathSync(file));
+  });
+
+  test("resolves an absolute path inside the staging directory", () => {
+    const { workspace, staging } = stagingWorkspace();
+    const file = join(staging, "backup.vbundle");
+    writeFileSync(file, "bundle");
+
+    expect(resolveStagedImportPath(file, workspace)).toBe(realpathSync(file));
+  });
+
+  test("rejects a missing file", () => {
+    const { workspace } = stagingWorkspace();
+    expect(() =>
+      resolveStagedImportPath(
+        `${RESTORE_STAGING_DIRNAME}/missing.vbundle`,
+        workspace,
+      ),
+    ).toThrow(StagedImportPathError);
+  });
+
+  test("rejects traversal out of the staging directory", () => {
+    const { workspace } = stagingWorkspace();
+    writeFileSync(join(workspace, "secret.vbundle"), "nope");
+
+    expect(() =>
+      resolveStagedImportPath(
+        `${RESTORE_STAGING_DIRNAME}/../secret.vbundle`,
+        workspace,
+      ),
+    ).toThrow(StagedImportPathError);
+  });
+
+  test("rejects a path outside the workspace", () => {
+    const { workspace } = stagingWorkspace();
+    const outside = join(tmpdir(), `outside-${Date.now()}.vbundle`);
+    writeFileSync(outside, "nope");
+
+    expect(() => resolveStagedImportPath(outside, workspace)).toThrow(
+      StagedImportPathError,
+    );
+  });
+
+  test("rejects a symlink even when it points at a staging file", () => {
+    const { workspace, staging } = stagingWorkspace();
+    const file = join(staging, "backup.vbundle");
+    writeFileSync(file, "bundle");
+    const link = join(staging, "alias.vbundle");
+    symlinkSync(file, link);
+
+    expect(() => resolveStagedImportPath(link, workspace)).toThrow(
+      StagedImportPathError,
+    );
+  });
+
+  test("rejects a non-.vbundle file in staging", () => {
+    const { workspace, staging } = stagingWorkspace();
+    const file = join(staging, "notes.txt");
+    writeFileSync(file, "nope");
+
+    expect(() =>
+      resolveStagedImportPath(`${RESTORE_STAGING_DIRNAME}/notes.txt`, workspace),
+    ).toThrow(StagedImportPathError);
+  });
+
+  test("rejects an empty path", () => {
+    const { workspace } = stagingWorkspace();
+    expect(() => resolveStagedImportPath("   ", workspace)).toThrow(
+      StagedImportPathError,
+    );
+  });
+});

--- a/assistant/src/runtime/migrations/staged-import-path.ts
+++ b/assistant/src/runtime/migrations/staged-import-path.ts
@@ -1,0 +1,116 @@
+/**
+ * Resolve a caller-supplied staged-bundle path for local restore.
+ *
+ * The daemon only opens files that realpath into
+ * `${workspaceDir}/.restore-staging/`. Absolute host paths, `..`
+ * traversal, and symlink escapes are rejected.
+ */
+
+import { existsSync, lstatSync, realpathSync, statSync } from "node:fs";
+import { relative, resolve, sep } from "node:path";
+
+export const RESTORE_STAGING_DIRNAME = ".restore-staging";
+
+export type StagedImportPathErrorCode =
+  | "empty"
+  | "not_found"
+  | "not_file"
+  | "symlink"
+  | "outside"
+  | "extension";
+
+export class StagedImportPathError extends Error {
+  public readonly code: StagedImportPathErrorCode;
+
+  constructor(code: StagedImportPathErrorCode, message: string) {
+    super(message);
+    this.name = "StagedImportPathError";
+    this.code = code;
+  }
+}
+
+/**
+ * Resolve `requestedPath` to a regular `.vbundle` file inside the
+ * workspace restore-staging directory.
+ */
+export function resolveStagedImportPath(
+  requestedPath: string,
+  workspaceDir: string,
+): string {
+  if (typeof requestedPath !== "string" || requestedPath.trim().length === 0) {
+    throw new StagedImportPathError("empty", "Staged bundle path is empty");
+  }
+  if (requestedPath.includes("\0")) {
+    throw new StagedImportPathError(
+      "empty",
+      "Staged bundle path is not a valid file path",
+    );
+  }
+
+  if (!existsSync(workspaceDir)) {
+    throw new StagedImportPathError(
+      "not_found",
+      "Staged bundle file not found",
+    );
+  }
+
+  const workspaceReal = realpathSync(workspaceDir);
+  const stagingRoot = resolve(workspaceReal, RESTORE_STAGING_DIRNAME);
+  const candidate = requestedPath.startsWith("/")
+    ? resolve(requestedPath)
+    : resolve(workspaceReal, requestedPath);
+
+  if (!existsSync(candidate)) {
+    throw new StagedImportPathError(
+      "not_found",
+      "Staged bundle file not found",
+    );
+  }
+
+  const linkStat = lstatSync(candidate);
+  if (linkStat.isSymbolicLink()) {
+    throw new StagedImportPathError(
+      "symlink",
+      "Staged bundle path must not be a symlink",
+    );
+  }
+
+  const realFile = realpathSync(candidate);
+  if (!existsSync(stagingRoot)) {
+    throw new StagedImportPathError(
+      "outside",
+      "Staged bundle path is not inside the restore staging directory",
+    );
+  }
+
+  const realStaging = realpathSync(stagingRoot);
+  const rel = relative(realStaging, realFile);
+  if (
+    rel === "" ||
+    rel.startsWith(`..${sep}`) ||
+    rel === ".." ||
+    rel.split(sep).includes("..")
+  ) {
+    throw new StagedImportPathError(
+      "outside",
+      "Staged bundle path is not inside the restore staging directory",
+    );
+  }
+
+  const fileStat = statSync(realFile);
+  if (!fileStat.isFile()) {
+    throw new StagedImportPathError(
+      "not_file",
+      "Staged bundle path is not a file",
+    );
+  }
+
+  if (!realFile.endsWith(".vbundle")) {
+    throw new StagedImportPathError(
+      "extension",
+      "Staged bundle must be a .vbundle file",
+    );
+  }
+
+  return realFile;
+}

--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -7,9 +7,11 @@
  * POST /v1/migrations/import          — commit a .vbundle archive import to disk.
  *
  * Accepts raw binary body (Content-Type: application/octet-stream),
- * multipart form data with a "file" field, or — on /import only — a JSON
- * body of shape `{ "url": "<signed-gcs-url>" }` that causes the daemon to
- * fetch the bundle from GCS and stream it through `streamCommitImport`.
+ * multipart form data with a "file" field, or a JSON body of shape
+ * `{ "url": "<signed-gcs-url>" }` (import only) or `{ "path": "<staged>" }`
+ * (import and import-preflight). The path form streams a file the CLI
+ * staged under `${workspace}/.restore-staging/`. The URL form fetches the
+ * bundle from GCS and streams it through `streamCommitImport`.
  * Returns structured validation results with is_valid flag and detailed
  * error descriptions.
  */
@@ -80,7 +82,16 @@ import {
   type ImportCommitReport,
   type ImportCommitResult,
 } from "../migrations/vbundle-importer.js";
+import {
+  resolveStagedImportPath,
+  StagedImportPathError,
+} from "../migrations/staged-import-path.js";
 import { streamCommitImport } from "../migrations/vbundle-streaming-importer.js";
+import {
+  readAndValidateManifest,
+  StreamingValidationError,
+} from "../migrations/vbundle-streaming-validator.js";
+import { parseVBundleStream } from "../migrations/vbundle-tar-stream.js";
 import { validateVBundle } from "../migrations/vbundle-validator.js";
 import {
   BadGatewayError,
@@ -806,6 +817,8 @@ async function extractFileData(
  * The file can be sent as:
  * - Raw binary body with Content-Type: application/octet-stream
  * - Multipart form data with a "file" field
+ * - JSON body `{ "path": "<staged-relative-or-absolute>" }` pointing at a
+ *   `.vbundle` the caller placed under `${workspace}/.restore-staging/`
  *
  * Returns:
  *   200: {
@@ -825,7 +838,13 @@ async function extractFileData(
 export async function handleMigrationImportPreflight({
   rawBody,
   headers,
+  body,
 }: RouteHandlerArgs) {
+  const contentType = headers?.["content-type"] ?? "";
+  if (contentType.includes("application/json")) {
+    return handleMigrationPreflightFromPath(body);
+  }
+
   const fileData = await extractFileData(rawBody, headers);
 
   try {
@@ -872,15 +891,18 @@ export async function handleMigrationImportPreflight({
  * 5. Verifies post-write integrity (SHA-256 check)
  * 6. Returns a detailed report of what was imported
  *
- * The bundle can be supplied in any of three ways:
+ * The bundle can be supplied as:
  * - Raw binary body with Content-Type: application/octet-stream
  * - Multipart form data with a "file" field
  * - JSON body `{ "url": "<signed-gcs-url>" }` (Content-Type:
  *   application/json). The daemon fetches and streams the archive
  *   through `streamCommitImport`, so peak memory stays bounded by a
  *   single tar entry rather than bundle size.
+ * - JSON body `{ "path": "<staged>" }` pointing at a `.vbundle` the
+ *   caller placed under `${workspace}/.restore-staging/`. The daemon
+ *   streams that file through `streamCommitImport`.
  *
- * Returns (all three paths):
+ * Returns:
  *   200: {
  *     success: true,
  *     summary: { total_files, files_created, files_overwritten, files_skipped, backups_created },
@@ -900,11 +922,10 @@ export async function handleMigrationImport(
   args: RouteHandlerArgs,
 ): Promise<unknown> {
   const { body, rawBody, headers } = args;
-  // JSON body means the caller is asking us to fetch the bundle from a
-  // signed URL and stream it through the importer.
+  // JSON body is either a signed URL fetch or a staged local-file stream.
   const contentType = headers?.["content-type"] ?? "";
   if (contentType.includes("application/json")) {
-    return handleMigrationImportFromUrl(body);
+    return handleMigrationImportFromJson(body);
   }
 
   const fileData = await extractFileData(rawBody, headers);
@@ -1014,6 +1035,8 @@ export async function handleMigrationImport(
 const URL_FETCH_TIMEOUT_MS = 60 * 60 * 1000;
 
 const MigrationImportUrlBody = z.object({ url: z.string().min(1) });
+
+const MigrationImportPathBody = z.object({ path: z.string().min(1) });
 
 const MigrationImportFromGcsBody = z.object({ bundle_url: z.string().url() });
 
@@ -1592,6 +1615,174 @@ async function runGcsImport(
 }
 
 /**
+ * Dispatch a JSON import body to the URL-fetch or staged-path streamer.
+ * The body must include exactly one of `url` or `path`.
+ */
+async function handleMigrationImportFromJson(
+  body: Record<string, unknown> | undefined,
+): Promise<unknown> {
+  const hasUrl = typeof body?.url === "string";
+  const hasPath = typeof body?.path === "string";
+  if (hasUrl && hasPath) {
+    throw new BadRequestError(
+      "Request body must include exactly one of url or path",
+    );
+  }
+  if (hasPath) {
+    return handleMigrationImportFromPath(body);
+  }
+  return handleMigrationImportFromUrl(body);
+}
+
+async function handleMigrationImportFromPath(
+  body: Record<string, unknown> | undefined,
+): Promise<unknown> {
+  const parsed = MigrationImportPathBody.safeParse(body);
+  if (!parsed.success) {
+    throw new BadRequestError(
+      "Request body must be { path: string } with a non-empty path",
+    );
+  }
+
+  let resolvedPath: string;
+  try {
+    resolvedPath = resolveStagedImportPath(parsed.data.path, getWorkspaceDir());
+  } catch (err) {
+    if (err instanceof StagedImportPathError) {
+      throw new BadRequestError(err.message);
+    }
+    throw err;
+  }
+
+  const source = createReadStream(resolvedPath);
+  const pathResolver = new DefaultPathResolver(
+    getWorkspaceDir(),
+    getWorkspaceHooksDir(),
+  );
+  let credentialsImported: CredentialImportSummary | undefined;
+  const credentialImportWarningSink: CredentialWarningSink = { warnings: [] };
+
+  try {
+    const result = await streamCommitImport({
+      source,
+      pathResolver,
+      workspaceDir: getWorkspaceDir(),
+      importCredentials: async (bundleCredentials) => {
+        credentialsImported = await importBundleCredentialsIntoCes(
+          bundleCredentials,
+          credentialImportWarningSink,
+        );
+      },
+    });
+
+    if (!result.ok) {
+      throwImportCommitFailure(result);
+    }
+
+    if (credentialImportWarningSink.warnings.length > 0) {
+      result.report.warnings.push(...credentialImportWarningSink.warnings);
+    }
+
+    await reconcileVellumMetadataFromCes(result.report);
+    appendNewerMigrationWarningsIfAny(result.report);
+    return importCommitSuccessResult(result.report, credentialsImported);
+  } catch (err) {
+    if (err instanceof RouteError) {
+      throw err;
+    }
+    log.error({ err }, "Unexpected error during staged-path import");
+    throw new InternalError(
+      err instanceof Error ? err.message : "Unexpected import error",
+    );
+  } finally {
+    source.destroy();
+  }
+}
+
+async function handleMigrationPreflightFromPath(
+  body: Record<string, unknown> | undefined,
+): Promise<unknown> {
+  const parsed = MigrationImportPathBody.safeParse(body);
+  if (!parsed.success) {
+    throw new BadRequestError(
+      "Request body must be { path: string } with a non-empty path",
+    );
+  }
+
+  let resolvedPath: string;
+  try {
+    resolvedPath = resolveStagedImportPath(parsed.data.path, getWorkspaceDir());
+  } catch (err) {
+    if (err instanceof StagedImportPathError) {
+      throw new BadRequestError(err.message);
+    }
+    throw err;
+  }
+
+  const source = createReadStream(resolvedPath);
+  try {
+    const entries = parseVBundleStream(source);
+    const first = await entries.next();
+    if (first.done) {
+      return {
+        can_import: false,
+        validation: {
+          is_valid: false as const,
+          errors: [
+            {
+              code: "empty_archive",
+              message: "Bundle archive is empty",
+            },
+          ],
+        },
+      };
+    }
+
+    let manifest;
+    try {
+      ({ manifest } = await readAndValidateManifest(first.value));
+    } catch (err) {
+      if (err instanceof StreamingValidationError) {
+        return {
+          can_import: false,
+          validation: {
+            is_valid: false as const,
+            errors: [
+              {
+                code: err.code,
+                message: err.message,
+                ...(err.archivePath !== undefined && { path: err.archivePath }),
+              },
+            ],
+          },
+        };
+      }
+      throw err;
+    }
+
+    for await (const entry of entries) {
+      entry.body.resume();
+    }
+
+    const pathResolver = new DefaultPathResolver(
+      getWorkspaceDir(),
+      getWorkspaceHooksDir(),
+    );
+    return analyzeImport({ manifest, pathResolver });
+  } catch (err) {
+    if (err instanceof RouteError) {
+      throw err;
+    }
+    log.error({ err }, "Unexpected error during staged-path preflight");
+    throw new InternalError(
+      err instanceof Error ? err.message : "Unexpected import preflight error",
+    );
+  } finally {
+    source.destroy();
+  }
+}
+
+/**
  * Handle a JSON `{ "url": "..." }` body on POST /v1/migrations/import.
  *
  * Thin wrapper around `runGcsImport` that preserves the legacy synchronous
@@ -2142,8 +2333,17 @@ export const ROUTES: RouteDefinition[] = [
     },
     summary: "Dry-run import analysis",
     description:
-      "Validate a .vbundle archive and return a report of what would change on import without modifying data.",
+      "Validate a .vbundle archive and return a report of what would change on import without modifying data. Accepts raw bytes, multipart form data, or JSON `{ path }` pointing at a file staged under the workspace `.restore-staging` directory.",
     tags: ["migrations"],
+    requestBody: z.object({
+      path: z
+        .string()
+        .min(1)
+        .optional()
+        .describe(
+          "Workspace-relative or absolute path to a staged .vbundle under .restore-staging (JSON body path only).",
+        ),
+    }),
     responseBody: z.object({
       can_import: z.boolean(),
       summary: z.object({}).passthrough(),
@@ -2163,14 +2363,22 @@ export const ROUTES: RouteDefinition[] = [
     },
     summary: "Import a .vbundle archive",
     description:
-      "Commit a .vbundle archive import to disk — destructive. Accepts the bundle as raw bytes (application/octet-stream), multipart/form-data, or a JSON body with `{ url }` carrying a signed URL the daemon fetches.",
+      "Commit a .vbundle archive import to disk — destructive. Accepts the bundle as raw bytes (application/octet-stream), multipart/form-data, a JSON body with `{ url }` carrying a signed URL the daemon fetches, or a JSON body with `{ path }` pointing at a file staged under the workspace `.restore-staging` directory.",
     tags: ["migrations"],
     requestBody: z.object({
       url: z
         .string()
         .url()
+        .optional()
         .describe(
           "A signed GCS URL pointing to the .vbundle archive (JSON body path only).",
+        ),
+      path: z
+        .string()
+        .min(1)
+        .optional()
+        .describe(
+          "Workspace-relative or absolute path to a staged .vbundle under .restore-staging (JSON body path only).",
         ),
     }),
     additionalResponses: {

--- a/assistant/src/runtime/routes/migration-routes.ts
+++ b/assistant/src/runtime/routes/migration-routes.ts
@@ -60,6 +60,10 @@ import {
   migrationJobs,
 } from "../migrations/job-registry.js";
 import { getOriginMode } from "../migrations/origin-mode.js";
+import {
+  resolveStagedImportPath,
+  StagedImportPathError,
+} from "../migrations/staged-import-path.js";
 import type {
   VBundleAssistantInfo,
   VBundleCompatibility,
@@ -82,10 +86,6 @@ import {
   type ImportCommitReport,
   type ImportCommitResult,
 } from "../migrations/vbundle-importer.js";
-import {
-  resolveStagedImportPath,
-  StagedImportPathError,
-} from "../migrations/staged-import-path.js";
 import { streamCommitImport } from "../migrations/vbundle-streaming-importer.js";
 import {
   readAndValidateManifest,

--- a/cli/src/__tests__/bundle-staging.test.ts
+++ b/cli/src/__tests__/bundle-staging.test.ts
@@ -7,30 +7,19 @@ import {
   spyOn,
   test,
 } from "bun:test";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import type { AssistantEntry } from "../lib/assistant-config.js";
-import * as loopbackFetch from "../lib/loopback-fetch.js";
-import * as stepRunner from "../lib/step-runner.js";
-
-const realLoopbackFetch = { ...loopbackFetch };
-const realStepRunner = { ...stepRunner };
-
-const loopbackSafeFetchMock = mock<typeof loopbackFetch.loopbackSafeFetch>();
-const execMock = mock<typeof stepRunner.exec>(async () => {});
-
-mock.module("../lib/loopback-fetch.js", () => ({
-  ...realLoopbackFetch,
-  loopbackSafeFetch: loopbackSafeFetchMock,
-}));
-
-mock.module("../lib/step-runner.js", () => ({
-  ...realStepRunner,
-  exec: execMock,
-}));
-
+import { restoreBackup } from "../lib/backup-ops.js";
 import {
   bundleFileSizeBytes,
   formatBundleSizeMb,
@@ -39,12 +28,11 @@ import {
   stageBundleForRestore,
   stagingTargetFromEntry,
 } from "../lib/bundle-staging.js";
-import { restoreBackup } from "../lib/backup-ops.js";
 import * as guardianToken from "../lib/guardian-token.js";
+import * as loopbackFetch from "../lib/loopback-fetch.js";
+import * as stepRunner from "../lib/step-runner.js";
 
-function makeEntry(
-  overrides: Partial<AssistantEntry> = {},
-): AssistantEntry {
+function makeEntry(overrides: Partial<AssistantEntry> = {}): AssistantEntry {
   return {
     assistantId: "assistant-123",
     runtimeUrl: "http://127.0.0.1:7831",
@@ -56,23 +44,27 @@ function makeEntry(
 }
 
 let tmpRoot: string;
+let fetchSpy: ReturnType<typeof spyOn<typeof loopbackFetch, "loopbackSafeFetch">>;
+let execSpy: ReturnType<typeof spyOn<typeof stepRunner, "exec">>;
 
 beforeEach(() => {
   tmpRoot = mkdtempSync(join(tmpdir(), "cli-bundle-staging-"));
-  loopbackSafeFetchMock.mockReset();
-  execMock.mockReset();
-  execMock.mockResolvedValue(undefined);
+  fetchSpy = spyOn(loopbackFetch, "loopbackSafeFetch");
+  execSpy = spyOn(stepRunner, "exec").mockResolvedValue(undefined);
 });
 
 afterEach(() => {
+  fetchSpy.mockRestore();
+  execSpy.mockRestore();
   rmSync(tmpRoot, { recursive: true, force: true });
 });
 
 describe("stagingTargetFromEntry", () => {
   test("returns docker staging for docker topology", () => {
-    expect(
-      stagingTargetFromEntry(makeEntry({ cloud: "docker" })),
-    ).toEqual({ kind: "docker", assistantId: "assistant-123" });
+    expect(stagingTargetFromEntry(makeEntry({ cloud: "docker" }))).toEqual({
+      kind: "docker",
+      assistantId: "assistant-123",
+    });
   });
 
   test("returns local staging when instanceDir is present", () => {
@@ -80,7 +72,9 @@ describe("stagingTargetFromEntry", () => {
       stagingTargetFromEntry(
         makeEntry({
           cloud: "local",
-          resources: { instanceDir: "/tmp/instance" } as AssistantEntry["resources"],
+          resources: {
+            instanceDir: "/tmp/instance",
+          } as AssistantEntry["resources"],
         }),
       ),
     ).toEqual({ kind: "local", instanceDir: "/tmp/instance" });
@@ -115,6 +109,7 @@ describe("stageBundleForRestore", () => {
     );
     expect(staged.relativePath.endsWith(".vbundle")).toBe(true);
     expect(readFileSync(dest, "utf8")).toBe("bundle-bytes");
+    expect(execSpy).not.toHaveBeenCalled();
 
     await staged.cleanup();
     expect(existsSync(dest)).toBe(false);
@@ -129,21 +124,21 @@ describe("stageBundleForRestore", () => {
       hostBundle,
     );
 
-    expect(execMock).toHaveBeenCalledWith("docker", [
+    expect(execSpy).toHaveBeenCalledWith("docker", [
       "exec",
       "assistant-123-assistant",
       "mkdir",
       "-p",
       `/workspace/${RESTORE_STAGING_DIRNAME}`,
     ]);
-    expect(execMock).toHaveBeenCalledWith("docker", [
+    expect(execSpy).toHaveBeenCalledWith("docker", [
       "cp",
       hostBundle,
       `assistant-123-assistant:/workspace/${staged.relativePath}`,
     ]);
 
     await staged.cleanup();
-    expect(execMock).toHaveBeenCalledWith("docker", [
+    expect(execSpy).toHaveBeenCalledWith("docker", [
       "exec",
       "assistant-123-assistant",
       "rm",
@@ -154,9 +149,9 @@ describe("stageBundleForRestore", () => {
 });
 
 describe("importStagedBundle", () => {
-  test("returns a direct 200 daemon response", async () => {
+  test("returns a direct 200 assistant response", async () => {
     const payload = { success: true, summary: { total_files: 1 } };
-    loopbackSafeFetchMock.mockResolvedValue(
+    fetchSpy.mockResolvedValue(
       new Response(JSON.stringify(payload), { status: 200 }),
     );
 
@@ -168,8 +163,8 @@ describe("importStagedBundle", () => {
 
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual(payload);
-    expect(loopbackSafeFetchMock).toHaveBeenCalledTimes(1);
-    const [url, init] = loopbackSafeFetchMock.mock.calls[0];
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0];
     expect(url).toBe("http://127.0.0.1:7831/v1/migrations/import");
     expect(init?.headers).toMatchObject({
       Authorization: "Bearer token",
@@ -190,7 +185,7 @@ describe("importStagedBundle", () => {
     globalThis.setTimeout = timeoutSpy as unknown as typeof setTimeout;
 
     try {
-      loopbackSafeFetchMock
+      fetchSpy
         .mockResolvedValueOnce(
           new Response(JSON.stringify({ job_id: "job-1", status: "pending" }), {
             status: 202,
@@ -222,8 +217,8 @@ describe("importStagedBundle", () => {
         success: true,
         summary: { total_files: 2 },
       });
-      expect(loopbackSafeFetchMock).toHaveBeenCalledTimes(3);
-      expect(String(loopbackSafeFetchMock.mock.calls[1][0])).toBe(
+      expect(fetchSpy).toHaveBeenCalledTimes(3);
+      expect(String(fetchSpy.mock.calls[1][0])).toBe(
         "http://127.0.0.1:7831/v1/migrations/import/job-1/status",
       );
     } finally {
@@ -244,7 +239,7 @@ describe("restoreBackup staged path", () => {
       accessTokenExpiresAt: new Date(Date.now() + 60_000).toISOString(),
     } as ReturnType<typeof guardianToken.loadGuardianToken>);
 
-    loopbackSafeFetchMock.mockResolvedValue(
+    fetchSpy.mockResolvedValue(
       new Response(JSON.stringify({ success: true }), { status: 200 }),
     );
 
@@ -256,8 +251,8 @@ describe("restoreBackup staged path", () => {
         { kind: "local", instanceDir },
       );
       expect(ok).toBe(true);
-      expect(loopbackSafeFetchMock).toHaveBeenCalledTimes(1);
-      const init = loopbackSafeFetchMock.mock.calls[0][1];
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      const init = fetchSpy.mock.calls[0][1];
       expect(init?.headers).toMatchObject({
         "Content-Type": "application/json",
       });

--- a/cli/src/__tests__/bundle-staging.test.ts
+++ b/cli/src/__tests__/bundle-staging.test.ts
@@ -1,0 +1,277 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  spyOn,
+  test,
+} from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { AssistantEntry } from "../lib/assistant-config.js";
+import * as loopbackFetch from "../lib/loopback-fetch.js";
+import * as stepRunner from "../lib/step-runner.js";
+
+const realLoopbackFetch = { ...loopbackFetch };
+const realStepRunner = { ...stepRunner };
+
+const loopbackSafeFetchMock = mock<typeof loopbackFetch.loopbackSafeFetch>();
+const execMock = mock<typeof stepRunner.exec>(async () => {});
+
+mock.module("../lib/loopback-fetch.js", () => ({
+  ...realLoopbackFetch,
+  loopbackSafeFetch: loopbackSafeFetchMock,
+}));
+
+mock.module("../lib/step-runner.js", () => ({
+  ...realStepRunner,
+  exec: execMock,
+}));
+
+import {
+  bundleFileSizeBytes,
+  formatBundleSizeMb,
+  importStagedBundle,
+  RESTORE_STAGING_DIRNAME,
+  stageBundleForRestore,
+  stagingTargetFromEntry,
+} from "../lib/bundle-staging.js";
+import { restoreBackup } from "../lib/backup-ops.js";
+import * as guardianToken from "../lib/guardian-token.js";
+
+function makeEntry(
+  overrides: Partial<AssistantEntry> = {},
+): AssistantEntry {
+  return {
+    assistantId: "assistant-123",
+    runtimeUrl: "http://127.0.0.1:7831",
+    cloud: "local",
+    species: "vellum",
+    hatchedAt: new Date().toISOString(),
+    ...overrides,
+  } as AssistantEntry;
+}
+
+let tmpRoot: string;
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), "cli-bundle-staging-"));
+  loopbackSafeFetchMock.mockReset();
+  execMock.mockReset();
+  execMock.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe("stagingTargetFromEntry", () => {
+  test("returns docker staging for docker topology", () => {
+    expect(
+      stagingTargetFromEntry(makeEntry({ cloud: "docker" })),
+    ).toEqual({ kind: "docker", assistantId: "assistant-123" });
+  });
+
+  test("returns local staging when instanceDir is present", () => {
+    expect(
+      stagingTargetFromEntry(
+        makeEntry({
+          cloud: "local",
+          resources: { instanceDir: "/tmp/instance" } as AssistantEntry["resources"],
+        }),
+      ),
+    ).toEqual({ kind: "local", instanceDir: "/tmp/instance" });
+  });
+
+  test("returns null for unknown topologies", () => {
+    expect(
+      stagingTargetFromEntry(makeEntry({ cloud: "custom", sshUser: "user" })),
+    ).toBeNull();
+  });
+});
+
+describe("stageBundleForRestore", () => {
+  test("copies a host bundle into the local workspace staging directory", async () => {
+    const instanceDir = join(tmpRoot, "instance");
+    const hostBundle = join(tmpRoot, "backup.vbundle");
+    writeFileSync(hostBundle, "bundle-bytes");
+
+    const staged = await stageBundleForRestore(
+      { kind: "local", instanceDir },
+      hostBundle,
+    );
+
+    const dest = join(
+      instanceDir,
+      ".vellum",
+      "workspace",
+      staged.relativePath,
+    );
+    expect(staged.relativePath.startsWith(`${RESTORE_STAGING_DIRNAME}/`)).toBe(
+      true,
+    );
+    expect(staged.relativePath.endsWith(".vbundle")).toBe(true);
+    expect(readFileSync(dest, "utf8")).toBe("bundle-bytes");
+
+    await staged.cleanup();
+    expect(existsSync(dest)).toBe(false);
+  });
+
+  test("copies a host bundle into the docker workspace via docker cp", async () => {
+    const hostBundle = join(tmpRoot, "backup.vbundle");
+    writeFileSync(hostBundle, "bundle-bytes");
+
+    const staged = await stageBundleForRestore(
+      { kind: "docker", assistantId: "assistant-123" },
+      hostBundle,
+    );
+
+    expect(execMock).toHaveBeenCalledWith("docker", [
+      "exec",
+      "assistant-123-assistant",
+      "mkdir",
+      "-p",
+      `/workspace/${RESTORE_STAGING_DIRNAME}`,
+    ]);
+    expect(execMock).toHaveBeenCalledWith("docker", [
+      "cp",
+      hostBundle,
+      `assistant-123-assistant:/workspace/${staged.relativePath}`,
+    ]);
+
+    await staged.cleanup();
+    expect(execMock).toHaveBeenCalledWith("docker", [
+      "exec",
+      "assistant-123-assistant",
+      "rm",
+      "-f",
+      `/workspace/${staged.relativePath}`,
+    ]);
+  });
+});
+
+describe("importStagedBundle", () => {
+  test("returns a direct 200 daemon response", async () => {
+    const payload = { success: true, summary: { total_files: 1 } };
+    loopbackSafeFetchMock.mockResolvedValue(
+      new Response(JSON.stringify(payload), { status: 200 }),
+    );
+
+    const response = await importStagedBundle(
+      "http://127.0.0.1:7831",
+      "token",
+      `${RESTORE_STAGING_DIRNAME}/backup.vbundle`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(payload);
+    expect(loopbackSafeFetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = loopbackSafeFetchMock.mock.calls[0];
+    expect(url).toBe("http://127.0.0.1:7831/v1/migrations/import");
+    expect(init?.headers).toMatchObject({
+      Authorization: "Bearer token",
+      "Content-Type": "application/json",
+    });
+    expect(init?.body).toBe(
+      JSON.stringify({
+        path: `${RESTORE_STAGING_DIRNAME}/backup.vbundle`,
+      }),
+    );
+  });
+
+  test("polls a 202 gateway job until complete", async () => {
+    const realSetTimeout = globalThis.setTimeout;
+    const timeoutSpy = mock((fn: (...args: unknown[]) => void) =>
+      realSetTimeout(fn, 0),
+    );
+    globalThis.setTimeout = timeoutSpy as unknown as typeof setTimeout;
+
+    try {
+      loopbackSafeFetchMock
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ job_id: "job-1", status: "pending" }), {
+            status: 202,
+          }),
+        )
+        .mockResolvedValueOnce(
+          new Response(JSON.stringify({ status: "processing" }), {
+            status: 200,
+          }),
+        )
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              status: "complete",
+              result: { success: true, summary: { total_files: 2 } },
+            }),
+            { status: 200 },
+          ),
+        );
+
+      const response = await importStagedBundle(
+        "http://127.0.0.1:7831",
+        "token",
+        `${RESTORE_STAGING_DIRNAME}/backup.vbundle`,
+      );
+
+      expect(response.status).toBe(200);
+      expect(await response.json()).toEqual({
+        success: true,
+        summary: { total_files: 2 },
+      });
+      expect(loopbackSafeFetchMock).toHaveBeenCalledTimes(3);
+      expect(String(loopbackSafeFetchMock.mock.calls[1][0])).toBe(
+        "http://127.0.0.1:7831/v1/migrations/import/job-1/status",
+      );
+    } finally {
+      globalThis.setTimeout = realSetTimeout;
+    }
+  });
+});
+
+describe("restoreBackup staged path", () => {
+  test("stages a local bundle and posts JSON { path }", async () => {
+    const instanceDir = join(tmpRoot, "instance");
+    mkdirSync(join(instanceDir, ".vellum", "workspace"), { recursive: true });
+    const backupPath = join(tmpRoot, "backup.vbundle");
+    writeFileSync(backupPath, "bundle-bytes");
+
+    const loadSpy = spyOn(guardianToken, "loadGuardianToken").mockReturnValue({
+      accessToken: "local-token",
+      accessTokenExpiresAt: new Date(Date.now() + 60_000).toISOString(),
+    } as ReturnType<typeof guardianToken.loadGuardianToken>);
+
+    loopbackSafeFetchMock.mockResolvedValue(
+      new Response(JSON.stringify({ success: true }), { status: 200 }),
+    );
+
+    try {
+      const ok = await restoreBackup(
+        "http://127.0.0.1:7831",
+        "assistant-123",
+        backupPath,
+        { kind: "local", instanceDir },
+      );
+      expect(ok).toBe(true);
+      expect(loopbackSafeFetchMock).toHaveBeenCalledTimes(1);
+      const init = loopbackSafeFetchMock.mock.calls[0][1];
+      expect(init?.headers).toMatchObject({
+        "Content-Type": "application/json",
+      });
+      const posted = JSON.parse(String(init?.body)) as { path: string };
+      expect(posted.path.startsWith(`${RESTORE_STAGING_DIRNAME}/`)).toBe(true);
+    } finally {
+      loadSpy.mockRestore();
+    }
+  });
+});
+
+describe("bundle size helpers", () => {
+  test("formatBundleSizeMb reports two decimal megabytes", () => {
+    expect(formatBundleSizeMb(1024 * 1024)).toBe("1.00");
+    expect(bundleFileSizeBytes(join(tmpRoot, "missing.vbundle"))).toBe(0);
+  });
+});

--- a/cli/src/commands/restore.ts
+++ b/cli/src/commands/restore.ts
@@ -583,7 +583,7 @@ export async function restore(): Promise<void> {
 
   // Obtain auth token (acquired before dry-run or before data import;
   // re-acquired after version rollback since containers restart).
-  let accessToken = await getAccessToken(
+  const accessToken = await getAccessToken(
     entry.runtimeUrl,
     entry.assistantId,
     name,
@@ -611,9 +611,6 @@ export async function restore(): Promise<void> {
       accessToken,
       stagedRelativePath,
       bundleData,
-      setAccessToken: (token) => {
-        accessToken = token;
-      },
     });
   } finally {
     if (cleanupStaged) {
@@ -630,7 +627,6 @@ async function runLocalRestore(opts: {
   accessToken: string;
   stagedRelativePath: string | undefined;
   bundleData: Buffer | undefined;
-  setAccessToken: (token: string) => void;
 }): Promise<void> {
   const {
     entry,
@@ -639,7 +635,6 @@ async function runLocalRestore(opts: {
     dryRun,
     stagedRelativePath,
     bundleData,
-    setAccessToken,
   } = opts;
   let accessToken = opts.accessToken;
 
@@ -754,7 +749,6 @@ async function runLocalRestore(opts: {
         name,
         entry.guardianBootstrapSecret,
       );
-      opts.setAccessToken(accessToken);
     }
 
     // Data import

--- a/cli/src/commands/restore.ts
+++ b/cli/src/commands/restore.ts
@@ -3,6 +3,14 @@ import { existsSync, readFileSync } from "fs";
 import { findAssistantByName } from "../lib/assistant-config.js";
 import type { AssistantEntry } from "../lib/assistant-config.js";
 import {
+  bundleFileSizeBytes,
+  formatBundleSizeMb,
+  importStagedBundle,
+  preflightStagedBundle,
+  stageBundleForRestore,
+  stagingTargetFromEntry,
+} from "../lib/bundle-staging.js";
+import {
   loadGuardianToken,
   leaseGuardianToken,
 } from "../lib/guardian-token.js";
@@ -546,9 +554,7 @@ export async function restore(): Promise<void> {
     process.exit(1);
   }
 
-  // Read the .vbundle file
-  const bundleData = readFileSync(fromPath);
-  const sizeMB = (bundleData.byteLength / (1024 * 1024)).toFixed(2);
+  const sizeMB = formatBundleSizeMb(bundleFileSizeBytes(fromPath));
   console.log(`Reading ${fromPath} (${sizeMB} MB)...`);
 
   // Detect topology and route platform assistants through Django import
@@ -563,6 +569,7 @@ export async function restore(): Promise<void> {
   }
 
   if (cloud === "vellum") {
+    const bundleData = readFileSync(fromPath);
     await restorePlatform(entry, name, bundleData, { version, dryRun });
     return;
   }
@@ -583,24 +590,83 @@ export async function restore(): Promise<void> {
     entry.guardianBootstrapSecret,
   );
 
+  const staging = stagingTargetFromEntry(entry);
+  let stagedRelativePath: string | undefined;
+  let bundleData: Buffer | undefined;
+  let cleanupStaged: (() => Promise<void>) | undefined;
+  if (staging) {
+    const staged = await stageBundleForRestore(staging, fromPath);
+    stagedRelativePath = staged.relativePath;
+    cleanupStaged = staged.cleanup;
+  } else {
+    bundleData = readFileSync(fromPath);
+  }
+
+  try {
+    await runLocalRestore({
+      entry,
+      name,
+      version,
+      dryRun,
+      accessToken,
+      stagedRelativePath,
+      bundleData,
+      setAccessToken: (token) => {
+        accessToken = token;
+      },
+    });
+  } finally {
+    if (cleanupStaged) {
+      await cleanupStaged();
+    }
+  }
+}
+
+async function runLocalRestore(opts: {
+  entry: AssistantEntry;
+  name: string;
+  version: string | undefined;
+  dryRun: boolean;
+  accessToken: string;
+  stagedRelativePath: string | undefined;
+  bundleData: Buffer | undefined;
+  setAccessToken: (token: string) => void;
+}): Promise<void> {
+  const {
+    entry,
+    name,
+    version,
+    dryRun,
+    stagedRelativePath,
+    bundleData,
+    setAccessToken,
+  } = opts;
+  let accessToken = opts.accessToken;
+
   if (dryRun) {
     // Preflight check
     console.log("Running preflight analysis...\n");
 
     let response: Response;
     try {
-      response = await loopbackSafeFetch(
-        `${entry.runtimeUrl}/v1/migrations/import-preflight`,
-        {
-          method: "POST",
-          headers: {
-            Authorization: `Bearer ${accessToken}`,
-            "Content-Type": "application/octet-stream",
-          },
-          body: bundleData,
-          signal: AbortSignal.timeout(120_000),
-        },
-      );
+      response = stagedRelativePath
+        ? await preflightStagedBundle(
+            entry.runtimeUrl,
+            accessToken,
+            stagedRelativePath,
+          )
+        : await loopbackSafeFetch(
+            `${entry.runtimeUrl}/v1/migrations/import-preflight`,
+            {
+              method: "POST",
+              headers: {
+                Authorization: `Bearer ${accessToken}`,
+                "Content-Type": "application/octet-stream",
+              },
+              body: bundleData,
+              signal: AbortSignal.timeout(120_000),
+            },
+          );
     } catch (err) {
       if (err instanceof Error && err.name === "TimeoutError") {
         console.error("Error: Preflight request timed out after 2 minutes.");
@@ -688,25 +754,38 @@ export async function restore(): Promise<void> {
         name,
         entry.guardianBootstrapSecret,
       );
+      opts.setAccessToken(accessToken);
     }
 
     // Data import
     console.log("Importing backup data...\n");
 
-    let response: Response;
+    let result: ImportResponse;
     try {
-      response = await loopbackSafeFetch(
-        `${entry.runtimeUrl}/v1/migrations/import`,
-        {
-          method: "POST",
-          headers: {
-            Authorization: `Bearer ${accessToken}`,
-            "Content-Type": "application/octet-stream",
-          },
-          body: bundleData,
-          signal: AbortSignal.timeout(120_000),
-        },
-      );
+      const response = stagedRelativePath
+        ? await importStagedBundle(
+            entry.runtimeUrl,
+            accessToken,
+            stagedRelativePath,
+          )
+        : await loopbackSafeFetch(
+            `${entry.runtimeUrl}/v1/migrations/import`,
+            {
+              method: "POST",
+              headers: {
+                Authorization: `Bearer ${accessToken}`,
+                "Content-Type": "application/octet-stream",
+              },
+              body: bundleData,
+              signal: AbortSignal.timeout(120_000),
+            },
+          );
+      if (!response.ok) {
+        const body = await response.text();
+        console.error(`Error: Import failed (${response.status}): ${body}`);
+        process.exit(1);
+      }
+      result = (await response.json()) as ImportResponse;
     } catch (err) {
       if (err instanceof Error && err.name === "TimeoutError") {
         console.error("Error: Import request timed out after 2 minutes.");
@@ -722,14 +801,6 @@ export async function restore(): Promise<void> {
       }
       throw err;
     }
-
-    if (!response.ok) {
-      const body = await response.text();
-      console.error(`Error: Import failed (${response.status}): ${body}`);
-      process.exit(1);
-    }
-
-    const result = (await response.json()) as ImportResponse;
 
     if (!result.success) {
       console.error(

--- a/cli/src/commands/restore.ts
+++ b/cli/src/commands/restore.ts
@@ -663,7 +663,7 @@ async function runLocalRestore(opts: {
                 Authorization: `Bearer ${accessToken}`,
                 "Content-Type": "application/octet-stream",
               },
-              body: bundleData,
+              body: bundleData ? new Uint8Array(bundleData) : undefined,
               signal: AbortSignal.timeout(120_000),
             },
           );
@@ -776,7 +776,7 @@ async function runLocalRestore(opts: {
                 Authorization: `Bearer ${accessToken}`,
                 "Content-Type": "application/octet-stream",
               },
-              body: bundleData,
+              body: bundleData ? new Uint8Array(bundleData) : undefined,
               signal: AbortSignal.timeout(120_000),
             },
           );

--- a/cli/src/commands/upgrade.ts
+++ b/cli/src/commands/upgrade.ts
@@ -654,6 +654,7 @@ async function upgradeDocker(
               entry.runtimeUrl,
               entry.assistantId,
               backupPath,
+              { kind: "docker", assistantId: entry.assistantId },
             );
             if (restored) {
               console.log("   ✅ Data restored successfully\n");

--- a/cli/src/lib/backup-ops.ts
+++ b/cli/src/lib/backup-ops.ts
@@ -222,25 +222,26 @@ export async function restoreBackup(
       return false;
     }
 
-    let accessToken = await getGuardianAccessToken(runtimeUrl, assistantId);
-    if (!accessToken) {
+    const initialToken = await getGuardianAccessToken(runtimeUrl, assistantId);
+    if (!initialToken) {
       console.warn(
         "Warning: restore skipped — no valid guardian token available",
       );
       return false;
     }
+    let token = initialToken;
 
     if (staging) {
       const staged = await stageBundleForRestore(staging, backupPath);
       try {
         const postImport = () =>
-          importStagedBundle(runtimeUrl, accessToken, staged.relativePath);
+          importStagedBundle(runtimeUrl, token, staged.relativePath);
         const response = await postRestoreWithRetries(
           postImport,
           runtimeUrl,
           assistantId,
-          (token) => {
-            accessToken = token;
+          (nextToken) => {
+            token = nextToken;
           },
         );
         if (!response) {
@@ -252,12 +253,12 @@ export async function restoreBackup(
       }
     }
 
-    const bundleData = readFileSync(backupPath);
+    const bundleData = new Uint8Array(readFileSync(backupPath));
     const postImport = () =>
       loopbackSafeFetch(`${runtimeUrl}/v1/migrations/import`, {
         method: "POST",
         headers: {
-          Authorization: `Bearer ${accessToken}`,
+          Authorization: `Bearer ${token}`,
           "Content-Type": "application/octet-stream",
         },
         body: bundleData,
@@ -267,8 +268,8 @@ export async function restoreBackup(
       postImport,
       runtimeUrl,
       assistantId,
-      (token) => {
-        accessToken = token;
+      (nextToken) => {
+        token = nextToken;
       },
     );
     if (!response) {

--- a/cli/src/lib/backup-ops.ts
+++ b/cli/src/lib/backup-ops.ts
@@ -9,6 +9,11 @@ import {
 import { homedir } from "os";
 import { dirname, join } from "path";
 
+import {
+  importStagedBundle,
+  stageBundleForRestore,
+  type RestoreStagingTarget,
+} from "./bundle-staging.js";
 import { loadGuardianToken, refreshGuardianToken } from "./guardian-token.js";
 import { loopbackSafeFetch } from "./loopback-fetch.js";
 
@@ -134,6 +139,72 @@ export async function createBackup(
   }
 }
 
+async function postRestoreWithRetries(
+  postImport: () => Promise<Response>,
+  runtimeUrl: string,
+  assistantId: string,
+  onTokenRefresh: (token: string) => void,
+): Promise<Response | null> {
+  let response = await postImport();
+
+  // Retry once with a refreshed token on 401 — the cached token may be
+  // stale after a container restart that regenerated the gateway signing key.
+  if (response.status === 401) {
+    const refreshed = await refreshGuardianToken(runtimeUrl, assistantId);
+    if (!refreshed) {
+      console.warn(`Warning: restore failed (401) and token refresh failed`);
+      return null;
+    }
+    onTokenRefresh(refreshed.accessToken);
+    response = await postImport();
+  }
+
+  // A freshly-(re)started gateway 503s {status:"starting"} for a couple of
+  // seconds until its own assistant poll observes the migration state and
+  // opens the traffic gate — retry through that window rather than failing
+  // the recovery. The daemon's running-migrations 503 carries a `reason`
+  // field and is excluded: the import must not race an in-flight migration.
+  const startingGateDeadline = Date.now() + 15_000;
+  while (!response.ok) {
+    const body = await response.text();
+    let gatewayStarting = false;
+    try {
+      const parsed = JSON.parse(body) as {
+        status?: string;
+        reason?: string;
+      };
+      gatewayStarting =
+        parsed.status === "starting" && parsed.reason === undefined;
+    } catch {
+      // Non-JSON error body — not the starting gate.
+    }
+    if (gatewayStarting && Date.now() < startingGateDeadline) {
+      await new Promise((r) => setTimeout(r, 1_000));
+      response = await postImport();
+      continue;
+    }
+    console.warn(`Warning: restore failed (${response.status}): ${body}`);
+    return null;
+  }
+
+  return response;
+}
+
+async function finishRestoreResponse(response: Response): Promise<boolean> {
+  const result = (await response.json()) as {
+    success: boolean;
+    message?: string;
+    reason?: string;
+  };
+  if (!result.success) {
+    console.warn(
+      `Warning: restore failed — ${result.message ?? result.reason ?? "unknown reason"}`,
+    );
+    return false;
+  }
+  return true;
+}
+
 /**
  * Restore a .vbundle backup into a running assistant.
  * Returns true if restore succeeded, false otherwise.
@@ -143,6 +214,7 @@ export async function restoreBackup(
   runtimeUrl: string,
   assistantId: string,
   backupPath: string,
+  staging?: RestoreStagingTarget | null,
 ): Promise<boolean> {
   try {
     if (!existsSync(backupPath)) {
@@ -150,7 +222,6 @@ export async function restoreBackup(
       return false;
     }
 
-    const bundleData = readFileSync(backupPath);
     let accessToken = await getGuardianAccessToken(runtimeUrl, assistantId);
     if (!accessToken) {
       console.warn(
@@ -159,6 +230,29 @@ export async function restoreBackup(
       return false;
     }
 
+    if (staging) {
+      const staged = await stageBundleForRestore(staging, backupPath);
+      try {
+        const postImport = () =>
+          importStagedBundle(runtimeUrl, accessToken, staged.relativePath);
+        const response = await postRestoreWithRetries(
+          postImport,
+          runtimeUrl,
+          assistantId,
+          (token) => {
+            accessToken = token;
+          },
+        );
+        if (!response) {
+          return false;
+        }
+        return await finishRestoreResponse(response);
+      } finally {
+        await staged.cleanup();
+      }
+    }
+
+    const bundleData = readFileSync(backupPath);
     const postImport = () =>
       loopbackSafeFetch(`${runtimeUrl}/v1/migrations/import`, {
         method: "POST",
@@ -169,62 +263,18 @@ export async function restoreBackup(
         body: bundleData,
         signal: AbortSignal.timeout(120_000),
       });
-
-    let response = await postImport();
-
-    // Retry once with a refreshed token on 401 — the cached token may be
-    // stale after a container restart that regenerated the gateway signing key.
-    if (response.status === 401) {
-      const refreshed = await refreshGuardianToken(runtimeUrl, assistantId);
-      if (!refreshed) {
-        console.warn(`Warning: restore failed (401) and token refresh failed`);
-        return false;
-      }
-      accessToken = refreshed.accessToken;
-      response = await postImport();
-    }
-
-    // A freshly-(re)started gateway 503s {status:"starting"} for a couple of
-    // seconds until its own assistant poll observes the migration state and
-    // opens the traffic gate — retry through that window rather than failing
-    // the recovery. The daemon's running-migrations 503 carries a `reason`
-    // field and is excluded: the import must not race an in-flight migration.
-    const startingGateDeadline = Date.now() + 15_000;
-    while (!response.ok) {
-      const body = await response.text();
-      let gatewayStarting = false;
-      try {
-        const parsed = JSON.parse(body) as {
-          status?: string;
-          reason?: string;
-        };
-        gatewayStarting =
-          parsed.status === "starting" && parsed.reason === undefined;
-      } catch {
-        // Non-JSON error body — not the starting gate.
-      }
-      if (gatewayStarting && Date.now() < startingGateDeadline) {
-        await new Promise((r) => setTimeout(r, 1_000));
-        response = await postImport();
-        continue;
-      }
-      console.warn(`Warning: restore failed (${response.status}): ${body}`);
+    const response = await postRestoreWithRetries(
+      postImport,
+      runtimeUrl,
+      assistantId,
+      (token) => {
+        accessToken = token;
+      },
+    );
+    if (!response) {
       return false;
     }
-
-    const result = (await response.json()) as {
-      success: boolean;
-      message?: string;
-      reason?: string;
-    };
-    if (!result.success) {
-      console.warn(
-        `Warning: restore failed — ${result.message ?? result.reason ?? "unknown reason"}`,
-      );
-      return false;
-    }
-
-    return true;
+    return await finishRestoreResponse(response);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     console.warn(`Warning: restore failed: ${msg}`);

--- a/cli/src/lib/bundle-staging.ts
+++ b/cli/src/lib/bundle-staging.ts
@@ -140,7 +140,7 @@ export async function importStagedBundle(
       signal: AbortSignal.timeout(120_000),
     });
 
-  let response = await postImport();
+  const response = await postImport();
 
   if (response.status === 202) {
     const accepted = (await response.json()) as { job_id?: string };

--- a/cli/src/lib/bundle-staging.ts
+++ b/cli/src/lib/bundle-staging.ts
@@ -1,0 +1,220 @@
+import { randomUUID } from "crypto";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  statSync,
+  unlinkSync,
+} from "fs";
+import { join } from "path";
+
+import type { AssistantEntry } from "./assistant-config.js";
+import { dockerResourceNames } from "./docker.js";
+import { loopbackSafeFetch } from "./loopback-fetch.js";
+import { exec } from "./step-runner.js";
+
+/** Workspace-relative directory the daemon will open for staged restores. */
+export const RESTORE_STAGING_DIRNAME = ".restore-staging";
+
+export type RestoreStagingTarget =
+  | { kind: "local"; instanceDir: string }
+  | { kind: "docker"; assistantId: string };
+
+export interface StagedBundle {
+  /** Path the daemon should receive in `{ path }`. */
+  relativePath: string;
+  cleanup: () => Promise<void>;
+}
+
+const IMPORT_POLL_INTERVAL_MS = 2_000;
+const IMPORT_POLL_TIMEOUT_MS = 60 * 60 * 1000;
+
+export function stagingTargetFromEntry(
+  entry: AssistantEntry,
+): RestoreStagingTarget | null {
+  const cloud =
+    entry.cloud || (entry.project ? "gcp" : entry.sshUser ? "custom" : "local");
+  if (cloud === "docker") {
+    return { kind: "docker", assistantId: entry.assistantId };
+  }
+  if (cloud === "local" && entry.resources?.instanceDir) {
+    return { kind: "local", instanceDir: entry.resources.instanceDir };
+  }
+  return null;
+}
+
+function localWorkspaceDir(instanceDir: string): string {
+  return join(instanceDir, ".vellum", "workspace");
+}
+
+export function formatBundleSizeMb(bytes: number): string {
+  return (bytes / (1024 * 1024)).toFixed(2);
+}
+
+/**
+ * Copy a host `.vbundle` into the assistant workspace staging directory
+ * so the daemon can stream it without a large HTTP body.
+ */
+export async function stageBundleForRestore(
+  target: RestoreStagingTarget,
+  hostBundlePath: string,
+): Promise<StagedBundle> {
+  const filename = `${randomUUID()}.vbundle`;
+  const relativePath = `${RESTORE_STAGING_DIRNAME}/${filename}`;
+
+  if (target.kind === "local") {
+    const stagingDir = join(
+      localWorkspaceDir(target.instanceDir),
+      RESTORE_STAGING_DIRNAME,
+    );
+    mkdirSync(stagingDir, { recursive: true });
+    const dest = join(stagingDir, filename);
+    copyFileSync(hostBundlePath, dest);
+    return {
+      relativePath,
+      cleanup: async () => {
+        try {
+          unlinkSync(dest);
+        } catch {
+          // Best-effort: a successful import may have swapped the workspace.
+        }
+      },
+    };
+  }
+
+  const container = dockerResourceNames(target.assistantId).assistantContainer;
+  const dest = `/workspace/${relativePath}`;
+  await exec("docker", [
+    "exec",
+    container,
+    "mkdir",
+    "-p",
+    `/workspace/${RESTORE_STAGING_DIRNAME}`,
+  ]);
+  await exec("docker", ["cp", hostBundlePath, `${container}:${dest}`]);
+  return {
+    relativePath,
+    cleanup: async () => {
+      try {
+        await exec("docker", ["exec", container, "rm", "-f", dest]);
+      } catch {
+        // Best-effort: a successful import may have swapped the workspace.
+      }
+    },
+  };
+}
+
+export async function preflightStagedBundle(
+  runtimeUrl: string,
+  accessToken: string,
+  relativePath: string,
+): Promise<Response> {
+  return loopbackSafeFetch(`${runtimeUrl}/v1/migrations/import-preflight`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ path: relativePath }),
+    signal: AbortSignal.timeout(120_000),
+  });
+}
+
+/**
+ * Import a staged bundle. The gateway JSON import path returns 202 and
+ * requires status polling; a direct daemon response of 200 is accepted too.
+ */
+export async function importStagedBundle(
+  runtimeUrl: string,
+  accessToken: string,
+  relativePath: string,
+): Promise<Response> {
+  const postImport = () =>
+    loopbackSafeFetch(`${runtimeUrl}/v1/migrations/import`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ path: relativePath }),
+      signal: AbortSignal.timeout(120_000),
+    });
+
+  let response = await postImport();
+
+  if (response.status === 202) {
+    const accepted = (await response.json()) as { job_id?: string };
+    if (!accepted.job_id) {
+      return new Response(
+        JSON.stringify({ error: "Import did not return a job_id" }),
+        { status: 502, headers: { "Content-Type": "application/json" } },
+      );
+    }
+    return pollImportJob(runtimeUrl, accessToken, accepted.job_id);
+  }
+
+  return response;
+}
+
+async function pollImportJob(
+  runtimeUrl: string,
+  accessToken: string,
+  jobId: string,
+): Promise<Response> {
+  const deadline = Date.now() + IMPORT_POLL_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    const statusResponse = await loopbackSafeFetch(
+      `${runtimeUrl}/v1/migrations/import/${jobId}/status`,
+      {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+        signal: AbortSignal.timeout(30_000),
+      },
+    );
+    if (statusResponse.status === 404) {
+      return new Response(
+        JSON.stringify({ error: `Unknown import job: ${jobId}` }),
+        { status: 404, headers: { "Content-Type": "application/json" } },
+      );
+    }
+    if (!statusResponse.ok) {
+      return statusResponse;
+    }
+
+    const job = (await statusResponse.json()) as {
+      status?: string;
+      error?: string;
+      result?: unknown;
+    };
+    if (job.status === "complete") {
+      return new Response(JSON.stringify(job.result ?? { success: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    if (job.status === "failed") {
+      return new Response(
+        JSON.stringify({
+          success: false,
+          message: job.error ?? "Import failed",
+        }),
+        { status: 500, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, IMPORT_POLL_INTERVAL_MS));
+  }
+
+  return new Response(
+    JSON.stringify({ error: "Import timed out after 60 minutes" }),
+    { status: 504, headers: { "Content-Type": "application/json" } },
+  );
+}
+
+export function bundleFileSizeBytes(path: string): number {
+  if (!existsSync(path)) {
+    return 0;
+  }
+  return statSync(path).size;
+}

--- a/cli/src/lib/upgrade-lifecycle.ts
+++ b/cli/src/lib/upgrade-lifecycle.ts
@@ -584,6 +584,7 @@ export async function attemptFailedStateRestore(opts: {
     opts.runtimeUrl,
     opts.assistantId,
     opts.backupPath,
+    { kind: "docker", assistantId: opts.assistantId },
   );
   if (!restored) {
     return { restored: false, ready: false };
@@ -1000,6 +1001,7 @@ export async function performDockerRollback(
               entry.runtimeUrl,
               entry.assistantId,
               preRollbackBackupPath,
+              { kind: "docker", assistantId: entry.assistantId },
             );
             if (restored) {
               console.log("   ✅ Data restored successfully\n");

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -3739,10 +3739,10 @@ export function buildSchema(): Record<string, unknown> {
         post: {
           summary: "Import workspace backup",
           description:
-            "Proxies a migration import request to the assistant. Two request shapes are accepted:\n" +
+            "Proxies a migration import request to the assistant. Request shapes:\n" +
             "\n" +
             "  - `application/octet-stream`: raw .vbundle body. The request is proxied synchronously and the caller's connection stays open for the full import duration (returns 200 on success).\n" +
-            '  - `application/json` with `{ "url": "<signed GCS URL>" }`: the gateway generates a jobId, kicks off the upstream assistant call in the background, and returns `202 Accepted` with `{ job_id, status: "pending" }` immediately. Callers poll `GET /v1/migrations/import/{jobId}/status` for progress.\n' +
+            '  - `application/json` with `{ "url": "<signed GCS URL>" }` or `{ "path": "<staged workspace path>" }`: the gateway generates a jobId, kicks off the upstream assistant call in the background, and returns `202 Accepted` with `{ job_id, status: "pending" }` immediately. Callers poll `GET /v1/migrations/import/{jobId}/status` for progress. The path form points at a `.vbundle` staged under the assistant workspace `.restore-staging` directory.\n' +
             "\n" +
             "Authenticated with an edge JWT. Synchronous-path timeout is 60 minutes to accommodate large 8 GB backups; the async path returns immediately.",
           operationId: "migrationImport",
@@ -3755,16 +3755,32 @@ export function buildSchema(): Record<string, unknown> {
               },
               "application/json": {
                 schema: {
-                  type: "object",
-                  required: ["url"],
-                  properties: {
-                    url: {
-                      type: "string",
-                      format: "uri",
-                      description:
-                        "Signed GCS URL pointing at a .vbundle archive.",
+                  oneOf: [
+                    {
+                      type: "object",
+                      required: ["url"],
+                      properties: {
+                        url: {
+                          type: "string",
+                          format: "uri",
+                          description:
+                            "Signed GCS URL pointing at a .vbundle archive.",
+                        },
+                      },
                     },
-                  },
+                    {
+                      type: "object",
+                      required: ["path"],
+                      properties: {
+                        path: {
+                          type: "string",
+                          minLength: 1,
+                          description:
+                            "Workspace-relative or absolute path to a staged .vbundle under .restore-staging.",
+                        },
+                      },
+                    },
+                  ],
                 },
               },
             },
@@ -3776,7 +3792,7 @@ export function buildSchema(): Record<string, unknown> {
             },
             "202": {
               description:
-                "Import accepted for async processing (JSON URL path). Poll `/v1/migrations/import/{jobId}/status` for progress.",
+                "Import accepted for async processing (JSON url or path body). Poll `/v1/migrations/import/{jobId}/status` for progress.",
               content: {
                 "application/json": {
                   schema: {
@@ -3802,7 +3818,7 @@ export function buildSchema(): Record<string, unknown> {
         get: {
           summary: "Poll async import job status",
           description:
-            "Returns the current status of an async `.vbundle` import kicked off by `POST /v1/migrations/import` with a JSON `{url}` body. Finished jobs remain queryable for 30 minutes before being pruned.",
+            "Returns the current status of an async `.vbundle` import kicked off by `POST /v1/migrations/import` with a JSON `{url}` or `{path}` body. Finished jobs remain queryable for 30 minutes before being pruned.",
           operationId: "migrationImportStatus",
           security: [{ BearerAuth: [] }],
           parameters: [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan

Implement the resolution for [#41000](https://github.com/vellum-ai/vellum-assistant/issues/41000) / EPD-2914. Local restore, `--dry-run` preflight, and upgrade failback posted the entire `.vbundle` as one `application/octet-stream` body and hit the 512 MiB gateway/assistant request cap. The issue author's chunked-upload suggestion is intentionally not used.

## Summary

- CLI copies the host backup into the assistant-visible workspace dir `.restore-staging/`, then POSTs JSON `{ path }` instead of the raw archive.
- The assistant realpaths that path and only opens a regular `.vbundle` that stays under `${workspace}/.restore-staging/`. Traversal, absolute escapes, and symlinks are rejected.
- Import streams the file through the existing `streamCommitImport` path. Preflight streams only far enough to validate the manifest, then runs `analyzeImport`.
- Local copies into `instanceDir/.vellum/workspace/.restore-staging/`. Docker uses `docker exec mkdir` + `docker cp` to `/workspace/.restore-staging/`.
- Platform/GCS restore is unchanged. Unknown topologies still use the octet-stream fallback.
- Gateway JSON import remains async (202 + poll). CLI `importStagedBundle` accepts a direct 200 or 202 + status poll.

Closes #41000
Closes EPD-2914

## CLI verb checklist

No new route. This extends the existing `POST /v1/migrations/import` and `POST /v1/migrations/import-preflight` JSON bodies. `vellum restore` and upgrade failback are the callers.

## Test plan

Ran locally:

- `cd assistant && bun test src/runtime/migrations/__tests__/staged-import-path.test.ts src/__tests__/migration-import-from-path.test.ts src/__tests__/migration-import-from-url.test.ts` (28 pass)
- `cd assistant && bun test src/__tests__/migration-import-preflight-http.test.ts src/__tests__/migration-import-commit-http.test.ts` (59 pass)
- `cd cli && bun test src/__tests__/bundle-staging.test.ts src/__tests__/backup.test.ts src/__tests__/upgrade-local.test.ts` (31 pass)
- `cd assistant && bun run typecheck:fast`
- `cd cli && bun run typecheck`
- `cd assistant && bun run generate:openapi -- --check`

## Risk

- Path allowlist is a security boundary. Review `resolveStagedImportPath` and the HTTP 400 cases (traversal, outside workspace, symlink, missing file, both `url` and `path`).
- Gateway JSON import still returns 202. Confirm CLI polling covers both direct-daemon 200 and gateway 202.
- Staging lives inside the workspace so the Docker volume can see it. A workspace swap can move the staged file; the read stream is opened first and cleanup is best-effort.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-608beb8d-68c8-4cac-9961-c0baa20b8439?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-608beb8d-68c8-4cac-9961-c0baa20b8439&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

