### PR TITLE
fix(assistant): let a slow identity check leave the tunnel healthy

### DIFF
--- a/assistant/src/inbound/__tests__/tunnel-probe.test.ts
+++ b/assistant/src/inbound/__tests__/tunnel-probe.test.ts
@@ -4,11 +4,11 @@
  * Three properties carry the feature. First, `/healthz` alone decides
  * liveness, so an edge whose nginx answers while the gateway behind it does
  * not must read `unreachable`, while an ingress that never serves
- * `/assistant/__config` at all still reads `healthy`. Second, `foreign` is an
- * accusation ("this URL now fronts someone else's assistant"), so it is
- * reserved for a positive mismatch of two known ids and every skew case reads
- * `healthy`. Third, the probe runs often enough that a body it never parses
- * has to be cancelled rather than left to GC.
+ * `/assistant/__config` at all, or is too slow to finish it, still reads
+ * `healthy`. Second, `foreign` is an accusation ("this URL now fronts someone
+ * else's assistant"), so it is reserved for a positive mismatch of two known
+ * ids and every skew case reads `healthy`. Third, the probe runs often enough
+ * that a body it never parses has to be cancelled rather than left to GC.
  *
  * Every case injects `fetchImpl`, so nothing here touches the network.
  */
@@ -149,6 +149,25 @@ describe("probeTunnel", () => {
     });
   });
 
