### PR TITLE
feat(ios): WidgetSnapshot plugin caching conversation summary in the App Group

### DIFF
--- a/clients/ios/App/App/MyViewController.swift
+++ b/clients/ios/App/App/MyViewController.swift
@@ -169,6 +169,7 @@ class MyViewController: CAPBridgeViewController {
         bridge?.registerPluginInstance(ApnsEnvironmentPlugin())
         bridge?.registerPluginInstance(SelfHostedServersPlugin())
         bridge?.registerPluginInstance(RecentChatsPlugin())
+        bridge?.registerPluginInstance(WidgetSnapshotPlugin())
         installNavigationDelegateProxy()
         installInputZoomPreventionUserScript()
         installViewportZoomLockUserScript()

--- a/clients/ios/App/App/Shared/AppGroupID.swift
+++ b/clients/ios/App/App/Shared/AppGroupID.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// The App Group container this build target shares with its sibling bundles,
+/// resolved from its own bundle rather than hardcoded.
+///
+/// Each environment sets `APP_GROUP_ID` in its xcconfig
+/// (`group.ai.vocify-inc.vellum-assistant-ios`, `...-ios.staging`,
+/// `...-ios.dev`), so a hardcoded literal would point a Dev or Staging build
+/// at the production container and let one environment read another's data.
+///
+/// Shared by the app target and the VoiceActivity widget extension so there is
+/// one implementation. Both read the same ``infoPlistKey`` string, populated
+/// from the very same `$(APP_GROUP_ID)` variable that reaches their
+/// entitlements plists: the entitlement is what actually grants access, but it
+/// is not readable from Swift, so the value is restated in Info.plist for code
+/// to resolve at runtime.
+///
+/// ``current`` is deliberately optional, mirroring ``BundleURLScheme``: there
+/// is no safe universal fallback. A build that ships no group id cannot open a
+/// container, and naming another environment's group would only trade a no-op
+/// for cross-environment data mixing. Each caller decides explicitly; the one
+/// caller today, ``WidgetSnapshotStore``, degrades to doing nothing.
+enum AppGroupID {
+    /// Info.plist key carrying the group id, restated from the entitlement.
+    static let infoPlistKey = "VellumAppGroupId"
+
+    /// The group for the currently running bundle, or `nil` when the bundle
+    /// declares none. See the type docs for why there is no default.
+    static let current: String? = resolve(in: .main)
+
+    static func resolve(in bundle: Bundle) -> String? {
+        (bundle.infoDictionary?[infoPlistKey] as? String).flatMap(substituted)
+    }
+
+    /// Rejects an empty value and one Xcode never expanded (`$(APP_GROUP_ID)`),
+    /// both of which would otherwise resolve to a suite nothing can reach.
+    private static func substituted(_ raw: String) -> String? {
+        guard !raw.isEmpty, !raw.contains("$") else { return nil }
+        return raw
+    }
+}

--- a/clients/ios/App/App/Shared/WidgetSnapshot.swift
+++ b/clients/ios/App/App/Shared/WidgetSnapshot.swift
@@ -1,0 +1,120 @@
+import Foundation
+
+/// One conversation of the widget snapshot: just enough to render a Home
+/// Screen row and to deep-link into the conversation it names.
+///
+/// `subtitle` is the conversation's group name, absent when it belongs to no
+/// group. `lastMessageAt` is absent for a conversation that has none.
+struct WidgetSnapshotConversation: Codable, Equatable {
+    let id: String
+    let title: String
+    let subtitle: String?
+    let lastMessageAt: Date?
+    let hasUnseen: Bool
+    let isProcessing: Bool
+}
+
+/// Everything the Home Screen knows about the signed-in user's conversations:
+/// two counts and the few most recent threads, as of `generatedAt`.
+struct WidgetSnapshot: Codable, Equatable {
+    /// Version of the stored shape. `WidgetSnapshotStore` refuses a blob
+    /// carrying any other value, so a field this build cannot make sense of
+    /// reads as no snapshot rather than as a half-decoded one.
+    static let currentSchemaVersion = 1
+
+    let schemaVersion: Int
+    let generatedAt: Date
+    let unreadCount: Int
+    let inProgressCount: Int
+    let conversations: [WidgetSnapshotConversation]
+}
+
+/// The `kind` string each Vellum widget registers under, and the identifier
+/// `WidgetCenter.reloadTimelines(ofKind:)` names to refresh it. Both sides
+/// read them from here so a rename cannot desynchronize a widget from the
+/// reload that is supposed to reach it.
+enum VellumWidgetKind {
+    static let catchUp = "VellumCatchUp"
+    static let status = "VellumStatus"
+    static let quickActions = "VellumQuickActions"
+
+    /// All of them, for a writer to reload: every kind renders from the one
+    /// snapshot, so a write invalidates all three.
+    static let all = [catchUp, status, quickActions]
+}
+
+/// App Group UserDefaults cache of the widget snapshot, written by
+/// `WidgetSnapshotPlugin` whenever the web layer's conversation summary
+/// changes, and readable from the VoiceActivity extension.
+///
+/// A cache is the only workable data source there: the conversation list lives
+/// in the SPA and its server, and the extension process has no network stack,
+/// no auth, and no way to run the SPA. Staleness is bounded by how recently
+/// the app was open, and the snapshot carries only display data (ids, titles,
+/// group names, counts, timestamps), never a credential.
+///
+/// The suite is the App Group rather than `UserDefaults.standard` because the
+/// appex is a different bundle with a different container. `AppGroupID.current`
+/// is per environment, so the Dev / Staging / production apps each keep their
+/// own snapshot, matching their separate origins. A nil group id, or an
+/// entitlement the running build cannot satisfy, makes every method here a
+/// silent no-op rather than a failure: reading nothing is a degradation, and
+/// neither the app nor the appex has an error path worth taking on a surface
+/// the user never asked to interact with.
+///
+/// ## Cache boundary
+///
+/// Unlike `RecentChatsStore`, which deliberately holds its cache across
+/// sign-out, this one is clearable and `WidgetSnapshotPlugin` exposes `clear`
+/// for the web layer to call. The difference is where the data is read: a
+/// Shortcuts picker opens only when someone drives the app, while a Home
+/// Screen widget renders whenever the screen lights up, including on a locked
+/// device. Conversation titles belonging to an account that is no longer
+/// signed in must not outlive the session on a surface like that.
+enum WidgetSnapshotStore {
+    static let defaultsKey = "widgetSnapshot"
+
+    private static var defaults: UserDefaults? {
+        AppGroupID.current.flatMap(UserDefaults.init(suiteName:))
+    }
+
+    /// One date strategy for both directions, so the blob a writer produces is
+    /// the blob a reader can decode.
+    private static let encoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }()
+
+    private static let decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }()
+
+    static func save(_ snapshot: WidgetSnapshot) {
+        guard let defaults, let data = try? encoder.encode(snapshot) else {
+            return
+        }
+        defaults.set(data, forKey: defaultsKey)
+    }
+
+    /// The stored snapshot, or `nil` when the app has never synced, when the
+    /// blob fails to decode, or when it was written against a different
+    /// schema version. All three read as no snapshot rather than as an error:
+    /// the reader falls back to its empty state and the next sync rewrites
+    /// the blob.
+    static func load() -> WidgetSnapshot? {
+        guard let data = defaults?.data(forKey: defaultsKey),
+              let snapshot = try? decoder.decode(WidgetSnapshot.self, from: data),
+              snapshot.schemaVersion == WidgetSnapshot.currentSchemaVersion
+        else {
+            return nil
+        }
+        return snapshot
+    }
+
+    static func clear() {
+        defaults?.removeObject(forKey: defaultsKey)
+    }
+}

