### PR TITLE
feat(providers): resolve backup-profile routes for managed connections

### DIFF
--- a/assistant/src/__tests__/managed-fallback-dispatch.test.ts
+++ b/assistant/src/__tests__/managed-fallback-dispatch.test.ts
@@ -400,4 +400,54 @@ describe("managed fallback dispatch", () => {
     expect(response.actualProvider).toBe("anthropic");
     expect(response.actualInferenceProfile).toBe("tweaked-backup");
   });
+
+  test("a backup routing outside the managed connection is refused", async () => {
+    // The schema allows a pointer at a user-defined profile that carries its
+    // own BYOK provider. Serving it here would authenticate someone's personal
+    // route with the managed credential and bill it as managed traffic, so the
+    // escalation is declined and the primary's failure stands.
+    setConfig("llm", {
+      profiles: {
+        "managed-primary": {
+          source: "user",
+          provider: "vellum",
+          model: "claude-opus-5",
+          fallbackProfile: "byok-target",
+          maxTokens: 1024,
+        },
+        "byok-target": {
+          source: "user",
+          provider: "anthropic",
+          model: "claude-sonnet-5",
+          maxTokens: 2048,
+        },
+      },
+      activeProfile: "managed-primary",
+    });
+    anthropicMode = "retired";
+
+    const provider = createAdapterFromConnection(
+      vellumConnection,
+      managedAuth(ANTHROPIC_PATH),
+      {
+        model: "claude-opus-5",
+        provider: "anthropic",
+        streamTimeoutMs: 30_000,
+      },
+    );
+    expect(provider).not.toBeNull();
+
+    const error = await provider!
+      .sendMessage(MESSAGES, { config: { callSite: "mainAgent" } })
+      .then(
+        () => null,
+        (err: unknown) => err,
+      );
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as { statusCode?: number }).statusCode).toBe(404);
+    // Nothing was re-routed: the backup's model never went on the wire.
+    const models = new Set(requests.map((r) => r.body.model));
+    expect(models).toEqual(new Set(["claude-opus-5"]));
+  });
 });

