### PR TITLE
fix(web): refresh paired-device activity so the relative label stays honest

### DIFF
--- a/clients/web/src/domains/settings/pair-device/paired-devices-section.test.tsx
+++ b/clients/web/src/domains/settings/pair-device/paired-devices-section.test.tsx
@@ -20,7 +20,9 @@ import { createTimerHarness } from "./pair-device-test-helpers";
 
 let listImpl: (assistantId: string) => Promise<LocalListDevicesResult>;
 let listCalls: string[] = [];
-let revokeResult: LocalRevokeDeviceResult = { ok: true };
+let revokeResult: LocalRevokeDeviceResult | Promise<LocalRevokeDeviceResult> = {
+  ok: true,
+};
 let revokeCalls: Array<{ assistantId: string; hashedDeviceId: string }> = [];
 let selectedAssistantId = "self";
 
@@ -70,8 +72,11 @@ mock.module("@/stores/resolved-assistants-store", () => {
 
 const { PairedDevicesSection } = await import("./paired-devices-section");
 
-/** The list poll's arm delay, telling it apart from the relative-age tick. */
+/** The pairing poll's arm delay, telling it apart from the other intervals. */
 const POLL_INTERVAL_MS = 5_000;
+
+/** The activity refresh's arm delay; the relative-age tick's 30s is neither. */
+const ACTIVITY_REFRESH_INTERVAL_MS = 60_000;
 
 const HASH_A = "aaaabbbbccccdddd0000111122223333";
 const HASH_B = "eeeeffff00001111aaaabbbbccccdddd";
@@ -107,6 +112,16 @@ async function renderExpanded(devices: LocalPairedDeviceRecord[]) {
 function clickConfirm() {
   fireEvent.click(
     document.querySelector<HTMLButtonElement>("[data-confirm-dialog-confirm]")!,
+  );
+}
+
+/** Timers armed at `delay` and still live, so cleared arms drop out. */
+function liveTimers(
+  harness: ReturnType<typeof createTimerHarness>,
+  delay: number,
+) {
+  return harness.timers.filter(
+    (timer) => !timer.cleared && timer.delay === delay,
   );
 }
 
@@ -306,10 +321,7 @@ describe("PairedDevicesSection", () => {
 
   test("polls while a pairing code is live and refreshes once more when it ends", async () => {
     const timerHarness = createTimerHarness();
-    const livePolls = () =>
-      timerHarness.timers.filter(
-        (t) => !t.cleared && t.delay === POLL_INTERVAL_MS,
-      );
+    const livePolls = () => liveTimers(timerHarness, POLL_INTERVAL_MS);
     timerHarness.install();
 
     try {
@@ -353,10 +365,138 @@ describe("PairedDevicesSection", () => {
     timerHarness.install();
     try {
       await renderExpanded([device()]);
+      expect(liveTimers(timerHarness, POLL_INTERVAL_MS)).toHaveLength(0);
+      // The slow activity refresh is the only list timer without a live code.
       expect(
-        timerHarness.timers.filter((t) => t.delay === POLL_INTERVAL_MS),
-      ).toHaveLength(0);
+        liveTimers(timerHarness, ACTIVITY_REFRESH_INTERVAL_MS),
+      ).toHaveLength(1);
       expect(listCalls).toEqual(["self"]);
+    } finally {
+      timerHarness.restore();
+    }
+  });
+
+  test("refreshes on the activity interval so the label tracks a fresh sample", async () => {
+    const timerHarness = createTimerHarness();
+    timerHarness.install();
+
+    try {
+      await renderExpanded([
+        device({ lastUsedAt: Date.now() - 3 * 60 * 60 * 1000 }),
+      ]);
+      expect(
+        screen.getByText(/^Paired \d.+ · Last used 3 hours ago$/),
+      ).toBeTruthy();
+      expect(
+        liveTimers(timerHarness, ACTIVITY_REFRESH_INTERVAL_MS),
+      ).toHaveLength(1);
+
+      // The device never stopped talking to the gateway; the refresh
+      // resamples `lastUsedAt` instead of aging the one taken at mount.
+      setListResult({
+        ok: true,
+        devices: [device({ lastUsedAt: Date.now() })],
+      });
+      await act(async () => {
+        for (const refreshTimer of liveTimers(
+          timerHarness,
+          ACTIVITY_REFRESH_INTERVAL_MS,
+        )) {
+          refreshTimer.handler();
+        }
+      });
+
+      expect(listCalls).toEqual(["self", "self"]);
+      expect(screen.getByText(/^Paired \d.+ · Active now$/)).toBeTruthy();
+    } finally {
+      timerHarness.restore();
+    }
+  });
+
+  test("stands the activity refresh down while the pairing poll runs", async () => {
+    const timerHarness = createTimerHarness();
+    timerHarness.install();
+
+    try {
+      setListResult({ ok: true, devices: [device()] });
+      const { rerender } = render(<PairedDevicesSection pollWhilePairing />);
+      await act(async () => {});
+      expect(liveTimers(timerHarness, POLL_INTERVAL_MS)).toHaveLength(1);
+      expect(
+        liveTimers(timerHarness, ACTIVITY_REFRESH_INTERVAL_MS),
+      ).toHaveLength(0);
+
+      // A tick of the live code's poll is the only fetch it produces.
+      await act(async () => {
+        for (const poll of liveTimers(timerHarness, POLL_INTERVAL_MS)) {
+          poll.handler();
+        }
+      });
+      expect(listCalls).toEqual(["self", "self"]);
+
+      // Code consumed/expired: the poll clears and the slow refresh takes over.
+      rerender(<PairedDevicesSection pollWhilePairing={false} />);
+      await act(async () => {});
+      expect(liveTimers(timerHarness, POLL_INTERVAL_MS)).toHaveLength(0);
+      expect(
+        liveTimers(timerHarness, ACTIVITY_REFRESH_INTERVAL_MS),
+      ).toHaveLength(1);
+      expect(listCalls).toEqual(["self", "self", "self"]);
+    } finally {
+      timerHarness.restore();
+    }
+  });
+
+  test("pauses the activity refresh while a revoke is in flight", async () => {
+    const timerHarness = createTimerHarness();
+    timerHarness.install();
+
+    try {
+      await renderExpanded([device()]);
+      expect(
+        liveTimers(timerHarness, ACTIVITY_REFRESH_INTERVAL_MS),
+      ).toHaveLength(1);
+
+      let resolveRevoke!: (result: LocalRevokeDeviceResult) => void;
+      revokeResult = new Promise<LocalRevokeDeviceResult>((resolve) => {
+        resolveRevoke = resolve;
+      });
+      fireEvent.click(screen.getByRole("button", { name: "Revoke" }));
+      await act(async () => {
+        clickConfirm();
+      });
+      expect(
+        liveTimers(timerHarness, ACTIVITY_REFRESH_INTERVAL_MS),
+      ).toHaveLength(0);
+
+      await act(async () => {
+        resolveRevoke({ ok: true });
+      });
+      expect(
+        liveTimers(timerHarness, ACTIVITY_REFRESH_INTERVAL_MS),
+      ).toHaveLength(1);
+    } finally {
+      timerHarness.restore();
+    }
+  });
+
+  test("clears the activity refresh on unmount", async () => {
+    const timerHarness = createTimerHarness();
+    timerHarness.install();
+
+    try {
+      setListResult({ ok: true, devices: [device()] });
+      const { unmount } = render(<PairedDevicesSection />);
+      await act(async () => {});
+      expect(
+        liveTimers(timerHarness, ACTIVITY_REFRESH_INTERVAL_MS),
+      ).toHaveLength(1);
+
+      unmount();
+
+      expect(
+        liveTimers(timerHarness, ACTIVITY_REFRESH_INTERVAL_MS),
+      ).toHaveLength(0);
     } finally {
       timerHarness.restore();
     }

--- a/clients/web/src/domains/settings/pair-device/use-paired-devices.ts
+++ b/clients/web/src/domains/settings/pair-device/use-paired-devices.ts
@@ -51,6 +51,9 @@ export interface UsePairedDevicesOptions {
 
 const PAIRING_POLL_INTERVAL_MS = 5_000;
 
+/** Keeps the rendered activity label honest by resampling `lastUsedAt`. */
+const ACTIVITY_REFRESH_INTERVAL_MS = 60_000;
+
 /**
  * Drives the "Paired devices" accordion: fetches the selected assistant's
  * paired devices through the host seam and runs the confirm-then-revoke flow.
@@ -149,6 +152,20 @@ export function usePairedDevices({
     }
     return undefined;
   }, [pollWhilePairing, isRevoking, refresh]);
+
+  // Each row's activity label is formatted from the `lastUsedAt` this fetch
+  // sampled, so a list left open ages one fixed instant and ends up claiming
+  // a device is idle while it is still talking to the gateway. Resample on a
+  // slow cadence while rows are on screen; the pairing poll already refreshes
+  // faster than this, so stand down whenever it is running.
+  const hasDevices = (list?.devices.length ?? 0) > 0;
+  useEffect(() => {
+    if (!hasDevices || pollWhilePairing || isRevoking) {
+      return undefined;
+    }
+    const id = setInterval(() => refresh(), ACTIVITY_REFRESH_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, [hasDevices, pollWhilePairing, isRevoking, refresh]);
 
   const requestRevoke = useCallback((device: LocalPairedDeviceRecord) => {
     setRevokeError(null);


### PR DESCRIPTION
## Summary
- `usePairedDevices` now resamples the list every 60s while rows are rendered, so the relative activity label ages against a fresh `lastUsedAt` instead of one sampled at mount.
- Without it the 30s relative-age tick walked a device in continuous use from 'Active now' to 'Last used an hour ago' with no refetch behind it.
- The new interval reuses the hook's existing `fetchSeqRef` out-of-order guard and `mountedRef` unmount guard, stands down while the 5s pairing poll is live (that poll already covers freshness) and while a revoke is in flight, and clears on unmount.
- Gated on a non-empty list: each refresh spawns the `vellum` CLI through the local-mode host seam, and the section renders nothing when there are no rows.
- Tests: proves the slow refresh drives a label change, proves no double-fetch alongside the pairing poll, proves the revoke pause and the unmount clear. The existing 5s-delay timer filters now go through a shared `liveTimers` helper so each assertion names the interval it means.

Fixes a gap found during self-review of plan: paired-devices-last-used.md