--- a/clients/ios/App/App/WidgetSnapshotPlugin.swift
+++ b/clients/ios/App/App/WidgetSnapshotPlugin.swift
@@ -1,0 +1,104 @@
+import Capacitor
+import Foundation
+import WidgetKit
+
+/// Capacitor plugin the web layer uses to mirror a small conversation summary
+/// (two counts and the most recent threads) into `WidgetSnapshotStore`, the
+/// App Group cache the VoiceActivity extension can read.
+///
+/// Two methods:
+/// - `sync({ generatedAt, unreadCount, inProgressCount, conversations })`
+///   replaces the whole snapshot. Full replacement rather than a diff keeps
+///   the contract trivial: the web side owns ordering and membership, and a
+///   sync after archiving or reading a thread needs no tombstones.
+/// - `clear()` drops it, for sign-out. See `WidgetSnapshotStore`'s cache
+///   boundary for why this store, unlike `RecentChatsStore`, has one.
+///
+/// The payload's own version field is not read. The shell re-encodes into its
+/// own model, so what lands in the store is a `currentSchemaVersion` blob by
+/// construction and a field this build does not know is simply dropped.
+///
+/// Malformed conversation entries are dropped rather than rejecting the call:
+/// a partial summary beats none, and the web producer already shapes the
+/// payload. Per the skew rule in `clients/web/docs/CAPACITOR.md`, the one
+/// result shape (`{ok: true}`) covers every state, including an empty payload.
+@objc(WidgetSnapshotPlugin)
+public class WidgetSnapshotPlugin: CAPPlugin, CAPBridgedPlugin {
+    public let identifier = "WidgetSnapshotPlugin"
+    public let jsName = "WidgetSnapshot"
+    public let pluginMethods: [CAPPluginMethod] = [
+        CAPPluginMethod(name: "sync", returnType: CAPPluginReturnPromise),
+        CAPPluginMethod(name: "clear", returnType: CAPPluginReturnPromise),
+    ]
+
+    /// The snapshot contract's ceiling. The web side already sends at most
+    /// this many; clamping here keeps a misbehaving caller from growing the
+    /// shared container without limit.
+    private static let maxConversations = 3
+
+    @objc public func sync(_ call: CAPPluginCall) {
+        let conversations = (call.getArray("conversations") ?? [])
+            .compactMap(Self.conversation(from:))
+            .prefix(Self.maxConversations)
+        let snapshot = WidgetSnapshot(
+            schemaVersion: WidgetSnapshot.currentSchemaVersion,
+            // The producer owns `generatedAt`; receipt time stands in only
+            // when the payload carries no parseable timestamp, so the stored
+            // value is always a real instant.
+            generatedAt: Self.date(from: call.getString("generatedAt")) ?? Date(),
+            unreadCount: max(0, call.getInt("unreadCount") ?? 0),
+            inProgressCount: max(0, call.getInt("inProgressCount") ?? 0),
+            conversations: Array(conversations)
+        )
+        WidgetSnapshotStore.save(snapshot)
+        Self.reloadWidgets()
+        call.resolve(["ok": true])
+    }
+
+    @objc public func clear(_ call: CAPPluginCall) {
+        WidgetSnapshotStore.clear()
+        Self.reloadWidgets()
+        call.resolve(["ok": true])
+    }
+
+    private static func conversation(from item: Any) -> WidgetSnapshotConversation? {
+        guard let dict = item as? [String: Any],
+              let id = dict["id"] as? String, !id.isEmpty,
+              let title = dict["title"] as? String, !title.isEmpty
+        else {
+            return nil
+        }
+        return WidgetSnapshotConversation(
+            id: id,
+            title: title,
+            subtitle: (dict["subtitle"] as? String).flatMap { $0.isEmpty ? nil : $0 },
+            lastMessageAt: date(from: dict["lastMessageAt"] as? String),
+            hasUnseen: dict["hasUnseen"] as? Bool ?? false,
+            isProcessing: dict["isProcessing"] as? Bool ?? false
+        )
+    }
+
+    /// JavaScript's `toISOString()` always carries milliseconds, which the
+    /// plain internet-date-time parser rejects outright, so both shapes are
+    /// tried before giving up.
+    private static func date(from raw: String?) -> Date? {
+        guard let raw, !raw.isEmpty else { return nil }
+        return fractionalSecondsFormatter.date(from: raw) ?? wholeSecondsFormatter.date(from: raw)
+    }
+
+    private static let fractionalSecondsFormatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+
+    private static let wholeSecondsFormatter = ISO8601DateFormatter()
+
+    /// Every kind renders from the one snapshot, so a write invalidates all of
+    /// them. `reloadTimelines` on a kind no widget is showing is a no-op.
+    private static func reloadWidgets() {
+        for kind in VellumWidgetKind.all {
+            WidgetCenter.shared.reloadTimelines(ofKind: kind)
+        }
+    }
+}

