### PR TITLE
fix(usage): attribute a fallback serve to the profile that actually served

### DIFF
--- a/assistant/src/__tests__/compactor-call-site-logging.test.ts
+++ b/assistant/src/__tests__/compactor-call-site-logging.test.ts
@@ -194,3 +194,64 @@ describe("compactor records llm_request_logs with call_site=compactionAgent", ()
     expect(recordRequestLogCalls[0]!.callSite).toBe("compactionAgent");
   });
 });
+
+describe("compaction result reports what actually served the summary", () => {
+  beforeEach(() => {
+    recordRequestLogCalls.length = 0;
+  });
+
+  test("rerouted summary carries the backup provider and profile", async () => {
+    // `RetryProvider` escalated the summary call to a backup profile on
+    // another provider and stamped the response, so the result must report
+    // the backup even though the compactor resolved `primaryProfile`.
+    const provider: Provider = {
+      name: "openai",
+      sendMessage: async () => ({
+        content: [{ type: "text", text: compactionResponse }],
+        model: "claude-sonnet-5",
+        actualProvider: "anthropic",
+        actualInferenceProfile: "backupProfile",
+        usage: { inputTokens: 100, outputTokens: 50 },
+        stopReason: "end_turn",
+        rawRequest: RAW_REQUEST,
+        rawResponse: RAW_RESPONSE,
+      }),
+    };
+
+    const result = await runAssistantDrivenCompaction({
+      ...args(provider),
+      overrideProfile: "primaryProfile",
+    });
+
+    expect(result.summaryModel).toBe("claude-sonnet-5");
+    expect(result.summaryActualProvider).toBe("anthropic");
+    expect(result.summaryActualInferenceProfile).toBe("backupProfile");
+    // The primary's resolution is still reported, just outranked downstream.
+    expect(result.summaryOverrideProfile).toBe("primaryProfile");
+    // Same value the request log recorded: one source of truth, not two.
+    expect(recordRequestLogCalls[0]!.provider).toBe("anthropic");
+  });
+
+  test("non-rerouted summary carries the configured provider and no profile", async () => {
+    const provider: Provider = {
+      name: "openai",
+      sendMessage: async () => ({
+        content: [{ type: "text", text: compactionResponse }],
+        model: "mock-model",
+        usage: { inputTokens: 100, outputTokens: 50 },
+        stopReason: "end_turn",
+        rawRequest: RAW_REQUEST,
+        rawResponse: RAW_RESPONSE,
+      }),
+    };
+
+    const result = await runAssistantDrivenCompaction({
+      ...args(provider),
+      overrideProfile: "primaryProfile",
+    });
+
+    expect(result.summaryActualProvider).toBe("openai");
+    expect(result.summaryActualInferenceProfile).toBeUndefined();
+    expect(result.summaryOverrideProfile).toBe("primaryProfile");
+  });
+});

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -23,6 +23,10 @@ import { resetPluginRegistryAndRegisterDefaults } from "../plugins/defaults/inde
 import { registerPlugin } from "../plugins/registry.js";
 import type { Message, Provider, ToolDefinition } from "../providers/types.js";
 import { ContextOverflowError } from "../providers/types.js";
+import {
+  resolveUsageAttribution,
+  type UsageAttributionInput,
+} from "../usage/attribution.js";
 import { getWorkspaceDir } from "../util/platform.js";
 import { setConfig } from "./helpers/set-config.js";
 
