### PR TITLE
refactor(gateway): admit actor tokens through one revocation and activity helper

### DIFF
--- a/gateway/src/__tests__/actor-token-revocation.test.ts
+++ b/gateway/src/__tests__/actor-token-revocation.test.ts
@@ -1,6 +1,7 @@
 /**
- * Tests for the hot-path actor-token revocation check: a revoked actor token
- * is rejected on live requests, with fail-open semantics for non-actor,
+ * Tests for hot-path actor-token admission: a revoked actor token is rejected
+ * on live requests and stamps nothing, an admitted one records its device's
+ * activity off the same lookup, with fail-open semantics for non-actor,
  * unrecorded, and DB-error cases.
  */
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
@@ -21,9 +22,8 @@ const { initGatewayDb, resetGatewayDb, getGatewayDb } =
 const { actorTokenRecords, contacts } = await import("../db/schema.js");
 const { hashToken } = await import("../auth/guardian-bootstrap.js");
 const {
-  isActorTokenRevoked,
+  admitActorToken,
   actorTokenRecordHash,
-  recordActorTokenUse,
   __resetLastUsedDebounceForTests,
 } = await import("../auth/actor-token-revocation.js");
 const { createRuntimeProxyHandler } =
@@ -74,6 +74,35 @@ function readRow(rawToken: string) {
     .get();
 }
 
+/** Records the SQL drizzle prepares while `fn` runs. */
+function captureSql(fn: () => void): string[] {
+  type PreparingClient = {
+    prepare: (sql: string, ...rest: unknown[]) => unknown;
+  };
+  const client = (getGatewayDb() as unknown as { $client: PreparingClient })
+    .$client;
+  const original = client.prepare;
+  const seen: string[] = [];
+  client.prepare = (sql, ...rest) => {
+    seen.push(sql);
+    return original.call(client, sql, ...rest);
+  };
+  try {
+    fn();
+  } finally {
+    client.prepare = original;
+  }
+  return seen;
+}
+
+function statementsOn(sql: string[], verb: "select" | "update"): string[] {
+  return sql.filter(
+    (stmt) =>
+      stmt.trim().toLowerCase().startsWith(verb) &&
+      stmt.includes("actor_token_records"),
+  );
+}
+
 function insertGuardianContact() {
   const now = Date.now();
   getGatewayDb()
@@ -120,31 +149,31 @@ afterEach(() => {
   }
 });
 
