### PR TITLE
fix(local-mode): remint a rejected guardian on mint 401

### DIFF
--- a/cli/src/__tests__/wake.test.ts
+++ b/cli/src/__tests__/wake.test.ts
@@ -352,9 +352,9 @@ describe("vellum wake", () => {
   });
 
   test("does NOT re-provision without --repair-guardian, even when the token is missing", async () => {
-    // The automatic connect-repair path spawns `wake <id>` with no flags. A
+    // A default `wake <id>` (no flags) only restarts and sibling-seeds. A
     // re-lease here would revoke other device-bound tokens (other tabs / local
-    // clients), so it must never run from auto-repair.
+    // clients), so it stays behind `--repair-guardian`.
     process.argv = ["bun", "vellum", "wake", "local-assistant"];
     loadGuardianTokenMock.mockReturnValue(null);
 

--- a/cli/src/commands/wake.ts
+++ b/cli/src/commands/wake.ts
@@ -62,10 +62,9 @@ export async function wake(): Promise<void> {
   const foreground = args.includes("--foreground");
   // Re-leasing the guardian token calls guardian/init, which revokes every
   // other device-bound token (other tabs, other local clients on this machine).
-  // Gate it behind an explicit flag so the automatic connect-repair path
-  // (`runWake` spawns `wake <id>` with no flags) can never revoke a live session
-  // — it only ever restarts + sibling-seeds. A genuine spent-bootstrap brick is
-  // recovered deliberately via `vellum wake <id> --repair-guardian`.
+  // Gate it behind an explicit flag so a default `wake <id>` (no flags) only
+  // restarts and sibling-seeds. Callers that have a mint 401 (the on-disk
+  // guardian is rejected by the running gateway) pass `--repair-guardian`.
   const repairGuardian = args.includes("--repair-guardian");
   const nameArg = args.find((a) => !a.startsWith("-"));
   const entry = resolveTargetAssistant(nameArg);
@@ -365,18 +364,17 @@ export async function wake(): Promise<void> {
   }
 
   // Last-resort recovery (explicit `--repair-guardian` only): force a
-  // re-provision. Token health can't be judged locally — a connect can 401
+  // re-provision. Token health can't be judged locally: a connect can 401
   // off a token whose local expiry looks fine (revoked, mis-seeded, wrong
-  // principal) — and the user explicitly confirmed the destructive repair,
-  // so guessing "looks healthy, skip" just recreates the no-op loop. The
-  // single-use bootstrap secret may already be spent — a prior connect can
-  // lease a token that's then lost, or the gateway marks the secret consumed
-  // before the client persists it — which otherwise bricks connect into a
-  // 401 → auth-rate-limit → 429 cascade with no path back short of retire+hatch.
-  // Reset the gateway's bootstrap lock+consumed state (loopback-only, authorized
-  // by the lockfile secret — mirrors the macOS client's forceReBootstrap), then
-  // re-lease. Gated behind the flag because the re-lease revokes other
-  // device-bound tokens; it must never run from the automatic repair path.
+  // principal), so guessing "looks healthy, skip" recreates the no-op loop.
+  // The single-use bootstrap secret may already be spent (a prior connect
+  // leased a token that's then lost, or the gateway marked the secret
+  // consumed before the client persisted it), which otherwise bricks
+  // connect into a 401 → auth-rate-limit → 429 cascade with no path back
+  // short of retire+hatch. Reset the gateway's bootstrap lock+consumed
+  // state (loopback-only, authorized by the lockfile secret; mirrors the
+  // macOS client's forceReBootstrap), then re-lease. Gated behind the
+  // flag because the re-lease revokes other device-bound tokens.
   if (repairGuardian) {
     const loopbackUrl = `http://127.0.0.1:${resources.gatewayPort}`;
     const maxAttempts = 3;

--- a/clients/web/src/lib/api-interceptors.ts
+++ b/clients/web/src/lib/api-interceptors.ts
@@ -491,8 +491,8 @@ export function daemonUnreachableInterceptor(response: Response): Response {
  * token), re-establishes the session **in place**. Local and paired
  * assistants re-run {@link primeLocalGatewayConnectionWithRepair} with
  * `forceMint`, which mints a fresh renderer token over the rejected one,
- * wakes and re-seeds a stopped or mis-seeded local assistant when the
- * mint is repairably rejected, and re-primes the self-hosted connection
+ * wakes a stopped or mis-seeded local assistant, remints a guardian the
+ * gateway has rejected at `/auth/token`, and re-primes the self-hosted connection
  * slot the request interceptor reads. Remote-gateway (paired browser)
  * sessions run {@link refreshRemoteGatewaySession} with `force`, which
  * exchanges the refresh cookie for a new access token. Neither path

--- a/clients/web/src/lib/local-mode-repair.test.ts
+++ b/clients/web/src/lib/local-mode-repair.test.ts
@@ -24,7 +24,10 @@ mock.module("@/runtime/local-mode-host", () => ({
   wakeLocalAssistantHost: (
     id: string,
     options?: { repairGuardian?: boolean },
-  ) => wakeLocalAssistantHost(id, options),
+  ) =>
+    options === undefined
+      ? wakeLocalAssistantHost(id)
+      : wakeLocalAssistantHost(id, options),
   // The post-wake reload reads back the lockfile; serve the in-store copy so the
   // retry resolves the selected assistant rather than hitting the real host.
   loadLockfileHost: async () =>

--- a/clients/web/src/lib/local-mode-repair.test.ts
+++ b/clients/web/src/lib/local-mode-repair.test.ts
@@ -12,12 +12,19 @@ const host = await import("@/runtime/local-mode-host");
 
 let primeShouldSucceed: () => boolean;
 let fetchGuardianTokenHost = mock(async (_id: string) => "tok");
-let wakeLocalAssistantHost = mock(async (_id: string) => ({ ok: true }));
+let wakeLocalAssistantHost = mock(
+  async (_id: string, _options?: { repairGuardian?: boolean }) => ({
+    ok: true,
+  }),
+);
 
 mock.module("@/runtime/local-mode-host", () => ({
   ...host,
   fetchGuardianTokenHost: (id: string) => fetchGuardianTokenHost(id),
-  wakeLocalAssistantHost: (id: string) => wakeLocalAssistantHost(id),
+  wakeLocalAssistantHost: (
+    id: string,
+    options?: { repairGuardian?: boolean },
+  ) => wakeLocalAssistantHost(id, options),
   // The post-wake reload reads back the lockfile; serve the in-store copy so the
   // retry resolves the selected assistant rather than hitting the real host.
   loadLockfileHost: async () =>
@@ -296,8 +303,77 @@ describe("primeLocalGatewayConnectionWithRepair", () => {
     expect(err).toBeInstanceOf(GuardianTokenError);
     expect((err as InstanceType<typeof GuardianTokenError>).status).toBe(401);
     expect(wakeLocalAssistantHost).toHaveBeenCalledTimes(1);
+    expect(wakeLocalAssistantHost).toHaveBeenCalledWith("local-a");
     // One pre-wake fetch plus one terminal post-wake fetch.
     expect(fetchGuardianTokenHost).toHaveBeenCalledTimes(2);
+  });
+
+  test("a mint 401 remints the guardian, then retries and succeeds", async () => {
+    let mintAttempts = 0;
+    ensureGatewayTokenImpl = async () => {
+      if (mintAttempts++ === 0) {
+        throw new GatewayTokenError(401, "Gateway token request failed: 401");
+      }
+    };
+
+    await primeLocalGatewayConnectionWithRepair();
+
+    expect(wakeLocalAssistantHost).toHaveBeenCalledTimes(1);
+    expect(wakeLocalAssistantHost).toHaveBeenCalledWith("local-a", {
+      repairGuardian: true,
+    });
+    expect(mintAttempts).toBe(2);
+  });
+
+  test("a persistent mint 401 after a plain wake remints the guardian once", async () => {
+    let fetches = 0;
+    fetchGuardianTokenHost = mock(async (_id: string) => {
+      fetches++;
+      if (fetches === 1) {
+        throw new GuardianTokenError(503, "Assistant gateway is unreachable");
+      }
+      return "tok";
+    });
+    let reminted = false;
+    wakeLocalAssistantHost = mock(
+      async (_id: string, options?: { repairGuardian?: boolean }) => {
+        if (options?.repairGuardian === true) {
+          reminted = true;
+        }
+        return { ok: true };
+      },
+    );
+    ensureGatewayTokenImpl = async () => {
+      if (!reminted) {
+        throw new GatewayTokenError(401, "Gateway token request failed: 401");
+      }
+    };
+
+    await primeLocalGatewayConnectionWithRepair();
+
+    expect(wakeLocalAssistantHost).toHaveBeenCalledTimes(2);
+    expect(wakeLocalAssistantHost.mock.calls[0]).toEqual(["local-a"]);
+    expect(wakeLocalAssistantHost.mock.calls[1]).toEqual([
+      "local-a",
+      { repairGuardian: true },
+    ]);
+  });
+
+  test("a mint 401 that persists after remint does not remint again", async () => {
+    ensureGatewayTokenImpl = async () => {
+      throw new GatewayTokenError(401, "Gateway token request failed: 401");
+    };
+
+    const err = await primeLocalGatewayConnectionWithRepair().catch(
+      (e: unknown) => e,
+    );
+
+    expect(err).toBeInstanceOf(GatewayTokenError);
+    expect((err as InstanceType<typeof GatewayTokenError>).status).toBe(401);
+    expect(wakeLocalAssistantHost).toHaveBeenCalledTimes(1);
+    expect(wakeLocalAssistantHost).toHaveBeenCalledWith("local-a", {
+      repairGuardian: true,
+    });
   });
 });
 

--- a/clients/web/src/lib/local-mode.ts
+++ b/clients/web/src/lib/local-mode.ts
@@ -16,6 +16,7 @@ import {
   GatewayTokenError,
   getGatewayToken,
   getLocalTokenUrl,
+  isRepairableGatewayTokenError,
 } from "@/lib/auth/gateway-session";
 import { getPlatformRuntimeUrl } from "@/lib/platform-runtime-url";
 import {
@@ -1024,15 +1025,19 @@ function isGatewayStillStarting(error: unknown): boolean {
 /**
  * A `wake`-restarted gateway that hasn't finished coming back up: it refuses
  * connections (a thrown transport error), answers `503`/`5xx`, or rejects the
- * mint with a repairable `401` while it re-provisions its guardian binding.
- * A guardian refresh `5xx` is the same window: the host shells out to
+ * mint with a repairable `401` after a guardian remint, while the new binding
+ * lands. A guardian refresh `5xx` is the same window: the host shells out to
  * `vellum gateway token refresh`, which cannot reach a gateway that is still
- * binding its port. A `403` loopback-boundary refusal is terminal, and a
- * missing (`404`) or rejected (`401`) guardian token will not heal by
- * waiting (the just-run `wake` already re-seeded the token and recorded the
- * port), so those fall through.
+ * binding its port. A `403` loopback-boundary refusal is terminal. A missing
+ * (`404`) or rejected (`401`) on-disk guardian will not heal by waiting (the
+ * just-run `wake` already re-seeded the token and recorded the port). A mint
+ * `401` after a plain wake is a rejected guardian, not a starting-up mint:
+ * waiting will not remint it, so it falls through to a remint wake.
  */
-function isGatewayRestartTransient(error: unknown): boolean {
+function isGatewayRestartTransient(
+  error: unknown,
+  remintedGuardian = false,
+): boolean {
   if (error instanceof GuardianTokenError) {
     return error.status >= 500;
   }
@@ -1040,7 +1045,13 @@ function isGatewayRestartTransient(error: unknown): boolean {
     return false;
   }
   if (error instanceof GatewayTokenError) {
-    return error.status !== 403;
+    if (error.status === 403) {
+      return false;
+    }
+    if (error.status === 401 && !remintedGuardian) {
+      return false;
+    }
+    return true;
   }
   // A thrown fetch/transport error — the gateway isn't accepting connections
   // yet as it restarts.
@@ -1091,6 +1102,38 @@ export async function primeLocalGatewayConnectionWithStartupRetry(
 }
 
 /**
+ * Wake the local assistant, reload any newly recorded gateway port, then
+ * prime again while the gateway comes back up. `repairGuardian` remints the
+ * on-disk guardian against the running gateway (and revokes other
+ * device-bound tokens). After a remint the retry force-mints the renderer
+ * token so a cached actor bearer from the previous guardian cannot succeed
+ * the prime and then 401 every request.
+ */
+async function wakeLocalAssistantAndRetryPrime(
+  assistant: LockfileAssistant,
+  options: PrimeLocalGatewayConnectionOptions,
+  repairGuardian: boolean,
+): Promise<"woke" | "wake-failed"> {
+  const assistantId = assistant.assistantId;
+  const repair = repairGuardian
+    ? await wakeLocalAssistantHost(assistantId, { repairGuardian: true })
+    : await wakeLocalAssistantHost(assistantId);
+  if (!repair.ok) {
+    return "wake-failed";
+  }
+  const lockfile = await loadLockfile();
+  const refreshed = lockfile.assistants.find(
+    (a) => a.assistantId === assistantId,
+  );
+  await primeLocalGatewayWithStartupRideout(
+    refreshed ?? assistant,
+    (error) => isGatewayRestartTransient(error, repairGuardian),
+    repairGuardian ? { ...options, forceMint: true } : options,
+  );
+  return "woke";
+}
+
+/**
  * Prime the local gateway connection, transparently repairing the assistant in
  * place when the first attempt fails for a repairable reason.
  *
@@ -1098,9 +1141,12 @@ export async function primeLocalGatewayConnectionWithStartupRetry(
  * expired, or mis-seeded local assistant before the failure ever reaches the
  * user: on a repairable failure it runs `wake` (re-seeds the guardian token
  * and restarts the daemon + gateway, leaving the assistant's data and identity
- * untouched), then primes the connection once more. A non-repairable failure,
- * a wake that itself fails, or a still-failing retry propagate the original
- * error so the existing connect-error UI surfaces it unchanged.
+ * untouched), then primes the connection once more. A mint `401`
+ * ({@link isRepairableGatewayTokenError}) is a rejected on-disk guardian, so
+ * that wake remints via `--repair-guardian`. A plain wake that still 401s at
+ * the mint gets one remint follow-up. A non-repairable failure, a wake that
+ * itself fails, or a still-failing retry propagate so the existing
+ * connect-error UI surfaces it unchanged.
  */
 export async function primeLocalGatewayConnectionWithRepair(
   target?: LockfileAssistant,
@@ -1121,25 +1167,33 @@ export async function primeLocalGatewayConnectionWithRepair(
     if (!isRepairableConnectError(error)) {
       throw error;
     }
-    const assistantId = assistant.assistantId;
-    const repair = await wakeLocalAssistantHost(assistantId);
-    if (!repair.ok) {
-      throw error;
+    const remintFirst = isRepairableGatewayTokenError(error);
+    try {
+      const result = await wakeLocalAssistantAndRetryPrime(
+        assistant,
+        options,
+        remintFirst,
+      );
+      if (result === "wake-failed") {
+        throw error;
+      }
+    } catch (retryError) {
+      if (retryError === error) {
+        throw error;
+      }
+      // A plain wake left a mint that still rejects the guardian. Remint
+      // once; a remint that itself 401s falls through to the recovery UI.
+      if (remintFirst || !isRepairableGatewayTokenError(retryError)) {
+        throw retryError;
+      }
+      const remint = await wakeLocalAssistantAndRetryPrime(
+        assistant,
+        options,
+        true,
+      );
+      if (remint === "wake-failed") {
+        throw retryError;
+      }
     }
-    // Wake may have established resources the renderer hadn't recorded (a legacy
-    // entry's gateway port) — reload so the retry resolves the fresh gateway.
-    const lockfile = await loadLockfile();
-    const refreshed = lockfile.assistants.find(
-      (a) => a.assistantId === assistantId,
-    );
-    // Wake restarts the daemon + gateway, so the retry races the gateway coming
-    // back up — a single prime here fails while it is still starting and the
-    // connect dead-ends to the recovery controls. Ride out that restart window
-    // instead, so a persisted local assistant reconnects on its own.
-    await primeLocalGatewayWithStartupRideout(
-      refreshed ?? assistant,
-      isGatewayRestartTransient,
-      options,
-    );
   }
 }

--- a/clients/web/src/runtime/local-mode-host.ts
+++ b/clients/web/src/runtime/local-mode-host.ts
@@ -485,10 +485,11 @@ export async function sleepLocalAssistantHost(
  * This is the non-destructive repair primitive: it revives a stopped or
  * mis-seeded assistant in place without touching its data or identity, the
  * counterpart to {@link retireLocalAssistantHost}'s destructive removal.
- * A plain wake (no options) is the safe auto-repair primitive. Passing
- * `repairGuardian: true` re-provisions the guardian token and revokes the
- * assistant's other device-bound tokens, so it must only be passed from
- * explicitly user-confirmed flows — never from silent auto-repair paths.
+ * A plain wake (no options) restarts the assistant and sibling-seeds the
+ * guardian token. Passing `repairGuardian: true` re-provisions the guardian
+ * token and revokes the assistant's other device-bound tokens, so callers
+ * pass it only when the gateway has rejected the on-disk guardian at
+ * `/auth/token` (a mint `401`) or the user confirmed recovery.
  * Older Electron hosts that predate this IPC channel resolve `wake` as
  * `undefined`; callers treat that as a no-op repair and fall through to the
  * underlying connect error. Older preloads whose `wake` takes one parameter

--- a/packages/ipc-contract/src/bridge.ts
+++ b/packages/ipc-contract/src/bridge.ts
@@ -55,9 +55,10 @@ import type {
 
 /**
  * Options for `localMode.wake`. `repairGuardian` re-provisions a
- * missing/expired guardian token via the CLI's `--repair-guardian` — it
- * revokes the assistant's other device-bound tokens, so callers must gate it
- * behind explicit user confirmation, never silent auto-repair.
+ * rejected or missing guardian token via the CLI's `--repair-guardian`.
+ * That remint revokes the assistant's other device-bound tokens, so
+ * callers pass it only for a mint `401` or a user-confirmed recovery,
+ * never on every wake.
  */
 export interface LocalWakeOptions {
   repairGuardian?: boolean;

--- a/packages/local-mode/src/wake.ts
+++ b/packages/local-mode/src/wake.ts
@@ -15,7 +15,7 @@ export type WakeResult =
   | { ok: false; status: number; error: string };
 
 export interface WakeOptions {
-  /** Pass --repair-guardian to re-provision a missing/expired guardian token. Revokes the assistant's other device-bound tokens, so callers must gate this behind explicit user confirmation. */
+  /** Pass --repair-guardian to re-provision a rejected or missing guardian token. Revokes the assistant's other device-bound tokens, so callers pass this only for a mint 401 or a user-confirmed recovery. */
   repairGuardian?: boolean;
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan

Desktop users with a rejected on-disk guardian token saw "Failed to authenticate user" on every launch. Settings → Update and `vellum wake <id> --repair-guardian` reminted and recovered. Regular `wake` and the 0.11.4 in-place 401 recovery only restarted processes, then presented the same rejected guardian, so `/auth/token` 401'd in a loop.

This PR makes the connect-repair path do the remint automatically when the mint is a repairable `401`.

## Summary
- On a local `/auth/token` mint `401` (`invalid_signature` / `guardian_repair_required`), `primeLocalGatewayConnectionWithRepair` wakes with `--repair-guardian` instead of a plain restart.
- A plain wake that still 401s at the mint gets one remint follow-up. A remint that still 401s does not remint again.
- Boot restore still never wakes. Stopped-gateway / missing-token failures still use a plain wake. `403` is still terminal.
- After a remint, the retry force-mints the renderer token so a cached actor bearer from the previous guardian cannot "succeed" the prime and then 401 every request.

## Test plan
- [x] `cd clients/web && bun test src/lib/local-mode-repair.test.ts` (18 pass)
  - mint 401 remints once, then reconnects
  - persistent mint 401 after a plain wake remints once
  - remint that still 401s does not remint again
  - boot restore still never wakes
  - spent on-disk guardian `401` still surfaces after one plain wake (recovery dialog)
- [x] `cd cli && bun test src/__tests__/wake.test.ts` (24 pass; default wake still does not remint)

## Risk
- `--repair-guardian` calls `guardian/init` and **revokes other device-bound tokens** (other tabs / local clients for that assistant). The remint is gated on a mint `401`, not every wake, matching the already-shipping Settings → Update path.
- Review focus: the `isRepairableGatewayTokenError` gate, the one-remint-only follow-up, and that boot restore still does not spawn processes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7f77a6f-d48b-44b7-9ba0-84ac2146cc01?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7f77a6f-d48b-44b7-9ba0-84ac2146cc01&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

