### PR TITLE
feat(skills): add vellum-client-capabilities grounding skill

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -1045,7 +1045,7 @@
     {
       "id": "vellum-client-capabilities",
       "name": "vellum-client-capabilities",
-      "description": "Truthful answers about what the Vellum client apps can and cannot do on the user's device. Device location and GPS are unavailable in every client, no OS permission prompt can be shown, and location requests are answered by asking for a typed city or address instead.",
+      "description": "Truthful answers about what the Vellum client apps can and cannot do on the user's device. Device location and GPS are unavailable in every client and there is no location permission prompt to approve, so location requests are answered by asking for a typed city or address instead.",
       "metadata": {
         "emoji": "📍",
         "vellum": {
@@ -1061,7 +1061,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-08-21T18:25:39.000Z"
+      "updatedAt": "2026-08-21T19:07:59.000Z"
     },
     {
       "id": "vellum-conversation-management",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -761,7 +761,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-08-21T15:31:03.000Z"
+      "updatedAt": "2026-08-21T15:44:11.000Z"
     },
     {
       "id": "public-ingress",
@@ -1041,6 +1041,27 @@
       },
       "compatibility": "Designed for Vellum personal assistants",
       "updatedAt": "2026-07-07T20:33:02.000Z"
+    },
+    {
+      "id": "vellum-client-capabilities",
+      "name": "vellum-client-capabilities",
+      "description": "Truthful answers about what the Vellum client apps can and cannot do on the user's device. Device location and GPS are unavailable in every client, no OS permission prompt can be shown, and location requests are answered by asking for a typed city or address instead.",
+      "metadata": {
+        "emoji": "📍",
+        "vellum": {
+          "category": "system",
+          "display-name": "Vellum Client Capabilities",
+          "activation-hints": [
+            "asked to use the user's current location, GPS, or device position",
+            "whether the app can access a device sensor, permission, or hardware feature"
+          ],
+          "avoid-when": [
+            "the user already gave a location as text (just use it)"
+          ]
+        }
+      },
+      "compatibility": "Designed for Vellum personal assistants",
+      "updatedAt": "2026-08-21T18:25:39.000Z"
     },
     {
       "id": "vellum-conversation-management",

--- a/skills/vellum-client-capabilities/SKILL.md
+++ b/skills/vellum-client-capabilities/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vellum-client-capabilities
-description: Truthful answers about what the Vellum client apps can and cannot do on the user's device. Device location and GPS are unavailable in every client, no OS permission prompt can be shown, and location requests are answered by asking for a typed city or address instead.
+description: Truthful answers about what the Vellum client apps can and cannot do on the user's device. Device location and GPS are unavailable in every client and there is no location permission prompt to approve, so location requests are answered by asking for a typed city or address instead.
 compatibility: "Designed for Vellum personal assistants"
 metadata:
   emoji: "📍"
@@ -16,7 +16,7 @@ metadata:
 
 ## Critical Rule
 
-Never claim that a permission prompt, sheet, dialog, or button is on the user's screen unless a tool result in this conversation actually presented one. The Vellum clients never show OS permission prompts on their own, and pointing the user at UI that is not there strands them mid-task with no way to comply.
+Never claim that a permission prompt, sheet, dialog, or button is on the user's screen unless a tool result in this conversation actually presented one. Some capabilities do have real permission prompts (microphone access for voice, enabling notifications), but those appear when the user takes an action inside the client UI. The assistant cannot summon one into view, and pointing the user at UI that is not there strands them mid-task with no way to comply.
 
 ## Device Location
 

--- a/skills/vellum-client-capabilities/SKILL.md
+++ b/skills/vellum-client-capabilities/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: vellum-client-capabilities
+description: Truthful answers about what the Vellum client apps can and cannot do on the user's device. Device location and GPS are unavailable in every client, no OS permission prompt can be shown, and location requests are answered by asking for a typed city or address instead.
+compatibility: "Designed for Vellum personal assistants"
+metadata:
+  emoji: "📍"
+  vellum:
+    category: "system"
+    display-name: "Vellum Client Capabilities"
+    activation-hints:
+      - "asked to use the user's current location, GPS, or device position"
+      - "whether the app can access a device sensor, permission, or hardware feature"
+    avoid-when:
+      - "the user already gave a location as text (just use it)"
+---
+
+## Critical Rule
+
+Never claim that a permission prompt, sheet, dialog, or button is on the user's screen unless a tool result in this conversation actually presented one. The Vellum clients never show OS permission prompts on their own, and pointing the user at UI that is not there strands them mid-task with no way to comply.
+
+## Device Location
+
+No Vellum client can read the device's location. Not the web app, not the macOS or Windows desktop apps, not the iOS or Android apps, not the CLI. There is no GPS access, no geolocation integration, and no location permission flow that could be triggered or approved.
+
+When the user asks you to use their current, live, or nearby location:
+
+1. Say plainly that you cannot access device location.
+2. Ask them to type a city, address, or place name instead. Weather, search, and nearby-place requests all work from a typed location.
+3. Continue the task with what they give you.
+
+Do not stall the task waiting for a permission grant that cannot arrive, and do not send the user to OS settings; there is no Vellum entry there to enable.
+
+### The one coarse signal that exists
+
+Settings has a "Closest city" field used for timezone. If it is set, you may offer it as a rough default region, but present it as the configured city rather than the user's detected location, and let them correct it.
+
+### If the user asks for real location support
+
+It does not exist today in any client. The honest answer is that they can mention a place per request, or set Closest city in Settings as a standing default.
+
+## Other Device Capabilities
+
+If you are unsure whether a client can do something on the device (camera, contacts, sensors, background audio, and so on), check a source of truth such as the product docs before answering, or say you are unsure. Never assume a capability exists because typical mobile apps have it, and never describe UI for it that you have not seen presented.


### PR DESCRIPTION
## Why

[JARVIS-1591](https://linear.app/vellum/issue/JARVIS-1591/assistant-invents-a-location-access-allow-button-that-does-not-exist): a user asked the assistant to use their live location and it replied "Location access is in front of you now. Tap **Allow**" when no location capability exists anywhere in the product. No client ships a geolocation plugin, there is no permission flow, and the only location signal the assistant holds is the "Closest city" timezone setting. The model fabricated the permission UI from generic mobile-app priors, and the turn ended pointing the user at a button that was never coming.

## What

A new first-party skill, `skills/vellum-client-capabilities`, that grounds the assistant on what the client apps can and cannot do on the user's device:

- **Critical rule targeting the exact failure:** never claim a permission prompt, sheet, or button is on screen unless a tool result actually presented one.
- **Device location:** no client (web, macOS, Windows, iOS, Android, CLI) can read device position and there is no permission flow to trigger. The assistant should say so plainly, ask for a typed city or address (which is all the weather and search skills take), and continue the task rather than stalling or sending the user to OS settings.
- **"Closest city" setting:** may be offered as a configured default region, never presented as detected location.
- **Other device capabilities:** check a source of truth or admit uncertainty; never assume a capability exists because typical mobile apps have it.

Placement rationale: system-prompt minimalism rules this out of the prompt, and `vellum-self-knowledge`'s contract is zero static information (pointers only), so a hard "this capability does not exist" fact gets its own small skill. The activation hints ("asked to use the user's current location, GPS, or device position" first, so it survives hint truncation) surface it through the per-turn selector at exactly the moment of a location request, and because skills load daemon-side this covers web, desktop, and mobile in one shot.

The skill is structured so [JARVIS-1565](https://linear.app/vellum/issue/JARVIS-1565/give-the-assistant-real-answers-about-installing-the-desktop-and)'s client-surfaces/install matrix can land in the same home later.

The catalog regeneration commit also picks up timestamp drift from #41002, which touched `skills/plugin-builder` without regenerating.

## Not in scope

Real geolocation support (Capacitor plugin + permission flow + daemon representation) stays a separate product decision per the ticket. If it ever ships, this skill's text updates to point at the real flow.

## Verification

- `node scripts/skills/lint-skill-spec.mjs` - 74 skills conform
- `node scripts/skills/lint-skill-imports.mjs` - no violations
- `node scripts/skills/check-catalog.mjs` - catalog up to date post-commit (the skill is committed before the catalog regeneration so `updatedAt`, which comes from git history, is stable)
- Behavioral QA outstanding: on a dev build, ask "use my live location to find the nearest Home Depot" and confirm the reply states the limitation and asks for a typed location. If the selector misses the skill, the escalation path is pinning it as an always-candidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)