### PR TITLE
fix(gateway): clear device activity on revoke and index the device lookup

### DIFF
--- a/gateway/src/__tests__/devices.test.ts
+++ b/gateway/src/__tests__/devices.test.ts
@@ -338,6 +338,48 @@ describe("POST /v1/devices/revoke", () => {
     expect(activeRefreshCount("device-B")).toBe(1);
   });
 
+  test("clears the device's activity stamp so a re-pair starts fresh", async () => {
+    // Device ids hash stably, so re-pairing reuses the same hashedDeviceId. The
+    // list reads the max stamp across statuses, so an uncleared revoked row
+    // would report a last use predating the new pairing.
+    seedActor({ device: "device-A", lastUsedAt: 1_700_000_000_000 });
+    seedRefresh({ device: "device-A" });
+
+    await handleRevokeDevice(
+      revokeRequest({ hashedDeviceId: hashToken("device-A") }),
+      LOOPBACK_IP,
+    );
+
+    // Re-pair: a fresh, unstamped active row for the same device.
+    seedActor({ device: "device-A" });
+
+    const res = await handleListDevices(listRequest(), LOOPBACK_IP);
+    const body = (await res.json()) as {
+      devices: { hashedDeviceId: string; lastUsedAt: number | null }[];
+    };
+    expect(body.devices).toHaveLength(1);
+    expect(body.devices[0]?.lastUsedAt).toBeNull();
+  });
+
+  test("leaves another device's stamp intact", async () => {
+    seedActor({ device: "device-A", lastUsedAt: 1_700_000_000_000 });
+    seedActor({ device: "device-B", lastUsedAt: 1_800_000_000_000 });
+
+    await handleRevokeDevice(
+      revokeRequest({ hashedDeviceId: hashToken("device-A") }),
+      LOOPBACK_IP,
+    );
+
+    const res = await handleListDevices(listRequest(), LOOPBACK_IP);
+    const body = (await res.json()) as {
+      devices: { hashedDeviceId: string; lastUsedAt: number | null }[];
+    };
+    const b = body.devices.find(
+      (d) => d.hashedDeviceId === hashToken("device-B"),
+    );
+    expect(b?.lastUsedAt).toBe(1_800_000_000_000);
+  });
+
   test("rejects a request without hashedDeviceId (400)", async () => {
     const res = await handleRevokeDevice(revokeRequest({}), LOOPBACK_IP);
     expect(res.status).toBe(400);

--- a/gateway/src/__tests__/refresh-device-binding.test.ts
+++ b/gateway/src/__tests__/refresh-device-binding.test.ts
@@ -15,7 +15,8 @@ initSigningKey(Buffer.from("test-signing-key-at-least-32-bytes-long-xx"));
 
 const { initGatewayDb, resetGatewayDb, getGatewayDb } =
   await import("../db/connection.js");
-const { actorRefreshTokenRecords, contacts } = await import("../db/schema.js");
+const { actorRefreshTokenRecords, actorTokenRecords, contacts } =
+  await import("../db/schema.js");
 const { hashToken } = await import("../auth/guardian-bootstrap.js");
 const { rotateCredentials } = await import("../auth/guardian-refresh.js");
 const { handleGuardianRefresh } =
@@ -54,6 +55,30 @@ function insertRefreshRecord(
       absoluteExpiresAt: now + 365 * 86_400_000,
       inactivityExpiresAt: now + 90 * 86_400_000,
       lastUsedAt: null,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .run();
+}
+
+function insertActorTokenRecord(
+  rawToken: string,
+  deviceId: string,
+  lastUsedAt: number | null,
+) {
+  const now = Date.now();
+  getGatewayDb()
+    .insert(actorTokenRecords)
+    .values({
+      id: `actor-${rawToken}`,
+      tokenHash: hashToken(rawToken),
+      guardianPrincipalId: PRINCIPAL,
+      hashedDeviceId: hashToken(deviceId),
+      platform: "cli",
+      status: "active",
+      issuedAt: now,
+      expiresAt: now + 86_400_000,
+      lastUsedAt,
       createdAt: now,
       updatedAt: now,
     })
@@ -231,5 +256,46 @@ describe("rotateCredentials guardian integrity gate", () => {
 
     expect(res.status).toBe(401);
     expect(await res.json()).toEqual({ error: "guardian_repair_required" });
+  });
+});
+
+describe("rotateCredentials activity history", () => {
+  test("keeps the rotated-out actor row's lastUsedAt stamp", () => {
+    // The device list reads the max stamp across statuses, so rotation must
+    // leave the stamp on the row it revokes. Clearing it here would reset a
+    // device's activity history on every credential refresh.
+    insertRefreshRecord("rt-stamped", DEVICE_A);
+    insertActorTokenRecord("at-stamped", DEVICE_A, 1_700_000_000_000);
+
+    const result = rotateCredentials({
+      refreshToken: "rt-stamped",
+      hashedDeviceId: hashToken(DEVICE_A),
+    });
+    expect(result.ok).toBe(true);
+
+    const rows = getGatewayDb().select().from(actorTokenRecords).all();
+    const rotatedOut = rows.find(
+      (r) => r.tokenHash === hashToken("at-stamped"),
+    );
+    expect(rotatedOut?.status).toBe("revoked");
+    expect(rotatedOut?.lastUsedAt).toBe(1_700_000_000_000);
+  });
+
+  test("clears the stamp when a replayed refresh token revokes the family", () => {
+    // Reuse detection is a security revoke: the replayed family's activity
+    // history must not carry forward onto whatever pairs next.
+    insertRefreshRecord("rt-replayed", DEVICE_A, "rotated");
+    insertActorTokenRecord("at-replayed", DEVICE_A, 1_700_000_000_000);
+
+    const result = rotateCredentials({
+      refreshToken: "rt-replayed",
+      hashedDeviceId: hashToken(DEVICE_A),
+    });
+    expect(result).toEqual({ ok: false, error: "refresh_reuse_detected" });
+
+    const rows = getGatewayDb().select().from(actorTokenRecords).all();
+    const revoked = rows.find((r) => r.tokenHash === hashToken("at-replayed"));
+    expect(revoked?.status).toBe("revoked");
+    expect(revoked?.lastUsedAt).toBeNull();
   });
 });

--- a/gateway/src/auth/guardian-bootstrap.ts
+++ b/gateway/src/auth/guardian-bootstrap.ts
@@ -573,6 +573,12 @@ export type DeviceBoundTokenPair = RefreshableTokenPair;
 
 /**
  * Revoke active actor tokens for a device binding.
+ *
+ * Clears `lastUsedAt` as well: the device list takes the max stamp across every
+ * status for a device, so leaving it set would let a re-paired device inherit
+ * the prior pairing's activity and report a last use older than its pairing
+ * date. Rotation revokes via `revokeActiveActorTokensByDevice` instead, which
+ * keeps the stamp so history survives a credential refresh.
  */
 export function revokeActorTokensByDevice(
   guardianPrincipalId: string,
@@ -581,7 +587,7 @@ export function revokeActorTokensByDevice(
   const now = Date.now();
   getGatewayDb()
     .update(actorTokenRecords)
-    .set({ status: "revoked", updatedAt: now })
+    .set({ status: "revoked", lastUsedAt: null, updatedAt: now })
     .where(
       and(
         eq(actorTokenRecords.guardianPrincipalId, guardianPrincipalId),

--- a/gateway/src/auth/guardian-refresh.ts
+++ b/gateway/src/auth/guardian-refresh.ts
@@ -86,6 +86,8 @@ function revokeFamily(familyId: string): void {
     .run();
 }
 
+// Rotation revoke: keeps `lastUsedAt` so the device list, which reads the max
+// stamp across statuses, carries activity history forward across a refresh.
 function revokeActiveActorTokensByDevice(
   guardianPrincipalId: string,
   hashedDeviceId: string,
@@ -104,6 +106,8 @@ function revokeActiveActorTokensByDevice(
     .run();
 }
 
+// Security revoke on refresh-token reuse: clears `lastUsedAt` so a replayed
+// family's activity history does not survive onto whatever pairs next.
 function revokeAllActorTokensByDevice(
   guardianPrincipalId: string,
   hashedDeviceId: string,
@@ -111,7 +115,7 @@ function revokeAllActorTokensByDevice(
   const now = Date.now();
   getGatewayDb()
     .update(actorTokenRecords)
-    .set({ status: "revoked", updatedAt: now })
+    .set({ status: "revoked", lastUsedAt: null, updatedAt: now })
     .where(
       and(
         eq(actorTokenRecords.guardianPrincipalId, guardianPrincipalId),

--- a/gateway/src/db/schema.ts
+++ b/gateway/src/db/schema.ts
@@ -284,6 +284,15 @@ export const actorTokenRecords = sqliteTable(
     // Unfiltered (not WHERE status='active') so the hot-path revocation lookup
     // — which matches by token_hash and must find REVOKED rows — is indexed.
     index("idx_actor_tokens_hash").on(table.tokenHash),
+    // Covers the device list's max(last_used_at) group-by, which spans every
+    // status and so cannot use the active-only unique index. Device-first so
+    // the active-only lookup keeps preferring the narrower partial index, and
+    // so per-device revocation (status IN ('active','derived')) seeks too.
+    index("idx_actor_tokens_device_last_used").on(
+      table.hashedDeviceId,
+      table.guardianPrincipalId,
+      table.lastUsedAt,
+    ),
   ],
 );
 

--- a/gateway/src/http/routes/devices.ts
+++ b/gateway/src/http/routes/devices.ts
@@ -53,7 +53,6 @@ export async function handleListDevices(
       platform: actorTokenRecords.platform,
       issuedAt: actorTokenRecords.issuedAt,
       expiresAt: actorTokenRecords.expiresAt,
-      lastUsedAt: actorTokenRecords.lastUsedAt,
     })
     .from(actorTokenRecords)
     .where(
@@ -67,6 +66,8 @@ export async function handleListDevices(
   // Refreshing credentials revokes the active row and mints an unstamped
   // replacement, so the newest stamp for a device can live on a revoked row.
   // Take the max across every status to keep activity history across rotation.
+  // Same principal filter as above with no status filter, so every listed
+  // device is covered by a group here.
   const lastUsedRows = db
     .select({
       hashedDeviceId: actorTokenRecords.hashedDeviceId,
@@ -86,7 +87,7 @@ export async function handleListDevices(
     platform: t.platform,
     issuedAt: t.issuedAt,
     expiresAt: t.expiresAt ?? null,
-    lastUsedAt: lastUsedByDevice.get(t.hashedDeviceId) ?? t.lastUsedAt ?? null,
+    lastUsedAt: lastUsedByDevice.get(t.hashedDeviceId) ?? null,
   }));
 
   return Response.json({ devices });


### PR DESCRIPTION
## Summary

Three gaps found during self-review of the device last-used plan.

**1. A revoked device's stamp was re-attributed to the re-paired device (user-visible bug).**
`revokeActorTokensByDevice` only flipped `status` to `revoked`, leaving `lastUsedAt` set. Device ids are a stable `sha256(deviceId)`, so re-pairing reuses the same `hashedDeviceId`, and `handleListDevices` takes `max(lastUsedAt)` across every status. The fresh unstamped active row was therefore overridden by the old revoked row: the UI showed "Paired today, Last used 2 months ago", a last use predating the pairing date on the same line. The user-revoke path now clears the stamp.

The three revoke helpers are deliberately split:
- `revokeActorTokensByDevice` (guardian-bootstrap.ts) is the user-revoke / re-pair path (`POST /v1/devices/revoke` and `mintAndRecordDeviceBoundTokenPair`). **Clears** `lastUsedAt`.
- `revokeActiveActorTokensByDevice` (guardian-refresh.ts) is the rotation path. **Untouched**: carrying the stamp across rotation is exactly what the max-across-statuses read exists to preserve.
- `revokeAllActorTokensByDevice` (guardian-refresh.ts) is reachable only from the refresh-token reuse-detection branch of `rotateRefreshTokenRecord`, which revokes the whole family. That is a security revoke, not a rotation, so it **clears** the stamp too: a replayed family should not carry history forward onto whatever pairs next.

Both behaviors are now locked in by tests.

**2. `/v1/devices` full-table-scanned a table nothing prunes (performance regression).**
The new `max()` group-by has no status filter, and no index covered `guardian_principal_id` unfiltered. `actor_token_records` grows without bound: `recordDerivedActorToken` inserts a row on every `/auth/token` mint, every rotation revokes-and-inserts, and nothing ever deletes or reaps by `expiresAt`.

Added `idx_actor_tokens_device_last_used` on `(hashed_device_id, guardian_principal_id, last_used_at)`. No migration file is needed: the gateway applies `schema.ts` via drizzle-kit `pushSQLiteSchema` at startup.

EXPLAIN QUERY PLAN against the real pushed schema:

| query | before | after |
| --- | --- | --- |
| `max(last_used_at)` group-by | `SCAN actor_token_records` + `USE TEMP B-TREE FOR GROUP BY` | `SCAN actor_token_records USING COVERING INDEX idx_actor_tokens_device_last_used` |
| active-row device list | `SEARCH ... USING INDEX idx_actor_tokens_active_device (guardian_principal_id=?)` | unchanged |
| per-device revoke (`status IN ('active','derived')`) | `SCAN actor_token_records` | `SEARCH ... USING INDEX idx_actor_tokens_device_last_used (hashed_device_id=? AND guardian_principal_id=?)` |

The group-by no longer touches table rows and no longer sorts, and both revoke helpers pick up an indexed seek where they previously scanned.

Column order note: the reviewed plan proposed `(guardian_principal_id, hashed_device_id, last_used_at)`. Measured, that shape fixes the group-by but **regresses** the sibling active-row query in the same handler: without `sqlite_stat1` stats (the gateway never runs `ANALYZE`) SQLite abandons the narrow partial index `idx_actor_tokens_active_device` for the new wide non-covering one, turning a per-device seek into a walk of every row for the principal plus a table lookup each. Since the gateway DB is effectively single-principal, the principal-leading seek buys nothing to offset that. Device-first keeps the partial index winning the active-row query (`hashed_device_id` is not constrained there, so the new index is never a seek candidate for it), still serves the group-by as a covering scan with no sort, and additionally indexes the per-device revoke. It is strictly better than the proposed order on every query on this table.

**3. Unreachable fallback in `handleListDevices` (dead code).**
The group-by filters on the same `guardianPrincipalId` with no status filter, so it is a strict superset of the active rows. Every `hashedDeviceId` is guaranteed a group, `.get()` can never return `undefined`, and when the MAX is null the aggregate covered a superset including that row so its own stamp is null too. Dropped `?? t.lastUsedAt`, which also made `lastUsedAt` in the first `select()` dead.

## Tests

Four new cases, all existing cases pass unchanged:
- `devices.test.ts`: stamped, revoked via `POST /v1/devices/revoke`, re-paired with a fresh active row, reports `null`; and a revoke leaves another device's stamp intact.
- `refresh-device-binding.test.ts`: rotation keeps the rotated-out row's stamp; reuse detection clears it.

`bun test` per file: devices 15 pass, refresh-device-binding 10 pass, actor-token-revocation 25 pass, edge-auth 38 pass, remote-web-pairing-token 13 pass, pair-device-bound pass. `tsc --noEmit` shows only the 3 pre-existing `channel-socket-health-handlers.ts` errors from worktree `@vellumai/*` resolution. eslint and prettier clean.

Fixes gaps found during self-review of plan: paired-devices-last-used.md