### PR TITLE
feat(gateway): record actor-token last-used activity per device

### DIFF
--- a/gateway/src/__tests__/actor-token-revocation.test.ts
+++ b/gateway/src/__tests__/actor-token-revocation.test.ts
@@ -486,7 +486,7 @@ describe("recordActorTokenUse", () => {
 
     const after = readRow("token-used");
     expect(after?.lastUsedAt).toBeGreaterThan(0);
-    // updatedAt tracks row lifecycle, not activity — it must not move.
+    // updatedAt tracks row lifecycle, not activity, so it must not move.
     expect(after?.updatedAt).toBe(before?.updatedAt ?? 0);
   });
 
@@ -548,5 +548,34 @@ describe("recordActorTokenUse", () => {
     expect(() =>
       recordActorTokenUse("token-anything", actorClaims),
     ).not.toThrow();
+  });
+
+  test("a failed stamp leaves the next attempt free to retry", () => {
+    insertTokenRecord("token-retry", "active");
+    const rawDb = (
+      getGatewayDb() as unknown as { $client: import("bun:sqlite").Database }
+    ).$client;
+    // Make the stamp UPDATE throw while the record lookup keeps working.
+    rawDb.exec(
+      "CREATE TRIGGER fail_last_used BEFORE UPDATE ON actor_token_records BEGIN SELECT RAISE(ABORT, 'stamp failed'); END",
+    );
+
+    recordActorTokenUse("token-retry", actorClaims);
+    expect(readRow("token-retry")?.lastUsedAt).toBeNull();
+
+    rawDb.exec("DROP TRIGGER fail_last_used");
+    // Inside the debounce window: only a completed stamp may suppress a retry.
+    recordActorTokenUse("token-retry", actorClaims);
+
+    expect(readRow("token-retry")?.lastUsedAt).toBeGreaterThan(0);
+  });
+
+  test("a missing record leaves a later stamp for the same token free to run", () => {
+    recordActorTokenUse("token-late", actorClaims);
+
+    insertTokenRecord("token-late", "active");
+    recordActorTokenUse("token-late", actorClaims);
+
+    expect(readRow("token-late")?.lastUsedAt).toBeGreaterThan(0);
   });
 });

--- a/gateway/src/__tests__/actor-token-revocation.test.ts
+++ b/gateway/src/__tests__/actor-token-revocation.test.ts
@@ -20,8 +20,12 @@ const { initGatewayDb, resetGatewayDb, getGatewayDb } =
   await import("../db/connection.js");
 const { actorTokenRecords, contacts } = await import("../db/schema.js");
 const { hashToken } = await import("../auth/guardian-bootstrap.js");
-const { isActorTokenRevoked, actorTokenRecordHash } =
-  await import("../auth/actor-token-revocation.js");
+const {
+  isActorTokenRevoked,
+  actorTokenRecordHash,
+  recordActorTokenUse,
+  __resetLastUsedDebounceForTests,
+} = await import("../auth/actor-token-revocation.js");
 const { createRuntimeProxyHandler } =
   await import("../http/routes/runtime-proxy.js");
 const { bustGuardianIntegrityCache } =
@@ -36,7 +40,11 @@ const actorClaims = { sub: ACTOR_SUB } as TokenClaims;
 
 let testRoot: string;
 
