### PR TITLE
style: replace em dashes on lines this branch touched

### DIFF
--- a/assistant/src/__tests__/default-provider-ensure.test.ts
+++ b/assistant/src/__tests__/default-provider-ensure.test.ts
@@ -190,7 +190,7 @@ describe("ensureDefaultProvider", () => {
     expect(llm().defaultProvider).toEqual({ provider: "gemini" });
   });
 
-  test("a legacy connectionName does not invalidate the value — no repair, no rewrite", async () => {
+  test("a legacy connectionName does not invalidate the value: no repair, no rewrite", async () => {
     // The retired pin is an unknown key now: it strips at parse (so the
     // value is schema-valid) and self-heals on the next strict write; the
     // ensure pass leaves the raw file alone.

--- a/assistant/src/config/default-provider-resolution.ts
+++ b/assistant/src/config/default-provider-resolution.ts
@@ -18,7 +18,7 @@ export function getDefaultProviderFromConfig(
 }
 
 /**
- * Pure by design — no connection-existence check. A dangling conventional
+ * Pure by design: no connection-existence check. A dangling conventional
  * name is allowed; see `DefaultProviderSchema`.
  *
  * The single home of the conventional-row naming: identities resolve to

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -631,7 +631,7 @@ type LLMCallSiteConfig = z.infer<typeof LLMCallSiteConfig>;
  *
  * No connection-existence validation on purpose: schema validation is
  * pure/sync and cannot see the sqlite connections table, so the
- * conventionally resolved connection may be dangling — that surfaces as an
+ * conventionally resolved connection may be dangling, which surfaces as an
  * explainable resolution error at read time.
  *
  * Unknown keys (including the retired `connectionName` pin) strip at parse;

--- a/assistant/src/runtime/routes/__tests__/default-provider-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/default-provider-routes.test.ts
@@ -213,7 +213,7 @@ describe("GET config/llm/default-provider", () => {
     expect(availability(result)).toEqual({ status: "ok" });
   });
 
-  test("a legacy stored connectionName pin strips at parse — convention wins", async () => {
+  test("a legacy stored connectionName pin strips at parse; convention wins", async () => {
     seedConnection({
       name: "openai-personal",
       provider: "openai",

--- a/assistant/src/runtime/routes/inference-provider-connection-routes.ts
+++ b/assistant/src/runtime/routes/inference-provider-connection-routes.ts
@@ -609,10 +609,10 @@ async function handleDeleteConnection({ pathParams = {} }: RouteHandlerArgs) {
 
   // llm.defaultProvider: guards both the convention-resolved connection name
   // and the case where the convention name is dangling but this is the last
-  // remaining connection for the default's provider — resolution treats a
+  // remaining connection for the default's provider: resolution treats a
   // dangling default as an explainable error; this guard keeps UI deletes
   // from orphaning it silently. Legacy managed rows are excluded from the
-  // count for the same reason the list route hides them — they aren't
+  // count for the same reason the list route hides them: they aren't
   // user-manageable connections.
   const dp = getDefaultProviderFromConfig(config);
   // A `vellum` default resolves to the canonical name, so this guard would

--- a/clients/web/src/domains/settings/ai/providers-section.test.tsx
+++ b/clients/web/src/domains/settings/ai/providers-section.test.tsx
@@ -278,7 +278,7 @@ describe("ProvidersSection - kebab actions", () => {
   test("a non-convention row offers no Set as default", async () => {
     // The PUT body carries only the provider, so on a suffix-named
     // duplicate the daemon would set the convention row instead of the
-    // clicked one — the affordance is hidden there.
+    // clicked one; the affordance is hidden there.
     connectionsState = [
       ...connectionsState,
       connection({

--- a/clients/web/src/lib/billing/byok-credit-route.ts
+++ b/clients/web/src/lib/billing/byok-credit-route.ts
@@ -316,7 +316,7 @@ export function defaultChatRouteBurnsManagedCredits(
  * resolved connection the daemon stamps onto default bodies
  * (`resolvedConnectionName` from the default-provider status), so an unset
  * name doesn't misread as unbound dispatch. Old daemons may still emit an
- * explicit `connectionName` pin in this evidence; it is ignored — their pins
+ * explicit `connectionName` pin in this evidence; it is ignored: their pins
  * were canonical-or-conventional anyway. Null when no default provider is
  * configured.
  */


### PR DESCRIPTION
## Summary
Applies the AGENTS.md no-em-dash rule to the lines this feature branch added or reworded, per the review comments on #41188. Text only: comments, docstrings, and two test titles. No behavior change.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41203" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->