### PR TITLE
Verify app icon apply/reset against re-read native state

### DIFF
--- a/clients/web/src/components/avatar/app-icon-match-prompt.test.tsx
+++ b/clients/web/src/components/avatar/app-icon-match-prompt.test.tsx
@@ -6,8 +6,8 @@
  * bundle) is pinned once in `use-app-icon-sync.test.tsx`, so only the flag case
  * stands here as the representative. An offer already on screen has to go quiet
  * on the same terms, so the tests below also take the question away
- * mid-display, and a swap iOS refuses has to leave the question exactly where
- * it was.
+ * mid-display, and a swap iOS refuses, or takes without moving the home screen,
+ * has to leave the question exactly where it was.
  */
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { act, cleanup, render, waitFor } from "@testing-library/react";
@@ -78,9 +78,21 @@ let iconState: AppIconState = {
 
 /** What the shell answers the next swap with: iOS is free to refuse one. */
 let swapSucceeds = true;
+/** iOS taking a swap and leaving the home screen exactly as it was. */
+let swapSilentlyNoOps = false;
 
 const getAppIconState = mock(async () => iconState);
-const setAppIcon = mock(async (_name: string | null) => swapSucceeds);
+// Mirrors the shell: a swap that lands changes what the next read reports, and
+// one that is refused, or silently dropped, leaves that read where it was.
+const setAppIcon = mock(async (name: string | null) => {
+  if (!swapSucceeds) {
+    return false;
+  }
+  if (!swapSilentlyNoOps) {
+    iconState = { ...iconState, current: name };
+  }
+  return true;
+});
 
 mock.module("@/runtime/app-icon", () => ({ getAppIconState, setAppIcon }));
 mock.module("@/runtime/platform-detection", () => ({
@@ -170,6 +182,7 @@ async function expectNoPrompt() {
 beforeEach(() => {
   avatarState = CHARACTER;
   swapSucceeds = true;
+  swapSilentlyNoOps = false;
   iconState = { supported: true, current: null, available: [ICON, OTHER_ICON] };
   localStorage.clear();
   __resetAppIconOfferSession();
@@ -234,6 +247,30 @@ describe("AppIconMatchPrompt", () => {
     await waitFor(() => {
       expect(setAppIcon).toHaveBeenCalledTimes(2);
     });
+    await waitFor(() => {
+      expect(dialogTitle()).toBeNull();
+    });
+  });
+
+  test("keeps the dialog up when the swap is taken but never made", async () => {
+    swapSilentlyNoOps = true;
+    renderPrompt();
+    await expectPrompt();
+
+    clickByText("Apply");
+
+    // The shell said yes and the home screen did not move, so the question is
+    // still a question and the dialog has to say so.
+    await waitFor(() => {
+      expect(alertText()).toBe(
+        "iOS did not change your home screen icon. You can try again.",
+      );
+    });
+    expect(dialogTitle()).toBe("Match your app icon to your avatar?");
+
+    swapSilentlyNoOps = false;
+    clickByText("Apply");
+
     await waitFor(() => {
       expect(dialogTitle()).toBeNull();
     });

--- a/clients/web/src/hooks/use-app-icon-sync.test.tsx
+++ b/clients/web/src/hooks/use-app-icon-sync.test.tsx
@@ -1,8 +1,9 @@
 /**
  * The invariants this feature rests on: an icon is only ever *offered* for a
  * character avatar the installed build ships a bundle for, `setAppIcon` is only
- * ever reached from a user-pressed callback, and every mounted consumer reads
- * the same shell snapshot.
+ * ever reached from a user-pressed callback, every mounted consumer reads the
+ * same shell snapshot, and a swap counts as landed only when a re-read of the
+ * shell says the home screen holds the icon that was asked for.
  */
 import { readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
@@ -53,6 +54,10 @@ let iconState: AppIconState = {
 /** What the shell answers the next swap with: iOS is free to refuse one. */
 let swapSucceeds = true;
 
+// The two are deliberately independent: what the shell answers a swap with and
+// what it reports afterwards are separate facts, so a test models a swap that
+// landed by moving `iconState` and a swap that silently did not by leaving it
+// where it was.
 const getAppIconState = mock(async () => iconState);
 const setAppIcon = mock(async (_name: string | null) => swapSucceeds);
 
@@ -215,7 +220,70 @@ describe("useAppIconSync", () => {
     });
   });
 
+  test("apply reports a swap the shell took but never made", async () => {
+    // iOS accepting `setAlternateIconName` and leaving the home screen alone:
+    // the request says it worked and the next read says otherwise.
+    const { result } = await renderSync();
+    await waitFor(() => {
+      expect(result.current.canOffer).toBe(true);
+    });
+
+    let applied: boolean | undefined;
+    await act(async () => {
+      applied = await result.current.apply();
+    });
+
+    expect(setAppIcon).toHaveBeenCalledTimes(1);
+    // The read is what counts, and it still reports the default icon.
+    expect(applied).toBe(false);
+    expect(useAppIconStore.getState().snapshot.current).toBeNull();
+    expect(result.current.currentIcon).toBeNull();
+    expect(result.current.canOffer).toBe(true);
+  });
+
+  test("apply reports failure when the re-read degrades", async () => {
+    const { result } = await renderSync();
+    await waitFor(() => {
+      expect(result.current.canOffer).toBe(true);
+    });
+    // The shell stops answering mid-swap, which every degrade path in
+    // `runtime/app-icon` turns into this snapshot rather than a rejection.
+    iconState = { supported: false, current: null, available: [] };
+
+    let applied: boolean | undefined;
+    await act(async () => {
+      applied = await result.current.apply();
+    });
+
+    expect(applied).toBe(false);
+    expect(useAppIconStore.getState().snapshot).toEqual(APP_ICON_UNSUPPORTED);
+    await waitFor(() => {
+      expect(result.current.enabled).toBe(false);
+    });
+  });
+
   test("reset restores the default icon", async () => {
+    iconState = { supported: true, current: ICON, available: [ICON] };
+    const { result } = await renderSync();
+    await waitFor(() => {
+      expect(result.current.currentIcon).toBe(ICON);
+    });
+    iconState = { supported: true, current: null, available: [ICON] };
+
+    let restored: boolean | undefined;
+    await act(async () => {
+      restored = await result.current.reset();
+    });
+
+    expect(restored).toBe(true);
+    expect(setAppIcon).toHaveBeenCalledTimes(1);
+    expect(setAppIcon.mock.calls[0]?.[0]).toBeNull();
+    await waitFor(() => {
+      expect(result.current.currentIcon).toBeNull();
+    });
+  });
+
+  test("reset reports a swap the shell took but never made", async () => {
     iconState = { supported: true, current: ICON, available: [ICON] };
     const { result } = await renderSync();
     await waitFor(() => {
@@ -227,9 +295,10 @@ describe("useAppIconSync", () => {
       restored = await result.current.reset();
     });
 
-    expect(restored).toBe(true);
     expect(setAppIcon).toHaveBeenCalledTimes(1);
-    expect(setAppIcon.mock.calls[0]?.[0]).toBeNull();
+    expect(restored).toBe(false);
+    expect(useAppIconStore.getState().snapshot.current).toBe(ICON);
+    expect(result.current.currentIcon).toBe(ICON);
   });
 
   test("apply hands back a refusal and leaves the snapshot truthful", async () => {

--- a/clients/web/src/hooks/use-app-icon-sync.test.tsx
+++ b/clients/web/src/hooks/use-app-icon-sync.test.tsx
@@ -283,6 +283,26 @@ describe("useAppIconSync", () => {
     });
   });
 
+  test("reset reports failure when the re-read degrades", async () => {
+    iconState = { supported: true, current: ICON, available: [ICON] };
+    const { result } = await renderSync();
+    await waitFor(() => {
+      expect(result.current.currentIcon).toBe(ICON);
+    });
+    iconState = { supported: false, current: null, available: [] };
+
+    let restored: boolean | undefined;
+    await act(async () => {
+      restored = await result.current.reset();
+    });
+
+    expect(restored).toBe(false);
+    expect(useAppIconStore.getState().snapshot).toEqual(APP_ICON_UNSUPPORTED);
+    await waitFor(() => {
+      expect(result.current.enabled).toBe(false);
+    });
+  });
+
   test("reset reports a swap the shell took but never made", async () => {
     iconState = { supported: true, current: ICON, available: [ICON] };
     const { result } = await renderSync();

--- a/clients/web/src/hooks/use-app-icon-sync.ts
+++ b/clients/web/src/hooks/use-app-icon-sync.ts
@@ -94,8 +94,8 @@ export function useAppIconSync(assistantId: string | null): AppIconSync {
   // both callbacks re-read the shell and report what that read found. The
   // caller has UI riding on the answer, and it should be riding on the home
   // screen rather than on the request. A read that degrades, an old shell or a
-  // bridge fault, reports nothing applied: an apply reads as failed instead of
-  // throwing, and a reset as already back to the default icon.
+  // bridge fault, cannot verify anything, so both callbacks report failure
+  // instead of throwing.
   const apply = useCallback(async () => {
     if (!enabled || !availableMatch || target === null) {
       return false;
@@ -111,7 +111,7 @@ export function useAppIconSync(assistantId: string | null): AppIconSync {
     }
     await setAppIcon(null);
     const restored = await refresh();
-    return restored.current === null;
+    return restored.supported && restored.current === null;
   }, [enabled, refresh]);
 
   return {

--- a/clients/web/src/hooks/use-app-icon-sync.ts
+++ b/clients/web/src/hooks/use-app-icon-sync.ts
@@ -43,8 +43,9 @@ export interface AppIconSync {
   /** True when the shell bundles `targetIcon` and it is not already applied. */
   canOffer: boolean;
   /**
-   * Apply `targetIcon`. User-initiated only. Resolves true only when the home
-   * screen actually changed, so callers can keep their action on screen.
+   * Apply `targetIcon`. User-initiated only. Resolves true only when a re-read
+   * of the shell finds the icon on the home screen, so callers can keep their
+   * action on screen.
    */
   apply: () => Promise<boolean>;
   /** Restore the default icon. User-initiated only. Resolves as `apply` does. */
@@ -60,12 +61,16 @@ export function useAppIconSync(assistantId: string | null): AppIconSync {
   const iconState = useAppIconStore.use.snapshot();
   const setSnapshot = useAppIconStore.use.setSnapshot();
 
+  // Publishes the shell's answer and hands the same snapshot back, so a caller
+  // that just asked for a swap can judge it against what the shell now reports.
   const refresh = useCallback(async () => {
     if (!gateOpen) {
       setSnapshot(APP_ICON_UNSUPPORTED);
-      return;
+      return APP_ICON_UNSUPPORTED;
     }
-    setSnapshot(await getAppIconState());
+    const next = await getAppIconState();
+    setSnapshot(next);
+    return next;
   }, [gateOpen, setSnapshot]);
 
   useEffect(() => {
@@ -83,26 +88,30 @@ export function useAppIconSync(assistantId: string | null): AppIconSync {
   const { target, availableMatch } = resolveAppIconTarget(state, iconState);
   const canOffer = availableMatch && target !== iconState.current;
 
-  // iOS can refuse a swap, and the caller has UI riding on the answer, so the
-  // shell's verdict is handed back rather than swallowed. The refresh runs
-  // either way: a refusal still has to leave the snapshot telling the truth
-  // about what is on the home screen.
+  // iOS can refuse a swap outright, and it can also take one and leave the home
+  // screen alone (the app backgrounded mid-swap, the iOS 26 regressions). The
+  // request's own answer is therefore not evidence that anything changed, so
+  // both callbacks re-read the shell and report what that read found. The
+  // caller has UI riding on the answer, and it should be riding on the home
+  // screen rather than on the request. A read that degrades, an old shell or a
+  // bridge fault, reports nothing applied: an apply reads as failed instead of
+  // throwing, and a reset as already back to the default icon.
   const apply = useCallback(async () => {
     if (!enabled || !availableMatch || target === null) {
       return false;
     }
-    const applied = await setAppIcon(target);
-    await refresh();
-    return applied;
+    await setAppIcon(target);
+    const applied = await refresh();
+    return applied.supported && applied.current === target;
   }, [enabled, availableMatch, target, refresh]);
 
   const reset = useCallback(async () => {
     if (!enabled) {
       return false;
     }
-    const restored = await setAppIcon(null);
-    await refresh();
-    return restored;
+    await setAppIcon(null);
+    const restored = await refresh();
+    return restored.current === null;
   }, [enabled, refresh]);
 
   return {


### PR DESCRIPTION
## Summary

- `apply` and `reset` no longer trust the swap request. After `setAppIcon` resolves, both re-read `getAppIconState()`, publish that snapshot to the app-icon store, and derive their boolean from the read: apply is true only when `supported` is still true and `current === target`, reset only when `current === null`.
- This closes the silent no-op hole. iOS can accept `setAlternateIconName` and leave the home screen alone (app backgrounded mid-swap, the iOS 26 regressions), and `setAppIcon` never rejects by design, so the request's own answer was never evidence that anything changed.
- The never-throw contract is preserved: a degraded read (old shell, bridge fault) is an unsupported snapshot, so apply reports failure rather than throwing.
- No new `setAppIcon(` call sites. The two-call-site scan test still passes, and `refresh` is still the only writer of the store.
- Consumers already branch on the boolean and needed no change; the prompt's `offerRef` stale-completion guard is untouched.
- Tests: the hook suite now pins apply/reset confirmed by the re-read, a swap the shell took but never made (apply and reset), and a re-read that degrades. The prompt's shell mock now mirrors the device (a landed swap moves what the next read reports), with a silent-no-op case that keeps the dialog up and retryable.

Follow-up to the ios-avatar-app-icons plan (FB PR #41181).