### PR TITLE
feat(web): add per-conversation delete to the conversation menu

### DIFF
--- a/clients/web/src/domains/chat/chat-conversation-header.tsx
+++ b/clients/web/src/domains/chat/chat-conversation-header.tsx
@@ -22,6 +22,7 @@ interface ChatConversationHeaderProps {
   showInternalActions: boolean;
   onArchive: (c: Conversation) => void;
   onUnarchive: (c: Conversation) => void;
+  onDelete: (c: Conversation) => void;
   onMarkUnread: (c: Conversation) => void;
   onMarkRead: (c: Conversation) => void;
   onPinToggle: (c: Conversation) => void;
@@ -35,6 +36,7 @@ export function ChatConversationHeader({
   showInternalActions,
   onArchive,
   onUnarchive,
+  onDelete,
   onMarkUnread,
   onMarkRead,
   onPinToggle,
@@ -91,6 +93,11 @@ export function ChatConversationHeader({
       onRename={() => onRename(activeConversation)}
       onArchive={() => onArchive(activeConversation)}
       onUnarchive={() => onUnarchive(activeConversation)}
+      onDelete={
+        activeConversation.conversationId
+          ? () => onDelete(activeConversation)
+          : undefined
+      }
       onForkConversation={
         !isReadonly &&
         headerSupplements?.hasPersistedMessage &&

--- a/clients/web/src/domains/chat/chat-conversation-header.tsx
+++ b/clients/web/src/domains/chat/chat-conversation-header.tsx
@@ -94,7 +94,7 @@ export function ChatConversationHeader({
       onArchive={() => onArchive(activeConversation)}
       onUnarchive={() => onUnarchive(activeConversation)}
       onDelete={
-        activeConversation.conversationId
+        activeConversation.conversationId && !activeConversation.draft
           ? () => onDelete(activeConversation)
           : undefined
       }

--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -106,6 +106,10 @@ import {
   ArchiveAllConfirmDialog,
   useArchiveAllConfirmation,
 } from "./components/archive-all-confirm-dialog";
+import {
+  DeleteConversationConfirmDialog,
+  useDeleteConversationConfirmation,
+} from "./components/delete-conversation-confirm-dialog";
 import { GroupNameDialogFromStore } from "./group-name-dialog-from-store";
 import { RenameDialogFromStore } from "./rename-dialog-from-store";
 import { useTranslation } from "@/i18n";
@@ -620,7 +624,7 @@ export function ChatLayout({
     [navigate],
   );
 
-  // --- Sidebar conversation actions (pin / rename / archive / mark / move) ---
+  // --- Sidebar conversation actions (pin / rename / archive / delete / mark / move) ---
   //
   // The sidebar's hover-revealed "…" menu reads its items from these
   // handlers; without them the popover renders empty (every menu item
@@ -633,6 +637,7 @@ export function ChatLayout({
   const {
     handleArchiveConversation,
     handleUnarchiveConversation,
+    handleDeleteConversation,
     handleMarkConversationUnread,
     handleMarkConversationRead,
     handleTogglePinConversation,
@@ -661,6 +666,16 @@ export function ChatLayout({
   } = useArchiveAllConfirmation({
     assistantId,
     archiveAllInGroup: handleArchiveAllInGroup,
+  });
+
+  const {
+    pending: pendingDeleteConversation,
+    requestDelete,
+    confirmDelete,
+    cancelDelete,
+  } = useDeleteConversationConfirmation({
+    assistantId,
+    deleteConversation: handleDeleteConversation,
   });
 
   // The move-to-group menu's "New group…" item and the group actions menu's
@@ -722,6 +737,7 @@ export function ChatLayout({
         showInternalActions={showInternalActions}
         onArchive={handleArchiveConversation}
         onUnarchive={handleUnarchiveConversation}
+        onDelete={requestDelete}
         onMarkUnread={handleMarkConversationUnread}
         onMarkRead={handleMarkConversationRead}
         onPinToggle={handleTogglePinConversation}
@@ -961,6 +977,7 @@ export function ChatLayout({
       onRenameConversation={handleRenameConversation}
       onArchiveConversation={handleArchiveConversation}
       onUnarchiveConversation={handleUnarchiveConversation}
+      onDeleteConversation={requestDelete}
       onMarkConversationUnread={handleMarkConversationUnread}
       onMarkConversationRead={handleMarkConversationRead}
       onCreateGroup={handleRequestCreateEmptyGroup}
@@ -1260,6 +1277,11 @@ export function ChatLayout({
         pending={pendingArchiveAll}
         onConfirm={confirmArchiveAll}
         onCancel={cancelArchiveAll}
+      />
+      <DeleteConversationConfirmDialog
+        pending={pendingDeleteConversation}
+        onConfirm={confirmDelete}
+        onCancel={cancelDelete}
       />
       <GroupNameDialogFromStore
         createGroup={createGroup}

--- a/clients/web/src/domains/chat/components/assistant-side-menu.stories.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.stories.tsx
@@ -262,6 +262,7 @@ const SHARED_ARGS = {
   onMarkConversationUnread: () => {},
   onPinConversation: () => {},
   onArchiveConversation: () => {},
+  onDeleteConversation: () => {},
   /* The real `PreferencesMenu`, not a stand-in: it is the sidebar's bottom
      entry, and without it these stories show every part of the rail except
      the one at its foot. `chat-layout` passes it the same way. */

--- a/clients/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -92,6 +92,7 @@ export interface AssistantSideMenuProps extends UseSidebarStateParams {
   onRenameConversation?: (conversation: Conversation) => void;
   onArchiveConversation?: (conversation: Conversation) => void;
   onUnarchiveConversation?: (conversation: Conversation) => void;
+  onDeleteConversation?: (conversation: Conversation) => void;
   onMarkConversationUnread?: (conversation: Conversation) => void;
   onMarkConversationRead?: (conversation: Conversation) => void;
   /**
@@ -221,6 +222,7 @@ export function AssistantSideMenu({
   onRenameConversation,
   onArchiveConversation,
   onUnarchiveConversation,
+  onDeleteConversation,
   onMarkConversationUnread,
   onMarkConversationRead,
   conversationGroups,
@@ -393,6 +395,7 @@ export function AssistantSideMenu({
     onRename: onRenameConversation,
     onArchive: onArchiveConversation,
     onUnarchive: onUnarchiveConversation,
+    onDelete: onDeleteConversation,
     onMarkRead: onMarkConversationRead,
     onMarkUnread: onMarkConversationUnread,
     onOpenInNewWindow,

--- a/clients/web/src/domains/chat/components/conversation-actions-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/conversation-actions-menu.test.tsx
@@ -194,6 +194,51 @@ describe("renderConversationMenuItems", () => {
     expect(html).toContain("Archive");
   });
 
+  test("renders Delete when onDelete is provided", () => {
+    const html = renderToStaticMarkup(
+      <>
+        {renderConversationMenuItems({
+          Primitive: Menu as unknown as ConversationMenuPrimitive,
+          t,
+          onDelete: () => {},
+        })}
+      </>,
+    );
+    expect(html).toContain("Delete");
+  });
+
+  test("omits Delete when onDelete is not provided", () => {
+    const html = renderToStaticMarkup(
+      <>
+        {renderConversationMenuItems({
+          Primitive: Menu as unknown as ConversationMenuPrimitive,
+          t,
+          onArchive: () => {},
+        })}
+      </>,
+    );
+    expect(html).toContain("Archive");
+    expect(html).not.toContain("Delete");
+  });
+
+  test("renders Delete for read-only conversations when wired", () => {
+    const html = renderToStaticMarkup(
+      <>
+        {renderConversationMenuItems({
+          Primitive: Menu as unknown as ConversationMenuPrimitive,
+          t,
+          isReadonly: true,
+          onArchive: () => {},
+          onDelete: () => {},
+          onMarkUnread: () => {},
+        })}
+      </>,
+    );
+    expect(html).toContain("Archive");
+    expect(html).toContain("Delete");
+    expect(html).not.toContain("Mark as unread");
+  });
+
   test("renders Unarchive when isArchived and onUnarchive are provided", () => {
     const html = renderToStaticMarkup(
       <>
@@ -270,6 +315,7 @@ describe("renderConversationMenuItems", () => {
           onPinToggle: () => {},
           onRename: () => {},
           onArchive: () => {},
+          onDelete: () => {},
         })}
       </>,
     );
@@ -284,6 +330,7 @@ describe("renderConversationMenuItems", () => {
       "Pin",
       "Rename",
       "Archive",
+      "Delete",
     ];
     const positions = order.map((label) => html.indexOf(label));
     expect(positions).not.toContain(-1);
@@ -698,6 +745,7 @@ describe("renderConversationMenuItemsAsPanelItems", () => {
           onPinToggle: () => {},
           onRename: () => {},
           onArchive: () => {},
+          onDelete: () => {},
           onClose: () => {},
         })}
       </>,
@@ -705,6 +753,7 @@ describe("renderConversationMenuItemsAsPanelItems", () => {
     expect(html).toContain("Pin");
     expect(html).toContain("Rename");
     expect(html).toContain("Archive");
+    expect(html).toContain("Delete");
   });
 
   test("renders the channel source link row when provided", () => {

--- a/clients/web/src/domains/chat/components/conversation-actions-menu.tsx
+++ b/clients/web/src/domains/chat/components/conversation-actions-menu.tsx
@@ -12,6 +12,7 @@ import {
   PinOff,
   RefreshCw,
   Sparkles,
+  Trash2,
   X,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
@@ -34,7 +35,7 @@ import { cn } from "@vellumai/design-library/utils/cn";
 /**
  * Hover-revealed "more" menu for a conversation row. Renders an ellipsis
  * button; clicking it opens a dropdown menu with Pin / Rename / Archive /
- * Mark as unread actions, plus an optional "Move to group" submenu.
+ * Delete / Mark as unread actions, plus an optional "Move to group" submenu.
  *
  * The same item set is also rendered by the row's right-click context menu
  * (`AssistantSideMenu`) via the shared `renderConversationMenuItems` helper
@@ -54,6 +55,12 @@ import { cn } from "@vellumai/design-library/utils/cn";
 
 type MenuSide = "top" | "right" | "bottom" | "left";
 type MenuAlign = "start" | "center" | "end";
+
+/** Destructive row colour shared by the dropdown and the mobile sheet. */
+const DELETE_ITEM_CLASS =
+  "text-[var(--system-negative-strong)] data-[highlighted]:text-[var(--system-negative-hover)] [&_[data-slot=menu-item-icon]]:text-inherit";
+const DELETE_SHEET_ITEM_CLASS =
+  "text-[var(--system-negative-strong)] [--panel-item-icon-fg:var(--system-negative-strong)]";
 
 /**
  * Subset of the compound-menu API shared by `Menu` and `ContextMenu`. The
@@ -82,6 +89,12 @@ export interface ConversationMenuItemsProps {
   onArchive?: () => void;
   /** Restore an archived conversation. When provided, takes precedence over `onArchive` when `isArchived` is true. */
   onUnarchive?: () => void;
+  /**
+   * Permanently delete the conversation. The host owns confirmation; this
+   * callback only requests the delete. Available for channel threads too:
+   * deletion is a local history wipe and does not write to the source channel.
+   */
+  onDelete?: () => void;
   /** Mark the most recent assistant message as unread. */
   onMarkUnread?: () => void;
   /**
@@ -184,6 +197,7 @@ export function renderConversationMenuItems({
   onRename,
   onArchive,
   onUnarchive,
+  onDelete,
   onMarkUnread,
   isMarkUnreadDisabled = false,
   onMarkRead,
@@ -240,6 +254,16 @@ export function renderConversationMenuItems({
         {t("conversationActions.archive")}
       </Primitive.Item>
     ) : null;
+
+  const deleteItem = onDelete ? (
+    <Primitive.Item
+      leftIcon={<Trash2 size={14} />}
+      onSelect={onDelete}
+      className={DELETE_ITEM_CLASS}
+    >
+      {t("conversationActions.delete")}
+    </Primitive.Item>
+  ) : null;
 
   const markReadUnreadItem =
     !isReadonly && onMarkRead ? (
@@ -362,6 +386,7 @@ export function renderConversationMenuItems({
         {renameItem}
         {moveToGroupItem}
         {archiveItem}
+        {deleteItem}
         {copyConversationIdItem}
       </>
     );
@@ -372,6 +397,7 @@ export function renderConversationMenuItems({
       {pinItem}
       {renameItem}
       {archiveItem}
+      {deleteItem}
 
       {markReadUnreadItem}
       {moveToGroupItem}
@@ -479,6 +505,7 @@ export function renderConversationMenuItemsAsPanelItems({
   onRename,
   onArchive,
   onUnarchive,
+  onDelete,
   onMarkUnread,
   isMarkUnreadDisabled = false,
   onMarkRead,
@@ -546,6 +573,17 @@ export function renderConversationMenuItemsAsPanelItems({
             onClose,
           })
         : null;
+
+  const deleteItem = onDelete
+    ? buildSheetMenuItem({
+        key: "delete",
+        icon: Trash2,
+        label: t("conversationActions.delete"),
+        className: DELETE_SHEET_ITEM_CLASS,
+        run: onDelete,
+        onClose,
+      })
+    : null;
 
   const markReadUnreadItem =
     !isReadonly && onMarkRead
@@ -683,6 +721,7 @@ export function renderConversationMenuItemsAsPanelItems({
         {pinItem}
         {renameItem}
         {archiveItem}
+        {deleteItem}
         {moveToGroupBlock}
         {copyConversationIdItem}
       </>
@@ -694,6 +733,7 @@ export function renderConversationMenuItemsAsPanelItems({
       {pinItem}
       {renameItem}
       {archiveItem}
+      {deleteItem}
       {markReadUnreadItem}
       {moveToGroupBlock}
       {channelSourceLinkItem}

--- a/clients/web/src/domains/chat/components/conversation-list-context.tsx
+++ b/clients/web/src/domains/chat/components/conversation-list-context.tsx
@@ -38,6 +38,8 @@ export interface ConversationListContextValue {
   onRename?: (conversation: Conversation) => void;
   onArchive?: (conversation: Conversation) => void;
   onUnarchive?: (conversation: Conversation) => void;
+  /** Permanently delete a conversation after the host's confirmation gate. */
+  onDelete?: (conversation: Conversation) => void;
   onMarkRead?: (conversation: Conversation) => void;
   onMarkUnread?: (conversation: Conversation) => void;
   onOpenInNewWindow?: (conversation: Conversation) => void;

--- a/clients/web/src/domains/chat/components/conversation-row.test.tsx
+++ b/clients/web/src/domains/chat/components/conversation-row.test.tsx
@@ -48,6 +48,14 @@ describe("buildMenuProps", () => {
     expect(typeof wired.onDelete).toBe("function");
   });
 
+  test("does not wire delete for unresolved draft conversations", () => {
+    const wired = buildMenuProps(
+      makeCtx({ onDelete: () => {} }),
+      conv({ draft: true }),
+    );
+    expect(wired.onDelete).toBeUndefined();
+  });
+
   test("offers mark-read for unread rows and mark-unread for read rows", () => {
     const ctx = makeCtx({ onMarkRead: () => {}, onMarkUnread: () => {} });
 

--- a/clients/web/src/domains/chat/components/conversation-row.test.tsx
+++ b/clients/web/src/domains/chat/components/conversation-row.test.tsx
@@ -33,13 +33,19 @@ describe("buildMenuProps", () => {
     const bare = buildMenuProps(makeCtx(), conv());
     expect(bare.onRename).toBeUndefined();
     expect(bare.onArchive).toBeUndefined();
+    expect(bare.onDelete).toBeUndefined();
 
     const wired = buildMenuProps(
-      makeCtx({ onRename: () => {}, onArchive: () => {} }),
+      makeCtx({
+        onRename: () => {},
+        onArchive: () => {},
+        onDelete: () => {},
+      }),
       conv(),
     );
     expect(typeof wired.onRename).toBe("function");
     expect(typeof wired.onArchive).toBe("function");
+    expect(typeof wired.onDelete).toBe("function");
   });
 
   test("offers mark-read for unread rows and mark-unread for read rows", () => {

--- a/clients/web/src/domains/chat/components/conversation-row.tsx
+++ b/clients/web/src/domains/chat/components/conversation-row.tsx
@@ -77,7 +77,9 @@ export function buildMenuProps(
       ? () => ctx.onUnarchive?.(conversation)
       : undefined,
     onDelete:
-      ctx.onDelete && hasId ? () => ctx.onDelete?.(conversation) : undefined,
+      ctx.onDelete && hasId && !conversation.draft
+        ? () => ctx.onDelete?.(conversation)
+        : undefined,
     onMarkRead:
       ctx.onMarkRead && canMarkRead(conversation)
         ? () => ctx.onMarkRead?.(conversation)

--- a/clients/web/src/domains/chat/components/conversation-row.tsx
+++ b/clients/web/src/domains/chat/components/conversation-row.tsx
@@ -76,6 +76,8 @@ export function buildMenuProps(
     onUnarchive: ctx.onUnarchive
       ? () => ctx.onUnarchive?.(conversation)
       : undefined,
+    onDelete:
+      ctx.onDelete && hasId ? () => ctx.onDelete?.(conversation) : undefined,
     onMarkRead:
       ctx.onMarkRead && canMarkRead(conversation)
         ? () => ctx.onMarkRead?.(conversation)

--- a/clients/web/src/domains/chat/components/delete-conversation-confirm-dialog.test.tsx
+++ b/clients/web/src/domains/chat/components/delete-conversation-confirm-dialog.test.tsx
@@ -1,0 +1,183 @@
+/**
+ * Tests for the per-conversation Delete confirmation gate. The invariant:
+ * requesting a delete must never run it; only the dialog's explicit
+ * confirm does, and cancel leaves the conversation untouched.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { act, cleanup, render, waitFor } from "@testing-library/react";
+import { createElement } from "react";
+
+import {
+  DeleteConversationConfirmDialog,
+  useDeleteConversationConfirmation,
+} from "@/domains/chat/components/delete-conversation-confirm-dialog";
+import type { Conversation } from "@/types/conversation-types";
+
+const CONVERSATION = {
+  conversationId: "conv-xyz",
+  title: "Planning notes",
+} as Conversation;
+
+function Harness({
+  assistantId,
+  deleteConversation,
+  requestConversation = CONVERSATION,
+}: {
+  assistantId: string | null;
+  deleteConversation: (conversation: Conversation) => void;
+  requestConversation?: Conversation;
+}) {
+  const { pending, requestDelete, confirmDelete, cancelDelete } =
+    useDeleteConversationConfirmation({ assistantId, deleteConversation });
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => requestDelete(requestConversation)}
+      >
+        request
+      </button>
+      <DeleteConversationConfirmDialog
+        pending={pending}
+        onConfirm={confirmDelete}
+        onCancel={cancelDelete}
+      />
+    </>
+  );
+}
+
+function clickByText(text: string) {
+  const button = Array.from(
+    document.querySelectorAll<HTMLElement>("button"),
+  ).find((el) => el.textContent?.trim() === text);
+  expect(button).toBeDefined();
+  act(() => {
+    button?.click();
+  });
+}
+
+async function waitForDialog() {
+  await waitFor(() => {
+    expect(
+      document.querySelector("[data-confirm-dialog-confirm]"),
+    ).not.toBeNull();
+  });
+}
+
+describe("useDeleteConversationConfirmation + DeleteConversationConfirmDialog", () => {
+  test("requesting shows the dialog and deletes nothing", async () => {
+    const calls: Conversation[] = [];
+    render(
+      createElement(Harness, {
+        assistantId: "asst-1",
+        deleteConversation: (conversation) => calls.push(conversation),
+      }),
+    );
+    try {
+      clickByText("request");
+      await waitForDialog();
+      expect(calls).toHaveLength(0);
+      expect(document.body.textContent).toContain("Planning notes");
+      expect(document.body.textContent).toContain("permanently removes");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("confirm deletes exactly the requested conversation, once", async () => {
+    const calls: Conversation[] = [];
+    render(
+      createElement(Harness, {
+        assistantId: "asst-1",
+        deleteConversation: (conversation) => calls.push(conversation),
+      }),
+    );
+    try {
+      clickByText("request");
+      await waitForDialog();
+      act(() => {
+        document
+          .querySelector<HTMLElement>("[data-confirm-dialog-confirm]")!
+          .click();
+      });
+      expect(calls).toHaveLength(1);
+      expect(calls[0]!.conversationId).toBe("conv-xyz");
+      await waitFor(() => {
+        expect(
+          document.querySelector("[data-confirm-dialog-confirm]"),
+        ).toBeNull();
+      });
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("cancel deletes nothing and closes the dialog", async () => {
+    const calls: Conversation[] = [];
+    render(
+      createElement(Harness, {
+        assistantId: "asst-1",
+        deleteConversation: (conversation) => calls.push(conversation),
+      }),
+    );
+    try {
+      clickByText("request");
+      await waitForDialog();
+      clickByText("Cancel");
+      await waitFor(() => {
+        expect(
+          document.querySelector("[data-confirm-dialog-confirm]"),
+        ).toBeNull();
+      });
+      expect(calls).toHaveLength(0);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("an untitled conversation uses the untitled fallback in the copy", async () => {
+    render(
+      createElement(Harness, {
+        assistantId: "asst-1",
+        deleteConversation: () => {},
+        requestConversation: { conversationId: "conv-xyz" } as Conversation,
+      }),
+    );
+    try {
+      clickByText("request");
+      await waitForDialog();
+      expect(document.body.textContent).toContain("Untitled");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("switching assistants drops the pending request", async () => {
+    const calls: Conversation[] = [];
+    const { rerender } = render(
+      createElement(Harness, {
+        assistantId: "asst-1",
+        deleteConversation: (conversation) => calls.push(conversation),
+      }),
+    );
+    try {
+      clickByText("request");
+      await waitForDialog();
+      rerender(
+        createElement(Harness, {
+          assistantId: "asst-2",
+          deleteConversation: (conversation) => calls.push(conversation),
+        }),
+      );
+      await waitFor(() => {
+        expect(
+          document.querySelector("[data-confirm-dialog-confirm]"),
+        ).toBeNull();
+      });
+      expect(calls).toHaveLength(0);
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/clients/web/src/domains/chat/components/delete-conversation-confirm-dialog.tsx
+++ b/clients/web/src/domains/chat/components/delete-conversation-confirm-dialog.tsx
@@ -1,0 +1,92 @@
+import { useCallback, useEffect, useState } from "react";
+
+import { useTranslation } from "@/i18n";
+
+import type { Conversation } from "@/types/conversation-types";
+import { ConfirmDialog } from "@vellumai/design-library";
+
+/**
+ * Confirmation gate for the per-conversation Delete action. One click
+ * must never permanently remove a conversation; the menu item requests
+ * via {@link useDeleteConversationConfirmation} and the delete only
+ * runs on the dialog's explicit confirm.
+ *
+ * Hosted by the chat layout next to the other sidebar dialogs rather
+ * than inside the sidebar itself: the mobile overlay drawer unmounts
+ * its subtree when it closes, and a pending confirmation must survive
+ * that.
+ */
+
+interface UseDeleteConversationConfirmationParams {
+  assistantId: string | null;
+  /** Performs the delete once the user confirms. */
+  deleteConversation: (conversation: Conversation) => void;
+}
+
+/**
+ * Owns the pending delete request. `requestDelete` snapshots the row at
+ * menu-click time so the conversation the user confirms is the one
+ * deleted; `confirmDelete` runs the delete and clears the request.
+ */
+export function useDeleteConversationConfirmation({
+  assistantId,
+  deleteConversation,
+}: UseDeleteConversationConfirmationParams) {
+  const [pending, setPending] = useState<Conversation | null>(null);
+
+  // A pending request holds a conversation from the assistant it was armed
+  // against; confirming it after a switch would delete across a mismatched
+  // assistant. Same rule as the archive-all confirmation gate.
+  useEffect(() => {
+    setPending(null);
+  }, [assistantId]);
+
+  const requestDelete = useCallback((conversation: Conversation) => {
+    setPending(conversation);
+  }, []);
+
+  const confirmDelete = useCallback(() => {
+    if (pending) {
+      deleteConversation(pending);
+    }
+    setPending(null);
+  }, [pending, deleteConversation]);
+
+  const cancelDelete = useCallback(() => {
+    setPending(null);
+  }, []);
+
+  return { pending, requestDelete, confirmDelete, cancelDelete };
+}
+
+export interface DeleteConversationConfirmDialogProps {
+  pending: Conversation | null;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function DeleteConversationConfirmDialog({
+  pending,
+  onConfirm,
+  onCancel,
+}: DeleteConversationConfirmDialogProps) {
+  const { t } = useTranslation("chat");
+  const title =
+    pending?.title?.trim() || t("deleteConversationConfirmDialog.untitled");
+  return (
+    <ConfirmDialog
+      open={pending !== null}
+      title={t("deleteConversationConfirmDialog.title")}
+      message={
+        pending
+          ? t("deleteConversationConfirmDialog.message", { title })
+          : ""
+      }
+      confirmLabel={t("deleteConversationConfirmDialog.confirm")}
+      cancelLabel={t("deleteConversationConfirmDialog.cancel")}
+      destructive
+      onConfirm={onConfirm}
+      onCancel={onCancel}
+    />
+  );
+}

--- a/clients/web/src/domains/chat/hooks/use-conversation-actions-delete.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-conversation-actions-delete.test.tsx
@@ -1,0 +1,278 @@
+/**
+ * Tests for the optimistic delete path in `useConversationActions`.
+ *
+ * Delete uses the same TanStack-recommended `useMutation` lifecycle as
+ * archive: optimistic `removeConversation` in `onMutate`, restore the
+ * caches that held the row in `onError`, and invalidate in `onSettled`.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createElement, type ReactNode } from "react";
+
+import * as sdkGen from "@/generated/daemon/sdk.gen";
+import type { Conversation } from "@/types/conversation-types";
+import type { ConversationListPage } from "@/utils/conversation-list-fetchers";
+import { conversationListQueryKey } from "@/utils/conversation-list-keys";
+import { listPage } from "@/utils/conversation-list.test-helper";
+
+type DeleteImpl = (opts: {
+  path: { assistant_id: string; id: string };
+  throwOnError: boolean;
+}) => Promise<{ data: undefined; response: { ok: boolean } }>;
+
+let deleteImpl: DeleteImpl = async () => ({
+  data: undefined,
+  response: { ok: true },
+});
+
+mock.module("@/generated/daemon/sdk.gen", () => ({
+  ...sdkGen,
+  conversationsByIdDelete: (opts: {
+    path: { assistant_id: string; id: string };
+    throwOnError: boolean;
+  }) => deleteImpl(opts),
+}));
+
+mock.module("@/utils/haptics", () => ({
+  haptic: { medium: () => {}, light: () => {} },
+}));
+
+mock.module("@sentry/react", () => ({
+  captureException: () => {},
+  captureMessage: () => {},
+  addBreadcrumb: () => {},
+}));
+
+const { useConversationActions } =
+  await import("@/domains/chat/hooks/use-conversation-actions");
+
+const ASSISTANT_ID = "asst-1";
+
+function makeConversation(overrides: Partial<Conversation> = {}): Conversation {
+  return { conversationId: "conv-1", ...overrides };
+}
+
+function seedClient(conversations: Conversation[]): QueryClient {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  client.setQueryData(
+    conversationListQueryKey(ASSISTANT_ID),
+    listPage(conversations),
+  );
+  return client;
+}
+
+function setupHook(opts: {
+  conversations: Conversation[];
+  activeConversationId?: string | null;
+}) {
+  const client = seedClient(opts.conversations);
+  const switchCalls: string[] = [];
+  const startNewCalls: number[] = [];
+
+  const { result } = renderHook(
+    () =>
+      useConversationActions({
+        assistantId: ASSISTANT_ID,
+        activeConversationId: opts.activeConversationId ?? null,
+        conversations: opts.conversations,
+        switchConversation: (conversationId: string) => {
+          switchCalls.push(conversationId);
+        },
+        startNewConversation: () => {
+          startNewCalls.push(Date.now());
+        },
+        prePinGroupIdsRef: { current: new Map() },
+      }),
+    {
+      wrapper: ({ children }: { children: ReactNode }) =>
+        createElement(QueryClientProvider, { client }, children),
+    },
+  );
+
+  return {
+    result,
+    client,
+    switchCalls,
+    startNewCalls,
+  };
+}
+
+function readList(client: QueryClient): Conversation[] {
+  return (
+    client.getQueryData<ConversationListPage>(
+      conversationListQueryKey(ASSISTANT_ID),
+    )?.conversations ?? []
+  );
+}
+
+function deferred<T = { data: undefined; response: { ok: boolean } }>() {
+  let resolve!: (value: T) => void;
+  let reject!: (err: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+beforeEach(() => {
+  deleteImpl = async () => ({ data: undefined, response: { ok: true } });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("handleDeleteConversation — optimistic update", () => {
+  test("removes the row from the list cache before the API resolves", async () => {
+    const conv = makeConversation({ conversationId: "conv-1" });
+    const other = makeConversation({ conversationId: "conv-2" });
+    const { result, client } = setupHook({ conversations: [conv, other] });
+
+    const d = deferred();
+    deleteImpl = () => d.promise;
+
+    await act(async () => {
+      result.current.handleDeleteConversation(conv);
+    });
+
+    expect(readList(client).map((c) => c.conversationId)).toEqual(["conv-2"]);
+
+    await act(async () => {
+      d.resolve({ data: undefined, response: { ok: true } });
+    });
+  });
+
+  test("switches to the next foreground conversation before the API resolves", async () => {
+    const deleted = makeConversation({ conversationId: "active" });
+    const next = makeConversation({ conversationId: "next" });
+    const { result, switchCalls } = setupHook({
+      conversations: [deleted, next],
+      activeConversationId: "active",
+    });
+
+    const d = deferred();
+    deleteImpl = () => d.promise;
+
+    await act(async () => {
+      result.current.handleDeleteConversation(deleted);
+    });
+
+    expect(switchCalls).toEqual(["next"]);
+
+    await act(async () => {
+      d.resolve({ data: undefined, response: { ok: true } });
+    });
+  });
+
+  test("starts a new conversation when the deleted row was the last one", async () => {
+    const deleted = makeConversation({ conversationId: "active" });
+    const { result, startNewCalls } = setupHook({
+      conversations: [deleted],
+      activeConversationId: "active",
+    });
+
+    await act(async () => {
+      result.current.handleDeleteConversation(deleted);
+    });
+
+    expect(startNewCalls).toHaveLength(1);
+  });
+
+  test("does not switch when deleting a non-active conversation", async () => {
+    const deleted = makeConversation({ conversationId: "other" });
+    const active = makeConversation({ conversationId: "active" });
+    const { result, switchCalls, startNewCalls } = setupHook({
+      conversations: [active, deleted],
+      activeConversationId: "active",
+    });
+
+    await act(async () => {
+      result.current.handleDeleteConversation(deleted);
+    });
+
+    expect(switchCalls).toEqual([]);
+    expect(startNewCalls).toHaveLength(0);
+  });
+
+  test("rolls the row back into the list when the API rejects", async () => {
+    const conv = makeConversation({ conversationId: "conv-1" });
+    const { result, client } = setupHook({ conversations: [conv] });
+
+    deleteImpl = async () => {
+      throw new Error("network failure");
+    };
+
+    await act(async () => {
+      result.current.handleDeleteConversation(conv);
+    });
+
+    await waitFor(() => {
+      expect(readList(client).map((c) => c.conversationId)).toEqual(["conv-1"]);
+    });
+  });
+
+  test("invalidates conversation caches on success", async () => {
+    const conv = makeConversation({ conversationId: "conv-1" });
+    const { result, client } = setupHook({ conversations: [conv] });
+
+    const beforeState = client.getQueryState(
+      conversationListQueryKey(ASSISTANT_ID),
+    );
+    expect(beforeState?.isInvalidated).toBe(false);
+
+    await act(async () => {
+      result.current.handleDeleteConversation(conv);
+    });
+
+    await waitFor(() => {
+      const afterState = client.getQueryState(
+        conversationListQueryKey(ASSISTANT_ID),
+      );
+      expect(afterState?.isInvalidated).toBe(true);
+    });
+  });
+
+  test("invalidates conversation caches even on error", async () => {
+    const conv = makeConversation({ conversationId: "conv-1" });
+    const { result, client } = setupHook({ conversations: [conv] });
+
+    deleteImpl = async () => {
+      throw new Error("network failure");
+    };
+
+    await act(async () => {
+      result.current.handleDeleteConversation(conv);
+    });
+
+    await waitFor(() => {
+      const afterState = client.getQueryState(
+        conversationListQueryKey(ASSISTANT_ID),
+      );
+      expect(afterState?.isInvalidated).toBe(true);
+    });
+  });
+
+  test("calls DELETE /conversations/:id with the conversation id", async () => {
+    const conv = makeConversation({ conversationId: "conv-xyz" });
+    const { result } = setupHook({ conversations: [conv] });
+
+    let requestedId: string | undefined;
+    deleteImpl = async (opts) => {
+      requestedId = opts.path.id;
+      return { data: undefined, response: { ok: true } };
+    };
+
+    await act(async () => {
+      result.current.handleDeleteConversation(conv);
+    });
+
+    await waitFor(() => {
+      expect(requestedId).toBe("conv-xyz");
+    });
+  });
+});

--- a/clients/web/src/domains/chat/hooks/use-conversation-actions-delete.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-conversation-actions-delete.test.tsx
@@ -257,6 +257,60 @@ describe("handleDeleteConversation — optimistic update", () => {
     });
   });
 
+  test("does not delete unresolved draft conversations", async () => {
+    const draft = makeConversation({
+      conversationId: "draft-123",
+      draft: true,
+    });
+    const { result, client } = setupHook({ conversations: [draft] });
+
+    let requestedId: string | undefined;
+    deleteImpl = async (opts) => {
+      requestedId = opts.path.id;
+      return { data: undefined, response: { ok: true } };
+    };
+
+    await act(async () => {
+      result.current.handleDeleteConversation(draft);
+    });
+
+    expect(requestedId).toBeUndefined();
+    expect(readList(client).map((c) => c.conversationId)).toEqual(["draft-123"]);
+  });
+
+  test("failed delete restores only the deleted row", async () => {
+    const deleted = makeConversation({ conversationId: "conv-1" });
+    const other = makeConversation({ conversationId: "conv-2" });
+    const { result, client } = setupHook({
+      conversations: [deleted, other],
+    });
+
+    const d = deferred();
+    deleteImpl = () => d.promise;
+
+    await act(async () => {
+      result.current.handleDeleteConversation(deleted);
+    });
+    expect(readList(client).map((c) => c.conversationId)).toEqual(["conv-2"]);
+
+    client.setQueryData(
+      conversationListQueryKey(ASSISTANT_ID),
+      listPage([{ ...other, archivedAt: 1234 }]),
+    );
+
+    await act(async () => {
+      d.reject(new Error("network failure"));
+    });
+
+    await waitFor(() => {
+      const list = readList(client);
+      expect(list.map((c) => c.conversationId)).toEqual(["conv-1", "conv-2"]);
+      expect(list.find((c) => c.conversationId === "conv-2")?.archivedAt).toBe(
+        1234,
+      );
+    });
+  });
+
   test("calls DELETE /conversations/:id with the conversation id", async () => {
     const conv = makeConversation({ conversationId: "conv-xyz" });
     const { result } = setupHook({ conversations: [conv] });

--- a/clients/web/src/domains/chat/hooks/use-conversation-actions.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-actions.ts
@@ -18,7 +18,10 @@ import {
 import {
   adjustSectionUnreadCache,
   adjustUnreadCountCache,
+  recordConversationPlacements,
   removeConversation,
+  restoreRemovedConversation,
+  type ConversationCachePlacement,
 } from "@/utils/conversation-cache-mutations";
 import { sidebarSectionsQueryKey } from "@/utils/conversation-list-fetchers";
 import {
@@ -119,12 +122,13 @@ type MarkUnreadContext = MutationContext & {
 };
 
 /**
- * Context for a per-conversation delete. Restores only the list caches that
- * held the row, so a failed delete does not clobber concurrent placements
- * in other sections. Unread deltas reverse the same way mark-unread does.
+ * Context for a per-conversation delete. Restores only the deleted row at
+ * the indexes it left, so a failed delete does not rewind concurrent
+ * mutations of other conversations in the same list cache. Unread deltas
+ * reverse the same way mark-unread does.
  */
 type DeleteContext = {
-  snapshot: ConversationCacheSnapshot;
+  placements: ConversationCachePlacement[];
   unreadCountDelta: number;
   unreadRow?: Conversation;
 };
@@ -335,11 +339,10 @@ export function useConversationActions({
     },
     onMutate: async ({ assistantId: aid, conversation }) => {
       await cancelConversationQueries(queryClient, aid);
-      const snapshot = snapshotConversationCaches(queryClient, aid).filter(
-        ([, data]) =>
-          data?.conversations.some(
-            (row) => row.conversationId === conversation.conversationId,
-          ),
+      const placements = recordConversationPlacements(
+        queryClient,
+        aid,
+        conversation.conversationId,
       );
       const unreadRow =
         conversation.hasUnseenLatestAssistantMessage &&
@@ -352,11 +355,15 @@ export function useConversationActions({
         adjustSectionUnreadCache(queryClient, aid, unreadRow, unreadCountDelta);
       }
       removeConversation(queryClient, aid, conversation.conversationId);
-      return { snapshot, unreadCountDelta, unreadRow };
+      return { placements, unreadCountDelta, unreadRow };
     },
-    onError: (err, { assistantId: aid }, context) => {
-      if (context?.snapshot) {
-        restoreConversationCaches(queryClient, context.snapshot);
+    onError: (err, { assistantId: aid, conversation }, context) => {
+      if (context?.placements) {
+        restoreRemovedConversation(
+          queryClient,
+          conversation,
+          context.placements,
+        );
       }
       if (context && context.unreadCountDelta !== 0 && context.unreadRow) {
         adjustUnreadCountCache(queryClient, aid, -context.unreadCountDelta);
@@ -605,7 +612,7 @@ export function useConversationActions({
 
   const handleDeleteConversation = useCallback(
     (conversation: Conversation) => {
-      if (!assistantId || !conversation.conversationId) {
+      if (!assistantId || !conversation.conversationId || conversation.draft) {
         return;
       }
       haptic.medium();

--- a/clients/web/src/domains/chat/hooks/use-conversation-actions.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-actions.ts
@@ -18,6 +18,7 @@ import {
 import {
   adjustSectionUnreadCache,
   adjustUnreadCountCache,
+  removeConversation,
 } from "@/utils/conversation-cache-mutations";
 import { sidebarSectionsQueryKey } from "@/utils/conversation-list-fetchers";
 import {
@@ -29,6 +30,7 @@ import { executeBulkWithFallback } from "@/utils/bulk-with-fallback";
 import {
   conversationsArchiveBulkPost,
   conversationsByIdArchivePost,
+  conversationsByIdDelete,
   conversationsByIdUnarchivePost,
   conversationsReorderPost,
   conversationsSeenBulkPost,
@@ -57,6 +59,10 @@ type ArchiveVars = {
   previousArchivedAt: number | undefined;
 };
 type UnarchiveVars = ArchiveVars;
+type DeleteVars = {
+  assistantId: string;
+  conversation: Conversation;
+};
 type MarkUnreadVars = { assistantId: string; conversationId: string };
 type MoveToGroupVars = {
   assistantId: string;
@@ -109,6 +115,17 @@ type PlacementContext = { token: number };
 type MarkUnreadContext = MutationContext & {
   unreadCountDelta: number;
   /** The row the deltas hit, for bucket-exact reversal; see MarkSeenContext. */
+  unreadRow?: Conversation;
+};
+
+/**
+ * Context for a per-conversation delete. Restores only the list caches that
+ * held the row, so a failed delete does not clobber concurrent placements
+ * in other sections. Unread deltas reverse the same way mark-unread does.
+ */
+type DeleteContext = {
+  snapshot: ConversationCacheSnapshot;
+  unreadCountDelta: number;
   unreadRow?: Conversation;
 };
 
@@ -167,8 +184,8 @@ function reconcilePlacement(
 }
 
 /**
- * Conversation CRUD actions: archive, unarchive, rename, mark read/unread,
- * pin/unpin, and move between groups.
+ * Conversation CRUD actions: archive, unarchive, delete, rename, mark
+ * read/unread, pin/unpin, and move between groups.
  *
  * Single-item mutations use `useMutation` with the TanStack-recommended
  * optimistic update lifecycle (`onMutate` → `onError` → `onSettled`):
@@ -304,6 +321,53 @@ export function useConversationActions({
         archivedAt: previousArchivedAt,
       });
       captureError(err, { context: "unarchiveConversation" });
+    },
+    onSettled: (_data, _err, { assistantId: aid }) =>
+      invalidateConversationQueries(queryClient, aid),
+  });
+
+  const deleteMutation = useMutation<void, Error, DeleteVars, DeleteContext>({
+    mutationFn: async ({ assistantId: aid, conversation }) => {
+      await conversationsByIdDelete({
+        path: { assistant_id: aid, id: conversation.conversationId },
+        throwOnError: true,
+      });
+    },
+    onMutate: async ({ assistantId: aid, conversation }) => {
+      await cancelConversationQueries(queryClient, aid);
+      const snapshot = snapshotConversationCaches(queryClient, aid).filter(
+        ([, data]) =>
+          data?.conversations.some(
+            (row) => row.conversationId === conversation.conversationId,
+          ),
+      );
+      const unreadRow =
+        conversation.hasUnseenLatestAssistantMessage &&
+        contributesToUnreadCount(conversation)
+          ? conversation
+          : undefined;
+      const unreadCountDelta = unreadRow ? -1 : 0;
+      if (unreadRow) {
+        adjustUnreadCountCache(queryClient, aid, unreadCountDelta);
+        adjustSectionUnreadCache(queryClient, aid, unreadRow, unreadCountDelta);
+      }
+      removeConversation(queryClient, aid, conversation.conversationId);
+      return { snapshot, unreadCountDelta, unreadRow };
+    },
+    onError: (err, { assistantId: aid }, context) => {
+      if (context?.snapshot) {
+        restoreConversationCaches(queryClient, context.snapshot);
+      }
+      if (context && context.unreadCountDelta !== 0 && context.unreadRow) {
+        adjustUnreadCountCache(queryClient, aid, -context.unreadCountDelta);
+        adjustSectionUnreadCache(
+          queryClient,
+          aid,
+          context.unreadRow,
+          -context.unreadCountDelta,
+        );
+      }
+      captureError(err, { context: "deleteConversation" });
     },
     onSettled: (_data, _err, { assistantId: aid }) =>
       invalidateConversationQueries(queryClient, aid),
@@ -537,6 +601,41 @@ export function useConversationActions({
       });
     },
     [assistantId, unarchiveMutation],
+  );
+
+  const handleDeleteConversation = useCallback(
+    (conversation: Conversation) => {
+      if (!assistantId || !conversation.conversationId) {
+        return;
+      }
+      haptic.medium();
+
+      const wasActive = conversation.conversationId === activeConversationId;
+      if (wasActive) {
+        const nextKey = findNextConversationId(
+          conversations,
+          conversation.conversationId,
+        );
+        if (nextKey) {
+          switchConversation(nextKey);
+        } else {
+          startNewConversation({ silent: true });
+        }
+      }
+
+      deleteMutation.mutate({
+        assistantId,
+        conversation,
+      });
+    },
+    [
+      activeConversationId,
+      assistantId,
+      conversations,
+      switchConversation,
+      startNewConversation,
+      deleteMutation,
+    ],
   );
 
   const handleMarkConversationUnread = useCallback(
@@ -785,6 +884,7 @@ export function useConversationActions({
   return {
     handleArchiveConversation,
     handleUnarchiveConversation,
+    handleDeleteConversation,
     handleMarkConversationUnread,
     handleMarkConversationRead,
     handleTogglePinConversation,

--- a/clients/web/src/domains/chat/hooks/use-conversation-secondary-actions.ts
+++ b/clients/web/src/domains/chat/hooks/use-conversation-secondary-actions.ts
@@ -4,7 +4,7 @@
  *
  * These are the "utility" actions surfaced in the conversation header chevron
  * menu and sidebar context menu. The primary CRUD-like actions (archive,
- * unarchive, pin, rename, mark read/unread) live in `useConversationActions`.
+ * unarchive, delete, pin, rename, mark read/unread) live in `useConversationActions`.
  */
 
 import { t } from "@/i18n";

--- a/clients/web/src/i18n/locales/en/chat.json
+++ b/clients/web/src/i18n/locales/en/chat.json
@@ -446,6 +446,7 @@
     "archive": "Archive",
     "copyConversation": "Copy Full Conversation",
     "copyConversationId": "Copy conversation ID",
+    "delete": "Delete",
     "forkConversation": "Fork Conversation",
     "inspect": "Analyze Conversation",
     "markRead": "Mark as read",
@@ -529,6 +530,13 @@
     "skipForToday": "Skip for today",
     "subtitle": "Vellum credit spend is paused until your limit resets at {resetPhrase}.",
     "title": "Daily credit limit reached"
+  },
+  "deleteConversationConfirmDialog": {
+    "cancel": "Cancel",
+    "confirm": "Delete",
+    "message": "Delete “{title}”? This permanently removes the conversation and its messages. This cannot be undone.",
+    "title": "Delete conversation",
+    "untitled": "Untitled"
   },
   "detailPanelStopButton": {
     "tooltip": "Stop"

--- a/clients/web/src/i18n/locales/es/chat.json
+++ b/clients/web/src/i18n/locales/es/chat.json
@@ -446,6 +446,7 @@
     "archive": "Archivar",
     "copyConversation": "Copiar conversación completa",
     "copyConversationId": "Copiar ID de conversación",
+    "delete": "Eliminar",
     "forkConversation": "Bifurcar conversación",
     "inspect": "Analizar conversación",
     "markRead": "Marcar como leída",
@@ -529,6 +530,13 @@
     "skipForToday": "Omitir por hoy",
     "subtitle": "El gasto de créditos de Vellum está pausado hasta que tu límite se reinicie a las {resetPhrase}.",
     "title": "Límite diario de créditos alcanzado"
+  },
+  "deleteConversationConfirmDialog": {
+    "cancel": "Cancelar",
+    "confirm": "Eliminar",
+    "message": "¿Eliminar “{title}”? Esto borra la conversación y sus mensajes de forma permanente. Esta acción no se puede deshacer.",
+    "title": "Eliminar conversación",
+    "untitled": "Sin título"
   },
   "detailPanelStopButton": {
     "tooltip": "Detener"

--- a/clients/web/src/i18n/locales/ru/chat.json
+++ b/clients/web/src/i18n/locales/ru/chat.json
@@ -180,6 +180,7 @@
     "archive": "В архив",
     "copyConversation": "Скопировать весь диалог",
     "copyConversationId": "Скопировать ID диалога",
+    "delete": "Удалить",
     "forkConversation": "Ответвить диалог",
     "inspect": "Разобрать диалог",
     "markRead": "Отметить как прочитанный",
@@ -218,6 +219,13 @@
     "conversationFailed": "Не удалось скопировать ID диалога.",
     "groupCopied": "ID группы скопирован в буфер обмена.",
     "groupFailed": "Не удалось скопировать ID группы."
+  },
+  "deleteConversationConfirmDialog": {
+    "cancel": "Отмена",
+    "confirm": "Удалить",
+    "message": "Удалить «{title}»? Диалог и его сообщения будут удалены навсегда. Это действие нельзя отменить.",
+    "title": "Удалить диалог",
+    "untitled": "Без названия"
   },
   "detailPanelStopButton": {
     "tooltip": "Стоп"

--- a/clients/web/src/utils/conversation-cache-mutations.test.ts
+++ b/clients/web/src/utils/conversation-cache-mutations.test.ts
@@ -26,7 +26,9 @@ import {
   applySurfacedConversation,
   markConversationSeenLocal,
   prependConversation,
+  recordConversationPlacements,
   removeConversation,
+  restoreRemovedConversation,
   shouldSurfaceConversation,
   surfaceConversationInCaches,
   resolveDraftKey,
@@ -324,6 +326,42 @@ describe("removeConversation", () => {
     removeConversation(qc, ASSISTANT_ID, "nonexistent");
 
     expect(getForeground(qc)).toBe(original);
+  });
+});
+
+describe("restoreRemovedConversation", () => {
+  test("reinserts only the deleted row at its recorded index", () => {
+    const a = makeConversation({ conversationId: "a" });
+    const b = makeConversation({ conversationId: "b" });
+    const c = makeConversation({ conversationId: "c" });
+    seedForeground(qc, [a, b, c]);
+
+    const placements = recordConversationPlacements(qc, ASSISTANT_ID, "b");
+    removeConversation(qc, ASSISTANT_ID, "b");
+    expect(getForeground(qc).map((row) => row.conversationId)).toEqual([
+      "a",
+      "c",
+    ]);
+
+    restoreRemovedConversation(qc, b, placements);
+    expect(getForeground(qc).map((row) => row.conversationId)).toEqual([
+      "a",
+      "b",
+      "c",
+    ]);
+  });
+
+  test("leaves concurrent mutations of other rows in place", () => {
+    const a = makeConversation({ conversationId: "a" });
+    const b = makeConversation({ conversationId: "b" });
+    seedForeground(qc, [a, b]);
+
+    const placements = recordConversationPlacements(qc, ASSISTANT_ID, "a");
+    removeConversation(qc, ASSISTANT_ID, "a");
+    removeConversation(qc, ASSISTANT_ID, "b");
+
+    restoreRemovedConversation(qc, a, placements);
+    expect(getForeground(qc).map((row) => row.conversationId)).toEqual(["a"]);
   });
 });
 

--- a/clients/web/src/utils/conversation-cache-mutations.ts
+++ b/clients/web/src/utils/conversation-cache-mutations.ts
@@ -196,6 +196,73 @@ export function removeConversation(
   updateAllConversationCaches(queryClient, assistantId, drop);
 }
 
+/**
+ * The list caches that currently hold a conversation, plus the index of
+ * that row in each. Used by delete so a failed mutation can put the row
+ * back without restoring a whole-page snapshot (which would also rewind
+ * concurrent mutations of other conversations in the same cache).
+ */
+export type ConversationCachePlacement = {
+  queryKey: readonly unknown[];
+  index: number;
+};
+
+export function recordConversationPlacements(
+  queryClient: QueryClient,
+  assistantId: string | null,
+  conversationId: string,
+): ConversationCachePlacement[] {
+  if (!assistantId) {
+    return [];
+  }
+  const placements: ConversationCachePlacement[] = [];
+  const entries = queryClient.getQueriesData<ConversationListPage>({
+    queryKey: conversationListPrefix(assistantId),
+  });
+  for (const [queryKey, data] of entries) {
+    const index = data?.conversations.findIndex(
+      (c) => c.conversationId === conversationId,
+    );
+    if (index === undefined || index < 0) {
+      continue;
+    }
+    placements.push({ queryKey, index });
+  }
+  return placements;
+}
+
+/**
+ * Re-insert a removed conversation into the caches that held it, at the
+ * recorded index. Skips a cache that already has the row or is no longer
+ * mounted. Other rows in those caches are left as they are.
+ */
+export function restoreRemovedConversation(
+  queryClient: QueryClient,
+  conversation: Conversation,
+  placements: readonly ConversationCachePlacement[],
+): void {
+  for (const { queryKey, index } of placements) {
+    const page = queryClient.getQueryData<ConversationListPage>(queryKey);
+    if (!page) {
+      continue;
+    }
+    if (
+      page.conversations.some(
+        (c) => c.conversationId === conversation.conversationId,
+      )
+    ) {
+      continue;
+    }
+    const next = [...page.conversations];
+    const insertAt = Math.min(Math.max(index, 0), next.length);
+    next.splice(insertAt, 0, conversation);
+    queryClient.setQueryData<ConversationListPage>(queryKey, {
+      ...page,
+      conversations: next,
+    });
+  }
+}
+
 export function shouldSurfaceConversation(conversation: Conversation): boolean {
   if (conversation.archivedAt != null) {
     return false;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- The conversation three-dot menu (sidebar, header, and mobile sheet) now includes a labeled **Delete** action.
- Delete asks for confirmation, then uses the existing `DELETE /conversations/:id` path. Cancel leaves the conversation untouched.
- The list removes the row immediately. If the request fails, only that row is reinserted at its recorded index so overlapping mutations of other conversations are not rewound. Conversation caches are then invalidated so other clients stay in sync.
- Unresolved draft conversations (client-local stubs before the first send lands) do not show Delete, and the handler no-ops for them.
- Background and system conversations stay hidden from the user-facing list. Channel threads can be deleted locally, matching archive: this does not write to the source channel.

## Test plan
- [x] `cd clients/web && bun test src/domains/chat/components/conversation-row.test.tsx src/domains/chat/hooks/use-conversation-actions-delete.test.tsx src/utils/conversation-cache-mutations.test.ts` (67 pass after the review follow-up)
- [x] Earlier: conversation-actions-menu, confirm-dialog, i18n catalogs, and `bunx tsc --noEmit`
- Manual: open a conversation's three-dot menu, confirm Delete removes it from the sidebar, Cancel keeps it, and deleting the active conversation switches to the next one

## Risk
- Low. Backend delete, sync invalidation, and `conversation-deleted` hooks already exist. This change is web UI wiring plus optimistic cache updates.
- Destructive action is confirmation-gated. A failed request restores only the deleted row and refetches.
- Draft rows cannot be deleted, which avoids a 404 against a client-only id.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-570ca238-2ad6-40c4-b0d2-2e5d6504a78e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-570ca238-2ad6-40c4-b0d2-2e5d6504a78e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

