### PR TITLE
Prompt-driven app icon apply UX with custom-avatar guard

### DIFF
--- a/clients/web/eslint.config.mjs
+++ b/clients/web/eslint.config.mjs
@@ -190,6 +190,7 @@ const authBoundaryAllowedPaths = [
  * noise, which is how these rules die.
  */
 const i18nEnforcedPaths = [
+  "src/components/avatar/app-icon-match-prompt.tsx",
   "src/components/companion-intro.tsx",
   "src/components/not-found.tsx",
   "src/components/section-actions-button.tsx",

--- a/clients/web/src/components/avatar/app-icon-match-prompt.test.tsx
+++ b/clients/web/src/components/avatar/app-icon-match-prompt.test.tsx
@@ -2,7 +2,8 @@
  * The prompt is the only surface that asks, so the tests here are about when
  * it must stay quiet: a non-character avatar, a build without the bundle, the
  * flag off, onboarding on screen, a name already declined, and a name already
- * asked about this session.
+ * asked about this session. An offer already on screen has to go quiet on the
+ * same terms, so the tests below also take the question away mid-display.
  */
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { act, cleanup, render, waitFor } from "@testing-library/react";
@@ -92,6 +93,8 @@ mock.module("@/hooks/use-assistant-avatar", () => ({
 
 const { AppIconMatchPrompt, __resetAppIconOfferSession } =
   await import("@/components/avatar/app-icon-match-prompt");
+const { APP_ICON_UNSUPPORTED, useAppIconStore } =
+  await import("@/stores/app-icon-store");
 const { useClientFeatureFlagStore } =
   await import("@/stores/client-feature-flag-store");
 const { useInChatOnboardingStore } =
@@ -104,6 +107,16 @@ function renderPrompt(pathname = "/assistant/c/conv-1") {
     createElement(
       MemoryRouter,
       { initialEntries: [pathname] },
+      createElement(AppIconMatchPrompt, { assistantId: "asst-1" }),
+    ),
+  );
+}
+
+function rerenderPrompt(view: ReturnType<typeof renderPrompt>) {
+  view.rerender(
+    createElement(
+      MemoryRouter,
+      { initialEntries: ["/assistant/c/conv-1"] },
       createElement(AppIconMatchPrompt, { assistantId: "asst-1" }),
     ),
   );
@@ -149,6 +162,7 @@ beforeEach(() => {
   iconState = { supported: true, current: null, available: [ICON, OTHER_ICON] };
   localStorage.clear();
   __resetAppIconOfferSession();
+  useAppIconStore.setState({ snapshot: APP_ICON_UNSUPPORTED });
   useClientFeatureFlagStore.setState({ iosAvatarAppIcon: true });
   useOnboardingFocusStore.setState({ focused: false });
   useInChatOnboardingStore.setState({ prototypeActive: false, stage: "done" });
@@ -272,6 +286,50 @@ describe("AppIconMatchPrompt", () => {
     renderPrompt();
 
     await expectNoPrompt();
+  });
+
+  test("closes an open offer when onboarding takes the screen", async () => {
+    renderPrompt();
+    await expectPrompt();
+
+    act(() => {
+      useOnboardingFocusStore.setState({ focused: true });
+    });
+
+    await waitFor(() => {
+      expect(dialogTitle()).toBeNull();
+    });
+    expect(setAppIcon).not.toHaveBeenCalled();
+  });
+
+  test("closes an open offer when the target becomes one already declined", async () => {
+    localStorage.setItem(`vellum:appIcon:declined:${OTHER_ICON}`, "1");
+    const view = renderPrompt();
+    await expectPrompt();
+
+    // The active assistant changes. The dialog on screen asks about the icon
+    // the old avatar wanted, but Apply now swaps to the new one, which this
+    // user already said no to.
+    avatarState = OTHER_CHARACTER;
+    rerenderPrompt(view);
+
+    await waitFor(() => {
+      expect(dialogTitle()).toBeNull();
+    });
+    expect(setAppIcon).not.toHaveBeenCalled();
+  });
+
+  test("closes an open offer when the avatar stops mapping to an icon", async () => {
+    const view = renderPrompt();
+    await expectPrompt();
+
+    avatarState = IMAGE_WITH_STALE_TRAITS;
+    rerenderPrompt(view);
+
+    await waitFor(() => {
+      expect(dialogTitle()).toBeNull();
+    });
+    expect(setAppIcon).not.toHaveBeenCalled();
   });
 
   test("never offers a name declined in an earlier session", async () => {

--- a/clients/web/src/components/avatar/app-icon-match-prompt.test.tsx
+++ b/clients/web/src/components/avatar/app-icon-match-prompt.test.tsx
@@ -1,0 +1,317 @@
+/**
+ * The prompt is the only surface that asks, so the tests here are about when
+ * it must stay quiet: a non-character avatar, a build without the bundle, the
+ * flag off, onboarding on screen, a name already declined, and a name already
+ * asked about this session.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { act, cleanup, render, waitFor } from "@testing-library/react";
+import { createElement } from "react";
+import { MemoryRouter } from "react-router";
+
+import type { AppIconState } from "@/runtime/app-icon";
+import type { AvatarState, CharacterComponents } from "@/types/avatar";
+
+const COMPONENTS: CharacterComponents = {
+  bodyShapes: [
+    {
+      id: "blob",
+      viewBox: { width: 128, height: 256 },
+      faceCenter: { x: 64, y: 80 },
+      svgPath: "M 64 128 C 80 144 96 160 64 176 C 32 160 48 144 64 128 Z",
+    },
+  ],
+  eyeStyles: [
+    {
+      id: "curious",
+      sourceViewBox: { width: 32, height: 32 },
+      eyeCenter: { x: 16, y: 16 },
+      paths: [{ svgPath: "M 8 16 A 8 8 0 0 1 24 16", color: "#000" }],
+    },
+  ],
+  colors: [{ id: "cosmic-purple", hex: "#7c3aed" }],
+  faceCenterOverrides: [],
+};
+
+const TRAITS = {
+  bodyShape: "blob",
+  eyeStyle: "curious",
+  color: "cosmic-purple",
+};
+const ICON = "avatar-blob-curious-cosmic-purple";
+const OTHER_TRAITS = { ...TRAITS, color: "moss" };
+const OTHER_ICON = "avatar-blob-curious-moss";
+
+const CHARACTER: AvatarState = {
+  kind: "character",
+  traits: TRAITS,
+  source: "builder",
+  image: null,
+};
+
+const OTHER_CHARACTER: AvatarState = {
+  kind: "character",
+  traits: OTHER_TRAITS,
+  source: "builder",
+  image: null,
+};
+
+/** An uploaded image whose traits sidecar was never cleaned up. */
+const IMAGE_WITH_STALE_TRAITS: AvatarState = {
+  kind: "image",
+  traits: TRAITS,
+  source: "upload",
+  image: null,
+};
+
+let avatarState: AvatarState | null = CHARACTER;
+let nativeIOS = true;
+let iconState: AppIconState = {
+  supported: true,
+  current: null,
+  available: [ICON, OTHER_ICON],
+};
+
+const getAppIconState = mock(async () => iconState);
+const setAppIcon = mock(async (_name: string | null) => true);
+
+mock.module("@/runtime/app-icon", () => ({ getAppIconState, setAppIcon }));
+mock.module("@/runtime/platform-detection", () => ({
+  useIsNativeIOS: () => nativeIOS,
+}));
+mock.module("@/hooks/use-assistant-avatar", () => ({
+  useAssistantAvatar: () => ({
+    components: COMPONENTS,
+    traits: avatarState?.traits ?? null,
+    customImageUrl: null,
+    state: avatarState,
+    isLoading: false,
+    invalidate: () => {},
+  }),
+}));
+
+const { AppIconMatchPrompt, __resetAppIconOfferSession } =
+  await import("@/components/avatar/app-icon-match-prompt");
+const { useClientFeatureFlagStore } =
+  await import("@/stores/client-feature-flag-store");
+const { useInChatOnboardingStore } =
+  await import("@/stores/in-chat-onboarding-store");
+const { useOnboardingFocusStore } =
+  await import("@/stores/onboarding-focus-store");
+
+function renderPrompt(pathname = "/assistant/c/conv-1") {
+  return render(
+    createElement(
+      MemoryRouter,
+      { initialEntries: [pathname] },
+      createElement(AppIconMatchPrompt, { assistantId: "asst-1" }),
+    ),
+  );
+}
+
+function dialogTitle(): string | null {
+  const title = document.querySelector<HTMLElement>(
+    '[data-slot="modal-title"]',
+  );
+  return title?.textContent?.trim() ?? null;
+}
+
+function clickByText(text: string) {
+  const button = Array.from(
+    document.querySelectorAll<HTMLElement>("button"),
+  ).find((element) => element.textContent?.trim() === text);
+  expect(button).toBeDefined();
+  act(() => {
+    button?.click();
+  });
+}
+
+async function expectPrompt() {
+  await waitFor(() => {
+    expect(dialogTitle()).toBe("Match your app icon to your avatar?");
+  });
+}
+
+async function expectNoPrompt() {
+  await waitFor(() => {
+    expect(getAppIconState).toHaveBeenCalled();
+  });
+  // Let any offer effect flush before asserting the absence.
+  await act(async () => {
+    await Promise.resolve();
+  });
+  expect(dialogTitle()).toBeNull();
+}
+
+beforeEach(() => {
+  avatarState = CHARACTER;
+  nativeIOS = true;
+  iconState = { supported: true, current: null, available: [ICON, OTHER_ICON] };
+  localStorage.clear();
+  __resetAppIconOfferSession();
+  useClientFeatureFlagStore.setState({ iosAvatarAppIcon: true });
+  useOnboardingFocusStore.setState({ focused: false });
+  useInChatOnboardingStore.setState({ prototypeActive: false, stage: "done" });
+});
+
+afterEach(() => {
+  cleanup();
+  getAppIconState.mockClear();
+  setAppIcon.mockClear();
+  useClientFeatureFlagStore.setState({ iosAvatarAppIcon: false });
+});
+
+describe("AppIconMatchPrompt", () => {
+  test("offers the matching icon for a character avatar", async () => {
+    renderPrompt();
+
+    await expectPrompt();
+  });
+
+  test("applies the target on Apply and closes", async () => {
+    renderPrompt();
+    await expectPrompt();
+
+    clickByText("Apply");
+
+    await waitFor(() => {
+      expect(setAppIcon).toHaveBeenCalledTimes(1);
+    });
+    expect(setAppIcon.mock.calls[0]?.[0]).toBe(ICON);
+    await waitFor(() => {
+      expect(dialogTitle()).toBeNull();
+    });
+    // Accepting is not declining: closing the dialog from the Apply path must
+    // not write the decline the dismiss path writes.
+    expect(localStorage.getItem(`vellum:appIcon:declined:${ICON}`)).toBeNull();
+  });
+
+  test("offers again when the avatar changes on another device", async () => {
+    const view = renderPrompt();
+    await expectPrompt();
+    clickByText("Not now");
+    await waitFor(() => {
+      expect(dialogTitle()).toBeNull();
+    });
+
+    // The `avatar_updated` sweep refetches and the query hands back a
+    // different character.
+    avatarState = OTHER_CHARACTER;
+    view.rerender(
+      createElement(
+        MemoryRouter,
+        { initialEntries: ["/assistant/c/conv-1"] },
+        createElement(AppIconMatchPrompt, { assistantId: "asst-1" }),
+      ),
+    );
+
+    await expectPrompt();
+  });
+
+  test("never offers for an uploaded image, even with stale traits", async () => {
+    avatarState = IMAGE_WITH_STALE_TRAITS;
+
+    renderPrompt();
+
+    await expectNoPrompt();
+    expect(setAppIcon).not.toHaveBeenCalled();
+  });
+
+  test("never offers with the flag off", async () => {
+    useClientFeatureFlagStore.setState({ iosAvatarAppIcon: false });
+
+    renderPrompt();
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(dialogTitle()).toBeNull();
+    expect(getAppIconState).not.toHaveBeenCalled();
+  });
+
+  test("never offers off native iOS", async () => {
+    nativeIOS = false;
+
+    renderPrompt();
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(dialogTitle()).toBeNull();
+    expect(getAppIconState).not.toHaveBeenCalled();
+  });
+
+  test("never offers a name this build does not bundle", async () => {
+    iconState = { supported: true, current: null, available: [OTHER_ICON] };
+
+    renderPrompt();
+
+    await expectNoPrompt();
+  });
+
+  test("never offers on an onboarding route", async () => {
+    renderPrompt("/assistant/onboarding/hatching");
+
+    await expectNoPrompt();
+  });
+
+  test("never offers while the focused onboarding chat is up", async () => {
+    useOnboardingFocusStore.setState({ focused: true });
+
+    renderPrompt();
+
+    await expectNoPrompt();
+  });
+
+  test("never offers while the in-chat tour is running", async () => {
+    useInChatOnboardingStore.setState({
+      prototypeActive: true,
+      stage: "tour",
+    });
+
+    renderPrompt();
+
+    await expectNoPrompt();
+  });
+
+  test("never offers a name declined in an earlier session", async () => {
+    localStorage.setItem(`vellum:appIcon:declined:${ICON}`, "1");
+
+    renderPrompt();
+
+    await expectNoPrompt();
+  });
+
+  test("a decline persists but a different avatar still gets asked", async () => {
+    renderPrompt();
+    await expectPrompt();
+    clickByText("Not now");
+
+    expect(localStorage.getItem(`vellum:appIcon:declined:${ICON}`)).toBe("1");
+
+    // A new session with a different avatar.
+    cleanup();
+    __resetAppIconOfferSession();
+    avatarState = OTHER_CHARACTER;
+    renderPrompt();
+
+    await expectPrompt();
+  });
+
+  test("asks about a name at most once per session", async () => {
+    renderPrompt();
+    await expectPrompt();
+    clickByText("Apply");
+    await waitFor(() => {
+      expect(dialogTitle()).toBeNull();
+    });
+
+    // Remount without clearing the session memory: applying did not decline
+    // the name, and the offer must still not come back.
+    cleanup();
+    iconState = { supported: true, current: null, available: [ICON] };
+    renderPrompt();
+
+    await expectNoPrompt();
+  });
+});

--- a/clients/web/src/components/avatar/app-icon-match-prompt.test.tsx
+++ b/clients/web/src/components/avatar/app-icon-match-prompt.test.tsx
@@ -3,7 +3,8 @@
  * it must stay quiet: a non-character avatar, a build without the bundle, the
  * flag off, onboarding on screen, a name already declined, and a name already
  * asked about this session. An offer already on screen has to go quiet on the
- * same terms, so the tests below also take the question away mid-display.
+ * same terms, so the tests below also take the question away mid-display, and
+ * a swap iOS refuses has to leave the question exactly where it was.
  */
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { act, cleanup, render, waitFor } from "@testing-library/react";
@@ -73,8 +74,11 @@ let iconState: AppIconState = {
   available: [ICON, OTHER_ICON],
 };
 
+/** What the shell answers the next swap with: iOS is free to refuse one. */
+let swapSucceeds = true;
+
 const getAppIconState = mock(async () => iconState);
-const setAppIcon = mock(async (_name: string | null) => true);
+const setAppIcon = mock(async (_name: string | null) => swapSucceeds);
 
 mock.module("@/runtime/app-icon", () => ({ getAppIconState, setAppIcon }));
 mock.module("@/runtime/platform-detection", () => ({
@@ -129,6 +133,11 @@ function dialogTitle(): string | null {
   return title?.textContent?.trim() ?? null;
 }
 
+function alertText(): string | null {
+  const alert = document.querySelector<HTMLElement>('[role="alert"]');
+  return alert?.textContent?.trim() ?? null;
+}
+
 function clickByText(text: string) {
   const button = Array.from(
     document.querySelectorAll<HTMLElement>("button"),
@@ -159,6 +168,7 @@ async function expectNoPrompt() {
 beforeEach(() => {
   avatarState = CHARACTER;
   nativeIOS = true;
+  swapSucceeds = true;
   iconState = { supported: true, current: null, available: [ICON, OTHER_ICON] };
   localStorage.clear();
   __resetAppIconOfferSession();
@@ -198,6 +208,52 @@ describe("AppIconMatchPrompt", () => {
     // Accepting is not declining: closing the dialog from the Apply path must
     // not write the decline the dismiss path writes.
     expect(localStorage.getItem(`vellum:appIcon:declined:${ICON}`)).toBeNull();
+  });
+
+  test("keeps the dialog up and retryable when iOS refuses the swap", async () => {
+    swapSucceeds = false;
+    renderPrompt();
+    await expectPrompt();
+
+    clickByText("Apply");
+
+    await waitFor(() => {
+      expect(alertText()).toBe(
+        "iOS did not change your home screen icon. You can try again.",
+      );
+    });
+    // The home screen never changed, so the question is still on screen and
+    // the refusal is neither an acceptance nor a decline.
+    expect(dialogTitle()).toBe("Match your app icon to your avatar?");
+    expect(localStorage.getItem(`vellum:appIcon:declined:${ICON}`)).toBeNull();
+
+    swapSucceeds = true;
+    clickByText("Apply");
+
+    await waitFor(() => {
+      expect(setAppIcon).toHaveBeenCalledTimes(2);
+    });
+    await waitFor(() => {
+      expect(dialogTitle()).toBeNull();
+    });
+  });
+
+  test("a refused apply leaves the name askable again this session", async () => {
+    swapSucceeds = false;
+    renderPrompt();
+    await expectPrompt();
+
+    clickByText("Apply");
+    await waitFor(() => {
+      expect(alertText()).not.toBeNull();
+    });
+
+    // A refusal spends nothing, so the same session gets to ask again.
+    cleanup();
+    renderPrompt();
+
+    await expectPrompt();
+    expect(alertText()).toBeNull();
   });
 
   test("offers again when the avatar changes on another device", async () => {

--- a/clients/web/src/components/avatar/app-icon-match-prompt.tsx
+++ b/clients/web/src/components/avatar/app-icon-match-prompt.tsx
@@ -72,16 +72,25 @@ export function AppIconMatchPrompt({ assistantId }: AppIconMatchPromptProps) {
 
   const [offer, setOffer] = useState<string | null>(null);
 
+  // An offer is about one icon name, so it only survives while that name is
+  // still the answer. Onboarding taking the screen, the avatar becoming one we
+  // ship no icon for, or the active assistant changing all retire the question
+  // on screen rather than leaving it to act on the new assistant's behalf.
   useEffect(() => {
     if (!canOffer || targetIcon === null || onboardingActive) {
+      setOffer(null);
+      return;
+    }
+    if (offer === targetIcon) {
       return;
     }
     if (offeredThisSession.has(targetIcon) || isDeclined(targetIcon)) {
+      setOffer(null);
       return;
     }
     offeredThisSession.add(targetIcon);
     setOffer(targetIcon);
-  }, [canOffer, targetIcon, onboardingActive]);
+  }, [canOffer, targetIcon, onboardingActive, offer]);
 
   if (!enabled) {
     return null;

--- a/clients/web/src/components/avatar/app-icon-match-prompt.tsx
+++ b/clients/web/src/components/avatar/app-icon-match-prompt.tsx
@@ -14,6 +14,10 @@
  * name forever, so the answer holds for that avatar but a different avatar is
  * a new question. And a name is offered at most once per app session, so a
  * query refetch or a route change cannot re-ask what is already on screen.
+ *
+ * Both guards spend the question, so only an answered question spends them. An
+ * Apply iOS refuses leaves the home screen untouched, so the dialog stays up
+ * with the failure named on it and the name goes back to the session.
  */
 import { useEffect, useState } from "react";
 import { useLocation } from "react-router";
@@ -71,6 +75,8 @@ export function AppIconMatchPrompt({ assistantId }: AppIconMatchPromptProps) {
   const onboardingActive = onSetupRoute || focusedOnboarding || tourActive;
 
   const [offer, setOffer] = useState<string | null>(null);
+  const [applyFailed, setApplyFailed] = useState(false);
+  const [pending, setPending] = useState(false);
 
   // An offer is about one icon name, so it only survives while that name is
   // still the answer. Onboarding taking the screen, the avatar becoming one we
@@ -79,6 +85,7 @@ export function AppIconMatchPrompt({ assistantId }: AppIconMatchPromptProps) {
   useEffect(() => {
     if (!canOffer || targetIcon === null || onboardingActive) {
       setOffer(null);
+      setApplyFailed(false);
       return;
     }
     if (offer === targetIcon) {
@@ -86,19 +93,40 @@ export function AppIconMatchPrompt({ assistantId }: AppIconMatchPromptProps) {
     }
     if (offeredThisSession.has(targetIcon) || isDeclined(targetIcon)) {
       setOffer(null);
+      setApplyFailed(false);
       return;
     }
     offeredThisSession.add(targetIcon);
     setOffer(targetIcon);
+    setApplyFailed(false);
   }, [canOffer, targetIcon, onboardingActive, offer]);
 
   if (!enabled) {
     return null;
   }
 
-  const handleApply = () => {
-    setOffer(null);
-    void apply();
+  const handleApply = async () => {
+    const name = offer;
+    if (name === null || pending) {
+      return;
+    }
+    setPending(true);
+    setApplyFailed(false);
+    try {
+      if (await apply()) {
+        // An earlier refusal in this same dialog handed the name back to the
+        // session, so a landed swap has to take it again.
+        offeredThisSession.add(name);
+        setOffer(null);
+        return;
+      }
+      // Nothing changed on the home screen, so nothing was answered: give the
+      // name back to the session and keep the dialog up to be tried again.
+      offeredThisSession.delete(name);
+      setApplyFailed(true);
+    } finally {
+      setPending(false);
+    }
   };
 
   const handleDismiss = () => {
@@ -138,12 +166,24 @@ export function AppIconMatchPrompt({ assistantId }: AppIconMatchPromptProps) {
           <Modal.Description>
             {t("appIconMatchPrompt.message")}
           </Modal.Description>
+          {applyFailed ? (
+            <p
+              role="alert"
+              className="mt-3 text-body-small-default text-[color:var(--content-negative)]"
+            >
+              {t("appIconMatchPrompt.error")}
+            </p>
+          ) : null}
         </Modal.Body>
         <Modal.Footer>
           <Button variant="outlined" onClick={handleDismiss}>
             {t("appIconMatchPrompt.notNow")}
           </Button>
-          <Button variant="primary" onClick={handleApply}>
+          <Button
+            variant="primary"
+            disabled={pending}
+            onClick={() => void handleApply()}
+          >
             {t("appIconMatchPrompt.apply")}
           </Button>
         </Modal.Footer>

--- a/clients/web/src/components/avatar/app-icon-match-prompt.tsx
+++ b/clients/web/src/components/avatar/app-icon-match-prompt.tsx
@@ -1,0 +1,144 @@
+/**
+ * The one surface that offers to match the iOS home-screen icon to the
+ * assistant's avatar.
+ *
+ * Three paths reach it and none needs code of its own, because all three are
+ * the same fact arriving: the avatar query says this assistant is a character
+ * the installed build ships an icon for, and that icon is not the one applied.
+ * Saving a character in the avatar editor invalidates that query; an avatar
+ * changed on another device arrives through the `avatar_updated` sweep, or on
+ * the next foreground; and a new user's first arrival in the main app is the
+ * query resolving for the first time.
+ *
+ * Two guards keep it from becoming nagging. A dismissal is remembered per icon
+ * name forever, so the answer holds for that avatar but a different avatar is
+ * a new question. And a name is offered at most once per app session, so a
+ * query refetch or a route change cannot re-ask what is already on screen.
+ */
+import { useEffect, useState } from "react";
+import { useLocation } from "react-router";
+
+import { AvatarRenderer } from "@/components/avatar-renderer";
+import { useAppIconSync } from "@/hooks/use-app-icon-sync";
+import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
+import { useTranslation } from "@/i18n";
+import {
+  selectTourActive,
+  useInChatOnboardingStore,
+} from "@/stores/in-chat-onboarding-store";
+import { useOnboardingFocusStore } from "@/stores/onboarding-focus-store";
+import { getLocalSetting, setLocalSetting } from "@/utils/local-settings";
+import { shouldSuppressRootStatusBanner } from "@/utils/status-banner-visibility";
+import { Button } from "@vellumai/design-library/components/button";
+import { Modal } from "@vellumai/design-library/components/modal";
+
+const DECLINED_KEY_PREFIX = "vellum:appIcon:declined:";
+
+/** Icon names already offered in this app session, whatever the answer was. */
+const offeredThisSession = new Set<string>();
+
+function isDeclined(name: string): boolean {
+  return getLocalSetting(DECLINED_KEY_PREFIX + name, "") === "1";
+}
+
+function decline(name: string): void {
+  setLocalSetting(DECLINED_KEY_PREFIX + name, "1");
+}
+
+/** Test seam: drops the once-per-session memory. */
+export function __resetAppIconOfferSession(): void {
+  offeredThisSession.clear();
+}
+
+interface AppIconMatchPromptProps {
+  assistantId: string | null;
+}
+
+export function AppIconMatchPrompt({ assistantId }: AppIconMatchPromptProps) {
+  const { t } = useTranslation();
+  const { enabled, targetIcon, canOffer, apply } = useAppIconSync(assistantId);
+  const { components, traits } = useAssistantAvatar(assistantId);
+
+  // Onboarding owns the whole screen while it runs, and a first-run user has
+  // not yet met the avatar this offer is about.
+  const location = useLocation();
+  const onSetupRoute = shouldSuppressRootStatusBanner(
+    location.pathname,
+    location.search,
+  );
+  const focusedOnboarding = useOnboardingFocusStore.use.focused();
+  const tourActive = useInChatOnboardingStore(selectTourActive);
+  const onboardingActive = onSetupRoute || focusedOnboarding || tourActive;
+
+  const [offer, setOffer] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!canOffer || targetIcon === null || onboardingActive) {
+      return;
+    }
+    if (offeredThisSession.has(targetIcon) || isDeclined(targetIcon)) {
+      return;
+    }
+    offeredThisSession.add(targetIcon);
+    setOffer(targetIcon);
+  }, [canOffer, targetIcon, onboardingActive]);
+
+  if (!enabled) {
+    return null;
+  }
+
+  const handleApply = () => {
+    setOffer(null);
+    void apply();
+  };
+
+  const handleDismiss = () => {
+    if (offer !== null) {
+      decline(offer);
+    }
+    setOffer(null);
+  };
+
+  return (
+    <Modal.Root
+      open={offer !== null}
+      onOpenChange={(next) => {
+        if (!next) {
+          handleDismiss();
+        }
+      }}
+    >
+      <Modal.Content size="sm" hideCloseButton>
+        <Modal.Header>
+          <Modal.Title>{t("appIconMatchPrompt.title")}</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          {components && traits ? (
+            <div className="mb-3 flex justify-center">
+              <div className="rounded-2xl bg-[var(--surface-sunken)] p-4">
+                <AvatarRenderer
+                  components={components}
+                  bodyShapeId={traits.bodyShape}
+                  eyeStyleId={traits.eyeStyle}
+                  colorId={traits.color}
+                  size={96}
+                />
+              </div>
+            </div>
+          ) : null}
+          <Modal.Description>
+            {t("appIconMatchPrompt.message")}
+          </Modal.Description>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button variant="outlined" onClick={handleDismiss}>
+            {t("appIconMatchPrompt.notNow")}
+          </Button>
+          <Button variant="primary" onClick={handleApply}>
+            {t("appIconMatchPrompt.apply")}
+          </Button>
+        </Modal.Footer>
+      </Modal.Content>
+    </Modal.Root>
+  );
+}

--- a/clients/web/src/components/avatar/app-icon-match-prompt.tsx
+++ b/clients/web/src/components/avatar/app-icon-match-prompt.tsx
@@ -19,7 +19,7 @@
  * Apply iOS refuses leaves the home screen untouched, so the dialog stays up
  * with the failure named on it and the name goes back to the session.
  */
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useLocation } from "react-router";
 
 import { AvatarRenderer } from "@/components/avatar-renderer";
@@ -75,6 +75,13 @@ export function AppIconMatchPrompt({ assistantId }: AppIconMatchPromptProps) {
   const onboardingActive = onSetupRoute || focusedOnboarding || tourActive;
 
   const [offer, setOffer] = useState<string | null>(null);
+  // Completion handlers read the offer through this ref: a swap can outlive
+  // the offer that started it, and only the dialog for the completed name may
+  // settle. Synced in an effect, never during render.
+  const offerRef = useRef<string | null>(null);
+  useEffect(() => {
+    offerRef.current = offer;
+  }, [offer]);
   const [applyFailed, setApplyFailed] = useState(false);
   const [pending, setPending] = useState(false);
 
@@ -117,13 +124,19 @@ export function AppIconMatchPrompt({ assistantId }: AppIconMatchPromptProps) {
         // An earlier refusal in this same dialog handed the name back to the
         // session, so a landed swap has to take it again.
         offeredThisSession.add(name);
-        setOffer(null);
+        // A replacement offer can appear while the swap is in flight; only
+        // the dialog for the completed name settles.
+        if (offerRef.current === name) {
+          setOffer(null);
+        }
         return;
       }
       // Nothing changed on the home screen, so nothing was answered: give the
       // name back to the session and keep the dialog up to be tried again.
       offeredThisSession.delete(name);
-      setApplyFailed(true);
+      if (offerRef.current === name) {
+        setApplyFailed(true);
+      }
     } finally {
       setPending(false);
     }

--- a/clients/web/src/domains/settings/components/app-icon-card.test.tsx
+++ b/clients/web/src/domains/settings/components/app-icon-card.test.tsx
@@ -1,6 +1,7 @@
 /**
  * The settings card is the user-initiated half of the feature: it ignores the
- * prompt's decline memory, and it is the only way back to the default icon.
+ * prompt's decline memory, and it is the only way back to the default icon, so
+ * Reset stays reachable for as long as one of our icons is applied.
  */
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { act, cleanup, render, waitFor } from "@testing-library/react";
@@ -15,6 +16,8 @@ const TRAITS = {
   color: "cosmic-purple",
 };
 const ICON = "avatar-blob-curious-cosmic-purple";
+/** One of ours, applied for an avatar the assistant no longer wears. */
+const STALE_ICON = "avatar-blob-curious-moss";
 
 const CHARACTER: AvatarState = {
   kind: "character",
@@ -39,7 +42,11 @@ let iconState: AppIconState = {
 };
 
 const getAppIconState = mock(async () => iconState);
-const setAppIcon = mock(async (_name: string | null) => true);
+// Mirrors the shell: a successful swap changes what the next read reports.
+const setAppIcon = mock(async (name: string | null) => {
+  iconState = { ...iconState, current: name };
+  return true;
+});
 
 mock.module("@/runtime/app-icon", () => ({ getAppIconState, setAppIcon }));
 mock.module("@/runtime/platform-detection", () => ({
@@ -58,6 +65,8 @@ mock.module("@/hooks/use-assistant-avatar", () => ({
 
 const { AppIconCard } =
   await import("@/domains/settings/components/app-icon-card");
+const { APP_ICON_UNSUPPORTED, useAppIconStore } =
+  await import("@/stores/app-icon-store");
 const { useClientFeatureFlagStore } =
   await import("@/stores/client-feature-flag-store");
 const { useResolvedAssistantsStore } =
@@ -82,6 +91,7 @@ beforeEach(() => {
   nativeIOS = true;
   iconState = { supported: true, current: null, available: [ICON] };
   localStorage.clear();
+  useAppIconStore.setState({ snapshot: APP_ICON_UNSUPPORTED });
   useClientFeatureFlagStore.setState({ iosAvatarAppIcon: true });
   useResolvedAssistantsStore.setState({ activeAssistantId: "asst-1" });
 });
@@ -133,8 +143,66 @@ describe("AppIconCard", () => {
     expect(setAppIcon.mock.calls[0]?.[0]).toBe(ICON);
   });
 
-  test("offers no reset while the avatar is a character", async () => {
+  test("keeps a reset once the icon matches the avatar", async () => {
     iconState = { supported: true, current: ICON, available: [ICON] };
+
+    await renderCard();
+
+    await waitFor(() => {
+      expect(buttonByText("Use default")).toBeDefined();
+    });
+    // Nothing left to match, so Reset stands alone.
+    expect(buttonByText("Match avatar")).toBeUndefined();
+  });
+
+  test("keeps a reset available after a successful match", async () => {
+    await renderCard();
+    await waitFor(() => {
+      expect(buttonByText("Match avatar")).toBeDefined();
+    });
+
+    act(() => {
+      buttonByText("Match avatar")?.click();
+    });
+
+    await waitFor(() => {
+      expect(buttonByText("Use default")).toBeDefined();
+    });
+    expect(buttonByText("Match avatar")).toBeUndefined();
+
+    setAppIcon.mockClear();
+    act(() => {
+      buttonByText("Use default")?.click();
+    });
+
+    await waitFor(() => {
+      expect(setAppIcon).toHaveBeenCalledTimes(1);
+    });
+    expect(setAppIcon.mock.calls[0]?.[0]).toBeNull();
+  });
+
+  test("offers reset beside match while a stale icon of ours is applied", async () => {
+    iconState = {
+      supported: true,
+      current: STALE_ICON,
+      available: [ICON, STALE_ICON],
+    };
+
+    await renderCard();
+
+    await waitFor(() => {
+      expect(buttonByText("Match avatar")).toBeDefined();
+    });
+    expect(buttonByText("Use default")).toBeDefined();
+  });
+
+  test("offers no reset for an icon this feature never applied", async () => {
+    avatarState = IMAGE;
+    iconState = {
+      supported: true,
+      current: "seasonal-winter",
+      available: [ICON, "seasonal-winter"],
+    };
 
     await renderCard();
 
@@ -142,7 +210,6 @@ describe("AppIconCard", () => {
       expect(getAppIconState).toHaveBeenCalled();
     });
     expect(buttonByText("Use default")).toBeUndefined();
-    expect(buttonByText("Match avatar")).toBeUndefined();
   });
 
   test("offers a reset once the avatar is no longer a character", async () => {

--- a/clients/web/src/domains/settings/components/app-icon-card.test.tsx
+++ b/clients/web/src/domains/settings/components/app-icon-card.test.tsx
@@ -1,7 +1,8 @@
 /**
  * The settings card is the user-initiated half of the feature: it ignores the
  * prompt's decline memory, and it is the only way back to the default icon, so
- * Reset stays reachable for as long as one of our icons is applied.
+ * Reset stays reachable for as long as one of our icons is applied, and a swap
+ * iOS refuses is reported rather than swallowed.
  */
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { act, cleanup, render, waitFor } from "@testing-library/react";
@@ -41,9 +42,16 @@ let iconState: AppIconState = {
   available: [ICON],
 };
 
+/** What the shell answers the next swap with: iOS is free to refuse one. */
+let swapSucceeds = true;
+
 const getAppIconState = mock(async () => iconState);
-// Mirrors the shell: a successful swap changes what the next read reports.
+// Mirrors the shell: a successful swap changes what the next read reports, and
+// a refused one leaves the home screen exactly as it was.
 const setAppIcon = mock(async (name: string | null) => {
+  if (!swapSucceeds) {
+    return false;
+  }
   iconState = { ...iconState, current: name };
   return true;
 });
@@ -72,10 +80,15 @@ const { useClientFeatureFlagStore } =
 const { useResolvedAssistantsStore } =
   await import("@/stores/resolved-assistants-store");
 
-function buttonByText(text: string): HTMLElement | undefined {
-  return Array.from(document.querySelectorAll<HTMLElement>("button")).find(
-    (element) => element.textContent?.trim() === text,
-  );
+function buttonByText(text: string): HTMLButtonElement | undefined {
+  return Array.from(
+    document.querySelectorAll<HTMLButtonElement>("button"),
+  ).find((element) => element.textContent?.trim() === text);
+}
+
+function alertText(): string | null {
+  const alert = document.querySelector<HTMLElement>('[role="alert"]');
+  return alert?.textContent?.trim() ?? null;
 }
 
 async function renderCard() {
@@ -89,6 +102,7 @@ async function renderCard() {
 beforeEach(() => {
   avatarState = CHARACTER;
   nativeIOS = true;
+  swapSucceeds = true;
   iconState = { supported: true, current: null, available: [ICON] };
   localStorage.clear();
   useAppIconStore.setState({ snapshot: APP_ICON_UNSUPPORTED });
@@ -179,6 +193,56 @@ describe("AppIconCard", () => {
       expect(setAppIcon).toHaveBeenCalledTimes(1);
     });
     expect(setAppIcon.mock.calls[0]?.[0]).toBeNull();
+  });
+
+  test("names a refused match and leaves the buttons live", async () => {
+    swapSucceeds = false;
+    await renderCard();
+    await waitFor(() => {
+      expect(buttonByText("Match avatar")).toBeDefined();
+    });
+
+    act(() => {
+      buttonByText("Match avatar")?.click();
+    });
+
+    await waitFor(() => {
+      expect(alertText()).toBe(
+        "iOS did not change your home screen icon. You can try again.",
+      );
+    });
+    expect(buttonByText("Match avatar")?.disabled).toBe(false);
+
+    // The next press lands, and the error goes with it.
+    swapSucceeds = true;
+    act(() => {
+      buttonByText("Match avatar")?.click();
+    });
+
+    await waitFor(() => {
+      expect(buttonByText("Use default")).toBeDefined();
+    });
+    expect(alertText()).toBeNull();
+  });
+
+  test("names a refused reset and keeps the icon reported as applied", async () => {
+    iconState = { supported: true, current: ICON, available: [ICON] };
+    swapSucceeds = false;
+    await renderCard();
+    await waitFor(() => {
+      expect(buttonByText("Use default")).toBeDefined();
+    });
+
+    act(() => {
+      buttonByText("Use default")?.click();
+    });
+
+    await waitFor(() => {
+      expect(alertText()).toBe(
+        "iOS did not change your home screen icon. You can try again.",
+      );
+    });
+    expect(buttonByText("Use default")?.disabled).toBe(false);
   });
 
   test("offers reset beside match while a stale icon of ours is applied", async () => {

--- a/clients/web/src/domains/settings/components/app-icon-card.test.tsx
+++ b/clients/web/src/domains/settings/components/app-icon-card.test.tsx
@@ -1,0 +1,177 @@
+/**
+ * The settings card is the user-initiated half of the feature: it ignores the
+ * prompt's decline memory, and it is the only way back to the default icon.
+ */
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { act, cleanup, render, waitFor } from "@testing-library/react";
+import { createElement } from "react";
+
+import type { AppIconState } from "@/runtime/app-icon";
+import type { AvatarState } from "@/types/avatar";
+
+const TRAITS = {
+  bodyShape: "blob",
+  eyeStyle: "curious",
+  color: "cosmic-purple",
+};
+const ICON = "avatar-blob-curious-cosmic-purple";
+
+const CHARACTER: AvatarState = {
+  kind: "character",
+  traits: TRAITS,
+  source: "builder",
+  image: null,
+};
+
+const IMAGE: AvatarState = {
+  kind: "image",
+  traits: null,
+  source: "upload",
+  image: null,
+};
+
+let avatarState: AvatarState | null = CHARACTER;
+let nativeIOS = true;
+let iconState: AppIconState = {
+  supported: true,
+  current: null,
+  available: [ICON],
+};
+
+const getAppIconState = mock(async () => iconState);
+const setAppIcon = mock(async (_name: string | null) => true);
+
+mock.module("@/runtime/app-icon", () => ({ getAppIconState, setAppIcon }));
+mock.module("@/runtime/platform-detection", () => ({
+  useIsNativeIOS: () => nativeIOS,
+}));
+mock.module("@/hooks/use-assistant-avatar", () => ({
+  useAssistantAvatar: () => ({
+    components: null,
+    traits: avatarState?.traits ?? null,
+    customImageUrl: null,
+    state: avatarState,
+    isLoading: false,
+    invalidate: () => {},
+  }),
+}));
+
+const { AppIconCard } =
+  await import("@/domains/settings/components/app-icon-card");
+const { useClientFeatureFlagStore } =
+  await import("@/stores/client-feature-flag-store");
+const { useResolvedAssistantsStore } =
+  await import("@/stores/resolved-assistants-store");
+
+function buttonByText(text: string): HTMLElement | undefined {
+  return Array.from(document.querySelectorAll<HTMLElement>("button")).find(
+    (element) => element.textContent?.trim() === text,
+  );
+}
+
+async function renderCard() {
+  const view = render(createElement(AppIconCard));
+  await act(async () => {
+    await Promise.resolve();
+  });
+  return view;
+}
+
+beforeEach(() => {
+  avatarState = CHARACTER;
+  nativeIOS = true;
+  iconState = { supported: true, current: null, available: [ICON] };
+  localStorage.clear();
+  useClientFeatureFlagStore.setState({ iosAvatarAppIcon: true });
+  useResolvedAssistantsStore.setState({ activeAssistantId: "asst-1" });
+});
+
+afterEach(() => {
+  cleanup();
+  getAppIconState.mockClear();
+  setAppIcon.mockClear();
+  useClientFeatureFlagStore.setState({ iosAvatarAppIcon: false });
+  useResolvedAssistantsStore.setState({ activeAssistantId: null });
+});
+
+describe("AppIconCard", () => {
+  test("draws nothing with the flag off", async () => {
+    useClientFeatureFlagStore.setState({ iosAvatarAppIcon: false });
+
+    const { container } = await renderCard();
+
+    expect(container.innerHTML).toBe("");
+    expect(getAppIconState).not.toHaveBeenCalled();
+  });
+
+  test("draws nothing on a build with no alternate icons", async () => {
+    iconState = { supported: false, current: null, available: [] };
+
+    const { container } = await renderCard();
+
+    await waitFor(() => {
+      expect(getAppIconState).toHaveBeenCalled();
+    });
+    expect(container.innerHTML).toBe("");
+  });
+
+  test("matches a name the user already declined in the prompt", async () => {
+    localStorage.setItem(`vellum:appIcon:declined:${ICON}`, "1");
+
+    await renderCard();
+
+    await waitFor(() => {
+      expect(buttonByText("Match avatar")).toBeDefined();
+    });
+    act(() => {
+      buttonByText("Match avatar")?.click();
+    });
+
+    await waitFor(() => {
+      expect(setAppIcon).toHaveBeenCalledTimes(1);
+    });
+    expect(setAppIcon.mock.calls[0]?.[0]).toBe(ICON);
+  });
+
+  test("offers no reset while the avatar is a character", async () => {
+    iconState = { supported: true, current: ICON, available: [ICON] };
+
+    await renderCard();
+
+    await waitFor(() => {
+      expect(getAppIconState).toHaveBeenCalled();
+    });
+    expect(buttonByText("Use default")).toBeUndefined();
+    expect(buttonByText("Match avatar")).toBeUndefined();
+  });
+
+  test("offers a reset once the avatar is no longer a character", async () => {
+    avatarState = IMAGE;
+    iconState = { supported: true, current: ICON, available: [ICON] };
+
+    await renderCard();
+
+    await waitFor(() => {
+      expect(buttonByText("Use default")).toBeDefined();
+    });
+    act(() => {
+      buttonByText("Use default")?.click();
+    });
+
+    await waitFor(() => {
+      expect(setAppIcon).toHaveBeenCalledTimes(1);
+    });
+    expect(setAppIcon.mock.calls[0]?.[0]).toBeNull();
+  });
+
+  test("offers no reset while the default icon is showing", async () => {
+    avatarState = IMAGE;
+
+    await renderCard();
+
+    await waitFor(() => {
+      expect(getAppIconState).toHaveBeenCalled();
+    });
+    expect(buttonByText("Use default")).toBeUndefined();
+  });
+});

--- a/clients/web/src/domains/settings/components/app-icon-card.tsx
+++ b/clients/web/src/domains/settings/components/app-icon-card.tsx
@@ -1,0 +1,85 @@
+/**
+ * Settings entry point for the iOS home-screen icon.
+ *
+ * The prompt asks once per avatar and takes no for an answer; this card is
+ * where a user who said no, or who changed their mind later, goes. It is
+ * therefore the only surface that ignores the decline memory, and the only way
+ * back to the default icon: nothing in this feature resets an icon on its own,
+ * so an avatar switched to an uploaded image leaves the old icon in place
+ * until someone presses Reset here.
+ *
+ * Draws nothing at all off native iOS, with the `ios-avatar-app-icon` flag
+ * off, or on a build that ships no alternate icons.
+ */
+import { useState } from "react";
+
+import { DetailCard } from "@/components/detail-card";
+import { useAppIconSync } from "@/hooks/use-app-icon-sync";
+import { useTranslation } from "@/i18n";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+import { Button } from "@vellumai/design-library/components/button";
+
+export function AppIconCard() {
+  const { t } = useTranslation("settings");
+  const assistantId = useResolvedAssistantsStore.use.activeAssistantId();
+  const { enabled, currentIcon, targetIcon, canOffer, apply, reset } =
+    useAppIconSync(assistantId);
+  const [pending, setPending] = useState(false);
+
+  if (!enabled) {
+    return null;
+  }
+
+  // An alternate icon is applied while the avatar maps to none: the avatar is
+  // an uploaded image now, or gone. Only this card can undo that.
+  const canReset = currentIcon !== null && targetIcon === null;
+
+  const status =
+    currentIcon === null
+      ? t("appIconCard.statusDefault")
+      : currentIcon === targetIcon
+        ? t("appIconCard.statusMatched")
+        : t("appIconCard.statusStale");
+
+  const run = async (action: () => Promise<void>) => {
+    setPending(true);
+    try {
+      await action();
+    } finally {
+      setPending(false);
+    }
+  };
+
+  return (
+    <DetailCard title={t("appIconCard.title")}>
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex-1">
+          <div className="text-body-medium-default text-[var(--content-default)]">
+            {status}
+          </div>
+          <p className="mt-1 text-body-small-default text-[var(--content-tertiary)]">
+            {t("appIconCard.description")}
+          </p>
+        </div>
+        {canOffer ? (
+          <Button
+            variant="outlined"
+            disabled={pending}
+            onClick={() => void run(apply)}
+          >
+            {t("appIconCard.match")}
+          </Button>
+        ) : null}
+        {canReset ? (
+          <Button
+            variant="outlined"
+            disabled={pending}
+            onClick={() => void run(reset)}
+          >
+            {t("appIconCard.reset")}
+          </Button>
+        ) : null}
+      </div>
+    </DetailCard>
+  );
+}

--- a/clients/web/src/domains/settings/components/app-icon-card.tsx
+++ b/clients/web/src/domains/settings/components/app-icon-card.tsx
@@ -55,8 +55,8 @@ export function AppIconCard() {
 
   return (
     <DetailCard title={t("appIconCard.title")}>
-      <div className="flex items-start justify-between gap-4">
-        <div className="flex-1">
+      <div className="flex flex-col gap-3">
+        <div>
           <div className="text-body-medium-default text-[var(--content-default)]">
             {status}
           </div>
@@ -64,23 +64,27 @@ export function AppIconCard() {
             {t("appIconCard.description")}
           </p>
         </div>
-        {canOffer ? (
-          <Button
-            variant="outlined"
-            disabled={pending}
-            onClick={() => void run(apply)}
-          >
-            {t("appIconCard.match")}
-          </Button>
-        ) : null}
-        {canReset ? (
-          <Button
-            variant="outlined"
-            disabled={pending}
-            onClick={() => void run(reset)}
-          >
-            {t("appIconCard.reset")}
-          </Button>
+        {canOffer || canReset ? (
+          <div className="flex flex-wrap gap-2">
+            {canOffer ? (
+              <Button
+                variant="outlined"
+                disabled={pending}
+                onClick={() => void run(apply)}
+              >
+                {t("appIconCard.match")}
+              </Button>
+            ) : null}
+            {canReset ? (
+              <Button
+                variant="outlined"
+                disabled={pending}
+                onClick={() => void run(reset)}
+              >
+                {t("appIconCard.reset")}
+              </Button>
+            ) : null}
+          </div>
         ) : null}
       </div>
     </DetailCard>

--- a/clients/web/src/domains/settings/components/app-icon-card.tsx
+++ b/clients/web/src/domains/settings/components/app-icon-card.tsx
@@ -26,6 +26,7 @@ export function AppIconCard() {
   const { enabled, currentIcon, targetIcon, canOffer, apply, reset } =
     useAppIconSync(assistantId);
   const [pending, setPending] = useState(false);
+  const [failed, setFailed] = useState(false);
 
   if (!enabled) {
     return null;
@@ -44,10 +45,12 @@ export function AppIconCard() {
         ? t("appIconCard.statusMatched")
         : t("appIconCard.statusStale");
 
-  const run = async (action: () => Promise<void>) => {
+  // iOS can refuse a swap. The buttons come back either way, since a refused
+  // swap leaves exactly the icon the user was trying to change still applied.
+  const run = async (action: () => Promise<boolean>) => {
     setPending(true);
     try {
-      await action();
+      setFailed(!(await action()));
     } finally {
       setPending(false);
     }
@@ -63,6 +66,14 @@ export function AppIconCard() {
           <p className="mt-1 text-body-small-default text-[var(--content-tertiary)]">
             {t("appIconCard.description")}
           </p>
+          {failed ? (
+            <p
+              role="alert"
+              className="mt-1 text-body-small-default text-[color:var(--content-negative)]"
+            >
+              {t("appIconCard.error")}
+            </p>
+          ) : null}
         </div>
         {canOffer || canReset ? (
           <div className="flex flex-wrap gap-2">

--- a/clients/web/src/domains/settings/components/app-icon-card.tsx
+++ b/clients/web/src/domains/settings/components/app-icon-card.tsx
@@ -17,6 +17,7 @@ import { DetailCard } from "@/components/detail-card";
 import { useAppIconSync } from "@/hooks/use-app-icon-sync";
 import { useTranslation } from "@/i18n";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+import { isAvatarAppIcon } from "@/utils/avatar-app-icon";
 import { Button } from "@vellumai/design-library/components/button";
 
 export function AppIconCard() {
@@ -30,9 +31,11 @@ export function AppIconCard() {
     return null;
   }
 
-  // An alternate icon is applied while the avatar maps to none: the avatar is
-  // an uploaded image now, or gone. Only this card can undo that.
-  const canReset = currentIcon !== null && targetIcon === null;
+  // Reset is offered for as long as one of our icons is applied, matching
+  // avatar or not. A user who just pressed Match has an alternate icon and an
+  // avatar that agrees with it, and this card is still their only way back to
+  // the default. It sits beside Match whenever a different icon is on offer.
+  const canReset = isAvatarAppIcon(currentIcon);
 
   const status =
     currentIcon === null

--- a/clients/web/src/domains/settings/pages/privacy-page.tsx
+++ b/clients/web/src/domains/settings/pages/privacy-page.tsx
@@ -8,6 +8,7 @@ import {
   useShareDiagnostics,
 } from "@/domains/onboarding/prefs";
 import { AccessConsentSetting } from "@/domains/settings/components/access-consent-setting";
+import { AppIconCard } from "@/domains/settings/components/app-icon-card";
 import { BiometricSettingsCard } from "@/domains/settings/components/biometric-settings-card";
 import { MediaEmbedsCard } from "@/domains/settings/components/media-embeds-card";
 import { RiskToleranceSettings } from "@/domains/settings/components/risk-tolerance-settings";
@@ -96,6 +97,7 @@ export function PrivacyPage() {
   return (
     <div className="space-y-4">
       <BiometricSettingsCard />
+      <AppIconCard />
       <SystemPermissionsCard />
       <TrustRules />
       <RiskToleranceSettings />

--- a/clients/web/src/hooks/use-app-icon-sync.test.tsx
+++ b/clients/web/src/hooks/use-app-icon-sync.test.tsx
@@ -1,0 +1,283 @@
+/**
+ * The invariants this feature rests on: an icon is only ever *offered* for a
+ * character avatar the installed build ships a bundle for, and `setAppIcon` is
+ * only ever reached from a user-pressed callback.
+ */
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+
+import type { AppIconState } from "@/runtime/app-icon";
+import type { AvatarState } from "@/types/avatar";
+
+const TRAITS = {
+  bodyShape: "blob",
+  eyeStyle: "curious",
+  color: "cosmic-purple",
+};
+const ICON = "avatar-blob-curious-cosmic-purple";
+
+const CHARACTER: AvatarState = {
+  kind: "character",
+  traits: TRAITS,
+  source: "builder",
+  image: null,
+};
+
+/** A custom image whose traits sidecar was never cleaned up. */
+const IMAGE_WITH_STALE_TRAITS: AvatarState = {
+  kind: "image",
+  traits: TRAITS,
+  source: "upload",
+  image: null,
+};
+
+const NONE: AvatarState = {
+  kind: "none",
+  traits: null,
+  source: null,
+  image: null,
+};
+
+let avatarState: AvatarState | null = CHARACTER;
+let nativeIOS = true;
+let iconState: AppIconState = {
+  supported: true,
+  current: null,
+  available: [ICON],
+};
+
+const getAppIconState = mock(async () => iconState);
+const setAppIcon = mock(async (_name: string | null) => true);
+
+mock.module("@/runtime/app-icon", () => ({ getAppIconState, setAppIcon }));
+mock.module("@/runtime/platform-detection", () => ({
+  useIsNativeIOS: () => nativeIOS,
+}));
+mock.module("@/hooks/use-assistant-avatar", () => ({
+  useAssistantAvatar: () => ({
+    components: null,
+    traits: avatarState?.traits ?? null,
+    customImageUrl: null,
+    state: avatarState,
+    isLoading: false,
+    invalidate: () => {},
+  }),
+}));
+
+const { useAppIconSync } = await import("@/hooks/use-app-icon-sync");
+const { useClientFeatureFlagStore } =
+  await import("@/stores/client-feature-flag-store");
+const { publish } = await import("@/lib/event-bus");
+
+async function renderSync() {
+  const view = renderHook(() => useAppIconSync("asst-1"));
+  await waitFor(() => {
+    expect(getAppIconState).toHaveBeenCalled();
+  });
+  return view;
+}
+
+beforeEach(() => {
+  avatarState = CHARACTER;
+  nativeIOS = true;
+  iconState = { supported: true, current: null, available: [ICON] };
+  useClientFeatureFlagStore.setState({ iosAvatarAppIcon: true });
+});
+
+afterEach(() => {
+  cleanup();
+  getAppIconState.mockClear();
+  setAppIcon.mockClear();
+  useClientFeatureFlagStore.setState({ iosAvatarAppIcon: false });
+});
+
+describe("useAppIconSync", () => {
+  test("offers the bundled icon for a character avatar", async () => {
+    const { result } = await renderSync();
+
+    await waitFor(() => {
+      expect(result.current.enabled).toBe(true);
+    });
+    expect(result.current.targetIcon).toBe(ICON);
+    expect(result.current.canOffer).toBe(true);
+  });
+
+  test("stays off the whole way down off native iOS", async () => {
+    nativeIOS = false;
+
+    const { result } = renderHook(() => useAppIconSync("asst-1"));
+
+    expect(result.current.enabled).toBe(false);
+    expect(result.current.canOffer).toBe(false);
+    expect(result.current.targetIcon).toBeNull();
+    expect(getAppIconState).not.toHaveBeenCalled();
+  });
+
+  test("stays off with the flag off", async () => {
+    useClientFeatureFlagStore.setState({ iosAvatarAppIcon: false });
+
+    const { result } = renderHook(() => useAppIconSync("asst-1"));
+
+    expect(result.current.enabled).toBe(false);
+    expect(result.current.canOffer).toBe(false);
+    expect(getAppIconState).not.toHaveBeenCalled();
+  });
+
+  test("stays off on a shell that ships no alternate icons", async () => {
+    iconState = { supported: false, current: null, available: [] };
+
+    const { result } = await renderSync();
+
+    await waitFor(() => {
+      expect(getAppIconState).toHaveBeenCalled();
+    });
+    expect(result.current.enabled).toBe(false);
+    expect(result.current.canOffer).toBe(false);
+  });
+
+  test("never offers for a custom image, even with stale traits", async () => {
+    avatarState = IMAGE_WITH_STALE_TRAITS;
+
+    const { result } = await renderSync();
+
+    await waitFor(() => {
+      expect(result.current.enabled).toBe(true);
+    });
+    expect(result.current.targetIcon).toBeNull();
+    expect(result.current.canOffer).toBe(false);
+  });
+
+  test("never offers when there is no avatar", async () => {
+    avatarState = NONE;
+
+    const { result } = await renderSync();
+
+    await waitFor(() => {
+      expect(result.current.enabled).toBe(true);
+    });
+    expect(result.current.targetIcon).toBeNull();
+    expect(result.current.canOffer).toBe(false);
+  });
+
+  test("never offers a name this build does not bundle", async () => {
+    iconState = { supported: true, current: null, available: ["avatar-other"] };
+
+    const { result } = await renderSync();
+
+    await waitFor(() => {
+      expect(result.current.enabled).toBe(true);
+    });
+    expect(result.current.targetIcon).toBe(ICON);
+    expect(result.current.canOffer).toBe(false);
+  });
+
+  test("does not offer the icon that is already applied", async () => {
+    iconState = { supported: true, current: ICON, available: [ICON] };
+
+    const { result } = await renderSync();
+
+    await waitFor(() => {
+      expect(result.current.currentIcon).toBe(ICON);
+    });
+    expect(result.current.canOffer).toBe(false);
+  });
+
+  test("apply swaps to the target and re-reads the shell", async () => {
+    const { result } = await renderSync();
+    await waitFor(() => {
+      expect(result.current.canOffer).toBe(true);
+    });
+    getAppIconState.mockClear();
+    iconState = { supported: true, current: ICON, available: [ICON] };
+
+    await act(async () => {
+      await result.current.apply();
+    });
+
+    expect(setAppIcon).toHaveBeenCalledTimes(1);
+    expect(setAppIcon.mock.calls[0]?.[0]).toBe(ICON);
+    expect(getAppIconState).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(result.current.canOffer).toBe(false);
+    });
+  });
+
+  test("reset restores the default icon", async () => {
+    iconState = { supported: true, current: ICON, available: [ICON] };
+    const { result } = await renderSync();
+    await waitFor(() => {
+      expect(result.current.currentIcon).toBe(ICON);
+    });
+
+    await act(async () => {
+      await result.current.reset();
+    });
+
+    expect(setAppIcon).toHaveBeenCalledTimes(1);
+    expect(setAppIcon.mock.calls[0]?.[0]).toBeNull();
+  });
+
+  test("apply is inert when nothing is offerable", async () => {
+    avatarState = NONE;
+    const { result } = await renderSync();
+    await waitFor(() => {
+      expect(result.current.enabled).toBe(true);
+    });
+
+    await act(async () => {
+      await result.current.apply();
+    });
+
+    expect(setAppIcon).not.toHaveBeenCalled();
+  });
+
+  test("re-reads the shell's answer on foreground", async () => {
+    const { result } = await renderSync();
+    await waitFor(() => {
+      expect(result.current.canOffer).toBe(true);
+    });
+    // The user put the default icon back from iOS Settings while the app was
+    // in the background.
+    iconState = { supported: true, current: ICON, available: [ICON] };
+
+    await act(async () => {
+      publish("app.resume", { signal: "app_state" });
+    });
+
+    await waitFor(() => {
+      expect(result.current.currentIcon).toBe(ICON);
+    });
+    expect(result.current.canOffer).toBe(false);
+  });
+});
+
+describe("setAppIcon call sites", () => {
+  test("only the sync hook's two callbacks reach the shell", () => {
+    const srcRoot = join(import.meta.dir, "..");
+    const counts: string[] = [];
+
+    for (const entry of readdirSync(srcRoot, { recursive: true })) {
+      const relative = String(entry);
+      if (!/\.tsx?$/.test(relative)) {
+        continue;
+      }
+      if (/\.(test|stories)\.tsx?$/.test(relative)) {
+        continue;
+      }
+      // The wrapper that defines it.
+      if (relative === join("runtime", "app-icon.ts")) {
+        continue;
+      }
+      const source = readFileSync(join(srcRoot, relative), "utf8");
+      const calls = source.split("setAppIcon(").length - 1;
+      if (calls > 0) {
+        counts.push(`${relative}:${calls}`);
+      }
+    }
+
+    expect(counts).toEqual([`${join("hooks", "use-app-icon-sync.ts")}:2`]);
+  });
+});

--- a/clients/web/src/hooks/use-app-icon-sync.test.tsx
+++ b/clients/web/src/hooks/use-app-icon-sync.test.tsx
@@ -50,8 +50,11 @@ let iconState: AppIconState = {
   available: [ICON],
 };
 
+/** What the shell answers the next swap with: iOS is free to refuse one. */
+let swapSucceeds = true;
+
 const getAppIconState = mock(async () => iconState);
-const setAppIcon = mock(async (_name: string | null) => true);
+const setAppIcon = mock(async (_name: string | null) => swapSucceeds);
 
 mock.module("@/runtime/app-icon", () => ({ getAppIconState, setAppIcon }));
 mock.module("@/runtime/platform-detection", () => ({
@@ -86,6 +89,7 @@ async function renderSync() {
 beforeEach(() => {
   avatarState = CHARACTER;
   nativeIOS = true;
+  swapSucceeds = true;
   iconState = { supported: true, current: null, available: [ICON] };
   useAppIconStore.setState({ snapshot: APP_ICON_UNSUPPORTED });
   useClientFeatureFlagStore.setState({ iosAvatarAppIcon: true });
@@ -197,10 +201,12 @@ describe("useAppIconSync", () => {
     getAppIconState.mockClear();
     iconState = { supported: true, current: ICON, available: [ICON] };
 
+    let applied: boolean | undefined;
     await act(async () => {
-      await result.current.apply();
+      applied = await result.current.apply();
     });
 
+    expect(applied).toBe(true);
     expect(setAppIcon).toHaveBeenCalledTimes(1);
     expect(setAppIcon.mock.calls[0]?.[0]).toBe(ICON);
     expect(getAppIconState).toHaveBeenCalled();
@@ -216,12 +222,52 @@ describe("useAppIconSync", () => {
       expect(result.current.currentIcon).toBe(ICON);
     });
 
+    let restored: boolean | undefined;
     await act(async () => {
-      await result.current.reset();
+      restored = await result.current.reset();
     });
 
+    expect(restored).toBe(true);
     expect(setAppIcon).toHaveBeenCalledTimes(1);
     expect(setAppIcon.mock.calls[0]?.[0]).toBeNull();
+  });
+
+  test("apply hands back a refusal and leaves the snapshot truthful", async () => {
+    swapSucceeds = false;
+    const { result } = await renderSync();
+    await waitFor(() => {
+      expect(result.current.canOffer).toBe(true);
+    });
+    getAppIconState.mockClear();
+
+    let applied: boolean | undefined;
+    await act(async () => {
+      applied = await result.current.apply();
+    });
+
+    expect(applied).toBe(false);
+    // Nothing changed on the home screen, so the shell is re-read anyway and
+    // the offer is still standing.
+    expect(getAppIconState).toHaveBeenCalled();
+    expect(result.current.currentIcon).toBeNull();
+    expect(result.current.canOffer).toBe(true);
+  });
+
+  test("reset hands back a refusal and leaves the icon applied", async () => {
+    swapSucceeds = false;
+    iconState = { supported: true, current: ICON, available: [ICON] };
+    const { result } = await renderSync();
+    await waitFor(() => {
+      expect(result.current.currentIcon).toBe(ICON);
+    });
+
+    let restored: boolean | undefined;
+    await act(async () => {
+      restored = await result.current.reset();
+    });
+
+    expect(restored).toBe(false);
+    expect(result.current.currentIcon).toBe(ICON);
   });
 
   test("apply is inert when nothing is offerable", async () => {
@@ -231,10 +277,12 @@ describe("useAppIconSync", () => {
       expect(result.current.enabled).toBe(true);
     });
 
+    let applied: boolean | undefined;
     await act(async () => {
-      await result.current.apply();
+      applied = await result.current.apply();
     });
 
+    expect(applied).toBe(false);
     expect(setAppIcon).not.toHaveBeenCalled();
   });
 

--- a/clients/web/src/hooks/use-app-icon-sync.test.tsx
+++ b/clients/web/src/hooks/use-app-icon-sync.test.tsx
@@ -1,7 +1,8 @@
 /**
  * The invariants this feature rests on: an icon is only ever *offered* for a
- * character avatar the installed build ships a bundle for, and `setAppIcon` is
- * only ever reached from a user-pressed callback.
+ * character avatar the installed build ships a bundle for, `setAppIcon` is only
+ * ever reached from a user-pressed callback, and every mounted consumer reads
+ * the same shell snapshot.
  */
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
@@ -68,6 +69,8 @@ mock.module("@/hooks/use-assistant-avatar", () => ({
 }));
 
 const { useAppIconSync } = await import("@/hooks/use-app-icon-sync");
+const { APP_ICON_UNSUPPORTED, useAppIconStore } =
+  await import("@/stores/app-icon-store");
 const { useClientFeatureFlagStore } =
   await import("@/stores/client-feature-flag-store");
 const { publish } = await import("@/lib/event-bus");
@@ -84,6 +87,7 @@ beforeEach(() => {
   avatarState = CHARACTER;
   nativeIOS = true;
   iconState = { supported: true, current: null, available: [ICON] };
+  useAppIconStore.setState({ snapshot: APP_ICON_UNSUPPORTED });
   useClientFeatureFlagStore.setState({ iosAvatarAppIcon: true });
 });
 
@@ -232,6 +236,46 @@ describe("useAppIconSync", () => {
     });
 
     expect(setAppIcon).not.toHaveBeenCalled();
+  });
+
+  test("an apply in one consumer reaches every other consumer", async () => {
+    // The root prompt and the settings card, both mounted while the user is on
+    // the Privacy page.
+    const prompt = await renderSync();
+    const card = renderHook(() => useAppIconSync("asst-1"));
+    await waitFor(() => {
+      expect(card.result.current.canOffer).toBe(true);
+    });
+    iconState = { supported: true, current: ICON, available: [ICON] };
+
+    await act(async () => {
+      await prompt.result.current.apply();
+    });
+
+    await waitFor(() => {
+      expect(card.result.current.currentIcon).toBe(ICON);
+    });
+    // The card must stop offering an icon that is already on the home screen,
+    // rather than firing a second iOS swap alert for it.
+    expect(card.result.current.canOffer).toBe(false);
+  });
+
+  test("a reset in one consumer reaches every other consumer", async () => {
+    iconState = { supported: true, current: ICON, available: [ICON] };
+    const card = await renderSync();
+    const prompt = renderHook(() => useAppIconSync("asst-1"));
+    await waitFor(() => {
+      expect(prompt.result.current.currentIcon).toBe(ICON);
+    });
+    iconState = { supported: true, current: null, available: [ICON] };
+
+    await act(async () => {
+      await card.result.current.reset();
+    });
+
+    await waitFor(() => {
+      expect(prompt.result.current.currentIcon).toBeNull();
+    });
   });
 
   test("re-reads the shell's answer on foreground", async () => {

--- a/clients/web/src/hooks/use-app-icon-sync.ts
+++ b/clients/web/src/hooks/use-app-icon-sync.ts
@@ -38,10 +38,13 @@ export interface AppIconSync {
   targetIcon: string | null;
   /** True when the shell bundles `targetIcon` and it is not already applied. */
   canOffer: boolean;
-  /** Apply `targetIcon`. User-initiated only. */
-  apply: () => Promise<void>;
-  /** Restore the default icon. User-initiated only. */
-  reset: () => Promise<void>;
+  /**
+   * Apply `targetIcon`. User-initiated only. Resolves true only when the home
+   * screen actually changed, so callers can keep their action on screen.
+   */
+  apply: () => Promise<boolean>;
+  /** Restore the default icon. User-initiated only. Resolves as `apply` does. */
+  reset: () => Promise<boolean>;
 }
 
 export function useAppIconSync(assistantId: string | null): AppIconSync {
@@ -76,20 +79,26 @@ export function useAppIconSync(assistantId: string | null): AppIconSync {
   const { target, availableMatch } = resolveAppIconTarget(state, iconState);
   const canOffer = availableMatch && target !== iconState.current;
 
+  // iOS can refuse a swap, and the caller has UI riding on the answer, so the
+  // shell's verdict is handed back rather than swallowed. The refresh runs
+  // either way: a refusal still has to leave the snapshot telling the truth
+  // about what is on the home screen.
   const apply = useCallback(async () => {
     if (!enabled || !availableMatch || target === null) {
-      return;
+      return false;
     }
-    await setAppIcon(target);
+    const applied = await setAppIcon(target);
     await refresh();
+    return applied;
   }, [enabled, availableMatch, target, refresh]);
 
   const reset = useCallback(async () => {
     if (!enabled) {
-      return;
+      return false;
     }
-    await setAppIcon(null);
+    const restored = await setAppIcon(null);
     await refresh();
+    return restored;
   }, [enabled, refresh]);
 
   return {

--- a/clients/web/src/hooks/use-app-icon-sync.ts
+++ b/clients/web/src/hooks/use-app-icon-sync.ts
@@ -1,0 +1,107 @@
+/**
+ * Reconciles the iOS home-screen icon with the assistant's avatar.
+ *
+ * The hook only ever *offers*. iOS shows a system alert the app cannot
+ * suppress on every icon swap, so `apply` and `reset` are the two functions in
+ * this repo allowed to reach `setAppIcon`, and both are bound to an explicit
+ * user tap (the match prompt's Apply, the settings card's Match / Reset).
+ * Nothing here fires on its own.
+ *
+ * Every name comes from `appIconNameForAvatar` through
+ * {@link resolveAppIconTarget}, so an uploaded image, an AI-generated avatar,
+ * or no avatar at all resolves to `null` and can never be offered.
+ *
+ * The whole surface reports `enabled: false`, and therefore draws nothing, off
+ * native iOS, with the `ios-avatar-app-icon` flag off, or on a shell whose
+ * build ships no alternate icons (`docs/CAPACITOR.md` § The skew rule).
+ */
+import { useCallback, useEffect, useState } from "react";
+
+import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
+import { useBusSubscription } from "@/hooks/use-bus-subscription";
+import {
+  getAppIconState,
+  setAppIcon,
+  type AppIconState,
+} from "@/runtime/app-icon";
+import { useIsNativeIOS } from "@/runtime/platform-detection";
+import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
+import { resolveAppIconTarget } from "@/utils/avatar-app-icon";
+
+const UNSUPPORTED: AppIconState = {
+  supported: false,
+  current: null,
+  available: [],
+};
+
+export interface AppIconSync {
+  /** Whether any app-icon UI may draw at all. */
+  enabled: boolean;
+  /** The alternate icon currently applied, or null for the default icon. */
+  currentIcon: string | null;
+  /** The icon this avatar maps to, or null when it maps to none. */
+  targetIcon: string | null;
+  /** True when the shell bundles `targetIcon` and it is not already applied. */
+  canOffer: boolean;
+  /** Apply `targetIcon`. User-initiated only. */
+  apply: () => Promise<void>;
+  /** Restore the default icon. User-initiated only. */
+  reset: () => Promise<void>;
+}
+
+export function useAppIconSync(assistantId: string | null): AppIconSync {
+  const isNativeIOS = useIsNativeIOS();
+  const flagEnabled = useClientFeatureFlagStore.use.iosAvatarAppIcon();
+  const gateOpen = isNativeIOS && flagEnabled;
+
+  const { state } = useAssistantAvatar(assistantId);
+  const [iconState, setIconState] = useState<AppIconState>(UNSUPPORTED);
+
+  const refresh = useCallback(async () => {
+    if (!gateOpen) {
+      setIconState(UNSUPPORTED);
+      return;
+    }
+    setIconState(await getAppIconState());
+  }, [gateOpen]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  // The user can put the default icon back from iOS Settings while the app is
+  // backgrounded, so the snapshot taken at mount goes stale. Re-read the
+  // shell's answer on every foreground rather than trusting it.
+  useBusSubscription("app.resume", () => {
+    void refresh();
+  });
+
+  const enabled = gateOpen && iconState.supported;
+  const { target, availableMatch } = resolveAppIconTarget(state, iconState);
+  const canOffer = availableMatch && target !== iconState.current;
+
+  const apply = useCallback(async () => {
+    if (!enabled || !availableMatch || target === null) {
+      return;
+    }
+    await setAppIcon(target);
+    await refresh();
+  }, [enabled, availableMatch, target, refresh]);
+
+  const reset = useCallback(async () => {
+    if (!enabled) {
+      return;
+    }
+    await setAppIcon(null);
+    await refresh();
+  }, [enabled, refresh]);
+
+  return {
+    enabled,
+    currentIcon: enabled ? iconState.current : null,
+    targetIcon: enabled ? target : null,
+    canOffer,
+    apply,
+    reset,
+  };
+}

--- a/clients/web/src/hooks/use-app-icon-sync.ts
+++ b/clients/web/src/hooks/use-app-icon-sync.ts
@@ -14,25 +14,20 @@
  * The whole surface reports `enabled: false`, and therefore draws nothing, off
  * native iOS, with the `ios-avatar-app-icon` flag off, or on a shell whose
  * build ships no alternate icons (`docs/CAPACITOR.md` § The skew rule).
+ *
+ * The shell's answer is one fact about one device, so it lives in
+ * {@link useAppIconStore} rather than in per-instance state: an apply from the
+ * root prompt has to reach the settings card mounted beside it.
  */
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect } from "react";
 
 import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
 import { useBusSubscription } from "@/hooks/use-bus-subscription";
-import {
-  getAppIconState,
-  setAppIcon,
-  type AppIconState,
-} from "@/runtime/app-icon";
+import { getAppIconState, setAppIcon } from "@/runtime/app-icon";
 import { useIsNativeIOS } from "@/runtime/platform-detection";
+import { APP_ICON_UNSUPPORTED, useAppIconStore } from "@/stores/app-icon-store";
 import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import { resolveAppIconTarget } from "@/utils/avatar-app-icon";
-
-const UNSUPPORTED: AppIconState = {
-  supported: false,
-  current: null,
-  available: [],
-};
 
 export interface AppIconSync {
   /** Whether any app-icon UI may draw at all. */
@@ -55,15 +50,16 @@ export function useAppIconSync(assistantId: string | null): AppIconSync {
   const gateOpen = isNativeIOS && flagEnabled;
 
   const { state } = useAssistantAvatar(assistantId);
-  const [iconState, setIconState] = useState<AppIconState>(UNSUPPORTED);
+  const iconState = useAppIconStore.use.snapshot();
+  const setSnapshot = useAppIconStore.use.setSnapshot();
 
   const refresh = useCallback(async () => {
     if (!gateOpen) {
-      setIconState(UNSUPPORTED);
+      setSnapshot(APP_ICON_UNSUPPORTED);
       return;
     }
-    setIconState(await getAppIconState());
-  }, [gateOpen]);
+    setSnapshot(await getAppIconState());
+  }, [gateOpen, setSnapshot]);
 
   useEffect(() => {
     void refresh();

--- a/clients/web/src/hooks/use-assistant-avatar.test.tsx
+++ b/clients/web/src/hooks/use-assistant-avatar.test.tsx
@@ -120,6 +120,9 @@ describe("useAssistantAvatar", () => {
     // traits present + no image ⇒ ChatAvatar renders AnimatedAvatar.
     expect(result.current.components).toEqual(components);
     expect(result.current.customImageUrl).toBeNull();
+    // The manifest itself travels with the derived fields, for consumers that
+    // need `kind` rather than just traits.
+    expect(result.current.state).toEqual(characterState);
     expect(fetchCharacterComponents).toHaveBeenCalledTimes(1);
     expect(fetchAvatarState).toHaveBeenCalledTimes(1);
     expect(fetchAvatarImageUrl).not.toHaveBeenCalled();
@@ -140,6 +143,7 @@ describe("useAssistantAvatar", () => {
     // image present + no traits ⇒ ChatAvatar renders the static circle.
     expect(result.current.components).toEqual(components);
     expect(result.current.traits).toBeNull();
+    expect(result.current.state).toEqual(imageState);
     expect(fetchCharacterComponents).toHaveBeenCalledTimes(1);
     expect(fetchAvatarState).toHaveBeenCalledTimes(1);
     expect(fetchAvatarImageUrl).toHaveBeenCalledTimes(1);
@@ -157,6 +161,7 @@ describe("useAssistantAvatar", () => {
     // both null ⇒ ChatAvatar falls back to default components / "V".
     expect(result.current.traits).toBeNull();
     expect(result.current.customImageUrl).toBeNull();
+    expect(result.current.state).toEqual(noneState);
     expect(fetchCharacterComponents).toHaveBeenCalledTimes(1);
     expect(fetchAvatarState).toHaveBeenCalledTimes(1);
     expect(fetchAvatarImageUrl).not.toHaveBeenCalled();
@@ -302,6 +307,14 @@ describe("useAssistantAvatar", () => {
 
     // Legacy path: no image ⇒ read traits sidecar, never touch `/avatar/state`.
     expect(result.current.customImageUrl).toBeNull();
+    // The file precedence is restated as a manifest, with the two fields the
+    // sidecars cannot answer left null.
+    expect(result.current.state).toEqual({
+      kind: "character",
+      traits,
+      source: null,
+      image: null,
+    });
     expect(fetchAvatarImageUrl).toHaveBeenCalledTimes(1);
     expect(fetchCharacterTraits).toHaveBeenCalledTimes(1);
     expect(fetchAvatarState).not.toHaveBeenCalled();
@@ -321,6 +334,12 @@ describe("useAssistantAvatar", () => {
 
     // A custom image exists ⇒ traits are intentionally not fetched.
     expect(result.current.traits).toBeNull();
+    expect(result.current.state).toEqual({
+      kind: "image",
+      traits: null,
+      source: null,
+      image: null,
+    });
     expect(fetchCharacterTraits).not.toHaveBeenCalled();
     expect(fetchAvatarState).not.toHaveBeenCalled();
   });

--- a/clients/web/src/hooks/use-assistant-avatar.ts
+++ b/clients/web/src/hooks/use-assistant-avatar.ts
@@ -7,7 +7,11 @@ import {
   fetchAvatarImageUrl,
   fetchCharacterTraits,
 } from "@/assistant/avatar-api";
-import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
+import type {
+  AvatarState,
+  CharacterComponents,
+  CharacterTraits,
+} from "@/types/avatar";
 import { useSupportsAvatarStateManifest } from "@/lib/backwards-compat/avatar-state-manifest";
 
 export const AVATAR_QUERY_KEY_PREFIX = "assistantAvatar";
@@ -21,6 +25,17 @@ export interface AvatarData {
   components: CharacterComponents | null;
   traits: CharacterTraits | null;
   customImageUrl: string | null;
+  /**
+   * The render manifest the three fields above were derived from. Consumers
+   * that need `kind` rather than just traits read it from here so they stay on
+   * this one query, because a second query would miss the `avatar_updated`
+   * sweep that keeps this one live.
+   *
+   * Optional because surfaces that seed this cache by hand (the takeover
+   * avatar stash, stories) carry only what they paint with. A missing state
+   * reads as unknown, which every consumer must treat as "not a character".
+   */
+  state?: AvatarState | null;
 }
 
 const activeBlobUrls = new Map<string, string>();
@@ -53,9 +68,11 @@ export interface AssistantAvatarOptions {
  * Query keeps the previously cached avatar instead of blanking out — see
  * the `retry` / `staleTime` options below.
  */
-async function fetchAvatarViaManifest(
-  assistantId: string,
-): Promise<{ traits: CharacterTraits | null; imageUrl: string | null }> {
+async function fetchAvatarViaManifest(assistantId: string): Promise<{
+  state: AvatarState;
+  traits: CharacterTraits | null;
+  imageUrl: string | null;
+}> {
   const state = await fetchAvatarState(assistantId);
   if (state === null) {
     // `fetchAvatarState` returns null only on transport failure. Throw
@@ -70,15 +87,19 @@ async function fetchAvatarViaManifest(
     // Built/AI character: render the animated SVG from traits. The daemon
     // also writes a derived avatar-image.png raster, but the web never
     // uses it, so we skip the image fetch entirely.
-    return { traits: state.traits, imageUrl: null };
+    return { state, traits: state.traits, imageUrl: null };
   }
   if (state.kind === "image") {
     // Custom uploaded image: render the static circle.
-    return { traits: null, imageUrl: await fetchAvatarImageUrl(assistantId) };
+    return {
+      state,
+      traits: null,
+      imageUrl: await fetchAvatarImageUrl(assistantId),
+    };
   }
   // kind === "none": both stay null, and ChatAvatar falls back to default
   // components / the "V".
-  return { traits: null, imageUrl: null };
+  return { state, traits: null, imageUrl: null };
 }
 
 /**
@@ -88,16 +109,26 @@ async function fetchAvatarViaManifest(
  * alive behind the version gate — see
  * `lib/backwards-compat/avatar-state-manifest.ts`.
  */
-async function fetchAvatarViaLegacyFiles(
-  assistantId: string,
-): Promise<{ traits: CharacterTraits | null; imageUrl: string | null }> {
+async function fetchAvatarViaLegacyFiles(assistantId: string): Promise<{
+  state: AvatarState;
+  traits: CharacterTraits | null;
+  imageUrl: string | null;
+}> {
   const imageUrl = await fetchAvatarImageUrl(assistantId);
   // Skip the traits fetch when a custom image exists — the traits file is
   // intentionally deleted on the daemon side in that case, so requesting it
   // just generates 404s. `AvatarRenderer` only reads `traits` when there is
   // no `customImageUrl`.
   const traits = imageUrl ? null : await fetchCharacterTraits(assistantId);
-  return { traits, imageUrl };
+  // The same file precedence, restated as a manifest so `state` has one shape
+  // on both paths. `source` and `image` stay null because the sidecar files
+  // carry neither.
+  const state: AvatarState = imageUrl
+    ? { kind: "image", traits: null, source: null, image: null }
+    : traits
+      ? { kind: "character", traits, source: null, image: null }
+      : { kind: "none", traits: null, source: null, image: null };
+  return { state, traits, imageUrl };
 }
 
 /**
@@ -124,7 +155,7 @@ export function useAssistantAvatar(
     queryKey: [...avatarQueryKey(assistantId ?? ""), supportsManifest],
     queryFn: async () => {
       const id = assistantId!;
-      const [components, { traits, imageUrl }] = await Promise.all([
+      const [components, { state, traits, imageUrl }] = await Promise.all([
         fetchCharacterComponents(id),
         supportsManifest
           ? fetchAvatarViaManifest(id)
@@ -149,7 +180,7 @@ export function useAssistantAvatar(
         activeBlobUrls.delete(id);
       }
 
-      return { components, traits, customImageUrl: imageUrl };
+      return { components, traits, customImageUrl: imageUrl, state };
     },
     enabled: Boolean(assistantId) && (options?.enabled ?? true),
     staleTime: Infinity,
@@ -173,6 +204,7 @@ export function useAssistantAvatar(
     components: data?.components ?? null,
     traits: data?.traits ?? null,
     customImageUrl: data?.customImageUrl ?? null,
+    state: data?.state ?? null,
     isLoading,
     invalidate,
   };

--- a/clients/web/src/i18n/locales/en/common.json
+++ b/clients/web/src/i18n/locales/en/common.json
@@ -5,6 +5,7 @@
   "appIconMatchPrompt": {
     "title": "Match your app icon to your avatar?",
     "message": "Your home screen icon becomes this avatar. You can change it back any time from Settings.",
+    "error": "iOS did not change your home screen icon. You can try again.",
     "apply": "Apply",
     "notNow": "Not now"
   },

--- a/clients/web/src/i18n/locales/en/common.json
+++ b/clients/web/src/i18n/locales/en/common.json
@@ -2,6 +2,12 @@
   "addCreditsModal": {
     "configureAutoReload": "Configure Auto-Reload"
   },
+  "appIconMatchPrompt": {
+    "title": "Match your app icon to your avatar?",
+    "message": "Your home screen icon becomes this avatar. You can change it back any time from Settings.",
+    "apply": "Apply",
+    "notNow": "Not now"
+  },
   "companionIntro": {
     "ariaLabel": "Introducing your companion",
     "meet": {

--- a/clients/web/src/i18n/locales/en/settings.json
+++ b/clients/web/src/i18n/locales/en/settings.json
@@ -71,6 +71,15 @@
     "unsupportedDescription": "Notification settings are unavailable in this app version.",
     "unsupportedLabel": "Unavailable"
   },
+  "appIconCard": {
+    "description": "Alternate icons ship with the app, and iOS confirms every swap with an alert of its own.",
+    "match": "Match avatar",
+    "reset": "Use default",
+    "statusDefault": "Your home screen shows the default Vellum icon.",
+    "statusMatched": "Your home screen icon matches your avatar.",
+    "statusStale": "Your home screen icon is from an earlier avatar.",
+    "title": "App Icon"
+  },
   "assistantBackups": {
     "columnCreated": "Created",
     "columnReady": "Ready",

--- a/clients/web/src/i18n/locales/en/settings.json
+++ b/clients/web/src/i18n/locales/en/settings.json
@@ -73,6 +73,7 @@
   },
   "appIconCard": {
     "description": "Alternate icons ship with the app, and iOS confirms every swap with an alert of its own.",
+    "error": "iOS did not change your home screen icon. You can try again.",
     "match": "Match avatar",
     "reset": "Use default",
     "statusDefault": "Your home screen shows the default Vellum icon.",

--- a/clients/web/src/i18n/locales/es/common.json
+++ b/clients/web/src/i18n/locales/es/common.json
@@ -5,6 +5,7 @@
   "appIconMatchPrompt": {
     "title": "¿Quieres que el icono de la app sea tu avatar?",
     "message": "El icono de tu pantalla de inicio pasa a ser este avatar. Puedes volver a cambiarlo cuando quieras desde la configuración.",
+    "error": "iOS no cambió el icono de tu pantalla de inicio. Puedes intentarlo de nuevo.",
     "apply": "Aplicar",
     "notNow": "Ahora no"
   },

--- a/clients/web/src/i18n/locales/es/common.json
+++ b/clients/web/src/i18n/locales/es/common.json
@@ -2,6 +2,12 @@
   "addCreditsModal": {
     "configureAutoReload": "Configurar la recarga automática"
   },
+  "appIconMatchPrompt": {
+    "title": "¿Quieres que el icono de la app sea tu avatar?",
+    "message": "El icono de tu pantalla de inicio pasa a ser este avatar. Puedes volver a cambiarlo cuando quieras desde la configuración.",
+    "apply": "Aplicar",
+    "notNow": "Ahora no"
+  },
   "companionIntro": {
     "ariaLabel": "Te presento a tu compañero",
     "meet": {

--- a/clients/web/src/i18n/locales/es/settings.json
+++ b/clients/web/src/i18n/locales/es/settings.json
@@ -71,6 +71,15 @@
     "unsupportedDescription": "Los ajustes de notificaciones no están disponibles en esta versión de la app.",
     "unsupportedLabel": "No disponible"
   },
+  "appIconCard": {
+    "description": "Los iconos alternativos vienen incluidos en la app, y iOS confirma cada cambio con su propio aviso.",
+    "match": "Usar el avatar",
+    "reset": "Usar el predeterminado",
+    "statusDefault": "Tu pantalla de inicio muestra el icono predeterminado de Vellum.",
+    "statusMatched": "El icono de tu pantalla de inicio coincide con tu avatar.",
+    "statusStale": "El icono de tu pantalla de inicio es de un avatar anterior.",
+    "title": "Icono de la app"
+  },
   "assistantBackups": {
     "columnCreated": "Creada",
     "columnReady": "Lista",

--- a/clients/web/src/i18n/locales/es/settings.json
+++ b/clients/web/src/i18n/locales/es/settings.json
@@ -73,6 +73,7 @@
   },
   "appIconCard": {
     "description": "Los iconos alternativos vienen incluidos en la app, y iOS confirma cada cambio con su propio aviso.",
+    "error": "iOS no cambió el icono de tu pantalla de inicio. Puedes intentarlo de nuevo.",
     "match": "Usar el avatar",
     "reset": "Usar el predeterminado",
     "statusDefault": "Tu pantalla de inicio muestra el icono predeterminado de Vellum.",

--- a/clients/web/src/root-layout.tsx
+++ b/clients/web/src/root-layout.tsx
@@ -90,6 +90,7 @@ import {
   removePairedAssistant,
   switchToAssistant,
 } from "@/assistant/switch-service";
+import { AppIconMatchPrompt } from "@/components/avatar/app-icon-match-prompt";
 import { CreateAssistantDialog } from "@/components/create-assistant-dialog";
 import { RemoveFromDeviceDialog } from "@/components/remove-from-device-dialog";
 import { RetireConfirmDialog } from "@/components/retire-confirm-dialog";
@@ -561,6 +562,11 @@ export function RootLayout() {
           focus/zone change. No-ops until an assistant id resolves. */}
       <TimezoneSync />
       <GlobalPushToTalkBridge assistantId={assistantId} />
+
+      {/* Offers to match the iOS home-screen icon to the assistant's avatar.
+          Mounted here so a cross-device avatar change lands wherever the user
+          is; draws nothing off iOS or with the flag off. */}
+      <AppIconMatchPrompt assistantId={assistantId} />
 
       {feedbackOpen ? (
         <LazyBoundary>

--- a/clients/web/src/stores/app-icon-store.test.ts
+++ b/clients/web/src/stores/app-icon-store.test.ts
@@ -1,0 +1,48 @@
+/**
+ * The store is written by every mounted `useAppIconSync` on every mount and
+ * every foreground, so identical answers arrive constantly. It has to treat
+ * those as no-ops.
+ */
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import { APP_ICON_UNSUPPORTED, useAppIconStore } from "./app-icon-store";
+
+const ICON = "avatar-blob-curious-cosmic-purple";
+
+beforeEach(() => {
+  useAppIconStore.setState({ snapshot: APP_ICON_UNSUPPORTED });
+});
+
+describe("useAppIconStore", () => {
+  test("starts on the snapshot that draws nothing", () => {
+    expect(useAppIconStore.getState().snapshot).toEqual(APP_ICON_UNSUPPORTED);
+  });
+
+  test("keeps the reference when the shell repeats itself", () => {
+    const { setSnapshot } = useAppIconStore.getState();
+    setSnapshot({ supported: true, current: null, available: [ICON] });
+    const first = useAppIconStore.getState().snapshot;
+
+    setSnapshot({ supported: true, current: null, available: [ICON] });
+
+    expect(useAppIconStore.getState().snapshot).toBe(first);
+  });
+
+  test("takes a snapshot whose applied icon changed", () => {
+    const { setSnapshot } = useAppIconStore.getState();
+    setSnapshot({ supported: true, current: null, available: [ICON] });
+
+    setSnapshot({ supported: true, current: ICON, available: [ICON] });
+
+    expect(useAppIconStore.getState().snapshot.current).toBe(ICON);
+  });
+
+  test("takes a snapshot whose bundle list changed", () => {
+    const { setSnapshot } = useAppIconStore.getState();
+    setSnapshot({ supported: true, current: null, available: [ICON] });
+
+    setSnapshot({ supported: true, current: null, available: [] });
+
+    expect(useAppIconStore.getState().snapshot.available).toEqual([]);
+  });
+});

--- a/clients/web/src/stores/app-icon-store.ts
+++ b/clients/web/src/stores/app-icon-store.ts
@@ -1,0 +1,63 @@
+/**
+ * The shell's alternate-app-icon snapshot, shared by every `useAppIconSync`
+ * consumer.
+ *
+ * This is one fact about one device, and more than one surface asks about it:
+ * the root match prompt and the settings card are mounted at the same time
+ * whenever the Privacy page is open. Held per hook instance, an apply from one
+ * leaves the other reporting the icon that was applied before it, so the card
+ * keeps offering "Match avatar" for an icon that is already on the home screen
+ * and pressing it fires a second iOS swap alert. Held here, both re-render on
+ * the same write.
+ *
+ * The store is a cache of what the shell last answered, never a wish: only
+ * `useAppIconSync`'s refresh writes it, always from `getAppIconState()`.
+ *
+ * Reference: {@link https://zustand.docs.pmnd.rs/}
+ */
+
+import { create } from "zustand";
+
+import { createSelectors } from "@/utils/create-selectors";
+import type { AppIconState } from "@/runtime/app-icon";
+
+/** What every degrade path resolves to: no icon UI may draw. */
+export const APP_ICON_UNSUPPORTED: AppIconState = {
+  supported: false,
+  current: null,
+  available: [],
+};
+
+export interface AppIconStoreState {
+  snapshot: AppIconState;
+}
+
+export interface AppIconStoreActions {
+  setSnapshot: (next: AppIconState) => void;
+}
+
+export type AppIconStore = AppIconStoreState & AppIconStoreActions;
+
+function isSameSnapshot(a: AppIconState, b: AppIconState): boolean {
+  return (
+    a.supported === b.supported &&
+    a.current === b.current &&
+    a.available.length === b.available.length &&
+    a.available.every((name, index) => name === b.available[index])
+  );
+}
+
+const useAppIconStoreBase = create<AppIconStore>()((set, get) => ({
+  snapshot: APP_ICON_UNSUPPORTED,
+
+  // Every mounted consumer refreshes on its own mount and on every foreground,
+  // so identical answers arrive constantly. Keeping the reference stable stops
+  // those from re-rendering the tree.
+  setSnapshot: (next) => {
+    if (!isSameSnapshot(get().snapshot, next)) {
+      set({ snapshot: next });
+    }
+  },
+}));
+
+export const useAppIconStore = createSelectors(useAppIconStoreBase);

--- a/clients/web/src/utils/avatar-app-icon.test.ts
+++ b/clients/web/src/utils/avatar-app-icon.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
-import { appIconNameForAvatar, resolveAppIconTarget } from "./avatar-app-icon";
+import {
+  appIconNameForAvatar,
+  isAvatarAppIcon,
+  resolveAppIconTarget,
+} from "./avatar-app-icon";
 import type { AvatarState } from "@/types/avatar";
 
 /**
@@ -132,5 +136,27 @@ describe("resolveAppIconTarget", () => {
       supportedShell,
     );
     expect(result).toEqual({ target: null, availableMatch: false });
+  });
+});
+
+describe("isAvatarAppIcon", () => {
+  test("recognizes a name this feature produced", () => {
+    const name = appIconNameForAvatar(
+      avatarState({
+        bodyShape: "blob",
+        eyeStyle: "curious",
+        color: "cosmic-purple",
+      }),
+    );
+
+    expect(isAvatarAppIcon(name)).toBe(true);
+  });
+
+  test("the default icon is not one of ours", () => {
+    expect(isAvatarAppIcon(null)).toBe(false);
+  });
+
+  test("an alternate from some other feature is not one of ours", () => {
+    expect(isAvatarAppIcon("seasonal-winter")).toBe(false);
   });
 });

--- a/clients/web/src/utils/avatar-app-icon.ts
+++ b/clients/web/src/utils/avatar-app-icon.ts
@@ -31,6 +31,9 @@ export interface AppIconTarget {
   availableMatch: boolean;
 }
 
+/** The namespace every icon this feature applies is emitted under. */
+const AVATAR_ICON_PREFIX = "avatar-";
+
 /**
  * The single chokepoint for the invariant that only character avatars have an
  * app icon. Uploaded images, AI-generated avatars, and "no avatar" all return
@@ -46,7 +49,18 @@ export function appIconNameForAvatar(state: AvatarState | null): string | null {
   if (!isCharacterTraits(traits)) {
     return null;
   }
-  return `avatar-${traits.bodyShape}-${traits.eyeStyle}-${traits.color}`;
+  return `${AVATAR_ICON_PREFIX}${traits.bodyShape}-${traits.eyeStyle}-${traits.color}`;
+}
+
+/**
+ * True when the applied icon is one this feature put there, whatever the
+ * avatar says today. Settings needs this to keep offering Reset after a
+ * successful match, and after an avatar changes to one with no icon of its
+ * own: the applied name is the only record that we ever swapped, since nothing
+ * here resets an icon on its own.
+ */
+export function isAvatarAppIcon(name: string | null): boolean {
+  return name !== null && name.startsWith(AVATAR_ICON_PREFIX);
 }
 
 /**


### PR DESCRIPTION
## Summary
- useAppIconSync derives the offer purely through the appIconNameForAvatar chokepoint and the shell's available list; apply/reset only ever run from explicit user taps
- One unified AppIconMatchPrompt covers local saves, cross-device avatar changes, and first post-onboarding arrival, with per-name decline memory and a per-session guard
- Settings AppIconCard offers Match/Reset; everything hidden behind the ios-avatar-app-icon flag (default off), non-iOS, and old-shell skew

Part of plan: ios-avatar-app-icons.md (PR 5 of 6)