--- a/assistant/src/__tests__/managed-fallback-dispatch.test.ts
+++ b/assistant/src/__tests__/managed-fallback-dispatch.test.ts
@@ -1,0 +1,347 @@
+/**
+ * Managed backup-profile dispatch, end to end against a mocked upstream.
+ *
+ * Everything below the test is production code: the real adapter factory, the
+ * real managed-proxy auth resolution, the real `RetryProvider` escalation, and
+ * the real Anthropic client. Only the upstream is faked, by a local
+ * `Bun.serve` standing in for the platform's runtime proxy, so the assertions
+ * are made on the bytes the backup route actually puts on the wire.
+ *
+ * Deliberately mock-free at the module level: `mock.module` is process-wide in
+ * bun, and stubbing the provider clients here would leak into every other file
+ * that exercises them.
+ */
+
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+
+import { createAdapterFromConnection } from "../providers/inference/adapter-factory.js";
+import type {
+  ProviderConnection,
+  ResolvedAuth,
+} from "../providers/inference/auth.js";
+import type { Message, ProviderResponse } from "../providers/types.js";
+import { credentialKey } from "../security/credential-key.js";
+import { setSecureKeyAsync } from "../security/secure-keys.js";
+import { setConfig } from "./helpers/set-config.js";
+
+// ── Mocked upstream ─────────────────────────────────────────────────────────
+
+interface UpstreamRequest {
+  path: string;
+  headers: Record<string, string>;
+  body: Record<string, unknown>;
+}
+
+const requests: UpstreamRequest[] = [];
+
+/**
+ * What the anthropic proxy path does. `retired` is the model rename/retirement
+ * shape: fallback-eligible but not retryable, so the escalation decision is
+ * reached on the first attempt instead of after a full retry budget.
+ */
+let anthropicMode: "serve" | "retired" = "serve";
+
+const ANTHROPIC_PATH = "/v1/runtime-proxy/anthropic";
+const OPENAI_PATH = "/v1/runtime-proxy/openai";
+
+/** A complete Anthropic Messages SSE stream for a one-word reply. */
+function anthropicCompletion(): Response {
+  const events = [
+    {
+      type: "message_start",
+      message: {
+        id: "msg_fallback_01",
+        type: "message",
+        role: "assistant",
+        content: [],
+        model: "claude-opus-5",
+        stop_reason: null,
+        stop_sequence: null,
+        usage: { input_tokens: 7, output_tokens: 1 },
+      },
+    },
+    {
+      type: "content_block_start",
+      index: 0,
+      content_block: { type: "text", text: "" },
+    },
+    {
+      type: "content_block_delta",
+      index: 0,
+      delta: { type: "text_delta", text: "served by the backup" },
+    },
+    { type: "content_block_stop", index: 0 },
+    {
+      type: "message_delta",
+      delta: { stop_reason: "end_turn", stop_sequence: null },
+      usage: { output_tokens: 4 },
+    },
+    { type: "message_stop" },
+  ];
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream({
+    start(controller) {
+      for (const event of events) {
+        controller.enqueue(
+          encoder.encode(
+            `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`,
+          ),
+        );
+      }
+      controller.close();
+    },
+  });
+  return new Response(stream, {
+    headers: { "Content-Type": "text/event-stream" },
+  });
+}
+
+/** The outage the primary route keeps returning. `retry-after: 0` keeps the
+ *  retry loop honest without making the test wait out real backoff. */
+function upstreamUnavailable(): Response {
+  return new Response(
+    JSON.stringify({ error: { message: "upstream unavailable" } }),
+    {
+      status: 503,
+      headers: { "content-type": "application/json", "retry-after": "0" },
+    },
+  );
+}
+
+/** A retired model id, the other outage shape fallback exists for. */
+function modelRetired(): Response {
+  return new Response(
+    JSON.stringify({
+      type: "error",
+      error: { type: "not_found_error", message: "model: unknown model id" },
+    }),
+    { status: 404, headers: { "content-type": "application/json" } },
+  );
+}
+
+let server: ReturnType<typeof Bun.serve>;
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+
+const MESSAGES: Message[] = [
+  { role: "user", content: [{ type: "text", text: "hi" }] },
+];
+
+const ASSISTANT_API_KEY = credentialKey("vellum", "assistant_api_key");
+const BYOK_CREDENTIAL = credentialKey("anthropic", "api_key");
+
+const vellumConnection = {
+  name: "vellum",
+  provider: "vellum",
+  auth: { type: "platform" },
+  label: "Vellum",
+  baseUrl: null,
+  models: null,
+} as unknown as ProviderConnection;
+
+const byokConnection = {
+  name: "anthropic-personal",
+  provider: "anthropic",
+  auth: { type: "api_key", credential: BYOK_CREDENTIAL },
+  label: "Anthropic (personal)",
+  baseUrl: null,
+  models: null,
+} as unknown as ProviderConnection;
+
+function managedAuth(proxyPath: string): ResolvedAuth {
+  return {
+    kind: "header",
+    headers: { Authorization: "Bearer test-assistant-key" },
+    baseUrl: `http://127.0.0.1:${server.port}${proxyPath}`,
+  };
+}
+
+function requestsTo(proxyPath: string): UpstreamRequest[] {
+  return requests.filter((r) => r.path.startsWith(proxyPath));
+}
+
+beforeAll(async () => {
+  server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const url = new URL(req.url);
+      let body: Record<string, unknown> = {};
+      try {
+        body = (await req.json()) as Record<string, unknown>;
+      } catch {
+        // Not every probe carries a JSON body; the path alone is enough.
+      }
+      requests.push({
+        path: url.pathname,
+        headers: Object.fromEntries(req.headers.entries()),
+        body,
+      });
+      if (url.pathname.startsWith(ANTHROPIC_PATH)) {
+        return anthropicMode === "serve"
+          ? anthropicCompletion()
+          : modelRetired();
+      }
+      return upstreamUnavailable();
+    },
+  });
+  // Managed-proxy prerequisites: the platform base URL points at the mock
+  // upstream, so `buildManagedBaseUrl` derives the per-provider proxy paths
+  // above and the backup route resolves its auth for real.
+  setConfig("platform", { baseUrl: `http://127.0.0.1:${server.port}` });
+  await setSecureKeyAsync(ASSISTANT_API_KEY, "test-assistant-key");
+  await setSecureKeyAsync(BYOK_CREDENTIAL, "test-byok-key");
+});
+
+afterAll(() => {
+  server.stop(true);
+});
+
+afterEach(() => {
+  requests.length = 0;
+  anthropicMode = "serve";
+});
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe("managed fallback dispatch", () => {
+  test("a managed quality-optimized outage is served on the backup profile", async () => {
+    setConfig("llm", { activeProfile: "quality-optimized" });
+
+    // The managed adapter for the primary route: the quality profile's own
+    // pin (`gpt-5.6-sol`), whose managed upstream is openai.
+    const provider = createAdapterFromConnection(
+      vellumConnection,
+      managedAuth(OPENAI_PATH),
+      {
+        model: "gpt-5.6-sol",
+        provider: "openai",
+        streamTimeoutMs: 30_000,
+      },
+    );
+    expect(provider).not.toBeNull();
+
+    const response: ProviderResponse = await provider!.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    // The primary was tried and kept failing before anything escalated.
+    expect(requestsTo(OPENAI_PATH).length).toBeGreaterThan(1);
+
+    // The backup profile's pin served the request, through the same managed
+    // connection, on the upstream its own model resolves to.
+    const backup = requestsTo(ANTHROPIC_PATH);
+    expect(backup.length).toBe(1);
+    expect(backup[0].body.model).toBe("claude-opus-5");
+    // The backup profile's own settings win over the failed primary's.
+    expect(backup[0].body.max_tokens).toBe(32000);
+    // `adaptive` is the wire form an adaptive-thinking-only model takes for the
+    // backup profile's `thinking.enabled`.
+    expect(backup[0].body.thinking).toMatchObject({ type: "adaptive" });
+
+    // Degraded traffic is attributed to the backup profile, both on the wire
+    // for the platform's usage events and on the response for the local ledger.
+    expect(backup[0].headers["x-vellum-inference-profile"]).toBe(
+      "quality-optimized-backup",
+    );
+    expect(response.actualInferenceProfile).toBe("quality-optimized-backup");
+    expect(response.actualProvider).toBe("anthropic");
+  });
+
+  test("a BYOK connection never falls back, even on an eligible error", async () => {
+    // Pointers like this never exist on a BYOK column, but seeding one proves
+    // the gate is the connection identity rather than the absence of a target.
+    setConfig("llm", {
+      profiles: {
+        "byok-primary": {
+          source: "user",
+          provider: "anthropic",
+          model: "claude-opus-5",
+          fallbackProfile: "byok-backup",
+          maxTokens: 1024,
+        },
+        "byok-backup": {
+          source: "user",
+          provider: "anthropic",
+          model: "claude-sonnet-5",
+          maxTokens: 2048,
+        },
+      },
+      activeProfile: "byok-primary",
+    });
+    anthropicMode = "retired";
+
+    const provider = createAdapterFromConnection(
+      byokConnection,
+      {
+        kind: "header",
+        headers: { Authorization: "Bearer test-byok-key" },
+        baseUrl: `http://127.0.0.1:${server.port}${ANTHROPIC_PATH}`,
+      },
+      { model: "claude-opus-5", streamTimeoutMs: 30_000 },
+    );
+    expect(provider).not.toBeNull();
+
+    const error = await provider!
+      .sendMessage(MESSAGES, { config: { callSite: "mainAgent" } })
+      .then(
+        () => null,
+        (err: unknown) => err,
+      );
+
+    // The primary's own error surfaces. A BYOK install may hold no credential
+    // for the backup's provider, so an escalation here would leave the vendor's
+    // answer to a foreign route in place of the real failure.
+    expect((error as { statusCode?: number }).statusCode).toBe(404);
+    // Every attempt used the primary's pin: no route was ever escalated.
+    const models = new Set(requests.map((r) => r.body.model));
+    expect(models).toEqual(new Set(["claude-opus-5"]));
+  });
+
+  test("a managed profile with no fallbackProfile rethrows the original error", async () => {
+    setConfig("llm", {
+      profiles: {
+        "managed-no-backup": {
+          source: "user",
+          provider: "anthropic",
+          model: "claude-opus-5",
+          maxTokens: 1024,
+        },
+      },
+      activeProfile: "managed-no-backup",
+    });
+    anthropicMode = "retired";
+
+    const provider = createAdapterFromConnection(
+      vellumConnection,
+      managedAuth(ANTHROPIC_PATH),
+      {
+        model: "claude-opus-5",
+        provider: "anthropic",
+        streamTimeoutMs: 30_000,
+      },
+    );
+    expect(provider).not.toBeNull();
+
+    const error = await provider!
+      .sendMessage(MESSAGES, { config: { callSite: "mainAgent" } })
+      .then(
+        () => null,
+        (err: unknown) => err,
+      );
+
+    // The original upstream failure surfaces unchanged: the callback found no
+    // pointer, so nothing was re-routed and no fallback error replaced it.
+    expect(error).toBeInstanceOf(Error);
+    expect((error as { statusCode?: number }).statusCode).toBe(404);
+    expect((error as { cause?: unknown }).cause).toBeUndefined();
+    const models = new Set(requests.map((r) => r.body.model));
+    expect(models).toEqual(new Set(["claude-opus-5"]));
+  });
+});

