### PR TITLE
Canonicalize exact profile route references without deleting fallbacks

### DIFF
--- a/assistant/src/__tests__/llm-resolver-override-or-default.test.ts
+++ b/assistant/src/__tests__/llm-resolver-override-or-default.test.ts
@@ -391,6 +391,33 @@ describe("composition", () => {
     expect(resolved.provider_connection).toBeUndefined();
   });
 
+  test("a model tweak preserves an exact entry route", () => {
+    for (const provider of ["anthropic-work", "connection:anthropic"]) {
+      const llm = LLMSchema.parse({
+        profiles: {
+          mine: {
+            ...completeCustom,
+            provider,
+            model: "claude-opus-4-8",
+            provider_connection: undefined,
+          },
+        },
+        callSites: {
+          conversationSummarization: {
+            profile: "mine",
+            model: "claude-haiku-4-5-20251001",
+          },
+        },
+        ...anthropicDp,
+      });
+
+      const resolved = resolveCallSiteConfig("conversationSummarization", llm);
+      expect(resolved.provider).toBe(provider);
+      expect(resolved.model).toBe("claude-haiku-4-5-20251001");
+      expect(resolved.provider_connection).toBeUndefined();
+    }
+  });
+
   test("a provider-pinning tweak over the vellum default keeps the managed routing", () => {
     const llm = LLMSchema.parse({
       callSites: {

--- a/assistant/src/__tests__/provider-connections-backfill.test.ts
+++ b/assistant/src/__tests__/provider-connections-backfill.test.ts
@@ -36,11 +36,11 @@ function seedConfig(profiles: Record<string, unknown>): void {
   );
 }
 
-function backfilledConnection(profileName: string): unknown {
+function backfilledProvider(profileName: string): unknown {
   const llm = loadRawConfig().llm as {
     profiles?: Record<string, Record<string, unknown>>;
   };
-  return llm.profiles?.[profileName]?.provider_connection;
+  return llm.profiles?.[profileName]?.provider;
 }
 
 beforeEach(() => {
@@ -67,7 +67,7 @@ test("managed mode prefers an existing user connection over the vellum default",
 
   runProviderConnectionsBackfill(getDb());
 
-  expect(backfilledConnection("byok")).toBe("anthropic-personal");
+  expect(backfilledProvider("byok")).toBe("anthropic-personal");
 });
 
 test("managed mode still stamps vellum when no user connection exists", () => {
@@ -76,7 +76,7 @@ test("managed mode still stamps vellum when no user connection exists", () => {
 
   runProviderConnectionsBackfill(getDb());
 
-  expect(backfilledConnection("byok")).toBe("vellum");
+  expect(backfilledProvider("byok")).toBe("vellum");
 });
 
 test("managed-owned entries keep the vellum stamp even when a user connection exists", () => {
@@ -111,10 +111,10 @@ test("managed-owned entries keep the vellum stamp even when a user connection ex
 
   runProviderConnectionsBackfill(getDb());
 
-  expect(backfilledConnection("balanced")).toBe("vellum");
-  expect(backfilledConnection("quality-optimized")).toBe("vellum");
-  expect(backfilledConnection("cost-optimized")).toBe("anthropic-personal");
-  expect(backfilledConnection("byok")).toBe("anthropic-personal");
+  expect(backfilledProvider("balanced")).toBe("vellum");
+  expect(backfilledProvider("quality-optimized")).toBe("vellum");
+  expect(backfilledProvider("cost-optimized")).toBe("anthropic-personal");
+  expect(backfilledProvider("byok")).toBe("anthropic-personal");
 });
 
 test("routing-identity providers are never stamped with a connection", () => {
@@ -126,8 +126,8 @@ test("routing-identity providers are never stamped with a connection", () => {
 
   runProviderConnectionsBackfill(getDb());
 
-  expect(backfilledConnection("managedRoute")).toBeUndefined();
-  expect(backfilledConnection("subscription")).toBeUndefined();
+  expect(backfilledProvider("managedRoute")).toBe("vellum");
+  expect(backfilledProvider("subscription")).toBe("chatgpt");
 });
 
 test("your-own mode reuses a custom-named connection instead of creating -personal", () => {
@@ -142,7 +142,7 @@ test("your-own mode reuses a custom-named connection instead of creating -person
 
   runProviderConnectionsBackfill(getDb());
 
-  expect(backfilledConnection("byok")).toBe("my-anthropic");
+  expect(backfilledProvider("byok")).toBe("my-anthropic");
   expect(getConnection(getDb(), "anthropic-personal")).toBeNull();
   // Exactly the user's connection — no parallel row was created.
   expect(

--- a/assistant/src/__tests__/workspace-migration-147-canonicalize-profile-route-references.test.ts
+++ b/assistant/src/__tests__/workspace-migration-147-canonicalize-profile-route-references.test.ts
@@ -1,0 +1,208 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { canonicalizeProfileRouteReferencesMigration } from "../workspace/migrations/147-canonicalize-profile-route-references.js";
+import { WORKSPACE_MIGRATIONS } from "../workspace/migrations/registry.js";
+import { assertNotLiveDb } from "./assert-not-live-db.js";
+
+let workspaceDir: string;
+
+function writeConfig(profiles: Record<string, unknown>): void {
+  writeFileSync(
+    join(workspaceDir, "config.json"),
+    JSON.stringify({ llm: { profiles } }, null, 2) + "\n",
+  );
+}
+
+function readProfiles(): Record<string, Record<string, unknown>> {
+  const config = JSON.parse(
+    readFileSync(join(workspaceDir, "config.json"), "utf-8"),
+  ) as { llm: { profiles: Record<string, Record<string, unknown>> } };
+  return config.llm.profiles;
+}
+
+function seedRows(rows: Array<{ name: string; provider: string }>): void {
+  mkdirSync(join(workspaceDir, "data", "db"), { recursive: true });
+  const db = new Database(join(workspaceDir, "data", "db", "assistant.db"));
+  db.run(`CREATE TABLE provider_connections (
+    name TEXT PRIMARY KEY,
+    provider TEXT NOT NULL,
+    auth TEXT NOT NULL,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL
+  )`);
+  for (const row of rows) {
+    db.query(
+      `INSERT INTO provider_connections (name, provider, auth, created_at, updated_at)
+       VALUES (?, ?, '{"type":"api_key"}', 1, 1)`,
+    ).run(row.name, row.provider);
+  }
+  db.close();
+}
+
+beforeEach(() => {
+  workspaceDir = join(
+    tmpdir(),
+    `vellum-migration-147-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(workspaceDir, { recursive: true });
+});
+
+afterEach(() => {
+  if (existsSync(workspaceDir)) {
+    assertNotLiveDb(workspaceDir);
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+describe("147-canonicalize-profile-route-references", () => {
+  test("is the final registered workspace migration", () => {
+    expect(WORKSPACE_MIGRATIONS.at(-1)).toBe(
+      canonicalizeProfileRouteReferencesMigration,
+    );
+  });
+
+  test("preserves a self-named exact pin with an explicit reference", () => {
+    seedRows([{ name: "anthropic", provider: "anthropic" }]);
+    writeConfig({
+      pinned: {
+        provider: "anthropic",
+        provider_connection: "anthropic",
+        model: "claude-opus-4-8",
+      },
+    });
+
+    canonicalizeProfileRouteReferencesMigration.run(workspaceDir);
+
+    expect(readProfiles().pinned).toEqual({
+      provider: "connection:anthropic",
+      model: "claude-opus-4-8",
+    });
+  });
+
+  test("keeps a non-colliding exact entry name readable", () => {
+    seedRows([{ name: "anthropic-work", provider: "anthropic" }]);
+    writeConfig({
+      work: {
+        provider: "anthropic",
+        provider_connection: "anthropic-work",
+        model: "claude-opus-4-8",
+      },
+    });
+
+    canonicalizeProfileRouteReferencesMigration.run(workspaceDir);
+
+    expect(readProfiles().work).toEqual({
+      provider: "anthropic-work",
+      model: "claude-opus-4-8",
+    });
+  });
+
+  test("escapes an entry name that starts with the reference prefix", () => {
+    seedRows([{ name: "connection:anthropic", provider: "anthropic" }]);
+    writeConfig({
+      escaped: {
+        provider: "anthropic",
+        provider_connection: "connection:anthropic",
+        model: "claude-opus-4-8",
+      },
+    });
+
+    canonicalizeProfileRouteReferencesMigration.run(workspaceDir);
+
+    expect(readProfiles().escaped.provider).toBe(
+      "connection:connection%3Aanthropic",
+    );
+    expect(readProfiles().escaped).not.toHaveProperty("provider_connection");
+  });
+
+  test("escapes a prefix entry already folded by migration 145", () => {
+    seedRows([{ name: "connection:anthropic", provider: "anthropic" }]);
+    writeConfig({
+      escaped: {
+        provider: "connection:anthropic",
+        model: "claude-opus-4-8",
+      },
+    });
+
+    canonicalizeProfileRouteReferencesMigration.run(workspaceDir);
+
+    expect(readProfiles().escaped.provider).toBe(
+      "connection:connection%3Aanthropic",
+    );
+  });
+
+  test("keeps mismatched, dangling, and identity-sensitive bindings", () => {
+    seedRows([
+      { name: "ollama-local", provider: "ollama" },
+      { name: "vellum", provider: "vellum" },
+    ]);
+    const profiles = {
+      mismatched: {
+        provider: "anthropic",
+        provider_connection: "ollama-local",
+        model: "claude-opus-4-8",
+      },
+      dangling: {
+        provider: "anthropic",
+        provider_connection: "deleted-row",
+        model: "claude-opus-4-8",
+      },
+      identitySensitive: {
+        provider: "anthropic",
+        provider_connection: "vellum",
+        model: "custom-model",
+      },
+    };
+    writeConfig(profiles);
+
+    canonicalizeProfileRouteReferencesMigration.run(workspaceDir);
+
+    expect(readProfiles()).toEqual(profiles);
+  });
+
+  test("retries instead of guessing when the connection table is unreadable", () => {
+    writeConfig({
+      pinned: {
+        provider: "anthropic",
+        provider_connection: "anthropic",
+        model: "claude-opus-4-8",
+      },
+    });
+    mkdirSync(join(workspaceDir, "data", "db"), { recursive: true });
+    new Database(join(workspaceDir, "data", "db", "assistant.db")).close();
+
+    expect(() =>
+      canonicalizeProfileRouteReferencesMigration.run(workspaceDir),
+    ).toThrow(/not readable/);
+    expect(readProfiles().pinned.provider_connection).toBe("anthropic");
+    expect(
+      canonicalizeProfileRouteReferencesMigration.retryFailedCheckpoint,
+    ).toBe(true);
+  });
+
+  test("is idempotent", () => {
+    seedRows([{ name: "anthropic", provider: "anthropic" }]);
+    writeConfig({
+      pinned: {
+        provider: "anthropic",
+        provider_connection: "anthropic",
+        model: "claude-opus-4-8",
+      },
+    });
+
+    canonicalizeProfileRouteReferencesMigration.run(workspaceDir);
+    const first = readProfiles();
+    canonicalizeProfileRouteReferencesMigration.run(workspaceDir);
+    expect(readProfiles()).toEqual(first);
+  });
+});

--- a/assistant/src/config/llm-resolver.ts
+++ b/assistant/src/config/llm-resolver.ts
@@ -20,6 +20,7 @@ import {
   type LLMSchema,
   type ProfileEntry,
   routingIdentityModelIssue,
+  unknownLlmProviderIssue,
 } from "./schemas/llm.js";
 
 /**
@@ -424,10 +425,15 @@ function resolveOverrideOrDefault(
     CODE_DEFAULT_BASE.provider;
   // A routing-identity winner serves any model its route can dispatch —
   // identity + model is the complete shape, so no provider implication.
+  // A provider outside the known set is an exact entry reference. Its row is
+  // the route authority, so a model tweak must not silently replace it with a
+  // conventional vendor route just because this pure resolver cannot inspect
+  // the row's model catalog.
   const winnerServesModel = (model: string): boolean =>
     ROUTING_IDENTITY_PROVIDERS.has(applicableProvider)
       ? routingIdentityModelIssue(applicableProvider, model) === null
-      : isModelInCatalog(applicableProvider, model);
+      : unknownLlmProviderIssue(applicableProvider) !== null ||
+        isModelInCatalog(applicableProvider, model);
   if (
     typeof tweak.model === "string" &&
     tweak.provider === undefined &&

--- a/assistant/src/config/profile-materialization.ts
+++ b/assistant/src/config/profile-materialization.ts
@@ -16,6 +16,7 @@ import {
   type LLMConfigBase,
   type ProfileEntry,
   routingIdentityModelIssue,
+  unknownLlmProviderIssue,
 } from "./schemas/llm.js";
 
 /**
@@ -87,10 +88,14 @@ export function completeCustomProfile(
 
   // A routing-identity fill base serves any model its route can dispatch —
   // identity + model is the complete shape, so no provider implication.
+  // An exact entry reference is likewise authoritative. This pure completion
+  // pass cannot inspect the row, so it preserves the route and leaves model
+  // compatibility to the connection-aware write guard and dispatch preflight.
   const fillBaseServesModel = (model: string): boolean =>
     ROUTING_IDENTITY_PROVIDERS.has(dflt.provider)
       ? routingIdentityModelIssue(dflt.provider, model) === null
-      : isModelInCatalog(dflt.provider, model);
+      : unknownLlmProviderIssue(dflt.provider) !== null ||
+        isModelInCatalog(dflt.provider, model);
   if (
     profile.model !== undefined &&
     profile.provider === undefined &&

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -598,10 +598,10 @@ export const ProfileEntry = LLMConfigFragment.extend({
   label: z.string().min(1).nullable().optional(),
   description: z.string().optional(),
   /**
-   * Name of a `provider_connections` row to use for this profile.
-   * The dispatcher resolves auth from this connection; the legacy `provider`
-   * and `source` fields remain as read-only deprecated fallbacks for profiles
-   * not yet backfilled by the boot-time migration.
+   * Legacy exact-connection reference. Current writers store the route in
+   * `provider` as a routing identity or entry reference. This field remains a
+   * read fallback for profiles whose two routing facts could not be collapsed
+   * without changing behavior.
    */
   provider_connection: z.string().min(1).optional(),
   /**

--- a/assistant/src/config/schemas/services.ts
+++ b/assistant/src/config/schemas/services.ts
@@ -44,9 +44,10 @@ const BaseServiceSchema = z.object({
 
 /**
  * Inference service entry. Carries no fields — routing is now governed
- * entirely by `provider_connections` rows and the `provider_connection`
- * reference on each `llm.profile`. The namespace is kept so callers
- * that walk `config.services.inference` do not need updating.
+ * entirely by connection rows and each profile's `provider` route reference,
+ * with `provider_connection` retained only for legacy profile fallbacks. The
+ * namespace is kept so callers that walk `config.services.inference` do not
+ * need updating.
  *
  * Legacy `provider`, `model`, and `mode` fields are stripped by workspace
  * migrations `039-drop-legacy-llm-keys` and `076-drop-services-inference-mode`.

--- a/assistant/src/providers/__tests__/dispatch-connection-routing.test.ts
+++ b/assistant/src/providers/__tests__/dispatch-connection-routing.test.ts
@@ -530,10 +530,7 @@ describe("routing identities", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Entry-name providers — a profile provider naming a connection row directly.
-// Write surfaces reject these until the entries model enables them; dispatch
-// translates them so hand-edited configs (and the collapse migration later)
-// route through the named row.
+// Entry-name providers: a profile provider naming a connection row directly.
 // ---------------------------------------------------------------------------
 
 describe("entry-name providers", () => {
@@ -572,6 +569,36 @@ describe("entry-name providers", () => {
     expect(resolveProviderCalls[0]?.name).toBe("anthropic-work");
     // The label is not a vendor: the row's own provider drives dispatch,
     // so no override is threaded.
+    expect(resolveProviderOpts[0]?.providerOverride).toBeUndefined();
+  });
+
+  test("an explicit reference dispatches through a self-named row", async () => {
+    registerConnection(
+      {
+        name: "anthropic",
+        provider: "anthropic",
+        auth: {
+          type: "api_key",
+          credential: "credential/anthropic/api_key",
+        },
+      },
+      { name: "anthropic", tag: "self-named-key" },
+    );
+    setLlmConfig({
+      profiles: {
+        pinned: {
+          provider: "connection:anthropic",
+          model: "claude-opus-4-8",
+        },
+      },
+    });
+
+    const result = await getConfiguredProvider("mainAgent", {
+      overrideProfile: "pinned",
+    });
+
+    expect(result).not.toBeNull();
+    expect(resolveProviderCalls[0]?.name).toBe("anthropic");
     expect(resolveProviderOpts[0]?.providerOverride).toBeUndefined();
   });
 
@@ -687,6 +714,28 @@ describe("entry-name providers", () => {
 
     expect(result).not.toBeNull();
     expect(resolveProviderCalls[0]?.name).toBe("vellum");
+  });
+
+  test("a missing explicit reference stays selected and fails loudly", async () => {
+    registerConnection(
+      { name: "vellum", provider: "vellum", auth: { type: "platform" } },
+      { name: "anthropic", tag: "managed-anchor" },
+    );
+    setLlmConfig({
+      profiles: {
+        pinned: {
+          provider: "connection:does-not-exist",
+          model: "claude-opus-4-8",
+        },
+      },
+    });
+
+    await expect(
+      getConfiguredProvider("mainAgent", { overrideProfile: "pinned" }),
+    ).rejects.toMatchObject({
+      reason: "not_found",
+      connectionName: "does-not-exist",
+    });
   });
 
   test("healing hands off to the anchor, whose own failures stay loud", async () => {

--- a/assistant/src/providers/__tests__/profile-provider-reference.test.ts
+++ b/assistant/src/providers/__tests__/profile-provider-reference.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  connectionNameFromProfileProviderReference,
+  profileProviderForConnection,
+} from "../profile-provider-reference.js";
+
+describe("profile provider references", () => {
+  test("keeps ordinary entry names readable", () => {
+    expect(profileProviderForConnection("anthropic-work")).toBe(
+      "anthropic-work",
+    );
+    expect(
+      connectionNameFromProfileProviderReference("anthropic-work"),
+    ).toBeNull();
+  });
+
+  test("namespaces exact rows that collide with provider ids", () => {
+    const reference = profileProviderForConnection("anthropic");
+    expect(reference).toBe("connection:anthropic");
+    expect(connectionNameFromProfileProviderReference(reference)).toBe(
+      "anthropic",
+    );
+  });
+
+  test("escapes row names that collide with the reference syntax", () => {
+    const reference = profileProviderForConnection("connection:anthropic");
+    expect(reference).toBe("connection:connection%3Aanthropic");
+    expect(connectionNameFromProfileProviderReference(reference)).toBe(
+      "connection:anthropic",
+    );
+  });
+
+  test("rejects empty and malformed references", () => {
+    expect(
+      connectionNameFromProfileProviderReference("connection:"),
+    ).toBeNull();
+    expect(
+      connectionNameFromProfileProviderReference("connection:%not-uri"),
+    ).toBeNull();
+  });
+});

--- a/assistant/src/providers/connection-resolution.ts
+++ b/assistant/src/providers/connection-resolution.ts
@@ -2,16 +2,15 @@
  * Connection-aware provider resolution helpers.
  *
  * These wrap `resolveProviderFromConnection` (in `registry.ts`) with the
- * DB lookup and lifecycle of a `provider_connection` reference. The
+ * DB lookup and lifecycle of a profile route reference. The
  * canonical dispatch path (`provider-send-message.ts`) and each satellite
  * site (subagent manager, daemon conversation/approval/guardian generators,
  * rollup producer) use these helpers so that connection-awareness behaves
  * identically across the codebase.
  *
  * Resolution policy:
- *   1. The profile MUST name a `provider_connection`. The boot-time
- *      backfill ensures every profile has one; a missing connection name
- *      is a configuration bug.
+ *   1. An exact route may come from the profile's provider entry reference
+ *      or the legacy `provider_connection` fallback.
  *   2. Hard config errors (DB lookup throws, row not found, provider
  *      mismatch with the resolving profile) throw so misconfigurations
  *      surface immediately rather than silently rerouting.
@@ -51,6 +50,7 @@ import {
   listConnections,
 } from "./inference/connections.js";
 import { resolveManagedProxyContext } from "./platform-proxy/context.js";
+import { connectionNameFromProfileProviderReference } from "./profile-provider-reference.js";
 import { checkCredentialPresence } from "./provider-availability.js";
 import type { ProvidersConfig } from "./registry.js";
 import { resolveProviderFromConnection } from "./registry.js";
@@ -72,19 +72,23 @@ const log = getLogger("providers/connection-resolution");
 
 /**
  * Resolve a provider label that names a connection row (an entry) to that
- * row's name. Returns null for catalog providers and routing identities
- * (those translate through their own rules) and for labels naming no row.
+ * row's name. Explicit namespaced references return their decoded target even
+ * when the row is missing so dispatch reports a hard not_found error. Returns
+ * null for catalog providers, routing identities, and ordinary labels naming
+ * no row.
  *
- * The write surfaces reject entry-name providers until the entries model
- * enables them, so a config carrying one reaches dispatch only through a
- * hand edit today and through the collapse migration later; translating
- * here makes both route explainably instead of failing as an unknown
- * provider.
  */
 export function resolveEntryConnectionName(
   provider: string | undefined,
 ): string | null {
-  if (!provider || VALID_CONNECTION_PROVIDERS.includes(provider)) {
+  if (!provider) {
+    return null;
+  }
+  const explicit = connectionNameFromProfileProviderReference(provider);
+  if (explicit !== null) {
+    return explicit;
+  }
+  if (VALID_CONNECTION_PROVIDERS.includes(provider)) {
     return null;
   }
   try {
@@ -104,6 +108,16 @@ export function resolveEntryConnectionName(
  * the entries demolition, so entries must not leak into them meanwhile.
  */
 export function writableProfileProviderIssue(provider: string): string | null {
+  const explicit = connectionNameFromProfileProviderReference(provider);
+  if (explicit !== null) {
+    try {
+      return getConnection(getDb(), explicit) == null
+        ? `Invalid provider "${provider}". No connection named "${explicit}" exists.`
+        : null;
+    } catch {
+      return `Connection "${explicit}" could not be verified. Try again.`;
+    }
+  }
   const issue = unknownLlmProviderIssue(provider);
   if (issue === null) {
     return null;
@@ -125,6 +139,12 @@ export function writableProfileProviderIssue(provider: string): string | null {
  * never heals away a valid entry profile; dispatch soft-fails on its own.
  */
 export function dispatchProviderResolvable(provider: string): boolean {
+  if (connectionNameFromProfileProviderReference(provider) !== null) {
+    // An exact reference remains the selected route even when the row is
+    // missing, so dispatch can surface the same hard not_found error as a
+    // legacy provider_connection pin instead of silently healing selection.
+    return true;
+  }
   if (VALID_CONNECTION_PROVIDERS.includes(provider)) {
     return true;
   }

--- a/assistant/src/providers/inference/backfill.ts
+++ b/assistant/src/providers/inference/backfill.ts
@@ -1,14 +1,15 @@
 /**
- * Boot-time backfill: migrates existing config.json from the legacy
- * `provider` + `source` model to the new `provider_connection` model.
+ * Boot-time connection-row repair and route canonicalization.
  *
  * Walks three locations in `llm.*` on every boot:
  *   - `llm.default`           — the legacy raw base blob still present in older configs
  *   - `llm.profiles.*`        — named alternate profiles (fast/balanced/...)
  *   - `llm.callSites.*`       — per-call-site overrides with bare `provider`
  *
- * Idempotent: any object that already has `provider_connection` is skipped.
- * Only modifies config.json when at least one location needs updating.
+ * Named profiles store an exact choice in `provider` as an entry reference.
+ * The legacy default blob and call-site fragments retain their compatibility
+ * `provider_connection` field. Only modifies config.json when a location needs
+ * repair.
  *
  * The `default` and `callSites` walks were added alongside Phase 1.1 of the
  * post-v1 inference-providers cleanup: dispatch now throws on missing
@@ -23,10 +24,12 @@ import type { DrizzleDb } from "../../persistence/db-connection.js";
 import { credentialKey } from "../../security/credential-key.js";
 import { getLogger } from "../../util/logger.js";
 import { isConnectionCompatibleWithModel } from "../connection-model-compat.js";
+import { profileProviderForConnection } from "../profile-provider-reference.js";
 import { MANAGED_ROUTABLE_PROVIDERS } from "../vellum-model-routing.js";
 import {
   PROVIDERS_REQUIRING_BASE_URL_AND_MODELS,
   ROUTING_IDENTITY_PROVIDERS,
+  VALID_CONNECTION_PROVIDERS,
 } from "./auth.js";
 import {
   createConnection,
@@ -51,7 +54,8 @@ const log = getLogger("provider-connections-backfill");
  *   1. Upsert canonical connections.
  *   2. Walk `llm.default`, `llm.profiles.*`, `llm.callSites.*` in config.json.
  *   3. For each entry without `provider_connection`, derive one from the
- *      entry's `provider` field + the global inference mode and write it back.
+ *      entry's `provider` field + the global inference mode. Named profiles
+ *      fold the result into `provider`; legacy locations keep the old field.
  *   4. Save config.json if any entry was updated.
  */
 export function runProviderConnectionsBackfill(db: DrizzleDb): void {
@@ -99,6 +103,14 @@ function backfillConfigProfiles(db: DrizzleDb): void {
         continue;
       }
       if (ensureProviderConnection(profile, profileName, db, globalMode)) {
+        const connectionName = profile.provider_connection;
+        if (typeof connectionName === "string") {
+          profile.provider =
+            connectionName === VELLUM_MANAGED_CONNECTION_NAME
+              ? "vellum"
+              : profileProviderForConnection(connectionName);
+          delete profile.provider_connection;
+        }
         profiles[profileName] = profile;
         changed = true;
       }
@@ -176,6 +188,13 @@ function ensureProviderConnection(
 
   const provider = entry.provider as string | undefined;
   if (!provider) {
+    return false;
+  }
+
+  // A non-vendor provider is already an entry reference. Its row owns the
+  // provider kind, so deriving a second connection from the label would
+  // create a bogus `<entry>-personal` row and reintroduce two routing axes.
+  if (!VALID_CONNECTION_PROVIDERS.includes(provider)) {
     return false;
   }
 

--- a/assistant/src/providers/profile-provider-reference.ts
+++ b/assistant/src/providers/profile-provider-reference.ts
@@ -1,0 +1,41 @@
+import { VALID_CONNECTION_PROVIDERS } from "./inference/auth.js";
+
+const CONNECTION_REFERENCE_PREFIX = "connection:";
+
+/**
+ * Encode an exact connection selection in the profile `provider` field when
+ * its raw name would be ambiguous with a provider id or the reference syntax.
+ * Ordinary entry names stay readable (`anthropic-work`); reserved names are
+ * namespaced (`connection:anthropic`).
+ */
+export function profileProviderForConnection(connectionName: string): string {
+  if (
+    VALID_CONNECTION_PROVIDERS.includes(connectionName) ||
+    connectionName.startsWith(CONNECTION_REFERENCE_PREFIX)
+  ) {
+    return `${CONNECTION_REFERENCE_PREFIX}${encodeURIComponent(connectionName)}`;
+  }
+  return connectionName;
+}
+
+/**
+ * Decode an explicitly namespaced connection reference. Returns null for a
+ * conventional provider value or an ordinary entry name.
+ */
+export function connectionNameFromProfileProviderReference(
+  provider: string | undefined,
+): string | null {
+  if (!provider?.startsWith(CONNECTION_REFERENCE_PREFIX)) {
+    return null;
+  }
+  const encoded = provider.slice(CONNECTION_REFERENCE_PREFIX.length);
+  if (encoded.length === 0) {
+    return null;
+  }
+  try {
+    const decoded = decodeURIComponent(encoded);
+    return decoded.length > 0 ? decoded : null;
+  } catch {
+    return null;
+  }
+}

--- a/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
@@ -852,7 +852,8 @@ describe("PUT /v1/config/llm/profiles/:name", () => {
       }
     ).profiles.custom;
 
-    expect(savedProfile.provider).toBe("openai");
+    expect(savedProfile.provider).toBe("openai-personal");
+    expect(savedProfile.provider_connection).toBeUndefined();
     expect(savedProfile.model).toBe("gpt-5.5");
     // Write normalization completes the entry against llm.default (schema
     // defaults here — the fixture has none), so UI-cleared fields land as
@@ -928,7 +929,7 @@ describe("PUT /v1/config/llm/profiles/:name", () => {
     expect(savedProfile.provider_connection).toBe("personal-openai");
   });
 
-  test("auto-derives provider_connection when omitted from body (Any active)", async () => {
+  test("stores the managed route in provider when the connection picker is omitted", async () => {
     // Start from a clean connection slate — provider_connections persists
     // across tests in this file, so a leaked openai-personal would otherwise
     // win the derivation.
@@ -968,7 +969,8 @@ describe("PUT /v1/config/llm/profiles/:name", () => {
 
     // No personal openai connection exists, so the route auto-derives the
     // single Vellum-managed connection for this managed-routable provider.
-    expect(savedProfile.provider_connection).toBe("vellum");
+    expect(savedProfile.provider).toBe("vellum");
+    expect(savedProfile.provider_connection).toBeUndefined();
   });
 
   test("Any active derivation skips orphaned legacy *-managed rows", async () => {
@@ -997,10 +999,11 @@ describe("PUT /v1/config/llm/profiles/:name", () => {
         profiles: Record<string, Record<string, unknown>>;
       }
     ).profiles.custom;
-    expect(savedProfile.provider_connection).toBe("vellum");
+    expect(savedProfile.provider).toBe("vellum");
+    expect(savedProfile.provider_connection).toBeUndefined();
   });
 
-  test("auto-derives provider_connection for BYOK provider (Any active)", async () => {
+  test("stores an exact colliding BYOK entry as an explicit provider reference", async () => {
     // Seed a fireworks connection in the DB.
     createConnection(getDb(), {
       name: "fireworks",
@@ -1023,11 +1026,11 @@ describe("PUT /v1/config/llm/profiles/:name", () => {
       }
     ).profiles.custom;
 
-    expect(savedProfile.provider).toBe("fireworks");
-    expect(savedProfile.provider_connection).toBe("fireworks");
+    expect(savedProfile.provider).toBe("connection:fireworks");
+    expect(savedProfile.provider_connection).toBeUndefined();
   });
 
-  test("auto-creates provider_connection when no connection exists for provider", async () => {
+  test("auto-creates and stores a non-colliding entry reference", async () => {
     const result = await replaceProfileRoute.handler({
       pathParams: { name: "custom" },
       body: {
@@ -1043,8 +1046,8 @@ describe("PUT /v1/config/llm/profiles/:name", () => {
       }
     ).profiles.custom;
 
-    expect(savedProfile.provider).toBe("openrouter");
-    expect(savedProfile.provider_connection).toBe("openrouter-personal");
+    expect(savedProfile.provider).toBe("openrouter-personal");
+    expect(savedProfile.provider_connection).toBeUndefined();
 
     const conn = getConnection(getDb(), "openrouter-personal");
     expect(conn).not.toBeNull();
@@ -1073,9 +1076,9 @@ describe("PUT /v1/config/llm/profiles/:name", () => {
       }
     ).profiles.custom;
 
-    expect(savedProfile.provider).toBe("minimax");
+    expect(savedProfile.provider).toBe("minimax-personal");
     expect(savedProfile.model).toBe("MiniMax-M2.7");
-    expect(savedProfile.provider_connection).toBe("minimax-personal");
+    expect(savedProfile.provider_connection).toBeUndefined();
 
     const conn = getConnection(getDb(), "minimax-personal");
     expect(conn).not.toBeNull();

--- a/assistant/src/runtime/routes/__tests__/inference-profiles-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/inference-profiles-routes.test.ts
@@ -166,6 +166,24 @@ describe("POST inference/profiles (create) validation", () => {
     expect(result.entry.model).toBe("claude-opus-4-8");
   });
 
+  test("stores an exact self-named connection without changing conventional provider meaning", async () => {
+    seedConnection("anthropic", "anthropic", {
+      type: "api_key",
+      credential: "credential/anthropic/api_key",
+    });
+    const result = (await call("inference_profiles_create", {
+      body: {
+        name: "pinned-anthropic",
+        provider: "anthropic",
+        connection: "anthropic",
+        model: "claude-opus-4-8",
+      },
+    })) as { entry: Record<string, unknown> };
+
+    expect(result.entry.provider).toBe("connection:anthropic");
+    expect(result.entry.provider_connection).toBeUndefined();
+  });
+
   test("rejects an entry-backed profile whose model the row's kind cannot serve", async () => {
     seedConnection("anthropic-work", "anthropic", {
       type: "api_key",

--- a/assistant/src/runtime/routes/__tests__/inference-profiles-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/inference-profiles-routes.test.ts
@@ -554,6 +554,47 @@ describe("inference-profile writes are availability-aware", () => {
       'assistant inference send --profile my-fast "Reply with OK"',
     );
   });
+
+  test("a model-only update validates a namespaced exact connection by its decoded name", async () => {
+    const now = Date.now();
+    getDb()
+      .insert(providerConnections)
+      .values({
+        name: "openai-compatible",
+        provider: "openai-compatible",
+        auth: JSON.stringify({ type: "none" }),
+        baseUrl: "http://localhost:9123/v1",
+        models: JSON.stringify([
+          { id: "stub-model-v1" },
+          { id: "stub-model-v2" },
+        ]),
+        createdAt: now,
+        updatedAt: now,
+      })
+      .run();
+    setConfig("llm", {
+      profiles: {
+        "stub-fast": {
+          source: "user",
+          provider: "connection:openai-compatible",
+          model: "stub-model-v1",
+        },
+      },
+    });
+
+    const result = (await call("inference_profiles_update", {
+      pathParams: { name: "stub-fast" },
+      body: { model: "stub-model-v2", allowUnavailable: true },
+    })) as { ok: true };
+
+    expect(result.ok).toBe(true);
+    expect(persistedProfiles()).toMatchObject({
+      "stub-fast": {
+        provider: "connection:openai-compatible",
+        model: "stub-model-v2",
+      },
+    });
+  });
 });
 
 // ── update validation ─────────────────────────────────────────────────────────

--- a/assistant/src/runtime/routes/__tests__/inference-provider-connection-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/inference-provider-connection-routes.test.ts
@@ -994,6 +994,32 @@ describe("DELETE inference/provider-connections/:name (delete)", () => {
     expect((err as ConflictError).message).toContain("my-profile");
   });
 
+  test("throws 409 for an explicit reference to a self-named connection", async () => {
+    seedConnection({
+      name: "anthropic",
+      provider: "anthropic",
+      auth: { type: "api_key", credential: "credential/anthropic/api_key" },
+    });
+    setConfig("llm", {
+      profiles: {
+        pinned: {
+          provider: "connection:anthropic",
+          model: "claude-opus-4-8",
+        },
+      },
+    });
+
+    const err = await call(
+      findHandler("inference_provider_connections_delete"),
+      { pathParams: { name: "anthropic" } },
+    ).catch((error: unknown) => error);
+
+    expect(err).toBeInstanceOf(ConflictError);
+    expect((err as ConflictError).details).toEqual({
+      referencedBy: ["pinned"],
+    });
+  });
+
   test("throws 404 (not 409) when a profile references a missing connection", async () => {
     // Stale ref in config: a profile points at a connection that was
     // already deleted. Delete on the dangling name must return 404 so

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -101,9 +101,16 @@ import { type LogRow } from "../../persistence/llm-request-log-store.js";
 import { getMemoryRecallLogByMessageIds } from "../../plugins/defaults/memory/memory-recall-log-store.js";
 import { getMemoryV2ActivationLogByMessageIds } from "../../plugins/defaults/memory/v2/activation-log-store.js";
 import { getMemoryV3SelectionForInspectorByMessageIds } from "../../plugins/defaults/memory/v3/selection-log-store.js";
-import { writableProfileProviderIssue } from "../../providers/connection-resolution.js";
-import { ROUTING_IDENTITY_PROVIDERS } from "../../providers/inference/auth.js";
-import { PROVIDERS_REQUIRING_BASE_URL_AND_MODELS } from "../../providers/inference/auth.js";
+import {
+  catalogProviderForProfile,
+  connectionProviderKind,
+  writableProfileProviderIssue,
+} from "../../providers/connection-resolution.js";
+import {
+  PROVIDERS_REQUIRING_BASE_URL_AND_MODELS,
+  ROUTING_IDENTITY_PROVIDERS,
+  VALID_CONNECTION_PROVIDERS,
+} from "../../providers/inference/auth.js";
 import {
   createConnection,
   getConnection,
@@ -112,6 +119,7 @@ import {
   VELLUM_MANAGED_CONNECTION_NAME,
 } from "../../providers/inference/connections.js";
 import { PROVIDER_CATALOG } from "../../providers/model-catalog.js";
+import { profileProviderForConnection } from "../../providers/profile-provider-reference.js";
 import { initializeProviders } from "../../providers/registry.js";
 import { MANAGED_ROUTABLE_PROVIDERS } from "../../providers/vellum-model-routing.js";
 import { credentialKey } from "../../security/credential-key.js";
@@ -1810,14 +1818,31 @@ async function handleReplaceInferenceProfile({
     });
   }
 
-  // When the UI sends provider but no provider_connection, derive the connection
-  // now so the config deep-merge doesn't inherit a stale connection from the
-  // default layer. Managed entries are excluded: the managed gate above
+  // Normalize a legacy two-field body only when the row confirms both facts
+  // agree. If the UI sends a bare provider, resolve its route now and store the
+  // connection entry or managed identity in `provider`, so the replacement
+  // cannot inherit a stale legacy connection. Managed entries are excluded: the managed gate above
   // already rejected any provider-carrying fragment, so their only surviving
   // body is a status re-enable, which derives no connection. A user-owned
   // profile sharing a managed name is fully editable, so it takes the
   // derivation like any other custom profile.
   const fragment = parsed.data as Record<string, unknown>;
+  const legacyBinding = fragment.provider_connection;
+  const fragmentProvider = fragment.provider;
+  const fragmentModel = fragment.model;
+  if (
+    typeof legacyBinding === "string" &&
+    typeof fragmentProvider === "string" &&
+    typeof fragmentModel === "string"
+  ) {
+    const expectedKind =
+      catalogProviderForProfile(fragmentProvider, fragmentModel) ??
+      fragmentProvider;
+    if (connectionProviderKind(legacyBinding, fragmentModel) === expectedKind) {
+      fragment.provider = profileProviderForConnection(legacyBinding);
+      delete fragment.provider_connection;
+    }
+  }
   // Routing identities resolve their connection per-request from the
   // provider value; deriving one here would stamp the canonical vellum row
   // ("vellum" is its stored provider) or create a junk "<identity>-personal"
@@ -1826,6 +1851,7 @@ async function handleReplaceInferenceProfile({
     !isManaged &&
     fragment.provider &&
     !fragment.provider_connection &&
+    VALID_CONNECTION_PROVIDERS.includes(fragment.provider as string) &&
     !ROUTING_IDENTITY_PROVIDERS.has(fragment.provider as string)
   ) {
     const provider = fragment.provider as string;
@@ -1838,14 +1864,14 @@ async function handleReplaceInferenceProfile({
       (c) => !LEGACY_MANAGED_CONNECTION_NAMES.has(c.name),
     );
     if (active) {
-      fragment.provider_connection = active.name;
+      fragment.provider = profileProviderForConnection(active.name);
     } else if (
       MANAGED_ROUTABLE_PROVIDERS.has(provider) &&
       getConnection(db, VELLUM_MANAGED_CONNECTION_NAME)
     ) {
       // Managed-routable providers are served by the single Vellum-managed
       // connection; prefer it over lazily creating a personal connection.
-      fragment.provider_connection = VELLUM_MANAGED_CONNECTION_NAME;
+      fragment.provider = "vellum";
     } else if (!PROVIDERS_REQUIRING_BASE_URL_AND_MODELS.has(provider)) {
       const connectionName = `${provider}-personal`;
       const isKeyless = provider === "ollama";
@@ -1860,7 +1886,7 @@ async function handleReplaceInferenceProfile({
             },
       });
       if (result.ok) {
-        fragment.provider_connection = connectionName;
+        fragment.provider = profileProviderForConnection(connectionName);
       }
     }
   }

--- a/assistant/src/runtime/routes/inference-profiles-routes.ts
+++ b/assistant/src/runtime/routes/inference-profiles-routes.ts
@@ -36,6 +36,7 @@ import {
 import { getDb } from "../../persistence/db-connection.js";
 import {
   catalogProviderForProfile,
+  connectionProviderKind,
   resolveEntryProviderKind,
   writableProfileProviderIssue,
 } from "../../providers/connection-resolution.js";
@@ -54,6 +55,7 @@ import {
   getModelDisplayName,
   isModelInCatalog,
 } from "../../providers/model-catalog.js";
+import { profileProviderForConnection } from "../../providers/profile-provider-reference.js";
 import { ACTOR_PRINCIPALS } from "../auth/route-policy.js";
 import {
   commitConfigWrite,
@@ -342,6 +344,22 @@ function assertConnectionExists(name: string): void {
   }
 }
 
+function providerForExactConnection(
+  name: string,
+  provider: string,
+  model: string,
+): string {
+  assertConnectionExists(name);
+  const expectedKind = catalogProviderForProfile(provider, model) ?? provider;
+  const actualKind = connectionProviderKind(name, model);
+  if (actualKind !== expectedKind) {
+    throw new BadRequestError(
+      `Connection "${name}" serves provider "${actualKind ?? "unknown"}", not "${expectedKind}".`,
+    );
+  }
+  return profileProviderForConnection(name);
+}
+
 function asPlainObject(value: unknown): Record<string, unknown> | null {
   if (value == null || typeof value !== "object" || Array.isArray(value)) {
     return null;
@@ -427,9 +445,6 @@ function fragmentFromBody(
   }
   if (typeof body.description === "string") {
     fragment.description = body.description;
-  }
-  if (typeof body.connection === "string") {
-    fragment.provider_connection = body.connection;
   }
   return fragment;
 }
@@ -586,20 +601,20 @@ async function handleCreateProfile({ body = {} }: RouteHandlerArgs) {
   }
 
   assertValidProvider(input.provider);
-  if (input.connection) {
-    assertConnectionExists(input.connection);
-  }
+  const routeProvider = input.connection
+    ? providerForExactConnection(input.connection, input.provider, input.model)
+    : input.provider;
   const warnings = validateModel(
-    input.provider,
+    routeProvider,
     input.model,
     input.allowUnlisted ?? false,
     input.connection,
   );
-  assertSaneMaxTokens(input.provider, input.model, input.maxTokens);
+  assertSaneMaxTokens(routeProvider, input.model, input.maxTokens);
 
   const entry: Record<string, unknown> = {
     ...fragmentFromBody(body as Record<string, unknown>),
-    provider: input.provider,
+    provider: routeProvider,
     model: input.model,
     source: "user",
     // `warnings` here can only be validateModel's unlisted verdict (the
@@ -700,9 +715,9 @@ async function handleUpdateProfile({
     );
   }
 
-  const nextProvider =
-    input.provider ??
-    (typeof existing.provider === "string" ? existing.provider : undefined);
+  const existingProvider =
+    typeof existing.provider === "string" ? existing.provider : undefined;
+  const requestedProvider = input.provider ?? existingProvider;
   const nextModel =
     input.model ??
     (typeof existing.model === "string" ? existing.model : undefined);
@@ -710,13 +725,24 @@ async function handleUpdateProfile({
   if (input.provider) {
     assertValidProvider(input.provider);
   }
-  let warnings: string[] = [];
-  if (input.connection) {
-    assertConnectionExists(input.connection);
+  if (input.connection && (!requestedProvider || !nextModel)) {
+    throw new BadRequestError(
+      "An exact connection selection requires the profile to have both provider and model.",
+    );
   }
+  const nextProvider =
+    input.connection && requestedProvider && nextModel
+      ? providerForExactConnection(
+          input.connection,
+          requestedProvider,
+          nextModel,
+        )
+      : requestedProvider;
+  let warnings: string[] = [];
   const nextConnection =
     input.connection ??
-    (typeof existing.provider_connection === "string"
+    (input.provider === undefined &&
+    typeof existing.provider_connection === "string"
       ? existing.provider_connection
       : undefined);
   if (
@@ -753,11 +779,16 @@ async function handleUpdateProfile({
   const merged: Record<string, unknown> = {
     ...existing,
     ...fragmentFromBody(body as Record<string, unknown>),
-    ...(input.provider !== undefined ? { provider: input.provider } : {}),
+    ...(input.provider !== undefined || input.connection !== undefined
+      ? { provider: nextProvider }
+      : {}),
     ...(input.model !== undefined ? { model: input.model } : {}),
     source:
       existing.source === "managed" ? "user" : (existing.source ?? "user"),
   };
+  if (input.provider !== undefined || input.connection !== undefined) {
+    delete merged.provider_connection;
+  }
   // Keep the allowUnlisted marker faithful to the pair being stored: stamp
   // it on a deliberate unlisted acceptance (warnings can only be the
   // unlisted verdict here), and drop a stale one when the pair is now

--- a/assistant/src/runtime/routes/inference-profiles-routes.ts
+++ b/assistant/src/runtime/routes/inference-profiles-routes.ts
@@ -37,6 +37,7 @@ import { getDb } from "../../persistence/db-connection.js";
 import {
   catalogProviderForProfile,
   connectionProviderKind,
+  resolveEntryConnectionName,
   resolveEntryProviderKind,
   writableProfileProviderIssue,
 } from "../../providers/connection-resolution.js";
@@ -210,13 +211,14 @@ function modelReachIssue(
       ? { identity: true, catalogProvider: provider, message: issue }
       : null;
   }
+  const entryConnectionName = resolveEntryConnectionName(provider);
   const entryKind = resolveEntryProviderKind(provider, model);
   const catalogProvider = entryKind ?? provider;
   if (isModelInCatalog(catalogProvider, model)) {
     return null;
   }
   const modelListConnection =
-    connectionName ?? (entryKind !== null ? provider : undefined);
+    connectionName ?? entryConnectionName ?? undefined;
   if (modelListConnection) {
     const connection = getConnection(getDb(), modelListConnection);
     if (connection?.models?.some((m) => m.id === model)) {

--- a/assistant/src/runtime/routes/inference-provider-connection-routes.ts
+++ b/assistant/src/runtime/routes/inference-provider-connection-routes.ts
@@ -44,6 +44,7 @@ import {
   testInferenceConnection,
 } from "../../providers/inference/endpoint-probe.js";
 import { PROVIDER_CATALOG } from "../../providers/model-catalog.js";
+import { connectionNameFromProfileProviderReference } from "../../providers/profile-provider-reference.js";
 import {
   isVellumManagedConnection,
   VELLUM_MANAGED_PROVIDER,
@@ -659,7 +660,9 @@ async function handleDeleteConnection({ pathParams = {} }: RouteHandlerArgs) {
       const entry = p as Record<string, unknown>;
       return (
         entry.provider_connection === name ||
-        (nameIsEntryName && entry.provider === name)
+        (nameIsEntryName && entry.provider === name) ||
+        (typeof entry.provider === "string" &&
+          connectionNameFromProfileProviderReference(entry.provider) === name)
       );
     })
     .map(([profileName]) => profileName);

--- a/assistant/src/workspace/migrations/147-canonicalize-profile-route-references.ts
+++ b/assistant/src/workspace/migrations/147-canonicalize-profile-route-references.ts
@@ -1,0 +1,214 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { Database } from "bun:sqlite";
+
+import { getLogger } from "../../util/logger.js";
+import type { WorkspaceMigration } from "./types.js";
+
+const log = getLogger("migrations/147-canonicalize-profile-route-references");
+
+// Frozen routing vocabulary for this migration. An exact connection whose
+// name collides with one of these values needs the explicit reference syntax;
+// otherwise the raw value keeps meaning conventional provider resolution.
+const PROVIDER_IDS = new Set([
+  "anthropic",
+  "openai",
+  "gemini",
+  "ollama",
+  "fireworks",
+  "openrouter",
+  "vercel-ai-gateway",
+  "openai-compatible",
+  "minimax",
+  "atlascloud",
+  "together",
+  "litellm",
+  "baseten",
+  "poolside",
+  "vellum",
+  "chatgpt",
+]);
+const ROUTING_IDENTITIES = new Set(["vellum", "chatgpt"]);
+const MANAGED_ROUTABLE = new Set([
+  "openai",
+  "anthropic",
+  "gemini",
+  "fireworks",
+  "together",
+]);
+const CONNECTION_REFERENCE_PREFIX = "connection:";
+
+export const canonicalizeProfileRouteReferencesMigration: WorkspaceMigration = {
+  id: "147-canonicalize-profile-route-references",
+  description:
+    "Represent exact profile connection selections in the provider route reference",
+  retryFailedCheckpoint: true,
+  run(workspaceDir: string): void {
+    const configPath = join(workspaceDir, "config.json");
+    if (!existsSync(configPath)) {
+      return;
+    }
+
+    const rawText = readFileSync(configPath, "utf-8");
+    let config: Record<string, unknown>;
+    try {
+      const parsed = JSON.parse(rawText);
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        return;
+      }
+      config = parsed as Record<string, unknown>;
+    } catch {
+      return;
+    }
+
+    const llm = asObject(config.llm);
+    const profiles = llm === null ? null : asObject(llm.profiles);
+    if (profiles === null || !hasLegacyOrAmbiguousRoute(profiles)) {
+      return;
+    }
+
+    const rows = readConnectionRows(workspaceDir);
+    if (rows === null) {
+      throw new Error(
+        "provider_connections is not readable; retrying route-reference canonicalization on the next run",
+      );
+    }
+
+    let changed = false;
+    for (const [profileName, rawEntry] of Object.entries(profiles)) {
+      const entry = asObject(rawEntry);
+      if (entry === null) {
+        continue;
+      }
+      const binding = entry.provider_connection;
+      const provider = entry.provider;
+      if (
+        typeof binding !== "string" &&
+        typeof provider === "string" &&
+        provider.startsWith(CONNECTION_REFERENCE_PREFIX) &&
+        rows.has(provider)
+      ) {
+        entry.provider = providerReferenceForConnection(provider);
+        changed = true;
+        continue;
+      }
+      if (
+        typeof binding !== "string" ||
+        binding.length === 0 ||
+        typeof provider !== "string"
+      ) {
+        continue;
+      }
+
+      const rowKind = rows.get(binding);
+      if (rowKind === undefined) {
+        log.warn(
+          { profile: profileName, provider, binding, reason: "row_missing" },
+          "Kept legacy profile binding because its connection row is missing",
+        );
+        continue;
+      }
+      if (!kindAgrees(rowKind, provider)) {
+        log.warn(
+          {
+            profile: profileName,
+            provider,
+            binding,
+            rowKind,
+            reason: "kind_mismatch",
+          },
+          "Kept legacy profile binding because its provider facts disagree",
+        );
+        continue;
+      }
+      if (ROUTING_IDENTITIES.has(binding) && binding !== provider) {
+        log.warn(
+          {
+            profile: profileName,
+            provider,
+            binding,
+            reason: "identity_semantics",
+          },
+          "Kept legacy profile binding because collapsing it could change model routing",
+        );
+        continue;
+      }
+
+      entry.provider = providerReferenceForConnection(binding);
+      delete entry.provider_connection;
+      changed = true;
+    }
+
+    if (changed) {
+      writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+    }
+  },
+  down(_workspaceDir: string): void {
+    // Forward-only.
+  },
+};
+
+function hasLegacyOrAmbiguousRoute(profiles: Record<string, unknown>): boolean {
+  return Object.values(profiles).some((value) => {
+    const entry = asObject(value);
+    return (
+      entry !== null &&
+      ((typeof entry.provider_connection === "string" &&
+        entry.provider_connection.length > 0) ||
+        (typeof entry.provider === "string" &&
+          entry.provider.startsWith(CONNECTION_REFERENCE_PREFIX)))
+    );
+  });
+}
+
+function providerReferenceForConnection(connectionName: string): string {
+  if (
+    PROVIDER_IDS.has(connectionName) ||
+    connectionName.startsWith(CONNECTION_REFERENCE_PREFIX)
+  ) {
+    return `${CONNECTION_REFERENCE_PREFIX}${encodeURIComponent(connectionName)}`;
+  }
+  return connectionName;
+}
+
+function kindAgrees(rowKind: string, provider: string): boolean {
+  if (rowKind === provider) {
+    return true;
+  }
+  if (rowKind === "chatgpt") {
+    return provider === "openai";
+  }
+  if (rowKind === "vellum") {
+    return MANAGED_ROUTABLE.has(provider);
+  }
+  return false;
+}
+
+function readConnectionRows(workspaceDir: string): Map<string, string> | null {
+  const dbPath = join(workspaceDir, "data", "db", "assistant.db");
+  if (!existsSync(dbPath)) {
+    return new Map();
+  }
+  let db: Database;
+  try {
+    db = new Database(dbPath);
+  } catch {
+    return null;
+  }
+  try {
+    const rows = db
+      .query("SELECT name, provider FROM provider_connections")
+      .all() as Array<{ name: string; provider: string }>;
+    return new Map(rows.map((row) => [row.name, row.provider]));
+  } catch {
+    return null;
+  } finally {
+    db.close();
+  }
+}
+
+function asObject(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -144,6 +144,7 @@ import { repairDeprecatedCodexModelIdMigration } from "./143-repair-deprecated-c
 import { convertStrandedSubscriptionOpenaiProfilesMigration } from "./144-convert-stranded-subscription-openai-profiles.js";
 import { collapseProfileBindingsToEntriesMigration } from "./145-collapse-profile-bindings-to-entries.js";
 import { repairRetiredFireworksDeepseekFlashModelIdMigration } from "./146-repair-retired-fireworks-deepseek-flash-model-id.js";
+import { canonicalizeProfileRouteReferencesMigration } from "./147-canonicalize-profile-route-references.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -303,4 +304,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   convertStrandedSubscriptionOpenaiProfilesMigration,
   collapseProfileBindingsToEntriesMigration,
   repairRetiredFireworksDeepseekFlashModelIdMigration,
+  canonicalizeProfileRouteReferencesMigration,
 ];


### PR DESCRIPTION
## Summary

- Stores exact profile connection selections in `provider`, while preserving bare provider IDs for conventional resolution and ordinary entry names for exact rows.
- Adds `connection:<encoded-name>` only for entry/provider namespace collisions, so a row named `anthropic` remains distinguishable from conventional Anthropic routing.
- Adds workspace migration 147 that folds only row-backed, kind-agreeing legacy bindings. Dangling, mismatched, and identity-sensitive `provider_connection` values remain compatibility fallbacks.
- Updates current profile write paths and boot repair to stop creating new two-field profile routes, while leaving call-site provider routing, `defaultProvider.connectionName`, and stored `auth.type` untouched.
- Preserves exact entry routing across call-site model tweaks and protects exact references from connection deletion.

## Validation

- `bunx tsc --noEmit`
- ESLint and Prettier checks on touched files
- 313 focused Bun tests across routing, profile writes, migration, backfill, and materialization

## Human attention

This is a compatibility-first replacement for the profile `provider_connection` deletion in #41188. It intentionally does not delete `provider_connection`: the field remains a legacy read fallback for stored states whose two facts cannot be collapsed without changing behavior. Physical removal should wait until those residual states are migrated or proven absent.

Please validate the collision semantics (`anthropic` versus `connection:anthropic`) and the migration conservatism in particular.

## Original prompt

> ok can we make a pr for this clean up?
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41243" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->