@@ -1761,6 +1765,108 @@ describe("session-agent-loop", () => {
       expect(mainAgentCall?.[1]).toBe(12);
       expect(mainAgentCall?.[2]).toBe(3);
       expect(mainAgentCall?.[3]).toBe("gpt-4.1-2026-03-01");
+    });
+
+    test("attributes a fallback serve to the profile that actually served", async () => {
+      // The turn resolved to the primary managed profile, the request hit an
+      // outage-shaped failure, and `RetryProvider` escalated to a backup
+      // profile on a different provider, stamping `actualProvider` and
+      // `actualInferenceProfile` on the response it returns.
+      seedLlmConfig({
+        profiles: {
+          ...disabledCatalogDefaultProfiles,
+          backupProfile: { provider: "anthropic", model: "claude-sonnet-5" },
+        },
+      });
+
+      const ctx = makeCtx({
+        providerResponses: [
+          {
+            content: [{ type: "text", text: "Hi there." }],
+            model: "claude-sonnet-5",
+            usage: { inputTokens: 12, outputTokens: 3 },
+            stopReason: "end_turn",
+            actualProvider: "anthropic",
+            actualInferenceProfile: "backupProfile",
+          },
+        ],
+        provider: {
+          name: "openai",
+          sendMessage: async () => ({
+            content: [{ type: "text", text: "title" }],
+            model: "mock",
+            usage: { inputTokens: 0, outputTokens: 0 },
+            stopReason: "end_turn",
+          }),
+        } as unknown as Conversation["provider"],
+      });
+
+      await runAgentLoopImpl(ctx, "hello", "msg-1", () => {});
+
+      const mainAgentCall = recordUsageMock.mock.calls.find(
+        (call) => (call as unknown[])[5] === "main_agent",
+      ) as unknown[] | undefined;
+
+      expect(mainAgentCall).toBeDefined();
+      // All three attribution facets of the row must describe the same call.
+      expect(mainAgentCall?.[0]).toMatchObject({ providerName: "anthropic" });
+      expect(mainAgentCall?.[3]).toBe("claude-sonnet-5");
+      const attribution = mainAgentCall?.[12] as UsageAttributionInput;
+      expect(attribution.callSite).toBe("mainAgent");
+      expect(attribution.overrideProfile).toBe("backupProfile");
+      expect(attribution.forceOverrideProfile).toBe(true);
+      // `inference_profile` on the persisted row is this snapshot's applied
+      // profile, so resolve it the way `recordUsage` does and assert the
+      // column value itself rather than only the input that feeds it.
+      expect(resolveUsageAttribution(attribution).appliedProfile).toBe(
+        "backupProfile",
+      );
+    });
+
+    test("leaves a non-fallback turn attributed to the conversation's own profile", async () => {
+      // No reroute: the response carries no `actualInferenceProfile`, so the
+      // attribution input stays exactly what the conversation resolved and
+      // carries no forced override.
+      seedLlmConfig({
+        profiles: {
+          ...disabledCatalogDefaultProfiles,
+          backupProfile: { provider: "anthropic", model: "claude-sonnet-5" },
+        },
+      });
+
+      const ctx = makeCtx({
+        providerResponses: [
+          {
+            content: [{ type: "text", text: "Hi there." }],
+            model: "gpt-4.1-2026-03-01",
+            usage: { inputTokens: 12, outputTokens: 3 },
+            stopReason: "end_turn",
+          },
+        ],
+        provider: {
+          name: "openai",
+          sendMessage: async () => ({
+            content: [{ type: "text", text: "title" }],
+            model: "mock",
+            usage: { inputTokens: 0, outputTokens: 0 },
+            stopReason: "end_turn",
+          }),
+        } as unknown as Conversation["provider"],
+      });
+
+      await runAgentLoopImpl(ctx, "hello", "msg-1", () => {});
+
+      const mainAgentCall = recordUsageMock.mock.calls.find(
+        (call) => (call as unknown[])[5] === "main_agent",
+      ) as unknown[] | undefined;
+
+      expect(mainAgentCall).toBeDefined();
+      expect(mainAgentCall?.[0]).toMatchObject({ providerName: "openai" });
+      expect(mainAgentCall?.[3]).toBe("gpt-4.1-2026-03-01");
+      expect(mainAgentCall?.[12]).toEqual({
+        callSite: "mainAgent",
+        overrideProfile: null,
+      });
     });
 
     test("persists the served model onto the assistant row's metadata at finalize", async () => {

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -4143,6 +4143,138 @@ describe("session-agent-loop", () => {
       );
     });
 
+    test("rerouted compaction records usage under the profile that actually served", async () => {
+      const ctx = makeCtx();
+
+      await applyCompactionResult(
+        ctx,
+        {
+          messages: [
+            { role: "user", content: [{ type: "text", text: "summary" }] },
+          ],
+          compactedPersistedMessages: 4,
+          previousEstimatedInputTokens: 12000,
+          estimatedInputTokens: 3000,
+          maxInputTokens: 100000,
+          thresholdTokens: 80000,
+          compactedMessages: 4,
+          summaryCalls: 1,
+          summaryInputTokens: 100,
+          summaryOutputTokens: 20,
+          summaryModel: "claude-sonnet-5",
+          summaryText: "summary",
+          summaryCallSite: "compactionAgent",
+          // What the compactor resolved before the call...
+          summaryOverrideProfile: "primaryProfile",
+          // ...and what the reroute actually served.
+          summaryActualProvider: "anthropic",
+          summaryActualInferenceProfile: "backupProfile",
+        },
+        () => {},
+        "req-1",
+      );
+
+      const compactorCall = recordUsageMock.mock.calls.find(
+        (call) => (call as unknown[])[5] === "context_compactor",
+      ) as unknown[] | undefined;
+
+      expect(compactorCall).toBeDefined();
+      // All three attribution facets of the row describe the same call.
+      expect(compactorCall?.[0]).toMatchObject({ providerName: "anthropic" });
+      expect(compactorCall?.[3]).toBe("claude-sonnet-5");
+      expect(compactorCall?.[12]).toEqual({
+        callSite: "compactionAgent",
+        overrideProfile: "backupProfile",
+        forceOverrideProfile: true,
+      });
+    });
+
+    test("non-rerouted compaction keeps the compactor's own attribution", async () => {
+      const ctx = makeCtx();
+
+      await applyCompactionResult(
+        ctx,
+        {
+          messages: [
+            { role: "user", content: [{ type: "text", text: "summary" }] },
+          ],
+          compactedPersistedMessages: 4,
+          previousEstimatedInputTokens: 12000,
+          estimatedInputTokens: 3000,
+          maxInputTokens: 100000,
+          thresholdTokens: 80000,
+          compactedMessages: 4,
+          summaryCalls: 1,
+          summaryInputTokens: 100,
+          summaryOutputTokens: 20,
+          summaryModel: "mock-model",
+          summaryText: "summary",
+          summaryCallSite: "compactionAgent",
+          summaryOverrideProfile: "primaryProfile",
+          summaryActualProvider: "openai",
+        },
+        () => {},
+        "req-1",
+      );
+
+      const compactorCall = recordUsageMock.mock.calls.find(
+        (call) => (call as unknown[])[5] === "context_compactor",
+      ) as unknown[] | undefined;
+
+      expect(compactorCall).toBeDefined();
+      expect(compactorCall?.[0]).toMatchObject({ providerName: "openai" });
+      expect(compactorCall?.[3]).toBe("mock-model");
+      expect(compactorCall?.[12]).toEqual({
+        callSite: "compactionAgent",
+        overrideProfile: "primaryProfile",
+      });
+    });
+
+    test("compaction that served no call falls back to the conversation's provider", async () => {
+      // The degraded shape: `emptyResult` paths record no served attribution
+      // because no call happened. Provider must fall back to the
+      // conversation's own, and the attribution input must be byte-identical
+      // to what it was before served attribution existed.
+      const ctx = makeCtx();
+
+      await applyCompactionResult(
+        ctx,
+        {
+          messages: [
+            { role: "user", content: [{ type: "text", text: "summary" }] },
+          ],
+          compactedPersistedMessages: 4,
+          previousEstimatedInputTokens: 12000,
+          estimatedInputTokens: 3000,
+          maxInputTokens: 100000,
+          thresholdTokens: 80000,
+          compactedMessages: 4,
+          summaryCalls: 1,
+          summaryInputTokens: 100,
+          summaryOutputTokens: 20,
+          summaryModel: "mock-model",
+          summaryText: "summary",
+          summaryCallSite: "compactionAgent",
+          summaryOverrideProfile: "primaryProfile",
+        },
+        () => {},
+        "req-1",
+      );
+
+      const compactorCall = recordUsageMock.mock.calls.find(
+        (call) => (call as unknown[])[5] === "context_compactor",
+      ) as unknown[] | undefined;
+
+      expect(compactorCall).toBeDefined();
+      expect(compactorCall?.[0]).toMatchObject({
+        providerName: "mock-provider",
+      });
+      expect(compactorCall?.[12]).toEqual({
+        callSite: "compactionAgent",
+        overrideProfile: "primaryProfile",
+      });
+    });
+
     test("applyCompactionResult advances the persisted count from the trusted in-context boundary", async () => {
       // Trusted views slice past the already-compacted prefix, so a further
       // compaction advances the persisted count from the mirrored DB boundary.

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -371,6 +371,16 @@ export type AgentEvent =
       cacheReadInputTokens?: number;
       model: string;
       actualProvider?: string;
+      /**
+       * Inference profile that actually governed the call, set only when a
+       * wrapper re-routed the request away from the caller's own resolution
+       * (`RetryProvider`'s fallback-profile escalation). Travels alongside
+       * `actualProvider` so the daemon's usage ledger attributes a degraded
+       * serve to the backup profile that answered rather than to the primary
+       * that failed. Absent on the normal (non-rerouted) path, where the
+       * caller's own resolution is already correct.
+       */
+      actualInferenceProfile?: string;
       providerDurationMs: number;
       rawRequest?: unknown;
       rawResponse?: unknown;
@@ -1819,6 +1829,14 @@ export class AgentLoop {
           cacheReadInputTokens: response.usage.cacheReadInputTokens,
           model: response.model,
           actualProvider: response.actualProvider ?? this.provider.name,
+          // Only present when a wrapper rerouted this call, so the normal
+          // path's event shape stays byte-identical. There is no caller-side
+          // fallback value to fill in: the loop's own profile resolution is
+          // exactly what a reroute invalidates, and the daemon already reads
+          // its own resolution when this is absent.
+          ...(response.actualInferenceProfile !== undefined
+            ? { actualInferenceProfile: response.actualInferenceProfile }
+            : {}),
           providerDurationMs,
           rawRequest: response.rawRequest,
           rawResponse: response.rawResponse,

--- a/assistant/src/context/compactor.ts
+++ b/assistant/src/context/compactor.ts
@@ -76,6 +76,40 @@ const COMPACTION_CALL_SITE: LLMCallSite = "mainAgent";
 const COMPACTION_LOG_CALL_SITE: LLMCallSite = "compactionAgent";
 
 /**
+ * What actually served a compaction call, for attribution on both the request
+ * log and the usage row. A wrapper may reroute the request away from the
+ * caller's resolution (`RetryProvider`'s fallback-profile escalation), in
+ * which case the response carries the provider and profile that answered.
+ *
+ * Single source of truth on purpose: the request log and the usage row must
+ * never disagree about which provider ran, and every result-construction site
+ * below spreads {@link servedAttribution} rather than re-deriving the pair.
+ */
+function servedProvider(
+  response: ProviderResponse,
+  provider: Provider,
+): string {
+  return response.actualProvider ?? provider.name;
+}
+
+function servedAttribution(
+  response: ProviderResponse,
+  provider: Provider,
+): Pick<
+  CompactionRunResult,
+  "summaryActualProvider" | "summaryActualInferenceProfile"
+> {
+  return {
+    summaryActualProvider: servedProvider(response, provider),
+    // Only present on a reroute. Absent leaves `summaryOverrideProfile` in
+    // charge, which is what the caller resolved and what actually ran.
+    ...(response.actualInferenceProfile !== undefined
+      ? { summaryActualInferenceProfile: response.actualInferenceProfile }
+      : {}),
+  };
+}
+
+/**
  * Best-effort: persist a successful compaction LLM call into
  * `llm_request_logs` with `call_site = "compactionAgent"`. The compactor
  * opts out of automatic usage tracking (`usageTracking: "manual"`), so
@@ -100,7 +134,7 @@ function recordCompactionRequestLog(
       JSON.stringify(response.rawRequest),
       JSON.stringify(response.rawResponse),
       undefined,
-      response.actualProvider ?? provider.name,
+      servedProvider(response, provider),
       COMPACTION_LOG_CALL_SITE,
     );
   } catch (err) {
@@ -321,6 +355,22 @@ export interface CompactionRunResult {
   summaryModel: string;
   summaryCallSite?: LLMCallSite;
   summaryOverrideProfile?: string | null;
+  /**
+   * Provider that actually served the summary call: the response's
+   * `actualProvider` when a wrapper rerouted the request, otherwise the
+   * configured provider's name. Set on every path that made a call, so the
+   * usage row's `provider` follows a fallback the way its `model` already
+   * does. Absent only where no call happened (see {@link emptyResult}), where
+   * the caller's own provider stands.
+   */
+  summaryActualProvider?: string;
+  /**
+   * Inference profile that actually governed the summary call, set only when
+   * a wrapper rerouted the request away from `summaryOverrideProfile`
+   * (`RetryProvider`'s fallback-profile escalation). Absent on the normal
+   * path, where `summaryOverrideProfile` is already correct.
+   */
+  summaryActualInferenceProfile?: string;
   summaryCacheCreationInputTokens?: number;
   summaryCacheReadInputTokens?: number;
   summaryRawResponses?: unknown[];
@@ -1052,6 +1102,18 @@ export function buildSummaryMemoryText(
 // Orchestrator
 // ---------------------------------------------------------------------------
 
+/**
+ * A result for every path that compacted nothing: the pre-call bail-outs
+ * (disabled, below threshold, no messages, bad boundary) and the two
+ * provider-error paths, which are spread over with `summaryFailed: true`.
+ *
+ * Deliberately carries no `summaryActualProvider` /
+ * `summaryActualInferenceProfile`: no call was served, so there is nothing to
+ * attribute to, and leaving them absent keeps the caller's own provider and
+ * profile in charge. Nothing is billed either way, since the zero token
+ * counts here make `recordUsage` return before it writes a row. The
+ * call-bearing paths below spread {@link servedAttribution} on top.
+ */
 function emptyResult(
   args: CompactionRunArgs,
   thresholdTokens: number,
@@ -1340,6 +1402,7 @@ export async function runAssistantDrivenCompaction(
       summaryInputTokens: response.usage.inputTokens,
       summaryOutputTokens: response.usage.outputTokens,
       summaryModel: response.model,
+      ...servedAttribution(response, args.provider),
       summaryCacheCreationInputTokens:
         response.usage.cacheCreationInputTokens ?? 0,
       summaryCacheReadInputTokens: response.usage.cacheReadInputTokens ?? 0,
@@ -1378,6 +1441,7 @@ export async function runAssistantDrivenCompaction(
         summaryInputTokens: response.usage.inputTokens,
         summaryOutputTokens: response.usage.outputTokens,
         summaryModel: response.model,
+        ...servedAttribution(response, args.provider),
         summaryCacheCreationInputTokens:
           response.usage.cacheCreationInputTokens ?? 0,
         summaryCacheReadInputTokens: response.usage.cacheReadInputTokens ?? 0,
@@ -1548,6 +1612,7 @@ export async function runAssistantDrivenCompaction(
       summaryInputTokens: response.usage.inputTokens,
       summaryOutputTokens: response.usage.outputTokens,
       summaryModel: response.model,
+      ...servedAttribution(response, args.provider),
       summaryCacheCreationInputTokens:
         response.usage.cacheCreationInputTokens ?? 0,
       summaryCacheReadInputTokens: response.usage.cacheReadInputTokens ?? 0,
@@ -1623,6 +1688,7 @@ export async function runAssistantDrivenCompaction(
     summaryModel: response.model,
     summaryCallSite: COMPACTION_CALL_SITE,
     summaryOverrideProfile: args.overrideProfile ?? null,
+    ...servedAttribution(response, args.provider),
     summaryCacheCreationInputTokens:
       response.usage.cacheCreationInputTokens ?? 0,
     summaryCacheReadInputTokens: response.usage.cacheReadInputTokens ?? 0,
@@ -1808,6 +1874,12 @@ export async function runEmergencyCompaction(
       summaryInputTokens: response.usage.inputTokens,
       summaryOutputTokens: response.usage.outputTokens,
       summaryModel: response.model,
+      // This path bills real tokens, so its provider must follow a reroute
+      // like every other call-bearing path. It is the one such path that sets
+      // no `summaryCallSite`/`summaryOverrideProfile`, which leaves its
+      // profile attribution null; that gap predates this change and is not
+      // widened by it.
+      ...servedAttribution(response, args.provider),
     };
   }
 
@@ -1855,6 +1927,7 @@ export async function runEmergencyCompaction(
     summaryModel: response.model,
     summaryCallSite: COMPACTION_CALL_SITE,
     summaryOverrideProfile: args.overrideProfile ?? null,
+    ...servedAttribution(response, args.provider),
     summaryCacheCreationInputTokens:
       response.usage.cacheCreationInputTokens ?? 0,
     summaryCacheReadInputTokens: response.usage.cacheReadInputTokens ?? 0,

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -211,6 +211,15 @@ export interface EventHandlerState {
   firstAssistantText: string;
   /** Most recent resolved provider for the current exchange's usage accounting. */
   exchangeProviderName: string | undefined;
+  /**
+   * Inference profile the most recent LLM call actually ran under, set only
+   * when a wrapper rerouted that call (`RetryProvider`'s fallback-profile
+   * escalation). Overwritten by every call, exactly like
+   * `exchangeProviderName` and `model`, so the ledger row's provider, model,
+   * and profile all describe the same call. `undefined` means the last call
+   * was not rerouted and the conversation's own profile resolution stands.
+   */
+  exchangeInferenceProfile: string | undefined;
   exchangeInputTokens: number;
   exchangeCacheCreationInputTokens: number;
   exchangeCacheReadInputTokens: number;
@@ -578,6 +587,7 @@ export function createEventHandlerState(): EventHandlerState {
     pendingDirectiveDisplayBuffer: "",
     firstAssistantText: "",
     exchangeProviderName: undefined,
+    exchangeInferenceProfile: undefined,
     exchangeInputTokens: 0,
     exchangeCacheCreationInputTokens: 0,
     exchangeCacheReadInputTokens: 0,
@@ -3071,6 +3081,11 @@ function handleUsage(
 ): void {
   const providerName = event.actualProvider ?? deps.ctx.provider.name;
   state.exchangeProviderName = providerName;
+  // Assigned unconditionally, not merged: a later non-rerouted call clearing
+  // this back to `undefined` is correct, because provider and model are being
+  // overwritten from that same call. Keeping a stale profile from an earlier
+  // fallback would reintroduce the very contradiction this field prevents.
+  state.exchangeInferenceProfile = event.actualInferenceProfile;
   state.exchangeLlmCallCount += 1;
   state.exchangeInputTokens += event.inputTokens;
   state.lastCallInputTokens = event.inputTokens;

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -1684,9 +1684,23 @@ export async function runAgentLoopImpl(
         tokens: state.lastCallInputTokens,
         maxTokens: resolveCurrentMaxInputTokens(),
       },
+      // When the turn's last LLM call was rerouted to a backup profile, that
+      // profile is what served the tokens being recorded, so it outranks the
+      // conversation's own resolution, which knows nothing about the
+      // reroute. `provider` and `model` on this same row already follow the
+      // backup (via `state.exchangeProviderName` / `state.model`), so
+      // attributing the profile from the primary would write a row that
+      // contradicts itself. `forceOverrideProfile` floats it above the
+      // call-site profile exactly as the fallback dispatch did.
       {
         callSite: turnCallSite,
-        overrideProfile: resolveCurrentOverrideProfile() ?? null,
+        overrideProfile:
+          state.exchangeInferenceProfile ??
+          resolveCurrentOverrideProfile() ??
+          null,
+        ...(state.exchangeInferenceProfile !== undefined
+          ? { forceOverrideProfile: true }
+          : {}),
       },
       turnCronRunId,
     );
@@ -1975,6 +1989,13 @@ function emitUsage(
   attribution?: {
     callSite: LLMCallSite | null;
     overrideProfile?: string | null;
+    /**
+     * Float `overrideProfile` above the call-site profile, matching how the
+     * dispatch path floated it. Set when the profile being attributed is the
+     * one a reroute actually served under rather than the caller's own
+     * resolution.
+     */
+    forceOverrideProfile?: boolean;
   },
   cronRunId: string | null = null,
 ): void {

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -2072,6 +2072,8 @@ export async function applyCompactionResult(
     summaryRawResponses?: unknown[];
     summaryCallSite?: LLMCallSite;
     summaryOverrideProfile?: string | null;
+    summaryActualProvider?: string;
+    summaryActualInferenceProfile?: string;
   },
   onEvent: (msg: AssistantEvent) => void,
   reqId: string | null,
@@ -2146,12 +2148,26 @@ export async function applyCompactionResult(
     result.summaryCacheCreationInputTokens ?? 0,
     result.summaryCacheReadInputTokens ?? 0,
     collapseRawResponses(result.summaryRawResponses),
-    undefined /* providerName */,
+    // The provider that actually served the summary, which follows a fallback
+    // reroute the way `summaryModel` already did. Undefined only where no call
+    // was made, and `emitUsage` then falls back to `ctx.provider.name` exactly
+    // as before.
+    result.summaryActualProvider /* providerName */,
     1 /* llmCallCount */,
     undefined /* contextWindow */,
+    // Same rule as the main-agent row above, applied to the compaction row:
+    // a rerouted summary is attributed to the profile that answered, not to
+    // the one the compactor resolved before the call. The two call sites set
+    // this parameter independently off their own state and never share it.
     {
       callSite: result.summaryCallSite ?? null,
-      overrideProfile: result.summaryOverrideProfile ?? null,
+      overrideProfile:
+        result.summaryActualInferenceProfile ??
+        result.summaryOverrideProfile ??
+        null,
+      ...(result.summaryActualInferenceProfile !== undefined
+        ? { forceOverrideProfile: true }
+        : {}),
     },
     options.cronRunId ?? null,
   );

--- a/assistant/src/plugins/defaults/compaction/window-manager.ts
+++ b/assistant/src/plugins/defaults/compaction/window-manager.ts
@@ -84,6 +84,10 @@ export interface ContextWindowResult {
   summaryModel: string;
   summaryCallSite?: LLMCallSite;
   summaryOverrideProfile?: string | null;
+  /** See {@link CompactionRunResult.summaryActualProvider}. */
+  summaryActualProvider?: string;
+  /** See {@link CompactionRunResult.summaryActualInferenceProfile}. */
+  summaryActualInferenceProfile?: string;
   summaryCacheCreationInputTokens?: number;
   summaryCacheReadInputTokens?: number;
   summaryRawResponses?: unknown[];

--- a/assistant/src/runtime/__tests__/agent-wake.test.ts
+++ b/assistant/src/runtime/__tests__/agent-wake.test.ts
@@ -266,6 +266,7 @@ const recordRequestLogCalls: Array<{
 }> = [];
 const recordUsageCalls: Array<{
   conversationId: string;
+  providerName: string | undefined;
   inputTokens: number;
   outputTokens: number;
   model: string;
@@ -279,7 +280,7 @@ const recordUsageCalls: Array<{
 }> = [];
 mock.module("../../daemon/conversation-usage.js", () => ({
   recordUsage: (
-    ctx: { conversationId: string },
+    ctx: { conversationId: string; providerName?: string },
     inputTokens: number,
     outputTokens: number,
     model: string,
@@ -300,6 +301,7 @@ mock.module("../../daemon/conversation-usage.js", () => ({
   ) => {
     recordUsageCalls.push({
       conversationId: ctx.conversationId,
+      providerName: ctx.providerName,
       inputTokens,
       outputTokens,
       model,
@@ -2982,6 +2984,96 @@ describe("wakeAgentForOpportunity", () => {
     expect(recordUsageCalls[0]).toMatchObject({
       overrideProfile: "source-profile",
       forceOverrideProfile: true,
+      selectionSeed: conversation.conversationId,
+    });
+  });
+
+  test("rerouted wake records usage under the profile that actually served", async () => {
+    // The wake resolved its own profile before the run; the request then hit
+    // an outage-shaped failure and `RetryProvider` escalated to a backup
+    // profile on a different provider, stamping both `actualProvider` and
+    // `actualInferenceProfile` on the response the loop reports.
+    const usageEvent: AgentEvent = {
+      type: "usage",
+      inputTokens: 100,
+      outputTokens: 5,
+      model: "claude-sonnet-5",
+      actualProvider: "anthropic",
+      actualInferenceProfile: "backupProfile",
+      providerDurationMs: 10,
+      rawRequest: { request: "rerouted wake" },
+      rawResponse: { response: "real reply" },
+    };
+    const conversation = makeWakeConversation({
+      baseline: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+      scriptedEvents: [usageEvent],
+      scriptedAssistant: {
+        role: "assistant",
+        content: [{ type: "text", text: "real reply" }],
+      },
+    });
+
+    await wakeAgentForOpportunity(
+      {
+        conversationId: conversation.conversationId,
+        hint: "do reply",
+        source: "unit-test",
+        callSite: "memoryRetrospective",
+      },
+      { resolveTarget: async () => conversation },
+    );
+
+    // All three attribution facets of the row must describe the same call.
+    // Provider and model already followed the backup off the event; the
+    // profile has to follow it too or the row contradicts itself.
+    expect(recordUsageCalls).toHaveLength(1);
+    expect(recordUsageCalls[0]).toMatchObject({
+      providerName: "anthropic",
+      model: "claude-sonnet-5",
+      overrideProfile: "backupProfile",
+      forceOverrideProfile: true,
+      selectionSeed: conversation.conversationId,
+    });
+  });
+
+  test("non-rerouted wake keeps its own profile resolution", async () => {
+    // No reroute: the event carries no `actualInferenceProfile`, so the wake's
+    // own pre-run resolution stands and nothing is floated above the call site.
+    const usageEvent: AgentEvent = {
+      type: "usage",
+      inputTokens: 100,
+      outputTokens: 5,
+      model: "test-model",
+      actualProvider: "test-provider",
+      providerDurationMs: 10,
+      rawRequest: { request: "normal wake" },
+      rawResponse: { response: "real reply" },
+    };
+    const conversation = makeWakeConversation({
+      baseline: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+      scriptedEvents: [usageEvent],
+      scriptedAssistant: {
+        role: "assistant",
+        content: [{ type: "text", text: "real reply" }],
+      },
+    });
+
+    await wakeAgentForOpportunity(
+      {
+        conversationId: conversation.conversationId,
+        hint: "do reply",
+        source: "unit-test",
+        callSite: "memoryRetrospective",
+      },
+      { resolveTarget: async () => conversation },
+    );
+
+    expect(recordUsageCalls).toHaveLength(1);
+    expect(recordUsageCalls[0]).toMatchObject({
+      providerName: "test-provider",
+      model: "test-model",
+      overrideProfile: null,
+      forceOverrideProfile: false,
       selectionSeed: conversation.conversationId,
     });
   });

--- a/assistant/src/runtime/agent-wake.ts
+++ b/assistant/src/runtime/agent-wake.ts
@@ -1125,10 +1125,23 @@ export async function wakeAgentForOpportunity(
             // the conversation-id seed resolves the same mix arm the dispatch
             // path chose. Without these, attribution credits the call-site
             // profile/arm instead of the one that ran.
+            //
+            // A rerouted call (`RetryProvider`'s fallback-profile escalation)
+            // outranks both: the wake resolved `overrideProfile` before the
+            // run and cannot know the request was escalated, while
+            // `providerName` and `model` on this same row already follow the
+            // backup off the event. Attributing the profile from the wake's
+            // own resolution would write a row that contradicts itself. One
+            // row is written per `usage` event, each from that event alone,
+            // so this needs no cross-call state: a later non-rerouted call
+            // writes its own row under the wake's resolution.
             {
               callSite,
-              overrideProfile: overrideProfile ?? null,
-              forceOverrideProfile,
+              overrideProfile:
+                event.actualInferenceProfile ?? overrideProfile ?? null,
+              forceOverrideProfile:
+                event.actualInferenceProfile !== undefined ||
+                forceOverrideProfile,
               selectionSeed: conversationId,
             },
             opts.cronRunId ?? null,


### PR DESCRIPTION
## Summary
- A degraded turn recorded provider and model from the backup but inference_profile from the failed primary, producing a self-contradictory llm_usage row and corrupting per-profile cost analysis
- Threads actualInferenceProfile through the usage event the same way actualProvider already travels, so the local ledger agrees with the platform's X-Vellum-* attribution
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41250" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->