--- a/assistant/src/__tests__/managed-fallback-dispatch.test.ts
+++ b/assistant/src/__tests__/managed-fallback-dispatch.test.ts
@@ -344,4 +344,60 @@ describe("managed fallback dispatch", () => {
     const models = new Set(requests.map((r) => r.body.model));
     expect(models).toEqual(new Set(["claude-opus-5"]));
   });
+
+  test("the backup adapter serves the model a call-site tweak resolves to", async () => {
+    // A call site's own tuning fragment layers OVER the winning profile, so a
+    // `model` tweak decides the model even when the backup profile is forced.
+    // The adapter has to be built for THAT model's upstream: deriving it from
+    // the backup profile's own pin would send an OpenAI-shaped request through
+    // an Anthropic adapter (or the reverse).
+    setConfig("llm", {
+      profiles: {
+        "tweaked-primary": {
+          source: "user",
+          provider: "vellum",
+          model: "gpt-5.6-sol",
+          fallbackProfile: "tweaked-backup",
+          maxTokens: 1024,
+        },
+        // Deliberately an OpenAI pin, so the backup profile's own model and the
+        // call-site tweak below resolve to different upstreams.
+        "tweaked-backup": {
+          source: "user",
+          provider: "vellum",
+          model: "gpt-5.6-terra",
+          maxTokens: 2048,
+        },
+      },
+      activeProfile: "tweaked-primary",
+      callSites: { mainAgent: { model: "claude-opus-5" } },
+    });
+
+    const provider = createAdapterFromConnection(
+      vellumConnection,
+      managedAuth(OPENAI_PATH),
+      {
+        model: "gpt-5.6-sol",
+        provider: "openai",
+        streamTimeoutMs: 30_000,
+      },
+    );
+    expect(provider).not.toBeNull();
+
+    const response: ProviderResponse = await provider!.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    // The escalation followed the tweak, not the backup profile's own pin: the
+    // request reached the Anthropic upstream carrying the Anthropic model.
+    const backup = requestsTo(ANTHROPIC_PATH);
+    expect(backup.length).toBe(1);
+    expect(backup[0].body.model).toBe("claude-opus-5");
+    // Deriving the upstream from the backup profile's own OpenAI pin instead
+    // would have escalated straight back to the failing OpenAI path, so the
+    // request never reaches Anthropic at all.
+    expect(requestsTo(OPENAI_PATH).length).toBeGreaterThan(0);
+    expect(response.actualProvider).toBe("anthropic");
+    expect(response.actualInferenceProfile).toBe("tweaked-backup");
+  });
 });

--- a/assistant/src/__tests__/managed-fallback-dispatch.test.ts
+++ b/assistant/src/__tests__/managed-fallback-dispatch.test.ts
@@ -496,4 +496,110 @@ describe("managed fallback dispatch", () => {
     expect(backup[0].body.model).toBe("claude-opus-5");
     expect(response.actualInferenceProfile).toBe("tweak-managed-backup");
   });
+
+  test("the backup upstream follows the resolved provider, not the model's catalog owner", async () => {
+    // The divergent shape: a call-site fragment pins a concrete upstream while
+    // the backup profile's own model belongs to a different one. Normal
+    // dispatch routes this by the resolved provider (`connection-resolution`
+    // threads it through as `providerOverride` for the managed connection), so
+    // the fallback has to as well. Deriving the upstream from the model instead
+    // sends the request somewhere the primary route never would have.
+    setConfig("llm", {
+      profiles: {
+        "divergent-primary": {
+          source: "user",
+          provider: "vellum",
+          model: "gpt-5.6-sol",
+          fallbackProfile: "divergent-backup",
+          maxTokens: 1024,
+        },
+        // An OpenAI-owned model under an Anthropic call-site pin: the resolved
+        // provider and the model's catalog owner disagree.
+        "divergent-backup": {
+          source: "user",
+          provider: "vellum",
+          model: "gpt-5.6-terra",
+          maxTokens: 2048,
+        },
+      },
+      activeProfile: "divergent-primary",
+      callSites: { mainAgent: { provider: "anthropic" } },
+    });
+
+    const provider = createAdapterFromConnection(
+      vellumConnection,
+      managedAuth(OPENAI_PATH),
+      {
+        model: "gpt-5.6-sol",
+        provider: "openai",
+        streamTimeoutMs: 30_000,
+      },
+    );
+    expect(provider).not.toBeNull();
+
+    const response: ProviderResponse = await provider!.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    // The escalation went to the pinned provider's upstream carrying the
+    // resolved model. Routing by the model's catalog owner would have escalated
+    // straight back onto the failing OpenAI path, so nothing reaches Anthropic.
+    const backup = requestsTo(ANTHROPIC_PATH);
+    expect(backup.length).toBe(1);
+    expect(backup[0].body.model).toBe("gpt-5.6-terra");
+    expect(response.actualProvider).toBe("anthropic");
+    expect(response.actualInferenceProfile).toBe("divergent-backup");
+  });
+
+  test("a backup whose resolved provider cannot front the managed proxy is refused", async () => {
+    // The connection guard passes (the resolver keeps the managed connection),
+    // but the pinned provider is not one the platform proxy serves. There is no
+    // upstream to build an adapter for, so the primary's failure stands rather
+    // than the request being quietly rerouted to the model's catalog owner.
+    setConfig("llm", {
+      profiles: {
+        "unroutable-primary": {
+          source: "user",
+          provider: "vellum",
+          model: "claude-opus-5",
+          fallbackProfile: "unroutable-backup",
+          maxTokens: 1024,
+        },
+        // Named on the managed connection, so the connection guard lets it
+        // through, but `openrouter` is not a managed-routable upstream.
+        "unroutable-backup": {
+          source: "user",
+          provider: "openrouter",
+          provider_connection: "vellum",
+          model: "claude-sonnet-5",
+          maxTokens: 2048,
+        },
+      },
+      activeProfile: "unroutable-primary",
+    });
+    anthropicMode = "retired";
+
+    const provider = createAdapterFromConnection(
+      vellumConnection,
+      managedAuth(ANTHROPIC_PATH),
+      {
+        model: "claude-opus-5",
+        provider: "anthropic",
+        streamTimeoutMs: 30_000,
+      },
+    );
+    expect(provider).not.toBeNull();
+
+    const error = await provider!
+      .sendMessage(MESSAGES, { config: { callSite: "mainAgent" } })
+      .then(
+        () => null,
+        (err: unknown) => err,
+      );
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as { statusCode?: number }).statusCode).toBe(404);
+    const models = new Set(requests.map((r) => r.body.model));
+    expect(models).toEqual(new Set(["claude-opus-5"]));
+  });
 });

