### PR TITLE
chore: route transfer sanitization through the shared ingress keys and correct a stale comment

### DIFF
--- a/assistant/src/config/sanitize-for-transfer.ts
+++ b/assistant/src/config/sanitize-for-transfer.ts
@@ -1,3 +1,8 @@
+import {
+  INGRESS_ASSISTANT_ID_KEY,
+  INGRESS_LAST_TUNNEL_KEY,
+} from "@vellumai/service-contracts/ingress";
+
 /**
  * Strips environment-specific fields from config JSON before transferring
  * between local and platform environments (teleport/restore).
@@ -48,8 +53,8 @@ export function sanitizeConfigForTransfer(configJson: string): string {
     delete ingress.publicBaseUrlManagedBy;
     // The remembered tunnel and the assistant it fronted belong to the source
     // host; carrying them over makes tunnel-status UIs name the old deployment.
-    delete ingress.lastTunnel;
-    delete ingress.assistantId;
+    delete ingress[INGRESS_LAST_TUNNEL_KEY];
+    delete ingress[INGRESS_ASSISTANT_ID_KEY];
   }
 
   // Strip the recorded Telegram webhook URL. It records where *this*

--- a/clients/web/src/domains/settings/pair-device/pair-device-card.tsx
+++ b/clients/web/src/domains/settings/pair-device/pair-device-card.tsx
@@ -29,7 +29,7 @@ import { usePairDevice } from "./use-pair-device";
 import { useRelativeAgeTick } from "./use-relative-age-tick";
 import { useTunnelStatus } from "./use-tunnel-status";
 
-/** Named explicitly: the CLI's `vellum` default is not implemented. */
+/** Named explicitly so the command does not depend on the CLI's default. */
 const TUNNEL_PROVIDER = "tailscale";
 const TUNNEL_HELP_COMMAND = "vellum tunnel --help";
 
@@ -41,8 +41,7 @@ const CODE_CLASS =
 
 /**
  * Settings card that pairs another device to this assistant without shell
- * commands —
- * the UI equivalent of `vellum pair --qr`. It mints and auto-approves a
+ * commands, the UI equivalent of `vellum pair --qr`. It mints and auto-approves a
  * device-code challenge against the host's loopback gateway and renders the
  * https pair URL as a QR with a copyable link and expiry countdown. It also
  * hosts the approval list for pairing requests minted elsewhere


### PR DESCRIPTION
## Summary
- `sanitizeConfigForTransfer` now deletes `ingress.lastTunnel` / `ingress.assistantId` via the shared `INGRESS_*_KEY` constants instead of string literals, so it cannot drift from the writer and the parsers.
- Corrects the `TUNNEL_PROVIDER` comment in the Pair-a-device card, which still claimed the CLI's `vellum` default is unimplemented after that default became `tailscale`.
- Drops an em dash from the card's docstring on a line already being changed.

Tidies three items flagged out of scope by the plan-review fix agents for tunnel-status-pairing.md.