### PR TITLE
feat(approvals): standing workspace-command grants for trusted contacts

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -7906,6 +7906,76 @@ paths:
                   - removedCount
                   - conversationId
                 additionalProperties: false
+  /v1/conversations/{id}/workspace-commands:
+    get:
+      operationId: conversations_by_id_workspacecommands_get
+      summary: Get workspace commands for contacts
+      description: Whether trusted contacts may run workspace shell commands in this conversation without a per-command approval.
+      tags:
+        - conversations
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  conversationId:
+                    type: string
+                  enabled:
+                    type: boolean
+                required:
+                  - conversationId
+                  - enabled
+                additionalProperties: false
+    put:
+      operationId: conversations_by_id_workspacecommands_put
+      summary: Set workspace commands for contacts
+      description:
+        Enable or disable standing workspace shell access for trusted contacts in this conversation. High-risk
+        commands still require approval.
+      tags:
+        - conversations
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                enabled:
+                  type: boolean
+              required:
+                - enabled
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  conversationId:
+                    type: string
+                  enabled:
+                    type: boolean
+                required:
+                  - conversationId
+                  - enabled
+                additionalProperties: false
   /v1/conversations/archive/bulk:
     post:
       operationId: conversations_archive_bulk_post
@@ -8223,6 +8293,82 @@ paths:
                   - channelId
                   - threadTs
                   - source
+                additionalProperties: false
+  /v1/conversations/cli/workspace-commands/get:
+    post:
+      operationId: conversations_cli_workspacecommands_get_post
+      summary: Get workspace commands for contacts (CLI)
+      description: Look up standing workspace-command access by conversation ID, Slack channel, or Slack user.
+      tags:
+        - conversations
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                conversationId:
+                  type: string
+                slackChannelId:
+                  type: string
+                slackUserId:
+                  type: string
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  conversationId:
+                    type: string
+                  enabled:
+                    type: boolean
+                required:
+                  - conversationId
+                  - enabled
+                additionalProperties: false
+  /v1/conversations/cli/workspace-commands/set:
+    post:
+      operationId: conversations_cli_workspacecommands_set_post
+      summary: Set workspace commands for contacts (CLI)
+      description: Enable or disable standing workspace-command access by conversation ID, Slack channel, or Slack user.
+      tags:
+        - conversations
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                conversationId:
+                  type: string
+                slackChannelId:
+                  type: string
+                slackUserId:
+                  type: string
+                enabled:
+                  type: boolean
+              required:
+                - enabled
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  conversationId:
+                    type: string
+                  enabled:
+                    type: boolean
+                required:
+                  - conversationId
+                  - enabled
                 additionalProperties: false
   /v1/conversations/fork:
     post:

--- a/assistant/src/__tests__/approval-primitive.test.ts
+++ b/assistant/src/__tests__/approval-primitive.test.ts
@@ -603,4 +603,74 @@ describe("approval-primitive / consumeGrantForInvocation retry", () => {
     // Should return nearly instantly — no retry loop
     expect(elapsed).toBeLessThan(100);
   });
+
+  test("mints a conversation_tool grant when conversationId and toolName are set", () => {
+    const result = mintGrantFromDecision(
+      mintParams({
+        scopeMode: "conversation_tool",
+        toolName: "bash",
+        conversationId: "conv-xyz",
+      }),
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    expect(result.grant.scopeMode).toBe("conversation_tool");
+    expect(result.grant.conversationId).toBe("conv-xyz");
+    expect(result.grant.toolName).toBe("bash");
+  });
+
+  test("rejects conversation_tool scope when conversationId is missing", () => {
+    const result = mintGrantFromDecision(
+      mintParams({
+        scopeMode: "conversation_tool",
+        toolName: "bash",
+        conversationId: null,
+      }),
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      return;
+    }
+    expect(result.reason).toBe("missing_conversation_fields");
+  });
+
+  test("consumeGrantForInvocation peeks a conversation_tool grant without consuming it", async () => {
+    mintGrantFromDecision(
+      mintParams({
+        scopeMode: "conversation_tool",
+        toolName: "bash",
+        conversationId: "conv-xyz",
+      }),
+    );
+
+    const first = await consumeGrantForInvocation(
+      {
+        toolName: "bash",
+        inputDigest: "sha256:first",
+        consumingRequestId: "c1",
+        conversationId: "conv-xyz",
+        requesterExternalUserId: "user-123",
+      },
+      { maxWaitMs: 0 },
+    );
+    expect(first.ok).toBe(true);
+
+    const second = await consumeGrantForInvocation(
+      {
+        toolName: "bash",
+        inputDigest: "sha256:second",
+        consumingRequestId: "c2",
+        conversationId: "conv-xyz",
+        requesterExternalUserId: "user-123",
+      },
+      { maxWaitMs: 0 },
+    );
+    expect(second.ok).toBe(true);
+    if (first.ok && second.ok) {
+      expect(first.grant.id).toBe(second.grant.id);
+      expect(second.grant.status).toBe("active");
+    }
+  });
 });

--- a/assistant/src/__tests__/approval-primitive.test.ts
+++ b/assistant/src/__tests__/approval-primitive.test.ts
@@ -636,7 +636,7 @@ describe("approval-primitive / consumeGrantForInvocation retry", () => {
     expect(result.reason).toBe("missing_conversation_fields");
   });
 
-  test("consumeGrantForInvocation peeks a conversation_tool grant without consuming it", async () => {
+  test("consumeGrantForInvocation does not treat a conversation_tool grant as a one-shot consume", async () => {
     mintGrantFromDecision(
       mintParams({
         scopeMode: "conversation_tool",
@@ -645,7 +645,7 @@ describe("approval-primitive / consumeGrantForInvocation retry", () => {
       }),
     );
 
-    const first = await consumeGrantForInvocation(
+    const result = await consumeGrantForInvocation(
       {
         toolName: "bash",
         inputDigest: "sha256:first",
@@ -655,22 +655,6 @@ describe("approval-primitive / consumeGrantForInvocation retry", () => {
       },
       { maxWaitMs: 0 },
     );
-    expect(first.ok).toBe(true);
-
-    const second = await consumeGrantForInvocation(
-      {
-        toolName: "bash",
-        inputDigest: "sha256:second",
-        consumingRequestId: "c2",
-        conversationId: "conv-xyz",
-        requesterExternalUserId: "user-123",
-      },
-      { maxWaitMs: 0 },
-    );
-    expect(second.ok).toBe(true);
-    if (first.ok && second.ok) {
-      expect(first.grant.id).toBe(second.grant.id);
-      expect(second.grant.status).toBe("active");
-    }
+    expect(result.ok).toBe(false);
   });
 });

--- a/assistant/src/__tests__/scoped-approval-grants.test.ts
+++ b/assistant/src/__tests__/scoped-approval-grants.test.ts
@@ -547,3 +547,145 @@ describe("tool-approval-digest", () => {
     expect(d1).toBe(d2);
   });
 });
+
+describe("scoped-approval-grants / conversation_tool scope", () => {
+  beforeEach(() => clearTables());
+
+  const {
+    peekConversationToolGrant,
+    findActiveConversationToolGrant,
+    hasActiveConversationToolGrant,
+    revokeConversationToolGrants,
+  } = _internal;
+
+  test("peek matches an active grant and does not consume it", () => {
+    const grant = createScopedApprovalGrant(
+      grantParams({
+        scopeMode: "conversation_tool",
+        toolName: "bash",
+        conversationId: "conv-xyz",
+      }),
+    );
+
+    const first = peekConversationToolGrant({
+      toolName: "bash",
+      conversationId: "conv-xyz",
+    });
+    expect(first?.id).toBe(grant.id);
+    expect(first?.status).toBe("active");
+
+    const second = peekConversationToolGrant({
+      toolName: "bash",
+      conversationId: "conv-xyz",
+    });
+    expect(second?.id).toBe(grant.id);
+    expect(second?.status).toBe("active");
+  });
+
+  test("peek prefers a requester-specific grant over a wildcard", () => {
+    const wildcard = createScopedApprovalGrant(
+      grantParams({
+        scopeMode: "conversation_tool",
+        toolName: "bash",
+        conversationId: "conv-xyz",
+      }),
+    );
+    const specific = createScopedApprovalGrant(
+      grantParams({
+        scopeMode: "conversation_tool",
+        toolName: "bash",
+        conversationId: "conv-xyz",
+        requesterExternalUserId: "user-123",
+      }),
+    );
+
+    const peeked = peekConversationToolGrant({
+      toolName: "bash",
+      conversationId: "conv-xyz",
+      requesterExternalUserId: "user-123",
+    });
+    expect(peeked?.id).toBe(specific.id);
+    expect(wildcard.id).not.toBe(specific.id);
+  });
+
+  test("peek with a requester still matches a wildcard grant", () => {
+    const grant = createScopedApprovalGrant(
+      grantParams({
+        scopeMode: "conversation_tool",
+        toolName: "bash",
+        conversationId: "conv-xyz",
+      }),
+    );
+
+    const peeked = peekConversationToolGrant({
+      toolName: "bash",
+      conversationId: "conv-xyz",
+      requesterExternalUserId: "user-123",
+    });
+    expect(peeked?.id).toBe(grant.id);
+  });
+
+  test("peek does not match a different conversation or tool", () => {
+    createScopedApprovalGrant(
+      grantParams({
+        scopeMode: "conversation_tool",
+        toolName: "bash",
+        conversationId: "conv-xyz",
+      }),
+    );
+
+    expect(
+      peekConversationToolGrant({
+        toolName: "bash",
+        conversationId: "conv-other",
+      }),
+    ).toBeNull();
+    expect(
+      peekConversationToolGrant({
+        toolName: "host_bash",
+        conversationId: "conv-xyz",
+      }),
+    ).toBeNull();
+  });
+
+  test("revokeConversationToolGrants revokes only conversation_tool rows", () => {
+    createScopedApprovalGrant(
+      grantParams({
+        scopeMode: "conversation_tool",
+        toolName: "bash",
+        conversationId: "conv-xyz",
+      }),
+    );
+    createScopedApprovalGrant(
+      grantParams({
+        scopeMode: "tool_signature",
+        toolName: "bash",
+        inputDigest: "sha256:keep",
+        conversationId: "conv-xyz",
+      }),
+    );
+
+    expect(revokeConversationToolGrants("conv-xyz", "bash")).toBe(1);
+    expect(
+      hasActiveConversationToolGrant({
+        toolName: "bash",
+        conversationId: "conv-xyz",
+      }),
+    ).toBe(false);
+    expect(
+      findActiveConversationToolGrant({
+        toolName: "bash",
+        conversationId: "conv-xyz",
+        requesterExternalUserId: null,
+      }),
+    ).toBeNull();
+
+    const leftover = consumeScopedApprovalGrantByToolSignature({
+      toolName: "bash",
+      inputDigest: "sha256:keep",
+      consumingRequestId: "c1",
+      conversationId: "conv-xyz",
+    });
+    expect(leftover.ok).toBe(true);
+  });
+});

--- a/assistant/src/__tests__/tool-approval-handler.test.ts
+++ b/assistant/src/__tests__/tool-approval-handler.test.ts
@@ -1240,6 +1240,81 @@ describe("ToolApprovalHandler / unparseable tool args gate", () => {
   });
 });
 
+describe("ToolApprovalHandler / conversation_tool standing grant", () => {
+  const handler = new ToolApprovalHandler();
+
+  beforeEach(() => {
+    clearTables();
+    resetAuditCalls();
+  });
+
+  test("trusted_contact + standing grant allows medium sandbox bash", async () => {
+    mintGrantFromDecision(
+      mintParams({
+        scopeMode: "conversation_tool",
+        toolName: "bash",
+        conversationId: "conv-1",
+      }),
+    );
+
+    const first = await handler.checkPreExecutionGates(
+      "bash",
+      { command: "find /workspace -name '*.csv'" },
+      makeContext({ trustClass: "trusted_contact" }),
+      "medium",
+      Date.now(),
+    );
+    expect(first.allowed).toBe(true);
+
+    const second = await handler.checkPreExecutionGates(
+      "bash",
+      { command: "sed -n '1,20p' /workspace/sales.csv" },
+      makeContext({ trustClass: "trusted_contact" }),
+      "medium",
+      Date.now(),
+    );
+    expect(second.allowed).toBe(true);
+  });
+
+  test("standing grant does not cover unknown actors", async () => {
+    mintGrantFromDecision(
+      mintParams({
+        scopeMode: "conversation_tool",
+        toolName: "bash",
+        conversationId: "conv-1",
+      }),
+    );
+
+    const result = await handler.checkPreExecutionGates(
+      "bash",
+      { command: "ls" },
+      makeContext({ trustClass: "unknown" }),
+      "medium",
+      Date.now(),
+    );
+    expect(result.allowed).toBe(false);
+  });
+
+  test("standing bash grant does not cover host_bash", async () => {
+    mintGrantFromDecision(
+      mintParams({
+        scopeMode: "conversation_tool",
+        toolName: "bash",
+        conversationId: "conv-1",
+      }),
+    );
+
+    const result = await handler.checkPreExecutionGates(
+      "host_bash",
+      { command: "ls" },
+      makeContext({ trustClass: "trusted_contact" }),
+      "medium",
+      Date.now(),
+    );
+    expect(result.allowed).toBe(false);
+  });
+});
+
 afterAll(() => {
   mock.restore();
 });

--- a/assistant/src/__tests__/tool-grant-request-escalation.test.ts
+++ b/assistant/src/__tests__/tool-grant-request-escalation.test.ts
@@ -650,4 +650,81 @@ describe("inline wait-and-resume", () => {
     });
     expect(requests.length).toBe(0);
   });
