### PR TITLE
Voice: acknowledge, work in silence, report back (JARVIS-1600)

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -949,7 +949,9 @@ describe("AssistantConfigSchema", () => {
         endpointExtensionMs: 1500,
         endpointMaxExtensions: 2,
         progress: {
-          enabled: true,
+          // Off by default: the working cue holds a long turn's silence, and
+          // spoken narration is the opt-in that replaces it.
+          enabled: false,
           opsThreshold: 3,
           idleIntervalMs: 5000,
           maxSilenceMs: 35000,
@@ -957,6 +959,13 @@ describe("AssistantConfigSchema", () => {
           minGapMs: 6000,
           generationTimeoutMs: 1500,
         },
+      },
+      workingCue: {
+        enabled: true,
+        intervalMs: 12000,
+        frequencyHz: 220,
+        durationMs: 260,
+        gain: 0.09,
       },
       flux: {
         turnEnd: { enabled: true },

--- a/assistant/src/calls/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/calls/__tests__/voice-session-bridge.test.ts
@@ -1541,10 +1541,11 @@ describe("startVoiceTurn race-loss state restore", () => {
 });
 
 describe("startVoiceTurn tool-event forwarding", () => {
-  // The agent loop's tool_use_start / tool_result events reach the voice
-  // callbacks so the session can track per-turn tool activity. The bridge is
-  // the single truncation point for tool results — the raw result can be
-  // huge and must never travel further into the voice layer.
+  // The agent loop's tool_use_preview_start / tool_use_start / tool_result
+  // events reach the voice callbacks so the session can track per-turn tool
+  // activity. The bridge is the single truncation point for tool results —
+  // the raw result can be huge and must never travel further into the voice
+  // layer.
 
   /** Scripts runAgentLoop to emit the given agent-loop events in order. */
   function makeEventEmittingConversation(events: unknown[]) {
@@ -1667,8 +1668,95 @@ describe("startVoiceTurn tool-event forwarding", () => {
     ]);
   });
 
+  test("tool_use_preview_start delivers the tool name and id", async () => {
+    makeEventEmittingConversation([
+      {
+        type: "tool_use_preview_start",
+        toolName: "web_search",
+        toolUseId: "toolu-1",
+      },
+    ]);
+
+    const previews: Array<{ toolName: string; toolUseId: string }> = [];
+    await startVoiceTurn({
+      ...makeTurnOptions(),
+      callbacks: {
+        tool_use_preview_start: (toolName, toolUseId) =>
+          previews.push({ toolName, toolUseId }),
+      },
+    });
+    await flushMicrotasks();
+
+    expect(previews).toEqual([
+      { toolName: "web_search", toolUseId: "toolu-1" },
+    ]);
+  });
+
+  test("a turn with no tool calls never fires tool_use_preview_start", async () => {
+    makeEventEmittingConversation([
+      { type: "assistant_text_delta", text: "hello" },
+    ]);
+
+    const previews: string[] = [];
+    await startVoiceTurn({
+      ...makeTurnOptions(),
+      callbacks: {
+        tool_use_preview_start: (toolName) => previews.push(toolName),
+      },
+    });
+    await flushMicrotasks();
+
+    expect(previews).toEqual([]);
+  });
+
+  test("the preview and the definitive start are independent callbacks", async () => {
+    // The preview is a structural signal only. Activity display keys off
+    // tool_use_start, so that callback must still fire with its full detail
+    // regardless of whether a consumer observes the preview.
+    makeEventEmittingConversation([
+      {
+        type: "tool_use_preview_start",
+        toolName: "web_search",
+        toolUseId: "toolu-1",
+      },
+      {
+        type: "tool_use_start",
+        toolName: "web_search",
+        input: { query: "weather" },
+        toolUseId: "toolu-1",
+      },
+    ]);
+
+    const fired: string[] = [];
+    const starts: Array<{ toolName: string; detail?: unknown }> = [];
+    await startVoiceTurn({
+      ...makeTurnOptions(),
+      callbacks: {
+        tool_use_preview_start: () => fired.push("preview"),
+        tool_use_start: (toolName, detail) => {
+          fired.push("start");
+          starts.push({ toolName, detail });
+        },
+      },
+    });
+    await flushMicrotasks();
+
+    expect(fired).toEqual(["preview", "start"]);
+    expect(starts).toEqual([
+      {
+        toolName: "web_search",
+        detail: { toolUseId: "toolu-1", input: { query: "weather" } },
+      },
+    ]);
+  });
+
   test("a callbacks object without the tool-event members doesn't throw", async () => {
     makeEventEmittingConversation([
+      {
+        type: "tool_use_preview_start",
+        toolName: "web_search",
+        toolUseId: "toolu-1",
+      },
       {
         type: "tool_use_start",
         toolName: "web_search",

--- a/assistant/src/calls/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/calls/__tests__/voice-session-bridge.test.ts
@@ -1541,7 +1541,8 @@ describe("startVoiceTurn race-loss state restore", () => {
 });
 
 describe("startVoiceTurn tool-event forwarding", () => {
-  // The agent loop's tool_use_preview_start / tool_use_start / tool_result
+  // The agent loop's tool_use_preview_start / server_tool_start /
+  // tool_use_start / tool_result
   // events reach the voice callbacks so the session can track per-turn tool
   // activity. The bridge is the single truncation point for tool results —
   // the raw result can be huge and must never travel further into the voice
@@ -1668,7 +1669,7 @@ describe("startVoiceTurn tool-event forwarding", () => {
     ]);
   });
 
-  test("tool_use_preview_start delivers the tool name and id", async () => {
+  test("tool_use_preview_start opens a tool block and delivers name and id", async () => {
     makeEventEmittingConversation([
       {
         type: "tool_use_preview_start",
@@ -1681,7 +1682,7 @@ describe("startVoiceTurn tool-event forwarding", () => {
     await startVoiceTurn({
       ...makeTurnOptions(),
       callbacks: {
-        tool_use_preview_start: (toolName, toolUseId) =>
+        tool_block_opened: (toolName, toolUseId) =>
           previews.push({ toolName, toolUseId }),
       },
     });
@@ -1692,7 +1693,72 @@ describe("startVoiceTurn tool-event forwarding", () => {
     ]);
   });
 
-  test("a turn with no tool calls never fires tool_use_preview_start", async () => {
+  test("a provider-native tool opens a block via its translated tool_use_start", async () => {
+    // Web search and friends reach this layer as a wire `tool_use_start`: the
+    // daemon translates the loop's `server_tool_start` into one (see that case
+    // in conversation-agent-loop-handlers.ts), and no preview event is emitted
+    // for them. A consumer wired only to tool_use_preview_start would miss
+    // every block boundary on such a turn.
+    makeEventEmittingConversation([
+      {
+        type: "tool_use_start",
+        toolName: "web_search",
+        toolUseId: "srvtoolu-1",
+        input: { query: "weather" },
+      },
+    ]);
+
+    const opened: Array<{ toolName: string; toolUseId: string }> = [];
+    await startVoiceTurn({
+      ...makeTurnOptions(),
+      callbacks: {
+        tool_block_opened: (toolName, toolUseId) =>
+          opened.push({ toolName, toolUseId }),
+      },
+    });
+    await flushMicrotasks();
+
+    expect(opened).toEqual([
+      { toolName: "web_search", toolUseId: "srvtoolu-1" },
+    ]);
+  });
+
+  test("a client tool that previews and then starts opens its block once", async () => {
+    // Both events describe the same call, so opening twice would advance the
+    // consumer's block counter past the block the following text belongs to.
+    makeEventEmittingConversation([
+      {
+        type: "tool_use_preview_start",
+        toolName: "calendar_read",
+        toolUseId: "toolu-1",
+      },
+      {
+        type: "tool_use_start",
+        toolName: "calendar_read",
+        toolUseId: "toolu-1",
+        input: { day: "today" },
+      },
+      {
+        type: "tool_use_start",
+        toolName: "web_search",
+        toolUseId: "srvtoolu-1",
+        input: { query: "weather" },
+      },
+    ]);
+
+    const opened: string[] = [];
+    await startVoiceTurn({
+      ...makeTurnOptions(),
+      callbacks: {
+        tool_block_opened: (toolName) => opened.push(toolName),
+      },
+    });
+    await flushMicrotasks();
+
+    expect(opened).toEqual(["calendar_read", "web_search"]);
+  });
+
+  test("a turn with no tool calls never opens a tool block", async () => {
     makeEventEmittingConversation([
       { type: "assistant_text_delta", text: "hello" },
     ]);
@@ -1701,7 +1767,7 @@ describe("startVoiceTurn tool-event forwarding", () => {
     await startVoiceTurn({
       ...makeTurnOptions(),
       callbacks: {
-        tool_use_preview_start: (toolName) => previews.push(toolName),
+        tool_block_opened: (toolName) => previews.push(toolName),
       },
     });
     await flushMicrotasks();
@@ -1732,7 +1798,7 @@ describe("startVoiceTurn tool-event forwarding", () => {
     await startVoiceTurn({
       ...makeTurnOptions(),
       callbacks: {
-        tool_use_preview_start: () => fired.push("preview"),
+        tool_block_opened: () => fired.push("preview"),
         tool_use_start: (toolName, detail) => {
           fired.push("start");
           starts.push({ toolName, detail });

--- a/assistant/src/calls/__tests__/voice-session-bridge.test.ts
+++ b/assistant/src/calls/__tests__/voice-session-bridge.test.ts
@@ -1544,7 +1544,7 @@ describe("startVoiceTurn tool-event forwarding", () => {
   // The agent loop's tool_use_preview_start / server_tool_start /
   // tool_use_start / tool_result
   // events reach the voice callbacks so the session can track per-turn tool
-  // activity. The bridge is the single truncation point for tool results —
+  // activity. The bridge is the single truncation point for tool results:
   // the raw result can be huge and must never travel further into the voice
   // layer.
 

--- a/assistant/src/calls/__tests__/voice-triage-escalate.test.ts
+++ b/assistant/src/calls/__tests__/voice-triage-escalate.test.ts
@@ -16,6 +16,7 @@ import {
   HOLD_VERDICT_TOKEN,
   isEscalationBridgeComplete,
   MAX_ESCALATION_BRIDGE_CHARS,
+  MIN_SPOKEN_BRIDGE_CHARS,
   needsFallbackBridge,
   spokenBridgeText,
 } from "../voice-triage-escalate.js";
@@ -25,9 +26,9 @@ describe("frontDoorCapabilityDigest", () => {
     const digest = frontDoorCapabilityDigest(["calendar_read", "web_search"]);
     expect(digest).toContain("calendar_read, web_search");
     expect(digest.toLowerCase()).toContain("escalate");
-    // The digest teaches routing, and the bridge phrase should name the
+    // The digest teaches routing, and the spoken sentence should name the
     // action rather than the model refusing or guessing.
-    expect(digest.toLowerCase()).toContain("holding phrase");
+    expect(digest.toLowerCase()).toContain("name the action");
   });
 
   test("is empty when no tool names are available (registry-less contexts)", () => {
@@ -170,9 +171,32 @@ describe("front-door decision rule", () => {
     );
   });
 
-  test("demands a single-sentence holding phrase on escalation", () => {
-    expect(rule.toLowerCase()).toContain("one short natural holding phrase");
+  test("demands a single-sentence acknowledgement on escalation", () => {
+    expect(rule.toLowerCase()).toContain("one short natural sentence");
     expect(rule.toLowerCase()).toContain("stop after that single sentence");
+  });
+
+  test("asks for an acknowledgement, not a request for thinking time", () => {
+    // The escalated leg can run for a minute of tools and reasoning, and it
+    // runs near-silent. A phrase promising "one second" sets an expectation
+    // that the silence then breaks, so the sentence has to accept the task,
+    // name the work, and imply a reply is coming back.
+    expect(rule.toLowerCase()).toContain("accepts the task");
+    expect(rule.toLowerCase()).toContain("names what you are going to do");
+    expect(rule.toLowerCase()).toContain(
+      "promise a response instead of asking for a moment to think",
+    );
+  });
+
+  test("forbids promising the task is already finished", () => {
+    // The escalated leg is allowed to come back with a question it genuinely
+    // needs answered, or with a tool failure. An acknowledgement that
+    // promised completion is contradicted by the next thing the caller
+    // hears, so the rule has to ask for a promise of contact, not success.
+    expect(rule.toLowerCase()).toContain(
+      "never promise the task is already finished",
+    );
+    expect(rule.toLowerCase()).toContain("ask the caller for a missing detail");
   });
 
   test("hold completeness is judged in the caller's language", () => {
@@ -193,9 +217,9 @@ describe("front-door decision rule", () => {
     expect(rule).toContain("Answer in the language the caller is speaking.");
   });
 
-  test("the escalation holding phrase demands the caller's language", () => {
+  test("the escalation acknowledgement demands the caller's language", () => {
     // The bridge examples are English; without an explicit requirement a
-    // Spanish turn that needs a tool gets an English holding phrase before
+    // Spanish turn that needs a tool gets an English acknowledgement before
     // the localized answer. The examples stay, labeled as English only.
     expect(rule).toContain("spoken in the language the caller is speaking");
     expect(rule).toContain("those examples are English only");
@@ -235,7 +259,7 @@ describe("escalated continuation rule", () => {
     );
   });
 
-  test("bans re-announcing the holding phrase (bridge-echo regression)", () => {
+  test("bans re-announcing the acknowledgement (bridge-echo regression)", () => {
     // Regression: after the bridge "Let me check your calendar", the quality
     // model opened with "Let me check what calendar connections…" — a
     // re-announcement echo. The rule must ban paraphrase/re-announce openers,
@@ -256,11 +280,14 @@ describe("fallbackEscalationBridgeFor", () => {
     }
   });
 
-  test("every bridge fits the session-side cap", () => {
+  test("every bridge fits between the spoken threshold and the cap", () => {
     for (const bridge of Object.values(
       FALLBACK_ESCALATION_BRIDGE_BY_LANGUAGE,
     )) {
       expect(bridge.length).toBeLessThanOrEqual(MAX_ESCALATION_BRIDGE_CHARS);
+      // Above the spoken threshold, so escalating with no bridge of the
+      // model's own still gives the caller real audio rather than nothing.
+      expect(bridge.trim().length).toBeGreaterThan(MIN_SPOKEN_BRIDGE_CHARS);
     }
   });
 
@@ -271,6 +298,42 @@ describe("fallbackEscalationBridgeFor", () => {
     expect(fallbackEscalationBridgeFor("JA")).toBe(
       FALLBACK_ESCALATION_BRIDGE_BY_LANGUAGE.ja!,
     );
+  });
+
+  test("no localized bridge promises the task will be finished", () => {
+    // The escalated leg may come back with a clarifying question or a tool
+    // failure, so every canned bridge promises contact and none promises
+    // success. There is no language-agnostic way to assert that, so this is
+    // a regression guard rather than a proof: each language lists the
+    // completion-conditional phrasings a rewrite is most likely to reach
+    // for. A language may only be added to the bridge table once it has an
+    // entry here, which forces the question to be asked for the new copy
+    // too.
+    const completionPhrasings: Readonly<Record<string, readonly string[]>> = {
+      en: ["when it's done", "when it's sent", "once it's done"],
+      es: ["cuando esté listo", "cuando termine", "cuando lo tenga"],
+      fr: ["dès que c'est prêt", "quand c'est prêt", "une fois terminé"],
+      de: ["wenn es fertig ist", "sobald es fertig ist", "wenn ich fertig bin"],
+      hi: ["पूरा होते ही", "हो जाने पर", "पूरा हो जाए"],
+      ru: ["когда будет готово", "как только будет готово", "когда закончу"],
+      pt: [
+        "quando estiver pronto",
+        "assim que estiver pronto",
+        "quando acabar",
+      ],
+      ja: ["終わりましたら", "完了しましたら", "終わり次第"],
+      it: ["quando è pronto", "quando ho finito", "appena è pronto"],
+      nl: ["als het klaar is", "zodra het klaar is", "als ik klaar ben"],
+    };
+    for (const [language, bridge] of Object.entries(
+      FALLBACK_ESCALATION_BRIDGE_BY_LANGUAGE,
+    )) {
+      const phrasings = completionPhrasings[language];
+      expect(phrasings).toBeDefined();
+      for (const phrasing of phrasings!) {
+        expect(bridge.toLowerCase()).not.toContain(phrasing.toLowerCase());
+      }
+    }
   });
 
   test("falls back to English for unknown or absent languages", () => {
@@ -340,7 +403,10 @@ describe("isEscalationBridgeComplete", () => {
   test("every localized fallback bridge ends in a recognized terminator", () => {
     // A model-spoken bridge in any roster language must hand off at its
     // terminator, never by buffering to the char cap; the canned bridges are
-    // the canonical sample of each language's ender.
+    // the canonical sample of each language's ender. The cap-identity check
+    // is also what keeps each canned bridge to ONE sentence: capping cuts at
+    // the first terminator, so a second sentence (the "I'll get back to you"
+    // half of the promise) would be truncated away before it was spoken.
     for (const bridge of Object.values(
       FALLBACK_ESCALATION_BRIDGE_BY_LANGUAGE,
     )) {
@@ -374,15 +440,15 @@ describe("spokenBridgeText", () => {
 });
 
 describe("needsFallbackBridge", () => {
-  test("false when the model spoke a real holding phrase after the verdict", () => {
+  test("false when the model spoke a real acknowledgement after the verdict", () => {
     expect(
       needsFallbackBridge(
-        `${ESCALATE_VERDICT_TOKEN} Let me think about that for a second.`,
+        `${ESCALATE_VERDICT_TOKEN} I'll check your calendar and let you know.`,
       ),
     ).toBe(false);
   });
 
-  test("true for a bare escalate verdict with no holding phrase", () => {
+  test("true for a bare escalate verdict with no acknowledgement", () => {
     expect(needsFallbackBridge(ESCALATE_VERDICT_TOKEN)).toBe(true);
   });
 });
@@ -426,6 +492,18 @@ describe("escalation continuation content", () => {
   test("is an echo-suppressed synthetic prompt (parenthesized, non-user-speech)", () => {
     expect(ESCALATION_CONTINUATION_CONTENT.startsWith("(")).toBe(true);
     expect(ESCALATION_CONTINUATION_CONTENT.endsWith(")")).toBe(true);
+  });
+
+  test("states the real premise: task accepted, silence since", () => {
+    // The escalated leg is not resuming from "give me a second to think":
+    // the caller was told the work was underway and has heard nothing since.
+    // Getting the premise wrong is what produces an answer that apologizes
+    // for the pause instead of delivering the result.
+    const content = ESCALATION_CONTINUATION_CONTENT.toLowerCase();
+    expect(content).toContain("accept the task");
+    expect(content).toContain("come back to them");
+    expect(content).toContain("heard nothing");
+    expect(content).toContain("do not repeat");
   });
 });
 

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -286,6 +286,18 @@ export interface VoiceTurnCallbacks {
     toolName: string,
     detail?: { toolUseId?: string; input?: Record<string, unknown> },
   ) => void;
+  /**
+   * Fired when the provider OPENS a tool-use content block, before its input
+   * JSON streams - earlier and weaker than `tool_use_start`, which waits for a
+   * definitive, parsed call.
+   *
+   * Consumers must not use this to display or act on a tool: the call may
+   * never materialize. It is a structural signal about the RESPONSE, not the
+   * tool - once a tool-use block opens, the text block before it is closed, so
+   * any text streamed since the last block boundary was working commentary
+   * rather than the turn's answer.
+   */
+  tool_use_preview_start?: (toolName: string, toolUseId: string) => void;
   /** Fired when a tool invocation finishes. */
   tool_result?: (event: VoiceToolResultEvent) => void;
 }
@@ -1767,6 +1779,16 @@ export async function startVoiceTurn(
             eventSink.onError(msg.userMessage);
           } else if (msg.type === "tool_use_start") {
             eventSink.onToolUse(msg.toolName, msg.input, msg.toolUseId);
+          } else if (msg.type === "tool_use_preview_start") {
+            // Routed through `opts.callbacks` rather than `eventSink`: the
+            // sink is the phone-shaped surface, and this is a live-voice-only
+            // structural signal about the response. Activity display stays on
+            // the definitive `tool_use_start`, which is the only tool event a
+            // consumer may show or act on.
+            opts.callbacks?.tool_use_preview_start?.(
+              msg.toolName,
+              msg.toolUseId,
+            );
           } else if (msg.type === "tool_result") {
             eventSink.onToolResult({
               toolName: msg.toolName,
@@ -1778,8 +1800,6 @@ export async function startVoiceTurn(
               ),
             });
           }
-          // Note: tool_use_preview_start is intentionally not handled here.
-          // Voice only reacts to the definitive tool_use_start event.
         },
         // Front-door legs resolve through their own call site, whose shipped
         // default pins the latency-class verdict model (see

--- a/assistant/src/calls/voice-session-bridge.ts
+++ b/assistant/src/calls/voice-session-bridge.ts
@@ -287,17 +287,23 @@ export interface VoiceTurnCallbacks {
     detail?: { toolUseId?: string; input?: Record<string, unknown> },
   ) => void;
   /**
-   * Fired when the provider OPENS a tool-use content block, before its input
-   * JSON streams - earlier and weaker than `tool_use_start`, which waits for a
-   * definitive, parsed call.
+   * Fired when the provider OPENS any tool block, before its input streams -
+   * earlier and weaker than `tool_use_start`, which waits for a definitive,
+   * parsed call.
    *
    * Consumers must not use this to display or act on a tool: the call may
    * never materialize. It is a structural signal about the RESPONSE, not the
-   * tool - once a tool-use block opens, the text block before it is closed, so
-   * any text streamed since the last block boundary was working commentary
-   * rather than the turn's answer.
+   * tool - once a tool block opens, the text block before it is closed, so any
+   * text streamed since the last block boundary was working commentary rather
+   * than the turn's answer.
+   *
+   * Both client-executed tools (`tool_use_preview_start`) and provider-native
+   * ones such as web search (`server_tool_start`) fire this. They are one
+   * concept here deliberately: a consumer that tracked only the former would
+   * silently miss every block boundary on a server-tool turn, and the text
+   * before that boundary would be misread as part of the answer.
    */
-  tool_use_preview_start?: (toolName: string, toolUseId: string) => void;
+  tool_block_opened?: (toolName: string, toolUseId: string) => void;
   /** Fired when a tool invocation finishes. */
   tool_result?: (event: VoiceToolResultEvent) => void;
 }
@@ -1736,6 +1742,29 @@ export async function startVoiceTurn(
       }
       const profilePin =
         opts.overrideProfile ?? (carriesImage ? VOICE_IMAGE_PROFILE : null);
+      // One block-open per tool call, whichever wire event announces it first.
+      // A client tool previews and then starts; a provider-native tool only
+      // ever starts. Firing twice for the same call would advance the
+      // consumer's block counter past the block the text actually belongs to.
+      const openedToolBlocks = new Set<string>();
+      const openToolBlock = (
+        toolName: string,
+        toolUseId: string | undefined,
+      ): void => {
+        // An id is what makes the two events for one call recognizable as one
+        // call. Without it there is nothing to dedupe on, so the block still
+        // opens: a missed boundary would misread commentary as the answer,
+        // which is worse than an extra boundary between blocks that hold no
+        // text anyway.
+        if (toolUseId !== undefined) {
+          if (openedToolBlocks.has(toolUseId)) {
+            return;
+          }
+          openedToolBlocks.add(toolUseId);
+        }
+        opts.callbacks?.tool_block_opened?.(toolName, toolUseId ?? "");
+      };
+
       await conversation.runAgentLoop(persistedContent, messageId, {
         onEvent: (msg: AssistantEvent) => {
           if (msg.type === "assistant_turn_start") {
@@ -1779,16 +1808,20 @@ export async function startVoiceTurn(
             eventSink.onError(msg.userMessage);
           } else if (msg.type === "tool_use_start") {
             eventSink.onToolUse(msg.toolName, msg.input, msg.toolUseId);
+            // Also a block boundary, and for a provider-native tool it is the
+            // ONLY one: the daemon translates the loop's `server_tool_start`
+            // into a wire `tool_use_start` (see the `server_tool_start` case in
+            // conversation-agent-loop-handlers.ts), so web search and friends
+            // never produce a preview event. `openToolBlock` dedupes, so a
+            // client tool that previewed first does not open twice.
+            openToolBlock(msg.toolName, msg.toolUseId);
           } else if (msg.type === "tool_use_preview_start") {
             // Routed through `opts.callbacks` rather than `eventSink`: the
             // sink is the phone-shaped surface, and this is a live-voice-only
             // structural signal about the response. Activity display stays on
             // the definitive `tool_use_start`, which is the only tool event a
             // consumer may show or act on.
-            opts.callbacks?.tool_use_preview_start?.(
-              msg.toolName,
-              msg.toolUseId,
-            );
+            openToolBlock(msg.toolName, msg.toolUseId);
           } else if (msg.type === "tool_result") {
             eventSink.onToolResult({
               toolName: msg.toolName,

--- a/assistant/src/calls/voice-triage-escalate.ts
+++ b/assistant/src/calls/voice-triage-escalate.ts
@@ -7,11 +7,13 @@
  *   - `[0]` ({@link HOLD_VERDICT_TOKEN}, unified front-door only): the
  *     caller is mid-thought — the leg is discarded and listening continues.
  *   - `[1]` ({@link ESCALATE_VERDICT_TOKEN}) followed by ONE short natural
- *     holding phrase: the turn is too tricky — the phrase is spoken (capped
- *     at a single sentence) while the turn re-runs on the call-site default
- *     profile, the model an un-routed voice turn would have used. Because
- *     the holding phrase is spoken, the caller never hears the stronger
- *     model's think-time as silence.
+ *     acknowledgement: the turn is too tricky, so the acknowledgement is
+ *     spoken (capped at a single sentence) while the turn re-runs on the
+ *     call-site default profile, the model an un-routed voice turn would
+ *     have used. It accepts the task and promises to come back to the caller
+ *     rather than asking for a pause: the escalated leg can spend a minute on
+ *     tools and reasoning, and the acknowledgement is what makes that stretch
+ *     read as work in progress instead of a stall.
  *   - Anything else: the output IS the answer, streamed straight to TTS
  *     (low first-token latency -> the caller hears audio fast).
  *
@@ -51,34 +53,55 @@ export { ESCALATE_VERDICT_TOKEN, HOLD_VERDICT_TOKEN };
 export type VoiceRoutingLeg = "front-door" | "escalated";
 
 /**
- * Spoken when the front-door model escalates without a meaningful holding
- * phrase of its own — guarantees the caller never hears dead air across the
- * hand-off. When the model does speak its own bridge, that natural text is
- * used instead and this is not injected.
+ * Spoken when the front-door model escalates without a meaningful
+ * acknowledgement of its own - guarantees the caller never hears dead air
+ * across the hand-off. When the model does speak its own bridge, that natural
+ * text is used instead and this is not injected.
+ *
+ * It accepts the task and promises to come back to the caller rather than
+ * asking for a second to think. A promised pause fits only the work a strong
+ * model finishes in a breath; an escalated leg can spend a minute on tools and
+ * reasoning, and that minute is near-silent by design. "A second" followed by
+ * ninety seconds of quiet reads as a stall or a dropped call, so the
+ * acknowledgement is what licenses the silence behind it.
+ *
+ * What it promises is contact, never success. The escalated leg is allowed to
+ * come back with a question it genuinely needs answered, or with a tool
+ * failure, so an acknowledgement that declared the task finished would be
+ * contradicted by the very next thing the caller hears ("I'll let you know
+ * when it's sent", then "what should the email say?").
+ *
+ * Exactly one sentence, here and in every localized spelling below:
+ * {@link capEscalationBridge} cuts at the first sentence terminator, so a
+ * second sentence would be truncated away unspoken.
  */
 export const FALLBACK_ESCALATION_BRIDGE =
-  "Let me think about that for a second.";
+  "I'm on it, and I'll get back to you.";
 
 /**
  * Per-language spellings of the fallback escalation bridge, keyed by
  * lowercased BCP 47 base subtag, covering the Deepgram code-switching roster
  * (DEEPGRAM_MULTI_LANGUAGE_CODES in providers/speech-to-text/deepgram.ts).
  * These are spoken audio; the English constant above also serves as the
- * prompt exemplar and stays the default.
+ * prompt exemplar and stays the default. Every entry carries the same meaning
+ * as the English one (task accepted, a reply to follow) in one sentence, none
+ * of them claiming the task will be finished, and each sticks to verb forms
+ * that do not pin a gender on the assistant (the gendered first-person
+ * past/future of Hindi and Russian is the trap here).
  */
 export const FALLBACK_ESCALATION_BRIDGE_BY_LANGUAGE: Readonly<
   Record<string, string>
 > = {
   en: FALLBACK_ESCALATION_BRIDGE,
-  es: "Déjame pensarlo un segundo.",
-  fr: "Laissez-moi y réfléchir un instant.",
-  de: "Lass mich kurz darüber nachdenken.",
-  hi: "मुझे एक पल सोचने दीजिए।",
-  ru: "Дайте мне секунду подумать.",
-  pt: "Deixe-me pensar nisso um segundo.",
-  ja: "少し考えさせてください。",
-  it: "Fammi pensare un attimo.",
-  nl: "Laat me daar even over nadenken.",
+  es: "Ya me encargo de eso y te aviso.",
+  fr: "Je m'en occupe et je reviens vers vous.",
+  de: "Ich kümmere mich darum und melde mich bei dir.",
+  hi: "इस पर काम शुरू कर दिया है, आपको जल्द ही बता दिया जाएगा।",
+  ru: "Уже занимаюсь этим и дам вам знать.",
+  pt: "Já estou cuidando disso e te aviso.",
+  ja: "承知しました、後ほどお知らせします。",
+  it: "Ci penso io e ti faccio sapere.",
+  nl: "Ik ga ermee aan de slag en laat het je weten.",
 };
 
 /**
@@ -332,14 +355,15 @@ export function createFrontDoorStreamGate(
  * just above it.
  */
 export const ESCALATION_CONTINUATION_CONTENT =
-  "(You just told the caller you needed a moment to think. Now give them your full, careful answer to their previous question — do not repeat the holding phrase.)";
+  "(The caller heard you accept the task and say you would come back to them, and has heard nothing from you since. Give them your full, careful answer to their previous question now, or ask for every detail you still need, in one go rather than one at a time, and do not repeat the acknowledgement.)";
 
 /**
  * Compact, registry-derived digest of the tools the ESCALATED leg can use.
  * The front-door leg runs toolless, so without this it has no way to know
  * what the assistant can actually do — and its failure mode is refusing or
  * fabricating instead of escalating. The digest teaches routing (and lets
- * the holding phrase name the action) without carrying executable schemas.
+ * the spoken acknowledgement name the action) without carrying executable
+ * schemas.
  * Empty input (registry unavailable) yields an empty digest; the decision
  * rule still works, it just can't enumerate capabilities.
  */
@@ -350,8 +374,8 @@ export function frontDoorCapabilityDigest(toolNames: string[]): string {
   return [
     "You have no tools on this leg, but the stronger model you can escalate to has these:",
     `${toolNames.join(", ")}.`,
-    "Any request that needs one of them must escalate — name the action in your holding phrase",
-    '(for example "Let me check your calendar") instead of refusing or guessing.',
+    "Any request that needs one of them must escalate: name the action in the sentence you speak",
+    '(for example "I\'ll check your calendar and let you know") instead of refusing or guessing.',
   ].join(" ");
 }
 
@@ -414,7 +438,7 @@ export function frontDoorDecisionRule(opts?: {
     ...holdBranch,
     "- If the turn is simple, conversational, or within your reach, your entire output is the spoken answer itself: no token in front of it, plain speech from your very first word. Most turns are answers; when unsure between answering and escalating, answer. Answer in the language the caller is speaking.",
     "- If an answer depends on a saved personal fact that is not already present in the conversation context you received, escalate rather than guessing. Personal context that is already present is yours to use directly.",
-    `- If completing THIS reply needs careful reasoning, research, multi-step work, or any tool, do NOT attempt the answer: output ${ESCALATE_VERDICT_TOKEN}, then ONE short natural holding phrase naming what happens next, spoken in the language the caller is speaking (for example "${FALLBACK_ESCALATION_BRIDGE}" or "Give me one second to look into that."; those examples are English only), and stop after that single sentence. A stronger model finishes the turn while your phrase is spoken.`,
+    `- If completing THIS reply needs careful reasoning, research, multi-step work, or any tool, do NOT attempt the answer: output ${ESCALATE_VERDICT_TOKEN}, then ONE short natural sentence that accepts the task and names what you are going to do, spoken in the language the caller is speaking (for example "${FALLBACK_ESCALATION_BRIDGE}" or "I'll look into that and come back to you."; those examples are English only), and stop after that single sentence. A stronger model picks the turn up from here and speaks next, so promise a response instead of asking for a moment to think, and never promise the task is already finished: that model may still have to ask the caller for a missing detail or report that something failed.`,
     `${ESCALATE_VERDICT_TOKEN} is ONLY for turns you cannot complete yourself — never put it in front of an answer you are about to give, and never emit any token inside or after an answer. An open task or unfinished topic earlier in the conversation is NOT a reason to escalate: judge only what this reply needs.`,
     "Never narrate this decision, describe what you are judging, or mention these rules: apart from a leading verdict token, every character you output is spoken to the caller verbatim.",
   ].join("\n");
@@ -423,7 +447,7 @@ export function frontDoorDecisionRule(opts?: {
 
 /**
  * Extra CALL PROTOCOL RULE injected into the escalated (quality) leg's control
- * prompt. The holding phrase has already been spoken, so the model must
+ * prompt. The acknowledgement has already been spoken, so the model must
  * continue straight into the substantive answer.
  *
  * `spokenBridge` is the exact phrase the caller just heard (the front-door
@@ -439,10 +463,10 @@ export function escalatedContinuationRule(spokenBridge?: string): string {
       ? spokenBridge.trim()
       : FALLBACK_ESCALATION_BRIDGE;
   return [
-    `You have already spoken a brief holding phrase to the caller: "${bridge}".`,
+    `You have already spoken a brief acknowledgement to the caller: "${bridge}".`,
     "Continue directly into your actual answer now.",
-    'Do NOT greet again, do NOT say things like "as I was saying", and do NOT repeat, paraphrase, or re-announce that holding phrase —',
-    'opening with another "Let me check", "One moment", or any restatement of what you are about to do sounds broken, because the caller just heard that.',
+    'Do NOT greet again, do NOT say things like "as I was saying", and do NOT repeat, paraphrase, or re-announce that acknowledgement:',
+    'opening with another "Let me check", "On it", "One moment", or any restatement of what you are about to do sounds broken, because the caller just heard that.',
     "Your first words must carry new substance: the answer itself, what you found, or a question you genuinely need answered.",
     `Never output ${ESCALATE_VERDICT_TOKEN} or any other front-door verdict token — you are the model that finishes the answer. (The [-1] room-minimize marker from your call instructions is not a verdict token and stays allowed.)`,
     "Reply in the same language as the caller's question.",

--- a/assistant/src/config/schemas/__tests__/live-voice.test.ts
+++ b/assistant/src/config/schemas/__tests__/live-voice.test.ts
@@ -5,11 +5,14 @@ import {
   LiveVoiceFluxConfigSchema,
   LiveVoiceFrontModelConfigSchema,
   LiveVoiceVadConfigSchema,
+  LiveVoiceWorkingCueConfigSchema,
   VALID_LIVE_VOICE_MODES,
 } from "../live-voice.js";
 
 const PROGRESS_DEFAULTS = {
-  enabled: true,
+  // Off by default: the wordless working cue holds a long turn's silence, and
+  // spoken narration is the opt-in that replaces it.
+  enabled: false,
   opsThreshold: 3,
   idleIntervalMs: 5_000,
   maxSilenceMs: 35_000,
@@ -23,6 +26,14 @@ const FRONT_MODEL_DEFAULTS = {
   endpointExtensionMs: 1500,
   endpointMaxExtensions: 2,
   progress: PROGRESS_DEFAULTS,
+};
+
+const WORKING_CUE_DEFAULTS = {
+  enabled: true,
+  intervalMs: 12_000,
+  frequencyHz: 220,
+  durationMs: 260,
+  gain: 0.09,
 };
 
 // `eagerEotThreshold` is deliberately absent: it has no default, and leaving it
@@ -165,9 +176,9 @@ describe("LiveVoiceFrontModelConfigSchema", () => {
 
   test("partial progress overrides merge with defaults", () => {
     const parsed = LiveVoiceFrontModelConfigSchema.parse({
-      progress: { enabled: false, opsThreshold: 5 },
+      progress: { enabled: true, opsThreshold: 5 },
     });
-    expect(parsed.progress.enabled).toBe(false);
+    expect(parsed.progress.enabled).toBe(true);
     expect(parsed.progress.opsThreshold).toBe(5);
     // Unspecified progress fields still get defaults
     expect(parsed.progress.idleIntervalMs).toBe(5_000);
@@ -226,6 +237,107 @@ describe("LiveVoiceFrontModelConfigSchema", () => {
         msgs.some((m) => m.includes("liveVoice.frontModel.progress.enabled")),
       ).toBe(true);
     }
+  });
+});
+
+describe("LiveVoiceWorkingCueConfigSchema", () => {
+  test("empty object parses to defaults", () => {
+    expect(LiveVoiceWorkingCueConfigSchema.parse({})).toEqual(
+      WORKING_CUE_DEFAULTS,
+    );
+  });
+
+  test("partial overrides merge with defaults", () => {
+    const parsed = LiveVoiceWorkingCueConfigSchema.parse({
+      intervalMs: 8_000,
+      frequencyHz: 440,
+    });
+    expect(parsed.intervalMs).toBe(8_000);
+    expect(parsed.frequencyHz).toBe(440);
+    expect(parsed.enabled).toBe(true);
+    expect(parsed.durationMs).toBe(260);
+    expect(parsed.gain).toBe(0.09);
+  });
+
+  test("the cue can be turned off", () => {
+    expect(
+      LiveVoiceWorkingCueConfigSchema.parse({ enabled: false }).enabled,
+    ).toBe(false);
+  });
+
+  test("rejects a non-positive intervalMs", () => {
+    const result = LiveVoiceWorkingCueConfigSchema.safeParse({ intervalMs: 0 });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const msgs = result.error.issues.map((i) => i.message);
+      expect(
+        msgs.some((m) => m.includes("liveVoice.workingCue.intervalMs")),
+      ).toBe(true);
+    }
+  });
+
+  test("rejects an intervalMs past the timer maximum", () => {
+    // setTimeout holds its delay in a signed 32-bit int, so a larger value
+    // wraps and fires almost immediately: the cue would become a continuous
+    // tone rather than the very long silence the number asks for.
+    const result = LiveVoiceWorkingCueConfigSchema.safeParse({
+      intervalMs: 2_147_483_648,
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const msgs = result.error.issues.map((i) => i.message);
+      expect(
+        msgs.some((m) => m.includes("liveVoice.workingCue.intervalMs")),
+      ).toBe(true);
+    }
+  });
+
+  test("accepts the largest interval a timer can hold", () => {
+    const result = LiveVoiceWorkingCueConfigSchema.safeParse({
+      intervalMs: 2_147_483_647,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects a durationMs past the cue-length cap", () => {
+    // The value sizes a PCM buffer at the client's sample rate, so an
+    // unbounded one is an unbounded Buffer.alloc from a timer callback.
+    const result = LiveVoiceWorkingCueConfigSchema.safeParse({
+      durationMs: 1_000_000_000,
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const msgs = result.error.issues.map((i) => i.message);
+      expect(
+        msgs.some((m) => m.includes("liveVoice.workingCue.durationMs")),
+      ).toBe(true);
+    }
+    // The cap is a ceiling on a short tone, not a ban on tuning it.
+    expect(
+      LiveVoiceWorkingCueConfigSchema.parse({ durationMs: 2_000 }).durationMs,
+    ).toBe(2_000);
+  });
+
+  test("rejects a frequencyHz past the top of hearing", () => {
+    expect(
+      LiveVoiceWorkingCueConfigSchema.safeParse({ frequencyHz: 96_000 })
+        .success,
+    ).toBe(false);
+    expect(
+      LiveVoiceWorkingCueConfigSchema.parse({ frequencyHz: 20_000 })
+        .frequencyHz,
+    ).toBe(20_000);
+  });
+
+  test("rejects a gain outside 0..1", () => {
+    // The renderer clamps, so an out-of-range gain would otherwise be a
+    // silently ignored setting rather than a visible mistake.
+    expect(
+      LiveVoiceWorkingCueConfigSchema.safeParse({ gain: 1.5 }).success,
+    ).toBe(false);
+    expect(
+      LiveVoiceWorkingCueConfigSchema.safeParse({ gain: -0.1 }).success,
+    ).toBe(false);
   });
 });
 
@@ -325,6 +437,9 @@ describe("LiveVoiceConfigSchema", () => {
         echoDrainSlackMs: 300,
       },
       frontModel: FRONT_MODEL_DEFAULTS,
+      // On by default: a working turn holds its silence with the cue rather
+      // than narrating over it.
+      workingCue: WORKING_CUE_DEFAULTS,
       // Off by default: Flux turn detection is opt-in, so the front-door hold
       // verdict keeps committing turns until it is enabled.
       flux: FLUX_DEFAULTS,
@@ -355,6 +470,7 @@ describe("LiveVoiceConfigSchema", () => {
       mode: "ptt",
       vad: { silenceThresholdMs: 900 },
       frontModel: { endpointDecisionTimeoutMs: 300 },
+      workingCue: { intervalMs: 20_000 },
       flux: { turnEnd: { enabled: true } },
       maxSessionDurationSeconds: 600,
     });
@@ -366,6 +482,9 @@ describe("LiveVoiceConfigSchema", () => {
     // Partial frontModel overrides merge with defaults
     expect(parsed.frontModel.endpointDecisionTimeoutMs).toBe(300);
     expect(parsed.frontModel.endpointExtensionMs).toBe(1500);
+    // Partial workingCue overrides merge with defaults
+    expect(parsed.workingCue.intervalMs).toBe(20_000);
+    expect(parsed.workingCue.enabled).toBe(true);
     // Partial flux overrides merge with defaults
     expect(parsed.flux.turnEnd.enabled).toBe(true);
     expect(parsed.flux.eotThreshold).toBe(0.7);

--- a/assistant/src/config/schemas/live-voice.ts
+++ b/assistant/src/config/schemas/live-voice.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+import { DEFAULT_WORKING_CUE_SHAPE } from "../../live-voice/working-cue.js";
+
 export const VALID_LIVE_VOICE_MODES = ["ptt", "open-mic"] as const;
 
 export const LiveVoiceVadConfigSchema = z
@@ -78,9 +80,9 @@ export const LiveVoiceProgressConfigSchema = z
       .boolean({
         error: "liveVoice.frontModel.progress.enabled must be a boolean",
       })
-      .default(true)
+      .default(false)
       .describe(
-        "Speak short progress updates during long-running tool-heavy turns; the opt-out for progress narration",
+        "Speak short progress updates during long-running tool-heavy turns. Off by default: a working turn holds its silence with the wordless liveVoice.workingCue instead, which says the same thing without making a claim the user has to listen to. This setting wins over the cue, so turning it on replaces the cue with spoken narration even where liveVoice.workingCue.enabled is also true.",
       ),
     opsThreshold: z
       .number({
@@ -168,6 +170,86 @@ export const LiveVoiceProgressConfigSchema = z
   })
   .describe(
     "Progress-narration tuning for live voice sessions (spoken updates during long-running turns)",
+  );
+
+/**
+ * Ceiling on the cue tone's length. The value is multiplied by the client's
+ * sample rate to size the rendered PCM buffer, so it is an allocation request
+ * arriving from config and reaching `Buffer.alloc` from a timer callback: a
+ * large finite value asks for gigabytes the moment the first cue fires. Two
+ * seconds is far past anything that still reads as punctuation and leaves the
+ * worst case well under a megabyte at any sample rate a client can ask for.
+ */
+const MAX_WORKING_CUE_DURATION_MS = 2_000;
+
+// setTimeout stores its delay in a signed 32-bit int, so a larger value wraps
+// and fires almost immediately. A cue interval past this would not be a very
+// long silence, it would be a continuous tone: exactly inverted from what the
+// number says. Reject it instead, since anything near the cap is already far
+// longer than a working turn.
+const MAX_WORKING_CUE_INTERVAL_MS = 2_147_483_647;
+
+/**
+ * Ceiling on the cue's fundamental. Above the top of human hearing the tone is
+ * inaudible, and above half the session's sample rate it aliases down to some
+ * unrelated pitch, so a value up here is always a mistake rather than a taste.
+ */
+const MAX_WORKING_CUE_FREQUENCY_HZ = 20_000;
+
+export const LiveVoiceWorkingCueConfigSchema = z
+  .object({
+    enabled: z
+      .boolean({ error: "liveVoice.workingCue.enabled must be a boolean" })
+      .default(true)
+      .describe(
+        "Hold a working turn's silence with a short wordless tone; the opt-out for the working cue. liveVoice.frontModel.progress.enabled wins over this, so a turn plays the cue only where spoken narration is off. Turning both off leaves the working turn silent.",
+      ),
+    intervalMs: z
+      .number({ error: "liveVoice.workingCue.intervalMs must be a number" })
+      .int("liveVoice.workingCue.intervalMs must be an integer")
+      .positive("liveVoice.workingCue.intervalMs must be a positive integer")
+      .max(
+        MAX_WORKING_CUE_INTERVAL_MS,
+        `liveVoice.workingCue.intervalMs must be at most ${MAX_WORKING_CUE_INTERVAL_MS}`,
+      )
+      .default(12_000)
+      .describe(
+        `Audible silence (ms) between cues while a turn works. This is a cadence for punctuation, not for speech, so it can sit far below what a spoken update would tolerate. Capped at ${MAX_WORKING_CUE_INTERVAL_MS}, the largest delay a timer can hold without wrapping to near-zero`,
+      ),
+    frequencyHz: z
+      .number({ error: "liveVoice.workingCue.frequencyHz must be a number" })
+      .positive("liveVoice.workingCue.frequencyHz must be a positive number")
+      .max(
+        MAX_WORKING_CUE_FREQUENCY_HZ,
+        `liveVoice.workingCue.frequencyHz must be at most ${MAX_WORKING_CUE_FREQUENCY_HZ}`,
+      )
+      .default(DEFAULT_WORKING_CUE_SHAPE.frequencyHz)
+      .describe(
+        `Fundamental (Hz) of the cue tone. Low reads as a hum under the call, high as a notification chime. Capped at ${MAX_WORKING_CUE_FREQUENCY_HZ}, the top of human hearing, above which the tone is either inaudible or aliased into an unrelated pitch`,
+      ),
+    durationMs: z
+      .number({ error: "liveVoice.workingCue.durationMs must be a number" })
+      .int("liveVoice.workingCue.durationMs must be an integer")
+      .positive("liveVoice.workingCue.durationMs must be a positive integer")
+      .max(
+        MAX_WORKING_CUE_DURATION_MS,
+        `liveVoice.workingCue.durationMs must be at most ${MAX_WORKING_CUE_DURATION_MS}`,
+      )
+      .default(DEFAULT_WORKING_CUE_SHAPE.durationMs)
+      .describe(
+        `Length (ms) of the cue tone, fades included. Short enough to read as punctuation rather than as audio the user is meant to attend to. Capped at ${MAX_WORKING_CUE_DURATION_MS}: the value sizes the rendered PCM buffer, so an unbounded one is an unbounded allocation from a timer callback`,
+      ),
+    gain: z
+      .number({ error: "liveVoice.workingCue.gain must be a number" })
+      .min(0, "liveVoice.workingCue.gain must be between 0 and 1")
+      .max(1, "liveVoice.workingCue.gain must be between 0 and 1")
+      .default(DEFAULT_WORKING_CUE_SHAPE.gain)
+      .describe(
+        "Peak amplitude (0..1) of the cue tone. Well below speech so it sits under the call",
+      ),
+  })
+  .describe(
+    "Working-cue tuning for live voice sessions (the wordless tone that holds a long turn's silence)",
   );
 
 export const LiveVoiceFrontModelConfigSchema = z
@@ -290,6 +372,9 @@ export const LiveVoiceConfigSchema = z
     frontModel: LiveVoiceFrontModelConfigSchema.default(
       LiveVoiceFrontModelConfigSchema.parse({}),
     ),
+    workingCue: LiveVoiceWorkingCueConfigSchema.default(
+      LiveVoiceWorkingCueConfigSchema.parse({}),
+    ),
     flux: LiveVoiceFluxConfigSchema.default(
       LiveVoiceFluxConfigSchema.parse({}),
     ),
@@ -321,5 +406,8 @@ export type LiveVoiceFrontModelConfig = z.infer<
 >;
 export type LiveVoiceProgressConfig = z.infer<
   typeof LiveVoiceProgressConfigSchema
+>;
+export type LiveVoiceWorkingCueConfig = z.infer<
+  typeof LiveVoiceWorkingCueConfigSchema
 >;
 export type LiveVoiceFluxConfig = z.infer<typeof LiveVoiceFluxConfigSchema>;

--- a/assistant/src/config/schemas/live-voice.ts
+++ b/assistant/src/config/schemas/live-voice.ts
@@ -202,7 +202,7 @@ export const LiveVoiceWorkingCueConfigSchema = z
       .boolean({ error: "liveVoice.workingCue.enabled must be a boolean" })
       .default(true)
       .describe(
-        "Hold a working turn's silence with a short wordless tone; the opt-out for the working cue. liveVoice.frontModel.progress.enabled wins over this, so a turn plays the cue only where spoken narration is off. Turning both off leaves the working turn silent.",
+        "Hold a working turn's silence with a short wordless tone; the opt-out for the working cue. liveVoice.frontModel.progress.enabled wins over this, so a turn plays the cue only where spoken narration is off. Turning both off leaves the working turn silent. The client must also declare it can read non-speech audio: one packaged before that capability is never sent the cue whatever this says, since it would score the tone as answer speech.",
       ),
     intervalMs: z
       .number({ error: "liveVoice.workingCue.intervalMs must be a number" })

--- a/assistant/src/live-voice/__tests__/live-activity-reporter.test.ts
+++ b/assistant/src/live-voice/__tests__/live-activity-reporter.test.ts
@@ -32,6 +32,11 @@ function sttFinal(text: string): LiveVoiceServerFramePayload {
   return { type: "stt_final", text } as LiveVoiceServerFramePayload;
 }
 
+/** A `tts_audio` frame carrying the wordless working cue rather than speech. */
+function cue(): LiveVoiceServerFramePayload {
+  return { type: "tts_audio", nonSpeech: true } as LiveVoiceServerFramePayload;
+}
+
 /** A reporter whose dispatches are captured instead of sent. */
 class RecordingReporter extends LiveActivityReporter {
   readonly dispatched: Array<{ phase: string; event: string; detail: string }> =
@@ -92,6 +97,19 @@ describe("phaseForFrame", () => {
   // discarded.
   test("an empty final moves nothing", () => {
     expect(phaseForFrame(sttFinal("   "), "transcribing")).toBeNull();
+  });
+
+  // The whole point of the working cue is that the turn is NOT talking: it
+  // holds a silence. An island that flipped to "Speaking…" on the tone would
+  // stay there for the entire tool run, since every later cue repeats the
+  // claim and a silent turn sends no speech to correct it.
+  test("the working cue is audio, not speech, so it moves no phase", () => {
+    expect(phaseForFrame(cue(), "thinking")).toBeNull();
+    expect(phaseForFrame(cue(), "listening")).toBeNull();
+  });
+
+  test("speech after a cue still reaches speaking", () => {
+    expect(phaseForFrame(frame("tts_audio"), "thinking")).toBe("speaking");
   });
 });
 

--- a/assistant/src/live-voice/__tests__/live-voice-metrics.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-metrics.test.ts
@@ -419,6 +419,32 @@ describe("LiveVoiceMetricsCollector", () => {
     ).toMatchObject({ progressUpdatesSpoken: 2 });
   });
 
+  test("accumulates working cues played on the turn and aggregate fields", () => {
+    const clock = makeClock(0);
+    const collector = new LiveVoiceMetricsCollector({
+      sessionId: "session-cue",
+      conversationId: "conversation-cue",
+      clock: clock.now,
+    });
+
+    collector.startTurn("turn-cue");
+    const frame = collector.markWorkingCuePlayed("turn-cue");
+    expect(frame.event).toBe("working_cue_played");
+    collector.markWorkingCuePlayed("turn-cue");
+    const completed = collector.completeTurn();
+
+    // The cue is the default floor-holder and narration is off by default, so
+    // without this counter a turn that hummed through its silence and one
+    // that sat in it are the same turn in telemetry.
+    expect(completed).toMatchObject({
+      turnId: "turn-cue",
+      workingCuesPlayed: 2,
+    });
+    expect(
+      getLiveVoiceMetricsAggregateFields(collector.getSnapshot(), "turn-cue"),
+    ).toMatchObject({ workingCuesPlayed: 2 });
+  });
+
   test("omits endpoint and progress fields for turns that never touch the features", () => {
     const clock = makeClock(0);
     const collector = new LiveVoiceMetricsCollector({
@@ -437,6 +463,7 @@ describe("LiveVoiceMetricsCollector", () => {
     expect(completed).not.toHaveProperty("endpointDecisionSource");
     expect(completed).not.toHaveProperty("ackSpoken");
     expect(completed).not.toHaveProperty("progressUpdatesSpoken");
+    expect(completed).not.toHaveProperty("workingCuesPlayed");
 
     const aggregateFields = getLiveVoiceMetricsAggregateFields(
       collector.getSnapshot(),
@@ -448,6 +475,7 @@ describe("LiveVoiceMetricsCollector", () => {
     expect(aggregateFields).not.toHaveProperty("endpointDecisionSource");
     expect(aggregateFields).not.toHaveProperty("ackSpoken");
     expect(aggregateFields).not.toHaveProperty("progressUpdatesSpoken");
+    expect(aggregateFields).not.toHaveProperty("workingCuesPlayed");
   });
 
   test("markEndpointCommit records the commit latency independently of the decision fields", () => {

--- a/assistant/src/live-voice/__tests__/live-voice-progress.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-progress.test.ts
@@ -9,6 +9,7 @@ import { loadRawConfig, saveRawConfig } from "../../config/loader.js";
 import type {
   LiveVoiceFrontModelConfig,
   LiveVoiceProgressConfig,
+  LiveVoiceWorkingCueConfig,
 } from "../../config/schemas/live-voice.js";
 import type {
   StreamingTranscriber,
@@ -26,6 +27,7 @@ import type {
   VoiceProgressTextInput,
 } from "../progress-narration.js";
 import {
+  approvalPendingPhraseFor,
   pickProgressPhrase,
   PROGRESS_FALLBACK_PHRASES,
   PROGRESS_FALLBACK_PHRASES_BY_LANGUAGE,
@@ -35,6 +37,10 @@ import {
   type LiveVoiceClientStartFrame,
   type LiveVoiceServerFrame,
 } from "../protocol.js";
+import {
+  DEFAULT_WORKING_CUE_SHAPE,
+  renderWorkingCuePcm,
+} from "../working-cue.js";
 
 const START_FRAME = {
   type: "start",
@@ -98,19 +104,30 @@ function createContext(): {
 function createCapturingTurnStarter(): {
   startVoiceTurn: LiveVoiceTurnStarter;
   getCallbacks: () => VoiceTurnCallbacks | undefined;
+  approvalPending: (requestId: string) => void;
 } {
   let callbacks: VoiceTurnCallbacks | undefined;
+  let onApprovalPending: VoiceTurnOptions["onApprovalPending"];
   const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
     callbacks = options.callbacks;
+    onApprovalPending = options.onApprovalPending;
     return { turnId: "bridge-turn-1", abort: mock() };
   });
-  return { startVoiceTurn, getCallbacks: () => callbacks };
+  return {
+    startVoiceTurn,
+    getCallbacks: () => callbacks,
+    approvalPending: (requestId) => onApprovalPending?.(requestId),
+  };
 }
 
 function createRecordingTtsStreamer(
   // Per-segment synthesis stall: a non-null promise keeps that segment's TTS
   // job unsettled (audio still emitting) until it resolves.
   gateTtsText?: (text: string) => Promise<void> | null,
+  // Emit this much silent PCM per segment. Without it the mock produces no
+  // audio at all, so the session's client playback-tail estimate never moves
+  // and every turn reads as instantly silent.
+  emitChunkMs?: number,
 ): {
   streamTtsAudio: LiveVoiceTtsStreamer;
   ttsTexts: string[];
@@ -121,6 +138,16 @@ function createRecordingTtsStreamer(
   const streamTtsAudio = mock(async (options: LiveVoiceTtsOptions) => {
     ttsTexts.push(options.text);
     ttsCalls.push(options);
+    if (emitChunkMs !== undefined) {
+      options.onAudioChunk({
+        type: "tts_audio",
+        contentType: "audio/pcm",
+        sampleRate: START_FRAME.audio.sampleRate,
+        dataBase64: Buffer.alloc(
+          Math.round((START_FRAME.audio.sampleRate * emitChunkMs) / 1_000) * 2,
+        ).toString("base64"),
+      });
+    }
     await gateTtsText?.(options.text);
     return {
       provider: "fish-audio" as const,
@@ -165,15 +192,21 @@ function progressConfig(
 function createProgressHarness(options: {
   frontModelConfig: Partial<LiveVoiceFrontModelConfig>;
   progressNarrator: VoiceProgressNarrator;
+  // The cue and spoken narration are alternatives, so a narration test turns
+  // the cue off. Cue tests pass their own config.
+  workingCueConfig?: Partial<LiveVoiceWorkingCueConfig>;
   emitMetrics?: boolean;
   gateTtsText?: (text: string) => Promise<void> | null;
+  emitChunkMs?: number;
   // Events the transcriber flushes at utterance release; defaults to a plain
   // untagged "hello" final.
   sttStopEvents?: SttStreamServerEvent[];
 }) {
-  const { startVoiceTurn, getCallbacks } = createCapturingTurnStarter();
+  const { startVoiceTurn, getCallbacks, approvalPending } =
+    createCapturingTurnStarter();
   const { streamTtsAudio, ttsTexts, ttsCalls } = createRecordingTtsStreamer(
     options.gateTtsText,
+    options.emitChunkMs,
   );
   const { context, frames } = createContext();
   const session = new LiveVoiceSession(context, {
@@ -183,12 +216,20 @@ function createProgressHarness(options: {
     startVoiceTurn,
     streamTtsAudio,
     frontModelConfig: options.frontModelConfig,
+    workingCueConfig: options.workingCueConfig ?? { enabled: false },
     progressNarrator: options.progressNarrator,
     createTurnId: () => "live-turn-1",
     emitMetrics: options.emitMetrics ?? false,
   });
 
-  return { frames, session, getCallbacks, ttsTexts, ttsCalls };
+  return {
+    frames,
+    session,
+    getCallbacks,
+    approvalPending,
+    ttsTexts,
+    ttsCalls,
+  };
 }
 
 async function startReleasedTurn(
@@ -925,5 +966,327 @@ describe("LiveVoiceSession progress narration", () => {
     expect(generateProgressText).toHaveBeenCalledTimes(2);
 
     emitMessageComplete(getCallbacks);
+  });
+});
+
+const CUE_INTERVAL_MS = 40;
+
+// A one-clause answer, so it survives sanitizeForTts unchanged and the text
+// the TTS mock records is the text emitted here.
+const ANSWER_TEXT = "Here is the answer.";
+
+const WORKING_CUE_CONFIG = {
+  enabled: true,
+  intervalMs: CUE_INTERVAL_MS,
+  // A cue leaves a playback-tail estimate behind, and that tail is part of
+  // the silence the next tick waits out. Shortening the tone keeps the
+  // silence-to-silence cadence close to the interval so these tests finish in
+  // a few hundred milliseconds.
+  durationMs: 20,
+} as const;
+
+// The cue the session renders for this start frame and config. Comparing
+// frames against the renderer's own output is what ties the emitted bytes to
+// the configured shape rather than to "some audio came out".
+const CUE_PCM = renderWorkingCuePcm(START_FRAME.audio.sampleRate, {
+  ...DEFAULT_WORKING_CUE_SHAPE,
+  durationMs: WORKING_CUE_CONFIG.durationMs,
+});
+const CUE_BASE64 = CUE_PCM.toString("base64");
+
+function cueFrames(
+  frames: LiveVoiceServerFrame[],
+): Extract<LiveVoiceServerFrame, { type: "tts_audio" }>[] {
+  return frames.filter(
+    (frame): frame is Extract<LiveVoiceServerFrame, { type: "tts_audio" }> =>
+      frame.type === "tts_audio" && frame.dataBase64 === CUE_BASE64,
+  );
+}
+
+// Session state the cue's contract is written against but no frame exposes.
+type TurnView = { ttsSegmentEnqueued: boolean; ttsAudioStarted: boolean };
+
+function turnInternals(session: LiveVoiceSession): {
+  ttsSegmentEnqueued: () => boolean | undefined;
+  ttsAudioStarted: () => boolean | undefined;
+  firstTtsAudioAtMs: () => number | null | undefined;
+  echoReference: () => Buffer;
+  audioIdle: () => boolean;
+} {
+  const internals = session as unknown as {
+    activeAssistantTurn: TurnView | null;
+    echoReferenceAudio: Buffer;
+    turnAudioIdle: (turn: TurnView) => boolean;
+    metrics: {
+      getSnapshot: () => {
+        activeTurn: { timestamps: { firstTtsAudioAtMs: number | null } } | null;
+      };
+    };
+  };
+  return {
+    ttsSegmentEnqueued: () => internals.activeAssistantTurn?.ttsSegmentEnqueued,
+    ttsAudioStarted: () => internals.activeAssistantTurn?.ttsAudioStarted,
+    firstTtsAudioAtMs: () =>
+      internals.metrics.getSnapshot().activeTurn?.timestamps.firstTtsAudioAtMs,
+    echoReference: () => internals.echoReferenceAudio,
+    audioIdle: () => {
+      const turn = internals.activeAssistantTurn;
+      return turn !== null && internals.turnAudioIdle(turn);
+    },
+  };
+}
+
+// Escalates the turn so it is in the working phase the cue exists for: the
+// canned bridge speaks, then the strong leg works in silence.
+async function startEscalatedProgressTurn(
+  session: LiveVoiceSession,
+  getCallbacks: () => VoiceTurnCallbacks | undefined,
+  ttsTexts: string[],
+): Promise<void> {
+  await startReleasedTurn(session, getCallbacks);
+  emitTextDelta(getCallbacks, "[1]");
+  emitMessageComplete(getCallbacks);
+  await waitFor(() => ttsTexts.length === 1);
+}
+
+describe("LiveVoiceSession working cue", () => {
+  test("an idle escalated turn plays the cue and speaks no narration", async () => {
+    const generateProgressText = mock(async () => GENERATED_NARRATION);
+    const { frames, session, getCallbacks, ttsTexts } = createProgressHarness({
+      // A narrator is wired up and would happily produce text, so what keeps
+      // the turn wordless is the config rather than a missing dependency.
+      frontModelConfig: progressConfig({
+        enabled: false,
+        idleIntervalMs: CUE_INTERVAL_MS,
+      }),
+      workingCueConfig: WORKING_CUE_CONFIG,
+      progressNarrator: makeProgressNarrator(generateProgressText),
+    });
+    await startEscalatedProgressTurn(session, getCallbacks, ttsTexts);
+
+    await waitFor(() => cueFrames(frames).length >= 1);
+    const cue = cueFrames(frames)[0];
+    // audio/pcm at the session rate: the contract appendEchoReference reads.
+    expect(cue?.mimeType).toBe("audio/pcm");
+    expect(cue?.sampleRate).toBe(START_FRAME.audio.sampleRate);
+
+    // The bridge is the only thing the turn spoke, and the narrator was never
+    // asked for a line to add to it.
+    expect(ttsTexts).toHaveLength(1);
+    expect(generateProgressText).not.toHaveBeenCalled();
+  });
+
+  test("the cue repeats on its interval while the silence lasts", async () => {
+    const { frames, session, getCallbacks, ttsTexts } = createProgressHarness({
+      frontModelConfig: progressConfig({ enabled: false }),
+      workingCueConfig: WORKING_CUE_CONFIG,
+      progressNarrator: makeProgressNarrator(async () => GENERATED_NARRATION),
+    });
+    await startEscalatedProgressTurn(session, getCallbacks, ttsTexts);
+
+    await waitFor(() => cueFrames(frames).length >= 1);
+    const afterFirstCueMs = Date.now();
+    await waitFor(() => cueFrames(frames).length >= 3);
+
+    // Two further cues cost two further intervals: the cadence is the
+    // configured one, not a burst. Timers never fire early, so the lower
+    // bound is the reliable half of the assertion.
+    expect(Date.now() - afterFirstCueMs).toBeGreaterThanOrEqual(
+      2 * CUE_INTERVAL_MS,
+    );
+    // Every cue is the same rendered audio.
+    for (const frame of cueFrames(frames)) {
+      expect(frame.dataBase64).toBe(CUE_BASE64);
+    }
+  });
+
+  test("narration's minGap does not slow the cue's own cadence", async () => {
+    // minGapMs is narration's spacing guard, tuned for spoken filler. The cue
+    // is spaced by its own intervalMs, so a large narration gap must not veto
+    // it: the two tunables live in separate config sections precisely so a
+    // workspace can tune one without silently retuning the other.
+    const { frames, session, getCallbacks, ttsTexts } = createProgressHarness({
+      frontModelConfig: progressConfig({
+        enabled: false,
+        minGapMs: 60_000,
+      }),
+      workingCueConfig: WORKING_CUE_CONFIG,
+      progressNarrator: makeProgressNarrator(async () => GENERATED_NARRATION),
+    });
+    await startEscalatedProgressTurn(session, getCallbacks, ttsTexts);
+
+    // A minGap 1500x the cue interval would pin this at one cue forever if the
+    // gap applied to the cue.
+    await waitFor(() => cueFrames(frames).length >= 3);
+    expect(cueFrames(frames).length).toBeGreaterThanOrEqual(3);
+  });
+
+  test("a turn whose speech is still playing waits it out before the cue", async () => {
+    const speechMs = 150;
+    const { frames, session, getCallbacks, ttsTexts } = createProgressHarness({
+      frontModelConfig: progressConfig({ enabled: false }),
+      workingCueConfig: WORKING_CUE_CONFIG,
+      progressNarrator: makeProgressNarrator(async () => GENERATED_NARRATION),
+      // The bridge is real audio now, so the turn is audibly busy for
+      // `speechMs` after the frame goes out even though its job has settled.
+      emitChunkMs: speechMs,
+    });
+    await startEscalatedProgressTurn(session, getCallbacks, ttsTexts);
+    await waitFor(() => frames.some((frame) => frame.type === "tts_audio"));
+    const bridgeSentAtMs = Date.now();
+
+    await waitFor(() => cueFrames(frames).length >= 1);
+
+    // Several idle ticks fall inside the bridge's playback, and every one of
+    // them stays quiet: a cue over the assistant's own voice is the chatter
+    // this design removes, not a reassurance.
+    expect(Date.now() - bridgeSentAtMs).toBeGreaterThanOrEqual(speechMs);
+  });
+
+  test("tool activity alone plays no cue; only silence does", async () => {
+    const { frames, session, getCallbacks, ttsTexts } = createProgressHarness({
+      frontModelConfig: progressConfig({ enabled: false, opsThreshold: 1 }),
+      // Far longer than this test runs, so nothing here can reach the cue
+      // through the idle tick and any cue that appears came from a tool event.
+      workingCueConfig: { ...WORKING_CUE_CONFIG, intervalMs: 60_000 },
+      progressNarrator: makeProgressNarrator(async () => GENERATED_NARRATION),
+    });
+    await startEscalatedProgressTurn(session, getCallbacks, ttsTexts);
+    // The bridge has to have drained first: a turn that is still speaking has
+    // its own reason to stay quiet, and this test is about the trigger.
+    await waitFor(() => turnInternals(session).audioIdle());
+
+    emitToolStart(getCallbacks, "web_search", "tool-1");
+    emitToolResult(getCallbacks, "web_search", "tool-1", "found it");
+    emitToolStart(getCallbacks, "file_read", "tool-2");
+    await sleep(CUE_INTERVAL_MS * 3);
+
+    // A tone carries nothing about which tool ran, so a tool starting or
+    // finishing is not news it can deliver. Only the silence is.
+    expect(cueFrames(frames)).toHaveLength(0);
+  });
+
+  test("with both off the working turn stays silent", async () => {
+    const generateProgressText = mock(async () => GENERATED_NARRATION);
+    const { frames, session, getCallbacks, ttsTexts } = createProgressHarness({
+      frontModelConfig: progressConfig({ enabled: false }),
+      workingCueConfig: { enabled: false },
+      progressNarrator: makeProgressNarrator(generateProgressText),
+    });
+    await startEscalatedProgressTurn(session, getCallbacks, ttsTexts);
+
+    await sleep(CUE_INTERVAL_MS * 3);
+    expect(cueFrames(frames)).toHaveLength(0);
+    expect(generateProgressText).not.toHaveBeenCalled();
+    expect(ttsTexts).toHaveLength(1);
+  });
+
+  test("a pending approval suppresses the cue and still speaks its phrase", async () => {
+    const approvalPhrase = sanitizeForTts(approvalPendingPhraseFor()).trim();
+    const { frames, session, getCallbacks, approvalPending, ttsTexts } =
+      createProgressHarness({
+        frontModelConfig: progressConfig({ enabled: false }),
+        workingCueConfig: WORKING_CUE_CONFIG,
+        progressNarrator: makeProgressNarrator(async () => GENERATED_NARRATION),
+      });
+    await startEscalatedProgressTurn(session, getCallbacks, ttsTexts);
+
+    approvalPending("approval-request-1");
+    await waitFor(() => ttsTexts.includes(approvalPhrase));
+
+    // Nothing is in flight while the call waits on a person, so the cue's
+    // claim that work is happening would be false. The turn said so once and
+    // then goes quiet.
+    await sleep(CUE_INTERVAL_MS * 3);
+    expect(cueFrames(frames)).toHaveLength(0);
+  });
+
+  test("explicitly enabled narration outranks the cue", async () => {
+    const generateProgressText = mock(async () => GENERATED_NARRATION);
+    const { frames, session, getCallbacks, ttsTexts } = createProgressHarness({
+      // Progress narration defaults to off, so `enabled: true` can only have
+      // come from a workspace asking for words. The cue is on as well, and
+      // loses.
+      frontModelConfig: progressConfig({
+        enabled: true,
+        idleIntervalMs: CUE_INTERVAL_MS,
+      }),
+      workingCueConfig: WORKING_CUE_CONFIG,
+      progressNarrator: makeProgressNarrator(generateProgressText),
+    });
+    await startEscalatedProgressTurn(session, getCallbacks, ttsTexts);
+
+    await waitFor(() => ttsTexts.includes(GENERATED_NARRATION));
+    // A workspace that asked to be narrated at gets narration only, not
+    // narration punctuated by a tone it never configured.
+    expect(cueFrames(frames)).toHaveLength(0);
+  });
+
+  test("the cue does not anchor the turn's first-TTS metrics", async () => {
+    // The answer's synthesis stalls open, so the turn is still active (and its
+    // metrics still the live turn's) while the assertions below run.
+    const answerSpoken = deferred<void>();
+    const { frames, session, getCallbacks, ttsTexts } = createProgressHarness({
+      frontModelConfig: progressConfig({ enabled: false }),
+      workingCueConfig: WORKING_CUE_CONFIG,
+      progressNarrator: makeProgressNarrator(async () => GENERATED_NARRATION),
+      gateTtsText: (text) =>
+        text === ANSWER_TEXT ? answerSpoken.promise : null,
+      // Real bytes per synthesized segment, so the speech below actually
+      // reaches forwardTtsChunk and can latch.
+      emitChunkMs: 10,
+    });
+    // A plain turn, so the cue is the first audio of any kind the turn emits.
+    await startReleasedTurn(session, getCallbacks);
+
+    await waitFor(() => cueFrames(frames).length >= 1);
+    // dispatchToFirstTtsAudioMs, roundTripMs, and
+    // firstAssistantDeltaToFirstTtsAudioMs all measure to this mark. Setting
+    // it here would report the hum's timing as the turn's speech latency on
+    // exactly the long working turns the cue exists for.
+    expect(turnInternals(session).ttsAudioStarted()).toBe(false);
+    expect(turnInternals(session).firstTtsAudioAtMs()).toBeNull();
+
+    emitTextDelta(getCallbacks, ANSWER_TEXT);
+    emitMessageComplete(getCallbacks);
+    await waitFor(() => ttsTexts.includes(ANSWER_TEXT));
+
+    // The first real speech still latches: the cue skips the mark, it does not
+    // consume it.
+    await waitFor(() => turnInternals(session).ttsAudioStarted() === true);
+    expect(turnInternals(session).firstTtsAudioAtMs()).not.toBeNull();
+    answerSpoken.resolve(undefined);
+  });
+
+  test("the cue does not spend the eager first-segment latch", async () => {
+    const { frames, session, getCallbacks } = createProgressHarness({
+      frontModelConfig: progressConfig({ enabled: false }),
+      workingCueConfig: WORKING_CUE_CONFIG,
+      progressNarrator: makeProgressNarrator(async () => GENERATED_NARRATION),
+    });
+    // A plain turn: nothing has been spoken, so the eager first-clause flush
+    // is still unspent when the cue plays.
+    await startReleasedTurn(session, getCallbacks);
+
+    await waitFor(() => cueFrames(frames).length >= 1);
+    expect(turnInternals(session).ttsSegmentEnqueued()).toBe(false);
+  });
+
+  test("the cue's chunk enters the echo reference", async () => {
+    const { frames, session, getCallbacks } = createProgressHarness({
+      frontModelConfig: progressConfig({ enabled: false }),
+      workingCueConfig: WORKING_CUE_CONFIG,
+      progressNarrator: makeProgressNarrator(async () => GENERATED_NARRATION),
+    });
+    await startReleasedTurn(session, getCallbacks);
+
+    await waitFor(() => cueFrames(frames).length >= 1);
+    // Without this the canceller has no record that the hum was the assistant,
+    // and the cue becomes a periodic barge-in trigger.
+    const reference = turnInternals(session).echoReference();
+    expect(reference.byteLength).toBeGreaterThanOrEqual(CUE_PCM.byteLength);
+    expect(reference.subarray(0, CUE_PCM.byteLength).equals(CUE_PCM)).toBe(
+      true,
+    );
   });
 });

--- a/assistant/src/live-voice/__tests__/live-voice-progress.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-progress.test.ts
@@ -17,6 +17,8 @@ import type {
 } from "../../stt/types.js";
 import {
   LiveVoiceSession,
+  type LiveVoiceSessionArchiveAudioInput,
+  type LiveVoiceSessionAudioArchiver,
   type LiveVoiceTtsStreamer,
   type LiveVoiceTurnStarter,
 } from "../live-voice-session.js";
@@ -128,6 +130,10 @@ function createRecordingTtsStreamer(
   // audio at all, so the session's client playback-tail estimate never moves
   // and every turn reads as instantly silent.
   emitChunkMs?: number,
+  // Content type the provider labels its chunks with. Some return a container
+  // format despite outputFormat "pcm", which is what makes the archive's mime
+  // stamp worth pinning.
+  chunkContentType = "audio/pcm",
 ): {
   streamTtsAudio: LiveVoiceTtsStreamer;
   ttsTexts: string[];
@@ -141,7 +147,7 @@ function createRecordingTtsStreamer(
     if (emitChunkMs !== undefined) {
       options.onAudioChunk({
         type: "tts_audio",
-        contentType: "audio/pcm",
+        contentType: chunkContentType,
         sampleRate: START_FRAME.audio.sampleRate,
         dataBase64: Buffer.alloc(
           Math.round((START_FRAME.audio.sampleRate * emitChunkMs) / 1_000) * 2,
@@ -198,6 +204,8 @@ function createProgressHarness(options: {
   emitMetrics?: boolean;
   gateTtsText?: (text: string) => Promise<void> | null;
   emitChunkMs?: number;
+  chunkContentType?: string;
+  archiveAudio?: LiveVoiceSessionAudioArchiver;
   // Events the transcriber flushes at utterance release; defaults to a plain
   // untagged "hello" final.
   sttStopEvents?: SttStreamServerEvent[];
@@ -207,6 +215,7 @@ function createProgressHarness(options: {
   const { streamTtsAudio, ttsTexts, ttsCalls } = createRecordingTtsStreamer(
     options.gateTtsText,
     options.emitChunkMs,
+    options.chunkContentType,
   );
   const { context, frames } = createContext();
   const session = new LiveVoiceSession(context, {
@@ -218,6 +227,7 @@ function createProgressHarness(options: {
     frontModelConfig: options.frontModelConfig,
     workingCueConfig: options.workingCueConfig ?? { enabled: false },
     progressNarrator: options.progressNarrator,
+    ...(options.archiveAudio ? { archiveAudio: options.archiveAudio } : {}),
     createTurnId: () => "live-turn-1",
     emitMetrics: options.emitMetrics ?? false,
   });
@@ -994,6 +1004,12 @@ const CUE_PCM = renderWorkingCuePcm(START_FRAME.audio.sampleRate, {
 });
 const CUE_BASE64 = CUE_PCM.toString("base64");
 
+// One `emitChunkMs: 10` speech chunk at the session rate, as bytes. The
+// archive assertion compares against exactly this, so a cue spliced into the
+// recording shows up as extra length rather than as "some audio came out".
+const SPEECH_CHUNK_BYTES =
+  Math.round((START_FRAME.audio.sampleRate * 10) / 1_000) * 2;
+
 function cueFrames(
   frames: LiveVoiceServerFrame[],
 ): Extract<LiveVoiceServerFrame, { type: "tts_audio" }>[] {
@@ -1270,6 +1286,178 @@ describe("LiveVoiceSession working cue", () => {
 
     await waitFor(() => cueFrames(frames).length >= 1);
     expect(turnInternals(session).ttsSegmentEnqueued()).toBe(false);
+  });
+
+  test("the cue is marked non-speech on the wire and real speech is not", async () => {
+    const { frames, session, getCallbacks, ttsTexts } = createProgressHarness({
+      frontModelConfig: progressConfig({ enabled: false }),
+      workingCueConfig: WORKING_CUE_CONFIG,
+      progressNarrator: makeProgressNarrator(async () => GENERATED_NARRATION),
+      emitChunkMs: 10,
+    });
+    await startReleasedTurn(session, getCallbacks);
+
+    await waitFor(() => cueFrames(frames).length >= 1);
+    // The client drives speaking state, hands-free barge-in eligibility,
+    // client-heard latency, and the spoken-word cursor off tts_audio frames.
+    // An unmarked tone corrupts all four, and the payload is the only other
+    // thing that separates it from speech.
+    expect(cueFrames(frames)[0]?.nonSpeech).toBe(true);
+
+    emitTextDelta(getCallbacks, ANSWER_TEXT);
+    emitMessageComplete(getCallbacks);
+    await waitFor(() => ttsTexts.includes(ANSWER_TEXT));
+    await waitFor(() =>
+      frames.some(
+        (frame) =>
+          frame.type === "tts_audio" && frame.dataBase64 !== CUE_BASE64,
+      ),
+    );
+
+    const speech = frames.filter(
+      (frame): frame is Extract<LiveVoiceServerFrame, { type: "tts_audio" }> =>
+        frame.type === "tts_audio" && frame.dataBase64 !== CUE_BASE64,
+    );
+    // Absent, not false: speech frames stay byte-identical to what they were
+    // before the cue existed.
+    for (const frame of speech) {
+      expect(frame).not.toHaveProperty("nonSpeech");
+    }
+  });
+
+  test("the cue stays out of the archived assistant audio", async () => {
+    const archived: LiveVoiceSessionArchiveAudioInput[] = [];
+    const { frames, session, getCallbacks, ttsTexts } = createProgressHarness({
+      frontModelConfig: progressConfig({ enabled: false }),
+      workingCueConfig: WORKING_CUE_CONFIG,
+      progressNarrator: makeProgressNarrator(async () => GENERATED_NARRATION),
+      emitChunkMs: 10,
+      // A provider that returns a container format despite outputFormat
+      // "pcm", which real ones do.
+      chunkContentType: "audio/wav",
+      archiveAudio: (input) => {
+        archived.push(input);
+        return {
+          type: "warning",
+          warning: {
+            code: "archive_failed",
+            message: "not stored in tests",
+          },
+        };
+      },
+    });
+    await startReleasedTurn(session, getCallbacks);
+
+    await waitFor(() => cueFrames(frames).length >= 1);
+    emitTextDelta(getCallbacks, ANSWER_TEXT);
+    emitMessageComplete(getCallbacks);
+    await waitFor(() => ttsTexts.includes(ANSWER_TEXT));
+    await waitFor(() => archived.some((input) => input.role === "assistant"));
+
+    // The archive is a recording of what the assistant said. Splicing raw cue
+    // PCM into it interleaves two encodings under one mime type, so the
+    // recording is corrupt from the first cue onward.
+    const assistant = archived.find((input) => input.role === "assistant");
+    expect(assistant?.mimeType).toBe("audio/wav");
+    const bytes = Buffer.from(assistant?.audio.dataBase64 ?? "", "base64");
+    expect(bytes.byteLength).toBe(SPEECH_CHUNK_BYTES);
+    expect(bytes.includes(CUE_PCM)).toBe(false);
+  });
+
+  test("a spoken filler does not anchor the turn's first-TTS metrics", async () => {
+    // The approval-pending line is not gated on progress.enabled, so it
+    // speaks on any turn that hits a decision gate in the default config.
+    const answerSpoken = deferred<void>();
+    const { frames, session, getCallbacks, approvalPending, ttsTexts } =
+      createProgressHarness({
+        frontModelConfig: progressConfig({ enabled: false }),
+        progressNarrator: makeProgressNarrator(async () => GENERATED_NARRATION),
+        gateTtsText: (text) =>
+          text === ANSWER_TEXT ? answerSpoken.promise : null,
+        emitChunkMs: 10,
+      });
+    await startReleasedTurn(session, getCallbacks);
+
+    const approvalPhrase = sanitizeForTts(approvalPendingPhraseFor()).trim();
+    approvalPending("approval-request-1");
+    await waitFor(() => ttsTexts.includes(approvalPhrase));
+    await waitFor(() => frames.some((frame) => frame.type === "tts_audio"));
+
+    // roundTripMs and friends measure to this mark, and they mean "when did
+    // the answer start". A filler plays into the dead air before the answer,
+    // so latching on it reports the wait as the turn's speech latency.
+    expect(turnInternals(session).ttsAudioStarted()).toBe(false);
+    expect(turnInternals(session).firstTtsAudioAtMs()).toBeNull();
+
+    emitTextDelta(getCallbacks, ANSWER_TEXT);
+    emitMessageComplete(getCallbacks);
+    await waitFor(() => ttsTexts.includes(ANSWER_TEXT));
+
+    // The first real answer audio still latches: a filler skips the mark, it
+    // does not consume it.
+    await waitFor(() => turnInternals(session).ttsAudioStarted() === true);
+    expect(turnInternals(session).firstTtsAudioAtMs()).not.toBeNull();
+    answerSpoken.resolve(undefined);
+  });
+
+  test("a cue turn lands workingCuesPlayed on the turn's metrics frame", async () => {
+    const { frames, session, getCallbacks } = createProgressHarness({
+      frontModelConfig: progressConfig({ enabled: false }),
+      workingCueConfig: WORKING_CUE_CONFIG,
+      progressNarrator: makeProgressNarrator(async () => GENERATED_NARRATION),
+      emitMetrics: true,
+    });
+
+    await startReleasedTurn(session, getCallbacks);
+    await waitFor(() => cueFrames(frames).length >= 1);
+
+    emitMessageComplete(getCallbacks);
+    await waitFor(() =>
+      frames.some(
+        (frame) => frame.type === "metrics" && frame.event === "turn_completed",
+      ),
+    );
+
+    // progressUpdatesSpoken is omitted when zero and narration is off by
+    // default, so without this counter nothing in telemetry separates a turn
+    // that hummed through its silence from one that sat in it.
+    const completedMetrics = frames.find(
+      (frame) => frame.type === "metrics" && frame.event === "turn_completed",
+    );
+    expect(completedMetrics).toMatchObject({
+      type: "metrics",
+      turnId: "live-turn-1",
+      workingCuesPlayed: 1,
+    });
+  });
+
+  test("a cue the caller never heard is not counted", async () => {
+    // The counter exists to separate a turn that hummed through its silence
+    // from one that sat in it, so a cue discarded before it reached the wire
+    // must not inflate it. Interrupting mid-turn stops the frame from being
+    // written while the cue job is still queued.
+    const { frames, session, getCallbacks } = createProgressHarness({
+      frontModelConfig: progressConfig({ enabled: false }),
+      workingCueConfig: WORKING_CUE_CONFIG,
+      progressNarrator: makeProgressNarrator(async () => GENERATED_NARRATION),
+      emitMetrics: true,
+    });
+
+    await startReleasedTurn(session, getCallbacks);
+    await session.handleClientFrame({ type: "interrupt" });
+    await waitFor(() =>
+      frames.some(
+        (frame) => frame.type === "metrics" && frame.event !== "turn_started",
+      ),
+    );
+
+    const terminal = frames.find(
+      (frame) => frame.type === "metrics" && frame.event !== "turn_started",
+    );
+    expect(terminal).toBeDefined();
+    // Omitted when zero, so absence is the assertion.
+    expect(terminal).not.toHaveProperty("workingCuesPlayed");
+    expect(cueFrames(frames).length).toBe(0);
   });
 
   test("the cue's chunk enters the echo reference", async () => {

--- a/assistant/src/live-voice/__tests__/live-voice-progress.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-progress.test.ts
@@ -52,6 +52,20 @@ const START_FRAME = {
     sampleRate: 24_000,
     channels: 1,
   },
+  // Every shipping client declares this, and the cue is gated on it, so the
+  // default frame here has to as well or no cue test would exercise a cue.
+  nonSpeechAudio: true,
+} as const satisfies LiveVoiceClientStartFrame;
+
+/** A client from before `nonSpeech`, which cannot be sent the cue. */
+const START_FRAME_NO_CUE_SUPPORT = {
+  type: "start",
+  conversationId: "conversation-123",
+  audio: {
+    mimeType: "audio/pcm",
+    sampleRate: 24_000,
+    channels: 1,
+  },
 } as const satisfies LiveVoiceClientStartFrame;
 
 const GENERATED_NARRATION = "Progress text.";
@@ -82,7 +96,7 @@ class MockStreamingTranscriber implements StreamingTranscriber {
   }
 }
 
-function createContext(): {
+function createContext(startFrame: LiveVoiceClientStartFrame = START_FRAME): {
   context: LiveVoiceSessionFactoryContext;
   frames: LiveVoiceServerFrame[];
 } {
@@ -93,7 +107,7 @@ function createContext(): {
     frames,
     context: {
       sessionId: "session-123",
-      startFrame: START_FRAME,
+      startFrame,
       sendFrame: mock(async (payload) => {
         const frame = sequencer.next(payload);
         frames.push(frame);
@@ -209,6 +223,9 @@ function createProgressHarness(options: {
   // Events the transcriber flushes at utterance release; defaults to a plain
   // untagged "hello" final.
   sttStopEvents?: SttStreamServerEvent[];
+  // Defaults to a client that declares `nonSpeechAudio`. Cue-gate tests pass a
+  // frame without it to stand in for a client packaged before the flag.
+  startFrame?: LiveVoiceClientStartFrame;
 }) {
   const { startVoiceTurn, getCallbacks, approvalPending } =
     createCapturingTurnStarter();
@@ -217,7 +234,7 @@ function createProgressHarness(options: {
     options.emitChunkMs,
     options.chunkContentType,
   );
-  const { context, frames } = createContext();
+  const { context, frames } = createContext(options.startFrame);
   const session = new LiveVoiceSession(context, {
     resolveTranscriber: mock(
       async () => new MockStreamingTranscriber(options.sttStopEvents),
@@ -1066,6 +1083,32 @@ async function startEscalatedProgressTurn(
 }
 
 describe("LiveVoiceSession working cue", () => {
+  // A packaged client ships on its own cadence and can be older than the
+  // daemon serving it. One that predates `nonSpeech` runs its old `tts_audio`
+  // handler on the tone and scores it as answer speech, so the cue is withheld
+  // rather than sent to be misread: the turn simply works in real silence.
+  test("a client that cannot read nonSpeech is sent no cue", async () => {
+    const generateProgressText = mock(async () => GENERATED_NARRATION);
+    const { frames, session, getCallbacks, ttsTexts } = createProgressHarness({
+      startFrame: START_FRAME_NO_CUE_SUPPORT,
+      // Config says yes; only the missing capability holds the cue back.
+      frontModelConfig: progressConfig({
+        enabled: false,
+        idleIntervalMs: CUE_INTERVAL_MS,
+      }),
+      workingCueConfig: WORKING_CUE_CONFIG,
+      progressNarrator: makeProgressNarrator(generateProgressText),
+    });
+    await startEscalatedProgressTurn(session, getCallbacks, ttsTexts);
+
+    // Well past the interval a supported client would have played two on.
+    await new Promise((resolve) => setTimeout(resolve, CUE_INTERVAL_MS * 3));
+    expect(cueFrames(frames)).toHaveLength(0);
+    // Silence, not a fallback to the narration this feature replaced.
+    expect(ttsTexts).toHaveLength(1);
+    expect(generateProgressText).not.toHaveBeenCalled();
+  });
+
   test("an idle escalated turn plays the cue and speaks no narration", async () => {
     const generateProgressText = mock(async () => GENERATED_NARRATION);
     const { frames, session, getCallbacks, ttsTexts } = createProgressHarness({

--- a/assistant/src/live-voice/__tests__/live-voice-triage-escalate.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-triage-escalate.test.ts
@@ -230,6 +230,30 @@ describe("live-voice triage-and-escalate routing", () => {
     expect(frontDoorPrompt).not.toContain("This includes connecting accounts");
   });
 
+  test("the spoken-close teaching reaches the escalated leg only", async () => {
+    const { starter } = scriptedStartVoiceTurn({
+      frontDoor: ["[1] ", "Let me think about that."],
+      escalated: ["The detailed answer is 42."],
+    });
+    const { frames, session } = createHarness(starter);
+
+    await driveTurn(session);
+    await waitFor(() => starter.mock.calls.length >= 2);
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    const frontDoorPrompt =
+      starter.mock.calls[0]?.[0]?.voiceControlPrompt ?? "";
+    const escalatedPrompt =
+      starter.mock.calls[1]?.[0]?.voiceControlPrompt ?? "";
+    // The teaching opens by telling the model what the caller has already
+    // heard ("you told them you were on it, and nothing since"), which is
+    // true of exactly one leg: the one that took over after a hand-off
+    // bridge. Any other leg is told something false about the call it is
+    // joining, including a turn the user never asked for.
+    expect(escalatedPrompt).toContain("You already told the caller");
+    expect(frontDoorPrompt).not.toContain("You already told the caller");
+  });
+
   test("the screen-reveal teaching reaches the escalated leg's prompt but never the front-door leg's", async () => {
     const { starter } = scriptedStartVoiceTurn({
       frontDoor: ["[1] ", "Let me think about that."],

--- a/assistant/src/live-voice/__tests__/live-voice-tts-session.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-tts-session.test.ts
@@ -14,6 +14,7 @@ import {
   LiveVoiceSession,
   type LiveVoiceTtsStreamer,
   type LiveVoiceTurnStarter,
+  NON_BLOCK_TTS_SEQ,
 } from "../live-voice-session.js";
 import type { LiveVoiceSessionFactoryContext } from "../live-voice-session-manager.js";
 import type {
@@ -297,6 +298,20 @@ function assistantTranscript(frames: LiveVoiceServerFrame[]): string {
 // structural so the test does not need the session's private job type.
 interface HeldJobView {
   readonly text: string;
+}
+
+// The block stamp a job carries, which decides which promotion or retraction
+// can select it. No frame exposes it, so the tests that pin it read the turn.
+interface StampedJobView {
+  readonly text: string;
+  readonly blockSeq: number;
+}
+
+function ttsJobStamps(session: LiveVoiceSession): StampedJobView[] {
+  const internals = session as unknown as {
+    activeAssistantTurn: { ttsJobs: StampedJobView[] } | null;
+  };
+  return internals.activeAssistantTurn?.ttsJobs ?? [];
 }
 
 // The slice of the session's private turn state these tests read.
@@ -1042,6 +1057,98 @@ describe("LiveVoiceSession TTS", () => {
     expect(ttsAudioPayloads(frames)).toEqual([b64("audio:held-1")]);
   });
 
+  test("a retracted held job stops reserving the held prefetch slot", async () => {
+    let callbacks: VoiceTurnCallbacks | undefined;
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      callbacks = options.callbacks;
+      return { turnId: "bridge-turn-1", abort: mock() };
+    });
+    const { streamTtsAudio, calls, events } = createControlledTtsStreamer();
+    const { frames, session } = createSessionHarness({
+      startVoiceTurn,
+      streamTtsAudio,
+    });
+
+    await startReleasedTurn(session);
+    callbacks?.assistant_text_delta?.(makeTextDelta(FIRST_SENTENCE));
+    const held = heldTtsController(session);
+    held.enqueue(HELD_SENTENCE);
+
+    // This provider ignores the abort, so the retracted stream stays open.
+    expect(held.retract((job) => job.text === HELD_SENTENCE)).toBe(1);
+    held.enqueue(OTHER_HELD_SENTENCE);
+    expect(events).toEqual([
+      `start:${FIRST_SENTENCE}`,
+      `start:${HELD_SENTENCE}`,
+    ]);
+
+    // The retracted job can never be promoted, so it is not the held prefetch
+    // the one held slot is reserved for. Counting it would leave the answer
+    // block un-synthesized until the turn ends, which is the full TTS round
+    // trip the hold exists to remove.
+    calls[0]?.options.onAudioChunk(makeTtsChunk("audio:live-1"));
+    calls[0]?.finish();
+    await waitFor(() => events.includes(`start:${OTHER_HELD_SENTENCE}`));
+
+    expect(held.promote((job) => job.text === OTHER_HELD_SENTENCE)).toBe(1);
+    calls[2]?.options.onAudioChunk(makeTtsChunk("audio:held-2"));
+    calls[2]?.finish();
+    callbacks?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    expect(ttsAudioPayloads(frames)).toEqual([
+      b64("audio:live-1"),
+      b64("audio:held-2"),
+    ]);
+  });
+
+  test("a job that reaches the head of the chain synthesizes even with both slots busy", async () => {
+    let callbacks: VoiceTurnCallbacks | undefined;
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      callbacks = options.callbacks;
+      return { turnId: "bridge-turn-1", abort: mock() };
+    });
+    const { streamTtsAudio, calls, events } = createControlledTtsStreamer();
+    const { frames, session } = createSessionHarness({
+      startVoiceTurn,
+      streamTtsAudio,
+    });
+
+    await startReleasedTurn(session);
+    callbacks?.assistant_text_delta?.(makeTextDelta(FIRST_SENTENCE));
+    const held = heldTtsController(session);
+
+    // Both slots end up held by jobs that are NOT ahead of the second spoken
+    // segment on the emission chain: one retracted job whose provider has not
+    // torn the stream down, and one held job waiting on a promotion that may
+    // never come. Neither is on the chain at all.
+    held.enqueue(HELD_SENTENCE);
+    expect(held.retract((job) => job.text === HELD_SENTENCE)).toBe(1);
+    held.enqueue(OTHER_HELD_SENTENCE);
+    calls[0]?.options.onAudioChunk(makeTtsChunk("audio:first-1"));
+    calls[0]?.finish();
+    await waitFor(() => events.includes(`start:${OTHER_HELD_SENTENCE}`));
+
+    // Enqueued behind a cap that is full, so it arrives at the head of the
+    // chain unstarted. Asking the cap for permission there would start
+    // nothing, and the segment would settle having emitted no audio at all:
+    // a silently dropped piece of the answer, with no frame, error, or log.
+    callbacks?.assistant_text_delta?.(makeTextDelta(SECOND_SENTENCE));
+    await waitFor(() => events.includes(`start:${SECOND_SENTENCE}`));
+    const secondCall = calls.find(
+      (call) => call.options.text === SECOND_SENTENCE,
+    );
+    secondCall?.options.onAudioChunk(makeTtsChunk("audio:second-1"));
+    secondCall?.finish();
+    callbacks?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    expect(ttsAudioPayloads(frames)).toEqual([
+      b64("audio:first-1"),
+      b64("audio:second-1"),
+    ]);
+  });
+
   test("tts_done still fires on a turn holding one segment and retracting another", async () => {
     let callbacks: VoiceTurnCallbacks | undefined;
     const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
@@ -1188,6 +1295,35 @@ describe("LiveVoiceSession TTS", () => {
     callbacks?.message_complete?.(makeMessageComplete());
     await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
     expect(ttsAudioPayloads(frames)).toEqual([]);
+  });
+
+  test("the completion sweep drops the stranded block's tail rather than speaking it", async () => {
+    let callbacks: VoiceTurnCallbacks | undefined;
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      callbacks = options.callbacks;
+      return { turnId: "bridge-turn-1", abort: mock() };
+    });
+    const { streamTtsAudio, synthesized } = createEchoTtsStreamer();
+    const { frames, session } = createSessionHarness({
+      startVoiceTurn,
+      streamTtsAudio,
+    });
+
+    await startReleasedTurn(session);
+    const held = heldTtsController(session);
+    held.enqueue(HELD_SENTENCE);
+    callbacks?.assistant_text_delta?.(makeTextDelta(PENDING_TAIL));
+    expect(held.pendingTail()).toBe(PENDING_TAIL);
+
+    callbacks?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    // The sweep drops a stranded held block because unresolved held text is
+    // commentary. Its un-segmented tail is the same commentary, so leaving it
+    // for the terminal flush would speak the fragment of the very block just
+    // dropped, as the turn's closing words.
+    expect(ttsAudioPayloads(frames)).toEqual([]);
+    expect(synthesizedTexts(synthesized)).not.toContain(PENDING_TAIL);
   });
 
   test("retraction discards the pending tail only when the caller owns it", async () => {
@@ -1429,7 +1565,8 @@ describe("LiveVoiceSession escalated-turn speech", () => {
 
   test("the escalation bridge is never held or retracted", async () => {
     const { streamTtsAudio, synthesized } = createEchoTtsStreamer();
-    const { frames, escalated } = await startEscalatedTurn(streamTtsAudio);
+    const { frames, session, escalated } =
+      await startEscalatedTurn(streamTtsAudio);
     const legs = escalated.callbacks;
 
     // The bridge is spoken during the tool phase, which is the whole point
@@ -1437,6 +1574,16 @@ describe("LiveVoiceSession escalated-turn speech", () => {
     await waitFor(() =>
       ttsAudioPayloads(frames).includes(b64(`audio:${BRIDGE_SENTENCE}`)),
     );
+
+    // Stamped as belonging to no block. Without the stamp it takes the
+    // escalated leg's first block, which the first tool call retracts, and
+    // the only thing keeping it audible would be the selectors' independent
+    // `held` filter: the audible outcome would be the same and the invariant
+    // NON_BLOCK_TTS_SEQ states would be false.
+    const bridgeJob = ttsJobStamps(session).find(
+      (job) => job.text === BRIDGE_SENTENCE,
+    );
+    expect(bridgeJob?.blockSeq).toBe(NON_BLOCK_TTS_SEQ);
 
     legs?.assistant_text_delta?.(makeTextDelta(`${FIRST_COMMENTARY} `));
     legs?.tool_block_opened?.("calendar_read", "toolu-1");
@@ -1478,6 +1625,72 @@ describe("LiveVoiceSession escalated-turn speech", () => {
     expect(calls[1]?.options.signal?.aborted).toBe(true);
     expect(ttsAudioPayloads(frames)).toEqual([]);
     expect(frames.some((frame) => frame.type === "tts_done")).toBe(false);
+  });
+
+  test("an errored turn retracts its held prefetch instead of leaving it streaming", async () => {
+    const { streamTtsAudio, calls } = createControlledTtsStreamer();
+    const { frames, escalated } = await startEscalatedTurn(streamTtsAudio);
+    const legs = escalated.callbacks;
+
+    // The bridge settles silently, so the only open provider stream is the
+    // held block's prefetch.
+    calls[0]?.finish();
+    legs?.assistant_text_delta?.(makeTextDelta(`${FIRST_COMMENTARY} `));
+    await waitFor(() => calls.length >= 2);
+    expect(calls[1]?.options.signal?.aborted).toBe(false);
+
+    escalated.onError?.("the provider fell over");
+
+    // A held job is off the emission chain, so nothing else will ever settle
+    // it: a terminal path that neither promotes nor retracts leaves its
+    // provider stream open past the turn, billing for audio nobody hears.
+    // Every terminal path has to cover it, not just the two that remembered.
+    await waitFor(() => calls[1]?.options.signal?.aborted === true);
+    expect(ttsAudioPayloads(frames)).toEqual([]);
+  });
+
+  test("a turn that ends with a tool block open speaks only the hand-off bridge", async () => {
+    const { streamTtsAudio } = createEchoTtsStreamer();
+    const { frames, escalated } = await startEscalatedTurn(streamTtsAudio);
+    const legs = escalated.callbacks;
+
+    legs?.assistant_text_delta?.(makeTextDelta(`${FIRST_COMMENTARY} `));
+    legs?.tool_block_opened?.("calendar_read", "toolu-1");
+    // The loop stops with the tool block still open (the tool-turn ceiling, a
+    // hook ending the turn). The block before it was retracted as commentary
+    // and nothing followed, so the terminal promotion has nothing to select.
+    legs?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    // The guarantee outranks having something to say: the commentary stays
+    // unspoken even when it is all the turn produced. The session logs the
+    // empty promotion so this reads as a known shape rather than a mystery.
+    expect(ttsAudioPayloads(frames)).toEqual([b64(`audio:${BRIDGE_SENTENCE}`)]);
+    expect(assistantTranscript(frames)).toContain(FIRST_COMMENTARY);
+  });
+
+  test("a withheld control-marker tail does not cross a block boundary", async () => {
+    const { streamTtsAudio } = createEchoTtsStreamer();
+    const { frames, escalated } = await startEscalatedTurn(streamTtsAudio);
+    const legs = escalated.callbacks;
+
+    // "[US" is a live control-marker candidate ("[USER_ANSWERED:" and
+    // friends), so the holdback withholds it rather than speaking a marker
+    // that is still streaming. It sits outside ttsBuffer, where the block
+    // retraction cannot reach it.
+    legs?.assistant_text_delta?.(makeTextDelta(`${FIRST_COMMENTARY} [US`));
+    legs?.tool_block_opened?.("calendar_read", "toolu-1");
+    legs?.assistant_text_delta?.(makeTextDelta(REPORT_SENTENCE));
+    legs?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    // Kept, the fragment is stamped with the report's block and spoken glued
+    // onto the front of it.
+    expect(ttsAudioPayloads(frames)).toEqual([
+      b64(`audio:${BRIDGE_SENTENCE}`),
+      b64(`audio:${REPORT_SENTENCE}`),
+    ]);
+    expect(assistantTranscript(frames)).not.toContain("[US");
   });
 
   test("an escalated turn with no tool calls speaks its single block", async () => {

--- a/assistant/src/live-voice/__tests__/live-voice-tts-session.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-tts-session.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, mock, test } from "bun:test";
 
+import { sanitizeForTts } from "../../calls/tts-text-sanitizer.js";
 import type {
   VoiceTurnCallbacks,
   VoiceTurnOptions,
 } from "../../calls/voice-session-bridge.js";
+import { ESCALATION_CONTINUATION_CONTENT } from "../../calls/voice-triage-escalate.js";
 import type {
   StreamingTranscriber,
   SttStreamServerEvent,
@@ -19,6 +21,7 @@ import type {
   LiveVoiceTtsOptions,
   LiveVoiceTtsResult,
 } from "../live-voice-tts.js";
+import { approvalPendingPhraseFor } from "../progress-phrases.js";
 import {
   createLiveVoiceServerFrameSequencer,
   type LiveVoiceClientStartFrame,
@@ -214,6 +217,82 @@ function createControlledTtsStreamer(): {
   return { streamTtsAudio, calls, events };
 }
 
+// A TTS streamer that answers every segment with one chunk and settles at
+// once. `synthesized` is what reached the provider, which on a held segment
+// is deliberately a different set from what the client hears.
+function createEchoTtsStreamer(): {
+  streamTtsAudio: LiveVoiceTtsStreamer;
+  synthesized: LiveVoiceTtsOptions[];
+} {
+  const synthesized: LiveVoiceTtsOptions[] = [];
+  const streamTtsAudio = mock(async (options: LiveVoiceTtsOptions) => {
+    synthesized.push(options);
+    options.onAudioChunk(makeTtsChunk(`audio:${options.text}`));
+    return makeTtsResult(options.text);
+  });
+  return { streamTtsAudio, synthesized };
+}
+
+function synthesizedTexts(synthesized: LiveVoiceTtsOptions[]): string[] {
+  return synthesized.map((options) => options.text);
+}
+
+// The front-door leg's escalate verdict plus the bridge it speaks across the
+// hand-off, and the sentences an escalated leg says while it works.
+const ESCALATE_VERDICT_DELTA = "[1] Let me look into that.";
+const BRIDGE_SENTENCE = "Let me look into that.";
+const FIRST_COMMENTARY = "Checking your calendar now.";
+const SECOND_COMMENTARY = "Now looking at tomorrow as well.";
+const REPORT_SENTENCE = "You have two meetings tomorrow.";
+const REPORT_QUESTION = "Which calendar should I check, work or personal?";
+
+/**
+ * Drive a turn through the escalate verdict and hand back the escalated leg's
+ * bridge options, so a test can script that leg block by block: text deltas,
+ * `tool_block_opened` for a tool block opening, and completion.
+ */
+async function startEscalatedTurn(
+  streamTtsAudio: LiveVoiceTtsStreamer,
+): Promise<{
+  frames: LiveVoiceServerFrame[];
+  session: LiveVoiceSession;
+  escalated: VoiceTurnOptions;
+}> {
+  let frontDoor: VoiceTurnCallbacks | undefined;
+  let escalated: VoiceTurnOptions | undefined;
+  const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+    if (options.content === ESCALATION_CONTINUATION_CONTENT) {
+      escalated = options;
+      return { turnId: "bridge-escalated", abort: mock() };
+    }
+    frontDoor = options.callbacks;
+    return { turnId: "bridge-front-door", abort: mock() };
+  });
+  const { frames, session } = createSessionHarness({
+    startVoiceTurn,
+    streamTtsAudio,
+  });
+
+  await startReleasedTurn(session);
+  frontDoor?.assistant_text_delta?.(makeTextDelta(ESCALATE_VERDICT_DELTA));
+  await waitFor(
+    () => escalated !== undefined,
+    "Timed out waiting for the escalated leg to start",
+  );
+  if (!escalated) {
+    throw new Error("Escalated leg never started");
+  }
+  return { frames, session, escalated };
+}
+
+function assistantTranscript(frames: LiveVoiceServerFrame[]): string {
+  return frames
+    .flatMap((frame) =>
+      frame.type === "assistant_text_delta" ? [frame.text] : [],
+    )
+    .join("");
+}
+
 // The slice of a TtsSegmentJob a held-segment selector can see. Kept
 // structural so the test does not need the session's private job type.
 interface HeldJobView {
@@ -226,9 +305,10 @@ interface TurnView {
   readonly ttsBuffer: string;
 }
 
-// Held segments have no production caller yet, so the tests drive the private
-// hold/promote/retract surface directly against the turn that
-// `startReleasedTurn` left active.
+// Drives the private hold/promote/retract surface directly against the turn
+// that `startReleasedTurn` left active, for the queue mechanics an escalated
+// turn cannot script on its own (a segment held past completion, a provider
+// that ignores its abort).
 function heldTtsController(session: LiveVoiceSession): {
   enqueue: (text: string) => void;
   promote: (select: (job: HeldJobView) => boolean) => number;
@@ -1141,5 +1221,277 @@ describe("LiveVoiceSession TTS", () => {
     callbacks?.message_complete?.(makeMessageComplete());
     await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
     expect(ttsAudioPayloads(frames)).toEqual([]);
+  });
+});
+
+describe("LiveVoiceSession escalated-turn speech", () => {
+  test("no commentary is ever audible on an escalated turn", async () => {
+    const { streamTtsAudio, synthesized } = createEchoTtsStreamer();
+    const { frames, escalated } = await startEscalatedTurn(streamTtsAudio);
+    const legs = escalated.callbacks;
+
+    // Two working blocks, each closed by a tool-use block opening, then the
+    // block nothing follows: the turn's report back.
+    legs?.assistant_text_delta?.(makeTextDelta(`${FIRST_COMMENTARY} `));
+    legs?.tool_block_opened?.("calendar_read", "toolu-1");
+    legs?.assistant_text_delta?.(makeTextDelta(`${SECOND_COMMENTARY} `));
+    legs?.tool_block_opened?.("calendar_read", "toolu-2");
+    legs?.assistant_text_delta?.(makeTextDelta(REPORT_SENTENCE));
+    legs?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    // The hard guarantee: the caller hears the hand-off bridge and the
+    // report, and no part of the play-by-play in between.
+    expect(ttsAudioPayloads(frames)).toEqual([
+      b64(`audio:${BRIDGE_SENTENCE}`),
+      b64(`audio:${REPORT_SENTENCE}`),
+    ]);
+    // The commentary was synthesized (that is what makes a promotion
+    // instant), it just never reached the client.
+    expect(synthesizedTexts(synthesized)).toContain(FIRST_COMMENTARY);
+    // Holding is a TTS-only concern: the transcript still carries every word.
+    const transcript = assistantTranscript(frames);
+    expect(transcript).toContain(FIRST_COMMENTARY);
+    expect(transcript).toContain(SECOND_COMMENTARY);
+    expect(transcript).toContain(REPORT_SENTENCE);
+  });
+
+  test("a provider-native tool closes a block like any other", async () => {
+    // Web search and friends arrive as server_tool_start rather than a
+    // preview event. The bridge routes both to tool_block_opened, so from
+    // here a provider-native tool is not a special case at all: this asserts
+    // the session treats that boundary like any other. That the bridge
+    // actually routes it is asserted in voice-session-bridge.test.ts.
+    const { streamTtsAudio, synthesized } = createEchoTtsStreamer();
+    const { frames, escalated } = await startEscalatedTurn(streamTtsAudio);
+    const legs = escalated.callbacks;
+
+    legs?.assistant_text_delta?.(makeTextDelta(`${FIRST_COMMENTARY} `));
+    legs?.tool_block_opened?.("web_search", "srvtoolu-1");
+    legs?.assistant_text_delta?.(makeTextDelta(REPORT_SENTENCE));
+    legs?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    expect(ttsAudioPayloads(frames)).toEqual([
+      b64(`audio:${BRIDGE_SENTENCE}`),
+      b64(`audio:${REPORT_SENTENCE}`),
+    ]);
+    expect(synthesizedTexts(synthesized)).toContain(FIRST_COMMENTARY);
+    // Holding is a TTS-only concern here too: the transcript keeps every word.
+    expect(assistantTranscript(frames)).toContain(FIRST_COMMENTARY);
+  });
+
+  test("a direct front-door answer is unchanged", async () => {
+    let callbacks: VoiceTurnCallbacks | undefined;
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      callbacks = options.callbacks;
+      return { turnId: "bridge-turn-1", abort: mock() };
+    });
+    const { streamTtsAudio } = createEchoTtsStreamer();
+    const { frames, session } = createSessionHarness({
+      startVoiceTurn,
+      streamTtsAudio,
+    });
+
+    await startReleasedTurn(session);
+    callbacks?.assistant_text_delta?.(
+      makeTextDelta("Sure, I can help with that, and here is the rest."),
+    );
+
+    // A front-door answer is never held, so the eager first-clause flush
+    // still speaks before the message completes.
+    await waitFor(() => frames.some((frame) => frame.type === "tts_audio"));
+    expect(ttsAudioPayloads(frames)[0]).toBe(
+      b64("audio:Sure, I can help with that,"),
+    );
+    expect(frames.some((frame) => frame.type === "tts_done")).toBe(false);
+
+    callbacks?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+    expect(ttsAudioPayloads(frames)).toEqual([
+      b64("audio:Sure, I can help with that,"),
+      b64("audio:and here is the rest."),
+    ]);
+  });
+
+  test("the report's first segment is pre-synthesized", async () => {
+    const { streamTtsAudio, synthesized } = createEchoTtsStreamer();
+    const { frames, escalated } = await startEscalatedTurn(streamTtsAudio);
+    const legs = escalated.callbacks;
+
+    legs?.assistant_text_delta?.(makeTextDelta(`${FIRST_COMMENTARY} `));
+    legs?.tool_block_opened?.("calendar_read", "toolu-1");
+    await flushAsyncCallbacks();
+    legs?.assistant_text_delta?.(makeTextDelta(REPORT_SENTENCE));
+    await waitFor(() =>
+      synthesizedTexts(synthesized).includes(REPORT_SENTENCE),
+    );
+
+    // Synthesis of the report runs while the leg is still streaming; only
+    // its emission waits for completion.
+    expect(ttsAudioPayloads(frames)).toEqual([b64(`audio:${BRIDGE_SENTENCE}`)]);
+
+    legs?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    expect(ttsAudioPayloads(frames)).toEqual([
+      b64(`audio:${BRIDGE_SENTENCE}`),
+      b64(`audio:${REPORT_SENTENCE}`),
+    ]);
+    // Promotion emits the audio it already has rather than re-synthesizing.
+    expect(
+      synthesizedTexts(synthesized).filter((text) => text === REPORT_SENTENCE),
+    ).toHaveLength(1);
+  });
+
+  test("a mid-turn question is spoken like an answer", async () => {
+    const { streamTtsAudio } = createEchoTtsStreamer();
+    const { frames, escalated } = await startEscalatedTurn(streamTtsAudio);
+    const legs = escalated.callbacks;
+
+    legs?.assistant_text_delta?.(makeTextDelta(`${FIRST_COMMENTARY} `));
+    legs?.tool_block_opened?.("calendar_read", "toolu-1");
+    legs?.assistant_text_delta?.(makeTextDelta(REPORT_QUESTION));
+    legs?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    // Coming back with a question the turn needs answered is a report back
+    // like any other: nothing followed it, so it is spoken.
+    expect(ttsAudioPayloads(frames)).toEqual([
+      b64(`audio:${BRIDGE_SENTENCE}`),
+      b64(`audio:${REPORT_QUESTION}`),
+    ]);
+  });
+
+  test("the approval-pending phrase is never held", async () => {
+    const { streamTtsAudio } = createEchoTtsStreamer();
+    const { frames, escalated } = await startEscalatedTurn(streamTtsAudio);
+    const legs = escalated.callbacks;
+    const approvalPhrase = sanitizeForTts(approvalPendingPhraseFor()).trim();
+
+    legs?.assistant_text_delta?.(makeTextDelta(`${FIRST_COMMENTARY} `));
+    escalated.onApprovalPending?.("approval-request-1");
+
+    // The line exists to be heard during the wait, so it speaks straight
+    // away while the block beside it is still held.
+    await waitFor(() =>
+      ttsAudioPayloads(frames).includes(b64(`audio:${approvalPhrase}`)),
+    );
+    expect(ttsAudioPayloads(frames)).toEqual([
+      b64(`audio:${BRIDGE_SENTENCE}`),
+      b64(`audio:${approvalPhrase}`),
+    ]);
+
+    legs?.tool_block_opened?.("send_email", "toolu-1");
+    legs?.assistant_text_delta?.(makeTextDelta(REPORT_SENTENCE));
+    legs?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    // The retraction that dropped the commentary left the phrase alone.
+    expect(ttsAudioPayloads(frames)).toEqual([
+      b64(`audio:${BRIDGE_SENTENCE}`),
+      b64(`audio:${approvalPhrase}`),
+      b64(`audio:${REPORT_SENTENCE}`),
+    ]);
+  });
+
+  test("a held escalated block blocks the idle gate and its retraction clears it", async () => {
+    const { streamTtsAudio, calls } = createControlledTtsStreamer();
+    const { frames, session, escalated } =
+      await startEscalatedTurn(streamTtsAudio);
+    const legs = escalated.callbacks;
+    const held = heldTtsController(session);
+
+    // The bridge settles without ever producing a chunk, so no playback-tail
+    // estimate stands between the turn and the idle gate.
+    calls[0]?.finish();
+    await waitFor(() => held.audioIdle());
+
+    // A held block is seconds from being spoken, so the turn is quiet rather
+    // than idle and the working cue must not talk over it.
+    legs?.assistant_text_delta?.(makeTextDelta(`${FIRST_COMMENTARY} `));
+    expect(held.audioIdle()).toBe(false);
+
+    // Retracting it makes it unhearable at once, even though the provider is
+    // still sitting on the aborted stream, so the tool phase reads idle.
+    legs?.tool_block_opened?.("calendar_read", "toolu-1");
+    expect(held.audioIdle()).toBe(true);
+
+    legs?.assistant_text_delta?.(makeTextDelta(REPORT_SENTENCE));
+    expect(held.audioIdle()).toBe(false);
+
+    legs?.message_complete?.(makeMessageComplete());
+    await waitFor(() => calls.length >= 3);
+    calls[2]?.finish();
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+    expect(ttsAudioPayloads(frames)).toEqual([]);
+  });
+
+  test("the escalation bridge is never held or retracted", async () => {
+    const { streamTtsAudio, synthesized } = createEchoTtsStreamer();
+    const { frames, escalated } = await startEscalatedTurn(streamTtsAudio);
+    const legs = escalated.callbacks;
+
+    // The bridge is spoken during the tool phase, which is the whole point
+    // of it: it covers the silence the escalated leg is about to create.
+    await waitFor(() =>
+      ttsAudioPayloads(frames).includes(b64(`audio:${BRIDGE_SENTENCE}`)),
+    );
+
+    legs?.assistant_text_delta?.(makeTextDelta(`${FIRST_COMMENTARY} `));
+    legs?.tool_block_opened?.("calendar_read", "toolu-1");
+    await flushAsyncCallbacks();
+
+    const bridgeCall = synthesized.find(
+      (options) => options.text === BRIDGE_SENTENCE,
+    );
+    expect(bridgeCall?.signal?.aborted).toBe(false);
+    expect(ttsAudioPayloads(frames)).toEqual([b64(`audio:${BRIDGE_SENTENCE}`)]);
+
+    legs?.assistant_text_delta?.(makeTextDelta(REPORT_SENTENCE));
+    legs?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+    expect(ttsAudioPayloads(frames)).toEqual([
+      b64(`audio:${BRIDGE_SENTENCE}`),
+      b64(`audio:${REPORT_SENTENCE}`),
+    ]);
+  });
+
+  test("a cancelled escalated turn speaks nothing", async () => {
+    const { streamTtsAudio, calls } = createControlledTtsStreamer();
+    const { frames, escalated } = await startEscalatedTurn(streamTtsAudio);
+    const legs = escalated.callbacks;
+
+    // The bridge settles silently, so nothing at all has been heard yet.
+    calls[0]?.finish();
+    legs?.assistant_text_delta?.(makeTextDelta(`${FIRST_COMMENTARY} `));
+    await waitFor(() => calls.length >= 2);
+
+    legs?.message_complete?.({
+      type: "generation_cancelled",
+      conversationId: "conversation-123",
+    });
+    await flushAsyncCallbacks();
+
+    // The held block dies with the turn: nothing is promoted, and its
+    // provider stream is torn down rather than left running.
+    expect(calls[1]?.options.signal?.aborted).toBe(true);
+    expect(ttsAudioPayloads(frames)).toEqual([]);
+    expect(frames.some((frame) => frame.type === "tts_done")).toBe(false);
+  });
+
+  test("an escalated turn with no tool calls speaks its single block", async () => {
+    const { streamTtsAudio } = createEchoTtsStreamer();
+    const { frames, escalated } = await startEscalatedTurn(streamTtsAudio);
+    const legs = escalated.callbacks;
+
+    legs?.assistant_text_delta?.(makeTextDelta(REPORT_SENTENCE));
+    legs?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    expect(ttsAudioPayloads(frames)).toEqual([
+      b64(`audio:${BRIDGE_SENTENCE}`),
+      b64(`audio:${REPORT_SENTENCE}`),
+    ]);
   });
 });

--- a/assistant/src/live-voice/__tests__/live-voice-tts-session.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-tts-session.test.ts
@@ -185,7 +185,9 @@ interface ControlledSynthesis {
 // A TTS streamer whose per-call completion is driven by the test: chunks are
 // injected via `calls[n].options.onAudioChunk` and the provider promise
 // settles on `finish`/`fail`. `events` records call starts and settles so
-// synthesis overlap can be asserted deterministically.
+// synthesis overlap can be asserted deterministically. Aborting a call does
+// not settle it, which is also how a provider that is slow to tear down on
+// abort behaves.
 function createControlledTtsStreamer(): {
   streamTtsAudio: LiveVoiceTtsStreamer;
   calls: ControlledSynthesis[];
@@ -212,9 +214,73 @@ function createControlledTtsStreamer(): {
   return { streamTtsAudio, calls, events };
 }
 
+// The slice of a TtsSegmentJob a held-segment selector can see. Kept
+// structural so the test does not need the session's private job type.
+interface HeldJobView {
+  readonly text: string;
+}
+
+// The slice of the session's private turn state these tests read.
+interface TurnView {
+  readonly token: symbol;
+  readonly ttsBuffer: string;
+}
+
+// Held segments have no production caller yet, so the tests drive the private
+// hold/promote/retract surface directly against the turn that
+// `startReleasedTurn` left active.
+function heldTtsController(session: LiveVoiceSession): {
+  enqueue: (text: string) => void;
+  promote: (select: (job: HeldJobView) => boolean) => number;
+  retract: (
+    select: (job: HeldJobView) => boolean,
+    options?: { discardPendingTail?: boolean },
+  ) => number;
+  pendingTail: () => string;
+  audioIdle: () => boolean;
+} {
+  const internals = session as unknown as {
+    activeAssistantTurn: TurnView | null;
+    enqueueTtsSegment: (
+      token: symbol,
+      segment: string,
+      options?: { held?: boolean },
+    ) => void;
+    promoteHeldTtsSegments: (
+      token: symbol,
+      select: (job: HeldJobView) => boolean,
+    ) => number;
+    retractHeldTtsSegments: (
+      token: symbol,
+      select: (job: HeldJobView) => boolean,
+      options?: { discardPendingTail?: boolean },
+    ) => number;
+    turnAudioIdle: (turn: TurnView) => boolean;
+  };
+  const turn = internals.activeAssistantTurn;
+  if (!turn) {
+    throw new Error("No active assistant turn to hold TTS segments on");
+  }
+  const { token } = turn;
+  return {
+    enqueue: (text) => internals.enqueueTtsSegment(token, text, { held: true }),
+    promote: (select) => internals.promoteHeldTtsSegments(token, select),
+    retract: (select, options) =>
+      internals.retractHeldTtsSegments(token, select, options),
+    pendingTail: () => turn.ttsBuffer,
+    audioIdle: () => internals.turnAudioIdle(turn),
+  };
+}
+
+const HELD_SENTENCE = "The held answer is ready to speak.";
+const OTHER_HELD_SENTENCE = "A second held sentence waits behind it.";
+const THIRD_HELD_SENTENCE = "A third held sentence waits even further back.";
 const FIRST_SENTENCE = "This is the first spoken sentence.";
 const SECOND_SENTENCE = "Here comes the second spoken sentence.";
 const THIRD_SENTENCE = "And now a third spoken sentence arrives.";
+// No terminal punctuation, so it stays in the turn's buffer as an
+// un-segmented tail instead of forming a job.
+const PENDING_TAIL = "an unfinished clause with no boundary yet";
 
 describe("LiveVoiceSession TTS", () => {
   test("starts streaming TTS audio before the assistant message completes at a segment boundary", async () => {
@@ -739,5 +805,341 @@ describe("LiveVoiceSession TTS", () => {
       type: "tts_done",
       turnId: "live-turn-1",
     });
+  });
+
+  test("a held segment synthesizes but forwards no audio until it is promoted", async () => {
+    let callbacks: VoiceTurnCallbacks | undefined;
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      callbacks = options.callbacks;
+      return { turnId: "bridge-turn-1", abort: mock() };
+    });
+    const { streamTtsAudio, calls, events } = createControlledTtsStreamer();
+    const { frames, session } = createSessionHarness({
+      startVoiceTurn,
+      streamTtsAudio,
+    });
+
+    await startReleasedTurn(session);
+    const held = heldTtsController(session);
+    held.enqueue(HELD_SENTENCE);
+
+    // Synthesis starts immediately: holding is about emission, not about
+    // deferring the provider round trip.
+    expect(events).toEqual([`start:${HELD_SENTENCE}`]);
+
+    calls[0]?.options.onAudioChunk(makeTtsChunk("audio:held-1"));
+    calls[0]?.finish();
+    await flushAsyncCallbacks();
+    expect(ttsAudioPayloads(frames)).toEqual([]);
+
+    expect(held.promote((job) => job.text === HELD_SENTENCE)).toBe(1);
+    await waitFor(() => ttsAudioPayloads(frames).length === 1);
+    expect(ttsAudioPayloads(frames)).toEqual([b64("audio:held-1")]);
+
+    callbacks?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+    expect(frames.at(-1)).toMatchObject({
+      type: "tts_done",
+      turnId: "live-turn-1",
+    });
+  });
+
+  test("a promoted held segment emits its buffered audio ahead of later segments", async () => {
+    let callbacks: VoiceTurnCallbacks | undefined;
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      callbacks = options.callbacks;
+      return { turnId: "bridge-turn-1", abort: mock() };
+    });
+    const { streamTtsAudio, calls } = createControlledTtsStreamer();
+    const { frames, session } = createSessionHarness({
+      startVoiceTurn,
+      streamTtsAudio,
+    });
+
+    await startReleasedTurn(session);
+    const held = heldTtsController(session);
+    held.enqueue(HELD_SENTENCE);
+    calls[0]?.options.onAudioChunk(makeTtsChunk("audio:held-1"));
+
+    // Promotion happens before the next segment is enqueued, so the held job
+    // is ahead of it on the emission chain.
+    expect(held.promote(() => true)).toBe(1);
+    callbacks?.assistant_text_delta?.(makeTextDelta(FIRST_SENTENCE));
+    expect(calls).toHaveLength(2);
+
+    // The later segment finishes first; ordering still follows the chain.
+    calls[1]?.options.onAudioChunk(makeTtsChunk("audio:later-1"));
+    calls[1]?.finish();
+    await flushAsyncCallbacks();
+    calls[0]?.options.onAudioChunk(makeTtsChunk("audio:held-2"));
+    calls[0]?.finish();
+    callbacks?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    expect(ttsAudioPayloads(frames)).toEqual([
+      b64("audio:held-1"),
+      b64("audio:held-2"),
+      b64("audio:later-1"),
+    ]);
+  });
+
+  test("a retracted held segment forwards nothing and aborts only its own synthesis", async () => {
+    let callbacks: VoiceTurnCallbacks | undefined;
+    const abort = mock();
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      callbacks = options.callbacks;
+      return { turnId: "bridge-turn-1", abort };
+    });
+    const { streamTtsAudio, calls } = createControlledTtsStreamer();
+    const { frames, session } = createSessionHarness({
+      startVoiceTurn,
+      streamTtsAudio,
+    });
+
+    await startReleasedTurn(session);
+    callbacks?.assistant_text_delta?.(makeTextDelta(FIRST_SENTENCE));
+    const held = heldTtsController(session);
+    held.enqueue(HELD_SENTENCE);
+    expect(calls).toHaveLength(2);
+    calls[1]?.options.onAudioChunk(makeTtsChunk("audio:held-1"));
+
+    expect(held.retract((job) => job.text === HELD_SENTENCE)).toBe(1);
+    expect(calls[1]?.options.signal?.aborted).toBe(true);
+    expect(calls[0]?.options.signal?.aborted).toBe(false);
+
+    // Late provider chunks on a retracted job are dropped rather than
+    // rebuffered, and the retraction never touched the live turn.
+    calls[1]?.options.onAudioChunk(makeTtsChunk("audio:held-2"));
+    calls[0]?.options.onAudioChunk(makeTtsChunk("audio:live-1"));
+    calls[0]?.finish();
+    callbacks?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    expect(abort).not.toHaveBeenCalled();
+    expect(ttsAudioPayloads(frames)).toEqual([b64("audio:live-1")]);
+    expect(frames.at(-1)).toMatchObject({
+      type: "tts_done",
+      turnId: "live-turn-1",
+    });
+  });
+
+  test("held segments occupy at most one synthesis slot", async () => {
+    let callbacks: VoiceTurnCallbacks | undefined;
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      callbacks = options.callbacks;
+      return { turnId: "bridge-turn-1", abort: mock() };
+    });
+    const { streamTtsAudio, calls, events } = createControlledTtsStreamer();
+    const { frames, session } = createSessionHarness({
+      startVoiceTurn,
+      streamTtsAudio,
+    });
+
+    await startReleasedTurn(session);
+    const held = heldTtsController(session);
+    held.enqueue(HELD_SENTENCE);
+    held.enqueue(OTHER_HELD_SENTENCE);
+    held.enqueue(THIRD_HELD_SENTENCE);
+
+    // A second open slot exists, but held jobs may not take it: the block may
+    // never be spoken, so only its first segment is worth synthesizing.
+    expect(events).toEqual([`start:${HELD_SENTENCE}`]);
+
+    // Promoting the first frees the held slot for the next one.
+    expect(held.promote((job) => job.text === HELD_SENTENCE)).toBe(1);
+    expect(events).toEqual([
+      `start:${HELD_SENTENCE}`,
+      `start:${OTHER_HELD_SENTENCE}`,
+    ]);
+
+    calls[0]?.options.onAudioChunk(makeTtsChunk("audio:held-1"));
+    calls[0]?.finish();
+    calls[1]?.finish();
+    expect(held.retract(() => true)).toBe(2);
+    callbacks?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    expect(ttsAudioPayloads(frames)).toEqual([b64("audio:held-1")]);
+  });
+
+  test("tts_done still fires on a turn holding one segment and retracting another", async () => {
+    let callbacks: VoiceTurnCallbacks | undefined;
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      callbacks = options.callbacks;
+      return { turnId: "bridge-turn-1", abort: mock() };
+    });
+    const { streamTtsAudio, calls } = createControlledTtsStreamer();
+    const { frames, session } = createSessionHarness({
+      startVoiceTurn,
+      streamTtsAudio,
+    });
+
+    await startReleasedTurn(session);
+    callbacks?.assistant_text_delta?.(makeTextDelta(FIRST_SENTENCE));
+    const held = heldTtsController(session);
+    held.enqueue(HELD_SENTENCE);
+    held.enqueue(OTHER_HELD_SENTENCE);
+
+    // One job stays held forever and one is retracted; neither is on the
+    // emission chain, so neither can stall the drain.
+    expect(held.retract((job) => job.text === OTHER_HELD_SENTENCE)).toBe(1);
+
+    calls[0]?.options.onAudioChunk(makeTtsChunk("audio:live-1"));
+    calls[0]?.finish();
+    callbacks?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    expect(ttsAudioPayloads(frames)).toEqual([b64("audio:live-1")]);
+    expect(frames.at(-1)).toMatchObject({
+      type: "tts_done",
+      turnId: "live-turn-1",
+    });
+  });
+
+  test("turn completion sweeps a held segment the caller never resolved", async () => {
+    let callbacks: VoiceTurnCallbacks | undefined;
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      callbacks = options.callbacks;
+      return { turnId: "bridge-turn-1", abort: mock() };
+    });
+    const { streamTtsAudio, calls } = createControlledTtsStreamer();
+    const { frames, session } = createSessionHarness({
+      startVoiceTurn,
+      streamTtsAudio,
+    });
+
+    await startReleasedTurn(session);
+    callbacks?.assistant_text_delta?.(makeTextDelta(FIRST_SENTENCE));
+    const held = heldTtsController(session);
+    held.enqueue(HELD_SENTENCE);
+
+    const strandedCall = calls.find(
+      (call) => call.options.text === HELD_SENTENCE,
+    );
+    expect(strandedCall).toBeDefined();
+    expect(strandedCall?.options.signal?.aborted).toBe(false);
+
+    calls[0]?.options.onAudioChunk(makeTtsChunk("audio:live-1"));
+    calls[0]?.finish();
+    callbacks?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    // The stranded job's provider request is aborted rather than left running
+    // into the next turn, and its audio is never spoken.
+    expect(strandedCall?.options.signal?.aborted).toBe(true);
+    expect(ttsAudioPayloads(frames)).toEqual([b64("audio:live-1")]);
+  });
+
+  test("a retracted segment holds its synthesis slot until the aborted stream settles", async () => {
+    let callbacks: VoiceTurnCallbacks | undefined;
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      callbacks = options.callbacks;
+      return { turnId: "bridge-turn-1", abort: mock() };
+    });
+    const { streamTtsAudio, calls, events } = createControlledTtsStreamer();
+    const { frames, session } = createSessionHarness({
+      startVoiceTurn,
+      streamTtsAudio,
+    });
+
+    await startReleasedTurn(session);
+    callbacks?.assistant_text_delta?.(makeTextDelta(FIRST_SENTENCE));
+    const held = heldTtsController(session);
+    held.enqueue(HELD_SENTENCE);
+    callbacks?.assistant_text_delta?.(makeTextDelta(SECOND_SENTENCE));
+
+    // Both slots are open, so the third segment is waiting on one.
+    expect(events).toEqual([
+      `start:${FIRST_SENTENCE}`,
+      `start:${HELD_SENTENCE}`,
+    ]);
+
+    // This provider ignores the abort, so the retracted stream is still open
+    // and its slot is still taken.
+    expect(held.retract((job) => job.text === HELD_SENTENCE)).toBe(1);
+    await flushAsyncCallbacks();
+    expect(events).toEqual([
+      `start:${FIRST_SENTENCE}`,
+      `start:${HELD_SENTENCE}`,
+    ]);
+
+    // Only the stream's own teardown releases it.
+    calls[1]?.finish();
+    await waitFor(() => events.includes(`start:${SECOND_SENTENCE}`));
+
+    calls[0]?.options.onAudioChunk(makeTtsChunk("audio:first-1"));
+    calls[0]?.finish();
+    calls[2]?.options.onAudioChunk(makeTtsChunk("audio:second-1"));
+    calls[2]?.finish();
+    callbacks?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+
+    expect(ttsAudioPayloads(frames)).toEqual([
+      b64("audio:first-1"),
+      b64("audio:second-1"),
+    ]);
+  });
+
+  test("a held segment blocks audio idle and a retracted one does not", async () => {
+    let callbacks: VoiceTurnCallbacks | undefined;
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      callbacks = options.callbacks;
+      return { turnId: "bridge-turn-1", abort: mock() };
+    });
+    const { streamTtsAudio } = createControlledTtsStreamer();
+    const { frames, session } = createSessionHarness({
+      startVoiceTurn,
+      streamTtsAudio,
+    });
+
+    await startReleasedTurn(session);
+    const held = heldTtsController(session);
+    expect(held.audioIdle()).toBe(true);
+
+    // Held audio is seconds from being spoken, so the turn is quiet, not idle.
+    held.enqueue(HELD_SENTENCE);
+    expect(held.audioIdle()).toBe(false);
+
+    // Retraction makes it unhearable immediately, even though the provider is
+    // still sitting on the aborted stream and the job has not settled.
+    expect(held.retract(() => true)).toBe(1);
+    expect(held.audioIdle()).toBe(true);
+
+    callbacks?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+    expect(ttsAudioPayloads(frames)).toEqual([]);
+  });
+
+  test("retraction discards the pending tail only when the caller owns it", async () => {
+    let callbacks: VoiceTurnCallbacks | undefined;
+    const startVoiceTurn = mock(async (options: VoiceTurnOptions) => {
+      callbacks = options.callbacks;
+      return { turnId: "bridge-turn-1", abort: mock() };
+    });
+    const { streamTtsAudio, calls } = createControlledTtsStreamer();
+    const { frames, session } = createSessionHarness({
+      startVoiceTurn,
+      streamTtsAudio,
+    });
+
+    await startReleasedTurn(session);
+    const held = heldTtsController(session);
+    held.enqueue(HELD_SENTENCE);
+    callbacks?.assistant_text_delta?.(makeTextDelta(PENDING_TAIL));
+    expect(held.pendingTail()).toBe(PENDING_TAIL);
+
+    // A selective retraction that matches nothing owns no speech, so the
+    // buffered tail survives it.
+    expect(held.retract((job) => job.text === SECOND_SENTENCE)).toBe(0);
+    expect(held.pendingTail()).toBe(PENDING_TAIL);
+
+    // A caller retracting its whole block says so, and the tail goes with it.
+    expect(held.retract(() => true, { discardPendingTail: true })).toBe(1);
+    expect(held.pendingTail()).toBe("");
+
+    calls[0]?.finish();
+    callbacks?.message_complete?.(makeMessageComplete());
+    await waitFor(() => frames.some((frame) => frame.type === "tts_done"));
+    expect(ttsAudioPayloads(frames)).toEqual([]);
   });
 });

--- a/assistant/src/live-voice/__tests__/protocol.test.ts
+++ b/assistant/src/live-voice/__tests__/protocol.test.ts
@@ -228,6 +228,45 @@ describe("parseLiveVoiceClientTextFrame", () => {
     });
   });
 
+  test("rejects a capture rate past the sane-hardware cap", () => {
+    // The session hands this number straight to buffer sizing for every
+    // synthesized segment and for the rendered working cue, so an absurd rate
+    // becomes an absurd allocation inside a timer callback. It has to be
+    // refused at the frame boundary, where it is still just a bad field.
+    const result = validateLiveVoiceClientFrame({
+      type: "start",
+      audio: {
+        mimeType: "audio/pcm",
+        sampleRate: 1_000_000_000,
+        channels: 1,
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      return;
+    }
+
+    expect(result.error).toMatchObject({
+      code: "invalid_field",
+      field: "audio.sampleRate",
+      frameType: "start",
+    });
+  });
+
+  test("accepts the highest capture rate real hardware opens with", () => {
+    const result = validateLiveVoiceClientFrame({
+      type: "start",
+      audio: {
+        mimeType: "audio/pcm",
+        sampleRate: 192_000,
+        channels: 1,
+      },
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
   test("parses start frames with turnDetection manual", () => {
     const result = parseLiveVoiceClientTextFrame(
       JSON.stringify({

--- a/assistant/src/live-voice/__tests__/protocol.test.ts
+++ b/assistant/src/live-voice/__tests__/protocol.test.ts
@@ -765,6 +765,61 @@ describe("parseLiveVoiceClientTextFrame", () => {
     });
   });
 
+  test("parses the nonSpeechAudio capability on the start frame", () => {
+    const result = validateLiveVoiceClientFrame({
+      type: "start",
+      nonSpeechAudio: true,
+      audio: { mimeType: "audio/pcm", sampleRate: 24000, channels: 1 },
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    expect(result.frame).toMatchObject({ type: "start", nonSpeechAudio: true });
+  });
+
+  test.each([
+    ["absent", {}],
+    ["false", { nonSpeechAudio: false }],
+  ])(
+    "omits nonSpeechAudio from the start frame when %s",
+    (_label, extra: Record<string, unknown>) => {
+      // Both mean the same thing downstream: the client has no handler that
+      // could tell a wordless cue from speech, so the session must not send
+      // one. Only an explicit true opens that gate.
+      const result = validateLiveVoiceClientFrame({
+        type: "start",
+        ...extra,
+        audio: { mimeType: "audio/pcm", sampleRate: 24000, channels: 1 },
+      });
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) {
+        return;
+      }
+      expect("nonSpeechAudio" in result.frame).toBe(false);
+    },
+  );
+
+  test("returns a typed protocol error for a non-boolean nonSpeechAudio", () => {
+    const result = validateLiveVoiceClientFrame({
+      type: "start",
+      nonSpeechAudio: "yes",
+      audio: { mimeType: "audio/pcm", sampleRate: 24000, channels: 1 },
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      return;
+    }
+    expect(result.error).toMatchObject({
+      code: "invalid_field",
+      field: "nonSpeechAudio",
+      frameType: "start",
+    });
+  });
+
   test("returns typed protocol errors for missing audio configuration fields", () => {
     const result = validateLiveVoiceClientFrame({
       type: "start",

--- a/assistant/src/live-voice/__tests__/protocol.test.ts
+++ b/assistant/src/live-voice/__tests__/protocol.test.ts
@@ -254,6 +254,46 @@ describe("parseLiveVoiceClientTextFrame", () => {
     });
   });
 
+  test("rejects a capture rate below narrowband telephony", () => {
+    // The cap has a floor for the same reason it has a ceiling: the rate
+    // sizes every rendered buffer. A rate this low rounds the working cue to
+    // zero frames, so the session would send an empty audio frame and still
+    // hold the floor for a whole interval. Refuse it here, where it is still
+    // just a bad field, rather than guarding the render downstream.
+    const result = validateLiveVoiceClientFrame({
+      type: "start",
+      audio: {
+        mimeType: "audio/pcm",
+        sampleRate: 1,
+        channels: 1,
+      },
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      return;
+    }
+
+    expect(result.error).toMatchObject({
+      code: "invalid_field",
+      field: "audio.sampleRate",
+      frameType: "start",
+    });
+  });
+
+  test("accepts the lowest capture rate a supported client opens with", () => {
+    const result = validateLiveVoiceClientFrame({
+      type: "start",
+      audio: {
+        mimeType: "audio/pcm",
+        sampleRate: 8_000,
+        channels: 1,
+      },
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
   test("accepts the highest capture rate real hardware opens with", () => {
     const result = validateLiveVoiceClientFrame({
       type: "start",

--- a/assistant/src/live-voice/__tests__/working-cue.test.ts
+++ b/assistant/src/live-voice/__tests__/working-cue.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Tests for the working-cue renderer: the framing contract (mono s16le at the
+ * requested rate), and the acoustic properties that decide whether the cue
+ * reads as a hold tone or as a glitch. The anti-click, no-clipping, and
+ * no-DC-offset assertions are the substance here: none of them is visible by
+ * reading the output, and all three are audible immediately if they break.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  DEFAULT_WORKING_CUE_SHAPE,
+  renderWorkingCuePcm,
+  type WorkingCueShape,
+} from "../working-cue.js";
+
+// Sample rates a client can ask for on the start frame: the STT-typical rate,
+// the TTS-typical one, and full-band.
+const SAMPLE_RATES = [16_000, 24_000, 48_000];
+
+// Mirrors FADE_FRACTION in the module under test. Duplicated rather than
+// exported because the tests assert the *shape* of the envelope, and reading
+// the production constant would let a bad value pass by agreeing with itself.
+const FADE_FRACTION = 0.15;
+
+const INT16_PEAK = 32_767;
+
+function samplesOf(pcm: Buffer): number[] {
+  const samples: number[] = [];
+  for (let offset = 0; offset < pcm.byteLength; offset += 2) {
+    samples.push(pcm.readInt16LE(offset));
+  }
+  return samples;
+}
+
+function expectedFrameCount(
+  sampleRate: number,
+  shape: WorkingCueShape,
+): number {
+  return Math.round((sampleRate * shape.durationMs) / 1_000);
+}
+
+describe("renderWorkingCuePcm", () => {
+  test.each(SAMPLE_RATES)(
+    "at %i Hz emits one s16le frame per sample of the requested duration",
+    (sampleRate) => {
+      const pcm = renderWorkingCuePcm(sampleRate, DEFAULT_WORKING_CUE_SHAPE);
+      const frames = expectedFrameCount(sampleRate, DEFAULT_WORKING_CUE_SHAPE);
+
+      expect(frames).toBeGreaterThan(0);
+      // Mono, 2 bytes per sample, no container header of any kind: the echo
+      // reference reads these bytes as bare PCM at the session rate.
+      expect(pcm.byteLength).toBe(frames * 2);
+    },
+  );
+
+  test.each(SAMPLE_RATES)(
+    "at %i Hz starts and ends at silence so neither edge clicks",
+    (sampleRate) => {
+      const samples = samplesOf(
+        renderWorkingCuePcm(sampleRate, DEFAULT_WORKING_CUE_SHAPE),
+      );
+
+      expect(samples[0]).toBe(0);
+      expect(samples[samples.length - 1]).toBe(0);
+
+      // Zero endpoints alone would also be satisfied by a waveform that leaps
+      // to full amplitude on the second sample, which clicks just as loudly.
+      // The ramp has to be gradual, so the first and last millisecond stay far
+      // below the peak.
+      const oneMs = Math.round(sampleRate / 1_000);
+      const ceiling = 0.05 * DEFAULT_WORKING_CUE_SHAPE.gain * INT16_PEAK;
+      for (let frame = 0; frame < oneMs; frame++) {
+        expect(Math.abs(samples[frame]!)).toBeLessThan(ceiling);
+        expect(Math.abs(samples[samples.length - 1 - frame]!)).toBeLessThan(
+          ceiling,
+        );
+      }
+    },
+  );
+
+  test.each(SAMPLE_RATES)(
+    "at %i Hz never exceeds the requested gain",
+    (sampleRate) => {
+      const samples = samplesOf(
+        renderWorkingCuePcm(sampleRate, DEFAULT_WORKING_CUE_SHAPE),
+      );
+      const peak = Math.round(DEFAULT_WORKING_CUE_SHAPE.gain * INT16_PEAK);
+
+      for (const sample of samples) {
+        expect(Math.abs(sample)).toBeLessThanOrEqual(peak);
+      }
+    },
+  );
+
+  test.each(SAMPLE_RATES)(
+    "at %i Hz reaches full amplitude inside the sustain",
+    (sampleRate) => {
+      const samples = samplesOf(
+        renderWorkingCuePcm(sampleRate, DEFAULT_WORKING_CUE_SHAPE),
+      );
+      const peak = Math.round(DEFAULT_WORKING_CUE_SHAPE.gain * INT16_PEAK);
+
+      let loudest = 0;
+      let loudestFrame = -1;
+      samples.forEach((sample, frame) => {
+        if (Math.abs(sample) > loudest) {
+          loudest = Math.abs(sample);
+          loudestFrame = frame;
+        }
+      });
+
+      // The envelope must open all the way, otherwise the cue is quieter than
+      // the configured gain and the fades are eating the whole tone.
+      expect(loudest).toBeGreaterThanOrEqual(0.99 * peak);
+
+      const fadeFrames = Math.floor(samples.length * FADE_FRACTION);
+      expect(loudestFrame).toBeGreaterThanOrEqual(fadeFrames);
+      expect(loudestFrame).toBeLessThan(samples.length - fadeFrames);
+    },
+  );
+
+  test.each(SAMPLE_RATES)("at %i Hz carries no DC offset", (sampleRate) => {
+    const samples = samplesOf(
+      renderWorkingCuePcm(sampleRate, DEFAULT_WORKING_CUE_SHAPE),
+    );
+    const peak = Math.round(DEFAULT_WORKING_CUE_SHAPE.gain * INT16_PEAK);
+    const mean = samples.reduce((a, b) => a + b, 0) / samples.length;
+
+    // A nonzero mean is inaudible on its own but shifts the echo reference off
+    // centre and eats headroom on whatever mixes the cue with speech.
+    expect(Math.abs(mean)).toBeLessThan(peak / 1_000);
+  });
+
+  test("is deterministic for a given rate and shape", () => {
+    const first = renderWorkingCuePcm(24_000, DEFAULT_WORKING_CUE_SHAPE);
+    const second = renderWorkingCuePcm(24_000, DEFAULT_WORKING_CUE_SHAPE);
+
+    expect(first.equals(second)).toBe(true);
+  });
+
+  test("honours a shape other than the default", () => {
+    const shape: WorkingCueShape = {
+      frequencyHz: 440,
+      durationMs: 100,
+      gain: 0.02,
+    };
+    const samples = samplesOf(renderWorkingCuePcm(24_000, shape));
+
+    expect(samples).toHaveLength(expectedFrameCount(24_000, shape));
+    for (const sample of samples) {
+      expect(Math.abs(sample)).toBeLessThanOrEqual(
+        Math.round(shape.gain * INT16_PEAK),
+      );
+    }
+  });
+
+  test("clamps an out-of-range gain instead of overflowing int16", () => {
+    // Gain becomes a config value, so a bad one has to render quietly wrong
+    // rather than throw partway through the buffer.
+    const samples = samplesOf(
+      renderWorkingCuePcm(24_000, { ...DEFAULT_WORKING_CUE_SHAPE, gain: 4 }),
+    );
+
+    for (const sample of samples) {
+      expect(Math.abs(sample)).toBeLessThanOrEqual(INT16_PEAK);
+    }
+  });
+
+  test("renders nothing for a zero-length cue", () => {
+    const pcm = renderWorkingCuePcm(24_000, {
+      ...DEFAULT_WORKING_CUE_SHAPE,
+      durationMs: 0,
+    });
+
+    expect(pcm.byteLength).toBe(0);
+  });
+
+  test("a cue too short to hold both fades still opens and closes at zero", () => {
+    // Two frames leaves one for the attack and one for the release, so the
+    // envelope has to degrade to all-fade rather than overlapping itself.
+    const samples = samplesOf(
+      renderWorkingCuePcm(24_000, {
+        ...DEFAULT_WORKING_CUE_SHAPE,
+        durationMs: 2 / 24,
+      }),
+    );
+
+    expect(samples).toHaveLength(2);
+    expect(samples[0]).toBe(0);
+    expect(samples[1]).toBe(0);
+  });
+});
+
+describe("DEFAULT_WORKING_CUE_SHAPE", () => {
+  test("stays a soft hum well under speech level", () => {
+    // Guards the intent of the defaults rather than the exact numbers, which
+    // are meant to be retuned by ear.
+    expect(DEFAULT_WORKING_CUE_SHAPE.gain).toBeGreaterThan(0);
+    expect(DEFAULT_WORKING_CUE_SHAPE.gain).toBeLessThan(0.2);
+    expect(DEFAULT_WORKING_CUE_SHAPE.frequencyHz).toBeGreaterThan(80);
+    expect(DEFAULT_WORKING_CUE_SHAPE.frequencyHz).toBeLessThan(1_000);
+    expect(DEFAULT_WORKING_CUE_SHAPE.durationMs).toBeGreaterThan(0);
+    expect(DEFAULT_WORKING_CUE_SHAPE.durationMs).toBeLessThan(1_000);
+  });
+});

--- a/assistant/src/live-voice/live-activity-reporter.ts
+++ b/assistant/src/live-voice/live-activity-reporter.ts
@@ -6,11 +6,12 @@
  *
  * Every phase the island shows is derived, client-side, from frames this
  * session sends: `utterance_ended` → transcribing, `stt_final`/`thinking` →
- * thinking, the first `tts_audio` → speaking. The web layer then pushes that
- * phase to ActivityKit itself, which works perfectly — right up to the moment
- * the app is backgrounded, which is the only moment the Lock Screen and the
- * Dynamic Island are on screen at all. iOS throttles and eventually suspends
- * that web view, and a suspended web view cannot report anything.
+ * thinking, the first `tts_audio` carrying speech → speaking. The web layer
+ * then pushes that phase to ActivityKit itself, which works perfectly — right
+ * up to the moment the app is backgrounded, which is the only moment the Lock
+ * Screen and the Dynamic Island are on screen at all. iOS throttles and
+ * eventually suspends that web view, and a suspended web view cannot report
+ * anything.
  *
  * So the same derivation runs here, on the side of the connection that stays
  * up. This is deliberately a *mirror* of the client's mapping rather than a new
@@ -89,6 +90,15 @@ export function phaseForFrame(
       // precisely when it has committed to a turn.
       return "thinking";
     case "tts_audio":
+      // The working cue is audio, not speech. It holds the floor of a turn
+      // that is deliberately silent, so it must not move the island to
+      // `speaking`. That label would also stick for the whole tool run: every
+      // later cue repeats it, and a silent turn sends no speech frame to
+      // correct it. Mirrors the `isSpeech` gate in the client's `ttsAudio`
+      // handler, which this function is required to agree with.
+      if (frame.nonSpeech === true) {
+        return null;
+      }
       return "speaking";
     case "tts_done":
       // The assistant stopped talking; the floor is the user's again.

--- a/assistant/src/live-voice/live-voice-metrics.ts
+++ b/assistant/src/live-voice/live-voice-metrics.ts
@@ -20,6 +20,7 @@ export type LiveVoiceMetricsEvent =
   | "final_transcript"
   | "first_assistant_delta"
   | "progress_spoken"
+  | "working_cue_played"
   | "first_tts_audio"
   | "turn_completed"
   | "turn_cancelled"
@@ -132,6 +133,10 @@ interface LiveVoiceTurnMetrics {
   endpointDecisionMaxLatencyMs?: number;
   endpointDecisionSource?: VoiceEndpointSource;
   progressUpdatesSpoken?: number;
+  // Working cues played into the turn's silence. The cue is the default
+  // floor-holder, so without this a turn that hummed and a turn that sat
+  // silent are indistinguishable in telemetry.
+  workingCuesPlayed?: number;
 }
 
 interface LiveVoiceDurationSummary {
@@ -181,6 +186,7 @@ interface LiveVoiceMetricsAggregateFields {
   endpointDecisionMaxLatencyMs?: number;
   endpointDecisionSource?: VoiceEndpointSource;
   progressUpdatesSpoken?: number;
+  workingCuesPlayed?: number;
 }
 
 export interface LiveVoiceMetricsFrame {
@@ -206,6 +212,7 @@ interface MutableTurn {
   // The decider behind the turn's most recent endpoint decision.
   endpointDecisionSource: VoiceEndpointSource | null;
   progressUpdatesSpoken: number;
+  workingCuesPlayed: number;
 }
 
 const DEFAULT_RECENT_TURN_LIMIT = 50;
@@ -273,6 +280,7 @@ export class LiveVoiceMetricsCollector {
       endpointDecisionMaxLatencyMs: null,
       endpointDecisionSource: null,
       progressUpdatesSpoken: 0,
+      workingCuesPlayed: 0,
     };
     this.applySeedMarks(this.activeTurn, seedMarks);
     this.emit("turn_started", turnId);
@@ -380,6 +388,14 @@ export class LiveVoiceMetricsCollector {
     const turn = this.ensureActiveTurn(turnId);
     turn.progressUpdatesSpoken += 1;
     return this.emit("progress_spoken", turn.turnId);
+  }
+
+  // A counter like markProgressSpoken: every cue played into the turn's
+  // silence bumps the per-turn count.
+  markWorkingCuePlayed(turnId?: string): LiveVoiceMetricsFrame {
+    const turn = this.ensureActiveTurn(turnId);
+    turn.workingCuesPlayed += 1;
+    return this.emit("working_cue_played", turn.turnId);
   }
 
   markBargeIn(turnId?: string): LiveVoiceMetricsFrame {
@@ -594,8 +610,8 @@ function aggregateFieldsForTurn(
 // Shared optional fields for turn snapshots and aggregate frame fields: the
 // commit latency is absent unless the turn committed against a local
 // speech-stop mark, and the front-model fields are absent unless the endpoint
-// decider was consulted or a progress narration spoke, so turns
-// that never touch the features are unchanged.
+// decider was consulted, a progress narration spoke, or a working cue played,
+// so turns that never touch the features are unchanged.
 function optionalTurnFields(
   // Accepts both MutableTurn (null = unset) and snapshot (absent = unset).
   turn: {
@@ -604,6 +620,7 @@ function optionalTurnFields(
     endpointDecisionMaxLatencyMs?: number | null;
     endpointDecisionSource?: VoiceEndpointSource | null;
     progressUpdatesSpoken?: number | null;
+    workingCuesPlayed?: number | null;
   },
 ): Pick<
   LiveVoiceTurnMetrics,
@@ -612,8 +629,10 @@ function optionalTurnFields(
   | "endpointDecisionMaxLatencyMs"
   | "endpointDecisionSource"
   | "progressUpdatesSpoken"
+  | "workingCuesPlayed"
 > {
   const progressUpdatesSpoken = turn.progressUpdatesSpoken ?? 0;
+  const workingCuesPlayed = turn.workingCuesPlayed ?? 0;
   return {
     ...(turn.endpointCommitLatencyMs != null
       ? { endpointCommitLatencyMs: turn.endpointCommitLatencyMs }
@@ -627,6 +646,7 @@ function optionalTurnFields(
         }
       : {}),
     ...(progressUpdatesSpoken > 0 ? { progressUpdatesSpoken } : {}),
+    ...(workingCuesPlayed > 0 ? { workingCuesPlayed } : {}),
   };
 }
 
@@ -674,6 +694,7 @@ function cloneMutableTurn(turn: MutableTurn): MutableTurn {
     endpointDecisionMaxLatencyMs: turn.endpointDecisionMaxLatencyMs,
     endpointDecisionSource: turn.endpointDecisionSource,
     progressUpdatesSpoken: turn.progressUpdatesSpoken,
+    workingCuesPlayed: turn.workingCuesPlayed,
   };
 }
 

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -36,6 +36,8 @@ import {
   LiveVoiceFluxConfigSchema,
   type LiveVoiceFrontModelConfig,
   LiveVoiceFrontModelConfigSchema,
+  type LiveVoiceWorkingCueConfig,
+  LiveVoiceWorkingCueConfigSchema,
 } from "../config/schemas/live-voice.js";
 import { ABORT_WATCHDOG_MS } from "../daemon/abort-watchdog.js";
 import { isRefusedInReadOnlyPass } from "../daemon/conversation-tool-setup.js";
@@ -137,6 +139,7 @@ import {
   LiveVoiceProtocolErrorCode,
   type LiveVoiceServerFramePayload,
 } from "./protocol.js";
+import { renderWorkingCuePcm } from "./working-cue.js";
 
 const log = getLogger("live-voice-session");
 
@@ -360,6 +363,13 @@ export interface LiveVoiceSessionOptions {
    */
   frontModelConfig?: Partial<LiveVoiceFrontModelConfig>;
   /**
+   * Working-cue tuning: the wordless tone that holds a long turn's silence.
+   * The production factory seeds this from `liveVoice.workingCue` config when
+   * unset; absent fields fall back to the schema defaults, which leave the cue
+   * on.
+   */
+  workingCueConfig?: Partial<LiveVoiceWorkingCueConfig>;
+  /**
    * Deepgram Flux turn-detection tuning. The production factory seeds this
    * from `liveVoice.flux` config when unset; absent fields fall back to the
    * schema defaults, which leave `turnEnd.enabled` on. A test that needs the
@@ -539,6 +549,15 @@ interface TtsSegmentJob {
   // block-scoped promotion or retraction selects exactly that block's
   // segments. NON_BLOCK_TTS_SEQ marks a segment that belongs to no block.
   readonly blockSeq: number;
+  // Rendered non-speech audio (the working cue) rather than a synthesized
+  // utterance. It is ordinary audio in every other respect: it reaches the
+  // client, enters the echo reference, and extends the playback-tail
+  // estimate. What it must not do is anchor the turn's first-TTS metrics,
+  // which measure when the answer starts being spoken. A cue plays into the
+  // dead air of a long working turn, well before the answer, so latching on
+  // it would report the tone's timing as the turn's speech latency on exactly
+  // the turns whose latency is worth knowing.
+  readonly nonSpeechCue: boolean;
   // The provider stream was started (the job holds an open-job slot).
   started: boolean;
   // The provider is done with this job, either because emission finished or
@@ -1355,6 +1374,13 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // option once, so every field carries its `liveVoice.frontModel` schema
   // default when unset.
   private readonly frontModelConfig: LiveVoiceFrontModelConfig;
+  // Complete working-cue tunables (the constructor schema-parses the partial
+  // option once, so every field carries its `liveVoice.workingCue` default).
+  private readonly workingCueConfig: LiveVoiceWorkingCueConfig;
+  // The session's rendered cue, built on first use. The output sample rate is
+  // whatever the start frame asked for and never changes, so one render
+  // serves every cue the session plays.
+  private workingCuePcm: Buffer | null = null;
   // Complete Flux tunables (the constructor schema-parses the partial option
   // once, so every field carries its `liveVoice.flux` schema default).
   private readonly fluxConfig: LiveVoiceFluxConfig;
@@ -1452,6 +1478,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     this.progressNarrator = options.progressNarrator ?? null;
     this.frontModelConfig = LiveVoiceFrontModelConfigSchema.parse(
       options.frontModelConfig ?? {},
+    );
+    this.workingCueConfig = LiveVoiceWorkingCueConfigSchema.parse(
+      options.workingCueConfig ?? {},
     );
     this.fluxConfig = LiveVoiceFluxConfigSchema.parse(options.fluxConfig ?? {});
     const turnDetectorConfig: TurnDetectorConfig = {
@@ -3829,11 +3858,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     if (!alreadyReleased) {
       void this.releaseUtterance();
     }
-    if (
-      this.frontModelConfig.progress.enabled &&
-      this.streamTtsAudio &&
-      this.progressNarrator
-    ) {
+    if (this.canHoldFloorWhileWorking()) {
       this.armProgressIdleTimer(turn);
     }
     return true;
@@ -4883,16 +4908,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       }, this.frontModelConfig.endpointDecisionTimeoutMs);
     }
 
-    // Progress narration speaks into the turn's audible dead air on a
-    // cadence, wherever in the turn it occurs; without TTS or a narrator there
-    // is nothing to speak (the idle trigger's static fallback still needs a
-    // generation attempt to fall back from).
-    if (
-      this.frontModelConfig.progress.enabled &&
-      this.streamTtsAudio &&
-      this.progressNarrator &&
-      !opts?.speculative
-    ) {
+    // The floor-holder plays into the turn's audible dead air on a cadence,
+    // wherever in the turn it occurs.
+    if (this.canHoldFloorWhileWorking() && !opts?.speculative) {
       this.armProgressIdleTimer(activeTurn);
     }
 
@@ -5529,16 +5547,12 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
 
     // Escalated legs run the slowest work in the system (strong-model
     // thinking + tool loops), and the bridge only covers the first couple of
-    // seconds of it — exactly the dead air progress narration exists for.
-    // Re-arm the idle narration timer (cleared above with the ack): its
-    // audible-silence gating means nothing speaks until the bridge audio has
+    // seconds of it, which is exactly the dead air the floor-holder exists
+    // for. Re-arm the idle timer (cleared above with the ack): its
+    // audible-silence gating means nothing plays until the bridge audio has
     // fully drained plus a whole idle interval. Acks stay suppressed
-    // post-handoff — the bridge already served that role.
-    if (
-      this.frontModelConfig.progress.enabled &&
-      this.streamTtsAudio &&
-      this.progressNarrator
-    ) {
+    // post-handoff, since the bridge already served that role.
+    if (this.canHoldFloorWhileWorking()) {
       this.armProgressIdleTimer(activeTurn);
     }
   }
@@ -5616,15 +5630,19 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     turn.deltaEpoch += 1;
   }
 
-  // Arms (or re-arms) the dead-air narration timer. The countdown measures
-  // audible silence — time since the turn's audio last (estimatedly) reached
-  // the user's ears — not time since launch, so it covers mid-turn silences
-  // for the whole turn. On expiry with audio still pending, or with the
-  // silence not yet a full interval old, it re-arms for the remainder; only a
-  // full interval of audible silence reaches the narration gatekeeper. The
-  // interval is a polling cadence, not a speaking cadence: most ticks find
-  // nothing new to report and stay quiet, so what the user hears follows the
-  // turn's tool activity (with `maxSilenceMs` as the heartbeat ceiling).
+  // Arms (or re-arms) the dead-air timer. The countdown measures audible
+  // silence (time since the turn's audio last, estimatedly, reached the user's
+  // ears) rather than time since launch, so it covers mid-turn silences for
+  // the whole turn. On expiry with audio still pending, or with the silence
+  // not yet a full interval old, it re-arms for the remainder; only a full
+  // interval of audible silence reaches the floor-holder gatekeeper.
+  //
+  // For the working cue the interval is the cue's own cadence: silence is the
+  // whole question it answers, so every tick that finds the turn quiet plays
+  // one. For spoken narration it is a polling cadence rather than a speaking
+  // cadence: most ticks find nothing new to report and stay quiet, so what
+  // the user hears follows the turn's tool activity (with `maxSilenceMs` as
+  // the heartbeat ceiling).
   private armProgressIdleTimer(
     turn: ActiveAssistantTurn,
     delayMs?: number,
@@ -5649,14 +5667,46 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       }
       this.maybeNarrateProgress(turn, "idle");
       this.armProgressIdleTimer(turn);
-    }, delayMs ?? this.frontModelConfig.progress.idleIntervalMs);
+    }, delayMs ?? this.floorHolderIntervalMs);
   }
 
   // Wall-clock instant the current audible silence turns a full interval old.
   private progressIdleDeadlineMs(turn: ActiveAssistantTurn): number {
+    return this.progressSilenceSinceMs(turn) + this.floorHolderIntervalMs;
+  }
+
+  // Cadence of whichever floor-holder holds this turn, and so the resolution
+  // of every silence measurement built on the idle tick. The two are paced
+  // separately on purpose: a tone every few seconds is punctuation, while a
+  // sentence every few seconds is the chatter this design exists to remove.
+  private get floorHolderIntervalMs(): number {
+    return this.narrationFloorHolder() !== null
+      ? this.frontModelConfig.progress.idleIntervalMs
+      : this.workingCueConfig.intervalMs;
+  }
+
+  // The narrator when spoken narration, rather than the cue, is what a working
+  // turn plays into its silence; null when the cue has the floor.
+  //
+  // `liveVoice.frontModel.progress.enabled` defaults to false, so a true value
+  // can only have come from a workspace explicitly asking to be narrated at,
+  // and that ask outranks the cue's default. The narrator is part of the test:
+  // narration's static phrase is the fallback for a failed generation, not a
+  // substitute for having a narrator at all.
+  private narrationFloorHolder(): VoiceProgressNarrator | null {
+    return this.frontModelConfig.progress.enabled
+      ? this.progressNarrator
+      : null;
+  }
+
+  // Whether the idle tick has anything to play, and so whether arming it is
+  // worth a timer at all.
+  private canHoldFloorWhileWorking(): boolean {
+    if (!this.streamTtsAudio) {
+      return false;
+    }
     return (
-      this.progressSilenceSinceMs(turn) +
-      this.frontModelConfig.progress.idleIntervalMs
+      this.narrationFloorHolder() !== null || this.workingCueConfig.enabled
     );
   }
 
@@ -5746,29 +5796,80 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     return false;
   }
 
-  // Gatekeeper for progress narration. It speaks only while the turn is
-  // audibly silent, with one generation at a time and the configured spacing.
+  // Gatekeeper for the turn's mid-work floor-holder. It plays only while the
+  // turn is audibly silent, one at a time and with the configured spacing.
   private maybeNarrateProgress(
     turn: ActiveAssistantTurn,
     trigger: "ops" | "idle" | "op_complete",
   ): void {
     const cfg = this.frontModelConfig.progress;
     const { progress } = turn;
-    const progressNarrator = this.progressNarrator;
     if (
-      !cfg.enabled ||
       !this.streamTtsAudio ||
-      !progressNarrator ||
       !this.turnCanNarrateProgress(turn) ||
-      progress.narrationInFlight ||
-      (progress.lastFloorHolderAtMs !== null &&
-        Date.now() - progress.lastFloorHolderAtMs < cfg.minGapMs) ||
-      (trigger === "ops" && progress.opsSinceNarration < cfg.opsThreshold) ||
-      (trigger === "idle" && !this.progressIdleHasSomethingToSay(turn))
+      progress.narrationInFlight
     ) {
       return;
     }
-    void this.speakProgressUpdate(turn, progressNarrator, trigger);
+
+    // Narration first: a workspace that turned it on asked to be told what is
+    // happening, and the cue is what a turn plays when nobody asked for words.
+    const progressNarrator = this.narrationFloorHolder();
+
+    // minGapMs is narration's own spacing guard, and it only applies to the
+    // holder it was tuned for. The cue is spaced by its own intervalMs, so
+    // letting a 6s narration gap veto a 3s cue would make the cue schema's
+    // cadence a lie and couple two tunables the config deliberately separates.
+    if (
+      progressNarrator !== null &&
+      progress.lastFloorHolderAtMs !== null &&
+      Date.now() - progress.lastFloorHolderAtMs < cfg.minGapMs
+    ) {
+      return;
+    }
+    if (progressNarrator !== null) {
+      if (
+        (trigger === "ops" && progress.opsSinceNarration < cfg.opsThreshold) ||
+        (trigger === "idle" && !this.progressIdleHasSomethingToSay(turn))
+      ) {
+        return;
+      }
+      void this.speakProgressUpdate(turn, progressNarrator, trigger);
+      return;
+    }
+
+    // The cue answers "am I still here", which is a question about silence and
+    // not about tool activity. A tool starting or finishing changes nothing a
+    // wordless tone could carry, so the activity triggers say nothing and only
+    // the idle tick plays it.
+    if (this.workingCueConfig.enabled && trigger === "idle") {
+      this.playWorkingCue(turn);
+    }
+  }
+
+  // Play one working cue into the turn's silence. It holds the floor exactly
+  // as a spoken filler does, so the next tick spaces from it and the cadence
+  // is silence-to-silence rather than start-to-start.
+  //
+  // The audio is rendered on first use: the output sample rate is fixed for
+  // the session's life, so one render serves every cue it plays.
+  private playWorkingCue(turn: ActiveAssistantTurn): void {
+    const pcm = (this.workingCuePcm ??= renderWorkingCuePcm(
+      this.context.startFrame.audio.sampleRate,
+      {
+        frequencyHz: this.workingCueConfig.frequencyHz,
+        durationMs: this.workingCueConfig.durationMs,
+        gain: this.workingCueConfig.gain,
+      },
+    ));
+    if (pcm.byteLength === 0) {
+      // A shape that rounds to no frames at this sample rate. Enqueuing it
+      // would send an empty frame and still take the floor for a full
+      // interval, which is worse than skipping the tick.
+      return;
+    }
+    this.enqueueTtsAudioCue(turn.token, pcm);
+    turn.progress.lastFloorHolderAtMs = Date.now();
   }
 
   // Generate and speak one audio-only progress narration. On a null result,
@@ -6189,6 +6290,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       text: segment,
       language: options.language,
       blockSeq: options.blockSeq ?? activeTurn.textBlockSeq,
+      nonSpeechCue: false,
       started: false,
       settled: false,
       emitting: false,
@@ -6207,6 +6309,63 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       // defeat the hold.
       return;
     }
+    activeTurn.ttsQueue = activeTurn.ttsQueue
+      .catch(() => {})
+      .then(() => this.emitTtsJob(token, job));
+  }
+
+  /**
+   * Enqueue rendered audio as a segment job. The bytes are already in hand, so
+   * the job is constructed `started` with its chunks pre-buffered and a
+   * resolved `synthesis`: `emitTtsJob` then promotes, flushes, and settles it
+   * exactly like a synthesized segment, with no change to the pump or the
+   * emission chain.
+   */
+  private enqueueTtsAudioCue(token: symbol, pcm: Buffer): void {
+    const activeTurn = this.activeAssistantTurn;
+    if (activeTurn?.token !== token || !this.streamTtsAudio) {
+      return;
+    }
+    const job: TtsSegmentJob = {
+      // Nothing synthesizes this job, so the only consumer of `text` (the
+      // provider dispatch in pumpTtsSynthesis) never sees it.
+      text: "",
+      language: undefined,
+      // The cue belongs to no model text block, so no block-scoped promotion
+      // or retraction can reach it.
+      blockSeq: NON_BLOCK_TTS_SEQ,
+      // Keeps the tone out of the turn's first-TTS metrics (see the field).
+      nonSpeechCue: true,
+      started: true,
+      settled: false,
+      emitting: false,
+      // The cue exists to be heard right now: holding one would be holding
+      // the very silence it was played to fill.
+      held: false,
+      cancelled: false,
+      abort: new AbortController(),
+      bufferedChunks: [
+        {
+          type: "tts_audio",
+          // Bare `audio/pcm` at the session rate is exactly what
+          // appendEchoReference accepts. Get either wrong and the cue still
+          // plays, but the echo canceller never learns the hum was us, so
+          // every cue reads as the user speaking over the assistant and the
+          // cadence becomes a periodic barge-in.
+          contentType: "audio/pcm",
+          sampleRate: this.context.startFrame.audio.sampleRate,
+          dataBase64: pcm.toString("base64"),
+        },
+      ],
+      synthesis: Promise.resolve(),
+      frames: Promise.resolve(),
+    };
+    activeTurn.ttsJobs.push(job);
+    // A cue does not spend the eager first-segment latch. `ttsSegmentEnqueued`
+    // gates the eager first-clause flush, which belongs to the model's opening
+    // words: whatever a turn plays into its dead air, its real first segment
+    // still flushes on the opening clause rather than waiting for a full
+    // sentence, so speech onset is as early as it would be without the cue.
     activeTurn.ttsQueue = activeTurn.ttsQueue
       .catch(() => {})
       .then(() => this.emitTtsJob(token, job));
@@ -6424,8 +6583,16 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       this.appendEchoReference(chunk);
       this.assistantPlaybackTailUntilMs =
         Math.max(now, this.assistantPlaybackTailUntilMs) + chunkMs;
+      // Everything above is what a cue is here for: the client hears it, the
+      // canceller learns it was us, and the tail estimate covers it. The
+      // first-TTS latch is where a cue stops, because that mark is the onset
+      // of the turn's speech (see `nonSpeechCue`).
       const turnAfterSend = this.activeAssistantTurn;
-      if (turnAfterSend?.token !== token || turnAfterSend.ttsAudioStarted) {
+      if (
+        job.nonSpeechCue ||
+        turnAfterSend?.token !== token ||
+        turnAfterSend.ttsAudioStarted
+      ) {
         return;
       }
       turnAfterSend.ttsAudioStarted = true;
@@ -6976,6 +7143,8 @@ export function createLiveVoiceSession(
       options.echoEmaHalfLifeMs ?? vadConfig?.echoEmaHalfLifeMs,
     echoDrainSlackMs: options.echoDrainSlackMs ?? vadConfig?.echoDrainSlackMs,
     frontModelConfig,
+    // Absent config leaves the schema defaults, which keep the cue on.
+    workingCueConfig: options.workingCueConfig ?? liveVoiceConfig?.workingCue,
     // Absent config leaves the schema defaults, which keep provider turn
     // detection off.
     fluxConfig: options.fluxConfig ?? liveVoiceConfig?.flux,

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -5795,15 +5795,29 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       : null;
   }
 
+  // Whether this session may play the working cue at all: the workspace has to
+  // want it AND the client has to be able to read it.
+  //
+  // The capability half is not belt-and-braces. A client that predates
+  // `nonSpeech` runs its old `tts_audio` handler on the tone and counts it as
+  // answer speech, latching speaking state, client-heard latency and the
+  // spoken-word cursor on a turn that has said nothing. A packaged client
+  // ships on its own cadence and can be older than the daemon serving it, so
+  // the cue waits to be told the frame will be understood. Absent means no.
+  private get workingCueEnabled(): boolean {
+    return (
+      this.workingCueConfig.enabled &&
+      this.context.startFrame.nonSpeechAudio === true
+    );
+  }
+
   // Whether the idle tick has anything to play, and so whether arming it is
   // worth a timer at all.
   private canHoldFloorWhileWorking(): boolean {
     if (!this.streamTtsAudio) {
       return false;
     }
-    return (
-      this.narrationFloorHolder() !== null || this.workingCueConfig.enabled
-    );
+    return this.narrationFloorHolder() !== null || this.workingCueEnabled;
   }
 
   // When the turn's current audible silence began: the latest of the last
@@ -5938,7 +5952,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     // not about tool activity. A tool starting or finishing changes nothing a
     // wordless tone could carry, so the activity triggers say nothing and only
     // the idle tick plays it.
-    if (this.workingCueConfig.enabled && trigger === "idle") {
+    if (this.workingCueEnabled && trigger === "idle") {
       this.playWorkingCue(turn);
     }
   }

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -519,6 +519,12 @@ type UtteranceStartResult =
   | { status: "unavailable"; message: string }
   | { status: "error"; message: string };
 
+// The block sequence for a segment that came from no model text block: a
+// fixed session phrase (the escalation bridge, the approval-pending line,
+// progress narration). Those exist to be heard while the turn works, so they
+// are never held, and no block-scoped selector can ever match them.
+const NON_BLOCK_TTS_SEQ = -1;
+
 // One TTS segment flowing through the turn's synthesis pipeline. Synthesis
 // may run ahead of the emission slot (prefetch), but frames only reach the
 // client in job-list order.
@@ -529,6 +535,10 @@ interface TtsSegmentJob {
   // the English fallback text carries "en" so an enforcing provider never
   // renders English words as ar/ko/ta. Undefined means the turn language.
   readonly language: string | undefined;
+  // Which of the leg's model text blocks this segment came from, so a
+  // block-scoped promotion or retraction selects exactly that block's
+  // segments. NON_BLOCK_TTS_SEQ marks a segment that belongs to no block.
+  readonly blockSeq: number;
   // The provider stream was started (the job holds an open-job slot).
   started: boolean;
   // The provider is done with this job, either because emission finished or
@@ -752,6 +762,14 @@ interface ActiveAssistantTurn {
   // front-door leg's trailing completion from finalizing the turn, and makes
   // the hand-off idempotent.
   escalationHandedOff: boolean;
+  // The leg currently streaming into this turn. An escalated leg is doing
+  // work, so its model text is held until the turn's shape says whether that
+  // text was working commentary or the report back.
+  routingLeg: VoiceRoutingLeg;
+  // Which of the current leg's model text blocks the turn is accumulating.
+  // A tool-use block opening closes the current one and bumps this, so each
+  // block's held segments are selectable as a unit.
+  textBlockSeq: number;
   ttsBuffer: string;
   // The turn is finalizing its TTS: every remaining enqueue is terminal by
   // construction, so holds are ignored past this point (see
@@ -862,6 +880,13 @@ const LIVE_VOICE_SCREEN_REVEAL_TEACHING =
 const LIVE_VOICE_SETUP_FLOW_TEACHING =
   "This includes connecting accounts. If a task needs an account connected or a sign-in completed, put the connection up on screen and let the user do it now. Do not decline it, and do not defer it to text chat. Say what you are connecting and that it is in front of them. ";
 
+// Holding stops the caller hearing the working commentary; nothing makes the
+// closing report short. A one-time instruction, not a per-block protocol the
+// model must keep executing. It also directly bounds the report's onset
+// delay, since the hold ends when this block finishes generating.
+const LIVE_VOICE_SPOKEN_CLOSE_TEACHING =
+  "You already told the caller you were on it, and they have heard nothing since. When you finish, close with one or two short sentences saying what you did or what you found: the result, not the route you took to it. If you need something from them to continue, ask for everything you need in one go. ";
+
 // System-level guidance appended to a barge-in turn's control prompt so the
 // model treats the new utterance as a continuation of the request it was cut
 // off answering, rather than a fresh follow-up. Reaches the model only; it is
@@ -919,9 +944,10 @@ function buildLiveDeliveryNote(request: string, answer: string): string {
 }
 
 // Assemble a leg's model-facing control prompt: the base live-voice rules, the
-// screen-reveal and setup-flow teaching (both withheld from the front-door leg,
-// see LIVE_VOICE_SCREEN_REVEAL_TEACHING), plus any pending barge-in merge
-// context, completed-continuation context, and/or the announcement instruction.
+// screen-reveal, setup-flow, and spoken-close teaching (all withheld from the
+// front-door leg, see LIVE_VOICE_SCREEN_REVEAL_TEACHING), plus any pending
+// barge-in merge context, completed-continuation context, and/or the
+// announcement instruction.
 // A turn can carry several (a barge-in follow-up that also has a continuation
 // result waiting); the notes are model-only and never render as user bubbles.
 function buildVoiceControlPrompt(
@@ -932,7 +958,9 @@ function buildVoiceControlPrompt(
     LIVE_VOICE_CONTROL_PROMPT_BASE +
     (leg.frontDoor === true
       ? ""
-      : LIVE_VOICE_SCREEN_REVEAL_TEACHING + LIVE_VOICE_SETUP_FLOW_TEACHING);
+      : LIVE_VOICE_SCREEN_REVEAL_TEACHING +
+        LIVE_VOICE_SETUP_FLOW_TEACHING +
+        LIVE_VOICE_SPOKEN_CLOSE_TEACHING);
   if (turn.language !== undefined) {
     prompt = `${prompt}\n\nThe caller has been speaking the language with code "${turn.language}" this turn. Reply in that language unless they clearly switch to another.`;
   }
@@ -4804,6 +4832,8 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       hiddenPrompt: opts?.hiddenPrompt === true,
       deltaEpoch: 0,
       escalationHandedOff: false,
+      routingLeg: "front-door",
+      textBlockSeq: 0,
       ttsBuffer: "",
       ttsCompleting: false,
       ttsReasoningFilter: createReasoningTagFilter(),
@@ -4916,6 +4946,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       return false;
     }
     const { token, utterance, turnId } = activeTurn;
+    // Set before anything of this leg can stream, so the TTS path knows which
+    // leg's text it is segmenting. The escalation bridge is enqueued before
+    // this runs, which is what keeps it on the front-door leg's terms.
+    activeTurn.routingLeg = leg.routingLeg ?? "front-door";
 
     // `rawText` accumulates this leg's full stream. A front-door leg starts
     // in `deciding` until its leading tokens classify as hold / escalate /
@@ -5156,9 +5190,28 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
             // emitted rather than dropped.
             if (!leg.frontDoor && msg.type === "message_complete") {
               flushLegText(rawText, { force: true });
+              if (leg.routingLeg === "escalated") {
+                // Nothing followed this block, so it is the turn's report
+                // back: the answer, or the question it needs answered. Its
+                // first segment is already synthesized, so promotion starts
+                // audio without a TTS round trip. Ordering is load-bearing:
+                // the force-flush above segments the block's tail first, and
+                // this runs before assistantCompleted closes the TTS path.
+                this.promoteHeldTtsSegments(
+                  token,
+                  (job) => job.blockSeq === current.textBlockSeq,
+                );
+              }
             }
             current.assistantCompleted = true;
             if (msg.type === "generation_cancelled") {
+              // The turn produced no report, so its held blocks have nothing
+              // to be promoted onto. Retracting them here tears their
+              // provider streams down at once rather than leaving them
+              // running behind a cancelled turn.
+              this.retractHeldTtsSegments(token, (job) => job.held, {
+                discardPendingTail: true,
+              });
               void this.finalizeAssistantTurn(
                 current,
                 "cancelled",
@@ -5185,6 +5238,29 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
               return;
             }
             current.assistantMessageId = messageId;
+          },
+          tool_block_opened: (toolName) => {
+            const current = this.activeAssistantTurn;
+            if (current?.token !== token || leg.routingLeg !== "escalated") {
+              return;
+            }
+            // The provider opened a tool-use block, so the text block before
+            // it is closed and was working commentary, not this turn's
+            // report. It was never emitted, so dropping it is silent.
+            // Deterministic: this reads the response structure, not the text.
+            const seq = current.textBlockSeq;
+            const dropped = this.retractHeldTtsSegments(
+              token,
+              (job) => job.blockSeq === seq,
+              // The retraction owns the block's un-segmented tail: text short
+              // of a segment boundary is still this block's commentary.
+              { discardPendingTail: true },
+            );
+            current.textBlockSeq += 1;
+            log.debug(
+              { turnId, toolName, dropped },
+              "Dropped held commentary segments at tool-use block open",
+            );
           },
           tool_use_start: (toolName, detail) => {
             const current = this.activeAssistantTurn;
@@ -5415,6 +5491,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         { type: "assistant_text_delta", text: spokenBridge },
         () => !activeTurn.abortController.signal.aborted && !this.isClosed,
       );
+      // Enqueued while the turn is still on the front-door leg, so the bridge
+      // is not held: it is the one thing the caller is meant to hear before
+      // the escalated leg reports back, and only held segments can be
+      // retracted.
       this.bufferAssistantTextForTts(activeTurn.token, `${spokenBridge} `);
       // Force-flush now: on the TTS path an unpunctuated bridge would
       // otherwise sit buffered until a sentence boundary and leave the
@@ -5427,6 +5507,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       const speakable = sanitizeForTts(spokenBridge).trim();
       if (speakable.length > 0) {
         this.enqueueTtsSegment(activeTurn.token, speakable, {
+          blockSeq: NON_BLOCK_TTS_SEQ,
           language: this.fixedPhraseLanguage(
             activeTurn,
             FALLBACK_ESCALATION_BRIDGE_BY_LANGUAGE,
@@ -5793,6 +5874,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     }
     this.enqueueTtsSegment(turn.token, phrase, {
       countsAsFirstSegment: false,
+      // A filler exists to be heard while the turn works, so it is never held
+      // and never retracted with the block it happens to land beside.
+      blockSeq: NON_BLOCK_TTS_SEQ,
       ...(language !== undefined ? { language } : {}),
     });
     // A spoken filler holds the floor, so narration's minGapMs spaces from it.
@@ -6059,7 +6143,13 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       if (speakable.length === 0) {
         continue;
       }
-      this.enqueueTtsSegment(token, speakable);
+      // An escalated leg is working, so what it says mid-turn is usually
+      // commentary on that work rather than the answer. Hold it: it is
+      // synthesized now (so promotion costs no provider round trip) and only
+      // the block the turn ends on is ever spoken.
+      this.enqueueTtsSegment(token, speakable, {
+        held: activeTurn.routingLeg === "escalated",
+      });
     }
   }
 
@@ -6073,6 +6163,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       // provider but stays off the emission chain until promoteHeldTtsSegments
       // puts it there, or retractHeldTtsSegments drops it.
       held?: boolean;
+      // Which model text block the segment came from. Defaults to the block
+      // the turn is accumulating; a fixed session phrase passes
+      // NON_BLOCK_TTS_SEQ so no block-scoped selector can reach it.
+      blockSeq?: number;
     } = {},
   ): void {
     const activeTurn = this.activeAssistantTurn;
@@ -6094,6 +6188,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     const job: TtsSegmentJob = {
       text: segment,
       language: options.language,
+      blockSeq: options.blockSeq ?? activeTurn.textBlockSeq,
       started: false,
       settled: false,
       emitting: false,

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -531,7 +531,9 @@ interface TtsSegmentJob {
   readonly language: string | undefined;
   // The provider stream was started (the job holds an open-job slot).
   started: boolean;
-  // Emission finished; the slot is free for the next queued segment.
+  // The provider is done with this job, either because emission finished or
+  // because a retraction's abort tore the stream down. The synthesis slot is
+  // free for the next queued segment.
   settled: boolean;
   // The job owns the emission slot: provider chunks forward to the client
   // live instead of buffering.
@@ -539,6 +541,19 @@ interface TtsSegmentJob {
   // Chunks received while prefetching, flushed in order on promotion.
   // Dropped with the turn on cancellation.
   bufferedChunks: LiveVoiceTtsAudioChunk[];
+  // Enqueued for synthesis but deliberately kept off the emission chain until
+  // the caller promotes it. A held job has forwarded no audio, so it is still
+  // silently cancellable, but it does count as pending audio: promotion is all
+  // that stands between it and the caller's ears.
+  held: boolean;
+  // Retracted before promotion: dropped from the emission chain with its
+  // provider stream aborted. Only ever set while `emitting` is false. It goes
+  // true the instant the retraction lands, ahead of `settled`, because a job
+  // stops being audible before its aborted stream stops being open.
+  cancelled: boolean;
+  // Per-job synthesis abort, so retracting one segment leaves the turn's other
+  // segments alone (the turn controller aborts all of them).
+  readonly abort: AbortController;
   // Settles when the provider stream ends; rejects on synthesis failure.
   synthesis: Promise<void> | null;
   // Ordered tts_audio frame writes for this job.
@@ -738,6 +753,10 @@ interface ActiveAssistantTurn {
   // the hand-off idempotent.
   escalationHandedOff: boolean;
   ttsBuffer: string;
+  // The turn is finalizing its TTS: every remaining enqueue is terminal by
+  // construction, so holds are ignored past this point (see
+  // enqueueTtsSegment) and stranded held jobs have already been swept.
+  ttsCompleting: boolean;
   // Strips inline <think> reasoning spans from the spoken stream. Stateful
   // per turn because spans and tags cross delta boundaries; display frames
   // keep the raw text.
@@ -4786,6 +4805,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       deltaEpoch: 0,
       escalationHandedOff: false,
       ttsBuffer: "",
+      ttsCompleting: false,
       ttsReasoningFilter: createReasoningTagFilter(),
       ttsSegmentEnqueued: false,
       ttsJobs: [],
@@ -5571,12 +5591,22 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   }
 
   // No assistant audio is pending or (estimatedly) still playing: nothing
-  // buffered toward the next sentence, every queued TTS segment fully
-  // emitted, and the client-side playback-tail estimate expired.
+  // buffered toward the next sentence, no queued TTS segment that can still be
+  // heard, and the client-side playback-tail estimate expired.
+  //
+  // A job sits on two independent axes. "Does it still occupy a provider
+  // synthesis slot" is `started && !settled`, and that is pumpTtsSynthesis's
+  // question, not this one. This is the other axis: "can it still produce
+  // audio the caller hears". A cancelled job never can, whatever its aborted
+  // stream is still doing, so it must not gate the idle tick: a provider that
+  // hangs on abort would otherwise mute narration for the rest of the turn. A
+  // held job is the opposite. It is heard the moment it is promoted, so a turn
+  // sitting on held segments is quiet rather than idle, and the tick must stay
+  // silent instead of talking over the answer that is about to land.
   private turnAudioIdle(turn: ActiveAssistantTurn): boolean {
     return (
       turn.ttsBuffer.length === 0 &&
-      turn.ttsJobs.every((job) => job.settled) &&
+      turn.ttsJobs.every((job) => job.settled || job.cancelled) &&
       Date.now() >= this.assistantPlaybackTailUntilMs
     );
   }
@@ -5799,6 +5829,116 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     this.flushTtsBuffer(token, false);
   }
 
+  /**
+   * Move held segments onto the emission chain. Their audio is already
+   * synthesized and buffered, so promotion is a buffer flush rather than a TTS
+   * round trip.
+   *
+   * Ordering contract: promoted jobs join the chain at promotion time, ordered
+   * among themselves by enqueue order, and land behind anything already queued.
+   * A held job deliberately does not reserve a position when it is enqueued.
+   * A reserved position would stall every later job behind a segment that may
+   * never be promoted at all, including the short "still working" tone whose
+   * entire purpose is to fill that hold, so the queue would go silent for
+   * exactly as long as the hold lasts. Keeping held jobs off the chain is what
+   * makes a hold quiet rather than blocking.
+   */
+  private promoteHeldTtsSegments(
+    token: symbol,
+    select: (job: TtsSegmentJob) => boolean,
+  ): number {
+    const activeTurn = this.activeAssistantTurn;
+    if (activeTurn?.token !== token) {
+      return 0;
+    }
+
+    // `ttsJobs` is in enqueue order, so chaining in filter order is what keeps
+    // the promoted block internally ordered.
+    const promoted = activeTurn.ttsJobs.filter(
+      (job) => job.held && !job.cancelled && select(job),
+    );
+    for (const job of promoted) {
+      job.held = false;
+      activeTurn.ttsQueue = activeTurn.ttsQueue
+        .catch(() => {})
+        .then(() => this.emitTtsJob(token, job));
+    }
+    // Promotion frees the standing held-job slot, so a segment that was
+    // waiting behind the cap can start synthesizing now.
+    this.pumpTtsSynthesis(token);
+    return promoted.length;
+  }
+
+  /**
+   * Retract held segments that have not reached the client. Returns the number
+   * dropped.
+   *
+   * A job that is already `emitting` is left alone: spoken audio cannot be
+   * un-said and cutting a segment mid-phrase sounds broken. In this design no
+   * held job is ever emitting, so that guard is belt-and-braces.
+   *
+   * `discardPendingTail` declares that the caller also owns whatever sits in
+   * `ttsBuffer` below the next segment boundary, so a caller retracting a whole
+   * block sets it and a selective retraction does not. Ownership is stated
+   * rather than inferred: the buffer is turn-wide, the selector only sees jobs
+   * that have already formed, and a selective retraction has no way to tell
+   * whose text the un-segmented tail is. Guessing would silently delete speech
+   * the retraction never covered.
+   */
+  private retractHeldTtsSegments(
+    token: symbol,
+    select: (job: TtsSegmentJob) => boolean,
+    options: { discardPendingTail?: boolean } = {},
+  ): number {
+    const activeTurn = this.activeAssistantTurn;
+    if (activeTurn?.token !== token) {
+      return 0;
+    }
+
+    const retracted = activeTurn.ttsJobs.filter(
+      (job) => job.held && !job.cancelled && !job.emitting && select(job),
+    );
+    for (const job of retracted) {
+      job.cancelled = true;
+      job.abort.abort(
+        createAbortReason("voice_session_aborted", "live-voice-tts-retract"),
+      );
+      job.bufferedChunks.length = 0;
+      if (job.synthesis === null) {
+        // Never handed to the provider, so it occupies no synthesis slot.
+        job.settled = true;
+        continue;
+      }
+      // A retracted job never reaches emitTtsJob, so nothing else will settle
+      // it. The slot stays taken until the provider stream actually tears
+      // down: a provider that does not honour the abort promptly would
+      // otherwise have the next job start alongside it and put more than
+      // TTS_MAX_OPEN_SYNTHESIS_JOBS streams open at once.
+      void job.synthesis.then(
+        () => this.settleRetractedTtsJob(token, job),
+        () => this.settleRetractedTtsJob(token, job),
+      );
+    }
+
+    if (options.discardPendingTail === true) {
+      // The block owns its un-segmented tail whether or not a job formed from
+      // it yet: text short of a segment boundary is still the block's, and a
+      // half-finished markdown or <think> construct left in the filter would
+      // bleed into the next block.
+      activeTurn.ttsBuffer = "";
+      activeTurn.ttsReasoningFilter.flush();
+    }
+    this.pumpTtsSynthesis(token);
+    return retracted.length;
+  }
+
+  // Releases a retracted job's synthesis slot once its aborted provider stream
+  // has torn down, and lets the next queued segment take it.
+  private settleRetractedTtsJob(token: symbol, job: TtsSegmentJob): void {
+    job.settled = true;
+    this.pumpTtsSynthesis(token);
+  }
+
   private completeTtsForTurn(token: symbol): void {
     const activeTurn = this.activeAssistantTurn;
     if (activeTurn?.token !== token) {
@@ -5806,6 +5946,26 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     }
 
     this.clearFillerTimers(activeTurn);
+    // Sweep held jobs the caller never resolved. Every held block is supposed
+    // to end in a promotion (it was the answer) or a retraction (a tool call
+    // proved it was commentary), but a caller that misses an exit would
+    // otherwise leave a provider request running past the turn: the job is off
+    // ttsQueue, so completion never awaits it, and its synthesis slot would
+    // still be occupied when the next turn starts. Retract rather than promote,
+    // because unresolved held text is commentary far more often than it is an
+    // answer, and speaking it is the failure this hold exists to prevent.
+    const strandedHeldJobs = this.retractHeldTtsSegments(
+      token,
+      (job) => job.held,
+    );
+    if (strandedHeldJobs > 0) {
+      log.warn(
+        { turnId: activeTurn.turnId, strandedHeldJobs },
+        "Live voice turn completed with held segments the caller never resolved",
+      );
+    }
+    // Past this point every enqueue is terminal, so nothing new is held.
+    activeTurn.ttsCompleting = true;
     activeTurn.ttsBuffer += activeTurn.ttsReasoningFilter.flush();
     this.flushTtsBuffer(token, true);
     activeTurn.ttsQueue = activeTurn.ttsQueue
@@ -5906,7 +6066,14 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   private enqueueTtsSegment(
     token: symbol,
     segment: string,
-    options: { countsAsFirstSegment?: boolean; language?: string } = {},
+    options: {
+      countsAsFirstSegment?: boolean;
+      language?: string;
+      // Synthesize now, speak later (or never): the job is queued for the
+      // provider but stays off the emission chain until promoteHeldTtsSegments
+      // puts it there, or retractHeldTtsSegments drops it.
+      held?: boolean;
+    } = {},
   ): void {
     const activeTurn = this.activeAssistantTurn;
     if (activeTurn?.token !== token || !this.streamTtsAudio) {
@@ -5918,18 +6085,33 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     if (options.countsAsFirstSegment ?? true) {
       activeTurn.ttsSegmentEnqueued = true;
     }
+    // A hold means "wait and see whether a tool call follows this text". Once
+    // the turn is completing, nothing can follow it, so a segment flushed here
+    // is terminal by construction and must never be held: holding it would
+    // strand the tail of the answer off the emission chain, where the leftover
+    // sweep below would then drop it.
+    const held = (options.held ?? false) && !activeTurn.ttsCompleting;
     const job: TtsSegmentJob = {
       text: segment,
       language: options.language,
       started: false,
       settled: false,
       emitting: false,
+      held,
+      cancelled: false,
+      abort: new AbortController(),
       bufferedChunks: [],
       synthesis: null,
       frames: Promise.resolve(),
     };
     activeTurn.ttsJobs.push(job);
     this.pumpTtsSynthesis(token);
+    if (job.held) {
+      // Synthesis has started; emission has not. Chaining the job onto
+      // ttsQueue is exactly what promotion does, so doing it here would
+      // defeat the hold.
+      return;
+    }
     activeTurn.ttsQueue = activeTurn.ttsQueue
       .catch(() => {})
       .then(() => this.emitTtsJob(token, job));
@@ -5955,7 +6137,24 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       activeTurn.ttsJobs.filter((job) => job.started && !job.settled).length <
       TTS_MAX_OPEN_SYNTHESIS_JOBS
     ) {
-      const job = activeTurn.ttsJobs.find((candidate) => !candidate.started);
+      // Held jobs get at most one of the open slots. Pre-synthesizing a held
+      // block's FIRST segment is what removes the TTS round trip from the
+      // answer's onset; later segments pipeline during that first segment's
+      // playback anyway, so synthesizing further ahead only risks paying for
+      // audio a tool call is about to cancel. A held job stays open until it
+      // is promoted, or until a retraction's abort tears its stream down, so
+      // the cap is a standing one.
+      const heldSlotTaken = activeTurn.ttsJobs.some(
+        (candidate) =>
+          candidate.held && candidate.started && !candidate.settled,
+      );
+      const job = activeTurn.ttsJobs.find(
+        (candidate) =>
+          !candidate.started &&
+          // A retracted job is dead: nothing will ever emit it.
+          !candidate.cancelled &&
+          (!candidate.held || !heldSlotTaken),
+      );
       if (!job) {
         return;
       }
@@ -5968,11 +6167,19 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         synthesis = streamTtsAudio({
           text: job.text,
           ...(language !== undefined ? { language } : {}),
-          signal: activeTurn.abortController.signal,
+          // Either the turn ending or this one segment being retracted stops
+          // the stream; the job's own controller is what lets a retraction
+          // leave the turn's other segments streaming.
+          signal: AbortSignal.any([
+            activeTurn.abortController.signal,
+            job.abort.signal,
+          ]),
           outputFormat: "pcm",
           sampleRate: this.context.startFrame.audio.sampleRate,
           onAudioChunk: (chunk) => {
-            if (!this.isForwardingTts(token)) {
+            // A retracted job keeps nothing: its buffer was already released
+            // and no promotion will ever flush it.
+            if (!this.isForwardingTts(token) || job.cancelled) {
               return;
             }
             if (job.emitting) {
@@ -6006,6 +6213,13 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       ) {
         // The turn is gone: release the prefetched audio immediately rather
         // than holding it until the turn object drops.
+        job.bufferedChunks.length = 0;
+        return;
+      }
+
+      if (job.cancelled) {
+        // Retracted while held: drop the prefetched audio without promoting
+        // it. Nothing was forwarded, so the client hears no seam.
         job.bufferedChunks.length = 0;
         return;
       }
@@ -6052,7 +6266,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     } finally {
       job.settled = true;
       const settledTurn = this.activeAssistantTurn;
-      if (settledTurn?.token === token) {
+      // A retracted job forwarded nothing, so it must not stand in for audio
+      // the user never heard and postpone the dead-air countdown.
+      if (settledTurn?.token === token && !job.cancelled) {
         // Anchor the dead-air countdown to the end of emission; the playback
         // -tail estimate covers any client-side buffer still draining.
         settledTurn.progress.lastAudibleAtMs = Date.now();

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -533,7 +533,26 @@ type UtteranceStartResult =
 // fixed session phrase (the escalation bridge, the approval-pending line,
 // progress narration). Those exist to be heard while the turn works, so they
 // are never held, and no block-scoped selector can ever match them.
-const NON_BLOCK_TTS_SEQ = -1;
+export const NON_BLOCK_TTS_SEQ = -1;
+
+/**
+ * What a TTS segment is to the caller, which decides how the session accounts
+ * for it rather than how it is played. Every role reaches the client, enters
+ * the echo reference, and extends the playback-tail estimate.
+ *
+ * - `answer`: the turn's own speech. It anchors the first-TTS metrics and is
+ *   archived as the assistant's audio.
+ * - `filler`: a spoken floor-holder (progress narration, the approval-pending
+ *   line). Real speech, so it archives like any other, but it must not anchor
+ *   the first-TTS metrics: those measure when the ANSWER starts speaking, and
+ *   a filler plays into the dead air before it.
+ * - `cue`: the rendered working tone. Not speech at all, so on top of the
+ *   filler's exclusion it stays out of the archived assistant audio (its bare
+ *   PCM would interleave with whatever container a provider returned) and is
+ *   marked `nonSpeech` on the wire, where a client latches speaking state,
+ *   barge-in eligibility, and the spoken-word cursor on every tts_audio frame.
+ */
+type TtsSegmentAudioRole = "answer" | "filler" | "cue";
 
 // One TTS segment flowing through the turn's synthesis pipeline. Synthesis
 // may run ahead of the emission slot (prefetch), but frames only reach the
@@ -549,15 +568,9 @@ interface TtsSegmentJob {
   // block-scoped promotion or retraction selects exactly that block's
   // segments. NON_BLOCK_TTS_SEQ marks a segment that belongs to no block.
   readonly blockSeq: number;
-  // Rendered non-speech audio (the working cue) rather than a synthesized
-  // utterance. It is ordinary audio in every other respect: it reaches the
-  // client, enters the echo reference, and extends the playback-tail
-  // estimate. What it must not do is anchor the turn's first-TTS metrics,
-  // which measure when the answer starts being spoken. A cue plays into the
-  // dead air of a long working turn, well before the answer, so latching on
-  // it would report the tone's timing as the turn's speech latency on exactly
-  // the turns whose latency is worth knowing.
-  readonly nonSpeechCue: boolean;
+  // Whether this segment is the turn's answer, a spoken floor-holder, or the
+  // rendered cue (see TtsSegmentAudioRole).
+  readonly audioRole: TtsSegmentAudioRole;
   // The provider stream was started (the job holds an open-job slot).
   started: boolean;
   // The provider is done with this job, either because emission finished or
@@ -801,16 +814,32 @@ interface ActiveAssistantTurn {
   // A non-empty speakable segment reached the TTS queue — gates the eager
   // first-segment flush that trades clause quality for speech onset.
   ttsSegmentEnqueued: boolean;
-  // Ordered TTS segment jobs for the turn; synthesis runs ahead of emission
-  // by at most one job (TTS_MAX_OPEN_SYNTHESIS_JOBS).
+  // Every TTS segment job of the turn, in enqueue order, whether or not it is
+  // on the emission chain. At most TTS_MAX_OPEN_SYNTHESIS_JOBS of them hold a
+  // provider stream open at once, and at most one of those may be a held job,
+  // so how far synthesis runs ahead of emission depends on which jobs are
+  // held: a held block's first segment is synthesized long before anything
+  // decides whether it will ever be spoken.
   ttsJobs: TtsSegmentJob[];
-  // Serial emission chain: one job's frames fully precede the next's, and
-  // the tts_done finale runs only after every job has drained.
+  // Serial emission chain: one job's frames fully precede the next's, and the
+  // tts_done finale runs after every job ON THE CHAIN has drained. A held job
+  // is deliberately off the chain, so completion never waits for one;
+  // completeTtsForTurn's sweep is what stops a held job outliving the turn.
   ttsQueue: Promise<void>;
   assistantMessageId: string | null;
   assistantAudioChunks: Buffer[];
   assistantAudioMimeType: string;
   assistantAudioSampleRate?: number;
+}
+
+/**
+ * A held job that can still be promoted, which is the only sense in which a
+ * turn has pending held audio. Cancellation is what ends a hold: a retracted
+ * job keeps `held` set (it still names the block it came from) but nothing
+ * will ever emit it, so every question about the hold has to exclude it.
+ */
+function isPendingHeldTtsJob(job: TtsSegmentJob): boolean {
+  return job.held && !job.cancelled;
 }
 
 /**
@@ -835,30 +864,48 @@ interface ActiveAssistantTurn {
  * a marker, so this stripping is defense against a model that emits one
  * regardless: an unspoken, unpersisted "[-1]" is the correct handling of a
  * token that now means nothing.
+ *
+ * `dropPendingTail` abandons whatever is currently withheld. The withheld tail
+ * is the only text of a block that does not live in `ttsBuffer`, so a caller
+ * that drops the block (a tool-use block opening on an escalated leg) has to
+ * say so here as well: left in place it would be emitted later, stamped with
+ * the NEXT block's sequence, and spoken glued onto that block's text.
+ *
+ * Known residual: the daemon's own guard buffer
+ * (`pendingSentinelGuardBuffer` in `daemon/conversation-agent-loop-handlers.ts`)
+ * withholds text on the same shape of rule and flushes it at message end. It
+ * sits upstream of this session and is not reachable from here.
  */
-function createControlMarkerHoldback(
-  turn: ActiveAssistantTurn,
-  emit: (chunk: string) => void,
-): (raw: string, opts?: { force?: boolean }) => void {
+function createControlMarkerHoldback(emit: (chunk: string) => void): {
+  flush: (raw: string, opts?: { force?: boolean }) => void;
+  dropPendingTail: () => void;
+} {
   let emitted = 0;
-  return (raw, opts) => {
-    let safeEnd = raw.length;
-    if (opts?.force !== true) {
-      for (
-        let i = raw.indexOf("[", emitted);
-        i !== -1;
-        i = raw.indexOf("[", i + 1)
-      ) {
-        if (isIncompleteControlMarkerTail(raw.slice(i))) {
-          safeEnd = i;
-          break;
+  let seen = 0;
+  return {
+    flush: (raw, opts) => {
+      seen = raw.length;
+      let safeEnd = raw.length;
+      if (opts?.force !== true) {
+        for (
+          let i = raw.indexOf("[", emitted);
+          i !== -1;
+          i = raw.indexOf("[", i + 1)
+        ) {
+          if (isIncompleteControlMarkerTail(raw.slice(i))) {
+            safeEnd = i;
+            break;
+          }
         }
       }
-    }
-    if (safeEnd > emitted) {
-      emit(stripInternalSpeechMarkers(raw.slice(emitted, safeEnd)));
-      emitted = safeEnd;
-    }
+      if (safeEnd > emitted) {
+        emit(stripInternalSpeechMarkers(raw.slice(emitted, safeEnd)));
+        emitted = safeEnd;
+      }
+    },
+    dropPendingTail: () => {
+      emitted = seen;
+    },
   };
 }
 
@@ -903,6 +950,12 @@ const LIVE_VOICE_SETUP_FLOW_TEACHING =
 // closing report short. A one-time instruction, not a per-block protocol the
 // model must keep executing. It also directly bounds the report's onset
 // delay, since the hold ends when this block finishes generating.
+//
+// The ESCALATED leg only. Its first sentence describes the caller's state
+// ("you already told them you were on it, and they have heard nothing since"),
+// and that is true of exactly one kind of turn: the one where a front-door leg
+// spoke a hand-off bridge and then went quiet while this leg works. Any other
+// leg is told something false about a call it is only now joining.
 const LIVE_VOICE_SPOKEN_CLOSE_TEACHING =
   "You already told the caller you were on it, and they have heard nothing since. When you finish, close with one or two short sentences saying what you did or what you found: the result, not the route you took to it. If you need something from them to continue, ask for everything you need in one go. ";
 
@@ -963,23 +1016,27 @@ function buildLiveDeliveryNote(request: string, answer: string): string {
 }
 
 // Assemble a leg's model-facing control prompt: the base live-voice rules, the
-// screen-reveal, setup-flow, and spoken-close teaching (all withheld from the
-// front-door leg, see LIVE_VOICE_SCREEN_REVEAL_TEACHING), plus any pending
+// screen-reveal and setup-flow teaching (both withheld from the front-door
+// leg, see LIVE_VOICE_SCREEN_REVEAL_TEACHING), the spoken-close teaching (the
+// escalated leg only, see LIVE_VOICE_SPOKEN_CLOSE_TEACHING), plus any pending
 // barge-in merge context, completed-continuation context, and/or the
 // announcement instruction.
 // A turn can carry several (a barge-in follow-up that also has a continuation
 // result waiting); the notes are model-only and never render as user bubbles.
+//
+// The two gates are separate because they answer different questions: whether
+// the leg can put something on screen, and whether the caller has already been
+// told to wait. A leg can be neither front-door nor escalated.
 function buildVoiceControlPrompt(
   turn: ActiveAssistantTurn,
-  leg: { frontDoor?: boolean },
+  leg: { frontDoor?: boolean; escalated?: boolean },
 ): string {
   let prompt =
     LIVE_VOICE_CONTROL_PROMPT_BASE +
     (leg.frontDoor === true
       ? ""
-      : LIVE_VOICE_SCREEN_REVEAL_TEACHING +
-        LIVE_VOICE_SETUP_FLOW_TEACHING +
-        LIVE_VOICE_SPOKEN_CLOSE_TEACHING);
+      : LIVE_VOICE_SCREEN_REVEAL_TEACHING + LIVE_VOICE_SETUP_FLOW_TEACHING) +
+    (leg.escalated === true ? LIVE_VOICE_SPOKEN_CLOSE_TEACHING : "");
   if (turn.language !== undefined) {
     prompt = `${prompt}\n\nThe caller has been speaking the language with code "${turn.language}" this turn. Reply in that language unless they clearly switch to another.`;
   }
@@ -5002,7 +5059,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       this.bufferAssistantTextForTts(token, chunk);
     };
 
-    const flushLegText = createControlMarkerHoldback(activeTurn, emitLegText);
+    const legText = createControlMarkerHoldback(emitLegText);
 
     // Hand off once enough of the post-verdict stream has arrived to cap
     // the bridge (sentence terminator or hard cap). Until then nothing is
@@ -5058,6 +5115,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         },
         voiceControlPrompt: buildVoiceControlPrompt(activeTurn, {
           ...(leg.frontDoor !== undefined ? { frontDoor: leg.frontDoor } : {}),
+          escalated: leg.routingLeg === "escalated",
         }),
         onApprovalPending: (requestId) => {
           this.revealRoomForPendingApproval(activeTurn, requestId);
@@ -5144,7 +5202,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
                 }
                 frontDoorStage = "answer";
               }
-              flushLegText(rawText);
+              legText.flush(rawText);
               return;
             }
             // Defensive: speculative legs are always front-door today, but a
@@ -5160,7 +5218,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
               }
             }
             rawText += msg.text;
-            flushLegText(rawText);
+            legText.flush(rawText);
           },
           message_complete: (msg) => {
             const current = this.activeAssistantTurn;
@@ -5207,7 +5265,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
             // and completeTtsForTurn signals the drain, so it is spoken and
             // emitted rather than dropped.
             if (!leg.frontDoor && msg.type === "message_complete") {
-              flushLegText(rawText, { force: true });
+              legText.flush(rawText, { force: true });
               if (leg.routingLeg === "escalated") {
                 // Nothing followed this block, so it is the turn's report
                 // back: the answer, or the question it needs answered. Its
@@ -5215,10 +5273,36 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
                 // audio without a TTS round trip. Ordering is load-bearing:
                 // the force-flush above segments the block's tail first, and
                 // this runs before assistantCompleted closes the TTS path.
-                this.promoteHeldTtsSegments(
+                const promoted = this.promoteHeldTtsSegments(
                   token,
                   (job) => job.blockSeq === current.textBlockSeq,
                 );
+                // A turn can stop with a tool-use block still open (the
+                // tool-turn ceiling, a hook ending the turn): textBlockSeq
+                // then points past the last block the model wrote, that block
+                // was retracted as commentary, and there is no report to
+                // promote. The caller hears the hand-off bridge and then
+                // nothing, which is indistinguishable from a working turn
+                // until it ends. Say so in the log rather than leaving the
+                // silence unexplained. A block whose text is still short of a
+                // segment boundary is not this case: completeTtsForTurn's
+                // terminal flush speaks that tail. Neither is a session with
+                // no TTS wired at all, which speaks nothing by design.
+                if (
+                  this.streamTtsAudio &&
+                  promoted === 0 &&
+                  current.ttsBuffer.trim().length === 0
+                ) {
+                  log.warn(
+                    {
+                      turnId,
+                      textBlockSeq: current.textBlockSeq,
+                      heldJobs:
+                        current.ttsJobs.filter(isPendingHeldTtsJob).length,
+                    },
+                    "Live voice escalated turn completed with no report to speak",
+                  );
+                }
               }
             }
             current.assistantCompleted = true;
@@ -5274,6 +5358,11 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
               // of a segment boundary is still this block's commentary.
               { discardPendingTail: true },
             );
+            // The marker holdback's withheld tail is the rest of the block's
+            // text, and it sits outside ttsBuffer where discardPendingTail
+            // cannot reach it. Kept, it would be emitted under the next
+            // block's sequence and spoken glued onto the report.
+            legText.dropPendingTail();
             current.textBlockSeq += 1;
             log.debug(
               { turnId, toolName, dropped },
@@ -5512,12 +5601,19 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       // Enqueued while the turn is still on the front-door leg, so the bridge
       // is not held: it is the one thing the caller is meant to hear before
       // the escalated leg reports back, and only held segments can be
-      // retracted.
-      this.bufferAssistantTextForTts(activeTurn.token, `${spokenBridge} `);
+      // retracted. Stamped NON_BLOCK_TTS_SEQ for the same reason the canned
+      // fallback below is: the bridge belongs to no block of the escalated
+      // leg, and the default stamp would be that leg's first block, which the
+      // first tool call retracts.
+      this.bufferAssistantTextForTts(activeTurn.token, `${spokenBridge} `, {
+        blockSeq: NON_BLOCK_TTS_SEQ,
+      });
       // Force-flush now: on the TTS path an unpunctuated bridge would
       // otherwise sit buffered until a sentence boundary and leave the
       // caller in silence during the escalated model's call.
-      this.flushTtsBuffer(activeTurn.token, true);
+      this.flushTtsBuffer(activeTurn.token, true, {
+        blockSeq: NON_BLOCK_TTS_SEQ,
+      });
     } else {
       // The canned bridge is a fixed localized-table phrase, enqueued
       // directly (it is already one complete sentence) so the segment can
@@ -5854,6 +5950,11 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
   // The audio is rendered on first use: the output sample rate is fixed for
   // the session's life, so one render serves every cue it plays.
   private playWorkingCue(turn: ActiveAssistantTurn): void {
+    // Non-empty by construction: the schema floors durationMs at 1ms and the
+    // start frame's sample rate at MIN_START_FRAME_SAMPLE_RATE, so the render
+    // always rounds to at least one frame. Both bounds are checked where the
+    // value enters, which is the only place a zero-length cue could have been
+    // built from.
     const pcm = (this.workingCuePcm ??= renderWorkingCuePcm(
       this.context.startFrame.audio.sampleRate,
       {
@@ -5862,12 +5963,6 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         gain: this.workingCueConfig.gain,
       },
     ));
-    if (pcm.byteLength === 0) {
-      // A shape that rounds to no frames at this sample rate. Enqueuing it
-      // would send an empty frame and still take the floor for a full
-      // interval, which is worse than skipping the tick.
-      return;
-    }
     this.enqueueTtsAudioCue(turn.token, pcm);
     turn.progress.lastFloorHolderAtMs = Date.now();
   }
@@ -5978,6 +6073,12 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       // A filler exists to be heard while the turn works, so it is never held
       // and never retracted with the block it happens to land beside.
       blockSeq: NON_BLOCK_TTS_SEQ,
+      // Real speech, but not the answer: it plays into the dead air BEFORE
+      // the answer, so anchoring the first-TTS metrics on it would report the
+      // filler's timing as the turn's speech latency. This reaches more than
+      // progress narration (which is off by default): the approval-pending
+      // line speaks on any turn that hits a decision gate.
+      audioRole: "filler",
       ...(language !== undefined ? { language } : {}),
     });
     // A spoken filler holds the floor, so narration's minGapMs spaces from it.
@@ -6000,7 +6101,11 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       : undefined;
   }
 
-  private bufferAssistantTextForTts(token: symbol, text: string): void {
+  private bufferAssistantTextForTts(
+    token: symbol,
+    text: string,
+    options: { blockSeq?: number } = {},
+  ): void {
     if (!this.streamTtsAudio || text.length === 0) {
       return;
     }
@@ -6011,7 +6116,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     }
 
     activeTurn.ttsBuffer += activeTurn.ttsReasoningFilter.push(text);
-    this.flushTtsBuffer(token, false);
+    this.flushTtsBuffer(token, false, options);
   }
 
   /**
@@ -6040,7 +6145,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     // `ttsJobs` is in enqueue order, so chaining in filter order is what keeps
     // the promoted block internally ordered.
     const promoted = activeTurn.ttsJobs.filter(
-      (job) => job.held && !job.cancelled && select(job),
+      (job) => isPendingHeldTtsJob(job) && select(job),
     );
     for (const job of promoted) {
       job.held = false;
@@ -6079,9 +6184,23 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     if (activeTurn?.token !== token) {
       return 0;
     }
+    return this.retractHeldTtsSegmentsOnTurn(activeTurn, select, options);
+  }
 
+  /**
+   * Retract against a turn directly rather than against whichever turn is
+   * active. A terminal path can have cleared `activeAssistantTurn` already
+   * (barge-in does, before it finalizes), and a dying turn's held jobs still
+   * have to be torn down.
+   */
+  private retractHeldTtsSegmentsOnTurn(
+    activeTurn: ActiveAssistantTurn,
+    select: (job: TtsSegmentJob) => boolean,
+    options: { discardPendingTail?: boolean } = {},
+  ): number {
+    const { token } = activeTurn;
     const retracted = activeTurn.ttsJobs.filter(
-      (job) => job.held && !job.cancelled && !job.emitting && select(job),
+      (job) => isPendingHeldTtsJob(job) && !job.emitting && select(job),
     );
     for (const job of retracted) {
       job.cancelled = true;
@@ -6139,11 +6258,20 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     // still be occupied when the next turn starts. Retract rather than promote,
     // because unresolved held text is commentary far more often than it is an
     // answer, and speaking it is the failure this hold exists to prevent.
-    const strandedHeldJobs = this.retractHeldTtsSegments(
-      token,
-      (job) => job.held,
-    );
-    if (strandedHeldJobs > 0) {
+    //
+    // Only when there is something to sweep: the option below also discards
+    // the turn's pending tail, and on an ordinary turn that tail is the last
+    // sentence of the answer, waiting for the terminal flush.
+    if (activeTurn.ttsJobs.some(isPendingHeldTtsJob)) {
+      const strandedHeldJobs = this.retractHeldTtsSegments(
+        token,
+        (job) => job.held,
+        // The sweep takes whole blocks, so it owns their un-segmented tail as
+        // well. Left behind, the terminal flush below would synthesize the
+        // trailing fragment of the very commentary just dropped and speak it
+        // as the turn's closing words.
+        { discardPendingTail: true },
+      );
       log.warn(
         { turnId: activeTurn.turnId, strandedHeldJobs },
         "Live voice turn completed with held segments the caller never resolved",
@@ -6217,7 +6345,15 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       });
   }
 
-  private flushTtsBuffer(token: symbol, force: boolean): void {
+  // `blockSeq` overrides the block stamp every segment this flush forms
+  // carries. Only a fixed session phrase that happens to ride the segmenter
+  // passes it (the model-authored escalation bridge); model text leaves it
+  // undefined and takes the block the turn is accumulating.
+  private flushTtsBuffer(
+    token: symbol,
+    force: boolean,
+    options: { blockSeq?: number } = {},
+  ): void {
     const activeTurn = this.activeAssistantTurn;
     if (activeTurn?.token !== token) {
       return;
@@ -6250,6 +6386,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       // the block the turn ends on is ever spoken.
       this.enqueueTtsSegment(token, speakable, {
         held: activeTurn.routingLeg === "escalated",
+        ...(options.blockSeq !== undefined
+          ? { blockSeq: options.blockSeq }
+          : {}),
       });
     }
   }
@@ -6268,6 +6407,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       // the turn is accumulating; a fixed session phrase passes
       // NON_BLOCK_TTS_SEQ so no block-scoped selector can reach it.
       blockSeq?: number;
+      // What the segment is to the caller. Defaults to the turn's own answer;
+      // a spoken floor-holder passes "filler" so it does not anchor the
+      // first-TTS metrics (see TtsSegmentAudioRole).
+      audioRole?: TtsSegmentAudioRole;
     } = {},
   ): void {
     const activeTurn = this.activeAssistantTurn;
@@ -6290,7 +6433,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       text: segment,
       language: options.language,
       blockSeq: options.blockSeq ?? activeTurn.textBlockSeq,
-      nonSpeechCue: false,
+      audioRole: options.audioRole ?? "answer",
       started: false,
       settled: false,
       emitting: false,
@@ -6334,8 +6477,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       // The cue belongs to no model text block, so no block-scoped promotion
       // or retraction can reach it.
       blockSeq: NON_BLOCK_TTS_SEQ,
-      // Keeps the tone out of the turn's first-TTS metrics (see the field).
-      nonSpeechCue: true,
+      // Rendered tone rather than speech: out of the turn's first-TTS metrics
+      // and out of the archived assistant audio, and marked on the wire (see
+      // TtsSegmentAudioRole).
+      audioRole: "cue",
       started: true,
       settled: false,
       emitting: false,
@@ -6398,9 +6543,18 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       // audio a tool call is about to cancel. A held job stays open until it
       // is promoted, or until a retraction's abort tears its stream down, so
       // the cap is a standing one.
+      //
+      // A cancelled job does not hold that slot, however long its aborted
+      // stream stays open: it will never be promoted, so it is not the held
+      // prefetch this slot is reserved for. Counting it would let a provider
+      // that is slow to tear down block held prefetch for the rest of the
+      // turn, and the answer block would then pay the full TTS round trip
+      // this design exists to remove. Same reasoning as turnAudioIdle's.
       const heldSlotTaken = activeTurn.ttsJobs.some(
         (candidate) =>
-          candidate.held && candidate.started && !candidate.settled,
+          isPendingHeldTtsJob(candidate) &&
+          candidate.started &&
+          !candidate.settled,
       );
       const job = activeTurn.ttsJobs.find(
         (candidate) =>
@@ -6412,46 +6566,73 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       if (!job) {
         return;
       }
-      job.started = true;
-      // The segment's own language override (fixed English fallback text)
-      // wins over the turn's language.
-      const language = job.language ?? activeTurn.language;
-      let synthesis: Promise<void>;
-      try {
-        synthesis = streamTtsAudio({
-          text: job.text,
-          ...(language !== undefined ? { language } : {}),
-          // Either the turn ending or this one segment being retracted stops
-          // the stream; the job's own controller is what lets a retraction
-          // leave the turn's other segments streaming.
-          signal: AbortSignal.any([
-            activeTurn.abortController.signal,
-            job.abort.signal,
-          ]),
-          outputFormat: "pcm",
-          sampleRate: this.context.startFrame.audio.sampleRate,
-          onAudioChunk: (chunk) => {
-            // A retracted job keeps nothing: its buffer was already released
-            // and no promotion will ever flush it.
-            if (!this.isForwardingTts(token) || job.cancelled) {
-              return;
-            }
-            if (job.emitting) {
-              this.forwardTtsChunk(token, job, chunk);
-            } else {
-              job.bufferedChunks.push(chunk);
-            }
-          },
-        }).then(() => undefined);
-      } catch (err) {
-        synthesis = Promise.reject(err);
+      this.startTtsSynthesis(token, job);
+      if (!job.started) {
+        // The session went away underneath the pump; the loop condition
+        // cannot make progress, so stop rather than spin.
+        return;
       }
-      // The job's emission step observes the rejection; this handler only
-      // keeps a failure on an already-cancelled turn from surfacing as an
-      // unhandled rejection.
-      synthesis.catch(() => {});
-      job.synthesis = synthesis;
     }
+  }
+
+  /**
+   * Open one job's provider stream, outside the open-job cap. Callers that are
+   * subject to the cap go through {@link pumpTtsSynthesis}; this is for the
+   * job the emission chain is already waiting on, which must produce audio
+   * whatever the prefetch budget currently looks like.
+   */
+  private startTtsSynthesis(token: symbol, job: TtsSegmentJob): void {
+    const activeTurn = this.activeAssistantTurn;
+    const streamTtsAudio = this.streamTtsAudio;
+    if (
+      activeTurn?.token !== token ||
+      !streamTtsAudio ||
+      activeTurn.abortController.signal.aborted ||
+      this.isClosed ||
+      job.started ||
+      job.cancelled
+    ) {
+      return;
+    }
+    job.started = true;
+    // The segment's own language override (fixed English fallback text)
+    // wins over the turn's language.
+    const language = job.language ?? activeTurn.language;
+    let synthesis: Promise<void>;
+    try {
+      synthesis = streamTtsAudio({
+        text: job.text,
+        ...(language !== undefined ? { language } : {}),
+        // Either the turn ending or this one segment being retracted stops
+        // the stream; the job's own controller is what lets a retraction
+        // leave the turn's other segments streaming.
+        signal: AbortSignal.any([
+          activeTurn.abortController.signal,
+          job.abort.signal,
+        ]),
+        outputFormat: "pcm",
+        sampleRate: this.context.startFrame.audio.sampleRate,
+        onAudioChunk: (chunk) => {
+          // A retracted job keeps nothing: its buffer was already released
+          // and no promotion will ever flush it.
+          if (!this.isForwardingTts(token) || job.cancelled) {
+            return;
+          }
+          if (job.emitting) {
+            this.forwardTtsChunk(token, job, chunk);
+          } else {
+            job.bufferedChunks.push(chunk);
+          }
+        },
+      }).then(() => undefined);
+    } catch (err) {
+      synthesis = Promise.reject(err);
+    }
+    // The job's emission step observes the rejection; this handler only
+    // keeps a failure on an already-cancelled turn from surfacing as an
+    // unhandled rejection.
+    synthesis.catch(() => {});
+    job.synthesis = synthesis;
   }
 
   // Emission slot for one job, run in strict segment order on the turn's
@@ -6478,10 +6659,16 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
         return;
       }
 
-      // Both slots can be busy when a job is enqueued; every earlier job has
-      // settled once it reaches the head of the chain, so a slot is free.
+      // Both slots can be busy when a job is enqueued, so a job can arrive
+      // here unstarted. At the head of the chain it is the job that must
+      // produce audio now, and it starts outside the open-job cap rather than
+      // asking the cap for permission: the cap orders prefetch, and jobs that
+      // are NOT ahead of this one on the chain can be holding both slots (a
+      // retracted job whose aborted stream has not torn down, plus a cue). Ask
+      // the pump instead and it would start nothing, leaving `synthesis` null,
+      // and the segment would settle having emitted no audio at all.
       if (!job.started) {
-        this.pumpTtsSynthesis(token);
+        this.startTtsSynthesis(token, job);
       }
 
       // Promote synchronously: no provider callback can land between the
@@ -6543,21 +6730,34 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     if (activeTurn?.token !== token) {
       return;
     }
-    // Only retain the assistant TTS audio when it will be archived (see
-    // collectUserAudio); the mime/sample-rate are cheap and left unconditional.
-    if (this.archiveAudio) {
-      activeTurn.assistantAudioChunks.push(
-        Buffer.from(chunk.dataBase64, "base64"),
-      );
+    // The archive is a recording of what the assistant SAID, so the rendered
+    // cue stays out of it: its bare PCM would interleave with whatever
+    // container a provider returned for the speech around it (some return
+    // audio/wav despite outputFormat "pcm"), and the archived mime would
+    // describe whichever chunk landed last rather than the recording.
+    //
+    // Only retain the audio when it will be archived (see collectUserAudio);
+    // the mime/sample-rate are cheap and left unconditional.
+    if (job.audioRole !== "cue") {
+      if (this.archiveAudio) {
+        activeTurn.assistantAudioChunks.push(
+          Buffer.from(chunk.dataBase64, "base64"),
+        );
+      }
+      activeTurn.assistantAudioMimeType = chunk.contentType;
+      activeTurn.assistantAudioSampleRate = chunk.sampleRate;
     }
-    activeTurn.assistantAudioMimeType = chunk.contentType;
-    activeTurn.assistantAudioSampleRate = chunk.sampleRate;
     job.frames = job.frames.then(async () => {
       const sent = await this.sendFrame(
         {
           type: "tts_audio",
           mimeType: chunk.contentType,
           sampleRate: chunk.sampleRate,
+          // The client latches speaking state, hands-free barge-in
+          // eligibility, client-heard latency, and the spoken-word cursor on
+          // tts_audio frames. An unmarked tone corrupts all four, so say on
+          // the wire that this frame is not speech.
+          ...(job.audioRole === "cue" ? { nonSpeech: true } : {}),
           dataBase64: chunk.dataBase64,
         },
         () => this.isForwardingTts(token),
@@ -6568,6 +6768,18 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       // a stale turn's late send from latching a newer turn.
       if (!sent) {
         return;
+      }
+      // Counted here rather than at enqueue: a cue queued behind earlier
+      // speech can be discarded by cancellation or a closing session before
+      // it is ever written, and a metric whose whole purpose is telling a
+      // turn that hummed from one that sat silent must not count a cue the
+      // caller did not hear. A cue is a single pre-buffered chunk, so this
+      // runs once per cue.
+      if (job.audioRole === "cue") {
+        const cueTurn = this.activeAssistantTurn;
+        if (cueTurn?.token === token) {
+          this.markWorkingCuePlayed(cueTurn);
+        }
       }
       // Extend the client playback-tail estimate by this chunk's PCM
       // duration (chunks queue gaplessly client-side, so the tail grows
@@ -6583,13 +6795,23 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       this.appendEchoReference(chunk);
       this.assistantPlaybackTailUntilMs =
         Math.max(now, this.assistantPlaybackTailUntilMs) + chunkMs;
-      // Everything above is what a cue is here for: the client hears it, the
-      // canceller learns it was us, and the tail estimate covers it. The
-      // first-TTS latch is where a cue stops, because that mark is the onset
-      // of the turn's speech (see `nonSpeechCue`).
+      // Everything above is what a cue or a spoken filler is here for: the
+      // client hears it, the canceller learns it was us, and the tail estimate
+      // covers it. The first-TTS latch is where both stop.
+      //
+      // What that mark means is narrower than "the answer began" and worth
+      // stating exactly, because this codebase has anchored a voice latency
+      // metric on the wrong event before. It is the first audio the caller
+      // hears that the model authored for this turn. A cue is not authored at
+      // all and a fixed filler phrase is not authored for this turn, so
+      // neither latches. The escalation bridge IS model-authored and does
+      // latch, so on an escalated turn this measures hand-off onset rather
+      // than report onset. That is deliberate for now: it is the behavior
+      // that predates the held-speech work, and changing it would silently
+      // move an existing metric by the length of a whole working phase.
       const turnAfterSend = this.activeAssistantTurn;
       if (
-        job.nonSpeechCue ||
+        job.audioRole !== "answer" ||
         turnAfterSend?.token !== token ||
         turnAfterSend.ttsAudioStarted
       ) {
@@ -6764,6 +6986,14 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     this.metrics.markProgressSpoken(activeTurn.turnId);
   }
 
+  private markWorkingCuePlayed(activeTurn: ActiveAssistantTurn): void {
+    const { utterance } = activeTurn;
+    if (!this.startMetricsTurnIfNeeded(utterance, activeTurn.turnId)) {
+      return;
+    }
+    this.metrics.markWorkingCuePlayed(activeTurn.turnId);
+  }
+
   private ensureTurnId(utterance: UtteranceCycle): string {
     if (!utterance.turnId) {
       utterance.turnId = this.createTurnId();
@@ -6850,6 +7080,18 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
 
     turn.finalized = true;
     this.clearFillerTimers(turn);
+    // Every terminal path owns the turn's held prefetch, not just the two that
+    // remembered to. A held job is off ttsQueue, so completion never awaits
+    // it and nothing else settles it: without a retraction here an errored or
+    // cancelled turn leaves its provider stream open and un-abortable, billing
+    // for audio nobody will hear. The paths that already retracted
+    // (generation_cancelled) or aborted the turn controller (barge-in) find
+    // their jobs cancelled and select nothing.
+    if (status === "cancelled") {
+      this.retractHeldTtsSegmentsOnTurn(turn, (job) => job.held, {
+        discardPendingTail: true,
+      });
+    }
     turn.utterance.completed = true;
     await this.archiveBufferedAudio({
       turnId: turn.turnId,

--- a/assistant/src/live-voice/protocol.ts
+++ b/assistant/src/live-voice/protocol.ts
@@ -8,6 +8,15 @@ import { type ClientOs, parseClientOs } from "../channels/types.js";
 // rejects only values that were never going to be real capture rates.
 const MAX_START_FRAME_SAMPLE_RATE = 192_000;
 
+// Lower bound on the same field. 8 kHz is narrowband telephony, below any
+// capture rate a supported client opens with, and it is the floor that makes
+// every rendered buffer non-degenerate: the working cue's shortest legal
+// duration (1ms) still rounds to whole frames at this rate, so a rendered
+// tone can never come out empty. Without a floor a rate of 1 validates and
+// rounds a cue to zero frames, which is a silent frame on the wire holding the
+// floor for a whole interval.
+const MIN_START_FRAME_SAMPLE_RATE = 8_000;
+
 const LIVE_VOICE_CLIENT_FRAME_TYPES = [
   "start",
   "audio",
@@ -417,6 +426,16 @@ export interface LiveVoiceTtsAudioServerFrame extends LiveVoiceServerFrameBase {
   readonly type: "tts_audio";
   readonly mimeType: string;
   readonly sampleRate: number;
+  /**
+   * Set only on audio that is not speech: today the rendered working cue that
+   * holds the floor while a turn works. Omitted for synthesized speech.
+   *
+   * Clients drive speaking state, hands-free barge-in eligibility,
+   * client-heard latency, and the spoken-word cursor off tts_audio frames.
+   * All four are about what the assistant SAID, so a frame carrying this must
+   * play as audio and count as nothing else.
+   */
+  readonly nonSpeech?: true;
   readonly dataBase64: string;
 }
 
@@ -495,6 +514,13 @@ export interface LiveVoiceMetricsServerFrame extends LiveVoiceServerFrameBase {
    * unchanged).
    */
   readonly progressUpdatesSpoken?: number;
+  /**
+   * Working cues played into the turn's silence. Present only when at least
+   * one played (otherwise the field is absent, keeping frames unchanged).
+   * The cue is the default floor-holder, so this is what separates a turn
+   * that hummed while it worked from one that sat silent.
+   */
+  readonly workingCuesPlayed?: number;
 }
 
 export interface LiveVoiceArchivedServerFrame extends LiveVoiceServerFrameBase {
@@ -1033,11 +1059,12 @@ function validateAudioConfig(
 
   if (
     !isPositiveInteger(value.sampleRate) ||
+    value.sampleRate < MIN_START_FRAME_SAMPLE_RATE ||
     value.sampleRate > MAX_START_FRAME_SAMPLE_RATE
   ) {
     return protocolError(
       "invalid_field",
-      `start frame audio.sampleRate must be a positive integer no greater than ${MAX_START_FRAME_SAMPLE_RATE}`,
+      `start frame audio.sampleRate must be an integer between ${MIN_START_FRAME_SAMPLE_RATE} and ${MAX_START_FRAME_SAMPLE_RATE}`,
       "audio.sampleRate",
       "start",
     );

--- a/assistant/src/live-voice/protocol.ts
+++ b/assistant/src/live-voice/protocol.ts
@@ -1,5 +1,13 @@
 import { type ClientOs, parseClientOs } from "../channels/types.js";
 
+// Upper bound on a client-declared capture rate. The session hands this number
+// straight to buffer sizing (it is the rate every synthesized segment and the
+// rendered working cue are produced at), so an absurd value becomes an absurd
+// allocation inside a timer callback rather than a rejected frame. 192 kHz is
+// double the highest rate any supported client actually opens with, so the cap
+// rejects only values that were never going to be real capture rates.
+const MAX_START_FRAME_SAMPLE_RATE = 192_000;
+
 const LIVE_VOICE_CLIENT_FRAME_TYPES = [
   "start",
   "audio",
@@ -1023,10 +1031,13 @@ function validateAudioConfig(
     );
   }
 
-  if (!isPositiveInteger(value.sampleRate)) {
+  if (
+    !isPositiveInteger(value.sampleRate) ||
+    value.sampleRate > MAX_START_FRAME_SAMPLE_RATE
+  ) {
     return protocolError(
       "invalid_field",
-      "start frame audio.sampleRate must be a positive integer",
+      `start frame audio.sampleRate must be a positive integer no greater than ${MAX_START_FRAME_SAMPLE_RATE}`,
       "audio.sampleRate",
       "start",
     );

--- a/assistant/src/live-voice/protocol.ts
+++ b/assistant/src/live-voice/protocol.ts
@@ -136,6 +136,25 @@ export interface LiveVoiceClientStartFrame {
    */
   readonly textInput?: boolean;
   /**
+   * The client understands `nonSpeech` on {@link LiveVoiceTtsAudioServerFrame}
+   * and will play such a frame as audio without counting it as the assistant
+   * talking.
+   *
+   * Load-bearing, not a feature announcement: it is what lets the server send
+   * the working cue at all. A client that predates the field runs its old
+   * `tts_audio` handler on the wordless tone and treats it as answer speech,
+   * latching speaking state, client-heard latency and the spoken-word cursor
+   * on a turn that has deliberately said nothing. An optional field cannot
+   * protect a consumer that never learned to read it, so the capability is
+   * declared here instead and the cue waits for it.
+   *
+   * Absent means false, which is the only thing an older client can have
+   * meant: it has no handler that could tell the tone from speech, so such a
+   * session holds its working silence with nothing rather than with audio
+   * that would be misread.
+   */
+  readonly nonSpeechAudio?: boolean;
+  /**
    * Which client opened the session. Absent from clients that predate the
    * field, in which case the originating client is simply unknown.
    *
@@ -963,6 +982,15 @@ function validateStartFrame(
     );
   }
 
+  if ("nonSpeechAudio" in value && typeof value.nonSpeechAudio !== "boolean") {
+    return protocolError(
+      "invalid_field",
+      "start frame field nonSpeechAudio must be a boolean",
+      "nonSpeechAudio",
+      "start",
+    );
+  }
+
   // An unrecognized client is dropped rather than rejected: the field is an
   // analytics dimension, and failing a session's startup over it would trade a
   // gap in a chart for a user who cannot talk to their assistant.
@@ -987,6 +1015,7 @@ function validateStartFrame(
         ? { bargeInMinSpeechMs: value.bargeInMinSpeechMs }
         : {}),
       ...(value.textInput === true ? { textInput: true } : {}),
+      ...(value.nonSpeechAudio === true ? { nonSpeechAudio: true } : {}),
     },
   };
 }

--- a/assistant/src/live-voice/working-cue.ts
+++ b/assistant/src/live-voice/working-cue.ts
@@ -1,0 +1,126 @@
+/**
+ * The working cue: a short, wordless tone that holds the floor while the
+ * assistant is busy on a tool-heavy turn.
+ *
+ * Words are the wrong instrument for that job. A spoken progress line makes a
+ * claim ("still working on it") that has to be true, has to be translated, and
+ * has to be re-said every few seconds before it starts sounding anxious. A
+ * tone claims nothing, needs no language, and reads as "the line is still
+ * open" the way a hold tone does on a phone call.
+ */
+
+/** The tunable dimensions of the cue. Every field is meant to be tried by ear. */
+export interface WorkingCueShape {
+  /** Fundamental in Hz. Low reads as a hum, high as a chime. */
+  frequencyHz: number;
+  /** Total length including fade in and out. */
+  durationMs: number;
+  /** Peak amplitude, 0..1. Well below speech so it sits under the call. */
+  gain: number;
+}
+
+/**
+ * Starting point for the cue, chosen to sound like a soft hum under the call
+ * rather than a notification demanding attention: low enough to sit beneath a
+ * speaking voice, short enough to read as punctuation, quiet enough that a
+ * listener notices the room is still occupied without listening *to* it.
+ *
+ * Every number here is a first guess, not a result. All three become config
+ * values, so treat them as defaults to override rather than as constants that
+ * carry meaning.
+ */
+export const DEFAULT_WORKING_CUE_SHAPE: WorkingCueShape = {
+  frequencyHz: 220,
+  durationMs: 260,
+  gain: 0.09,
+};
+
+/**
+ * Portion of the buffer given to the attack, and the same again to the
+ * release. A fifteenth-ish of a quarter-second is a few tens of milliseconds:
+ * long enough to remove the click (see below), short enough that the cue still
+ * has an audible body between the two ramps.
+ */
+const FADE_FRACTION = 0.15;
+
+/**
+ * Full-scale for signed 16-bit samples. 32767 rather than 32768 so a peak of
+ * exactly `gain` cannot round to -32768, which has no positive counterpart.
+ */
+const INT16_PEAK = 32767;
+
+/**
+ * Render the cue as mono signed 16-bit little-endian PCM at `sampleRate`.
+ *
+ * Rendered rather than shipped as an asset: the session's sample rate is
+ * whatever the client asked for on the start frame, so an asset would need
+ * resampling, and every parameter here is a number worth tuning by ear.
+ *
+ * Raw samples only, with no WAV or other container header. The bytes ride the
+ * same `tts_audio` frame path as synthesized speech, and the session's echo
+ * canceller feeds its reference from that path by treating the payload as
+ * bare `audio/pcm` at the session rate. A header would be interpreted as
+ * leading samples: audible as a tick, and worse, wrong in the echo reference.
+ */
+export function renderWorkingCuePcm(
+  sampleRate: number,
+  shape: WorkingCueShape,
+): Buffer {
+  const frameCount = Math.max(
+    0,
+    Math.round((sampleRate * shape.durationMs) / 1_000),
+  );
+  const pcm = Buffer.alloc(frameCount * 2);
+
+  // Both ramps have to fit, so a cue too short for the nominal fraction
+  // degrades to all attack and release rather than letting the two envelopes
+  // overlap. At least one fade frame whenever there is room for one: dropping
+  // the ramp on a very short cue would reintroduce exactly the click the
+  // envelope exists to remove.
+  const fadeFrames = Math.min(
+    Math.max(1, Math.floor(frameCount * FADE_FRACTION)),
+    Math.floor(frameCount / 2),
+  );
+  const radiansPerFrame = (2 * Math.PI * shape.frequencyHz) / sampleRate;
+  // Gain is clamped here rather than per sample: it arrives from config, and a
+  // value outside 0..1 would otherwise make `writeInt16LE` throw partway
+  // through the render on the first sample that overflows.
+  const peak = Math.min(1, Math.max(0, shape.gain)) * INT16_PEAK;
+
+  for (let frame = 0; frame < frameCount; frame++) {
+    const sample =
+      envelopeAt(frame, frameCount, fadeFrames) *
+      peak *
+      Math.sin(radiansPerFrame * frame);
+    pcm.writeInt16LE(Math.round(sample), frame * 2);
+  }
+
+  return pcm;
+}
+
+/**
+ * Raised-cosine attack and release, 0 at both edges and 1 across the sustain.
+ *
+ * This is required, not cosmetic. A sine that begins or ends at a nonzero
+ * amplitude is a step discontinuity, and a step is broadband: the listener
+ * hears a click. A click does not read as a cue that the assistant is working,
+ * it reads as a glitch in the call, which is the opposite of the reassurance
+ * the tone exists to give. The raised cosine is chosen over a linear ramp
+ * because its slope is also zero at the edges, so neither the amplitude nor
+ * its first derivative jumps.
+ */
+function envelopeAt(
+  frame: number,
+  frameCount: number,
+  fadeFrames: number,
+): number {
+  if (fadeFrames <= 0) {
+    return 1;
+  }
+  // Distance from whichever edge is nearer, so the release mirrors the attack.
+  const framesFromEdge = Math.min(frame, frameCount - 1 - frame);
+  if (framesFromEdge >= fadeFrames) {
+    return 1;
+  }
+  return 0.5 * (1 - Math.cos((Math.PI * framesFromEdge) / fadeFrames));
+}

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-client.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-client.test.ts
@@ -201,6 +201,7 @@ describe("connect", () => {
         type: "start",
         client: "web",
         textInput: true,
+        nonSpeechAudio: true,
         audio: { mimeType: "audio/pcm", sampleRate: 16000, channels: 1 },
         conversationId: "conv-xyz",
       },
@@ -215,6 +216,7 @@ describe("connect", () => {
       type: "start",
       client: "web",
       textInput: true,
+      nonSpeechAudio: true,
       audio: { mimeType: "audio/pcm", sampleRate: 16000, channels: 1 },
     });
   });
@@ -253,6 +255,7 @@ describe("connect", () => {
         type: "start",
         client: "web",
         textInput: true,
+        nonSpeechAudio: true,
         audio: { mimeType: "audio/pcm", sampleRate: 16000, channels: 1 },
         turnDetection: "server_vad",
       },
@@ -272,6 +275,7 @@ describe("connect", () => {
         type: "start",
         client: "web",
         textInput: true,
+        nonSpeechAudio: true,
         audio: { mimeType: "audio/pcm", sampleRate: 16000, channels: 1 },
         turnDetection: "server_vad",
         silenceThresholdMs: 1500,
@@ -772,6 +776,7 @@ describe("sendAudio", () => {
         type: "start",
         client: "web",
         textInput: true,
+        nonSpeechAudio: true,
         audio: { mimeType: "audio/pcm", sampleRate: 16000, channels: 1 },
       },
     ]);
@@ -833,6 +838,7 @@ describe("control frames", () => {
         type: "start",
         client: "web",
         textInput: true,
+        nonSpeechAudio: true,
         audio: { mimeType: "audio/pcm", sampleRate: 16000, channels: 1 },
       },
     ]);

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-client.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-client.ts
@@ -503,6 +503,11 @@ export class LiveVoiceChannelClient {
       // session outright with `credentials_unavailable`, which is precisely
       // the outcome the text-only path exists to avoid.
       textInput: true,
+      // Unconditional for the same reason: the `nonSpeech` handling lives in
+      // this file's `ttsAudio` path and in the player, so any build that can
+      // send this frame can also read the flag. It is the daemon's gate for
+      // the working cue, which stays silent for a client that cannot say this.
+      nonSpeechAudio: true,
       ...(this.conversationId ? { conversationId: this.conversationId } : {}),
       ...(this.turnDetection ? { turnDetection: this.turnDetection } : {}),
       ...(this.silenceThresholdMs !== undefined

--- a/clients/web/src/domains/chat/voice/live-voice/protocol.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/protocol.ts
@@ -107,6 +107,16 @@ export interface LiveVoiceClientStartFrame {
    * back on `ready` as `audioInput: false`.
    */
   readonly textInput?: boolean;
+  /**
+   * This client reads `nonSpeech` on `tts_audio` and plays such a frame as
+   * audio without counting it as the assistant talking.
+   *
+   * The daemon holds the working cue back until it sees this, because a client
+   * that predates the flag would treat the wordless tone as answer speech and
+   * latch speaking state, client-heard latency and the spoken-word cursor on a
+   * turn that has said nothing. Declaring it is what turns the cue on.
+   */
+  readonly nonSpeechAudio?: boolean;
 }
 
 export interface LiveVoiceClientPttReleaseFrame {

--- a/clients/web/src/domains/chat/voice/live-voice/protocol.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/protocol.ts
@@ -337,6 +337,19 @@ export interface LiveVoiceTtsAudioServerFrame extends LiveVoiceServerFrameBase {
   readonly mimeType: string;
   readonly sampleRate: number;
   readonly dataBase64: string;
+  /**
+   * Rendered non-speech audio rather than a synthesized utterance: the working
+   * cue, a short wordless tone the daemon plays into the silence of a long
+   * tool-heavy turn. It travels on this frame so it inherits the speech path's
+   * echo cancellation and ordering.
+   *
+   * Omitted entirely for speech, so an absent field means speech (including on
+   * daemons predating the marker). It is audio in every respect that reaches
+   * the speaker, and nothing beyond that: a marked frame must not be read as
+   * the assistant talking, which is what the phase, the barge-in gate, the
+   * client-heard latency, and the spoken-word cursor all measure.
+   */
+  readonly nonSpeech?: true;
 }
 
 export interface LiveVoiceTtsDoneServerFrame extends LiveVoiceServerFrameBase {
@@ -421,6 +434,13 @@ export interface LiveVoiceMetricsServerFrame extends LiveVoiceServerFrameBase {
    * unchanged).
    */
   readonly progressUpdatesSpoken?: number;
+  /**
+   * Working cues played into the turn's silence. Present only when at least
+   * one played (otherwise the field is absent, keeping frames unchanged).
+   * The cue is the default floor-holder, so this is what separates a turn
+   * that hummed while it worked from one that sat silent.
+   */
+  readonly workingCuesPlayed?: number;
 }
 
 export interface LiveVoiceArchivedServerFrame extends LiveVoiceServerFrameBase {

--- a/clients/web/src/domains/chat/voice/live-voice/tts-playback.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/tts-playback.test.ts
@@ -928,6 +928,46 @@ describe("LiveVoiceAudioPlayer", () => {
       expect(player.getPlaybackProgress()).toBeNull();
     });
 
+    test("a non-speech chunk plays but reports no progress", () => {
+      player.enqueue({ ...chunk(new Array(24000).fill(1)), nonSpeech: true });
+
+      // It is scheduled and audible, and it holds the queue open.
+      expect(ctx.sources).toHaveLength(1);
+      expect(ctx.sources[0]!.startedAt).toBe(0);
+      expect(player.isPlaying).toBe(true);
+      // It carries no words, so there is nothing for a cursor to follow.
+      expect(player.getPlaybackProgress()).toBeNull();
+    });
+
+    test("a cue ahead of speech never inflates total or played", () => {
+      // 1.0s cue at t=0, then the report's first second of speech behind it.
+      player.enqueue({ ...chunk(new Array(24000).fill(1)), nonSpeech: true });
+      player.enqueue(chunk(new Array(24000).fill(1)));
+
+      // Only the speech counts, and none of it has sounded while the cue plays.
+      expect(player.getPlaybackProgress()).toEqual({
+        playedSeconds: 0,
+        totalSeconds: 1,
+      });
+
+      ctx.currentTime = 1;
+      expect(player.getPlaybackProgress()).toEqual({
+        playedSeconds: 0,
+        totalSeconds: 1,
+      });
+
+      ctx.currentTime = 1.5;
+      expect(player.getPlaybackProgress()!.playedSeconds).toBeCloseTo(0.5, 6);
+    });
+
+    test("container path: a non-speech decode contributes nothing to total", async () => {
+      player.enqueue({ ...frame("audio/wav"), nonSpeech: true });
+      await flushMicrotasks();
+
+      expect(ctx.sources).toHaveLength(1);
+      expect(player.getPlaybackProgress()).toBeNull();
+    });
+
     test("container path: a resolved async decode contributes its duration to total", async () => {
       player.enqueue(frame("audio/wav"));
       // Not scheduled yet: no progress until the decode resolves.

--- a/clients/web/src/domains/chat/voice/live-voice/tts-playback.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/tts-playback.ts
@@ -56,17 +56,28 @@ export interface TtsAudioChunk {
   sampleRate: number;
   /** MIME type of the audio payload (e.g. "audio/pcm", "audio/wav"). */
   mimeType: string;
+  /**
+   * Rendered non-speech audio (the working cue) rather than a synthesized
+   * utterance. It plays like any other chunk and holds the queue open, but
+   * carries no words, so it is left out of the playback progress that drives
+   * the spoken-word cursor. Absent means speech.
+   */
+  nonSpeech?: boolean;
 }
 
 /**
  * Playback progress of the current response's TTS audio.
  *
- * `totalSeconds` is the cumulative duration of every buffer scheduled since the
- * last reset (new response / stop); `playedSeconds` is how much of it has
- * actually sounded, derived from the audio playhead. During a mid-turn silence
- * (queue drained, more speech coming) `playedSeconds === totalSeconds`, so a
- * consumer's cursor holds at the last spoken word rather than resetting — the
- * next audio burst grows `totalSeconds` and the cursor advances again.
+ * `totalSeconds` is the cumulative duration of every speech buffer scheduled
+ * since the last reset (new response / stop); `playedSeconds` is how much of
+ * it has actually sounded, derived from the audio playhead. Non-speech chunks
+ * ({@link TtsAudioChunk.nonSpeech}) play but enter neither number, so a cue
+ * holding a silent turn's floor never advances a word cursor.
+ *
+ * During a mid-turn silence (queue drained, more speech coming)
+ * `playedSeconds === totalSeconds`, so a consumer's cursor holds at the last
+ * spoken word rather than resetting: the next audio burst grows `totalSeconds`
+ * and the cursor advances again.
  */
 export interface LiveVoicePlaybackProgress {
   /** Seconds of scheduled audio already played, in [0, totalSeconds]. */
@@ -316,8 +327,8 @@ export class LiveVoiceAudioPlayer {
   private playingState = false;
 
   /**
-   * Cumulative duration (seconds) of every buffer scheduled since the last
-   * progress reset. Backs {@link getPlaybackProgress}.
+   * Cumulative duration (seconds) of every speech buffer scheduled since the
+   * last progress reset. Backs {@link getPlaybackProgress}.
    *
    * Deliberately NOT reset in {@link settleIfIdle}: a drain mid-turn (ack →
    * tool run → more speech) zeroes only the playhead, so progress reports
@@ -451,7 +462,7 @@ export class LiveVoiceAudioPlayer {
     const buffer = context.createBuffer(1, samples.length, chunk.sampleRate);
     buffer.getChannelData(0).set(samples);
 
-    this.scheduleBuffer(context, buffer);
+    this.scheduleBuffer(context, buffer, chunk.nonSpeech === true);
   }
 
   /**
@@ -474,6 +485,7 @@ export class LiveVoiceAudioPlayer {
   private enqueueContainer(chunk: TtsAudioChunk, mimeType: string): void {
     const context = this.ensureContext();
     const arrayBuffer = base64ToArrayBuffer(chunk.dataBase64);
+    const nonSpeech = chunk.nonSpeech === true;
     const generation = this.generation;
     this.pendingContainerDecodes += 1;
 
@@ -499,7 +511,7 @@ export class LiveVoiceAudioPlayer {
         ) {
           return;
         }
-        this.scheduleBuffer(context, buffer);
+        this.scheduleBuffer(context, buffer, nonSpeech);
       } finally {
         // A stop() between start and resolution already zeroed the counter (and
         // resolved drain); skip the accounting so we don't go negative.
@@ -513,8 +525,18 @@ export class LiveVoiceAudioPlayer {
     });
   }
 
-  /** Connect a decoded buffer to the destination and start it gaplessly. */
-  private scheduleBuffer(context: AudioContextLike, buffer: AudioBuffer): void {
+  /**
+   * Connect a decoded buffer to the destination and start it gaplessly.
+   *
+   * A non-speech buffer takes its place on the timeline like any other, so
+   * ordering and the echo reference are unchanged; it just contributes no
+   * duration to the progress a word cursor reads.
+   */
+  private scheduleBuffer(
+    context: AudioContextLike,
+    buffer: AudioBuffer,
+    nonSpeech: boolean,
+  ): void {
     const source = context.createBufferSource();
     source.buffer = buffer;
 
@@ -533,7 +555,9 @@ export class LiveVoiceAudioPlayer {
     const startAt = Math.max(this.playheadTime, context.currentTime);
     source.start(startAt);
     this.playheadTime = startAt + buffer.duration;
-    this.totalScheduledSeconds += buffer.duration;
+    if (!nonSpeech) {
+      this.totalScheduledSeconds += buffer.duration;
+    }
 
     this.activeSources.add(source);
     source.onended = () => {
@@ -920,6 +944,12 @@ export class LiveVoiceAudioPlayer {
    * scheduled timeline, so silent gaps between bursts never inflate played
    * time, and after a drain (`playheadTime` zeroed) progress reports
    * `played == total`. Side-effect-free: reading never advances state.
+   *
+   * Non-speech audio still sits on that timeline, so while a cue is playing
+   * ahead of queued speech the tail it occupies reads as unplayed speech and
+   * `playedSeconds` floors at 0 rather than going negative. That understates
+   * played time by at most the cue's own length, and only until the cue
+   * finishes; a consumer's cursor is monotonic, so it holds rather than moves.
    */
   getPlaybackProgress(): LiveVoicePlaybackProgress | null {
     if (this.context === null || this.totalScheduledSeconds === 0) {

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
@@ -354,6 +354,121 @@ describe("assistant-audio activity", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Working cue: a `tts_audio` frame marked `nonSpeech`
+// ---------------------------------------------------------------------------
+
+describe("working cue (non-speech tts_audio)", () => {
+  function emitCue(h: ReturnType<typeof renderController>, seq: number) {
+    h.client.emit("ttsAudio", {
+      type: "tts_audio",
+      seq,
+      mimeType: "audio/pcm",
+      sampleRate: 24000,
+      dataBase64: "AAAA",
+      nonSpeech: true,
+    });
+  }
+
+  function emitSpeech(h: ReturnType<typeof renderController>, seq: number) {
+    h.client.emit("ttsAudio", {
+      type: "tts_audio",
+      seq,
+      mimeType: "audio/pcm",
+      sampleRate: 24000,
+      dataBase64: "AAAA",
+    });
+  }
+
+  test("plays without flipping the room to `speaking`", async () => {
+    const h = renderController();
+    await startListening(h, { handsFree: true });
+
+    act(() => {
+      h.client.emit("thinking", { type: "thinking", seq: 2, turnId: "t1" });
+      emitCue(h, 3);
+      emitCue(h, 4);
+    });
+
+    // Audible: both cues reach the player, marked so the player leaves them
+    // out of the progress the word cursor reads.
+    expect(h.player.enqueued).toHaveLength(2);
+    expect(h.player.enqueued[0]).toMatchObject({ nonSpeech: true });
+    // Inert: the working turn stays quiet rather than blinking through
+    // `speaking` once per cue.
+    expect(h.view.result.current.state).toBe("thinking");
+    expect(useLiveVoiceStore.getState().assistantAudioActive).toBe(false);
+
+    // The report that follows is speech and does flip the room.
+    act(() => {
+      emitSpeech(h, 5);
+    });
+    expect(h.view.result.current.state).toBe("speaking");
+    expect(useLiveVoiceStore.getState().assistantAudioActive).toBe(true);
+    expect(h.player.enqueued[2]).toMatchObject({ nonSpeech: undefined });
+  });
+
+  test("does not open hands-free barge-in during the silent working stretch", async () => {
+    const h = renderController();
+    await startListening(h, { handsFree: true });
+
+    act(() => {
+      h.client.emit("thinking", { type: "thinking", seq: 2, turnId: "t1" });
+      emitCue(h, 3);
+    });
+
+    // "Stop response" while the turn is still working: there is no response to
+    // stop, so the turn is left running rather than cancelled by the tone.
+    act(() => {
+      useLiveVoiceStore.getState().controls?.interrupt();
+    });
+    expect(h.client.interruptCount).toBe(0);
+    expect(h.player.stopCount).toBe(0);
+    expect(h.view.result.current.state).toBe("thinking");
+
+    // Once the answer is actually being spoken, the same control cancels it.
+    act(() => {
+      emitSpeech(h, 4);
+    });
+    act(() => {
+      useLiveVoiceStore.getState().controls?.interrupt();
+    });
+    expect(h.client.interruptCount).toBe(1);
+    expect(h.view.result.current.state).toBe("listening");
+  });
+
+  test("does not latch the client-heard latency", async () => {
+    const h = renderController();
+    await startListening(h, { handsFree: true });
+
+    act(() => {
+      h.client.emit("utteranceEnd", {
+        type: "utterance_end",
+        seq: 2,
+        reason: "silence",
+      });
+    });
+    await act(async () => {
+      await sleep(10);
+    });
+    act(() => {
+      h.client.emit("thinking", { type: "thinking", seq: 3, turnId: "t1" });
+      emitCue(h, 4);
+    });
+
+    // The tone is not the answer starting to be spoken, so the end-of-speech
+    // stamp is still unspent.
+    expect(useLiveVoiceStore.getState().lastTurnLatency).toBeNull();
+
+    act(() => {
+      emitSpeech(h, 5);
+    });
+    const latency = useLiveVoiceStore.getState().lastTurnLatency;
+    expect(latency).not.toBeNull();
+    expect(latency!.clientHeardLatencyMs).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Barge-in
 // ---------------------------------------------------------------------------
 

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -1049,18 +1049,33 @@ export function useLiveVoice(
           if (session.interruptSent) {
             return;
           }
-          beginAssistantAudioIfNeeded(session);
+          // The working cue is audio, not speech. It plays, which is the whole
+          // reason the daemon sends it on this frame at all, but a wordless
+          // tone holding a silent turn's floor is not the assistant talking.
+          // So everything downstream that means "talking" stays where it was:
+          // the phase (a cue every ~12s would otherwise blink the room in and
+          // out of `speaking` for the whole working stretch), the hands-free
+          // barge-in gate that reads that phase, the client-heard latency
+          // (which measures when the answer starts being spoken), and the
+          // spoken-word cursor's played/total accounting.
+          const isSpeech = frame.nonSpeech !== true;
+          if (isSpeech) {
+            beginAssistantAudioIfNeeded(session);
+          }
           const chunk: TtsAudioChunk = {
             dataBase64: frame.dataBase64,
             sampleRate: frame.sampleRate,
             mimeType: frame.mimeType,
+            nonSpeech: frame.nonSpeech,
           };
           session.player.enqueue(chunk);
-          // Mark audio flowing before the phase flip so no render observes
-          // `speaking` without `assistantAudioActive` (which would blink the
-          // avatar to `thinking` at the top of every response — JARVIS-1279).
-          markAssistantAudioActive(session);
-          useLiveVoiceStore.getState().setState("speaking");
+          if (isSpeech) {
+            // Mark audio flowing before the phase flip so no render observes
+            // `speaking` without `assistantAudioActive` (which would blink the
+            // avatar to `thinking` at the top of every response — JARVIS-1279).
+            markAssistantAudioActive(session);
+            useLiveVoiceStore.getState().setState("speaking");
+          }
         }),
         client.on("ttsDone", () => {
           if (!live()) {
@@ -1681,6 +1696,10 @@ function interruptIfSpeaking(
  * Unlike the manual barge-in above this does not require `player.isPlaying`:
  * `speaking` can hold between chunks with more audio still inbound, and the
  * cancel must land regardless.
+ *
+ * The `speaking` gate is also what keeps a long working stretch quiet: a
+ * working cue plays without entering `speaking`, so the tone does not make a
+ * turn interruptible during the silence it exists to hold.
  */
 function interruptTurnHandsFree(session: SessionContext): void {
   if (useLiveVoiceStore.getState().state !== "speaking") {
@@ -1736,10 +1755,12 @@ const ASSISTANT_AUDIO_IDLE_MS = 500;
 
 /**
  * Mark assistant TTS audio as flowing and (re)arm the idle check. Called on
- * every `tts_audio` frame: a continuous stream keeps re-arming the timer so the
- * flag stays true for the whole spoken stretch; once frames stop and the queue
- * drains, {@link scheduleAssistantAudioIdleCheck} flips it false. Drives the
- * avatar's `speaking → responding` vs `thinking` split (JARVIS-1279).
+ * every speech `tts_audio` frame: a continuous stream keeps re-arming the timer
+ * so the flag stays true for the whole spoken stretch; once frames stop and the
+ * queue drains, {@link scheduleAssistantAudioIdleCheck} flips it false. Drives
+ * the avatar's `speaking → responding` vs `thinking` split (JARVIS-1279). A
+ * non-speech frame is skipped: the flag says the assistant is talking, and a
+ * working cue is audible without being that.
  */
 function markAssistantAudioActive(session: SessionContext): void {
   useLiveVoiceStore.getState().setAssistantAudioActive(true);

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -1072,7 +1072,7 @@ export function useLiveVoice(
           if (isSpeech) {
             // Mark audio flowing before the phase flip so no render observes
             // `speaking` without `assistantAudioActive` (which would blink the
-            // avatar to `thinking` at the top of every response — JARVIS-1279).
+            // avatar to `thinking` at the top of every response; JARVIS-1279).
             markAssistantAudioActive(session);
             useLiveVoiceStore.getState().setState("speaking");
           }

--- a/clients/web/src/domains/chat/voice/voice-room/use-spoken-word-cursor.ts
+++ b/clients/web/src/domains/chat/voice/voice-room/use-spoken-word-cursor.ts
@@ -13,6 +13,11 @@
  * keeps the cursor at the pace of real speech until the mapping becomes
  * trustworthy.
  *
+ * The progress the player reports counts only speech. Non-speech audio (the
+ * working cue that holds a long turn's silence) plays without entering either
+ * number, so a turn that spends minutes making tones and no words leaves the
+ * cursor where it was rather than dragging it across words nothing spoke.
+ *
  * The cursor advances only while audio remains scheduled
  * (`playedSeconds < totalSeconds`). When the queue is caught up
  * (played == total — a mid-response silence while synthesis lags the streamed


### PR DESCRIPTION
## Summary

A work-shaped voice turn now behaves like a real assistant taking a task: it acknowledges receipt, goes quiet, and comes back when it is done or when it needs something. Previously it spoke every intermediate text block, plus a progress narration line every 6-7 seconds on top.

Reported by Alex: asking it to create a case from a Slack message meant sitting through the entire play-by-play before the answer.

## How it works

The `[1]` escalation verdict is the deterministic signal that a turn is work-shaped. It is decided once per turn by the front door, so nothing is asked of the working model mid-turn and no per-block token is spent.

On an escalated leg:

- Model text is enqueued **held**: synthesized, but kept off the TTS emission chain. A held job has forwarded no audio, so it is silently cancellable.
- When the provider opens a tool block, the text before it is structurally proven to be working commentary, and its held segments are cancelled before a byte reaches the client.
- At `message_complete` the terminal block is promoted onto already-synthesized audio, so the report starts without a TTS round trip.

**Guarantee: no working commentary is ever audible.** Not "usually" - never. The transcript still carries every word, so the thread keeps the detail while the call hears only the conclusion.

The silence is held open by a short rendered tone rather than words, and the acknowledgement was reworded to promise contact rather than completion ("I'm on it, and I'll get back to you") so the silence reads as work rather than a dropped call.

## Designs rejected on the way here

- **Hold every block and classify at its end** - correct, but delays the answer's onset by a whole generation.
- **A leading marker the model emits per block** - streams fine, but costs tokens on every block and makes the guarantee contingent on the model remembering a protocol.
- **Speculative speech with retraction** - zero latency and deterministic, but only a *probabilistic* guarantee, since promoted audio cannot be un-said.

The retraction mechanism from the third survives; it is what makes the hard guarantee cheap.

## Review found real defects

Fresh-eyes review across the merged branch caught several things worth naming, all fixed:

- A segment of the answer could be **silently dropped** - `emitTtsJob` assumed every job was on the queue in order, which stopped being true once held jobs came off it.
- A retracted job **disabled held prefetch for the rest of the turn**, so the answer paid a full TTS round trip at exactly the moment this design exists to remove one.
- The completion sweep **spoke the commentary it had just dropped**.
- Provider-native tools (web search) never closed a text block, so commentary was promoted alongside the report.
- The cue was **indistinguishable from speech on the wire**, so the web client flipped the room to `speaking`, opened hands-free barge-in during silent work, latched client-heard latency on the tone, and dragged the caption cursor.

## Follow-ups filed

- JARVIS-1623 - TTS synthesis concurrency is per-turn, so an ignored abort leaks across turns (pre-existing)
- JARVIS-1624 - mark which text was spoken, so the word cursor stops guessing (subsumes JARVIS-1319)
- JARVIS-1625 - the escalated leg is told the same thing three times per request
- JARVIS-1626 - decide what `firstTtsAudioAtMs` means on an escalated turn

## Not yet verified

Everything here is verified by test, not by ear. The cue's timbre, gain, and 12s cadence are first guesses. Manual dogfood is the next step, and the things most worth listening for are in the plan attached below.

Closes JARVIS-1600