### PR TITLE
feat(ios): shared avatar rendering for widgets (eyes, image, blurred background, derived palette)

### DIFF
--- a/clients/ios/App/App/Shared/CSSHexColor.swift
+++ b/clients/ios/App/App/Shared/CSSHexColor.swift
@@ -9,6 +9,12 @@ import UIKit
 /// background, `accentHex` for the Live Activity, the widget snapshot's avatar
 /// accent). ``canonicalCSSHex(_:)`` validates against exactly this grammar, so
 /// a canonicalized string always parses here.
+///
+/// It also carries the few derivations a native surface has to make from one
+/// of those colors on its own. The web computes them in
+/// `clients/web/src/utils/avatar-tone.ts`, which is the source of truth for
+/// every one of them; a widget renders in a process that never runs the SPA,
+/// so it has to land on the same numbers by doing the same arithmetic.
 extension UIColor {
     /// Parse a CSS hex color string (`#RGB`, `#RRGGBB`, or `#RRGGBBAA`) as
     /// reported by `getComputedStyle().getPropertyValue()`. Returns `nil` for
@@ -99,4 +105,68 @@ func canonicalCSSHex(_ raw: String) -> String? {
         return nil
     }
     return "#" + digits
+}
+
+/// Near-black ground that avatar-tinted full-bleed surfaces blend over.
+/// `SURFACE_GROUND` in `avatar-tone.ts`.
+let avatarSurfaceGround = "#151515"
+
+/// Multiply every channel of `hex` by `factor`, clamping to the 0-255 range.
+///
+/// Mirrors `darkenHex` in `clients/web/src/utils/avatar-tone.ts`, the way
+/// ``UIColor/contrastingForeground`` mirrors that file's `contrastForeground`.
+/// It is how a surface painted with an avatar accent gets its dark-appearance
+/// variant: one hex arrives in the snapshot, and both appearances have to come
+/// out of it. A string this file cannot read comes back unchanged, as it does
+/// on the web, so the caller's own fallback still has something to reject.
+func darkenHex(_ hex: String, _ factor: Double) -> String {
+    guard let channels = hexChannels(hex) else {
+        return hex
+    }
+    func scale(_ channel: Int) -> Int {
+        return max(0, min(255, Int((Double(channel) * factor).rounded())))
+    }
+    return hexString(r: scale(channels.r), g: scale(channels.g), b: scale(channels.b))
+}
+
+/// Composite `overlay` at `alpha` over the solid `base`, returning the
+/// resulting opaque color. Mirrors `blendHex` in `avatar-tone.ts`, including
+/// its answer for a color it cannot read: `base`, unchanged.
+func blendHex(base: String, overlay: String, alpha: Double) -> String {
+    guard let b = hexChannels(base), let o = hexChannels(overlay) else {
+        return base
+    }
+    let a = max(0, min(1, alpha))
+    func mix(_ from: Int, _ to: Int) -> Int {
+        return Int((Double(from) * (1 - a) + Double(to) * a).rounded())
+    }
+    return hexString(r: mix(b.r, o.r), g: mix(b.g, o.g), b: mix(b.b, o.b))
+}
+
+/// Deep full-bleed surface for an avatar accent: the accent washed over
+/// ``avatarSurfaceGround``. Mirrors `avatarSurfaceHex` in `avatar-tone.ts`,
+/// 0.14 and all, so a native surface lands on the same ground the takeover
+/// paints behind the same avatar.
+func avatarSurfaceHex(_ accentHex: String) -> String {
+    return blendHex(base: avatarSurfaceGround, overlay: accentHex, alpha: 0.14)
+}
+
+/// The red, green and blue channels of a CSS hex color as 0-255 integers, or
+/// `nil` when the string is not one.
+///
+/// Grammar comes from ``canonicalCSSHex(_:)`` rather than a second regex, for
+/// the reason this file exists at all. Alpha, where the string carries it, is
+/// dropped: every derivation above produces a surface, and a surface with a
+/// hole in it is not one.
+private func hexChannels(_ hex: String) -> (r: Int, g: Int, b: Int)? {
+    guard let canonical = canonicalCSSHex(hex),
+          let value = UInt64(canonical.dropFirst().prefix(6), radix: 16)
+    else {
+        return nil
+    }
+    return (r: Int((value >> 16) & 0xFF), g: Int((value >> 8) & 0xFF), b: Int(value & 0xFF))
+}
+
+private func hexString(r: Int, g: Int, b: Int) -> String {
+    return String(format: "#%02X%02X%02X", r, g, b)
 }

