### PR TITLE
ci(dev-release): wait for npm publish processing before meta shrinkwrap

### DIFF
--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -2210,58 +2210,10 @@ jobs:
             .dependencies["@vellumai/vellum-gateway"] = $v |
             .dependencies["@vellumai/web"] = $v
           ' package.json > tmp && mv tmp package.json
-      # The meta package was just stamped to depend on freshly published
-      # @vellumai/* versions, but `npm publish` returning 0 does not mean the
-      # version is resolvable yet: npm queues some publishes for asynchronous
-      # processing ("Your package is being processed and may take a few
-      # minutes to become available"). @vellumai/cli hits that queue on every
-      # dev release and has been landing on the registry a consistent ~5m
-      # after its publish job goes green, so a shrinkwrap install kicked off
-      # right after the last publish fails with ETARGET. Wait until every dep
-      # is actually resolvable before installing.
-      #
-      # The deadline sits well past the observed ~5m lag on purpose. The
-      # equivalent prod steps in release.yml originally waited 300s, close
-      # enough to that lag to be a coin flip; they are widened to match.
       - name: Wait for dependencies to propagate
-        working-directory: meta
-        run: |
-          node -e '
-            const deps = require("./package.json").dependencies || {};
-            for (const [name, version] of Object.entries(deps)) {
-              if (name.startsWith("@vellumai/")) console.log(`${name}@${version}`);
-            }
-          ' > /tmp/vellum-meta-deps.txt
-          deadline=$((SECONDS + 900))
-          while read -r spec; do
-            [ -z "$spec" ] && continue
-            until npm view "$spec" version >/dev/null 2>&1; do
-              if [ "$SECONDS" -ge "$deadline" ]; then
-                echo "::error::$spec still not resolvable on the registry after waiting ~15m"
-                exit 1
-              fi
-              echo "  $spec not yet available; retrying in 10s..."
-              sleep 10
-            done
-            echo "  ✓ $spec available"
-          done < /tmp/vellum-meta-deps.txt
-      # npm only honors "overrides" in the root package.json, so they are
-      # ignored when end users run `npm install -g vellum`. Shipping an
-      # npm-shrinkwrap.json generated with the overrides applied makes npm
-      # follow the same resolution for installed copies of the package.
+        run: ./scripts/npm-wait-for-meta-deps.sh
       - name: Generate npm-shrinkwrap.json
-        working-directory: meta
-        run: |
-          for attempt in 1 2 3; do
-            npm install --package-lock-only && break
-            if [ "$attempt" -eq 3 ]; then
-              echo "::error::npm install --package-lock-only failed after 3 attempts"
-              exit 1
-            fi
-            echo "npm install failed (attempt $attempt); retrying in 15s..."
-            sleep 15
-          done
-          npm shrinkwrap
+        run: ./scripts/npm-generate-meta-shrinkwrap.sh
       - name: Publish
         working-directory: meta
         env:

--- a/.github/workflows/dev-release.yaml
+++ b/.github/workflows/dev-release.yaml
@@ -2189,7 +2189,7 @@ jobs:
     name: publish-npm-dev (meta)
     needs: [compute-version, publish-npm-dev, publish-web-dev]
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 20
     permissions:
       contents: read
     steps:
@@ -2210,6 +2210,41 @@ jobs:
             .dependencies["@vellumai/vellum-gateway"] = $v |
             .dependencies["@vellumai/web"] = $v
           ' package.json > tmp && mv tmp package.json
+      # The meta package was just stamped to depend on freshly published
+      # @vellumai/* versions, but `npm publish` returning 0 does not mean the
+      # version is resolvable yet: npm queues some publishes for asynchronous
+      # processing ("Your package is being processed and may take a few
+      # minutes to become available"). @vellumai/cli hits that queue on every
+      # dev release and has been landing on the registry a consistent ~5m
+      # after its publish job goes green, so a shrinkwrap install kicked off
+      # right after the last publish fails with ETARGET. Wait until every dep
+      # is actually resolvable before installing.
+      #
+      # The deadline sits well past the observed ~5m lag on purpose. The
+      # equivalent prod steps in release.yml originally waited 300s, close
+      # enough to that lag to be a coin flip; they are widened to match.
+      - name: Wait for dependencies to propagate
+        working-directory: meta
+        run: |
+          node -e '
+            const deps = require("./package.json").dependencies || {};
+            for (const [name, version] of Object.entries(deps)) {
+              if (name.startsWith("@vellumai/")) console.log(`${name}@${version}`);
+            }
+          ' > /tmp/vellum-meta-deps.txt
+          deadline=$((SECONDS + 900))
+          while read -r spec; do
+            [ -z "$spec" ] && continue
+            until npm view "$spec" version >/dev/null 2>&1; do
+              if [ "$SECONDS" -ge "$deadline" ]; then
+                echo "::error::$spec still not resolvable on the registry after waiting ~15m"
+                exit 1
+              fi
+              echo "  $spec not yet available; retrying in 10s..."
+              sleep 10
+            done
+            echo "  ✓ $spec available"
+          done < /tmp/vellum-meta-deps.txt
       # npm only honors "overrides" in the root package.json, so they are
       # ignored when end users run `npm install -g vellum`. Shipping an
       # npm-shrinkwrap.json generated with the overrides applied makes npm
