### PR TITLE
Trait-to-icon mapping util and feature flag registration

### DIFF
--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -380,6 +380,14 @@
       "label": "Obscure Credits",
       "description": "Replaces the dollar amounts on the billing Plan section with a usage-relative view: the current-plan tile trades its price footer for a Usage Balance bar (managed spend this billing cycle against the package's included credits) and the credits spec chip reads \"<Package> usage, reset monthly\" instead of naming a dollar bundle. Spec chips wrap horizontally to fit the shorter labels. Off leaves the Plan section exactly as it ships today.",
       "defaultEnabled": false
+    },
+    {
+      "id": "ios-avatar-app-icon",
+      "scope": "client",
+      "key": "ios-avatar-app-icon",
+      "label": "iOS Avatar App Icon",
+      "description": "Offers to match the iOS home screen icon to the assistant's character avatar, swapping in the bundled alternate icon for that body shape, eye style, and color. Only character avatars qualify: uploaded and AI-generated avatars never change the app icon. Off leaves the default icon in place and hides the prompt entirely.",
+      "defaultEnabled": false
     }
   ]
 }

--- a/clients/web/src/utils/avatar-app-icon.test.ts
+++ b/clients/web/src/utils/avatar-app-icon.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, test } from "bun:test";
+
+import { appIconNameForAvatar, resolveAppIconTarget } from "./avatar-app-icon";
+import type { AvatarState } from "@/types/avatar";
+
+/**
+ * Pins two contracts:
+ *
+ *   1. Only `kind: "character"` avatars ever produce an icon name, so uploaded
+ *      images, AI-generated avatars, and "no avatar" can never be offered or
+ *      applied an app icon.
+ *   2. The name format itself, which is shared with the icon bundle generator:
+ *      the bundles are emitted under exactly these names, so changing the
+ *      literal below without regenerating them silently breaks every install.
+ */
+
+/** A character avatar by default; `overrides` swaps in the other kinds. */
+function avatarState(
+  traits: AvatarState["traits"],
+  overrides: Partial<AvatarState> = {},
+): AvatarState {
+  return {
+    kind: "character",
+    traits,
+    source: "builder",
+    image: null,
+    ...overrides,
+  };
+}
+
+describe("appIconNameForAvatar", () => {
+  test("character traits map to the generator's icon name", () => {
+    const name = appIconNameForAvatar(
+      avatarState({
+        bodyShape: "blob",
+        eyeStyle: "grumpy",
+        color: "green",
+      }),
+    );
+    expect(name).toBe("avatar-blob-grumpy-green");
+  });
+
+  test("an uploaded image avatar has no icon, even with stale traits", () => {
+    const state = avatarState(
+      { bodyShape: "blob", eyeStyle: "grumpy", color: "green" },
+      { kind: "image", source: "upload", image: { updatedAt: "x", etag: "y" } },
+    );
+    expect(appIconNameForAvatar(state)).toBeNull();
+  });
+
+  test("an AI-generated image avatar has no icon", () => {
+    const state = avatarState(null, {
+      kind: "image",
+      source: "ai",
+      image: { updatedAt: "x", etag: "y" },
+    });
+    expect(appIconNameForAvatar(state)).toBeNull();
+  });
+
+  test("kind none has no icon", () => {
+    expect(
+      appIconNameForAvatar(avatarState(null, { kind: "none", source: null })),
+    ).toBeNull();
+  });
+
+  test("a null state has no icon", () => {
+    expect(appIconNameForAvatar(null)).toBeNull();
+  });
+
+  test("malformed traits have no icon instead of a name with holes", () => {
+    const malformed = { bodyShape: "blob", color: "green" } as unknown;
+    const state = avatarState(malformed as AvatarState["traits"]);
+    expect(appIconNameForAvatar(state)).toBeNull();
+  });
+});
+
+describe("resolveAppIconTarget", () => {
+  const supportedShell = {
+    supported: true,
+    current: null,
+    available: ["avatar-blob-grumpy-green"],
+  };
+
+  test("a bundled icon resolves to an available match", () => {
+    const result = resolveAppIconTarget(
+      avatarState({
+        bodyShape: "blob",
+        eyeStyle: "grumpy",
+        color: "green",
+      }),
+      supportedShell,
+    );
+    expect(result).toEqual({
+      target: "avatar-blob-grumpy-green",
+      availableMatch: true,
+    });
+  });
+
+  test("a trait the installed shell has no bundle for is a no-op", () => {
+    const result = resolveAppIconTarget(
+      avatarState({
+        bodyShape: "nebula",
+        eyeStyle: "smitten",
+        color: "chartreuse",
+      }),
+      supportedShell,
+    );
+    expect(result).toEqual({
+      target: "avatar-nebula-smitten-chartreuse",
+      availableMatch: false,
+    });
+  });
+
+  test("an unsupported shell never matches, whatever it lists", () => {
+    const result = resolveAppIconTarget(
+      avatarState({
+        bodyShape: "blob",
+        eyeStyle: "grumpy",
+        color: "green",
+      }),
+      { ...supportedShell, supported: false },
+    );
+    expect(result).toEqual({
+      target: "avatar-blob-grumpy-green",
+      availableMatch: false,
+    });
+  });
+
+  test("a non-character avatar never matches", () => {
+    const result = resolveAppIconTarget(
+      avatarState(null, { kind: "none", source: null }),
+      supportedShell,
+    );
+    expect(result).toEqual({ target: null, availableMatch: false });
+  });
+});