+
+  test("approving bash mints a standing conversation_tool grant", async () => {
+    const req = seedGrantRequest("sha256:standing");
+
+    const result = await applyGuardianDecision({
+      requestId: req.id,
+      action: "approve_once",
+      actorContext: guardianActor(),
+    });
+    expect(result.applied).toBe(true);
+
+    const rows = getDb().select().from(scopedApprovalGrants).all();
+    expect(
+      rows.some(
+        (row) =>
+          row.scopeMode === "conversation_tool" &&
+          row.toolName === "bash" &&
+          row.conversationId === "conv-1" &&
+          row.status === "active",
+      ),
+    ).toBe(true);
+    expect(
+      rows.some(
+        (row) =>
+          row.scopeMode === "tool_signature" &&
+          row.inputDigest === "sha256:standing",
+      ),
+    ).toBe(true);
+  });
+
+  test("standing grant lets a later medium bash proceed without a new card", async () => {
+    const laterHandler = new ToolApprovalHandler({
+      inlineGrantWait: TEST_INLINE_WAIT_CONFIG,
+    });
+    const req = seedGrantRequest("sha256:first-cmd");
+    await applyGuardianDecision({
+      requestId: req.id,
+      action: "approve_once",
+      actorContext: guardianActor(),
+    });
+
+    const result = await laterHandler.checkPreExecutionGates(
+      "bash",
+      { command: "find /workspace -name sales.csv" },
+      makeContext({ requestId: "req-later" }),
+      "medium",
+      Date.now(),
+    );
+    expect(result.allowed).toBe(true);
+
+    const pending = await sim.module.listGuardianRequestsOrEmpty({
+      kind: "tool_grant_request",
+      status: "pending",
+    });
+    expect(pending.length).toBe(0);
+  });
+
+  test("standing grant does not skip high-risk bash", async () => {
+    const laterHandler = new ToolApprovalHandler({
+      inlineGrantWait: TEST_INLINE_WAIT_CONFIG,
+    });
+    const req = seedGrantRequest("sha256:first-cmd");
+    await applyGuardianDecision({
+      requestId: req.id,
+      action: "approve_once",
+      actorContext: guardianActor(),
+    });
+
+    const result = await laterHandler.checkPreExecutionGates(
+      "bash",
+      { command: "rm -rf /workspace" },
+      makeContext({ requestId: "req-high" }),
+      "high",
+      Date.now(),
+    );
+    expect(result.allowed).toBe(false);
+  });
 });

--- a/assistant/src/approvals/__tests__/conversation-tool-grant.test.ts
+++ b/assistant/src/approvals/__tests__/conversation-tool-grant.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { getDb } from "../../persistence/db-connection.js";
+import { initializeDb } from "../../persistence/db-init.js";
+import { scopedApprovalGrants } from "../../persistence/schema/index.js";
+import {
+  conversationWorkspaceCommandsEnabled,
+  disableConversationWorkspaceCommands,
+  upsertConversationToolGrant,
+} from "../conversation-tool-grant.js";
+
+await initializeDb();
+
+function clearTables(): void {
+  getDb().delete(scopedApprovalGrants).run();
+}
+
+describe("conversation-tool-grant", () => {
+  beforeEach(() => clearTables());
+
+  test("upsert is idempotent for the same conversation", () => {
+    const first = upsertConversationToolGrant({
+      conversationId: "conv-xyz",
+      requestChannel: "cli",
+      decisionChannel: "cli",
+    });
+    const second = upsertConversationToolGrant({
+      conversationId: "conv-xyz",
+      requestChannel: "cli",
+      decisionChannel: "cli",
+    });
+    expect(second.id).toBe(first.id);
+    expect(conversationWorkspaceCommandsEnabled("conv-xyz")).toBe(true);
+  });
+
+  test("disable revokes the standing grant", () => {
+    upsertConversationToolGrant({
+      conversationId: "conv-xyz",
+      requestChannel: "http",
+      decisionChannel: "http",
+    });
+    expect(disableConversationWorkspaceCommands("conv-xyz")).toBe(1);
+    expect(conversationWorkspaceCommandsEnabled("conv-xyz")).toBe(false);
+  });
+});

--- a/assistant/src/approvals/approval-primitive.ts
+++ b/assistant/src/approvals/approval-primitive.ts
@@ -15,6 +15,7 @@ import {
   _internal,
   type ConsumeByRequestIdResult,
   type ConsumeByToolSignatureResult,
+  type ScopeMode,
   type ScopedApprovalGrant,
 } from "./scoped-approval-grants.js";
 
@@ -22,6 +23,7 @@ const {
   createScopedApprovalGrant,
   consumeScopedApprovalGrantByRequestId,
   consumeScopedApprovalGrantByToolSignature,
+  peekConversationToolGrant,
 } = _internal;
 import { getLogger } from "../util/logger.js";
 
