### PR TITLE
Record the alternate-icon name cache contract and rule out 180px detail capping

### DIFF
--- a/clients/ios/README.md
+++ b/clients/ios/README.md
@@ -361,6 +361,27 @@ That is **34.3 KiB per alternate icon** compiled, against 8.82 MiB of PNGs
 checked in. The whole catalog is one `Assets.car` slice, so the cost lands on
 every install whether or not the user ever switches icons.
 
+**Do not try to shrink this by capping the rendered detail.** Rendering at
+180 px (the largest size iOS ever draws an alternate icon at) and upscaling
+onto the 1024 canvas is a standard icon-shrinking trick, and it backfires
+badly on this artwork. The avatars are flat vector shapes, so a native 1024
+render is almost entirely uniform regions separated by hairline antialiased
+edges, which is the best case there is for compression. A bilinear upscale
+replaces every one of those edges with a six-pixel gradient ramp:
+
+| Full catalog, 540 icons | Committed PNGs | `Assets.car` |
+| ----------------------- | -------------- | ------------ |
+| Native 1024 render (current) | 9,142,935 B (8.72 MiB) | 18,963,192 B (18.08 MiB) |
+| 180 px detail, bilinear upscale | 64,211,254 B (61.24 MiB) | 118,320,408 B (112.84 MiB) |
+
+Those `Assets.car` figures come from compiling `AvatarIcons.xcassets` alone
+through `actool`, which lands within 0.1 percent of the in-build delta above.
+Rendering at 360 px instead of 180 only halves the overshoot. Nearest-neighbour
+upscaling does shrink the compiled catalog by 45 percent, but the 5.69x
+non-integer scale leaves visible stair-stepping: max per-channel error against
+the current icons at display size is about 220 of 255, against about 110 for
+bilinear. Display-size fidelity was never the problem, the compressed size was.
+
 ### Bundle ID vs capacitor.config appId
 
 There's a deliberate mismatch:

--- a/clients/ios/scripts/generate-avatar-icons.ts
+++ b/clients/ios/scripts/generate-avatar-icons.ts
@@ -120,6 +120,10 @@ export interface GenerateAvatarIconsOptions {
  * name when it asks iOS to switch icons, so this format is a wire contract:
  * changing it breaks every already-installed app until both sides ship
  * together.
+ *
+ * The name is also a cache key: iOS caches an alternate icon's artwork under
+ * it, so once this has shipped, never redraw the artwork behind an existing
+ * name. Changed art has to go out under a new versioned name.
  */
 export function iconNameForTraits(traits: AvatarIconTraits): string {
   return `avatar-${traits.bodyShape}-${traits.eyeStyle}-${traits.color}`;

--- a/clients/ios/scripts/generate-avatar-icons.ts
+++ b/clients/ios/scripts/generate-avatar-icons.ts
@@ -122,8 +122,8 @@ export interface GenerateAvatarIconsOptions {
  * together.
  *
  * The name is also a cache key: iOS caches an alternate icon's artwork under
- * it, so once this has shipped, never redraw the artwork behind an existing
- * name. Changed art has to go out under a new versioned name.
+ * it, so each name permanently identifies one artwork version. Changed art
+ * goes out under a new versioned name, never behind an existing one.
  */
 export function iconNameForTraits(traits: AvatarIconTraits): string {
   return `avatar-${traits.bodyShape}-${traits.eyeStyle}-${traits.color}`;


### PR DESCRIPTION
## Summary

The planned change was to cap the rendered detail of the 540 alternate app
icons at 180 px (the largest size iOS ever draws one at) and upscale onto the
1024 canvas Xcode requires. It was implemented, measured against the plan's
">= 10 percent compiled savings" gate, and **rejected: on this artwork it makes
the compiled catalog 6.2x larger, not smaller.**

What ships is the part that stands on its own: the cache-busting convention
comment, plus the measurements recorded in `clients/ios/README.md` so nobody
retries this.

## Measured, full 540-icon catalog

| Variant | Committed PNGs | `Assets.car` |
| ------- | -------------- | ------------ |
| Native 1024 render (current) | 9,142,935 B (8.72 MiB) | 18,963,192 B (18.08 MiB) |
| 180 px detail, bilinear upscale | 64,211,254 B (61.24 MiB) | 118,320,408 B (112.84 MiB) |
| Delta | +602 percent | **+524 percent** |

Gate required at least 10 percent savings. Measured: minus 524 percent.

`Assets.car` figures come from compiling `AvatarIcons.xcassets` alone through
`actool` (iphoneos, iphone + ipad idioms, `--include-all-app-icons`). That
method reproduces the in-build `Assets.car` delta recorded on #41163 to within
0.1 percent, so it is a faithful stand-in for a full `xcodebuild`.

### Why it backfires

The avatars are flat vector shapes. A native 1024 render is almost entirely
uniform color regions separated by hairline antialiased edges, which is the
best case there is for compression. Bilinear upscaling from 180 replaces every
one of those edges with a six-pixel gradient ramp, which is the worst case.
`assetutil --info` confirms actool stores the full 1024 bitmap in `Assets.car`
(one rendition each for phone and pad) and lets iOS downscale at runtime, so
the pixel entropy of the 1024 image is exactly what gets paid for.

Ladder measured on the 24-icon pilot slice, same actool flags:

| Render detail | `Assets.car` | vs native |
| ------------- | ------------ | --------- |
| Native 1024 | 815,272 B | baseline |
| 360 px, bilinear | 3,131,784 B | +284 percent |
| 180 px, bilinear | 4,851,784 B | +495 percent |
| 180 px, nearest neighbour | 451,944 B | minus 45 percent |

### Fidelity is not what failed

36 icons spanning 9 body shapes, all 9 eye styles and all 6 colors, comparing
the current 1024 assets against the 180 px bilinear ones after downscaling both
to the sizes iOS actually displays:

| Downscale | Mean absolute per-channel error |
| --------- | ------------------------------- |
| 180 px, bilinear | 0.345 to 0.753 of 255 |
| 180 px, area | 0.325 to 0.642 of 255 |
| 120 px, bilinear | 0.542 to 1.051 of 255 |
| 120 px, area | 0.281 to 0.575 of 255 |

All comfortably inside the 2/255 bar, worst single-channel error 156 and
confined to antialiased edges, and side-by-side contact sheets at 180 px are
visually indistinguishable. 120 px (the 2x devices) is no worse than 180 px.

### The one variant that would save space

Nearest-neighbour upscaling from 180 shrinks the compiled catalog 45 percent.
But 1024/180 is 5.69, a non-integer scale, so blocks alternate between 5 and 6
pixels and the result stair-steps: mean per-channel error rises to 1.19 to 1.95
of 255 (up against the 2/255 bar) and max per-channel error to about 220 of
255, double bilinear's. Against a "must not look even slightly off on device"
bar that is a deliberate call for the lead, not something to slip in here.

## What actually changed

- `clients/ios/scripts/generate-avatar-icons.ts`: four comment lines on
  `iconNameForTraits` recording that iOS caches alternate-icon artwork by name,
  so redrawn art has to ship under a new versioned name.
- `clients/ios/README.md`: the measurements above, under the existing
  "Alternate icon size cost" section.

No generated asset changed, and no render path changed.

## Verification

`cd clients/ios && bun test scripts/__tests__/generate-avatar-icons.test.ts`
passes: 11 pass, 0 fail, 3793 assertions, 130s. That includes the drift guard,
which regenerates all 540 icons and diffs them byte for byte against the
committed catalog.

Follow-up to the ios-avatar-app-icons plan (FB PR #41181).