### PR TITLE
fix(ios): widget review remediations (timeline policy, privacy, shared controls)

### DIFF
--- a/clients/ios/App/App/AppDelegate.swift
+++ b/clients/ios/App/App/AppDelegate.swift
@@ -278,10 +278,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     ///
     /// Called only by the App Intents (the voice intents via
     /// `VoiceModeDeepLink.route()`, `SendMessageToChatIntent` via
-    /// `ThreadDeepLink.route()`), which run in-process and therefore never
-    /// pass through `application(_:open:)`. That exclusivity is load-bearing:
-    /// it is what lets this method vouch for the URL by adding the provenance
-    /// marker the external entry points strip (see `CommandURLProvenance`).
+    /// `ThreadDeepLink.route()`, and `OpenCameraIntent` / `OpenNewChatIntent`
+    /// via `CommandDeepLink.route(host:)`), which run in-process and therefore
+    /// never pass through `application(_:open:)`. A widget tap is no exception:
+    /// those intents declare `openAppWhenRun`, so the system performs them in
+    /// the app process rather than in the appex. That exclusivity is
+    /// load-bearing: it is what lets this method vouch for the URL by adding
+    /// the provenance marker the external entry points strip (see
+    /// `CommandURLProvenance`).
     /// Do not route anything that arrived from outside the process through
     /// here; the terminated-launch path in `didFinishLaunchingWithOptions`
     /// deliberately stashes into `pendingCommandURL` directly instead.

--- a/clients/ios/App/App/MyViewController.swift
+++ b/clients/ios/App/App/MyViewController.swift
@@ -6,8 +6,9 @@ import WebKit
 ///
 /// 1. Registers `NativeAuthPlugin`, `NativeBiometricPlugin`,
 ///    `VoiceAudioSessionPlugin`, `VoiceLiveActivityPlugin`,
-///    `ApnsEnvironmentPlugin`, `SelfHostedServersPlugin`, and
-///    `RecentChatsPlugin` as local plugin instances at bridge init time.
+///    `ApnsEnvironmentPlugin`, `SelfHostedServersPlugin`,
+///    `RecentChatsPlugin`, and `WidgetSnapshotPlugin` as local plugin
+///    instances at bridge init time.
 ///    These plugins live inside the App target (no SPM module) so the bridge
 ///    won't discover them automatically.
 ///

