### PR TITLE
refactor(gateway): reuse StringDedupCache and debounce unrecorded token lookups

### DIFF
--- a/gateway/src/__tests__/actor-token-revocation.test.ts
+++ b/gateway/src/__tests__/actor-token-revocation.test.ts
@@ -570,12 +570,36 @@ describe("recordActorTokenUse", () => {
     expect(readRow("token-retry")?.lastUsedAt).toBeGreaterThan(0);
   });
 
-  test("a missing record leaves a later stamp for the same token free to run", () => {
+  test("an unrecorded token hash is looked up at most once per debounce window", () => {
+    // Nothing to find: the definitive "no record" answer arms the debounce.
     recordActorTokenUse("token-late", actorClaims);
 
+    // Seed the row the first call missed. A second call inside the window
+    // leaves it unstamped, which is only possible if the lookup was skipped.
     insertTokenRecord("token-late", "active");
     recordActorTokenUse("token-late", actorClaims);
+    expect(readRow("token-late")?.lastUsedAt).toBeNull();
 
+    // Once the window lapses the lookup runs again and finds the row.
+    __resetLastUsedDebounceForTests();
+    recordActorTokenUse("token-late", actorClaims);
     expect(readRow("token-late")?.lastUsedAt).toBeGreaterThan(0);
+  });
+
+  test("a lookup that throws is retried on the next request", () => {
+    // Distinguishes a transient failure from a stable miss: the DB-error path
+    // arms nothing, so the very next call re-queries.
+    const rawDb = (
+      getGatewayDb() as unknown as { $client: import("bun:sqlite").Database }
+    ).$client;
+    rawDb.exec("ALTER TABLE actor_token_records RENAME TO actor_token_stash");
+
+    recordActorTokenUse("token-transient", actorClaims);
+
+    rawDb.exec("ALTER TABLE actor_token_stash RENAME TO actor_token_records");
+    insertTokenRecord("token-transient", "active");
+    recordActorTokenUse("token-transient", actorClaims);
+
+    expect(readRow("token-transient")?.lastUsedAt).toBeGreaterThan(0);
   });
 });

--- a/gateway/src/auth/actor-token-revocation.ts
+++ b/gateway/src/auth/actor-token-revocation.ts
@@ -26,6 +26,7 @@ import { and, eq } from "drizzle-orm";
 
 import { getGatewayDb } from "../db/connection.js";
 import { actorTokenRecords } from "../db/schema.js";
+import { StringDedupCache } from "../dedup-cache.js";
 import { getLogger } from "../logger.js";
 import type { TokenClaims } from "./types.js";
 import { parseSub } from "./subject.js";
@@ -34,10 +35,10 @@ const log = getLogger("actor-token-revocation");
 
 /** One stamp per token per window; the label's resolution is this coarse. */
 const STAMP_DEBOUNCE_MS = 5 * 60 * 1000;
-/** Bound on the debounce map so long-lived gateways cannot leak. */
+/** Bound on the debounce cache so long-lived gateways cannot leak. */
 const MAX_TRACKED_TOKENS = 5_000;
 
