### PR TITLE
feat(discord): edit a sent message, so a reply can settle in place

### DIFF
--- a/assistant/src/messaging/providers/__tests__/transport-dispatch.test.ts
+++ b/assistant/src/messaging/providers/__tests__/transport-dispatch.test.ts
@@ -45,6 +45,7 @@ const discord = {
   sendDiscordTypingIndicator: mock((..._args: unknown[]) =>
     Promise.resolve(true),
   ),
+  editDiscordMessage: mock((..._args: unknown[]) => Promise.resolve()),
   sendDiscordAttachments: mock((..._args: unknown[]) =>
     Promise.resolve({ allFailed: false, failureCount: 0, totalCount: 0 }),
   ),
@@ -242,17 +243,46 @@ describe("capability gating across channels", () => {
   });
 
   test("a channel that cannot revise a sent message resolves quietly", async () => {
-    // Discord has no `edit` yet. A channel without the method is not a failed
+    // WhatsApp has no `edit`. A channel without the method is not a failed
     // delivery: nothing is attempted, nothing throws, and no fresh message is
     // posted in place of the revision.
     expect(
-      await editChannelMessage(`${BASE}/deliver/discord`, {
+      await editChannelMessage(`${BASE}/deliver/whatsapp`, {
         chatId: "C1",
         messageId: "1",
         text: "revised",
       }),
     ).toEqual({ ok: true });
+    expect(whatsapp.sendWhatsAppReply).not.toHaveBeenCalled();
+  });
+
+  test("Discord edits in place instead of posting", async () => {
+    await editChannelMessage(`${BASE}/deliver/discord`, {
+      chatId: "C1",
+      messageId: "M9",
+      text: "revised",
+    });
+
+    expect(discord.editDiscordMessage).toHaveBeenCalledTimes(1);
+    // Same distinction the Slack case asserts: an edit never reaches the post
+    // path, so a failed edit cannot become a second visible message.
     expect(discord.sendDiscordReply).not.toHaveBeenCalled();
+  });
+
+  test("Discord renders a muted edit as subtext", async () => {
+    await editChannelMessage(`${BASE}/deliver/discord`, {
+      chatId: "C1",
+      messageId: "M9",
+      text: "This approval request has been resolved.",
+      emphasis: "muted",
+    });
+
+    // `muted` is surface-agnostic and each channel picks its own token. Slack
+    // uses a context block; Discord's nearest equivalent is subtext, which it
+    // renders at the size and colour of a dismiss line.
+    expect(discord.editDiscordMessage.mock.calls[0][3]).toEqual({
+      emphasis: "muted",
+    });
   });
 
   test("the activity capability is read from the transport, not the channel name", () => {

--- a/assistant/src/messaging/providers/discord/send.test.ts
+++ b/assistant/src/messaging/providers/discord/send.test.ts
@@ -30,7 +30,8 @@ mock.module("../../../util/logger.js", () => ({
   getLogger: () => ({ debug() {}, info() {}, warn() {}, error() {} }),
 }));
 
-const { sendDiscordReply, sendDiscordAttachments } = await import("./send.js");
+const { sendDiscordReply, sendDiscordAttachments, editDiscordMessage } =
+  await import("./send.js");
 
 const originalFetch = globalThis.fetch;
 
@@ -175,5 +176,49 @@ describe("sendDiscordAttachments", () => {
     expect(result.allFailed).toBe(true);
     // Only the failure notice, never a zero-byte upload.
     expect(calls.every((c) => typeof c.body === "string")).toBe(true);
+  });
+});
+
+describe("editDiscordMessage", () => {
+  const bodyOf = (index = 0): Record<string, unknown> =>
+    JSON.parse(String(calls[index]?.body)) as Record<string, unknown>;
+
+  test("patches the message rather than posting a new one", async () => {
+    await editDiscordMessage({ channelId: "C1" }, "M9", "revised");
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.method).toBe("PATCH");
+    expect(calls[0]?.url).toContain("/channels/C1/messages/M9");
+    expect(bodyOf().content).toBe("revised");
+  });
+
+  test("marks every line of a muted edit, not just the first", async () => {
+    // Discord's subtext applies per line, so one marker would render the first
+    // line small and leave the rest at body size.
+    await editDiscordMessage({ channelId: "C1" }, "M9", "Resolved.\nBy Ada.", {
+      emphasis: "muted",
+    });
+
+    expect(bodyOf().content).toBe("-# Resolved.\n-# By Ada.");
+  });
+
+  test("leaves a blank line alone", async () => {
+    // A bare `-# ` renders an empty subtext line rather than a gap.
+    await editDiscordMessage({ channelId: "C1" }, "M9", "One.\n\nTwo.", {
+      emphasis: "muted",
+    });
+
+    expect(bodyOf().content).toBe("-# One.\n\n-# Two.");
+  });
+
+  test("a rejected edit throws rather than posting a replacement", async () => {
+    // The reason editing is its own capability: falling back to a post would
+    // leave the original standing beside a duplicate.
+    stubFetch(400, { message: "Invalid Form Body" });
+
+    await expect(
+      editDiscordMessage({ channelId: "C1" }, "M9", "revised"),
+    ).rejects.toThrow();
+    expect(calls.every((call) => call.method === "PATCH")).toBe(true);
   });
 });

--- a/assistant/src/messaging/providers/discord/send.ts
+++ b/assistant/src/messaging/providers/discord/send.ts
@@ -66,6 +66,57 @@ export interface DiscordSendResult {
 }
 
 /**
+ * Discord's rendering of a settled message.
+ *
+ * `-# ` is Discord's subtext markdown, which it describes as the same size and
+ * colour as the dismiss line under a bot message. It is the closest thing
+ * Discord has to Slack's context block, and it applies per line, so every line
+ * carries the marker rather than only the first.
+ *
+ * @see https://support.discord.com/hc/en-us/articles/210298617
+ */
+function mutedText(text: string): string {
+  return text
+    .split("\n")
+    .map((line) => (line.trim().length === 0 ? line : `-# ${line}`))
+    .join("\n");
+}
+
+/**
+ * Replace a message the assistant already sent.
+ *
+ * Never posts. A failed edit throws so the original stands alone rather than
+ * gaining a duplicate beside it, which is the whole reason editing is its own
+ * capability.
+ *
+ * Deliberately does not chunk. An edit addresses one message, and a
+ * replacement too long for one is a condition the caller has to know about
+ * rather than one this can paper over by dropping the tail. Discord rejects an
+ * over-length body and that rejection propagates.
+ *
+ * @see https://discord.com/developers/docs/resources/message#edit-message
+ */
+export async function editDiscordMessage(
+  target: DiscordSendTarget,
+  messageId: string,
+  text: string,
+  options?: { emphasis?: "muted" },
+): Promise<void> {
+  await callDiscordApi<DiscordMessage>(
+    "PATCH",
+    `${messagesRoute(target)}/${encodeURIComponent(messageId)}`,
+    {
+      content: options?.emphasis === "muted" ? mutedText(text) : text,
+      allowed_mentions: DISCORD_ALLOWED_MENTIONS,
+    },
+  );
+  log.debug(
+    { channelId: target.channelId, messageId },
+    "Discord message edited",
+  );
+}
+
+/**
  * Send a text reply, split across as many messages as Discord's content cap
  * requires. Chunks post in order so the reply reads top to bottom.
  */

--- a/assistant/src/messaging/providers/discord/transport.ts
+++ b/assistant/src/messaging/providers/discord/transport.ts
@@ -9,6 +9,7 @@ import { isBusyActivityPhase } from "../channel-transport.js";
 import { openDiscordDmChannel } from "./api.js";
 import type { DiscordSendTarget } from "./send.js";
 import {
+  editDiscordMessage,
   sendDiscordAttachments,
   sendDiscordReply,
   sendDiscordTypingIndicator,
@@ -50,6 +51,16 @@ export const discordTransport: ChannelTransport = {
 
   // Discord clears a typing indicator after ten seconds.
   activityRefreshMs: 8_000,
+
+  async edit(ctx, target) {
+    await editDiscordMessage(
+      await sendTarget(ctx, target.chatId),
+      target.messageId,
+      target.text,
+      { ...(target.emphasis ? { emphasis: target.emphasis } : {}) },
+    );
+    return { ok: true };
+  },
 
   async setActivity(ctx, target) {
     // Discord's typing indicator expires by itself after ten seconds, so a


### PR DESCRIPTION
## TL;DR

Discord was the only one of the three channels that could not revise a message it had sent. That blocked every in-place rendering there: an approval that resolves, a plan that advances, anything a reader watches change rather than re-read.

Prerequisite for channels rendering surfaces, which is the next parity item under LUM-3356.

## What changes for a person

| | Before | After |
| -- | -- | -- |
| A resolved approval in Discord | the original prompt stays as it was | the message settles in place |
| The same in Slack or Telegram | already settles | unchanged |
| A muted revision in Discord | not possible | renders as subtext: small and grey |
| A revision Discord rejects | not possible | fails, and no duplicate is posted |

## Rendering `muted`

`emphasis` is surface-agnostic and each channel picks its own token. Slack uses a context block. Discord's nearest equivalent is subtext, which its own formatting guide describes as the size and colour of the dismiss line under a bot message.

Subtext applies per line, so every line carries the marker. One marker on a multi-line replacement would render the first line small and leave the rest at body size, which reads as a formatting bug rather than a settled message. Blank lines are left alone, because a bare marker draws an empty subtext line rather than a gap. Both are asserted.

## Two deliberate non-behaviours

**It never posts.** A failed edit throws. Falling back to a post would leave the original standing beside a duplicate, which is the reason editing is its own capability rather than a flag on sending. The transport contract says so and there is a test for it.

**It does not chunk.** An edit addresses one message. A replacement too long for one is a condition the caller has to know about rather than one this can paper over by dropping the tail, so Discord's own rejection propagates rather than being pre-empted by a truncation policy invented here.

## Permissions

None added. `PATCH` on the bot's own message needs no extra scope; `MANAGE_MESSAGES` is required only to edit someone else's, which this never does.

## Tests

At the send layer, against the file's existing fetch stub, so the assertion is on the real request: the method is `PATCH` and the route addresses the message, not the channel. That matters because `callDiscordApiMultipart` hardcodes `POST`, and an edit that silently posted would be the exact failure the contract forbids.

The dispatch test used Discord as its example of a channel that cannot revise a message. WhatsApp takes that role now, which keeps the negative case honest rather than deleting it.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41200" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->