### PR TITLE
fix(assistant): make healthz the tunnel liveness verdict and stop leaking probe bodies

### DIFF
--- a/assistant/src/inbound/__tests__/tunnel-probe.test.ts
+++ b/assistant/src/inbound/__tests__/tunnel-probe.test.ts
@@ -1,11 +1,14 @@
 /**
  * Tests for the tunnel reachability probe.
  *
- * Two properties carry the feature. First, healthy means the whole chain is
- * live, so an edge whose nginx answers while the gateway behind it does not
- * must read `unreachable`. Second, `foreign` is an accusation ("this URL now
- * fronts someone else's assistant"), so it is reserved for a positive
- * mismatch of two known ids and every skew case reads `healthy`.
+ * Three properties carry the feature. First, `/healthz` alone decides
+ * liveness, so an edge whose nginx answers while the gateway behind it does
+ * not must read `unreachable`, while an ingress that never serves
+ * `/assistant/__config` at all still reads `healthy`. Second, `foreign` is an
+ * accusation ("this URL now fronts someone else's assistant"), so it is
+ * reserved for a positive mismatch of two known ids and every skew case reads
+ * `healthy`. Third, the probe runs often enough that a body it never parses
+ * has to be cancelled rather than left to GC.
  *
  * Every case injects `fetchImpl`, so nothing here touches the network.
  */
@@ -16,7 +19,7 @@ import { probeTunnel } from "../tunnel-probe.js";
 
 const BASE = "https://edge.example";
 
-type Route = { status?: number; body?: string };
+type Route = { status?: number; body?: string; reject?: unknown };
 
 /** `typeof fetch` carries extras (e.g. `preconnect`) a stub has no use for. */
 function asFetch(
@@ -25,21 +28,47 @@ function asFetch(
   return stub as unknown as typeof fetch;
 }
 
-/** Serves canned responses per path, and records the URLs it was asked for. */
+/**
+ * A hand-rolled response rather than a real one, so `body.cancel()` is
+ * observable and stays callable after a failed `json()`.
+ */
+function stubResponse(route: Route, onCancel: () => void): Response {
+  const status = route.status ?? 200;
+  const text = route.body ?? "";
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    body: {
+      cancel: async (): Promise<void> => {
+        onCancel();
+      },
+    },
+    json: async (): Promise<unknown> => JSON.parse(text),
+  } as unknown as Response;
+}
+
+/** Serves canned responses per path, recording requests and body cancels. */
 function stubFetch(routes: { healthz?: Route; config?: Route }): {
   fetchImpl: typeof fetch;
   urls: string[];
+  cancelled: string[];
 } {
   const urls: string[] = [];
+  const cancelled: string[] = [];
   const fetchImpl = asFetch(async (input) => {
     const url = String(input);
     urls.push(url);
-    const route = url.endsWith("/healthz")
-      ? (routes.healthz ?? { status: 200, body: "ok" })
-      : (routes.config ?? { status: 200, body: "{}" });
-    return new Response(route.body ?? "", { status: route.status ?? 200 });
+    const isHealth = url.endsWith("/healthz");
+    const label = isHealth ? "healthz" : "config";
+    const route = isHealth
+      ? (routes.healthz ?? { body: "ok" })
+      : (routes.config ?? { body: "{}" });
+    if (route.reject !== undefined) {
+      throw route.reject;
+    }
+    return stubResponse(route, () => cancelled.push(label));
   });
-  return { fetchImpl, urls };
+  return { fetchImpl, urls, cancelled };
 }
 
 function configBody(config: Record<string, unknown>): Route {
@@ -137,6 +166,40 @@ describe("probeTunnel", () => {
     });
   });
 