@@ -32,7 +34,7 @@ const log = getLogger("approval-primitive");
 // ---------------------------------------------------------------------------
 
 export interface MintGrantParams {
-  scopeMode: "request_id" | "tool_signature";
+  scopeMode: ScopeMode;
   requestId?: string | null;
   toolName?: string | null;
   inputDigest?: string | null;
@@ -50,7 +52,11 @@ type MintGrantResult =
   | { ok: true; grant: ScopedApprovalGrant }
   | {
       ok: false;
-      reason: "missing_request_id" | "missing_tool_fields" | "storage_error";
+      reason:
+        | "missing_request_id"
+        | "missing_tool_fields"
+        | "missing_conversation_fields"
+        | "storage_error";
       error?: unknown;
     };
 
@@ -61,6 +67,7 @@ type MintGrantResult =
  * storage layer:
  *   - `request_id` scope requires a non-null `requestId`.
  *   - `tool_signature` scope requires both `toolName` and `inputDigest`.
+ *   - `conversation_tool` scope requires both `toolName` and `conversationId`.
  *
  * Returns a discriminated result so callers can inspect failure reasons
  * without catching exceptions.
@@ -100,6 +107,25 @@ export function mintGrantFromDecision(
       "Mint rejected: tool_signature scope requires both toolName and inputDigest",
     );
     return { ok: false, reason: "missing_tool_fields" };
+  }
+
+  if (
+    params.scopeMode === "conversation_tool" &&
+    (!params.toolName || !params.conversationId)
+  ) {
+    log.warn(
+      {
+        event: "approval_primitive_mint_rejected",
+        reason: "missing_conversation_fields",
+        scopeMode: params.scopeMode,
+        toolName: params.toolName ?? null,
+        conversationId: params.conversationId ?? null,
+        requestChannel: params.requestChannel,
+        decisionChannel: params.decisionChannel,
+      },
+      "Mint rejected: conversation_tool scope requires both toolName and conversationId",
+    );
+    return { ok: false, reason: "missing_conversation_fields" };
   }
 
   try {
@@ -268,6 +294,29 @@ function consumeGrantSync(params: ConsumeGrantParams): ConsumeGrantResult {
     },
     "No tool_signature grant match found",
   );
+
+  if (params.conversationId) {
+    const standing = peekConversationToolGrant({
+      toolName: params.toolName,
+      conversationId: params.conversationId,
+      requesterExternalUserId: params.requesterExternalUserId,
+      now: params.now,
+    });
+    if (standing) {
+      log.info(
+        {
+          event: "approval_primitive_peek_hit",
+          mode: "conversation_tool",
+          grantId: standing.id,
+          toolName: params.toolName,
+          conversationId: params.conversationId,
+          consumingRequestId: params.consumingRequestId,
+        },
+        "Standing conversation_tool grant peeked",
+      );
+      return { ok: true, grant: standing };
+    }
+  }
 
   return { ok: false, reason: "no_match" };
 }

--- a/assistant/src/approvals/approval-primitive.ts
+++ b/assistant/src/approvals/approval-primitive.ts
@@ -295,30 +295,16 @@ function consumeGrantSync(params: ConsumeGrantParams): ConsumeGrantResult {
     "No tool_signature grant match found",
   );
 
-  if (params.conversationId) {
-    const standing = peekConversationToolGrant({
-      toolName: params.toolName,
-      conversationId: params.conversationId,
-      requesterExternalUserId: params.requesterExternalUserId,
-      now: params.now,
-    });
-    if (standing) {
-      log.info(
-        {
-          event: "approval_primitive_peek_hit",
-          mode: "conversation_tool",
-          grantId: standing.id,
-          toolName: params.toolName,
-          conversationId: params.conversationId,
-          consumingRequestId: params.consumingRequestId,
-        },
-        "Standing conversation_tool grant peeked",
-      );
-      return { ok: true, grant: standing };
-    }
-  }
-
   return { ok: false, reason: "no_match" };
