### PR TITLE
feat(desktop): pin the current conversation from the File menu

### DIFF
--- a/clients/macos/src/main/menu.ts
+++ b/clients/macos/src/main/menu.ts
@@ -193,6 +193,9 @@ const buildTemplate = (): MenuItemConstructorOptions[] => {
         fileItem("New Conversation", { kind: "newConversation" }),
         fileItem("Current Conversation", { kind: "currentConversation" }),
         { type: "separator" },
+        fileItem("Pin Current Conversation", {
+          kind: "togglePinConversation",
+        }),
         fileItem("Mark Current as Unread", { kind: "markCurrentUnread" }),
         { type: "separator" },
         fileItem("Previous Conversation", { kind: "previousConversation" }),

--- a/clients/macos/src/main/menu.ts
+++ b/clients/macos/src/main/menu.ts
@@ -193,9 +193,7 @@ const buildTemplate = (): MenuItemConstructorOptions[] => {
         fileItem("New Conversation", { kind: "newConversation" }),
         fileItem("Current Conversation", { kind: "currentConversation" }),
         { type: "separator" },
-        fileItem("Pin Current Conversation", {
-          kind: "togglePinConversation",
-        }),
+        fileItem("Pin Current Conversation", { kind: "togglePinConversation" }),
         fileItem("Mark Current as Unread", { kind: "markCurrentUnread" }),
         { type: "separator" },
         fileItem("Previous Conversation", { kind: "previousConversation" }),

--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -824,6 +824,17 @@ export function ChatLayout({
         handleMarkConversationUnread(conversation);
       }
     },
+    togglePinConversation: () => {
+      if (!activeConversationId) {
+        return;
+      }
+      const conversation = conversations.find(
+        (c) => c.conversationId === activeConversationId,
+      );
+      if (conversation) {
+        handleTogglePinConversation(conversation);
+      }
+    },
     markAllRead: () => {
       void handleMarkAllReadInGroup(conversations);
     },

--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -792,6 +792,17 @@ export function ChatLayout({
     }
   }, [commandPalette.isOpen, paletteEverOpened]);
 
+  // Menu commands that act on the open conversation take the row from
+  // `activeConversation`, which resolves background, scheduled, and archived
+  // threads the foreground `conversations` list deliberately omits. They
+  // no-op while no conversation is open.
+  const withActiveConversation =
+    (action: (conversation: Conversation) => void) => () => {
+      if (activeConversation) {
+        action(activeConversation);
+      }
+    };
+
   // Electron host commands (File menu / global hotkeys). The hook is a
   // no-op on the web host. Handlers close over the latest state via an
   // internal ref, so we don't need to memoize them. Composer focus is
@@ -813,28 +824,8 @@ export function ChatLayout({
       }
       requestComposerFocus();
     },
-    markCurrentUnread: () => {
-      if (!activeConversationId) {
-        return;
-      }
-      const conversation = conversations.find(
-        (c) => c.conversationId === activeConversationId,
-      );
-      if (conversation) {
-        handleMarkConversationUnread(conversation);
-      }
-    },
-    togglePinConversation: () => {
-      if (!activeConversationId) {
-        return;
-      }
-      const conversation = conversations.find(
-        (c) => c.conversationId === activeConversationId,
-      );
-      if (conversation) {
-        handleTogglePinConversation(conversation);
-      }
-    },
+    markCurrentUnread: withActiveConversation(handleMarkConversationUnread),
+    togglePinConversation: withActiveConversation(handleTogglePinConversation),
     markAllRead: () => {
       void handleMarkAllReadInGroup(conversations);
     },

--- a/clients/windows/src/main/menu.ts
+++ b/clients/windows/src/main/menu.ts
@@ -52,6 +52,9 @@ export const buildWindowsMenu = ({
       commandItem("New Conversation", { kind: "newConversation" }),
       commandItem("Current Conversation", { kind: "currentConversation" }),
       { type: "separator" },
+      commandItem("Pin Current Conversation", {
+        kind: "togglePinConversation",
+      }),
       commandItem("Mark Current as Unread", { kind: "markCurrentUnread" }),
       commandItem("Previous Conversation", { kind: "previousConversation" }),
       commandItem("Next Conversation", { kind: "nextConversation" }),

--- a/packages/electron-desktop/src/command-palette-window.ts
+++ b/packages/electron-desktop/src/command-palette-window.ts
@@ -56,6 +56,7 @@ const payloadlessCommandKindSchema = z.enum([
   "newConversation",
   "currentConversation",
   "markCurrentUnread",
+  "togglePinConversation",
   "openSettings",
   "shareFeedback",
   "find",

--- a/packages/electron-desktop/src/commands.test.ts
+++ b/packages/electron-desktop/src/commands.test.ts
@@ -73,7 +73,9 @@ describe("compiled accelerator defaults", () => {
       ...Object.entries(DEFAULT_ACCELERATORS),
       ...Object.entries(GLOBAL_SHORTCUT_DEFAULTS),
     ]) {
-      if (!accelerator) continue;
+      if (!accelerator) {
+        continue;
+      }
       const claimants = owners.get(accelerator);
       if (claimants) {
         claimants.push(kind);

--- a/packages/electron-desktop/src/commands.test.ts
+++ b/packages/electron-desktop/src/commands.test.ts
@@ -74,14 +74,17 @@ describe("compiled accelerator defaults", () => {
       ...Object.entries(GLOBAL_SHORTCUT_DEFAULTS),
     ]) {
       if (!accelerator) continue;
-      owners.set(accelerator, [...(owners.get(accelerator) ?? []), kind]);
+      const claimants = owners.get(accelerator);
+      if (claimants) {
+        claimants.push(kind);
+      } else {
+        owners.set(accelerator, [kind]);
+      }
     }
 
     // Electron binds a duplicated chord to whichever menu item it builds
     // first and drops the other silently, so a collision reads as "the
-    // shortcut does nothing" rather than as an error. Naming the colliding
-    // commands here means the next default lands with its conflict spelled
-    // out instead of as a bug report.
+    // shortcut does nothing" rather than as an error.
     const collisions = [...owners.entries()]
       .filter(([, kinds]) => kinds.length > 1)
       .map(([accelerator, kinds]) => `${accelerator}: ${kinds.join(", ")}`);

--- a/packages/electron-desktop/src/commands.test.ts
+++ b/packages/electron-desktop/src/commands.test.ts
@@ -6,8 +6,12 @@ mock.module("electron", () => ({
   BrowserWindow: { getFocusedWindow: () => null, getAllWindows: () => [] },
 }));
 
-const { configureHotkeySettings, DEFAULT_ACCELERATORS, resolveAccelerator } =
-  await import("./commands");
+const {
+  configureHotkeySettings,
+  DEFAULT_ACCELERATORS,
+  GLOBAL_SHORTCUT_DEFAULTS,
+  resolveAccelerator,
+} = await import("./commands");
 
 configureHotkeySettings({
   read: () =>
@@ -59,5 +63,28 @@ describe("resolveAccelerator", () => {
     expect(resolveAccelerator("markCurrentUnread")).toBe(
       DEFAULT_ACCELERATORS.markCurrentUnread,
     );
+  });
+});
+
+describe("compiled accelerator defaults", () => {
+  test("no chord is claimed by two commands", () => {
+    const owners = new Map<string, string[]>();
+    for (const [kind, accelerator] of [
+      ...Object.entries(DEFAULT_ACCELERATORS),
+      ...Object.entries(GLOBAL_SHORTCUT_DEFAULTS),
+    ]) {
+      if (!accelerator) continue;
+      owners.set(accelerator, [...(owners.get(accelerator) ?? []), kind]);
+    }
+
+    // Electron binds a duplicated chord to whichever menu item it builds
+    // first and drops the other silently, so a collision reads as "the
+    // shortcut does nothing" rather than as an error. Naming the colliding
+    // commands here means the next default lands with its conflict spelled
+    // out instead of as a bug report.
+    const collisions = [...owners.entries()]
+      .filter(([, kinds]) => kinds.length > 1)
+      .map(([accelerator, kinds]) => `${accelerator}: ${kinds.join(", ")}`);
+    expect(collisions).toEqual([]);
   });
 });

--- a/packages/electron-desktop/src/commands.ts
+++ b/packages/electron-desktop/src/commands.ts
@@ -64,6 +64,7 @@ export const DEFAULT_ACCELERATORS: Record<VellumCommandKind, string> = {
   newConversation: "CmdOrCtrl+N",
   currentConversation: "CmdOrCtrl+Shift+N",
   markCurrentUnread: "CmdOrCtrl+Shift+U",
+  togglePinConversation: "CmdOrCtrl+Shift+P",
   openSettings: "CmdOrCtrl+,",
   shareFeedback: "",
   find: "CmdOrCtrl+F",

--- a/packages/electron-desktop/src/hotkeys.test.ts
+++ b/packages/electron-desktop/src/hotkeys.test.ts
@@ -72,6 +72,7 @@ describe("resolveHotkeyCatalog", () => {
       "newConversation",
       "currentConversation",
       "markCurrentUnread",
+      "togglePinConversation",
       "sidebarToggle",
       "popOut",
       "home",

--- a/packages/electron-desktop/src/hotkeys.ts
+++ b/packages/electron-desktop/src/hotkeys.ts
@@ -30,10 +30,12 @@ interface HotkeyCommand {
 }
 
 /**
- * The rebindable commands surfaced in the Keyboard Shortcuts settings, in menu
- * order. Voice input, Find, Command Palette, and Settings are intentionally
- * absent: they are bound but not rebindable, and ride along in
- * `RESERVED_COMMANDS` below so conflict detection still sees their chords.
+ * The rebindable commands surfaced in the Keyboard Shortcuts settings, in the
+ * order their rows render: system-wide shortcuts first, then the menu
+ * commands. This is not the menu's own order and does not track it. Voice
+ * input, Find, Command Palette, and Settings are intentionally absent: they
+ * are bound but not rebindable, and ride along in `RESERVED_COMMANDS` below
+ * so conflict detection still sees their chords.
  */
 const HOTKEY_CATALOG: readonly HotkeyCommand[] = [
   { key: "globalHotkey", label: "Open Vellum", scope: "global" },

--- a/packages/electron-desktop/src/hotkeys.ts
+++ b/packages/electron-desktop/src/hotkeys.ts
@@ -24,17 +24,16 @@ export type { HotkeyScope, ResolvedHotkey };
 interface HotkeyCommand {
   /** Key into `settings.hotkeys` and the matching defaults map. */
   key: string;
-  /** User-facing label, matching the native app's Keyboard Shortcuts card. */
+  /** User-facing label for the Keyboard Shortcuts settings row. */
   label: string;
   scope: HotkeyScope;
 }
 
 /**
- * The rebindable commands surfaced in the Keyboard Shortcuts settings, in the
- * same order and with the same labels as the native macOS app's
- * `SettingsAppearanceTab` "Keyboard Shortcuts" card. This is the parity
- * contract: commands the native card does not let the user rebind (voice
- * input, Find, Command Palette, Settings) are intentionally absent.
+ * The rebindable commands surfaced in the Keyboard Shortcuts settings, in menu
+ * order. Voice input, Find, Command Palette, and Settings are intentionally
+ * absent: they are bound but not rebindable, and ride along in
+ * `RESERVED_COMMANDS` below so conflict detection still sees their chords.
  */
 const HOTKEY_CATALOG: readonly HotkeyCommand[] = [
   { key: "globalHotkey", label: "Open Vellum", scope: "global" },
@@ -47,6 +46,7 @@ const HOTKEY_CATALOG: readonly HotkeyCommand[] = [
     label: "Mark conversation as unread",
     scope: "menu",
   },
+  { key: "togglePinConversation", label: "Pin conversation", scope: "menu" },
   { key: "sidebarToggle", label: "Toggle sidebar", scope: "menu" },
   { key: "popOut", label: "Pop out conversation", scope: "menu" },
   { key: "home", label: "Home", scope: "menu" },

--- a/packages/ipc-contract/src/types.ts
+++ b/packages/ipc-contract/src/types.ts
@@ -29,6 +29,13 @@ export type VellumCommand =
   | { kind: "newConversation" }
   | { kind: "currentConversation" }
   | { kind: "markCurrentUnread" }
+  /**
+   * Pin the conversation the user is looking at, or unpin it when it is
+   * already pinned. One kind for both edges because the renderer owns the
+   * pinned state; main builds a single static menu item and never learns
+   * which edge a press is.
+   */
+  | { kind: "togglePinConversation" }
   | { kind: "openSettings" }
   | { kind: "shareFeedback" }
   | { kind: "find" }


### PR DESCRIPTION
## TL;DR

Pinning a conversation is currently reachable only by right-clicking a sidebar row. This adds it to the File menu on both desktop shells as **Pin Current Conversation**, bound to `Cmd/Ctrl+Shift+P`.

```
File
  New Conversation           ⌘N
  Current Conversation       ⇧⌘N
  ──────────────────────────────
  Pin Current Conversation   ⇧⌘P     <- new
  Mark Current as Unread     ⇧⌘U
  ──────────────────────────────
  Previous Conversation      ⌘↑
  Next Conversation          ⌘↓
```

## What changes for the user

| Before | After |
| --- | --- |
| Pinning required finding the conversation in the sidebar and right-clicking it. | The open conversation can be pinned from the File menu, or with `⇧⌘P`, without leaving the keyboard. |
| No keyboard route to pinning at all. | `⇧⌘P` by default, and rebindable in Settings > Keyboard Shortcuts alongside the other menu commands. |
| **Mark Current as Unread did nothing when the open conversation was a background, scheduled, or archived thread.** | Both it and the new pin command act on any open conversation, matching the buttons in the conversation header. |

Nothing is removed and no existing chord changes.

## Why `Cmd+Shift+P` and not `Cmd+P`

`Cmd+P` is already **Pop Out Conversation**. There is no cross-application convention for pinning to borrow from (Slack, Notion, and Chrome all ship it unbound), so the strongest available signal is the menu section's own pattern: its neighbours are `⇧⌘N` and `⇧⌘U`. `⇧⌘P` is unclaimed by every compiled default, global shortcut, and renderer key handler in the repo.

`⇧⌘P` is the command palette chord in VS Code and Chrome DevTools. That does not leak in here: these are Electron menu accelerators, scoped to the app while it has focus, not `globalShortcut` registrations.

## Resolving "the current conversation"

Both File menu commands take their target row from `activeConversation`, the value `useActiveConversation` resolves. The foreground `conversations` list deliberately omits background, scheduled, and archived threads, so a lookup against it misses precisely the conversations that hook exists to resolve, and the command would silently do nothing on them.

`ChatConversationHeader` already acts on that same row for its own Pin and Mark Unread buttons, so the menu and the header now agree on what "the current conversation" means. A single `withActiveConversation` helper states the "no open conversation, no-op" rule once for both commands.

This corrects a pre-existing gap in `markCurrentUnread`, which is why that row appears in the table above.

## Why the label is static

The item always reads "Pin Current Conversation", including when the open conversation is already pinned and the press will unpin it.

One `togglePinConversation` command kind covers both edges. The pinned state lives in the renderer, and the main process, which builds the menu, has no channel carrying it. A `Pin` / `Unpin` label that flips with state would need a new renderer-to-main IPC channel publishing pinned state on every conversation switch, following the existing `vellum:menu:setPlatformSession` pattern, plus a preload field, a runtime wrapper, and a domain sync hook. That roughly doubles the change and adds a state channel that has to stay in sync, so it is deliberately out of scope. This matches how the File menu already behaves: nothing in it tracks conversation state today.

## Why this is safe

- **No new pinning logic.** The renderer handler routes to `handleTogglePinConversation`, the same callback the sidebar context menu and the conversation header already call. Every entry point takes an identical optimistic-update, rollback, and invalidation path. There is no second implementation to drift.
- **Additive at every contract boundary.** A new union member, a new map entry, a new menu item, a new catalog row, a new schema enum member, and a new handler. The only existing behaviour that changes is the `markCurrentUnread` fix described above.
- **The exhaustive maps are compiler-enforced.** `DEFAULT_ACCELERATORS` is a `Record<VellumCommandKind, string>` and the palette dispatch schema is checked against the command union, so a kind added without its accelerator or schema entry fails to compile rather than failing silently at runtime. Type checking passes on all four projects that see the union.
- **No migration needed for persisted hotkeys.** `settings.hotkeys` is persisted user state, but a new `DEFAULT_ACCELERATORS` entry cannot disturb it: defaults merge lazily at menu-build time rather than through the electron-store schema `default` block, precisely so a schema change never clobbers a user's overrides. An existing install picks up `Shift+Cmd+P` without losing any chord it had already rebound.
- **The chord is verified free, and stays that way.** A new test asserts no two compiled accelerator defaults claim the same chord. Electron resolves a duplicate by binding whichever menu item it builds first and dropping the other with no error, so a collision surfaces as "the shortcut does nothing". The test was sensitivity-checked: it fails, naming both commands, if pinning is set to `Cmd+P`.

## Deferred

- **No renderer test for the command handler.** `markCurrentUnread`, the handler this one is now unified with, has no test either, so there is no `ChatLayout` command harness to extend. Building one for a single handler is disproportionate to the change; it is worth doing when the first handler needs coverage for its own sake, at which point it covers the whole map.
- **Dynamic Pin / Unpin label.** Reasoning above. Worth revisiting if the static label proves confusing in use.

## Incidental

`HOTKEY_CATALOG`'s docstring described the list as ordered to match a native macOS Keyboard Shortcuts card (`SettingsAppearanceTab`) that no longer exists in this tree. The catalog is not in menu order and never has been: `sidebarToggle`, `popOut`, and `home` sit ahead of the File menu's Previous and Next Conversation while living in the View and Window menus. The docstring now describes the order the rows actually render in, system-wide shortcuts first and then menu commands, and says explicitly that it does not track menu order. Reordering the catalog instead would have shuffled existing settings rows for no user-visible benefit.

## Verification

- Type checking passes on `packages/electron-desktop`, `clients/macos`, `clients/windows`, and `clients/web`.
- Lint passes on the touched web file.
- The six files in the repo that enumerate command kinds are exactly the six touched here, confirmed by grep.
- Test suites were not run locally; CI is the gate. The two edited test files are list assertions checked by hand against the new catalog order.