--- a/assistant/src/__tests__/managed-fallback-dispatch.test.ts
+++ b/assistant/src/__tests__/managed-fallback-dispatch.test.ts
@@ -450,4 +450,50 @@ describe("managed fallback dispatch", () => {
     const models = new Set(requests.map((r) => r.body.model));
     expect(models).toEqual(new Set(["claude-opus-5"]));
   });
+
+  test("a managed backup still serves under a call-site provider tweak", async () => {
+    // A call-site fragment pinning a concrete upstream over a managed winner
+    // resolves to that provider while the resolver keeps the managed
+    // connection, so this is managed traffic and must still fall back. The
+    // guard above keys on the connection precisely so this case survives.
+    setConfig("llm", {
+      profiles: {
+        "tweak-primary": {
+          source: "user",
+          provider: "vellum",
+          model: "gpt-5.6-sol",
+          fallbackProfile: "tweak-managed-backup",
+          maxTokens: 1024,
+        },
+        "tweak-managed-backup": {
+          source: "user",
+          provider: "vellum",
+          model: "claude-opus-5",
+          maxTokens: 2048,
+        },
+      },
+      activeProfile: "tweak-primary",
+      callSites: { mainAgent: { provider: "anthropic" } },
+    });
+
+    const provider = createAdapterFromConnection(
+      vellumConnection,
+      managedAuth(OPENAI_PATH),
+      {
+        model: "gpt-5.6-sol",
+        provider: "openai",
+        streamTimeoutMs: 30_000,
+      },
+    );
+    expect(provider).not.toBeNull();
+
+    const response: ProviderResponse = await provider!.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    const backup = requestsTo(ANTHROPIC_PATH);
+    expect(backup.length).toBe(1);
+    expect(backup[0].body.model).toBe("claude-opus-5");
+    expect(response.actualInferenceProfile).toBe("tweak-managed-backup");
+  });
 });

--- a/assistant/src/__tests__/retry-fallback-escalation.test.ts
+++ b/assistant/src/__tests__/retry-fallback-escalation.test.ts
@@ -79,15 +79,22 @@ function failingProvider(
 }
 
 /** Backup stub that records the options it was sent and serves a response. */
-function backupProvider(name = "anthropic"): {
+function backupProvider(
+  name = "anthropic",
+  opts: { supportsNativeWebSearch?: boolean } = {},
+): {
   provider: Provider;
   calls: () => number;
   seenConfig: () => Record<string, unknown>;
+  seenToolNames: () => string[];
 } {
   let calls = 0;
   let seen: SendMessageOptions | undefined;
   const provider: Provider = {
     name,
+    ...(opts.supportsNativeWebSearch === undefined
+      ? {}
+      : { supportsNativeWebSearch: opts.supportsNativeWebSearch }),
     sendMessage: async (_messages: Message[], options?: SendMessageOptions) => {
       calls += 1;
       seen = options;
@@ -99,6 +106,7 @@ function backupProvider(name = "anthropic"): {
     provider,
     calls: () => calls,
     seenConfig: () => (seen?.config ?? {}) as Record<string, unknown>,
+    seenToolNames: () => (seen?.tools ?? []).map((tool) => tool.name),
   };
 }
 
@@ -773,5 +781,71 @@ describe("RetryProvider fallback-route escalation", () => {
     });
 
     expect(result.actualInferenceProfile).toBe("inner-specific-profile");
+  });
+
+  test("native web search sentinel is dropped when the backup cannot serve it", async () => {
+    // The caller appended the sentinel from the PRIMARY route's capability, so
+    // a backup without server-side search would answer with a tool call
+    // nothing can execute. Degraded mode loses native search, not the turn.
+    const primary = failingProvider(
+      "openai",
+      () => new ProviderError("model not found", "openai", 404),
+    );
+    const backup = backupProvider("gemini", { supportsNativeWebSearch: false });
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    await wrapped.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+      tools: [
+        {
+          name: "read_file",
+          description: "d",
+          input_schema: { type: "object" },
+        },
+        {
+          name: "web_search",
+          description: "d",
+          input_schema: { type: "object" },
+        },
+      ],
+    });
+
+    expect(backup.calls()).toBe(1);
+    expect(backup.seenToolNames()).toEqual(["read_file"]);
+  });
+
+  test("native web search sentinel survives when the backup serves it too", async () => {
+    const primary = failingProvider(
+      "openai",
+      () => new ProviderError("model not found", "openai", 404),
+    );
+    const backup = backupProvider("anthropic", {
+      supportsNativeWebSearch: true,
+    });
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    await wrapped.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+      tools: [
+        {
+          name: "read_file",
+          description: "d",
+          input_schema: { type: "object" },
+        },
+        {
+          name: "web_search",
+          description: "d",
+          input_schema: { type: "object" },
+        },
+      ],
+    });
+
+    expect(backup.seenToolNames()).toEqual(["read_file", "web_search"]);
   });
 });

