### PR TITLE
refactor(channels): separate setup progress from operational health

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -4360,7 +4360,17 @@ paths:
                         setupStatus:
                           anyOf:
                             - type: string
+                              enum:
+                                - not_configured
+                                - incomplete
+                                - ready
                             - type: "null"
+                        health:
+                          type: string
+                          enum:
+                            - ok
+                            - failing
+                            - unknown
                         checkedAt:
                           anyOf:
                             - type: number
@@ -4370,7 +4380,16 @@ paths:
                         reasons:
                           type: array
                           items:
-                            type: string
+                            type: object
+                            properties:
+                              code:
+                                type: string
+                              text:
+                                type: string
+                            required:
+                              - code
+                              - text
+                            additionalProperties: false
                         localChecks:
                           type: array
                           items:
@@ -4384,6 +4403,13 @@ paths:
                                 anyOf:
                                   - type: string
                                   - type: "null"
+                              indeterminate:
+                                type: boolean
+                              kind:
+                                type: string
+                                enum:
+                                  - configuration
+                                  - operational
                             required:
                               - name
                               - passed
@@ -4401,6 +4427,13 @@ paths:
                                 anyOf:
                                   - type: string
                                   - type: "null"
+                              indeterminate:
+                                type: boolean
+                              kind:
+                                type: string
+                                enum:
+                                  - configuration
+                                  - operational
                             required:
                               - name
                               - passed
@@ -4482,7 +4515,17 @@ paths:
                         setupStatus:
                           anyOf:
                             - type: string
+                              enum:
+                                - not_configured
+                                - incomplete
+                                - ready
                             - type: "null"
+                        health:
+                          type: string
+                          enum:
+                            - ok
+                            - failing
+                            - unknown
                         checkedAt:
                           anyOf:
                             - type: number
@@ -4492,7 +4535,16 @@ paths:
                         reasons:
                           type: array
                           items:
-                            type: string
+                            type: object
+                            properties:
+                              code:
+                                type: string
+                              text:
+                                type: string
+                            required:
+                              - code
+                              - text
+                            additionalProperties: false
                         localChecks:
                           type: array
                           items:
@@ -4506,6 +4558,13 @@ paths:
                                 anyOf:
                                   - type: string
                                   - type: "null"
+                              indeterminate:
+                                type: boolean
+                              kind:
+                                type: string
+                                enum:
+                                  - configuration
+                                  - operational
                             required:
                               - name
                               - passed
@@ -4523,6 +4582,13 @@ paths:
                                 anyOf:
                                   - type: string
                                   - type: "null"
+                              indeterminate:
+                                type: boolean
+                              kind:
+                                type: string
+                                enum:
+                                  - configuration
+                                  - operational
                             required:
                               - name
                               - passed

--- a/assistant/src/__tests__/channel-readiness-service.test.ts
+++ b/assistant/src/__tests__/channel-readiness-service.test.ts
@@ -566,3 +566,129 @@ describe("ChannelReadinessService", () => {
     expect(probe.remoteCallCount).toBe(1);
   });
 });
