### PR TITLE
docs(gateway): record why the device stamp precedes final authorization

### DIFF
--- a/gateway/src/http/middleware/auth.ts
+++ b/gateway/src/http/middleware/auth.ts
@@ -357,6 +357,13 @@ export function createAuthMiddleware(
    * a 401 response when revoked, or null to continue. Fail-open for non-actor
    * and unrecorded tokens (see isActorTokenRevoked). On the allow path, stamps
    * the presenting device's last-used activity (debounced, fail-open).
+   *
+   * The stamp runs here, before the scope and guardian-match checks that
+   * callers apply afterwards, so "last used" means "presented a valid,
+   * unrevoked credential" rather than "made a request we served". That is
+   * deliberate: a device refused for insufficient scope is still demonstrably
+   * active, and a guardian-mismatched device never appears in /v1/devices
+   * anyway (it scopes to the local guardian principal).
    */
   function rejectIfActorTokenRevoked(
     req: Request,


### PR DESCRIPTION
## Summary

- Documents that `rejectIfActorTokenRevoked` stamps device activity before the scope and guardian-match checks its callers apply afterwards, so "last used" means "presented a valid, unrevoked credential" rather than "made a request we served".
- Two independent self-review passes flagged this ordering; both concluded the behavior is correct and should stay. The same ordering exists at five sites (two in this file, plus ipc-runtime-proxy, live-voice-websocket, and auth-token), so changing one in isolation would make them inconsistent.
- Comment only, no behavior change.

Fixes a gap found during self-review of plan: paired-devices-last-used.md