### PR TITLE
fix(voice): hold the working silence with a cue instead of narration

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -949,7 +949,9 @@ describe("AssistantConfigSchema", () => {
         endpointExtensionMs: 1500,
         endpointMaxExtensions: 2,
         progress: {
-          enabled: true,
+          // Off by default: the working cue holds a long turn's silence, and
+          // spoken narration is the opt-in that replaces it.
+          enabled: false,
           opsThreshold: 3,
           idleIntervalMs: 5000,
           maxSilenceMs: 35000,
@@ -957,6 +959,13 @@ describe("AssistantConfigSchema", () => {
           minGapMs: 6000,
           generationTimeoutMs: 1500,
         },
+      },
+      workingCue: {
+        enabled: true,
+        intervalMs: 12000,
+        frequencyHz: 220,
+        durationMs: 260,
+        gain: 0.09,
       },
       flux: {
         turnEnd: { enabled: false },

--- a/assistant/src/config/schemas/__tests__/live-voice.test.ts
+++ b/assistant/src/config/schemas/__tests__/live-voice.test.ts
@@ -5,11 +5,14 @@ import {
   LiveVoiceFluxConfigSchema,
   LiveVoiceFrontModelConfigSchema,
   LiveVoiceVadConfigSchema,
+  LiveVoiceWorkingCueConfigSchema,
   VALID_LIVE_VOICE_MODES,
 } from "../live-voice.js";
 
 const PROGRESS_DEFAULTS = {
-  enabled: true,
+  // Off by default: the wordless working cue holds a long turn's silence, and
+  // spoken narration is the opt-in that replaces it.
+  enabled: false,
   opsThreshold: 3,
   idleIntervalMs: 5_000,
   maxSilenceMs: 35_000,
@@ -23,6 +26,14 @@ const FRONT_MODEL_DEFAULTS = {
   endpointExtensionMs: 1500,
   endpointMaxExtensions: 2,
   progress: PROGRESS_DEFAULTS,
+};
+
+const WORKING_CUE_DEFAULTS = {
+  enabled: true,
+  intervalMs: 12_000,
+  frequencyHz: 220,
+  durationMs: 260,
+  gain: 0.09,
 };
 
 // `eagerEotThreshold` is deliberately absent: it has no default, and leaving it
@@ -164,9 +175,9 @@ describe("LiveVoiceFrontModelConfigSchema", () => {
 
   test("partial progress overrides merge with defaults", () => {
     const parsed = LiveVoiceFrontModelConfigSchema.parse({
-      progress: { enabled: false, opsThreshold: 5 },
+      progress: { enabled: true, opsThreshold: 5 },
     });
-    expect(parsed.progress.enabled).toBe(false);
+    expect(parsed.progress.enabled).toBe(true);
     expect(parsed.progress.opsThreshold).toBe(5);
     // Unspecified progress fields still get defaults
     expect(parsed.progress.idleIntervalMs).toBe(5_000);
@@ -225,6 +236,54 @@ describe("LiveVoiceFrontModelConfigSchema", () => {
         msgs.some((m) => m.includes("liveVoice.frontModel.progress.enabled")),
       ).toBe(true);
     }
+  });
+});
+
+describe("LiveVoiceWorkingCueConfigSchema", () => {
+  test("empty object parses to defaults", () => {
+    expect(LiveVoiceWorkingCueConfigSchema.parse({})).toEqual(
+      WORKING_CUE_DEFAULTS,
+    );
+  });
+
+  test("partial overrides merge with defaults", () => {
+    const parsed = LiveVoiceWorkingCueConfigSchema.parse({
+      intervalMs: 8_000,
+      frequencyHz: 440,
+    });
+    expect(parsed.intervalMs).toBe(8_000);
+    expect(parsed.frequencyHz).toBe(440);
+    expect(parsed.enabled).toBe(true);
+    expect(parsed.durationMs).toBe(260);
+    expect(parsed.gain).toBe(0.09);
+  });
+
+  test("the cue can be turned off", () => {
+    expect(
+      LiveVoiceWorkingCueConfigSchema.parse({ enabled: false }).enabled,
+    ).toBe(false);
+  });
+
+  test("rejects a non-positive intervalMs", () => {
+    const result = LiveVoiceWorkingCueConfigSchema.safeParse({ intervalMs: 0 });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const msgs = result.error.issues.map((i) => i.message);
+      expect(
+        msgs.some((m) => m.includes("liveVoice.workingCue.intervalMs")),
+      ).toBe(true);
+    }
+  });
+
+  test("rejects a gain outside 0..1", () => {
+    // The renderer clamps, so an out-of-range gain would otherwise be a
+    // silently ignored setting rather than a visible mistake.
+    expect(
+      LiveVoiceWorkingCueConfigSchema.safeParse({ gain: 1.5 }).success,
+    ).toBe(false);
+    expect(
+      LiveVoiceWorkingCueConfigSchema.safeParse({ gain: -0.1 }).success,
+    ).toBe(false);
   });
 });
 
@@ -324,6 +383,9 @@ describe("LiveVoiceConfigSchema", () => {
         echoDrainSlackMs: 300,
       },
       frontModel: FRONT_MODEL_DEFAULTS,
+      // On by default: a working turn holds its silence with the cue rather
+      // than narrating over it.
+      workingCue: WORKING_CUE_DEFAULTS,
       // Off by default: Flux turn detection is opt-in, so the front-door hold
       // verdict keeps committing turns until it is enabled.
       flux: FLUX_DEFAULTS,
@@ -354,6 +416,7 @@ describe("LiveVoiceConfigSchema", () => {
       mode: "ptt",
       vad: { silenceThresholdMs: 900 },
       frontModel: { endpointDecisionTimeoutMs: 300 },
+      workingCue: { intervalMs: 20_000 },
       flux: { turnEnd: { enabled: true } },
       maxSessionDurationSeconds: 600,
     });
@@ -365,6 +428,9 @@ describe("LiveVoiceConfigSchema", () => {
     // Partial frontModel overrides merge with defaults
     expect(parsed.frontModel.endpointDecisionTimeoutMs).toBe(300);
     expect(parsed.frontModel.endpointExtensionMs).toBe(1500);
+    // Partial workingCue overrides merge with defaults
+    expect(parsed.workingCue.intervalMs).toBe(20_000);
+    expect(parsed.workingCue.enabled).toBe(true);
     // Partial flux overrides merge with defaults
     expect(parsed.flux.turnEnd.enabled).toBe(true);
     expect(parsed.flux.eotThreshold).toBe(0.7);

--- a/assistant/src/config/schemas/__tests__/live-voice.test.ts
+++ b/assistant/src/config/schemas/__tests__/live-voice.test.ts
@@ -275,6 +275,29 @@ describe("LiveVoiceWorkingCueConfigSchema", () => {
     }
   });
 
+  test("rejects an intervalMs past the timer maximum", () => {
+    // setTimeout holds its delay in a signed 32-bit int, so a larger value
+    // wraps and fires almost immediately: the cue would become a continuous
+    // tone rather than the very long silence the number asks for.
+    const result = LiveVoiceWorkingCueConfigSchema.safeParse({
+      intervalMs: 2_147_483_648,
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const msgs = result.error.issues.map((i) => i.message);
+      expect(
+        msgs.some((m) => m.includes("liveVoice.workingCue.intervalMs")),
+      ).toBe(true);
+    }
+  });
+
+  test("accepts the largest interval a timer can hold", () => {
+    const result = LiveVoiceWorkingCueConfigSchema.safeParse({
+      intervalMs: 2_147_483_647,
+    });
+    expect(result.success).toBe(true);
+  });
+
   test("rejects a durationMs past the cue-length cap", () => {
     // The value sizes a PCM buffer at the client's sample rate, so an
     // unbounded one is an unbounded Buffer.alloc from a timer callback.

--- a/assistant/src/config/schemas/__tests__/live-voice.test.ts
+++ b/assistant/src/config/schemas/__tests__/live-voice.test.ts
@@ -275,6 +275,36 @@ describe("LiveVoiceWorkingCueConfigSchema", () => {
     }
   });
 
+  test("rejects a durationMs past the cue-length cap", () => {
+    // The value sizes a PCM buffer at the client's sample rate, so an
+    // unbounded one is an unbounded Buffer.alloc from a timer callback.
+    const result = LiveVoiceWorkingCueConfigSchema.safeParse({
+      durationMs: 1_000_000_000,
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const msgs = result.error.issues.map((i) => i.message);
+      expect(
+        msgs.some((m) => m.includes("liveVoice.workingCue.durationMs")),
+      ).toBe(true);
+    }
+    // The cap is a ceiling on a short tone, not a ban on tuning it.
+    expect(
+      LiveVoiceWorkingCueConfigSchema.parse({ durationMs: 2_000 }).durationMs,
+    ).toBe(2_000);
+  });
+
+  test("rejects a frequencyHz past the top of hearing", () => {
+    expect(
+      LiveVoiceWorkingCueConfigSchema.safeParse({ frequencyHz: 96_000 })
+        .success,
+    ).toBe(false);
+    expect(
+      LiveVoiceWorkingCueConfigSchema.parse({ frequencyHz: 20_000 })
+        .frequencyHz,
+    ).toBe(20_000);
+  });
+
   test("rejects a gain outside 0..1", () => {
     // The renderer clamps, so an out-of-range gain would otherwise be a
     // silently ignored setting rather than a visible mistake.

--- a/assistant/src/config/schemas/live-voice.ts
+++ b/assistant/src/config/schemas/live-voice.ts
@@ -182,6 +182,13 @@ export const LiveVoiceProgressConfigSchema = z
  */
 const MAX_WORKING_CUE_DURATION_MS = 2_000;
 
+// setTimeout stores its delay in a signed 32-bit int, so a larger value wraps
+// and fires almost immediately. A cue interval past this would not be a very
+// long silence, it would be a continuous tone: exactly inverted from what the
+// number says. Reject it instead, since anything near the cap is already far
+// longer than a working turn.
+const MAX_WORKING_CUE_INTERVAL_MS = 2_147_483_647;
+
 /**
  * Ceiling on the cue's fundamental. Above the top of human hearing the tone is
  * inaudible, and above half the session's sample rate it aliases down to some
@@ -201,9 +208,13 @@ export const LiveVoiceWorkingCueConfigSchema = z
       .number({ error: "liveVoice.workingCue.intervalMs must be a number" })
       .int("liveVoice.workingCue.intervalMs must be an integer")
       .positive("liveVoice.workingCue.intervalMs must be a positive integer")
+      .max(
+        MAX_WORKING_CUE_INTERVAL_MS,
+        `liveVoice.workingCue.intervalMs must be at most ${MAX_WORKING_CUE_INTERVAL_MS}`,
+      )
       .default(12_000)
       .describe(
-        "Audible silence (ms) between cues while a turn works. This is a cadence for punctuation, not for speech, so it can sit far below what a spoken update would tolerate",
+        `Audible silence (ms) between cues while a turn works. This is a cadence for punctuation, not for speech, so it can sit far below what a spoken update would tolerate. Capped at ${MAX_WORKING_CUE_INTERVAL_MS}, the largest delay a timer can hold without wrapping to near-zero`,
       ),
     frequencyHz: z
       .number({ error: "liveVoice.workingCue.frequencyHz must be a number" })

--- a/assistant/src/config/schemas/live-voice.ts
+++ b/assistant/src/config/schemas/live-voice.ts
@@ -82,7 +82,7 @@ export const LiveVoiceProgressConfigSchema = z
       })
       .default(false)
       .describe(
-        "Speak short progress updates during long-running tool-heavy turns. Off by default: a working turn holds its silence with the wordless liveVoice.workingCue instead, which says the same thing without making a claim the user has to listen to. Turning this on replaces the cue with spoken narration.",
+        "Speak short progress updates during long-running tool-heavy turns. Off by default: a working turn holds its silence with the wordless liveVoice.workingCue instead, which says the same thing without making a claim the user has to listen to. This setting wins over the cue, so turning it on replaces the cue with spoken narration even where liveVoice.workingCue.enabled is also true.",
       ),
     opsThreshold: z
       .number({
@@ -172,13 +172,30 @@ export const LiveVoiceProgressConfigSchema = z
     "Progress-narration tuning for live voice sessions (spoken updates during long-running turns)",
   );
 
+/**
+ * Ceiling on the cue tone's length. The value is multiplied by the client's
+ * sample rate to size the rendered PCM buffer, so it is an allocation request
+ * arriving from config and reaching `Buffer.alloc` from a timer callback: a
+ * large finite value asks for gigabytes the moment the first cue fires. Two
+ * seconds is far past anything that still reads as punctuation and leaves the
+ * worst case well under a megabyte at any sample rate a client can ask for.
+ */
+const MAX_WORKING_CUE_DURATION_MS = 2_000;
+
+/**
+ * Ceiling on the cue's fundamental. Above the top of human hearing the tone is
+ * inaudible, and above half the session's sample rate it aliases down to some
+ * unrelated pitch, so a value up here is always a mistake rather than a taste.
+ */
+const MAX_WORKING_CUE_FREQUENCY_HZ = 20_000;
+
 export const LiveVoiceWorkingCueConfigSchema = z
   .object({
     enabled: z
       .boolean({ error: "liveVoice.workingCue.enabled must be a boolean" })
       .default(true)
       .describe(
-        "Hold a working turn's silence with a short wordless tone; the opt-out for the working cue. Disabling it leaves the turn silent unless liveVoice.frontModel.progress.enabled speaks instead.",
+        "Hold a working turn's silence with a short wordless tone; the opt-out for the working cue. liveVoice.frontModel.progress.enabled wins over this, so a turn plays the cue only where spoken narration is off. Turning both off leaves the working turn silent.",
       ),
     intervalMs: z
       .number({ error: "liveVoice.workingCue.intervalMs must be a number" })
@@ -191,17 +208,25 @@ export const LiveVoiceWorkingCueConfigSchema = z
     frequencyHz: z
       .number({ error: "liveVoice.workingCue.frequencyHz must be a number" })
       .positive("liveVoice.workingCue.frequencyHz must be a positive number")
+      .max(
+        MAX_WORKING_CUE_FREQUENCY_HZ,
+        `liveVoice.workingCue.frequencyHz must be at most ${MAX_WORKING_CUE_FREQUENCY_HZ}`,
+      )
       .default(DEFAULT_WORKING_CUE_SHAPE.frequencyHz)
       .describe(
-        "Fundamental (Hz) of the cue tone. Low reads as a hum under the call, high as a notification chime",
+        `Fundamental (Hz) of the cue tone. Low reads as a hum under the call, high as a notification chime. Capped at ${MAX_WORKING_CUE_FREQUENCY_HZ}, the top of human hearing, above which the tone is either inaudible or aliased into an unrelated pitch`,
       ),
     durationMs: z
       .number({ error: "liveVoice.workingCue.durationMs must be a number" })
       .int("liveVoice.workingCue.durationMs must be an integer")
       .positive("liveVoice.workingCue.durationMs must be a positive integer")
+      .max(
+        MAX_WORKING_CUE_DURATION_MS,
+        `liveVoice.workingCue.durationMs must be at most ${MAX_WORKING_CUE_DURATION_MS}`,
+      )
       .default(DEFAULT_WORKING_CUE_SHAPE.durationMs)
       .describe(
-        "Length (ms) of the cue tone, fades included. Short enough to read as punctuation rather than as audio the user is meant to attend to",
+        `Length (ms) of the cue tone, fades included. Short enough to read as punctuation rather than as audio the user is meant to attend to. Capped at ${MAX_WORKING_CUE_DURATION_MS}: the value sizes the rendered PCM buffer, so an unbounded one is an unbounded allocation from a timer callback`,
       ),
     gain: z
       .number({ error: "liveVoice.workingCue.gain must be a number" })

--- a/assistant/src/config/schemas/live-voice.ts
+++ b/assistant/src/config/schemas/live-voice.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+import { DEFAULT_WORKING_CUE_SHAPE } from "../../live-voice/working-cue.js";
+
 export const VALID_LIVE_VOICE_MODES = ["ptt", "open-mic"] as const;
 
 export const LiveVoiceVadConfigSchema = z
@@ -78,9 +80,9 @@ export const LiveVoiceProgressConfigSchema = z
       .boolean({
         error: "liveVoice.frontModel.progress.enabled must be a boolean",
       })
-      .default(true)
+      .default(false)
       .describe(
-        "Speak short progress updates during long-running tool-heavy turns; the opt-out for progress narration",
+        "Speak short progress updates during long-running tool-heavy turns. Off by default: a working turn holds its silence with the wordless liveVoice.workingCue instead, which says the same thing without making a claim the user has to listen to. Turning this on replaces the cue with spoken narration.",
       ),
     opsThreshold: z
       .number({
@@ -168,6 +170,50 @@ export const LiveVoiceProgressConfigSchema = z
   })
   .describe(
     "Progress-narration tuning for live voice sessions (spoken updates during long-running turns)",
+  );
+
+export const LiveVoiceWorkingCueConfigSchema = z
+  .object({
+    enabled: z
+      .boolean({ error: "liveVoice.workingCue.enabled must be a boolean" })
+      .default(true)
+      .describe(
+        "Hold a working turn's silence with a short wordless tone; the opt-out for the working cue. Disabling it leaves the turn silent unless liveVoice.frontModel.progress.enabled speaks instead.",
+      ),
+    intervalMs: z
+      .number({ error: "liveVoice.workingCue.intervalMs must be a number" })
+      .int("liveVoice.workingCue.intervalMs must be an integer")
+      .positive("liveVoice.workingCue.intervalMs must be a positive integer")
+      .default(12_000)
+      .describe(
+        "Audible silence (ms) between cues while a turn works. This is a cadence for punctuation, not for speech, so it can sit far below what a spoken update would tolerate",
+      ),
+    frequencyHz: z
+      .number({ error: "liveVoice.workingCue.frequencyHz must be a number" })
+      .positive("liveVoice.workingCue.frequencyHz must be a positive number")
+      .default(DEFAULT_WORKING_CUE_SHAPE.frequencyHz)
+      .describe(
+        "Fundamental (Hz) of the cue tone. Low reads as a hum under the call, high as a notification chime",
+      ),
+    durationMs: z
+      .number({ error: "liveVoice.workingCue.durationMs must be a number" })
+      .int("liveVoice.workingCue.durationMs must be an integer")
+      .positive("liveVoice.workingCue.durationMs must be a positive integer")
+      .default(DEFAULT_WORKING_CUE_SHAPE.durationMs)
+      .describe(
+        "Length (ms) of the cue tone, fades included. Short enough to read as punctuation rather than as audio the user is meant to attend to",
+      ),
+    gain: z
+      .number({ error: "liveVoice.workingCue.gain must be a number" })
+      .min(0, "liveVoice.workingCue.gain must be between 0 and 1")
+      .max(1, "liveVoice.workingCue.gain must be between 0 and 1")
+      .default(DEFAULT_WORKING_CUE_SHAPE.gain)
+      .describe(
+        "Peak amplitude (0..1) of the cue tone. Well below speech so it sits under the call",
+      ),
+  })
+  .describe(
+    "Working-cue tuning for live voice sessions (the wordless tone that holds a long turn's silence)",
   );
 
 export const LiveVoiceFrontModelConfigSchema = z
@@ -281,6 +327,9 @@ export const LiveVoiceConfigSchema = z
     frontModel: LiveVoiceFrontModelConfigSchema.default(
       LiveVoiceFrontModelConfigSchema.parse({}),
     ),
+    workingCue: LiveVoiceWorkingCueConfigSchema.default(
+      LiveVoiceWorkingCueConfigSchema.parse({}),
+    ),
     flux: LiveVoiceFluxConfigSchema.default(
       LiveVoiceFluxConfigSchema.parse({}),
     ),
@@ -312,5 +361,8 @@ export type LiveVoiceFrontModelConfig = z.infer<
 >;
 export type LiveVoiceProgressConfig = z.infer<
   typeof LiveVoiceProgressConfigSchema
+>;
+export type LiveVoiceWorkingCueConfig = z.infer<
+  typeof LiveVoiceWorkingCueConfigSchema
 >;
 export type LiveVoiceFluxConfig = z.infer<typeof LiveVoiceFluxConfigSchema>;

--- a/assistant/src/live-voice/__tests__/live-voice-progress.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-progress.test.ts
@@ -9,6 +9,7 @@ import { loadRawConfig, saveRawConfig } from "../../config/loader.js";
 import type {
   LiveVoiceFrontModelConfig,
   LiveVoiceProgressConfig,
+  LiveVoiceWorkingCueConfig,
 } from "../../config/schemas/live-voice.js";
 import type {
   StreamingTranscriber,
@@ -26,6 +27,7 @@ import type {
   VoiceProgressTextInput,
 } from "../progress-narration.js";
 import {
+  approvalPendingPhraseFor,
   pickProgressPhrase,
   PROGRESS_FALLBACK_PHRASES,
   PROGRESS_FALLBACK_PHRASES_BY_LANGUAGE,
@@ -35,6 +37,10 @@ import {
   type LiveVoiceClientStartFrame,
   type LiveVoiceServerFrame,
 } from "../protocol.js";
+import {
+  DEFAULT_WORKING_CUE_SHAPE,
+  renderWorkingCuePcm,
+} from "../working-cue.js";
 
 const START_FRAME = {
   type: "start",
@@ -98,19 +104,30 @@ function createContext(): {
 function createCapturingTurnStarter(): {
   startVoiceTurn: LiveVoiceTurnStarter;
   getCallbacks: () => VoiceTurnCallbacks | undefined;
+  approvalPending: (requestId: string) => void;
 } {
   let callbacks: VoiceTurnCallbacks | undefined;
+  let onApprovalPending: VoiceTurnOptions["onApprovalPending"];
   const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
     callbacks = options.callbacks;
+    onApprovalPending = options.onApprovalPending;
     return { turnId: "bridge-turn-1", abort: mock() };
   });
-  return { startVoiceTurn, getCallbacks: () => callbacks };
+  return {
+    startVoiceTurn,
+    getCallbacks: () => callbacks,
+    approvalPending: (requestId) => onApprovalPending?.(requestId),
+  };
 }
 
 function createRecordingTtsStreamer(
   // Per-segment synthesis stall: a non-null promise keeps that segment's TTS
   // job unsettled (audio still emitting) until it resolves.
   gateTtsText?: (text: string) => Promise<void> | null,
+  // Emit this much silent PCM per segment. Without it the mock produces no
+  // audio at all, so the session's client playback-tail estimate never moves
+  // and every turn reads as instantly silent.
+  emitChunkMs?: number,
 ): {
   streamTtsAudio: LiveVoiceTtsStreamer;
   ttsTexts: string[];
@@ -121,6 +138,16 @@ function createRecordingTtsStreamer(
   const streamTtsAudio = mock(async (options: LiveVoiceTtsOptions) => {
     ttsTexts.push(options.text);
     ttsCalls.push(options);
+    if (emitChunkMs !== undefined) {
+      options.onAudioChunk({
+        type: "tts_audio",
+        contentType: "audio/pcm",
+        sampleRate: START_FRAME.audio.sampleRate,
+        dataBase64: Buffer.alloc(
+          Math.round((START_FRAME.audio.sampleRate * emitChunkMs) / 1_000) * 2,
+        ).toString("base64"),
+      });
+    }
     await gateTtsText?.(options.text);
     return {
       provider: "fish-audio" as const,
@@ -165,15 +192,21 @@ function progressConfig(
 function createProgressHarness(options: {
   frontModelConfig: Partial<LiveVoiceFrontModelConfig>;
   progressNarrator: VoiceProgressNarrator;
+  // The cue and spoken narration are alternatives, so a narration test turns
+  // the cue off. Cue tests pass their own config.
+  workingCueConfig?: Partial<LiveVoiceWorkingCueConfig>;
   emitMetrics?: boolean;
   gateTtsText?: (text: string) => Promise<void> | null;
+  emitChunkMs?: number;
   // Events the transcriber flushes at utterance release; defaults to a plain
   // untagged "hello" final.
   sttStopEvents?: SttStreamServerEvent[];
 }) {
-  const { startVoiceTurn, getCallbacks } = createCapturingTurnStarter();
+  const { startVoiceTurn, getCallbacks, approvalPending } =
+    createCapturingTurnStarter();
   const { streamTtsAudio, ttsTexts, ttsCalls } = createRecordingTtsStreamer(
     options.gateTtsText,
+    options.emitChunkMs,
   );
   const { context, frames } = createContext();
   const session = new LiveVoiceSession(context, {
@@ -183,12 +216,20 @@ function createProgressHarness(options: {
     startVoiceTurn,
     streamTtsAudio,
     frontModelConfig: options.frontModelConfig,
+    workingCueConfig: options.workingCueConfig ?? { enabled: false },
     progressNarrator: options.progressNarrator,
     createTurnId: () => "live-turn-1",
     emitMetrics: options.emitMetrics ?? false,
   });
 
-  return { frames, session, getCallbacks, ttsTexts, ttsCalls };
+  return {
+    frames,
+    session,
+    getCallbacks,
+    approvalPending,
+    ttsTexts,
+    ttsCalls,
+  };
 }
 
 async function startReleasedTurn(
@@ -925,5 +966,233 @@ describe("LiveVoiceSession progress narration", () => {
     expect(generateProgressText).toHaveBeenCalledTimes(2);
 
     emitMessageComplete(getCallbacks);
+  });
+});
+
+const CUE_INTERVAL_MS = 40;
+
+const WORKING_CUE_CONFIG = {
+  enabled: true,
+  intervalMs: CUE_INTERVAL_MS,
+  // A cue leaves a playback-tail estimate behind, and that tail is part of
+  // the silence the next tick waits out. Shortening the tone keeps the
+  // silence-to-silence cadence close to the interval so these tests finish in
+  // a few hundred milliseconds.
+  durationMs: 20,
+} as const;
+
+// The cue the session renders for this start frame and config. Comparing
+// frames against the renderer's own output is what ties the emitted bytes to
+// the configured shape rather than to "some audio came out".
+const CUE_PCM = renderWorkingCuePcm(START_FRAME.audio.sampleRate, {
+  ...DEFAULT_WORKING_CUE_SHAPE,
+  durationMs: WORKING_CUE_CONFIG.durationMs,
+});
+const CUE_BASE64 = CUE_PCM.toString("base64");
+
+function cueFrames(
+  frames: LiveVoiceServerFrame[],
+): Extract<LiveVoiceServerFrame, { type: "tts_audio" }>[] {
+  return frames.filter(
+    (frame): frame is Extract<LiveVoiceServerFrame, { type: "tts_audio" }> =>
+      frame.type === "tts_audio" && frame.dataBase64 === CUE_BASE64,
+  );
+}
+
+// Session state the cue's contract is written against but no frame exposes.
+type TurnView = { ttsSegmentEnqueued: boolean };
+
+function turnInternals(session: LiveVoiceSession): {
+  ttsSegmentEnqueued: () => boolean | undefined;
+  echoReference: () => Buffer;
+  audioIdle: () => boolean;
+} {
+  const internals = session as unknown as {
+    activeAssistantTurn: TurnView | null;
+    echoReferenceAudio: Buffer;
+    turnAudioIdle: (turn: TurnView) => boolean;
+  };
+  return {
+    ttsSegmentEnqueued: () => internals.activeAssistantTurn?.ttsSegmentEnqueued,
+    echoReference: () => internals.echoReferenceAudio,
+    audioIdle: () => {
+      const turn = internals.activeAssistantTurn;
+      return turn !== null && internals.turnAudioIdle(turn);
+    },
+  };
+}
+
+// Escalates the turn so it is in the working phase the cue exists for: the
+// canned bridge speaks, then the strong leg works in silence.
+async function startEscalatedProgressTurn(
+  session: LiveVoiceSession,
+  getCallbacks: () => VoiceTurnCallbacks | undefined,
+  ttsTexts: string[],
+): Promise<void> {
+  await startReleasedTurn(session, getCallbacks);
+  emitTextDelta(getCallbacks, "[1]");
+  emitMessageComplete(getCallbacks);
+  await waitFor(() => ttsTexts.length === 1);
+}
+
+describe("LiveVoiceSession working cue", () => {
+  test("an idle escalated turn plays the cue and speaks no narration", async () => {
+    const generateProgressText = mock(async () => GENERATED_NARRATION);
+    const { frames, session, getCallbacks, ttsTexts } = createProgressHarness({
+      // Narration is fully available: enabled, with a narrator that would
+      // happily produce text. The cue still wins, so this asserts the swap
+      // rather than the absence of a narrator.
+      frontModelConfig: progressConfig({ idleIntervalMs: CUE_INTERVAL_MS }),
+      workingCueConfig: WORKING_CUE_CONFIG,
+      progressNarrator: makeProgressNarrator(generateProgressText),
+    });
+    await startEscalatedProgressTurn(session, getCallbacks, ttsTexts);
+
+    await waitFor(() => cueFrames(frames).length >= 1);
+    const cue = cueFrames(frames)[0];
+    // audio/pcm at the session rate: the contract appendEchoReference reads.
+    expect(cue?.mimeType).toBe("audio/pcm");
+    expect(cue?.sampleRate).toBe(START_FRAME.audio.sampleRate);
+
+    // The bridge is the only thing the turn spoke, and the narrator was never
+    // asked for a line to add to it.
+    expect(ttsTexts).toHaveLength(1);
+    expect(generateProgressText).not.toHaveBeenCalled();
+  });
+
+  test("the cue repeats on its interval while the silence lasts", async () => {
+    const { frames, session, getCallbacks, ttsTexts } = createProgressHarness({
+      frontModelConfig: progressConfig({ enabled: false }),
+      workingCueConfig: WORKING_CUE_CONFIG,
+      progressNarrator: makeProgressNarrator(async () => GENERATED_NARRATION),
+    });
+    await startEscalatedProgressTurn(session, getCallbacks, ttsTexts);
+
+    await waitFor(() => cueFrames(frames).length >= 1);
+    const afterFirstCueMs = Date.now();
+    await waitFor(() => cueFrames(frames).length >= 3);
+
+    // Two further cues cost two further intervals: the cadence is the
+    // configured one, not a burst. Timers never fire early, so the lower
+    // bound is the reliable half of the assertion.
+    expect(Date.now() - afterFirstCueMs).toBeGreaterThanOrEqual(
+      2 * CUE_INTERVAL_MS,
+    );
+    // Every cue is the same rendered audio.
+    for (const frame of cueFrames(frames)) {
+      expect(frame.dataBase64).toBe(CUE_BASE64);
+    }
+  });
+
+  test("a turn whose speech is still playing waits it out before the cue", async () => {
+    const speechMs = 150;
+    const { frames, session, getCallbacks, ttsTexts } = createProgressHarness({
+      frontModelConfig: progressConfig({ enabled: false }),
+      workingCueConfig: WORKING_CUE_CONFIG,
+      progressNarrator: makeProgressNarrator(async () => GENERATED_NARRATION),
+      // The bridge is real audio now, so the turn is audibly busy for
+      // `speechMs` after the frame goes out even though its job has settled.
+      emitChunkMs: speechMs,
+    });
+    await startEscalatedProgressTurn(session, getCallbacks, ttsTexts);
+    await waitFor(() => frames.some((frame) => frame.type === "tts_audio"));
+    const bridgeSentAtMs = Date.now();
+
+    await waitFor(() => cueFrames(frames).length >= 1);
+
+    // Several idle ticks fall inside the bridge's playback, and every one of
+    // them stays quiet: a cue over the assistant's own voice is the chatter
+    // this design removes, not a reassurance.
+    expect(Date.now() - bridgeSentAtMs).toBeGreaterThanOrEqual(speechMs);
+  });
+
+  test("tool activity alone plays no cue; only silence does", async () => {
+    const { frames, session, getCallbacks, ttsTexts } = createProgressHarness({
+      frontModelConfig: progressConfig({ enabled: false, opsThreshold: 1 }),
+      // Far longer than this test runs, so nothing here can reach the cue
+      // through the idle tick and any cue that appears came from a tool event.
+      workingCueConfig: { ...WORKING_CUE_CONFIG, intervalMs: 60_000 },
+      progressNarrator: makeProgressNarrator(async () => GENERATED_NARRATION),
+    });
+    await startEscalatedProgressTurn(session, getCallbacks, ttsTexts);
+    // The bridge has to have drained first: a turn that is still speaking has
+    // its own reason to stay quiet, and this test is about the trigger.
+    await waitFor(() => turnInternals(session).audioIdle());
+
+    emitToolStart(getCallbacks, "web_search", "tool-1");
+    emitToolResult(getCallbacks, "web_search", "tool-1", "found it");
+    emitToolStart(getCallbacks, "file_read", "tool-2");
+    await sleep(CUE_INTERVAL_MS * 3);
+
+    // A tone carries nothing about which tool ran, so a tool starting or
+    // finishing is not news it can deliver. Only the silence is.
+    expect(cueFrames(frames)).toHaveLength(0);
+  });
+
+  test("with both off the working turn stays silent", async () => {
+    const generateProgressText = mock(async () => GENERATED_NARRATION);
+    const { frames, session, getCallbacks, ttsTexts } = createProgressHarness({
+      frontModelConfig: progressConfig({ enabled: false }),
+      workingCueConfig: { enabled: false },
+      progressNarrator: makeProgressNarrator(generateProgressText),
+    });
+    await startEscalatedProgressTurn(session, getCallbacks, ttsTexts);
+
+    await sleep(CUE_INTERVAL_MS * 3);
+    expect(cueFrames(frames)).toHaveLength(0);
+    expect(generateProgressText).not.toHaveBeenCalled();
+    expect(ttsTexts).toHaveLength(1);
+  });
+
+  test("a pending approval suppresses the cue and still speaks its phrase", async () => {
+    const approvalPhrase = sanitizeForTts(approvalPendingPhraseFor()).trim();
+    const { frames, session, getCallbacks, approvalPending, ttsTexts } =
+      createProgressHarness({
+        frontModelConfig: progressConfig({ enabled: false }),
+        workingCueConfig: WORKING_CUE_CONFIG,
+        progressNarrator: makeProgressNarrator(async () => GENERATED_NARRATION),
+      });
+    await startEscalatedProgressTurn(session, getCallbacks, ttsTexts);
+
+    approvalPending("approval-request-1");
+    await waitFor(() => ttsTexts.includes(approvalPhrase));
+
+    // Nothing is in flight while the call waits on a person, so the cue's
+    // claim that work is happening would be false. The turn said so once and
+    // then goes quiet.
+    await sleep(CUE_INTERVAL_MS * 3);
+    expect(cueFrames(frames)).toHaveLength(0);
+  });
+
+  test("the cue does not spend the eager first-segment latch", async () => {
+    const { frames, session, getCallbacks } = createProgressHarness({
+      frontModelConfig: progressConfig({ enabled: false }),
+      workingCueConfig: WORKING_CUE_CONFIG,
+      progressNarrator: makeProgressNarrator(async () => GENERATED_NARRATION),
+    });
+    // A plain turn: nothing has been spoken, so the eager first-clause flush
+    // is still unspent when the cue plays.
+    await startReleasedTurn(session, getCallbacks);
+
+    await waitFor(() => cueFrames(frames).length >= 1);
+    expect(turnInternals(session).ttsSegmentEnqueued()).toBe(false);
+  });
+
+  test("the cue's chunk enters the echo reference", async () => {
+    const { frames, session, getCallbacks } = createProgressHarness({
+      frontModelConfig: progressConfig({ enabled: false }),
+      workingCueConfig: WORKING_CUE_CONFIG,
+      progressNarrator: makeProgressNarrator(async () => GENERATED_NARRATION),
+    });
+    await startReleasedTurn(session, getCallbacks);
+
+    await waitFor(() => cueFrames(frames).length >= 1);
+    // Without this the canceller has no record that the hum was the assistant,
+    // and the cue becomes a periodic barge-in trigger.
+    const reference = turnInternals(session).echoReference();
+    expect(reference.byteLength).toBeGreaterThanOrEqual(CUE_PCM.byteLength);
+    expect(reference.subarray(0, CUE_PCM.byteLength).equals(CUE_PCM)).toBe(
+      true,
+    );
   });
 });

--- a/assistant/src/live-voice/__tests__/live-voice-progress.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-progress.test.ts
@@ -1100,6 +1100,27 @@ describe("LiveVoiceSession working cue", () => {
     }
   });
 
+  test("narration's minGap does not slow the cue's own cadence", async () => {
+    // minGapMs is narration's spacing guard, tuned for spoken filler. The cue
+    // is spaced by its own intervalMs, so a large narration gap must not veto
+    // it: the two tunables live in separate config sections precisely so a
+    // workspace can tune one without silently retuning the other.
+    const { frames, session, getCallbacks, ttsTexts } = createProgressHarness({
+      frontModelConfig: progressConfig({
+        enabled: false,
+        minGapMs: 60_000,
+      }),
+      workingCueConfig: WORKING_CUE_CONFIG,
+      progressNarrator: makeProgressNarrator(async () => GENERATED_NARRATION),
+    });
+    await startEscalatedProgressTurn(session, getCallbacks, ttsTexts);
+
+    // A minGap 1500x the cue interval would pin this at one cue forever if the
+    // gap applied to the cue.
+    await waitFor(() => cueFrames(frames).length >= 3);
+    expect(cueFrames(frames).length).toBeGreaterThanOrEqual(3);
+  });
+
   test("a turn whose speech is still playing waits it out before the cue", async () => {
     const speechMs = 150;
     const { frames, session, getCallbacks, ttsTexts } = createProgressHarness({

--- a/assistant/src/live-voice/__tests__/live-voice-progress.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-progress.test.ts
@@ -971,6 +971,10 @@ describe("LiveVoiceSession progress narration", () => {
 
 const CUE_INTERVAL_MS = 40;
 
+// A one-clause answer, so it survives sanitizeForTts unchanged and the text
+// the TTS mock records is the text emitted here.
+const ANSWER_TEXT = "Here is the answer.";
+
 const WORKING_CUE_CONFIG = {
   enabled: true,
   intervalMs: CUE_INTERVAL_MS,
@@ -1000,10 +1004,12 @@ function cueFrames(
 }
 
 // Session state the cue's contract is written against but no frame exposes.
-type TurnView = { ttsSegmentEnqueued: boolean };
+type TurnView = { ttsSegmentEnqueued: boolean; ttsAudioStarted: boolean };
 
 function turnInternals(session: LiveVoiceSession): {
   ttsSegmentEnqueued: () => boolean | undefined;
+  ttsAudioStarted: () => boolean | undefined;
+  firstTtsAudioAtMs: () => number | null | undefined;
   echoReference: () => Buffer;
   audioIdle: () => boolean;
 } {
@@ -1011,9 +1017,17 @@ function turnInternals(session: LiveVoiceSession): {
     activeAssistantTurn: TurnView | null;
     echoReferenceAudio: Buffer;
     turnAudioIdle: (turn: TurnView) => boolean;
+    metrics: {
+      getSnapshot: () => {
+        activeTurn: { timestamps: { firstTtsAudioAtMs: number | null } } | null;
+      };
+    };
   };
   return {
     ttsSegmentEnqueued: () => internals.activeAssistantTurn?.ttsSegmentEnqueued,
+    ttsAudioStarted: () => internals.activeAssistantTurn?.ttsAudioStarted,
+    firstTtsAudioAtMs: () =>
+      internals.metrics.getSnapshot().activeTurn?.timestamps.firstTtsAudioAtMs,
     echoReference: () => internals.echoReferenceAudio,
     audioIdle: () => {
       const turn = internals.activeAssistantTurn;
@@ -1039,10 +1053,12 @@ describe("LiveVoiceSession working cue", () => {
   test("an idle escalated turn plays the cue and speaks no narration", async () => {
     const generateProgressText = mock(async () => GENERATED_NARRATION);
     const { frames, session, getCallbacks, ttsTexts } = createProgressHarness({
-      // Narration is fully available: enabled, with a narrator that would
-      // happily produce text. The cue still wins, so this asserts the swap
-      // rather than the absence of a narrator.
-      frontModelConfig: progressConfig({ idleIntervalMs: CUE_INTERVAL_MS }),
+      // A narrator is wired up and would happily produce text, so what keeps
+      // the turn wordless is the config rather than a missing dependency.
+      frontModelConfig: progressConfig({
+        enabled: false,
+        idleIntervalMs: CUE_INTERVAL_MS,
+      }),
       workingCueConfig: WORKING_CUE_CONFIG,
       progressNarrator: makeProgressNarrator(generateProgressText),
     });
@@ -1162,6 +1178,63 @@ describe("LiveVoiceSession working cue", () => {
     // then goes quiet.
     await sleep(CUE_INTERVAL_MS * 3);
     expect(cueFrames(frames)).toHaveLength(0);
+  });
+
+  test("explicitly enabled narration outranks the cue", async () => {
+    const generateProgressText = mock(async () => GENERATED_NARRATION);
+    const { frames, session, getCallbacks, ttsTexts } = createProgressHarness({
+      // Progress narration defaults to off, so `enabled: true` can only have
+      // come from a workspace asking for words. The cue is on as well, and
+      // loses.
+      frontModelConfig: progressConfig({
+        enabled: true,
+        idleIntervalMs: CUE_INTERVAL_MS,
+      }),
+      workingCueConfig: WORKING_CUE_CONFIG,
+      progressNarrator: makeProgressNarrator(generateProgressText),
+    });
+    await startEscalatedProgressTurn(session, getCallbacks, ttsTexts);
+
+    await waitFor(() => ttsTexts.includes(GENERATED_NARRATION));
+    // A workspace that asked to be narrated at gets narration only, not
+    // narration punctuated by a tone it never configured.
+    expect(cueFrames(frames)).toHaveLength(0);
+  });
+
+  test("the cue does not anchor the turn's first-TTS metrics", async () => {
+    // The answer's synthesis stalls open, so the turn is still active (and its
+    // metrics still the live turn's) while the assertions below run.
+    const answerSpoken = deferred<void>();
+    const { frames, session, getCallbacks, ttsTexts } = createProgressHarness({
+      frontModelConfig: progressConfig({ enabled: false }),
+      workingCueConfig: WORKING_CUE_CONFIG,
+      progressNarrator: makeProgressNarrator(async () => GENERATED_NARRATION),
+      gateTtsText: (text) =>
+        text === ANSWER_TEXT ? answerSpoken.promise : null,
+      // Real bytes per synthesized segment, so the speech below actually
+      // reaches forwardTtsChunk and can latch.
+      emitChunkMs: 10,
+    });
+    // A plain turn, so the cue is the first audio of any kind the turn emits.
+    await startReleasedTurn(session, getCallbacks);
+
+    await waitFor(() => cueFrames(frames).length >= 1);
+    // dispatchToFirstTtsAudioMs, roundTripMs, and
+    // firstAssistantDeltaToFirstTtsAudioMs all measure to this mark. Setting
+    // it here would report the hum's timing as the turn's speech latency on
+    // exactly the long working turns the cue exists for.
+    expect(turnInternals(session).ttsAudioStarted()).toBe(false);
+    expect(turnInternals(session).firstTtsAudioAtMs()).toBeNull();
+
+    emitTextDelta(getCallbacks, ANSWER_TEXT);
+    emitMessageComplete(getCallbacks);
+    await waitFor(() => ttsTexts.includes(ANSWER_TEXT));
+
+    // The first real speech still latches: the cue skips the mark, it does not
+    // consume it.
+    await waitFor(() => turnInternals(session).ttsAudioStarted() === true);
+    expect(turnInternals(session).firstTtsAudioAtMs()).not.toBeNull();
+    answerSpoken.resolve(undefined);
   });
 
   test("the cue does not spend the eager first-segment latch", async () => {

--- a/assistant/src/live-voice/__tests__/protocol.test.ts
+++ b/assistant/src/live-voice/__tests__/protocol.test.ts
@@ -227,6 +227,45 @@ describe("parseLiveVoiceClientTextFrame", () => {
     });
   });
 
+  test("rejects a capture rate past the sane-hardware cap", () => {
+    // The session hands this number straight to buffer sizing for every
+    // synthesized segment and for the rendered working cue, so an absurd rate
+    // becomes an absurd allocation inside a timer callback. It has to be
+    // refused at the frame boundary, where it is still just a bad field.
+    const result = validateLiveVoiceClientFrame({
+      type: "start",
+      audio: {
+        mimeType: "audio/pcm",
+        sampleRate: 1_000_000_000,
+        channels: 1,
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      return;
+    }
+
+    expect(result.error).toMatchObject({
+      code: "invalid_field",
+      field: "audio.sampleRate",
+      frameType: "start",
+    });
+  });
+
+  test("accepts the highest capture rate real hardware opens with", () => {
+    const result = validateLiveVoiceClientFrame({
+      type: "start",
+      audio: {
+        mimeType: "audio/pcm",
+        sampleRate: 192_000,
+        channels: 1,
+      },
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
   test("parses start frames with turnDetection manual", () => {
     const result = parseLiveVoiceClientTextFrame(
       JSON.stringify({

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -36,6 +36,8 @@ import {
   LiveVoiceFluxConfigSchema,
   type LiveVoiceFrontModelConfig,
   LiveVoiceFrontModelConfigSchema,
+  type LiveVoiceWorkingCueConfig,
+  LiveVoiceWorkingCueConfigSchema,
 } from "../config/schemas/live-voice.js";
 import { ABORT_WATCHDOG_MS } from "../daemon/abort-watchdog.js";
 import { isRefusedInReadOnlyPass } from "../daemon/conversation-tool-setup.js";
@@ -132,6 +134,7 @@ import {
   LiveVoiceProtocolErrorCode,
   type LiveVoiceServerFramePayload,
 } from "./protocol.js";
+import { renderWorkingCuePcm } from "./working-cue.js";
 
 const log = getLogger("live-voice-session");
 
@@ -354,6 +357,13 @@ export interface LiveVoiceSessionOptions {
    * schema-parses the partial into a complete config).
    */
   frontModelConfig?: Partial<LiveVoiceFrontModelConfig>;
+  /**
+   * Working-cue tuning: the wordless tone that holds a long turn's silence.
+   * The production factory seeds this from `liveVoice.workingCue` config when
+   * unset; absent fields fall back to the schema defaults, which leave the cue
+   * on.
+   */
+  workingCueConfig?: Partial<LiveVoiceWorkingCueConfig>;
   /**
    * Deepgram Flux turn-detection tuning. The production factory seeds this
    * from `liveVoice.flux` config when unset; absent fields fall back to the
@@ -1310,6 +1320,13 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // option once, so every field carries its `liveVoice.frontModel` schema
   // default when unset.
   private readonly frontModelConfig: LiveVoiceFrontModelConfig;
+  // Complete working-cue tunables (the constructor schema-parses the partial
+  // option once, so every field carries its `liveVoice.workingCue` default).
+  private readonly workingCueConfig: LiveVoiceWorkingCueConfig;
+  // The session's rendered cue, built on first use. The output sample rate is
+  // whatever the start frame asked for and never changes, so one render
+  // serves every cue the session plays.
+  private workingCuePcm: Buffer | null = null;
   // Complete Flux tunables (the constructor schema-parses the partial option
   // once, so every field carries its `liveVoice.flux` schema default).
   private readonly fluxConfig: LiveVoiceFluxConfig;
@@ -1407,6 +1424,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     this.progressNarrator = options.progressNarrator ?? null;
     this.frontModelConfig = LiveVoiceFrontModelConfigSchema.parse(
       options.frontModelConfig ?? {},
+    );
+    this.workingCueConfig = LiveVoiceWorkingCueConfigSchema.parse(
+      options.workingCueConfig ?? {},
     );
     this.fluxConfig = LiveVoiceFluxConfigSchema.parse(options.fluxConfig ?? {});
     const turnDetectorConfig: TurnDetectorConfig = {
@@ -3613,11 +3633,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     if (!alreadyReleased) {
       void this.releaseUtterance();
     }
-    if (
-      this.frontModelConfig.progress.enabled &&
-      this.streamTtsAudio &&
-      this.progressNarrator
-    ) {
+    if (this.canHoldFloorWhileWorking()) {
       this.armProgressIdleTimer(turn);
     }
     return true;
@@ -4662,16 +4678,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       }, this.frontModelConfig.endpointDecisionTimeoutMs);
     }
 
-    // Progress narration speaks into the turn's audible dead air on a
-    // cadence, wherever in the turn it occurs; without TTS or a narrator there
-    // is nothing to speak (the idle trigger's static fallback still needs a
-    // generation attempt to fall back from).
-    if (
-      this.frontModelConfig.progress.enabled &&
-      this.streamTtsAudio &&
-      this.progressNarrator &&
-      !opts?.speculative
-    ) {
+    // The floor-holder plays into the turn's audible dead air on a cadence,
+    // wherever in the turn it occurs.
+    if (this.canHoldFloorWhileWorking() && !opts?.speculative) {
       this.armProgressIdleTimer(activeTurn);
     }
 
@@ -5289,16 +5298,12 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
 
     // Escalated legs run the slowest work in the system (strong-model
     // thinking + tool loops), and the bridge only covers the first couple of
-    // seconds of it — exactly the dead air progress narration exists for.
-    // Re-arm the idle narration timer (cleared above with the ack): its
-    // audible-silence gating means nothing speaks until the bridge audio has
-    // fully drained plus a whole idle interval. Acks stay suppressed
-    // post-handoff — the bridge already served that role.
-    if (
-      this.frontModelConfig.progress.enabled &&
-      this.streamTtsAudio &&
-      this.progressNarrator
-    ) {
+    // seconds of it — exactly the dead air the floor-holder exists for.
+    // Re-arm the idle timer (cleared above with the ack): its audible-silence
+    // gating means nothing plays until the bridge audio has fully drained plus
+    // a whole idle interval. Acks stay suppressed post-handoff — the bridge
+    // already served that role.
+    if (this.canHoldFloorWhileWorking()) {
       this.armProgressIdleTimer(activeTurn);
     }
   }
@@ -5376,15 +5381,19 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     turn.deltaEpoch += 1;
   }
 
-  // Arms (or re-arms) the dead-air narration timer. The countdown measures
-  // audible silence — time since the turn's audio last (estimatedly) reached
-  // the user's ears — not time since launch, so it covers mid-turn silences
-  // for the whole turn. On expiry with audio still pending, or with the
-  // silence not yet a full interval old, it re-arms for the remainder; only a
-  // full interval of audible silence reaches the narration gatekeeper. The
-  // interval is a polling cadence, not a speaking cadence: most ticks find
-  // nothing new to report and stay quiet, so what the user hears follows the
-  // turn's tool activity (with `maxSilenceMs` as the heartbeat ceiling).
+  // Arms (or re-arms) the dead-air timer. The countdown measures audible
+  // silence — time since the turn's audio last (estimatedly) reached the
+  // user's ears — not time since launch, so it covers mid-turn silences for
+  // the whole turn. On expiry with audio still pending, or with the silence
+  // not yet a full interval old, it re-arms for the remainder; only a full
+  // interval of audible silence reaches the floor-holder gatekeeper.
+  //
+  // For the working cue the interval is the cue's own cadence: silence is the
+  // whole question it answers, so every tick that finds the turn quiet plays
+  // one. For spoken narration it is a polling cadence rather than a speaking
+  // cadence: most ticks find nothing new to report and stay quiet, so what
+  // the user hears follows the turn's tool activity (with `maxSilenceMs` as
+  // the heartbeat ceiling).
   private armProgressIdleTimer(
     turn: ActiveAssistantTurn,
     delayMs?: number,
@@ -5409,14 +5418,35 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       }
       this.maybeNarrateProgress(turn, "idle");
       this.armProgressIdleTimer(turn);
-    }, delayMs ?? this.frontModelConfig.progress.idleIntervalMs);
+    }, delayMs ?? this.floorHolderIntervalMs);
   }
 
   // Wall-clock instant the current audible silence turns a full interval old.
   private progressIdleDeadlineMs(turn: ActiveAssistantTurn): number {
+    return this.progressSilenceSinceMs(turn) + this.floorHolderIntervalMs;
+  }
+
+  // Cadence of whichever floor-holder is configured, and so the resolution of
+  // every silence measurement built on the idle tick. The two are paced
+  // separately on purpose: a tone every few seconds is punctuation, while a
+  // sentence every few seconds is the chatter this design exists to remove.
+  private get floorHolderIntervalMs(): number {
+    return this.workingCueConfig.enabled
+      ? this.workingCueConfig.intervalMs
+      : this.frontModelConfig.progress.idleIntervalMs;
+  }
+
+  // Whether the idle tick has anything to play, and so whether arming it is
+  // worth a timer at all. The cue needs only the TTS path; spoken narration
+  // also needs a narrator to generate from, since its static phrase is what a
+  // failed generation falls back to rather than a substitute for one.
+  private canHoldFloorWhileWorking(): boolean {
+    if (!this.streamTtsAudio) {
+      return false;
+    }
     return (
-      this.progressSilenceSinceMs(turn) +
-      this.frontModelConfig.progress.idleIntervalMs
+      this.workingCueConfig.enabled ||
+      (this.frontModelConfig.progress.enabled && this.progressNarrator !== null)
     );
   }
 
@@ -5506,29 +5536,70 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     return false;
   }
 
-  // Gatekeeper for progress narration. It speaks only while the turn is
-  // audibly silent, with one generation at a time and the configured spacing.
+  // Gatekeeper for the turn's mid-work floor-holder. It plays only while the
+  // turn is audibly silent, one at a time and with the configured spacing.
   private maybeNarrateProgress(
     turn: ActiveAssistantTurn,
     trigger: "ops" | "idle" | "op_complete",
   ): void {
     const cfg = this.frontModelConfig.progress;
     const { progress } = turn;
-    const progressNarrator = this.progressNarrator;
     if (
-      !cfg.enabled ||
       !this.streamTtsAudio ||
-      !progressNarrator ||
       !this.turnCanNarrateProgress(turn) ||
       progress.narrationInFlight ||
       (progress.lastFloorHolderAtMs !== null &&
-        Date.now() - progress.lastFloorHolderAtMs < cfg.minGapMs) ||
+        Date.now() - progress.lastFloorHolderAtMs < cfg.minGapMs)
+    ) {
+      return;
+    }
+
+    if (this.workingCueConfig.enabled) {
+      // The cue answers "am I still here", which is a question about silence
+      // and not about tool activity. A tool starting or finishing changes
+      // nothing a wordless tone could carry, so the activity triggers say
+      // nothing and only the idle tick plays it.
+      if (trigger === "idle") {
+        this.playWorkingCue(turn);
+      }
+      return;
+    }
+
+    const progressNarrator = this.progressNarrator;
+    if (
+      !cfg.enabled ||
+      !progressNarrator ||
       (trigger === "ops" && progress.opsSinceNarration < cfg.opsThreshold) ||
       (trigger === "idle" && !this.progressIdleHasSomethingToSay(turn))
     ) {
       return;
     }
     void this.speakProgressUpdate(turn, progressNarrator, trigger);
+  }
+
+  // Play one working cue into the turn's silence. It holds the floor exactly
+  // as a spoken filler does, so the next tick spaces from it and the cadence
+  // is silence-to-silence rather than start-to-start.
+  //
+  // The audio is rendered on first use: the output sample rate is fixed for
+  // the session's life, so one render serves every cue it plays.
+  private playWorkingCue(turn: ActiveAssistantTurn): void {
+    const pcm = (this.workingCuePcm ??= renderWorkingCuePcm(
+      this.context.startFrame.audio.sampleRate,
+      {
+        frequencyHz: this.workingCueConfig.frequencyHz,
+        durationMs: this.workingCueConfig.durationMs,
+        gain: this.workingCueConfig.gain,
+      },
+    ));
+    if (pcm.byteLength === 0) {
+      // A shape that rounds to no frames at this sample rate. Enqueuing it
+      // would send an empty frame and still take the floor for a full
+      // interval, which is worse than skipping the tick.
+      return;
+    }
+    this.enqueueTtsAudioCue(turn.token, pcm);
+    turn.progress.lastFloorHolderAtMs = Date.now();
   }
 
   // Generate and speak one audio-only progress narration. On a null result,
@@ -5967,6 +6038,58 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       // defeat the hold.
       return;
     }
+    activeTurn.ttsQueue = activeTurn.ttsQueue
+      .catch(() => {})
+      .then(() => this.emitTtsJob(token, job));
+  }
+
+  /**
+   * Enqueue rendered audio as a segment job. The bytes are already in hand, so
+   * the job is constructed `started` with its chunks pre-buffered and a
+   * resolved `synthesis`: `emitTtsJob` then promotes, flushes, and settles it
+   * exactly like a synthesized segment, with no change to the pump or the
+   * emission chain.
+   */
+  private enqueueTtsAudioCue(token: symbol, pcm: Buffer): void {
+    const activeTurn = this.activeAssistantTurn;
+    if (activeTurn?.token !== token || !this.streamTtsAudio) {
+      return;
+    }
+    const job: TtsSegmentJob = {
+      // Nothing synthesizes this job, so the only consumer of `text` (the
+      // provider dispatch in pumpTtsSynthesis) never sees it.
+      text: "",
+      language: undefined,
+      // The cue belongs to no model text block, so no block-scoped promotion
+      // or retraction can reach it.
+      blockSeq: NON_BLOCK_TTS_SEQ,
+      started: true,
+      settled: false,
+      emitting: false,
+      // The cue exists to be heard right now: holding one would be holding
+      // the very silence it was played to fill.
+      held: false,
+      cancelled: false,
+      abort: new AbortController(),
+      bufferedChunks: [
+        {
+          type: "tts_audio",
+          // Bare `audio/pcm` at the session rate is exactly what
+          // appendEchoReference accepts. Get either wrong and the cue still
+          // plays, but the echo canceller never learns the hum was us, so
+          // every cue reads as the user speaking over the assistant and the
+          // cadence becomes a periodic barge-in.
+          contentType: "audio/pcm",
+          sampleRate: this.context.startFrame.audio.sampleRate,
+          dataBase64: pcm.toString("base64"),
+        },
+      ],
+      synthesis: Promise.resolve(),
+      frames: Promise.resolve(),
+    };
+    activeTurn.ttsJobs.push(job);
+    // `ttsSegmentEnqueued` stays where it was: the eager first-clause flush is
+    // for the model's opening words, and a cue must not spend it.
     activeTurn.ttsQueue = activeTurn.ttsQueue
       .catch(() => {})
       .then(() => this.emitTtsJob(token, job));
@@ -6713,6 +6836,8 @@ export function createLiveVoiceSession(
       options.echoEmaHalfLifeMs ?? vadConfig?.echoEmaHalfLifeMs,
     echoDrainSlackMs: options.echoDrainSlackMs ?? vadConfig?.echoDrainSlackMs,
     frontModelConfig,
+    // Absent config leaves the schema defaults, which keep the cue on.
+    workingCueConfig: options.workingCueConfig ?? liveVoiceConfig?.workingCue,
     // Absent config leaves the schema defaults, which keep provider turn
     // detection off.
     fluxConfig: options.fluxConfig ?? liveVoiceConfig?.flux,

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -5567,9 +5567,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     if (
       !this.streamTtsAudio ||
       !this.turnCanNarrateProgress(turn) ||
-      progress.narrationInFlight ||
-      (progress.lastFloorHolderAtMs !== null &&
-        Date.now() - progress.lastFloorHolderAtMs < cfg.minGapMs)
+      progress.narrationInFlight
     ) {
       return;
     }
@@ -5577,6 +5575,18 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     // Narration first: a workspace that turned it on asked to be told what is
     // happening, and the cue is what a turn plays when nobody asked for words.
     const progressNarrator = this.narrationFloorHolder();
+
+    // minGapMs is narration's own spacing guard, and it only applies to the
+    // holder it was tuned for. The cue is spaced by its own intervalMs, so
+    // letting a 6s narration gap veto a 3s cue would make the cue schema's
+    // cadence a lie and couple two tunables the config deliberately separates.
+    if (
+      progressNarrator !== null &&
+      progress.lastFloorHolderAtMs !== null &&
+      Date.now() - progress.lastFloorHolderAtMs < cfg.minGapMs
+    ) {
+      return;
+    }
     if (progressNarrator !== null) {
       if (
         (trigger === "ops" && progress.opsSinceNarration < cfg.opsThreshold) ||

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -543,6 +543,15 @@ interface TtsSegmentJob {
   // block-scoped promotion or retraction selects exactly that block's
   // segments. NON_BLOCK_TTS_SEQ marks a segment that belongs to no block.
   readonly blockSeq: number;
+  // Rendered non-speech audio (the working cue) rather than a synthesized
+  // utterance. It is ordinary audio in every other respect: it reaches the
+  // client, enters the echo reference, and extends the playback-tail
+  // estimate. What it must not do is anchor the turn's first-TTS metrics,
+  // which measure when the answer starts being spoken. A cue plays into the
+  // dead air of a long working turn, well before the answer, so latching on
+  // it would report the tone's timing as the turn's speech latency on exactly
+  // the turns whose latency is worth knowing.
+  readonly nonSpeechCue: boolean;
   // The provider stream was started (the job holds an open-job slot).
   started: boolean;
   // The provider is done with this job, either because emission finished or
@@ -5298,11 +5307,11 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
 
     // Escalated legs run the slowest work in the system (strong-model
     // thinking + tool loops), and the bridge only covers the first couple of
-    // seconds of it — exactly the dead air the floor-holder exists for.
-    // Re-arm the idle timer (cleared above with the ack): its audible-silence
-    // gating means nothing plays until the bridge audio has fully drained plus
-    // a whole idle interval. Acks stay suppressed post-handoff — the bridge
-    // already served that role.
+    // seconds of it, which is exactly the dead air the floor-holder exists
+    // for. Re-arm the idle timer (cleared above with the ack): its
+    // audible-silence gating means nothing plays until the bridge audio has
+    // fully drained plus a whole idle interval. Acks stay suppressed
+    // post-handoff, since the bridge already served that role.
     if (this.canHoldFloorWhileWorking()) {
       this.armProgressIdleTimer(activeTurn);
     }
@@ -5382,8 +5391,8 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   }
 
   // Arms (or re-arms) the dead-air timer. The countdown measures audible
-  // silence — time since the turn's audio last (estimatedly) reached the
-  // user's ears — not time since launch, so it covers mid-turn silences for
+  // silence (time since the turn's audio last, estimatedly, reached the user's
+  // ears) rather than time since launch, so it covers mid-turn silences for
   // the whole turn. On expiry with audio still pending, or with the silence
   // not yet a full interval old, it re-arms for the remainder; only a full
   // interval of audible silence reaches the floor-holder gatekeeper.
@@ -5426,27 +5435,38 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     return this.progressSilenceSinceMs(turn) + this.floorHolderIntervalMs;
   }
 
-  // Cadence of whichever floor-holder is configured, and so the resolution of
-  // every silence measurement built on the idle tick. The two are paced
+  // Cadence of whichever floor-holder holds this turn, and so the resolution
+  // of every silence measurement built on the idle tick. The two are paced
   // separately on purpose: a tone every few seconds is punctuation, while a
   // sentence every few seconds is the chatter this design exists to remove.
   private get floorHolderIntervalMs(): number {
-    return this.workingCueConfig.enabled
-      ? this.workingCueConfig.intervalMs
-      : this.frontModelConfig.progress.idleIntervalMs;
+    return this.narrationFloorHolder() !== null
+      ? this.frontModelConfig.progress.idleIntervalMs
+      : this.workingCueConfig.intervalMs;
+  }
+
+  // The narrator when spoken narration, rather than the cue, is what a working
+  // turn plays into its silence; null when the cue has the floor.
+  //
+  // `liveVoice.frontModel.progress.enabled` defaults to false, so a true value
+  // can only have come from a workspace explicitly asking to be narrated at,
+  // and that ask outranks the cue's default. The narrator is part of the test:
+  // narration's static phrase is the fallback for a failed generation, not a
+  // substitute for having a narrator at all.
+  private narrationFloorHolder(): VoiceProgressNarrator | null {
+    return this.frontModelConfig.progress.enabled
+      ? this.progressNarrator
+      : null;
   }
 
   // Whether the idle tick has anything to play, and so whether arming it is
-  // worth a timer at all. The cue needs only the TTS path; spoken narration
-  // also needs a narrator to generate from, since its static phrase is what a
-  // failed generation falls back to rather than a substitute for one.
+  // worth a timer at all.
   private canHoldFloorWhileWorking(): boolean {
     if (!this.streamTtsAudio) {
       return false;
     }
     return (
-      this.workingCueConfig.enabled ||
-      (this.frontModelConfig.progress.enabled && this.progressNarrator !== null)
+      this.narrationFloorHolder() !== null || this.workingCueConfig.enabled
     );
   }
 
@@ -5554,27 +5574,27 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       return;
     }
 
-    if (this.workingCueConfig.enabled) {
-      // The cue answers "am I still here", which is a question about silence
-      // and not about tool activity. A tool starting or finishing changes
-      // nothing a wordless tone could carry, so the activity triggers say
-      // nothing and only the idle tick plays it.
-      if (trigger === "idle") {
-        this.playWorkingCue(turn);
+    // Narration first: a workspace that turned it on asked to be told what is
+    // happening, and the cue is what a turn plays when nobody asked for words.
+    const progressNarrator = this.narrationFloorHolder();
+    if (progressNarrator !== null) {
+      if (
+        (trigger === "ops" && progress.opsSinceNarration < cfg.opsThreshold) ||
+        (trigger === "idle" && !this.progressIdleHasSomethingToSay(turn))
+      ) {
+        return;
       }
+      void this.speakProgressUpdate(turn, progressNarrator, trigger);
       return;
     }
 
-    const progressNarrator = this.progressNarrator;
-    if (
-      !cfg.enabled ||
-      !progressNarrator ||
-      (trigger === "ops" && progress.opsSinceNarration < cfg.opsThreshold) ||
-      (trigger === "idle" && !this.progressIdleHasSomethingToSay(turn))
-    ) {
-      return;
+    // The cue answers "am I still here", which is a question about silence and
+    // not about tool activity. A tool starting or finishing changes nothing a
+    // wordless tone could carry, so the activity triggers say nothing and only
+    // the idle tick plays it.
+    if (this.workingCueConfig.enabled && trigger === "idle") {
+      this.playWorkingCue(turn);
     }
-    void this.speakProgressUpdate(turn, progressNarrator, trigger);
   }
 
   // Play one working cue into the turn's silence. It holds the floor exactly
@@ -6020,6 +6040,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       text: segment,
       language: options.language,
       blockSeq: options.blockSeq ?? activeTurn.textBlockSeq,
+      nonSpeechCue: false,
       started: false,
       settled: false,
       emitting: false,
@@ -6063,6 +6084,8 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       // The cue belongs to no model text block, so no block-scoped promotion
       // or retraction can reach it.
       blockSeq: NON_BLOCK_TTS_SEQ,
+      // Keeps the tone out of the turn's first-TTS metrics (see the field).
+      nonSpeechCue: true,
       started: true,
       settled: false,
       emitting: false,
@@ -6088,8 +6111,11 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       frames: Promise.resolve(),
     };
     activeTurn.ttsJobs.push(job);
-    // `ttsSegmentEnqueued` stays where it was: the eager first-clause flush is
-    // for the model's opening words, and a cue must not spend it.
+    // A cue does not spend the eager first-segment latch. `ttsSegmentEnqueued`
+    // gates the eager first-clause flush, which belongs to the model's opening
+    // words: whatever a turn plays into its dead air, its real first segment
+    // still flushes on the opening clause rather than waiting for a full
+    // sentence, so speech onset is as early as it would be without the cue.
     activeTurn.ttsQueue = activeTurn.ttsQueue
       .catch(() => {})
       .then(() => this.emitTtsJob(token, job));
@@ -6307,8 +6333,16 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       this.appendEchoReference(chunk);
       this.assistantPlaybackTailUntilMs =
         Math.max(now, this.assistantPlaybackTailUntilMs) + chunkMs;
+      // Everything above is what a cue is here for: the client hears it, the
+      // canceller learns it was us, and the tail estimate covers it. The
+      // first-TTS latch is where a cue stops, because that mark is the onset
+      // of the turn's speech (see `nonSpeechCue`).
       const turnAfterSend = this.activeAssistantTurn;
-      if (turnAfterSend?.token !== token || turnAfterSend.ttsAudioStarted) {
+      if (
+        job.nonSpeechCue ||
+        turnAfterSend?.token !== token ||
+        turnAfterSend.ttsAudioStarted
+      ) {
         return;
       }
       turnAfterSend.ttsAudioStarted = true;

--- a/assistant/src/live-voice/protocol.ts
+++ b/assistant/src/live-voice/protocol.ts
@@ -1,5 +1,13 @@
 import { type ClientOs, parseClientOs } from "../channels/types.js";
 
+// Upper bound on a client-declared capture rate. The session hands this number
+// straight to buffer sizing (it is the rate every synthesized segment and the
+// rendered working cue are produced at), so an absurd value becomes an absurd
+// allocation inside a timer callback rather than a rejected frame. 192 kHz is
+// double the highest rate any supported client actually opens with, so the cap
+// rejects only values that were never going to be real capture rates.
+const MAX_START_FRAME_SAMPLE_RATE = 192_000;
+
 const LIVE_VOICE_CLIENT_FRAME_TYPES = [
   "start",
   "audio",
@@ -837,10 +845,13 @@ function validateAudioConfig(
     );
   }
 
-  if (!isPositiveInteger(value.sampleRate)) {
+  if (
+    !isPositiveInteger(value.sampleRate) ||
+    value.sampleRate > MAX_START_FRAME_SAMPLE_RATE
+  ) {
     return protocolError(
       "invalid_field",
-      "start frame audio.sampleRate must be a positive integer",
+      `start frame audio.sampleRate must be a positive integer no greater than ${MAX_START_FRAME_SAMPLE_RATE}`,
       "audio.sampleRate",
       "start",
     );


### PR DESCRIPTION
## Summary
- Play a short rendered tone on the idle tick instead of speaking progress narration, so a long working turn stays wordless.
- The cue rides the existing tts_audio path as a pre-filled job, so it enters the echo reference and cannot self-trigger barge-in, and no client changes are needed.
- Adds liveVoice.workingCue config; spoken narration defaults off but still works when enabled.

Part of plan: voice-speak-final-answer-only.md (PR 6 of 6)