### PR TITLE
fix(macos): keep native fullscreen available on Tahoe

### DIFF
--- a/clients/macos/src/main/main-window.test.ts
+++ b/clients/macos/src/main/main-window.test.ts
@@ -506,6 +506,18 @@ describe("onboarding window sizing", () => {
     expect(win.stub.isResizable()).toBe(true);
     // A saved windowed state stays windowed — never upgraded to fullscreen.
     expect(win.opts.fullscreen).toBeUndefined();
+    expect(win.opts.fullscreenable).toBe(true);
+    expect(win.stub.setFullScreenable).toHaveBeenCalledWith(true);
+  });
+
+  test("does not pass fullscreen: false from a saved windowed session", () => {
+    restoredBounds = { width: 1280, height: 800, fullscreen: false };
+    ensureVisible();
+    const win = constructed[0];
+    if (!win) throw new Error("expected a window");
+    expect(win.opts.fullscreen).toBeUndefined();
+    expect(win.opts.fullscreenable).toBe(true);
+    expect(win.stub.setFullScreenable).toHaveBeenCalledWith(true);
   });
 
   test("setOnboarding(true) persists the mode without resizing the window", () => {
@@ -648,6 +660,7 @@ describe("maximized default", () => {
     // Maximized means work-area bounds — a normal window, never native
     // fullscreen.
     expect(win.opts.fullscreen).toBeUndefined();
+    expect(win.opts.fullscreenable).toBe(true);
   });
 
   test("constructs at the work-area bounds when onboarding is active too", () => {
@@ -660,6 +673,7 @@ describe("maximized default", () => {
     expect(win.opts.width).toBe(1512);
     expect(win.opts.height).toBe(944);
     expect(win.opts.fullscreen).toBeUndefined();
+    expect(win.opts.fullscreenable).toBe(true);
   });
 });
 
@@ -670,6 +684,8 @@ describe("fullscreen session restore", () => {
     const win = constructed[0];
     if (!win) throw new Error("expected a window");
     expect(win.opts.fullscreen).toBe(true);
+    expect(win.opts.fullscreenable).toBe(true);
+    expect(win.stub.setFullScreenable).toHaveBeenCalledWith(true);
   });
 
   test("restores a saved fullscreen session even when onboarding is active", () => {

--- a/clients/macos/src/main/main-window.ts
+++ b/clients/macos/src/main/main-window.ts
@@ -153,14 +153,17 @@ const createMainWindow = (): BrowserWindow => {
   const loadTarget = getRendererRootUrl(app.isPackaged);
 
   // Onboarding and the main app share the same sizing: restore the user's
-  // saved main-app state — which defaults to maximized (work-area bounds)
-  // when nothing has been persisted yet. A saved fullscreen session's
-  // `fullscreen` flag rides the spread into the `BrowserWindow` constructor.
-  // The window can't be dragged below the 800×600 floor (mirroring the Swift
-  // client's `contentMinSize`). The persisted onboarding flag now only drives
-  // the traffic-light position (compact surfaces have no inline title bar).
+  // saved main-app state, which defaults to maximized (work-area bounds)
+  // when nothing has been persisted yet. A saved fullscreen session includes
+  // `fullscreen: true` on the constructor; a windowed session omits the key
+  // so Electron keeps the native fullscreen button (`AXFullScreenButton`)
+  // and Control+Command+F. `fullscreenable: true` keeps the green traffic
+  // light as the Spaces fullscreen control rather than zoom. The window
+  // can't be dragged below the 800×600 floor (mirroring the Swift client's
+  // `contentMinSize`). The persisted onboarding flag only drives the
+  // traffic-light position (compact surfaces have no inline title bar).
   const onboardingActive = readOnboardingActive();
-  const { maximized: _maximized, ...restoredBounds } = restoreBounds(
+  const { maximized: _maximized, fullscreen, ...restoredBounds } = restoreBounds(
     "main",
     MAIN_DEFAULT_STATE,
   );
@@ -168,6 +171,8 @@ const createMainWindow = (): BrowserWindow => {
     ...restoredBounds,
     minWidth: MAIN_MIN_SIZE.width,
     minHeight: MAIN_MIN_SIZE.height,
+    fullscreenable: true,
+    ...(fullscreen === true ? { fullscreen: true } : {}),
   };
 
   const win = createWindow({
@@ -181,6 +186,11 @@ const createMainWindow = (): BrowserWindow => {
     // a floating panel on screen) while the user works in another app.
     backgroundThrottling: false,
   });
+  // AppKit needs `.fullScreenPrimary` on the collection behavior so the
+  // green button stays a native Spaces fullscreen control and
+  // Control+Command+F keeps `AXFullScreenButton`. `titleBarStyle: "hidden"`
+  // alone does not guarantee that mask on macOS Tahoe.
+  win.setFullScreenable(true);
 
   // Main owns the window title (the active assistant's name). Block the
   // renderer's static `<title>` ("Vellum Assistant") from overriding it via

--- a/clients/macos/src/main/menu.test.ts
+++ b/clients/macos/src/main/menu.test.ts
@@ -11,6 +11,7 @@ type TemplateItem = {
   role?: string;
   type?: string;
   enabled?: boolean;
+  accelerator?: string;
   click?: () => void | Promise<void>;
   submenu?: TemplateItem[];
 };
@@ -359,6 +360,22 @@ describe("CLI path menu items in unpackaged builds", () => {
     expect(getCliPathInstallStateMock).not.toHaveBeenCalled();
     expect(appMenuLabels()).not.toContain(INSTALL_LABEL);
     expect(appMenuLabels()).not.toContain(UNINSTALL_LABEL);
+  });
+});
+
+describe("View menu native fullscreen", () => {
+  const viewSubmenu = (): TemplateItem[] =>
+    lastTemplate().find((item) => item.label === "View")?.submenu ?? [];
+
+  test("registers Toggle Full Screen with the macOS Control+Command+F equivalent", async () => {
+    await refreshCliPathMenuState();
+    const toggleFullscreen = viewSubmenu().find(
+      (item) => item.role === "togglefullscreen",
+    );
+    expect(toggleFullscreen).toEqual({
+      role: "togglefullscreen",
+      accelerator: "Control+Command+F",
+    });
   });
 });
 

--- a/clients/macos/src/main/menu.ts
+++ b/clients/macos/src/main/menu.ts
@@ -234,7 +234,10 @@ const buildTemplate = (): MenuItemConstructorOptions[] => {
         { role: "zoomIn" },
         { role: "zoomOut" },
         { type: "separator" },
-        { role: "togglefullscreen" },
+        {
+          role: "togglefullscreen",
+          accelerator: "Control+Command+F",
+        },
       ],
     },
     {

--- a/packages/electron-desktop/src/window-state.test.ts
+++ b/packages/electron-desktop/src/window-state.test.ts
@@ -116,7 +116,6 @@ describe("restoreBounds", () => {
       y: 200,
       width: 1000,
       height: 700,
-      fullscreen: false,
     });
   });
 
@@ -148,7 +147,6 @@ describe("restoreBounds", () => {
       y: 80,
       width: 1280,
       height: 720,
-      fullscreen: false,
     });
   });
 
@@ -215,6 +213,17 @@ describe("restoreBounds", () => {
     expect(restoreBounds("main", DEFAULTS).fullscreen).toBe(true);
   });
 
+  test("omits fullscreen for a windowed session so BrowserWindow stays fullscreenable", () => {
+    savedWindows.main = {
+      x: 100,
+      y: 200,
+      width: 1000,
+      height: 700,
+      isFullScreen: false,
+    };
+    expect(restoreBounds("main", DEFAULTS)).not.toHaveProperty("fullscreen");
+  });
+
   test("forwards a saved maximized flag", () => {
     savedWindows.main = {
       x: 0,
@@ -250,7 +259,6 @@ describe("restoreBounds", () => {
       y: 200,
       width: 1000,
       height: 700,
-      fullscreen: false,
     });
   });
 

--- a/packages/electron-desktop/src/window-state.ts
+++ b/packages/electron-desktop/src/window-state.ts
@@ -209,7 +209,13 @@ export interface RestoredWindowState {
   y?: number;
   width: number;
   height: number;
-  fullscreen?: boolean;
+  /**
+   * Present only for a saved native-fullscreen session. Callers spread this
+   * into `BrowserWindow` options; Electron treats an explicit
+   * `fullscreen: false` as "hide the macOS fullscreen button", which drops
+   * `AXFullScreenButton` and makes Control+Command+F a no-op.
+   */
+  fullscreen?: true;
   maximized?: boolean;
 }
 
@@ -278,7 +284,7 @@ export const restoreBounds = (
     y,
     width,
     height,
-    fullscreen: saved.isFullScreen,
+    ...(saved.isFullScreen ? { fullscreen: true as const } : {}),
     ...(saved.isMaximized === undefined
       ? {}
       : { maximized: saved.isMaximized }),
@@ -300,9 +306,8 @@ export const restoreBounds = (
  * would leave a tiny window. `getNormalBounds()` also returns the
  * pre-minimize bounds when the window is minimized, so no special
  * handling is needed for the common macOS "minimize to dock, then
- * Cmd+Q" path. `isFullScreen()` is tracked separately and passed
- * through to the `BrowserWindow` constructor on restore, so the window
- * comes back in the same display mode it was left in.
+ * Cmd+Q" path. `isFullScreen()` is tracked separately; restore only
+ * forwards `fullscreen: true` so a windowed session stays fullscreenable.
  *
  * `shouldPersist` gates each save. It defaults to always-on, but callers
  * that reuse one window across multiple layouts (the main window's


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan

macOS Tahoe (26.x) report: `Control+Command+F` no longer toggles native Spaces fullscreen in the Electron desktop client, and the green traffic-light button falls back to zoom because the window loses `AXFullScreenButton`.

Two causes:

1. `restoreBounds()` forwarded `fullscreen: false` for every saved windowed session. Electron treats an explicit `false` as "hide or disable the macOS fullscreen button."
2. The main window uses `titleBarStyle: "hidden"` and did not declare `fullscreenable: true`, so AppKit on Tahoe does not grant `.fullScreenPrimary`.

The fix omits `fullscreen` unless the saved session was fullscreen, marks the main window `fullscreenable`, calls `setFullScreenable(true)` after construction, and registers the View menu Toggle Full Screen key equivalent as `Control+Command+F`.

## Test plan

- [x] `packages/electron-desktop` `src/window-state.test.ts` (33 pass): windowed restore omits `fullscreen`; fullscreen sessions still restore
- [x] `clients/macos` `src/main/main-window.test.ts` (44 pass): constructor never gets `fullscreen: false`; `fullscreenable: true`; `setFullScreenable(true)`
- [x] `clients/macos` `src/main/menu.test.ts` (19 pass): View menu registers `togglefullscreen` + `Control+Command+F`
- [x] `bunx tsc --noEmit` in `clients/macos` and `packages/electron-desktop`
- [ ] Manual confirmation on macOS Tahoe: green button enters a Space, `Control+Command+F` toggles, View > Toggle Full Screen works

## Risk

Low. Windowed sessions still open windowed; only a saved fullscreen session still starts fullscreen. Native fullscreen capability is restored rather than changed. This environment cannot execute the AppKit path; please verify on a Tahoe machine before merge if possible.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-37e526ed-94e6-4825-b8bd-c6475858cda0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-37e526ed-94e6-4825-b8bd-c6475858cda0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