@@ -2217,7 +2252,15 @@ jobs:
       - name: Generate npm-shrinkwrap.json
         working-directory: meta
         run: |
-          npm install --package-lock-only
+          for attempt in 1 2 3; do
+            npm install --package-lock-only && break
+            if [ "$attempt" -eq 3 ]; then
+              echo "::error::npm install --package-lock-only failed after 3 attempts"
+              exit 1
+            fi
+            echo "npm install failed (attempt $attempt); retrying in 15s..."
+            sleep 15
+          done
           npm shrinkwrap
       - name: Publish
         working-directory: meta

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1807,54 +1807,10 @@ jobs:
             .dependencies["@vellumai/vellum-gateway"] = $v |
             .dependencies["@vellumai/web"] = $v
           ' package.json > tmp && mv tmp package.json
-      # The meta package was just stamped to depend on freshly published
-      # @vellumai/* versions, but `npm publish` returning 0 does not mean the
-      # version is resolvable yet: npm queues some publishes for asynchronous
-      # processing ("Your package is being processed and may take a few
-      # minutes to become available"), and @vellumai/cli reliably lands on
-      # that queue, showing up on the registry ~5m after its publish job goes
-      # green. A shrinkwrap install kicked off right after the last publish
-      # therefore hits ETARGET. Wait until every dep is actually resolvable
-      # before installing.
       - name: Wait for dependencies to propagate
-        working-directory: meta
-        run: |
-          node -e '
-            const deps = require("./package.json").dependencies || {};
-            for (const [name, version] of Object.entries(deps)) {
-              if (name.startsWith("@vellumai/")) console.log(`${name}@${version}`);
-            }
-          ' > /tmp/vellum-meta-deps.txt
-          deadline=$((SECONDS + 900))
-          while read -r spec; do
-            [ -z "$spec" ] && continue
-            until npm view "$spec" version >/dev/null 2>&1; do
-              if [ "$SECONDS" -ge "$deadline" ]; then
-                echo "::error::$spec still not resolvable on the registry after waiting ~15m"
-                exit 1
-              fi
-              echo "  $spec not yet available; retrying in 10s..."
-              sleep 10
-            done
-            echo "  ✓ $spec available"
-          done < /tmp/vellum-meta-deps.txt
-      # npm only honors "overrides" in the root package.json, so they are
-      # ignored when end users run `npm install -g vellum`. Shipping an
-      # npm-shrinkwrap.json generated with the overrides applied makes npm
-      # follow the same resolution for installed copies of the package.
+        run: ./scripts/npm-wait-for-meta-deps.sh
       - name: Generate npm-shrinkwrap.json
-        working-directory: meta
-        run: |
-          for attempt in 1 2 3; do
-            npm install --package-lock-only && break
-            if [ "$attempt" -eq 3 ]; then
-              echo "::error::npm install --package-lock-only failed after 3 attempts"
-              exit 1
-            fi
-            echo "npm install failed (attempt $attempt); retrying in 15s..."
-            sleep 15
-          done
-          npm shrinkwrap
+        run: ./scripts/npm-generate-meta-shrinkwrap.sh
       - name: Publish
         working-directory: meta
         env:
@@ -2056,55 +2012,10 @@ jobs:
           node-version-file: .nvmrc
           registry-url: https://registry.npmjs.org
 
-      # The meta package was just stamped to depend on freshly published
-      # @vellumai/* versions, but `npm publish` returning 0 does not mean the
-      # version is resolvable yet: npm queues some publishes for asynchronous
-      # processing ("Your package is being processed and may take a few
-      # minutes to become available"), and @vellumai/cli reliably lands on
-      # that queue, showing up on the registry ~5m after its publish job goes
-      # green. A shrinkwrap install kicked off right after the last publish
-      # therefore hits ETARGET. Wait until every dep is actually resolvable
-      # before installing.
       - name: Wait for dependencies to propagate
