### PR TITLE
feat(web): restyle the Connect Claude Code card and drop its dismiss button

### DIFF
--- a/clients/web/eslint.config.mjs
+++ b/clients/web/eslint.config.mjs
@@ -191,6 +191,8 @@ const authBoundaryAllowedPaths = [
  */
 const i18nEnforcedPaths = [
   "src/components/companion-intro.tsx",
+  "src/domains/chat/transcript/acp-connect-affordance.tsx",
+  "src/hooks/use-connect-claude.ts",
   "src/components/not-found.tsx",
   "src/components/section-actions-button.tsx",
   "src/domains/chat/components/allow-options-menu.tsx",

--- a/clients/web/src/domains/chat/acp-connect-prompt.test.ts
+++ b/clients/web/src/domains/chat/acp-connect-prompt.test.ts
@@ -73,7 +73,7 @@ describe("acp connect prompt — store lifecycle", () => {
   });
 
   test("a dismissed failure is not resurrected by a later restore (no history nag)", () => {
-    // Card shown, then dismissed (an explicit X or the implicit dismiss-on-send).
+    // Card shown, then dismissed (the implicit dismiss-on-send).
     useInteractionStore.getState().showAcpConnect({ toolUseId: "tc-1" });
     useInteractionStore.getState().dismissAcpConnect();
     expect(useInteractionStore.getState().pendingAcpConnect).toBeNull();

--- a/clients/web/src/domains/chat/acp-connect-prompt.test.ts
+++ b/clients/web/src/domains/chat/acp-connect-prompt.test.ts
@@ -73,7 +73,8 @@ describe("acp connect prompt — store lifecycle", () => {
   });
 
   test("a dismissed failure is not resurrected by a later restore (no history nag)", () => {
-    // Card shown, then dismissed (the implicit dismiss-on-send).
+    // Card shown, then retired (auto-continue after connect, or the
+    // already-connected self-heal).
     useInteractionStore.getState().showAcpConnect({ toolUseId: "tc-1" });
     useInteractionStore.getState().dismissAcpConnect();
     expect(useInteractionStore.getState().pendingAcpConnect).toBeNull();

--- a/clients/web/src/domains/chat/hooks/use-conversation-history.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-history.ts
@@ -355,8 +355,8 @@ export function useConversationHistory({
     // failed acp_spawn (persisted `acp_claude_oauth_missing` marker). Without
     // this, a page reload or SSE reconnect wipes the in-memory prompt and the
     // card silently disappears. Skipped when a prompt is already active;
-    // `showAcpConnect` additionally no-ops a failure the user already dismissed
-    // this session, so a reseed can't resurrect a card after dismiss-on-send.
+    // `showAcpConnect` additionally no-ops a failure already retired this
+    // session (auto-continue or self-heal), so a reseed can't resurrect it.
     const wirePendingAcpConnect = extractWirePendingAcpConnect(
       pagination.messages,
     );

--- a/clients/web/src/domains/chat/interaction-store.ts
+++ b/clients/web/src/domains/chat/interaction-store.ts
@@ -79,16 +79,18 @@ export interface InteractionState {
    * NOT a turn-blocking interaction — the turn already ended in error; it is a
    * remediation CTA. It is restored on a `/messages` reseed from the failed
    * tool call's persisted `errorCode` marker (so a reload/reconnect no longer
-   * loses it), but to avoid nagging from history — the reason it was originally
-   * kept off the reseed path — a dismissal (explicit X, or the implicit
-   * dismiss-on-send) is recorded in `dismissedAcpConnectToolUseIds` and
-   * suppresses any later restore of that same failed spawn.
+   * loses it), but to avoid nagging from history (the reason it was originally
+   * kept off the reseed path), a dismissal (the implicit dismiss-on-send, or
+   * the already-connected self-heal) is recorded in
+   * `dismissedAcpConnectToolUseIds` and suppresses any later restore of that
+   * same failed spawn.
    */
   pendingAcpConnect: PendingAcpConnectState | null;
 
   /**
-   * Failed-`acp_spawn` tool-call ids whose Connect prompt the user already
-   * dealt with this session (dismissed via X or superseded by a send). The
+   * Failed-`acp_spawn` tool-call ids whose Connect prompt was already dealt
+   * with this session (superseded by a send, or retired by the
+   * already-connected self-heal). The
    * `errorCode` marker lives permanently in history, so without this a reseed
    * would re-raise the card on every turn until Claude is connected; recording
    * the id lets `showAcpConnect` no-op a restore the user already dismissed. A

--- a/clients/web/src/domains/chat/interaction-store.ts
+++ b/clients/web/src/domains/chat/interaction-store.ts
@@ -78,10 +78,9 @@ export interface InteractionState {
    * prompt, anchored to the failed tool call. Unlike the other prompts this is
    * NOT a turn-blocking interaction — the turn already ended in error; it is a
    * remediation CTA. It is restored on a `/messages` reseed from the failed
-   * tool call's persisted `errorCode` marker (so a reload/reconnect no longer
-   * loses it), but to avoid nagging from history (the reason it was originally
-   * kept off the reseed path), a dismissal (the connect flow's auto-continue,
-   * or the already-connected self-heal) is recorded in
+   * tool call's persisted `errorCode` marker, so a reload or reconnect does
+   * not lose it. To avoid nagging from history, a dismissal (the connect
+   * flow's auto-continue, or the already-connected self-heal) is recorded in
    * `dismissedAcpConnectToolUseIds` and suppresses any later restore of that
    * same failed spawn.
    */

--- a/clients/web/src/domains/chat/interaction-store.ts
+++ b/clients/web/src/domains/chat/interaction-store.ts
@@ -80,20 +80,20 @@ export interface InteractionState {
    * remediation CTA. It is restored on a `/messages` reseed from the failed
    * tool call's persisted `errorCode` marker (so a reload/reconnect no longer
    * loses it), but to avoid nagging from history (the reason it was originally
-   * kept off the reseed path), a dismissal (the implicit dismiss-on-send, or
-   * the already-connected self-heal) is recorded in
+   * kept off the reseed path), a dismissal (the connect flow's auto-continue,
+   * or the already-connected self-heal) is recorded in
    * `dismissedAcpConnectToolUseIds` and suppresses any later restore of that
    * same failed spawn.
    */
   pendingAcpConnect: PendingAcpConnectState | null;
 
   /**
-   * Failed-`acp_spawn` tool-call ids whose Connect prompt was already dealt
-   * with this session (superseded by a send, or retired by the
+   * Failed-`acp_spawn` tool-call ids whose Connect prompt was already retired
+   * this session (by the connect flow's auto-continue or by the
    * already-connected self-heal). The
    * `errorCode` marker lives permanently in history, so without this a reseed
    * would re-raise the card on every turn until Claude is connected; recording
-   * the id lets `showAcpConnect` no-op a restore the user already dismissed. A
+   * the id lets `showAcpConnect` no-op a restore of a retired prompt. A
    * genuine new failure gets a fresh tool-use id, so it is never suppressed.
    * Cleared with the rest of the store on conversation switch (`resetAll`).
    */

--- a/clients/web/src/domains/chat/transcript/acp-connect-affordance.stories.tsx
+++ b/clients/web/src/domains/chat/transcript/acp-connect-affordance.stories.tsx
@@ -128,8 +128,7 @@ export const TwoStepPasteError: Story = {
       connection={stubConnection({
         phase: "awaiting_paste",
         mode: "manual",
-        error:
-          "Couldn't complete Connect Claude. Check the pasted code and try again.",
+        error: "Check the pasted key and try again.",
       })}
       initialPastedCode="bad-code#state"
     />

--- a/clients/web/src/domains/chat/transcript/acp-connect-affordance.stories.tsx
+++ b/clients/web/src/domains/chat/transcript/acp-connect-affordance.stories.tsx
@@ -1,0 +1,146 @@
+/**
+ * The inline "Connect Claude Code" card rendered under a failed `acp_spawn`
+ * tool call (missing or rejected `claude-agent-acp` OAuth token).
+ *
+ * The exported `AcpConnectAffordance` wrapper is hook-coupled: a daemon
+ * version gate, a live already-connected self-heal check, and flow state
+ * driven by the daemon's Connect routes. These stories drive the two
+ * pure-props cards directly with a stubbed connection instead.
+ *
+ * One-step is the desktop/loopback shape: a single Connect click is the whole
+ * flow, so every phase lives in the subtitle beside one action slot. Two-step
+ * is the browser/cloud shape: Connect opens a tab, then the paste step adds a
+ * masked key field + Save row under the same header.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+
+import type { UseConnectClaudeResult } from "@/hooks/use-connect-claude";
+
+import { OneStepCard, TwoStepCard } from "./acp-connect-affordance";
+
+function stubConnection(
+  overrides: Partial<UseConnectClaudeResult> = {},
+): UseConnectClaudeResult {
+  return {
+    phase: "idle",
+    mode: null,
+    error: null,
+    isBusy: false,
+    connect: async () => {},
+    submitPastedCode: async () => {},
+    reset: () => {},
+    ...overrides,
+  };
+}
+
+/** The paste step owns its field value, so give the story real input state. */
+function TwoStepHarness({
+  connection,
+  initialPastedCode = "",
+}: {
+  connection: UseConnectClaudeResult;
+  initialPastedCode?: string;
+}) {
+  const [pastedCode, setPastedCode] = useState(initialPastedCode);
+  return (
+    <TwoStepCard
+      connection={connection}
+      pastedCode={pastedCode}
+      onPastedCodeChange={setPastedCode}
+    />
+  );
+}
+
+const meta: Meta = {
+  title: "Chat/AcpConnectAffordance",
+  parameters: { layout: "padded" },
+  decorators: [
+    (Story) => (
+      <div className="max-w-2xl">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj;
+
+/** The resting one-step card: icon, title, subtitle, and Connect. */
+export const OneStepIdle: Story = {
+  render: () => <OneStepCard connection={stubConnection()} />,
+};
+
+/** Sign-in tab opened; the action slot swaps to a spinner while polling. */
+export const OneStepWaiting: Story = {
+  render: () => (
+    <OneStepCard
+      connection={stubConnection({ phase: "awaiting_capture", isBusy: true })}
+    />
+  ),
+};
+
+/**
+ * A failed start (here: blocked pop-up). The error takes the subtitle slot and
+ * Connect stays available for a retry.
+ */
+export const OneStepError: Story = {
+  render: () => (
+    <OneStepCard
+      connection={stubConnection({
+        phase: "error",
+        error:
+          "Your browser blocked the sign-in tab. Allow pop-ups for this site, then click Connect again.",
+      })}
+    />
+  ),
+};
+
+/** Token captured; the card confirms before the auto-continue send clears it. */
+export const OneStepConnected: Story = {
+  render: () => (
+    <OneStepCard connection={stubConnection({ phase: "connected" })} />
+  ),
+};
+
+/** The resting two-step card is identical to one-step until the flow starts. */
+export const TwoStepIdle: Story = {
+  render: () => <TwoStepHarness connection={stubConnection()} />,
+};
+
+/** The paste step: subtitle flips to the instruction, key field + Save appear. */
+export const TwoStepAwaitingPaste: Story = {
+  render: () => (
+    <TwoStepHarness
+      connection={stubConnection({ phase: "awaiting_paste", mode: "manual" })}
+    />
+  ),
+};
+
+/**
+ * A failed exchange (bad/expired code) returns to the paste step with the
+ * error in the subtitle and the field value kept for a retry.
+ */
+export const TwoStepPasteError: Story = {
+  render: () => (
+    <TwoStepHarness
+      connection={stubConnection({
+        phase: "awaiting_paste",
+        mode: "manual",
+        error:
+          "Couldn't complete Connect Claude. Check the pasted code and try again.",
+      })}
+      initialPastedCode="bad-code#state"
+    />
+  ),
+};
+
+/** The exchange succeeded; same confirmation row as one-step. */
+export const TwoStepConnected: Story = {
+  render: () => (
+    <TwoStepHarness
+      connection={stubConnection({ phase: "connected", mode: "manual" })}
+    />
+  ),
+};

--- a/clients/web/src/domains/chat/transcript/acp-connect-affordance.test.tsx
+++ b/clients/web/src/domains/chat/transcript/acp-connect-affordance.test.tsx
@@ -312,7 +312,7 @@ describe("AcpConnectAffordance", () => {
     fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
     // The error text appears...
-    await screen.findByText(/Couldn't complete Connect Claude/i);
+    await screen.findByText(/Check the pasted key and try again/i);
     // ...and the paste field + Save remain for a retry, with the value intact.
     const retryInput = screen.getByPlaceholderText(
       "Paste your key",

--- a/clients/web/src/domains/chat/transcript/acp-connect-affordance.test.tsx
+++ b/clients/web/src/domains/chat/transcript/acp-connect-affordance.test.tsx
@@ -138,6 +138,12 @@ describe("AcpConnectAffordance", () => {
     render(<AcpConnectAffordance assistantId="assistant-123" />);
 
     expect(screen.getByRole("button", { name: "Connect" })).not.toBeNull();
+    expect(
+      screen.getByText("Use your Claude Code subscription"),
+    ).not.toBeNull();
+    // The card has no manual dismissal; it retires via connect, self-heal, or
+    // the implicit dismiss-on-send.
+    expect(screen.queryByRole("button", { name: "Dismiss" })).toBeNull();
   });
 
   test("renders nothing when the daemon is too old to support Connect", () => {
@@ -265,6 +271,10 @@ describe("AcpConnectAffordance", () => {
       expect(screen.getByPlaceholderText("Paste your key")).not.toBeNull(),
     );
     expect(screen.getByRole("button", { name: "Save" })).not.toBeNull();
+    expect(
+      screen.getByText("Paste the key from the tab that opened"),
+    ).not.toBeNull();
+    expect(screen.queryByRole("button", { name: "Dismiss" })).toBeNull();
   });
 
   test("signals auto-continue once the connect flow completes", async () => {

--- a/clients/web/src/domains/chat/transcript/acp-connect-affordance.test.tsx
+++ b/clients/web/src/domains/chat/transcript/acp-connect-affordance.test.tsx
@@ -141,8 +141,8 @@ describe("AcpConnectAffordance", () => {
     expect(
       screen.getByText("Use your Claude Code subscription"),
     ).not.toBeNull();
-    // The card has no manual dismissal; it retires via connect, self-heal, or
-    // the implicit dismiss-on-send.
+    // The card has no manual dismissal; it retires via the connect flow's
+    // auto-continue or the already-connected self-heal.
     expect(screen.queryByRole("button", { name: "Dismiss" })).toBeNull();
   });
 

--- a/clients/web/src/domains/chat/transcript/acp-connect-affordance.tsx
+++ b/clients/web/src/domains/chat/transcript/acp-connect-affordance.tsx
@@ -1,6 +1,6 @@
 import { Button } from "@vellumai/design-library/components/button";
 import { Input } from "@vellumai/design-library/components/input";
-import { Check, Loader2, X } from "lucide-react";
+import { Check, Loader2 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 
 import { AcpAgentIcon } from "@/domains/chat/components/acp-run-inline-card/acp-agent-icon";
@@ -39,10 +39,10 @@ import { isElectron } from "@/runtime/is-electron";
 // Two card shapes, chosen the same way the client tells the daemon which flow to
 // run (`preferManual: !isElectron()`), so the shape matches the flow the user
 // gets:
-//   - one-step (desktop/loopback): a compact row — the daemon captures the token
-//     on its own callback, so a single "Connect" click is the whole flow.
-//   - two-step (browser/cloud): a stacked card — "Connect" opens a tab, then the
-//     user pastes the key it shows back into a masked field to finish.
+//   - one-step (desktop/loopback): the daemon captures the token on its own
+//     callback, so a single "Connect" click is the whole flow.
+//   - two-step (browser/cloud): "Connect" opens a tab, then the user pastes the
+//     key it shows back into a masked field to finish.
 
 export function AcpConnectAffordance({
   assistantId,
@@ -78,7 +78,7 @@ function AcpConnectAffordanceInner({ assistantId }: { assistantId: string }) {
   // Skipped for an `auth_required` prompt: that check asks "is a token
   // stored", the wrong question when the stored token itself was rejected. A
   // "yes" would retire the card over the failure it exists to repair; those
-  // prompts clear only via the flow or explicit dismissal.
+  // prompts clear only via the flow or the implicit dismiss-on-send.
   useEffect(() => {
     if (reason === "auth_required") {
       return;
@@ -133,8 +133,6 @@ function AcpConnectAffordanceInner({ assistantId }: { assistantId: string }) {
     return null;
   }
 
-  const dismiss = () => useInteractionStore.getState().dismissAcpConnect();
-
   // The daemon has the final say on loopback (one-step) vs manual (two-step): a
   // containerized/cloud assistant forces manual even in the desktop app, whose
   // localhost callback can't reach the pod. So once the flow starts and the
@@ -147,13 +145,12 @@ function AcpConnectAffordanceInner({ assistantId }: { assistantId: string }) {
     : isElectron();
 
   return oneStep ? (
-    <OneStepCard connection={connection} onDismiss={dismiss} />
+    <OneStepCard connection={connection} />
   ) : (
     <TwoStepCard
       connection={connection}
       pastedCode={pastedCode}
       onPastedCodeChange={setPastedCode}
-      onDismiss={dismiss}
     />
   );
 }
@@ -178,41 +175,16 @@ function Title() {
   );
 }
 
-function DismissButton({ onDismiss }: { onDismiss: () => void }) {
-  return (
-    <button
-      type="button"
-      aria-label="Dismiss"
-      title="Dismiss"
-      onClick={onDismiss}
-      className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-[var(--content-secondary)] transition-colors hover:bg-[var(--surface-hover)] hover:text-[var(--content-strong)]"
-    >
-      <X className="h-4 w-4" />
-    </button>
-  );
-}
-
-function BusyRow({ label }: { label: string }) {
-  return (
-    <div className="flex items-center gap-2">
-      <Loader2 className="h-4 w-4 animate-spin text-[var(--content-tertiary)]" />
-      <span className="text-body-medium-lighter text-[var(--content-tertiary)]">
-        {label}
-      </span>
-    </div>
-  );
-}
-
 // ---------------------------------------------------------------------------
 // One-step (desktop / loopback): compact single row
 // ---------------------------------------------------------------------------
 
-function OneStepCard({
+// Exported (with TwoStepCard) for Storybook, which drives the pure-props cards
+// directly; production callers stay within this file.
+export function OneStepCard({
   connection,
-  onDismiss,
 }: {
   connection: UseConnectClaudeResult;
-  onDismiss: () => void;
 }) {
   const { phase, error, connect } = connection;
 
@@ -226,8 +198,8 @@ function OneStepCard({
           : phase === "exchanging"
             ? "Completing sign-in..."
             : phase === "connected"
-              ? "Claude Code connected — continuing..."
-              : "Sign in — no API key needed";
+              ? "Claude Code connected, continuing..."
+              : "Use your Claude Code subscription";
 
   const subtitleColor =
     phase === "error"
@@ -265,112 +237,101 @@ function OneStepCard({
       ) : phase === "connected" ? (
         <Check className="h-5 w-5 shrink-0 text-[var(--system-positive-strong)]" />
       ) : null}
-
-      <DismissButton onDismiss={onDismiss} />
     </div>
   );
 }
 
 // ---------------------------------------------------------------------------
-// Two-step (browser / cloud): stacked card with a paste step
+// Two-step (browser / cloud): the same compact row, plus a paste step
 // ---------------------------------------------------------------------------
 
-function TwoStepCard({
+export function TwoStepCard({
   connection,
   pastedCode,
   onPastedCodeChange,
-  onDismiss,
 }: {
   connection: UseConnectClaudeResult;
   pastedCode: string;
   onPastedCodeChange: (value: string) => void;
-  onDismiss: () => void;
 }) {
   const { phase, error, connect, submitPastedCode } = connection;
+
+  // A failed exchange (bad/expired code, 400) returns to `awaiting_paste` with
+  // an error set; surface it in the subtitle so Save doesn't look like a no-op.
+  // The input keeps its value for a retry.
+  const subtitle =
+    phase === "error"
+      ? (error ?? "Connecting Claude failed. Please try again.")
+      : phase === "starting"
+        ? "Starting sign-in..."
+        : phase === "awaiting_capture"
+          ? "Waiting for Claude sign-in..."
+          : phase === "exchanging"
+            ? "Completing sign-in..."
+            : phase === "awaiting_paste"
+              ? (error ?? "Paste the key from the tab that opened")
+              : phase === "connected"
+                ? "Claude Code connected, continuing..."
+                : "Use your Claude Code subscription";
+
+  const subtitleColor =
+    phase === "error" || (phase === "awaiting_paste" && error)
+      ? "text-[var(--system-negative-strong)]"
+      : phase === "connected"
+        ? "text-[var(--system-positive-strong)]"
+        : "text-[var(--content-quiet)]";
+
+  const canConnect = phase === "idle" || phase === "error";
+  const busy =
+    phase === "starting" ||
+    phase === "awaiting_capture" ||
+    phase === "exchanging";
 
   return (
     <div
       data-testid="acp-connect-affordance"
-      className="mt-2 rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] p-4 shadow-sm"
+      className="mt-2 rounded-xl border border-[var(--border-subtle)] bg-[var(--surface-base)] px-3 py-2.5 shadow-sm"
     >
       <div className="flex items-center gap-3">
         <BrandIcon />
         <div className="min-w-0 flex-1">
           <Title />
+          <div className={`text-body-medium-lighter ${subtitleColor}`}>
+            {subtitle}
+          </div>
         </div>
-        <DismissButton onDismiss={onDismiss} />
+
+        {canConnect ? (
+          <Button variant="primary" onClick={() => void connect()}>
+            Connect
+          </Button>
+        ) : busy ? (
+          <Loader2 className="h-4 w-4 shrink-0 animate-spin text-[var(--content-tertiary)]" />
+        ) : phase === "connected" ? (
+          <Check className="h-5 w-5 shrink-0 text-[var(--system-positive-strong)]" />
+        ) : null}
       </div>
 
-      <div className="mt-3 space-y-3">
-        {phase === "idle" || phase === "error" ? (
-          <>
-            <p
-              className={`text-body-medium-lighter ${
-                phase === "error"
-                  ? "text-[var(--system-negative-strong)]"
-                  : "text-[var(--content-quiet)]"
-              }`}
-            >
-              {phase === "error"
-                ? (error ?? "Connecting Claude failed. Please try again.")
-                : "Sign in with your Claude account to run this agent. No API key required."}
-            </p>
-            <Button variant="primary" fullWidth onClick={() => void connect()}>
-              Connect
-            </Button>
-          </>
-        ) : null}
-
-        {phase === "starting" ? <BusyRow label="Starting sign-in..." /> : null}
-        {phase === "awaiting_capture" ? (
-          <BusyRow label="Waiting for Claude sign-in..." />
-        ) : null}
-        {phase === "exchanging" ? (
-          <BusyRow label="Completing sign-in..." />
-        ) : null}
-
-        {phase === "awaiting_paste" ? (
-          <>
-            <p
-              className={`text-body-medium-lighter ${
-                error
-                  ? "text-[var(--system-negative-strong)]"
-                  : "text-[var(--content-quiet)]"
-              }`}
-            >
-              {/* A failed exchange (bad/expired code, 400) returns here with an
-                  error set; show it on the paste step so Save doesn't look
-                  like a no-op. The input keeps its value for a retry. */}
-              {error ??
-                "A browser tab opened. Paste the key it gives you to finish."}
-            </p>
-            <div className="flex items-center gap-2">
-              <div className="min-w-0 flex-1">
-                <Input
-                  type="password"
-                  value={pastedCode}
-                  onChange={(e) => onPastedCodeChange(e.target.value)}
-                  placeholder="Paste your key"
-                  fullWidth
-                />
-              </div>
-              <Button
-                variant="primary"
-                disabled={!pastedCode.trim()}
-                onClick={() => void submitPastedCode(pastedCode)}
-              >
-                Save
-              </Button>
-            </div>
-          </>
-        ) : null}
-
-        {phase === "connected" ? (
-          <p className="text-body-medium-lighter text-[var(--system-positive-strong)]">
-            Claude Code connected — continuing...
-          </p>
-        ) : null}
-      </div>
+      {phase === "awaiting_paste" ? (
+        <div className="mt-3 flex items-center gap-2">
+          <div className="min-w-0 flex-1">
+            <Input
+              type="password"
+              value={pastedCode}
+              onChange={(e) => onPastedCodeChange(e.target.value)}
+              placeholder="Paste your key"
+              fullWidth
+            />
+          </div>
+          <Button
+            variant="primary"
+            disabled={!pastedCode.trim()}
+            onClick={() => void submitPastedCode(pastedCode)}
+          >
+            Save
+          </Button>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/clients/web/src/domains/chat/transcript/acp-connect-affordance.tsx
+++ b/clients/web/src/domains/chat/transcript/acp-connect-affordance.tsx
@@ -78,7 +78,7 @@ function AcpConnectAffordanceInner({ assistantId }: { assistantId: string }) {
   // Skipped for an `auth_required` prompt: that check asks "is a token
   // stored", the wrong question when the stored token itself was rejected. A
   // "yes" would retire the card over the failure it exists to repair; those
-  // prompts clear only via the flow or the implicit dismiss-on-send.
+  // prompts clear only by completing the connect flow.
   useEffect(() => {
     if (reason === "auth_required") {
       return;

--- a/clients/web/src/domains/chat/transcript/acp-connect-affordance.tsx
+++ b/clients/web/src/domains/chat/transcript/acp-connect-affordance.tsx
@@ -10,6 +10,7 @@ import {
   useConnectClaude,
   type UseConnectClaudeResult,
 } from "@/hooks/use-connect-claude";
+import { useTranslation } from "@/i18n";
 import { useSupportsAcpConnect } from "@/lib/backwards-compat/use-supports-acp-connect";
 import { recordLifecycleDiagnostic } from "@/lib/diagnostics";
 import { isElectron } from "@/runtime/is-electron";
@@ -168,9 +169,10 @@ function BrandIcon() {
 }
 
 function Title() {
+  const { t } = useTranslation("chat");
   return (
     <div className="text-title-small text-[var(--content-strong)]">
-      Connect Claude Code
+      {t("acpConnectAffordance.title")}
     </div>
   );
 }
@@ -187,19 +189,20 @@ export function OneStepCard({
   connection: UseConnectClaudeResult;
 }) {
   const { phase, error, connect } = connection;
+  const { t } = useTranslation("chat");
 
   const subtitle =
     phase === "error"
-      ? (error ?? "Connecting Claude failed. Please try again.")
+      ? (error ?? t("acpConnectAffordance.errorFallback"))
       : phase === "starting"
-        ? "Starting sign-in..."
+        ? t("acpConnectAffordance.subtitleStarting")
         : phase === "awaiting_capture" || phase === "awaiting_paste"
-          ? "Waiting for Claude sign-in..."
+          ? t("acpConnectAffordance.subtitleWaiting")
           : phase === "exchanging"
-            ? "Completing sign-in..."
+            ? t("acpConnectAffordance.subtitleExchanging")
             : phase === "connected"
-              ? "Claude Code connected, continuing..."
-              : "Use your Claude Code subscription";
+              ? t("acpConnectAffordance.subtitleConnected")
+              : t("acpConnectAffordance.subtitleIdle");
 
   const subtitleColor =
     phase === "error"
@@ -230,7 +233,7 @@ export function OneStepCard({
 
       {canConnect ? (
         <Button variant="primary" onClick={() => void connect()}>
-          Connect
+          {t("acpConnectAffordance.connectButton")}
         </Button>
       ) : busy ? (
         <Loader2 className="h-4 w-4 shrink-0 animate-spin text-[var(--content-tertiary)]" />
@@ -255,24 +258,25 @@ export function TwoStepCard({
   onPastedCodeChange: (value: string) => void;
 }) {
   const { phase, error, connect, submitPastedCode } = connection;
+  const { t } = useTranslation("chat");
 
   // A failed exchange (bad/expired code, 400) returns to `awaiting_paste` with
   // an error set; surface it in the subtitle so Save doesn't look like a no-op.
   // The input keeps its value for a retry.
   const subtitle =
     phase === "error"
-      ? (error ?? "Connecting Claude failed. Please try again.")
+      ? (error ?? t("acpConnectAffordance.errorFallback"))
       : phase === "starting"
-        ? "Starting sign-in..."
+        ? t("acpConnectAffordance.subtitleStarting")
         : phase === "awaiting_capture"
-          ? "Waiting for Claude sign-in..."
+          ? t("acpConnectAffordance.subtitleWaiting")
           : phase === "exchanging"
-            ? "Completing sign-in..."
+            ? t("acpConnectAffordance.subtitleExchanging")
             : phase === "awaiting_paste"
-              ? (error ?? "Paste the key from the tab that opened")
+              ? (error ?? t("acpConnectAffordance.subtitlePaste"))
               : phase === "connected"
-                ? "Claude Code connected, continuing..."
-                : "Use your Claude Code subscription";
+                ? t("acpConnectAffordance.subtitleConnected")
+                : t("acpConnectAffordance.subtitleIdle");
 
   const subtitleColor =
     phase === "error" || (phase === "awaiting_paste" && error)
@@ -303,7 +307,7 @@ export function TwoStepCard({
 
         {canConnect ? (
           <Button variant="primary" onClick={() => void connect()}>
-            Connect
+            {t("acpConnectAffordance.connectButton")}
           </Button>
         ) : busy ? (
           <Loader2 className="h-4 w-4 shrink-0 animate-spin text-[var(--content-tertiary)]" />
@@ -319,7 +323,7 @@ export function TwoStepCard({
               type="password"
               value={pastedCode}
               onChange={(e) => onPastedCodeChange(e.target.value)}
-              placeholder="Paste your key"
+              placeholder={t("acpConnectAffordance.pastePlaceholder")}
               fullWidth
             />
           </div>
@@ -328,7 +332,7 @@ export function TwoStepCard({
             disabled={!pastedCode.trim()}
             onClick={() => void submitPastedCode(pastedCode)}
           >
-            Save
+            {t("acpConnectAffordance.saveButton")}
           </Button>
         </div>
       ) : null}

--- a/clients/web/src/hooks/use-connect-claude.ts
+++ b/clients/web/src/hooks/use-connect-claude.ts
@@ -181,9 +181,7 @@ export function useConnectClaude(assistantId: string): UseConnectClaudeResult {
         if (isStale(flowId)) {
           return;
         }
-        setError(
-          "Couldn't complete Connect Claude. Check the pasted code and try again.",
-        );
+        setError("Check the pasted key and try again.");
         setPhase("awaiting_paste");
         return;
       }

--- a/clients/web/src/hooks/use-connect-claude.ts
+++ b/clients/web/src/hooks/use-connect-claude.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import { t } from "@/i18n";
+import { useTranslation } from "@/i18n";
 import { openUrlInNewTab } from "@/runtime/browser";
 import {
   exchangeConnectClaude,
@@ -34,6 +34,22 @@ const POLL_INTERVAL_MS = 2000;
 // ~5 min of polling, comfortably inside the daemon's 10-min pending-flow TTL.
 const MAX_POLL_ATTEMPTS = 150;
 
+type ConnectClaudeErrorKey =
+  | "failed"
+  | "timedOut"
+  | "startFailed"
+  | "popupBlocked"
+  | "pasteEmpty"
+  | "notStarted"
+  | "exchangeFailed";
+
+// Errors are stored as catalog keys (or the daemon's own message) and
+// translated at render with the reactive `t`, so a locale switch re-renders a
+// displayed error in the new language along with the rest of the card.
+type ConnectClaudeErrorState =
+  | { key: ConnectClaudeErrorKey }
+  | { message: string };
+
 export interface UseConnectClaudeResult {
   phase: ConnectClaudePhase;
   mode: ConnectClaudeMode | null;
@@ -49,9 +65,12 @@ export interface UseConnectClaudeResult {
 }
 
 export function useConnectClaude(assistantId: string): UseConnectClaudeResult {
+  const { t } = useTranslation();
   const [phase, setPhase] = useState<ConnectClaudePhase>("idle");
   const [mode, setMode] = useState<ConnectClaudeMode | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const [errorState, setErrorState] = useState<ConnectClaudeErrorState | null>(
+    null,
+  );
 
   // Bumped on every reset / new connect and on unmount, so a stale poll loop
   // from an abandoned flow can't write state after the user restarts.
@@ -93,12 +112,14 @@ export function useConnectClaude(assistantId: string): UseConnectClaudeResult {
           return;
         }
         if (result.status === "error") {
-          setError(result.error ?? t("useConnectClaude.failed"));
+          setErrorState(
+            result.error ? { message: result.error } : { key: "failed" },
+          );
           setPhase("error");
           return;
         }
       }
-      setError(t("useConnectClaude.timedOut"));
+      setErrorState({ key: "timedOut" });
       setPhase("error");
     },
     [assistantId, isStale],
@@ -106,7 +127,7 @@ export function useConnectClaude(assistantId: string): UseConnectClaudeResult {
 
   const connect = useCallback(async () => {
     const flowId = ++flowIdRef.current;
-    setError(null);
+    setErrorState(null);
     setMode(null);
     setPhase("starting");
 
@@ -117,7 +138,7 @@ export function useConnectClaude(assistantId: string): UseConnectClaudeResult {
       if (isStale(flowId)) {
         return;
       }
-      setError(t("useConnectClaude.startFailed"));
+      setErrorState({ key: "startFailed" });
       setPhase("error");
       return;
     }
@@ -139,7 +160,7 @@ export function useConnectClaude(assistantId: string): UseConnectClaudeResult {
       return;
     }
     if (!opened) {
-      setError(t("useConnectClaude.popupBlocked"));
+      setErrorState({ key: "popupBlocked" });
       setPhase("error");
       return;
     }
@@ -159,16 +180,16 @@ export function useConnectClaude(assistantId: string): UseConnectClaudeResult {
     async (pasted: string) => {
       const trimmed = pasted.trim();
       if (!trimmed) {
-        setError(t("useConnectClaude.pasteEmpty"));
+        setErrorState({ key: "pasteEmpty" });
         return;
       }
       const state = stateRef.current;
       if (!state) {
-        setError(t("useConnectClaude.notStarted"));
+        setErrorState({ key: "notStarted" });
         return;
       }
       const flowId = flowIdRef.current;
-      setError(null);
+      setErrorState(null);
       setPhase("exchanging");
       try {
         // The daemon splits a pasted `code#state`; passing the tracked `state`
@@ -178,7 +199,7 @@ export function useConnectClaude(assistantId: string): UseConnectClaudeResult {
         if (isStale(flowId)) {
           return;
         }
-        setError(t("useConnectClaude.exchangeFailed"));
+        setErrorState({ key: "exchangeFailed" });
         setPhase("awaiting_paste");
         return;
       }
@@ -194,7 +215,7 @@ export function useConnectClaude(assistantId: string): UseConnectClaudeResult {
     flowIdRef.current++;
     stateRef.current = null;
     setMode(null);
-    setError(null);
+    setErrorState(null);
     setPhase("idle");
   }, []);
 
@@ -202,6 +223,13 @@ export function useConnectClaude(assistantId: string): UseConnectClaudeResult {
     phase === "starting" ||
     phase === "awaiting_capture" ||
     phase === "exchanging";
+
+  const error =
+    errorState === null
+      ? null
+      : "key" in errorState
+        ? t(`useConnectClaude.${errorState.key}`)
+        : errorState.message;
 
   return { phase, mode, error, isBusy, connect, submitPastedCode, reset };
 }

--- a/clients/web/src/hooks/use-connect-claude.ts
+++ b/clients/web/src/hooks/use-connect-claude.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
+import { t } from "@/i18n";
 import { openUrlInNewTab } from "@/runtime/browser";
 import {
   exchangeConnectClaude,
@@ -92,14 +93,12 @@ export function useConnectClaude(assistantId: string): UseConnectClaudeResult {
           return;
         }
         if (result.status === "error") {
-          setError(
-            result.error ?? "Connecting Claude failed. Please try again.",
-          );
+          setError(result.error ?? t("useConnectClaude.failed"));
           setPhase("error");
           return;
         }
       }
-      setError("Timed out waiting for Claude to connect. Please try again.");
+      setError(t("useConnectClaude.timedOut"));
       setPhase("error");
     },
     [assistantId, isStale],
@@ -118,7 +117,7 @@ export function useConnectClaude(assistantId: string): UseConnectClaudeResult {
       if (isStale(flowId)) {
         return;
       }
-      setError("Couldn't start Connect Claude. Please try again.");
+      setError(t("useConnectClaude.startFailed"));
       setPhase("error");
       return;
     }
@@ -140,9 +139,7 @@ export function useConnectClaude(assistantId: string): UseConnectClaudeResult {
       return;
     }
     if (!opened) {
-      setError(
-        "Your browser blocked the sign-in tab. Allow pop-ups for this site, then click Connect again.",
-      );
+      setError(t("useConnectClaude.popupBlocked"));
       setPhase("error");
       return;
     }
@@ -162,12 +159,12 @@ export function useConnectClaude(assistantId: string): UseConnectClaudeResult {
     async (pasted: string) => {
       const trimmed = pasted.trim();
       if (!trimmed) {
-        setError("Paste the code shown on the Claude page.");
+        setError(t("useConnectClaude.pasteEmpty"));
         return;
       }
       const state = stateRef.current;
       if (!state) {
-        setError("Start the Connect Claude flow first.");
+        setError(t("useConnectClaude.notStarted"));
         return;
       }
       const flowId = flowIdRef.current;
@@ -181,7 +178,7 @@ export function useConnectClaude(assistantId: string): UseConnectClaudeResult {
         if (isStale(flowId)) {
           return;
         }
-        setError("Check the pasted key and try again.");
+        setError(t("useConnectClaude.exchangeFailed"));
         setPhase("awaiting_paste");
         return;
       }

--- a/clients/web/src/hooks/use-connect-claude.ts
+++ b/clients/web/src/hooks/use-connect-claude.ts
@@ -34,20 +34,23 @@ const POLL_INTERVAL_MS = 2000;
 // ~5 min of polling, comfortably inside the daemon's 10-min pending-flow TTL.
 const MAX_POLL_ATTEMPTS = 150;
 
-type ConnectClaudeErrorKey =
-  | "failed"
-  | "timedOut"
-  | "startFailed"
-  | "popupBlocked"
-  | "pasteEmpty"
-  | "notStarted"
-  | "exchangeFailed";
+// Full catalog keys spelled out per error (rather than a template over the
+// suffix) so `catalogs.test.ts` can see each key referenced in source.
+const ERROR_MESSAGE_KEYS = {
+  failed: "useConnectClaude.failed",
+  timedOut: "useConnectClaude.timedOut",
+  startFailed: "useConnectClaude.startFailed",
+  popupBlocked: "useConnectClaude.popupBlocked",
+  pasteEmpty: "useConnectClaude.pasteEmpty",
+  notStarted: "useConnectClaude.notStarted",
+  exchangeFailed: "useConnectClaude.exchangeFailed",
+} as const;
 
 // Errors are stored as catalog keys (or the daemon's own message) and
 // translated at render with the reactive `t`, so a locale switch re-renders a
 // displayed error in the new language along with the rest of the card.
 type ConnectClaudeErrorState =
-  | { key: ConnectClaudeErrorKey }
+  | { key: keyof typeof ERROR_MESSAGE_KEYS }
   | { message: string };
 
 export interface UseConnectClaudeResult {
@@ -228,7 +231,7 @@ export function useConnectClaude(assistantId: string): UseConnectClaudeResult {
     errorState === null
       ? null
       : "key" in errorState
-        ? t(`useConnectClaude.${errorState.key}`)
+        ? t(ERROR_MESSAGE_KEYS[errorState.key])
         : errorState.message;
 
   return { phase, mode, error, isBusy, connect, submitPastedCode, reset };

--- a/clients/web/src/i18n/locales/en/chat.json
+++ b/clients/web/src/i18n/locales/en/chat.json
@@ -1,4 +1,17 @@
 {
+  "acpConnectAffordance": {
+    "title": "Connect Claude Code",
+    "subtitleIdle": "Use your Claude Code subscription",
+    "subtitleStarting": "Starting sign-in...",
+    "subtitleWaiting": "Waiting for Claude sign-in...",
+    "subtitleExchanging": "Completing sign-in...",
+    "subtitleConnected": "Claude Code connected, continuing...",
+    "subtitlePaste": "Paste the key from the tab that opened",
+    "errorFallback": "Connecting Claude failed. Please try again.",
+    "connectButton": "Connect",
+    "saveButton": "Save",
+    "pastePlaceholder": "Paste your key"
+  },
   "activityStepsPanel": {
     "backAria": "Back to all steps",
     "backTooltip": "All steps"

--- a/clients/web/src/i18n/locales/en/common.json
+++ b/clients/web/src/i18n/locales/en/common.json
@@ -42,6 +42,15 @@
   "sectionActionsButton": {
     "ariaLabel": "{name} actions"
   },
+  "useConnectClaude": {
+    "failed": "Connecting Claude failed. Please try again.",
+    "timedOut": "Timed out waiting for Claude to connect. Please try again.",
+    "startFailed": "Couldn't start Connect Claude. Please try again.",
+    "popupBlocked": "Your browser blocked the sign-in tab. Allow pop-ups for this site, then click Connect again.",
+    "pasteEmpty": "Paste the code shown on the Claude page.",
+    "notStarted": "Start the Connect Claude flow first.",
+    "exchangeFailed": "Check the pasted key and try again."
+  },
   "windowsMenuBar": {
     "file": "File",
     "view": "View",

--- a/clients/web/src/i18n/locales/es/chat.json
+++ b/clients/web/src/i18n/locales/es/chat.json
@@ -1,4 +1,17 @@
 {
+  "acpConnectAffordance": {
+    "title": "Conectar Claude Code",
+    "subtitleIdle": "Usa tu suscripción a Claude Code",
+    "subtitleStarting": "Preparando el inicio de sesión...",
+    "subtitleWaiting": "Esperando el inicio de sesión de Claude...",
+    "subtitleExchanging": "Completando el inicio de sesión...",
+    "subtitleConnected": "Claude Code conectado, continuando...",
+    "subtitlePaste": "Pega la clave de la pestaña que se abrió",
+    "errorFallback": "No se pudo conectar Claude. Inténtalo de nuevo.",
+    "connectButton": "Conectar",
+    "saveButton": "Guardar",
+    "pastePlaceholder": "Pega tu clave"
+  },
   "activityStepsPanel": {
     "backAria": "Volver a todos los pasos",
     "backTooltip": "Todos los pasos"

--- a/clients/web/src/i18n/locales/es/common.json
+++ b/clients/web/src/i18n/locales/es/common.json
@@ -42,6 +42,15 @@
   "sectionActionsButton": {
     "ariaLabel": "Acciones de {name}"
   },
+  "useConnectClaude": {
+    "failed": "No se pudo conectar Claude. Inténtalo de nuevo.",
+    "timedOut": "Se agotó el tiempo de espera para conectar Claude. Inténtalo de nuevo.",
+    "startFailed": "No se pudo iniciar Connect Claude. Inténtalo de nuevo.",
+    "popupBlocked": "Tu navegador bloqueó la pestaña de inicio de sesión. Permite las ventanas emergentes para este sitio y vuelve a hacer clic en Conectar.",
+    "pasteEmpty": "Pega el código que se muestra en la página de Claude.",
+    "notStarted": "Primero inicia el flujo de Connect Claude.",
+    "exchangeFailed": "Comprueba la clave pegada e inténtalo de nuevo."
+  },
   "windowsMenuBar": {
     "file": "Archivo",
     "view": "Ver",


### PR DESCRIPTION
Summary:
Restyles the inline ACP "Connect Claude Code" affordance to match the new design mocks: both variants now share a compact header row (icon, title, one-line subtitle, right-aligned action), the idle copy reads "Use your Claude Code subscription", and the X dismiss button is removed. Adds a Storybook catalog covering every phase of both cards.

Changes:
- One-step card: idle subtitle is now "Use your Claude Code subscription"; X button removed
- Two-step card: restructured from a stacked card into the same compact header layout, with a right-aligned Connect button and the paste-step subtitle "Paste the key from the tab that opened"; the full-width key input + Save row is unchanged
- Removed the dismiss plumbing that only served the X (`DismissButton`, `BusyRow`, `onDismiss` props); the store's `dismissAcpConnect` stays for the self-heal and auto-continue paths
- Updated stale comments that referenced the explicit X dismissal, and added test assertions for the new copy and the absent Dismiss button
- New `acp-connect-affordance.stories.tsx` ("Chat/AcpConnectAffordance") driving the pure-props cards through all 8 phase states

Behavioral note: with the X gone, the card can no longer be manually retired; it clears via the connect flow's auto-continue or the already-connected self-heal, and it deliberately survives sends and conversation switches until the connection is made.

Testing:
- `bun test` on both affected test files (12/12 and 11/11 pass); eslint clean; `tsc --noEmit` unchanged vs main
- All 8 Storybook stories rendered and screenshot-verified against the mocks, including the co-mounted autodocs page

🤖 Generated with [Claude Code](https://claude.com/claude-code)
