### PR TITLE
Mobile drawer polish: opaque surface, level pills, search beside the bell

### DIFF
--- a/clients/web/src/components/collapsible-nav-section.tsx
+++ b/clients/web/src/components/collapsible-nav-section.tsx
@@ -299,11 +299,13 @@ function CollapsibleNavSectionSection({
         // the click target and long labels still truncate. The primitive
         // hardcodes `flex` on it, so the growth comes from here.
         "[&>[data-slot=collapsible-header]]:min-w-0 [&>[data-slot=collapsible-header]]:flex-1",
-        /* A card's header is the height of its label. The controls beside it
-           are touch targets rather than content, so they keep their own size
-           and centre-overflow this row instead of setting it; the card's top
-           padding is deeper than the overflow, so nothing escapes the card. */
-        card && "h-4",
+        /* A card's header row, sized so that with the card's 12px vertical
+           inset the collapsed pill lands on the overlay tile size (44px).
+           The controls beside it are touch targets rather than content, so
+           they keep their own size and centre-overflow this row instead of
+           setting it; the card's top padding is deeper than the overflow,
+           so nothing escapes the card. */
+        card && "h-5",
         drag && "cursor-grab active:cursor-grabbing",
       )}
       {...drag?.headerProps}

--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -1191,11 +1191,11 @@ export function ChatLayout({
                   hosts is transparent, so this one fill covers both the menu
                   and the safe-area padding ring around it, which is what
                   keeps tinted strips off the notch / home-indicator edges on
-                  iOS. It thins toward the chat side (Figma 7842-83305), so
-                  the page stays legible behind the drawer while the column of
-                  navigation itself rests on solid ground. Painting it here
-                  rather than on the menu also keeps it one layer: two
-                  translucent fills would compose back to opaque. No border:
+                  iOS. The fill is fully opaque (Figma 7842-83305), so the
+                  chat never bleeds through the sheet. Painting it here
+                  rather than on the menu keeps one owner of the surface
+                  color; a second fill on the menu would composite over this
+                  one and shift the drawn color off its token. No border:
                   the sheet covers the full screen, so there is no edge to draw.
                   No bottom padding either: the SideMenu root clips its
                   children (`overflow-hidden`), so a bottom inset places the

--- a/clients/web/src/domains/chat/components/assistant-side-menu.stories.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.stories.tsx
@@ -433,9 +433,9 @@ export const CharacterAvatar: Story = {
 /**
  * The mobile drawer (Figma 7842-83305). Its own decorator, because the
  * overlay's shell is not the desktop one: `chat-layout` mounts it as a
- * full-bleed sheet over the chat, and the sheet's surface thins toward the
- * chat edge, so the page behind it has to be there for the gradient to mean
- * anything. The frame is a 402x874 phone.
+ * full-bleed sheet over the chat, and the page behind it has to be there to
+ * confirm the sheet's opaque surface fully covers it. The frame is a
+ * 402x874 phone.
  */
 export const OverlayDrawer: Story = {
   name: "Overlay drawer (mobile)",
@@ -444,8 +444,8 @@ export const OverlayDrawer: Story = {
   decorators: [
     (Story) => (
       <div className="relative h-[874px] w-[402px] overflow-hidden bg-[var(--surface-base)]">
-        {/* Stand-in for the chat the drawer covers: only its legibility
-            through the sheet is under test, not its own layout. */}
+        {/* Stand-in for the chat the drawer covers: only whether the sheet
+            fully hides it is under test, not its own layout. */}
         <div className="absolute inset-0 flex flex-col gap-3 p-4 pt-24 text-body-medium-lighter text-[var(--content-default)]">
           <p>You&rsquo;re absolutely right, and thank you for correcting me.</p>
           <p>

--- a/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
@@ -966,6 +966,9 @@ describe("AssistantSideMenu · overlay section card geometry", () => {
     expect(cardTokens).toContain("rounded-[16px]");
     expect(cardTokens).toContain("pt-3");
     expect(cardTokens).toContain("pb-3");
+    // Without this the Card's default transparent 1px border grows the
+    // border-box to 46px.
+    expect(cardTokens).toContain("border-0");
 
     const header = container.querySelector(
       '[data-slot="collapsible-nav-section-header"]',

--- a/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
@@ -206,6 +206,7 @@ function renderMenu(props: {
   conversationsFailed?: boolean;
   onRetryConversations?: () => void;
   onWidthChange?: (width: number) => void;
+  includeNotificationsAction?: boolean;
 }): string {
   setSectionRows(props.conversations);
   const includeFooterAction = props.includeFooterAction ?? true;
@@ -228,6 +229,9 @@ function renderMenu(props: {
         : undefined,
       tipCard: props.includeTipCard
         ? createElement("span", null, "TipSentinel")
+        : undefined,
+      notificationsAction: props.includeNotificationsAction
+        ? createElement("span", { "data-testid": "bell-stub" }, "Bell")
         : undefined,
     }),
   );
@@ -906,6 +910,23 @@ describe("AssistantSideMenu · native mobile floating glyph row", () => {
     );
   });
 
+  test("search sits in the right cluster beside the notifications bell", () => {
+    const container = document.createElement("div");
+    container.innerHTML = renderMenu({
+      conversations,
+      variant: "overlay",
+      includeNotificationsAction: true,
+    });
+
+    // Mirrors the chat header's right cluster: search directly left of the
+    // bell, with the close glyph alone on the other side of the row.
+    const cluster = glyph(container, "Search (⌘K)").parentElement;
+    expect(cluster?.querySelector('[data-testid="bell-stub"]')).not.toBeNull();
+    expect(
+      cluster?.querySelector('[aria-label="Close navigation"]'),
+    ).toBeNull();
+  });
+
   test("the scroll body reserves the glyph band and carries both mask declarations", () => {
     const body = classTokens(
       overlayDom().querySelector('[data-slot="side-menu-body"]'),
@@ -926,6 +947,31 @@ describe("AssistantSideMenu · native mobile floating glyph row", () => {
     expect(body).toContain(
       "native-mobile:[-webkit-mask-image:linear-gradient(to_bottom,transparent,black_2.75rem)]",
     );
+  });
+});
+
+describe("AssistantSideMenu · overlay section card geometry", () => {
+  // Class-presence pins: 12px vertical inset + 20px header row put the
+  // collapsed section pill at the overlay tile size (44px), level with the
+  // assistant pill.
+  test("the overlay card and its header carry the 44px pill geometry", () => {
+    const container = document.createElement("div");
+    container.innerHTML = renderMenu({
+      conversations: [makeConversation({ conversationId: "a", title: "Alpha" })],
+      variant: "overlay",
+    });
+
+    const card = container.querySelector('[data-slot="card"]');
+    const cardTokens = card ? Array.from(card.classList) : [];
+    expect(cardTokens).toContain("rounded-[16px]");
+    expect(cardTokens).toContain("pt-3");
+    expect(cardTokens).toContain("pb-3");
+
+    const header = container.querySelector(
+      '[data-slot="collapsible-nav-section-header"]',
+    );
+    const headerTokens = header ? Array.from(header.classList) : [];
+    expect(headerTokens).toContain("h-5");
   });
 });
 

--- a/clients/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -75,9 +75,9 @@ export interface AssistantSideMenuProps extends UseSidebarStateParams {
   onStartNewConversation?: () => void;
   footerAction?: ReactNode;
   /**
-   * Trailing control in the overlay's glyph row, opposite dismiss and search.
-   * A slot rather than a direct render: the control belongs to another
-   * domain, so the page composes it and this menu stays free of the
+   * Trailing control in the overlay's glyph row, beside search and opposite
+   * dismiss. A slot rather than a direct render: the control belongs to
+   * another domain, so the page composes it and this menu stays free of the
    * dependency (and of the router context it needs).
    */
   notificationsAction?: ReactNode;

--- a/clients/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -522,29 +522,32 @@ export function AssistantSideMenu({
       >
         <SideMenu.Header>
           {variant === "overlay" ? (
-            /* Dismiss and search lead together on the left, notifications
-               sits alone on the right (Figma 7842-83305). In Capacitor
-               mobile shells the row floats over the scrollport so list
-               content travels beneath the bare glyphs;
-               `pointer-events-none` keeps the gap between the clusters
-               scrollable. */
+            /* Dismiss leads alone on the left; search sits with
+               notifications on the right, mirroring the chat header's
+               right cluster so the glyphs hold one position whether the
+               drawer is open or closed. In Capacitor mobile shells the row
+               floats over the scrollport so list content travels beneath
+               the bare glyphs; `pointer-events-none` keeps the gap between
+               the clusters scrollable. */
             <div
               data-slot="side-menu-glyph-row"
               className="flex items-center justify-between gap-2 native-mobile:pointer-events-none native-mobile:absolute native-mobile:inset-x-3 native-mobile:top-4 native-mobile:z-10"
             >
-              <div className="flex items-center gap-1">
-                <Button
-                  variant="ghost"
-                  iconOnly={<X />}
-                  aria-label={t("assistantSideMenu.closeNavAria")}
-                  className="pointer-events-auto"
-                  onClick={() => onClose?.()}
-                />
+              <Button
+                variant="ghost"
+                iconOnly={<X />}
+                aria-label={t("assistantSideMenu.closeNavAria")}
+                className="pointer-events-auto"
+                onClick={() => onClose?.()}
+              />
+              <div className="flex items-center gap-2">
                 <SearchButton />
+                {notificationsAction ? (
+                  <div className="pointer-events-auto">
+                    {notificationsAction}
+                  </div>
+                ) : null}
               </div>
-              {notificationsAction ? (
-                <div className="pointer-events-auto">{notificationsAction}</div>
-              ) : null}
             </div>
           ) : (
             builtInNav

--- a/clients/web/src/domains/chat/components/sidebar-section-card.tsx
+++ b/clients/web/src/domains/chat/components/sidebar-section-card.tsx
@@ -135,10 +135,12 @@ export function SidebarSectionCard({
            inset its header and row list sit flush inside (Figma 7842-83305).
            The 12px vertical inset plus the 20px header row makes the
            collapsed pill exactly the overlay tile size (44px), so it stands
-           level with the assistant pill above it. The rail keeps the radius
-           that makes its 36px header read as fully round. */
+           level with the assistant pill above it. `border-0` drops the
+           Card's default transparent 1px border, which would otherwise grow
+           the border-box to 46px. The rail keeps that border and the radius
+           that makes its header read as fully round. */
         overlayCards
-          ? "rounded-[16px] pt-3 pr-3 pb-3 pl-2"
+          ? "rounded-[16px] border-0 pt-3 pr-3 pb-3 pl-2"
           : "rounded-[18px]",
         "has-[[data-state=open]]:w-full",
         /* `width` toggles between the measured `--section-collapsed-width`

--- a/clients/web/src/domains/chat/components/sidebar-section-card.tsx
+++ b/clients/web/src/domains/chat/components/sidebar-section-card.tsx
@@ -132,11 +132,13 @@ export function SidebarSectionCard({
            lag behind the width/height change since it never moves. */
         "w-[var(--section-collapsed-width,fit-content)]",
         /* The overlay's card is squarer than the rail's pill and carries the
-           inset its header and row list sit flush inside (Figma 7842-83305);
-           the rail keeps the radius that makes its 36px header read as fully
-           round. */
+           inset its header and row list sit flush inside (Figma 7842-83305).
+           The 12px vertical inset plus the 20px header row makes the
+           collapsed pill exactly the overlay tile size (44px), so it stands
+           level with the assistant pill above it. The rail keeps the radius
+           that makes its 36px header read as fully round. */
         overlayCards
-          ? "rounded-[16px] pt-2.5 pr-3 pb-1.5 pl-2"
+          ? "rounded-[16px] pt-3 pr-3 pb-3 pl-2"
           : "rounded-[18px]",
         "has-[[data-state=open]]:w-full",
         /* `width` toggles between the measured `--section-collapsed-width`

--- a/clients/web/src/domains/chat/components/sidebar-section-card.tsx
+++ b/clients/web/src/domains/chat/components/sidebar-section-card.tsx
@@ -112,11 +112,11 @@ export function SidebarSectionCard({
            row: the card is what owns the fill, and every swipeable thing it
            holds inherits the one value. */
         "[--swipe-reveal-bg:var(--surface-lift)]",
-        /* No padding of its own: the header row is already a self-contained
-           pill (its own height, its own 12px/6px inset) per Figma, and
-           wrapping it in another layer of padding would inflate the pill
-           past its spec. The row list picks up the matching horizontal
-           inset directly (see `CollapsibleNavSection.Section`'s Content). */
+        /* No padding of its own: the overlay class branch below owns the
+           card's inset, and wrapping it in another layer of Card padding
+           would inflate the pill past its spec. The row list picks up the
+           matching horizontal inset directly (see
+           `CollapsibleNavSection.Section`'s Content). */
         /* Collapsed, a section is a pill that hugs its own header: nothing
            inside it needs the full rail width. Its own `Collapsible.Item`
            descendant carries Radix's `data-state`, so `has-[]` reads that

--- a/clients/web/src/domains/chat/utils/drawer-surface.test.ts
+++ b/clients/web/src/domains/chat/utils/drawer-surface.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, test } from "bun:test";
+
+import { DRAWER_SURFACE_BACKGROUND } from "@/domains/chat/utils/drawer-surface";
+
+describe("DRAWER_SURFACE_BACKGROUND", () => {
+  test("paints a fully opaque surface token", () => {
+    // The drawer covers the chat; nothing behind it may bleed through.
+    expect(DRAWER_SURFACE_BACKGROUND).toBe("var(--surface-base)");
+  });
+});

--- a/clients/web/src/domains/chat/utils/drawer-surface.ts
+++ b/clients/web/src/domains/chat/utils/drawer-surface.ts
@@ -1,15 +1,14 @@
 /**
  * The mobile drawer's painted surface (Figma 7842-83305).
  *
- * The sheet covers the chat rather than sitting beside it, so it thins toward
- * the chat edge and leaves the page legible through its right side while the
- * column of navigation rests on solid ground.
+ * The sheet covers the chat rather than sitting beside it and paints a fully
+ * opaque ground, so the page behind never bleeds through the navigation
+ * column.
  *
  * Exported rather than written at the call site because two places draw it:
  * `chat-layout` mounts the real drawer, and the side-menu story mounts one
- * over a stand-in chat so the translucency can be reviewed. A story holding
+ * over a stand-in chat so the surface can be reviewed. A story holding
  * its own copy of the value can drift from the runtime surface and keep a
  * visual review green while showing a presentation nobody receives.
  */
-export const DRAWER_SURFACE_BACKGROUND =
-  "linear-gradient(to right, var(--surface-base), color-mix(in srgb, var(--surface-base) 90%, transparent))";
+export const DRAWER_SURFACE_BACKGROUND = "var(--surface-base)";

--- a/packages/design-library/src/components/side-menu/side-menu.tsx
+++ b/packages/design-library/src/components/side-menu/side-menu.tsx
@@ -267,9 +267,9 @@ const ROOT_RAIL_RESIZABLE_CLASSES = [
 ].join(" ");
 
 /**
- * The overlay paints no surface of its own. Its host owns one, and that
- * surface is translucent on the chat side, so a second fill here would
- * compose with it and close the gap the design opens onto the page beneath.
+ * The overlay paints no surface of its own. Its host owns the one opaque
+ * fill, so a second fill here would composite over it and shift the drawn
+ * color away from the token the host chose.
  */
 const ROOT_OVERLAY_CLASSES = [
   "w-full",


### PR DESCRIPTION
## Summary

Three visual fixes to the mobile navigation drawer (the overlay conversation list):

1. **Fully opaque surface.** The sheet painted a gradient that thinned toward the chat edge, letting the page bleed through its right side. `DRAWER_SURFACE_BACKGROUND` is now plain `var(--surface-base)`, so the drawer fully covers the chat. The Storybook `OverlayDrawer` story shares the constant by design and follows automatically; its docs and a stale design-library comment describing the translucency were updated.

2. **Collapsed Chats pill stands level with the assistant pill.** The collapsed section pill was 32px (10px top inset + 16px header row + 6px bottom inset) next to the assistant pill's 44px. The overlay card now uses a symmetric 12px vertical inset around a 20px header row, landing the collapsed pill exactly on the overlay tile size (44px) with its content centered. Scoped to the overlay (`overlayCards` / `card` flags); the desktop rail is untouched. Side effect: the expanded Chats card gains 2px top and 6px bottom padding.

3. **Search sits directly left of the notification bell.** The search glyph moves out of the left cluster (where it sat beside the X) into a right cluster with the bell, using the same `gap-2` as the chat header's right cluster, so search and bell hold one position whether the drawer is open or closed. The X stays alone on the left. Behavior is unchanged (command palette opens, drawer stays beneath it).

## Test plan

- New pins in the file's established class-token style: the opaque surface constant (`drawer-surface.test.ts`), the 44px card geometry tokens, and search-shares-a-cluster-with-the-bell (the glyph-row tests were already written to survive regrouping and pass unchanged).
- `assistant-side-menu`, `collapsible-nav-section`, `chat-layout-header`, and `drawer-surface` test files green; web and design-library typechecks clean; lint clean.
- Visual QA: `bun storybook` in clients/web, story "Overlay drawer (mobile)"; then on a device or narrow browser, check the drawer's full opacity, the two pills sitting level, and the search/bell pairing top-right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
