### PR TITLE
Flag misconfigured profiles with a warning icon in listings

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -5133,6 +5133,8 @@ paths:
                 provider_connection:
                   type: string
                   minLength: 1
+                allowUnlisted:
+                  type: boolean
                 status:
                   anyOf:
                     - $ref: "#/components/schemas/ProfileStatus"
@@ -34609,6 +34611,10 @@ components:
             - type: string
               minLength: 1
             - type: "null"
+        allowUnlisted:
+          anyOf:
+            - type: boolean
+            - type: "null"
         status:
           anyOf:
             - anyOf:
@@ -35381,6 +35387,8 @@ components:
         provider_connection:
           type: string
           minLength: 1
+        allowUnlisted:
+          type: boolean
         status:
           anyOf:
             - $ref: "#/components/schemas/ProfileStatus"
@@ -35694,7 +35702,8 @@ components:
           type: string
           enum:
             - model_unknown
-            - max_tokens_invalid
+            - over_output_cap
+            - no_input_room
         message:
           type: string
       required:

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -35657,6 +35657,8 @@ components:
           anyOf:
             - $ref: "#/components/schemas/ProfileConnectionAvailability"
             - type: "null"
+        config_issue:
+          $ref: "#/components/schemas/InferenceProfileConfigIssue"
       required:
         - name
         - label
@@ -35684,6 +35686,20 @@ components:
           type: string
       required:
         - status
+      additionalProperties: false
+    InferenceProfileConfigIssue:
+      type: object
+      properties:
+        code:
+          type: string
+          enum:
+            - model_unknown
+            - max_tokens_invalid
+        message:
+          type: string
+      required:
+        - code
+        - message
       additionalProperties: false
     InferenceProfileWriteResult:
       type: object
@@ -35725,6 +35741,8 @@ components:
           anyOf:
             - $ref: "#/components/schemas/ProfileConnectionAvailability"
             - type: "null"
+        config_issue:
+          $ref: "#/components/schemas/InferenceProfileConfigIssue"
       required:
         - name
         - entry

--- a/assistant/src/cli/commands/inference-profiles.ts
+++ b/assistant/src/cli/commands/inference-profiles.ts
@@ -28,6 +28,8 @@ interface ProfileSummary {
   source: "managed" | "user";
   provider_connection?: string;
   availability: { status: string; message?: string } | null;
+  /** Static problem with the stored entry itself; absent when it checks out. */
+  config_issue?: { code: string; message: string };
 }
 
 interface ProfileWriteResult {
@@ -178,7 +180,16 @@ export function attachProfilesSubcommand(inference: Command): void {
       return;
     }
     renderTable(
-      ["NAME", "LABEL", "PROVIDER", "MODEL", "STATUS", "SOURCE", "AVAIL"],
+      [
+        "NAME",
+        "LABEL",
+        "PROVIDER",
+        "MODEL",
+        "STATUS",
+        "SOURCE",
+        "AVAIL",
+        "CONFIG",
+      ],
       rows.map((p) => [
         p.name,
         p.label ?? "-",
@@ -187,6 +198,7 @@ export function attachProfilesSubcommand(inference: Command): void {
         p.status,
         p.source,
         p.availability ? p.availability.status : "-",
+        p.config_issue ? p.config_issue.code : "ok",
       ]),
     );
   });
