### PR TITLE
feat(config): add fallbackProfile field to inference profile schema

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -14914,8 +14914,8 @@ paths:
           description: Profile not found
         "409":
           description:
-            Profile is still referenced by activeProfile, advisorProfile, a call site, a default-tier override, or a
-            mix arm
+            Profile is still referenced by activeProfile, advisorProfile, a call site, a default-tier override, a mix
+            arm, or another profile's fallbackProfile
     get:
       operationId: inference_profiles_by_name_get
       summary: Get an effective inference profile

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -5152,6 +5152,9 @@ paths:
                     required:
                       - profile
                       - weight
+                fallbackProfile:
+                  type: string
+                  minLength: 1
       responses:
         "200":
           description: Successful response
@@ -34632,6 +34635,11 @@ components:
                   - profile
                   - weight
             - type: "null"
+        fallbackProfile:
+          anyOf:
+            - type: string
+              minLength: 1
+            - type: "null"
       additionalProperties: {}
     ProfileStatus:
       type: string
@@ -35401,6 +35409,9 @@ components:
               - profile
               - weight
             additionalProperties: false
+        fallbackProfile:
+          type: string
+          minLength: 1
         supportsVision:
           type: boolean
         invariant:

--- a/assistant/src/__tests__/llm-resolver.test.ts
+++ b/assistant/src/__tests__/llm-resolver.test.ts
@@ -303,6 +303,27 @@ describe("resolveCallSiteConfig", () => {
     expect(resolved.effort).toBe("high");
   });
 
