### PR TITLE
feat(widgets): snapshot schema v2 with avatar accent and image payload

### DIFF
--- a/clients/ios/App/App/Shared/CSSHexColor.swift
+++ b/clients/ios/App/App/Shared/CSSHexColor.swift
@@ -6,9 +6,9 @@ import UIKit
 ///
 /// This is the single native parser for the `#RGB` / `#RRGGBB` / `#RRGGBBAA`
 /// strings the web side hands across (`--surface-overlay` for the shell
-/// background, `accentHex` for the Live Activity). `VoiceSessionAttributes`'s
-/// `canonicalAccentHex` validates against exactly this grammar, so a
-/// canonicalized accent always parses here.
+/// background, `accentHex` for the Live Activity, the widget snapshot's avatar
+/// accent). ``canonicalCSSHex(_:)`` validates against exactly this grammar, so
+/// a canonicalized string always parses here.
 extension UIColor {
     /// Parse a CSS hex color string (`#RGB`, `#RRGGBB`, or `#RRGGBBAA`) as
     /// reported by `getComputedStyle().getPropertyValue()`. Returns `nil` for
@@ -75,4 +75,28 @@ extension Color {
     var contrastingForeground: Color {
         Color(uiColor: UIColor(self).contrastingForeground)
     }
+}
+
+/// Canonicalizes a CSS hex color (`#RGB`, `#RRGGBB`, `#RRGGBBAA`, with the `#`
+/// optional) to `#` plus uppercase digits, or `nil` when it is none of those.
+///
+/// One canonicalizer for every web-supplied color, so the surfaces that read
+/// them cannot come to accept different spellings. Each supplies its own answer
+/// for `nil`: the Live Activity substitutes its neutral gray, since a running
+/// session always renders something, while a widget keeps a nil accent and
+/// falls back to its static brand palette.
+func canonicalCSSHex(_ raw: String) -> String? {
+    var digits = raw.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
+    if digits.hasPrefix("#") {
+        digits.removeFirst()
+    }
+    if digits.count == 3 {
+        digits = digits.map { "\($0)\($0)" }.joined()
+    }
+    guard digits.count == 6 || digits.count == 8,
+          digits.allSatisfy({ $0.isASCII && $0.isHexDigit })
+    else {
+        return nil
+    }
+    return "#" + digits
 }

--- a/clients/ios/App/App/Shared/VoiceSessionAttributes.swift
+++ b/clients/ios/App/App/Shared/VoiceSessionAttributes.swift
@@ -121,7 +121,7 @@ struct VoiceSessionAttributes: ActivityAttributes {
         ) {
             self.phase = phase
             self.label = label
-            self.accentHex = Self.canonicalAccentHex(accentHex)
+            self.accentHex = canonicalCSSHex(accentHex) ?? Self.neutralAccentHex
             self.muted = muted
             self.outputMuted = outputMuted
             self.detail = detail
@@ -164,26 +164,6 @@ struct VoiceSessionAttributes: ActivityAttributes {
                     forKey: .approvalRequestId
                 ) ?? ""
             )
-        }
-
-        /// Canonicalizes a CSS hex color (`#RGB`, `#RRGGBB`, `#RRGGBBAA`, with
-        /// the `#` optional) to `#` plus uppercase digits, falling back to
-        /// ``neutralAccentHex`` for anything else. The accepted grammar matches
-        /// `UIColor(cssHex:)`, so the canonical form always parses.
-        static func canonicalAccentHex(_ raw: String) -> String {
-            var digits = raw.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
-            if digits.hasPrefix("#") {
-                digits.removeFirst()
-            }
-            if digits.count == 3 {
-                digits = digits.map { "\($0)\($0)" }.joined()
-            }
-            guard digits.count == 6 || digits.count == 8,
-                  digits.allSatisfy({ $0.isASCII && $0.isHexDigit })
-            else {
-                return neutralAccentHex
-            }
-            return "#" + digits
         }
     }
 

--- a/clients/ios/App/App/Shared/WidgetSnapshot.swift
+++ b/clients/ios/App/App/Shared/WidgetSnapshot.swift
@@ -14,19 +14,42 @@ struct WidgetSnapshotConversation: Codable, Equatable {
     let isProcessing: Bool
 }
 
+/// The assistant's avatar, so a widget can draw the user's own colors and face
+/// instead of a fixed brand palette.
+///
+/// The image travels as bytes because the extension has no network stack and
+/// no auth of its own, the same reason the Live Activity's avatar does.
+///
+/// `kind` is the web side's `AvatarRender` vocabulary (`character`, `image`,
+/// `none`) rather than a native enum: an unknown value has to read as "no
+/// avatar I can draw", which is a fallback every widget already has, and not as
+/// a decode failure that would cost the counts and rows too. `accentHex` is
+/// canonical (see ``canonicalCSSHex(_:)``) or nil, and is nil for a custom
+/// image by design, since there is no single color to match.
+struct WidgetSnapshotAvatar: Codable, Equatable {
+    let kind: String
+    let accentHex: String?
+    let imageData: Data?
+}
+
 /// Everything the Home Screen knows about the signed-in user's conversations:
-/// two counts and the few most recent threads, as of `generatedAt`.
+/// two counts and the few most recent threads, as of `generatedAt`, plus the
+/// avatar the widgets theme themselves from.
 struct WidgetSnapshot: Codable, Equatable {
     /// Version of the stored shape. `WidgetSnapshotStore` refuses a blob
     /// carrying any other value, so a field this build cannot make sense of
     /// reads as no snapshot rather than as a half-decoded one.
-    static let currentSchemaVersion = 1
+    static let currentSchemaVersion = 2
 
     let schemaVersion: Int
     let generatedAt: Date
     let unreadCount: Int
     let inProgressCount: Int
     let conversations: [WidgetSnapshotConversation]
+    /// Optional even though the producer always sends it: a dict the shell
+    /// cannot make sense of should cost the widgets their theming, never their
+    /// counts and rows.
+    let avatar: WidgetSnapshotAvatar?
 }
 
 /// The `kind` string each Vellum widget registers under, and the identifier

--- a/clients/ios/App/App/WidgetSnapshotPlugin.swift
+++ b/clients/ios/App/App/WidgetSnapshotPlugin.swift
@@ -7,7 +7,7 @@ import WidgetKit
 /// App Group cache the VoiceActivity extension can read.
 ///
 /// Two methods:
-/// - `sync({ generatedAt, unreadCount, inProgressCount, conversations })`
+/// - `sync({ generatedAt, unreadCount, inProgressCount, conversations, avatar })`
 ///   replaces the whole snapshot. Full replacement rather than a diff keeps
 ///   the contract trivial: the web side owns ordering and membership, and a
 ///   sync after archiving or reading a thread needs no tombstones.
@@ -25,10 +25,11 @@ import WidgetKit
 /// This is the write-side half of the check `WidgetSnapshotStore.load()`
 /// already makes on read.
 ///
