### PR TITLE
fix: review gaps (mix determinism, config-set fold, underivable-row repair, hygiene)

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -4831,9 +4831,9 @@ paths:
       operationId: config_llm_defaultprovider_get
       summary: Get the default provider and its availability
       description:
-        Returns `llm.defaultProvider`, the connection name it conventionally resolves to, and whether that
+        "Returns `llm.defaultProvider`, the connection name it conventionally resolves to, and whether that
         connection is currently usable (connection exists, credential stored, Vellum authenticated). Availability is
-        informational — a broken default is a valid persisted state that surfaces explainable errors at resolution time.
+        informational: a broken default is a valid persisted state that surfaces explainable errors at resolution time."
       tags:
         - config
       responses:
@@ -4847,9 +4847,9 @@ paths:
       operationId: config_llm_defaultprovider_put
       summary: Set the default provider
       description:
-        Replaces `llm.defaultProvider`. Strict-validates the body (unlike the generic config write paths, which
-        silently drop invalid values). Does not require the conventionally resolved connection to exist — a dangling
-        name is allowed by design and reported via the availability status.
+        "Replaces `llm.defaultProvider`. Strict-validates the body (unlike the generic config write paths, which
+        silently drop invalid values). Does not require the conventionally resolved connection to exist: a dangling name
+        is allowed by design and reported via the availability status."
       tags:
         - config
       requestBody:

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -627,10 +627,15 @@ let mockConversationErrorClassification = {
   retryable: false,
   errorCategory: "processing_failed",
 };