-function insertTokenRecord(rawToken: string, status: "active" | "revoked") {
+function insertTokenRecord(
+  rawToken: string,
+  status: "active" | "revoked" | "derived",
+  deviceLabel = "device-A",
+) {
   const now = Date.now();
   getGatewayDb()
     .insert(actorTokenRecords)
@@ -44,7 +52,7 @@ function insertTokenRecord(rawToken: string, status: "active" | "revoked") {
       id: `id-${rawToken}`,
       tokenHash: hashToken(rawToken),
       guardianPrincipalId: "guardian-001",
-      hashedDeviceId: hashToken("device-A"),
+      hashedDeviceId: hashToken(deviceLabel),
       platform: "web",
       status,
       issuedAt: now,
@@ -53,6 +61,17 @@ function insertTokenRecord(rawToken: string, status: "active" | "revoked") {
       updatedAt: now,
     })
     .run();
+}
+
+function readRow(rawToken: string) {
+  return getGatewayDb()
+    .select({
+      lastUsedAt: actorTokenRecords.lastUsedAt,
+      updatedAt: actorTokenRecords.updatedAt,
+    })
+    .from(actorTokenRecords)
+    .where(eq(actorTokenRecords.tokenHash, hashToken(rawToken)))
+    .get();
 }
 
 function insertGuardianContact() {
@@ -76,6 +95,7 @@ beforeEach(async () => {
   mkdirSync(securityDir, { recursive: true });
   process.env.GATEWAY_SECURITY_DIR = securityDir;
   await initGatewayDb();
+  __resetLastUsedDebounceForTests();
   // The integrity state is module-cached across tests; token rows seeded here
   // are integrity evidence, so keep the reporter silenced and the cache cold.
   bustGuardianIntegrityCache();
@@ -453,5 +473,80 @@ describe("m0004 token-hash index migration", () => {
     // The index now exists and no longer filters on status.
     expect(indexSql()).not.toBe("");
     expect(indexSql().toLowerCase()).not.toContain("where");
+  });
+});
+
+describe("recordActorTokenUse", () => {
+  test("stamps last_used_at on the active row for a recorded actor token", () => {
+    insertTokenRecord("token-used", "active");
+    const before = readRow("token-used");
+    expect(before?.lastUsedAt).toBeNull();
+
+    recordActorTokenUse("token-used", actorClaims);
+
+    const after = readRow("token-used");
+    expect(after?.lastUsedAt).toBeGreaterThan(0);
+    // updatedAt tracks row lifecycle, not activity — it must not move.
+    expect(after?.updatedAt).toBe(before?.updatedAt ?? 0);
+  });
+
+  test("does not write again inside the debounce window", () => {
+    insertTokenRecord("token-debounced", "active");
+    recordActorTokenUse("token-debounced", actorClaims);
+
+    const sentinel = 12_345;
+    getGatewayDb()
+      .update(actorTokenRecords)
+      .set({ lastUsedAt: sentinel })
+      .where(eq(actorTokenRecords.tokenHash, hashToken("token-debounced")))
+      .run();
+
+    recordActorTokenUse("token-debounced", actorClaims);
+
+    expect(readRow("token-debounced")?.lastUsedAt).toBe(sentinel);
+  });
+
+  test("a derived token stamps the sibling active row for the same device", () => {
+    insertTokenRecord("token-source", "active");
+    insertTokenRecord("token-derived", "derived");
+
+    recordActorTokenUse("token-derived", actorClaims);
+
+    expect(readRow("token-source")?.lastUsedAt).toBeGreaterThan(0);
+    expect(readRow("token-derived")?.lastUsedAt).toBeNull();
+  });
+
+  test("leaves other devices' rows untouched", () => {
+    insertTokenRecord("token-device-a", "active");
+    insertTokenRecord("token-device-b", "active", "device-B");
+
+    recordActorTokenUse("token-device-a", actorClaims);
+
+    expect(readRow("token-device-b")?.lastUsedAt).toBeNull();
+  });
+
+  test("is a no-op for non-actor tokens (svc)", () => {
+    insertTokenRecord("svc-token", "active");
+    const svcClaims = { sub: "svc:gateway:self" } as TokenClaims;
+
+    recordActorTokenUse("svc-token", svcClaims);
+
+    expect(readRow("svc-token")?.lastUsedAt).toBeNull();
+  });
+
+  test("is a no-op for an unrecorded token hash", () => {
+    insertTokenRecord("token-recorded", "active");
+
+    expect(() =>
+      recordActorTokenUse("token-unrecorded", actorClaims),
+    ).not.toThrow();
+    expect(readRow("token-recorded")?.lastUsedAt).toBeNull();
+  });
+
+  test("swallows a DB failure (fail-open)", () => {
+    resetGatewayDb();
+    expect(() =>
+      recordActorTokenUse("token-anything", actorClaims),
+    ).not.toThrow();
   });
 });

--- a/gateway/src/auth/actor-token-revocation.ts
+++ b/gateway/src/auth/actor-token-revocation.ts
@@ -1,5 +1,6 @@
 /**
- * Hot-path actor-token revocation check.
+ * Hot-path actor-token revocation check, plus the debounced last-used stamp
+ * that rides the same lookup ({@link recordActorTokenUse}).
  *
  * Edge-token validation ({@link validateEdgeToken}) only verifies the JWT
  * (signature, audience, expiry, policy epoch) — it never consults the DB. That
@@ -21,7 +22,7 @@
  */
 import { createHash } from "node:crypto";
 
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 
 import { getGatewayDb } from "../db/connection.js";
 import { actorTokenRecords } from "../db/schema.js";
@@ -30,6 +31,13 @@ import type { TokenClaims } from "./types.js";
 import { parseSub } from "./subject.js";
 
 const log = getLogger("actor-token-revocation");
+
+/** One stamp per token per window; the label's resolution is this coarse. */
+const STAMP_DEBOUNCE_MS = 5 * 60 * 1000;
+/** Bound on the debounce map so long-lived gateways cannot leak. */
+const MAX_TRACKED_TOKENS = 5_000;
+
+const lastStampedByTokenHash = new Map<string, number>();
 
 /**
  * SHA-256 hex digest, matching how tokens are hashed at mint time. Inlined
@@ -113,4 +121,78 @@ export function isActorTokenRevoked(
     );
     return false;
   }
+}
+
+function evictStaleStamps(now: number): void {
+  for (const [hash, stamped] of lastStampedByTokenHash) {
+    if (now - stamped >= STAMP_DEBOUNCE_MS) lastStampedByTokenHash.delete(hash);
+  }
+  if (lastStampedByTokenHash.size > MAX_TRACKED_TOKENS) {
+    lastStampedByTokenHash.clear();
+  }
+}
+
+/**
+ * Stamp `lastUsedAt` for the device behind `rawToken`, powering the "Paired
+ * devices" list's last-used label.
+ *
+ * Debounced to one write per token per {@link STAMP_DEBOUNCE_MS}, and resolved
+ * through the DEVICE rather than the presented row — `/auth/token` mints
+ * `status = 'derived'` rows sharing the source row's `hashed_device_id`, and
+ * only the `active` row is ever displayed — so derived-token traffic counts.
+ *
+ * Deliberately leaves `updatedAt` alone: that column tracks row lifecycle
+ * (status changes), and moving it every few minutes would destroy that signal.
+ *
+ * Fail-open like the rest of this module: non-actor tokens, unrecorded tokens,
+ * and DB errors are all no-ops.
+ */
+export function recordActorTokenUse(
+  rawToken: string,
+  claims: TokenClaims,
+): void {
+  const parsed = parseSub(claims.sub);
+  if (!parsed.ok || parsed.principalType !== "actor") return;
+
+  const now = Date.now();
+  const tokenHash = actorTokenRecordHash(rawToken);
+  const stamped = lastStampedByTokenHash.get(tokenHash);
+  if (stamped !== undefined && now - stamped < STAMP_DEBOUNCE_MS) return;
+
+  if (lastStampedByTokenHash.size >= MAX_TRACKED_TOKENS) evictStaleStamps(now);
+  lastStampedByTokenHash.set(tokenHash, now);
+
+  try {
+    const db = getGatewayDb();
+    const record = db
+      .select({
+        guardianPrincipalId: actorTokenRecords.guardianPrincipalId,
+        hashedDeviceId: actorTokenRecords.hashedDeviceId,
+      })
+      .from(actorTokenRecords)
+      .where(eq(actorTokenRecords.tokenHash, tokenHash))
+      .get();
+    if (!record) return;
+
+    db.update(actorTokenRecords)
+      .set({ lastUsedAt: now })
+      .where(
+        and(
+          eq(actorTokenRecords.guardianPrincipalId, record.guardianPrincipalId),
+          eq(actorTokenRecords.hashedDeviceId, record.hashedDeviceId),
+          eq(actorTokenRecords.status, "active"),
+        ),
+      )
+      .run();
+  } catch (err) {
+    log.warn(
+      { err: err instanceof Error ? err.message : String(err) },
+      "Actor-token last-used stamp failed — ignoring (fail-open)",
+    );
+  }
+}
+
+/** Clears the last-used debounce map. Exists solely for tests. */
+export function __resetLastUsedDebounceForTests(): void {
+  lastStampedByTokenHash.clear();
 }

--- a/gateway/src/auth/actor-token-revocation.ts
+++ b/gateway/src/auth/actor-token-revocation.ts
@@ -125,7 +125,9 @@ export function isActorTokenRevoked(
 
 function evictStaleStamps(now: number): void {
   for (const [hash, stamped] of lastStampedByTokenHash) {
-    if (now - stamped >= STAMP_DEBOUNCE_MS) lastStampedByTokenHash.delete(hash);
+    if (now - stamped >= STAMP_DEBOUNCE_MS) {
+      lastStampedByTokenHash.delete(hash);
+    }
   }
   if (lastStampedByTokenHash.size > MAX_TRACKED_TOKENS) {
     lastStampedByTokenHash.clear();
@@ -136,10 +138,12 @@ function evictStaleStamps(now: number): void {
  * Stamp `lastUsedAt` for the device behind `rawToken`, powering the "Paired
  * devices" list's last-used label.
  *
- * Debounced to one write per token per {@link STAMP_DEBOUNCE_MS}, and resolved
- * through the DEVICE rather than the presented row — `/auth/token` mints
- * `status = 'derived'` rows sharing the source row's `hashed_device_id`, and
- * only the `active` row is ever displayed — so derived-token traffic counts.
+ * Debounced to one write per token per {@link STAMP_DEBOUNCE_MS}, counted from
+ * a completed stamp so a DB error leaves the next request free to retry.
+ *
+ * Resolved through the DEVICE rather than the presented row: `/auth/token`
+ * mints `status = 'derived'` rows sharing the source row's `hashed_device_id`
+ * and only the `active` row is ever displayed, so derived-token traffic counts.
  *
  * Deliberately leaves `updatedAt` alone: that column tracks row lifecycle
  * (status changes), and moving it every few minutes would destroy that signal.
@@ -152,15 +156,16 @@ export function recordActorTokenUse(
   claims: TokenClaims,
 ): void {
   const parsed = parseSub(claims.sub);
-  if (!parsed.ok || parsed.principalType !== "actor") return;
+  if (!parsed.ok || parsed.principalType !== "actor") {
+    return;
+  }
 
   const now = Date.now();
   const tokenHash = actorTokenRecordHash(rawToken);
   const stamped = lastStampedByTokenHash.get(tokenHash);
-  if (stamped !== undefined && now - stamped < STAMP_DEBOUNCE_MS) return;
-
-  if (lastStampedByTokenHash.size >= MAX_TRACKED_TOKENS) evictStaleStamps(now);
-  lastStampedByTokenHash.set(tokenHash, now);
+  if (stamped !== undefined && now - stamped < STAMP_DEBOUNCE_MS) {
+    return;
+  }
 
   try {
     const db = getGatewayDb();
@@ -172,7 +177,9 @@ export function recordActorTokenUse(
       .from(actorTokenRecords)
       .where(eq(actorTokenRecords.tokenHash, tokenHash))
       .get();
-    if (!record) return;
+    if (!record) {
+      return;
+    }
 
     db.update(actorTokenRecords)
       .set({ lastUsedAt: now })
@@ -184,10 +191,15 @@ export function recordActorTokenUse(
         ),
       )
       .run();
+
+    if (lastStampedByTokenHash.size >= MAX_TRACKED_TOKENS) {
+      evictStaleStamps(now);
+    }
+    lastStampedByTokenHash.set(tokenHash, now);
   } catch (err) {
     log.warn(
       { err: err instanceof Error ? err.message : String(err) },
-      "Actor-token last-used stamp failed — ignoring (fail-open)",
+      "Actor-token last-used stamp failed, ignoring (fail-open)",
     );
   }
 }

--- a/gateway/src/db/schema.ts
+++ b/gateway/src/db/schema.ts
@@ -273,6 +273,7 @@ export const actorTokenRecords = sqliteTable(
     status: text("status").notNull().default("active"),
     issuedAt: integer("issued_at").notNull(),
     expiresAt: integer("expires_at"),
+    lastUsedAt: integer("last_used_at"),
     createdAt: integer("created_at").notNull(),
     updatedAt: integer("updated_at").notNull(),
   },


### PR DESCRIPTION
## Summary
- Add a nullable `last_used_at` column to `actor_token_records` (plain additive column; drizzle-kit's startup push applies it non-interactively — verified against a DB seeded without the column).
- Add `recordActorTokenUse(rawToken, claims)` to `actor-token-revocation.ts`: an in-memory 5-minute debounce (bounded at 5k tracked hashes with stale-entry eviction) short-circuits the steady state, then it resolves the device from the presented token and stamps the device's `status = 'active'` row — so `derived` token traffic counts. Fail-open throughout; deliberately leaves `updated_at` alone, since that column tracks row lifecycle.
- Exported but not yet called from production code, so the tree is deployable with behavior unchanged. Covered by 7 new tests (stamp, debounce, derived-to-active routing, device isolation, non-actor no-op, unrecorded token, DB failure).

Part of plan: paired-devices-last-used.md (PR 1 of 6)