### PR TITLE
refactor(assistant): remove dead per-run model pin

### DIFF
--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -541,12 +541,6 @@ interface AgentLoopRunOptionsBase {
   onEvent: (event: AgentEvent) => void | Promise<void>;
   signal?: AbortSignal;
   requestId: string;
-  /**
-   * Explicit model override (provider/model string) for every LLM call in
-   * this run. When omitted, the model is resolved through the normal
-   * call-site / profile resolution path.
-   */
-  model?: string;
   onCheckpoint?: (
     checkpoint: CheckpointInfo,
   ) => CheckpointDecision | Promise<CheckpointDecision>;
@@ -1049,7 +1043,6 @@ export class AgentLoop {
       resolveOverrideProfile,
       compactInPlace = false,
       isNonInteractive = false,
-      model: runModel,
       latencyTracker,
     } = options;
     // Snapshot the system prompt once per run. The instance field is mutable
@@ -1421,11 +1414,10 @@ export class AgentLoop {
           : resolvedTools;
 
         // Field precedence (highest wins):
-        //   1. Per-run explicit (`runModel`)
-        //   2. Call-site resolved values (filled by
+        //   1. Call-site resolved values (filled by
         //      `RetryProvider.normalizeSendMessageOptions` from
         //      `resolveCallSiteConfig(callSite, llm)`)
-        //   3. Conversation defaults (`this.config.*`, from the resolved
+        //   2. Conversation defaults (`this.config.*`, from the resolved
         //      default call-site config)
         //
         // When `callSite` is present we deliberately leave
@@ -1441,10 +1433,6 @@ export class AgentLoop {
 
         if (!callSite) {
           providerConfig.max_tokens = this.config.maxTokens;
-        }
-
-        if (runModel) {
-          providerConfig.model = runModel;
         }
 
         if (!callSite) {

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -426,11 +426,6 @@ function normalizeSendMessageOptions(
       selectionSeed: config.selectionSeed,
     });
 
-    const explicitModel =
-      typeof config.model === "string" && config.model.trim().length > 0
-        ? config.model.trim()
-        : undefined;
-
     // Routing key is consumed by the resolver above and must not leak
     // downstream as a wire-format field.
     delete nextConfig.callSite;
@@ -455,7 +450,11 @@ function normalizeSendMessageOptions(
     }
 
     // Apply resolved values, letting per-call explicit fields win where set.
-    nextConfig.model = explicitModel ?? resolved.model;
+    // `model` has no explicit-field escape hatch: the last producer (the
+    // agent loop's per-run `model` option) was removed as dead code, and a
+    // caller-set model would graft one model's id onto another model's
+    // resolved parameters. Call-site/profile resolution alone decides it.
+    nextConfig.model = resolved.model;
     if (nextConfig.max_tokens === undefined) {
       nextConfig.max_tokens = resolved.maxTokens;
     }

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -450,10 +450,10 @@ function normalizeSendMessageOptions(
     }
 
     // Apply resolved values, letting per-call explicit fields win where set.
-    // `model` has no explicit-field escape hatch: the last producer (the
-    // agent loop's per-run `model` option) was removed as dead code, and a
-    // caller-set model would graft one model's id onto another model's
-    // resolved parameters. Call-site/profile resolution alone decides it.
+    // `model` has no explicit-field escape hatch: call-site/profile
+    // resolution is the sole source of the model, because a caller-set model
+    // would graft one model's id onto another model's resolved parameters
+    // (thinking encoding, token budgets, and effort mapping are per-model).
     nextConfig.model = resolved.model;
     if (nextConfig.max_tokens === undefined) {
       nextConfig.max_tokens = resolved.maxTokens;


### PR DESCRIPTION
## Why

The agent loop's `model` run option is a legacy escape hatch from the original assistant scaffolding, predating the inference profile system. A sweep found no remaining producer:

- Both live `loop.run()` callers (workflow leaf runner, agent wake) pass `overrideProfile`, the profile-shaped override.
- No test passes `model` as a run option.
- No send path sets `config.model` alongside a `callSite` (the compactor passes `callSite` + `overrideProfile` only), so the `explicitModel` precedence branch in `normalizeSendMessageOptions` had no producer either.

Beyond being dead, the pin was hazardous: a bare model id grafted one model's name onto another model's resolved parameters (thinking encoding, token budgets, effort mapping are per-model), and it would have resent a dead model during the upcoming managed-profile fallback work (see the Fallbacks design doc / plan). Removing it at the source simplifies that series.

## What

- Drop `model?: string` from `AgentLoopRunOptionsBase`, the `runModel` destructure, and the `providerConfig.model = runModel` assignment in `assistant/src/agent/loop.ts`; update the field-precedence comment.
- Drop the `explicitModel ?? resolved.model` branch in `normalizeSendMessageOptions` (`assistant/src/providers/retry.ts`); model choice now flows exclusively through call-site/profile resolution, with a comment explaining why no explicit-field escape hatch exists for `model`.

No behavior change for any existing caller.

## Checks

- `bun run typecheck:fast` clean
- `bun run lint` clean
- `bun test` on retry + agent-loop suites: 103 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LdboqoEn3ZtHxqeYfZvvz1
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41162" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->