### PR TITLE
Wire alternate avatar icons into the Xcode project and verify the build

### DIFF
--- a/clients/ios/App/App/Config/App-Dev.xcconfig
+++ b/clients/ios/App/App/Config/App-Dev.xcconfig
@@ -2,6 +2,9 @@
 
 #include "Base.xcconfig"
 
+// Generated; supplies ASSETCATALOG_COMPILER_ALTERNATE_APPICON_NAMES.
+#include "AvatarIcons.xcconfig"
+
 ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon-Dev
 ASSOCIATED_DOMAIN = dev-assistant.vellum.ai
 BUNDLE_DISPLAY_NAME = Vellum Dev

--- a/clients/ios/App/App/Config/App-Staging.xcconfig
+++ b/clients/ios/App/App/Config/App-Staging.xcconfig
@@ -2,6 +2,9 @@
 
 #include "Base.xcconfig"
 
+// Generated; supplies ASSETCATALOG_COMPILER_ALTERNATE_APPICON_NAMES.
+#include "AvatarIcons.xcconfig"
+
 ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon-Staging
 ASSOCIATED_DOMAIN = staging-assistant.vellum.ai
 BUNDLE_DISPLAY_NAME = Vellum Staging

--- a/clients/ios/App/App/Config/App.xcconfig
+++ b/clients/ios/App/App/Config/App.xcconfig
@@ -2,6 +2,9 @@
 
 #include "Base.xcconfig"
 
+// Generated; supplies ASSETCATALOG_COMPILER_ALTERNATE_APPICON_NAMES.
+#include "AvatarIcons.xcconfig"
+
 ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon
 ASSOCIATED_DOMAIN = www.vellum.ai
 BUNDLE_DISPLAY_NAME = Vellum

--- a/clients/ios/App/project.yml
+++ b/clients/ios/App/project.yml
@@ -52,10 +52,10 @@ targetTemplates:
       # ASSETCATALOG_COMPILER_APPICON_NAME (set per-target via xcconfig)
       # resolves to a bundled resource.
       #
-      # `AvatarIcons/` holds the generated avatar alternate icons (see
-      # clients/ios/scripts/generate-avatar-icons.ts). No target ships them
-      # yet, so they stay out of the build until a target opts in alongside
-      # Config/AvatarIcons.xcconfig.
+      # `AvatarIcons/` is swept up by this path, so every app target ships
+      # the whole generated alternate set that
+      # ASSETCATALOG_COMPILER_ALTERNATE_APPICON_NAMES names (see
+      # Config/AvatarIcons.xcconfig, included by each App*.xcconfig).
       - path: App
         excludes:
           - "Info.plist"
@@ -64,7 +64,6 @@ targetTemplates:
           - "AppIcon.icon"
           - "AppIcon-Dev.icon"
           - "AppIcon-Staging.icon"
-          - "AvatarIcons"
           - "capacitor.config.json"
           - "config.xml"
           - "public"

--- a/clients/ios/README.md
+++ b/clients/ios/README.md
@@ -320,10 +320,42 @@ inline in `App/project.yml` under the `AppEnvironment` template.
   `cd clients/ios && bun test scripts/__tests__/generate-avatar-icons.test.ts`.
   `pr-ios.yaml` and `ci-main-ios.yaml` run that same check, and both watch
   `assistant/src/avatar/**`, so a catalog edit without a regeneration fails
-  CI. No target builds them yet, so `project.yml` excludes the directory.
+  CI.
+- All three app targets ship the whole avatar set. `project.yml` sweeps
+  `AvatarIcons/` up through the shared `AppEnvironment` source path, and
+  `App.xcconfig`, `App-Staging.xcconfig`, and `App-Dev.xcconfig` each
+  `#include "AvatarIcons.xcconfig"` for
+  `ASSETCATALOG_COMPILER_ALTERNATE_APPICON_NAMES` while keeping their own
+  `ASSETCATALOG_COMPILER_APPICON_NAME`. `AppIconPlugin.swift` reads the
+  resulting `CFBundleIcons` / `CFBundleAlternateIcons` back out of the
+  built `Info.plist`, so that xcconfig is what the web side sees as the
+  available set.
 - `App/App/Base.lproj/LaunchScreen.storyboard` references the `Splash`
   imageset in `Assets.xcassets/`. Those 2732×2732 PNGs are a solid green
   background with a centered white V — same palette as the icon.
