### PR TITLE
fix: round-2 review gaps (migration fail-safe directions, mix-arm validation, corrupt-row repair)

### DIFF
--- a/assistant/src/__tests__/workspace-migration-147-strip-call-site-provider-overrides.test.ts
+++ b/assistant/src/__tests__/workspace-migration-147-strip-call-site-provider-overrides.test.ts
@@ -265,6 +265,65 @@ describe("147-strip-call-site-provider-overrides", () => {
     expect(readCallSites()).not.toHaveProperty("memoryExtraction");
   });
 
+  test("a vellum pin on a routing-identity profile judges the identity", () => {
+    // Migration 148 handles routing identities first: the profile keeps
+    // "chatgpt" and the stray binding is dropped, so the post-fold winner is
+    // the Codex allowlist, not the managed route.
+    writeConfig({
+      llm: {
+        profiles: {
+          subscription: {
+            source: "user",
+            provider: "chatgpt",
+            provider_connection: "vellum",
+            model: "gpt-5.5",
+          },
+        },
+        callSites: {
+          // Vellum-routable but not a Codex model.
+          memoryExtraction: {
+            profile: "subscription",
+            model: "gemini-2.5-pro",
+          },
+        },
+      },
+    });
+
+    run();
+
+    expect(readCallSites()).not.toHaveProperty("memoryExtraction");
+  });
+
+  test("keeps a tweak carrying the undated DeepSeek id under a vellum winner", () => {
+    // Migration 146 normally rewrites this id first, but a deferred 146 (the
+    // runner continues past a failed migration) leaves it in place for this
+    // boot. Deletion must fail open, or the tweak 146's retry would have
+    // healed is destroyed permanently.
+    writeConfig({
+      llm: {
+        profiles: {
+          managed: {
+            source: "user",
+            provider: "vellum",
+            model: "claude-opus-4-8",
+          },
+        },
+        callSites: {
+          memoryExtraction: {
+            profile: "managed",
+            model: "accounts/fireworks/models/deepseek-v4-flash",
+          },
+        },
+      },
+    });
+
+    run();
+
+    expect(readCallSites().memoryExtraction.model).toBe(
+      "accounts/fireworks/models/deepseek-v4-flash",
+    );
+  });
+
   test("an entry-name winner is judged through its connection row", () => {
     seedRows([{ name: "my-openai", provider: "openai" }]);
     writeConfig({

--- a/assistant/src/__tests__/workspace-migration-148-delete-provider-connection-residue.test.ts
+++ b/assistant/src/__tests__/workspace-migration-148-delete-provider-connection-residue.test.ts
@@ -8,11 +8,42 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Database } from "bun:sqlite";
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
-import { deleteProviderConnectionResidueMigration } from "../workspace/migrations/148-delete-provider-connection-residue.js";
-import { WORKSPACE_MIGRATIONS } from "../workspace/migrations/registry.js";
 import { assertNotLiveDb } from "./assert-not-live-db.js";
+
+// The migration's structured logs are the only observable difference between
+// its delete branches, so they are captured. `getLogger` is called at module
+// scope, so the mock must be registered before the migration module is
+// evaluated — hence the dynamic imports below.
+interface LogCall {
+  level: string;
+  fields: Record<string, unknown>;
+}
+const logCalls: LogCall[] = [];
+function capture(level: string) {
+  return (...args: unknown[]) => {
+    logCalls.push({
+      level,
+      fields: (args[0] ?? {}) as Record<string, unknown>,
+    });
+  };
+}
+mock.module("../util/logger.js", () => ({
+  getLogger: () => ({
+    info: capture("info"),
+    warn: capture("warn"),
+    error: capture("error"),
+    debug: capture("debug"),
+    trace: capture("trace"),
+    fatal: capture("fatal"),
+  }),
+}));
+
+const { deleteProviderConnectionResidueMigration } =
+  await import("../workspace/migrations/148-delete-provider-connection-residue.js");
+const { WORKSPACE_MIGRATIONS } =
+  await import("../workspace/migrations/registry.js");
 
 let workspaceDir: string;
 
@@ -65,6 +96,7 @@ function run(): void {
 }
 
 beforeEach(() => {
+  logCalls.length = 0;
   workspaceDir = join(
     tmpdir(),
     `vellum-migration-148-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
@@ -137,6 +169,39 @@ describe("148-delete-provider-connection-residue", () => {
     );
   });
 
+  test("warn-drops a vellum binding carrying the retired undated DeepSeek id", () => {
+    // Migration 146 normally rewrites this id first; when it defers, folding
+    // onto the identity would write a pair the read-path schema strips, so
+    // the binding drops and the declared provider stays.
+    seedRows([{ name: "vellum", provider: "vellum" }]);
+    writeConfig({
+      llm: {
+        profiles: {
+          deepseek: {
+            provider: "fireworks",
+            provider_connection: "vellum",
+            model: "accounts/fireworks/models/deepseek-v4-flash",
+          },
+        },
+      },
+    });
+
+    run();
+
+    const deepseek = readProfiles().deepseek;
+    expect(deepseek.provider).toBe("fireworks");
+    expect(deepseek).not.toHaveProperty("provider_connection");
+    expect(logCalls).toContainEqual({
+      level: "warn",
+      fields: {
+        profile: "deepseek",
+        provider: "fireworks",
+        binding: "vellum",
+        reason: "dangling_binding_dropped",
+      },
+    });
+  });
+
   test("deletes a self-named pin shadowed by the conventional row", () => {
     // With both the self-named row and `<provider>-personal` present,
     // bare-vendor dispatch prefers the conventional row, so the delete is
@@ -163,9 +228,21 @@ describe("148-delete-provider-connection-residue", () => {
     const pinned = readProfiles().pinned;
     expect(pinned.provider).toBe("anthropic");
     expect(pinned).not.toHaveProperty("provider_connection");
+    expect(logCalls).toContainEqual({
+      level: "warn",
+      fields: {
+        profile: "pinned",
+        provider: "anthropic",
+        binding: "anthropic",
+        reason: "self_named_binding_shadowed",
+      },
+    });
   });
 
-  test("folds a self-named pin (the entry name is the vendor)", () => {
+  test("deletes a self-named pin with no conventional sibling losslessly", () => {
+    // Without `<provider>-personal`, auto-resolve's second preference is the
+    // self-named row the pin named, so the delete loses nothing and is
+    // recorded at info: no shadowing cohort to identify.
     seedRows([
       { name: "anthropic", provider: "anthropic" },
       { name: "anthropic-2", provider: "anthropic" },
@@ -187,6 +264,11 @@ describe("148-delete-provider-connection-residue", () => {
     const pinned = readProfiles().pinned;
     expect(pinned.provider).toBe("anthropic");
     expect(pinned).not.toHaveProperty("provider_connection");
+    expect(logCalls.filter((c) => c.level === "warn")).toEqual([]);
+    expect(logCalls).toContainEqual({
+      level: "info",
+      fields: { profile: "pinned", provider: "anthropic" },
+    });
   });
 
   test("drops a dangling binding with the vendor kept", () => {

--- a/assistant/src/persistence/schema/inference.ts
+++ b/assistant/src/persistence/schema/inference.ts
@@ -4,8 +4,8 @@ import { index, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
  * Named provider connections.
  *
  * Each row is a named auth-config instance for a code-defined provider.
- * Profiles in config.json reference connections by `name` via the
- * `provider_connection` field.
+ * Profiles in config.json reference an entry by putting its `name` in their
+ * `provider` field.
  *
  * Created by migration 243.
  */

--- a/assistant/src/providers/inference/connections.ts
+++ b/assistant/src/providers/inference/connections.ts
@@ -72,6 +72,20 @@ function parseAuth(raw: unknown, provider: string): Auth | null {
 }
 
 /**
+ * The stored auth column as JSON, or null when the column does not parse.
+ * A corrupt payload must read as an invalid row (hidden from list/get,
+ * removable by DELETE), never throw the whole read out from under the
+ * caller.
+ */
+function parseStoredAuthColumn(raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Payload-only JSON persisted in the auth column. The auth type is derived
  * from the provider column on read, so it is never stored.
  */
@@ -110,7 +124,7 @@ export function listConnections(
     : db.select().from(providerConnections).all();
 
   return rows.flatMap((row) => {
-    const auth = parseAuth(JSON.parse(row.auth), row.provider);
+    const auth = parseAuth(parseStoredAuthColumn(row.auth), row.provider);
     if (!auth) {
       return [];
     }
@@ -145,7 +159,7 @@ export function getConnection(
   if (!row) {
     return null;
   }
-  const auth = parseAuth(JSON.parse(row.auth), row.provider);
+  const auth = parseAuth(parseStoredAuthColumn(row.auth), row.provider);
   if (!auth) {
     return null;
   }

--- a/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
@@ -1880,9 +1880,10 @@ describe("call-site model writes are validated against the winning route", () =>
     );
   });
 
-  // Mix winners expand via an unseeded random arm pick per resolution, so
-  // any judgment would be against a nondeterministic route; the loops catch
-  // a regression that only misjudges on some arm picks.
+  // A mix winner expands via an unseeded random arm pick per resolution, so
+  // it has no single route to fingerprint; an introduced model is judged
+  // against every arm instead. The loops catch a regression that resolves an
+  // arm and so only misjudges on some picks.
   const mixedProfiles = {
     op: { source: "user", provider: "openai", model: "gpt-5.5" },
     an: { source: "user", provider: "anthropic", model: "claude-opus-4-8" },
@@ -1896,8 +1897,8 @@ describe("call-site model writes are validated against the winning route", () =>
     },
   };
 
-  test("a call-site model write under a mix winner always saves", async () => {
-    for (let i = 0; i < 20; i += 1) {
+  test("a call-site model only one mix arm serves returns 400 every time", async () => {
+    for (let i = 0; i < 10; i += 1) {
       rawConfigFixture = {
         llm: {
           profiles: structuredClone(mixedProfiles),
@@ -1905,16 +1906,75 @@ describe("call-site model writes are validated against the winning route", () =>
         },
       };
       seedRawConfig();
-      await configPatchRoute.handler({
-        body: {
-          llm: { callSites: { memoryExtraction: { model: "gpt-5.4-nano" } } },
-        },
-      });
-      const llm = loadRawConfig().llm as {
-        callSites?: Record<string, Record<string, unknown>>;
-      };
-      expect(llm.callSites?.memoryExtraction?.model).toBe("gpt-5.4-nano");
+      await expect(
+        configPatchRoute.handler({
+          body: {
+            llm: { callSites: { memoryExtraction: { model: "gpt-5.4-nano" } } },
+          },
+        }),
+      ).rejects.toThrow(
+        'Model "gpt-5.4-nano" is not served by provider "anthropic". (llm.callSites.memoryExtraction.model, mix arm "an")',
+      );
     }
+  });
+
+  test("a call-site model every mix arm serves saves", async () => {
+    rawConfigFixture = {
+      llm: {
+        profiles: {
+          op: { source: "user", provider: "openai", model: "gpt-5.5" },
+          op2: { source: "user", provider: "openai", model: "gpt-5.2" },
+          ab: {
+            source: "user",
+            mix: [
+              { profile: "op", weight: 1 },
+              { profile: "op2", weight: 1 },
+            ],
+          },
+        },
+        callSites: { memoryExtraction: { profile: "ab" } },
+      },
+    };
+    seedRawConfig();
+    await configPatchRoute.handler({
+      body: {
+        llm: { callSites: { memoryExtraction: { model: "gpt-5.4-nano" } } },
+      },
+    });
+    const llm = loadRawConfig().llm as {
+      callSites?: Record<string, Record<string, unknown>>;
+    };
+    expect(llm.callSites?.memoryExtraction?.model).toBe("gpt-5.4-nano");
+  });
+
+  test("mix arms whose kind is indeterminate fail open", async () => {
+    getDb().delete(providerConnections).run();
+    rawConfigFixture = {
+      llm: {
+        profiles: {
+          e1: { source: "user", provider: "my-conn-a", model: "gpt-5.5" },
+          e2: { source: "user", provider: "my-conn-b", model: "gpt-5.5" },
+          ab: {
+            source: "user",
+            mix: [
+              { profile: "e1", weight: 1 },
+              { profile: "e2", weight: 1 },
+            ],
+          },
+        },
+        callSites: { memoryExtraction: { profile: "ab" } },
+      },
+    };
+    seedRawConfig();
+    await configPatchRoute.handler({
+      body: {
+        llm: { callSites: { memoryExtraction: { model: "anything-goes" } } },
+      },
+    });
+    const llm = loadRawConfig().llm as {
+      callSites?: Record<string, Record<string, unknown>>;
+    };
+    expect(llm.callSites?.memoryExtraction?.model).toBe("anything-goes");
   });
 
   test("an unrelated save under a mix winner never rejects", async () => {

--- a/assistant/src/runtime/routes/__tests__/inference-provider-connection-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/inference-provider-connection-routes.test.ts
@@ -10,7 +10,7 @@
  *   Auth   — 401 (missing key) and 403 (insufficient scope) via route-policy assertions
  */
 
-import { beforeEach, describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 // ── Real imports ──────────────────────────────────────────────────────────────
 import { setConfig } from "../../../__tests__/helpers/set-config.js";
@@ -18,11 +18,26 @@ import { LLMSchema } from "../../../config/schemas/llm.js";
 import { getDb } from "../../../persistence/db-connection.js";
 import { initializeDb } from "../../../persistence/db-init.js";
 import { providerConnections } from "../../../persistence/schema/inference.js";
+import { credentialKey } from "../../../security/credential-key.js";
+import * as secureKeys from "../../../security/secure-keys.js";
 // Route policies are read directly off `route.policy` now (ATL-315
 // followup) — no registry lookup.
 import { BadRequestError, ConflictError, NotFoundError } from "../errors.js";
 import { ROUTES } from "../inference-provider-connection-routes.js";
 import type { RouteDefinition, RouteHandlerArgs } from "../types.js";
+
+// ── Vault stub ────────────────────────────────────────────────────────────────
+
+// The route deletes a connection's credential slot best-effort; the stub
+// records which key it asked for without touching a real vault backend.
+const vaultKeys = new Set<string>();
+mock.module("../../../security/secure-keys.js", () => ({
+  ...secureKeys,
+  deleteSecureKeyAsync: async (key: string) => {
+    const had = vaultKeys.delete(key);
+    return had ? ("deleted" as const) : ("not-found" as const);
+  },
+}));
 
 // ── DB bootstrap ──────────────────────────────────────────────────────────────
 
@@ -1145,6 +1160,16 @@ describe("DELETE repairs a row whose stored auth is underivable", () => {
     ).rejects.toBeInstanceOf(ConflictError);
   });
 
+  test("DELETE frees the per-name credential slot the row owned when healthy", async () => {
+    vaultKeys.add(credentialKey("zombie", "api_key"));
+
+    await call(findHandler("inference_provider_connections_delete"), {
+      pathParams: { name: "zombie" },
+    });
+
+    expect(vaultKeys.has(credentialKey("zombie", "api_key"))).toBe(false);
+  });
+
   test("DELETE proceeds even when the default provider resolves to the name", async () => {
     // The default is already broken (resolution cannot load the row), so
     // the orphan guard must not block the one repair path.
@@ -1161,6 +1186,53 @@ describe("DELETE repairs a row whose stored auth is underivable", () => {
       { pathParams: { name: "anthropic-personal" } },
     )) as { ok: boolean };
     expect(result.ok).toBe(true);
+  });
+});
+
+describe("DELETE repairs a row whose stored auth is not JSON at all", () => {
+  // A corrupt auth column must read as an invalid row, not throw out of the
+  // loaders — otherwise the whole list breaks and DELETE (the one repair
+  // path) 500s instead of removing the row.
+  beforeEach(() => {
+    const now = Date.now();
+    getDb()
+      .insert(providerConnections)
+      .values({
+        name: "corrupt",
+        provider: "anthropic",
+        auth: "not json at all",
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+  });
+
+  test("list succeeds and excludes the row", async () => {
+    const result = (await call(
+      findHandler("inference_provider_connections_list"),
+      {},
+    )) as { connections: { name: string }[] };
+    expect(result.connections.map((c) => c.name)).not.toContain("corrupt");
+  });
+
+  test("DELETE succeeds and frees the name for re-create", async () => {
+    const result = (await call(
+      findHandler("inference_provider_connections_delete"),
+      { pathParams: { name: "corrupt" } },
+    )) as { ok: boolean };
+    expect(result.ok).toBe(true);
+
+    const recreated = (await call(
+      findHandler("inference_provider_connections_create"),
+      {
+        body: {
+          name: "corrupt",
+          provider: "anthropic",
+          auth: { type: "api_key", credential: "vault/anthropic/key" },
+        },
+      },
+    )) as { name: string };
+    expect(recreated.name).toBe("corrupt");
   });
 });
 

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -1451,7 +1451,9 @@ function assertRoutableIdentityEntries(
  * anything indeterminate (an unparseable `llm` section whose parse error
  * surfaces elsewhere, a winner whose connection row cannot be read, or a
  * route whose model set is not code-known: endpoint-supplied providers,
- * keyless ollama), matching `preflightResolvedConfig`'s posture.
+ * keyless ollama), matching `preflightResolvedConfig`'s posture. A mix
+ * winner has no single route to fingerprint, so an introduced or changed
+ * model is judged against its arms instead (`assertServableByEveryMixArm`).
  */
 function assertServableCallSiteModels(
   preWrite: Record<string, unknown>,
@@ -1497,6 +1499,8 @@ function assertServableCallSiteModels(
      * rather than a dispatch-translated vendor. Null = indeterminate.
      */
     kind: string | null;
+    /** The winning profile's name when the winner is a mix, else null. */
+    mixProfile: string | null;
   }
   const routeFingerprint = (
     llm: z.infer<typeof LLMSchema>,
@@ -1506,24 +1510,27 @@ function assertServableCallSiteModels(
     // A mix winner expands to a random arm on every unseeded resolution
     // here, so its route cannot be fingerprinted: any judgment would be
     // against a nondeterministic arm. Indeterminate, like the other
-    // fail-open cases.
+    // fail-open cases; its name is carried out so an introduced model can
+    // still be judged arm by arm.
     if (profileName != null && llm.profiles?.[profileName]?.mix != null) {
-      return { provider: null, kind: null };
+      return { provider: null, kind: null, mixProfile: profileName };
     }
-    const kind = (VALID_CONNECTION_PROVIDERS as readonly string[]).includes(
-      config.provider,
-    )
-      ? config.provider
-      : connectionRowKind(config.provider);
-    return { provider: config.provider, kind };
+    return {
+      provider: config.provider,
+      kind: providerKind(config.provider),
+      mixProfile: null,
+    };
   };
 
   for (const { site, model } of modelBearing) {
     const route = routeFingerprint(post.data, site);
+    const modelChanged = model !== readPlainObject(priorSites[site])?.model;
     if (route.kind == null) {
+      if (modelChanged && route.mixProfile != null) {
+        assertServableByEveryMixArm(post.data, route.mixProfile, site, model);
+      }
       continue;
     }
-    const modelChanged = model !== readPlainObject(priorSites[site])?.model;
     if (!modelChanged) {
       // Model untouched: validate only when this write moved the site's
       // route. An indeterminable pre-write config counts as unmoved, so a
@@ -1539,13 +1546,69 @@ function assertServableCallSiteModels(
         continue;
       }
     }
-    const issue = ROUTING_IDENTITY_PROVIDERS.has(route.kind)
-      ? routingIdentityModelIssue(route.kind, model)
-      : catalogServabilityIssue(route.kind, model);
+    const issue = servabilityIssue(route.kind, model);
     if (issue) {
       throw new BadRequestError(`${issue} (llm.callSites.${site}.model)`);
     }
   }
+}
+
+/**
+ * Reject a call-site model no arm of a mix winner can serve. A mix has no
+ * single route to fingerprint (the arm is a seeded per-conversation pick),
+ * but its arms are fully knowable: the schema guarantees every arm exists
+ * and is a standard profile, so a model this write introduces or changes is
+ * required to be servable by all of them. Judged only for arms whose kind is
+ * determinable; an arm that cannot be judged fails open on its own, and a
+ * disabled arm is skipped because selection falls through to another winner
+ * entirely when the pick lands on it.
+ */
+function assertServableByEveryMixArm(
+  llm: z.infer<typeof LLMSchema>,
+  mixProfile: string,
+  site: LLMCallSite,
+  model: string,
+): void {
+  for (const arm of llm.profiles?.[mixProfile]?.mix ?? []) {
+    const entry = llm.profiles?.[arm.profile];
+    if (
+      entry == null ||
+      entry.status === "disabled" ||
+      entry.provider == null
+    ) {
+      continue;
+    }
+    const kind = providerKind(entry.provider);
+    if (kind == null) {
+      continue;
+    }
+    const issue = servabilityIssue(kind, model);
+    if (issue) {
+      throw new BadRequestError(
+        `${issue} (llm.callSites.${site}.model, mix arm "${arm.profile}")`,
+      );
+    }
+  }
+}
+
+/**
+ * Why a route kind cannot serve a model, or null when it can (or cannot be
+ * judged): identities by their routing table, vendors by catalog membership.
+ */
+function servabilityIssue(kind: string, model: string): string | null {
+  return ROUTING_IDENTITY_PROVIDERS.has(kind)
+    ? routingIdentityModelIssue(kind, model)
+    : catalogServabilityIssue(kind, model);
+}
+
+/**
+ * The kind a provider value is judged by: a vendor value verbatim,
+ * otherwise the entry-name row's provider column. Null = indeterminate.
+ */
+function providerKind(provider: string): string | null {
+  return (VALID_CONNECTION_PROVIDERS as readonly string[]).includes(provider)
+    ? provider
+    : connectionRowKind(provider);
 }
 
 /**

--- a/assistant/src/runtime/routes/inference-provider-connection-routes.ts
+++ b/assistant/src/runtime/routes/inference-provider-connection-routes.ts
@@ -572,11 +572,12 @@ async function handleDeleteConnection({ pathParams = {} }: RouteHandlerArgs) {
   // connection returns 404 (not 409).
   const existing = getConnection(getDb(), name);
   // A row whose stored auth payload is underivable (`parseAuth` returns
-  // null) is hidden by the typed loader but still occupies its name;
-  // DELETE is the one repair path, so fall through to the raw row and run
-  // the guards below on it. Such a row can never be the managed row (the
-  // managed row's auth always derives), cannot be routed through, and
-  // carries no credential slot to clean up.
+  // null, including a column that is not JSON at all) is hidden by the typed
+  // loader but still occupies its name; DELETE is the one repair path, so
+  // fall through to the raw row and run the guards below on it. Such a row
+  // can never be the managed row (the managed row's auth always derives) and
+  // cannot be routed through, but it may still own the per-name credential
+  // slot from when it was healthy, so the cleanup below covers it.
   const rawRow = existing ?? getConnectionRowRaw(getDb(), name);
   if (!rawRow) {
     throw new NotFoundError(`Connection "${name}" not found.`);
@@ -673,20 +674,24 @@ async function handleDeleteConnection({ pathParams = {} }: RouteHandlerArgs) {
 
   // A per-connection credential slot is owned by exactly this row, so the
   // delete removes it too. Provider-keyed and custom refs stay: they can be
-  // shared across rows. Awaited so the response orders after the vault
-  // delete — a client that deletes, recreates the name, and saves a new key
-  // must never have that key erased by a still-in-flight deletion. Failures
-  // are logged, never surfaced: a vault outage leaves an orphaned secret,
-  // not a failed delete (the timeout on vault calls bounds the wait).
+  // shared across rows. An underivable row has no readable pointer to check,
+  // but it can still own that slot from when it was healthy, so the repair
+  // path clears it best-effort. Awaited so the response orders after the
+  // vault delete — a client that deletes, recreates the name, and saves a new
+  // key must never have that key erased by a still-in-flight deletion.
+  // Failures are logged, never surfaced: a vault outage leaves an orphaned
+  // secret, not a failed delete (the timeout on vault calls bounds the wait).
+  const perNameCredential = credentialKey(name, "api_key");
   if (
-    existing?.auth.type === "api_key" &&
-    existing.auth.credential === credentialKey(name, "api_key")
+    existing == null ||
+    (existing.auth.type === "api_key" &&
+      existing.auth.credential === perNameCredential)
   ) {
     try {
-      await deleteSecureKeyAsync(existing.auth.credential);
+      await deleteSecureKeyAsync(perNameCredential);
     } catch (err) {
       log.warn(
-        { err, connection: name, credential: existing.auth.credential },
+        { err, connection: name, credential: perNameCredential },
         "Failed to delete the connection's credential slot — secret orphaned in the vault",
       );
     }

--- a/assistant/src/workspace/migrations/147-strip-call-site-provider-overrides.ts
+++ b/assistant/src/workspace/migrations/147-strip-call-site-provider-overrides.ts
@@ -133,9 +133,18 @@ const VELLUM_ROUTABLE_MODELS = new Set([
   "accounts/fireworks/models/minimax-m3",
   "accounts/fireworks/models/minimax-m2p7",
   "accounts/fireworks/models/deepseek-v4-pro",
+  // Migration 146 (which runs first) rewrites the undated DeepSeek flash id
+  // to the dated one, but a deferred 146 leaves the undated form in place for
+  // this same boot. This pass gates DELETION, so both forms are listed: an
+  // omission would permanently delete a tweak 146's retry would have healed.
+  "accounts/fireworks/models/deepseek-v4-flash",
   "accounts/fireworks/models/deepseek-v4-flash-0731",
   "MiniMaxAI/MiniMax-M3",
 ]);
+
+// Frozen snapshot of the routing identities: provider values that name a
+// route rather than a vendor.
+const ROUTING_IDENTITIES = new Set(["vellum", "chatgpt"]);
 
 // Frozen snapshot of the ChatGPT-subscription (Codex) allowlist.
 const CODEX_MODELS = new Set([
@@ -193,6 +202,8 @@ const CATALOG_MODELS: Record<string, ReadonlySet<string>> = {
     "accounts/fireworks/models/minimax-m3",
     "accounts/fireworks/models/minimax-m2p7",
     "accounts/fireworks/models/deepseek-v4-pro",
+    // Both DeepSeek flash forms, for the deferred-146 reason above.
+    "accounts/fireworks/models/deepseek-v4-flash",
     "accounts/fireworks/models/deepseek-v4-flash-0731",
   ]),
   together: new Set(["MiniMaxAI/MiniMax-M3"]),
@@ -412,8 +423,8 @@ function winnerProviderForSite(
 
 /**
  * A named rung's provider: the profile's own provider when it is plainly
- * usable (judged as the vellum identity when the profile pins the managed
- * "vellum" connection and its model is vellum-routable, mirroring
+ * usable (judged as the vellum identity when a non-identity profile pins the
+ * managed "vellum" connection and its model is vellum-routable, mirroring
  * migration 148's fold), the intent column for default-key names with no
  * workspace entry
  * (or an explicitly managed stub, which the resolver overrides with the
@@ -449,9 +460,12 @@ function rungProvider(
     // folds the pin into the vellum identity when the profile's model is
     // vellum-routable. Servability is judged by that post-fold winner, not
     // the declared vendor, so this pass never deletes a tweak the managed
-    // route serves.
+    // route serves. A profile that already declares a routing identity is
+    // excluded: 148 handles identities first (it keeps the identity and
+    // drops the stray binding), so the declared identity is the winner.
     if (
       entry.provider_connection === "vellum" &&
+      !ROUTING_IDENTITIES.has(usableProvider) &&
       model !== null &&
       VELLUM_ROUTABLE_MODELS.has(model)
     ) {

--- a/assistant/src/workspace/migrations/148-delete-provider-connection-residue.ts
+++ b/assistant/src/workspace/migrations/148-delete-provider-connection-residue.ts
@@ -49,7 +49,10 @@ const log = getLogger("migrations/148-delete-provider-connection-residue");
 //
 // The identity mapping, managed-routable set, and identity model tables are
 // frozen snapshots (migrations are self-contained) of the routing tables as
-// of 2026-08-20, matching migration 147's snapshots.
+// of 2026-08-20. They mirror the live tables exactly, unlike migration 147's
+// deliberately over-inclusive copies: this pass STAMPS an identity, so an
+// extra id would write a pair the read path strips, where 147 gates deletion
+// and must fail open.
 
 const ROUTING_IDENTITIES = new Set(["vellum", "chatgpt"]);
 const MANAGED_ROUTABLE = new Set([
@@ -97,9 +100,9 @@ const VELLUM_ROUTABLE_MODELS = new Set([
   "accounts/fireworks/models/minimax-m3",
   "accounts/fireworks/models/minimax-m2p7",
   "accounts/fireworks/models/deepseek-v4-pro",
-  // Migration 146 (which runs first) rewrites the undated DeepSeek flash id
-  // to the dated one; both are listed so either form folds.
-  "accounts/fireworks/models/deepseek-v4-flash",
+  // The retired undated DeepSeek flash id is deliberately absent (see above):
+  // a profile still carrying it because migration 146 deferred takes the
+  // dangling_binding_dropped path and keeps its declared provider.
   "accounts/fireworks/models/deepseek-v4-flash-0731",
   "MiniMaxAI/MiniMax-M3",
 ]);


### PR DESCRIPTION
## Summary
Round-2 re-review fixes for conn-removal-13b-step4-demolition.md.

**Gap 1:** 147 over-includes the retired DeepSeek id (deletion must fail open across a deferred 146); 148 excludes it (identity folds must mirror the live routable set).
**Gap 2:** 147's vellum-pin shortcut no longer applies to routing-identity profiles (148 keeps the identity and drops the stray binding).
**Gap 3:** write-time call-site validation now judges new or changed models against every determinable mix arm (deterministic, per-arm fail-open).
**Gap 4:** corrupt-JSON auth rows read as invalid instead of throwing, so list works and DELETE repairs them; raw-path delete also clears the per-name vault slot.
**Gap 5:** the shadowed-pin migration test now asserts the structured warn.
**Gap 6:** stale provider_connection docstring in persistence/schema/inference.ts.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41182" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->