### PR TITLE
feat(ios): Status small widget with unread and in-progress counts

### DIFF
--- a/clients/ios/App/VoiceActivity/VoiceActivityBundle.swift
+++ b/clients/ios/App/VoiceActivity/VoiceActivityBundle.swift
@@ -3,13 +3,14 @@ import WidgetKit
 
 /// Widget bundle entry point for the VoiceActivity extension.
 ///
-/// Four members: the live-voice Live Activity
-/// (`VoiceSessionLiveActivity.swift`), the Catch Up Home Screen widget
-/// (`Widgets/CatchUpWidget.swift`), and two Control Center / Lock Screen
-/// controls, one starting a voice conversation (`StartVoiceControl.swift`) and
-/// one opening the app (`OpenVellumControl.swift`). A `WidgetBundle` holds
-/// Home Screen widgets alongside the rest, which is why the widgets join this
-/// list rather than needing another extension target.
+/// Five members: the live-voice Live Activity
+/// (`VoiceSessionLiveActivity.swift`), the Catch Up and Status Home Screen
+/// widgets (`Widgets/CatchUpWidget.swift`, `Widgets/StatusWidget.swift`), and
+/// two Control Center / Lock Screen controls, one starting a voice
+/// conversation (`StartVoiceControl.swift`) and one opening the app
+/// (`OpenVellumControl.swift`). A `WidgetBundle` holds Home Screen widgets
+/// alongside the rest, which is why the widgets join this list rather than
+/// needing another extension target.
 ///
 /// The controls are `@available(iOS 18.0, *)` while the app deploys to 17.0,
 /// so they are listed under an `#available` check, the one shape that works
@@ -23,6 +24,7 @@ struct VoiceActivityBundle: WidgetBundle {
     var body: some Widget {
         VoiceSessionLiveActivity()
         CatchUpWidget()
+        StatusWidget()
         if #available(iOS 18.0, *) {
             StartVoiceControl()
             OpenVellumControl()

--- a/clients/ios/App/VoiceActivity/Widgets/StatusWidget.swift
+++ b/clients/ios/App/VoiceActivity/Widgets/StatusWidget.swift
@@ -1,0 +1,127 @@
+import SwiftUI
+import WidgetKit
+
+/// The small Home Screen widget: how much is waiting, and the two ways in.
+///
+/// Small only. Two numbers over two buttons is what the family fits, and it is
+/// the whole idea: this is the widget for someone who wants the count without
+/// the list, so a medium version would just be the Catch Up widget with its
+/// rows deleted.
+///
+/// It declares no `widgetURL`, deliberately. A tap outside the buttons should
+/// land the user wherever they left off, which is what a widget carrying no URL
+/// already does. Every custom-scheme host the web layer parses is a command
+/// (`voice`, `thread`, `camera`, `new-chat`), so there is no plain-open URL to
+/// hand over, and minting one would add a launch destination to keep in sync
+/// with the SPA for no change in behavior.
+struct StatusWidget: Widget {
+    var body: some WidgetConfiguration {
+        StaticConfiguration(
+            kind: VellumWidgetKind.status,
+            provider: SnapshotProvider()
+        ) { entry in
+            StatusWidgetView(entry: entry)
+                .containerBackground(WidgetTheme.surface, for: .widget)
+        }
+        .configurationDisplayName("Status")
+        .description("See how much is unread or still working in Vellum, and start a new chat or voice session.")
+        .supportedFamilies([.systemSmall])
+    }
+}
+
+/// The readout on top, the actions along the bottom.
+struct StatusWidgetView: View {
+    let entry: SnapshotEntry
+
+    /// Height of the action row, so the tiles claim a fixed strip rather than
+    /// growing into the readout above them: both tiles fill whatever frame
+    /// they are handed.
+    private static let actionRowHeight: CGFloat = 54
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            readout
+            Spacer(minLength: 0)
+            HStack(spacing: 7) {
+                WidgetActionTile(
+                    intent: OpenNewChatIntent(),
+                    icon: Image("VellumV"),
+                    title: "New Chat",
+                    fill: WidgetTheme.newChatFill,
+                    tint: WidgetTheme.brand
+                )
+                WidgetActionTile(
+                    intent: StartNewVoiceConversationIntent(),
+                    icon: Image(systemName: "waveform"),
+                    title: "Voice",
+                    fill: WidgetTheme.voiceFill,
+                    tint: WidgetTheme.textPrimary
+                )
+            }
+            .frame(height: Self.actionRowHeight)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    /// The counts, or the one sentence that stands in for them.
+    ///
+    /// A count of zero drops its line rather than printing "0", and two zeroes
+    /// are said once instead of twice.
+    ///
+    /// Staleness drops both lines, not just the perishable one. On a widget
+    /// that is nothing but a readout, a lone "2 unread" also asserts that
+    /// nothing is running, which an aged snapshot cannot know. The Catch Up
+    /// rows keep their unread markers past the same threshold because each one
+    /// hangs off a conversation the reader recognizes; a bare number has
+    /// nothing to qualify it.
+    @ViewBuilder
+    private var readout: some View {
+        if let snapshot = entry.snapshot {
+            if entry.isStale {
+                prompt("Open Vellum for the latest.")
+            } else if snapshot.unreadCount <= 0, snapshot.inProgressCount <= 0 {
+                prompt("All caught up.")
+            } else {
+                VStack(alignment: .leading, spacing: 6) {
+                    if snapshot.unreadCount > 0 {
+                        countLine(icon: "bubble.left", text: "\(snapshot.unreadCount) unread")
+                    }
+                    if snapshot.inProgressCount > 0 {
+                        countLine(icon: "ellipsis.bubble", text: "\(snapshot.inProgressCount) in progress")
+                    }
+                }
+            }
+        } else {
+            prompt("Open Vellum to see what is waiting.")
+        }
+    }
+
+    /// The glyph is decorative: the text beside it already says everything
+    /// VoiceOver needs to read.
+    private func countLine(icon: String, text: String) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: icon)
+                .font(.system(size: 12))
+                .foregroundStyle(WidgetTheme.brand)
+                .frame(width: 14)
+                .accessibilityHidden(true)
+            Text(text)
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(WidgetTheme.textPrimary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.8)
+        }
+    }
+
+    /// The line that stands in for the counts. Its three phrasings are three
+    /// different facts rather than spare wordings of one: nothing has ever
+    /// synced, the snapshot is too old to read as a status, or there is
+    /// genuinely nothing waiting. The buttons below stay live in all three, so
+    /// the widget is still a way in when it has nothing to report.
+    private func prompt(_ text: String) -> some View {
+        Text(text)
+            .font(.system(size: 12, weight: .medium))
+            .foregroundStyle(WidgetTheme.textSecondary)
+            .lineLimit(2)
+    }
+}


### PR DESCRIPTION
## Summary
- Adds the Status systemSmall widget: unread and in-progress counts from the shared snapshot with staleness and empty states, New Chat and Voice intent buttons
- Reuses the shared snapshot timeline provider and widget theme

Part of plan: ios-widgets.md (PR 6 of 7)