### PR TITLE
fix(gateway): read device last-used from the actor token row

### DIFF
--- a/gateway/src/__tests__/devices.test.ts
+++ b/gateway/src/__tests__/devices.test.ts
@@ -24,8 +24,12 @@ mock.module("../db/assistant-db-proxy.js", () => ({
 
 const { initGatewayDb, resetGatewayDb, getGatewayDb } =
   await import("../db/connection.js");
-const { actorTokenRecords, actorRefreshTokenRecords, contacts, contactChannels } =
-  await import("../db/schema.js");
+const {
+  actorTokenRecords,
+  actorRefreshTokenRecords,
+  contacts,
+  contactChannels,
+} = await import("../db/schema.js");
 const { hashToken } = await import("../auth/guardian-bootstrap.js");
 const { handleListDevices, handleRevokeDevice } =
   await import("../http/routes/devices.js");
@@ -34,6 +38,8 @@ const LOOPBACK_IP = "127.0.0.1";
 const GUARDIAN_ID = "guardian-001";
 
 let testRoot: string;
+
+let actorSeedSeq = 0;
 
 function seedActor(opts: {
   device: string;
@@ -44,11 +50,12 @@ function seedActor(opts: {
 }): void {
   const now = Date.now();
   const principal = opts.principal ?? GUARDIAN_ID;
+  actorSeedSeq += 1;
   getGatewayDb()
     .insert(actorTokenRecords)
     .values({
       id: randomUUID(),
-      tokenHash: hashToken(`acc-${principal}-${opts.device}`),
+      tokenHash: hashToken(`acc-${principal}-${opts.device}-${actorSeedSeq}`),
       guardianPrincipalId: principal,
       hashedDeviceId: hashToken(opts.device),
       platform: opts.platform ?? "cli",
@@ -224,6 +231,66 @@ describe("GET /v1/devices", () => {
       (d) => d.hashedDeviceId === hashToken("device-B"),
     );
     expect(b?.lastUsedAt).toBeNull();
+  });
+
+  test("keeps the stamp from a rotated-out row when the active row is unstamped", async () => {
+    // Refreshing credentials revokes the stamped row and mints an unstamped
+    // replacement; the device's activity history must survive that.
+    seedActor({
+      device: "device-A",
+      status: "revoked",
+      lastUsedAt: 1_700_000_000_000,
+    });
+    seedActor({ device: "device-A" });
+
+    const res = await handleListDevices(listRequest(), LOOPBACK_IP);
+    const body = (await res.json()) as {
+      devices: { hashedDeviceId: string; lastUsedAt: number | null }[];
+    };
+    expect(body.devices).toHaveLength(1);
+    expect(body.devices[0]?.lastUsedAt).toBe(1_700_000_000_000);
+  });
+
+  test("prefers the active row's stamp when it is newer than a rotated-out one", async () => {
+    seedActor({
+      device: "device-A",
+      status: "revoked",
+      lastUsedAt: 1_700_000_000_000,
+    });
+    seedActor({ device: "device-A", lastUsedAt: 1_800_000_000_000 });
+
+    const res = await handleListDevices(listRequest(), LOOPBACK_IP);
+    const body = (await res.json()) as {
+      devices: { hashedDeviceId: string; lastUsedAt: number | null }[];
+    };
+    expect(body.devices[0]?.lastUsedAt).toBe(1_800_000_000_000);
+  });
+
+  test("returns null when no row for the device carries a stamp", async () => {
+    seedActor({ device: "device-A", status: "revoked" });
+    seedActor({ device: "device-A" });
+
+    const res = await handleListDevices(listRequest(), LOOPBACK_IP);
+    const body = (await res.json()) as {
+      devices: { hashedDeviceId: string; lastUsedAt: number | null }[];
+    };
+    expect(body.devices[0]?.lastUsedAt).toBeNull();
+  });
+
+  test("does not borrow another principal's stamp for the same device hash", async () => {
+    seedActor({
+      device: "device-A",
+      principal: "other-guardian",
+      lastUsedAt: 1_700_000_000_000,
+    });
+    seedActor({ device: "device-A" });
+
+    const res = await handleListDevices(listRequest(), LOOPBACK_IP);
+    const body = (await res.json()) as {
+      devices: { hashedDeviceId: string; lastUsedAt: number | null }[];
+    };
+    expect(body.devices).toHaveLength(1);
+    expect(body.devices[0]?.lastUsedAt).toBeNull();
   });
 
   test("rejects a non-loopback caller (403)", async () => {

--- a/gateway/src/__tests__/devices.test.ts
+++ b/gateway/src/__tests__/devices.test.ts
@@ -40,6 +40,7 @@ function seedActor(opts: {
   principal?: string;
   status?: "active" | "revoked";
   platform?: string;
+  lastUsedAt?: number;
 }): void {
   const now = Date.now();
   const principal = opts.principal ?? GUARDIAN_ID;
@@ -54,6 +55,7 @@ function seedActor(opts: {
       status: opts.status ?? "active",
       issuedAt: now,
       expiresAt: now + 86_400_000,
+      lastUsedAt: opts.lastUsedAt ?? null,
       createdAt: now,
       updatedAt: now,
     })
@@ -196,10 +198,8 @@ describe("GET /v1/devices", () => {
     expect(a?.platform).toBe("cli");
   });
 
-  test("surfaces lastUsedAt from the refresh record (null when none)", async () => {
-    seedActor({ device: "device-A" });
-    seedActor({ device: "device-B" });
-    seedRefresh({ device: "device-A", lastUsedAt: 1_700_000_000_000 });
+  test("surfaces lastUsedAt from the actor token row", async () => {
+    seedActor({ device: "device-A", lastUsedAt: 1_700_000_000_000 });
 
     const res = await handleListDevices(listRequest(), LOOPBACK_IP);
     const body = (await res.json()) as {
@@ -208,10 +208,21 @@ describe("GET /v1/devices", () => {
     const a = body.devices.find(
       (d) => d.hashedDeviceId === hashToken("device-A"),
     );
+    expect(a?.lastUsedAt).toBe(1_700_000_000_000);
+  });
+
+  test("serializes lastUsedAt as null when the token row is unstamped", async () => {
+    seedActor({ device: "device-B" });
+    // Guards against the refresh record's timestamp leaking into the response.
+    seedRefresh({ device: "device-B", lastUsedAt: 1_700_000_000_000 });
+
+    const res = await handleListDevices(listRequest(), LOOPBACK_IP);
+    const body = (await res.json()) as {
+      devices: { hashedDeviceId: string; lastUsedAt: number | null }[];
+    };
     const b = body.devices.find(
       (d) => d.hashedDeviceId === hashToken("device-B"),
     );
-    expect(a?.lastUsedAt).toBe(1_700_000_000_000);
     expect(b?.lastUsedAt).toBeNull();
   });
 

--- a/gateway/src/http/routes/devices.ts
+++ b/gateway/src/http/routes/devices.ts
@@ -18,10 +18,7 @@ import {
   revokeRefreshTokensByDevice,
 } from "../../auth/guardian-bootstrap.js";
 import { getGatewayDb } from "../../db/connection.js";
-import {
-  actorRefreshTokenRecords,
-  actorTokenRecords,
-} from "../../db/schema.js";
+import { actorTokenRecords } from "../../db/schema.js";
 import {
   enforceLoopbackOnly,
   errorResponse,
@@ -56,6 +53,7 @@ export async function handleListDevices(
       platform: actorTokenRecords.platform,
       issuedAt: actorTokenRecords.issuedAt,
       expiresAt: actorTokenRecords.expiresAt,
+      lastUsedAt: actorTokenRecords.lastUsedAt,
     })
     .from(actorTokenRecords)
     .where(
@@ -66,30 +64,12 @@ export async function handleListDevices(
     )
     .all();
 
-  // lastUsedAt lives on the refresh record; map by device for enrichment.
-  const refresh = db
-    .select({
-      hashedDeviceId: actorRefreshTokenRecords.hashedDeviceId,
-      lastUsedAt: actorRefreshTokenRecords.lastUsedAt,
-    })
-    .from(actorRefreshTokenRecords)
-    .where(
-      and(
-        eq(actorRefreshTokenRecords.guardianPrincipalId, guardianPrincipalId),
-        eq(actorRefreshTokenRecords.status, "active"),
-      ),
-    )
-    .all();
-  const lastUsedByDevice = new Map(
-    refresh.map((r) => [r.hashedDeviceId, r.lastUsedAt ?? null]),
-  );
-
   const devices = tokens.map((t) => ({
     hashedDeviceId: t.hashedDeviceId,
     platform: t.platform,
     issuedAt: t.issuedAt,
     expiresAt: t.expiresAt ?? null,
-    lastUsedAt: lastUsedByDevice.get(t.hashedDeviceId) ?? null,
+    lastUsedAt: t.lastUsedAt ?? null,
   }));
 
   return Response.json({ devices });

--- a/gateway/src/http/routes/devices.ts
+++ b/gateway/src/http/routes/devices.ts
@@ -11,7 +11,7 @@
  * the local assistant's guardian principal.
  */
 
-import { and, eq } from "drizzle-orm";
+import { and, eq, max } from "drizzle-orm";
 
 import {
   revokeActorTokensByDevice,
@@ -64,12 +64,29 @@ export async function handleListDevices(
     )
     .all();
 
+  // Refreshing credentials revokes the active row and mints an unstamped
+  // replacement, so the newest stamp for a device can live on a revoked row.
+  // Take the max across every status to keep activity history across rotation.
+  const lastUsedRows = db
+    .select({
+      hashedDeviceId: actorTokenRecords.hashedDeviceId,
+      lastUsedAt: max(actorTokenRecords.lastUsedAt),
+    })
+    .from(actorTokenRecords)
+    .where(eq(actorTokenRecords.guardianPrincipalId, guardianPrincipalId))
+    .groupBy(actorTokenRecords.hashedDeviceId)
+    .all();
+
+  const lastUsedByDevice = new Map<string, number | null>(
+    lastUsedRows.map((r) => [r.hashedDeviceId, r.lastUsedAt ?? null]),
+  );
+
   const devices = tokens.map((t) => ({
     hashedDeviceId: t.hashedDeviceId,
     platform: t.platform,
     issuedAt: t.issuedAt,
     expiresAt: t.expiresAt ?? null,
-    lastUsedAt: t.lastUsedAt ?? null,
+    lastUsedAt: lastUsedByDevice.get(t.hashedDeviceId) ?? t.lastUsedAt ?? null,
   }));
 
   return Response.json({ devices });


### PR DESCRIPTION
## Summary

- `GET /v1/devices` now reads `lastUsedAt` from the `actor_token_records` row (the column PR 1 added and the stamping helper writes) instead of the `actor_refresh_token_records` join.
- That join was structurally dead: its only writer, `markRotated`, sets `lastUsedAt` and flips the row to `status = 'rotated'` in the same UPDATE, so the `status = 'active'` rows it selected were guaranteed to hold null. Every paired device reported an unknown last-used time.
- Deleting it also removes a full extra query per request. `markRotated`'s write stays in place as rotation bookkeeping; this PR only stops reading it for this field.
- Tests cover both a stamped row returning its timestamp verbatim and an unstamped row serializing as `null` even when a refresh record carries a timestamp.

No contract change: `lastUsedAt: number | null` already flows to the CLI, which still prints `never` for null.

Part of plan: paired-devices-last-used.md (PR 4 of 6)