### PR TITLE
fix(web): stop telling a gateway-auth guardian their login failed

### DIFF
--- a/clients/web/src/domains/chat/hooks/use-conversation-loader-resume-grace.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-conversation-loader-resume-grace.test.tsx
@@ -55,13 +55,17 @@ mock.module("@/lib/sentry/capture-error", () => ({
   captureError: () => {},
 }));
 
-// Which auth mode the session is in decides whether a 401 means "your login
-// failed" at all. Stubbed so each case states its own mode rather than
-// inheriting whatever the ambient config resolves to.
+// Whether the session authenticates through a gateway decides whether a 401
+// means "your login failed" at all. Both predicates are stubbed: the real
+// `isGatewayAuthMode` reads the gateway token, which the guardian-repair
+// handoff clears before the 401 lands, so a case can hold them apart to model
+// that ordering.
+let gatewayAuthEnabled = false;
 let gatewayAuthMode = false;
 mock.module(
   "@/lib/auth/gateway-session",
   (): Partial<typeof GatewaySession> => ({
+    isGatewayAuthEnabled: () => gatewayAuthEnabled,
     isGatewayAuthMode: () => gatewayAuthMode,
   }),
 );
@@ -106,6 +110,7 @@ beforeEach(() => {
   __setResumeGraceMsForTesting(DEFAULT_RESUME_GRACE_MS);
   listError = null;
   toastErrorMock = mock((_message: string) => {});
+  gatewayAuthEnabled = false;
   gatewayAuthMode = false;
   useChatSessionStore.getState().setError(null);
 });
@@ -196,6 +201,7 @@ describe("useConversationLoader resume grace on list-load errors", () => {
      */
 
     // GIVEN a local session authenticated through the gateway
+    gatewayAuthEnabled = true;
     gatewayAuthMode = true;
     const { rerender } = renderLoader();
 
@@ -204,6 +210,29 @@ describe("useConversationLoader resume grace on list-load errors", () => {
     rerender();
 
     // THEN nothing claims the user failed to authenticate
+    expect(toastErrorMock).not.toHaveBeenCalled();
+  });
+
+  test("stays quiet when the repair handoff cleared the token before the 401", () => {
+    /**
+     * The guardian-repair handoff calls `clearGatewayToken()` and only then
+     * returns the 401 to the caller, so by the time this effect runs
+     * `isGatewayAuthMode()` reads false: it bottoms out at
+     * `getGatewayToken() !== null`. Classifying on that would call the repair
+     * path a platform session and toast on it, which is the one path this
+     * suppression exists for.
+     */
+
+    // GIVEN a gateway session whose token the handoff has already cleared
+    gatewayAuthEnabled = true;
+    gatewayAuthMode = false;
+    const { rerender } = renderLoader();
+
+    // WHEN the 401 that triggered the handoff reaches the loader
+    listError = new ApiError(401, "unauthorized");
+    rerender();
+
+    // THEN it is still recognised as a gateway session, and says nothing
     expect(toastErrorMock).not.toHaveBeenCalled();
   });
 });

--- a/clients/web/src/domains/chat/hooks/use-conversation-loader-resume-grace.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-conversation-loader-resume-grace.test.tsx
@@ -7,6 +7,7 @@ import { __setResumeGraceMsForTesting } from "@/hooks/use-resume-grace";
 import { __resetForTesting, publish } from "@/lib/event-bus";
 import { useChatSessionStore } from "@/domains/chat/chat-session-store";
 import { ApiError } from "@/utils/api-errors";
+import type * as GatewaySession from "@/lib/auth/gateway-session";
 
 const CONVERSATION_LIST_LOAD_FAILED_CODE = "CONVERSATION_LIST_LOAD_FAILED";
 const DEFAULT_RESUME_GRACE_MS = 15_000;
@@ -54,6 +55,17 @@ mock.module("@/lib/sentry/capture-error", () => ({
   captureError: () => {},
 }));
 