+
+describe("setup progress and operational health are separate axes", () => {
+  const configured = (name: string): ReadinessCheckResult => ({
+    name,
+    passed: true,
+    message: "configured",
+  });
+
+  test("a configured channel whose delivery fails is set up, not half set up", () => {
+    // The defect this separates: telling the owner of a fully configured
+    // channel to finish setup sends them to fix the one thing that is not
+    // broken. Setup is done; delivery is down.
+    const service = new ChannelReadinessService();
+    service.registerProbe(
+      makeProbe(
+        "phone",
+        [configured("creds")],
+        [
+          {
+            name: "inbound_delivery",
+            passed: false,
+            message: "nothing is arriving",
+            kind: "operational",
+          },
+        ],
+      ),
+    );
+
+    return service.getReadiness("phone", true).then(([snapshot]) => {
+      expect(snapshot.setupStatus).toBe("ready");
+      expect(snapshot.health).toBe("failing");
+      expect(snapshot.ready).toBe(false);
+    });
+  });
+
+  test("a delivery check that establishes nothing reads unknown, not failing", async () => {
+    const service = new ChannelReadinessService();
+    service.registerProbe(
+      makeProbe(
+        "phone",
+        [configured("creds")],
+        [
+          {
+            name: "inbound_delivery",
+            passed: true,
+            indeterminate: true,
+            message: "could not reach the provider",
+            kind: "operational",
+          },
+        ],
+      ),
+    );
+
+    const [snapshot] = await service.getReadiness("phone", true);
+    expect(snapshot.setupStatus).toBe("ready");
+    expect(snapshot.health).toBe("unknown");
+    // Unknown is not proof, so it cannot make the channel ready, and it is
+    // not a fault, so it must not be reported as one.
+    expect(snapshot.ready).toBe(false);
+    expect(snapshot.reasons).toEqual([]);
+  });
+
+  test("a channel that measures nothing operational reports no health at all", async () => {
+    // Absent, not "unknown": nothing was asked, so nothing is claimed, and
+    // readiness rests on configuration alone. This is the shape every channel
+    // without a delivery check still has today.
+    const service = new ChannelReadinessService();
+    service.registerProbe(makeProbe("phone", [configured("creds")]));
+
+    const [snapshot] = await service.getReadiness("phone", true);
+    expect(snapshot.health).toBeUndefined();
+    expect(snapshot.setupStatus).toBe("ready");
+    expect(snapshot.ready).toBe(true);
+  });
+
+  test("incomplete configuration still reads incomplete", async () => {
+    const service = new ChannelReadinessService();
+    service.registerProbe(
+      makeProbe("phone", [
+        configured("creds"),
+        { name: "ingress", passed: false, message: "no public URL" },
+      ]),
+    );
+
+    const [snapshot] = await service.getReadiness("phone", true);
+    expect(snapshot.setupStatus).toBe("incomplete");
+    expect(snapshot.ready).toBe(false);
+  });
+
+  test("an untouched channel is not_configured, not incomplete", async () => {
+    const service = new ChannelReadinessService();
+    service.registerProbe(
+      makeProbe("phone", [
+        { name: "creds", passed: false, message: "not configured" },
+      ]),
+    );
+
+    const [snapshot] = await service.getReadiness("phone", true);
+    expect(snapshot.setupStatus).toBe("not_configured");
+    expect(snapshot.ready).toBe(false);
+  });
+
+  test("ready still means every check verified, exactly as before", async () => {
+    // The safety property for this change: splitting the derivation must not
+    // move `ready` for any input, because the CLI and the web both gate on it.
+    const service = new ChannelReadinessService();
+    service.registerProbe(
+      makeProbe(
+        "phone",
+        [configured("creds")],
+        [
+          {
+            name: "inbound_delivery",
+            passed: true,
+            message: "arriving",
+            kind: "operational",
+          },
+        ],
+      ),
+    );
+
+    const [snapshot] = await service.getReadiness("phone", true);
+    expect(snapshot.ready).toBe(true);
+    expect(snapshot.health).toBe("ok");
+  });
+});

--- a/assistant/src/runtime/channel-readiness-service.ts
+++ b/assistant/src/runtime/channel-readiness-service.ts
@@ -534,13 +534,12 @@ export class ChannelReadinessService {
       // progress reports an untouched workspace as `incomplete`, which is what
       // sends the Channels UI down the "finish setup" path instead of the
       // normal setup flow.
-      // Two axes, not one ladder. Setup progress asks whether the channel is
-      // configured; health asks whether it is working. They were the same
-      // question only while readiness meant "are the credentials present", and
-      // stopped being the same the moment a check started reporting delivery:
-      // a fully configured channel whose socket just died is not half set up,
-      // and telling its owner to finish setup sends them to fix the one thing
-      // that is not broken.
+      // Two axes, not one ladder. Setup progress derives from configuration
+      // checks and health from operational ones, because "is this configured"
+      // and "is it working" have different answers and different remedies. A
+      // fully configured channel whose delivery is failing is not half set
+      // up, and reporting it as incomplete sends its owner to fix the one
+      // thing that is not broken.
       const configurationChecks = consideredChecks.filter(
         (c) => (c.kind ?? "configuration") === "configuration",
       );

--- a/assistant/src/runtime/channel-readiness-service.ts
+++ b/assistant/src/runtime/channel-readiness-service.ts
@@ -9,6 +9,7 @@ import { credentialKey } from "../security/credential-key.js";
 import { getSecureKeyAsync } from "../security/secure-keys.js";
 import { resolveWhatsAppDisplayNumber } from "./channel-invite-transports/whatsapp.js";
 import type {
+  ChannelHealth,
   ChannelId,
   ChannelProbe,
   ChannelProbeContext,
@@ -252,7 +253,10 @@ const telegramProbe: ChannelProbe = {
       "Telegram is delivering to this assistant",
       health.detail,
     );
-    return [indeterminate ? { ...result, indeterminate: true } : result];
+    const operational = { ...result, kind: "operational" as const };
+    return [
+      indeterminate ? { ...operational, indeterminate: true } : operational,
+    ];
   },
 };
 
