### PR TITLE
fix(cli): guard the tailscale default against configured webhooks and honor the edge fingerprint on restore

### DIFF
--- a/cli/src/__tests__/client-web-config.test.ts
+++ b/cli/src/__tests__/client-web-config.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Tests for the config `vellum client --interface web` serves at
+ * `/assistant/__config`. It is the same document the nginx tunnel edge serves,
+ * and a caller probes it to learn which assistant an origin fronts, so the two
+ * producers must agree on carrying `assistantId`.
+ */
+import { describe, expect, test } from "bun:test";
+
+import { buildWebInterfaceConfig } from "../commands/client.js";
+import { DAEMON_INTERNAL_ASSISTANT_ID } from "../lib/constants.js";
+
+const BASE = {
+  webUrl: "https://app.example.com",
+  platformUrl: "https://platform.example.com",
+  disablePlatform: true,
+};
+
+describe("vellum client web __config", () => {
+  test("stamps the assistant the front is bound to", () => {
+    expect(
+      buildWebInterfaceConfig({ ...BASE, assistantId: "assistant-1" }),
+    ).toEqual({ ...BASE, assistantId: "assistant-1" });
+  });
+
+  test("omits the daemon-internal placeholder so a probe reads an unknown identity", () => {
+    expect(
+      buildWebInterfaceConfig({
+        ...BASE,
+        assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
+      }),
+    ).toEqual(BASE);
+  });
+
+  test("omits an absent assistant id", () => {
+    expect(buildWebInterfaceConfig(BASE)).toEqual(BASE);
+  });
+});

--- a/cli/src/__tests__/tunnel.test.ts
+++ b/cli/src/__tests__/tunnel.test.ts
@@ -118,6 +118,24 @@ function makeAppleContainerEntry(assistantId = "apple-1"): AssistantEntry {
   };
 }
 