--- a/assistant/src/__tests__/retry-fallback-escalation.test.ts
+++ b/assistant/src/__tests__/retry-fallback-escalation.test.ts
@@ -798,7 +798,7 @@ describe("RetryProvider fallback-route escalation", () => {
     });
 
     await wrapped.sendMessage(MESSAGES, {
-      config: { callSite: "mainAgent" },
+      config: { callSite: "mainAgent", nativeWebSearchSentinel: true },
       tools: [
         {
           name: "read_file",
@@ -831,6 +831,40 @@ describe("RetryProvider fallback-route escalation", () => {
     });
 
     await wrapped.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent", nativeWebSearchSentinel: true },
+      tools: [
+        {
+          name: "read_file",
+          description: "d",
+          input_schema: { type: "object" },
+        },
+        {
+          name: "web_search",
+          description: "d",
+          input_schema: { type: "object" },
+        },
+      ],
+    });
+
+    expect(backup.seenToolNames()).toEqual(["read_file", "web_search"]);
+  });
+
+  test("an app-executed web_search tool survives the fallback untouched", async () => {
+    // With a search backend such as Brave or the platform search proxy, the
+    // daemon executes `web_search` itself and the caller sets no sentinel
+    // marker. Filtering it by name would strip a capability the backup can
+    // still serve, so the tool list has to carry over unchanged.
+    const primary = failingProvider(
+      "openai",
+      () => new ProviderError("model not found", "openai", 404),
+    );
+    const backup = backupProvider("gemini", { supportsNativeWebSearch: false });
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    await wrapped.sendMessage(MESSAGES, {
       config: { callSite: "mainAgent" },
       tools: [
         {
@@ -847,5 +881,30 @@ describe("RetryProvider fallback-route escalation", () => {
     });
 
     expect(backup.seenToolNames()).toEqual(["read_file", "web_search"]);
+  });
+
+  test("the sentinel marker never reaches the provider wire config", async () => {
+    const primary = failingProvider(
+      "openai",
+      () => new ProviderError("model not found", "openai", 404),
+    );
+    const backup = backupProvider("gemini", { supportsNativeWebSearch: false });
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    await wrapped.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent", nativeWebSearchSentinel: true },
+      tools: [
+        {
+          name: "web_search",
+          description: "d",
+          input_schema: { type: "object" },
+        },
+      ],
+    });
+
+    expect(backup.seenConfig().nativeWebSearchSentinel).toBeUndefined();
   });
 });

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -1470,6 +1470,14 @@ export class AgentLoop {
           providerConfig.tool_choice = { type: "auto" };
         }
 
+        // Mark the sentinel so a route change downstream can tell it from an
+        // app-executed `web_search` of the same name (see
+        // `SendMessageConfig.nativeWebSearchSentinel`). Only set when true so
+        // the wire config stays byte-identical otherwise.
+        if (attachNativeWebSearch) {
+          providerConfig.nativeWebSearchSentinel = true;
+        }
+
         if (this.config.cacheTtl) {
           providerConfig.cacheTtl = this.config.cacheTtl;
         }

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -43,7 +43,10 @@ import type {
   ToolDefinition,
   ToolResultContent,
 } from "../providers/types.js";