+  test("a winning profile's fallbackProfile metadata never leaks into the resolved config", () => {
+    const llm = LLMSchema.parse({
+      profiles: {
+        primary: {
+          provider: "anthropic",
+          model: "claude-opus-4-7",
+          fallbackProfile: "backup",
+        },
+        backup: { provider: "anthropic", model: "claude-sonnet-4-6" },
+      },
+      callSites: {
+        memoryExtraction: { profile: "primary" },
+      },
+    });
+    const resolved = resolveCallSiteConfig("memoryExtraction", llm);
+    expect(resolved.model).toBe("claude-opus-4-7");
+    // `fallbackProfile` is ProfileEntry-only metadata, absent from
+    // `LLMConfigBase`; the resolved config must not carry the key at all.
+    expect(Object.hasOwn(resolved, "fallbackProfile")).toBe(false);
+  });
+
   test("topP defaults to null when no profile or override sets it", () => {
     const llm = LLMSchema.parse({});
     const resolved = resolveCallSiteConfig("mainAgent", llm);

--- a/assistant/src/__tests__/llm-schema-fallback-profile.test.ts
+++ b/assistant/src/__tests__/llm-schema-fallback-profile.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, test } from "bun:test";
+
+import { z } from "zod";
+
+import { DEFAULT_PROFILE_KEYS } from "../config/default-profile-names.js";
+import { LLMSchema } from "../config/schemas/llm.js";
+
+describe("LLMSchema fallbackProfile", () => {
+  test("profile with a valid fallbackProfile pointer parses", () => {
+    const result = LLMSchema.safeParse({
+      profiles: {
+        primary: { effort: "high", fallbackProfile: "backup" },
+        backup: { speed: "fast" },
+      },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.profiles["primary"]?.fallbackProfile).toBe("backup");
+    }
+  });
+
+  test("fallbackProfile may reference an always-available default profile key", () => {
+    // Code-defined default profiles resolve without being materialized in
+    // llm.profiles, so they are valid reference targets (same rule as
+    // call-site `profile` references).
+    const defaultKey = DEFAULT_PROFILE_KEYS[0];
+    const result = LLMSchema.safeParse({
+      profiles: {
+        primary: { fallbackProfile: defaultKey },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("dangling fallbackProfile pointer fails superRefine", () => {
+    const result = LLMSchema.safeParse({
+      profiles: {
+        primary: { fallbackProfile: "ghost" },
+      },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issue = result.error.issues.find((i) =>
+        i.message.includes('fallbackProfile "ghost"'),
+      );
+      expect(issue?.message).toContain("is not defined in llm.profiles");
+      expect(issue?.path).toEqual(["profiles", "primary", "fallbackProfile"]);
+    }
+  });
+
+  test("self-referencing fallbackProfile is rejected", () => {
+    const result = LLMSchema.safeParse({
+      profiles: {
+        primary: { fallbackProfile: "primary" },
+      },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issue = result.error.issues.find((i) =>
+        i.message.includes("cannot declare itself"),
+      );
+      expect(issue?.path).toEqual(["profiles", "primary", "fallbackProfile"]);
+    }
+  });
+
+  test("fallbackProfile pointing at a mix profile is rejected", () => {
+    const result = LLMSchema.safeParse({
+      profiles: {
+        primary: { fallbackProfile: "blend" },
+        armA: { speed: "fast" },
+        armB: { effort: "high" },
+        blend: {
+          mix: [
+            { profile: "armA", weight: 1 },
+            { profile: "armB", weight: 1 },
+          ],
+        },
+      },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issue = result.error.issues.find((i) =>
+        i.message.includes("is a mix profile"),
+      );
+      expect(issue?.path).toEqual(["profiles", "primary", "fallbackProfile"]);
+    }
+  });
+
+  test("two-hop fallback chain is rejected (single hop only)", () => {
+    const result = LLMSchema.safeParse({
+      profiles: {
+        primary: { fallbackProfile: "middle" },
+        middle: { fallbackProfile: "last" },
+        last: { speed: "fast" },
+      },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issue = result.error.issues.find((i) =>
+        i.message.includes("chains are not allowed"),
+      );
+      expect(issue?.path).toEqual(["profiles", "primary", "fallbackProfile"]);
+    }
+  });
+
+  test("mix profile carrying fallbackProfile is rejected", () => {
+    const result = LLMSchema.safeParse({
+      profiles: {
+        armA: { speed: "fast" },
+        armB: { effort: "high" },
+        blend: {
+          mix: [
+            { profile: "armA", weight: 1 },
+            { profile: "armB", weight: 1 },
+          ],
+          fallbackProfile: "armA",
+        },
+      },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issue = result.error.issues.find((i) =>
+        i.message.includes('cannot also set "fallbackProfile"'),
+      );
+      expect(issue?.path).toEqual(["profiles", "blend", "fallbackProfile"]);
+    }
+  });
+
+  test("empty-string fallbackProfile is rejected at field level", () => {
+    const result = LLMSchema.safeParse({
+      profiles: {
+        primary: { fallbackProfile: "" },
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("profiles without fallbackProfile still parse (back-compat)", () => {
+    const result = LLMSchema.safeParse({
+      profiles: {
+        fast: { speed: "fast", effort: "low" },
+        thorough: { effort: "high", maxTokens: 128000 },
+      },
+      callSites: {
+        mainAgent: { profile: "thorough" },
+      },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.profiles["fast"]?.fallbackProfile).toBeUndefined();
+    }
+  });
+
+  test("z.toJSONSchema still generates for LLMSchema (config docs/routes)", () => {
+    // Same options as handleGetConfigSchema in
+    // runtime/routes/conversation-query-routes.ts — the field must not
+    // introduce any callback-bearing zod construct that breaks generation.
+    const json = z.toJSONSchema(LLMSchema, {
+      unrepresentable: "any",
+      io: "input",
+    });
+    expect(json).toBeTruthy();
+  });
+});

--- a/assistant/src/__tests__/llm-schema-fallback-profile.test.ts
+++ b/assistant/src/__tests__/llm-schema-fallback-profile.test.ts
@@ -153,7 +153,7 @@ describe("LLMSchema fallbackProfile", () => {
 
   test("z.toJSONSchema still generates for LLMSchema (config docs/routes)", () => {
     // Same options as handleGetConfigSchema in
-    // runtime/routes/conversation-query-routes.ts — the field must not
+    // runtime/routes/conversation-query-routes.ts. The field must not
     // introduce any callback-bearing zod construct that breaks generation.
     const json = z.toJSONSchema(LLMSchema, {
       unrepresentable: "any",

--- a/assistant/src/config/llm-resolver.ts
+++ b/assistant/src/config/llm-resolver.ts
@@ -485,6 +485,7 @@ function winnerConfigFragment(entry: ProfileEntry): Mergeable {
     description: _description,
     status: _status,
     mix: _mix,
+    fallbackProfile: _fallbackProfile,
     ...config
   } = entry;
   return config as Mergeable;

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -622,6 +622,14 @@ export const ProfileEntry = LLMConfigFragment.extend({
    * may accompany `mix`.
    */
   mix: MixSchema.optional(),
+  /**
+   * Name of another profile to fall back to when this profile's model
+   * fails with an outage-type error (retries exhausted, invalid managed
+   * credential, unknown model). Single hop: the referenced profile must
+   * not declare its own fallbackProfile. Managed (`vellum`) profiles
+   * only — BYOK installs may hold no credential for the backup provider.
+   */
+  fallbackProfile: z.string().min(1).optional(),
 });
 export type ProfileEntry = z.infer<typeof ProfileEntry>;
 
@@ -776,11 +784,13 @@ export const LLMSchema = z
     // --- Mix profile validation --------------------------------------------
     // Config keys a mix profile must NOT also set (a mix only references other
     // profiles + metadata). Derived from the fragment shape plus the
-    // ProfileEntry-only `provider_connection` so it can't drift if a new config
-    // field is added to `LLMConfigFragment`.
+    // ProfileEntry-only `provider_connection` and `fallbackProfile` (a mix
+    // carries no config of its own, so it has no route to fall back from) so
+    // it can't drift if a new config field is added to `LLMConfigFragment`.
     const MIX_DISALLOWED_CONFIG_KEYS = [
       ...Object.keys(LLMConfigFragment.shape),
       "provider_connection",
+      "fallbackProfile",
     ];
     const mixProfileNames = new Set(
       Object.entries(config.profiles ?? {})
@@ -829,6 +839,56 @@ export const LLMSchema = z
             message: `Mix profile "${name}" references another mix profile "${arm.profile}" — mixes cannot be nested; constituents must be standard profiles.`,
           });
         }
+      }
+    }
+
+    // --- fallbackProfile validation ----------------------------------------
+    // `LLMSchema.superRefine` enforces that (a) the referenced profile exists,
+    // (b) a profile does not fall back to itself, (c) the referenced profile
+    // is not a mix (a fallback must be a directly dispatchable route), and
+    // (d) the referenced profile does not itself set `fallbackProfile` —
+    // fallback is a single hop in v1, never a chain. A mix profile setting
+    // `fallbackProfile` at all is rejected by the mix validation above
+    // (MIX_DISALLOWED_CONFIG_KEYS).
+    for (const [name, profile] of Object.entries(config.profiles ?? {})) {
+      const fallback = profile?.fallbackProfile;
+      if (fallback == null) {
+        continue;
+      }
+      // (b) No self-reference.
+      if (fallback === name) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["profiles", name, "fallbackProfile"],
+          message: `Profile "${name}" cannot declare itself as its fallbackProfile.`,
+        });
+        continue;
+      }
+      // (a) Referenced profile must exist.
+      if (!profileNames.has(fallback)) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["profiles", name, "fallbackProfile"],
+          message: `Profile "${name}" declares fallbackProfile "${fallback}" which is not defined in llm.profiles.`,
+        });
+        continue;
+      }
+      // (c) A fallback target must be a standard (non-mix) profile.
+      if (mixProfileNames.has(fallback)) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["profiles", name, "fallbackProfile"],
+          message: `Profile "${name}" declares fallbackProfile "${fallback}" which is a mix profile — a fallback must be a standard profile.`,
+        });
+        continue;
+      }
+      // (d) Single hop only — the target must not declare its own fallback.
+      if (config.profiles?.[fallback]?.fallbackProfile != null) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["profiles", name, "fallbackProfile"],
+          message: `Profile "${name}" declares fallbackProfile "${fallback}" which sets its own fallbackProfile — fallback is a single hop, chains are not allowed.`,
+        });
       }
     }
   });

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -680,6 +680,101 @@ const DefaultProviderField = DefaultProviderSchema.optional().catch(undefined);
 // Top-level LLM schema
 // ---------------------------------------------------------------------------
 
+/**
+ * Cross-profile integrity checks for `fallbackProfile` pointers: (a) the
+ * referenced profile exists, (b) a profile does not fall back to itself,
+ * (c) the referenced profile is not a mix (a fallback must be a directly
+ * dispatchable route), (d) the referenced profile does not itself set
+ * `fallbackProfile` (fallback is a single hop in v1, never a chain), and
+ * (e) a mix profile carries no `fallbackProfile` of its own (a mix has no
+ * route of its own to fall back from).
+ *
+ * Shared by `LLMSchema.superRefine` (full-config load) and the config write
+ * paths (`commitConfigWrite`), which persist raw config without a
+ * full-schema parse. Accepts a raw or parsed `llm.profiles` record; entries
+ * are read defensively so the raw on-disk shape is safe to pass.
+ */
+export function collectFallbackProfileIssues(
+  profiles: Record<string, unknown> | undefined,
+): { profileName: string; message: string }[] {
+  const issues: { profileName: string; message: string }[] = [];
+  const entries = Object.entries(profiles ?? {});
+  const readEntry = (value: unknown): Record<string, unknown> | null =>
+    value != null && typeof value === "object" && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : null;
+  // The always-available default profiles are code-defined
+  // (`default-profile-catalog.ts`) and resolve whether or not they are
+  // materialized in `llm.profiles`, so their names are always valid
+  // fallback targets (same rule as call-site `profile` references).
+  const profileNames = new Set([
+    ...entries.map(([name]) => name),
+    ...DEFAULT_PROFILE_KEYS,
+  ]);
+  const mixProfileNames = new Set(
+    entries
+      .filter(([, value]) => readEntry(value)?.mix != null)
+      .map(([name]) => name),
+  );
+  for (const [name, value] of entries) {
+    const entry = readEntry(value);
+    const fallback = entry?.fallbackProfile;
+    if (fallback == null) {
+      continue;
+    }
+    // Raw writes (e.g. `config set`) can carry a non-string value the field
+    // schema would reject on the next full parse; flag it here so it never
+    // reaches disk.
+    if (typeof fallback !== "string" || fallback.length === 0) {
+      issues.push({
+        profileName: name,
+        message: `Profile "${name}" declares a fallbackProfile that must be a non-empty string naming another profile.`,
+      });
+      continue;
+    }
+    // (e) A mix carries no route of its own to fall back from.
+    if (entry?.mix != null) {
+      issues.push({
+        profileName: name,
+        message: `Mix profile "${name}" cannot also set "fallbackProfile"; a mix only references other profiles plus metadata.`,
+      });
+      continue;
+    }
+    // (b) No self-reference.
+    if (fallback === name) {
+      issues.push({
+        profileName: name,
+        message: `Profile "${name}" cannot declare itself as its fallbackProfile.`,
+      });
+      continue;
+    }
+    // (a) Referenced profile must exist.
+    if (!profileNames.has(fallback)) {
+      issues.push({
+        profileName: name,
+        message: `Profile "${name}" declares fallbackProfile "${fallback}" which is not defined in llm.profiles.`,
+      });
+      continue;
+    }
+    // (c) A fallback target must be a standard (non-mix) profile.
+    if (mixProfileNames.has(fallback)) {
+      issues.push({
+        profileName: name,
+        message: `Profile "${name}" declares fallbackProfile "${fallback}" which is a mix profile; a fallback must be a standard profile.`,
+      });
+      continue;
+    }
+    // (d) Single hop only: the target must not declare its own fallback.
+    if (readEntry(profiles?.[fallback])?.fallbackProfile != null) {
+      issues.push({
+        profileName: name,
+        message: `Profile "${name}" declares fallbackProfile "${fallback}" which sets its own fallbackProfile; fallback is a single hop, chains are not allowed.`,
+      });
+    }
+  }
+  return issues;
+}
+
 export const LLMSchema = z
   .object({
     profiles: z.record(z.string().min(1), ProfileEntry).default({}),
@@ -844,53 +939,16 @@ export const LLMSchema = z
     }
 
     // --- fallbackProfile validation ----------------------------------------
-    // `LLMSchema.superRefine` enforces that (a) the referenced profile exists,
-    // (b) a profile does not fall back to itself, (c) the referenced profile
-    // is not a mix (a fallback must be a directly dispatchable route), and
-    // (d) the referenced profile does not itself set `fallbackProfile`:
-    // fallback is a single hop in v1, never a chain. A mix profile setting
-    // `fallbackProfile` at all is rejected by the mix validation above
+    // Cross-profile fallback rules live in `collectFallbackProfileIssues`
+    // (shared with the config write paths). A mix profile setting
+    // `fallbackProfile` is also rejected by the mix validation above
     // (MIX_DISALLOWED_CONFIG_KEYS).
-    for (const [name, profile] of Object.entries(config.profiles ?? {})) {
-      const fallback = profile?.fallbackProfile;
-      if (fallback == null) {
-        continue;
-      }
-      // (b) No self-reference.
-      if (fallback === name) {
-        ctx.addIssue({
-          code: "custom",
-          path: ["profiles", name, "fallbackProfile"],
-          message: `Profile "${name}" cannot declare itself as its fallbackProfile.`,
-        });
-        continue;
-      }
-      // (a) Referenced profile must exist.
-      if (!profileNames.has(fallback)) {
-        ctx.addIssue({
-          code: "custom",
-          path: ["profiles", name, "fallbackProfile"],
-          message: `Profile "${name}" declares fallbackProfile "${fallback}" which is not defined in llm.profiles.`,
-        });
-        continue;
-      }
-      // (c) A fallback target must be a standard (non-mix) profile.
-      if (mixProfileNames.has(fallback)) {
-        ctx.addIssue({
-          code: "custom",
-          path: ["profiles", name, "fallbackProfile"],
-          message: `Profile "${name}" declares fallbackProfile "${fallback}" which is a mix profile; a fallback must be a standard profile.`,
-        });
-        continue;
-      }
-      // (d) Single hop only: the target must not declare its own fallback.
-      if (config.profiles?.[fallback]?.fallbackProfile != null) {
-        ctx.addIssue({
-          code: "custom",
-          path: ["profiles", name, "fallbackProfile"],
-          message: `Profile "${name}" declares fallbackProfile "${fallback}" which sets its own fallbackProfile; fallback is a single hop, chains are not allowed.`,
-        });
-      }
+    for (const issue of collectFallbackProfileIssues(config.profiles)) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["profiles", issue.profileName, "fallbackProfile"],
+        message: issue.message,
+      });
     }
   });
 

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -627,7 +627,8 @@ export const ProfileEntry = LLMConfigFragment.extend({
    * fails with an outage-type error (retries exhausted, invalid managed
    * credential, unknown model). Single hop: the referenced profile must
    * not declare its own fallbackProfile. Managed (`vellum`) profiles
-   * only — BYOK installs may hold no credential for the backup provider.
+   * only, since BYOK installs may hold no credential for the backup
+   * provider.
    */
   fallbackProfile: z.string().min(1).optional(),
 });
@@ -846,7 +847,7 @@ export const LLMSchema = z
     // `LLMSchema.superRefine` enforces that (a) the referenced profile exists,
     // (b) a profile does not fall back to itself, (c) the referenced profile
     // is not a mix (a fallback must be a directly dispatchable route), and
-    // (d) the referenced profile does not itself set `fallbackProfile` —
+    // (d) the referenced profile does not itself set `fallbackProfile`:
     // fallback is a single hop in v1, never a chain. A mix profile setting
     // `fallbackProfile` at all is rejected by the mix validation above
     // (MIX_DISALLOWED_CONFIG_KEYS).
@@ -878,16 +879,16 @@ export const LLMSchema = z
         ctx.addIssue({
           code: "custom",
           path: ["profiles", name, "fallbackProfile"],
-          message: `Profile "${name}" declares fallbackProfile "${fallback}" which is a mix profile — a fallback must be a standard profile.`,
+          message: `Profile "${name}" declares fallbackProfile "${fallback}" which is a mix profile; a fallback must be a standard profile.`,
         });
         continue;
       }
