### PR TITLE
feat(config): add managed backup profiles and fallbackProfile pointers

### DIFF
--- a/assistant/src/__tests__/config-loader-backfill.test.ts
+++ b/assistant/src/__tests__/config-loader-backfill.test.ts
@@ -1411,6 +1411,48 @@ describe("loadConfig startup behavior", () => {
     expect(effective.balanced?.provider_connection).toBe("anthropic-personal");
   });
 
+  test("an active managed backup profile survives a reload", () => {
+    // A managed backup resolves from the code catalog without being
+    // materialized in `llm.profiles`, so selecting one persists nothing but
+    // the reference. If the schema did not treat backup keys as
+    // always-available references, the strip-and-reparse in `loadConfig`
+    // would drop `activeProfile` and the seeder would reset the user's
+    // chat-model selection to `balanced` on the next boot.
+    writeConfig({
+      llm: {
+        defaultProvider: { provider: "vellum" },
+        profiles: {},
+        activeProfile: "balanced-backup",
+      },
+    });
+
+    const config = loadConfig();
+    expect(config.llm.activeProfile).toBe("balanced-backup");
+
+    mergeDefaultConfigAndSeedInferenceProfiles();
+
+    const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+    expect(raw.llm.activeProfile).toBe("balanced-backup");
+    expect(raw.llm.profiles["balanced-backup"]).toBeUndefined();
+  });
+
+  test("a call site pinned to a managed backup profile survives a reload", () => {
+    writeConfig({
+      llm: {
+        defaultProvider: { provider: "vellum" },
+        profiles: {},
+        activeProfile: "balanced",
+        callSites: { recall: { profile: "cost-optimized-backup" } },
+      },
+    });
+
+    const config = loadConfig();
+    expect(config.llm.callSites.recall?.profile).toBe("cost-optimized-backup");
+
+    const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+    expect(raw.llm.callSites.recall.profile).toBe("cost-optimized-backup");
+  });
+
   test("still quarantines corrupt JSON", () => {
     // Corrupt-config quarantine is a recovery path: the broken file is
     // renamed to `config.json.corrupt-<ts>.json` and the daemon proceeds

--- a/assistant/src/__tests__/config-loader-backfill.test.ts
+++ b/assistant/src/__tests__/config-loader-backfill.test.ts
@@ -1436,6 +1436,29 @@ describe("loadConfig startup behavior", () => {
     expect(raw.llm.profiles["balanced-backup"]).toBeUndefined();
   });
 
+  test("an active managed backup profile is repaired on a BYOK install", () => {
+    // Backups live on the managed column alone, so under a BYOK default
+    // provider the selection names a profile that resolves to nothing. The
+    // schema rejects the reference on load and the seeder, which resolves
+    // availability through the same provider-aware view, repairs the stored
+    // selection instead of preserving a dead pointer.
+    writeConfig({
+      llm: {
+        defaultProvider: { provider: "anthropic" },
+        profiles: {},
+        activeProfile: "balanced-backup",
+      },
+    });
+
+    const config = loadConfig();
+    expect(config.llm.activeProfile).toBeUndefined();
+
+    mergeDefaultConfigAndSeedInferenceProfiles();
+
+    const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+    expect(raw.llm.activeProfile).toBe("balanced");
+  });
+
   test("a call site pinned to a managed backup profile survives a reload", () => {
     writeConfig({
       llm: {

--- a/assistant/src/__tests__/config-loader-backfill.test.ts
+++ b/assistant/src/__tests__/config-loader-backfill.test.ts
@@ -1800,6 +1800,10 @@ describe("seedInferenceProfiles BYOK-mode default profiles", () => {
       "quality-optimized",
       "cost-optimized",
       "latency-optimized",
+      "balanced-backup",
+      "quality-optimized-backup",
+      "cost-optimized-backup",
+      "latency-optimized-backup",
       "my-custom",
     ]);
   });

--- a/assistant/src/__tests__/default-profile-catalog-fallback.test.ts
+++ b/assistant/src/__tests__/default-profile-catalog-fallback.test.ts
@@ -201,29 +201,34 @@ describe("effective-profile machinery", () => {
     }
   });
 
-  test("a managed-source stub overlays only label/status/topP on a backup", () => {
-    const workspace: Record<string, ProfileEntry> = {
-      "balanced-backup": {
-        source: "managed",
-        label: "My Backup",
-        status: "disabled",
-        topP: 0.7,
-        // Stale content drift on disk must lose to the code default body.
-        provider: "anthropic",
-        model: "claude-sonnet-4-6",
-        maxTokens: 1,
-      },
-    };
-    const entry = getEffectiveProfile(workspace, "balanced-backup");
-    expect(entry?.label).toBe("My Backup");
-    expect(entry?.status).toBe("disabled");
-    expect(entry?.topP).toBe(0.7);
-    expect(entry?.model).toBe(
-      CODE_DEFAULT_PROFILE_ENTRIES["balanced-backup"].model,
-    );
-    expect(entry?.maxTokens).toBe(
-      CODE_DEFAULT_PROFILE_ENTRIES["balanced-backup"].maxTokens,
-    );
+  test("a workspace entry never overlays a backup, whatever its source", () => {
+    // Backups are code-owned (`CODE_OWNED_PROFILE_NAMES`), so unlike the
+    // primaries they take no workspace overlay at all: not the usual
+    // label/status/topP whitelist from a managed stub, and not a user-owned
+    // shadow. Disabling a backup through a hand-edited config would strand
+    // the primary's fallback exactly when it is needed.
+    for (const source of ["managed", "user"] as const) {
+      const workspace: Record<string, ProfileEntry> = {
+        "balanced-backup": {
+          source,
+          label: "My Backup",
+          status: "disabled",
+          topP: 0.7,
+          // Stale content drift on disk must lose to the code default body.
+          provider: "anthropic",
+          model: "claude-sonnet-4-6",
+          maxTokens: 1,
+        },
+      };
+      const entry = getEffectiveProfile(workspace, "balanced-backup");
+      const body = CODE_DEFAULT_PROFILE_ENTRIES["balanced-backup"];
+      expect(entry?.label).toBe(body.label);
+      expect(entry?.status).toBeUndefined();
+      expect(entry?.topP).toBe(body.topP);
+      expect(entry?.model).toBe(body.model);
+      expect(entry?.maxTokens).toBe(body.maxTokens);
+      expect(String(entry?.provider)).toBe("vellum");
+    }
   });
 
   test("backup profiles are delete-protected like the other managed defaults", () => {

--- a/assistant/src/__tests__/default-profile-catalog-fallback.test.ts
+++ b/assistant/src/__tests__/default-profile-catalog-fallback.test.ts
@@ -179,6 +179,51 @@ describe("managed-column-only scoping", () => {
       expect(effective[key]?.fallbackProfile).toBeUndefined();
     }
   });
+
+  test("a persisted managed stub does not resurrect a backup off the managed column", () => {
+    // A `config get` -> `config set` round-trip on a managed install can
+    // leave a thin managed stub for a backup in `llm.profiles`
+    // (`normalizeManagedProfileWrites`). The stub is the workspace's slot for
+    // a code-owned body, not a profile, so once the column has no body behind
+    // it the name must stop being listed rather than resolve to a
+    // providerless entry the pickers would offer and `LLMSchema` would
+    // reject.
+    const workspace: Record<string, ProfileEntry> = {
+      "balanced-backup": { source: "managed" },
+    };
+    for (const provider of ["anthropic", "chatgpt"] as const) {
+      const effective = getEffectiveProfilesForProvider(workspace, {
+        provider,
+      });
+      expect(effective["balanced-backup"]).toBeUndefined();
+      expect(
+        resolveDefaultProfileForProvider(workspace, "balanced-backup", {
+          provider,
+        }),
+      ).toBeUndefined();
+    }
+    // The managed column still has a body for the stub to stand for.
+    expect(
+      getEffectiveProfilesForProvider(workspace, vellum)["balanced-backup"]
+        ?.model,
+    ).toBe(CODE_DEFAULT_PROFILE_ENTRIES["balanced-backup"]?.model);
+  });
+
+  test("a user-owned entry under a backup name stays listed off the managed column", () => {
+    // Nothing code-owned resolves there, so the entry is simply a profile of
+    // that name and keeps its own body.
+    const workspace: Record<string, ProfileEntry> = {
+      "balanced-backup": {
+        source: "user",
+        provider: "anthropic",
+        model: "claude-opus-4-7",
+      },
+    };
+    const effective = getEffectiveProfilesForProvider(workspace, {
+      provider: "anthropic",
+    });
+    expect(effective["balanced-backup"]?.model).toBe("claude-opus-4-7");
+  });
 });
 
 describe("effective-profile machinery", () => {

--- a/assistant/src/__tests__/default-profile-catalog-fallback.test.ts
+++ b/assistant/src/__tests__/default-profile-catalog-fallback.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Managed backup profiles and the `fallbackProfile` pointers of the vellum
+ * column (`default-profile-catalog.ts`).
+ *
+ * The invariants under test:
+ * - Every default profile's managed (vellum) implementation points at a
+ *   backup profile that exists in the code catalog.
+ * - Cross-provider rule: a backup pins its model at a DIFFERENT managed
+ *   upstream than its primary, so an outage at the primary's provider can
+ *   be served by the backup. Holds for the experiment arms too.
+ * - Probe coverage: every backup model is a catalog member of its upstream
+ *   provider, which is what feeds the platform's model liveness probe.
+ * - Scoping: backups exist for the managed column only. A BYOK or chatgpt
+ *   default provider materializes no backup profiles, and its primaries
+ *   carry no `fallbackProfile` pointers.
+ * - The effective catalog parses under `LLMSchema` (exercising the
+ *   `fallbackProfile` superRefine against the real entries), and backups
+ *   are delete-protected like the other managed defaults.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { BALANCED_MODEL_EXPERIMENT_FLAG_KEY } from "../config/balanced-model-experiment.js";
+import {
+  CODE_DEFAULT_PROFILE_ENTRIES,
+  getEffectiveProfile,
+  getEffectiveProfiles,
+  getEffectiveProfilesForProvider,
+  INVARIANT_PROFILE_NAMES,
+  MANAGED_PROFILE_NAMES,
+  MANAGED_PROFILE_TEMPLATES,
+  PROFILE_IMPLS,
+  resolveDefaultProfileForProvider,
+} from "../config/default-profile-catalog.js";
+import {
+  BACKUP_PROFILE_KEYS,
+  DEFAULT_PROFILE_KEYS,
+  DEFAULT_PROFILE_PROVIDERS,
+  FALLBACK_PROFILE_BY_KEY,
+} from "../config/default-profile-names.js";
+import { clearCachedOverrides } from "../config/feature-flag-cache.js";
+import {
+  type DefaultProviderConfig,
+  LLMSchema,
+  type ProfileEntry,
+} from "../config/schemas/llm.js";
+import { isModelInCatalog } from "../providers/model-catalog.js";
+import { getManagedUpstream } from "../providers/vellum-model-routing.js";
+import { setOverridesForTesting } from "./feature-flag-test-helpers.js";
+
+const vellum: DefaultProviderConfig = { provider: "vellum" };
+
+afterEach(() => {
+  clearCachedOverrides();
+});
+
+describe("fallbackProfile pointers on the vellum column", () => {
+  test("every default profile's vellum impl points at an existing backup", () => {
+    for (const key of DEFAULT_PROFILE_KEYS) {
+      const impl = PROFILE_IMPLS[key].vellum;
+      expect(impl.fallbackProfile).toBe(FALLBACK_PROFILE_BY_KEY[key]);
+      const backup = CODE_DEFAULT_PROFILE_ENTRIES[FALLBACK_PROFILE_BY_KEY[key]];
+      expect(backup).toBeDefined();
+      expect(backup.provider).toBe("vellum");
+      expect(backup.source).toBe("managed");
+      // Single hop: a backup never declares a fallback of its own.
+      expect(backup.fallbackProfile).toBeUndefined();
+    }
+  });
+
+  test("no BYOK or chatgpt column impl carries fallbackProfile", () => {
+    for (const key of DEFAULT_PROFILE_KEYS) {
+      for (const provider of DEFAULT_PROFILE_PROVIDERS) {
+        if (provider === "vellum") {
+          continue;
+        }
+        expect(PROFILE_IMPLS[key][provider].fallbackProfile).toBeUndefined();
+      }
+      // A default-capable provider without a named matrix column
+      // materializes from the shared BYOK templates: no pointer either.
+      const entry = resolveDefaultProfileForProvider(undefined, key, {
+        provider: "together",
+      });
+      expect(entry?.fallbackProfile).toBeUndefined();
+    }
+  });
+});
+
+describe("cross-provider rule", () => {
+  test("every backup dispatches through a different managed upstream than its primary", () => {
+    for (const key of DEFAULT_PROFILE_KEYS) {
+      const primary = CODE_DEFAULT_PROFILE_ENTRIES[key];
+      const backup = CODE_DEFAULT_PROFILE_ENTRIES[FALLBACK_PROFILE_BY_KEY[key]];
+      const primaryUpstream = getManagedUpstream(primary.model as string);
+      const backupUpstream = getManagedUpstream(backup.model as string);
+      expect(primaryUpstream).not.toBeNull();
+      expect(backupUpstream).not.toBeNull();
+      expect(backupUpstream).not.toBe(primaryUpstream);
+    }
+  });
+
+  test("the balanced experiment arms keep the cross-provider split", () => {
+    const backup =
+      CODE_DEFAULT_PROFILE_ENTRIES[FALLBACK_PROFILE_BY_KEY.balanced];
+    const backupUpstream = getManagedUpstream(backup.model as string);
+    for (const arm of ["terra", "glm-5p2"]) {
+      setOverridesForTesting({ [BALANCED_MODEL_EXPERIMENT_FLAG_KEY]: arm });
+      const armed = resolveDefaultProfileForProvider(
+        undefined,
+        "balanced",
+        vellum,
+      );
+      expect(armed?.fallbackProfile).toBe(FALLBACK_PROFILE_BY_KEY.balanced);
+      const armedUpstream = getManagedUpstream(armed?.model as string);
+      expect(armedUpstream).not.toBeNull();
+      expect(armedUpstream).not.toBe(backupUpstream);
+    }
+  });
+
+  test("every backup model is a catalog member of its upstream (liveness-probe coverage)", () => {
+    for (const key of BACKUP_PROFILE_KEYS) {
+      const model = CODE_DEFAULT_PROFILE_ENTRIES[key].model as string;
+      const upstream = getManagedUpstream(model);
+      expect(upstream).not.toBeNull();
+      expect(isModelInCatalog(upstream as string, model)).toBe(true);
+    }
+  });
+});
+
+describe("managed-column-only scoping", () => {
+  test("the managed column materializes the backups after the primaries", () => {
+    const effective = getEffectiveProfilesForProvider(undefined, vellum);
+    for (const key of BACKUP_PROFILE_KEYS) {
+      expect(effective[key]).toBeDefined();
+      expect(effective[key]?.provider).toBe("vellum");
+      expect(effective[key]?.source).toBe("managed");
+    }
+    // The seeder inserts missing managed keys in MANAGED_PROFILE_TEMPLATES
+    // order, which is what places backups after the primaries in
+    // `profileOrder` presentation.
+    expect(Object.keys(MANAGED_PROFILE_TEMPLATES)).toEqual([
+      ...DEFAULT_PROFILE_KEYS,
+      ...BACKUP_PROFILE_KEYS,
+    ]);
+  });
+
+  test("a null defaultProvider (pre-defaultProvider install) keeps its backups", () => {
+    const effective = getEffectiveProfiles(undefined);
+    for (const key of BACKUP_PROFILE_KEYS) {
+      expect(effective[key]).toBeDefined();
+      expect(
+        resolveDefaultProfileForProvider(undefined, key, null),
+      ).toBeDefined();
+    }
+  });
+
+  test("a BYOK default provider materializes no backups and no pointers", () => {
+    for (const provider of ["anthropic", "openai", "gemini"] as const) {
+      const effective = getEffectiveProfilesForProvider(undefined, {
+        provider,
+      });
+      for (const key of BACKUP_PROFILE_KEYS) {
+        expect(effective[key]).toBeUndefined();
+      }
+      for (const key of DEFAULT_PROFILE_KEYS) {
+        expect(effective[key]?.fallbackProfile).toBeUndefined();
+      }
+    }
+  });
+
+  test("the chatgpt column materializes no backups and no pointers", () => {
+    const effective = getEffectiveProfilesForProvider(undefined, {
+      provider: "chatgpt",
+    });
+    for (const key of BACKUP_PROFILE_KEYS) {
+      expect(effective[key]).toBeUndefined();
+    }
+    for (const key of DEFAULT_PROFILE_KEYS) {
+      expect(effective[key]?.fallbackProfile).toBeUndefined();
+    }
+  });
+});
+
+describe("effective-profile machinery", () => {
+  test("the full effective catalog parses under LLMSchema", () => {
+    // Exercises the fallbackProfile superRefine (target exists, no self
+    // reference, no mix target, single hop) against the real entries.
+    for (const profiles of [
+      getEffectiveProfiles(undefined),
+      getEffectiveProfilesForProvider(undefined, vellum),
+    ]) {
+      const parsed = LLMSchema.parse({
+        profiles,
+        activeProfile: "balanced",
+      });
+      for (const key of DEFAULT_PROFILE_KEYS) {
+        expect(parsed.profiles[key]?.fallbackProfile).toBe(
+          FALLBACK_PROFILE_BY_KEY[key],
+        );
+      }
+    }
+  });
+
+  test("a managed-source stub overlays only label/status/topP on a backup", () => {
+    const workspace: Record<string, ProfileEntry> = {
+      "balanced-backup": {
+        source: "managed",
+        label: "My Backup",
+        status: "disabled",
+        topP: 0.7,
+        // Stale content drift on disk must lose to the code default body.
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+        maxTokens: 1,
+      },
+    };
+    const entry = getEffectiveProfile(workspace, "balanced-backup");
+    expect(entry?.label).toBe("My Backup");
+    expect(entry?.status).toBe("disabled");
+    expect(entry?.topP).toBe(0.7);
+    expect(entry?.model).toBe(
+      CODE_DEFAULT_PROFILE_ENTRIES["balanced-backup"].model,
+    );
+    expect(entry?.maxTokens).toBe(
+      CODE_DEFAULT_PROFILE_ENTRIES["balanced-backup"].maxTokens,
+    );
+  });
+
+  test("backup profiles are delete-protected like the other managed defaults", () => {
+    // Membership in these sets is what wires the route-level deletion
+    // rejection (`rejectManagedProfileDeletion`, `handleCreateProfile`) and
+    // the commitConfigWrite invariant guard
+    // (`assertInvariantProfilesPreserved`).
+    for (const key of BACKUP_PROFILE_KEYS) {
+      expect(MANAGED_PROFILE_NAMES.has(key)).toBe(true);
+      expect(INVARIANT_PROFILE_NAMES.has(key)).toBe(true);
+    }
+  });
+});

--- a/assistant/src/__tests__/llm-schema-fallback-profile.test.ts
+++ b/assistant/src/__tests__/llm-schema-fallback-profile.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, test } from "bun:test";
 
 import { z } from "zod";
 
-import { DEFAULT_PROFILE_KEYS } from "../config/default-profile-names.js";
+import {
+  BACKUP_PROFILE_KEYS,
+  DEFAULT_PROFILE_KEYS,
+} from "../config/default-profile-names.js";
 import { LLMSchema } from "../config/schemas/llm.js";
 
 describe("LLMSchema fallbackProfile", () => {
@@ -27,6 +30,19 @@ describe("LLMSchema fallbackProfile", () => {
     const result = LLMSchema.safeParse({
       profiles: {
         primary: { fallbackProfile: defaultKey },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("fallbackProfile may reference a managed backup profile key", () => {
+    // Backups resolve from the code catalog without being materialized in
+    // llm.profiles, exactly like the always-available defaults, so a pointer
+    // at one is a valid reference.
+    const backupKey = BACKUP_PROFILE_KEYS[0];
+    const result = LLMSchema.safeParse({
+      profiles: {
+        primary: { fallbackProfile: backupKey },
       },
     });
     expect(result.success).toBe(true);

--- a/assistant/src/__tests__/llm-schema-fallback-profile.test.ts
+++ b/assistant/src/__tests__/llm-schema-fallback-profile.test.ts
@@ -191,10 +191,13 @@ describe("LLMSchema fallbackProfile", () => {
     }
   });
 
-  test("a materialized backup entry is a valid target on any column", () => {
-    // Conditioning applies to the code-defined name, not to a workspace
-    // entry: an on-disk profile of that name is a real entry and resolves
-    // whatever the default provider is.
+  test("a user-owned materialized backup entry is a valid target on any column", () => {
+    // Conditioning applies to the code-defined name, not to a user-owned
+    // workspace entry: that entry carries its own body, and with no
+    // code-owned body to lose on a BYOK column it is what the name resolves
+    // to, so a pointer at it stays valid. A `source` other than `managed`,
+    // absent included, is what makes an entry user-owned, matching
+    // `resolveAgainstBody`.
     const backupKey = BACKUP_PROFILE_KEYS[0];
     const result = LLMSchema.safeParse({
       defaultProvider: { provider: "anthropic" },
@@ -333,6 +336,108 @@ describe("LLMSchema backup profile references vs llm.defaultProvider", () => {
           LLMSchema.safeParse({ defaultProvider, activeProfile: key }).success,
         ).toBe(true);
       }
+    }
+  });
+
+  // A managed install can persist a thin `{ source: "managed" }` stub for a
+  // backup key: `normalizeManagedProfileWrites` reduces a `config get` ->
+  // `config set` echo of the effective profile list to exactly that. The stub
+  // holds no body of its own, so it must not carry a reference past the
+  // provider gate once the install moves off the managed column.
+  const stub = { source: "managed" } as const;
+
+  test("a managed stub does not keep a backup reference alive off the managed column", () => {
+    for (const defaultProvider of nonManaged) {
+      const result = LLMSchema.safeParse({
+        defaultProvider,
+        profiles: { [backupKey]: stub, primary: { effort: "high" } },
+        activeProfile: backupKey,
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const issue = result.error.issues.find(
+          (i) => i.path.join(".") === "activeProfile",
+        );
+        expect(issue?.message).toContain("managed backup profile");
+      }
+    }
+  });
+
+  test("a managed stub does not keep a call-site pin or mix arm alive either", () => {
+    for (const defaultProvider of nonManaged) {
+      const callSitePin = LLMSchema.safeParse({
+        defaultProvider,
+        profiles: { [backupKey]: stub },
+        callSites: { recall: { profile: backupKey } },
+      });
+      expect(callSitePin.success).toBe(false);
+
+      const mixArm = LLMSchema.safeParse({
+        defaultProvider,
+        profiles: {
+          [backupKey]: stub,
+          armA: { speed: "fast" },
+          blend: {
+            mix: [
+              { profile: backupKey, weight: 1 },
+              { profile: "armA", weight: 1 },
+            ],
+          },
+        },
+      });
+      expect(mixArm.success).toBe(false);
+    }
+  });
+
+  test("a managed stub does not keep a fallbackProfile pointer alive either", () => {
+    for (const defaultProvider of nonManaged) {
+      const result = LLMSchema.safeParse({
+        defaultProvider,
+        profiles: {
+          [backupKey]: stub,
+          primary: { fallbackProfile: backupKey },
+        },
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const issue = result.error.issues.find(
+          (i) => i.path.join(".") === "profiles.primary.fallbackProfile",
+        );
+        expect(issue?.message).toContain("managed backup profile");
+      }
+    }
+  });
+
+  test("a managed stub keeps its references valid on the managed column", () => {
+    // The stub stands for a body that does resolve here, so nothing about it
+    // makes the reference worse than the unmaterialized case.
+    const result = LLMSchema.safeParse({
+      defaultProvider: managed,
+      profiles: {
+        [backupKey]: stub,
+        primary: { fallbackProfile: backupKey },
+      },
+      activeProfile: backupKey,
+      callSites: { recall: { profile: backupKey } },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("a user-owned entry under a backup name keeps its references on every column", () => {
+    for (const defaultProvider of [managed, ...nonManaged]) {
+      const result = LLMSchema.safeParse({
+        defaultProvider,
+        profiles: {
+          [backupKey]: {
+            source: "user",
+            provider: "anthropic",
+            model: "claude-opus-4-7",
+          },
+          primary: { fallbackProfile: backupKey },
+        },
+        activeProfile: backupKey,
+      });
+      expect(result.success).toBe(true);
     }
   });
 });

--- a/assistant/src/__tests__/llm-schema-fallback-profile.test.ts
+++ b/assistant/src/__tests__/llm-schema-fallback-profile.test.ts
@@ -38,7 +38,8 @@ describe("LLMSchema fallbackProfile", () => {
   test("fallbackProfile may reference a managed backup profile key", () => {
     // Backups resolve from the code catalog without being materialized in
     // llm.profiles, exactly like the always-available defaults, so a pointer
-    // at one is a valid reference.
+    // at one is a valid reference. No `defaultProvider` means the managed
+    // column (the reading an install predating the field gets).
     const backupKey = BACKUP_PROFILE_KEYS[0];
     const result = LLMSchema.safeParse({
       profiles: {
@@ -167,6 +168,44 @@ describe("LLMSchema fallbackProfile", () => {
     }
   });
 
+  test("a backup fallbackProfile target is rejected on a non-managed column", () => {
+    // The backups exist only on the managed column, so under a BYOK or
+    // ChatGPT default provider the pointer names a target that can never
+    // resolve, and keeping it would leave the primary silently unprotected.
+    const backupKey = BACKUP_PROFILE_KEYS[0];
+    for (const provider of ["anthropic", "chatgpt"] as const) {
+      const result = LLMSchema.safeParse({
+        defaultProvider: { provider },
+        profiles: {
+          primary: { fallbackProfile: backupKey },
+        },
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const issue = result.error.issues.find((i) =>
+          i.message.includes(`fallbackProfile "${backupKey}"`),
+        );
+        expect(issue?.message).toContain("managed backup profile");
+        expect(issue?.path).toEqual(["profiles", "primary", "fallbackProfile"]);
+      }
+    }
+  });
+
+  test("a materialized backup entry is a valid target on any column", () => {
+    // Conditioning applies to the code-defined name, not to a workspace
+    // entry: an on-disk profile of that name is a real entry and resolves
+    // whatever the default provider is.
+    const backupKey = BACKUP_PROFILE_KEYS[0];
+    const result = LLMSchema.safeParse({
+      defaultProvider: { provider: "anthropic" },
+      profiles: {
+        primary: { fallbackProfile: backupKey },
+        [backupKey]: { provider: "anthropic", model: "claude-opus-4-7" },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
   test("z.toJSONSchema still generates for LLMSchema (config docs/routes)", () => {
     // Same options as handleGetConfigSchema in
     // runtime/routes/conversation-query-routes.ts. The field must not
@@ -176,5 +215,124 @@ describe("LLMSchema fallbackProfile", () => {
       io: "input",
     });
     expect(json).toBeTruthy();
+  });
+});
+
+describe("LLMSchema backup profile references vs llm.defaultProvider", () => {
+  const backupKey = BACKUP_PROFILE_KEYS[0];
+  const managed = { provider: "vellum" } as const;
+  const nonManaged = [{ provider: "anthropic" }, { provider: "chatgpt" }];
+
+  test("activeProfile naming a backup parses on the managed column", () => {
+    const result = LLMSchema.safeParse({
+      defaultProvider: managed,
+      activeProfile: backupKey,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("activeProfile naming a backup is rejected on a non-managed column", () => {
+    for (const defaultProvider of nonManaged) {
+      const result = LLMSchema.safeParse({
+        defaultProvider,
+        activeProfile: backupKey,
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const issue = result.error.issues.find(
+          (i) => i.path.join(".") === "activeProfile",
+        );
+        expect(issue?.message).toContain("managed backup profile");
+      }
+    }
+  });
+
+  test("advisorProfile naming a backup follows the same split", () => {
+    expect(
+      LLMSchema.safeParse({
+        defaultProvider: managed,
+        advisorProfile: backupKey,
+      }).success,
+    ).toBe(true);
+    for (const defaultProvider of nonManaged) {
+      const result = LLMSchema.safeParse({
+        defaultProvider,
+        advisorProfile: backupKey,
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(
+          result.error.issues.some(
+            (i) => i.path.join(".") === "advisorProfile",
+          ),
+        ).toBe(true);
+      }
+    }
+  });
+
+  test("a call-site pin on a backup follows the same split", () => {
+    expect(
+      LLMSchema.safeParse({
+        defaultProvider: managed,
+        callSites: { recall: { profile: backupKey } },
+      }).success,
+    ).toBe(true);
+    for (const defaultProvider of nonManaged) {
+      const result = LLMSchema.safeParse({
+        defaultProvider,
+        callSites: { recall: { profile: backupKey } },
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const issue = result.error.issues.find(
+          (i) => i.path.join(".") === "callSites.recall.profile",
+        );
+        expect(issue?.message).toContain("managed backup profile");
+      }
+    }
+  });
+
+  test("a mix arm naming a backup follows the same split", () => {
+    const mixConfig = (defaultProvider: { provider: string }) => ({
+      defaultProvider,
+      profiles: {
+        armA: { speed: "fast" },
+        blend: {
+          mix: [
+            { profile: backupKey, weight: 1 },
+            { profile: "armA", weight: 1 },
+          ],
+        },
+      },
+    });
+    expect(LLMSchema.safeParse(mixConfig(managed)).success).toBe(true);
+    for (const defaultProvider of nonManaged) {
+      expect(LLMSchema.safeParse(mixConfig(defaultProvider)).success).toBe(
+        false,
+      );
+    }
+  });
+
+  test("an absent or malformed defaultProvider reads as the managed column", () => {
+    // `DefaultProviderField` catches an invalid value to `undefined`, and an
+    // install predating the field is managed by definition, so both keep
+    // their backups referenceable rather than losing a valid selection.
+    for (const defaultProvider of [undefined, { provider: 42 }, "vellum"]) {
+      const result = LLMSchema.safeParse({
+        defaultProvider,
+        activeProfile: backupKey,
+      });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  test("the default profile keys stay valid on every column", () => {
+    for (const defaultProvider of [managed, ...nonManaged]) {
+      for (const key of DEFAULT_PROFILE_KEYS) {
+        expect(
+          LLMSchema.safeParse({ defaultProvider, activeProfile: key }).success,
+        ).toBe(true);
+      }
+    }
   });
 });

--- a/assistant/src/__tests__/managed-profile-guard.test.ts
+++ b/assistant/src/__tests__/managed-profile-guard.test.ts
@@ -286,6 +286,34 @@ describe("PUT /v1/config/llm/profiles/:name — managed profile guard", () => {
     expectNothingCommitted();
   });
 
+  test("PUT on a managed backup profile is rejected as code-owned", async () => {
+    // Backups are code-owned too, and they carry no on-disk entry, so the
+    // code-owned rejection has to win over the availability gate: reporting
+    // "not currently available" would be wrong for a profile the picker
+    // lists and the user can select.
+    seedRawConfig({ llm: { profiles: {} } });
+
+    for (const name of [
+      "balanced-backup",
+      "quality-optimized-backup",
+      "cost-optimized-backup",
+      "latency-optimized-backup",
+    ]) {
+      for (const body of [
+        { label: "Zippy" },
+        { status: "active" as const },
+        { status: null },
+      ]) {
+        await expect(
+          replaceRoute.handler({ pathParams: { name }, body }),
+        ).rejects.toThrow(
+          `Profile "${name}" is code-owned and cannot be edited.`,
+        );
+      }
+    }
+    expectNothingCommitted();
+  });
+
   test("PUT { status: null } on managed profile clears status (back to active-by-absence)", async () => {
     seedRawConfig({
       llm: {

--- a/assistant/src/__tests__/plugin-api-model-profiles.test.ts
+++ b/assistant/src/__tests__/plugin-api-model-profiles.test.ts
@@ -64,8 +64,12 @@ describe("getModelProfiles", () => {
       "balanced",
       "cost-optimized",
       "alpha",
+      "balanced-backup",
+      "cost-optimized-backup",
       "latency-optimized",
+      "latency-optimized-backup",
       "quality-optimized",
+      "quality-optimized-backup",
       "zeta",
     ]);
   });
@@ -95,9 +99,13 @@ describe("getModelProfiles", () => {
       ["beta", false],
       ["blend", true],
       ["balanced", false],
+      ["balanced-backup", false],
       ["cost-optimized", false],
+      ["cost-optimized-backup", false],
       ["latency-optimized", false],
+      ["latency-optimized-backup", false],
       ["quality-optimized", false],
+      ["quality-optimized-backup", false],
     ]);
   });
 
@@ -145,9 +153,13 @@ describe("getModelProfiles", () => {
       ["alpha", false],
       ["beta", true],
       ["balanced", false],
+      ["balanced-backup", false],
       ["cost-optimized", false],
+      ["cost-optimized-backup", false],
       ["latency-optimized", false],
+      ["latency-optimized-backup", false],
       ["quality-optimized", false],
+      ["quality-optimized-backup", false],
     ]);
   });
 
@@ -190,9 +202,13 @@ describe("getModelProfiles", () => {
       ["alpha", false],
       ["beta", true],
       ["balanced", false],
+      ["balanced-backup", false],
       ["cost-optimized", false],
+      ["cost-optimized-backup", false],
       ["latency-optimized", false],
+      ["latency-optimized-backup", false],
       ["quality-optimized", false],
+      ["quality-optimized-backup", false],
     ]);
   });
 
@@ -230,9 +246,13 @@ describe("getModelProfiles", () => {
         .sort(),
     ).toEqual([
       "balanced",
+      "balanced-backup",
       "cost-optimized",
+      "cost-optimized-backup",
       "latency-optimized",
+      "latency-optimized-backup",
       "quality-optimized",
+      "quality-optimized-backup",
     ]);
   });
 });

--- a/assistant/src/__tests__/workspace-migration-147-rename-colliding-backup-profile-names.test.ts
+++ b/assistant/src/__tests__/workspace-migration-147-rename-colliding-backup-profile-names.test.ts
@@ -1,0 +1,357 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  BACKUP_PROFILE_KEYS,
+  DEFAULT_PROFILE_KEYS,
+} from "../config/default-profile-names.js";
+import { LLMSchema } from "../config/schemas/llm.js";
+import { renameCollidingBackupProfileNamesMigration } from "../workspace/migrations/147-rename-colliding-backup-profile-names.js";
+import { WORKSPACE_MIGRATIONS } from "../workspace/migrations/registry.js";
+import { assertNotLiveDb } from "./assert-not-live-db.js";
+
+let workspaceDir: string;
+
+function freshWorkspace(): void {
+  workspaceDir = join(
+    tmpdir(),
+    `vellum-migration-147-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(workspaceDir, { recursive: true });
+}
+
+function writeConfig(data: Record<string, unknown>): void {
+  writeFileSync(
+    join(workspaceDir, "config.json"),
+    JSON.stringify(data, null, 2) + "\n",
+  );
+}
+
+function readConfig(): Record<string, any> {
+  return JSON.parse(readFileSync(join(workspaceDir, "config.json"), "utf-8"));
+}
+
+function seedProfilePinTables(rows: {
+  conversations: string[];
+  cronJobs: string[];
+}): void {
+  mkdirSync(join(workspaceDir, "data", "db"), { recursive: true });
+  const db = new Database(join(workspaceDir, "data", "db", "assistant.db"));
+  db.run(
+    `CREATE TABLE conversations (id TEXT PRIMARY KEY, inference_profile TEXT)`,
+  );
+  db.run(
+    `CREATE TABLE cron_jobs (id TEXT PRIMARY KEY, inference_profile TEXT)`,
+  );
+  rows.conversations.forEach((profile, index) => {
+    db.query(
+      `INSERT INTO conversations (id, inference_profile) VALUES (?, ?)`,
+    ).run(`conv-${index}`, profile);
+  });
+  rows.cronJobs.forEach((profile, index) => {
+    db.query(`INSERT INTO cron_jobs (id, inference_profile) VALUES (?, ?)`).run(
+      `job-${index}`,
+      profile,
+    );
+  });
+  db.close();
+}
+
+function readPins(table: string): string[] {
+  const db = new Database(join(workspaceDir, "data", "db", "assistant.db"));
+  try {
+    return (
+      db
+        .query(`SELECT inference_profile AS p FROM ${table} ORDER BY id`)
+        .all() as Array<{ p: string }>
+    ).map((row) => row.p);
+  } finally {
+    db.close();
+  }
+}
+
+beforeEach(() => {
+  freshWorkspace();
+});
+
+afterEach(() => {
+  if (existsSync(workspaceDir)) {
+    assertNotLiveDb(workspaceDir);
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+describe("147-rename-colliding-backup-profile-names migration", () => {
+  test("has correct migration id and is registered", () => {
+    expect(renameCollidingBackupProfileNamesMigration.id).toBe(
+      "147-rename-colliding-backup-profile-names",
+    );
+    expect(WORKSPACE_MIGRATIONS.map((m) => m.id)).toContain(
+      "147-rename-colliding-backup-profile-names",
+    );
+  });
+
+  test("renames a colliding user profile and rewrites every reference", () => {
+    writeConfig({
+      llm: {
+        defaultProvider: { provider: "vellum" },
+        profiles: {
+          "balanced-backup": {
+            source: "user",
+            provider: "anthropic",
+            model: "claude-opus-4-7",
+            label: "My Backup",
+          },
+          scratch: { source: "user", fallbackProfile: "balanced-backup" },
+          armA: { source: "user", speed: "fast" },
+          blend: {
+            source: "user",
+            mix: [
+              { profile: "balanced-backup", weight: 1 },
+              { profile: "armA", weight: 1 },
+            ],
+          },
+        },
+        profileOrder: ["balanced", "balanced-backup", "blend"],
+        activeProfile: "balanced-backup",
+        advisorProfile: "balanced-backup",
+        callSites: { recall: { profile: "balanced-backup", maxTokens: 4096 } },
+      },
+    });
+
+    renameCollidingBackupProfileNamesMigration.run(workspaceDir);
+
+    const llm = readConfig().llm;
+    expect(llm.profiles["balanced-backup"]).toBeUndefined();
+    expect(llm.profiles["balanced-backup-custom"]).toEqual({
+      source: "user",
+      provider: "anthropic",
+      model: "claude-opus-4-7",
+      label: "My Backup",
+    });
+    expect(llm.activeProfile).toBe("balanced-backup-custom");
+    expect(llm.advisorProfile).toBe("balanced-backup-custom");
+    expect(llm.callSites.recall.profile).toBe("balanced-backup-custom");
+    expect(llm.callSites.recall.maxTokens).toBe(4096);
+    expect(llm.profiles.scratch.fallbackProfile).toBe("balanced-backup-custom");
+    expect(llm.profiles.blend.mix[0].profile).toBe("balanced-backup-custom");
+    expect(llm.profiles.blend.mix[1].profile).toBe("armA");
+    expect(llm.profileOrder).toEqual([
+      "balanced",
+      "balanced-backup-custom",
+      "blend",
+    ]);
+  });
+
+  test("the code-owned backup is available under the reserved name afterwards", () => {
+    writeConfig({
+      llm: {
+        defaultProvider: { provider: "vellum" },
+        profiles: {
+          "balanced-backup": {
+            source: "user",
+            provider: "anthropic",
+            model: "claude-opus-4-7",
+          },
+        },
+        activeProfile: "balanced-backup",
+      },
+    });
+
+    renameCollidingBackupProfileNamesMigration.run(workspaceDir);
+
+    const llm = readConfig().llm;
+    // The reserved key is free, so it resolves to the code-owned backup body
+    // rather than the user's profile, and the user's selection still points
+    // at their own profile.
+    expect(llm.profiles["balanced-backup"]).toBeUndefined();
+    expect(llm.activeProfile).toBe("balanced-backup-custom");
+    // A reference to the now-free reserved key remains valid on the managed
+    // column, which is what the schema's always-available set encodes.
+    const parsed = LLMSchema.safeParse({
+      ...llm,
+      activeProfile: "balanced-backup",
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  test("the migrated config parses under LLMSchema", () => {
+    writeConfig({
+      llm: {
+        defaultProvider: { provider: "vellum" },
+        profiles: {
+          "cost-optimized-backup": {
+            source: "user",
+            provider: "anthropic",
+            model: "claude-opus-4-7",
+          },
+          scratch: {
+            source: "user",
+            fallbackProfile: "cost-optimized-backup",
+          },
+        },
+        profileOrder: ["cost-optimized-backup", "scratch"],
+        activeProfile: "cost-optimized-backup",
+        callSites: { recall: { profile: "cost-optimized-backup" } },
+      },
+    });
+
+    renameCollidingBackupProfileNamesMigration.run(workspaceDir);
+
+    const parsed = LLMSchema.safeParse(readConfig().llm);
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.activeProfile).toBe("cost-optimized-backup-custom");
+    }
+  });
+
+  test("renames every colliding key and keeps suffixing past taken names", () => {
+    const profiles: Record<string, unknown> = {
+      "balanced-backup-custom": { source: "user", speed: "fast" },
+      "balanced-backup-custom-2": { source: "user", speed: "fast" },
+    };
+    for (const key of BACKUP_PROFILE_KEYS) {
+      profiles[key] = { source: "user", provider: "anthropic" };
+    }
+    writeConfig({ llm: { profiles } });
+
+    renameCollidingBackupProfileNamesMigration.run(workspaceDir);
+
+    const renamed = readConfig().llm.profiles;
+    expect(renamed["balanced-backup-custom-3"]).toBeDefined();
+    for (const key of BACKUP_PROFILE_KEYS) {
+      expect(renamed[key]).toBeUndefined();
+    }
+    for (const key of BACKUP_PROFILE_KEYS.slice(1)) {
+      expect(renamed[`${key}-custom`]).toBeDefined();
+    }
+  });
+
+  test("never renames onto another reserved code-defined name", () => {
+    // Contrived: a profile literally named `<backup>-custom` would be a
+    // legitimate rename target, but a reserved name never is.
+    writeConfig({
+      llm: {
+        profiles: Object.fromEntries(
+          [...DEFAULT_PROFILE_KEYS, ...BACKUP_PROFILE_KEYS, "os-beta"].map(
+            (key) => [key, { source: "user", provider: "anthropic" }],
+          ),
+        ),
+      },
+    });
+
+    renameCollidingBackupProfileNamesMigration.run(workspaceDir);
+
+    const renamed = Object.keys(readConfig().llm.profiles);
+    for (const key of BACKUP_PROFILE_KEYS) {
+      expect(renamed).toContain(`${key}-custom`);
+    }
+    // The user-owned entries on the non-reserved-for-this-migration names are
+    // untouched: only the backup keys became newly reserved.
+    for (const key of [...DEFAULT_PROFILE_KEYS, "os-beta"]) {
+      expect(renamed).toContain(key);
+    }
+  });
+
+  test("leaves managed stubs and non-object values alone", () => {
+    writeConfig({
+      llm: {
+        profiles: {
+          "balanced-backup": { source: "managed", status: "disabled" },
+          "quality-optimized-backup": "not-a-profile",
+        },
+        activeProfile: "balanced-backup",
+      },
+    });
+
+    renameCollidingBackupProfileNamesMigration.run(workspaceDir);
+
+    const llm = readConfig().llm;
+    expect(llm.profiles["balanced-backup"]).toEqual({
+      source: "managed",
+      status: "disabled",
+    });
+    expect(llm.profiles["quality-optimized-backup"]).toBe("not-a-profile");
+    expect(llm.activeProfile).toBe("balanced-backup");
+  });
+
+  test("repoints conversation and schedule profile pins", () => {
+    seedProfilePinTables({
+      conversations: ["balanced-backup", "balanced", "balanced-backup"],
+      cronJobs: ["balanced-backup", "scratch"],
+    });
+    writeConfig({
+      llm: {
+        profiles: {
+          "balanced-backup": { source: "user", provider: "anthropic" },
+          scratch: { source: "user", speed: "fast" },
+        },
+      },
+    });
+
+    renameCollidingBackupProfileNamesMigration.run(workspaceDir);
+
+    expect(readPins("conversations")).toEqual([
+      "balanced-backup-custom",
+      "balanced",
+      "balanced-backup-custom",
+    ]);
+    expect(readPins("cron_jobs")).toEqual([
+      "balanced-backup-custom",
+      "scratch",
+    ]);
+  });
+
+  test("is a no-op without a collision and idempotent on re-run", () => {
+    const config = {
+      llm: {
+        defaultProvider: { provider: "vellum" },
+        profiles: {
+          scratch: { source: "user", speed: "fast" },
+        },
+        activeProfile: "balanced",
+        callSites: { recall: { profile: "balanced-backup" } },
+      },
+    };
+    writeConfig(config);
+
+    renameCollidingBackupProfileNamesMigration.run(workspaceDir);
+    expect(readConfig()).toEqual(config);
+
+    // With a collision, a second run finds nothing left to rename.
+    writeConfig({
+      llm: {
+        profiles: { "balanced-backup": { source: "user", speed: "fast" } },
+        activeProfile: "balanced-backup",
+      },
+    });
+    renameCollidingBackupProfileNamesMigration.run(workspaceDir);
+    const first = readConfig();
+    renameCollidingBackupProfileNamesMigration.run(workspaceDir);
+    expect(readConfig()).toEqual(first);
+  });
+
+  test("handles missing config, missing llm block, and invalid JSON", () => {
+    expect(() =>
+      renameCollidingBackupProfileNamesMigration.run(workspaceDir),
+    ).not.toThrow();
+
+    writeConfig({ theme: "dark" });
+    renameCollidingBackupProfileNamesMigration.run(workspaceDir);
+    expect(readConfig()).toEqual({ theme: "dark" });
+
+    writeFileSync(join(workspaceDir, "config.json"), "{not json");
+    expect(() =>
+      renameCollidingBackupProfileNamesMigration.run(workspaceDir),
+    ).not.toThrow();
+  });
+});

--- a/assistant/src/__tests__/workspace-migration-147-rename-colliding-backup-profile-names.test.ts
+++ b/assistant/src/__tests__/workspace-migration-147-rename-colliding-backup-profile-names.test.ts
@@ -17,6 +17,10 @@ import {
 import { LLMSchema } from "../config/schemas/llm.js";
 import { renameCollidingBackupProfileNamesMigration } from "../workspace/migrations/147-rename-colliding-backup-profile-names.js";
 import { WORKSPACE_MIGRATIONS } from "../workspace/migrations/registry.js";
+import {
+  loadCheckpoints,
+  runWorkspaceMigrations,
+} from "../workspace/migrations/runner.js";
 import { assertNotLiveDb } from "./assert-not-live-db.js";
 
 let workspaceDir: string;
@@ -38,6 +42,10 @@ function writeConfig(data: Record<string, unknown>): void {
 
 function readConfig(): Record<string, any> {
   return JSON.parse(readFileSync(join(workspaceDir, "config.json"), "utf-8"));
+}
+
+function dbPath(): string {
+  return join(workspaceDir, "data", "db", "assistant.db");
 }
 
 function seedProfilePinTables(rows: {
@@ -91,7 +99,7 @@ afterEach(() => {
 });
 
 describe("147-rename-colliding-backup-profile-names migration", () => {
-  test("has correct migration id and is registered", () => {
+  test("has correct migration id and is registered", async () => {
     expect(renameCollidingBackupProfileNamesMigration.id).toBe(
       "147-rename-colliding-backup-profile-names",
     );
@@ -100,7 +108,7 @@ describe("147-rename-colliding-backup-profile-names migration", () => {
     );
   });
 
-  test("renames a colliding user profile and rewrites every reference", () => {
+  test("renames a colliding user profile and rewrites every reference", async () => {
     writeConfig({
       llm: {
         defaultProvider: { provider: "vellum" },
@@ -128,7 +136,7 @@ describe("147-rename-colliding-backup-profile-names migration", () => {
       },
     });
 
-    renameCollidingBackupProfileNamesMigration.run(workspaceDir);
+    await renameCollidingBackupProfileNamesMigration.run(workspaceDir);
 
     const llm = readConfig().llm;
     expect(llm.profiles["balanced-backup"]).toBeUndefined();
@@ -152,7 +160,7 @@ describe("147-rename-colliding-backup-profile-names migration", () => {
     ]);
   });
 
-  test("the code-owned backup is available under the reserved name afterwards", () => {
+  test("the code-owned backup is available under the reserved name afterwards", async () => {
     writeConfig({
       llm: {
         defaultProvider: { provider: "vellum" },
@@ -167,7 +175,7 @@ describe("147-rename-colliding-backup-profile-names migration", () => {
       },
     });
 
-    renameCollidingBackupProfileNamesMigration.run(workspaceDir);
+    await renameCollidingBackupProfileNamesMigration.run(workspaceDir);
 
     const llm = readConfig().llm;
     // The reserved key is free, so it resolves to the code-owned backup body
@@ -184,7 +192,7 @@ describe("147-rename-colliding-backup-profile-names migration", () => {
     expect(parsed.success).toBe(true);
   });
 
-  test("the migrated config parses under LLMSchema", () => {
+  test("the migrated config parses under LLMSchema", async () => {
     writeConfig({
       llm: {
         defaultProvider: { provider: "vellum" },
@@ -205,7 +213,7 @@ describe("147-rename-colliding-backup-profile-names migration", () => {
       },
     });
 
-    renameCollidingBackupProfileNamesMigration.run(workspaceDir);
+    await renameCollidingBackupProfileNamesMigration.run(workspaceDir);
 
     const parsed = LLMSchema.safeParse(readConfig().llm);
     expect(parsed.success).toBe(true);
@@ -214,7 +222,7 @@ describe("147-rename-colliding-backup-profile-names migration", () => {
     }
   });
 
-  test("renames every colliding key and keeps suffixing past taken names", () => {
+  test("renames every colliding key and keeps suffixing past taken names", async () => {
     const profiles: Record<string, unknown> = {
       "balanced-backup-custom": { source: "user", speed: "fast" },
       "balanced-backup-custom-2": { source: "user", speed: "fast" },
@@ -224,7 +232,7 @@ describe("147-rename-colliding-backup-profile-names migration", () => {
     }
     writeConfig({ llm: { profiles } });
 
-    renameCollidingBackupProfileNamesMigration.run(workspaceDir);
+    await renameCollidingBackupProfileNamesMigration.run(workspaceDir);
 
     const renamed = readConfig().llm.profiles;
     expect(renamed["balanced-backup-custom-3"]).toBeDefined();
@@ -236,7 +244,7 @@ describe("147-rename-colliding-backup-profile-names migration", () => {
     }
   });
 
-  test("never renames onto another reserved code-defined name", () => {
+  test("never renames onto another reserved code-defined name", async () => {
     // Contrived: a profile literally named `<backup>-custom` would be a
     // legitimate rename target, but a reserved name never is.
     writeConfig({
@@ -249,7 +257,7 @@ describe("147-rename-colliding-backup-profile-names migration", () => {
       },
     });
 
-    renameCollidingBackupProfileNamesMigration.run(workspaceDir);
+    await renameCollidingBackupProfileNamesMigration.run(workspaceDir);
 
     const renamed = Object.keys(readConfig().llm.profiles);
     for (const key of BACKUP_PROFILE_KEYS) {
@@ -262,7 +270,7 @@ describe("147-rename-colliding-backup-profile-names migration", () => {
     }
   });
 
-  test("leaves managed stubs and non-object values alone", () => {
+  test("leaves managed stubs and non-object values alone", async () => {
     writeConfig({
       llm: {
         profiles: {
@@ -273,7 +281,7 @@ describe("147-rename-colliding-backup-profile-names migration", () => {
       },
     });
 
-    renameCollidingBackupProfileNamesMigration.run(workspaceDir);
+    await renameCollidingBackupProfileNamesMigration.run(workspaceDir);
 
     const llm = readConfig().llm;
     expect(llm.profiles["balanced-backup"]).toEqual({
@@ -284,7 +292,7 @@ describe("147-rename-colliding-backup-profile-names migration", () => {
     expect(llm.activeProfile).toBe("balanced-backup");
   });
 
-  test("repoints conversation and schedule profile pins", () => {
+  test("repoints conversation and schedule profile pins", async () => {
     seedProfilePinTables({
       conversations: ["balanced-backup", "balanced", "balanced-backup"],
       cronJobs: ["balanced-backup", "scratch"],
@@ -298,7 +306,7 @@ describe("147-rename-colliding-backup-profile-names migration", () => {
       },
     });
 
-    renameCollidingBackupProfileNamesMigration.run(workspaceDir);
+    await renameCollidingBackupProfileNamesMigration.run(workspaceDir);
 
     expect(readPins("conversations")).toEqual([
       "balanced-backup-custom",
@@ -311,7 +319,7 @@ describe("147-rename-colliding-backup-profile-names migration", () => {
     ]);
   });
 
-  test("is a no-op without a collision and idempotent on re-run", () => {
+  test("is a no-op without a collision and idempotent on re-run", async () => {
     const config = {
       llm: {
         defaultProvider: { provider: "vellum" },
@@ -324,7 +332,7 @@ describe("147-rename-colliding-backup-profile-names migration", () => {
     };
     writeConfig(config);
 
-    renameCollidingBackupProfileNamesMigration.run(workspaceDir);
+    await renameCollidingBackupProfileNamesMigration.run(workspaceDir);
     expect(readConfig()).toEqual(config);
 
     // With a collision, a second run finds nothing left to rename.
@@ -334,24 +342,135 @@ describe("147-rename-colliding-backup-profile-names migration", () => {
         activeProfile: "balanced-backup",
       },
     });
-    renameCollidingBackupProfileNamesMigration.run(workspaceDir);
+    await renameCollidingBackupProfileNamesMigration.run(workspaceDir);
     const first = readConfig();
-    renameCollidingBackupProfileNamesMigration.run(workspaceDir);
+    await renameCollidingBackupProfileNamesMigration.run(workspaceDir);
     expect(readConfig()).toEqual(first);
   });
 
-  test("handles missing config, missing llm block, and invalid JSON", () => {
-    expect(() =>
+  test("handles missing config, missing llm block, and invalid JSON", async () => {
+    await expect(
       renameCollidingBackupProfileNamesMigration.run(workspaceDir),
-    ).not.toThrow();
+    ).resolves.toBeUndefined();
 
     writeConfig({ theme: "dark" });
-    renameCollidingBackupProfileNamesMigration.run(workspaceDir);
+    await renameCollidingBackupProfileNamesMigration.run(workspaceDir);
     expect(readConfig()).toEqual({ theme: "dark" });
 
     writeFileSync(join(workspaceDir, "config.json"), "{not json");
-    expect(() =>
+    await expect(
       renameCollidingBackupProfileNamesMigration.run(workspaceDir),
-    ).not.toThrow();
+    ).resolves.toBeUndefined();
+  });
+
+  test("retries a pin rewrite the database refuses, then completes", async () => {
+    seedProfilePinTables({
+      conversations: ["balanced-backup", "balanced"],
+      cronJobs: ["balanced-backup"],
+    });
+    writeConfig({
+      llm: {
+        profiles: {
+          "balanced-backup": { source: "user", provider: "anthropic" },
+        },
+        activeProfile: "balanced-backup",
+      },
+    });
+
+    // A second connection holding the write lock makes every UPDATE fail with
+    // SQLITE_BUSY until it commits, which is the contention the retry exists
+    // for.
+    const blocker = new Database(dbPath());
+    blocker.run("BEGIN IMMEDIATE");
+    let released = false;
+    const release = setTimeout(() => {
+      blocker.run("COMMIT");
+      blocker.close();
+      released = true;
+    }, 10);
+
+    await renameCollidingBackupProfileNamesMigration.run(workspaceDir);
+    clearTimeout(release);
+
+    // The lock is released from a timer, which can only fire while the
+    // migration is waiting out a backoff: a first attempt that had succeeded
+    // would have finished the run before this point.
+    expect(released).toBe(true);
+    expect(readPins("conversations")).toEqual([
+      "balanced-backup-custom",
+      "balanced",
+    ]);
+    expect(readPins("cron_jobs")).toEqual(["balanced-backup-custom"]);
+    expect(readConfig().llm.activeProfile).toBe("balanced-backup-custom");
+  });
+
+  test("stays unapplied and retries on the next boot when the pins cannot be rewritten", async () => {
+    seedProfilePinTables({
+      conversations: ["balanced-backup"],
+      cronJobs: ["balanced-backup"],
+    });
+    const config = {
+      llm: {
+        profiles: {
+          "balanced-backup": { source: "user", provider: "anthropic" },
+        },
+        activeProfile: "balanced-backup",
+      },
+    };
+    writeConfig(config);
+
+    const blocker = new Database(dbPath());
+    blocker.run("BEGIN IMMEDIATE");
+
+    const firstBoot = await runWorkspaceMigrations(workspaceDir, [
+      renameCollidingBackupProfileNamesMigration,
+    ]);
+
+    // Failed, not completed: the config keeps the old key, so the rename is
+    // still pending and the mapping is still derivable from it.
+    expect(firstBoot).toEqual({ applied: 0, skipped: 0, failed: 1 });
+    expect(
+      loadCheckpoints(workspaceDir).applied[
+        "147-rename-colliding-backup-profile-names"
+      ]?.status,
+    ).toBe("failed");
+    expect(readConfig()).toEqual(config);
+    expect(readPins("conversations")).toEqual(["balanced-backup"]);
+
+    blocker.run("COMMIT");
+    blocker.close();
+
+    const secondBoot = await runWorkspaceMigrations(workspaceDir, [
+      renameCollidingBackupProfileNamesMigration,
+    ]);
+
+    expect(secondBoot).toEqual({ applied: 1, skipped: 0, failed: 0 });
+    expect(readConfig().llm.activeProfile).toBe("balanced-backup-custom");
+    expect(readPins("conversations")).toEqual(["balanced-backup-custom"]);
+    expect(readPins("cron_jobs")).toEqual(["balanced-backup-custom"]);
+  });
+
+  test("touches the database not at all without a collision", async () => {
+    seedProfilePinTables({
+      conversations: ["balanced-backup"],
+      cronJobs: ["scratch"],
+    });
+    writeConfig({
+      llm: {
+        profiles: { scratch: { source: "user", speed: "fast" } },
+        activeProfile: "balanced",
+      },
+    });
+
+    // Holding the write lock for the whole run proves no write is attempted:
+    // one would fail, and a failure now throws.
+    const blocker = new Database(dbPath());
+    blocker.run("BEGIN IMMEDIATE");
+    await renameCollidingBackupProfileNamesMigration.run(workspaceDir);
+    blocker.run("COMMIT");
+    blocker.close();
+
+    expect(readPins("conversations")).toEqual(["balanced-backup"]);
+    expect(readPins("cron_jobs")).toEqual(["scratch"]);
   });
 });

--- a/assistant/src/config/__tests__/default-profile-catalog.test.ts
+++ b/assistant/src/config/__tests__/default-profile-catalog.test.ts
@@ -12,6 +12,7 @@ import {
   resolveDefaultProfileForProvider,
 } from "../default-profile-catalog.js";
 import {
+  BACKUP_PROFILE_KEYS,
   DEFAULT_PROFILE_KEYS,
   DEFAULT_PROFILE_PROVIDERS,
   OS_BETA_PROFILE_KEY,
@@ -78,7 +79,7 @@ describe("getEffectiveProfiles", () => {
   test("defaults absent from the workspace resolve from the catalog; os-beta stays flag-gated", () => {
     const effective = getEffectiveProfiles(undefined);
     expect(Object.keys(effective).sort()).toEqual(
-      [...DEFAULT_PROFILE_KEYS].sort(),
+      [...DEFAULT_PROFILE_KEYS, ...BACKUP_PROFILE_KEYS].sort(),
     );
     expect(getEffectiveProfile({}, "balanced")?.model).toBe(
       CODE_DEFAULT_PROFILE_ENTRIES.balanced.model as string,

--- a/assistant/src/config/__tests__/default-profile-catalog.test.ts
+++ b/assistant/src/config/__tests__/default-profile-catalog.test.ts
@@ -268,6 +268,40 @@ describe("resolver integration", () => {
       }),
     ).not.toThrow();
   });
+
+  test("a user profile cannot shadow a managed backup profile", () => {
+    // Every backup is code-owned for the same reason `latency-optimized` is:
+    // a backup earns its place by pinning a different upstream than the
+    // primary it backs, and a user shadow can repoint it at the primary's
+    // own provider, so the fallback re-sends into the outage it exists to
+    // route around. `latency-optimized-backup` additionally serves the
+    // live-voice path whenever that primary falls back.
+    for (const key of BACKUP_PROFILE_KEYS) {
+      const llm = LLMSchema.parse({
+        profiles: {
+          [key]: {
+            source: "user",
+            provider: "anthropic",
+            model: "claude-opus-4-6",
+            provider_connection: "anthropic-personal",
+            maxTokens: 32000,
+            effort: "high",
+          },
+        },
+      });
+      const body = CODE_DEFAULT_PROFILE_ENTRIES[key]!;
+      const effective = getEffectiveProfiles(llm.profiles)[key];
+      expect(effective?.model).toBe(body.model);
+      expect(effective?.model).not.toBe("claude-opus-4-6");
+      expect(String(effective?.provider)).toBe("vellum");
+      expect(effective?.provider_connection).toBeUndefined();
+      // Resolution through the managed column agrees with the listing.
+      const resolved = resolveDefaultProfileForProvider(llm.profiles, key, {
+        provider: "vellum",
+      });
+      expect(resolved?.model).toBe(body.model);
+    }
+  });
 });
 
 describe("schema validation", () => {
@@ -300,6 +334,27 @@ describe("schema validation", () => {
     expect(() =>
       LLMSchema.parse({ callSites: { mainAgent: { profile: "no-such" } } }),
     ).toThrow();
+  });
+
+  test("managed backup names are valid references without being materialized", () => {
+    // Backups are listed in the effective catalog and are selectable, but
+    // selecting one persists only the reference: nothing lands in
+    // `llm.profiles`. Unless the schema treats the keys as always-available,
+    // the next load strips the selection and silently reverts it.
+    for (const key of BACKUP_PROFILE_KEYS) {
+      expect(() => LLMSchema.parse({ activeProfile: key })).not.toThrow();
+      expect(() => LLMSchema.parse({ advisorProfile: key })).not.toThrow();
+      expect(() =>
+        LLMSchema.parse({ callSites: { mainAgent: { profile: key } } }),
+      ).not.toThrow();
+    }
+    // The keys stay out of `DEFAULT_PROFILE_KEYS`: that array drives picker
+    // order and the intent x provider matrix.
+    expect(
+      BACKUP_PROFILE_KEYS.some((key) =>
+        (DEFAULT_PROFILE_KEYS as readonly string[]).includes(key),
+      ),
+    ).toBe(false);
   });
 
   test("defaultProvider accepts any default-capable API-key provider and drops the rest", () => {

--- a/assistant/src/config/default-profile-catalog.ts
+++ b/assistant/src/config/default-profile-catalog.ts
@@ -506,8 +506,23 @@ export const OS_BETA_PROFILE_TEMPLATE: DefaultProfileTemplate = {
  * audible dead air rather than a slow reply. A same-named
  * workspace entry stays on disk and stays listed; it just never governs what
  * this name resolves to.
+ *
+ * All four backups carry the same protection rather than only
+ * `latency-optimized-backup`. The narrow argument covers that one alone: it
+ * serves the live-voice path whenever the primary falls back, so a shadow
+ * reintroduces exactly the dead-air risk the primary's protection exists to
+ * prevent. The broader argument covers all four, and is why the whole set is
+ * here: a backup only earns its place by pinning a model at a different
+ * upstream than the primary it backs (see `BACKUP_PROFILE_IMPLS`), and a
+ * user-owned shadow can silently repoint it at the primary's own provider,
+ * so the fallback re-sends into the outage it exists to route around. A
+ * backup also has no per-provider matrix column, so there is nothing a
+ * workspace overlay could legitimately own on it.
  */
-export const CODE_OWNED_PROFILE_NAMES = new Set<string>(["latency-optimized"]);
+export const CODE_OWNED_PROFILE_NAMES = new Set<string>([
+  "latency-optimized",
+  ...BACKUP_PROFILE_KEYS,
+]);
 
 // All managed profiles, including the flag-gated os-beta, are invariant:
 // their MANAGED-SOURCE entries are read-only to user-facing writes except

--- a/assistant/src/config/default-profile-catalog.ts
+++ b/assistant/src/config/default-profile-catalog.ts
@@ -9,10 +9,14 @@ import type { ModelIntent } from "../providers/types.js";
 import { getManagedUpstream } from "../providers/vellum-model-routing.js";
 import { getBalancedModelExperimentArm } from "./balanced-model-experiment.js";
 import {
+  BACKUP_PROFILE_KEYS,
+  type BackupProfileKey,
   DEFAULT_PROFILE_KEYS,
   DEFAULT_PROFILE_PROVIDERS,
   type DefaultProfileKey,
   type DefaultProfileProvider,
+  FALLBACK_PROFILE_BY_KEY,
+  isBackupProfileKey,
   isDefaultProfileProvider,
   OS_BETA_PROFILE_KEY,
 } from "./default-profile-names.js";
@@ -70,6 +74,13 @@ type ProfileImpls = Record<DefaultProfileKey, DefaultProfileTemplate>;
  * concrete dispatch providers, and the model is what selects the upstream.
  * Overwritten in workspace config on every daemon boot so Vellum can push
  * model/config updates to customers in new releases.
+ *
+ * Each implementation points at its managed backup profile via
+ * `fallbackProfile` (`BACKUP_PROFILE_IMPLS` below): a backup pins a model at
+ * a different upstream provider, so an outage-type failure at the primary's
+ * provider can be served by re-sending on the backup. Vellum column only:
+ * the BYOK and chatgpt columns carry no pointers, since those installs may
+ * hold no credential for the backup's provider.
  */
 const VELLUM_PROFILE_IMPLS: ProfileImpls = {
   balanced: {
@@ -78,6 +89,7 @@ const VELLUM_PROFILE_IMPLS: ProfileImpls = {
     source: "managed",
     label: "Balanced",
     description: "Good balance of quality, cost, and speed",
+    fallbackProfile: FALLBACK_PROFILE_BY_KEY.balanced,
     maxTokens: 32000,
     effort: "high",
     thinking: { enabled: true, streamThinking: true },
@@ -91,6 +103,7 @@ const VELLUM_PROFILE_IMPLS: ProfileImpls = {
     source: "managed",
     label: "Quality",
     description: "High-quality results with the most capable model",
+    fallbackProfile: FALLBACK_PROFILE_BY_KEY["quality-optimized"],
     maxTokens: 32000,
     effort: "high",
     thinking: { enabled: true, streamThinking: true },
@@ -107,6 +120,7 @@ const VELLUM_PROFILE_IMPLS: ProfileImpls = {
     // surface the live model beside the description, so a model name in
     // this copy would go stale the moment the pin moves.
     description: "Cheapest responses, for high-volume work",
+    fallbackProfile: FALLBACK_PROFILE_BY_KEY["cost-optimized"],
     maxTokens: 8192,
     // Explicit reasoning opt-out. OpenAI-compat APIs default reasoning to
     // "medium" when the field is omitted, and effort-driven providers encode
@@ -136,12 +150,87 @@ const VELLUM_PROFILE_IMPLS: ProfileImpls = {
     source: "managed",
     label: "Speed",
     description: "Fastest responses, with reasoning turned off",
+    fallbackProfile: FALLBACK_PROFILE_BY_KEY["latency-optimized"],
     maxTokens: 8192,
     // Explicit reasoning opt-out, matching `cost-optimized` above: this
     // profile advertises reasoning as off, and OpenAI-compat APIs default
     // reasoning to "medium" when the field is omitted, so the opt-out has to
     // be stated rather than implied.
     effort: "none",
+    thinking: { enabled: false, streamThinking: false },
+    contextWindow: {
+      maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS,
+    },
+  },
+};
+
+/**
+ * The managed backup profiles, one per default profile: the route a primary's
+ * `fallbackProfile` pointer names. Vellum column only: backups never
+ * materialize for BYOK or chatgpt installs. Like the primaries, models are
+ * pinned (never intents) and stamped `provider: "vellum"`, so dispatch
+ * derives the upstream from the model. Every backup pins its model at a
+ * DIFFERENT upstream provider than its primary (that cross-provider split is
+ * the entire point), and the module-load validation below enforces
+ * routability.
+ *
+ * Descriptions name the tier they back, never the concrete model: clients
+ * surface the live model beside the description, so a model name in this
+ * copy would go stale the moment a pin moves.
+ */
+const BACKUP_PROFILE_IMPLS: Record<BackupProfileKey, DefaultProfileTemplate> = {
+  "balanced-backup": {
+    model: "claude-sonnet-5",
+    provider: "vellum",
+    source: "managed",
+    label: "Balanced Backup",
+    description: "Automatic backup for the Balanced profile",
+    maxTokens: 32000,
+    effort: "high",
+    thinking: { enabled: true, streamThinking: true },
+    contextWindow: {
+      maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS,
+    },
+  },
+  "quality-optimized-backup": {
+    model: "claude-opus-5",
+    provider: "vellum",
+    source: "managed",
+    label: "Quality Backup",
+    description: "Automatic backup for the Quality profile",
+    maxTokens: 32000,
+    effort: "high",
+    thinking: { enabled: true, streamThinking: true },
+    contextWindow: {
+      maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS,
+    },
+  },
+  "cost-optimized-backup": {
+    model: "gemini-3.1-flash-lite",
+    provider: "vellum",
+    source: "managed",
+    label: "Cost Backup",
+    description: "Automatic backup for the Cost profile",
+    maxTokens: 8192,
+    // Explicit reasoning opt-out, matching the primary Cost profile: OpenAI-
+    // compat APIs default reasoning to "medium" when the field is omitted,
+    // and effort-driven providers encode disabled thinking through this same
+    // knob (see DISABLED_THINKING_USES_EFFORT_PROVIDERS in
+    // providers/retry.ts).
+    effort: "none",
+    thinking: { enabled: false, streamThinking: false },
+    contextWindow: {
+      maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS,
+    },
+  },
+  "latency-optimized-backup": {
+    model: "gemini-3.6-flash",
+    provider: "vellum",
+    source: "managed",
+    label: "Speed Backup",
+    description: "Automatic backup for the Speed profile",
+    maxTokens: 8192,
+    effort: "low",
     thinking: { enabled: false, streamThinking: false },
     contextWindow: {
       maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS,
@@ -335,14 +424,18 @@ export const PROFILE_IMPLS: Record<
 >;
 
 /**
- * Managed profiles, i.e. the `vellum` column keyed by profile name. Keyed by
- * the user-facing defaults only: an internal profile is code-resolved and
- * never listed or ordered.
+ * Managed profiles, i.e. the `vellum` column keyed by profile name, plus the
+ * managed backup profiles. Backups come after the primaries, which is what
+ * places them after the primaries in `profileOrder` presentation: the seeder
+ * inserts missing managed keys in this record's order. Keyed by the
+ * user-facing defaults only: an internal profile is code-resolved and never
+ * listed or ordered.
  */
 export const MANAGED_PROFILE_TEMPLATES: Record<string, DefaultProfileTemplate> =
-  Object.fromEntries(
-    DEFAULT_PROFILE_KEYS.map((key) => [key, PROFILE_IMPLS[key].vellum]),
-  );
+  Object.fromEntries([
+    ...DEFAULT_PROFILE_KEYS.map((key) => [key, PROFILE_IMPLS[key].vellum]),
+    ...BACKUP_PROFILE_KEYS.map((key) => [key, BACKUP_PROFILE_IMPLS[key]]),
+  ]);
 
 /**
  * The values BYOK hatch seeding wrote onto each `custom-*` copy, for the keys
@@ -423,6 +516,7 @@ export const CODE_OWNED_PROFILE_NAMES = new Set<string>(["latency-optimized"]);
 // the on-disk entry's `source` being `managed`.
 export const INVARIANT_PROFILE_NAMES = new Set<string>([
   ...DEFAULT_PROFILE_KEYS,
+  ...BACKUP_PROFILE_KEYS,
   OS_BETA_PROFILE_KEY,
 ]);
 
@@ -435,6 +529,7 @@ export const INVARIANT_PROFILE_NAMES = new Set<string>([
 // same-named user profile.
 export const MANAGED_PROFILE_NAMES = new Set<string>([
   ...DEFAULT_PROFILE_KEYS,
+  ...BACKUP_PROFILE_KEYS,
   OS_BETA_PROFILE_KEY,
 ]);
 
@@ -502,6 +597,22 @@ for (const key of DEFAULT_PROFILE_KEYS) {
   }
 }
 
+// Backup profiles get the same eager verification as the vellum column: a
+// pinned model that no managed upstream serves would make the fallback route
+// undispatchable exactly when it is needed. The cross-provider rule (backup
+// upstream differs from the primary's) is asserted in
+// __tests__/default-profile-catalog-fallback.test.ts, arm pins included.
+for (const key of BACKUP_PROFILE_KEYS) {
+  const impl = BACKUP_PROFILE_IMPLS[key];
+  if (impl.model == null || getManagedUpstream(impl.model) === null) {
+    throw new Error(
+      `BACKUP_PROFILE_IMPLS[${key}] references model "${impl.model ?? ""}" ` +
+        `which is not served by any managed upstream. ` +
+        `Update model-catalog.ts or default-profile-catalog.ts.`,
+    );
+  }
+}
+
 // The experiment arms substitute into the managed column at request time, so
 // they need the same routability guarantee as the pins validated above: a
 // LaunchDarkly arm must never select a model no managed upstream serves.
@@ -540,6 +651,10 @@ function buildDefaultProfileEntries(): Record<string, ProfileEntry> {
   const entries: Record<string, ProfileEntry> = {};
   for (const key of DEFAULT_PROFILE_KEYS) {
     const impl = PROFILE_IMPLS[key].vellum;
+    entries[key] = materializeProfile(impl, impl.provider);
+  }
+  for (const key of BACKUP_PROFILE_KEYS) {
+    const impl = BACKUP_PROFILE_IMPLS[key];
     entries[key] = materializeProfile(impl, impl.provider);
   }
   entries[OS_BETA_PROFILE_KEY] = materializeProfile(
@@ -706,6 +821,19 @@ function defaultProfileBodyForProvider(
   defaultProvider: DefaultProviderConfig | null,
 ): ProfileEntry | undefined {
   if (!isDefaultProfileKey(name)) {
+    // Backup profiles are companions of the managed (`vellum`) column only:
+    // under a BYOK or chatgpt default provider the primaries carry no
+    // `fallbackProfile` pointers, and the backups must not materialize
+    // either, since the install may hold no credential for the backup's
+    // provider. A null defaultProvider predates `llm.defaultProvider` and
+    // resolves to the managed column, so it keeps its backups.
+    if (
+      isBackupProfileKey(name) &&
+      defaultProvider != null &&
+      defaultProvider.provider !== "vellum"
+    ) {
+      return undefined;
+    }
     return CODE_DEFAULT_PROFILE_ENTRIES[name];
   }
   if (defaultProvider == null) {

--- a/assistant/src/config/default-profile-catalog.ts
+++ b/assistant/src/config/default-profile-catalog.ts
@@ -22,6 +22,7 @@ import {
 } from "./default-profile-names.js";
 import { resolveDefaultConnectionName } from "./default-provider-resolution.js";
 import {
+  backupProfilesResolveUnderDefaultProvider,
   DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS,
   DEFAULT_PROVIDER_CHOICES,
   type DefaultProviderConfig,
@@ -844,8 +845,7 @@ function defaultProfileBodyForProvider(
     // resolves to the managed column, so it keeps its backups.
     if (
       isBackupProfileKey(name) &&
-      defaultProvider != null &&
-      defaultProvider.provider !== "vellum"
+      !backupProfilesResolveUnderDefaultProvider(defaultProvider)
     ) {
       return undefined;
     }
@@ -895,6 +895,15 @@ function clampMaxTokensToModelCap(body: ProfileEntry): ProfileEntry {
  * available code default, merged per `getEffectiveProfile`. This is the
  * record all runtime readers of `llm.profiles` should consume; the raw
  * workspace record is a write-path concern.
+ *
+ * Deliberately provider-agnostic: it lists the managed backups whatever
+ * `llm.defaultProvider` says, because it resolves names against the passed
+ * catalog alone and never reads config. Any caller that JUDGES AVAILABILITY
+ * (is this name selectable? does this reference still resolve?) must use
+ * `getEffectiveProfilesForProvider` instead, which hides the backups on the
+ * BYOK and ChatGPT columns the same way `resolveDefaultProfileForProvider`
+ * does. Duplicating that conditioning here would fork the rule across two
+ * functions, and the sibling already owns it.
  */
 export function getEffectiveProfiles(
   workspaceProfiles: Record<string, ProfileEntry> | undefined,

--- a/assistant/src/config/default-profile-catalog.ts
+++ b/assistant/src/config/default-profile-catalog.ts
@@ -748,6 +748,16 @@ function resolveAgainstBody(
   body: ProfileEntry | undefined,
 ): ProfileEntry | undefined {
   if (body == null) {
+    // A managed stub is the workspace's slot for a code-owned profile, never
+    // a profile of its own, so with no body behind it there is nothing to
+    // resolve. Only a backup name reaches this branch with a stub (the
+    // default keys always have a body), and it reaches it on the columns
+    // where the backups do not exist. Resolving to the stub would list a
+    // profile with no provider or model and let a reference to it look
+    // valid, which is precisely what `LLMSchema` rejects on those columns.
+    if (isBackupProfileKey(name) && workspace?.source === "managed") {
+      return undefined;
+    }
     return workspace;
   }
   if (CODE_OWNED_PROFILE_NAMES.has(name)) {
@@ -946,7 +956,13 @@ export function getEffectiveProfilesForProvider(
     );
     if (entry != null) {
       effective[name] = entry;
+      continue;
     }
+    // Nothing resolved, so the name must not survive from the workspace
+    // spread above: a backup carrying only a managed stub on a column that
+    // has no backups would otherwise be listed as an available profile with
+    // no provider or model behind it.
+    delete effective[name];
   }
   return effective;
 }

--- a/assistant/src/config/default-profile-names.ts
+++ b/assistant/src/config/default-profile-names.ts
@@ -27,6 +27,43 @@ export const DEFAULT_PROFILE_KEYS = [
 export type DefaultProfileKey = (typeof DEFAULT_PROFILE_KEYS)[number];
 
 /**
+ * Stable keys of the managed backup profiles, one per default profile.
+ * Deliberately NOT part of `DEFAULT_PROFILE_KEYS`: that array drives picker
+ * order and the intent x provider matrix, while backups are companions of
+ * the managed (`vellum`) column only. Each backup pins a model at a
+ * different upstream provider than its primary, so an outage at the
+ * primary's provider can be served by re-sending on the backup (see the
+ * `fallbackProfile` field on `ProfileEntry`).
+ */
+export const BACKUP_PROFILE_KEYS = [
+  "balanced-backup",
+  "quality-optimized-backup",
+  "cost-optimized-backup",
+  "latency-optimized-backup",
+] as const;
+export type BackupProfileKey = (typeof BACKUP_PROFILE_KEYS)[number];
+
+/**
+ * The backup profile each default profile falls back to. Applied to the
+ * managed (`vellum`) column implementations only: BYOK installs may hold no
+ * credential for the backup's provider, so their columns carry no
+ * `fallbackProfile` pointers.
+ */
+export const FALLBACK_PROFILE_BY_KEY: Record<
+  DefaultProfileKey,
+  BackupProfileKey
+> = {
+  balanced: "balanced-backup",
+  "quality-optimized": "quality-optimized-backup",
+  "cost-optimized": "cost-optimized-backup",
+  "latency-optimized": "latency-optimized-backup",
+};
+
+export function isBackupProfileKey(value: string): value is BackupProfileKey {
+  return (BACKUP_PROFILE_KEYS as readonly string[]).includes(value);
+}
+
+/**
  * Flag-gated default profile: only available while the `os-beta` feature
  * flag has reconciled it into the workspace (see `sync-gated-profiles.ts`).
  * Deliberately NOT part of `DEFAULT_PROFILE_KEYS`: it is never

--- a/assistant/src/config/inference-profile-validation.ts
+++ b/assistant/src/config/inference-profile-validation.ts
@@ -1,16 +1,25 @@
-import { getEffectiveProfiles } from "./default-profile-catalog.js";
+import { getEffectiveProfilesForProvider } from "./default-profile-catalog.js";
 import { getConfigReadOnly } from "./loader.js";
 
 /**
  * Validate an inference-profile key against the effective profile catalog
  * (code-defined defaults + workspace `llm.profiles`). Returns a user-facing
  * error message when the key is empty or unknown, or `null` when valid.
+ *
+ * Resolved through the `llm.defaultProvider`-aware view so availability
+ * matches what actually dispatches: the managed backup profiles exist on the
+ * managed column only, so on a BYOK or ChatGPT install they are not
+ * selectable and must not be reported as available.
  */
 export function validateInferenceProfileKey(profile: string): string | null {
   if (!profile.trim()) {
     return "inferenceProfile must be a non-empty string";
   }
-  const profiles = getEffectiveProfiles(getConfigReadOnly().llm?.profiles);
+  const llm = getConfigReadOnly().llm;
+  const profiles = getEffectiveProfilesForProvider(
+    llm?.profiles,
+    llm?.defaultProvider ?? null,
+  );
   const entry = profiles[profile];
   if (entry === undefined) {
     const available = Object.keys(profiles).sort();

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -677,6 +677,52 @@ export type DefaultProviderConfig = z.infer<typeof DefaultProviderSchema>;
  */
 const DefaultProviderField = DefaultProviderSchema.optional().catch(undefined);
 
+/**
+ * Whether the managed backup profiles (`BACKUP_PROFILE_KEYS`) resolve under a
+ * given `llm.defaultProvider`.
+ *
+ * Backups are companions of the managed (`vellum`) column only: on a BYOK or
+ * ChatGPT default provider `defaultProfileBodyForProvider` returns `undefined`
+ * for them, because the install may hold no credential for the backup's
+ * upstream. So a reference to one is a target that can never resolve there,
+ * and the schema must reject it rather than preserve a selection the picker
+ * cannot show.
+ *
+ * Accepts an unknown value so the raw write paths (which validate on-disk
+ * shapes without a full parse) can share the rule. A missing or malformed
+ * value resolves to the managed column: `DefaultProviderField` catches an
+ * invalid value to `undefined`, and an install predating
+ * `llm.defaultProvider` is managed by definition.
+ */
+export function backupProfilesResolveUnderDefaultProvider(
+  defaultProvider: unknown,
+): boolean {
+  const provider =
+    defaultProvider != null &&
+    typeof defaultProvider === "object" &&
+    !Array.isArray(defaultProvider)
+      ? (defaultProvider as Record<string, unknown>).provider
+      : undefined;
+  return typeof provider !== "string" || provider === "vellum";
+}
+
+/**
+ * Why a referenced profile name does not resolve, for the reference error
+ * messages. A backup key under a non-managed default provider gets its own
+ * reason: the name is real and code-defined, it just has no body outside the
+ * managed column, and "not defined in llm.profiles" would send the reader
+ * looking for a missing entry that was never supposed to exist.
+ */
+function unresolvableProfileReason(
+  name: string,
+  backupsResolve: boolean,
+): string {
+  return !backupsResolve &&
+    (BACKUP_PROFILE_KEYS as readonly string[]).includes(name)
+    ? "is a managed backup profile, which resolves only while llm.defaultProvider is the managed provider"
+    : "is not defined in llm.profiles";
+}
+
 // ---------------------------------------------------------------------------
 // Top-level LLM schema
 // ---------------------------------------------------------------------------
@@ -694,9 +740,14 @@ const DefaultProviderField = DefaultProviderSchema.optional().catch(undefined);
  * paths (`commitConfigWrite`), which persist raw config without a
  * full-schema parse. Accepts a raw or parsed `llm.profiles` record; entries
  * are read defensively so the raw on-disk shape is safe to pass.
+ *
+ * `defaultProvider` is the sibling `llm.defaultProvider` value (raw or
+ * parsed): it decides whether the managed backups are valid targets, since
+ * they resolve on the managed column alone.
  */
 export function collectFallbackProfileIssues(
   profiles: Record<string, unknown> | undefined,
+  defaultProvider?: unknown,
 ): { profileName: string; message: string }[] {
   const issues: { profileName: string; message: string }[] = [];
   const entries = Object.entries(profiles ?? {});
@@ -708,11 +759,14 @@ export function collectFallbackProfileIssues(
   // (`default-profile-catalog.ts`) and resolve whether or not they are
   // materialized in `llm.profiles`, so their names are always valid
   // fallback targets (same rule as call-site `profile` references). The
-  // managed backups resolve the same way, so they are valid targets too.
+  // managed backups resolve the same way, but on the managed column only,
+  // so they are valid targets only under a managed `llm.defaultProvider`.
+  const backupsResolve =
+    backupProfilesResolveUnderDefaultProvider(defaultProvider);
   const profileNames = new Set([
     ...entries.map(([name]) => name),
     ...DEFAULT_PROFILE_KEYS,
-    ...BACKUP_PROFILE_KEYS,
+    ...(backupsResolve ? BACKUP_PROFILE_KEYS : []),
   ]);
   const mixProfileNames = new Set(
     entries
@@ -755,7 +809,7 @@ export function collectFallbackProfileIssues(
     if (!profileNames.has(fallback)) {
       issues.push({
         profileName: name,
-        message: `Profile "${name}" declares fallbackProfile "${fallback}" which is not defined in llm.profiles.`,
+        message: `Profile "${name}" declares fallbackProfile "${fallback}" which ${unresolvableProfileReason(fallback, backupsResolve)}.`,
       });
       continue;
     }
@@ -844,13 +898,20 @@ export const LLMSchema = z
     // code-defined on the same terms and are listed in the effective
     // catalog, so a selection naming one (`activeProfile`, `advisorProfile`,
     // a call-site pin) must survive the next load rather than being stripped
-    // back to a default. The flag-gated `os-beta` is excluded: it resolves
-    // only while a workspace entry exists, so a reference to it is valid
-    // only when that entry is present in `config.profiles`.
+    // back to a default. Backups are scoped to the managed column though, so
+    // they join the set only under a managed `llm.defaultProvider`: on a BYOK
+    // or ChatGPT default provider they have no body to resolve to, and
+    // keeping the reference would strand a selection the picker cannot show.
+    // The flag-gated `os-beta` is excluded: it resolves only while a
+    // workspace entry exists, so a reference to it is valid only when that
+    // entry is present in `config.profiles`.
+    const backupsResolve = backupProfilesResolveUnderDefaultProvider(
+      config.defaultProvider,
+    );
     const profileNames = new Set([
       ...Object.keys(config.profiles ?? {}),
       ...DEFAULT_PROFILE_KEYS,
-      ...BACKUP_PROFILE_KEYS,
+      ...(backupsResolve ? BACKUP_PROFILE_KEYS : []),
     ]);
     for (const [siteId, siteConfig] of Object.entries(config.callSites ?? {})) {
       if (siteConfig?.profile == null) {
@@ -860,7 +921,7 @@ export const LLMSchema = z
         ctx.addIssue({
           code: "custom",
           path: ["callSites", siteId, "profile"],
-          message: `Profile "${siteConfig.profile}" referenced by call site "${siteId}" is not defined in llm.profiles`,
+          message: `Profile "${siteConfig.profile}" referenced by call site "${siteId}" ${unresolvableProfileReason(siteConfig.profile, backupsResolve)}`,
         });
       }
     }
@@ -871,7 +932,7 @@ export const LLMSchema = z
       ctx.addIssue({
         code: "custom",
         path: ["activeProfile"],
-        message: `Profile "${config.activeProfile}" referenced by llm.activeProfile is not defined in llm.profiles`,
+        message: `Profile "${config.activeProfile}" referenced by llm.activeProfile ${unresolvableProfileReason(config.activeProfile, backupsResolve)}`,
       });
     }
     if (
@@ -881,7 +942,7 @@ export const LLMSchema = z
       ctx.addIssue({
         code: "custom",
         path: ["advisorProfile"],
-        message: `Profile "${config.advisorProfile}" referenced by llm.advisorProfile is not defined in llm.profiles`,
+        message: `Profile "${config.advisorProfile}" referenced by llm.advisorProfile ${unresolvableProfileReason(config.advisorProfile, backupsResolve)}`,
       });
     }
 
@@ -931,7 +992,7 @@ export const LLMSchema = z
           ctx.addIssue({
             code: "custom",
             path: ["profiles", name, "mix", index, "profile"],
-            message: `Mix profile "${name}" references profile "${arm.profile}" which is not defined in llm.profiles.`,
+            message: `Mix profile "${name}" references profile "${arm.profile}" which ${unresolvableProfileReason(arm.profile, backupsResolve)}.`,
           });
           continue;
         }
@@ -951,7 +1012,10 @@ export const LLMSchema = z
     // (shared with the config write paths). A mix profile setting
     // `fallbackProfile` is also rejected by the mix validation above
     // (MIX_DISALLOWED_CONFIG_KEYS).
-    for (const issue of collectFallbackProfileIssues(config.profiles)) {
+    for (const issue of collectFallbackProfileIssues(
+      config.profiles,
+      config.defaultProvider,
+    )) {
       ctx.addIssue({
         code: "custom",
         path: ["profiles", issue.profileName, "fallbackProfile"],

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -11,6 +11,7 @@ import {
   parseVellumModel,
 } from "../../providers/vellum-model-routing.js";
 import {
+  BACKUP_PROFILE_KEYS,
   DEFAULT_PROFILE_KEYS,
   DEFAULT_PROFILE_PROVIDERS,
 } from "../default-profile-names.js";
@@ -706,10 +707,12 @@ export function collectFallbackProfileIssues(
   // The always-available default profiles are code-defined
   // (`default-profile-catalog.ts`) and resolve whether or not they are
   // materialized in `llm.profiles`, so their names are always valid
-  // fallback targets (same rule as call-site `profile` references).
+  // fallback targets (same rule as call-site `profile` references). The
+  // managed backups resolve the same way, so they are valid targets too.
   const profileNames = new Set([
     ...entries.map(([name]) => name),
     ...DEFAULT_PROFILE_KEYS,
+    ...BACKUP_PROFILE_KEYS,
   ]);
   const mixProfileNames = new Set(
     entries
@@ -837,12 +840,17 @@ export const LLMSchema = z
     // The always-available default profiles are code-defined
     // (`default-profile-catalog.ts`) and resolve whether or not they are
     // materialized in `llm.profiles`, so their names are always valid
-    // reference targets. The flag-gated `os-beta` is excluded: it resolves
+    // reference targets. The managed backups (`BACKUP_PROFILE_KEYS`) are
+    // code-defined on the same terms and are listed in the effective
+    // catalog, so a selection naming one (`activeProfile`, `advisorProfile`,
+    // a call-site pin) must survive the next load rather than being stripped
+    // back to a default. The flag-gated `os-beta` is excluded: it resolves
     // only while a workspace entry exists, so a reference to it is valid
     // only when that entry is present in `config.profiles`.
     const profileNames = new Set([
       ...Object.keys(config.profiles ?? {}),
       ...DEFAULT_PROFILE_KEYS,
+      ...BACKUP_PROFILE_KEYS,
     ]);
     for (const [siteId, siteConfig] of Object.entries(config.callSites ?? {})) {
       if (siteConfig?.profile == null) {

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -14,6 +14,7 @@ import {
   BACKUP_PROFILE_KEYS,
   DEFAULT_PROFILE_KEYS,
   DEFAULT_PROFILE_PROVIDERS,
+  isBackupProfileKey,
 } from "../default-profile-names.js";
 
 /**
@@ -723,6 +724,46 @@ function unresolvableProfileReason(
     : "is not defined in llm.profiles";
 }
 
+/**
+ * The `llm.profiles` keys that are reference targets in their own right,
+ * given whether the managed backups resolve under the current
+ * `llm.defaultProvider`.
+ *
+ * Every on-disk key qualifies but one: a reserved backup name whose entry is
+ * a thin `source: "managed"` stub. The stub is not a profile, it is the
+ * workspace's slot for a code-owned one, and it can reach disk on a managed
+ * install through nothing more than a `config get` -> `config set` round-trip
+ * of the effective profile list (`normalizeManagedProfileWrites` reduces the
+ * echoed body to exactly that stub). Counting it as an ordinary raw key would
+ * let it launder a backup reference past the provider gate: after a switch to
+ * a BYOK or ChatGPT default provider the reference would keep validating
+ * while the code-owned body it stands for has resolved to nothing, leaving a
+ * selection that names a providerless stub.
+ *
+ * A genuinely user-owned entry under a backup name is the opposite case: it
+ * carries its own body, and with no code-owned body to lose on a non-managed
+ * column `resolveAgainstBody` resolves the workspace entry itself. So it
+ * stays a valid target on every column. The `source` test is the same one
+ * the resolver uses, which is what keeps the two in step.
+ */
+function referenceableProfileKeys(
+  profiles: Record<string, unknown> | undefined,
+  backupsResolve: boolean,
+): string[] {
+  return Object.entries(profiles ?? {})
+    .filter(([name, value]) => {
+      if (backupsResolve || !isBackupProfileKey(name)) {
+        return true;
+      }
+      const entry =
+        value != null && typeof value === "object" && !Array.isArray(value)
+          ? (value as Record<string, unknown>)
+          : null;
+      return entry != null && entry.source !== "managed";
+    })
+    .map(([name]) => name);
+}
+
 // ---------------------------------------------------------------------------
 // Top-level LLM schema
 // ---------------------------------------------------------------------------
@@ -761,10 +802,12 @@ export function collectFallbackProfileIssues(
   // fallback targets (same rule as call-site `profile` references). The
   // managed backups resolve the same way, but on the managed column only,
   // so they are valid targets only under a managed `llm.defaultProvider`.
+  // A persisted managed stub for a backup name does not change that, see
+  // `referenceableProfileKeys`.
   const backupsResolve =
     backupProfilesResolveUnderDefaultProvider(defaultProvider);
   const profileNames = new Set([
-    ...entries.map(([name]) => name),
+    ...referenceableProfileKeys(profiles, backupsResolve),
     ...DEFAULT_PROFILE_KEYS,
     ...(backupsResolve ? BACKUP_PROFILE_KEYS : []),
   ]);
@@ -904,12 +947,17 @@ export const LLMSchema = z
     // keeping the reference would strand a selection the picker cannot show.
     // The flag-gated `os-beta` is excluded: it resolves only while a
     // workspace entry exists, so a reference to it is valid only when that
-    // entry is present in `config.profiles`.
+    // entry is present in `config.profiles`. A backup name materialized as a
+    // thin managed stub does not re-enter the set on a non-managed column
+    // either, see `referenceableProfileKeys`.
     const backupsResolve = backupProfilesResolveUnderDefaultProvider(
       config.defaultProvider,
     );
     const profileNames = new Set([
-      ...Object.keys(config.profiles ?? {}),
+      ...referenceableProfileKeys(
+        config.profiles as Record<string, unknown> | undefined,
+        backupsResolve,
+      ),
       ...DEFAULT_PROFILE_KEYS,
       ...(backupsResolve ? BACKUP_PROFILE_KEYS : []),
     ]);

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -9,13 +9,17 @@ import { PROVIDER_CATALOG } from "../providers/model-catalog.js";
 import { credentialKey } from "../security/credential-key.js";
 import { getLogger } from "../util/logger.js";
 import {
-  getEffectiveProfiles,
+  getEffectiveProfilesForProvider,
   MANAGED_PROFILE_NAMES,
   MANAGED_PROFILE_TEMPLATES,
 } from "./default-profile-catalog.js";
 import { loadRawConfig, saveRawConfig } from "./loader.js";
 import { isDispatchableProfile } from "./profile-dispatchability.js";
-import { isDefaultProviderChoice, type ProfileEntry } from "./schemas/llm.js";
+import {
+  type DefaultProviderConfig,
+  isDefaultProviderChoice,
+  type ProfileEntry,
+} from "./schemas/llm.js";
 
 const log = getLogger("seed-inference-profiles");
 
@@ -141,8 +145,13 @@ export function seedInferenceProfiles(
   // Profile lookups below go through the effective view: a default profile
   // resolves from the code catalog whether or not the workspace carries a
   // stub for it, and a stub contributes only its status/label overlays.
-  const effectiveProfiles = getEffectiveProfiles(
+  // Resolved against `llm.defaultProvider` so the managed backups count as
+  // available only on the managed column, matching what the schema accepts
+  // as a reference: an `activeProfile` naming a backup on a BYOK install is
+  // then repaired here rather than preserved as a dangling selection.
+  const effectiveProfiles = getEffectiveProfilesForProvider(
     profiles as Record<string, ProfileEntry>,
+    seedResolutionDefaultProvider(llm),
   ) as Record<string, Record<string, unknown>>;
 
   // Active profile resolution.
@@ -228,6 +237,26 @@ export function seedInferenceProfiles(
   }
 
   saveRawConfig(config);
+}
+
+/**
+ * The `llm.defaultProvider` to resolve the effective catalog against, read
+ * from RAW config. Only a value the matrix can implement is used: a
+ * hand-edited or legacy provider outside `DEFAULT_PROVIDER_CHOICES` has no
+ * column and no verified intent resolution, so materializing against it
+ * could throw and fail the whole boot seed. Such a value falls back to
+ * `null`, which resolves the managed column.
+ */
+function seedResolutionDefaultProvider(
+  llm: Record<string, unknown>,
+): DefaultProviderConfig | null {
+  const raw = readObject(llm.defaultProvider);
+  const provider = readString(raw?.provider);
+  if (provider === undefined || !isDefaultProviderChoice(provider)) {
+    return null;
+  }
+  const connectionName = readString(raw?.connectionName);
+  return { provider, ...(connectionName ? { connectionName } : {}) };
 }
 
 export function readObject(value: unknown): Record<string, unknown> | null {

--- a/assistant/src/plugin-api/model-profiles.test.ts
+++ b/assistant/src/plugin-api/model-profiles.test.ts
@@ -62,12 +62,16 @@ describe("getModelProfiles", () => {
     const result = listProfiles();
     // The code-catalog defaults are always present; the two workspace
     // entries shadow their catalog counterparts, and the remaining catalog
-    // default sorts after the explicit order.
+    // defaults (managed backups included) sort after the explicit order.
     expect(result.map((p) => p.key)).toEqual([
       "balanced",
       "quality-optimized",
+      "balanced-backup",
       "cost-optimized",
+      "cost-optimized-backup",
       "latency-optimized",
+      "latency-optimized-backup",
+      "quality-optimized-backup",
     ]);
   });
 
@@ -84,10 +88,14 @@ describe("getModelProfiles", () => {
     const result = listProfiles();
     expect(result.map((p) => p.key).sort()).toEqual([
       "balanced",
+      "balanced-backup",
       "cost-optimized",
+      "cost-optimized-backup",
       "disabled",
       "latency-optimized",
+      "latency-optimized-backup",
       "quality-optimized",
+      "quality-optimized-backup",
     ]);
     const disabled = result.find((p) => p.key === "disabled");
     expect(disabled?.isDisabled).toBe(true);
@@ -123,9 +131,13 @@ describe("getModelProfiles", () => {
       "provider-only",
       "mix",
       "balanced",
+      "balanced-backup",
       "cost-optimized",
+      "cost-optimized-backup",
       "latency-optimized",
+      "latency-optimized-backup",
       "quality-optimized",
+      "quality-optimized-backup",
     ]);
   });
 
@@ -133,9 +145,13 @@ describe("getModelProfiles", () => {
     const result = listProfiles();
     expect(result.map((p) => p.key).sort()).toEqual([
       "balanced",
+      "balanced-backup",
       "cost-optimized",
+      "cost-optimized-backup",
       "latency-optimized",
+      "latency-optimized-backup",
       "quality-optimized",
+      "quality-optimized-backup",
     ]);
     for (const profile of result) {
       expect(profile.isDisabled).toBe(false);

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -1420,8 +1420,14 @@ function assertRoutableIdentityEntries(
  * the repair path for a hand-edited config.
  */
 function assertValidFallbackProfileGraph(raw: Record<string, unknown>): void {
-  const profiles = readPlainObject(readPlainObject(raw.llm)?.profiles);
-  const issues = collectFallbackProfileIssues(profiles ?? undefined);
+  const llm = readPlainObject(raw.llm);
+  const profiles = readPlainObject(llm?.profiles);
+  // The sibling `llm.defaultProvider` decides whether the managed backups are
+  // valid fallback targets: they resolve on the managed column alone.
+  const issues = collectFallbackProfileIssues(
+    profiles ?? undefined,
+    llm?.defaultProvider,
+  );
   if (issues.length > 0) {
     throw new BadRequestError(issues.map((issue) => issue.message).join(" "));
   }

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -1743,6 +1743,18 @@ async function handleReplaceInferenceProfile({
   const isManaged =
     MANAGED_PROFILE_NAMES.has(name) &&
     (existingProfile == null || existingProfile.source === "managed");
+  if (CODE_OWNED_PROFILE_NAMES.has(name)) {
+    // A code-owned profile resolves from the catalog whatever the workspace
+    // holds, so even a status re-enable would persist a stub that never
+    // governs anything. Reject the write rather than accept a silent no-op.
+    // Checked ahead of the availability gate below so the code-owned backups,
+    // which are always available yet are not `DEFAULT_PROFILE_KEYS` members,
+    // report why the write is refused rather than claiming they do not exist.
+    throw new BadRequestError(
+      `Profile "${name}" is code-owned and cannot be edited. ` +
+        `Duplicate it to a custom profile to customize.`,
+    );
+  }
   // A flag-gated managed name (`os-beta`) with no materialized entry cannot
   // be patched: it only resolves while the flag reconcile has created its
   // stub, so writing status here would persist an entry that fights the
@@ -1755,15 +1767,6 @@ async function handleReplaceInferenceProfile({
   ) {
     throw new BadRequestError(
       `Profile "${name}" is not currently available and cannot be edited.`,
-    );
-  }
-  if (CODE_OWNED_PROFILE_NAMES.has(name)) {
-    // A code-owned profile resolves from the catalog whatever the workspace
-    // holds, so even a status re-enable would persist a stub that never
-    // governs anything. Reject the write rather than accept a silent no-op.
-    throw new BadRequestError(
-      `Profile "${name}" is code-owned and cannot be edited. ` +
-        `Duplicate it to a custom profile to customize.`,
     );
   }
   if (isManaged) {

--- a/assistant/src/tools/workflows/run-workflow.test.ts
+++ b/assistant/src/tools/workflows/run-workflow.test.ts
@@ -338,12 +338,17 @@ describe("manage_workflows", () => {
     );
     expect(res.isError).toBe(false);
     const parsed = JSON.parse(res.content);
-    // The effective view always includes the code-catalog defaults.
+    // The effective view always includes the code-catalog defaults,
+    // managed backup profiles included.
     expect(parsed.profiles).toEqual([
       "balanced",
+      "balanced-backup",
       "cost-optimized",
+      "cost-optimized-backup",
       "latency-optimized",
+      "latency-optimized-backup",
       "quality-optimized",
+      "quality-optimized-backup",
     ]);
     expect(parsed.activeProfile).toBe("balanced");
   });

--- a/assistant/src/workspace/migrations/147-rename-colliding-backup-profile-names.ts
+++ b/assistant/src/workspace/migrations/147-rename-colliding-backup-profile-names.ts
@@ -1,0 +1,306 @@
+/**
+ * Workspace migration `147-rename-colliding-backup-profile-names`.
+ *
+ * The four managed backup profile keys (`balanced-backup`,
+ * `quality-optimized-backup`, `cost-optimized-backup`,
+ * `latency-optimized-backup`) became reserved code-owned names. From that
+ * release on, a name in the code-owned set resolves to the code body no
+ * matter what `llm.profiles` holds, so a user-created profile that happens
+ * to carry one of those names is silently replaced in the effective catalog:
+ * the user's own model, provider, and tuning stop being what their
+ * `activeProfile`, call-site pin, mix arm, or `fallbackProfile` reference
+ * routes through.
+ *
+ * This migration runs before the reservation can take effect (workspace
+ * migrations run ahead of the first config load and the profile seeder) and
+ * gives any such profile a fresh key, rewriting every reference to it so the
+ * user keeps both the profile and its wiring:
+ *
+ *   - `llm.profiles` key (insertion order preserved)
+ *   - `llm.activeProfile`, `llm.advisorProfile`
+ *   - `llm.profileOrder` entries
+ *   - `llm.callSites.<site>.profile` pins
+ *   - `llm.profiles.<key>.mix[].profile` arms
+ *   - `llm.profiles.<key>.fallbackProfile` targets
+ *   - `conversations.inference_profile` and `cron_jobs.inference_profile`
+ *     rows (best effort, see below)
+ *
+ * The new key is `<name>-custom`, suffixed `-custom-2`, `-custom-3`, ... when
+ * that is taken. Candidates are checked against every existing profile key
+ * AND every reserved code-defined name, so a rename never lands on another
+ * name the catalog owns.
+ *
+ * Only workspace-owned profiles are renamed. An entry whose `source` is
+ * `managed` is a thin stub for a code-owned profile, not a user profile, and
+ * a non-object value under one of these keys is not a profile at all (the
+ * loader strips it); both are left alone.
+ *
+ * The DB rewrite is best effort: a missing, locked, or unqueryable database
+ * is logged and skipped rather than blocking the config repair. A stranded
+ * conversation or schedule pin degrades to the default profile selection,
+ * which is the documented behaviour for a pin whose profile no longer
+ * exists, while leaving the config unrepaired would keep the user's profile
+ * shadowed by ours.
+ *
+ * Idempotent: after a successful run no workspace-owned profile carries a
+ * reserved backup name, so a re-run finds nothing to rename and writes
+ * nothing.
+ */
+
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { Database } from "bun:sqlite";
+
+import { getLogger } from "../../util/logger.js";
+import type { WorkspaceMigration } from "./types.js";
+
+const log = getLogger(
+  "workspace-migration-147-rename-colliding-backup-profile-names",
+);
+
+/**
+ * The newly reserved keys this migration clears. Frozen snapshot of
+ * `BACKUP_PROFILE_KEYS` as of 2026-08-21 (migrations are self-contained).
+ */
+const BACKUP_PROFILE_KEYS = [
+  "balanced-backup",
+  "quality-optimized-backup",
+  "cost-optimized-backup",
+  "latency-optimized-backup",
+];
+
+/**
+ * Every code-defined profile name as of 2026-08-21: the default keys, the
+ * backups, and the flag-gated `os-beta`. A renamed profile must not land on
+ * any of them, or the rename would just move the collision.
+ */
+const RESERVED_PROFILE_NAMES = new Set<string>([
+  "balanced",
+  "quality-optimized",
+  "cost-optimized",
+  "latency-optimized",
+  ...BACKUP_PROFILE_KEYS,
+  "os-beta",
+]);
+
+const RENAME_SUFFIX = "-custom";
+
+export const renameCollidingBackupProfileNamesMigration: WorkspaceMigration = {
+  id: "147-rename-colliding-backup-profile-names",
+  description:
+    "Rename user profiles colliding with the reserved managed backup keys and rewrite their references",
+  retryFailedCheckpoint: true,
+
+  run(workspaceDir: string): void {
+    const configPath = join(workspaceDir, "config.json");
+    if (!existsSync(configPath)) {
+      return;
+    }
+
+    let config: Record<string, unknown>;
+    try {
+      const parsed = JSON.parse(readFileSync(configPath, "utf-8"));
+      if (!isPlainObject(parsed)) {
+        return;
+      }
+      config = parsed;
+    } catch {
+      return;
+    }
+
+    const llm = asObject(config.llm);
+    const profiles = llm === null ? null : asObject(llm.profiles);
+    if (llm === null || profiles === null) {
+      return;
+    }
+
+    const renames = planRenames(profiles);
+    if (renames.size === 0) {
+      return;
+    }
+
+    // The DB rewrite runs first so an interrupted migration re-runs with the
+    // config still holding the old keys, i.e. with the mapping intact.
+    rewriteDbReferences(workspaceDir, renames);
+
+    llm.profiles = renameProfileKeys(profiles, renames);
+    rewriteConfigReferences(llm, renames);
+
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+    log.info(
+      { renames: Object.fromEntries(renames) },
+      "Renamed user profiles colliding with reserved managed backup keys",
+    );
+  },
+
+  down(_workspaceDir: string): void {
+    // Forward-only: the reserved names cannot be handed back.
+  },
+};
+
+/**
+ * Old key -> new key for every workspace-owned profile sitting on a reserved
+ * backup name. Deterministic: keys are considered in `BACKUP_PROFILE_KEYS`
+ * order and each assigned name is reserved against later candidates, so the
+ * same config always produces the same mapping.
+ */
+function planRenames(profiles: Record<string, unknown>): Map<string, string> {
+  const renames = new Map<string, string>();
+  const taken = new Set<string>([
+    ...Object.keys(profiles),
+    ...RESERVED_PROFILE_NAMES,
+  ]);
+
+  for (const key of BACKUP_PROFILE_KEYS) {
+    if (!(key in profiles)) {
+      continue;
+    }
+    const entry = asObject(profiles[key]);
+    if (entry === null) {
+      log.warn(
+        { profile: key },
+        "Left a non-object value under a reserved backup key; it is not a profile to preserve",
+      );
+      continue;
+    }
+    if (entry.source === "managed") {
+      // A managed stub is the workspace's overlay slot for a code-owned
+      // profile, not a user profile. Backups take no overlay, so the stub is
+      // inert; renaming it would manufacture a phantom user profile.
+      continue;
+    }
+    let candidate = `${key}${RENAME_SUFFIX}`;
+    let counter = 2;
+    while (taken.has(candidate)) {
+      candidate = `${key}${RENAME_SUFFIX}-${counter}`;
+      counter += 1;
+    }
+    taken.add(candidate);
+    renames.set(key, candidate);
+  }
+
+  return renames;
+}
+
+/** Rebuild the profiles record with the renamed keys, preserving order. */
+function renameProfileKeys(
+  profiles: Record<string, unknown>,
+  renames: Map<string, string>,
+): Record<string, unknown> {
+  const renamed: Record<string, unknown> = {};
+  for (const [name, value] of Object.entries(profiles)) {
+    renamed[renames.get(name) ?? name] = value;
+  }
+  return renamed;
+}
+
+/** Point every config reference at the renamed key. */
+function rewriteConfigReferences(
+  llm: Record<string, unknown>,
+  renames: Map<string, string>,
+): void {
+  for (const field of ["activeProfile", "advisorProfile"]) {
+    const current = llm[field];
+    if (typeof current === "string" && renames.has(current)) {
+      llm[field] = renames.get(current);
+    }
+  }
+
+  if (Array.isArray(llm.profileOrder)) {
+    llm.profileOrder = (llm.profileOrder as unknown[]).map((name) =>
+      typeof name === "string" ? (renames.get(name) ?? name) : name,
+    );
+  }
+
+  const callSites = asObject(llm.callSites);
+  if (callSites !== null) {
+    for (const value of Object.values(callSites)) {
+      const site = asObject(value);
+      if (
+        site !== null &&
+        typeof site.profile === "string" &&
+        renames.has(site.profile)
+      ) {
+        site.profile = renames.get(site.profile);
+      }
+    }
+  }
+
+  const profiles = asObject(llm.profiles);
+  if (profiles === null) {
+    return;
+  }
+  for (const value of Object.values(profiles)) {
+    const entry = asObject(value);
+    if (entry === null) {
+      continue;
+    }
+    if (
+      typeof entry.fallbackProfile === "string" &&
+      renames.has(entry.fallbackProfile)
+    ) {
+      entry.fallbackProfile = renames.get(entry.fallbackProfile);
+    }
+    if (!Array.isArray(entry.mix)) {
+      continue;
+    }
+    for (const armValue of entry.mix as unknown[]) {
+      const arm = asObject(armValue);
+      if (
+        arm !== null &&
+        typeof arm.profile === "string" &&
+        renames.has(arm.profile)
+      ) {
+        arm.profile = renames.get(arm.profile);
+      }
+    }
+  }
+}
+
+/**
+ * Repoint the profile pins stored outside config.json: the sticky
+ * per-conversation profile and the per-schedule profile. Best effort, see
+ * the file header.
+ */
+function rewriteDbReferences(
+  workspaceDir: string,
+  renames: Map<string, string>,
+): void {
+  const dbPath = join(workspaceDir, "data", "db", "assistant.db");
+  if (!existsSync(dbPath)) {
+    return;
+  }
+  let db: Database;
+  try {
+    db = new Database(dbPath);
+  } catch (err) {
+    log.warn({ err }, "Could not open the database to repoint profile pins");
+    return;
+  }
+  try {
+    for (const table of ["conversations", "cron_jobs"]) {
+      for (const [from, to] of renames) {
+        try {
+          db.query(
+            `UPDATE ${table} SET inference_profile = ? WHERE inference_profile = ?`,
+          ).run(to, from);
+        } catch (err) {
+          log.warn(
+            { err, table, from, to },
+            "Could not repoint profile pins on this table; stranded pins fall back to the default selection",
+          );
+        }
+      }
+    }
+  } finally {
+    db.close();
+  }
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function asObject(value: unknown): Record<string, unknown> | null {
+  return isPlainObject(value) ? value : null;
+}

--- a/assistant/src/workspace/migrations/147-rename-colliding-backup-profile-names.ts
+++ b/assistant/src/workspace/migrations/147-rename-colliding-backup-profile-names.ts
@@ -23,7 +23,7 @@
  *   - `llm.profiles.<key>.mix[].profile` arms
  *   - `llm.profiles.<key>.fallbackProfile` targets
  *   - `conversations.inference_profile` and `cron_jobs.inference_profile`
- *     rows (best effort, see below)
+ *     rows (see below)
  *
  * The new key is `<name>-custom`, suffixed `-custom-2`, `-custom-3`, ... when
  * that is taken. Candidates are checked against every existing profile key
@@ -35,16 +35,25 @@
  * a non-object value under one of these keys is not a profile at all (the
  * loader strips it); both are left alone.
  *
- * The DB rewrite is best effort: a missing, locked, or unqueryable database
- * is logged and skipped rather than blocking the config repair. A stranded
- * conversation or schedule pin degrades to the default profile selection,
- * which is the documented behaviour for a pin whose profile no longer
- * exists, while leaving the config unrepaired would keep the user's profile
- * shadowed by ours.
+ * The DB rewrite is NOT best effort. A pin the rewrite abandons does not
+ * degrade to the default selection: its old name is now a reserved code-owned
+ * key, so the conversation or schedule silently starts routing through the
+ * managed backup instead of the user's profile. So a database that exists but
+ * cannot be opened or written is retried a bounded number of times with a
+ * short backoff, and a failure that outlives the retries throws. The runner
+ * then records a `failed` checkpoint, and `retryFailedCheckpoint` makes the
+ * next boot re-run the whole migration. An absent database file is a real
+ * state (no pins to strand) and a table the schema does not carry yet is
+ * nothing to rewrite; both are skipped without failing.
+ *
+ * The DB rewrite deliberately runs BEFORE the config write, so a throw leaves
+ * config.json holding the old keys and the next run rebuilds the same
+ * mapping from it.
  *
  * Idempotent: after a successful run no workspace-owned profile carries a
  * reserved backup name, so a re-run finds nothing to rename and writes
- * nothing.
+ * nothing. The pin rewrite matches on the old name, so re-running it after a
+ * partial pass is a no-op on the rows already repointed.
  */
 
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
@@ -85,13 +94,23 @@ const RESERVED_PROFILE_NAMES = new Set<string>([
 
 const RENAME_SUFFIX = "-custom";
 
+/** Total attempts at the pin rewrite, the first one included. */
+const DB_ATTEMPTS = 4;
+
+/** First backoff step; each further wait doubles it (50, 100, 200 ms). */
+const DB_RETRY_BASE_DELAY_MS = 50;
+
 export const renameCollidingBackupProfileNamesMigration: WorkspaceMigration = {
   id: "147-rename-colliding-backup-profile-names",
   description:
     "Rename user profiles colliding with the reserved managed backup keys and rewrite their references",
+  // The failure this migration can hit is a database it cannot write, and
+  // both halves of the run are idempotent, so a failed checkpoint is worth
+  // re-running: the config still holds the old keys, the mapping rebuilds
+  // from them, and the pin rewrite matches on the old name.
   retryFailedCheckpoint: true,
 
-  run(workspaceDir: string): void {
+  async run(workspaceDir: string): Promise<void> {
     const configPath = join(workspaceDir, "config.json");
     if (!existsSync(configPath)) {
       return;
@@ -119,9 +138,11 @@ export const renameCollidingBackupProfileNamesMigration: WorkspaceMigration = {
       return;
     }
 
-    // The DB rewrite runs first so an interrupted migration re-runs with the
-    // config still holding the old keys, i.e. with the mapping intact.
-    rewriteDbReferences(workspaceDir, renames);
+    // The DB rewrite runs first so an interrupted or failed migration re-runs
+    // with the config still holding the old keys, i.e. with the mapping
+    // intact. A rewrite that cannot be completed throws out of here, which
+    // stops the config rename below rather than stranding the pins.
+    await rewriteDbReferences(workspaceDir, renames);
 
     llm.profiles = renameProfileKeys(profiles, renames);
     rewriteConfigReferences(llm, renames);
@@ -259,41 +280,74 @@ function rewriteConfigReferences(
 
 /**
  * Repoint the profile pins stored outside config.json: the sticky
- * per-conversation profile and the per-schedule profile. Best effort, see
- * the file header.
+ * per-conversation profile and the per-schedule profile.
+ *
+ * Retried as a whole rather than per statement: opening the database, reading
+ * `sqlite_master` and running the updates all fail the same way under write
+ * contention (`SQLITE_BUSY` from a second connection), and every step is
+ * idempotent, so re-running the block is the simplest recovery that cannot
+ * double-apply. A failure that outlives the attempts throws, which fails the
+ * migration for `retryFailedCheckpoint` to pick up on the next boot.
  */
-function rewriteDbReferences(
+async function rewriteDbReferences(
   workspaceDir: string,
   renames: Map<string, string>,
-): void {
+): Promise<void> {
   const dbPath = join(workspaceDir, "data", "db", "assistant.db");
   if (!existsSync(dbPath)) {
+    // No database yet, so there are no pins that could be stranded.
     return;
   }
-  let db: Database;
-  try {
-    db = new Database(dbPath);
-  } catch (err) {
-    log.warn({ err }, "Could not open the database to repoint profile pins");
-    return;
-  }
-  try {
-    for (const table of ["conversations", "cron_jobs"]) {
-      for (const [from, to] of renames) {
-        try {
+  await withDbRetry(() => {
+    const db = new Database(dbPath);
+    try {
+      for (const table of ["conversations", "cron_jobs"]) {
+        const present = db
+          .query(
+            `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?`,
+          )
+          .get(table);
+        if (!present) {
+          // A workspace whose schema does not carry this table holds no pins
+          // in it. Nothing to rewrite, and nothing to fail over.
+          log.info({ table }, "No profile pin table to repoint");
+          continue;
+        }
+        for (const [from, to] of renames) {
           db.query(
             `UPDATE ${table} SET inference_profile = ? WHERE inference_profile = ?`,
           ).run(to, from);
-        } catch (err) {
-          log.warn(
-            { err, table, from, to },
-            "Could not repoint profile pins on this table; stranded pins fall back to the default selection",
-          );
         }
       }
+    } finally {
+      db.close();
     }
-  } finally {
-    db.close();
+  });
+}
+
+/**
+ * Run the pin rewrite, retrying a transient database failure with a short
+ * doubling backoff. Rethrows once the attempts are spent so the caller stops
+ * before the config rename.
+ */
+async function withDbRetry(attempt: () => void): Promise<void> {
+  for (let index = 0; ; index += 1) {
+    try {
+      attempt();
+      return;
+    } catch (err) {
+      if (index >= DB_ATTEMPTS - 1) {
+        throw new Error(
+          `Could not repoint conversation and schedule profile pins after ${DB_ATTEMPTS} attempts; leaving the config unrenamed so the next boot retries`,
+          { cause: err },
+        );
+      }
+      log.warn(
+        { err, attempt: index },
+        "Could not repoint profile pins; retrying",
+      );
+      await Bun.sleep(DB_RETRY_BASE_DELAY_MS * 2 ** index);
+    }
   }
 }
 

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -144,6 +144,7 @@ import { repairDeprecatedCodexModelIdMigration } from "./143-repair-deprecated-c
 import { convertStrandedSubscriptionOpenaiProfilesMigration } from "./144-convert-stranded-subscription-openai-profiles.js";
 import { collapseProfileBindingsToEntriesMigration } from "./145-collapse-profile-bindings-to-entries.js";
 import { repairRetiredFireworksDeepseekFlashModelIdMigration } from "./146-repair-retired-fireworks-deepseek-flash-model-id.js";
+import { renameCollidingBackupProfileNamesMigration } from "./147-rename-colliding-backup-profile-names.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -303,4 +304,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   convertStrandedSubscriptionOpenaiProfilesMigration,
   collapseProfileBindingsToEntriesMigration,
   repairRetiredFireworksDeepseekFlashModelIdMigration,
+  renameCollidingBackupProfileNamesMigration,
 ];


### PR DESCRIPTION
## Summary
- Four managed backup profiles (Quality/Balanced/Speed/Cost Backup) pinned to cross-provider models with per-model tuning
- Primary managed profiles point at their backups via fallbackProfile
- Catalog tests: cross-provider rule, liveness-probe coverage, schema parse, managed-column-only scoping

Part of plan: model-fallbacks.md (PR 2 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41174" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->