### PR TITLE
Native AppIcon Capacitor plugin and web runtime wrapper

### DIFF
--- a/clients/ios/App/App/AppIconPlugin.swift
+++ b/clients/ios/App/App/AppIconPlugin.swift
@@ -1,0 +1,76 @@
+import Capacitor
+import Foundation
+import UIKit
+
+/// Capacitor plugin exposing the alternate app icons this build ships, so the
+/// web layer (`clients/web/src/runtime/app-icon.ts`) can match the home-screen
+/// icon to the assistant's character avatar.
+///
+/// Methods:
+/// - `getState` resolves `{ supported, current, available }`. `available` is
+///   read from the bundle's `CFBundleIcons` -> `CFBundleAlternateIcons`, so the
+///   shell is the source of truth for which names exist and the web side
+///   validates its computed name against that list instead of guessing.
+/// - `set({ name })` swaps the icon, or restores the primary one when `name` is
+///   null or absent.
+///
+/// Per the skew rule in `clients/web/docs/CAPACITOR.md`, one result shape
+/// encodes every state and neither method rejects: a build with no alternates
+/// resolves an empty `available`, and a refused icon swap resolves
+/// `{ok: false, error}` rather than rejecting. An older shell without the
+/// plugin fails the bridge call, which the web side reads as the feature being
+/// off.
+@objc(AppIconPlugin)
+public class AppIconPlugin: CAPPlugin, CAPBridgedPlugin {
+    public let identifier = "AppIconPlugin"
+    public let jsName = "AppIcon"
+    public let pluginMethods: [CAPPluginMethod] = [
+        CAPPluginMethod(name: "getState", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "set", returnType: CAPPluginReturnPromise),
+    ]
+
+    @objc public func getState(_ call: CAPPluginCall) {
+        // `UIApplication` is main-actor only, so every read runs on the main
+        // queue even though the bundle scan below does not need it.
+        DispatchQueue.main.async {
+            let application = UIApplication.shared
+            call.resolve([
+                "supported": application.supportsAlternateIcons,
+                "current": Self.nullable(application.alternateIconName),
+                "available": Self.alternateIconNames(),
+            ])
+        }
+    }
+
+    @objc public func set(_ call: CAPPluginCall) {
+        let name = call.getString("name")
+        DispatchQueue.main.async {
+            UIApplication.shared.setAlternateIconName(name) { error in
+                if let error {
+                    call.resolve(["ok": false, "error": error.localizedDescription])
+                    return
+                }
+                call.resolve(["ok": true])
+            }
+        }
+    }
+
+    /// Alternate icon names declared in `Info.plist`, sorted so the list is
+    /// stable across launches (`CFBundleAlternateIcons` is a dictionary).
+    private static func alternateIconNames() -> [String] {
+        guard
+            let icons = Bundle.main.object(forInfoDictionaryKey: "CFBundleIcons") as? [String: Any],
+            let alternates = icons["CFBundleAlternateIcons"] as? [String: Any]
+        else {
+            return []
+        }
+        return alternates.keys.sorted()
+    }
+
+    private static func nullable(_ value: String?) -> Any {
+        if let value {
+            return value
+        }
+        return NSNull()
+    }
+}

