### PR TITLE
fix(design-library): let a sidebar pill truncate instead of overflowing

### DIFF
--- a/packages/design-library/src/components/panel-item/panel-item.test.tsx
+++ b/packages/design-library/src/components/panel-item/panel-item.test.tsx
@@ -142,30 +142,15 @@ describe("PanelItem shape", () => {
     const html = renderShaped("pill");
     expect(html).toContain("rounded-full");
     expect(html).toContain("w-fit");
+    /* The cap belongs to that width: without it a pill whose label is wider
+       than its panel overflows rather than truncating, for the reason
+       `PILL_SHAPE_CLASSES` gives. */
+    expect(html).toContain("max-w-full");
     expect(html).not.toContain("rounded-[6px]");
-    /* Matched as a whole class rather than a substring: the pill's own
-       `max-w-full` ends in the row's `w-full`, so a plain `toContain` would
-       read the cap as the width it is meant to have replaced. */
+    /* A whole class, not a substring: `max-w-full` ends in `w-full`, which a
+       plain `toContain` would read as the row width still being here. */
     expect(html).not.toMatch(/[\s"]w-full[\s"]/);
     expect(html).not.toContain("w-auto");
-  });
-
-  /* The cap that goes with the intrinsic width, asserted beside it because
-     each alone is a different bug: `w-fit` on its own is the pill that
-     overflows its panel, and a cap on its own would need `w-full` back and
-     stop being a pill at all.
-
-     `fit-content` cannot resolve below the label's min-content, and the label
-     is `white-space: nowrap`, so a pill in a panel narrower than its text
-     sizes to the text and hangs out of the panel - the label's `min-w-0`
-     cannot pull it back, since `min-width` is a floor and not a cap. The
-     cap makes the used width definite, which is what lets the label shrink
-     and ellipsise. Markup is all this asserts; the layout it buys is only
-     observable in a browser. */
-  test("pill caps its intrinsic width at the panel, so a long label truncates", () => {
-    const html = renderShaped("pill");
-    expect(html).toContain("max-w-full");
-    expect(html).toContain("truncate");
   });
 
   /* The other half of the split. Without it, collapsing both shapes back onto

--- a/packages/design-library/src/components/panel-item/panel-item.test.tsx
+++ b/packages/design-library/src/components/panel-item/panel-item.test.tsx
@@ -143,8 +143,29 @@ describe("PanelItem shape", () => {
     expect(html).toContain("rounded-full");
     expect(html).toContain("w-fit");
     expect(html).not.toContain("rounded-[6px]");
-    expect(html).not.toContain("w-full");
+    /* Matched as a whole class rather than a substring: the pill's own
+       `max-w-full` ends in the row's `w-full`, so a plain `toContain` would
+       read the cap as the width it is meant to have replaced. */
+    expect(html).not.toMatch(/[\s"]w-full[\s"]/);
     expect(html).not.toContain("w-auto");