@@ -198,6 +210,7 @@ export function attachProfilesSubcommand(inference: Command): void {
         name: string;
         entry: Record<string, unknown>;
         availability: { status: string; message?: string } | null;
+        config_issue?: { code: string; message: string };
       }>("inference_profiles_get", { pathParams: { name } });
       if (!ipcResult.ok) {
         writeCliError(ipcResult.error ?? "Unknown error", opts.json);
@@ -217,6 +230,10 @@ export function attachProfilesSubcommand(inference: Command): void {
         if (result.availability.message) {
           writeLine(`    ${result.availability.message}`);
         }
+      }
+      if (result.config_issue) {
+        writeLine(`  config: ${result.config_issue.code}`);
+        writeLine(`    ${result.config_issue.message}`);
       }
     },
   );

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -605,6 +605,13 @@ export const ProfileEntry = LLMConfigFragment.extend({
    */
   provider_connection: z.string().min(1).optional(),
   /**
+   * The profile was deliberately created for a model the catalog does not
+   * list (the write routes' allowUnlisted escape hatch). Stamped at write
+   * time so listings do not flag the row as misconfigured on every read;
+   * a model the checks can vouch for never needs it.
+   */
+  allowUnlisted: z.boolean().optional(),
+  /**
    * Absent means active. `.nullable()` matches `label` so the PUT route's
    * "send `null` to clear" sentinel works for status too — a managed
    * re-enable body of `{status: null}` clears back to active-by-absence

--- a/assistant/src/runtime/routes/__tests__/inference-profiles-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/inference-profiles-routes.test.ts
@@ -766,6 +766,48 @@ describe("POST inference/profiles/:name/validate billing guards", () => {
   });
 });
 
+describe("GET inference/profiles config_issue verdict", () => {
+  test("flags a stored profile whose model the provider does not serve", async () => {
+    seedConnection("anthropic-personal", "anthropic", {
+      type: "api_key",
+      credential: "credential/anthropic/api_key",
+    });
+    setConfig("llm", {
+      profiles: {
+        busted: { provider: "anthropic", model: "bub bub" },
+        fine: { provider: "anthropic", model: "claude-opus-4-8" },
+      },
+    });
+    const result = (await call("inference_profiles_list", {})) as {
+      profiles: Array<{
+        name: string;
+        config_issue?: { code: string; message: string };
+      }>;
+    };
+    const busted = result.profiles.find((p) => p.name === "busted");
+    expect(busted?.config_issue?.code).toBe("model_unknown");
+    expect(busted?.config_issue?.message).toContain("bub bub");
+    const fine = result.profiles.find((p) => p.name === "fine");
+    expect(fine?.config_issue).toBeUndefined();
+  });
+
+  test("flags an impossible stored token budget and mirrors on the detail route", async () => {
+    setConfig("llm", {
+      profiles: {
+        overweight: {
+          provider: "anthropic",
+          model: "claude-opus-4-8",
+          maxTokens: 999999999,
+        },
+      },
+    });
+    const detail = (await call("inference_profiles_get", {
+      pathParams: { name: "overweight" },
+    })) as { config_issue?: { code: string } };
+    expect(detail.config_issue?.code).toBe("max_tokens_invalid");
+  });
+});
+
 describe("PUT inference/active-profile validation", () => {
   test("sets a valid profile", async () => {
     seedKeyedConnection("anthropic");

--- a/assistant/src/runtime/routes/__tests__/inference-profiles-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/inference-profiles-routes.test.ts
@@ -804,7 +804,32 @@ describe("GET inference/profiles config_issue verdict", () => {
     const detail = (await call("inference_profiles_get", {
       pathParams: { name: "overweight" },
     })) as { config_issue?: { code: string } };
-    expect(detail.config_issue?.code).toBe("max_tokens_invalid");
+    expect(detail.config_issue?.code).toBe("over_output_cap");
+  });
+
+  test("does not flag a deliberately allowUnlisted profile", async () => {
+    seedConnection("anthropic-personal", "anthropic", {
+      type: "api_key",
+      credential: "credential/anthropic/api_key",
+    });
+    await call("inference_profiles_create", {
+      body: {
+        name: "early-adopter",
+        provider: "anthropic",
+        model: "claude-6-preview",
+        connection: "anthropic-personal",
+        allowUnlisted: true,
+        allowUnavailable: true,
+      },
+    });
+    const result = (await call("inference_profiles_list", {})) as {
+      profiles: Array<{
+        name: string;
+        config_issue?: { code: string };
+      }>;
+    };
+    const row = result.profiles.find((p) => p.name === "early-adopter");
+    expect(row?.config_issue).toBeUndefined();
   });
 });
 

--- a/assistant/src/runtime/routes/inference-profiles-routes.ts
+++ b/assistant/src/runtime/routes/inference-profiles-routes.ts
@@ -87,6 +87,18 @@ const availabilitySchema = z
   })
   .meta({ id: "ProfileConnectionAvailability" });
 
+/**
+ * Static config problem with the stored entry itself (unknown model,
+ * impossible token budget), distinct from `availability` which judges the
+ * connection and credential behind it. Absent when the config checks out.
+ */
+const profileConfigIssueSchema = z
+  .object({
+    code: z.enum(["model_unknown", "max_tokens_invalid"]),
+    message: z.string(),
+  })
+  .meta({ id: "InferenceProfileConfigIssue" });
+
 const profileSummarySchema = z
   .object({
     name: z.string(),
@@ -98,6 +110,7 @@ const profileSummarySchema = z
     provider_connection: z.string().optional(),
     /** Null when the profile has no provider to judge (e.g. mix profiles). */
     availability: availabilitySchema.nullable(),
+    config_issue: profileConfigIssueSchema.optional(),
   })
   .meta({ id: "InferenceProfileSummary" });
 
@@ -106,6 +119,7 @@ const profileDetailSchema = z
     name: z.string(),
     entry: z.record(z.string(), z.unknown()),
     availability: availabilitySchema.nullable(),
+    config_issue: profileConfigIssueSchema.optional(),
   })
   .meta({ id: "InferenceProfileDetail" });
 