-const lastStampedByTokenHash = new Map<string, number>();
+let stampDebounce = new StringDedupCache(STAMP_DEBOUNCE_MS, MAX_TRACKED_TOKENS);
 
 /**
  * SHA-256 hex digest, matching how tokens are hashed at mint time. Inlined
@@ -123,23 +124,15 @@ export function isActorTokenRevoked(
   }
 }
 
-function evictStaleStamps(now: number): void {
-  for (const [hash, stamped] of lastStampedByTokenHash) {
-    if (now - stamped >= STAMP_DEBOUNCE_MS) {
-      lastStampedByTokenHash.delete(hash);
-    }
-  }
-  if (lastStampedByTokenHash.size > MAX_TRACKED_TOKENS) {
-    lastStampedByTokenHash.clear();
-  }
-}
-
 /**
  * Stamp `lastUsedAt` for the device behind `rawToken`, powering the "Paired
  * devices" list's last-used label.
  *
- * Debounced to one write per token per {@link STAMP_DEBOUNCE_MS}, counted from
- * a completed stamp so a DB error leaves the next request free to retry.
+ * Debounced to one DB round-trip per token per {@link STAMP_DEBOUNCE_MS}. The
+ * window is armed by a completed stamp, and also by a definitive "no such
+ * record" answer: unrecorded tokens are a permanent supported state, so their
+ * lookup must not repeat on every request. A DB error arms nothing, leaving the
+ * next request free to retry immediately.
  *
  * Resolved through the DEVICE rather than the presented row: `/auth/token`
  * mints `status = 'derived'` rows sharing the source row's `hashed_device_id`
@@ -162,8 +155,7 @@ export function recordActorTokenUse(
 
   const now = Date.now();
   const tokenHash = actorTokenRecordHash(rawToken);
-  const stamped = lastStampedByTokenHash.get(tokenHash);
-  if (stamped !== undefined && now - stamped < STAMP_DEBOUNCE_MS) {
+  if (stampDebounce.has(tokenHash)) {
     return;
   }
 
@@ -178,6 +170,8 @@ export function recordActorTokenUse(
       .where(eq(actorTokenRecords.tokenHash, tokenHash))
       .get();
     if (!record) {
+      // A stable answer, not a failure: hold the lookup off for a window.
+      stampDebounce.mark(tokenHash);
       return;
     }
 
@@ -192,10 +186,7 @@ export function recordActorTokenUse(
       )
       .run();
 
-    if (lastStampedByTokenHash.size >= MAX_TRACKED_TOKENS) {
-      evictStaleStamps(now);
-    }
-    lastStampedByTokenHash.set(tokenHash, now);
+    stampDebounce.mark(tokenHash);
   } catch (err) {
     log.warn(
       { err: err instanceof Error ? err.message : String(err) },
@@ -204,7 +195,7 @@ export function recordActorTokenUse(
   }
 }
 
-/** Clears the last-used debounce map. Exists solely for tests. */
+/** Clears the last-used debounce state. Exists solely for tests. */
 export function __resetLastUsedDebounceForTests(): void {
-  lastStampedByTokenHash.clear();
+  stampDebounce = new StringDedupCache(STAMP_DEBOUNCE_MS, MAX_TRACKED_TOKENS);
 }


### PR DESCRIPTION
## Summary

- Replace the hand-rolled last-used debounce map in `actor-token-revocation.ts` with the existing `StringDedupCache(ttlMs, maxSize)` from `gateway/src/dedup-cache.ts`. Its `has()` / `mark()` split matches the required semantics exactly, including the subtle one: only a completed stamp suppresses a retry, because `mark()` runs after the UPDATE succeeds. Deletes `evictStaleStamps`, the raw `Map`, and the manual size guard (two-tier eviction is already inside the cache).
- Arm the debounce on the `!record` path. An unrecorded actor token is a permanent, supported, fail-open state (loopback and browser-extension pairing in `pair.ts` mints non-device-bound tokens that are never inserted into `actor_token_records`), so every request for such a token was re-running the same indexed `SELECT ... WHERE token_hash = ?` forever, doubling the DB round-trips `isActorTokenRevoked` already makes on the hot path. It now runs at most once per 5 minute window.
- The `catch` path still arms nothing, so a transient DB error leaves the next request free to retry immediately. Every recording mint path inserts the row before handing out the token (`guardian-bootstrap.ts`, `guardian-refresh.ts`, `auth-token.ts`), so "no record" is a stable answer rather than a race, which is what makes the two paths safe to separate.
- Docstring now covers both the stable-miss and transient-failure cases.

## Test change

`a missing record leaves a later stamp for the same token free to run` asserted the exact behavior this PR fixes, so it is inverted rather than preserved. It is now `an unrecorded token hash is looked up at most once per debounce window`: the second call inside the window leaves a newly seeded row unstamped (proving the lookup was skipped), and resetting the debounce makes the third call find and stamp it.

Also adds `a lookup that throws is retried on the next request`, which renames the table out from under the SELECT so the failure lands in `catch`, then proves the very next call re-queries. Paired with the pre-existing `BEFORE UPDATE` RAISE(ABORT) case, the transient path is covered on both the read and the write side.

26/26 pass in `actor-token-revocation.test.ts`; `dedup-cache`, `edge-auth`, and `devices` are green (78/78).

Fixes gaps found during self-review of plan: paired-devices-last-used.md