### PR TITLE
fix(openrouter): align MiniMax M2.7 rates with live OpenRouter card

### DIFF
--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -1609,9 +1609,9 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         supportsVision: false,
         supportsToolUse: true,
         pricing: {
-          inputPer1mTokens: 0.24,
-          outputPer1mTokens: 0.96,
-          cacheReadPer1mTokens: 0.048,
+          inputPer1mTokens: 0.3,
+          outputPer1mTokens: 1.2,
+          cacheReadPer1mTokens: 0.06,
         },
       },
       {

--- a/meta/llm-provider-catalog.json
+++ b/meta/llm-provider-catalog.json
@@ -1516,9 +1516,9 @@
           "supportsVision": false,
           "supportsToolUse": true,
           "pricing": {
-            "inputPer1mTokens": 0.24,
-            "outputPer1mTokens": 0.96,
-            "cacheReadPer1mTokens": 0.048
+            "inputPer1mTokens": 0.3,
+            "outputPer1mTokens": 1.2,
+            "cacheReadPer1mTokens": 0.06
           }
         },
         {


### PR DESCRIPTION
## Why

`src/__tests__/openrouter-catalog-parity.test.ts` checks the catalog against OpenRouter's live `/api/v1/models` card and is failing the `Test` job on every open PR (seen on #41249): `minimax/minimax-m2.7: input 0.24 vs OpenRouter 0.3`.

## What

Update the `minimax/minimax-m2.7` OpenRouter catalog entry to the live rates: input 0.30, output 1.20, cache read 0.06 per 1M tokens (was 0.24 / 0.96 / 0.048).

## Verification

`cd assistant && bun test src/__tests__/openrouter-catalog-parity.test.ts` passes against the live card (4 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PM5pPvvN9En4GCZrgnHwg

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41254" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->