-/// Malformed conversation entries are dropped rather than rejecting the call:
-/// a partial summary beats none, and the web producer already shapes the
-/// payload. Per the skew rule in `clients/web/docs/CAPACITOR.md`, the one
-/// result shape (`{ok: true}`) covers every state, including an empty payload.
+/// Malformed conversation entries, and an avatar this build cannot read, are
+/// dropped rather than rejecting the call: a partial summary beats none, and
+/// the web producer already shapes the payload. Per the skew rule in
+/// `clients/web/docs/CAPACITOR.md`, the one result shape (`{ok: true}`) covers
+/// every state, including an empty payload.
 @objc(WidgetSnapshotPlugin)
 public class WidgetSnapshotPlugin: CAPPlugin, CAPBridgedPlugin {
     public let identifier = "WidgetSnapshotPlugin"
@@ -42,6 +43,18 @@ public class WidgetSnapshotPlugin: CAPPlugin, CAPBridgedPlugin {
     /// this many; clamping here keeps a misbehaving caller from growing the
     /// shared container without limit.
     private static let maxConversations = 3
+
+    /// Ceiling on the decoded avatar image. The producer encodes well under it
+    /// (`WIDGET_AVATAR_MAX_BYTES` in `use-native-widget-snapshot-sync.ts`), so
+    /// this is the guard against a caller that does not: the blob is written to
+    /// a container the widget extension has to load on every timeline refresh,
+    /// and a snapshot no widget can afford to read is worse than an unthemed
+    /// one.
+    private static let maxAvatarImageBytes = 96 * 1024
+
+    /// The same ceiling in base64 characters, so an oversized image is rejected
+    /// before anything decodes it.
+    private static let maxAvatarBase64Count = 4 * ((maxAvatarImageBytes + 2) / 3)
 
     @objc public func sync(_ call: CAPPluginCall) {
         // A payload with no version is as unreadable as one carrying a version
@@ -69,7 +82,8 @@ public class WidgetSnapshotPlugin: CAPPlugin, CAPBridgedPlugin {
             generatedAt: Self.date(from: call.getString("generatedAt")) ?? Date(),
             unreadCount: max(0, call.getInt("unreadCount") ?? 0),
             inProgressCount: max(0, call.getInt("inProgressCount") ?? 0),
-            conversations: Array(conversations)
+            conversations: Array(conversations),
+            avatar: Self.avatar(from: call.getObject("avatar"))
         )
         WidgetSnapshotStore.save(snapshot)
         Self.reloadWidgets()
@@ -128,6 +142,38 @@ public class WidgetSnapshotPlugin: CAPPlugin, CAPBridgedPlugin {
             hasUnseen: dict["hasUnseen"] as? Bool ?? false,
             isProcessing: dict["isProcessing"] as? Bool ?? false
         )
+    }
+
+    /// The avatar the widgets theme themselves from, or nil when the payload
+    /// carries none this build can use. A `kind` is the whole of what makes the
+    /// dict usable: the accent and the image are each independently optional,
+    /// and a `none` avatar carries neither.
+    private static func avatar(from dict: JSObject?) -> WidgetSnapshotAvatar? {
+        guard let dict, let kind = dict["kind"] as? String, !kind.isEmpty else {
+            return nil
+        }
+        return WidgetSnapshotAvatar(
+            kind: kind,
+            accentHex: (dict["accentHex"] as? String).flatMap(canonicalCSSHex),
+            imageData: avatarImage(fromBase64: dict["imageBase64"] as? String)
+        )
+    }
+
+    /// The avatar image's bytes, or nil for a payload that carries none, one
+    /// past ``maxAvatarImageBytes``, and one that is not base64 at all. All
+    /// three read as an avatar with no image, which every widget draws by
+    /// falling back to its accent or brand mark.
+    private static func avatarImage(fromBase64 raw: String?) -> Data? {
+        guard let raw, !raw.isEmpty else {
+            return nil
+        }
+        guard raw.count <= maxAvatarBase64Count,
+              let data = Data(base64Encoded: raw)
+        else {
+            NSLog("[widget] Dropping an unusable avatar image of %d base64 characters", raw.count)
+            return nil
+        }
+        return data
     }
 
     /// JavaScript's `toISOString()` always carries milliseconds, which the

--- a/clients/ios/App/VoiceActivity/Widgets/SnapshotTimeline.swift
+++ b/clients/ios/App/VoiceActivity/Widgets/SnapshotTimeline.swift
@@ -143,6 +143,9 @@ extension WidgetSnapshot {
                 hasUnseen: false,
                 isProcessing: true
             ),
-        ]
+        ],
+        // The gallery entry shows the brand palette rather than an invented
+        // avatar: whoever is holding the phone may not be the account holder.
+        avatar: nil
     )
 }

--- a/clients/web/src/domains/chat/hooks/use-native-widget-snapshot-sync.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-native-widget-snapshot-sync.test.tsx
@@ -38,10 +38,14 @@
  * and a launch that reaches no sync of its own would otherwise never honor it.
  *
  * The avatar rides along so the widgets can draw the user's own colors and
- * face. It is read from the two imperative publishers rather than subscribed
- * to, and its encoded bytes are deliberately outside the dedup key: they are
+ * face. Its encoded bytes are deliberately outside the dedup key: they are
  * tens of kilobytes, the key is re-serialized on every list re-render, and an
- * identity in their place still tells one photo from the next.
+ * identity in their place still tells one photo from the next. It is a
+ * reactive input rather than a read taken as the payload is built, so a change
+ * with no conversation change still re-runs the sync: `RootLayout` publishes
+ * its own copies from a parent effect, which React runs after this layout's,
+ * and a snapshot that read those back would pin the previous assistant's face
+ * in the dedup key across an in-SPA switch into a cached destination.
  */
 
 import {
@@ -55,15 +59,16 @@ import {
 } from "bun:test";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, renderHook } from "@testing-library/react";
-import { createElement, type ReactNode } from "react";
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { createElement, useSyncExternalStore, type ReactNode } from "react";
 
+import type { AvatarData } from "@/hooks/use-assistant-avatar";
 import type {
   Conversation,
   ConversationGroup,
 } from "@/types/conversation-types";
 import type { WidgetSnapshotPayload } from "@/runtime/widget-snapshot";
-import type { AvatarRender } from "@/utils/avatar-render";
+import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
 import * as listFetchers from "@/utils/conversation-list-fetchers";
 
 // Nothing in this file should reach the network: the count endpoint stands in
@@ -141,28 +146,50 @@ function settle(): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, 0));
 }
 
-// The avatar, as `RootLayout` publishes it: two module-level getters the hook
-// reads imperatively, so a test sets them directly. The encode is stubbed
-// because it rasterizes onto a canvas, which happy-dom does not have. All three
-// modules are spread over their real surface, since `mock.module` is
-// process-global in bun.
-let avatarSource: AvatarRender | null = null;
-let avatarAccentHex: string | null = null;
+// The avatar, as the hook reads it: the assistant-avatar query `RootLayout`
+// derives its own published copies from. Mocked as an external store rather
+// than as a plain getter because the hook SUBSCRIBES to it, and the claim under
+// test is that a new avatar re-runs the sync with nothing else moving. The
+// render and the accent come from the real resolvers, so the widget can only
+// ever draw what the app does. The encode is stubbed because it rasterizes onto
+// a canvas, which happy-dom does not have. Both mocked modules are spread over
+// their real surface, since `mock.module` is process-global in bun.
+const NO_AVATAR: AvatarData = {
+  components: null,
+  traits: null,
+  customImageUrl: null,
+};
+let avatarData: AvatarData = NO_AVATAR;
+const avatarListeners = new Set<() => void>();
 let encodeOutcome: "bytes" | "nothing-fits" | "throws" = "bytes";
 let encodeCalls = 0;
 /** Long enough that a dedup key carrying it would be unmistakable. */
 const AVATAR_BASE64 = "Zm9vYmFy".repeat(2_000);
 
-const realAvatarAccentVar = await import("@/hooks/use-avatar-accent-var");
-mock.module("@/hooks/use-avatar-accent-var", () => ({
-  ...realAvatarAccentVar,
-  getRenderedAvatarAccentHex: () => avatarAccentHex,
-}));
+/** Serve a new avatar the way a settling query does, waking its subscribers. */
+function publishAvatar(next: AvatarData): void {
+  avatarData = next;
+  for (const listener of avatarListeners) {
+    listener();
+  }
+}
 
