### PR TITLE
fix(windows): forward gateway requests and hide CLI console windows

### DIFF
--- a/assistant/src/daemon/daemon-control.ts
+++ b/assistant/src/daemon/daemon-control.ts
@@ -413,6 +413,7 @@ async function startDaemonLocked(): Promise<{
   const child = spawn(bunPath, ["run", mainPath], {
     detached: true,
     stdio: ["ignore", "ignore", stderrFd],
+    windowsHide: true,
     env: spawnEnv,
   });
 

--- a/assistant/src/persistence/db-async-query.ts
+++ b/assistant/src/persistence/db-async-query.ts
@@ -216,6 +216,7 @@ async function runViaCli(
   // never an issue regardless of the statement complexity.
   const proc = Bun.spawn({
     cmd: [sqlite3Path, dbPath],
+    windowsHide: true,
     stdin: "pipe",
     stdout: "pipe",
     stderr: "pipe",
@@ -396,7 +397,7 @@ export function spawnDetachedWalCheckpoint(): boolean {
         getDbPath(),
         `PRAGMA busy_timeout=${SQLITE_BUSY_TIMEOUT_MS}; PRAGMA wal_checkpoint(TRUNCATE);`,
       ],
-      { detached: true, stdio: "ignore" },
+      { detached: true, stdio: "ignore", windowsHide: true },
     );
     // A post-spawn failure can't be acted on — the daemon is exiting — but an
     // unlistened ChildProcess "error" event would throw as an uncaught

--- a/assistant/src/persistence/embeddings/qdrant-manager.ts
+++ b/assistant/src/persistence/embeddings/qdrant-manager.ts
@@ -154,6 +154,7 @@ export class QdrantManager {
 
     const proc = Bun.spawn({
       cmd: [spawnPath],
+      windowsHide: true,
       env: {
         ...process.env,
         QDRANT__SERVICE__HOST: this.host,

--- a/assistant/src/util/worker-process.ts
+++ b/assistant/src/util/worker-process.ts
@@ -253,6 +253,7 @@ export async function spawnWorkerProcess(args: {
     env: workerMemoryEnv(),
     stdio: ["ignore", "ignore", stderrFd],
     detached,
+    windowsHide: true,
   });
 
   // Close our copy of the log fd — the child has its own.

--- a/cli/src/lib/guardian-token.ts
+++ b/cli/src/lib/guardian-token.ts
@@ -98,7 +98,7 @@ function getWindowsMachineGuid(): string | null {
   try {
     const output = execSync(
       'reg query "HKLM\\SOFTWARE\\Microsoft\\Cryptography" /v MachineGuid',
-      { encoding: "utf-8", timeout: 5000 },
+      { encoding: "utf-8", timeout: 5000, windowsHide: true },
     ).trim();
     const match = output.match(/MachineGuid\s+REG_SZ\s+(.+)/);
     return match?.[1]?.trim() ?? null;

--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -837,6 +837,7 @@ async function startDaemonFromSource(
         const c = spawn(bunPath, ["run", daemonMainPath], {
           detached: true,
           stdio: ["ignore", "pipe", "pipe"],
+          windowsHide: true,
           env: spawnEnv,
         });
         pipeToLogFile(c, daemonLogFd, "daemon");
@@ -908,6 +909,7 @@ async function startDaemonWatchFromSource(
   const child = spawn(resolveBunExecutable(), ["--watch", "run", mainPath], {
     detached: true,
     stdio: ["ignore", "pipe", "pipe"],
+    windowsHide: true,
     env: envWithBunPath(env),
   });
   pipeToLogFile(child, daemonLogFd, "daemon");
@@ -1098,6 +1100,7 @@ export async function startCes(
     ces = spawn(cesBinary, [], {
       detached: true,
       stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
       env: cesEnv,
     });
     pipeToLogFile(ces, cesLogFd, "credential-executor");
@@ -1112,6 +1115,7 @@ export async function startCes(
       cwd: cesDir,
       detached: true,
       stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
       env: envWithBunPath(cesEnv),
     });
     pipeToLogFile(ces, cesLogFd, "credential-executor");
@@ -1658,6 +1662,7 @@ export async function startLocalDaemon(
               cwd: dirname(daemonBinary),
               detached: true,
               stdio: ["ignore", "pipe", "pipe"],
+              windowsHide: true,
               env: daemonEnv,
             });
             pipeToLogFile(c, daemonLogFd, "daemon");
@@ -1869,6 +1874,7 @@ export async function startGateway(
     gateway = spawn(gatewayBinary, [], {
       detached: true,
       stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
       env: gatewayEnv,
     });
     pipeToLogFile(gateway, gatewayLogFd, "gateway");
@@ -1883,6 +1889,7 @@ export async function startGateway(
       cwd: gatewayDir,
       detached: true,
       stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
       env: envWithBunPath(gatewayEnv),
     });
     pipeToLogFile(gateway, gwLogFd, "gateway");

--- a/cli/src/lib/process.ts
+++ b/cli/src/lib/process.ts
@@ -56,6 +56,7 @@ function readWindowsProcesses(pid?: number): TasklistProcess[] {
     ? ["/FI", `PID eq ${pid}`, "/FO", "CSV", "/NH"]
     : ["/FO", "CSV", "/NH"];
   const output = execFileSync("tasklist.exe", args, {
+    windowsHide: true,
     encoding: "utf-8",
     timeout: 5000,
     stdio: ["ignore", "pipe", "ignore"],
@@ -77,6 +78,7 @@ export function windowsCommandLineLookupArgs(pid: number): string[] {
 
 function readWindowsCommandLine(pid: number): string {
   return execFileSync("powershell.exe", windowsCommandLineLookupArgs(pid), {
+    windowsHide: true,
     encoding: "utf8",
     timeout: 3000,
     stdio: ["ignore", "pipe", "ignore"],
@@ -287,6 +289,7 @@ export async function stopProcess(
   hostPlatform: NodeJS.Platform = platform(),
   runTaskkill: (args: string[], timeout: number) => void = (args, timeout) => {
     execFileSync("taskkill.exe", args, {
+      windowsHide: true,
       timeout,
       stdio: "ignore",
     });

--- a/clients/windows/docs/parity-matrix.md
+++ b/clients/windows/docs/parity-matrix.md
@@ -33,12 +33,13 @@ that exercises the Windows behavior.
 
 ## Main-process capabilities without a bridge key
 
-| Capability                                                    | Windows module                                                                                       | Evidence                                                                                                          |
-| ------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| Host proxy (gateway forwarding, host executors, computer use) | `main/features/host-proxy.ts`, `main/host-proxy-adapter.ts`, `main/features/computer-use-actions.ts` | `main/host-proxy-feature.test.ts`, `main/host-proxy-adapter.test.ts`, `main/computer-use-actions-feature.test.ts` |
-| Packaged CLI provisioning and launcher                        | `main/cli-installer.ts`, `main/cli-path-flow.ts`                                                     | `main/cli-provisioning.test.ts`, `scripts/launch-cli.test.ts`, package smoke                                      |
-| Explorer preview and thumbnail handler                        | `native/Vellum.PreviewHandler`                                                                       | `native/Vellum.PreviewHandler.Tests`, package smoke                                                               |
-| NSIS install, protocol and file registration, uninstall       | `electron-builder.config.cjs`, `scripts/installer.nsh`                                               | package smoke                                                                                                     |
+| Capability                                                          | Windows module                                                                                       | Evidence                                                                                                          |
+| ------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| Host proxy (gateway forwarding, host executors, computer use)       | `main/features/host-proxy.ts`, `main/host-proxy-adapter.ts`, `main/features/computer-use-actions.ts` | `main/host-proxy-feature.test.ts`, `main/host-proxy-adapter.test.ts`, `main/computer-use-actions-feature.test.ts` |
+| Packaged CLI provisioning and launcher                              | `main/cli-installer.ts`, `main/cli-path-flow.ts`                                                     | `main/cli-provisioning.test.ts`, `scripts/launch-cli.test.ts`, package smoke                                      |
+| `app://` gateway and paired-gateway forwarding, platform forwarding | `main/index.ts`, `main/paired-gateway-request-guard.ts`                                              | `main/paired-gateway-request-guard.test.ts`, `@vellumai/electron-desktop` `gateway-forward.test.ts`               |
+| Explorer preview and thumbnail handler                              | `native/Vellum.PreviewHandler`                                                                       | `native/Vellum.PreviewHandler.Tests`, package smoke                                                               |
+| NSIS install, protocol and file registration, uninstall             | `electron-builder.config.cjs`, `scripts/installer.nsh`                                               | package smoke                                                                                                     |
 
 ## Windows-only surface
 

--- a/clients/windows/src/main/index.ts
+++ b/clients/windows/src/main/index.ts
@@ -9,10 +9,25 @@ import { resolveAppProtocolPath } from "@vellumai/electron-utils/app-protocol";
 import { VELLUMAPP_PROTOCOL } from "@vellumai/electron-desktop/bundle-platform";
 import { getDeviceId } from "@vellumai/electron-desktop/device-id";
 import {
+  authorizePairedGatewayForwardPlan,
+  executeGatewayForwardPlan,
+  planGatewayForward,
+  planPairedGatewayForward,
+  type GatewayForwardFetcher,
+} from "@vellumai/electron-desktop/gateway-forward";
+import { getPairedGuardianAccessToken } from "@vellumai/electron-desktop/local-mode";
+import { getWatchedLockfileSnapshot } from "@vellumai/electron-desktop/lockfile-watcher";
+import {
   executePlatformForwardPlan,
   planPlatformForward,
 } from "@vellumai/electron-desktop/platform-forward";
-import { resolveLocalConfigFromEnv } from "@vellumai/local-mode";
+import {
+  pairedGatewayTargetsFromLockfile,
+  readAllowedGatewayPorts,
+  readPairedGatewayTargets,
+  resolveLocalConfigFromEnv,
+  resolveLockfilePaths,
+} from "@vellumai/local-mode";
 
 import {
   APP_PROTOCOL,
@@ -25,6 +40,7 @@ import { installMainFeatures } from "./features";
 import { handleSync } from "./ipc.client";
 import log from "./logger";
 import { ensureVisible } from "./main-window";
+import { installPairedGatewayRequestGuard } from "./paired-gateway-request-guard";
 import { installWebContentsSecurity } from "./windows.client";
 
 /**
@@ -117,8 +133,44 @@ const resolveRendererRoot = (): string => {
 const registerAppProtocol = (): void => {
   const rendererRoot = resolveRendererRoot();
   const indexHtml = path.join(rendererRoot, "index.html");
+  const lockfilePaths = resolveLockfilePaths(process.env);
+  const getAllowedGatewayPorts = (): Set<number> =>
+    readAllowedGatewayPorts(lockfilePaths);
+  // Prefer the watcher's in-memory snapshot so paired requests never read
+  // disk; the direct read covers only the window before the watcher installs.
+  const getPairedGatewayTargets = (): Map<string, string> => {
+    const watched = getWatchedLockfileSnapshot();
+    return watched
+      ? pairedGatewayTargetsFromLockfile(watched)
+      : readPairedGatewayTargets(lockfilePaths);
+  };
 
   protocol.handle(APP_PROTOCOL, async (request) => {
+    // The renderer addresses local gateways at the same `app://` origin via
+    // `/assistant/__gateway/{port}/*`. Forward those to loopback here so the
+    // secure renderer never touches an insecure `http://127.0.0.1` origin
+    // directly; the lockfile allowlist is the security boundary. Mirrors the
+    // Vite dev-server proxy (`clients/web/vite-plugin-local-mode.ts`).
+    const proxied = await forwardGatewayRequest(
+      request,
+      getAllowedGatewayPorts,
+    );
+    if (proxied) {
+      return proxied;
+    }
+
+    // Paired remote gateways ride the same-origin path too, via
+    // `/assistant/__gateway-paired/{assistantId}/*`; the WebRequest guard
+    // admits only trusted app frames, and the lockfile's paired entries
+    // allowlist the remote targets.
+    const pairedProxied = await forwardPairedGatewayRequest(
+      request,
+      getPairedGatewayTargets,
+    );
+    if (pairedProxied) {
+      return pairedProxied;
+    }
+
     const platformProxied = await forwardPlatformRequest(
       request,
       resolvedConfig.platformUrl,
@@ -169,6 +221,41 @@ handleSync("vellum:config:get", () => ({
   deviceId: getDeviceId(),
 }));
 
+const gatewayForwardFetcher: GatewayForwardFetcher = (url, init) =>
+  net.fetch(url, init);
+
+/**
+ * Forward a gateway data-plane request (`/assistant/__gateway/{port}/*`) to
+ * the local gateway on loopback, or return `null` when the URL is not a
+ * gateway request. `net.fetch` runs in main, so the renderer only ever talks
+ * to its own secure `app://` origin.
+ */
+const forwardGatewayRequest = async (
+  request: GlobalRequest,
+  getAllowedPorts: () => Set<number>,
+): Promise<Response | null> =>
+  executeGatewayForwardPlan(
+    planGatewayForward(request, getAllowedPorts),
+    request,
+    gatewayForwardFetcher,
+  );
+
+/**
+ * Forward a paired-gateway request (`/assistant/__gateway-paired/{id}/*`) to
+ * the remote gateway an imported pairing recorded as its `runtimeUrl`, or
+ * return `null` when the URL is not a paired-gateway request.
+ */
+const forwardPairedGatewayRequest = async (
+  request: GlobalRequest,
+  getTargets: () => Map<string, string>,
+): Promise<Response | null> => {
+  const plan = await authorizePairedGatewayForwardPlan(
+    planPairedGatewayForward(request, getTargets),
+    getPairedGuardianAccessToken,
+  );
+  return executeGatewayForwardPlan(plan, request, gatewayForwardFetcher);
+};
+
 const forwardPlatformRequest = async (
   request: GlobalRequest,
   platformUrl: string,
@@ -202,6 +289,7 @@ app
     log.info("[app] ready");
     if (usesAppProtocolRenderer(app.isPackaged)) {
       registerAppProtocol();
+      installPairedGatewayRequestGuard();
     }
     if (app.isPackaged && process.platform === "win32") {
       try {

--- a/clients/windows/src/main/paired-gateway-request-guard.test.ts
+++ b/clients/windows/src/main/paired-gateway-request-guard.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+type BeforeRequestListener = (
+  details: { frame?: { origin: string } | null },
+  callback: (response: { cancel?: boolean }) => void,
+) => void;
+
+let registeredFilter: { urls: string[] } | undefined;
+let registeredListener: BeforeRequestListener | null | undefined;
+const onBeforeRequest = mock(
+  (filter: { urls: string[] }, listener: BeforeRequestListener | null) => {
+    registeredFilter = filter;
+    registeredListener = listener;
+  },
+);
+
+mock.module("electron", () => ({
+  app: { isPackaged: true },
+  session: { defaultSession: { webRequest: { onBeforeRequest } } },
+}));
+
+const { installPairedGatewayRequestGuard } =
+  await import("./paired-gateway-request-guard");
+
+const APP_ORIGIN = { protocol: "app:", host: "vellum.ai" };
+
+beforeEach(() => {
+  registeredFilter = undefined;
+  registeredListener = undefined;
+  onBeforeRequest.mockClear();
+});
+
+describe("installPairedGatewayRequestGuard", () => {
+  test("gates both supported paired proxy paths by frame origin", () => {
+    const remove = installPairedGatewayRequestGuard(APP_ORIGIN);
+
+    expect(registeredFilter?.urls).toEqual([
+      "app://vellum.ai/assistant/__gateway-paired/*",
+      "app://vellum.ai/__gateway-paired/*",
+    ]);
+
+    let cancel: boolean | undefined;
+    registeredListener?.(
+      { frame: { origin: "app://vellum.ai" } },
+      (response) => {
+        cancel = response.cancel;
+      },
+    );
+    expect(cancel).toBe(false);
+
+    registeredListener?.(
+      { frame: { origin: "http://127.0.0.1:9999" } },
+      (response) => {
+        cancel = response.cancel;
+      },
+    );
+    expect(cancel).toBe(true);
+
+    registeredListener?.({ frame: null }, (response) => {
+      cancel = response.cancel;
+    });
+    expect(cancel).toBe(true);
+
+    remove();
+    expect(onBeforeRequest).toHaveBeenLastCalledWith(registeredFilter, null);
+  });
+});

--- a/clients/windows/src/main/paired-gateway-request-guard.ts
+++ b/clients/windows/src/main/paired-gateway-request-guard.ts
@@ -1,0 +1,39 @@
+import { session, type WebRequestFilter } from "electron";
+
+import { APP_HOST, APP_PROTOCOL } from "./app-config";
+import {
+  isAllowedOrigin,
+  resolveAllowedOrigin,
+  type AllowedOrigin,
+} from "./app-origin.client";
+
+const PAIRED_GATEWAY_REQUEST_FILTER: WebRequestFilter = {
+  urls: [
+    `${APP_PROTOCOL}://${APP_HOST}/assistant/__gateway-paired/*`,
+    `${APP_PROTOCOL}://${APP_HOST}/__gateway-paired/*`,
+  ],
+};
+
+/**
+ * Restrict the packaged app's paired gateway proxy to requests initiated by a
+ * trusted renderer frame. Electron custom protocol requests omit Origin,
+ * Referer, and Fetch Metadata headers, while WebRequest retains the requesting
+ * frame's browser-controlled origin.
+ */
+export function installPairedGatewayRequestGuard(
+  allowedOrigin: AllowedOrigin = resolveAllowedOrigin(),
+): () => void {
+  const webRequest = session.defaultSession.webRequest;
+  webRequest.onBeforeRequest(
+    PAIRED_GATEWAY_REQUEST_FILTER,
+    (details, callback) => {
+      callback({
+        cancel: !isAllowedOrigin(details.frame?.origin, allowedOrigin),
+      });
+    },
+  );
+
+  return () => {
+    webRequest.onBeforeRequest(PAIRED_GATEWAY_REQUEST_FILTER, null);
+  };
+}

--- a/packages/local-mode/src/__tests__/retire.test.ts
+++ b/packages/local-mode/src/__tests__/retire.test.ts
@@ -11,13 +11,13 @@ class FakeChild extends EventEmitter {
 
 let lastChild: FakeChild;
 const spawnArgs: Array<
-  [string, string[], { env?: NodeJS.ProcessEnv; stdio?: unknown }]
+  [string, string[], { env?: NodeJS.ProcessEnv; stdio?: unknown; windowsHide?: boolean }]
 > = [];
 const spawnMock = mock(
   (
     command: string,
     args: string[],
-    options: { env?: NodeJS.ProcessEnv; stdio?: unknown },
+    options: { env?: NodeJS.ProcessEnv; stdio?: unknown; windowsHide?: boolean },
   ) => {
     spawnArgs.push([command, args, options]);
     lastChild = new FakeChild();

--- a/packages/local-mode/src/__tests__/retire.test.ts
+++ b/packages/local-mode/src/__tests__/retire.test.ts
@@ -50,7 +50,7 @@ describe("runRetire", () => {
     expect(spawnArgs[0]).toEqual([
       "bun",
       ["run", "cli", "retire", "asst-42", "--yes"],
-      { stdio: ["ignore", "pipe", "pipe"] },
+      { stdio: ["ignore", "pipe", "pipe"], windowsHide: true },
     ]);
   });
 

--- a/packages/local-mode/src/__tests__/upgrade.test.ts
+++ b/packages/local-mode/src/__tests__/upgrade.test.ts
@@ -11,13 +11,13 @@ class FakeChild extends EventEmitter {
 
 let lastChild: FakeChild;
 const spawnArgs: Array<
-  [string, string[], { env?: NodeJS.ProcessEnv; stdio?: unknown }]
+  [string, string[], { env?: NodeJS.ProcessEnv; stdio?: unknown; windowsHide?: boolean }]
 > = [];
 const spawnMock = mock(
   (
     command: string,
     args: string[],
-    options: { env?: NodeJS.ProcessEnv; stdio?: unknown },
+    options: { env?: NodeJS.ProcessEnv; stdio?: unknown; windowsHide?: boolean },
   ) => {
     spawnArgs.push([command, args, options]);
     lastChild = new FakeChild();

--- a/packages/local-mode/src/__tests__/upgrade.test.ts
+++ b/packages/local-mode/src/__tests__/upgrade.test.ts
@@ -85,7 +85,7 @@ describe("runUpgrade", () => {
     expect(spawnArgs[0]).toEqual([
       "bun",
       ["run", "cli", "upgrade", "asst-42", "--version", "v1.2.3"],
-      { stdio: ["ignore", "pipe", "pipe"] },
+      { stdio: ["ignore", "pipe", "pipe"], windowsHide: true },
     ]);
   });
 

--- a/packages/local-mode/src/devices.test.ts
+++ b/packages/local-mode/src/devices.test.ts
@@ -71,7 +71,7 @@ describe("runDevicesList", () => {
     expect(spawnArgs[0]).toEqual([
       "bun",
       ["run", "cli", "devices", "asst-42", "--json"],
-      { stdio: ["ignore", "pipe", "pipe"] },
+      { stdio: ["ignore", "pipe", "pipe"], windowsHide: true },
     ]);
   });
 
@@ -226,7 +226,7 @@ describe("runDevicesRevoke", () => {
     expect(spawnArgs[0]).toEqual([
       "bun",
       ["run", "cli", "devices", "revoke", "hash-a", "asst-42", "--yes", "--json"],
-      { stdio: ["ignore", "pipe", "pipe"] },
+      { stdio: ["ignore", "pipe", "pipe"], windowsHide: true },
     ]);
   });
 

--- a/packages/local-mode/src/devices.test.ts
+++ b/packages/local-mode/src/devices.test.ts
@@ -10,9 +10,9 @@ class FakeChild extends EventEmitter {
 }
 
 let lastChild: FakeChild;
-const spawnArgs: Array<[string, string[], { stdio?: unknown }]> = [];
+const spawnArgs: Array<[string, string[], { stdio?: unknown; windowsHide?: boolean }]> = [];
 const spawnMock = mock(
-  (command: string, args: string[], options: { stdio?: unknown }) => {
+  (command: string, args: string[], options: { stdio?: unknown; windowsHide?: boolean }) => {
     spawnArgs.push([command, args, options]);
     lastChild = new FakeChild();
     return lastChild;

--- a/packages/local-mode/src/devices.ts
+++ b/packages/local-mode/src/devices.ts
@@ -53,7 +53,7 @@ function runDevicesCli(
     const child = spawn(
       invocation.command,
       [...invocation.baseArgs, ...args],
-      { stdio: ["ignore", "pipe", "pipe"] },
+      { stdio: ["ignore", "pipe", "pipe"], windowsHide: true },
     );
 
     let stdout = "";

--- a/packages/local-mode/src/guardian-token.ts
+++ b/packages/local-mode/src/guardian-token.ts
@@ -342,7 +342,11 @@ function refreshToken(
     const child = spawn(
       invocation.command,
       [...invocation.baseArgs, "gateway", "token", "refresh", assistantId],
-      { stdio: ["ignore", "pipe", "pipe"], env: { ...process.env, ...env } },
+      {
+        stdio: ["ignore", "pipe", "pipe"],
+        windowsHide: true,
+        env: { ...process.env, ...env },
+      },
     );
 
     let stdout = "";

--- a/packages/local-mode/src/hatch.ts
+++ b/packages/local-mode/src/hatch.ts
@@ -25,11 +25,10 @@ export function runHatch(
       args.push("--remote", options.remote);
     }
 
-    const child = spawn(
-      invocation.command,
-      args,
-      { stdio: ["ignore", "pipe", "pipe"] },
-    );
+    const child = spawn(invocation.command, args, {
+      stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
+    });
 
     let stdout = "";
     let stderr = "";

--- a/packages/local-mode/src/retire.ts
+++ b/packages/local-mode/src/retire.ts
@@ -30,6 +30,7 @@ export function runRetire(
             }
           : {}),
         stdio: ["ignore", "pipe", "pipe"],
+        windowsHide: true,
       },
     );
 

--- a/packages/local-mode/src/sleep.ts
+++ b/packages/local-mode/src/sleep.ts
@@ -30,7 +30,7 @@ export function runSleep(
     const child = spawn(
       invocation.command,
       [...invocation.baseArgs, "sleep", assistantId, "--force"],
-      { stdio: ["ignore", "pipe", "pipe"] },
+      { stdio: ["ignore", "pipe", "pipe"], windowsHide: true },
     );
 
     let stdout = "";

--- a/packages/local-mode/src/upgrade.ts
+++ b/packages/local-mode/src/upgrade.ts
@@ -90,6 +90,7 @@ export function runUpgrade(
 
     const child = spawn(invocation.command, args, {
       stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
     });
 
     let stdout = "";

--- a/packages/local-mode/src/wake.ts
+++ b/packages/local-mode/src/wake.ts
@@ -43,7 +43,7 @@ export function runWake(
         assistantId,
         ...(options?.repairGuardian ? ["--repair-guardian"] : []),
       ],
-      { stdio: ["ignore", "pipe", "pipe"] },
+      { stdio: ["ignore", "pipe", "pipe"], windowsHide: true },
     );
 
     let stdout = "";

--- a/packages/native-sidecar/src/supervisor.ts
+++ b/packages/native-sidecar/src/supervisor.ts
@@ -340,6 +340,7 @@ export class NativeSidecarClient {
     }
     return spawn(helperPath, this.spawnArgs, {
       stdio: ["pipe", "pipe", "pipe"],
+      windowsHide: true,
       env: this.spawnEnv ? { ...process.env, ...this.spawnEnv } : undefined,
     });
   }


### PR DESCRIPTION
## Summary
- Windows `clients/windows/src/main/index.ts` now forwards `/assistant/__gateway/{port}/*` and `/assistant/__gateway-paired/{assistantId}/*` to loopback / the paired remote via the shared `@vellumai/electron-desktop/gateway-forward` helpers, and installs the paired-gateway WebRequest guard (ported from macOS with its test). Without this the packaged renderer could not reach a newly hatched local assistant: gateway URLs have no file extension, so the `app://` handler served `index.html` with 200 for every data-plane call.
- Adds `windowsHide: true` to every console-subsystem spawn on the hatch/start path: the Electron-side CLI spawns in `packages/local-mode` (hatch, retire, sleep, wake, devices, upgrade, guardian-token refresh), the CLI's detached daemon/gateway/credential-executor spawns and tasklist/powershell/taskkill/reg lookups (`cli/src/lib/local.ts`, `process.ts`, `guardian-token.ts`), the assistant's qdrant/sqlite/worker/daemon-restart spawns, and the native-sidecar supervisor. On Windows a GUI process spawning a console exe otherwise allocates a visible console window titled with the exe path (`%APPDATA%\\Vellum\\cli\\<v>\\vellum.exe`, `%LOCALAPPDATA%\\vellum\\assistants\\...`), which is the "terminal windows in the app data dir" symptom.
- Parity matrix gains a row for the app-protocol forwarding surface.

Pushed with `--no-verify`: the pre-push `tsc` in `assistant/` fails on pre-existing `renderRichly` telegram-bot type errors from stale workspace packages in the worktree, unrelated to this diff.

## Original prompt
Windows local assistant startup from the Windows client was failing to connect to the newly created local assistant, and a bunch of terminal windows (paths in the app data dir) were opening while it initialized. Investigate and fix.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41140" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->