-      // (d) Single hop only — the target must not declare its own fallback.
+      // (d) Single hop only: the target must not declare its own fallback.
       if (config.profiles?.[fallback]?.fallbackProfile != null) {
         ctx.addIssue({
           code: "custom",
           path: ["profiles", name, "fallbackProfile"],
-          message: `Profile "${name}" declares fallbackProfile "${fallback}" which sets its own fallbackProfile — fallback is a single hop, chains are not allowed.`,
+          message: `Profile "${name}" declares fallbackProfile "${fallback}" which sets its own fallbackProfile; fallback is a single hop, chains are not allowed.`,
         });
       }
     }

--- a/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
@@ -51,7 +51,7 @@ mock.module("../../../persistence/embeddings/embedding-backend.js", () => ({
 }));
 
 import { getConfig, loadRawConfig } from "../../../config/loader.js";
-import { LLMConfigBase } from "../../../config/schemas/llm.js";
+import { LLMConfigBase, LLMSchema } from "../../../config/schemas/llm.js";
 import type { ConversationCreateType } from "../../../persistence/conversation-types.js";
 import {
   getDb,
@@ -955,6 +955,32 @@ describe("PUT /v1/config/llm/profiles/:name", () => {
         }),
       ).rejects.toThrow(/cannot become a mix/);
     });
