### PR TITLE
fix(openrouter): align model catalog with live OpenRouter rates

### DIFF
--- a/assistant/src/__tests__/llm-catalog-parity.test.ts
+++ b/assistant/src/__tests__/llm-catalog-parity.test.ts
@@ -244,6 +244,51 @@ describe("LLM catalog parity: daemon vs client", () => {
     }
   });
 
+  test("OpenRouter supportsCaching requires cache-read pricing", () => {
+    const openrouter = PROVIDER_CATALOG.find((entry) => entry.id === "openrouter");
+    expect(openrouter).toBeDefined();
+
+    for (const model of openrouter!.models) {
+      if (model.supportsCaching) {
+        expect(
+          model.pricing?.cacheReadPer1mTokens,
+          `openrouter/${model.id} supportsCaching requires cacheReadPer1mTokens`,
+        ).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  test("OpenRouter cache-read pricing implies supportsCaching except xAI", () => {
+    const openrouter = PROVIDER_CATALOG.find((entry) => entry.id === "openrouter");
+    expect(openrouter).toBeDefined();
+
+    for (const model of openrouter!.models) {
+      if (model.pricing?.cacheReadPer1mTokens === undefined) {
+        continue;
+      }
+      if (model.id.startsWith("x-ai/")) {
+        expect(
+          model.supportsCaching,
+          `openrouter/${model.id} keeps supportsCaching false: OpenRouter xAI routes do not report cached tokens`,
+        ).toBe(false);
+        continue;
+      }
+      expect(
+        model.supportsCaching,
+        `openrouter/${model.id} publishes cacheReadPer1mTokens so supportsCaching must be true`,
+      ).toBe(true);
+    }
+  });
+
+  test("OpenRouter catalog drops ids OpenRouter no longer serves", () => {
+    const openrouter = PROVIDER_CATALOG.find((entry) => entry.id === "openrouter");
+    expect(openrouter).toBeDefined();
+    const ids = new Set(openrouter!.models.map((model) => model.id));
+    expect(ids.has("deepseek/deepseek-v3.2-speciale")).toBe(false);
+    expect(ids.has("mistralai/devstral-2512")).toBe(false);
+    expect(ids.has("openrouter/owl-alpha")).toBe(false);
+  });
+
   test("every model default context is capped by its context window", () => {
     const json = loadClientCatalog();
 

--- a/assistant/src/__tests__/openrouter-catalog-parity.test.ts
+++ b/assistant/src/__tests__/openrouter-catalog-parity.test.ts
@@ -1,0 +1,184 @@
+/**
+ * OpenRouter is the one catalog provider that publishes machine-readable
+ * prices for every id. These tests keep the `openrouter` block of
+ * `model-catalog.ts` aligned with https://openrouter.ai/api/v1/models.
+ *
+ * Local invariants always run. The live fetch fails the build on missing
+ * ids or >2% rate drift when the endpoint is reachable, and skips (does
+ * not fail) when it is not, so CI is not hostage to a network blip.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { PROVIDER_CATALOG } from "../providers/model-catalog.js";
+
+const OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models";
+const RATE_TOLERANCE = 0.02;
+const LIVE_FETCH_TIMEOUT_MS = 15_000;
+
+interface OpenRouterPricing {
+  prompt?: string;
+  completion?: string;
+  input_cache_read?: string;
+  input_cache_write?: string;
+}
+
+interface OpenRouterModel {
+  id: string;
+  pricing?: OpenRouterPricing;
+}
+
+interface OpenRouterModelsResponse {
+  data?: OpenRouterModel[];
+}
+
+function perMillionFromOpenRouterPrice(
+  raw: string | number | undefined | null,
+): number | undefined {
+  if (raw == null || raw === "") {
+    return undefined;
+  }
+  const n = typeof raw === "number" ? raw : Number(raw);
+  if (!Number.isFinite(n) || n === 0) {
+    return undefined;
+  }
+  return n * 1_000_000;
+}
+
+function rateDiffers(
+  catalog: number | undefined,
+  live: number | undefined,
+  tolerance = RATE_TOLERANCE,
+): boolean {
+  if (catalog === undefined && live === undefined) {
+    return false;
+  }
+  if (catalog === undefined || live === undefined) {
+    return true;
+  }
+  const denom = Math.max(Math.abs(live), Math.abs(catalog), Number.EPSILON);
+  return Math.abs(catalog - live) / denom > tolerance;
+}
+
+function openrouterCatalogModels() {
+  const entry = PROVIDER_CATALOG.find((provider) => provider.id === "openrouter");
+  if (!entry) {
+    throw new Error("PROVIDER_CATALOG is missing the openrouter entry");
+  }
+  return entry.models;
+}
+
+describe("OpenRouter catalog parity helpers", () => {
+  test("treats a zero OpenRouter price as absent", () => {
+    expect(perMillionFromOpenRouterPrice("0")).toBeUndefined();
+    expect(perMillionFromOpenRouterPrice(0)).toBeUndefined();
+  });
+
+  test("converts per-token OpenRouter prices to per-1M", () => {
+    expect(perMillionFromOpenRouterPrice("0.000002")).toBeCloseTo(2, 10);
+    expect(perMillionFromOpenRouterPrice("0.0000000435145")).toBeCloseTo(
+      0.0435145,
+      10,
+    );
+  });
+
+  test("rateDiffers uses a 2% relative band", () => {
+    expect(rateDiffers(1, 1.019)).toBe(false);
+    expect(rateDiffers(1, 1.021)).toBe(true);
+    expect(rateDiffers(0.55, 0.5)).toBe(true);
+    expect(rateDiffers(undefined, 0.3)).toBe(true);
+    expect(rateDiffers(undefined, undefined)).toBe(false);
+  });
+});
+
+describe("OpenRouter catalog vs live OpenRouter card", () => {
+  test(
+    "catalog ids exist and base rates stay within 2% of OpenRouter",
+    async () => {
+      let payload: OpenRouterModelsResponse;
+      try {
+        const response = await fetch(OPENROUTER_MODELS_URL, {
+          signal: AbortSignal.timeout(LIVE_FETCH_TIMEOUT_MS),
+        });
+        if (!response.ok) {
+          console.warn(
+            `Skipping live OpenRouter catalog check: HTTP ${response.status}`,
+          );
+          return;
+        }
+        payload = (await response.json()) as OpenRouterModelsResponse;
+      } catch (error) {
+        console.warn(
+          `Skipping live OpenRouter catalog check: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+        return;
+      }
+
+      const liveModels = payload.data;
+      expect(
+        Array.isArray(liveModels) && liveModels.length > 0,
+        "OpenRouter /api/v1/models returned no models",
+      ).toBe(true);
+
+      const liveById = new Map(
+        (liveModels ?? []).map((model) => [model.id, model]),
+      );
+      const drifts: string[] = [];
+
+      for (const model of openrouterCatalogModels()) {
+        const live = liveById.get(model.id);
+        if (!live) {
+          drifts.push(`${model.id}: missing from OpenRouter catalog`);
+          continue;
+        }
+
+        const liveInput = perMillionFromOpenRouterPrice(live.pricing?.prompt);
+        const liveOutput = perMillionFromOpenRouterPrice(
+          live.pricing?.completion,
+        );
+        const liveCacheRead = perMillionFromOpenRouterPrice(
+          live.pricing?.input_cache_read,
+        );
+        const liveCacheWrite = perMillionFromOpenRouterPrice(
+          live.pricing?.input_cache_write,
+        );
+
+        if (rateDiffers(model.pricing?.inputPer1mTokens, liveInput)) {
+          drifts.push(
+            `${model.id}: input ${model.pricing?.inputPer1mTokens} vs OpenRouter ${liveInput}`,
+          );
+        }
+        if (rateDiffers(model.pricing?.outputPer1mTokens, liveOutput)) {
+          drifts.push(
+            `${model.id}: output ${model.pricing?.outputPer1mTokens} vs OpenRouter ${liveOutput}`,
+          );
+        }
+        if (rateDiffers(model.pricing?.cacheReadPer1mTokens, liveCacheRead)) {
+          drifts.push(
+            `${model.id}: cacheRead ${model.pricing?.cacheReadPer1mTokens} vs OpenRouter ${liveCacheRead}`,
+          );
+        }
+        if (
+          liveCacheWrite !== undefined &&
+          rateDiffers(model.pricing?.cacheWritePer1mTokens, liveCacheWrite)
+        ) {
+          drifts.push(
+            `${model.id}: cacheWrite ${model.pricing?.cacheWritePer1mTokens} vs OpenRouter ${liveCacheWrite}`,
+          );
+        }
+
+        const isXai = model.id.startsWith("x-ai/");
+        if (liveCacheRead !== undefined && !isXai && !model.supportsCaching) {
+          drifts.push(
+            `${model.id}: OpenRouter publishes input_cache_read ${liveCacheRead} but supportsCaching is false`,
+          );
+        }
+      }
+
+      expect(drifts, drifts.join("\n")).toEqual([]);
+    },
+    LIVE_FETCH_TIMEOUT_MS + 5_000,
+  );
+});

--- a/assistant/src/__tests__/pricing.test.ts
+++ b/assistant/src/__tests__/pricing.test.ts
@@ -834,8 +834,8 @@ describe("Anthropic models on OpenRouter", () => {
     });
 
     expect(result.pricingStatus).toBe("priced");
-    // 0.05M x $0.1 direct + 0.05M x $0.125 write + 0.05M x $0.01 read
-    expect(result.estimatedCostUsd).toBeCloseTo(0.005 + 0.00625 + 0.0005, 10);
+    // 0.05M x $0.2 direct + 0.05M x $0.25 write + 0.05M x $0.02 read
+    expect(result.estimatedCostUsd).toBeCloseTo(0.01 + 0.0125 + 0.001, 10);
   });
 
   test("returns unpriced for unknown non-Anthropic OpenRouter model", () => {

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -1196,9 +1196,10 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
       // / 1.5x output / 2x cache-read+write for the whole request, per
       // OpenAI's model cards.
       //
-      // Rates are OpenRouter's own card (https://openrouter.ai/api/v1/models),
-      // which discounts Terra and Luna below OpenAI's direct list price; Sol
-      // matches direct pricing.
+      // Rates are OpenRouter's own card (https://openrouter.ai/api/v1/models)
+      // and can differ from OpenAI's direct list. cacheWrite is 1.25x input.
+      // Long-context (>272K input) is 2x input / 1.5x output / 2x
+      // cache-read+write for the whole request, per OpenAI's model cards.
       {
         id: "openai/gpt-5.6-sol",
         displayName: "GPT-5.6 Sol",
@@ -1212,17 +1213,17 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         supportsToolUse: true,
         supportsPromptCacheBreakpoints: true,
         pricing: {
-          inputPer1mTokens: 5.0,
-          outputPer1mTokens: 30.0,
-          cacheWritePer1mTokens: 6.25,
-          cacheReadPer1mTokens: 0.5,
+          inputPer1mTokens: 2.0,
+          outputPer1mTokens: 10.0,
+          cacheWritePer1mTokens: 2.5,
+          cacheReadPer1mTokens: 0.2,
           tiers: [
             {
               inputTokenThreshold: OPENAI_LONG_CONTEXT_PRICING_THRESHOLD_TOKENS,
-              inputPer1mTokens: 10,
-              outputPer1mTokens: 45,
-              cacheWritePer1mTokens: 12.5,
-              cacheReadPer1mTokens: 1,
+              inputPer1mTokens: 4,
+              outputPer1mTokens: 15,
+              cacheWritePer1mTokens: 5,
+              cacheReadPer1mTokens: 0.4,
             },
           ],
         },
@@ -1240,17 +1241,17 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         supportsToolUse: true,
         supportsPromptCacheBreakpoints: true,
         pricing: {
-          inputPer1mTokens: 5.0,
-          outputPer1mTokens: 30.0,
-          cacheWritePer1mTokens: 6.25,
-          cacheReadPer1mTokens: 0.5,
+          inputPer1mTokens: 2.0,
+          outputPer1mTokens: 10.0,
+          cacheWritePer1mTokens: 2.5,
+          cacheReadPer1mTokens: 0.2,
           tiers: [
             {
               inputTokenThreshold: OPENAI_LONG_CONTEXT_PRICING_THRESHOLD_TOKENS,
-              inputPer1mTokens: 10,
-              outputPer1mTokens: 45,
-              cacheWritePer1mTokens: 12.5,
-              cacheReadPer1mTokens: 1,
+              inputPer1mTokens: 4,
+              outputPer1mTokens: 15,
+              cacheWritePer1mTokens: 5,
+              cacheReadPer1mTokens: 0.4,
             },
           ],
         },
@@ -1268,17 +1269,17 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         supportsToolUse: true,
         supportsPromptCacheBreakpoints: true,
         pricing: {
-          inputPer1mTokens: 1.0,
-          outputPer1mTokens: 6.0,
-          cacheWritePer1mTokens: 1.25,
-          cacheReadPer1mTokens: 0.1,
+          inputPer1mTokens: 2.0,
+          outputPer1mTokens: 12.0,
+          cacheWritePer1mTokens: 2.5,
+          cacheReadPer1mTokens: 0.2,
           tiers: [
             {
               inputTokenThreshold: OPENAI_LONG_CONTEXT_PRICING_THRESHOLD_TOKENS,
-              inputPer1mTokens: 2,
-              outputPer1mTokens: 9,
-              cacheWritePer1mTokens: 2.5,
-              cacheReadPer1mTokens: 0.2,
+              inputPer1mTokens: 4,
+              outputPer1mTokens: 18,
+              cacheWritePer1mTokens: 5,
+              cacheReadPer1mTokens: 0.4,
             },
           ],
         },
@@ -1296,17 +1297,17 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         supportsToolUse: true,
         supportsPromptCacheBreakpoints: true,
         pricing: {
-          inputPer1mTokens: 1.0,
-          outputPer1mTokens: 6.0,
-          cacheWritePer1mTokens: 1.25,
-          cacheReadPer1mTokens: 0.1,
+          inputPer1mTokens: 2.0,
+          outputPer1mTokens: 12.0,
+          cacheWritePer1mTokens: 2.5,
+          cacheReadPer1mTokens: 0.2,
           tiers: [
             {
               inputTokenThreshold: OPENAI_LONG_CONTEXT_PRICING_THRESHOLD_TOKENS,
-              inputPer1mTokens: 2,
-              outputPer1mTokens: 9,
-              cacheWritePer1mTokens: 2.5,
-              cacheReadPer1mTokens: 0.2,
+              inputPer1mTokens: 4,
+              outputPer1mTokens: 18,
+              cacheWritePer1mTokens: 5,
+              cacheReadPer1mTokens: 0.4,
             },
           ],
         },
@@ -1324,17 +1325,17 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         supportsToolUse: true,
         supportsPromptCacheBreakpoints: true,
         pricing: {
-          inputPer1mTokens: 0.1,
-          outputPer1mTokens: 0.6,
-          cacheWritePer1mTokens: 0.125,
-          cacheReadPer1mTokens: 0.01,
+          inputPer1mTokens: 0.2,
+          outputPer1mTokens: 1.2,
+          cacheWritePer1mTokens: 0.25,
+          cacheReadPer1mTokens: 0.02,
           tiers: [
             {
               inputTokenThreshold: OPENAI_LONG_CONTEXT_PRICING_THRESHOLD_TOKENS,
-              inputPer1mTokens: 0.2,
-              outputPer1mTokens: 0.9,
-              cacheWritePer1mTokens: 0.25,
-              cacheReadPer1mTokens: 0.02,
+              inputPer1mTokens: 0.4,
+              outputPer1mTokens: 1.8,
+              cacheWritePer1mTokens: 0.5,
+              cacheReadPer1mTokens: 0.04,
             },
           ],
         },
@@ -1352,17 +1353,17 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         supportsToolUse: true,
         supportsPromptCacheBreakpoints: true,
         pricing: {
-          inputPer1mTokens: 0.1,
-          outputPer1mTokens: 0.6,
-          cacheWritePer1mTokens: 0.125,
-          cacheReadPer1mTokens: 0.01,
+          inputPer1mTokens: 0.2,
+          outputPer1mTokens: 1.2,
+          cacheWritePer1mTokens: 0.25,
+          cacheReadPer1mTokens: 0.02,
           tiers: [
             {
               inputTokenThreshold: OPENAI_LONG_CONTEXT_PRICING_THRESHOLD_TOKENS,
-              inputPer1mTokens: 0.2,
-              outputPer1mTokens: 0.9,
-              cacheWritePer1mTokens: 0.25,
-              cacheReadPer1mTokens: 0.02,
+              inputPer1mTokens: 0.4,
+              outputPer1mTokens: 1.8,
+              cacheWritePer1mTokens: 0.5,
+              cacheReadPer1mTokens: 0.04,
             },
           ],
         },
@@ -1390,7 +1391,7 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         pricing: {
           inputPer1mTokens: 2,
           outputPer1mTokens: 6,
-          cacheReadPer1mTokens: 0.5,
+          cacheReadPer1mTokens: 0.3,
         },
       },
       {
@@ -1430,10 +1431,14 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         contextWindowTokens: 163840,
         maxOutputTokens: 32000,
         supportsThinking: true,
-        supportsCaching: false,
+        supportsCaching: true,
         supportsVision: false,
         supportsToolUse: true,
-        pricing: { inputPer1mTokens: 0.55, outputPer1mTokens: 2.19 },
+        pricing: {
+          inputPer1mTokens: 0.5,
+          outputPer1mTokens: 2.15,
+          cacheReadPer1mTokens: 0.35,
+        },
       },
       {
         id: "deepseek/deepseek-chat-v3-0324",
@@ -1444,7 +1449,7 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         supportsCaching: false,
         supportsVision: false,
         supportsToolUse: true,
-        pricing: { inputPer1mTokens: 0.27, outputPer1mTokens: 1.1 },
+        pricing: { inputPer1mTokens: 0.25, outputPer1mTokens: 1.0 },
       },
       {
         id: "deepseek/deepseek-v4-pro",
@@ -1452,10 +1457,14 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         contextWindowTokens: 1048576,
         maxOutputTokens: 384000,
         supportsThinking: true,
-        supportsCaching: false,
+        supportsCaching: true,
         supportsVision: false,
         supportsToolUse: true,
-        pricing: { inputPer1mTokens: 0.435, outputPer1mTokens: 0.87 },
+        pricing: {
+          inputPer1mTokens: 0.522174,
+          outputPer1mTokens: 1.044348,
+          cacheReadPer1mTokens: 0.0435145,
+        },
       },
       {
         id: "deepseek/deepseek-v4-flash",
@@ -1463,21 +1472,14 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         contextWindowTokens: 1048576,
         maxOutputTokens: 384000,
         supportsThinking: true,
-        supportsCaching: false,
+        supportsCaching: true,
         supportsVision: false,
         supportsToolUse: true,
-        pricing: { inputPer1mTokens: 0.14, outputPer1mTokens: 0.28 },
-      },
-      {
-        id: "deepseek/deepseek-v3.2-speciale",
-        displayName: "DeepSeek V3.2 Speciale",
-        contextWindowTokens: 163840,
-        maxOutputTokens: 163840,
-        supportsThinking: true,
-        supportsCaching: false,
-        supportsVision: false,
-        supportsToolUse: false,
-        pricing: { inputPer1mTokens: 0.287, outputPer1mTokens: 0.431 },
+        pricing: {
+          inputPer1mTokens: 0.056,
+          outputPer1mTokens: 0.112,
+          cacheReadPer1mTokens: 0.0112,
+        },
       },
       // Qwen
       {
@@ -1489,7 +1491,7 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         supportsCaching: false,
         supportsVision: false,
         supportsToolUse: true,
-        pricing: { inputPer1mTokens: 0.8, outputPer1mTokens: 2.4 },
+        pricing: { inputPer1mTokens: 0.26, outputPer1mTokens: 1.56 },
       },
       {
         id: "qwen/qwen3.5-397b-a17b",
@@ -1497,10 +1499,14 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         contextWindowTokens: 131072,
         maxOutputTokens: 8192,
         supportsThinking: true,
-        supportsCaching: false,
+        supportsCaching: true,
         supportsVision: false,
         supportsToolUse: true,
-        pricing: { inputPer1mTokens: 0.9, outputPer1mTokens: 2.7 },
+        pricing: {
+          inputPer1mTokens: 0.5,
+          outputPer1mTokens: 3.6,
+          cacheReadPer1mTokens: 0.3,
+        },
       },
       {
         id: "qwen/qwen3.5-flash-02-23",
@@ -1511,7 +1517,7 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         supportsCaching: false,
         supportsVision: false,
         supportsToolUse: true,
-        pricing: { inputPer1mTokens: 0.2, outputPer1mTokens: 0.6 },
+        pricing: { inputPer1mTokens: 0.065, outputPer1mTokens: 0.26 },
       },
       {
         id: "qwen/qwen3-coder-next",
@@ -1519,10 +1525,14 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         contextWindowTokens: 131072,
         maxOutputTokens: 8192,
         supportsThinking: false,
-        supportsCaching: false,
+        supportsCaching: true,
         supportsVision: false,
         supportsToolUse: true,
-        pricing: { inputPer1mTokens: 0.5, outputPer1mTokens: 1.5 },
+        pricing: {
+          inputPer1mTokens: 0.12,
+          outputPer1mTokens: 0.8,
+          cacheReadPer1mTokens: 0.07,
+        },
       },
       // Moonshot
       {
@@ -1532,10 +1542,14 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         maxOutputTokens: 131072,
         supportsThinking: true,
         adaptiveThinkingOnly: true,
-        supportsCaching: false,
+        supportsCaching: true,
         supportsVision: true,
         supportsToolUse: true,
-        pricing: { inputPer1mTokens: 3, outputPer1mTokens: 15 },
+        pricing: {
+          inputPer1mTokens: 3,
+          outputPer1mTokens: 15,
+          cacheReadPer1mTokens: 0.3,
+        },
       },
       {
         id: "moonshotai/kimi-k2.6",
@@ -1543,10 +1557,14 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         contextWindowTokens: 262144,
         maxOutputTokens: 32768,
         supportsThinking: true,
-        supportsCaching: false,
+        supportsCaching: true,
         supportsVision: true,
         supportsToolUse: true,
-        pricing: { inputPer1mTokens: 0.6, outputPer1mTokens: 2.8 },
+        pricing: {
+          inputPer1mTokens: 0.95,
+          outputPer1mTokens: 4.0,
+          cacheReadPer1mTokens: 0.16,
+        },
       },
       {
         id: "moonshotai/kimi-k2.5",
@@ -1554,10 +1572,14 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         contextWindowTokens: 256000,
         maxOutputTokens: 32768,
         supportsThinking: false,
-        supportsCaching: false,
+        supportsCaching: true,
         supportsVision: false,
         supportsToolUse: true,
-        pricing: { inputPer1mTokens: 0.6, outputPer1mTokens: 2.5 },
+        pricing: {
+          inputPer1mTokens: 0.6,
+          outputPer1mTokens: 3.0,
+          cacheReadPer1mTokens: 0.1,
+        },
       },
       // MiniMax
       {
@@ -1568,10 +1590,14 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         contextWindowTokens: 524288,
         maxOutputTokens: 512000,
         supportsThinking: true,
-        supportsCaching: false,
+        supportsCaching: true,
         supportsVision: true,
         supportsToolUse: true,
-        pricing: { inputPer1mTokens: 0.3, outputPer1mTokens: 1.2 },
+        pricing: {
+          inputPer1mTokens: 0.3,
+          outputPer1mTokens: 1.2,
+          cacheReadPer1mTokens: 0.06,
+        },
       },
       {
         id: "minimax/minimax-m2.7",
@@ -1579,10 +1605,14 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         contextWindowTokens: 196608,
         maxOutputTokens: 131072,
         supportsThinking: true,
-        supportsCaching: false,
+        supportsCaching: true,
         supportsVision: false,
         supportsToolUse: true,
-        pricing: { inputPer1mTokens: 0.279, outputPer1mTokens: 1.2 },
+        pricing: {
+          inputPer1mTokens: 0.24,
+          outputPer1mTokens: 0.96,
+          cacheReadPer1mTokens: 0.048,
+        },
       },
       {
         id: "minimax/minimax-m2.5",
@@ -1590,10 +1620,14 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         contextWindowTokens: 196608,
         maxOutputTokens: 196608,
         supportsThinking: true,
-        supportsCaching: false,
+        supportsCaching: true,
         supportsVision: false,
         supportsToolUse: true,
-        pricing: { inputPer1mTokens: 0.15, outputPer1mTokens: 1.15 },
+        pricing: {
+          inputPer1mTokens: 0.27,
+          outputPer1mTokens: 1.08,
+          cacheReadPer1mTokens: 0.027,
+        },
       },
       {
         id: "minimax/minimax-m2.1",
@@ -1601,10 +1635,14 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         contextWindowTokens: 196608,
         maxOutputTokens: 196608,
         supportsThinking: true,
-        supportsCaching: false,
+        supportsCaching: true,
         supportsVision: false,
         supportsToolUse: true,
-        pricing: { inputPer1mTokens: 0.29, outputPer1mTokens: 0.95 },
+        pricing: {
+          inputPer1mTokens: 0.3,
+          outputPer1mTokens: 1.2,
+          cacheReadPer1mTokens: 0.03,
+        },
       },
       {
         id: "minimax/minimax-m2",
@@ -1615,7 +1653,7 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         supportsCaching: false,
         supportsVision: false,
         supportsToolUse: true,
-        pricing: { inputPer1mTokens: 0.255, outputPer1mTokens: 1.0 },
+        pricing: { inputPer1mTokens: 0.255, outputPer1mTokens: 1.02 },
       },
       {
         id: "minimax/minimax-m2-her",
@@ -1623,10 +1661,14 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         contextWindowTokens: 65536,
         maxOutputTokens: 2048,
         supportsThinking: false,
-        supportsCaching: false,
+        supportsCaching: true,
         supportsVision: false,
         supportsToolUse: false,
-        pricing: { inputPer1mTokens: 0.3, outputPer1mTokens: 1.2 },
+        pricing: {
+          inputPer1mTokens: 0.3,
+          outputPer1mTokens: 1.2,
+          cacheReadPer1mTokens: 0.03,
+        },
       },
       {
         id: "minimax/minimax-m1",
@@ -1637,7 +1679,7 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         supportsCaching: false,
         supportsVision: false,
         supportsToolUse: true,
-        pricing: { inputPer1mTokens: 0.4, outputPer1mTokens: 2.2 },
+        pricing: { inputPer1mTokens: 0.55, outputPer1mTokens: 2.2 },
       },
       {
         id: "minimax/minimax-01",
@@ -1657,10 +1699,14 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         contextWindowTokens: 1048576,
         maxOutputTokens: 131072,
         supportsThinking: true,
-        supportsCaching: false,
+        supportsCaching: true,
         supportsVision: false,
         supportsToolUse: true,
-        pricing: { inputPer1mTokens: 1.4, outputPer1mTokens: 4.4 },
+        pricing: {
+          inputPer1mTokens: 0.966,
+          outputPer1mTokens: 3.036,
+          cacheReadPer1mTokens: 0.1932,
+        },
       },
       // Mistral
       {
@@ -1669,10 +1715,14 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         contextWindowTokens: 131072,
         maxOutputTokens: 16000,
         supportsThinking: false,
-        supportsCaching: false,
+        supportsCaching: true,
         supportsVision: false,
         supportsToolUse: true,
-        pricing: { inputPer1mTokens: 0.4, outputPer1mTokens: 2.0 },
+        pricing: {
+          inputPer1mTokens: 0.4,
+          outputPer1mTokens: 2.0,
+          cacheReadPer1mTokens: 0.04,
+        },
       },
       {
         id: "mistralai/mistral-small-2603",
@@ -1680,21 +1730,14 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         contextWindowTokens: 131072,
         maxOutputTokens: 16000,
         supportsThinking: false,
-        supportsCaching: false,
+        supportsCaching: true,
         supportsVision: false,
         supportsToolUse: true,
-        pricing: { inputPer1mTokens: 0.2, outputPer1mTokens: 0.6 },
-      },
-      {
-        id: "mistralai/devstral-2512",
-        displayName: "Devstral 2",
-        contextWindowTokens: 131072,
-        maxOutputTokens: 16000,
-        supportsThinking: false,
-        supportsCaching: false,
-        supportsVision: false,
-        supportsToolUse: true,
-        pricing: { inputPer1mTokens: 0.1, outputPer1mTokens: 0.3 },
+        pricing: {
+          inputPer1mTokens: 0.15,
+          outputPer1mTokens: 0.6,
+          cacheReadPer1mTokens: 0.015,
+        },
       },
       // Meta
       {
@@ -1706,7 +1749,7 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         supportsCaching: false,
         supportsVision: true,
         supportsToolUse: true,
-        pricing: { inputPer1mTokens: 0.27, outputPer1mTokens: 0.85 },
+        pricing: { inputPer1mTokens: 0.2, outputPer1mTokens: 0.8 },
       },
       {
         id: "meta-llama/llama-4-scout",
@@ -1717,7 +1760,7 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         supportsCaching: false,
         supportsVision: true,
         supportsToolUse: true,
-        pricing: { inputPer1mTokens: 0.11, outputPer1mTokens: 0.34 },
+        pricing: { inputPer1mTokens: 0.1, outputPer1mTokens: 0.3 },
       },
       // Amazon
       {
@@ -1730,18 +1773,6 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         supportsVision: true,
         supportsToolUse: true,
         pricing: { inputPer1mTokens: 0.8, outputPer1mTokens: 3.2 },
-      },
-      // Owl (OpenRouter first-party)
-      {
-        id: "openrouter/owl-alpha",
-        displayName: "Owl Alpha",
-        contextWindowTokens: 1048576,
-        maxOutputTokens: 262144,
-        supportsThinking: false,
-        supportsCaching: false,
-        supportsVision: false,
-        supportsToolUse: true,
-        pricing: { inputPer1mTokens: 0, outputPer1mTokens: 0 },
       },
     ],
     defaultModel: "x-ai/grok-4.20",

--- a/clients/web/src/assistant/llm-model-catalog.ts
+++ b/clients/web/src/assistant/llm-model-catalog.ts
@@ -568,14 +568,6 @@ export const MODELS_BY_PROVIDER = {
       supportsThinking: true,
     },
     {
-      id: "deepseek/deepseek-v3.2-speciale",
-      displayName: "DeepSeek V3.2 Speciale",
-      contextWindowTokens: 163_840,
-      defaultContextWindowTokens: 163_840,
-      maxOutputTokens: 163_840,
-      supportsThinking: true,
-    },
-    {
       id: "qwen/qwen3.5-plus-02-15",
       displayName: "Qwen 3.5 Plus",
       contextWindowTokens: 131_072,
@@ -714,13 +706,6 @@ export const MODELS_BY_PROVIDER = {
       maxOutputTokens: 16_000,
     },
     {
-      id: "mistralai/devstral-2512",
-      displayName: "Devstral 2",
-      contextWindowTokens: 131_072,
-      defaultContextWindowTokens: 131_072,
-      maxOutputTokens: 16_000,
-    },
-    {
       id: "meta-llama/llama-4-maverick",
       displayName: "Llama 4 Maverick",
       contextWindowTokens: 1_000_000,
@@ -740,13 +725,6 @@ export const MODELS_BY_PROVIDER = {
       contextWindowTokens: 300_000,
       defaultContextWindowTokens: 200_000,
       maxOutputTokens: 5_000,
-    },
-    {
-      id: "openrouter/owl-alpha",
-      displayName: "Owl Alpha",
-      contextWindowTokens: 1_048_576,
-      defaultContextWindowTokens: 200_000,
-      maxOutputTokens: 262_144,
     },
   ],
   "vercel-ai-gateway": [

--- a/meta/llm-provider-catalog.json
+++ b/meta/llm-provider-catalog.json
@@ -1096,17 +1096,17 @@
           "supportsVision": true,
           "supportsToolUse": true,
           "pricing": {
-            "inputPer1mTokens": 5,
-            "outputPer1mTokens": 30,
-            "cacheWritePer1mTokens": 6.25,
-            "cacheReadPer1mTokens": 0.5,
+            "inputPer1mTokens": 2,
+            "outputPer1mTokens": 10,
+            "cacheWritePer1mTokens": 2.5,
+            "cacheReadPer1mTokens": 0.2,
             "tiers": [
               {
                 "inputTokenThreshold": 272000,
-                "inputPer1mTokens": 10,
-                "outputPer1mTokens": 45,
-                "cacheWritePer1mTokens": 12.5,
-                "cacheReadPer1mTokens": 1
+                "inputPer1mTokens": 4,
+                "outputPer1mTokens": 15,
+                "cacheWritePer1mTokens": 5,
+                "cacheReadPer1mTokens": 0.4
               }
             ]
           }
@@ -1124,17 +1124,17 @@
           "supportsVision": true,
           "supportsToolUse": true,
           "pricing": {
-            "inputPer1mTokens": 5,
-            "outputPer1mTokens": 30,
-            "cacheWritePer1mTokens": 6.25,
-            "cacheReadPer1mTokens": 0.5,
+            "inputPer1mTokens": 2,
+            "outputPer1mTokens": 10,
+            "cacheWritePer1mTokens": 2.5,
+            "cacheReadPer1mTokens": 0.2,
             "tiers": [
               {
                 "inputTokenThreshold": 272000,
-                "inputPer1mTokens": 10,
-                "outputPer1mTokens": 45,
-                "cacheWritePer1mTokens": 12.5,
-                "cacheReadPer1mTokens": 1
+                "inputPer1mTokens": 4,
+                "outputPer1mTokens": 15,
+                "cacheWritePer1mTokens": 5,
+                "cacheReadPer1mTokens": 0.4
               }
             ]
           }
@@ -1152,17 +1152,17 @@
           "supportsVision": true,
           "supportsToolUse": true,
           "pricing": {
-            "inputPer1mTokens": 1,
-            "outputPer1mTokens": 6,
-            "cacheWritePer1mTokens": 1.25,
-            "cacheReadPer1mTokens": 0.1,
+            "inputPer1mTokens": 2,
+            "outputPer1mTokens": 12,
+            "cacheWritePer1mTokens": 2.5,
+            "cacheReadPer1mTokens": 0.2,
             "tiers": [
               {
                 "inputTokenThreshold": 272000,
-                "inputPer1mTokens": 2,
-                "outputPer1mTokens": 9,
-                "cacheWritePer1mTokens": 2.5,
-                "cacheReadPer1mTokens": 0.2
+                "inputPer1mTokens": 4,
+                "outputPer1mTokens": 18,
+                "cacheWritePer1mTokens": 5,
+                "cacheReadPer1mTokens": 0.4
               }
             ]
           }
@@ -1180,17 +1180,17 @@
           "supportsVision": true,
           "supportsToolUse": true,
           "pricing": {
-            "inputPer1mTokens": 1,
-            "outputPer1mTokens": 6,
-            "cacheWritePer1mTokens": 1.25,
-            "cacheReadPer1mTokens": 0.1,
+            "inputPer1mTokens": 2,
+            "outputPer1mTokens": 12,
+            "cacheWritePer1mTokens": 2.5,
+            "cacheReadPer1mTokens": 0.2,
             "tiers": [
               {
                 "inputTokenThreshold": 272000,
-                "inputPer1mTokens": 2,
-                "outputPer1mTokens": 9,
-                "cacheWritePer1mTokens": 2.5,
-                "cacheReadPer1mTokens": 0.2
+                "inputPer1mTokens": 4,
+                "outputPer1mTokens": 18,
+                "cacheWritePer1mTokens": 5,
+                "cacheReadPer1mTokens": 0.4
               }
             ]
           }
@@ -1208,17 +1208,17 @@
           "supportsVision": true,
           "supportsToolUse": true,
           "pricing": {
-            "inputPer1mTokens": 0.1,
-            "outputPer1mTokens": 0.6,
-            "cacheWritePer1mTokens": 0.125,
-            "cacheReadPer1mTokens": 0.01,
+            "inputPer1mTokens": 0.2,
+            "outputPer1mTokens": 1.2,
+            "cacheWritePer1mTokens": 0.25,
+            "cacheReadPer1mTokens": 0.02,
             "tiers": [
               {
                 "inputTokenThreshold": 272000,
-                "inputPer1mTokens": 0.2,
-                "outputPer1mTokens": 0.9,
-                "cacheWritePer1mTokens": 0.25,
-                "cacheReadPer1mTokens": 0.02
+                "inputPer1mTokens": 0.4,
+                "outputPer1mTokens": 1.8,
+                "cacheWritePer1mTokens": 0.5,
+                "cacheReadPer1mTokens": 0.04
               }
             ]
           }
@@ -1236,17 +1236,17 @@
           "supportsVision": true,
           "supportsToolUse": true,
           "pricing": {
-            "inputPer1mTokens": 0.1,
-            "outputPer1mTokens": 0.6,
-            "cacheWritePer1mTokens": 0.125,
-            "cacheReadPer1mTokens": 0.01,
+            "inputPer1mTokens": 0.2,
+            "outputPer1mTokens": 1.2,
+            "cacheWritePer1mTokens": 0.25,
+            "cacheReadPer1mTokens": 0.02,
             "tiers": [
               {
                 "inputTokenThreshold": 272000,
-                "inputPer1mTokens": 0.2,
-                "outputPer1mTokens": 0.9,
-                "cacheWritePer1mTokens": 0.25,
-                "cacheReadPer1mTokens": 0.02
+                "inputPer1mTokens": 0.4,
+                "outputPer1mTokens": 1.8,
+                "cacheWritePer1mTokens": 0.5,
+                "cacheReadPer1mTokens": 0.04
               }
             ]
           }
@@ -1265,7 +1265,7 @@
           "pricing": {
             "inputPer1mTokens": 2,
             "outputPer1mTokens": 6,
-            "cacheReadPer1mTokens": 0.5
+            "cacheReadPer1mTokens": 0.3
           }
         },
         {
@@ -1310,12 +1310,13 @@
           "defaultContextWindowTokens": 163840,
           "longContextMode": "unsupported",
           "supportsThinking": true,
-          "supportsCaching": false,
+          "supportsCaching": true,
           "supportsVision": false,
           "supportsToolUse": true,
           "pricing": {
-            "inputPer1mTokens": 0.55,
-            "outputPer1mTokens": 2.19
+            "inputPer1mTokens": 0.5,
+            "outputPer1mTokens": 2.15,
+            "cacheReadPer1mTokens": 0.35
           }
         },
         {
@@ -1330,8 +1331,8 @@
           "supportsVision": false,
           "supportsToolUse": true,
           "pricing": {
-            "inputPer1mTokens": 0.27,
-            "outputPer1mTokens": 1.1
+            "inputPer1mTokens": 0.25,
+            "outputPer1mTokens": 1
           }
         },
         {
@@ -1342,12 +1343,13 @@
           "defaultContextWindowTokens": 200000,
           "longContextMode": "native-model",
           "supportsThinking": true,
-          "supportsCaching": false,
+          "supportsCaching": true,
           "supportsVision": false,
           "supportsToolUse": true,
           "pricing": {
-            "inputPer1mTokens": 0.435,
-            "outputPer1mTokens": 0.87
+            "inputPer1mTokens": 0.522174,
+            "outputPer1mTokens": 1.044348,
+            "cacheReadPer1mTokens": 0.0435145
           }
         },
         {
@@ -1358,28 +1360,13 @@
           "defaultContextWindowTokens": 200000,
           "longContextMode": "native-model",
           "supportsThinking": true,
-          "supportsCaching": false,
+          "supportsCaching": true,
           "supportsVision": false,
           "supportsToolUse": true,
           "pricing": {
-            "inputPer1mTokens": 0.14,
-            "outputPer1mTokens": 0.28
-          }
-        },
-        {
-          "id": "deepseek/deepseek-v3.2-speciale",
-          "displayName": "DeepSeek V3.2 Speciale",
-          "contextWindowTokens": 163840,
-          "maxOutputTokens": 163840,
-          "defaultContextWindowTokens": 163840,
-          "longContextMode": "unsupported",
-          "supportsThinking": true,
-          "supportsCaching": false,
-          "supportsVision": false,
-          "supportsToolUse": false,
-          "pricing": {
-            "inputPer1mTokens": 0.287,
-            "outputPer1mTokens": 0.431
+            "inputPer1mTokens": 0.056,
+            "outputPer1mTokens": 0.112,
+            "cacheReadPer1mTokens": 0.0112
           }
         },
         {
@@ -1394,8 +1381,8 @@
           "supportsVision": false,
           "supportsToolUse": true,
           "pricing": {
-            "inputPer1mTokens": 0.8,
-            "outputPer1mTokens": 2.4
+            "inputPer1mTokens": 0.26,
+            "outputPer1mTokens": 1.56
           }
         },
         {
@@ -1406,12 +1393,13 @@
           "defaultContextWindowTokens": 131072,
           "longContextMode": "unsupported",
           "supportsThinking": true,
-          "supportsCaching": false,
+          "supportsCaching": true,
           "supportsVision": false,
           "supportsToolUse": true,
           "pricing": {
-            "inputPer1mTokens": 0.9,
-            "outputPer1mTokens": 2.7
+            "inputPer1mTokens": 0.5,
+            "outputPer1mTokens": 3.6,
+            "cacheReadPer1mTokens": 0.3
           }
         },
         {
@@ -1426,8 +1414,8 @@
           "supportsVision": false,
           "supportsToolUse": true,
           "pricing": {
-            "inputPer1mTokens": 0.2,
-            "outputPer1mTokens": 0.6
+            "inputPer1mTokens": 0.065,
+            "outputPer1mTokens": 0.26
           }
         },
         {
@@ -1438,12 +1426,13 @@
           "defaultContextWindowTokens": 131072,
           "longContextMode": "unsupported",
           "supportsThinking": false,
-          "supportsCaching": false,
+          "supportsCaching": true,
           "supportsVision": false,
           "supportsToolUse": true,
           "pricing": {
-            "inputPer1mTokens": 0.5,
-            "outputPer1mTokens": 1.5
+            "inputPer1mTokens": 0.12,
+            "outputPer1mTokens": 0.8,
+            "cacheReadPer1mTokens": 0.07
           }
         },
         {
@@ -1455,12 +1444,13 @@
           "longContextMode": "native-model",
           "supportsThinking": true,
           "adaptiveThinkingOnly": true,
-          "supportsCaching": false,
+          "supportsCaching": true,
           "supportsVision": true,
           "supportsToolUse": true,
           "pricing": {
             "inputPer1mTokens": 3,
-            "outputPer1mTokens": 15
+            "outputPer1mTokens": 15,
+            "cacheReadPer1mTokens": 0.3
           }
         },
         {
@@ -1471,12 +1461,13 @@
           "defaultContextWindowTokens": 200000,
           "longContextMode": "native-model",
           "supportsThinking": true,
-          "supportsCaching": false,
+          "supportsCaching": true,
           "supportsVision": true,
           "supportsToolUse": true,
           "pricing": {
-            "inputPer1mTokens": 0.6,
-            "outputPer1mTokens": 2.8
+            "inputPer1mTokens": 0.95,
+            "outputPer1mTokens": 4,
+            "cacheReadPer1mTokens": 0.16
           }
         },
         {
@@ -1487,12 +1478,13 @@
           "defaultContextWindowTokens": 200000,
           "longContextMode": "native-model",
           "supportsThinking": false,
-          "supportsCaching": false,
+          "supportsCaching": true,
           "supportsVision": false,
           "supportsToolUse": true,
           "pricing": {
             "inputPer1mTokens": 0.6,
-            "outputPer1mTokens": 2.5
+            "outputPer1mTokens": 3,
+            "cacheReadPer1mTokens": 0.1
           }
         },
         {
@@ -1503,12 +1495,13 @@
           "defaultContextWindowTokens": 200000,
           "longContextMode": "native-model",
           "supportsThinking": true,
-          "supportsCaching": false,
+          "supportsCaching": true,
           "supportsVision": true,
           "supportsToolUse": true,
           "pricing": {
             "inputPer1mTokens": 0.3,
-            "outputPer1mTokens": 1.2
+            "outputPer1mTokens": 1.2,
+            "cacheReadPer1mTokens": 0.06
           }
         },
         {
@@ -1519,12 +1512,13 @@
           "defaultContextWindowTokens": 196608,
           "longContextMode": "unsupported",
           "supportsThinking": true,
-          "supportsCaching": false,
+          "supportsCaching": true,
           "supportsVision": false,
           "supportsToolUse": true,
           "pricing": {
-            "inputPer1mTokens": 0.279,
-            "outputPer1mTokens": 1.2
+            "inputPer1mTokens": 0.24,
+            "outputPer1mTokens": 0.96,
+            "cacheReadPer1mTokens": 0.048
           }
         },
         {
@@ -1535,12 +1529,13 @@
           "defaultContextWindowTokens": 196608,
           "longContextMode": "unsupported",
           "supportsThinking": true,
-          "supportsCaching": false,
+          "supportsCaching": true,
           "supportsVision": false,
           "supportsToolUse": true,
           "pricing": {
-            "inputPer1mTokens": 0.15,
-            "outputPer1mTokens": 1.15
+            "inputPer1mTokens": 0.27,
+            "outputPer1mTokens": 1.08,
+            "cacheReadPer1mTokens": 0.027
           }
         },
         {
@@ -1551,12 +1546,13 @@
           "defaultContextWindowTokens": 196608,
           "longContextMode": "unsupported",
           "supportsThinking": true,
-          "supportsCaching": false,
+          "supportsCaching": true,
           "supportsVision": false,
           "supportsToolUse": true,
           "pricing": {
-            "inputPer1mTokens": 0.29,
-            "outputPer1mTokens": 0.95
+            "inputPer1mTokens": 0.3,
+            "outputPer1mTokens": 1.2,
+            "cacheReadPer1mTokens": 0.03
           }
         },
         {
@@ -1572,7 +1568,7 @@
           "supportsToolUse": true,
           "pricing": {
             "inputPer1mTokens": 0.255,
-            "outputPer1mTokens": 1
+            "outputPer1mTokens": 1.02
           }
         },
         {
@@ -1583,12 +1579,13 @@
           "defaultContextWindowTokens": 65536,
           "longContextMode": "unsupported",
           "supportsThinking": false,
-          "supportsCaching": false,
+          "supportsCaching": true,
           "supportsVision": false,
           "supportsToolUse": false,
           "pricing": {
             "inputPer1mTokens": 0.3,
-            "outputPer1mTokens": 1.2
+            "outputPer1mTokens": 1.2,
+            "cacheReadPer1mTokens": 0.03
           }
         },
         {
@@ -1603,7 +1600,7 @@
           "supportsVision": false,
           "supportsToolUse": true,
           "pricing": {
-            "inputPer1mTokens": 0.4,
+            "inputPer1mTokens": 0.55,
             "outputPer1mTokens": 2.2
           }
         },
@@ -1631,12 +1628,13 @@
           "defaultContextWindowTokens": 200000,
           "longContextMode": "native-model",
           "supportsThinking": true,
-          "supportsCaching": false,
+          "supportsCaching": true,
           "supportsVision": false,
           "supportsToolUse": true,
           "pricing": {
-            "inputPer1mTokens": 1.4,
-            "outputPer1mTokens": 4.4
+            "inputPer1mTokens": 0.966,
+            "outputPer1mTokens": 3.036,
+            "cacheReadPer1mTokens": 0.1932
           }
         },
         {
@@ -1647,12 +1645,13 @@
           "defaultContextWindowTokens": 131072,
           "longContextMode": "unsupported",
           "supportsThinking": false,
-          "supportsCaching": false,
+          "supportsCaching": true,
           "supportsVision": false,
           "supportsToolUse": true,
           "pricing": {
             "inputPer1mTokens": 0.4,
-            "outputPer1mTokens": 2
+            "outputPer1mTokens": 2,
+            "cacheReadPer1mTokens": 0.04
           }
         },
         {
@@ -1663,28 +1662,13 @@
           "defaultContextWindowTokens": 131072,
           "longContextMode": "unsupported",
           "supportsThinking": false,
-          "supportsCaching": false,
+          "supportsCaching": true,
           "supportsVision": false,
           "supportsToolUse": true,
           "pricing": {
-            "inputPer1mTokens": 0.2,
-            "outputPer1mTokens": 0.6
-          }
-        },
-        {
-          "id": "mistralai/devstral-2512",
-          "displayName": "Devstral 2",
-          "contextWindowTokens": 131072,
-          "maxOutputTokens": 16000,
-          "defaultContextWindowTokens": 131072,
-          "longContextMode": "unsupported",
-          "supportsThinking": false,
-          "supportsCaching": false,
-          "supportsVision": false,
-          "supportsToolUse": true,
-          "pricing": {
-            "inputPer1mTokens": 0.1,
-            "outputPer1mTokens": 0.3
+            "inputPer1mTokens": 0.15,
+            "outputPer1mTokens": 0.6,
+            "cacheReadPer1mTokens": 0.015
           }
         },
         {
@@ -1699,8 +1683,8 @@
           "supportsVision": true,
           "supportsToolUse": true,
           "pricing": {
-            "inputPer1mTokens": 0.27,
-            "outputPer1mTokens": 0.85
+            "inputPer1mTokens": 0.2,
+            "outputPer1mTokens": 0.8
           }
         },
         {
@@ -1715,8 +1699,8 @@
           "supportsVision": true,
           "supportsToolUse": true,
           "pricing": {
-            "inputPer1mTokens": 0.11,
-            "outputPer1mTokens": 0.34
+            "inputPer1mTokens": 0.1,
+            "outputPer1mTokens": 0.3
           }
         },
         {
@@ -1733,22 +1717,6 @@
           "pricing": {
             "inputPer1mTokens": 0.8,
             "outputPer1mTokens": 3.2
-          }
-        },
-        {
-          "id": "openrouter/owl-alpha",
-          "displayName": "Owl Alpha",
-          "contextWindowTokens": 1048576,
-          "maxOutputTokens": 262144,
-          "defaultContextWindowTokens": 200000,
-          "longContextMode": "native-model",
-          "supportsThinking": false,
-          "supportsCaching": false,
-          "supportsVision": false,
-          "supportsToolUse": true,
-          "pricing": {
-            "inputPer1mTokens": 0,
-            "outputPer1mTokens": 0
           }
         }
       ]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan
Address https://github.com/vellum-ai/vellum-assistant/issues/41199 on the vellum-assistant side only.

The OpenRouter block in `assistant/src/providers/model-catalog.ts` had drifted from `https://openrouter.ai/api/v1/models`: stale input/output rates, three ids OpenRouter no longer serves, and models marked `supportsCaching: false` despite a published `input_cache_read` price.

## Summary
- Update OpenRouter input/output (and GPT-5.6 cache write/read) rates to OpenRouter's published card, including long-context tiers scaled from the new GPT-5.6 bases.
- Remove `deepseek/deepseek-v3.2-speciale`, `mistralai/devstral-2512`, and `openrouter/owl-alpha`. Profile writes that name those ids already fail the un-dispatchable-profile guard.
- Flip `supportsCaching` to `true` and add `cacheReadPer1mTokens` for models that publish a cache-read price. Keep the existing xAI exception: OpenRouter lists a cache-read rate for Grok, but those routes do not report cached tokens, so `supportsCaching` stays `false` (Grok 4.5 cache-read updated 0.5 to 0.3).
- Sync `meta/llm-provider-catalog.json` and drop the three removed ids from the web catalog mirror.
- Add local cache-flag guards plus a live OpenRouter drift test (fails on missing ids or >2% rate drift when the endpoint is reachable; skips on network failure).

Rates come from the live OpenRouter catalog, not only the issue table. Notable live-vs-issue differences: `moonshotai/kimi-k2.5` is 0.6 / 3.0 / cache 0.1 (issue had 0.45 / 2.25 / 0.07). Models with no published `input_cache_read` stay `supportsCaching: false` (`deepseek-chat-v3-0324`, `qwen3.5-plus`, `qwen3.5-flash`, `minimax-m2`, `minimax-m1`, Llama 4, Nova Pro).

Closes #41199
Closes EPD-2915

## Test Plan
- `cd assistant && bun test src/__tests__/llm-catalog-parity.test.ts src/__tests__/openrouter-catalog-parity.test.ts src/__tests__/pricing.test.ts`
- `cd clients/web && bun test src/assistant/llm-model-catalog.test.ts`
- `cd assistant && bun run sync:llm-catalog -- --check`

## Risk
- Users with saved OpenRouter profiles pointing at the three removed ids cannot re-save those profiles until they pick a live model. Dispatch of those ids already fails upstream.
- Usage and cost estimates for OpenRouter models change immediately (some rates go down, some go up). `kimi-k2.6` now matches the Vercel AI Gateway block at 0.95 / 4.0.
- The live drift test will fail CI when OpenRouter moves prices by more than 2%. That is intentional so this block cannot silently drift again. The test skips if the public catalog is unreachable.
- No platform / Terraform companion PR. No migrations. No feature flags.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe7fd1c2-f6c9-4b29-9e3d-4dbcf0729c52?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe7fd1c2-f6c9-4b29-9e3d-4dbcf0729c52&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