+  test("healthy when the served id is padded with whitespace", async () => {
+    // The recorded id is read through a trimming parser, so a served id that
+    // only differs by padding is the same assistant, not a foreign one.
+    const { fetchImpl } = stubFetch({
+      config: configBody({ assistantId: "  asst_1  ", assistantName: " Ada " }),
+    });
+    await expect(
+      probeTunnel({
+        publicBaseUrl: BASE,
+        expectedAssistantId: " asst_1 ",
+        fetchImpl,
+      }),
+    ).resolves.toEqual({
+      kind: "healthy",
+      assistantId: "asst_1",
+      assistantName: "Ada",
+    });
+  });
+
   test("healthy when the config body is not JSON", async () => {
     const { fetchImpl } = stubFetch({
       config: { status: 200, body: "<html>nope</html>" },
@@ -237,12 +256,23 @@ describe("probeTunnel", () => {
     ).resolves.toEqual({ kind: "unreachable", detail: "timeout" });
   });
 
-  test("unreachable when only the config request times out", async () => {
+  test("healthy when a slow edge answers /healthz but not the config", async () => {
+    // Both requests share one deadline, so an edge that answers `/healthz`
+    // just inside it loses the identity request to it. That is still a
+    // working tunnel.
     const timeout = new DOMException("The operation timed out", "TimeoutError");
     const { fetchImpl } = stubFetch({ config: { reject: timeout } });
     await expect(
-      probeTunnel({ publicBaseUrl: BASE, fetchImpl }),
-    ).resolves.toEqual({ kind: "unreachable", detail: "timeout" });
+      probeTunnel({
+        publicBaseUrl: BASE,
+        expectedAssistantId: "asst_1",
+        fetchImpl,
+      }),
+    ).resolves.toEqual({
+      kind: "healthy",
+      assistantId: undefined,
+      assistantName: undefined,
+    });
   });
 
   test("surfaces the syscall code hidden under a generic fetch wrapper", async () => {

--- a/assistant/src/inbound/tunnel-probe.ts
+++ b/assistant/src/inbound/tunnel-probe.ts
@@ -18,9 +18,9 @@
  *     in `cli/src/lib/nginx-ingress.ts`). A gateway-direct tunnel, a
  *     bring-your-own HTTPS front, or a hand-set `ingress.publicBaseUrl` will
  *     404 there while working perfectly, so a config that is missing,
- *     failing, or unreadable leaves the identity unknown and never fails the
- *     probe. An edge answering with a body this cannot read is still an edge
- *     that is answering.
+ *     failing, slow, or unreadable leaves the identity unknown and never
+ *     fails the probe. An edge answering with a body this cannot read is
+ *     still an edge that is answering.
  *
  * Neither path is denylisted, so both are publicly reachable.
  *
@@ -29,7 +29,10 @@
  * probe an arbitrary URL and lets tests run without network access.
  */
 
-import { normalizeHttpPublicBaseUrl } from "@vellumai/service-contracts/ingress";
+import {
+  normalizeHttpPublicBaseUrlWithoutTrailingSlash,
+  trimmedNonEmptyString,
+} from "@vellumai/service-contracts/ingress";
 
 import { isPlainObject } from "../util/object.js";
 import { truncate } from "../util/truncate.js";
@@ -74,13 +77,17 @@ export async function probeTunnel(args: {
   // The same validation the config writers apply, so a value they would have
   // rejected is named as malformed rather than handed to `fetch` and reported
   // through whatever string that layer happens to produce.
-  const normalized = normalizeHttpPublicBaseUrl(args.publicBaseUrl);
-  if (normalized === undefined) {
+  const base = normalizeHttpPublicBaseUrlWithoutTrailingSlash(
+    args.publicBaseUrl,
+  );
+  if (base === undefined) {
     return { kind: "unreachable", detail: "not an http(s) URL" };
   }
-  const base = normalized.replace(/\/+$/, "");
 
   const fetchImpl = args.fetchImpl ?? globalThis.fetch.bind(globalThis);
+  // One deadline covers both requests: `/healthz` alone decides the verdict,
+  // so a slow edge that answers it and loses the config request to the same
+  // deadline is still a working tunnel with an unknown identity.
   const signal = AbortSignal.timeout(args.timeoutMs ?? DEFAULT_TIMEOUT_MS);
   const [health, config] = await Promise.allSettled([
     fetchImpl(`${base}/healthz`, { signal }),
@@ -99,14 +106,9 @@ export async function probeTunnel(args: {
     await discardBody(configResponse);
     return unreachable(`HTTP ${health.value.status}`, base);
   }
-  // An edge that stopped answering mid-probe outranks the liveness the 2xx
-  // established, so a timeout on either path is still unreachable.
-  if (config.status === "rejected" && isTimeoutError(config.reason)) {
-    return unreachable("timeout", base);
-  }
 
   const served = await readServedConfig(configResponse);
-  const expected = nonEmptyString(args.expectedAssistantId);
+  const expected = trimmedNonEmptyString(args.expectedAssistantId);
   const isForeign =
     expected !== undefined &&
     served.assistantId !== undefined &&
@@ -145,14 +147,17 @@ function isTimeoutError(error: unknown): boolean {
   );
 }
 
+function isGenericFetchMessage(message: string): boolean {
+  return GENERIC_FETCH_MESSAGES.has(message.toLowerCase());
+}
+
 /**
  * A dead tunnel surfaces as a generic wrapper ("fetch failed") whose `cause`
  * carries the reason worth reading (`ECONNREFUSED`, `ENOTFOUND`), so walk the
  * chain for a code, then for the first message that says something.
  */
 function describeError(error: unknown): string {
-  let firstMessage: string | undefined;
-  let specificMessage: string | undefined;
+  let message: string | undefined;
   let current: unknown = error;
 
   for (let depth = 0; depth < MAX_CAUSE_DEPTH; depth += 1) {
@@ -162,33 +167,23 @@ function describeError(error: unknown): string {
     if (isTimeoutError(current)) {
       return "timeout";
     }
-    const code = nonEmptyString(current.code);
+    const code = trimmedNonEmptyString(current.code);
     if (code !== undefined) {
       return code;
     }
-    const message = nonEmptyString(current.message);
-    if (message !== undefined) {
-      firstMessage ??= message;
-      if (
-        specificMessage === undefined &&
-        !GENERIC_FETCH_MESSAGES.has(message.toLowerCase())
-      ) {
-        specificMessage = message;
-      }
+    // A wrapper only holds the slot until a deeper level fills it.
+    if (message === undefined || isGenericFetchMessage(message)) {
+      message = trimmedNonEmptyString(current.message) ?? message;
     }
     current = current.cause;
   }
 
-  return specificMessage ?? firstMessage ?? String(error);
+  return message ?? String(error);
 }
 
 interface ServedEdgeConfig {
   assistantId?: string;
   assistantName?: string;
-}
-
-function nonEmptyString(value: unknown): string | undefined {
-  return typeof value === "string" && value.length > 0 ? value : undefined;
 }
 
 /** Identity only: every failure here yields an unknown identity. */
@@ -205,8 +200,8 @@ async function readServedConfig(
       return {};
     }
     return {
-      assistantId: nonEmptyString(body.assistantId),
-      assistantName: nonEmptyString(body.assistantName),
+      assistantId: trimmedNonEmptyString(body.assistantId),
+      assistantName: trimmedNonEmptyString(body.assistantName),
     };
   } catch {
     await discardBody(response);

--- a/packages/service-contracts/src/__tests__/ingress.test.ts
+++ b/packages/service-contracts/src/__tests__/ingress.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, test } from "bun:test";
 
 import {
   normalizeHttpPublicBaseUrl,
+  normalizeHttpPublicBaseUrlWithoutTrailingSlash,
   normalizePublicBaseUrl,
   parseLastTunnelRecord,
   parseRecordedAssistantId,
+  trimmedNonEmptyString,
   TUNNEL_PROVIDERS,
   velayHostForPlatformHost,
 } from "../ingress.js";
@@ -88,6 +90,35 @@ describe("normalizeHttpPublicBaseUrl", () => {
   });
 });
 
+describe("normalizeHttpPublicBaseUrlWithoutTrailingSlash", () => {
+  test("drops the root path its sibling always emits", () => {
+    expect(
+      normalizeHttpPublicBaseUrlWithoutTrailingSlash("https://x.test"),
+    ).toBe("https://x.test");
+    expect(
+      normalizeHttpPublicBaseUrlWithoutTrailingSlash("https://x.test/"),
+    ).toBe("https://x.test");
+    expect(
+      normalizeHttpPublicBaseUrlWithoutTrailingSlash(" https://x.test/api/// "),
+    ).toBe("https://x.test/api");
+  });
+
+  test("rejects everything its sibling rejects", () => {
+    for (const value of [
+      "",
+      "   ",
+      "notaurl",
+      "ftp://x.test",
+      "https://x.test?a=b",
+      42,
+    ]) {
+      expect(
+        normalizeHttpPublicBaseUrlWithoutTrailingSlash(value),
+      ).toBeUndefined();
+    }
+  });
+});
+
 describe("Twilio ingress helpers", () => {
   test("resolves public base URL with fallback", () => {
     expect(
@@ -138,13 +169,18 @@ describe("parseLastTunnelRecord", () => {
     }
   });
 
-  test("trims the recorded URL", () => {
-    expect(
-      parseLastTunnelRecord({
-        provider: "ngrok",
-        publicBaseUrl: ` ${TUNNEL_URL} `,
-      }),
-    ).toEqual({ provider: "ngrok", publicBaseUrl: TUNNEL_URL });
+  test("returns the URL in the shape its own validator produces", () => {
+    // Padding and trailing slashes are normalized away rather than handed
+    // back, so readers never re-normalize what they were given.
+    for (const publicBaseUrl of [
+      ` ${TUNNEL_URL} `,
+      `${TUNNEL_URL}/`,
+      `${TUNNEL_URL}///`,
+    ]) {
+      expect(
+        parseLastTunnelRecord({ provider: "ngrok", publicBaseUrl }),
+      ).toEqual({ provider: "ngrok", publicBaseUrl: TUNNEL_URL });
+    }
   });
 
   test("rejects values that are not a record", () => {
@@ -181,6 +217,15 @@ describe("parseLastTunnelRecord", () => {
       expect(
         parseLastTunnelRecord({ provider: "ngrok", publicBaseUrl }),
       ).toBeNull();
+    }
+  });
+});
+
+describe("trimmedNonEmptyString", () => {
+  test("trims and rejects blank or non-string values", () => {
+    expect(trimmedNonEmptyString(" assistant-1 ")).toBe("assistant-1");
+    for (const value of ["", "   ", undefined, null, 42]) {
+      expect(trimmedNonEmptyString(value)).toBeUndefined();
     }
   });
 });

--- a/packages/service-contracts/src/ingress.ts
+++ b/packages/service-contracts/src/ingress.ts
@@ -49,6 +49,32 @@ export function normalizeHttpPublicBaseUrl(value: unknown): string | undefined {
   }
 }
 
+/**
+ * The same validation as `normalizeHttpPublicBaseUrl`, minus the root path it
+ * always emits (`https://x` becomes `https://x/`). Callers that append a path
+ * or persist the result want this shape, so they neither join through a double
+ * slash nor re-strip what the normalizer just added.
+ */
+export function normalizeHttpPublicBaseUrlWithoutTrailingSlash(
+  value: unknown,
+): string | undefined {
+  return normalizePublicBaseUrl(normalizeHttpPublicBaseUrl(value));
+}
+
+/**
+ * A trimmed string, or undefined when the value is not a non-blank string.
+ *
+ * Exported because the identity check in the daemon's tunnel probe compares an
+ * id recorded here against one an edge serves, and the two sides have to trim
+ * alike: a padded served id must read as a match, not as a different
+ * assistant.
+ */
+export function trimmedNonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
 // Records `vellum tunnel` leaves in the workspace config's `ingress` section.
 // The CLI writes them and the daemon reads them, and the two are separate
 // build units that cannot import each other, so the key names, the provider
@@ -89,27 +115,26 @@ function isTunnelProviderName(value: unknown): value is TunnelProviderName {
  * A hand-edited config must not hand callers an unusable address or a provider
  * name no command accepts: the provider is checked against the allowlist
  * because readers render it into a restart command, and the URL faces the same
- * absolute HTTP(S) constraint as every other public base URL.
+ * absolute HTTP(S) constraint as every other public base URL. The URL comes
+ * back in the shape the validator produced, so readers never re-normalize it.
  */
 export function parseLastTunnelRecord(value: unknown): LastTunnelRecord | null {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
     return null;
   }
   const { provider, publicBaseUrl } = value as Record<string, unknown>;
-  if (!isTunnelProviderName(provider) || typeof publicBaseUrl !== "string") {
+  if (!isTunnelProviderName(provider)) {
     return null;
   }
-  if (!normalizeHttpPublicBaseUrl(publicBaseUrl)) {
+  const normalized =
+    normalizeHttpPublicBaseUrlWithoutTrailingSlash(publicBaseUrl);
+  if (normalized === undefined) {
     return null;
   }
-  return { provider, publicBaseUrl: publicBaseUrl.trim() };
+  return { provider, publicBaseUrl: normalized };
 }
 
 /** Parse an `ingress.assistantId` value, or null when it is absent or blank. */
 export function parseRecordedAssistantId(value: unknown): string | null {
-  if (typeof value !== "string") {
-    return null;
-  }
-  const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : null;
+  return trimmedNonEmptyString(value) ?? null;
 }


### PR DESCRIPTION
## Summary
- `/healthz` is now genuinely the sole liveness verdict: an `/assistant/__config` request that loses the shared deadline leaves the identity unknown instead of reporting a working tunnel as `unreachable`, matching what the module docstring already claimed.
- `parseLastTunnelRecord` returns the shape its own validator produces via a new no-trailing-slash sibling normalizer, so the probe no longer re-strips the root path that `normalizeHttpPublicBaseUrl` adds.
- One shared `trimmedNonEmptyString` now trims both sides of the identity comparison, so a padded served `assistantId` reads as `healthy` rather than `foreign`; `describeError` collapses to a single accumulator.

Fixes re-review gaps for tunnel-status-pairing.md.