--- a/clients/ios/App/VoiceActivity/Widgets/WidgetActionControls.swift
+++ b/clients/ios/App/VoiceActivity/Widgets/WidgetActionControls.swift
@@ -1,5 +1,6 @@
 import AppIntents
 import SwiftUI
+import UIKit
 
 // The controls every Vellum Home Screen widget builds its actions out of: a
 // tile, a circle, a pill, and the secondary line of text that stands in when
@@ -19,18 +20,24 @@ struct WidgetActionTile<ActionIntent: AppIntent>: View {
     /// tile reads as a smaller instance of the card it sits on.
     private static var cornerRadius: CGFloat { 14 }
 
+    private static var iconSize: CGFloat { 22 }
+
     let intent: ActionIntent
     let icon: Image
     let title: String
     let fill: Color
     let tint: Color
 
+    /// The user's avatar, drawn in place of ``icon`` when the snapshot carries
+    /// one. Optional because the tiles standing for an action rather than for
+    /// the assistant keep their symbol, and because nothing has synced yet on a
+    /// fresh install.
+    var avatarImage: UIImage? = nil
+
     var body: some View {
         Button(intent: intent) {
             VStack(spacing: 4) {
-                icon
-                    .font(.system(size: 22))
-                    .foregroundStyle(tint)
+                glyph
                 Text(title)
                     .font(.system(size: 9, weight: .medium))
                     .foregroundStyle(WidgetTheme.textPrimary)
@@ -41,6 +48,19 @@ struct WidgetActionTile<ActionIntent: AppIntent>: View {
         }
         .buttonStyle(.plain)
         .accessibilityLabel(title)
+    }
+
+    /// A symbol takes its size from the font and its color from the tile's
+    /// tint; a bitmap can do neither, so it is sized and clipped instead.
+    @ViewBuilder
+    private var glyph: some View {
+        if let avatarImage {
+            WidgetAvatarImageView(image: avatarImage, size: Self.iconSize)
+        } else {
+            icon
+                .font(.system(size: Self.iconSize))
+                .foregroundStyle(tint)
+        }
     }
 }
 
@@ -107,11 +127,13 @@ struct PillActionButton<ActionIntent: AppIntent>: View {
     let tint: Color
     let height: CGFloat
 
+    /// See ``WidgetActionTile/avatarImage``.
+    var avatarImage: UIImage? = nil
+
     var body: some View {
         Button(intent: intent) {
             HStack(spacing: 6) {
-                icon
-                    .font(.system(size: height * 0.4))
+                glyph
                 Text(title)
                     .font(.system(size: 15, weight: .semibold))
             }
@@ -123,6 +145,20 @@ struct PillActionButton<ActionIntent: AppIntent>: View {
         .buttonStyle(.plain)
         .accessibilityLabel(title)
     }
+
+    /// The glyph is sized off the pill's height either way, so swapping the
+    /// symbol for the avatar does not move the word beside it.
+    @ViewBuilder
+    private var glyph: some View {
+        if let avatarImage {
+            WidgetAvatarImageView(image: avatarImage, size: iconSize)
+        } else {
+            icon
+                .font(.system(size: iconSize))
+        }
+    }
+
+    private var iconSize: CGFloat { height * 0.4 }
 }
 
 /// The quiet line a widget prints when it has nothing to list: an empty state,

--- a/clients/ios/App/VoiceActivity/Widgets/WidgetAvatarRendering.swift
+++ b/clients/ios/App/VoiceActivity/Widgets/WidgetAvatarRendering.swift
@@ -226,7 +226,13 @@ extension SnapshotEntry {
     /// and a card that changed color half an hour after the phone was last
     /// unlocked would be the widget lying about something it does know.
     var avatarKind: WidgetAvatarKind {
-        WidgetAvatarKind(snapshotKind: snapshot?.avatar?.kind)
+        let kind = WidgetAvatarKind(snapshotKind: snapshot?.avatar?.kind)
+        if kind == .image && avatarImage == nil {
+            // An image avatar whose bytes were dropped for budget or fail to
+            // decode has no photo to blur; the brand fallback stands in.
+            return .none
+        }
+        return kind
     }
 
     /// The avatar's raster, decoded. `nil` for an avatar carrying none and for
@@ -236,9 +242,14 @@ extension SnapshotEntry {
     }
 
     /// The colors to theme this rendering with, already fallen back to the
-    /// static brand card when there is no accent.
+    /// static brand card when there is no accent. Only a character avatar
+    /// themes the card: any other kind keeps the static palette even if a
+    /// malformed or newer-schema snapshot carries an accent alongside it.
     var avatarPalette: WidgetAvatarPalette {
-        WidgetAvatarPalette(accentHex: snapshot?.avatar?.accentHex)
+        guard avatarKind == .character else {
+            return WidgetAvatarPalette(accentHex: nil)
+        }
+        return WidgetAvatarPalette(accentHex: snapshot?.avatar?.accentHex)
     }
 }
 

--- a/clients/ios/App/VoiceActivity/Widgets/WidgetAvatarRendering.swift
+++ b/clients/ios/App/VoiceActivity/Widgets/WidgetAvatarRendering.swift
@@ -1,0 +1,344 @@
+import SwiftUI
+import UIKit
+
+// Everything a Vellum Home Screen widget needs to draw the user's own
+// assistant rather than a fixed brand mark: the colors derived from its
+// accent, the eyes, the avatar image, and the blurred photo card a custom
+// avatar sits on. They live together because a widget that themed itself would
+// theme itself slightly differently from the next one.
+
+/// What a widget can do with the snapshot's avatar, as the three treatments it
+/// actually has rather than as the string the payload carries.
+///
+/// Anything unrecognized reads as ``none``, matching the payload's own
+/// contract: an avatar this build cannot draw costs the widget its theming and
+/// nothing else.
+enum WidgetAvatarKind {
+    /// A composed character: an accent color, and a raster of its face.
+    case character
+    /// An uploaded photo. Carries no accent by design, so the card blurs the
+    /// photo instead of tinting itself with a color extracted from it.
+    case image
+    /// No avatar to draw. The static brand palette stands in.
+    case none
+
+    init(snapshotKind: String?) {
+        switch snapshotKind {
+        case "character":
+            self = .character
+        case "image":
+            self = .image
+        default:
+            self = .none
+        }
+    }
+}
+
+/// The colors a widget card painted with an avatar accent draws from.
+///
+/// One hex arrives in the snapshot and the rest is derived, because the
+/// extension is handed a single color and needs a card, a foreground that
+/// survives it, and a control fill that reads as cut out of it rather than
+/// placed on top. The foreground follows the surface's own luminance: a yellow
+/// avatar and a deep green one both have to produce a legible card, which a
+/// fixed white cannot.
+///
+/// Both appearances are resolved up front and handed over as dynamic colors.
+/// The foreground has to contrast with whichever surface is actually drawn,
+/// and asking a trait-less color what it looks like answers for only one of
+/// them.
+struct WidgetAvatarPalette {
+    /// Factor deepening an accent for dark appearance, so a saturated card is
+    /// not the brightest thing on a dark Home Screen. Calibrated on the brand
+    /// green: it turns ``WidgetTheme/brandCardSurface``'s light `#0E9B8B` into
+    /// exactly the `#0B7A6E` it was hand-picked to pair with, so the derived
+    /// palette and the static one agree wherever they overlap.
+    private static let darkSurfaceFactor = 0.79
+
+    /// Opacity a control's fill sits at on the card, matching
+    /// ``WidgetTheme/onBrandFill``.
+    private static let controlFillOpacity = 0.22
+
+    /// The card behind everything.
+    let surface: Color
+
+    /// Glyphs and text drawn on ``surface``.
+    let onSurface: Color
+
+    /// A control's fill on ``surface``: ``onSurface`` at low opacity.
+    let controlFill: Color
+
+    /// The palette for an avatar accent, or the static brand card when there
+    /// is no accent to work from and when the one on offer is unreadable.
+    init(accentHex: String?) {
+        guard let accentHex,
+              let canonical = canonicalCSSHex(accentHex),
+              let light = UIColor(cssHex: canonical),
+              let dark = UIColor(cssHex: darkenHex(canonical, Self.darkSurfaceFactor))
+        else {
+            surface = WidgetTheme.brandCardSurface
+            onSurface = WidgetTheme.onBrand
+            controlFill = WidgetTheme.onBrandFill
+            return
+        }
+        let lightOn = light.contrastingForeground
+        let darkOn = dark.contrastingForeground
+        surface = Self.dynamic(light: light, dark: dark)
+        onSurface = Self.dynamic(light: lightOn, dark: darkOn)
+        controlFill = Self.dynamic(
+            light: lightOn.withAlphaComponent(Self.controlFillOpacity),
+            dark: darkOn.withAlphaComponent(Self.controlFillOpacity)
+        )
+    }
+
+    /// A color that resolves from the appearance the widget is rendered in.
+    /// ``WidgetTheme`` keeps its own copy of this for the literals it holds;
+    /// this one composes colors derived at render time.
+    private static func dynamic(light: UIColor, dark: UIColor) -> Color {
+        return Color(uiColor: UIColor { traits in
+            traits.userInterfaceStyle == .dark ? dark : light
+        })
+    }
+}
+
+/// The assistant's eyes, drawn straight onto the card behind them.
+///
+/// Shapes rather than a bitmap: they stay sharp at every scale and on every
+/// display, and they cost the extension no asset. The face's raster travels in
+/// the snapshot for the slots that show the whole avatar, but a card whose
+/// background *is* the avatar's color wants the eyes alone on it, with nothing
+/// boxed around them.
+///
+/// Sized from one number so a widget places the pair by picking its height:
+/// each eye is 28x33 at the default, and the pair is 61 wide.
+struct WidgetAvatarEyes: View {
+    /// Width of one eye, as a share of its height.
+    private static let widthRatio: CGFloat = 28.0 / 33.0
+
+    /// Gap between the two, as a share of eye height.
+    private static let gapRatio: CGFloat = 5.0 / 33.0
+
+    /// Pupil diameter and how far it sits off the bottom of the white, both as
+    /// a share of eye height. Pupils sit low, which is the whole trick:
+    /// centered dots read as punctuation, low ones read as a face looking back.
+    private static let pupilRatio: CGFloat = 0.41
+    private static let pupilInsetRatio: CGFloat = 0.18
+
+    var eyeHeight: CGFloat = 33
+
+    var body: some View {
+        HStack(spacing: eyeHeight * Self.gapRatio) {
+            eye
+            eye
+        }
+        .accessibilityHidden(true)
+    }
+
+    private var eye: some View {
+        Ellipse()
+            .fill(WidgetTheme.avatarSclera)
+            .frame(width: eyeHeight * Self.widthRatio, height: eyeHeight)
+            .overlay(alignment: .bottom) {
+                Circle()
+                    .fill(WidgetTheme.avatarPupil)
+                    .frame(width: eyeHeight * Self.pupilRatio, height: eyeHeight * Self.pupilRatio)
+                    .padding(.bottom, eyeHeight * Self.pupilInsetRatio)
+            }
+    }
+}
+
+/// The avatar itself, from the raster the snapshot carries.
+///
+/// Filled rather than fitted, and clipped, because every slot that shows this
+/// is a mark of a known size in a laid-out card: a photo letterboxed inside its
+/// slot would leave the card with a hole the size of the difference. `nil`
+/// corner radius clips to a circle.
+///
+/// `.privacySensitive()` because it is the user's own avatar and a widget draws
+/// on a locked device.
+struct WidgetAvatarImageView: View {
+    let image: UIImage
+    let size: CGFloat
+    var cornerRadius: CGFloat? = nil
+
+    var body: some View {
+        Image(uiImage: image)
+            .resizable()
+            .scaledToFill()
+            .frame(width: size, height: size)
+            .clipShape(RoundedRectangle(cornerRadius: cornerRadius ?? size / 2, style: .continuous))
+            .privacySensitive()
+            .accessibilityHidden(true)
+    }
+}
+
+/// The card behind a custom avatar: the photo, blurred past recognition, under
+/// a scrim deep enough that anything drawn on top stays legible.
+///
+/// This is the treatment the takeover backdrop and the identity page already
+/// give the same picture, at the same blur and the same scrim, so a custom
+/// avatar looks like itself everywhere it appears.
+///
+/// Deliberately not `.privacySensitive()`: the blur has already destroyed every
+/// detail a redaction would be protecting, and redacting the card's own ground
+/// would blank the widget rather than protect anything. The marks drawn on top
+/// carry the redaction.
+struct BlurredAvatarBackground: View {
+    private static let blurRadius: CGFloat = 30
+    private static let scrimOpacity = 0.55
+
+    /// The photo, absent when the snapshot carries none and when its bytes do
+    /// not form an image. Both fall through to the ground below, which is what
+    /// makes this safe to hand a card's whole background to.
+    let image: UIImage?
+
+    /// Tints the ground for the case where there is no photo to blur, the way
+    /// the takeover tints its own. Nil leaves the ground hue-neutral, which is
+    /// all an uploaded photo can offer: it carries no accent by design.
+    var accentHex: String? = nil
+
+    var body: some View {
+        ground
+            .overlay {
+                if let image {
+                    Image(uiImage: image)
+                        .resizable()
+                        .scaledToFill()
+                        .blur(radius: Self.blurRadius)
+                        .overlay { Color.black.opacity(Self.scrimOpacity) }
+                }
+            }
+            .clipped()
+            .accessibilityHidden(true)
+    }
+
+    private var ground: Color {
+        let hex = accentHex.map(avatarSurfaceHex) ?? avatarSurfaceGround
+        return Color(cssHex: hex) ?? .black
+    }
+}
+
+extension SnapshotEntry {
+    /// Which of the three avatar treatments this rendering calls for.
+    ///
+    /// Not gated on ``isStale``. Staleness drops claims about what is happening
+    /// right now; which assistant the account belongs to is not one of them,
+    /// and a card that changed color half an hour after the phone was last
+    /// unlocked would be the widget lying about something it does know.
+    var avatarKind: WidgetAvatarKind {
+        WidgetAvatarKind(snapshotKind: snapshot?.avatar?.kind)
+    }
+
+    /// The avatar's raster, decoded. `nil` for an avatar carrying none and for
+    /// bytes that do not form an image; every widget draws both the same way.
+    var avatarImage: UIImage? {
+        snapshot?.avatar?.imageData.flatMap(UIImage.init(data:))
+    }
+
+    /// The colors to theme this rendering with, already fallen back to the
+    /// static brand card when there is no accent.
+    var avatarPalette: WidgetAvatarPalette {
+        WidgetAvatarPalette(accentHex: snapshot?.avatar?.accentHex)
+    }
+}
+
+#if DEBUG
+
+/// A card built out of the whole kit, so a preview shows the palette holding up
+/// under the things actually drawn on it rather than three color swatches.
+private struct WidgetAvatarKitPreviewCard: View {
+    let title: String
+    let palette: WidgetAvatarPalette
+
+    var body: some View {
+        VStack(spacing: 10) {
+            WidgetAvatarEyes(eyeHeight: 26)
+            Text(title)
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(palette.onSurface)
+            HStack(spacing: 8) {
+                controlCircle("camera.fill")
+                controlCircle("waveform")
+            }
+        }
+        .frame(width: 150, height: 150)
+        .background(palette.surface)
+        .clipShape(RoundedRectangle(cornerRadius: 22, style: .continuous))
+    }
+
+    private func controlCircle(_ symbol: String) -> some View {
+        Image(systemName: symbol)
+            .font(.system(size: 15))
+            .foregroundStyle(palette.onSurface)
+            .frame(width: 38, height: 38)
+            .background(palette.controlFill, in: Circle())
+    }
+}
+
+/// The same content in both appearances, side by side: every value in this file
+/// resolves per appearance, so a preview showing one of them is half a preview.
+private func previewAppearances<Content: View>(
+    @ViewBuilder _ content: @escaping () -> Content
+) -> some View {
+    HStack(spacing: 16) {
+        ForEach([ColorScheme.light, ColorScheme.dark], id: \.self) { scheme in
+            content()
+                .padding(12)
+                .background(scheme == .dark ? Color.black : Color(white: 0.92))
+                .environment(\.colorScheme, scheme)
+        }
+    }
+    .padding()
+}
+
+/// A stand-in photo, drawn rather than shipped so the previews cost the
+/// extension no asset.
+private func previewAvatarPhoto() -> UIImage {
+    let size = CGSize(width: 120, height: 120)
+    return UIGraphicsImageRenderer(size: size).image { context in
+        (UIColor(cssHex: "#3B6EA5") ?? .systemBlue).setFill()
+        context.fill(CGRect(origin: .zero, size: size))
+        (UIColor(cssHex: "#E8B04B") ?? .systemOrange).setFill()
+        context.cgContext.fillEllipse(in: CGRect(x: 22, y: 26, width: 76, height: 76))
+    }
+}
+
+#Preview("Character accents") {
+    previewAppearances {
+        HStack(spacing: 12) {
+            WidgetAvatarKitPreviewCard(
+                title: "Teal",
+                palette: WidgetAvatarPalette(accentHex: "#0E9B8B")
+            )
+            // The light one: its on-colors have to come out dark, or the card
+            // is white text on yellow.
+            WidgetAvatarKitPreviewCard(
+                title: "Yellow",
+                palette: WidgetAvatarPalette(accentHex: "#F2C94C")
+            )
+        }
+    }
+}
+
+#Preview("Custom image") {
+    let photo = previewAvatarPhoto()
+    previewAppearances {
+        ZStack {
+            BlurredAvatarBackground(image: photo)
+            WidgetAvatarImageView(image: photo, size: 44, cornerRadius: 14)
+        }
+        .frame(width: 150, height: 150)
+        .clipShape(RoundedRectangle(cornerRadius: 22, style: .continuous))
+    }
+}
+
+#Preview("No avatar") {
+    previewAppearances {
+        WidgetAvatarKitPreviewCard(
+            title: "Fallback",
+            palette: WidgetAvatarPalette(accentHex: nil)
+        )
+    }
+}
+
+#endif

--- a/clients/ios/App/VoiceActivity/Widgets/WidgetAvatarRendering.swift
+++ b/clients/ios/App/VoiceActivity/Widgets/WidgetAvatarRendering.swift
@@ -73,7 +73,7 @@ struct WidgetAvatarPalette {
     init(accentHex: String?) {
         guard let accentHex,
               let canonical = canonicalCSSHex(accentHex),
-              let light = UIColor(cssHex: canonical),
+              let parsed = UIColor(cssHex: canonical),
               let dark = UIColor(cssHex: darkenHex(canonical, Self.darkSurfaceFactor))
         else {
             surface = WidgetTheme.brandCardSurface
@@ -81,6 +81,10 @@ struct WidgetAvatarPalette {
             controlFill = WidgetTheme.onBrandFill
             return
         }
+        // A card surface is opaque by definition. An 8-digit accent keeps its
+        // alpha through the parser while the darkened variant drops it, so the
+        // light side is squared with the dark side here.
+        let light = parsed.withAlphaComponent(1)
         let lightOn = light.contrastingForeground
         let darkOn = dark.contrastingForeground
         surface = WidgetTheme.appearanceDynamic(light: light, dark: dark)

--- a/clients/ios/App/VoiceActivity/Widgets/WidgetAvatarRendering.swift
+++ b/clients/ios/App/VoiceActivity/Widgets/WidgetAvatarRendering.swift
@@ -187,6 +187,11 @@ struct BlurredAvatarBackground: View {
     private static let blurRadius: CGFloat = 30
     private static let scrimOpacity = 0.55
 
+    /// The blur samples transparency past the layer's edge, so the photo grows
+    /// beyond the card by twice the radius per side before blurring and the
+    /// clip trims the excess; otherwise the perimeter fades into the ground.
+    private static let overscan: CGFloat = blurRadius * 2
+
     /// The photo, absent when the snapshot carries none and when its bytes do
     /// not form an image. Both fall through to the ground below, which is what
     /// makes this safe to hand a card's whole background to.
@@ -201,11 +206,21 @@ struct BlurredAvatarBackground: View {
         ground
             .overlay {
                 if let image {
-                    Image(uiImage: image)
-                        .resizable()
-                        .scaledToFill()
-                        .blur(radius: Self.blurRadius)
-                        .overlay { Color.black.opacity(Self.scrimOpacity) }
+                    GeometryReader { geo in
+                        Image(uiImage: image)
+                            .resizable()
+                            .scaledToFill()
+                            .frame(
+                                width: geo.size.width + Self.overscan * 2,
+                                height: geo.size.height + Self.overscan * 2
+                            )
+                            .position(
+                                x: geo.size.width / 2,
+                                y: geo.size.height / 2
+                            )
+                            .blur(radius: Self.blurRadius)
+                    }
+                    .overlay { Color.black.opacity(Self.scrimOpacity) }
                 }
             }
             .clipped()

--- a/clients/ios/App/VoiceActivity/Widgets/WidgetAvatarRendering.swift
+++ b/clients/ios/App/VoiceActivity/Widgets/WidgetAvatarRendering.swift
@@ -83,22 +83,14 @@ struct WidgetAvatarPalette {
         }
         let lightOn = light.contrastingForeground
         let darkOn = dark.contrastingForeground
-        surface = Self.dynamic(light: light, dark: dark)
-        onSurface = Self.dynamic(light: lightOn, dark: darkOn)
-        controlFill = Self.dynamic(
+        surface = WidgetTheme.appearanceDynamic(light: light, dark: dark)
+        onSurface = WidgetTheme.appearanceDynamic(light: lightOn, dark: darkOn)
+        controlFill = WidgetTheme.appearanceDynamic(
             light: lightOn.withAlphaComponent(Self.controlFillOpacity),
             dark: darkOn.withAlphaComponent(Self.controlFillOpacity)
         )
     }
 
-    /// A color that resolves from the appearance the widget is rendered in.
-    /// ``WidgetTheme`` keeps its own copy of this for the literals it holds;
-    /// this one composes colors derived at render time.
-    private static func dynamic(light: UIColor, dark: UIColor) -> Color {
-        return Color(uiColor: UIColor { traits in
-            traits.userInterfaceStyle == .dark ? dark : light
-        })
-    }
 }
 
 /// The assistant's eyes, drawn straight onto the card behind them.

--- a/clients/ios/App/VoiceActivity/Widgets/WidgetTheme.swift
+++ b/clients/ios/App/VoiceActivity/Widgets/WidgetTheme.swift
@@ -79,8 +79,15 @@ enum WidgetTheme {
     private static func dynamic(light: String, dark: String) -> Color {
         let lightColor = UIColor(cssHex: light) ?? .white
         let darkColor = UIColor(cssHex: dark) ?? .black
-        return Color(uiColor: UIColor { traits in
-            traits.userInterfaceStyle == .dark ? darkColor : lightColor
+        return appearanceDynamic(light: lightColor, dark: darkColor)
+    }
+
+    /// Composes two resolved colors into one that follows the appearance the
+    /// widget renders in. The single owner of trait selection for widget
+    /// palettes, static literals and render-time derivations alike.
+    static func appearanceDynamic(light: UIColor, dark: UIColor) -> Color {
+        Color(uiColor: UIColor { traits in
+            traits.userInterfaceStyle == .dark ? dark : light
         })
     }
 


### PR DESCRIPTION
## Summary
- Swift ports of the web avatar color math (darken, surface wash) beside the existing contrast helper
- Shared widget views: derived palette, drawn eyes, clipped avatar image, blurred-photo background with scrim
- Action tile and pill gain an optional bitmap avatar icon with the brand-mark fallback; existing widgets render unchanged

Part of plan: ios-widgets-v2.md (PR 5 of 7)