### PR TITLE
feat(gateway): stamp device activity on websocket and IPC token paths

### DIFF
--- a/gateway/src/http/routes/auth-token.ts
+++ b/gateway/src/http/routes/auth-token.ts
@@ -5,6 +5,7 @@ import { eq } from "drizzle-orm";
 import {
   actorTokenRecordHash,
   isActorTokenRevoked,
+  recordActorTokenUse,
 } from "../../auth/actor-token-revocation.js";
 import {
   ensureVellumGuardianBinding,
@@ -154,6 +155,7 @@ export async function handleCreateToken(
     log.warn("Token create rejected: source token revoked");
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
+  recordActorTokenUse(bearerToken, verifyResult.claims);
 
   const sourceRecord = findSourceActorTokenRecord(bearerToken);
   let guardianPrincipalId = sourceRecord?.guardianPrincipalId;

--- a/gateway/src/http/routes/ipc-runtime-proxy.ts
+++ b/gateway/src/http/routes/ipc-runtime-proxy.ts
@@ -12,7 +12,10 @@
  * IPC, and converts the result back into an HTTP Response.
  */
 
-import { isActorTokenRevoked } from "../../auth/actor-token-revocation.js";
+import {
+  isActorTokenRevoked,
+  recordActorTokenUse,
+} from "../../auth/actor-token-revocation.js";
 import { resolveScopeProfile } from "../../auth/scopes.js";
 import { parseSub } from "../../auth/subject.js";
 import { validateEdgeToken } from "../../auth/token-exchange.js";
@@ -82,6 +85,7 @@ export async function tryIpcProxy(
       );
       return Response.json({ error: "Unauthorized" }, { status: 401 });
     }
+    recordActorTokenUse(edgeJwt, result.claims);
     claims = result.claims;
   }
 

--- a/gateway/src/http/routes/live-voice-websocket.ts
+++ b/gateway/src/http/routes/live-voice-websocket.ts
@@ -4,7 +4,10 @@ import {
   validateEdgeToken,
   mintServiceToken,
 } from "../../auth/token-exchange.js";
-import { isActorTokenRevoked } from "../../auth/actor-token-revocation.js";
+import {
+  isActorTokenRevoked,
+  recordActorTokenUse,
+} from "../../auth/actor-token-revocation.js";
 import { parseSub } from "../../auth/subject.js";
 import type { GatewayConfig } from "../../config.js";
 import { getLogger } from "../../logger.js";
@@ -130,6 +133,7 @@ async function checkLiveVoiceAuth(
     log.warn("Live voice WS: rejected — actor token revoked");
     return new Response("Unauthorized", { status: 401 });
   }
+  recordActorTokenUse(rawToken, result.claims);
 
   const parsed = parseSub(result.claims.sub);
   if (

--- a/gateway/src/http/routes/runtime-audio-stream.ts
+++ b/gateway/src/http/routes/runtime-audio-stream.ts
@@ -35,7 +35,10 @@ import {
   validateEdgeToken,
   mintServiceToken,
 } from "../../auth/token-exchange.js";
-import { isActorTokenRevoked } from "../../auth/actor-token-revocation.js";
+import {
+  isActorTokenRevoked,
+  recordActorTokenUse,
+} from "../../auth/actor-token-revocation.js";
 import { parseSub } from "../../auth/subject.js";
 import type { GatewayConfig } from "../../config.js";
 
@@ -126,6 +129,7 @@ export function authorizeRuntimeAudioStream(
       response: new Response("Unauthorized", { status: 401 }),
     };
   }
+  recordActorTokenUse(rawToken, result.claims);
 
   // An actor principal and nothing else. These are client-facing paths, and a
   // service token reaching one would let a credential minted for machine to


### PR DESCRIPTION
## Summary
- Stamps actor-token device activity on the remaining gateway entry points that run their own inline auth: the IPC runtime proxy, the live-voice WebSocket upgrade, the shared runtime audio-stream gate, and the `/auth/token` derived-token mint.
- Each `recordActorTokenUse` call sits immediately after the existing `isActorTokenRevoked` guard, on the allow path only, so a revoked token still 401s without stamping.
- The plan named `stt-stream-websocket.ts`, but that route has no revocation check of its own: its token gate is factored into `authorizeRuntimeAudioStream` in `runtime-audio-stream.ts`, so the stamp went there. That also covers `/v1/watch/stream`, which shares the same gate.

Part of plan: paired-devices-last-used.md (PR 3 of 6)