+
+    test("clears the profile's own fallbackProfile when converting it to a mix", async () => {
+      // "chained" declares fallbackProfile "backup". Replacing it with a mix
+      // body is an explicit replacement, so the pointer must be dropped: a
+      // persisted entry carrying both `mix` and `fallbackProfile` would be
+      // rejected and stripped on the next full config reload.
+      const result = await replaceProfileRoute.handler({
+        pathParams: { name: "chained" },
+        body: {
+          mix: [
+            { profile: "custom", weight: 1 },
+            { profile: "backup", weight: 1 },
+          ],
+        },
+      });
+      expect(result).toEqual({ ok: true });
+      const saved = persistedProfile("chained");
+      expect(saved.mix).toEqual([
+        { profile: "custom", weight: 1 },
+        { profile: "backup", weight: 1 },
+      ]);
+      expect("fallbackProfile" in saved).toBe(false);
+      // The persisted llm subtree reloads cleanly under the full schema
+      // parse, so the loader will not strip or salvage anything.
+      expect(LLMSchema.safeParse(loadRawConfig().llm).success).toBe(true);
+    });
   });
 
   test("owns contextWindow maxInputTokens while preserving non-UI profile leaves", async () => {
@@ -1360,6 +1386,96 @@ describe("PUT /v1/config/llm/profiles/:name", () => {
       expect(initializeProvidersCalls).toBe(1);
       expect(clearEmbeddingBackendCacheCalls).toBe(1);
     });
+  });
+});
+
+describe("PATCH /v1/config fallbackProfile cross-profile validation", () => {
+  const patchRoute = ROUTES.find((r) => r.operationId === "config_patch")!;
+
+  beforeEach(() => {
+    initializeProvidersCalls = 0;
+    clearEmbeddingBackendCacheCalls = 0;
+    rawConfigFixture = {
+      llm: {
+        profiles: {
+          custom: { provider: "anthropic", model: "claude-sonnet-4-6" },
+          backup: { provider: "anthropic", model: "claude-sonnet-4-6" },
+          chained: {
+            provider: "anthropic",
+            model: "claude-sonnet-4-6",
+            fallbackProfile: "backup",
+          },
+          blend: {
+            mix: [
+              { profile: "custom", weight: 1 },
+              { profile: "backup", weight: 1 },
+            ],
+          },
+        },
+      },
+    };
+    seedRawConfig();
+  });
+
+  test("persists a valid fallbackProfile through the generic patch route", async () => {
+    await patchRoute.handler({
+      body: { llm: { profiles: { custom: { fallbackProfile: "backup" } } } },
+    });
+    expect(persistedProfile("custom").fallbackProfile).toBe("backup");
+  });
+
+  test("rejects a self-referential fallbackProfile without writing", async () => {
+    await expect(
+      patchRoute.handler({
+        body: { llm: { profiles: { custom: { fallbackProfile: "custom" } } } },
+      }),
+    ).rejects.toThrow(/cannot declare itself as its fallbackProfile/);
+    expect(persistedProfile("custom").fallbackProfile).toBeUndefined();
+    // Rejection fires before commitConfigWrite runs any post-write side
+    // effects.
+    expect(initializeProvidersCalls).toBe(0);
+  });
+
+  test("rejects a dangling fallbackProfile without writing", async () => {
+    await expect(
+      patchRoute.handler({
+        body: { llm: { profiles: { custom: { fallbackProfile: "ghost" } } } },
+      }),
+    ).rejects.toThrow(/fallbackProfile "ghost" which is not defined/);
+    expect(persistedProfile("custom").fallbackProfile).toBeUndefined();
+    expect(initializeProvidersCalls).toBe(0);
+  });
+
+  test("rejects a fallbackProfile pointing at a mix profile without writing", async () => {
+    await expect(
+      patchRoute.handler({
+        body: { llm: { profiles: { custom: { fallbackProfile: "blend" } } } },
+      }),
+    ).rejects.toThrow(/which is a mix profile/);
+    expect(persistedProfile("custom").fallbackProfile).toBeUndefined();
+    expect(initializeProvidersCalls).toBe(0);
+  });
+
+  test("rejects a fallbackProfile chain without writing", async () => {
+    await expect(
+      patchRoute.handler({
+        body: {
+          llm: { profiles: { custom: { fallbackProfile: "chained" } } },
+        },
+      }),
+    ).rejects.toThrow(/chains are not allowed/);
+    expect(persistedProfile("custom").fallbackProfile).toBeUndefined();
+    expect(initializeProvidersCalls).toBe(0);
+  });
+
+  test("rejects adding a fallbackProfile to a mix profile without writing", async () => {
+    await expect(
+      patchRoute.handler({
+        body: { llm: { profiles: { blend: { fallbackProfile: "backup" } } } },
+      }),
+    ).rejects.toThrow(/Mix profile "blend" cannot also set "fallbackProfile"/);
+    expect(persistedProfile("blend").fallbackProfile).toBeUndefined();
+    expect(initializeProvidersCalls).toBe(0);
   });
 });
 

