### PR TITLE
fix(voice): close held-segment lifecycle and cue-marking gaps found in review

### DIFF
--- a/assistant/src/live-voice/__tests__/live-voice-metrics.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-metrics.test.ts
@@ -419,6 +419,32 @@ describe("LiveVoiceMetricsCollector", () => {
     ).toMatchObject({ progressUpdatesSpoken: 2 });
   });
 
+  test("accumulates working cues played on the turn and aggregate fields", () => {
+    const clock = makeClock(0);
+    const collector = new LiveVoiceMetricsCollector({
+      sessionId: "session-cue",
+      conversationId: "conversation-cue",
+      clock: clock.now,
+    });
+
+    collector.startTurn("turn-cue");
+    const frame = collector.markWorkingCuePlayed("turn-cue");
+    expect(frame.event).toBe("working_cue_played");
+    collector.markWorkingCuePlayed("turn-cue");
+    const completed = collector.completeTurn();
+
+    // The cue is the default floor-holder and narration is off by default, so
+    // without this counter a turn that hummed through its silence and one
+    // that sat in it are the same turn in telemetry.
+    expect(completed).toMatchObject({
+      turnId: "turn-cue",
+      workingCuesPlayed: 2,
+    });
+    expect(
+      getLiveVoiceMetricsAggregateFields(collector.getSnapshot(), "turn-cue"),
+    ).toMatchObject({ workingCuesPlayed: 2 });
+  });
+
   test("omits endpoint and progress fields for turns that never touch the features", () => {
     const clock = makeClock(0);
     const collector = new LiveVoiceMetricsCollector({
@@ -437,6 +463,7 @@ describe("LiveVoiceMetricsCollector", () => {
     expect(completed).not.toHaveProperty("endpointDecisionSource");
     expect(completed).not.toHaveProperty("ackSpoken");
     expect(completed).not.toHaveProperty("progressUpdatesSpoken");
+    expect(completed).not.toHaveProperty("workingCuesPlayed");
 
     const aggregateFields = getLiveVoiceMetricsAggregateFields(
       collector.getSnapshot(),
@@ -448,6 +475,7 @@ describe("LiveVoiceMetricsCollector", () => {
     expect(aggregateFields).not.toHaveProperty("endpointDecisionSource");
     expect(aggregateFields).not.toHaveProperty("ackSpoken");
     expect(aggregateFields).not.toHaveProperty("progressUpdatesSpoken");
+    expect(aggregateFields).not.toHaveProperty("workingCuesPlayed");
   });
 
   test("markEndpointCommit records the commit latency independently of the decision fields", () => {

--- a/assistant/src/live-voice/__tests__/live-voice-progress.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-progress.test.ts
@@ -17,6 +17,8 @@ import type {
 } from "../../stt/types.js";
 import {
   LiveVoiceSession,
+  type LiveVoiceSessionArchiveAudioInput,
+  type LiveVoiceSessionAudioArchiver,
   type LiveVoiceTtsStreamer,
   type LiveVoiceTurnStarter,
 } from "../live-voice-session.js";
@@ -128,6 +130,10 @@ function createRecordingTtsStreamer(
   // audio at all, so the session's client playback-tail estimate never moves
   // and every turn reads as instantly silent.
   emitChunkMs?: number,
+  // Content type the provider labels its chunks with. Some return a container
+  // format despite outputFormat "pcm", which is what makes the archive's mime
+  // stamp worth pinning.
+  chunkContentType = "audio/pcm",
 ): {
   streamTtsAudio: LiveVoiceTtsStreamer;
   ttsTexts: string[];
@@ -141,7 +147,7 @@ function createRecordingTtsStreamer(
     if (emitChunkMs !== undefined) {
       options.onAudioChunk({
         type: "tts_audio",
-        contentType: "audio/pcm",
+        contentType: chunkContentType,
         sampleRate: START_FRAME.audio.sampleRate,
         dataBase64: Buffer.alloc(
           Math.round((START_FRAME.audio.sampleRate * emitChunkMs) / 1_000) * 2,
@@ -198,6 +204,8 @@ function createProgressHarness(options: {
   emitMetrics?: boolean;
   gateTtsText?: (text: string) => Promise<void> | null;
   emitChunkMs?: number;
+  chunkContentType?: string;
+  archiveAudio?: LiveVoiceSessionAudioArchiver;
   // Events the transcriber flushes at utterance release; defaults to a plain
   // untagged "hello" final.
   sttStopEvents?: SttStreamServerEvent[];
@@ -207,6 +215,7 @@ function createProgressHarness(options: {
   const { streamTtsAudio, ttsTexts, ttsCalls } = createRecordingTtsStreamer(
     options.gateTtsText,
     options.emitChunkMs,
+    options.chunkContentType,
   );
   const { context, frames } = createContext();
   const session = new LiveVoiceSession(context, {
@@ -218,6 +227,7 @@ function createProgressHarness(options: {
     frontModelConfig: options.frontModelConfig,
     workingCueConfig: options.workingCueConfig ?? { enabled: false },
     progressNarrator: options.progressNarrator,
+    ...(options.archiveAudio ? { archiveAudio: options.archiveAudio } : {}),
     createTurnId: () => "live-turn-1",
     emitMetrics: options.emitMetrics ?? false,
   });
@@ -994,6 +1004,12 @@ const CUE_PCM = renderWorkingCuePcm(START_FRAME.audio.sampleRate, {
 });
 const CUE_BASE64 = CUE_PCM.toString("base64");
 
+// One `emitChunkMs: 10` speech chunk at the session rate, as bytes. The
+// archive assertion compares against exactly this, so a cue spliced into the
+// recording shows up as extra length rather than as "some audio came out".
+const SPEECH_CHUNK_BYTES =
+  Math.round((START_FRAME.audio.sampleRate * 10) / 1_000) * 2;
+
 function cueFrames(
   frames: LiveVoiceServerFrame[],
 ): Extract<LiveVoiceServerFrame, { type: "tts_audio" }>[] {
@@ -1270,6 +1286,149 @@ describe("LiveVoiceSession working cue", () => {
 
     await waitFor(() => cueFrames(frames).length >= 1);
     expect(turnInternals(session).ttsSegmentEnqueued()).toBe(false);
+  });
+
+  test("the cue is marked non-speech on the wire and real speech is not", async () => {
+    const { frames, session, getCallbacks, ttsTexts } = createProgressHarness({
+      frontModelConfig: progressConfig({ enabled: false }),
+      workingCueConfig: WORKING_CUE_CONFIG,
+      progressNarrator: makeProgressNarrator(async () => GENERATED_NARRATION),
+      emitChunkMs: 10,
+    });
+    await startReleasedTurn(session, getCallbacks);
+
+    await waitFor(() => cueFrames(frames).length >= 1);
+    // The client drives speaking state, hands-free barge-in eligibility,
+    // client-heard latency, and the spoken-word cursor off tts_audio frames.
+    // An unmarked tone corrupts all four, and the payload is the only other
+    // thing that separates it from speech.
+    expect(cueFrames(frames)[0]?.nonSpeech).toBe(true);
+
+    emitTextDelta(getCallbacks, ANSWER_TEXT);
+    emitMessageComplete(getCallbacks);
+    await waitFor(() => ttsTexts.includes(ANSWER_TEXT));
+    await waitFor(() =>
+      frames.some(
+        (frame) =>
+          frame.type === "tts_audio" && frame.dataBase64 !== CUE_BASE64,
+      ),
+    );
+
+    const speech = frames.filter(
+      (frame): frame is Extract<LiveVoiceServerFrame, { type: "tts_audio" }> =>
+        frame.type === "tts_audio" && frame.dataBase64 !== CUE_BASE64,
+    );
+    // Absent, not false: speech frames stay byte-identical to what they were
+    // before the cue existed.
+    for (const frame of speech) {
+      expect(frame).not.toHaveProperty("nonSpeech");
+    }
+  });
+
+  test("the cue stays out of the archived assistant audio", async () => {
+    const archived: LiveVoiceSessionArchiveAudioInput[] = [];
+    const { frames, session, getCallbacks, ttsTexts } = createProgressHarness({
+      frontModelConfig: progressConfig({ enabled: false }),
+      workingCueConfig: WORKING_CUE_CONFIG,
+      progressNarrator: makeProgressNarrator(async () => GENERATED_NARRATION),
+      emitChunkMs: 10,
+      // A provider that returns a container format despite outputFormat
+      // "pcm", which real ones do.
+      chunkContentType: "audio/wav",
+      archiveAudio: (input) => {
+        archived.push(input);
+        return {
+          type: "warning",
+          warning: {
+            code: "archive_failed",
+            message: "not stored in tests",
+          },
+        };
+      },
+    });
+    await startReleasedTurn(session, getCallbacks);
+
+    await waitFor(() => cueFrames(frames).length >= 1);
+    emitTextDelta(getCallbacks, ANSWER_TEXT);
+    emitMessageComplete(getCallbacks);
+    await waitFor(() => ttsTexts.includes(ANSWER_TEXT));
+    await waitFor(() => archived.some((input) => input.role === "assistant"));
+
+    // The archive is a recording of what the assistant said. Splicing raw cue
+    // PCM into it interleaves two encodings under one mime type, so the
+    // recording is corrupt from the first cue onward.
+    const assistant = archived.find((input) => input.role === "assistant");
+    expect(assistant?.mimeType).toBe("audio/wav");
+    const bytes = Buffer.from(assistant?.audio.dataBase64 ?? "", "base64");
+    expect(bytes.byteLength).toBe(SPEECH_CHUNK_BYTES);
+    expect(bytes.includes(CUE_PCM)).toBe(false);
+  });
+
+  test("a spoken filler does not anchor the turn's first-TTS metrics", async () => {
+    // The approval-pending line is not gated on progress.enabled, so it
+    // speaks on any turn that hits a decision gate in the default config.
+    const answerSpoken = deferred<void>();
+    const { frames, session, getCallbacks, approvalPending, ttsTexts } =
+      createProgressHarness({
+        frontModelConfig: progressConfig({ enabled: false }),
+        progressNarrator: makeProgressNarrator(async () => GENERATED_NARRATION),
+        gateTtsText: (text) =>
+          text === ANSWER_TEXT ? answerSpoken.promise : null,
+        emitChunkMs: 10,
+      });
+    await startReleasedTurn(session, getCallbacks);
+
+    const approvalPhrase = sanitizeForTts(approvalPendingPhraseFor()).trim();
+    approvalPending("approval-request-1");
+    await waitFor(() => ttsTexts.includes(approvalPhrase));
+    await waitFor(() => frames.some((frame) => frame.type === "tts_audio"));
+
+    // roundTripMs and friends measure to this mark, and they mean "when did
+    // the answer start". A filler plays into the dead air before the answer,
+    // so latching on it reports the wait as the turn's speech latency.
+    expect(turnInternals(session).ttsAudioStarted()).toBe(false);
+    expect(turnInternals(session).firstTtsAudioAtMs()).toBeNull();
+
+    emitTextDelta(getCallbacks, ANSWER_TEXT);
+    emitMessageComplete(getCallbacks);
+    await waitFor(() => ttsTexts.includes(ANSWER_TEXT));
+
+    // The first real answer audio still latches: a filler skips the mark, it
+    // does not consume it.
+    await waitFor(() => turnInternals(session).ttsAudioStarted() === true);
+    expect(turnInternals(session).firstTtsAudioAtMs()).not.toBeNull();
+    answerSpoken.resolve(undefined);
+  });
+
+  test("a cue turn lands workingCuesPlayed on the turn's metrics frame", async () => {
+    const { frames, session, getCallbacks } = createProgressHarness({
+      frontModelConfig: progressConfig({ enabled: false }),
+      workingCueConfig: WORKING_CUE_CONFIG,
+      progressNarrator: makeProgressNarrator(async () => GENERATED_NARRATION),
+      emitMetrics: true,
+    });
+
+    await startReleasedTurn(session, getCallbacks);
+    await waitFor(() => cueFrames(frames).length >= 1);
+
+    emitMessageComplete(getCallbacks);
+    await waitFor(() =>
+      frames.some(
+        (frame) => frame.type === "metrics" && frame.event === "turn_completed",
+      ),
+    );
+
+    // progressUpdatesSpoken is omitted when zero and narration is off by
+    // default, so without this counter nothing in telemetry separates a turn
+    // that hummed through its silence from one that sat in it.
+    const completedMetrics = frames.find(
+      (frame) => frame.type === "metrics" && frame.event === "turn_completed",
+    );
+    expect(completedMetrics).toMatchObject({
+      type: "metrics",
+      turnId: "live-turn-1",
+      workingCuesPlayed: 1,
+    });
   });
 
   test("the cue's chunk enters the echo reference", async () => {

--- a/assistant/src/live-voice/__tests__/live-voice-progress.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-progress.test.ts
@@ -1431,6 +1431,35 @@ describe("LiveVoiceSession working cue", () => {
     });
   });
 
+  test("a cue the caller never heard is not counted", async () => {
+    // The counter exists to separate a turn that hummed through its silence
+    // from one that sat in it, so a cue discarded before it reached the wire
+    // must not inflate it. Interrupting mid-turn stops the frame from being
+    // written while the cue job is still queued.
+    const { frames, session, getCallbacks } = createProgressHarness({
+      frontModelConfig: progressConfig({ enabled: false }),
+      workingCueConfig: WORKING_CUE_CONFIG,
+      progressNarrator: makeProgressNarrator(async () => GENERATED_NARRATION),
+      emitMetrics: true,
+    });
+
+    await startReleasedTurn(session, getCallbacks);
+    await session.handleClientFrame({ type: "interrupt" });
+    await waitFor(() =>
+      frames.some(
+        (frame) => frame.type === "metrics" && frame.event !== "turn_started",
+      ),
+    );
+
+    const terminal = frames.find(
+      (frame) => frame.type === "metrics" && frame.event !== "turn_started",
+    );
+    expect(terminal).toBeDefined();
+    // Omitted when zero, so absence is the assertion.
+    expect(terminal).not.toHaveProperty("workingCuesPlayed");
+    expect(cueFrames(frames).length).toBe(0);
+  });
+
   test("the cue's chunk enters the echo reference", async () => {
     const { frames, session, getCallbacks } = createProgressHarness({
       frontModelConfig: progressConfig({ enabled: false }),

--- a/assistant/src/live-voice/__tests__/live-voice-triage-escalate.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-triage-escalate.test.ts
@@ -230,6 +230,30 @@ describe("live-voice triage-and-escalate routing", () => {
     expect(frontDoorPrompt).not.toContain("This includes connecting accounts");
   });
 
+  test("the spoken-close teaching reaches the escalated leg only", async () => {
+    const { starter } = scriptedStartVoiceTurn({
+      frontDoor: ["[1] ", "Let me think about that."],
+      escalated: ["The detailed answer is 42."],
+    });
+    const { frames, session } = createHarness(starter);
+
+    await driveTurn(session);
+    await waitFor(() => starter.mock.calls.length >= 2);
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    const frontDoorPrompt =
+      starter.mock.calls[0]?.[0]?.voiceControlPrompt ?? "";
+    const escalatedPrompt =
+      starter.mock.calls[1]?.[0]?.voiceControlPrompt ?? "";
+    // The teaching opens by telling the model what the caller has already
+    // heard ("you told them you were on it, and nothing since"), which is
+    // true of exactly one leg: the one that took over after a hand-off
+    // bridge. Any other leg is told something false about the call it is
+    // joining, including a turn the user never asked for.
+    expect(escalatedPrompt).toContain("You already told the caller");
+    expect(frontDoorPrompt).not.toContain("You already told the caller");
+  });
+
   test("the screen-reveal teaching reaches the escalated leg's prompt but never the front-door leg's", async () => {
     const { starter } = scriptedStartVoiceTurn({
       frontDoor: ["[1] ", "Let me think about that."],

--- a/assistant/src/live-voice/__tests__/live-voice-tts-session.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-tts-session.test.ts
@@ -14,6 +14,7 @@ import {
   LiveVoiceSession,
   type LiveVoiceTtsStreamer,
   type LiveVoiceTurnStarter,
+  NON_BLOCK_TTS_SEQ,
 } from "../live-voice-session.js";
 import type { LiveVoiceSessionFactoryContext } from "../live-voice-session-manager.js";
 import type {
@@ -297,6 +298,20 @@ function assistantTranscript(frames: LiveVoiceServerFrame[]): string {
 // structural so the test does not need the session's private job type.
 interface HeldJobView {
   readonly text: string;
+}
+
+// The block stamp a job carries, which decides which promotion or retraction
+// can select it. No frame exposes it, so the tests that pin it read the turn.
+interface StampedJobView {
+  readonly text: string;
+  readonly blockSeq: number;
+}
+
+function ttsJobStamps(session: LiveVoiceSession): StampedJobView[] {
+  const internals = session as unknown as {
+    activeAssistantTurn: { ttsJobs: StampedJobView[] } | null;
+  };
+  return internals.activeAssistantTurn?.ttsJobs ?? [];
 }
 
 // The slice of the session's private turn state these tests read.
@@ -1042,6 +1057,98 @@ describe("LiveVoiceSession TTS", () => {
     expect(ttsAudioPayloads(frames)).toEqual([b64("audio:held-1")]);
   });
 
+  test("a retracted held job stops reserving the held prefetch slot", async () => {
+    let callbacks: VoiceTurnCallbacks | undefined;
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      callbacks = options.callbacks;
+      return { turnId: "bridge-turn-1", abort: mock() };
+    });
+    const { streamTtsAudio, calls, events } = createControlledTtsStreamer();
+    const { frames, session } = createSessionHarness({
+      startVoiceTurn,
+      streamTtsAudio,
+    });
+
+    await startReleasedTurn(session);
+    callbacks?.assistant_text_delta?.(makeTextDelta(FIRST_SENTENCE));
+    const held = heldTtsController(session);
+    held.enqueue(HELD_SENTENCE);
+
+    // This provider ignores the abort, so the retracted stream stays open.
+    expect(held.retract((job) => job.text === HELD_SENTENCE)).toBe(1);
+    held.enqueue(OTHER_HELD_SENTENCE);
+    expect(events).toEqual([
+      `start:${FIRST_SENTENCE}`,
+      `start:${HELD_SENTENCE}`,
+    ]);
+
+    // The retracted job can never be promoted, so it is not the held prefetch
+    // the one held slot is reserved for. Counting it would leave the answer
+    // block un-synthesized until the turn ends, which is the full TTS round
+    // trip the hold exists to remove.
+    calls[0]?.options.onAudioChunk(makeTtsChunk("audio:live-1"));
+    calls[0]?.finish();
+    await waitFor(() => events.includes(`start:${OTHER_HELD_SENTENCE}`));
+
+    expect(held.promote((job) => job.text === OTHER_HELD_SENTENCE)).toBe(1);
+    calls[2]?.options.onAudioChunk(makeTtsChunk("audio:held-2"));
+    calls[2]?.finish();
+    callbacks?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    expect(ttsAudioPayloads(frames)).toEqual([
+      b64("audio:live-1"),
+      b64("audio:held-2"),
+    ]);
+  });
+
+  test("a job that reaches the head of the chain synthesizes even with both slots busy", async () => {
+    let callbacks: VoiceTurnCallbacks | undefined;
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      callbacks = options.callbacks;
+      return { turnId: "bridge-turn-1", abort: mock() };
+    });
+    const { streamTtsAudio, calls, events } = createControlledTtsStreamer();
+    const { frames, session } = createSessionHarness({
+      startVoiceTurn,
+      streamTtsAudio,
+    });
+
+    await startReleasedTurn(session);
+    callbacks?.assistant_text_delta?.(makeTextDelta(FIRST_SENTENCE));
+    const held = heldTtsController(session);
+
+    // Both slots end up held by jobs that are NOT ahead of the second spoken
+    // segment on the emission chain: one retracted job whose provider has not
+    // torn the stream down, and one held job waiting on a promotion that may
+    // never come. Neither is on the chain at all.
+    held.enqueue(HELD_SENTENCE);
+    expect(held.retract((job) => job.text === HELD_SENTENCE)).toBe(1);
+    held.enqueue(OTHER_HELD_SENTENCE);
+    calls[0]?.options.onAudioChunk(makeTtsChunk("audio:first-1"));
+    calls[0]?.finish();
+    await waitFor(() => events.includes(`start:${OTHER_HELD_SENTENCE}`));
+
+    // Enqueued behind a cap that is full, so it arrives at the head of the
+    // chain unstarted. Asking the cap for permission there would start
+    // nothing, and the segment would settle having emitted no audio at all:
+    // a silently dropped piece of the answer, with no frame, error, or log.
+    callbacks?.assistant_text_delta?.(makeTextDelta(SECOND_SENTENCE));
+    await waitFor(() => events.includes(`start:${SECOND_SENTENCE}`));
+    const secondCall = calls.find(
+      (call) => call.options.text === SECOND_SENTENCE,
+    );
+    secondCall?.options.onAudioChunk(makeTtsChunk("audio:second-1"));
+    secondCall?.finish();
+    callbacks?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    expect(ttsAudioPayloads(frames)).toEqual([
+      b64("audio:first-1"),
+      b64("audio:second-1"),
+    ]);
+  });
+
   test("tts_done still fires on a turn holding one segment and retracting another", async () => {
     let callbacks: VoiceTurnCallbacks | undefined;
     const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
@@ -1188,6 +1295,35 @@ describe("LiveVoiceSession TTS", () => {
     callbacks?.message_complete?.(makeMessageComplete());
     await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
     expect(ttsAudioPayloads(frames)).toEqual([]);
+  });
+
+  test("the completion sweep drops the stranded block's tail rather than speaking it", async () => {
+    let callbacks: VoiceTurnCallbacks | undefined;
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      callbacks = options.callbacks;
+      return { turnId: "bridge-turn-1", abort: mock() };
+    });
+    const { streamTtsAudio, synthesized } = createEchoTtsStreamer();
+    const { frames, session } = createSessionHarness({
+      startVoiceTurn,
+      streamTtsAudio,
+    });
+
+    await startReleasedTurn(session);
+    const held = heldTtsController(session);
+    held.enqueue(HELD_SENTENCE);
+    callbacks?.assistant_text_delta?.(makeTextDelta(PENDING_TAIL));
+    expect(held.pendingTail()).toBe(PENDING_TAIL);
+
+    callbacks?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    // The sweep drops a stranded held block because unresolved held text is
+    // commentary. Its un-segmented tail is the same commentary, so leaving it
+    // for the terminal flush would speak the fragment of the very block just
+    // dropped, as the turn's closing words.
+    expect(ttsAudioPayloads(frames)).toEqual([]);
+    expect(synthesizedTexts(synthesized)).not.toContain(PENDING_TAIL);
   });
 
   test("retraction discards the pending tail only when the caller owns it", async () => {
@@ -1429,7 +1565,8 @@ describe("LiveVoiceSession escalated-turn speech", () => {
 
   test("the escalation bridge is never held or retracted", async () => {
     const { streamTtsAudio, synthesized } = createEchoTtsStreamer();
-    const { frames, escalated } = await startEscalatedTurn(streamTtsAudio);
+    const { frames, session, escalated } =
+      await startEscalatedTurn(streamTtsAudio);
     const legs = escalated.callbacks;
 
     // The bridge is spoken during the tool phase, which is the whole point
@@ -1437,6 +1574,16 @@ describe("LiveVoiceSession escalated-turn speech", () => {
     await waitFor(() =>
       ttsAudioPayloads(frames).includes(b64(`audio:${BRIDGE_SENTENCE}`)),
     );
+
+    // Stamped as belonging to no block. Without the stamp it takes the
+    // escalated leg's first block, which the first tool call retracts, and
+    // the only thing keeping it audible would be the selectors' independent
+    // `held` filter: the audible outcome would be the same and the invariant
+    // NON_BLOCK_TTS_SEQ states would be false.
+    const bridgeJob = ttsJobStamps(session).find(
+      (job) => job.text === BRIDGE_SENTENCE,
+    );
+    expect(bridgeJob?.blockSeq).toBe(NON_BLOCK_TTS_SEQ);
 
     legs?.assistant_text_delta?.(makeTextDelta(`${FIRST_COMMENTARY} `));
     legs?.tool_block_opened?.("calendar_read", "toolu-1");
@@ -1478,6 +1625,72 @@ describe("LiveVoiceSession escalated-turn speech", () => {
     expect(calls[1]?.options.signal?.aborted).toBe(true);
     expect(ttsAudioPayloads(frames)).toEqual([]);
     expect(frames.some((frame) => frame.type === "tts_done")).toBe(false);
+  });
+
+  test("an errored turn retracts its held prefetch instead of leaving it streaming", async () => {
+    const { streamTtsAudio, calls } = createControlledTtsStreamer();
+    const { frames, escalated } = await startEscalatedTurn(streamTtsAudio);
+    const legs = escalated.callbacks;
+
+    // The bridge settles silently, so the only open provider stream is the
+    // held block's prefetch.
+    calls[0]?.finish();
+    legs?.assistant_text_delta?.(makeTextDelta(`${FIRST_COMMENTARY} `));
+    await waitFor(() => calls.length >= 2);
+    expect(calls[1]?.options.signal?.aborted).toBe(false);
+
+    escalated.onError?.("the provider fell over");
+
+    // A held job is off the emission chain, so nothing else will ever settle
+    // it: a terminal path that neither promotes nor retracts leaves its
+    // provider stream open past the turn, billing for audio nobody hears.
+    // Every terminal path has to cover it, not just the two that remembered.
+    await waitFor(() => calls[1]?.options.signal?.aborted === true);
+    expect(ttsAudioPayloads(frames)).toEqual([]);
+  });
+
+  test("a turn that ends with a tool block open speaks only the hand-off bridge", async () => {
+    const { streamTtsAudio } = createEchoTtsStreamer();
+    const { frames, escalated } = await startEscalatedTurn(streamTtsAudio);
+    const legs = escalated.callbacks;
+
+    legs?.assistant_text_delta?.(makeTextDelta(`${FIRST_COMMENTARY} `));
+    legs?.tool_block_opened?.("calendar_read", "toolu-1");
+    // The loop stops with the tool block still open (the tool-turn ceiling, a
+    // hook ending the turn). The block before it was retracted as commentary
+    // and nothing followed, so the terminal promotion has nothing to select.
+    legs?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    // The guarantee outranks having something to say: the commentary stays
+    // unspoken even when it is all the turn produced. The session logs the
+    // empty promotion so this reads as a known shape rather than a mystery.
+    expect(ttsAudioPayloads(frames)).toEqual([b64(`audio:${BRIDGE_SENTENCE}`)]);
+    expect(assistantTranscript(frames)).toContain(FIRST_COMMENTARY);
+  });
+
+  test("a withheld control-marker tail does not cross a block boundary", async () => {
+    const { streamTtsAudio } = createEchoTtsStreamer();
+    const { frames, escalated } = await startEscalatedTurn(streamTtsAudio);
+    const legs = escalated.callbacks;
+
+    // "[US" is a live control-marker candidate ("[USER_ANSWERED:" and
+    // friends), so the holdback withholds it rather than speaking a marker
+    // that is still streaming. It sits outside ttsBuffer, where the block
+    // retraction cannot reach it.
+    legs?.assistant_text_delta?.(makeTextDelta(`${FIRST_COMMENTARY} [US`));
+    legs?.tool_block_opened?.("calendar_read", "toolu-1");
+    legs?.assistant_text_delta?.(makeTextDelta(REPORT_SENTENCE));
+    legs?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    // Kept, the fragment is stamped with the report's block and spoken glued
+    // onto the front of it.
+    expect(ttsAudioPayloads(frames)).toEqual([
+      b64(`audio:${BRIDGE_SENTENCE}`),
+      b64(`audio:${REPORT_SENTENCE}`),
+    ]);
+    expect(assistantTranscript(frames)).not.toContain("[US");
   });
 
   test("an escalated turn with no tool calls speaks its single block", async () => {

--- a/assistant/src/live-voice/__tests__/protocol.test.ts
+++ b/assistant/src/live-voice/__tests__/protocol.test.ts
@@ -253,6 +253,46 @@ describe("parseLiveVoiceClientTextFrame", () => {
     });
   });
 
+  test("rejects a capture rate below narrowband telephony", () => {
+    // The cap has a floor for the same reason it has a ceiling: the rate
+    // sizes every rendered buffer. A rate this low rounds the working cue to
+    // zero frames, so the session would send an empty audio frame and still
+    // hold the floor for a whole interval. Refuse it here, where it is still
+    // just a bad field, rather than guarding the render downstream.
+    const result = validateLiveVoiceClientFrame({
+      type: "start",
+      audio: {
+        mimeType: "audio/pcm",
+        sampleRate: 1,
+        channels: 1,
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      return;
+    }
+
+    expect(result.error).toMatchObject({
+      code: "invalid_field",
+      field: "audio.sampleRate",
+      frameType: "start",
+    });
+  });
+
+  test("accepts the lowest capture rate a supported client opens with", () => {
+    const result = validateLiveVoiceClientFrame({
+      type: "start",
+      audio: {
+        mimeType: "audio/pcm",
+        sampleRate: 8_000,
+        channels: 1,
+      },
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
   test("accepts the highest capture rate real hardware opens with", () => {
     const result = validateLiveVoiceClientFrame({
       type: "start",

--- a/assistant/src/live-voice/live-voice-metrics.ts
+++ b/assistant/src/live-voice/live-voice-metrics.ts
@@ -20,6 +20,7 @@ export type LiveVoiceMetricsEvent =
   | "final_transcript"
   | "first_assistant_delta"
   | "progress_spoken"
+  | "working_cue_played"
   | "first_tts_audio"
   | "turn_completed"
   | "turn_cancelled"
@@ -132,6 +133,10 @@ interface LiveVoiceTurnMetrics {
   endpointDecisionMaxLatencyMs?: number;
   endpointDecisionSource?: VoiceEndpointSource;
   progressUpdatesSpoken?: number;
+  // Working cues played into the turn's silence. The cue is the default
+  // floor-holder, so without this a turn that hummed and a turn that sat
+  // silent are indistinguishable in telemetry.
+  workingCuesPlayed?: number;
 }
 
 interface LiveVoiceDurationSummary {
@@ -181,6 +186,7 @@ interface LiveVoiceMetricsAggregateFields {
   endpointDecisionMaxLatencyMs?: number;
   endpointDecisionSource?: VoiceEndpointSource;
   progressUpdatesSpoken?: number;
+  workingCuesPlayed?: number;
 }
 
 export interface LiveVoiceMetricsFrame {
@@ -206,6 +212,7 @@ interface MutableTurn {
   // The decider behind the turn's most recent endpoint decision.
   endpointDecisionSource: VoiceEndpointSource | null;
   progressUpdatesSpoken: number;
+  workingCuesPlayed: number;
 }
 
 const DEFAULT_RECENT_TURN_LIMIT = 50;
@@ -273,6 +280,7 @@ export class LiveVoiceMetricsCollector {
       endpointDecisionMaxLatencyMs: null,
       endpointDecisionSource: null,
       progressUpdatesSpoken: 0,
+      workingCuesPlayed: 0,
     };
     this.applySeedMarks(this.activeTurn, seedMarks);
     this.emit("turn_started", turnId);
@@ -380,6 +388,14 @@ export class LiveVoiceMetricsCollector {
     const turn = this.ensureActiveTurn(turnId);
     turn.progressUpdatesSpoken += 1;
     return this.emit("progress_spoken", turn.turnId);
+  }
+
+  // A counter like markProgressSpoken: every cue played into the turn's
+  // silence bumps the per-turn count.
+  markWorkingCuePlayed(turnId?: string): LiveVoiceMetricsFrame {
+    const turn = this.ensureActiveTurn(turnId);
+    turn.workingCuesPlayed += 1;
+    return this.emit("working_cue_played", turn.turnId);
   }
 
   markBargeIn(turnId?: string): LiveVoiceMetricsFrame {
@@ -594,8 +610,8 @@ function aggregateFieldsForTurn(
 // Shared optional fields for turn snapshots and aggregate frame fields: the
 // commit latency is absent unless the turn committed against a local
 // speech-stop mark, and the front-model fields are absent unless the endpoint
-// decider was consulted or a progress narration spoke, so turns
-// that never touch the features are unchanged.
+// decider was consulted, a progress narration spoke, or a working cue played,
+// so turns that never touch the features are unchanged.
 function optionalTurnFields(
   // Accepts both MutableTurn (null = unset) and snapshot (absent = unset).
   turn: {
@@ -604,6 +620,7 @@ function optionalTurnFields(
     endpointDecisionMaxLatencyMs?: number | null;
     endpointDecisionSource?: VoiceEndpointSource | null;
     progressUpdatesSpoken?: number | null;
+    workingCuesPlayed?: number | null;
   },
 ): Pick<
   LiveVoiceTurnMetrics,
@@ -612,8 +629,10 @@ function optionalTurnFields(
   | "endpointDecisionMaxLatencyMs"
   | "endpointDecisionSource"
   | "progressUpdatesSpoken"
+  | "workingCuesPlayed"
 > {
   const progressUpdatesSpoken = turn.progressUpdatesSpoken ?? 0;
+  const workingCuesPlayed = turn.workingCuesPlayed ?? 0;
   return {
     ...(turn.endpointCommitLatencyMs != null
       ? { endpointCommitLatencyMs: turn.endpointCommitLatencyMs }
@@ -627,6 +646,7 @@ function optionalTurnFields(
         }
       : {}),
     ...(progressUpdatesSpoken > 0 ? { progressUpdatesSpoken } : {}),
+    ...(workingCuesPlayed > 0 ? { workingCuesPlayed } : {}),
   };
 }
 
@@ -674,6 +694,7 @@ function cloneMutableTurn(turn: MutableTurn): MutableTurn {
     endpointDecisionMaxLatencyMs: turn.endpointDecisionMaxLatencyMs,
     endpointDecisionSource: turn.endpointDecisionSource,
     progressUpdatesSpoken: turn.progressUpdatesSpoken,
+    workingCuesPlayed: turn.workingCuesPlayed,
   };
 }
 

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -5725,7 +5725,6 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     ));
     this.enqueueTtsAudioCue(turn.token, pcm);
     turn.progress.lastFloorHolderAtMs = Date.now();
-    this.markWorkingCuePlayed(turn);
   }
 
   // Generate and speak one audio-only progress narration. On a null result,
@@ -6529,6 +6528,18 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       // a stale turn's late send from latching a newer turn.
       if (!sent) {
         return;
+      }
+      // Counted here rather than at enqueue: a cue queued behind earlier
+      // speech can be discarded by cancellation or a closing session before
+      // it is ever written, and a metric whose whole purpose is telling a
+      // turn that hummed from one that sat silent must not count a cue the
+      // caller did not hear. A cue is a single pre-buffered chunk, so this
+      // runs once per cue.
+      if (job.audioRole === "cue") {
+        const cueTurn = this.activeAssistantTurn;
+        if (cueTurn?.token === token) {
+          this.markWorkingCuePlayed(cueTurn);
+        }
       }
       // Extend the client playback-tail estimate by this chunk's PCM
       // duration (chunks queue gaplessly client-side, so the tail grows

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -6557,8 +6557,18 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         Math.max(now, this.assistantPlaybackTailUntilMs) + chunkMs;
       // Everything above is what a cue or a spoken filler is here for: the
       // client hears it, the canceller learns it was us, and the tail estimate
-      // covers it. The first-TTS latch is where both stop, because that mark
-      // is the onset of the turn's ANSWER (see TtsSegmentAudioRole).
+      // covers it. The first-TTS latch is where both stop.
+      //
+      // What that mark means is narrower than "the answer began" and worth
+      // stating exactly, because this codebase has anchored a voice latency
+      // metric on the wrong event before. It is the first audio the caller
+      // hears that the model authored for this turn. A cue is not authored at
+      // all and a fixed filler phrase is not authored for this turn, so
+      // neither latches. The escalation bridge IS model-authored and does
+      // latch, so on an escalated turn this measures hand-off onset rather
+      // than report onset. That is deliberate for now: it is the behavior
+      // that predates the held-speech work, and changing it would silently
+      // move an existing metric by the length of a whole working phase.
       const turnAfterSend = this.activeAssistantTurn;
       if (
         job.audioRole !== "answer" ||

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -527,7 +527,26 @@ type UtteranceStartResult =
 // fixed session phrase (the escalation bridge, the approval-pending line,
 // progress narration). Those exist to be heard while the turn works, so they
 // are never held, and no block-scoped selector can ever match them.
-const NON_BLOCK_TTS_SEQ = -1;
+export const NON_BLOCK_TTS_SEQ = -1;
+
+/**
+ * What a TTS segment is to the caller, which decides how the session accounts
+ * for it rather than how it is played. Every role reaches the client, enters
+ * the echo reference, and extends the playback-tail estimate.
+ *
+ * - `answer`: the turn's own speech. It anchors the first-TTS metrics and is
+ *   archived as the assistant's audio.
+ * - `filler`: a spoken floor-holder (progress narration, the approval-pending
+ *   line). Real speech, so it archives like any other, but it must not anchor
+ *   the first-TTS metrics: those measure when the ANSWER starts speaking, and
+ *   a filler plays into the dead air before it.
+ * - `cue`: the rendered working tone. Not speech at all, so on top of the
+ *   filler's exclusion it stays out of the archived assistant audio (its bare
+ *   PCM would interleave with whatever container a provider returned) and is
+ *   marked `nonSpeech` on the wire, where a client latches speaking state,
+ *   barge-in eligibility, and the spoken-word cursor on every tts_audio frame.
+ */
+type TtsSegmentAudioRole = "answer" | "filler" | "cue";
 
 // One TTS segment flowing through the turn's synthesis pipeline. Synthesis
 // may run ahead of the emission slot (prefetch), but frames only reach the
@@ -543,15 +562,9 @@ interface TtsSegmentJob {
   // block-scoped promotion or retraction selects exactly that block's
   // segments. NON_BLOCK_TTS_SEQ marks a segment that belongs to no block.
   readonly blockSeq: number;
-  // Rendered non-speech audio (the working cue) rather than a synthesized
-  // utterance. It is ordinary audio in every other respect: it reaches the
-  // client, enters the echo reference, and extends the playback-tail
-  // estimate. What it must not do is anchor the turn's first-TTS metrics,
-  // which measure when the answer starts being spoken. A cue plays into the
-  // dead air of a long working turn, well before the answer, so latching on
-  // it would report the tone's timing as the turn's speech latency on exactly
-  // the turns whose latency is worth knowing.
-  readonly nonSpeechCue: boolean;
+  // Whether this segment is the turn's answer, a spoken floor-holder, or the
+  // rendered cue (see TtsSegmentAudioRole).
+  readonly audioRole: TtsSegmentAudioRole;
   // The provider stream was started (the job holds an open-job slot).
   started: boolean;
   // The provider is done with this job, either because emission finished or
@@ -791,16 +804,32 @@ interface ActiveAssistantTurn {
   // A non-empty speakable segment reached the TTS queue — gates the eager
   // first-segment flush that trades clause quality for speech onset.
   ttsSegmentEnqueued: boolean;
-  // Ordered TTS segment jobs for the turn; synthesis runs ahead of emission
-  // by at most one job (TTS_MAX_OPEN_SYNTHESIS_JOBS).
+  // Every TTS segment job of the turn, in enqueue order, whether or not it is
+  // on the emission chain. At most TTS_MAX_OPEN_SYNTHESIS_JOBS of them hold a
+  // provider stream open at once, and at most one of those may be a held job,
+  // so how far synthesis runs ahead of emission depends on which jobs are
+  // held: a held block's first segment is synthesized long before anything
+  // decides whether it will ever be spoken.
   ttsJobs: TtsSegmentJob[];
-  // Serial emission chain: one job's frames fully precede the next's, and
-  // the tts_done finale runs only after every job has drained.
+  // Serial emission chain: one job's frames fully precede the next's, and the
+  // tts_done finale runs after every job ON THE CHAIN has drained. A held job
+  // is deliberately off the chain, so completion never waits for one;
+  // completeTtsForTurn's sweep is what stops a held job outliving the turn.
   ttsQueue: Promise<void>;
   assistantMessageId: string | null;
   assistantAudioChunks: Buffer[];
   assistantAudioMimeType: string;
   assistantAudioSampleRate?: number;
+}
+
+/**
+ * A held job that can still be promoted, which is the only sense in which a
+ * turn has pending held audio. Cancellation is what ends a hold: a retracted
+ * job keeps `held` set (it still names the block it came from) but nothing
+ * will ever emit it, so every question about the hold has to exclude it.
+ */
+function isPendingHeldTtsJob(job: TtsSegmentJob): boolean {
+  return job.held && !job.cancelled;
 }
 
 /**
@@ -825,30 +854,48 @@ interface ActiveAssistantTurn {
  * a marker, so this stripping is defense against a model that emits one
  * regardless: an unspoken, unpersisted "[-1]" is the correct handling of a
  * token that now means nothing.
+ *
+ * `dropPendingTail` abandons whatever is currently withheld. The withheld tail
+ * is the only text of a block that does not live in `ttsBuffer`, so a caller
+ * that drops the block (a tool-use block opening on an escalated leg) has to
+ * say so here as well: left in place it would be emitted later, stamped with
+ * the NEXT block's sequence, and spoken glued onto that block's text.
+ *
+ * Known residual: the daemon's own guard buffer
+ * (`pendingSentinelGuardBuffer` in `daemon/conversation-agent-loop-handlers.ts`)
+ * withholds text on the same shape of rule and flushes it at message end. It
+ * sits upstream of this session and is not reachable from here.
  */
-function createControlMarkerHoldback(
-  turn: ActiveAssistantTurn,
-  emit: (chunk: string) => void,
-): (raw: string, opts?: { force?: boolean }) => void {
+function createControlMarkerHoldback(emit: (chunk: string) => void): {
+  flush: (raw: string, opts?: { force?: boolean }) => void;
+  dropPendingTail: () => void;
+} {
   let emitted = 0;
-  return (raw, opts) => {
-    let safeEnd = raw.length;
-    if (opts?.force !== true) {
-      for (
-        let i = raw.indexOf("[", emitted);
-        i !== -1;
-        i = raw.indexOf("[", i + 1)
-      ) {
-        if (isIncompleteControlMarkerTail(raw.slice(i))) {
-          safeEnd = i;
-          break;
+  let seen = 0;
+  return {
+    flush: (raw, opts) => {
+      seen = raw.length;
+      let safeEnd = raw.length;
+      if (opts?.force !== true) {
+        for (
+          let i = raw.indexOf("[", emitted);
+          i !== -1;
+          i = raw.indexOf("[", i + 1)
+        ) {
+          if (isIncompleteControlMarkerTail(raw.slice(i))) {
+            safeEnd = i;
+            break;
+          }
         }
       }
-    }
-    if (safeEnd > emitted) {
-      emit(stripInternalSpeechMarkers(raw.slice(emitted, safeEnd)));
-      emitted = safeEnd;
-    }
+      if (safeEnd > emitted) {
+        emit(stripInternalSpeechMarkers(raw.slice(emitted, safeEnd)));
+        emitted = safeEnd;
+      }
+    },
+    dropPendingTail: () => {
+      emitted = seen;
+    },
   };
 }
 
@@ -893,6 +940,12 @@ const LIVE_VOICE_SETUP_FLOW_TEACHING =
 // closing report short. A one-time instruction, not a per-block protocol the
 // model must keep executing. It also directly bounds the report's onset
 // delay, since the hold ends when this block finishes generating.
+//
+// The ESCALATED leg only. Its first sentence describes the caller's state
+// ("you already told them you were on it, and they have heard nothing since"),
+// and that is true of exactly one kind of turn: the one where a front-door leg
+// spoke a hand-off bridge and then went quiet while this leg works. Any other
+// leg is told something false about a call it is only now joining.
 const LIVE_VOICE_SPOKEN_CLOSE_TEACHING =
   "You already told the caller you were on it, and they have heard nothing since. When you finish, close with one or two short sentences saying what you did or what you found: the result, not the route you took to it. If you need something from them to continue, ask for everything you need in one go. ";
 
@@ -953,23 +1006,27 @@ function buildLiveDeliveryNote(request: string, answer: string): string {
 }
 
 // Assemble a leg's model-facing control prompt: the base live-voice rules, the
-// screen-reveal, setup-flow, and spoken-close teaching (all withheld from the
-// front-door leg, see LIVE_VOICE_SCREEN_REVEAL_TEACHING), plus any pending
+// screen-reveal and setup-flow teaching (both withheld from the front-door
+// leg, see LIVE_VOICE_SCREEN_REVEAL_TEACHING), the spoken-close teaching (the
+// escalated leg only, see LIVE_VOICE_SPOKEN_CLOSE_TEACHING), plus any pending
 // barge-in merge context, completed-continuation context, and/or the
 // announcement instruction.
 // A turn can carry several (a barge-in follow-up that also has a continuation
 // result waiting); the notes are model-only and never render as user bubbles.
+//
+// The two gates are separate because they answer different questions: whether
+// the leg can put something on screen, and whether the caller has already been
+// told to wait. A leg can be neither front-door nor escalated.
 function buildVoiceControlPrompt(
   turn: ActiveAssistantTurn,
-  leg: { frontDoor?: boolean },
+  leg: { frontDoor?: boolean; escalated?: boolean },
 ): string {
   let prompt =
     LIVE_VOICE_CONTROL_PROMPT_BASE +
     (leg.frontDoor === true
       ? ""
-      : LIVE_VOICE_SCREEN_REVEAL_TEACHING +
-        LIVE_VOICE_SETUP_FLOW_TEACHING +
-        LIVE_VOICE_SPOKEN_CLOSE_TEACHING);
+      : LIVE_VOICE_SCREEN_REVEAL_TEACHING + LIVE_VOICE_SETUP_FLOW_TEACHING) +
+    (leg.escalated === true ? LIVE_VOICE_SPOKEN_CLOSE_TEACHING : "");
   if (turn.language !== undefined) {
     prompt = `${prompt}\n\nThe caller has been speaking the language with code "${turn.language}" this turn. Reply in that language unless they clearly switch to another.`;
   }
@@ -4781,7 +4838,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       this.bufferAssistantTextForTts(token, chunk);
     };
 
-    const flushLegText = createControlMarkerHoldback(activeTurn, emitLegText);
+    const legText = createControlMarkerHoldback(emitLegText);
 
     // Hand off once enough of the post-verdict stream has arrived to cap
     // the bridge (sentence terminator or hard cap). Until then nothing is
@@ -4818,6 +4875,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         },
         voiceControlPrompt: buildVoiceControlPrompt(activeTurn, {
           ...(leg.frontDoor !== undefined ? { frontDoor: leg.frontDoor } : {}),
+          escalated: leg.routingLeg === "escalated",
         }),
         onApprovalPending: (requestId) => {
           this.revealRoomForPendingApproval(activeTurn, requestId);
@@ -4904,7 +4962,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
                 }
                 frontDoorStage = "answer";
               }
-              flushLegText(rawText);
+              legText.flush(rawText);
               return;
             }
             // Defensive: speculative legs are always front-door today, but a
@@ -4920,7 +4978,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
               }
             }
             rawText += msg.text;
-            flushLegText(rawText);
+            legText.flush(rawText);
           },
           message_complete: (msg) => {
             const current = this.activeAssistantTurn;
@@ -4967,7 +5025,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
             // and completeTtsForTurn signals the drain, so it is spoken and
             // emitted rather than dropped.
             if (!leg.frontDoor && msg.type === "message_complete") {
-              flushLegText(rawText, { force: true });
+              legText.flush(rawText, { force: true });
               if (leg.routingLeg === "escalated") {
                 // Nothing followed this block, so it is the turn's report
                 // back: the answer, or the question it needs answered. Its
@@ -4975,10 +5033,36 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
                 // audio without a TTS round trip. Ordering is load-bearing:
                 // the force-flush above segments the block's tail first, and
                 // this runs before assistantCompleted closes the TTS path.
-                this.promoteHeldTtsSegments(
+                const promoted = this.promoteHeldTtsSegments(
                   token,
                   (job) => job.blockSeq === current.textBlockSeq,
                 );
+                // A turn can stop with a tool-use block still open (the
+                // tool-turn ceiling, a hook ending the turn): textBlockSeq
+                // then points past the last block the model wrote, that block
+                // was retracted as commentary, and there is no report to
+                // promote. The caller hears the hand-off bridge and then
+                // nothing, which is indistinguishable from a working turn
+                // until it ends. Say so in the log rather than leaving the
+                // silence unexplained. A block whose text is still short of a
+                // segment boundary is not this case: completeTtsForTurn's
+                // terminal flush speaks that tail. Neither is a session with
+                // no TTS wired at all, which speaks nothing by design.
+                if (
+                  this.streamTtsAudio &&
+                  promoted === 0 &&
+                  current.ttsBuffer.trim().length === 0
+                ) {
+                  log.warn(
+                    {
+                      turnId,
+                      textBlockSeq: current.textBlockSeq,
+                      heldJobs:
+                        current.ttsJobs.filter(isPendingHeldTtsJob).length,
+                    },
+                    "Live voice escalated turn completed with no report to speak",
+                  );
+                }
               }
             }
             current.assistantCompleted = true;
@@ -5034,6 +5118,11 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
               // of a segment boundary is still this block's commentary.
               { discardPendingTail: true },
             );
+            // The marker holdback's withheld tail is the rest of the block's
+            // text, and it sits outside ttsBuffer where discardPendingTail
+            // cannot reach it. Kept, it would be emitted under the next
+            // block's sequence and spoken glued onto the report.
+            legText.dropPendingTail();
             current.textBlockSeq += 1;
             log.debug(
               { turnId, toolName, dropped },
@@ -5272,12 +5361,19 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       // Enqueued while the turn is still on the front-door leg, so the bridge
       // is not held: it is the one thing the caller is meant to hear before
       // the escalated leg reports back, and only held segments can be
-      // retracted.
-      this.bufferAssistantTextForTts(activeTurn.token, `${spokenBridge} `);
+      // retracted. Stamped NON_BLOCK_TTS_SEQ for the same reason the canned
+      // fallback below is: the bridge belongs to no block of the escalated
+      // leg, and the default stamp would be that leg's first block, which the
+      // first tool call retracts.
+      this.bufferAssistantTextForTts(activeTurn.token, `${spokenBridge} `, {
+        blockSeq: NON_BLOCK_TTS_SEQ,
+      });
       // Force-flush now: on the TTS path an unpunctuated bridge would
       // otherwise sit buffered until a sentence boundary and leave the
       // caller in silence during the escalated model's call.
-      this.flushTtsBuffer(activeTurn.token, true);
+      this.flushTtsBuffer(activeTurn.token, true, {
+        blockSeq: NON_BLOCK_TTS_SEQ,
+      });
     } else {
       // The canned bridge is a fixed localized-table phrase, enqueued
       // directly (it is already one complete sentence) so the segment can
@@ -5614,6 +5710,11 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // The audio is rendered on first use: the output sample rate is fixed for
   // the session's life, so one render serves every cue it plays.
   private playWorkingCue(turn: ActiveAssistantTurn): void {
+    // Non-empty by construction: the schema floors durationMs at 1ms and the
+    // start frame's sample rate at MIN_START_FRAME_SAMPLE_RATE, so the render
+    // always rounds to at least one frame. Both bounds are checked where the
+    // value enters, which is the only place a zero-length cue could have been
+    // built from.
     const pcm = (this.workingCuePcm ??= renderWorkingCuePcm(
       this.context.startFrame.audio.sampleRate,
       {
@@ -5622,14 +5723,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         gain: this.workingCueConfig.gain,
       },
     ));
-    if (pcm.byteLength === 0) {
-      // A shape that rounds to no frames at this sample rate. Enqueuing it
-      // would send an empty frame and still take the floor for a full
-      // interval, which is worse than skipping the tick.
-      return;
-    }
     this.enqueueTtsAudioCue(turn.token, pcm);
     turn.progress.lastFloorHolderAtMs = Date.now();
+    this.markWorkingCuePlayed(turn);
   }
 
   // Generate and speak one audio-only progress narration. On a null result,
@@ -5738,6 +5834,12 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       // A filler exists to be heard while the turn works, so it is never held
       // and never retracted with the block it happens to land beside.
       blockSeq: NON_BLOCK_TTS_SEQ,
+      // Real speech, but not the answer: it plays into the dead air BEFORE
+      // the answer, so anchoring the first-TTS metrics on it would report the
+      // filler's timing as the turn's speech latency. This reaches more than
+      // progress narration (which is off by default): the approval-pending
+      // line speaks on any turn that hits a decision gate.
+      audioRole: "filler",
       ...(language !== undefined ? { language } : {}),
     });
     // A spoken filler holds the floor, so narration's minGapMs spaces from it.
@@ -5760,7 +5862,11 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       : undefined;
   }
 
-  private bufferAssistantTextForTts(token: symbol, text: string): void {
+  private bufferAssistantTextForTts(
+    token: symbol,
+    text: string,
+    options: { blockSeq?: number } = {},
+  ): void {
     if (!this.streamTtsAudio || text.length === 0) {
       return;
     }
@@ -5771,7 +5877,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     }
 
     activeTurn.ttsBuffer += activeTurn.ttsReasoningFilter.push(text);
-    this.flushTtsBuffer(token, false);
+    this.flushTtsBuffer(token, false, options);
   }
 
   /**
@@ -5800,7 +5906,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     // `ttsJobs` is in enqueue order, so chaining in filter order is what keeps
     // the promoted block internally ordered.
     const promoted = activeTurn.ttsJobs.filter(
-      (job) => job.held && !job.cancelled && select(job),
+      (job) => isPendingHeldTtsJob(job) && select(job),
     );
     for (const job of promoted) {
       job.held = false;
@@ -5839,9 +5945,23 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     if (activeTurn?.token !== token) {
       return 0;
     }
+    return this.retractHeldTtsSegmentsOnTurn(activeTurn, select, options);
+  }
 
+  /**
+   * Retract against a turn directly rather than against whichever turn is
+   * active. A terminal path can have cleared `activeAssistantTurn` already
+   * (barge-in does, before it finalizes), and a dying turn's held jobs still
+   * have to be torn down.
+   */
+  private retractHeldTtsSegmentsOnTurn(
+    activeTurn: ActiveAssistantTurn,
+    select: (job: TtsSegmentJob) => boolean,
+    options: { discardPendingTail?: boolean } = {},
+  ): number {
+    const { token } = activeTurn;
     const retracted = activeTurn.ttsJobs.filter(
-      (job) => job.held && !job.cancelled && !job.emitting && select(job),
+      (job) => isPendingHeldTtsJob(job) && !job.emitting && select(job),
     );
     for (const job of retracted) {
       job.cancelled = true;
@@ -5899,11 +6019,20 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     // still be occupied when the next turn starts. Retract rather than promote,
     // because unresolved held text is commentary far more often than it is an
     // answer, and speaking it is the failure this hold exists to prevent.
-    const strandedHeldJobs = this.retractHeldTtsSegments(
-      token,
-      (job) => job.held,
-    );
-    if (strandedHeldJobs > 0) {
+    //
+    // Only when there is something to sweep: the option below also discards
+    // the turn's pending tail, and on an ordinary turn that tail is the last
+    // sentence of the answer, waiting for the terminal flush.
+    if (activeTurn.ttsJobs.some(isPendingHeldTtsJob)) {
+      const strandedHeldJobs = this.retractHeldTtsSegments(
+        token,
+        (job) => job.held,
+        // The sweep takes whole blocks, so it owns their un-segmented tail as
+        // well. Left behind, the terminal flush below would synthesize the
+        // trailing fragment of the very commentary just dropped and speak it
+        // as the turn's closing words.
+        { discardPendingTail: true },
+      );
       log.warn(
         { turnId: activeTurn.turnId, strandedHeldJobs },
         "Live voice turn completed with held segments the caller never resolved",
@@ -5977,7 +6106,15 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       });
   }
 
-  private flushTtsBuffer(token: symbol, force: boolean): void {
+  // `blockSeq` overrides the block stamp every segment this flush forms
+  // carries. Only a fixed session phrase that happens to ride the segmenter
+  // passes it (the model-authored escalation bridge); model text leaves it
+  // undefined and takes the block the turn is accumulating.
+  private flushTtsBuffer(
+    token: symbol,
+    force: boolean,
+    options: { blockSeq?: number } = {},
+  ): void {
     const activeTurn = this.activeAssistantTurn;
     if (activeTurn?.token !== token) {
       return;
@@ -6010,6 +6147,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       // the block the turn ends on is ever spoken.
       this.enqueueTtsSegment(token, speakable, {
         held: activeTurn.routingLeg === "escalated",
+        ...(options.blockSeq !== undefined
+          ? { blockSeq: options.blockSeq }
+          : {}),
       });
     }
   }
@@ -6028,6 +6168,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       // the turn is accumulating; a fixed session phrase passes
       // NON_BLOCK_TTS_SEQ so no block-scoped selector can reach it.
       blockSeq?: number;
+      // What the segment is to the caller. Defaults to the turn's own answer;
+      // a spoken floor-holder passes "filler" so it does not anchor the
+      // first-TTS metrics (see TtsSegmentAudioRole).
+      audioRole?: TtsSegmentAudioRole;
     } = {},
   ): void {
     const activeTurn = this.activeAssistantTurn;
@@ -6050,7 +6194,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       text: segment,
       language: options.language,
       blockSeq: options.blockSeq ?? activeTurn.textBlockSeq,
-      nonSpeechCue: false,
+      audioRole: options.audioRole ?? "answer",
       started: false,
       settled: false,
       emitting: false,
@@ -6094,8 +6238,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       // The cue belongs to no model text block, so no block-scoped promotion
       // or retraction can reach it.
       blockSeq: NON_BLOCK_TTS_SEQ,
-      // Keeps the tone out of the turn's first-TTS metrics (see the field).
-      nonSpeechCue: true,
+      // Rendered tone rather than speech: out of the turn's first-TTS metrics
+      // and out of the archived assistant audio, and marked on the wire (see
+      // TtsSegmentAudioRole).
+      audioRole: "cue",
       started: true,
       settled: false,
       emitting: false,
@@ -6158,9 +6304,18 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       // audio a tool call is about to cancel. A held job stays open until it
       // is promoted, or until a retraction's abort tears its stream down, so
       // the cap is a standing one.
+      //
+      // A cancelled job does not hold that slot, however long its aborted
+      // stream stays open: it will never be promoted, so it is not the held
+      // prefetch this slot is reserved for. Counting it would let a provider
+      // that is slow to tear down block held prefetch for the rest of the
+      // turn, and the answer block would then pay the full TTS round trip
+      // this design exists to remove. Same reasoning as turnAudioIdle's.
       const heldSlotTaken = activeTurn.ttsJobs.some(
         (candidate) =>
-          candidate.held && candidate.started && !candidate.settled,
+          isPendingHeldTtsJob(candidate) &&
+          candidate.started &&
+          !candidate.settled,
       );
       const job = activeTurn.ttsJobs.find(
         (candidate) =>
@@ -6172,46 +6327,73 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       if (!job) {
         return;
       }
-      job.started = true;
-      // The segment's own language override (fixed English fallback text)
-      // wins over the turn's language.
-      const language = job.language ?? activeTurn.language;
-      let synthesis: Promise<void>;
-      try {
-        synthesis = streamTtsAudio({
-          text: job.text,
-          ...(language !== undefined ? { language } : {}),
-          // Either the turn ending or this one segment being retracted stops
-          // the stream; the job's own controller is what lets a retraction
-          // leave the turn's other segments streaming.
-          signal: AbortSignal.any([
-            activeTurn.abortController.signal,
-            job.abort.signal,
-          ]),
-          outputFormat: "pcm",
-          sampleRate: this.context.startFrame.audio.sampleRate,
-          onAudioChunk: (chunk) => {
-            // A retracted job keeps nothing: its buffer was already released
-            // and no promotion will ever flush it.
-            if (!this.isForwardingTts(token) || job.cancelled) {
-              return;
-            }
-            if (job.emitting) {
-              this.forwardTtsChunk(token, job, chunk);
-            } else {
-              job.bufferedChunks.push(chunk);
-            }
-          },
-        }).then(() => undefined);
-      } catch (err) {
-        synthesis = Promise.reject(err);
+      this.startTtsSynthesis(token, job);
+      if (!job.started) {
+        // The session went away underneath the pump; the loop condition
+        // cannot make progress, so stop rather than spin.
+        return;
       }
-      // The job's emission step observes the rejection; this handler only
-      // keeps a failure on an already-cancelled turn from surfacing as an
-      // unhandled rejection.
-      synthesis.catch(() => {});
-      job.synthesis = synthesis;
     }
+  }
+
+  /**
+   * Open one job's provider stream, outside the open-job cap. Callers that are
+   * subject to the cap go through {@link pumpTtsSynthesis}; this is for the
+   * job the emission chain is already waiting on, which must produce audio
+   * whatever the prefetch budget currently looks like.
+   */
+  private startTtsSynthesis(token: symbol, job: TtsSegmentJob): void {
+    const activeTurn = this.activeAssistantTurn;
+    const streamTtsAudio = this.streamTtsAudio;
+    if (
+      activeTurn?.token !== token ||
+      !streamTtsAudio ||
+      activeTurn.abortController.signal.aborted ||
+      this.isClosed ||
+      job.started ||
+      job.cancelled
+    ) {
+      return;
+    }
+    job.started = true;
+    // The segment's own language override (fixed English fallback text)
+    // wins over the turn's language.
+    const language = job.language ?? activeTurn.language;
+    let synthesis: Promise<void>;
+    try {
+      synthesis = streamTtsAudio({
+        text: job.text,
+        ...(language !== undefined ? { language } : {}),
+        // Either the turn ending or this one segment being retracted stops
+        // the stream; the job's own controller is what lets a retraction
+        // leave the turn's other segments streaming.
+        signal: AbortSignal.any([
+          activeTurn.abortController.signal,
+          job.abort.signal,
+        ]),
+        outputFormat: "pcm",
+        sampleRate: this.context.startFrame.audio.sampleRate,
+        onAudioChunk: (chunk) => {
+          // A retracted job keeps nothing: its buffer was already released
+          // and no promotion will ever flush it.
+          if (!this.isForwardingTts(token) || job.cancelled) {
+            return;
+          }
+          if (job.emitting) {
+            this.forwardTtsChunk(token, job, chunk);
+          } else {
+            job.bufferedChunks.push(chunk);
+          }
+        },
+      }).then(() => undefined);
+    } catch (err) {
+      synthesis = Promise.reject(err);
+    }
+    // The job's emission step observes the rejection; this handler only
+    // keeps a failure on an already-cancelled turn from surfacing as an
+    // unhandled rejection.
+    synthesis.catch(() => {});
+    job.synthesis = synthesis;
   }
 
   // Emission slot for one job, run in strict segment order on the turn's
@@ -6238,10 +6420,16 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         return;
       }
 
-      // Both slots can be busy when a job is enqueued; every earlier job has
-      // settled once it reaches the head of the chain, so a slot is free.
+      // Both slots can be busy when a job is enqueued, so a job can arrive
+      // here unstarted. At the head of the chain it is the job that must
+      // produce audio now, and it starts outside the open-job cap rather than
+      // asking the cap for permission: the cap orders prefetch, and jobs that
+      // are NOT ahead of this one on the chain can be holding both slots (a
+      // retracted job whose aborted stream has not torn down, plus a cue). Ask
+      // the pump instead and it would start nothing, leaving `synthesis` null,
+      // and the segment would settle having emitted no audio at all.
       if (!job.started) {
-        this.pumpTtsSynthesis(token);
+        this.startTtsSynthesis(token, job);
       }
 
       // Promote synchronously: no provider callback can land between the
@@ -6303,21 +6491,34 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     if (activeTurn?.token !== token) {
       return;
     }
-    // Only retain the assistant TTS audio when it will be archived (see
-    // collectUserAudio); the mime/sample-rate are cheap and left unconditional.
-    if (this.archiveAudio) {
-      activeTurn.assistantAudioChunks.push(
-        Buffer.from(chunk.dataBase64, "base64"),
-      );
+    // The archive is a recording of what the assistant SAID, so the rendered
+    // cue stays out of it: its bare PCM would interleave with whatever
+    // container a provider returned for the speech around it (some return
+    // audio/wav despite outputFormat "pcm"), and the archived mime would
+    // describe whichever chunk landed last rather than the recording.
+    //
+    // Only retain the audio when it will be archived (see collectUserAudio);
+    // the mime/sample-rate are cheap and left unconditional.
+    if (job.audioRole !== "cue") {
+      if (this.archiveAudio) {
+        activeTurn.assistantAudioChunks.push(
+          Buffer.from(chunk.dataBase64, "base64"),
+        );
+      }
+      activeTurn.assistantAudioMimeType = chunk.contentType;
+      activeTurn.assistantAudioSampleRate = chunk.sampleRate;
     }
-    activeTurn.assistantAudioMimeType = chunk.contentType;
-    activeTurn.assistantAudioSampleRate = chunk.sampleRate;
     job.frames = job.frames.then(async () => {
       const sent = await this.sendFrame(
         {
           type: "tts_audio",
           mimeType: chunk.contentType,
           sampleRate: chunk.sampleRate,
+          // The client latches speaking state, hands-free barge-in
+          // eligibility, client-heard latency, and the spoken-word cursor on
+          // tts_audio frames. An unmarked tone corrupts all four, so say on
+          // the wire that this frame is not speech.
+          ...(job.audioRole === "cue" ? { nonSpeech: true } : {}),
           dataBase64: chunk.dataBase64,
         },
         () => this.isForwardingTts(token),
@@ -6343,13 +6544,13 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       this.appendEchoReference(chunk);
       this.assistantPlaybackTailUntilMs =
         Math.max(now, this.assistantPlaybackTailUntilMs) + chunkMs;
-      // Everything above is what a cue is here for: the client hears it, the
-      // canceller learns it was us, and the tail estimate covers it. The
-      // first-TTS latch is where a cue stops, because that mark is the onset
-      // of the turn's speech (see `nonSpeechCue`).
+      // Everything above is what a cue or a spoken filler is here for: the
+      // client hears it, the canceller learns it was us, and the tail estimate
+      // covers it. The first-TTS latch is where both stop, because that mark
+      // is the onset of the turn's ANSWER (see TtsSegmentAudioRole).
       const turnAfterSend = this.activeAssistantTurn;
       if (
-        job.nonSpeechCue ||
+        job.audioRole !== "answer" ||
         turnAfterSend?.token !== token ||
         turnAfterSend.ttsAudioStarted
       ) {
@@ -6501,6 +6702,14 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     this.metrics.markProgressSpoken(activeTurn.turnId);
   }
 
+  private markWorkingCuePlayed(activeTurn: ActiveAssistantTurn): void {
+    const { utterance } = activeTurn;
+    if (!this.startMetricsTurnIfNeeded(utterance, activeTurn.turnId)) {
+      return;
+    }
+    this.metrics.markWorkingCuePlayed(activeTurn.turnId);
+  }
+
   private ensureTurnId(utterance: UtteranceCycle): string {
     if (!utterance.turnId) {
       utterance.turnId = this.createTurnId();
@@ -6587,6 +6796,18 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
 
     turn.finalized = true;
     this.clearFillerTimers(turn);
+    // Every terminal path owns the turn's held prefetch, not just the two that
+    // remembered to. A held job is off ttsQueue, so completion never awaits
+    // it and nothing else settles it: without a retraction here an errored or
+    // cancelled turn leaves its provider stream open and un-abortable, billing
+    // for audio nobody will hear. The paths that already retracted
+    // (generation_cancelled) or aborted the turn controller (barge-in) find
+    // their jobs cancelled and select nothing.
+    if (status === "cancelled") {
+      this.retractHeldTtsSegmentsOnTurn(turn, (job) => job.held, {
+        discardPendingTail: true,
+      });
+    }
     turn.utterance.completed = true;
     await this.archiveBufferedAudio({
       turnId: turn.turnId,

--- a/assistant/src/live-voice/protocol.ts
+++ b/assistant/src/live-voice/protocol.ts
@@ -8,6 +8,15 @@ import { type ClientOs, parseClientOs } from "../channels/types.js";
 // rejects only values that were never going to be real capture rates.
 const MAX_START_FRAME_SAMPLE_RATE = 192_000;
 
+// Lower bound on the same field. 8 kHz is narrowband telephony, below any
+// capture rate a supported client opens with, and it is the floor that makes
+// every rendered buffer non-degenerate: the working cue's shortest legal
+// duration (1ms) still rounds to whole frames at this rate, so a rendered
+// tone can never come out empty. Without a floor a rate of 1 validates and
+// rounds a cue to zero frames, which is a silent frame on the wire holding the
+// floor for a whole interval.
+const MIN_START_FRAME_SAMPLE_RATE = 8_000;
+
 const LIVE_VOICE_CLIENT_FRAME_TYPES = [
   "start",
   "audio",
@@ -307,6 +316,16 @@ export interface LiveVoiceTtsAudioServerFrame extends LiveVoiceServerFrameBase {
   readonly type: "tts_audio";
   readonly mimeType: string;
   readonly sampleRate: number;
+  /**
+   * Set only on audio that is not speech: today the rendered working cue that
+   * holds the floor while a turn works. Omitted for synthesized speech.
+   *
+   * Clients drive speaking state, hands-free barge-in eligibility,
+   * client-heard latency, and the spoken-word cursor off tts_audio frames.
+   * All four are about what the assistant SAID, so a frame carrying this must
+   * play as audio and count as nothing else.
+   */
+  readonly nonSpeech?: true;
   readonly dataBase64: string;
 }
 
@@ -385,6 +404,13 @@ export interface LiveVoiceMetricsServerFrame extends LiveVoiceServerFrameBase {
    * unchanged).
    */
   readonly progressUpdatesSpoken?: number;
+  /**
+   * Working cues played into the turn's silence. Present only when at least
+   * one played (otherwise the field is absent, keeping frames unchanged).
+   * The cue is the default floor-holder, so this is what separates a turn
+   * that hummed while it worked from one that sat silent.
+   */
+  readonly workingCuesPlayed?: number;
 }
 
 export interface LiveVoiceArchivedServerFrame extends LiveVoiceServerFrameBase {
@@ -847,11 +873,12 @@ function validateAudioConfig(
 
   if (
     !isPositiveInteger(value.sampleRate) ||
+    value.sampleRate < MIN_START_FRAME_SAMPLE_RATE ||
     value.sampleRate > MAX_START_FRAME_SAMPLE_RATE
   ) {
     return protocolError(
       "invalid_field",
-      `start frame audio.sampleRate must be a positive integer no greater than ${MAX_START_FRAME_SAMPLE_RATE}`,
+      `start frame audio.sampleRate must be an integer between ${MIN_START_FRAME_SAMPLE_RATE} and ${MAX_START_FRAME_SAMPLE_RATE}`,
       "audio.sampleRate",
       "start",
     );


### PR DESCRIPTION
## Summary
Fixes found by fresh-eyes review of the feature branch. See the commit body for the full list; the load-bearing ones are a silently dropped answer segment, a retracted job disabling held prefetch for the rest of the turn, the completion sweep speaking the commentary it just dropped, a turn that could end speaking nothing, and marking the working cue on the wire so clients can tell it from speech.

Part of plan: voice-speak-final-answer-only.md (review remediation)