@@ -180,59 +194,123 @@ function assertValidProvider(provider: string): void {
  * (never throws) when `allowUnlisted`; throws otherwise for an uncataloged
  * model. An uncataloged model always warns, whether or not it is allowed.
  */
+/**
+ * Why a (provider, model, connection) triple cannot be vouched for, or null.
+ * The same reach checks dispatch applies: routing identities against their
+ * routing table, entry names against their row's dispatchable kind, vendor
+ * ids against the catalog, with the named connection's advertised model list
+ * authoritative for models the code-owned catalog doesn't know (a custom
+ * endpoint declares its own models at connection-create time).
+ */
+function modelReachIssue(
+  provider: string,
+  model: string,
+  connectionName?: string,
+): { identity: boolean; catalogProvider: string; message: string } | null {
+  if (ROUTING_IDENTITY_PROVIDERS.has(provider)) {
+    const issue = routingIdentityModelIssue(provider, model);
+    return issue
+      ? { identity: true, catalogProvider: provider, message: issue }
+      : null;
+  }
+  const entryKind = resolveEntryProviderKind(provider, model);
+  const catalogProvider = entryKind ?? provider;
+  if (isModelInCatalog(catalogProvider, model)) {
+    return null;
+  }
+  const modelListConnection =
+    connectionName ?? (entryKind !== null ? provider : undefined);
+  if (modelListConnection) {
+    const connection = getConnection(getDb(), modelListConnection);
+    if (connection?.models?.some((m) => m.id === model)) {
+      return null;
+    }
+  }
+  return {
+    identity: false,
+    catalogProvider,
+    message: `Model "${model}" is not in the catalog for provider "${catalogProvider}".`,
+  };
+}
+
 function validateModel(
   provider: string,
   model: string,
   allowUnlisted: boolean,
   connectionName?: string,
 ): string[] {
-  // Routing identities key no catalog entries; they validate against their
-  // route's actual reach — the same checks dispatch applies per-request.
-  // allowUnlisted deliberately does not apply: the routing table ships in
-  // this build, so an unroutable pair fails every request, and the schema
-  // strips it on the next config read.
-  if (ROUTING_IDENTITY_PROVIDERS.has(provider)) {
-    const issue = routingIdentityModelIssue(provider, model);
-    if (issue) {
-      throw new BadRequestError(
-        `${issue} Pick a model this route serves, or a concrete provider.`,
-      );
-    }
+  const issue = modelReachIssue(provider, model, connectionName);
+  if (!issue) {
     return [];
   }
-  // An entry-name provider validates against its row's dispatchable kind,
-  // the same translation dispatch uses; the entry itself also serves as the
-  // model-list connection for custom endpoints below.
-  const entryKind = resolveEntryProviderKind(provider, model);
-  const catalogProvider = entryKind ?? provider;
-  if (isModelInCatalog(catalogProvider, model)) {
-    return [];
-  }
-  // The named connection's advertised model list is authoritative for models
-  // the code-owned catalog doesn't know — a custom (openai-compatible)
-  // endpoint declares its own models at connection-create time.
-  const modelListConnection =
-    connectionName ?? (entryKind !== null ? provider : undefined);
-  if (modelListConnection) {
-    const connection = getConnection(getDb(), modelListConnection);
-    if (connection?.models?.some((m) => m.id === model)) {
-      return [];
-    }
+  // allowUnlisted deliberately does not apply to routing identities: the
+  // routing table ships in this build, so an unroutable pair fails every
+  // request, and the schema strips it on the next config read.
+  if (issue.identity) {
+    throw new BadRequestError(
+      `${issue.message} Pick a model this route serves, or a concrete provider.`,
+    );
   }
   if (!allowUnlisted) {
     const remedy =
-      catalogProvider === "openai-compatible"
+      issue.catalogProvider === "openai-compatible"
         ? `Pass allowUnlisted to create it anyway, or declare the model on the connection ` +
           `("assistant inference providers update <name> --model ${model}").`
         : `Pass allowUnlisted to create it anyway, or run ` +
           `"assistant inference models list --provider ${provider}" to see valid ids.`;
-    throw new BadRequestError(
-      `Model "${model}" is not in the catalog for provider "${catalogProvider}". ${remedy}`,
-    );
+    throw new BadRequestError(`${issue.message} ${remedy}`);
   }
-  return [
-    `Model "${model}" is not in the catalog for provider "${catalogProvider}"; created anyway (allowUnlisted).`,
-  ];
+  return [`${issue.message} Created anyway (allowUnlisted).`];
+}
+
+/**
+ * Static config verdict for a stored profile: the model-reach and
+ * token-budget judgments the write routes enforce, recomputed over the
+ * entry so rows that predate validation (or were written through the
+ * generic config escape hatch) surface their problem in listings. Cheap
+ * and offline; the live probe covers what only a request can prove. Mix
+ * arms are judged on their own rows, and managed bodies are code-owned.
+ */
+function profileConfigIssue(
+  record: Record<string, unknown>,
+): { code: "model_unknown" | "max_tokens_invalid"; message: string } | null {
+  if (record.mix != null || record.source === "managed") {
+    return null;
+  }
+  const provider =
+    typeof record.provider === "string" ? record.provider : undefined;
+  const model = typeof record.model === "string" ? record.model : undefined;
+  if (!provider || !model) {
+    // A missing provider/model is availability's `incomplete` verdict.
+    return null;
+  }
+  const reach = modelReachIssue(
+    provider,
+    model,
+    typeof record.provider_connection === "string"
+      ? record.provider_connection
+      : undefined,
+  );
+  if (reach) {
+    return { code: "model_unknown", message: reach.message };
+  }
+  if (typeof record.maxTokens === "number") {
+    const catalogProvider = catalogProviderForProfile(provider, model);
+    if (catalogProvider !== null) {
+      const budget = validateInferenceProfileConfig({
+        maxTokens: record.maxTokens,
+        modelMaxOutputTokens: catalogMaxOutputTokens(catalogProvider, model),
+        modelContextWindowTokens: catalogContextWindowTokens(
+          catalogProvider,
+          model,
+        ),
+      });
+      if (budget) {
+        return { code: "max_tokens_invalid", message: budget.message };
+      }
+    }
+  }
+  return null;
 }
 
 function assertConnectionExists(name: string): void {
@@ -434,6 +512,7 @@ async function handleListProfiles() {
   const profiles = await Promise.all(
     Object.entries(effective).map(async ([name, entry]) => {
       const record = entry as Record<string, unknown>;
+      const configIssue = profileConfigIssue(record);
       return {
         name,
         label: typeof record.label === "string" ? record.label : null,
@@ -445,6 +524,7 @@ async function handleListProfiles() {
           ? { provider_connection: record.provider_connection }
           : {}),
         availability: await computeProfileAvailability(record),
+        ...(configIssue ? { config_issue: configIssue } : {}),
       };
     }),
   );
@@ -466,10 +546,12 @@ async function handleGetProfile({ pathParams = {} }: RouteHandlerArgs) {
     throw new NotFoundError(`Profile "${name}" not found.`);
   }
   const record = entry as Record<string, unknown>;
+  const configIssue = profileConfigIssue(record);
   return {
     name,
     entry: record,
     availability: await computeProfileAvailability(record),
+    ...(configIssue ? { config_issue: configIssue } : {}),
   };
 }
 

--- a/assistant/src/runtime/routes/inference-profiles-routes.ts
+++ b/assistant/src/runtime/routes/inference-profiles-routes.ts
@@ -295,22 +295,37 @@ function profileConfigIssue(
     return { code: "model_unknown", message: reach.message };
   }
   if (typeof record.maxTokens === "number") {
-    const catalogProvider = catalogProviderForProfile(provider, model);
-    if (catalogProvider !== null) {
-      const budget = validateInferenceProfileConfig({
-        maxTokens: record.maxTokens,
-        modelMaxOutputTokens: catalogMaxOutputTokens(catalogProvider, model),
-        modelContextWindowTokens: catalogContextWindowTokens(
-          catalogProvider,
-          model,
-        ),
-      });
-      if (budget) {
-        return { code: "max_tokens_invalid", message: budget.message };
-      }
+    const budget = maxTokensBudgetIssue(provider, model, record.maxTokens);
+    if (budget) {
+      return { code: "max_tokens_invalid", message: budget.message };
     }
   }
   return null;
+}
+
+/**
+ * The shared token-budget judgment over a (provider, model, maxTokens)
+ * triple with the catalog-provider translation applied. Null when the budget
+ * passes or the catalog knows nothing to judge against. One implementation
+ * for the write routes and the listing verdict so the two cannot drift.
+ */
+function maxTokensBudgetIssue(
+  provider: string,
+  model: string,
+  maxTokens: number,
+): ReturnType<typeof validateInferenceProfileConfig> {
+  const catalogProvider = catalogProviderForProfile(provider, model);
+  if (catalogProvider === null) {
+    return null;
+  }
+  return validateInferenceProfileConfig({
+    maxTokens,
+    modelMaxOutputTokens: catalogMaxOutputTokens(catalogProvider, model),
+    modelContextWindowTokens: catalogContextWindowTokens(
+      catalogProvider,
+      model,
+    ),
+  });
 }
 
 function assertConnectionExists(name: string): void {
@@ -482,18 +497,7 @@ function assertSaneMaxTokens(
   if (maxTokens === undefined) {
     return;
   }
-  const catalogProvider = catalogProviderForProfile(provider, model);
-  if (catalogProvider === null) {
-    return;
-  }
-  const issue = validateInferenceProfileConfig({
-    maxTokens,
-    modelMaxOutputTokens: catalogMaxOutputTokens(catalogProvider, model),
-    modelContextWindowTokens: catalogContextWindowTokens(
-      catalogProvider,
-      model,
-    ),
-  });
+  const issue = maxTokensBudgetIssue(provider, model, maxTokens);
   if (issue) {
     throw new BadRequestError(issue.message);
   }

--- a/assistant/src/runtime/routes/inference-profiles-routes.ts
+++ b/assistant/src/runtime/routes/inference-profiles-routes.ts
@@ -94,7 +94,7 @@ const availabilitySchema = z
  */
 const profileConfigIssueSchema = z
   .object({
-    code: z.enum(["model_unknown", "max_tokens_invalid"]),
+    code: z.enum(["model_unknown", "over_output_cap", "no_input_room"]),
     message: z.string(),
   })
   .meta({ id: "InferenceProfileConfigIssue" });
@@ -190,11 +190,6 @@ function assertValidProvider(provider: string): void {
 }
 
 /**
- * Validate a (provider, model) pair against the catalog. Returns warnings
- * (never throws) when `allowUnlisted`; throws otherwise for an uncataloged
- * model. An uncataloged model always warns, whether or not it is allowed.
- */
-/**
  * Why a (provider, model, connection) triple cannot be vouched for, or null.
  * The same reach checks dispatch applies: routing identities against their
  * routing table, entry names against their row's dispatchable kind, vendor
@@ -233,6 +228,11 @@ function modelReachIssue(
   };
 }
 
+/**
+ * Validate a (provider, model) pair against the catalog. Returns warnings
+ * (never throws) when `allowUnlisted`; throws otherwise for an uncataloged
+ * model. An uncataloged model always warns, whether or not it is allowed.
+ */
 function validateModel(
   provider: string,
   model: string,
@@ -271,9 +271,10 @@ function validateModel(
  * and offline; the live probe covers what only a request can prove. Mix
  * arms are judged on their own rows, and managed bodies are code-owned.
  */
-function profileConfigIssue(
-  record: Record<string, unknown>,
-): { code: "model_unknown" | "max_tokens_invalid"; message: string } | null {
+function profileConfigIssue(record: Record<string, unknown>): {
+  code: "model_unknown" | "over_output_cap" | "no_input_room";
+  message: string;
+} | null {
   if (record.mix != null || record.source === "managed") {
     return null;
   }
@@ -284,20 +285,24 @@ function profileConfigIssue(
     // A missing provider/model is availability's `incomplete` verdict.
     return null;
   }
-  const reach = modelReachIssue(
-    provider,
-    model,
-    typeof record.provider_connection === "string"
-      ? record.provider_connection
-      : undefined,
-  );
-  if (reach) {
-    return { code: "model_unknown", message: reach.message };
+  // A stored allowUnlisted marker records that catalog absence was accepted
+  // deliberately at write time; the live probe is the check for those.
+  if (record.allowUnlisted !== true) {
+    const reach = modelReachIssue(
+      provider,
+      model,
+      typeof record.provider_connection === "string"
+        ? record.provider_connection
+        : undefined,
+    );
+    if (reach) {
+      return { code: "model_unknown", message: reach.message };
+    }
   }
   if (typeof record.maxTokens === "number") {
     const budget = maxTokensBudgetIssue(provider, model, record.maxTokens);
     if (budget) {
-      return { code: "max_tokens_invalid", message: budget.message };
+      return { code: budget.code, message: budget.message };
     }
   }
   return null;
@@ -597,6 +602,12 @@ async function handleCreateProfile({ body = {} }: RouteHandlerArgs) {
     provider: input.provider,
     model: input.model,
     source: "user",
+    // `warnings` here can only be validateModel's unlisted verdict (the
+    // availability warning pushes later), so its presence is exactly the
+    // deliberate allowUnlisted acceptance the listing verdict must honor.
+    ...(input.allowUnlisted && warnings.length > 0
+      ? { allowUnlisted: true }
+      : {}),
   };
   // Pickers render the label, so a label-less profile shows its raw config
   // key (e.g. "gemini-latest"). Default it to the model's human-readable
@@ -747,6 +758,17 @@ async function handleUpdateProfile({
     source:
       existing.source === "managed" ? "user" : (existing.source ?? "user"),
   };
+  // Keep the allowUnlisted marker faithful to the pair being stored: stamp
+  // it on a deliberate unlisted acceptance (warnings can only be the
+  // unlisted verdict here), and drop a stale one when the pair is now
+  // vouched for. Untouched pairs keep their stored marker.
+  if (input.provider !== undefined || input.model !== undefined) {
+    if (input.allowUnlisted && warnings.length > 0) {
+      merged.allowUnlisted = true;
+    } else if (warnings.length === 0) {
+      delete merged.allowUnlisted;
+    }
+  }
   validateProfileEntry(merged);
 
   // The availability guard runs only when the write touches the fields that

--- a/clients/web/src/domains/settings/ai/profile-row.tsx
+++ b/clients/web/src/domains/settings/ai/profile-row.tsx
@@ -99,9 +99,11 @@ export function ProfileRow({
     configIssue != null
       ? t("profileRow.providerUnavailableFixable", {
           message: t(
-            configIssue.code === "max_tokens_invalid"
-              ? "profileRow.configIssueMaxTokens"
-              : "profileRow.configIssueModelUnknown",
+            configIssue.code === "over_output_cap"
+              ? "profileRow.configIssueOverOutputCap"
+              : configIssue.code === "no_input_room"
+                ? "profileRow.configIssueNoInputRoom"
+                : "profileRow.configIssueModelUnknown",
           ),
         })
       : availability != null && availability.status !== "ok"

--- a/clients/web/src/domains/settings/ai/profile-row.tsx
+++ b/clients/web/src/domains/settings/ai/profile-row.tsx
@@ -92,11 +92,17 @@ export function ProfileRow({
   const availabilityMessage =
     availability?.message ?? t("profileRow.providerUnavailableDefault");
   // A config issue outranks availability: the entry itself is wrong, so the
-  // connection verdict behind it is secondary.
+  // connection verdict behind it is secondary. Composed from catalog copy
+  // keyed on the issue code, so the surface stays translated; the daemon's
+  // English detail remains in the editor and CLI.
   const rowProblem =
     configIssue != null
       ? t("profileRow.providerUnavailableFixable", {
-          message: configIssue.message,
+          message: t(
+            configIssue.code === "max_tokens_invalid"
+              ? "profileRow.configIssueMaxTokens"
+              : "profileRow.configIssueModelUnknown",
+          ),
         })
       : availability != null && availability.status !== "ok"
         ? fixableHere

--- a/clients/web/src/domains/settings/ai/profile-row.tsx
+++ b/clients/web/src/domains/settings/ai/profile-row.tsx
@@ -80,22 +80,31 @@ export function ProfileRow({
   }
 
   const availability = profile.availability;
+  const configIssue = profile.config_issue;
   // This row opens the profile editor, which is where a missing provider or
   // model is filled in. A connection or credential problem is repaired
   // elsewhere, and those messages already name where, so only the
-  // `incomplete` case invites a click: promising a fix the editor cannot
-  // perform would send the user somewhere that does not help.
-  const fixableHere = availability?.status === "incomplete";
+  // `incomplete` availability case and a config issue (bad model or token
+  // budget, both edited right here) invite a click: promising a fix the
+  // editor cannot perform would send the user somewhere that does not help.
+  const fixableHere =
+    configIssue != null || availability?.status === "incomplete";
   const availabilityMessage =
     availability?.message ?? t("profileRow.providerUnavailableDefault");
-  const availabilityProblem =
-    availability != null && availability.status !== "ok"
-      ? fixableHere
-        ? t("profileRow.providerUnavailableFixable", {
-            message: availabilityMessage,
-          })
-        : availabilityMessage
-      : null;
+  // A config issue outranks availability: the entry itself is wrong, so the
+  // connection verdict behind it is secondary.
+  const rowProblem =
+    configIssue != null
+      ? t("profileRow.providerUnavailableFixable", {
+          message: configIssue.message,
+        })
+      : availability != null && availability.status !== "ok"
+        ? fixableHere
+          ? t("profileRow.providerUnavailableFixable", {
+              message: availabilityMessage,
+            })
+          : availabilityMessage
+        : null;
 
   return (
     <ListRow
@@ -117,13 +126,13 @@ export function ProfileRow({
       trailingInteractive
       trailing={
         <>
-          {availabilityProblem != null ? (
-            <Tooltip content={availabilityProblem}>
+          {rowProblem != null ? (
+            <Tooltip content={rowProblem}>
               {fixableHere ? (
                 <button
                   type="button"
                   onClick={onOpen}
-                  aria-label={availabilityProblem}
+                  aria-label={rowProblem}
                   className="inline-flex cursor-pointer rounded-sm p-0.5 keyboard-focus:ring-2 keyboard-focus:ring-[var(--ring)]"
                 >
                   <AlertCircle
@@ -135,7 +144,7 @@ export function ProfileRow({
                 <span className="inline-flex p-0.5" tabIndex={0}>
                   <AlertCircle
                     className="h-4 w-4 text-[var(--system-mid-strong)]"
-                    aria-label={availabilityProblem}
+                    aria-label={rowProblem}
                     role="img"
                   />
                 </span>
@@ -162,9 +171,7 @@ export function ProfileRow({
             </Menu.Trigger>
             <Menu.Content align="end" sideOffset={4}>
               <Menu.Item onSelect={onOpen}>
-                {isManaged
-                  ? t("profileRow.view")
-                  : t("profileRow.edit")}
+                {isManaged ? t("profileRow.view") : t("profileRow.edit")}
               </Menu.Item>
               {!isActiveProfile && !isDisabled ? (
                 <Menu.Item onSelect={onMakeActive}>

--- a/clients/web/src/i18n/locales/en/settings.json
+++ b/clients/web/src/i18n/locales/en/settings.json
@@ -1529,6 +1529,8 @@
     "makeDefault": "Make Default",
     "managedByVellum": "Managed by Vellum",
     "openProfileAriaLabel": "Open profile {displayName}",
+    "configIssueMaxTokens": "This profile's max output tokens exceed what its model supports.",
+    "configIssueModelUnknown": "This profile's model is not available from its provider.",
     "providerUnavailableDefault": "This profile's provider is not available.",
     "providerUnavailableFixable": "{message} Click to fix.",
     "view": "View"

--- a/clients/web/src/i18n/locales/en/settings.json
+++ b/clients/web/src/i18n/locales/en/settings.json
@@ -1529,8 +1529,9 @@
     "makeDefault": "Make Default",
     "managedByVellum": "Managed by Vellum",
     "openProfileAriaLabel": "Open profile {displayName}",
-    "configIssueMaxTokens": "This profile's max output tokens exceed what its model supports.",
     "configIssueModelUnknown": "This profile's model is not available from its provider.",
+    "configIssueNoInputRoom": "This profile's max output tokens leave no room for input in the model's context window.",
+    "configIssueOverOutputCap": "This profile's max output tokens exceed what its model supports.",
     "providerUnavailableDefault": "This profile's provider is not available.",
     "providerUnavailableFixable": "{message} Click to fix.",
     "view": "View"

--- a/clients/web/src/i18n/locales/es/settings.json
+++ b/clients/web/src/i18n/locales/es/settings.json
@@ -1529,6 +1529,8 @@
     "makeDefault": "Hacer predeterminado",
     "managedByVellum": "Gestionado por Vellum",
     "openProfileAriaLabel": "Abrir perfil {displayName}",
+    "configIssueMaxTokens": "El máximo de tokens de salida de este perfil supera lo que admite su modelo.",
+    "configIssueModelUnknown": "El modelo de este perfil no está disponible en su proveedor.",
     "providerUnavailableDefault": "El proveedor de este perfil no está disponible.",
     "providerUnavailableFixable": "{message} Haz clic para corregirlo.",
     "view": "Ver"

--- a/clients/web/src/i18n/locales/es/settings.json
+++ b/clients/web/src/i18n/locales/es/settings.json
@@ -1529,8 +1529,9 @@
     "makeDefault": "Hacer predeterminado",
     "managedByVellum": "Gestionado por Vellum",
     "openProfileAriaLabel": "Abrir perfil {displayName}",
-    "configIssueMaxTokens": "El máximo de tokens de salida de este perfil supera lo que admite su modelo.",
     "configIssueModelUnknown": "El modelo de este perfil no está disponible en su proveedor.",
+    "configIssueNoInputRoom": "El máximo de tokens de salida de este perfil no deja espacio para la entrada en la ventana de contexto del modelo.",
+    "configIssueOverOutputCap": "El máximo de tokens de salida de este perfil supera lo que admite su modelo.",
     "providerUnavailableDefault": "El proveedor de este perfil no está disponible.",
     "providerUnavailableFixable": "{message} Haz clic para corregirlo.",
     "view": "Ver"


### PR DESCRIPTION
## Summary
- The `inference_profiles_list` and `get` routes attach an optional `config_issue: { code, message }` per profile (codes `model_unknown`, `max_tokens_invalid`), computed statically from the same shipped judgments the write routes enforce: model reach (catalog via `catalogProviderForProfile`, connection-declared models, routing-identity tables) via a `modelReachIssue` helper extracted from `validateModel`, and token budgets via the shared `validateInferenceProfileConfig`. No probe, no network; mix arms are judged on their own rows and managed bodies are code-owned.
- The web profile row folds `config_issue` into its existing availability warning affordance (same icon, tooltip, and i18n copy; clickable since the editor is exactly where model and budget are fixed), so a row like "bub bub" with a model Anthropic does not serve now shows the warning icon instead of rendering healthy.
- `assistant inference profiles list` gains a CONFIG column and `profiles get` prints the verdict; route tests cover the flagged and clean cases on both routes.

## Original prompt
Manual testing after the save-time validation PRs (#41010/#41015) showed that a misconfigured profile (screenshot: profile "bub bub" with provider Anthropic and model "bub bub") renders as a normal row in the Models and Services settings with no warning icon, because the row's only health signal, `availability`, judges the connection and credential rather than the stored config. The ask: in a fresh branch and PR, give such rows a persistent warning indicator driven by a cheap static verdict, reusing the validation logic that already shipped rather than inventing new checks.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41166" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->