### PR TITLE
fix(cli): keep a running edge in front when the edge rebuild fails

### DIFF
--- a/cli/src/__tests__/wake.test.ts
+++ b/cli/src/__tests__/wake.test.ts
@@ -655,11 +655,11 @@ describe("vellum wake — tunnel edge restore", () => {
     expect(ensureTunnelEdgeMock).not.toHaveBeenCalled();
   });
 
-  test("a recorded edge with a stale config fingerprint is restarted, not adopted", async () => {
+  test("a running edge is rebuilt through ensureTunnelEdge, never adopted at its recorded port", async () => {
     // Recorded mode and gateway port are not a licence to reuse: only
     // ensureTunnelEdge compares the injected-config fingerprint, so an edge
     // predating the current edge template (one serving no assistantId, which
-    // makes the identity probe degrade to always-healthy) must be restarted
+    // makes the identity probe degrade to always-healthy) must be rebuilt
     // rather than carried across the wake at its recorded listen port.
     loadRawConfigMock.mockReturnValue(webhookConfig);
     isIngressRunningMock.mockReturnValue(true);
@@ -679,6 +679,82 @@ describe("vellum wake — tunnel edge restore", () => {
     });
     expect(maybeStartNgrokTunnelMock).toHaveBeenCalledWith(
       7840,
+      workspaceDirOf(tempDir),
+      "local-assistant",
+    );
+  });
+
+  test("a failed rebuild keeps tunneling the SPA edge that is still running", async () => {
+    // web-dist-missing bails before the running edge is stopped, and a drifted
+    // edge whose stop fails reports staleRemoteWebConfig; both throw while the
+    // edge keeps serving. Tunneling the gateway directly would put the
+    // sensitive-route denylist behind the tunnel instead of in front of it.
+    loadRawConfigMock.mockReturnValue(webhookConfig);
+    isIngressRunningMock.mockReturnValue(true);
+    readIngressStateMock.mockReturnValue({
+      listenPort: 7845,
+      includeWebApp: true,
+      gatewayPort: 7830,
+      remoteWebConfigHash: "fingerprint-of-an-older-edge-template",
+    });
+    ensureTunnelEdgeMock.mockRejectedValue(
+      new Error(
+        "The nginx edge is still serving an outdated remote web config and could not be restarted with the updated one. Run `vellum nginx-ingress down` and retry.",
+      ),
+    );
+
+    await wake();
+
+    expect(maybeStartNgrokTunnelMock).toHaveBeenCalledWith(
+      7845,
+      workspaceDirOf(tempDir),
+      "local-assistant",
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("127.0.0.1:7845"),
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("vellum nginx-ingress down"),
+    );
+  });
+
+  test("a failed rebuild falls back to the gateway port when the running edge fronts another gateway", async () => {
+    loadRawConfigMock.mockReturnValue(webhookConfig);
+    isIngressRunningMock.mockReturnValue(true);
+    readIngressStateMock.mockReturnValue({
+      listenPort: 7845,
+      includeWebApp: true,
+      gatewayPort: 7831,
+    });
+    ensureTunnelEdgeMock.mockRejectedValue(
+      new Error("The nginx edge is still proxying gateway port 7831."),
+    );
+
+    await wake();
+
+    expect(maybeStartNgrokTunnelMock).toHaveBeenCalledWith(
+      7830,
+      workspaceDirOf(tempDir),
+      "local-assistant",
+    );
+  });
+
+  test("a failed rebuild falls back to the gateway port when only a webhooks-only edge survives", async () => {
+    loadRawConfigMock.mockReturnValue(webhookConfig);
+    isIngressRunningMock.mockReturnValue(true);
+    readIngressStateMock.mockReturnValue({
+      listenPort: 7845,
+      includeWebApp: false,
+      gatewayPort: 7830,
+    });
+    ensureTunnelEdgeMock.mockRejectedValue(
+      new Error("The nginx edge is still running in webhooks-only mode."),
+    );
+
+    await wake();
+
+    expect(maybeStartNgrokTunnelMock).toHaveBeenCalledWith(
+      7830,
       workspaceDirOf(tempDir),
       "local-assistant",
     );

--- a/cli/src/lib/tunnel-edge.ts
+++ b/cli/src/lib/tunnel-edge.ts
@@ -4,6 +4,8 @@ import { loadRawConfig } from "./ingress-config.js";
 import {
   ensureTunnelEdge,
   formatEdgeMode,
+  isIngressRunning,
+  readIngressState,
   type TunnelEdge,
 } from "./nginx-ingress.js";
 import { hasWebhookIntegrations, maybeStartNgrokTunnel } from "./ngrok.js";
@@ -38,6 +40,27 @@ function wantsTunnelEdge(workspaceDir: string): boolean {
 }
 
 /**
+ * Listen port of an SPA edge still serving in front of `gatewayPort`, or null
+ * when nothing verifiably fronts that gateway (an unrecorded upstream port is
+ * unverified, see `IngressState`).
+ */
+function survivingSpaEdgePort(
+  workspaceDir: string,
+  gatewayPort: number,
+): number | null {
+  try {
+    const recorded = isIngressRunning(workspaceDir)
+      ? readIngressState(workspaceDir)
+      : null;
+    return recorded?.includeWebApp && recorded.gatewayPort === gatewayPort
+      ? recorded.listenPort
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Bring the nginx edge back up after a wake or local upgrade and point the
  * webhook auto-tunnel at it. The edge is wanted when webhook integrations are
  * configured or the workspace ingress config is enabled with a saved public
@@ -47,11 +70,15 @@ function wantsTunnelEdge(workspaceDir: string): boolean {
  * respects (a renamed assistant, a changed hub URL, an older edge template) is
  * restarted rather than adopted, which is what keeps a wake from serving a
  * config the current CLI would never generate.
- * Edge failures warn
- * (with the error's install or diagnostic text) and fall back to tunneling the
- * gateway port directly, which `maybeStartNgrokTunnel` only does when webhook
- * integrations are configured, so webhook channels on nginx-less machines
- * keep working, and the caller never fails because of edge problems.
+ *
+ * Several of those failures leave the old edge serving (the web-dist preflight
+ * bails before it is stopped; a drifted edge whose stop fails is reported as
+ * stale), and tunneling the gateway directly would take the edge's
+ * sensitive-route denylist out from in front of the tunnel. So a failure warns
+ * and keeps a surviving SPA edge as the target; the gateway port is the target
+ * only when nothing fronts it, which `maybeStartNgrokTunnel` tunnels only when
+ * webhook integrations are configured, so webhook channels on nginx-less
+ * machines keep working and the caller never fails because of edge problems.
  *
  * Returns the spawned ngrok child (for PID tracking) or null.
  */
@@ -70,11 +97,16 @@ export async function restoreTunnelEdgeAndAutoTunnel(
         gatewayPort,
       });
     } catch (err) {
-      console.warn(
-        `   Could not restore the tunnel edge: ${
-          err instanceof Error ? err.message : String(err)
-        } Bring it up manually with \`vellum nginx-ingress up\`.`,
-      );
+      const detail = err instanceof Error ? err.message : String(err);
+      const survivingPort = survivingSpaEdgePort(workspaceDir, gatewayPort);
+      if (survivingPort !== null) {
+        tunnelTargetPort = survivingPort;
+      }
+      const hint =
+        survivingPort === null
+          ? "Bring it up manually with `vellum nginx-ingress up`."
+          : `The edge already running on 127.0.0.1:${survivingPort} stays in front of the gateway, serving an outdated config until \`vellum nginx-ingress down\` then \`vellum nginx-ingress up\` rebuilds it.`;
+      console.warn(`   Could not restore the tunnel edge: ${detail} ${hint}`);
     }
     if (edge) {
       tunnelTargetPort = edge.port;


### PR DESCRIPTION
## Summary

- `restoreTunnelEdgeAndAutoTunnel` still delegates the reuse/fingerprint decision to `ensureTunnelEdge`, but a throw no longer discards a still-running edge: on catch it re-reads the ingress state and, when an SPA edge is still up on the requested gateway port, targets that edge's `listenPort` instead of the gateway port. Two `ensureTunnelEdge` failure modes (`web-dist-missing`, which bails before the running edge is stopped, and a drifted edge whose `stopIngressNginx` fails, reported as `staleRemoteWebConfig`) fire while a perfectly good edge keeps serving, and the gateway-direct fallback took the edge's sensitive-route `DENYLIST_LOCATIONS` out from in front of the tunnel and then saved that URL as `ingress.publicBaseUrl`.
- The warning now names the surviving edge's port and how to force a rebuild (`vellum nginx-ingress down` then `up`). The gateway port stays the target only when nothing verifiably fronts it (no edge running, webhooks-only mode, or a different/unrecorded upstream port).
- Wake tests: the mocks for `isIngressRunning`/`readIngressState` are load-bearing again; the surviving "stale fingerprint" test is retitled to what it actually locks in (a running edge is rebuilt through `ensureTunnelEdge`, never adopted at its recorded port), and three tests cover the regression (surviving SPA edge keeps the tunnel) and both no-edge-in-front fallbacks. The new regression test fails against the pre-fix code (tunnel targeted 7830 instead of the edge's 7845).

Fixes a re-review regression for tunnel-status-pairing.md.