### PR TITLE
fix(cli): stop the tailscale path clobbering the webhook callback base

### DIFF
--- a/cli/src/__tests__/client-web-config.test.ts
+++ b/cli/src/__tests__/client-web-config.test.ts
@@ -1,13 +1,14 @@
 /**
  * Tests for the config `vellum client --interface web` serves at
- * `/assistant/__config`. It is the same document the nginx tunnel edge serves,
- * and a caller probes it to learn which assistant an origin fronts, so the two
- * producers must agree on carrying `assistantId`.
+ * `/assistant/__config`, the document a caller probes to learn which assistant
+ * an origin fronts. This host also serves the `__local` endpoints, so its SPA
+ * switches between every assistant in the lockfile and the origin has no single
+ * identity to report: the config must stay free of an `assistantId`, matching
+ * the Vite dev server's local-mode plugin.
  */
 import { describe, expect, test } from "bun:test";
 
 import { buildWebInterfaceConfig } from "../commands/client.js";
-import { DAEMON_INTERNAL_ASSISTANT_ID } from "../lib/constants.js";
 
 const BASE = {
   webUrl: "https://app.example.com",
@@ -16,22 +17,12 @@ const BASE = {
 };
 
 describe("vellum client web __config", () => {
-  test("stamps the assistant the front is bound to", () => {
-    expect(
-      buildWebInterfaceConfig({ ...BASE, assistantId: "assistant-1" }),
-    ).toEqual({ ...BASE, assistantId: "assistant-1" });
-  });
+  test("reports no assistant identity for the multi-assistant origin", () => {
+    const config = buildWebInterfaceConfig(BASE);
 
-  test("omits the daemon-internal placeholder so a probe reads an unknown identity", () => {
-    expect(
-      buildWebInterfaceConfig({
-        ...BASE,
-        assistantId: DAEMON_INTERNAL_ASSISTANT_ID,
-      }),
-    ).toEqual(BASE);
-  });
-
-  test("omits an absent assistant id", () => {
-    expect(buildWebInterfaceConfig(BASE)).toEqual(BASE);
+    expect(config).toEqual(BASE);
+    // A stamped id would be the launch-time one, so a probe for any other
+    // assistant this origin serves would read a false `foreign`.
+    expect(config).not.toHaveProperty("assistantId");
   });
 });

--- a/cli/src/__tests__/ingress-config.test.ts
+++ b/cli/src/__tests__/ingress-config.test.ts
@@ -7,13 +7,12 @@ import { join } from "node:path";
 const testDir = mkdtempSync(join(tmpdir(), "ingress-config-test-"));
 process.env.VELLUM_LOCKFILE_DIR = testDir;
 
-import { parseLastTunnelRecord } from "@vellumai/service-contracts/ingress";
-
 import {
-  clearIngressUrl,
-  saveIngressUrl,
+  parseLastTunnelRecord,
   TUNNEL_PROVIDERS,
-} from "../lib/ingress-config.js";
+} from "@vellumai/service-contracts/ingress";
+
+import { clearIngressUrl, saveIngressUrl } from "../lib/ingress-config.js";
 
 function writeLockfile(entry: Record<string, unknown>): void {
   writeFileSync(

--- a/cli/src/__tests__/tailscale-tunnel.test.ts
+++ b/cli/src/__tests__/tailscale-tunnel.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -12,6 +18,7 @@ import {
   type TailscaleCommandResult,
   type TailscaleDeps,
 } from "../lib/tailscale-tunnel.js";
+import { snapshotEnv } from "./helpers/env.js";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -55,7 +62,34 @@ function makeDeps(opts: {
   return { deps, calls };
 }
 
+/** Point the lockfile at a temp dir holding one entry; returns its path. */
+function useTempLockfile(assistantId: string): string {
+  const lockfileDir = makeWorkspace();
+  process.env.VELLUM_LOCKFILE_DIR = lockfileDir;
+  const lockfilePath = join(lockfileDir, ".vellum.lock.json");
+  writeFileSync(
+    lockfilePath,
+    JSON.stringify({
+      activeAssistant: assistantId,
+      assistants: [
+        { assistantId, runtimeUrl: "http://127.0.0.1:7830", cloud: "local" },
+      ],
+    }),
+  );
+  return lockfilePath;
+}
+
+function readLockfileEntry(lockfilePath: string): Record<string, unknown> {
+  const data = JSON.parse(readFileSync(lockfilePath, "utf-8")) as {
+    assistants: Record<string, unknown>[];
+  };
+  return data.assistants[0];
+}
+
+const restoreEnv = snapshotEnv(["VELLUM_LOCKFILE_DIR"]);
+
 afterEach(() => {
+  restoreEnv();
   for (const dir of tempDirs.splice(0)) {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -169,6 +203,50 @@ describe("startTailscaleServe", () => {
       "https://my-host.tail-scale.ts.net",
     );
     expect(config.ingress.enabled).toBe(true);
+  });
+
+  test("preserveIngressUrl publishes to the lockfile and leaves the ingress record", async () => {
+    const workspaceDir = makeWorkspace();
+    const webhookBase = "https://existing.ngrok.app";
+    writeFileSync(
+      join(workspaceDir, "config.json"),
+      JSON.stringify({
+        ingress: {
+          enabled: true,
+          publicBaseUrl: webhookBase,
+          lastTunnel: { provider: "ngrok", publicBaseUrl: webhookBase },
+        },
+      }),
+    );
+    const lockfilePath = useTempLockfile("ts-1");
+    const { deps } = makeDeps({
+      responses: {
+        "status --json": ok(RUNNING_STATUS),
+        "serve --bg 7840": ok(),
+      },
+    });
+
+    await startTailscaleServe(
+      {
+        port: 7840,
+        workspaceDir,
+        assistantId: "ts-1",
+        preserveIngressUrl: true,
+      },
+      deps,
+    );
+
+    // The webhook callback base and the tunnel it names survive untouched...
+    const config = JSON.parse(
+      readFileSync(join(workspaceDir, "config.json"), "utf-8"),
+    );
+    expect(config.ingress.publicBaseUrl).toBe(webhookBase);
+    expect(config.ingress.lastTunnel.provider).toBe("ngrok");
+    // ...while the tailnet URL lands on the lockfile entry, where pairing
+    // reads its advertised default.
+    expect(readLockfileEntry(lockfilePath).ingressUrl).toBe(
+      "https://my-host.tail-scale.ts.net",
+    );
   });
 
   test("surfaces tailscale's enable-URL guidance when serve is not enabled", async () => {

--- a/cli/src/__tests__/tunnel.test.ts
+++ b/cli/src/__tests__/tunnel.test.ts
@@ -22,12 +22,13 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import { TUNNEL_PROVIDERS } from "@vellumai/service-contracts/ingress";
+
 import * as cloudflareTunnel from "../lib/cloudflare-tunnel.js";
 import * as ngrok from "../lib/ngrok.js";
 import * as nginxIngress from "../lib/nginx-ingress.js";
 import * as tailscaleTunnel from "../lib/tailscale-tunnel.js";
 import type { AssistantEntry } from "../lib/assistant-config.js";
-import { TUNNEL_PROVIDERS } from "../lib/ingress-config.js";
 
 const realCloudflareTunnel = { ...cloudflareTunnel };
 const realNgrok = { ...ngrok };
@@ -681,7 +682,7 @@ describe("tunnel edge targeting", () => {
     expect(runTailscaleTunnelMock).not.toHaveBeenCalled();
   });
 
-  test("an explicit --provider tailscale runs with a warning when webhook integrations are configured", async () => {
+  test("an explicit --provider tailscale keeps the webhook callback base and says so", async () => {
     const entry = makeLocalEntry();
     writeLockfile(entry);
     const workspaceDir = writeEntryWorkspaceConfig(entry, {
@@ -701,9 +702,27 @@ describe("tunnel edge targeting", () => {
       warnSpy.mockRestore();
     }
 
-    expect(warnings.join("\n")).toContain(
-      "reachable only from your own tailnet",
-    );
+    const warned = warnings.join("\n");
+    expect(warned).toContain("reachable only from your own tailnet");
+    expect(warned).toContain("saved ingress base URL stays as it is");
+    // The tunnel publishes a pairing address instead of replacing the URL the
+    // webhook callbacks resolve through.
+    expect(runTailscaleTunnelMock).toHaveBeenCalledWith({
+      port: EDGE_PORT,
+      assistantId: "assistant-1",
+      workspaceDir,
+      preserveIngressUrl: true,
+    });
+  });
+
+  test("tailscale without webhook integrations still owns the ingress URL", async () => {
+    const entry = makeLocalEntry();
+    writeLockfile(entry);
+    const workspaceDir = writeEntryWorkspaceConfig(entry, {});
+    process.argv = ["bun", "vellum", "tunnel", "--provider", "tailscale"];
+
+    await runTunnelCapturingLogs();
+
     expect(runTailscaleTunnelMock).toHaveBeenCalledWith({
       port: EDGE_PORT,
       assistantId: "assistant-1",

--- a/cli/src/commands/client.ts
+++ b/cli/src/commands/client.ts
@@ -1211,24 +1211,22 @@ async function spawnBackgroundWebInterface(
 /**
  * Config the local web host injects as `window.__VELLUM_CONFIG__` and serves at
  * `/assistant/__config`, the document a caller probes to learn which assistant
- * an origin fronts. `assistantId` is omitted when only the daemon-internal
- * placeholder is known, so the probe reads an unknown identity rather than a
- * mismatch (same contract as the nginx edge's served config).
+ * an origin fronts.
+ *
+ * It carries no `assistantId`: this host also serves `handleLocalEndpoints`, so
+ * the SPA on it switches between every assistant in the lockfile, exactly like
+ * the Vite dev server (`clients/web/vite-plugin-local-mode.ts`, which omits the
+ * id for the same reason). An id here would be the launch-time one, and a probe
+ * for any other assistant this origin serves would read it as a mismatch and
+ * report a false `foreign`. An absent id is deliberately benign to the probe.
  */
 export function buildWebInterfaceConfig(opts: {
   webUrl: string;
   platformUrl: string;
   disablePlatform: boolean;
-  assistantId?: string;
 }): Record<string, unknown> {
-  const { webUrl, platformUrl, disablePlatform, assistantId } = opts;
-  const named = assistantId && assistantId !== DAEMON_INTERNAL_ASSISTANT_ID;
-  return {
-    webUrl,
-    platformUrl,
-    disablePlatform,
-    ...(named ? { assistantId } : {}),
-  };
+  const { webUrl, platformUrl, disablePlatform } = opts;
+  return { webUrl, platformUrl, disablePlatform };
 }
 
 async function runWebInterface(
@@ -1237,7 +1235,6 @@ async function runWebInterface(
   disablePlatform: boolean,
   openInBrowser: boolean,
   webPort: number | undefined,
-  assistantId: string,
 ): Promise<void> {
   // Propagate flag env vars so child processes (e.g. hatch from the web UI) inherit them.
   Object.assign(process.env, flagEnvVars);
@@ -1272,12 +1269,7 @@ async function runWebInterface(
   const safeJson = (v: unknown) =>
     JSON.stringify(v).replace(/</g, "\\u003c").replace(/>/g, "\\u003e");
   const configJson = safeJson(
-    buildWebInterfaceConfig({
-      webUrl,
-      platformUrl,
-      disablePlatform,
-      assistantId,
-    }),
+    buildWebInterfaceConfig({ webUrl, platformUrl, disablePlatform }),
   );
   const hasOverrides = Object.keys(parsedFlagOverrides).length > 0;
   const flagOverridesSnippet = hasOverrides
@@ -1575,7 +1567,6 @@ export async function client(): Promise<void> {
       disablePlatform,
       openInBrowser,
       webPort,
-      assistantId,
     );
     return;
   }

--- a/cli/src/commands/tunnel.ts
+++ b/cli/src/commands/tunnel.ts
@@ -1,5 +1,7 @@
 import { join } from "path";
 
+import { TUNNEL_PROVIDERS } from "@vellumai/service-contracts/ingress";
+
 import {
   formatAssistantReference,
   loadAllAssistants,
@@ -10,16 +12,14 @@ import { parseAssistantTargetArg } from "../lib/assistant-target-args.js";
 import { runCloudflareTunnel } from "../lib/cloudflare-tunnel.js";
 import {
   getDefaultWorkspaceDir,
-  loadRawConfig,
   saveNgrokDomain,
-  TUNNEL_PROVIDERS,
 } from "../lib/ingress-config.js";
 import {
   ensureTunnelEdge,
   formatEdgeMode,
   type TunnelEdge,
 } from "../lib/nginx-ingress.js";
-import { hasWebhookIntegrations, runNgrokTunnel } from "../lib/ngrok";
+import { hasWebhookIntegrationsConfigured, runNgrokTunnel } from "../lib/ngrok";
 import { STALE_CLI_UPDATE_HINT } from "../lib/stale-cli-hint.js";
 import { runTailscaleTunnel } from "../lib/tailscale-tunnel.js";
 import { parseGatewayPortFromEntryUrls } from "./nginx-ingress.js";
@@ -120,8 +120,12 @@ function parseArgs(): TunnelArgs {
         "               Reachable only from your own tailnet (private; LetsEncrypt cert).",
       );
       console.log(
-        "               Must be named explicitly when webhook integrations are configured.",
+        "               Must be named explicitly when webhook integrations are configured,",
       );
+      console.log(
+        "               and then records its URL for device pairing only, leaving the saved",
+      );
+      console.log("               webhook callback base as it is.");
       console.log("");
       console.log("Examples:");
       console.log("  $ vellum tunnel --provider ngrok");
@@ -287,42 +291,39 @@ function resolveLocalTunnelTarget(
   process.exit(1);
 }
 
-/** Whether the workspace declares webhook integrations; false when unreadable. */
-function hasWebhookIntegrationsConfigured(workspaceDir: string): boolean {
-  try {
-    return hasWebhookIntegrations(loadRawConfig(workspaceDir));
-  } catch {
-    return false;
-  }
-}
-
 /**
- * Gate the tailnet-only tailscale tunnel behind an explicit `--provider` when
- * webhook integrations are configured. Its URL becomes the webhook callback
- * base, so falling into it would repoint those callbacks at an address
- * external services cannot resolve and would suppress the ngrok auto-tunnel on
- * every later wake (a non-ngrok ingress URL reads as ingress already handled).
- * An explicit choice is honored, with the same consequence spelled out.
+ * Decide how the tailnet-only tailscale tunnel may treat the saved ingress base
+ * URL, which is also the webhook callback base. Returns true when the run must
+ * leave that URL in place and record the tailnet address for pairing only.
+ *
+ * A tailnet address in the callback base would repoint those callbacks at
+ * something external services cannot resolve, so no run replaces it while
+ * webhook integrations are configured. Falling into the tunnel by default is
+ * refused outright, since the tunnel cannot carry those callbacks either; an
+ * explicit choice is honored, with what it does and does not record spelled
+ * out.
  */
 function guardTailnetOnlyWebhookIngress(
   workspaceDir: string,
   providerExplicit: boolean,
-): void {
+): boolean {
   if (!hasWebhookIntegrationsConfigured(workspaceDir)) {
-    return;
+    return false;
   }
   if (providerExplicit) {
     console.warn(
-      "⚠ Webhook integrations are configured, and the tailscale tunnel is reachable only from your own tailnet. " +
-        "Saving its URL as the ingress base URL leaves them without a reachable callback address.",
+      "⚠ Webhook integrations are configured, and the tailscale tunnel is reachable only from your own tailnet, " +
+        "so it cannot serve their callbacks. The saved ingress base URL stays as it is and the tailnet URL is " +
+        "recorded for device pairing only. For a tunnel those integrations can reach too, use --provider ngrok " +
+        "or --provider cloudflare.",
     );
-    return;
+    return true;
   }
   console.error(
     "Error: webhook integrations are configured, and the default tailscale tunnel is reachable only from your own tailnet.",
   );
   console.error(
-    "Starting it would replace the saved ingress base URL, which is also the webhook callback base, with a tailnet address.",
+    "It cannot serve their callbacks, so falling into it by default would leave them without working ingress.",
   );
   console.error("");
   console.error("Run one of:");
@@ -333,7 +334,7 @@ function guardTailnetOnlyWebhookIngress(
     "  vellum tunnel --provider cloudflare   Public tunnel that webhook integrations can reach",
   );
   console.error(
-    "  vellum tunnel --provider tailscale    Accept the tailnet-only tunnel",
+    "  vellum tunnel --provider tailscale    Tailnet-only tunnel for pairing; leaves the callback base alone",
   );
   process.exit(1);
 }
@@ -352,9 +353,9 @@ export async function tunnel(): Promise<void> {
   const { entry, gatewayPort, workspaceDir } =
     resolveLocalTunnelTarget(assistantName);
 
-  if (provider === "tailscale") {
+  const preserveIngressUrl =
+    provider === "tailscale" &&
     guardTailnetOnlyWebhookIngress(workspaceDir, providerExplicit);
-  }
 
   if (clearDomain) {
     saveNgrokDomain(workspaceDir, null);
@@ -397,5 +398,8 @@ export async function tunnel(): Promise<void> {
     return;
   }
 
-  await runTailscaleTunnel(baseTunnelOpts);
+  await runTailscaleTunnel({
+    ...baseTunnelOpts,
+    ...(preserveIngressUrl ? { preserveIngressUrl } : {}),
+  });
 }

--- a/cli/src/lib/ingress-config.ts
+++ b/cli/src/lib/ingress-config.ts
@@ -6,7 +6,6 @@ import {
   INGRESS_ASSISTANT_ID_KEY,
   INGRESS_LAST_TUNNEL_KEY,
   type LastTunnelRecord,
-  TUNNEL_PROVIDERS,
   type TunnelProviderName,
 } from "@vellumai/service-contracts/ingress";
 
@@ -25,10 +24,6 @@ import {
  * that CLI features (e.g. remote-web pairing defaults) read, per the
  * no-`.vellum/`-reads boundary in cli/AGENTS.md.
  */
-
-// The tunnel-record contract (provider registry, record shape, key names) is
-// shared with the daemon, which reads what this module writes.
-export { TUNNEL_PROVIDERS, type TunnelProviderName };
 
 /** Default workspace dir: `$VELLUM_WORKSPACE_DIR` or `~/.vellum/workspace`. */
 export function getDefaultWorkspaceDir(): string {
@@ -52,14 +47,6 @@ export function loadRawConfig(workspaceDir: string): Record<string, unknown> {
   >;
 }
 
-function loadIngressSection(
-  workspaceDir: string,
-): Record<string, unknown> | undefined {
-  return loadRawConfig(workspaceDir).ingress as
-    | Record<string, unknown>
-    | undefined;
-}
-
 /** Write the workspace `config.json`, creating parent directories as needed. */
 export function saveRawConfig(
   workspaceDir: string,
@@ -70,8 +57,12 @@ export function saveRawConfig(
   writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
 }
 
-/** Mirror the ingress URL onto the lockfile entry; null removes it. */
-function stampLockfileIngressUrl(
+/**
+ * Mirror the ingress URL onto the lockfile entry; null removes it. Exported on
+ * its own for tunnels that publish an address to pair against while leaving the
+ * workspace `ingress` record (the webhook callback base) alone.
+ */
+export function stampLockfileIngressUrl(
   assistantId: string,
   publicUrl: string | null,
 ): void {
@@ -139,9 +130,10 @@ export function saveNgrokDomain(
 
 /** Read the reserved ngrok domain from the workspace config, if saved. */
 export function loadNgrokDomain(workspaceDir: string): string | null {
-  const ngrok = loadIngressSection(workspaceDir)?.ngrok as
+  const ingress = loadRawConfig(workspaceDir).ingress as
     | Record<string, unknown>
     | undefined;
+  const ngrok = ingress?.ngrok as Record<string, unknown> | undefined;
   const domain = ngrok?.domain;
   return typeof domain === "string" && domain.trim() ? domain : null;
 }

--- a/cli/src/lib/ngrok.ts
+++ b/cli/src/lib/ngrok.ts
@@ -203,10 +203,13 @@ export function hasWebhookIntegrations(
 }
 
 /**
- * Check whether any webhook-based integrations (e.g. Telegram, Twilio) are
- * configured that require a public ingress URL.
+ * Check whether the workspace at `workspaceDir` configures any webhook-based
+ * integrations that require a public ingress URL. False when the config cannot
+ * be read, so an unreadable workspace never blocks a caller.
  */
-function hasWebhookIntegrationsConfigured(workspaceDir: string): boolean {
+export function hasWebhookIntegrationsConfigured(
+  workspaceDir: string,
+): boolean {
   try {
     return hasWebhookIntegrations(loadRawConfig(workspaceDir));
   } catch {

--- a/cli/src/lib/tailscale-tunnel.ts
+++ b/cli/src/lib/tailscale-tunnel.ts
@@ -5,6 +5,7 @@ import {
   clearIngressUrl,
   getDefaultWorkspaceDir,
   saveIngressUrl,
+  stampLockfileIngressUrl,
 } from "./ingress-config.js";
 
 // ── Tailscale CLI discovery + invocation ────────────────────────────────────
@@ -166,6 +167,46 @@ export interface RunTailscaleTunnelOptions {
   workspaceDir?: string;
   /** Lockfile entry to mirror the ingress URL onto (`ingressUrl`). */
   assistantId?: string;
+  /**
+   * Publish the tailnet URL to the lockfile entry only, leaving the workspace
+   * `ingress` record untouched. Set when the saved public base URL is a live
+   * webhook callback base: those callbacks must keep resolving to an address
+   * their callers can reach while devices pair over the tailnet.
+   */
+  preserveIngressUrl?: boolean;
+}
+
+/**
+ * Record the serve URL as the address to reach this assistant at: the workspace
+ * ingress base URL plus the lockfile mirror, or the lockfile alone when the
+ * workspace record must be preserved.
+ */
+function publishServeUrl(
+  opts: RunTailscaleTunnelOptions,
+  workspaceDir: string,
+  publicUrl: string,
+): void {
+  if (!opts.preserveIngressUrl) {
+    saveIngressUrl(workspaceDir, publicUrl, opts.assistantId, "tailscale");
+    return;
+  }
+  if (opts.assistantId) {
+    stampLockfileIngressUrl(opts.assistantId, publicUrl);
+  }
+}
+
+/** Drop what {@link publishServeUrl} recorded, from the same places. */
+function retractServeUrl(
+  opts: RunTailscaleTunnelOptions,
+  workspaceDir: string,
+): void {
+  if (!opts.preserveIngressUrl) {
+    clearIngressUrl(workspaceDir, opts.assistantId);
+    return;
+  }
+  if (opts.assistantId) {
+    stampLockfileIngressUrl(opts.assistantId, null);
+  }
 }
 
 export interface TailscaleServeInfo {
@@ -177,7 +218,8 @@ export interface TailscaleServeInfo {
 
 /**
  * Preflight tailscale, front the local edge with `tailscale serve --bg`, and
- * persist the resulting tailnet URL as the ingress base URL.
+ * persist the resulting tailnet URL (as the ingress base URL, or as the
+ * lockfile pairing address alone under `preserveIngressUrl`).
  *
  * `serve --bg` registers the mapping in tailscaled and returns immediately;
  * there is no long-lived child process to supervise. Throws on any failure
@@ -213,7 +255,7 @@ export async function startTailscaleServe(
     throw new Error(serveFailureMessage(serveResult));
   }
 
-  saveIngressUrl(workspaceDir, publicUrl, opts.assistantId, "tailscale");
+  publishServeUrl(opts, workspaceDir, publicUrl);
 
   return { publicUrl, port, binary, workspaceDir };
 }
@@ -232,15 +274,19 @@ export function stopTailscaleServe(
 /**
  * Run the tailscale tunnel workflow: preflight, serve the local edge over the
  * tailnet, persist the URL, then hold until Ctrl+C to tear the serve down and
- * clear the ingress URL.
+ * drop what was persisted.
  *
  * The tailnet URL carries a real LetsEncrypt certificate but is reachable only
- * from devices signed in to the same tailnet — no public exposure.
+ * from devices signed in to the same tailnet: no public exposure.
  */
 export async function runTailscaleTunnel(
   opts: RunTailscaleTunnelOptions = {},
 ): Promise<void> {
   const deps = realTailscaleDeps();
+  // What this run publishes, and therefore what Ctrl+C takes back.
+  const publishedLabel = opts.preserveIngressUrl
+    ? "pairing address"
+    : "ingress URL";
 
   console.log("Setting up tailscale serve...");
   const { publicUrl, port, binary, workspaceDir } = await startTailscaleServe(
@@ -252,7 +298,11 @@ export async function runTailscaleTunnel(
   console.log(`Tunnel established: ${publicUrl}`);
   console.log(`Serving:            localhost:${port}`);
   console.log("");
-  console.log("Ingress URL saved to config.");
+  console.log(
+    opts.preserveIngressUrl
+      ? "Recorded as this assistant's pairing address. The saved ingress base URL, which is also the webhook callback base, is left as it was."
+      : "Ingress URL saved to config.",
+  );
   console.log(
     "This URL is reachable only from devices signed in to your tailnet.",
   );
@@ -264,12 +314,14 @@ export async function runTailscaleTunnel(
     "The serve runs in the background (tailscaled) and persists after this",
   );
   console.log(
-    "command exits. Press Ctrl+C to stop serving and clear the ingress URL,",
+    `command exits. Press Ctrl+C to stop serving and clear the ${publishedLabel},`,
   );
   console.log("or stop it later with: tailscale serve --https=443 off");
 
   const teardown = (): void => {
-    console.log("\nStopping tailscale serve and clearing the ingress URL...");
+    console.log(
+      `\nStopping tailscale serve and clearing the ${publishedLabel}...`,
+    );
     let result: TailscaleCommandResult | null = null;
     try {
       result = stopTailscaleServe(binary, deps);
@@ -289,10 +341,10 @@ export async function runTailscaleTunnel(
       );
     }
     if (shouldClearIngressUrl(result)) {
-      clearIngressUrl(workspaceDir, opts.assistantId);
+      retractServeUrl(opts, workspaceDir);
     } else {
       console.error(
-        "Keeping the saved ingress URL since serve may still be active. " +
+        `Keeping the saved ${publishedLabel} since serve may still be active. ` +
           "After stopping serve manually, clear it with another Ctrl+C run " +
           "or by re-running the tunnel command.",
       );

--- a/docs/self-hosted-phone.md
+++ b/docs/self-hosted-phone.md
@@ -112,7 +112,10 @@ vellum tunnel --provider tailscale
 ```
 
 `tailscale` is the default provider, so a bare `vellum tunnel` does the same
-thing. `vellum tunnel --help` lists the other providers and options.
+thing, unless a webhook integration (a phone number, a chat channel) is
+already configured: a tailnet-only front cannot carry its callbacks, so the
+bare command asks you to name a provider explicitly rather than let you fall
+into one. `vellum tunnel --help` lists the other providers and options.
 
 `vellum tunnel` manages the nginx edge for you: it starts the edge on
 `http://127.0.0.1:7840` (or reuses one already running) and fronts it, so a
@@ -132,8 +135,11 @@ The tunnel records the public URL in your workspace config
 (`ingress.publicBaseUrl`). A `ts.net` address is reachable only from inside
 your own tailnet, so channel integrations that call in from the public
 internet (Telegram, Twilio, …) need one of the public providers below
-instead: `--provider ngrok` or `--provider cloudflare`. The tunnel prints the
-address it established:
+instead: `--provider ngrok` or `--provider cloudflare`. With one of those
+integrations already configured, an explicit `--provider tailscale` leaves
+`ingress.publicBaseUrl` as it is and records the tailnet address for device
+pairing only, so inbound calls and messages keep reaching the public URL you
+set up for them. The tunnel prints the address it established:
 
 ```
 Tunnel established: https://your-machine.your-tailnet.ts.net
@@ -164,10 +170,11 @@ tailscale serve status   # prints your https://<host>.<tailnet>.ts.net URL
 ```
 
 That URL fronts the nginx edge over your tailnet with automatic HTTPS. Use it
-as the `--url` value in [Step 4](#4-pair-your-devices). To let channel
-integrations use it as well, run `vellum tunnel --provider tailscale` instead,
-which manages the edge itself and also writes the URL to
-`ingress.publicBaseUrl`.
+as the `--url` value in [Step 4](#4-pair-your-devices). To skip that step, run
+`vellum tunnel --provider tailscale` instead: it manages the edge itself and
+saves the address for pairing to reuse (as `ingress.publicBaseUrl`, or, when a
+webhook integration is configured, on its own so that integration's public
+callback URL stays put).
 
 </details>
 


### PR DESCRIPTION
## Summary

- `vellum tunnel --provider tailscale` no longer overwrites `ingress.publicBaseUrl` when webhook integrations are configured: it records the tailnet URL on the lockfile entry (the pairing address `vellum pair` and the Pair-a-device card read) and leaves the webhook callback base, and its teardown, untouched. The warning now says exactly that, and the bare-invocation error explains the real problem (a tailnet front cannot carry those callbacks) instead of a clobber that no longer happens.
- `vellum client --interface web` stops stamping a launch-time `assistantId` into the served `__config`: that host also serves `handleLocalEndpoints`, so its SPA switches assistants like the Vite dev server does, and a stamped id made the daemon's probe report a false `foreign` for an origin that does serve the assistant.
- Collapses the duplicated `hasWebhookIntegrationsConfigured` onto the existing `lib/ngrok` export, drops the `TUNNEL_PROVIDERS` pass-through re-export so the CLI imports the contract from one path, inlines the one-caller `loadIngressSection`, and refreshes the self-hosted phone doc to match the guard's actual behavior.

Fixes re-review gaps for tunnel-status-pairing.md.