+
+### Alternate icon size cost
+
+Each Icon Composer alternate compiles into `Assets.car` as eight
+1024x1024 pre-rendered ARGB images: light, dark, and two tintable
+variants, every one of them duplicated for the `phone` and `pad` idioms.
+That is about **1.30 MiB per alternate icon**, measured on an unsigned
+`App Dev` build:
+
+| Build                      | `.app` total | `Assets.car` |
+| -------------------------- | ------------ | ------------ |
+| Without `AvatarIcons`      | 11.9 MiB     | 1.67 MiB     |
+| With the 24-icon pilot set | 43.1 MiB     | 32.9 MiB     |
+
+`Assets.car` is byte-identical between Debug and Release, so the cost is
+not a debug artifact, and it does not amortize across icons. None of the
+obvious levers move it much: passing only `--target-device iphone`, or
+naming iOS alone in the bundle's `supported-platforms`, still emits the
+duplicate `pad` renditions; zeroing the group `shadow` saves about 16
+percent; clearing `specular` saves nothing. Budget against this number
+before widening the generated set. The full trait catalog is 540
+combinations, which at this rate is on the order of 700 MiB of app icon
+and would need a different icon format rather than more `.icon` bundles.
 
 ### Bundle ID vs capacitor.config appId
 
@@ -453,7 +485,9 @@ On first build after pulling:
   `App/App/AppIcon.icon/` (alongside `Info.plist`), _not_ inside
   `Assets.xcassets/`. It's wired into `project.yml` as a per-target
   resource and shows up in the regenerated `project.pbxproj` as a
-  `folder.iconcomposer.icon` reference.
+  `folder.iconcomposer.icon` reference. Only `Assets.xcassets/` is off
+  limits, not nesting as such: the alternates under `App/App/AvatarIcons/`
+  compile fine from that subdirectory.
 - **Splash looks stretched** — the storyboard uses `scaleAspectFill`
   on a 2732×2732 square. On phones this crops horizontally; the
   centered V stays visible.
@@ -718,7 +752,7 @@ clients/
     │   │   ├── AppIcon.icon/         # Production icon (green)
     │   │   ├── AppIcon-Staging.icon/  # Staging icon (yellow)
     │   │   ├── AppIcon-Dev.icon/      # Dev icon (pink)
-    │   │   ├── AvatarIcons/          # Generated avatar alternate icons (not in any target yet)
+    │   │   ├── AvatarIcons/          # Generated avatar alternate icons (all 3 app targets)
     │   │   ├── Assets.xcassets/      # Splash imageset lives here
     │   │   ├── Base.lproj/           # LaunchScreen.storyboard, Main.storyboard
     │   │   ├── AppDelegate.swift     # Universal Links + APNs token forwarding


### PR DESCRIPTION
Wires the 24 pilot Icon Composer avatar bundles from PR 1 into all three iOS
app targets and measures what they cost. This is the spike PR of the plan: the
size number below is the go/no-go input for the full 540-icon catalog.

## What changed

- `clients/ios/App/project.yml`: dropped the `AvatarIcons` exclude from the
  shared `AppEnvironment` source sweep, so all three app targets pick up the
  whole set. The per-target re-add pattern the `AppIcon-*.icon` bundles use
  exists because each target ships exactly one primary icon; every target
  ships every alternate, so the shared sweep is the right place. Both spec
  shapes were generated and compared: the resulting `project.pbxproj` is
  identical (24 `wrapper.icon` file refs, 72 resource build files, one
  `AvatarIcons` group), so this is the smaller diff for the same output.
- `App.xcconfig` / `App-Staging.xcconfig` / `App-Dev.xcconfig`: each now
  `#include "AvatarIcons.xcconfig"` for
  `ASSETCATALOG_COMPILER_ALTERNATE_APPICON_NAMES`, keeping its own
  `ASSETCATALOG_COMPILER_APPICON_NAME`.
- `clients/ios/README.md`: documents the wiring and adds an "Alternate icon
  size cost" section with the measurements.

No contingency was needed. actool accepted `.icon` alternates from the
`AvatarIcons/` subdirectory with zero warnings, so
`generate-avatar-icons.ts` and the committed bundles are untouched and the
drift test stays green.

## Build verification

Ran the `pr-ios.yaml` recipe locally (`bun install --filter=@vellumai/web`,
`VELLUM_ENVIRONMENT=dev bunx cap sync ios`, `xcodegen generate`, unsigned
`xcodebuild build`), Xcode 26.2.

| Scheme | Result | Primary icon | Alternates in built Info.plist |
| ------ | ------ | ------------ | ------------------------------ |
| App Dev | exit 0 | `AppIcon-Dev` | 24 |
| App (production) | exit 0 | `AppIcon` | 24 |

The sync guard passed on both, the whole build log carries no `warning:`
lines, and no gitignored pbxproj content is committed.

