### PR TITLE
feat(web): one voice room look for custom and character avatars (LUM-3437)

### DIFF
--- a/clients/web/src/domains/chat/voice/voice-room/use-custom-avatar-field.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/use-custom-avatar-field.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * The room's custom-avatar field color: async, cached, and never allowed to
+ * throw. The color math itself is tested in `utils/avatar-image-color.test.ts`;
+ * this covers the part the room depends on, which is that it always has an
+ * answer to paint with.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+
+const sampleSpy = mock(async (_src: string): Promise<string | null> => "#3B5C8A");
+mock.module("@/utils/avatar-image-color", () => ({
+  sampleAvatarFieldHex: sampleSpy,
+}));
+
+const { useCustomAvatarFieldHex, clearCustomAvatarFieldCache } = await import(
+  "./use-custom-avatar-field"
+);
+
+function Probe({ url }: { url: string | null }) {
+  const hex = useCustomAvatarFieldHex(url);
+  return <div data-testid="field">{hex ?? "none"}</div>;
+}
+
+const field = () => screen.getByTestId("field").textContent;
+
+beforeEach(() => {
+  clearCustomAvatarFieldCache();
+  sampleSpy.mockClear();
+  sampleSpy.mockImplementation(async () => "#3B5C8A");
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("useCustomAvatarFieldHex", () => {
+  test("paints nothing until the sample lands", async () => {
+    render(<Probe url="blob:avatar-1" />);
+    // The first commit is what the room paints its first frame from, so the
+    // decode must not be on that path.
+    expect(field()).toBe("none");
+    await waitFor(() => expect(field()).toBe("#3B5C8A"));
+  });
+
+  test("skips the work entirely without a custom image", () => {
+    render(<Probe url={null} />);
+    expect(field()).toBe("none");
+    expect(sampleSpy).not.toHaveBeenCalled();
+  });
+
+  test("decodes each image once per session", async () => {
+    render(<Probe url="blob:avatar-1" />);
+    await waitFor(() => expect(field()).toBe("#3B5C8A"));
+    cleanup();
+    render(<Probe url="blob:avatar-1" />);
+    // Cached, so re-entering the room paints on the first commit rather than
+    // flashing the void again while the same image re-decodes.
+    expect(field()).toBe("#3B5C8A");
+    expect(sampleSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not retry an image it already failed to read", async () => {
+    sampleSpy.mockImplementation(async () => null);
+    render(<Probe url="blob:broken" />);
+    await waitFor(() => expect(sampleSpy).toHaveBeenCalledTimes(1));
+    cleanup();
+    render(<Probe url="blob:broken" />);
+    expect(field()).toBe("none");
+    expect(sampleSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("re-samples when the assistant's image changes", async () => {
+    render(<Probe url="blob:avatar-1" />);
+    await waitFor(() => expect(field()).toBe("#3B5C8A"));
+    sampleSpy.mockImplementation(async () => "#7A4C2F");
+    cleanup();
+    render(<Probe url="blob:avatar-2" />);
+    await waitFor(() => expect(field()).toBe("#7A4C2F"));
+  });
+});

--- a/clients/web/src/domains/chat/voice/voice-room/use-custom-avatar-field.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/use-custom-avatar-field.test.tsx
@@ -7,7 +7,7 @@
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
 
 const sampleSpy = mock(async (_src: string): Promise<string | null> => "#3B5C8A");
 mock.module("@/utils/avatar-image-color", () => ({
@@ -78,5 +78,26 @@ describe("useCustomAvatarFieldHex", () => {
     cleanup();
     render(<Probe url="blob:avatar-2" />);
     await waitFor(() => expect(field()).toBe("#7A4C2F"));
+  });
+
+  test("drops the old color the moment the image is replaced", async () => {
+    // Replacing an assistant's avatar swaps the URL under a mounted hook. The
+    // room, the composer bar and the pill would otherwise keep painting the
+    // previous avatar's color for as long as the new decode takes.
+    let resolveSecond: ((hex: string | null) => void) | undefined;
+    const { rerender } = render(<Probe url="blob:avatar-1" />);
+    await waitFor(() => expect(field()).toBe("#3B5C8A"));
+    sampleSpy.mockImplementation(
+      () =>
+        new Promise<string | null>((resolve) => {
+          resolveSecond = resolve;
+        }),
+    );
+    rerender(<Probe url="blob:avatar-2" />);
+    expect(field()).toBe("none");
+    await act(async () => {
+      resolveSecond?.("#7A4C2F");
+    });
+    expect(field()).toBe("#7A4C2F");
   });
 });

--- a/clients/web/src/domains/chat/voice/voice-room/use-custom-avatar-field.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/use-custom-avatar-field.ts
@@ -48,6 +48,10 @@ export function useCustomAvatarFieldHex(
       setHex(sampled.get(customImageUrl) ?? null);
       return;
     }
+    // Any color held here belongs to a different image, and the surfaces
+    // reading it would paint that one until this decode lands. Null is what
+    // they already handle as "no color yet".
+    setHex(null);
     let cancelled = false;
     void sampleAvatarFieldHex(customImageUrl).then((next) => {
       sampled.set(customImageUrl, next);

--- a/clients/web/src/domains/chat/voice/voice-room/use-custom-avatar-field.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/use-custom-avatar-field.ts
@@ -1,0 +1,64 @@
+/**
+ * The room-fill color for an assistant whose avatar is an uploaded image.
+ *
+ * A character avatar carries its color as data, so the room can paint itself
+ * the moment the avatar query settles. An uploaded image carries pixels, so the
+ * color has to be sampled out of it (see `utils/avatar-image-color.ts`), which
+ * is async and can fail. This hook wraps that: null until a sample resolves,
+ * null forever if it cannot, and the caller keeps its colorless fallback in
+ * both cases rather than blocking the room's first paint on a decode.
+ *
+ * Results are cached by URL for the session, including failures, so returning
+ * to a room does not re-decode the image and a broken one is not retried on
+ * every mount. The URLs are per-assistant blob URLs minted by the avatar query,
+ * so the cache key is stable for as long as the avatar is.
+ */
+
+import { useEffect, useState } from "react";
+
+import { sampleAvatarFieldHex } from "@/utils/avatar-image-color";
+
+/** Sampled field color per image URL. A cached `null` is a known failure. */
+const sampled = new Map<string, string | null>();
+
+/** Reset the session cache. Tests only. */
+export function clearCustomAvatarFieldCache(): void {
+  sampled.clear();
+}
+
+/**
+ * Field color sampled from `customImageUrl`, or null while it resolves, when
+ * there is no custom image, or when the image cannot be read.
+ */
+export function useCustomAvatarFieldHex(
+  customImageUrl: string | null,
+): string | null {
+  const [hex, setHex] = useState<string | null>(() =>
+    customImageUrl ? (sampled.get(customImageUrl) ?? null) : null,
+  );
+
+  useEffect(() => {
+    if (!customImageUrl) {
+      setHex(null);
+      return;
+    }
+    // `has` rather than a truthy check: a cached null is a resolved failure and
+    // must not queue the decode again.
+    if (sampled.has(customImageUrl)) {
+      setHex(sampled.get(customImageUrl) ?? null);
+      return;
+    }
+    let cancelled = false;
+    void sampleAvatarFieldHex(customImageUrl).then((next) => {
+      sampled.set(customImageUrl, next);
+      if (!cancelled) {
+        setHex(next);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [customImageUrl]);
+
+  return hex;
+}

--- a/clients/web/src/domains/chat/voice/voice-room/use-voice-surface-paint.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/use-voice-surface-paint.ts
@@ -10,6 +10,7 @@ import { toneForBg } from "@/utils/avatar-tone";
 import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
 
 import { VOICE_SURFACE_DARK, resolveVoiceRoomLook } from "./voice-room-eyes";
+import { useCustomAvatarFieldHex } from "./use-custom-avatar-field";
 import type { VoiceSurfacePaint } from "./voice-surface-paint";
 
 /**
@@ -19,6 +20,12 @@ import type { VoiceSurfacePaint } from "./voice-surface-paint";
  * and then again to the avatar color; holding null until the answer is real
  * lets the caller keep its normal surface and change color once.
  *
+ * An uploaded-image avatar has its color sampled off the image, which lands a
+ * beat after the query does, so that one does change color a second time: the
+ * surface holds the ambient dark until the sample arrives. Painting the room a
+ * color while the pill it minimizes into stayed dark would be the more visible
+ * wrong, and a failed sample still lands on that same dark.
+ *
  * Pass a null `assistantId` to skip the fetch entirely (a hidden surface).
  */
 export function useVoiceSurfacePaint(
@@ -26,12 +33,13 @@ export function useVoiceSurfacePaint(
 ): VoiceSurfacePaint | null {
   const { components, traits, customImageUrl, isLoading } =
     useAssistantAvatar(assistantId);
+  const customFieldHex = useCustomAvatarFieldHex(customImageUrl);
 
   if (!assistantId || isLoading) {
     return null;
   }
 
   const look = resolveVoiceRoomLook(components, traits, customImageUrl);
-  const bgHex = look?.bgHex ?? VOICE_SURFACE_DARK;
+  const bgHex = look?.bgHex ?? customFieldHex ?? VOICE_SURFACE_DARK;
   return { bgHex, tone: toneForBg(bgHex) };
 }

--- a/clients/web/src/domains/chat/voice/voice-room/voice-avatar.stories.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-avatar.stories.tsx
@@ -16,7 +16,6 @@ import { toneForBg } from "@/utils/avatar-tone";
 
 import { VoiceRoomAmbientBackground } from "./voice-room-ambient-background";
 import {
-  VoiceListeningWaves,
   type VoiceWavePalette,
   type VoiceWavePlacement,
   type VoiceWaveStyle,
@@ -24,10 +23,12 @@ import {
 import { VoiceAvatar } from "./voice-avatar";
 import type { VoiceAvatarVisual } from "./voice-avatar-state";
 import {
-  VoiceRespondingRings,
+  VOICE_ROOM_WAVE_PLACEMENT,
   VoiceRoomColorLook,
+  VoiceRoomVoiceBands,
   VoiceStateCaption,
   resolveVoiceRoomLook,
+  voiceRoomImageLook,
   type VoiceEyePlacement,
   type VoiceRespondingStyle,
 } from "./voice-room-eyes";
@@ -145,62 +146,84 @@ interface RoomSceneProps {
   amplitude: number;
   oscillate: boolean;
   waveStyle: VoiceWaveStyle;
-  palette: VoiceWavePalette;
+  /** Field color sampled from the uploaded image; `null` is the loading state. */
+  fieldHex: string | null;
   realAvatar: boolean;
   size?: number;
   minHeight?: number;
 }
 
 /**
- * A full room scene for one visual: the deep-dark void, ambient particles, the
- * top-edge listening waves (only in `listening`), the responding rings behind
- * the avatar (only in `responding`), the centered avatar, and the shared state
- * caption below it — all driven by one shared amplitude source so the avatar,
- * waves, and rings move together. Mirrors the app's void look, which shares the
- * color look's foreground chrome (top waves + rings + caption) bar the
- * full-screen color and eyes.
+ * The room an assistant with an uploaded image gets: the field color sampled
+ * out of that image, the same voice bands and caption every look draws, and the
+ * image itself in the centerpiece the eyes would otherwise hold. One amplitude
+ * source drives the avatar and the bands together.
+ *
+ * `fieldHex: null` is the other thing this scene shows: the room before the
+ * sample lands (or after it fails), which is the deep-dark ambient void with
+ * its bands riding the avatar tint, since the dark assistant ink cannot be seen
+ * against it. That is a loading state rather than a second look.
  */
 function RoomScene({
   visual,
   amplitude,
   oscillate,
   waveStyle,
-  palette,
+  fieldHex,
   realAvatar,
   size = 200,
   minHeight = 420,
 }: RoomSceneProps) {
   const getAmplitude = useAmplitudeDriver(amplitude, oscillate);
   const { ref, size: box } = useBoxSize();
+  const look = useMemo(
+    () => (fieldHex ? voiceRoomImageLook(fieldHex) : null),
+    [fieldHex],
+  );
+  const tone = look ? toneForBg(look.bgHex) : null;
+  const toneVars = {
+    "--room-fg": tone?.fg ?? "#FFFFFF",
+    "--room-fg-muted": tone?.fgMuted ?? "rgba(255,255,255,0.7)",
+    "--room-wash": tone?.wash ?? "rgba(255,255,255,0.1)",
+    "--room-border": tone?.wash ?? "rgba(255,255,255,0.15)",
+  } as Record<string, string>;
   return (
     <div
       ref={ref}
-      data-theme="dark"
-      /* No backdrop of its own: `VoiceRoomAmbientBackground` paints the room's
-         void gradient across `inset-0`, so anything set here would only ever
-         be a guess at one of its stops. */
+      data-theme={tone?.isLight ? "light" : "dark"}
+      /* No backdrop of its own: the look paints the field across `inset-0`, and
+         without one `VoiceRoomAmbientBackground` paints the void gradient
+         there, so anything set here would only ever be a guess at one of its
+         stops. */
       className="relative flex items-center justify-center overflow-hidden rounded-lg"
       style={{
         minHeight,
         ["--avatar-accent" as string]: SAMPLE_ACCENT,
+        ...toneVars,
       }}
     >
-      <VoiceRoomAmbientBackground />
-      {visual === "listening" ? (
-        <VoiceListeningWaves
+      {look && box.w > 0 ? (
+        <VoiceRoomColorLook
+          key={`${fieldHex}-${visual === "idle" ? "idle" : "live"}`}
+          look={look}
+          visual={visual}
           getAmplitude={getAmplitude}
           waveStyle={waveStyle}
-          palette={palette}
-          // Same top edge as the color look — positional parity.
-          placement="top"
+          viewport={box}
         />
-      ) : null}
-      {/* Responding: the same concentric rings the color look radiates from
-          behind the eyes, here behind the centered avatar. Sized against the
-          story box (not the window) so they match this frame. */}
-      {visual === "responding" && box.w > 0 ? (
-        <VoiceRespondingRings getAmplitude={getAmplitude} viewport={box} />
-      ) : null}
+      ) : (
+        <>
+          <VoiceRoomAmbientBackground />
+          <VoiceRoomVoiceBands
+            visual={visual}
+            getAmplitude={getAmplitude}
+            waveStyle={waveStyle}
+            ink="accent"
+            viewport={box.w > 0 ? box : undefined}
+          />
+          <VoiceStateCaption visual={visual} />
+        </>
+      )}
       <div className="relative z-0 flex items-center justify-center">
         <VoiceAvatar
           assistantId={realAvatar ? SAMPLE_ASSISTANT_ID : null}
@@ -209,9 +232,6 @@ function RoomScene({
           size={size}
         />
       </div>
-      {/* Shared caption in the room's lower text zone, matching the app's void
-          look — the same anchor the color look uses. */}
-      <VoiceStateCaption visual={visual} />
     </div>
   );
 }
@@ -355,9 +375,12 @@ const colorArgs = {
   oscillate: true,
   waveStyle: "fill" as VoiceWaveStyle,
   eyePlacement: "center" as VoiceEyePlacement,
-  wavePlacement: "top" as VoiceWavePlacement,
+  // The shipped room: both bands from the floor, the assistant answering in
+  // the opposite ink. The knobs stay so the alternatives can still be compared
+  // against it, but the default has to be what users actually get.
+  wavePlacement: VOICE_ROOM_WAVE_PLACEMENT,
   wavePalette: "tone" as VoiceWavePalette,
-  respondingStyle: "rings" as VoiceRespondingStyle,
+  respondingStyle: "waves" as VoiceRespondingStyle,
   colorId: SAMPLE_COLOR_ID,
   eyeStyle: "grumpy",
   bodyShape: "blob",
@@ -425,7 +448,7 @@ const meta: Meta<typeof ColorLookScene> = {
 
 export default meta;
 type Story = StoryObj<typeof ColorLookScene>;
-type VoidStory = StoryObj<typeof RoomScene>;
+type RoomStory = StoryObj<typeof RoomScene>;
 
 /**
  * Playground for the room's color-with-eyes look — every knob live. Change any
@@ -441,11 +464,11 @@ export const Playground: Story = {};
  * centered throughout and express the state by size (a smooth scale tween);
  * a soft caption names the beat below them:
  * - `idle` — eyes centered at a resting size, no treatment or caption.
- * - `listening` — eyes wide ("all ears"), the waveform sweeping in from the top
- *   edge, "Listening" below.
+ * - `listening`: eyes wide ("all ears"), the band rising from the floor,
+ *   "Listening" below.
  * - `thinking` — eyes small, the dot triad just above them, "Thinking" below.
- * - `responding` — eyes medium, the responding treatment radiating outward,
- *   "Speaking" below.
+ * - `responding`: eyes medium, the assistant's band answering from that same
+ *   floor in the opposite ink, "Speaking" below.
  * - `reconnecting` — eyes at the resting size but dimmed.
  *
  * Scrub `visual` in the Playground to watch the size + caption cross-fade.
@@ -462,7 +485,7 @@ export const States: Story = {
             {...args}
             visual={visual}
             eyePlacement="center"
-            wavePlacement="top"
+            wavePlacement={VOICE_ROOM_WAVE_PLACEMENT}
             // Tall enough that the lower zone's caption clears the eyes in a
             // grid cell — the zone anchors off the frame, not the centerpiece.
             minHeight={320}
@@ -521,34 +544,37 @@ export const RespondingSketches: Story = {
 };
 
 // ---------------------------------------------------------------------------
-// Void look — the deep-dark ambient fallback for custom-image / no-character
-// avatars (kept for reference; the color look above is the default).
+// Custom-image avatars: the same room, its field color sampled off the upload
+// and the image standing where the eyes would.
 // ---------------------------------------------------------------------------
 
-const voidArgs = {
+/** A plausible sample: pinned to the same band `normalizeFieldHex` produces. */
+const SAMPLE_FIELD_HEX = "#3B5C8A";
+
+const customArgs = {
   visual: "listening" as VoiceAvatarVisual,
   amplitude: 0.5,
   oscillate: true,
   waveStyle: "fill" as VoiceWaveStyle,
-  palette: "accent" as VoiceWavePalette,
+  fieldHex: SAMPLE_FIELD_HEX as string | null,
   realAvatar: true,
   size: 200,
 };
 
-const voidArgTypes = {
+const customArgTypes = {
   ...sharedArgTypes,
-  palette: {
-    options: ["aurora", "accent", "tone"] satisfies VoiceWavePalette[],
-    control: { type: "inline-radio" as const },
+  fieldHex: {
+    options: [SAMPLE_FIELD_HEX, "#8A5A3B", "#6B6B6B", null],
+    control: { type: "select" as const },
     description:
-      "Fixed cyan→indigo, tinted from the avatar accent, or room-fg tone.",
+      "Field color sampled off the upload; null is the room before it lands.",
   },
   realAvatar: {
     control: { type: "boolean" as const },
     description: "Real bundled character vs the “V” fallback.",
   },
   size: { control: { type: "range" as const, min: 80, max: 320, step: 4 } },
-  // Color-look-only knobs — irrelevant to the void look.
+  // Character-only knobs: there are no eyes or traits to vary here.
   eyePlacement: { table: { disable: true } },
   wavePlacement: { table: { disable: true } },
   wavePalette: { table: { disable: true } },
@@ -559,19 +585,26 @@ const voidArgTypes = {
   replay: { table: { disable: true } },
 };
 
-/** Void-look playground — the centered avatar, ambient void, and top waves. */
-export const VoidLookPlayground: VoidStory = {
-  name: "Void Look — Playground",
+/**
+ * Custom-image playground: the sampled field, the shared bands, and the
+ * uploaded avatar in the middle. Set `fieldHex` to null to see the room while
+ * the sample is still decoding.
+ */
+export const CustomImagePlayground: RoomStory = {
+  name: "Custom Image — Playground",
   render: (args) => <RoomScene {...args} />,
-  args: voidArgs,
-  argTypes: voidArgTypes,
+  args: customArgs,
+  argTypes: customArgTypes,
 };
 
-/** Every state in the void look, all driven by the same simulated-speech envelope. */
-export const VoidLookStates: VoidStory = {
-  name: "Void Look — States",
-  args: voidArgs,
-  argTypes: voidArgTypes,
+/**
+ * Every state for a custom-image avatar. Compare against "States" above: the
+ * bands and the caption are the same in both, and only the centerpiece differs.
+ */
+export const CustomImageStates: RoomStory = {
+  name: "Custom Image — States",
+  args: customArgs,
+  argTypes: customArgTypes,
   render: (args) => (
     <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
       {VISUALS.map((visual) => (

--- a/clients/web/src/domains/chat/voice/voice-room/voice-avatar.stories.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-avatar.stories.tsx
@@ -13,6 +13,7 @@ import { avatarQueryKey } from "@/hooks/use-assistant-avatar";
 import type { CharacterTraits } from "@/types/avatar";
 
 import { toneForBg } from "@/utils/avatar-tone";
+import { normalizeFieldHex } from "@/utils/avatar-image-color";
 
 import { VoiceRoomAmbientBackground } from "./voice-room-ambient-background";
 import {
@@ -548,8 +549,11 @@ export const RespondingSketches: Story = {
 // and the image standing where the eyes would.
 // ---------------------------------------------------------------------------
 
-/** A plausible sample: pinned to the same band `normalizeFieldHex` produces. */
-const SAMPLE_FIELD_HEX = "#3B5C8A";
+/** Plausible samples, run through the same normalization the room applies, so
+ *  the knob shows colors a real upload can actually produce. */
+const SAMPLE_FIELD_HEX = normalizeFieldHex("#3B5C8A");
+const SAMPLE_FIELD_WARM = normalizeFieldHex("#C2410C");
+const SAMPLE_FIELD_GRAY = normalizeFieldHex("#8A8A8A");
 
 const customArgs = {
   visual: "listening" as VoiceAvatarVisual,
@@ -564,7 +568,7 @@ const customArgs = {
 const customArgTypes = {
   ...sharedArgTypes,
   fieldHex: {
-    options: [SAMPLE_FIELD_HEX, "#8A5A3B", "#6B6B6B", null],
+    options: [SAMPLE_FIELD_HEX, SAMPLE_FIELD_WARM, SAMPLE_FIELD_GRAY, null],
     control: { type: "select" as const },
     description:
       "Field color sampled off the upload; null is the room before it lands.",

--- a/clients/web/src/domains/chat/voice/voice-room/voice-avatar.stories.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-avatar.stories.tsx
@@ -591,7 +591,7 @@ const customArgTypes = {
  * the sample is still decoding.
  */
 export const CustomImagePlayground: RoomStory = {
-  name: "Custom Image — Playground",
+  name: "Custom Image: Playground",
   render: (args) => <RoomScene {...args} />,
   args: customArgs,
   argTypes: customArgTypes,
@@ -602,7 +602,7 @@ export const CustomImagePlayground: RoomStory = {
  * bands and the caption are the same in both, and only the centerpiece differs.
  */
 export const CustomImageStates: RoomStory = {
-  name: "Custom Image — States",
+  name: "Custom Image: States",
   args: customArgs,
   argTypes: customArgTypes,
   render: (args) => (

--- a/clients/web/src/domains/chat/voice/voice-room/voice-reactive-waves.stories.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-reactive-waves.stories.tsx
@@ -45,6 +45,7 @@ import { VoiceComposerBar } from "@/domains/chat/components/chat-composer/voice-
 import type { LiveVoiceSessionState } from "@/domains/chat/voice/live-voice/live-voice-store";
 
 import {
+  VOICE_ROOM_WAVE_PLACEMENT,
   VoiceRoomColorLook,
   resolveVoiceRoomLook,
   type VoiceCaptionEmphasis,
@@ -330,7 +331,7 @@ function RoomFrame({
           // Both voices sit on the floor and are told apart by ink instead
           // (see `BAND_VOICE`); `wavePlacement` still moves the listening band
           // to the ceiling if the split-by-position version is wanted back.
-          wavePlacement="bottom"
+          wavePlacement={VOICE_ROOM_WAVE_PLACEMENT}
           respondingStyle={args.respondingStyle}
           captionEmphasis={args.captionEmphasis}
           eyePlacement="center"

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-eyes.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-eyes.tsx
@@ -22,24 +22,28 @@
  * Per-state treatments (driven by `visual`, cross-faded so nothing pops): the
  * eyes stay centered throughout and express the state by *size* — a smooth
  * scale tween, no vertical travel. While the user speaks (`listening`) the
- * mic-amplitude waveform sweeps in from the top edge (clear of the centered
- * eyes) and the eyes open wide (large — all ears). When the turn passes to the
+ * mic-amplitude band rises from the room's floor (clear of the centered eyes)
+ * and the eyes open wide (large — all ears). When the turn passes to the
  * assistant, `thinking` shrinks them small and a quiet dot triad works away
  * just above them, then `responding` settles them to a medium size while the
- * assistant's voice radiates outward from behind them (see
- * {@link VoiceRespondingStyle}). A soft state caption ("Listening" / "Thinking"
- * / "Speaking") fades in down in the room's lower text zone (see
- * `voice-room-layout.ts`), naming the beat from the same baseline the
- * assistant's own speech would occupy. `reconnecting` fades the eyes back —
- * presence dimmed while away.
+ * assistant's own band answers from that same floor in the opposite ink (see
+ * {@link VoiceRoomVoiceBands} and {@link VoiceRespondingStyle}). A soft state
+ * caption ("Listening" / "Thinking" / "Speaking") fades in down in the room's
+ * lower text zone (see `voice-room-layout.ts`), naming the beat from the same
+ * baseline the assistant's own speech would occupy. `reconnecting` fades the
+ * eyes back — presence dimmed while away.
  *
  * Geometry and timing mirror onboarding's `IntroductionScreen` +
  * `OnboardingPeekingEyes`. Traits default like `ChatAvatar` does (first
  * component of each type), so a default-character assistant gets the same
- * color and eyes the user sees in its small avatar. Custom-image /
- * no-character avatars resolve to `null` and the room falls back to its
- * ambient-void look — what that look should become is an open design
- * question.
+ * color and eyes the user sees in its small avatar.
+ *
+ * An assistant with a custom uploaded image has no eyes and no body to grow,
+ * but it still gets this look: the room samples a field color out of the image
+ * (see `use-custom-avatar-field.ts`) and passes a look whose `art` is null, so
+ * the color field, the voice bands and the caption are all shared and the
+ * uploaded avatar takes the centerpiece the eyes would have held. Avatar type
+ * decides what stands in the middle of the room and nothing else.
  *
  * Decorative: `aria-hidden`, `pointer-events-none`, reduced-motion safe. It
  * resolves to the presented entrance (no grow), and drops the parallax; the
@@ -224,11 +228,25 @@ export interface VoiceRoomEyeArt {
 export interface VoiceRoomLook {
   /** The avatar color that fills the room. */
   bgHex: string;
-  /** The avatar's eye art, sized/framed by its union bounding box. */
-  art: VoiceRoomEyeArt;
+  /**
+   * The avatar's eye art, sized/framed by its union bounding box. Null for an
+   * uploaded-image avatar, which has no eyes: the look then paints the field
+   * and the bands, and the room's centered avatar is the centerpiece.
+   */
+  art: VoiceRoomEyeArt | null;
   /** The avatar's body shape, grown to cover the screen on entrance. */
   body: { svgPath: string; viewBox: { width: number; height: number } } | null;
 }
+
+/**
+ * The edge both voice bands rise from, for every look.
+ *
+ * Single-sourced because the two looks drifted apart on exactly this value once
+ * already: the custom-avatar room raised its band from the ceiling while the
+ * character room raised it from the floor, so the same session read as two
+ * different products depending on which avatar the assistant wore.
+ */
+export const VOICE_ROOM_WAVE_PLACEMENT: VoiceWavePlacement = "bottom";
 
 /**
  * Resolve the room's color-with-eyes look from the session assistant's avatar
@@ -286,6 +304,16 @@ export function resolveVoiceRoomLook(
 }
 
 /**
+ * The same look for an assistant whose avatar is an uploaded image: the field
+ * color sampled out of that image, with no eyes and no body to grow. The room
+ * keeps drawing its centered avatar over this, so the image is the centerpiece
+ * the eyes would otherwise be.
+ */
+export function voiceRoomImageLook(bgHex: string): VoiceRoomLook {
+  return { bgHex, art: null, body: null };
+}
+
+/**
  * The on-screen height of the eyes in a `w`×`h` room — capped at
  * `EYE_TARGET_HEIGHT` of the smaller dimension, clamped so the width stays
  * within `EYE_MAX_WIDTH`, and finally bounded by the absolute
@@ -314,7 +342,7 @@ export function VoiceRoomColorLook({
   getResponseAmplitude,
   respondingStyle = "waves",
   eyePlacement = "center",
-  wavePlacement = "bottom",
+  wavePlacement = VOICE_ROOM_WAVE_PLACEMENT,
   wavePalette = "tone",
   waveStyle = "fill",
   showStateCaption = true,
@@ -374,9 +402,8 @@ export function VoiceRoomColorLook({
   // size (`EYE_STATE_SCALE`): wide while the user speaks, small while thinking,
   // medium while speaking. The centered eyes are framed at the full (listening)
   // size; `centeredEyeTop` is that frame's top edge.
-  const showWaves = visual === "listening";
   const sizeScale = EYE_STATE_SCALE[visual];
-  const eyeH = eyeDisplayHeight(look.art, w, h);
+  const eyeH = look.art ? eyeDisplayHeight(look.art, w, h) : 0;
   const centeredEyeTop = (h - eyeH) / 2;
   // Spatial model (shared with both text zones — see `voice-room-layout.ts`):
   // above the eyes is the user's space (the user transcript), below is the
@@ -451,38 +478,25 @@ export function VoiceRoomColorLook({
         </motion.svg>
       ) : null}
 
-      {/* Per-state treatment layer — the listening waves, the thinking dots,
-          and the responding treatment cross-fade as the session moves between
-          states (only one is live at a time), so nothing pops in or vanishes
-          hard. The listening→thinking hand-off in particular reads as the waves
-          dissolving out and the dots dissolving in while the eyes ride up. */}
-      <AnimatePresence>
-        {/* The user's voice, gathering behind the eyes while they speak. */}
-        {showWaves && getAmplitude ? (
-          <motion.div
-            key="listening"
-            className="pointer-events-none absolute inset-0"
-            initial={reduce ? false : { opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            transition={{ duration: reduce ? 0 : 0.3 }}
-          >
-            <WaveBand
-              engine={waveEngine}
-              getAmplitude={getAmplitude}
-              waveStyle={waveStyle}
-              palette={wavePalette}
-              placement={wavePlacement}
-              color={BAND_VOICE.listening.color}
-              peakOpacity={BAND_VOICE.listening.peakOpacity}
-              opacityKnee={BAND_VOICE.listening.opacityKnee}
-            />
-          </motion.div>
-        ) : null}
+      <VoiceRoomVoiceBands
+        visual={visual}
+        engine={waveEngine}
+        getAmplitude={getAmplitude}
+        getResponseAmplitude={getResponseAmplitude}
+        waveStyle={waveStyle}
+        palette={wavePalette}
+        placement={wavePlacement}
+        respondingStyle={respondingStyle}
+        viewport={{ w, h }}
+      />
 
-        {/* Thinking: the eyes have ridden back up to center; a quiet dot triad
-            works away just above them. */}
-        {visual === "thinking" ? (
+      {/* Thinking is the one beat the bands are silent for, and the dots that
+          fill it are placed against the eyes, so they stay with the eyes rather
+          than moving into the shared bands. Its own AnimatePresence: the fade
+          is per-layer, so the hand-off still reads as the band dissolving out
+          while the dots dissolve in. */}
+      <AnimatePresence>
+        {visual === "thinking" && look.art ? (
           <motion.div
             key="thinking"
             className="pointer-events-none absolute inset-0"
@@ -497,54 +511,31 @@ export function VoiceRoomColorLook({
             />
           </motion.div>
         ) : null}
-
-        {/* Responding: the eyes stay centered (engaged, addressing the user)
-            and the assistant's voice radiates outward from behind them, driven
-            by the TTS-output amplitude — energy going out, the mirror of
-            listening's incoming waves. */}
-        {visual === "responding" ? (
-          <motion.div
-            key="responding"
-            className="pointer-events-none absolute inset-0"
-            initial={reduce ? false : { opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            transition={{ duration: reduce ? 0 : 0.3 }}
-          >
-            <VoiceRespondingTreatment
-              style={respondingStyle}
-              engine={waveEngine}
-              getAmplitude={getResponseAmplitude ?? getAmplitude}
-              waveStyle={waveStyle}
-              wavePlacement={wavePlacement}
-              wavePalette={wavePalette}
-              viewport={{ w, h }}
-            />
-          </motion.div>
-        ) : null}
       </AnimatePresence>
 
-      <VoiceRoomEyes
-        art={look.art}
-        placement={eyePlacement}
-        viewport={{ w, h }}
-        entranceOrigin={origin}
-        entrance={entrance}
-        // The centered eyes never move — they express the state by size.
-        sizeScale={sizeScale}
-        // Reconnecting: fade the eyes back — presence dimmed while away.
-        dimmed={visual === "reconnecting"}
-        // Audio reaction on top of the size tween: the eyes widen with the
-        // user's mic while listening and pulse with the assistant's own voice
-        // while responding, so they stay alive through a turn instead of
-        // holding one pose for its whole duration.
-        eyeReaction={EYE_REACTION[visual]}
-        getAmplitude={
-          visual === "responding"
-            ? (getResponseAmplitude ?? getAmplitude)
-            : getAmplitude
-        }
-      />
+      {look.art ? (
+        <VoiceRoomEyes
+          art={look.art}
+          placement={eyePlacement}
+          viewport={{ w, h }}
+          entranceOrigin={origin}
+          entrance={entrance}
+          // The centered eyes never move — they express the state by size.
+          sizeScale={sizeScale}
+          // Reconnecting: fade the eyes back — presence dimmed while away.
+          dimmed={visual === "reconnecting"}
+          // Audio reaction on top of the size tween: the eyes widen with the
+          // user's mic while listening and pulse with the assistant's own voice
+          // while responding, so they stay alive through a turn instead of
+          // holding one pose for its whole duration.
+          eyeReaction={EYE_REACTION[visual]}
+          getAmplitude={
+            visual === "responding"
+              ? (getResponseAmplitude ?? getAmplitude)
+              : getAmplitude
+          }
+        />
+      ) : null}
 
       {/* State caption in the room's lower zone (unless the live captions are
           on — the assistant transcript occupies that zone instead). */}
@@ -552,6 +543,120 @@ export function VoiceRoomColorLook({
         <VoiceStateCaption visual={visual} emphasis={captionEmphasis} />
       ) : null}
     </>
+  );
+}
+
+/**
+ * Which ink the bands are drawn in.
+ *
+ * `voice` is the room's real vocabulary: both voices rise from the same edge
+ * and are told apart by ink alone, a pale sheet for the user and a dark one for
+ * the assistant ({@link BAND_VOICE}). It needs a mid-tone color field behind it
+ * to read, which every resolved avatar now provides.
+ *
+ * `accent` is the fallback for the one surface that has no field: the room
+ * while the avatar is still unresolved, painted near-black, where dark ink
+ * would be invisible. Both voices ride the avatar tint there and are told apart
+ * by the centerpiece rather than by the band.
+ */
+export type VoiceBandInk = "voice" | "accent";
+
+/**
+ * The room's two voice bands: the user's mic while `listening`, the
+ * assistant's TTS while `responding`, cross-fading as the turn passes between
+ * them.
+ *
+ * Shared by every look, which is the entire point of it being a component. The
+ * bands are the room's account of whose turn it is, so a room that draws them
+ * differently is a different product, and they used to: the character look
+ * raised both from the floor while the custom-avatar look raised the user's
+ * from the ceiling and answered with concentric rings.
+ */
+export function VoiceRoomVoiceBands({
+  visual,
+  engine = "mesh",
+  getAmplitude,
+  getResponseAmplitude,
+  waveStyle = "fill",
+  palette = "tone",
+  placement = VOICE_ROOM_WAVE_PLACEMENT,
+  respondingStyle = "waves",
+  ink = "voice",
+  viewport,
+}: {
+  visual: VoiceAvatarVisual;
+  engine?: VoiceWaveEngine;
+  /** Mic (input) amplitude source (0-1), drawn as the listening band. */
+  getAmplitude?: () => number;
+  /** TTS (output) amplitude source (0-1), drawn as the responding band. Falls back to
+   *  {@link getAmplitude} when omitted. */
+  getResponseAmplitude?: () => number;
+  waveStyle?: VoiceWaveStyle;
+  palette?: VoiceWavePalette;
+  placement?: VoiceWavePlacement;
+  /** Sketch knob for the responding beat. See {@link VoiceRespondingStyle}. */
+  respondingStyle?: VoiceRespondingStyle;
+  /** See {@link VoiceBandInk}. */
+  ink?: VoiceBandInk;
+  /** The box to size against; falls back to the window when omitted. */
+  viewport?: { w: number; h: number };
+}) {
+  const reduce = useReducedMotion();
+  // Only subscribe to the window when the caller has no box of its own: every
+  // in-app caller measures and passes one.
+  const measured = useLayoutViewportSize(!viewport);
+  // The opacity shaping is the band's own dynamics and holds either way; only
+  // the explicit ink is dropped, which hands the color back to the palette.
+  const voiceInk = ink === "voice";
+
+  return (
+    <AnimatePresence>
+      {/* The user's voice, gathering at the room's edge while they speak. */}
+      {visual === "listening" && getAmplitude ? (
+        <motion.div
+          key="listening"
+          className="pointer-events-none absolute inset-0"
+          initial={reduce ? false : { opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: reduce ? 0 : 0.3 }}
+        >
+          <WaveBand
+            engine={engine}
+            getAmplitude={getAmplitude}
+            waveStyle={waveStyle}
+            palette={voiceInk ? palette : "accent"}
+            placement={placement}
+            color={voiceInk ? BAND_VOICE.listening.color : undefined}
+            peakOpacity={BAND_VOICE.listening.peakOpacity}
+            opacityKnee={BAND_VOICE.listening.opacityKnee}
+          />
+        </motion.div>
+      ) : null}
+
+      {/* The assistant answering, from the same edge in the opposite ink. */}
+      {visual === "responding" ? (
+        <motion.div
+          key="responding"
+          className="pointer-events-none absolute inset-0"
+          initial={reduce ? false : { opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: reduce ? 0 : 0.3 }}
+        >
+          <VoiceRespondingTreatment
+            style={respondingStyle}
+            engine={engine}
+            getAmplitude={getResponseAmplitude ?? getAmplitude}
+            waveStyle={waveStyle}
+            wavePlacement={placement}
+            wavePalette={voiceInk ? palette : "accent"}
+            ink={ink}
+            viewport={viewport ?? measured}
+          />
+        </motion.div>
+      ) : null}
+    </AnimatePresence>
   );
 }
 
@@ -810,6 +915,7 @@ function VoiceRespondingTreatment({
   waveStyle,
   wavePlacement,
   wavePalette,
+  ink = "voice",
   viewport,
 }: {
   style: VoiceRespondingStyle;
@@ -818,6 +924,8 @@ function VoiceRespondingTreatment({
   waveStyle: VoiceWaveStyle;
   wavePlacement: VoiceWavePlacement;
   wavePalette: VoiceWavePalette;
+  /** See {@link VoiceBandInk}. */
+  ink?: VoiceBandInk;
   viewport: { w: number; h: number };
 }) {
   const ampRef = useRespondingAmp(getAmplitude);
@@ -827,19 +935,18 @@ function VoiceRespondingTreatment({
   const M = Math.min(viewport.w, viewport.h);
 
   if (style === "waves") {
-    // The mirror of listening: the same band, the same engine, anchored to the
-    // floor instead of the ceiling and fed the TTS output rather than the mic.
+    // The mirror of listening: the same band, the same engine, the same edge,
+    // fed the TTS output rather than the mic and drawn in the opposite ink.
     // Nothing about it is a different visual language — that is the point. The
-    // room says who is speaking by *where* the energy is, not by switching
-    // metaphors mid-turn.
+    // room says who is speaking by the ink, not by switching metaphors mid-turn.
     return getAmplitude ? (
       <WaveBand
         engine={engine}
         getAmplitude={getAmplitude}
         waveStyle={waveStyle}
         palette={wavePalette}
-        placement="bottom"
-        color={BAND_VOICE.responding.color}
+        placement={wavePlacement}
+        color={ink === "voice" ? BAND_VOICE.responding.color : undefined}
         peakOpacity={BAND_VOICE.responding.peakOpacity}
         opacityKnee={BAND_VOICE.responding.opacityKnee}
       />
@@ -899,8 +1006,10 @@ function VoiceRespondingTreatment({
     );
   }
 
-  // `rings` — concentric rings expanding outward from the eyes; overall
-  // presence scales with the TTS amplitude.
+  // `rings`: concentric rings expanding outward from the room's center;
+  // overall presence scales with the TTS amplitude. A sketch alternative to the
+  // shipped band: the room drew this behind a custom avatar until both looks
+  // settled on the band, and it is kept for comparison in Storybook.
   return (
     <div
       ref={ampRef}
@@ -938,39 +1047,6 @@ function VoiceRespondingTreatment({
         />
       ))}
     </div>
-  );
-}
-
-/**
- * The `rings` responding treatment as a self-contained layer: the concentric
- * rings radiating outward from the room's center on the TTS-output amplitude.
- * Pass `viewport` to size against the room's own box (the room passes its
- * measured panel; Storybook its frame); omitted, it falls back to the live
- * window. Exported for the void look, which renders it behind the centered
- * avatar so a custom avatar emits the same rings the eyes do in the color look.
- */
-export function VoiceRespondingRings({
-  getAmplitude,
-  viewport,
-}: {
-  /** TTS (output) amplitude source (0–1) — drives the rings' presence. */
-  getAmplitude?: () => number;
-  /** The room box to size against; omitted, falls back to the window. */
-  viewport?: { w: number; h: number };
-}) {
-  const measured = useLayoutViewportSize();
-  return (
-    <VoiceRespondingTreatment
-      style="rings"
-      getAmplitude={getAmplitude}
-      // engine/waveStyle/wavePlacement/wavePalette are only read by the band
-      // styles (`waves`, `waveform`); inert for the rings.
-      engine="reactive"
-      waveStyle="fill"
-      wavePlacement="top"
-      wavePalette="tone"
-      viewport={viewport ?? measured}
-    />
   );
 }
 

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room-eyes.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room-eyes.tsx
@@ -23,7 +23,7 @@
  * eyes stay centered throughout and express the state by *size* — a smooth
  * scale tween, no vertical travel. While the user speaks (`listening`) the
  * mic-amplitude band rises from the room's floor (clear of the centered eyes)
- * and the eyes open wide (large — all ears). When the turn passes to the
+ * and the eyes open wide (large, all ears). When the turn passes to the
  * assistant, `thinking` shrinks them small and a quiet dot triad works away
  * just above them, then `responding` settles them to a medium size while the
  * assistant's own band answers from that same floor in the opposite ink (see
@@ -31,7 +31,7 @@
  * caption ("Listening" / "Thinking" / "Speaking") fades in down in the room's
  * lower text zone (see `voice-room-layout.ts`), naming the beat from the same
  * baseline the assistant's own speech would occupy. `reconnecting` fades the
- * eyes back — presence dimmed while away.
+ * eyes back: presence dimmed while away.
  *
  * Geometry and timing mirror onboarding's `IntroductionScreen` +
  * `OnboardingPeekingEyes`. Traits default like `ChatAvatar` does (first
@@ -239,12 +239,8 @@ export interface VoiceRoomLook {
 }
 
 /**
- * The edge both voice bands rise from, for every look.
- *
- * Single-sourced because the two looks drifted apart on exactly this value once
- * already: the custom-avatar room raised its band from the ceiling while the
- * character room raised it from the floor, so the same session read as two
- * different products depending on which avatar the assistant wore.
+ * The edge both voice bands rise from, in every look. One constant so no
+ * surface can put a session's two halves on different edges.
  */
 export const VOICE_ROOM_WAVE_PLACEMENT: VoiceWavePlacement = "bottom";
 
@@ -491,10 +487,10 @@ export function VoiceRoomColorLook({
       />
 
       {/* Thinking is the one beat the bands are silent for, and the dots that
-          fill it are placed against the eyes, so they stay with the eyes rather
-          than moving into the shared bands. Its own AnimatePresence: the fade
-          is per-layer, so the hand-off still reads as the band dissolving out
-          while the dots dissolve in. */}
+          fill it are placed against the eyes, so they belong to the eyes rather
+          than to the shared bands. Their own AnimatePresence: the fade is
+          per-layer, so the hand-off reads as the band dissolving out while the
+          dots dissolve in. */}
       <AnimatePresence>
         {visual === "thinking" && look.art ? (
           <motion.div
@@ -520,9 +516,9 @@ export function VoiceRoomColorLook({
           viewport={{ w, h }}
           entranceOrigin={origin}
           entrance={entrance}
-          // The centered eyes never move — they express the state by size.
+          // The centered eyes never move: they express the state by size.
           sizeScale={sizeScale}
-          // Reconnecting: fade the eyes back — presence dimmed while away.
+          // Reconnecting: fade the eyes back, presence dimmed while away.
           dimmed={visual === "reconnecting"}
           // Audio reaction on top of the size tween: the eyes widen with the
           // user's mic while listening and pulse with the assistant's own voice
@@ -549,15 +545,14 @@ export function VoiceRoomColorLook({
 /**
  * Which ink the bands are drawn in.
  *
- * `voice` is the room's real vocabulary: both voices rise from the same edge
- * and are told apart by ink alone, a pale sheet for the user and a dark one for
- * the assistant ({@link BAND_VOICE}). It needs a mid-tone color field behind it
- * to read, which every resolved avatar now provides.
+ * `voice` is the room's vocabulary: both voices rise from the same edge and are
+ * told apart by ink alone, a pale sheet for the user and a dark one for the
+ * assistant ({@link BAND_VOICE}). It needs the mid-tone color field a resolved
+ * avatar paints to read against.
  *
- * `accent` is the fallback for the one surface that has no field: the room
- * while the avatar is still unresolved, painted near-black, where dark ink
- * would be invisible. Both voices ride the avatar tint there and are told apart
- * by the centerpiece rather than by the band.
+ * `accent` serves the one surface with no field: the room while the avatar is
+ * unresolved, painted near-black, where dark ink is invisible. Both voices ride
+ * the avatar tint there and are told apart by the centerpiece instead.
  */
 export type VoiceBandInk = "voice" | "accent";
 
@@ -566,11 +561,9 @@ export type VoiceBandInk = "voice" | "accent";
  * assistant's TTS while `responding`, cross-fading as the turn passes between
  * them.
  *
- * Shared by every look, which is the entire point of it being a component. The
- * bands are the room's account of whose turn it is, so a room that draws them
- * differently is a different product, and they used to: the character look
- * raised both from the floor while the custom-avatar look raised the user's
- * from the ceiling and answered with concentric rings.
+ * Every look draws these, which is the point of them being one component: the
+ * bands are the room's account of whose turn it is, and a room that drew them
+ * differently would read as a different product.
  */
 export function VoiceRoomVoiceBands({
   visual,
@@ -1008,8 +1001,7 @@ function VoiceRespondingTreatment({
 
   // `rings`: concentric rings expanding outward from the room's center;
   // overall presence scales with the TTS amplitude. A sketch alternative to the
-  // shipped band: the room drew this behind a custom avatar until both looks
-  // settled on the band, and it is kept for comparison in Storybook.
+  // shipped band, reachable only from Storybook.
   return (
     <div
       ref={ampRef}

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
@@ -137,6 +137,16 @@ mock.module("@/hooks/use-assistant-avatar", () => ({
   avatarQueryKey: (id: string) => ["assistantAvatar", id],
 }));
 
+// The field color a custom-image avatar paints the room with is sampled off a
+// canvas, which no test environment decodes. Stubbed with a mutable value so
+// the three states the room actually branches on are all reachable: a resolved
+// sample, a still-pending one, and an image that could not be read.
+let mockCustomFieldHex: string | null = null;
+mock.module("@/domains/chat/voice/voice-room/use-custom-avatar-field", () => ({
+  useCustomAvatarFieldHex: () => mockCustomFieldHex,
+  clearCustomAvatarFieldCache: () => {},
+}));
+
 /** Minimal character components: one body/eye/color of each. */
 const CHARACTER_COMPONENTS = {
   bodyShapes: [
@@ -154,6 +164,23 @@ const CHARACTER_COMPONENTS = {
   ],
   colors: [{ id: "green", hex: "#4C9B50" }],
 };
+
+/**
+ * Point the room at one kind of avatar. `character` brings traits, eyes and a
+ * palette color; `custom` is an uploaded image, whose field color is sampled
+ * (stubbed above) and whose room therefore has no eyes to draw.
+ */
+function seedAvatar(kind: "character" | "custom"): void {
+  mockAvatarData = {
+    components: CHARACTER_COMPONENTS,
+    traits:
+      kind === "character"
+        ? { bodyShape: "sprout", eyeStyle: "curious", color: "green" }
+        : null,
+    customImageUrl: kind === "character" ? null : "blob:custom-avatar",
+  };
+  mockCustomFieldHex = kind === "custom" ? "#3B5C8A" : null;
+}
 
 // Stub the OAuth connect surface (pulls the managed-oauth + generated-SDK
 // graph) so the room-slot tests assert only the wiring: that the room renders
@@ -275,6 +302,7 @@ beforeEach(() => {
   mockMainView = "chat";
   mockIsMobile = false;
   mockAvatarData = { components: null, traits: null, customImageUrl: null };
+  mockCustomFieldHex = null;
   controls.stop.mockClear();
   controls.release.mockClear();
   controls.interrupt.mockClear();
@@ -844,25 +872,32 @@ describe("VoiceRoom: mobile sheet", () => {
   });
 });
 
-describe("VoiceRoom — listening waves", () => {
+describe("VoiceRoom — voice bands (avatar still unresolved)", () => {
   const waves = () => screen.queryByTestId("listening-waves");
 
-  test("mounts the listening waves while listening (energy coming in)", () => {
+  test("mounts the listening band while listening (energy coming in)", () => {
     startOwnedSession("listening");
     render(<VoiceRoom />);
     expect(roomDialog()).not.toBeNull();
     expect(waves()).not.toBeNull();
   });
 
-  test("hides the waves while responding — the avatar emanates instead", () => {
+  test("answers with a band while responding, same as every other look", () => {
     startOwnedSession("speaking");
     render(<VoiceRoom />);
-    // Room is still open (an active phase), but there are no incoming waves.
     expect(roomDialog()).not.toBeNull();
-    expect(waves()).toBeNull();
+    expect(waves()).not.toBeNull();
   });
 
-  test("hides the waves while thinking", () => {
+  test("rides the avatar tint here, not the two-ink vocabulary", () => {
+    // No field has been painted yet, so there is nothing for the dark
+    // assistant ink to be seen against; both voices take the accent instead.
+    startOwnedSession("speaking");
+    render(<VoiceRoom />);
+    expect(waves()?.dataset.color).toBeUndefined();
+  });
+
+  test("leaves the floor empty while thinking", () => {
     startOwnedSession("thinking");
     render(<VoiceRoom />);
     expect(waves()).toBeNull();
@@ -1146,11 +1181,7 @@ describe("VoiceRoom — looks (color-with-eyes vs ambient void)", () => {
   const eyes = () => screen.queryByTestId("voice-room-eyes");
 
   test("a character avatar gets the color-with-eyes look", () => {
-    mockAvatarData = {
-      components: CHARACTER_COMPONENTS,
-      traits: { bodyShape: "sprout", eyeStyle: "curious", color: "green" },
-      customImageUrl: null,
-    };
+    seedAvatar("character");
     startOwnedSession("listening");
     render(<VoiceRoom />);
     expect(eyes()).not.toBeNull();
@@ -1163,11 +1194,7 @@ describe("VoiceRoom — looks (color-with-eyes vs ambient void)", () => {
   });
 
   function renderCharacterAt(state: LiveVoiceSessionState) {
-    mockAvatarData = {
-      components: CHARACTER_COMPONENTS,
-      traits: { bodyShape: "sprout", eyeStyle: "curious", color: "green" },
-      customImageUrl: null,
-    };
+    seedAvatar("character");
     startOwnedSession(state);
     render(<VoiceRoom />);
     return screen.queryByTestId("listening-waves");
@@ -1211,12 +1238,22 @@ describe("VoiceRoom — looks (color-with-eyes vs ambient void)", () => {
     expect(eyes()).not.toBeNull();
   });
 
-  test("a custom-image avatar keeps the ambient-void look", () => {
-    mockAvatarData = {
-      components: CHARACTER_COMPONENTS,
-      traits: null,
-      customImageUrl: "blob:custom-avatar",
-    };
+  test("a custom-image avatar fills the room with its sampled color", () => {
+    seedAvatar("custom");
+    startOwnedSession("listening");
+    render(<VoiceRoom />);
+    // No eyes to draw, so the uploaded image takes the centerpiece, and
+    // that is the ONLY thing about the room that differs from a character.
+    expect(eyes()).toBeNull();
+    expect(screen.getByTestId("voice-avatar")).toBeTruthy();
+    expect(screen.getByTestId("listening-waves")).toBeTruthy();
+  });
+
+  test("a custom-image avatar holds the void until its color lands", () => {
+    // The sample is a canvas decode: async, and it can fail outright. Either
+    // way the room paints rather than waiting on it.
+    seedAvatar("custom");
+    mockCustomFieldHex = null;
     startOwnedSession("listening");
     render(<VoiceRoom />);
     expect(eyes()).toBeNull();
@@ -1232,27 +1269,116 @@ describe("VoiceRoom — looks (color-with-eyes vs ambient void)", () => {
   });
 });
 
+describe("VoiceRoom — the bands read the same for every avatar", () => {
+  // The bug this pins: a custom avatar raised the user's band from the ceiling
+  // and answered with concentric rings, while a character raised both from the
+  // floor. Same session, same product, two different rooms.
+  function renderWith(
+    avatar: "character" | "custom",
+    state: LiveVoiceSessionState,
+  ) {
+    seedAvatar(avatar);
+    startOwnedSession(state);
+    render(<VoiceRoom />);
+    const band = screen.queryByTestId("listening-waves");
+    return { placement: band?.dataset.placement, color: band?.dataset.color };
+  }
+
+  test("both voices rise from the floor, whichever avatar is on screen", () => {
+    for (const state of ["listening", "speaking"] as const) {
+      for (const avatar of ["character", "custom"] as const) {
+        expect(renderWith(avatar, state).placement).toBe("bottom");
+        cleanup();
+      }
+    }
+  });
+
+  test("the two-ink vocabulary is the same one in both rooms", () => {
+    const characterListening = renderWith("character", "listening");
+    cleanup();
+    const customListening = renderWith("custom", "listening");
+    cleanup();
+    const characterSpeaking = renderWith("character", "speaking");
+    cleanup();
+    const customSpeaking = renderWith("custom", "speaking");
+    expect(customListening.color).toBe(characterListening.color);
+    expect(customSpeaking.color).toBe(characterSpeaking.color);
+    expect(characterListening.color).not.toBe(characterSpeaking.color);
+  });
+
+  test("no room answers with rings any more", () => {
+    renderWith("custom", "speaking");
+    expect(screen.queryByTestId("voice-responding-rings")).toBeNull();
+    cleanup();
+    renderWith("character", "speaking");
+    expect(screen.queryByTestId("voice-responding-rings")).toBeNull();
+  });
+});
+
+describe("VoiceRoom — live transcript (shared across looks)", () => {
+  // The report behind this work was "custom avatars show transcription on
+  // screen, native ones don't". They never diverged: the transcript reads two
+  // persisted prefs and nothing about the avatar. What differed was whose
+  // account had the prefs on. These pin that, so a future look change cannot
+  // quietly make the complaint true.
+  const userHalf = () => screen.queryByTestId("voice-ambient-user");
+  const assistantHalf = () => screen.queryByTestId("voice-ambient-assistant");
+
+  function renderWith(avatar: "character" | "custom") {
+    seedAvatar(avatar);
+    startOwnedSession("speaking");
+    useLiveVoiceStore.setState({
+      partialTranscript: "what is on my calendar",
+      assistantTranscript: "three meetings today",
+    });
+    render(<VoiceRoom />);
+  }
+
+  test("both prefs default off, so no room shows text", () => {
+    // Read from a fresh store rather than the suite's own seeding, so this
+    // fails if the shipped defaults ever flip.
+    useVoicePrefsStore.persist?.clearStorage?.();
+    const prefs = useVoicePrefsStore.getState();
+    expect(prefs.showUserTranscript).toBe(false);
+    expect(prefs.showAssistantTranscript).toBe(false);
+  });
+
+  test("stays absent for both avatars while the prefs are off", () => {
+    for (const avatar of ["character", "custom"] as const) {
+      renderWith(avatar);
+      expect(userHalf()).toBeNull();
+      expect(assistantHalf()).toBeNull();
+      cleanup();
+    }
+  });
+
+  test("appears in both zones for both avatars once the prefs are on", () => {
+    useVoicePrefsStore.setState({
+      showUserTranscript: true,
+      showAssistantTranscript: true,
+    });
+    for (const avatar of ["character", "custom"] as const) {
+      renderWith(avatar);
+      expect(userHalf()?.textContent).toContain("calendar");
+      expect(assistantHalf()?.textContent).toContain("meetings");
+      cleanup();
+    }
+  });
+});
+
 describe("VoiceRoom — state caption (shared across looks)", () => {
   const caption = () => screen.queryByTestId("voice-state-caption");
 
   function renderCharacterLook(state: LiveVoiceSessionState) {
-    mockAvatarData = {
-      components: CHARACTER_COMPONENTS,
-      traits: { bodyShape: "sprout", eyeStyle: "curious", color: "green" },
-      customImageUrl: null,
-    };
+    seedAvatar("character");
     startOwnedSession(state);
     render(<VoiceRoom />);
   }
 
   // The void look (custom-image / unresolved avatar) carries the centered
   // avatar, not the eyes, but shares the same caption beat.
-  function renderVoidLook(state: LiveVoiceSessionState) {
-    mockAvatarData = {
-      components: CHARACTER_COMPONENTS,
-      traits: null,
-      customImageUrl: "blob:custom-avatar",
-    };
+  function renderCustomLook(state: LiveVoiceSessionState) {
+    seedAvatar("custom");
     startOwnedSession(state);
     render(<VoiceRoom />);
   }
@@ -1268,7 +1394,7 @@ describe("VoiceRoom — state caption (shared across looks)", () => {
   });
 
   test("paints no caption in the void look either", () => {
-    renderVoidLook("speaking");
+    renderCustomLook("speaking");
     expect(screen.getByTestId("voice-avatar")).toBeTruthy();
     expect(screen.queryByTestId("voice-room-eyes")).toBeNull();
     expect(caption()).toBeNull();
@@ -1309,34 +1435,6 @@ describe("VoiceStateCaption — emphasis", () => {
       render(<VoiceStateCaption visual={visual} emphasis="full" />);
       expect(caption()).toBeNull();
     }
-  });
-});
-
-describe("VoiceRoom — void-look responding rings", () => {
-  const rings = () => screen.queryByTestId("voice-responding-rings");
-
-  function renderVoidLook(state: LiveVoiceSessionState) {
-    mockAvatarData = {
-      components: CHARACTER_COMPONENTS,
-      traits: null,
-      customImageUrl: "blob:custom-avatar",
-    };
-    startOwnedSession(state);
-    render(<VoiceRoom />);
-  }
-
-  test("emits the same concentric rings behind the custom avatar while responding", () => {
-    renderVoidLook("speaking");
-    // The custom avatar (not the eyes) is the centerpiece, but it radiates the
-    // color look's rings — parity with the eyes' responding treatment.
-    expect(screen.getByTestId("voice-avatar")).toBeTruthy();
-    expect(screen.queryByTestId("voice-room-eyes")).toBeNull();
-    expect(rings()).toBeTruthy();
-  });
-
-  test("shows no rings outside responding (energy going out only while speaking)", () => {
-    renderVoidLook("listening");
-    expect(rings()).toBeNull();
   });
 });
 

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.test.tsx
@@ -872,7 +872,7 @@ describe("VoiceRoom: mobile sheet", () => {
   });
 });
 
-describe("VoiceRoom — voice bands (avatar still unresolved)", () => {
+describe("VoiceRoom: voice bands (avatar still unresolved)", () => {
   const waves = () => screen.queryByTestId("listening-waves");
 
   test("mounts the listening band while listening (energy coming in)", () => {
@@ -1269,10 +1269,10 @@ describe("VoiceRoom — looks (color-with-eyes vs ambient void)", () => {
   });
 });
 
-describe("VoiceRoom — the bands read the same for every avatar", () => {
-  // The bug this pins: a custom avatar raised the user's band from the ceiling
-  // and answered with concentric rings, while a character raised both from the
-  // floor. Same session, same product, two different rooms.
+describe("VoiceRoom: the bands read the same for every avatar", () => {
+  // The bands are the room's account of whose turn it is, so an avatar that
+  // changed where they sit, or what answers the user, would make one session
+  // read as two different rooms.
   function renderWith(
     avatar: "character" | "custom",
     state: LiveVoiceSessionState,
@@ -1315,12 +1315,10 @@ describe("VoiceRoom — the bands read the same for every avatar", () => {
   });
 });
 
-describe("VoiceRoom — live transcript (shared across looks)", () => {
-  // The report behind this work was "custom avatars show transcription on
-  // screen, native ones don't". They never diverged: the transcript reads two
-  // persisted prefs and nothing about the avatar. What differed was whose
-  // account had the prefs on. These pin that, so a future look change cannot
-  // quietly make the complaint true.
+describe("VoiceRoom: live transcript (shared across looks)", () => {
+  // The transcript reads two persisted prefs and nothing about the avatar, so
+  // what is on screen is a property of the account, not of the assistant's
+  // look. These pin that, so a look change cannot make it avatar-dependent.
   const userHalf = () => screen.queryByTestId("voice-ambient-user");
   const assistantHalf = () => screen.queryByTestId("voice-ambient-assistant");
 

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -5,18 +5,25 @@ import { useTranslation } from "@/i18n";
  * voice bar and display transcript still render underneath, hidden by this
  * layer, so removing the room leaves the old UI intact.
  *
- * Two looks, resolved per session assistant ({@link resolveVoiceRoomLook}):
+ * One look, whatever the assistant wears. Every resolved avatar fills the room
+ * with a color and draws the same voice bands, the same transcript zones and
+ * the same toned chrome ({@link toneForBg}, via the `--room-*` CSS vars); the
+ * only thing avatar type decides is what stands in the middle of it:
  *
- * - Character avatars get the onboarding "full-screen color with eyes"
- *   treatment — entering the room plays the Introduction-step grow (the
- *   avatar's body springs from its on-screen size to BE the screen, the color
- *   fades in behind it, the giant eyes grow into the center; see
- *   {@link VoiceRoomColorLook}), the mic waveform swells behind the eyes while
- *   the user speaks, and the control chrome is toned for contrast against that
- *   color ({@link toneForBg}, via the `--room-*` CSS vars).
- * - Custom-image / no-character avatars fall back to the deep-dark ambient
- *   void with the state-driven avatar at its center and the listening waves —
- *   what this look should become is an open design question.
+ * - Character avatars ({@link resolveVoiceRoomLook}) bring their palette color
+ *   and their eyes, so entering plays the onboarding Introduction-step grow:
+ *   the body springs from its on-screen size to BE the screen, the color fades
+ *   in behind it, the giant eyes grow into the center. See
+ *   {@link VoiceRoomColorLook}.
+ * - Custom-image avatars have no palette color and no eyes, so the room samples
+ *   a field color out of the uploaded image ({@link useCustomAvatarFieldHex})
+ *   and the image itself takes the center. Everything else is the character
+ *   room, which is the point: the two used to differ in wave placement and in
+ *   how the assistant's turn was drawn, so one product read as two.
+ * - Until the avatar query settles there is no color to paint with, so the room
+ *   holds the deep-dark ambient void and its bands ride the avatar tint (the
+ *   dark voice ink would be invisible on it). That is a loading state, not a
+ *   look.
  *
  * Two placement variants (see `chat-layout.tsx` for the mounts):
  *
@@ -41,8 +48,8 @@ import { useTranslation } from "@/i18n";
  *   want, and the default.
  *
  * The look is laid out against the ROOM's box, not the window's. See
- * {@link useRoomBox}. As a panel those are different rectangles, so the color
- * look's field, its giant eyes, and the responding rings are all sized to the
+ * {@link useRoomBox}. As a panel those are different rectangles, so the look's
+ * color field, its giant eyes, and its voice bands are all sized to the
  * panel, and the entry origin (published in viewport space by the composer) is
  * converted to room-local space before the entrance grows from it. The sheet
  * reads no origin: it presents the look rather than growing it.
@@ -165,18 +172,19 @@ import {
 } from "./voice-room-entrance";
 import { VoiceAmbientTranscript } from "./voice-ambient-transcript";
 import { VoiceAvatar } from "./voice-avatar";
-import { VoiceMeshWaves } from "./voice-mesh-waves";
 import { VoiceRoomAmbientBackground } from "./voice-room-ambient-background";
+import { useCustomAvatarFieldHex } from "./use-custom-avatar-field";
 // Every circular icon control in the room is one of these: the corner
 // minimize, the two mutes, the camera toggle, flip camera and end session. See
 // that module for the toning, and for why the design library's `Button` is not
 // the element here.
 import { VoiceRoomControl } from "./voice-room-control";
 import {
-  VoiceRespondingRings,
   VoiceRoomColorLook,
+  VoiceRoomVoiceBands,
   VoiceStateCaption,
   resolveVoiceRoomLook,
+  voiceRoomImageLook,
 } from "./voice-room-eyes";
 import { useIsVoiceRoomVisible } from "./use-is-voice-room-visible";
 
@@ -494,15 +502,25 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
     useVoiceRoomCamera(assistantId, viewfinderRef);
   const cameraOpen = camera.open;
 
-  // Resolve the assistant's look: color-with-eyes for character avatars, the
-  // ambient void otherwise. The accent var is still published for the
-  // fallback look's listening waves (null for custom-image / "none" /
-  // still-loading avatars, where the waves keep their aurora fallback) — the
-  // same derivation the iOS Live Activity mirrors, so island and room agree.
+  // Resolve the assistant's look. A character avatar hands over its palette
+  // color and its eyes; an uploaded image hands over pixels, so the field color
+  // is sampled out of it and the look carries no eyes (the room's centered
+  // avatar is the centerpiece there). Null only while the avatar query is still
+  // unresolved, which is the ambient-void loading state.
+  //
+  // The sample resolves a frame or more after the query does, and can fail
+  // outright, so the room paints the void until it lands rather than holding
+  // its first frame on a decode.
   const { components, traits, customImageUrl } =
     useAssistantAvatar(assistantId);
-  const look = resolveVoiceRoomLook(components, traits, customImageUrl);
+  const customFieldHex = useCustomAvatarFieldHex(customImageUrl);
+  const look =
+    resolveVoiceRoomLook(components, traits, customImageUrl) ??
+    (customFieldHex ? voiceRoomImageLook(customFieldHex) : null);
   const tone = look ? toneForBg(look.bgHex) : null;
+  // The accent var, published for the void state's bands and mirrored by the
+  // iOS Live Activity so island and room agree. Null for custom-image / "none"
+  // / still-loading avatars, where those bands keep their own fallback.
   const accentHex = resolveWaveAccentHex(components, traits, customImageUrl);
 
   // Control-chrome colors for the active look, consumed by the shared control
@@ -614,21 +632,18 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
         ...(accentHex ? { [AVATAR_ACCENT_CSS_VAR]: accentHex } : {}),
       }}
       // On close the chrome and rectangular backgrounds fade, while the avatar
-      // shape itself shrinks back toward the entry origin — the color look's
-      // body + eyes and the void look's centered avatar each own that exit — so
+      // shape itself shrinks back toward the entry origin (the character
+      // look's body + eyes and the centered avatar each own that exit), so
       // the room collapses into the avatar, not a shrinking rectangle. Under
       // the sheet none of that applies: the chrome slides the whole room out in
       // one piece, and this box holds still.
       {...choreography.shell}
     >
-      {/* The color look (body grow entrance + color fade + centered waves +
-          centered eyes) is the entire cast; the void look expresses the
-          session through the centered avatar, but shares the color look's
-          foreground chrome — the listening waves sweep in from the same top edge
-          and the same state caption names the beat below the centerpiece — so
-          the room reads identically for a custom avatar bar the full-screen
-          color + eyes. Both draw the waves only while `listening`, from live mic
-          amplitude. */}
+      {/* The look: a color field plus the room's shared cast (voice bands,
+          state caption, and the eyes when the avatar has any). A custom-image
+          avatar takes the same path with its sampled field color and no eyes,
+          so nothing about the bands or the caption depends on avatar type; the
+          centered avatar below fills the middle in its place. */}
       {!camera.native && look ? (
         // Held back until the box is measured. That is one pre-paint commit, so the
         // entrance still plays from the room's first painted frame, but it
@@ -652,30 +667,17 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
         ) : null
       ) : !camera.native ? (
         <>
+          {/* No avatar resolved yet, so there is no field to paint. The bands
+              are the same component at the same edge; only the ink changes,
+              because the dark voice ink cannot be seen on the void. */}
           <VoiceRoomAmbientBackground />
-          {visual === "listening" ? (
-            <VoiceMeshWaves
-              getAmplitude={getLiveVoiceInputAmplitude}
-              palette="accent"
-              // Same top edge as the color look, above the centered avatar —
-              // positional parity, only the aurora/accent color differs from the
-              // color look's avatar-toned band.
-              placement="top"
-            />
-          ) : null}
-          {/* Responding: the same concentric rings the color look radiates from
-              behind the eyes, here behind the centered avatar (both centered, so
-              they emanate from the centerpiece the same way). Rendered before the
-              avatar so it paints them behind it; rides the TTS-output amplitude. */}
-          {visual === "responding" && box ? (
-            <VoiceRespondingRings
-              getAmplitude={getLiveVoiceOutputAmplitude}
-              viewport={box}
-            />
-          ) : null}
-          {/* Same state caption + gating as the color look (stands down while
-              the assistant transcript is on), in the same shared lower zone —
-              both looks name the beat from one baseline. */}
+          <VoiceRoomVoiceBands
+            visual={visual}
+            getAmplitude={getLiveVoiceInputAmplitude}
+            getResponseAmplitude={getLiveVoiceOutputAmplitude}
+            ink="accent"
+            viewport={box ?? undefined}
+          />
           {!showAssistantTranscript ? (
             <VoiceStateCaption visual={visual} />
           ) : null}
@@ -812,11 +814,12 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
         </VoiceRoomControl>
       </div>
 
-      {/* Void look: the avatar springs to center once on entry (the wrapper
+      {/* The centerpiece for every assistant without eyes: an uploaded image,
+          or none resolved yet. It springs to center once on entry (the wrapper
           owns the one-time entry spring); per-state expression is the avatar's
-          own CSS loop, which cross-fades in place without re-popping. The
-          color look has no centered figure — the bottom eyes are the cast. */}
-      {!camera.native && !look ? (
+          own CSS loop, which cross-fades in place without re-popping. A
+          character look has no centered figure: its eyes are the cast. */}
+      {!camera.native && !look?.art ? (
         <motion.div
           className="relative z-0"
           {...voidAvatarMotion(choreography.entrance)}

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -18,8 +18,8 @@ import { useTranslation } from "@/i18n";
  * - Custom-image avatars have no palette color and no eyes, so the room samples
  *   a field color out of the uploaded image ({@link useCustomAvatarFieldHex})
  *   and the image itself takes the center. Everything else is the character
- *   room, which is the point: the two used to differ in wave placement and in
- *   how the assistant's turn was drawn, so one product read as two.
+ *   room, which is the point: a session reads the same whichever avatar the
+ *   assistant wears.
  * - Until the avatar query settles there is no color to paint with, so the room
  *   holds the deep-dark ambient void and its bands ride the avatar tint (the
  *   dark voice ink would be invisible on it). That is a loading state, not a

--- a/clients/web/src/utils/avatar-image-color.test.ts
+++ b/clients/web/src/utils/avatar-image-color.test.ts
@@ -1,0 +1,103 @@
+/**
+ * The color math behind an uploaded avatar's room-fill color. The canvas half
+ * (`sampleAvatarFieldHex`) is not exercised here — no test environment decodes
+ * an image — so the sampling is split so the part that decides the color can be
+ * tested from pixels alone.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  fieldHexFromImageData,
+  normalizeFieldHex,
+} from "./avatar-image-color";
+
+/** Build an RGBA block from `[r, g, b, a]` tuples, each repeated `count` times. */
+function pixels(...runs: [number, number, number, number, number][]) {
+  const out: number[] = [];
+  for (const [r, g, b, a, count] of runs) {
+    for (let i = 0; i < count; i += 1) {
+      out.push(r, g, b, a);
+    }
+  }
+  return new Uint8ClampedArray(out);
+}
+
+/** Perceived brightness (YIQ), the same measure `toneForBg` reads. */
+function brightness(hex: string): number {
+  const n = parseInt(hex.slice(1), 16);
+  const r = (n >> 16) & 0xff;
+  const g = (n >> 8) & 0xff;
+  const b = n & 0xff;
+  return (r * 299 + g * 587 + b * 114) / 1000 / 255;
+}
+
+function saturation(hex: string): number {
+  const n = parseInt(hex.slice(1), 16);
+  const ch = [(n >> 16) & 0xff, (n >> 8) & 0xff, n & 0xff].map((c) => c / 255);
+  const max = Math.max(...ch);
+  const min = Math.min(...ch);
+  const l = (max + min) / 2;
+  return max === min ? 0 : (max - min) / (1 - Math.abs(2 * l - 1));
+}
+
+describe("normalizeFieldHex", () => {
+  test("pins every color into the band the room's ink was tuned against", () => {
+    // Anything drawn over an avatar color assumes the character palette's
+    // range. A near-white or near-black upload has to land there too, or the
+    // pale/dark band ink stops reading.
+    for (const hex of ["#FFFFFF", "#000000", "#FF0000", "#123456"]) {
+      expect(brightness(normalizeFieldHex(hex))).toBeGreaterThan(0.3);
+      expect(brightness(normalizeFieldHex(hex))).toBeLessThan(0.62);
+    }
+  });
+
+  test("keeps the hue it was given", () => {
+    // A blue avatar must not come back green: the field is the assistant's
+    // color, normalized, not a color of the room's choosing.
+    const blue = normalizeFieldHex("#0A1F7A");
+    const n = parseInt(blue.slice(1), 16);
+    expect(n & 0xff).toBeGreaterThan((n >> 16) & 0xff);
+  });
+
+  test("caps saturation so a one-ink logo is not a headache full-screen", () => {
+    expect(saturation(normalizeFieldHex("#FF0000"))).toBeLessThanOrEqual(0.69);
+  });
+
+  test("leaves a gray avatar gray rather than inventing a hue", () => {
+    expect(saturation(normalizeFieldHex("#8A8A8A"))).toBeLessThan(0.02);
+  });
+
+  test("returns a malformed input untouched", () => {
+    expect(normalizeFieldHex("not-a-color")).toBe("not-a-color");
+  });
+});
+
+describe("fieldHexFromImageData", () => {
+  test("lets the colored pixels carry a logo on a white ground", () => {
+    // The failure this guards: a flat average of a red mark on white is pale
+    // pink, so every logo upload produced the same washed-out room.
+    const hex = fieldHexFromImageData(
+      pixels([255, 255, 255, 255, 90], [200, 30, 30, 255, 10]),
+    );
+    const n = parseInt(hex!.slice(1), 16);
+    expect((n >> 16) & 0xff).toBeGreaterThan((n >> 8) & 0xff);
+    expect(saturation(hex!)).toBeGreaterThan(0.2);
+  });
+
+  test("skips transparent pixels — a cutout's ground is not its color", () => {
+    const cutout = fieldHexFromImageData(
+      pixels([0, 0, 0, 0, 90], [40, 120, 200, 255, 10]),
+    );
+    const opaque = fieldHexFromImageData(pixels([40, 120, 200, 255, 10]));
+    expect(cutout).toBe(opaque);
+  });
+
+  test("returns null when nothing is opaque enough to sample", () => {
+    expect(fieldHexFromImageData(pixels([12, 34, 56, 0, 40]))).toBeNull();
+  });
+
+  test("returns null for an empty block", () => {
+    expect(fieldHexFromImageData(new Uint8ClampedArray())).toBeNull();
+  });
+});

--- a/clients/web/src/utils/avatar-image-color.test.ts
+++ b/clients/web/src/utils/avatar-image-color.test.ts
@@ -32,6 +32,21 @@ function brightness(hex: string): number {
   return (r * 299 + g * 587 + b * 114) / 1000 / 255;
 }
 
+/** WCAG relative luminance, for the contrast check below. */
+function luminance(hex: string): number {
+  const n = parseInt(hex.slice(1), 16);
+  const ch = (shift: number) => {
+    const c = ((n >> shift) & 0xff) / 255;
+    return c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+  };
+  return 0.2126 * ch(16) + 0.7152 * ch(8) + 0.0722 * ch(0);
+}
+
+function contrastRatio(a: string, b: string): number {
+  const [hi, lo] = [luminance(a), luminance(b)].sort((x, y) => y - x);
+  return (hi! + 0.05) / (lo! + 0.05);
+}
+
 function saturation(hex: string): number {
   const n = parseInt(hex.slice(1), 16);
   const ch = [(n >> 16) & 0xff, (n >> 8) & 0xff, n & 0xff].map((c) => c / 255);
@@ -41,14 +56,34 @@ function saturation(hex: string): number {
   return max === min ? 0 : (max - min) / (1 - Math.abs(2 * l - 1));
 }
 
+/** Fully saturated samples right around the hue wheel, plus the achromatic ends. */
+const HUE_SWEEP = [
+  "#FF0000", "#FF8000", "#FFFF00", "#80FF00", "#00FF00", "#00FF80",
+  "#00FFFF", "#0080FF", "#0000FF", "#8000FF", "#FF00FF", "#FF0080",
+  "#FFFFFF", "#000000", "#123456", "#8A8A8A",
+];
+
 describe("normalizeFieldHex", () => {
-  test("pins every color into the band the room's ink was tuned against", () => {
-    // Anything drawn over an avatar color assumes the character palette's
-    // range. A near-white or near-black upload has to land there too, or the
-    // pale/dark band ink stops reading.
-    for (const hex of ["#FFFFFF", "#000000", "#FF0000", "#123456"]) {
-      expect(brightness(normalizeFieldHex(hex))).toBeGreaterThan(0.3);
-      expect(brightness(normalizeFieldHex(hex))).toBeLessThan(0.62);
+  test("pins every hue into the band the room's ink was tuned against", () => {
+    // Perceived brightness, which is what decides whether the pale and dark
+    // band inks read, and it is not HSL lightness: the eye weights green about
+    // five times blue, so a hue-blind normalization leaves saturated blues half
+    // as bright as saturated yellows and the dark ink vanishes into them.
+    for (const hex of HUE_SWEEP) {
+      const b = brightness(normalizeFieldHex(hex));
+      expect({ hex, b }).toMatchObject({ hex });
+      expect(b).toBeGreaterThan(0.4);
+      expect(b).toBeLessThan(0.5);
+    }
+  });
+
+  test("keeps both band inks legible on every hue", () => {
+    // The two inks are the room's whole account of whose turn it is. A field
+    // that swallows either one takes that away, whatever the avatar looks like.
+    for (const hex of HUE_SWEEP) {
+      const field = normalizeFieldHex(hex);
+      expect(contrastRatio(field, "#FFFFFF")).toBeGreaterThan(2.4);
+      expect(contrastRatio(field, "#000000")).toBeGreaterThan(2.4);
     }
   });
 

--- a/clients/web/src/utils/avatar-image-color.test.ts
+++ b/clients/web/src/utils/avatar-image-color.test.ts
@@ -1,8 +1,8 @@
 /**
  * The color math behind an uploaded avatar's room-fill color. The canvas half
- * (`sampleAvatarFieldHex`) is not exercised here — no test environment decodes
- * an image — so the sampling is split so the part that decides the color can be
- * tested from pixels alone.
+ * (`sampleAvatarFieldHex`) is not exercised here, because no test environment
+ * decodes an image. The sampling is split so the part that decides the color
+ * can be tested from pixels alone.
  */
 
 import { describe, expect, test } from "bun:test";
@@ -75,8 +75,8 @@ describe("normalizeFieldHex", () => {
 
 describe("fieldHexFromImageData", () => {
   test("lets the colored pixels carry a logo on a white ground", () => {
-    // The failure this guards: a flat average of a red mark on white is pale
-    // pink, so every logo upload produced the same washed-out room.
+    // A flat average of a red mark on white is pale pink, which is how every
+    // logo upload ends up with the same washed-out room.
     const hex = fieldHexFromImageData(
       pixels([255, 255, 255, 255, 90], [200, 30, 30, 255, 10]),
     );
@@ -85,7 +85,7 @@ describe("fieldHexFromImageData", () => {
     expect(saturation(hex!)).toBeGreaterThan(0.2);
   });
 
-  test("skips transparent pixels — a cutout's ground is not its color", () => {
+  test("skips transparent pixels: a cutout's ground is not its color", () => {
     const cutout = fieldHexFromImageData(
       pixels([0, 0, 0, 0, 90], [40, 120, 200, 255, 10]),
     );

--- a/clients/web/src/utils/avatar-image-color.ts
+++ b/clients/web/src/utils/avatar-image-color.ts
@@ -2,17 +2,16 @@
  * Deriving a room-fill color from a custom (uploaded) avatar image.
  *
  * A character avatar hands every avatar-tinted surface an explicit palette
- * color to paint with. An uploaded image hands over pixels instead, so the
- * surfaces that fill themselves with "the assistant's color" had nothing to
- * read and fell back to a colorless treatment. This samples one representative
- * color out of the image so an uploaded avatar can drive the same surfaces a
- * character does.
+ * color to paint with. An uploaded image hands over pixels instead, so a
+ * surface that fills itself with "the assistant's color" has to sample one out
+ * of those pixels. That is what this does: one representative color, so an
+ * uploaded avatar drives the same surfaces a character does.
  *
  * The sample is normalized rather than used raw: a photograph's average is
  * usually a washed-out near-white or a muddy near-black, neither of which is a
  * background anything can be drawn on. {@link normalizeFieldHex} keeps the
- * sampled hue and pins the lightness into the same band the character palette
- * occupies, which is the band every avatar-tinted treatment was tuned against.
+ * sampled hue and pins the lightness into the band the character palette
+ * occupies, which is the band avatar-tinted treatments are tuned against.
  */
 
 import { coverCropSquare } from "./avatar-raster";

--- a/clients/web/src/utils/avatar-image-color.ts
+++ b/clients/web/src/utils/avatar-image-color.ts
@@ -10,18 +10,23 @@
  * The sample is normalized rather than used raw: a photograph's average is
  * usually a washed-out near-white or a muddy near-black, neither of which is a
  * background anything can be drawn on. {@link normalizeFieldHex} keeps the
- * sampled hue and pins the lightness into the band the character palette
- * occupies, which is the band avatar-tinted treatments are tuned against.
+ * sampled hue and pins the perceived brightness into the band the character
+ * palette occupies, which is the band avatar-tinted treatments are tuned
+ * against.
  */
 
 import { coverCropSquare } from "./avatar-raster";
 
 /**
- * Lightness the field is pinned to, matching the character palette's own range
- * (its darkest color, teal, sits at ~0.44). Treatments drawn over an avatar
- * color assume that band: pale ink reads on it, and so does dark ink.
+ * Perceived brightness the field is pinned to, matching the character palette's
+ * own range (its darkest color, teal, sits at ~0.44). Treatments drawn over an
+ * avatar color assume that band: pale ink reads on it, and so does dark ink.
+ *
+ * Perceived, not HSL lightness: the eye weights green far above blue, so a
+ * fixed lightness leaves a saturated blue at roughly half the brightness of a
+ * saturated yellow, dark enough that the dark ink drawn over it disappears.
  */
-const FIELD_LIGHTNESS = 0.42;
+const FIELD_BRIGHTNESS = 0.45;
 
 /**
  * Saturation ceiling. A logo built from one fully-saturated ink samples at
@@ -96,8 +101,12 @@ function rgbToHsl(
   return { h: h < 0 ? h + 1 : h, s, l };
 }
 
-/** HSL (all 0-1) back to a `#rrggbb` hex. */
-function hslToHex(h: number, s: number, l: number): string {
+/** HSL (all 0-1) back to RGB (0-255). */
+function hslToRgb(
+  h: number,
+  s: number,
+  l: number,
+): [number, number, number] {
   const c = (1 - Math.abs(2 * l - 1)) * s;
   const hp = h * 6;
   const x = c * (1 - Math.abs((hp % 2) - 1));
@@ -114,13 +123,40 @@ function hslToHex(h: number, s: number, l: number): string {
               ? [x, 0, c]
               : [c, 0, x];
   const m = l - c / 2;
-  return toHex((r1 + m) * 255, (g1 + m) * 255, (b1 + m) * 255);
+  return [(r1 + m) * 255, (g1 + m) * 255, (b1 + m) * 255];
+}
+
+/** Perceived brightness (YIQ), 0-1: the measure `toneForBg` judges a fill by. */
+function brightness(r: number, g: number, b: number): number {
+  return (r * 299 + g * 587 + b * 114) / 1000 / 255;
+}
+
+/**
+ * The `h`/`s` color whose perceived brightness is `target`.
+ *
+ * Brightness climbs monotonically with lightness at a fixed hue and saturation,
+ * so this bisects for it. Inverting the piecewise HSL conversion analytically
+ * would mean a case per hue sector for no gain: twenty halvings land within a
+ * thousandth of a channel step.
+ */
+function hexAtBrightness(h: number, s: number, target: number): string {
+  let lo = 0;
+  let hi = 1;
+  for (let i = 0; i < 20; i += 1) {
+    const mid = (lo + hi) / 2;
+    if (brightness(...hslToRgb(h, s, mid)) < target) {
+      lo = mid;
+    } else {
+      hi = mid;
+    }
+  }
+  return toHex(...hslToRgb(h, s, (lo + hi) / 2));
 }
 
 /**
  * Pin a sampled color into the band avatar-tinted surfaces are drawn for: the
- * hue is kept, the lightness is set to {@link FIELD_LIGHTNESS}, and the
- * saturation is capped. Returns the input unchanged if it is not a hex.
+ * hue is kept, the saturation is capped, and the perceived brightness is set to
+ * {@link FIELD_BRIGHTNESS}. Returns the input unchanged if it is not a hex.
  */
 export function normalizeFieldHex(hex: string): string {
   const rgb = parseHex(hex);
@@ -128,7 +164,11 @@ export function normalizeFieldHex(hex: string): string {
     return hex;
   }
   const { h, s } = rgbToHsl(rgb[0], rgb[1], rgb[2]);
-  return hslToHex(h, Math.min(s, FIELD_MAX_SATURATION), FIELD_LIGHTNESS);
+  return hexAtBrightness(
+    h,
+    Math.min(s, FIELD_MAX_SATURATION),
+    FIELD_BRIGHTNESS,
+  );
 }
 
 /**

--- a/clients/web/src/utils/avatar-image-color.ts
+++ b/clients/web/src/utils/avatar-image-color.ts
@@ -1,0 +1,219 @@
+/**
+ * Deriving a room-fill color from a custom (uploaded) avatar image.
+ *
+ * A character avatar hands every avatar-tinted surface an explicit palette
+ * color to paint with. An uploaded image hands over pixels instead, so the
+ * surfaces that fill themselves with "the assistant's color" had nothing to
+ * read and fell back to a colorless treatment. This samples one representative
+ * color out of the image so an uploaded avatar can drive the same surfaces a
+ * character does.
+ *
+ * The sample is normalized rather than used raw: a photograph's average is
+ * usually a washed-out near-white or a muddy near-black, neither of which is a
+ * background anything can be drawn on. {@link normalizeFieldHex} keeps the
+ * sampled hue and pins the lightness into the same band the character palette
+ * occupies, which is the band every avatar-tinted treatment was tuned against.
+ */
+
+import { coverCropSquare } from "./avatar-raster";
+
+/**
+ * Lightness the field is pinned to, matching the character palette's own range
+ * (its darkest color, teal, sits at ~0.44). Treatments drawn over an avatar
+ * color assume that band: pale ink reads on it, and so does dark ink.
+ */
+const FIELD_LIGHTNESS = 0.42;
+
+/**
+ * Saturation ceiling. A logo built from one fully-saturated ink samples at
+ * S = 1, which as a full-screen field is a headache rather than a backdrop.
+ * There is deliberately no floor: a grayscale avatar earns a gray room.
+ */
+const FIELD_MAX_SATURATION = 0.68;
+
+/** Pixels below this alpha are skipped: a transparent logo's ground is not its color. */
+const MIN_ALPHA = 128;
+
+/**
+ * How strongly a pixel's colorfulness weights it in the average.
+ *
+ * A flat average is dominated by whatever fills the most area, which for most
+ * uploads is a white or black background, so the "avatar color" of a red logo
+ * on white comes out pale pink. Weighting by chroma lets the colored pixels
+ * carry the result while the base weight keeps a genuinely gray image gray.
+ */
+const CHROMA_WEIGHT = 4;
+const BASE_WEIGHT = 0.25;
+
+/** Parse `#rgb` / `#rrggbb` into 0-255 channels; null when malformed. */
+function parseHex(hex: string): [number, number, number] | null {
+  const m = /^#?([0-9a-f]{3}|[0-9a-f]{6})$/i.exec(hex.trim());
+  if (!m) {
+    return null;
+  }
+  const h = m[1]!;
+  const full =
+    h.length === 3
+      ? h
+          .split("")
+          .map((c) => c + c)
+          .join("")
+      : h;
+  const n = parseInt(full, 16);
+  return [(n >> 16) & 0xff, (n >> 8) & 0xff, n & 0xff];
+}
+
+function toHex(r: number, g: number, b: number): string {
+  const ch = (v: number) => Math.max(0, Math.min(255, Math.round(v)));
+  return `#${((1 << 24) | (ch(r) << 16) | (ch(g) << 8) | ch(b)).toString(16).slice(1)}`;
+}
+
+/** RGB (0-255) to HSL (all 0-1). */
+function rgbToHsl(
+  r: number,
+  g: number,
+  b: number,
+): { h: number; s: number; l: number } {
+  const rn = r / 255;
+  const gn = g / 255;
+  const bn = b / 255;
+  const max = Math.max(rn, gn, bn);
+  const min = Math.min(rn, gn, bn);
+  const l = (max + min) / 2;
+  const d = max - min;
+  if (d === 0) {
+    return { h: 0, s: 0, l };
+  }
+  const s = d / (1 - Math.abs(2 * l - 1));
+  let h: number;
+  if (max === rn) {
+    h = ((gn - bn) / d) % 6;
+  } else if (max === gn) {
+    h = (bn - rn) / d + 2;
+  } else {
+    h = (rn - gn) / d + 4;
+  }
+  h /= 6;
+  return { h: h < 0 ? h + 1 : h, s, l };
+}
+
+/** HSL (all 0-1) back to a `#rrggbb` hex. */
+function hslToHex(h: number, s: number, l: number): string {
+  const c = (1 - Math.abs(2 * l - 1)) * s;
+  const hp = h * 6;
+  const x = c * (1 - Math.abs((hp % 2) - 1));
+  const [r1, g1, b1] =
+    hp < 1
+      ? [c, x, 0]
+      : hp < 2
+        ? [x, c, 0]
+        : hp < 3
+          ? [0, c, x]
+          : hp < 4
+            ? [0, x, c]
+            : hp < 5
+              ? [x, 0, c]
+              : [c, 0, x];
+  const m = l - c / 2;
+  return toHex((r1 + m) * 255, (g1 + m) * 255, (b1 + m) * 255);
+}
+
+/**
+ * Pin a sampled color into the band avatar-tinted surfaces are drawn for: the
+ * hue is kept, the lightness is set to {@link FIELD_LIGHTNESS}, and the
+ * saturation is capped. Returns the input unchanged if it is not a hex.
+ */
+export function normalizeFieldHex(hex: string): string {
+  const rgb = parseHex(hex);
+  if (!rgb) {
+    return hex;
+  }
+  const { h, s } = rgbToHsl(rgb[0], rgb[1], rgb[2]);
+  return hslToHex(h, Math.min(s, FIELD_MAX_SATURATION), FIELD_LIGHTNESS);
+}
+
+/**
+ * One representative color for a block of RGBA pixels, normalized per
+ * {@link normalizeFieldHex}. Null when the block holds no pixel opaque enough
+ * to count (an all-transparent crop), so the caller keeps its own fallback.
+ *
+ * Split out from the canvas work so the color math is testable without a DOM.
+ */
+export function fieldHexFromImageData(data: Uint8ClampedArray): string | null {
+  let totalWeight = 0;
+  let r = 0;
+  let g = 0;
+  let b = 0;
+  for (let i = 0; i + 3 < data.length; i += 4) {
+    const alpha = data[i + 3]!;
+    if (alpha < MIN_ALPHA) {
+      continue;
+    }
+    const pr = data[i]!;
+    const pg = data[i + 1]!;
+    const pb = data[i + 2]!;
+    const chroma =
+      (Math.max(pr, pg, pb) - Math.min(pr, pg, pb)) / 255;
+    const weight = BASE_WEIGHT + chroma * CHROMA_WEIGHT;
+    totalWeight += weight;
+    r += pr * weight;
+    g += pg * weight;
+    b += pb * weight;
+  }
+  if (totalWeight === 0) {
+    return null;
+  }
+  return normalizeFieldHex(
+    toHex(r / totalWeight, g / totalWeight, b / totalWeight),
+  );
+}
+
+/**
+ * Sample `src` (a renderer-owned blob URL or a data URI) down to a small
+ * offscreen canvas and return its field color, or null when the image cannot
+ * be read.
+ *
+ * Null covers every failure the caller has to survive: a decode error, an
+ * image with no extent, a browser that hands back no 2D context, and a remote
+ * URL served without CORS headers, which taints the canvas so `getImageData`
+ * throws. Every one of them means "no color to paint with", never a thrown
+ * error: this drives decoration, and a decorative sample must not be able to
+ * take a surface down.
+ *
+ * Non-square uploads are center-cropped with {@link coverCropSquare}, the same
+ * crop `ChatAvatar` renders, so the sample comes from the pixels the user can
+ * actually see rather than from bands that are cropped away.
+ */
+export async function sampleAvatarFieldHex(
+  src: string,
+  size = 24,
+): Promise<string | null> {
+  if (!src || typeof document === "undefined") {
+    return null;
+  }
+  const image = new Image();
+  image.decoding = "async";
+  const loaded = new Promise<void>((resolve, reject) => {
+    image.onload = () => resolve();
+    image.onerror = () => reject(new Error("avatar image failed to load"));
+  });
+  try {
+    image.src = src;
+    await loaded;
+    const crop = coverCropSquare(image.naturalWidth, image.naturalHeight);
+    if (!crop) {
+      return null;
+    }
+    const canvas = document.createElement("canvas");
+    canvas.width = size;
+    canvas.height = size;
+    const ctx = canvas.getContext("2d", { willReadFrequently: true });
+    if (!ctx) {
+      return null;
+    }
+    ctx.drawImage(image, crop.sx, crop.sy, crop.side, crop.side, 0, 0, size, size);
+    return fieldHexFromImageData(ctx.getImageData(0, 0, size, size).data);
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

- The voice room now draws one look for every assistant. A custom-image avatar samples a field color out of its uploaded image and takes the same colored room a character gets: same voice bands, same ink, same caption, same toned chrome. The only thing avatar type still decides is what stands in the middle, eyes or the image.
- Both bands now rise from the floor for every avatar. The custom room used to raise the user's band from the ceiling and answer with concentric rings, while a character raised both from the floor, so one session read as two different products. The edge is single-sourced as `VOICE_ROOM_WAVE_PLACEMENT` and the bands are one shared `VoiceRoomVoiceBands`, so they cannot drift again. The dead `VoiceRespondingRings` wrapper is gone; `rings` survives as a Storybook sketch style.
- Field color comes from `sampleAvatarFieldHex` (a small offscreen canvas draw, center-cropped the way `ChatAvatar` renders non-square uploads), weighted toward the colored pixels so a logo on white does not average to pale pink, then pinned to the lightness band the character palette occupies so the pale and dark band inks both read on it. Sampling is async and never blocks the room's first paint; a decode failure, a missing 2D context or a tainted canvas all resolve to "no color", and the room keeps the ambient void.
- The minimized composer bar and title-bar pill read the same sampled color, so the surface a custom-avatar session minimizes into no longer disagrees with the room it came from.
- Live transcription never diverged by avatar type: it reads two persisted prefs, both defaulting off. Tests now pin that, so the reported behavior cannot quietly become true.

## Original prompt

Anita reported in Slack that voice mode looked like two different products: her custom-avatar assistant showed on-screen transcription with the waveforms stacked at the top, while Nick's little-dude assistant put the waveforms at the bottom with no transcription. Filed as LUM-3437, high priority, with a note to squeeze it in for the mobile launch. Tracing it showed two separate causes: the waveform split was real (a hardcoded `placement="top"` plus rings-versus-band for the responding beat), while the transcription difference was just per-user pref state. Alex's call was that nothing should differ between the two avatar types, that the standard/native treatment wins, and that the color sampling the character components use could be reused to give custom avatars a real color.

## Verification

- `bun test` on every voice-room suite plus the composer bar and pill, file by file (`mock.module` leaks across a directory run in this package). `bunx tsc --noEmit` and `eslint` clean.
- Checked both rooms side by side in Storybook (`Chat/Voice/VoiceAvatar` → "States" and the new "Custom Image — States"): pale listening band and dark responding band from the floor in both, same caption anchor.

## Worth a look

The field color for an uploaded image is a judgement call, not a correctness one: `FIELD_LIGHTNESS` / `FIELD_MAX_SATURATION` and the chroma weighting in `avatar-image-color.ts` decide how a photo or a logo reads as a full-screen room. The Storybook story has a `fieldHex` knob (including `null`, the room before the sample lands) to try alternatives against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XJXLNGL5SF2pFPNEhhmLpC