### PR TITLE
feat(gateway): store per-contact auto-approve threshold

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -4342,6 +4342,15 @@ paths:
                             - type: "null"
                         memberDisplayName:
                           type: string
+                        autoApproveThreshold:
+                          anyOf:
+                            - type: string
+                              enum:
+                                - none
+                                - low
+                                - medium
+                                - high
+                            - type: "null"
                         interactionCount:
                           type: number
                         hasInterceptableVerificationSession:

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -5602,6 +5602,15 @@ paths:
                         anyOf:
                           - type: number
                           - type: "null"
+                      autoApproveThreshold:
+                        anyOf:
+                          - type: string
+                            enum:
+                              - none
+                              - low
+                              - medium
+                              - high
+                          - type: "null"
                       createdAt:
                         type: number
                       updatedAt:
@@ -5766,6 +5775,15 @@ paths:
                           anyOf:
                             - type: number
                             - type: "null"
+                        autoApproveThreshold:
+                          anyOf:
+                            - type: string
+                              enum:
+                                - none
+                                - low
+                                - medium
+                                - high
+                            - type: "null"
                         createdAt:
                           type: number
                         updatedAt:
@@ -5898,6 +5916,15 @@ paths:
                       interactionCount:
                         anyOf:
                           - type: number
+                          - type: "null"
+                      autoApproveThreshold:
+                        anyOf:
+                          - type: string
+                            enum:
+                              - none
+                              - low
+                              - medium
+                              - high
                           - type: "null"
                       createdAt:
                         type: number
@@ -6303,6 +6330,15 @@ paths:
                         anyOf:
                           - type: number
                           - type: "null"
+                      autoApproveThreshold:
+                        anyOf:
+                          - type: string
+                            enum:
+                              - none
+                              - low
+                              - medium
+                              - high
+                          - type: "null"
                       createdAt:
                         type: number
                       updatedAt:
@@ -6501,6 +6537,15 @@ paths:
                     interactionCount:
                       anyOf:
                         - type: number
+                        - type: "null"
+                    autoApproveThreshold:
+                      anyOf:
+                        - type: string
+                          enum:
+                            - none
+                            - low
+                            - medium
+                            - high
                         - type: "null"
                     createdAt:
                       type: number

