### PR TITLE
feat(ios): restyle the Catch Up widget row list to the mock's spacing

### DIFF
--- a/clients/ios/App/VoiceActivity/Widgets/CatchUpWidget.swift
+++ b/clients/ios/App/VoiceActivity/Widgets/CatchUpWidget.swift
@@ -26,6 +26,7 @@ struct CatchUpWidget: Widget {
         .configurationDisplayName("Catch Up")
         .description("See your most recent Vellum conversations and start a new chat or a voice session.")
         .supportedFamilies([.systemMedium])
+        .contentMarginsDisabled()
     }
 }
 
@@ -41,6 +42,11 @@ struct CatchUpWidgetView: View {
     /// share of the widget, so the rows beside it get every remaining point.
     private static let actionColumnWidth: CGFloat = 71
 
+    /// The widget disables the system content margins and draws this one
+    /// instead: the default margins leave the row list short of the three
+    /// full-height rows it is laid out for.
+    private static let contentMargin: CGFloat = 16
+
     var body: some View {
         HStack(alignment: .top, spacing: 14) {
             VStack(spacing: 7) {
@@ -49,10 +55,11 @@ struct CatchUpWidgetView: View {
             }
             .frame(width: Self.actionColumnWidth)
 
-            VStack(alignment: .leading, spacing: 4) {
+            VStack(alignment: .leading, spacing: 0) {
                 Text("Catch up:")
                     .font(.system(size: 10))
                     .foregroundStyle(WidgetTheme.textSecondary)
+                    .padding(.bottom, 5)
                 if entry.conversations.isEmpty {
                     emptyPrompt
                 } else {
@@ -64,6 +71,7 @@ struct CatchUpWidgetView: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
         }
+        .padding(Self.contentMargin)
     }
 
     /// The row, wrapped in a `Link` when this build declares a URL scheme.
@@ -106,6 +114,11 @@ struct CatchUpRow: View {
     /// about work in flight. See ``SnapshotProvider/staleAfter``.
     let isStale: Bool
 
+    /// Rows sit flush against each other at a fixed height, so the space
+    /// between a title and the next one belongs to the row that owns it
+    /// rather than to a gap the eye has to assign.
+    private static let height: CGFloat = 37
+
     var body: some View {
         HStack(spacing: 7) {
             statusGlyph
@@ -128,7 +141,7 @@ struct CatchUpRow: View {
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.vertical, 3)
+        .frame(height: Self.height)
     }
 
     /// Working beats unread, and staleness beats working.

--- a/clients/ios/App/VoiceActivity/Widgets/CatchUpWidget.swift
+++ b/clients/ios/App/VoiceActivity/Widgets/CatchUpWidget.swift
@@ -44,7 +44,7 @@ struct CatchUpWidgetView: View {
 
     /// The widget disables the system content margins and draws this one
     /// instead: the default margins leave the row list short of the three
-    /// full-height rows it is laid out for.
+    /// rows it is laid out for.
     private static let contentMargin: CGFloat = 16
 
     var body: some View {
@@ -62,16 +62,37 @@ struct CatchUpWidgetView: View {
                     .padding(.bottom, 5)
                 if entry.conversations.isEmpty {
                     emptyPrompt
+                    Spacer(minLength: 0)
                 } else {
-                    ForEach(entry.conversations, id: \.id) { conversation in
-                        linkedRow(for: conversation)
-                    }
+                    rowList
                 }
-                Spacer(minLength: 0)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
         }
         .padding(Self.contentMargin)
+    }
+
+    /// The rows, sized to the space left under the header rather than to a
+    /// fixed height: the medium widget is 148pt tall on a 4.7-inch phone, which
+    /// is too short for three rows at the height the taller phones draw them.
+    private var rowList: some View {
+        GeometryReader { proxy in
+            let height = rowHeight(fitting: proxy.size.height)
+            VStack(alignment: .leading, spacing: 0) {
+                ForEach(entry.conversations, id: \.id) { conversation in
+                    linkedRow(for: conversation, height: height)
+                }
+                Spacer(minLength: 0)
+            }
+        }
+    }
+
+    /// The rows split the available height evenly, capped so a tall widget does
+    /// not stretch them past the height they are designed at, and floored so a
+    /// short one keeps them legible instead of collapsing the subtitle.
+    private func rowHeight(fitting available: CGFloat) -> CGFloat {
+        let share = available / CGFloat(max(1, entry.conversations.count))
+        return min(CatchUpRow.preferredHeight, max(CatchUpRow.minimumHeight, share))
     }
 
     /// The row, wrapped in a `Link` when this build declares a URL scheme.
@@ -81,8 +102,8 @@ struct CatchUpWidgetView: View {
     /// production app), and the titles are still true, so the widget loses a
     /// tap target rather than its content.
     @ViewBuilder
-    private func linkedRow(for conversation: WidgetSnapshotConversation) -> some View {
-        let row = CatchUpRow(conversation: conversation, isStale: entry.isStale)
+    private func linkedRow(for conversation: WidgetSnapshotConversation, height: CGFloat) -> some View {
+        let row = CatchUpRow(conversation: conversation, isStale: entry.isStale, height: height)
         if let url = ThreadDeepLink(threadId: conversation.id).url() {
             Link(destination: url) { row }
         } else {
@@ -114,10 +135,17 @@ struct CatchUpRow: View {
     /// about work in flight. See ``SnapshotProvider/staleAfter``.
     let isStale: Bool
 
-    /// Rows sit flush against each other at a fixed height, so the space
-    /// between a title and the next one belongs to the row that owns it
-    /// rather than to a gap the eye has to assign.
-    private static let height: CGFloat = 37
+    /// Rows sit flush against each other, so the space between a title and the
+    /// next one belongs to the row that owns it rather than to a gap the eye
+    /// has to assign. The owner picks the height from what the widget has room
+    /// for, between ``minimumHeight`` and ``preferredHeight``.
+    let height: CGFloat
+
+    /// The height a row is drawn at when the widget has the room, and the floor
+    /// it stops shrinking at when it does not: below the floor the title and
+    /// subtitle stop clearing their own line heights.
+    static let preferredHeight: CGFloat = 37
+    static let minimumHeight: CGFloat = 31
 
     var body: some View {
         HStack(spacing: 7) {
@@ -141,7 +169,7 @@ struct CatchUpRow: View {
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .frame(height: Self.height)
+        .frame(height: height)
     }
 
     /// Working beats unread, and staleness beats working.


### PR DESCRIPTION
## Summary
- Rows move from ~34pt with 4pt gaps to fixed 37pt contiguous rows with the breathing room inside the row
- The widget owns its 16pt content margins via contentMarginsDisabled instead of inheriting the system default

Part of plan: ios-widgets-v2.md (PR 3 of 7)