### PR TITLE
feat(web): mirror a widget snapshot (unread, in-progress, top-3) into the iOS shell

### DIFF
--- a/clients/web/src/assistant/switch-origin.ts
+++ b/clients/web/src/assistant/switch-origin.ts
@@ -9,6 +9,7 @@ import { remoteGatewayPublicBaseUrl } from "@/lib/auth/remote-gateway-session";
 import { isRemoteGatewayMode } from "@/lib/local-mode";
 import { isNativeMobile } from "@/runtime/platform-detection";
 import { nativeSwitchToOrigin } from "@/runtime/self-hosted-servers";
+import { clearWidgetSnapshot } from "@/runtime/widget-snapshot";
 import {
   normalizeOriginUrl,
   type RememberedOrigin,
@@ -37,6 +38,14 @@ export async function switchToOrigin(origin: RememberedOrigin): Promise<void> {
     navigate();
     return;
   }
+  // The target origin is a different deployment with its own conversations,
+  // so the iOS widget snapshot the running one produced is about to be wrong.
+  // Clearing before the swap leaves the widgets empty until the new origin
+  // resolves its own list, which beats showing the old deployment's titles on
+  // a Home Screen that never reloads on its own. Inside the native branch
+  // rather than above it because the web path has to reach its navigation
+  // synchronously, and the snapshot only exists on a native shell anyway.
+  await clearWidgetSnapshot();
   if (!(await nativeSwitchToOrigin(origin.url))) {
     navigate();
   }

--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -41,6 +41,7 @@ import {
 import { useChatLayoutSlotsStore } from "@/components/layout/chat-layout-slots-store";
 import { useElectronDockSync } from "@/domains/chat/hooks/use-electron-dock-sync";
 import { useNativeRecentChatsSync } from "@/domains/chat/hooks/use-native-recent-chats-sync";
+import { useNativeWidgetSnapshotSync } from "@/domains/chat/hooks/use-native-widget-snapshot-sync";
 import { useOpenAppFromChat } from "@/domains/chat/hooks/use-open-app-from-chat";
 import { DRAWER_SURFACE_BACKGROUND } from "@/domains/chat/utils/drawer-surface";
 import {
@@ -276,6 +277,19 @@ export function ChatLayout({
   // through its whole retry budget into a terminal error (#40621).
   useNativeRecentChatsSync(
     conversations,
+    !isConversationListPending && !conversationsFailed,
+  );
+
+  // And into the iOS shell's widget snapshot, which backs the Home Screen
+  // widgets (unread and in-progress counts, the three most recent chats).
+  // No-op off Capacitor iOS, and resolved carries the same meaning it does
+  // for the recent-chats sync above: an unresolved `[]` would blank the
+  // widgets for as long as the list failed to load.
+  useNativeWidgetSnapshotSync(
+    assistantId,
+    conversations,
+    conversationGroups,
+    isAssistantActive,
     !isConversationListPending && !conversationsFailed,
   );
 

--- a/clients/web/src/domains/chat/hooks/use-native-widget-snapshot-sync.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-native-widget-snapshot-sync.test.tsx
@@ -1,0 +1,279 @@
+/**
+ * Covers the iOS widget-snapshot contract: the `listResolved` guard, the
+ * payload the Home Screen widgets read, and the dedup that keeps a re-render
+ * from costing bridge traffic and a widget timeline reload.
+ *
+ * The guard is the same one the recent-chats sync carries: the
+ * conversation-list query serves an `[]` fallback while loading, gated, or
+ * errored, and syncing that would blank the widgets on every launch, and for
+ * as long as the failure lasted on a launch that never loads. An empty list
+ * from a *successful* query must still sync: genuinely having no
+ * conversations should empty the widgets.
+ *
+ * `generatedAt` is deliberately outside the dedup key. It changes on every
+ * render by construction, so including it would leave the dedup dead.
+ */
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+  setSystemTime,
+} from "bun:test";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, renderHook } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+
+import type {
+  Conversation,
+  ConversationGroup,
+} from "@/types/conversation-types";
+import type { WidgetSnapshotPayload } from "@/runtime/widget-snapshot";
+import * as listFetchers from "@/utils/conversation-list-fetchers";
+
+// Nothing in this file should reach the network: the count endpoint stands in
+// as a request that never settles, so every case reads the derived fallback.
+mock.module("@/utils/conversation-list-fetchers", () => ({
+  ...listFetchers,
+  fetchUnreadConversationCount: () => new Promise(() => {}),
+}));
+
+const syncedSnapshots: WidgetSnapshotPayload[] = [];
+let syncAvailable = true;
+
+// Full module surface: `mock.module` is process-global in bun, so a partial
+// shape would shadow the other exports for later test files in the run.
+mock.module("@/runtime/widget-snapshot", () => ({
+  WIDGET_SNAPSHOT_SCHEMA_VERSION: 1,
+  isWidgetSnapshotSyncAvailable: () => syncAvailable,
+  syncWidgetSnapshot: async (snapshot: WidgetSnapshotPayload) => {
+    syncedSnapshots.push(snapshot);
+  },
+  clearWidgetSnapshot: async () => {},
+}));
+
+const { useConversationStore } = await import("@/stores/conversation-store");
+const { useNativeWidgetSnapshotSync } =
+  await import("@/domains/chat/hooks/use-native-widget-snapshot-sync");
+
+const ASSISTANT_ID = "asst-1";
+const NO_GROUPS: ConversationGroup[] = [];
+
+function conversation(
+  conversationId: string,
+  overrides: Partial<Conversation> = {},
+): Conversation {
+  return {
+    conversationId,
+    title: conversationId,
+    lastMessageAt: Date.parse("2026-08-01T00:00:00Z"),
+    ...overrides,
+  };
+}
+
+function group(id: string, name: string): ConversationGroup {
+  return { id, name, sortPosition: 0, isSystemGroup: false };
+}
+
+interface Props {
+  conversations: Conversation[];
+  conversationGroups: ConversationGroup[];
+  listResolved: boolean;
+}
+
+function render(initialProps: Props) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return renderHook(
+    (props: Props) =>
+      useNativeWidgetSnapshotSync(
+        ASSISTANT_ID,
+        props.conversations,
+        props.conversationGroups,
+        true,
+        props.listResolved,
+      ),
+    {
+      initialProps,
+      wrapper: ({ children }: { children: ReactNode }) =>
+        createElement(QueryClientProvider, { client }, children),
+    },
+  );
+}
+
+beforeEach(() => {
+  syncedSnapshots.length = 0;
+  syncAvailable = true;
+  useConversationStore.setState({ processingConversationIds: new Set() });
+});
+
+afterEach(() => {
+  cleanup();
+  setSystemTime();
+});
+
+describe("useNativeWidgetSnapshotSync", () => {
+  it("does not sync the pre-load [] fallback, then syncs once the list resolves", () => {
+    const { rerender } = render({
+      conversations: [],
+      conversationGroups: NO_GROUPS,
+      listResolved: false,
+    });
+    expect(syncedSnapshots).toHaveLength(0);
+
+    rerender({
+      conversations: [conversation("c1", { title: "Groceries" })],
+      conversationGroups: NO_GROUPS,
+      listResolved: true,
+    });
+    expect(syncedSnapshots).toHaveLength(1);
+    expect(syncedSnapshots[0]?.conversations).toHaveLength(1);
+  });
+
+  it("a list that un-resolves after syncing does not blank the widgets", () => {
+    const { rerender } = render({
+      conversations: [conversation("c1")],
+      conversationGroups: NO_GROUPS,
+      listResolved: true,
+    });
+    expect(syncedSnapshots).toHaveLength(1);
+
+    // The query fell into a terminal error: the caller reports unresolved and
+    // the list is the `[]` fallback again.
+    rerender({
+      conversations: [],
+      conversationGroups: NO_GROUPS,
+      listResolved: false,
+    });
+    expect(syncedSnapshots).toHaveLength(1);
+  });
+
+  it("syncs the three most recent rows with group names, unseen and processing state", () => {
+    useConversationStore.setState({
+      processingConversationIds: new Set(["c-client-turn"]),
+    });
+    render({
+      conversations: [
+        conversation("c-old", {
+          title: "Oldest",
+          lastMessageAt: Date.parse("2026-07-01T00:00:00Z"),
+        }),
+        conversation("c-archived", {
+          lastMessageAt: Date.parse("2026-08-05T00:00:00Z"),
+          archivedAt: Date.parse("2026-08-05T00:00:00Z"),
+        }),
+        conversation("c-client-turn", {
+          title: "Client turn",
+          lastMessageAt: Date.parse("2026-08-04T00:00:00Z"),
+        }),
+        conversation("c-server-turn", {
+          title: "Server turn",
+          lastMessageAt: Date.parse("2026-08-03T00:00:00Z"),
+          isProcessing: true,
+          groupId: "g1",
+        }),
+        conversation("c-unseen", {
+          title: undefined,
+          lastMessageAt: Date.parse("2026-08-02T00:00:00Z"),
+          hasUnseenLatestAssistantMessage: true,
+          groupId: "g-missing",
+        }),
+      ],
+      conversationGroups: [group("g1", "Errands")],
+      listResolved: true,
+    });
+
+    expect(syncedSnapshots).toHaveLength(1);
+    const snapshot = syncedSnapshots[0];
+    expect(snapshot?.schemaVersion).toBe(1);
+    expect(snapshot?.unreadCount).toBe(1);
+    // Both processing sources count, and the archived row is excluded from
+    // the count as well as from the rows.
+    expect(snapshot?.inProgressCount).toBe(2);
+    expect(snapshot?.conversations).toEqual([
+      {
+        id: "c-client-turn",
+        title: "Client turn",
+        subtitle: undefined,
+        lastMessageAt: "2026-08-04T00:00:00.000Z",
+        hasUnseen: false,
+        isProcessing: true,
+      },
+      {
+        id: "c-server-turn",
+        title: "Server turn",
+        subtitle: "Errands",
+        lastMessageAt: "2026-08-03T00:00:00.000Z",
+        hasUnseen: false,
+        isProcessing: true,
+      },
+      {
+        id: "c-unseen",
+        title: "Untitled",
+        subtitle: undefined,
+        lastMessageAt: "2026-08-02T00:00:00.000Z",
+        hasUnseen: true,
+        isProcessing: false,
+      },
+    ]);
+  });
+
+  it("syncs an empty snapshot once an empty list resolves", () => {
+    render({
+      conversations: [],
+      conversationGroups: NO_GROUPS,
+      listResolved: true,
+    });
+    expect(syncedSnapshots).toHaveLength(1);
+    expect(syncedSnapshots[0]).toMatchObject({
+      unreadCount: 0,
+      inProgressCount: 0,
+      conversations: [],
+    });
+  });
+
+  it("dedupes identical data across re-renders, ignoring the moving generatedAt", () => {
+    setSystemTime(new Date("2026-08-21T16:00:00Z"));
+    const { rerender } = render({
+      conversations: [conversation("c1", { title: "Groceries" })],
+      conversationGroups: NO_GROUPS,
+      listResolved: true,
+    });
+    expect(syncedSnapshots).toHaveLength(1);
+    expect(syncedSnapshots[0]?.generatedAt).toBe("2026-08-21T16:00:00.000Z");
+
+    // A later render of the same data would carry a different `generatedAt`.
+    // The dedup key excludes it, so nothing reaches the bridge.
+    setSystemTime(new Date("2026-08-21T16:05:00Z"));
+    rerender({
+      conversations: [conversation("c1", { title: "Groceries" })],
+      conversationGroups: NO_GROUPS,
+      listResolved: true,
+    });
+    expect(syncedSnapshots).toHaveLength(1);
+
+    // A real change still gets through.
+    rerender({
+      conversations: [conversation("c1", { title: "Groceries and dinner" })],
+      conversationGroups: NO_GROUPS,
+      listResolved: true,
+    });
+    expect(syncedSnapshots).toHaveLength(2);
+    expect(syncedSnapshots[1]?.generatedAt).toBe("2026-08-21T16:05:00.000Z");
+  });
+
+  it("is a no-op off Capacitor iOS", () => {
+    syncAvailable = false;
+    render({
+      conversations: [conversation("c1")],
+      conversationGroups: NO_GROUPS,
+      listResolved: true,
+    });
+    expect(syncedSnapshots).toHaveLength(0);
+  });
+});

--- a/clients/web/src/domains/chat/hooks/use-native-widget-snapshot-sync.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-native-widget-snapshot-sync.test.tsx
@@ -43,19 +43,30 @@ mock.module("@/utils/conversation-list-fetchers", () => ({
 }));
 
 const syncedSnapshots: WidgetSnapshotPayload[] = [];
+const syncedAssistantIds: (string | null)[] = [];
 let clearCount = 0;
 let syncAvailable = true;
+// Stands in for the producer id the bridge persists beside the App Group
+// snapshot, so a test can start from a snapshot a previous run left behind.
+let persistedAssistantId: string | null = null;
 
 // Full module surface: `mock.module` is process-global in bun, so a partial
 // shape would shadow the other exports for later test files in the run.
 mock.module("@/runtime/widget-snapshot", () => ({
   WIDGET_SNAPSHOT_SCHEMA_VERSION: 1,
   isWidgetSnapshotSyncAvailable: () => syncAvailable,
-  syncWidgetSnapshot: async (snapshot: WidgetSnapshotPayload) => {
+  readWidgetSnapshotAssistantId: () => persistedAssistantId,
+  syncWidgetSnapshot: async (
+    snapshot: WidgetSnapshotPayload,
+    assistantId: string | null,
+  ) => {
     syncedSnapshots.push(snapshot);
+    syncedAssistantIds.push(assistantId);
+    persistedAssistantId = assistantId;
   },
   clearWidgetSnapshot: async () => {
     clearCount++;
+    persistedAssistantId = null;
   },
 }));
 
@@ -83,7 +94,7 @@ function group(id: string, name: string): ConversationGroup {
 }
 
 interface Props {
-  assistantId?: string;
+  assistantId?: string | null;
   conversations: Conversation[];
   conversationGroups: ConversationGroup[];
   listResolved: boolean;
@@ -96,7 +107,7 @@ function render(initialProps: Props) {
   return renderHook(
     (props: Props) =>
       useNativeWidgetSnapshotSync(
-        props.assistantId ?? ASSISTANT_ID,
+        props.assistantId === undefined ? ASSISTANT_ID : props.assistantId,
         props.conversations,
         props.conversationGroups,
         true,
@@ -112,8 +123,10 @@ function render(initialProps: Props) {
 
 beforeEach(() => {
   syncedSnapshots.length = 0;
+  syncedAssistantIds.length = 0;
   clearCount = 0;
   syncAvailable = true;
+  persistedAssistantId = null;
   useConversationStore.setState({ processingConversationIds: new Set() });
 });
 
@@ -264,6 +277,69 @@ describe("useNativeWidgetSnapshotSync", () => {
     });
     expect(clearCount).toBe(0);
     expect(syncedSnapshots).toHaveLength(0);
+  });
+
+  it("records the producing assistant with the snapshot it writes", () => {
+    render({
+      conversations: [conversation("c1")],
+      conversationGroups: NO_GROUPS,
+      listResolved: true,
+    });
+    expect(syncedAssistantIds).toEqual([ASSISTANT_ID]);
+  });
+
+  it("clears a cold-boot snapshot left by another assistant before any list resolves", () => {
+    // The launch that motivates the persisted id: the App Group still holds
+    // the previous run's snapshot, this run starts on a different assistant,
+    // and nothing in memory knows the difference.
+    persistedAssistantId = "asst-previous-run";
+    const { rerender } = render({
+      conversations: [],
+      conversationGroups: NO_GROUPS,
+      listResolved: false,
+    });
+    expect(clearCount).toBe(1);
+    expect(syncedSnapshots).toHaveLength(0);
+
+    // The producer is consulted once, so a list that stays unresolved does
+    // not cost a clear per render.
+    rerender({
+      conversations: [],
+      conversationGroups: NO_GROUPS,
+      listResolved: false,
+    });
+    expect(clearCount).toBe(1);
+  });
+
+  it("keeps a cold-boot snapshot this assistant produced while its list is pending", () => {
+    persistedAssistantId = ASSISTANT_ID;
+    render({
+      conversations: [],
+      conversationGroups: NO_GROUPS,
+      listResolved: false,
+    });
+    expect(clearCount).toBe(0);
+    expect(syncedSnapshots).toHaveLength(0);
+  });
+
+  it("waits for the active assistant before judging a cold-boot snapshot", () => {
+    // `activeAssistantId` resolves after the layout mounts. A null id matches
+    // nothing, so acting on it would blank the widgets on every launch.
+    persistedAssistantId = "asst-previous-run";
+    const { rerender } = render({
+      assistantId: null,
+      conversations: [],
+      conversationGroups: NO_GROUPS,
+      listResolved: false,
+    });
+    expect(clearCount).toBe(0);
+
+    rerender({
+      conversations: [],
+      conversationGroups: NO_GROUPS,
+      listResolved: false,
+    });
+    expect(clearCount).toBe(1);
   });
 
   it("syncs the three most recent rows with group names, unseen and processing state", () => {

--- a/clients/web/src/domains/chat/hooks/use-native-widget-snapshot-sync.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-native-widget-snapshot-sync.test.tsx
@@ -43,6 +43,7 @@ mock.module("@/utils/conversation-list-fetchers", () => ({
 }));
 
 const syncedSnapshots: WidgetSnapshotPayload[] = [];
+let clearCount = 0;
 let syncAvailable = true;
 
 // Full module surface: `mock.module` is process-global in bun, so a partial
@@ -53,7 +54,9 @@ mock.module("@/runtime/widget-snapshot", () => ({
   syncWidgetSnapshot: async (snapshot: WidgetSnapshotPayload) => {
     syncedSnapshots.push(snapshot);
   },
-  clearWidgetSnapshot: async () => {},
+  clearWidgetSnapshot: async () => {
+    clearCount++;
+  },
 }));
 
 const { useConversationStore } = await import("@/stores/conversation-store");
@@ -80,6 +83,7 @@ function group(id: string, name: string): ConversationGroup {
 }
 
 interface Props {
+  assistantId?: string;
   conversations: Conversation[];
   conversationGroups: ConversationGroup[];
   listResolved: boolean;
@@ -92,7 +96,7 @@ function render(initialProps: Props) {
   return renderHook(
     (props: Props) =>
       useNativeWidgetSnapshotSync(
-        ASSISTANT_ID,
+        props.assistantId ?? ASSISTANT_ID,
         props.conversations,
         props.conversationGroups,
         true,
@@ -108,6 +112,7 @@ function render(initialProps: Props) {
 
 beforeEach(() => {
   syncedSnapshots.length = 0;
+  clearCount = 0;
   syncAvailable = true;
   useConversationStore.setState({ processingConversationIds: new Set() });
 });
@@ -151,6 +156,114 @@ describe("useNativeWidgetSnapshotSync", () => {
       listResolved: false,
     });
     expect(syncedSnapshots).toHaveLength(1);
+    expect(clearCount).toBe(0);
+  });
+
+  it("clears the snapshot when the assistant changes before the new list resolves", () => {
+    const { rerender } = render({
+      conversations: [conversation("c1", { title: "Groceries" })],
+      conversationGroups: NO_GROUPS,
+      listResolved: true,
+    });
+    expect(syncedSnapshots).toHaveLength(1);
+    expect(clearCount).toBe(0);
+
+    // The switch lands: the new assistant's list query starts over, so it is
+    // the unresolved `[]` fallback again. The previous assistant's rows must
+    // not survive it.
+    rerender({
+      assistantId: "asst-2",
+      conversations: [],
+      conversationGroups: NO_GROUPS,
+      listResolved: false,
+    });
+    expect(clearCount).toBe(1);
+    expect(syncedSnapshots).toHaveLength(1);
+
+    // A second unresolved render of the same new assistant is not another
+    // switch.
+    rerender({
+      assistantId: "asst-2",
+      conversations: [],
+      conversationGroups: NO_GROUPS,
+      listResolved: false,
+    });
+    expect(clearCount).toBe(1);
+
+    // The new assistant's own list finally lands.
+    rerender({
+      assistantId: "asst-2",
+      conversations: [conversation("c2", { title: "Flights" })],
+      conversationGroups: NO_GROUPS,
+      listResolved: true,
+    });
+    expect(syncedSnapshots).toHaveLength(2);
+    expect(syncedSnapshots[1]?.conversations[0]?.id).toBe("c2");
+  });
+
+  it("writes the new assistant's snapshot without a clear when its list is already resolved", () => {
+    const { rerender } = render({
+      conversations: [conversation("c1", { title: "Groceries" })],
+      conversationGroups: NO_GROUPS,
+      listResolved: true,
+    });
+    expect(syncedSnapshots).toHaveLength(1);
+
+    rerender({
+      assistantId: "asst-2",
+      conversations: [conversation("c2", { title: "Flights" })],
+      conversationGroups: NO_GROUPS,
+      listResolved: true,
+    });
+    expect(clearCount).toBe(0);
+    expect(syncedSnapshots).toHaveLength(2);
+    expect(syncedSnapshots[1]?.conversations[0]?.id).toBe("c2");
+  });
+
+  it("re-syncs identical data across an assistant switch", () => {
+    // The dedup key is the serialized payload, so two assistants with the
+    // same rows would collide. The switch drops the key with the snapshot.
+    const { rerender } = render({
+      conversations: [conversation("c1", { title: "Groceries" })],
+      conversationGroups: NO_GROUPS,
+      listResolved: true,
+    });
+    expect(syncedSnapshots).toHaveLength(1);
+
+    rerender({
+      assistantId: "asst-2",
+      conversations: [],
+      conversationGroups: NO_GROUPS,
+      listResolved: false,
+    });
+    rerender({
+      assistantId: "asst-2",
+      conversations: [conversation("c1", { title: "Groceries" })],
+      conversationGroups: NO_GROUPS,
+      listResolved: true,
+    });
+    expect(clearCount).toBe(1);
+    expect(syncedSnapshots).toHaveLength(2);
+  });
+
+  it("does not clear on the launch transition into the first assistant", () => {
+    // `activeAssistantId` resolves after the layout mounts, so the hook sees
+    // one unresolved render before the id arrives. That is not a switch: the
+    // App Group's last-known-good snapshot has to survive it.
+    const { rerender } = render({
+      assistantId: "asst-1",
+      conversations: [],
+      conversationGroups: NO_GROUPS,
+      listResolved: false,
+    });
+    rerender({
+      assistantId: "asst-2",
+      conversations: [],
+      conversationGroups: NO_GROUPS,
+      listResolved: false,
+    });
+    expect(clearCount).toBe(0);
+    expect(syncedSnapshots).toHaveLength(0);
   });
 
   it("syncs the three most recent rows with group names, unseen and processing state", () => {

--- a/clients/web/src/domains/chat/hooks/use-native-widget-snapshot-sync.ts
+++ b/clients/web/src/domains/chat/hooks/use-native-widget-snapshot-sync.ts
@@ -4,6 +4,7 @@ import { useUnreadConversationCount } from "@/hooks/conversation-queries";
 import {
   clearWidgetSnapshot,
   isWidgetSnapshotSyncAvailable,
+  readWidgetSnapshotAssistantId,
   syncWidgetSnapshot,
   WIDGET_SNAPSHOT_SCHEMA_VERSION,
   type WidgetSnapshotConversation,
@@ -68,8 +69,16 @@ const MAX_SNAPSHOT_CONVERSATIONS = 3;
  * previous assistant's titles, counts and conversation targets on a Home
  * Screen that never reloads on its own, indefinitely if the new assistant
  * never comes up. So the hook tracks which assistant produced the snapshot it
- * last wrote and drops it as soon as that id changes. A launch (no snapshot
- * written yet) is not a switch and keeps the preservation.
+ * last wrote and drops it as soon as that id changes.
+ *
+ * An in-memory ref alone cannot answer that on a cold launch: the App Group
+ * snapshot outlives the page, so a run that starts on a different assistant
+ * begins with the ref null and would preserve another assistant's titles for
+ * as long as its own list stayed unresolved. The producer id is therefore
+ * also persisted next to the snapshot (`readWidgetSnapshotAssistantId`), and
+ * consulted once per launch as the ref's cold-boot complement. A launch with
+ * no recorded producer, or one recorded for the assistant now active, is not
+ * a switch and keeps the preservation.
  */
 export function useNativeWidgetSnapshotSync(
   assistantId: string | null,
@@ -83,6 +92,10 @@ export function useNativeWidgetSnapshotSync(
   // this hook has written one, which is what keeps a launch from reading as
   // a switch.
   const syncedAssistantIdRef = useRef<string | null>(null);
+  // Whether the persisted producer id has been consulted. It only answers for
+  // a snapshot this page lifetime did not write, so one read per launch is
+  // enough and the ref is authoritative from then on.
+  const readPersistedOwnerRef = useRef(false);
   const processingConversationIds =
     useConversationStore.use.processingConversationIds();
 
@@ -102,9 +115,19 @@ export function useNativeWidgetSnapshotSync(
     // to resolve. Dropping the dedup key too, so the new assistant's first
     // resolved list always reaches the bridge even when it happens to
     // serialize identically to what the previous one last wrote.
+    //
+    // On a cold launch the ref is null while a snapshot from a previous run
+    // may still be on the Home Screen, so its producer comes from storage
+    // instead. Deferred until the active assistant is known, so a launch that
+    // has not resolved one yet is never mistaken for a switch.
+    let persistedOwnerId: string | null = null;
+    if (!readPersistedOwnerRef.current && assistantId !== null) {
+      readPersistedOwnerRef.current = true;
+      persistedOwnerId = readWidgetSnapshotAssistantId();
+    }
+    const snapshotOwnerId = syncedAssistantIdRef.current ?? persistedOwnerId;
     const switchedAssistant =
-      syncedAssistantIdRef.current !== null &&
-      syncedAssistantIdRef.current !== assistantId;
+      snapshotOwnerId !== null && snapshotOwnerId !== assistantId;
     if (switchedAssistant) {
       syncedAssistantIdRef.current = null;
       lastPayloadRef.current = null;
@@ -161,10 +184,13 @@ export function useNativeWidgetSnapshotSync(
     }
     lastPayloadRef.current = serialized;
     syncedAssistantIdRef.current = assistantId;
-    void syncWidgetSnapshot({
-      ...content,
-      generatedAt: new Date().toISOString(),
-    });
+    void syncWidgetSnapshot(
+      {
+        ...content,
+        generatedAt: new Date().toISOString(),
+      },
+      assistantId,
+    );
   }, [
     assistantId,
     conversations,

--- a/clients/web/src/domains/chat/hooks/use-native-widget-snapshot-sync.ts
+++ b/clients/web/src/domains/chat/hooks/use-native-widget-snapshot-sync.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef } from "react";
 
 import { useUnreadConversationCount } from "@/hooks/conversation-queries";
 import {
+  clearWidgetSnapshot,
   isWidgetSnapshotSyncAvailable,
   syncWidgetSnapshot,
   WIDGET_SNAPSHOT_SCHEMA_VERSION,
@@ -59,6 +60,16 @@ const MAX_SNAPSHOT_CONVERSATIONS = 3;
  * long as it lasted, despite a last-known-good snapshot sitting in the App
  * Group. An empty list from a *successful* query does sync: genuinely having
  * no conversations should empty the widgets.
+ *
+ * That preservation is scoped to ONE assistant. A snapshot describes the
+ * assistant it was built from, so an in-SPA switch
+ * (`switchToResolvedAssistant`) invalidates it outright: the new assistant's
+ * list starts unresolved, and preserving across the switch would leave the
+ * previous assistant's titles, counts and conversation targets on a Home
+ * Screen that never reloads on its own, indefinitely if the new assistant
+ * never comes up. So the hook tracks which assistant produced the snapshot it
+ * last wrote and drops it as soon as that id changes. A launch (no snapshot
+ * written yet) is not a switch and keeps the preservation.
  */
 export function useNativeWidgetSnapshotSync(
   assistantId: string | null,
@@ -68,6 +79,10 @@ export function useNativeWidgetSnapshotSync(
   listResolved: boolean,
 ): void {
   const lastPayloadRef = useRef<string | null>(null);
+  // The assistant the snapshot in the App Group was built from; null until
+  // this hook has written one, which is what keeps a launch from reading as
+  // a switch.
+  const syncedAssistantIdRef = useRef<string | null>(null);
   const processingConversationIds =
     useConversationStore.use.processingConversationIds();
 
@@ -78,7 +93,29 @@ export function useNativeWidgetSnapshotSync(
   );
 
   useEffect(() => {
-    if (!isWidgetSnapshotSyncAvailable() || !listResolved) {
+    if (!isWidgetSnapshotSyncAvailable()) {
+      return;
+    }
+
+    // Checked ahead of the `listResolved` guard, which would otherwise hold
+    // the previous assistant's snapshot for the whole time the new one takes
+    // to resolve. Dropping the dedup key too, so the new assistant's first
+    // resolved list always reaches the bridge even when it happens to
+    // serialize identically to what the previous one last wrote.
+    const switchedAssistant =
+      syncedAssistantIdRef.current !== null &&
+      syncedAssistantIdRef.current !== assistantId;
+    if (switchedAssistant) {
+      syncedAssistantIdRef.current = null;
+      lastPayloadRef.current = null;
+    }
+
+    if (!listResolved) {
+      // Only on a switch: a pending or errored query for the SAME assistant
+      // still keeps its last-known-good snapshot.
+      if (switchedAssistant) {
+        void clearWidgetSnapshot();
+      }
       return;
     }
 
@@ -123,11 +160,13 @@ export function useNativeWidgetSnapshotSync(
       return;
     }
     lastPayloadRef.current = serialized;
+    syncedAssistantIdRef.current = assistantId;
     void syncWidgetSnapshot({
       ...content,
       generatedAt: new Date().toISOString(),
     });
   }, [
+    assistantId,
     conversations,
     conversationGroups,
     processingConversationIds,

--- a/clients/web/src/domains/chat/hooks/use-native-widget-snapshot-sync.ts
+++ b/clients/web/src/domains/chat/hooks/use-native-widget-snapshot-sync.ts
@@ -1,0 +1,137 @@
+import { useEffect, useRef } from "react";
+
+import { useUnreadConversationCount } from "@/hooks/conversation-queries";
+import {
+  isWidgetSnapshotSyncAvailable,
+  syncWidgetSnapshot,
+  WIDGET_SNAPSHOT_SCHEMA_VERSION,
+  type WidgetSnapshotConversation,
+  type WidgetSnapshotPayload,
+} from "@/runtime/widget-snapshot";
+import { useConversationStore } from "@/stores/conversation-store";
+import type {
+  Conversation,
+  ConversationGroup,
+} from "@/types/conversation-types";
+import { compareByRecency } from "@/utils/conversation-order";
+
+/**
+ * How many conversations the Home Screen widgets get. The Catch Up medium
+ * widget draws three rows and nothing else reads the list, so a longer
+ * payload would only cost bridge traffic and App Group space.
+ */
+const MAX_SNAPSHOT_CONVERSATIONS = 3;
+
+/**
+ * Mirror the conversation list into the iOS shell's `WidgetSnapshot` plugin
+ * so the Home Screen widgets can draw unread and in-progress counts and the
+ * three most recent chats. No-ops everywhere but Capacitor iOS.
+ *
+ * Mount once at a layout that already holds the conversation list (currently
+ * `ChatLayout`, beside `useNativeRecentChatsSync`, its Shortcuts sibling).
+ *
+ * The unread count prefers the assistant's server-side count and falls back
+ * to the loaded rows, the same resolution the Electron Dock badge uses, so
+ * the two surfaces never disagree about the number. The count query is gated
+ * on the platform and on the assistant being active: `ChatLayout` mounts
+ * before the assistant finishes starting, and querying a starting assistant
+ * spends the retry budget on a request that cannot succeed.
+ *
+ * In-progress rows come from two sources that have to be unioned, exactly as
+ * the sidebar row does it: the server-seeded `isProcessing` flag, and the
+ * client's own in-flight turns tracked in `processingConversationIds`. Either
+ * alone under-reports, since a turn started in this session may not be
+ * reflected in the list payload yet and a turn started elsewhere is only in
+ * the payload.
+ *
+ * Syncs are deduped on the serialized snapshot with `generatedAt` excluded.
+ * Including it would make every render a fresh payload and the dedup dead,
+ * so the shell would take bridge traffic and a widget timeline reload on
+ * every re-render of the layout.
+ *
+ * `listResolved` must be false until the conversation-list query has actually
+ * SUCCEEDED. The query serves an `[]` fallback while pending (loading, or
+ * gated on the assistant/pod) AND while in a terminal error state, and the
+ * caller must exclude both (`!isPending && !isError`): a bare `!isPending`
+ * lets the error case through. Without the guard, every launch would blank
+ * the widgets before the first load, and a launch that never loads (offline,
+ * assistant never ready, pod waking into a 503 error) would blank them for as
+ * long as it lasted, despite a last-known-good snapshot sitting in the App
+ * Group. An empty list from a *successful* query does sync: genuinely having
+ * no conversations should empty the widgets.
+ */
+export function useNativeWidgetSnapshotSync(
+  assistantId: string | null,
+  conversations: Conversation[],
+  conversationGroups: ConversationGroup[],
+  isAssistantActive: boolean,
+  listResolved: boolean,
+): void {
+  const lastPayloadRef = useRef<string | null>(null);
+  const processingConversationIds =
+    useConversationStore.use.processingConversationIds();
+
+  const unreadCount = useUnreadConversationCount(
+    assistantId,
+    conversations,
+    isWidgetSnapshotSyncAvailable() && isAssistantActive,
+  );
+
+  useEffect(() => {
+    if (!isWidgetSnapshotSyncAvailable() || !listResolved) {
+      return;
+    }
+
+    const isProcessing = (conversation: Conversation): boolean =>
+      conversation.isProcessing === true ||
+      processingConversationIds.has(conversation.conversationId);
+
+    const groupNames = new Map(
+      conversationGroups.map((group) => [group.id, group.name]),
+    );
+    const active = conversations.filter(
+      (conversation) => conversation.archivedAt === undefined,
+    );
+    const inProgressCount = active.filter(isProcessing).length;
+    const rows: WidgetSnapshotConversation[] = active
+      .sort(compareByRecency)
+      .slice(0, MAX_SNAPSHOT_CONVERSATIONS)
+      .map((conversation) => ({
+        id: conversation.conversationId,
+        title: conversation.title ?? "Untitled",
+        subtitle:
+          conversation.groupId === undefined
+            ? undefined
+            : groupNames.get(conversation.groupId),
+        lastMessageAt:
+          conversation.lastMessageAt === undefined
+            ? undefined
+            : new Date(conversation.lastMessageAt).toISOString(),
+        hasUnseen: conversation.hasUnseenLatestAssistantMessage === true,
+        isProcessing: isProcessing(conversation),
+      }));
+
+    // Built without `generatedAt` so the serialized form is the dedup key.
+    const content: Omit<WidgetSnapshotPayload, "generatedAt"> = {
+      schemaVersion: WIDGET_SNAPSHOT_SCHEMA_VERSION,
+      unreadCount,
+      inProgressCount,
+      conversations: rows,
+    };
+    const serialized = JSON.stringify(content);
+    if (serialized === lastPayloadRef.current) {
+      return;
+    }
+    lastPayloadRef.current = serialized;
+    void syncWidgetSnapshot({
+      ...content,
+      generatedAt: new Date().toISOString(),
+    });
+  }, [
+    conversations,
+    conversationGroups,
+    processingConversationIds,
+    unreadCount,
+    listResolved,
+  ]);
+}

--- a/clients/web/src/runtime/widget-snapshot.test.ts
+++ b/clients/web/src/runtime/widget-snapshot.test.ts
@@ -1,0 +1,85 @@
+/**
+ * The bridge's two safety properties: it never touches the plugin off
+ * Capacitor iOS, and a shell too old to carry `WidgetSnapshot` is an expected
+ * state rather than a fault. Every web deploy reaches installed shells that
+ * predate the plugin, so a rejection there has to resolve as a silent debug
+ * no-op; a caller that awaited a throw would break sign-out.
+ */
+
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+import type { WidgetSnapshotPayload } from "./widget-snapshot";
+
+let platform = "ios";
+let pluginRejects = false;
+const syncCalls: unknown[] = [];
+let clearCalls = 0;
+
+mock.module("@capacitor/core", () => ({
+  Capacitor: {
+    getPlatform: () => platform,
+  },
+  registerPlugin: () => ({
+    sync: async (options: unknown) => {
+      syncCalls.push(options);
+      if (pluginRejects) {
+        throw new Error("WidgetSnapshot does not have an implementation");
+      }
+      return { ok: true };
+    },
+    clear: async () => {
+      clearCalls += 1;
+      if (pluginRejects) {
+        throw new Error("WidgetSnapshot does not have an implementation");
+      }
+      return { ok: true };
+    },
+  }),
+}));
+
+const {
+  clearWidgetSnapshot,
+  isWidgetSnapshotSyncAvailable,
+  syncWidgetSnapshot,
+  WIDGET_SNAPSHOT_SCHEMA_VERSION,
+} = await import("./widget-snapshot");
+
+const SNAPSHOT: WidgetSnapshotPayload = {
+  schemaVersion: WIDGET_SNAPSHOT_SCHEMA_VERSION,
+  generatedAt: "2026-08-21T16:00:00.000Z",
+  unreadCount: 2,
+  inProgressCount: 1,
+  conversations: [],
+};
+
+beforeEach(() => {
+  platform = "ios";
+  pluginRejects = false;
+  syncCalls.length = 0;
+  clearCalls = 0;
+});
+
+describe("widget-snapshot bridge", () => {
+  it("passes the snapshot through on Capacitor iOS", async () => {
+    expect(isWidgetSnapshotSyncAvailable()).toBe(true);
+    await syncWidgetSnapshot(SNAPSHOT);
+    await clearWidgetSnapshot();
+    expect(syncCalls).toEqual([SNAPSHOT]);
+    expect(clearCalls).toBe(1);
+  });
+
+  it("never reaches the plugin off Capacitor iOS", async () => {
+    platform = "web";
+    expect(isWidgetSnapshotSyncAvailable()).toBe(false);
+    await syncWidgetSnapshot(SNAPSHOT);
+    await clearWidgetSnapshot();
+    expect(syncCalls).toHaveLength(0);
+    expect(clearCalls).toBe(0);
+  });
+
+  it("resolves silently on a shell too old to carry the plugin", async () => {
+    pluginRejects = true;
+    await expect(syncWidgetSnapshot(SNAPSHOT)).resolves.toBeUndefined();
+    await expect(clearWidgetSnapshot()).resolves.toBeUndefined();
+  });
+});

--- a/clients/web/src/runtime/widget-snapshot.test.ts
+++ b/clients/web/src/runtime/widget-snapshot.test.ts
@@ -4,6 +4,11 @@
  * state rather than a fault. Every web deploy reaches installed shells that
  * predate the plugin, so a rejection there has to resolve as a silent debug
  * no-op; a caller that awaited a throw would break sign-out.
+ *
+ * Plus the producer id the bridge records beside the snapshot. The App Group
+ * cache outlives the page, so it is the only thing a cold launch can use to
+ * tell whose snapshot it inherited, and it has to track the writes that
+ * actually landed.
  */
 
 import { beforeEach, describe, expect, it, mock } from "bun:test";
@@ -40,6 +45,7 @@ mock.module("@capacitor/core", () => ({
 const {
   clearWidgetSnapshot,
   isWidgetSnapshotSyncAvailable,
+  readWidgetSnapshotAssistantId,
   syncWidgetSnapshot,
   WIDGET_SNAPSHOT_SCHEMA_VERSION,
 } = await import("./widget-snapshot");
@@ -57,12 +63,13 @@ beforeEach(() => {
   pluginRejects = false;
   syncCalls.length = 0;
   clearCalls = 0;
+  localStorage.clear();
 });
 
 describe("widget-snapshot bridge", () => {
   it("passes the snapshot through on Capacitor iOS", async () => {
     expect(isWidgetSnapshotSyncAvailable()).toBe(true);
-    await syncWidgetSnapshot(SNAPSHOT);
+    await syncWidgetSnapshot(SNAPSHOT, "asst-1");
     await clearWidgetSnapshot();
     expect(syncCalls).toEqual([SNAPSHOT]);
     expect(clearCalls).toBe(1);
@@ -71,15 +78,81 @@ describe("widget-snapshot bridge", () => {
   it("never reaches the plugin off Capacitor iOS", async () => {
     platform = "web";
     expect(isWidgetSnapshotSyncAvailable()).toBe(false);
-    await syncWidgetSnapshot(SNAPSHOT);
+    await syncWidgetSnapshot(SNAPSHOT, "asst-1");
     await clearWidgetSnapshot();
     expect(syncCalls).toHaveLength(0);
     expect(clearCalls).toBe(0);
+    expect(readWidgetSnapshotAssistantId()).toBeNull();
   });
 
   it("resolves silently on a shell too old to carry the plugin", async () => {
     pluginRejects = true;
-    await expect(syncWidgetSnapshot(SNAPSHOT)).resolves.toBeUndefined();
+    await expect(
+      syncWidgetSnapshot(SNAPSHOT, "asst-1"),
+    ).resolves.toBeUndefined();
     await expect(clearWidgetSnapshot()).resolves.toBeUndefined();
+  });
+});
+
+describe("the recorded snapshot producer", () => {
+  it("is unknown until a snapshot is written, then names the producer", async () => {
+    expect(readWidgetSnapshotAssistantId()).toBeNull();
+    await syncWidgetSnapshot(SNAPSHOT, "asst-1");
+    expect(readWidgetSnapshotAssistantId()).toBe("asst-1");
+    await syncWidgetSnapshot(SNAPSHOT, "asst-2");
+    expect(readWidgetSnapshotAssistantId()).toBe("asst-2");
+  });
+
+  it("is dropped with the snapshot on clear", async () => {
+    await syncWidgetSnapshot(SNAPSHOT, "asst-1");
+    await clearWidgetSnapshot();
+    expect(readWidgetSnapshotAssistantId()).toBeNull();
+  });
+
+  it("still names the last landed write when the bridge rejects", async () => {
+    // A rejected call changed nothing in the App Group, so the snapshot there
+    // still belongs to whoever last wrote one.
+    await syncWidgetSnapshot(SNAPSHOT, "asst-1");
+    pluginRejects = true;
+    await syncWidgetSnapshot(SNAPSHOT, "asst-2");
+    expect(readWidgetSnapshotAssistantId()).toBe("asst-1");
+    await clearWidgetSnapshot();
+    expect(readWidgetSnapshotAssistantId()).toBe("asst-1");
+  });
+
+  it("reads as unknown when storage is unusable, and the sync still lands", async () => {
+    // Private browsing, quota exhaustion, or storage disabled by policy.
+    // happy-dom's Storage is a Proxy, so overwriting `setItem` on it just
+    // writes an entry; swap the whole global instead.
+    const original = Object.getOwnPropertyDescriptor(
+      globalThis,
+      "localStorage",
+    )!;
+    const throwing = {
+      getItem: () => {
+        throw new Error("localStorage unavailable");
+      },
+      setItem: () => {
+        throw new Error("localStorage unavailable");
+      },
+      removeItem: () => {
+        throw new Error("localStorage unavailable");
+      },
+    };
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      get: () => throwing,
+    });
+    try {
+      await expect(
+        syncWidgetSnapshot(SNAPSHOT, "asst-1"),
+      ).resolves.toBeUndefined();
+      await expect(clearWidgetSnapshot()).resolves.toBeUndefined();
+      expect(readWidgetSnapshotAssistantId()).toBeNull();
+      expect(syncCalls).toHaveLength(1);
+      expect(clearCalls).toBe(1);
+    } finally {
+      Object.defineProperty(globalThis, "localStorage", original);
+    }
   });
 });

--- a/clients/web/src/runtime/widget-snapshot.ts
+++ b/clients/web/src/runtime/widget-snapshot.ts
@@ -1,0 +1,99 @@
+/**
+ * Bridge to the iOS shell's `WidgetSnapshot` plugin
+ * (`clients/ios/App/App/WidgetSnapshotPlugin.swift`), which caches a small
+ * summary of the conversation list in the App Group so the Home Screen
+ * widgets can draw unread and in-progress counts plus the three most recent
+ * chats without a network stack or auth of their own.
+ * `useNativeWidgetSnapshotSync` is the one producer.
+ *
+ * iOS-only by design: only the iOS shell ships WidgetKit surfaces, so
+ * pushing this cache anywhere else would be pure bridge traffic. Widen the
+ * gate if another platform grows a home-screen surface.
+ *
+ * Nothing secret crosses the bridge. The snapshot carries conversation ids,
+ * titles, group names and counts, never tokens, and the widget process reads
+ * it without ever holding a session of its own.
+ */
+
+import { Capacitor, registerPlugin } from "@capacitor/core";
+
+/**
+ * Wire-format version. Must stay in lockstep with the Swift side's
+ * `WidgetSnapshot.currentSchemaVersion`: a snapshot written under a version
+ * the reader does not recognize is discarded rather than misread, which is
+ * how a shell and a web bundle that disagree degrade to the empty state
+ * instead of to garbled rows.
+ */
+export const WIDGET_SNAPSHOT_SCHEMA_VERSION = 1;
+
+export interface WidgetSnapshotConversation {
+  id: string;
+  title: string;
+  /** The conversation's group name; omitted when it is ungrouped. */
+  subtitle?: string;
+  /** ISO 8601 UTC; omitted when the conversation has no timestamp yet. */
+  lastMessageAt?: string;
+  hasUnseen: boolean;
+  isProcessing: boolean;
+}
+
+export interface WidgetSnapshotPayload {
+  schemaVersion: typeof WIDGET_SNAPSHOT_SCHEMA_VERSION;
+  /** ISO 8601 UTC, stamped by the producer as the payload is built. */
+  generatedAt: string;
+  unreadCount: number;
+  inProgressCount: number;
+  /** The most recent non-archived conversations, newest first, at most three. */
+  conversations: WidgetSnapshotConversation[];
+}
+
+interface WidgetSnapshotPlugin {
+  sync(options: WidgetSnapshotPayload): Promise<{ ok: boolean }>;
+  clear(): Promise<{ ok: boolean }>;
+}
+
+const WidgetSnapshot = registerPlugin<WidgetSnapshotPlugin>("WidgetSnapshot");
+
+export function isWidgetSnapshotSyncAvailable(): boolean {
+  return Capacitor.getPlatform() === "ios";
+}
+
+/**
+ * Replace the native snapshot with `snapshot` (the caller owns membership,
+ * ordering and the counts). Swallows bridge failures with a debug log per
+ * the skew convention (see `apns-environment.ts`): an older installed shell
+ * without the plugin is an expected state on every web deploy, not a fault.
+ */
+export async function syncWidgetSnapshot(
+  snapshot: WidgetSnapshotPayload,
+): Promise<void> {
+  if (!isWidgetSnapshotSyncAvailable()) {
+    return;
+  }
+  try {
+    await WidgetSnapshot.sync(snapshot);
+  } catch (err) {
+    console.debug("[widget-snapshot] WidgetSnapshot bridge unavailable:", err);
+  }
+}
+
+/**
+ * Drop the native snapshot, leaving the widgets on their empty state.
+ *
+ * Called when a session ends. A Home Screen widget is readable without
+ * unlocking the app, so the previous account's conversation titles must not
+ * outlive the session that produced them.
+ *
+ * Gated and guarded like {@link syncWidgetSnapshot}, because its callers are
+ * platform-neutral session seams rather than the iOS-only producer hook.
+ */
+export async function clearWidgetSnapshot(): Promise<void> {
+  if (!isWidgetSnapshotSyncAvailable()) {
+    return;
+  }
+  try {
+    await WidgetSnapshot.clear();
+  } catch (err) {
+    console.debug("[widget-snapshot] WidgetSnapshot bridge unavailable:", err);
+  }
+}

--- a/clients/web/src/runtime/widget-snapshot.ts
+++ b/clients/web/src/runtime/widget-snapshot.ts
@@ -17,6 +17,29 @@
 
 import { Capacitor, registerPlugin } from "@capacitor/core";
 
+import {
+  getLocalSetting,
+  removeLocalSetting,
+  setLocalSetting,
+} from "@/utils/local-settings";
+
+/**
+ * Which assistant produced the snapshot currently in the App Group.
+ *
+ * The cache outlives the page, so a cold launch inherits a snapshot no
+ * in-memory ref can account for and has to be able to tell whether it belongs
+ * to the assistant now active. Per-device UI bookkeeping rather than wire
+ * state, so it lives in localStorage beside the client's other local
+ * settings; a read or write that fails leaves it absent, which reads as "no
+ * known producer" and preserves the last-known-good snapshot.
+ */
+const SNAPSHOT_ASSISTANT_ID_KEY = "vellum:widgetSnapshotAssistantId";
+
+/** The assistant that wrote the snapshot in the App Group, if it is known. */
+export function readWidgetSnapshotAssistantId(): string | null {
+  return getLocalSetting(SNAPSHOT_ASSISTANT_ID_KEY, "") || null;
+}
+
 /**
  * Wire-format version. Must stay in lockstep with the Swift side's
  * `WidgetSnapshot.currentSchemaVersion`: a snapshot written under a version
@@ -63,9 +86,15 @@ export function isWidgetSnapshotSyncAvailable(): boolean {
  * ordering and the counts). Swallows bridge failures with a debug log per
  * the skew convention (see `apns-environment.ts`): an older installed shell
  * without the plugin is an expected state on every web deploy, not a fault.
+ *
+ * `assistantId` is the assistant the snapshot was built from, recorded once
+ * the write lands so a later cold launch can recognize a snapshot it did not
+ * produce. A rejected sync leaves whatever the last successful one wrote, and
+ * so leaves the recorded producer with it.
  */
 export async function syncWidgetSnapshot(
   snapshot: WidgetSnapshotPayload,
+  assistantId: string | null,
 ): Promise<void> {
   if (!isWidgetSnapshotSyncAvailable()) {
     return;
@@ -74,7 +103,13 @@ export async function syncWidgetSnapshot(
     await WidgetSnapshot.sync(snapshot);
   } catch (err) {
     console.debug("[widget-snapshot] WidgetSnapshot bridge unavailable:", err);
+    return;
   }
+  if (assistantId === null) {
+    removeLocalSetting(SNAPSHOT_ASSISTANT_ID_KEY);
+    return;
+  }
+  setLocalSetting(SNAPSHOT_ASSISTANT_ID_KEY, assistantId);
 }
 
 /**
@@ -86,6 +121,9 @@ export async function syncWidgetSnapshot(
  *
  * Gated and guarded like {@link syncWidgetSnapshot}, because its callers are
  * platform-neutral session seams rather than the iOS-only producer hook.
+ *
+ * Drops the recorded producer with the snapshot, so every caller (sign-out,
+ * assistant switch, the producer hook) leaves the two consistent.
  */
 export async function clearWidgetSnapshot(): Promise<void> {
   if (!isWidgetSnapshotSyncAvailable()) {
@@ -95,5 +133,7 @@ export async function clearWidgetSnapshot(): Promise<void> {
     await WidgetSnapshot.clear();
   } catch (err) {
     console.debug("[widget-snapshot] WidgetSnapshot bridge unavailable:", err);
+    return;
   }
+  removeLocalSetting(SNAPSHOT_ASSISTANT_ID_KEY);
 }

--- a/clients/web/src/stores/auth-store.test.ts
+++ b/clients/web/src/stores/auth-store.test.ts
@@ -324,6 +324,17 @@ mock.module("@/lib/auth/session-cleanup", () => ({
   clearUserScopedStorage: clearUserScopedStorageMock,
 }));
 
+// The iOS widget snapshot outlives the page, so every session-ending path has
+// to drop it. Full module surface: `mock.module` is process-global in bun, so
+// a partial shape would shadow the other exports for later test files.
+const clearWidgetSnapshotMock = mock(async () => {});
+mock.module("@/runtime/widget-snapshot", () => ({
+  WIDGET_SNAPSHOT_SCHEMA_VERSION: 1,
+  isWidgetSnapshotSyncAvailable: () => false,
+  syncWidgetSnapshot: async () => {},
+  clearWidgetSnapshot: clearWidgetSnapshotMock,
+}));
+
 // Use the REAL resolved-assistants store: it's dependency-light, so loading it
 // for real is cheap, and the `beforeEach` resets it between tests. (The list is
 // now loaded by the platform-assistants-sync subscription, not the auth store —
@@ -461,6 +472,7 @@ beforeEach(() => {
   mockFetchConsentError = null;
   clearOrganizationMock.mockClear();
   clearUserScopedStorageMock.mockClear();
+  clearWidgetSnapshotMock.mockClear();
   logoutMock.mockClear();
   deleteBiometricTokenMock.mockClear();
   installSessionCookiesMock.mockClear();
@@ -1703,6 +1715,113 @@ describe("session cleanup on logout", () => {
     await useAuthStore.getState().logout();
 
     expect(order).toEqual(["reset", "clear:null"]);
+  });
+});
+
+// A Home Screen widget is readable without unlocking the device, so the iOS
+// widget snapshot must not outlive the session it was built from. Explicit
+// logout is the rare way a session ends; a revoked or expired one settles
+// through `refreshSession` or `initSession` instead, so the drop belongs to
+// the shared session-ended transition rather than to `logout()`.
+describe("iOS widget snapshot on session end", () => {
+  test("logout drops the widget snapshot", async () => {
+    await useAuthStore.getState().logout();
+
+    expect(clearWidgetSnapshotMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("gateway logout drops the widget snapshot", async () => {
+    mockIsGatewayAuth = true;
+    mockGatewayToken = "access-token";
+    useAuthStore.setState({ sessionStatus: "authenticated" });
+
+    await useAuthStore.getState().logout();
+
+    expect(clearWidgetSnapshotMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("the drop completes before the session leaves authenticated", async () => {
+    // The state write is what hands a signed-out page to its redirect, which
+    // on the logout path can be a hard navigation. A detached bridge call
+    // would race that teardown.
+    let statusAtClearTime = useAuthStore.getState().sessionStatus;
+    clearWidgetSnapshotMock.mockImplementationOnce(async () => {
+      statusAtClearTime = useAuthStore.getState().sessionStatus;
+    });
+    useAuthStore.setState({ sessionStatus: "authenticated" });
+
+    await useAuthStore.getState().logout();
+
+    expect(statusAtClearTime).toBe("authenticated");
+    expect(useAuthStore.getState().sessionStatus).toBe("unauthenticated");
+  });
+
+  test("a settled 401 on refreshSession drops the widget snapshot", async () => {
+    // The revoked-session path: no logout call ever runs, so this is the one
+    // chance to drop the previous account's conversation titles.
+    mockIsLocalClient = false;
+    mockPlatformAssistants = [];
+    sessionUser = null;
+    useAuthStore.setState({
+      sessionStatus: "authenticated",
+      platformSession: "present",
+    });
+
+    await expect(useAuthStore.getState().refreshSession()).resolves.toBe(false);
+
+    expect(useAuthStore.getState().sessionStatus).toBe("unauthenticated");
+    expect(clearWidgetSnapshotMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("a failed remote-gateway refresh drops the widget snapshot", async () => {
+    mockIsRemoteGatewayMode = true;
+    useAuthStore.setState({ ...authenticatedLocalUserForTest() });
+
+    await expect(useAuthStore.getState().refreshSession()).resolves.toBe(false);
+
+    expect(clearWidgetSnapshotMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("a boot probe that finds no session drops the widget snapshot", async () => {
+    sessionUser = null;
+
+    await useAuthStore.getState().initSession();
+
+    expect(useAuthStore.getState().sessionStatus).toBe("unauthenticated");
+    expect(clearWidgetSnapshotMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("an inconclusive probe keeps the session and the widget snapshot", async () => {
+    // Offline resume (LUM-2412): the session never ended, so blanking the
+    // widgets would be a regression, not a cleanup.
+    getSessionThrows = true;
+    useAuthStore.setState({
+      sessionStatus: "authenticated",
+      platformSession: "present",
+    });
+
+    await expect(useAuthStore.getState().refreshSession()).resolves.toBe(true);
+
+    expect(clearWidgetSnapshotMock).not.toHaveBeenCalled();
+  });
+
+  test("a local session that survives a settled 401 keeps the widget snapshot", async () => {
+    // The demotion path drops the platform user but not the session, so the
+    // local assistant's conversations are still the user's own.
+    mockIsLocalClient = true;
+    mockIsGatewayAuth = false;
+    mockGatewayToken = null;
+    mockPlatformAssistants = [];
+    sessionUser = null;
+    useAuthStore.setState({
+      sessionStatus: "authenticated",
+      platformSession: "unknown",
+    });
+
+    await expect(useAuthStore.getState().refreshSession()).resolves.toBe(true);
+
+    expect(useAuthStore.getState().sessionStatus).toBe("authenticated");
+    expect(clearWidgetSnapshotMock).not.toHaveBeenCalled();
   });
 });
 

--- a/clients/web/src/stores/auth-store.test.ts
+++ b/clients/web/src/stores/auth-store.test.ts
@@ -331,6 +331,7 @@ const clearWidgetSnapshotMock = mock(async () => {});
 mock.module("@/runtime/widget-snapshot", () => ({
   WIDGET_SNAPSHOT_SCHEMA_VERSION: 1,
   isWidgetSnapshotSyncAvailable: () => false,
+  readWidgetSnapshotAssistantId: () => null,
   syncWidgetSnapshot: async () => {},
   clearWidgetSnapshot: clearWidgetSnapshotMock,
 }));

--- a/clients/web/src/stores/auth-store.test.ts
+++ b/clients/web/src/stores/auth-store.test.ts
@@ -1791,6 +1791,43 @@ describe("iOS widget snapshot on session end", () => {
     expect(clearWidgetSnapshotMock).toHaveBeenCalledTimes(1);
   });
 
+  test("an exhausted gateway prime drops the widget snapshot", async () => {
+    // Boot ends the authenticated session after the startup-retry budget is
+    // spent, so the previous session's titles must not survive on the Home
+    // Screen while the app shows the recovery controls.
+    mockIsLocalClient = true;
+    mockIsGatewayAuth = true;
+    mockPrimeError = new Error("Gateway token request failed: 401");
+
+    await useAuthStore.getState().initSession();
+
+    expect(useAuthStore.getState().sessionStatus).toBe("unauthenticated");
+    expect(clearWidgetSnapshotMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("the exhausted gateway prime leaves the platform probe unsettled", async () => {
+    // The snapshot drop must not drag the rest of the `sessionEnded()`
+    // transition along: writing `platformSession: "absent"` here would settle
+    // the probe on a value the follow-up probe is about to replace.
+    mockIsLocalClient = true;
+    mockIsGatewayAuth = true;
+    mockPrimeError = new Error("Gateway token request failed: 401");
+    sessionUser = { id: "user-1", email: "user@example.com" };
+    useAuthStore.setState({ platformSession: "unknown" });
+
+    const gates: Array<() => void> = [];
+    getSessionGates = gates;
+
+    await useAuthStore.getState().initSession();
+
+    expect(useAuthStore.getState().platformSession).toBe("unknown");
+
+    gates[0]?.();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(useAuthStore.getState().platformSession).toBe("present");
+  });
+
   test("an inconclusive probe keeps the session and the widget snapshot", async () => {
     // Offline resume (LUM-2412): the session never ended, so blanking the
     // widgets would be a regression, not a cleanup.

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -34,6 +34,7 @@ import {
   readUserSnapshot,
 } from "@/lib/auth/user-snapshot";
 import { getElectronSessionToken } from "@/runtime/session-token";
+import { clearWidgetSnapshot } from "@/runtime/widget-snapshot";
 import {
   isGatewayAuthEnabled,
   isGatewayAuthMode,
@@ -1186,6 +1187,13 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
   },
 
   logout: async () => {
+    // Drop the iOS widget snapshot first, ahead of both branches below: a
+    // Home Screen widget is readable without unlocking the device, so the
+    // previous account's conversation titles must not outlive the session.
+    // Awaited rather than fired and forgotten because a logout that ends in
+    // a hard navigation can tear the page down before a detached bridge call
+    // reaches the shell. No-op off Capacitor iOS.
+    await clearWidgetSnapshot();
     if (isGatewayAuthMode()) {
       // Clear lifecycle state BEFORE `sessionStatus` leaves `authenticated`
       // so the assistant sync hooks don't observe a stale assistant id in

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -225,6 +225,28 @@ const sessionEnded = (): Partial<AuthState> => ({
 });
 
 /**
+ * Apply the {@link sessionEnded} transition. Every path that ends a session
+ * goes through here, not through a bare `set(sessionEnded())`, because a
+ * session ends far more often without an explicit `logout()` than with one:
+ * a revoked or expired session settles through `refreshSession`'s 401 branch,
+ * and a boot that finds no session settles through `initSession`.
+ *
+ * The one thing that has to happen off-store is dropping the iOS widget
+ * snapshot. A Home Screen widget is readable without unlocking the device, so
+ * the previous account's conversation titles must not outlive the session that
+ * produced them, whichever way it ended. No-op off Capacitor iOS.
+ *
+ * Awaited BEFORE the state write: the write is what flips signed-in surfaces
+ * to the login screen, and on the logout path that can end in a hard
+ * navigation that tears the page down before a detached bridge call would
+ * reach the shell.
+ */
+async function endSession(set: AuthSet): Promise<void> {
+  await clearWidgetSnapshot();
+  set(sessionEnded());
+}
+
+/**
  * A `getSession()` outcome that says nothing about the session itself —
  * the request threw (fetch rejection), never completed, or failed for a
  * non-auth reason (429 rate limiting, 5xx outages, the Electron proxy's
@@ -862,7 +884,7 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
       if (await hasRemoteGatewaySessionAfterRefresh()) {
         set({ ...authenticatedLocalUser(), platformSession: "absent" });
       } else {
-        set(sessionEnded());
+        await endSession(set);
       }
       return;
     }
@@ -921,7 +943,7 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
         } else {
           clearUserSnapshot();
         }
-        set(sessionEnded());
+        await endSession(set);
         return;
       }
       set(authenticatedLocalUser());
@@ -990,7 +1012,7 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
     if (!isInconclusiveProbe(result)) {
       clearUserSnapshot();
     }
-    set(sessionEnded());
+    await endSession(set);
   },
 
   /**
@@ -1088,7 +1110,7 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
         set({ ...authenticatedLocalUser(), platformSession: "absent" });
         return true;
       }
-      set(sessionEnded());
+      await endSession(set);
       return false;
     }
 
@@ -1106,7 +1128,7 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
         }
         set({ sessionStatus: "authenticated" });
       } catch {
-        set(sessionEnded());
+        await endSession(set);
         return false;
       }
       probePlatformSessionIfReachable(set, { clearOnFailure: true });
@@ -1182,18 +1204,11 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
     }
     clearUserSnapshot();
     await syncUserScopedState(null);
-    set(sessionEnded());
+    await endSession(set);
     return false;
   },
 
   logout: async () => {
-    // Drop the iOS widget snapshot first, ahead of both branches below: a
-    // Home Screen widget is readable without unlocking the device, so the
-    // previous account's conversation titles must not outlive the session.
-    // Awaited rather than fired and forgotten because a logout that ends in
-    // a hard navigation can tear the page down before a detached bridge call
-    // reaches the shell. No-op off Capacitor iOS.
-    await clearWidgetSnapshot();
     if (isGatewayAuthMode()) {
       // Clear lifecycle state BEFORE `sessionStatus` leaves `authenticated`
       // so the assistant sync hooks don't observe a stale assistant id in
@@ -1208,7 +1223,7 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
       clearGatewayToken();
       clearOrganization();
       clearUserScopedStorage();
-      set(sessionEnded());
+      await endSession(set);
       broadcastAuthChange();
       return;
     }
@@ -1241,7 +1256,7 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
       // removed the persisted key, and a surviving slice would resolve the
       // previous user's assistant after re-login.
       await setSelectedAssistant(null);
-      set(sessionEnded());
+      await endSession(set);
       broadcastAuthChange();
     }
   },

--- a/clients/web/src/stores/auth-store.ts
+++ b/clients/web/src/stores/auth-store.ts
@@ -240,10 +240,24 @@ const sessionEnded = (): Partial<AuthState> => ({
  * to the login screen, and on the logout path that can end in a hard
  * navigation that tears the page down before a detached bridge call would
  * reach the shell.
+ *
+ * `keepPlatformSession` omits the `platformSession: "absent"` half of the
+ * transition for the one caller that ends the session with a platform probe
+ * still in flight. Writing `"absent"` there would settle
+ * {@link isPlatformSessionSettled} on a value the probe is about to replace,
+ * and consumers that gate on the settle (the billing tab rewrite,
+ * `usePlatformGate`) would act on it. The snapshot drop is unconditional.
  */
-async function endSession(set: AuthSet): Promise<void> {
+async function endSession(
+  set: AuthSet,
+  options?: { keepPlatformSession?: boolean },
+): Promise<void> {
   await clearWidgetSnapshot();
-  set(sessionEnded());
+  set(
+    options?.keepPlatformSession
+      ? { sessionStatus: "unauthenticated", user: null }
+      : sessionEnded(),
+  );
 }
 
 /**
@@ -902,7 +916,7 @@ const useAuthStoreBase = create<AuthStore>()((set, get) => ({
       } catch {
         // Gateway prime failed: settle to unauthenticated but leave
         // `platformSession` for the follow-up probe to resolve.
-        set({ sessionStatus: "unauthenticated", user: null });
+        await endSession(set, { keepPlatformSession: true });
       }
       probePlatformSessionIfReachable(set);
       return;


### PR DESCRIPTION
## Summary
- Adds runtime/widget-snapshot.ts bridge to the iOS WidgetSnapshot plugin (skew-safe no-op on shells without it)
- Adds useNativeWidgetSnapshotSync mounted in ChatLayout: unread count, in-progress count, top-3 conversations, deduped excluding generatedAt
- Clears the snapshot on sign-out

Part of plan: ios-widgets.md (PR 3 of 7)