-describe("isActorTokenRevoked", () => {
-  test("returns true for an actor token whose record is revoked", () => {
+describe("admitActorToken: revocation verdict", () => {
+  test("rejects an actor token whose record is revoked", () => {
     insertTokenRecord("token-revoked", "revoked");
-    expect(isActorTokenRevoked("token-revoked", actorClaims)).toBe(true);
+    expect(admitActorToken("token-revoked", actorClaims)).toBe(false);
   });
 
-  test("returns false for an actor token whose record is active", () => {
+  test("admits an actor token whose record is active", () => {
     insertTokenRecord("token-active", "active");
-    expect(isActorTokenRevoked("token-active", actorClaims)).toBe(false);
+    expect(admitActorToken("token-active", actorClaims)).toBe(true);
   });
 
-  test("returns false (fail-open) for an actor token with no record", () => {
-    expect(isActorTokenRevoked("token-unknown", actorClaims)).toBe(false);
+  test("admits (fail-open) an actor token with no record", () => {
+    expect(admitActorToken("token-unknown", actorClaims)).toBe(true);
   });
 
   test("never checks non-actor tokens (svc)", () => {
     // Even if a row with this hash were revoked, a svc sub must be ignored.
     insertTokenRecord("svc-token", "revoked");
     const svcClaims = { sub: "svc:gateway:self" } as TokenClaims;
-    expect(isActorTokenRevoked("svc-token", svcClaims)).toBe(false);
+    expect(admitActorToken("svc-token", svcClaims)).toBe(true);
   });
 
-  test("returns false (fail-open) when the gateway DB is unavailable", () => {
+  test("admits (fail-open) when the gateway DB is unavailable", () => {
     resetGatewayDb();
-    expect(isActorTokenRevoked("token-anything", actorClaims)).toBe(false);
+    expect(admitActorToken("token-anything", actorClaims)).toBe(true);
   });
 
   test("still detects revocation when the token has surrounding whitespace", () => {
@@ -152,8 +181,20 @@ describe("isActorTokenRevoked", () => {
     // supplied with trailing whitespace (e.g. a `?token=<jwt>%20` WS param)
     // must still resolve to the revoked record.
     insertTokenRecord("token-revoked", "revoked");
-    expect(isActorTokenRevoked("token-revoked ", actorClaims)).toBe(true);
-    expect(isActorTokenRevoked(" token-revoked\n", actorClaims)).toBe(true);
+    expect(admitActorToken("token-revoked ", actorClaims)).toBe(false);
+    expect(admitActorToken(" token-revoked\n", actorClaims)).toBe(false);
+  });
+
+  test("a revoked token is rejected without stamping any row", () => {
+    // A re-paired device: the revoked row and a fresh active row share a
+    // hashed device id, so a misordered stamp would land on the active one.
+    insertTokenRecord("token-stale", "revoked");
+    insertTokenRecord("token-fresh", "active");
+
+    expect(admitActorToken("token-stale", actorClaims)).toBe(false);
+
+    expect(readRow("token-stale")?.lastUsedAt).toBeNull();
+    expect(readRow("token-fresh")?.lastUsedAt).toBeNull();
   });
 });
 
@@ -181,19 +222,19 @@ describe("signature-encoding canonicalization (revocation bypass)", () => {
     insertTokenRecord(jwt, "revoked"); // stored under the canonical token hash
 
     // Baseline: the canonical token is detected as revoked.
-    expect(isActorTokenRevoked(jwt, actorClaims)).toBe(true);
+    expect(admitActorToken(jwt, actorClaims)).toBe(false);
 
     // Bypass attempt: same token, signature re-encoded (different string, same
     // bytes). Must still resolve to the revoked record.
     const padded = padSignature(jwt);
     expect(padded).not.toBe(jwt);
-    expect(isActorTokenRevoked(padded, actorClaims)).toBe(true);
+    expect(admitActorToken(padded, actorClaims)).toBe(false);
   });
 
   test("does not falsely revoke an active token re-encoded with padding", () => {
     const jwt = mintActorJwt();
     insertTokenRecord(jwt, "active");
-    expect(isActorTokenRevoked(padSignature(jwt), actorClaims)).toBe(false);
+    expect(admitActorToken(padSignature(jwt), actorClaims)).toBe(true);
   });
 });
 
@@ -319,12 +360,12 @@ describe("/auth/token revocation", () => {
       .get();
 
     expect(derivedRecord?.status).toBe("derived");
-    expect(isActorTokenRevoked(derivedJwt, actorClaims)).toBe(false);
+    expect(admitActorToken(derivedJwt, actorClaims)).toBe(true);
 
     revokeActorTokensByDevice("guardian-001", hashToken("device-A"));
 
-    expect(isActorTokenRevoked(sourceJwt, actorClaims)).toBe(true);
-    expect(isActorTokenRevoked(derivedJwt, actorClaims)).toBe(true);
+    expect(admitActorToken(sourceJwt, actorClaims)).toBe(false);
+    expect(admitActorToken(derivedJwt, actorClaims)).toBe(false);
   });
 
   test("fails closed with a repairable 401 when guardian rows are lost over evidence (no divergent mint)", async () => {
@@ -476,13 +517,13 @@ describe("m0004 token-hash index migration", () => {
   });
 });
 
-describe("recordActorTokenUse", () => {
+describe("admitActorToken: device last-used stamping", () => {
   test("stamps last_used_at on the active row for a recorded actor token", () => {
     insertTokenRecord("token-used", "active");
     const before = readRow("token-used");
     expect(before?.lastUsedAt).toBeNull();
 
-    recordActorTokenUse("token-used", actorClaims);
+    expect(admitActorToken("token-used", actorClaims)).toBe(true);
 
     const after = readRow("token-used");
     expect(after?.lastUsedAt).toBeGreaterThan(0);
@@ -490,9 +531,21 @@ describe("recordActorTokenUse", () => {
     expect(after?.updatedAt).toBe(before?.updatedAt ?? 0);
   });
 
+  test("admitting a recorded token costs exactly one row lookup", () => {
+    insertTokenRecord("token-counted", "active");
+
+    const sql = captureSql(() => {
+      expect(admitActorToken("token-counted", actorClaims)).toBe(true);
+    });
+
+    // The verdict and the stamp share one SELECT; the stamp adds the UPDATE.
+    expect(statementsOn(sql, "select")).toHaveLength(1);
+    expect(statementsOn(sql, "update")).toHaveLength(1);
+  });
+
   test("does not write again inside the debounce window", () => {
     insertTokenRecord("token-debounced", "active");
-    recordActorTokenUse("token-debounced", actorClaims);
+    admitActorToken("token-debounced", actorClaims);
 
     const sentinel = 12_345;
     getGatewayDb()
@@ -501,16 +554,21 @@ describe("recordActorTokenUse", () => {
       .where(eq(actorTokenRecords.tokenHash, hashToken("token-debounced")))
       .run();
 
-    recordActorTokenUse("token-debounced", actorClaims);
+    const sql = captureSql(() => {
+      expect(admitActorToken("token-debounced", actorClaims)).toBe(true);
+    });
 
     expect(readRow("token-debounced")?.lastUsedAt).toBe(sentinel);
+    // The verdict still costs its lookup: revocation is never debounced.
+    expect(statementsOn(sql, "select")).toHaveLength(1);
+    expect(statementsOn(sql, "update")).toHaveLength(0);
   });
 
   test("a derived token stamps the sibling active row for the same device", () => {
     insertTokenRecord("token-source", "active");
     insertTokenRecord("token-derived", "derived");
 
-    recordActorTokenUse("token-derived", actorClaims);
+    admitActorToken("token-derived", actorClaims);
 
     expect(readRow("token-source")?.lastUsedAt).toBeGreaterThan(0);
     expect(readRow("token-derived")?.lastUsedAt).toBeNull();
@@ -520,7 +578,7 @@ describe("recordActorTokenUse", () => {
     insertTokenRecord("token-device-a", "active");
     insertTokenRecord("token-device-b", "active", "device-B");
 
-    recordActorTokenUse("token-device-a", actorClaims);
+    admitActorToken("token-device-a", actorClaims);
 
     expect(readRow("token-device-b")?.lastUsedAt).toBeNull();
   });
@@ -529,25 +587,25 @@ describe("recordActorTokenUse", () => {
     insertTokenRecord("svc-token", "active");
     const svcClaims = { sub: "svc:gateway:self" } as TokenClaims;
 
-    recordActorTokenUse("svc-token", svcClaims);
+    const sql = captureSql(() => {
+      expect(admitActorToken("svc-token", svcClaims)).toBe(true);
+    });
 
     expect(readRow("svc-token")?.lastUsedAt).toBeNull();
+    // Not even a lookup: a non-actor sub short-circuits before any DB work.
+    expect(sql).toHaveLength(0);
   });
 
   test("is a no-op for an unrecorded token hash", () => {
     insertTokenRecord("token-recorded", "active");
 
-    expect(() =>
-      recordActorTokenUse("token-unrecorded", actorClaims),
-    ).not.toThrow();
+    expect(admitActorToken("token-unrecorded", actorClaims)).toBe(true);
     expect(readRow("token-recorded")?.lastUsedAt).toBeNull();
   });
 
   test("swallows a DB failure (fail-open)", () => {
     resetGatewayDb();
-    expect(() =>
-      recordActorTokenUse("token-anything", actorClaims),
-    ).not.toThrow();
+    expect(() => admitActorToken("token-anything", actorClaims)).not.toThrow();
   });
 
   test("a failed stamp leaves the next attempt free to retry", () => {
@@ -560,29 +618,29 @@ describe("recordActorTokenUse", () => {
       "CREATE TRIGGER fail_last_used BEFORE UPDATE ON actor_token_records BEGIN SELECT RAISE(ABORT, 'stamp failed'); END",
     );
 
-    recordActorTokenUse("token-retry", actorClaims);
+    expect(admitActorToken("token-retry", actorClaims)).toBe(true);
     expect(readRow("token-retry")?.lastUsedAt).toBeNull();
 
     rawDb.exec("DROP TRIGGER fail_last_used");
     // Inside the debounce window: only a completed stamp may suppress a retry.
-    recordActorTokenUse("token-retry", actorClaims);
+    admitActorToken("token-retry", actorClaims);
 
     expect(readRow("token-retry")?.lastUsedAt).toBeGreaterThan(0);
   });
 
-  test("an unrecorded token hash is looked up at most once per debounce window", () => {
+  test("an unrecorded token hash does not stamp until the window lapses", () => {
     // Nothing to find: the definitive "no record" answer arms the debounce.
-    recordActorTokenUse("token-late", actorClaims);
+    admitActorToken("token-late", actorClaims);
 
     // Seed the row the first call missed. A second call inside the window
-    // leaves it unstamped, which is only possible if the lookup was skipped.
+    // finds it (the verdict lookup always runs) but must not stamp it.
     insertTokenRecord("token-late", "active");
-    recordActorTokenUse("token-late", actorClaims);
+    admitActorToken("token-late", actorClaims);
     expect(readRow("token-late")?.lastUsedAt).toBeNull();
 
-    // Once the window lapses the lookup runs again and finds the row.
+    // Once the window lapses the stamp runs.
     __resetLastUsedDebounceForTests();
-    recordActorTokenUse("token-late", actorClaims);
+    admitActorToken("token-late", actorClaims);
     expect(readRow("token-late")?.lastUsedAt).toBeGreaterThan(0);
   });
 
@@ -594,11 +652,11 @@ describe("recordActorTokenUse", () => {
     ).$client;
     rawDb.exec("ALTER TABLE actor_token_records RENAME TO actor_token_stash");
 
-    recordActorTokenUse("token-transient", actorClaims);
+    expect(admitActorToken("token-transient", actorClaims)).toBe(true);
 
     rawDb.exec("ALTER TABLE actor_token_stash RENAME TO actor_token_records");
     insertTokenRecord("token-transient", "active");
-    recordActorTokenUse("token-transient", actorClaims);
+    admitActorToken("token-transient", actorClaims);
 
     expect(readRow("token-transient")?.lastUsedAt).toBeGreaterThan(0);
   });

--- a/gateway/src/auth/actor-token-revocation.ts
+++ b/gateway/src/auth/actor-token-revocation.ts
@@ -1,21 +1,22 @@
 /**
- * Hot-path actor-token revocation check, plus the debounced last-used stamp
- * that rides the same lookup ({@link recordActorTokenUse}).
+ * Hot-path admission for actor tokens ({@link admitActorToken}): one lookup
+ * that both enforces revocation and stamps the presenting device's last-used
+ * activity.
  *
  * Edge-token validation ({@link validateEdgeToken}) only verifies the JWT
- * (signature, audience, expiry, policy epoch) — it never consults the DB. That
- * means marking an actor token "revoked" in `actorTokenRecords` (on re-pair,
- * device unpair, etc.) has no effect on live requests until the token expires.
+ * (signature, audience, expiry, policy epoch), never the DB. That means
+ * marking an actor token "revoked" in `actorTokenRecords` (on re-pair, device
+ * unpair, etc.) has no effect on live requests until the token expires.
  *
- * This check closes that gap: on the request hot path, after the JWT is
+ * Admission closes that gap: on the request hot path, after the JWT is
  * validated, reject an actor token whose recorded row is `status = 'revoked'`.
  *
  * Policy is **fail-OPEN**:
  *   - Non-actor tokens (svc/local) are never checked.
- *   - An actor token with NO record is allowed — legacy/unrecorded tokens (and
+ *   - An actor token with NO record is allowed. Legacy/unrecorded tokens (and
  *     any mint path not yet recording to the DB) must never be broken.
  *   - Any DB error (incl. the gateway DB not being initialized) allows the
- *     request and logs a warning — a revocation check must never take down auth
+ *     request and logs a warning. A revocation check must never take down auth
  *     on a DB hiccup; we are no worse off than before this check existed.
  *
  * Only an explicit `status = 'revoked'` row results in rejection.
@@ -72,7 +73,9 @@ function hashToken(token: string): string {
 function canonicalizeTokenForHash(rawToken: string): string {
   const trimmed = rawToken.trim();
   const parts = trimmed.split(".");
-  if (parts.length !== 3) return trimmed;
+  if (parts.length !== 3) {
+    return trimmed;
+  }
   try {
     return parts
       .map((seg) => Buffer.from(seg, "base64url").toString("base64url"))
@@ -83,10 +86,10 @@ function canonicalizeTokenForHash(rawToken: string): string {
 }
 
 /**
- * Hash a caller-supplied actor token exactly as revocation lookups do.
+ * Hash a caller-supplied actor token exactly as admission lookups do.
  *
  * Use this for DB writes/reads that need to line up with
- * `isActorTokenRevoked`, including token-mint paths that persist derived
+ * {@link admitActorToken}, including token-mint paths that persist derived
  * actor tokens for later device revocation.
  */
 export function actorTokenRecordHash(rawToken: string): string {
@@ -94,45 +97,20 @@ export function actorTokenRecordHash(rawToken: string): string {
 }
 
 /**
- * True only when `rawToken` is an actor token with an explicitly revoked record.
- * Fail-open in every other case (non-actor, no record, DB error).
- */
-export function isActorTokenRevoked(
-  rawToken: string,
-  claims: TokenClaims,
-): boolean {
-  const parsed = parseSub(claims.sub);
-  if (!parsed.ok || parsed.principalType !== "actor") {
-    return false;
-  }
-
-  const tokenHash = actorTokenRecordHash(rawToken);
-
-  try {
-    const record = getGatewayDb()
-      .select({ status: actorTokenRecords.status })
-      .from(actorTokenRecords)
-      .where(eq(actorTokenRecords.tokenHash, tokenHash))
-      .get();
-    return record?.status === "revoked";
-  } catch (err) {
-    log.warn(
-      { err: err instanceof Error ? err.message : String(err) },
-      "Actor-token revocation lookup failed — allowing request (fail-open)",
-    );
-    return false;
-  }
-}
-
-/**
- * Stamp `lastUsedAt` for the device behind `rawToken`, powering the "Paired
- * devices" list's last-used label.
+ * Decide whether a validated token may proceed, and record the activity of the
+ * device that presented it. Returns false only for an actor token whose record
+ * is explicitly `status = 'revoked'`; every other case is fail-open.
  *
- * Debounced to one DB round-trip per token per {@link STAMP_DEBOUNCE_MS}. The
- * window is armed by a completed stamp, and also by a definitive "no such
- * record" answer: unrecorded tokens are a permanent supported state, so their
- * lookup must not repeat on every request. A DB error arms nothing, leaving the
- * next request free to retry immediately.
+ * One canonicalize + hash + indexed SELECT serves both jobs, and the two are
+ * inseparable by construction: a caller cannot enforce revocation while
+ * forgetting to stamp, which would silently drop that device off the "Paired
+ * devices" list.
+ *
+ * The stamp is debounced to one DB round-trip per token per
+ * {@link STAMP_DEBOUNCE_MS}, armed by a completed stamp and also by a
+ * definitive "no such record" answer (unrecorded tokens are a permanent
+ * supported state). A DB error arms nothing, leaving the next request free to
+ * retry immediately.
  *
  * Resolved through the DEVICE rather than the presented row: `/auth/token`
  * mints `status = 'derived'` rows sharing the source row's `hashed_device_id`
@@ -140,43 +118,47 @@ export function isActorTokenRevoked(
  *
  * Deliberately leaves `updatedAt` alone: that column tracks row lifecycle
  * (status changes), and moving it every few minutes would destroy that signal.
- *
- * Fail-open like the rest of this module: non-actor tokens, unrecorded tokens,
- * and DB errors are all no-ops.
  */
-export function recordActorTokenUse(
+export function admitActorToken(
   rawToken: string,
   claims: TokenClaims,
-): void {
+): boolean {
   const parsed = parseSub(claims.sub);
   if (!parsed.ok || parsed.principalType !== "actor") {
-    return;
+    return true;
   }
 
-  const now = Date.now();
   const tokenHash = actorTokenRecordHash(rawToken);
-  if (stampDebounce.has(tokenHash)) {
-    return;
-  }
 
   try {
     const db = getGatewayDb();
     const record = db
       .select({
+        status: actorTokenRecords.status,
         guardianPrincipalId: actorTokenRecords.guardianPrincipalId,
         hashedDeviceId: actorTokenRecords.hashedDeviceId,
       })
       .from(actorTokenRecords)
       .where(eq(actorTokenRecords.tokenHash, tokenHash))
       .get();
+
+    // Verdict first: a rejected token must never stamp.
+    if (record?.status === "revoked") {
+      return false;
+    }
+
+    if (stampDebounce.has(tokenHash)) {
+      return true;
+    }
+
     if (!record) {
-      // A stable answer, not a failure: hold the lookup off for a window.
+      // A stable answer, not a failure: arm the window like a completed stamp.
       stampDebounce.mark(tokenHash);
-      return;
+      return true;
     }
 
     db.update(actorTokenRecords)
-      .set({ lastUsedAt: now })
+      .set({ lastUsedAt: Date.now() })
       .where(
         and(
           eq(actorTokenRecords.guardianPrincipalId, record.guardianPrincipalId),
@@ -187,11 +169,13 @@ export function recordActorTokenUse(
       .run();
 
     stampDebounce.mark(tokenHash);
+    return true;
   } catch (err) {
     log.warn(
       { err: err instanceof Error ? err.message : String(err) },
-      "Actor-token last-used stamp failed, ignoring (fail-open)",
+      "Actor-token admission failed, allowing request (fail-open)",
     );
+    return true;
   }
 }
 

--- a/gateway/src/http/middleware/auth.ts
+++ b/gateway/src/http/middleware/auth.ts
@@ -1,9 +1,6 @@
 import type { Server } from "bun";
 
-import {
-  isActorTokenRevoked,
-  recordActorTokenUse,
-} from "../../auth/actor-token-revocation.js";
+import { admitActorToken } from "../../auth/actor-token-revocation.js";
 import { findVellumGuardian } from "../../auth/guardian-bootstrap.js";
 import { resolveScopeProfile } from "../../auth/scopes.js";
 import { parseSub } from "../../auth/subject.js";
@@ -353,12 +350,12 @@ export function createAuthMiddleware(
   }
 
   /**
-   * Reject a validated edge token whose actor record has been revoked. Returns
-   * a 401 response when revoked, or null to continue. Fail-open for non-actor
-   * and unrecorded tokens (see isActorTokenRevoked). On the allow path, stamps
-   * the presenting device's last-used activity (debounced, fail-open).
+   * Run a validated edge token through actor-token admission: revoked records
+   * get a 401, everything else continues (null) with the presenting device's
+   * last-used activity stamped. Fail-open for non-actor and unrecorded tokens
+   * (see admitActorToken).
    *
-   * The stamp runs here, before the scope and guardian-match checks that
+   * Admission runs here, before the scope and guardian-match checks that
    * callers apply afterwards, so "last used" means "presented a valid,
    * unrevoked credential" rather than "made a request we served". That is
    * deliberate: a device refused for insufficient scope is still demonstrably
@@ -370,7 +367,7 @@ export function createAuthMiddleware(
     token: string,
     claims: TokenClaims,
   ): Response | null {
-    if (isActorTokenRevoked(token, claims)) {
+    if (!admitActorToken(token, claims)) {
       authRateLimiter.recordFailure(getClientIp());
       log.warn(
         { path: new URL(req.url).pathname },
@@ -378,7 +375,6 @@ export function createAuthMiddleware(
       );
       return Response.json({ error: "Unauthorized" }, { status: 401 });
     }
-    recordActorTokenUse(token, claims);
     return null;
   }
 

--- a/gateway/src/http/routes/auth-token.ts
+++ b/gateway/src/http/routes/auth-token.ts
@@ -4,8 +4,7 @@ import { eq } from "drizzle-orm";
 
 import {
   actorTokenRecordHash,
-  isActorTokenRevoked,
-  recordActorTokenUse,
+  admitActorToken,
 } from "../../auth/actor-token-revocation.js";
 import {
   ensureVellumGuardianBinding,
@@ -151,11 +150,10 @@ export async function handleCreateToken(
   // Don't let a revoked token re-mint a fresh one — that would be an escape
   // hatch around device revocation, since the source token still verifies by
   // signature until it expires.
-  if (isActorTokenRevoked(bearerToken, verifyResult.claims)) {
+  if (!admitActorToken(bearerToken, verifyResult.claims)) {
     log.warn("Token create rejected: source token revoked");
     return Response.json({ error: "Unauthorized" }, { status: 401 });
   }
-  recordActorTokenUse(bearerToken, verifyResult.claims);
 
   const sourceRecord = findSourceActorTokenRecord(bearerToken);
   let guardianPrincipalId = sourceRecord?.guardianPrincipalId;

--- a/gateway/src/http/routes/ipc-runtime-proxy.ts
+++ b/gateway/src/http/routes/ipc-runtime-proxy.ts
@@ -12,10 +12,7 @@
  * IPC, and converts the result back into an HTTP Response.
  */
 
-import {
-  isActorTokenRevoked,
-  recordActorTokenUse,
-} from "../../auth/actor-token-revocation.js";
+import { admitActorToken } from "../../auth/actor-token-revocation.js";
 import { resolveScopeProfile } from "../../auth/scopes.js";
 import { parseSub } from "../../auth/subject.js";
 import { validateEdgeToken } from "../../auth/token-exchange.js";
@@ -78,14 +75,13 @@ export async function tryIpcProxy(
       );
       return Response.json({ error: "Unauthorized" }, { status: 401 });
     }
-    if (isActorTokenRevoked(edgeJwt, result.claims)) {
+    if (!admitActorToken(edgeJwt, result.claims)) {
       log.warn(
         { method: req.method, path: new URL(req.url).pathname },
         "IPC proxy auth rejected: actor token revoked",
       );
       return Response.json({ error: "Unauthorized" }, { status: 401 });
     }
-    recordActorTokenUse(edgeJwt, result.claims);
     claims = result.claims;
   }
 

--- a/gateway/src/http/routes/live-voice-websocket.ts
+++ b/gateway/src/http/routes/live-voice-websocket.ts
@@ -4,10 +4,7 @@ import {
   validateEdgeToken,
   mintServiceToken,
 } from "../../auth/token-exchange.js";
-import {
-  isActorTokenRevoked,
-  recordActorTokenUse,
-} from "../../auth/actor-token-revocation.js";
+import { admitActorToken } from "../../auth/actor-token-revocation.js";
 import { parseSub } from "../../auth/subject.js";
 import type { GatewayConfig } from "../../config.js";
 import { getLogger } from "../../logger.js";
@@ -129,11 +126,10 @@ async function checkLiveVoiceAuth(
     return new Response("Unauthorized", { status: 401 });
   }
 
-  if (isActorTokenRevoked(rawToken, result.claims)) {
-    log.warn("Live voice WS: rejected — actor token revoked");
+  if (!admitActorToken(rawToken, result.claims)) {
+    log.warn("Live voice WS: rejected, actor token revoked");
     return new Response("Unauthorized", { status: 401 });
   }
-  recordActorTokenUse(rawToken, result.claims);
 
   const parsed = parseSub(result.claims.sub);
   if (

--- a/gateway/src/http/routes/runtime-audio-stream.ts
+++ b/gateway/src/http/routes/runtime-audio-stream.ts
@@ -35,10 +35,7 @@ import {
   validateEdgeToken,
   mintServiceToken,
 } from "../../auth/token-exchange.js";
-import {
-  isActorTokenRevoked,
-  recordActorTokenUse,
-} from "../../auth/actor-token-revocation.js";
+import { admitActorToken } from "../../auth/actor-token-revocation.js";
 import { parseSub } from "../../auth/subject.js";
 import type { GatewayConfig } from "../../config.js";
 
@@ -122,14 +119,13 @@ export function authorizeRuntimeAudioStream(
     };
   }
 
-  if (isActorTokenRevoked(rawToken, result.claims)) {
+  if (!admitActorToken(rawToken, result.claims)) {
     log.warn("audio stream WS: rejected, actor token revoked");
     return {
       ok: false,
       response: new Response("Unauthorized", { status: 401 }),
     };
   }
-  recordActorTokenUse(rawToken, result.claims);
 
   // An actor principal and nothing else. These are client-facing paths, and a
   // service token reaching one would let a credential minted for machine to

--- a/gateway/src/http/routes/runtime-proxy.ts
+++ b/gateway/src/http/routes/runtime-proxy.ts
@@ -11,10 +11,7 @@ import {
   mintExchangeToken,
   mintServiceToken,
 } from "../../auth/token-exchange.js";
-import {
-  isActorTokenRevoked,
-  recordActorTokenUse,
-} from "../../auth/actor-token-revocation.js";
+import { admitActorToken } from "../../auth/actor-token-revocation.js";
 import type { GatewayConfig } from "../../config.js";
 import { fetchImpl } from "../../fetch.js";
 import { getLogger } from "../../logger.js";
@@ -81,14 +78,13 @@ export function createRuntimeProxyHandler(config: GatewayConfig) {
         );
         return Response.json({ error: "Unauthorized" }, { status: 401 });
       }
-      if (isActorTokenRevoked(edgeJwt, result.claims)) {
+      if (!admitActorToken(edgeJwt, result.claims)) {
         log.warn(
           { method: req.method, path: url.pathname },
           "Runtime proxy auth rejected: actor token revoked",
         );
         return Response.json({ error: "Unauthorized" }, { status: 401 });
       }
-      recordActorTokenUse(edgeJwt, result.claims);
       exchangeToken = mintExchangeToken(
         result.claims,
         result.claims.scope_profile,


### PR DESCRIPTION
## Summary

- Replace `isActorTokenRevoked` + `recordActorTokenUse` with one exported `admitActorToken(rawToken, claims): boolean` in `gateway/src/auth/actor-token-revocation.ts`; both originals are deleted.
- One canonicalize, one hash and one indexed SELECT now fetch `status`, `guardianPrincipalId` and `hashedDeviceId`. Revoked returns `false` before any stamping work; admitted runs the debounced stamp against the already-fetched row, so the allowed path drops from two SELECTs to one.
- The durable win is not the saved lookup, it is that the contract is no longer forgettable: a new auth path cannot enforce revocation while silently skipping the activity stamp, which would drop that device off the paired-devices list.
- Migrated all six production callsites to `if (!admitActorToken(tok, claims)) { ... }`: edge auth middleware, runtime proxy, IPC runtime proxy, live-voice WS, runtime audio stream WS, and `/auth/token`.
- Behavior preserved exactly: non-actor tokens short-circuit with no lookup and no stamp, unrecorded tokens fail open and arm the debounce, DB errors fail open and arm nothing so the next request retries, the stamp still targets the `status='active'` row for the `(guardianPrincipalId, hashedDeviceId)` pair, and `updatedAt` is untouched.
- Tests: every prior behavior stays covered, plus two new invariants: a revoked token stamps no row (including an active sibling sharing its device), and an admitted token costs exactly one SELECT plus one UPDATE (counted by wrapping the sqlite client's `prepare`).
- Mutation-checked: reverting the revoked verdict (9 failures), stamping before the revoked check (4), stamping on the non-actor path (2), and setting `updatedAt` alongside `lastUsedAt` (2) each turn the suite red; baseline is 92 pass / 0 fail.
- `findSourceActorTokenRecord` in `auth-token.ts` is deliberately left alone: it needs `platform` (which the hot path does not fetch), it runs regardless of principal type while the helper deliberately skips the lookup for non-actor subs, and `/auth/token` is a low-frequency refresh, so widening the helper's return shape for all six callers to save one query on a cold path is the wrong trade.

Addresses Codex review feedback on #41228 (AGENTS.md Single Source of Truth).