### PR TITLE
fix(web): treat the live-voice working cue as audio, not as speech

### DIFF
--- a/clients/web/src/domains/chat/voice/live-voice/protocol.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/protocol.ts
@@ -261,6 +261,19 @@ export interface LiveVoiceTtsAudioServerFrame extends LiveVoiceServerFrameBase {
   readonly mimeType: string;
   readonly sampleRate: number;
   readonly dataBase64: string;
+  /**
+   * Rendered non-speech audio rather than a synthesized utterance: the working
+   * cue, a short wordless tone the daemon plays into the silence of a long
+   * tool-heavy turn. It travels on this frame so it inherits the speech path's
+   * echo cancellation and ordering.
+   *
+   * Omitted entirely for speech, so an absent field means speech (including on
+   * daemons predating the marker). It is audio in every respect that reaches
+   * the speaker, and nothing beyond that: a marked frame must not be read as
+   * the assistant talking, which is what the phase, the barge-in gate, the
+   * client-heard latency, and the spoken-word cursor all measure.
+   */
+  readonly nonSpeech?: true;
 }
 
 export interface LiveVoiceTtsDoneServerFrame extends LiveVoiceServerFrameBase {

--- a/clients/web/src/domains/chat/voice/live-voice/protocol.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/protocol.ts
@@ -358,6 +358,13 @@ export interface LiveVoiceMetricsServerFrame extends LiveVoiceServerFrameBase {
    * unchanged).
    */
   readonly progressUpdatesSpoken?: number;
+  /**
+   * Working cues played into the turn's silence. Present only when at least
+   * one played (otherwise the field is absent, keeping frames unchanged).
+   * The cue is the default floor-holder, so this is what separates a turn
+   * that hummed while it worked from one that sat silent.
+   */
+  readonly workingCuesPlayed?: number;
 }
 
 export interface LiveVoiceArchivedServerFrame extends LiveVoiceServerFrameBase {

--- a/clients/web/src/domains/chat/voice/live-voice/tts-playback.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/tts-playback.test.ts
@@ -928,6 +928,46 @@ describe("LiveVoiceAudioPlayer", () => {
       expect(player.getPlaybackProgress()).toBeNull();
     });
 
+    test("a non-speech chunk plays but reports no progress", () => {
+      player.enqueue({ ...chunk(new Array(24000).fill(1)), nonSpeech: true });
+
+      // It is scheduled and audible, and it holds the queue open.
+      expect(ctx.sources).toHaveLength(1);
+      expect(ctx.sources[0]!.startedAt).toBe(0);
+      expect(player.isPlaying).toBe(true);
+      // It carries no words, so there is nothing for a cursor to follow.
+      expect(player.getPlaybackProgress()).toBeNull();
+    });
+
+    test("a cue ahead of speech never inflates total or played", () => {
+      // 1.0s cue at t=0, then the report's first second of speech behind it.
+      player.enqueue({ ...chunk(new Array(24000).fill(1)), nonSpeech: true });
+      player.enqueue(chunk(new Array(24000).fill(1)));
+
+      // Only the speech counts, and none of it has sounded while the cue plays.
+      expect(player.getPlaybackProgress()).toEqual({
+        playedSeconds: 0,
+        totalSeconds: 1,
+      });
+
+      ctx.currentTime = 1;
+      expect(player.getPlaybackProgress()).toEqual({
+        playedSeconds: 0,
+        totalSeconds: 1,
+      });
+
+      ctx.currentTime = 1.5;
+      expect(player.getPlaybackProgress()!.playedSeconds).toBeCloseTo(0.5, 6);
+    });
+
+    test("container path: a non-speech decode contributes nothing to total", async () => {
+      player.enqueue({ ...frame("audio/wav"), nonSpeech: true });
+      await flushMicrotasks();
+
+      expect(ctx.sources).toHaveLength(1);
+      expect(player.getPlaybackProgress()).toBeNull();
+    });
+
     test("container path: a resolved async decode contributes its duration to total", async () => {
       player.enqueue(frame("audio/wav"));
       // Not scheduled yet: no progress until the decode resolves.

--- a/clients/web/src/domains/chat/voice/live-voice/tts-playback.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/tts-playback.ts
@@ -56,17 +56,28 @@ export interface TtsAudioChunk {
   sampleRate: number;
   /** MIME type of the audio payload (e.g. "audio/pcm", "audio/wav"). */
   mimeType: string;
+  /**
+   * Rendered non-speech audio (the working cue) rather than a synthesized
+   * utterance. It plays like any other chunk and holds the queue open, but
+   * carries no words, so it is left out of the playback progress that drives
+   * the spoken-word cursor. Absent means speech.
+   */
+  nonSpeech?: boolean;
 }
 
 /**
  * Playback progress of the current response's TTS audio.
  *
- * `totalSeconds` is the cumulative duration of every buffer scheduled since the
- * last reset (new response / stop); `playedSeconds` is how much of it has
- * actually sounded, derived from the audio playhead. During a mid-turn silence
- * (queue drained, more speech coming) `playedSeconds === totalSeconds`, so a
- * consumer's cursor holds at the last spoken word rather than resetting — the
- * next audio burst grows `totalSeconds` and the cursor advances again.
+ * `totalSeconds` is the cumulative duration of every speech buffer scheduled
+ * since the last reset (new response / stop); `playedSeconds` is how much of
+ * it has actually sounded, derived from the audio playhead. Non-speech chunks
+ * ({@link TtsAudioChunk.nonSpeech}) play but enter neither number, so a cue
+ * holding a silent turn's floor never advances a word cursor.
+ *
+ * During a mid-turn silence (queue drained, more speech coming)
+ * `playedSeconds === totalSeconds`, so a consumer's cursor holds at the last
+ * spoken word rather than resetting: the next audio burst grows `totalSeconds`
+ * and the cursor advances again.
  */
 export interface LiveVoicePlaybackProgress {
   /** Seconds of scheduled audio already played, in [0, totalSeconds]. */
@@ -315,8 +326,8 @@ export class LiveVoiceAudioPlayer {
   private playingState = false;
 
   /**
-   * Cumulative duration (seconds) of every buffer scheduled since the last
-   * progress reset. Backs {@link getPlaybackProgress}.
+   * Cumulative duration (seconds) of every speech buffer scheduled since the
+   * last progress reset. Backs {@link getPlaybackProgress}.
    *
    * Deliberately NOT reset in {@link settleIfIdle}: a drain mid-turn (ack →
    * tool run → more speech) zeroes only the playhead, so progress reports
@@ -450,7 +461,7 @@ export class LiveVoiceAudioPlayer {
     const buffer = context.createBuffer(1, samples.length, chunk.sampleRate);
     buffer.getChannelData(0).set(samples);
 
-    this.scheduleBuffer(context, buffer);
+    this.scheduleBuffer(context, buffer, chunk.nonSpeech === true);
   }
 
   /**
@@ -473,6 +484,7 @@ export class LiveVoiceAudioPlayer {
   private enqueueContainer(chunk: TtsAudioChunk, mimeType: string): void {
     const context = this.ensureContext();
     const arrayBuffer = base64ToArrayBuffer(chunk.dataBase64);
+    const nonSpeech = chunk.nonSpeech === true;
     const generation = this.generation;
     this.pendingContainerDecodes += 1;
 
@@ -498,7 +510,7 @@ export class LiveVoiceAudioPlayer {
         ) {
           return;
         }
-        this.scheduleBuffer(context, buffer);
+        this.scheduleBuffer(context, buffer, nonSpeech);
       } finally {
         // A stop() between start and resolution already zeroed the counter (and
         // resolved drain); skip the accounting so we don't go negative.
@@ -512,8 +524,18 @@ export class LiveVoiceAudioPlayer {
     });
   }
 
-  /** Connect a decoded buffer to the destination and start it gaplessly. */
-  private scheduleBuffer(context: AudioContextLike, buffer: AudioBuffer): void {
+  /**
+   * Connect a decoded buffer to the destination and start it gaplessly.
+   *
+   * A non-speech buffer takes its place on the timeline like any other, so
+   * ordering and the echo reference are unchanged; it just contributes no
+   * duration to the progress a word cursor reads.
+   */
+  private scheduleBuffer(
+    context: AudioContextLike,
+    buffer: AudioBuffer,
+    nonSpeech: boolean,
+  ): void {
     const source = context.createBufferSource();
     source.buffer = buffer;
 
@@ -532,7 +554,9 @@ export class LiveVoiceAudioPlayer {
     const startAt = Math.max(this.playheadTime, context.currentTime);
     source.start(startAt);
     this.playheadTime = startAt + buffer.duration;
-    this.totalScheduledSeconds += buffer.duration;
+    if (!nonSpeech) {
+      this.totalScheduledSeconds += buffer.duration;
+    }
 
     this.activeSources.add(source);
     source.onended = () => {
@@ -919,6 +943,12 @@ export class LiveVoiceAudioPlayer {
    * scheduled timeline, so silent gaps between bursts never inflate played
    * time, and after a drain (`playheadTime` zeroed) progress reports
    * `played == total`. Side-effect-free: reading never advances state.
+   *
+   * Non-speech audio still sits on that timeline, so while a cue is playing
+   * ahead of queued speech the tail it occupies reads as unplayed speech and
+   * `playedSeconds` floors at 0 rather than going negative. That understates
+   * played time by at most the cue's own length, and only until the cue
+   * finishes; a consumer's cursor is monotonic, so it holds rather than moves.
    */
   getPlaybackProgress(): LiveVoicePlaybackProgress | null {
     if (this.context === null || this.totalScheduledSeconds === 0) {

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
@@ -351,6 +351,121 @@ describe("assistant-audio activity", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Working cue: a `tts_audio` frame marked `nonSpeech`
+// ---------------------------------------------------------------------------
+
+describe("working cue (non-speech tts_audio)", () => {
+  function emitCue(h: ReturnType<typeof renderController>, seq: number) {
+    h.client.emit("ttsAudio", {
+      type: "tts_audio",
+      seq,
+      mimeType: "audio/pcm",
+      sampleRate: 24000,
+      dataBase64: "AAAA",
+      nonSpeech: true,
+    });
+  }
+
+  function emitSpeech(h: ReturnType<typeof renderController>, seq: number) {
+    h.client.emit("ttsAudio", {
+      type: "tts_audio",
+      seq,
+      mimeType: "audio/pcm",
+      sampleRate: 24000,
+      dataBase64: "AAAA",
+    });
+  }
+
+  test("plays without flipping the room to `speaking`", async () => {
+    const h = renderController();
+    await startListening(h, { handsFree: true });
+
+    act(() => {
+      h.client.emit("thinking", { type: "thinking", seq: 2, turnId: "t1" });
+      emitCue(h, 3);
+      emitCue(h, 4);
+    });
+
+    // Audible: both cues reach the player, marked so the player leaves them
+    // out of the progress the word cursor reads.
+    expect(h.player.enqueued).toHaveLength(2);
+    expect(h.player.enqueued[0]).toMatchObject({ nonSpeech: true });
+    // Inert: the working turn stays quiet rather than blinking through
+    // `speaking` once per cue.
+    expect(h.view.result.current.state).toBe("thinking");
+    expect(useLiveVoiceStore.getState().assistantAudioActive).toBe(false);
+
+    // The report that follows is speech and does flip the room.
+    act(() => {
+      emitSpeech(h, 5);
+    });
+    expect(h.view.result.current.state).toBe("speaking");
+    expect(useLiveVoiceStore.getState().assistantAudioActive).toBe(true);
+    expect(h.player.enqueued[2]).toMatchObject({ nonSpeech: undefined });
+  });
+
+  test("does not open hands-free barge-in during the silent working stretch", async () => {
+    const h = renderController();
+    await startListening(h, { handsFree: true });
+
+    act(() => {
+      h.client.emit("thinking", { type: "thinking", seq: 2, turnId: "t1" });
+      emitCue(h, 3);
+    });
+
+    // "Stop response" while the turn is still working: there is no response to
+    // stop, so the turn is left running rather than cancelled by the tone.
+    act(() => {
+      useLiveVoiceStore.getState().controls?.interrupt();
+    });
+    expect(h.client.interruptCount).toBe(0);
+    expect(h.player.stopCount).toBe(0);
+    expect(h.view.result.current.state).toBe("thinking");
+
+    // Once the answer is actually being spoken, the same control cancels it.
+    act(() => {
+      emitSpeech(h, 4);
+    });
+    act(() => {
+      useLiveVoiceStore.getState().controls?.interrupt();
+    });
+    expect(h.client.interruptCount).toBe(1);
+    expect(h.view.result.current.state).toBe("listening");
+  });
+
+  test("does not latch the client-heard latency", async () => {
+    const h = renderController();
+    await startListening(h, { handsFree: true });
+
+    act(() => {
+      h.client.emit("utteranceEnd", {
+        type: "utterance_end",
+        seq: 2,
+        reason: "silence",
+      });
+    });
+    await act(async () => {
+      await sleep(10);
+    });
+    act(() => {
+      h.client.emit("thinking", { type: "thinking", seq: 3, turnId: "t1" });
+      emitCue(h, 4);
+    });
+
+    // The tone is not the answer starting to be spoken, so the end-of-speech
+    // stamp is still unspent.
+    expect(useLiveVoiceStore.getState().lastTurnLatency).toBeNull();
+
+    act(() => {
+      emitSpeech(h, 5);
+    });
+    const latency = useLiveVoiceStore.getState().lastTurnLatency;
+    expect(latency).not.toBeNull();
+    expect(latency!.clientHeardLatencyMs).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Barge-in
 // ---------------------------------------------------------------------------
 

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -969,18 +969,33 @@ export function useLiveVoice(
           if (session.interruptSent) {
             return;
           }
-          beginAssistantAudioIfNeeded(session);
+          // The working cue is audio, not speech. It plays, which is the whole
+          // reason the daemon sends it on this frame at all, but a wordless
+          // tone holding a silent turn's floor is not the assistant talking.
+          // So everything downstream that means "talking" stays where it was:
+          // the phase (a cue every ~12s would otherwise blink the room in and
+          // out of `speaking` for the whole working stretch), the hands-free
+          // barge-in gate that reads that phase, the client-heard latency
+          // (which measures when the answer starts being spoken), and the
+          // spoken-word cursor's played/total accounting.
+          const isSpeech = frame.nonSpeech !== true;
+          if (isSpeech) {
+            beginAssistantAudioIfNeeded(session);
+          }
           const chunk: TtsAudioChunk = {
             dataBase64: frame.dataBase64,
             sampleRate: frame.sampleRate,
             mimeType: frame.mimeType,
+            nonSpeech: frame.nonSpeech,
           };
           session.player.enqueue(chunk);
-          // Mark audio flowing before the phase flip so no render observes
-          // `speaking` without `assistantAudioActive` (which would blink the
-          // avatar to `thinking` at the top of every response — JARVIS-1279).
-          markAssistantAudioActive(session);
-          useLiveVoiceStore.getState().setState("speaking");
+          if (isSpeech) {
+            // Mark audio flowing before the phase flip so no render observes
+            // `speaking` without `assistantAudioActive` (which would blink the
+            // avatar to `thinking` at the top of every response — JARVIS-1279).
+            markAssistantAudioActive(session);
+            useLiveVoiceStore.getState().setState("speaking");
+          }
         }),
         client.on("ttsDone", () => {
           if (!live()) {
@@ -1570,6 +1585,10 @@ function interruptIfSpeaking(
  * Unlike the manual barge-in above this does not require `player.isPlaying`:
  * `speaking` can hold between chunks with more audio still inbound, and the
  * cancel must land regardless.
+ *
+ * The `speaking` gate is also what keeps a long working stretch quiet: a
+ * working cue plays without entering `speaking`, so the tone does not make a
+ * turn interruptible during the silence it exists to hold.
  */
 function interruptTurnHandsFree(session: SessionContext): void {
   if (useLiveVoiceStore.getState().state !== "speaking") {
@@ -1625,10 +1644,12 @@ const ASSISTANT_AUDIO_IDLE_MS = 500;
 
 /**
  * Mark assistant TTS audio as flowing and (re)arm the idle check. Called on
- * every `tts_audio` frame: a continuous stream keeps re-arming the timer so the
- * flag stays true for the whole spoken stretch; once frames stop and the queue
- * drains, {@link scheduleAssistantAudioIdleCheck} flips it false. Drives the
- * avatar's `speaking → responding` vs `thinking` split (JARVIS-1279).
+ * every speech `tts_audio` frame: a continuous stream keeps re-arming the timer
+ * so the flag stays true for the whole spoken stretch; once frames stop and the
+ * queue drains, {@link scheduleAssistantAudioIdleCheck} flips it false. Drives
+ * the avatar's `speaking → responding` vs `thinking` split (JARVIS-1279). A
+ * non-speech frame is skipped: the flag says the assistant is talking, and a
+ * working cue is audible without being that.
  */
 function markAssistantAudioActive(session: SessionContext): void {
   useLiveVoiceStore.getState().setAssistantAudioActive(true);

--- a/clients/web/src/domains/chat/voice/voice-room/use-spoken-word-cursor.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/use-spoken-word-cursor.ts
@@ -13,6 +13,11 @@
  * keeps the cursor at the pace of real speech until the mapping becomes
  * trustworthy.
  *
+ * The progress the player reports counts only speech. Non-speech audio (the
+ * working cue that holds a long turn's silence) plays without entering either
+ * number, so a turn that spends minutes making tones and no words leaves the
+ * cursor where it was rather than dragging it across words nothing spoke.
+ *
  * The cursor advances only while audio remains scheduled
  * (`playedSeconds < totalSeconds`). When the queue is caught up
  * (played == total — a mid-response silence while synthesis lags the streamed


### PR DESCRIPTION
## Summary
- Mirror the tts_audio non-speech marker and consume it in the live-voice client.
- A marked frame plays but no longer flips the room to speaking, opens hands-free barge-in, latches client-heard latency, or feeds the spoken-word cursor's progress accounting.
- Unmarked speech frames are unchanged.

Part of plan: voice-speak-final-answer-only.md (review remediation)