### PR TITLE
feat(providers): add fallback-route escalation to RetryProvider

### DIFF
--- a/assistant/src/__tests__/provider-usage-tracking.test.ts
+++ b/assistant/src/__tests__/provider-usage-tracking.test.ts
@@ -164,6 +164,62 @@ describe("UsageTrackingProvider", () => {
     });
   });
 
+  test("attributes a fallback-served response to the stamped backup profile", async () => {
+    // RetryProvider's fallback escalation stamps `actualProvider` and
+    // `actualInferenceProfile` on the response it serves from the backup
+    // route. The usage event must follow those stamps, not the original
+    // request options, which still carry the failed primary's resolution.
+    setLlmConfig({
+      profiles: {
+        balanced: {
+          provider: "openai",
+          model: "gpt-5.4-mini",
+        },
+        "backup-profile": {
+          provider: "anthropic",
+          model: "claude-sonnet-4-5",
+        },
+      },
+      activeProfile: "balanced",
+      callSites: {
+        conversationTitle: { profile: "balanced" },
+      },
+      pricingOverrides: [],
+    });
+
+    const provider = new UsageTrackingProvider(
+      makeProvider({
+        content: [{ type: "text", text: "Title" }],
+        model: "claude-sonnet-4-5",
+        actualProvider: "anthropic",
+        actualInferenceProfile: "backup-profile",
+        usage: {
+          inputTokens: 1_000,
+          outputTokens: 2_000,
+        },
+        stopReason: "end_turn",
+      }),
+    );
+
+    await provider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: "Summarize" }] }],
+      {
+        config: {
+          callSite: "conversationTitle",
+        },
+      },
+    );
+
+    const events = listUsageEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      provider: "anthropic",
+      model: "claude-sonnet-4-5",
+      callSite: "conversationTitle",
+      inferenceProfile: "backup-profile",
+    });
+  });
+
   test("does not record calls without a call site", async () => {
     const provider = new UsageTrackingProvider(
       makeProvider({

--- a/assistant/src/__tests__/retry-fallback-escalation.test.ts
+++ b/assistant/src/__tests__/retry-fallback-escalation.test.ts
@@ -259,6 +259,77 @@ describe("RetryProvider fallback-route escalation", () => {
     expect(result.model).toBe("backup-model");
   });
 
+  test.each(["unknown", undefined] as const)(
+    "404 with reason %s → status fallback applies, backup serves",
+    async (reason) => {
+      const primary = failingProvider(
+        "openai",
+        () =>
+          new ProviderError("not found", "openai", 404, {
+            ...(reason !== undefined ? { reason } : {}),
+          }),
+      );
+      const backup = backupProvider();
+      const route = makeRoute(backup.provider);
+      const wrapped = new RetryProvider(primary.provider, {
+        resolveFallbackRoute: route.resolveFallbackRoute,
+      });
+
+      const result = await wrapped.sendMessage(MESSAGES, {
+        config: { callSite: "mainAgent" },
+      });
+
+      expect(route.calls()).toBe(1);
+      expect(result.model).toBe("backup-model");
+    },
+  );
+
+  test("404 with provider-classified reason model_not_found → falls back immediately", async () => {
+    const primary = failingProvider(
+      "openai",
+      () =>
+        new ProviderError("model not found", "openai", 404, {
+          reason: "model_not_found",
+        }),
+    );
+    const backup = backupProvider();
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    const result = await wrapped.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    expect(primary.calls()).toBe(1);
+    expect(route.calls()).toBe(1);
+    expect(result.model).toBe("backup-model");
+  });
+
+  test("404 with a definitive non-model reason (bad_request) → callback never invoked", async () => {
+    // Anthropic classifies a 404 without a model signal as `bad_request`: a
+    // missing gateway resource or other deterministic request failure. The
+    // provider-stamped semantic reason takes precedence over the raw status,
+    // so the request must surface its real error instead of switching routes.
+    const requestError = new ProviderError("not found", "anthropic", 404, {
+      reason: "bad_request",
+    });
+    const primary = failingProvider("anthropic", () => requestError);
+    const route = makeRoute(backupProvider().provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    const thrown = await captureError(
+      wrapped.sendMessage(MESSAGES, { config: { callSite: "mainAgent" } }),
+    );
+
+    expect(thrown).toBe(requestError);
+    expect(primary.calls()).toBe(1);
+    expect(route.calls()).toBe(0);
+  });
+
   test("managed proxy preflight 400 for a retired model → falls back immediately", async () => {
     const primary = failingProvider(
       "openai",
@@ -451,6 +522,52 @@ describe("RetryProvider fallback-route escalation", () => {
     expect(backup.calls()).toBe(0);
   });
 
+  test("route returned for a mix backup profile → no send on the backup adapter, original error rethrown", async () => {
+    // The fallback schema forbids `fallbackProfile` from referencing a mix,
+    // and RetryProvider must not trust that: a mix backup without a
+    // `selectionSeed` would be re-expanded independently by the apply guard,
+    // the route callback, and the normalization, potentially sending one
+    // arm's model through another arm's provider adapter.
+    setConfig("llm", {
+      profiles: {
+        ...LLM_FIXTURE.profiles,
+        "arm-a": {
+          source: "user",
+          provider: "anthropic",
+          model: "arm-a-model",
+        },
+        "arm-b": {
+          source: "user",
+          provider: "openai",
+          model: "arm-b-model",
+        },
+        "backup-mix": {
+          source: "user",
+          mix: [
+            { profile: "arm-a", weight: 1 },
+            { profile: "arm-b", weight: 1 },
+          ],
+        },
+      },
+      activeProfile: "primary-profile",
+    });
+    const originalError = new ProviderError("model not found", "openai", 404);
+    const primary = failingProvider("openai", () => originalError);
+    const backup = backupProvider();
+    const route = makeRoute(backup.provider, { overrideProfile: "backup-mix" });
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    const thrown = await captureError(
+      wrapped.sendMessage(MESSAGES, { config: { callSite: "mainAgent" } }),
+    );
+
+    expect(thrown).toBe(originalError);
+    expect(route.calls()).toBe(1);
+    expect(backup.calls()).toBe(0);
+  });
+
   test("backup also fails → fallback error rethrown with original as cause, no second fallback attempt", async () => {
     const originalError = new ProviderError("model not found", "openai", 404);
     const primary = failingProvider("openai", () => originalError);
@@ -610,5 +727,51 @@ describe("RetryProvider fallback-route escalation", () => {
     });
 
     expect(result.actualProvider).toBe("openrouter/anthropic");
+  });
+
+  test("fallback response → stamped with the backup profile key so usage tracking attributes it correctly", async () => {
+    // The outer UsageTrackingProvider resolves `inferenceProfile` from the
+    // ORIGINAL request options, which still carry the failed primary's
+    // resolution. The stamp is what lets the usage event bill the fallback
+    // serve under the backup profile.
+    const primary = failingProvider(
+      "openai",
+      () => new ProviderError("model not found", "openai", 404),
+    );
+    const backup = backupProvider();
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    const result = await wrapped.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    expect(result.actualInferenceProfile).toBe("backup-profile");
+  });
+
+  test("fallback response with a wrapper-set actualInferenceProfile → preserved, not overwritten", async () => {
+    const primary = failingProvider(
+      "openai",
+      () => new ProviderError("model not found", "openai", 404),
+    );
+    const backup: Provider = {
+      name: "anthropic",
+      sendMessage: async () => ({
+        ...okResponse("backup-model"),
+        actualInferenceProfile: "inner-specific-profile",
+      }),
+    };
+    const route = makeRoute(backup);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    const result = await wrapped.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    expect(result.actualInferenceProfile).toBe("inner-specific-profile");
   });
 });

--- a/assistant/src/__tests__/retry-fallback-escalation.test.ts
+++ b/assistant/src/__tests__/retry-fallback-escalation.test.ts
@@ -132,7 +132,7 @@ async function captureError(promise: Promise<unknown>): Promise<unknown> {
 
 // ── Tests ───────────────────────────────────────────────────────────────────
 
-describe("RetryProvider — fallback-route escalation", () => {
+describe("RetryProvider fallback-route escalation", () => {
   test("retries exhaust on 503 → callback invoked once, backup serves, headers restamped", async () => {
     const primary = failingProvider(
       "openai",
@@ -202,6 +202,32 @@ describe("RetryProvider — fallback-route escalation", () => {
     expect(route.calls()).toBe(1);
     expect(result.model).toBe("backup-model");
   });
+
+  test.each(["byok", "oauth-subscription", "no-auth", undefined] as const)(
+    "401 invalid_credentials on a %s route → callback never invoked, auth error surfaces",
+    async (credentialSource) => {
+      // The credential eligibility case is restricted to `vellum-managed`
+      // routes. A broken personal credential must surface so the user can
+      // fix it, not silently reroute to a differently billed backup.
+      const authError = new ProviderError("Unauthorized", "openai", 401, {
+        reason: "invalid_credentials",
+      });
+      const primary = failingProvider("openai", () => authError);
+      const route = makeRoute(backupProvider().provider);
+      const wrapped = new RetryProvider(primary.provider, {
+        ...(credentialSource !== undefined ? { credentialSource } : {}),
+        resolveFallbackRoute: route.resolveFallbackRoute,
+      });
+
+      const thrown = await captureError(
+        wrapped.sendMessage(MESSAGES, { config: { callSite: "mainAgent" } }),
+      );
+
+      expect(thrown).toBe(authError);
+      expect(primary.calls()).toBe(1);
+      expect(route.calls()).toBe(0);
+    },
+  );
 
   test("404 model-not-found (non-retryable) → falls back immediately", async () => {
     const primary = failingProvider(
@@ -311,7 +337,7 @@ describe("RetryProvider — fallback-route escalation", () => {
 
   test("explicit config.model pin + outage-shaped error → callback never invoked, original error rethrown", async () => {
     // Per-conversation `modelOverride` is a live feature; a pinned
-    // conversation keeps today's retry-then-error behavior — the fallback
+    // conversation keeps today's retry-then-error behavior. The fallback
     // must never silently serve a different model against an explicit pin.
     const finalError = new ProviderError("Service Unavailable", "openai", 503);
     const primary = failingProvider("openai", () => finalError);
@@ -353,6 +379,66 @@ describe("RetryProvider — fallback-route escalation", () => {
     expect((thrown as { retriesExhausted?: boolean }).retriesExhausted).toBe(
       true,
     );
+  });
+
+  test("route returned for a disabled backup profile → no send on the backup adapter, original error rethrown", async () => {
+    // A disabled override profile is skipped by winner selection, which
+    // would resolve back to the primary profile while the request still
+    // dispatches on the backup adapter (provider/model mismatch). The guard
+    // must refuse the fallback send and surface the original error.
+    setConfig("llm", {
+      ...LLM_FIXTURE,
+      profiles: {
+        ...LLM_FIXTURE.profiles,
+        "backup-profile": {
+          ...LLM_FIXTURE.profiles["backup-profile"],
+          status: "disabled",
+        },
+      },
+    });
+    const originalError = new ProviderError("model not found", "openai", 404);
+    const primary = failingProvider("openai", () => originalError);
+    const backup = backupProvider();
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    const thrown = await captureError(
+      wrapped.sendMessage(MESSAGES, { config: { callSite: "mainAgent" } }),
+    );
+
+    expect(thrown).toBe(originalError);
+    expect(route.calls()).toBe(1);
+    expect(backup.calls()).toBe(0);
+  });
+
+  test("route returned for an incomplete backup profile (no model) → no send on the backup adapter, original error rethrown", async () => {
+    setConfig("llm", {
+      ...LLM_FIXTURE,
+      profiles: {
+        ...LLM_FIXTURE.profiles,
+        "backup-profile": {
+          source: "user",
+          provider: "anthropic",
+        },
+      },
+    });
+    const originalError = new ProviderError("model not found", "openai", 404);
+    const primary = failingProvider("openai", () => originalError);
+    const backup = backupProvider();
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    const thrown = await captureError(
+      wrapped.sendMessage(MESSAGES, { config: { callSite: "mainAgent" } }),
+    );
+
+    expect(thrown).toBe(originalError);
+    expect(route.calls()).toBe(1);
+    expect(backup.calls()).toBe(0);
   });
 
   test("backup also fails → fallback error rethrown with original as cause, no second fallback attempt", async () => {

--- a/assistant/src/__tests__/retry-fallback-escalation.test.ts
+++ b/assistant/src/__tests__/retry-fallback-escalation.test.ts
@@ -1,0 +1,418 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import * as retryUtil from "../util/retry.js";
+
+// Instant sleep so exhausted-retry cases don't wait out real backoff delays;
+// everything else is the real module.
+mock.module("../util/retry.js", () => ({
+  ...retryUtil,
+  sleep: async () => {},
+}));
+
+import type {
+  Message,
+  Provider,
+  ProviderResponse,
+  SendMessageOptions,
+} from "../providers/types.js";
+import { setConfig } from "./helpers/set-config.js";
+
+const { RetryProvider } = await import("../providers/retry.js");
+const { ContextOverflowError } = await import("../providers/types.js");
+const { ProviderError } = await import("../util/errors.js");
+const { DEFAULT_MAX_RETRIES } = await import("../util/retry.js");
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+
+const MESSAGES: Message[] = [
+  { role: "user", content: [{ type: "text", text: "hi" }] },
+];
+
+// Primary route resolves through the active profile; the fallback forces the
+// backup profile via `overrideProfile` + `forceOverrideProfile`, so the
+// backup's model/maxTokens must win on the re-normalized options.
+const LLM_FIXTURE = {
+  profiles: {
+    "primary-profile": {
+      source: "user",
+      provider: "openai",
+      model: "primary-model",
+      maxTokens: 1111,
+    },
+    "backup-profile": {
+      source: "user",
+      provider: "anthropic",
+      model: "backup-model",
+      maxTokens: 2222,
+    },
+  },
+  activeProfile: "primary-profile",
+};
+
+beforeEach(() => {
+  setConfig("llm", LLM_FIXTURE);
+});
+
+function okResponse(model: string): ProviderResponse {
+  return {
+    content: [{ type: "text", text: "ok" }],
+    model,
+    usage: { inputTokens: 1, outputTokens: 1 },
+    stopReason: "end_turn",
+  } as ProviderResponse;
+}
+
+/** Primary stub that always throws `makeError()`. */
+function failingProvider(
+  name: string,
+  makeError: () => unknown,
+): { provider: Provider; calls: () => number } {
+  let calls = 0;
+  const provider: Provider = {
+    name,
+    sendMessage: async () => {
+      calls += 1;
+      throw makeError();
+    },
+  };
+  return { provider, calls: () => calls };
+}
+
+/** Backup stub that records the options it was sent and serves a response. */
+function backupProvider(name = "anthropic"): {
+  provider: Provider;
+  calls: () => number;
+  seenConfig: () => Record<string, unknown>;
+} {
+  let calls = 0;
+  let seen: SendMessageOptions | undefined;
+  const provider: Provider = {
+    name,
+    sendMessage: async (_messages: Message[], options?: SendMessageOptions) => {
+      calls += 1;
+      seen = options;
+      const config = options?.config as Record<string, unknown> | undefined;
+      return okResponse((config?.model as string | undefined) ?? "unresolved");
+    },
+  };
+  return {
+    provider,
+    calls: () => calls,
+    seenConfig: () => (seen?.config ?? {}) as Record<string, unknown>,
+  };
+}
+
+function makeRoute(
+  provider: Provider,
+  overrideProfile = "backup-profile",
+): {
+  resolveFallbackRoute: (
+    failedOptions: SendMessageOptions | undefined,
+  ) => Promise<{ provider: Provider; overrideProfile: string } | null>;
+  calls: () => number;
+} {
+  let calls = 0;
+  return {
+    resolveFallbackRoute: async () => {
+      calls += 1;
+      return { provider, overrideProfile };
+    },
+    calls: () => calls,
+  };
+}
+
+async function captureError(promise: Promise<unknown>): Promise<unknown> {
+  try {
+    await promise;
+  } catch (error) {
+    return error;
+  }
+  throw new Error("expected the promise to reject");
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe("RetryProvider — fallback-route escalation", () => {
+  test("retries exhaust on 503 → callback invoked once, backup serves, headers restamped", async () => {
+    const primary = failingProvider(
+      "openai",
+      () => new ProviderError("Service Unavailable", "openai", 503),
+    );
+    const backup = backupProvider();
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      forwardUsageAttributionHeaders: true,
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    const result = await wrapped.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    // Full retry budget burned on the primary before escalating.
+    expect(primary.calls()).toBe(1 + DEFAULT_MAX_RETRIES);
+    expect(route.calls()).toBe(1);
+    expect(backup.calls()).toBe(1);
+    expect(result.model).toBe("backup-model");
+
+    // The re-normalized options carry the backup profile's resolved values...
+    const config = backup.seenConfig();
+    expect(config.model).toBe("backup-model");
+    expect(config.max_tokens).toBe(2222);
+    // ...with routing keys stripped before the fallback provider sees them.
+    expect(config.callSite).toBeUndefined();
+    expect(config.overrideProfile).toBeUndefined();
+    expect(config.forceOverrideProfile).toBeUndefined();
+    // Usage-attribution headers come from the backup resolution so platform
+    // usage events attribute degraded traffic to the backup profile.
+    const headers = config.usageAttributionHeaders as Record<string, string>;
+    expect(headers["X-Vellum-Inference-Profile"]).toBe("backup-profile");
+    expect(headers["X-Vellum-Resolved-Model"]).toBe("backup-model");
+    expect(headers["X-Vellum-Resolved-Provider"]).toBe("anthropic");
+  });
+
+  test("401 invalid_credentials after refresh fails → falls back without burning the retry budget", async () => {
+    const primary = failingProvider(
+      "openai",
+      () =>
+        new ProviderError("Unauthorized", "openai", 401, {
+          reason: "invalid_credentials",
+        }),
+    );
+    const backup = backupProvider();
+    const route = makeRoute(backup.provider);
+    let refreshCalls = 0;
+    const wrapped = new RetryProvider(primary.provider, {
+      credentialSource: "vellum-managed",
+      refreshCredentialProvider: async () => {
+        refreshCalls += 1;
+        return null;
+      },
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    const result = await wrapped.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    // The existing credential-refresh path ran first; the 401 is
+    // non-retryable, so the primary was attempted exactly once.
+    expect(refreshCalls).toBe(1);
+    expect(primary.calls()).toBe(1);
+    expect(route.calls()).toBe(1);
+    expect(result.model).toBe("backup-model");
+  });
+
+  test("404 model-not-found (non-retryable) → falls back immediately", async () => {
+    const primary = failingProvider(
+      "openai",
+      () => new ProviderError("model not found", "openai", 404),
+    );
+    const backup = backupProvider();
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    const result = await wrapped.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    expect(primary.calls()).toBe(1);
+    expect(route.calls()).toBe(1);
+    expect(result.model).toBe("backup-model");
+  });
+
+  test("managed proxy preflight 400 for a retired model → falls back immediately", async () => {
+    const primary = failingProvider(
+      "openai",
+      () =>
+        new ProviderError(
+          "Model 'gpt-old' is not yet supported on the Vellum hosted service.",
+          "openai",
+          400,
+        ),
+    );
+    const backup = backupProvider();
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    const result = await wrapped.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    expect(primary.calls()).toBe(1);
+    expect(route.calls()).toBe(1);
+    expect(result.model).toBe("backup-model");
+  });
+
+  test("plain 400 (request problem) → callback never invoked", async () => {
+    const primary = failingProvider(
+      "openai",
+      () => new ProviderError("invalid request", "openai", 400),
+    );
+    const route = makeRoute(backupProvider().provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    const thrown = await captureError(
+      wrapped.sendMessage(MESSAGES, { config: { callSite: "mainAgent" } }),
+    );
+
+    expect((thrown as InstanceType<typeof ProviderError>).statusCode).toBe(400);
+    expect(route.calls()).toBe(0);
+  });
+
+  test("context overflow → callback never invoked", async () => {
+    const primary = failingProvider(
+      "openai",
+      () => new ContextOverflowError("prompt too long", "openai"),
+    );
+    const route = makeRoute(backupProvider().provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    const thrown = await captureError(
+      wrapped.sendMessage(MESSAGES, { config: { callSite: "mainAgent" } }),
+    );
+
+    expect(thrown).toBeInstanceOf(ContextOverflowError);
+    expect(primary.calls()).toBe(1);
+    expect(route.calls()).toBe(0);
+  });
+
+  test("caller abort → callback never invoked", async () => {
+    const primary = failingProvider(
+      "openai",
+      () =>
+        new ProviderError("Request was aborted.", "openai", undefined, {
+          abortReason: "user_cancelled",
+        }),
+    );
+    const route = makeRoute(backupProvider().provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    const thrown = await captureError(
+      wrapped.sendMessage(MESSAGES, { config: { callSite: "mainAgent" } }),
+    );
+
+    expect((thrown as InstanceType<typeof ProviderError>).abortReason).toBe(
+      "user_cancelled",
+    );
+    expect(primary.calls()).toBe(1);
+    expect(route.calls()).toBe(0);
+  });
+
+  test("explicit config.model pin + outage-shaped error → callback never invoked, original error rethrown", async () => {
+    // Per-conversation `modelOverride` is a live feature; a pinned
+    // conversation keeps today's retry-then-error behavior — the fallback
+    // must never silently serve a different model against an explicit pin.
+    const finalError = new ProviderError("Service Unavailable", "openai", 503);
+    const primary = failingProvider("openai", () => finalError);
+    const route = makeRoute(backupProvider().provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    const thrown = await captureError(
+      wrapped.sendMessage(MESSAGES, {
+        config: { callSite: "mainAgent", model: "pinned-model" },
+      }),
+    );
+
+    expect(thrown).toBe(finalError);
+    expect(route.calls()).toBe(0);
+    expect((thrown as { retriesExhausted?: boolean }).retriesExhausted).toBe(
+      true,
+    );
+  });
+
+  test("callback returns null (no fallbackProfile) → original error rethrown with retriesExhausted tagging", async () => {
+    const finalError = new ProviderError("Service Unavailable", "openai", 503);
+    const primary = failingProvider("openai", () => finalError);
+    let routeCalls = 0;
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: async () => {
+        routeCalls += 1;
+        return null;
+      },
+    });
+
+    const thrown = await captureError(
+      wrapped.sendMessage(MESSAGES, { config: { callSite: "mainAgent" } }),
+    );
+
+    expect(routeCalls).toBe(1);
+    expect(thrown).toBe(finalError);
+    expect((thrown as { retriesExhausted?: boolean }).retriesExhausted).toBe(
+      true,
+    );
+  });
+
+  test("backup also fails → fallback error rethrown with original as cause, no second fallback attempt", async () => {
+    const originalError = new ProviderError("model not found", "openai", 404);
+    const primary = failingProvider("openai", () => originalError);
+    const fallbackError = new ProviderError("backup down", "anthropic", 500);
+    const backup = failingProvider("anthropic", () => fallbackError);
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    const thrown = await captureError(
+      wrapped.sendMessage(MESSAGES, { config: { callSite: "mainAgent" } }),
+    );
+
+    expect(thrown).toBe(fallbackError);
+    expect((thrown as Error).cause).toBe(originalError);
+    expect(route.calls()).toBe(1);
+    expect(backup.calls()).toBe(1);
+  });
+
+  test("resolveFallbackRoute unset → behavior unchanged (original error rethrown)", async () => {
+    const finalError = new ProviderError("Service Unavailable", "openai", 503);
+    const primary = failingProvider("openai", () => finalError);
+    const wrapped = new RetryProvider(primary.provider);
+
+    const thrown = await captureError(
+      wrapped.sendMessage(MESSAGES, { config: { callSite: "mainAgent" } }),
+    );
+
+    expect(thrown).toBe(finalError);
+    expect(primary.calls()).toBe(1 + DEFAULT_MAX_RETRIES);
+  });
+
+  test("explicit max_tokens/effort/thinking are cleared so the backup profile's values win", async () => {
+    const primary = failingProvider(
+      "openai",
+      () => new ProviderError("model not found", "openai", 404),
+    );
+    const backup = backupProvider();
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    await wrapped.sendMessage(MESSAGES, {
+      config: {
+        callSite: "mainAgent",
+        max_tokens: 42,
+        effort: "low",
+        thinking: { type: "disabled" },
+      },
+    });
+
+    const config = backup.seenConfig();
+    expect(config.model).toBe("backup-model");
+    // The explicit per-call cap was cleared; the backup profile's resolved
+    // maxTokens applies instead.
+    expect(config.max_tokens).toBe(2222);
+    expect(config.effort).not.toBe("low");
+  });
+});

--- a/assistant/src/__tests__/retry-fallback-escalation.test.ts
+++ b/assistant/src/__tests__/retry-fallback-escalation.test.ts
@@ -104,18 +104,28 @@ function backupProvider(name = "anthropic"): {
 
 function makeRoute(
   provider: Provider,
-  overrideProfile = "backup-profile",
+  {
+    overrideProfile = "backup-profile",
+    forwardUsageAttributionHeaders = true,
+  }: {
+    overrideProfile?: string;
+    forwardUsageAttributionHeaders?: boolean;
+  } = {},
 ): {
   resolveFallbackRoute: (
     failedOptions: SendMessageOptions | undefined,
-  ) => Promise<{ provider: Provider; overrideProfile: string } | null>;
+  ) => Promise<{
+    provider: Provider;
+    overrideProfile: string;
+    forwardUsageAttributionHeaders: boolean;
+  } | null>;
   calls: () => number;
 } {
   let calls = 0;
   return {
     resolveFallbackRoute: async () => {
       calls += 1;
-      return { provider, overrideProfile };
+      return { provider, overrideProfile, forwardUsageAttributionHeaders };
     },
     calls: () => calls,
   };
@@ -500,5 +510,105 @@ describe("RetryProvider fallback-route escalation", () => {
     // maxTokens applies instead.
     expect(config.max_tokens).toBe(2222);
     expect(config.effort).not.toBe("low");
+  });
+
+  test("route with forwardUsageAttributionHeaders false → no X-Vellum-* headers reach the backup adapter, even when the primary forwards them", async () => {
+    // A managed primary (forwarding enabled) falling back to a BYOK or other
+    // third-party adapter must not leak billing metadata: the fallback
+    // normalization follows the ROUTE's policy, not the primary's.
+    const primary = failingProvider(
+      "openai",
+      () => new ProviderError("model not found", "openai", 404),
+    );
+    const backup = backupProvider();
+    const route = makeRoute(backup.provider, {
+      forwardUsageAttributionHeaders: false,
+    });
+    const wrapped = new RetryProvider(primary.provider, {
+      forwardUsageAttributionHeaders: true,
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    const result = await wrapped.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    expect(result.model).toBe("backup-model");
+    expect(backup.seenConfig().usageAttributionHeaders).toBeUndefined();
+  });
+
+  test("route with forwardUsageAttributionHeaders true → headers present and reflect the backup profile, even when the primary does not forward them", async () => {
+    // A non-managed primary (forwarding disabled) falling back to the
+    // managed proxy must include the required attribution headers.
+    const primary = failingProvider(
+      "openai",
+      () => new ProviderError("model not found", "openai", 404),
+    );
+    const backup = backupProvider();
+    const route = makeRoute(backup.provider, {
+      forwardUsageAttributionHeaders: true,
+    });
+    const wrapped = new RetryProvider(primary.provider, {
+      forwardUsageAttributionHeaders: false,
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    const result = await wrapped.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    expect(result.model).toBe("backup-model");
+    const headers = backup.seenConfig().usageAttributionHeaders as Record<
+      string,
+      string
+    >;
+    expect(headers["X-Vellum-Inference-Profile"]).toBe("backup-profile");
+    expect(headers["X-Vellum-Resolved-Model"]).toBe("backup-model");
+    expect(headers["X-Vellum-Resolved-Provider"]).toBe("anthropic");
+  });
+
+  test("fallback response without actualProvider → stamped with the backup provider's name", async () => {
+    // The outer call-site router attributes success by `actualProvider`;
+    // without the stamp it would record the fallback under the failed
+    // primary provider and apply the wrong pricing.
+    const primary = failingProvider(
+      "openai",
+      () => new ProviderError("model not found", "openai", 404),
+    );
+    const backup = backupProvider();
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    const result = await wrapped.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    expect(result.actualProvider).toBe("anthropic");
+  });
+
+  test("fallback response with adapter-set actualProvider → preserved, not overwritten", async () => {
+    const primary = failingProvider(
+      "openai",
+      () => new ProviderError("model not found", "openai", 404),
+    );
+    const backup: Provider = {
+      name: "anthropic",
+      sendMessage: async () => ({
+        ...okResponse("backup-model"),
+        actualProvider: "openrouter/anthropic",
+      }),
+    };
+    const route = makeRoute(backup);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    const result = await wrapped.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    expect(result.actualProvider).toBe("openrouter/anthropic");
   });
 });

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -1,4 +1,7 @@
-import { resolveCallSiteConfig } from "../config/llm-resolver.js";
+import {
+  resolveCallSiteConfig,
+  selectWinningProfile,
+} from "../config/llm-resolver.js";
 import { getConfig } from "../config/loader.js";
 import {
   resolveUsageAttribution,
@@ -334,7 +337,7 @@ function isRetryableError(error: unknown): boolean {
  * The managed proxy's preflight guard rejects a model with no billing rate
  * card using a 400 whose body carries this phrase (django
  * `app/runtime_proxy/views.py`). It marks a model rename/retirement incident
- * — a route problem, not a request problem — so it is fallback-eligible even
+ * (a route problem, not a request problem), so it is fallback-eligible even
  * though 400s are otherwise final.
  */
 const MANAGED_PROXY_UNSUPPORTED_MODEL_PATTERN =
@@ -343,7 +346,10 @@ const MANAGED_PROXY_UNSUPPORTED_MODEL_PATTERN =
 /** Outage-shaped failures that justify switching to a backup profile. */
 function isFallbackEligibleError(
   error: unknown,
-  opts: { retriesExhausted: boolean },
+  opts: {
+    retriesExhausted: boolean;
+    credentialSource?: ProviderCredentialSource;
+  },
 ): boolean {
   // Deterministic request failures and caller-initiated aborts never justify
   // a different route (same short-circuits as `isRetryableError`): the same
@@ -356,18 +362,23 @@ function isFallbackEligibleError(
     return false;
   }
   // (a) The retry loop burned its whole budget on a transient error
-  // (429/5xx/overloaded/network/transport-abort) — the primary route is down.
+  // (429/5xx/overloaded/network/transport-abort): the primary route is down.
   if (opts.retriesExhausted && isRetryableError(error)) {
     return true;
   }
   if (!(error instanceof ProviderError)) {
     return false;
   }
-  // (b) Invalid managed credential (the invalid-key incident). Only reached
-  // after `sendMessage`'s credential-refresh path has already been attempted
-  // for managed routes — same status/reason gate as
+  // (b) Invalid managed credential (the invalid-key incident). Applies only
+  // to `vellum-managed` routes, where the platform owns the credential and a
+  // broken key is a platform incident. A BYOK or OAuth-subscription route
+  // with a broken personal credential must surface the auth error so the
+  // user can fix it, not silently reroute to a differently billed backup.
+  // Only reached after `sendMessage`'s credential-refresh path has already
+  // been attempted for managed routes: same status/reason gate as
   // `shouldRefreshManagedCredential`.
   if (
+    opts.credentialSource === "vellum-managed" &&
     (error.statusCode === 401 || error.statusCode === 403) &&
     (error.reason === undefined ||
       error.reason === "unknown" ||
@@ -412,7 +423,7 @@ function fallbackErrorType(error: unknown, retriesExhausted: boolean): string {
  * `config.model` pin (the live per-conversation `modelOverride` feature)
  * disqualifies the request: the pin wins over any resolved profile model in
  * `normalizeSendMessageOptions`, and silently serving a different model
- * against an explicit pin would violate user intent — a profile user asked
+ * against an explicit pin would violate user intent: a profile user asked
  * for a tier, a pinning user asked for that exact model. Pinned conversations
  * keep today's retry-then-error behavior.
  */
@@ -990,9 +1001,9 @@ export class RetryProvider implements Provider {
        * Escalation hook: resolve a backup route (a ready adapter plus the
        * backup profile key) for a request whose primary route failed with an
        * outage-shaped error (see {@link isFallbackEligibleError}). The
-       * callback owns all profile knowledge — it inspects the failed call's
+       * callback owns all profile knowledge: it inspects the failed call's
        * winning profile and returns null when that profile declares no
-       * `fallbackProfile` — mirroring how `refreshCredentialProvider` keeps
+       * `fallbackProfile`, mirroring how `refreshCredentialProvider` keeps
        * this wrapper ignorant of credential storage. One hop max; the
        * fallback attempt itself gets no retry loop.
        */
@@ -1160,7 +1171,10 @@ export class RetryProvider implements Provider {
           !fallbackAttempted &&
           this.options.resolveFallbackRoute !== undefined &&
           canReRouteToFallbackProfile(options) &&
-          isFallbackEligibleError(error, { retriesExhausted })
+          isFallbackEligibleError(error, {
+            retriesExhausted,
+            credentialSource: this.options.credentialSource,
+          })
         ) {
           fallbackAttempted = true;
           const fallbackResult = await this.sendOnFallbackRoute(
@@ -1183,7 +1197,7 @@ export class RetryProvider implements Provider {
    * Attempt the failed request once on the backup route resolved by
    * `resolveFallbackRoute`. Returns null when no backup route applies (the
    * caller rethrows the original error unchanged); throws the fallback
-   * error — with the original error attached as `cause` — when the backup
+   * error (with the original error attached as `cause`) when the backup
    * attempt itself fails.
    */
   private async sendOnFallbackRoute(
@@ -1206,10 +1220,45 @@ export class RetryProvider implements Provider {
       return null;
     }
 
+    // Guard against a backup profile that does not actually apply: the
+    // resolver skips a disabled, incomplete, or missing override profile and
+    // falls through to the next rung (often the failed primary), while the
+    // request would still dispatch on the backup adapter, producing a
+    // provider/model mismatch. Verify the backup profile wins the winner
+    // selection the re-normalization below will perform; if it does not,
+    // surface the original error instead of sending a mismatched request.
+    const failedConfig = options?.config;
+    const callSite = failedConfig?.callSite;
+    const selectionSeed = failedConfig?.selectionSeed;
+    const selection =
+      callSite === undefined
+        ? null
+        : selectWinningProfile(callSite, getConfig().llm, {
+            overrideProfile: route.overrideProfile,
+            ...(selectionSeed !== undefined ? { selectionSeed } : {}),
+          });
+    if (
+      selection === null ||
+      selection.source !== "override" ||
+      selection.profileName !== route.overrideProfile
+    ) {
+      log.warn(
+        {
+          provider: this.name,
+          connectionName: this.options.connectionName,
+          overrideProfile: route.overrideProfile,
+          selectionSource: selection?.source,
+          selectedProfile: selection?.profileName,
+        },
+        "Backup profile did not apply on re-resolution; rethrowing the original error",
+      );
+      return null;
+    }
+
     // Re-resolve the ORIGINAL caller options with the backup profile forced
     // (`resolveCallSiteConfig` floats a forced override to the top of the
     // selection chain). Explicit per-call `max_tokens`/`effort`/`thinking`
-    // are cleared so the backup profile's resolved values win — the pin gate
+    // are cleared so the backup profile's resolved values win; the pin gate
     // in `canReRouteToFallbackProfile` already excluded explicit
     // `config.model`. Re-normalizing on a callSite-bearing config also
     // restamps the usage-attribution headers from the backup resolution, so

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -998,18 +998,28 @@ export class RetryProvider implements Provider {
       connectionName?: string;
       refreshCredentialProvider?: () => Promise<Provider | null>;
       /**
-       * Escalation hook: resolve a backup route (a ready adapter plus the
-       * backup profile key) for a request whose primary route failed with an
+       * Escalation hook: resolve a backup route (a ready adapter, the backup
+       * profile key, and the backup route's usage-attribution forwarding
+       * policy) for a request whose primary route failed with an
        * outage-shaped error (see {@link isFallbackEligibleError}). The
        * callback owns all profile knowledge: it inspects the failed call's
        * winning profile and returns null when that profile declares no
        * `fallbackProfile`, mirroring how `refreshCredentialProvider` keeps
-       * this wrapper ignorant of credential storage. One hop max; the
-       * fallback attempt itself gets no retry loop.
+       * this wrapper ignorant of credential storage.
+       * `forwardUsageAttributionHeaders` must describe the BACKUP route, not
+       * the primary: managed-proxy routes pass true, BYOK and other
+       * third-party routes pass false. The fallback send normalizes with the
+       * returned policy so `X-Vellum-*` billing metadata never leaks to a
+       * third party and is never omitted from the managed proxy. One hop
+       * max; the fallback attempt itself gets no retry loop.
        */
       resolveFallbackRoute?: (
         failedOptions: SendMessageOptions | undefined,
-      ) => Promise<{ provider: Provider; overrideProfile: string } | null>;
+      ) => Promise<{
+        provider: Provider;
+        overrideProfile: string;
+        forwardUsageAttributionHeaders: boolean;
+      } | null>;
     } = {},
   ) {
     this.inner = inner;
@@ -1206,7 +1216,11 @@ export class RetryProvider implements Provider {
     originalError: unknown,
     retriesExhausted: boolean,
   ): Promise<ProviderResponse | null> {
-    let route: { provider: Provider; overrideProfile: string } | null;
+    let route: {
+      provider: Provider;
+      overrideProfile: string;
+      forwardUsageAttributionHeaders: boolean;
+    } | null;
     try {
       route = (await this.options.resolveFallbackRoute?.(options)) ?? null;
     } catch (resolveError) {
@@ -1262,7 +1276,11 @@ export class RetryProvider implements Provider {
     // in `canReRouteToFallbackProfile` already excluded explicit
     // `config.model`. Re-normalizing on a callSite-bearing config also
     // restamps the usage-attribution headers from the backup resolution, so
-    // platform usage events attribute degraded traffic to the backup profile.
+    // platform usage events attribute degraded traffic to the backup
+    // profile. Whether those headers are forwarded at all follows the
+    // FALLBACK route's policy, not the primary's: a managed primary falling
+    // back to a third-party adapter must not leak billing metadata, and a
+    // non-managed primary falling back to the managed proxy must include it.
     const fallbackConfig: Record<string, unknown> = { ...options?.config };
     delete fallbackConfig.max_tokens;
     delete fallbackConfig.effort;
@@ -1274,7 +1292,7 @@ export class RetryProvider implements Provider {
       { ...options, config: fallbackConfig },
       {
         forwardUsageAttributionHeaders:
-          this.options.forwardUsageAttributionHeaders === true,
+          route.forwardUsageAttributionHeaders === true,
       },
     );
 
@@ -1295,7 +1313,19 @@ export class RetryProvider implements Provider {
 
     try {
       // One hop, one attempt: the fallback send gets no retry loop in v1.
-      return await route.provider.sendMessage(messages, fallbackOptions);
+      const response = await route.provider.sendMessage(
+        messages,
+        fallbackOptions,
+      );
+      // Stamp the provider that actually served the response. Without this,
+      // a backup adapter that does not set `actualProvider` leaves the outer
+      // call-site router recording the success under the failed primary
+      // provider (wrong provider, wrong pricing attribution). Never
+      // overwrite a more specific value the adapter already set.
+      if (response.actualProvider === undefined) {
+        response.actualProvider = route.provider.name;
+      }
+      return response;
     } catch (fallbackError) {
       if (fallbackError instanceof Error && fallbackError.cause === undefined) {
         fallbackError.cause = originalError;

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -386,9 +386,24 @@ function isFallbackEligibleError(
   ) {
     return true;
   }
-  // (c) Model not found: a hard 404, or the managed proxy's preflight 400
-  // for a renamed/retired model.
-  if (error.statusCode === 404) {
+  // (c) Model not found: a provider-classified model_not_found, a 404 with
+  // no definitive classification, or the managed proxy's preflight 400 for a
+  // renamed/retired model. As in `isRetryableError`, a provider-stamped
+  // semantic reason takes precedence over the status fallback: a 404 whose
+  // classifier assigned a definitive non-model reason (Anthropic, for
+  // example, stamps `bad_request` on a 404 without a model signal) marks a
+  // deterministic request/routing failure that a different model route would
+  // not fix, so it must not switch routes. Only an absent or `unknown`
+  // reason falls through to the raw 404 check. `model_restricted` is a
+  // credential/policy denial, not a missing model, so it is deliberately not
+  // fallback-eligible here.
+  if (error.reason === "model_not_found") {
+    return true;
+  }
+  if (
+    error.statusCode === 404 &&
+    (error.reason === undefined || error.reason === "unknown")
+  ) {
     return true;
   }
   if (
@@ -1234,6 +1249,26 @@ export class RetryProvider implements Provider {
       return null;
     }
 
+    // Reject a mix backup profile outright. The fallback schema already
+    // forbids `fallbackProfile` from referencing a mix, but this wrapper must
+    // not trust that: honoring one would require the route callback, the
+    // winner-selection guard below, and the re-normalization to agree on the
+    // same seeded arm, and a request without a `selectionSeed` expands the
+    // mix independently at each of those points, so one arm's model could be
+    // sent through another arm's provider adapter. Treat it as non-applying
+    // and surface the original error.
+    if (getConfig().llm.profiles?.[route.overrideProfile]?.mix != null) {
+      log.warn(
+        {
+          provider: this.name,
+          connectionName: this.options.connectionName,
+          overrideProfile: route.overrideProfile,
+        },
+        "Backup profile is a mix, which fallback routing does not support; rethrowing the original error",
+      );
+      return null;
+    }
+
     // Guard against a backup profile that does not actually apply: the
     // resolver skips a disabled, incomplete, or missing override profile and
     // falls through to the next rung (often the failed primary), while the
@@ -1324,6 +1359,15 @@ export class RetryProvider implements Provider {
       // overwrite a more specific value the adapter already set.
       if (response.actualProvider === undefined) {
         response.actualProvider = route.provider.name;
+      }
+      // Stamp the profile that actually governed the response for the same
+      // reason: the outer `UsageTrackingProvider` resolves attribution from
+      // the ORIGINAL request options, which still carry the failed primary's
+      // resolution, so without this the usage event would bill the fallback
+      // serve under the wrong profile. Never overwrite a more specific value
+      // an inner wrapper already set.
+      if (response.actualInferenceProfile === undefined) {
+        response.actualInferenceProfile = route.overrideProfile;
       }
       return response;
     } catch (fallbackError) {

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -331,6 +331,100 @@ function isRetryableError(error: unknown): boolean {
 }
 
 /**
+ * The managed proxy's preflight guard rejects a model with no billing rate
+ * card using a 400 whose body carries this phrase (django
+ * `app/runtime_proxy/views.py`). It marks a model rename/retirement incident
+ * — a route problem, not a request problem — so it is fallback-eligible even
+ * though 400s are otherwise final.
+ */
+const MANAGED_PROXY_UNSUPPORTED_MODEL_PATTERN =
+  /is not yet supported on the Vellum hosted service/;
+
+/** Outage-shaped failures that justify switching to a backup profile. */
+function isFallbackEligibleError(
+  error: unknown,
+  opts: { retriesExhausted: boolean },
+): boolean {
+  // Deterministic request failures and caller-initiated aborts never justify
+  // a different route (same short-circuits as `isRetryableError`): the same
+  // oversized prompt overflows the backup too, and a cancelled request must
+  // stay cancelled.
+  if (isContextOverflowError(error)) {
+    return false;
+  }
+  if (error instanceof ProviderError && error.abortReason !== undefined) {
+    return false;
+  }
+  // (a) The retry loop burned its whole budget on a transient error
+  // (429/5xx/overloaded/network/transport-abort) — the primary route is down.
+  if (opts.retriesExhausted && isRetryableError(error)) {
+    return true;
+  }
+  if (!(error instanceof ProviderError)) {
+    return false;
+  }
+  // (b) Invalid managed credential (the invalid-key incident). Only reached
+  // after `sendMessage`'s credential-refresh path has already been attempted
+  // for managed routes — same status/reason gate as
+  // `shouldRefreshManagedCredential`.
+  if (
+    (error.statusCode === 401 || error.statusCode === 403) &&
+    (error.reason === undefined ||
+      error.reason === "unknown" ||
+      error.reason === "invalid_credentials")
+  ) {
+    return true;
+  }
+  // (c) Model not found: a hard 404, or the managed proxy's preflight 400
+  // for a renamed/retired model.
+  if (error.statusCode === 404) {
+    return true;
+  }
+  if (
+    error.statusCode === 400 &&
+    MANAGED_PROXY_UNSUPPORTED_MODEL_PATTERN.test(error.message)
+  ) {
+    return true;
+  }
+  return false;
+}
+
+/** Structured error class for the "Falling back to backup profile" log. */
+function fallbackErrorType(error: unknown, retriesExhausted: boolean): string {
+  if (retriesExhausted) {
+    return "retries_exhausted";
+  }
+  if (error instanceof ProviderError) {
+    if (error.statusCode === 401 || error.statusCode === 403) {
+      return "invalid_credentials";
+    }
+    if (error.statusCode === 404 || error.statusCode === 400) {
+      return "model_not_found";
+    }
+  }
+  return "unknown";
+}
+
+/**
+ * Whether a failed request can be re-routed to a backup profile. Fallback
+ * re-resolves the ORIGINAL caller options with the backup profile forced,
+ * which requires a `callSite`-bearing config. An explicit per-call
+ * `config.model` pin (the live per-conversation `modelOverride` feature)
+ * disqualifies the request: the pin wins over any resolved profile model in
+ * `normalizeSendMessageOptions`, and silently serving a different model
+ * against an explicit pin would violate user intent — a profile user asked
+ * for a tier, a pinning user asked for that exact model. Pinned conversations
+ * keep today's retry-then-error behavior.
+ */
+function canReRouteToFallbackProfile(options?: SendMessageOptions): boolean {
+  const config = options?.config;
+  if (config?.callSite === undefined) {
+    return false;
+  }
+  return !(typeof config.model === "string" && config.model.trim().length > 0);
+}
+
+/**
  * Whether the request lands on Anthropic's Messages API wire: direct Anthropic
  * calls, plus OpenRouter / Vercel AI Gateway calls that delegate `anthropic/*`
  * models to it. Anthropic's thinking wire constraints (forced tool_choice,
@@ -892,6 +986,19 @@ export class RetryProvider implements Provider {
       credentialSource?: ProviderCredentialSource;
       connectionName?: string;
       refreshCredentialProvider?: () => Promise<Provider | null>;
+      /**
+       * Escalation hook: resolve a backup route (a ready adapter plus the
+       * backup profile key) for a request whose primary route failed with an
+       * outage-shaped error (see {@link isFallbackEligibleError}). The
+       * callback owns all profile knowledge — it inspects the failed call's
+       * winning profile and returns null when that profile declares no
+       * `fallbackProfile` — mirroring how `refreshCredentialProvider` keeps
+       * this wrapper ignorant of credential storage. One hop max; the
+       * fallback attempt itself gets no retry loop.
+       */
+      resolveFallbackRoute?: (
+        failedOptions: SendMessageOptions | undefined,
+      ) => Promise<{ provider: Provider; overrideProfile: string } | null>;
     } = {},
   ) {
     this.inner = inner;
@@ -936,6 +1043,7 @@ export class RetryProvider implements Provider {
     let didRetry = false;
     let retryAttempt = 0;
     let credentialRefreshAttempted = false;
+    let fallbackAttempted = false;
     let messagesForAttempt = messages;
 
     const normalizedOptions = normalizeSendMessageOptions(this.name, options, {
@@ -1037,14 +1145,113 @@ export class RetryProvider implements Provider {
         // stops retrying when either (a) retries are exhausted, or (b) the
         // error isn't retryable — so we check the retryable predicate here to
         // distinguish the two cases.
-        if (didRetry && isRetryableError(error) && error instanceof Error) {
+        const retriesExhausted = didRetry && isRetryableError(error);
+        if (retriesExhausted && error instanceof Error) {
           (error as Error & { retriesExhausted?: boolean }).retriesExhausted =
             true;
         }
 
         this.attributeCredential(error);
+
+        // Last resort before rethrowing: escalate an outage-shaped failure to
+        // the backup profile's route when the construction site wired one in.
+        // One hop max; a request pinned to an explicit model never re-routes.
+        if (
+          !fallbackAttempted &&
+          this.options.resolveFallbackRoute !== undefined &&
+          canReRouteToFallbackProfile(options) &&
+          isFallbackEligibleError(error, { retriesExhausted })
+        ) {
+          fallbackAttempted = true;
+          const fallbackResult = await this.sendOnFallbackRoute(
+            messages,
+            options,
+            error,
+            retriesExhausted,
+          );
+          if (fallbackResult !== null) {
+            return fallbackResult;
+          }
+        }
+
         throw error;
       }
+    }
+  }
+
+  /**
+   * Attempt the failed request once on the backup route resolved by
+   * `resolveFallbackRoute`. Returns null when no backup route applies (the
+   * caller rethrows the original error unchanged); throws the fallback
+   * error — with the original error attached as `cause` — when the backup
+   * attempt itself fails.
+   */
+  private async sendOnFallbackRoute(
+    messages: Message[],
+    options: SendMessageOptions | undefined,
+    originalError: unknown,
+    retriesExhausted: boolean,
+  ): Promise<ProviderResponse | null> {
+    let route: { provider: Provider; overrideProfile: string } | null;
+    try {
+      route = (await this.options.resolveFallbackRoute?.(options)) ?? null;
+    } catch (resolveError) {
+      log.warn(
+        { provider: this.name, resolveError },
+        "Failed to resolve fallback route; rethrowing the original error",
+      );
+      return null;
+    }
+    if (route === null) {
+      return null;
+    }
+
+    // Re-resolve the ORIGINAL caller options with the backup profile forced
+    // (`resolveCallSiteConfig` floats a forced override to the top of the
+    // selection chain). Explicit per-call `max_tokens`/`effort`/`thinking`
+    // are cleared so the backup profile's resolved values win — the pin gate
+    // in `canReRouteToFallbackProfile` already excluded explicit
+    // `config.model`. Re-normalizing on a callSite-bearing config also
+    // restamps the usage-attribution headers from the backup resolution, so
+    // platform usage events attribute degraded traffic to the backup profile.
+    const fallbackConfig: Record<string, unknown> = { ...options?.config };
+    delete fallbackConfig.max_tokens;
+    delete fallbackConfig.effort;
+    delete fallbackConfig.thinking;
+    fallbackConfig.overrideProfile = route.overrideProfile;
+    fallbackConfig.forceOverrideProfile = true;
+    const fallbackOptions = normalizeSendMessageOptions(
+      route.provider.name,
+      { ...options, config: fallbackConfig },
+      {
+        forwardUsageAttributionHeaders:
+          this.options.forwardUsageAttributionHeaders === true,
+      },
+    );
+
+    log.warn(
+      {
+        provider: this.name,
+        connectionName: this.options.connectionName,
+        fallbackProvider: route.provider.name,
+        overrideProfile: route.overrideProfile,
+        errorType: fallbackErrorType(originalError, retriesExhausted),
+        message:
+          originalError instanceof Error
+            ? originalError.message
+            : String(originalError),
+      },
+      "Falling back to backup profile",
+    );
+
+    try {
+      // One hop, one attempt: the fallback send gets no retry loop in v1.
+      return await route.provider.sendMessage(messages, fallbackOptions);
+    } catch (fallbackError) {
+      if (fallbackError instanceof Error && fallbackError.cause === undefined) {
+        fallbackError.cause = originalError;
+      }
+      throw fallbackError;
     }
   }
 }

--- a/assistant/src/providers/types.ts
+++ b/assistant/src/providers/types.ts
@@ -192,6 +192,15 @@ export interface ProviderResponse {
   /** Provider that actually produced this response, which may differ from a wrapper provider name. */
   actualProvider?: string;
   /**
+   * Inference profile key that actually governed this response when a
+   * wrapper re-routed the request away from the caller's own resolution
+   * (`RetryProvider`'s fallback-route escalation). `UsageTrackingProvider`
+   * prefers this over re-resolving from the original request options, so a
+   * successful fallback serve is attributed to the backup profile rather
+   * than the failed primary's. Absent on the normal (non-rerouted) path.
+   */
+  actualInferenceProfile?: string;
+  /**
    * Base URL the provider's HTTP client actually resolved to for this request,
    * read from the live SDK client instance rather than re-derived from config.
    * Lets diagnostics observe the true routing target (e.g. a misrouted host)

--- a/assistant/src/providers/usage-tracking.ts
+++ b/assistant/src/providers/usage-tracking.ts
@@ -66,9 +66,20 @@ export class UsageTrackingProvider implements Provider {
     }
 
     try {
+      // A fallback-serving wrapper (`RetryProvider`'s escalation) stamps the
+      // profile that actually governed the response; prefer it over the
+      // original request's resolution so a degraded serve bills under the
+      // backup profile, not the failed primary's. `forceOverrideProfile`
+      // mirrors how the fallback dispatch floated that profile above the
+      // call-site layers.
+      const appliedOverride =
+        response.actualInferenceProfile ?? config.overrideProfile;
       const attribution = resolveUsageAttribution({
         callSite: config.callSite,
-        overrideProfile: config.overrideProfile,
+        overrideProfile: appliedOverride,
+        ...(response.actualInferenceProfile !== undefined
+          ? { forceOverrideProfile: true }
+          : {}),
       });
       const providerName = response.actualProvider ?? this.inner.name;
       const pricingUsage = buildPricingUsageFromResponse(


### PR DESCRIPTION
## Summary
- `isFallbackEligibleError`: outage-shaped failures (exhausted retryables, invalid managed credential, model-not-found) qualify for backup-profile escalation
- New `resolveFallbackRoute` RetryProvider option (mirrors `refreshCredentialProvider`); one fallback hop, re-normalized with forced backup profile
- Explicit `config.model` pins are excluded — pinned conversations keep retry-then-error behavior

Part of plan: model-fallbacks.md (PR 3 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41164" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->