+// Which auth mode the session is in decides whether a 401 means "your login
+// failed" at all. Stubbed so each case states its own mode rather than
+// inheriting whatever the ambient config resolves to.
+let gatewayAuthMode = false;
+mock.module(
+  "@/lib/auth/gateway-session",
+  (): Partial<typeof GatewaySession> => ({
+    isGatewayAuthMode: () => gatewayAuthMode,
+  }),
+);
+
 const { useConversationLoader } =
   await import("@/domains/chat/hooks/use-conversation-loader");
 
@@ -94,6 +106,7 @@ beforeEach(() => {
   __setResumeGraceMsForTesting(DEFAULT_RESUME_GRACE_MS);
   listError = null;
   toastErrorMock = mock((_message: string) => {});
+  gatewayAuthMode = false;
   useChatSessionStore.getState().setError(null);
 });
 
@@ -154,10 +167,11 @@ describe("useConversationLoader resume grace on list-load errors", () => {
     expect(currentErrorCode()).toBe(CONVERSATION_LIST_LOAD_FAILED_CODE);
   });
 
-  // A 401 is never transient: the session is gone and the user has to
-  // re-authenticate, so the toast fires regardless of the grace window.
+  // On a platform session a 401 is never transient: the session is gone and
+  // the user has to re-authenticate, so the toast fires regardless of the
+  // grace window.
   test("still toasts an auth failure inside the resume grace window", () => {
-    // GIVEN a mounted loader that just resumed from the background
+    // GIVEN a platform session that just resumed from the background
     const { rerender } = renderLoader();
     act(() => {
       publish("app.resume", { signal: "visibility" });
@@ -170,5 +184,26 @@ describe("useConversationLoader resume grace on list-load errors", () => {
     // THEN the auth toast fires and no load-failed banner is raised
     expect(toastErrorMock).toHaveBeenCalledWith("Failed to authenticate user.");
     expect(currentErrorCode()).toBeNull();
+  });
+
+  test("says nothing about authentication on a gateway-auth 401", () => {
+    /**
+     * In gateway-auth mode there is no user login to fail. A 401 means the
+     * gateway rejected the bearer, which the 401 recovery either re-mints
+     * through or hands to the chooser's guardian repair, so the guardian is
+     * told their authentication failed while it is working and pointed at a
+     * sign-in that would not help.
+     */
+
+    // GIVEN a local session authenticated through the gateway
+    gatewayAuthMode = true;
+    const { rerender } = renderLoader();
+
+    // WHEN the gateway rejects the bearer
+    listError = new ApiError(401, "unauthorized");
+    rerender();
+
+    // THEN nothing claims the user failed to authenticate
+    expect(toastErrorMock).not.toHaveBeenCalled();
   });
 });

--- a/clients/web/src/domains/chat/hooks/use-conversation-loader.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-loader.ts
@@ -1,5 +1,5 @@
 import { t } from "@/i18n";
-import { isGatewayAuthMode } from "@/lib/auth/gateway-session";
+import { isGatewayAuthEnabled } from "@/lib/auth/gateway-session";
 import { captureError } from "@/lib/sentry/capture-error";
 import { useViewerStore } from "@/stores/viewer-store";
 
@@ -216,15 +216,22 @@ export function useConversationLoader({
   // not on every render. The banner consumer below intentionally skips 401
   // because this toast already surfaces the right message.
   //
-  // Platform sessions only. In gateway-auth mode there is no user login to
-  // fail: the guardian is authenticated locally and a 401 means the gateway
-  // rejected the bearer, which the 401 recovery either re-mints through or
-  // hands to the chooser's guardian repair. Telling that user their
-  // authentication failed names the wrong subject and points them at a
-  // sign-in they do not need.
+  // Platform sessions only. Where the session authenticates through a gateway
+  // there is no user login to fail: the guardian is authenticated locally and
+  // a 401 means the gateway rejected the bearer, which the 401 recovery either
+  // re-mints through or hands to the chooser's guardian repair. Telling that
+  // user their authentication failed names the wrong subject and points them
+  // at a sign-in they do not need.
+  //
+  // Keyed on `isGatewayAuthEnabled` rather than `isGatewayAuthMode`, because
+  // the latter bottoms out at `getGatewayToken() !== null` and the repair
+  // handoff clears that token before this 401 arrives. Reading it here would
+  // classify the guardian-repair path, the one this exists for, as a platform
+  // session. Enablement comes from the lockfile and survives the token going
+  // away.
   // -------------------------------------------------------------------------
   useEffect(() => {
-    if (isGatewayAuthMode()) {
+    if (isGatewayAuthEnabled()) {
       return;
     }
     if (

--- a/clients/web/src/domains/chat/hooks/use-conversation-loader.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-loader.ts
@@ -1,4 +1,5 @@
 import { t } from "@/i18n";
+import { isGatewayAuthMode } from "@/lib/auth/gateway-session";
 import { captureError } from "@/lib/sentry/capture-error";
 import { useViewerStore } from "@/stores/viewer-store";
 
@@ -214,8 +215,18 @@ export function useConversationLoader({
   // Effect-scoped so the toast fires once per transition to a 401 error,
   // not on every render. The banner consumer below intentionally skips 401
   // because this toast already surfaces the right message.
+  //
+  // Platform sessions only. In gateway-auth mode there is no user login to
+  // fail: the guardian is authenticated locally and a 401 means the gateway
+  // rejected the bearer, which the 401 recovery either re-mints through or
+  // hands to the chooser's guardian repair. Telling that user their
+  // authentication failed names the wrong subject and points them at a
+  // sign-in they do not need.
   // -------------------------------------------------------------------------
   useEffect(() => {
+    if (isGatewayAuthMode()) {
+      return;
+    }
     if (
       conversationListError instanceof ApiError &&
       conversationListError.status === 401


### PR DESCRIPTION
## TL;DR

Any 401 from the conversation list fires **"Failed to authenticate user."** On a platform session that is true. In gateway-auth mode it is a lie told at the worst possible moment, and #41099 made it reachable in a new way. Gated to platform sessions.

## What changes for the user

| Situation | Before | After |
|---|---|---|
| Platform session, session really expired | "Failed to authenticate user." | Unchanged |
| Local/paired session, gateway rejects the bearer | "Failed to authenticate user.", while the recovery is re-minting or handing off to the repair | No toast; the recovery's own outcome is what they see |
| Local session hitting the LUM-3370 failure | Told their login failed on the way to the guardian-repair dialog | Lands on the repair with no contradictory message |

## Why the message is wrong, not just badly timed

In gateway-auth mode there is no user login to fail. The guardian is authenticated locally; a 401 means the gateway refused the bearer. The recovery interceptor either force-mints through it or, since #41099, drops the rejected token and routes to the chooser's guardian re-provision. Neither outcome is fixed by signing in, which is the only action the toast suggests.

The failure it names most often now is the one #41099 was written for: a rejected guardian token. Whoever hits that gets the toast on their way to the dialog that actually repairs it.

## Why it is safe

- The platform branch is untouched: `isGatewayAuthMode()` is false there, so an expired platform session toasts exactly as before.
- The banner consumer's `!isAuthFail` exclusion is left alone, so nothing changes about which errors raise the load-failed banner.
- The effect stays effect-scoped and keyed on `conversationListError`, so it still fires once per transition rather than per render.

## Deliberately not in this PR

Local 401s that no recovery reaches stay silent. Making them visible is the local-health work in JARVIS-1412 gap 3, and it cannot land alone: `unreachable` currently renders as "Your assistant is asleep", so surfacing a reconnecting session through that path swaps one wrong message for another. Those two want fixing together, which is more than this.

Suppressing a wrong message is not the same as hiding a failure. The recovery paths that can succeed are unaffected, and the one that cannot now routes somewhere visible.

## Testing

`use-conversation-loader-resume-grace.test.tsx` stubbed neither auth mode, so its existing 401 case passed on whatever the ambient config happened to resolve to. Both cases now state their mode explicitly, and a new case asserts nothing claims an auth failure on a gateway-auth 401.

Part of JARVIS-1412.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41138" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->