+// Captures the context passed to the real classifier so attribution tests
+// can assert what the loop derived (the mock discards it otherwise).
+let lastClassifyErrorCtx: Record<string, unknown> | undefined;
 
 mock.module("../daemon/conversation-error.js", () => ({
-  classifyConversationError: (_err: unknown, _ctx: unknown) =>
-    mockConversationErrorClassification,
+  classifyConversationError: (_err: unknown, ctx: unknown) => {
+    lastClassifyErrorCtx = ctx as Record<string, unknown>;
+    return mockConversationErrorClassification;
+  },
   isUserCancellation: (err: unknown, ctx: { aborted?: boolean }) => {
     if (!ctx.aborted) {
       return false;
@@ -688,6 +693,10 @@ import {
 } from "../daemon/conversation-agent-loop.js";
 import type { QueueDrainReason } from "../daemon/conversation-queue-manager.js";
 import { settleTurnTail } from "../daemon/turn-tail-chain.js";
+import { getDb } from "../persistence/db-connection.js";
+import { initializeDb } from "../persistence/db-init.js";
+import { providerConnections } from "../persistence/schema/inference.js";
+import { createConnection } from "../providers/inference/connections.js";
 import { asConversation } from "./helpers/mock-conversation.js";
 import {
   createMockProvider,
@@ -973,6 +982,7 @@ beforeEach(() => {
     retryable: false,
     errorCategory: "processing_failed",
   };
+  lastClassifyErrorCtx = undefined;
   indexMessageNowMock.mockClear();
   projectAssistantMessageMock.mockClear();
   publishSyncInvalidationMock.mockClear();
@@ -1981,6 +1991,42 @@ describe("session-agent-loop", () => {
         type: "conversation_error",
         code: "CONVERSATION_PROCESSING_FAILED",
         errorCategory: "processing_failed",
+      });
+    });
+
+    test("error attribution auto-resolves the connection for a bare-vendor winner", async () => {
+      await initializeDb();
+      getDb().delete(providerConnections).run();
+      createConnection(getDb(), {
+        name: "anthropic-personal",
+        provider: "anthropic",
+        auth: { type: "api_key", credential: "credential/anthropic/api_key" },
+      });
+      seedLlmConfig({
+        profiles: {
+          ...disabledCatalogDefaultProfiles,
+          bare: {
+            source: "user",
+            provider: "anthropic",
+            model: "claude-opus-4-8",
+          },
+        },
+        activeProfile: "bare",
+      });
+
+      const ctx = makeCtx({
+        loopProvider: {
+          name: "mock-provider",
+          async sendMessage() {
+            throw new Error("provider exploded");
+          },
+        } as unknown as Provider,
+      });
+      await runAgentLoopImpl(ctx, "hi", "msg-1", () => {});
+
+      expect(lastClassifyErrorCtx).toMatchObject({
+        connectionName: "anthropic-personal",
+        profileName: "bare",
       });
     });
 

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -53,6 +53,7 @@ import {
   updateConversationSlackContextWatermark,
 } from "../persistence/conversation-crud.js";
 import { isReplaceableTitle } from "../persistence/conversation-title-service.js";
+import { getDb } from "../persistence/db-connection.js";
 import {
   backfillMessageIdOnLogs,
   recordSyntheticAgentErrorMessageLog,
@@ -61,11 +62,13 @@ import { HOOKS } from "../plugin-api/constants.js";
 import type { ConversationGraphMemory } from "../plugins/defaults/memory/graph/conversation-graph-memory.js";
 import { enqueueMemoryRetrospectiveOnCompaction } from "../plugins/defaults/memory/memory-retrospective-enqueue.js";
 import { runHook } from "../plugins/pipeline.js";
+import { pickAutoResolvedConnection } from "../providers/connection-model-compat.js";
 import {
   dispatchProviderResolvable,
   isManagedConnectionRoute,
   resolveEntryConnectionName,
 } from "../providers/connection-resolution.js";
+import { listConnections } from "../providers/inference/connections.js";
 import {
   ConnectionResolutionError,
   resolveRoutingIdentity,
@@ -534,6 +537,14 @@ export async function runAgentLoopImpl(
       // dispatch-side translation.
       connectionName ??=
         resolveEntryConnectionName(resolved.provider) ?? undefined;
+      // A bare vendor auto-resolves to a row, matching dispatch's rung, so
+      // the now-typical connection-less profile still names the row that
+      // served the request.
+      connectionName ??= pickAutoResolvedConnection(
+        listConnections(getDb(), { provider: resolved.provider }),
+        resolved.provider,
+        resolved.model,
+      )?.name;
       // Managed-ness comes from the connection row, matching what dispatch
       // decides. The profile's own provider can't stand in: a concrete
       // provider tweak over a managed winner keeps the managed connection

--- a/assistant/src/providers/inference/connections.ts
+++ b/assistant/src/providers/inference/connections.ts
@@ -164,6 +164,29 @@ export function getConnection(
   };
 }
 
+/**
+ * The raw name and provider column of a stored row, bypassing auth
+ * derivation. Exists for the delete repair path: a row whose stored auth
+ * payload is underivable (`parseAuth` returns null) is invisible to
+ * list/get but still occupies its name, so DELETE must be able to see and
+ * remove it.
+ */
+export function getConnectionRowRaw(
+  db: DrizzleDb,
+  name: string,
+): { name: string; provider: string } | null {
+  return (
+    db
+      .select({
+        name: providerConnections.name,
+        provider: providerConnections.provider,
+      })
+      .from(providerConnections)
+      .where(eq(providerConnections.name, name))
+      .get() ?? null
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Write
 // ---------------------------------------------------------------------------

--- a/assistant/src/providers/model-intents.ts
+++ b/assistant/src/providers/model-intents.ts
@@ -1,5 +1,4 @@
 import { isModelInCatalog, PROVIDER_CATALOG } from "./model-catalog.js";
-import { isCodexSubscriptionModel } from "./openai/codex-models.js";
 import type { ModelIntent } from "./types.js";
 
 /**
@@ -89,23 +88,6 @@ for (const [provider, intents] of Object.entries(PROVIDER_MODEL_INTENTS)) {
           `which is not in PROVIDER_CATALOG. Update model-catalog.ts or model-intents.ts.`,
       );
     }
-  }
-}
-
-// The openai column must additionally stay inside the ChatGPT Codex
-// subscription set: the subscription default provider is stored as
-// `llm.defaultProvider = { provider: "openai", connectionName:
-// "chatgpt-subscription" }`, so the materialized default profiles resolve
-// through this column while pinning the subscription connection, which
-// bypasses the auto-resolution compat gate and hard-routes to the Codex
-// endpoint, where a non-Codex model 400s on every request.
-for (const [intent, modelId] of Object.entries(PROVIDER_MODEL_INTENTS.openai)) {
-  if (!isCodexSubscriptionModel(modelId)) {
-    throw new Error(
-      `PROVIDER_MODEL_INTENTS[openai][${intent}] references model "${modelId}" ` +
-        `which the ChatGPT subscription cannot serve. Pick a model from ` +
-        `CODEX_SUBSCRIPTION_MODEL_IDS in openai/codex-models.ts.`,
-    );
   }
 }
 

--- a/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
@@ -1449,6 +1449,96 @@ describe("PATCH profile entries fold the legacy provider_connection", () => {
   });
 });
 
+describe("SET profile writes fold the legacy provider_connection", () => {
+  const configSetRoute = ROUTES.find((r) => r.operationId === "config_set")!;
+
+  const savedProfiles = () =>
+    (
+      loadRawConfig().llm as {
+        profiles?: Record<string, Record<string, unknown>>;
+      }
+    ).profiles ?? {};
+
+  beforeEach(() => {
+    getDb().delete(providerConnections).run();
+    rawConfigFixture = {
+      llm: {
+        profiles: {
+          mine: {
+            source: "user",
+            provider: "openai",
+            model: "gpt-5.5",
+          },
+        },
+      },
+    };
+    seedRawConfig();
+  });
+
+  test("an object set containing a verified binding folds it", async () => {
+    createConnection(getDb(), {
+      name: "personal-openai",
+      provider: "openai",
+      auth: { type: "api_key", credential: "credential/openai/api_key" },
+    });
+    await configSetRoute.handler({
+      body: {
+        path: "llm.profiles.mine",
+        value: {
+          source: "user",
+          provider: "openai",
+          provider_connection: "personal-openai",
+          model: "gpt-5.5",
+        },
+      },
+    });
+    const saved = savedProfiles().mine!;
+    expect(saved.provider).toBe("personal-openai");
+    expect(saved).not.toHaveProperty("provider_connection");
+  });
+
+  test("a leaf set of a verified binding folds into provider", async () => {
+    createConnection(getDb(), {
+      name: "personal-openai",
+      provider: "openai",
+      auth: { type: "api_key", credential: "credential/openai/api_key" },
+    });
+    await configSetRoute.handler({
+      body: {
+        path: "llm.profiles.mine.provider_connection",
+        value: "personal-openai",
+      },
+    });
+    const saved = savedProfiles().mine!;
+    expect(saved.provider).toBe("personal-openai");
+    expect(saved).not.toHaveProperty("provider_connection");
+  });
+
+  test("a leaf set of a dangling binding is rejected loudly, config untouched", async () => {
+    await expect(
+      configSetRoute.handler({
+        body: {
+          path: "llm.profiles.mine.provider_connection",
+          value: "deleted-row",
+        },
+      }),
+    ).rejects.toThrow(/Connection "deleted-row" does not exist/);
+    const saved = savedProfiles().mine!;
+    expect(saved.provider).toBe("openai");
+    expect(saved).not.toHaveProperty("provider_connection");
+  });
+
+  test("a leaf set of null (cleared binding) is a no-op with no residue", async () => {
+    const result = await configSetRoute.handler({
+      body: { path: "llm.profiles.mine.provider_connection", value: null },
+    });
+    expect(result).toEqual({ ok: true });
+    const saved = savedProfiles().mine!;
+    expect(saved.provider).toBe("openai");
+    expect(saved).not.toHaveProperty("provider_connection");
+  });
+});
+
 describe("call-site override writes stay sparse", () => {
   const configPatchRoute = ROUTES.find(
     (r) => r.operationId === "config_patch",
@@ -1788,6 +1878,65 @@ describe("call-site model writes are validated against the winning route", () =>
     expect(llm.callSites?.conversationSummarization?.model).toBe(
       "gpt-5.4-mini",
     );
+  });
+
+  // Mix winners expand via an unseeded random arm pick per resolution, so
+  // any judgment would be against a nondeterministic route; the loops catch
+  // a regression that only misjudges on some arm picks.
+  const mixedProfiles = {
+    op: { source: "user", provider: "openai", model: "gpt-5.5" },
+    an: { source: "user", provider: "anthropic", model: "claude-opus-4-8" },
+    ab: {
+      source: "user",
+      label: "A/B",
+      mix: [
+        { profile: "op", weight: 1 },
+        { profile: "an", weight: 1 },
+      ],
+    },
+  };
+
+  test("a call-site model write under a mix winner always saves", async () => {
+    for (let i = 0; i < 20; i += 1) {
+      rawConfigFixture = {
+        llm: {
+          profiles: structuredClone(mixedProfiles),
+          callSites: { memoryExtraction: { profile: "ab" } },
+        },
+      };
+      seedRawConfig();
+      await configPatchRoute.handler({
+        body: {
+          llm: { callSites: { memoryExtraction: { model: "gpt-5.4-nano" } } },
+        },
+      });
+      const llm = loadRawConfig().llm as {
+        callSites?: Record<string, Record<string, unknown>>;
+      };
+      expect(llm.callSites?.memoryExtraction?.model).toBe("gpt-5.4-nano");
+    }
+  });
+
+  test("an unrelated save under a mix winner never rejects", async () => {
+    rawConfigFixture = {
+      llm: {
+        profiles: structuredClone(mixedProfiles),
+        callSites: {
+          memoryExtraction: { profile: "ab", model: "gpt-5.4-nano" },
+        },
+      },
+    };
+    seedRawConfig();
+    for (let i = 0; i < 20; i += 1) {
+      await configPatchRoute.handler({
+        body: { llm: { callSites: { recall: { maxTokens: 512 + i } } } },
+      });
+    }
+    const llm = loadRawConfig().llm as {
+      callSites?: Record<string, Record<string, unknown>>;
+    };
+    expect(llm.callSites?.recall?.maxTokens).toBe(531);
+    expect(llm.callSites?.memoryExtraction?.model).toBe("gpt-5.4-nano");
   });
 });
 

--- a/assistant/src/runtime/routes/__tests__/inference-provider-connection-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/inference-provider-connection-routes.test.ts
@@ -1091,6 +1091,79 @@ describe("DELETE inference/provider-connections/:name (delete)", () => {
   });
 });
 
+// ── Underivable rows (auth payload the typed loader cannot derive) ───────────
+
+describe("DELETE repairs a row whose stored auth is underivable", () => {
+  // A keyed provider with no credential payload derives no auth
+  // (`parseAuth` returns null), e.g. a legacy `auth: {type: "none"}` row
+  // stripped to `{}` by migration 367.
+  beforeEach(() => {
+    seedConnection({ name: "zombie", provider: "anthropic", auth: {} });
+  });
+
+  test("list and get exclude the row", async () => {
+    const result = (await call(
+      findHandler("inference_provider_connections_list"),
+      {},
+    )) as { connections: { name: string }[] };
+    expect(result.connections.map((c) => c.name)).not.toContain("zombie");
+    await expect(
+      call(findHandler("inference_provider_connections_get"), {
+        pathParams: { name: "zombie" },
+      }),
+    ).rejects.toBeInstanceOf(NotFoundError);
+  });
+
+  test("DELETE succeeds and frees the name for re-create", async () => {
+    const result = (await call(
+      findHandler("inference_provider_connections_delete"),
+      { pathParams: { name: "zombie" } },
+    )) as { ok: boolean };
+    expect(result.ok).toBe(true);
+
+    const recreated = (await call(
+      findHandler("inference_provider_connections_create"),
+      {
+        body: {
+          name: "zombie",
+          provider: "anthropic",
+          auth: { type: "api_key", credential: "vault/anthropic/key" },
+        },
+      },
+    )) as { name: string };
+    expect(recreated.name).toBe("zombie");
+  });
+
+  test("a profile reference still blocks the delete", async () => {
+    setConfig("llm", {
+      profiles: { "my-profile": { provider: "zombie" } },
+    });
+    await expect(
+      call(findHandler("inference_provider_connections_delete"), {
+        pathParams: { name: "zombie" },
+      }),
+    ).rejects.toBeInstanceOf(ConflictError);
+  });
+
+  test("DELETE proceeds even when the default provider resolves to the name", async () => {
+    // The default is already broken (resolution cannot load the row), so
+    // the orphan guard must not block the one repair path.
+    clearConnections();
+    seedConnection({
+      name: "anthropic-personal",
+      provider: "anthropic",
+      auth: {},
+    });
+    setConfig("llm", { defaultProvider: { provider: "anthropic" } });
+
+    const result = (await call(
+      findHandler("inference_provider_connections_delete"),
+      { pathParams: { name: "anthropic-personal" } },
+    )) as { ok: boolean };
+    expect(result.ok).toBe(true);
+  });
+});
+
 // ── llm.defaultProvider guard ─────────────────────────────────────────────────
 
 describe("DELETE guards the llm.defaultProvider reference", () => {

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -1485,8 +1485,11 @@ function assertServableCallSiteModels(
     readPlainObject(readPlainObject(preWrite.llm)?.callSites) ?? {};
 
   interface RouteFingerprint {
-    /** The winner's raw provider value (entry names untranslated). */
-    provider: string;
+    /**
+     * The winner's raw provider value (entry names untranslated). Null =
+     * indeterminate (a mix winner).
+     */
+    provider: string | null;
     /**
      * The kind the route is judged by: a vendor provider value verbatim,
      * otherwise the entry-name row's provider column, so an identity row
@@ -1499,7 +1502,14 @@ function assertServableCallSiteModels(
     llm: z.infer<typeof LLMSchema>,
     site: LLMCallSite,
   ): RouteFingerprint => {
-    const { config } = resolveCallSiteConfigWithProfile(site, llm);
+    const { config, profileName } = resolveCallSiteConfigWithProfile(site, llm);
+    // A mix winner expands to a random arm on every unseeded resolution
+    // here, so its route cannot be fingerprinted: any judgment would be
+    // against a nondeterministic arm. Indeterminate, like the other
+    // fail-open cases.
+    if (profileName != null && llm.profiles?.[profileName]?.mix != null) {
+      return { provider: null, kind: null };
+    }
     const kind = (VALID_CONNECTION_PROVIDERS as readonly string[]).includes(
       config.provider,
     )
@@ -1775,6 +1785,33 @@ async function handleSetConfig({ body }: RouteHandlerArgs) {
   rejectMcpTransportHeaderWrite(patchShape);
 
   const raw = loadRawConfig();
+  // The deprecated `provider_connection` binding folds here like PATCH:
+  // the pin becomes the entry's `provider` or the write is rejected loudly
+  // (never silently dropped). An object-shape SET (`llm`, `llm.profiles`,
+  // an entry) is covered by reference: the fold mutates the same object
+  // `setNestedValue` writes below. A leaf SET of the key itself bypasses
+  // that object, so its write is redirected to the folded result.
+  foldDeprecatedProfileBindings(patchShape, raw);
+  let writePath = path;
+  let writeValue = value;
+  if (
+    pathSegments[0] === "llm" &&
+    pathSegments[1] === "profiles" &&
+    pathSegments.length >= 4 &&
+    pathSegments[3] === "provider_connection"
+  ) {
+    const folded = readPlainObject(
+      readPlainObject(readPlainObject(patchShape.llm)?.profiles)?.[
+        pathSegments[2]!
+      ],
+    );
+    if (typeof folded?.provider !== "string") {
+      // A null/empty clear of a field that no longer exists: a no-op.
+      return { ok: true };
+    }
+    writePath = `llm.profiles.${pathSegments[2]}.provider`;
+    writeValue = folded.provider;
+  }
   // A SET below the entry level (`llm.profiles.<name>.<leaf>`) writes the
   // primitive leaf directly into `raw`, bypassing the by-reference
   // normalization above — creating an entry for a managed-owned name would
@@ -1793,7 +1830,7 @@ async function handleSetConfig({ body }: RouteHandlerArgs) {
         readPlainObject(readPlainObject(raw.llm)?.profiles)?.[managedEntryName],
       )
     : undefined;
-  setNestedValue(raw, path, value);
+  setNestedValue(raw, writePath, writeValue);
   if (
     managedEntryName &&
     (priorManagedEntry == null || priorManagedEntry.source === "managed")

--- a/assistant/src/runtime/routes/default-provider-routes.ts
+++ b/assistant/src/runtime/routes/default-provider-routes.ts
@@ -107,7 +107,7 @@ export const ROUTES: RouteDefinition[] = [
     handler: handleGetDefaultProvider,
     summary: "Get the default provider and its availability",
     description:
-      "Returns `llm.defaultProvider`, the connection name it conventionally resolves to, and whether that connection is currently usable (connection exists, credential stored, Vellum authenticated). Availability is informational — a broken default is a valid persisted state that surfaces explainable errors at resolution time.",
+      "Returns `llm.defaultProvider`, the connection name it conventionally resolves to, and whether that connection is currently usable (connection exists, credential stored, Vellum authenticated). Availability is informational: a broken default is a valid persisted state that surfaces explainable errors at resolution time.",
     tags: ["config"],
     responseBody: defaultProviderStatusSchema,
   },
@@ -122,7 +122,7 @@ export const ROUTES: RouteDefinition[] = [
     handler: handlePutDefaultProvider,
     summary: "Set the default provider",
     description:
-      "Replaces `llm.defaultProvider`. Strict-validates the body (unlike the generic config write paths, which silently drop invalid values). Does not require the conventionally resolved connection to exist — a dangling name is allowed by design and reported via the availability status.",
+      "Replaces `llm.defaultProvider`. Strict-validates the body (unlike the generic config write paths, which silently drop invalid values). Does not require the conventionally resolved connection to exist: a dangling name is allowed by design and reported via the availability status.",
     tags: ["config"],
     requestBody: DefaultProviderSchema,
     responseBody: defaultProviderStatusSchema,

--- a/assistant/src/runtime/routes/inference-provider-connection-routes.ts
+++ b/assistant/src/runtime/routes/inference-provider-connection-routes.ts
@@ -34,6 +34,7 @@ import {
   createConnection,
   deleteConnection,
   getConnection,
+  getConnectionRowRaw,
   LEGACY_MANAGED_CONNECTION_NAMES,
   listConnections,
   MANAGED_CONNECTION_NAMES,
@@ -570,7 +571,14 @@ async function handleDeleteConnection({ pathParams = {} }: RouteHandlerArgs) {
   // Existence check first so a stale profile reference to a missing
   // connection returns 404 (not 409).
   const existing = getConnection(getDb(), name);
-  if (!existing) {
+  // A row whose stored auth payload is underivable (`parseAuth` returns
+  // null) is hidden by the typed loader but still occupies its name;
+  // DELETE is the one repair path, so fall through to the raw row and run
+  // the guards below on it. Such a row can never be the managed row (the
+  // managed row's auth always derives), cannot be routed through, and
+  // carries no credential slot to clean up.
+  const rawRow = existing ?? getConnectionRowRaw(getDb(), name);
+  if (!rawRow) {
     throw new NotFoundError(`Connection "${name}" not found.`);
   }
 
@@ -585,7 +593,8 @@ async function handleDeleteConnection({ pathParams = {} }: RouteHandlerArgs) {
   // managed routing ignores. That row must stay deletable, since deleting it
   // is what lets boot seeding restore the real managed connection.
   const claimsManagedName =
-    MANAGED_CONNECTION_NAMES.has(name) && !isVellumManagedConnection(existing);
+    MANAGED_CONNECTION_NAMES.has(name) &&
+    (existing == null || !isVellumManagedConnection(existing));
   if (MANAGED_CONNECTION_NAMES.has(name) && !claimsManagedName) {
     throw new BadRequestError(
       `Cannot delete managed connection "${name}". This is a Vellum-managed connection that is re-seeded on every startup.`,
@@ -605,8 +614,10 @@ async function handleDeleteConnection({ pathParams = {} }: RouteHandlerArgs) {
   // A `vellum` default resolves to the canonical name, so this guard would
   // otherwise block deleting a row that merely claims that name. Deleting it
   // does not orphan the default: boot seeding writes the real managed
-  // connection under the same name on the next restart.
-  if (dp && !claimsManagedName) {
+  // connection under the same name on the next restart. An underivable row
+  // (existing == null) is skipped for the same reason: a default resolving
+  // to it is already broken, and delete + re-create is the repair.
+  if (dp && !claimsManagedName && existing != null) {
     if (name === resolveDefaultConnectionName(dp)) {
       throw new ConflictError(
         `Connection "${name}" is referenced by llm.defaultProvider. Update llm.defaultProvider before deleting.`,
@@ -614,7 +625,7 @@ async function handleDeleteConnection({ pathParams = {} }: RouteHandlerArgs) {
       );
     }
     if (
-      existing.provider === dp.provider &&
+      rawRow.provider === dp.provider &&
       listConnections(getDb(), { provider: dp.provider }).filter(
         (c) => !LEGACY_MANAGED_CONNECTION_NAMES.has(c.name),
       ).length === 1
@@ -668,7 +679,7 @@ async function handleDeleteConnection({ pathParams = {} }: RouteHandlerArgs) {
   // are logged, never surfaced: a vault outage leaves an orphaned secret,
   // not a failed delete (the timeout on vault calls bounds the wait).
   if (
-    existing.auth.type === "api_key" &&
+    existing?.auth.type === "api_key" &&
     existing.auth.credential === credentialKey(name, "api_key")
   ) {
     try {

--- a/clients/web/src/assistant/llm-model-catalog.ts
+++ b/clients/web/src/assistant/llm-model-catalog.ts
@@ -1041,12 +1041,6 @@ export const ALL_CATALOG_MODELS = dedupedModelUnion(
 );
 
 /**
- * The managed upstream that serves a model picked under the Vellum entry —
- * the first VELLUM_SERVED_PROVIDERS member whose catalog lists the id. Used
- * at profile-save time to derive the wire-shape provider for
- * provider_connection: "vellum" profiles.
- */
-/**
  * Decode a `<provider>/<model>` Vellum routing string (mirrors the daemon's
  * parseVellumModel): the prefix names the upstream, the remainder is the
  * upstream's native model id. Null for anything else.


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for conn-removal-13b-step4-demolition.md.

**Gap B:** mix winners are now indeterminate in write-time call-site validation (was an unseeded random arm pick).
**Gap F:** config set now runs the deprecated-binding fold; pins can no longer be silently dropped.
**Gap E:** DELETE can remove connection rows whose stored auth is underivable (no more invisible occupied names).
**Gap I:** error attribution gains the auto-resolve rung for bare-vendor profiles.
**Gap G:** em dashes in default-provider API descriptions, stale model-intents rationale, orphaned web JSDoc.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41121" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->