+  test("healthy when the ingress does not serve the config path at all", async () => {
+    const { fetchImpl } = stubFetch({
+      config: { status: 404, body: "not found" },
+    });
+    await expect(
+      probeTunnel({
+        publicBaseUrl: BASE,
+        expectedAssistantId: "asst_1",
+        fetchImpl,
+      }),
+    ).resolves.toEqual({
+      kind: "healthy",
+      assistantId: undefined,
+      assistantName: undefined,
+    });
+  });
+
+  test("healthy when the config request rejects but the gateway answers", async () => {
+    const { fetchImpl } = stubFetch({
+      config: { reject: new TypeError("fetch failed") },
+    });
+    await expect(
+      probeTunnel({
+        publicBaseUrl: BASE,
+        expectedAssistantId: "asst_1",
+        fetchImpl,
+      }),
+    ).resolves.toEqual({
+      kind: "healthy",
+      assistantId: undefined,
+      assistantName: undefined,
+    });
+  });
+
   test("unreachable when the request rejects", async () => {
     const fetchImpl = asFetch(async () => {
       throw new TypeError("Unable to connect");
@@ -174,6 +237,40 @@ describe("probeTunnel", () => {
     ).resolves.toEqual({ kind: "unreachable", detail: "timeout" });
   });
 
+  test("unreachable when only the config request times out", async () => {
+    const timeout = new DOMException("The operation timed out", "TimeoutError");
+    const { fetchImpl } = stubFetch({ config: { reject: timeout } });
+    await expect(
+      probeTunnel({ publicBaseUrl: BASE, fetchImpl }),
+    ).resolves.toEqual({ kind: "unreachable", detail: "timeout" });
+  });
+
+  test("surfaces the syscall code hidden under a generic fetch wrapper", async () => {
+    const cause = Object.assign(new Error("connect ECONNREFUSED 127.0.0.1:80"), {
+      code: "ECONNREFUSED",
+    });
+    const fetchImpl = asFetch(async () => {
+      throw new TypeError("fetch failed", { cause });
+    });
+    await expect(
+      probeTunnel({ publicBaseUrl: BASE, fetchImpl }),
+    ).resolves.toEqual({ kind: "unreachable", detail: "ECONNREFUSED" });
+  });
+
+  test("falls back to the cause's message when neither level has a code", async () => {
+    const fetchImpl = asFetch(async () => {
+      throw new TypeError("fetch failed", {
+        cause: new Error("getaddrinfo lookup failed"),
+      });
+    });
+    await expect(
+      probeTunnel({ publicBaseUrl: BASE, fetchImpl }),
+    ).resolves.toEqual({
+      kind: "unreachable",
+      detail: "getaddrinfo lookup failed",
+    });
+  });
+
   test("keeps the probed URL out of the failure detail", async () => {
     const fetchImpl = asFetch(async (input) => {
       throw new TypeError(`Failed to parse URL from ${String(input)}`);
@@ -192,5 +289,65 @@ describe("probeTunnel", () => {
       detail: "no public base URL",
     });
     expect(urls).toEqual([]);
+  });
+
+  test.each(["not-a-url", "one.ngrok.app", "ftp://x", "https://x?a=b"])(
+    "unreachable without a request for the malformed URL %p",
+    async (publicBaseUrl) => {
+      const { fetchImpl, urls } = stubFetch({});
+      const result = await probeTunnel({ publicBaseUrl, fetchImpl });
+      expect(result).toEqual({
+        kind: "unreachable",
+        detail: "not an http(s) URL",
+      });
+      expect(urls).toEqual([]);
+    },
+  );
+
+  test("cancels the health body it never reads", async () => {
+    const { fetchImpl, cancelled } = stubFetch({
+      config: configBody({ assistantId: "asst_1" }),
+    });
+    await probeTunnel({ publicBaseUrl: BASE, fetchImpl });
+    expect(cancelled).toEqual(["healthz"]);
+  });
+
+  test("cancels both bodies when the gateway is down", async () => {
+    const { fetchImpl, cancelled } = stubFetch({
+      healthz: { status: 502, body: "bad gateway" },
+      config: configBody({ assistantId: "asst_1" }),
+    });
+    await probeTunnel({ publicBaseUrl: BASE, fetchImpl });
+    expect(cancelled.sort()).toEqual(["config", "healthz"]);
+  });
+
+  test("cancels the config body it does not parse", async () => {
+    const { fetchImpl, cancelled } = stubFetch({
+      config: { status: 404, body: "not found" },
+    });
+    await probeTunnel({ publicBaseUrl: BASE, fetchImpl });
+    expect(cancelled.sort()).toEqual(["config", "healthz"]);
+  });
+
+  test("survives a body that refuses to be cancelled", async () => {
+    const fetchImpl = asFetch(async () =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        body: {
+          cancel: async (): Promise<void> => {
+            throw new Error("already locked");
+          },
+        },
+        json: async (): Promise<unknown> => ({ assistantId: "asst_1" }),
+      } as unknown as Response),
+    );
+    await expect(
+      probeTunnel({ publicBaseUrl: BASE, fetchImpl }),
+    ).resolves.toEqual({
+      kind: "healthy",
+      assistantId: "asst_1",
+      assistantName: undefined,
+    });
   });
 });

--- a/assistant/src/inbound/tunnel-probe.ts
+++ b/assistant/src/inbound/tunnel-probe.ts
@@ -5,24 +5,34 @@
  * URL says nothing about whether anything still answers on it: the tunnel
  * process can die, the nginx edge can stay up while the gateway behind it is
  * down, and a URL can end up fronting a different assistant entirely. The
- * probe resolves that by asking the edge two questions at once:
+ * probe asks the edge two questions at once, and the two answers carry very
+ * different weight:
  *
- *   - `GET /healthz` is proxied through nginx to the gateway, so a 2xx proves
- *     the whole chain tunnel -> nginx -> gateway.
- *   - `GET /assistant/__config` is a static nginx response carrying the
- *     assistant's identity, so it proves which assistant the edge fronts.
+ *   - `GET /healthz` is the liveness verdict, and the only one. Every ingress
+ *     shape answers it: the nginx edge proxies it to the gateway, and a
+ *     tunnel pointed straight at the gateway port serves it from the gateway
+ *     itself. A 2xx proves the whole chain; anything else means the URL is
+ *     not usable.
+ *   - `GET /assistant/__config` establishes identity, nothing more. Only the
+ *     nginx remote-web SPA edge serves it (`buildRemoteWebIngressLocations`
+ *     in `cli/src/lib/nginx-ingress.ts`). A gateway-direct tunnel, a
+ *     bring-your-own HTTPS front, or a hand-set `ingress.publicBaseUrl` will
+ *     404 there while working perfectly, so a config that is missing,
+ *     failing, or unreadable leaves the identity unknown and never fails the
+ *     probe. An edge answering with a body this cannot read is still an edge
+ *     that is answering.
  *
- * Both paths live in `cli/src/lib/nginx-ingress.ts` and neither is denylisted,
- * so both are publicly reachable.
+ * Neither path is denylisted, so both are publicly reachable.
  *
  * The module takes a URL and an expected id and returns a verdict: it reads no
  * config and knows nothing about workspace paths, which is what lets callers
  * probe an arbitrary URL and lets tests run without network access.
  */
 
-import { normalizePublicBaseUrl } from "@vellumai/service-contracts/ingress";
+import { normalizeHttpPublicBaseUrl } from "@vellumai/service-contracts/ingress";
 
 import { isPlainObject } from "../util/object.js";
+import { truncate } from "../util/truncate.js";
 
 /**
  * Verdict for one probe.
@@ -42,6 +52,15 @@ const DEFAULT_TIMEOUT_MS = 4_000;
 /** Placeholder swapped in for the probed URL so `detail` stays URL-free. */
 const REDACTED_URL = "<url>";
 
+/** `detail` is rendered inline in a settings card, so it has to stay short. */
+const MAX_DETAIL_LENGTH = 120;
+
+/** Bound on the `cause` walk, so a self-referential chain cannot spin. */
+const MAX_CAUSE_DEPTH = 5;
+
+/** Wrappers fetch layers raise when the real reason sits one `cause` down. */
+const GENERIC_FETCH_MESSAGES = new Set(["fetch failed", "failed to fetch"]);
+
 export async function probeTunnel(args: {
   publicBaseUrl: string;
   /** Id recorded when this URL was saved; omit to skip the identity check. */
@@ -49,10 +68,17 @@ export async function probeTunnel(args: {
   timeoutMs?: number;
   fetchImpl?: typeof fetch;
 }): Promise<TunnelProbeResult> {
-  const base = normalizePublicBaseUrl(args.publicBaseUrl);
-  if (!base) {
+  if (args.publicBaseUrl.trim().length === 0) {
     return { kind: "unreachable", detail: "no public base URL" };
   }
+  // The same validation the config writers apply, so a value they would have
+  // rejected is named as malformed rather than handed to `fetch` and reported
+  // through whatever string that layer happens to produce.
+  const normalized = normalizeHttpPublicBaseUrl(args.publicBaseUrl);
+  if (normalized === undefined) {
+    return { kind: "unreachable", detail: "not an http(s) URL" };
+  }
+  const base = normalized.replace(/\/+$/, "");
 
   const fetchImpl = args.fetchImpl ?? globalThis.fetch.bind(globalThis);
   const signal = AbortSignal.timeout(args.timeoutMs ?? DEFAULT_TIMEOUT_MS);
@@ -60,21 +86,26 @@ export async function probeTunnel(args: {
     fetchImpl(`${base}/healthz`, { signal }),
     fetchImpl(`${base}/assistant/__config`, { signal }),
   ]);
+  const configResponse =
+    config.status === "fulfilled" ? config.value : undefined;
 
   if (health.status === "rejected") {
+    await discardBody(configResponse);
     return unreachable(describeError(health.reason), base);
   }
-  if (config.status === "rejected") {
-    return unreachable(describeError(config.reason), base);
-  }
+  // Liveness is the status line; the health body is never read.
+  await discardBody(health.value);
   if (!health.value.ok) {
+    await discardBody(configResponse);
     return unreachable(`HTTP ${health.value.status}`, base);
   }
-  if (!config.value.ok) {
-    return unreachable(`HTTP ${config.value.status}`, base);
+  // An edge that stopped answering mid-probe outranks the liveness the 2xx
+  // established, so a timeout on either path is still unreachable.
+  if (config.status === "rejected" && isTimeoutError(config.reason)) {
+    return unreachable("timeout", base);
   }
 
-  const served = await readServedConfig(config.value);
+  const served = await readServedConfig(configResponse);
   const expected = nonEmptyString(args.expectedAssistantId);
   const isForeign =
     expected !== undefined &&
@@ -89,20 +120,66 @@ export async function probeTunnel(args: {
  * message, and the caller already knows which URL it asked about.
  */
 function unreachable(detail: string, base: string): TunnelProbeResult {
-  return { kind: "unreachable", detail: detail.replaceAll(base, REDACTED_URL) };
+  return {
+    kind: "unreachable",
+    detail: truncate(detail.replaceAll(base, REDACTED_URL), MAX_DETAIL_LENGTH),
+  };
 }
 
+/**
+ * An unread fetch body pins its socket until GC under Bun and undici, and the
+ * probe runs on every settings mount, resume, and manual refresh.
+ */
+async function discardBody(response: Response | undefined): Promise<void> {
+  try {
+    await response?.body?.cancel();
+  } catch {
+    /* best effort */
+  }
+}
+
+function isTimeoutError(error: unknown): boolean {
+  return (
+    isPlainObject(error) &&
+    (error.name === "TimeoutError" || error.name === "AbortError")
+  );
+}
+
+/**
+ * A dead tunnel surfaces as a generic wrapper ("fetch failed") whose `cause`
+ * carries the reason worth reading (`ECONNREFUSED`, `ENOTFOUND`), so walk the
+ * chain for a code, then for the first message that says something.
+ */
 function describeError(error: unknown): string {
-  if (isPlainObject(error)) {
-    if (error.name === "TimeoutError" || error.name === "AbortError") {
+  let firstMessage: string | undefined;
+  let specificMessage: string | undefined;
+  let current: unknown = error;
+
+  for (let depth = 0; depth < MAX_CAUSE_DEPTH; depth += 1) {
+    if (!isPlainObject(current)) {
+      break;
+    }
+    if (isTimeoutError(current)) {
       return "timeout";
     }
-    const text = nonEmptyString(error.message);
-    if (text !== undefined) {
-      return text;
+    const code = nonEmptyString(current.code);
+    if (code !== undefined) {
+      return code;
     }
+    const message = nonEmptyString(current.message);
+    if (message !== undefined) {
+      firstMessage ??= message;
+      if (
+        specificMessage === undefined &&
+        !GENERIC_FETCH_MESSAGES.has(message.toLowerCase())
+      ) {
+        specificMessage = message;
+      }
+    }
+    current = current.cause;
   }
-  return String(error);
+
+  return specificMessage ?? firstMessage ?? String(error);
 }
 
 interface ServedEdgeConfig {
@@ -114,12 +191,14 @@ function nonEmptyString(value: unknown): string | undefined {
   return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 
-/**
- * An edge answering with a body this cannot read is still an edge that is
- * answering, so an unreadable config yields an unknown identity rather than a
- * failure.
- */
-async function readServedConfig(response: Response): Promise<ServedEdgeConfig> {
+/** Identity only: every failure here yields an unknown identity. */
+async function readServedConfig(
+  response: Response | undefined,
+): Promise<ServedEdgeConfig> {
+  if (response === undefined || !response.ok) {
+    await discardBody(response);
+    return {};
+  }
   try {
     const body: unknown = await response.json();
     if (!isPlainObject(body)) {
@@ -130,6 +209,7 @@ async function readServedConfig(response: Response): Promise<ServedEdgeConfig> {
       assistantName: nonEmptyString(body.assistantName),
     };
   } catch {
+    await discardBody(response);
     return {};
   }
 }


### PR DESCRIPTION
## Summary

- `/healthz` alone decides liveness now that `/assistant/__config` is identity-only: a missing, failing, or rejected config no longer reports a working gateway-direct tunnel (or a bring-your-own HTTPS front, or a hand-set `ingress.publicBaseUrl`) as "not answering". A non-2xx or rejected `/healthz` still reads `unreachable`, and a timeout on either path still does too.
- Every response body the probe does not parse is cancelled, so the settings mount / resume / manual-refresh cadence stops pinning sockets until GC.
- `detail` unwraps `error.cause` (depth-bounded) for a syscall code like `ECONNREFUSED` instead of Bun/undici's generic "fetch failed", and the probe validates the URL with the strict `normalizeHttpPublicBaseUrl` its sibling record readers use, so a malformed value short-circuits before any fetch.

Fixes gaps identified during plan review for tunnel-status-pairing.md.