### PR TITLE
fix(gateway): clear device activity on every row when a pairing is revoked

### DIFF
--- a/gateway/src/__tests__/devices.test.ts
+++ b/gateway/src/__tests__/devices.test.ts
@@ -47,6 +47,7 @@ function seedActor(opts: {
   status?: "active" | "revoked";
   platform?: string;
   lastUsedAt?: number;
+  updatedAt?: number;
 }): void {
   const now = Date.now();
   const principal = opts.principal ?? GUARDIAN_ID;
@@ -64,7 +65,7 @@ function seedActor(opts: {
       expiresAt: now + 86_400_000,
       lastUsedAt: opts.lastUsedAt ?? null,
       createdAt: now,
-      updatedAt: now,
+      updatedAt: opts.updatedAt ?? now,
     })
     .run();
 }
@@ -359,6 +360,61 @@ describe("POST /v1/devices/revoke", () => {
     };
     expect(body.devices).toHaveLength(1);
     expect(body.devices[0]?.lastUsedAt).toBeNull();
+  });
+
+  test("clears the stamp on a rotated-out row so a re-pair starts fresh", async () => {
+    // Any device older than one access-token TTL has rotated at least once,
+    // which leaves a stamped revoked row behind. The list reads the max stamp
+    // across statuses, so a revoke that only clears the active row would still
+    // report the old activity after the re-pair.
+    seedActor({
+      device: "device-A",
+      status: "revoked",
+      lastUsedAt: 1_700_000_000_000,
+    });
+    seedActor({ device: "device-A", lastUsedAt: 1_800_000_000_000 });
+    seedRefresh({ device: "device-A" });
+
+    await handleRevokeDevice(
+      revokeRequest({ hashedDeviceId: hashToken("device-A") }),
+      LOOPBACK_IP,
+    );
+
+    // Re-pair: a fresh, unstamped active row for the same device.
+    seedActor({ device: "device-A" });
+
+    const res = await handleListDevices(listRequest(), LOOPBACK_IP);
+    const body = (await res.json()) as {
+      devices: { hashedDeviceId: string; lastUsedAt: number | null }[];
+    };
+    expect(body.devices).toHaveLength(1);
+    expect(body.devices[0]?.lastUsedAt).toBeNull();
+  });
+
+  test("does not bump updatedAt on rows whose status is already revoked", async () => {
+    // updatedAt tracks lifecycle, lastUsedAt tracks activity: clearing the
+    // stamp on an already-revoked row must not read as a lifecycle change.
+    seedActor({
+      device: "device-A",
+      status: "revoked",
+      lastUsedAt: 1_700_000_000_000,
+      updatedAt: 1_700_000_000_000,
+    });
+    seedActor({ device: "device-A" });
+
+    await handleRevokeDevice(
+      revokeRequest({ hashedDeviceId: hashToken("device-A") }),
+      LOOPBACK_IP,
+    );
+
+    const rows = getGatewayDb()
+      .select()
+      .from(actorTokenRecords)
+      .where(eq(actorTokenRecords.hashedDeviceId, hashToken("device-A")))
+      .all();
+    const untouched = rows.filter((r) => r.updatedAt === 1_700_000_000_000);
+    expect(untouched).toHaveLength(1);
+    expect(untouched[0]?.lastUsedAt).toBeNull();
   });
 
   test("leaves another device's stamp intact", async () => {

--- a/gateway/src/__tests__/refresh-device-binding.test.ts
+++ b/gateway/src/__tests__/refresh-device-binding.test.ts
@@ -65,6 +65,7 @@ function insertActorTokenRecord(
   rawToken: string,
   deviceId: string,
   lastUsedAt: number | null,
+  status: "active" | "revoked" = "active",
 ) {
   const now = Date.now();
   getGatewayDb()
@@ -75,7 +76,7 @@ function insertActorTokenRecord(
       guardianPrincipalId: PRINCIPAL,
       hashedDeviceId: hashToken(deviceId),
       platform: "cli",
-      status: "active",
+      status,
       issuedAt: now,
       expiresAt: now + 86_400_000,
       lastUsedAt,
@@ -297,5 +298,28 @@ describe("rotateCredentials activity history", () => {
     const revoked = rows.find((r) => r.tokenHash === hashToken("at-replayed"));
     expect(revoked?.status).toBe("revoked");
     expect(revoked?.lastUsedAt).toBeNull();
+  });
+
+  test("clears the stamp on rows an earlier rotation already revoked", () => {
+    // A device that rotated before the replay carries a stamped revoked row,
+    // and the device list reads the max stamp across statuses, so the security
+    // revoke has to reach that row too.
+    insertRefreshRecord("rt-replayed-old", DEVICE_A, "rotated");
+    insertActorTokenRecord(
+      "at-rotated-out",
+      DEVICE_A,
+      1_700_000_000_000,
+      "revoked",
+    );
+    insertActorTokenRecord("at-current", DEVICE_A, 1_800_000_000_000);
+
+    const result = rotateCredentials({
+      refreshToken: "rt-replayed-old",
+      hashedDeviceId: hashToken(DEVICE_A),
+    });
+    expect(result).toEqual({ ok: false, error: "refresh_reuse_detected" });
+
+    const rows = getGatewayDb().select().from(actorTokenRecords).all();
+    expect(rows.map((r) => r.lastUsedAt)).toEqual([null, null]);
   });
 });

--- a/gateway/src/auth/guardian-bootstrap.ts
+++ b/gateway/src/auth/guardian-bootstrap.ts
@@ -572,13 +572,38 @@ export interface RefreshableTokenPair {
 export type DeviceBoundTokenPair = RefreshableTokenPair;
 
 /**
- * Revoke active actor tokens for a device binding.
+ * Clear a device's activity stamp on every actor token row, whatever its
+ * status.
  *
- * Clears `lastUsedAt` as well: the device list takes the max stamp across every
- * status for a device, so leaving it set would let a re-paired device inherit
- * the prior pairing's activity and report a last use older than its pairing
- * date. Rotation revokes via `revokeActiveActorTokensByDevice` instead, which
- * keeps the stamp so history survives a credential refresh.
+ * The device list takes the max `lastUsedAt` across statuses, and rotation
+ * revokes deliberately keep their stamp, so a status-scoped clear would leave
+ * a stamped revoked row behind for a re-paired device to inherit, reporting a
+ * last use older than its pairing date. Kept separate from the status update
+ * so `updatedAt`, which tracks lifecycle, is not bumped on rows whose
+ * lifecycle did not change.
+ */
+export function clearDeviceActivityStamp(
+  guardianPrincipalId: string,
+  hashedDeviceId: string,
+): void {
+  getGatewayDb()
+    .update(actorTokenRecords)
+    .set({ lastUsedAt: null })
+    .where(
+      and(
+        eq(actorTokenRecords.guardianPrincipalId, guardianPrincipalId),
+        eq(actorTokenRecords.hashedDeviceId, hashedDeviceId),
+      ),
+    )
+    .run();
+}
+
+/**
+ * Revoke active actor tokens for a device binding, ending the pairing.
+ *
+ * Clears the device's activity stamp as well so a later re-pair starts fresh.
+ * Rotation revokes via `revokeActiveActorTokensByDevice` instead, which keeps
+ * the stamp so history survives a credential refresh.
  */
 export function revokeActorTokensByDevice(
   guardianPrincipalId: string,
@@ -587,7 +612,7 @@ export function revokeActorTokensByDevice(
   const now = Date.now();
   getGatewayDb()
     .update(actorTokenRecords)
-    .set({ status: "revoked", lastUsedAt: null, updatedAt: now })
+    .set({ status: "revoked", updatedAt: now })
     .where(
       and(
         eq(actorTokenRecords.guardianPrincipalId, guardianPrincipalId),
@@ -596,6 +621,7 @@ export function revokeActorTokensByDevice(
       ),
     )
     .run();
+  clearDeviceActivityStamp(guardianPrincipalId, hashedDeviceId);
 }
 
 /**

--- a/gateway/src/auth/guardian-refresh.ts
+++ b/gateway/src/auth/guardian-refresh.ts
@@ -12,6 +12,7 @@ import { actorRefreshTokenRecords, actorTokenRecords } from "../db/schema.js";
 import { getLogger } from "../logger.js";
 
 import {
+  clearDeviceActivityStamp,
   getExternalAssistantId,
   hashToken,
   ACCESS_TOKEN_TTL_MS,
@@ -106,8 +107,9 @@ function revokeActiveActorTokensByDevice(
     .run();
 }
 
-// Security revoke on refresh-token reuse: clears `lastUsedAt` so a replayed
-// family's activity history does not survive onto whatever pairs next.
+// Security revoke on refresh-token reuse: clears the device's stamp on every
+// row, at any status, so a replayed family's activity history does not survive
+// onto whatever pairs next.
 function revokeAllActorTokensByDevice(
   guardianPrincipalId: string,
   hashedDeviceId: string,
@@ -115,7 +117,7 @@ function revokeAllActorTokensByDevice(
   const now = Date.now();
   getGatewayDb()
     .update(actorTokenRecords)
-    .set({ status: "revoked", lastUsedAt: null, updatedAt: now })
+    .set({ status: "revoked", updatedAt: now })
     .where(
       and(
         eq(actorTokenRecords.guardianPrincipalId, guardianPrincipalId),
@@ -124,6 +126,7 @@ function revokeAllActorTokensByDevice(
       ),
     )
     .run();
+  clearDeviceActivityStamp(guardianPrincipalId, hashedDeviceId);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- The explicit device revoke and the refresh-reuse security revoke cleared `lastUsedAt` only on rows matching `status IN ('active','derived')`. Rotation deliberately leaves the stamp on the rows it flips to `revoked`, and nothing prunes `actor_token_records`, so any device that had refreshed credentials at least once kept a stamped revoked row. The device list reads `max(lastUsedAt)` across every status, so a re-paired device still reported a last use predating its new pairing.
- Access tokens live 30 days and refresh at 80 percent of that, so every device older than about 24 days has rotated at least once. This hit the long-lived devices the feature exists for, not an edge case.
- Both revoke paths now follow the status-scoped lifecycle update with an unfiltered `lastUsedAt = null` for the whole (principal, device) pair, via a shared `clearDeviceActivityStamp` helper. It stays a separate statement so `updatedAt` is not bumped on rows whose lifecycle did not change: `updatedAt` tracks lifecycle, `lastUsedAt` tracks activity.
- The rotation path (`revokeActiveActorTokensByDevice`) is untouched and still carries the stamp forward, which is what keeps activity history alive across a credential refresh.
- Tests: a revoke case seeding a stamped revoked row plus an active row, then re-pairing, and asserting the list reports null; a case locking in that an already-revoked row keeps its `updatedAt`; and a reuse-detection case covering a device that rotated before the replay. All three fail without the production change (51 pass / 3 fail) and pass with it (54 pass / 0 fail).

Fixes a gap found during self-review of plan: paired-devices-last-used.md