### PR TITLE
feat(web): order paired devices by most recent activity

### DIFF
--- a/clients/web/src/domains/settings/pair-device/paired-devices-section.test.tsx
+++ b/clients/web/src/domains/settings/pair-device/paired-devices-section.test.tsx
@@ -75,6 +75,7 @@ const POLL_INTERVAL_MS = 5_000;
 
 const HASH_A = "aaaabbbbccccdddd0000111122223333";
 const HASH_B = "eeeeffff00001111aaaabbbbccccdddd";
+const HASH_C = "1111222233334444aaaabbbbccccdddd";
 
 function device(
   overrides: Partial<LocalPairedDeviceRecord> = {},
@@ -107,6 +108,13 @@ function clickConfirm() {
   fireEvent.click(
     document.querySelector<HTMLButtonElement>("[data-confirm-dialog-confirm]")!,
   );
+}
+
+/** Rendered rows in order, read off the full hash each row's chip carries. */
+function renderedDeviceOrder(): string[] {
+  return Array.from(
+    document.querySelectorAll<HTMLSpanElement>("span[title]"),
+  ).map((span) => span.title);
 }
 
 beforeEach(() => {
@@ -377,6 +385,52 @@ describe("PairedDevicesSection", () => {
     expect(screen.getByText(/^Paired \d\S+$/)).toBeTruthy();
     expect(screen.queryByText(/Last used/)).toBeNull();
     expect(document.body.textContent).not.toContain("unknown");
+  });
+
+  test("orders devices by most recent activity, never-seen ones last", async () => {
+    await renderExpanded([
+      device({ hashedDeviceId: HASH_A, lastUsedAt: null }),
+      device({
+        hashedDeviceId: HASH_B,
+        lastUsedAt: Date.parse("2026-08-10T12:00:00Z"),
+      }),
+      device({
+        hashedDeviceId: HASH_C,
+        lastUsedAt: Date.parse("2026-08-20T12:00:00Z"),
+      }),
+    ]);
+
+    expect(renderedDeviceOrder()).toEqual([HASH_C, HASH_B, HASH_A]);
+  });
+
+  test("revoking targets the clicked row once the list is reordered", async () => {
+    await renderExpanded([
+      device({
+        hashedDeviceId: HASH_A,
+        platform: "ios",
+        lastUsedAt: Date.parse("2026-08-10T12:00:00Z"),
+      }),
+      device({
+        hashedDeviceId: HASH_B,
+        platform: "android",
+        lastUsedAt: Date.parse("2026-08-20T12:00:00Z"),
+      }),
+    ]);
+
+    // The android device is the more recently used one, so it sorts first.
+    expect(renderedDeviceOrder()).toEqual([HASH_B, HASH_A]);
+    fireEvent.click(screen.getAllByRole("button", { name: "Revoke" })[0]!);
+
+    expect(
+      screen.getByText(new RegExp(`Android device ${HASH_B.slice(0, 12)}`)),
+    ).toBeTruthy();
+    clickConfirm();
+
+    await waitFor(() =>
+      expect(revokeCalls).toEqual([
+        { assistantId: "self", hashedDeviceId: HASH_B },
+      ]),
+    );
   });
 
   test("a failed revoke keeps the dialog open with the error", async () => {

--- a/clients/web/src/domains/settings/pair-device/paired-devices-section.tsx
+++ b/clients/web/src/domains/settings/pair-device/paired-devices-section.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from "react";
+
 import { ChevronDown } from "lucide-react";
 
 import { Button } from "@vellumai/design-library/components/button";
@@ -81,7 +83,19 @@ export function PairedDevicesSection({
   // refetches on its own while pairing, so without a tick they freeze.
   useRelativeAgeTick(devices?.some((d) => d.lastUsedAt !== null) ?? false);
 
-  if (devices === null || devices.length === 0) {
+  // Live devices first, never-seen last, so revoke candidates cluster at the
+  // bottom. The controller owns `devices`, so the sort runs on a copy.
+  const orderedDevices = useMemo(
+    () =>
+      devices === null
+        ? null
+        : [...devices].sort(
+            (a, b) => (b.lastUsedAt ?? 0) - (a.lastUsedAt ?? 0),
+          ),
+    [devices],
+  );
+
+  if (orderedDevices === null || orderedDevices.length === 0) {
     return null;
   }
 
@@ -91,13 +105,15 @@ export function PairedDevicesSection({
         <Collapsible.Item value="paired-devices">
           <Collapsible.Trigger className="group flex w-full items-center justify-between gap-3">
             <span className="text-body-medium-default text-[var(--content-secondary)]">
-              {t("pairedDevicesSection.title", { count: devices.length })}
+              {t("pairedDevicesSection.title", {
+                count: orderedDevices.length,
+              })}
             </span>
             <ChevronDown className="h-4 w-4 shrink-0 text-[var(--content-tertiary)] transition-transform group-data-[state=open]:rotate-180" />
           </Collapsible.Trigger>
           <Collapsible.Content>
             <div className="mt-3 flex flex-col gap-3">
-              {devices.map((device) => (
+              {orderedDevices.map((device) => (
                 <div
                   key={device.hashedDeviceId}
                   className="flex items-center justify-between gap-3"


### PR DESCRIPTION
## Summary

- Sorts the Paired devices list by `lastUsedAt` descending with never-seen devices last, so eight near-identical rows are finally tellable apart: live devices float to the top, revoke candidates cluster at the bottom.
- Derives the order in the view via `useMemo` on a copy of the controller's array, so `usePairedDevices` stays a fetch/revoke seam and nothing mutates state it does not own. The sort is stable, so equal stamps keep the host's order.
- Adds coverage for the reordering (including nulls last) and for the revoke confirm dialog still naming and revoking the row the user clicked after the list is reordered.

Part of plan: paired-devices-last-used.md (PR 6 of 6)