+}
+
+export function peekConversationToolGrantForInvocation(params: {
+  toolName: string;
+  conversationId: string;
+  requesterExternalUserId?: string;
+  now?: number;
+}): ScopedApprovalGrant | null {
+  return peekConversationToolGrant(params);
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/approvals/conversation-tool-grant.ts
+++ b/assistant/src/approvals/conversation-tool-grant.ts
@@ -1,0 +1,89 @@
+/**
+ * Standing conversation_tool grants for sandbox workspace commands.
+ *
+ * A grant authorizes trusted contacts to run sandbox `bash` in one
+ * conversation without a per-command guardian card. High-risk bash still
+ * escalates. host_bash is never covered.
+ */
+
+import { mintGrantFromDecision } from "./approval-primitive.js";
+import {
+  _internal,
+  type ScopedApprovalGrant,
+} from "./scoped-approval-grants.js";
+
+const {
+  findActiveConversationToolGrant,
+  hasActiveConversationToolGrant,
+  revokeConversationToolGrants,
+} = _internal;
+
+/** Sandbox tool covered by a conversation workspace-commands grant. */
+export const CONVERSATION_WORKSPACE_COMMANDS_TOOL = "bash";
+
+/**
+ * Standing grants last until revoked. expireScopedApprovalGrants sweeps
+ * any row whose expiresAt is in the past, so this must be far in the future.
+ */
+export const CONVERSATION_TOOL_GRANT_EXPIRES_AT = Date.parse(
+  "2099-12-31T00:00:00.000Z",
+);
+
+export interface UpsertConversationToolGrantParams {
+  conversationId: string;
+  requestChannel: string;
+  decisionChannel: string;
+  requesterExternalUserId?: string | null;
+  guardianExternalUserId?: string | null;
+  toolName?: string;
+}
+
+export function upsertConversationToolGrant(
+  params: UpsertConversationToolGrantParams,
+): ScopedApprovalGrant {
+  const toolName = params.toolName ?? CONVERSATION_WORKSPACE_COMMANDS_TOOL;
+  const requesterExternalUserId = params.requesterExternalUserId ?? null;
+
+  const existing = findActiveConversationToolGrant({
+    toolName,
+    conversationId: params.conversationId,
+    requesterExternalUserId,
+  });
+  if (existing) {
+    return existing;
+  }
+
+  const result = mintGrantFromDecision({
+    scopeMode: "conversation_tool",
+    toolName,
+    requestChannel: params.requestChannel,
+    decisionChannel: params.decisionChannel,
+    conversationId: params.conversationId,
+    requesterExternalUserId,
+    guardianExternalUserId: params.guardianExternalUserId ?? null,
+    expiresAt: CONVERSATION_TOOL_GRANT_EXPIRES_AT,
+  });
+
+  if (!result.ok) {
+    throw new Error(`Failed to mint conversation_tool grant: ${result.reason}`);
+  }
+
+  return result.grant;
+}
+
+export function conversationWorkspaceCommandsEnabled(
+  conversationId: string,
+  toolName: string = CONVERSATION_WORKSPACE_COMMANDS_TOOL,
+): boolean {
+  return hasActiveConversationToolGrant({
+    toolName,
+    conversationId,
+  });
+}
+
+export function disableConversationWorkspaceCommands(
+  conversationId: string,
+  toolName: string = CONVERSATION_WORKSPACE_COMMANDS_TOOL,
+): number {
+  return revokeConversationToolGrants(conversationId, toolName);
+}

--- a/assistant/src/approvals/guardian-decision-primitive.ts
+++ b/assistant/src/approvals/guardian-decision-primitive.ts
@@ -46,6 +46,7 @@ import {
 } from "../runtime/channel-approval-types.js";
 import { getLogger } from "../util/logger.js";
 import { mintGrantFromDecision } from "./approval-primitive.js";
+import { upsertConversationToolGrant } from "./conversation-tool-grant.js";
 import { withdrawGuardianRequestCards } from "./guardian-card-withdrawal.js";
 import {
   type ActorContext,
@@ -97,6 +98,34 @@ export function mintGuardianRequestGrant(params: {
     return { minted: false };
   }
 
+  let standingMinted = false;
+  if (
+    request.kind === "tool_grant_request" &&
+    request.toolName === "bash" &&
+    request.sourceConversationId
+  ) {
+    try {
+      upsertConversationToolGrant({
+        conversationId: request.sourceConversationId,
+        requestChannel: request.sourceChannel ?? "unknown",
+        decisionChannel: actorChannel,
+        requesterExternalUserId: request.requesterExternalUserId ?? null,
+        guardianExternalUserId: guardianExternalUserId ?? null,
+      });
+      standingMinted = true;
+    } catch (error) {
+      log.error(
+        {
+          event: "conversation_tool_grant_mint_failed",
+          err: error,
+          requestId: request.id,
+          conversationId: request.sourceConversationId,
+        },
+        "Failed to mint standing conversation_tool grant (non-fatal)",
+      );
+    }
+  }
+
   const result = mintGrantFromDecision({
     scopeMode: "tool_signature",
     toolName: request.toolName,
@@ -118,6 +147,7 @@ export function mintGuardianRequestGrant(params: {
         requestId: request.id,
         toolName: request.toolName,
         conversationId: request.sourceConversationId,
+        standingMinted,
       },
       "Minted scoped approval grant for guardian request",
     );
@@ -133,7 +163,7 @@ export function mintGuardianRequestGrant(params: {
     },
     "Failed to mint scoped approval grant for guardian request (non-fatal)",
   );
-  return { minted: false };
+  return { minted: standingMinted };
 }
 
 // ---------------------------------------------------------------------------

--- a/assistant/src/approvals/scoped-approval-grants.ts
+++ b/assistant/src/approvals/scoped-approval-grants.ts
@@ -1,14 +1,19 @@
 /**
- * CRUD and atomic consume for scoped approval grants.
+ * CRUD, atomic consume, and peek for scoped approval grants.
  *
- * Grants authorise exactly one tool execution.  Two scope modes exist:
- *   - `request_id`      — grant is bound to a specific pending request
- *   - `tool_signature`  — grant is bound to a tool name + input digest
+ * Scope modes:
+ *   - `request_id`         grant is bound to a specific pending request
+ *   - `tool_signature`     grant is bound to a tool name + input digest
+ *   - `conversation_tool`  standing grant bound to a conversation + tool name
+ *
+ * `request_id` and `tool_signature` authorise exactly one tool execution
+ * (CAS: active -> consumed). `conversation_tool` is peeked and left active
+ * so later matching invocations in that conversation can reuse it.
  *
  * Invariants:
- *   - At most one successful consume per grant (CAS: active -> consumed).
+ *   - At most one successful consume per consumable grant.
  *   - Matching requires all non-null scope fields to match exactly.
- *   - Expired and revoked grants cannot be consumed.
+ *   - Expired and revoked grants cannot be consumed or peeked.
  */
 
 import { and, eq, sql } from "drizzle-orm";
@@ -25,7 +30,7 @@ const log = getLogger("scoped-approval-grants");
 // Types
 // ---------------------------------------------------------------------------
 
-export type ScopeMode = "request_id" | "tool_signature";
+export type ScopeMode = "request_id" | "tool_signature" | "conversation_tool";
 export type GrantStatus = "active" | "consumed" | "expired" | "revoked";
 
 export interface ScopedApprovalGrant {
@@ -541,11 +546,197 @@ export function revokeScopedApprovalGrantsForContext(
   return count;
 }
 
-// @internal — exposed for tests and the approval-primitive wrapper only.
+// ---------------------------------------------------------------------------
+// Peek conversation_tool (does not consume)
+// ---------------------------------------------------------------------------
+
+export interface PeekConversationToolGrantParams {
+  toolName: string;
+  conversationId: string;
+  requesterExternalUserId?: string;
+  now?: number;
+}
+
+/**
+ * Look up an active conversation_tool grant without changing its status.
+ *
+ * conversationId and toolName must match exactly. A grant with a null
+ * requester matches any caller; a grant with a requester matches only
+ * that requester. When both a specific and a wildcard grant match,
+ * the specific grant is preferred.
+ */
+function peekConversationToolGrant(
+  params: PeekConversationToolGrantParams,
+): ScopedApprovalGrant | null {
+  const db = getDb();
+  const currentTime = params.now ?? Date.now();
+
+  const conditions = [
+    eq(scopedApprovalGrants.scopeMode, "conversation_tool"),
+    eq(scopedApprovalGrants.status, "active"),
+    eq(scopedApprovalGrants.toolName, params.toolName),
+    eq(scopedApprovalGrants.conversationId, params.conversationId),
+    sql`${scopedApprovalGrants.expiresAt} > ${currentTime}`,
+  ];
+
+  if (params.requesterExternalUserId !== undefined) {
+    conditions.push(
+      sql`(${scopedApprovalGrants.requesterExternalUserId} IS NULL OR ${scopedApprovalGrants.requesterExternalUserId} = ${params.requesterExternalUserId})`,
+    );
+  } else {
+    conditions.push(
+      sql`${scopedApprovalGrants.requesterExternalUserId} IS NULL`,
+    );
+  }
+
+  const specificityOrder = sql`(CASE WHEN ${scopedApprovalGrants.requesterExternalUserId} IS NOT NULL THEN 1 ELSE 0 END) DESC`;
+
+  const row = db
+    .select()
+    .from(scopedApprovalGrants)
+    .where(and(...conditions))
+    .orderBy(specificityOrder)
+    .limit(1)
+    .get();
+
+  if (!row) {
+    return null;
+  }
+
+  log.info(
+    {
+      event: "scoped_grant_peek_hit",
+      grantId: row.id,
+      scopeMode: "conversation_tool",
+      toolName: params.toolName,
+      conversationId: params.conversationId,
+    },
+    "Active conversation_tool grant peeked",
+  );
+
+  return rowToGrant(row);
+}
+
+/**
+ * True when any active conversation_tool grant exists for this
+ * conversation and tool, regardless of requester.
+ */
+function hasActiveConversationToolGrant(params: {
+  toolName: string;
+  conversationId: string;
+  now?: number;
+}): boolean {
+  const db = getDb();
+  const currentTime = params.now ?? Date.now();
+  const row = db
+    .select({ id: scopedApprovalGrants.id })
+    .from(scopedApprovalGrants)
+    .where(
+      and(
+        eq(scopedApprovalGrants.scopeMode, "conversation_tool"),
+        eq(scopedApprovalGrants.status, "active"),
+        eq(scopedApprovalGrants.toolName, params.toolName),
+        eq(scopedApprovalGrants.conversationId, params.conversationId),
+        sql`${scopedApprovalGrants.expiresAt} > ${currentTime}`,
+      ),
+    )
+    .limit(1)
+    .get();
+  return row !== undefined;
+}
+
+/**
+ * Find an exact active conversation_tool grant for upsert dedupe.
+ * requesterExternalUserId null matches only wildcard grants.
+ */
+function findActiveConversationToolGrant(params: {
+  toolName: string;
+  conversationId: string;
+  requesterExternalUserId: string | null;
+  now?: number;
+}): ScopedApprovalGrant | null {
+  const db = getDb();
+  const currentTime = params.now ?? Date.now();
+  const requesterCondition =
+    params.requesterExternalUserId === null
+      ? sql`${scopedApprovalGrants.requesterExternalUserId} IS NULL`
+      : eq(
+          scopedApprovalGrants.requesterExternalUserId,
+          params.requesterExternalUserId,
+        );
+
+  const row = db
+    .select()
+    .from(scopedApprovalGrants)
+    .where(
+      and(
+        eq(scopedApprovalGrants.scopeMode, "conversation_tool"),
+        eq(scopedApprovalGrants.status, "active"),
+        eq(scopedApprovalGrants.toolName, params.toolName),
+        eq(scopedApprovalGrants.conversationId, params.conversationId),
+        requesterCondition,
+        sql`${scopedApprovalGrants.expiresAt} > ${currentTime}`,
+      ),
+    )
+    .limit(1)
+    .get();
+
+  return row ? rowToGrant(row) : null;
+}
+
+/**
+ * Revoke active conversation_tool grants for a conversation and tool.
+ * Returns the number of grants revoked.
+ */
+function revokeConversationToolGrants(
+  conversationId: string,
+  toolName: string,
+  now?: number,
+): number {
+  const db = getDb();
+  const currentTime = now ?? Date.now();
+
+  db.update(scopedApprovalGrants)
+    .set({
+      status: "revoked",
+      updatedAt: currentTime,
+    })
+    .where(
+      and(
+        eq(scopedApprovalGrants.status, "active"),
+        eq(scopedApprovalGrants.scopeMode, "conversation_tool"),
+        eq(scopedApprovalGrants.conversationId, conversationId),
+        eq(scopedApprovalGrants.toolName, toolName),
+      ),
+    )
+    .run();
+
+  const count = rawChanges();
+  if (count > 0) {
+    log.info(
+      {
+        event: "scoped_grant_revoked",
+        count,
+        scopeMode: "conversation_tool",
+        conversationId,
+        toolName,
+      },
+      `Revoked ${count} conversation_tool grant(s)`,
+    );
+  }
+
+  return count;
+}
+
+// @internal. Exposed for tests and the approval-primitive wrapper only.
 // Do not import these from production code outside this package; use the
 // approval-primitive API instead.
 export const _internal = {
   createScopedApprovalGrant,
   consumeScopedApprovalGrantByRequestId,
   consumeScopedApprovalGrantByToolSignature,
+  peekConversationToolGrant,
+  findActiveConversationToolGrant,
+  hasActiveConversationToolGrant,
+  revokeConversationToolGrants,
 };

--- a/assistant/src/cli/commands/__tests__/conversations-workspace-commands.test.ts
+++ b/assistant/src/cli/commands/__tests__/conversations-workspace-commands.test.ts
@@ -1,0 +1,138 @@
+import * as nodeFs from "node:fs";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { Command } from "commander";
+
+let lastIpcCall: { method: string; params?: Record<string, unknown> } | null =
+  null;
+const loggerCalls: { level: string; msg: string }[] = [];
+
+let mockIpcResult: { ok: boolean; result?: unknown; error?: string } = {
+  ok: true,
+  result: { conversationId: "conv-xyz", enabled: true },
+};
+
+mock.module("../../../ipc/cli-client.js", () => ({
+  cliIpcCall: async (method: string, params?: Record<string, unknown>) => {
+    lastIpcCall = { method, params };
+    return mockIpcResult;
+  },
+  exitCodeFromIpcResult: (r: { statusCode?: number }) =>
+    r.statusCode === undefined
+      ? 10
+      : r.statusCode >= 500
+        ? 3
+        : r.statusCode >= 400
+          ? 2
+          : 1,
+  exitFromIpcResult: (r: { error?: string }) => {
+    process.exitCode = 1;
+    loggerCalls.push({ level: "error", msg: r.error ?? "Unknown error" });
+  },
+}));
+
+const fakeLogger = {
+  info: (m: unknown) => loggerCalls.push({ level: "info", msg: String(m) }),
+  warn: () => {},
+  error: (m: unknown) => loggerCalls.push({ level: "error", msg: String(m) }),
+  debug: () => {},
+};
+
+mock.module("../../../util/logger.js", () => ({
+  getLogger: () => fakeLogger,
+  getCliLogger: () => fakeLogger,
+  initLogger: () => {},
+  truncateForLog: (v: string) => v,
+  pruneOldLogFiles: () => 0,
+  LOG_FILE_PATTERN: /^assistant-(\d{4}-\d{2}-\d{2})\.log$/,
+  getCurrentLogFilePath: () => "/tmp/test-assistant.log",
+}));
+
+const realFs = { ...nodeFs };
+mock.module("node:fs", () => ({ ...realFs }));
+
+const { registerConversationsCommand } = await import("../conversations.js");
+
+async function run(args: string[]): Promise<number> {
+  const program = new Command();
+  program.exitOverride();
+  program.configureOutput({ writeErr: () => {}, writeOut: () => {} });
+  registerConversationsCommand(program);
+  try {
+    await program.parseAsync(["node", "assistant", "conversations", ...args]);
+  } catch {
+    if (process.exitCode === 0 || process.exitCode === undefined) {
+      process.exitCode = 1;
+    }
+  }
+  const code = Number(process.exitCode ?? 0);
+  process.exitCode = 0;
+  return code;
+}
+
+beforeEach(() => {
+  lastIpcCall = null;
+  loggerCalls.length = 0;
+  process.exitCode = 0;
+  mockIpcResult = {
+    ok: true,
+    result: { conversationId: "conv-xyz", enabled: true },
+  };
+});
+
+afterEach(() => {
+  process.exitCode = 0;
+});
+
+describe("conversations workspace-commands", () => {
+  test("allow sends enabled true for a conversation id", async () => {
+    const code = await run([
+      "workspace-commands",
+      "allow",
+      "conv-xyz",
+      "--json",
+    ]);
+    expect(code).toBe(0);
+    expect(lastIpcCall?.method).toBe(
+      "conversation_workspace_commands_set_cli",
+    );
+    expect(lastIpcCall?.params).toEqual({
+      body: { conversationId: "conv-xyz", enabled: true },
+    });
+    expect(JSON.parse(loggerCalls[loggerCalls.length - 1]!.msg)).toEqual({
+      ok: true,
+      conversationId: "conv-xyz",
+      enabled: true,
+    });
+  });
+
+  test("get can resolve a Slack user", async () => {
+    mockIpcResult = {
+      ok: true,
+      result: { conversationId: "conv-xyz", enabled: false },
+    };
+    const code = await run([
+      "workspace-commands",
+      "get",
+      "--slack-user",
+      "U12345678",
+      "--json",
+    ]);
+    expect(code).toBe(0);
+    expect(lastIpcCall?.method).toBe(
+      "conversation_workspace_commands_get_cli",
+    );
+    expect(lastIpcCall?.params).toEqual({
+      body: { slackUserId: "U12345678" },
+    });
+  });
+
+  test("deny without a target exits non-zero before IPC", async () => {
+    const code = await run(["workspace-commands", "deny", "--json"]);
+    expect(code).toBe(1);
+    expect(lastIpcCall).toBeNull();
+    expect(JSON.parse(loggerCalls[loggerCalls.length - 1]!.msg)).toMatchObject({
+      ok: false,
+    });
+  });
+});

--- a/assistant/src/cli/commands/conversations.help.ts
+++ b/assistant/src/cli/commands/conversations.help.ts
@@ -15,6 +15,7 @@ Examples:
   $ assistant conversations search "project planning"
   $ assistant conversations new "Project planning"
   $ assistant conversations export
+  $ assistant conversations workspace-commands allow conv-xyz
   $ assistant conversations clear`,
   subcommands: [
     {
@@ -319,6 +320,109 @@ Examples:
   $ assistant conversations slack detach conv-123
   $ assistant conversations slack mute --channel C123 --thread 1700000000.000100
   $ assistant conversations slack detach --json`,
+        },
+      ],
+    },
+    {
+      name: "workspace-commands",
+      description:
+        "Allow trusted contacts to run workspace shell commands in a conversation",
+      helpText: `
+Standing access for trusted contacts to run workspace shell commands
+(sandbox bash) in one conversation without a per-command approval.
+High-risk commands still require guardian approval. host_bash is never
+covered.
+
+Find the conversation ID with 'assistant conversations list' or
+'assistant conversations search'. Slack DMs can also be targeted with
+--slack-channel or --slack-user.
+
+Examples:
+  $ assistant conversations workspace-commands get conv-xyz
+  $ assistant conversations workspace-commands allow conv-xyz
+  $ assistant conversations workspace-commands deny conv-xyz
+  $ assistant conversations workspace-commands allow --slack-user U12345678`,
+      subcommands: [
+        {
+          name: "get",
+          args: "[conversationId]",
+          description: "Show whether workspace commands are allowed",
+          options: [
+            {
+              flags: "--slack-channel <id>",
+              description: "Resolve the conversation from a Slack channel ID",
+            },
+            {
+              flags: "--slack-user <id>",
+              description: "Resolve the conversation from a Slack user ID",
+            },
+            {
+              flags: "--json",
+              description: "Output result as machine-readable JSON",
+            },
+          ],
+          helpText: `
+Arguments:
+  conversationId   Conversation ID. Run 'assistant conversations list' to
+                   find it. Omit when using --slack-channel or --slack-user.
+
+Examples:
+  $ assistant conversations workspace-commands get conv-xyz
+  $ assistant conversations workspace-commands get --slack-channel D01234567
+  $ assistant conversations workspace-commands get --json`,
+        },
+        {
+          name: "allow",
+          args: "[conversationId]",
+          description:
+            "Allow trusted contacts to run workspace commands without per-command approval",
+          options: [
+            {
+              flags: "--slack-channel <id>",
+              description: "Resolve the conversation from a Slack channel ID",
+            },
+            {
+              flags: "--slack-user <id>",
+              description: "Resolve the conversation from a Slack user ID",
+            },
+            {
+              flags: "--json",
+              description: "Output result as machine-readable JSON",
+            },
+          ],
+          helpText: `
+Writes a standing grant so trusted contacts can run workspace shell
+commands in this conversation without paging the owner for each command.
+High-risk commands still require approval.
+
+Examples:
+  $ assistant conversations workspace-commands allow conv-xyz
+  $ assistant conversations workspace-commands allow --slack-user U12345678`,
+        },
+        {
+          name: "deny",
+          args: "[conversationId]",
+          description: "Revoke standing workspace-command access",
+          options: [
+            {
+              flags: "--slack-channel <id>",
+              description: "Resolve the conversation from a Slack channel ID",
+            },
+            {
+              flags: "--slack-user <id>",
+              description: "Resolve the conversation from a Slack user ID",
+            },
+            {
+              flags: "--json",
+              description: "Output result as machine-readable JSON",
+            },
+          ],
+          helpText: `
+Revokes standing workspace-command access for this conversation. Trusted
+contacts will need guardian approval again for sandbox bash.
+
+Examples:
+  $ assistant conversations workspace-commands deny conv-xyz`,
         },
       ],
     },

--- a/assistant/src/cli/commands/conversations.ts
+++ b/assistant/src/cli/commands/conversations.ts
@@ -494,6 +494,122 @@ export function registerConversationsCommand(program: Command): void {
         );
 
       // -------------------------------------------------------------------
+      // workspace-commands
+      // -------------------------------------------------------------------
+
+      const workspaceCommands = subcommand(conversations, "workspace-commands");
+
+      const runWorkspaceCommands = async (
+        action: "get" | "allow" | "deny",
+        conversationIdArg: string | undefined,
+        opts: { slackChannel?: string; slackUser?: string; json?: boolean },
+      ): Promise<void> => {
+        const conversationId = tryResolveConversationId({
+          explicit: conversationIdArg,
+        });
+        const slackChannelId = opts.slackChannel?.trim();
+        const slackUserId = opts.slackUser?.trim();
+        const provided = [conversationId, slackChannelId, slackUserId].filter(
+          Boolean,
+        );
+        if (provided.length !== 1) {
+          const message =
+            "Provide exactly one of a conversation ID, --slack-channel, or --slack-user. Run 'assistant conversations list' to find IDs.";
+          if (opts.json) {
+            log.info(JSON.stringify({ ok: false, error: message }));
+          } else {
+            log.error(`Error: ${message}`);
+          }
+          process.exitCode = 1;
+          return;
+        }
+
+        type WorkspaceCommandsResult = {
+          conversationId: string;
+          enabled: boolean;
+        };
+
+        const body: Record<string, unknown> = {};
+        if (conversationId) {
+          body.conversationId = conversationId;
+        }
+        if (slackChannelId) {
+          body.slackChannelId = slackChannelId;
+        }
+        if (slackUserId) {
+          body.slackUserId = slackUserId;
+        }
+
+        let result: {
+          ok: boolean;
+          result?: WorkspaceCommandsResult;
+          error?: string;
+        };
+        if (action === "get") {
+          result = await cliIpcCall<WorkspaceCommandsResult>(
+            "conversation_workspace_commands_get_cli",
+            { body },
+          );
+        } else {
+          result = await cliIpcCall<WorkspaceCommandsResult>(
+            "conversation_workspace_commands_set_cli",
+            { body: { ...body, enabled: action === "allow" } },
+          );
+        }
+
+        if (!result.ok) {
+          if (opts.json) {
+            log.info(
+              JSON.stringify({
+                ok: false,
+                error: result.error ?? "Workspace commands update failed",
+              }),
+            );
+            process.exitCode = exitCodeFromIpcResult(result);
+            return;
+          }
+          return exitFromIpcResult(result);
+        }
+
+        const payload = result.result!;
+        if (opts.json) {
+          log.info(JSON.stringify({ ok: true, ...payload }));
+          return;
+        }
+        const state = payload.enabled ? "allowed" : "denied";
+        log.info(
+          `Workspace commands for trusted contacts are ${state} on conversation ${payload.conversationId}.`,
+        );
+      };
+
+      subcommand(workspaceCommands, "get").action(
+        async (
+          conversationIdArg: string | undefined,
+          opts: { slackChannel?: string; slackUser?: string; json?: boolean },
+        ) => {
+          await runWorkspaceCommands("get", conversationIdArg, opts);
+        },
+      );
+
+      subcommand(workspaceCommands, "allow").action(
+        async (
+          conversationIdArg: string | undefined,
+          opts: { slackChannel?: string; slackUser?: string; json?: boolean },
+        ) => {
+          await runWorkspaceCommands("allow", conversationIdArg, opts);
+        },
+      );
+
+      subcommand(workspaceCommands, "deny").action(
+        async (
+          conversationIdArg: string | undefined,
+          opts: { slackChannel?: string; slackUser?: string; json?: boolean },
+        ) => {
+          await runWorkspaceCommands("deny", conversationIdArg, opts);
+        },
+      );
+
+      // -------------------------------------------------------------------
       // clear
       // -------------------------------------------------------------------
 

--- a/assistant/src/cli/commands/conversations.ts
+++ b/assistant/src/cli/commands/conversations.ts
@@ -540,22 +540,16 @@ export function registerConversationsCommand(program: Command): void {
           body.slackUserId = slackUserId;
         }
 
-        let result: {
-          ok: boolean;
-          result?: WorkspaceCommandsResult;
-          error?: string;
-        };
-        if (action === "get") {
-          result = await cliIpcCall<WorkspaceCommandsResult>(
-            "conversation_workspace_commands_get_cli",
-            { body },
-          );
-        } else {
-          result = await cliIpcCall<WorkspaceCommandsResult>(
-            "conversation_workspace_commands_set_cli",
-            { body: { ...body, enabled: action === "allow" } },
-          );
-        }
+        const result =
+          action === "get"
+            ? await cliIpcCall<WorkspaceCommandsResult>(
+                "conversation_workspace_commands_get_cli",
+                { body },
+              )
+            : await cliIpcCall<WorkspaceCommandsResult>(
+                "conversation_workspace_commands_set_cli",
+                { body: { ...body, enabled: action === "allow" } },
+              );
 
         if (!result.ok) {
           if (opts.json) {

--- a/assistant/src/persistence/external-conversation-store.ts
+++ b/assistant/src/persistence/external-conversation-store.ts
@@ -340,6 +340,26 @@ export function deleteBindingByChannelChatThread(
 }
 
 /**
+ * List bindings for a channel identity (source channel + external user id).
+ */
+export function listBindingsByExternalUser(
+  sourceChannel: string,
+  externalUserId: string,
+): ExternalConversationBinding[] {
+  const db = getDb();
+  return db
+    .select()
+    .from(externalConversationBindings)
+    .where(
+      and(
+        eq(externalConversationBindings.sourceChannel, sourceChannel),
+        eq(externalConversationBindings.externalUserId, externalUserId),
+      ),
+    )
+    .all();
+}
+
+/**
  * Get bindings for multiple conversation IDs at once.
  * Returns a map of conversationId -> binding for efficient lookup.
  */

--- a/assistant/src/persistence/schema/guardian.ts
+++ b/assistant/src/persistence/schema/guardian.ts
@@ -4,7 +4,7 @@ export const scopedApprovalGrants = sqliteTable(
   "scoped_approval_grants",
   {
     id: text("id").primaryKey(),
-    scopeMode: text("scope_mode").notNull(), // 'request_id' | 'tool_signature'
+    scopeMode: text("scope_mode").notNull(), // 'request_id' | 'tool_signature' | 'conversation_tool'
     requestId: text("request_id"),
     toolName: text("tool_name"),
     inputDigest: text("input_digest"),

--- a/assistant/src/runtime/routes/__tests__/conversation-workspace-commands-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-workspace-commands-routes.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { getDb } from "../../../persistence/db-connection.js";
+import { initializeDb } from "../../../persistence/db-init.js";
+import { conversations } from "../../../persistence/schema/index.js";
+import { upsertBinding } from "../../../persistence/external-conversation-store.js";
+import { ROUTES } from "../conversation-workspace-commands-routes.js";
+import type { RouteDefinition } from "../types.js";
+
+await initializeDb();
+
+function findHandler(operationId: string) {
+  const route = ROUTES.find((r: RouteDefinition) => r.operationId === operationId);
+  if (!route) {
+    throw new Error(`Route ${operationId} not found`);
+  }
+  return route.handler;
+}
+
+const getHandler = findHandler("getConversationWorkspaceCommands");
+const putHandler = findHandler("setConversationWorkspaceCommands");
+const getCliHandler = findHandler("conversation_workspace_commands_get_cli");
+const setCliHandler = findHandler("conversation_workspace_commands_set_cli");
+
+function seedConversation(id: string): void {
+  const now = Date.now();
+  getDb()
+    .insert(conversations)
+    .values({
+      id,
+      title: "Slack DM",
+      createdAt: now,
+      updatedAt: now,
+      source: "test",
+      conversationType: "standard",
+    })
+    .run();
+}
+
+function clear(): void {
+  getDb().run("DELETE FROM scoped_approval_grants");
+  getDb().run("DELETE FROM external_conversation_bindings");
+  getDb().delete(conversations).run();
+}
+
+describe("conversation workspace-commands routes", () => {
+  beforeEach(() => {
+    clear();
+    seedConversation("conv-xyz");
+  });
+
+  test("GET reports disabled until a standing grant is written", async () => {
+    const before = await getHandler({ pathParams: { id: "conv-xyz" } });
+    expect(before).toEqual({ conversationId: "conv-xyz", enabled: false });
+
+    const after = await putHandler({
+      pathParams: { id: "conv-xyz" },
+      body: { enabled: true },
+    });
+    expect(after).toEqual({ conversationId: "conv-xyz", enabled: true });
+
+    const reread = await getHandler({ pathParams: { id: "conv-xyz" } });
+    expect(reread).toEqual({ conversationId: "conv-xyz", enabled: true });
+  });
+
+  test("PUT enabled false revokes the standing grant", async () => {
+    await putHandler({
+      pathParams: { id: "conv-xyz" },
+      body: { enabled: true },
+    });
+    const denied = await putHandler({
+      pathParams: { id: "conv-xyz" },
+      body: { enabled: false },
+    });
+    expect(denied).toEqual({ conversationId: "conv-xyz", enabled: false });
+  });
+
+  test("CLI allow resolves a Slack user DM", async () => {
+    upsertBinding({
+      conversationId: "conv-xyz",
+      sourceChannel: "slack",
+      externalChatId: "D01234567",
+      externalUserId: "U12345678",
+    });
+
+    const result = await setCliHandler({
+      body: { slackUserId: "U12345678", enabled: true },
+    });
+    expect(result).toEqual({ conversationId: "conv-xyz", enabled: true });
+
+    const status = await getCliHandler({
+      body: { slackChannelId: "D01234567" },
+    });
+    expect(status).toEqual({ conversationId: "conv-xyz", enabled: true });
+  });
+
+  test("CLI rejects multiple identifiers", async () => {
+    await expect(
+      getCliHandler({
+        body: { conversationId: "conv-xyz", slackUserId: "U12345678" },
+      }),
+    ).rejects.toThrow("exactly one");
+  });
+});

--- a/assistant/src/runtime/routes/__tests__/conversation-workspace-commands-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-workspace-commands-routes.test.ts
@@ -95,10 +95,10 @@ describe("conversation workspace-commands routes", () => {
   });
 
   test("CLI rejects multiple identifiers", async () => {
-    await expect(
+    expect(() =>
       getCliHandler({
         body: { conversationId: "conv-xyz", slackUserId: "U12345678" },
       }),
-    ).rejects.toThrow("exactly one");
+    ).toThrow("exactly one");
   });
 });

--- a/assistant/src/runtime/routes/conversation-management-routes.ts
+++ b/assistant/src/runtime/routes/conversation-management-routes.ts
@@ -23,6 +23,7 @@
 import { v7 as uuidv7 } from "uuid";
 import { z } from "zod";
 
+import { disableConversationWorkspaceCommands } from "../../approvals/conversation-tool-grant.js";
 import { isUserCancellation } from "../../daemon/conversation-error.js";
 import { touchConversation } from "../../daemon/conversation-evictor.js";
 import {
@@ -517,6 +518,7 @@ async function handleDeleteConversation({
   // In-memory teardown only: `deleteConversation` drops the durable subagent
   // rows inside its own transaction.
   destroyActiveConversation(resolvedId, { keepSubagentRecords: true });
+  disableConversationWorkspaceCommands(resolvedId);
   const deleted = deleteConversation(resolvedId);
   for (const segId of deleted.segmentIds) {
     enqueueMemoryJob("delete_qdrant_vectors", {

--- a/assistant/src/runtime/routes/conversation-workspace-commands-routes.ts
+++ b/assistant/src/runtime/routes/conversation-workspace-commands-routes.ts
@@ -1,0 +1,258 @@
+/**
+ * Conversation workspace-commands grants.
+ *
+ * GET/PUT /v1/conversations/:id/workspace-commands
+ * CLI variants accept a conversation id or a Slack channel/user lookup.
+ */
+
+import { z } from "zod";
+
+import {
+  conversationWorkspaceCommandsEnabled,
+  disableConversationWorkspaceCommands,
+  upsertConversationToolGrant,
+} from "../../approvals/conversation-tool-grant.js";
+import { getConversation } from "../../persistence/conversation-crud.js";
+import { resolveConversationId } from "../../persistence/conversation-key-store.js";
+import {
+  getBindingByChannelChat,
+  listBindingsByExternalUser,
+} from "../../persistence/external-conversation-store.js";
+import { ACTOR_PRINCIPALS, LOCAL_PRINCIPALS } from "../auth/route-policy.js";
+import { BadRequestError, NotFoundError } from "./errors.js";
+import type { RouteDefinition, RouteHandlerArgs } from "./types.js";
+
+const workspaceCommandsResponseSchema = z.object({
+  conversationId: z.string(),
+  enabled: z.boolean(),
+});
+
+function resolveOrThrow(rawId: string): string {
+  const id = resolveConversationId(rawId);
+  if (!id) {
+    throw new NotFoundError(`Conversation ${rawId} not found`);
+  }
+  return id;
+}
+
+function requireExistingConversation(conversationId: string): string {
+  const conversation = getConversation(conversationId);
+  if (!conversation) {
+    throw new NotFoundError(`Conversation ${conversationId} not found`);
+  }
+  return conversationId;
+}
+
+function resolveSlackConversation(params: {
+  slackChannelId?: string;
+  slackUserId?: string;
+}): string {
+  const slackChannelId = params.slackChannelId?.trim();
+  const slackUserId = params.slackUserId?.trim();
+  if (slackChannelId && slackUserId) {
+    throw new BadRequestError(
+      "Provide either slackChannelId or slackUserId, not both.",
+    );
+  }
+  if (slackChannelId) {
+    const binding = getBindingByChannelChat("slack", slackChannelId);
+    if (!binding) {
+      throw new NotFoundError(
+        `No Slack conversation is bound to channel ${slackChannelId}.`,
+      );
+    }
+    return binding.conversationId;
+  }
+  if (slackUserId) {
+    const bindings = listBindingsByExternalUser("slack", slackUserId);
+    if (bindings.length === 0) {
+      throw new NotFoundError(
+        `No Slack conversation is bound to user ${slackUserId}.`,
+      );
+    }
+    if (bindings.length === 1) {
+      return bindings[0]!.conversationId;
+    }
+    const dms = bindings.filter((binding) =>
+      binding.externalChatId.startsWith("D"),
+    );
+    if (dms.length === 1) {
+      return dms[0]!.conversationId;
+    }
+    const candidates = bindings
+      .map((binding) => binding.conversationId)
+      .join(", ");
+    throw new BadRequestError(
+      `Multiple Slack conversations match this user. Pass a conversation ID from assistant conversations list. Candidates: ${candidates}`,
+    );
+  }
+  throw new BadRequestError("Missing conversation identifier.");
+}
+
+function resolveCliConversation(body: Record<string, unknown>): string {
+  const conversationId =
+    typeof body.conversationId === "string" ? body.conversationId.trim() : "";
+  const slackChannelId =
+    typeof body.slackChannelId === "string" ? body.slackChannelId.trim() : "";
+  const slackUserId =
+    typeof body.slackUserId === "string" ? body.slackUserId.trim() : "";
+  const provided = [conversationId, slackChannelId, slackUserId].filter(
+    Boolean,
+  );
+  if (provided.length !== 1) {
+    throw new BadRequestError(
+      "Provide exactly one of conversationId, slackChannelId, or slackUserId.",
+    );
+  }
+  if (conversationId) {
+    return requireExistingConversation(resolveOrThrow(conversationId));
+  }
+  return requireExistingConversation(
+    resolveSlackConversation({ slackChannelId, slackUserId }),
+  );
+}
+
+function readWorkspaceCommands(conversationId: string): {
+  conversationId: string;
+  enabled: boolean;
+} {
+  return {
+    conversationId,
+    enabled: conversationWorkspaceCommandsEnabled(conversationId),
+  };
+}
+
+function writeWorkspaceCommands(
+  conversationId: string,
+  enabled: boolean,
+  requestChannel: string,
+): {
+  conversationId: string;
+  enabled: boolean;
+} {
+  if (enabled) {
+    upsertConversationToolGrant({
+      conversationId,
+      requestChannel,
+      decisionChannel: requestChannel,
+      requesterExternalUserId: null,
+    });
+  } else {
+    disableConversationWorkspaceCommands(conversationId);
+  }
+  return readWorkspaceCommands(conversationId);
+}
+
+function handleGetWorkspaceCommands({ pathParams = {} }: RouteHandlerArgs) {
+  const conversationId = requireExistingConversation(
+    resolveOrThrow(pathParams.id!),
+  );
+  return readWorkspaceCommands(conversationId);
+}
+
+function handleSetWorkspaceCommands({
+  pathParams = {},
+  body = {},
+}: RouteHandlerArgs) {
+  if (typeof body.enabled !== "boolean") {
+    throw new BadRequestError("enabled must be a boolean");
+  }
+  const conversationId = requireExistingConversation(
+    resolveOrThrow(pathParams.id!),
+  );
+  return writeWorkspaceCommands(conversationId, body.enabled, "http");
+}
+
+function handleGetWorkspaceCommandsCli({ body = {} }: RouteHandlerArgs) {
+  return readWorkspaceCommands(resolveCliConversation(body));
+}
+
+function handleSetWorkspaceCommandsCli({ body = {} }: RouteHandlerArgs) {
+  if (typeof body.enabled !== "boolean") {
+    throw new BadRequestError("enabled must be a boolean");
+  }
+  return writeWorkspaceCommands(
+    resolveCliConversation(body),
+    body.enabled,
+    "cli",
+  );
+}
+
+export const ROUTES: RouteDefinition[] = [
+  {
+    operationId: "getConversationWorkspaceCommands",
+    endpoint: "conversations/:id/workspace-commands",
+    method: "GET",
+    policy: {
+      requiredScopes: ["chat.read"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    pathParams: [{ name: "id", type: "string" }],
+    summary: "Get workspace commands for contacts",
+    description:
+      "Whether trusted contacts may run workspace shell commands in this conversation without a per-command approval.",
+    tags: ["conversations"],
+    responseBody: workspaceCommandsResponseSchema,
+    handler: handleGetWorkspaceCommands,
+  },
+  {
+    operationId: "setConversationWorkspaceCommands",
+    endpoint: "conversations/:id/workspace-commands",
+    method: "PUT",
+    policy: {
+      requiredScopes: ["chat.write"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    pathParams: [{ name: "id", type: "string" }],
+    summary: "Set workspace commands for contacts",
+    description:
+      "Enable or disable standing workspace shell access for trusted contacts in this conversation. High-risk commands still require approval.",
+    tags: ["conversations"],
+    requestBody: z.object({
+      enabled: z.boolean(),
+    }),
+    responseBody: workspaceCommandsResponseSchema,
+    handler: handleSetWorkspaceCommands,
+  },
+  {
+    operationId: "conversation_workspace_commands_get_cli",
+    endpoint: "conversations/cli/workspace-commands/get",
+    method: "POST",
+    policy: {
+      requiredScopes: ["settings.read"],
+      allowedPrincipalTypes: LOCAL_PRINCIPALS,
+    },
+    summary: "Get workspace commands for contacts (CLI)",
+    description:
+      "Look up standing workspace-command access by conversation ID, Slack channel, or Slack user.",
+    tags: ["conversations"],
+    requestBody: z.object({
+      conversationId: z.string().optional(),
+      slackChannelId: z.string().optional(),
+      slackUserId: z.string().optional(),
+    }),
+    responseBody: workspaceCommandsResponseSchema,
+    handler: handleGetWorkspaceCommandsCli,
+  },
+  {
+    operationId: "conversation_workspace_commands_set_cli",
+    endpoint: "conversations/cli/workspace-commands/set",
+    method: "POST",
+    policy: {
+      requiredScopes: ["settings.write"],
+      allowedPrincipalTypes: LOCAL_PRINCIPALS,
+    },
+    summary: "Set workspace commands for contacts (CLI)",
+    description:
+      "Enable or disable standing workspace-command access by conversation ID, Slack channel, or Slack user.",
+    tags: ["conversations"],
+    requestBody: z.object({
+      conversationId: z.string().optional(),
+      slackChannelId: z.string().optional(),
+      slackUserId: z.string().optional(),
+      enabled: z.boolean(),
+    }),
+    responseBody: workspaceCommandsResponseSchema,
+    handler: handleSetWorkspaceCommandsCli,
+  },
+];

--- a/assistant/src/runtime/routes/index.ts
+++ b/assistant/src/runtime/routes/index.ts
@@ -50,6 +50,7 @@ import { ROUTES as CONVERSATION_CLI_ROUTES } from "./conversation-cli-routes.js"
 import { ROUTES as CONVERSATION_COMPACTION_ROUTES } from "./conversation-compaction-routes.js";
 import { ROUTES as CONVERSATION_LIST_ROUTES } from "./conversation-list-routes.js";
 import { ROUTES as CONVERSATION_MANAGEMENT_ROUTES } from "./conversation-management-routes.js";
+import { ROUTES as CONVERSATION_WORKSPACE_COMMANDS_ROUTES } from "./conversation-workspace-commands-routes.js";
 import { ROUTES as CONVERSATION_QUERY_ROUTES } from "./conversation-query-routes.js";
 import { ROUTES as CONVERSATION_MESSAGE_ROUTES } from "./conversation-routes.js";
 import { ROUTES as CONVERSATION_STARTER_ROUTES } from "./conversation-starter-routes.js";
@@ -196,6 +197,7 @@ export const ROUTES: RouteDefinition[] = [
   ...CONVERSATION_CLI_ROUTES,
   ...CONVERSATION_LIST_ROUTES,
   ...CONVERSATION_MANAGEMENT_ROUTES,
+  ...CONVERSATION_WORKSPACE_COMMANDS_ROUTES,
   ...CONVERSATIONS_IMPORT_ROUTES,
   ...CONVERSATION_MESSAGE_ROUTES,
   ...CONSOLIDATION_ROUTES,

--- a/assistant/src/tools/tool-approval-handler.ts
+++ b/assistant/src/tools/tool-approval-handler.ts
@@ -487,6 +487,25 @@ export function resolveSensitiveToolDecision(input: {
 const CODE_EXECUTION_TOOLS: ReadonlySet<string> = new Set(["bash"]);
 
 /**
+ * A conversation_tool grant covers sandbox bash for a trusted contact
+ * when the classified risk is not high. High-risk bash and host execution
+ * still escalate.
+ */
+function isStandingWorkspaceCommandGrantHonored(params: {
+  toolName: string;
+  executionTarget: ExecutionTarget;
+  trustClass: ToolContext["trustClass"];
+  riskLevel: string;
+}): boolean {
+  return (
+    params.toolName === "bash" &&
+    params.executionTarget === "sandbox" &&
+    params.trustClass === "trusted_contact" &&
+    params.riskLevel !== "high"
+  );
+}
+
+/**
  * Whether an invocation reaches the private network — localhost, which is the
  * daemon's own HTTP surface, the gateway, and whatever else listens on the
  * guardian's machine. Keyed on the input rather than the tool, because the
@@ -954,18 +973,41 @@ export class ToolApprovalHandler {
       );
 
       if (grantResult.ok) {
-        log.info(
-          {
+        if (
+          grantResult.grant.scopeMode === "conversation_tool" &&
+          !isStandingWorkspaceCommandGrantHonored({
             toolName: name,
-            conversationId: context.conversationId,
-            trustClass: context.trustClass,
             executionTarget,
-            grantId: grantResult.grant.id,
-          },
-          "Scoped grant consumed - allowing untrusted actor tool invocation",
-        );
+            trustClass: context.trustClass,
+            riskLevel,
+          })
+        ) {
+          log.info(
+            {
+              toolName: name,
+              conversationId: context.conversationId,
+              trustClass: context.trustClass,
+              executionTarget,
+              riskLevel,
+              grantId: grantResult.grant.id,
+            },
+            "Standing conversation_tool grant does not cover this invocation",
+          );
+        } else {
+          log.info(
+            {
+              toolName: name,
+              conversationId: context.conversationId,
+              trustClass: context.trustClass,
+              executionTarget,
+              grantId: grantResult.grant.id,
+              scopeMode: grantResult.grant.scopeMode,
+            },
+            "Scoped grant consumed - allowing untrusted actor tool invocation",
+          );
 
-        return { allowed: true, tool, grantConsumed: true, parsedInput };
+          return { allowed: true, tool, grantConsumed: true, parsedInput };
+        }
       }
 
       // Treat abort as a cancellation - not a grant denial. This matches

--- a/assistant/src/tools/tool-approval-handler.ts
+++ b/assistant/src/tools/tool-approval-handler.ts
@@ -1,4 +1,7 @@
-import { consumeGrantForInvocation } from "../approvals/approval-primitive.js";
+import {
+  consumeGrantForInvocation,
+  peekConversationToolGrantForInvocation,
+} from "../approvals/approval-primitive.js";
 import {
   getGuardianRequestOrNull,
   updateGuardianRequest,
@@ -966,6 +969,35 @@ export class ToolApprovalHandler {
     // minting (2-5s). Non-voice channels get an instant sync lookup so
     // normal denials are not delayed.
     if (needsGrantConsumption && deferredConsumeParams) {
+      if (
+        isStandingWorkspaceCommandGrantHonored({
+          toolName: name,
+          executionTarget,
+          trustClass: context.trustClass,
+          riskLevel,
+        })
+      ) {
+        const standing = peekConversationToolGrantForInvocation({
+          toolName: name,
+          conversationId: context.conversationId,
+          requesterExternalUserId: context.requesterExternalUserId,
+        });
+        if (standing) {
+          log.info(
+            {
+              toolName: name,
+              conversationId: context.conversationId,
+              trustClass: context.trustClass,
+              executionTarget,
+              grantId: standing.id,
+              scopeMode: standing.scopeMode,
+            },
+            "Standing conversation_tool grant peeked - allowing trusted contact workspace command",
+          );
+          return { allowed: true, tool, grantConsumed: true, parsedInput };
+        }
+      }
+
       const isVoice = context.executionChannel === "phone";
       const grantResult = await consumeGrantForInvocation(
         deferredConsumeParams,
@@ -973,41 +1005,18 @@ export class ToolApprovalHandler {
       );
 
       if (grantResult.ok) {
-        if (
-          grantResult.grant.scopeMode === "conversation_tool" &&
-          !isStandingWorkspaceCommandGrantHonored({
+        log.info(
+          {
             toolName: name,
-            executionTarget,
+            conversationId: context.conversationId,
             trustClass: context.trustClass,
-            riskLevel,
-          })
-        ) {
-          log.info(
-            {
-              toolName: name,
-              conversationId: context.conversationId,
-              trustClass: context.trustClass,
-              executionTarget,
-              riskLevel,
-              grantId: grantResult.grant.id,
-            },
-            "Standing conversation_tool grant does not cover this invocation",
-          );
-        } else {
-          log.info(
-            {
-              toolName: name,
-              conversationId: context.conversationId,
-              trustClass: context.trustClass,
-              executionTarget,
-              grantId: grantResult.grant.id,
-              scopeMode: grantResult.grant.scopeMode,
-            },
-            "Scoped grant consumed - allowing untrusted actor tool invocation",
-          );
+            executionTarget,
+            grantId: grantResult.grant.id,
+          },
+          "Scoped grant consumed - allowing untrusted actor tool invocation",
+        );
 
-          return { allowed: true, tool, grantConsumed: true, parsedInput };
-        }
+        return { allowed: true, tool, grantConsumed: true, parsedInput };
       }
 
       // Treat abort as a cancellation - not a grant denial. This matches

--- a/gateway/src/risk/command-registry/commands/assistant.ts
+++ b/gateway/src/risk/command-registry/commands/assistant.ts
@@ -110,6 +110,10 @@ const ASSISTANT_SUPPORTED_COMMAND_PATHS = [
   "conversations export",
   "conversations clear",
   "conversations wake",
+  "conversations workspace-commands",
+  "conversations workspace-commands get",
+  "conversations workspace-commands allow",
+  "conversations workspace-commands deny",
   "pending",
   "pending list",
   "credentials",
@@ -469,6 +473,18 @@ const riskOverrides: AssistantRiskOverride[] = [
   { path: "conversations new", risk: "low" },
   { path: "conversations rename", risk: "low" },
   { path: "conversations wake", risk: "low" },
+  { path: "conversations workspace-commands get", risk: "low" },
+  {
+    path: "conversations workspace-commands allow",
+    risk: "high",
+    reason:
+      "Grants trusted contacts standing workspace shell access in a conversation",
+  },
+  {
+    path: "conversations workspace-commands deny",
+    risk: "medium",
+    reason: "Revokes standing workspace shell access for a conversation",
+  },
   {
     path: "db repair",
     risk: "medium",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan

Trusted Slack contacts were paging the owner for every sandbox `bash` call. Guardian Approve minted a one-shot 5-minute `tool_signature` grant, so the next command (or an expired card) started over. This PR adds a conversation-scoped standing grant so the owner can approve once, or write the grant up front, and later medium-risk workspace commands proceed.

## Summary

- New `conversation_tool` scope on `scoped_approval_grants`. Peeked, not consumed. Bound to conversation + `bash`.
- Approving a trusted-contact sandbox bash request still mints the one-shot grant for the in-flight command, and also upserts a standing grant for the rest of the conversation.
- The pre-exec gate honors that standing grant for `trusted_contact` + sandbox `bash` when classified risk is not high. High-risk bash and `host_bash` still escalate.
- Standing grants are peeked only in the approval handler. `consumeGrantForInvocation` stays one-shot only, so `waitForInlineGrant` cannot treat a standing grant as approval for host or high-risk bash.
- Proactive write path so support or the owner can enable this before the first card:
  - `GET`/`PUT /v1/conversations/:id/workspace-commands`
  - `assistant conversations workspace-commands get|allow|deny [conversationId]`
  - Slack lookup via `--slack-channel` or `--slack-user`
- Deleting a conversation revokes its standing grants.

Out of scope (multiplayer follow-up): per-contact Contacts toggle, gateway `contacts.sandbox_shell` ACL, lifting bash on Slack channel permission cells, persisting guardian-on-behalf trust rules.

This agent cannot write a customer's production database. After merge, enable it on the Slack DM with:

```
assistant conversations workspace-commands allow --slack-user <slackUserId>
```

or pass the conversation ID from `assistant conversations list`.

## Test plan

- Focused assistant tests for grant peek/upsert, mint-on-approve, medium vs high vs unknown vs host_bash, CLI, and HTTP/CLI routes
- 150 focused tests pass, including the high-risk path that must still wait for a one-shot grant
- Gateway command-registry coverage for the new CLI verbs
- Assistant `typecheck:fast` on touched contracts

## CLI verb checklist

- [x] New routes have `assistant conversations workspace-commands` get/allow/deny wrappers

## Risk

Identity-boundary change: a standing grant lets a trusted contact run sandbox bash (including writes that can touch workspace control-plane files via `echo`/`tee`). Scope is one conversation, trusted contacts only, and high-risk still prompts. No new feature flag. No DB migration (reuses `scoped_approval_grants`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0631fd84-675f-44ba-85f6-ca52a3aa1376?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0631fd84-675f-44ba-85f6-ca52a3aa1376&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

