### PR TITLE
feat(telegram): revise a delivered notification in place

### DIFF
--- a/assistant/src/__tests__/notification-telegram-adapter.test.ts
+++ b/assistant/src/__tests__/notification-telegram-adapter.test.ts
@@ -13,6 +13,15 @@ const sendCalls: Array<{
 /** When true, sendTelegramReply throws if an approval argument is present. */
 let rejectRichDelivery = false;
 
+const editCalls: Array<{
+  chatId: string;
+  messageId: string;
+  text: string;
+}> = [];
+
+/** When set, editTelegramMessage rejects with this message. */
+let editFailure: string | undefined;
+
 mock.module("../messaging/providers/telegram-bot/send.js", () => ({
   sendTelegramReply: async (
     chatId: string,
@@ -37,6 +46,16 @@ mock.module("../messaging/providers/telegram-bot/send.js", () => ({
     totalCount: 0,
   }),
   sendTelegramTypingIndicator: async () => true,
+  editTelegramMessage: async (
+    chatId: string,
+    messageId: string,
+    text: string,
+  ) => {
+    if (editFailure) {
+      throw new Error(editFailure);
+    }
+    editCalls.push({ chatId, messageId, text });
+  },
 }));
 
 import { TelegramAdapter } from "../notifications/adapters/telegram.js";
@@ -72,7 +91,9 @@ function makeDestination(
 describe("TelegramAdapter", () => {
   beforeEach(() => {
     sendCalls.length = 0;
+    editCalls.length = 0;
     rejectRichDelivery = false;
+    editFailure = undefined;
   });
 
   test("prefers deliveryText and does not append deterministic label", async () => {
@@ -300,5 +321,86 @@ describe("TelegramAdapter", () => {
       "Someone is requesting access to the assistant.",
     );
     expect(call.text).toContain("XYZW");
+  });
+
+  describe("update", () => {
+    test("edits the delivered message in place and keeps its id", async () => {
+      const adapter = new TelegramAdapter();
+
+      const result = await adapter.update(
+        {
+          deliveryId: "del-1",
+          destination: "chat-123",
+          messageId: "5150",
+          conversationId: null,
+        },
+        { body: "Approved by Ashlee" },
+      );
+
+      expect(result.success).toBe(true);
+      expect(editCalls).toEqual([
+        { chatId: "chat-123", messageId: "5150", text: "Approved by Ashlee" },
+      ]);
+      // An edit addresses one message and leaves it in place, so the delivery
+      // row's id must still identify the card afterwards.
+      expect(result.messageId).toBe("5150");
+      // Revising a card must never post a second one beside it.
+      expect(sendCalls).toHaveLength(0);
+    });
+
+    test("falls back to the title when no body is supplied", async () => {
+      const adapter = new TelegramAdapter();
+
+      await adapter.update(
+        {
+          deliveryId: "del-1",
+          destination: "chat-123",
+          messageId: "5150",
+          conversationId: null,
+        },
+        { title: "Expired" },
+      );
+
+      expect(editCalls[0]?.text).toBe("Expired");
+    });
+
+    test("refuses a delivery that captured no message id", async () => {
+      const adapter = new TelegramAdapter();
+
+      const result = await adapter.update(
+        {
+          deliveryId: "del-1",
+          destination: "chat-123",
+          messageId: null,
+          conversationId: null,
+        },
+        { body: "Approved" },
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("missing_message_id");
+      expect(editCalls).toHaveLength(0);
+    });
+
+    test("reports a failed edit rather than posting a replacement", async () => {
+      const adapter = new TelegramAdapter();
+      editFailure = "Telegram API error: message to edit not found";
+
+      const result = await adapter.update(
+        {
+          deliveryId: "del-1",
+          destination: "chat-123",
+          messageId: "5150",
+          conversationId: null,
+        },
+        { body: "Approved" },
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("message to edit not found");
+      // The original would otherwise sit beside the replacement, which reads
+      // as the assistant answering twice.
+      expect(sendCalls).toHaveLength(0);
+    });
   });
 });

--- a/assistant/src/__tests__/notification-telegram-adapter.test.ts
+++ b/assistant/src/__tests__/notification-telegram-adapter.test.ts
@@ -334,12 +334,12 @@ describe("TelegramAdapter", () => {
           messageId: "5150",
           conversationId: null,
         },
-        { body: "Approved by Ashlee" },
+        { body: "Approved by Alice" },
       );
 
       expect(result.success).toBe(true);
       expect(editCalls).toEqual([
-        { chatId: "chat-123", messageId: "5150", text: "Approved by Ashlee" },
+        { chatId: "chat-123", messageId: "5150", text: "Approved by Alice" },
       ]);
       // An edit addresses one message and leaves it in place, so the delivery
       // row's id must still identify the card afterwards.

--- a/assistant/src/messaging/providers/telegram-bot/send.test.ts
+++ b/assistant/src/messaging/providers/telegram-bot/send.test.ts
@@ -343,7 +343,28 @@ describe("editTelegramMessage", () => {
     expect(method).toBe("editMessageText");
     // Telegram wants a numeric message id, where the capability carries the
     // channel's id as a string.
-    expect(body).toEqual({ chat_id: "123", message_id: 456, text: "revised" });
+    expect(body).toEqual({
+      chat_id: "123",
+      message_id: 456,
+      text: "revised",
+      reply_markup: { inline_keyboard: [] },
+    });
+  });
+
+  test("clears the inline keyboard, so a settled message keeps no buttons", async () => {
+    await telegramTransport.edit!(ctx as CallbackContext, {
+      chatId: "123",
+      messageId: "456",
+      text: "\u2713 Approved",
+    });
+
+    const [, body] = callTelegramBotApiMock.mock.calls[0]!;
+    // Omitting reply_markup leaves an existing keyboard in place, which would
+    // leave live Approve and Reject buttons under text saying the request is
+    // already decided. The field has to be sent, and sent empty.
+    expect((body as Record<string, unknown>).reply_markup).toEqual({
+      inline_keyboard: [],
+    });
   });
 
   test("treats an unchanged message as already done", async () => {

--- a/assistant/src/messaging/providers/telegram-bot/send.ts
+++ b/assistant/src/messaging/providers/telegram-bot/send.ts
@@ -148,6 +148,12 @@ export interface TelegramSendResult {
  * Unlike a send, this cannot split long text across messages, because an edit
  * addresses exactly one. Telegram rejects text past its limit, and that
  * rejection reaches the caller rather than being papered over.
+ *
+ * The empty `reply_markup` is load-bearing. `editMessageText` leaves an
+ * existing inline keyboard alone when the field is omitted, so a message
+ * revised to read as settled would keep its live buttons beside that text.
+ * Every caller here edits a message into a settled state, and the approval
+ * interception path says so outright, so the keyboard goes with the revision.
  */
 export async function editTelegramMessage(
   chatId: string,
@@ -159,6 +165,7 @@ export async function editTelegramMessage(
       chat_id: chatId,
       message_id: Number(messageId),
       text,
+      reply_markup: { inline_keyboard: [] },
     });
   } catch (err) {
     if (

--- a/assistant/src/notifications/adapters/telegram.ts
+++ b/assistant/src/notifications/adapters/telegram.ts
@@ -8,13 +8,18 @@
  * plain text with typed-command instructions.
  */
 
-import { sendTelegramReply } from "../../messaging/providers/telegram-bot/send.js";
+import {
+  editTelegramMessage,
+  sendTelegramReply,
+} from "../../messaging/providers/telegram-bot/send.js";
 import { ConfigError } from "../../util/errors.js";
 import { getLogger } from "../../util/logger.js";
 import type {
   ChannelAdapter,
   ChannelDeliveryPayload,
   ChannelDestination,
+  ChannelUpdateContext,
+  ChannelUpdatePayload,
   DeliveryResult,
   NotificationChannel,
 } from "../types.js";
@@ -93,6 +98,48 @@ export class TelegramAdapter implements ChannelAdapter {
       logFn(
         { err, sourceEventName: payload.sourceEventName, chatId },
         "Failed to deliver Telegram notification",
+      );
+      return { success: false, error: message };
+    }
+  }
+
+  /**
+   * Replace a delivered notification in place, so a card that has been
+   * answered or withdrawn stops reading as still waiting.
+   *
+   * The edit carries no `reply_markup`, which is how Telegram is told to drop
+   * the inline keyboard: a settled card must not keep live Approve and Reject
+   * buttons beside text saying it is settled.
+   */
+  async update(
+    delivery: ChannelUpdateContext,
+    patch: ChannelUpdatePayload,
+  ): Promise<DeliveryResult> {
+    if (!delivery.messageId) {
+      return {
+        success: false,
+        error:
+          "missing_message_id: this delivery has no captured Telegram message id",
+      };
+    }
+    const text = patch.body?.trim() || patch.title?.trim();
+    if (!text) {
+      return { success: false, error: "no body or title supplied for update" };
+    }
+    try {
+      await editTelegramMessage(delivery.destination, delivery.messageId, text);
+      log.info(
+        { chatId: delivery.destination, messageId: delivery.messageId },
+        "Telegram notification updated",
+      );
+      // An edit keeps the message it addressed, so the delivery row's id
+      // still identifies the card.
+      return { success: true, messageId: delivery.messageId };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log.error(
+        { err, chatId: delivery.destination, messageId: delivery.messageId },
+        "Failed to update Telegram notification",
       );
       return { success: false, error: message };
     }

--- a/assistant/src/notifications/adapters/telegram.ts
+++ b/assistant/src/notifications/adapters/telegram.ts
@@ -107,9 +107,9 @@ export class TelegramAdapter implements ChannelAdapter {
    * Replace a delivered notification in place, so a card that has been
    * answered or withdrawn stops reading as still waiting.
    *
-   * The edit carries no `reply_markup`, which is how Telegram is told to drop
-   * the inline keyboard: a settled card must not keep live Approve and Reject
-   * buttons beside text saying it is settled.
+   * `editTelegramMessage` clears the card's inline keyboard as part of the
+   * revision, so a card rewritten to read as settled cannot keep live Approve
+   * and Reject buttons beside that text.
    */
   async update(
     delivery: ChannelUpdateContext,


### PR DESCRIPTION
## TL;DR

Telegram's notification adapter gains `update`, so a delivered notification can be revised in place the way a Slack one already can. Building it surfaced a live bug in the shared edit helper, fixed here too: a revised Telegram message kept its inline keyboard.

## Why this was missing rather than declined

There are two outbound contracts, not one. `ChannelTransport` under `messaging/providers/` carries replies, edits, activity and streaming. `ChannelAdapter` under `notifications/adapters/` carries approval cards and guardian requests, reached by `editNotification`. They share no base type, and only the first is described anywhere as the channel contract.

Telegram implements `edit` on the transport (#41115) and had no `update` on the adapter, so `editNotification` returned `outcome: "unsupported"` with the reason "telegram adapter does not support in-place edits" for a channel that edits messages fine one seam over.

That it was unfinished rather than intentional is written in the file: the adapter's `send` already persists the sent message id, with a comment saying it exists so the delivery row can address the card later. Nothing could address it. Only the method was absent.

## Why it is safe

- Additive. No existing method changes, and no caller is rewired.
- The single producer of `editNotification` is the CLI's `notifications edit` command, so the blast radius is that one command.
- A failed edit is reported, never answered with a fresh message. The transport's `edit` made the same call for the same reason: a replacement posted beside the original reads as the assistant answering twice.
- The edit now sends an empty `reply_markup`, so a card revised to read as settled cannot keep live Approve and Reject buttons beside that text.

## Before and after

| | Before | After |
| --- | --- | --- |
| `notifications edit` on a Slack delivery | Rewrites the message in place | Unchanged |
| `notifications edit` on a Telegram delivery | Refused, "adapter does not support in-place edits" | Rewrites the message in place |
| Buttons on a revised Telegram card | n/a | Removed with the same edit |
| A Telegram edit that fails | n/a | Reported as failed, nothing posted |
| A decided Telegram approval | Retitled "Approved", buttons still tappable | Retitled, buttons gone |

## The bug this surfaced

`editMessageText` leaves an existing inline keyboard alone when `reply_markup` is omitted. The transport's `edit` uses the same helper, and its call site in `guardian-approval-interception.ts` edits an approval to "Approved" or "Denied" expressly to "show the decision and remove stale action buttons". On Telegram it removed nothing, so a decided request kept live Approve and Reject buttons under text saying it was already decided. #41115 shipped that.

The tell was already in the tree: if omitting the field cleared the keyboard, `telegram-bot/withdraw.ts` would not need its explicit `editMessageReplyMarkup` dance. Fixed at the helper rather than in the adapter, because both callers edit a message into a settled state and neither wants the old affordances to outlive it.

## What this does not change

Settled approval cards were never affected. Withdrawal does not use this path: `approvals/guardian-card-withdrawal.ts` dispatches to per-channel `withdraw` modules, and `telegram-bot/withdraw.ts` already clears the keyboard in place and posts a quoted outcome reply. Three paths revise a delivered message and only this one had a hole.

## Deferred, with reasons

- **Discord has no notification adapter at all**, so it can answer a person and can never receive an approval, a guardian request or a parked question. That is the substantive parity gap and wants its own change rather than riding along here.
- **The two contracts stay two.** LUM-3356 examined the adapters calling provider helpers directly and found them correctly below the delivery seam, because a notification carries its own delivery identity and patch semantics that an assistant turn does not. Merging them is not the fix; the gap was that nothing tells an implementor there are two.

## Testing

Four cases on the new method: the in-place edit keeps the delivery's message id and posts nothing; a title-only patch is used when no body is supplied; a delivery with no captured message id is refused before calling the API; a failing edit is reported without a replacement being sent.

The existing suite's `mock.module` replaces the whole send module, so the edit helper is stubbed there too. Without that the adapter's new import resolves to `undefined` under test.
