### PR TITLE
fix(voice): bind deep-link-started voice sessions to the on-screen composer so the room opens

### DIFF
--- a/clients/web/src/domains/chat/chat-layout.tsx
+++ b/clients/web/src/domains/chat/chat-layout.tsx
@@ -61,6 +61,7 @@ import { useChatLayoutDrawerGestures } from "@/domains/chat/hooks/use-chat-layou
 import { useChatLayoutShortcuts } from "@/domains/chat/hooks/use-chat-layout-shortcuts";
 import { useConversationActions } from "@/domains/chat/hooks/use-conversation-actions";
 import { useConversationGroupActions } from "@/domains/chat/hooks/use-conversation-group-actions";
+import { useMaterializedDraftReconcile } from "@/domains/chat/hooks/use-materialized-draft-reconcile";
 import { useGroupNameRequestStore } from "@/domains/chat/group-name-request-store";
 import { useCanUseInternalThreadActions } from "@/lib/auth/internal-thread-actions";
 import {
@@ -234,6 +235,12 @@ export function ChatLayout({
     isPending: isGroupsPending,
     isError: groupsFailed,
   } = useConversationGroupsQuery(assistantId, isAssistantActive);
+
+  // A client-minted conversation key stops being a draft once the server's own
+  // list carries a row for it. Mounted against the list this layout already
+  // subscribes to, so it costs no request. See
+  // `./hooks/use-materialized-draft-reconcile.ts`.
+  useMaterializedDraftReconcile(conversations);
 
   // Whether the transcript is on screen, resolved here because this is where
   // the route, the viewer and the viewport are all in hand. One owner, so

--- a/clients/web/src/domains/chat/hooks/use-materialized-draft-reconcile.test.ts
+++ b/clients/web/src/domains/chat/hooks/use-materialized-draft-reconcile.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Tests for `useMaterializedDraftReconcile`.
+ *
+ * Drives the real `useConversationStore`, so what is asserted is the state a
+ * consumer reads (`draftConversationIds`) rather than a call count.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, renderHook } from "@testing-library/react";
+
+import { useMaterializedDraftReconcile } from "@/domains/chat/hooks/use-materialized-draft-reconcile";
+import { useConversationStore } from "@/stores/conversation-store";
+import type { Conversation } from "@/types/conversation-types";
+
+afterEach(() => {
+  cleanup();
+  useConversationStore.getState().reset();
+});
+
+const list = (...conversationIds: string[]): Conversation[] =>
+  conversationIds.map((conversationId) => ({ conversationId }));
+
+const isDraft = (conversationId: string): boolean =>
+  useConversationStore.getState().draftConversationIds.has(conversationId);
+
+describe("useMaterializedDraftReconcile", () => {
+  test("a refetched list carrying the draft's id clears the mark", () => {
+    useConversationStore.getState().registerDraftConversationId("conv-draft");
+    const { rerender } = renderHook(
+      (conversations: Conversation[]) =>
+        useMaterializedDraftReconcile(conversations),
+      { initialProps: list("conv-old") },
+    );
+    expect(isDraft("conv-draft")).toBe(true);
+
+    // What a create invalidation produces: the same query, a new array, the
+    // new row in it.
+    rerender(list("conv-draft", "conv-old"));
+
+    expect(isDraft("conv-draft")).toBe(false);
+  });
+
+  test("a list without the id leaves the mark, however often it refetches", () => {
+    useConversationStore.getState().registerDraftConversationId("conv-draft");
+    const { rerender } = renderHook(
+      (conversations: Conversation[]) =>
+        useMaterializedDraftReconcile(conversations),
+      { initialProps: list("conv-old") },
+    );
+
+    rerender(list("conv-old", "conv-other"));
+
+    expect(isDraft("conv-draft")).toBe(true);
+  });
+
+  test("only the ids the list carries lose their mark", () => {
+    useConversationStore.getState().registerDraftConversationId("conv-draft");
+    useConversationStore.getState().registerDraftConversationId("conv-other");
+    const { rerender } = renderHook(
+      (conversations: Conversation[]) =>
+        useMaterializedDraftReconcile(conversations),
+      { initialProps: list() },
+    );
+
+    rerender(list("conv-draft"));
+
+    expect(isDraft("conv-draft")).toBe(false);
+    expect(isDraft("conv-other")).toBe(true);
+  });
+});

--- a/clients/web/src/domains/chat/hooks/use-materialized-draft-reconcile.ts
+++ b/clients/web/src/domains/chat/hooks/use-materialized-draft-reconcile.ts
@@ -1,0 +1,69 @@
+/**
+ * Retire draft conversation keys the server has since written a row for.
+ *
+ * A draft key is a client invention: `draftConversationIds` marks the ids that
+ * name nothing server-side, so surfaces can tell "empty because brand new"
+ * apart from "empty because history is still loading". The mark must come off
+ * the instant a row exists and never before, because a key wrongly treated as
+ * persisted loads history that 404s and resolves its billing profile from a
+ * row that is not there.
+ *
+ * The conversation list is the one signal that answers "does the row exist"
+ * with the server's own answer. The text path has a closer one and keeps it:
+ * its POST returns the resolved id, so `use-send-message` clears on the spot.
+ * A live-voice turn writes its row inside the daemon with no response for the
+ * client to read, leaving nothing local to key on. Intersecting the draft set
+ * with the fetched list covers that path, and self-heals any key whose own
+ * clear was missed.
+ *
+ * Fetched, not promised: a frame announcing an imminent turn is not a row.
+ * The daemon publishes a `conversationsList` invalidation as it creates one
+ * (`defaultStartVoiceTurn`), the sync hook refreshes the list windows, and a
+ * key that shows up in the result is a key with a row behind it. A session
+ * that ends without ever writing one leaves its draft mark alone forever,
+ * which is what keeps the empty state and the fresh composer correct.
+ */
+
+import { useEffect } from "react";
+
+import { useConversationStore } from "@/stores/conversation-store";
+import type { Conversation } from "@/types/conversation-types";
+
+/**
+ * Clear the draft mark from every id in `conversationIds` that carries one.
+ *
+ * Guarded on membership so the common case (nothing minted, or a list of rows
+ * none of which is a draft) touches the store not at all.
+ */
+export function reconcileMaterializedDrafts(
+  conversationIds: Iterable<string>,
+): void {
+  const { draftConversationIds, clearDraftConversationId } =
+    useConversationStore.getState();
+  if (draftConversationIds.size === 0) {
+    return;
+  }
+  for (const conversationId of conversationIds) {
+    if (draftConversationIds.has(conversationId)) {
+      clearDraftConversationId(conversationId);
+    }
+  }
+}
+
+/**
+ * Run {@link reconcileMaterializedDrafts} over each fetched conversation list.
+ *
+ * Mounted in `ChatLayout`, which already subscribes to the foreground list for
+ * the sidebar, so this adds no request of its own and runs on exactly the
+ * edges that matter: a refetch triggered by the daemon's create invalidation
+ * hands back a new array, and the row it just added is in it.
+ */
+export function useMaterializedDraftReconcile(
+  conversations: Conversation[],
+): void {
+  useEffect(() => {
+    reconcileMaterializedDrafts(
+      conversations.map((conversation) => conversation.conversationId),
+    );
+  }, [conversations]);
+}

--- a/clients/web/src/domains/chat/voice/global-push-to-talk-bridge.test.tsx
+++ b/clients/web/src/domains/chat/voice/global-push-to-talk-bridge.test.tsx
@@ -167,6 +167,45 @@ describe("GlobalPushToTalkBridge", () => {
     );
   });
 
