### PR TITLE
chore(plugins): bump natural marketplace pin to e71880d (schema-compliant mcp.json)

### DIFF
--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -310,7 +310,7 @@
       "source": {
         "source": "github",
         "repo": "vellum-ai/natural",
-        "ref": "3cfc8c97c14df311fc64992ab8b172c1b2d64eb0"
+        "ref": "e71880d144337d1b8b6d3e65ab98006b7d015ef6"
       },
       "description": "Hosted MCP access to Natural payment operations for Vellum assistants.",
       "category": "finance",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan
Repin the curated Natural plugin to the latest `vellum-ai/natural` `main` commit so catalog installs pick up the MCP transport fix.

## Summary
- Bump `plugins/marketplace.json` `natural.source.ref` from `3cfc8c97c14df311fc64992ab8b172c1b2d64eb0` to `e71880d144337d1b8b6d3e65ab98006b7d015ef6`.
- That SHA is current `main` on [`vellum-ai/natural`](https://github.com/vellum-ai/natural): [Ship a schema-compliant mcp.json and prefer it over the agent-key setup (#4)](https://github.com/vellum-ai/natural/pull/4).
- The previous pin declared MCP type `http`, which the Agent Plugins 1.0.0 schema and Vellum host reject, so the plugin server never connected. The new pin declares `streamable-http` to `https://mcp.natural.com`, prefers hosted OAuth in client connection settings, and keeps the agent-key skill script as a fallback.

This is a pin-only change. Catalog metadata (name, description, category, homepage, license, icon) is unchanged.

## Test plan
- Manifest JSON parses; `natural.source.ref` is a full 40-hex SHA.
- Confirmed `e71880d144337d1b8b6d3e65ab98006b7d015ef6` is a public, reachable commit on `vellum-ai/natural`.
- After merge, `assistant plugins install natural` (or upgrade of an existing install) should resolve this pin.

## Risk
Low. Catalog pin only. Existing installs stay on the old SHA until a user upgrades. The new pin is required for the Natural MCP server to connect under the current host schema.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cbf9dece-642b-4886-b169-cefe93af11aa?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cbf9dece-642b-4886-b169-cefe93af11aa&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