-        working-directory: meta
-        run: |
-          node -e '
-            const deps = require("./package.json").dependencies || {};
-            for (const [name, version] of Object.entries(deps)) {
-              if (name.startsWith("@vellumai/")) console.log(`${name}@${version}`);
-            }
-          ' > /tmp/vellum-meta-deps.txt
-          deadline=$((SECONDS + 900))
-          while read -r spec; do
-            [ -z "$spec" ] && continue
-            until npm view "$spec" version >/dev/null 2>&1; do
-              if [ "$SECONDS" -ge "$deadline" ]; then
-                echo "::error::$spec still not resolvable on the registry after waiting ~15m"
-                exit 1
-              fi
-              echo "  $spec not yet available; retrying in 10s..."
-              sleep 10
-            done
-            echo "  ✓ $spec available"
-          done < /tmp/vellum-meta-deps.txt
-
-      # npm only honors "overrides" in the root package.json, so they are
-      # ignored when end users run `npm install -g vellum`. Shipping an
-      # npm-shrinkwrap.json generated with the overrides applied makes npm
-      # follow the same resolution for installed copies of the package.
+        run: ./scripts/npm-wait-for-meta-deps.sh
       - name: Generate npm-shrinkwrap.json
-        working-directory: meta
-        run: |
-          for attempt in 1 2 3; do
-            npm install --package-lock-only && break
-            if [ "$attempt" -eq 3 ]; then
-              echo "::error::npm install --package-lock-only failed after 3 attempts"
-              exit 1
-            fi
-            echo "npm install failed (attempt $attempt); retrying in 15s..."
-            sleep 15
-          done
-          npm shrinkwrap
+        run: ./scripts/npm-generate-meta-shrinkwrap.sh
 
       - name: Publish meta-package
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1786,7 +1786,7 @@ jobs:
     needs: [extract-version, publish-npm-staging, publish-web-staging]
     if: ${{ needs.extract-version.outputs.is_staging == 'true' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     permissions:
       contents: read
     steps:
@@ -1808,10 +1808,14 @@ jobs:
             .dependencies["@vellumai/web"] = $v
           ' package.json > tmp && mv tmp package.json
       # The meta package was just stamped to depend on freshly published
-      # @vellumai/* versions. npm's read path (CDN/replicas) lags the publish
-      # by seconds-to-minutes, so a shrinkwrap install kicked off right after
-      # the last dependency publish can hit ETARGET. Wait until every dep is
-      # resolvable before installing.
+      # @vellumai/* versions, but `npm publish` returning 0 does not mean the
+      # version is resolvable yet: npm queues some publishes for asynchronous
+      # processing ("Your package is being processed and may take a few
+      # minutes to become available"), and @vellumai/cli reliably lands on
+      # that queue, showing up on the registry ~5m after its publish job goes
+      # green. A shrinkwrap install kicked off right after the last publish
+      # therefore hits ETARGET. Wait until every dep is actually resolvable
+      # before installing.
       - name: Wait for dependencies to propagate
         working-directory: meta
         run: |
@@ -1821,12 +1825,12 @@ jobs:
               if (name.startsWith("@vellumai/")) console.log(`${name}@${version}`);
             }
           ' > /tmp/vellum-meta-deps.txt
-          deadline=$((SECONDS + 300))
+          deadline=$((SECONDS + 900))
           while read -r spec; do
             [ -z "$spec" ] && continue
             until npm view "$spec" version >/dev/null 2>&1; do
               if [ "$SECONDS" -ge "$deadline" ]; then
-                echo "::error::$spec still not resolvable on the registry after waiting ~5m"
+                echo "::error::$spec still not resolvable on the registry after waiting ~15m"
                 exit 1
               fi
               echo "  $spec not yet available; retrying in 10s..."
@@ -2041,7 +2045,7 @@ jobs:
     needs: [extract-version, publish-npm-prod, publish-web-prod]
     if: ${{ needs.extract-version.outputs.is_staging != 'true' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     permissions:
       contents: read
     steps:
@@ -2052,10 +2056,15 @@ jobs:
           node-version-file: .nvmrc
           registry-url: https://registry.npmjs.org
 
-      # The meta package depends on freshly published @vellumai/* versions.
-      # npm's read path (CDN/replicas) lags the publish by seconds-to-minutes,
-      # so a shrinkwrap install kicked off right after the last dependency
-      # publish can hit ETARGET. Wait until every dep is resolvable first.
+      # The meta package was just stamped to depend on freshly published
+      # @vellumai/* versions, but `npm publish` returning 0 does not mean the
+      # version is resolvable yet: npm queues some publishes for asynchronous
+      # processing ("Your package is being processed and may take a few
+      # minutes to become available"), and @vellumai/cli reliably lands on
+      # that queue, showing up on the registry ~5m after its publish job goes
+      # green. A shrinkwrap install kicked off right after the last publish
+      # therefore hits ETARGET. Wait until every dep is actually resolvable
+      # before installing.
       - name: Wait for dependencies to propagate
         working-directory: meta
         run: |
@@ -2065,12 +2074,12 @@ jobs:
               if (name.startsWith("@vellumai/")) console.log(`${name}@${version}`);
             }
           ' > /tmp/vellum-meta-deps.txt
-          deadline=$((SECONDS + 300))
+          deadline=$((SECONDS + 900))
           while read -r spec; do
             [ -z "$spec" ] && continue
             until npm view "$spec" version >/dev/null 2>&1; do
               if [ "$SECONDS" -ge "$deadline" ]; then
-                echo "::error::$spec still not resolvable on the registry after waiting ~5m"
+                echo "::error::$spec still not resolvable on the registry after waiting ~15m"
                 exit 1
               fi
               echo "  $spec not yet available; retrying in 10s..."

--- a/scripts/npm-generate-meta-shrinkwrap.sh
+++ b/scripts/npm-generate-meta-shrinkwrap.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# npm-generate-meta-shrinkwrap.sh
+#
+# Regenerate meta/npm-shrinkwrap.json from the stamped meta/package.json.
+#
+# npm only honors "overrides" in the root package.json, so they are ignored
+# when end users run `npm install -g vellum`. Shipping an npm-shrinkwrap.json
+# generated with the overrides applied makes npm follow the same resolution
+# for installed copies of the package.
+#
+# The install is retried because registry reads immediately after a publish
+# are the least reliable point in the release; run
+# scripts/npm-wait-for-meta-deps.sh first so the retries cover transient
+# registry errors rather than a dependency that has not finished publishing.
+#
+# Usage:
+#   ./scripts/npm-generate-meta-shrinkwrap.sh
+
+set -euo pipefail
+
+MAX_ATTEMPTS="${MAX_ATTEMPTS:-3}"
+RETRY_DELAY_SECONDS="${RETRY_DELAY_SECONDS:-15}"
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT/meta"
+
+for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+  if npm install --package-lock-only; then
+    break
+  fi
+  if [ "$attempt" -eq "$MAX_ATTEMPTS" ]; then
+    echo "::error::npm install --package-lock-only failed after $MAX_ATTEMPTS attempts"
+    exit 1
+  fi
+  echo "npm install failed (attempt $attempt); retrying in ${RETRY_DELAY_SECONDS}s..."
+  sleep "$RETRY_DELAY_SECONDS"
+done
+
+npm shrinkwrap

--- a/scripts/npm-wait-for-meta-deps.sh
+++ b/scripts/npm-wait-for-meta-deps.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+#
+# npm-wait-for-meta-deps.sh
+#
+# Block until every @vellumai/* dependency pinned in meta/package.json is
+# resolvable on the npm registry.
+#
+# `npm publish` exiting 0 does not mean the version can be installed yet: npm
+# queues some publishes for asynchronous processing ("Your package is being
+# processed and may take a few minutes to become available"). @vellumai/cli
+# lands in that queue on every release and appears on the registry roughly
+# five minutes after its publish job goes green. The meta package is stamped
+# to depend on exact versions published moments earlier, so a shrinkwrap
+# install that starts before processing finishes fails with ETARGET.
+#
+# The deadline covers that processing window with room to spare.
+#
+# Usage:
+#   ./scripts/npm-wait-for-meta-deps.sh
+
+set -euo pipefail
+
+DEADLINE_SECONDS="${DEADLINE_SECONDS:-900}"
+POLL_INTERVAL_SECONDS="${POLL_INTERVAL_SECONDS:-10}"
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT/meta"
+
+deadline=$((SECONDS + DEADLINE_SECONDS))
+
+while read -r spec; do
+  [ -z "$spec" ] && continue
+  until npm view "$spec" version >/dev/null 2>&1; do
+    if [ "$SECONDS" -ge "$deadline" ]; then
+      echo "::error::$spec still not resolvable on the registry after waiting ${DEADLINE_SECONDS}s"
+      exit 1
+    fi
+    echo "  $spec not yet available; retrying in ${POLL_INTERVAL_SECONDS}s..."
+    sleep "$POLL_INTERVAL_SECONDS"
+  done
+  echo "  ✓ $spec available"
+done < <(node -e '
+  const deps = require("./package.json").dependencies || {};
+  for (const [name, version] of Object.entries(deps)) {
+    if (name.startsWith("@vellumai/")) console.log(`${name}@${version}`);
+  }
+')


### PR DESCRIPTION
## What's broken

Every hourly dev release today has failed on `publish-npm-dev (meta)` at the **Generate npm-shrinkwrap.json** step:

```
npm error code ETARGET
npm error notarget No matching version found for @vellumai/cli@0.11.4-dev.202608212007.d4c91a4.
```

Failing runs: [14:14](https://github.com/vellum-ai/vellum-assistant/actions/runs/32491096634), [15:12](https://github.com/vellum-ai/vellum-assistant/actions/runs/32496303194), [16:10](https://github.com/vellum-ai/vellum-assistant/actions/runs/32501516714), [18:10](https://github.com/vellum-ai/vellum-assistant/actions/runs/32512014617), [19:12](https://github.com/vellum-ai/vellum-assistant/actions/runs/32517274305), [20:07](https://github.com/vellum-ai/vellum-assistant/actions/runs/32521934562) — all the same job, all on `@vellumai/cli`.

## Root cause

The cli publish job is green. Its log ends with:

```
npm notice Publishing to https://registry.npmjs.org/ with tag dev and public access
npm notice Your package is being processed and may take a few minutes to become available.
+ @vellumai/cli@0.11.4-dev.202608212007.d4c91a4
```

npm accepted the tarball but **queued it for asynchronous processing**, so `npm publish` exits 0 well before the version is resolvable. In the 20:07 run:

| event | time |
| --- | --- |
| `publish-npm-dev (cli)` job completes | 20:15:18 |
| meta runs `npm install --package-lock-only` | 20:19:50 |
| meta fails with ETARGET | 20:20:16 |
| registry actually records the version | **20:20:24** |

The lag is a near-constant **~5m05s** across runs (19:27:18, 18:25:48, 20:20:24), which looks like a fixed npm-side queue rather than CDN jitter. `@vellumai/cli` is the only one of the five packages that lands in it — assistant (15.2 MB), gateway (4.5 MB), web (6.8 MB) and credential-executor all publish synchronously, and cli at 2.1 MB is the second-smallest, so this is not about tarball size.

## Knock-on effect

`upload-electron-updates` is gated on the meta publish (["never offer an auto-update for a release that didn't publish"](https://github.com/vellum-ai/vellum-assistant/blob/main/.github/workflows/dev-release.yaml#L1883-L1886)). Both `build-electron` legs succeed, but the GCS update feed is never pushed — so the Electron package effectively stops publishing whenever meta fails. That gate is working as designed; meta is the actual break.

## The fix

`release.yml` already grew a **"Wait for dependencies to propagate"** step for this class of failure in #35474, applied to the staging and prod meta jobs. `dev-release.yaml`'s `publish-meta-dev` never got it. This ports it across, along with the 3x retry on the shrinkwrap install.

It also **widens the deadline from 300s to 900s in all three meta jobs** (dev, staging, prod). 300s is shorter than the observed 5m05s lag, so the existing prod guard would have been a coin flip against this exact failure mode. `timeout-minutes` on the three jobs goes to 20 to cover the longer wait.

The stale "npm's read path (CDN/replicas) lags the publish" comments are rewritten to describe the actual mechanism.

## Verification

Ran both branches of the wait loop locally against the live registry:

- all five real dev specs from the 20:07 run resolve immediately and the loop passes through
- a bogus spec (`@vellumai/cli@0.0.0-does-not-exist`) retries, then hits the deadline and exits 1 with the `::error::` annotation

Both workflow files re-parse as YAML with the meta jobs' steps in the expected order.

## Follow-up worth chasing separately

npm queueing only `@vellumai/cli` for processing is worth raising with npm support — this PR absorbs the 5 minutes rather than removing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mvc4548pLfiTkstNuQnUN9