### PR TITLE
feat(gateway): stamp device activity on edge and runtime-proxy requests

### DIFF
--- a/gateway/src/__tests__/edge-auth.test.ts
+++ b/gateway/src/__tests__/edge-auth.test.ts
@@ -16,6 +16,11 @@
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { eq } from "drizzle-orm";
 
 import "./test-preload.js";
 
@@ -51,6 +56,11 @@ mock.module("../auth/token-exchange.js", () => ({
 const { AuthRateLimiter } = await import("../auth-rate-limiter.js");
 const { createAuthMiddleware, loopbackFallbackCountTracker } =
   await import("../http/middleware/auth.js");
+const { initGatewayDb, resetGatewayDb, getGatewayDb } =
+  await import("../db/connection.js");
+const { actorTokenRecords } = await import("../db/schema.js");
+const { actorTokenRecordHash, __resetLastUsedDebounceForTests } =
+  await import("../auth/actor-token-revocation.js");
 
 const PLATFORM_USER_ID = "user-abc-123";
 
@@ -505,5 +515,101 @@ describe("requireEdgeAuth — trustProxy loopback fallback", () => {
     // platform 401 (missing user header), NOT a loopback free pass.
     const res = await requireEdgeAuth(makeReq(), makeLoopbackServer());
     expect(res?.status).toBe(401);
+  });
+});
+
+// =========================================================================
+// Device last-used stamping: the edge allow path records activity for the
+// presenting device so the "Paired devices" list can show it.
+// =========================================================================
+
+describe("requireEdgeAuth: device last-used stamping", () => {
+  // Every seeded row belongs to the same device, so a stamp routed through the
+  // device lands on whichever row is active.
+  function seedTokenRow(rawToken: string, status: "active" | "revoked") {
+    const now = Date.now();
+    getGatewayDb()
+      .insert(actorTokenRecords)
+      .values({
+        id: `row-${rawToken}`,
+        tokenHash: actorTokenRecordHash(rawToken),
+        guardianPrincipalId: "guardian-001",
+        hashedDeviceId: "hashed-device-web",
+        platform: "web",
+        status,
+        issuedAt: now,
+        expiresAt: now + 86_400_000,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+  }
+
+  function readLastUsedAt(rawToken: string) {
+    return getGatewayDb()
+      .select({ lastUsedAt: actorTokenRecords.lastUsedAt })
+      .from(actorTokenRecords)
+      .where(eq(actorTokenRecords.tokenHash, actorTokenRecordHash(rawToken)))
+      .get()?.lastUsedAt;
+  }
+
+  // Own the security dir: the shared preload's env vars are already restored by
+  // the time this file runs as part of the full suite.
+  let savedSecurityDir: string | undefined;
+  let dbRoot: string;
+
+  beforeEach(async () => {
+    savedSecurityDir = process.env.GATEWAY_SECURITY_DIR;
+    dbRoot = mkdtempSync(join(tmpdir(), "edge-auth-last-used-"));
+    const securityDir = join(dbRoot, "protected");
+    mkdirSync(securityDir, { recursive: true });
+    process.env.GATEWAY_SECURITY_DIR = securityDir;
+    await initGatewayDb();
+    __resetLastUsedDebounceForTests();
+    mockValidateEdgeToken = mock(() => ({
+      ok: true,
+      claims: { sub: "actor:asst:123", scope_profile: "actor_client_v1" },
+    }));
+  });
+
+  afterEach(() => {
+    resetGatewayDb();
+    if (savedSecurityDir === undefined) {
+      delete process.env.GATEWAY_SECURITY_DIR;
+    } else {
+      process.env.GATEWAY_SECURITY_DIR = savedSecurityDir;
+    }
+    try {
+      rmSync(dbRoot, { recursive: true, force: true });
+    } catch {
+      /* best effort */
+    }
+  });
+
+  test("stamps last_used_at on the device's active row", async () => {
+    seedTokenRow("live-token", "active");
+    expect(readLastUsedAt("live-token")).toBeNull();
+
+    const { requireEdgeAuth } = makeMiddleware();
+    const res = await requireEdgeAuth(
+      makeReq({ authorization: "Bearer live-token" }),
+    );
+
+    expect(res).toBeNull();
+    expect(readLastUsedAt("live-token")).toBeGreaterThan(0);
+  });
+
+  test("a revoked token 401s and stamps nothing", async () => {
+    seedTokenRow("dead-token", "revoked");
+    seedTokenRow("live-token", "active");
+
+    const { requireEdgeAuth } = makeMiddleware();
+    const res = await requireEdgeAuth(
+      makeReq({ authorization: "Bearer dead-token" }),
+    );
+
+    expect(res?.status).toBe(401);
+    expect(readLastUsedAt("live-token")).toBeNull();
+    expect(readLastUsedAt("dead-token")).toBeNull();
   });
 });

--- a/gateway/src/http/middleware/auth.ts
+++ b/gateway/src/http/middleware/auth.ts
@@ -1,6 +1,9 @@
 import type { Server } from "bun";
 
-import { isActorTokenRevoked } from "../../auth/actor-token-revocation.js";
+import {
+  isActorTokenRevoked,
+  recordActorTokenUse,
+} from "../../auth/actor-token-revocation.js";
 import { findVellumGuardian } from "../../auth/guardian-bootstrap.js";
 import { resolveScopeProfile } from "../../auth/scopes.js";
 import { parseSub } from "../../auth/subject.js";
@@ -352,20 +355,24 @@ export function createAuthMiddleware(
   /**
    * Reject a validated edge token whose actor record has been revoked. Returns
    * a 401 response when revoked, or null to continue. Fail-open for non-actor
-   * and unrecorded tokens (see isActorTokenRevoked).
+   * and unrecorded tokens (see isActorTokenRevoked). On the allow path, stamps
+   * the presenting device's last-used activity (debounced, fail-open).
    */
   function rejectIfActorTokenRevoked(
     req: Request,
     token: string,
     claims: TokenClaims,
   ): Response | null {
-    if (!isActorTokenRevoked(token, claims)) return null;
-    authRateLimiter.recordFailure(getClientIp());
-    log.warn(
-      { path: new URL(req.url).pathname },
-      "Edge auth rejected: actor token revoked",
-    );
-    return Response.json({ error: "Unauthorized" }, { status: 401 });
+    if (isActorTokenRevoked(token, claims)) {
+      authRateLimiter.recordFailure(getClientIp());
+      log.warn(
+        { path: new URL(req.url).pathname },
+        "Edge auth rejected: actor token revoked",
+      );
+      return Response.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    recordActorTokenUse(token, claims);
+    return null;
   }
 
   function allowLegacyLoopbackFallback(

--- a/gateway/src/http/routes/runtime-proxy.ts
+++ b/gateway/src/http/routes/runtime-proxy.ts
@@ -11,7 +11,10 @@ import {
   mintExchangeToken,
   mintServiceToken,
 } from "../../auth/token-exchange.js";
-import { isActorTokenRevoked } from "../../auth/actor-token-revocation.js";
+import {
+  isActorTokenRevoked,
+  recordActorTokenUse,
+} from "../../auth/actor-token-revocation.js";
 import type { GatewayConfig } from "../../config.js";
 import { fetchImpl } from "../../fetch.js";
 import { getLogger } from "../../logger.js";
@@ -85,6 +88,7 @@ export function createRuntimeProxyHandler(config: GatewayConfig) {
         );
         return Response.json({ error: "Unauthorized" }, { status: 401 });
       }
+      recordActorTokenUse(edgeJwt, result.claims);
       exchangeToken = mintExchangeToken(
         result.claims,
         result.claims.scope_profile,


### PR DESCRIPTION
## Summary

- Stamp `last_used_at` for the presenting device on the edge auth middleware's allow path, after the actor-token revocation check passes (covers every `edge`, `edge-scoped`, and `edge-guardian` route).
- Stamp in the runtime-proxy catch-all too: it does its own inline auth, never reaches the middleware, and carries the actual client message traffic to the daemon.
- Reject paths are unchanged, so a revoked token still 401s and writes nothing; no response body, status code, or header changes. Covered by two new cases in `edge-auth.test.ts`.

Part of plan: paired-devices-last-used.md (PR 2 of 6)