### PR TITLE
feat(gateway): verify Standard Webhooks on plugin ingress

### DIFF
--- a/gateway/src/channels/ingress-verification.test.ts
+++ b/gateway/src/channels/ingress-verification.test.ts
@@ -7,6 +7,7 @@ import {
   canonicalVerification,
   IngressVerificationSchema,
   MAX_FRESHNESS_TOLERANCE_SECONDS,
+  STANDARD_WEBHOOKS_TOLERANCE_SECONDS,
   verifyDeclaredSignature,
   type IngressVerification,
 } from "./ingress-verification.js";
@@ -20,6 +21,11 @@ const BODY_ONLY: IngressVerification = {
   secret: { field: "comms_webhook_secret" },
   signature: { header: "X-Osis-Signature", encoding: "hex", prefix: "sha256=" },
   payload: ["body"],
+};
+
+const STANDARD_WEBHOOKS: IngressVerification = {
+  kind: "standard-webhooks",
+  secret: { field: "linq_webhook_secret" },
 };
 
 const TIMESTAMPED: IngressVerification = {
@@ -75,6 +81,9 @@ describe("the descriptor schema", () => {
   it("accepts the shapes the shipped plugins declare", () => {
     expect(IngressVerificationSchema.safeParse(BODY_ONLY).success).toBe(true);
     expect(IngressVerificationSchema.safeParse(TIMESTAMPED).success).toBe(true);
+    expect(IngressVerificationSchema.safeParse(STANDARD_WEBHOOKS).success).toBe(
+      true,
+    );
   });
 
   it("rejects an unknown kind rather than falling back to a default", () => {
@@ -397,5 +406,115 @@ describe("canonicalVerification", () => {
     expect(canonicalVerification(forward)).not.toBe(
       canonicalVerification(reversed),
     );
+  });
+});
+
+describe("standard-webhooks verification", () => {
+  const KEY_BYTES = Buffer.from("standard-webhooks-test-key-bytes!!");
+  const WHSEC = `whsec_${KEY_BYTES.toString("base64")}`;
+  const MSG_ID = "msg_01JABC";
+  const TS = String(Math.floor(NOW_MS / 1000));
+  const BODY = '{"event_type":"message.received"}';
+
+  function sign(
+    body: string,
+    opts: { id?: string; timestamp?: string; key?: Buffer } = {},
+  ): string {
+    const id = opts.id ?? MSG_ID;
+    const timestamp = opts.timestamp ?? TS;
+    const key = opts.key ?? KEY_BYTES;
+    const digest = createHmac("sha256", key)
+      .update(`${id}.${timestamp}.${body}`, "utf8")
+      .digest("base64");
+    return `v1,${digest}`;
+  }
+
+  function headers(
+    signature: string,
+    extra: Record<string, string> = {},
+  ): Record<string, string> {
+    return {
+      "webhook-id": MSG_ID,
+      "webhook-timestamp": TS,
+      "webhook-signature": signature,
+      ...extra,
+    };
+  }
+
+  it("accepts a delivery signed the spec's way", () => {
+    expect(
+      verify(STANDARD_WEBHOOKS, headers(sign(BODY)), BODY, { secret: WHSEC }),
+    ).toEqual({ ok: true });
+  });
+
+  it("decodes a secret stored without the whsec_ prefix", () => {
+    expect(
+      verify(STANDARD_WEBHOOKS, headers(sign(BODY)), BODY, {
+        secret: KEY_BYTES.toString("base64"),
+      }),
+    ).toEqual({ ok: true });
+  });
+
+  it("accepts any matching v1 signature when several are presented", () => {
+    const other = createHmac("sha256", Buffer.from("other-key"))
+      .update("x")
+      .digest("base64");
+    const presented = `v1,${other} ${sign(BODY)}`;
+    expect(
+      verify(STANDARD_WEBHOOKS, headers(presented), BODY, { secret: WHSEC }),
+    ).toEqual({ ok: true });
+  });
+
+  it("covers the bytes as received, not a reserialization", () => {
+    expect(
+      verify(STANDARD_WEBHOOKS, headers(sign('{"a":1}')), '{ "a" : 1 }', {
+        secret: WHSEC,
+      }),
+    ).toEqual({ ok: false, reason: "bad_signature" });
+  });
+
+  it("rejects a stale timestamp", () => {
+    const stale = String(
+      Math.floor(NOW_MS / 1000) - STANDARD_WEBHOOKS_TOLERANCE_SECONDS - 1,
+    );
+    expect(
+      verify(
+        STANDARD_WEBHOOKS,
+        headers(sign(BODY, { timestamp: stale }), {
+          "webhook-timestamp": stale,
+        }),
+        BODY,
+        { secret: WHSEC },
+      ),
+    ).toEqual({ ok: false, reason: "stale_timestamp" });
+  });
+
+  it("rejects a header with no v1 signature as malformed", () => {
+    expect(
+      verify(STANDARD_WEBHOOKS, headers("v2,abcd"), BODY, { secret: WHSEC }),
+    ).toEqual({ ok: false, reason: "malformed_signature" });
+  });
+
+  it("rejects a missing webhook-id as a missing payload header", () => {
+    expect(
+      verify(
+        STANDARD_WEBHOOKS,
+        {
+          "webhook-timestamp": TS,
+          "webhook-signature": sign(BODY),
+        },
+        BODY,
+        { secret: WHSEC },
+      ),
+    ).toEqual({ ok: false, reason: "missing_payload_header" });
+  });
+
+  it("changes the digest when the secret field changes", () => {
+    expect(
+      canonicalVerification({
+        ...STANDARD_WEBHOOKS,
+        secret: { field: "other_secret" },
+      }),
+    ).not.toBe(canonicalVerification(STANDARD_WEBHOOKS));
   });
 });

--- a/gateway/src/channels/ingress-verification.ts
+++ b/gateway/src/channels/ingress-verification.ts
@@ -7,12 +7,13 @@
  * such a route could be declared, approved, registered with the vendor, and
  * then 403 every delivery — the only schemes the gateway knew were its own.
  *
- * So a route may declare *how* to verify it, as data. The gateway implements
- * one HMAC engine and reads the vendor's specifics — algorithm, which header
- * carries the digest, how it is encoded, and exactly which bytes it covers —
- * out of the manifest. A third vendor is a manifest edit rather than gateway
- * code, which is the whole point: the alternative is a growing switch of
- * per-vendor verifiers that only the gateway team can extend.
+ * So a route may declare *how* to verify it, as data. Most vendors fit the
+ * HMAC engine: algorithm, which header carries the digest, how it is
+ * encoded, and exactly which bytes it covers, all read from the manifest.
+ * Standard Webhooks is a second kind because its secret encoding and
+ * multi-signature header cannot be expressed as that list. A third HMAC
+ * vendor is still a manifest edit rather than gateway code. A fourth
+ * complete scheme is an added union member.
  *
  * What stays gateway-side, and must:
  *
@@ -121,15 +122,37 @@ export const HmacVerificationSchema = z
   .strict();
 
 /**
+ * Standard Webhooks (`standardwebhooks.com`).
+ *
+ * A complete scheme, not a list of HMAC parts: the signed content is always
+ * `{webhook-id}.{webhook-timestamp}.{raw body}`, the key is the base64
+ * payload of a `whsec_` secret, and the header is
+ * `webhook-signature: v1,<base64>` (space-separated when rotated). Linq
+ * and any other vendor that adopted the spec declare this kind instead of
+ * reconstructing those rules as an `hmac` payload list, which cannot decode
+ * the secret or accept multiple signatures.
+ *
+ * Replay window is five minutes, matching the spec's default.
+ */
+export const StandardWebhooksVerificationSchema = z
+  .object({
+    kind: z.literal("standard-webhooks"),
+    secret: z.object({ field: CredentialFieldSchema }).strict(),
+  })
+  .strict();
+
+/** Replay window Standard Webhooks requires. */
+export const STANDARD_WEBHOOKS_TOLERANCE_SECONDS = 5 * 60;
+
+/**
  * How a route is verified.
  *
- * A discriminated union of one member today. It is a union rather than a bare
- * object so a second scheme — a vendor that signs an asymmetric signature, say
- * — is an added member with its own required fields, and every existing
- * manifest keeps parsing.
+ * A discriminated union. A second scheme is an added member with its own
+ * required fields, and every existing manifest keeps parsing.
  */
 export const IngressVerificationSchema = z.discriminatedUnion("kind", [
   HmacVerificationSchema,
+  StandardWebhooksVerificationSchema,
 ]);
 export type IngressVerification = z.infer<typeof IngressVerificationSchema>;
 
@@ -199,6 +222,96 @@ function decodeDigest(
     : null;
 }
 
+/**
+ * Decode a Standard Webhooks secret into the HMAC key bytes.
+ *
+ * A `whsec_` prefix is stripped, then the remainder is base64. A secret
+ * stored without the prefix is decoded as-is so a caller that already
+ * stripped it still verifies.
+ */
+function standardWebhooksKey(secret: string): Buffer | null {
+  const encoded = secret.startsWith("whsec_") ? secret.slice(6) : secret;
+  if (!encoded) {
+    return null;
+  }
+  const key = Buffer.from(encoded, "base64");
+  return key.length > 0 ? key : null;
+}
+
+/**
+ * Verify a Standard Webhooks delivery.
+ *
+ * Headers are looked up case-insensitively (`Headers.get`). The signed
+ * content is `{webhook-id}.{webhook-timestamp}.{raw body}`. Any `v1,`
+ * signature in the space-separated header is enough.
+ */
+function verifyStandardWebhooks(opts: {
+  headers: Headers;
+  body: Uint8Array;
+  secret: string;
+  nowMs: number;
+}): VerificationResult {
+  const { headers, body, secret, nowMs } = opts;
+  if (!secret) {
+    return { ok: false, reason: "missing_signature" };
+  }
+
+  const msgId = headers.get("webhook-id");
+  const timestamp = headers.get("webhook-timestamp");
+  const signatureHeader = headers.get("webhook-signature");
+  if (!signatureHeader) {
+    return { ok: false, reason: "missing_signature" };
+  }
+  if (msgId === null) {
+    return { ok: false, reason: "missing_payload_header" };
+  }
+  if (timestamp === null) {
+    return { ok: false, reason: "missing_timestamp" };
+  }
+
+  if (!/^-?\d+$/.test(timestamp)) {
+    return { ok: false, reason: "missing_timestamp" };
+  }
+  const stampedMs = Number(timestamp) * 1000;
+  if (!Number.isSafeInteger(Number(timestamp))) {
+    return { ok: false, reason: "missing_timestamp" };
+  }
+  if (Math.abs(nowMs - stampedMs) > STANDARD_WEBHOOKS_TOLERANCE_SECONDS * 1000) {
+    return { ok: false, reason: "stale_timestamp" };
+  }
+
+  const key = standardWebhooksKey(secret);
+  if (!key) {
+    return { ok: false, reason: "missing_signature" };
+  }
+
+  const signedContent = Buffer.concat([
+    Buffer.from(`${msgId}.${timestamp}.`, "utf8"),
+    Buffer.from(body),
+  ]);
+  const expected = createHmac("sha256", key).update(signedContent).digest();
+
+  let sawV1 = false;
+  for (const entry of signatureHeader.split(" ")) {
+    if (!entry.startsWith("v1,")) {
+      continue;
+    }
+    sawV1 = true;
+    const digest = decodeDigest(entry.slice(3), "base64");
+    if (!digest || digest.length !== expected.length) {
+      continue;
+    }
+    if (timingSafeEqual(digest, expected)) {
+      return { ok: true };
+    }
+  }
+
+  return {
+    ok: false,
+    reason: sawV1 ? "bad_signature" : "malformed_signature",
+  };
+}
+
 /** Unix milliseconds for a timestamp in the declared format, or `null`. */
 function timestampMs(value: string, format: string): number | null {
   if (format === "rfc3339") {
@@ -226,6 +339,10 @@ export function verifyDeclaredSignature(opts: {
 }): VerificationResult {
   const { verification, headers, body, secret } = opts;
   const nowMs = opts.nowMs ?? Date.now();
+
+  if (verification.kind === "standard-webhooks") {
+    return verifyStandardWebhooks({ headers, body, secret, nowMs });
+  }
 
   const presented = headers.get(verification.signature.header);
   if (!presented || !secret) {

--- a/gateway/src/channels/plugin-ingress.test.ts
+++ b/gateway/src/channels/plugin-ingress.test.ts
@@ -168,6 +168,26 @@ describe("parsePluginIngressManifest", () => {
     ).toThrow(/only valid for websocket/);
   });
 
+  it("accepts a standard-webhooks verification descriptor", () => {
+    const manifest = parsePluginIngressManifest({
+      routes: [
+        {
+          path: "events-linq",
+          kind: "http",
+          verification: {
+            kind: "standard-webhooks",
+            secret: { field: "linq_webhook_secret" },
+          },
+          description: "inbound linq deliveries",
+        },
+      ],
+    });
+    expect(manifest.routes[0]!.verification).toEqual({
+      kind: "standard-webhooks",
+      secret: { field: "linq_webhook_secret" },
+    });
+  });
+
   it("accepts a verification descriptor on an http route", () => {
     const manifest = parsePluginIngressManifest({
       routes: [

--- a/gateway/src/channels/plugin-ingress.ts
+++ b/gateway/src/channels/plugin-ingress.ts
@@ -140,12 +140,16 @@ export const IngressRouteSchema = z.object({
    * the body, keyed by whichever `webhook_secret` {@link signer} selects.
    * That is right for a caller Vellum controls and wrong for every other one
    * — Comms signs `X-Osis-Signature`, Photon signs `X-Spectrum-Signature` over
-   * a timestamped preamble, and neither can be asked to sign ours.
+   * a timestamped preamble, and Linq signs Standard Webhooks
+   * (`webhook-id` / `webhook-timestamp` / `webhook-signature`). None of
+   * those callers can be asked to sign ours.
    *
-   * Present, the route is verified by the descriptor instead: the gateway
-   * runs one HMAC engine and reads the vendor's specifics as data, so a new
-   * vendor is a manifest edit rather than gateway code. See
-   * `ingress-verification.ts` for the scheme and for what stays gateway-side.
+   * Present, the route is verified by the descriptor instead. `hmac` is a
+   * single engine that reads the vendor's parts as data. `standard-webhooks`
+   * is a complete scheme (key encoding, signed content, and replay window)
+   * because that spec cannot be reconstructed as an `hmac` payload list.
+   * See `ingress-verification.ts` for the schemes and for what stays
+   * gateway-side.
    *
    * The descriptor supersedes {@link signer} — it names its own credential
    * field, under this plugin's own service — so declaring it alongside

--- a/gateway/src/http/routes/channel-ingress.test.ts
+++ b/gateway/src/http/routes/channel-ingress.test.ts
@@ -267,6 +267,32 @@ describe("list", () => {
     });
   });
 
+  it("summarises a Standard Webhooks declaration the same way", async () => {
+    writePlugin("meeting-bot", [
+      {
+        path: "events-linq",
+        kind: "http",
+        description: "inbound",
+        verification: {
+          kind: "standard-webhooks",
+          secret: { field: "linq_webhook_secret" },
+        },
+      },
+    ]);
+
+    const body = (await (await list()).json()) as {
+      sources: { routes: Record<string, unknown>[] }[];
+    };
+
+    expect(body.sources[0]!.routes[0]).toMatchObject({
+      credential: "credential/meeting-bot/linq_webhook_secret",
+      verification: {
+        algorithm: "sha256",
+        signatureHeader: "webhook-signature",
+      },
+    });
+  });
+
   it("reports an approved declaration as approved", async () => {
     writePlugin("meeting-bot");
     approvePluginIngress({

--- a/gateway/src/http/routes/channel-ingress.ts
+++ b/gateway/src/http/routes/channel-ingress.ts
@@ -20,6 +20,7 @@ import {
   resolvePluginIngress,
   type PluginIngressResolution,
 } from "../../channels/plugin-ingress-approvals.js";
+import type { IngressVerification } from "../../channels/ingress-verification.js";
 import {
   pluginWebhookPath,
   type IngressRoute,
@@ -45,6 +46,29 @@ const ApproveBodySchema = ApproveChannelIngressRequestSchema;
 // ---------------------------------------------------------------------------
 // GET /v1/channel-ingress: what has been declared, and what is being served
 // ---------------------------------------------------------------------------
+
+/**
+ * The parts of a declared scheme a guardian listing can show.
+ *
+ * HMAC names its own algorithm and header. Standard Webhooks always signs
+ * with sha256 and always presents the digest in `webhook-signature`, so
+ * those values are filled in rather than stored on the descriptor.
+ */
+function verificationView(verification: IngressVerification): {
+  algorithm: string;
+  signatureHeader: string;
+} {
+  if (verification.kind === "standard-webhooks") {
+    return {
+      algorithm: "sha256",
+      signatureHeader: "webhook-signature",
+    };
+  }
+  return {
+    algorithm: verification.algorithm,
+    signatureHeader: verification.signature.header,
+  };
+}
 
 /**
  * One route, as the guardian needs to read it.
@@ -91,10 +115,7 @@ function routeView(
           "webhook_secret",
         ),
     verification: route.verification
-      ? {
-          algorithm: route.verification.algorithm,
-          signatureHeader: route.verification.signature.header,
-        }
+      ? verificationView(route.verification)
       : undefined,
   };
 }

--- a/gateway/src/http/routes/plugin-webhook.test.ts
+++ b/gateway/src/http/routes/plugin-webhook.test.ts
@@ -914,6 +914,117 @@ describe("declared verification", () => {
   });
 });
 
+describe("standard-webhooks verification", () => {
+  const KEY_BYTES = Buffer.from("standard-webhooks-test-key-bytes!!");
+  const WHSEC = `whsec_${KEY_BYTES.toString("base64")}`;
+  const MSG_ID = "msg_01JABC";
+
+  const STANDARD: IngressRoute = {
+    ...ROUTE,
+    verification: {
+      kind: "standard-webhooks",
+      secret: { field: "standard_webhooks_secret" },
+    },
+  };
+
+  const STANDARD_CREDENTIALS = credentialsFor({
+    "credential/meeting-bot/webhook_secret": PLUGIN_SECRET,
+    "credential/vellum/webhook_secret": VELLUM_SECRET,
+    "credential/meeting-bot/standard_webhooks_secret": WHSEC,
+  });
+
+  function signStandard(
+    body: string,
+    opts: { id?: string; timestamp?: string } = {},
+  ): { id: string; timestamp: string; signature: string } {
+    const id = opts.id ?? MSG_ID;
+    const timestamp =
+      opts.timestamp ?? String(Math.floor(Date.now() / 1000));
+    const digest = createHmac("sha256", KEY_BYTES)
+      .update(`${id}.${timestamp}.${body}`, "utf8")
+      .digest("base64");
+    return { id, timestamp, signature: `v1,${digest}` };
+  }
+
+  it("forwards a delivery signed the spec's way", async () => {
+    const { calls, fetchImpl } = recordingFetch();
+    const handle = createPluginWebhookHandler({
+      config: CONFIG,
+      credentials: STANDARD_CREDENTIALS,
+      resolve: () => approvedWith([STANDARD]),
+      fetchImpl,
+    });
+
+    const body = '{"event_type":"message.received"}';
+    const signed = signStandard(body);
+    const res = await handle(
+      vendorPost(body, {
+        "webhook-id": signed.id,
+        "webhook-timestamp": signed.timestamp,
+        "webhook-signature": signed.signature,
+      }),
+      "meeting-bot",
+      "realtime",
+    );
+
+    expect(res.status).toBe(200);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.body).toBe(body);
+  });
+
+  it("rejects a bad Standard Webhooks signature", async () => {
+    const { calls, fetchImpl } = recordingFetch();
+    const handle = createPluginWebhookHandler({
+      config: CONFIG,
+      credentials: STANDARD_CREDENTIALS,
+      resolve: () => approvedWith([STANDARD]),
+      fetchImpl,
+    });
+
+    const body = '{"event_type":"message.received"}';
+    const signed = signStandard(body);
+    const res = await handle(
+      vendorPost(body, {
+        "webhook-id": signed.id,
+        "webhook-timestamp": signed.timestamp,
+        "webhook-signature": "v1,AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+      }),
+      "meeting-bot",
+      "realtime",
+    );
+
+    expect(res.status).toBe(403);
+    expect(calls).toEqual([]);
+  });
+
+  it("409s when the Standard Webhooks secret field holds nothing", async () => {
+    const { calls, fetchImpl } = recordingFetch();
+    const handle = createPluginWebhookHandler({
+      config: CONFIG,
+      credentials: credentialsFor({
+        "credential/meeting-bot/webhook_secret": PLUGIN_SECRET,
+      }),
+      resolve: () => approvedWith([STANDARD]),
+      fetchImpl,
+    });
+
+    const body = '{"event_type":"message.received"}';
+    const signed = signStandard(body);
+    const res = await handle(
+      vendorPost(body, {
+        "webhook-id": signed.id,
+        "webhook-timestamp": signed.timestamp,
+        "webhook-signature": signed.signature,
+      }),
+      "meeting-bot",
+      "realtime",
+    );
+
+    expect(res.status).toBe(409);
+    expect(calls).toEqual([]);
+  });
+});
+
 describe("payload limits", () => {
   it("rejects a body over the webhook cap without forwarding it", async () => {
     const { calls, fetchImpl } = recordingFetch();

--- a/gateway/src/http/routes/plugin-webhook.test.ts
+++ b/gateway/src/http/routes/plugin-webhook.test.ts
@@ -933,6 +933,14 @@ describe("standard-webhooks verification", () => {
     "credential/meeting-bot/standard_webhooks_secret": WHSEC,
   });
 
+  function vendorPost(body: string, headers: Record<string, string>): Request {
+    return new Request("http://gateway/webhooks/plugins/meeting-bot/realtime", {
+      method: "POST",
+      body,
+      headers,
+    });
+  }
+
   function signStandard(
     body: string,
     opts: { id?: string; timestamp?: string } = {},

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -761,7 +761,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-08-21T15:44:11.000Z"
+      "updatedAt": "2026-08-24T15:13:55.000Z"
     },
     {
       "id": "public-ingress",
@@ -899,7 +899,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-08-22T11:18:08.000Z"
+      "updatedAt": "2026-08-24T14:09:38.000Z"
     },
     {
       "id": "start-the-day",

--- a/skills/plugin-builder/references/channels.md
+++ b/skills/plugin-builder/references/channels.md
@@ -34,7 +34,7 @@ That route is served at `/webhooks/plugins/<plugin-name>/events` and handled by 
 | `kind`         | yes      |                    | `"http"` or `"websocket"`. The gateway bridges the two differently, so the kind has to be known before a connection arrives.                                                                                                                  |
 | `description`  | yes      |                    | Human-readable purpose, surfaced in gateway logs and the approval UI.                                                                                                                                                                         |
 | `handshake`    | no       | `"signed-headers"` | Where the caller carries its signature. `"signed-headers"` (default) puts it in request headers. `"signed-query"` puts the same HMAC in the URL, WebSocket only, for a caller that is handed a URL and nothing else.                          |
-| `verification` | no       | vendor HMAC        | How a third-party caller's signature is checked. HTTP only.                                                                                                                                                                                   |
+| `verification` | no       | vendor HMAC        | How a third-party caller's signature is checked. HTTP only. `hmac` (parts as data) or `standard-webhooks` (the complete spec).                                                                                                                |
 | `inbound`      | no       | webhook only       | That this route's replies carry inbound messages, and how to read them. HTTP only.                                                                                                                                                            |
 
 Duplicate paths in one file fail the whole declaration. A malformed file disables ingress for that plugin only; sibling plugins keep theirs.
@@ -49,7 +49,7 @@ Ask the user to approve pending ingress from the channels settings once the plug
 
 ## Third-party verification
 
-A vendor that signs `X-Example-Signature` has its own scheme. Declare `verification` so the gateway runs one HMAC engine and reads the vendor's specifics as data:
+A vendor that signs `X-Example-Signature` has its own scheme. Declare `verification` so the gateway checks it. Most vendors fit `kind: "hmac"`: one engine, vendor specifics as data:
 
 ```json
 {
@@ -75,12 +75,26 @@ A vendor that signs `X-Example-Signature` has its own scheme. Declare `verificat
 }
 ```
 
+A vendor that adopted [Standard Webhooks](https://www.standardwebhooks.com/) (`webhook-id`, `webhook-timestamp`, `webhook-signature: v1,<base64>`, `whsec_` secret) declares that complete scheme instead. The signed content, key encoding, and five-minute replay window are fixed by the spec, so they are not listed as HMAC parts:
+
+```json
+{
+  "path": "events",
+  "kind": "http",
+  "description": "Inbound deliveries from Example Courier",
+  "verification": {
+    "kind": "standard-webhooks",
+    "secret": { "field": "courier_webhook_secret" }
+  }
+}
+```
+
 Rules that stay gateway-side:
 
 - The credential **service** is the plugin's directory name. The descriptor names only a **field** (`courier_webhook_secret` above). A manifest cannot point a route at another plugin's secret or at the platform's.
 - Store the secret via `assistant credentials prompt` (or `storeCredential` from a hook/tool/route). Never put it in the file.
-- `payload` is the exact bytes the vendor signs, in order: `"body"`, `{ "header": "..." }`, or `{ "literal": "..." }`. A header named in `payload` but absent from the request fails verification rather than contributing an empty string.
-- `freshness` is a replay window. Declare it when the vendor binds a timestamp. A signature over the body alone stays valid for as long as the secret does.
+- For `hmac`, `payload` is the exact bytes the vendor signs, in order: `"body"`, `{ "header": "..." }`, or `{ "literal": "..." }`. A header named in `payload` but absent from the request fails verification rather than contributing an empty string.
+- For `hmac`, `freshness` is a replay window. Declare it when the vendor binds a timestamp. A signature over the body alone stays valid for as long as the secret does.
 - Unrecognized fields fail the declaration rather than guessing a scheme.
 
 ## Delivering inbound messages


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `kind: "standard-webhooks"` to plugin ingress verification so a vendor that adopted the spec can declare it instead of reconstructing it as an `hmac` payload list.

## Why

Linq (and any other Standard Webhooks vendor) signs `{webhook-id}.{webhook-timestamp}.{raw body}` with the base64 payload of a `whsec_` secret, and presents one or more `v1,<base64>` signatures. That cannot be expressed with the existing HMAC descriptor: the secret is not UTF-8 HMAC of the raw string, and the header can carry multiple signatures.

This unblocks inbound for the iMessage Linq provider:

https://github.com/vellum-ai/imessage/pull/43

Existing `hmac` manifests keep parsing. Replay window is five minutes, matching the spec.

## What landed

- Discriminated union on `IngressVerificationSchema`: `hmac` | `standard-webhooks`
- `standard-webhooks` names only `secret.field` (headers and signed content are fixed)
- Route handler and approval digest already go through `verifyDeclaredSignature` / `canonicalVerification`
- Plugin-builder channel docs describe the new kind

## Test plan

- `cd gateway && bun test src/channels/ingress-verification.test.ts src/channels/plugin-ingress.test.ts src/http/routes/plugin-webhook.test.ts` (145 pass)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e4962d4e-2ec1-41e9-a672-94c27c721e8c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e4962d4e-2ec1-41e9-a672-94c27c721e8c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

