### PR TITLE
fix: round-3 review gaps (mix fingerprint determinism, default-profile arms, migration 147 fail-open)

### DIFF
--- a/assistant/src/__tests__/helpers/mock-logger.ts
+++ b/assistant/src/__tests__/helpers/mock-logger.ts
@@ -57,6 +57,7 @@ export function createMockLoggerModule(
     truncateForLog: (value: string) => value,
     pruneOldLogFiles: () => 0,
     getCurrentLogFilePath: () => "/tmp/assistant-test-mock.log",
+    setBundledLoggerModules: () => {},
     LOG_FILE_PATTERN: /^assistant-(\d{4}-\d{2}-\d{2})\.log$/,
     ...overrides,
   };

--- a/assistant/src/__tests__/workspace-migration-147-strip-call-site-provider-overrides.test.ts
+++ b/assistant/src/__tests__/workspace-migration-147-strip-call-site-provider-overrides.test.ts
@@ -294,6 +294,38 @@ describe("147-strip-call-site-provider-overrides", () => {
     expect(readCallSites()).not.toHaveProperty("memoryExtraction");
   });
 
+  test("keeps a tweak whose identity winner the loader itself discards", () => {
+    // The profile declares "chatgpt" but carries a model only the managed
+    // route serves, so `LLMSchema` rejects the leaf and the loader drops the
+    // profile: this rung never wins at runtime and the site falls to another
+    // one. Judging the tweak against the Codex allowlist would delete it on
+    // a winner that does not exist.
+    writeConfig({
+      llm: {
+        profiles: {
+          subscription: {
+            source: "user",
+            provider: "chatgpt",
+            model: "claude-opus-5",
+          },
+        },
+        callSites: {
+          memoryExtraction: {
+            profile: "subscription",
+            model: "gemini-2.5-pro",
+          },
+        },
+      },
+    });
+
+    run();
+
+    expect(readCallSites().memoryExtraction).toEqual({
+      profile: "subscription",
+      model: "gemini-2.5-pro",
+    });
+  });
+
   test("keeps a tweak carrying the undated DeepSeek id under a vellum winner", () => {
     // Migration 146 normally rewrites this id first, but a deferred 146 (the
     // runner continues past a failed migration) leaves it in place for this

--- a/assistant/src/__tests__/workspace-migration-148-delete-provider-connection-residue.test.ts
+++ b/assistant/src/__tests__/workspace-migration-148-delete-provider-connection-residue.test.ts
@@ -8,14 +8,23 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Database } from "bun:sqlite";
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
 
 import { assertNotLiveDb } from "./assert-not-live-db.js";
+import { createMockLoggerModule } from "./helpers/mock-logger.js";
 
 // The migration's structured logs are the only observable difference between
 // its delete branches, so they are captured. `getLogger` is called at module
 // scope, so the mock must be registered before the migration module is
-// evaluated — hence the dynamic imports below.
+// evaluated, hence the dynamic imports below.
 interface LogCall {
   level: string;
   fields: Record<string, unknown>;
@@ -29,16 +38,20 @@ function capture(level: string) {
     });
   };
 }
-mock.module("../util/logger.js", () => ({
-  getLogger: () => ({
-    info: capture("info"),
-    warn: capture("warn"),
-    error: capture("error"),
-    debug: capture("debug"),
-    trace: capture("trace"),
-    fatal: capture("fatal"),
-  }),
-}));
+// Only the two levels the migration emits are captured. Everything else is
+// an inert method returning the same logger: a Bun module mock is
+// process-global for every module loaded after it, so a stub missing
+// `debug`/`child` would break unrelated suites sharing the run.
+const captureLogger: Record<string, unknown> = new Proxy(
+  { info: capture("info"), warn: capture("warn") } as Record<string, unknown>,
+  { get: (target, prop) => target[prop as string] ?? (() => captureLogger) },
+);
+mock.module("../util/logger.js", () =>
+  createMockLoggerModule({ getLogger: () => captureLogger }),
+);
+afterAll(() => {
+  mock.restore();
+});
 
 const { deleteProviderConnectionResidueMigration } =
   await import("../workspace/migrations/148-delete-provider-connection-residue.js");

