### PR TITLE
fix(assistant): treat unset ingress.enabled as on and stop naming stale tunnels

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -15474,11 +15474,11 @@ paths:
       summary: Get ingress tunnel status
       description:
         Probe the configured public ingress URL and report whether a tunnel is serving this assistant.
-        `unconfigured` means no tunnel has ever been recorded (or the assistant is platform-hosted, which never uses
-        one), `stopped` means a tunnel ran before and is not running now (ingress is switched off, or its URL is gone),
-        `healthy` means the URL answers and fronts this assistant, `unreachable` means it does not answer, and `foreign`
-        means it answers for a different assistant. `lastTunnel` names the tunnel to restart on every state but
-        `healthy` and `unconfigured`.
+        `unconfigured` means no tunnel has ever been recorded (or the ingress is managed for this assistant, as it is
+        when platform-hosted or fronted by a Velay tunnel), `stopped` means a tunnel ran before and is not running now
+        (ingress is explicitly switched off, or its URL is gone), `healthy` means the URL answers and fronts this
+        assistant, `unreachable` means it does not answer, and `foreign` means it answers for a different assistant.
+        `lastTunnel` names the tunnel to restart, on the states where a recorded one applies to the configured URL.
       tags:
         - config
       responses:
@@ -15502,8 +15502,8 @@ paths:
                     type: string
                   lastTunnel:
                     description:
-                      "The tunnel to restart. Set whenever one is recorded and the URL is not serving this assistant: stopped,
-                      unreachable, and foreign."
+                      The tunnel to restart. Set on stopped whenever one is recorded, and on unreachable and foreign when the
+                      recorded tunnel fronted the configured URL.
                     type: object
                     properties:
                       provider:

