### PR TITLE
refactor(channels): one activity capability, on Slack's current API

### DIFF
--- a/assistant/src/cli/commands/__tests__/conversations-slack.test.ts
+++ b/assistant/src/cli/commands/__tests__/conversations-slack.test.ts
@@ -112,7 +112,7 @@ mock.module("../../../messaging/providers/slack/send.js", () => ({
   },
   sendSlackStreamOp: async () => ({ ok: true, ts: "1700000000.000200" }),
   sendSlackReaction: async () => {},
-  sendSlackAssistantThreadStatus: async () => {},
+  sendSlackAgentSessionStatus: async () => {},
   sendSlackAttachments: async () => ({
     allFailed: false,
     failureCount: 0,

--- a/assistant/src/messaging/providers/__tests__/transport-dispatch.test.ts
+++ b/assistant/src/messaging/providers/__tests__/transport-dispatch.test.ts
@@ -9,9 +9,7 @@ const slack = {
     Promise.resolve({ ts: "slack-ts" }),
   ),
   sendSlackReaction: mock((..._args: unknown[]) => Promise.resolve()),
-  sendSlackAssistantThreadStatus: mock((..._args: unknown[]) =>
-    Promise.resolve(),
-  ),
+  sendSlackAgentSessionStatus: mock((..._args: unknown[]) => Promise.resolve()),
   sendSlackAttachments: mock((..._args: unknown[]) =>
     Promise.resolve({ allFailed: false, failureCount: 0 }),
   ),
@@ -66,9 +64,8 @@ const {
   editChannelMessage,
   sendChannelReaction,
   sendChannelStreamOp,
-  sendChannelTyping,
-  setChannelThreadStatus,
-  supportsChannelTyping,
+  setChannelActivity,
+  supportsChannelActivity,
   isDirectDelivery,
   getTransportForCallback,
 } = await import("../index.js");
@@ -172,30 +169,21 @@ describe("Slack sub-operation selection", () => {
     expect(slack.sendSlackReply).not.toHaveBeenCalled();
   });
 
-  test("setChannelThreadStatus reaches Slack without touching the text path", async () => {
-    await setChannelThreadStatus(`${BASE}/deliver/slack`, {
+  test("setChannelActivity reaches Slack without touching the text path", async () => {
+    await setChannelActivity(`${BASE}/deliver/slack`, {
       chatId: "C1",
-      threadTs: "1700.5",
-      status: "is thinking",
+      phase: "thinking",
     });
 
-    expect(slack.sendSlackAssistantThreadStatus).toHaveBeenCalledTimes(1);
+    expect(slack.sendSlackAgentSessionStatus).toHaveBeenCalledTimes(1);
     expect(slack.sendSlackReply).not.toHaveBeenCalled();
   });
 
-  test("a channel with no status surface resolves quietly", async () => {
-    const result = await setChannelThreadStatus(`${BASE}/deliver/telegram`, {
+  test("a channel with no activity indicator resolves quietly", async () => {
+    const result = await setChannelActivity(`${BASE}/deliver/whatsapp`, {
       chatId: "123",
-      threadTs: "1700.5",
-      status: "is thinking",
+      phase: "thinking",
     });
-
-    expect(result).toEqual({ ok: true });
-    expect(telegram.sendTelegramReply).not.toHaveBeenCalled();
-  });
-
-  test("sendChannelTyping resolves quietly for a channel with no typing capability", async () => {
-    const result = await sendChannelTyping(`${BASE}/deliver/slack`, "C1");
 
     expect(result).toEqual({ ok: true });
     expect(slack.sendSlackReply).not.toHaveBeenCalled();
@@ -296,18 +284,24 @@ describe("capability gating across channels", () => {
     expect(discord.sendDiscordReply).not.toHaveBeenCalled();
   });
 
-  test("the typing capability is read from the transport, not the channel name", () => {
-    // The heartbeat gate in background-dispatch asks this rather than testing
-    // `sourceChannel === "telegram"`, so a channel that implements the method
-    // starts showing an indicator without a caller being changed.
-    expect(supportsChannelTyping(`${BASE}/deliver/telegram`)).toBe(true);
-    expect(supportsChannelTyping(`${BASE}/deliver/discord`)).toBe(true);
-    expect(supportsChannelTyping(`${BASE}/deliver/slack`)).toBe(false);
-    expect(supportsChannelTyping(`${BASE}/deliver/whatsapp`)).toBe(false);
+  test("the activity capability is read from the transport, not the channel name", () => {
+    // The gate in background-dispatch asks this rather than testing
+    // `sourceChannel === "slack"`, so a channel that implements the method
+    // starts showing an indicator without a caller being changed. All three
+    // answer the same question now, which is the point of the single method:
+    // Slack holds its indicator and the other two re-assert theirs, and a
+    // caller cannot tell the difference.
+    expect(supportsChannelActivity(`${BASE}/deliver/slack`)).toBe(true);
+    expect(supportsChannelActivity(`${BASE}/deliver/telegram`)).toBe(true);
+    expect(supportsChannelActivity(`${BASE}/deliver/discord`)).toBe(true);
+    expect(supportsChannelActivity(`${BASE}/deliver/whatsapp`)).toBe(false);
   });
 
-  test("sendChannelTyping reaches Telegram's typing indicator", async () => {
-    await sendChannelTyping(`${BASE}/deliver/telegram`, "123");
+  test("setChannelActivity reaches Telegram's typing indicator", async () => {
+    await setChannelActivity(`${BASE}/deliver/telegram`, {
+      chatId: "123",
+      phase: "thinking",
+    });
 
     expect(telegram.sendTelegramTypingIndicator).toHaveBeenCalledTimes(1);
   });
@@ -346,8 +340,11 @@ describe("capability gating across channels", () => {
     });
   });
 
-  test("sendChannelTyping reaches Discord's typing indicator", async () => {
-    await sendChannelTyping(`${BASE}/deliver/discord`, "999");
+  test("setChannelActivity reaches Discord's typing indicator", async () => {
+    await setChannelActivity(`${BASE}/deliver/discord`, {
+      chatId: "999",
+      phase: "thinking",
+    });
 
     expect(discord.sendDiscordTypingIndicator).toHaveBeenCalledTimes(1);
   });

--- a/assistant/src/messaging/providers/__tests__/transport-dispatch.test.ts
+++ b/assistant/src/messaging/providers/__tests__/transport-dispatch.test.ts
@@ -62,7 +62,6 @@ mock.module("../../../util/logger.js", () => ({
 const {
   deliverDirect,
   editChannelMessage,
-  sendChannelReaction,
   sendChannelStreamOp,
   setChannelActivity,
   supportsChannelActivity,
@@ -144,18 +143,6 @@ describe("Slack sub-operation selection", () => {
     expect(opts.threadTs).toBe("1700.9");
   });
 
-  test("sendChannelReaction reaches Slack without touching the text path", async () => {
-    await sendChannelReaction(`${BASE}/deliver/slack`, {
-      chatId: "C1",
-      messageId: "1700.5",
-      emoji: "white_check_mark",
-      action: "add",
-    });
-
-    expect(slack.sendSlackReaction).toHaveBeenCalledTimes(1);
-    expect(slack.sendSlackReply).not.toHaveBeenCalled();
-  });
-
   test("editChannelMessage updates in place instead of posting", async () => {
     await editChannelMessage(`${BASE}/deliver/slack`, {
       chatId: "C1",
@@ -206,22 +193,6 @@ describe("Slack sub-operation selection", () => {
 });
 
 describe("capability gating across channels", () => {
-  test("a channel with no reaction capability resolves quietly", async () => {
-    // Slack is the only channel that implements it, because the only producer
-    // is Slack's own acknowledgement fallback. A channel without the method
-    // is not a failed delivery, so nothing is attempted and nothing throws.
-    const target = {
-      chatId: "C1",
-      messageId: "1",
-      emoji: "eyes",
-      action: "add",
-    } as const;
-    expect(
-      await sendChannelReaction(`${BASE}/deliver/telegram`, target),
-    ).toEqual({ ok: true });
-    expect(telegram.sendTelegramReply).not.toHaveBeenCalled();
-  });
-
   test("Slack renders a muted edit as its own context block", async () => {
     await editChannelMessage(`${BASE}/deliver/slack`, {
       chatId: "C1",

--- a/assistant/src/messaging/providers/channel-transport.ts
+++ b/assistant/src/messaging/providers/channel-transport.ts
@@ -17,15 +17,6 @@ export interface CallbackContext {
   readonly params: Readonly<Record<string, string>>;
 }
 
-/** The message an emoji reaction lands on, and what to do there. */
-export interface ReactionTarget {
-  readonly chatId: string;
-  /** The target message, in the channel's own id space. */
-  readonly messageId: string;
-  readonly emoji: string;
-  readonly action: "add" | "remove";
-}
-
 /**
  * How busy the assistant is in one conversation, for the channel to show.
  *
@@ -139,19 +130,6 @@ export interface ChannelTransport {
    * cadence here keeps the caller from having to know which channel it is.
    */
   readonly activityRefreshMs?: number;
-
-  /**
-   * Add or remove one of the assistant's own emoji reactions on a message.
-   *
-   * `messageId` is the target's id in the channel's own space, the same way
-   * `chatId` is: Slack spells it as a timestamp, Discord and Telegram as ids.
-   * Nothing outside the channel reads it, so nothing outside needs a shared
-   * spelling for it.
-   */
-  react?(
-    ctx: CallbackContext,
-    target: ReactionTarget,
-  ): Promise<ChannelDeliveryResult>;
 
   /**
    * Advance a streamed reply: open it, add to it, or close it.

--- a/assistant/src/messaging/providers/channel-transport.ts
+++ b/assistant/src/messaging/providers/channel-transport.ts
@@ -4,6 +4,7 @@ import type {
   SlackStreamOp,
 } from "@vellumai/gateway-client";
 
+import type { AssistantActivityPhase } from "../../api/index.js";
 import type { ChannelId } from "../../channels/types.js";
 
 /**
@@ -26,15 +27,35 @@ export interface ReactionTarget {
 }
 
 /**
- * A status surface update. `chatId` is the room, spelled the way every other
- * method on this interface spells it.
+ * How busy the assistant is in one conversation, for the channel to show.
+ *
+ * `phase` is the daemon's own activity phase rather than a channel's word for
+ * it, so every channel is told the same lifecycle and decides how to render
+ * it. A channel whose indicator expires on its own re-sends while the busy
+ * phases last; a channel whose indicator holds sets it once and clears it on
+ * `idle`. Neither shape leaks into what the caller says.
  */
-export interface ThreadStatus {
+export interface ActivityTarget {
   readonly chatId: string;
-  readonly threadTs: string;
-  readonly status: string;
-  /** Rotating hints shown under the status while it holds. */
-  readonly loadingMessages?: readonly string[];
+  readonly phase: AssistantActivityPhase;
+  /**
+   * Who started the turn. Channels that attribute a session to a person read
+   * it when the session is created, and ignore it afterwards.
+   */
+  readonly initiatorUserId?: string;
+}
+
+/**
+ * Whether a phase means a turn is actually running.
+ *
+ * A channel with a plain busy indicator shows it for these and nothing else.
+ * `awaiting_confirmation` is deliberately not one: an approval is waiting on a
+ * person, and a typing bubble there promises output that is not coming.
+ */
+export function isBusyActivityPhase(phase: AssistantActivityPhase): boolean {
+  return (
+    phase === "thinking" || phase === "streaming" || phase === "tool_running"
+  );
 }
 
 /**
@@ -96,13 +117,28 @@ export interface ChannelTransport {
   ): Promise<ChannelDeliveryResult>;
 
   /**
-   * Show that the assistant is working, in whatever form the channel has.
+   * Show how busy the assistant is, in whatever form the channel has.
    *
-   * Takes the place and nothing else, because that is all it needs. A channel
-   * without the affordance omits the method, so implementing it is the whole
-   * of declaring the capability.
+   * One capability rather than one per indicator shape: a self-expiring typing
+   * bubble and a status that holds until cleared answer the same question, and
+   * splitting them by how the channel keeps them alive forces every caller to
+   * know which channel it is talking to. A channel without any such affordance
+   * omits the method, so implementing it is the whole of declaring it.
    */
-  typing?(ctx: CallbackContext, chatId: string): Promise<ChannelDeliveryResult>;
+  setActivity?(
+    ctx: CallbackContext,
+    target: ActivityTarget,
+  ): Promise<ChannelDeliveryResult>;
+
+  /**
+   * How often a busy indicator must be re-asserted to stay visible, for a
+   * channel whose indicator expires on its own.
+   *
+   * Omitted by a channel whose indicator holds until it is changed, which is
+   * how a caller knows to set it once rather than run a timer. Declaring the
+   * cadence here keeps the caller from having to know which channel it is.
+   */
+  readonly activityRefreshMs?: number;
 
   /**
    * Add or remove one of the assistant's own emoji reactions on a message.
@@ -115,18 +151,6 @@ export interface ChannelTransport {
   react?(
     ctx: CallbackContext,
     target: ReactionTarget,
-  ): Promise<ChannelDeliveryResult>;
-
-  /**
-   * Set or clear the channel's own "working on it" surface.
-   *
-   * Distinct from `typing`: an indicator a channel refreshes on a timer versus
-   * a status a channel holds until it is changed. Slack has both and uses this
-   * one; a channel with only the first implements only `typing`.
-   */
-  setThreadStatus?(
-    ctx: CallbackContext,
-    status: ThreadStatus,
   ): Promise<ChannelDeliveryResult>;
 
   /**

--- a/assistant/src/messaging/providers/discord/transport.ts
+++ b/assistant/src/messaging/providers/discord/transport.ts
@@ -5,6 +5,7 @@ import type {
   CallbackContext,
   ChannelTransport,
 } from "../channel-transport.js";
+import { isBusyActivityPhase } from "../channel-transport.js";
 import { openDiscordDmChannel } from "./api.js";
 import type { DiscordSendTarget } from "./send.js";
 import {
@@ -47,9 +48,20 @@ async function sendTarget(
 export const discordTransport: ChannelTransport = {
   channel: "discord",
 
-  async typing(ctx, chatId) {
-    await sendDiscordTypingIndicator(await sendTarget(ctx, chatId));
-    log.debug({ chatId }, "Discord typing indicator delivered (direct)");
+  // Discord clears a typing indicator after ten seconds.
+  activityRefreshMs: 8_000,
+
+  async setActivity(ctx, target) {
+    // Discord's typing indicator expires by itself after ten seconds, so a
+    // phase that is not running needs no clearing call.
+    if (!isBusyActivityPhase(target.phase)) {
+      return { ok: true };
+    }
+    await sendDiscordTypingIndicator(await sendTarget(ctx, target.chatId));
+    log.debug(
+      { chatId: target.chatId, phase: target.phase },
+      "Discord typing indicator delivered (direct)",
+    );
     return { ok: true };
   },
 

--- a/assistant/src/messaging/providers/index.ts
+++ b/assistant/src/messaging/providers/index.ts
@@ -22,7 +22,6 @@ import type {
   CallbackContext,
   ChannelTransport,
   EditTarget,
-  ReactionTarget,
 } from "./channel-transport.js";
 import { discordTransport } from "./discord/transport.js";
 import { slackTransport } from "./slack/transport.js";
@@ -107,24 +106,6 @@ export async function editChannelMessage(
     return { ok: true };
   }
   return transport.edit(callbackContext(callbackUrl), target);
-}
-
-/**
- * Add or remove one of the assistant's own reactions on a message.
- *
- * Resolves to nothing when the channel has none, the same as the activity
- * indicator: a reaction is an acknowledgement, and a channel that cannot show
- * one is not a failed delivery.
- */
-export async function sendChannelReaction(
-  callbackUrl: string,
-  target: ReactionTarget,
-): Promise<ChannelDeliveryResult> {
-  const transport = getTransportForCallback(callbackUrl);
-  if (!transport?.react) {
-    return { ok: true };
-  }
-  return transport.react(callbackContext(callbackUrl), target);
 }
 
 /**

--- a/assistant/src/messaging/providers/index.ts
+++ b/assistant/src/messaging/providers/index.ts
@@ -18,11 +18,11 @@ import { a2aTransport } from "./a2a/transport.js";
 import type { DirectDeliveryChannel } from "./callback-routing.js";
 import { channelForCallback } from "./callback-routing.js";
 import type {
+  ActivityTarget,
   CallbackContext,
   ChannelTransport,
   EditTarget,
   ReactionTarget,
-  ThreadStatus,
 } from "./channel-transport.js";
 import { discordTransport } from "./discord/transport.js";
 import { slackTransport } from "./slack/transport.js";
@@ -53,40 +53,44 @@ export function getTransportForCallback(
 }
 
 /**
- * Whether the channel this callback addresses can show a working indicator.
+ * Whether the channel this callback addresses can show how busy the assistant
+ * is.
  *
  * Asks the transport rather than the channel id, so a channel that gains the
  * method starts being asked without a caller being told about it.
  */
-export function supportsChannelTyping(callbackUrl: string): boolean {
-  return getTransportForCallback(callbackUrl)?.typing !== undefined;
+export function supportsChannelActivity(callbackUrl: string): boolean {
+  return getTransportForCallback(callbackUrl)?.setActivity !== undefined;
 }
 
 /**
- * Show that the assistant is working on the channel this callback addresses.
+ * How often this channel's busy indicator has to be re-asserted, or
+ * `undefined` when it holds until changed and one call is enough.
+ */
+export function channelActivityRefreshMs(
+  callbackUrl: string,
+): number | undefined {
+  return getTransportForCallback(callbackUrl)?.activityRefreshMs;
+}
+
+/**
+ * Show how busy the assistant is on the channel this callback addresses.
  *
  * Resolves to nothing when the channel has no such affordance, which is the
  * ordinary case rather than a failure: the indicator is decoration, and a
  * channel that cannot show one is not degraded by its absence.
  */
-export async function sendChannelTyping(
+export async function setChannelActivity(
   callbackUrl: string,
-  chatId: string,
+  target: ActivityTarget,
 ): Promise<ChannelDeliveryResult> {
   const transport = getTransportForCallback(callbackUrl);
-  if (!transport?.typing) {
+  if (!transport?.setActivity) {
     return { ok: true };
   }
-  return transport.typing(callbackContext(callbackUrl), chatId);
+  return transport.setActivity(callbackContext(callbackUrl), target);
 }
 
-/**
- * Add or remove one of the assistant's own reactions on a message.
- *
- * Resolves to nothing when the channel has none, the same as typing: a
- * reaction is an acknowledgement, and a channel that cannot show one is not a
- * failed delivery.
- */
 /**
  * Replace a message the assistant already sent.
  *
@@ -105,6 +109,13 @@ export async function editChannelMessage(
   return transport.edit(callbackContext(callbackUrl), target);
 }
 
+/**
+ * Add or remove one of the assistant's own reactions on a message.
+ *
+ * Resolves to nothing when the channel has none, the same as the activity
+ * indicator: a reaction is an acknowledgement, and a channel that cannot show
+ * one is not a failed delivery.
+ */
 export async function sendChannelReaction(
   callbackUrl: string,
   target: ReactionTarget,
@@ -114,23 +125,6 @@ export async function sendChannelReaction(
     return { ok: true };
   }
   return transport.react(callbackContext(callbackUrl), target);
-}
-
-/**
- * Set or clear the channel's status surface.
- *
- * Resolves to nothing when the channel holds none, so a caller does not have
- * to know which channels do.
- */
-export async function setChannelThreadStatus(
-  callbackUrl: string,
-  status: ThreadStatus,
-): Promise<ChannelDeliveryResult> {
-  const transport = getTransportForCallback(callbackUrl);
-  if (!transport?.setThreadStatus) {
-    return { ok: true };
-  }
-  return transport.setThreadStatus(callbackContext(callbackUrl), status);
 }
 
 /**

--- a/assistant/src/messaging/providers/slack/send.test.ts
+++ b/assistant/src/messaging/providers/slack/send.test.ts
@@ -28,55 +28,112 @@ mock.module("./api.js", () => ({
 // the (unmocked) shared transport, so thrown test errors must be real
 // instances or every branch under test would silently take the generic path.
 const { SlackApiError } = await import("./web-api-transport.js");
-const { sendSlackAssistantThreadStatus, sendSlackReply, updateSlackMessage } =
+const { sendSlackAgentSessionStatus, sendSlackReply, updateSlackMessage } =
   await import("./send.js");
 
-describe("sendSlackAssistantThreadStatus", () => {
+describe("sendSlackAgentSessionStatus", () => {
+  const threadTs = "1700000000.000100";
+
   beforeEach(() => {
     callSlackApiMock.mockReset();
     callSlackApiMock.mockImplementation(async () => ({ ok: true }));
   });
 
-  test("serializes loading messages for Slack assistant thread status", async () => {
-    await sendSlackAssistantThreadStatus(
-      "C123",
-      "1700000000.000100",
-      "is working...",
-      ["Reading files", "Running tests"],
-    );
+  // Every phase, so a mapping that loses one fails here rather than showing
+  // the wrong thing in Slack. `suspended` is the one with teeth: an approval
+  // is waiting on a person, and Slack renders that differently from a turn
+  // that is still running.
+  test.each([
+    ["idle", "active"],
+    ["thinking", "processing"],
+    ["streaming", "processing"],
+    ["tool_running", "processing"],
+    ["awaiting_confirmation", "suspended"],
+  ] as const)("sends %s as the %s session status", async (phase, status) => {
+    await sendSlackAgentSessionStatus({ channel: "C123", phase, threadTs });
 
     expect(callSlackApiMock).toHaveBeenCalledTimes(1);
-    expect(callSlackApiMock).toHaveBeenCalledWith(
-      "assistant.threads.setStatus",
-      {
-        channel_id: "C123",
-        thread_ts: "1700000000.000100",
-        status: "is working...",
-        loading_messages: ["Reading files", "Running tests"],
-      },
-    );
+    expect(callSlackApiMock).toHaveBeenCalledWith("agents.sessions.setStatus", {
+      channel_id: "C123",
+      status,
+      thread_ts: threadTs,
+    });
   });
 
-  test("falls back to the reaction path when status API delivery fails", async () => {
+  test("carries the initiator, which Slack reads only when it opens the session", async () => {
+    await sendSlackAgentSessionStatus({
+      channel: "C123",
+      phase: "thinking",
+      threadTs,
+      initiatorUserId: "U0READER",
+    });
+
+    expect(callSlackApiMock).toHaveBeenCalledWith("agents.sessions.setStatus", {
+      channel_id: "C123",
+      status: "processing",
+      thread_ts: threadTs,
+      initiator_user_id: "U0READER",
+    });
+  });
+
+  test("omits thread_ts in a conversation the app has not threaded", async () => {
+    await sendSlackAgentSessionStatus({ channel: "D123", phase: "thinking" });
+
+    expect(callSlackApiMock).toHaveBeenCalledWith("agents.sessions.setStatus", {
+      channel_id: "D123",
+      status: "processing",
+    });
+  });
+
+  test("falls back to adding a reaction when the status call fails", async () => {
     callSlackApiMock
       .mockImplementationOnce(async () => {
         throw new Error("missing_scope");
       })
       .mockImplementationOnce(async () => ({ ok: true }));
 
-    await sendSlackAssistantThreadStatus(
-      "C123",
-      "1700000000.000100",
-      "is working...",
-      ["Reading files"],
-    );
+    await sendSlackAgentSessionStatus({
+      channel: "C123",
+      phase: "thinking",
+      threadTs,
+    });
 
     expect(callSlackApiMock).toHaveBeenCalledTimes(2);
     expect(callSlackApiMock).toHaveBeenNthCalledWith(2, "reactions.add", {
       channel: "C123",
       name: "eyes",
-      timestamp: "1700000000.000100",
+      timestamp: threadTs,
     });
+  });
+
+  test("falls back to removing the reaction once the turn is no longer running", async () => {
+    callSlackApiMock
+      .mockImplementationOnce(async () => {
+        throw new Error("missing_scope");
+      })
+      .mockImplementationOnce(async () => ({ ok: true }));
+
+    await sendSlackAgentSessionStatus({
+      channel: "C123",
+      phase: "idle",
+      threadTs,
+    });
+
+    expect(callSlackApiMock).toHaveBeenNthCalledWith(2, "reactions.remove", {
+      channel: "C123",
+      name: "eyes",
+      timestamp: threadTs,
+    });
+  });
+
+  test("stays quiet when the status fails and there is nothing to react to", async () => {
+    callSlackApiMock.mockImplementationOnce(async () => {
+      throw new Error("missing_scope");
+    });
+
+    await sendSlackAgentSessionStatus({ channel: "D123", phase: "thinking" });
+
+    expect(callSlackApiMock).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/assistant/src/messaging/providers/slack/send.ts
+++ b/assistant/src/messaging/providers/slack/send.ts
@@ -403,7 +403,9 @@ const SLACK_SESSION_STATUS: Record<
  * passed on every call and Slack ignores it after the first.
  *
  * Falls back to an emoji reaction on failure, which is all a workspace that
- * denies the scope can show.
+ * denies the scope can show. Reports whether the session status itself landed,
+ * because a caller that owes a terminal transition has to know it was lost: the
+ * reaction cannot clear a status the API already set.
  */
 export async function sendSlackAgentSessionStatus(params: {
   channel: string;
@@ -413,7 +415,7 @@ export async function sendSlackAgentSessionStatus(params: {
   /** The message that opened the turn, used only by the reaction fallback. */
   messageTs?: string;
   initiatorUserId?: string;
-}): Promise<void> {
+}): Promise<boolean> {
   const { channel, phase, threadTs, messageTs, initiatorUserId } = params;
   const status = SLACK_SESSION_STATUS[phase];
   try {
@@ -423,7 +425,7 @@ export async function sendSlackAgentSessionStatus(params: {
       ...(threadTs ? { thread_ts: threadTs } : {}),
       ...(initiatorUserId ? { initiator_user_id: initiatorUserId } : {}),
     });
-    return;
+    return true;
   } catch {
     log.warn(
       { channel, status },
@@ -433,7 +435,7 @@ export async function sendSlackAgentSessionStatus(params: {
 
   const reactionTarget = threadTs ?? messageTs;
   if (!reactionTarget) {
-    return;
+    return false;
   }
   await sendSlackReaction(
     channel,
@@ -441,6 +443,7 @@ export async function sendSlackAgentSessionStatus(params: {
     reactionTarget,
     status === "processing" ? "add" : "remove",
   );
+  return false;
 }
 
 export type SlackAttachmentResult = {

--- a/assistant/src/messaging/providers/slack/send.ts
+++ b/assistant/src/messaging/providers/slack/send.ts
@@ -2,8 +2,8 @@
  * Slack outbound message orchestration.
  *
  * Handles text + Block Kit delivery, message updates, approval prompts,
- * typing indicators, reactions, thread status, ephemeral messages, and
- * attachments by calling the Slack Web API directly via ./api.ts.
+ * agent session status, reactions, ephemeral messages, and attachments by
+ * calling the Slack Web API directly via ./api.ts.
  */
 
 import type { Button, KnownBlock } from "@slack/types";
@@ -13,6 +13,7 @@ import type {
   SlackStreamOp,
 } from "@vellumai/gateway-client";
 
+import type { AssistantActivityPhase } from "../../../api/index.js";
 import { getAttachmentContent } from "../../../persistence/attachments-store.js";
 import type { RuntimeAttachmentMetadata } from "../../../runtime/http-types.js";
 import { getLogger } from "../../../util/logger.js";
@@ -210,11 +211,6 @@ function buildApprovalFallbackText(
 }
 
 /**
- * Post a Slack text message with optional Block Kit formatting.
- *
- * Always posts. Replacing an existing message is {@link updateSlackMessage}.
- */
-/**
  * Replace a Slack message in place via `chat.update`.
  *
  * A failed update throws rather than posting a fresh message, mirroring
@@ -244,6 +240,11 @@ export async function updateSlackMessage(
   return result;
 }
 
+/**
+ * Post a Slack text message with optional Block Kit formatting.
+ *
+ * Always posts. Replacing an existing message is {@link updateSlackMessage}.
+ */
 export async function sendSlackReply(
   chatId: string,
   text: string,
@@ -376,37 +377,70 @@ export async function sendSlackReaction(
   }
 }
 
-/**
- * Set or clear the Slack Assistants API thread status indicator.
- * Falls back to emoji reactions for installs without `assistant:write` scope.
- */
-export async function sendSlackAssistantThreadStatus(
-  channel: string,
-  threadTs: string,
-  status: string,
-  loadingMessages?: readonly string[],
-): Promise<void> {
-  try {
-    const body: Record<string, unknown> = {
-      channel_id: channel,
-      thread_ts: threadTs,
-      status,
-    };
-    if (loadingMessages !== undefined) {
-      body.loading_messages = loadingMessages;
-    }
+/** How Slack spells each activity phase on an agent session. */
+const SLACK_SESSION_STATUS: Record<
+  AssistantActivityPhase,
+  "active" | "processing" | "suspended"
+> = {
+  idle: "active",
+  thinking: "processing",
+  streaming: "processing",
+  tool_running: "processing",
+  // Slack's own word for a session waiting on a person, which is what an
+  // approval is. It suppresses the stop button, which would otherwise offer to
+  // cancel a turn that is not running.
+  awaiting_confirmation: "suspended",
+};
 
-    await callSlackApi("assistant.threads.setStatus", body);
+/**
+ * Set the status of the Slack agent session for a thread.
+ *
+ * `active` is a real transition rather than a clear: the loading UX stays up
+ * for an hour if a turn ends without one, so every caller that sets a busy
+ * phase owes an `idle`.
+ *
+ * `initiator_user_id` is read only when Slack creates the session, so it is
+ * passed on every call and Slack ignores it after the first.
+ *
+ * Falls back to an emoji reaction on failure, which is all a workspace that
+ * denies the scope can show.
+ */
+export async function sendSlackAgentSessionStatus(params: {
+  channel: string;
+  phase: AssistantActivityPhase;
+  /** Thread root, absent in a DM the app has not threaded. */
+  threadTs?: string;
+  /** The message that opened the turn, used only by the reaction fallback. */
+  messageTs?: string;
+  initiatorUserId?: string;
+}): Promise<void> {
+  const { channel, phase, threadTs, messageTs, initiatorUserId } = params;
+  const status = SLACK_SESSION_STATUS[phase];
+  try {
+    await callSlackApi("agents.sessions.setStatus", {
+      channel_id: channel,
+      status,
+      ...(threadTs ? { thread_ts: threadTs } : {}),
+      ...(initiatorUserId ? { initiator_user_id: initiatorUserId } : {}),
+    });
     return;
   } catch {
     log.warn(
-      { channel },
-      "Slack assistant.threads.setStatus failed, falling back to reaction",
+      { channel, status },
+      "Slack agents.sessions.setStatus failed, falling back to reaction",
     );
   }
 
-  const isSet = status.length > 0;
-  await sendSlackReaction(channel, "eyes", threadTs, isSet ? "add" : "remove");
+  const reactionTarget = threadTs ?? messageTs;
+  if (!reactionTarget) {
+    return;
+  }
+  await sendSlackReaction(
+    channel,
+    "eyes",
+    reactionTarget,
+    status === "processing" ? "add" : "remove",
+  );
 }
 
 export type SlackAttachmentResult = {

--- a/assistant/src/messaging/providers/slack/transport.ts
+++ b/assistant/src/messaging/providers/slack/transport.ts
@@ -4,7 +4,7 @@ import { ChannelDeliveryError } from "@vellumai/gateway-client/http-delivery";
 import { getLogger } from "../../../util/logger.js";
 import type { ChannelTransport } from "../channel-transport.js";
 import {
-  sendSlackAssistantThreadStatus,
+  sendSlackAgentSessionStatus,
   sendSlackAttachments,
   sendSlackReaction,
   sendSlackReply,
@@ -84,13 +84,14 @@ export const slackTransport: ChannelTransport = {
     return { ok: true };
   },
 
-  async setThreadStatus(_ctx, status) {
-    await sendSlackAssistantThreadStatus(
-      status.chatId,
-      status.threadTs,
-      status.status,
-      status.loadingMessages,
-    );
+  async setActivity(ctx, target) {
+    await sendSlackAgentSessionStatus({
+      channel: target.chatId,
+      phase: target.phase,
+      threadTs: ctx.params.threadTs,
+      messageTs: ctx.params.messageTs,
+      initiatorUserId: target.initiatorUserId,
+    });
     return { ok: true };
   },
 

--- a/assistant/src/messaging/providers/slack/transport.ts
+++ b/assistant/src/messaging/providers/slack/transport.ts
@@ -6,7 +6,6 @@ import type { ChannelTransport } from "../channel-transport.js";
 import {
   sendSlackAgentSessionStatus,
   sendSlackAttachments,
-  sendSlackReaction,
   sendSlackReply,
   sendSlackStreamOp,
   updateSlackMessage,
@@ -74,25 +73,15 @@ export const slackTransport: ChannelTransport = {
     return { ok: true, ts: result.ts };
   },
 
-  async react(_ctx, target) {
-    await sendSlackReaction(
-      target.chatId,
-      target.emoji,
-      target.messageId,
-      target.action,
-    );
-    return { ok: true };
-  },
-
   async setActivity(ctx, target) {
-    await sendSlackAgentSessionStatus({
+    const ok = await sendSlackAgentSessionStatus({
       channel: target.chatId,
       phase: target.phase,
       threadTs: ctx.params.threadTs,
       messageTs: ctx.params.messageTs,
       initiatorUserId: target.initiatorUserId,
     });
-    return { ok: true };
+    return { ok };
   },
 
   async streamReply(_ctx, chatId, op) {

--- a/assistant/src/messaging/providers/telegram-bot/send.test.ts
+++ b/assistant/src/messaging/providers/telegram-bot/send.test.ts
@@ -273,7 +273,10 @@ describe("telegramTransport topic targeting", () => {
   });
 
   test("typing indicators target the topic", async () => {
-    await telegramTransport.typing!(topicCtx, "123");
+    await telegramTransport.setActivity!(topicCtx, {
+      chatId: "123",
+      phase: "thinking",
+    });
 
     expect(callTelegramBotApiMock).toHaveBeenCalledWith("sendChatAction", {
       chat_id: "123",
@@ -282,6 +285,21 @@ describe("telegramTransport topic targeting", () => {
     });
   });
 
+  // Telegram's chat action expires on its own, so a phase that is not running
+  // has nothing to say. Asserting the call count rather than the absence of a
+  // "stop" call is what catches a clearing request being invented later.
+  test.each(["idle", "awaiting_confirmation"] as const)(
+    "says nothing to Telegram for the %s phase",
+    async (phase) => {
+      await telegramTransport.setActivity!(topicCtx, {
+        chatId: "123",
+        phase,
+      });
+
+      expect(callTelegramBotApiMock).not.toHaveBeenCalled();
+    },
+  );
+
   test("a callback URL without threadId keeps sends thread-less", async () => {
     const bareCtx: CallbackContext = {
       callbackUrl: "/deliver/telegram",
@@ -289,7 +307,10 @@ describe("telegramTransport topic targeting", () => {
     };
 
     await telegramTransport.deliver(bareCtx, payload({ renderRichly: false }));
-    await telegramTransport.typing!(bareCtx, "123");
+    await telegramTransport.setActivity!(bareCtx, {
+      chatId: "123",
+      phase: "thinking",
+    });
 
     expect(callTelegramBotApiMock).toHaveBeenCalledWith("sendMessage", {
       chat_id: "123",

--- a/assistant/src/messaging/providers/telegram-bot/transport.ts
+++ b/assistant/src/messaging/providers/telegram-bot/transport.ts
@@ -5,6 +5,7 @@ import type {
   CallbackContext,
   ChannelTransport,
 } from "../channel-transport.js";
+import { isBusyActivityPhase } from "../channel-transport.js";
 import type { TelegramSendOptions } from "./send.js";
 import {
   editTelegramMessage,
@@ -27,6 +28,9 @@ function threadOptions(ctx: CallbackContext): TelegramSendOptions | undefined {
 
 export const telegramTransport: ChannelTransport = {
   channel: "telegram",
+
+  // Telegram clears a chat action after about five seconds.
+  activityRefreshMs: 4_000,
 
   async deliver(ctx, payload) {
     const { chatId, text, attachments, approval } = payload;
@@ -72,9 +76,17 @@ export const telegramTransport: ChannelTransport = {
     return { ok: true };
   },
 
-  async typing(ctx, chatId) {
-    await sendTelegramTypingIndicator(chatId, threadOptions(ctx));
-    log.debug({ chatId }, "Telegram typing indicator delivered (direct)");
+  async setActivity(ctx, target) {
+    // Telegram's chat action expires by itself after a few seconds, so a phase
+    // that is not running needs no clearing call.
+    if (!isBusyActivityPhase(target.phase)) {
+      return { ok: true };
+    }
+    await sendTelegramTypingIndicator(target.chatId, threadOptions(ctx));
+    log.debug(
+      { chatId: target.chatId, phase: target.phase },
+      "Telegram typing indicator delivered (direct)",
+    );
     return { ok: true };
   },
 };

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.test.ts
@@ -96,10 +96,20 @@ const sentStreamOps: Array<Record<string, unknown>> = [];
 let sendChannelStreamOpImpl: (
   op: Record<string, unknown>,
 ) => Promise<{ ok: boolean; ts?: string }> = async () => ({ ok: true });
-const sentThreadStatuses: Array<Record<string, unknown>> = [];
+const sentActivity: Array<Record<string, unknown>> = [];
 mock.module("../../../messaging/providers/index.js", () => ({
-  sendChannelTyping: async () => ({ ok: true }),
-  supportsChannelTyping: () => false,
+  supportsChannelActivity: () => true,
+  // Undefined stands for a channel whose indicator holds until it is changed,
+  // so the controller reports each phase once and the assertions below read as
+  // the turn's lifecycle rather than as timer ticks.
+  channelActivityRefreshMs: () => undefined,
+  setChannelActivity: async (
+    _callbackUrl: string,
+    target: Record<string, unknown>,
+  ) => {
+    sentActivity.push(target);
+    return { ok: true };
+  },
   sendChannelStreamOp: async (
     _callbackUrl: string,
     _chatId: string,
@@ -107,13 +117,6 @@ mock.module("../../../messaging/providers/index.js", () => ({
   ) => {
     sentStreamOps.push(op);
     return sendChannelStreamOpImpl(op);
-  },
-  setChannelThreadStatus: async (
-    _callbackUrl: string,
-    status: Record<string, unknown>,
-  ) => {
-    sentThreadStatuses.push(status);
-    return { ok: true };
   },
   sendChannelReaction: async (
     callbackUrl: string,
@@ -154,8 +157,8 @@ import type { MessageProcessor } from "../../http-types.js";
 import {
   isBoundGuardianActor,
   processChannelMessageInBackground,
-  shouldStartSlackThinkingStatusForText,
-  shouldStartSlackThinkingStatusImmediately,
+  shouldShowActivityForText,
+  shouldShowActivityImmediately,
 } from "./background-dispatch.js";
 import { __resetChannelTurnAdmissionForTests } from "./channel-turn-admission.js";
 
@@ -166,7 +169,7 @@ beforeEach(() => {
   sentReactions.length = 0;
   sentStreamOps.length = 0;
   sendChannelStreamOpImpl = async () => ({ ok: true });
-  sentThreadStatuses.length = 0;
+  sentActivity.length = 0;
   markedProcessedEvents.length = 0;
   processingFailureEvents.length = 0;
   retryableFailureEvents.length = 0;
@@ -893,13 +896,7 @@ describe("processChannelMessageInBackground — admission (queue if busy)", () =
   });
 });
 
-describe("Slack thinking status timing", () => {
-  const slackStatusLabels = [
-    "is on it",
-    "is working hard",
-    "is touching grass",
-  ];
-
+describe("channel activity timing", () => {
   const trustCtx: TrustContext = {
     trustClass: "guardian",
     guardianExternalUserId: "guardian-1",
@@ -909,73 +906,49 @@ describe("Slack thinking status timing", () => {
   const flush = (): Promise<void> =>
     new Promise((resolve) => setTimeout(resolve, 10));
 
+  const phases = (): unknown[] =>
+    sentActivity.map((entry) => (entry as { phase?: unknown }).phase);
+
   beforeEach(() => {
     deliveredChannelReplies.length = 0;
   });
 
-  test("recognizes only deliverable text as a Slack thinking-status trigger", () => {
-    expect(shouldStartSlackThinkingStatusForText("")).toBe(false);
-    expect(shouldStartSlackThinkingStatusForText("   ")).toBe(false);
-    expect(shouldStartSlackThinkingStatusForText("<")).toBe(false);
-    expect(shouldStartSlackThinkingStatusForText("<no_response")).toBe(false);
-    expect(shouldStartSlackThinkingStatusForText("<no_response/>")).toBe(false);
-    expect(shouldStartSlackThinkingStatusForText("  <no_response />  ")).toBe(
-      false,
+  test("recognizes only deliverable text as a reason to show activity", () => {
+    expect(shouldShowActivityForText("")).toBe(false);
+    expect(shouldShowActivityForText("   ")).toBe(false);
+    expect(shouldShowActivityForText("<")).toBe(false);
+    expect(shouldShowActivityForText("<no_response")).toBe(false);
+    expect(shouldShowActivityForText("<no_response/>")).toBe(false);
+    expect(shouldShowActivityForText("  <no_response />  ")).toBe(false);
+    expect(shouldShowActivityForText("Real response.")).toBe(true);
+    expect(shouldShowActivityForText("<no_response/>\nReal response.")).toBe(
+      true,
     );
-    expect(shouldStartSlackThinkingStatusForText("Real response.")).toBe(true);
-    expect(
-      shouldStartSlackThinkingStatusForText("<no_response/>\nReal response."),
-    ).toBe(true);
   });
 
-  test("starts Slack thinking status immediately for DMs and direct mentions", () => {
-    expect(
-      shouldStartSlackThinkingStatusImmediately({
-        sourceChannel: "slack",
-        chatType: "im",
-      }),
-    ).toBe(true);
-    expect(
-      shouldStartSlackThinkingStatusImmediately({
-        sourceChannel: "slack",
-        slackBotMentioned: true,
-      }),
-    ).toBe(true);
-    expect(
-      shouldStartSlackThinkingStatusImmediately({
-        sourceChannel: "slack",
-        chatType: "channel",
-      }),
-    ).toBe(false);
-    expect(
-      shouldStartSlackThinkingStatusImmediately({
-        sourceChannel: "telegram",
-        chatType: "im",
-        slackBotMentioned: true,
-      }),
-    ).toBe(false);
+  test("shows activity immediately only when the assistant was addressed", () => {
+    expect(shouldShowActivityImmediately({ chatType: "im" })).toBe(true);
+    expect(shouldShowActivityImmediately({ botMentioned: true })).toBe(true);
+    expect(shouldShowActivityImmediately({ chatType: "channel" })).toBe(false);
+    expect(shouldShowActivityImmediately({})).toBe(false);
   });
 
-  test("sets Slack thinking indicator immediately for a DM", async () => {
-    const conversationId = "conv-dm-immediate-status";
+  test("shows activity immediately in a DM and settles it when the turn ends", async () => {
+    const conversationId = "conv-dm-immediate-activity";
     const channelId = "D-DM-IMMEDIATE";
     const messageTs = "1700000000.000010";
 
     const processMessage: MessageProcessor = async () => {
-      expect(sentReactions).toHaveLength(1);
-      expect(sentReactions[0]!.target).toEqual({
-        chatId: channelId,
-        messageId: messageTs,
-        emoji: "eyes",
-        action: "add",
-      });
+      // Already showing before the turn does any work: a DM is addressed to
+      // the assistant, so nothing needs to be observed first.
+      expect(phases()).toEqual(["thinking"]);
       return { messageId: "user-msg-dm-immediate" };
     };
 
     processChannelMessageInBackground({
       processMessage,
       conversationId,
-      eventId: "evt-dm-immediate-status",
+      eventId: "evt-dm-immediate-activity",
       content: "dm message",
       sourceChannel: "slack",
       sourceInterface: "slack",
@@ -988,39 +961,27 @@ describe("Slack thinking status timing", () => {
 
     await flush();
 
-    expect(sentReactions.map((entry) => entry.target)).toEqual([
-      { chatId: channelId, messageId: messageTs, emoji: "eyes", action: "add" },
-      {
-        chatId: channelId,
-        messageId: messageTs,
-        emoji: "eyes",
-        action: "remove",
-      },
-    ]);
+    // `idle` is owed explicitly. A channel that holds its indicator keeps it
+    // up until told otherwise, so a missing terminal phase is a stuck spinner
+    // rather than a cosmetic slip.
+    expect(phases()).toEqual(["thinking", "idle"]);
+    expect(sentActivity[0]).toEqual({ chatId: channelId, phase: "thinking" });
   });
 
-  test("sets Slack thinking status immediately for an app mention", async () => {
-    const conversationId = "conv-mention-immediate-status";
+  test("shows activity immediately for an app mention and settles it", async () => {
+    const conversationId = "conv-mention-immediate-activity";
     const channelId = "C-MENTION-IMMEDIATE";
     const threadTs = "1700000000.000011";
 
     const processMessage: MessageProcessor = async () => {
-      expect(sentThreadStatuses).toHaveLength(1);
-      expect(sentThreadStatuses[0]).toEqual({
-        chatId: channelId,
-        threadTs,
-        status: expect.any(String),
-        loadingMessages: ["Thinking\u2026"],
-      });
-      const threadStatus = sentThreadStatuses[0] as { status: string };
-      expect(slackStatusLabels).toContain(threadStatus.status);
+      expect(phases()).toEqual(["thinking"]);
       return { messageId: "user-msg-mention-immediate" };
     };
 
     processChannelMessageInBackground({
       processMessage,
       conversationId,
-      eventId: "evt-mention-immediate-status",
+      eventId: "evt-mention-immediate-activity",
       content: "@assistant please respond",
       sourceChannel: "slack",
       sourceInterface: "slack",
@@ -1033,15 +994,11 @@ describe("Slack thinking status timing", () => {
 
     await flush();
 
-    const statuses = sentThreadStatuses.map(
-      (entry) => (entry as { status?: string }).status,
-    );
-    expect(slackStatusLabels).toContain(statuses[0]!);
-    expect(statuses[1]).toBe("");
+    expect(phases()).toEqual(["thinking", "idle"]);
   });
 
-  test("does not set Slack thinking status for no_response text deltas", async () => {
-    const conversationId = "conv-no-response-status";
+  test("stays silent for a turn that decides not to answer", async () => {
+    const conversationId = "conv-no-response-activity";
     const channelId = "C-NO-RESPONSE";
     const threadTs = "1700000000.000003";
 
@@ -1061,7 +1018,7 @@ describe("Slack thinking status timing", () => {
     processChannelMessageInBackground({
       processMessage,
       conversationId,
-      eventId: "evt-no-response-status",
+      eventId: "evt-no-response-activity",
       content: "ambient channel chatter",
       sourceChannel: "slack",
       sourceInterface: "slack",
@@ -1073,11 +1030,15 @@ describe("Slack thinking status timing", () => {
 
     await flush();
 
+    // Not merely "no spinner": nothing at all was said to the channel. An
+    // `idle` here would still be a message about a turn nobody asked to see,
+    // and in a shared room it announces that the assistant read the traffic.
+    expect(sentActivity).toEqual([]);
     expect(deliveredChannelReplies).toEqual([]);
   });
 
-  test("sets and clears Slack thinking status after real assistant text starts", async () => {
-    const conversationId = "conv-real-response-status";
+  test("waits for real text in a room it was not addressed in, then settles", async () => {
+    const conversationId = "conv-real-response-activity";
     const channelId = "C-REAL-RESPONSE";
     const threadTs = "1700000000.000004";
 
@@ -1091,20 +1052,22 @@ describe("Slack thinking status timing", () => {
         text: "<",
         conversationId,
       });
-      expect(deliveredChannelReplies).toEqual([]);
+      // A partial `<` could still become `<no_response/>`, so nothing shows.
+      expect(sentActivity).toEqual([]);
 
       options?.onEvent?.({
         type: "assistant_text_delta",
         text: "b>Working on it.",
         conversationId,
       });
+      expect(phases()).toEqual(["thinking"]);
       return { messageId: "user-msg-real-response" };
     };
 
     processChannelMessageInBackground({
       processMessage,
       conversationId,
-      eventId: "evt-real-response-status",
+      eventId: "evt-real-response-activity",
       content: "please respond",
       sourceChannel: "slack",
       sourceInterface: "slack",
@@ -1116,222 +1079,6 @@ describe("Slack thinking status timing", () => {
 
     await flush();
 
-    const statuses = sentThreadStatuses.map(
-      (entry) => (entry as { status?: string }).status,
-    );
-    expect(slackStatusLabels).toContain(statuses[0]!);
-    expect(statuses[1]).toBe("");
-  });
-
-  test("buffers task_progress for ambiguous Slack turns until deliverable text appears", async () => {
-    const conversationId = "conv-progress-buffered";
-    const channelId = "C-PROGRESS-BUFFERED";
-    const threadTs = "1700000000.000012";
-
-    const processMessage: MessageProcessor = async (
-      _conversationId,
-      _content,
-      options,
-    ) => {
-      options?.onEvent?.({
-        type: "ui_surface_show",
-        conversationId,
-        surfaceId: "surface-progress",
-        surfaceType: "card",
-        data: {
-          title: "Task progress",
-          body: "Working",
-          template: "task_progress",
-          templateData: {
-            steps: [
-              { label: "Search docs", status: "in_progress" },
-              { label: "Summarize", status: "pending" },
-            ],
-          },
-        },
-      });
-      expect(deliveredChannelReplies).toEqual([]);
-
-      options?.onEvent?.({
-        type: "assistant_text_delta",
-        text: "I found the answer.",
-        conversationId,
-      });
-      return { messageId: "user-msg-progress-buffered" };
-    };
-
-    processChannelMessageInBackground({
-      processMessage,
-      conversationId,
-      eventId: "evt-progress-buffered",
-      content: "ambient request",
-      sourceChannel: "slack",
-      sourceInterface: "slack",
-      externalChatId: channelId,
-      trustCtx,
-      metadataHints: [],
-      replyCallbackUrl: `https://example.test/deliver/slack?channel=${channelId}&threadTs=${threadTs}`,
-    });
-
-    await flush();
-
-    const statuses = sentThreadStatuses;
-    expect(statuses).toEqual([
-      {
-        chatId: channelId,
-        threadTs,
-        status: expect.any(String),
-        loadingMessages: ["In progress (1/2): Search docs"],
-      },
-      {
-        chatId: channelId,
-        threadTs,
-        status: "",
-      },
-    ]);
-    expect(slackStatusLabels).toContain(
-      (statuses[0] as { status: string }).status,
-    );
-  });
-
-  test("keeps ambiguous Slack no_response turns quiet even with task_progress", async () => {
-    const conversationId = "conv-progress-no-response";
-    const channelId = "C-PROGRESS-NO-RESPONSE";
-    const threadTs = "1700000000.000013";
-
-    const processMessage: MessageProcessor = async (
-      _conversationId,
-      _content,
-      options,
-    ) => {
-      options?.onEvent?.({
-        type: "ui_surface_show",
-        conversationId,
-        surfaceId: "surface-progress-no-response",
-        surfaceType: "card",
-        data: {
-          title: "Task progress",
-          body: "Working",
-          template: "task_progress",
-          templateData: {
-            steps: [{ label: "Inspect", status: "in_progress" }],
-          },
-        },
-      });
-      options?.onEvent?.({
-        type: "assistant_text_delta",
-        text: "<no_response/>",
-        conversationId,
-      });
-      return { messageId: "user-msg-progress-no-response" };
-    };
-
-    processChannelMessageInBackground({
-      processMessage,
-      conversationId,
-      eventId: "evt-progress-no-response",
-      content: "ambient chatter",
-      sourceChannel: "slack",
-      sourceInterface: "slack",
-      externalChatId: channelId,
-      trustCtx,
-      metadataHints: [],
-      replyCallbackUrl: `https://example.test/deliver/slack?channel=${channelId}&threadTs=${threadTs}`,
-    });
-
-    await flush();
-
-    expect(deliveredChannelReplies).toEqual([]);
-  });
-
-  test("updates Slack loading message when task_progress changes", async () => {
-    const conversationId = "conv-progress-update";
-    const channelId = "C-PROGRESS-UPDATE";
-    const threadTs = "1700000000.000014";
-
-    const processMessage: MessageProcessor = async (
-      _conversationId,
-      _content,
-      options,
-    ) => {
-      options?.onEvent?.({
-        type: "ui_surface_show",
-        conversationId,
-        surfaceId: "surface-progress-update",
-        surfaceType: "card",
-        data: {
-          title: "Task progress",
-          body: "Working",
-          template: "task_progress",
-          templateData: {
-            steps: [
-              { label: "Read request", status: "in_progress" },
-              { label: "Write answer", status: "pending" },
-            ],
-          },
-        },
-      });
-      options?.onEvent?.({
-        type: "assistant_text_delta",
-        text: "On it.",
-        conversationId,
-      });
-      options?.onEvent?.({
-        type: "ui_surface_update",
-        conversationId,
-        surfaceId: "surface-progress-update",
-        data: {
-          templateData: {
-            steps: [
-              { label: "Read request", status: "completed" },
-              { label: "Write answer", status: "in_progress" },
-            ],
-          },
-        },
-      });
-      return { messageId: "user-msg-progress-update" };
-    };
-
-    processChannelMessageInBackground({
-      processMessage,
-      conversationId,
-      eventId: "evt-progress-update",
-      content: "please respond",
-      sourceChannel: "slack",
-      sourceInterface: "slack",
-      externalChatId: channelId,
-      trustCtx,
-      metadataHints: [],
-      replyCallbackUrl: `https://example.test/deliver/slack?channel=${channelId}&threadTs=${threadTs}`,
-    });
-
-    await flush();
-
-    const statuses = sentThreadStatuses;
-    expect(statuses).toEqual([
-      {
-        chatId: channelId,
-        threadTs,
-        status: expect.any(String),
-        loadingMessages: ["In progress (1/2): Read request"],
-      },
-      {
-        chatId: channelId,
-        threadTs,
-        status: expect.any(String),
-        loadingMessages: ["In progress (2/2): Write answer"],
-      },
-      {
-        chatId: channelId,
-        threadTs,
-        status: "",
-      },
-    ]);
-    expect(slackStatusLabels).toContain(
-      (statuses[0] as { status: string }).status,
-    );
-    expect(slackStatusLabels).toContain(
-      (statuses[1] as { status: string }).status,
-    );
+    expect(phases()).toEqual(["thinking", "idle"]);
   });
 });

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.test.ts
@@ -97,6 +97,9 @@ let sendChannelStreamOpImpl: (
   op: Record<string, unknown>,
 ) => Promise<{ ok: boolean; ts?: string }> = async () => ({ ok: true });
 const sentActivity: Array<Record<string, unknown>> = [];
+let setChannelActivityImpl: (target: Record<string, unknown>) => {
+  ok: boolean;
+} = () => ({ ok: true });
 mock.module("../../../messaging/providers/index.js", () => ({
   supportsChannelActivity: () => true,
   // Undefined stands for a channel whose indicator holds until it is changed,
@@ -108,7 +111,7 @@ mock.module("../../../messaging/providers/index.js", () => ({
     target: Record<string, unknown>,
   ) => {
     sentActivity.push(target);
-    return { ok: true };
+    return setChannelActivityImpl(target);
   },
   sendChannelStreamOp: async (
     _callbackUrl: string,
@@ -170,6 +173,7 @@ beforeEach(() => {
   sentStreamOps.length = 0;
   sendChannelStreamOpImpl = async () => ({ ok: true });
   sentActivity.length = 0;
+  setChannelActivityImpl = () => ({ ok: true });
   markedProcessedEvents.length = 0;
   processingFailureEvents.length = 0;
   retryableFailureEvents.length = 0;
@@ -926,11 +930,36 @@ describe("channel activity timing", () => {
     );
   });
 
-  test("shows activity immediately only when the assistant was addressed", () => {
+  test("recognizes a direct conversation in every channel's word for one", () => {
+    // One idea, three spellings, because `chatType` arrives as whatever the
+    // channel called it. Slack `im`, Discord `dm`, Telegram `private`. Missing
+    // one does not fail loudly: that channel silently reads as an ambient room
+    // and stops showing an indicator it used to show.
     expect(shouldShowActivityImmediately({ chatType: "im" })).toBe(true);
-    expect(shouldShowActivityImmediately({ botMentioned: true })).toBe(true);
+    expect(shouldShowActivityImmediately({ chatType: "dm" })).toBe(true);
+    expect(shouldShowActivityImmediately({ chatType: "private" })).toBe(true);
+  });
+
+  test("treats a room with other readers as ambient, including a group DM", () => {
+    // Slack's `mpim` has other readers, so it is a room: the assistant may
+    // process the traffic and decide to stay quiet, and an indicator there
+    // announces it was reading.
+    expect(shouldShowActivityImmediately({ chatType: "mpim" })).toBe(false);
     expect(shouldShowActivityImmediately({ chatType: "channel" })).toBe(false);
+    expect(shouldShowActivityImmediately({ chatType: "supergroup" })).toBe(
+      false,
+    );
     expect(shouldShowActivityImmediately({})).toBe(false);
+  });
+
+  test("shows activity immediately when the assistant is mentioned", () => {
+    expect(shouldShowActivityImmediately({ botMentioned: true })).toBe(true);
+    expect(
+      shouldShowActivityImmediately({
+        chatType: "channel",
+        botMentioned: true,
+      }),
+    ).toBe(true);
   });
 
   test("shows activity immediately in a DM and settles it when the turn ends", async () => {
@@ -995,6 +1024,40 @@ describe("channel activity timing", () => {
     await flush();
 
     expect(phases()).toEqual(["thinking", "idle"]);
+  });
+
+  test("retries a terminal transition the channel failed to accept", async () => {
+    const conversationId = "conv-idle-retry";
+    const channelId = "D-IDLE-RETRY";
+    let idleAttempts = 0;
+    setChannelActivityImpl = (target) => {
+      if (target.phase === "idle") {
+        idleAttempts += 1;
+        return { ok: idleAttempts > 1 };
+      }
+      return { ok: true };
+    };
+
+    processChannelMessageInBackground({
+      processMessage: async () => ({ messageId: "user-msg-idle-retry" }),
+      conversationId,
+      eventId: "evt-idle-retry",
+      content: "dm message",
+      sourceChannel: "slack",
+      sourceInterface: "slack",
+      externalChatId: channelId,
+      trustCtx,
+      metadataHints: [],
+      chatType: "im",
+      replyCallbackUrl: `https://example.test/deliver/slack?channel=${channelId}&messageTs=1700000000.000020`,
+    });
+
+    await flush();
+
+    // A dropped `idle` is not cosmetic on a channel that holds its indicator:
+    // Slack keeps showing the assistant as working for an hour, so the
+    // terminal transition is the one worth attempting twice.
+    expect(idleAttempts).toBe(2);
   });
 
   test("stays silent for a turn that decides not to answer", async () => {

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.test.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.test.ts
@@ -88,24 +88,22 @@ mock.module("../../gateway-client.js", () => ({
   },
 }));
 
-const sentReactions: Array<{
-  callbackUrl: string;
-  target: Record<string, unknown>;
-}> = [];
 const sentStreamOps: Array<Record<string, unknown>> = [];
 let sendChannelStreamOpImpl: (
   op: Record<string, unknown>,
 ) => Promise<{ ok: boolean; ts?: string }> = async () => ({ ok: true });
 const sentActivity: Array<Record<string, unknown>> = [];
-let setChannelActivityImpl: (target: Record<string, unknown>) => {
-  ok: boolean;
-} = () => ({ ok: true });
+let setChannelActivityImpl: (
+  target: Record<string, unknown>,
+) => { ok: boolean } | Promise<{ ok: boolean }> = () => ({ ok: true });
+// Undefined stands for a channel whose indicator holds until it is changed, so
+// the controller reports each phase once and the assertions read as the turn's
+// lifecycle rather than as timer ticks. A test that needs the self-expiring
+// shape sets a cadence.
+let activityRefreshMsImpl: () => number | undefined = () => undefined;
 mock.module("../../../messaging/providers/index.js", () => ({
   supportsChannelActivity: () => true,
-  // Undefined stands for a channel whose indicator holds until it is changed,
-  // so the controller reports each phase once and the assertions below read as
-  // the turn's lifecycle rather than as timer ticks.
-  channelActivityRefreshMs: () => undefined,
+  channelActivityRefreshMs: () => activityRefreshMsImpl(),
   setChannelActivity: async (
     _callbackUrl: string,
     target: Record<string, unknown>,
@@ -120,13 +118,6 @@ mock.module("../../../messaging/providers/index.js", () => ({
   ) => {
     sentStreamOps.push(op);
     return sendChannelStreamOpImpl(op);
-  },
-  sendChannelReaction: async (
-    callbackUrl: string,
-    target: Record<string, unknown>,
-  ) => {
-    sentReactions.push({ callbackUrl, target });
-    return { ok: true };
   },
 }));
 
@@ -169,11 +160,11 @@ beforeEach(() => {
   __resetChannelTurnAdmissionForTests();
   clearConversations();
   deliveredChannelReplies.length = 0;
-  sentReactions.length = 0;
   sentStreamOps.length = 0;
   sendChannelStreamOpImpl = async () => ({ ok: true });
   sentActivity.length = 0;
   setChannelActivityImpl = () => ({ ok: true });
+  activityRefreshMsImpl = () => undefined;
   markedProcessedEvents.length = 0;
   processingFailureEvents.length = 0;
   retryableFailureEvents.length = 0;
@@ -1058,6 +1049,63 @@ describe("channel activity timing", () => {
     // Slack keeps showing the assistant as working for an hour, so the
     // terminal transition is the one worth attempting twice.
     expect(idleAttempts).toBe(2);
+  });
+
+  test("runs idle next when the turn stops during a slow request, with no stale busy phase between", async () => {
+    const conversationId = "conv-slow-refresh";
+    const channelId = "D-SLOW-REFRESH";
+
+    // A self-expiring channel re-asserts on a timer, which is the only shape
+    // where a refresh backlog can form at all.
+    activityRefreshMsImpl = () => 5;
+
+    let release: (() => void) | undefined;
+    let calls = 0;
+    setChannelActivityImpl = (target) => {
+      calls += 1;
+      if (calls === 1 && target.phase !== "idle") {
+        // Hold the first busy call open across many refresh intervals.
+        return new Promise<{ ok: boolean }>((resolve) => {
+          release = () => resolve({ ok: true });
+        });
+      }
+      return { ok: true };
+    };
+
+    const processMessage: MessageProcessor = async () => {
+      // Long enough for several ticks to fire while the first call is unresolved.
+      await new Promise((resolve) => setTimeout(resolve, 40));
+      return { messageId: "user-msg-slow-refresh" };
+    };
+
+    processChannelMessageInBackground({
+      processMessage,
+      conversationId,
+      eventId: "evt-slow-refresh",
+      content: "dm message",
+      sourceChannel: "slack",
+      sourceInterface: "slack",
+      externalChatId: channelId,
+      trustCtx,
+      metadataHints: [],
+      chatType: "im",
+      replyCallbackUrl: `https://example.test/deliver/slack?channel=${channelId}&messageTs=1700000000.000030`,
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 60));
+    release?.();
+    await flush();
+
+    const seen = phases();
+    // The terminal phase is last and nothing busy follows it. A busy phase
+    // executing after `idle` is the visible bug: the indicator comes back on a
+    // turn that has already replied, which teaches people to distrust it.
+    expect(seen.at(-1)).toBe("idle");
+    expect(seen.slice(seen.indexOf("idle") + 1)).toEqual([]);
+    // Ticks did not accumulate behind the outstanding call. Counting rather
+    // than checking the last entry is what catches a backlog that happens to
+    // drain in a harmless order.
+    expect(seen.filter((phase) => phase === "thinking")).toHaveLength(1);
   });
 
   test("stays silent for a turn that decides not to answer", async () => {

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
@@ -7,13 +7,11 @@
  * Extracted from inbound-message-handler.ts to keep the top-level handler
  * focused on orchestration.
  */
-import type { AssistantEvent } from "../../../api/index.js";
+import type {
+  AssistantActivityPhase,
+  AssistantEvent,
+} from "../../../api/index.js";
 import { resolveGuardianPromptDelivery } from "../../../approvals/guardian-channel-delivery.js";
-import {
-  extractMessageTsFromCallbackUrl,
-  extractThreadTsFromCallbackUrl,
-  isSlackDeliveryCallbackUrl,
-} from "../../../channels/slack-callback-url.js";
 import type { ChannelId, InterfaceId } from "../../../channels/types.js";
 import {
   getGuardianDelivery,
@@ -22,10 +20,9 @@ import {
 import { isConversationBusyError } from "../../../daemon/conversation-messaging.js";
 import type { TrustContext } from "../../../daemon/trust-context-types.js";
 import {
-  sendChannelReaction,
-  sendChannelTyping,
-  setChannelThreadStatus,
-  supportsChannelTyping,
+  channelActivityRefreshMs,
+  setChannelActivity,
+  supportsChannelActivity,
 } from "../../../messaging/providers/index.js";
 import {
   getSiblingStreamedReplyTs,
@@ -56,11 +53,6 @@ import type {
 } from "../../http-types.js";
 import { hasDeliverableAssistantText } from "../../no-response.js";
 import { createSlackReplySession } from "../../slack-reply-session.js";
-import type { TaskProgressData } from "../../slack-task-progress.js";
-import {
-  getTaskProgressDataFromSurfaceData,
-  mergeTaskProgressData,
-} from "../../slack-task-progress.js";
 import { isContactTrustClass } from "../../trust-class.js";
 import { resolveRoutingState } from "../../trust-context-resolver.js";
 import { finalizeEventDelivery } from "../channel-delivery-routes.js";
@@ -168,19 +160,14 @@ export function processChannelMessageInBackground(
   // `channel-turn-admission.ts` for why channel turns defer rather than route
   // through the SSE-oriented conversation queue.
   void withChannelTurnAdmission(conversationId, async () => {
-    const stopTypingHeartbeat =
-      replyCallbackUrl && supportsChannelTyping(replyCallbackUrl)
-        ? startTypingHeartbeat(replyCallbackUrl, externalChatId)
-        : undefined;
-
-    const slackThinkingStatus = createSlackThinkingStatusController({
-      sourceChannel,
+    const channelActivity = startChannelActivity({
       replyCallbackUrl,
+      conversationId,
       chatId: externalChatId,
-      startImmediately: shouldStartSlackThinkingStatusImmediately({
-        sourceChannel,
+      initiatorUserId: slackInbound?.actorExternalUserId,
+      startImmediately: shouldShowActivityImmediately({
         chatType,
-        slackBotMentioned,
+        botMentioned: slackBotMentioned,
       }),
     });
     const stopApprovalWatcher = replyCallbackUrl
@@ -244,7 +231,7 @@ export function processChannelMessageInBackground(
           replyMessageId = msg.messageId;
         }
         slackReplySession?.observeEvent(msg);
-        slackThinkingStatus?.observeEvent(msg);
+        channelActivity?.observeEvent(msg);
       };
 
       let userMessageId: string | undefined;
@@ -366,8 +353,7 @@ export function processChannelMessageInBackground(
         }
       }
     } finally {
-      stopTypingHeartbeat?.();
-      slackThinkingStatus?.stop();
+      channelActivity?.stop();
       stopApprovalWatcher?.();
       stopTcApprovalNotifier?.();
     }
@@ -380,361 +366,140 @@ export function processChannelMessageInBackground(
 }
 
 // ---------------------------------------------------------------------------
-// Telegram typing heartbeat
+// Channel activity indicator
 // ---------------------------------------------------------------------------
 
 /**
- * How often the working indicator is re-sent while a turn runs.
- *
- * Every channel that has one expires it after a few seconds and offers no
- * start/stop pair to hold it open, so showing it across a multi-second turn
- * means re-sending on a timer. The interval has to stay under the shortest
- * expiry of any channel that implements `typing`: Telegram is about five
- * seconds, Discord about ten. Anyone changing it should check the current
- * windows first.
- *
- * No explicit stop is needed: both clear the indicator when the bot posts.
- *
- * https://core.telegram.org/bots/api#sendchataction
- * https://discord.com/developers/docs/resources/channel#trigger-typing-indicator
+ * How often the phase is recomputed for a channel whose indicator holds until
+ * it is changed. Such a channel is only called when the phase actually moves,
+ * so this costs a comparison rather than a request.
  */
-const TYPING_INTERVAL_MS = 4_000;
+const ACTIVITY_PHASE_POLL_MS = 1_000;
 
-function startTypingHeartbeat(callbackUrl: string, chatId: string): () => void {
-  let active = true;
-  let inFlight = false;
-
-  const emitTyping = (): void => {
-    if (!active || inFlight) {
-      return;
-    }
-    inFlight = true;
-    void sendChannelTyping(callbackUrl, chatId)
-      .catch((err) => {
-        log.debug(
-          { err, chatId },
-          "Failed to deliver Telegram typing indicator",
-        );
-      })
-      .finally(() => {
-        inFlight = false;
-      });
-  };
-
-  emitTyping();
-
-  const interval = setInterval(emitTyping, TYPING_INTERVAL_MS);
-  (interval as { unref?: () => void }).unref?.();
-
-  return () => {
-    active = false;
-    clearInterval(interval);
-  };
-}
-
-// ---------------------------------------------------------------------------
-// Slack Assistants API thinking status indicator
-// ---------------------------------------------------------------------------
-
-type SlackThinkingStatusController = {
+type ChannelActivityController = {
   observeEvent: (msg: AssistantEvent) => void;
   stop: () => void;
 };
 
-type SlackThinkingStatusHandle = {
-  updateLoadingMessages: (loadingMessages?: string[]) => void;
-  clear: () => void;
-};
-
-export function shouldStartSlackThinkingStatusForText(text: string): boolean {
+export function shouldShowActivityForText(text: string): boolean {
   return hasDeliverableAssistantText(text);
 }
 
-function shouldEmitSlackThinkingStatus(
-  sourceChannel: ChannelId,
-  replyCallbackUrl?: string,
-): boolean {
-  return (
-    sourceChannel === "slack" && isSlackDeliveryCallbackUrl(replyCallbackUrl)
-  );
-}
-
-export function shouldStartSlackThinkingStatusImmediately(params: {
-  sourceChannel: ChannelId;
+/**
+ * Whether the assistant should show it is working before it has produced any
+ * text: it was addressed directly, so a reply is expected either way.
+ */
+export function shouldShowActivityImmediately(params: {
   chatType?: string;
-  slackBotMentioned?: boolean;
+  botMentioned?: boolean;
 }): boolean {
-  if (params.sourceChannel !== "slack") {
-    return false;
-  }
-  return params.chatType === "im" || params.slackBotMentioned === true;
+  return params.chatType === "im" || params.botMentioned === true;
 }
 
-function createSlackThinkingStatusController(params: {
-  sourceChannel: ChannelId;
+/**
+ * Drive one conversation's activity indicator for the length of a turn.
+ *
+ * The indicator is held back until the turn is known to be producing a reply,
+ * because a channel where the assistant was not addressed may process a
+ * message and decide to stay quiet, and an indicator there promises something
+ * that is not coming. Being addressed directly is enough on its own.
+ *
+ * TRANSITIONAL: the phase is derived here from what this dispatch knows, and
+ * the daemon already publishes the same lifecycle as `assistant_activity_state`
+ * with a monotonic version. That event reaches conversation observers rather
+ * than this turn's `onEvent`, so consuming it is its own change; until then
+ * this is a second derivation of one lifecycle and should not be extended.
+ */
+function startChannelActivity(params: {
   replyCallbackUrl?: string;
+  conversationId: string;
   chatId: string;
-  startImmediately?: boolean;
-}): SlackThinkingStatusController | undefined {
-  const { sourceChannel, replyCallbackUrl, chatId, startImmediately } = params;
-  if (
-    !replyCallbackUrl ||
-    !shouldEmitSlackThinkingStatus(sourceChannel, replyCallbackUrl)
-  ) {
+  initiatorUserId?: string;
+  startImmediately: boolean;
+}): ChannelActivityController | undefined {
+  const { replyCallbackUrl, conversationId, chatId, initiatorUserId } = params;
+  if (!replyCallbackUrl || !supportsChannelActivity(replyCallbackUrl)) {
     return undefined;
   }
-  const callbackUrl = replyCallbackUrl;
+  const url = replyCallbackUrl;
 
+  const refreshMs = channelActivityRefreshMs(url);
   let stopped = false;
-  let slackThinkingStatus: SlackThinkingStatusHandle | undefined;
+  let showing = false;
   let observedAssistantText = "";
-  let currentLoadingMessages: string[] | undefined = startImmediately
-    ? [...SLACK_GENERIC_LOADING_MESSAGES]
-    : undefined;
-  let lastSentLoadingMessageKey: string | undefined;
-  const taskProgressBySurfaceId = new Map<string, TaskProgressData>();
+  let lastPhase: AssistantActivityPhase | undefined;
 
-  const start = (): void => {
-    if (stopped || slackThinkingStatus) {
-      return;
-    }
-    slackThinkingStatus = setSlackThinkingStatus(
-      callbackUrl,
-      chatId,
-      currentLoadingMessages,
+  // Serialized so a later phase cannot overtake an earlier one and leave the
+  // channel showing a state the turn has already left.
+  let pending: Promise<unknown> = Promise.resolve();
+
+  const send = (phase: AssistantActivityPhase): void => {
+    lastPhase = phase;
+    pending = pending.then(() =>
+      setChannelActivity(url, {
+        chatId,
+        phase,
+        ...(initiatorUserId ? { initiatorUserId } : {}),
+      }).catch((err) => {
+        log.debug({ err, chatId, phase }, "Failed to set channel activity");
+      }),
     );
-    lastSentLoadingMessageKey = getLoadingMessagesKey(currentLoadingMessages);
   };
 
-  const maybeUpdateLoadingMessages = (): void => {
-    const nextLoadingMessageKey = getLoadingMessagesKey(currentLoadingMessages);
-    if (nextLoadingMessageKey === lastSentLoadingMessageKey) {
+  const currentPhase = (): AssistantActivityPhase =>
+    getApprovalInfoByConversation(conversationId).length > 0
+      ? "awaiting_confirmation"
+      : "thinking";
+
+  const tick = (): void => {
+    if (stopped || !showing) {
       return;
     }
-    lastSentLoadingMessageKey = nextLoadingMessageKey;
-    slackThinkingStatus?.updateLoadingMessages(currentLoadingMessages);
+    const phase = currentPhase();
+    // A channel whose indicator expires needs the same phase re-asserted; one
+    // that holds only needs to hear about a change.
+    if (phase !== lastPhase || refreshMs !== undefined) {
+      send(phase);
+    }
   };
 
-  const observeTaskProgress = (msg: AssistantEvent): void => {
-    if (msg.type === "ui_surface_show") {
-      const progress = getTaskProgressDataFromSurfaceData(msg.data);
-      if (!progress) {
-        return;
-      }
-      taskProgressBySurfaceId.set(msg.surfaceId, progress);
-    } else if (msg.type === "ui_surface_update") {
-      const existing = taskProgressBySurfaceId.get(msg.surfaceId);
-      const progress = mergeTaskProgressData(existing, msg.data);
-      if (!progress) {
-        return;
-      }
-      taskProgressBySurfaceId.set(msg.surfaceId, progress);
-    } else {
+  const interval = setInterval(tick, refreshMs ?? ACTIVITY_PHASE_POLL_MS);
+  (interval as { unref?: () => void }).unref?.();
+
+  const show = (): void => {
+    if (stopped || showing) {
       return;
     }
-
-    currentLoadingMessages =
-      getTaskProgressLoadingMessage(
-        taskProgressBySurfaceId.get(msg.surfaceId),
-      ) ?? [];
-    maybeUpdateLoadingMessages();
+    showing = true;
+    send(currentPhase());
   };
 
-  if (startImmediately) {
-    start();
+  if (params.startImmediately) {
+    show();
   }
 
   return {
     observeEvent(msg) {
-      if (stopped) {
+      if (stopped || showing || msg.type !== "assistant_text_delta") {
         return;
       }
-
-      if (msg.type === "ui_surface_show" || msg.type === "ui_surface_update") {
-        observeTaskProgress(msg);
-        return;
-      }
-
-      if (slackThinkingStatus || msg.type !== "assistant_text_delta") {
-        return;
-      }
-
       observedAssistantText += msg.text;
-      if (shouldStartSlackThinkingStatusForText(observedAssistantText)) {
-        start();
+      if (shouldShowActivityForText(observedAssistantText)) {
+        show();
       }
     },
     stop() {
-      stopped = true;
-      slackThinkingStatus?.clear();
-    },
-  };
-}
-
-const SLACK_THINKING_MAX_DURATION_MS = 120_000;
-const SLACK_GENERIC_LOADING_MESSAGES = ["Thinking…"] as const;
-const SLACK_THINKING_STATUSES = ["is on it", "is working hard"] as const;
-
-function getRandomSlackThinkingStatus(): string {
-  return SLACK_THINKING_STATUSES[
-    Math.floor(Math.random() * SLACK_THINKING_STATUSES.length)
-  ]!;
-}
-
-function getLoadingMessagesKey(loadingMessages?: string[]): string | undefined {
-  return loadingMessages?.join("\n");
-}
-
-function getTaskProgressLoadingMessage(
-  progress: TaskProgressData | undefined,
-): string[] | undefined {
-  if (!progress) {
-    return undefined;
-  }
-
-  const activeStepIndex = progress.steps.findIndex(
-    (step) => step.status === "in_progress",
-  );
-  if (activeStepIndex < 0) {
-    return undefined;
-  }
-
-  const activeStep = progress.steps[activeStepIndex]!;
-  return [
-    `In progress (${activeStepIndex + 1}/${progress.steps.length}): ${
-      activeStep.label
-    }`,
-  ];
-}
-
-/**
- * Set Slack Assistants API status on the thread and return a handle for
- * updating loading messages or clearing the indicator.
- *
- * A safety timer auto-clears the status after {@link SLACK_THINKING_MAX_DURATION_MS}
- * to prevent a stuck indicator when `processMessage` hangs.
- */
-function setSlackThinkingStatus(
-  callbackUrl: string,
-  chatId: string,
-  loadingMessages?: string[],
-): SlackThinkingStatusHandle {
-  let cleared = false;
-
-  // Extract the thread timestamp from the callback URL so we can target
-  // the correct thread for the Assistants API status.
-  const threadTs = extractThreadTsFromCallbackUrl(callbackUrl);
-
-  // For non-threaded DMs, fall back to emoji reaction on the original message.
-  if (!threadTs) {
-    const messageTs = extractMessageTsFromCallbackUrl(callbackUrl);
-    if (!messageTs) {
-      return {
-        updateLoadingMessages: () => {},
-        clear: () => {},
-      };
-    }
-
-    const addPromise = sendChannelReaction(callbackUrl, {
-      chatId,
-      messageId: messageTs,
-      emoji: "eyes",
-      action: "add",
-    }).catch((err) => {
-      log.debug({ err, chatId, messageTs }, "Failed to add eyes reaction");
-    });
-
-    const clearReaction = (): void => {
-      if (cleared) {
+      if (stopped) {
         return;
       }
-      cleared = true;
-      clearTimeout(safetyTimer);
-      void addPromise.then(() =>
-        sendChannelReaction(callbackUrl, {
-          chatId,
-          messageId: messageTs,
-          emoji: "eyes",
-          action: "remove",
-        }).catch((err) => {
-          log.debug(
-            { err, chatId, messageTs },
-            "Failed to remove eyes reaction",
-          );
-        }),
-      );
-    };
-
-    const safetyTimer = setTimeout(
-      clearReaction,
-      SLACK_THINKING_MAX_DURATION_MS,
-    );
-    (safetyTimer as { unref?: () => void }).unref?.();
-
-    return {
-      updateLoadingMessages: () => {},
-      clear: clearReaction,
-    };
-  }
-
-  // Track the set promise so clear waits for it to settle first,
-  // preventing a race where clear arrives at Slack before set.
-  let statusPromise = setChannelThreadStatus(callbackUrl, {
-    chatId,
-    threadTs,
-    status: getRandomSlackThinkingStatus(),
-    ...(loadingMessages ? { loadingMessages } : {}),
-  }).catch((err) => {
-    log.debug({ err, chatId, threadTs }, "Failed to set Slack thinking status");
-  });
-
-  const updateLoadingMessages = (nextLoadingMessages?: string[]): void => {
-    if (cleared) {
-      return;
-    }
-    statusPromise = statusPromise.then(() =>
-      setChannelThreadStatus(callbackUrl, {
-        chatId,
-        threadTs,
-        status: getRandomSlackThinkingStatus(),
-        ...(nextLoadingMessages
-          ? { loadingMessages: nextLoadingMessages }
-          : {}),
-      }).catch((err) => {
-        log.debug(
-          { err, chatId, threadTs },
-          "Failed to update Slack thinking status",
-        );
-      }),
-    );
-  };
-
-  const clearStatus = (): void => {
-    if (cleared) {
-      return;
-    }
-    cleared = true;
-    clearTimeout(safetyTimer);
-    void statusPromise.then(() =>
-      setChannelThreadStatus(callbackUrl, {
-        chatId,
-        threadTs,
-        status: "",
-      }).catch((err) => {
-        log.debug(
-          { err, chatId, threadTs },
-          "Failed to clear Slack thinking status",
-        );
-      }),
-    );
-  };
-
-  const safetyTimer = setTimeout(clearStatus, SLACK_THINKING_MAX_DURATION_MS);
-  (safetyTimer as { unref?: () => void }).unref?.();
-
-  return {
-    updateLoadingMessages,
-    clear: clearStatus,
+      stopped = true;
+      clearInterval(interval);
+      // Only owed when something was shown. `idle` is a real transition on
+      // channels that hold the indicator, not a no-op clear.
+      if (showing) {
+        send("idle");
+      }
+    },
   };
 }
 

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
@@ -386,6 +386,24 @@ export function shouldShowActivityForText(text: string): boolean {
 }
 
 /**
+ * Room shapes with one other participant, in each channel's own word for it.
+ *
+ * SHIM. `chatType` reaches the daemon as whatever the channel called it, so one
+ * idea arrives under three spellings and a fourth channel would add a fourth.
+ * It belongs normalized at ingress, where each channel already parses its own
+ * payload and knows the answer. Until then this is the single place that has to
+ * widen for a new channel, and the single place to delete once it does not.
+ *
+ * Slack's `mpim` is deliberately absent: a group DM has other readers, so it is
+ * a room rather than a direct conversation.
+ */
+const DIRECT_CHAT_TYPES: ReadonlySet<string> = new Set([
+  "im", // Slack
+  "dm", // Discord
+  "private", // Telegram
+]);
+
+/**
  * Whether the assistant should show it is working before it has produced any
  * text: it was addressed directly, so a reply is expected either way.
  */
@@ -393,7 +411,10 @@ export function shouldShowActivityImmediately(params: {
   chatType?: string;
   botMentioned?: boolean;
 }): boolean {
-  return params.chatType === "im" || params.botMentioned === true;
+  return (
+    (params.chatType !== undefined && DIRECT_CHAT_TYPES.has(params.chatType)) ||
+    params.botMentioned === true
+  );
 }
 
 /**
@@ -432,18 +453,48 @@ function startChannelActivity(params: {
   // Serialized so a later phase cannot overtake an earlier one and leave the
   // channel showing a state the turn has already left.
   let pending: Promise<unknown> = Promise.resolve();
+  let inFlight = false;
 
-  const send = (phase: AssistantActivityPhase): void => {
-    lastPhase = phase;
-    pending = pending.then(() =>
-      setChannelActivity(url, {
-        chatId,
-        phase,
-        ...(initiatorUserId ? { initiatorUserId } : {}),
-      }).catch((err) => {
+  const deliver = (phase: AssistantActivityPhase): Promise<boolean> =>
+    setChannelActivity(url, {
+      chatId,
+      phase,
+      ...(initiatorUserId ? { initiatorUserId } : {}),
+    })
+      .then((result) => result.ok)
+      .catch((err) => {
         log.debug({ err, chatId, phase }, "Failed to set channel activity");
-      }),
-    );
+        return false;
+      });
+
+  /**
+   * `refresh` is a re-assertion of a phase the channel is already showing, so
+   * it is dropped while a call is outstanding. A slow channel would otherwise
+   * queue one per tick, and those land after the turn's `idle` and raise the
+   * indicator again on a turn that has finished.
+   */
+  const send = (
+    phase: AssistantActivityPhase,
+    options?: { refresh?: boolean; retryOnce?: boolean },
+  ): void => {
+    if (options?.refresh && inFlight) {
+      return;
+    }
+    lastPhase = phase;
+    inFlight = true;
+    pending = pending
+      .then(async () => {
+        const ok = await deliver(phase);
+        // A lost terminal transition is not cosmetic: a channel that holds its
+        // indicator keeps showing the assistant as working until something
+        // else changes it, which on Slack is an hour away.
+        if (!ok && options?.retryOnce) {
+          await deliver(phase);
+        }
+      })
+      .finally(() => {
+        inFlight = false;
+      });
   };
 
   const currentPhase = (): AssistantActivityPhase =>
@@ -458,8 +509,10 @@ function startChannelActivity(params: {
     const phase = currentPhase();
     // A channel whose indicator expires needs the same phase re-asserted; one
     // that holds only needs to hear about a change.
-    if (phase !== lastPhase || refreshMs !== undefined) {
+    if (phase !== lastPhase) {
       send(phase);
+    } else if (refreshMs !== undefined) {
+      send(phase, { refresh: true });
     }
   };
 
@@ -497,7 +550,7 @@ function startChannelActivity(params: {
       // Only owed when something was shown. `idle` is a real transition on
       // channels that hold the indicator, not a no-op clear.
       if (showing) {
-        send("idle");
+        send("idle", { retryOnce: true });
       }
     },
   };

--- a/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
+++ b/assistant/src/runtime/routes/inbound-stages/background-dispatch.ts
@@ -453,7 +453,7 @@ function startChannelActivity(params: {
   // Serialized so a later phase cannot overtake an earlier one and leave the
   // channel showing a state the turn has already left.
   let pending: Promise<unknown> = Promise.resolve();
-  let inFlight = false;
+  let outstanding = 0;
 
   const deliver = (phase: AssistantActivityPhase): Promise<boolean> =>
     setChannelActivity(url, {
@@ -469,19 +469,24 @@ function startChannelActivity(params: {
 
   /**
    * `refresh` is a re-assertion of a phase the channel is already showing, so
-   * it is dropped while a call is outstanding. A slow channel would otherwise
-   * queue one per tick, and those land after the turn's `idle` and raise the
-   * indicator again on a turn that has finished.
+   * it is dropped whenever anything is still outstanding. A slow channel would
+   * otherwise queue one per tick, and a busy phase that runs after the turn's
+   * `idle` raises the indicator again on a turn that has finished.
+   *
+   * `outstanding` counts sends that are queued or running, not just the one in
+   * flight. A flag cannot express two at once: the earlier link's completion
+   * would clear it while its successor is still waiting its turn on the chain,
+   * and the next tick would queue a third.
    */
   const send = (
     phase: AssistantActivityPhase,
     options?: { refresh?: boolean; retryOnce?: boolean },
   ): void => {
-    if (options?.refresh && inFlight) {
+    if (options?.refresh && outstanding > 0) {
       return;
     }
     lastPhase = phase;
-    inFlight = true;
+    outstanding += 1;
     pending = pending
       .then(async () => {
         const ok = await deliver(phase);
@@ -493,7 +498,7 @@ function startChannelActivity(params: {
         }
       })
       .finally(() => {
-        inFlight = false;
+        outstanding -= 1;
       });
   };
 


### PR DESCRIPTION
## TL;DR

`typing` and `setThreadStatus` were two channel capabilities answering one
question, split by how each channel keeps its indicator alive. They become one
`setActivity` carrying the daemon's own activity phase. Slack moves off the
legacy `assistant.threads.setStatus` onto `agents.sessions.setStatus`, which it
should already have been using, and an approval now shows as `suspended`.

Net 322 lines removed. Follows LUM-3356.

## Why this and not a rename

The intent was to migrate one deprecated Slack call. Reading Slack's reference
first, as the channel work is supposed to, showed the migration is not a rename:

| | legacy `assistant.threads.setStatus` | new `agents.sessions.setStatus` |
| -- | -- | -- |
| `status` | free text, `"is thinking..."`, `""` clears | enum: `active` / `processing` / `suspended` / `closed` |
| `loading_messages` | up to 10 rotating strings | not supported |
| a forgotten clear | self-heals after 2 minutes | holds for **1 hour** |
| while processing | nothing | Slack renders a stop button |

Slack replaced display text with a lifecycle enum because the lifecycle is the
shared concept and the rendering is the channel's business. That is the same
argument for merging our two capabilities, so the two changes are one change.

`ThreadStatus` was carrying `threadTs`, a free-text `status` and
`loadingMessages`: three of one channel's words on a type every channel shares,
the same defect as `blocks` before it. The thread root now comes from the
callback context, which is what that context is for.

## What changes for a person

| | Before | After |
| -- | -- | -- |
| Slack shows the assistant is working | via a deprecated method behind the new agent surface | via the method that surface expects |
| A Slack turn ends | status cleared by sending empty text | `active` sent as a real transition |
| A Slack turn ends and something goes wrong | indicator cleared itself after 2 minutes | explicit `active`, so it does not rely on a timeout that is now an hour |
| An approval is waiting on you in Slack | reads as a turn still running | reads as `suspended`, which is what it is |
| Rotating plan hints under Slack's status | shown | gone, see below |
| Telegram and Discord typing | 4s heartbeat | unchanged behaviour, cadence now declared by the channel (Discord 8s, under its 10s expiry) |
| A Slack DM with no thread | producer added an eyes reaction, never called the status API | transport calls the session API, reaction only if that fails |

## The one removal, and why it is not a loss

`agents.sessions.setStatus` accepts no `loading_messages`. Slack dropped custom
loading text deliberately, so building a replacement would be inventing a
requirement the platform just said it does not have.

Plan progress reaches Slack twice today: flattened into rotating status text,
and as structured `SlackStreamTask` on the stream path. Only the flattened copy
goes. The semantic one, which is the better one, is untouched.

## Producer side

Two producers become one: a four second heartbeat for Telegram and Discord, and
a 260 line event-observing controller for Slack. The channel declares its own
refresh cadence via `activityRefreshMs`, so the caller no longer needs to know
which channels hold an indicator and which re-assert it.

The gate is preserved deliberately. `hasDeliverableAssistantText` is not only
lifecycle derivation: it also encodes whether the turn will say anything at all.
In a room where the assistant was not addressed it may process a message and
stay quiet, and an indicator there promises output that is not coming. Being
addressed directly still shows immediately.

The local 2 minute cap is gone rather than migrated. It mirrored Slack's own
2 minute expiry; against a 1 hour timeout the same cap would blank the indicator
during a long turn, which is worse than what it guarded.

## Transitional, and marked as such

Phase is still derived from what dispatch knows rather than read from
`assistant_activity_state`, which is the canonical source and carries a phase, a
reason and a monotonic version.

It is not consumed here because it does not arrive. `emit` delivers
conversation-level events to the sink and to `addEventObserver` observers, while
the agent loop's stream rides the per-turn `onEvent` that channel dispatch
supplies. Membership in the `AssistantEvent` union looked like proof that the
event was reachable and was not; reading the emit path is what showed otherwise.

Consuming it needs the observer path plus three answers: whether observers fire
for subagent re-enveloped events, whether version ordering matters across turns,
and whether the conversation lookup is safe under the DB-readiness gate. Those
belong in their own change rather than at the end of this one. The controller
says so at its definition so the derivation is not extended.

## Tests

Slack's phase mapping is covered for all five phases, so a mapping that loses
one fails there rather than in a workspace. Added cases for the initiator, for
a conversation with no thread, and for both reaction fallback directions.

The dispatch test now asserts that Slack, Telegram and Discord all answer the
same capability check, which is the property the merge buys and which no test
could previously express.

Three tests were deleted with the feature they covered: they exercised
`loading_messages` construction from task progress. The gate they incidentally
touched is covered directly by the no-response test, which now asserts nothing
at all was sent rather than merely that no reply was delivered.

`conversations-slack.test.ts` still stubbed the removed Slack function. Nothing
caught it, because `mock.module` stubs are untyped and the compiler cannot see a
stale name in one. Fixed here; worth knowing when auditing the next rename.

## Not in scope

`awaiting_confirmation` reaching Slack as `suspended` is unit-tested at the
transport, but not end to end through the producer. Doing that means mocking the
approval store that the approval-prompt watcher in the same file polls for real,
and I would rather not weaken those tests to strengthen this one.

Whether apps already installed on the old manifest need anything is a separate
question and deliberately not answered here.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41142" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->