### PR TITLE
fix(web): let the first-run card re-check and quote pasted commands safely

### DIFF
--- a/clients/web/src/domains/settings/pair-device/code-chip.ts
+++ b/clients/web/src/domains/settings/pair-device/code-chip.ts
@@ -1,0 +1,8 @@
+/**
+ * Shared look of the `<code>` chips in the Pair-a-device card: the tunnel
+ * commands offered for pasting, the help command inside the first-run notice,
+ * and a pending request's user code. Padding stays per site, and a chip meant
+ * to be read across a room overrides the type scale and colour.
+ */
+export const CODE_CHIP_CLASS =
+  "rounded-md bg-[var(--surface-active)] text-body-small-default text-[color:var(--content-primary)]";

--- a/clients/web/src/domains/settings/pair-device/pair-device-card.test.tsx
+++ b/clients/web/src/domains/settings/pair-device/pair-device-card.test.tsx
@@ -244,6 +244,13 @@ function openUrlField() {
   fireEvent.click(screen.getByRole("button", { name: URL_DISCLOSURE_LABEL }));
 }
 
+/** The re-check the status row and the first-run notice both offer. */
+const RECHECK_LABEL = "Check the tunnel again";
+
+function recheckButton(): HTMLElement | null {
+  return screen.queryByRole("button", { name: RECHECK_LABEL });
+}
+
 beforeEach(() => {
   gatewayPath = "/assistant/__gateway/20100";
   supportsPairingRoutes = true;
@@ -725,9 +732,25 @@ describe("PairDeviceCard: tunnel status", () => {
 
     expect(await screen.findByText("Open a tunnel first")).toBeTruthy();
     expect(screen.getByText("vellum tunnel --provider tailscale")).toBeTruthy();
+  });
+
+  // The user leaves this state to run `vellum tunnel` in a terminal beside the
+  // window, which is never a foreground edge, so `app.resume` alone would
+  // strand the card on "Open a tunnel first" until a full reload.
+  test("re-checks from the first-run notice, which the row cannot offer", async () => {
+    probeAnswers({ state: "unconfigured" });
+    renderCard();
+    await screen.findByText("Open a tunnel first");
+    expect(probeMock).toHaveBeenCalledTimes(1);
+
+    probeAnswers(healthyStatus());
+    fireEvent.click(recheckButton()!);
+
+    await waitFor(() => expect(probeMock).toHaveBeenCalledTimes(2));
     expect(
-      screen.queryByRole("button", { name: "Check the tunnel again" }),
-    ).toBeNull();
+      await screen.findByText("The tunnel is running and reachable."),
+    ).toBeTruthy();
+    expect(screen.queryByText("Open a tunnel first")).toBeNull();
   });
 
   test("re-checks the tunnel when the app resumes", async () => {
@@ -921,6 +944,27 @@ describe("PairDeviceCard: tunnel status", () => {
     ).toBe(true);
   });
 
+  // Reachable after ingress is switched off with no tunnel left on record.
+  // The daemon answered, so its verdict stands: falling back here would
+  // re-advertise the recorded ingress URL the probe exists to replace.
+  test("trusts a stopped verdict the daemon remembers no tunnel for", async () => {
+    selectedAssistant = {
+      assistantId: ASSISTANT_ID,
+      cloud: "local",
+      ingressUrl: RECORDED_INGRESS_URL,
+    };
+    probeAnswers({ state: "stopped" });
+    renderCard();
+
+    await screen.findByText(
+      "The tunnel is stopped, so other devices cannot reach this assistant.",
+    );
+    expect(urlField().value).toBe("");
+    expect(screen.queryByText("Open a tunnel first")).toBeNull();
+    // No provider on record, so nothing claims to know the restart command.
+    expect(screen.queryByText(/vellum tunnel --provider/)).toBeNull();
+  });
+
   test("keeps the URL field leading when the verdict carries no address", async () => {
     // `publicBaseUrl` is optional on every state of the flat wire response, so
     // an empty one must not read as an address the card can lead with.
@@ -954,7 +998,7 @@ describe("PairDeviceCard: tunnel status", () => {
     ).toBeTruthy();
     expect(screen.getByText("connection refused")).toBeTruthy();
     expect(
-      screen.getByText('vellum tunnel "My Assistant" --provider tailscale'),
+      screen.getByText("vellum tunnel 'My Assistant' --provider tailscale"),
     ).toBeTruthy();
   });
 
@@ -969,7 +1013,7 @@ describe("PairDeviceCard: tunnel status", () => {
 
     expect(await screen.findByText("Open a tunnel first")).toBeTruthy();
     expect(
-      screen.getByText('vellum tunnel "My Assistant" --provider tailscale'),
+      screen.getByText("vellum tunnel 'My Assistant' --provider tailscale"),
     ).toBeTruthy();
   });
 
@@ -1055,15 +1099,16 @@ describe("PairDeviceCard: when the tunnel probe gives up", () => {
     ).toBe(false);
     expect(screen.queryByText("Open a tunnel first")).toBeNull();
     // Nothing to report and nothing to re-check from: the row stays silent.
-    expect(
-      screen.queryByRole("button", { name: "Check the tunnel again" }),
-    ).toBeNull();
+    expect(recheckButton()).toBeNull();
   });
 
   test("falls back to the field-derived empty state with nothing recorded", async () => {
     renderCard();
 
     expect(await screen.findByText("Open a tunnel first")).toBeTruthy();
+    // Inferred from the field rather than reported, so there is no verdict to
+    // re-check and the notice offers none.
+    expect(recheckButton()).toBeNull();
     expect(urlField().value).toBe("");
     expect(
       (
@@ -1086,9 +1131,7 @@ describe("PairDeviceCard: without the ingress-status route", () => {
     renderCard();
 
     expect(urlField().value).toBe(RECORDED_INGRESS_URL);
-    expect(
-      screen.queryByRole("button", { name: "Check the tunnel again" }),
-    ).toBeNull();
+    expect(recheckButton()).toBeNull();
     // A recorded URL is the pre-probe evidence of a tunnel, so no first-run
     // notice even though the probe never reported one.
     expect(screen.queryByText("Open a tunnel first")).toBeNull();
@@ -1106,6 +1149,9 @@ describe("PairDeviceCard: without the ingress-status route", () => {
     renderCard();
 
     expect(screen.getByText("Open a tunnel first")).toBeTruthy();
+    // A re-check below the version floor would probe a route that is not
+    // there, so the notice offers none.
+    expect(recheckButton()).toBeNull();
     expect(probeMock).not.toHaveBeenCalled();
   });
 

--- a/clients/web/src/domains/settings/pair-device/pair-device-card.tsx
+++ b/clients/web/src/domains/settings/pair-device/pair-device-card.tsx
@@ -7,6 +7,7 @@ import { Collapsible } from "@vellumai/design-library/components/collapsible";
 import { Input } from "@vellumai/design-library/components/input";
 import { Notice } from "@vellumai/design-library/components/notice";
 import { cn } from "@vellumai/design-library/utils/cn";
+import type { TunnelProviderName } from "@vellumai/service-contracts/ingress";
 
 import { DetailCard } from "@/components/detail-card";
 import { useBusSubscription } from "@/hooks/use-bus-subscription";
@@ -15,10 +16,13 @@ import { Trans, useTranslation } from "@/i18n";
 import { useSupportsRemoteWebPairing } from "@/lib/backwards-compat/remote-web-pairing-gate";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 
+import { CODE_CHIP_CLASS } from "./code-chip";
 import { resolvePairDeviceTarget } from "./pair-device-client";
 import { PairDeviceReady } from "./pair-device-ready";
 import { PairedDevicesSection } from "./paired-devices-section";
 import { PendingPairingRequests } from "./pending-pairing-requests";
+import { useRelativeAgeTick } from "./relative-age";
+import { TunnelRecheckButton } from "./tunnel-recheck-button";
 import {
   statusCheckedAt,
   statusPublicBaseUrl,
@@ -26,18 +30,18 @@ import {
   tunnelStartCommand,
 } from "./tunnel-status-row";
 import { usePairDevice } from "./use-pair-device";
-import { useRelativeAgeTick } from "./use-relative-age-tick";
 import { useTunnelStatus } from "./use-tunnel-status";
 
-/** Named explicitly so the command does not depend on the CLI's default. */
-const TUNNEL_PROVIDER = "tailscale";
+/**
+ * Named explicitly so the command does not depend on the CLI's default, and
+ * typed against the shared registry so it can only name a provider the CLI
+ * accepts.
+ */
+const TUNNEL_PROVIDER: TunnelProviderName = "tailscale";
 const TUNNEL_HELP_COMMAND = "vellum tunnel --help";
 
 /** The URL field's disclosure holds a single section. */
 const URL_FIELD_SECTION = "public-url";
-
-const CODE_CLASS =
-  "rounded-md bg-[var(--surface-active)] text-body-small-default text-[color:var(--content-primary)]";
 
 /**
  * Settings card that pairs another device to this assistant without shell
@@ -51,10 +55,12 @@ const CODE_CLASS =
  * ({@link useTunnelStatus}), which drives the status row, the first-run
  * notice, the URL field's prefill and whether it hides behind its disclosure,
  * and how much the Generate button insists. The probe re-runs on the
- * `app.resume` foreground edge. Where that probe has no verdict, because the
- * assistant sits below the ingress-status version floor or because the query
- * gave up, the card falls back to the assistant's recorded ingress URL and
- * infers the empty state from the field.
+ * `app.resume` foreground edge, and on the re-check both the status row and
+ * the first-run notice carry: the user opens the tunnel in a terminal beside
+ * the window, which is not a foreground edge at all. Where the probe has no
+ * verdict, because the assistant sits below the ingress-status version floor
+ * or because the query gave up, the card falls back to the assistant's
+ * recorded ingress URL and infers the empty state from the field.
  *
  * Rendered only in desktop/local mode against an on-machine gateway (the gate
  * lives in {@link resolvePairDeviceTarget}) whose assistant version serves the
@@ -125,6 +131,10 @@ export function PairDeviceCard() {
   const showNoTunnelGuidance = probeAnswered
     ? tunnel.status.kind === "unconfigured"
     : pair.prefillSource === "none" && pair.publicBaseUrl.trim() === "";
+  // The first-run notice is where the user leaves to start a tunnel, so it
+  // carries the re-check for coming back. Only a verdict can be re-checked:
+  // below the version floor, or with the probe given up, `refresh` is a no-op.
+  const offerFirstRunRecheck = showNoTunnelGuidance && probeAnswered;
   // The probe doubts the address. The status row already says so, so the
   // button softens to match instead of repeating the warning.
   const tunnelWarns =
@@ -191,12 +201,24 @@ export function PairDeviceCard() {
     >
       <div className="flex flex-col gap-4">
         {showNoTunnelGuidance && (
-          <Notice tone="info" title={t("pairDeviceCard.noTunnelTitle")}>
+          <Notice
+            tone="info"
+            title={t("pairDeviceCard.noTunnelTitle")}
+            actions={
+              offerFirstRunRecheck ? (
+                <TunnelRecheckButton
+                  onRefresh={tunnel.refresh}
+                  isRefreshing={tunnel.isRefreshing}
+                  labelled
+                />
+              ) : undefined
+            }
+          >
             <div className="flex flex-col gap-2">
               <p>{t("pairDeviceCard.noTunnelWhy", { name: assistantLabel })}</p>
               <code
                 className={cn(
-                  CODE_CLASS,
+                  CODE_CHIP_CLASS,
                   "w-fit max-w-full overflow-x-auto px-2.5 py-1.5",
                 )}
               >
@@ -209,7 +231,9 @@ export function PairDeviceCard() {
                   ns="settings"
                   values={{ command: TUNNEL_HELP_COMMAND }}
                   components={{
-                    code: <code className={cn(CODE_CLASS, "px-1.5 py-0.5")} />,
+                    code: (
+                      <code className={cn(CODE_CHIP_CLASS, "px-1.5 py-0.5")} />
+                    ),
                   }}
                 />
               </p>

--- a/clients/web/src/domains/settings/pair-device/pair-device-test-helpers.ts
+++ b/clients/web/src/domains/settings/pair-device/pair-device-test-helpers.ts
@@ -127,7 +127,7 @@ export function pendingRequest(
   };
 }
 
-export interface RecordedFetch {
+interface RecordedFetch {
   url: string;
   init: RequestInit | undefined;
 }
@@ -175,7 +175,7 @@ export interface ArmedTimer {
   cleared: boolean;
 }
 
-export interface TimerHarness {
+interface TimerHarness {
   /** Every interval armed since {@link TimerHarness.install}, oldest first. */
   timers: ArmedTimer[];
   install: () => void;

--- a/clients/web/src/domains/settings/pair-device/paired-devices-section.test.tsx
+++ b/clients/web/src/domains/settings/pair-device/paired-devices-section.test.tsx
@@ -16,6 +16,8 @@ import type {
   LocalRevokeDeviceResult,
 } from "@/runtime/local-mode-host";
 
+import { createTimerHarness } from "./pair-device-test-helpers";
+
 let listImpl: (assistantId: string) => Promise<LocalListDevicesResult>;
 let listCalls: string[] = [];
 let revokeResult: LocalRevokeDeviceResult = { ok: true };
@@ -292,27 +294,16 @@ describe("PairedDevicesSection", () => {
   });
 
   test("polls while a pairing code is live and refreshes once more when it ends", async () => {
-    // bun:test has no fake timers; capture interval callbacks and fire them
-    // by hand so the test stays deterministic.
-    const intervals = new Map<unknown, () => void>();
-    let nextIntervalId = 1;
-    const originalSetInterval = globalThis.setInterval;
-    const originalClearInterval = globalThis.clearInterval;
-    globalThis.setInterval = ((fn: () => void) => {
-      const id = nextIntervalId++;
-      intervals.set(id, fn);
-      return id;
-    }) as unknown as typeof setInterval;
-    globalThis.clearInterval = ((id: unknown) => {
-      intervals.delete(id);
-    }) as typeof clearInterval;
+    const timerHarness = createTimerHarness();
+    const livePolls = () => timerHarness.timers.filter((t) => !t.cleared);
+    timerHarness.install();
 
     try {
       setListResult({ ok: true, devices: [device()] });
       const { rerender } = render(<PairedDevicesSection pollWhilePairing />);
       await act(async () => {});
       expect(listCalls).toEqual(["self"]);
-      expect(intervals.size).toBe(1);
+      expect(livePolls()).toHaveLength(1);
 
       // Another device claims the live code; the next tick surfaces it.
       setListResult({
@@ -323,8 +314,8 @@ describe("PairedDevicesSection", () => {
         ],
       });
       await act(async () => {
-        for (const tick of intervals.values()) {
-          tick();
+        for (const poll of livePolls()) {
+          poll.handler();
         }
       });
       expect(listCalls).toEqual(["self", "self"]);
@@ -336,27 +327,22 @@ describe("PairedDevicesSection", () => {
       // refresh catches a claim in the last window.
       rerender(<PairedDevicesSection pollWhilePairing={false} />);
       await act(async () => {});
-      expect(intervals.size).toBe(0);
+      expect(livePolls()).toHaveLength(0);
       expect(listCalls).toEqual(["self", "self", "self"]);
     } finally {
-      globalThis.setInterval = originalSetInterval;
-      globalThis.clearInterval = originalClearInterval;
+      timerHarness.restore();
     }
   });
 
   test("does not poll without a live pairing code", async () => {
-    const originalSetInterval = globalThis.setInterval;
-    let intervalCount = 0;
-    globalThis.setInterval = ((...args: Parameters<typeof setInterval>) => {
-      intervalCount++;
-      return originalSetInterval(...args);
-    }) as typeof setInterval;
+    const timerHarness = createTimerHarness();
+    timerHarness.install();
     try {
       await renderExpanded([device()]);
-      expect(intervalCount).toBe(0);
+      expect(timerHarness.timers).toHaveLength(0);
       expect(listCalls).toEqual(["self"]);
     } finally {
-      globalThis.setInterval = originalSetInterval;
+      timerHarness.restore();
     }
   });
 

--- a/clients/web/src/domains/settings/pair-device/pending-pairing-requests.tsx
+++ b/clients/web/src/domains/settings/pair-device/pending-pairing-requests.tsx
@@ -1,11 +1,12 @@
 import { Button } from "@vellumai/design-library/components/button";
 import { Notice } from "@vellumai/design-library/components/notice";
+import { cn } from "@vellumai/design-library/utils/cn";
 import { Loader2 } from "lucide-react";
 
-import { currentLocale, useTranslation } from "@/i18n";
-import { formatRelativeTime } from "@/lib/relative-time";
+import { useTranslation } from "@/i18n";
 
-import { useRelativeAgeTick } from "./use-relative-age-tick";
+import { CODE_CHIP_CLASS } from "./code-chip";
+import { formatRelativeAge, useRelativeAgeTick } from "./relative-age";
 import { usePendingPairingRequests } from "./use-pending-pairing-requests";
 
 interface PendingPairingRequestsProps {
@@ -13,18 +14,6 @@ interface PendingPairingRequestsProps {
   base: string;
   /** Fired when an action pairs a device, so siblings can revalidate. */
   onApproved?: () => void;
-}
-
-/**
- * Relative label for a request's timestamp in the active i18n locale.
- * Pending requests are short-lived, so minute granularity is enough;
- * anything under a minute reads as "now".
- */
-function formatRequestedAt(iso: string): string {
-  return formatRelativeTime(new Date(iso).getTime(), {
-    locale: currentLocale(),
-    minimumUnit: "minute",
-  });
 }
 
 /**
@@ -78,7 +67,12 @@ export function PendingPairingRequests({
                 key={request.requestId}
                 className="flex flex-col gap-2 rounded-lg border border-[var(--border-element)] p-3"
               >
-                <code className="w-fit rounded-md bg-[var(--surface-active)] px-2.5 py-1.5 text-title-medium tracking-wide text-[var(--content-emphasised)]">
+                <code
+                  className={cn(
+                    CODE_CHIP_CLASS,
+                    "w-fit px-2.5 py-1.5 text-title-medium tracking-wide text-[color:var(--content-emphasised)]",
+                  )}
+                >
                   {request.userCode}
                 </code>
                 <div className="flex flex-col gap-0.5">
@@ -87,10 +81,10 @@ export function PendingPairingRequests({
                       ? // Host-originated mint: the requester IP is a loopback
                         // address, so naming this computer is the honest label.
                         t("pendingPairingRequests.requestedMetaHost", {
-                          when: formatRequestedAt(request.requestedAt),
+                          when: formatRelativeAge(request.requestedAt),
                         })
                       : t("pendingPairingRequests.requestedMeta", {
-                          when: formatRequestedAt(request.requestedAt),
+                          when: formatRelativeAge(request.requestedAt),
                           ip: request.requesterIp,
                         })}
                   </p>

--- a/clients/web/src/domains/settings/pair-device/relative-age.ts
+++ b/clients/web/src/domains/settings/pair-device/relative-age.ts
@@ -1,5 +1,8 @@
 import { useEffect, useState } from "react";
 
+import { currentLocale } from "@/i18n";
+import { formatRelativeTime } from "@/lib/relative-time";
+
 /** How often a visible relative age re-renders; 30s suits minute phrasing. */
 const AGE_REFRESH_INTERVAL_MS = 30_000;
 
@@ -23,4 +26,16 @@ export function useRelativeAgeTick(active: boolean): void {
     );
     return () => clearInterval(intervalId);
   }, [active]);
+}
+
+/**
+ * An ISO instant as a relative age in the active locale. Minute granularity is
+ * what {@link useRelativeAgeTick}'s tick can keep honest, so anything fresher
+ * reads as "now" rather than as a second count that goes stale between ticks.
+ */
+export function formatRelativeAge(iso: string): string {
+  return formatRelativeTime(new Date(iso).getTime(), {
+    locale: currentLocale(),
+    minimumUnit: "minute",
+  });
 }

--- a/clients/web/src/domains/settings/pair-device/tunnel-recheck-button.tsx
+++ b/clients/web/src/domains/settings/pair-device/tunnel-recheck-button.tsx
@@ -1,0 +1,54 @@
+import { Button } from "@vellumai/design-library/components/button";
+import { RefreshCw } from "lucide-react";
+
+import { useTranslation } from "@/i18n";
+
+interface TunnelRecheckButtonProps {
+  /** Re-runs the daemon-side probe. This button owns no fetching of its own. */
+  onRefresh: () => void;
+  isRefreshing: boolean;
+  /**
+   * Show the copy beside the icon, for the first-run notice where the button
+   * stands on its own. The status row is already a labelled line, so there the
+   * same copy is the icon's accessible name instead.
+   */
+  labelled?: boolean;
+}
+
+/**
+ * Re-runs the tunnel probe. Two surfaces offer it, the status row and the
+ * first-run notice the row draws nothing for, and the two have to stay one
+ * affordance: same copy, same spinner, same refusal to fire twice at once.
+ */
+export function TunnelRecheckButton({
+  onRefresh,
+  isRefreshing,
+  labelled = false,
+}: TunnelRecheckButtonProps) {
+  const { t } = useTranslation("settings");
+  const label = t("tunnelStatusRow.refreshLabel");
+  const icon = (
+    <RefreshCw className={isRefreshing ? "animate-spin" : undefined} />
+  );
+
+  return labelled ? (
+    <Button
+      variant="outlined"
+      size="compact"
+      leftIcon={icon}
+      disabled={isRefreshing}
+      onClick={onRefresh}
+    >
+      {label}
+    </Button>
+  ) : (
+    <Button
+      variant="ghost"
+      size="compact"
+      iconOnly={icon}
+      aria-label={label}
+      disabled={isRefreshing}
+      onClick={onRefresh}
+    />
+  );
+}

--- a/clients/web/src/domains/settings/pair-device/tunnel-status-row.test.tsx
+++ b/clients/web/src/domains/settings/pair-device/tunnel-status-row.test.tsx
@@ -5,6 +5,7 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import {
   statusPublicBaseUrl,
   TunnelStatusRow,
+  tunnelStartCommand,
   type TunnelStatusView,
 } from "./tunnel-status-row";
 
@@ -196,8 +197,25 @@ describe("TunnelStatusRow", () => {
     );
 
     expect(
-      screen.getByText('vellum tunnel "My Assistant" --provider tailscale'),
+      screen.getByText("vellum tunnel 'My Assistant' --provider tailscale"),
     ).toBeDefined();
+  });
+
+  // Reachable whenever ingress is switched off with no tunnel on record: the
+  // daemon still answered "stopped", so the row reports it rather than
+  // leaving the card to re-advertise an address nothing is serving.
+  test("reports a stopped tunnel the daemon remembers nothing about", () => {
+    renderRow({ kind: "stopped" });
+
+    expect(
+      screen.getByText(
+        "The tunnel is stopped, so other devices cannot reach this assistant.",
+      ),
+    ).toBeDefined();
+    // No provider to name, so no restart command and no address.
+    expect(screen.queryByText(/vellum tunnel/)).toBeNull();
+    expect(screen.queryByText(PUBLIC_URL)).toBeNull();
+    expect(refreshButton().disabled).toBe(false);
   });
 
   test("refreshing calls back to the owner", () => {
@@ -223,6 +241,52 @@ describe("TunnelStatusRow", () => {
     );
 
     expect(refreshButton().disabled).toBe(true);
+  });
+});
+
+// Assistant names are free-form user text and this string is offered for
+// pasting into a terminal, so anything the shell would act on has to be inert.
+describe("tunnelStartCommand", () => {
+  test("leaves a plain name unquoted", () => {
+    expect(tunnelStartCommand("tailscale", "jarvis-2.0_beta")).toBe(
+      "vellum tunnel jarvis-2.0_beta --provider tailscale",
+    );
+  });
+
+  test("neutralizes a command separator", () => {
+    expect(tunnelStartCommand("tailscale", "Bob&Alice")).toBe(
+      "vellum tunnel 'Bob&Alice' --provider tailscale",
+    );
+  });
+
+  test("neutralizes variable expansion", () => {
+    expect(tunnelStartCommand("tailscale", "My $team")).toBe(
+      "vellum tunnel 'My $team' --provider tailscale",
+    );
+  });
+
+  test("neutralizes command substitution", () => {
+    expect(tunnelStartCommand("tailscale", "a`whoami`")).toBe(
+      "vellum tunnel 'a`whoami`' --provider tailscale",
+    );
+  });
+
+  test("closes, escapes and reopens around an embedded single quote", () => {
+    expect(tunnelStartCommand("tailscale", "Bob's box")).toBe(
+      "vellum tunnel 'Bob'\\''s box' --provider tailscale",
+    );
+  });
+
+  test("keeps a name with whitespace one argument", () => {
+    expect(tunnelStartCommand("ngrok", "My Assistant")).toBe(
+      "vellum tunnel 'My Assistant' --provider ngrok",
+    );
+  });
+
+  test("omits the name when none is known", () => {
+    expect(tunnelStartCommand("cloudflare", null)).toBe(
+      "vellum tunnel --provider cloudflare",
+    );
   });
 });
 

--- a/clients/web/src/domains/settings/pair-device/tunnel-status-row.tsx
+++ b/clients/web/src/domains/settings/pair-device/tunnel-status-row.tsx
@@ -1,8 +1,10 @@
-import { Button } from "@vellumai/design-library/components/button";
-import { RefreshCw } from "lucide-react";
+import { cn } from "@vellumai/design-library/utils/cn";
 
-import { currentLocale, Trans, type TFunction, useTranslation } from "@/i18n";
-import { formatRelativeTime } from "@/lib/relative-time";
+import { Trans, type TFunction, useTranslation } from "@/i18n";
+
+import { CODE_CHIP_CLASS } from "./code-chip";
+import { formatRelativeAge } from "./relative-age";
+import { TunnelRecheckButton } from "./tunnel-recheck-button";
 
 /**
  * What the Pair-a-device card knows about the tunnel right now. Local to this
@@ -14,7 +16,13 @@ export type TunnelStatusView =
   | { kind: "unconfigured" }
   /** No verdict to report: the probe never ran, or it gave up. */
   | { kind: "unavailable" }
-  | { kind: "stopped"; provider: string; publicBaseUrl: string }
+  | {
+      kind: "stopped";
+      /** Provider of the tunnel on record, when the daemon remembers one. */
+      provider?: string;
+      /** Address that tunnel served, when the daemon remembers one. */
+      publicBaseUrl?: string;
+    }
   | { kind: "healthy"; publicBaseUrl: string; checkedAt: string }
   | {
       kind: "unreachable";
@@ -71,9 +79,20 @@ export function tunnelStartCommand(
     : `vellum tunnel --provider ${provider}`;
 }
 
-/** Keeps a name with whitespace in it a single shell argument. */
+/** Names that survive a shell verbatim; everything else has to be quoted. */
+const SHELL_SAFE_ARG = /^[A-Za-z0-9._-]+$/;
+
+/**
+ * A free-form assistant name as one shell word. The card offers this command
+ * for pasting into a terminal, so a name is single-quoted unless it is plainly
+ * inert: single quotes are the only ones that also neutralize `$`, backticks
+ * and backslashes, and an embedded one closes the quote, escapes itself, and
+ * reopens.
+ */
 function shellArg(value: string): string {
-  return /\s/.test(value) ? `"${value.replace(/"/g, '\\"')}"` : value;
+  return SHELL_SAFE_ARG.test(value)
+    ? value
+    : `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
 interface TunnelStatusRowProps {
@@ -96,9 +115,6 @@ const DOT_COLOR: Record<RenderedTunnelStatus["kind"], string> = {
 const SUBDUED_CLASS = "text-body-small-default text-[var(--content-tertiary)]";
 const SUBDUED_TRUNCATE_CLASS = `truncate ${SUBDUED_CLASS}`;
 
-const CODE_CLASS =
-  "rounded-md bg-[var(--surface-active)] px-1.5 py-0.5 text-[color:var(--content-primary)]";
-
 /**
  * One compact line reporting whether this assistant's public address is
  * actually serving it: a tone dot, a sentence, the address, when it was last
@@ -110,7 +126,9 @@ const CODE_CLASS =
  * and the tick that keeps the check age current all belong to the card above
  * it, per `docs/EVENT_BUS.md`.
  * Renders nothing for `unconfigured` or `unavailable`: with no tunnel and
- * with no verdict there is nothing to report, and the card speaks instead.
+ * with no verdict there is nothing to report, and the card speaks instead. Its
+ * first-run notice carries the same {@link TunnelRecheckButton} for the state
+ * this row draws nothing for.
  */
 export function TunnelStatusRow({
   status,
@@ -157,7 +175,9 @@ export function TunnelStatusRow({
               }
               ns="settings"
               values={{ command: tunnelStartCommand(provider, assistantName) }}
-              components={{ code: <code className={CODE_CLASS} /> }}
+              components={{
+                code: <code className={cn(CODE_CHIP_CLASS, "px-1.5 py-0.5")} />,
+              }}
             />
           </p>
         )}
@@ -169,26 +189,12 @@ export function TunnelStatusRow({
         {checkedAt && (
           <p className={SUBDUED_CLASS}>
             {t("tunnelStatusRow.checkedAt", {
-              when: formatRelativeTime(new Date(checkedAt).getTime(), {
-                locale: currentLocale(),
-                // The card re-renders this label on a slow tick, so minute
-                // phrasing is what it can keep honest.
-                minimumUnit: "minute",
-              }),
+              when: formatRelativeAge(checkedAt),
             })}
           </p>
         )}
       </div>
-      <Button
-        variant="ghost"
-        size="compact"
-        iconOnly={
-          <RefreshCw className={isRefreshing ? "animate-spin" : undefined} />
-        }
-        aria-label={t("tunnelStatusRow.refreshLabel")}
-        disabled={isRefreshing}
-        onClick={onRefresh}
-      />
+      <TunnelRecheckButton onRefresh={onRefresh} isRefreshing={isRefreshing} />
     </div>
   );
 }

--- a/clients/web/src/domains/settings/pair-device/use-tunnel-status.test.ts
+++ b/clients/web/src/domains/settings/pair-device/use-tunnel-status.test.ts
@@ -111,12 +111,12 @@ describe("toStatusView", () => {
     });
   });
 
-  test("degrades a stopped verdict with no record to unavailable", () => {
-    // A stopped row exists to name the command that restarts the tunnel; with
-    // no provider there is nothing to tell the user, and nothing usable came
-    // back either, so the card keeps its own fallbacks.
+  // Ingress switched off with no tunnel on record. The daemon still answered,
+  // so the verdict stands: degrading it to `unavailable` would send the card
+  // back to the recorded ingress URL this probe exists to replace.
+  test("keeps a stopped verdict with no record a stopped row", () => {
     expect(toStatusView({ state: "stopped" }, false)).toEqual({
-      kind: "unavailable",
+      kind: "stopped",
     });
   });
 

--- a/clients/web/src/domains/settings/pair-device/use-tunnel-status.ts
+++ b/clients/web/src/domains/settings/pair-device/use-tunnel-status.ts
@@ -76,12 +76,12 @@ export function useTunnelStatus(enabled: boolean): TunnelStatusController {
  * a killed tunnel answers as `unreachable`, and the provider on record is
  * what lets the row print the command that starts it again.
  *
- * Only the daemon's own verdict becomes `unconfigured`. Everything the probe
- * cannot answer degrades to `unavailable` instead: no response with nothing
- * in flight (the probe is gated off, or the query exhausted its retries), or
- * a `stopped` verdict whose `lastTunnel` record is missing. The row draws
- * both as nothing, but the card reads `unavailable` as "the probe told us
- * nothing" and keeps its pre-probe fallbacks.
+ * Only an answer the card never got becomes `unavailable`: no response with
+ * nothing in flight, because the probe is gated off or the query exhausted
+ * its retries. Every verdict the daemon does give stands, a `stopped` one
+ * carrying no `lastTunnel` record included, since the card reads
+ * `unavailable` as "the probe told us nothing" and falls back to the recorded
+ * ingress URL this probe exists to replace.
  */
 export function toStatusView(
   response: IntegrationsIngressStatusGetResponse | undefined,
@@ -91,27 +91,24 @@ export function toStatusView(
     return isFetching ? { kind: "checking" } : { kind: "unavailable" };
   }
 
+  const { lastTunnel } = response;
   // Both are set by the daemon for every probed state; the wire marks them
   // optional because the response is one flat object across all five.
   const publicBaseUrl = response.publicBaseUrl ?? "";
   const checkedAt = response.checkedAt ?? "";
   // Spread onto the states that take it optionally, so an absent record stays
   // an absent key rather than an explicit `undefined`.
-  const recordedProvider = response.lastTunnel
-    ? { provider: response.lastTunnel.provider }
-    : {};
+  const recordedProvider = lastTunnel ? { provider: lastTunnel.provider } : {};
 
   switch (response.state) {
     case "unconfigured":
       return { kind: "unconfigured" };
     case "stopped":
-      return response.lastTunnel
-        ? {
-            kind: "stopped",
-            provider: response.lastTunnel.provider,
-            publicBaseUrl: response.lastTunnel.publicBaseUrl,
-          }
-        : { kind: "unavailable" };
+      return {
+        kind: "stopped",
+        ...recordedProvider,
+        ...(lastTunnel ? { publicBaseUrl: lastTunnel.publicBaseUrl } : {}),
+      };
     case "healthy":
       return { kind: "healthy", publicBaseUrl, checkedAt };
     case "unreachable":


### PR DESCRIPTION
## Summary

- The first-run "Open a tunnel first" notice now carries the same re-check the status row does (shared `TunnelRecheckButton`), shown only once the daemon has actually answered. `app.resume` never fires for a terminal beside a browser window, so without it the card sat on the empty state until a full reload.
- A `stopped` verdict with no `lastTunnel` on record stays a stopped row instead of degrading to `unavailable`, so the card no longer falls back to the stale platform `ingress_url` the probe exists to replace.
- The pasted `vellum tunnel <name>` command single-quotes free-form assistant names (`&`, `$`, backticks, embedded quotes), plus small cleanups: one shared relative-age formatter, one shared code-chip class, the shared timer harness in `paired-devices-section.test.tsx`, and the provider literal typed against `TunnelProviderName`.

Fixes re-review gaps for tunnel-status-pairing.md.