--- a/clients/ios/README.md
+++ b/clients/ios/README.md
@@ -43,11 +43,12 @@ which URL is baked into the build.
   process. With `server.url`, only native shell changes (Swift code,
   entitlements, Capacitor plugin updates) require a store submission.
 - **Thin native surface** - the IPC bridge between the WKWebView and
-  native code is minimal (seven app-local plugins: `NativeAuthPlugin`,
+  native code is minimal (eight app-local plugins: `NativeAuthPlugin`,
   `NativeBiometricPlugin`, `VoiceAudioSessionPlugin`,
   `VoiceLiveActivityPlugin`, `ApnsEnvironmentPlugin`,
-  `SelfHostedServersPlugin`, and `RecentChatsPlugin`, plus the
-  auto-discovered community camera preview dependency), so version skew risk between the web app and native
+  `SelfHostedServersPlugin`, `RecentChatsPlugin`, and
+  `WidgetSnapshotPlugin`, plus the auto-discovered community camera
+  preview dependency), so version skew risk between the web app and native
   shell is low. Every plugin call from the web side must still have a
   working missing-plugin fallback because a new web bundle always ships
   ahead of the shell that hosts it. Contrast
@@ -152,7 +153,7 @@ Apple's reference for the toolbar controls:
 
 The app has two layers: the **WKWebView contents** (the React app loaded
 from the configured server URL) and the **native Swift shell** (Capacitor
-bridge, `MyViewController`, the seven app-local plugins, and linked package
+bridge, `MyViewController`, the eight app-local plugins, and linked package
 plugins such as `CameraPreview`). Each has its own
 debugger.
 