`plutil -extract CFBundleIcons.CFBundleAlternateIcons` on
`App Dev.app/Info.plist` returns all 24 names, each mapping to its own
`CFBundleIconName`:

```
avatar-blob-gentle-green    avatar-ghost-gentle-green
avatar-blob-gentle-orange   avatar-ghost-gentle-orange
avatar-blob-gentle-pink     avatar-ghost-gentle-pink
avatar-blob-gentle-purple   avatar-ghost-gentle-purple
avatar-blob-gentle-teal     avatar-ghost-gentle-teal
avatar-blob-gentle-yellow   avatar-ghost-gentle-yellow
avatar-blob-grumpy-green    avatar-ghost-grumpy-green
avatar-blob-grumpy-orange   avatar-ghost-grumpy-orange
avatar-blob-grumpy-pink     avatar-ghost-grumpy-pink
avatar-blob-grumpy-purple   avatar-ghost-grumpy-purple
avatar-blob-grumpy-teal     avatar-ghost-grumpy-teal
avatar-blob-grumpy-yellow   avatar-ghost-grumpy-yellow
```

```json
{"avatar-blob-gentle-green":{"CFBundleIconName":"avatar-blob-gentle-green"}, ...}
```

That is the exact shape `AppIconPlugin.swift` (PR 3) enumerates.

## Size delta: this is the problem

**24 alternate icons cost 31.2 MiB. The app goes from 11.9 MiB to 43.1 MiB,
a 3.6x increase.**

| Build (`App Dev`, unsigned) | `.app` total | `Assets.car` |
| --------------------------- | ------------ | ------------ |
| Base commit, no `AvatarIcons` | 12,477,505 B (11.9 MiB) | 1,749,608 B (1.67 MiB) |
| This PR, 24 pilot icons | 45,231,241 B (43.1 MiB) | 34,502,664 B (32.9 MiB) |
| Delta | +32,753,736 B (+31.2 MiB) | +32,753,056 B |

**1.30 MiB per alternate icon.** A Release-configuration build produces a
byte-identical `Assets.car` (34,502,664 B), so this is not a debug artifact.

`assetutil --info` shows where it goes. Each alternate compiles to eight
1024x1024 pre-rendered ARGB images, one pair per appearance duplicated across
the `phone` and `pad` idioms:

```
   260760  phone  1024px  (light)
   260760  pad    1024px  (light)
   234400  phone  1024px  UIAppearanceDark
   234400  pad    1024px  UIAppearanceDark
    27908  phone  1024px  ISAppearanceTintable
    27908  pad    1024px  ISAppearanceTintable
    20934  phone  1024px  ISAppearanceTintable
    20934  pad    1024px  ISAppearanceTintable
```

Levers tested by compiling single-bundle variants through actool directly:

| Change | Effect |
| ------ | ------ |
| `--target-device iphone` only | none, `pad` renditions still emitted |
| `supported-platforms` naming iOS alone | none |
| group `specular: false` | none |
| group `shadow.opacity: 0` | -16% (1.04 MiB to 0.87 MiB on the sample) |
| `lighting: "none"` | invalid, actool fails with `Icon export exited with status 255` |

### What this means for PR 6

**Extrapolated to the full 540-combination catalog: roughly 700 MiB of app
icon.** That is not shippable, and no combination of the levers above gets it
within an order of magnitude of viable. PR 6 cannot be a straight flip to
`--full`; it needs either a much smaller curated set or a different icon
format (classic `.appiconset` alternates at 120/180 px are single-digit KB
each, at the cost of the iOS 26 layered look). Flagging for a decision before
PR 6 starts.

The same question applies to this PR: it ships +31.2 MiB for a feature behind
`ios-avatar-app-icon`, which defaults OFF. If the pilot set is not meant to
reach a release build, the wiring should land with a much smaller pilot.

## Schema verification (the two points PR 1 flagged)

**`scale: 1.4` on a 1024pt canvas renders correctly.** Compiling a bundle with
`--standalone-icon-behavior all` emits the rendered PNG; the character is
centered and occupies about 70% of the canvas as intended. The constant also
matches the existing `AppIcon.icon` precedent, where a 92x92 SVG at `scale: 6`
lands at 552pt on the same canvas, so `scale` multiplies the SVG's intrinsic
size in points.

**The carried-over `fill-specializations: [{appearance: "dark", value: "none"}]`
is a no-op, not a blanking.** Compiling the bundle with and without that key
produces byte-identical renditions in every appearance (the two `Assets.car`
files differ by 176 bytes, which is the specialization metadata itself). The
dark rendition is 234,400 B of real artwork, not an empty background. No
generator change needed.

Part of plan: ios-avatar-app-icons.md (PR 2 of 6)