### PR TITLE
fix(voice): speak only the report back on escalated turns (JARVIS-1600)

### DIFF
--- a/assistant/src/calls/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/calls/__tests__/voice-session-bridge.test.ts
@@ -1472,7 +1472,8 @@ describe("startVoiceTurn race-loss state restore", () => {
 });
 
 describe("startVoiceTurn tool-event forwarding", () => {
-  // The agent loop's tool_use_preview_start / tool_use_start / tool_result
+  // The agent loop's tool_use_preview_start / server_tool_start /
+  // tool_use_start / tool_result
   // events reach the voice callbacks so the session can track per-turn tool
   // activity. The bridge is the single truncation point for tool results —
   // the raw result can be huge and must never travel further into the voice
@@ -1599,7 +1600,7 @@ describe("startVoiceTurn tool-event forwarding", () => {
     ]);
   });
 
-  test("tool_use_preview_start delivers the tool name and id", async () => {
+  test("tool_use_preview_start opens a tool block and delivers name and id", async () => {
     makeEventEmittingConversation([
       {
         type: "tool_use_preview_start",
@@ -1612,7 +1613,7 @@ describe("startVoiceTurn tool-event forwarding", () => {
     await startVoiceTurn({
       ...makeTurnOptions(),
       callbacks: {
-        tool_use_preview_start: (toolName, toolUseId) =>
+        tool_block_opened: (toolName, toolUseId) =>
           previews.push({ toolName, toolUseId }),
       },
     });
@@ -1623,7 +1624,63 @@ describe("startVoiceTurn tool-event forwarding", () => {
     ]);
   });
 
-  test("a turn with no tool calls never fires tool_use_preview_start", async () => {
+  test("server_tool_start opens a tool block too, keyed by its own name field", async () => {
+    // Provider-native tools (web search and friends) emit server_tool_start
+    // and never a preview event, and the event names the tool as `name`, not
+    // `toolName`. A consumer wired only to tool_use_preview_start would miss
+    // every block boundary on such a turn.
+    makeEventEmittingConversation([
+      {
+        type: "server_tool_start",
+        name: "web_search",
+        toolUseId: "srvtoolu-1",
+        input: { query: "weather" },
+      },
+    ]);
+
+    const opened: Array<{ toolName: string; toolUseId: string }> = [];
+    await startVoiceTurn({
+      ...makeTurnOptions(),
+      callbacks: {
+        tool_block_opened: (toolName, toolUseId) =>
+          opened.push({ toolName, toolUseId }),
+      },
+    });
+    await flushMicrotasks();
+
+    expect(opened).toEqual([
+      { toolName: "web_search", toolUseId: "srvtoolu-1" },
+    ]);
+  });
+
+  test("both tool block kinds open blocks, in stream order", async () => {
+    makeEventEmittingConversation([
+      {
+        type: "tool_use_preview_start",
+        toolName: "calendar_read",
+        toolUseId: "toolu-1",
+      },
+      {
+        type: "server_tool_start",
+        name: "web_search",
+        toolUseId: "srvtoolu-1",
+        input: {},
+      },
+    ]);
+
+    const opened: string[] = [];
+    await startVoiceTurn({
+      ...makeTurnOptions(),
+      callbacks: {
+        tool_block_opened: (toolName) => opened.push(toolName),
+      },
+    });
+    await flushMicrotasks();
+
+    expect(opened).toEqual(["calendar_read", "web_search"]);
+  });
+
+  test("a turn with no tool calls never opens a tool block", async () => {
     makeEventEmittingConversation([
       { type: "assistant_text_delta", text: "hello" },
     ]);
@@ -1632,7 +1689,7 @@ describe("startVoiceTurn tool-event forwarding", () => {
     await startVoiceTurn({
       ...makeTurnOptions(),
       callbacks: {
-        tool_use_preview_start: (toolName) => previews.push(toolName),
+        tool_block_opened: (toolName) => previews.push(toolName),
       },
     });
     await flushMicrotasks();
@@ -1663,7 +1720,7 @@ describe("startVoiceTurn tool-event forwarding", () => {
     await startVoiceTurn({
       ...makeTurnOptions(),
       callbacks: {
-        tool_use_preview_start: () => fired.push("preview"),
+        tool_block_opened: () => fired.push("preview"),
         tool_use_start: (toolName, detail) => {
           fired.push("start");
           starts.push({ toolName, detail });

--- a/assistant/src/calls/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/calls/__tests__/voice-session-bridge.test.ts
@@ -1624,15 +1624,16 @@ describe("startVoiceTurn tool-event forwarding", () => {
     ]);
   });
 
-  test("server_tool_start opens a tool block too, keyed by its own name field", async () => {
-    // Provider-native tools (web search and friends) emit server_tool_start
-    // and never a preview event, and the event names the tool as `name`, not
-    // `toolName`. A consumer wired only to tool_use_preview_start would miss
+  test("a provider-native tool opens a block via its translated tool_use_start", async () => {
+    // Web search and friends reach this layer as a wire `tool_use_start`: the
+    // daemon translates the loop's `server_tool_start` into one (see that case
+    // in conversation-agent-loop-handlers.ts), and no preview event is emitted
+    // for them. A consumer wired only to tool_use_preview_start would miss
     // every block boundary on such a turn.
     makeEventEmittingConversation([
       {
-        type: "server_tool_start",
-        name: "web_search",
+        type: "tool_use_start",
+        toolName: "web_search",
         toolUseId: "srvtoolu-1",
         input: { query: "weather" },
       },
@@ -1653,7 +1654,9 @@ describe("startVoiceTurn tool-event forwarding", () => {
     ]);
   });
 
-  test("both tool block kinds open blocks, in stream order", async () => {
+  test("a client tool that previews and then starts opens its block once", async () => {
+    // Both events describe the same call, so opening twice would advance the
+    // consumer's block counter past the block the following text belongs to.
     makeEventEmittingConversation([
       {
         type: "tool_use_preview_start",
@@ -1661,10 +1664,16 @@ describe("startVoiceTurn tool-event forwarding", () => {
         toolUseId: "toolu-1",
       },
       {
-        type: "server_tool_start",
-        name: "web_search",
+        type: "tool_use_start",
+        toolName: "calendar_read",
+        toolUseId: "toolu-1",
+        input: { day: "today" },
+      },
+      {
+        type: "tool_use_start",
+        toolName: "web_search",
         toolUseId: "srvtoolu-1",
-        input: {},
+        input: { query: "weather" },
       },
     ]);
 

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -251,17 +251,23 @@ export interface VoiceTurnCallbacks {
     detail?: { toolUseId?: string; input?: Record<string, unknown> },
   ) => void;
   /**
-   * Fired when the provider OPENS a tool-use content block, before its input
-   * JSON streams - earlier and weaker than `tool_use_start`, which waits for a
-   * definitive, parsed call.
+   * Fired when the provider OPENS any tool block, before its input streams -
+   * earlier and weaker than `tool_use_start`, which waits for a definitive,
+   * parsed call.
    *
    * Consumers must not use this to display or act on a tool: the call may
    * never materialize. It is a structural signal about the RESPONSE, not the
-   * tool - once a tool-use block opens, the text block before it is closed, so
-   * any text streamed since the last block boundary was working commentary
-   * rather than the turn's answer.
+   * tool - once a tool block opens, the text block before it is closed, so any
+   * text streamed since the last block boundary was working commentary rather
+   * than the turn's answer.
+   *
+   * Both client-executed tools (`tool_use_preview_start`) and provider-native
+   * ones such as web search (`server_tool_start`) fire this. They are one
+   * concept here deliberately: a consumer that tracked only the former would
+   * silently miss every block boundary on a server-tool turn, and the text
+   * before that boundary would be misread as part of the answer.
    */
-  tool_use_preview_start?: (toolName: string, toolUseId: string) => void;
+  tool_block_opened?: (toolName: string, toolUseId: string) => void;
   /** Fired when a tool invocation finishes. */
   tool_result?: (event: VoiceToolResultEvent) => void;
 }
@@ -1718,10 +1724,12 @@ export async function startVoiceTurn(
             // structural signal about the response. Activity display stays on
             // the definitive `tool_use_start`, which is the only tool event a
             // consumer may show or act on.
-            opts.callbacks?.tool_use_preview_start?.(
-              msg.toolName,
-              msg.toolUseId,
-            );
+            opts.callbacks?.tool_block_opened?.(msg.toolName, msg.toolUseId);
+          } else if (msg.type === "server_tool_start") {
+            // A provider-native tool (web search and friends) opens a block the
+            // same way, and there is no preview event for it. Same boundary,
+            // same callback: text before it is commentary, not the answer.
+            opts.callbacks?.tool_block_opened?.(msg.name, msg.toolUseId);
           } else if (msg.type === "tool_result") {
             eventSink.onToolResult({
               toolName: msg.toolName,

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -1675,6 +1675,29 @@ export async function startVoiceTurn(
         conversation.toolsDisabledDepth++;
         frontDoorToolsSuppressed = true;
       }
+      // One block-open per tool call, whichever wire event announces it first.
+      // A client tool previews and then starts; a provider-native tool only
+      // ever starts. Firing twice for the same call would advance the
+      // consumer's block counter past the block the text actually belongs to.
+      const openedToolBlocks = new Set<string>();
+      const openToolBlock = (
+        toolName: string,
+        toolUseId: string | undefined,
+      ): void => {
+        // An id is what makes the two events for one call recognizable as one
+        // call. Without it there is nothing to dedupe on, so the block still
+        // opens: a missed boundary would misread commentary as the answer,
+        // which is worse than an extra boundary between blocks that hold no
+        // text anyway.
+        if (toolUseId !== undefined) {
+          if (openedToolBlocks.has(toolUseId)) {
+            return;
+          }
+          openedToolBlocks.add(toolUseId);
+        }
+        opts.callbacks?.tool_block_opened?.(toolName, toolUseId ?? "");
+      };
+
       await conversation.runAgentLoop(persistedContent, messageId, {
         onEvent: (msg: AssistantEvent) => {
           if (msg.type === "assistant_turn_start") {
@@ -1718,18 +1741,20 @@ export async function startVoiceTurn(
             eventSink.onError(msg.userMessage);
           } else if (msg.type === "tool_use_start") {
             eventSink.onToolUse(msg.toolName, msg.input, msg.toolUseId);
+            // Also a block boundary, and for a provider-native tool it is the
+            // ONLY one: the daemon translates the loop's `server_tool_start`
+            // into a wire `tool_use_start` (see the `server_tool_start` case in
+            // conversation-agent-loop-handlers.ts), so web search and friends
+            // never produce a preview event. `openToolBlock` dedupes, so a
+            // client tool that previewed first does not open twice.
+            openToolBlock(msg.toolName, msg.toolUseId);
           } else if (msg.type === "tool_use_preview_start") {
             // Routed through `opts.callbacks` rather than `eventSink`: the
             // sink is the phone-shaped surface, and this is a live-voice-only
             // structural signal about the response. Activity display stays on
             // the definitive `tool_use_start`, which is the only tool event a
             // consumer may show or act on.
-            opts.callbacks?.tool_block_opened?.(msg.toolName, msg.toolUseId);
-          } else if (msg.type === "server_tool_start") {
-            // A provider-native tool (web search and friends) opens a block the
-            // same way, and there is no preview event for it. Same boundary,
-            // same callback: text before it is commentary, not the answer.
-            opts.callbacks?.tool_block_opened?.(msg.name, msg.toolUseId);
+            openToolBlock(msg.toolName, msg.toolUseId);
           } else if (msg.type === "tool_result") {
             eventSink.onToolResult({
               toolName: msg.toolName,

--- a/assistant/src/live-voice/__tests__/live-voice-tts-session.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-tts-session.test.ts
@@ -249,7 +249,7 @@ const REPORT_QUESTION = "Which calendar should I check, work or personal?";
 /**
  * Drive a turn through the escalate verdict and hand back the escalated leg's
  * bridge options, so a test can script that leg block by block: text deltas,
- * `tool_use_preview_start` for a tool-use block opening, and completion.
+ * `tool_block_opened` for a tool block opening, and completion.
  */
 async function startEscalatedTurn(
   streamTtsAudio: LiveVoiceTtsStreamer,
@@ -1233,9 +1233,9 @@ describe("LiveVoiceSession escalated-turn speech", () => {
     // Two working blocks, each closed by a tool-use block opening, then the
     // block nothing follows: the turn's report back.
     legs?.assistant_text_delta?.(makeTextDelta(`${FIRST_COMMENTARY} `));
-    legs?.tool_use_preview_start?.("calendar_read", "toolu-1");
+    legs?.tool_block_opened?.("calendar_read", "toolu-1");
     legs?.assistant_text_delta?.(makeTextDelta(`${SECOND_COMMENTARY} `));
-    legs?.tool_use_preview_start?.("calendar_read", "toolu-2");
+    legs?.tool_block_opened?.("calendar_read", "toolu-2");
     legs?.assistant_text_delta?.(makeTextDelta(REPORT_SENTENCE));
     legs?.message_complete?.(makeMessageComplete());
     await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
@@ -1254,6 +1254,31 @@ describe("LiveVoiceSession escalated-turn speech", () => {
     expect(transcript).toContain(FIRST_COMMENTARY);
     expect(transcript).toContain(SECOND_COMMENTARY);
     expect(transcript).toContain(REPORT_SENTENCE);
+  });
+
+  test("a provider-native tool closes a block like any other", async () => {
+    // Web search and friends arrive as server_tool_start rather than a
+    // preview event. The bridge routes both to tool_block_opened, so from
+    // here a provider-native tool is not a special case at all: this asserts
+    // the session treats that boundary like any other. That the bridge
+    // actually routes it is asserted in voice-session-bridge.test.ts.
+    const { streamTtsAudio, synthesized } = createEchoTtsStreamer();
+    const { frames, escalated } = await startEscalatedTurn(streamTtsAudio);
+    const legs = escalated.callbacks;
+
+    legs?.assistant_text_delta?.(makeTextDelta(`${FIRST_COMMENTARY} `));
+    legs?.tool_block_opened?.("web_search", "srvtoolu-1");
+    legs?.assistant_text_delta?.(makeTextDelta(REPORT_SENTENCE));
+    legs?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    expect(ttsAudioPayloads(frames)).toEqual([
+      b64(`audio:${BRIDGE_SENTENCE}`),
+      b64(`audio:${REPORT_SENTENCE}`),
+    ]);
+    expect(synthesizedTexts(synthesized)).toContain(FIRST_COMMENTARY);
+    // Holding is a TTS-only concern here too: the transcript keeps every word.
+    expect(assistantTranscript(frames)).toContain(FIRST_COMMENTARY);
   });
 
   test("a direct front-door answer is unchanged", async () => {
@@ -1295,7 +1320,7 @@ describe("LiveVoiceSession escalated-turn speech", () => {
     const legs = escalated.callbacks;
 
     legs?.assistant_text_delta?.(makeTextDelta(`${FIRST_COMMENTARY} `));
-    legs?.tool_use_preview_start?.("calendar_read", "toolu-1");
+    legs?.tool_block_opened?.("calendar_read", "toolu-1");
     await flushAsyncCallbacks();
     legs?.assistant_text_delta?.(makeTextDelta(REPORT_SENTENCE));
     await waitFor(() =>
@@ -1325,7 +1350,7 @@ describe("LiveVoiceSession escalated-turn speech", () => {
     const legs = escalated.callbacks;
 
     legs?.assistant_text_delta?.(makeTextDelta(`${FIRST_COMMENTARY} `));
-    legs?.tool_use_preview_start?.("calendar_read", "toolu-1");
+    legs?.tool_block_opened?.("calendar_read", "toolu-1");
     legs?.assistant_text_delta?.(makeTextDelta(REPORT_QUESTION));
     legs?.message_complete?.(makeMessageComplete());
     await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
@@ -1357,7 +1382,7 @@ describe("LiveVoiceSession escalated-turn speech", () => {
       b64(`audio:${approvalPhrase}`),
     ]);
 
-    legs?.tool_use_preview_start?.("send_email", "toolu-1");
+    legs?.tool_block_opened?.("send_email", "toolu-1");
     legs?.assistant_text_delta?.(makeTextDelta(REPORT_SENTENCE));
     legs?.message_complete?.(makeMessageComplete());
     await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
@@ -1389,7 +1414,7 @@ describe("LiveVoiceSession escalated-turn speech", () => {
 
     // Retracting it makes it unhearable at once, even though the provider is
     // still sitting on the aborted stream, so the tool phase reads idle.
-    legs?.tool_use_preview_start?.("calendar_read", "toolu-1");
+    legs?.tool_block_opened?.("calendar_read", "toolu-1");
     expect(held.audioIdle()).toBe(true);
 
     legs?.assistant_text_delta?.(makeTextDelta(REPORT_SENTENCE));
@@ -1414,7 +1439,7 @@ describe("LiveVoiceSession escalated-turn speech", () => {
     );
 
     legs?.assistant_text_delta?.(makeTextDelta(`${FIRST_COMMENTARY} `));
-    legs?.tool_use_preview_start?.("calendar_read", "toolu-1");
+    legs?.tool_block_opened?.("calendar_read", "toolu-1");
     await flushAsyncCallbacks();
 
     const bridgeCall = synthesized.find(

--- a/assistant/src/live-voice/__tests__/live-voice-tts-session.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-tts-session.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, mock, test } from "bun:test";
 
+import { sanitizeForTts } from "../../calls/tts-text-sanitizer.js";
 import type {
   VoiceTurnCallbacks,
   VoiceTurnOptions,
 } from "../../calls/voice-session-bridge.js";
+import { ESCALATION_CONTINUATION_CONTENT } from "../../calls/voice-triage-escalate.js";
 import type {
   StreamingTranscriber,
   SttStreamServerEvent,
@@ -19,6 +21,7 @@ import type {
   LiveVoiceTtsOptions,
   LiveVoiceTtsResult,
 } from "../live-voice-tts.js";
+import { approvalPendingPhraseFor } from "../progress-phrases.js";
 import {
   createLiveVoiceServerFrameSequencer,
   type LiveVoiceClientStartFrame,
@@ -214,6 +217,82 @@ function createControlledTtsStreamer(): {
   return { streamTtsAudio, calls, events };
 }
 
+// A TTS streamer that answers every segment with one chunk and settles at
+// once. `synthesized` is what reached the provider, which on a held segment
+// is deliberately a different set from what the client hears.
+function createEchoTtsStreamer(): {
+  streamTtsAudio: LiveVoiceTtsStreamer;
+  synthesized: LiveVoiceTtsOptions[];
+} {
+  const synthesized: LiveVoiceTtsOptions[] = [];
+  const streamTtsAudio = mock(async (options: LiveVoiceTtsOptions) => {
+    synthesized.push(options);
+    options.onAudioChunk(makeTtsChunk(`audio:${options.text}`));
+    return makeTtsResult(options.text);
+  });
+  return { streamTtsAudio, synthesized };
+}
+
+function synthesizedTexts(synthesized: LiveVoiceTtsOptions[]): string[] {
+  return synthesized.map((options) => options.text);
+}
+
+// The front-door leg's escalate verdict plus the bridge it speaks across the
+// hand-off, and the sentences an escalated leg says while it works.
+const ESCALATE_VERDICT_DELTA = "[1] Let me look into that.";
+const BRIDGE_SENTENCE = "Let me look into that.";
+const FIRST_COMMENTARY = "Checking your calendar now.";
+const SECOND_COMMENTARY = "Now looking at tomorrow as well.";
+const REPORT_SENTENCE = "You have two meetings tomorrow.";
+const REPORT_QUESTION = "Which calendar should I check, work or personal?";
+
+/**
+ * Drive a turn through the escalate verdict and hand back the escalated leg's
+ * bridge options, so a test can script that leg block by block: text deltas,
+ * `tool_use_preview_start` for a tool-use block opening, and completion.
+ */
+async function startEscalatedTurn(
+  streamTtsAudio: LiveVoiceTtsStreamer,
+): Promise<{
+  frames: LiveVoiceServerFrame[];
+  session: LiveVoiceSession;
+  escalated: VoiceTurnOptions;
+}> {
+  let frontDoor: VoiceTurnCallbacks | undefined;
+  let escalated: VoiceTurnOptions | undefined;
+  const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+    if (options.content === ESCALATION_CONTINUATION_CONTENT) {
+      escalated = options;
+      return { turnId: "bridge-escalated", abort: mock() };
+    }
+    frontDoor = options.callbacks;
+    return { turnId: "bridge-front-door", abort: mock() };
+  });
+  const { frames, session } = createSessionHarness({
+    startVoiceTurn,
+    streamTtsAudio,
+  });
+
+  await startReleasedTurn(session);
+  frontDoor?.assistant_text_delta?.(makeTextDelta(ESCALATE_VERDICT_DELTA));
+  await waitFor(
+    () => escalated !== undefined,
+    "Timed out waiting for the escalated leg to start",
+  );
+  if (!escalated) {
+    throw new Error("Escalated leg never started");
+  }
+  return { frames, session, escalated };
+}
+
+function assistantTranscript(frames: LiveVoiceServerFrame[]): string {
+  return frames
+    .flatMap((frame) =>
+      frame.type === "assistant_text_delta" ? [frame.text] : [],
+    )
+    .join("");
+}
+
 // The slice of a TtsSegmentJob a held-segment selector can see. Kept
 // structural so the test does not need the session's private job type.
 interface HeldJobView {
@@ -226,9 +305,10 @@ interface TurnView {
   readonly ttsBuffer: string;
 }
 
-// Held segments have no production caller yet, so the tests drive the private
-// hold/promote/retract surface directly against the turn that
-// `startReleasedTurn` left active.
+// Drives the private hold/promote/retract surface directly against the turn
+// that `startReleasedTurn` left active, for the queue mechanics an escalated
+// turn cannot script on its own (a segment held past completion, a provider
+// that ignores its abort).
 function heldTtsController(session: LiveVoiceSession): {
   enqueue: (text: string) => void;
   promote: (select: (job: HeldJobView) => boolean) => number;
@@ -1141,5 +1221,252 @@ describe("LiveVoiceSession TTS", () => {
     callbacks?.message_complete?.(makeMessageComplete());
     await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
     expect(ttsAudioPayloads(frames)).toEqual([]);
+  });
+});
+
+describe("LiveVoiceSession escalated-turn speech", () => {
+  test("no commentary is ever audible on an escalated turn", async () => {
+    const { streamTtsAudio, synthesized } = createEchoTtsStreamer();
+    const { frames, escalated } = await startEscalatedTurn(streamTtsAudio);
+    const legs = escalated.callbacks;
+
+    // Two working blocks, each closed by a tool-use block opening, then the
+    // block nothing follows: the turn's report back.
+    legs?.assistant_text_delta?.(makeTextDelta(`${FIRST_COMMENTARY} `));
+    legs?.tool_use_preview_start?.("calendar_read", "toolu-1");
+    legs?.assistant_text_delta?.(makeTextDelta(`${SECOND_COMMENTARY} `));
+    legs?.tool_use_preview_start?.("calendar_read", "toolu-2");
+    legs?.assistant_text_delta?.(makeTextDelta(REPORT_SENTENCE));
+    legs?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    // The hard guarantee: the caller hears the hand-off bridge and the
+    // report, and no part of the play-by-play in between.
+    expect(ttsAudioPayloads(frames)).toEqual([
+      b64(`audio:${BRIDGE_SENTENCE}`),
+      b64(`audio:${REPORT_SENTENCE}`),
+    ]);
+    // The commentary was synthesized (that is what makes a promotion
+    // instant), it just never reached the client.
+    expect(synthesizedTexts(synthesized)).toContain(FIRST_COMMENTARY);
+    // Holding is a TTS-only concern: the transcript still carries every word.
+    const transcript = assistantTranscript(frames);
+    expect(transcript).toContain(FIRST_COMMENTARY);
+    expect(transcript).toContain(SECOND_COMMENTARY);
+    expect(transcript).toContain(REPORT_SENTENCE);
+  });
+
+  test("a direct front-door answer is unchanged", async () => {
+    let callbacks: VoiceTurnCallbacks | undefined;
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      callbacks = options.callbacks;
+      return { turnId: "bridge-turn-1", abort: mock() };
+    });
+    const { streamTtsAudio } = createEchoTtsStreamer();
+    const { frames, session } = createSessionHarness({
+      startVoiceTurn,
+      streamTtsAudio,
+    });
+
+    await startReleasedTurn(session);
+    callbacks?.assistant_text_delta?.(
+      makeTextDelta("Sure, I can help with that, and here is the rest."),
+    );
+
+    // A front-door answer is never held, so the eager first-clause flush
+    // still speaks before the message completes.
+    await waitFor(() => frames.some((frame) => frame.type === "tts_audio"));
+    expect(ttsAudioPayloads(frames)[0]).toBe(
+      b64("audio:Sure, I can help with that,"),
+    );
+    expect(frames.some((frame) => frame.type === "tts_done")).toBe(false);
+
+    callbacks?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+    expect(ttsAudioPayloads(frames)).toEqual([
+      b64("audio:Sure, I can help with that,"),
+      b64("audio:and here is the rest."),
+    ]);
+  });
+
+  test("the report's first segment is pre-synthesized", async () => {
+    const { streamTtsAudio, synthesized } = createEchoTtsStreamer();
+    const { frames, escalated } = await startEscalatedTurn(streamTtsAudio);
+    const legs = escalated.callbacks;
+
+    legs?.assistant_text_delta?.(makeTextDelta(`${FIRST_COMMENTARY} `));
+    legs?.tool_use_preview_start?.("calendar_read", "toolu-1");
+    await flushAsyncCallbacks();
+    legs?.assistant_text_delta?.(makeTextDelta(REPORT_SENTENCE));
+    await waitFor(() =>
+      synthesizedTexts(synthesized).includes(REPORT_SENTENCE),
+    );
+
+    // Synthesis of the report runs while the leg is still streaming; only
+    // its emission waits for completion.
+    expect(ttsAudioPayloads(frames)).toEqual([b64(`audio:${BRIDGE_SENTENCE}`)]);
+
+    legs?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    expect(ttsAudioPayloads(frames)).toEqual([
+      b64(`audio:${BRIDGE_SENTENCE}`),
+      b64(`audio:${REPORT_SENTENCE}`),
+    ]);
+    // Promotion emits the audio it already has rather than re-synthesizing.
+    expect(
+      synthesizedTexts(synthesized).filter((text) => text === REPORT_SENTENCE),
+    ).toHaveLength(1);
+  });
+
+  test("a mid-turn question is spoken like an answer", async () => {
+    const { streamTtsAudio } = createEchoTtsStreamer();
+    const { frames, escalated } = await startEscalatedTurn(streamTtsAudio);
+    const legs = escalated.callbacks;
+
+    legs?.assistant_text_delta?.(makeTextDelta(`${FIRST_COMMENTARY} `));
+    legs?.tool_use_preview_start?.("calendar_read", "toolu-1");
+    legs?.assistant_text_delta?.(makeTextDelta(REPORT_QUESTION));
+    legs?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    // Coming back with a question the turn needs answered is a report back
+    // like any other: nothing followed it, so it is spoken.
+    expect(ttsAudioPayloads(frames)).toEqual([
+      b64(`audio:${BRIDGE_SENTENCE}`),
+      b64(`audio:${REPORT_QUESTION}`),
+    ]);
+  });
+
+  test("the approval-pending phrase is never held", async () => {
+    const { streamTtsAudio } = createEchoTtsStreamer();
+    const { frames, escalated } = await startEscalatedTurn(streamTtsAudio);
+    const legs = escalated.callbacks;
+    const approvalPhrase = sanitizeForTts(approvalPendingPhraseFor()).trim();
+
+    legs?.assistant_text_delta?.(makeTextDelta(`${FIRST_COMMENTARY} `));
+    escalated.onApprovalPending?.("approval-request-1");
+
+    // The line exists to be heard during the wait, so it speaks straight
+    // away while the block beside it is still held.
+    await waitFor(() =>
+      ttsAudioPayloads(frames).includes(b64(`audio:${approvalPhrase}`)),
+    );
+    expect(ttsAudioPayloads(frames)).toEqual([
+      b64(`audio:${BRIDGE_SENTENCE}`),
+      b64(`audio:${approvalPhrase}`),
+    ]);
+
+    legs?.tool_use_preview_start?.("send_email", "toolu-1");
+    legs?.assistant_text_delta?.(makeTextDelta(REPORT_SENTENCE));
+    legs?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    // The retraction that dropped the commentary left the phrase alone.
+    expect(ttsAudioPayloads(frames)).toEqual([
+      b64(`audio:${BRIDGE_SENTENCE}`),
+      b64(`audio:${approvalPhrase}`),
+      b64(`audio:${REPORT_SENTENCE}`),
+    ]);
+  });
+
+  test("a held escalated block blocks the idle gate and its retraction clears it", async () => {
+    const { streamTtsAudio, calls } = createControlledTtsStreamer();
+    const { frames, session, escalated } =
+      await startEscalatedTurn(streamTtsAudio);
+    const legs = escalated.callbacks;
+    const held = heldTtsController(session);
+
+    // The bridge settles without ever producing a chunk, so no playback-tail
+    // estimate stands between the turn and the idle gate.
+    calls[0]?.finish();
+    await waitFor(() => held.audioIdle());
+
+    // A held block is seconds from being spoken, so the turn is quiet rather
+    // than idle and the working cue must not talk over it.
+    legs?.assistant_text_delta?.(makeTextDelta(`${FIRST_COMMENTARY} `));
+    expect(held.audioIdle()).toBe(false);
+
+    // Retracting it makes it unhearable at once, even though the provider is
+    // still sitting on the aborted stream, so the tool phase reads idle.
+    legs?.tool_use_preview_start?.("calendar_read", "toolu-1");
+    expect(held.audioIdle()).toBe(true);
+
+    legs?.assistant_text_delta?.(makeTextDelta(REPORT_SENTENCE));
+    expect(held.audioIdle()).toBe(false);
+
+    legs?.message_complete?.(makeMessageComplete());
+    await waitFor(() => calls.length >= 3);
+    calls[2]?.finish();
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+    expect(ttsAudioPayloads(frames)).toEqual([]);
+  });
+
+  test("the escalation bridge is never held or retracted", async () => {
+    const { streamTtsAudio, synthesized } = createEchoTtsStreamer();
+    const { frames, escalated } = await startEscalatedTurn(streamTtsAudio);
+    const legs = escalated.callbacks;
+
+    // The bridge is spoken during the tool phase, which is the whole point
+    // of it: it covers the silence the escalated leg is about to create.
+    await waitFor(() =>
+      ttsAudioPayloads(frames).includes(b64(`audio:${BRIDGE_SENTENCE}`)),
+    );
+
+    legs?.assistant_text_delta?.(makeTextDelta(`${FIRST_COMMENTARY} `));
+    legs?.tool_use_preview_start?.("calendar_read", "toolu-1");
+    await flushAsyncCallbacks();
+
+    const bridgeCall = synthesized.find(
+      (options) => options.text === BRIDGE_SENTENCE,
+    );
+    expect(bridgeCall?.signal?.aborted).toBe(false);
+    expect(ttsAudioPayloads(frames)).toEqual([b64(`audio:${BRIDGE_SENTENCE}`)]);
+
+    legs?.assistant_text_delta?.(makeTextDelta(REPORT_SENTENCE));
+    legs?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+    expect(ttsAudioPayloads(frames)).toEqual([
+      b64(`audio:${BRIDGE_SENTENCE}`),
+      b64(`audio:${REPORT_SENTENCE}`),
+    ]);
+  });
+
+  test("a cancelled escalated turn speaks nothing", async () => {
+    const { streamTtsAudio, calls } = createControlledTtsStreamer();
+    const { frames, escalated } = await startEscalatedTurn(streamTtsAudio);
+    const legs = escalated.callbacks;
+
+    // The bridge settles silently, so nothing at all has been heard yet.
+    calls[0]?.finish();
+    legs?.assistant_text_delta?.(makeTextDelta(`${FIRST_COMMENTARY} `));
+    await waitFor(() => calls.length >= 2);
+
+    legs?.message_complete?.({
+      type: "generation_cancelled",
+      conversationId: "conversation-123",
+    });
+    await flushAsyncCallbacks();
+
+    // The held block dies with the turn: nothing is promoted, and its
+    // provider stream is torn down rather than left running.
+    expect(calls[1]?.options.signal?.aborted).toBe(true);
+    expect(ttsAudioPayloads(frames)).toEqual([]);
+    expect(frames.some((frame) => frame.type === "tts_done")).toBe(false);
+  });
+
+  test("an escalated turn with no tool calls speaks its single block", async () => {
+    const { streamTtsAudio } = createEchoTtsStreamer();
+    const { frames, escalated } = await startEscalatedTurn(streamTtsAudio);
+    const legs = escalated.callbacks;
+
+    legs?.assistant_text_delta?.(makeTextDelta(REPORT_SENTENCE));
+    legs?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    expect(ttsAudioPayloads(frames)).toEqual([
+      b64(`audio:${BRIDGE_SENTENCE}`),
+      b64(`audio:${REPORT_SENTENCE}`),
+    ]);
   });
 });

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -4999,7 +4999,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
             }
             current.assistantMessageId = messageId;
           },
-          tool_use_preview_start: (toolName) => {
+          tool_block_opened: (toolName) => {
             const current = this.activeAssistantTurn;
             if (current?.token !== token || leg.routingLeg !== "escalated") {
               return;

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -513,6 +513,12 @@ type UtteranceStartResult =
   | { status: "unavailable"; message: string }
   | { status: "error"; message: string };
 
+// The block sequence for a segment that came from no model text block: a
+// fixed session phrase (the escalation bridge, the approval-pending line,
+// progress narration). Those exist to be heard while the turn works, so they
+// are never held, and no block-scoped selector can ever match them.
+const NON_BLOCK_TTS_SEQ = -1;
+
 // One TTS segment flowing through the turn's synthesis pipeline. Synthesis
 // may run ahead of the emission slot (prefetch), but frames only reach the
 // client in job-list order.
@@ -523,6 +529,10 @@ interface TtsSegmentJob {
   // the English fallback text carries "en" so an enforcing provider never
   // renders English words as ar/ko/ta. Undefined means the turn language.
   readonly language: string | undefined;
+  // Which of the leg's model text blocks this segment came from, so a
+  // block-scoped promotion or retraction selects exactly that block's
+  // segments. NON_BLOCK_TTS_SEQ marks a segment that belongs to no block.
+  readonly blockSeq: number;
   // The provider stream was started (the job holds an open-job slot).
   started: boolean;
   // The provider is done with this job, either because emission finished or
@@ -742,6 +752,14 @@ interface ActiveAssistantTurn {
   // front-door leg's trailing completion from finalizing the turn, and makes
   // the hand-off idempotent.
   escalationHandedOff: boolean;
+  // The leg currently streaming into this turn. An escalated leg is doing
+  // work, so its model text is held until the turn's shape says whether that
+  // text was working commentary or the report back.
+  routingLeg: VoiceRoutingLeg;
+  // Which of the current leg's model text blocks the turn is accumulating.
+  // A tool-use block opening closes the current one and bumps this, so each
+  // block's held segments are selectable as a unit.
+  textBlockSeq: number;
   ttsBuffer: string;
   // The turn is finalizing its TTS: every remaining enqueue is terminal by
   // construction, so holds are ignored past this point (see
@@ -852,6 +870,13 @@ const LIVE_VOICE_SCREEN_REVEAL_TEACHING =
 const LIVE_VOICE_SETUP_FLOW_TEACHING =
   "This includes connecting accounts. If a task needs an account connected or a sign-in completed, put the connection up on screen and let the user do it now. Do not decline it, and do not defer it to text chat. Say what you are connecting and that it is in front of them. ";
 
+// Holding stops the caller hearing the working commentary; nothing makes the
+// closing report short. A one-time instruction, not a per-block protocol the
+// model must keep executing. It also directly bounds the report's onset
+// delay, since the hold ends when this block finishes generating.
+const LIVE_VOICE_SPOKEN_CLOSE_TEACHING =
+  "You already told the caller you were on it, and they have heard nothing since. When you finish, close with one or two short sentences saying what you did or what you found: the result, not the route you took to it. If you need something from them to continue, ask for everything you need in one go. ";
+
 // System-level guidance appended to a barge-in turn's control prompt so the
 // model treats the new utterance as a continuation of the request it was cut
 // off answering, rather than a fresh follow-up. Reaches the model only; it is
@@ -909,9 +934,10 @@ function buildLiveDeliveryNote(request: string, answer: string): string {
 }
 
 // Assemble a leg's model-facing control prompt: the base live-voice rules, the
-// screen-reveal and setup-flow teaching (both withheld from the front-door leg,
-// see LIVE_VOICE_SCREEN_REVEAL_TEACHING), plus any pending barge-in merge
-// context, completed-continuation context, and/or the announcement instruction.
+// screen-reveal, setup-flow, and spoken-close teaching (all withheld from the
+// front-door leg, see LIVE_VOICE_SCREEN_REVEAL_TEACHING), plus any pending
+// barge-in merge context, completed-continuation context, and/or the
+// announcement instruction.
 // A turn can carry several (a barge-in follow-up that also has a continuation
 // result waiting); the notes are model-only and never render as user bubbles.
 function buildVoiceControlPrompt(
@@ -922,7 +948,9 @@ function buildVoiceControlPrompt(
     LIVE_VOICE_CONTROL_PROMPT_BASE +
     (leg.frontDoor === true
       ? ""
-      : LIVE_VOICE_SCREEN_REVEAL_TEACHING + LIVE_VOICE_SETUP_FLOW_TEACHING);
+      : LIVE_VOICE_SCREEN_REVEAL_TEACHING +
+        LIVE_VOICE_SETUP_FLOW_TEACHING +
+        LIVE_VOICE_SPOKEN_CLOSE_TEACHING);
   if (turn.language !== undefined) {
     prompt = `${prompt}\n\nThe caller has been speaking the language with code "${turn.language}" this turn. Reply in that language unless they clearly switch to another.`;
   }
@@ -4583,6 +4611,8 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       continuationDelivery: opts?.continuationDelivery ?? null,
       deltaEpoch: 0,
       escalationHandedOff: false,
+      routingLeg: "front-door",
+      textBlockSeq: 0,
       ttsBuffer: "",
       ttsCompleting: false,
       ttsReasoningFilter: createReasoningTagFilter(),
@@ -4695,6 +4725,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       return false;
     }
     const { token, utterance, turnId } = activeTurn;
+    // Set before anything of this leg can stream, so the TTS path knows which
+    // leg's text it is segmenting. The escalation bridge is enqueued before
+    // this runs, which is what keeps it on the front-door leg's terms.
+    activeTurn.routingLeg = leg.routingLeg ?? "front-door";
 
     // `rawText` accumulates this leg's full stream. A front-door leg starts
     // in `deciding` until its leading tokens classify as hold / escalate /
@@ -4916,9 +4950,28 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
             // emitted rather than dropped.
             if (!leg.frontDoor && msg.type === "message_complete") {
               flushLegText(rawText, { force: true });
+              if (leg.routingLeg === "escalated") {
+                // Nothing followed this block, so it is the turn's report
+                // back: the answer, or the question it needs answered. Its
+                // first segment is already synthesized, so promotion starts
+                // audio without a TTS round trip. Ordering is load-bearing:
+                // the force-flush above segments the block's tail first, and
+                // this runs before assistantCompleted closes the TTS path.
+                this.promoteHeldTtsSegments(
+                  token,
+                  (job) => job.blockSeq === current.textBlockSeq,
+                );
+              }
             }
             current.assistantCompleted = true;
             if (msg.type === "generation_cancelled") {
+              // The turn produced no report, so its held blocks have nothing
+              // to be promoted onto. Retracting them here tears their
+              // provider streams down at once rather than leaving them
+              // running behind a cancelled turn.
+              this.retractHeldTtsSegments(token, (job) => job.held, {
+                discardPendingTail: true,
+              });
               void this.finalizeAssistantTurn(
                 current,
                 "cancelled",
@@ -4945,6 +4998,29 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
               return;
             }
             current.assistantMessageId = messageId;
+          },
+          tool_use_preview_start: (toolName) => {
+            const current = this.activeAssistantTurn;
+            if (current?.token !== token || leg.routingLeg !== "escalated") {
+              return;
+            }
+            // The provider opened a tool-use block, so the text block before
+            // it is closed and was working commentary, not this turn's
+            // report. It was never emitted, so dropping it is silent.
+            // Deterministic: this reads the response structure, not the text.
+            const seq = current.textBlockSeq;
+            const dropped = this.retractHeldTtsSegments(
+              token,
+              (job) => job.blockSeq === seq,
+              // The retraction owns the block's un-segmented tail: text short
+              // of a segment boundary is still this block's commentary.
+              { discardPendingTail: true },
+            );
+            current.textBlockSeq += 1;
+            log.debug(
+              { turnId, toolName, dropped },
+              "Dropped held commentary segments at tool-use block open",
+            );
           },
           tool_use_start: (toolName, detail) => {
             const current = this.activeAssistantTurn;
@@ -5175,6 +5251,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         { type: "assistant_text_delta", text: spokenBridge },
         () => !activeTurn.abortController.signal.aborted && !this.isClosed,
       );
+      // Enqueued while the turn is still on the front-door leg, so the bridge
+      // is not held: it is the one thing the caller is meant to hear before
+      // the escalated leg reports back, and only held segments can be
+      // retracted.
       this.bufferAssistantTextForTts(activeTurn.token, `${spokenBridge} `);
       // Force-flush now: on the TTS path an unpunctuated bridge would
       // otherwise sit buffered until a sentence boundary and leave the
@@ -5187,6 +5267,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       const speakable = sanitizeForTts(spokenBridge).trim();
       if (speakable.length > 0) {
         this.enqueueTtsSegment(activeTurn.token, speakable, {
+          blockSeq: NON_BLOCK_TTS_SEQ,
           language: this.fixedPhraseLanguage(
             activeTurn,
             FALLBACK_ESCALATION_BRIDGE_BY_LANGUAGE,
@@ -5553,6 +5634,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     }
     this.enqueueTtsSegment(turn.token, phrase, {
       countsAsFirstSegment: false,
+      // A filler exists to be heard while the turn works, so it is never held
+      // and never retracted with the block it happens to land beside.
+      blockSeq: NON_BLOCK_TTS_SEQ,
       ...(language !== undefined ? { language } : {}),
     });
     // A spoken filler holds the floor, so narration's minGapMs spaces from it.
@@ -5819,7 +5903,13 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       if (speakable.length === 0) {
         continue;
       }
-      this.enqueueTtsSegment(token, speakable);
+      // An escalated leg is working, so what it says mid-turn is usually
+      // commentary on that work rather than the answer. Hold it: it is
+      // synthesized now (so promotion costs no provider round trip) and only
+      // the block the turn ends on is ever spoken.
+      this.enqueueTtsSegment(token, speakable, {
+        held: activeTurn.routingLeg === "escalated",
+      });
     }
   }
 
@@ -5833,6 +5923,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       // provider but stays off the emission chain until promoteHeldTtsSegments
       // puts it there, or retractHeldTtsSegments drops it.
       held?: boolean;
+      // Which model text block the segment came from. Defaults to the block
+      // the turn is accumulating; a fixed session phrase passes
+      // NON_BLOCK_TTS_SEQ so no block-scoped selector can reach it.
+      blockSeq?: number;
     } = {},
   ): void {
     const activeTurn = this.activeAssistantTurn;
@@ -5854,6 +5948,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     const job: TtsSegmentJob = {
       text: segment,
       language: options.language,
+      blockSeq: options.blockSeq ?? activeTurn.textBlockSeq,
       started: false,
       settled: false,
       emitting: false,


### PR DESCRIPTION
## Summary
- On an escalated leg, model text is enqueued held: synthesized but kept off the emission chain.
- A tool-use block opening proves the preceding text was working commentary, so its held segments are retracted before any audio reaches the client.
- `message_complete` promotes the terminal block onto already-synthesized audio, so the report starts without a TTS round trip.
- Guarantee: no working commentary is ever audible. Transcript output is unchanged.

Part of plan: voice-speak-final-answer-only.md (PR 3 of 6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GSC7vXVsNdNLUEBRzF87bc