+/** Seed a local entry's workspace config; returns that workspace dir. */
+function writeEntryWorkspaceConfig(
+  entry: AssistantEntry,
+  config: Record<string, unknown>,
+): string {
+  const workspaceDir = join(
+    entry.resources!.instanceDir,
+    ".vellum",
+    "workspace",
+  );
+  mkdirSync(workspaceDir, { recursive: true });
+  writeFileSync(
+    join(workspaceDir, "config.json"),
+    JSON.stringify(config, null, 2),
+  );
+  return workspaceDir;
+}
+
 /** Point the default workspace dir at a temp dir; returns that dir. */
 function useTempDefaultWorkspaceDir(): string {
   const workspaceDir = mkdtempSync(join(tmpdir(), "vellum-tunnel-ws-"));
@@ -642,6 +660,72 @@ describe("tunnel edge targeting", () => {
     });
     expect(runNgrokTunnelMock).not.toHaveBeenCalled();
     expect(runCloudflareTunnelMock).not.toHaveBeenCalled();
+  });
+
+  test("a bare invocation refuses tailscale when webhook integrations are configured", async () => {
+    const entry = makeLocalEntry();
+    writeLockfile(entry);
+    writeEntryWorkspaceConfig(entry, {
+      telegram: { botUsername: "example_bot" },
+    });
+    process.argv = ["bun", "vellum", "tunnel"];
+
+    const { exited, errors } = await runTunnelExpectingExit1();
+
+    expect(exited).toBe(true);
+    expect(errors).toContain("reachable only from your own tailnet");
+    expect(errors).toContain("vellum tunnel --provider ngrok");
+    expect(errors).toContain("vellum tunnel --provider tailscale");
+    // Nothing is started and nothing is recorded until the user has chosen.
+    expect(ensureTunnelEdgeMock).not.toHaveBeenCalled();
+    expect(runTailscaleTunnelMock).not.toHaveBeenCalled();
+  });
+
+  test("an explicit --provider tailscale runs with a warning when webhook integrations are configured", async () => {
+    const entry = makeLocalEntry();
+    writeLockfile(entry);
+    const workspaceDir = writeEntryWorkspaceConfig(entry, {
+      telegram: { botUsername: "example_bot" },
+    });
+    process.argv = ["bun", "vellum", "tunnel", "--provider", "tailscale"];
+
+    const warnings: string[] = [];
+    const warnSpy = spyOn(console, "warn").mockImplementation(
+      (...a: unknown[]) => {
+        warnings.push(a.join(" "));
+      },
+    );
+    try {
+      await runTunnelCapturingLogs();
+    } finally {
+      warnSpy.mockRestore();
+    }
+
+    expect(warnings.join("\n")).toContain(
+      "reachable only from your own tailnet",
+    );
+    expect(runTailscaleTunnelMock).toHaveBeenCalledWith({
+      port: EDGE_PORT,
+      assistantId: "assistant-1",
+      workspaceDir,
+    });
+  });
+
+  test("a public provider is unaffected by configured webhook integrations", async () => {
+    const entry = makeLocalEntry();
+    writeLockfile(entry);
+    const workspaceDir = writeEntryWorkspaceConfig(entry, {
+      telegram: { botUsername: "example_bot" },
+    });
+    process.argv = ["bun", "vellum", "tunnel", "--provider", "ngrok"];
+
+    await runTunnelCapturingLogs();
+
+    expect(runNgrokTunnelMock).toHaveBeenCalledWith({
+      port: EDGE_PORT,
+      assistantId: "assistant-1",
+      workspaceDir,
+    });
   });
 
   test("missing nginx aborts before any provider spawn", async () => {

--- a/cli/src/__tests__/wake.test.ts
+++ b/cli/src/__tests__/wake.test.ts
@@ -655,83 +655,33 @@ describe("vellum wake — tunnel edge restore", () => {
     expect(ensureTunnelEdgeMock).not.toHaveBeenCalled();
   });
 
-  test("a running edge recorded against this gateway port is reused without ensureTunnelEdge", async () => {
+  test("a recorded edge with a stale config fingerprint is restarted, not adopted", async () => {
+    // Recorded mode and gateway port are not a licence to reuse: only
+    // ensureTunnelEdge compares the injected-config fingerprint, so an edge
+    // predating the current edge template (one serving no assistantId, which
+    // makes the identity probe degrade to always-healthy) must be restarted
+    // rather than carried across the wake at its recorded listen port.
     loadRawConfigMock.mockReturnValue(webhookConfig);
     isIngressRunningMock.mockReturnValue(true);
     readIngressStateMock.mockReturnValue({
       listenPort: 7845,
       includeWebApp: true,
       gatewayPort: 7830,
+      remoteWebConfigHash: "fingerprint-of-an-older-edge-template",
     });
 
     await wake();
 
-    expect(ensureTunnelEdgeMock).not.toHaveBeenCalled();
-    expect(logSpy).toHaveBeenCalledWith(
-      "   Tunnel edge already running on 127.0.0.1:7845 (remote web + webhooks).",
-    );
-    expect(maybeStartNgrokTunnelMock).toHaveBeenCalledWith(
-      7845,
-      workspaceDirOf(tempDir),
-      "local-assistant",
-    );
-  });
-
-  test("a running webhooks-only edge goes through ensureTunnelEdge to upgrade to the SPA edge", async () => {
-    loadRawConfigMock.mockReturnValue(webhookConfig);
-    isIngressRunningMock.mockReturnValue(true);
-    readIngressStateMock.mockReturnValue({
-      listenPort: 7845,
-      includeWebApp: false,
+    expect(ensureTunnelEdgeMock).toHaveBeenCalledWith({
+      assistantId: "local-assistant",
+      workspaceDir: workspaceDirOf(tempDir),
       gatewayPort: 7830,
     });
-
-    await wake();
-
-    expect(ensureTunnelEdgeMock).toHaveBeenCalledWith(
-      expect.objectContaining({ gatewayPort: 7830 }),
-    );
     expect(maybeStartNgrokTunnelMock).toHaveBeenCalledWith(
       7840,
       workspaceDirOf(tempDir),
       "local-assistant",
     );
-  });
-
-  test("a running edge recorded against a different gateway port goes through ensureTunnelEdge", async () => {
-    loadRawConfigMock.mockReturnValue(webhookConfig);
-    isIngressRunningMock.mockReturnValue(true);
-    readIngressStateMock.mockReturnValue({
-      listenPort: 7845,
-      includeWebApp: true,
-      gatewayPort: 7900,
-    });
-
-    await wake();
-
-    expect(ensureTunnelEdgeMock).toHaveBeenCalledWith(
-      expect.objectContaining({ gatewayPort: 7830 }),
-    );
-    expect(maybeStartNgrokTunnelMock).toHaveBeenCalledWith(
-      7840,
-      workspaceDirOf(tempDir),
-      "local-assistant",
-    );
-  });
-
-  test("a running edge without a recorded gateway port goes through ensureTunnelEdge", async () => {
-    // An unverified upstream must not be reused blindly; ensureTunnelEdge
-    // restarts it so the running config provably targets the requested port.
-    loadRawConfigMock.mockReturnValue(webhookConfig);
-    isIngressRunningMock.mockReturnValue(true);
-    readIngressStateMock.mockReturnValue({
-      listenPort: 7845,
-      includeWebApp: true,
-    });
-
-    await wake();
-
-    expect(ensureTunnelEdgeMock).toHaveBeenCalled();
   });
 
   test("nginx-missing falls back to the gateway-port tunnel with a warning", async () => {

--- a/cli/src/commands/client.ts
+++ b/cli/src/commands/client.ts
@@ -1208,12 +1208,36 @@ async function spawnBackgroundWebInterface(
   console.log(`Stop with: kill ${child.pid}`);
 }
 
+/**
+ * Config the local web host injects as `window.__VELLUM_CONFIG__` and serves at
+ * `/assistant/__config`, the document a caller probes to learn which assistant
+ * an origin fronts. `assistantId` is omitted when only the daemon-internal
+ * placeholder is known, so the probe reads an unknown identity rather than a
+ * mismatch (same contract as the nginx edge's served config).
+ */
+export function buildWebInterfaceConfig(opts: {
+  webUrl: string;
+  platformUrl: string;
+  disablePlatform: boolean;
+  assistantId?: string;
+}): Record<string, unknown> {
+  const { webUrl, platformUrl, disablePlatform, assistantId } = opts;
+  const named = assistantId && assistantId !== DAEMON_INTERNAL_ASSISTANT_ID;
+  return {
+    webUrl,
+    platformUrl,
+    disablePlatform,
+    ...(named ? { assistantId } : {}),
+  };
+}
+
 async function runWebInterface(
   flagEnvVars: Record<string, string>,
   parsedFlagOverrides: Record<string, boolean | string>,
   disablePlatform: boolean,
   openInBrowser: boolean,
   webPort: number | undefined,
+  assistantId: string,
 ): Promise<void> {
   // Propagate flag env vars so child processes (e.g. hatch from the web UI) inherit them.
   Object.assign(process.env, flagEnvVars);
@@ -1247,7 +1271,14 @@ async function runWebInterface(
   const webUrl = getWebUrl();
   const safeJson = (v: unknown) =>
     JSON.stringify(v).replace(/</g, "\\u003c").replace(/>/g, "\\u003e");
-  const configJson = safeJson({ webUrl, platformUrl, disablePlatform });
+  const configJson = safeJson(
+    buildWebInterfaceConfig({
+      webUrl,
+      platformUrl,
+      disablePlatform,
+      assistantId,
+    }),
+  );
   const hasOverrides = Object.keys(parsedFlagOverrides).length > 0;
   const flagOverridesSnippet = hasOverrides
     ? `;window.__VELLUM_FLAG_OVERRIDES__=${safeJson(parsedFlagOverrides)}`
@@ -1544,6 +1575,7 @@ export async function client(): Promise<void> {
       disablePlatform,
       openInBrowser,
       webPort,
+      assistantId,
     );
     return;
   }

--- a/cli/src/commands/tunnel.ts
+++ b/cli/src/commands/tunnel.ts
@@ -10,6 +10,7 @@ import { parseAssistantTargetArg } from "../lib/assistant-target-args.js";
 import { runCloudflareTunnel } from "../lib/cloudflare-tunnel.js";
 import {
   getDefaultWorkspaceDir,
+  loadRawConfig,
   saveNgrokDomain,
   TUNNEL_PROVIDERS,
 } from "../lib/ingress-config.js";
@@ -18,7 +19,7 @@ import {
   formatEdgeMode,
   type TunnelEdge,
 } from "../lib/nginx-ingress.js";
-import { runNgrokTunnel } from "../lib/ngrok";
+import { hasWebhookIntegrations, runNgrokTunnel } from "../lib/ngrok";
 import { STALE_CLI_UPDATE_HINT } from "../lib/stale-cli-hint.js";
 import { runTailscaleTunnel } from "../lib/tailscale-tunnel.js";
 import { parseGatewayPortFromEntryUrls } from "./nginx-ingress.js";
@@ -34,6 +35,9 @@ const DEFAULT_PROVIDER: TunnelProvider = "tailscale";
 interface TunnelArgs {
   assistantName: string | null;
   provider: TunnelProvider;
+  /** True when `--provider` named the provider, so the tailnet-only default
+   *  is a deliberate choice rather than one the user fell into. */
+  providerExplicit: boolean;
   domain: string | null;
   clearDomain: boolean;
 }
@@ -43,6 +47,7 @@ const FLAGS_WITH_VALUES = ["--provider", "--domain"] as const;
 function parseArgs(): TunnelArgs {
   const args = process.argv.slice(3);
   let provider: TunnelProvider = DEFAULT_PROVIDER;
+  let providerExplicit = false;
   let domain: string | null = null;
   let clearDomain = false;
 
@@ -51,21 +56,19 @@ function parseArgs(): TunnelArgs {
     if (arg === "--help" || arg === "-h") {
       console.log("Usage: vellum tunnel [<name>] [options]");
       console.log("");
+      console.log("Front a locally running assistant with an HTTPS tunnel.");
       console.log(
-        "Expose a locally running assistant to the internet via a tunnel.",
-      );
-      console.log(
-        "The public URL is saved to the workspace config as the ingress base URL,",
-      );
-      console.log(
-        "enabling webhook integrations (Telegram, Twilio, etc.) to reach the assistant.",
+        "The tunnel URL is saved to the workspace config as the ingress base URL.",
       );
       console.log("");
       console.log(
-        "The default tailscale provider is reachable only from your own tailnet.",
+        "How far that URL reaches depends on the provider. The default tailscale",
       );
       console.log(
-        "Public webhook ingress needs --provider ngrok or --provider cloudflare.",
+        "tunnel is reachable only from your own tailnet; webhook integrations need",
+      );
+      console.log(
+        "a public tunnel: --provider ngrok or --provider cloudflare.",
       );
       console.log("");
       console.log(
@@ -116,6 +119,9 @@ function parseArgs(): TunnelArgs {
       console.log(
         "               Reachable only from your own tailnet (private; LetsEncrypt cert).",
       );
+      console.log(
+        "               Must be named explicitly when webhook integrations are configured.",
+      );
       console.log("");
       console.log("Examples:");
       console.log("  $ vellum tunnel --provider ngrok");
@@ -144,6 +150,7 @@ function parseArgs(): TunnelArgs {
         process.exit(1);
       }
       provider = next as TunnelProvider;
+      providerExplicit = true;
       i++;
     } else if (arg === "--domain") {
       const next = args[i + 1];
@@ -189,7 +196,7 @@ function parseArgs(): TunnelArgs {
     process.exit(1);
   }
 
-  return { assistantName, provider, domain, clearDomain };
+  return { assistantName, provider, providerExplicit, domain, clearDomain };
 }
 
 /** A tunnelable assistant plus the gateway port and workspace the edge fronts. */
@@ -280,8 +287,60 @@ function resolveLocalTunnelTarget(
   process.exit(1);
 }
 
+/** Whether the workspace declares webhook integrations; false when unreadable. */
+function hasWebhookIntegrationsConfigured(workspaceDir: string): boolean {
+  try {
+    return hasWebhookIntegrations(loadRawConfig(workspaceDir));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Gate the tailnet-only tailscale tunnel behind an explicit `--provider` when
+ * webhook integrations are configured. Its URL becomes the webhook callback
+ * base, so falling into it would repoint those callbacks at an address
+ * external services cannot resolve and would suppress the ngrok auto-tunnel on
+ * every later wake (a non-ngrok ingress URL reads as ingress already handled).
+ * An explicit choice is honored, with the same consequence spelled out.
+ */
+function guardTailnetOnlyWebhookIngress(
+  workspaceDir: string,
+  providerExplicit: boolean,
+): void {
+  if (!hasWebhookIntegrationsConfigured(workspaceDir)) {
+    return;
+  }
+  if (providerExplicit) {
+    console.warn(
+      "⚠ Webhook integrations are configured, and the tailscale tunnel is reachable only from your own tailnet. " +
+        "Saving its URL as the ingress base URL leaves them without a reachable callback address.",
+    );
+    return;
+  }
+  console.error(
+    "Error: webhook integrations are configured, and the default tailscale tunnel is reachable only from your own tailnet.",
+  );
+  console.error(
+    "Starting it would replace the saved ingress base URL, which is also the webhook callback base, with a tailnet address.",
+  );
+  console.error("");
+  console.error("Run one of:");
+  console.error(
+    "  vellum tunnel --provider ngrok        Public tunnel that webhook integrations can reach",
+  );
+  console.error(
+    "  vellum tunnel --provider cloudflare   Public tunnel that webhook integrations can reach",
+  );
+  console.error(
+    "  vellum tunnel --provider tailscale    Accept the tailnet-only tunnel",
+  );
+  process.exit(1);
+}
+
 export async function tunnel(): Promise<void> {
-  const { assistantName, provider, domain, clearDomain } = parseArgs();
+  const { assistantName, provider, providerExplicit, domain, clearDomain } =
+    parseArgs();
 
   if (provider === "vellum") {
     throw new Error(
@@ -292,6 +351,10 @@ export async function tunnel(): Promise<void> {
 
   const { entry, gatewayPort, workspaceDir } =
     resolveLocalTunnelTarget(assistantName);
+
+  if (provider === "tailscale") {
+    guardTailnetOnlyWebhookIngress(workspaceDir, providerExplicit);
+  }
 
   if (clearDomain) {
     saveNgrokDomain(workspaceDir, null);

--- a/cli/src/lib/tunnel-edge.ts
+++ b/cli/src/lib/tunnel-edge.ts
@@ -4,8 +4,6 @@ import { loadRawConfig } from "./ingress-config.js";
 import {
   ensureTunnelEdge,
   formatEdgeMode,
-  isIngressRunning,
-  readIngressState,
   type TunnelEdge,
 } from "./nginx-ingress.js";
 import { hasWebhookIntegrations, maybeStartNgrokTunnel } from "./ngrok.js";
@@ -16,7 +14,8 @@ import { hasWebhookIntegrations, maybeStartNgrokTunnel } from "./ngrok.js";
  */
 function wantsWebIngress(config: Record<string, unknown>): boolean {
   const ingress = config.ingress as
-    { enabled?: unknown; publicBaseUrl?: unknown } | undefined;
+    | { enabled?: unknown; publicBaseUrl?: unknown }
+    | undefined;
   return (
     ingress?.enabled === true &&
     typeof ingress.publicBaseUrl === "string" &&
@@ -42,13 +41,12 @@ function wantsTunnelEdge(workspaceDir: string): boolean {
  * Bring the nginx edge back up after a wake or local upgrade and point the
  * webhook auto-tunnel at it. The edge is wanted when webhook integrations are
  * configured or the workspace ingress config is enabled with a saved public
- * URL. A healthy SPA edge whose recorded state already targets the requested
- * gateway port is reused without the `remoteWebConfigHash` comparison
- * `startRemoteWebIngress` performs; injected-config drift (a renamed
- * assistant, a changed hub URL) is repaired by the next explicit
- * `vellum tunnel` or `vellum nginx-ingress up`, not by background wakes.
- * A recorded webhooks-only edge is never reused: it goes through
- * `ensureTunnelEdge` so the wake upgrades it to the SPA edge.
+ * URL. `ensureTunnelEdge` owns the reuse decision, so a running edge is adopted
+ * only while its mode, gateway port, and injected SPA config fingerprint all
+ * match what this restore asks for; an edge that drifted in any of those
+ * respects (a renamed assistant, a changed hub URL, an older edge template) is
+ * restarted rather than adopted, which is what keeps a wake from serving a
+ * config the current CLI would never generate.
  * Edge failures warn
  * (with the error's install or diagnostic text) and fall back to tunneling the
  * gateway port directly, which `maybeStartNgrokTunnel` only does when webhook
@@ -64,34 +62,19 @@ export async function restoreTunnelEdgeAndAutoTunnel(
 ): Promise<ChildProcess | null> {
   let tunnelTargetPort = gatewayPort;
   if (wantsTunnelEdge(workspaceDir)) {
-    const recorded = isIngressRunning(workspaceDir)
-      ? readIngressState(workspaceDir)
-      : null;
     let edge: TunnelEdge | null = null;
-    if (
-      recorded !== null &&
-      recorded.gatewayPort === gatewayPort &&
-      recorded.includeWebApp
-    ) {
-      edge = {
-        port: recorded.listenPort,
-        started: false,
-        includesWebApp: true,
-      };
-    } else {
-      try {
-        edge = await ensureTunnelEdge({
-          assistantId,
-          workspaceDir,
-          gatewayPort,
-        });
-      } catch (err) {
-        console.warn(
-          `   Could not restore the tunnel edge: ${
-            err instanceof Error ? err.message : String(err)
-          } Bring it up manually with \`vellum nginx-ingress up\`.`,
-        );
-      }
+    try {
+      edge = await ensureTunnelEdge({
+        assistantId,
+        workspaceDir,
+        gatewayPort,
+      });
+    } catch (err) {
+      console.warn(
+        `   Could not restore the tunnel edge: ${
+          err instanceof Error ? err.message : String(err)
+        } Bring it up manually with \`vellum nginx-ingress up\`.`,
+      );
     }
     if (edge) {
       tunnelTargetPort = edge.port;


### PR DESCRIPTION
## Summary

- `vellum tunnel` no longer falls into the tailnet-only tailscale default when the workspace has webhook integrations configured: `ingress.publicBaseUrl` is the webhook callback base, so a silent `*.ts.net` write breaks those channels and suppresses the ngrok auto-tunnel on every later wake. It now refuses without an explicit `--provider tailscale` (which still warns), and the `--help` opening no longer promises webhook ingress for the default.
- `restoreTunnelEdgeAndAutoTunnel` no longer short-circuits a recorded edge into reuse. `ensureTunnelEdge` owns the decision, so the `remoteWebConfigHash` fingerprint (including the edge-template version) is consulted on wake/upgrade and a template-3 edge serving no `assistantId` is restarted instead of carried forward.
- `vellum client --interface web` stamps `assistantId` into the `/assistant/__config` it serves, matching the nginx edge's document so a probe of that origin can report `foreign`.

Fixes gaps identified during plan review for tunnel-status-pairing.md.