--- a/clients/web/docs/CAPACITOR.md
+++ b/clients/web/docs/CAPACITOR.md
@@ -169,7 +169,7 @@ References:
 
 Live voice is a web feature with native accessories. The session, including mic capture, the velay socket, TTS playback, and every user-facing string, lives under `src/domains/chat/voice/live-voice/`. iOS adds interruption reporting, a Dynamic Island and Lock Screen presence, and App Intents. Android adds foreground audio focus, a microphone foreground service, and an ongoing status notification. The voice-room camera is the capture exception: native mobile shells use `@capacitor-community/camera-preview`, while browsers and older shells use a web `MediaStream` fallback.
 
-The shell registers **seven app-local** Capacitor plugins in [`MyViewController.capacitorDidLoad()`](../../../clients/ios/App/App/MyViewController.swift) (count them there, not from prose). `CameraPreview` is an external SPM/Gradle dependency that Capacitor discovers automatically, so it is not registered in that method.
+The shell registers **eight app-local** Capacitor plugins in [`MyViewController.capacitorDidLoad()`](../../../clients/ios/App/App/MyViewController.swift) (count them there, not from prose). `CameraPreview` is an external SPM/Gradle dependency that Capacitor discovers automatically, so it is not registered in that method.
 
 | Plugin | Web module | What it does |
 | --- | --- | --- |
@@ -180,6 +180,7 @@ The shell registers **seven app-local** Capacitor plugins in [`MyViewController.
 | `ApnsEnvironment` | [`src/runtime/apns-environment.ts`](../src/runtime/apns-environment.ts) | The build's real APNs entitlement environment (`development` / `production` / `unknown`), read from the embedded provisioning profile |
 | `SelfHostedServers` | [`src/runtime/self-hosted-servers.ts`](../src/runtime/self-hosted-servers.ts) | List, add, remove, and switch between self-hosted server origins; `switchTo` swaps the shell's configured origin and reloads without leaving the app. See the section below |
 | `RecentChats` | [`src/runtime/recent-chats.ts`](../src/runtime/recent-chats.ts) | Mirrors the sidebar conversation list (ids + titles) into a UserDefaults cache that backs the Shortcuts app's chat picker (`ChatEntityQuery`); synced from `ChatLayout` once the list query has resolved |
+| `WidgetSnapshot` | `src/runtime/widget-snapshot.ts` | Mirrors a conversation summary (unread and in-progress counts plus the three most recent threads) into App Group UserDefaults for the Home Screen widgets, reloading their timelines after each write. `sync` replaces the whole snapshot; `clear` drops it, so a signed-out account's titles do not outlive the session on a surface that renders without unlocking the app |
 
 The two voice plugins are consumed only through `use-live-voice-session-controller.ts` (audio session) and `use-live-activity-mirror.ts` (Live Activity), both mounted at `ChatLayout` scope so their lifetime is exactly the session's.
 


### PR DESCRIPTION
## Summary
- Adds AppGroupID resolver and the appex-safe WidgetSnapshot models, store, and widget kind identifiers in App/Shared
- Adds WidgetSnapshotPlugin (sync/clear) writing App Group UserDefaults and reloading widget timelines, registered in MyViewController
- Documents the plugin in CAPACITOR.md

Part of plan: ios-widgets.md (PR 2 of 7)