### PR TITLE
fix: migration 147/148 review gaps (snapshot drift, residue-fold ordering, self-named pins)

### DIFF
--- a/assistant/src/__tests__/workspace-migration-147-strip-call-site-provider-overrides.test.ts
+++ b/assistant/src/__tests__/workspace-migration-147-strip-call-site-provider-overrides.test.ts
@@ -210,6 +210,61 @@ describe("147-strip-call-site-provider-overrides", () => {
     expect(sites.replySuggestion).toEqual({ profile: "mine" });
   });
 
+  test("a vellum-pinned winner judges servability by the managed route", () => {
+    // A 145-residue profile still carrying `provider_connection: "vellum"`
+    // routes managed (migration 148 folds it into the vellum identity), so
+    // servability is judged by the managed route, not the declared vendor.
+    writeConfig({
+      llm: {
+        profiles: {
+          residue: {
+            source: "user",
+            provider: "openai",
+            provider_connection: "vellum",
+            model: "gpt-5.5",
+          },
+        },
+        callSites: {
+          memoryExtraction: { profile: "residue", model: "gemini-2.5-pro" },
+          conversationTitle: { profile: "residue", model: "not-a-real-model" },
+        },
+      },
+    });
+
+    run();
+
+    // The managed route serves the gemini model: kept.
+    expect(readCallSites().memoryExtraction.model).toBe("gemini-2.5-pro");
+    // A model the managed route cannot serve still deletes: the vellum
+    // winner is judged, not treated as indeterminate.
+    expect(readCallSites()).not.toHaveProperty("conversationTitle");
+  });
+
+  test("a vellum pin the identity cannot serve judges the declared vendor", () => {
+    // Migration 148 refuses the fold when the profile's own model is not
+    // vellum-routable (the pin drops and the declared provider stays), so
+    // the tweak is judged against that vendor.
+    writeConfig({
+      llm: {
+        profiles: {
+          refused: {
+            source: "user",
+            provider: "openai",
+            provider_connection: "vellum",
+            model: "claude-ancient-1",
+          },
+        },
+        callSites: {
+          memoryExtraction: { profile: "refused", model: "gemini-2.5-pro" },
+        },
+      },
+    });
+
+    run();
+
+    expect(readCallSites()).not.toHaveProperty("memoryExtraction");
+  });
+
   test("an entry-name winner is judged through its connection row", () => {
     seedRows([{ name: "my-openai", provider: "openai" }]);
     writeConfig({

--- a/assistant/src/__tests__/workspace-migration-148-delete-provider-connection-residue.test.ts
+++ b/assistant/src/__tests__/workspace-migration-148-delete-provider-connection-residue.test.ts
@@ -111,6 +111,60 @@ describe("148-delete-provider-connection-residue", () => {
     expect(work.model).toBe("claude-opus-4-8");
   });
 
+  test("folds a vellum binding carrying the dated DeepSeek id migration 146 writes", () => {
+    // Migration 146 (which runs first) rewrites the undated Fireworks
+    // DeepSeek flash id to the dated one, so this is the form the fold sees.
+    seedRows([{ name: "vellum", provider: "vellum" }]);
+    writeConfig({
+      llm: {
+        profiles: {
+          deepseek: {
+            provider: "fireworks",
+            provider_connection: "vellum",
+            model: "accounts/fireworks/models/deepseek-v4-flash-0731",
+          },
+        },
+      },
+    });
+
+    run();
+
+    const deepseek = readProfiles().deepseek;
+    expect(deepseek.provider).toBe("vellum");
+    expect(deepseek).not.toHaveProperty("provider_connection");
+    expect(deepseek.model).toBe(
+      "accounts/fireworks/models/deepseek-v4-flash-0731",
+    );
+  });
+
+  test("deletes a self-named pin shadowed by the conventional row", () => {
+    // With both the self-named row and `<provider>-personal` present,
+    // bare-vendor dispatch prefers the conventional row, so the delete is
+    // recorded with reason "self_named_binding_shadowed"; the field is
+    // schema-dead and dropped either way.
+    seedRows([
+      { name: "anthropic", provider: "anthropic" },
+      { name: "anthropic-personal", provider: "anthropic" },
+    ]);
+    writeConfig({
+      llm: {
+        profiles: {
+          pinned: {
+            provider: "anthropic",
+            provider_connection: "anthropic",
+            model: "claude-opus-4-8",
+          },
+        },
+      },
+    });
+
+    run();
+
+    const pinned = readProfiles().pinned;
+    expect(pinned.provider).toBe("anthropic");
+    expect(pinned).not.toHaveProperty("provider_connection");
+  });
+
   test("folds a self-named pin (the entry name is the vendor)", () => {
     seedRows([
       { name: "anthropic", provider: "anthropic" },

--- a/assistant/src/workspace/migrations/147-strip-call-site-provider-overrides.ts
+++ b/assistant/src/workspace/migrations/147-strip-call-site-provider-overrides.ts
@@ -412,7 +412,10 @@ function winnerProviderForSite(
 
 /**
  * A named rung's provider: the profile's own provider when it is plainly
- * usable, the intent column for default-key names with no workspace entry
+ * usable (judged as the vellum identity when the profile pins the managed
+ * "vellum" connection and its model is vellum-routable, mirroring
+ * migration 148's fold), the intent column for default-key names with no
+ * workspace entry
  * (or an explicitly managed stub, which the resolver overrides with the
  * code-owned body), "fall_through" when the name resolves to nothing, and
  * null when the outcome cannot be determined. A user-owned workspace entry
@@ -435,11 +438,25 @@ function rungProvider(
     // A mix winner's arm is a seeded pick this migration does not reproduce.
     return null;
   }
+  const model = asNonEmptyString(entry.model);
   const usableProvider =
-    entry.status !== "disabled" && asNonEmptyString(entry.model) !== null
+    entry.status !== "disabled" && model !== null
       ? asNonEmptyString(entry.provider)
       : null;
   if (usableProvider !== null) {
+    // A profile still carrying a `provider_connection` pin on the managed
+    // "vellum" connection routes managed: migration 148 (which runs next)
+    // folds the pin into the vellum identity when the profile's model is
+    // vellum-routable. Servability is judged by that post-fold winner, not
+    // the declared vendor, so this pass never deletes a tweak the managed
+    // route serves.
+    if (
+      entry.provider_connection === "vellum" &&
+      model !== null &&
+      VELLUM_ROUTABLE_MODELS.has(model)
+    ) {
+      return "vellum";
+    }
     return usableProvider;
   }
   // A managed stub of a default key is overridden by the code-owned intent

--- a/assistant/src/workspace/migrations/148-delete-provider-connection-residue.ts
+++ b/assistant/src/workspace/migrations/148-delete-provider-connection-residue.ts
@@ -30,8 +30,14 @@ const log = getLogger("migrations/148-delete-provider-connection-residue");
 //   end state: the field is deleted with a structured warn
 //   `{ profile, provider, binding, reason: "dangling_binding_dropped" }`
 //   and the entry keeps its declared provider.
-// - A binding equal to the declared provider is a plain delete: the bare
-//   vendor value already means the default entry of that kind.
+// - A binding equal to the declared provider is deleted: the bare vendor
+//   value already means the default entry of that kind. Bare-vendor
+//   dispatch auto-resolves convention-first (`<provider>-personal`
+//   outranks a row named exactly the vendor), so when BOTH rows exist the
+//   pin's row is not the one dispatch picks; the delete then logs a
+//   structured warn with reason "self_named_binding_shadowed" so the
+//   cohort is identifiable. With no conventional sibling the delete is
+//   lossless (auto-resolve's second preference is the self-named row).
 //
 // With bindings to judge, an unreadable or unqueryable connection table
 // DEFERS the run (failed checkpoint, retried next boot) instead of
@@ -42,8 +48,8 @@ const log = getLogger("migrations/148-delete-provider-connection-residue");
 // Idempotent: a config without the field is untouched. Forward-only.
 //
 // The identity mapping, managed-routable set, and identity model tables are
-// frozen snapshots (migrations are self-contained), copied from migration
-// 145 (as of 2026-08-10).
+// frozen snapshots (migrations are self-contained) of the routing tables as
+// of 2026-08-20, matching migration 147's snapshots.
 
 const ROUTING_IDENTITIES = new Set(["vellum", "chatgpt"]);
 const MANAGED_ROUTABLE = new Set([
@@ -91,7 +97,10 @@ const VELLUM_ROUTABLE_MODELS = new Set([
   "accounts/fireworks/models/minimax-m3",
   "accounts/fireworks/models/minimax-m2p7",
   "accounts/fireworks/models/deepseek-v4-pro",
+  // Migration 146 (which runs first) rewrites the undated DeepSeek flash id
+  // to the dated one; both are listed so either form folds.
   "accounts/fireworks/models/deepseek-v4-flash",
+  "accounts/fireworks/models/deepseek-v4-flash-0731",
   "MiniMaxAI/MiniMax-M3",
 ]);
 const CODEX_MODELS = new Set([
@@ -192,10 +201,22 @@ export const deleteProviderConnectionResidueMigration: WorkspaceMigration = {
       }
 
       if (binding === provider) {
-        log.info(
-          { profile: key, provider },
-          "Deleted self-referential binding (bare vendor means the default entry)",
-        );
+        if (rows.has(binding) && rows.has(`${provider}-personal`)) {
+          log.warn(
+            {
+              profile: key,
+              provider,
+              binding,
+              reason: "self_named_binding_shadowed",
+            },
+            "Deleted self-named binding; bare-vendor dispatch prefers the conventional row over the row this pin named",
+          );
+        } else {
+          log.info(
+            { profile: key, provider },
+            "Deleted self-referential binding (bare vendor means the default entry)",
+          );
+        }
         continue;
       }
 


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for conn-removal-13b-step4-demolition.md.

**Gap A:** 148's frozen vellum model set missed the dated DeepSeek id migration 146 rewrites to; managed bindings were dropped instead of folded.
**Gap C:** 147 judged 145-residue winners by provider only, deleting call-site tweaks 148's vellum fold would have made servable.
**Gap D:** self-named binding deletion audited against the dispatch ladder (see PR body for verdict).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41120" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->