--- a/assistant/src/runtime/routes/__tests__/contact-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/contact-routes.test.ts
@@ -316,6 +316,7 @@ const nativeGatewayRead = {
   contactType: "human",
   lastInteraction: 9200,
   interactionCount: 11,
+  autoApproveThreshold: "high",
   createdAt: 1000,
   updatedAt: 1500,
   channels: [
@@ -376,6 +377,9 @@ describe("filtered/native contact reads: daemon filters, gateway hydrates teleme
     // (4/4200/4100).
     expect(contact.interactionCount).toBe(11);
     expect(contact.lastInteraction).toBe(9200);
+    expect(
+      (contact as { autoApproveThreshold?: string | null }).autoApproveThreshold,
+    ).toBe("high");
     const channel = contact.channels[0] as Record<string, unknown>;
     expect(channel.interactionCount).toBe(11);
     expect(channel.lastSeenAt).toBe(9100);
@@ -404,6 +408,9 @@ describe("filtered/native contact reads: daemon filters, gateway hydrates teleme
     const [contact] = result.contacts;
     expect(contact.interactionCount).toBe(0);
     expect(contact.lastInteraction).toBeNull();
+    expect(
+      (contact as { autoApproveThreshold?: string | null }).autoApproveThreshold,
+    ).toBeNull();
     const channel = contact.channels[0] as Record<string, unknown>;
     expect(channel.interactionCount).toBe(0);
     expect(channel.lastSeenAt).toBeNull();

--- a/assistant/src/runtime/routes/contact-routes.ts
+++ b/assistant/src/runtime/routes/contact-routes.ts
@@ -12,6 +12,7 @@ import {
   INVITES_IPC_METHODS,
   RedeemInviteByTokenRequestSchema,
   RedeemVoiceInviteRequestSchema,
+  RiskThresholdSchema,
 } from "@vellumai/gateway-client";
 import type { ContactRead } from "@vellumai/gateway-client/gateway-ipc-contracts";
 import {
@@ -173,11 +174,12 @@ function isContactType(value: string): value is ContactType {
 // `role` is gateway-sourced: relayed reads trust the role on the `ContactRead`,
 // while daemon-native reads derive it from the gateway guardian id set at the
 // serve layer (see prepareContactResponse). Interaction telemetry
-// (lastSeenAt/interactionCount/lastInteraction) is gateway-owned: relayed reads
-// carry it directly, and daemon-native reads batch-hydrate it from the gateway
-// (see hydrateTelemetryFromGateway). On a gateway fail-soft the count
-// `interactionCount` defaults to 0 (never served as null, so callers render a
-// real number); the `lastSeenAt`/`lastInteraction` timestamps degrade to null.
+// (lastSeenAt/interactionCount/lastInteraction) and `autoApproveThreshold`
+// are gateway-owned: relayed reads carry them directly, and daemon-native
+// reads batch-hydrate them from the gateway (see hydrateTelemetryFromGateway).
+// On a gateway fail-soft the count `interactionCount` defaults to 0 (never
+// served as null, so callers render a real number); the
+// `lastSeenAt`/`lastInteraction` timestamps and the ceiling degrade to null.
 // The timestamp fields stay `.nullable()`; `interactionCount` is kept nullable
 // defensively for the relay path, but is never emitted null.
 const contactChannelSchema = z.object({
@@ -207,6 +209,7 @@ const contactSchema = z.object({
   contactType: z.enum(["human", "assistant"]),
   lastInteraction: z.number().nullable().optional(),
   interactionCount: z.number().nullable(),
+  autoApproveThreshold: RiskThresholdSchema.nullable().optional(),
   createdAt: z.number(),
   updatedAt: z.number(),
   channels: z.array(contactChannelSchema),
@@ -252,6 +255,7 @@ async function relayListContacts(limit: number, role: ContactRole | undefined) {
 type ContactWithGatewayTelemetry = Omit<ContactWithChannels, "channels"> & {
   interactionCount: number;
   lastInteraction: number | null;
+  autoApproveThreshold: ContactRead["autoApproveThreshold"];
   channels: Array<
     ContactChannel & {
       lastSeenAt: number | null;
@@ -271,16 +275,16 @@ function channelKey(type: string, address: string): string {
 }
 
 /**
- * Overlay gateway-owned interaction telemetry onto daemon-native contact reads
- * (search / contactType-filtered), which bypass the gateway list relay. The
- * daemon still owns the FILTERING (gateway-native search/contactType is
- * design-blocked), but telemetry (contact + channel
- * interactionCount/lastInteraction, channel lastSeenAt) is gateway-owned — so
- * batch-fetch it via `contacts_list_rich` keyed by the filtered id set and
- * overlay it, keeping the local assistant-DB aggregation out of the served
- * payload. Fail-soft: if the gateway read fails or omits a contact, its
- * interaction counts degrade to 0 and its timestamps to null rather than
- * falling back to the local assistant-DB aggregation.
+ * Overlay gateway-owned interaction telemetry and the contact auto-approve
+ * ceiling onto daemon-native contact reads (search / contactType-filtered),
+ * which bypass the gateway list relay. The daemon still owns the FILTERING
+ * (gateway-native search/contactType is design-blocked), but telemetry
+ * (contact + channel interactionCount/lastInteraction, channel lastSeenAt)
+ * and `autoApproveThreshold` are gateway-owned, so batch-fetch them via
+ * `contacts_list_rich` keyed by the filtered id set and overlay them. Fail-soft:
+ * if the gateway read fails or omits a contact, counts degrade to 0,
+ * timestamps to null, and the ceiling to null rather than falling back to
+ * the local assistant-DB aggregation.
  */
 async function hydrateTelemetryFromGateway(
   contacts: ContactWithChannels[],
@@ -321,6 +325,7 @@ async function hydrateTelemetryFromGateway(
       ...c,
       interactionCount: gw?.interactionCount ?? 0,
       lastInteraction: gw?.lastInteraction ?? null,
+      autoApproveThreshold: gw?.autoApproveThreshold ?? null,
       channels: c.channels.map((ch) => {
         const gwCh =
           gwChannelById.get(ch.id) ??

--- a/gateway/openapi.json
+++ b/gateway/openapi.json
@@ -1047,6 +1047,16 @@
                   "notes": {
                     "anyOf": [{ "type": "string" }, { "type": "null" }]
                   },
+                  "autoApproveThreshold": {
+                    "description": "Per-contact auto-approve ceiling. Omit to preserve; null clears.",
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": ["none", "low", "medium", "high"]
+                      },
+                      { "type": "null" }
+                    ]
+                  },
                   "contactType": { "type": "string" },
                   "assistantMetadata": {
                     "description": "Required when contactType is 'assistant'",
@@ -1121,6 +1131,16 @@
                         "interactionCount": { "type": "number" },
                         "lastInteraction": {
                           "anyOf": [{ "type": "number" }, { "type": "null" }]
+                        },
+                        "autoApproveThreshold": {
+                          "anyOf": [
+                            {
+                              "type": "string",
+                              "enum": ["none", "low", "medium", "high"]
+                            },
+                            { "type": "null" }
+                          ],
+                          "description": "Per-contact auto-approve ceiling. Null means unset (inherit cascade)."
                         },
                         "assistantMetadata": {
                           "anyOf": [
@@ -1270,6 +1290,7 @@
                         "updatedAt",
                         "interactionCount",
                         "lastInteraction",
+                        "autoApproveThreshold",
                         "assistantMetadata",
                         "channels"
                       ],

--- a/gateway/src/__tests__/contact-rich-read.test.ts
+++ b/gateway/src/__tests__/contact-rich-read.test.ts
@@ -132,6 +132,7 @@ function seedGatewayContact(opts: {
   displayName?: string;
   role?: string;
   updatedAt?: number;
+  autoApproveThreshold?: string | null;
 }): void {
   const db = getGatewayDb();
   db.insert(contacts)
@@ -140,6 +141,7 @@ function seedGatewayContact(opts: {
       displayName: opts.displayName ?? `name-${opts.id}`,
       role: opts.role ?? "contact",
       principalId: null,
+      autoApproveThreshold: opts.autoApproveThreshold ?? null,
       createdAt: opts.updatedAt ?? Date.now(),
       updatedAt: opts.updatedAt ?? Date.now(),
     })
@@ -238,6 +240,7 @@ describe("ContactStore.listContactsRich", () => {
     // Trust signals derived from gateway channels.
     expect(c1.interactionCount).toBe(4);
     expect(c1.lastInteraction).toBe(900);
+    expect(c1.autoApproveThreshold).toBeNull();
     // Channel ACL fields from gateway DB.
     const ch = c1.channels[0];
     expect(ch.status).toBe("active");
@@ -404,6 +407,7 @@ describe("ContactStore.getContactRich", () => {
     expect(result!.contact.interactionCount).toBe(7);
     expect(result!.contact.createdAt).toBe(321);
     expect(result!.contact.updatedAt).toBe(321);
+    expect(result!.contact.autoApproveThreshold).toBeNull();
     expect(result!.assistantMetadata).toBeUndefined();
 
     // Validate against the get-contact IPC response contract.
@@ -448,6 +452,35 @@ describe("ContactStore.getContactRich", () => {
     expect(result!.assistantMetadata).toBeUndefined();
   });
 
+  test("projects a stored contact auto-approve threshold", async () => {
+    seedGatewayContact({
+      id: "c-high",
+      autoApproveThreshold: "high",
+    });
+    seedGatewayChannel({ id: "ch-high", contactId: "c-high" });
+    seedAssistantInfo({ id: "c-high", contactType: "human" });
+
+    const listed = await new ContactStore().listContactsRich();
+    expect(listed[0].autoApproveThreshold).toBe("high");
+    expect(ContactReadSchema.parse(listed[0]).autoApproveThreshold).toBe(
+      "high",
+    );
+
+    const got = await new ContactStore().getContactRich("c-high");
+    expect(got!.contact.autoApproveThreshold).toBe("high");
+  });
+
+  test("treats a corrupt stored auto-approve threshold as unset", async () => {
+    seedGatewayContact({
+      id: "c-bad",
+      autoApproveThreshold: "full",
+    });
+    seedAssistantInfo({ id: "c-bad", contactType: "human" });
+
+    const listed = await new ContactStore().listContactsRich();
+    expect(listed[0].autoApproveThreshold).toBeNull();
+  });
+
   test("soft-fails on assistant DB outage for single contact", async () => {
     seedGatewayContact({ id: "c1" });
     seedAssistantInfo({ id: "c1", notes: "lost", contactType: "human" });
@@ -457,5 +490,32 @@ describe("ContactStore.getContactRich", () => {
     expect(result).not.toBeNull();
     expect(result!.contact.notes).toBeNull();
     expect(result!.contact.contactType).toBeNull();
+  });
+});
+
+describe("ContactStore.upsertContact autoApproveThreshold", () => {
+  test("persists, omit-to-preserves, and clears the contact ceiling", async () => {
+    const store = new ContactStore();
+    const created = await store.upsertContact({
+      displayName: "Alice",
+      autoApproveThreshold: "high",
+      channels: [{ type: "email", address: "alice@example.com" }],
+    });
+    expect(created.created).toBe(true);
+    expect(created.contact.autoApproveThreshold).toBe("high");
+
+    const omitted = await store.upsertContact({
+      id: created.contact.id,
+      displayName: "Alice",
+    });
+    expect(omitted.created).toBe(false);
+    expect(omitted.contact.autoApproveThreshold).toBe("high");
+
+    const cleared = await store.upsertContact({
+      id: created.contact.id,
+      displayName: "Alice",
+      autoApproveThreshold: null,
+    });
+    expect(cleared.contact.autoApproveThreshold).toBeNull();
   });
 });

--- a/gateway/src/__tests__/contacts-control-plane-proxy.test.ts
+++ b/gateway/src/__tests__/contacts-control-plane-proxy.test.ts
@@ -129,7 +129,11 @@ type ChannelAcl = {
   revokedReason: string | null;
   blockedReason: string | null;
 };
-type ContactAcl = { role: string; channels: Map<string, ChannelAcl> };
+type ContactAcl = {
+  role: string;
+  autoApproveThreshold?: string | null;
+  channels: Map<string, ChannelAcl>;
+};
 type GetAclFn = (ids: string[]) => Promise<Map<string, ContactAcl>>;
 let contactStoreGetAclMock: ReturnType<typeof mock<GetAclFn>> = mock(
   async () => new Map<string, ContactAcl>(),
@@ -1388,6 +1392,7 @@ describe("handleListContacts ACL overlay (filtered/search path)", () => {
             "c1",
             {
               role: "guardian",
+              autoApproveThreshold: "high",
               channels: new Map<string, ChannelAcl>([
                 [
                   "ch1",
@@ -1417,6 +1422,7 @@ describe("handleListContacts ACL overlay (filtered/search path)", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.contacts[0].role).toBe("guardian");
+    expect(body.contacts[0].autoApproveThreshold).toBe("high");
     const ch = body.contacts[0].channels[0];
     expect(ch.status).toBe("active");
     expect(ch.policy).toBe("deny");

--- a/gateway/src/__tests__/contacts-control-plane-proxy.test.ts
+++ b/gateway/src/__tests__/contacts-control-plane-proxy.test.ts
@@ -87,6 +87,7 @@ const DEFAULT_MOCK_CONTACT = {
   updatedAt: 1000000,
   interactionCount: 0,
   lastInteraction: null as number | null,
+  autoApproveThreshold: null as string | null,
   channels: [] as unknown[],
   assistantMetadata: null as Record<string, unknown> | null,
 };
@@ -655,6 +656,87 @@ describe("handleUpsertContact (gateway-native)", () => {
       Record<string, unknown>,
     ];
     expect(params.displayName).toBe("Alice");
+    expect(params.autoApproveThreshold).toBeUndefined();
+  });
+
+  test("passes a valid autoApproveThreshold through to the store", async () => {
+    const mockContact = {
+      ...DEFAULT_MOCK_CONTACT,
+      id: "ct_high",
+      displayName: "Alice",
+      autoApproveThreshold: "high",
+    };
+    contactStoreUpsertMock = mock(async () => ({
+      contact: mockContact,
+      created: false,
+    }));
+
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleUpsertContact(
+      new Request("http://localhost:7830/v1/contacts", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          id: "ct_high",
+          displayName: "Alice",
+          autoApproveThreshold: "high",
+        }),
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.contact.autoApproveThreshold).toBe("high");
+    const [params] = contactStoreUpsertMock.mock.calls[0] as [
+      Record<string, unknown>,
+    ];
+    expect(params.autoApproveThreshold).toBe("high");
+  });
+
+  test("clears autoApproveThreshold when the body sends null", async () => {
+    contactStoreUpsertMock = mock(async () => ({
+      contact: { ...DEFAULT_MOCK_CONTACT, displayName: "Alice" },
+      created: false,
+    }));
+
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleUpsertContact(
+      new Request("http://localhost:7830/v1/contacts", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          id: "ct_high",
+          displayName: "Alice",
+          autoApproveThreshold: null,
+        }),
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    const [params] = contactStoreUpsertMock.mock.calls[0] as [
+      Record<string, unknown>,
+    ];
+    expect(params.autoApproveThreshold).toBeNull();
+  });
+
+  test("returns 400 for an invalid autoApproveThreshold", async () => {
+    const handler = createContactsControlPlaneProxyHandler(makeConfig());
+    const res = await handler.handleUpsertContact(
+      new Request("http://localhost:7830/v1/contacts", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          displayName: "Alice",
+          autoApproveThreshold: "full",
+        }),
+      }),
+    );
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe("BAD_REQUEST");
+    expect(body.error.message).toMatch(/autoApproveThreshold/);
+    expect(contactStoreUpsertMock).not.toHaveBeenCalled();
   });
 
   test("strips role and principalId from request body (privilege escalation guard)", async () => {
@@ -907,6 +989,7 @@ describe("handleListContacts (gateway-native)", () => {
     expect(body.contacts).toHaveLength(2);
     expect(body.contacts[0].id).toBe("c1");
     expect(body.contacts[0].displayName).toBe("Alice");
+    expect(body.contacts[0].autoApproveThreshold).toBeNull();
     // Compat: externalUserId = address on each channel.
     // (DEFAULT_MOCK_CONTACT has empty channels, so this is vacuous here.)
     expect(contactStoreListMock).toHaveBeenCalledTimes(1);

--- a/gateway/src/__tests__/contacts-info-joiner.test.ts
+++ b/gateway/src/__tests__/contacts-info-joiner.test.ts
@@ -437,6 +437,7 @@ describe("ContactStore.getContactWithInfo", () => {
     expect(result!.notes).toBe("my guardian");
     expect(result!.interactionCount).toBe(7);
     expect(result!.lastInteraction).toBe(999);
+    expect(result!.autoApproveThreshold).toBeNull();
   });
 
   test("soft-fails on assistant DB outage for single contact", async () => {

--- a/gateway/src/__tests__/contacts-info-joiner.test.ts
+++ b/gateway/src/__tests__/contacts-info-joiner.test.ts
@@ -126,6 +126,7 @@ function seedGatewayContact(opts: {
   id: string;
   role?: string;
   createdAt?: number;
+  autoApproveThreshold?: string | null;
 }): void {
   const db = getGatewayDb();
   db.insert(contacts)
@@ -134,6 +135,7 @@ function seedGatewayContact(opts: {
       displayName: `name-${opts.id}`,
       role: opts.role ?? "contact",
       principalId: null,
+      autoApproveThreshold: opts.autoApproveThreshold ?? null,
       createdAt: opts.createdAt ?? Date.now(),
       updatedAt: opts.createdAt ?? Date.now(),
     })
@@ -479,6 +481,7 @@ describe("ContactStore.getAclByContactIds", () => {
 
     const c1 = result.get("c1")!;
     expect(c1.role).toBe("guardian");
+    expect(c1.autoApproveThreshold).toBeNull();
     expect(c1.channels.size).toBe(2);
     expect(c1.channels.get("ch1")!.status).toBe("active");
     expect(c1.channels.get("ch1")!.address).toBe("addr-ch1");
@@ -487,9 +490,20 @@ describe("ContactStore.getAclByContactIds", () => {
     const c2 = result.get("c2")!;
     expect(c2.role).toBe("contact");
     expect(c2.channels.get("ch3")!.status).toBe("blocked");
+    expect(c2.autoApproveThreshold).toBeNull();
 
     // The assistant DB must NOT be consulted for ACL.
     expect(fakeAssistantDb.queryCalls.length).toBe(0);
+  });
+
+  test("includes a stored contact auto-approve threshold", async () => {
+    seedGatewayContact({
+      id: "c-high",
+      autoApproveThreshold: "high",
+    });
+
+    const result = await new ContactStore().getAclByContactIds(["c-high"]);
+    expect(result.get("c-high")!.autoApproveThreshold).toBe("high");
   });
 
   test("contact with no channels yields an empty channel map", async () => {

--- a/gateway/src/db/__tests__/contact-auto-approve-threshold.test.ts
+++ b/gateway/src/db/__tests__/contact-auto-approve-threshold.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Tests for the contact-row auto-approve threshold parser.
+ *
+ * Corrupt or unknown stored values fail closed to unset (null) so a bad
+ * write cannot invent a ceiling the rest of the stack does not understand.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { parseContactAutoApproveThreshold } from "../contact-auto-approve-threshold.js";
+
+describe("parseContactAutoApproveThreshold", () => {
+  test("maps the RiskThreshold vocabulary", () => {
+    expect(parseContactAutoApproveThreshold("none")).toBe("none");
+    expect(parseContactAutoApproveThreshold("low")).toBe("low");
+    expect(parseContactAutoApproveThreshold("medium")).toBe("medium");
+    expect(parseContactAutoApproveThreshold("high")).toBe("high");
+  });
+
+  test("treats null and undefined as unset", () => {
+    expect(parseContactAutoApproveThreshold(null)).toBeNull();
+    expect(parseContactAutoApproveThreshold(undefined)).toBeNull();
+  });
+
+  test("treats unknown or malformed values as unset", () => {
+    expect(parseContactAutoApproveThreshold("full")).toBeNull();
+    expect(parseContactAutoApproveThreshold("HIGH")).toBeNull();
+    expect(parseContactAutoApproveThreshold("")).toBeNull();
+    expect(parseContactAutoApproveThreshold("relaxed")).toBeNull();
+  });
+});

--- a/gateway/src/db/contact-auto-approve-threshold.ts
+++ b/gateway/src/db/contact-auto-approve-threshold.ts
@@ -1,0 +1,20 @@
+/**
+ * Per-contact auto-approve ceiling stored on gateway `contacts`.
+ *
+ * Same vocabulary as the owner globals and channel-permission matrix
+ * (`RiskThreshold`: none | low | medium | high). Null means unset.
+ */
+
+import {
+  isRiskThreshold,
+  type RiskThreshold,
+} from "@vellumai/gateway-client";
+
+export function parseContactAutoApproveThreshold(
+  value: string | null | undefined,
+): RiskThreshold | null {
+  if (value == null) {
+    return null;
+  }
+  return isRiskThreshold(value) ? value : null;
+}

--- a/gateway/src/db/contact-store.ts
+++ b/gateway/src/db/contact-store.ts
@@ -2,13 +2,17 @@ import { type Database } from "bun:sqlite";
 
 import { and, desc, eq, gt, ne, sql } from "drizzle-orm";
 
-import { isBindingDemotion } from "@vellumai/gateway-client";
+import {
+  isBindingDemotion,
+  type RiskThreshold,
+} from "@vellumai/gateway-client";
 import {
   type AssistantContactMetadata,
   type ContactRead,
 } from "@vellumai/gateway-client/gateway-ipc-contracts";
 
 import { type GatewayDb, getGatewayDb } from "./connection.js";
+import { parseContactAutoApproveThreshold } from "./contact-auto-approve-threshold.js";
 import { contacts, contactChannels, ingressInvites } from "./schema.js";
 import {
   type ContactInfoFields,
@@ -100,6 +104,7 @@ export class ContactStore {
         displayName: contacts.displayName,
         role: contacts.role,
         principalId: contacts.principalId,
+        autoApproveThreshold: contacts.autoApproveThreshold,
         createdAt: contacts.createdAt,
         updatedAt: contacts.updatedAt,
       })
@@ -129,9 +134,9 @@ export class ContactStore {
   // These methods read the ACL shape (contacts + contact_channels) from the
   // gateway DB and join the informational shape (notes, userFile, contactType,
   // assistant_contact_metadata) from the assistant DB in a single batched
-  // query. Trust signals (interactionCount, lastInteraction, role) are
-  // derived from gateway rows only — the assistant copy is not trusted for
-  // ACL-relevant fields.
+  // query. Trust signals (interactionCount, lastInteraction, role,
+  // autoApproveThreshold) are derived from gateway rows only. The assistant
+  // copy is not trusted for ACL-relevant fields.
   //
   // Soft-fail: if the assistant DB read throws, info fields become null and
   // the ACL shape is still returned. A contact present in gateway but missing
@@ -373,6 +378,7 @@ export class ContactStore {
       contactType: c.contactType,
       interactionCount: c.interactionCount,
       lastInteraction: c.lastInteraction,
+      autoApproveThreshold: c.autoApproveThreshold,
       createdAt: c.createdAt,
       updatedAt: c.updatedAt,
       channels: c.channels.map((ch) => ({
@@ -468,6 +474,9 @@ export class ContactStore {
       displayName: contact.displayName,
       role: contact.role,
       principalId: contact.principalId,
+      autoApproveThreshold: parseContactAutoApproveThreshold(
+        contact.autoApproveThreshold,
+      ),
       createdAt: contact.createdAt,
       updatedAt: contact.updatedAt,
       channels: channels.map((ch) => ({
@@ -1164,6 +1173,7 @@ export class ContactStore {
     id?: string;
     displayName?: string;
     notes?: string | null;
+    autoApproveThreshold?: RiskThreshold | null;
     contactType?: string;
     assistantMetadata?: {
       species: string;
@@ -1231,6 +1241,9 @@ export class ContactStore {
         updatedAt: gatewayRow.updatedAt,
         interactionCount: 0,
         lastInteraction: null,
+        autoApproveThreshold: parseContactAutoApproveThreshold(
+          gatewayRow.autoApproveThreshold,
+        ),
         channels: [],
         assistantMetadata: null,
       },
@@ -1276,6 +1289,9 @@ export class ContactStore {
       if (params.displayName !== undefined) {
         updateSet.displayName = params.displayName;
       }
+      if (params.autoApproveThreshold !== undefined) {
+        updateSet.autoApproveThreshold = params.autoApproveThreshold;
+      }
       this.db.update(contacts).set(updateSet).where(eq(contacts.id, id)).run();
     };
 
@@ -1299,6 +1315,7 @@ export class ContactStore {
             displayName: newContactName,
             role: "contact",
             principalId: null,
+            autoApproveThreshold: params.autoApproveThreshold ?? null,
             createdAt: now,
             updatedAt: now,
           })
@@ -1342,6 +1359,7 @@ export class ContactStore {
             params.displayName ?? canonicalChannels?.[0]?.address ?? "Unknown",
           role: "contact",
           principalId: null,
+          autoApproveThreshold: params.autoApproveThreshold ?? null,
           createdAt: now,
           updatedAt: now,
         })
@@ -1805,6 +1823,7 @@ export interface ContactWithInfo {
   displayName: string;
   role: string;
   principalId: string | null;
+  autoApproveThreshold: RiskThreshold | null;
   createdAt: number;
   updatedAt: number;
   channels: ContactChannelShape[];

--- a/gateway/src/db/contact-store.ts
+++ b/gateway/src/db/contact-store.ts
@@ -242,9 +242,10 @@ export class ContactStore {
    * authoritative ACL onto daemon-forwarded (filtered/search) contact reads,
    * which carry neutral ACL.
    *
-   * Returns a map of contactId → { role, channels }, where `channels` is keyed
-   * by channel `id`. Empty input → empty map. Contacts/channels absent from the
-   * gateway are simply absent from the map (the caller leaves them untouched).
+   * Returns a map of contactId → { role, autoApproveThreshold, channels },
+   * where `channels` is keyed by channel `id`. Empty input → empty map.
+   * Contacts/channels absent from the gateway are simply absent from the map
+   * (the caller leaves them untouched).
    */
   async getAclByContactIds(ids: string[]): Promise<Map<string, ContactAcl>> {
     const result = new Map<string, ContactAcl>();
@@ -266,7 +267,13 @@ export class ContactStore {
       const id = row.contact.id;
       let entry = result.get(id);
       if (!entry) {
-        entry = { role: row.contact.role, channels: new Map() };
+        entry = {
+          role: row.contact.role,
+          autoApproveThreshold: parseContactAutoApproveThreshold(
+            row.contact.autoApproveThreshold,
+          ),
+          channels: new Map(),
+        };
         result.set(id, entry);
       }
       const ch = row.channel;
@@ -1782,9 +1789,10 @@ export interface ChannelAcl {
   blockedReason: string | null;
 }
 
-/** Contact-level role + channel ACL map (channel id → ChannelAcl). */
+/** Contact-level role, auto-approve ceiling, and channel ACL map. */
 export interface ContactAcl {
   role: string;
+  autoApproveThreshold: RiskThreshold | null;
   channels: Map<string, ChannelAcl>;
 }
 

--- a/gateway/src/db/schema.ts
+++ b/gateway/src/db/schema.ts
@@ -126,6 +126,7 @@ export const oneTimeMigrations = sqliteTable("one_time_migrations", {
 //
 // Gateway-owned (this table + contact_channels): id, role, principalId,
 // displayName (cache only — NOT used for ACL, kept for log readability),
+// autoApproveThreshold (per-contact RiskThreshold override, null = inherit),
 // and every contact_channels column (type, address, status, policy,
 // verifiedAt, verifiedVia, inviteId, lastSeenAt, interactionCount,
 // lastInteraction, revokedReason, blockedReason).
@@ -139,6 +140,13 @@ export const contacts = sqliteTable("contacts", {
   displayName: text("display_name").notNull(),
   role: text("role").notNull().default("contact"),
   principalId: text("principal_id"),
+  /**
+   * Per-contact auto-approve ceiling (`none` | `low` | `medium` | `high`).
+   * Null means unset: later approval resolution inherits the existing
+   * room / trust-class cascade. Same vocabulary as `auto_approve_thresholds`
+   * and the channel-permission matrix (`RiskThreshold`).
+   */
+  autoApproveThreshold: text("auto_approve_threshold"),
   createdAt: integer("created_at").notNull(),
   updatedAt: integer("updated_at").notNull(),
 });

--- a/gateway/src/http/routes/contacts-control-plane-proxy.ts
+++ b/gateway/src/http/routes/contacts-control-plane-proxy.ts
@@ -853,10 +853,11 @@ function channelKey(type: string, address: string): string {
 
 /**
  * Overlay authoritative gateway ACL onto a parsed daemon contact-list body
- * (in place). For each contact, replace contact-level `role` and per-channel
- * ACL fields from the gateway map. Channels match by `id` first, then by
- * `(type, address)`; an unmatched channel keeps the daemon's ACL. A contact
- * absent from the gateway map (dual-write gap) is left untouched + warned.
+ * (in place). For each contact, replace contact-level `role`,
+ * `autoApproveThreshold`, and per-channel ACL fields from the gateway map.
+ * Channels match by `id` first, then by `(type, address)`; an unmatched
+ * channel keeps the daemon's ACL. A contact absent from the gateway map
+ * (dual-write gap) is left untouched + warned.
  *
  * Pure aside from the warn log; mutates the passed contacts array's elements.
  */
@@ -879,6 +880,7 @@ function overlayAclOntoContacts(
     }
 
     contact.role = acl.role;
+    contact.autoApproveThreshold = acl.autoApproveThreshold;
 
     const channels = contact.channels;
     if (!Array.isArray(channels)) continue;

--- a/gateway/src/http/routes/contacts-control-plane-proxy.ts
+++ b/gateway/src/http/routes/contacts-control-plane-proxy.ts
@@ -15,7 +15,9 @@ import {
   generateInviteToken,
   hashInviteCode,
   hashInviteToken,
+  isRiskThreshold,
   isValidE164,
+  type RiskThreshold,
 } from "@vellumai/gateway-client";
 import { eq } from "drizzle-orm";
 
@@ -591,6 +593,7 @@ function toContactPayload(c: ContactWithInfo): Record<string, unknown> {
     updatedAt: c.updatedAt,
     interactionCount: c.interactionCount,
     lastInteraction: c.lastInteraction,
+    autoApproveThreshold: c.autoApproveThreshold,
     assistantMetadata: c.assistantMetadata,
     channels: c.channels.map((ch) => ({
       id: ch.id,
@@ -1196,6 +1199,29 @@ export function createContactsControlPlaneProxyHandler(config: GatewayConfig) {
       }
       const displayName = (body.displayName as string).trim();
 
+      let autoApproveThreshold: RiskThreshold | null | undefined;
+      if (body.autoApproveThreshold !== undefined) {
+        if (
+          body.autoApproveThreshold !== null &&
+          !isRiskThreshold(body.autoApproveThreshold)
+        ) {
+          return Response.json(
+            {
+              error: {
+                code: "BAD_REQUEST",
+                message:
+                  "Invalid autoApproveThreshold. Must be one of: none, low, medium, high, or null.",
+              },
+            },
+            { status: 400 },
+          );
+        }
+        autoApproveThreshold =
+          body.autoApproveThreshold === null
+            ? null
+            : body.autoApproveThreshold;
+      }
+
       if (body.contactType !== undefined && !isContactType(body.contactType)) {
         return Response.json(
           {
@@ -1358,6 +1384,7 @@ export function createContactsControlPlaneProxyHandler(config: GatewayConfig) {
         id: body.id as string | undefined,
         displayName,
         notes: body.notes as string | null | undefined,
+        autoApproveThreshold,
         contactType: body.contactType as string | undefined,
         assistantMetadata:
           body.contactType === "assistant" && assistantMeta

--- a/gateway/src/http/routes/contacts-control-plane-routes.ts
+++ b/gateway/src/http/routes/contacts-control-plane-routes.ts
@@ -1,3 +1,4 @@
+import { RiskThresholdSchema } from "@vellumai/gateway-client";
 import { z } from "zod";
 
 import type { GatewayRouteDefinition } from "./types.js";
@@ -67,6 +68,9 @@ const ContactPayloadSchema = z.object({
   updatedAt: z.number(),
   interactionCount: z.number(),
   lastInteraction: z.number().nullable(),
+  autoApproveThreshold: RiskThresholdSchema.nullable().describe(
+    "Per-contact auto-approve ceiling. Null means unset (inherit cascade).",
+  ),
   assistantMetadata: AssistantContactMetadataSchema.nullable(),
   channels: z.array(ContactChannelPayloadSchema),
 });
@@ -101,6 +105,11 @@ const UpsertContactRequestSchema = z.object({
     .min(1)
     .describe("Required on every upsert, including updates by id"),
   notes: z.string().nullable().optional(),
+  autoApproveThreshold: RiskThresholdSchema.nullable()
+    .optional()
+    .describe(
+      "Per-contact auto-approve ceiling. Omit to preserve; null clears.",
+    ),
   contactType: z.string().optional(),
   assistantMetadata: z
     .object({

--- a/gateway/src/risk/__tests__/trust-verdict-resolver.test.ts
+++ b/gateway/src/risk/__tests__/trust-verdict-resolver.test.ts
@@ -32,6 +32,7 @@ function insertContact(args: {
   displayName: string;
   role?: string;
   principalId?: string;
+  autoApproveThreshold?: string | null;
 }): void {
   const now = Date.now();
   getGatewayDb()
@@ -41,6 +42,7 @@ function insertContact(args: {
       displayName: args.displayName,
       role: args.role ?? "contact",
       principalId: args.principalId ?? null,
+      autoApproveThreshold: args.autoApproveThreshold ?? null,
       createdAt: now,
       updatedAt: now,
     })
@@ -143,6 +145,7 @@ describe("resolveTrustVerdict", () => {
     expect(verdict.guardianDisplayName).toBe("The Guardian");
     expect(verdict.contactId).toBe("c-guardian");
     expect(verdict.status).toBe("active");
+    expect(verdict.autoApproveThreshold).toBeNull();
   });
 
   test("active non-guardian member → trusted_contact, member ACL fields populated", async () => {
@@ -157,7 +160,11 @@ describe("resolveTrustVerdict", () => {
       contactId: "c-guardian",
       address: "U_GUARDIAN",
     });
-    insertContact({ id: "c-member", displayName: "Trusted Member" });
+    insertContact({
+      id: "c-member",
+      displayName: "Trusted Member",
+      autoApproveThreshold: "high",
+    });
     insertChannel({
       id: "ch-member",
       contactId: "c-member",
@@ -180,6 +187,7 @@ describe("resolveTrustVerdict", () => {
     expect(verdict.address).toBe("U_MEMBER");
     expect(verdict.externalChatId).toBe("chat-member");
     expect(verdict.memberDisplayName).toBe("Trusted Member");
+    expect(verdict.autoApproveThreshold).toBe("high");
     // Interaction telemetry carried straight off the member channel row.
     expect(verdict.interactionCount).toBe(7);
     // Guardian fields still populated from the channel binding.
@@ -218,8 +226,42 @@ describe("resolveTrustVerdict", () => {
     expect(verdict.channelId).toBeUndefined();
     expect(verdict.status).toBeUndefined();
     expect(verdict.guardianExternalUserId).toBeUndefined();
-    // No member channel → no interaction telemetry.
+    // No member channel → no interaction telemetry or contact ceiling.
     expect(verdict.interactionCount).toBeUndefined();
+    expect(verdict.autoApproveThreshold).toBeUndefined();
+  });
+
+  test("unset member threshold stamps null; corrupt stored value is treated as unset", async () => {
+    insertContact({ id: "c-unset", displayName: "Unset Member" });
+    insertChannel({
+      id: "ch-unset",
+      contactId: "c-unset",
+      address: "U_UNSET",
+    });
+    insertContact({
+      id: "c-corrupt",
+      displayName: "Corrupt Member",
+      autoApproveThreshold: "full",
+    });
+    insertChannel({
+      id: "ch-corrupt",
+      contactId: "c-corrupt",
+      address: "U_CORRUPT",
+    });
+
+    const unsetVerdict = await resolveTrustVerdict({
+      channelType: CHANNEL,
+      actorExternalId: "U_UNSET",
+    });
+    expect(unsetVerdict.contactId).toBe("c-unset");
+    expect(unsetVerdict.autoApproveThreshold).toBeNull();
+
+    const corruptVerdict = await resolveTrustVerdict({
+      channelType: CHANNEL,
+      actorExternalId: "U_CORRUPT",
+    });
+    expect(corruptVerdict.contactId).toBe("c-corrupt");
+    expect(corruptVerdict.autoApproveThreshold).toBeNull();
   });
 
   test("no actorExternalId → unknown, canonicalSenderId null", async () => {

--- a/gateway/src/risk/trust-verdict-resolver.ts
+++ b/gateway/src/risk/trust-verdict-resolver.ts
@@ -18,6 +18,7 @@ import type { TrustClass, TrustVerdict } from "@vellumai/gateway-client";
 import { and, desc, eq, sql } from "drizzle-orm";
 
 import { guardianIntegrityState } from "../auth/guardian-integrity.js";
+import { parseContactAutoApproveThreshold } from "../db/contact-auto-approve-threshold.js";
 import { getGatewayDb } from "../db/connection.js";
 import {
   contacts as gwContacts,
@@ -103,6 +104,7 @@ export async function resolveTrustVerdict(
           memberDisplayName: gwContacts.displayName,
           memberRole: gwContacts.role,
           memberPrincipalId: gwContacts.principalId,
+          autoApproveThreshold: gwContacts.autoApproveThreshold,
         })
         .from(gwContactChannels)
         .innerJoin(gwContacts, eq(gwContactChannels.contactId, gwContacts.id))
@@ -267,6 +269,9 @@ export async function resolveTrustVerdict(
     verdict.verifiedAt = memberRow.verifiedAt;
     verdict.interactionCount = memberRow.interactionCount;
     verdict.memberDisplayName = memberRow.memberDisplayName;
+    verdict.autoApproveThreshold = parseContactAutoApproveThreshold(
+      memberRow.autoApproveThreshold,
+    );
   }
 
   return verdict;

--- a/packages/gateway-client/src/__tests__/contact-read-contracts.test.ts
+++ b/packages/gateway-client/src/__tests__/contact-read-contracts.test.ts
@@ -20,6 +20,7 @@ describe("contact read contracts", () => {
       contactType: "human",
       lastInteraction: 1700000000,
       interactionCount: 12,
+      autoApproveThreshold: "medium",
       createdAt: 1699000000,
       updatedAt: 1700000000,
       channels: [
@@ -46,6 +47,7 @@ describe("contact read contracts", () => {
     const parsed = ContactReadSchema.parse(contact);
     expect(parsed.createdAt).toBe(1699000000);
     expect(parsed.updatedAt).toBe(1700000000);
+    expect(parsed.autoApproveThreshold).toBe("medium");
   });
 
   test("ContactReadSchema accepts null interactionCount (daemon-native gateway-telemetry outage fail-soft)", () => {
@@ -82,6 +84,36 @@ describe("contact read contracts", () => {
     const parsed = ContactReadSchema.parse(contact);
     expect(parsed.interactionCount).toBeNull();
     expect(parsed.channels[0].interactionCount).toBeNull();
+    expect(parsed.autoApproveThreshold).toBeUndefined();
+  });
+
+  test("ContactReadSchema accepts a null auto-approve threshold", () => {
+    const contact = {
+      id: "c1",
+      displayName: "Example User",
+      role: "contact",
+      interactionCount: 0,
+      autoApproveThreshold: null,
+      createdAt: 1699000000,
+      updatedAt: 1700000000,
+      channels: [],
+    };
+    expect(ContactReadSchema.parse(contact).autoApproveThreshold).toBeNull();
+  });
+
+  test("ContactReadSchema rejects an unknown auto-approve threshold", () => {
+    expect(() =>
+      ContactReadSchema.parse({
+        id: "c1",
+        displayName: "Example User",
+        role: "contact",
+        interactionCount: 0,
+        autoApproveThreshold: "full",
+        createdAt: 1699000000,
+        updatedAt: 1700000000,
+        channels: [],
+      }),
+    ).toThrow();
   });
 
   test("ContactReadSchema requires createdAt/updatedAt", () => {

--- a/packages/gateway-client/src/__tests__/trust-verdict-contract.test.ts
+++ b/packages/gateway-client/src/__tests__/trust-verdict-contract.test.ts
@@ -31,11 +31,29 @@ const fullVerdict: TrustVerdict = {
   verifiedAt: 1699999999,
   interactionCount: 12,
   memberDisplayName: "Member Name",
+  autoApproveThreshold: "high",
 };
 
 describe("TrustVerdictSchema", () => {
   test("round-trips a fully-populated verdict", () => {
     expect(TrustVerdictSchema.parse(fullVerdict)).toEqual(fullVerdict);
+  });
+
+  test("parses a verdict with a null contact auto-approve threshold", () => {
+    const verdict = {
+      ...fullVerdict,
+      autoApproveThreshold: null,
+    } satisfies TrustVerdict;
+    expect(TrustVerdictSchema.parse(verdict)).toEqual(verdict);
+  });
+
+  test("rejects an unknown contact auto-approve threshold", () => {
+    expect(() =>
+      TrustVerdictSchema.parse({
+        ...fullVerdict,
+        autoApproveThreshold: "full",
+      }),
+    ).toThrow();
   });
 
   test("parses a minimal verdict", () => {

--- a/packages/gateway-client/src/channel-permission-contract.ts
+++ b/packages/gateway-client/src/channel-permission-contract.ts
@@ -10,7 +10,9 @@
  *
  * Storage lives in the gateway DB (`channel_permission_overrides`) so the
  * assistant cannot tamper with it, matching `channel_admission_policy` and
- * `auto_approve_thresholds`.
+ * `auto_approve_thresholds`. A contact-level ceiling can live on
+ * `contacts.auto_approve_threshold` and is stamped on the trust verdict;
+ * that override is not a matrix cell.
  */
 
 import { z } from "zod";

--- a/packages/gateway-client/src/gateway-ipc-contracts.ts
+++ b/packages/gateway-client/src/gateway-ipc-contracts.ts
@@ -5,6 +5,8 @@
 import { CHANNEL_IDS } from "@vellumai/service-contracts/channels";
 import { z } from "zod";
 
+import { RiskThresholdSchema } from "./channel-permission-contract.js";
+
 export const GATEWAY_LOG_LEVEL_NAMES = [
   "trace",
   "debug",
@@ -275,6 +277,11 @@ export const ContactReadSchema = z.object({
   contactType: z.string().nullable().optional(),
   lastInteraction: z.number().nullable().optional(),
   interactionCount: z.number().nullable(),
+  /**
+   * Per-contact auto-approve ceiling. Null when unset (inherit cascade).
+   * Optional on the wire for version skew; gateway reads always emit it.
+   */
+  autoApproveThreshold: RiskThresholdSchema.nullable().optional(),
   createdAt: z.number(),
   updatedAt: z.number(),
   channels: z.array(ContactReadChannelSchema),

--- a/packages/gateway-client/src/trust-verdict-contract.ts
+++ b/packages/gateway-client/src/trust-verdict-contract.ts
@@ -78,6 +78,17 @@ export const TrustVerdictSchema = z.object({
   policy: z.string().optional(),
   verifiedAt: z.number().nullable().optional(),
   memberDisplayName: z.string().optional(),
+  /**
+   * Contact-level auto-approve ceiling from the gateway `contacts` row.
+   * Present when a member channel resolves. Null means the contact has no
+   * explicit override (inherit the room / trust-class cascade).
+   * Same vocabulary as `RiskThreshold` (`none` | `low` | `medium` | `high`).
+   * Inlined here so this leaf contract does not import the permission matrix.
+   */
+  autoApproveThreshold: z
+    .enum(["none", "low", "medium", "high"])
+    .nullable()
+    .optional(),
 
   // Gateway-owned interaction telemetry (a trust signal, not an info field per
   // the 2×2) — carried straight off the member `contact_channels` row.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan

Trusted Slack contacts currently get a guardian approval card for every sandbox `bash` call. Standing command grants (conversation-scoped in #41147, contact-scoped in #41220) were the wrong model. A contact should carry a risk ceiling using the existing `none | low | medium | high` vocabulary (the same values as the Strict / Conservative / Relaxed / Full access presets).

This PR is **storage and wire only**. It does not change approval calculation.

1. **This PR (data model):** nullable `contacts.auto_approve_threshold` on the gateway. Stamped on `TrustVerdict` when a member channel resolves. Exposed on `ContactRead`, `POST /v1/contacts` (omit-to-preserve, `null` clears), gateway OpenAPI upsert/payload schemas, and filtered list overlay/hydration.
2. **Next PR (usage):** approval calculation honors the stamped ceiling, including lifting sandbox `bash` when the contact ceiling allows it.
3. **Later PR (UI):** Contacts page can edit the ceiling.

Shelves #41147 and #41220. No assistant CLI, no conversation/contact bash grant table, no feature flag, no Terraform. Null on existing rows is the correct inherit default, so there is no backfill.

## Test plan

Verified locally (file-scoped `bun test` plus `tsc --noEmit` / OpenAPI `--check`):

- `packages/gateway-client` contract tests: 24 pass
- `gateway` parser, trust-verdict-resolver, contact-rich-read, contacts-info-joiner, contacts-control-plane-proxy
- `assistant` contact-routes relay + filtered hydration
- `cd assistant && bun run generate:openapi -- --check`
- `cd gateway && bun run generate:openapi -- --check`
- `assistant` `openrouter-catalog-parity` + `llm-catalog-parity` after aligning MiniMax M2.7 to live OpenRouter rates (0.3 / 1.2 / 0.06)

## CLI verb checklist

No new IPC route. Threshold writes go through existing `POST /v1/contacts`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0631fd84-675f-44ba-85f6-ca52a3aa1376?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0631fd84-675f-44ba-85f6-ca52a3aa1376&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