--- a/clients/ios/App/App/MyViewController.swift
+++ b/clients/ios/App/App/MyViewController.swift
@@ -169,6 +169,7 @@ class MyViewController: CAPBridgeViewController {
         bridge?.registerPluginInstance(ApnsEnvironmentPlugin())
         bridge?.registerPluginInstance(SelfHostedServersPlugin())
         bridge?.registerPluginInstance(RecentChatsPlugin())
+        bridge?.registerPluginInstance(AppIconPlugin())
         installNavigationDelegateProxy()
         installInputZoomPreventionUserScript()
         installViewportZoomLockUserScript()

--- a/clients/ios/README.md
+++ b/clients/ios/README.md
@@ -43,10 +43,10 @@ which URL is baked into the build.
   process. With `server.url`, only native shell changes (Swift code,
   entitlements, Capacitor plugin updates) require a store submission.
 - **Thin native surface** - the IPC bridge between the WKWebView and
-  native code is minimal (seven app-local plugins: `NativeAuthPlugin`,
+  native code is minimal (eight app-local plugins: `NativeAuthPlugin`,
   `NativeBiometricPlugin`, `VoiceAudioSessionPlugin`,
   `VoiceLiveActivityPlugin`, `ApnsEnvironmentPlugin`,
-  `SelfHostedServersPlugin`, and `RecentChatsPlugin`, plus the
+  `SelfHostedServersPlugin`, `RecentChatsPlugin`, and `AppIconPlugin`, plus the
   auto-discovered community camera preview dependency), so version skew risk between the web app and native
   shell is low. Every plugin call from the web side must still have a
   working missing-plugin fallback because a new web bundle always ships
@@ -152,7 +152,7 @@ Apple's reference for the toolbar controls:
 
 The app has two layers: the **WKWebView contents** (the React app loaded
 from the configured server URL) and the **native Swift shell** (Capacitor
-bridge, `MyViewController`, the seven app-local plugins, and linked package
+bridge, `MyViewController`, the eight app-local plugins, and linked package
 plugins such as `CameraPreview`). Each has its own
 debugger.
 
@@ -715,6 +715,7 @@ clients/
     │   │   ├── SelfHostedServer.swift      # Active + remembered self-hosted origins
     │   │   ├── SelfHostedServersPlugin.swift # Server list / origin switching bridge
     │   │   ├── RecentChatsPlugin.swift # Conversation-list cache for the Shortcuts chat picker
+    │   │   ├── AppIconPlugin.swift   # Alternate app icon state + selection bridge
     │   │   ├── Intents/              # App Intents + AppShortcutsProvider
     │   │   ├── Shared/               # Compiled into app + widget extension
     │   │   └── Info.plist

--- a/clients/web/docs/CAPACITOR.md
+++ b/clients/web/docs/CAPACITOR.md
@@ -169,7 +169,7 @@ References:
 
 Live voice is a web feature with native accessories. The session, including mic capture, the velay socket, TTS playback, and every user-facing string, lives under `src/domains/chat/voice/live-voice/`. iOS adds interruption reporting, a Dynamic Island and Lock Screen presence, and App Intents. Android adds foreground audio focus, a microphone foreground service, and an ongoing status notification. The voice-room camera is the capture exception: native mobile shells use `@capacitor-community/camera-preview`, while browsers and older shells use a web `MediaStream` fallback.
 
-The shell registers **seven app-local** Capacitor plugins in [`MyViewController.capacitorDidLoad()`](../../../clients/ios/App/App/MyViewController.swift) (count them there, not from prose). `CameraPreview` is an external SPM/Gradle dependency that Capacitor discovers automatically, so it is not registered in that method.
+The shell registers **eight app-local** Capacitor plugins in [`MyViewController.capacitorDidLoad()`](../../../clients/ios/App/App/MyViewController.swift) (count them there, not from prose). `CameraPreview` is an external SPM/Gradle dependency that Capacitor discovers automatically, so it is not registered in that method.
 
 | Plugin | Web module | What it does |
 | --- | --- | --- |
@@ -180,6 +180,7 @@ The shell registers **seven app-local** Capacitor plugins in [`MyViewController.
 | `ApnsEnvironment` | [`src/runtime/apns-environment.ts`](../src/runtime/apns-environment.ts) | The build's real APNs entitlement environment (`development` / `production` / `unknown`), read from the embedded provisioning profile |
 | `SelfHostedServers` | [`src/runtime/self-hosted-servers.ts`](../src/runtime/self-hosted-servers.ts) | List, add, remove, and switch between self-hosted server origins; `switchTo` swaps the shell's configured origin and reloads without leaving the app. See the section below |
 | `RecentChats` | [`src/runtime/recent-chats.ts`](../src/runtime/recent-chats.ts) | Mirrors the sidebar conversation list (ids + titles) into a UserDefaults cache that backs the Shortcuts app's chat picker (`ChatEntityQuery`); synced from `ChatLayout` once the list query has resolved |
+| `AppIcon` | [`src/runtime/app-icon.ts`](../src/runtime/app-icon.ts) | Reads the alternate home-screen icons the build ships (`CFBundleAlternateIcons`) and swaps between them, so the app icon can match the assistant's character avatar |
 
 The two voice plugins are consumed only through `use-live-voice-session-controller.ts` (audio session) and `use-live-activity-mirror.ts` (Live Activity), both mounted at `ChatLayout` scope so their lifetime is exactly the session's.
 

--- a/clients/web/src/runtime/app-icon.test.ts
+++ b/clients/web/src/runtime/app-icon.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Tests for the `AppIcon` bridge.
+ *
+ * The contract under test is skew-safety: the iOS shell ships through App
+ * Store review while this bundle deploys continuously, so an arbitrarily old
+ * shell can host it with no such plugin compiled in. Every degrade path
+ * (non-iOS platform, missing plugin, a rejecting bridge) must resolve the
+ * feature-off state without throwing and without touching the bridge.
+ *
+ * Self-contained mocks: run this file solo (`mock.module` leaks across a
+ * shared `bun test` run).
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+let onNativeIOS = true;
+let pluginAvailable = true;
+
+mock.module("@/runtime/platform-detection", () => ({
+  isNativeIOS: () => onNativeIOS,
+}));
+
+interface NativeState {
+  supported?: boolean;
+  current?: string | null;
+  available?: string[];
+}
+
+let stateResult: NativeState = {
+  supported: true,
+  current: null,
+  available: ["avatar-a", "avatar-b"],
+};
+let stateRejects = false;
+let setResult: { ok?: boolean; error?: string } = { ok: true };
+let setRejects = false;
+
+const getStateMock = mock(async (): Promise<NativeState> => {
+  if (stateRejects) {
+    throw new Error("AppIcon.getState() is not implemented on ios");
+  }
+  return stateResult;
+});
+const setMock = mock(async (_options: { name: string | null }) => {
+  if (setRejects) {
+    throw new Error("AppIcon.set() is not implemented on ios");
+  }
+  return setResult;
+});
+
+mock.module("@capacitor/core", () => ({
+  Capacitor: {
+    isPluginAvailable: () => pluginAvailable,
+  },
+  registerPlugin: () => ({ getState: getStateMock, set: setMock }),
+}));
+
+const captureErrorMock = mock(() => {});
+mock.module("@/lib/sentry/capture-error", () => ({
+  captureError: captureErrorMock,
+}));
+
+const { getAppIconState, setAppIcon } = await import("@/runtime/app-icon");
+
+const OFF = { supported: false, current: null, available: [] };
+
+beforeEach(() => {
+  onNativeIOS = true;
+  pluginAvailable = true;
+  stateResult = {
+    supported: true,
+    current: null,
+    available: ["avatar-a", "avatar-b"],
+  };
+  stateRejects = false;
+  setResult = { ok: true };
+  setRejects = false;
+  getStateMock.mockClear();
+  setMock.mockClear();
+  captureErrorMock.mockClear();
+});
+
+describe("getAppIconState", () => {
+  test("reports what the shell says when the plugin answers", async () => {
+    stateResult = {
+      supported: true,
+      current: "avatar-b",
+      available: ["avatar-a", "avatar-b"],
+    };
+
+    expect(await getAppIconState()).toEqual({
+      supported: true,
+      current: "avatar-b",
+      available: ["avatar-a", "avatar-b"],
+    });
+  });
+
+  test("degrades to feature-off without calling the bridge off iOS", async () => {
+    onNativeIOS = false;
+
+    expect(await getAppIconState()).toEqual(OFF);
+    expect(getStateMock).not.toHaveBeenCalled();
+    expect(captureErrorMock).not.toHaveBeenCalled();
+  });
+
+  test("degrades to feature-off on a shell without the plugin", async () => {
+    pluginAvailable = false;
+
+    expect(await getAppIconState()).toEqual(OFF);
+    expect(getStateMock).not.toHaveBeenCalled();
+    expect(captureErrorMock).not.toHaveBeenCalled();
+  });
+
+  test("degrades to feature-off when the bridge call rejects", async () => {
+    stateRejects = true;
+
+    expect(await getAppIconState()).toEqual(OFF);
+    expect(captureErrorMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("fills in fields an older or newer shell omits", async () => {
+    stateResult = {};
+
+    expect(await getAppIconState()).toEqual(OFF);
+  });
+});
+
+describe("setAppIcon", () => {
+  test("resolves true only when the shell applied the change", async () => {
+    expect(await setAppIcon("avatar-a")).toBe(true);
+    expect(setMock).toHaveBeenCalledWith({ name: "avatar-a" });
+
+    expect(await setAppIcon(null)).toBe(true);
+    expect(setMock).toHaveBeenCalledWith({ name: null });
+    expect(captureErrorMock).not.toHaveBeenCalled();
+  });
+
+  test("resolves false when the shell refuses the icon", async () => {
+    setResult = { ok: false, error: "The icon is not in the bundle." };
+
+    expect(await setAppIcon("avatar-missing")).toBe(false);
+    expect(captureErrorMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("resolves false when the bridge call rejects", async () => {
+    setRejects = true;
+
+    expect(await setAppIcon("avatar-a")).toBe(false);
+    expect(captureErrorMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("resolves false without calling the bridge off iOS or with no plugin", async () => {
+    onNativeIOS = false;
+    expect(await setAppIcon("avatar-a")).toBe(false);
+
+    onNativeIOS = true;
+    pluginAvailable = false;
+    expect(await setAppIcon("avatar-a")).toBe(false);
+
+    expect(setMock).not.toHaveBeenCalled();
+    expect(captureErrorMock).not.toHaveBeenCalled();
+  });
+});

--- a/clients/web/src/runtime/app-icon.ts
+++ b/clients/web/src/runtime/app-icon.ts
@@ -1,0 +1,103 @@
+/**
+ * Bridge to the iOS shell's `AppIcon` plugin
+ * (`clients/ios/App/App/AppIconPlugin.swift`), which swaps the home-screen
+ * icon between the alternates the build ships.
+ *
+ * iOS-only: alternate app icons are an iOS bundle feature with no Android
+ * equivalent, and the web app has no home-screen icon to swap.
+ *
+ * `getState().available` is the only source of truth for which icon names
+ * exist. The iOS shell loads this bundle remotely, so an arbitrarily old shell
+ * can be running arbitrarily new web (see `docs/CAPACITOR.md` § The skew rule):
+ * a name the web layer computes may simply not be in the installed build, and
+ * only the shell can say. Every degrade path (older shell, non-iOS platform,
+ * bridge failure) resolves `supported: false` with an empty `available`, so
+ * callers have one thing to check and no error branch to write.
+ */
+
+import { Capacitor, registerPlugin } from "@capacitor/core";
+
+import { captureError } from "@/lib/sentry/capture-error";
+import { isNativeIOS } from "@/runtime/platform-detection";
+
+export interface AppIconState {
+  /** Whether the device and build allow swapping the icon at all. */
+  supported: boolean;
+  /** Active alternate icon name, or null when the primary icon is showing. */
+  current: string | null;
+  /** Alternate icon names this build ships, sorted. */
+  available: string[];
+}
+
+interface AppIconPlugin {
+  getState(): Promise<{
+    supported?: boolean;
+    current?: string | null;
+    available?: string[];
+  }>;
+  set(options: {
+    name: string | null;
+  }): Promise<{ ok?: boolean; error?: string }>;
+}
+
+const APP_ICON_PLUGIN = "AppIcon";
+const AppIcon = registerPlugin<AppIconPlugin>(APP_ICON_PLUGIN);
+
+function unsupported(): AppIconState {
+  return { supported: false, current: null, available: [] };
+}
+
+/**
+ * Gates on the bridge's own plugin registry, so an older shell degrades before
+ * any call is made and the `captureError`s below only ever see real faults.
+ */
+function isAvailable(): boolean {
+  return isNativeIOS() && Capacitor.isPluginAvailable(APP_ICON_PLUGIN);
+}
+
+/** Reads what the installed shell can do, never throwing. */
+export async function getAppIconState(): Promise<AppIconState> {
+  if (!isAvailable()) {
+    return unsupported();
+  }
+  try {
+    // Only the result crosses this `async` boundary, never the plugin Proxy
+    // itself (see docs/CAPACITOR.md).
+    const { supported, current, available } = await AppIcon.getState();
+    return {
+      supported: supported === true,
+      current: typeof current === "string" ? current : null,
+      available: available ?? [],
+    };
+  } catch (error) {
+    captureError(error, { context: "app_icon_get_state", bestEffort: true });
+    return unsupported();
+  }
+}
+
+/**
+ * Swaps the home-screen icon to `name`, or back to the primary icon when
+ * `name` is null. Resolves true only when the shell applied the change.
+ *
+ * iOS shows a system alert on every successful swap, so this must only ever
+ * run from an explicit user action.
+ */
+export async function setAppIcon(name: string | null): Promise<boolean> {
+  if (!isAvailable()) {
+    return false;
+  }
+  try {
+    const { ok, error: nativeError } = await AppIcon.set({ name });
+    if (ok === true) {
+      return true;
+    }
+    captureError(new Error(nativeError ?? "setAlternateIconName failed"), {
+      context: "app_icon_set",
+      bestEffort: true,
+    });
+    return false;
+  } catch (error) {
+    captureError(error, { context: "app_icon_set", bestEffort: true });
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- AppIconPlugin (getState/set) follows the ApnsEnvironmentPlugin pattern, registered in MyViewController; set never rejects and getState enumerates CFBundleAlternateIcons
- clients/web/src/runtime/app-icon.ts wraps it skew-silently: missing plugin or non-iOS resolves supported=false with no error
- Wrapper degrade paths unit-tested
- CAPACITOR.md's app-local plugin table gains the AppIcon row and its count goes from seven to eight

Part of plan: ios-avatar-app-icons.md (PR 3 of 6)