--- a/clients/web/src/utils/avatar-app-icon.ts
+++ b/clients/web/src/utils/avatar-app-icon.ts
@@ -1,0 +1,69 @@
+import { isCharacterTraits } from "@/types/avatar";
+import type { AvatarState } from "@/types/avatar";
+
+/**
+ * Maps an assistant avatar onto the name of a bundled iOS alternate app icon.
+ *
+ * The iOS shell ships one alternate icon per character combination, named
+ * `avatar-<bodyShape>-<eyeStyle>-<color>` by the icon bundle generator. That
+ * name is the wire contract between the generated bundles and the runtime, so
+ * it is produced in exactly one place: `appIconNameForAvatar`.
+ */
+
+/**
+ * The installed shell's alternate-icon capability, typed structurally so this
+ * module does not depend on the native plugin wrapper that reports it.
+ */
+export interface AppIconAvailability {
+  /** False on web, Android, and iOS builds without alternate-icon support. */
+  supported: boolean;
+  /** The alternate icon currently applied, or null for the default icon. */
+  current: string | null;
+  /** Alternate icon names the installed binary actually bundles. */
+  available: string[];
+}
+
+/** A resolved icon target plus whether the installed shell can apply it. */
+export interface AppIconTarget {
+  /** The icon name this avatar maps to, or null when it maps to none. */
+  target: string | null;
+  /** True only when `target` is an icon the installed shell bundles. */
+  availableMatch: boolean;
+}
+
+/**
+ * The single chokepoint for the invariant that only character avatars have an
+ * app icon. Uploaded images, AI-generated avatars, and "no avatar" all return
+ * null here, so nothing downstream can offer or apply an icon for them, and a
+ * character state with malformed traits returns null rather than a name built
+ * from `undefined`.
+ */
+export function appIconNameForAvatar(state: AvatarState | null): string | null {
+  if (state === null || state.kind !== "character") {
+    return null;
+  }
+  const traits = state.traits;
+  if (!isCharacterTraits(traits)) {
+    return null;
+  }
+  return `avatar-${traits.bodyShape}-${traits.eyeStyle}-${traits.color}`;
+}
+
+/**
+ * Resolve the icon an avatar wants and whether the installed shell can apply
+ * it. This is where version skew becomes a no-op: a web build that knows a
+ * trait combination the installed binary has no bundle for, or an older shell
+ * with no alternate-icon support at all, reports `availableMatch: false` and
+ * callers leave the icon alone.
+ */
+export function resolveAppIconTarget(
+  state: AvatarState | null,
+  iconState: AppIconAvailability,
+): AppIconTarget {
+  const target = appIconNameForAvatar(state);
+  const availableMatch =
+    iconState.supported &&
+    target !== null &&
+    iconState.available.includes(target);
+  return { target, availableMatch };
+}

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -380,6 +380,14 @@
       "label": "Obscure Credits",
       "description": "Replaces the dollar amounts on the billing Plan section with a usage-relative view: the current-plan tile trades its price footer for a Usage Balance bar (managed spend this billing cycle against the package's included credits) and the credits spec chip reads \"<Package> usage, reset monthly\" instead of naming a dollar bundle. Spec chips wrap horizontally to fit the shorter labels. Off leaves the Plan section exactly as it ships today.",
       "defaultEnabled": false
+    },
+    {
+      "id": "ios-avatar-app-icon",
+      "scope": "client",
+      "key": "ios-avatar-app-icon",
+      "label": "iOS Avatar App Icon",
+      "description": "Offers to match the iOS home screen icon to the assistant's character avatar, swapping in the bundled alternate icon for that body shape, eye style, and color. Only character avatars qualify: uploaded and AI-generated avatars never change the app icon. Off leaves the default icon in place and hides the prompt entirely.",
+      "defaultEnabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary
- appIconNameForAvatar is the single chokepoint: only kind=character avatars with valid traits produce an icon name, so custom/AI/none avatars can never be offered an icon
- resolveAppIconTarget validates the name against the installed shell's available list (version-skew no-op)
- Registers the ios-avatar-app-icon client flag, defaultEnabled false, bundled copies synced

Part of plan: ios-avatar-app-icons.md (PR 4 of 6)