### PR TITLE
fix(web): unbreak main, duplicate TUNNEL_HELP_COMMAND from the v0.11.5 release merge

### DIFF
--- a/clients/web/src/domains/settings/pair-device/pair-device-card.tsx
+++ b/clients/web/src/domains/settings/pair-device/pair-device-card.tsx
@@ -56,13 +56,6 @@ const DOUBTED_KINDS = new Set<TunnelStatusView["kind"]>([
   "foreign",
 ]);
 
-/** Names a provider explicitly: the CLI's `vellum` default is not implemented. */
-const TUNNEL_COMMAND = "vellum tunnel --provider tailscale";
-const TUNNEL_HELP_COMMAND = "vellum tunnel --help";
-
-const CODE_CLASS =
-  "rounded-md bg-[var(--surface-active)] text-body-small-default text-[color:var(--content-primary)]";
-
 /**
  * Settings card that pairs another device to this assistant without shell
  * commands, the UI equivalent of `vellum pair --qr`. It mints and auto-approves a


### PR DESCRIPTION
## TL;DR

`main` cannot build. `pair-device-card.tsx` declares `TUNNEL_HELP_COMMAND` twice at module scope, which is a parse error, so Build, Type Check and Lint fail on main and on every open web pull request. This deletes the seven resurrected lines. One file, no behaviour change.

```
error TS2451: Cannot redeclare block-scoped variable 'TUNNEL_HELP_COMMAND'.
  pair-device-card.tsx(42,7)
  pair-device-card.tsx(61,7)
```

## How it got in

A semantic conflict that git resolved silently, because the two versions sat in different hunks and never overlapped textually.

- #41134 (tunnel status detection, Phase 1) rewrote the block: a typed `TUNNEL_PROVIDER` fed to `tunnelStartCommand()`, and the shared `CODE_CHIP_CLASS` import in place of a local class string.
- The v0.11.5 release cherry-pick (`c7bbd1fbfa`) re-applied #41092, which still carried the older block.

Git merged both. No conflict marker, no review signal, and the release merge is not gated on a web build.

## Why deleting the whole block is right, not just the duplicate line

Every constant in the re-added block is superseded by something already in the file:

| Resurrected | What the live code uses | Verified |
| --- | --- | --- |
| `TUNNEL_COMMAND = "vellum tunnel --provider tailscale"` | `tunnelStartCommand(TUNNEL_PROVIDER, ...)` at line 229, typed against the provider registry | zero references repo-wide |
| `CODE_CLASS = "rounded-md bg-..."` | `CODE_CHIP_CLASS`, imported at line 19 and used at lines 232 and 246 | zero references repo-wide |
| `TUNNEL_HELP_COMMAND` | the identical declaration at line 42 | still used at line 236 |

So the surviving declaration is the newer one and nothing that reads these constants changes. Keeping the duplicate line alive and deleting only one of the two would have left two dead constants behind.

## Before and after, for a user

Nothing. No rendered string, class, or command changes: the Pair-a-device card still prints the same start command and the same `--help` pointer. This only removes declarations that no code reads.

## Verification

Run against `main` with this commit applied:

- `bun run build` succeeds (this is the job that fails on main)
- `tsc --noEmit` reports zero errors
- `eslint` clean

## Not addressed here

The release merge process has no web build gate, which is what let a parse error reach `main`. That is a CI change and a separate discussion, so it is deliberately not in this pull request.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41173" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->