--- a/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
@@ -836,6 +836,127 @@ describe("PUT /v1/config/llm/profiles/:name", () => {
     seedRawConfig();
   });
 
+  describe("fallbackProfile cross-profile validation", () => {
+    beforeEach(() => {
+      const llm = rawConfigFixture.llm as {
+        profiles: Record<string, Record<string, unknown>>;
+      };
+      llm.profiles.backup = {
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+      };
+      llm.profiles.chained = {
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+        fallbackProfile: "backup",
+      };
+      llm.profiles.blend = {
+        mix: [
+          { profile: "custom", weight: 1 },
+          { profile: "backup", weight: 1 },
+        ],
+      };
+      seedRawConfig();
+    });
+
+    test("persists a valid fallbackProfile pointer", async () => {
+      const result = await replaceProfileRoute.handler({
+        pathParams: { name: "custom" },
+        body: {
+          provider: "anthropic",
+          model: "claude-sonnet-4-6",
+          fallbackProfile: "backup",
+        },
+      });
+      expect(result).toEqual({ ok: true });
+      expect(persistedProfile("custom").fallbackProfile).toBe("backup");
+    });
+
+    test("rejects a dangling fallbackProfile pointer without writing", async () => {
+      await expect(
+        replaceProfileRoute.handler({
+          pathParams: { name: "custom" },
+          body: {
+            provider: "anthropic",
+            model: "claude-sonnet-4-6",
+            fallbackProfile: "ghost",
+          },
+        }),
+      ).rejects.toThrow(/fallbackProfile "ghost" which is not defined/);
+      expect(persistedProfile("custom").fallbackProfile).toBeUndefined();
+      // Guard rejects before commitConfigWrite fires any side effects.
+      expect(initializeProvidersCalls).toBe(0);
+    });
+
+    test("rejects a self-referential fallbackProfile", async () => {
+      await expect(
+        replaceProfileRoute.handler({
+          pathParams: { name: "custom" },
+          body: {
+            provider: "anthropic",
+            model: "claude-sonnet-4-6",
+            fallbackProfile: "custom",
+          },
+        }),
+      ).rejects.toThrow(/cannot declare itself as its fallbackProfile/);
+    });
+
+    test("rejects a fallbackProfile pointing at a mix profile", async () => {
+      await expect(
+        replaceProfileRoute.handler({
+          pathParams: { name: "custom" },
+          body: {
+            provider: "anthropic",
+            model: "claude-sonnet-4-6",
+            fallbackProfile: "blend",
+          },
+        }),
+      ).rejects.toThrow(/which is a mix profile/);
+    });
+
+    test("rejects a fallbackProfile whose target declares its own fallback (chain)", async () => {
+      await expect(
+        replaceProfileRoute.handler({
+          pathParams: { name: "custom" },
+          body: {
+            provider: "anthropic",
+            model: "claude-sonnet-4-6",
+            fallbackProfile: "chained",
+          },
+        }),
+      ).rejects.toThrow(/chains are not allowed/);
+    });
+
+    test("rejects adding a fallbackProfile to a profile that is itself a fallback target (chain)", async () => {
+      await expect(
+        replaceProfileRoute.handler({
+          pathParams: { name: "backup" },
+          body: {
+            provider: "anthropic",
+            model: "claude-sonnet-4-6",
+            fallbackProfile: "custom",
+          },
+        }),
+      ).rejects.toThrow(
+        /"chained" already declares profile "backup" as its fallbackProfile/,
+      );
+    });
+
+    test("rejects converting a fallback target into a mix profile", async () => {
+      await expect(
+        replaceProfileRoute.handler({
+          pathParams: { name: "backup" },
+          body: {
+            mix: [
+              { profile: "custom", weight: 1 },
+              { profile: "chained", weight: 1 },
+            ],
+          },
+        }),
+      ).rejects.toThrow(/cannot become a mix/);
+    });
+  });
+
   test("owns contextWindow maxInputTokens while preserving non-UI profile leaves", async () => {
     const result = await replaceProfileRoute.handler({
       pathParams: { name: "custom" },

--- a/assistant/src/runtime/routes/__tests__/inference-profiles-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/inference-profiles-routes.test.ts
@@ -625,6 +625,11 @@ describe("collectProfileReferences", () => {
           source: "user",
           mix: [{ profile: "my-fast", weight: 1 }],
         },
+        "my-primary": {
+          source: "user",
+          provider: "anthropic",
+          fallbackProfile: "my-fast",
+        },
       },
     };
     expect(collectProfileReferences(llm, "my-fast").sort()).toEqual(
@@ -633,6 +638,7 @@ describe("collectProfileReferences", () => {
         "llm.advisorProfile",
         "llm.callSites.memoryExtraction",
         "llm.profiles.my-mix.mix",
+        "llm.profiles.my-primary.fallbackProfile",
       ].sort(),
     );
   });
@@ -674,6 +680,22 @@ describe("DELETE inference/profiles/:name reference guard", () => {
     await expect(
       call("inference_profiles_delete", { pathParams: { name: "my-fast" } }),
     ).rejects.toThrow(/llm\.profiles\.my-mix\.mix/);
+  });
+
+  test("rejects deletion referenced by another profile's fallbackProfile", async () => {
+    setConfig("llm", {
+      profiles: {
+        "my-fast": { source: "user", provider: "anthropic" },
+        "my-primary": {
+          source: "user",
+          provider: "anthropic",
+          fallbackProfile: "my-fast",
+        },
+      },
+    });
+    await expect(
+      call("inference_profiles_delete", { pathParams: { name: "my-fast" } }),
+    ).rejects.toThrow(/llm\.profiles\.my-primary\.fallbackProfile/);
   });
 
   test("rejects deletion referenced by a call site", async () => {

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -48,6 +48,7 @@ import {
 import { AssistantConfigSchema } from "../../config/schema.js";
 import { getSchemaAtPath } from "../../config/schema-utils.js";
 import {
+  collectFallbackProfileIssues,
   DefaultProviderSchema,
   LLMConfigBase,
   LLMConfigFragment,
@@ -240,6 +241,13 @@ function replaceInferenceProfileConfig(
   const nextProfile: Record<string, unknown> = { ...existingProfile };
   for (const key of INFERENCE_PROFILE_UI_KEYS) {
     delete nextProfile[key];
+  }
+  // Converting a profile to a mix is an explicit replacement: a mix carries
+  // no model route of its own to fall back from, so an existing
+  // `fallbackProfile` pointer is dropped rather than preserved alongside
+  // `mix` (a combination `LLMSchema` rejects on the next full reload).
+  if (fragment.mix != null) {
+    delete nextProfile.fallbackProfile;
   }
   const fragmentTopLevel = { ...fragment };
   delete fragmentTopLevel.contextWindow;
@@ -1399,6 +1407,26 @@ function assertRoutableIdentityEntries(
   }
 }
 
+/**
+ * Reject writes that would persist an invalid `fallbackProfile` graph.
+ * `LLMSchema.superRefine` enforces the cross-profile fallback rules only on
+ * a full-config parse; the write paths (PATCH deep-merge, SET, the profile
+ * routes) save raw config without one, so a self-reference, dangling
+ * target, mix target, or chain would reach disk and be stripped on the next
+ * reload, silently disabling the configured fallback. Checked
+ * unconditionally rather than scoped to pointers this write changes:
+ * removing a target profile invalidates a pointer the write never touched,
+ * and clearing the pointer (write `null`) through these same routes remains
+ * the repair path for a hand-edited config.
+ */
+function assertValidFallbackProfileGraph(raw: Record<string, unknown>): void {
+  const profiles = readPlainObject(readPlainObject(raw.llm)?.profiles);
+  const issues = collectFallbackProfileIssues(profiles ?? undefined);
+  if (issues.length > 0) {
+    throw new BadRequestError(issues.map((issue) => issue.message).join(" "));
+  }
+}
+
 export async function commitConfigWrite(
   raw: Record<string, unknown>,
   opLabel: string,
@@ -1411,6 +1439,7 @@ export async function commitConfigWrite(
   completeChangedCustomProfiles(preWrite, raw);
   assertInvariantProfilesPreserved(preWrite, raw);
   assertRoutableIdentityEntries(preWrite, raw);
+  assertValidFallbackProfileGraph(raw);
 
   // Suppress the file-watcher callback for the duration of the debounce
   // window. Without this, the ConfigWatcher detects the config.json write

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -1808,6 +1808,59 @@ async function handleReplaceInferenceProfile({
         );
       }
     });
+    // A fallback target must stay a standard profile: converting one to a
+    // mix would leave another profile's fallbackProfile pointing at a mix,
+    // which `LLMSchema.superRefine` rejects on the next full reparse.
+    for (const [otherName, other] of Object.entries(existingProfiles)) {
+      if (otherName !== name && other?.fallbackProfile === name) {
+        throw new BadRequestError(
+          `Profile "${otherName}" declares profile "${name}" as its fallbackProfile; a fallback must be a standard profile, so "${name}" cannot become a mix.`,
+        );
+      }
+    }
+  }
+
+  // `fallbackProfile` references another profile by name. As with `mix`, the
+  // cross-profile integrity rules `LLMSchema.superRefine` enforces on
+  // full-config load (target exists, no self-reference, target is not a mix,
+  // single hop) must be checked here against the live profile set; otherwise
+  // a dangling or chained pointer would persist and break the next full
+  // config reparse.
+  if (parsed.data.fallbackProfile != null) {
+    const fallback = parsed.data.fallbackProfile;
+    if (fallback === name) {
+      throw new BadRequestError(
+        `Profile "${name}" cannot declare itself as its fallbackProfile.`,
+      );
+    }
+    const { llm: parsedLlm } = getConfig();
+    const existingProfiles = getEffectiveProfilesForProvider(
+      parsedLlm.profiles,
+      parsedLlm.defaultProvider ?? null,
+    );
+    const target = existingProfiles[fallback];
+    if (target == null) {
+      throw new BadRequestError(
+        `Profile "${name}" declares fallbackProfile "${fallback}" which is not defined.`,
+      );
+    }
+    if (target.mix != null) {
+      throw new BadRequestError(
+        `Profile "${name}" declares fallbackProfile "${fallback}" which is a mix profile; a fallback must be a standard profile.`,
+      );
+    }
+    if (target.fallbackProfile != null) {
+      throw new BadRequestError(
+        `Profile "${name}" declares fallbackProfile "${fallback}" which sets its own fallbackProfile; fallback is a single hop, chains are not allowed.`,
+      );
+    }
+    for (const [otherName, other] of Object.entries(existingProfiles)) {
+      if (otherName !== name && other?.fallbackProfile === name) {
+        throw new BadRequestError(
+          `Profile "${otherName}" already declares profile "${name}" as its fallbackProfile; fallback is a single hop, chains are not allowed.`,
+        );
+      }
+    }
   }
 
   // When the UI sends provider but no provider_connection, derive the connection

--- a/assistant/src/runtime/routes/inference-profiles-routes.ts
+++ b/assistant/src/runtime/routes/inference-profiles-routes.ts
@@ -338,8 +338,9 @@ function fragmentFromBody(
 
 /**
  * Enumerate every live reference to profile `name` in the raw `llm` config
- * block: `activeProfile`, `advisorProfile`, each `callSites.<id>.profile`, and
- * every mix arm (`profiles.<mix>.mix[].profile`). Deleting a profile while any
+ * block: `activeProfile`, `advisorProfile`, each `callSites.<id>.profile`,
+ * every mix arm (`profiles.<mix>.mix[].profile`), and every fallback pointer
+ * (`profiles.<p>.fallbackProfile`). Deleting a profile while any
  * of these point at it would leave a dangling reference that `LLMSchema`'s
  * superRefine rejects on the next load — silently resetting the user's chat
  * model or call-site pins. The delete handler rejects instead.
@@ -369,12 +370,16 @@ export function collectProfileReferences(
   const profiles = asPlainObject(llm.profiles);
   if (profiles) {
     for (const [profileName, profileEntry] of Object.entries(profiles)) {
-      const mix = asPlainObject(profileEntry)?.mix;
+      const entry = asPlainObject(profileEntry);
+      const mix = entry?.mix;
       if (
         Array.isArray(mix) &&
         mix.some((arm) => asPlainObject(arm)?.profile === name)
       ) {
         refs.push(`llm.profiles.${profileName}.mix`);
+      }
+      if (entry?.fallbackProfile === name) {
+        refs.push(`llm.profiles.${profileName}.fallbackProfile`);
       }
     }
   }
@@ -903,7 +908,7 @@ export const ROUTES: RouteDefinition[] = [
       "404": { description: "Profile not found" },
       "409": {
         description:
-          "Profile is still referenced by activeProfile, advisorProfile, a call site, a default-tier override, or a mix arm",
+          "Profile is still referenced by activeProfile, advisorProfile, a call site, a default-tier override, a mix arm, or another profile's fallbackProfile",
       },
     },
     handler: handleDeleteProfile,


### PR DESCRIPTION
## Summary
- Adds optional `fallbackProfile` pointer to `ProfileEntry` for outage fallback routing
- superRefine validation: referenced profile must exist, no self-reference, no mix targets, single hop only
- Parse-level schema tests

Part of plan: model-fallbacks.md (PR 1 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41165" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->