+  test("lands a soft-landed transcript in the conversation already selected", async () => {
+    // Dictation is text the user is composing, so it belongs in the chat they
+    // are already in. Reading the selection first is also what keeps a press
+    // made from another app from throwing the main view over to the chat.
+    useConversationStore.getState().setActiveConversationId("conv-existing");
+    useViewerStore.getState().setMainView("app");
+    const voiceInput = renderBridge();
+
+    await act(async () => {
+      await voiceInput.onTranscript("dictated text");
+    });
+
+    expect(useConversationStore.getState().activeConversationId).toBe(
+      "conv-existing",
+    );
+    expect(useConversationStore.getState().draftConversationIds.size).toBe(0);
+    expect(useViewerStore.getState().mainView).toBe("app");
+    expect(useComposerStore.getState().input).toBe("dictated text");
+  });
+
+  test("mints a draft and reveals the chat when nothing is selected", async () => {
+    // The fallback, and the only case that mints: a press made on a route with
+    // no conversation selected still needs a composer to land the text in.
+    useConversationStore.getState().setActiveConversationId(null);
+    useViewerStore.getState().setMainView("app");
+    const voiceInput = renderBridge();
+
+    await act(async () => {
+      await voiceInput.onTranscript("dictated text");
+    });
+
+    const draftId = useConversationStore.getState().activeConversationId;
+    expect(draftId).not.toBeNull();
+    expect(
+      useConversationStore.getState().draftConversationIds.has(draftId ?? ""),
+    ).toBe(true);
+    expect(useViewerStore.getState().mainView).toBe("chat");
+  });
+
   test("uses stable toast IDs for repeated voice errors", () => {
     const voiceInput = renderBridge();
 

--- a/clients/web/src/domains/chat/voice/global-push-to-talk-bridge.tsx
+++ b/clients/web/src/domains/chat/voice/global-push-to-talk-bridge.tsx
@@ -6,18 +6,17 @@ import {
 } from "@/domains/chat/components/voice-input-button";
 import { useComposerStore } from "@/domains/chat/composer-store";
 import { useDictationOverlaySync } from "@/domains/chat/hooks/use-dictation-overlay-sync";
-import { createDraftConversationId } from "@/domains/chat/utils/conversation-selection";
 import { formatVoiceError } from "@/domains/chat/utils/chat";
 import { postDictation } from "@/domains/chat/voice/dictation-api";
 import { getPushToTalkTarget } from "@/domains/chat/voice/push-to-talk-target";
 import { supportsKeyboardActivation } from "@/domains/chat/voice/keyboard-activation-host";
 import { useAudioAmplitude } from "@/domains/chat/voice/use-audio-amplitude";
 import { useVoiceModeHotkey } from "@/domains/chat/voice/use-voice-mode-hotkey";
+import { mintVoiceDraftConversation } from "@/domains/chat/voice/voice-draft-conversation";
 import { useVoiceRecordingStore } from "@/domains/chat/voice/voice-recording-store";
 import { subscribeToDictationOverlayStop } from "@/runtime/dictation-overlay";
 import { insertTextIntoFrontApp } from "@/runtime/text-insertion";
 import { useConversationStore } from "@/stores/conversation-store";
-import { useViewerStore } from "@/stores/viewer-store";
 import { toast } from "@vellumai/design-library/components/toast";
 
 interface GlobalPushToTalkBridgeProps {
@@ -33,16 +32,17 @@ function appendTranscript(current: string, text: string): string {
   return `${current}${needsLeadingSpace ? " " : ""}${trimmed}`;
 }
 
+/**
+ * The conversation this transcript lands in: whatever is selected, and a fresh
+ * draft only when nothing is. Dictation is text the user is composing, so it
+ * belongs in the chat they are in; minting is the fallback for a press made
+ * with no conversation selected at all.
+ */
 function ensureConversationKey(): string {
-  const existing = useConversationStore.getState().activeConversationId;
-  if (existing) {
-    return existing;
-  }
-
-  const draftId = createDraftConversationId();
-  useConversationStore.getState().setActiveConversationId(draftId);
-  useViewerStore.getState().setMainView("chat");
-  return draftId;
+  return (
+    useConversationStore.getState().activeConversationId ??
+    mintVoiceDraftConversation()
+  );
 }
 
 function showVoiceErrorToast(code: string): void {

--- a/clients/web/src/domains/chat/voice/live-voice/start-voice-request.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/start-voice-request.test.ts
@@ -211,9 +211,9 @@ describe("starting a session", () => {
   });
 
   test("a start binds to a conversation of its own, never the one the app was left on", async () => {
-    // The regression this guards: reading the store's selection attached the
-    // call to whatever thread the user was last in, which for a widget button
-    // or a Siri shortcut is an unrelated conversation from another day.
+    // The store's selection is wherever the user was last, which for a widget
+    // button or a Siri shortcut is an unrelated conversation from another day.
+    // An externally initiated start must never reuse it.
     identityHydrated();
     registerStarter();
 

--- a/clients/web/src/domains/chat/voice/live-voice/start-voice-request.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/start-voice-request.test.ts
@@ -61,6 +61,7 @@ const { __resetPendingDeepLinkForTesting, usePendingDeepLinkStore } =
 const { useResolvedAssistantsStore } =
   await import("@/stores/resolved-assistants-store");
 const { useVoicePrefsStore } = await import("@/stores/voice-prefs-store");
+const { routes } = await import("@/utils/routes");
 
 // ---------------------------------------------------------------------------
 // Harness
@@ -69,8 +70,17 @@ const { useVoicePrefsStore } = await import("@/stores/voice-prefs-store");
 /** New enough to serve `POST /v1/live-voice/preflight`. */
 const SUPPORTED_VERSION = "0.10.12";
 
-/** The conversation the composer is sitting on unless a test says otherwise. */
-const ACTIVE_CONVERSATION_ID = "conv-active";
+/**
+ * The conversation the app was left sitting on. Selection survives navigation
+ * and cold launches, so every start below is made with an unrelated earlier
+ * thread selected: the state a widget button or a Siri shortcut actually finds.
+ */
+const PRIOR_CONVERSATION_ID = "conv-prior";
+
+/** The app's navigation, which the drain uses to land on the draft it mints. */
+const navigate = mock(
+  (_to: string, _options?: { replace?: boolean }) => undefined,
+);
 
 /**
  * Stands in for the controller's starter, and binds the session to the
@@ -116,6 +126,29 @@ function isParked(): boolean {
   return usePendingDeepLinkStore.getState().pendingVoiceStartAt !== null;
 }
 
+/** The draft the drain minted, which is a fresh uuid rather than a literal. */
+function mintedConversationId(): string {
+  const draftId = useConversationStore.getState().activeConversationId;
+  if (draftId === null) {
+    throw new Error("expected the drain to mint a draft conversation");
+  }
+  return draftId;
+}
+
+/**
+ * The whole binding in one assertion: the session was started on a conversation
+ * minted for it rather than the one the app was left on, and the composer for
+ * that conversation was navigated onto the screen so it can own the session.
+ */
+function expectStartedOnFreshDraft(): void {
+  const draftId = mintedConversationId();
+  expect(draftId).not.toBe(PRIOR_CONVERSATION_ID);
+  expect(starter).toHaveBeenCalledWith("assistant-1", draftId);
+  expect(navigate).toHaveBeenCalledWith(routes.conversation(draftId), {
+    replace: true,
+  });
+}
+
 beforeEach(() => {
   useLiveVoiceStore.getState().reset();
   useLiveVoiceStore.getState().setStarter(null);
@@ -129,8 +162,9 @@ beforeEach(() => {
   useConversationStore.getState().reset();
   useConversationStore
     .getState()
-    .setActiveConversationId(ACTIVE_CONVERSATION_ID);
+    .setActiveConversationId(PRIOR_CONVERSATION_ID);
   useViewerStore.getState().setMainView("app");
+  navigate.mockClear();
   starter.mockClear();
   whenAssistantVersionKnown.mockClear();
   preflightLiveVoice.mockClear();
@@ -152,12 +186,10 @@ describe("starting a session", () => {
     identityHydrated();
     registerStarter();
 
-    requestVoiceStart();
+    requestVoiceStart(navigate);
     await flushDrain();
 
-    // Bound to the conversation the composer is on, which is what lets that
-    // composer own the session and show the room.
-    expect(starter).toHaveBeenCalledWith("assistant-1", ACTIVE_CONVERSATION_ID);
+    expectStartedOnFreshDraft();
     expect(isParked()).toBe(false);
   });
 
@@ -165,50 +197,71 @@ describe("starting a session", () => {
     identityHydrated();
 
     // No `ChatLayout` yet: the drain no-ops and the request stays parked.
-    requestVoiceStart();
+    requestVoiceStart(navigate);
     await Promise.resolve();
     expect(starter).not.toHaveBeenCalled();
     expect(isParked()).toBe(true);
 
     // The controller mounts and drains, exactly as it does on registration.
     registerStarter();
-    await drainPendingVoiceStart();
+    await drainPendingVoiceStart(navigate);
 
-    expect(starter).toHaveBeenCalledWith("assistant-1", ACTIVE_CONVERSATION_ID);
+    expectStartedOnFreshDraft();
     expect(isParked()).toBe(false);
   });
 
-  test("the started session is owned by the composer it lands on", async () => {
-    // The bug this replaced: a hardcoded `null` conversation left the session
-    // owned by nobody, so the room never opened and the title-bar pill stood
-    // in for it.
+  test("a start binds to a conversation of its own, never the one the app was left on", async () => {
+    // The regression this guards: reading the store's selection attached the
+    // call to whatever thread the user was last in, which for a widget button
+    // or a Siri shortcut is an unrelated conversation from another day.
     identityHydrated();
     registerStarter();
-    useConversationStore.getState().setActiveConversationId("draft-1");
 
-    requestVoiceStart();
+    requestVoiceStart(navigate);
     await flushDrain();
 
-    expect(starter).toHaveBeenCalledWith("assistant-1", "draft-1");
+    const draftId = mintedConversationId();
+    expect(draftId).not.toBe(PRIOR_CONVERSATION_ID);
+    expect(starter).not.toHaveBeenCalledWith(
+      "assistant-1",
+      PRIOR_CONVERSATION_ID,
+    );
     expect(
-      isLiveVoiceSessionOwnedBy(useLiveVoiceStore.getState(), "draft-1"),
+      isLiveVoiceSessionOwnedBy(
+        useLiveVoiceStore.getState(),
+        PRIOR_CONVERSATION_ID,
+      ),
+    ).toBe(false);
+  });
+
+  test("the started session is owned by the composer the drain lands on", async () => {
+    // The bug this replaced: a session bound to a conversation no composer on
+    // screen is bound to is owned by nobody, so the room never opens and the
+    // title-bar pill stands in for it.
+    identityHydrated();
+    registerStarter();
+
+    requestVoiceStart(navigate);
+    await flushDrain();
+
+    const draftId = mintedConversationId();
+    expect(navigate).toHaveBeenCalledWith(routes.conversation(draftId), {
+      replace: true,
+    });
+    expect(
+      isLiveVoiceSessionOwnedBy(useLiveVoiceStore.getState(), draftId),
     ).toBe(true);
   });
 
-  test("mints a draft when nothing is selected", async () => {
-    // A cold launch straight into voice has no conversation yet. Minting one
-    // here is what gives the session a composer to belong to, and the chat
-    // view is what puts that composer on screen.
+  test("puts the chat on screen for the draft it mints", async () => {
+    // On desktop the composer counts as on screen only while the main view is
+    // the chat, so a draft minted behind the app viewer owns nothing.
     identityHydrated();
     registerStarter();
-    useConversationStore.getState().setActiveConversationId(null);
 
-    requestVoiceStart();
+    requestVoiceStart(navigate);
     await flushDrain();
 
-    const minted = useConversationStore.getState().activeConversationId;
-    expect(minted).not.toBeNull();
-    expect(starter).toHaveBeenCalledWith("assistant-1", minted);
     expect(useViewerStore.getState().mainView).toBe("chat");
   });
 
@@ -216,10 +269,11 @@ describe("starting a session", () => {
     identityHydrated();
     registerStarter();
 
-    await drainPendingVoiceStart();
+    await drainPendingVoiceStart(navigate);
 
     expect(whenAssistantVersionKnown).not.toHaveBeenCalled();
     expect(starter).not.toHaveBeenCalled();
+    expect(navigate).not.toHaveBeenCalled();
   });
 });
 
@@ -236,16 +290,16 @@ describe("a request that cannot be served yet stays parked", () => {
     useResolvedAssistantsStore.setState({ activeAssistantId: "assistant-1" });
     registerStarter();
 
-    requestVoiceStart();
-    await drainPendingVoiceStart();
+    requestVoiceStart(navigate);
+    await drainPendingVoiceStart(navigate);
 
     expect(starter).not.toHaveBeenCalled();
     expect(isParked()).toBe(true);
 
     // The identity lands and the next drain runs it.
     identityHydrated();
-    await drainPendingVoiceStart();
-    expect(starter).toHaveBeenCalledWith("assistant-1", ACTIVE_CONVERSATION_ID);
+    await drainPendingVoiceStart(navigate);
+    expectStartedOnFreshDraft();
   });
 
   test("the controller unmounts across the version await", async () => {
@@ -258,7 +312,7 @@ describe("a request that cannot be served yet stays parked", () => {
     });
 
     usePendingDeepLinkStore.getState().setPendingVoiceStart();
-    const drained = drainPendingVoiceStart();
+    const drained = drainPendingVoiceStart(navigate);
     // Navigating off the chat layout mid-await: there is no starter left to
     // hand this to.
     useLiveVoiceStore.getState().setStarter(null);
@@ -271,8 +325,8 @@ describe("a request that cannot be served yet stays parked", () => {
     // The next `ChatLayout` mount picks it up.
     versionResolution = Promise.resolve();
     registerStarter();
-    await drainPendingVoiceStart();
-    expect(starter).toHaveBeenCalledWith("assistant-1", ACTIVE_CONVERSATION_ID);
+    await drainPendingVoiceStart(navigate);
+    expectStartedOnFreshDraft();
   });
 });
 
@@ -288,11 +342,17 @@ describe("a request that will never be served is discarded", () => {
     identityHydrated("0.10.11");
     registerStarter();
 
-    requestVoiceStart();
-    await drainPendingVoiceStart();
+    requestVoiceStart(navigate);
+    await drainPendingVoiceStart(navigate);
 
     expect(starter).not.toHaveBeenCalled();
     expect(isParked()).toBe(false);
+    // No conversation is minted for a start that never happens, so the user is
+    // not left staring at an empty new chat.
+    expect(useConversationStore.getState().activeConversationId).toBe(
+      PRIOR_CONVERSATION_ID,
+    );
+    expect(navigate).not.toHaveBeenCalled();
   });
 
   test("a park older than its TTL", async () => {
@@ -305,10 +365,11 @@ describe("a request that will never be served is discarded", () => {
     usePendingDeepLinkStore.setState({
       pendingVoiceStartAt: Date.now() - PENDING_VOICE_START_TTL_MS - 1,
     });
-    await drainPendingVoiceStart();
+    await drainPendingVoiceStart(navigate);
 
     expect(starter).not.toHaveBeenCalled();
     expect(isParked()).toBe(false);
+    expect(navigate).not.toHaveBeenCalled();
   });
 
   test("a park inside its TTL still starts", async () => {
@@ -318,9 +379,9 @@ describe("a request that will never be served is discarded", () => {
     usePendingDeepLinkStore.setState({
       pendingVoiceStartAt: Date.now() - PENDING_VOICE_START_TTL_MS + 5_000,
     });
-    await drainPendingVoiceStart();
+    await drainPendingVoiceStart(navigate);
 
-    expect(starter).toHaveBeenCalledWith("assistant-1", ACTIVE_CONVERSATION_ID);
+    expectStartedOnFreshDraft();
   });
 });
 
@@ -333,23 +394,26 @@ describe("one-shot delivery", () => {
     identityHydrated();
     registerStarter();
 
-    requestVoiceStart();
-    await drainPendingVoiceStart();
-    await drainPendingVoiceStart();
-    await drainPendingVoiceStart();
+    requestVoiceStart(navigate);
+    await drainPendingVoiceStart(navigate);
+    await drainPendingVoiceStart(navigate);
+    await drainPendingVoiceStart(navigate);
 
     expect(starter).toHaveBeenCalledTimes(1);
+    // One start, so one draft: repeat drains must not mint a new conversation
+    // each time they run.
+    expect(navigate).toHaveBeenCalledTimes(1);
   });
 
   test("two links before a drain are one request", async () => {
     identityHydrated();
 
-    requestVoiceStart();
-    requestVoiceStart();
+    requestVoiceStart(navigate);
+    requestVoiceStart(navigate);
     await Promise.resolve();
 
     registerStarter();
-    await drainPendingVoiceStart();
+    await drainPendingVoiceStart(navigate);
 
     expect(starter).toHaveBeenCalledTimes(1);
   });
@@ -360,14 +424,13 @@ describe("one-shot delivery", () => {
 // ---------------------------------------------------------------------------
 
 describe("startVoiceFromSurface", () => {
-  test("navigates to the draft composer and parks the request", () => {
+  test("navigates to the chat and parks the request", () => {
     identityHydrated();
-    const navigate = mock((_to: string) => undefined);
 
     startVoiceFromSurface(navigate);
 
     // Navigating to the chat is what mounts the layout that owns the starter;
-    // the drain then binds the session to the composer it lands on.
+    // the drain then mints the conversation the session binds to.
     expect(navigate).toHaveBeenCalledWith("/assistant");
     expect(isParked()).toBe(true);
   });
@@ -376,7 +439,6 @@ describe("startVoiceFromSurface", () => {
     // The press lands where no chat layout is mounted, so nothing can serve it
     // yet. It must survive until one does rather than being spent on arrival.
     identityHydrated();
-    const navigate = mock((_to: string) => undefined);
 
     startVoiceFromSurface(navigate);
     await Promise.resolve();
@@ -384,16 +446,17 @@ describe("startVoiceFromSurface", () => {
     expect(isParked()).toBe(true);
 
     registerStarter();
-    await drainPendingVoiceStart();
+    await drainPendingVoiceStart(navigate);
 
-    expect(starter).toHaveBeenCalledWith("assistant-1", ACTIVE_CONVERSATION_ID);
+    // The press was made from outside the conversation the app was left on,
+    // and it opens a call of its own rather than resuming that thread.
+    expectStartedOnFreshDraft();
   });
 
   test("a running session spends the press", () => {
     identityHydrated();
     registerStarter();
     useLiveVoiceStore.getState().setState("listening");
-    const navigate = mock((_to: string) => undefined);
 
     startVoiceFromSurface(navigate);
 
@@ -416,7 +479,7 @@ describe("entry guards", () => {
     registerStarter();
     useVoicePrefsStore.setState({ firstRunSeen: false });
 
-    requestVoiceStart();
+    requestVoiceStart(navigate);
     await Promise.resolve();
     await Promise.resolve();
 
@@ -436,7 +499,7 @@ describe("entry guards", () => {
     registerStarter();
     useVoicePrefsStore.setState({ firstRunSeen: false });
 
-    requestVoiceStart();
+    requestVoiceStart(navigate);
     await Promise.resolve();
     await Promise.resolve();
 
@@ -453,7 +516,7 @@ describe("entry guards", () => {
     registerStarter();
     useVoicePrefsStore.setState({ firstRunSeen: true });
 
-    requestVoiceStart();
+    requestVoiceStart(navigate);
     await Promise.resolve();
     await Promise.resolve();
 
@@ -465,8 +528,8 @@ describe("entry guards", () => {
     registerStarter();
     preflightVerdict = { status: "not-ready", userMessage: "Set up a voice." };
 
-    requestVoiceStart();
-    await drainPendingVoiceStart();
+    requestVoiceStart(navigate);
+    await drainPendingVoiceStart(navigate);
 
     expect(useLiveVoiceStore.getState().configNotice).toBe("Set up a voice.");
     expect(starter).not.toHaveBeenCalled();
@@ -480,10 +543,10 @@ describe("entry guards", () => {
     registerStarter();
     preflightVerdict = null;
 
-    requestVoiceStart();
-    await drainPendingVoiceStart();
+    requestVoiceStart(navigate);
+    await drainPendingVoiceStart(navigate);
 
-    expect(starter).toHaveBeenCalledWith("assistant-1", ACTIVE_CONVERSATION_ID);
+    expectStartedOnFreshDraft();
     expect(useLiveVoiceStore.getState().configNotice).toBeNull();
   });
 
@@ -501,7 +564,7 @@ describe("entry guards", () => {
         }),
     );
 
-    const drain = drainPendingVoiceStart();
+    const drain = drainPendingVoiceStart(navigate);
     await Promise.resolve();
     await Promise.resolve();
     useLiveVoiceStore.getState().setStarter(null);

--- a/clients/web/src/domains/chat/voice/live-voice/start-voice-request.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/start-voice-request.test.ts
@@ -50,10 +50,12 @@ const {
   requestVoiceStart,
   startVoiceFromSurface,
 } = await import("@/domains/chat/voice/live-voice/start-voice-request");
-const { useLiveVoiceStore } =
+const { isLiveVoiceSessionOwnedBy, useLiveVoiceStore } =
   await import("@/domains/chat/voice/live-voice/live-voice-store");
 const { useAssistantIdentityStore } =
   await import("@/stores/assistant-identity-store");
+const { useConversationStore } = await import("@/stores/conversation-store");
+const { useViewerStore } = await import("@/stores/viewer-store");
 const { __resetPendingDeepLinkForTesting, usePendingDeepLinkStore } =
   await import("@/stores/pending-deep-link-store");
 const { useResolvedAssistantsStore } =
@@ -67,9 +69,19 @@ const { useVoicePrefsStore } = await import("@/stores/voice-prefs-store");
 /** New enough to serve `POST /v1/live-voice/preflight`. */
 const SUPPORTED_VERSION = "0.10.12";
 
-const starter = mock(
-  (_assistantId: string, _conversationId: string | null) => undefined,
-);
+/** The conversation the composer is sitting on unless a test says otherwise. */
+const ACTIVE_CONVERSATION_ID = "conv-active";
+
+/**
+ * Stands in for the controller's starter, and binds the session to the
+ * conversation it was handed exactly as `useLiveVoice` does at connect time.
+ * Ownership is the whole point of the argument, so a spy that only records it
+ * could not tell a bound session from an orphaned one.
+ */
+const starter = mock((assistantId: string, conversationId: string | null) => {
+  useLiveVoiceStore.getState().setSessionContext(assistantId, conversationId);
+  useLiveVoiceStore.getState().setState("listening");
+});
 
 function registerStarter(): void {
   useLiveVoiceStore.getState().setStarter({
@@ -114,6 +126,11 @@ beforeEach(() => {
     name: null,
   });
   useResolvedAssistantsStore.setState({ activeAssistantId: null });
+  useConversationStore.getState().reset();
+  useConversationStore
+    .getState()
+    .setActiveConversationId(ACTIVE_CONVERSATION_ID);
+  useViewerStore.getState().setMainView("app");
   starter.mockClear();
   whenAssistantVersionKnown.mockClear();
   preflightLiveVoice.mockClear();
@@ -138,9 +155,9 @@ describe("starting a session", () => {
     requestVoiceStart();
     await flushDrain();
 
-    // `null` conversation is the supported "new conversation" start — the
-    // server assigns one and echoes it on `ready`.
-    expect(starter).toHaveBeenCalledWith("assistant-1", null);
+    // Bound to the conversation the composer is on, which is what lets that
+    // composer own the session and show the room.
+    expect(starter).toHaveBeenCalledWith("assistant-1", ACTIVE_CONVERSATION_ID);
     expect(isParked()).toBe(false);
   });
 
@@ -157,8 +174,42 @@ describe("starting a session", () => {
     registerStarter();
     await drainPendingVoiceStart();
 
-    expect(starter).toHaveBeenCalledWith("assistant-1", null);
+    expect(starter).toHaveBeenCalledWith("assistant-1", ACTIVE_CONVERSATION_ID);
     expect(isParked()).toBe(false);
+  });
+
+  test("the started session is owned by the composer it lands on", async () => {
+    // The bug this replaced: a hardcoded `null` conversation left the session
+    // owned by nobody, so the room never opened and the title-bar pill stood
+    // in for it.
+    identityHydrated();
+    registerStarter();
+    useConversationStore.getState().setActiveConversationId("draft-1");
+
+    requestVoiceStart();
+    await flushDrain();
+
+    expect(starter).toHaveBeenCalledWith("assistant-1", "draft-1");
+    expect(
+      isLiveVoiceSessionOwnedBy(useLiveVoiceStore.getState(), "draft-1"),
+    ).toBe(true);
+  });
+
+  test("mints a draft when nothing is selected", async () => {
+    // A cold launch straight into voice has no conversation yet. Minting one
+    // here is what gives the session a composer to belong to, and the chat
+    // view is what puts that composer on screen.
+    identityHydrated();
+    registerStarter();
+    useConversationStore.getState().setActiveConversationId(null);
+
+    requestVoiceStart();
+    await flushDrain();
+
+    const minted = useConversationStore.getState().activeConversationId;
+    expect(minted).not.toBeNull();
+    expect(starter).toHaveBeenCalledWith("assistant-1", minted);
+    expect(useViewerStore.getState().mainView).toBe("chat");
   });
 
   test("draining with nothing parked never touches the version gate", async () => {
@@ -194,7 +245,7 @@ describe("a request that cannot be served yet stays parked", () => {
     // The identity lands and the next drain runs it.
     identityHydrated();
     await drainPendingVoiceStart();
-    expect(starter).toHaveBeenCalledWith("assistant-1", null);
+    expect(starter).toHaveBeenCalledWith("assistant-1", ACTIVE_CONVERSATION_ID);
   });
 
   test("the controller unmounts across the version await", async () => {
@@ -221,7 +272,7 @@ describe("a request that cannot be served yet stays parked", () => {
     versionResolution = Promise.resolve();
     registerStarter();
     await drainPendingVoiceStart();
-    expect(starter).toHaveBeenCalledWith("assistant-1", null);
+    expect(starter).toHaveBeenCalledWith("assistant-1", ACTIVE_CONVERSATION_ID);
   });
 });
 
@@ -269,7 +320,7 @@ describe("a request that will never be served is discarded", () => {
     });
     await drainPendingVoiceStart();
 
-    expect(starter).toHaveBeenCalledWith("assistant-1", null);
+    expect(starter).toHaveBeenCalledWith("assistant-1", ACTIVE_CONVERSATION_ID);
   });
 });
 
@@ -315,9 +366,8 @@ describe("startVoiceFromSurface", () => {
 
     startVoiceFromSurface(navigate);
 
-    // The draft route, not the open conversation: the session starts with no
-    // conversation and the server assigns one on `ready`. Navigating is also
-    // what mounts the layout that owns the starter.
+    // Navigating to the chat is what mounts the layout that owns the starter;
+    // the drain then binds the session to the composer it lands on.
     expect(navigate).toHaveBeenCalledWith("/assistant");
     expect(isParked()).toBe(true);
   });
@@ -336,7 +386,7 @@ describe("startVoiceFromSurface", () => {
     registerStarter();
     await drainPendingVoiceStart();
 
-    expect(starter).toHaveBeenCalledWith("assistant-1", null);
+    expect(starter).toHaveBeenCalledWith("assistant-1", ACTIVE_CONVERSATION_ID);
   });
 
   test("a running session spends the press", () => {
@@ -433,7 +483,7 @@ describe("entry guards", () => {
     requestVoiceStart();
     await drainPendingVoiceStart();
 
-    expect(starter).toHaveBeenCalledWith("assistant-1", null);
+    expect(starter).toHaveBeenCalledWith("assistant-1", ACTIVE_CONVERSATION_ID);
     expect(useLiveVoiceStore.getState().configNotice).toBeNull();
   });
 

--- a/clients/web/src/domains/chat/voice/live-voice/start-voice-request.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/start-voice-request.test.ts
@@ -235,9 +235,8 @@ describe("starting a session", () => {
   });
 
   test("the started session is owned by the composer the drain lands on", async () => {
-    // The bug this replaced: a session bound to a conversation no composer on
-    // screen is bound to is owned by nobody, so the room never opens and the
-    // title-bar pill stands in for it.
+    // A session without an owning on-screen composer cannot open the room;
+    // the title-bar pill stands in for it instead.
     identityHydrated();
     registerStarter();
 

--- a/clients/web/src/domains/chat/voice/live-voice/start-voice-request.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/start-voice-request.ts
@@ -20,6 +20,7 @@
  * when it registers a starter. No polling, no retry timer.
  */
 
+import { createDraftConversationId } from "@/domains/chat/utils/conversation-selection";
 import {
   isLiveVoiceSessionActive,
   useLiveVoiceStore,
@@ -33,8 +34,10 @@ import { supportsLiveVoice } from "@/lib/backwards-compat/use-supports-live-voic
 import { ensureMainWindowVisible } from "@/runtime/main-window";
 import { whenAssistantVersionKnown } from "@/lib/backwards-compat/utils";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
+import { useConversationStore } from "@/stores/conversation-store";
 import { usePendingDeepLinkStore } from "@/stores/pending-deep-link-store";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+import { useViewerStore } from "@/stores/viewer-store";
 import { routes } from "@/utils/routes";
 
 /**
@@ -49,6 +52,33 @@ import { routes } from "@/utils/routes";
  * cold launch and far shorter than "later".
  */
 export const PENDING_VOICE_START_TTL_MS = 60_000;
+
+/**
+ * The conversation the session belongs to: whatever is selected, or a fresh
+ * draft when nothing is.
+ *
+ * A session must be bound to a composer key or no composer can own it
+ * (`isLiveVoiceSessionOwnedBy`), which leaves the title-bar pill as the only
+ * surface for a session the user asked for full-screen. Read-else-mint is
+ * race-proof against the conversation loader in both directions: if this runs
+ * first the loader sees a selected id and stands down, and if the loader runs
+ * first this reads its draft.
+ *
+ * Mirrors the push-to-talk bridge's `ensureConversationKey`, `setMainView`
+ * included: on desktop the composer counts as on screen only while the main
+ * view is the chat.
+ */
+function ensureConversationKey(): string {
+  const existing = useConversationStore.getState().activeConversationId;
+  if (existing) {
+    return existing;
+  }
+
+  const draftId = createDraftConversationId();
+  useConversationStore.getState().setActiveConversationId(draftId);
+  useViewerStore.getState().setMainView("chat");
+  return draftId;
+}
 
 /**
  * Ask for a live-voice session.
@@ -74,9 +104,10 @@ export function requestVoiceStart(): void {
  *   the user is in; the starter refuses a second anyway, and navigating would
  *   only walk the app away from the composer that owns it. Callers that toggle
  *   handle the end themselves before reaching here.
- * - **The draft composer, so the session starts with no conversation** and the
- *   server assigns one on `ready`. Navigating is also what mounts `ChatLayout`
- *   and therefore the starter the request is waiting for.
+ * - **The chat, so a composer is on screen to own the session.** The drain
+ *   binds the session to whichever conversation that lands on. Navigating is
+ *   also what mounts `ChatLayout` and therefore the starter the request is
+ *   waiting for.
  * - **The window is not raised for an ordinary start.** Every caller is a
  *   surface the user reached for precisely because they are working somewhere
  *   else, and that surface is where the call then shows itself. The one
@@ -180,12 +211,9 @@ export async function drainPendingVoiceStart(): Promise<void> {
   if (!consume()) {
     return;
   }
-  // `null` conversation is the supported "new conversation" start: the server
-  // assigns one and echoes it on the `ready` frame (`LiveVoiceState.conversationId`).
-  //
   // No `prewarm()` here, unlike the composer: prewarming exists to unlock
   // playback while a user gesture is still active, and this path has no gesture
   // to borrow (Siri, the Action Button, a Live Activity tap). `start()` creates
   // its own player when none was reserved.
-  readyStarter.start(assistantId, null);
+  readyStarter.start(assistantId, ensureConversationKey());
 }

--- a/clients/web/src/domains/chat/voice/live-voice/start-voice-request.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/start-voice-request.ts
@@ -20,7 +20,6 @@
  * when it registers a starter. No polling, no retry timer.
  */
 
-import { createDraftConversationId } from "@/domains/chat/utils/conversation-selection";
 import {
   isLiveVoiceSessionActive,
   useLiveVoiceStore,
@@ -30,14 +29,13 @@ import {
   publishConfigNotice,
   voiceReadiness,
 } from "@/domains/chat/voice/live-voice/voice-entry-guards";
+import { mintVoiceDraftConversation } from "@/domains/chat/voice/voice-draft-conversation";
 import { supportsLiveVoice } from "@/lib/backwards-compat/use-supports-live-voice";
 import { ensureMainWindowVisible } from "@/runtime/main-window";
 import { whenAssistantVersionKnown } from "@/lib/backwards-compat/utils";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
-import { useConversationStore } from "@/stores/conversation-store";
 import { usePendingDeepLinkStore } from "@/stores/pending-deep-link-store";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
-import { useViewerStore } from "@/stores/viewer-store";
 import { routes } from "@/utils/routes";
 
 /**
@@ -54,29 +52,43 @@ import { routes } from "@/utils/routes";
 export const PENDING_VOICE_START_TTL_MS = 60_000;
 
 /**
- * The conversation the session belongs to: whatever is selected, or a fresh
- * draft when nothing is.
+ * The navigation a start needs from its caller: a path, and whether it
+ * replaces the entry it lands on.
  *
- * A session must be bound to a composer key or no composer can own it
- * (`isLiveVoiceSessionOwnedBy`), which leaves the title-bar pill as the only
- * surface for a session the user asked for full-screen. Read-else-mint is
- * race-proof against the conversation loader in both directions: if this runs
- * first the loader sees a selected id and stands down, and if the loader runs
- * first this reads its draft.
- *
- * Mirrors the push-to-talk bridge's `ensureConversationKey`, `setMainView`
- * included: on desktop the composer counts as on screen only while the main
- * view is the chat.
+ * Structural rather than react-router's `NavigateFunction` so a caller can
+ * hand over a wrapper that reads its own `navigate` ref. The drain navigates
+ * after two awaits, by which time a captured `navigate` may belong to a
+ * location the app has moved on from.
  */
-function ensureConversationKey(): string {
-  const existing = useConversationStore.getState().activeConversationId;
-  if (existing) {
-    return existing;
-  }
+export type VoiceStartNavigate = (
+  to: string,
+  options?: { replace?: boolean },
+) => unknown;
 
-  const draftId = createDraftConversationId();
-  useConversationStore.getState().setActiveConversationId(draftId);
-  useViewerStore.getState().setMainView("chat");
+/**
+ * The conversation a start-voice request opens into: a fresh draft, always.
+ *
+ * Never whatever the conversation store has selected. That selection survives
+ * navigation and cold launches by design, so it is wherever the user last was,
+ * while every surface that reaches this drain means *new*: the widget button,
+ * the Action Button, Control Center, a Siri shortcut, the Talk shortcut.
+ * Reading it would attach the call to an unrelated thread.
+ *
+ * Landing on the draft is the other half of the binding rather than a nicety.
+ * A session is owned by the composer bound to its conversation
+ * ({@link isLiveVoiceSessionOwnedBy}), and the composer on screen is the one
+ * the URL names, so a draft minted while the URL sits elsewhere is a session
+ * nothing on screen owns, leaving the title-bar pill standing in for the room
+ * the user asked for. `replace` because the entry it overwrites is the
+ * `routes.assistant` step on the way here, not a place the user chose.
+ *
+ * The conversation loader lands on the same draft rather than fighting this:
+ * the id is in the store before the navigation, and the URL key it resolves
+ * next is that same id.
+ */
+function bindFreshConversation(navigate: VoiceStartNavigate): string {
+  const draftId = mintVoiceDraftConversation();
+  void navigate(routes.conversation(draftId), { replace: true });
   return draftId;
 }
 
@@ -86,10 +98,13 @@ function ensureConversationKey(): string {
  * Always parks first, then drains: one code path for both the warm case (a
  * controller is already mounted, so the drain starts immediately) and the
  * cold-launch case (the drain no-ops and the controller picks the request up).
+ *
+ * `navigate` serves the warm case only. A parked request is drained by the
+ * controller, which navigates with its own.
  */
-export function requestVoiceStart(): void {
+export function requestVoiceStart(navigate: VoiceStartNavigate): void {
   usePendingDeepLinkStore.getState().setPendingVoiceStart();
-  void drainPendingVoiceStart();
+  void drainPendingVoiceStart(navigate);
 }
 
 /**
@@ -104,22 +119,21 @@ export function requestVoiceStart(): void {
  *   the user is in; the starter refuses a second anyway, and navigating would
  *   only walk the app away from the composer that owns it. Callers that toggle
  *   handle the end themselves before reaching here.
- * - **The chat, so a composer is on screen to own the session.** The drain
- *   binds the session to whichever conversation that lands on. Navigating is
- *   also what mounts `ChatLayout` and therefore the starter the request is
- *   waiting for.
+ * - **The chat, so the layout that owns the starter is mounted.** That is all
+ *   this navigation is for: the drain mints the conversation the session binds
+ *   to and lands on it from here.
  * - **The window is not raised for an ordinary start.** Every caller is a
  *   surface the user reached for precisely because they are working somewhere
  *   else, and that surface is where the call then shows itself. The one
  *   exception is the first-run card below: it asks a question, and a question
  *   drawn behind whatever the user is working in is a press that did nothing.
  */
-export function startVoiceFromSurface(navigate: (to: string) => unknown): void {
+export function startVoiceFromSurface(navigate: VoiceStartNavigate): void {
   if (isLiveVoiceSessionActive(useLiveVoiceStore.getState().state)) {
     return;
   }
   void navigate(routes.assistant);
-  requestVoiceStart();
+  requestVoiceStart(navigate);
 }
 
 /**
@@ -137,7 +151,9 @@ export function startVoiceFromSurface(navigate: (to: string) => unknown): void {
  * launch against a hibernating assistant, where the version resolution can hit
  * its timeout with `version` still `null`.
  */
-export async function drainPendingVoiceStart(): Promise<void> {
+export async function drainPendingVoiceStart(
+  navigate: VoiceStartNavigate,
+): Promise<void> {
   if (usePendingDeepLinkStore.getState().pendingVoiceStartAt === null) {
     return;
   }
@@ -215,5 +231,5 @@ export async function drainPendingVoiceStart(): Promise<void> {
   // playback while a user gesture is still active, and this path has no gesture
   // to borrow (Siri, the Action Button, a Live Activity tap). `start()` creates
   // its own player when none was reserved.
-  readyStarter.start(assistantId, ensureConversationKey());
+  readyStarter.start(assistantId, bindFreshConversation(navigate));
 }

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.test.tsx
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.test.tsx
@@ -15,6 +15,7 @@
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { act, cleanup, renderHook } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
 import type { VoiceAudioInterruptionEvent } from "@/runtime/native-audio-session";
 
 // The default client factory in use-live-voice statically imports the real
@@ -124,23 +125,30 @@ function renderPersistentController(
 
   let renderCount = 0;
 
-  const view = renderHook(() => {
-    renderCount += 1;
-    useLiveVoiceSessionController({
-      createClient: () => {
-        const client = new FakeClient();
-        clients.push(client);
-        return client as unknown as LiveVoiceChannelClient;
-      },
-      createPlayer: () => player as unknown as LiveVoiceAudioPlayer,
-      createCapture: (options) => {
-        const capture = new FakeCapture(options);
-        configureCapture?.(capture);
-        captures.push(capture);
-        return capture as unknown as LiveVoiceAudioCapture;
-      },
-    });
-  });
+  // Under a router because the controller lands on the conversation a drained
+  // start-voice request mints for its session, exactly as `ChatLayout` does.
+  const view = renderHook(
+    () => {
+      renderCount += 1;
+      useLiveVoiceSessionController({
+        createClient: () => {
+          const client = new FakeClient();
+          clients.push(client);
+          return client as unknown as LiveVoiceChannelClient;
+        },
+        createPlayer: () => player as unknown as LiveVoiceAudioPlayer,
+        createCapture: (options) => {
+          const capture = new FakeCapture(options);
+          configureCapture?.(capture);
+          captures.push(capture);
+          return capture as unknown as LiveVoiceAudioCapture;
+        },
+      });
+    },
+    {
+      wrapper: ({ children }) => <MemoryRouter>{children}</MemoryRouter>,
+    },
+  );
 
   return {
     view,
@@ -282,11 +290,17 @@ describe("starter registration", () => {
       await Promise.resolve();
     });
 
-    // The drain binds the session to the composer on screen, which is what
-    // lets that composer own it and show the room.
+    // The drain mints a conversation for the session and lands on it, so the
+    // composer there can own it and show the room. Not `conv-1`: a start asked
+    // for from outside the chat is a new call, and the selection it finds is
+    // just wherever the user was last.
+    const draftId =
+      useConversationStore.getState().activeConversationId ?? undefined;
+    expect(draftId).toBeDefined();
+    expect(draftId).not.toBe("conv-1");
     expect(h.lastClient().connectArgs).toEqual({
       assistantId: "assistant-1",
-      conversationId: "conv-1",
+      conversationId: draftId,
       turnDetection: "server_vad",
     });
     expect(usePendingDeepLinkStore.getState().pendingVoiceStartAt).toBeNull();

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.test.tsx
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.test.tsx
@@ -108,6 +108,7 @@ const { __resetPendingDeepLinkForTesting, usePendingDeepLinkStore } =
   await import("@/stores/pending-deep-link-store");
 const { useLiveVoiceStore } =
   await import("@/domains/chat/voice/live-voice/live-voice-store");
+const { useConversationStore } = await import("@/stores/conversation-store");
 
 // ---------------------------------------------------------------------------
 // Harness
@@ -191,6 +192,7 @@ beforeEach(() => {
     firstRunSeen: true,
   });
   __resetPendingDeepLinkForTesting();
+  useConversationStore.getState().reset();
   useAssistantIdentityStore.setState({ assistantId: null, version: null });
   useResolvedAssistantsStore.setState({ activeAssistantId: null });
   interruptionHandlers = [];
@@ -271,6 +273,7 @@ describe("starter registration", () => {
       version: "0.10.12",
     });
     useResolvedAssistantsStore.setState({ activeAssistantId: "assistant-1" });
+    useConversationStore.getState().setActiveConversationId("conv-1");
     usePendingDeepLinkStore.getState().setPendingVoiceStart();
 
     const h = renderPersistentController();
@@ -279,9 +282,11 @@ describe("starter registration", () => {
       await Promise.resolve();
     });
 
+    // The drain binds the session to the composer on screen, which is what
+    // lets that composer own it and show the room.
     expect(h.lastClient().connectArgs).toEqual({
       assistantId: "assistant-1",
-      conversationId: undefined,
+      conversationId: "conv-1",
       turnDetection: "server_vad",
     });
     expect(usePendingDeepLinkStore.getState().pendingVoiceStartAt).toBeNull();

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.ts
@@ -31,7 +31,8 @@
  * what its buttons do ({@link useLiveActivityControls}).
  */
 
-import { useEffect } from "react";
+import { useEffect, useLayoutEffect, useRef } from "react";
+import { useNavigate } from "react-router";
 
 import {
   useLiveVoice,
@@ -174,6 +175,16 @@ export function useLiveVoiceSessionController(
     observeAudioState: false,
   });
 
+  // A parked start-voice request is drained here, and the drain lands on the
+  // conversation it mints for the session (see `start-voice-request.ts`). Held
+  // in a ref, and read only when the drain gets that far, so a fresh
+  // `navigate` identity never re-registers the starter.
+  const navigate = useNavigate();
+  const navigateRef = useRef(navigate);
+  useLayoutEffect(() => {
+    navigateRef.current = navigate;
+  });
+
   useEffect(() => {
     useLiveVoiceStore.getState().setStarter({
       prewarm: prewarmPlayback,
@@ -191,7 +202,9 @@ export function useLiveVoiceSessionController(
     // A start-voice deep link that arrived before this mount (cold launch from
     // Siri / the Action Button / a Live Activity tap) is parked; now that a
     // starter exists, run it. One-shot, so the re-runs of this effect are free.
-    void drainPendingVoiceStart();
+    void drainPendingVoiceStart((to, navigateOptions) =>
+      navigateRef.current(to, navigateOptions),
+    );
     return () => {
       useLiveVoiceStore.getState().setStarter(null);
     };

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
@@ -54,6 +54,7 @@ const {
   restoreVoiceRoom,
 } = await import("@/domains/chat/voice/live-voice/live-voice-store");
 const { useVoicePrefsStore } = await import("@/stores/voice-prefs-store");
+const { useConversationStore } = await import("@/stores/conversation-store");
 
 // ---------------------------------------------------------------------------
 // Harness
@@ -2333,6 +2334,90 @@ describe("session context and controls", () => {
     expect(store.controls).toBeNull();
     expect(store.assistantId).toBeNull();
     expect(store.conversationId).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Draft materialization
+// ---------------------------------------------------------------------------
+
+describe("draft materialization", () => {
+  const isDraft = (conversationId: string): boolean =>
+    useConversationStore.getState().draftConversationIds.has(conversationId);
+
+  beforeEach(() => {
+    useConversationStore.getState().reset();
+  });
+
+  afterEach(() => {
+    useConversationStore.getState().reset();
+  });
+
+  /** Open a session bound to `conversationId` and drive it to `ready`. */
+  async function startOn(
+    h: ReturnType<typeof renderController>,
+    conversationId: string,
+  ) {
+    await act(async () => {
+      await h.view.result.current.start("assistant-1", conversationId);
+    });
+    await act(async () => {
+      h.client.emit("ready", {
+        type: "ready",
+        seq: 1,
+        sessionId: "s1",
+        conversationId,
+      });
+      await Promise.resolve();
+    });
+  }
+
+  /** The frame the daemon sends as it dispatches a turn. */
+  async function emitThinking(h: ReturnType<typeof renderController>) {
+    await act(async () => {
+      h.client.emit("thinking", { type: "thinking", seq: 2, turnId: "t1" });
+      await Promise.resolve();
+    });
+  }
+
+  test("a dispatched turn stops the started conversation being a draft", async () => {
+    // The composer's voice button starts on whatever key it is bound to, and a
+    // new chat's key is a client-minted draft, so this covers that route as
+    // much as the deep-link drain's freshly minted one.
+    useConversationStore.getState().registerDraftConversationId("conv-draft");
+    const h = renderController();
+    await startOn(h, "conv-draft");
+    // `ready` is not the row: the daemon mints it on the first dispatch.
+    expect(isDraft("conv-draft")).toBe(true);
+
+    await emitThinking(h);
+
+    expect(isDraft("conv-draft")).toBe(false);
+  });
+
+  test("a session that produces no turn leaves the draft intact", async () => {
+    useConversationStore.getState().registerDraftConversationId("conv-draft");
+    const h = renderController();
+    await startOn(h, "conv-draft");
+
+    await act(async () => {
+      await h.view.result.current.stop();
+    });
+
+    // Nothing was said, so nothing exists server-side to stop being a draft.
+    expect(isDraft("conv-draft")).toBe(true);
+  });
+
+  test("a turn clears only the conversation its own session started on", async () => {
+    useConversationStore.getState().registerDraftConversationId("conv-draft");
+    useConversationStore.getState().registerDraftConversationId("conv-other");
+    const h = renderController();
+    await startOn(h, "conv-draft");
+
+    await emitThinking(h);
+
+    expect(isDraft("conv-draft")).toBe(false);
+    expect(isDraft("conv-other")).toBe(true);
   });
 });
 

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
@@ -55,6 +55,8 @@ const {
 } = await import("@/domains/chat/voice/live-voice/live-voice-store");
 const { useVoicePrefsStore } = await import("@/stores/voice-prefs-store");
 const { useConversationStore } = await import("@/stores/conversation-store");
+const { reconcileMaterializedDrafts } =
+  await import("@/domains/chat/hooks/use-materialized-draft-reconcile");
 
 // ---------------------------------------------------------------------------
 // Harness
@@ -2372,7 +2374,7 @@ describe("draft materialization", () => {
     });
   }
 
-  /** The frame the daemon sends as it dispatches a turn. */
+  /** The frame the daemon sends as a turn begins, ahead of any row. */
   async function emitThinking(h: ReturnType<typeof renderController>) {
     await act(async () => {
       h.client.emit("thinking", { type: "thinking", seq: 2, turnId: "t1" });
@@ -2380,41 +2382,46 @@ describe("draft materialization", () => {
     });
   }
 
-  test("a dispatched turn stops the started conversation being a draft", async () => {
+  test("a dispatched turn whose row reaches the list stops being a draft", async () => {
     // The composer's voice button starts on whatever key it is bound to, and a
     // new chat's key is a client-minted draft, so this covers that route as
     // much as the deep-link drain's freshly minted one.
     useConversationStore.getState().registerDraftConversationId("conv-draft");
     const h = renderController();
     await startOn(h, "conv-draft");
-    // `ready` is not the row: the daemon mints it on the first dispatch.
+    await emitThinking(h);
+    // The frame alone is a promise of a turn, not a row.
     expect(isDraft("conv-draft")).toBe(true);
 
-    await emitThinking(h);
+    reconcileMaterializedDrafts(["conv-draft"]);
 
     expect(isDraft("conv-draft")).toBe(false);
   });
 
-  test("a session that produces no turn leaves the draft intact", async () => {
+  test("a turn cancelled before its row exists leaves the draft intact", async () => {
     useConversationStore.getState().registerDraftConversationId("conv-draft");
     const h = renderController();
     await startOn(h, "conv-draft");
+    await emitThinking(h);
 
     await act(async () => {
       await h.view.result.current.stop();
     });
+    // Cancellation means the turn never dispatched, so no row was written and
+    // every list the client sees from here holds only what existed before.
+    reconcileMaterializedDrafts(["conv-unrelated"]);
 
-    // Nothing was said, so nothing exists server-side to stop being a draft.
     expect(isDraft("conv-draft")).toBe(true);
   });
 
-  test("a turn clears only the conversation its own session started on", async () => {
+  test("a materialized row clears only its own key", async () => {
     useConversationStore.getState().registerDraftConversationId("conv-draft");
     useConversationStore.getState().registerDraftConversationId("conv-other");
     const h = renderController();
     await startOn(h, "conv-draft");
-
     await emitThinking(h);
+
+    reconcileMaterializedDrafts(["conv-draft"]);
 
     expect(isDraft("conv-draft")).toBe(false);
     expect(isDraft("conv-other")).toBe(true);

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -99,7 +99,6 @@ import {
   useLiveVoiceStore,
   type LiveVoiceSessionState,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
-import { useConversationStore } from "@/stores/conversation-store";
 import {
   interruptSensitivityToMs,
   useVoicePrefsStore,
@@ -903,26 +902,13 @@ export function useLiveVoice(
           if (!live()) {
             return;
           }
-          // Dispatching the first turn is what mints the conversation row
-          // server-side (`defaultStartVoiceTurn` ensures it exists before
-          // persisting the user message, then publishes the conversation-list
-          // invalidation), so a client-minted key stops being a draft here,
-          // exactly as a text send stops being one once its POST returns. Not
-          // on `ready`: a session that opens and never speaks leaves no row, so
-          // clearing at start would strand a key naming nothing. Not on
-          // `archived`: audio archiving is off by default, so that frame
-          // usually never arrives. Both entry points pass through, the
-          // composer's voice button (bound to whatever conversation is on
-          // screen, drafts included) and the deep-link drain's own mint.
-          // The start-time key, not the id `ready` republished: the daemon
-          // adopts the client's verbatim, and an id it picked for itself was
-          // never a draft. Clearing a non-draft is a no-op, so the repeat on
-          // later turns is free.
-          if (conversationId !== undefined) {
-            useConversationStore
-              .getState()
-              .clearDraftConversationId(conversationId);
-          }
+          // No draft bookkeeping here. `thinking` is sent before the turn is
+          // dispatched and the session can still return early on cancellation,
+          // so the row this frame promises may never be written. The draft mark
+          // is cleared where the row is confirmed instead, by
+          // `useMaterializedDraftReconcile` against the fetched conversation
+          // list.
+          //
           // New response: reset the per-response transcript and barge-in flags.
           session.responseEpoch += 1;
           session.responseAudioStarted = false;

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -99,6 +99,7 @@ import {
   useLiveVoiceStore,
   type LiveVoiceSessionState,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
+import { useConversationStore } from "@/stores/conversation-store";
 import {
   interruptSensitivityToMs,
   useVoicePrefsStore,
@@ -901,6 +902,26 @@ export function useLiveVoice(
         client.on("thinking", () => {
           if (!live()) {
             return;
+          }
+          // Dispatching the first turn is what mints the conversation row
+          // server-side (`defaultStartVoiceTurn` ensures it exists before
+          // persisting the user message, then publishes the conversation-list
+          // invalidation), so a client-minted key stops being a draft here,
+          // exactly as a text send stops being one once its POST returns. Not
+          // on `ready`: a session that opens and never speaks leaves no row, so
+          // clearing at start would strand a key naming nothing. Not on
+          // `archived`: audio archiving is off by default, so that frame
+          // usually never arrives. Both entry points pass through, the
+          // composer's voice button (bound to whatever conversation is on
+          // screen, drafts included) and the deep-link drain's own mint.
+          // The start-time key, not the id `ready` republished: the daemon
+          // adopts the client's verbatim, and an id it picked for itself was
+          // never a draft. Clearing a non-draft is a no-op, so the repeat on
+          // later turns is free.
+          if (conversationId !== undefined) {
+            useConversationStore
+              .getState()
+              .clearDraftConversationId(conversationId);
           }
           // New response: reset the per-response transcript and barge-in flags.
           session.responseEpoch += 1;

--- a/clients/web/src/domains/chat/voice/voice-draft-conversation.ts
+++ b/clients/web/src/domains/chat/voice/voice-draft-conversation.ts
@@ -1,0 +1,35 @@
+/**
+ * The one place voice mints a conversation to talk into.
+ *
+ * Voice is reachable from surfaces that hold no composer key: a
+ * `<scheme>://voice` link (a widget button, the Action Button, Control Center,
+ * a Siri shortcut), the Talk shortcut, push-to-talk on a route with nothing
+ * selected. Each of them needs the same thing from a new key, so the sequence
+ * lives here rather than once per entry point and the entries cannot drift
+ * into different ideas of what a fresh chat is.
+ *
+ * What differs between them is *when* they want one, which stays at the call
+ * site: the start-voice drain mints unconditionally (a start asked for from
+ * outside the chat is a new call), while push-to-talk dictates into whatever
+ * conversation is already selected and only mints when none is.
+ *
+ * `setMainView("chat")` is part of the mint rather than a step after it. On
+ * desktop the composer counts as on screen only while the main view is the
+ * chat ({@link useComposerOnScreen}), so a draft minted behind the app viewer
+ * would be a conversation with no composer to speak into.
+ */
+
+import { createDraftConversationId } from "@/domains/chat/utils/conversation-selection";
+import { useConversationStore } from "@/stores/conversation-store";
+import { useViewerStore } from "@/stores/viewer-store";
+
+/**
+ * Mint a fresh draft conversation, select it, and put the chat on screen.
+ * Returns the draft's id, which is the key its composer is bound to.
+ */
+export function mintVoiceDraftConversation(): string {
+  const draftId = createDraftConversationId();
+  useConversationStore.getState().setActiveConversationId(draftId);
+  useViewerStore.getState().setMainView("chat");
+  return draftId;
+}

--- a/clients/web/src/domains/chat/voice/voice-room/use-is-voice-room-visible.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/use-is-voice-room-visible.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * The room/pill complement for a session started from outside the composer.
+ *
+ * A `<scheme>://voice` link (widget button, Siri, the Action Button) starts
+ * its session through `drainPendingVoiceStart`, with no composer involved in
+ * the press. The user still expects the full-screen room, and the room only
+ * renders for a session the on-screen composer owns, so the binding the drain
+ * chooses is what decides between the room and the title-bar pill standing in
+ * for it. That end-to-end path is asserted here rather than in
+ * `start-voice-request.test.ts`, which sees the starter argument but not what
+ * renders because of it.
+ *
+ * Mocked: the router (mutable pathname), `useIsMobile`, the pill's avatar hook
+ * and navigation util (heavy dependency graphs), and the two live-voice
+ * preflight seams the drain awaits.
+ */
+
+import { afterEach, beforeEach, expect, mock, test } from "bun:test";
+
+import { cleanup, render, renderHook } from "@testing-library/react";
+
+import { routes } from "@/utils/routes";
+
+const utils = await import("@/lib/backwards-compat/utils");
+const whenAssistantVersionKnown = mock(() => Promise.resolve());
+mock.module("@/lib/backwards-compat/utils", () => ({
+  ...utils,
+  whenAssistantVersionKnown,
+}));
+
+mock.module("@/runtime/main-window", () => ({
+  ensureMainWindowVisible: () => Promise.resolve(),
+}));
+
+const preflightLiveVoice = mock(async () => ({ status: "ready" }));
+mock.module("@/domains/chat/voice/live-voice/live-voice-preflight-api", () => ({
+  preflightLiveVoice,
+}));
+
+let mockPathname: string = routes.assistant;
+const navigateFn = mock(() => {});
+mock.module("react-router", () => ({
+  useLocation: () => ({ pathname: mockPathname, search: "" }),
+  useNavigate: () => navigateFn,
+}));
+
+mock.module("@/hooks/use-is-mobile", () => ({
+  useIsMobile: () => false,
+  MOBILE_MEDIA_QUERY: "(max-width: 767px)",
+}));
+
+mock.module("@/utils/conversation-navigation", () => ({
+  navigateToConversation: () => {},
+}));
+
+mock.module("@/hooks/use-assistant-avatar", () => ({
+  useAssistantAvatar: () => ({
+    components: null,
+    traits: null,
+    customImageUrl: null,
+    isLoading: false,
+    invalidate: () => {},
+  }),
+}));
+
+// Imported after the mocks so every module below picks them up.
+const { requestVoiceStart } =
+  await import("@/domains/chat/voice/live-voice/start-voice-request");
+const { useLiveVoiceStore } =
+  await import("@/domains/chat/voice/live-voice/live-voice-store");
+const { useIsVoiceRoomVisible } =
+  await import("@/domains/chat/voice/voice-room/use-is-voice-room-visible");
+const { VoiceSessionPillHost } =
+  await import("@/domains/chat/components/voice-session-pill-host");
+const { useAssistantIdentityStore } =
+  await import("@/stores/assistant-identity-store");
+const { __resetPendingDeepLinkForTesting } =
+  await import("@/stores/pending-deep-link-store");
+const { useResolvedAssistantsStore } =
+  await import("@/stores/resolved-assistants-store");
+const { useConversationStore } = await import("@/stores/conversation-store");
+const { useViewerStore } = await import("@/stores/viewer-store");
+const { useVoicePrefsStore } = await import("@/stores/voice-prefs-store");
+
+const CONVERSATION_ID = "conv-owning";
+
+/** The controller's starter, binding the session as `useLiveVoice` does. */
+function registerStarter(): void {
+  useLiveVoiceStore.getState().setStarter({
+    prewarm: () => {},
+    cancelPrewarm: () => {},
+    start: (assistantId, conversationId) => {
+      useLiveVoiceStore
+        .getState()
+        .setSessionContext(assistantId, conversationId ?? null);
+      useLiveVoiceStore.getState().setState("listening");
+    },
+  });
+}
+
+/** Let the fire-and-forget drain run to completion. */
+async function flushDrain(): Promise<void> {
+  for (let i = 0; i < 8; i++) {
+    await Promise.resolve();
+  }
+}
+
+beforeEach(() => {
+  mockPathname = routes.conversation(CONVERSATION_ID);
+  useLiveVoiceStore.getState().reset();
+  useLiveVoiceStore.getState().setStarter(null);
+  __resetPendingDeepLinkForTesting();
+  useConversationStore.getState().reset();
+  useViewerStore.getState().setMainView("chat");
+  useAssistantIdentityStore.setState({
+    assistantId: "assistant-1",
+    version: "0.10.12",
+    name: "Ada",
+  });
+  useResolvedAssistantsStore.setState({ activeAssistantId: "assistant-1" });
+  useVoicePrefsStore.setState({ firstRunSeen: true });
+});
+
+afterEach(() => {
+  cleanup();
+  useLiveVoiceStore.getState().reset();
+  useConversationStore.getState().reset();
+});
+
+test("a deep-link start opens the room on the composer it lands on, not the pill", async () => {
+  useConversationStore.getState().setActiveConversationId(CONVERSATION_ID);
+  registerStarter();
+
+  requestVoiceStart();
+  await flushDrain();
+
+  const { result } = renderHook(() => useIsVoiceRoomVisible());
+  expect(result.current).toBe(true);
+
+  // The exact complement: with the room up, the title-bar pill renders
+  // nothing. A session bound to no conversation used to invert this pair.
+  const { container } = render(<VoiceSessionPillHost />);
+  expect(container.firstChild).toBeNull();
+});

--- a/clients/web/src/domains/chat/voice/voice-room/use-is-voice-room-visible.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/use-is-voice-room-visible.test.tsx
@@ -37,8 +37,16 @@ mock.module("@/domains/chat/voice/live-voice/live-voice-preflight-api", () => ({
   preflightLiveVoice,
 }));
 
+/**
+ * Location the app is "on", advanced by the drain's own navigation. The room
+ * predicate reads `useLocation` to decide whether a composer is on screen, so
+ * driving it from `navigateFn` is what makes this an end-to-end assertion: the
+ * drain has to land somewhere the room actually renders.
+ */
 let mockPathname: string = routes.assistant;
-const navigateFn = mock(() => {});
+const navigateFn = mock((to: string) => {
+  mockPathname = to.split("?")[0] ?? to;
+});
 mock.module("react-router", () => ({
   useLocation: () => ({ pathname: mockPathname, search: "" }),
   useNavigate: () => navigateFn,
@@ -82,7 +90,8 @@ const { useConversationStore } = await import("@/stores/conversation-store");
 const { useViewerStore } = await import("@/stores/viewer-store");
 const { useVoicePrefsStore } = await import("@/stores/voice-prefs-store");
 
-const CONVERSATION_ID = "conv-owning";
+/** An earlier thread the app was left sitting on when the link arrives. */
+const PRIOR_CONVERSATION_ID = "conv-prior";
 
 /** The controller's starter, binding the session as `useLiveVoice` does. */
 function registerStarter(): void {
@@ -106,7 +115,8 @@ async function flushDrain(): Promise<void> {
 }
 
 beforeEach(() => {
-  mockPathname = routes.conversation(CONVERSATION_ID);
+  mockPathname = routes.conversation(PRIOR_CONVERSATION_ID);
+  navigateFn.mockClear();
   useLiveVoiceStore.getState().reset();
   useLiveVoiceStore.getState().setStarter(null);
   __resetPendingDeepLinkForTesting();
@@ -127,12 +137,22 @@ afterEach(() => {
   useConversationStore.getState().reset();
 });
 
-test("a deep-link start opens the room on the composer it lands on, not the pill", async () => {
-  useConversationStore.getState().setActiveConversationId(CONVERSATION_ID);
+test("a deep-link start opens the room on the conversation it mints, not the pill", async () => {
+  // The app was left on an earlier thread, which is the state a widget button
+  // or a Siri shortcut finds. The call belongs to neither that thread nor to
+  // nothing at all: it gets one of its own, and the composer for it has to be
+  // the one on screen or the room never opens.
+  useConversationStore
+    .getState()
+    .setActiveConversationId(PRIOR_CONVERSATION_ID);
   registerStarter();
 
-  requestVoiceStart();
+  requestVoiceStart(navigateFn);
   await flushDrain();
+
+  const draftId = useConversationStore.getState().activeConversationId;
+  expect(draftId).not.toBe(PRIOR_CONVERSATION_ID);
+  expect(mockPathname).toBe(routes.conversation(draftId ?? ""));
 
   const { result } = renderHook(() => useIsVoiceRoomVisible());
   expect(result.current).toBe(true);

--- a/clients/web/src/domains/chat/voice/voice-room/use-is-voice-room-visible.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/use-is-voice-room-visible.test.tsx
@@ -157,8 +157,8 @@ test("a deep-link start opens the room on the conversation it mints, not the pil
   const { result } = renderHook(() => useIsVoiceRoomVisible());
   expect(result.current).toBe(true);
 
-  // The exact complement: with the room up, the title-bar pill renders
-  // nothing. A session bound to no conversation used to invert this pair.
+  // The room and the pill are exact complements: with the room up, the
+  // title-bar pill renders nothing.
   const { container } = render(<VoiceSessionPillHost />);
   expect(container.firstChild).toBeNull();
 });

--- a/clients/web/src/hooks/use-global-deep-link-consumer.test.tsx
+++ b/clients/web/src/hooks/use-global-deep-link-consumer.test.tsx
@@ -497,20 +497,29 @@ describe("deeplink.startVoice", () => {
   const isVoiceRoomVisible = (): boolean =>
     renderHook(() => useIsVoiceRoomVisible()).result.current;
 
+  /** An earlier thread the app is left sitting on when a link arrives. */
+  const PRIOR_CONVERSATION_ID = "conv-prior";
+
   /**
-   * The session is started for the conversation on screen, minting a draft
-   * when there is none, so that the composer there can own it and show the
-   * room. A minted id is a fresh uuid, hence the assertion against the store
-   * rather than a literal.
+   * The session is started on a conversation minted for it, and the app lands
+   * on that conversation so its composer can own the session and show the
+   * room. Never the selection already in the store: that is wherever the user
+   * was last, while a link asking for voice means a new call. A minted id is a
+   * fresh uuid, hence the assertions against the store rather than a literal.
    */
-  const expectStartedOnActiveConversation = (starterMock: unknown): void => {
+  const expectStartedOnFreshDraft = (starterMock: unknown): void => {
     const conversationId = useConversationStore.getState().activeConversationId;
     expect(conversationId).not.toBeNull();
+    expect(conversationId).not.toBe(PRIOR_CONVERSATION_ID);
     expect(starterMock).toHaveBeenCalledWith("assistant-1", conversationId);
+    expect(mockPathname).toBe(routes.conversation(conversationId ?? ""));
   };
 
-  test("mode=new starts a session bound to the composer it lands on", async () => {
+  test("mode=new starts a session on a conversation of its own, not the one the app was left on", async () => {
     seedEligibleAssistant();
+    useConversationStore
+      .getState()
+      .setActiveConversationId(PRIOR_CONVERSATION_ID);
     const starter = mock((_a: string, _c: string | null) => undefined);
     useLiveVoiceStore.getState().setStarter(asStarter(starter));
     renderConsumer();
@@ -525,7 +534,11 @@ describe("deeplink.startVoice", () => {
     await flush();
 
     expect(navigateMock).toHaveBeenCalledWith("/assistant");
-    expectStartedOnActiveConversation(starter);
+    expectStartedOnFreshDraft(starter);
+    expect(starter).not.toHaveBeenCalledWith(
+      "assistant-1",
+      PRIOR_CONVERSATION_ID,
+    );
     expect(ensureMainWindowVisibleMock).toHaveBeenCalledTimes(1);
   });
 
@@ -548,14 +561,15 @@ describe("deeplink.startVoice", () => {
     ).not.toBeNull();
     expect(navigateMock).toHaveBeenCalledWith("/assistant");
 
-    // What `useLiveVoiceSessionController` does when it mounts.
+    // What `useLiveVoiceSessionController` does when it mounts, navigation
+    // included: it lands on the conversation the drain mints.
     const starter = mock((_a: string, _c: string | null) => undefined);
     useLiveVoiceStore.getState().setStarter(asStarter(starter));
     await act(async () => {
-      await drainPendingVoiceStart();
+      await drainPendingVoiceStart(navigateMock);
     });
 
-    expectStartedOnActiveConversation(starter);
+    expectStartedOnFreshDraft(starter);
     expect(usePendingDeepLinkStore.getState().pendingVoiceStartAt).toBeNull();
   });
 
@@ -677,7 +691,7 @@ describe("deeplink.startVoice", () => {
     // `restoreVoiceRoom` no-ops with no active session, so the fresh session
     // the starter opens is not pre-emptively un-minimized by this path.
     expect(useLiveVoiceStore.getState().roomMinimized).toBe(false);
-    expectStartedOnActiveConversation(starter);
+    expectStartedOnFreshDraft(starter);
   });
 
   test("mode=new during a live call surfaces that call instead of navigating away and starting nothing", async () => {
@@ -726,7 +740,7 @@ describe("deeplink.startVoice", () => {
     await flush();
 
     expect(navigateMock).toHaveBeenCalledWith("/assistant");
-    expectStartedOnActiveConversation(starter);
+    expectStartedOnFreshDraft(starter);
   });
 
   // -------------------------------------------------------------------------
@@ -840,7 +854,7 @@ describe("deeplink.startVoice", () => {
     });
     await flush();
 
-    expectStartedOnActiveConversation(starter);
+    expectStartedOnFreshDraft(starter);
     // No session yet, so no room — the room appears once the starter's session
     // reaches an active phase, exactly as it does for a `mode=new` link.
     expect(isVoiceRoomVisible()).toBe(false);
@@ -982,7 +996,7 @@ describe("deeplink.startVoice", () => {
     await flush();
 
     expect(navigateMock).toHaveBeenCalledWith("/assistant");
-    expectStartedOnActiveConversation(starter);
+    expectStartedOnFreshDraft(starter);
     // Nothing parked: a promptless link must not disturb the composer.
     expect(usePendingDeepLinkStore.getState().pendingComposerMessage).toBe(
       null,

--- a/clients/web/src/hooks/use-global-deep-link-consumer.test.tsx
+++ b/clients/web/src/hooks/use-global-deep-link-consumer.test.tsx
@@ -497,7 +497,19 @@ describe("deeplink.startVoice", () => {
   const isVoiceRoomVisible = (): boolean =>
     renderHook(() => useIsVoiceRoomVisible()).result.current;
 
-  test("mode=new starts a session on the draft composer — no conversation, so the server assigns one", async () => {
+  /**
+   * The session is started for the conversation on screen, minting a draft
+   * when there is none, so that the composer there can own it and show the
+   * room. A minted id is a fresh uuid, hence the assertion against the store
+   * rather than a literal.
+   */
+  const expectStartedOnActiveConversation = (starterMock: unknown): void => {
+    const conversationId = useConversationStore.getState().activeConversationId;
+    expect(conversationId).not.toBeNull();
+    expect(starterMock).toHaveBeenCalledWith("assistant-1", conversationId);
+  };
+
+  test("mode=new starts a session bound to the composer it lands on", async () => {
     seedEligibleAssistant();
     const starter = mock((_a: string, _c: string | null) => undefined);
     useLiveVoiceStore.getState().setStarter(asStarter(starter));
@@ -513,7 +525,7 @@ describe("deeplink.startVoice", () => {
     await flush();
 
     expect(navigateMock).toHaveBeenCalledWith("/assistant");
-    expect(starter).toHaveBeenCalledWith("assistant-1", null);
+    expectStartedOnActiveConversation(starter);
     expect(ensureMainWindowVisibleMock).toHaveBeenCalledTimes(1);
   });
 
@@ -543,7 +555,7 @@ describe("deeplink.startVoice", () => {
       await drainPendingVoiceStart();
     });
 
-    expect(starter).toHaveBeenCalledWith("assistant-1", null);
+    expectStartedOnActiveConversation(starter);
     expect(usePendingDeepLinkStore.getState().pendingVoiceStartAt).toBeNull();
   });
 
@@ -665,7 +677,7 @@ describe("deeplink.startVoice", () => {
     // `restoreVoiceRoom` no-ops with no active session, so the fresh session
     // the starter opens is not pre-emptively un-minimized by this path.
     expect(useLiveVoiceStore.getState().roomMinimized).toBe(false);
-    expect(starter).toHaveBeenCalledWith("assistant-1", null);
+    expectStartedOnActiveConversation(starter);
   });
 
   test("mode=new during a live call surfaces that call instead of navigating away and starting nothing", async () => {
@@ -714,7 +726,7 @@ describe("deeplink.startVoice", () => {
     await flush();
 
     expect(navigateMock).toHaveBeenCalledWith("/assistant");
-    expect(starter).toHaveBeenCalledWith("assistant-1", null);
+    expectStartedOnActiveConversation(starter);
   });
 
   // -------------------------------------------------------------------------
@@ -828,7 +840,7 @@ describe("deeplink.startVoice", () => {
     });
     await flush();
 
-    expect(starter).toHaveBeenCalledWith("assistant-1", null);
+    expectStartedOnActiveConversation(starter);
     // No session yet, so no room — the room appears once the starter's session
     // reaches an active phase, exactly as it does for a `mode=new` link.
     expect(isVoiceRoomVisible()).toBe(false);
@@ -970,7 +982,7 @@ describe("deeplink.startVoice", () => {
     await flush();
 
     expect(navigateMock).toHaveBeenCalledWith("/assistant");
-    expect(starter).toHaveBeenCalledWith("assistant-1", null);
+    expectStartedOnActiveConversation(starter);
     // Nothing parked: a promptless link must not disturb the composer.
     expect(usePendingDeepLinkStore.getState().pendingComposerMessage).toBe(
       null,

--- a/clients/web/src/hooks/use-global-deep-link-consumer.ts
+++ b/clients/web/src/hooks/use-global-deep-link-consumer.ts
@@ -280,10 +280,11 @@ export function useGlobalDeepLinkConsumer(): void {
       requestComposerFocus();
       return;
     }
-    // The draft composer (no conversation): the session starts without one and
-    // the server assigns it on `ready`.
+    // The chat, so the layout that registers the starter is mounted. The drain
+    // mints the fresh conversation the session binds to and lands on it from
+    // there, reading the ref because it navigates after its own awaits.
     navigateRef.current(routes.assistant);
-    requestVoiceStart();
+    requestVoiceStart((to, options) => navigateRef.current(to, options));
   });
 
   // The Home Screen widgets' New Chat buttons. `navigateToNewConversation` is


### PR DESCRIPTION
## Summary
- Deep-link and hotkey voice starts passed a null conversation id, so no composer owned the session and the voice room never rendered (the title-bar pill showed instead)
- Resolve-or-mint the active conversation id before starting, mirroring the push-to-talk bridge, and set the main view to chat when minting
- Regression tests for ownership, draft minting, and room visibility

Part of plan: ios-widgets-v2.md (PR 1 of 7)