--- a/assistant/src/__tests__/sanitize-config-for-transfer.test.ts
+++ b/assistant/src/__tests__/sanitize-config-for-transfer.test.ts
@@ -9,11 +9,6 @@ describe("sanitizeConfigForTransfer", () => {
         publicBaseUrl: "https://example.com",
         enabled: true,
         publicBaseUrlManagedBy: "velay",
-        lastTunnel: {
-          provider: "ngrok",
-          publicBaseUrl: "https://source.ngrok.app",
-        },
-        assistantId: "source-assistant",
         webhook: { path: "/hook" },
       },
       daemon: { port: 3000, logLevel: "debug" },
@@ -38,8 +33,6 @@ describe("sanitizeConfigForTransfer", () => {
     expect(result.ingress.publicBaseUrl).toBe("");
     expect(result.ingress.enabled).toBeUndefined();
     expect(result.ingress.publicBaseUrlManagedBy).toBeUndefined();
-    expect(result.ingress.lastTunnel).toBeUndefined();
-    expect(result.ingress.assistantId).toBeUndefined();
     expect(result.daemon).toBeUndefined();
     expect(result.skills.load.extraDirs).toEqual([]);
     expect(result.hostBrowser).toEqual({

--- a/assistant/src/daemon/handlers/__tests__/config-ingress-tunnel-records.test.ts
+++ b/assistant/src/daemon/handlers/__tests__/config-ingress-tunnel-records.test.ts
@@ -1,9 +1,10 @@
 /**
- * Unit tests for the ingress section of the workspace config, including the
- * records `vellum tunnel` leaves behind. The record truth table lives on the
- * shared parser (`packages/service-contracts/src/__tests__/ingress.test.ts`);
- * what is checked here is that the daemon reads the keys the CLI writes and
- * inherits that validation.
+ * Unit tests for the ingress section of the workspace config: the records
+ * `vellum tunnel` leaves behind, who owns the public base URL, and when the
+ * records are dropped. The record truth table lives on the shared parser
+ * (`packages/service-contracts/src/__tests__/ingress.test.ts`); what is
+ * checked here is that the daemon reads the keys the CLI and the gateway
+ * write, and inherits that validation.
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -15,7 +16,9 @@ mock.module("../../../config/loader.js", () => ({
 }));
 
 import {
+  dropTunnelRecordsForNewUrl,
   getIngressConfigResult,
+  isVelayManagedIngress,
   loadLastTunnelRecord,
   loadRecordedAssistantId,
 } from "../config-ingress.js";
@@ -91,5 +94,67 @@ describe("workspace tunnel records", () => {
 
     expect(config.publicBaseUrl).toBe("");
     expect(config.enabled).toBe(false);
+    expect(config.explicitlyDisabled).toBe(false);
+  });
+
+  test("reports Velay ownership of the public base URL", () => {
+    rawConfig = {
+      ingress: { publicBaseUrl: TUNNEL_URL, publicBaseUrlManagedBy: "velay" },
+    };
+    expect(isVelayManagedIngress()).toBe(true);
+
+    rawConfig = { ingress: { publicBaseUrl: TUNNEL_URL } };
+    expect(isVelayManagedIngress()).toBe(false);
+  });
+});
+
+describe("explicitlyDisabled", () => {
+  beforeEach(() => {
+    rawConfig = {};
+  });
+
+  test("only an explicit false is an opt-out", () => {
+    // `ingress.enabled` is opt-out across the assistant: a URL set through
+    // `config set ingress.publicBaseUrl` never writes the flag and is live.
+    rawConfig = { ingress: { publicBaseUrl: TUNNEL_URL } };
+    expect(getIngressConfigResult().explicitlyDisabled).toBe(false);
+
+    rawConfig = { ingress: { publicBaseUrl: TUNNEL_URL, enabled: true } };
+    expect(getIngressConfigResult().explicitlyDisabled).toBe(false);
+
+    rawConfig = { ingress: { publicBaseUrl: TUNNEL_URL, enabled: false } };
+    expect(getIngressConfigResult().explicitlyDisabled).toBe(true);
+  });
+});
+
+describe("dropTunnelRecordsForNewUrl", () => {
+  const records = () => ({
+    publicBaseUrl: TUNNEL_URL,
+    assistantId: "assistant-1",
+    lastTunnel: { provider: "tailscale", publicBaseUrl: TUNNEL_URL },
+  });
+
+  test("keeps the records when the URL is unchanged", () => {
+    const ingress: Record<string, unknown> = records();
+
+    dropTunnelRecordsForNewUrl(ingress, ` ${TUNNEL_URL}/ `);
+
+    expect(ingress).toEqual(records());
+  });
+
+  test("drops the records when the URL is retargeted or cleared", () => {
+    const retargeted: Record<string, unknown> = records();
+    dropTunnelRecordsForNewUrl(retargeted, "https://other.example.ts.net");
+    expect(retargeted).toEqual({ publicBaseUrl: TUNNEL_URL });
+
+    const cleared: Record<string, unknown> = records();
+    dropTunnelRecordsForNewUrl(cleared, undefined);
+    expect(cleared).toEqual({ publicBaseUrl: TUNNEL_URL });
+  });
+
+  test("is a no-op without an ingress section", () => {
+    expect(() =>
+      dropTunnelRecordsForNewUrl(undefined, TUNNEL_URL),
+    ).not.toThrow();
   });
 });

--- a/assistant/src/daemon/handlers/config-ingress.ts
+++ b/assistant/src/daemon/handlers/config-ingress.ts
@@ -2,6 +2,7 @@ import {
   INGRESS_ASSISTANT_ID_KEY,
   INGRESS_LAST_TUNNEL_KEY,
   type LastTunnelRecord,
+  normalizePublicBaseUrl,
   parseLastTunnelRecord,
   parseRecordedAssistantId,
 } from "@vellumai/service-contracts/ingress";
@@ -19,6 +20,7 @@ import {
   getTwilioStatusCallbackUrl,
   getTwilioVoiceWebhookUrl,
   type IngressConfig,
+  isPublicIngressDisabled,
 } from "../../inbound/public-ingress-urls.js";
 import { isPlainObject } from "../../util/object.js";
 import { log } from "./shared.js";
@@ -55,6 +57,51 @@ export function loadRecordedAssistantId(): string | null {
   );
 }
 
+/** Key under `ingress` naming the component that owns `publicBaseUrl`. */
+const INGRESS_MANAGED_BY_KEY = "publicBaseUrlManagedBy";
+
+/** Value that key carries when a self-hosted gateway's Velay tunnel owns it. */
+const VELAY_MANAGED_BY = "velay";
+
+/**
+ * True when Velay owns `ingress.publicBaseUrl`.
+ *
+ * A gateway started with `VELAY_BASE_URL` writes the URL when its tunnel comes
+ * up, clears it when the tunnel drops, and reconnects on its own
+ * (`gateway/src/velay/client.ts`). Readers must not offer the user a tunnel
+ * command for an ingress they do not own.
+ */
+export function isVelayManagedIngress(): boolean {
+  return readIngressSection()[INGRESS_MANAGED_BY_KEY] === VELAY_MANAGED_BY;
+}
+
+/**
+ * Drop `ingress.assistantId` and `ingress.lastTunnel` from `ingress` when
+ * `nextPublicBaseUrl` replaces a different address, mutating it in place.
+ *
+ * Both records describe the address being replaced, so keeping them makes the
+ * status route call a legitimate retarget `foreign` and name a tunnel that
+ * never fronted the new address. Every writer of `ingress.publicBaseUrl` owes
+ * this cleanup, so it lives here rather than in each of them. An absent
+ * `ingress` section carries no records to drop.
+ */
+export function dropTunnelRecordsForNewUrl(
+  ingress: Record<string, unknown> | undefined,
+  nextPublicBaseUrl: unknown,
+): void {
+  if (!ingress) {
+    return;
+  }
+  if (
+    normalizePublicBaseUrl(nextPublicBaseUrl) ===
+    normalizePublicBaseUrl(ingress.publicBaseUrl)
+  ) {
+    return;
+  }
+  delete ingress[INGRESS_ASSISTANT_ID_KEY];
+  delete ingress[INGRESS_LAST_TUNNEL_KEY];
+}
+
 /**
  * Read the current ingress config from the raw workspace config file.
  * Extracted so it can be called from both the daemon message handler
@@ -62,6 +109,7 @@ export function loadRecordedAssistantId(): string | null {
  */
 export function getIngressConfigResult(): {
   enabled: boolean;
+  explicitlyDisabled: boolean;
   publicBaseUrl: string;
   localGatewayTarget: string;
   managedCallbacks: boolean;
@@ -77,6 +125,7 @@ export function getIngressConfigResult(): {
     if (assistantId) {
       return {
         enabled: true,
+        explicitlyDisabled: false,
         publicBaseUrl: `${platformBase}/gateway/callbacks/${assistantId}`,
         localGatewayTarget: computeGatewayTarget(),
         managedCallbacks: true,
@@ -90,9 +139,13 @@ export function getIngressConfigResult(): {
   // value whose type contradicts this function's return type.
   const publicBaseUrl =
     typeof ingress.publicBaseUrl === "string" ? ingress.publicBaseUrl : "";
-  const enabled = ingress.enabled === true;
+  const enabled =
+    typeof ingress.enabled === "boolean" ? ingress.enabled : undefined;
   return {
-    enabled,
+    enabled: enabled === true,
+    // `enabled` is opt-out across the assistant, so an unset flag is not off:
+    // callers asking whether ingress is live read this, not `!enabled`.
+    explicitlyDisabled: isPublicIngressDisabled({ ingress: { enabled } }),
     publicBaseUrl,
     localGatewayTarget: computeGatewayTarget(),
     managedCallbacks: false,

--- a/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
@@ -1764,3 +1764,83 @@ describe("provider membership at the write choke point", () => {
     ).rejects.toThrow(/Invalid provider/);
   });
 });
+
+describe("ingress URL writes through the generic config routes", () => {
+  const configPatchRoute = ROUTES.find(
+    (r) => r.operationId === "config_patch",
+  )!;
+  const configSetRoute = ROUTES.find((r) => r.operationId === "config_set")!;
+
+  const TUNNEL_URL = "https://assistant-1.example.ts.net";
+  const OTHER_URL = "https://assistant-2.example.ts.net";
+  const LAST_TUNNEL = { provider: "tailscale", publicBaseUrl: TUNNEL_URL };
+
+  const savedIngress = () =>
+    (loadRawConfig().ingress ?? {}) as Record<string, unknown>;
+
+  beforeEach(() => {
+    // `assistant config set ingress.publicBaseUrl <url>` is what the webhook
+    // diagnostics tell users to run when their tunnel address changed, so it
+    // has to leave the same clean state the settings route does.
+    rawConfigFixture = {
+      ingress: {
+        publicBaseUrl: TUNNEL_URL,
+        assistantId: "assistant-1",
+        lastTunnel: LAST_TUNNEL,
+      },
+    };
+    seedRawConfig();
+  });
+
+  test("a config_set retarget drops the tunnel records", async () => {
+    await configSetRoute.handler({
+      body: { path: "ingress.publicBaseUrl", value: OTHER_URL },
+    });
+
+    const ingress = savedIngress();
+    expect(ingress.publicBaseUrl).toBe(OTHER_URL);
+    expect(ingress.assistantId).toBeUndefined();
+    expect(ingress.lastTunnel).toBeUndefined();
+  });
+
+  test("a config_set of the same URL keeps them", async () => {
+    await configSetRoute.handler({
+      body: { path: "ingress.publicBaseUrl", value: `${TUNNEL_URL}/` },
+    });
+
+    const ingress = savedIngress();
+    expect(ingress.assistantId).toBe("assistant-1");
+    expect(ingress.lastTunnel).toEqual(LAST_TUNNEL);
+  });
+
+  test("a config_set of another ingress key keeps them", async () => {
+    await configSetRoute.handler({
+      body: { path: "ingress.enabled", value: false },
+    });
+
+    const ingress = savedIngress();
+    expect(ingress.assistantId).toBe("assistant-1");
+    expect(ingress.lastTunnel).toEqual(LAST_TUNNEL);
+  });
+
+  test("a config_patch retarget drops the tunnel records", async () => {
+    await configPatchRoute.handler({
+      body: { ingress: { publicBaseUrl: OTHER_URL } },
+    });
+
+    const ingress = savedIngress();
+    expect(ingress.publicBaseUrl).toBe(OTHER_URL);
+    expect(ingress.assistantId).toBeUndefined();
+    expect(ingress.lastTunnel).toBeUndefined();
+  });
+
+  test("a config_patch that leaves the URL alone keeps them", async () => {
+    await configPatchRoute.handler({
+      body: { ingress: { enabled: false } },
+    });
+
+    const ingress = savedIngress();
+    expect(ingress.assistantId).toBe("assistant-1");
+    expect(ingress.lastTunnel).toEqual(LAST_TUNNEL);
+  });
+});

--- a/assistant/src/runtime/routes/__tests__/ingress-status-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/ingress-status-routes.test.ts
@@ -14,11 +14,13 @@ import { ACTOR_PRINCIPALS } from "../../auth/route-policy.js";
 
 let ingressConfig = {
   enabled: true,
+  explicitlyDisabled: false,
   publicBaseUrl: "",
   localGatewayTarget: "http://127.0.0.1:4000",
   managedCallbacks: false,
   success: true,
 };
+let velayManaged = false;
 let lastTunnel: LastTunnelRecord | null = null;
 let recordedAssistantId: string | null = null;
 let probeResult: TunnelProbeResult = { kind: "healthy" };
@@ -32,6 +34,7 @@ const probeTunnelMock = mock(
 
 mock.module("../../../daemon/handlers/config-ingress.js", () => ({
   getIngressConfigResult: () => ingressConfig,
+  isVelayManagedIngress: () => velayManaged,
   loadLastTunnelRecord: () => lastTunnel,
   loadRecordedAssistantId: () => recordedAssistantId,
 }));
@@ -52,11 +55,13 @@ describe("integrations_ingress_status route", () => {
   beforeEach(() => {
     ingressConfig = {
       enabled: true,
+      explicitlyDisabled: false,
       publicBaseUrl: "",
       localGatewayTarget: "http://127.0.0.1:4000",
       managedCallbacks: false,
       success: true,
     };
+    velayManaged = false;
     lastTunnel = null;
     recordedAssistantId = null;
     probeResult = { kind: "healthy" };
@@ -107,6 +112,7 @@ describe("integrations_ingress_status route", () => {
     ingressConfig = {
       ...ingressConfig,
       enabled: false,
+      explicitlyDisabled: true,
       publicBaseUrl: TUNNEL_URL,
     };
     lastTunnel = { provider: "tailscale", publicBaseUrl: TUNNEL_URL };
@@ -122,11 +128,31 @@ describe("integrations_ingress_status route", () => {
     ingressConfig = {
       ...ingressConfig,
       enabled: false,
+      explicitlyDisabled: true,
       publicBaseUrl: TUNNEL_URL,
     };
 
     expect(await route.handler({})).toEqual({ state: "stopped" });
     expect(probeTunnelMock).not.toHaveBeenCalled();
+  });
+
+  test("probes a URL configured without the enabled flag", async () => {
+    // A bring-your-own-HTTPS front is set up with `config set
+    // ingress.publicBaseUrl`, which never writes `ingress.enabled`. Only an
+    // explicit opt-out means stopped.
+    ingressConfig = {
+      ...ingressConfig,
+      enabled: false,
+      explicitlyDisabled: false,
+      publicBaseUrl: TUNNEL_URL,
+    };
+
+    const result = (await route.handler({})) as Record<string, unknown>;
+
+    expect(result.state).toBe("healthy");
+    expect(probeTunnelMock).toHaveBeenCalledWith({
+      publicBaseUrl: TUNNEL_URL,
+    });
   });
 
   test("reports healthy with a timestamp when the probe succeeds", async () => {
@@ -218,6 +244,67 @@ describe("integrations_ingress_status route", () => {
       provider: "ngrok",
       publicBaseUrl: TUNNEL_URL,
     });
+  });
+
+  test("ignores trailing slashes when matching the recorded tunnel", async () => {
+    ingressConfig = { ...ingressConfig, publicBaseUrl: `${TUNNEL_URL}/` };
+    lastTunnel = { provider: "ngrok", publicBaseUrl: TUNNEL_URL };
+    probeResult = { kind: "unreachable", detail: "HTTP 502" };
+
+    const result = (await route.handler({})) as Record<string, unknown>;
+
+    expect(result.lastTunnel).toEqual({
+      provider: "ngrok",
+      publicBaseUrl: TUNNEL_URL,
+    });
+  });
+
+  test("omits a recorded tunnel that fronted a different URL", async () => {
+    // `saveIngressUrl` keeps `lastTunnel` when it replaces the URL without a
+    // provider, so the record can outlive the address it described. Restarting
+    // it would not bring the configured URL back.
+    ingressConfig = { ...ingressConfig, publicBaseUrl: TUNNEL_URL };
+    lastTunnel = { provider: "ngrok", publicBaseUrl: "https://old.ngrok.app" };
+    probeResult = { kind: "unreachable", detail: "HTTP 502" };
+
+    const result = (await route.handler({})) as Record<string, unknown>;
+
+    expect(result.state).toBe("unreachable");
+    expect(result).not.toHaveProperty("lastTunnel");
+  });
+
+  test("omits a stale recorded tunnel from a foreign response", async () => {
+    ingressConfig = { ...ingressConfig, publicBaseUrl: TUNNEL_URL };
+    lastTunnel = { provider: "ngrok", publicBaseUrl: "https://old.ngrok.app" };
+    probeResult = { kind: "foreign", assistantId: "assistant-2" };
+
+    const result = (await route.handler({})) as Record<string, unknown>;
+
+    expect(result.state).toBe("foreign");
+    expect(result).not.toHaveProperty("lastTunnel");
+  });
+
+  test("reports unconfigured for a Velay-managed ingress with no URL", async () => {
+    // The gateway clears the URL when its tunnel drops and reconnects on its
+    // own, so there is no tunnel command to offer the user.
+    velayManaged = true;
+    ingressConfig = { ...ingressConfig, publicBaseUrl: "" };
+    lastTunnel = { provider: "ngrok", publicBaseUrl: TUNNEL_URL };
+
+    expect(await route.handler({})).toEqual({ state: "unconfigured" });
+    expect(probeTunnelMock).not.toHaveBeenCalled();
+  });
+
+  test("probes a Velay-managed URL but names no tunnel to restart", async () => {
+    velayManaged = true;
+    ingressConfig = { ...ingressConfig, publicBaseUrl: TUNNEL_URL };
+    lastTunnel = { provider: "ngrok", publicBaseUrl: TUNNEL_URL };
+    probeResult = { kind: "unreachable", detail: "HTTP 502" };
+
+    const result = (await route.handler({})) as Record<string, unknown>;
+
+    expect(result.state).toBe("unreachable");
+    expect(result).not.toHaveProperty("lastTunnel");
   });
 
   test("omits lastTunnel from a healthy response", async () => {

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -66,6 +66,7 @@ import {
   getEmbeddingConfigInfo,
   setEmbeddingConfig,
 } from "../../daemon/handlers/config-embeddings.js";
+import { dropTunnelRecordsForNewUrl } from "../../daemon/handlers/config-ingress.js";
 import {
   getModelInfo,
   type ModelSetContext,
@@ -1525,6 +1526,10 @@ async function handlePatchConfig({ body }: RouteHandlerArgs) {
 
   const raw = loadRawConfig();
   const patch = body as Record<string, unknown>;
+  const patchedIngressUrl = readPlainObject(patch.ingress)?.publicBaseUrl;
+  if (patchedIngressUrl !== undefined) {
+    dropTunnelRecordsForNewUrl(readPlainObject(raw.ingress), patchedIngressUrl);
+  }
   deepMergeOverwrite(raw, patch);
   scrubRemovedServiceModes(raw);
   seedSttProviderForSparseBlock(raw);
@@ -1615,6 +1620,11 @@ async function handleSetConfig({ body }: RouteHandlerArgs) {
         readPlainObject(readPlainObject(raw.llm)?.profiles)?.[managedEntryName],
       )
     : undefined;
+  // `assistant config set ingress.publicBaseUrl <url>`, what the webhook
+  // diagnostics tell users to run, retargets ingress like the settings route.
+  if (path === "ingress.publicBaseUrl") {
+    dropTunnelRecordsForNewUrl(readPlainObject(raw.ingress), value);
+  }
   setNestedValue(raw, path, value);
   if (
     managedEntryName &&

--- a/assistant/src/runtime/routes/ingress-status-routes.ts
+++ b/assistant/src/runtime/routes/ingress-status-routes.ts
@@ -10,12 +10,17 @@
  *
  * Platform-hosted assistants receive webhooks through platform callback
  * routing and never run `vellum tunnel`, so they report `unconfigured`
- * rather than a tunnel state they cannot act on.
+ * rather than a tunnel state they cannot act on. A self-hosted gateway whose
+ * Velay tunnel owns the URL is the same story one layer down: it is still
+ * probed while a URL is published, but it is never handed a tunnel command,
+ * because the gateway publishes and restores that URL itself.
  */
+import { normalizePublicBaseUrl } from "@vellumai/service-contracts/ingress";
 import { z } from "zod";
 
 import {
   getIngressConfigResult,
+  isVelayManagedIngress,
   loadLastTunnelRecord,
   loadRecordedAssistantId,
 } from "../../daemon/handlers/config-ingress.js";
@@ -45,7 +50,7 @@ const IngressStatusResponseSchema = z.object({
     .object({ provider: z.string(), publicBaseUrl: z.string() })
     .optional()
     .describe(
-      "The tunnel to restart. Set whenever one is recorded and the URL is not serving this assistant: stopped, unreachable, and foreign.",
+      "The tunnel to restart. Set on stopped whenever one is recorded, and on unreachable and foreign when the recorded tunnel fronted the configured URL.",
     ),
   servingAssistantName: z
     .string()
@@ -72,20 +77,29 @@ async function handleIngressStatus(): Promise<IngressStatusResponse> {
     return { state: "unconfigured" };
   }
 
-  // Carried by every state the user has to act on, so the client can name the
-  // command that brings the tunnel back.
-  const lastTunnel = loadLastTunnelRecord();
-  const restartHint = lastTunnel ? { lastTunnel } : {};
+  // A Velay-managed URL belongs to the gateway, which writes it, clears it,
+  // and reconnects on its own, so there is no tunnel for the user to restart.
+  const lastTunnel = isVelayManagedIngress() ? null : loadLastTunnelRecord();
 
   const publicBaseUrl = config.publicBaseUrl.trim();
   if (!publicBaseUrl && !lastTunnel) {
     return { state: "unconfigured" };
   }
-  // The URL survives the enabled toggle, so probing while ingress is off would
-  // report a tunnel the user switched off as healthy.
-  if (!publicBaseUrl || !config.enabled) {
-    return { state: "stopped", ...restartHint };
+  // The URL survives the enabled toggle, so probing while ingress is opted out
+  // would report a tunnel the user switched off as healthy. An unset flag is
+  // not an opt-out: a bring-your-own-HTTPS front sets only the URL.
+  if (!publicBaseUrl || config.explicitlyDisabled) {
+    return { state: "stopped", ...(lastTunnel ? { lastTunnel } : {}) };
   }
+
+  // A record left over from an address that is no longer configured names a
+  // tunnel that never fronted this one, so it is no help in getting back.
+  const restartHint =
+    lastTunnel &&
+    normalizePublicBaseUrl(lastTunnel.publicBaseUrl) ===
+      normalizePublicBaseUrl(publicBaseUrl)
+      ? { lastTunnel }
+      : {};
 
   // Omitted when unrecorded so the probe skips the identity check entirely
   // rather than reading every served id as a mismatch.
@@ -131,7 +145,7 @@ export const ROUTES: RouteDefinition[] = [
     },
     summary: "Get ingress tunnel status",
     description:
-      "Probe the configured public ingress URL and report whether a tunnel is serving this assistant. `unconfigured` means no tunnel has ever been recorded (or the assistant is platform-hosted, which never uses one), `stopped` means a tunnel ran before and is not running now (ingress is switched off, or its URL is gone), `healthy` means the URL answers and fronts this assistant, `unreachable` means it does not answer, and `foreign` means it answers for a different assistant. `lastTunnel` names the tunnel to restart on every state but `healthy` and `unconfigured`.",
+      "Probe the configured public ingress URL and report whether a tunnel is serving this assistant. `unconfigured` means no tunnel has ever been recorded (or the ingress is managed for this assistant, as it is when platform-hosted or fronted by a Velay tunnel), `stopped` means a tunnel ran before and is not running now (ingress is explicitly switched off, or its URL is gone), `healthy` means the URL answers and fronts this assistant, `unreachable` means it does not answer, and `foreign` means it answers for a different assistant. `lastTunnel` names the tunnel to restart, on the states where a recorded one applies to the configured URL.",
     tags: ["config"],
     handler: handleIngressStatus,
     responseBody: IngressStatusResponseSchema,

--- a/assistant/src/runtime/routes/settings-routes.ts
+++ b/assistant/src/runtime/routes/settings-routes.ts
@@ -6,11 +6,7 @@
 import { readFileSync } from "node:fs";
 import { basename, join } from "node:path";
 
-import {
-  INGRESS_ASSISTANT_ID_KEY,
-  INGRESS_LAST_TUNNEL_KEY,
-  normalizePublicBaseUrl,
-} from "@vellumai/service-contracts/ingress";
+import { normalizePublicBaseUrl } from "@vellumai/service-contracts/ingress";
 import { z } from "zod";
 
 import { setImage } from "../../avatar/avatar-store.js";
@@ -29,6 +25,7 @@ import {
 } from "../../daemon/conversation-tool-setup.js";
 import {
   computeGatewayTarget,
+  dropTunnelRecordsForNewUrl,
   getIngressConfigResult,
 } from "../../daemon/handlers/config-ingress.js";
 import { normalizeActivationKey } from "../../daemon/handlers/config-voice.js";
@@ -842,12 +839,12 @@ function handleGetPlatformConfig() {
 function handleUpdatePlatformConfig({ body = {} }: RouteHandlerArgs) {
   try {
     const { baseUrl: rawBaseUrl } = body as { baseUrl?: string };
-    const value = (rawBaseUrl ?? "").trim().replace(/\/+$/, "");
+    const value = normalizePublicBaseUrl(rawBaseUrl);
     const raw = loadRawConfig();
     const platform = (raw?.platform ?? {}) as Record<string, unknown>;
-    platform.baseUrl = value || undefined;
+    platform.baseUrl = value;
     saveRawConfig({ ...raw, platform });
-    return { baseUrl: value, success: true };
+    return { baseUrl: value ?? "", success: true };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     log.error({ err }, "Failed to update platform config");
@@ -868,13 +865,7 @@ function handleUpdateIngressConfig({ body = {} }: RouteHandlerArgs) {
     const value = normalizePublicBaseUrl(rawUrl);
     const raw = loadRawConfig();
     const ingress = (raw?.ingress ?? {}) as Record<string, unknown>;
-    if (value !== normalizePublicBaseUrl(ingress.publicBaseUrl)) {
-      // Both records describe the address being replaced, so keeping them
-      // makes the status route call a legitimate retarget `foreign` and name
-      // a tunnel that never fronted the new address.
-      delete ingress[INGRESS_ASSISTANT_ID_KEY];
-      delete ingress[INGRESS_LAST_TUNNEL_KEY];
-    }
+    dropTunnelRecordsForNewUrl(ingress, value);
     ingress.publicBaseUrl = value;
     if (enabled !== undefined) {
       ingress.enabled = enabled;


### PR DESCRIPTION
## Summary

- `integrations/ingress/status` now stops only on an explicit `ingress.enabled: false`, so a bring-your-own-HTTPS front (set with `config set ingress.publicBaseUrl`, which never writes the flag) is probed instead of reported `stopped`; `getIngressConfigResult` gained `explicitlyDisabled`, derived through the shared `isPublicIngressDisabled`.
- `lastTunnel` is attached to `unreachable`/`foreign` only when its URL matches the configured one (compared through `normalizePublicBaseUrl`), and a Velay-managed ingress never gets restart guidance at all: with no URL it reports `unconfigured` rather than telling the user to run `vellum tunnel` for an ingress the gateway reconnects itself.
- The 'URL changed drops the tunnel records' rule moved into one exported helper next to the other ingress readers, called from the settings route and from the generic `config set` / `config patch` writers; `handleUpdatePlatformConfig` uses the shared URL normalizer, and the duplicated transfer-sanitizer assertions are back to one dedicated test.

Fixes re-review gaps for tunnel-status-pairing.