### PR TITLE
fix(chat): land the camera deep link on a stable conversation route and consume the park last

### DIFF
--- a/clients/web/src/domains/chat/components/chat-attachments/use-camera-deep-link.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/use-camera-deep-link.test.tsx
@@ -47,6 +47,9 @@ const { useConversationStore } = await import("@/stores/conversation-store");
 
 const onFiles = mock((_files: File[]) => {});
 
+/** The conversation the host below is mounted on, and so the park's address. */
+const HOST_CONVERSATION_ID = "conv-host";
+
 function Host({ enabled }: { enabled: boolean }) {
   const { overlayNode, captureOpen } = useCameraDeepLink({ onFiles, enabled });
   return createElement(
@@ -56,8 +59,17 @@ function Host({ enabled }: { enabled: boolean }) {
   );
 }
 
-const renderCameraDeepLink = (enabled = true) =>
-  render(createElement(Host, { enabled }));
+// The drain reads its conversation off the route, so the host lives on one.
+const hostTree = (enabled: boolean) => (
+  <MemoryRouter initialEntries={[routes.conversation(HOST_CONVERSATION_ID)]}>
+    <Host enabled={enabled} />
+  </MemoryRouter>
+);
+
+const renderCameraDeepLink = (enabled = true) => render(hostTree(enabled));
+
+const parkForHost = () =>
+  usePendingDeepLinkStore.getState().setPendingCamera(HOST_CONVERSATION_ID);
 
 const surface = () => screen.queryByTestId("camera-surface");
 const captureOpen = () =>
@@ -85,13 +97,13 @@ describe("useCameraDeepLink", () => {
   });
 
   test("drains a park made before the composer mounted, the cold-launch case", () => {
-    usePendingDeepLinkStore.getState().setPendingCamera();
+    parkForHost();
 
     renderCameraDeepLink();
 
     expect(surface()).not.toBeNull();
     expect(captureOpen()).toBe("true");
-    expect(usePendingDeepLinkStore.getState().pendingCameraAt).toBeNull();
+    expect(usePendingDeepLinkStore.getState().pendingCamera).toBeNull();
   });
 
   test("drains a park that arrives while already mounted, the warm case", () => {
@@ -99,14 +111,14 @@ describe("useCameraDeepLink", () => {
     expect(surface()).toBeNull();
 
     act(() => {
-      usePendingDeepLinkStore.getState().setPendingCamera();
+      parkForHost();
     });
 
     expect(surface()).not.toBeNull();
   });
 
   test("hands the photo to the composer's attachment pipeline as files", () => {
-    usePendingDeepLinkStore.getState().setPendingCamera();
+    parkForHost();
     renderCameraDeepLink();
 
     const photo = new File([new Uint8Array([1, 2, 3])], "photo-1.jpg", {
@@ -123,7 +135,7 @@ describe("useCameraDeepLink", () => {
   });
 
   test("closing without a photo takes the surface down and attaches nothing", () => {
-    usePendingDeepLinkStore.getState().setPendingCamera();
+    parkForHost();
     renderCameraDeepLink();
 
     act(() => {
@@ -136,31 +148,37 @@ describe("useCameraDeepLink", () => {
   });
 
   test("delivers exactly once: a closed surface does not come back on re-render", () => {
-    usePendingDeepLinkStore.getState().setPendingCamera();
+    parkForHost();
     const { rerender } = renderCameraDeepLink();
 
     act(() => {
       overlayProps?.onClose();
     });
-    rerender(createElement(Host, { enabled: true }));
+    rerender(hostTree(true));
 
     expect(surface()).toBeNull();
   });
 
   test("a park older than the TTL is spent, not acted on: no camera minutes later", () => {
     usePendingDeepLinkStore.setState({
-      pendingCameraAt: Date.now() - PENDING_CAMERA_TTL_MS - 1,
+      pendingCamera: {
+        targetConversationId: HOST_CONVERSATION_ID,
+        parkedAt: Date.now() - PENDING_CAMERA_TTL_MS - 1,
+      },
     });
 
     renderCameraDeepLink();
 
     expect(surface()).toBeNull();
-    expect(usePendingDeepLinkStore.getState().pendingCameraAt).toBeNull();
+    expect(usePendingDeepLinkStore.getState().pendingCamera).toBeNull();
   });
 
   test("a park just inside the TTL still opens the camera", () => {
     usePendingDeepLinkStore.setState({
-      pendingCameraAt: Date.now() - PENDING_CAMERA_TTL_MS + 1_000,
+      pendingCamera: {
+        targetConversationId: HOST_CONVERSATION_ID,
+        parkedAt: Date.now() - PENDING_CAMERA_TTL_MS + 1_000,
+      },
     });
 
     renderCameraDeepLink();
@@ -172,7 +190,7 @@ describe("useCameraDeepLink", () => {
     // The room's viewfinder and this one are two hooks over one native preview
     // layer, so the drain gives way rather than fighting it for the camera.
     useLiveVoiceStore.setState({ state: "listening" });
-    usePendingDeepLinkStore.getState().setPendingCamera();
+    parkForHost();
 
     const { rerender } = renderCameraDeepLink();
 
@@ -180,25 +198,54 @@ describe("useCameraDeepLink", () => {
     expect(captureOpen()).toBe("false");
     // Spent rather than parked: a call outlives the TTL, so a held request
     // would raise a viewfinder long after the tap asked for one.
-    expect(usePendingDeepLinkStore.getState().pendingCameraAt).toBeNull();
+    expect(usePendingDeepLinkStore.getState().pendingCamera).toBeNull();
 
     useLiveVoiceStore.setState({ state: "idle" });
-    rerender(createElement(Host, { enabled: true }));
+    rerender(hostTree(true));
 
     expect(surface()).toBeNull();
   });
 
   test("a disabled composer leaves the park alone for the one that answers it", () => {
-    usePendingDeepLinkStore.getState().setPendingCamera();
+    parkForHost();
 
     const { rerender } = renderCameraDeepLink(false);
 
     expect(surface()).toBeNull();
-    expect(usePendingDeepLinkStore.getState().pendingCameraAt).not.toBeNull();
+    expect(usePendingDeepLinkStore.getState().pendingCamera).not.toBeNull();
 
-    rerender(createElement(Host, { enabled: true }));
+    rerender(hostTree(true));
 
     expect(surface()).not.toBeNull();
+  });
+
+  test("a park addressed to another conversation is left where it is", () => {
+    usePendingDeepLinkStore.getState().setPendingCamera("some-other-conv");
+
+    renderCameraDeepLink();
+
+    expect(surface()).toBeNull();
+    expect(captureOpen()).toBe("false");
+    // Untouched, not spent: the composer it names still has to find it.
+    expect(
+      usePendingDeepLinkStore.getState().pendingCamera?.targetConversationId,
+    ).toBe("some-other-conv");
+  });
+
+  test("a park addressed to another conversation still ages out", () => {
+    // Expiry is not addressed: whichever composer notices a park past its TTL
+    // clears it, so a landing that never happened cannot leave one behind.
+    usePendingDeepLinkStore.setState({
+      pendingCamera: {
+        targetConversationId: "some-other-conv",
+        parkedAt: Date.now() - PENDING_CAMERA_TTL_MS - 1,
+      },
+    });
+
+    renderCameraDeepLink();
+
+    expect(surface()).toBeNull();
+    expect(usePendingDeepLinkStore.getState().pendingCamera).toBeNull();
   });
 });
 
@@ -295,6 +342,33 @@ describe("the camera link across the app's landings", () => {
     expect(useConversationStore.getState().activeConversationId).toBe(
       landedConversationId(),
     );
+  });
+
+  test("the composer on the route being left alone lets the draft's have the park", async () => {
+    // The navigating branch publishes the park while the outgoing route is
+    // still mounted, so a composer sitting on it sees the park first. It must
+    // not take it: the navigation would unmount the viewfinder it raised a beat
+    // later, and the one-shot park would already be gone.
+    renderAt(routes.conversation("A"));
+
+    await act(async () => {
+      usePendingDeepLinkStore.getState().setPendingCamera("draft-B");
+    });
+
+    expect(surface()).toBeNull();
+    expect(landedConversationId()).toBe("A");
+    expect(
+      usePendingDeepLinkStore.getState().pendingCamera?.targetConversationId,
+    ).toBe("draft-B");
+
+    // The landing the deep link was navigating to.
+    await act(async () => {
+      publish("deeplink.openThread", { threadId: "draft-B" });
+    });
+
+    expect(landedConversationId()).toBe("draft-B");
+    expect(surface()).not.toBeNull();
+    expect(usePendingDeepLinkStore.getState().pendingCamera).toBeNull();
   });
 
   test("a second tap does not raise a second camera", async () => {

--- a/clients/web/src/domains/chat/components/chat-attachments/use-camera-deep-link.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/use-camera-deep-link.test.tsx
@@ -1,6 +1,18 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { act, cleanup, render, screen } from "@testing-library/react";
-import { createElement } from "react";
+import { createElement, useEffect } from "react";
+import {
+  MemoryRouter,
+  Outlet,
+  Route,
+  Routes,
+  useNavigate,
+  useParams,
+} from "react-router";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+import { routes } from "@/utils/routes";
 
 // The viewfinder itself is covered by `camera-capture-overlay.test.tsx`; this
 // suite is about the park-and-drain that raises it, so the surface is stubbed
@@ -22,14 +34,16 @@ mock.module(
   }),
 );
 
-const { PENDING_CAMERA_TTL_MS, useCameraDeepLink } = await import(
-  "@/domains/chat/components/chat-attachments/use-camera-deep-link"
-);
+const { PENDING_CAMERA_TTL_MS, useCameraDeepLink } =
+  await import("@/domains/chat/components/chat-attachments/use-camera-deep-link");
 const { __resetPendingDeepLinkForTesting, usePendingDeepLinkStore } =
   await import("@/stores/pending-deep-link-store");
-const { useLiveVoiceStore } = await import(
-  "@/domains/chat/voice/live-voice/live-voice-store"
-);
+const { useLiveVoiceStore } =
+  await import("@/domains/chat/voice/live-voice/live-voice-store");
+const { useGlobalDeepLinkConsumer } =
+  await import("@/hooks/use-global-deep-link-consumer");
+const { __resetForTesting, publish } = await import("@/lib/event-bus");
+const { useConversationStore } = await import("@/stores/conversation-store");
 
 const onFiles = mock((_files: File[]) => {});
 
@@ -185,5 +199,113 @@ describe("useCameraDeepLink", () => {
     rerender(createElement(Host, { enabled: true }));
 
     expect(surface()).not.toBeNull();
+  });
+});
+
+/**
+ * The camera link end to end, over a route tree shaped like the real one.
+ *
+ * The bare `/assistant` index is the trap: `useConversationLoader` replace
+ * navigates off it to a conversation key the moment it mounts, which swaps the
+ * leaf element and remounts the composer. The overlay lives in composer-local
+ * state, so a link that lands there raises a viewfinder and loses it a beat
+ * later. `LoaderIndex` below is that redirect, so any landing that touches the
+ * index fails these tests the way it fails on a phone.
+ */
+describe("the camera link across the app's landings", () => {
+  function LoaderIndex() {
+    const navigate = useNavigate();
+    useEffect(() => {
+      void navigate(routes.conversation("loaded-1"), { replace: true });
+    }, [navigate]);
+    return null;
+  }
+
+  function ComposerRoute() {
+    const { conversationId } = useParams();
+    const { overlayNode } = useCameraDeepLink({ onFiles, enabled: true });
+    return (
+      <div data-testid="composer" data-conversation-id={conversationId}>
+        {overlayNode}
+      </div>
+    );
+  }
+
+  function Shell() {
+    useGlobalDeepLinkConsumer();
+    return <Outlet />;
+  }
+
+  const renderAt = (initialPath: string) =>
+    render(
+      <QueryClientProvider
+        client={
+          new QueryClient({ defaultOptions: { queries: { retry: false } } })
+        }
+      >
+        <MemoryRouter initialEntries={[initialPath]}>
+          <Routes>
+            <Route path={routes.assistant} element={<Shell />}>
+              <Route index element={<LoaderIndex />} />
+              <Route
+                path="conversations/:conversationId"
+                element={<ComposerRoute />}
+              />
+              <Route path="settings" element={<div />} />
+            </Route>
+          </Routes>
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+  const landedConversationId = () =>
+    screen.getByTestId("composer").getAttribute("data-conversation-id");
+
+  beforeEach(() => {
+    __resetForTesting();
+    useConversationStore.getState().reset();
+  });
+
+  afterEach(() => {
+    __resetForTesting();
+    useConversationStore.getState().reset();
+  });
+
+  test("a tap with the composer already up keeps the conversation and the viewfinder", async () => {
+    renderAt(routes.conversation("A"));
+
+    await act(async () => {
+      publish("deeplink.openCamera", { provenance: "intent" });
+    });
+
+    expect(surface()).not.toBeNull();
+    expect(landedConversationId()).toBe("A");
+  });
+
+  test("a tap from elsewhere opens the camera on a fresh conversation", async () => {
+    renderAt(`${routes.assistant}/settings`);
+
+    await act(async () => {
+      publish("deeplink.openCamera", { provenance: "intent" });
+    });
+
+    expect(surface()).not.toBeNull();
+    // The draft the link minted, not the key the index route redirects to.
+    expect(landedConversationId()).not.toBe("loaded-1");
+    expect(useConversationStore.getState().activeConversationId).toBe(
+      landedConversationId(),
+    );
+  });
+
+  test("a second tap does not raise a second camera", async () => {
+    renderAt(routes.conversation("A"));
+
+    await act(async () => {
+      publish("deeplink.openCamera", { provenance: "intent" });
+      publish("deeplink.openCamera", { provenance: "intent" });
+    });
+
+    expect(screen.getAllByTestId("camera-surface")).toHaveLength(1);
+    expect(landedConversationId()).toBe("A");
   });
 });

--- a/clients/web/src/domains/chat/components/chat-attachments/use-camera-deep-link.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/use-camera-deep-link.tsx
@@ -70,13 +70,14 @@ export function useCameraDeepLink({
     if (!enabled || pendingCameraAt === null) {
       return;
     }
-    // Consumed whatever the age: an expired park is spent, not left to be
-    // drained by a later mount.
-    if (
-      !usePendingDeepLinkStore
+    const consume = () =>
+      usePendingDeepLinkStore
         .getState()
-        .consumePendingCamera(PENDING_CAMERA_TTL_MS)
-    ) {
+        .consumePendingCamera(PENDING_CAMERA_TTL_MS);
+    // Spent whatever the age: an expired park is not left behind for a later
+    // mount to drain.
+    if (Date.now() - pendingCameraAt > PENDING_CAMERA_TTL_MS) {
+      consume();
       return;
     }
     // A running call owns the camera. `useVoiceCamera` is a hook over one
@@ -94,9 +95,14 @@ export function useCameraDeepLink({
     // open": nothing publishes the latter, since it lives in the room's own
     // `useVoiceCamera` instance.
     if (isLiveVoiceSessionActive(useLiveVoiceStore.getState().state)) {
+      consume();
       return;
     }
+    // Consumed last, after the surface is actually raised: everything above is
+    // a reason to spend the request deliberately, and nothing between here and
+    // the park can fail with the command silently gone.
     setCaptureOpen(true);
+    consume();
   }, [enabled, pendingCameraAt]);
 
   const closeCapture = useCallback(() => setCaptureOpen(false), []);

--- a/clients/web/src/domains/chat/components/chat-attachments/use-camera-deep-link.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/use-camera-deep-link.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import { useCallback, useEffect, useState } from "react";
+import { useLocation } from "react-router";
 
 import { CameraCaptureOverlay } from "@/domains/chat/components/chat-attachments/camera-capture-overlay";
 import {
@@ -7,6 +8,7 @@ import {
   useLiveVoiceStore,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
 import { usePendingDeepLinkStore } from "@/stores/pending-deep-link-store";
+import { conversationIdForPath } from "@/utils/routes";
 
 /**
  * How long a parked camera request stays live.
@@ -30,7 +32,8 @@ interface UseCameraDeepLinkOptions {
    * and a one-shot park would otherwise be spent by whichever mounted first.
    * One `ChatMainPanel` is on screen at a time (its two layout branches, the
    * app-editing split and the plain chat, are mutually exclusive), so that
-   * gate leaves exactly one taker.
+   * gate leaves exactly one taker. The park's address tells composers on
+   * different routes apart; this tells apart the two that share one.
    */
   enabled: boolean;
 }
@@ -58,16 +61,27 @@ interface UseCameraDeepLinkResult {
  * answered too. The consume is one-shot, so a re-render cannot replay it, and a
  * drain landing during a live-voice call spends the request without raising
  * anything: the call owns the one camera layer.
+ *
+ * A park names the conversation it is for, and this only drains one addressed
+ * to the route it is mounted on. Without that, a composer on the route a tap is
+ * navigating *away* from spends the park on a viewfinder its own unmount takes
+ * down, and the composer the tap was for finds nothing waiting.
  */
 export function useCameraDeepLink({
   onFiles,
   enabled,
 }: UseCameraDeepLinkOptions): UseCameraDeepLinkResult {
   const [captureOpen, setCaptureOpen] = useState(false);
-  const pendingCameraAt = usePendingDeepLinkStore.use.pendingCameraAt();
+  const pendingCamera = usePendingDeepLinkStore.use.pendingCamera();
+  // The conversation this composer is bound to, read off the route rather than
+  // off the active conversation in the store. The store's id is set to the
+  // draft *before* the router leaves the old route, so every mounted composer
+  // would answer to it; the route is the one thing that still tells the
+  // outgoing composer apart from the one being navigated to.
+  const routeConversationId = conversationIdForPath(useLocation().pathname);
 
   useEffect(() => {
-    if (!enabled || pendingCameraAt === null) {
+    if (!enabled || pendingCamera === null) {
       return;
     }
     const consume = () =>
@@ -76,8 +90,14 @@ export function useCameraDeepLink({
         .consumePendingCamera(PENDING_CAMERA_TTL_MS);
     // Spent whatever the age: an expired park is not left behind for a later
     // mount to drain.
-    if (Date.now() - pendingCameraAt > PENDING_CAMERA_TTL_MS) {
+    if (Date.now() - pendingCamera.parkedAt > PENDING_CAMERA_TTL_MS) {
       consume();
+      return;
+    }
+    // Addressed to some other conversation: left parked, untouched, for the
+    // composer it names. Spending it here would cost the command outright,
+    // since the park is one-shot.
+    if (pendingCamera.targetConversationId !== routeConversationId) {
       return;
     }
     // A running call owns the camera. `useVoiceCamera` is a hook over one
@@ -103,7 +123,7 @@ export function useCameraDeepLink({
     // the park can fail with the command silently gone.
     setCaptureOpen(true);
     consume();
-  }, [enabled, pendingCameraAt]);
+  }, [enabled, pendingCamera, routeConversationId]);
 
   const closeCapture = useCallback(() => setCaptureOpen(false), []);
 

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -261,7 +261,10 @@ mock.module("react-router", () => ({
   useNavigate: () => navigateSpy,
   // The composer captures pop-out mode once at mount from the URL search
   // string; a plain window (no `?popout=1`) is the default test context.
-  useLocation: () => ({ search: "" }),
+  // `pathname` is what the camera deep link's drain reads to know which
+  // conversation it is bound to; the assistant index names none, which is the
+  // honest stand-in for a composer rendered outside the route tree.
+  useLocation: () => ({ pathname: "/assistant", search: "" }),
 }));
 
 // "Add to chat" sheet, kept for the Android shell. Stubbed to a probe that

--- a/clients/web/src/hooks/use-global-deep-link-consumer.test.tsx
+++ b/clients/web/src/hooks/use-global-deep-link-consumer.test.tsx
@@ -1062,7 +1062,6 @@ describe("deeplink.openCamera", () => {
     });
 
     expect(ensureMainWindowVisibleMock).toHaveBeenCalledTimes(1);
-    expect(usePendingDeepLinkStore.getState().pendingCameraAt).not.toBeNull();
     // The index route replace-navigates off itself, remounting the composer
     // that holds the open viewfinder in local state.
     expect(navigateMock).not.toHaveBeenCalledWith(routes.assistant);
@@ -1073,6 +1072,11 @@ describe("deeplink.openCamera", () => {
       useConversationStore.getState().draftConversationIds.has(draftId),
     ).toBe(true);
     expect(useConversationStore.getState().activeConversationId).toBe(draftId);
+    // Addressed to the draft it navigated to, so a composer still mounted on
+    // the outgoing route cannot spend the one-shot park on its way out.
+    expect(
+      usePendingDeepLinkStore.getState().pendingCamera?.targetConversationId,
+    ).toBe(draftId);
   });
 
   test("a composer already on screen keeps its conversation: the tap navigates nowhere", () => {
@@ -1083,7 +1087,9 @@ describe("deeplink.openCamera", () => {
       publish("deeplink.openCamera", { provenance: "intent" });
     });
 
-    expect(usePendingDeepLinkStore.getState().pendingCameraAt).not.toBeNull();
+    expect(
+      usePendingDeepLinkStore.getState().pendingCamera?.targetConversationId,
+    ).toBe("conv-1");
     expect(navigateMock).not.toHaveBeenCalled();
   });
 
@@ -1097,7 +1103,9 @@ describe("deeplink.openCamera", () => {
     });
 
     expect(useViewerStore.getState().mainView).toBe("chat");
-    expect(usePendingDeepLinkStore.getState().pendingCameraAt).not.toBeNull();
+    expect(
+      usePendingDeepLinkStore.getState().pendingCamera?.targetConversationId,
+    ).toBe("conv-1");
     expect(navigateMock).not.toHaveBeenCalled();
   });
 
@@ -1123,7 +1131,9 @@ describe("deeplink.openCamera", () => {
       expect(useConversationStore.getState().editingConversationId).toBe(
         "conv-1",
       );
-      expect(usePendingDeepLinkStore.getState().pendingCameraAt).not.toBeNull();
+      expect(
+        usePendingDeepLinkStore.getState().pendingCamera?.targetConversationId,
+      ).toBe("conv-1");
       expect(navigateMock).not.toHaveBeenCalled();
     } finally {
       restoreViewport();
@@ -1151,15 +1161,16 @@ describe("deeplink.openCamera", () => {
     act(() => {
       publish("deeplink.openCamera", { provenance: null });
     });
-    const first = usePendingDeepLinkStore.getState().pendingCameraAt;
+    const first = usePendingDeepLinkStore.getState().pendingCamera;
     act(() => {
       publish("deeplink.openCamera", { provenance: "intent" });
     });
-    const second = usePendingDeepLinkStore.getState().pendingCameraAt;
+    const second = usePendingDeepLinkStore.getState().pendingCamera;
 
     expect(first).not.toBeNull();
     expect(second).not.toBeNull();
-    expect(second!).toBeGreaterThanOrEqual(first!);
+    expect(second!.targetConversationId).toBe("conv-1");
+    expect(second!.parkedAt).toBeGreaterThanOrEqual(first!.parkedAt);
     expect(navigateMock).not.toHaveBeenCalled();
   });
 });

--- a/clients/web/src/hooks/use-global-deep-link-consumer.test.tsx
+++ b/clients/web/src/hooks/use-global-deep-link-consumer.test.tsx
@@ -1054,7 +1054,7 @@ describe("deeplink.newChat", () => {
 });
 
 describe("deeplink.openCamera", () => {
-  test("parks the request and lands on /assistant, where the composer that owns the camera mounts", () => {
+  test("parks the request and mints a draft to land on, never the bouncing /assistant index", () => {
     renderConsumer();
 
     act(() => {
@@ -1062,11 +1062,47 @@ describe("deeplink.openCamera", () => {
     });
 
     expect(ensureMainWindowVisibleMock).toHaveBeenCalledTimes(1);
-    expect(navigateMock).toHaveBeenCalledWith(routes.assistant);
     expect(usePendingDeepLinkStore.getState().pendingCameraAt).not.toBeNull();
+    // The index route replace-navigates off itself, remounting the composer
+    // that holds the open viewfinder in local state.
+    expect(navigateMock).not.toHaveBeenCalledWith(routes.assistant);
+    const [to] = navigateMock.mock.calls.at(-1) as [string];
+    expect(to).toMatch(/^\/assistant\/conversations\/[^/?]+$/);
+    const draftId = to.split("/").at(-1)!;
+    expect(
+      useConversationStore.getState().draftConversationIds.has(draftId),
+    ).toBe(true);
+    expect(useConversationStore.getState().activeConversationId).toBe(draftId);
+  });
+
+  test("a composer already on screen keeps its conversation: the tap navigates nowhere", () => {
+    mockPathname = routes.conversation("conv-1");
+    renderConsumer();
+
+    act(() => {
+      publish("deeplink.openCamera", { provenance: "intent" });
+    });
+
+    expect(usePendingDeepLinkStore.getState().pendingCameraAt).not.toBeNull();
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  test("a conversation subroute has no composer, so the tap lands on one", () => {
+    const inspector = `${routes.conversation("conv-1")}/inspect`;
+    mockPathname = inspector;
+    renderConsumer();
+
+    act(() => {
+      publish("deeplink.openCamera", { provenance: "intent" });
+    });
+
+    const [to] = navigateMock.mock.calls.at(-1) as [string];
+    expect(to).toMatch(/^\/assistant\/conversations\/[^/?]+$/);
+    expect(to).not.toBe(inspector);
   });
 
   test("a second tap refreshes the park rather than queueing a second camera", () => {
+    mockPathname = routes.conversation("conv-1");
     renderConsumer();
 
     act(() => {
@@ -1081,6 +1117,7 @@ describe("deeplink.openCamera", () => {
     expect(first).not.toBeNull();
     expect(second).not.toBeNull();
     expect(second!).toBeGreaterThanOrEqual(first!);
+    expect(navigateMock).not.toHaveBeenCalled();
   });
 });
 

--- a/clients/web/src/hooks/use-global-deep-link-consumer.test.tsx
+++ b/clients/web/src/hooks/use-global-deep-link-consumer.test.tsx
@@ -1079,7 +1079,7 @@ describe("deeplink.openCamera", () => {
     ).toBe(draftId);
   });
 
-  test("a composer already on screen keeps its conversation: the tap navigates nowhere", () => {
+  test("a composer already on screen keeps its conversation: the tap re-lands on it", () => {
     mockPathname = routes.conversation("conv-1");
     renderConsumer();
 
@@ -1090,7 +1090,11 @@ describe("deeplink.openCamera", () => {
     expect(
       usePendingDeepLinkStore.getState().pendingCamera?.targetConversationId,
     ).toBe("conv-1");
-    expect(navigateMock).not.toHaveBeenCalled();
+    // The replace re-navigation is a no-op at rest and cancels an in-flight
+    // transition away from the conversation the park is addressed to.
+    expect(navigateMock).toHaveBeenCalledWith(routes.conversation("conv-1"), {
+      replace: true,
+    });
   });
 
   test("reveals the chat behind a full-screen app viewer, which mounts no composer to drain the park", () => {
@@ -1106,7 +1110,9 @@ describe("deeplink.openCamera", () => {
     expect(
       usePendingDeepLinkStore.getState().pendingCamera?.targetConversationId,
     ).toBe("conv-1");
-    expect(navigateMock).not.toHaveBeenCalled();
+    expect(navigateMock).toHaveBeenCalledWith(routes.conversation("conv-1"), {
+      replace: true,
+    });
   });
 
   test("keeps a loaded app in the side-by-side layout, where the composer is mounted beside it", () => {
@@ -1134,7 +1140,9 @@ describe("deeplink.openCamera", () => {
       expect(
         usePendingDeepLinkStore.getState().pendingCamera?.targetConversationId,
       ).toBe("conv-1");
-      expect(navigateMock).not.toHaveBeenCalled();
+      expect(navigateMock).toHaveBeenCalledWith(routes.conversation("conv-1"), {
+        replace: true,
+      });
     } finally {
       restoreViewport();
     }
@@ -1171,7 +1179,9 @@ describe("deeplink.openCamera", () => {
     expect(second).not.toBeNull();
     expect(second!.targetConversationId).toBe("conv-1");
     expect(second!.parkedAt).toBeGreaterThanOrEqual(first!.parkedAt);
-    expect(navigateMock).not.toHaveBeenCalled();
+    for (const call of navigateMock.mock.calls) {
+      expect(call).toEqual([routes.conversation("conv-1"), { replace: true }]);
+    }
   });
 });
 

--- a/clients/web/src/hooks/use-global-deep-link-consumer.test.tsx
+++ b/clients/web/src/hooks/use-global-deep-link-consumer.test.tsx
@@ -41,15 +41,19 @@ import { stubViewportAxes } from "@/hooks/viewport-axes.test-helper";
  * route the deep link actually landed on* rather than at a hand-written path.
  */
 let mockPathname: string = routes.assistant;
-const navigateMock = mock((to: string) => {
-  mockPathname = to.split("?")[0] ?? to;
-  return undefined;
-});
+let mockSearch = "";
+const navigateMock = mock(
+  (to: string | { pathname: string; search?: string; hash?: string }) => {
+    const path = typeof to === "string" ? to : to.pathname;
+    mockPathname = path.split("?")[0] ?? path;
+    return undefined;
+  },
+);
 mock.module("react-router", () => ({
   useNavigate: () => navigateMock,
   // Empty `search` is the main window — the room's pop-out gate
   // (`isPopoutWindow`) looks for `popout=1`.
-  useLocation: () => ({ pathname: mockPathname, search: "" }),
+  useLocation: () => ({ pathname: mockPathname, search: mockSearch, hash: "" }),
 }));
 
 const ensureMainWindowVisibleMock = mock(async () => undefined);
@@ -140,6 +144,7 @@ beforeEach(() => {
   __resetPendingDeepLinkForTesting();
   __resetConnectDialogForTesting();
   mockPathname = routes.assistant;
+  mockSearch = "";
   queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
@@ -1092,9 +1097,10 @@ describe("deeplink.openCamera", () => {
     ).toBe("conv-1");
     // The replace re-navigation is a no-op at rest and cancels an in-flight
     // transition away from the conversation the park is addressed to.
-    expect(navigateMock).toHaveBeenCalledWith(routes.conversation("conv-1"), {
-      replace: true,
-    });
+    expect(navigateMock).toHaveBeenCalledWith(
+      { pathname: routes.conversation("conv-1"), search: "", hash: "" },
+      { replace: true },
+    );
   });
 
   test("reveals the chat behind a full-screen app viewer, which mounts no composer to drain the park", () => {
@@ -1110,9 +1116,10 @@ describe("deeplink.openCamera", () => {
     expect(
       usePendingDeepLinkStore.getState().pendingCamera?.targetConversationId,
     ).toBe("conv-1");
-    expect(navigateMock).toHaveBeenCalledWith(routes.conversation("conv-1"), {
-      replace: true,
-    });
+    expect(navigateMock).toHaveBeenCalledWith(
+      { pathname: routes.conversation("conv-1"), search: "", hash: "" },
+      { replace: true },
+    );
   });
 
   test("keeps a loaded app in the side-by-side layout, where the composer is mounted beside it", () => {
@@ -1140,9 +1147,10 @@ describe("deeplink.openCamera", () => {
       expect(
         usePendingDeepLinkStore.getState().pendingCamera?.targetConversationId,
       ).toBe("conv-1");
-      expect(navigateMock).toHaveBeenCalledWith(routes.conversation("conv-1"), {
-        replace: true,
-      });
+      expect(navigateMock).toHaveBeenCalledWith(
+        { pathname: routes.conversation("conv-1"), search: "", hash: "" },
+        { replace: true },
+      );
     } finally {
       restoreViewport();
     }
@@ -1180,8 +1188,30 @@ describe("deeplink.openCamera", () => {
     expect(second!.targetConversationId).toBe("conv-1");
     expect(second!.parkedAt).toBeGreaterThanOrEqual(first!.parkedAt);
     for (const call of navigateMock.mock.calls) {
-      expect(call).toEqual([routes.conversation("conv-1"), { replace: true }]);
+      expect(call).toEqual([
+        { pathname: routes.conversation("conv-1"), search: "", hash: "" },
+        { replace: true },
+      ]);
     }
+  });
+
+  test("the re-landing keeps the query string, so pending query effects survive", () => {
+    mockPathname = routes.conversation("conv-1");
+    mockSearch = "?prompt=hello";
+    renderConsumer();
+
+    act(() => {
+      publish("deeplink.openCamera", { provenance: "intent" });
+    });
+
+    expect(navigateMock).toHaveBeenCalledWith(
+      {
+        pathname: routes.conversation("conv-1"),
+        search: "?prompt=hello",
+        hash: "",
+      },
+      { replace: true },
+    );
   });
 });
 

--- a/clients/web/src/hooks/use-global-deep-link-consumer.test.tsx
+++ b/clients/web/src/hooks/use-global-deep-link-consumer.test.tsx
@@ -1087,6 +1087,49 @@ describe("deeplink.openCamera", () => {
     expect(navigateMock).not.toHaveBeenCalled();
   });
 
+  test("reveals the chat behind a full-screen app viewer, which mounts no composer to drain the park", () => {
+    mockPathname = routes.conversation("conv-1");
+    useViewerStore.setState({ mainView: "app" });
+    renderConsumer();
+
+    act(() => {
+      publish("deeplink.openCamera", { provenance: "intent" });
+    });
+
+    expect(useViewerStore.getState().mainView).toBe("chat");
+    expect(usePendingDeepLinkStore.getState().pendingCameraAt).not.toBeNull();
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  test("keeps a loaded app in the side-by-side layout, where the composer is mounted beside it", () => {
+    const restoreViewport = stubViewportAxes({
+      narrow: false,
+      coarsePointer: false,
+    });
+    mockPathname = routes.conversation("conv-1");
+    useViewerStore.setState({
+      mainView: "app",
+      activeAppId: "app-1",
+      openedAppState: { appId: "app-1", name: "My App", html: "<h1>hi</h1>" },
+    });
+    renderConsumer();
+
+    try {
+      act(() => {
+        publish("deeplink.openCamera", { provenance: null });
+      });
+
+      expect(useViewerStore.getState().mainView).toBe("app-editing");
+      expect(useConversationStore.getState().editingConversationId).toBe(
+        "conv-1",
+      );
+      expect(usePendingDeepLinkStore.getState().pendingCameraAt).not.toBeNull();
+      expect(navigateMock).not.toHaveBeenCalled();
+    } finally {
+      restoreViewport();
+    }
+  });
+
   test("a conversation subroute has no composer, so the tap lands on one", () => {
     const inspector = `${routes.conversation("conv-1")}/inspect`;
     mockPathname = inspector;

--- a/clients/web/src/hooks/use-global-deep-link-consumer.ts
+++ b/clients/web/src/hooks/use-global-deep-link-consumer.ts
@@ -149,7 +149,7 @@ function connectGuidanceMessage(url: string | null): string {
 
 export function useGlobalDeepLinkConsumer(): void {
   const navigate = useNavigate();
-  const { pathname } = useLocation();
+  const { pathname, search, hash } = useLocation();
   const queryClient = useQueryClient();
   const navigateRef = useRef(navigate);
   useLayoutEffect(() => {
@@ -327,8 +327,12 @@ export function useGlobalDeepLinkConsumer(): void {
       revealConversationView(settledId);
       // Re-navigating to the settled conversation is a no-op when the router
       // is at rest, and cancels any in-flight transition away from it that
-      // would otherwise unmount the composer this park is addressed to.
-      navigateRef.current(routes.conversation(settledId), { replace: true });
+      // would otherwise unmount the composer this park is addressed to. The
+      // search and hash ride along so pending query-driven effects survive.
+      navigateRef.current(
+        { pathname: routes.conversation(settledId), search, hash },
+        { replace: true },
+      );
       targetId = settledId;
     } else {
       targetId = navigateToNewConversation(navigateRef.current, {

--- a/clients/web/src/hooks/use-global-deep-link-consumer.ts
+++ b/clients/web/src/hooks/use-global-deep-link-consumer.ts
@@ -60,10 +60,11 @@ import { conversationIdForPath, routes } from "@/utils/routes";
  *   way. See below.
  * - `deeplink.newChat` → `ensureMainWindowVisible()` +
  *   `navigateToNewConversation()`, the Home Screen widgets' New Chat button.
- * - `deeplink.openCamera` → `ensureMainWindowVisible()` + park the request in
- *   `usePendingDeepLinkStore` for the composer's attachment layer to drain
- *   (`useCameraDeepLink`), then reveal the chat and stay put on a conversation
- *   route, or land on a fresh draft from anywhere else.
+ * - `deeplink.openCamera` → `ensureMainWindowVisible()`, then reveal the chat
+ *   and stay put on a conversation route, or land on a fresh draft from
+ *   anywhere else, and park the request in `usePendingDeepLinkStore` addressed
+ *   to whichever conversation that was, for its composer's attachment layer to
+ *   drain (`useCameraDeepLink`).
  * - `deeplink.connect` → `ensureMainWindowVisible()` + park the request
  *   in the connect-dialog store + navigate to the assistant chooser,
  *   which opens its Connect a Remote Assistant dialog off that store: a
@@ -316,17 +317,26 @@ export function useGlobalDeepLinkConsumer(): void {
   // and not for a new chat's flourish.
   useBusSubscription("deeplink.openCamera", () => {
     void ensureMainWindowVisible();
-    usePendingDeepLinkStore.getState().setPendingCamera();
     // A named conversation only. The `/assistant` index mounts a composer too,
     // but `useConversationLoader` replace-navigates off it to a conversation
     // key on arrival, so a composer mounted there is remounted a beat later and
     // anything it holds in local state goes with it.
     const settledId = conversationIdForPath(pathname);
+    let targetId: string;
     if (settledId !== null) {
       revealConversationView(settledId);
-      return;
+      targetId = settledId;
+    } else {
+      targetId = navigateToNewConversation(navigateRef.current, {
+        silent: true,
+      });
     }
-    navigateToNewConversation(navigateRef.current, { silent: true });
+    // Addressed to the conversation the tap lands on rather than broadcast to
+    // whichever composer wakes first. The draft branch above has only *started*
+    // its route transition, so a composer on the outgoing route is still
+    // mounted and would otherwise spend this one-shot park on a viewfinder the
+    // navigation takes down with it, leaving the draft's composer nothing.
+    usePendingDeepLinkStore.getState().setPendingCamera(targetId);
   });
 
   useBusSubscription(

--- a/clients/web/src/hooks/use-global-deep-link-consumer.ts
+++ b/clients/web/src/hooks/use-global-deep-link-consumer.ts
@@ -62,8 +62,8 @@ import { isConversationChatPath, routes } from "@/utils/routes";
  *   `navigateToNewConversation()`, the Home Screen widgets' New Chat button.
  * - `deeplink.openCamera` → `ensureMainWindowVisible()` + park the request in
  *   `usePendingDeepLinkStore` for the composer's attachment layer to drain
- *   (`useCameraDeepLink`), then stay put on a conversation route or land on a
- *   fresh draft from anywhere else.
+ *   (`useCameraDeepLink`), then reveal the chat and stay put on a conversation
+ *   route, or land on a fresh draft from anywhere else.
  * - `deeplink.connect` → `ensureMainWindowVisible()` + park the request
  *   in the connect-dialog store + navigate to the assistant chooser,
  *   which opens its Connect a Remote Assistant dialog off that store: a
@@ -147,17 +147,20 @@ function connectGuidanceMessage(url: string | null): string {
 }
 
 /**
- * Whether `pathname` is a route whose composer stays mounted where it is. The
- * `/assistant` index, which {@link isConversationChatPath} accepts, is
- * deliberately excluded: `useConversationLoader` replace-navigates off it to a
- * conversation key on arrival, so a composer mounted there is remounted a beat
- * later and anything it holds in local state goes with it.
+ * The conversation `pathname` is settled on, or `null` when it is not a route
+ * whose composer stays mounted where it is. The `/assistant` index, which
+ * {@link isConversationChatPath} accepts, is deliberately excluded:
+ * `useConversationLoader` replace-navigates off it to a conversation key on
+ * arrival, so a composer mounted there is remounted a beat later and anything
+ * it holds in local state goes with it.
  */
-function isSettledConversationPath(pathname: string): boolean {
-  return (
-    pathname.startsWith(`${routes.conversations}/`) &&
-    isConversationChatPath(pathname)
-  );
+function settledConversationId(pathname: string): string | null {
+  const prefix = `${routes.conversations}/`;
+  if (!pathname.startsWith(prefix) || !isConversationChatPath(pathname)) {
+    return null;
+  }
+  // `isConversationChatPath` already bounded this to one non-empty segment.
+  return pathname.slice(prefix.length).replace(/\/+$/, "");
 }
 
 export function useGlobalDeepLinkConsumer(): void {
@@ -316,15 +319,24 @@ export function useGlobalDeepLinkConsumer(): void {
   // the request is parked in the same one-shot inbox the voice start uses and
   // the composer drains it when it mounts (`useCameraDeepLink`).
   //
-  // The landing has to be a route the composer *stays* mounted on. A composer
-  // already on screen keeps the photo in the conversation the user is looking
-  // at, so the tap navigates nowhere; from anywhere else it lands on a fresh
-  // draft, the same registered-draft landing the New Chat button gets, silent
-  // because the tap was for the camera and not for a new chat's flourish.
+  // The landing has to be a route the composer *stays* mounted on, and a view
+  // that mounts one at all. A composer already on screen keeps the photo in the
+  // conversation the user is looking at, so the tap navigates nowhere and only
+  // reveals the chat, which the full-screen app viewer would otherwise be
+  // holding with `ChatMainPanel` swapped out (`ChatContentLayout`): the park
+  // would sit there with no consumer, the tap would read as doing nothing, and
+  // the camera would open by itself whenever the app was dismissed inside the
+  // TTL. `revealConversationView` is the reveal `navigateToNewConversation`
+  // runs below, so an app open beside the chat is kept either way. From
+  // anywhere else the tap lands on a fresh draft, the same registered-draft
+  // landing the New Chat button gets, silent because the tap was for the camera
+  // and not for a new chat's flourish.
   useBusSubscription("deeplink.openCamera", () => {
     void ensureMainWindowVisible();
     usePendingDeepLinkStore.getState().setPendingCamera();
-    if (isSettledConversationPath(pathname)) {
+    const settledId = settledConversationId(pathname);
+    if (settledId !== null) {
+      revealConversationView(settledId);
       return;
     }
     navigateToNewConversation(navigateRef.current, { silent: true });

--- a/clients/web/src/hooks/use-global-deep-link-consumer.ts
+++ b/clients/web/src/hooks/use-global-deep-link-consumer.ts
@@ -22,7 +22,7 @@ import {
   navigateToNewConversation,
   revealConversationView,
 } from "@/utils/conversation-navigation";
-import { isConversationChatPath, routes } from "@/utils/routes";
+import { conversationIdForPath, routes } from "@/utils/routes";
 
 /**
  * Global deep-link consumer — mounted at `RootLayout` so it's alive
@@ -144,23 +144,6 @@ function connectGuidanceMessage(url: string | null): string {
       ? "the assistant's machine"
       : `the assistant's machine at ${host}`;
   return `This link came from a pairing QR code. To connect this Mac, run vellum pair on ${machine} and paste the bundle here.`;
-}
-
-/**
- * The conversation `pathname` is settled on, or `null` when it is not a route
- * whose composer stays mounted where it is. The `/assistant` index, which
- * {@link isConversationChatPath} accepts, is deliberately excluded:
- * `useConversationLoader` replace-navigates off it to a conversation key on
- * arrival, so a composer mounted there is remounted a beat later and anything
- * it holds in local state goes with it.
- */
-function settledConversationId(pathname: string): string | null {
-  const prefix = `${routes.conversations}/`;
-  if (!pathname.startsWith(prefix) || !isConversationChatPath(pathname)) {
-    return null;
-  }
-  // `isConversationChatPath` already bounded this to one non-empty segment.
-  return pathname.slice(prefix.length).replace(/\/+$/, "");
 }
 
 export function useGlobalDeepLinkConsumer(): void {
@@ -334,7 +317,11 @@ export function useGlobalDeepLinkConsumer(): void {
   useBusSubscription("deeplink.openCamera", () => {
     void ensureMainWindowVisible();
     usePendingDeepLinkStore.getState().setPendingCamera();
-    const settledId = settledConversationId(pathname);
+    // A named conversation only. The `/assistant` index mounts a composer too,
+    // but `useConversationLoader` replace-navigates off it to a conversation
+    // key on arrival, so a composer mounted there is remounted a beat later and
+    // anything it holds in local state goes with it.
+    const settledId = conversationIdForPath(pathname);
     if (settledId !== null) {
       revealConversationView(settledId);
       return;

--- a/clients/web/src/hooks/use-global-deep-link-consumer.ts
+++ b/clients/web/src/hooks/use-global-deep-link-consumer.ts
@@ -1,6 +1,6 @@
 import { useLayoutEffect, useRef } from "react";
 import * as Sentry from "@sentry/react";
-import { useNavigate } from "react-router";
+import { useLocation, useNavigate } from "react-router";
 
 import { useQueryClient } from "@tanstack/react-query";
 
@@ -22,7 +22,7 @@ import {
   navigateToNewConversation,
   revealConversationView,
 } from "@/utils/conversation-navigation";
-import { routes } from "@/utils/routes";
+import { isConversationChatPath, routes } from "@/utils/routes";
 
 /**
  * Global deep-link consumer — mounted at `RootLayout` so it's alive
@@ -60,9 +60,10 @@ import { routes } from "@/utils/routes";
  *   way. See below.
  * - `deeplink.newChat` → `ensureMainWindowVisible()` +
  *   `navigateToNewConversation()`, the Home Screen widgets' New Chat button.
- * - `deeplink.openCamera` → `ensureMainWindowVisible()` + navigate to
- *   `/assistant` + park the request in `usePendingDeepLinkStore` for the
- *   composer's attachment layer to drain on mount (`useCameraDeepLink`).
+ * - `deeplink.openCamera` → `ensureMainWindowVisible()` + park the request in
+ *   `usePendingDeepLinkStore` for the composer's attachment layer to drain
+ *   (`useCameraDeepLink`), then stay put on a conversation route or land on a
+ *   fresh draft from anywhere else.
  * - `deeplink.connect` → `ensureMainWindowVisible()` + park the request
  *   in the connect-dialog store + navigate to the assistant chooser,
  *   which opens its Connect a Remote Assistant dialog off that store: a
@@ -145,8 +146,23 @@ function connectGuidanceMessage(url: string | null): string {
   return `This link came from a pairing QR code. To connect this Mac, run vellum pair on ${machine} and paste the bundle here.`;
 }
 
+/**
+ * Whether `pathname` is a route whose composer stays mounted where it is. The
+ * `/assistant` index, which {@link isConversationChatPath} accepts, is
+ * deliberately excluded: `useConversationLoader` replace-navigates off it to a
+ * conversation key on arrival, so a composer mounted there is remounted a beat
+ * later and anything it holds in local state goes with it.
+ */
+function isSettledConversationPath(pathname: string): boolean {
+  return (
+    pathname.startsWith(`${routes.conversations}/`) &&
+    isConversationChatPath(pathname)
+  );
+}
+
 export function useGlobalDeepLinkConsumer(): void {
   const navigate = useNavigate();
+  const { pathname } = useLocation();
   const queryClient = useQueryClient();
   const navigateRef = useRef(navigate);
   useLayoutEffect(() => {
@@ -298,12 +314,20 @@ export function useGlobalDeepLinkConsumer(): void {
   // The Quick Actions widget's camera button. The camera input belongs to the
   // composer's attachment layer, which does not exist yet on a cold launch, so
   // the request is parked in the same one-shot inbox the voice start uses and
-  // the composer drains it when it mounts (`useCameraDeepLink`). Landing on
-  // `routes.assistant` is what mounts that composer.
+  // the composer drains it when it mounts (`useCameraDeepLink`).
+  //
+  // The landing has to be a route the composer *stays* mounted on. A composer
+  // already on screen keeps the photo in the conversation the user is looking
+  // at, so the tap navigates nowhere; from anywhere else it lands on a fresh
+  // draft, the same registered-draft landing the New Chat button gets, silent
+  // because the tap was for the camera and not for a new chat's flourish.
   useBusSubscription("deeplink.openCamera", () => {
     void ensureMainWindowVisible();
     usePendingDeepLinkStore.getState().setPendingCamera();
-    navigateRef.current(routes.assistant);
+    if (isSettledConversationPath(pathname)) {
+      return;
+    }
+    navigateToNewConversation(navigateRef.current, { silent: true });
   });
 
   useBusSubscription(
@@ -338,11 +362,13 @@ export function useGlobalDeepLinkConsumer(): void {
     void ensureMainWindowVisible();
     // Park before navigating so the chooser mounts with the dialog
     // already open (its auto-skip stands down while it is).
-    useConnectDialogStore.getState().openConnectDialog(
-      bundle !== null
-        ? { initialBundle: bundle }
-        : { guidanceMessage: connectGuidanceMessage(url) },
-    );
+    useConnectDialogStore
+      .getState()
+      .openConnectDialog(
+        bundle !== null
+          ? { initialBundle: bundle }
+          : { guidanceMessage: connectGuidanceMessage(url) },
+      );
     navigateRef.current(routes.selectAssistant);
   });
 

--- a/clients/web/src/hooks/use-global-deep-link-consumer.ts
+++ b/clients/web/src/hooks/use-global-deep-link-consumer.ts
@@ -325,6 +325,10 @@ export function useGlobalDeepLinkConsumer(): void {
     let targetId: string;
     if (settledId !== null) {
       revealConversationView(settledId);
+      // Re-navigating to the settled conversation is a no-op when the router
+      // is at rest, and cancels any in-flight transition away from it that
+      // would otherwise unmount the composer this park is addressed to.
+      navigateRef.current(routes.conversation(settledId), { replace: true });
       targetId = settledId;
     } else {
       targetId = navigateToNewConversation(navigateRef.current, {

--- a/clients/web/src/stores/pending-deep-link-store.ts
+++ b/clients/web/src/stores/pending-deep-link-store.ts
@@ -57,21 +57,34 @@ export interface PendingDeepLinkState {
    */
   pendingThreadSend: PendingThreadSend | null;
   /**
-   * When a `deeplink.openCamera` was parked waiting for the composer's
-   * attachment layer (`Date.now()`), or `null` if none is. Same race as
+   * A parked `deeplink.openCamera` request, or `null` if none is. Same race as
    * `pendingVoiceStartAt`, one layer lower: the camera input is owned by the
    * composer, which does not exist yet when a widget tap cold-launches the app
-   * and never exists on settings / logs / account routes. A timestamp rather
-   * than a payload for the same reason too, since the command carries nothing
-   * and the drain needs to know how stale it is.
+   * and never exists on settings / logs / account routes. The command carries
+   * nothing of its own, so the park is only an address and a timestamp: the
+   * address names the composer that answers it (see {@link PendingCamera}) and
+   * the timestamp lets the drain know how stale it is.
    */
-  pendingCameraAt: number | null;
+  pendingCamera: PendingCamera | null;
 }
 
 /** A proven send-into-thread request; see `pendingThreadSend`. */
 export interface PendingThreadSend {
   threadId: string;
   message: string;
+  parkedAt: number;
+}
+
+/** A parked open-the-camera request; see `pendingCamera`. */
+export interface PendingCamera {
+  /**
+   * The conversation whose composer answers this request. Addressed rather
+   * than broadcast because the handler parks around a navigation: a composer
+   * still mounted on the route the tap is leaving would otherwise drain the
+   * one-shot park and raise a viewfinder that the navigation unmounts a beat
+   * later, leaving the composer the tap was meant for with nothing to open.
+   */
+  targetConversationId: string;
   parkedAt: number;
 }
 
@@ -111,14 +124,19 @@ export interface PendingDeepLinkActions {
    * than dropped, and only the consumer can do that demotion.
    */
   consumePendingThreadSend: () => PendingThreadSend | null;
-  /** Park a camera deep link until the composer's attachment layer mounts. */
-  setPendingCamera: () => void;
+  /**
+   * Park a camera deep link until the attachment layer of the composer bound
+   * to `targetConversationId` mounts. A newer request replaces an older one,
+   * as with the composer message.
+   */
+  setPendingCamera: (targetConversationId: string) => void;
   /**
    * Read and clear the parked camera request. Returns `false` when none was
    * parked, and when the parked one is older than `maxAgeMs`: a park that was
    * never drained (its navigation bounced off a route guard, say) must not
    * throw the camera open minutes later. Either way the park is cleared. The
-   * age bound belongs to the drain site, as with the voice start.
+   * age bound belongs to the drain site, as with the voice start, and so does
+   * the address check: only the drain knows which conversation it is bound to.
    */
   consumePendingCamera: (maxAgeMs: number) => boolean;
 }
@@ -131,7 +149,7 @@ const usePendingDeepLinkStoreBase = create<PendingDeepLinkStore>()(
     pendingComposerMessage: null,
     pendingVoiceStartAt: null,
     pendingThreadSend: null,
-    pendingCameraAt: null,
+    pendingCamera: null,
     setPendingComposerMessage: (message) =>
       set({ pendingComposerMessage: message }),
     consumePendingComposerMessage: () => {
@@ -159,14 +177,15 @@ const usePendingDeepLinkStoreBase = create<PendingDeepLinkStore>()(
       }
       return parked;
     },
-    setPendingCamera: () => set({ pendingCameraAt: Date.now() }),
+    setPendingCamera: (targetConversationId) =>
+      set({ pendingCamera: { targetConversationId, parkedAt: Date.now() } }),
     consumePendingCamera: (maxAgeMs) => {
-      const parkedAt = get().pendingCameraAt;
-      if (parkedAt === null) {
+      const parked = get().pendingCamera;
+      if (parked === null) {
         return false;
       }
-      set({ pendingCameraAt: null });
-      return Date.now() - parkedAt <= maxAgeMs;
+      set({ pendingCamera: null });
+      return Date.now() - parked.parkedAt <= maxAgeMs;
     },
   }),
 );
@@ -183,6 +202,6 @@ export function __resetPendingDeepLinkForTesting(): void {
     pendingComposerMessage: null,
     pendingVoiceStartAt: null,
     pendingThreadSend: null,
-    pendingCameraAt: null,
+    pendingCamera: null,
   });
 }

--- a/clients/web/src/utils/conversation-navigation.ts
+++ b/clients/web/src/utils/conversation-navigation.ts
@@ -120,12 +120,16 @@ export interface NavigateToNewConversationOptions {
  * `useAutoSendEffects` picks up to fire the message once the conversation is
  * mounted.
  *
+ * Returns the draft's id, for callers that have to address something at the
+ * conversation being navigated to before its route mounts (the camera deep
+ * link parks a request for that conversation's composer).
+ *
  * Pure imperative function — reads stores via `.getState()`, no React hooks.
  */
 export function navigateToNewConversation(
   navigate: NavigateFunction,
   options?: NavigateToNewConversationOptions,
-): void {
+): string {
   if (!options?.silent) {
     haptic.light();
     void getSoundManager().play("new_conversation");
@@ -144,4 +148,5 @@ export function navigateToNewConversation(
   }
   void navigate(path);
   requestComposerFocus();
+  return draftId;
 }

--- a/clients/web/src/utils/routes.test.ts
+++ b/clients/web/src/utils/routes.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import {
   ABOUT_ASSISTANT_SECTIONS,
+  conversationIdForPath,
   isAboutAssistantPath,
   isConversationChatPath,
   isConversationPath,
@@ -85,6 +86,43 @@ describe("isConversationPath (conversation area, subroutes included)", () => {
   test("rejects non-conversation routes", () => {
     expect(isConversationPath("/assistant/home")).toBe(false);
     expect(isConversationPath("/assistant/library")).toBe(false);
+  });
+});
+
+describe("conversationIdForPath (the id a path names, if any)", () => {
+  test("extracts the id from a bare conversation route", () => {
+    expect(conversationIdForPath(routes.conversation("conv-1"))).toBe("conv-1");
+  });
+
+  test("tolerates a trailing slash", () => {
+    expect(conversationIdForPath(`${routes.conversation("conv-1")}/`)).toBe(
+      "conv-1",
+    );
+    expect(conversationIdForPath(`${routes.conversation("conv-1")}//`)).toBe(
+      "conv-1",
+    );
+  });
+
+  test("rejects the chat index, which names no conversation", () => {
+    // `isConversationChatPath` accepts it (a composer mounts there), so the
+    // two must stay distinguishable.
+    expect(conversationIdForPath("/assistant")).toBeNull();
+    expect(conversationIdForPath("/assistant/")).toBeNull();
+    expect(isConversationChatPath("/assistant")).toBe(true);
+  });
+
+  test("rejects conversation subroutes like the inspector", () => {
+    expect(conversationIdForPath(routes.inspect("conv-1"))).toBeNull();
+  });
+
+  test("rejects the conversations list, with or without a trailing slash", () => {
+    expect(conversationIdForPath(routes.conversations)).toBeNull();
+    expect(conversationIdForPath(`${routes.conversations}/`)).toBeNull();
+  });
+
+  test("rejects non-conversation routes", () => {
+    expect(conversationIdForPath("/assistant/home")).toBeNull();
+    expect(conversationIdForPath("/assistant/library")).toBeNull();
   });
 });
 

--- a/clients/web/src/utils/routes.ts
+++ b/clients/web/src/utils/routes.ts
@@ -358,6 +358,11 @@ export function isAboutAssistantPath(pathname: string): boolean {
   );
 }
 
+/** Whether `pathname` is the `/assistant` index, trailing slash tolerated. */
+function isAssistantIndexPath(pathname: string): boolean {
+  return pathname === routes.assistant || pathname === `${routes.assistant}/`;
+}
+
 /**
  * Whether `pathname` falls inside the conversation *area* — the `/assistant`
  * index (draft conversation) or anything under `/assistant/conversations/`,
@@ -369,10 +374,34 @@ export function isAboutAssistantPath(pathname: string): boolean {
  */
 export function isConversationPath(pathname: string): boolean {
   return (
-    pathname === routes.assistant ||
-    pathname === `${routes.assistant}/` ||
+    isAssistantIndexPath(pathname) ||
     pathname.startsWith(`${routes.conversations}/`)
   );
+}
+
+/**
+ * The conversation id `pathname` names, or `null` when it names none. Matches
+ * exactly `/assistant/conversations/:id` (a trailing slash is tolerated), so
+ * both the `/assistant` index, which mounts a chat surface without naming a
+ * conversation, and conversation subroutes such as the inspector
+ * (`/assistant/conversations/:id/inspect`) yield `null`.
+ *
+ * Sole owner of the conversation URL shape: {@link isConversationChatPath}
+ * derives from it, and callers wanting the id itself rather than a yes/no read
+ * it here, so the two cannot drift apart.
+ */
+export function conversationIdForPath(pathname: string): string | null {
+  const prefix = `${routes.conversations}/`;
+  if (!pathname.startsWith(prefix)) {
+    return null;
+  }
+  // Exactly one path segment after the prefix (a bare conversation id,
+  // tolerating a trailing slash); deeper segments are other pages.
+  const id = pathname.slice(prefix.length).replace(/\/+$/, "");
+  if (id.length === 0 || id.includes("/")) {
+    return null;
+  }
+  return id;
 }
 
 /**
@@ -385,17 +414,9 @@ export function isConversationPath(pathname: string): boolean {
  * replaces `ChatPage` and has no composer.
  */
 export function isConversationChatPath(pathname: string): boolean {
-  if (pathname === routes.assistant || pathname === `${routes.assistant}/`) {
-    return true;
-  }
-  const prefix = `${routes.conversations}/`;
-  if (!pathname.startsWith(prefix)) {
-    return false;
-  }
-  // Exactly one path segment after the prefix (a bare conversation id,
-  // tolerating a trailing slash) — deeper segments are other pages.
-  const rest = pathname.slice(prefix.length).replace(/\/+$/, "");
-  return rest.length > 0 && !rest.includes("/");
+  return (
+    isAssistantIndexPath(pathname) || conversationIdForPath(pathname) !== null
+  );
 }
 
 const WWW_DOMAIN = "vellum.ai";


### PR DESCRIPTION
## Summary
- The camera deep link navigated to the bare assistant index route, which the conversation loader always redirects off, remounting the composer and killing the overlay a beat after it opened
- Land in place when already on a conversation route, otherwise go straight to a new draft conversation; consume the parked request only after the overlay is actually up
- Route-level regression test covering the loader's replace-navigation

Part of plan: ios-widgets-v2.md (PR 2 of 7)