### PR TITLE
feat(ios): Quick Actions small widget with brand and light appearances

### DIFF
--- a/clients/ios/App/VoiceActivity/VoiceActivityBundle.swift
+++ b/clients/ios/App/VoiceActivity/VoiceActivityBundle.swift
@@ -3,9 +3,10 @@ import WidgetKit
 
 /// Widget bundle entry point for the VoiceActivity extension.
 ///
-/// Four members: the live-voice Live Activity
-/// (`VoiceSessionLiveActivity.swift`), the Catch Up Home Screen widget
-/// (`Widgets/CatchUpWidget.swift`), and two Control Center / Lock Screen
+/// Five members: the live-voice Live Activity
+/// (`VoiceSessionLiveActivity.swift`), two Home Screen widgets, Catch Up
+/// (`Widgets/CatchUpWidget.swift`) and Quick Actions
+/// (`Widgets/QuickActionsWidget.swift`), and two Control Center / Lock Screen
 /// controls, one starting a voice conversation (`StartVoiceControl.swift`) and
 /// one opening the app (`OpenVellumControl.swift`). A `WidgetBundle` holds
 /// Home Screen widgets alongside the rest, which is why the widgets join this
@@ -23,6 +24,7 @@ struct VoiceActivityBundle: WidgetBundle {
     var body: some Widget {
         VoiceSessionLiveActivity()
         CatchUpWidget()
+        QuickActionsWidget()
         if #available(iOS 18.0, *) {
             StartVoiceControl()
             OpenVellumControl()

--- a/clients/ios/App/VoiceActivity/Widgets/QuickActionsAppearanceIntent.swift
+++ b/clients/ios/App/VoiceActivity/Widgets/QuickActionsAppearanceIntent.swift
@@ -1,0 +1,40 @@
+import AppIntents
+
+/// How the Quick Actions widget paints itself.
+///
+/// The two looks are the same widget, not two widgets. They offer the identical
+/// actions and differ only in which Home Screen they disappear into: the brand
+/// card is a saturated green block that reads as a Vellum tile, the light card
+/// is the quiet system surface the other Vellum widgets sit on, which follows
+/// the device appearance and so is dark on a dark Home Screen. The choice is
+/// brand block or system card, not a second theme switch. Shipping the two as
+/// one configurable entry keeps the widget gallery honest, where two
+/// near-identical rows would just make the user guess.
+enum QuickActionsAppearance: String, AppEnum {
+    case brand
+    case light
+
+    static var typeDisplayRepresentation: TypeDisplayRepresentation = "Appearance"
+
+    static var caseDisplayRepresentations: [QuickActionsAppearance: DisplayRepresentation] = [
+        .brand: "Brand",
+        .light: "Light",
+    ]
+}
+
+/// The configuration behind the Quick Actions widget, carrying the one choice
+/// the user makes in Edit Widget.
+///
+/// A `WidgetConfigurationIntent` needs no `perform()`: nothing runs it. The
+/// system stores the chosen parameters and hands them back to the timeline
+/// provider on every reload, which is the whole job.
+struct QuickActionsAppearanceIntent: WidgetConfigurationIntent {
+    static var title: LocalizedStringResource = "Quick Actions"
+
+    static var description = IntentDescription(
+        "Choose whether the Quick Actions widget uses the brand or the light card."
+    )
+
+    @Parameter(title: "Appearance", default: .brand)
+    var appearance: QuickActionsAppearance
+}

--- a/clients/ios/App/VoiceActivity/Widgets/QuickActionsAppearanceIntent.swift
+++ b/clients/ios/App/VoiceActivity/Widgets/QuickActionsAppearanceIntent.swift
@@ -2,14 +2,17 @@ import AppIntents
 
 /// How the Quick Actions widget paints itself.
 ///
-/// The two looks are the same widget, not two widgets. They offer the identical
-/// actions and differ only in which Home Screen they disappear into: the brand
-/// card is a saturated green block that reads as a Vellum tile, the light card
-/// is the quiet system surface the other Vellum widgets sit on, which follows
-/// the device appearance and so is dark on a dark Home Screen. The choice is
-/// brand block or system card, not a second theme switch. Shipping the two as
-/// one configurable entry keeps the widget gallery honest, where two
-/// near-identical rows would just make the user guess.
+/// The two looks are the same widget, not two widgets. Both lead with camera
+/// and voice, and they differ in which Home Screen they disappear into: the
+/// brand card is a saturated green block that reads as a Vellum tile, the light
+/// card is the quiet system surface the other Vellum widgets sit on, which
+/// follows the device appearance and so is dark on a dark Home Screen. The
+/// light card also carries a Chat button, because it spends on a pill the width
+/// the brand card gives the mark; on the brand card a tap outside the two
+/// circles opens the app instead. The choice is brand block or system card, not
+/// a second theme switch. Shipping the two as one configurable entry keeps the
+/// widget gallery honest, where two near-identical rows would just make the
+/// user guess.
 enum QuickActionsAppearance: String, AppEnum {
     case brand
     case light

--- a/clients/ios/App/VoiceActivity/Widgets/QuickActionsWidget.swift
+++ b/clients/ios/App/VoiceActivity/Widgets/QuickActionsWidget.swift
@@ -1,0 +1,350 @@
+import AppIntents
+import SwiftUI
+import WidgetKit
+
+/// The small Home Screen widget: the ways to start something, plus a count of
+/// what is waiting.
+///
+/// Small only. Every action here is one tap target and none of them grow with
+/// more room, so a medium instance would be the same buttons with half a card
+/// of padding around them. `CatchUpWidget` is the medium answer.
+///
+/// Configurable rather than static, and configurable for exactly one reason:
+/// the card is either the brand block or the system surface. See
+/// ``QuickActionsAppearance``.
+///
+/// The widget declares no `widgetURL`, so a tap outside the buttons falls
+/// through to WidgetKit's default of launching the app, which is the same
+/// "land where you left off" behavior `OpenVellumIntent` gives the Control
+/// Center control. Nothing here needs a destination the app does not already
+/// have the user parked on.
+struct QuickActionsWidget: Widget {
+    var body: some WidgetConfiguration {
+        AppIntentConfiguration(
+            kind: VellumWidgetKind.quickActions,
+            intent: QuickActionsAppearanceIntent.self,
+            provider: QuickActionsProvider()
+        ) { entry in
+            QuickActionsWidgetView(entry: entry)
+                .containerBackground(entry.appearance.cardSurface, for: .widget)
+        }
+        .configurationDisplayName("Quick Actions")
+        .description("Take a photo, start a voice conversation, or open a new chat.")
+        .supportedFamilies([.systemSmall])
+    }
+}
+
+/// One rendering of the Quick Actions widget: the snapshot every Vellum widget
+/// shares, plus the appearance this particular instance was configured with.
+///
+/// The appearance rides on the entry because that is the only channel an
+/// `AppIntentConfiguration` gives the view: the content closure receives an
+/// entry and nothing else, so the provider is where configuration and snapshot
+/// meet.
+struct QuickActionsEntry: TimelineEntry {
+    let snapshotEntry: SnapshotEntry
+    let appearance: QuickActionsAppearance
+
+    var date: Date { snapshotEntry.date }
+
+    /// The number for the unread chip, or nil when there is no chip to draw:
+    /// nothing unread, nothing synced, or a snapshot old enough that the count
+    /// is a claim about an inbox from half an hour ago.
+    ///
+    /// `CatchUpRow` keeps its unread dot past that same threshold, and the two
+    /// are consistent rather than in tension. A dot says "this conversation
+    /// has something in it you have not read", which stays true until someone
+    /// opens the app and resyncs. A count says how many are waiting *now*, and
+    /// messages arriving while the app is closed are exactly what the widget
+    /// cannot see. So the fact survives staleness and the tally does not.
+    var unreadCount: Int? {
+        guard !snapshotEntry.isStale,
+              let count = snapshotEntry.snapshot?.unreadCount,
+              count > 0
+        else {
+            return nil
+        }
+        return count
+    }
+}
+
+/// ``SnapshotProvider``'s timeline, restated in the async shape a configurable
+/// widget requires, with the chosen appearance folded into every entry.
+///
+/// `AppIntentConfiguration` takes an `AppIntentTimelineProvider` and the shared
+/// provider is a plain `TimelineProvider`, so something has to bridge the two.
+/// This delegates instead of re-reading the store: which snapshot to render and
+/// when it stops being fresh are one decision for all the Vellum widgets, and a
+/// second copy of the staleness rule is a second copy that drifts.
+struct QuickActionsProvider: AppIntentTimelineProvider {
+    private let snapshots = SnapshotProvider()
+
+    func placeholder(in context: Context) -> QuickActionsEntry {
+        QuickActionsEntry(snapshotEntry: snapshots.placeholder(in: context), appearance: .brand)
+    }
+
+    func snapshot(
+        for configuration: QuickActionsAppearanceIntent,
+        in context: Context
+    ) async -> QuickActionsEntry {
+        let entry: SnapshotEntry = await withCheckedContinuation { continuation in
+            snapshots.getSnapshot(in: context) { continuation.resume(returning: $0) }
+        }
+        return QuickActionsEntry(snapshotEntry: entry, appearance: configuration.appearance)
+    }
+
+    func timeline(
+        for configuration: QuickActionsAppearanceIntent,
+        in context: Context
+    ) async -> Timeline<QuickActionsEntry> {
+        let timeline: Timeline<SnapshotEntry> = await withCheckedContinuation { continuation in
+            snapshots.getTimeline(in: context) { continuation.resume(returning: $0) }
+        }
+        return Timeline(
+            entries: timeline.entries.map {
+                QuickActionsEntry(snapshotEntry: $0, appearance: configuration.appearance)
+            },
+            policy: timeline.policy
+        )
+    }
+}
+
+/// Two cards, both leading with camera and voice.
+///
+/// There is no empty state and no signed-out state to draw: the buttons are
+/// what the widget is, and they work with nothing synced at all. The unread
+/// chip is the one part that reads the snapshot, so a missing snapshot costs
+/// the widget a chip and nothing else.
+struct QuickActionsWidgetView: View {
+    /// The height everything on the card is drawn at: both circles, the Chat
+    /// pill, and the avatar above them. A small widget has room for one unit of
+    /// measure, and a handful of elements at a handful of sizes reads as an
+    /// accident rather than as a layout.
+    private static let controlDiameter: CGFloat = 44
+
+    let entry: QuickActionsEntry
+
+    var body: some View {
+        switch entry.appearance {
+        case .brand:
+            brandCard
+        case .light:
+            lightCard
+        }
+    }
+
+    /// The mark up top, the two most physical actions under it, and the chip
+    /// tucked into the corner the mark leaves empty.
+    ///
+    /// Chat is not on this card. Three buttons on a green block crowds it, and
+    /// a tap anywhere outside the two circles already opens the app, which is
+    /// most of the way to a new chat. The light card, which spends its width on
+    /// a pill instead of on a mark, is where Chat gets a button of its own.
+    private var brandCard: some View {
+        VStack(spacing: 0) {
+            QuickActionsAvatar(size: Self.controlDiameter)
+            Spacer(minLength: 10)
+            cameraAndVoice
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .overlay(alignment: .topTrailing) { unreadChip }
+    }
+
+    /// The quiet card: two circles over a full-width Chat pill.
+    ///
+    /// Chat gets the wide target because it is the action most people want most
+    /// often, and the pill is the only shape on a small widget that can say so.
+    private var lightCard: some View {
+        VStack(spacing: 12) {
+            cameraAndVoice
+            PillActionButton(
+                intent: OpenNewChatIntent(),
+                icon: Image("VellumV"),
+                title: "Chat",
+                fill: WidgetTheme.newChatFill,
+                tint: WidgetTheme.brand,
+                height: Self.controlDiameter
+            )
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    /// The pair both cards lead with, written once so the two appearances
+    /// cannot drift into offering different actions or different VoiceOver
+    /// labels. Only the colors differ, and those come from the appearance.
+    private var cameraAndVoice: some View {
+        HStack(spacing: 12) {
+            CircleActionButton(
+                intent: OpenCameraIntent(),
+                icon: Image(systemName: "camera.fill"),
+                label: "Take a photo",
+                fill: entry.appearance.controlFill,
+                tint: entry.appearance.controlTint,
+                diameter: Self.controlDiameter
+            )
+            CircleActionButton(
+                intent: StartNewVoiceConversationIntent(),
+                icon: Image(systemName: "waveform"),
+                label: "New voice conversation",
+                fill: entry.appearance.controlFill,
+                tint: entry.appearance.controlTint,
+                diameter: Self.controlDiameter
+            )
+        }
+    }
+
+    /// How many conversations are waiting, when that is worth saying.
+    ///
+    /// The number is `.privacySensitive()` while the glyph beside it is not, so
+    /// a locked device still shows that something arrived without spelling out
+    /// how far behind its owner is. Counts above two digits collapse to `99+`:
+    /// past that the exact figure stops being information and the chip would
+    /// grow into the mark.
+    @ViewBuilder
+    private var unreadChip: some View {
+        if let count = entry.unreadCount {
+            HStack(spacing: 3) {
+                Image(systemName: "bubble.left.fill")
+                    .font(.system(size: 9))
+                Text(count > 99 ? "99+" : "\(count)")
+                    .font(.system(size: 11, weight: .semibold))
+                    .privacySensitive()
+            }
+            .foregroundStyle(.white)
+            .padding(.horizontal, 7)
+            .padding(.vertical, 3)
+            .background(.white.opacity(0.22), in: Capsule())
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel("\(count) unread")
+        }
+    }
+}
+
+/// The assistant's face, drawn rather than shipped as an image.
+///
+/// The product's avatars are composed per assistant from body shapes and eye
+/// styles the SPA fetches, and none of that reaches this process: the snapshot
+/// carries conversations, not a rendered avatar. So the brand card draws a
+/// fixed stand-in built the same way, a rounded body with two googly eyes, out
+/// of shapes rather than a bitmap. Shapes stay sharp at every scale and on
+/// every display, which is more than a flattened export of a mock would manage,
+/// and they cost the extension no asset at all.
+private struct QuickActionsAvatar: View {
+    let size: CGFloat
+
+    var body: some View {
+        RoundedRectangle(cornerRadius: size * 0.34, style: .continuous)
+            .fill(WidgetTheme.avatarBody)
+            .frame(width: size, height: size)
+            .overlay {
+                HStack(spacing: size * 0.1) {
+                    eye
+                    eye
+                }
+            }
+            .accessibilityHidden(true)
+    }
+
+    /// Pupils sit low in the whites, which is the whole trick: centered dots
+    /// read as punctuation, low ones read as a face looking back.
+    private var eye: some View {
+        Ellipse()
+            .fill(WidgetTheme.avatarSclera)
+            .frame(width: size * 0.26, height: size * 0.34)
+            .overlay(alignment: .bottom) {
+                Circle()
+                    .fill(WidgetTheme.avatarPupil)
+                    .frame(width: size * 0.14, height: size * 0.14)
+                    .padding(.bottom, size * 0.06)
+            }
+    }
+}
+
+/// A round tap target running an App Intent, with the glyph as its whole label.
+///
+/// Generic over the intent for the reason `WidgetActionTile` is: `Button(intent:)`
+/// takes a concrete `AppIntent` and these buttons run different ones. Both
+/// intents declare `openAppWhenRun`, so the system performs them in the app
+/// process and the appex only needs the types to exist.
+private struct CircleActionButton<ActionIntent: AppIntent>: View {
+    let intent: ActionIntent
+    let icon: Image
+    let label: String
+    let fill: Color
+    let tint: Color
+    let diameter: CGFloat
+
+    var body: some View {
+        Button(intent: intent) {
+            icon
+                .font(.system(size: diameter * 0.4))
+                .foregroundStyle(tint)
+                .frame(width: diameter, height: diameter)
+                .background(fill, in: Circle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(label)
+    }
+}
+
+/// A full-width capsule running an App Intent, glyph beside a word.
+private struct PillActionButton<ActionIntent: AppIntent>: View {
+    let intent: ActionIntent
+    let icon: Image
+    let title: String
+    let fill: Color
+    let tint: Color
+    let height: CGFloat
+
+    var body: some View {
+        Button(intent: intent) {
+            HStack(spacing: 6) {
+                icon
+                    .font(.system(size: height * 0.4))
+                Text(title)
+                    .font(.system(size: 15, weight: .semibold))
+            }
+            .foregroundStyle(tint)
+            .frame(maxWidth: .infinity)
+            .frame(height: height)
+            .background(fill, in: Capsule())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(title)
+    }
+}
+
+/// The whole of what an appearance decides: three colors.
+private extension QuickActionsAppearance {
+    /// The card behind everything.
+    var cardSurface: Color {
+        switch self {
+        case .brand:
+            return WidgetTheme.brandCardSurface
+        case .light:
+            return WidgetTheme.surface
+        }
+    }
+
+    /// The circle behind an action glyph. Translucent white on the brand card,
+    /// so the circles read as cut out of the green rather than as a second
+    /// color placed on top of it, and the card stays one block.
+    var controlFill: Color {
+        switch self {
+        case .brand:
+            return .white.opacity(0.22)
+        case .light:
+            return WidgetTheme.voiceFill
+        }
+    }
+
+    /// The action glyph itself.
+    var controlTint: Color {
+        switch self {
+        case .brand:
+            return .white
+        case .light:
+            return WidgetTheme.textPrimary
+        }
+    }
+}

--- a/clients/ios/App/VoiceActivity/Widgets/QuickActionsWidget.swift
+++ b/clients/ios/App/VoiceActivity/Widgets/QuickActionsWidget.swift
@@ -29,7 +29,7 @@ struct QuickActionsWidget: Widget {
                 .containerBackground(entry.appearance.cardSurface, for: .widget)
         }
         .configurationDisplayName("Quick Actions")
-        .description("Take a photo, start a voice conversation, or open a new chat.")
+        .description("Take a photo or start a voice conversation. The Light appearance adds a Chat button.")
         .supportedFamilies([.systemSmall])
     }
 }
@@ -170,8 +170,9 @@ struct QuickActionsWidgetView: View {
     }
 
     /// The pair both cards lead with, written once so the two appearances
-    /// cannot drift into offering different actions or different VoiceOver
-    /// labels. Only the colors differ, and those come from the appearance.
+    /// cannot drift into offering different camera and voice actions or
+    /// different VoiceOver labels. Only the colors differ, and those come from
+    /// the appearance.
     private var cameraAndVoice: some View {
         HStack(spacing: 12) {
             CircleActionButton(

--- a/clients/ios/App/VoiceActivity/Widgets/WidgetTheme.swift
+++ b/clients/ios/App/VoiceActivity/Widgets/WidgetTheme.swift
@@ -40,6 +40,27 @@ enum WidgetTheme {
     /// chrome, and so it survives sitting on the green tile's neighbours.
     static let unseenIndicator = dynamic(light: "#FFB200", dark: "#FFC13D")
 
+    /// The whole card, for the Quick Actions widget's brand appearance.
+    ///
+    /// Deepened for dark mode where ``brand`` is lightened, because the two
+    /// play opposite roles: `brand` is drawn *on* `surface` and has to separate
+    /// from it, while this one *is* the surface, and a mint block would be the
+    /// brightest thing on a dark Home Screen. Content drawn on it is white in
+    /// both appearances, which is why there is no companion text color here.
+    static let brandCardSurface = dynamic(light: "#0E9B8B", dark: "#0B7A6E")
+
+    /// The assistant mark's body on the brand card, lighter than the card it
+    /// sits on. That contrast is the only reason it is a separate value: a
+    /// brand-green mark on a brand-green card is not a mark.
+    static let avatarBody = fixed("#7FD7C8")
+
+    /// The mark's eye whites and pupils, carrying the values the product's
+    /// avatar compositor draws with so the widget's stand-in is recognizably
+    /// the same character. Fixed rather than dynamic for the same reason a
+    /// face does not change color with the Home Screen behind it.
+    static let avatarSclera = fixed("#F2F2F2")
+    static let avatarPupil = fixed("#1A1A1A")
+
     /// A color that resolves from the appearance the widget is rendered in.
     ///
     /// Both hex strings go through ``UIColor/init(cssHex:)`` so this file does
@@ -51,5 +72,13 @@ enum WidgetTheme {
         return Color(uiColor: UIColor { traits in
             traits.userInterfaceStyle == .dark ? darkColor : lightColor
         })
+    }
+
+    /// A color that is the same in both appearances, for the few values whose
+    /// job is to be one specific color rather than to sit legibly on a surface
+    /// that changes. Same parser and same unreachable-fallback story as
+    /// ``dynamic(light:dark:)``.
+    private static func fixed(_ hex: String) -> Color {
+        Color(uiColor: UIColor(cssHex: hex) ?? .gray)
     }
 }

--- a/clients/ios/README.md
+++ b/clients/ios/README.md
@@ -9,7 +9,8 @@ This is _not_ a port of the web app — it's a thin `WKWebView` shell in
 (`options.deploymentTarget.iOS`) — both, because the xcconfig wins for
 targets that carry one and the `project.yml` value covers those that
 don't. Do not lower it: Live Activities need 16.1, interactive Live
-Activity content 17.0, and the Action Button 17.1. The Control Center
+Activity content 17.0, the Home Screen widgets' `Button(intent:)`
+targets 17.0, and the Action Button 17.1. The Control Center
 control needs 18.0 and is therefore `@available`-gated rather than
 holding the whole app back.
 
@@ -751,11 +752,15 @@ clients/
     │   │   ├── SelfHostedServer.swift      # Active + remembered self-hosted origins
     │   │   ├── SelfHostedServersPlugin.swift # Server list / origin switching bridge
     │   │   ├── RecentChatsPlugin.swift # Conversation-list cache for the Shortcuts chat picker
+    │   │   ├── WidgetSnapshotPlugin.swift # App Group snapshot the Home Screen widgets render
     │   │   ├── Intents/              # App Intents + AppShortcutsProvider
     │   │   ├── Shared/               # Compiled into app + widget extension
     │   │   └── Info.plist
     │   ├── VoiceActivity/            # WidgetKit extension: Live Activity
-    │   │                             # presentations + Control Center controls
+    │   │   │                         # presentations + Control Center controls
+    │   │   └── Widgets/              # Catch Up, Status, and Quick Actions
+    │   │                             # Home Screen widgets over the App Group
+    │   │                             # snapshot
     │   └── CapApp-SPM/               # SPM local package: pulls in @capacitor/ios
     │                                 # and any Capacitor plugin native deps
     └── debug.xcconfig                # Sets CAPACITOR_DEBUG for Debug builds

--- a/clients/ios/docs/NATIVE_VOICE.md
+++ b/clients/ios/docs/NATIVE_VOICE.md
@@ -22,8 +22,8 @@ exactly four things:
 | --- | --- |
 | `VoiceAudioSessionPlugin` | Owns `AVAudioSession` for the duration of a session (`.playAndRecord` / `.voiceChat`), and reports interruptions |
 | `VoiceLiveActivityPlugin` | Requests, updates, and ends the one ActivityKit activity mirroring the session |
-| `VoiceActivity` widget extension | Renders that activity on the Lock Screen and in the Dynamic Island, plus the Control Center controls (the voice one below, and the non-voice "Open Vellum" app launcher) |
-| App Intents + `AppShortcutsProvider` | Turn a Siri phrase, a Spotlight hit, an Action Button press, or a control tap into a `<scheme>://voice` URL |
+| `VoiceActivity` widget extension | Renders that activity on the Lock Screen and in the Dynamic Island, plus the two Control Center / Lock Screen controls (the voice one below, and the non-voice "Open Vellum" app launcher). The same bundle also hosts three non-voice Home Screen widgets, Catch Up, Status, and Quick Actions, which draw the shared App Group snapshot and carry a voice button of their own |
+| App Intents + `AppShortcutsProvider` | Turn a Siri phrase, a Spotlight hit, an Action Button press, a control tap, or a widget button into a `<scheme>://voice` URL |
 
 Everything native is *additive*. Remove all of it and voice still works — that
 property is load-bearing, because the shell ships on App Store review cadence
@@ -63,6 +63,7 @@ Siri phrase / Spotlight / Action Button   →  StartVoiceModeIntent
                                              StartNewVoiceConversationIntent
                                              AskVellumIntent
 Control Center / Lock Screen control      →  StartNewVoiceConversationIntent
+Home Screen widget voice button           →  StartNewVoiceConversationIntent
 Dynamic Island / Lock Screen tap          →  .widgetURL(VoiceModeDeepLink.resume.url())
 Safari, a test link, another app          →  application(_:open:) / launchOptions[.url]
         │                        all of them produce  <scheme>://voice?mode=…
@@ -260,7 +261,7 @@ otherwise arrive as a `prompt` of `Ben ` plus a stray parameter.
 | Producer | Mode | Where |
 | --- | --- | --- |
 | `StartVoiceModeIntent` (Siri: "Talk to Vellum") | `resume` | `App/App/Intents/` |
-| `StartNewVoiceConversationIntent` (Action Button, Control Center) | `new` | `App/App/Shared/` |
+| `StartNewVoiceConversationIntent` (Action Button, Control Center, Home Screen widgets) | `new` | `App/App/Shared/` |
 | `AskVellumIntent` (Siri collects the question) | `new` + `prompt` | `App/App/Intents/` |
 | Live Activity `widgetURL` (island / Lock Screen tap) | `resume` | `App/VoiceActivity/VoiceSessionLiveActivity.swift` |
 | Safari, a note, another app, a test link | either | — |
@@ -807,6 +808,7 @@ agree character for character across the portal, the xcconfigs, and
 | `App/App/Shared/VoiceSessionControlIntent.swift` | The intent behind every island button; in `Shared/` so the appex can name it |
 | `App/App/Intents/` | The other two intents and `VoiceAppShortcuts` |
 | `App/VoiceActivity/` | Widget extension: bundle, Live Activity, island views, Control Center controls |
+| `App/VoiceActivity/Widgets/` | The three Home Screen widgets, their shared snapshot timeline, and the widget palette; snapshot-driven and unrelated to voice apart from a shared voice button |
 | `App/App/Config/Extension*.xcconfig` | Extension build settings; bundle IDs, schemes, profile specifiers |
 | `App/project.yml` | Six targets, `VOICE_ACTIVITY_EXTENSION`, embed relationships |
 


### PR DESCRIPTION
## Summary
- Adds the Quick Actions systemSmall widget: camera, voice, and chat launchers with a configurable brand or light appearance and an unread chip
- One gallery entry; the appearance is chosen via Edit Widget

## Notes for review

**Avatar is drawn, not shipped as an asset.** The product's avatars are composed per assistant from body shapes and eye styles the SPA fetches, and none of that reaches the extension process (the snapshot carries conversations, not a rendered avatar). `QuickActionsAvatar` draws a fixed stand-in built the same way, a rounded body with two googly eyes, out of SwiftUI shapes. That keeps it sharp at every scale and in both appearances, and adds no imageset to `VoiceActivity/Assets.xcassets`.

**Provider.** `AppIntentConfiguration` requires an `AppIntentTimelineProvider` and the shared `SnapshotProvider` is a plain `TimelineProvider`, so `QuickActionsProvider` bridges the two by delegating to it and folding the configured appearance into each entry. `SnapshotTimeline.swift` is unchanged: which snapshot to render and when it stops being fresh stay one decision for every Vellum widget.

**Unread chip vs `CatchUpRow`'s unread dot.** The chip is hidden once the snapshot goes stale while the row's dot is not, which is deliberate: a dot is a fact about a message that already arrived and stays true until someone reads it, while a count claims how many are waiting right now, and messages arriving with the app closed are exactly what the widget cannot see.

**Palette.** Three tokens added to `WidgetTheme`: the brand card surface plus the avatar's body, eye whites and pupils.

## Skew caveat

On a shell whose web bundle predates the camera deep link, tapping the camera button still launches the app: `OpenCameraIntent` runs in the app process, `CameraDeepLink.route()` delivers `<scheme>://camera`, and an older parser returns null and ignores the unknown host. The tap degrades to opening the app, with no error and no crash. That behavior comes from the existing parser and needs no code here.

## Verification

- `xcodegen generate` clean
- `xcodebuild build -target "VoiceActivity Dev" -sdk iphonesimulator CODE_SIGNING_ALLOWED=NO` succeeds with no new warnings
- No em dashes on changed lines
- Device/simulator QA outstanding: gallery entry and placeholder, Edit Widget switching brand and light, chip appearing only with a fresh nonzero count, and each button landing in the right environment's app

Part of plan: ios-widgets.md (PR 7 of 7)