+  });
+
+  /* The cap that goes with the intrinsic width, asserted beside it because
+     each alone is a different bug: `w-fit` on its own is the pill that
+     overflows its panel, and a cap on its own would need `w-full` back and
+     stop being a pill at all.
+
+     `fit-content` cannot resolve below the label's min-content, and the label
+     is `white-space: nowrap`, so a pill in a panel narrower than its text
+     sizes to the text and hangs out of the panel - the label's `min-w-0`
+     cannot pull it back, since `min-width` is a floor and not a cap. The
+     cap makes the used width definite, which is what lets the label shrink
+     and ellipsise. Markup is all this asserts; the layout it buys is only
+     observable in a browser. */
+  test("pill caps its intrinsic width at the panel, so a long label truncates", () => {
+    const html = renderShaped("pill");
+    expect(html).toContain("max-w-full");
+    expect(html).toContain("truncate");
   });
 
   /* The other half of the split. Without it, collapsing both shapes back onto

--- a/packages/design-library/src/components/panel-item/panel-item.tsx
+++ b/packages/design-library/src/components/panel-item/panel-item.tsx
@@ -262,6 +262,16 @@ const PILL_HOVER_CLASS =
  * row width in every ordinary layout. `width: fit-content` shrink-wraps while
  * leaving `display: flex` alone, which the row's internal layout depends on.
  *
+ * `max-w-full` is what lets a pill narrower than its label truncate rather
+ * than overflow, and it is not redundant with `fit-content`. A pill's label is
+ * `white-space: nowrap`, so its min-content contribution is the whole string,
+ * and `fit-content` never resolves below min-content; `min-w-0` on the label
+ * cannot lower that, because `min-width` is a floor and not a cap. Left alone,
+ * the pill sizes to its text and hangs out of the panel. Capping the used
+ * width at the containing block makes the width definite, which is the
+ * condition flex shrinking needs: the label then takes the space that is left
+ * and ellipsises, exactly as it does in a `w-full` row.
+ *
  * A pill is taller than a row, and how much taller is the panel's decision
  * rather than each caller's: `SideMenu` publishes `--side-menu-tile-size`, the
  * height its collapsed tiles are drawn at, and a pill mounted in one takes it,
@@ -290,7 +300,7 @@ const PILL_HOVER_CLASS =
  * whole treatment collapses to the default when nothing declares them.
  */
 const PILL_SHAPE_CLASSES = [
-  "w-fit rounded-full",
+  "w-fit max-w-full rounded-full",
   "h-[var(--side-menu-tile-size,36px)]",
   "max-md:min-h-[var(--side-menu-tile-size,36px)]",
   "bg-[var(--panel-item-bg,var(--surface-lift))]",

--- a/packages/design-library/src/components/panel-item/panel-item.tsx
+++ b/packages/design-library/src/components/panel-item/panel-item.tsx
@@ -262,15 +262,12 @@ const PILL_HOVER_CLASS =
  * row width in every ordinary layout. `width: fit-content` shrink-wraps while
  * leaving `display: flex` alone, which the row's internal layout depends on.
  *
- * `max-w-full` is what lets a pill narrower than its label truncate rather
- * than overflow, and it is not redundant with `fit-content`. A pill's label is
- * `white-space: nowrap`, so its min-content contribution is the whole string,
- * and `fit-content` never resolves below min-content; `min-w-0` on the label
- * cannot lower that, because `min-width` is a floor and not a cap. Left alone,
- * the pill sizes to its text and hangs out of the panel. Capping the used
- * width at the containing block makes the width definite, which is the
- * condition flex shrinking needs: the label then takes the space that is left
- * and ellipsises, exactly as it does in a `w-full` row.
+ * `max-w-full` beside it is not redundant. A label is `white-space: nowrap`,
+ * so its min-content contribution is the whole string and `fit-content`
+ * resolves to the full text however narrow the panel is; the label's
+ * `min-w-0` cannot pull that back, `min-width` being a floor and not a cap.
+ * The cap makes the used width definite, which is the condition flex
+ * shrinking needs, so a label too long for the panel truncates.
  *
  * A pill is taller than a row, and how much taller is the panel's decision
  * rather than each caller's: `SideMenu` publishes `--side-menu-tile-size`, the


### PR DESCRIPTION
## TL;DR

Sidebar pills (pinned apps, the assistant identity row, New Chat, Preferences) grew past the sidebar's edge instead of truncating when the sidebar was made narrow. One class on the pill shape fixes all of them.

## Before / after

| | Before | After |
|---|---|---|
| Pinned app with a long name, narrow sidebar | The pill grows to fit the whole name and hangs off the right edge, clipped mid-word with no ellipsis | The pill stops at the sidebar's edge and the name ellipsises, like a conversation row |
| Assistant name / New Chat / Preferences pill | Same overflow | Same fix, no call-site change |
| Pill whose label already fits | Hugs its label | Unchanged, pixel for pixel |
| Collapsed rail | Circular tiles, unaffected | Unchanged |

## Why it happened

`shape="pill"` sizes with `width: fit-content`, and `fit-content` never resolves below its content's min-content size. A pill's label is `white-space: nowrap`, so its min-content contribution is the entire string. The label's `min-w-0` does not help: `min-width` is a floor, not a cap, so it cannot lower a min-content contribution. The pill therefore sized to its text and overflowed.

A `shape="row"` pill does not have this problem because `w-full` gives it a definite width up front, which is what lets flex shrinking run and the label truncate. So the fix is to give the pill a definite width too, without giving up the hug: cap the used width at the containing block with `max-w-full`. Below the cap nothing changes; at the cap the width becomes definite and the label shrinks and ellipsises.

## Why it is safe

- One class on `PILL_SHAPE_CLASSES`. No call site changes, no new props, no behaviour switch.
- `max-width` only ever narrows a box. Every pill whose label fits its panel is untouched, verified by measurement in Storybook: the four sidebar pills render at 71 / 117 / 126 / 154 px before and after.
- The collapsed rail draws pinned apps as `SideMenu.Item` tiles, not `PanelItem` pills, so it is out of this change entirely.
- The existing shape test asserted `not.toContain("w-full")` to prove the row's width was replaced. `max-w-full` ends in that substring, so the assertion is now anchored to whole class tokens; a real `w-full` regression still fails it.

## Verification

Measured in Storybook (`Chat/AssistantSideMenu`), driving a long label into each pill and reading `getBoundingClientRect()` plus `scrollWidth > clientWidth`:

- Before: pill 529 px inside a 274 px panel, no truncation.
- After: pill 274 px, label truncating, on all four sidebar pills and the footer's Preferences pill.

Design library typecheck passes. Tests run in CI (local runs are blocked in this environment).

## Not in this PR

Two things came up alongside this and are deliberately out of scope:

- **Rename / change icon on a pinned app.** This has never existed on `main` for apps, in either the sidebar menu or the Library card menu, so there is nothing to restore. The daemon has no route that can change an app's name or icon (`app-management-routes.ts` exposes list / open / fork / import / sign / delete / preview / bundle / share, and no update). The rename-plus-icon modal that exists today is `NameInputDialog` with its icon picker, wired only to sidebar conversation *groups*. Giving apps the same treatment is a new daemon route plus an OpenAPI and SDK regeneration before any UI, which is its own PR.
- **Pinned apps leaking across assistants.** Tracked as LUM-3452; root cause commented there. `app-pin-storage.ts` uses a single unscoped `vellum:pinnedApps` key while every neighbouring sidebar preference uses `createKeyedStorageAccessor` keyed by assistant id.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41233" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->