### PR TITLE
fix(web): give unhealthy tunnel states a way out and stop the check age freezing

### DIFF
--- a/clients/web/src/domains/settings/pair-device/pair-device-card.test.tsx
+++ b/clients/web/src/domains/settings/pair-device/pair-device-card.test.tsx
@@ -1,6 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   act,
   cleanup,
@@ -10,9 +9,22 @@ import {
   waitFor,
 } from "@testing-library/react";
 
-import type { IntegrationsIngressStatusGetResponse } from "@/generated/daemon/types.gen";
 import { publish, __resetForTesting as resetEventBus } from "@/lib/event-bus";
 import type { LocalListDevicesResult } from "@/runtime/local-mode-host";
+
+import {
+  createQueryClientWrapper,
+  createTimerHarness,
+  fetchLog,
+  installFetch as installRecordingFetch,
+  installIngressProbe,
+  jsonResponse,
+  pendingRequest,
+  requestBody,
+  resetFetchLog,
+  restoreFetch,
+  VERSION_BELOW_INGRESS_STATUS,
+} from "./pair-device-test-helpers";
 
 let gatewayPath: string | undefined = "/assistant/__gateway/20100";
 let supportsPairingRoutes = true;
@@ -55,36 +67,13 @@ mock.module("@/hooks/use-is-org-ready", () => ({
   useIsOrgReady: () => true,
 }));
 
