### PR TITLE
fix(providers): give breaker-open sends a retry budget and stop false outage verdicts

### DIFF
--- a/assistant/src/__tests__/fallback-breaker.test.ts
+++ b/assistant/src/__tests__/fallback-breaker.test.ts
@@ -1026,6 +1026,41 @@ describe("recovery probe verdicts", () => {
     expect(shouldSkipPrimary(PRIMARY_ROUTE)).toBe(true);
   });
 
+  test("a probe that spent a corrective resend keeps the same total budget", async () => {
+    // The repaired path: the probe sends twice (the original plus the
+    // corrective resend) before the stream corruption hands the request to the
+    // retry loop. A seed that counted only the original probe would let this
+    // request make one more primary send than everyone else, which is the
+    // opposite of what seeding was for.
+    const primary = primaryProvider(
+      () =>
+        new ProviderError(
+          `Anthropic: ${UNPARSEABLE_TOOL_ARGS_SDK_MESSAGE}`,
+          UPSTREAM,
+          undefined,
+        ),
+      () => corruptedStream(),
+      () => corruptedStream(),
+      () => corruptedStream(),
+      () => corruptedStream(),
+      () => corruptedStream(),
+    );
+    const backup = backupProvider();
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+    recordFallbackServed(UPSTREAM_ROUTE, Date.now() - MAX_COOLDOWN_MS - 1);
+
+    const result = await wrapped.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    // Two probe sends plus two loop sends, not two plus three.
+    expect(primary.calls()).toBe(1 + DEFAULT_MAX_RETRIES);
+    expect(result.model).toBe("backup-model");
+  });
+
   test("a probe repairs malformed tool arguments instead of reporting an outage", async () => {
     // The main retry loop repairs this deterministically with a corrective
     // note; the probe gets the same one-shot repair rather than reading a

--- a/assistant/src/__tests__/fallback-breaker.test.ts
+++ b/assistant/src/__tests__/fallback-breaker.test.ts
@@ -852,9 +852,9 @@ describe("RetryProvider under an open breaker", () => {
 describe("the backup's retry budget", () => {
   test("a breaker-open request retries a transient failure on the backup instead of failing the turn", async () => {
     // The breaker trips after a single successful fallback serve, so for the
-    // whole cooldown every request skips the primary. Serving those on one
-    // attempt would make a lone 429 or mid-stream cut fail the turn, a worse
-    // posture than the three retries the same request had before this feature.
+    // whole cooldown every request skips the primary. Those requests spend no
+    // retry budget on the way, so they get one on the backup: on a single
+    // attempt a lone 429 or mid-stream cut fails the turn.
     const primary = primaryProvider();
     const backup = backupProvider(() => transient());
     const route = makeRoute(backup.provider);
@@ -996,11 +996,12 @@ describe("recovery probe verdicts", () => {
     expect(shouldSkipPrimary(PRIMARY_ROUTE)).toBe(false);
   });
 
-  test("a corrupted-stream probe leaves the request the budget it would have had without probing", async () => {
+  test("a corrupted-stream probe leaves the request the same total budget as one that never probes", async () => {
     // The probe's send counts as this request's first attempt, so continuing
-    // into the retry loop must not hand it a wider budget than everyone else.
-    // Four sends total, then the backup as the loop's ordinary last resort, so
-    // the turn still finishes even when the primary never stops corrupting.
+    // into the retry loop must not hand it a wider budget than a request that
+    // never probes. Four sends total, then the backup as the loop's ordinary
+    // last resort, so the turn finishes even when the primary never stops
+    // corrupting.
     const primary = primaryProvider(
       () => corruptedStream(),
       () => corruptedStream(),
@@ -1029,9 +1030,8 @@ describe("recovery probe verdicts", () => {
   test("a probe that spent a corrective resend keeps the same total budget", async () => {
     // The repaired path: the probe sends twice (the original plus the
     // corrective resend) before the stream corruption hands the request to the
-    // retry loop. A seed that counted only the original probe would let this
-    // request make one more primary send than everyone else, which is the
-    // opposite of what seeding was for.
+    // retry loop. The seed has to count both, or this request makes one more
+    // primary send than a request that never probes.
     const primary = primaryProvider(
       () =>
         new ProviderError(

--- a/assistant/src/__tests__/fallback-breaker.test.ts
+++ b/assistant/src/__tests__/fallback-breaker.test.ts
@@ -1151,3 +1151,138 @@ describe("recovery probe verdicts", () => {
     );
   });
 });
+
+// ── What counts as having spent the retry budget ────────────────────────────
+
+describe("retry exhaustion accounting", () => {
+  /**
+   * The primary of a probe that uses both of its repairs before failing for
+   * real. The first send is rejected as an expired managed credential, the
+   * refreshed adapter answers the resend with malformed tool arguments, and the
+   * corrective resend after that comes back as a stream corruption. Three sends
+   * are spent by the time the request reaches the ordinary loop, leaving it
+   * exactly one, which it spends on `lastError`.
+   */
+  function repairedProbeAdapters(lastError: () => unknown): {
+    primary: ReturnType<typeof primaryProvider>;
+    refreshed: ReturnType<typeof primaryProvider>;
+  } {
+    return {
+      primary: primaryProvider(
+        () =>
+          new ProviderError("Unauthorized", UPSTREAM, 401, {
+            reason: "invalid_credentials",
+          }),
+      ),
+      refreshed: primaryProvider(
+        () =>
+          new ProviderError(
+            `Anthropic: ${UNPARSEABLE_TOOL_ARGS_SDK_MESSAGE}`,
+            UPSTREAM,
+            undefined,
+          ),
+        () => corruptedStream(),
+        lastError,
+      ),
+    };
+  }
+
+  test("a probe that spends the whole budget on repairs still reaches the backup", async () => {
+    // Exhaustion decides escalation eligibility, not just Sentry suppression,
+    // so a request whose budget was consumed inside the probe has to be seen as
+    // exhausted. Otherwise the turn this feature exists to rescue fails while a
+    // healthy backup sits unused.
+    const { primary, refreshed } = repairedProbeAdapters(() =>
+      corruptedStream(),
+    );
+    const backup = backupProvider();
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      credentialSource: "vellum-managed",
+      refreshCredentialProvider: async () => refreshed.provider,
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+    recordFallbackServed(UPSTREAM_ROUTE, Date.now() - MAX_COOLDOWN_MS - 1);
+
+    const result = await wrapped.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    expect(result.model).toBe("backup-model");
+    expect(backup.calls()).toBe(1);
+    // One send on the original adapter plus three on the refreshed one: the
+    // budget, spent exactly once.
+    expect(primary.calls() + refreshed.calls()).toBe(1 + DEFAULT_MAX_RETRIES);
+    expect(refreshed.calls()).toBe(3);
+  });
+
+  test("a probe that spends the whole budget on repairs tags the error as exhausted", async () => {
+    // The same sequence with no backup available, so the error surfaces and its
+    // tag can be read. Untagged, this is a Sentry capture for a flap the retry
+    // loop already did everything about.
+    const { primary, refreshed } = repairedProbeAdapters(() =>
+      corruptedStream(),
+    );
+    const wrapped = new RetryProvider(primary.provider, {
+      credentialSource: "vellum-managed",
+      refreshCredentialProvider: async () => refreshed.provider,
+      resolveFallbackRoute: async () => null,
+    });
+    recordFallbackServed(UPSTREAM_ROUTE, Date.now() - MAX_COOLDOWN_MS - 1);
+
+    const thrown = await captureError(
+      wrapped.sendMessage(MESSAGES, { config: { callSite: "mainAgent" } }),
+    );
+
+    expect((thrown as { retriesExhausted?: boolean }).retriesExhausted).toBe(
+      true,
+    );
+    expect(primary.calls() + refreshed.calls()).toBe(1 + DEFAULT_MAX_RETRIES);
+  });
+
+  test("a request that spends its budget in the ordinary loop is exhausted", async () => {
+    // The control for a request that never probes: unchanged behavior, tagged
+    // and escalated after the full budget.
+    const primary = primaryProvider(
+      () => transient(),
+      () => transient(),
+      () => transient(),
+      () => transient(),
+    );
+    const backup = backupProvider();
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    const result = await wrapped.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    expect(primary.calls()).toBe(1 + DEFAULT_MAX_RETRIES);
+    expect(result.model).toBe("backup-model");
+  });
+
+  test("a request that fails on a non-retryable error is not exhausted", async () => {
+    // The other control: one attempt, no budget spent, so nothing is tagged and
+    // a plain request failure never counts as an outage.
+    const primary = primaryProvider(
+      () => new ProviderError("invalid request", UPSTREAM, 400),
+    );
+    const backup = backupProvider();
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    const thrown = await captureError(
+      wrapped.sendMessage(MESSAGES, { config: { callSite: "mainAgent" } }),
+    );
+
+    expect(
+      (thrown as { retriesExhausted?: boolean }).retriesExhausted,
+    ).toBeUndefined();
+    expect(primary.calls()).toBe(1);
+    expect(backup.calls()).toBe(0);
+  });
+});

--- a/assistant/src/__tests__/fallback-breaker.test.ts
+++ b/assistant/src/__tests__/fallback-breaker.test.ts
@@ -196,6 +196,21 @@ function transient(status = 503): ProviderError {
   });
 }
 
+/**
+ * A mid-stream corruption: the upstream accepted the request and streamed, so
+ * the error carries no HTTP status. `retryAfterMs` is a test convenience only,
+ * standing in for a Retry-After header this shape would not really carry, so a
+ * retry budget can be counted without sitting through real backoff.
+ */
+function corruptedStream(): ProviderError {
+  return new ProviderError(
+    "stream ended without producing a message",
+    UPSTREAM,
+    undefined,
+    { retryAfterMs: 0 },
+  );
+}
+
 function makeRoute(provider: Provider): {
   resolveFallbackRoute: (
     failedOptions: SendMessageOptions | undefined,
@@ -953,17 +968,14 @@ describe("the backup's retry budget", () => {
 // ── What a failed probe is allowed to conclude ──────────────────────────────
 
 describe("recovery probe verdicts", () => {
-  test("a probe that fails with a corrupted stream does not extend the outage", async () => {
+  test("a probe that fails with a corrupted stream closes the breaker and still completes the turn", async () => {
     // Every stream-corruption pattern requires an absent HTTP status, which
     // means the upstream accepted the request, returned 200, and streamed. The
     // failure is in the bytes it produced, not in its ability to serve, so it
-    // is evidence the primary is healthy.
-    const corrupted = new ProviderError(
-      "stream ended without producing a message",
-      UPSTREAM,
-      undefined,
-    );
-    const primary = primaryProvider(() => corrupted);
+    // is evidence the primary is healthy. The verdict must not cost the request
+    // that established it: this is exactly the failure the main loop repairs by
+    // resending, so the probe hands the request back to that loop.
+    const primary = primaryProvider(() => corruptedStream());
     const backup = backupProvider();
     const route = makeRoute(backup.provider);
     const wrapped = new RetryProvider(primary.provider, {
@@ -971,16 +983,47 @@ describe("recovery probe verdicts", () => {
     });
     recordFallbackServed(UPSTREAM_ROUTE, Date.now() - MAX_COOLDOWN_MS - 1);
 
-    const thrown = await captureError(
-      wrapped.sendMessage(MESSAGES, { config: { callSite: "mainAgent" } }),
-    );
+    const result = await wrapped.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
 
-    expect(thrown).toBe(corrupted);
-    expect(primary.calls()).toBe(1);
+    // The turn completed on the route the probe just cleared.
+    expect(result.model).toBe("primary-model");
+    expect(primary.calls()).toBe(2);
     expect(backup.calls()).toBe(0);
     // The breaker closed rather than re-tripping with a doubled cooldown, so
     // the next request takes the primary and gets its full retry budget.
     expect(shouldSkipPrimary(PRIMARY_ROUTE)).toBe(false);
+  });
+
+  test("a corrupted-stream probe leaves the request the budget it would have had without probing", async () => {
+    // The probe's send counts as this request's first attempt, so continuing
+    // into the retry loop must not hand it a wider budget than everyone else.
+    // Four sends total, then the backup as the loop's ordinary last resort, so
+    // the turn still finishes even when the primary never stops corrupting.
+    const primary = primaryProvider(
+      () => corruptedStream(),
+      () => corruptedStream(),
+      () => corruptedStream(),
+      () => corruptedStream(),
+      () => corruptedStream(),
+    );
+    const backup = backupProvider();
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+    recordFallbackServed(UPSTREAM_ROUTE, Date.now() - MAX_COOLDOWN_MS - 1);
+
+    const result = await wrapped.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    expect(primary.calls()).toBe(1 + DEFAULT_MAX_RETRIES);
+    expect(result.model).toBe("backup-model");
+    // A backup that had to serve is proof the route is down after all, so the
+    // breaker is remembered again on the way out.
+    expect(shouldSkipPrimary(PRIMARY_ROUTE)).toBe(true);
   });
 
   test("a probe repairs malformed tool arguments instead of reporting an outage", async () => {
@@ -1035,7 +1078,10 @@ describe("recovery probe verdicts", () => {
       config: { callSite: "mainAgent" },
     });
 
+    // Exactly one attempt on a route just judged down: the request goes
+    // straight to the backup rather than spending a retry budget on it.
     expect(primary.calls()).toBe(1);
+    expect(backup.calls()).toBe(1);
     expect(result.model).toBe("backup-model");
     expect(shouldSkipPrimary(PRIMARY_ROUTE)).toBe(true);
   });
@@ -1059,6 +1105,9 @@ describe("recovery probe verdicts", () => {
     });
 
     expect(result.model).toBe("backup-model");
+    // No extra attempts on the primary either: an outage verdict fails fast
+    // into the backup instead of continuing into the retry loop.
+    expect(primary.calls()).toBe(1);
     expect(shouldSkipPrimary(PRIMARY_ROUTE)).toBe(true);
     // A failed probe doubles the wait, so the re-trip lands above the base.
     expectWithinJitterBand(

--- a/assistant/src/__tests__/fallback-breaker.test.ts
+++ b/assistant/src/__tests__/fallback-breaker.test.ts
@@ -27,7 +27,9 @@ import type {
   ProviderResponse,
   SendMessageOptions,
 } from "../providers/types.js";
+import { UNPARSEABLE_TOOL_ARGS_SDK_MESSAGE } from "../providers/unparseable-tool-args.js";
 import { ProviderError } from "../util/errors.js";
+import { DEFAULT_MAX_RETRIES } from "../util/retry.js";
 import { setConfig } from "./helpers/set-config.js";
 
 // ── Fixtures ────────────────────────────────────────────────────────────────
@@ -135,14 +137,17 @@ function primaryProvider(...errors: (() => unknown)[]): {
   provider: Provider;
   calls: () => number;
   seenModels: () => (string | undefined)[];
+  seenMessages: () => Message[][];
 } {
   const seen: (string | undefined)[] = [];
+  const seenMessages: Message[][] = [];
   let calls = 0;
   const provider: Provider = {
     name: UPSTREAM,
-    sendMessage: async (_messages: Message[], options?: SendMessageOptions) => {
+    sendMessage: async (messages: Message[], options?: SendMessageOptions) => {
       calls += 1;
       seen.push(options?.config?.model);
+      seenMessages.push(messages);
       const next = errors.shift();
       if (next) {
         throw next();
@@ -150,20 +155,45 @@ function primaryProvider(...errors: (() => unknown)[]): {
       return okResponse(options?.config?.model ?? "unresolved");
     },
   };
-  return { provider, calls: () => calls, seenModels: () => seen };
+  return {
+    provider,
+    calls: () => calls,
+    seenModels: () => seen,
+    seenMessages: () => seenMessages,
+  };
 }
 
-/** Backup stub that serves whatever model the re-normalized options resolved. */
-function backupProvider(): { provider: Provider; calls: () => number } {
+/**
+ * Backup stub that serves whatever model the re-normalized options resolved,
+ * after throwing the next error from `errors` while any remain.
+ */
+function backupProvider(...errors: (() => unknown)[]): {
+  provider: Provider;
+  calls: () => number;
+} {
   let calls = 0;
   const provider: Provider = {
     name: "anthropic",
     sendMessage: async (_messages: Message[], options?: SendMessageOptions) => {
       calls += 1;
+      const next = errors.shift();
+      if (next) {
+        throw next();
+      }
       return okResponse(options?.config?.model ?? "unresolved");
     },
   };
   return { provider, calls: () => calls };
+}
+
+/**
+ * A transient upstream failure that names a zero wait, so a retry budget can be
+ * exercised without the test sitting through real exponential backoff.
+ */
+function transient(status = 503): ProviderError {
+  return new ProviderError("Service Unavailable", "anthropic", status, {
+    retryAfterMs: 0,
+  });
 }
 
 function makeRoute(provider: Provider): {
@@ -799,5 +829,241 @@ describe("RetryProvider under an open breaker", () => {
     expect(backup.calls()).toBe(2);
     // Only the first request ever reached the upstream.
     expect(primary.calls()).toBe(1);
+  });
+});
+
+// ── The retry budget a breaker-driven send gets on the backup ───────────────
+
+describe("the backup's retry budget", () => {
+  test("a breaker-open request retries a transient failure on the backup instead of failing the turn", async () => {
+    // The breaker trips after a single successful fallback serve, so for the
+    // whole cooldown every request skips the primary. Serving those on one
+    // attempt would make a lone 429 or mid-stream cut fail the turn, a worse
+    // posture than the three retries the same request had before this feature.
+    const primary = primaryProvider();
+    const backup = backupProvider(() => transient());
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+    recordFallbackServed(UPSTREAM_ROUTE);
+
+    const result = await wrapped.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    expect(result.model).toBe("backup-model");
+    expect(backup.calls()).toBe(2);
+    // The primary is still skipped entirely: the retry budget moved to the
+    // backup, it was not restored to a route known to be down.
+    expect(primary.calls()).toBe(0);
+  });
+
+  test("a retried backup never escalates to a second fallback", async () => {
+    // One hop is structural, not a budget: the route callback is consulted
+    // exactly once however many attempts the backup takes.
+    const primary = primaryProvider();
+    const backup = backupProvider(
+      () => transient(),
+      () => transient(),
+      () => transient(),
+      () => transient(),
+    );
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+    recordFallbackServed(UPSTREAM_ROUTE);
+
+    const thrown = await captureError(
+      wrapped.sendMessage(MESSAGES, { config: { callSite: "mainAgent" } }),
+    );
+
+    expect(backup.calls()).toBe(1 + DEFAULT_MAX_RETRIES);
+    expect(route.calls()).toBe(1);
+    expect(primary.calls()).toBe(0);
+    // Tagged like the primary loop's own exhaustion, so Sentry capture reads a
+    // flapping backup as noise rather than an engineering signal.
+    expect((thrown as { retriesExhausted?: boolean }).retriesExhausted).toBe(
+      true,
+    );
+  });
+
+  test("a failed probe hands its request a retry budget on the backup too", async () => {
+    // A probe is one attempt on the primary, not a retry loop, so its request
+    // has spent no budget either by the time it reaches the backup.
+    const primary = primaryProvider(
+      () => new ProviderError("Service Unavailable", UPSTREAM, 503),
+    );
+    const backup = backupProvider(() => transient());
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+    recordFallbackServed(UPSTREAM_ROUTE, Date.now() - MAX_COOLDOWN_MS - 1);
+
+    const result = await wrapped.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    expect(primary.calls()).toBe(1);
+    expect(backup.calls()).toBe(2);
+    expect(result.model).toBe("backup-model");
+  });
+
+  test("an escalation after the primary burned its budget still gets one attempt", async () => {
+    // The asymmetry worth keeping: this request already waited out a full
+    // retry loop, so the backup answers once or the turn fails.
+    const primary = primaryProvider(
+      () =>
+        new ProviderError("Service Unavailable", UPSTREAM, 503, {
+          retryAfterMs: 0,
+        }),
+      () =>
+        new ProviderError("Service Unavailable", UPSTREAM, 503, {
+          retryAfterMs: 0,
+        }),
+      () =>
+        new ProviderError("Service Unavailable", UPSTREAM, 503, {
+          retryAfterMs: 0,
+        }),
+      () =>
+        new ProviderError("Service Unavailable", UPSTREAM, 503, {
+          retryAfterMs: 0,
+        }),
+    );
+    const backup = backupProvider(
+      () => transient(),
+      () => transient(),
+    );
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    await captureError(
+      wrapped.sendMessage(MESSAGES, { config: { callSite: "mainAgent" } }),
+    );
+
+    expect(primary.calls()).toBe(1 + DEFAULT_MAX_RETRIES);
+    expect(backup.calls()).toBe(1);
+  });
+});
+
+// ── What a failed probe is allowed to conclude ──────────────────────────────
+
+describe("recovery probe verdicts", () => {
+  test("a probe that fails with a corrupted stream does not extend the outage", async () => {
+    // Every stream-corruption pattern requires an absent HTTP status, which
+    // means the upstream accepted the request, returned 200, and streamed. The
+    // failure is in the bytes it produced, not in its ability to serve, so it
+    // is evidence the primary is healthy.
+    const corrupted = new ProviderError(
+      "stream ended without producing a message",
+      UPSTREAM,
+      undefined,
+    );
+    const primary = primaryProvider(() => corrupted);
+    const backup = backupProvider();
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+    recordFallbackServed(UPSTREAM_ROUTE, Date.now() - MAX_COOLDOWN_MS - 1);
+
+    const thrown = await captureError(
+      wrapped.sendMessage(MESSAGES, { config: { callSite: "mainAgent" } }),
+    );
+
+    expect(thrown).toBe(corrupted);
+    expect(primary.calls()).toBe(1);
+    expect(backup.calls()).toBe(0);
+    // The breaker closed rather than re-tripping with a doubled cooldown, so
+    // the next request takes the primary and gets its full retry budget.
+    expect(shouldSkipPrimary(PRIMARY_ROUTE)).toBe(false);
+  });
+
+  test("a probe repairs malformed tool arguments instead of reporting an outage", async () => {
+    // The main retry loop repairs this deterministically with a corrective
+    // note; the probe gets the same one-shot repair rather than reading a
+    // request-conditioned failure as the route still being down.
+    const primary = primaryProvider(
+      () =>
+        new ProviderError(
+          `Anthropic: ${UNPARSEABLE_TOOL_ARGS_SDK_MESSAGE}`,
+          UPSTREAM,
+          undefined,
+        ),
+    );
+    const backup = backupProvider();
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+    recordFallbackServed(UPSTREAM_ROUTE, Date.now() - MAX_COOLDOWN_MS - 1);
+
+    const result = await wrapped.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    expect(result.model).toBe("primary-model");
+    expect(primary.calls()).toBe(2);
+    expect(backup.calls()).toBe(0);
+    // The resend carried the corrective note, which is the whole point of it.
+    const resent = primary.seenMessages()[1];
+    const tail = resent[resent.length - 1].content;
+    expect(JSON.stringify(tail)).toContain("[assistant runtime]");
+    expect(shouldSkipPrimary(PRIMARY_ROUTE)).toBe(false);
+  });
+
+  test("a probe rate-limited by the primary still reads the outage as continuing", async () => {
+    // Deliberately not treated like a stream corruption. A 429 is the route
+    // refusing to do the work: no resend repairs it, only waiting does, and
+    // that is exactly what the cooldown provides. Reading it as recovery would
+    // send every request back to a primary that rejects all of them.
+    const primary = primaryProvider(
+      () => new ProviderError("Too Many Requests", UPSTREAM, 429),
+    );
+    const backup = backupProvider();
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+    recordFallbackServed(UPSTREAM_ROUTE, Date.now() - MAX_COOLDOWN_MS - 1);
+
+    const result = await wrapped.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    expect(primary.calls()).toBe(1);
+    expect(result.model).toBe("backup-model");
+    expect(shouldSkipPrimary(PRIMARY_ROUTE)).toBe(true);
+  });
+
+  test("a probe that fails with a 5xx still extends the outage", async () => {
+    // The control for the two cases above: a genuine server error is what the
+    // breaker exists to remember, and it must keep re-tripping.
+    const primary = primaryProvider(
+      () => new ProviderError("Service Unavailable", UPSTREAM, 503),
+    );
+    const backup = backupProvider();
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+    const trippedAt = Date.now() - MAX_COOLDOWN_MS - 1;
+    recordFallbackServed(UPSTREAM_ROUTE, trippedAt);
+
+    const result = await wrapped.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    expect(result.model).toBe("backup-model");
+    expect(shouldSkipPrimary(PRIMARY_ROUTE)).toBe(true);
+    // A failed probe doubles the wait, so the re-trip lands above the base.
+    expectWithinJitterBand(
+      observedCooldownMs(UPSTREAM_ROUTE, Date.now()),
+      BASE_COOLDOWN_MS * 2,
+    );
   });
 });

--- a/assistant/src/__tests__/retry-fallback-escalation.test.ts
+++ b/assistant/src/__tests__/retry-fallback-escalation.test.ts
@@ -887,6 +887,119 @@ describe("RetryProvider fallback-route escalation", () => {
     expect(backup.seenToolNames()).toEqual(["read_file", "web_search"]);
   });
 
+  test("a tool-less call site loses the tool_choice paired with the sentinel", async () => {
+    // `AgentLoop` sets `tool_choice: { type: "auto" }` under the same condition
+    // that appends the sentinel, so a call site with no tools of its own sends
+    // the sentinel as its ONLY tool. Filtering it and leaving the tool_choice
+    // behind puts a choice with nothing to choose from on the wire, which
+    // Anthropic rejects outright: a recoverable outage would become a hard 400
+    // on the backup.
+    const primary = failingProvider(
+      "openai",
+      () => new ProviderError("model not found", "openai", 404),
+    );
+    const backup = backupProvider("gemini", { supportsNativeWebSearch: false });
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    await wrapped.sendMessage(MESSAGES, {
+      config: {
+        callSite: "mainAgent",
+        nativeWebSearchSentinel: true,
+        tool_choice: { type: "auto" },
+      },
+      tools: [
+        {
+          name: "web_search",
+          description: "d",
+          input_schema: { type: "object" },
+        },
+      ],
+    });
+
+    expect(backup.calls()).toBe(1);
+    expect(backup.seenToolNames()).toEqual([]);
+    expect(backup.seenConfig().tool_choice).toBeUndefined();
+  });
+
+  test("a tool_choice survives the fallback whenever a tool is left to choose", async () => {
+    // The rule is deliberately narrow. A conversation-level `toolChoice` takes
+    // precedence over the sentinel's `auto` in `AgentLoop`, so it is caller
+    // intent a route change must not quietly discard, and the request it
+    // produces is valid on every wire.
+    const primary = failingProvider(
+      "openai",
+      () => new ProviderError("model not found", "openai", 404),
+    );
+    const backup = backupProvider("gemini", { supportsNativeWebSearch: false });
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    await wrapped.sendMessage(MESSAGES, {
+      config: {
+        callSite: "mainAgent",
+        nativeWebSearchSentinel: true,
+        tool_choice: { type: "tool", name: "read_file" },
+      },
+      tools: [
+        {
+          name: "read_file",
+          description: "d",
+          input_schema: { type: "object" },
+        },
+        {
+          name: "web_search",
+          description: "d",
+          input_schema: { type: "object" },
+        },
+      ],
+    });
+
+    expect(backup.seenToolNames()).toEqual(["read_file"]);
+    expect(backup.seenConfig().tool_choice).toEqual({
+      type: "tool",
+      name: "read_file",
+    });
+  });
+
+  test("a tool_choice survives when the sentinel was never filtered", async () => {
+    // A backup that serves native search keeps the whole list, so nothing about
+    // the caller's config changes either.
+    const primary = failingProvider(
+      "openai",
+      () => new ProviderError("model not found", "openai", 404),
+    );
+    const backup = backupProvider("anthropic", {
+      supportsNativeWebSearch: true,
+    });
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    await wrapped.sendMessage(MESSAGES, {
+      config: {
+        callSite: "mainAgent",
+        nativeWebSearchSentinel: true,
+        tool_choice: { type: "auto" },
+      },
+      tools: [
+        {
+          name: "web_search",
+          description: "d",
+          input_schema: { type: "object" },
+        },
+      ],
+    });
+
+    expect(backup.seenToolNames()).toEqual(["web_search"]);
+    expect(backup.seenConfig().tool_choice).toEqual({ type: "auto" });
+  });
+
   test("the sentinel marker never reaches the provider wire config", async () => {
     const primary = failingProvider(
       "openai",

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -1286,6 +1286,12 @@ export class RetryProvider implements Provider {
         // back. Malformed tool-argument JSON gets the same corrective note the
         // retry loop appends, because that failure is conditioned on the
         // request rather than the route.
+        //
+        // The probe ends the moment it reports a verdict. What happens to the
+        // request that carried it then depends on that verdict: an outage sends
+        // it to the backup, and a recovery hands it back to the ordinary retry
+        // loop below, which is now the right place for it because the route it
+        // just cleared is the one that loop sends to.
         while (true) {
           try {
             const response = await this.inner.sendMessage(
@@ -1371,7 +1377,30 @@ export class RetryProvider implements Provider {
             );
             this.attributeCredential(error);
             if (!outage) {
-              throw error;
+              // The route answered, the breaker is closed, and this request is
+              // an ordinary request again. A deterministic rejection (a plain
+              // 400, a classified 404, a context overflow) is the route's real
+              // answer and no resend changes it, so it surfaces as itself.
+              if (!isRetryableError(error)) {
+                throw error;
+              }
+              // Anything still standing here is the stream-corruption family
+              // the exclusion above lets through: exactly the failure the main
+              // loop repairs by resending, against a route that was just
+              // cleared. Throwing it would sacrifice the request that carried
+              // the probe to establish a verdict every LATER request gets to
+              // use, so it falls through into the ordinary loop instead. That
+              // loop also keeps the backup as its last resort, so a primary
+              // that streams corruption all the way through still finishes the
+              // turn somewhere.
+              //
+              // The probe's send WAS this request's first attempt, so the loop
+              // starts one attempt in. Total sends on the primary stay at
+              // `DEFAULT_MAX_RETRIES + 1`, exactly what a request that never
+              // probed would get, which is what keeps this from quietly
+              // becoming a wider budget than everyone else's.
+              retryAttempt = 1;
+              break;
             }
             fallbackAttempted = true;
             const served = await this.sendOnFallbackRoute(

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -1207,7 +1207,6 @@ export class RetryProvider implements Provider {
     messages: Message[],
     options?: SendMessageOptions,
   ): Promise<ProviderResponse> {
-    let didRetry = false;
     let retryAttempt = 0;
     let credentialRefreshAttempted = false;
     let correctiveResendAttempted = false;
@@ -1479,19 +1478,28 @@ export class RetryProvider implements Provider {
             },
             "Retrying after transient error",
           );
-          didRetry = true;
           retryAttempt++;
           await sleep(delay);
           continue;
         }
 
         // If we exhausted retries on a retryable error, tag the error so
-        // downstream consumers (Sentry capture, etc.) can recognize that the
-        // retry loop already tried its best. The catch-site logic above only
-        // stops retrying when either (a) retries are exhausted, or (b) the
-        // error isn't retryable — so we check the retryable predicate here to
-        // distinguish the two cases.
-        const retriesExhausted = didRetry && isRetryableError(error);
+        // downstream consumers (Sentry capture, escalation eligibility) can
+        // recognize that the retry loop already tried its best. Control
+        // reaches here for two reasons only, and the retryable predicate is
+        // what separates them: either the budget is gone, or the error was
+        // never retryable in the first place.
+        //
+        // Exhaustion is read off the same counter the retry guard above reads,
+        // never off whether this loop happened to perform a retry itself. A
+        // request can arrive here with its budget already consumed elsewhere:
+        // a recovery probe seeds `retryAttempt` with the sends it made, so a
+        // probe that spent the budget on its own repairs leaves the loop below
+        // no retry to perform and would otherwise look like a request that had
+        // never tried at all. Reading the counter keeps the two definitions
+        // from drifting apart however the seed changes.
+        const retriesExhausted =
+          retryAttempt >= DEFAULT_MAX_RETRIES && isRetryableError(error);
         if (retriesExhausted && error instanceof Error) {
           (error as Error & { retriesExhausted?: boolean }).retriesExhausted =
             true;

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -353,6 +353,53 @@ function isRetryableError(error: unknown): boolean {
   return isRetryableNetworkError(error);
 }
 
+/** Cap server-suggested delays at 60s. */
+const MAX_RETRY_DELAY_MS = 60_000;
+
+/**
+ * How long to wait before the next attempt, and whether the upstream named the
+ * wait itself. A server-provided `Retry-After` wins over exponential backoff,
+ * capped so a pathological header cannot stall a turn.
+ */
+function retryPlan(
+  error: unknown,
+  attempt: number,
+): { delay: number; retryAfterHeader: boolean } {
+  const retryAfter =
+    error instanceof ProviderError ? error.retryAfterMs : undefined;
+  return {
+    delay: Math.min(
+      retryAfter ?? computeRetryDelay(attempt, DEFAULT_BASE_DELAY_MS),
+      MAX_RETRY_DELAY_MS,
+    ),
+    retryAfterHeader: retryAfter !== undefined,
+  };
+}
+
+/** Structured `errorType` for the "Retrying after transient error" logs. */
+function retryErrorType(error: unknown): string {
+  if (error instanceof ProviderError && error.statusCode === 429) {
+    return "rate_limit";
+  }
+  if (
+    error instanceof ProviderError &&
+    error.statusCode !== undefined &&
+    error.statusCode >= 500
+  ) {
+    return `server_error_${error.statusCode}`;
+  }
+  if (isRetryableProviderMessage(error)) {
+    return "provider_overloaded";
+  }
+  if (isRetryableStreamError(error)) {
+    return "stream_corruption";
+  }
+  if (isRetryableTransportAbort(error)) {
+    return "transport_abort";
+  }
+  return "network_error";
+}
+
 /**
  * The managed proxy's preflight guard rejects a model with no billing rate
  * card using a 400 whose body carries this phrase (django
@@ -1072,8 +1119,11 @@ export class RetryProvider implements Provider {
        * the primary: managed-proxy routes pass true, BYOK and other
        * third-party routes pass false. The fallback send normalizes with the
        * returned policy so `X-Vellum-*` billing metadata never leaks to a
-       * third party and is never omitted from the managed proxy. One hop
-       * max; the fallback attempt itself gets no retry loop.
+       * third party and is never omitted from the managed proxy. One hop max:
+       * the returned adapter must be RAW, so the backup can never escalate
+       * again whatever happens to it. Whether the backup send gets a retry
+       * budget depends on which entry point escalated; see
+       * `sendOnFallbackRoute`.
        */
       resolveFallbackRoute?: (
         failedOptions: SendMessageOptions | undefined,
@@ -1160,6 +1210,7 @@ export class RetryProvider implements Provider {
     let didRetry = false;
     let retryAttempt = 0;
     let credentialRefreshAttempted = false;
+    let correctiveResendAttempted = false;
     let fallbackAttempted = false;
     let messagesForAttempt = messages;
 
@@ -1205,6 +1256,12 @@ export class RetryProvider implements Provider {
           options,
           undefined,
           false,
+          // This request never touched the primary, so no retry budget has
+          // been spent anywhere. Without one on the backup a single 429 or
+          // mid-stream cut would fail the turn outright, which is a worse
+          // posture than the three retries the same request would have had
+          // before this feature existed.
+          { backupRetryBudget: true },
         );
         if (served !== null) {
           return served;
@@ -1222,11 +1279,13 @@ export class RetryProvider implements Provider {
           },
           "Probing the primary route for recovery",
         );
-        // One probe, one attempt: no retry loop. A managed credential that
-        // expired during the outage is the exception, because the probe would
-        // otherwise read its own 401 as the outage continuing and the route
-        // could never come back. The refresh is the same one-shot step the
-        // retry loop runs, and it shares the send's budget for it.
+        // One probe, one attempt: no retry loop. Two one-shot repairs are the
+        // exception, both because the probe would otherwise misread its own
+        // failure as the route still being down. A managed credential that
+        // expired during the outage is refreshed, or the route could never come
+        // back. Malformed tool-argument JSON gets the same corrective note the
+        // retry loop appends, because that failure is conditioned on the
+        // request rather than the route.
         while (true) {
           try {
             const response = await this.inner.sendMessage(
@@ -1255,14 +1314,47 @@ export class RetryProvider implements Provider {
                 continue;
               }
             }
+            // The same one-shot corrective resend the retry loop performs. A
+            // byte-identical resend can reproduce malformed tool-argument JSON
+            // indefinitely, so without the note the probe would report an
+            // outage the route had nothing to do with. Skipped when the hint
+            // has nowhere to go (an assistant prefill tail), since an
+            // unchanged resend would only cost another round trip.
+            if (
+              !correctiveResendAttempted &&
+              isUnparseableToolArgsError(error)
+            ) {
+              correctiveResendAttempted = true;
+              const repaired = withUnparseableToolArgsHint(messages);
+              if (repaired !== messages) {
+                messagesForAttempt = repaired;
+                continue;
+              }
+            }
             // The probe stands in for the whole retry budget while the breaker
             // is open, so a failure the retry loop would have exhausted itself
             // against means the outage continues. Any other failure means the
             // route answered the request, which is all the probe asked.
-            const outage = isFallbackEligibleError(error, {
-              retriesExhausted: true,
-              credentialSource: this.options.credentialSource,
-            });
+            //
+            // A mid-stream corruption is such an answer: every pattern in
+            // `RETRYABLE_STREAM_PATTERNS` requires an absent HTTP status, which
+            // means the upstream accepted the request, returned 200, and
+            // streamed content. The failure is in the bytes it produced, not in
+            // its ability to serve, so it is evidence the primary is HEALTHY
+            // and must not extend a remembered outage that can reach ten
+            // minutes. A 429 is deliberately NOT treated the same way: the
+            // route refused to do the work, no resend repairs it (only waiting
+            // does, which is exactly what the cooldown provides), and reading a
+            // rate limit as recovery would send the whole fleet back to a
+            // primary that rejects every request. Provider-declared
+            // `overloaded` and transport aborts stay outages for the same
+            // reason: neither produced a usable answer.
+            const outage =
+              !isRetryableStreamError(error) &&
+              isFallbackEligibleError(error, {
+                retriesExhausted: true,
+                credentialSource: this.options.credentialSource,
+              });
             // The probe's own error decides what stays remembered, not the
             // scope of the entry it was acquired under: an upstream that
             // answers with a retired-model 404 has stopped being an outage,
@@ -1287,6 +1379,10 @@ export class RetryProvider implements Provider {
               options,
               error,
               true,
+              // The probe is one attempt on the primary, not a retry loop, so
+              // this request has spent no retry budget either. Same reasoning
+              // as the breaker-open skip above.
+              { backupRetryBudget: true },
             );
             if (served !== null) {
               // No trip needed: the failed probe already re-tripped the breaker
@@ -1329,35 +1425,14 @@ export class RetryProvider implements Provider {
             messagesForAttempt = withUnparseableToolArgsHint(messages);
           }
           // Prefer server-provided Retry-After; fall back to exponential backoff.
-          const retryAfter =
-            error instanceof ProviderError ? error.retryAfterMs : undefined;
-          const MAX_RETRY_DELAY_MS = 60_000; // Cap server-suggested delays at 60s
-          const delay = Math.min(
-            retryAfter ??
-              computeRetryDelay(retryAttempt, DEFAULT_BASE_DELAY_MS),
-            MAX_RETRY_DELAY_MS,
-          );
-          const errorType =
-            error instanceof ProviderError && error.statusCode === 429
-              ? "rate_limit"
-              : error instanceof ProviderError &&
-                  error.statusCode !== undefined &&
-                  error.statusCode >= 500
-                ? `server_error_${error.statusCode}`
-                : isRetryableProviderMessage(error)
-                  ? "provider_overloaded"
-                  : isRetryableStreamError(error)
-                    ? "stream_corruption"
-                    : isRetryableTransportAbort(error)
-                      ? "transport_abort"
-                      : "network_error";
+          const { delay, retryAfterHeader } = retryPlan(error, retryAttempt);
           log.warn(
             {
               attempt: retryAttempt + 1,
               maxRetries: DEFAULT_MAX_RETRIES,
               delay,
-              retryAfterHeader: retryAfter !== undefined,
-              errorType,
+              retryAfterHeader,
+              errorType: retryErrorType(error),
               correctiveHint: messagesForAttempt !== messages,
               provider: this.name,
               message: error instanceof Error ? error.message : String(error),
@@ -1411,6 +1486,12 @@ export class RetryProvider implements Provider {
             options,
             error,
             retriesExhausted,
+            // One hop, one attempt stays right here: the primary loop above
+            // already ran to a definitive verdict, either exhausting its whole
+            // budget against a transient failure or receiving an error no
+            // resend would change. The user has been waiting through all of
+            // that, so the backup answers once or the turn fails.
+            { backupRetryBudget: false },
           );
           if (fallbackResult !== null) {
             // A completed backup serve is proof the primary is down and the
@@ -1442,32 +1523,126 @@ export class RetryProvider implements Provider {
    * search backend like Brave or the platform search proxy configured, a tool
    * of the same name is app-executed and works on every route, so filtering it
    * would take away a capability the backup can still serve.
+   *
+   * `dropToolChoice` reports that filtering emptied the list. `AgentLoop` sets
+   * `tool_choice: { type: "auto" }` under the same condition that appends the
+   * sentinel, so a tool-less call site with native search enabled carries the
+   * sentinel as its ONLY tool. Filtering it and leaving the paired
+   * `tool_choice` behind would put a choice with nothing to choose from on the
+   * wire. The Anthropic Messages API rejects that (its client spreads
+   * `tool_choice` out of the request config whether or not any `tools`
+   * survived), and the OpenAI Responses API would too if its client did not
+   * happen to gate the field on a non-empty tool list. A recoverable outage
+   * would become a hard 400 on the backup.
+   *
+   * Deliberately narrow: the flag is raised only for an EMPTY filtered list,
+   * the one case that is invalid on the wire. A non-empty list keeps whatever
+   * `tool_choice` the caller set. A conversation-level `toolChoice` takes
+   * precedence over the sentinel's `auto` in `AgentLoop`, so it is caller
+   * intent that a route change must not quietly discard, and the request it
+   * produces is still valid.
    */
   private fallbackTools(
     options: SendMessageOptions | undefined,
     route: { provider: Provider },
-  ): { tools?: ToolDefinition[] } {
+  ): { tools?: ToolDefinition[]; dropToolChoice: boolean } {
     const tools = options?.tools;
     if (
       options?.config?.nativeWebSearchSentinel !== true ||
       tools === undefined ||
       !tools.some((tool) => tool.name === NATIVE_WEB_SEARCH_TOOL_NAME)
     ) {
-      return {};
+      return { dropToolChoice: false };
     }
     const backupServesNativeSearch = route.provider.supportsNativeWebSearchFor
       ? route.provider.supportsNativeWebSearchFor(options)
       : route.provider.supportsNativeWebSearch === true;
     if (backupServesNativeSearch) {
-      return {};
+      return { dropToolChoice: false };
     }
-    return {
-      tools: tools.filter((tool) => tool.name !== NATIVE_WEB_SEARCH_TOOL_NAME),
-    };
+    const filtered = tools.filter(
+      (tool) => tool.name !== NATIVE_WEB_SEARCH_TOOL_NAME,
+    );
+    return { tools: filtered, dropToolChoice: filtered.length === 0 };
   }
 
   /**
-   * Attempt the failed request once on the backup route resolved by
+   * Send on the backup adapter, optionally with a retry budget of its own.
+   *
+   * The one-hop rule is structural rather than conditional here: `route
+   * .provider` is the RAW adapter the route callback built, with no
+   * `RetryProvider` of its own and therefore no `resolveFallbackRoute`, so
+   * nothing this loop calls can escalate to a second backup no matter how many
+   * times it retries.
+   *
+   * `fallbackOptions` is sent verbatim on every attempt, never re-normalized.
+   * `normalizeSendMessageOptions` has already consumed the `callSite` and
+   * stamped the backup route's `usageAttributionHeaders`; running it again over
+   * that now callSite-less config would delete the headers and have no way to
+   * rebuild them, leaving degraded traffic unattributed on the platform's
+   * billing events. This is the same reason the route callback hands back a raw
+   * adapter instead of a wrapped one.
+   */
+  private async sendOnBackupAdapter(
+    route: { provider: Provider },
+    messages: Message[],
+    fallbackOptions: SendMessageOptions | undefined,
+    retryBudget: boolean,
+  ): Promise<ProviderResponse> {
+    let attempt = 0;
+    let didRetry = false;
+    let messagesForAttempt = messages;
+    while (true) {
+      try {
+        return await route.provider.sendMessage(
+          messagesForAttempt,
+          fallbackOptions,
+        );
+      } catch (error) {
+        if (
+          !retryBudget ||
+          attempt >= DEFAULT_MAX_RETRIES ||
+          !isRetryableError(error)
+        ) {
+          // Same tagging contract as the primary loop, so a backup that flapped
+          // its way through the whole budget is recognizable to Sentry capture
+          // as noise no engineering action would change.
+          if (didRetry && isRetryableError(error) && error instanceof Error) {
+            (error as Error & { retriesExhausted?: boolean }).retriesExhausted =
+              true;
+          }
+          throw error;
+        }
+        // Built from the original `messages` each time, so the corrective note
+        // appears exactly once however many attempts fail this way.
+        if (isUnparseableToolArgsError(error)) {
+          messagesForAttempt = withUnparseableToolArgsHint(messages);
+        }
+        const { delay, retryAfterHeader } = retryPlan(error, attempt);
+        log.warn(
+          {
+            attempt: attempt + 1,
+            maxRetries: DEFAULT_MAX_RETRIES,
+            delay,
+            retryAfterHeader,
+            errorType: retryErrorType(error),
+            correctiveHint: messagesForAttempt !== messages,
+            provider: this.name,
+            backupProvider: route.provider.name,
+            connectionName: this.options.connectionName,
+            message: error instanceof Error ? error.message : String(error),
+          },
+          "Retrying the backup route after a transient error",
+        );
+        didRetry = true;
+        attempt++;
+        await sleep(delay);
+      }
+    }
+  }
+
+  /**
+   * Attempt the failed request on the backup route resolved by
    * `resolveFallbackRoute`. Returns null when no backup route applies (the
    * caller rethrows the original error unchanged); throws the fallback
    * error (with the original error attached as `cause`) when the backup
@@ -1476,12 +1651,18 @@ export class RetryProvider implements Provider {
    * `originalError` is undefined when the circuit breaker skipped the primary
    * outright: there is no failure of this request to report or to attach, only
    * the remembered outage of an earlier one.
+   *
+   * `backupRetryBudget` says whether the backup send gets a retry loop of its
+   * own. It is the caller's answer to one question: has this request already
+   * spent a retry budget somewhere? See the three call sites for the reasoning
+   * behind each answer.
    */
   private async sendOnFallbackRoute(
     messages: Message[],
     options: SendMessageOptions | undefined,
     originalError: unknown,
     retriesExhausted: boolean,
+    { backupRetryBudget }: { backupRetryBudget: boolean },
   ): Promise<ProviderResponse | null> {
     let route: {
       provider: Provider;
@@ -1574,12 +1755,22 @@ export class RetryProvider implements Provider {
     delete fallbackConfig.thinking;
     fallbackConfig.overrideProfile = route.overrideProfile;
     fallbackConfig.forceOverrideProfile = true;
+    const { dropToolChoice, ...toolsOverride } = this.fallbackTools(
+      options,
+      route,
+    );
+    // Filtering the sentinel emptied the tool list, so the `tool_choice` the
+    // call site paired with it now names a choice among no tools. See
+    // `fallbackTools` for why that is a hard 400 rather than a no-op.
+    if (dropToolChoice) {
+      delete fallbackConfig.tool_choice;
+    }
     const fallbackOptions = normalizeSendMessageOptions(
       route.provider.name,
       {
         ...options,
         config: fallbackConfig,
-        ...this.fallbackTools(options, route),
+        ...toolsOverride,
       },
       {
         forwardUsageAttributionHeaders:
@@ -1609,10 +1800,11 @@ export class RetryProvider implements Provider {
     );
 
     try {
-      // One hop, one attempt: the fallback send gets no retry loop in v1.
-      const response = await route.provider.sendMessage(
+      const response = await this.sendOnBackupAdapter(
+        route,
         messages,
         fallbackOptions,
+        backupRetryBudget,
       );
       // Stamp the provider that actually served the response. Without this,
       // a backup adapter that does not set `actualProvider` leaves the outer

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -1256,11 +1256,10 @@ export class RetryProvider implements Provider {
           options,
           undefined,
           false,
-          // This request never touched the primary, so no retry budget has
-          // been spent anywhere. Without one on the backup a single 429 or
-          // mid-stream cut would fail the turn outright, which is a worse
-          // posture than the three retries the same request would have had
-          // before this feature existed.
+          // The rule this argument encodes: a request gets a retry budget on
+          // the backup only when it has not already spent one. This request
+          // skips the primary outright, so it has spent nothing, and on a
+          // single attempt a lone 429 or mid-stream cut would fail the turn.
           { backupRetryBudget: true },
         );
         if (served !== null) {
@@ -1406,12 +1405,11 @@ export class RetryProvider implements Provider {
               // retries while `retryAttempt < DEFAULT_MAX_RETRIES`, so seeding
               // it with `probeSends` leaves `1 + (DEFAULT_MAX_RETRIES -
               // probeSends)` sends below and `DEFAULT_MAX_RETRIES + 1` in
-              // total, for any number of probe sends. That is exactly what a
-              // request that never probed gets, which is what keeps this from
-              // quietly becoming a wider budget than everyone else's. Counting
-              // the sends rather than the entries into this branch is what
-              // makes a repaired probe (a credential refresh, a corrective
-              // resend) come out at the same total as a plain one.
+              // total, for any number of probe sends: the same budget a request
+              // that never probes gets. Counting sends rather than entries into
+              // this branch is what holds that equality for a probe whose
+              // repairs (a credential refresh, a corrective resend) each cost a
+              // send of their own.
               retryAttempt = probeSends;
               break;
             }
@@ -1528,11 +1526,11 @@ export class RetryProvider implements Provider {
             options,
             error,
             retriesExhausted,
-            // One hop, one attempt stays right here: the primary loop above
-            // already ran to a definitive verdict, either exhausting its whole
+            // No budget here: the primary loop above runs to a definitive
+            // verdict before reaching this point, either exhausting its whole
             // budget against a transient failure or receiving an error no
-            // resend would change. The user has been waiting through all of
-            // that, so the backup answers once or the turn fails.
+            // resend changes. The user has waited through all of that, so the
+            // backup answers once or the turn fails.
             { backupRetryBudget: false },
           );
           if (fallbackResult !== null) {

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -1292,8 +1292,15 @@ export class RetryProvider implements Provider {
         // it to the backup, and a recovery hands it back to the ordinary retry
         // loop below, which is now the right place for it because the route it
         // just cleared is the one that loop sends to.
+        //
+        // Every send the probe makes is counted, repairs included. A repair is
+        // still a send against the primary, so it is what the seed below has to
+        // be built from: a constant would only be right on the path where no
+        // repair ran.
+        let probeSends = 0;
         while (true) {
           try {
+            probeSends += 1;
             const response = await this.inner.sendMessage(
               messagesForAttempt,
               normalizedOptions,
@@ -1394,12 +1401,18 @@ export class RetryProvider implements Provider {
               // that streams corruption all the way through still finishes the
               // turn somewhere.
               //
-              // The probe's send WAS this request's first attempt, so the loop
-              // starts one attempt in. Total sends on the primary stay at
-              // `DEFAULT_MAX_RETRIES + 1`, exactly what a request that never
-              // probed would get, which is what keeps this from quietly
-              // becoming a wider budget than everyone else's.
-              retryAttempt = 1;
+              // Every send the probe made WAS this request spending its own
+              // attempts, so the loop starts that many attempts in. The loop
+              // retries while `retryAttempt < DEFAULT_MAX_RETRIES`, so seeding
+              // it with `probeSends` leaves `1 + (DEFAULT_MAX_RETRIES -
+              // probeSends)` sends below and `DEFAULT_MAX_RETRIES + 1` in
+              // total, for any number of probe sends. That is exactly what a
+              // request that never probed gets, which is what keeps this from
+              // quietly becoming a wider budget than everyone else's. Counting
+              // the sends rather than the entries into this branch is what
+              // makes a repaired probe (a credential refresh, a corrective
+              // resend) come out at the same total as a plain one.
+              retryAttempt = probeSends;
               break;
             }
             fallbackAttempted = true;


### PR DESCRIPTION
## Summary
Fixes three defects found by the fallback feature's integration self-review.

- A breaker-open request previously got a single attempt with no retries, a worse availability posture than before the feature, since the breaker trips after one successful fallback serve
- Filtering the native-search sentinel left its paired tool_choice behind, so a tool-less call site fell back with an empty tool list and a tool_choice both Anthropic and OpenAI reject
- The recovery probe treated request-conditioned failures (stream corruption, unparseable tool args) as continued outage, extending the fleet's outage memory on evidence the primary was healthy
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41253" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->