### PR TITLE
fix(web): declare the injected assistant id and refresh the self-hosted pairing doc

### DIFF
--- a/clients/web/src/env.d.ts
+++ b/clients/web/src/env.d.ts
@@ -81,6 +81,8 @@ interface Window {
     platformUrl?: string;
     /** Serving assistant's display name (remote-web ingress configs only). */
     assistantName?: string;
+    /** Serving assistant's id (remote-web ingress configs only). */
+    assistantId?: string;
     /** Cloud web SPA base for this build's environment (remote-web ingress configs only). */
     hubUrl?: string;
   };

--- a/clients/web/vite-plugin-local-mode.ts
+++ b/clients/web/vite-plugin-local-mode.ts
@@ -75,6 +75,9 @@ export function localModePlugin(env: Record<string, string>): Plugin {
   const config = resolveLocalConfigFromEnv(env);
   const baseDir = path.resolve(import.meta.dirname, "..", "..");
 
+  // The `/assistant/__config` document, also injected into the index. No
+  // `assistantId`: the dev server fronts every assistant in the lockfile at
+  // once, so it has no single identity to report the way an nginx edge does.
   const configJson = JSON.stringify({
     webUrl: config.webUrl,
     platformUrl: config.platformUrl,
@@ -91,9 +94,7 @@ export function localModePlugin(env: Record<string, string>): Plugin {
     configureServer(server) {
       server.middlewares.use(loopbackCallbackMiddleware());
       server.middlewares.use(platformSessionMiddleware());
-      server.middlewares.use(
-        configMiddleware(config.webUrl, config.platformUrl),
-      );
+      server.middlewares.use(configMiddleware(configJson));
       server.middlewares.use(lockfileMiddleware(config.lockfilePaths));
       server.middlewares.use(hatchMiddleware(baseDir));
       server.middlewares.use(retireMiddleware(baseDir, config.lockfilePaths));
@@ -264,18 +265,13 @@ function platformSessionMiddleware(): Connect.NextHandleFunction {
   };
 }
 
-function configMiddleware(
-  webUrl: string,
-  platformUrl: string,
-): Connect.NextHandleFunction {
-  const body = JSON.stringify({ webUrl, platformUrl });
-
+function configMiddleware(configJson: string): Connect.NextHandleFunction {
   return (req, res, next) => {
     if (req.url !== "/assistant/__config" && req.url !== "/__config") {
       return next();
     }
     res.writeHead(200, { "Content-Type": "application/json" });
-    res.end(body);
+    res.end(configJson);
   };
 }
 

--- a/docs/self-hosted-phone.md
+++ b/docs/self-hosted-phone.md
@@ -111,6 +111,9 @@ quick tunnel's URL is temporary on top (details in its section below).
 vellum tunnel --provider tailscale
 ```
 
+`tailscale` is the default provider, so a bare `vellum tunnel` does the same
+thing. `vellum tunnel --help` lists the other providers and options.
+
 `vellum tunnel` manages the nginx edge for you: it starts the edge on
 `http://127.0.0.1:7840` (or reuses one already running) and fronts it, so a
 single address serves the web app and forwards API and webhook traffic to
@@ -126,8 +129,11 @@ vellum nginx-ingress down     # stop the edge
 ```
 
 The tunnel records the public URL in your workspace config
-(`ingress.publicBaseUrl`), so channel integrations (Telegram, Twilio, …) can
-reach the assistant too. It prints the address it established:
+(`ingress.publicBaseUrl`). A `ts.net` address is reachable only from inside
+your own tailnet, so channel integrations that call in from the public
+internet (Telegram, Twilio, …) need one of the public providers below
+instead: `--provider ngrok` or `--provider cloudflare`. The tunnel prints the
+address it established:
 
 ```
 Tunnel established: https://your-machine.your-tailnet.ts.net
@@ -140,8 +146,10 @@ automatically.
 
 **Verify:** open that `https://…ts.net` address in the browser of a device
 you want to connect (with Tailscale connected on it). You should get the
-assistant's sign-in page. If it doesn't load, stop and fix this before
-pairing — a broken HTTPS front is the most common reason later steps fail.
+assistant's sign-in page. A front that doesn't answer is the most common
+reason later steps fail, so fix it before pairing. Pairing from the desktop
+app instead of the terminal? Its card runs the same check from the host and
+reports the verdict in a status row (see [Step 4](#4-pair-your-devices)).
 
 <details>
 <summary>Manual Tailscale fallback (no <code>vellum tunnel</code> needed)</summary>
@@ -166,7 +174,8 @@ which manages the edge itself and also writes the URL to
 <details>
 <summary>Public alternatives: ngrok / Cloudflare quick tunnels</summary>
 
-If you can't use Tailscale, expose the edge over the public internet:
+If you can't use Tailscale, or you need channel webhooks (Telegram, Twilio,
+…) to call in from the public internet, expose the edge publicly:
 
 ```bash
 vellum tunnel --provider cloudflare   # quick tunnel, no account required
@@ -252,10 +261,26 @@ stay signed in. Pairing codes are **single-use and expire after 10 minutes**;
 run `vellum pair --qr` again to add another device or replace a lapsed code.
 
 **Prefer a UI over the terminal?** The desktop app has the same flow as a
-card: **Settings → General → Pair a device**. It prefills the address
-`vellum tunnel` recorded (or shows "No tunnel detected" guidance when there
-isn't one), rejects lookalike tunnel-provider website URLs, and names the
-assistant it pairs — generate the QR there and scan it the same way.
+card: **Settings → General → Pair a device**. Generate the QR there and scan
+it the same way.
+
+The card doesn't assume your tunnel is up; it checks. A status row reports
+whether the saved address is answering right now and serving _this_
+assistant, along with the address and how long ago it was checked. It
+re-checks whenever you come back to the app, so the usual loop is to run
+`vellum tunnel` in a terminal, switch back, and find the row already updated.
+The refresh button beside it re-checks on demand. A stopped tunnel's row
+names the command that restarts it. An address that isn't answering demotes
+the button to **Generate anyway** rather than blocking you, since the check
+runs from the host and can be wrong about your network.
+
+When the card has a working address it leads with the button and keeps the
+**Public URL** field behind **Use a different address**, one click away for
+when your devices reach the assistant somewhere else. With no address to
+reuse, the field leads instead and the card shows the same `vellum tunnel`
+instructions as [Step 3](#3-put-an-https-address-in-front). The field rejects
+lookalike tunnel-provider website URLs, and the card names the assistant it
+pairs.
 
 ## 5. Using the Vellum iOS app
 


### PR DESCRIPTION
## Summary

- Declare `assistantId` on `Window["__VELLUM_CONFIG__"]` so the type keeps step with what the nginx remote-web edge now injects (it lands in both `/assistant/__config` and the served index alongside `assistantName` and `hubUrl`).
- Note at the Vite dev server's `/assistant/__config` site why it deliberately carries no `assistantId`: the dev server fronts every assistant in the lockfile at once, so it has no single identity to report. Building that document once instead of twice puts the note in one place.
- Refresh `docs/self-hosted-phone.md` for the shipped Pair-a-device card: the status row as the verification step, its refresh button and return-to-tab re-check, the Public URL field behind "Use a different address", "Generate anyway" on an unreachable address, `tailscale` as the bare `vellum tunnel` default, and public webhook ingress needing ngrok or cloudflare. Drops the stale "No tunnel detected" quote.

Fixes gaps identified during plan review for tunnel-status-pairing.md.