-let probeResponse: IntegrationsIngressStatusGetResponse = {
-  state: "unconfigured",
-};
-/** Set by a test to make the probe fail the way a dead daemon would. */
-let probeFailure: Error | null = null;
-/** Set by a test to leave the probe in flight the way a slow daemon would. */
-let probeStalls = false;
-const probeMock = mock(async () => {
-  if (probeStalls) {
-    await new Promise(() => {});
-  }
-  if (probeFailure) {
-    throw probeFailure;
-  }
-  return {
-    data: probeResponse,
-    error: undefined,
-    response: new Response(null, { status: 200 }),
-  };
-});
-
-/* Spread over the real module rather than replacing it: the generated SDK is a
-   single barrel that the query-options barrel also pulls from, and a bare
-   object drops every export this file does not name. */
-const realDaemonSdk = await import("@/generated/daemon/sdk.gen");
-
-mock.module("@/generated/daemon/sdk.gen", () => ({
-  ...realDaemonSdk,
-  integrationsIngressStatusGet: probeMock,
-}));
+const {
+  probe: probeMock,
+  respondWith: probeAnswers,
+  failWith: probeFails,
+  stall: probeStalls,
+  reset: resetProbe,
+} = await installIngressProbe({ state: "unconfigured" });
 
 let listDevicesResult: LocalListDevicesResult = {
   ok: false,
@@ -113,22 +102,9 @@ const { useAssistantIdentityStore } = await import(
 const { useResolvedAssistantsStore } = await import(
   "@/stores/resolved-assistants-store"
 );
-const {
-  createTimerHarness,
-  fetchLog,
-  installFetch: installRecordingFetch,
-  jsonResponse,
-  pendingRequest,
-  requestBody,
-  resetFetchLog,
-  restoreFetch,
-} = await import("./pair-device-test-helpers");
-
 const PUBLIC_URL = "https://foo.ts.net";
 const PAIR_URL = "https://foo.ts.net/assistant/pair#device_code=DEV-123";
 const ASSISTANT_ID = "self";
-/** Below the ingress-status floor, so the probe stays out of reach. */
-const VERSION_WITHOUT_INGRESS_STATUS = "0.11.5";
 const TUNNEL_URL = "https://tunnel.example.ts.net";
 const RECORDED_INGRESS_URL = "https://recorded.example.ts.net";
 /** Where `usePairDevice` remembers the last URL that minted a code. */
@@ -152,13 +128,11 @@ function healthyStatus(publicBaseUrl = TUNNEL_URL) {
 
 /** Render inside a fresh query client, which the tunnel-status probe needs. */
 function renderCard() {
-  const client = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
-  });
+  const { wrapper: QueryWrapper } = createQueryClientWrapper();
   return render(
-    <QueryClientProvider client={client}>
+    <QueryWrapper>
       <PairDeviceCard />
-    </QueryClientProvider>,
+    </QueryWrapper>,
   );
 }
 
@@ -280,15 +254,12 @@ beforeEach(() => {
   listDevicesCalls = 0;
   resetFetchLog();
   localStorage.clear();
-  probeResponse = { state: "unconfigured" };
-  probeFailure = null;
-  probeStalls = false;
-  probeMock.mockClear();
+  resetProbe();
   useResolvedAssistantsStore.getState().setActiveAssistantId(ASSISTANT_ID);
   // Tests that exercise the status row opt into a version that serves it.
   useAssistantIdentityStore
     .getState()
-    .setIdentity("Test", VERSION_WITHOUT_INGRESS_STATUS, ASSISTANT_ID);
+    .setIdentity("Test", VERSION_BELOW_INGRESS_STATUS, ASSISTANT_ID);
   // A rendered card polls the pending-request list on mount, so every test
   // needs the route answered; minting stays unexpected unless overridden.
   installFetch(unexpectedMint);
@@ -732,7 +703,7 @@ describe("PairDeviceCard: tunnel status", () => {
   });
 
   test("shows the status row for a healthy tunnel, without the first-run notice", async () => {
-    probeResponse = healthyStatus();
+    probeAnswers(healthyStatus());
     renderCard();
 
     expect(
@@ -743,7 +714,7 @@ describe("PairDeviceCard: tunnel status", () => {
   });
 
   test("shows the first-run notice only once the daemon reports no tunnel", async () => {
-    probeResponse = { state: "unconfigured" };
+    probeAnswers({ state: "unconfigured" });
     renderCard();
 
     // The in-flight probe is not an empty state, so the row speaks first.
@@ -760,7 +731,7 @@ describe("PairDeviceCard: tunnel status", () => {
   });
 
   test("re-checks the tunnel when the app resumes", async () => {
-    probeResponse = healthyStatus();
+    probeAnswers(healthyStatus());
     renderCard();
     await screen.findByText("The tunnel is running and reachable.");
     expect(probeMock).toHaveBeenCalledTimes(1);
@@ -776,7 +747,7 @@ describe("PairDeviceCard: tunnel status", () => {
       cloud: "local",
       ingressUrl: RECORDED_INGRESS_URL,
     };
-    probeResponse = healthyStatus();
+    probeAnswers(healthyStatus());
     renderCard();
 
     await screen.findByText("The tunnel is running and reachable.");
@@ -794,7 +765,7 @@ describe("PairDeviceCard: tunnel status", () => {
       cloud: "local",
       ingressUrl: RECORDED_INGRESS_URL,
     };
-    probeResponse = { state: "unconfigured" };
+    probeAnswers({ state: "unconfigured" });
     renderCard();
 
     expect(await screen.findByText("Open a tunnel first")).toBeTruthy();
@@ -802,7 +773,7 @@ describe("PairDeviceCard: tunnel status", () => {
   });
 
   test("keeps a typed URL, and the field open, when the probe answers again", async () => {
-    probeResponse = healthyStatus();
+    probeAnswers(healthyStatus());
     renderCard();
     await screen.findByText("The tunnel is running and reachable.");
     openUrlField();
@@ -814,7 +785,7 @@ describe("PairDeviceCard: tunnel status", () => {
   });
 
   test("offers a primary Generate button when the tunnel is healthy", async () => {
-    probeResponse = healthyStatus();
+    probeAnswers(healthyStatus());
     renderCard();
 
     await screen.findByText("The tunnel is running and reachable.");
@@ -826,11 +797,11 @@ describe("PairDeviceCard: tunnel status", () => {
   });
 
   test("an unreachable tunnel demotes Generate without disabling it", async () => {
-    probeResponse = {
+    probeAnswers({
       state: "unreachable",
       publicBaseUrl: TUNNEL_URL,
       checkedAt: new Date().toISOString(),
-    };
+    });
     renderCard();
 
     const button = (await screen.findByRole("button", {
@@ -846,11 +817,11 @@ describe("PairDeviceCard: tunnel status", () => {
   });
 
   test("a foreign tunnel gets the same Generate anyway treatment", async () => {
-    probeResponse = {
+    probeAnswers({
       state: "foreign",
       publicBaseUrl: TUNNEL_URL,
       checkedAt: new Date().toISOString(),
-    };
+    });
     renderCard();
 
     const button = (await screen.findByRole("button", {
@@ -860,7 +831,7 @@ describe("PairDeviceCard: tunnel status", () => {
   });
 
   test("hides the URL field behind a disclosure once an address is known", async () => {
-    probeResponse = healthyStatus();
+    probeAnswers(healthyStatus());
     renderCard();
 
     await screen.findByText("The tunnel is running and reachable.");
@@ -874,7 +845,7 @@ describe("PairDeviceCard: tunnel status", () => {
     // The stale-address hazard: without a verdict yet, the field is prefilled
     // from the last URL that worked, and Generate would mint against it.
     localStorage.setItem(STORED_URL_KEY, STORED_URL);
-    probeStalls = true;
+    probeStalls();
     renderCard();
 
     expect(
@@ -893,7 +864,7 @@ describe("PairDeviceCard: tunnel status", () => {
 
   test("collapses the field only once the verdict carries the daemon's address", async () => {
     localStorage.setItem(STORED_URL_KEY, STORED_URL);
-    probeResponse = healthyStatus();
+    probeAnswers(healthyStatus());
     renderCard();
 
     // First render is the in-flight probe: the stored address still leads.
@@ -907,7 +878,7 @@ describe("PairDeviceCard: tunnel status", () => {
   });
 
   test("a verdict arriving mid-typing cannot collapse the field", async () => {
-    probeResponse = healthyStatus();
+    probeAnswers(healthyStatus());
     renderCard();
 
     // Typed into the pre-verdict layout, before the disclosure exists.
@@ -918,7 +889,7 @@ describe("PairDeviceCard: tunnel status", () => {
   });
 
   test("keeps the URL field in the open when the daemon reports no tunnel", async () => {
-    probeResponse = { state: "unconfigured" };
+    probeAnswers({ state: "unconfigured" });
     renderCard();
 
     expect(await screen.findByText("Open a tunnel first")).toBeTruthy();
@@ -926,23 +897,121 @@ describe("PairDeviceCard: tunnel status", () => {
     expect(urlDisclosure()).toBeNull();
   });
 
-  test("keeps the URL field in the open for a stopped tunnel, prefilled from its record", async () => {
-    probeResponse = {
+  test("leaves a stopped tunnel's Generate disabled behind an empty field", async () => {
+    probeAnswers({
       state: "stopped",
       lastTunnel: { provider: "tailscale", publicBaseUrl: TUNNEL_URL },
-    };
+    });
     renderCard();
 
     await screen.findByText(
       "The tunnel is stopped, so other devices cannot reach this assistant.",
     );
-    expect(urlField().value).toBe(TUNNEL_URL);
+    // The recorded address serves nothing, so the row prints it as part of the
+    // restart hint and the field stays empty rather than advertising it.
+    expect(screen.getByText(TUNNEL_URL)).toBeTruthy();
+    expect(urlField().value).toBe("");
     expect(urlDisclosure()).toBeNull();
+    expect(
+      (
+        screen.getByRole("button", {
+          name: "Generate pairing QR",
+        }) as HTMLButtonElement
+      ).disabled,
+    ).toBe(true);
+  });
+
+  test("keeps the URL field leading when the verdict carries no address", async () => {
+    // `publicBaseUrl` is optional on every state of the flat wire response, so
+    // an empty one must not read as an address the card can lead with.
+    probeAnswers({ state: "healthy", checkedAt: new Date().toISOString() });
+    renderCard();
+
+    expect(
+      await screen.findByText("The tunnel is running and reachable."),
+    ).toBeTruthy();
+    expect(urlDisclosure()).toBeNull();
+    expect(urlField().value).toBe("");
+  });
+
+  test("tells an unreachable tunnel how to start again, naming the assistant", async () => {
+    selectedAssistant = {
+      assistantId: ASSISTANT_ID,
+      cloud: "local",
+      name: "My Assistant",
+    };
+    probeAnswers({
+      state: "unreachable",
+      publicBaseUrl: TUNNEL_URL,
+      checkedAt: new Date().toISOString(),
+      detail: "connection refused",
+      lastTunnel: { provider: "tailscale", publicBaseUrl: TUNNEL_URL },
+    });
+    renderCard();
+
+    expect(
+      await screen.findByText("This address is not answering right now."),
+    ).toBeTruthy();
+    expect(screen.getByText("connection refused")).toBeTruthy();
+    expect(
+      screen.getByText('vellum tunnel "My Assistant" --provider tailscale'),
+    ).toBeTruthy();
+  });
+
+  test("names the assistant in the first-run tunnel command", async () => {
+    selectedAssistant = {
+      assistantId: ASSISTANT_ID,
+      cloud: "local",
+      name: "My Assistant",
+    };
+    probeAnswers({ state: "unconfigured" });
+    renderCard();
+
+    expect(await screen.findByText("Open a tunnel first")).toBeTruthy();
+    expect(
+      screen.getByText('vellum tunnel "My Assistant" --provider tailscale'),
+    ).toBeTruthy();
+  });
+
+  test("the check age advances while the card sits open", async () => {
+    probeAnswers({
+      state: "healthy",
+      publicBaseUrl: TUNNEL_URL,
+      checkedAt: new Date(Date.now() - 60_000).toISOString(),
+    });
+    // Timer harness instead of fake timers (bun has none): the card's age tick
+    // is fired by hand, and the harness is restored in `finally`.
+    const timerHarness = createTimerHarness();
+    const realDateNow = Date.now;
+    timerHarness.install();
+    try {
+      renderCard();
+      // `waitFor` needs the real `setInterval` the harness replaced, so the
+      // probe's verdict is waited out by hand instead.
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      });
+      expect(screen.getByText("Checked 1 minute ago")).toBeTruthy();
+
+      // Advance the clock 4 minutes and fire the age-refresh tick.
+      const now = realDateNow();
+      Date.now = () => now + 4 * 60_000;
+      const ageTick = timerHarness.timers.find(
+        (timer) => timer.delay === 30_000,
+      );
+      expect(ageTick).toBeTruthy();
+      act(() => ageTick?.handler());
+
+      expect(screen.getByText("Checked 5 minutes ago")).toBeTruthy();
+    } finally {
+      timerHarness.restore();
+      Date.now = realDateNow;
+    }
   });
 
   test("mints against the address typed into the disclosed field", async () => {
     installFetch(() => jsonResponse(challengeBody()));
-    probeResponse = healthyStatus();
+    probeAnswers(healthyStatus());
     renderCard();
     await screen.findByText("The tunnel is running and reachable.");
 
@@ -965,7 +1034,7 @@ describe("PairDeviceCard: tunnel status", () => {
 describe("PairDeviceCard: when the tunnel probe gives up", () => {
   beforeEach(() => {
     enableTunnelStatus();
-    probeFailure = new Error("connection refused");
+    probeFails(new Error("connection refused"));
   });
 
   test("falls back to the recorded ingress URL, notice and all", async () => {
@@ -1013,7 +1082,7 @@ describe("PairDeviceCard: without the ingress-status route", () => {
       cloud: "local",
       ingressUrl: RECORDED_INGRESS_URL,
     };
-    probeResponse = healthyStatus();
+    probeAnswers(healthyStatus());
     renderCard();
 
     expect(urlField().value).toBe(RECORDED_INGRESS_URL);

--- a/clients/web/src/domains/settings/pair-device/pair-device-card.tsx
+++ b/clients/web/src/domains/settings/pair-device/pair-device-card.tsx
@@ -8,12 +8,10 @@ import { Input } from "@vellumai/design-library/components/input";
 import { Notice } from "@vellumai/design-library/components/notice";
 import { cn } from "@vellumai/design-library/utils/cn";
 
-import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
 import { DetailCard } from "@/components/detail-card";
 import { useBusSubscription } from "@/hooks/use-bus-subscription";
 import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
 import { Trans, useTranslation } from "@/i18n";
-import { useSupportsIngressStatus } from "@/lib/backwards-compat/ingress-status-gate";
 import { useSupportsRemoteWebPairing } from "@/lib/backwards-compat/remote-web-pairing-gate";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 
@@ -21,12 +19,18 @@ import { resolvePairDeviceTarget } from "./pair-device-client";
 import { PairDeviceReady } from "./pair-device-ready";
 import { PairedDevicesSection } from "./paired-devices-section";
 import { PendingPairingRequests } from "./pending-pairing-requests";
-import { statusPublicBaseUrl, TunnelStatusRow } from "./tunnel-status-row";
+import {
+  statusCheckedAt,
+  statusPublicBaseUrl,
+  TunnelStatusRow,
+  tunnelStartCommand,
+} from "./tunnel-status-row";
 import { usePairDevice } from "./use-pair-device";
+import { useRelativeAgeTick } from "./use-relative-age-tick";
 import { useTunnelStatus } from "./use-tunnel-status";
 
-/** Names a provider explicitly: the CLI's `vellum` default is not implemented. */
-const TUNNEL_COMMAND = "vellum tunnel --provider tailscale";
+/** Named explicitly: the CLI's `vellum` default is not implemented. */
+const TUNNEL_PROVIDER = "tailscale";
 const TUNNEL_HELP_COMMAND = "vellum tunnel --help";
 
 /** The URL field's disclosure holds a single section. */
@@ -49,9 +53,9 @@ const CODE_CLASS =
  * notice, the URL field's prefill and whether it hides behind its disclosure,
  * and how much the Generate button insists. The probe re-runs on the
  * `app.resume` foreground edge. Where that probe has no verdict, because the
- * assistant sits below {@link useSupportsIngressStatus}'s floor or because the
- * query gave up, the card falls back to the assistant's recorded ingress URL
- * and infers the empty state from the field.
+ * assistant sits below the ingress-status version floor or because the query
+ * gave up, the card falls back to the assistant's recorded ingress URL and
+ * infers the empty state from the field.
  *
  * Rendered only in desktop/local mode against an on-machine gateway (the gate
  * lives in {@link resolvePairDeviceTarget}) whose assistant version serves the
@@ -67,23 +71,29 @@ export function PairDeviceCard() {
   const supported = useSupportsRemoteWebPairing();
   const webRemoteIngressOn = useClientFeatureFlagStore.use.webRemoteIngress();
   const pairedDevicesUIOn = useClientFeatureFlagStore.use.pairedDevicesUI();
-  const assistantId = useActiveAssistantId();
-  const probesTunnel = useSupportsIngressStatus(assistantId);
   const surfaceEnabled = supported && webRemoteIngressOn;
   const tunnel = useTunnelStatus(surfaceEnabled && target !== null);
-  // Whether the daemon's verdict is the card's source of truth right now. An
-  // assistant that cannot be asked, and a probe that came back with nothing,
-  // both leave the card on its pre-probe behavior below.
-  const probeAnswered = probesTunnel && tunnel.status.kind !== "unavailable";
+  // Whether the daemon's verdict is the card's source of truth right now. The
+  // hook already folds every way the probe can fail to answer into
+  // `unavailable`, the version gate included, so this is the whole condition;
+  // re-deriving the gate here would only give it a second place to drift.
+  const probeAnswered = tunnel.status.kind !== "unavailable";
   // The user starts the tunnel in a terminal and tabs back, so the foreground
   // edge is the re-check that matters most.
   useBusSubscription("app.resume", () => {
     tunnel.refresh();
   });
+  // The card owns the tick behind the row's check age; the row stays
+  // timer-free, per its own docstring.
+  useRelativeAgeTick(statusCheckedAt(tunnel.status) !== null);
   // The address the daemon's current answer carries, if any. `null` while the
   // probe is still checking, so nothing downstream mistakes a fallback for a
-  // reported address.
-  const statusAddress = statusPublicBaseUrl(tunnel.status);
+  // reported address, and `null` for a stopped tunnel: its recorded address
+  // serves nothing, so it is a command to re-run rather than one to advertise.
+  const statusAddress =
+    tunnel.status.kind === "stopped"
+      ? null
+      : statusPublicBaseUrl(tunnel.status);
   const pair = usePairDevice(
     target?.base ?? null,
     probeAnswered ? statusAddress : (target?.ingressUrl ?? null),
@@ -130,10 +140,8 @@ export function PairDeviceCard() {
         : t("pairDeviceCard.generateButton");
   // The URL field only hides behind its disclosure once the address it would
   // advertise is the one the daemon just reported. Until then it leads, so a
-  // click can never mint a stale stored address the user never saw. A stopped
-  // tunnel's recorded address serves nothing, so its field leads too.
-  const daemonHasAddress =
-    probeAnswered && statusAddress !== null && tunnel.status.kind !== "stopped";
+  // click can never mint a stale stored address the user never saw.
+  const daemonHasAddress = probeAnswered && statusAddress !== null;
   // A rejected address opens the field too, or its error would report from
   // inside a closed disclosure.
   const urlFieldOpen = urlFieldOpened || pair.inputError !== null;
@@ -193,7 +201,7 @@ export function PairDeviceCard() {
                   "w-fit max-w-full overflow-x-auto px-2.5 py-1.5",
                 )}
               >
-                {TUNNEL_COMMAND}
+                {tunnelStartCommand(TUNNEL_PROVIDER, target.assistantName)}
               </code>
               <p>{t("pairDeviceCard.noTunnelNext")}</p>
               <p>
@@ -213,6 +221,7 @@ export function PairDeviceCard() {
           status={tunnel.status}
           onRefresh={tunnel.refresh}
           isRefreshing={tunnel.isRefreshing}
+          assistantName={target.assistantName}
         />
         {/* With a reported address in hand the action leads and the field
             hides behind its disclosure. Without one the field leads and the

--- a/clients/web/src/domains/settings/pair-device/pair-device-test-helpers.ts
+++ b/clients/web/src/domains/settings/pair-device/pair-device-test-helpers.ts
@@ -1,17 +1,108 @@
 /**
  * Shared scaffolding for the pair-device test files: the fetch stub with its
- * request log, JSON response builders, the pending-request fixture, and the
- * armed-timer capture harness standing in for fake timers (bun's test runner
- * has none). Test semantics stay in the test files; only plumbing lives here.
+ * request log, JSON response builders, the pending-request fixture, the
+ * tunnel-probe mock, the query-client wrapper, and the armed-timer capture
+ * harness standing in for fake timers (bun's test runner has none). Test
+ * semantics stay in the test files; only plumbing lives here.
  */
 
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { mock } from "bun:test";
+import { createElement, type ReactElement, type ReactNode } from "react";
 
 import type { RemoteWebPairingRequestSummary } from "@vellumai/service-contracts/remote-web-pairing";
+
+import type { IntegrationsIngressStatusGetResponse } from "@/generated/daemon/types.gen";
 
 /** Local-gateway base URL used across the pair-device tests. */
 export const TEST_GATEWAY_BASE =
   "http://localhost:3000/assistant/__gateway/20100";
+
+/** An assistant version below the ingress-status floor, so no probe goes out. */
+export const VERSION_BELOW_INGRESS_STATUS = "0.11.5";
+
+/**
+ * A fresh query client and the provider wrapper around it, which anything
+ * rendering the tunnel-status probe needs. Retries are off so a failing probe
+ * reaches its error state inside a test's patience.
+ */
+export function createQueryClientWrapper(): {
+  client: QueryClient;
+  wrapper: (props: { children: ReactNode }) => ReactElement;
+} {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return {
+    client,
+    wrapper: ({ children }) =>
+      createElement(QueryClientProvider, { client }, children),
+  };
+}
+
+/**
+ * Swap the generated ingress-status call for a mock the caller steers. Call it
+ * at the top level of a test file, before importing the module under test, and
+ * `reset()` it in `beforeEach`.
+ *
+ * Mocking the SDK call, rather than only reading TanStack's `fetchStatus`, is
+ * what lets a test count probes: an imperative `refetch()` that a guard should
+ * have swallowed leaves no trace in the query state but does show up here.
+ */
+export async function installIngressProbe(
+  defaultResponse: IntegrationsIngressStatusGetResponse,
+) {
+  let response = defaultResponse;
+  let failure: Error | null = null;
+  let stalls = false;
+
+  const probe = mock(async () => {
+    if (stalls) {
+      await new Promise(() => {});
+    }
+    if (failure) {
+      throw failure;
+    }
+    return {
+      data: response,
+      error: undefined,
+      response: new Response(null, { status: 200 }),
+    };
+  });
+
+  /* Spread over the real module rather than replacing it: the generated SDK is
+     a single barrel that the query-options barrel also pulls from, and a bare
+     object drops every export not named here. */
+  const realDaemonSdk = await import("@/generated/daemon/sdk.gen");
+  mock.module("@/generated/daemon/sdk.gen", () => ({
+    ...realDaemonSdk,
+    integrationsIngressStatusGet: probe,
+  }));
+
+  return {
+    /** The mocked call itself, for call-count assertions. */
+    probe,
+    /** Answer every probe from here on with this response. */
+    respondWith(next: IntegrationsIngressStatusGetResponse) {
+      response = next;
+    },
+    /** Fail every probe from here on, the way a dead daemon would. */
+    failWith(error: Error) {
+      failure = error;
+    },
+    /** Leave every probe from here on in flight, the way a slow daemon would. */
+    stall() {
+      stalls = true;
+    },
+    /** Back to the default answer, with the call log cleared. */
+    reset() {
+      response = defaultResponse;
+      failure = null;
+      stalls = false;
+      probe.mockClear();
+    },
+  };
+}
 
 export function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {

--- a/clients/web/src/domains/settings/pair-device/pending-pairing-requests.tsx
+++ b/clients/web/src/domains/settings/pair-device/pending-pairing-requests.tsx
@@ -1,5 +1,3 @@
-import { useEffect, useState } from "react";
-
 import { Button } from "@vellumai/design-library/components/button";
 import { Notice } from "@vellumai/design-library/components/notice";
 import { Loader2 } from "lucide-react";
@@ -7,6 +5,7 @@ import { Loader2 } from "lucide-react";
 import { currentLocale, useTranslation } from "@/i18n";
 import { formatRelativeTime } from "@/lib/relative-time";
 
+import { useRelativeAgeTick } from "./use-relative-age-tick";
 import { usePendingPairingRequests } from "./use-pending-pairing-requests";
 
 interface PendingPairingRequestsProps {
@@ -15,9 +14,6 @@ interface PendingPairingRequestsProps {
   /** Fired when an action pairs a device, so siblings can revalidate. */
   onApproved?: () => void;
 }
-
-/** How often visible relative ages re-render; 30s suits minute phrasing. */
-const AGE_REFRESH_INTERVAL_MS = 30_000;
 
 /**
  * Relative label for a request's timestamp in the active i18n locale.
@@ -48,20 +44,8 @@ export function PendingPairingRequests({
     usePendingPairingRequests(base, onApproved);
 
   // The hook keeps a stable list reference while the pending set is unchanged,
-  // so nothing re-renders on its own and relative ages would freeze. Tick a
-  // render while any request is visible so `formatRequestedAt` stays current.
-  const hasRequests = requests.length > 0;
-  const [, setAgeTick] = useState(0);
-  useEffect(() => {
-    if (!hasRequests) {
-      return;
-    }
-    const intervalId = setInterval(
-      () => setAgeTick((tick) => tick + 1),
-      AGE_REFRESH_INTERVAL_MS,
-    );
-    return () => clearInterval(intervalId);
-  }, [hasRequests]);
+  // so nothing here re-renders on its own and the ages below would freeze.
+  useRelativeAgeTick(requests.length > 0);
 
   // An empty list with no error is the quiet normal state; a poll error must
   // still surface so an outage isn't mistaken for an empty queue.

--- a/clients/web/src/domains/settings/pair-device/tunnel-status-row.test.tsx
+++ b/clients/web/src/domains/settings/pair-device/tunnel-status-row.test.tsx
@@ -2,14 +2,21 @@ import { afterEach, describe, expect, test } from "bun:test";
 
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 
-import { TunnelStatusRow, type TunnelStatusView } from "./tunnel-status-row";
+import {
+  statusPublicBaseUrl,
+  TunnelStatusRow,
+  type TunnelStatusView,
+} from "./tunnel-status-row";
 
 const PUBLIC_URL = "https://foo.ts.net";
 const REFRESH_LABEL = "Check the tunnel again";
 
 function renderRow(
   status: TunnelStatusView,
-  { isRefreshing = false }: { isRefreshing?: boolean } = {},
+  {
+    isRefreshing = false,
+    assistantName = null,
+  }: { isRefreshing?: boolean; assistantName?: string | null } = {},
 ) {
   const calls: number[] = [];
   const result = render(
@@ -17,6 +24,7 @@ function renderRow(
       status={status}
       onRefresh={() => calls.push(1)}
       isRefreshing={isRefreshing}
+      assistantName={assistantName}
     />,
   );
   return { calls, result };
@@ -40,7 +48,7 @@ describe("TunnelStatusRow", () => {
   });
 
   test("names the probe in flight and disables the refresh", () => {
-    renderRow({ kind: "checking" });
+    renderRow({ kind: "checking" }, { isRefreshing: true });
 
     expect(
       screen.getByText("Checking whether the tunnel is reachable…"),
@@ -52,14 +60,26 @@ describe("TunnelStatusRow", () => {
     renderRow({
       kind: "healthy",
       publicBaseUrl: PUBLIC_URL,
-      checkedAt: new Date(Date.now() - 5_000).toISOString(),
+      checkedAt: new Date(Date.now() - 2 * 60_000).toISOString(),
     });
 
     expect(
       screen.getByText("The tunnel is running and reachable."),
     ).toBeDefined();
     expect(screen.getByText(PUBLIC_URL)).toBeDefined();
-    expect(screen.getByText("Checked 5 seconds ago")).toBeDefined();
+    expect(screen.getByText("Checked 2 minutes ago")).toBeDefined();
+  });
+
+  // The card re-renders the age on a 30s tick, so the label is phrased in
+  // minutes; anything fresher reads as "now" rather than a stale second count.
+  test("phrases a just-finished check as now", () => {
+    renderRow({
+      kind: "healthy",
+      publicBaseUrl: PUBLIC_URL,
+      checkedAt: new Date(Date.now() - 5_000).toISOString(),
+    });
+
+    expect(screen.getByText("Checked now")).toBeDefined();
   });
 
   test("reports an unreachable address", () => {
@@ -73,6 +93,40 @@ describe("TunnelStatusRow", () => {
       screen.getByText("This address is not answering right now."),
     ).toBeDefined();
     expect(screen.getByText(PUBLIC_URL)).toBeDefined();
+  });
+
+  test("shows the daemon's reason beside the unreachable sentence", () => {
+    renderRow({
+      kind: "unreachable",
+      publicBaseUrl: PUBLIC_URL,
+      checkedAt: new Date().toISOString(),
+      detail: "connection refused",
+    });
+
+    expect(screen.getByText("connection refused")).toBeDefined();
+  });
+
+  test("tells an unreachable tunnel how to start again", () => {
+    renderRow({
+      kind: "unreachable",
+      publicBaseUrl: PUBLIC_URL,
+      checkedAt: new Date().toISOString(),
+      provider: "tailscale",
+    });
+
+    expect(screen.getByText(/Start this assistant's tunnel again/)).toBeDefined();
+    expect(screen.getByText("vellum tunnel --provider tailscale")).toBeDefined();
+  });
+
+  test("tells a foreign edge how to start this assistant's tunnel again", () => {
+    renderRow({
+      kind: "foreign",
+      publicBaseUrl: PUBLIC_URL,
+      checkedAt: new Date().toISOString(),
+      provider: "ngrok",
+    });
+
+    expect(screen.getByText("vellum tunnel --provider ngrok")).toBeDefined();
   });
 
   test("names the assistant a foreign edge is serving", () => {
@@ -122,6 +176,30 @@ describe("TunnelStatusRow", () => {
     expect(screen.getByText(PUBLIC_URL)).toBeDefined();
   });
 
+  // A computer running several assistants would otherwise be told to run a
+  // command that starts a tunnel for whichever one is active.
+  test("names the assistant in the restart command", () => {
+    renderRow(
+      { kind: "stopped", provider: "tailscale", publicBaseUrl: PUBLIC_URL },
+      { assistantName: "jarvis" },
+    );
+
+    expect(
+      screen.getByText("vellum tunnel jarvis --provider tailscale"),
+    ).toBeDefined();
+  });
+
+  test("quotes an assistant name with whitespace in it", () => {
+    renderRow(
+      { kind: "stopped", provider: "tailscale", publicBaseUrl: PUBLIC_URL },
+      { assistantName: "My Assistant" },
+    );
+
+    expect(
+      screen.getByText('vellum tunnel "My Assistant" --provider tailscale'),
+    ).toBeDefined();
+  });
+
   test("refreshing calls back to the owner", () => {
     const { calls } = renderRow({
       kind: "healthy",
@@ -145,5 +223,34 @@ describe("TunnelStatusRow", () => {
     );
 
     expect(refreshButton().disabled).toBe(true);
+  });
+});
+
+describe("statusPublicBaseUrl", () => {
+  test("reports the address a probed state carries", () => {
+    expect(
+      statusPublicBaseUrl({
+        kind: "healthy",
+        publicBaseUrl: PUBLIC_URL,
+        checkedAt: "",
+      }),
+    ).toBe(PUBLIC_URL);
+  });
+
+  // The wire marks the field optional across every state, so a probed verdict
+  // without one must read as "no address" rather than as an empty one: the
+  // card decides whether to lead with the URL field on this answer.
+  test("reports no address when the daemon reported an empty one", () => {
+    expect(
+      statusPublicBaseUrl({
+        kind: "healthy",
+        publicBaseUrl: "",
+        checkedAt: "",
+      }),
+    ).toBeNull();
+  });
+
+  test("reports no address for the states carrying none", () => {
+    expect(statusPublicBaseUrl({ kind: "unconfigured" })).toBeNull();
   });
 });

--- a/clients/web/src/domains/settings/pair-device/tunnel-status-row.tsx
+++ b/clients/web/src/domains/settings/pair-device/tunnel-status-row.tsx
@@ -16,12 +16,22 @@ export type TunnelStatusView =
   | { kind: "unavailable" }
   | { kind: "stopped"; provider: string; publicBaseUrl: string }
   | { kind: "healthy"; publicBaseUrl: string; checkedAt: string }
-  | { kind: "unreachable"; publicBaseUrl: string; checkedAt: string }
+  | {
+      kind: "unreachable";
+      publicBaseUrl: string;
+      checkedAt: string;
+      /** Short, already-redacted diagnostic from the daemon. Not localized. */
+      detail?: string;
+      /** Provider of the tunnel on record, when the daemon remembers one. */
+      provider?: string;
+    }
   | {
       kind: "foreign";
       publicBaseUrl: string;
       checkedAt: string;
       servingAssistantName?: string;
+      /** Provider of the tunnel on record, when the daemon remembers one. */
+      provider?: string;
     };
 
 /** Every state the row actually draws; the card covers the other two itself. */
@@ -30,9 +40,40 @@ type RenderedTunnelStatus = Exclude<
   { kind: "unconfigured" | "unavailable" }
 >;
 
-/** The public address a status reports, or `null` in the states carrying none. */
+/**
+ * The public address a status reports, or `null` in the states carrying none.
+ * An empty address is none: the wire marks the field optional across every
+ * state, so a probed verdict without one must not read as an address.
+ */
 export function statusPublicBaseUrl(status: TunnelStatusView): string | null {
-  return "publicBaseUrl" in status ? status.publicBaseUrl : null;
+  return "publicBaseUrl" in status && status.publicBaseUrl
+    ? status.publicBaseUrl
+    : null;
+}
+
+/** When the probe last answered, or `null` in the states carrying no check. */
+export function statusCheckedAt(status: TunnelStatusView): string | null {
+  return "checkedAt" in status && status.checkedAt ? status.checkedAt : null;
+}
+
+/**
+ * The command that starts this assistant's tunnel. Names the assistant where
+ * one is known: on a computer running several, an unnamed `vellum tunnel`
+ * may start a different assistant's tunnel than the card is reporting on.
+ */
+export function tunnelStartCommand(
+  provider: string,
+  assistantName: string | null,
+): string {
+  const name = assistantName?.trim();
+  return name
+    ? `vellum tunnel ${shellArg(name)} --provider ${provider}`
+    : `vellum tunnel --provider ${provider}`;
+}
+
+/** Keeps a name with whitespace in it a single shell argument. */
+function shellArg(value: string): string {
+  return /\s/.test(value) ? `"${value.replace(/"/g, '\\"')}"` : value;
 }
 
 interface TunnelStatusRowProps {
@@ -40,6 +81,8 @@ interface TunnelStatusRowProps {
   /** Re-runs the daemon-side probe. The row owns no fetching of its own. */
   onRefresh: () => void;
   isRefreshing: boolean;
+  /** Assistant the restart command should name, when the card knows one. */
+  assistantName?: string | null;
 }
 
 const DOT_COLOR: Record<RenderedTunnelStatus["kind"], string> = {
@@ -50,18 +93,22 @@ const DOT_COLOR: Record<RenderedTunnelStatus["kind"], string> = {
   foreign: "var(--system-negative-strong)",
 };
 
-/** The command that restarts the tunnel the stopped record came from. */
-function restartCommand(provider: string): string {
-  return `vellum tunnel --provider ${provider}`;
-}
+const SUBDUED_CLASS = "text-body-small-default text-[var(--content-tertiary)]";
+const SUBDUED_TRUNCATE_CLASS = `truncate ${SUBDUED_CLASS}`;
+
+const CODE_CLASS =
+  "rounded-md bg-[var(--surface-active)] px-1.5 py-0.5 text-[color:var(--content-primary)]";
 
 /**
  * One compact line reporting whether this assistant's public address is
  * actually serving it: a tone dot, a sentence, the address, when it was last
- * checked, and a manual re-check.
+ * checked, and a manual re-check. Every state the daemon has a tunnel on
+ * record for also prints the command that starts it again, since a dead
+ * address and a stopped tunnel have the same fix.
  *
  * Pure by design: props in, markup out. Fetching, the `app.resume` re-check
- * and any polling belong to the card above it, per `docs/EVENT_BUS.md`.
+ * and the tick that keeps the check age current all belong to the card above
+ * it, per `docs/EVENT_BUS.md`.
  * Renders nothing for `unconfigured` or `unavailable`: with no tunnel and
  * with no verdict there is nothing to report, and the card speaks instead.
  */
@@ -69,6 +116,7 @@ export function TunnelStatusRow({
   status,
   onRefresh,
   isRefreshing,
+  assistantName = null,
 }: TunnelStatusRowProps) {
   const { t } = useTranslation("settings");
 
@@ -76,9 +124,10 @@ export function TunnelStatusRow({
     return null;
   }
 
-  const busy = status.kind === "checking" || isRefreshing;
-  const checkedAt = "checkedAt" in status ? status.checkedAt : null;
+  const checkedAt = statusCheckedAt(status);
   const publicBaseUrl = statusPublicBaseUrl(status);
+  const provider = "provider" in status ? status.provider : undefined;
+  const detail = status.kind === "unreachable" ? status.detail : undefined;
 
   return (
     <div className="flex items-start gap-2.5 rounded-lg border border-[var(--border-element)] px-3 py-2.5">
@@ -91,33 +140,40 @@ export function TunnelStatusRow({
         <p className="text-body-small-default text-[var(--content-default)]">
           {statusSentence(status, t)}
         </p>
-        {status.kind === "stopped" && (
-          <p className="text-body-small-default text-[var(--content-tertiary)]">
+        {/* The daemon's own words for the failure: already redacted, and not
+            translated, so it sits beside the sentence rather than inside it. */}
+        {detail && (
+          <p className={SUBDUED_TRUNCATE_CLASS} title={detail}>
+            {detail}
+          </p>
+        )}
+        {provider && (
+          <p className={SUBDUED_CLASS}>
             <Trans
-              i18nKey="tunnelStatusRow.stoppedRestart"
+              i18nKey={
+                status.kind === "stopped"
+                  ? "tunnelStatusRow.stoppedRestart"
+                  : "tunnelStatusRow.restartHint"
+              }
               ns="settings"
-              values={{ command: restartCommand(status.provider) }}
-              components={{
-                code: (
-                  <code className="rounded-md bg-[var(--surface-active)] px-1.5 py-0.5 text-[color:var(--content-primary)]" />
-                ),
-              }}
+              values={{ command: tunnelStartCommand(provider, assistantName) }}
+              components={{ code: <code className={CODE_CLASS} /> }}
             />
           </p>
         )}
         {publicBaseUrl && (
-          <p
-            className="truncate text-body-small-default text-[var(--content-tertiary)]"
-            title={publicBaseUrl}
-          >
+          <p className={SUBDUED_TRUNCATE_CLASS} title={publicBaseUrl}>
             {publicBaseUrl}
           </p>
         )}
         {checkedAt && (
-          <p className="text-body-small-default text-[var(--content-tertiary)]">
+          <p className={SUBDUED_CLASS}>
             {t("tunnelStatusRow.checkedAt", {
               when: formatRelativeTime(new Date(checkedAt).getTime(), {
                 locale: currentLocale(),
+                // The card re-renders this label on a slow tick, so minute
+                // phrasing is what it can keep honest.
+                minimumUnit: "minute",
               }),
             })}
           </p>
@@ -126,9 +182,11 @@ export function TunnelStatusRow({
       <Button
         variant="ghost"
         size="compact"
-        iconOnly={<RefreshCw className={busy ? "animate-spin" : undefined} />}
+        iconOnly={
+          <RefreshCw className={isRefreshing ? "animate-spin" : undefined} />
+        }
         aria-label={t("tunnelStatusRow.refreshLabel")}
-        disabled={busy}
+        disabled={isRefreshing}
         onClick={onRefresh}
       />
     </div>

--- a/clients/web/src/domains/settings/pair-device/use-relative-age-tick.ts
+++ b/clients/web/src/domains/settings/pair-device/use-relative-age-tick.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from "react";
+
+/** How often a visible relative age re-renders; 30s suits minute phrasing. */
+const AGE_REFRESH_INTERVAL_MS = 30_000;
+
+/**
+ * Re-render the caller on a slow tick while `active`, so a relative age label
+ * ("Requested 2 minutes ago", "Checked 5 minutes ago") keeps up with the
+ * clock. Those labels are formatted from a fixed instant, and neither the
+ * pending-request list nor the tunnel probe re-renders on its own between
+ * updates, so without a tick the age freezes at whatever it read when the data
+ * landed and reports a stale reading as a fresh one.
+ */
+export function useRelativeAgeTick(active: boolean): void {
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    if (!active) {
+      return;
+    }
+    const intervalId = setInterval(
+      () => setTick((tick) => tick + 1),
+      AGE_REFRESH_INTERVAL_MS,
+    );
+    return () => clearInterval(intervalId);
+  }, [active]);
+}

--- a/clients/web/src/domains/settings/pair-device/use-tunnel-status.test.ts
+++ b/clients/web/src/domains/settings/pair-device/use-tunnel-status.test.ts
@@ -2,22 +2,24 @@
  * Tests for the tunnel-status query hook and its wire-to-view mapper.
  *
  * `useIsOrgReady` and the generated probe call are the two `mock.module`s
- * here; the version gate and the active assistant id are driven through their
- * real stores so the gating the hook actually ships with is what gets
- * exercised. Mocking the SDK call (rather than only reading TanStack's
- * `fetchStatus`) is what lets the refresh tests count probes: an imperative
- * `refetch()` that the guard should have swallowed leaves no trace in the
- * query state, but it would show up as a call here.
+ * here (the probe through the shared `installIngressProbe` harness); the
+ * version gate and the active assistant id are driven through their real
+ * stores so the gating the hook actually ships with is what gets exercised.
  */
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { QueryClient } from "@tanstack/react-query";
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
-import { createElement, type ReactNode } from "react";
 
 import { integrationsIngressStatusGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
 import { MIN_VERSION } from "@/lib/backwards-compat/ingress-status-gate";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+
+import {
+  createQueryClientWrapper,
+  installIngressProbe,
+  VERSION_BELOW_INGRESS_STATUS,
+} from "./pair-device-test-helpers";
 
 const ASSISTANT_ID = "asst-1";
 const PUBLIC_URL = "https://foo.ts.net";
@@ -28,33 +30,15 @@ mock.module("@/hooks/use-is-org-ready", () => ({
   useIsOrgReady: () => orgReady,
 }));
 
-/** Set by a test to make the probe fail the way a dead daemon would. */
-let probeFailure: Error | null = null;
-
-const probeMock = mock(async () => {
-  if (probeFailure) {
-    throw probeFailure;
-  }
-  return {
-    data: {
-      state: "healthy",
-      publicBaseUrl: PUBLIC_URL,
-      checkedAt: CHECKED_AT,
-    },
-    error: undefined,
-    response: new Response(null, { status: 200 }),
-  };
+const {
+  probe: probeMock,
+  failWith,
+  reset: resetProbe,
+} = await installIngressProbe({
+  state: "healthy",
+  publicBaseUrl: PUBLIC_URL,
+  checkedAt: CHECKED_AT,
 });
-
-/* Spread over the real module rather than replacing it: the generated SDK is a
-   single barrel that the query-options barrel also pulls from, and a bare
-   object drops every export this file does not name. */
-const realDaemonSdk = await import("@/generated/daemon/sdk.gen");
-
-mock.module("@/generated/daemon/sdk.gen", () => ({
-  ...realDaemonSdk,
-  integrationsIngressStatusGet: probeMock,
-}));
 
 const { toStatusView, useTunnelStatus } = await import("./use-tunnel-status");
 
@@ -70,11 +54,7 @@ function probeFetchStatus(client: QueryClient): string {
 }
 
 function renderStatus(enabled = true) {
-  const client = new QueryClient({
-    defaultOptions: { queries: { retry: false } },
-  });
-  const wrapper = ({ children }: { children: ReactNode }) =>
-    createElement(QueryClientProvider, { client }, children);
+  const { client, wrapper } = createQueryClientWrapper();
   const { result } = renderHook(() => useTunnelStatus(enabled), { wrapper });
   return { result, client };
 }
@@ -85,8 +65,7 @@ async function settle() {
 
 beforeEach(() => {
   orgReady = true;
-  probeFailure = null;
-  probeMock.mockClear();
+  resetProbe();
   useResolvedAssistantsStore.getState().setActiveAssistantId(ASSISTANT_ID);
   useAssistantIdentityStore
     .getState()
@@ -154,7 +133,7 @@ describe("toStatusView", () => {
     });
   });
 
-  test("maps unreachable and drops the daemon's detail string", () => {
+  test("carries the daemon's detail onto unreachable", () => {
     expect(
       toStatusView(
         {
@@ -169,6 +148,47 @@ describe("toStatusView", () => {
       kind: "unreachable",
       publicBaseUrl: PUBLIC_URL,
       checkedAt: CHECKED_AT,
+      detail: "connection refused",
+    });
+  });
+
+  // A killed tunnel answers as unreachable, and the record the daemon kept is
+  // what lets the row name the command that starts it again.
+  test("carries the last tunnel's provider onto unreachable", () => {
+    expect(
+      toStatusView(
+        {
+          state: "unreachable",
+          publicBaseUrl: PUBLIC_URL,
+          checkedAt: CHECKED_AT,
+          lastTunnel: { provider: "tailscale", publicBaseUrl: PUBLIC_URL },
+        },
+        false,
+      ),
+    ).toEqual({
+      kind: "unreachable",
+      publicBaseUrl: PUBLIC_URL,
+      checkedAt: CHECKED_AT,
+      provider: "tailscale",
+    });
+  });
+
+  test("carries the last tunnel's provider onto foreign", () => {
+    expect(
+      toStatusView(
+        {
+          state: "foreign",
+          publicBaseUrl: PUBLIC_URL,
+          checkedAt: CHECKED_AT,
+          lastTunnel: { provider: "ngrok", publicBaseUrl: PUBLIC_URL },
+        },
+        false,
+      ),
+    ).toEqual({
+      kind: "foreign",
+      publicBaseUrl: PUBLIC_URL,
+      checkedAt: CHECKED_AT,
+      provider: "ngrok",
     });
   });
 
@@ -217,7 +237,7 @@ describe("useTunnelStatus", () => {
   test("never probes an assistant whose version predates the route", () => {
     useAssistantIdentityStore
       .getState()
-      .setIdentity("Test", "0.11.5", ASSISTANT_ID);
+      .setIdentity("Test", VERSION_BELOW_INGRESS_STATUS, ASSISTANT_ID);
     const { result, client } = renderStatus();
 
     expect(probeFetchStatus(client)).toBe("idle");
@@ -260,7 +280,7 @@ describe("useTunnelStatus", () => {
   });
 
   test("reports unavailable once the probe gives up", async () => {
-    probeFailure = new Error("connection refused");
+    failWith(new Error("connection refused"));
     const { result } = renderStatus();
 
     await waitFor(() =>
@@ -277,7 +297,7 @@ describe("useTunnelStatus · refresh", () => {
   test("does not probe when the assistant predates the route", async () => {
     useAssistantIdentityStore
       .getState()
-      .setIdentity("Test", "0.11.5", ASSISTANT_ID);
+      .setIdentity("Test", VERSION_BELOW_INGRESS_STATUS, ASSISTANT_ID);
     const { result } = renderStatus();
 
     act(() => result.current.refresh());

--- a/clients/web/src/domains/settings/pair-device/use-tunnel-status.ts
+++ b/clients/web/src/domains/settings/pair-device/use-tunnel-status.ts
@@ -72,6 +72,10 @@ export function useTunnelStatus(enabled: boolean): TunnelStatusController {
  * state) while the view is a union, so this narrows on `state` and drops the
  * fields that state does not populate.
  *
+ * `lastTunnel` is carried onto the unhealthy states too, not just `stopped`:
+ * a killed tunnel answers as `unreachable`, and the provider on record is
+ * what lets the row print the command that starts it again.
+ *
  * Only the daemon's own verdict becomes `unconfigured`. Everything the probe
  * cannot answer degrades to `unavailable` instead: no response with nothing
  * in flight (the probe is gated off, or the query exhausted its retries), or
@@ -91,6 +95,11 @@ export function toStatusView(
   // optional because the response is one flat object across all five.
   const publicBaseUrl = response.publicBaseUrl ?? "";
   const checkedAt = response.checkedAt ?? "";
+  // Spread onto the states that take it optionally, so an absent record stays
+  // an absent key rather than an explicit `undefined`.
+  const recordedProvider = response.lastTunnel
+    ? { provider: response.lastTunnel.provider }
+    : {};
 
   switch (response.state) {
     case "unconfigured":
@@ -106,7 +115,13 @@ export function toStatusView(
     case "healthy":
       return { kind: "healthy", publicBaseUrl, checkedAt };
     case "unreachable":
-      return { kind: "unreachable", publicBaseUrl, checkedAt };
+      return {
+        kind: "unreachable",
+        publicBaseUrl,
+        checkedAt,
+        ...(response.detail ? { detail: response.detail } : {}),
+        ...recordedProvider,
+      };
     case "foreign":
       return {
         kind: "foreign",
@@ -115,6 +130,7 @@ export function toStatusView(
         ...(response.servingAssistantName
           ? { servingAssistantName: response.servingAssistantName }
           : {}),
+        ...recordedProvider,
       };
   }
 }

--- a/clients/web/src/i18n/locales/en/settings.json
+++ b/clients/web/src/i18n/locales/en/settings.json
@@ -947,6 +947,7 @@
     "foreignStatusNamed": "This address is serving {name} right now, not this assistant.",
     "healthyStatus": "The tunnel is running and reachable.",
     "refreshLabel": "Check the tunnel again",
+    "restartHint": "Start this assistant's tunnel again with <code>{command}</code> in a terminal on this computer.",
     "stoppedRestart": "Run <code>{command}</code> in a terminal on this computer to start it again.",
     "stoppedStatus": "The tunnel is stopped, so other devices cannot reach this assistant.",
     "unreachableStatus": "This address is not answering right now."

--- a/clients/web/src/i18n/locales/es/settings.json
+++ b/clients/web/src/i18n/locales/es/settings.json
@@ -947,6 +947,7 @@
     "foreignStatusNamed": "Esta dirección está sirviendo a {name} ahora mismo, no a este asistente.",
     "healthyStatus": "El túnel está en marcha y es accesible.",
     "refreshLabel": "Comprobar el túnel de nuevo",
+    "restartHint": "Vuelve a iniciar el túnel de este asistente con <code>{command}</code> en una terminal de este equipo.",
     "stoppedRestart": "Ejecuta <code>{command}</code> en una terminal de este equipo para volver a iniciarlo.",
     "stoppedStatus": "El túnel está detenido, por lo que otros dispositivos no pueden alcanzar este asistente.",
     "unreachableStatus": "Esta dirección no responde ahora mismo."


### PR DESCRIPTION
## Summary

- A `stopped` verdict no longer prefills the URL field, so Generate is genuinely disabled on a dead address, and `unreachable`/`foreign` now carry the daemon's `lastTunnel` provider and print the command that starts the tunnel again. Both that command and the first-run one name the selected assistant (quoted when it contains whitespace), so a computer running several does not restart the wrong tunnel.
- `unreachable.detail` is rendered as a subdued, non-localized hint beside the localized sentence instead of being dropped, and the check age advances on a 30s tick owned by the card (the row stays timer-free) with minute-granularity phrasing.
- Cleanups: the card drops its redundant version-gate derivation (the hook already folds gated-off into `unavailable`), an empty `publicBaseUrl` now reads as no address rather than as one, the row's dead `busy` conjunct is collapsed, the duplicated age tick is shared with the pending-request list, and the probe mock / query-client wrapper / version constants moved into `pair-device-test-helpers.ts`.

New catalog keys: `settings:tunnelStatusRow.restartHint` (en + es).

Fixes gaps identified during plan review for tunnel-status-pairing.md.