### PR TITLE
fix(cli): proxy /readyz on remote-web nginx ingress

### DIFF
--- a/cli/src/__tests__/nginx-ingress.test.ts
+++ b/cli/src/__tests__/nginx-ingress.test.ts
@@ -748,7 +748,7 @@ function spaConfigHash(
   return createHash("sha256")
     .update(
       JSON.stringify({
-        template: 4,
+        template: 5,
         config: {
           mode: "remote-gateway",
           apiBaseUrl: "/v1",

--- a/cli/src/__tests__/nginx-ingress.test.ts
+++ b/cli/src/__tests__/nginx-ingress.test.ts
@@ -292,6 +292,7 @@ describe("buildIngressNginxConfig", () => {
 
   test("proxies health and public API traffic to the gateway in remote web mode", () => {
     expect(remoteConf).toContain("location = /healthz {");
+    expect(remoteConf).toContain("location = /readyz {");
     expect(remoteConf).toContain("location ^~ /v1/ {");
     expect(remoteConf).toContain("proxy_pass http://127.0.0.1:7830;");
     expect(remoteConf).toContain("proxy_request_buffering off;");
@@ -319,6 +320,20 @@ describe("buildIngressNginxConfig", () => {
     expect(conf).not.toContain("/healthz { return 404; }");
     expect(conf).toContain("location / {");
     expect(conf).toContain("proxy_pass http://127.0.0.1:7830;");
+  });
+
+  test("proxies /readyz in remote web mode so pairing does not look expired", () => {
+    expect(remoteConf).toContain("location = /readyz {");
+    const readyzStart = remoteConf.indexOf("location = /readyz {");
+    const readyzBlock = remoteConf.slice(
+      readyzStart,
+      remoteConf.indexOf("location ^~ /v1/", readyzStart),
+    );
+    expect(readyzBlock).toContain("proxy_pass http://127.0.0.1:7830;");
+    // Catch-all 404 must come after the exact /readyz location.
+    expect(remoteConf.indexOf("location = /readyz {")).toBeLessThan(
+      remoteConf.lastIndexOf("location / {"),
+    );
   });
 
   test("blocks local-only bootstrap helpers before generic API proxying", () => {

--- a/cli/src/__tests__/nginx-ingress.test.ts
+++ b/cli/src/__tests__/nginx-ingress.test.ts
@@ -871,6 +871,7 @@ describe("startRemoteWebIngress", () => {
     );
     expect(conf).toContain("location ^~ /assistant/ {");
     expect(conf).toContain("location ^~ /webhooks/ {");
+    expect(conf).toContain("location = /readyz {");
     const indexHtml = realFs.readFileSync(
       join(ws, "data", "ingress", "assistant-index.html"),
       "utf-8",
@@ -885,6 +886,45 @@ describe("startRemoteWebIngress", () => {
       gatewayPort: 7830,
       remoteWebConfigHash: spaConfigHash(),
     });
+  });
+
+  test("replaces leftover nginx.conf that omitted /readyz when the edge starts", async () => {
+    // sleep stops nginx and leaves the last generated file. The next start
+    // (wake) writes nginx.conf from the current template rather than reuse
+    // that leftover, so a prior file without /readyz cannot keep pairing
+    // broken after boot.
+    const ws = makeWorkspace();
+    mockNginxInstalled();
+    mockNginxSpawn();
+    mockWebDistPresent();
+    mkdirSync(join(ws, "data", "ingress"), { recursive: true });
+    writeFileSync(
+      ingressConfPath(ws),
+      [
+        "location = /healthz {",
+        "  proxy_pass http://127.0.0.1:7830;",
+        "}",
+        "location / {",
+        "  return 404;",
+        "}",
+      ].join("\n"),
+    );
+
+    const result = await startRemoteWebIngress({
+      workspaceDir: ws,
+      gatewayPort: 7830,
+      listenPort: 7845,
+    });
+
+    expect(result.status).toBe("started");
+    const conf = realFs.readFileSync(ingressConfPath(ws), "utf-8");
+    expect(conf).toContain("location = /readyz {");
+    const readyzStart = conf.indexOf("location = /readyz {");
+    const readyzBlock = conf.slice(
+      readyzStart,
+      conf.indexOf("location ^~ /v1/", readyzStart),
+    );
+    expect(readyzBlock).toContain("proxy_pass http://127.0.0.1:7830;");
   });
 
   test("stamps the assistant label into the served config when provided", async () => {
@@ -1225,6 +1265,8 @@ describe("startRemoteWebIngress", () => {
 
     expect(result.status).toBe("started");
     expect(edge.killed()).toBe(true);
+    const conf = realFs.readFileSync(ingressConfPath(ws), "utf-8");
+    expect(conf).toContain("location = /readyz {");
     expect((readConfig(ws).ingress as Record<string, unknown>).nginx).toEqual({
       listenPort: 7845,
       includeWebApp: true,

--- a/cli/src/lib/nginx-ingress.ts
+++ b/cli/src/lib/nginx-ingress.ts
@@ -345,6 +345,10 @@ function buildRemoteWebIngressLocations(opts: {
 ${proxyBlock}
     }
 
+    location = /readyz {
+${proxyBlock}
+    }
+
     location ^~ /v1/ {
 ${proxyBlock}
     }

--- a/cli/src/lib/nginx-ingress.ts
+++ b/cli/src/lib/nginx-ingress.ts
@@ -180,7 +180,7 @@ function remoteWebIngressConfig(
  * fingerprint matches, so this must change whenever the generated index or
  * nginx template does.
  */
-const EDGE_TEMPLATE_VERSION = 4;
+const EDGE_TEMPLATE_VERSION = 5;
 
 /**
  * Stable fingerprint of the SPA config injected into the served index and


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan

Follow-up to #40849. Cherry-picks Igor Ganapolsky's commits that add an exact-match `/readyz` location to the generated remote-web nginx ingress, then addresses review and follow-up feedback.

Fixes #40687.

The generated remote-web nginx ingress proxied `/healthz` but not `/readyz`. The paired desktop client probes `<pairedUrl>/readyz`. That 404 was wrapped as a `GuardianTokenError` and shown as an expired pairing even when the token was still valid.

This PR:

- Adds an exact-match `/readyz` location that uses the same gateway proxy block as `/healthz`, before the catch-all 404 (cherry-picked from #40849, attribution retained).
- Increments `EDGE_TEMPLATE_VERSION` from 4 to 5 (and the `spaConfigHash` test fixture) so an upgraded CLI restarts a detached edge whose on-disk config still lacks `/readyz`.
- Covers the wake rewrite path: `sleep` stops nginx and leaves the last generated `nginx.conf`; the next `wake` writes that file from the current template. On 0.11.5 the template still omits `/readyz`, so a manual patch is wiped each boot. After this change, that rewrite emits `/readyz`.

Supersedes #40849.

## Test plan

- `cd cli && bun test src/__tests__/nginx-ingress.test.ts` (70 pass)
- Covers `/readyz` location generation, the gateway proxy block, restart of an edge recorded against an older template version, and replacement of leftover on-disk `nginx.conf` that omitted `/readyz`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-47632a4a-b772-48fa-9005-c09b76296cf6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-47632a4a-b772-48fa-9005-c09b76296cf6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

