### PR TITLE
simplify: write-time call-site validation does not judge mix winners

### DIFF
--- a/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
@@ -1880,9 +1880,6 @@ describe("call-site model writes are validated against the winning route", () =>
     );
   });
 
-  // A mix winner expands to a per-conversation seeded arm pick, so it has no
-  // single route to fingerprint; a model this write introduces or moves onto
-  // the mix is judged against every arm instead.
   const mixedProfiles = {
     op: { source: "user", provider: "openai", model: "gpt-5.5" },
     an: { source: "user", provider: "anthropic", model: "claude-opus-4-8" },
@@ -1896,7 +1893,9 @@ describe("call-site model writes are validated against the winning route", () =>
     },
   };
 
-  test("a call-site model only one mix arm serves returns 400", async () => {
+  // The deliberate asymmetry between the two winners: write-time validation
+  // judges a concrete route and refuses to judge a mix.
+  test("a model no mix arm serves saves; the same model under a concrete winner is rejected", async () => {
     rawConfigFixture = {
       llm: {
         profiles: structuredClone(mixedProfiles),
@@ -1904,21 +1903,59 @@ describe("call-site model writes are validated against the winning route", () =>
       },
     };
     seedRawConfig();
+    await configPatchRoute.handler({
+      body: {
+        llm: { callSites: { memoryExtraction: { model: "gemini-3.6-flash" } } },
+      },
+    });
+    const llm = loadRawConfig().llm as {
+      callSites?: Record<string, Record<string, unknown>>;
+    };
+    expect(llm.callSites?.memoryExtraction?.model).toBe("gemini-3.6-flash");
+
+    rawConfigFixture = {
+      llm: {
+        profiles: structuredClone(mixedProfiles),
+        callSites: { memoryExtraction: { profile: "an" } },
+      },
+    };
+    seedRawConfig();
     await expect(
       configPatchRoute.handler({
         body: {
-          llm: { callSites: { memoryExtraction: { model: "gpt-5.4-nano" } } },
+          llm: {
+            callSites: { memoryExtraction: { model: "gemini-3.6-flash" } },
+          },
         },
       }),
     ).rejects.toThrow(
-      'Model "gpt-5.4-nano" is not served by provider "anthropic". (llm.callSites.memoryExtraction.model, mix arm "an")',
+      'Model "gemini-3.6-flash" is not served by provider "anthropic". (llm.callSites.memoryExtraction.model)',
     );
   });
 
-  // A mix rung whose pick lands on a disabled arm falls through to a
-  // different winner entirely, so a fingerprint that resolved an arm would
-  // see the mix on only some picks and judge the site against a route it may
-  // not take. The loops catch any save that disagrees with its twin.
+  test("a mix winner turning concrete revalidates an unchanged model", async () => {
+    rawConfigFixture = {
+      llm: {
+        profiles: structuredClone(mixedProfiles),
+        callSites: {
+          memoryExtraction: { profile: "ab", model: "gpt-5.4-nano" },
+        },
+      },
+    };
+    seedRawConfig();
+    await expect(
+      configPatchRoute.handler({
+        body: { llm: { callSites: { memoryExtraction: { profile: "an" } } } },
+      }),
+    ).rejects.toThrow(
+      'Model "gpt-5.4-nano" is not served by provider "anthropic". (llm.callSites.memoryExtraction.model)',
+    );
+  });
+
+  // A mix rung whose seeded pick lands on a disabled arm falls through to a
+  // different winner entirely, so detection that resolved an arm would see
+  // the mix on only some picks and judge the site against a route it may not
+  // take. The loops catch any save that disagrees with its twin.
   const disabledArmProfiles = (mixName: string) => ({
     op: { source: "user", provider: "openai", model: "gpt-5.5" },
     an: {
@@ -1936,7 +1973,7 @@ describe("call-site model writes are validated against the winning route", () =>
     },
   });
 
-  test("a mix with a disabled arm judges a pinned site identically every save", async () => {
+  test("a mix with a disabled arm accepts a pinned site's model every save", async () => {
     for (let i = 0; i < 10; i += 1) {
       rawConfigFixture = {
         llm: {
@@ -1945,223 +1982,36 @@ describe("call-site model writes are validated against the winning route", () =>
         },
       };
       seedRawConfig();
-      await expect(
-        configPatchRoute.handler({
-          body: {
-            llm: {
-              callSites: { memoryExtraction: { model: "claude-opus-4-8" } },
-            },
+      await configPatchRoute.handler({
+        body: {
+          llm: {
+            callSites: { memoryExtraction: { model: "claude-opus-4-8" } },
           },
-        }),
-      ).rejects.toThrow(
-        'Model "claude-opus-4-8" is not served by provider "openai". (llm.callSites.memoryExtraction.model, mix arm "op")',
-      );
+        },
+      });
+      const llm = loadRawConfig().llm as {
+        callSites?: Record<string, Record<string, unknown>>;
+      };
+      expect(llm.callSites?.memoryExtraction?.model).toBe("claude-opus-4-8");
     }
   });
 
-  test("a mix with a disabled arm judges the anchor rung identically every save", async () => {
+  test("a mix with a disabled arm accepts an anchor-rung model every save", async () => {
     // `vision` has no shipped profile intent, so selection bottoms out on the
     // anchor: a mix there expands with no winning profile name to report.
     for (let i = 0; i < 10; i += 1) {
       rawConfigFixture = { llm: { profiles: disabledArmProfiles("balanced") } };
       seedRawConfig();
-      await expect(
-        configPatchRoute.handler({
-          body: {
-            llm: { callSites: { vision: { model: "claude-opus-4-8" } } },
-          },
-        }),
-      ).rejects.toThrow(
-        'Model "claude-opus-4-8" is not served by provider "openai". (llm.callSites.vision.model, mix arm "op")',
-      );
+      await configPatchRoute.handler({
+        body: {
+          llm: { callSites: { vision: { model: "claude-opus-4-8" } } },
+        },
+      });
+      const llm = loadRawConfig().llm as {
+        callSites?: Record<string, Record<string, unknown>>;
+      };
+      expect(llm.callSites?.vision?.model).toBe("claude-opus-4-8");
     }
-  });
-
-  test("a mix over default profile keys validates its arms", async () => {
-    // Default profile bodies are never materialized into workspace config, so
-    // arms naming them resolve only through the effective-profile catalog.
-    rawConfigFixture = {
-      llm: {
-        defaultProvider: { provider: "anthropic" },
-        profiles: {
-          ab: {
-            source: "user",
-            mix: [
-              { profile: "balanced", weight: 1 },
-              { profile: "cost-optimized", weight: 1 },
-            ],
-          },
-        },
-        callSites: { memoryExtraction: { profile: "ab" } },
-      },
-    };
-    seedRawConfig();
-    await expect(
-      configPatchRoute.handler({
-        body: {
-          llm: { callSites: { memoryExtraction: { model: "gpt-5.4-nano" } } },
-        },
-      }),
-    ).rejects.toThrow(
-      'Model "gpt-5.4-nano" is not served by provider "anthropic". (llm.callSites.memoryExtraction.model, mix arm "balanced")',
-    );
-  });
-
-  test("moving a site's winner onto a mix revalidates an unchanged model", async () => {
-    rawConfigFixture = {
-      llm: {
-        profiles: structuredClone(mixedProfiles),
-        callSites: {
-          memoryExtraction: { profile: "an", model: "claude-opus-4-8" },
-        },
-      },
-    };
-    seedRawConfig();
-    await expect(
-      configPatchRoute.handler({
-        body: { llm: { callSites: { memoryExtraction: { profile: "ab" } } } },
-      }),
-    ).rejects.toThrow(
-      'Model "claude-opus-4-8" is not served by provider "openai". (llm.callSites.memoryExtraction.model, mix arm "op")',
-    );
-  });
-
-  test("moving a site's winner between mixes revalidates an unchanged model", async () => {
-    rawConfigFixture = {
-      llm: {
-        profiles: {
-          ...structuredClone(mixedProfiles),
-          an2: {
-            source: "user",
-            provider: "anthropic",
-            model: "claude-sonnet-5",
-          },
-          anthropicOnly: {
-            source: "user",
-            mix: [
-              { profile: "an", weight: 1 },
-              { profile: "an2", weight: 1 },
-            ],
-          },
-        },
-        callSites: {
-          memoryExtraction: {
-            profile: "anthropicOnly",
-            model: "claude-opus-4-8",
-          },
-        },
-      },
-    };
-    seedRawConfig();
-    await expect(
-      configPatchRoute.handler({
-        body: { llm: { callSites: { memoryExtraction: { profile: "ab" } } } },
-      }),
-    ).rejects.toThrow(
-      'Model "claude-opus-4-8" is not served by provider "openai". (llm.callSites.memoryExtraction.model, mix arm "op")',
-    );
-  });
-
-  test("swapping an arm of the winning mix revalidates an unchanged model", async () => {
-    rawConfigFixture = {
-      llm: {
-        profiles: {
-          op: { source: "user", provider: "openai", model: "gpt-5.5" },
-          op2: { source: "user", provider: "openai", model: "gpt-5.2" },
-          an: {
-            source: "user",
-            provider: "anthropic",
-            model: "claude-opus-4-8",
-          },
-          ab: {
-            source: "user",
-            mix: [
-              { profile: "op", weight: 1 },
-              { profile: "op2", weight: 1 },
-            ],
-          },
-        },
-        callSites: { memoryExtraction: { profile: "ab", model: "gpt-5.5" } },
-      },
-    };
-    seedRawConfig();
-    await expect(
-      configPatchRoute.handler({
-        body: {
-          llm: {
-            profiles: {
-              ab: {
-                mix: [
-                  { profile: "op", weight: 1 },
-                  { profile: "an", weight: 1 },
-                ],
-              },
-            },
-          },
-        },
-      }),
-    ).rejects.toThrow(
-      'Model "gpt-5.5" is not served by provider "anthropic". (llm.callSites.memoryExtraction.model, mix arm "an")',
-    );
-  });
-
-  test("a call-site model every mix arm serves saves", async () => {
-    rawConfigFixture = {
-      llm: {
-        profiles: {
-          op: { source: "user", provider: "openai", model: "gpt-5.5" },
-          op2: { source: "user", provider: "openai", model: "gpt-5.2" },
-          ab: {
-            source: "user",
-            mix: [
-              { profile: "op", weight: 1 },
-              { profile: "op2", weight: 1 },
-            ],
-          },
-        },
-        callSites: { memoryExtraction: { profile: "ab" } },
-      },
-    };
-    seedRawConfig();
-    await configPatchRoute.handler({
-      body: {
-        llm: { callSites: { memoryExtraction: { model: "gpt-5.4-nano" } } },
-      },
-    });
-    const llm = loadRawConfig().llm as {
-      callSites?: Record<string, Record<string, unknown>>;
-    };
-    expect(llm.callSites?.memoryExtraction?.model).toBe("gpt-5.4-nano");
-  });
-
-  test("mix arms whose kind is indeterminate fail open", async () => {
-    getDb().delete(providerConnections).run();
-    rawConfigFixture = {
-      llm: {
-        profiles: {
-          e1: { source: "user", provider: "my-conn-a", model: "gpt-5.5" },
-          e2: { source: "user", provider: "my-conn-b", model: "gpt-5.5" },
-          ab: {
-            source: "user",
-            mix: [
-              { profile: "e1", weight: 1 },
-              { profile: "e2", weight: 1 },
-            ],
-          },
-        },
-        callSites: { memoryExtraction: { profile: "ab" } },
-      },
-    };
-    seedRawConfig();
-    await configPatchRoute.handler({
-      body: {
-        llm: { callSites: { memoryExtraction: { model: "anything-goes" } } },
-      },
-    });
-    const llm = loadRawConfig().llm as {
-      callSites?: Record<string, Record<string, unknown>>;
-    };
-    expect(llm.callSites?.memoryExtraction?.model).toBe("anything-goes");
   });
 
   test("an unrelated save under a mix winner never rejects", async () => {

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -1451,10 +1451,16 @@ function assertRoutableIdentityEntries(
  * anything indeterminate (an unparseable `llm` section whose parse error
  * surfaces elsewhere, a winner whose connection row cannot be read, or a
  * route whose model set is not code-known: endpoint-supplied providers,
- * keyless ollama), matching `preflightResolvedConfig`'s posture. A mix
- * winner has no single route to fingerprint, so a model this write
- * introduces, changes, or moves onto the mix is judged against its arms
- * instead (`assertServableByEveryMixArm`).
+ * keyless ollama), matching `preflightResolvedConfig`'s posture.
+ *
+ * A mix winner is never judged. Its winning arm is a seeded
+ * per-conversation pick, so any single judgment is against one of several
+ * real routes and can wrongly reject a legitimate save as readily as
+ * wrongly accept one; an unservable pair is reported loudly at dispatch
+ * instead. Workspace migration 147 takes the same posture toward mixes. A
+ * mix therefore fingerprints as indeterminate, which also keeps a site
+ * from reading as moved merely because a mix was involved; a mix that
+ * becomes concrete still revalidates, the concrete side being judgeable.
  */
 function assertServableCallSiteModels(
   preWrite: Record<string, unknown>,
@@ -1500,48 +1506,25 @@ function assertServableCallSiteModels(
      * rather than a dispatch-translated vendor. Null = indeterminate.
      */
     kind: string | null;
-    /** The mix profile the route expanded through, else null. */
-    mixProfile: string | null;
-    /** That mix's arm names, so an arm-list edit reads as a move. */
-    mixArms: string | null;
   }
   const routeFingerprint = (
     llm: z.infer<typeof LLMSchema>,
     site: LLMCallSite,
   ): RouteFingerprint => {
     // The seed is fixed so a pre-write and a post-write resolution of the
-    // same config expand mixes identically and an unchanged route never
-    // reads as moved. It is reproducibility only, never the basis of a
-    // judgment: a mix is still judged arm by arm below.
-    const expandedMixes: string[] = [];
+    // same config expand mixes identically: whether a site's winner is a
+    // mix is then a property of the config alone, on every rung including
+    // the anchor and when a seeded pick falls through a disabled arm.
+    let expandedMix = false;
     const { config } = resolveCallSiteConfigWithProfile(site, llm, {
       selectionSeed: site,
-      onMixSelected: ({ mixProfile }) => {
-        expandedMixes.push(mixProfile);
+      onMixSelected: () => {
+        expandedMix = true;
       },
     });
-    // Any mix the chain expanded (a named rung's or the anchor's) makes the
-    // route a per-conversation pick, so it cannot be fingerprinted: a rung
-    // whose arm is unusable under this seed still wins under another. The
-    // last expansion is the lowest-precedence one the chain reached, so it
-    // is the mix that either won or stood between the site and its winner.
-    // Indeterminate, like the other fail-open cases; the mix's name and arms
-    // are carried out so the model can still be judged arm by arm.
-    const mixProfile = expandedMixes[expandedMixes.length - 1] ?? null;
-    if (mixProfile != null) {
-      return {
-        provider: null,
-        kind: null,
-        mixProfile,
-        mixArms: JSON.stringify(mixArmNames(llm, mixProfile)),
-      };
-    }
-    return {
-      provider: config.provider,
-      kind: providerKind(config.provider),
-      mixProfile: null,
-      mixArms: null,
-    };
+    return expandedMix
+      ? { provider: null, kind: null }
+      : { provider: config.provider, kind: providerKind(config.provider) };
   };
 
   for (const { site, model } of modelBearing) {
@@ -1557,16 +1540,10 @@ function assertServableCallSiteModels(
       const prior = routeFingerprint(pre.data, site);
       const moved =
         prior.provider !== route.provider ||
-        (prior.kind != null && prior.kind !== route.kind) ||
-        prior.mixProfile !== route.mixProfile ||
-        prior.mixArms !== route.mixArms;
+        (prior.kind != null && prior.kind !== route.kind);
       if (!moved) {
         continue;
       }
-    }
-    if (route.mixProfile != null) {
-      assertServableByEveryMixArm(post.data, route.mixProfile, site, model);
-      continue;
     }
     if (route.kind == null) {
       continue;
@@ -1574,70 +1551,6 @@ function assertServableCallSiteModels(
     const issue = servabilityIssue(route.kind, model);
     if (issue) {
       throw new BadRequestError(`${issue} (llm.callSites.${site}.model)`);
-    }
-  }
-}
-
-/**
- * The arm profile names of a mix, resolved the way the runtime resolver
- * resolves the mix itself; empty when the name is not a mix.
- */
-function mixArmNames(
-  llm: z.infer<typeof LLMSchema>,
-  mixProfile: string,
-): string[] {
-  const entry = resolveDefaultProfileForProvider(
-    llm.profiles,
-    mixProfile,
-    llm.defaultProvider ?? null,
-  );
-  return (entry?.mix ?? []).map((arm) => arm.profile);
-}
-
-/**
- * Reject a call-site model no arm of a mix winner can serve. A mix has no
- * single route to fingerprint (the arm is a seeded per-conversation pick),
- * but its arms are fully knowable: `LLMSchema.superRefine` guarantees every
- * arm names a standard profile that RESOLVES, which for a default-profile
- * key means the code-owned body rather than a `llm.profiles` entry (defaults
- * are never materialized into workspace config). Arms therefore resolve
- * through the same effective-profile catalog the runtime uses; an arm that
- * resolves to nothing is a genuine fail-open, not the common case. Judged
- * only for arms whose kind is determinable; an arm that cannot be judged
- * fails open on its own, and a disabled or incomplete arm is skipped because
- * selection falls through to another winner entirely when the pick lands
- * on it.
- */
-function assertServableByEveryMixArm(
-  llm: z.infer<typeof LLMSchema>,
-  mixProfile: string,
-  site: LLMCallSite,
-  model: string,
-): void {
-  const defaultProvider = llm.defaultProvider ?? null;
-  for (const armName of mixArmNames(llm, mixProfile)) {
-    const entry = resolveDefaultProfileForProvider(
-      llm.profiles,
-      armName,
-      defaultProvider,
-    );
-    if (
-      entry == null ||
-      entry.status === "disabled" ||
-      entry.provider == null ||
-      entry.model == null
-    ) {
-      continue;
-    }
-    const kind = providerKind(entry.provider);
-    if (kind == null) {
-      continue;
-    }
-    const issue = servabilityIssue(kind, model);
-    if (issue) {
-      throw new BadRequestError(
-        `${issue} (llm.callSites.${site}.model, mix arm "${armName}")`,
-      );
     }
   }
 }


### PR DESCRIPTION
## Summary
Mix winners are excluded from write-time call-site model validation. A mix expands to a seeded per-conversation arm, so any single judgment is against one of several real routes: the previous arm-by-arm approach could wrongly reject a legitimate save as well as wrongly accept one, and needed resolver selection semantics mirrored inside the route layer to get right.

- Concrete winners are judged exactly as before, including route-move revalidation.
- Mix detection stays deterministic (fixed selection seed plus the resolver's onMixSelected callback), so a mix winner reliably reads as indeterminate on every rung including the anchor, and non-mix sites are never misjudged.
- An unservable model under a mix winner is reported loudly at dispatch. Workspace migration 147 and the overrides UI already take this posture.

Resolves the open review threads on #41184 (validate-every-expanded-rung, arm-body edits) by removing the judgment rather than enumerating every reachable route.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41187" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->