### PR TITLE
fix(assistant): share one tunnel-record contract and harden the ingress status route

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -15475,9 +15475,10 @@ paths:
       description:
         Probe the configured public ingress URL and report whether a tunnel is serving this assistant.
         `unconfigured` means no tunnel has ever been recorded (or the assistant is platform-hosted, which never uses
-        one), `stopped` means a tunnel ran before and `lastTunnel` names it, `healthy` means the URL answers and fronts
-        this assistant, `unreachable` means it does not answer, and `foreign` means it answers for a different
-        assistant.
+        one), `stopped` means a tunnel ran before and is not running now (ingress is switched off, or its URL is gone),
+        `healthy` means the URL answers and fronts this assistant, `unreachable` means it does not answer, and `foreign`
+        means it answers for a different assistant. `lastTunnel` names the tunnel to restart on every state but
+        `healthy` and `unconfigured`.
       tags:
         - config
       responses:
@@ -15500,7 +15501,9 @@ paths:
                     description: The probed URL. Set for healthy, unreachable, and foreign.
                     type: string
                   lastTunnel:
-                    description: The tunnel to restart. Set for stopped.
+                    description:
+                      "The tunnel to restart. Set whenever one is recorded and the URL is not serving this assistant: stopped,
+                      unreachable, and foreign."
                     type: object
                     properties:
                       provider:

--- a/assistant/src/__tests__/settings-routes.test.ts
+++ b/assistant/src/__tests__/settings-routes.test.ts
@@ -1,9 +1,11 @@
 /**
- * Tests for the `workspace-files` list/read endpoints in settings-routes.
+ * Tests for the `workspace-files` list/read and ingress-config endpoints in
+ * settings-routes.
  *
  * Focus: the list includes the guardian's per-user persona file
- * (`users/<slug>.md`) whenever a guardian exists, and the read endpoint
- * accepts paths under `users/`.
+ * (`users/<slug>.md`) whenever a guardian exists, the read endpoint accepts
+ * paths under `users/`, and writing a different ingress URL drops the tunnel
+ * records that described the old one.
  */
 
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
@@ -192,5 +194,85 @@ describe("GET /workspace-files/read", () => {
     expect(() => handler(makeArgs({ path: "users/nobody.md" }))).toThrow(
       NotFoundError,
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PUT /integrations/ingress/config
+// ---------------------------------------------------------------------------
+
+describe("PUT integrations/ingress/config", () => {
+  const handler = getHandler("integrations/ingress/config", "PUT");
+  const configPath = join(testWorkspaceDir, "config.json");
+
+  const TUNNEL_URL = "https://assistant-1.example.ts.net";
+  const LAST_TUNNEL = { provider: "tailscale", publicBaseUrl: TUNNEL_URL };
+
+  function readConfig(): Record<string, unknown> {
+    return existsSync(configPath)
+      ? JSON.parse(readFileSync(configPath, "utf-8"))
+      : {};
+  }
+
+  function seedIngress(ingress: Record<string, unknown>): void {
+    writeFileSync(
+      configPath,
+      JSON.stringify({ ...readConfig(), ingress }, null, 2),
+      "utf-8",
+    );
+  }
+
+  function readIngress(): Record<string, unknown> {
+    return readConfig().ingress as Record<string, unknown>;
+  }
+
+  beforeEach(() => {
+    seedIngress({
+      publicBaseUrl: TUNNEL_URL,
+      enabled: true,
+      assistantId: "assistant-1",
+      lastTunnel: LAST_TUNNEL,
+    });
+  });
+
+  test("keeps the records when the URL is unchanged", async () => {
+    await handler(makeArgs({}, { publicBaseUrl: TUNNEL_URL, enabled: false }));
+
+    const ingress = readIngress();
+    expect(ingress.assistantId).toBe("assistant-1");
+    expect(ingress.lastTunnel).toEqual(LAST_TUNNEL);
+  });
+
+  test("ignores trailing slashes and whitespace when comparing", async () => {
+    await handler(
+      makeArgs({}, { publicBaseUrl: ` ${TUNNEL_URL}/ `, enabled: true }),
+    );
+
+    const ingress = readIngress();
+    expect(ingress.assistantId).toBe("assistant-1");
+    expect(ingress.lastTunnel).toEqual(LAST_TUNNEL);
+  });
+
+  test("drops the records when the URL is retargeted", async () => {
+    await handler(
+      makeArgs(
+        {},
+        { publicBaseUrl: "https://other.example.ts.net", enabled: true },
+      ),
+    );
+
+    const ingress = readIngress();
+    expect(ingress.publicBaseUrl).toBe("https://other.example.ts.net");
+    expect(ingress.assistantId).toBeUndefined();
+    expect(ingress.lastTunnel).toBeUndefined();
+  });
+
+  test("drops the records when the URL is cleared", async () => {
+    await handler(makeArgs({}, { publicBaseUrl: "", enabled: false }));
+
+    const ingress = readIngress();
+    expect(ingress.publicBaseUrl).toBeUndefined();
+    expect(ingress.assistantId).toBeUndefined();
+    expect(ingress.lastTunnel).toBeUndefined();
   });
 });

--- a/assistant/src/daemon/handlers/__tests__/config-ingress-tunnel-records.test.ts
+++ b/assistant/src/daemon/handlers/__tests__/config-ingress-tunnel-records.test.ts
@@ -1,7 +1,9 @@
 /**
  * Unit tests for the ingress section of the workspace config, including the
- * records `vellum tunnel` leaves behind. A hand-edited or half-written entry
- * must yield a typed fallback or null, never a throw or an unusable address.
+ * records `vellum tunnel` leaves behind. The record truth table lives on the
+ * shared parser (`packages/service-contracts/src/__tests__/ingress.test.ts`);
+ * what is checked here is that the daemon reads the keys the CLI writes and
+ * inherits that validation.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -52,21 +54,28 @@ describe("workspace tunnel records", () => {
     expect(loadRecordedAssistantId()).toBeNull();
   });
 
-  test("returns null for a record missing either field", () => {
-    rawConfig = { ingress: { lastTunnel: { provider: "ngrok" } } };
-    expect(loadLastTunnelRecord()).toBeNull();
+  test("returns null for a provider outside the shared registry", () => {
+    // Readers render the provider into a shell command they tell the user to
+    // run, so an unknown one makes the whole record unusable.
+    rawConfig = {
+      ingress: {
+        lastTunnel: { provider: "wireguard", publicBaseUrl: TUNNEL_URL },
+      },
+    };
 
-    rawConfig = { ingress: { lastTunnel: { publicBaseUrl: TUNNEL_URL } } };
     expect(loadLastTunnelRecord()).toBeNull();
   });
 
-  test("returns null for a URL that is not absolute HTTP(S)", () => {
-    for (const publicBaseUrl of ["", "   ", "example.ts.net", "ftp://x.test"]) {
-      rawConfig = {
-        ingress: { lastTunnel: { provider: "ngrok", publicBaseUrl } },
-      };
-      expect(loadLastTunnelRecord()).toBeNull();
-    }
+  test("returns null for a malformed record", () => {
+    rawConfig = { ingress: { lastTunnel: { provider: "ngrok" } } };
+    expect(loadLastTunnelRecord()).toBeNull();
+
+    rawConfig = {
+      ingress: {
+        lastTunnel: { provider: "ngrok", publicBaseUrl: "example.ts.net" },
+      },
+    };
+    expect(loadLastTunnelRecord()).toBeNull();
   });
 
   test("returns null for a blank recorded assistant id", () => {

--- a/assistant/src/daemon/handlers/config-ingress.ts
+++ b/assistant/src/daemon/handlers/config-ingress.ts
@@ -1,4 +1,10 @@
-import { normalizeHttpPublicBaseUrl } from "@vellumai/service-contracts/ingress";
+import {
+  INGRESS_ASSISTANT_ID_KEY,
+  INGRESS_LAST_TUNNEL_KEY,
+  type LastTunnelRecord,
+  parseLastTunnelRecord,
+  parseRecordedAssistantId,
+} from "@vellumai/service-contracts/ingress";
 
 import { updatePhoneNumberWebhooks } from "../../calls/twilio-rest.js";
 import {
@@ -24,46 +30,19 @@ export function computeGatewayTarget(): string {
 /**
  * The `ingress` section of the raw workspace config.
  *
- * `vellum tunnel` writes this section (`cli/src/lib/ingress-config.ts`), so
- * the field names below are the contract between the two packages: the CLI is
- * a separate build unit the assistant does not depend on, so the assistant
- * reads the same keys rather than importing the CLI's readers.
+ * `vellum tunnel` writes this section (`cli/src/lib/ingress-config.ts`). The
+ * CLI is a separate build unit the assistant does not depend on, so the key
+ * names and the record validation are shared through
+ * `@vellumai/service-contracts/ingress` instead.
  */
 function readIngressSection(): Record<string, unknown> {
   const ingress = loadRawConfig().ingress;
   return isPlainObject(ingress) ? ingress : {};
 }
 
-function readNonEmptyString(value: unknown): string | null {
-  const trimmed = typeof value === "string" ? value.trim() : "";
-  return trimmed.length > 0 ? trimmed : null;
-}
-
-/** The tunnel that most recently ran; the CLI keeps it across teardown. */
-export interface LastTunnelRecord {
-  /** Provider name as the CLI wrote it, opaque here. */
-  provider: string;
-  publicBaseUrl: string;
-}
-
 /** Read the last tunnel that ran, or null when it is absent or malformed. */
 export function loadLastTunnelRecord(): LastTunnelRecord | null {
-  const record = readIngressSection().lastTunnel;
-  if (!isPlainObject(record)) {
-    return null;
-  }
-  const provider = readNonEmptyString(record.provider);
-  const publicBaseUrl = readNonEmptyString(record.publicBaseUrl);
-  // A hand-edited config must not hand callers an unusable address, so the
-  // URL faces the same absolute HTTP(S) constraint the CLI applies to it.
-  if (
-    !provider ||
-    !publicBaseUrl ||
-    !normalizeHttpPublicBaseUrl(publicBaseUrl)
-  ) {
-    return null;
-  }
-  return { provider, publicBaseUrl };
+  return parseLastTunnelRecord(readIngressSection()[INGRESS_LAST_TUNNEL_KEY]);
 }
 
 /**
@@ -71,7 +50,9 @@ export function loadLastTunnelRecord(): LastTunnelRecord | null {
  * daemon cannot derive it: it scopes itself as `self` internally.
  */
 export function loadRecordedAssistantId(): string | null {
-  return readNonEmptyString(readIngressSection().assistantId);
+  return parseRecordedAssistantId(
+    readIngressSection()[INGRESS_ASSISTANT_ID_KEY],
+  );
 }
 
 /**

--- a/assistant/src/runtime/routes/__tests__/ingress-status-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/ingress-status-routes.test.ts
@@ -7,12 +7,13 @@
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
-import type { LastTunnelRecord } from "../../../daemon/handlers/config-ingress.js";
+import type { LastTunnelRecord } from "@vellumai/service-contracts/ingress";
+
 import type { TunnelProbeResult } from "../../../inbound/tunnel-probe.js";
 import { ACTOR_PRINCIPALS } from "../../auth/route-policy.js";
 
 let ingressConfig = {
-  enabled: false,
+  enabled: true,
   publicBaseUrl: "",
   localGatewayTarget: "http://127.0.0.1:4000",
   managedCallbacks: false,
@@ -50,7 +51,7 @@ const TUNNEL_URL = "https://assistant-1.example.ts.net";
 describe("integrations_ingress_status route", () => {
   beforeEach(() => {
     ingressConfig = {
-      enabled: false,
+      enabled: true,
       publicBaseUrl: "",
       localGatewayTarget: "http://127.0.0.1:4000",
       managedCallbacks: false,
@@ -75,7 +76,6 @@ describe("integrations_ingress_status route", () => {
   test("reports unconfigured for a platform-hosted assistant", async () => {
     ingressConfig = {
       ...ingressConfig,
-      enabled: true,
       publicBaseUrl: "https://platform.example.com/gateway/callbacks/a-1",
       managedCallbacks: true,
     };
@@ -86,11 +86,14 @@ describe("integrations_ingress_status route", () => {
   });
 
   test("reports unconfigured with no URL and no recorded tunnel", async () => {
+    ingressConfig = { ...ingressConfig, publicBaseUrl: "" };
+
     expect(await route.handler({})).toEqual({ state: "unconfigured" });
     expect(probeTunnelMock).not.toHaveBeenCalled();
   });
 
   test("reports stopped with the recorded tunnel when the URL is gone", async () => {
+    ingressConfig = { ...ingressConfig, publicBaseUrl: "" };
     lastTunnel = { provider: "tailscale", publicBaseUrl: TUNNEL_URL };
 
     expect(await route.handler({})).toEqual({
@@ -100,12 +103,34 @@ describe("integrations_ingress_status route", () => {
     expect(probeTunnelMock).not.toHaveBeenCalled();
   });
 
-  test("reports healthy with a timestamp when the probe succeeds", async () => {
+  test("reports stopped without probing when ingress is switched off", async () => {
     ingressConfig = {
       ...ingressConfig,
-      enabled: true,
+      enabled: false,
       publicBaseUrl: TUNNEL_URL,
     };
+    lastTunnel = { provider: "tailscale", publicBaseUrl: TUNNEL_URL };
+
+    expect(await route.handler({})).toEqual({
+      state: "stopped",
+      lastTunnel: { provider: "tailscale", publicBaseUrl: TUNNEL_URL },
+    });
+    expect(probeTunnelMock).not.toHaveBeenCalled();
+  });
+
+  test("reports stopped for a disabled URL with no recorded tunnel", async () => {
+    ingressConfig = {
+      ...ingressConfig,
+      enabled: false,
+      publicBaseUrl: TUNNEL_URL,
+    };
+
+    expect(await route.handler({})).toEqual({ state: "stopped" });
+    expect(probeTunnelMock).not.toHaveBeenCalled();
+  });
+
+  test("reports healthy with a timestamp when the probe succeeds", async () => {
+    ingressConfig = { ...ingressConfig, publicBaseUrl: TUNNEL_URL };
     recordedAssistantId = "assistant-1";
 
     const result = (await route.handler({})) as Record<string, unknown>;
@@ -120,11 +145,7 @@ describe("integrations_ingress_status route", () => {
   });
 
   test("omits expectedAssistantId when no id was recorded", async () => {
-    ingressConfig = {
-      ...ingressConfig,
-      enabled: true,
-      publicBaseUrl: TUNNEL_URL,
-    };
+    ingressConfig = { ...ingressConfig, publicBaseUrl: TUNNEL_URL };
 
     await route.handler({});
 
@@ -134,11 +155,7 @@ describe("integrations_ingress_status route", () => {
   });
 
   test("reports unreachable with the probe's detail", async () => {
-    ingressConfig = {
-      ...ingressConfig,
-      enabled: true,
-      publicBaseUrl: TUNNEL_URL,
-    };
+    ingressConfig = { ...ingressConfig, publicBaseUrl: TUNNEL_URL };
     probeResult = { kind: "unreachable", detail: "HTTP 502" };
 
     const result = (await route.handler({})) as Record<string, unknown>;
@@ -150,11 +167,7 @@ describe("integrations_ingress_status route", () => {
   });
 
   test("reports foreign with the name the edge serves under", async () => {
-    ingressConfig = {
-      ...ingressConfig,
-      enabled: true,
-      publicBaseUrl: TUNNEL_URL,
-    };
+    ingressConfig = { ...ingressConfig, publicBaseUrl: TUNNEL_URL };
     recordedAssistantId = "assistant-1";
     probeResult = {
       kind: "foreign",
@@ -170,11 +183,7 @@ describe("integrations_ingress_status route", () => {
   });
 
   test("omits servingAssistantName when the edge reports no name", async () => {
-    ingressConfig = {
-      ...ingressConfig,
-      enabled: true,
-      publicBaseUrl: TUNNEL_URL,
-    };
+    ingressConfig = { ...ingressConfig, publicBaseUrl: TUNNEL_URL };
     probeResult = { kind: "foreign", assistantId: "assistant-2" };
 
     const result = (await route.handler({})) as Record<string, unknown>;
@@ -183,8 +192,46 @@ describe("integrations_ingress_status route", () => {
     expect(result).not.toHaveProperty("servingAssistantName");
   });
 
+  test("names the tunnel to restart when the URL is unreachable", async () => {
+    ingressConfig = { ...ingressConfig, publicBaseUrl: TUNNEL_URL };
+    lastTunnel = { provider: "ngrok", publicBaseUrl: TUNNEL_URL };
+    probeResult = { kind: "unreachable", detail: "HTTP 502" };
+
+    const result = (await route.handler({})) as Record<string, unknown>;
+
+    expect(result.state).toBe("unreachable");
+    expect(result.lastTunnel).toEqual({
+      provider: "ngrok",
+      publicBaseUrl: TUNNEL_URL,
+    });
+  });
+
+  test("names the tunnel to restart when the URL is foreign", async () => {
+    ingressConfig = { ...ingressConfig, publicBaseUrl: TUNNEL_URL };
+    lastTunnel = { provider: "ngrok", publicBaseUrl: TUNNEL_URL };
+    probeResult = { kind: "foreign", assistantId: "assistant-2" };
+
+    const result = (await route.handler({})) as Record<string, unknown>;
+
+    expect(result.state).toBe("foreign");
+    expect(result.lastTunnel).toEqual({
+      provider: "ngrok",
+      publicBaseUrl: TUNNEL_URL,
+    });
+  });
+
+  test("omits lastTunnel from a healthy response", async () => {
+    ingressConfig = { ...ingressConfig, publicBaseUrl: TUNNEL_URL };
+    lastTunnel = { provider: "ngrok", publicBaseUrl: TUNNEL_URL };
+
+    const result = (await route.handler({})) as Record<string, unknown>;
+
+    expect(result.state).toBe("healthy");
+    expect(result).not.toHaveProperty("lastTunnel");
+  });
+
   test("treats a whitespace-only URL as no URL", async () => {
-    ingressConfig = { ...ingressConfig, enabled: true, publicBaseUrl: "   " };
+    ingressConfig = { ...ingressConfig, publicBaseUrl: "   " };
 
     expect(await route.handler({})).toEqual({ state: "unconfigured" });
     expect(probeTunnelMock).not.toHaveBeenCalled();

--- a/assistant/src/runtime/routes/ingress-status-routes.ts
+++ b/assistant/src/runtime/routes/ingress-status-routes.ts
@@ -44,7 +44,9 @@ const IngressStatusResponseSchema = z.object({
   lastTunnel: z
     .object({ provider: z.string(), publicBaseUrl: z.string() })
     .optional()
-    .describe("The tunnel to restart. Set for stopped."),
+    .describe(
+      "The tunnel to restart. Set whenever one is recorded and the URL is not serving this assistant: stopped, unreachable, and foreign.",
+    ),
   servingAssistantName: z
     .string()
     .optional()
@@ -70,12 +72,19 @@ async function handleIngressStatus(): Promise<IngressStatusResponse> {
     return { state: "unconfigured" };
   }
 
+  // Carried by every state the user has to act on, so the client can name the
+  // command that brings the tunnel back.
+  const lastTunnel = loadLastTunnelRecord();
+  const restartHint = lastTunnel ? { lastTunnel } : {};
+
   const publicBaseUrl = config.publicBaseUrl.trim();
-  if (!publicBaseUrl) {
-    const lastTunnel = loadLastTunnelRecord();
-    return lastTunnel
-      ? { state: "stopped", lastTunnel }
-      : { state: "unconfigured" };
+  if (!publicBaseUrl && !lastTunnel) {
+    return { state: "unconfigured" };
+  }
+  // The URL survives the enabled toggle, so probing while ingress is off would
+  // report a tunnel the user switched off as healthy.
+  if (!publicBaseUrl || !config.enabled) {
+    return { state: "stopped", ...restartHint };
   }
 
   // Omitted when unrecorded so the probe skips the identity check entirely
@@ -91,11 +100,17 @@ async function handleIngressStatus(): Promise<IngressStatusResponse> {
     case "healthy":
       return { state: "healthy", ...checked };
     case "unreachable":
-      return { state: "unreachable", ...checked, detail: result.detail };
+      return {
+        state: "unreachable",
+        ...checked,
+        ...restartHint,
+        detail: result.detail,
+      };
     case "foreign":
       return {
         state: "foreign",
         ...checked,
+        ...restartHint,
         ...(result.assistantName
           ? { servingAssistantName: result.assistantName }
           : {}),
@@ -116,7 +131,7 @@ export const ROUTES: RouteDefinition[] = [
     },
     summary: "Get ingress tunnel status",
     description:
-      "Probe the configured public ingress URL and report whether a tunnel is serving this assistant. `unconfigured` means no tunnel has ever been recorded (or the assistant is platform-hosted, which never uses one), `stopped` means a tunnel ran before and `lastTunnel` names it, `healthy` means the URL answers and fronts this assistant, `unreachable` means it does not answer, and `foreign` means it answers for a different assistant.",
+      "Probe the configured public ingress URL and report whether a tunnel is serving this assistant. `unconfigured` means no tunnel has ever been recorded (or the assistant is platform-hosted, which never uses one), `stopped` means a tunnel ran before and is not running now (ingress is switched off, or its URL is gone), `healthy` means the URL answers and fronts this assistant, `unreachable` means it does not answer, and `foreign` means it answers for a different assistant. `lastTunnel` names the tunnel to restart on every state but `healthy` and `unconfigured`.",
     tags: ["config"],
     handler: handleIngressStatus,
     responseBody: IngressStatusResponseSchema,

--- a/assistant/src/runtime/routes/settings-routes.ts
+++ b/assistant/src/runtime/routes/settings-routes.ts
@@ -6,6 +6,11 @@
 import { readFileSync } from "node:fs";
 import { basename, join } from "node:path";
 
+import {
+  INGRESS_ASSISTANT_ID_KEY,
+  INGRESS_LAST_TUNNEL_KEY,
+  normalizePublicBaseUrl,
+} from "@vellumai/service-contracts/ingress";
 import { z } from "zod";
 
 import { setImage } from "../../avatar/avatar-store.js";
@@ -860,10 +865,17 @@ function handleUpdateIngressConfig({ body = {} }: RouteHandlerArgs) {
       publicBaseUrl?: string;
       enabled?: boolean;
     };
-    const value = (rawUrl ?? "").trim().replace(/\/+$/, "");
+    const value = normalizePublicBaseUrl(rawUrl);
     const raw = loadRawConfig();
     const ingress = (raw?.ingress ?? {}) as Record<string, unknown>;
-    ingress.publicBaseUrl = value || undefined;
+    if (value !== normalizePublicBaseUrl(ingress.publicBaseUrl)) {
+      // Both records describe the address being replaced, so keeping them
+      // makes the status route call a legitimate retarget `foreign` and name
+      // a tunnel that never fronted the new address.
+      delete ingress[INGRESS_ASSISTANT_ID_KEY];
+      delete ingress[INGRESS_LAST_TUNNEL_KEY];
+    }
+    ingress.publicBaseUrl = value;
     if (enabled !== undefined) {
       ingress.enabled = enabled;
     }
@@ -878,7 +890,7 @@ function handleUpdateIngressConfig({ body = {} }: RouteHandlerArgs) {
 
     return {
       enabled: isEnabled,
-      publicBaseUrl: value,
+      publicBaseUrl: value ?? "",
       localGatewayTarget: computeGatewayTarget(),
       success: true,
     };

--- a/cli/src/__tests__/ingress-config.test.ts
+++ b/cli/src/__tests__/ingress-config.test.ts
@@ -7,10 +7,10 @@ import { join } from "node:path";
 const testDir = mkdtempSync(join(tmpdir(), "ingress-config-test-"));
 process.env.VELLUM_LOCKFILE_DIR = testDir;
 
+import { parseLastTunnelRecord } from "@vellumai/service-contracts/ingress";
+
 import {
   clearIngressUrl,
-  loadLastTunnel,
-  loadRecordedAssistantId,
   saveIngressUrl,
   TUNNEL_PROVIDERS,
 } from "../lib/ingress-config.js";
@@ -131,11 +131,6 @@ describe("last-tunnel record", () => {
       publicBaseUrl: "https://a.trycloudflare.com",
     });
     expect(ingress.assistantId).toBe("ingress-test");
-    expect(loadLastTunnel(ws)).toEqual({
-      provider: "cloudflare",
-      publicBaseUrl: "https://a.trycloudflare.com",
-    });
-    expect(loadRecordedAssistantId(ws)).toBe("ingress-test");
   });
 
   test("clearIngressUrl drops the URL but keeps the tunnel and assistant records", () => {
@@ -149,12 +144,13 @@ describe("last-tunnel record", () => {
 
     clearIngressUrl(ws);
 
-    expect(readIngress(ws).publicBaseUrl).toBeUndefined();
-    expect(loadLastTunnel(ws)).toEqual({
+    const ingress = readIngress(ws);
+    expect(ingress.publicBaseUrl).toBeUndefined();
+    expect(ingress.lastTunnel).toEqual({
       provider: "tailscale",
       publicBaseUrl: "https://tunnel.example.ts.net",
     });
-    expect(loadRecordedAssistantId(ws)).toBe("ingress-test");
+    expect(ingress.assistantId).toBe("ingress-test");
   });
 
   test("saving without a provider leaves an existing lastTunnel untouched", () => {
@@ -163,69 +159,31 @@ describe("last-tunnel record", () => {
 
     saveIngressUrl(ws, "https://two.ngrok.app");
 
-    expect(readIngress(ws).publicBaseUrl).toBe("https://two.ngrok.app");
-    expect(loadLastTunnel(ws)).toEqual({
+    const ingress = readIngress(ws);
+    expect(ingress.publicBaseUrl).toBe("https://two.ngrok.app");
+    expect(ingress.lastTunnel).toEqual({
       provider: "ngrok",
       publicBaseUrl: "https://one.ngrok.app",
     });
   });
 
-  test("loadLastTunnel returns null for missing, unknown, or empty records", () => {
-    const missing = makeWorkspace();
-    expect(loadLastTunnel(missing)).toBeNull();
-    expect(loadRecordedAssistantId(missing)).toBeNull();
+  test("saving without a provider records no tunnel", () => {
+    const ws = makeWorkspace();
 
-    saveIngressUrl(missing, "https://one.ngrok.app");
-    expect(loadLastTunnel(missing)).toBeNull();
-    expect(loadRecordedAssistantId(missing)).toBeNull();
+    saveIngressUrl(ws, "https://one.ngrok.app");
 
-    const unknown = makeWorkspace();
-    writeFileSync(
-      join(unknown, "config.json"),
-      JSON.stringify({
-        ingress: {
-          lastTunnel: {
-            provider: "wireguard",
-            publicBaseUrl: "https://x.test",
-          },
-        },
-      }),
-    );
-    expect(loadLastTunnel(unknown)).toBeNull();
-
-    const emptyUrl = makeWorkspace();
-    writeFileSync(
-      join(emptyUrl, "config.json"),
-      JSON.stringify({
-        ingress: { lastTunnel: { provider: "ngrok", publicBaseUrl: "  " } },
-      }),
-    );
-    expect(loadLastTunnel(emptyUrl)).toBeNull();
+    const ingress = readIngress(ws);
+    expect(ingress.lastTunnel).toBeUndefined();
+    expect(ingress.assistantId).toBeUndefined();
   });
 
-  test("loadLastTunnel rejects a URL that is not absolute HTTP(S)", () => {
-    for (const publicBaseUrl of [
-      "not-a-url",
-      "one.ngrok.app",
-      "ftp://one.ngrok.app",
-      "https://one.ngrok.app?token=x",
-    ]) {
-      const ws = makeWorkspace();
-      writeFileSync(
-        join(ws, "config.json"),
-        JSON.stringify({
-          ingress: { lastTunnel: { provider: "ngrok", publicBaseUrl } },
-        }),
-      );
-      expect(loadLastTunnel(ws)).toBeNull();
-    }
-  });
-
-  test("every provider in the shared registry round-trips", () => {
+  test("every provider the CLI writes is one the shared parser accepts", () => {
+    // The daemon reads these records through parseLastTunnelRecord, so what
+    // `vellum tunnel` writes has to survive that parse for every provider.
     for (const provider of TUNNEL_PROVIDERS) {
       const ws = makeWorkspace();
       saveIngressUrl(ws, `https://${provider}.test`, undefined, provider);
-      expect(loadLastTunnel(ws)).toEqual({
+      expect(parseLastTunnelRecord(readIngress(ws).lastTunnel)).toEqual({
         provider,
         publicBaseUrl: `https://${provider}.test`,
       });

--- a/cli/src/lib/ingress-config.ts
+++ b/cli/src/lib/ingress-config.ts
@@ -2,7 +2,13 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 
-import { normalizeHttpPublicBaseUrl } from "@vellumai/service-contracts/ingress";
+import {
+  INGRESS_ASSISTANT_ID_KEY,
+  INGRESS_LAST_TUNNEL_KEY,
+  type LastTunnelRecord,
+  TUNNEL_PROVIDERS,
+  type TunnelProviderName,
+} from "@vellumai/service-contracts/ingress";
 
 import {
   lookupAssistantByIdentifier,
@@ -20,27 +26,9 @@ import {
  * no-`.vellum/`-reads boundary in cli/AGENTS.md.
  */
 
-/**
- * The local tunnel providers the CLI can start, in the order they are offered.
- * Single source of truth: the provider type, the persisted-record validation
- * below, and `vellum tunnel`'s accepted `--provider` values all derive from it.
- */
-export const TUNNEL_PROVIDERS = ["ngrok", "cloudflare", "tailscale"] as const;
-
-export type TunnelProviderName = (typeof TUNNEL_PROVIDERS)[number];
-
-function isTunnelProviderName(value: unknown): value is TunnelProviderName {
-  return (
-    typeof value === "string" &&
-    (TUNNEL_PROVIDERS as readonly string[]).includes(value)
-  );
-}
-
-/** The tunnel that most recently ran, kept after teardown so UIs can name the command to restart. */
-export interface LastTunnelRecord {
-  provider: TunnelProviderName;
-  publicBaseUrl: string;
-}
+// The tunnel-record contract (provider registry, record shape, key names) is
+// shared with the daemon, which reads what this module writes.
+export { TUNNEL_PROVIDERS, type TunnelProviderName };
 
 /** Default workspace dir: `$VELLUM_WORKSPACE_DIR` or `~/.vellum/workspace`. */
 export function getDefaultWorkspaceDir(): string {
@@ -117,47 +105,20 @@ export function saveIngressUrl(
   ingress.publicBaseUrl = publicUrl;
   ingress.enabled = true;
   if (provider) {
-    ingress.lastTunnel = {
+    ingress[INGRESS_LAST_TUNNEL_KEY] = {
       provider,
       publicBaseUrl: publicUrl,
     } satisfies LastTunnelRecord;
   }
   // The daemon can't derive this: it uses 'self' internally.
   if (assistantId) {
-    ingress.assistantId = assistantId;
+    ingress[INGRESS_ASSISTANT_ID_KEY] = assistantId;
   }
   config.ingress = ingress;
   saveRawConfig(workspaceDir, config);
   if (assistantId) {
     stampLockfileIngressUrl(assistantId, publicUrl);
   }
-}
-
-/** Read the last tunnel that ran, or null when absent or malformed. */
-export function loadLastTunnel(workspaceDir: string): LastTunnelRecord | null {
-  const record = loadIngressSection(workspaceDir)?.lastTunnel as
-    | Record<string, unknown>
-    | undefined;
-  const provider = record?.provider;
-  const publicBaseUrl = record?.publicBaseUrl;
-  // A hand-edited config must not hand callers an unusable address, so the URL
-  // faces the same absolute HTTP(S) constraint as every other public base URL.
-  if (
-    !isTunnelProviderName(provider) ||
-    typeof publicBaseUrl !== "string" ||
-    !normalizeHttpPublicBaseUrl(publicBaseUrl)
-  ) {
-    return null;
-  }
-  return { provider, publicBaseUrl: publicBaseUrl.trim() };
-}
-
-/** Read the assistant ID the last tunnel fronted, or null when absent. */
-export function loadRecordedAssistantId(workspaceDir: string): string | null {
-  const assistantId = loadIngressSection(workspaceDir)?.assistantId;
-  return typeof assistantId === "string" && assistantId.trim()
-    ? assistantId
-    : null;
 }
 
 /** Persist a reserved ngrok domain under `ingress.ngrok.domain`; null clears it. */

--- a/packages/service-contracts/src/__tests__/ingress.test.ts
+++ b/packages/service-contracts/src/__tests__/ingress.test.ts
@@ -3,6 +3,9 @@ import { describe, expect, test } from "bun:test";
 import {
   normalizeHttpPublicBaseUrl,
   normalizePublicBaseUrl,
+  parseLastTunnelRecord,
+  parseRecordedAssistantId,
+  TUNNEL_PROVIDERS,
   velayHostForPlatformHost,
 } from "../ingress.js";
 import {
@@ -121,5 +124,75 @@ describe("Twilio ingress helpers", () => {
       statusCallbackUrl: "https://example.test/webhooks/twilio/status",
       voiceUrl: "https://example.test/webhooks/twilio/voice",
     });
+  });
+});
+
+describe("parseLastTunnelRecord", () => {
+  const TUNNEL_URL = "https://assistant-1.example.ts.net";
+
+  test("accepts every provider in the registry", () => {
+    for (const provider of TUNNEL_PROVIDERS) {
+      expect(
+        parseLastTunnelRecord({ provider, publicBaseUrl: TUNNEL_URL }),
+      ).toEqual({ provider, publicBaseUrl: TUNNEL_URL });
+    }
+  });
+
+  test("trims the recorded URL", () => {
+    expect(
+      parseLastTunnelRecord({
+        provider: "ngrok",
+        publicBaseUrl: ` ${TUNNEL_URL} `,
+      }),
+    ).toEqual({ provider: "ngrok", publicBaseUrl: TUNNEL_URL });
+  });
+
+  test("rejects values that are not a record", () => {
+    for (const value of [undefined, null, "nonsense", 42, []]) {
+      expect(parseLastTunnelRecord(value)).toBeNull();
+    }
+  });
+
+  test("rejects a record missing either field", () => {
+    expect(parseLastTunnelRecord({ provider: "ngrok" })).toBeNull();
+    expect(parseLastTunnelRecord({ publicBaseUrl: TUNNEL_URL })).toBeNull();
+  });
+
+  test("rejects a provider outside the registry", () => {
+    // Readers render the provider into a `vellum tunnel --provider <name>`
+    // command, so a hand-edited config must not reach a terminal.
+    for (const provider of ["wireguard", "; rm -rf /", "", 42]) {
+      expect(
+        parseLastTunnelRecord({ provider, publicBaseUrl: TUNNEL_URL }),
+      ).toBeNull();
+    }
+  });
+
+  test("rejects a URL that is not absolute HTTP(S)", () => {
+    for (const publicBaseUrl of [
+      "",
+      "   ",
+      "not-a-url",
+      "example.ts.net",
+      "ftp://x.test",
+      "https://one.ngrok.app?token=x",
+      42,
+    ]) {
+      expect(
+        parseLastTunnelRecord({ provider: "ngrok", publicBaseUrl }),
+      ).toBeNull();
+    }
+  });
+});
+
+describe("parseRecordedAssistantId", () => {
+  test("trims a recorded id", () => {
+    expect(parseRecordedAssistantId(" assistant-1 ")).toBe("assistant-1");
+  });
+
+  test("rejects blank and non-string values", () => {
+    for (const value of ["", "   ", undefined, null, 42]) {
+      expect(parseRecordedAssistantId(value)).toBeNull();
+    }
   });
 });

--- a/packages/service-contracts/src/ingress.ts
+++ b/packages/service-contracts/src/ingress.ts
@@ -48,3 +48,68 @@ export function normalizeHttpPublicBaseUrl(value: unknown): string | undefined {
     return undefined;
   }
 }
+
+// Records `vellum tunnel` leaves in the workspace config's `ingress` section.
+// The CLI writes them and the daemon reads them, and the two are separate
+// build units that cannot import each other, so the key names, the provider
+// allowlist, and the validation all live here rather than in a copy on each
+// side.
+
+/** Key under `ingress` holding the tunnel that most recently ran. */
+export const INGRESS_LAST_TUNNEL_KEY = "lastTunnel";
+
+/** Key under `ingress` holding the assistant id that tunnel fronted. */
+export const INGRESS_ASSISTANT_ID_KEY = "assistantId";
+
+/**
+ * The local tunnel providers the CLI can start, in the order they are offered.
+ * `vellum tunnel`'s accepted `--provider` values and the persisted-record
+ * validation below both derive from it.
+ */
+export const TUNNEL_PROVIDERS = ["ngrok", "cloudflare", "tailscale"] as const;
+
+export type TunnelProviderName = (typeof TUNNEL_PROVIDERS)[number];
+
+/** The tunnel that most recently ran, kept after teardown so UIs can name the command to restart. */
+export interface LastTunnelRecord {
+  provider: TunnelProviderName;
+  publicBaseUrl: string;
+}
+
+function isTunnelProviderName(value: unknown): value is TunnelProviderName {
+  return (
+    typeof value === "string" &&
+    (TUNNEL_PROVIDERS as readonly string[]).includes(value)
+  );
+}
+
+/**
+ * Parse an `ingress.lastTunnel` value, or null when it is absent or malformed.
+ *
+ * A hand-edited config must not hand callers an unusable address or a provider
+ * name no command accepts: the provider is checked against the allowlist
+ * because readers render it into a restart command, and the URL faces the same
+ * absolute HTTP(S) constraint as every other public base URL.
+ */
+export function parseLastTunnelRecord(value: unknown): LastTunnelRecord | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return null;
+  }
+  const { provider, publicBaseUrl } = value as Record<string, unknown>;
+  if (!isTunnelProviderName(provider) || typeof publicBaseUrl !== "string") {
+    return null;
+  }
+  if (!normalizeHttpPublicBaseUrl(publicBaseUrl)) {
+    return null;
+  }
+  return { provider, publicBaseUrl: publicBaseUrl.trim() };
+}
+
+/** Parse an `ingress.assistantId` value, or null when it is absent or blank. */
+export function parseRecordedAssistantId(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}


### PR DESCRIPTION
## Summary

- Move the tunnel-record contract (`ingress.lastTunnel` / `ingress.assistantId` key names, `TUNNEL_PROVIDERS`, `LastTunnelRecord`, and one validating parser pair) into `@vellumai/service-contracts/ingress`, so the CLI writer and the daemon reader stop drifting; the CLI's unused readers are deleted and the daemon's hand-rolled copy now delegates. An unknown `provider` invalidates the record, so a hand-edited config can no longer put arbitrary text into the `vellum tunnel --provider ...` command the UI tells the user to run.
- Teach `integrations/ingress/status` to honor `ingress.enabled`: a recorded URL with ingress switched off reports `stopped` instead of probing, and `lastTunnel` now rides along on `unreachable` and `foreign` too so those states can name a restart command.
- Drop `ingress.assistantId` and `ingress.lastTunnel` in `integrations_ingress_config_put` when the URL being written differs from the recorded one, so retargeting through settings no longer surfaces as `foreign` and clearing the URL no longer prints a restart command for a tunnel the user never ran.

`openapi.yaml` changes are description-only (no field or type changes, so the generated SDK is unaffected).

Fixes gaps identified during plan review for tunnel-status-pairing.md.