-const realIslandAvatarSource = await import("@/hooks/use-island-avatar-source");
-mock.module("@/hooks/use-island-avatar-source", () => ({
-  ...realIslandAvatarSource,
-  getIslandAvatarSource: () => avatarSource,
+function subscribeAvatar(onChange: () => void): () => void {
+  avatarListeners.add(onChange);
+  return () => {
+    avatarListeners.delete(onChange);
+  };
+}
+
+const realAssistantAvatar = await import("@/hooks/use-assistant-avatar");
+mock.module("@/hooks/use-assistant-avatar", () => ({
+  ...realAssistantAvatar,
+  // The assistant id is ignored: one avatar is served at a time, which is what
+  // the real query does too once the active assistant's entry settles.
+  useAssistantAvatar: () => {
+    const data = useSyncExternalStore(subscribeAvatar, () => avatarData);
+    return { ...data, isLoading: false, invalidate: () => {} };
+  },
 }));
 
 const realAvatarIslandEncode = await import("@/utils/avatar-island-encode");
@@ -177,18 +204,25 @@ mock.module("@/utils/avatar-island-encode", () => ({
   },
 }));
 
-/** A character avatar, a distinct render each call as a real change produces. */
-function characterAvatar(): AvatarRender {
+/**
+ * A character avatar in the palette color named, as the query serves one: a
+ * distinct object each call, which is what a real avatar change produces.
+ */
+function characterAvatar(color: string): AvatarData {
   return {
-    kind: "character",
-    svg: "<svg />",
-    dataUri: "data:image/svg+xml,%3Csvg%20%2F%3E",
+    components: BUNDLED_COMPONENTS,
+    traits: { bodyShape: "blob", eyeStyle: "grumpy", color },
+    customImageUrl: null,
   };
 }
 
-function imageAvatar(url: string): AvatarRender {
-  return { kind: "image", url };
+function imageAvatar(url: string): AvatarData {
+  return { components: null, traits: null, customImageUrl: url };
 }
+
+/** The hexes {@link characterAvatar}'s colors resolve to through the palette. */
+const ORANGE_HEX = "#E9642F";
+const TEAL_HEX = "#0E9B8B";
 
 /** Everything `JSON.stringify` produced while `body` ran. */
 function recordSerialized(body: () => void): string[] {
@@ -311,8 +345,8 @@ beforeEach(() => {
   persistedAssistantId = null;
   podIsServing = true;
   armedTimers = [];
-  avatarSource = null;
-  avatarAccentHex = null;
+  avatarData = NO_AVATAR;
+  avatarListeners.clear();
   encodeOutcome = "bytes";
   encodeCalls = 0;
   useConversationStore.setState({ processingConversationIds: new Set() });
@@ -1090,8 +1124,7 @@ describe("useNativeWidgetSnapshotSync", () => {
   });
 
   it("carries a character avatar's rendered accent and encoded face", async () => {
-    avatarSource = characterAvatar();
-    avatarAccentHex = "#E9642F";
+    avatarData = characterAvatar("orange");
     render({
       conversations: [conversation("c1", { title: "Groceries" })],
       conversationGroups: NO_GROUPS,
@@ -1102,7 +1135,7 @@ describe("useNativeWidgetSnapshotSync", () => {
     expect(syncedSnapshots).toHaveLength(1);
     expect(syncedSnapshots[0]?.avatar).toEqual({
       kind: "character",
-      accentHex: "#E9642F",
+      accentHex: ORANGE_HEX,
       imageBase64: AVATAR_BASE64,
     });
   });
@@ -1110,8 +1143,7 @@ describe("useNativeWidgetSnapshotSync", () => {
   it("carries a custom image with no accent to match", async () => {
     // The rendered accent is null for an uploaded avatar by construction, and
     // the widget blurs the photo for its background instead.
-    avatarSource = imageAvatar("blob:avatar-1");
-    avatarAccentHex = null;
+    avatarData = imageAvatar("blob:avatar-1");
     render({
       conversations: [conversation("c1")],
       conversationGroups: NO_GROUPS,
@@ -1147,8 +1179,7 @@ describe("useNativeWidgetSnapshotSync", () => {
     // Both ways it can fail: nothing fit the budget, and the raster threw. The
     // widgets are for the counts and the rows, so neither may cost a snapshot.
     encodeOutcome = "nothing-fits";
-    avatarSource = characterAvatar();
-    avatarAccentHex = "#E9642F";
+    avatarData = characterAvatar("orange");
     const { rerender } = render({
       conversations: [conversation("c1", { title: "Groceries" })],
       conversationGroups: NO_GROUPS,
@@ -1157,13 +1188,13 @@ describe("useNativeWidgetSnapshotSync", () => {
     await settle();
     expect(syncedSnapshots[0]?.avatar).toEqual({
       kind: "character",
-      accentHex: "#E9642F",
+      accentHex: ORANGE_HEX,
       imageBase64: null,
     });
     expect(syncedSnapshots[0]?.conversations).toHaveLength(1);
 
     encodeOutcome = "throws";
-    avatarSource = characterAvatar();
+    avatarData = characterAvatar("orange");
     rerender({
       conversations: [conversation("c1", { title: "Groceries" })],
       conversationGroups: NO_GROUPS,
@@ -1178,7 +1209,7 @@ describe("useNativeWidgetSnapshotSync", () => {
   it("re-sends unchanged conversations when the avatar changes", async () => {
     // One photo swapped for another changes neither the kind nor the accent, so
     // only the identity the key carries can tell the snapshots apart.
-    avatarSource = imageAvatar("blob:avatar-1");
+    avatarData = imageAvatar("blob:avatar-1");
     const { rerender } = render({
       conversations: [conversation("c1", { title: "Groceries" })],
       conversationGroups: NO_GROUPS,
@@ -1187,7 +1218,7 @@ describe("useNativeWidgetSnapshotSync", () => {
     await settle();
     expect(syncedSnapshots).toHaveLength(1);
 
-    avatarSource = imageAvatar("blob:avatar-2");
+    avatarData = imageAvatar("blob:avatar-2");
     rerender({
       conversations: [conversation("c1", { title: "Groceries" })],
       conversationGroups: NO_GROUPS,
@@ -1211,7 +1242,7 @@ describe("useNativeWidgetSnapshotSync", () => {
     // The wait on the canvas draw is the one window in which a switch can
     // overtake a snapshot. Letting it land would put the departed assistant's
     // rows straight back on a Home Screen that was just cleared.
-    avatarSource = characterAvatar();
+    avatarData = characterAvatar("orange");
     const { rerender } = render({
       conversations: [conversation("c1", { title: "Groceries" })],
       conversationGroups: NO_GROUPS,
@@ -1233,8 +1264,7 @@ describe("useNativeWidgetSnapshotSync", () => {
   });
 
   it("keeps the avatar's bytes out of the dedup key", async () => {
-    avatarSource = characterAvatar();
-    avatarAccentHex = "#E9642F";
+    avatarData = characterAvatar("orange");
     const serialized = recordSerialized(() => {
       const { rerender } = render({
         conversations: [conversation("c1", { title: "Groceries" })],
@@ -1260,11 +1290,47 @@ describe("useNativeWidgetSnapshotSync", () => {
     expect(syncedSnapshots[0]?.avatar.imageBase64).toBe(AVATAR_BASE64);
   });
 
-  it("beats with an avatar that changed while nothing else did", async () => {
-    // An avatar change re-renders nothing here: the publishers are read
-    // imperatively, so the tick is what carries it to the Home Screen.
-    avatarSource = characterAvatar();
-    avatarAccentHex = "#E9642F";
+  it("syncs an avatar that changed while nothing else did", async () => {
+    // The gap this closes: `RootLayout` publishes its avatar copies from a
+    // PARENT effect, and React runs a child's effects first, so a snapshot
+    // built from those would be a render behind whenever the avatar and the
+    // conversation data move in one commit. An in-SPA assistant switch into an
+    // already-cached destination is that commit, and the dedup key would then
+    // pin the previous assistant's face until the heartbeat. Reading the avatar
+    // reactively is what makes the change its own trigger.
+    avatarData = characterAvatar("orange");
+    render({
+      conversations: [conversation("c1", { title: "Groceries" })],
+      conversationGroups: NO_GROUPS,
+      inputsResolved: true,
+    });
+    await settle();
+    expect(syncedSnapshots).toHaveLength(1);
+    expect(syncedSnapshots[0]?.avatar.accentHex).toBe(ORANGE_HEX);
+
+    // Nothing about the conversation list moves and nothing re-renders the
+    // layout of its own accord: the avatar arriving is the whole event.
+    act(() => {
+      publishAvatar(characterAvatar("teal"));
+    });
+    await settle();
+    expect(syncedSnapshots).toHaveLength(2);
+    expect(syncedSnapshots[1]?.avatar).toEqual({
+      kind: "character",
+      accentHex: TEAL_HEX,
+      imageBase64: AVATAR_BASE64,
+    });
+    expect(syncedSnapshots[1]?.conversations).toEqual(
+      syncedSnapshots[0]?.conversations ?? [],
+    );
+    // And it got there without the heartbeat, which is still armed and unfired.
+    expect(liveHeartbeats()).toHaveLength(1);
+  });
+
+  it("beats with the avatar the session currently has", async () => {
+    // The tick shares the send path, so it carries whatever the avatar is now
+    // rather than what the last data sync happened to encode.
+    avatarData = characterAvatar("orange");
     render({
       conversations: [conversation("c1", { title: "Groceries" })],
       conversationGroups: NO_GROUPS,
@@ -1273,17 +1339,21 @@ describe("useNativeWidgetSnapshotSync", () => {
     await settle();
     expect(syncedSnapshots).toHaveLength(1);
 
-    avatarSource = imageAvatar("blob:avatar-1");
-    avatarAccentHex = null;
-    fireHeartbeat();
+    act(() => {
+      publishAvatar(imageAvatar("blob:avatar-1"));
+    });
     await settle();
     expect(syncedSnapshots).toHaveLength(2);
-    expect(syncedSnapshots[1]?.avatar).toEqual({
+
+    fireHeartbeat();
+    await settle();
+    expect(syncedSnapshots).toHaveLength(3);
+    expect(syncedSnapshots[2]?.avatar).toEqual({
       kind: "image",
       accentHex: null,
       imageBase64: AVATAR_BASE64,
     });
-    expect(syncedSnapshots[1]?.conversations).toEqual(
+    expect(syncedSnapshots[2]?.conversations).toEqual(
       syncedSnapshots[0]?.conversations ?? [],
     );
   });

--- a/clients/web/src/domains/chat/hooks/use-native-widget-snapshot-sync.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-native-widget-snapshot-sync.test.tsx
@@ -36,6 +36,12 @@
  * The hook is also the seam that finishes a clear a previous session could not:
  * a sign-out or origin swap whose bridge call failed persists the obligation,
  * and a launch that reaches no sync of its own would otherwise never honor it.
+ *
+ * The avatar rides along so the widgets can draw the user's own colors and
+ * face. It is read from the two imperative publishers rather than subscribed
+ * to, and its encoded bytes are deliberately outside the dedup key: they are
+ * tens of kilobytes, the key is re-serialized on every list re-render, and an
+ * identity in their place still tells one photo from the next.
  */
 
 import {
@@ -57,6 +63,7 @@ import type {
   ConversationGroup,
 } from "@/types/conversation-types";
 import type { WidgetSnapshotPayload } from "@/runtime/widget-snapshot";
+import type { AvatarRender } from "@/utils/avatar-render";
 import * as listFetchers from "@/utils/conversation-list-fetchers";
 
 // Nothing in this file should reach the network: the count endpoint stands in
@@ -87,7 +94,7 @@ let persistedAssistantId: string | null = null;
 // Full module surface: `mock.module` is process-global in bun, so a partial
 // shape would shadow the other exports for later test files in the run.
 mock.module("@/runtime/widget-snapshot", () => ({
-  WIDGET_SNAPSHOT_SCHEMA_VERSION: 1,
+  WIDGET_SNAPSHOT_SCHEMA_VERSION: 2,
   isWidgetSnapshotSyncAvailable: () => syncAvailable,
   readWidgetSnapshotAssistantId: () => persistedAssistantId,
   syncWidgetSnapshot: async (
@@ -132,6 +139,74 @@ mock.module("@/runtime/widget-snapshot", () => ({
  */
 function settle(): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+// The avatar, as `RootLayout` publishes it: two module-level getters the hook
+// reads imperatively, so a test sets them directly. The encode is stubbed
+// because it rasterizes onto a canvas, which happy-dom does not have. All three
+// modules are spread over their real surface, since `mock.module` is
+// process-global in bun.
+let avatarSource: AvatarRender | null = null;
+let avatarAccentHex: string | null = null;
+let encodeOutcome: "bytes" | "nothing-fits" | "throws" = "bytes";
+let encodeCalls = 0;
+/** Long enough that a dedup key carrying it would be unmistakable. */
+const AVATAR_BASE64 = "Zm9vYmFy".repeat(2_000);
+
+const realAvatarAccentVar = await import("@/hooks/use-avatar-accent-var");
+mock.module("@/hooks/use-avatar-accent-var", () => ({
+  ...realAvatarAccentVar,
+  getRenderedAvatarAccentHex: () => avatarAccentHex,
+}));
+
+const realIslandAvatarSource = await import("@/hooks/use-island-avatar-source");
+mock.module("@/hooks/use-island-avatar-source", () => ({
+  ...realIslandAvatarSource,
+  getIslandAvatarSource: () => avatarSource,
+}));
+
+const realAvatarIslandEncode = await import("@/utils/avatar-island-encode");
+mock.module("@/utils/avatar-island-encode", () => ({
+  ...realAvatarIslandEncode,
+  encodeAvatarForIsland: async () => {
+    encodeCalls++;
+    if (encodeOutcome === "throws") {
+      throw new Error("canvas unavailable");
+    }
+    return encodeOutcome === "bytes" ? AVATAR_BASE64 : null;
+  },
+}));
+
+/** A character avatar, a distinct render each call as a real change produces. */
+function characterAvatar(): AvatarRender {
+  return {
+    kind: "character",
+    svg: "<svg />",
+    dataUri: "data:image/svg+xml,%3Csvg%20%2F%3E",
+  };
+}
+
+function imageAvatar(url: string): AvatarRender {
+  return { kind: "image", url };
+}
+
+/** Everything `JSON.stringify` produced while `body` ran. */
+function recordSerialized(body: () => void): string[] {
+  const serialized: string[] = [];
+  const real = JSON.stringify;
+  JSON.stringify = ((...args: Parameters<typeof JSON.stringify>) => {
+    const result = real(...args);
+    if (typeof result === "string") {
+      serialized.push(result);
+    }
+    return result;
+  }) as typeof JSON.stringify;
+  try {
+    body();
+  } finally {
+    JSON.stringify = real;
+  }
+  return serialized;
 }
 
 // The pod half of the queries' daemon gate. Spread over the real module: the
@@ -236,6 +311,10 @@ beforeEach(() => {
   persistedAssistantId = null;
   podIsServing = true;
   armedTimers = [];
+  avatarSource = null;
+  avatarAccentHex = null;
+  encodeOutcome = "bytes";
+  encodeCalls = 0;
   useConversationStore.setState({ processingConversationIds: new Set() });
 
   globalThis.setInterval = ((handler: () => void, delay: number) => {
@@ -573,7 +652,7 @@ describe("useNativeWidgetSnapshotSync", () => {
 
     expect(syncedSnapshots).toHaveLength(1);
     const snapshot = syncedSnapshots[0];
-    expect(snapshot?.schemaVersion).toBe(1);
+    expect(snapshot?.schemaVersion).toBe(2);
     expect(snapshot?.unreadCount).toBe(1);
     // Both processing sources count, and the archived row is excluded from
     // the count as well as from the rows.
@@ -1008,6 +1087,205 @@ describe("useNativeWidgetSnapshotSync", () => {
     // timestamp, and racing it would retire the attempt it counts on.
     fireHeartbeat();
     expect(syncedSnapshots).toHaveLength(1);
+  });
+
+  it("carries a character avatar's rendered accent and encoded face", async () => {
+    avatarSource = characterAvatar();
+    avatarAccentHex = "#E9642F";
+    render({
+      conversations: [conversation("c1", { title: "Groceries" })],
+      conversationGroups: NO_GROUPS,
+      inputsResolved: true,
+    });
+    await settle();
+
+    expect(syncedSnapshots).toHaveLength(1);
+    expect(syncedSnapshots[0]?.avatar).toEqual({
+      kind: "character",
+      accentHex: "#E9642F",
+      imageBase64: AVATAR_BASE64,
+    });
+  });
+
+  it("carries a custom image with no accent to match", async () => {
+    // The rendered accent is null for an uploaded avatar by construction, and
+    // the widget blurs the photo for its background instead.
+    avatarSource = imageAvatar("blob:avatar-1");
+    avatarAccentHex = null;
+    render({
+      conversations: [conversation("c1")],
+      conversationGroups: NO_GROUPS,
+      inputsResolved: true,
+    });
+    await settle();
+
+    expect(syncedSnapshots[0]?.avatar).toEqual({
+      kind: "image",
+      accentHex: null,
+      imageBase64: AVATAR_BASE64,
+    });
+  });
+
+  it("carries an empty avatar when the assistant has none", () => {
+    render({
+      conversations: [conversation("c1")],
+      conversationGroups: NO_GROUPS,
+      inputsResolved: true,
+    });
+
+    // Nothing to encode, so the snapshot is not held for one either: the send
+    // is synchronous with the render that fired it.
+    expect(syncedSnapshots[0]?.avatar).toEqual({
+      kind: "none",
+      accentHex: null,
+      imageBase64: null,
+    });
+    expect(encodeCalls).toBe(0);
+  });
+
+  it("still sends the counts and rows when the avatar will not encode", async () => {
+    // Both ways it can fail: nothing fit the budget, and the raster threw. The
+    // widgets are for the counts and the rows, so neither may cost a snapshot.
+    encodeOutcome = "nothing-fits";
+    avatarSource = characterAvatar();
+    avatarAccentHex = "#E9642F";
+    const { rerender } = render({
+      conversations: [conversation("c1", { title: "Groceries" })],
+      conversationGroups: NO_GROUPS,
+      inputsResolved: true,
+    });
+    await settle();
+    expect(syncedSnapshots[0]?.avatar).toEqual({
+      kind: "character",
+      accentHex: "#E9642F",
+      imageBase64: null,
+    });
+    expect(syncedSnapshots[0]?.conversations).toHaveLength(1);
+
+    encodeOutcome = "throws";
+    avatarSource = characterAvatar();
+    rerender({
+      conversations: [conversation("c1", { title: "Groceries" })],
+      conversationGroups: NO_GROUPS,
+      inputsResolved: true,
+    });
+    await settle();
+    expect(syncedSnapshots).toHaveLength(2);
+    expect(syncedSnapshots[1]?.avatar.imageBase64).toBeNull();
+    expect(syncedSnapshots[1]?.conversations).toHaveLength(1);
+  });
+
+  it("re-sends unchanged conversations when the avatar changes", async () => {
+    // One photo swapped for another changes neither the kind nor the accent, so
+    // only the identity the key carries can tell the snapshots apart.
+    avatarSource = imageAvatar("blob:avatar-1");
+    const { rerender } = render({
+      conversations: [conversation("c1", { title: "Groceries" })],
+      conversationGroups: NO_GROUPS,
+      inputsResolved: true,
+    });
+    await settle();
+    expect(syncedSnapshots).toHaveLength(1);
+
+    avatarSource = imageAvatar("blob:avatar-2");
+    rerender({
+      conversations: [conversation("c1", { title: "Groceries" })],
+      conversationGroups: NO_GROUPS,
+      inputsResolved: true,
+    });
+    await settle();
+    expect(syncedSnapshots).toHaveLength(2);
+
+    // And the same avatar with the same rows still costs no bridge traffic.
+    rerender({
+      conversations: [conversation("c1", { title: "Groceries" })],
+      conversationGroups: NO_GROUPS,
+      inputsResolved: true,
+    });
+    expect(syncedSnapshots).toHaveLength(2);
+    // Once per avatar, however many snapshots each one feeds.
+    expect(encodeCalls).toBe(2);
+  });
+
+  it("drops a write the assistant switched out from under while it encoded", async () => {
+    // The wait on the canvas draw is the one window in which a switch can
+    // overtake a snapshot. Letting it land would put the departed assistant's
+    // rows straight back on a Home Screen that was just cleared.
+    avatarSource = characterAvatar();
+    const { rerender } = render({
+      conversations: [conversation("c1", { title: "Groceries" })],
+      conversationGroups: NO_GROUPS,
+      inputsResolved: true,
+    });
+    expect(syncedSnapshots).toHaveLength(0);
+
+    rerender({
+      assistantId: "asst-2",
+      conversations: [],
+      conversationGroups: NO_GROUPS,
+      inputsResolved: false,
+    });
+    expect(clearCount).toBe(1);
+
+    await settle();
+    expect(syncedSnapshots).toHaveLength(0);
+    expect(bridgeOrder).toEqual(["clear"]);
+  });
+
+  it("keeps the avatar's bytes out of the dedup key", async () => {
+    avatarSource = characterAvatar();
+    avatarAccentHex = "#E9642F";
+    const serialized = recordSerialized(() => {
+      const { rerender } = render({
+        conversations: [conversation("c1", { title: "Groceries" })],
+        conversationGroups: NO_GROUPS,
+        inputsResolved: true,
+      });
+      rerender({
+        conversations: [conversation("c1", { title: "Groceries" })],
+        conversationGroups: NO_GROUPS,
+        inputsResolved: true,
+      });
+    });
+    await settle();
+
+    // The key was built, and the multi-kilobyte body never went through it.
+    expect(serialized.some((entry) => entry.includes('"unreadCount"'))).toBe(
+      true,
+    );
+    expect(serialized.some((entry) => entry.includes(AVATAR_BASE64))).toBe(
+      false,
+    );
+    // The bytes still reached the bridge.
+    expect(syncedSnapshots[0]?.avatar.imageBase64).toBe(AVATAR_BASE64);
+  });
+
+  it("beats with an avatar that changed while nothing else did", async () => {
+    // An avatar change re-renders nothing here: the publishers are read
+    // imperatively, so the tick is what carries it to the Home Screen.
+    avatarSource = characterAvatar();
+    avatarAccentHex = "#E9642F";
+    render({
+      conversations: [conversation("c1", { title: "Groceries" })],
+      conversationGroups: NO_GROUPS,
+      inputsResolved: true,
+    });
+    await settle();
+    expect(syncedSnapshots).toHaveLength(1);
+
+    avatarSource = imageAvatar("blob:avatar-1");
+    avatarAccentHex = null;
+    fireHeartbeat();
+    await settle();
+    expect(syncedSnapshots).toHaveLength(2);
+    expect(syncedSnapshots[1]?.avatar).toEqual({
+      kind: "image",
+      accentHex: null,
+      imageBase64: AVATAR_BASE64,
+    });
+    expect(syncedSnapshots[1]?.conversations).toEqual(
+      syncedSnapshots[0]?.conversations ?? [],
+    );
   });
 
   it("is a no-op off Capacitor iOS", () => {

--- a/clients/web/src/domains/chat/hooks/use-native-widget-snapshot-sync.ts
+++ b/clients/web/src/domains/chat/hooks/use-native-widget-snapshot-sync.ts
@@ -1,11 +1,11 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 
 import {
   useCanQueryDaemon,
   useUnreadConversationCount,
 } from "@/hooks/conversation-queries";
-import { getRenderedAvatarAccentHex } from "@/hooks/use-avatar-accent-var";
-import { getIslandAvatarSource } from "@/hooks/use-island-avatar-source";
+import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
+import { resolveRenderedAvatarAccentHex } from "@/hooks/use-avatar-accent-var";
 import { useTranslation } from "@/i18n";
 import {
   clearWidgetSnapshot,
@@ -24,7 +24,7 @@ import type {
   ConversationGroup,
 } from "@/types/conversation-types";
 import { encodeAvatarForIsland } from "@/utils/avatar-island-encode";
-import type { AvatarRender } from "@/utils/avatar-render";
+import { resolveAvatarRender, type AvatarRender } from "@/utils/avatar-render";
 import { activeConversationsByRecency } from "@/utils/conversation-order";
 
 /**
@@ -64,6 +64,16 @@ export const WIDGET_SNAPSHOT_HEARTBEAT_MS = 15 * 60 * 1000;
  */
 const WIDGET_AVATAR_MAX_BYTES = 64_000;
 
+/**
+ * Size the character avatar is composited at before it is rasterized.
+ *
+ * The composited SVG is resolution-independent, so this only caps the top of
+ * {@link encodeAvatarForIsland}'s ladder rather than setting the size a widget
+ * draws. Matches what `useIslandAvatarSource` composites for the Live Activity,
+ * so the two native surfaces rasterize the same source.
+ */
+const AVATAR_SOURCE_SIZE = 128;
+
 /** A snapshot before it is stamped and before its avatar bytes are attached. */
 type SnapshotContent = Omit<WidgetSnapshotPayload, "generatedAt" | "avatar">;
 
@@ -87,13 +97,13 @@ interface SnapshotAvatarFingerprint {
  * The avatar last encoded for a snapshot, keyed by the render it came from.
  *
  * Module scope, mirroring `use-live-activity-mirror.ts`: the encode is a canvas
- * draw, and the key is the resolved `AvatarRender`, a stable object republished
+ * draw, and the key is the resolved `AvatarRender`, a stable object recomputed
  * only when the avatar itself changes, so identity comparison is enough and
  * there is nothing to invalidate. The resolved bytes are kept beside the
  * promise so only the first snapshot after a change has anything to wait for.
  */
 interface AvatarEncode {
-  source: AvatarRender | null;
+  source: AvatarRender;
   /** Distinguishes one encode from the next inside the dedup key. */
   revision: number;
   /** Null while `encoding` is unsettled, and when nothing fit the budget. */
@@ -109,25 +119,29 @@ let avatarEncodes = 0;
  * The avatar the next snapshot should carry, starting its encode if this is
  * the first read since it changed.
  *
- * Read imperatively from the two publishers in `RootLayout` rather than
- * subscribed to, for the reason they are published at all: this hook runs
- * inside an effect at layout scope, and a query subscription here would
- * re-render the whole layout on every avatar settle. An avatar that changes
- * with nothing else reaches the Home Screen on the next heartbeat.
+ * `source` and `accentHex` are resolved reactively by the hook rather than read
+ * back from the two imperative publishers in `RootLayout`. Those are written by
+ * a parent's effect, and React runs a child's effects first, so a sync that
+ * read them would be a render behind whenever the avatar and the conversation
+ * data move in the same commit. An in-SPA assistant switch into an already
+ * cached destination is exactly that commit, and the stale face would then be
+ * pinned by the dedup key until the heartbeat.
  */
-function currentSnapshotAvatar(): {
+function snapshotAvatar(
+  source: AvatarRender,
+  accentHex: string | null,
+): {
   fingerprint: SnapshotAvatarFingerprint;
   encode: AvatarEncode;
 } {
-  const source = getIslandAvatarSource();
   if (avatarEncode === null || avatarEncode.source !== source) {
     avatarEncode = startAvatarEncode(source);
   }
   const encode = avatarEncode;
   return {
     fingerprint: {
-      kind: source?.kind ?? "none",
-      accentHex: getRenderedAvatarAccentHex(),
+      kind: source.kind,
+      accentHex,
       image: encode.revision,
     },
     encode,
@@ -135,7 +149,7 @@ function currentSnapshotAvatar(): {
 }
 
 /** Start encoding `source`, or record that there is nothing to encode. */
-function startAvatarEncode(source: AvatarRender | null): AvatarEncode {
+function startAvatarEncode(source: AvatarRender): AvatarEncode {
   avatarEncodes += 1;
   const encode: AvatarEncode = {
     source,
@@ -143,7 +157,7 @@ function startAvatarEncode(source: AvatarRender | null): AvatarEncode {
     base64: null,
     encoding: null,
   };
-  if (source === null) {
+  if (source.kind === "none") {
     return encode;
   }
   // An encode that fails or fits nothing is an avatar-less snapshot, never a
@@ -195,6 +209,17 @@ function snapshotKey(
  * every re-render of the layout. The avatar is in that key as an identity
  * rather than as its bytes (see {@link SnapshotAvatarFingerprint}), and the
  * bytes are attached as the payload is sent.
+ *
+ * The avatar is a reactive input rather than a read taken as the payload is
+ * built, so an avatar that changes with nothing else re-runs the sync instead
+ * of waiting for whatever re-renders the layout next. It is resolved here from
+ * the same query `RootLayout` derives its published copies from, not read back
+ * through those publishers: they are written by a parent's effect, which React
+ * runs after this layout's, so a read would be a render behind whenever an
+ * avatar change and a conversation change land in one commit. That is precisely
+ * an in-SPA assistant switch whose destination is already cached, and the dedup
+ * key would then hold the previous assistant's face on the Home Screen until
+ * the heartbeat.
  *
  * That leaves the timestamp to a heartbeat
  * ({@link WIDGET_SNAPSHOT_HEARTBEAT_MS}), because the widget reads it as
@@ -355,13 +380,39 @@ export function useNativeWidgetSnapshotSync(
   const canQueryDaemon = useCanQueryDaemon(assistantId);
   const inputsAreLive = isAssistantActive && canQueryDaemon;
 
+  // The active assistant's avatar, off the same query and through the same
+  // resolvers `RootLayout` publishes from, so the widget can never draw a
+  // different face than the app does. Subscribed rather than read back from
+  // those publishers: see {@link snapshotAvatar}. The query is already mounted
+  // at root scope, so this is another observer on a cached entry rather than a
+  // second fetch.
+  const avatar = useAssistantAvatar(assistantId);
+  const avatarSource = useMemo(
+    () =>
+      resolveAvatarRender(
+        avatar.customImageUrl,
+        avatar.components,
+        avatar.traits,
+        AVATAR_SOURCE_SIZE,
+      ),
+    [avatar.customImageUrl, avatar.components, avatar.traits],
+  );
+  const avatarAccentHex = resolveRenderedAvatarAccentHex(
+    avatar.components,
+    avatar.traits,
+    avatar.customImageUrl,
+  );
+
   // The one way to the bridge, shared by data syncs and the heartbeat so a
   // heartbeat cannot corrupt the bookkeeping a data sync depends on.
   const sendSnapshot = useCallback(
-    (content: SnapshotContent, ownerId: string | null): void => {
-      // Resolved here rather than passed in, so a heartbeat carrying content
-      // nothing has re-rendered still picks up an avatar that changed under it.
-      const { fingerprint, encode } = currentSnapshotAvatar();
+    (
+      content: SnapshotContent,
+      ownerId: string | null,
+      source: AvatarRender,
+      accentHex: string | null,
+    ): void => {
+      const { fingerprint, encode } = snapshotAvatar(source, accentHex);
       const serialized = snapshotKey(content, fingerprint);
       // The producer is recorded as the call is fired rather than when it
       // lands. A write already on the bridge can land at any moment, so a
@@ -503,7 +554,7 @@ export function useNativeWidgetSnapshotSync(
     };
     const serialized = snapshotKey(
       content,
-      currentSnapshotAvatar().fingerprint,
+      snapshotAvatar(avatarSource, avatarAccentHex).fingerprint,
     );
     // Recorded whether or not this run sends it, since it describes what the
     // App Group should hold rather than what reached it.
@@ -514,7 +565,7 @@ export function useNativeWidgetSnapshotSync(
     ) {
       return;
     }
-    sendSnapshot(content, assistantId);
+    sendSnapshot(content, assistantId, avatarSource, avatarAccentHex);
   }, [
     assistantId,
     conversations,
@@ -522,6 +573,8 @@ export function useNativeWidgetSnapshotSync(
     processingConversationIds,
     unreadCount,
     inputsResolved,
+    avatarSource,
+    avatarAccentHex,
     sendSnapshot,
     t,
   ]);
@@ -534,6 +587,11 @@ export function useNativeWidgetSnapshotSync(
   // Current means both resolved and still being refetched: cached rows from an
   // assistant that stopped serving are resolved forever, and re-stamping them
   // would defeat the native staleness degradation exactly when it applies.
+  //
+  // The avatar is a dependency, so a change re-arms the interval. That is the
+  // wanted behavior rather than a cost: the same change syncs a fresh
+  // `generatedAt` through the effect above, so restarting the window from that
+  // write is what the timer would be counting from anyway.
   useEffect(() => {
     if (!isWidgetSnapshotSyncAvailable() || !inputsResolved || !inputsAreLive) {
       return;
@@ -548,10 +606,17 @@ export function useNativeWidgetSnapshotSync(
       if (desired === null || inFlightPayloadRef.current !== null) {
         return;
       }
-      sendSnapshot(desired, assistantId);
+      sendSnapshot(desired, assistantId, avatarSource, avatarAccentHex);
     }, WIDGET_SNAPSHOT_HEARTBEAT_MS);
     return () => {
       clearInterval(heartbeat);
     };
-  }, [assistantId, inputsResolved, inputsAreLive, sendSnapshot]);
+  }, [
+    assistantId,
+    inputsResolved,
+    inputsAreLive,
+    avatarSource,
+    avatarAccentHex,
+    sendSnapshot,
+  ]);
 }

--- a/clients/web/src/domains/chat/hooks/use-native-widget-snapshot-sync.ts
+++ b/clients/web/src/domains/chat/hooks/use-native-widget-snapshot-sync.ts
@@ -4,6 +4,8 @@ import {
   useCanQueryDaemon,
   useUnreadConversationCount,
 } from "@/hooks/conversation-queries";
+import { getRenderedAvatarAccentHex } from "@/hooks/use-avatar-accent-var";
+import { getIslandAvatarSource } from "@/hooks/use-island-avatar-source";
 import { useTranslation } from "@/i18n";
 import {
   clearWidgetSnapshot,
@@ -12,6 +14,7 @@ import {
   retryPendingWidgetSnapshotClear,
   syncWidgetSnapshot,
   WIDGET_SNAPSHOT_SCHEMA_VERSION,
+  type WidgetSnapshotAvatar,
   type WidgetSnapshotConversation,
   type WidgetSnapshotPayload,
 } from "@/runtime/widget-snapshot";
@@ -20,6 +23,8 @@ import type {
   Conversation,
   ConversationGroup,
 } from "@/types/conversation-types";
+import { encodeAvatarForIsland } from "@/utils/avatar-island-encode";
+import type { AvatarRender } from "@/utils/avatar-render";
 import { activeConversationsByRecency } from "@/utils/conversation-order";
 
 /**
@@ -46,13 +51,126 @@ const MAX_SNAPSHOT_CONVERSATIONS = 3;
  */
 export const WIDGET_SNAPSHOT_HEARTBEAT_MS = 15 * 60 * 1000;
 
-/** A snapshot before it is stamped, which is also the dedup key's shape. */
-type SnapshotContent = Omit<WidgetSnapshotPayload, "generatedAt">;
+/**
+ * Byte ceiling for the avatar image a snapshot carries.
+ *
+ * Deliberately not the Live Activity's ceiling
+ * ({@link encodeAvatarForIsland}'s default): that one is ActivityKit's
+ * attribute budget, where going over costs the whole activity, so it is
+ * measured in single kilobytes. This payload is a UserDefaults write into an
+ * App Group, and a widget draws the avatar far larger than an island does, so
+ * the budget is set by what is worth writing rather than by what will start.
+ * The shell rejects anything past its own cap, which sits above this one.
+ */
+const WIDGET_AVATAR_MAX_BYTES = 64_000;
+
+/** A snapshot before it is stamped and before its avatar bytes are attached. */
+type SnapshotContent = Omit<WidgetSnapshotPayload, "generatedAt" | "avatar">;
+
+/**
+ * The avatar as the dedup key sees it.
+ *
+ * `image` is the identity of the encoded bytes rather than the bytes
+ * themselves: a widget-sized avatar is tens of kilobytes of base64, and
+ * re-serializing that on every list re-render is exactly the cost the key
+ * exists to avoid. It has to be in the key at all because a photo swapped for
+ * another photo changes neither the kind nor the accent, and would otherwise
+ * never reach the Home Screen.
+ */
+interface SnapshotAvatarFingerprint {
+  kind: WidgetSnapshotAvatar["kind"];
+  accentHex: string | null;
+  image: number;
+}
+
+/**
+ * The avatar last encoded for a snapshot, keyed by the render it came from.
+ *
+ * Module scope, mirroring `use-live-activity-mirror.ts`: the encode is a canvas
+ * draw, and the key is the resolved `AvatarRender`, a stable object republished
+ * only when the avatar itself changes, so identity comparison is enough and
+ * there is nothing to invalidate. The resolved bytes are kept beside the
+ * promise so only the first snapshot after a change has anything to wait for.
+ */
+interface AvatarEncode {
+  source: AvatarRender | null;
+  /** Distinguishes one encode from the next inside the dedup key. */
+  revision: number;
+  /** Null while `encoding` is unsettled, and when nothing fit the budget. */
+  base64: string | null;
+  /** The encode in flight, or null when there is nothing to wait for. */
+  encoding: Promise<string | null> | null;
+}
+
+let avatarEncode: AvatarEncode | null = null;
+let avatarEncodes = 0;
+
+/**
+ * The avatar the next snapshot should carry, starting its encode if this is
+ * the first read since it changed.
+ *
+ * Read imperatively from the two publishers in `RootLayout` rather than
+ * subscribed to, for the reason they are published at all: this hook runs
+ * inside an effect at layout scope, and a query subscription here would
+ * re-render the whole layout on every avatar settle. An avatar that changes
+ * with nothing else reaches the Home Screen on the next heartbeat.
+ */
+function currentSnapshotAvatar(): {
+  fingerprint: SnapshotAvatarFingerprint;
+  encode: AvatarEncode;
+} {
+  const source = getIslandAvatarSource();
+  if (avatarEncode === null || avatarEncode.source !== source) {
+    avatarEncode = startAvatarEncode(source);
+  }
+  const encode = avatarEncode;
+  return {
+    fingerprint: {
+      kind: source?.kind ?? "none",
+      accentHex: getRenderedAvatarAccentHex(),
+      image: encode.revision,
+    },
+    encode,
+  };
+}
+
+/** Start encoding `source`, or record that there is nothing to encode. */
+function startAvatarEncode(source: AvatarRender | null): AvatarEncode {
+  avatarEncodes += 1;
+  const encode: AvatarEncode = {
+    source,
+    revision: avatarEncodes,
+    base64: null,
+    encoding: null,
+  };
+  if (source === null) {
+    return encode;
+  }
+  // An encode that fails or fits nothing is an avatar-less snapshot, never a
+  // missing one: the counts and the rows are what the widgets are for.
+  encode.encoding = encodeAvatarForIsland(source, WIDGET_AVATAR_MAX_BYTES)
+    .catch(() => null)
+    .then((base64) => {
+      encode.base64 = base64;
+      encode.encoding = null;
+      return base64;
+    });
+  return encode;
+}
+
+/** The dedup key: everything a snapshot says, with the avatar as an identity. */
+function snapshotKey(
+  content: SnapshotContent,
+  avatar: SnapshotAvatarFingerprint,
+): string {
+  return JSON.stringify({ ...content, avatar });
+}
 
 /**
  * Mirror the conversation list into the iOS shell's `WidgetSnapshot` plugin
- * so the Home Screen widgets can draw unread and in-progress counts and the
- * three most recent chats. No-ops everywhere but Capacitor iOS.
+ * so the Home Screen widgets can draw unread and in-progress counts, the three
+ * most recent chats, and the assistant's own avatar. No-ops everywhere but
+ * Capacitor iOS.
  *
  * Mount once at a layout that already holds the conversation list (currently
  * `ChatLayout`, beside `useNativeRecentChatsSync`, its Shortcuts sibling).
@@ -74,7 +192,9 @@ type SnapshotContent = Omit<WidgetSnapshotPayload, "generatedAt">;
  * Syncs are deduped on the serialized snapshot with `generatedAt` excluded.
  * Including it would make every render a fresh payload and the dedup dead,
  * so the shell would take bridge traffic and a widget timeline reload on
- * every re-render of the layout.
+ * every re-render of the layout. The avatar is in that key as an identity
+ * rather than as its bytes (see {@link SnapshotAvatarFingerprint}), and the
+ * bytes are attached as the payload is sent.
  *
  * That leaves the timestamp to a heartbeat
  * ({@link WIDGET_SNAPSHOT_HEARTBEAT_MS}), because the widget reads it as
@@ -239,7 +359,10 @@ export function useNativeWidgetSnapshotSync(
   // heartbeat cannot corrupt the bookkeeping a data sync depends on.
   const sendSnapshot = useCallback(
     (content: SnapshotContent, ownerId: string | null): void => {
-      const serialized = JSON.stringify(content);
+      // Resolved here rather than passed in, so a heartbeat carrying content
+      // nothing has re-rendered still picks up an avatar that changed under it.
+      const { fingerprint, encode } = currentSnapshotAvatar();
+      const serialized = snapshotKey(content, fingerprint);
       // The producer is recorded as the call is fired rather than when it
       // lands. A write already on the bridge can land at any moment, so a
       // switch that happens in between has to see this assistant as an owner.
@@ -249,22 +372,43 @@ export function useNativeWidgetSnapshotSync(
       syncedAssistantIdRef.current = ownerId;
       inFlightPayloadRef.current = serialized;
       const attempt = (syncAttemptRef.current += 1);
-      void syncWidgetSnapshot(
-        {
-          ...content,
-          generatedAt: new Date().toISOString(),
-        },
-        ownerId,
-      ).then((landed) => {
+      const write = (imageBase64: string | null): void => {
+        // Retires a write the wait below outlived: an assistant switch clears
+        // the App Group, and a snapshot landing after it would put the
+        // departed assistant's rows straight back on the Home Screen.
         if (attempt !== syncAttemptRef.current) {
           return;
         }
-        inFlightPayloadRef.current = null;
-        if (!landed) {
-          return;
-        }
-        lastPayloadRef.current = serialized;
-      });
+        void syncWidgetSnapshot(
+          {
+            ...content,
+            avatar: {
+              kind: fingerprint.kind,
+              accentHex: fingerprint.accentHex,
+              imageBase64,
+            },
+            generatedAt: new Date().toISOString(),
+          },
+          ownerId,
+        ).then((landed) => {
+          if (attempt !== syncAttemptRef.current) {
+            return;
+          }
+          inFlightPayloadRef.current = null;
+          if (!landed) {
+            return;
+          }
+          lastPayloadRef.current = serialized;
+        });
+      };
+      // Only the first snapshot after an avatar change waits on the canvas
+      // draw; every later one reads the bytes it left behind and stays
+      // synchronous with the render that fired it.
+      if (encode.encoding === null) {
+        write(encode.base64);
+        return;
+      }
+      void encode.encoding.then(write);
     },
     [],
   );
@@ -349,14 +493,18 @@ export function useNativeWidgetSnapshotSync(
         isProcessing: isProcessing(conversation),
       }));
 
-    // Built without `generatedAt` so the serialized form is the dedup key.
+    // Built without `generatedAt` and without the avatar's bytes, so the
+    // serialized form is the dedup key.
     const content: SnapshotContent = {
       schemaVersion: WIDGET_SNAPSHOT_SCHEMA_VERSION,
       unreadCount,
       inProgressCount,
       conversations: rows,
     };
-    const serialized = JSON.stringify(content);
+    const serialized = snapshotKey(
+      content,
+      currentSnapshotAvatar().fingerprint,
+    );
     // Recorded whether or not this run sends it, since it describes what the
     // App Group should hold rather than what reached it.
     desiredContentRef.current = content;

--- a/clients/web/src/runtime/widget-snapshot.test.ts
+++ b/clients/web/src/runtime/widget-snapshot.test.ts
@@ -176,6 +176,7 @@ const SNAPSHOT: WidgetSnapshotPayload = {
   unreadCount: 2,
   inProgressCount: 1,
   conversations: [],
+  avatar: { kind: "character", accentHex: "#E9642F", imageBase64: null },
 };
 
 beforeEach(() => {

--- a/clients/web/src/runtime/widget-snapshot.ts
+++ b/clients/web/src/runtime/widget-snapshot.ts
@@ -11,8 +11,8 @@
  * gate if another platform grows a home-screen surface.
  *
  * Nothing secret crosses the bridge. The snapshot carries conversation ids,
- * titles, group names and counts, never tokens, and the widget process reads
- * it without ever holding a session of its own.
+ * titles, group names, counts and the assistant's avatar, never tokens, and
+ * the widget process reads it without ever holding a session of its own.
  */
 
 import { Capacitor, registerPlugin } from "@capacitor/core";
@@ -81,7 +81,7 @@ let pendingClearRetry: Promise<boolean> | null = null;
  * how a shell and a web bundle that disagree degrade to the empty state
  * instead of to garbled rows.
  */
-export const WIDGET_SNAPSHOT_SCHEMA_VERSION = 1;
+export const WIDGET_SNAPSHOT_SCHEMA_VERSION = 2;
 
 /**
  * One row as a widget draws it. No timestamp: the producer sends the rows in
@@ -98,6 +98,28 @@ export interface WidgetSnapshotConversation {
   isProcessing: boolean;
 }
 
+/**
+ * The assistant's avatar, so the widgets draw the user's own colors and face
+ * rather than a fixed brand palette.
+ *
+ * The bytes travel with the snapshot for the reason the Live Activity's do:
+ * the widget extension has no network stack and no auth, so an avatar handed
+ * over as a URL would never resolve.
+ *
+ * `kind` mirrors `AvatarRender`. A `character` carries the accent it is drawn
+ * with and a rasterized face; a custom `image` carries the photo and no accent,
+ * since there is no single color to match and the widget blurs the photo
+ * instead; `none` carries neither and leaves the widgets on their static brand
+ * palette. `imageBase64` is raw base64 with no data-URI prefix, and is null
+ * whenever the encode found nothing that fit, which every reader must treat as
+ * ordinary rather than as a failure.
+ */
+export interface WidgetSnapshotAvatar {
+  kind: "character" | "image" | "none";
+  accentHex: string | null;
+  imageBase64: string | null;
+}
+
 export interface WidgetSnapshotPayload {
   schemaVersion: typeof WIDGET_SNAPSHOT_SCHEMA_VERSION;
   /** ISO 8601 UTC, stamped by the producer as the payload is built. */
@@ -106,6 +128,7 @@ export interface WidgetSnapshotPayload {
   inProgressCount: number;
   /** The most recent non-archived conversations, newest first, at most three. */
   conversations: WidgetSnapshotConversation[];
+  avatar: WidgetSnapshotAvatar;
 }
 
 interface WidgetSnapshotPlugin {

--- a/clients/web/src/stores/auth-store.test.ts
+++ b/clients/web/src/stores/auth-store.test.ts
@@ -329,7 +329,7 @@ mock.module("@/lib/auth/session-cleanup", () => ({
 // a partial shape would shadow the other exports for later test files.
 const clearWidgetSnapshotMock = mock(async () => true);
 mock.module("@/runtime/widget-snapshot", () => ({
-  WIDGET_SNAPSHOT_SCHEMA_VERSION: 1,
+  WIDGET_SNAPSHOT_SCHEMA_VERSION: 2,
   isWidgetSnapshotSyncAvailable: () => false,
   readWidgetSnapshotAssistantId: () => null,
   syncWidgetSnapshot: async () => false,


### PR DESCRIPTION
## Summary
- Snapshot schema moves to v2 with a first-class avatar field: kind, rendered accent hex, and encoded image bytes
- The producer reuses the Live Activity avatar getters and encoder with a widget-sized byte budget, keeping bytes out of the dedup key
- Swift store and plugin decode the avatar with canonicalized hex and a hard size cap; the canonicalizer is hoisted into CSSHexColor for both call sites

Part of plan: ios-widgets-v2.md (PR 4 of 7)