-import { isContextOverflowError } from "../providers/types.js";
+import {
+  isContextOverflowError,
+  NATIVE_WEB_SEARCH_TOOL_NAME,
+} from "../providers/types.js";
 import { getTool } from "../tools/registry.js";
 import type { SensitiveOutputBinding } from "../tools/sensitive-output-placeholders.js";
 import {
@@ -132,7 +135,7 @@ export interface AgentLoopConfig {
  * `input_schema` is informational — the provider supplies the real schema.
  */
 const NATIVE_WEB_SEARCH_TOOL: ToolDefinition = {
-  name: "web_search",
+  name: NATIVE_WEB_SEARCH_TOOL_NAME,
   description:
     "Search the web for current information to ground your response.",
   input_schema: {

--- a/assistant/src/providers/inference/adapter-factory.ts
+++ b/assistant/src/providers/inference/adapter-factory.ts
@@ -45,6 +45,7 @@ import { UsageTrackingProvider } from "../usage-tracking.js";
 import {
   getManagedUpstream,
   isVellumManagedConnection,
+  VELLUM_MANAGED_PROVIDER,
 } from "../vellum-model-routing.js";
 import { VercelAIGatewayProvider } from "../vercel-ai-gateway/client.js";
 import type { ResolvedAuth } from "./auth.js";
@@ -371,6 +372,30 @@ export function createAdapterFromConnection(
           forceOverrideProfile: true,
           selectionSeed: failedConfig?.selectionSeed,
         });
+        // This callback authenticates the backup with the managed connection
+        // it was built for, so it can only serve a backup that routes through
+        // the managed column. The schema permits a pointer at a user-defined
+        // profile carrying its own `provider_connection` or a BYOK `provider`;
+        // serving one here would bill it as managed traffic and authenticate
+        // it with a credential its author never chose, so it is refused and
+        // the original error stands.
+        const backupConnection = resolvedBackup.provider_connection;
+        if (
+          (backupConnection !== undefined &&
+            backupConnection !== connection.name) ||
+          resolvedBackup.provider !== VELLUM_MANAGED_PROVIDER
+        ) {
+          log.warn(
+            {
+              connectionName: connection.name,
+              overrideProfile,
+              backupProvider: resolvedBackup.provider,
+              backupConnection,
+            },
+            "Backup profile routes outside the managed connection; keeping the original error",
+          );
+          return null;
+        }
         const upstream = getManagedUpstream(resolvedBackup.model);
         if (upstream === null) {
           log.warn(

--- a/assistant/src/providers/inference/adapter-factory.ts
+++ b/assistant/src/providers/inference/adapter-factory.ts
@@ -18,7 +18,11 @@
  *   3. Register the client in `ADAPTER_FACTORIES` below.
  */
 
+import { resolveDefaultProfileForProvider } from "../../config/default-profile-catalog.js";
+import { selectWinningProfile } from "../../config/llm-resolver.js";
+import { getConfig } from "../../config/loader.js";
 import { normalizeCredentialRef } from "../../security/credential-key.js";
+import { getLogger } from "../../util/logger.js";
 import { AnthropicProvider } from "../anthropic/client.js";
 import { AtlasCloudProvider } from "../atlascloud/client.js";
 import { BasetenProvider } from "../baseten/client.js";
@@ -33,9 +37,12 @@ import { OpenRouterProvider } from "../openrouter/client.js";
 import { PoolsideProvider } from "../poolside/client.js";
 import { RetryProvider } from "../retry.js";
 import { TogetherProvider } from "../together/client.js";
-import type { Provider } from "../types.js";
+import type { Provider, SendMessageOptions } from "../types.js";
 import { UsageTrackingProvider } from "../usage-tracking.js";
-import { isVellumManagedConnection } from "../vellum-model-routing.js";
+import {
+  getManagedUpstream,
+  isVellumManagedConnection,
+} from "../vellum-model-routing.js";
 import { VercelAIGatewayProvider } from "../vercel-ai-gateway/client.js";
 import type { ResolvedAuth } from "./auth.js";
 import type { ProviderConnection } from "./auth.js";
@@ -57,6 +64,15 @@ export interface AdapterCreateOpts {
 }
 
 type AdapterFactory = (opts: AdapterCreateOpts) => Provider;
+
+const log = getLogger("adapter-factory");
+
+/** The backup route `RetryProvider` escalates to; see {@link makeFallbackRouteResolver}. */
+interface FallbackRoute {
+  provider: Provider;
+  overrideProfile: string;
+  forwardUsageAttributionHeaders: boolean;
+}
 
 /**
  * Catalog-keyed factory table. Each entry takes a unified
@@ -284,6 +300,107 @@ export function createAdapterFromConnection(
     };
   }
 
+  /**
+   * Resolve the backup-profile route for a request whose primary route just
+   * failed with an outage-shaped error, so `RetryProvider` can serve it on a
+   * different provider instead of surfacing the outage.
+   *
+   * The winning profile of the FAILED call is re-resolved from the same
+   * inputs `normalizeSendMessageOptions` uses (call site plus the request's
+   * own override/seed fields), and its `fallbackProfile` pointer names the
+   * backup. A `vellum` profile carries no upstream of its own, so the backup's
+   * model determines it.
+   *
+   * Returns a RAW adapter, exactly like `makeCredentialRefresher` above:
+   * `RetryProvider` hands the backup route options it has ALREADY normalized
+   * (call site consumed, wire params resolved from the backup profile, usage
+   * attribution headers stamped). A second `RetryProvider` in between would
+   * re-normalize that call-site-less config and strip those headers, leaving
+   * degraded traffic unattributed on the platform's billing events.
+   *
+   * Never throws: a broken backup lookup must surface the original provider
+   * error, not a new one.
+   */
+  function makeFallbackRouteResolver(): (
+    failedOptions: SendMessageOptions | undefined,
+  ) => Promise<FallbackRoute | null> {
+    return async (failedOptions): Promise<FallbackRoute | null> => {
+      const failedConfig = failedOptions?.config;
+      const callSite = failedConfig?.callSite;
+      if (callSite === undefined) {
+        return null;
+      }
+      try {
+        const { llm } = getConfig();
+        const winner = selectWinningProfile(callSite, llm, {
+          overrideProfile: failedConfig?.overrideProfile,
+          forceOverrideProfile: failedConfig?.forceOverrideProfile,
+          selectionSeed: failedConfig?.selectionSeed,
+        });
+        const overrideProfile = winner.entry?.fallbackProfile;
+        if (overrideProfile === undefined) {
+          return null;
+        }
+        // Resolved the provider-aware way the runtime resolver resolves every
+        // profile name: the backups are companions of the managed column and
+        // must not materialize under a BYOK or ChatGPT default provider.
+        const backup = resolveDefaultProfileForProvider(
+          llm.profiles,
+          overrideProfile,
+          llm.defaultProvider ?? null,
+        );
+        const upstream =
+          backup?.model != null ? getManagedUpstream(backup.model) : null;
+        if (backup?.model == null || upstream === null) {
+          log.warn(
+            {
+              connectionName: connection.name,
+              overrideProfile,
+              backupModel: backup?.model,
+            },
+            "Backup profile does not resolve to a managed upstream; keeping the original error",
+          );
+          return null;
+        }
+        // Re-resolve auth for the BACKUP upstream: the managed proxy's base URL
+        // is per-upstream, so the primary's resolved auth cannot be reused.
+        const backupAuth = await resolveAuth(
+          effectiveConnectionAuth(connection),
+          upstream,
+          { baseUrl: connection.baseUrl },
+        );
+        if (!backupAuth.ok) {
+          return null;
+        }
+        const backupAdapter = buildConnectionAdapter(
+          connection,
+          backupAuth.resolved,
+          // `useNativeWebSearch` carries over from the primary: it is a
+          // property of this request's web-search config, and every managed
+          // backup pin either supports native search or ignores the flag.
+          { ...opts, model: backup.model, provider: upstream },
+        );
+        if (backupAdapter === null) {
+          return null;
+        }
+        return {
+          provider: backupAdapter,
+          overrideProfile,
+          // Always true: this callback is wired only on the managed proxy, so
+          // the backup route runs through it too and its `X-Vellum-*` billing
+          // metadata reaches our own backend, never a third party.
+          forwardUsageAttributionHeaders: true,
+        };
+      } catch (err) {
+        log.warn(
+          { err, connectionName: connection.name, callSite },
+          "Failed to resolve a backup profile route; keeping the original error",
+        );
+        return null;
+      }
+    };
+  }
+
   // Usage-attribution headers (`X-Vellum-*`) are only meaningful when the
   // request is routed through the Vellum-managed proxy. They carry billing
   // metadata for our own backend. Forwarding them to a third-party endpoint
@@ -304,8 +421,15 @@ export function createAdapterFromConnection(
               ? "no-auth"
               : undefined,
       connectionName: connection.name,
+      // Both escalations are managed-route only. A BYOK, oauth-subscription,
+      // or no-auth connection must never fall back: the install may hold no
+      // credential for the backup profile's provider, and only the managed
+      // column carries `fallbackProfile` pointers in the first place.
       ...(isManagedProxy
-        ? { refreshCredentialProvider: makeCredentialRefresher() }
+        ? {
+            refreshCredentialProvider: makeCredentialRefresher(),
+            resolveFallbackRoute: makeFallbackRouteResolver(),
+          }
         : {}),
     }),
   );

--- a/assistant/src/providers/inference/adapter-factory.ts
+++ b/assistant/src/providers/inference/adapter-factory.ts
@@ -19,7 +19,10 @@
  */
 
 import { resolveDefaultProfileForProvider } from "../../config/default-profile-catalog.js";
-import { selectWinningProfile } from "../../config/llm-resolver.js";
+import {
+  resolveCallSiteConfig,
+  selectWinningProfile,
+} from "../../config/llm-resolver.js";
 import { getConfig } from "../../config/loader.js";
 import { normalizeCredentialRef } from "../../security/credential-key.js";
 import { getLogger } from "../../util/logger.js";
@@ -349,14 +352,32 @@ export function createAdapterFromConnection(
           overrideProfile,
           llm.defaultProvider ?? null,
         );
-        const upstream =
-          backup?.model != null ? getManagedUpstream(backup.model) : null;
-        if (backup?.model == null || upstream === null) {
+        if (backup?.model == null) {
+          log.warn(
+            { connectionName: connection.name, overrideProfile },
+            "Backup profile does not resolve on this default provider; keeping the original error",
+          );
+          return null;
+        }
+        // The model the adapter serves must be the model the request will
+        // actually carry, so it comes from the same resolution the fallback
+        // send runs (`sendOnFallbackRoute` forces this profile through
+        // `normalizeSendMessageOptions`). Building from `backup.model` alone
+        // would ignore a call-site fragment that pins a model, and a pinned
+        // Gemini model on an Anthropic backup would send Gemini wire params to
+        // an Anthropic adapter.
+        const resolvedBackup = resolveCallSiteConfig(callSite, llm, {
+          overrideProfile,
+          forceOverrideProfile: true,
+          selectionSeed: failedConfig?.selectionSeed,
+        });
+        const upstream = getManagedUpstream(resolvedBackup.model);
+        if (upstream === null) {
           log.warn(
             {
               connectionName: connection.name,
               overrideProfile,
-              backupModel: backup?.model,
+              backupModel: resolvedBackup.model,
             },
             "Backup profile does not resolve to a managed upstream; keeping the original error",
           );
@@ -378,7 +399,7 @@ export function createAdapterFromConnection(
           // `useNativeWebSearch` carries over from the primary: it is a
           // property of this request's web-search config, and every managed
           // backup pin either supports native search or ignores the flag.
-          { ...opts, model: backup.model, provider: upstream },
+          { ...opts, model: resolvedBackup.model, provider: upstream },
         );
         if (backupAdapter === null) {
           return null;

--- a/assistant/src/providers/inference/adapter-factory.ts
+++ b/assistant/src/providers/inference/adapter-factory.ts
@@ -379,12 +379,19 @@ export function createAdapterFromConnection(
         // serving one here would bill it as managed traffic and authenticate
         // it with a credential its author never chose, so it is refused and
         // the original error stands.
+        // Keyed on the connection, not the provider: a call-site fragment that
+        // pins a concrete upstream over a managed winner keeps the managed
+        // routing and is stamped with this connection's name by the resolver
+        // (see `llm-resolver.ts`), so a concrete `provider` here is still
+        // managed traffic. Only a profile that names a different connection,
+        // or a concrete provider carrying no managed connection at all (a BYOK
+        // winner), routes somewhere this callback cannot authenticate.
         const backupConnection = resolvedBackup.provider_connection;
-        if (
-          (backupConnection !== undefined &&
-            backupConnection !== connection.name) ||
-          resolvedBackup.provider !== VELLUM_MANAGED_PROVIDER
-        ) {
+        const routesThroughThisConnection =
+          backupConnection === undefined
+            ? resolvedBackup.provider === VELLUM_MANAGED_PROVIDER
+            : backupConnection === connection.name;
+        if (!routesThroughThisConnection) {
           log.warn(
             {
               connectionName: connection.name,

--- a/assistant/src/providers/inference/adapter-factory.ts
+++ b/assistant/src/providers/inference/adapter-factory.ts
@@ -45,6 +45,7 @@ import { UsageTrackingProvider } from "../usage-tracking.js";
 import {
   getManagedUpstream,
   isVellumManagedConnection,
+  MANAGED_ROUTABLE_PROVIDERS,
   VELLUM_MANAGED_PROVIDER,
 } from "../vellum-model-routing.js";
 import { VercelAIGatewayProvider } from "../vercel-ai-gateway/client.js";
@@ -312,8 +313,9 @@ export function createAdapterFromConnection(
    * The winning profile of the FAILED call is re-resolved from the same
    * inputs `normalizeSendMessageOptions` uses (call site plus the request's
    * own override/seed fields), and its `fallbackProfile` pointer names the
-   * backup. A `vellum` profile carries no upstream of its own, so the backup's
-   * model determines it.
+   * backup. The upstream comes from the backup's resolved provider; only the
+   * `vellum` routing identity carries no upstream of its own, and there the
+   * backup's model determines it.
    *
    * Returns a RAW adapter, exactly like `makeCredentialRefresher` above:
    * `RetryProvider` hands the backup route options it has ALREADY normalized
@@ -403,12 +405,31 @@ export function createAdapterFromConnection(
           );
           return null;
         }
-        const upstream = getManagedUpstream(resolvedBackup.model);
+        // The upstream is the resolved provider, the same way normal dispatch
+        // picks it for this connection: `connection-resolution.ts` threads the
+        // resolved provider through as `providerOverride` for a `vellum`
+        // connection and derives the upstream from the model only when the
+        // provider is the routing-identity sentinel (`resolveRoutingIdentity`,
+        // and the `isVellum && !expectedProvider` branch). Deriving it from the
+        // model here regardless would send a provider-pinned call-site fragment
+        // to a different upstream than a primary send of the same resolution,
+        // and would refuse a managed model the catalog does not list yet even
+        // though normal dispatch serves it. A provider the managed proxy cannot
+        // front (a non-routable id, or another routing identity such as
+        // `chatgpt`) is refused rather than routed.
+        const declaredProvider = resolvedBackup.provider;
+        const upstream =
+          declaredProvider === VELLUM_MANAGED_PROVIDER
+            ? getManagedUpstream(resolvedBackup.model)
+            : MANAGED_ROUTABLE_PROVIDERS.has(declaredProvider)
+              ? declaredProvider
+              : null;
         if (upstream === null) {
           log.warn(
             {
               connectionName: connection.name,
               overrideProfile,
+              backupProvider: declaredProvider,
               backupModel: resolvedBackup.model,
             },
             "Backup profile does not resolve to a managed upstream; keeping the original error",

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -523,17 +523,18 @@ function normalizeSendMessageOptions(
     nextConfig.promptCacheKey = config.selectionSeed;
   }
 
-  // `overrideProfile`, `forceOverrideProfile`, `selectionSeed`, and
-  // `conversationId` are routing/resolution-time concerns (consumed by the
-  // resolver below, `CallSiteRoutingProvider`'s provider selection, and
-  // `UsageTrackingProvider`'s ledger attribution); none is a wire-format
-  // field. Strip unconditionally (after the `openai` promptCacheKey copy
-  // above) so they never leak into provider request bodies even when callers
-  // set them without a `callSite`.
+  // `overrideProfile`, `forceOverrideProfile`, `selectionSeed`,
+  // `conversationId`, and `nativeWebSearchSentinel` are routing/resolution-time
+  // concerns (consumed by the resolver below, `CallSiteRoutingProvider`'s
+  // provider selection, `UsageTrackingProvider`'s ledger attribution, and the
+  // fallback tool filter); none is a wire-format field. Strip unconditionally
+  // (after the `openai` promptCacheKey copy above) so they never leak into
+  // provider request bodies even when callers set them without a `callSite`.
   delete nextConfig.overrideProfile;
   delete nextConfig.forceOverrideProfile;
   delete nextConfig.selectionSeed;
   delete nextConfig.conversationId;
+  delete nextConfig.nativeWebSearchSentinel;
 
   if (config.callSite !== undefined) {
     const resolved = resolveCallSiteConfig(config.callSite, getConfig().llm, {
@@ -1229,6 +1230,11 @@ export class RetryProvider implements Provider {
    * no server-side search would receive a tool it cannot execute and answer
    * with a tool call nothing can service. The sentinel is dropped for those
    * routes: degraded mode loses native search rather than the whole turn.
+   *
+   * Gated on `config.nativeWebSearchSentinel`, never on the name alone: with a
+   * search backend like Brave or the platform search proxy configured, a tool
+   * of the same name is app-executed and works on every route, so filtering it
+   * would take away a capability the backup can still serve.
    */
   private fallbackTools(
     options: SendMessageOptions | undefined,
@@ -1236,6 +1242,7 @@ export class RetryProvider implements Provider {
   ): { tools?: ToolDefinition[] } {
     const tools = options?.tools;
     if (
+      options?.config?.nativeWebSearchSentinel !== true ||
       tools === undefined ||
       !tools.some((tool) => tool.name === NATIVE_WEB_SEARCH_TOOL_NAME)
     ) {

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -38,9 +38,11 @@ import {
 import {
   isContextOverflowError,
   type Message,
+  NATIVE_WEB_SEARCH_TOOL_NAME,
   type Provider,
   type ProviderResponse,
   type SendMessageOptions,
+  type ToolDefinition,
 } from "./types.js";
 import { UNPARSEABLE_TOOL_ARGS_SDK_MESSAGE } from "./unparseable-tool-args.js";
 
@@ -1219,6 +1221,38 @@ export class RetryProvider implements Provider {
   }
 
   /**
+   * The `tools` override for the fallback send, or nothing when the original
+   * list carries over unchanged.
+   *
+   * The caller decided whether to append the native web search sentinel from
+   * the PRIMARY route's capability (see `AgentLoop`), so a backup that runs
+   * no server-side search would receive a tool it cannot execute and answer
+   * with a tool call nothing can service. The sentinel is dropped for those
+   * routes: degraded mode loses native search rather than the whole turn.
+   */
+  private fallbackTools(
+    options: SendMessageOptions | undefined,
+    route: { provider: Provider },
+  ): { tools?: ToolDefinition[] } {
+    const tools = options?.tools;
+    if (
+      tools === undefined ||
+      !tools.some((tool) => tool.name === NATIVE_WEB_SEARCH_TOOL_NAME)
+    ) {
+      return {};
+    }
+    const backupServesNativeSearch = route.provider.supportsNativeWebSearchFor
+      ? route.provider.supportsNativeWebSearchFor(options)
+      : route.provider.supportsNativeWebSearch === true;
+    if (backupServesNativeSearch) {
+      return {};
+    }
+    return {
+      tools: tools.filter((tool) => tool.name !== NATIVE_WEB_SEARCH_TOOL_NAME),
+    };
+  }
+
+  /**
    * Attempt the failed request once on the backup route resolved by
    * `resolveFallbackRoute`. Returns null when no backup route applies (the
    * caller rethrows the original error unchanged); throws the fallback
@@ -1324,7 +1358,11 @@ export class RetryProvider implements Provider {
     fallbackConfig.forceOverrideProfile = true;
     const fallbackOptions = normalizeSendMessageOptions(
       route.provider.name,
-      { ...options, config: fallbackConfig },
+      {
+        ...options,
+        config: fallbackConfig,
+        ...this.fallbackTools(options, route),
+      },
       {
         forwardUsageAttributionHeaders:
           route.forwardUsageAttributionHeaders === true,

--- a/assistant/src/providers/types.ts
+++ b/assistant/src/providers/types.ts
@@ -1,6 +1,16 @@
 import type { ToolDefinition } from "../tools/tool-types.js";
 export type { ToolDefinition };
 
+/**
+ * The tool name that activates provider-native web search. Callers append a
+ * tool under this name only to instances reporting
+ * {@link Provider.supportsNativeWebSearch}; anywhere a request can change
+ * routes after that decision (see `RetryProvider`'s backup-profile
+ * escalation), the tool has to be dropped again when the new route cannot
+ * serve it, or the model answers with a tool call nothing can execute.
+ */
+export const NATIVE_WEB_SEARCH_TOOL_NAME = "web_search";
+
 import type { LLMCallSite } from "../config/schemas/llm.js";
 import {
   ProviderError,

--- a/assistant/src/providers/types.ts
+++ b/assistant/src/providers/types.ts
@@ -301,6 +301,18 @@ export interface SendMessageConfig {
    */
   forceOverrideProfile?: boolean;
   /**
+   * True when the caller appended {@link NATIVE_WEB_SEARCH_TOOL_NAME} purely
+   * to activate the route's provider-native web search, rather than passing an
+   * app-executed search tool of the same name (which is what runs when a
+   * search backend like Brave or the platform search proxy is configured).
+   * Only the caller can tell those apart, and a route change after that
+   * decision has to: `RetryProvider` drops the tool on a backup that runs no
+   * native search, and must not touch it when the daemon executes it itself.
+   * A resolution/routing-time concern only; stripped before any provider wire
+   * request.
+   */
+  nativeWebSearchSentinel?: boolean;
+  /**
    * Per-conversation seed for deterministic `mix`-profile expansion. The agent
    * loop sets this to the conversation id so every resolver call this send
    * triggers — provider/transport selection, wire-param normalization, usage


### PR DESCRIPTION
## Summary
- Wires `resolveFallbackRoute` into the managed-proxy `RetryProvider` construction, gated on `isVellumManagedConnection` so BYOK, oauth-subscription, and no-auth routes never fall back
- Re-resolves the failed call's winning profile, reads its `fallbackProfile`, derives the backup's upstream via `getManagedUpstream`, re-resolves auth for that upstream, and builds the backup adapter through the existing connection path
- Returns a raw adapter (like `makeCredentialRefresher`) so RetryProvider's already-normalized options keep their usage-attribution headers; never throws, so a broken lookup surfaces the original provider error

Part of plan: model-fallbacks.md (PR 4 of 5)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41207" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->