@@ -519,14 +523,7 @@ export class ChannelReadinessService {
       // itself live on the strength of a check that never ran.
       const verified = (c: ReadinessCheckResult): boolean =>
         c.passed && !c.indeterminate;
-      const allLocalPassed = localChecks.every(verified);
-      const allRemotePassed =
-        remoteChecks && remoteChecksAffectReadiness
-          ? remoteChecks.every(verified)
-          : true;
-      const ready = allLocalPassed && allRemotePassed;
 
-      // setupStatus: considers all checks (credentials + infrastructure)
       const consideredChecks = [
         ...localChecks,
         ...(remoteChecks && remoteChecksAffectReadiness ? remoteChecks : []),
@@ -537,12 +534,38 @@ export class ChannelReadinessService {
       // progress reports an untouched workspace as `incomplete`, which is what
       // sends the Channels UI down the "finish setup" path instead of the
       // normal setup flow.
-      const anyCheckPassed = consideredChecks.some(verified);
-      const setupStatus: SetupStatus = !anyCheckPassed
+      // Two axes, not one ladder. Setup progress asks whether the channel is
+      // configured; health asks whether it is working. They were the same
+      // question only while readiness meant "are the credentials present", and
+      // stopped being the same the moment a check started reporting delivery:
+      // a fully configured channel whose socket just died is not half set up,
+      // and telling its owner to finish setup sends them to fix the one thing
+      // that is not broken.
+      const configurationChecks = consideredChecks.filter(
+        (c) => (c.kind ?? "configuration") === "configuration",
+      );
+      const operationalChecks = consideredChecks.filter(
+        (c) => c.kind === "operational",
+      );
+
+      const setupStatus: SetupStatus = !configurationChecks.some(verified)
         ? "not_configured"
-        : ready
+        : configurationChecks.every(verified)
           ? "ready"
           : "incomplete";
+
+      // Absent, not "unknown", when the channel asks no operational question.
+      // Nothing was measured, so nothing is claimed, and readiness rests on
+      // configuration alone. Collapsing that into `unknown` would report every
+      // channel without a delivery check as unverifiable.
+      const health: ChannelHealth | undefined =
+        operationalChecks.length === 0
+          ? undefined
+          : operationalChecks.some((c) => !c.passed)
+            ? "failing"
+            : operationalChecks.every(verified)
+              ? "ok"
+              : "unknown";
 
       const reasons: Array<{ code: string; text: string }> = [];
       for (const check of localChecks) {
@@ -560,8 +583,12 @@ export class ChannelReadinessService {
 
       const snapshot: ChannelReadinessSnapshot = {
         channel: ch,
-        ready,
+        ready:
+          setupStatus === "ready" &&
+          health !== "failing" &&
+          health !== "unknown",
         setupStatus,
+        health,
         checkedAt:
           remoteChecks && cached && !remoteChecksFreshlyFetched
             ? cached.checkedAt

--- a/assistant/src/runtime/channel-readiness-types.ts
+++ b/assistant/src/runtime/channel-readiness-types.ts
@@ -4,8 +4,46 @@ import type { ChannelId } from "../channels/types.js";
 
 export type { ChannelId };
 
-/** Setup progress for a channel: not_configured → incomplete → ready. */
-export type SetupStatus = "not_configured" | "incomplete" | "ready";
+/**
+ * Setup progress for a channel: not_configured → incomplete → ready.
+ *
+ * Progress only. A channel that is fully configured is `ready` here even when
+ * it is not currently working, because "have I finished setting this up" and
+ * "is it working right now" are different questions with different answers and
+ * different remedies. Operational state is {@link ChannelHealth}.
+ */
+export const SETUP_STATUSES = [
+  "not_configured",
+  "incomplete",
+  "ready",
+] as const;
+export type SetupStatus = (typeof SETUP_STATUSES)[number];
+
+/** What a check establishes. */
+export const CHECK_KINDS = [
+  /** Whether the channel is configured: credentials, ingress, policy. */
+  "configuration",
+  /** Whether the channel is currently working: is anything arriving. */
+  "operational",
+] as const;
+export type CheckKind = (typeof CHECK_KINDS)[number];
+
+/**
+ * Whether a configured channel is currently working.
+ *
+ * Absent when a channel measures no operational checks at all, which is not
+ * the same as failing to establish them: nothing was asked, so nothing is
+ * claimed either way, and readiness is decided on configuration alone.
+ */
+export const CHANNEL_HEALTHS = [
+  /** Every operational check confirmed the channel is working. */
+  "ok",
+  /** An operational check found a fault. */
+  "failing",
+  /** Operational checks ran but established nothing either way. */
+  "unknown",
+] as const;
+export type ChannelHealth = (typeof CHANNEL_HEALTHS)[number];
 
 /** Result of a single readiness check (local or remote). */
 export interface ReadinessCheckResult {
@@ -30,13 +68,22 @@ export interface ReadinessCheckResult {
    * require this to be absent or false.
    */
   indeterminate?: boolean;
+  /**
+   * Which question this check answers. Defaults to `configuration`, so a
+   * check that does not say is treated as setup evidence rather than as a
+   * claim about whether the channel is working.
+   */
+  kind?: CheckKind;
 }
 
 /** Point-in-time snapshot of a channel's readiness state. */
 export interface ChannelReadinessSnapshot {
   channel: ChannelId;
+  /** Configured and confirmed working: `setupStatus === "ready"` and health is not in doubt. */
   ready: boolean;
   setupStatus: SetupStatus;
+  /** Absent when the channel measures no operational checks. */
+  health?: ChannelHealth;
   checkedAt: number;
   stale: boolean;
   reasons: Array<{ code: string; text: string }>;

--- a/assistant/src/runtime/routes/channel-readiness-routes.ts
+++ b/assistant/src/runtime/routes/channel-readiness-routes.ts
@@ -14,6 +14,11 @@ import {
   getInviteAdapterRegistry,
   resolveAdapterHandle,
 } from "../channel-invite-transport.js";
+import {
+  CHANNEL_HEALTHS,
+  CHECK_KINDS,
+  SETUP_STATUSES,
+} from "../channel-readiness-types.js";
 import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
 
 async function enrichSnapshots(
@@ -32,6 +37,7 @@ async function enrichSnapshots(
         channel: s.channel,
         ready: s.ready,
         setupStatus: s.setupStatus,
+        health: s.health,
         checkedAt: s.checkedAt,
         stale: s.stale,
         reasons: s.reasons,
@@ -89,15 +95,21 @@ const readinessCheckSchema = z.object({
   name: z.string(),
   passed: z.boolean(),
   message: z.string().nullable().optional(),
+  // `passed` alone cannot say "I could not tell", and dropping this at the
+  // boundary is why a client cannot distinguish a channel that is broken from
+  // one whose state could not be established.
+  indeterminate: z.boolean().optional(),
+  kind: z.enum(CHECK_KINDS).optional(),
 });
 
 const readinessSnapshotSchema = z.object({
   channel: z.enum(CHANNEL_IDS),
   ready: z.boolean(),
-  setupStatus: z.string().nullable().optional(),
+  setupStatus: z.enum(SETUP_STATUSES).nullable().optional(),
+  health: z.enum(CHANNEL_HEALTHS).optional(),
   checkedAt: z.number().nullable().optional(),
   stale: z.boolean().optional(),
-  reasons: z.array(z.string()).optional(),
+  reasons: z.array(z.object({ code: z.string(), text: z.string() })).optional(),
   localChecks: z.array(readinessCheckSchema).optional(),
   remoteChecks: z.array(readinessCheckSchema).optional(),
   channelHandle: z.string().nullable().optional(),

--- a/clients/web/src/hooks/use-assistant-channels.ts
+++ b/clients/web/src/hooks/use-assistant-channels.ts
@@ -266,11 +266,16 @@ function toChannelStatus(
   if (!snap) {
     return "not_configured";
   }
-  if (snap.ready || snap.setupStatus === "ready") {
+  // `ready` is the only thing that means working. `setupStatus` is progress:
+  // a fully configured channel whose delivery is failing reports
+  // `setupStatus: "ready"` and `ready: false`, and treating the former as
+  // connected would show a broken channel as healthy. The CLI already reads
+  // it in this order.
+  if (snap.ready) {
     return "ready";
   }
-  if (snap.setupStatus === "incomplete") {
-    return "incomplete";
+  if (snap.setupStatus === "not_configured") {
+    return "not_configured";
   }
-  return "not_configured";
+  return "incomplete";
 }


### PR DESCRIPTION
## TL;DR

Readiness collapsed two different questions into one ladder. A fully configured channel whose delivery just failed reports `setupStatus: "incomplete"`, and the product tells its owner to **finish setup** — the one thing that is not broken.

Checks now say which question they answer. `setupStatus` derives from configuration alone; a new `health` derives from operational checks.

## Why this exists

`not_configured → incomplete → ready` is a progress axis, and `ready` was every check passing. That was correct while readiness meant "are the credentials present."

It stopped being correct when checks began reporting *delivery*. Since then, "have I finished setting this up" and "is it working right now" have been different questions with different answers and different remedies, and one ladder cannot carry both.

This is a live bug today for Telegram, independent of anything else in flight.

## The shape

| | before | after |
| --- | --- | --- |
| Configured, delivering | `ready`, ready=true | `ready` + `health: ok`, ready=true |
| Configured, delivery **failing** | `incomplete`, ready=false | `ready` + `health: failing`, ready=false |
| Configured, delivery **unverifiable** | `incomplete`, ready=false | `ready` + `health: unknown`, ready=false |
| Half configured | `incomplete` | `incomplete` |
| Untouched | `not_configured` | `not_configured` |

`health` is **absent**, not `"unknown"`, when a channel measures nothing operational. Nothing was asked, so nothing is claimed, and readiness rests on configuration alone. Collapsing those would report every channel without a delivery check as unverifiable, which is most of them today.

## Why it is safe

**`ready` does not move for any input.** It was "every considered check verified" and it still is, because configuration and operational checks partition exactly that set. The CLI and the web both gate on `ready`, and neither needed to change for it.

The web needed one fix for a different reason: `toChannelStatus` treated `setupStatus === "ready"` as connected. Under honest data that would render a *broken* channel as healthy, so it reads `ready` first now — which is what the CLI's `statusGlyph` already did. Rendering is byte-identical to today; only the data underneath became honest.

## Three wire defects fixed on the way

All in the schema this change already edits:

- **`indeterminate` was not on the wire at all.** The field that decides whether a channel may claim ready was stripped at the boundary, so no client could distinguish "broken" from "could not tell". That is why this could not have been fixed UI-side alone.
- **`reasons` was typed `Array<string>`** while the daemon sends `{ code, text }`. The generated client was simply wrong. Nothing in the web reads it yet, so this was a landmine rather than a live bug.
- **`setupStatus` was a bare `string`**, losing its union in the generated type.

The three unions now have canonical `as const` arrays that both the TypeScript type and the Zod wire schema derive from, so the schema cannot drift from the model again.

## Tests

Each row of the table above, plus the safety property stated explicitly: `ready` still means every check verified. The "measures nothing operational" case is pinned separately, because that is the shape every channel without a delivery check still has.

## What this unblocks

The Slack socket-health work in #41137, currently parked in draft. Its delivery check becomes an `operational` check and can sit in `runRemoteChecks` beside Telegram's, where it belongs semantically, rather than in the local array where I had moved it to dodge a five-minute cache.

Follow-up, deliberately not here: `health` is carried to the client but nothing renders it distinctly yet, so "broken" and "half set up" still look the same in the UI. That needs new copy and belongs with the Channels presentation work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41146" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->