### PR TITLE
fix(web): only refresh paired-device activity while the list is expanded

### DIFF
--- a/clients/web/src/domains/settings/pair-device/paired-devices-section.test.tsx
+++ b/clients/web/src/domains/settings/pair-device/paired-devices-section.test.tsx
@@ -101,12 +101,16 @@ function setListResult(result: LocalListDevicesResult) {
 
 async function renderExpanded(devices: LocalPairedDeviceRecord[]) {
   setListResult({ ok: true, devices });
-  render(<PairedDevicesSection />);
+  const result = render(<PairedDevicesSection />);
   // The list fetch is microtask-only; an awaited act drains it without timers.
   await act(async () => {});
-  fireEvent.click(
-    screen.getByRole("button", { name: `Paired devices (${devices.length})` }),
-  );
+  fireEvent.click(deviceListTrigger(devices.length));
+  return result;
+}
+
+/** The accordion trigger, which is also the expand/collapse toggle. */
+function deviceListTrigger(count: number): HTMLElement {
+  return screen.getByRole("button", { name: `Paired devices (${count})` });
 }
 
 function clickConfirm() {
@@ -421,6 +425,7 @@ describe("PairedDevicesSection", () => {
       setListResult({ ok: true, devices: [device()] });
       const { rerender } = render(<PairedDevicesSection pollWhilePairing />);
       await act(async () => {});
+      fireEvent.click(deviceListTrigger(1));
       expect(liveTimers(timerHarness, POLL_INTERVAL_MS)).toHaveLength(1);
       expect(
         liveTimers(timerHarness, ACTIVITY_REFRESH_INTERVAL_MS),
@@ -485,9 +490,7 @@ describe("PairedDevicesSection", () => {
     timerHarness.install();
 
     try {
-      setListResult({ ok: true, devices: [device()] });
-      const { unmount } = render(<PairedDevicesSection />);
-      await act(async () => {});
+      const { unmount } = await renderExpanded([device()]);
       expect(
         liveTimers(timerHarness, ACTIVITY_REFRESH_INTERVAL_MS),
       ).toHaveLength(1);
@@ -497,6 +500,51 @@ describe("PairedDevicesSection", () => {
       expect(
         liveTimers(timerHarness, ACTIVITY_REFRESH_INTERVAL_MS),
       ).toHaveLength(0);
+    } finally {
+      timerHarness.restore();
+    }
+  });
+
+  test("leaves the activity refresh disarmed while the list is collapsed", async () => {
+    const timerHarness = createTimerHarness();
+    timerHarness.install();
+
+    try {
+      setListResult({ ok: true, devices: [device()] });
+      render(<PairedDevicesSection />);
+      await act(async () => {});
+
+      // The trigger renders, but the rows behind it do not: refreshing them
+      // would spawn a host subprocess every minute for a label nobody can read.
+      expect(deviceListTrigger(1)).toBeTruthy();
+      expect(
+        liveTimers(timerHarness, ACTIVITY_REFRESH_INTERVAL_MS),
+      ).toHaveLength(0);
+      expect(listCalls).toEqual(["self"]);
+    } finally {
+      timerHarness.restore();
+    }
+  });
+
+  test("arms the activity refresh on expand and clears it on collapse", async () => {
+    const timerHarness = createTimerHarness();
+    timerHarness.install();
+
+    try {
+      setListResult({ ok: true, devices: [device()] });
+      render(<PairedDevicesSection />);
+      await act(async () => {});
+
+      fireEvent.click(deviceListTrigger(1));
+      expect(
+        liveTimers(timerHarness, ACTIVITY_REFRESH_INTERVAL_MS),
+      ).toHaveLength(1);
+
+      fireEvent.click(deviceListTrigger(1));
+      expect(
+        liveTimers(timerHarness, ACTIVITY_REFRESH_INTERVAL_MS),
+      ).toHaveLength(0);
+      expect(listCalls).toEqual(["self"]);
     } finally {
       timerHarness.restore();
     }

--- a/clients/web/src/domains/settings/pair-device/paired-devices-section.tsx
+++ b/clients/web/src/domains/settings/pair-device/paired-devices-section.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 
 import { ChevronDown } from "lucide-react";
 
@@ -14,6 +14,9 @@ import { usePairedDevices } from "./use-paired-devices";
 
 /** Wider than the gateway's stamp debounce, so the label cannot flap. */
 const ACTIVE_NOW_WINDOW_MS = 10 * 60 * 1000;
+
+/** The accordion's single item; its presence in `value` means "expanded". */
+const DEVICES_ITEM_VALUE = "paired-devices";
 
 function shortHash(hashedDeviceId: string): string {
   return hashedDeviceId.slice(0, 12);
@@ -76,7 +79,14 @@ export function PairedDevicesSection({
   revalidateKey,
 }: PairedDevicesSectionProps = {}) {
   const { t } = useTranslation("settings");
-  const controller = usePairedDevices({ pollWhilePairing, revalidateKey });
+  // The accordion mounts collapsed, and refreshing the list costs a host
+  // subprocess, so the controller only resamples once the rows are on screen.
+  const [isExpanded, setIsExpanded] = useState(false);
+  const controller = usePairedDevices({
+    pollWhilePairing,
+    revalidateKey,
+    isExpanded,
+  });
   const { devices, confirmTarget } = controller;
 
   // Activity labels are formatted from a fixed instant, and the list only
@@ -101,8 +111,14 @@ export function PairedDevicesSection({
 
   return (
     <>
-      <Collapsible.Root type="multiple">
-        <Collapsible.Item value="paired-devices">
+      <Collapsible.Root
+        type="multiple"
+        value={isExpanded ? [DEVICES_ITEM_VALUE] : []}
+        onValueChange={(open) =>
+          setIsExpanded(open.includes(DEVICES_ITEM_VALUE))
+        }
+      >
+        <Collapsible.Item value={DEVICES_ITEM_VALUE}>
           <Collapsible.Trigger className="group flex w-full items-center justify-between gap-3">
             <span className="text-body-medium-default text-[var(--content-secondary)]">
               {t("pairedDevicesSection.title", {

--- a/clients/web/src/domains/settings/pair-device/use-paired-devices.ts
+++ b/clients/web/src/domains/settings/pair-device/use-paired-devices.ts
@@ -47,6 +47,12 @@ export interface UsePairedDevicesOptions {
    * a pairing); leaves any open confirm dialog alone.
    */
   revalidateKey?: number;
+  /**
+   * Whether the device rows are on screen. The activity refresh only runs
+   * while they are: each refetch spawns a `vellum` subprocess through the
+   * host seam, which is not worth paying to keep a hidden label fresh.
+   */
+  isExpanded?: boolean;
 }
 
 const PAIRING_POLL_INTERVAL_MS = 5_000;
@@ -69,6 +75,7 @@ const ACTIVITY_REFRESH_INTERVAL_MS = 60_000;
 export function usePairedDevices({
   pollWhilePairing = false,
   revalidateKey,
+  isExpanded = false,
 }: UsePairedDevicesOptions = {}): PairedDevicesController {
   const [list, setList] = useState<FetchedDeviceList | null>(null);
   const [confirmTarget, setConfirmTarget] =
@@ -154,18 +161,20 @@ export function usePairedDevices({
   }, [pollWhilePairing, isRevoking, refresh]);
 
   // Each row's activity label is formatted from the `lastUsedAt` this fetch
-  // sampled, so a list left open ages one fixed instant and ends up claiming
+  // sampled, so an expanded list ages one fixed instant and ends up claiming
   // a device is idle while it is still talking to the gateway. Resample on a
-  // slow cadence while rows are on screen; the pairing poll already refreshes
-  // faster than this, so stand down whenever it is running.
+  // slow cadence, but only while the rows are actually expanded: a refetch
+  // costs a `vellum` subprocess on the host, so a collapsed accordion must
+  // not pay it. The pairing poll already refreshes faster than this, so stand
+  // down whenever it is running.
   const hasDevices = (list?.devices.length ?? 0) > 0;
   useEffect(() => {
-    if (!hasDevices || pollWhilePairing || isRevoking) {
+    if (!isExpanded || !hasDevices || pollWhilePairing || isRevoking) {
       return undefined;
     }
     const id = setInterval(() => refresh(), ACTIVITY_REFRESH_INTERVAL_MS);
     return () => clearInterval(id);
-  }, [hasDevices, pollWhilePairing, isRevoking, refresh]);
+  }, [isExpanded, hasDevices, pollWhilePairing, isRevoking, refresh]);
 
   const requestRevoke = useCallback((device: LocalPairedDeviceRecord) => {
     setRevokeError(null);


### PR DESCRIPTION
## Summary

- The 60s `ACTIVITY_REFRESH_INTERVAL_MS` refetch in `use-paired-devices.ts` gated only on `hasDevices`, `pollWhilePairing`, and `isRevoking`. It did not gate on visibility, and `PairedDevicesSection` renders `Collapsible.Root` with no default value, so the section mounts collapsed and the timer armed anyway.
- Each tick is not a cheap HTTP poll: `listPairedDevicesHost` routes through the Electron host to `packages/local-mode/src/devices.ts`, which spawns the `vellum` CLI (`devices --json`). A Settings panel left open cost one subprocess a minute, indefinitely, to keep fresh a label nobody was looking at.
- `PairedDevicesSection` now owns the accordion's open state (controlled `value` / `onValueChange` on `Collapsible.Root`) and passes `isExpanded` into `usePairedDevices`, which ANDs it into the interval condition. This matches the `useRelativeAgeTick(active)` precedent already in this directory.
- The effect's comment now says what it does: resample only while the rows are expanded.
- No change to the 5s pairing poll, the 30s relative-age tick, the sort, or the `hasDevices` gate.

## Tests

- "clears the activity refresh on unmount" rendered collapsed and would have asserted nothing under the new gate; it now expands first via `renderExpanded`.
- "stands the activity refresh down while the pairing poll runs" also rendered collapsed; it now expands before asserting the hand-off.
- New: no 60s timer is armed while collapsed.
- New: expanding arms it, collapsing clears it.
- Mutation-checked: dropping `!isExpanded ||` from the gate turns both new tests red (22 pass / 2 fail); with the gate, 24 pass / 0 fail.

Fixes a gap found during self-review of plan: paired-devices-last-used.md