### PR TITLE
feat(ios): Catch Up medium widget showing the three most recent conversations

### DIFF
--- a/clients/ios/App/App/Shared/ThreadDeepLink.swift
+++ b/clients/ios/App/App/Shared/ThreadDeepLink.swift
@@ -1,9 +1,10 @@
 import Foundation
+#if !VOICE_ACTIVITY_EXTENSION
 import UIKit
+#endif
 
-/// The `<scheme>://thread/<id>?message=…` command `SendMessageToChatIntent`
-/// hands to the web layer: open the given conversation with `message` staged
-/// in its composer.
+/// The `<scheme>://thread/<id>?message=…` command that opens a conversation,
+/// with `message` staged in its composer when one is supplied.
 ///
 /// Mirrors the macOS shell's `vellum://thread/<id>` link (see
 /// `clients/macos/src/main/deep-links.ts`) with a `message` query parameter
@@ -12,8 +13,13 @@ import UIKit
 /// (`clients/web/src/runtime/native-deep-link.ts`, routed by
 /// `runtime/event-sources/capacitor-deep-links.ts`).
 ///
-/// Lives in the app target only: no extension builds these links, so unlike
-/// `VoiceModeDeepLink` there is nothing to share and no compiled-out body.
+/// Lives in `Shared/` because two very different callers build these links:
+/// `SendMessageToChatIntent` in the app target, which carries a message, and
+/// the Catch Up widget in the VoiceActivity extension, whose rows are plain
+/// `Link`s into a conversation. ``route(message:)`` stays app-only, and unlike
+/// `VoiceModeDeepLink` it is compiled out of the appex entirely rather than
+/// emptied: no extension code hands a thread command to the shell, because the
+/// system opens a widget's `Link` itself.
 struct ThreadDeepLink {
     /// Host segment shared with `OPEN_THREAD_DEEP_LINK_HOST` on the web side.
     private static let host = "thread"
@@ -23,13 +29,14 @@ struct ThreadDeepLink {
     /// The command URL for the *running build*, or `nil` when the bundle
     /// declares no usable scheme. No fallback, same as voice: sending a
     /// message to the wrong app's assistant is strictly worse than sending
-    /// nothing.
+    /// nothing, and a widget row that opened a different environment's app
+    /// would be worse still.
     ///
     /// - Parameter message: what to stage in the conversation. Omitted from
-    ///   the URL when blank, so such a link degrades to just opening the
-    ///   thread. The web parser bounds and sanitizes whatever arrives;
-    ///   nothing is trusted for being locally produced.
-    func url(message: String) -> URL? {
+    ///   the URL when blank, which is how the widget's rows build a link that
+    ///   just opens the thread. The web parser bounds and sanitizes whatever
+    ///   arrives; nothing is trusted for being locally produced.
+    func url(message: String = "") -> URL? {
         guard let scheme = BundleURLScheme.current else { return nil }
         var components = URLComponents()
         components.scheme = scheme
@@ -47,9 +54,15 @@ struct ThreadDeepLink {
         return components.url
     }
 
+    #if !VOICE_ACTIVITY_EXTENSION
     /// Hand this command to the shell. Returns immediately: App Intents run
     /// under a short execution budget, so `perform()` must hand off rather
     /// than wait for the web layer to act.
+    ///
+    /// Compiled out of the VoiceActivity extension, which defines
+    /// `VOICE_ACTIVITY_EXTENSION`, so `UIApplication.shared` (unavailable to
+    /// app extensions) and `AppDelegate` (which links Capacitor, which the
+    /// appex does not) stay out of the appex binary.
     @MainActor
     func route(message: String) {
         guard let url = url(message: message) else {
@@ -58,4 +71,5 @@ struct ThreadDeepLink {
         }
         (UIApplication.shared.delegate as? AppDelegate)?.deliverCommandURL(url)
     }
+    #endif
 }

--- a/clients/ios/App/VoiceActivity/VoiceActivityBundle.swift
+++ b/clients/ios/App/VoiceActivity/VoiceActivityBundle.swift
@@ -3,12 +3,13 @@ import WidgetKit
 
 /// Widget bundle entry point for the VoiceActivity extension.
 ///
-/// Three members: the live-voice Live Activity
-/// (`VoiceSessionLiveActivity.swift`) and two Control Center / Lock Screen
+/// Four members: the live-voice Live Activity
+/// (`VoiceSessionLiveActivity.swift`), the Catch Up Home Screen widget
+/// (`Widgets/CatchUpWidget.swift`), and two Control Center / Lock Screen
 /// controls, one starting a voice conversation (`StartVoiceControl.swift`) and
-/// one opening the app (`OpenVellumControl.swift`). A `WidgetBundle` can hold
-/// home-screen widgets alongside them, so anything added later joins this list
-/// rather than needing another extension target.
+/// one opening the app (`OpenVellumControl.swift`). A `WidgetBundle` holds
+/// Home Screen widgets alongside the rest, which is why the widgets join this
+/// list rather than needing another extension target.
 ///
 /// The controls are `@available(iOS 18.0, *)` while the app deploys to 17.0,
 /// so they are listed under an `#available` check, the one shape that works
@@ -21,6 +22,7 @@ import WidgetKit
 struct VoiceActivityBundle: WidgetBundle {
     var body: some Widget {
         VoiceSessionLiveActivity()
+        CatchUpWidget()
         if #available(iOS 18.0, *) {
             StartVoiceControl()
             OpenVellumControl()

--- a/clients/ios/App/VoiceActivity/Widgets/CatchUpWidget.swift
+++ b/clients/ios/App/VoiceActivity/Widgets/CatchUpWidget.swift
@@ -1,0 +1,226 @@
+import AppIntents
+import SwiftUI
+import WidgetKit
+
+/// The medium Home Screen widget: what happened while you were away, and the
+/// two ways to start something new.
+///
+/// Medium only. The left column's two actions and three legible conversation
+/// rows are what the widget is for, and neither the small nor the large family
+/// renders that: small fits one of the two halves, and large would pad three
+/// rows with empty card.
+///
+/// Every row is a `Link` rather than a `Button(intent:)`. Opening a
+/// conversation is navigation, the URL is the same one the SPA already parses
+/// from Siri and from Safari, and the system opens a `Link` itself, which is
+/// one fewer process hop than an intent that would only turn around and hand
+/// the same URL to the shell.
+struct CatchUpWidget: Widget {
+    var body: some WidgetConfiguration {
+        StaticConfiguration(
+            kind: VellumWidgetKind.catchUp,
+            provider: SnapshotProvider()
+        ) { entry in
+            CatchUpWidgetView(entry: entry)
+                .containerBackground(WidgetTheme.surface, for: .widget)
+        }
+        .configurationDisplayName("Catch Up")
+        .description("See your most recent Vellum conversations and start a new chat or a voice session.")
+        .supportedFamilies([.systemMedium])
+    }
+}
+
+/// Actions on the left, conversations on the right.
+///
+/// The split is the point: the actions are always available and always in the
+/// same place, so the half of the widget that changes cannot move the half the
+/// user aims at.
+struct CatchUpWidgetView: View {
+    let entry: SnapshotEntry
+
+    /// Width of the action column, sized to the two tiles rather than to a
+    /// share of the widget, so the rows beside it get every remaining point.
+    private static let actionColumnWidth: CGFloat = 71
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 14) {
+            VStack(spacing: 7) {
+                WidgetActionTile(
+                    intent: OpenNewChatIntent(),
+                    icon: Image("VellumV"),
+                    title: "New Chat",
+                    fill: WidgetTheme.newChatFill,
+                    tint: WidgetTheme.brand
+                )
+                WidgetActionTile(
+                    intent: StartNewVoiceConversationIntent(),
+                    icon: Image(systemName: "waveform"),
+                    title: "Voice",
+                    fill: WidgetTheme.voiceFill,
+                    tint: WidgetTheme.textPrimary
+                )
+            }
+            .frame(width: Self.actionColumnWidth)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Catch up:")
+                    .font(.system(size: 10))
+                    .foregroundStyle(WidgetTheme.textSecondary)
+                if entry.conversations.isEmpty {
+                    emptyPrompt
+                } else {
+                    ForEach(entry.conversations, id: \.id) { conversation in
+                        linkedRow(for: conversation)
+                    }
+                }
+                Spacer(minLength: 0)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    /// The row, wrapped in a `Link` when this build declares a URL scheme.
+    ///
+    /// A missing scheme drops the link and keeps the row: there is no fallback
+    /// scheme to reach for (guessing one would send a Dev build's tap into the
+    /// production app), and the titles are still true, so the widget loses a
+    /// tap target rather than its content.
+    @ViewBuilder
+    private func linkedRow(for conversation: WidgetSnapshotConversation) -> some View {
+        let row = CatchUpRow(conversation: conversation, isStale: entry.isStale)
+        if let url = ThreadDeepLink(threadId: conversation.id).url() {
+            Link(destination: url) { row }
+        } else {
+            row
+        }
+    }
+
+    /// One line covering both empty cases, because they are the same to the
+    /// person reading it: nothing synced (signed out, fresh install, a shell
+    /// older than the sync) and nothing to sync (no conversations yet) both
+    /// end with opening the app. The actions beside it stay live, so the
+    /// widget is still a way in.
+    private var emptyPrompt: some View {
+        Text("Open Vellum to see your recent chats.")
+            .font(.system(size: 11, weight: .medium))
+            .foregroundStyle(WidgetTheme.textSecondary)
+            .lineLimit(2)
+            .padding(.top, 2)
+    }
+}
+
+/// One conversation: a status glyph, the title, and the group it belongs to.
+///
+/// Title and subtitle are `.privacySensitive()`, so iOS redacts them on a
+/// locked device. That redaction is what makes it defensible to carry titles
+/// into the snapshot at all: the widget can say a conversation is waiting
+/// without spelling out which one to whoever picks the phone up.
+struct CatchUpRow: View {
+    let conversation: WidgetSnapshotConversation
+
+    /// Whether the snapshot behind this row has stopped being trustworthy
+    /// about work in flight. See ``SnapshotProvider/staleAfter``.
+    let isStale: Bool
+
+    var body: some View {
+        HStack(spacing: 7) {
+            statusGlyph
+                .frame(width: 12, height: 12)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(conversation.title)
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(WidgetTheme.textPrimary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                    .privacySensitive()
+                if let subtitle = conversation.subtitle, !subtitle.isEmpty {
+                    Text(subtitle)
+                        .font(.system(size: 9, weight: .medium))
+                        .foregroundStyle(WidgetTheme.textSecondary)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                        .privacySensitive()
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.vertical, 3)
+    }
+
+    /// Working beats unread, and staleness beats working.
+    ///
+    /// A turn in flight is the more useful of the two facts and the more
+    /// perishable, which is why it is the one that drops once the snapshot
+    /// ages out: nothing has confirmed that turn is still running, and an
+    /// indicator claiming otherwise is the row lying. Unread survives, because
+    /// it is a fact about a message that already arrived and stays true until
+    /// someone reads it, which takes opening the app and resyncing.
+    ///
+    /// The working treatment is deliberately generic. The snapshot carries no
+    /// `statusText`, so this says "something is happening here" and nothing
+    /// more, rather than fossilizing wording the SPA deploys continuously.
+    @ViewBuilder
+    private var statusGlyph: some View {
+        if conversation.isProcessing && !isStale {
+            Image(systemName: "ellipsis")
+                .font(.system(size: 11, weight: .bold))
+                .foregroundStyle(WidgetTheme.textSecondary)
+                .accessibilityLabel("Working")
+        } else if conversation.hasUnseen {
+            bubble
+                .overlay(alignment: .topTrailing) {
+                    Circle()
+                        .fill(WidgetTheme.unseenIndicator)
+                        .frame(width: 4, height: 4)
+                        .offset(x: 1, y: -1)
+                }
+                .accessibilityLabel("Unread")
+        } else {
+            bubble
+                .accessibilityHidden(true)
+        }
+    }
+
+    private var bubble: some View {
+        Image(systemName: "bubble.left")
+            .font(.system(size: 11))
+            .foregroundStyle(WidgetTheme.textPrimary)
+    }
+}
+
+/// One tile in the action column: a glyph over a word, filling a rounded
+/// square, wired to an App Intent.
+///
+/// Generic over the intent because `Button(intent:)` takes a concrete
+/// `AppIntent` and the two tiles run different ones. Both intents declare
+/// `openAppWhenRun`, so the system performs them in the app process; the appex
+/// only needs the types to exist.
+struct WidgetActionTile<ActionIntent: AppIntent>: View {
+    /// Matched to the squircle the system clips the widget itself with, so a
+    /// tile reads as a smaller instance of the card it sits on.
+    private static var cornerRadius: CGFloat { 14 }
+
+    let intent: ActionIntent
+    let icon: Image
+    let title: String
+    let fill: Color
+    let tint: Color
+
+    var body: some View {
+        Button(intent: intent) {
+            VStack(spacing: 4) {
+                icon
+                    .font(.system(size: 22))
+                    .foregroundStyle(tint)
+                Text(title)
+                    .font(.system(size: 9, weight: .medium))
+                    .foregroundStyle(WidgetTheme.textPrimary)
+                    .lineLimit(1)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(fill, in: RoundedRectangle(cornerRadius: Self.cornerRadius))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(title)
+    }
+}

--- a/clients/ios/App/VoiceActivity/Widgets/SnapshotTimeline.swift
+++ b/clients/ios/App/VoiceActivity/Widgets/SnapshotTimeline.swift
@@ -1,0 +1,132 @@
+import Foundation
+import WidgetKit
+
+/// One rendering of the App Group snapshot, at the moment WidgetKit draws it.
+///
+/// `isStale` is carried on the entry rather than recomputed in the view because
+/// a widget's views are drawn from entries the system may have held for a
+/// while: the timeline decides when the snapshot stops being trustworthy, and
+/// every view renders the decision it was handed.
+struct SnapshotEntry: TimelineEntry {
+    let date: Date
+
+    /// The cached snapshot, or `nil` when no app build has ever synced one
+    /// into this environment's App Group (a fresh install, a signed-out
+    /// account, a shell whose web bundle predates the sync).
+    let snapshot: WidgetSnapshot?
+
+    /// Whether the snapshot is old enough that its claims about work happening
+    /// *right now* are dropped. See ``SnapshotProvider/staleAfter``.
+    let isStale: Bool
+
+    /// The conversations to render, empty whenever there is no snapshot.
+    var conversations: [WidgetSnapshotConversation] {
+        snapshot?.conversations ?? []
+    }
+}
+
+/// The timeline behind every Vellum Home Screen widget: read the App Group
+/// snapshot, hand it over, and schedule the one moment it stops being fresh.
+///
+/// The extension has no network stack and no auth, so there is nothing to
+/// fetch here. `WidgetSnapshotPlugin` writes the snapshot while the app is
+/// open and calls `WidgetCenter.reloadTimelines(ofKind:)`, which is what
+/// actually keeps these widgets current; the `.atEnd` policy is the floor
+/// under that, not the mechanism.
+struct SnapshotProvider: TimelineProvider {
+    /// How long a snapshot's live claims are trusted.
+    ///
+    /// The app is the only writer, so an untouched phone's snapshot ages
+    /// without bound. Half an hour is well past any plausible "I just put the
+    /// phone down" gap and well short of leaving a spinner on the Home Screen
+    /// all afternoon for a turn that finished before lunch. Titles and group
+    /// names keep rendering past it: what a conversation is called does not go
+    /// out of date the way "working on it" does.
+    static let staleAfter: TimeInterval = 30 * 60
+
+    func placeholder(in context: Context) -> SnapshotEntry {
+        SnapshotEntry(date: Date(), snapshot: .placeholder, isStale: false)
+    }
+
+    /// The gallery and the widget's transient previews ask through here. A
+    /// preview shows the fixture rather than the real snapshot, so browsing
+    /// the gallery on a locked device cannot put someone's conversation titles
+    /// on screen, and so an account with nothing synced yet is still offered a
+    /// widget that looks like something.
+    func getSnapshot(in context: Context, completion: @escaping (SnapshotEntry) -> Void) {
+        if context.isPreview {
+            completion(placeholder(in: context))
+            return
+        }
+        completion(entry(at: Date(), for: WidgetSnapshotStore.load()))
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<SnapshotEntry>) -> Void) {
+        let now = Date()
+        let snapshot = WidgetSnapshotStore.load()
+        var entries = [entry(at: now, for: snapshot)]
+        if let snapshot {
+            // The one scheduled transition: the same snapshot, redrawn without
+            // its live claims. Omitted when the snapshot is already past it,
+            // in which case the entry above is stale from the start.
+            let staleAt = snapshot.generatedAt.addingTimeInterval(Self.staleAfter)
+            if staleAt > now {
+                entries.append(SnapshotEntry(date: staleAt, snapshot: snapshot, isStale: true))
+            }
+        }
+        completion(Timeline(entries: entries, policy: .atEnd))
+    }
+
+    private func entry(at date: Date, for snapshot: WidgetSnapshot?) -> SnapshotEntry {
+        guard let snapshot else {
+            return SnapshotEntry(date: date, snapshot: nil, isStale: false)
+        }
+        return SnapshotEntry(
+            date: date,
+            snapshot: snapshot,
+            isStale: date.timeIntervalSince(snapshot.generatedAt) >= Self.staleAfter
+        )
+    }
+}
+
+extension WidgetSnapshot {
+    /// Filler for `placeholder(in:)` and the widget gallery.
+    ///
+    /// Invented rather than sampled from the store, for the reason the gallery
+    /// preview exists at all: whatever this renders can be seen by anyone
+    /// holding the phone, including before it is unlocked. It covers all three
+    /// row treatments (unread, working, plain) so the gallery entry shows what
+    /// the widget can actually tell you.
+    static let placeholder = WidgetSnapshot(
+        schemaVersion: WidgetSnapshot.currentSchemaVersion,
+        generatedAt: Date(),
+        unreadCount: 2,
+        inProgressCount: 1,
+        conversations: [
+            WidgetSnapshotConversation(
+                id: "placeholder-1",
+                title: "Your morning briefing",
+                subtitle: "Daily",
+                lastMessageAt: nil,
+                hasUnseen: true,
+                isProcessing: false
+            ),
+            WidgetSnapshotConversation(
+                id: "placeholder-2",
+                title: "Trip planning notes",
+                subtitle: "Travel",
+                lastMessageAt: nil,
+                hasUnseen: true,
+                isProcessing: false
+            ),
+            WidgetSnapshotConversation(
+                id: "placeholder-3",
+                title: "Looking that up",
+                subtitle: nil,
+                lastMessageAt: nil,
+                hasUnseen: false,
+                isProcessing: true
+            ),
+        ]
+    )
+}

--- a/clients/ios/App/VoiceActivity/Widgets/WidgetTheme.swift
+++ b/clients/ios/App/VoiceActivity/Widgets/WidgetTheme.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+import UIKit
+
+/// The one palette the Vellum Home Screen widgets draw from.
+///
+/// A widget renders in a process that never runs the SPA, so the CSS custom
+/// properties the rest of the product themes itself with cannot reach it, and
+/// `CSSHexColor` solves a different problem: it parses colors the web layer
+/// *hands across* at runtime, and nothing hands a widget anything. The values
+/// are therefore literals, collected here rather than spelled at each use so
+/// the widgets cannot drift into three slightly different greens.
+///
+/// Every entry carries a dark variant, resolved per render from the trait
+/// collection. A Home Screen widget is drawn in whatever appearance the device
+/// is in, and a white card on a dark Home Screen would be the brightest thing
+/// on the display.
+enum WidgetTheme {
+    /// The card the whole widget sits on, passed to `containerBackground`.
+    static let surface = dynamic(light: "#FFFFFF", dark: "#1C1C1E")
+
+    /// Fill behind the New Chat action, tinted toward the brand green.
+    static let newChatFill = dynamic(light: "#E6F5F3", dark: "#123832")
+
+    /// Fill behind the Voice action: neutral, so the two tiles read as a
+    /// primary action and a secondary one rather than as two peers.
+    static let voiceFill = dynamic(light: "#F6F5F4", dark: "#2C2C2E")
+
+    /// Vellum green. Lightened in dark mode, where the light-mode value does
+    /// not clear contrast against `surface`.
+    static let brand = dynamic(light: "#0E9B8B", dark: "#2FC1AE")
+
+    /// Conversation titles and action labels.
+    static let textPrimary = dynamic(light: "#111417", dark: "#F2F2F7")
+
+    /// Group names, the section header, and the empty-state prompt.
+    static let textSecondary = dynamic(light: "#7C8894", dark: "#98A2AE")
+
+    /// The dot marking a conversation with something unread in it. Amber
+    /// rather than the brand green so it reads as an alert instead of as more
+    /// chrome, and so it survives sitting on the green tile's neighbours.
+    static let unseenIndicator = dynamic(light: "#FFB200", dark: "#FFC13D")
+
+    /// A color that resolves from the appearance the widget is rendered in.
+    ///
+    /// Both hex strings go through ``UIColor/init(cssHex:)`` so this file does
+    /// not grow a second parser. The fallbacks are unreachable for the
+    /// literals above and exist only to keep the result non-optional.
+    private static func dynamic(light: String, dark: String) -> Color {
+        let lightColor = UIColor(cssHex: light) ?? .white
+        let darkColor = UIColor(cssHex: dark) ?? .black
+        return Color(uiColor: UIColor { traits in
+            traits.userInterfaceStyle == .dark ? darkColor : lightColor
+        })
+    }
+}


### PR DESCRIPTION
## Summary
- Adds the Catch Up systemMedium widget to the VoiceActivity bundle: snapshot-backed timeline with staleness degradation, per-row thread links, New Chat and Voice intent buttons
- Moves ThreadDeepLink to App/Shared with an appex-safe url() so the widget builds thread links
- Adds WidgetTheme and the shared snapshot timeline provider that PR 6 and PR 7 reuse

Part of plan: ios-widgets.md (PR 5 of 7)