### PR TITLE
fix(web): keep notification rows at full height in the bell's capped list (LUM-3438)

### DIFF
--- a/clients/web/src/domains/home/home-recap-row.tsx
+++ b/clients/web/src/domains/home/home-recap-row.tsx
@@ -294,10 +294,15 @@ export function HomeRecapRow({
       onOpenChange={longPress.onOpenChange}
     >
       <div {...longPress.wrapperProps}>
+        {/* `shrink-0`: the swipe branch clips its own overflow, which zeroes a
+            flex item's automatic minimum size, and the long-press wrapper is
+            `display: contents`, so this element is the flex item a list sizes.
+            Without it a height-capped column (the notifications bell's list)
+            squashes every row down to its border instead of scrolling. */}
         <SwipeActionReveal
           leadingActions={swipeActionsFor(actions, "leading")}
           trailingActions={swipeActionsFor(actions, "trailing")}
-          className="rounded-[var(--radius-lg)]"
+          className="shrink-0 rounded-[var(--radius-lg)]"
         >
           {card}
         </SwipeActionReveal>


### PR DESCRIPTION
## TL;DR

On a phone, the notifications bell collapsed every row to a thin line once
there were more notifications than the panel could seat. `shrink-0` on the
recap row fixes it. Desktop was never affected.

Fixes [LUM-3438](https://linear.app/vellum/issue/LUM-3438/ios-tf-notifications-bug-dev-202608210733)

## What was wrong

The bell draws its list as a height-capped flex column (`flex flex-col
gap-sm overflow-y-auto`, capped at `60dvh` on a bottom sheet).

On a coarse pointer, each row arms `SwipeActionReveal`, and its armed branch
carries `relative overflow-hidden` so the action layers stay hidden until a
swipe reveals them. The long-press wrapper that sits between the list and that
element is `display: contents`, so the clipping element is itself the flex item
the list sizes.

A flex item whose overflow is not `visible` has its automatic minimum size
resolved to zero rather than to its content, so nothing stopped the column from
shrinking the rows: with more notifications than the cap could seat, every row
was squashed toward zero and the panel painted a stack of borders instead of
scrolling.

Desktop takes the passthrough branch (no swipe armed, no clip), so the
automatic minimum still held each row at its content height and the list
scrolled normally.

## Before / after

| Surface | Before | After |
| -- | -- | -- |
| Bell on a phone, more notifications than fit | Every row is a hairline: no title, no timestamp, nothing to tap, and the list does not scroll | Rows keep their full height and the list scrolls |
| Bell on a phone, a few notifications | Rows shrink proportionally, so they look cramped rather than empty | Rows keep their full height |
| Bell on desktop | Correct already | Unchanged |
| Activity page rows | Correct already (the page grows rather than capping) | Unchanged |

## Why this is safe

- One utility class on one element. `shrink-0` only matters when the row is a
  flex item in a container that wants to shrink it, which is exactly the case
  that was broken.
- The desktop branch is unchanged in behaviour: its automatic minimum size
  already held the row at content height, so `shrink-0` is a no-op there. Both
  branches now lay out identically, which is the invariant that broke.
- Scoped to `HomeRecapRow` rather than to `SwipeActionReveal` itself, because
  `flex-shrink` applies on whichever axis the parent flex runs. A recap row is
  always a vertical list item; the other swipe rows (conversation rows, pinned
  app tiles, library cards) are not, and none of them sits in a height-capped
  flex column today, so none of them has the live bug.

## How it was verified

happy-dom has no layout engine, so this cannot be measured in the unit suite.
Measured in a real browser instead, at a coarse-pointer viewport, rendering
real `HomeRecapRow` components inside the bell's list shape (capped at 300px,
14 compact rows):

| | row height | list scrollHeight |
| -- | -- | -- |
| without `shrink-0` | 14px | 300px (does not scroll) |
| with `shrink-0` | 73px | 1126px (scrolls) |

73px is exactly the compact card height the bell's own height budget is derived
from. The squashed height scales with item count: at the roughly 60
notifications in the report the rows land near 2px, which matches the ~9.5pt
line pitch measured off the TestFlight screenshot.

## No automated test

Both `home-recap-row.test.tsx` and `notifications-bell.test.tsx` state at the
top that they never assert class strings, and a class assertion would not
embody the failure anyway: the bug is a layout outcome no DOM-only runner can
observe. I verified in a browser rather than adding a test that checks for the
class and calls it coverage. If we want this class of bug covered, the missing
piece is a browser-run story assertion, which is a separate change.

## Regression window

#40772 (Aug 18) gave the recap row its swipe actions and long-press sheet; the
bell's list has been height-capped since #40279 (Aug 6). Build
202608210733 was the first TestFlight build carrying both.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41259" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->