--- a/assistant/src/providers/inference/connections.ts
+++ b/assistant/src/providers/inference/connections.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import type { DrizzleDb } from "../../persistence/db-connection.js";
 import { providerConnections } from "../../persistence/schema/inference.js";
 import { normalizeCredentialRef } from "../../security/credential-key.js";
+import { parseJsonSafe } from "../../util/json.js";
 import { getLogger } from "../../util/logger.js";
 import { clearConnectionProviderCache } from "../registry.js";
 import {
@@ -55,7 +56,10 @@ function isManagedRow(row: {
  * key in stored JSON is inert. Credential references are normalized to the
  * vault-key form on read as well as write, healing rows stored with the
  * secrets-API wire name (e.g. `openrouter:api_key`) without a migration.
- * Returns null for an underivable value; callers treat the row as invalid.
+ * Returns null for an underivable value, including the `null` a corrupt
+ * stored column parses to; callers treat the row as invalid (hidden from
+ * list/get, removable by DELETE) rather than throwing the read out from
+ * under themselves.
  */
 function parseAuth(raw: unknown, provider: string): Auth | null {
   if (raw === null || typeof raw !== "object") {
@@ -69,20 +73,6 @@ function parseAuth(raw: unknown, provider: string): Auth | null {
     return null;
   }
   return deriveStoredAuth(provider, normalizeCredentialRef(credential));
-}
-
-/**
- * The stored auth column as JSON, or null when the column does not parse.
- * A corrupt payload must read as an invalid row (hidden from list/get,
- * removable by DELETE), never throw the whole read out from under the
- * caller.
- */
-function parseStoredAuthColumn(raw: string): unknown {
-  try {
-    return JSON.parse(raw);
-  } catch {
-    return null;
-  }
 }
 
 /**
@@ -124,7 +114,7 @@ export function listConnections(
     : db.select().from(providerConnections).all();
 
   return rows.flatMap((row) => {
-    const auth = parseAuth(parseStoredAuthColumn(row.auth), row.provider);
+    const auth = parseAuth(parseJsonSafe(row.auth), row.provider);
     if (!auth) {
       return [];
     }
@@ -159,7 +149,7 @@ export function getConnection(
   if (!row) {
     return null;
   }
-  const auth = parseAuth(parseStoredAuthColumn(row.auth), row.provider);
+  const auth = parseAuth(parseJsonSafe(row.auth), row.provider);
   if (!auth) {
     return null;
   }
@@ -518,7 +508,7 @@ export function canonicalVellumConnection(): ProviderConnection {
  *     blocking prevents a confusing delete → re-appear loop).
  *   - PATCH that changes `auth` is blocked (auth is locked to `{type:"platform"}`
  *     so any other value would be reverted on the next boot upsert).
- *   - PATCH that changes `label` is allowed — users may legitimately relabel the
+ *   - PATCH that changes `label` is allowed: users may legitimately relabel the
  *     managed connection. `label` is seeded on initial INSERT and backfilled when
  *     null on subsequent boots so pre-seed installs pick up the default; a non-null
  *     user-customized label is preserved (see `seedCanonicalConnections`).

--- a/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
@@ -1880,10 +1880,9 @@ describe("call-site model writes are validated against the winning route", () =>
     );
   });
 
-  // A mix winner expands via an unseeded random arm pick per resolution, so
-  // it has no single route to fingerprint; an introduced model is judged
-  // against every arm instead. The loops catch a regression that resolves an
-  // arm and so only misjudges on some picks.
+  // A mix winner expands to a per-conversation seeded arm pick, so it has no
+  // single route to fingerprint; a model this write introduces or moves onto
+  // the mix is judged against every arm instead.
   const mixedProfiles = {
     op: { source: "user", provider: "openai", model: "gpt-5.5" },
     an: { source: "user", provider: "anthropic", model: "claude-opus-4-8" },
@@ -1897,11 +1896,51 @@ describe("call-site model writes are validated against the winning route", () =>
     },
   };
 
-  test("a call-site model only one mix arm serves returns 400 every time", async () => {
+  test("a call-site model only one mix arm serves returns 400", async () => {
+    rawConfigFixture = {
+      llm: {
+        profiles: structuredClone(mixedProfiles),
+        callSites: { memoryExtraction: { profile: "ab" } },
+      },
+    };
+    seedRawConfig();
+    await expect(
+      configPatchRoute.handler({
+        body: {
+          llm: { callSites: { memoryExtraction: { model: "gpt-5.4-nano" } } },
+        },
+      }),
+    ).rejects.toThrow(
+      'Model "gpt-5.4-nano" is not served by provider "anthropic". (llm.callSites.memoryExtraction.model, mix arm "an")',
+    );
+  });
+
+  // A mix rung whose pick lands on a disabled arm falls through to a
+  // different winner entirely, so a fingerprint that resolved an arm would
+  // see the mix on only some picks and judge the site against a route it may
+  // not take. The loops catch any save that disagrees with its twin.
+  const disabledArmProfiles = (mixName: string) => ({
+    op: { source: "user", provider: "openai", model: "gpt-5.5" },
+    an: {
+      source: "user",
+      provider: "anthropic",
+      model: "claude-opus-4-8",
+      status: "disabled",
+    },
+    [mixName]: {
+      source: "user",
+      mix: [
+        { profile: "op", weight: 1 },
+        { profile: "an", weight: 1 },
+      ],
+    },
+  });
+
+  test("a mix with a disabled arm judges a pinned site identically every save", async () => {
     for (let i = 0; i < 10; i += 1) {
       rawConfigFixture = {
         llm: {
-          profiles: structuredClone(mixedProfiles),
+          profiles: disabledArmProfiles("ab"),
           callSites: { memoryExtraction: { profile: "ab" } },
         },
       };
@@ -1909,13 +1948,161 @@ describe("call-site model writes are validated against the winning route", () =>
       await expect(
         configPatchRoute.handler({
           body: {
-            llm: { callSites: { memoryExtraction: { model: "gpt-5.4-nano" } } },
+            llm: {
+              callSites: { memoryExtraction: { model: "claude-opus-4-8" } },
+            },
           },
         }),
       ).rejects.toThrow(
-        'Model "gpt-5.4-nano" is not served by provider "anthropic". (llm.callSites.memoryExtraction.model, mix arm "an")',
+        'Model "claude-opus-4-8" is not served by provider "openai". (llm.callSites.memoryExtraction.model, mix arm "op")',
       );
     }
+  });
+
+  test("a mix with a disabled arm judges the anchor rung identically every save", async () => {
+    // `vision` has no shipped profile intent, so selection bottoms out on the
+    // anchor: a mix there expands with no winning profile name to report.
+    for (let i = 0; i < 10; i += 1) {
+      rawConfigFixture = { llm: { profiles: disabledArmProfiles("balanced") } };
+      seedRawConfig();
+      await expect(
+        configPatchRoute.handler({
+          body: {
+            llm: { callSites: { vision: { model: "claude-opus-4-8" } } },
+          },
+        }),
+      ).rejects.toThrow(
+        'Model "claude-opus-4-8" is not served by provider "openai". (llm.callSites.vision.model, mix arm "op")',
+      );
+    }
+  });
+
+  test("a mix over default profile keys validates its arms", async () => {
+    // Default profile bodies are never materialized into workspace config, so
+    // arms naming them resolve only through the effective-profile catalog.
+    rawConfigFixture = {
+      llm: {
+        defaultProvider: { provider: "anthropic" },
+        profiles: {
+          ab: {
+            source: "user",
+            mix: [
+              { profile: "balanced", weight: 1 },
+              { profile: "cost-optimized", weight: 1 },
+            ],
+          },
+        },
+        callSites: { memoryExtraction: { profile: "ab" } },
+      },
+    };
+    seedRawConfig();
+    await expect(
+      configPatchRoute.handler({
+        body: {
+          llm: { callSites: { memoryExtraction: { model: "gpt-5.4-nano" } } },
+        },
+      }),
+    ).rejects.toThrow(
+      'Model "gpt-5.4-nano" is not served by provider "anthropic". (llm.callSites.memoryExtraction.model, mix arm "balanced")',
+    );
+  });
+
+  test("moving a site's winner onto a mix revalidates an unchanged model", async () => {
+    rawConfigFixture = {
+      llm: {
+        profiles: structuredClone(mixedProfiles),
+        callSites: {
+          memoryExtraction: { profile: "an", model: "claude-opus-4-8" },
+        },
+      },
+    };
+    seedRawConfig();
+    await expect(
+      configPatchRoute.handler({
+        body: { llm: { callSites: { memoryExtraction: { profile: "ab" } } } },
+      }),
+    ).rejects.toThrow(
+      'Model "claude-opus-4-8" is not served by provider "openai". (llm.callSites.memoryExtraction.model, mix arm "op")',
+    );
+  });
+
+  test("moving a site's winner between mixes revalidates an unchanged model", async () => {
+    rawConfigFixture = {
+      llm: {
+        profiles: {
+          ...structuredClone(mixedProfiles),
+          an2: {
+            source: "user",
+            provider: "anthropic",
+            model: "claude-sonnet-5",
+          },
+          anthropicOnly: {
+            source: "user",
+            mix: [
+              { profile: "an", weight: 1 },
+              { profile: "an2", weight: 1 },
+            ],
+          },
+        },
+        callSites: {
+          memoryExtraction: {
+            profile: "anthropicOnly",
+            model: "claude-opus-4-8",
+          },
+        },
+      },
+    };
+    seedRawConfig();
+    await expect(
+      configPatchRoute.handler({
+        body: { llm: { callSites: { memoryExtraction: { profile: "ab" } } } },
+      }),
+    ).rejects.toThrow(
+      'Model "claude-opus-4-8" is not served by provider "openai". (llm.callSites.memoryExtraction.model, mix arm "op")',
+    );
+  });
+
+  test("swapping an arm of the winning mix revalidates an unchanged model", async () => {
+    rawConfigFixture = {
+      llm: {
+        profiles: {
+          op: { source: "user", provider: "openai", model: "gpt-5.5" },
+          op2: { source: "user", provider: "openai", model: "gpt-5.2" },
+          an: {
+            source: "user",
+            provider: "anthropic",
+            model: "claude-opus-4-8",
+          },
+          ab: {
+            source: "user",
+            mix: [
+              { profile: "op", weight: 1 },
+              { profile: "op2", weight: 1 },
+            ],
+          },
+        },
+        callSites: { memoryExtraction: { profile: "ab", model: "gpt-5.5" } },
+      },
+    };
+    seedRawConfig();
+    await expect(
+      configPatchRoute.handler({
+        body: {
+          llm: {
+            profiles: {
+              ab: {
+                mix: [
+                  { profile: "op", weight: 1 },
+                  { profile: "an", weight: 1 },
+                ],
+              },
+            },
+          },
+        },
+      }),
+    ).rejects.toThrow(
+      'Model "gpt-5.5" is not served by provider "anthropic". (llm.callSites.memoryExtraction.model, mix arm "an")',
+    );
   });
 
   test("a call-site model every mix arm serves saves", async () => {

--- a/assistant/src/runtime/routes/__tests__/inference-provider-connection-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/inference-provider-connection-routes.test.ts
@@ -1191,7 +1191,7 @@ describe("DELETE repairs a row whose stored auth is underivable", () => {
 
 describe("DELETE repairs a row whose stored auth is not JSON at all", () => {
   // A corrupt auth column must read as an invalid row, not throw out of the
-  // loaders — otherwise the whole list breaks and DELETE (the one repair
+  // loaders: otherwise the whole list breaks and DELETE (the one repair
   // path) 500s instead of removing the row.
   beforeEach(() => {
     const now = Date.now();

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -1452,8 +1452,9 @@ function assertRoutableIdentityEntries(
  * surfaces elsewhere, a winner whose connection row cannot be read, or a
  * route whose model set is not code-known: endpoint-supplied providers,
  * keyless ollama), matching `preflightResolvedConfig`'s posture. A mix
- * winner has no single route to fingerprint, so an introduced or changed
- * model is judged against its arms instead (`assertServableByEveryMixArm`).
+ * winner has no single route to fingerprint, so a model this write
+ * introduces, changes, or moves onto the mix is judged against its arms
+ * instead (`assertServableByEveryMixArm`).
  */
 function assertServableCallSiteModels(
   preWrite: Record<string, unknown>,
@@ -1499,38 +1500,53 @@ function assertServableCallSiteModels(
      * rather than a dispatch-translated vendor. Null = indeterminate.
      */
     kind: string | null;
-    /** The winning profile's name when the winner is a mix, else null. */
+    /** The mix profile the route expanded through, else null. */
     mixProfile: string | null;
+    /** That mix's arm names, so an arm-list edit reads as a move. */
+    mixArms: string | null;
   }
   const routeFingerprint = (
     llm: z.infer<typeof LLMSchema>,
     site: LLMCallSite,
   ): RouteFingerprint => {
-    const { config, profileName } = resolveCallSiteConfigWithProfile(site, llm);
-    // A mix winner expands to a random arm on every unseeded resolution
-    // here, so its route cannot be fingerprinted: any judgment would be
-    // against a nondeterministic arm. Indeterminate, like the other
-    // fail-open cases; its name is carried out so an introduced model can
-    // still be judged arm by arm.
-    if (profileName != null && llm.profiles?.[profileName]?.mix != null) {
-      return { provider: null, kind: null, mixProfile: profileName };
+    // The seed is fixed so a pre-write and a post-write resolution of the
+    // same config expand mixes identically and an unchanged route never
+    // reads as moved. It is reproducibility only, never the basis of a
+    // judgment: a mix is still judged arm by arm below.
+    const expandedMixes: string[] = [];
+    const { config } = resolveCallSiteConfigWithProfile(site, llm, {
+      selectionSeed: site,
+      onMixSelected: ({ mixProfile }) => {
+        expandedMixes.push(mixProfile);
+      },
+    });
+    // Any mix the chain expanded (a named rung's or the anchor's) makes the
+    // route a per-conversation pick, so it cannot be fingerprinted: a rung
+    // whose arm is unusable under this seed still wins under another. The
+    // last expansion is the lowest-precedence one the chain reached, so it
+    // is the mix that either won or stood between the site and its winner.
+    // Indeterminate, like the other fail-open cases; the mix's name and arms
+    // are carried out so the model can still be judged arm by arm.
+    const mixProfile = expandedMixes[expandedMixes.length - 1] ?? null;
+    if (mixProfile != null) {
+      return {
+        provider: null,
+        kind: null,
+        mixProfile,
+        mixArms: JSON.stringify(mixArmNames(llm, mixProfile)),
+      };
     }
     return {
       provider: config.provider,
       kind: providerKind(config.provider),
       mixProfile: null,
+      mixArms: null,
     };
   };
 
   for (const { site, model } of modelBearing) {
     const route = routeFingerprint(post.data, site);
     const modelChanged = model !== readPlainObject(priorSites[site])?.model;
-    if (route.kind == null) {
-      if (modelChanged && route.mixProfile != null) {
-        assertServableByEveryMixArm(post.data, route.mixProfile, site, model);
-      }
-      continue;
-    }
     if (!modelChanged) {
       // Model untouched: validate only when this write moved the site's
       // route. An indeterminable pre-write config counts as unmoved, so a
@@ -1541,10 +1557,19 @@ function assertServableCallSiteModels(
       const prior = routeFingerprint(pre.data, site);
       const moved =
         prior.provider !== route.provider ||
-        (prior.kind != null && prior.kind !== route.kind);
+        (prior.kind != null && prior.kind !== route.kind) ||
+        prior.mixProfile !== route.mixProfile ||
+        prior.mixArms !== route.mixArms;
       if (!moved) {
         continue;
       }
+    }
+    if (route.mixProfile != null) {
+      assertServableByEveryMixArm(post.data, route.mixProfile, site, model);
+      continue;
+    }
+    if (route.kind == null) {
+      continue;
     }
     const issue = servabilityIssue(route.kind, model);
     if (issue) {
@@ -1554,14 +1579,34 @@ function assertServableCallSiteModels(
 }
 
 /**
+ * The arm profile names of a mix, resolved the way the runtime resolver
+ * resolves the mix itself; empty when the name is not a mix.
+ */
+function mixArmNames(
+  llm: z.infer<typeof LLMSchema>,
+  mixProfile: string,
+): string[] {
+  const entry = resolveDefaultProfileForProvider(
+    llm.profiles,
+    mixProfile,
+    llm.defaultProvider ?? null,
+  );
+  return (entry?.mix ?? []).map((arm) => arm.profile);
+}
+
+/**
  * Reject a call-site model no arm of a mix winner can serve. A mix has no
  * single route to fingerprint (the arm is a seeded per-conversation pick),
- * but its arms are fully knowable: the schema guarantees every arm exists
- * and is a standard profile, so a model this write introduces or changes is
- * required to be servable by all of them. Judged only for arms whose kind is
- * determinable; an arm that cannot be judged fails open on its own, and a
- * disabled arm is skipped because selection falls through to another winner
- * entirely when the pick lands on it.
+ * but its arms are fully knowable: `LLMSchema.superRefine` guarantees every
+ * arm names a standard profile that RESOLVES, which for a default-profile
+ * key means the code-owned body rather than a `llm.profiles` entry (defaults
+ * are never materialized into workspace config). Arms therefore resolve
+ * through the same effective-profile catalog the runtime uses; an arm that
+ * resolves to nothing is a genuine fail-open, not the common case. Judged
+ * only for arms whose kind is determinable; an arm that cannot be judged
+ * fails open on its own, and a disabled or incomplete arm is skipped because
+ * selection falls through to another winner entirely when the pick lands
+ * on it.
  */
 function assertServableByEveryMixArm(
   llm: z.infer<typeof LLMSchema>,
@@ -1569,12 +1614,18 @@ function assertServableByEveryMixArm(
   site: LLMCallSite,
   model: string,
 ): void {
-  for (const arm of llm.profiles?.[mixProfile]?.mix ?? []) {
-    const entry = llm.profiles?.[arm.profile];
+  const defaultProvider = llm.defaultProvider ?? null;
+  for (const armName of mixArmNames(llm, mixProfile)) {
+    const entry = resolveDefaultProfileForProvider(
+      llm.profiles,
+      armName,
+      defaultProvider,
+    );
     if (
       entry == null ||
       entry.status === "disabled" ||
-      entry.provider == null
+      entry.provider == null ||
+      entry.model == null
     ) {
       continue;
     }
@@ -1585,7 +1636,7 @@ function assertServableByEveryMixArm(
     const issue = servabilityIssue(kind, model);
     if (issue) {
       throw new BadRequestError(
-        `${issue} (llm.callSites.${site}.model, mix arm "${arm.profile}")`,
+        `${issue} (llm.callSites.${site}.model, mix arm "${armName}")`,
       );
     }
   }

--- a/assistant/src/runtime/routes/inference-provider-connection-routes.ts
+++ b/assistant/src/runtime/routes/inference-provider-connection-routes.ts
@@ -574,10 +574,13 @@ async function handleDeleteConnection({ pathParams = {} }: RouteHandlerArgs) {
   // A row whose stored auth payload is underivable (`parseAuth` returns
   // null, including a column that is not JSON at all) is hidden by the typed
   // loader but still occupies its name; DELETE is the one repair path, so
-  // fall through to the raw row and run the guards below on it. Such a row
-  // can never be the managed row (the managed row's auth always derives) and
-  // cannot be routed through, but it may still own the per-name credential
-  // slot from when it was healthy, so the cleanup below covers it.
+  // fall through to the raw row and run the guards below on it. A corrupt
+  // auth column on the canonical row reads as underivable too, so
+  // `claimsManagedName` goes true and the managed-delete protection is
+  // bypassed: that is the intended repair, since boot re-seeds the real
+  // managed connection under the same name. Such a row cannot be routed
+  // through, but it may still own its credential slot (see the cleanup at
+  // the end of this handler).
   const rawRow = existing ?? getConnectionRowRaw(getDb(), name);
   if (!rawRow) {
     throw new NotFoundError(`Connection "${name}" not found.`);
@@ -677,7 +680,7 @@ async function handleDeleteConnection({ pathParams = {} }: RouteHandlerArgs) {
   // shared across rows. An underivable row has no readable pointer to check,
   // but it can still own that slot from when it was healthy, so the repair
   // path clears it best-effort. Awaited so the response orders after the
-  // vault delete — a client that deletes, recreates the name, and saves a new
+  // vault delete: a client that deletes, recreates the name, and saves a new
   // key must never have that key erased by a still-in-flight deletion.
   // Failures are logged, never surfaced: a vault outage leaves an orphaned
   // secret, not a failed delete (the timeout on vault calls bounds the wait).

--- a/assistant/src/workspace/migrations/147-strip-call-site-provider-overrides.ts
+++ b/assistant/src/workspace/migrations/147-strip-call-site-provider-overrides.ts
@@ -430,10 +430,10 @@ function winnerProviderForSite(
  * (or an explicitly managed stub, which the resolver overrides with the
  * code-owned body), "fall_through" when the name resolves to nothing, and
  * null when the outcome cannot be determined. A user-owned workspace entry
- * in any state that is not plainly usable is indeterminate on purpose: the
- * effective profile view materializes default bodies through workspace
- * state this migration does not reproduce, and deletion must never ride on
- * an approximation.
+ * in any state that is not plainly usable, and any profile the read path
+ * would reject outright, are indeterminate on purpose: the effective profile
+ * view materializes default bodies through workspace state this migration
+ * does not reproduce, and deletion must never ride on an approximation.
  */
 function rungProvider(
   name: string,
@@ -470,6 +470,21 @@ function rungProvider(
       VELLUM_ROUTABLE_MODELS.has(model)
     ) {
       return "vellum";
+    }
+    // A declared routing identity that cannot serve the profile's OWN model
+    // is rejected at parse (`routingIdentityModelIssue` fails the leaf and
+    // the loader drops the profile), so this rung's winner does not exist on
+    // the read path and the site really falls through to a later rung.
+    // Indeterminate rather than judged: a deletion must never ride on a
+    // winner the runtime discards.
+    if (
+      ROUTING_IDENTITIES.has(usableProvider) &&
+      model !== null &&
+      !(
+        usableProvider === "vellum" ? VELLUM_ROUTABLE_MODELS : CODEX_MODELS
+      ).has(model)
+    ) {
+      return null;
     }
     return usableProvider;
   }


### PR DESCRIPTION
## Summary
Round-3 re-review fixes for conn-removal-13b-step4-demolition.md. Gaps 1-3 are regressions from the previous fix round.

**Gap 1:** the call-site route fingerprint resolved mixes unseeded, so identical saves could disagree; it is now deterministic and detects mixes on every rung including the anchor.
**Gap 2:** mix-arm validation dereferenced arms raw, so it validated nothing for unmaterialized default-profile arms (the canonical A/B shape); arms now resolve through the effective-profile catalog.
**Gap 3:** migration 147's identity guard could delete a call-site tweak whose winner the loader strips; identities the profile's own model cannot reach are indeterminate again (keep, never delete on an approximation).
**Gap 4:** a route move onto a mix now revalidates an unchanged model, matching the guard's stated contract.
**Gap 5:** the migration-148 logger mock uses the sanctioned full-surface helper and restores itself.
**Gap 6:** parseJsonSafe reuse, em dashes, and two stale/duplicated comments.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41184" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->