### PR TITLE
docs: document device access per client and route location questions through self-knowledge

### DIFF
--- a/clients/docs/src/app/docs/_components/developer-guide-features-content.tsx
+++ b/clients/docs/src/app/docs/_components/developer-guide-features-content.tsx
@@ -10,15 +10,20 @@ const TOC_ITEMS = [
   { id: "browser", label: "Browser", level: 2 },
   { id: "attachments", label: "Attachments", level: 2 },
   { id: "inline-media-embeds", label: "Inline Media Embeds", level: 2 },
+  { id: "device-access", label: "Device Access", level: 2 },
 ];
 
 export function DeveloperGuideFeaturesContent() {
   return (
     <>
-      <DocsContent title="Features & Capabilities" breadcrumb="Docs / Developer Guide / Features">
+      <DocsContent
+        title="Features & Capabilities"
+        breadcrumb="Docs / Developer Guide / Features"
+      >
         <p className="mb-8 text-zinc-600">
-          A deep dive into the platform&apos;s major feature areas — integrations, skill authoring, browser automation,
-          file attachments, and media embeds.
+          A deep dive into the platform&apos;s major feature areas —
+          integrations, skill authoring, browser automation, file attachments,
+          media embeds, and what the client apps can access on your device.
         </p>
 
         {/* Integrations */}
@@ -27,18 +32,24 @@ export function DeveloperGuideFeaturesContent() {
             Integrations
           </SectionHeading>
           <p className="mb-4 text-zinc-600">
-            Vellum integrates with third-party services via OAuth2, each exposed as a bundled skill with its own set of tools.
+            Vellum integrates with third-party services via OAuth2, each exposed
+            as a bundled skill with its own set of tools.
           </p>
           <p className="mb-4 text-zinc-600">
-            The unified messaging layer provides platform-agnostic tools (<code className="text-sm">messaging_send</code>,{" "}
-            <code className="text-sm">messaging_read</code>, <code className="text-sm">messaging_search</code>) that delegate to
-            provider adapters for Gmail, Slack, and Telegram. Platform-specific tools (e.g.{" "}
-            <code className="text-sm">gmail_archive</code>, <code className="text-sm">slack_add_reaction</code>) extend beyond the
-            generic interface.
+            The unified messaging layer provides platform-agnostic tools (
+            <code className="text-sm">messaging_send</code>,{" "}
+            <code className="text-sm">messaging_read</code>,{" "}
+            <code className="text-sm">messaging_search</code>) that delegate to
+            provider adapters for Gmail, Slack, and Telegram. Platform-specific
+            tools (e.g. <code className="text-sm">gmail_archive</code>,{" "}
+            <code className="text-sm">slack_add_reaction</code>) extend beyond
+            the generic interface.
           </p>
           <p className="mb-4 text-zinc-600">
-            Connect via the Settings UI or the <code className="text-sm">integration_connect</code> HTTP endpoint.
-            OAuth2 tokens are stored in the credential vault — the LLM never sees raw tokens. Telegram uses a bot token (not OAuth).
+            Connect via the Settings UI or the{" "}
+            <code className="text-sm">integration_connect</code> HTTP endpoint.
+            OAuth2 tokens are stored in the credential vault — the LLM never
+            sees raw tokens. Telegram uses a bot token (not OAuth).
           </p>
         </section>
 
@@ -48,45 +59,84 @@ export function DeveloperGuideFeaturesContent() {
             Dynamic Skill Authoring
           </SectionHeading>
           <p className="mb-4 text-zinc-600">
-            The assistant can create, test, and persist new skills at runtime when no existing tool covers a user&apos;s need.
+            The assistant can create, test, and persist new skills at runtime
+            when no existing tool covers a user&apos;s need.
           </p>
           <ol className="mb-6 list-decimal space-y-2 pl-6 text-zinc-600">
-            <li><strong>Evaluate</strong> — drafts a TypeScript snippet, tests in a sandbox via <code className="text-sm">evaluate_typescript_code</code>. Iterates until it passes.</li>
-            <li><strong>Persist</strong> — writes the skill to <code className="text-sm">~/.vellum/workspace/skills/&lt;id&gt;/</code> via <code className="text-sm">scaffold_managed_skill</code>.</li>
-            <li><strong>Load</strong> — calls <code className="text-sm">skill_load</code> to activate the new skill.</li>
-            <li><strong>Delete</strong> — removes via <code className="text-sm">delete_managed_skill</code>.</li>
+            <li>
+              <strong>Evaluate</strong> — drafts a TypeScript snippet, tests in
+              a sandbox via{" "}
+              <code className="text-sm">evaluate_typescript_code</code>.
+              Iterates until it passes.
+            </li>
+            <li>
+              <strong>Persist</strong> — writes the skill to{" "}
+              <code className="text-sm">
+                ~/.vellum/workspace/skills/&lt;id&gt;/
+              </code>{" "}
+              via <code className="text-sm">scaffold_managed_skill</code>.
+            </li>
+            <li>
+              <strong>Load</strong> — calls{" "}
+              <code className="text-sm">skill_load</code> to activate the new
+              skill.
+            </li>
+            <li>
+              <strong>Delete</strong> — removes via{" "}
+              <code className="text-sm">delete_managed_skill</code>.
+            </li>
           </ol>
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
               <thead>
                 <tr className="border-b border-zinc-200 dark:border-zinc-700">
-                  <th className="py-2 pr-4 text-left font-medium text-zinc-900 dark:text-zinc-100">Tool</th>
-                  <th className="py-2 pr-4 text-left font-medium text-zinc-900 dark:text-zinc-100">Risk</th>
-                  <th className="py-2 text-left font-medium text-zinc-900 dark:text-zinc-100">Description</th>
+                  <th className="py-2 pr-4 text-left font-medium text-zinc-900 dark:text-zinc-100">
+                    Tool
+                  </th>
+                  <th className="py-2 pr-4 text-left font-medium text-zinc-900 dark:text-zinc-100">
+                    Risk
+                  </th>
+                  <th className="py-2 text-left font-medium text-zinc-900 dark:text-zinc-100">
+                    Description
+                  </th>
                 </tr>
               </thead>
               <tbody className="text-zinc-600 dark:text-zinc-400">
                 <tr className="border-b border-zinc-100 dark:border-zinc-800">
-                  <td className="py-2 pr-4"><code className="text-xs">evaluate_typescript_code</code></td>
+                  <td className="py-2 pr-4">
+                    <code className="text-xs">evaluate_typescript_code</code>
+                  </td>
                   <td className="py-2 pr-4">High</td>
-                  <td className="py-2">Run a TypeScript snippet in a sandbox</td>
+                  <td className="py-2">
+                    Run a TypeScript snippet in a sandbox
+                  </td>
                 </tr>
                 <tr className="border-b border-zinc-100 dark:border-zinc-800">
-                  <td className="py-2 pr-4"><code className="text-xs">scaffold_managed_skill</code></td>
+                  <td className="py-2 pr-4">
+                    <code className="text-xs">scaffold_managed_skill</code>
+                  </td>
                   <td className="py-2 pr-4">High</td>
-                  <td className="py-2">Write a managed skill with SKILL.md frontmatter</td>
+                  <td className="py-2">
+                    Write a managed skill with SKILL.md frontmatter
+                  </td>
                 </tr>
                 <tr>
-                  <td className="py-2 pr-4"><code className="text-xs">delete_managed_skill</code></td>
+                  <td className="py-2 pr-4">
+                    <code className="text-xs">delete_managed_skill</code>
+                  </td>
                   <td className="py-2 pr-4">High</td>
-                  <td className="py-2">Remove a managed skill directory and index entry</td>
+                  <td className="py-2">
+                    Remove a managed skill directory and index entry
+                  </td>
                 </tr>
               </tbody>
             </table>
           </div>
           <p className="mt-4 text-sm text-zinc-500">
-            All authoring tools require explicit user approval. Skills can declare child relationships via the{" "}
-            <code className="text-sm">includes</code> frontmatter field. Managed skills appear in the macOS Settings UI.
+            All authoring tools require explicit user approval. Skills can
+            declare child relationships via the{" "}
+            <code className="text-sm">includes</code> frontmatter field. Managed
+            skills appear in the macOS Settings UI.
           </p>
         </section>
 
@@ -96,57 +146,89 @@ export function DeveloperGuideFeaturesContent() {
             Browser
           </SectionHeading>
           <p className="mb-4 text-zinc-600">
-            Web browsing is provided by the bundled <code className="text-sm">browser</code> skill. Activate via{" "}
-            <code className="text-sm">/browser</code> or let the agent load it automatically. Browser automation is
-            executed through <code className="text-sm">assistant browser</code> commands.
+            Web browsing is provided by the bundled{" "}
+            <code className="text-sm">browser</code> skill. Activate via{" "}
+            <code className="text-sm">/browser</code> or let the agent load it
+            automatically. Browser automation is executed through{" "}
+            <code className="text-sm">assistant browser</code> commands.
           </p>
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
               <thead>
                 <tr className="border-b border-zinc-200 dark:border-zinc-700">
-                  <th className="py-2 pr-4 text-left font-medium text-zinc-900 dark:text-zinc-100">Command</th>
-                  <th className="py-2 text-left font-medium text-zinc-900 dark:text-zinc-100">Description</th>
+                  <th className="py-2 pr-4 text-left font-medium text-zinc-900 dark:text-zinc-100">
+                    Command
+                  </th>
+                  <th className="py-2 text-left font-medium text-zinc-900 dark:text-zinc-100">
+                    Description
+                  </th>
                 </tr>
               </thead>
               <tbody className="text-zinc-600 dark:text-zinc-400">
                 <tr className="border-b border-zinc-100 dark:border-zinc-800">
-                  <td className="py-2 pr-4"><code className="text-xs">assistant browser navigate</code></td>
+                  <td className="py-2 pr-4">
+                    <code className="text-xs">assistant browser navigate</code>
+                  </td>
                   <td className="py-2">Navigate to a URL</td>
                 </tr>
                 <tr className="border-b border-zinc-100 dark:border-zinc-800">
-                  <td className="py-2 pr-4"><code className="text-xs">assistant browser snapshot</code></td>
+                  <td className="py-2 pr-4">
+                    <code className="text-xs">assistant browser snapshot</code>
+                  </td>
                   <td className="py-2">List interactive elements</td>
                 </tr>
                 <tr className="border-b border-zinc-100 dark:border-zinc-800">
-                  <td className="py-2 pr-4"><code className="text-xs">assistant browser screenshot</code></td>
+                  <td className="py-2 pr-4">
+                    <code className="text-xs">
+                      assistant browser screenshot
+                    </code>
+                  </td>
                   <td className="py-2">Take a visual screenshot</td>
                 </tr>
                 <tr className="border-b border-zinc-100 dark:border-zinc-800">
-                  <td className="py-2 pr-4"><code className="text-xs">assistant browser click</code></td>
+                  <td className="py-2 pr-4">
+                    <code className="text-xs">assistant browser click</code>
+                  </td>
                   <td className="py-2">Click an element</td>
                 </tr>
                 <tr className="border-b border-zinc-100 dark:border-zinc-800">
-                  <td className="py-2 pr-4"><code className="text-xs">assistant browser type</code></td>
+                  <td className="py-2 pr-4">
+                    <code className="text-xs">assistant browser type</code>
+                  </td>
                   <td className="py-2">Type text into an input</td>
                 </tr>
                 <tr className="border-b border-zinc-100 dark:border-zinc-800">
-                  <td className="py-2 pr-4"><code className="text-xs">assistant browser press_key</code></td>
+                  <td className="py-2 pr-4">
+                    <code className="text-xs">assistant browser press_key</code>
+                  </td>
                   <td className="py-2">Press a keyboard key</td>
                 </tr>
                 <tr className="border-b border-zinc-100 dark:border-zinc-800">
-                  <td className="py-2 pr-4"><code className="text-xs">assistant browser wait_for</code></td>
+                  <td className="py-2 pr-4">
+                    <code className="text-xs">assistant browser wait_for</code>
+                  </td>
                   <td className="py-2">Wait for a condition</td>
                 </tr>
                 <tr className="border-b border-zinc-100 dark:border-zinc-800">
-                  <td className="py-2 pr-4"><code className="text-xs">assistant browser extract</code></td>
+                  <td className="py-2 pr-4">
+                    <code className="text-xs">assistant browser extract</code>
+                  </td>
                   <td className="py-2">Extract page text content</td>
                 </tr>
                 <tr className="border-b border-zinc-100 dark:border-zinc-800">
-                  <td className="py-2 pr-4"><code className="text-xs">assistant browser fill_credential</code></td>
-                  <td className="py-2">Fill a stored credential into a form field</td>
+                  <td className="py-2 pr-4">
+                    <code className="text-xs">
+                      assistant browser fill_credential
+                    </code>
+                  </td>
+                  <td className="py-2">
+                    Fill a stored credential into a form field
+                  </td>
                 </tr>
                 <tr>
-                  <td className="py-2 pr-4"><code className="text-xs">assistant browser close</code></td>
+                  <td className="py-2 pr-4">
+                    <code className="text-xs">assistant browser close</code>
+                  </td>
                   <td className="py-2">Close the browser page</td>
                 </tr>
               </tbody>
@@ -154,7 +236,8 @@ export function DeveloperGuideFeaturesContent() {
           </div>
           <p className="mt-4 text-sm text-zinc-500">
             All browser operations are auto-allowed by default. Navigation with{" "}
-            <code className="text-sm">allow_private_network=true</code> is elevated to high-risk.
+            <code className="text-sm">allow_private_network=true</code> is
+            elevated to high-risk.
           </p>
         </section>
 
@@ -164,16 +247,33 @@ export function DeveloperGuideFeaturesContent() {
             Attachments
           </SectionHeading>
           <p className="mb-4 text-zinc-600">
-            The assistant attaches files and images to replies, delivered across three channels:
+            The assistant attaches files and images to replies, delivered across
+            three channels:
           </p>
           <ul className="mb-4 list-disc space-y-2 pl-6 text-zinc-600">
-            <li><strong>Desktop</strong> — inline base64 in SSE events; macOS app renders thumbnails</li>
-            <li><strong>Telegram</strong> — gateway delivers via <code className="text-sm">sendPhoto</code>/<code className="text-sm">sendDocument</code> (20 MB limit)</li>
-            <li><strong>HTTP API</strong> — <code className="text-sm">GET /v1/assistants/:id/messages</code> returns metadata; <code className="text-sm">GET /v1/assistants/:assistantId/attachments/:attachmentId</code> returns full payload</li>
+            <li>
+              <strong>Desktop</strong> — inline base64 in SSE events; macOS app
+              renders thumbnails
+            </li>
+            <li>
+              <strong>Telegram</strong> — gateway delivers via{" "}
+              <code className="text-sm">sendPhoto</code>/
+              <code className="text-sm">sendDocument</code> (20 MB limit)
+            </li>
+            <li>
+              <strong>HTTP API</strong> —{" "}
+              <code className="text-sm">GET /v1/assistants/:id/messages</code>{" "}
+              returns metadata;{" "}
+              <code className="text-sm">
+                GET /v1/assistants/:assistantId/attachments/:attachmentId
+              </code>{" "}
+              returns full payload
+            </li>
           </ul>
           <p className="mb-4 text-zinc-600">
-            Sources: <code className="text-sm">&lt;vellum-attachment&gt;</code> directives in response text, or auto-converted from
-            tool output. Limit: 100 MB per attachment.
+            Sources: <code className="text-sm">&lt;vellum-attachment&gt;</code>{" "}
+            directives in response text, or auto-converted from tool output.
+            Limit: 100 MB per attachment.
           </p>
         </section>
 
@@ -183,46 +283,173 @@ export function DeveloperGuideFeaturesContent() {
             Inline Media Embeds
           </SectionHeading>
           <p className="mb-4 text-zinc-600">
-            The desktop app renders inline previews for images and video URLs (YouTube, Vimeo, Loom).
+            The desktop app renders inline previews for images and video URLs
+            (YouTube, Vimeo, Loom).
           </p>
           <ul className="mb-4 list-disc space-y-2 pl-6 text-zinc-600">
-            <li>Videos use <strong>ephemeral webview storage</strong> — no cookies persist between sessions</li>
-            <li>Videos require <strong>click to play</strong>; nothing auto-plays</li>
-            <li>Images are <strong>lazy-loaded</strong></li>
-            <li>Video webviews are <strong>torn down when scrolled offscreen</strong></li>
+            <li>
+              Videos use <strong>ephemeral webview storage</strong> — no cookies
+              persist between sessions
+            </li>
+            <li>
+              Videos require <strong>click to play</strong>; nothing auto-plays
+            </li>
+            <li>
+              Images are <strong>lazy-loaded</strong>
+            </li>
+            <li>
+              Video webviews are{" "}
+              <strong>torn down when scrolled offscreen</strong>
+            </li>
           </ul>
           <p className="mb-4 text-zinc-600">
-            Controlled via <code className="rounded bg-zinc-100 px-1.5 py-0.5 text-sm dark:bg-zinc-800">ui.mediaEmbeds</code> in{" "}
-            <code className="rounded bg-zinc-100 px-1.5 py-0.5 text-sm dark:bg-zinc-800">~/.vellum/workspace/config.json</code>.
+            Controlled via{" "}
+            <code className="rounded bg-zinc-100 px-1.5 py-0.5 text-sm dark:bg-zinc-800">
+              ui.mediaEmbeds
+            </code>{" "}
+            in{" "}
+            <code className="rounded bg-zinc-100 px-1.5 py-0.5 text-sm dark:bg-zinc-800">
+              ~/.vellum/workspace/config.json
+            </code>
+            .
           </p>
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
               <thead>
                 <tr className="border-b border-zinc-200 dark:border-zinc-700">
-                  <th className="py-2 pr-4 text-left font-medium text-zinc-900 dark:text-zinc-100">Setting</th>
-                  <th className="py-2 pr-4 text-left font-medium text-zinc-900 dark:text-zinc-100">Default</th>
-                  <th className="py-2 text-left font-medium text-zinc-900 dark:text-zinc-100">Description</th>
+                  <th className="py-2 pr-4 text-left font-medium text-zinc-900 dark:text-zinc-100">
+                    Setting
+                  </th>
+                  <th className="py-2 pr-4 text-left font-medium text-zinc-900 dark:text-zinc-100">
+                    Default
+                  </th>
+                  <th className="py-2 text-left font-medium text-zinc-900 dark:text-zinc-100">
+                    Description
+                  </th>
                 </tr>
               </thead>
               <tbody className="text-zinc-600 dark:text-zinc-400">
                 <tr className="border-b border-zinc-100 dark:border-zinc-800">
-                  <td className="py-2 pr-4"><code className="text-xs">enabled</code></td>
-                  <td className="py-2 pr-4"><code className="text-xs">true</code></td>
-                  <td className="py-2">Global toggle for all inline media embeds</td>
+                  <td className="py-2 pr-4">
+                    <code className="text-xs">enabled</code>
+                  </td>
+                  <td className="py-2 pr-4">
+                    <code className="text-xs">true</code>
+                  </td>
+                  <td className="py-2">
+                    Global toggle for all inline media embeds
+                  </td>
                 </tr>
                 <tr className="border-b border-zinc-100 dark:border-zinc-800">
-                  <td className="py-2 pr-4"><code className="text-xs">videoAllowlistDomains</code></td>
-                  <td className="py-2 pr-4"><code className="text-xs">[&quot;youtube.com&quot;, ...]</code></td>
-                  <td className="py-2">Domains allowed to render video embeds</td>
+                  <td className="py-2 pr-4">
+                    <code className="text-xs">videoAllowlistDomains</code>
+                  </td>
+                  <td className="py-2 pr-4">
+                    <code className="text-xs">
+                      [&quot;youtube.com&quot;, ...]
+                    </code>
+                  </td>
+                  <td className="py-2">
+                    Domains allowed to render video embeds
+                  </td>
                 </tr>
                 <tr>
-                  <td className="py-2 pr-4"><code className="text-xs">enabledSince</code></td>
-                  <td className="py-2 pr-4"><em>timestamp</em></td>
-                  <td className="py-2">Only messages after this date show embeds</td>
+                  <td className="py-2 pr-4">
+                    <code className="text-xs">enabledSince</code>
+                  </td>
+                  <td className="py-2 pr-4">
+                    <em>timestamp</em>
+                  </td>
+                  <td className="py-2">
+                    Only messages after this date show embeds
+                  </td>
                 </tr>
               </tbody>
             </table>
           </div>
+        </section>
+
+        {/* Device Access */}
+        <section id="device-access" className="mt-12">
+          <SectionHeading id="device-access" level={2}>
+            Device Access
+          </SectionHeading>
+          <p className="mb-4 text-zinc-600">
+            The assistant runs in the cloud (or on your own machine when
+            self-hosted) and talks to you through the client apps: web, macOS,
+            Windows, iOS, Android, and the CLI. The clients pass along what you
+            type, attach, or say. They do not expose device sensors to the
+            assistant beyond what is listed here.
+          </p>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-zinc-200 dark:border-zinc-700">
+                  <th className="py-2 pr-4 text-left font-medium text-zinc-900 dark:text-zinc-100">
+                    Capability
+                  </th>
+                  <th className="py-2 pr-4 text-left font-medium text-zinc-900 dark:text-zinc-100">
+                    Available
+                  </th>
+                  <th className="py-2 text-left font-medium text-zinc-900 dark:text-zinc-100">
+                    Notes
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="text-zinc-600 dark:text-zinc-400">
+                <tr className="border-b border-zinc-100 dark:border-zinc-800">
+                  <td className="py-2 pr-4">Device location (GPS)</td>
+                  <td className="py-2 pr-4">No client</td>
+                  <td className="py-2">
+                    No client reads device position and there is no location
+                    permission to grant. Give the assistant a city, address, or
+                    place name in your message. The{" "}
+                    <strong>Closest city</strong> field in Settings sets your
+                    timezone only; it is not a detected location.
+                  </td>
+                </tr>
+                <tr className="border-b border-zinc-100 dark:border-zinc-800">
+                  <td className="py-2 pr-4">Microphone</td>
+                  <td className="py-2 pr-4">Web, desktop, mobile</td>
+                  <td className="py-2">
+                    Used for voice input. The OS asks for permission the first
+                    time you start dictation or a voice session.
+                  </td>
+                </tr>
+                <tr className="border-b border-zinc-100 dark:border-zinc-800">
+                  <td className="py-2 pr-4">Files and photos</td>
+                  <td className="py-2 pr-4">All clients</td>
+                  <td className="py-2">
+                    Attach files from the system picker; on mobile that includes
+                    the photo library and camera, and the OS asks for permission
+                    when you open them. See{" "}
+                    <a
+                      href="#attachments"
+                      className="text-mint-600 hover:underline"
+                    >
+                      Attachments
+                    </a>
+                    .
+                  </td>
+                </tr>
+                <tr>
+                  <td className="py-2 pr-4">
+                    Host computer use (files, terminal, screen)
+                  </td>
+                  <td className="py-2 pr-4">Desktop, CLI</td>
+                  <td className="py-2">
+                    Opt-in per conversation. Mobile and web clients never expose
+                    the host machine.
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <p className="mt-4 text-sm text-zinc-500">
+            Permission prompts for the microphone, camera, and photos are shown
+            by the operating system when you take the action in the client. The
+            assistant cannot open one from a chat reply.
+          </p>
         </section>
       </DocsContent>
       <TableOfContents items={TOC_ITEMS} />

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -761,7 +761,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-08-21T15:31:03.000Z"
+      "updatedAt": "2026-08-21T15:44:11.000Z"
     },
     {
       "id": "public-ingress",
@@ -1167,6 +1167,7 @@
             "how Vellum works or its architecture",
             "its current configuration or settings",
             "what it can do, or what skills/tools are available",
+            "asked to use the user's current location, GPS, or a device sensor or permission",
             "whether a service is connected, and in which sense",
             "how to self-host a Vellum assistant",
             "how to configure your own model API key"
@@ -1177,7 +1178,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-08-07T07:15:43.000Z"
+      "updatedAt": "2026-08-21T23:31:08.000Z"
     },
     {
       "id": "vellum-skills-catalog",

--- a/skills/vellum-self-knowledge/SKILL.md
+++ b/skills/vellum-self-knowledge/SKILL.md
@@ -12,6 +12,7 @@ metadata:
       - "how Vellum works or its architecture"
       - "its current configuration or settings"
       - "what it can do, or what skills/tools are available"
+      - "asked to use the user's current location, GPS, or a device sensor or permission"
       - "whether a service is connected, and in which sense"
       - "how to self-host a Vellum assistant"
       - "how to configure your own model API key"
@@ -77,39 +78,40 @@ whether something is connected.
 For "what is", "how does", and "why" questions, fetch the relevant page from the docs site.
 Base URL: `https://www.vellum.ai/docs`
 
-| Topic                    | Path                                      |
-| ------------------------ | ----------------------------------------- |
-| What is Vellum           | `/getting-started/what-is-vellum`         |
-| Installation             | `/getting-started/installation`           |
-| Quick start              | `/getting-started/quick-start`            |
-| Your first skill         | `/getting-started/your-first-skill`       |
-| How it all fits together | `/key-concepts/how-it-all-fits-together`  |
-| The workspace            | `/key-concepts/the-workspace`             |
-| Skills & tools           | `/key-concepts/skills-and-tools`          |
-| Memory & context         | `/key-concepts/memory-and-context`        |
-| Channels                 | `/key-concepts/channels`                  |
-| Identity                 | `/key-concepts/identity`                  |
-| Scheduling               | `/key-concepts/scheduling`                |
-| Glossary                 | `/key-concepts/glossary`                  |
-| Privacy & data           | `/trust-security/privacy-and-data`        |
-| The permissions model    | `/trust-security/the-permissions-model`   |
-| Security best practices  | `/trust-security/security-best-practices` |
-| Architecture             | `/developer-guide/architecture`           |
-| Security (developer)     | `/developer-guide/security`               |
-| Features & capabilities  | `/developer-guide/features`               |
-| API & communication      | `/developer-guide/api`                    |
-| Development workflow     | `/developer-guide/development-workflow`   |
-| Contributing             | `/developer-guide/contributing`           |
-| Local hosting            | `/hosting-options/local-hosting`          |
-| Advanced hosting         | `/hosting-options/advanced-options`       |
-| Environments             | `/environments`                           |
-| Pricing                  | `/pricing`                                |
-| Roadmap                  | `/roadmap`                                |
-| FAQ                      | `/help/faq`                               |
-| Common issues            | `/help/common-issues`                     |
-| Getting help             | `/help/getting-help`                      |
-| Skills reference index   | `/skills-reference`                       |
-| Specific skill reference | `/skills-reference/<skill-name>`          |
+| Topic                                       | Path                                      |
+| ------------------------------------------- | ----------------------------------------- |
+| What is Vellum                              | `/getting-started/what-is-vellum`         |
+| Installation                                | `/getting-started/installation`           |
+| Quick start                                 | `/getting-started/quick-start`            |
+| Your first skill                            | `/getting-started/your-first-skill`       |
+| How it all fits together                    | `/key-concepts/how-it-all-fits-together`  |
+| The workspace                               | `/key-concepts/the-workspace`             |
+| Skills & tools                              | `/key-concepts/skills-and-tools`          |
+| Memory & context                            | `/key-concepts/memory-and-context`        |
+| Channels                                    | `/key-concepts/channels`                  |
+| Identity                                    | `/key-concepts/identity`                  |
+| Scheduling                                  | `/key-concepts/scheduling`                |
+| Glossary                                    | `/key-concepts/glossary`                  |
+| Privacy & data                              | `/trust-security/privacy-and-data`        |
+| The permissions model                       | `/trust-security/the-permissions-model`   |
+| Security best practices                     | `/trust-security/security-best-practices` |
+| Architecture                                | `/developer-guide/architecture`           |
+| Security (developer)                        | `/developer-guide/security`               |
+| Features & capabilities                     | `/developer-guide/features`               |
+| Device access (location, mic, camera, host) | `/developer-guide/features#device-access` |
+| API & communication                         | `/developer-guide/api`                    |
+| Development workflow                        | `/developer-guide/development-workflow`   |
+| Contributing                                | `/developer-guide/contributing`           |
+| Local hosting                               | `/hosting-options/local-hosting`          |
+| Advanced hosting                            | `/hosting-options/advanced-options`       |
+| Environments                                | `/environments`                           |
+| Pricing                                     | `/pricing`                                |
+| Roadmap                                     | `/roadmap`                                |
+| FAQ                                         | `/help/faq`                               |
+| Common issues                               | `/help/common-issues`                     |
+| Getting help                                | `/help/getting-help`                      |
+| Skills reference index                      | `/skills-reference`                       |
+| Specific skill reference                    | `/skills-reference/<skill-name>`          |
 
 Use `web_fetch` to pull the page content. If a URL 404s, try fetching the docs homepage and navigating from the sidebar.
 


### PR DESCRIPTION
## Why

[JARVIS-1591](https://linear.app/vellum/issue/JARVIS-1591/assistant-invents-a-location-access-allow-button-that-does-not-exist): a user asked the assistant to use their live location and it replied "Tap **Allow**" for a permission prompt no client has. No client reads device position.

#41135 fixes this with a new bespoke skill that hardcodes the fact. This PR is the generic alternative: the assistant already has one path for "what can the product do" questions, `vellum-self-knowledge` ("never answer from memory, go to a source of truth", extended by #39365), and the docs site it points at now lives in this repo (`clients/docs/`). So the fact goes in the docs and the skill gets one more trigger. No second capabilities surface to drift, and JARVIS-1565's install matrix can land in the docs the same way.

## What

- `clients/docs` Features & Capabilities page: new **Device Access** section with a per-client table (location unavailable in every client and no permission to grant; `Closest city` is timezone only; mic, files/photos, host computer use; OS owns the permission prompts and the assistant cannot open one from a reply). Served at `/docs/developer-guide/features#device-access` and mirrored to `/docs/developer-guide/features.md` for `web_fetch`.
- `skills/vellum-self-knowledge`: activation hint for "asked to use the user's current location, GPS, or a device sensor or permission" and a docs-table row pointing at the new section. Prettier realigned the table columns; only the one row is new.
- `skills/catalog.json` regenerated (also absorbs the `updatedAt` drift from #41002).

Part of JARVIS-1591. Supersedes #41135 if accepted.

## Verification

- `bunx tsc --noEmit` and `eslint` in `clients/docs`: clean
- `bun run generate:agent-markdown`: the Device Access section renders into `generated/md/docs/developer-guide/features.md`
- `bun test src/__tests__/vellum-self-knowledge-inline-command.test.ts`: 8 pass
- `node scripts/skills/lint-skill-spec.mjs` (73 conform), `check-catalog.mjs` up to date
- Behavioral QA outstanding: on a dev build, "use my live location to find the nearest hardware store" should fire self-knowledge, fetch the docs page, and ask for a typed location.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0191JQLnLUVGqCmacp7qfQdc