--- a/clients/ios/App/App/Shared/CameraDeepLink.swift
+++ b/clients/ios/App/App/Shared/CameraDeepLink.swift
@@ -20,11 +20,6 @@ enum CameraDeepLink {
     /// Host segment shared with `CAMERA_DEEP_LINK_HOST` on the web side.
     private static let host = "camera"
 
-    /// The command URL for the running build; see ``CommandDeepLink/url(host:)``.
-    static func url() -> URL? {
-        CommandDeepLink.url(host: host)
-    }
-
     /// Hand this command to the shell; see ``CommandDeepLink/route(host:)``.
     @MainActor
     static func route() {

--- a/clients/ios/App/App/Shared/NewChatDeepLink.swift
+++ b/clients/ios/App/App/Shared/NewChatDeepLink.swift
@@ -20,11 +20,6 @@ enum NewChatDeepLink {
     /// Host segment shared with `NEW_CHAT_DEEP_LINK_HOST` on the web side.
     private static let host = "new-chat"
 
-    /// The command URL for the running build; see ``CommandDeepLink/url(host:)``.
-    static func url() -> URL? {
-        CommandDeepLink.url(host: host)
-    }
-
     /// Hand this command to the shell; see ``CommandDeepLink/route(host:)``.
     @MainActor
     static func route() {

--- a/clients/ios/App/App/Shared/WidgetSnapshot.swift
+++ b/clients/ios/App/App/Shared/WidgetSnapshot.swift
@@ -4,12 +4,12 @@ import Foundation
 /// Screen row and to deep-link into the conversation it names.
 ///
 /// `subtitle` is the conversation's group name, absent when it belongs to no
-/// group. `lastMessageAt` is absent for a conversation that has none.
+/// group. Ordering is the producer's, so the rows carry no timestamp of their
+/// own: nothing here renders one.
 struct WidgetSnapshotConversation: Codable, Equatable {
     let id: String
     let title: String
     let subtitle: String?
-    let lastMessageAt: Date?
     let hasUnseen: Bool
     let isProcessing: Bool
 }

--- a/clients/ios/App/App/WidgetSnapshotPlugin.swift
+++ b/clients/ios/App/App/WidgetSnapshotPlugin.swift
@@ -72,7 +72,6 @@ public class WidgetSnapshotPlugin: CAPPlugin, CAPBridgedPlugin {
             id: id,
             title: title,
             subtitle: (dict["subtitle"] as? String).flatMap { $0.isEmpty ? nil : $0 },
-            lastMessageAt: date(from: dict["lastMessageAt"] as? String),
             hasUnseen: dict["hasUnseen"] as? Bool ?? false,
             isProcessing: dict["isProcessing"] as? Bool ?? false
         )

--- a/clients/ios/App/VoiceActivity/Widgets/CatchUpWidget.swift
+++ b/clients/ios/App/VoiceActivity/Widgets/CatchUpWidget.swift
@@ -1,4 +1,3 @@
-import AppIntents
 import SwiftUI
 import WidgetKit
 
@@ -45,20 +44,8 @@ struct CatchUpWidgetView: View {
     var body: some View {
         HStack(alignment: .top, spacing: 14) {
             VStack(spacing: 7) {
-                WidgetActionTile(
-                    intent: OpenNewChatIntent(),
-                    icon: Image("VellumV"),
-                    title: "New Chat",
-                    fill: WidgetTheme.newChatFill,
-                    tint: WidgetTheme.brand
-                )
-                WidgetActionTile(
-                    intent: StartNewVoiceConversationIntent(),
-                    icon: Image(systemName: "waveform"),
-                    title: "Voice",
-                    fill: WidgetTheme.voiceFill,
-                    tint: WidgetTheme.textPrimary
-                )
+                WidgetActionTile.newChat
+                WidgetActionTile.voice
             }
             .frame(width: Self.actionColumnWidth)
 
@@ -101,10 +88,7 @@ struct CatchUpWidgetView: View {
     /// end with opening the app. The actions beside it stay live, so the
     /// widget is still a way in.
     private var emptyPrompt: some View {
-        Text("Open Vellum to see your recent chats.")
-            .font(.system(size: 11, weight: .medium))
-            .foregroundStyle(WidgetTheme.textSecondary)
-            .lineLimit(2)
+        WidgetPromptText("Open Vellum to see your recent chats.", size: 11)
             .padding(.top, 2)
     }
 }
@@ -185,42 +169,5 @@ struct CatchUpRow: View {
         Image(systemName: "bubble.left")
             .font(.system(size: 11))
             .foregroundStyle(WidgetTheme.textPrimary)
-    }
-}
-
-/// One tile in the action column: a glyph over a word, filling a rounded
-/// square, wired to an App Intent.
-///
-/// Generic over the intent because `Button(intent:)` takes a concrete
-/// `AppIntent` and the two tiles run different ones. Both intents declare
-/// `openAppWhenRun`, so the system performs them in the app process; the appex
-/// only needs the types to exist.
-struct WidgetActionTile<ActionIntent: AppIntent>: View {
-    /// Matched to the squircle the system clips the widget itself with, so a
-    /// tile reads as a smaller instance of the card it sits on.
-    private static var cornerRadius: CGFloat { 14 }
-
-    let intent: ActionIntent
-    let icon: Image
-    let title: String
-    let fill: Color
-    let tint: Color
-
-    var body: some View {
-        Button(intent: intent) {
-            VStack(spacing: 4) {
-                icon
-                    .font(.system(size: 22))
-                    .foregroundStyle(tint)
-                Text(title)
-                    .font(.system(size: 9, weight: .medium))
-                    .foregroundStyle(WidgetTheme.textPrimary)
-                    .lineLimit(1)
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(fill, in: RoundedRectangle(cornerRadius: Self.cornerRadius))
-        }
-        .buttonStyle(.plain)
-        .accessibilityLabel(title)
     }
 }

--- a/clients/ios/App/VoiceActivity/Widgets/QuickActionsWidget.swift
+++ b/clients/ios/App/VoiceActivity/Widgets/QuickActionsWidget.swift
@@ -68,14 +68,15 @@ struct QuickActionsEntry: TimelineEntry {
     }
 }
 
-/// ``SnapshotProvider``'s timeline, restated in the async shape a configurable
+/// ``SnapshotProvider``'s timeline, restated in the shape a configurable
 /// widget requires, with the chosen appearance folded into every entry.
 ///
 /// `AppIntentConfiguration` takes an `AppIntentTimelineProvider` and the shared
-/// provider is a plain `TimelineProvider`, so something has to bridge the two.
-/// This delegates instead of re-reading the store: which snapshot to render and
-/// when it stops being fresh are one decision for all the Vellum widgets, and a
-/// second copy of the staleness rule is a second copy that drifts.
+/// provider is a plain `TimelineProvider`, so something has to restate one as
+/// the other. This calls ``SnapshotProvider``'s synchronous producers instead
+/// of re-reading the store: which snapshot to render and when it stops being
+/// fresh are one decision for all the Vellum widgets, and a second copy of the
+/// staleness rule is a second copy that drifts.
 struct QuickActionsProvider: AppIntentTimelineProvider {
     private let snapshots = SnapshotProvider()
 
@@ -87,19 +88,17 @@ struct QuickActionsProvider: AppIntentTimelineProvider {
         for configuration: QuickActionsAppearanceIntent,
         in context: Context
     ) async -> QuickActionsEntry {
-        let entry: SnapshotEntry = await withCheckedContinuation { continuation in
-            snapshots.getSnapshot(in: context) { continuation.resume(returning: $0) }
-        }
-        return QuickActionsEntry(snapshotEntry: entry, appearance: configuration.appearance)
+        QuickActionsEntry(
+            snapshotEntry: snapshots.entry(in: context),
+            appearance: configuration.appearance
+        )
     }
 
     func timeline(
         for configuration: QuickActionsAppearanceIntent,
         in context: Context
     ) async -> Timeline<QuickActionsEntry> {
-        let timeline: Timeline<SnapshotEntry> = await withCheckedContinuation { continuation in
-            snapshots.getTimeline(in: context) { continuation.resume(returning: $0) }
-        }
+        let timeline = snapshots.timeline(now: Date())
         return Timeline(
             entries: timeline.entries.map {
                 QuickActionsEntry(snapshotEntry: $0, appearance: configuration.appearance)
@@ -211,10 +210,10 @@ struct QuickActionsWidgetView: View {
                     .font(.system(size: 11, weight: .semibold))
                     .privacySensitive()
             }
-            .foregroundStyle(.white)
+            .foregroundStyle(WidgetTheme.onBrand)
             .padding(.horizontal, 7)
             .padding(.vertical, 3)
-            .background(.white.opacity(0.22), in: Capsule())
+            .background(WidgetTheme.onBrandFill, in: Capsule())
             .accessibilityElement(children: .ignore)
             .accessibilityLabel("\(count) unread")
         }
@@ -261,60 +260,6 @@ private struct QuickActionsAvatar: View {
     }
 }
 
-/// A round tap target running an App Intent, with the glyph as its whole label.
-///
-/// Generic over the intent for the reason `WidgetActionTile` is: `Button(intent:)`
-/// takes a concrete `AppIntent` and these buttons run different ones. Both
-/// intents declare `openAppWhenRun`, so the system performs them in the app
-/// process and the appex only needs the types to exist.
-private struct CircleActionButton<ActionIntent: AppIntent>: View {
-    let intent: ActionIntent
-    let icon: Image
-    let label: String
-    let fill: Color
-    let tint: Color
-    let diameter: CGFloat
-
-    var body: some View {
-        Button(intent: intent) {
-            icon
-                .font(.system(size: diameter * 0.4))
-                .foregroundStyle(tint)
-                .frame(width: diameter, height: diameter)
-                .background(fill, in: Circle())
-        }
-        .buttonStyle(.plain)
-        .accessibilityLabel(label)
-    }
-}
-
-/// A full-width capsule running an App Intent, glyph beside a word.
-private struct PillActionButton<ActionIntent: AppIntent>: View {
-    let intent: ActionIntent
-    let icon: Image
-    let title: String
-    let fill: Color
-    let tint: Color
-    let height: CGFloat
-
-    var body: some View {
-        Button(intent: intent) {
-            HStack(spacing: 6) {
-                icon
-                    .font(.system(size: height * 0.4))
-                Text(title)
-                    .font(.system(size: 15, weight: .semibold))
-            }
-            .foregroundStyle(tint)
-            .frame(maxWidth: .infinity)
-            .frame(height: height)
-            .background(fill, in: Capsule())
-        }
-        .buttonStyle(.plain)
-        .accessibilityLabel(title)
-    }
-}
-
 /// The whole of what an appearance decides: three colors.
 private extension QuickActionsAppearance {
     /// The card behind everything.
@@ -327,13 +272,11 @@ private extension QuickActionsAppearance {
         }
     }
 
-    /// The circle behind an action glyph. Translucent white on the brand card,
-    /// so the circles read as cut out of the green rather than as a second
-    /// color placed on top of it, and the card stays one block.
+    /// The circle behind an action glyph.
     var controlFill: Color {
         switch self {
         case .brand:
-            return .white.opacity(0.22)
+            return WidgetTheme.onBrandFill
         case .light:
             return WidgetTheme.voiceFill
         }
@@ -343,7 +286,7 @@ private extension QuickActionsAppearance {
     var controlTint: Color {
         switch self {
         case .brand:
-            return .white
+            return WidgetTheme.onBrand
         case .light:
             return WidgetTheme.textPrimary
         }

--- a/clients/ios/App/VoiceActivity/Widgets/SnapshotTimeline.swift
+++ b/clients/ios/App/VoiceActivity/Widgets/SnapshotTimeline.swift
@@ -31,8 +31,20 @@ struct SnapshotEntry: TimelineEntry {
 /// The extension has no network stack and no auth, so there is nothing to
 /// fetch here. `WidgetSnapshotPlugin` writes the snapshot while the app is
 /// open and calls `WidgetCenter.reloadTimelines(ofKind:)`, which is what
-/// actually keeps these widgets current; the `.atEnd` policy is the floor
-/// under that, not the mechanism.
+/// actually keeps these widgets current and costs no refresh budget.
+///
+/// The refresh policy follows from what the timeline managed to schedule.
+/// When a staleness transition is still ahead, the timeline ends with
+/// `.atEnd`, so the system comes back once that second entry has been drawn.
+/// When the only entry is dated now, because nothing is synced or the
+/// snapshot already aged out, there is nothing further to draw and the
+/// timeline ends with `.never`: asking again would spend the widget's
+/// refresh budget re-reading a store only the app writes.
+///
+/// The producers are synchronous. `TimelineProvider` wants completions and
+/// `AppIntentTimelineProvider` wants `async`, and both shapes are satisfied
+/// by forwarding to ``entry(in:)`` and ``timeline(now:)`` so the staleness
+/// rule lives in one place.
 struct SnapshotProvider: TimelineProvider {
     /// How long a snapshot's live claims are trusted.
     ///
@@ -48,21 +60,20 @@ struct SnapshotProvider: TimelineProvider {
         SnapshotEntry(date: Date(), snapshot: .placeholder, isStale: false)
     }
 
-    /// The gallery and the widget's transient previews ask through here. A
-    /// preview shows the fixture rather than the real snapshot, so browsing
-    /// the gallery on a locked device cannot put someone's conversation titles
-    /// on screen, and so an account with nothing synced yet is still offered a
-    /// widget that looks like something.
-    func getSnapshot(in context: Context, completion: @escaping (SnapshotEntry) -> Void) {
+    /// The single entry the gallery and the widget's transient previews ask
+    /// for. A preview shows the fixture rather than the real snapshot, so
+    /// browsing the gallery on a locked device cannot put someone's
+    /// conversation titles on screen, and so an account with nothing synced
+    /// yet is still offered a widget that looks like something.
+    func entry(in context: Context) -> SnapshotEntry {
         if context.isPreview {
-            completion(placeholder(in: context))
-            return
+            return placeholder(in: context)
         }
-        completion(entry(at: Date(), for: WidgetSnapshotStore.load()))
+        return entry(at: Date(), for: WidgetSnapshotStore.load())
     }
 
-    func getTimeline(in context: Context, completion: @escaping (Timeline<SnapshotEntry>) -> Void) {
-        let now = Date()
+    /// What to draw now, and the one moment after it worth redrawing.
+    func timeline(now: Date) -> Timeline<SnapshotEntry> {
         let snapshot = WidgetSnapshotStore.load()
         var entries = [entry(at: now, for: snapshot)]
         if let snapshot {
@@ -74,7 +85,15 @@ struct SnapshotProvider: TimelineProvider {
                 entries.append(SnapshotEntry(date: staleAt, snapshot: snapshot, isStale: true))
             }
         }
-        completion(Timeline(entries: entries, policy: .atEnd))
+        return Timeline(entries: entries, policy: entries.count > 1 ? .atEnd : .never)
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (SnapshotEntry) -> Void) {
+        completion(entry(in: context))
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<SnapshotEntry>) -> Void) {
+        completion(timeline(now: Date()))
     }
 
     private func entry(at date: Date, for snapshot: WidgetSnapshot?) -> SnapshotEntry {
@@ -107,7 +126,6 @@ extension WidgetSnapshot {
                 id: "placeholder-1",
                 title: "Your morning briefing",
                 subtitle: "Daily",
-                lastMessageAt: nil,
                 hasUnseen: true,
                 isProcessing: false
             ),
@@ -115,7 +133,6 @@ extension WidgetSnapshot {
                 id: "placeholder-2",
                 title: "Trip planning notes",
                 subtitle: "Travel",
-                lastMessageAt: nil,
                 hasUnseen: true,
                 isProcessing: false
             ),
@@ -123,7 +140,6 @@ extension WidgetSnapshot {
                 id: "placeholder-3",
                 title: "Looking that up",
                 subtitle: nil,
-                lastMessageAt: nil,
                 hasUnseen: false,
                 isProcessing: true
             ),

--- a/clients/ios/App/VoiceActivity/Widgets/StatusWidget.swift
+++ b/clients/ios/App/VoiceActivity/Widgets/StatusWidget.swift
@@ -43,20 +43,8 @@ struct StatusWidgetView: View {
             readout
             Spacer(minLength: 0)
             HStack(spacing: 7) {
-                WidgetActionTile(
-                    intent: OpenNewChatIntent(),
-                    icon: Image("VellumV"),
-                    title: "New Chat",
-                    fill: WidgetTheme.newChatFill,
-                    tint: WidgetTheme.brand
-                )
-                WidgetActionTile(
-                    intent: StartNewVoiceConversationIntent(),
-                    icon: Image(systemName: "waveform"),
-                    title: "Voice",
-                    fill: WidgetTheme.voiceFill,
-                    tint: WidgetTheme.textPrimary
-                )
+                WidgetActionTile.newChat
+                WidgetActionTile.voice
             }
             .frame(height: Self.actionRowHeight)
         }
@@ -74,13 +62,19 @@ struct StatusWidgetView: View {
     /// rows keep their unread markers past the same threshold because each one
     /// hangs off a conversation the reader recognizes; a bare number has
     /// nothing to qualify it.
+    ///
+    /// The three prompts that stand in for the counts are three different
+    /// facts rather than spare wordings of one: nothing has ever synced, the
+    /// snapshot is too old to read as a status, or there is genuinely nothing
+    /// waiting. The buttons below stay live in all three, so the widget is
+    /// still a way in when it has nothing to report.
     @ViewBuilder
     private var readout: some View {
         if let snapshot = entry.snapshot {
             if entry.isStale {
-                prompt("Open Vellum for the latest.")
+                WidgetPromptText("Open Vellum for the latest.")
             } else if snapshot.unreadCount <= 0, snapshot.inProgressCount <= 0 {
-                prompt("All caught up.")
+                WidgetPromptText("All caught up.")
             } else {
                 VStack(alignment: .leading, spacing: 6) {
                     if snapshot.unreadCount > 0 {
@@ -92,12 +86,16 @@ struct StatusWidgetView: View {
                 }
             }
         } else {
-            prompt("Open Vellum to see what is waiting.")
+            WidgetPromptText("Open Vellum to see what is waiting.")
         }
     }
 
     /// The glyph is decorative: the text beside it already says everything
     /// VoiceOver needs to read.
+    ///
+    /// The line is `.privacySensitive()` while the glyph beside it is not,
+    /// matching the Quick Actions chip: a locked device still shows that
+    /// something is waiting without spelling out how far behind its owner is.
     private func countLine(icon: String, text: String) -> some View {
         HStack(spacing: 6) {
             Image(systemName: icon)
@@ -110,18 +108,7 @@ struct StatusWidgetView: View {
                 .foregroundStyle(WidgetTheme.textPrimary)
                 .lineLimit(1)
                 .minimumScaleFactor(0.8)
+                .privacySensitive()
         }
-    }
-
-    /// The line that stands in for the counts. Its three phrasings are three
-    /// different facts rather than spare wordings of one: nothing has ever
-    /// synced, the snapshot is too old to read as a status, or there is
-    /// genuinely nothing waiting. The buttons below stay live in all three, so
-    /// the widget is still a way in when it has nothing to report.
-    private func prompt(_ text: String) -> some View {
-        Text(text)
-            .font(.system(size: 12, weight: .medium))
-            .foregroundStyle(WidgetTheme.textSecondary)
-            .lineLimit(2)
     }
 }

--- a/clients/ios/App/VoiceActivity/Widgets/WidgetActionControls.swift
+++ b/clients/ios/App/VoiceActivity/Widgets/WidgetActionControls.swift
@@ -1,0 +1,151 @@
+import AppIntents
+import SwiftUI
+
+// The controls every Vellum Home Screen widget builds its actions out of: a
+// tile, a circle, a pill, and the secondary line of text that stands in when
+// there is nothing to list. They live here rather than beside whichever widget
+// reached for them first, because a control that lives in one widget's file is
+// a control the next widget copies.
+
+/// One tile in an action column: a glyph over a word, filling a rounded
+/// square, wired to an App Intent.
+///
+/// Generic over the intent because `Button(intent:)` takes a concrete
+/// `AppIntent` and the tiles run different ones. Both intents declare
+/// `openAppWhenRun`, so the system performs them in the app process; the appex
+/// only needs the types to exist.
+struct WidgetActionTile<ActionIntent: AppIntent>: View {
+    /// Matched to the squircle the system clips the widget itself with, so a
+    /// tile reads as a smaller instance of the card it sits on.
+    private static var cornerRadius: CGFloat { 14 }
+
+    let intent: ActionIntent
+    let icon: Image
+    let title: String
+    let fill: Color
+    let tint: Color
+
+    var body: some View {
+        Button(intent: intent) {
+            VStack(spacing: 4) {
+                icon
+                    .font(.system(size: 22))
+                    .foregroundStyle(tint)
+                Text(title)
+                    .font(.system(size: 9, weight: .medium))
+                    .foregroundStyle(WidgetTheme.textPrimary)
+                    .lineLimit(1)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(fill, in: RoundedRectangle(cornerRadius: Self.cornerRadius))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(title)
+    }
+}
+
+extension WidgetActionTile where ActionIntent == OpenNewChatIntent {
+    /// The New Chat tile, spelled once so the widgets offering it cannot drift
+    /// into different wording, glyphs or colors. The frame around it stays with
+    /// the caller: the column and the row size their tiles differently.
+    static var newChat: Self {
+        WidgetActionTile(
+            intent: OpenNewChatIntent(),
+            icon: Image("VellumV"),
+            title: "New Chat",
+            fill: WidgetTheme.newChatFill,
+            tint: WidgetTheme.brand
+        )
+    }
+}
+
+extension WidgetActionTile where ActionIntent == StartNewVoiceConversationIntent {
+    /// The Voice tile, the secondary half of the pair. Neutral fill against
+    /// ``newChat``'s tinted one, so the two read as a primary action and a
+    /// secondary one rather than as two peers.
+    static var voice: Self {
+        WidgetActionTile(
+            intent: StartNewVoiceConversationIntent(),
+            icon: Image(systemName: "waveform"),
+            title: "Voice",
+            fill: WidgetTheme.voiceFill,
+            tint: WidgetTheme.textPrimary
+        )
+    }
+}
+
+/// A round tap target running an App Intent, with the glyph as its whole label.
+///
+/// Generic over the intent for the reason ``WidgetActionTile`` is.
+struct CircleActionButton<ActionIntent: AppIntent>: View {
+    let intent: ActionIntent
+    let icon: Image
+    let label: String
+    let fill: Color
+    let tint: Color
+    let diameter: CGFloat
+
+    var body: some View {
+        Button(intent: intent) {
+            icon
+                .font(.system(size: diameter * 0.4))
+                .foregroundStyle(tint)
+                .frame(width: diameter, height: diameter)
+                .background(fill, in: Circle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(label)
+    }
+}
+
+/// A full-width capsule running an App Intent, glyph beside a word.
+struct PillActionButton<ActionIntent: AppIntent>: View {
+    let intent: ActionIntent
+    let icon: Image
+    let title: String
+    let fill: Color
+    let tint: Color
+    let height: CGFloat
+
+    var body: some View {
+        Button(intent: intent) {
+            HStack(spacing: 6) {
+                icon
+                    .font(.system(size: height * 0.4))
+                Text(title)
+                    .font(.system(size: 15, weight: .semibold))
+            }
+            .foregroundStyle(tint)
+            .frame(maxWidth: .infinity)
+            .frame(height: height)
+            .background(fill, in: Capsule())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(title)
+    }
+}
+
+/// The quiet line a widget prints when it has nothing to list: an empty state,
+/// a snapshot too old to read as a status, or an account with nothing synced.
+///
+/// One treatment for all of them, because they are one thing to the person
+/// reading: a sentence that is not the widget's content, sized down and in the
+/// secondary color so it does not compete with the actions beside it. The
+/// size is adjustable for the narrower medium-widget column; spacing stays
+/// with the caller.
+struct WidgetPromptText: View {
+    private let text: String
+    private let size: CGFloat
+
+    init(_ text: String, size: CGFloat = 12) {
+        self.text = text
+        self.size = size
+    }
+
+    var body: some View {
+        Text(text)
+            .font(.system(size: size, weight: .medium))
+            .foregroundStyle(WidgetTheme.textSecondary)
+            .lineLimit(2)
+    }
+}

--- a/clients/ios/App/VoiceActivity/Widgets/WidgetTheme.swift
+++ b/clients/ios/App/VoiceActivity/Widgets/WidgetTheme.swift
@@ -45,9 +45,19 @@ enum WidgetTheme {
     /// Deepened for dark mode where ``brand`` is lightened, because the two
     /// play opposite roles: `brand` is drawn *on* `surface` and has to separate
     /// from it, while this one *is* the surface, and a mint block would be the
-    /// brightest thing on a dark Home Screen. Content drawn on it is white in
-    /// both appearances, which is why there is no companion text color here.
+    /// brightest thing on a dark Home Screen.
     static let brandCardSurface = dynamic(light: "#0E9B8B", dark: "#0B7A6E")
+
+    /// Glyphs and text drawn on ``brandCardSurface``. Fixed rather than
+    /// dynamic: the card underneath is a deep green in both appearances, so
+    /// this answers to the card rather than to the Home Screen behind it.
+    static let onBrand = fixed("#FFFFFF")
+
+    /// A control's fill on ``brandCardSurface``: ``onBrand`` at low opacity, so
+    /// the action circles and the unread chip read as cut out of the green
+    /// rather than as a second color placed on top of it, and the card stays
+    /// one block.
+    static let onBrandFill = onBrand.opacity(0.22)
 
     /// The assistant mark's body on the brand card, lighter than the card it
     /// sits on. That contrast is the only reason it is a separate value: a


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan self-review for ios-widgets.md: .never policy for terminal timeline states, privacySensitive Status counts, consolidated widget action controls and prompt text, dead lastMessageAt and url() members removed, on-brand colors in WidgetTheme, stale doc enumerations updated.