### PR TITLE
feat: automatic model fallback for managed inference profiles

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -5152,6 +5152,9 @@ paths:
                     required:
                       - profile
                       - weight
+                fallbackProfile:
+                  type: string
+                  minLength: 1
       responses:
         "200":
           description: Successful response
@@ -14911,8 +14914,8 @@ paths:
           description: Profile not found
         "409":
           description:
-            Profile is still referenced by activeProfile, advisorProfile, a call site, a default-tier override, or a
-            mix arm
+            Profile is still referenced by activeProfile, advisorProfile, a call site, a default-tier override, a mix
+            arm, or another profile's fallbackProfile
     get:
       operationId: inference_profiles_by_name_get
       summary: Get an effective inference profile
@@ -34632,6 +34635,11 @@ components:
                   - profile
                   - weight
             - type: "null"
+        fallbackProfile:
+          anyOf:
+            - type: string
+              minLength: 1
+            - type: "null"
       additionalProperties: {}
     ProfileStatus:
       type: string
@@ -35401,6 +35409,9 @@ components:
               - profile
               - weight
             additionalProperties: false
+        fallbackProfile:
+          type: string
+          minLength: 1
         supportsVision:
           type: boolean
         invariant:

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -5153,6 +5153,7 @@ paths:
                       - profile
                       - weight
                 fallbackProfile:
+                  readOnly: true
                   type: string
                   minLength: 1
       responses:
@@ -34637,7 +34638,8 @@ components:
             - type: "null"
         fallbackProfile:
           anyOf:
-            - type: string
+            - readOnly: true
+              type: string
               minLength: 1
             - type: "null"
       additionalProperties: {}
@@ -35410,6 +35412,7 @@ components:
               - weight
             additionalProperties: false
         fallbackProfile:
+          readOnly: true
           type: string
           minLength: 1
         supportsVision:

--- a/assistant/src/__tests__/compactor-call-site-logging.test.ts
+++ b/assistant/src/__tests__/compactor-call-site-logging.test.ts
@@ -194,3 +194,64 @@ describe("compactor records llm_request_logs with call_site=compactionAgent", ()
     expect(recordRequestLogCalls[0]!.callSite).toBe("compactionAgent");
   });
 });
+
+describe("compaction result reports what actually served the summary", () => {
+  beforeEach(() => {
+    recordRequestLogCalls.length = 0;
+  });
+
+  test("rerouted summary carries the backup provider and profile", async () => {
+    // `RetryProvider` escalated the summary call to a backup profile on
+    // another provider and stamped the response, so the result must report
+    // the backup even though the compactor resolved `primaryProfile`.
+    const provider: Provider = {
+      name: "openai",
+      sendMessage: async () => ({
+        content: [{ type: "text", text: compactionResponse }],
+        model: "claude-sonnet-5",
+        actualProvider: "anthropic",
+        actualInferenceProfile: "backupProfile",
+        usage: { inputTokens: 100, outputTokens: 50 },
+        stopReason: "end_turn",
+        rawRequest: RAW_REQUEST,
+        rawResponse: RAW_RESPONSE,
+      }),
+    };
+
+    const result = await runAssistantDrivenCompaction({
+      ...args(provider),
+      overrideProfile: "primaryProfile",
+    });
+
+    expect(result.summaryModel).toBe("claude-sonnet-5");
+    expect(result.summaryActualProvider).toBe("anthropic");
+    expect(result.summaryActualInferenceProfile).toBe("backupProfile");
+    // The primary's resolution is still reported, just outranked downstream.
+    expect(result.summaryOverrideProfile).toBe("primaryProfile");
+    // Same value the request log recorded: one source of truth, not two.
+    expect(recordRequestLogCalls[0]!.provider).toBe("anthropic");
+  });
+
+  test("non-rerouted summary carries the configured provider and no profile", async () => {
+    const provider: Provider = {
+      name: "openai",
+      sendMessage: async () => ({
+        content: [{ type: "text", text: compactionResponse }],
+        model: "mock-model",
+        usage: { inputTokens: 100, outputTokens: 50 },
+        stopReason: "end_turn",
+        rawRequest: RAW_REQUEST,
+        rawResponse: RAW_RESPONSE,
+      }),
+    };
+
+    const result = await runAssistantDrivenCompaction({
+      ...args(provider),
+      overrideProfile: "primaryProfile",
+    });
+
+    expect(result.summaryActualProvider).toBe("openai");
+    expect(result.summaryActualInferenceProfile).toBeUndefined();
+    expect(result.summaryOverrideProfile).toBe("primaryProfile");
+  });
+});

--- a/assistant/src/__tests__/config-loader-backfill.test.ts
+++ b/assistant/src/__tests__/config-loader-backfill.test.ts
@@ -1411,6 +1411,71 @@ describe("loadConfig startup behavior", () => {
     expect(effective.balanced?.provider_connection).toBe("anthropic-personal");
   });
 
+  test("an active managed backup profile survives a reload", () => {
+    // A managed backup resolves from the code catalog without being
+    // materialized in `llm.profiles`, so selecting one persists nothing but
+    // the reference. If the schema did not treat backup keys as
+    // always-available references, the strip-and-reparse in `loadConfig`
+    // would drop `activeProfile` and the seeder would reset the user's
+    // chat-model selection to `balanced` on the next boot.
+    writeConfig({
+      llm: {
+        defaultProvider: { provider: "vellum" },
+        profiles: {},
+        activeProfile: "balanced-backup",
+      },
+    });
+
+    const config = loadConfig();
+    expect(config.llm.activeProfile).toBe("balanced-backup");
+
+    mergeDefaultConfigAndSeedInferenceProfiles();
+
+    const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+    expect(raw.llm.activeProfile).toBe("balanced-backup");
+    expect(raw.llm.profiles["balanced-backup"]).toBeUndefined();
+  });
+
+  test("an active managed backup profile is repaired on a BYOK install", () => {
+    // Backups live on the managed column alone, so under a BYOK default
+    // provider the selection names a profile that resolves to nothing. The
+    // schema rejects the reference on load and the seeder, which resolves
+    // availability through the same provider-aware view, repairs the stored
+    // selection instead of preserving a dead pointer.
+    writeConfig({
+      llm: {
+        defaultProvider: { provider: "anthropic" },
+        profiles: {},
+        activeProfile: "balanced-backup",
+      },
+    });
+
+    const config = loadConfig();
+    expect(config.llm.activeProfile).toBeUndefined();
+
+    mergeDefaultConfigAndSeedInferenceProfiles();
+
+    const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+    expect(raw.llm.activeProfile).toBe("balanced");
+  });
+
+  test("a call site pinned to a managed backup profile survives a reload", () => {
+    writeConfig({
+      llm: {
+        defaultProvider: { provider: "vellum" },
+        profiles: {},
+        activeProfile: "balanced",
+        callSites: { recall: { profile: "cost-optimized-backup" } },
+      },
+    });
+
+    const config = loadConfig();
+    expect(config.llm.callSites.recall?.profile).toBe("cost-optimized-backup");
+
+    const raw = JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+    expect(raw.llm.callSites.recall.profile).toBe("cost-optimized-backup");
+  });
+
   test("still quarantines corrupt JSON", () => {
     // Corrupt-config quarantine is a recovery path: the broken file is
     // renamed to `config.json.corrupt-<ts>.json` and the daemon proceeds
@@ -1800,6 +1865,10 @@ describe("seedInferenceProfiles BYOK-mode default profiles", () => {
       "quality-optimized",
       "cost-optimized",
       "latency-optimized",
+      "balanced-backup",
+      "quality-optimized-backup",
+      "cost-optimized-backup",
+      "latency-optimized-backup",
       "my-custom",
     ]);
   });

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -23,6 +23,10 @@ import { resetPluginRegistryAndRegisterDefaults } from "../plugins/defaults/inde
 import { registerPlugin } from "../plugins/registry.js";
 import type { Message, Provider, ToolDefinition } from "../providers/types.js";
 import { ContextOverflowError } from "../providers/types.js";
+import {
+  resolveUsageAttribution,
+  type UsageAttributionInput,
+} from "../usage/attribution.js";
 import { getWorkspaceDir } from "../util/platform.js";
 import { setConfig } from "./helpers/set-config.js";
 
@@ -1761,6 +1765,108 @@ describe("session-agent-loop", () => {
       expect(mainAgentCall?.[1]).toBe(12);
       expect(mainAgentCall?.[2]).toBe(3);
       expect(mainAgentCall?.[3]).toBe("gpt-4.1-2026-03-01");
+    });
+
+    test("attributes a fallback serve to the profile that actually served", async () => {
+      // The turn resolved to the primary managed profile, the request hit an
+      // outage-shaped failure, and `RetryProvider` escalated to a backup
+      // profile on a different provider, stamping `actualProvider` and
+      // `actualInferenceProfile` on the response it returns.
+      seedLlmConfig({
+        profiles: {
+          ...disabledCatalogDefaultProfiles,
+          backupProfile: { provider: "anthropic", model: "claude-sonnet-5" },
+        },
+      });
+
+      const ctx = makeCtx({
+        providerResponses: [
+          {
+            content: [{ type: "text", text: "Hi there." }],
+            model: "claude-sonnet-5",
+            usage: { inputTokens: 12, outputTokens: 3 },
+            stopReason: "end_turn",
+            actualProvider: "anthropic",
+            actualInferenceProfile: "backupProfile",
+          },
+        ],
+        provider: {
+          name: "openai",
+          sendMessage: async () => ({
+            content: [{ type: "text", text: "title" }],
+            model: "mock",
+            usage: { inputTokens: 0, outputTokens: 0 },
+            stopReason: "end_turn",
+          }),
+        } as unknown as Conversation["provider"],
+      });
+
+      await runAgentLoopImpl(ctx, "hello", "msg-1", () => {});
+
+      const mainAgentCall = recordUsageMock.mock.calls.find(
+        (call) => (call as unknown[])[5] === "main_agent",
+      ) as unknown[] | undefined;
+
+      expect(mainAgentCall).toBeDefined();
+      // All three attribution facets of the row must describe the same call.
+      expect(mainAgentCall?.[0]).toMatchObject({ providerName: "anthropic" });
+      expect(mainAgentCall?.[3]).toBe("claude-sonnet-5");
+      const attribution = mainAgentCall?.[12] as UsageAttributionInput;
+      expect(attribution.callSite).toBe("mainAgent");
+      expect(attribution.overrideProfile).toBe("backupProfile");
+      expect(attribution.forceOverrideProfile).toBe(true);
+      // `inference_profile` on the persisted row is this snapshot's applied
+      // profile, so resolve it the way `recordUsage` does and assert the
+      // column value itself rather than only the input that feeds it.
+      expect(resolveUsageAttribution(attribution).appliedProfile).toBe(
+        "backupProfile",
+      );
+    });
+
+    test("leaves a non-fallback turn attributed to the conversation's own profile", async () => {
+      // No reroute: the response carries no `actualInferenceProfile`, so the
+      // attribution input stays exactly what the conversation resolved and
+      // carries no forced override.
+      seedLlmConfig({
+        profiles: {
+          ...disabledCatalogDefaultProfiles,
+          backupProfile: { provider: "anthropic", model: "claude-sonnet-5" },
+        },
+      });
+
+      const ctx = makeCtx({
+        providerResponses: [
+          {
+            content: [{ type: "text", text: "Hi there." }],
+            model: "gpt-4.1-2026-03-01",
+            usage: { inputTokens: 12, outputTokens: 3 },
+            stopReason: "end_turn",
+          },
+        ],
+        provider: {
+          name: "openai",
+          sendMessage: async () => ({
+            content: [{ type: "text", text: "title" }],
+            model: "mock",
+            usage: { inputTokens: 0, outputTokens: 0 },
+            stopReason: "end_turn",
+          }),
+        } as unknown as Conversation["provider"],
+      });
+
+      await runAgentLoopImpl(ctx, "hello", "msg-1", () => {});
+
+      const mainAgentCall = recordUsageMock.mock.calls.find(
+        (call) => (call as unknown[])[5] === "main_agent",
+      ) as unknown[] | undefined;
+
+      expect(mainAgentCall).toBeDefined();
+      expect(mainAgentCall?.[0]).toMatchObject({ providerName: "openai" });
+      expect(mainAgentCall?.[3]).toBe("gpt-4.1-2026-03-01");
+      expect(mainAgentCall?.[12]).toEqual({
+        callSite: "mainAgent",
+        overrideProfile: null,
+      });
     });
 
     test("persists the served model onto the assistant row's metadata at finalize", async () => {
@@ -4035,6 +4141,138 @@ describe("session-agent-loop", () => {
       expect(events.some((event) => event.type === "context_compacted")).toBe(
         true,
       );
+    });
+
+    test("rerouted compaction records usage under the profile that actually served", async () => {
+      const ctx = makeCtx();
+
+      await applyCompactionResult(
+        ctx,
+        {
+          messages: [
+            { role: "user", content: [{ type: "text", text: "summary" }] },
+          ],
+          compactedPersistedMessages: 4,
+          previousEstimatedInputTokens: 12000,
+          estimatedInputTokens: 3000,
+          maxInputTokens: 100000,
+          thresholdTokens: 80000,
+          compactedMessages: 4,
+          summaryCalls: 1,
+          summaryInputTokens: 100,
+          summaryOutputTokens: 20,
+          summaryModel: "claude-sonnet-5",
+          summaryText: "summary",
+          summaryCallSite: "compactionAgent",
+          // What the compactor resolved before the call...
+          summaryOverrideProfile: "primaryProfile",
+          // ...and what the reroute actually served.
+          summaryActualProvider: "anthropic",
+          summaryActualInferenceProfile: "backupProfile",
+        },
+        () => {},
+        "req-1",
+      );
+
+      const compactorCall = recordUsageMock.mock.calls.find(
+        (call) => (call as unknown[])[5] === "context_compactor",
+      ) as unknown[] | undefined;
+
+      expect(compactorCall).toBeDefined();
+      // All three attribution facets of the row describe the same call.
+      expect(compactorCall?.[0]).toMatchObject({ providerName: "anthropic" });
+      expect(compactorCall?.[3]).toBe("claude-sonnet-5");
+      expect(compactorCall?.[12]).toEqual({
+        callSite: "compactionAgent",
+        overrideProfile: "backupProfile",
+        forceOverrideProfile: true,
+      });
+    });
+
+    test("non-rerouted compaction keeps the compactor's own attribution", async () => {
+      const ctx = makeCtx();
+
+      await applyCompactionResult(
+        ctx,
+        {
+          messages: [
+            { role: "user", content: [{ type: "text", text: "summary" }] },
+          ],
+          compactedPersistedMessages: 4,
+          previousEstimatedInputTokens: 12000,
+          estimatedInputTokens: 3000,
+          maxInputTokens: 100000,
+          thresholdTokens: 80000,
+          compactedMessages: 4,
+          summaryCalls: 1,
+          summaryInputTokens: 100,
+          summaryOutputTokens: 20,
+          summaryModel: "mock-model",
+          summaryText: "summary",
+          summaryCallSite: "compactionAgent",
+          summaryOverrideProfile: "primaryProfile",
+          summaryActualProvider: "openai",
+        },
+        () => {},
+        "req-1",
+      );
+
+      const compactorCall = recordUsageMock.mock.calls.find(
+        (call) => (call as unknown[])[5] === "context_compactor",
+      ) as unknown[] | undefined;
+
+      expect(compactorCall).toBeDefined();
+      expect(compactorCall?.[0]).toMatchObject({ providerName: "openai" });
+      expect(compactorCall?.[3]).toBe("mock-model");
+      expect(compactorCall?.[12]).toEqual({
+        callSite: "compactionAgent",
+        overrideProfile: "primaryProfile",
+      });
+    });
+
+    test("compaction that served no call falls back to the conversation's provider", async () => {
+      // The degraded shape: `emptyResult` paths record no served attribution
+      // because no call happened. Provider must fall back to the
+      // conversation's own, and the attribution input must be byte-identical
+      // to what it was before served attribution existed.
+      const ctx = makeCtx();
+
+      await applyCompactionResult(
+        ctx,
+        {
+          messages: [
+            { role: "user", content: [{ type: "text", text: "summary" }] },
+          ],
+          compactedPersistedMessages: 4,
+          previousEstimatedInputTokens: 12000,
+          estimatedInputTokens: 3000,
+          maxInputTokens: 100000,
+          thresholdTokens: 80000,
+          compactedMessages: 4,
+          summaryCalls: 1,
+          summaryInputTokens: 100,
+          summaryOutputTokens: 20,
+          summaryModel: "mock-model",
+          summaryText: "summary",
+          summaryCallSite: "compactionAgent",
+          summaryOverrideProfile: "primaryProfile",
+        },
+        () => {},
+        "req-1",
+      );
+
+      const compactorCall = recordUsageMock.mock.calls.find(
+        (call) => (call as unknown[])[5] === "context_compactor",
+      ) as unknown[] | undefined;
+
+      expect(compactorCall).toBeDefined();
+      expect(compactorCall?.[0]).toMatchObject({
+        providerName: "mock-provider",
+      });
+      expect(compactorCall?.[12]).toEqual({
+        callSite: "compactionAgent",
+        overrideProfile: "primaryProfile",
+      });
     });
 
     test("applyCompactionResult advances the persisted count from the trusted in-context boundary", async () => {

--- a/assistant/src/__tests__/conversation-slash.test.ts
+++ b/assistant/src/__tests__/conversation-slash.test.ts
@@ -36,6 +36,7 @@ describe("/model list", () => {
     expect(message).toContain("`balanced`");
     expect(message).toContain("`quality-optimized`");
     expect(message).toContain("`cost-optimized`");
+    expect(message).not.toContain("`balanced-backup`");
   });
 
   test("default profile descriptions follow the default provider's column", async () => {
@@ -71,6 +72,14 @@ describe("/model list", () => {
 });
 
 describe("/model switch", () => {
+  test("rejects a managed backup profile as a direct selection", async () => {
+    const result = await resolveSlash("/model balanced-backup");
+    expect(result.kind).toBe("unknown");
+    expect((result as { message: string }).message).toContain(
+      "Profile `balanced-backup` not found",
+    );
+  });
+
   test("rejects an unknown profile with the available set", async () => {
     const result = await resolveSlash("/model nope");
     expect(result.kind).toBe("unknown");

--- a/assistant/src/__tests__/default-profile-catalog-fallback.test.ts
+++ b/assistant/src/__tests__/default-profile-catalog-fallback.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Managed backup profiles and the `fallbackProfile` pointers of the vellum
+ * column (`default-profile-catalog.ts`).
+ *
+ * The invariants under test:
+ * - Every default profile's managed (vellum) implementation points at a
+ *   backup profile that exists in the code catalog.
+ * - Cross-provider rule: a backup pins its model at a DIFFERENT managed
+ *   upstream than its primary, so an outage at the primary's provider can
+ *   be served by the backup. Holds for the experiment arms too.
+ * - Probe coverage: every backup model is a catalog member of its upstream
+ *   provider, which is what feeds the platform's model liveness probe.
+ * - Scoping: backups exist for the managed column only. A BYOK or chatgpt
+ *   default provider materializes no backup profiles, and its primaries
+ *   carry no `fallbackProfile` pointers.
+ * - The effective catalog parses under `LLMSchema` (exercising the
+ *   `fallbackProfile` superRefine against the real entries), and backups
+ *   are delete-protected like the other managed defaults.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { BALANCED_MODEL_EXPERIMENT_FLAG_KEY } from "../config/balanced-model-experiment.js";
+import {
+  CODE_DEFAULT_PROFILE_ENTRIES,
+  getEffectiveProfile,
+  getEffectiveProfiles,
+  getEffectiveProfilesForProvider,
+  INVARIANT_PROFILE_NAMES,
+  MANAGED_PROFILE_NAMES,
+  MANAGED_PROFILE_TEMPLATES,
+  PROFILE_IMPLS,
+  resolveDefaultProfileForProvider,
+} from "../config/default-profile-catalog.js";
+import {
+  BACKUP_PROFILE_KEYS,
+  DEFAULT_PROFILE_KEYS,
+  DEFAULT_PROFILE_PROVIDERS,
+  FALLBACK_PROFILE_BY_KEY,
+} from "../config/default-profile-names.js";
+import { clearCachedOverrides } from "../config/feature-flag-cache.js";
+import {
+  type DefaultProviderConfig,
+  LLMSchema,
+  type ProfileEntry,
+} from "../config/schemas/llm.js";
+import { isModelInCatalog } from "../providers/model-catalog.js";
+import { getManagedUpstream } from "../providers/vellum-model-routing.js";
+import { setOverridesForTesting } from "./feature-flag-test-helpers.js";
+
+const vellum: DefaultProviderConfig = { provider: "vellum" };
+
+afterEach(() => {
+  clearCachedOverrides();
+});
+
+describe("fallbackProfile pointers on the vellum column", () => {
+  test("every default profile's vellum impl points at an existing backup", () => {
+    for (const key of DEFAULT_PROFILE_KEYS) {
+      const impl = PROFILE_IMPLS[key].vellum;
+      expect(impl.fallbackProfile).toBe(FALLBACK_PROFILE_BY_KEY[key]);
+      const backup = CODE_DEFAULT_PROFILE_ENTRIES[FALLBACK_PROFILE_BY_KEY[key]];
+      expect(backup).toBeDefined();
+      expect(backup.provider).toBe("vellum");
+      expect(backup.source).toBe("managed");
+      // Single hop: a backup never declares a fallback of its own.
+      expect(backup.fallbackProfile).toBeUndefined();
+    }
+  });
+
+  test("no BYOK or chatgpt column impl carries fallbackProfile", () => {
+    for (const key of DEFAULT_PROFILE_KEYS) {
+      for (const provider of DEFAULT_PROFILE_PROVIDERS) {
+        if (provider === "vellum") {
+          continue;
+        }
+        expect(PROFILE_IMPLS[key][provider].fallbackProfile).toBeUndefined();
+      }
+      // A default-capable provider without a named matrix column
+      // materializes from the shared BYOK templates: no pointer either.
+      const entry = resolveDefaultProfileForProvider(undefined, key, {
+        provider: "together",
+      });
+      expect(entry?.fallbackProfile).toBeUndefined();
+    }
+  });
+});
+
+describe("cross-provider rule", () => {
+  test("every backup dispatches through a different managed upstream than its primary", () => {
+    for (const key of DEFAULT_PROFILE_KEYS) {
+      const primary = CODE_DEFAULT_PROFILE_ENTRIES[key];
+      const backup = CODE_DEFAULT_PROFILE_ENTRIES[FALLBACK_PROFILE_BY_KEY[key]];
+      const primaryUpstream = getManagedUpstream(primary.model as string);
+      const backupUpstream = getManagedUpstream(backup.model as string);
+      expect(primaryUpstream).not.toBeNull();
+      expect(backupUpstream).not.toBeNull();
+      expect(backupUpstream).not.toBe(primaryUpstream);
+    }
+  });
+
+  test("the balanced experiment arms keep the cross-provider split", () => {
+    const backup =
+      CODE_DEFAULT_PROFILE_ENTRIES[FALLBACK_PROFILE_BY_KEY.balanced];
+    const backupUpstream = getManagedUpstream(backup.model as string);
+    for (const arm of ["terra", "glm-5p2"]) {
+      setOverridesForTesting({ [BALANCED_MODEL_EXPERIMENT_FLAG_KEY]: arm });
+      const armed = resolveDefaultProfileForProvider(
+        undefined,
+        "balanced",
+        vellum,
+      );
+      expect(armed?.fallbackProfile).toBe(FALLBACK_PROFILE_BY_KEY.balanced);
+      const armedUpstream = getManagedUpstream(armed?.model as string);
+      expect(armedUpstream).not.toBeNull();
+      expect(armedUpstream).not.toBe(backupUpstream);
+    }
+  });
+
+  test("every backup model is a catalog member of its upstream (liveness-probe coverage)", () => {
+    for (const key of BACKUP_PROFILE_KEYS) {
+      const model = CODE_DEFAULT_PROFILE_ENTRIES[key].model as string;
+      const upstream = getManagedUpstream(model);
+      expect(upstream).not.toBeNull();
+      expect(isModelInCatalog(upstream as string, model)).toBe(true);
+    }
+  });
+});
+
+describe("managed-column-only scoping", () => {
+  test("the managed column materializes the backups after the primaries", () => {
+    const effective = getEffectiveProfilesForProvider(undefined, vellum);
+    for (const key of BACKUP_PROFILE_KEYS) {
+      expect(effective[key]).toBeDefined();
+      expect(effective[key]?.provider).toBe("vellum");
+      expect(effective[key]?.source).toBe("managed");
+    }
+    // The seeder inserts missing managed keys in MANAGED_PROFILE_TEMPLATES
+    // order, which is what places backups after the primaries in
+    // `profileOrder` presentation.
+    expect(Object.keys(MANAGED_PROFILE_TEMPLATES)).toEqual([
+      ...DEFAULT_PROFILE_KEYS,
+      ...BACKUP_PROFILE_KEYS,
+    ]);
+  });
+
+  test("a null defaultProvider (pre-defaultProvider install) keeps its backups", () => {
+    const effective = getEffectiveProfiles(undefined);
+    for (const key of BACKUP_PROFILE_KEYS) {
+      expect(effective[key]).toBeDefined();
+      expect(
+        resolveDefaultProfileForProvider(undefined, key, null),
+      ).toBeDefined();
+    }
+  });
+
+  test("a BYOK default provider materializes no backups and no pointers", () => {
+    for (const provider of ["anthropic", "openai", "gemini"] as const) {
+      const effective = getEffectiveProfilesForProvider(undefined, {
+        provider,
+      });
+      for (const key of BACKUP_PROFILE_KEYS) {
+        expect(effective[key]).toBeUndefined();
+      }
+      for (const key of DEFAULT_PROFILE_KEYS) {
+        expect(effective[key]?.fallbackProfile).toBeUndefined();
+      }
+    }
+  });
+
+  test("the chatgpt column materializes no backups and no pointers", () => {
+    const effective = getEffectiveProfilesForProvider(undefined, {
+      provider: "chatgpt",
+    });
+    for (const key of BACKUP_PROFILE_KEYS) {
+      expect(effective[key]).toBeUndefined();
+    }
+    for (const key of DEFAULT_PROFILE_KEYS) {
+      expect(effective[key]?.fallbackProfile).toBeUndefined();
+    }
+  });
+
+  test("a persisted managed stub does not resurrect a backup off the managed column", () => {
+    // A `config get` -> `config set` round-trip on a managed install can
+    // leave a thin managed stub for a backup in `llm.profiles`
+    // (`normalizeManagedProfileWrites`). The stub is the workspace's slot for
+    // a code-owned body, not a profile, so once the column has no body behind
+    // it the name must stop being listed rather than resolve to a
+    // providerless entry the pickers would offer and `LLMSchema` would
+    // reject.
+    const workspace: Record<string, ProfileEntry> = {
+      "balanced-backup": { source: "managed" },
+    };
+    for (const provider of ["anthropic", "chatgpt"] as const) {
+      const effective = getEffectiveProfilesForProvider(workspace, {
+        provider,
+      });
+      expect(effective["balanced-backup"]).toBeUndefined();
+      expect(
+        resolveDefaultProfileForProvider(workspace, "balanced-backup", {
+          provider,
+        }),
+      ).toBeUndefined();
+    }
+    // The managed column still has a body for the stub to stand for.
+    expect(
+      getEffectiveProfilesForProvider(workspace, vellum)["balanced-backup"]
+        ?.model,
+    ).toBe(CODE_DEFAULT_PROFILE_ENTRIES["balanced-backup"]?.model);
+  });
+
+  test("a user-owned entry under a backup name stays listed off the managed column", () => {
+    // Nothing code-owned resolves there, so the entry is simply a profile of
+    // that name and keeps its own body.
+    const workspace: Record<string, ProfileEntry> = {
+      "balanced-backup": {
+        source: "user",
+        provider: "anthropic",
+        model: "claude-opus-4-7",
+      },
+    };
+    const effective = getEffectiveProfilesForProvider(workspace, {
+      provider: "anthropic",
+    });
+    expect(effective["balanced-backup"]?.model).toBe("claude-opus-4-7");
+  });
+});
+
+describe("effective-profile machinery", () => {
+  test("the full effective catalog parses under LLMSchema", () => {
+    // Exercises the fallbackProfile superRefine (target exists, no self
+    // reference, no mix target, single hop) against the real entries.
+    for (const profiles of [
+      getEffectiveProfiles(undefined),
+      getEffectiveProfilesForProvider(undefined, vellum),
+    ]) {
+      const parsed = LLMSchema.parse({
+        profiles,
+        activeProfile: "balanced",
+      });
+      for (const key of DEFAULT_PROFILE_KEYS) {
+        expect(parsed.profiles[key]?.fallbackProfile).toBe(
+          FALLBACK_PROFILE_BY_KEY[key],
+        );
+      }
+    }
+  });
+
+  test("a workspace entry never overlays a backup, whatever its source", () => {
+    // Backups are code-owned (`CODE_OWNED_PROFILE_NAMES`), so unlike the
+    // primaries they take no workspace overlay at all: not the usual
+    // label/status/topP whitelist from a managed stub, and not a user-owned
+    // shadow. Disabling a backup through a hand-edited config would strand
+    // the primary's fallback exactly when it is needed.
+    for (const source of ["managed", "user"] as const) {
+      const workspace: Record<string, ProfileEntry> = {
+        "balanced-backup": {
+          source,
+          label: "My Backup",
+          status: "disabled",
+          topP: 0.7,
+          // Stale content drift on disk must lose to the code default body.
+          provider: "anthropic",
+          model: "claude-sonnet-4-6",
+          maxTokens: 1,
+        },
+      };
+      const entry = getEffectiveProfile(workspace, "balanced-backup");
+      const body = CODE_DEFAULT_PROFILE_ENTRIES["balanced-backup"];
+      expect(entry?.label).toBe(body.label);
+      expect(entry?.status).toBeUndefined();
+      expect(entry?.topP).toBe(body.topP);
+      expect(entry?.model).toBe(body.model);
+      expect(entry?.maxTokens).toBe(body.maxTokens);
+      expect(String(entry?.provider)).toBe("vellum");
+    }
+  });
+
+  test("backup profiles are delete-protected like the other managed defaults", () => {
+    // Membership in these sets is what wires the route-level deletion
+    // rejection (`rejectManagedProfileDeletion`, `handleCreateProfile`) and
+    // the commitConfigWrite invariant guard
+    // (`assertInvariantProfilesPreserved`).
+    for (const key of BACKUP_PROFILE_KEYS) {
+      expect(MANAGED_PROFILE_NAMES.has(key)).toBe(true);
+      expect(INVARIANT_PROFILE_NAMES.has(key)).toBe(true);
+    }
+  });
+});

--- a/assistant/src/__tests__/fallback-breaker.test.ts
+++ b/assistant/src/__tests__/fallback-breaker.test.ts
@@ -1,0 +1,803 @@
+/**
+ * The fallback circuit breaker: its own state machine under an injected clock,
+ * and the `RetryProvider` behavior it drives.
+ *
+ * Deliberately mock-free. The breaker takes `now` on every entry point, so the
+ * state machine is tested against explicit timestamps instead of a faked
+ * global clock, and the `RetryProvider` cases use stub providers whose call
+ * counts are the assertion.
+ */
+
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  type BreakerRoute,
+  recordFallbackServed,
+  recordPrimaryFailure,
+  recordPrimarySuccess,
+  releaseRecoveryProbe,
+  resetFallbackBreaker,
+  shouldSkipPrimary,
+  tryAcquireRecoveryProbe,
+} from "../providers/fallback-breaker.js";
+import { RetryProvider } from "../providers/retry.js";
+import type {
+  Message,
+  Provider,
+  ProviderResponse,
+  SendMessageOptions,
+} from "../providers/types.js";
+import { ProviderError } from "../util/errors.js";
+import { setConfig } from "./helpers/set-config.js";
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+
+const UPSTREAM = "openai";
+const T0 = 1_700_000_000_000;
+
+const FAILURE_WINDOW_MS = 5 * 60_000;
+const BASE_COOLDOWN_MS = 120_000;
+const MAX_COOLDOWN_MS = 10 * 60_000;
+const JITTER = 0.2;
+
+/** The whole upstream, as an outage marks it. */
+const UPSTREAM_ROUTE: BreakerRoute = { upstream: UPSTREAM };
+/** The primary profile's own model, as a retirement marks it. */
+const PRIMARY_ROUTE: BreakerRoute = {
+  upstream: UPSTREAM,
+  model: "primary-model",
+};
+/** A second, healthy model on the same upstream. */
+const OTHER_ROUTE: BreakerRoute = { upstream: UPSTREAM, model: "other-model" };
+
+const MESSAGES: Message[] = [
+  { role: "user", content: [{ type: "text", text: "hi" }] },
+];
+
+const LLM_FIXTURE = {
+  profiles: {
+    "primary-profile": {
+      source: "user",
+      provider: "openai",
+      model: "primary-model",
+      maxTokens: 1111,
+    },
+    // A second profile on the same upstream, so a model-scoped trip can be
+    // shown to leave healthy models alone.
+    "other-profile": {
+      source: "user",
+      provider: "openai",
+      model: "other-model",
+      maxTokens: 1111,
+    },
+    "backup-profile": {
+      source: "user",
+      provider: "anthropic",
+      model: "backup-model",
+      maxTokens: 2222,
+    },
+  },
+  activeProfile: "primary-profile",
+};
+
+/** Per-call config that resolves to `other-model` on the same upstream. */
+const OTHER_MODEL_CALL = {
+  callSite: "mainAgent",
+  overrideProfile: "other-profile",
+  forceOverrideProfile: true,
+} as const;
+
+beforeEach(() => {
+  resetFallbackBreaker();
+  setConfig("llm", LLM_FIXTURE);
+});
+
+/**
+ * The cooldown the breaker actually picked, recovered by bisecting the first
+ * offset from `trippedAt` at which it stops skipping the primary. Jitter makes
+ * the value unpredictable by design, so tests assert on the band it lands in
+ * rather than on a number the test itself computed.
+ */
+function observedCooldownMs(route: BreakerRoute, trippedAt: number): number {
+  let lo = 0;
+  let hi = MAX_COOLDOWN_MS + 1;
+  while (lo < hi) {
+    const mid = Math.floor((lo + hi) / 2);
+    if (shouldSkipPrimary(route, trippedAt + mid)) {
+      lo = mid + 1;
+    } else {
+      hi = mid;
+    }
+  }
+  return lo;
+}
+
+function expectWithinJitterBand(cooldown: number, base: number): void {
+  expect(cooldown).toBeGreaterThanOrEqual(Math.floor(base * (1 - JITTER)));
+  expect(cooldown).toBeLessThanOrEqual(Math.ceil(base * (1 + JITTER)));
+  expect(cooldown).toBeLessThanOrEqual(MAX_COOLDOWN_MS);
+}
+
+function okResponse(model: string): ProviderResponse {
+  return {
+    content: [{ type: "text", text: "ok" }],
+    model,
+    usage: { inputTokens: 1, outputTokens: 1 },
+    stopReason: "end_turn",
+  } as ProviderResponse;
+}
+
+/**
+ * Primary stub that answers with whatever model the resolved options carry, or
+ * throws the next error from `errors` while any remain.
+ */
+function primaryProvider(...errors: (() => unknown)[]): {
+  provider: Provider;
+  calls: () => number;
+  seenModels: () => (string | undefined)[];
+} {
+  const seen: (string | undefined)[] = [];
+  let calls = 0;
+  const provider: Provider = {
+    name: UPSTREAM,
+    sendMessage: async (_messages: Message[], options?: SendMessageOptions) => {
+      calls += 1;
+      seen.push(options?.config?.model);
+      const next = errors.shift();
+      if (next) {
+        throw next();
+      }
+      return okResponse(options?.config?.model ?? "unresolved");
+    },
+  };
+  return { provider, calls: () => calls, seenModels: () => seen };
+}
+
+/** Backup stub that serves whatever model the re-normalized options resolved. */
+function backupProvider(): { provider: Provider; calls: () => number } {
+  let calls = 0;
+  const provider: Provider = {
+    name: "anthropic",
+    sendMessage: async (_messages: Message[], options?: SendMessageOptions) => {
+      calls += 1;
+      return okResponse(options?.config?.model ?? "unresolved");
+    },
+  };
+  return { provider, calls: () => calls };
+}
+
+function makeRoute(provider: Provider): {
+  resolveFallbackRoute: (
+    failedOptions: SendMessageOptions | undefined,
+  ) => Promise<{
+    provider: Provider;
+    overrideProfile: string;
+    forwardUsageAttributionHeaders: boolean;
+  } | null>;
+  calls: () => number;
+} {
+  let calls = 0;
+  return {
+    resolveFallbackRoute: async () => {
+      calls += 1;
+      return {
+        provider,
+        overrideProfile: "backup-profile",
+        forwardUsageAttributionHeaders: true,
+      };
+    },
+    calls: () => calls,
+  };
+}
+
+async function captureError(promise: Promise<unknown>): Promise<unknown> {
+  try {
+    await promise;
+  } catch (error) {
+    return error;
+  }
+  throw new Error("expected the promise to reject");
+}
+
+// ── The breaker state machine ───────────────────────────────────────────────
+
+describe("fallback breaker state machine", () => {
+  test("two eligible failures inside the window trip the breaker", () => {
+    recordPrimaryFailure(UPSTREAM_ROUTE, T0);
+    expect(shouldSkipPrimary(UPSTREAM_ROUTE, T0)).toBe(false);
+
+    recordPrimaryFailure(UPSTREAM_ROUTE, T0 + 1_000);
+    expect(shouldSkipPrimary(UPSTREAM_ROUTE, T0 + 1_000)).toBe(true);
+  });
+
+  test("failures spread beyond the window never accumulate into a trip", () => {
+    recordPrimaryFailure(UPSTREAM_ROUTE, T0);
+    recordPrimaryFailure(UPSTREAM_ROUTE, T0 + FAILURE_WINDOW_MS + 1);
+    expect(shouldSkipPrimary(UPSTREAM_ROUTE, T0 + FAILURE_WINDOW_MS + 1)).toBe(
+      false,
+    );
+  });
+
+  test("a success between failures resets the count, so isolated blips never trip", () => {
+    recordPrimaryFailure(UPSTREAM_ROUTE, T0);
+    recordPrimarySuccess(UPSTREAM_ROUTE, T0 + 1_000);
+    recordPrimaryFailure(UPSTREAM_ROUTE, T0 + 2_000);
+    expect(shouldSkipPrimary(UPSTREAM_ROUTE, T0 + 2_000)).toBe(false);
+
+    recordPrimaryFailure(UPSTREAM_ROUTE, T0 + 3_000);
+    expect(shouldSkipPrimary(UPSTREAM_ROUTE, T0 + 3_000)).toBe(true);
+  });
+
+  test("a completed backup serve trips the breaker on its own", () => {
+    recordFallbackServed(UPSTREAM_ROUTE, T0);
+    expect(shouldSkipPrimary(UPSTREAM_ROUTE, T0)).toBe(true);
+  });
+
+  test("a success closes an open breaker", () => {
+    recordFallbackServed(UPSTREAM_ROUTE, T0);
+    recordPrimarySuccess(UPSTREAM_ROUTE, T0 + 1_000);
+    expect(shouldSkipPrimary(UPSTREAM_ROUTE, T0 + 1_000)).toBe(false);
+  });
+
+  test("the cooldown lands inside the jitter band and varies between trips", () => {
+    const seen = new Set<number>();
+    for (let i = 0; i < 40; i += 1) {
+      resetFallbackBreaker();
+      recordFallbackServed(UPSTREAM_ROUTE, T0);
+      const cooldown = observedCooldownMs(UPSTREAM_ROUTE, T0);
+      expectWithinJitterBand(cooldown, BASE_COOLDOWN_MS);
+      seen.add(cooldown);
+    }
+    // Jitter exists so a fleet of daemons does not probe a recovering upstream
+    // in the same second; a constant cooldown would defeat that.
+    expect(seen.size).toBeGreaterThan(1);
+  });
+
+  test("after the cooldown exactly one caller wins the probe, the rest keep skipping", () => {
+    recordFallbackServed(UPSTREAM_ROUTE, T0);
+    const cooldown = observedCooldownMs(UPSTREAM_ROUTE, T0);
+    const ready = T0 + cooldown;
+
+    expect(shouldSkipPrimary(UPSTREAM_ROUTE, ready)).toBe(false);
+    expect(tryAcquireRecoveryProbe(UPSTREAM_ROUTE, ready)).toBe(true);
+
+    // While that probe is deciding recovery, everyone else stays on the backup
+    // rather than piling onto a route that may still be down.
+    expect(tryAcquireRecoveryProbe(UPSTREAM_ROUTE, ready)).toBe(false);
+    expect(shouldSkipPrimary(UPSTREAM_ROUTE, ready)).toBe(true);
+    expect(shouldSkipPrimary(UPSTREAM_ROUTE, ready + 60_000)).toBe(true);
+  });
+
+  test("a successful probe closes the breaker", () => {
+    recordFallbackServed(UPSTREAM_ROUTE, T0);
+    const ready = T0 + observedCooldownMs(UPSTREAM_ROUTE, T0);
+    expect(tryAcquireRecoveryProbe(UPSTREAM_ROUTE, ready)).toBe(true);
+
+    releaseRecoveryProbe(UPSTREAM_ROUTE, { verdict: "recovered" }, ready + 500);
+
+    expect(shouldSkipPrimary(UPSTREAM_ROUTE, ready + 500)).toBe(false);
+    expect(tryAcquireRecoveryProbe(UPSTREAM_ROUTE, ready + 500)).toBe(false);
+  });
+
+  test("a failed probe re-trips with a doubled cooldown, capped at 10 minutes", () => {
+    recordFallbackServed(UPSTREAM_ROUTE, T0);
+    let at = T0;
+    expectWithinJitterBand(
+      observedCooldownMs(UPSTREAM_ROUTE, at),
+      BASE_COOLDOWN_MS,
+    );
+
+    for (const expectedBase of [
+      BASE_COOLDOWN_MS * 2,
+      BASE_COOLDOWN_MS * 4,
+      MAX_COOLDOWN_MS,
+      MAX_COOLDOWN_MS,
+    ]) {
+      at += observedCooldownMs(UPSTREAM_ROUTE, at);
+      expect(tryAcquireRecoveryProbe(UPSTREAM_ROUTE, at)).toBe(true);
+      releaseRecoveryProbe(
+        UPSTREAM_ROUTE,
+        { verdict: "failing", failedRoute: UPSTREAM_ROUTE },
+        at,
+      );
+      expectWithinJitterBand(
+        observedCooldownMs(UPSTREAM_ROUTE, at),
+        expectedBase,
+      );
+    }
+  });
+
+  test("resetFallbackBreaker drops every remembered route", () => {
+    recordFallbackServed(UPSTREAM_ROUTE, T0);
+    resetFallbackBreaker();
+    expect(shouldSkipPrimary(UPSTREAM_ROUTE, T0)).toBe(false);
+  });
+});
+
+// ── Scope: one model versus the whole upstream ──────────────────────────────
+
+describe("fallback breaker scope", () => {
+  test("a retired model is remembered for that model alone", () => {
+    recordFallbackServed(PRIMARY_ROUTE, T0);
+
+    expect(shouldSkipPrimary(PRIMARY_ROUTE, T0)).toBe(true);
+    // A healthy profile on the same upstream keeps its own primary: the
+    // upstream never failed, one model on it did.
+    expect(shouldSkipPrimary(OTHER_ROUTE, T0)).toBe(false);
+    expect(shouldSkipPrimary(UPSTREAM_ROUTE, T0)).toBe(false);
+  });
+
+  test("an upstream outage is remembered for every model on it", () => {
+    recordFallbackServed(UPSTREAM_ROUTE, T0);
+
+    expect(shouldSkipPrimary(PRIMARY_ROUTE, T0)).toBe(true);
+    expect(shouldSkipPrimary(OTHER_ROUTE, T0)).toBe(true);
+  });
+
+  test("probing a healthy model does not close another model's outage", () => {
+    recordFallbackServed(PRIMARY_ROUTE, T0);
+    // Remembered long enough ago that its cooldown has expired and a probe is
+    // due, unlike the retired model's.
+    recordFallbackServed(OTHER_ROUTE, T0 - MAX_COOLDOWN_MS - 1);
+
+    expect(tryAcquireRecoveryProbe(OTHER_ROUTE, T0)).toBe(true);
+    releaseRecoveryProbe(OTHER_ROUTE, { verdict: "recovered" }, T0);
+
+    expect(shouldSkipPrimary(OTHER_ROUTE, T0)).toBe(false);
+    expect(shouldSkipPrimary(PRIMARY_ROUTE, T0)).toBe(true);
+  });
+
+  test("a success on one model leaves another model's outage remembered", () => {
+    recordFallbackServed(PRIMARY_ROUTE, T0);
+    recordPrimarySuccess(OTHER_ROUTE, T0 + 1_000);
+    expect(shouldSkipPrimary(PRIMARY_ROUTE, T0 + 1_000)).toBe(true);
+  });
+
+  test("a success on any model closes an upstream-wide outage", () => {
+    // The upstream answered, which is what an upstream-wide trip was claiming
+    // it would not do.
+    recordFallbackServed(UPSTREAM_ROUTE, T0);
+    recordPrimarySuccess(OTHER_ROUTE, T0 + 1_000);
+    expect(shouldSkipPrimary(PRIMARY_ROUTE, T0 + 1_000)).toBe(false);
+  });
+
+  test("a probe needs every outage covering the route to have cooled down", () => {
+    recordFallbackServed(UPSTREAM_ROUTE, T0);
+    // The model's own outage is remembered later, so its cooldown outlasts the
+    // upstream's.
+    recordFallbackServed(PRIMARY_ROUTE, T0 + MAX_COOLDOWN_MS);
+    const upstreamReady = T0 + observedCooldownMs(UPSTREAM_ROUTE, T0);
+
+    expect(tryAcquireRecoveryProbe(PRIMARY_ROUTE, upstreamReady)).toBe(false);
+    expect(shouldSkipPrimary(PRIMARY_ROUTE, upstreamReady)).toBe(true);
+  });
+
+  test("a probe failing on one model narrows an upstream outage to that model", () => {
+    // The upstream answered the probe, so it is no longer the thing that is
+    // down; what it answered with is about a single model.
+    recordFallbackServed(UPSTREAM_ROUTE, T0);
+    const ready = T0 + observedCooldownMs(UPSTREAM_ROUTE, T0);
+    expect(tryAcquireRecoveryProbe(PRIMARY_ROUTE, ready)).toBe(true);
+
+    releaseRecoveryProbe(
+      PRIMARY_ROUTE,
+      { verdict: "failing", failedRoute: PRIMARY_ROUTE },
+      ready,
+    );
+
+    // Every healthy model on the upstream is servable again.
+    expect(shouldSkipPrimary(OTHER_ROUTE, ready)).toBe(false);
+    expect(shouldSkipPrimary(UPSTREAM_ROUTE, ready)).toBe(false);
+    // The model the probe indicted is still skipped, on the escalated cooldown
+    // the failed probe earned rather than a fresh base wait.
+    expect(shouldSkipPrimary(PRIMARY_ROUTE, ready)).toBe(true);
+    expectWithinJitterBand(
+      observedCooldownMs(PRIMARY_ROUTE, ready),
+      BASE_COOLDOWN_MS * 2,
+    );
+
+    // And it is still clearable: nothing is stranded by the narrowing.
+    const modelReady = ready + observedCooldownMs(PRIMARY_ROUTE, ready);
+    expect(tryAcquireRecoveryProbe(PRIMARY_ROUTE, modelReady)).toBe(true);
+    releaseRecoveryProbe(PRIMARY_ROUTE, { verdict: "recovered" }, modelReady);
+    expect(shouldSkipPrimary(PRIMARY_ROUTE, modelReady)).toBe(false);
+  });
+
+  test("a probe failing with an outage widens a model's outage to the upstream", () => {
+    recordFallbackServed(PRIMARY_ROUTE, T0);
+    const ready = T0 + observedCooldownMs(PRIMARY_ROUTE, T0);
+    expect(tryAcquireRecoveryProbe(PRIMARY_ROUTE, ready)).toBe(true);
+
+    releaseRecoveryProbe(
+      PRIMARY_ROUTE,
+      { verdict: "failing", failedRoute: UPSTREAM_ROUTE },
+      ready,
+    );
+
+    // The fresh evidence is upstream-wide, so it governs every model on it.
+    expect(shouldSkipPrimary(OTHER_ROUTE, ready)).toBe(true);
+    expect(shouldSkipPrimary(PRIMARY_ROUTE, ready)).toBe(true);
+    expectWithinJitterBand(
+      observedCooldownMs(UPSTREAM_ROUTE, ready),
+      BASE_COOLDOWN_MS * 2,
+    );
+  });
+
+  test("a probe failure the breaker cannot name closes what it tested", () => {
+    recordFallbackServed(UPSTREAM_ROUTE, T0);
+    const ready = T0 + observedCooldownMs(UPSTREAM_ROUTE, T0);
+    expect(tryAcquireRecoveryProbe(UPSTREAM_ROUTE, ready)).toBe(true);
+
+    releaseRecoveryProbe(
+      UPSTREAM_ROUTE,
+      { verdict: "failing", failedRoute: null },
+      ready,
+    );
+
+    // Better to rediscover the outage on the next request than to keep an
+    // entry open that names something no future probe can clear.
+    expect(shouldSkipPrimary(PRIMARY_ROUTE, ready)).toBe(false);
+  });
+
+  test("an abandoned probe hands the claim back and changes nothing else", () => {
+    recordFallbackServed(UPSTREAM_ROUTE, T0);
+    const cooldown = observedCooldownMs(UPSTREAM_ROUTE, T0);
+    const ready = T0 + cooldown;
+    expect(tryAcquireRecoveryProbe(UPSTREAM_ROUTE, ready)).toBe(true);
+
+    releaseRecoveryProbe(UPSTREAM_ROUTE, { verdict: "abandoned" }, ready);
+
+    // The entry survives with the same deadline: a cancelled probe neither
+    // recovers the route nor restarts its wait.
+    expect(observedCooldownMs(UPSTREAM_ROUTE, T0)).toBe(cooldown);
+    // Concurrent traffic during the cancelled probe was skipping the primary;
+    // now the claim is free, so the next request can probe instead.
+    expect(tryAcquireRecoveryProbe(UPSTREAM_ROUTE, ready)).toBe(true);
+    releaseRecoveryProbe(UPSTREAM_ROUTE, { verdict: "recovered" }, ready);
+    expect(shouldSkipPrimary(UPSTREAM_ROUTE, ready)).toBe(false);
+  });
+
+  test("an abandoned probe does not count toward the escalation", () => {
+    recordFallbackServed(UPSTREAM_ROUTE, T0);
+    const ready = T0 + observedCooldownMs(UPSTREAM_ROUTE, T0);
+
+    expect(tryAcquireRecoveryProbe(UPSTREAM_ROUTE, ready)).toBe(true);
+    releaseRecoveryProbe(UPSTREAM_ROUTE, { verdict: "abandoned" }, ready);
+    expect(tryAcquireRecoveryProbe(UPSTREAM_ROUTE, ready)).toBe(true);
+    releaseRecoveryProbe(
+      UPSTREAM_ROUTE,
+      { verdict: "failing", failedRoute: UPSTREAM_ROUTE },
+      ready,
+    );
+
+    // The first real failure earns the first doubling. Counting the
+    // cancellation would have skipped a rung and made the route wait twice as
+    // long for no evidence.
+    expectWithinJitterBand(
+      observedCooldownMs(UPSTREAM_ROUTE, ready),
+      BASE_COOLDOWN_MS * 2,
+    );
+  });
+});
+
+// ── What RetryProvider does with it ─────────────────────────────────────────
+
+describe("RetryProvider under an open breaker", () => {
+  test("a tripped route goes straight to the backup without calling the primary", async () => {
+    const primary = primaryProvider(
+      () => new ProviderError("Service Unavailable", UPSTREAM, 503),
+    );
+    const backup = backupProvider();
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+    recordFallbackServed(UPSTREAM_ROUTE);
+
+    const startedAt = Date.now();
+    const result = await wrapped.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    expect(result.model).toBe("backup-model");
+    expect(primary.calls()).toBe(0);
+    expect(backup.calls()).toBe(1);
+    // Skipping the primary also skips its retry budget, so no backoff delay is
+    // spent on a route already known to be down.
+    expect(Date.now() - startedAt).toBeLessThan(1_000);
+  });
+
+  test("an elapsed cooldown admits one probe, and its success restores the primary", async () => {
+    const primary = primaryProvider();
+    const backup = backupProvider();
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+    // Tripped long enough ago that the longest possible cooldown has expired.
+    recordFallbackServed(UPSTREAM_ROUTE, Date.now() - MAX_COOLDOWN_MS - 1);
+
+    const result = await wrapped.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    expect(result.model).toBe("primary-model");
+    expect(primary.calls()).toBe(1);
+    expect(backup.calls()).toBe(0);
+    // The breaker is closed, so the next request takes the primary directly.
+    expect(shouldSkipPrimary(PRIMARY_ROUTE)).toBe(false);
+
+    const second = await wrapped.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+    expect(second.model).toBe("primary-model");
+    expect(primary.calls()).toBe(2);
+  });
+
+  test("a failed probe re-trips the breaker and the backup serves that request", async () => {
+    const primary = primaryProvider(
+      () => new ProviderError("Service Unavailable", UPSTREAM, 503),
+    );
+    const backup = backupProvider();
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+    recordFallbackServed(UPSTREAM_ROUTE, Date.now() - MAX_COOLDOWN_MS - 1);
+
+    const result = await wrapped.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    // One probe attempt, no retry loop behind it, then the backup.
+    expect(primary.calls()).toBe(1);
+    expect(result.model).toBe("backup-model");
+    expect(shouldSkipPrimary(PRIMARY_ROUTE)).toBe(true);
+  });
+
+  test("a probe refreshes an expired managed credential before judging the route down", async () => {
+    // The credential expired during the outage. Without the refresh the probe
+    // reads its own 401 as the outage continuing, re-trips, and the route can
+    // never come back.
+    const primary = primaryProvider(
+      () =>
+        new ProviderError("Unauthorized", UPSTREAM, 401, {
+          reason: "invalid_credentials",
+        }),
+    );
+    const refreshed = primaryProvider();
+    const backup = backupProvider();
+    const route = makeRoute(backup.provider);
+    let refreshCalls = 0;
+    const wrapped = new RetryProvider(primary.provider, {
+      credentialSource: "vellum-managed",
+      refreshCredentialProvider: async () => {
+        refreshCalls += 1;
+        return refreshed.provider;
+      },
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+    recordFallbackServed(UPSTREAM_ROUTE, Date.now() - MAX_COOLDOWN_MS - 1);
+
+    const result = await wrapped.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    expect(refreshCalls).toBe(1);
+    expect(primary.calls()).toBe(1);
+    // Still one probe: the refreshed adapter serves the same single attempt.
+    expect(refreshed.calls()).toBe(1);
+    expect(backup.calls()).toBe(0);
+    expect(result.model).toBe("primary-model");
+    expect(shouldSkipPrimary(PRIMARY_ROUTE)).toBe(false);
+  });
+
+  test("a probe rejected by the primary itself closes the breaker and surfaces the error", async () => {
+    // A plain 400 is the route answering the request, which is all the probe
+    // asked: the upstream is up, so the breaker closes and the caller sees the
+    // real error instead of a backup answer to a malformed request.
+    const requestError = new ProviderError("invalid request", UPSTREAM, 400);
+    const primary = primaryProvider(() => requestError);
+    const backup = backupProvider();
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+    recordFallbackServed(UPSTREAM_ROUTE, Date.now() - MAX_COOLDOWN_MS - 1);
+
+    const thrown = await captureError(
+      wrapped.sendMessage(MESSAGES, { config: { callSite: "mainAgent" } }),
+    );
+
+    expect(thrown).toBe(requestError);
+    expect(primary.calls()).toBe(1);
+    expect(backup.calls()).toBe(0);
+    expect(shouldSkipPrimary(PRIMARY_ROUTE)).toBe(false);
+  });
+
+  test("a cancelled probe leaves the breaker tripped instead of reporting recovery", async () => {
+    const cancelled = new ProviderError(
+      "Request was aborted.",
+      UPSTREAM,
+      undefined,
+      { abortReason: "user_cancelled" },
+    );
+    const primary = primaryProvider(
+      () => cancelled,
+      () => new ProviderError("Service Unavailable", UPSTREAM, 503),
+    );
+    const backup = backupProvider();
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+    recordFallbackServed(UPSTREAM_ROUTE, Date.now() - MAX_COOLDOWN_MS - 1);
+
+    const thrown = await captureError(
+      wrapped.sendMessage(MESSAGES, { config: { callSite: "mainAgent" } }),
+    );
+
+    // The cancellation surfaces as itself and nothing is re-routed: a request
+    // the caller stopped must stay stopped.
+    expect(thrown).toBe(cancelled);
+    expect(primary.calls()).toBe(1);
+    expect(backup.calls()).toBe(0);
+
+    // The entry survived the cancellation, so the next request probes once and
+    // escalates. Had the cancellation been read as recovery, this request would
+    // have paid the primary's whole retry budget instead.
+    const next = await wrapped.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+    expect(next.model).toBe("backup-model");
+    expect(primary.calls()).toBe(2);
+    expect(backup.calls()).toBe(1);
+    expect(shouldSkipPrimary(PRIMARY_ROUTE)).toBe(true);
+  });
+
+  test("a route without resolveFallbackRoute never consults the breaker", async () => {
+    // BYOK and every other route with no escalation hook keep today's
+    // behavior: a remembered outage on the same upstream name is irrelevant to
+    // them, and their traffic must not close it either.
+    const primary = primaryProvider();
+    const wrapped = new RetryProvider(primary.provider);
+    recordFallbackServed(UPSTREAM_ROUTE);
+
+    const result = await wrapped.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    expect(result.model).toBe("primary-model");
+    expect(primary.calls()).toBe(1);
+    expect(shouldSkipPrimary(PRIMARY_ROUTE)).toBe(true);
+  });
+
+  test("a request pinned to an explicit model ignores an open breaker and cannot close it", async () => {
+    // A pinned request can never re-route (the pin outranks any backup
+    // profile), so skipping the primary would only lose it the only route it
+    // has. By the same token its success says nothing about the traffic the
+    // breaker was opened for, so it must not clear the trip.
+    const primary = primaryProvider();
+    const backup = backupProvider();
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+    recordFallbackServed(UPSTREAM_ROUTE);
+
+    const result = await wrapped.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent", model: "pinned-model" },
+    });
+
+    expect(result.model).toBe("pinned-model");
+    expect(primary.calls()).toBe(1);
+    expect(backup.calls()).toBe(0);
+    expect(shouldSkipPrimary(PRIMARY_ROUTE)).toBe(true);
+  });
+
+  test("a fallback serve trips the breaker for the next request", async () => {
+    const primary = primaryProvider(
+      () => new ProviderError("model not found", UPSTREAM, 404),
+      () => new ProviderError("model not found", UPSTREAM, 404),
+    );
+    const backup = backupProvider();
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    await wrapped.sendMessage(MESSAGES, { config: { callSite: "mainAgent" } });
+    expect(primary.calls()).toBe(1);
+
+    await wrapped.sendMessage(MESSAGES, { config: { callSite: "mainAgent" } });
+    expect(primary.calls()).toBe(1);
+    expect(backup.calls()).toBe(2);
+  });
+
+  test("a retired model diverts only itself, not a healthy model on the same upstream", async () => {
+    // The retired-model incident this feature exists for must not take the
+    // whole upstream down with it.
+    const primary = primaryProvider(
+      () => new ProviderError("model not found", UPSTREAM, 404),
+    );
+    const backup = backupProvider();
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    await wrapped.sendMessage(MESSAGES, { config: { callSite: "mainAgent" } });
+    expect(backup.calls()).toBe(1);
+
+    // A profile pinned to another model on the same upstream still goes to its
+    // own primary.
+    const healthy = await wrapped.sendMessage(MESSAGES, {
+      config: { ...OTHER_MODEL_CALL },
+    });
+    expect(healthy.model).toBe("other-model");
+    expect(primary.seenModels()).toEqual(["primary-model", "other-model"]);
+    expect(backup.calls()).toBe(1);
+
+    // The retired model itself is still remembered.
+    await wrapped.sendMessage(MESSAGES, { config: { callSite: "mainAgent" } });
+    expect(backup.calls()).toBe(2);
+    expect(primary.calls()).toBe(2);
+  });
+
+  test("a probe that comes back with a retired model frees the rest of the upstream", async () => {
+    const primary = primaryProvider(
+      () => new ProviderError("model not found", UPSTREAM, 404),
+    );
+    const backup = backupProvider();
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+    recordFallbackServed(UPSTREAM_ROUTE, Date.now() - MAX_COOLDOWN_MS - 1);
+
+    // The probe reaches the upstream and comes back with a retired model, so
+    // the outage that opened the entry is over and the retirement replaces it.
+    const probed = await wrapped.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+    expect(primary.calls()).toBe(1);
+    expect(probed.model).toBe("backup-model");
+
+    // A healthy model on the same upstream is servable again...
+    const healthy = await wrapped.sendMessage(MESSAGES, {
+      config: { ...OTHER_MODEL_CALL },
+    });
+    expect(healthy.model).toBe("other-model");
+
+    // ...while the retired model keeps going to the backup.
+    await wrapped.sendMessage(MESSAGES, { config: { callSite: "mainAgent" } });
+    expect(backup.calls()).toBe(2);
+    expect(primary.seenModels()).toEqual(["primary-model", "other-model"]);
+  });
+
+  test("an upstream outage diverts every model on it", async () => {
+    // A managed credential rejection indicts the upstream, not one model, so
+    // the healthy model is skipped too.
+    const primary = primaryProvider(
+      () =>
+        new ProviderError("Unauthorized", UPSTREAM, 401, {
+          reason: "invalid_credentials",
+        }),
+    );
+    const backup = backupProvider();
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      credentialSource: "vellum-managed",
+      refreshCredentialProvider: async () => null,
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    await wrapped.sendMessage(MESSAGES, { config: { callSite: "mainAgent" } });
+    expect(backup.calls()).toBe(1);
+
+    await wrapped.sendMessage(MESSAGES, { config: { ...OTHER_MODEL_CALL } });
+    expect(backup.calls()).toBe(2);
+    // Only the first request ever reached the upstream.
+    expect(primary.calls()).toBe(1);
+  });
+});

--- a/assistant/src/__tests__/fallback-breaker.test.ts
+++ b/assistant/src/__tests__/fallback-breaker.test.ts
@@ -27,7 +27,9 @@ import type {
   ProviderResponse,
   SendMessageOptions,
 } from "../providers/types.js";
+import { UNPARSEABLE_TOOL_ARGS_SDK_MESSAGE } from "../providers/unparseable-tool-args.js";
 import { ProviderError } from "../util/errors.js";
+import { DEFAULT_MAX_RETRIES } from "../util/retry.js";
 import { setConfig } from "./helpers/set-config.js";
 
 // ── Fixtures ────────────────────────────────────────────────────────────────
@@ -135,14 +137,17 @@ function primaryProvider(...errors: (() => unknown)[]): {
   provider: Provider;
   calls: () => number;
   seenModels: () => (string | undefined)[];
+  seenMessages: () => Message[][];
 } {
   const seen: (string | undefined)[] = [];
+  const seenMessages: Message[][] = [];
   let calls = 0;
   const provider: Provider = {
     name: UPSTREAM,
-    sendMessage: async (_messages: Message[], options?: SendMessageOptions) => {
+    sendMessage: async (messages: Message[], options?: SendMessageOptions) => {
       calls += 1;
       seen.push(options?.config?.model);
+      seenMessages.push(messages);
       const next = errors.shift();
       if (next) {
         throw next();
@@ -150,20 +155,60 @@ function primaryProvider(...errors: (() => unknown)[]): {
       return okResponse(options?.config?.model ?? "unresolved");
     },
   };
-  return { provider, calls: () => calls, seenModels: () => seen };
+  return {
+    provider,
+    calls: () => calls,
+    seenModels: () => seen,
+    seenMessages: () => seenMessages,
+  };
 }
 
-/** Backup stub that serves whatever model the re-normalized options resolved. */
-function backupProvider(): { provider: Provider; calls: () => number } {
+/**
+ * Backup stub that serves whatever model the re-normalized options resolved,
+ * after throwing the next error from `errors` while any remain.
+ */
+function backupProvider(...errors: (() => unknown)[]): {
+  provider: Provider;
+  calls: () => number;
+} {
   let calls = 0;
   const provider: Provider = {
     name: "anthropic",
     sendMessage: async (_messages: Message[], options?: SendMessageOptions) => {
       calls += 1;
+      const next = errors.shift();
+      if (next) {
+        throw next();
+      }
       return okResponse(options?.config?.model ?? "unresolved");
     },
   };
   return { provider, calls: () => calls };
+}
+
+/**
+ * A transient upstream failure that names a zero wait, so a retry budget can be
+ * exercised without the test sitting through real exponential backoff.
+ */
+function transient(status = 503): ProviderError {
+  return new ProviderError("Service Unavailable", "anthropic", status, {
+    retryAfterMs: 0,
+  });
+}
+
+/**
+ * A mid-stream corruption: the upstream accepted the request and streamed, so
+ * the error carries no HTTP status. `retryAfterMs` is a test convenience only,
+ * standing in for a Retry-After header this shape would not really carry, so a
+ * retry budget can be counted without sitting through real backoff.
+ */
+function corruptedStream(): ProviderError {
+  return new ProviderError(
+    "stream ended without producing a message",
+    UPSTREAM,
+    undefined,
+    { retryAfterMs: 0 },
+  );
 }
 
 function makeRoute(provider: Provider): {
@@ -799,5 +844,445 @@ describe("RetryProvider under an open breaker", () => {
     expect(backup.calls()).toBe(2);
     // Only the first request ever reached the upstream.
     expect(primary.calls()).toBe(1);
+  });
+});
+
+// ── The retry budget a breaker-driven send gets on the backup ───────────────
+
+describe("the backup's retry budget", () => {
+  test("a breaker-open request retries a transient failure on the backup instead of failing the turn", async () => {
+    // The breaker trips after a single successful fallback serve, so for the
+    // whole cooldown every request skips the primary. Those requests spend no
+    // retry budget on the way, so they get one on the backup: on a single
+    // attempt a lone 429 or mid-stream cut fails the turn.
+    const primary = primaryProvider();
+    const backup = backupProvider(() => transient());
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+    recordFallbackServed(UPSTREAM_ROUTE);
+
+    const result = await wrapped.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    expect(result.model).toBe("backup-model");
+    expect(backup.calls()).toBe(2);
+    // The primary is still skipped entirely: the retry budget moved to the
+    // backup, it was not restored to a route known to be down.
+    expect(primary.calls()).toBe(0);
+  });
+
+  test("a retried backup never escalates to a second fallback", async () => {
+    // One hop is structural, not a budget: the route callback is consulted
+    // exactly once however many attempts the backup takes.
+    const primary = primaryProvider();
+    const backup = backupProvider(
+      () => transient(),
+      () => transient(),
+      () => transient(),
+      () => transient(),
+    );
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+    recordFallbackServed(UPSTREAM_ROUTE);
+
+    const thrown = await captureError(
+      wrapped.sendMessage(MESSAGES, { config: { callSite: "mainAgent" } }),
+    );
+
+    expect(backup.calls()).toBe(1 + DEFAULT_MAX_RETRIES);
+    expect(route.calls()).toBe(1);
+    expect(primary.calls()).toBe(0);
+    // Tagged like the primary loop's own exhaustion, so Sentry capture reads a
+    // flapping backup as noise rather than an engineering signal.
+    expect((thrown as { retriesExhausted?: boolean }).retriesExhausted).toBe(
+      true,
+    );
+  });
+
+  test("a failed probe hands its request a retry budget on the backup too", async () => {
+    // A probe is one attempt on the primary, not a retry loop, so its request
+    // has spent no budget either by the time it reaches the backup.
+    const primary = primaryProvider(
+      () => new ProviderError("Service Unavailable", UPSTREAM, 503),
+    );
+    const backup = backupProvider(() => transient());
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+    recordFallbackServed(UPSTREAM_ROUTE, Date.now() - MAX_COOLDOWN_MS - 1);
+
+    const result = await wrapped.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    expect(primary.calls()).toBe(1);
+    expect(backup.calls()).toBe(2);
+    expect(result.model).toBe("backup-model");
+  });
+
+  test("an escalation after the primary burned its budget still gets one attempt", async () => {
+    // The asymmetry worth keeping: this request already waited out a full
+    // retry loop, so the backup answers once or the turn fails.
+    const primary = primaryProvider(
+      () =>
+        new ProviderError("Service Unavailable", UPSTREAM, 503, {
+          retryAfterMs: 0,
+        }),
+      () =>
+        new ProviderError("Service Unavailable", UPSTREAM, 503, {
+          retryAfterMs: 0,
+        }),
+      () =>
+        new ProviderError("Service Unavailable", UPSTREAM, 503, {
+          retryAfterMs: 0,
+        }),
+      () =>
+        new ProviderError("Service Unavailable", UPSTREAM, 503, {
+          retryAfterMs: 0,
+        }),
+    );
+    const backup = backupProvider(
+      () => transient(),
+      () => transient(),
+    );
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    await captureError(
+      wrapped.sendMessage(MESSAGES, { config: { callSite: "mainAgent" } }),
+    );
+
+    expect(primary.calls()).toBe(1 + DEFAULT_MAX_RETRIES);
+    expect(backup.calls()).toBe(1);
+  });
+});
+
+// ── What a failed probe is allowed to conclude ──────────────────────────────
+
+describe("recovery probe verdicts", () => {
+  test("a probe that fails with a corrupted stream closes the breaker and still completes the turn", async () => {
+    // Every stream-corruption pattern requires an absent HTTP status, which
+    // means the upstream accepted the request, returned 200, and streamed. The
+    // failure is in the bytes it produced, not in its ability to serve, so it
+    // is evidence the primary is healthy. The verdict must not cost the request
+    // that established it: this is exactly the failure the main loop repairs by
+    // resending, so the probe hands the request back to that loop.
+    const primary = primaryProvider(() => corruptedStream());
+    const backup = backupProvider();
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+    recordFallbackServed(UPSTREAM_ROUTE, Date.now() - MAX_COOLDOWN_MS - 1);
+
+    const result = await wrapped.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    // The turn completed on the route the probe just cleared.
+    expect(result.model).toBe("primary-model");
+    expect(primary.calls()).toBe(2);
+    expect(backup.calls()).toBe(0);
+    // The breaker closed rather than re-tripping with a doubled cooldown, so
+    // the next request takes the primary and gets its full retry budget.
+    expect(shouldSkipPrimary(PRIMARY_ROUTE)).toBe(false);
+  });
+
+  test("a corrupted-stream probe leaves the request the same total budget as one that never probes", async () => {
+    // The probe's send counts as this request's first attempt, so continuing
+    // into the retry loop must not hand it a wider budget than a request that
+    // never probes. Four sends total, then the backup as the loop's ordinary
+    // last resort, so the turn finishes even when the primary never stops
+    // corrupting.
+    const primary = primaryProvider(
+      () => corruptedStream(),
+      () => corruptedStream(),
+      () => corruptedStream(),
+      () => corruptedStream(),
+      () => corruptedStream(),
+    );
+    const backup = backupProvider();
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+    recordFallbackServed(UPSTREAM_ROUTE, Date.now() - MAX_COOLDOWN_MS - 1);
+
+    const result = await wrapped.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    expect(primary.calls()).toBe(1 + DEFAULT_MAX_RETRIES);
+    expect(result.model).toBe("backup-model");
+    // A backup that had to serve is proof the route is down after all, so the
+    // breaker is remembered again on the way out.
+    expect(shouldSkipPrimary(PRIMARY_ROUTE)).toBe(true);
+  });
+
+  test("a probe that spent a corrective resend keeps the same total budget", async () => {
+    // The repaired path: the probe sends twice (the original plus the
+    // corrective resend) before the stream corruption hands the request to the
+    // retry loop. The seed has to count both, or this request makes one more
+    // primary send than a request that never probes.
+    const primary = primaryProvider(
+      () =>
+        new ProviderError(
+          `Anthropic: ${UNPARSEABLE_TOOL_ARGS_SDK_MESSAGE}`,
+          UPSTREAM,
+          undefined,
+        ),
+      () => corruptedStream(),
+      () => corruptedStream(),
+      () => corruptedStream(),
+      () => corruptedStream(),
+      () => corruptedStream(),
+    );
+    const backup = backupProvider();
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+    recordFallbackServed(UPSTREAM_ROUTE, Date.now() - MAX_COOLDOWN_MS - 1);
+
+    const result = await wrapped.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    // Two probe sends plus two loop sends, not two plus three.
+    expect(primary.calls()).toBe(1 + DEFAULT_MAX_RETRIES);
+    expect(result.model).toBe("backup-model");
+  });
+
+  test("a probe repairs malformed tool arguments instead of reporting an outage", async () => {
+    // The main retry loop repairs this deterministically with a corrective
+    // note; the probe gets the same one-shot repair rather than reading a
+    // request-conditioned failure as the route still being down.
+    const primary = primaryProvider(
+      () =>
+        new ProviderError(
+          `Anthropic: ${UNPARSEABLE_TOOL_ARGS_SDK_MESSAGE}`,
+          UPSTREAM,
+          undefined,
+        ),
+    );
+    const backup = backupProvider();
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+    recordFallbackServed(UPSTREAM_ROUTE, Date.now() - MAX_COOLDOWN_MS - 1);
+
+    const result = await wrapped.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    expect(result.model).toBe("primary-model");
+    expect(primary.calls()).toBe(2);
+    expect(backup.calls()).toBe(0);
+    // The resend carried the corrective note, which is the whole point of it.
+    const resent = primary.seenMessages()[1];
+    const tail = resent[resent.length - 1].content;
+    expect(JSON.stringify(tail)).toContain("[assistant runtime]");
+    expect(shouldSkipPrimary(PRIMARY_ROUTE)).toBe(false);
+  });
+
+  test("a probe rate-limited by the primary still reads the outage as continuing", async () => {
+    // Deliberately not treated like a stream corruption. A 429 is the route
+    // refusing to do the work: no resend repairs it, only waiting does, and
+    // that is exactly what the cooldown provides. Reading it as recovery would
+    // send every request back to a primary that rejects all of them.
+    const primary = primaryProvider(
+      () => new ProviderError("Too Many Requests", UPSTREAM, 429),
+    );
+    const backup = backupProvider();
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+    recordFallbackServed(UPSTREAM_ROUTE, Date.now() - MAX_COOLDOWN_MS - 1);
+
+    const result = await wrapped.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    // Exactly one attempt on a route just judged down: the request goes
+    // straight to the backup rather than spending a retry budget on it.
+    expect(primary.calls()).toBe(1);
+    expect(backup.calls()).toBe(1);
+    expect(result.model).toBe("backup-model");
+    expect(shouldSkipPrimary(PRIMARY_ROUTE)).toBe(true);
+  });
+
+  test("a probe that fails with a 5xx still extends the outage", async () => {
+    // The control for the two cases above: a genuine server error is what the
+    // breaker exists to remember, and it must keep re-tripping.
+    const primary = primaryProvider(
+      () => new ProviderError("Service Unavailable", UPSTREAM, 503),
+    );
+    const backup = backupProvider();
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+    const trippedAt = Date.now() - MAX_COOLDOWN_MS - 1;
+    recordFallbackServed(UPSTREAM_ROUTE, trippedAt);
+
+    const result = await wrapped.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    expect(result.model).toBe("backup-model");
+    // No extra attempts on the primary either: an outage verdict fails fast
+    // into the backup instead of continuing into the retry loop.
+    expect(primary.calls()).toBe(1);
+    expect(shouldSkipPrimary(PRIMARY_ROUTE)).toBe(true);
+    // A failed probe doubles the wait, so the re-trip lands above the base.
+    expectWithinJitterBand(
+      observedCooldownMs(UPSTREAM_ROUTE, Date.now()),
+      BASE_COOLDOWN_MS * 2,
+    );
+  });
+});
+
+// ── What counts as having spent the retry budget ────────────────────────────
+
+describe("retry exhaustion accounting", () => {
+  /**
+   * The primary of a probe that uses both of its repairs before failing for
+   * real. The first send is rejected as an expired managed credential, the
+   * refreshed adapter answers the resend with malformed tool arguments, and the
+   * corrective resend after that comes back as a stream corruption. Three sends
+   * are spent by the time the request reaches the ordinary loop, leaving it
+   * exactly one, which it spends on `lastError`.
+   */
+  function repairedProbeAdapters(lastError: () => unknown): {
+    primary: ReturnType<typeof primaryProvider>;
+    refreshed: ReturnType<typeof primaryProvider>;
+  } {
+    return {
+      primary: primaryProvider(
+        () =>
+          new ProviderError("Unauthorized", UPSTREAM, 401, {
+            reason: "invalid_credentials",
+          }),
+      ),
+      refreshed: primaryProvider(
+        () =>
+          new ProviderError(
+            `Anthropic: ${UNPARSEABLE_TOOL_ARGS_SDK_MESSAGE}`,
+            UPSTREAM,
+            undefined,
+          ),
+        () => corruptedStream(),
+        lastError,
+      ),
+    };
+  }
+
+  test("a probe that spends the whole budget on repairs still reaches the backup", async () => {
+    // Exhaustion decides escalation eligibility, not just Sentry suppression,
+    // so a request whose budget was consumed inside the probe has to be seen as
+    // exhausted. Otherwise the turn this feature exists to rescue fails while a
+    // healthy backup sits unused.
+    const { primary, refreshed } = repairedProbeAdapters(() =>
+      corruptedStream(),
+    );
+    const backup = backupProvider();
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      credentialSource: "vellum-managed",
+      refreshCredentialProvider: async () => refreshed.provider,
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+    recordFallbackServed(UPSTREAM_ROUTE, Date.now() - MAX_COOLDOWN_MS - 1);
+
+    const result = await wrapped.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    expect(result.model).toBe("backup-model");
+    expect(backup.calls()).toBe(1);
+    // One send on the original adapter plus three on the refreshed one: the
+    // budget, spent exactly once.
+    expect(primary.calls() + refreshed.calls()).toBe(1 + DEFAULT_MAX_RETRIES);
+    expect(refreshed.calls()).toBe(3);
+  });
+
+  test("a probe that spends the whole budget on repairs tags the error as exhausted", async () => {
+    // The same sequence with no backup available, so the error surfaces and its
+    // tag can be read. Untagged, this is a Sentry capture for a flap the retry
+    // loop already did everything about.
+    const { primary, refreshed } = repairedProbeAdapters(() =>
+      corruptedStream(),
+    );
+    const wrapped = new RetryProvider(primary.provider, {
+      credentialSource: "vellum-managed",
+      refreshCredentialProvider: async () => refreshed.provider,
+      resolveFallbackRoute: async () => null,
+    });
+    recordFallbackServed(UPSTREAM_ROUTE, Date.now() - MAX_COOLDOWN_MS - 1);
+
+    const thrown = await captureError(
+      wrapped.sendMessage(MESSAGES, { config: { callSite: "mainAgent" } }),
+    );
+
+    expect((thrown as { retriesExhausted?: boolean }).retriesExhausted).toBe(
+      true,
+    );
+    expect(primary.calls() + refreshed.calls()).toBe(1 + DEFAULT_MAX_RETRIES);
+  });
+
+  test("a request that spends its budget in the ordinary loop is exhausted", async () => {
+    // The control for a request that never probes: unchanged behavior, tagged
+    // and escalated after the full budget.
+    const primary = primaryProvider(
+      () => transient(),
+      () => transient(),
+      () => transient(),
+      () => transient(),
+    );
+    const backup = backupProvider();
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    const result = await wrapped.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    expect(primary.calls()).toBe(1 + DEFAULT_MAX_RETRIES);
+    expect(result.model).toBe("backup-model");
+  });
+
+  test("a request that fails on a non-retryable error is not exhausted", async () => {
+    // The other control: one attempt, no budget spent, so nothing is tagged and
+    // a plain request failure never counts as an outage.
+    const primary = primaryProvider(
+      () => new ProviderError("invalid request", UPSTREAM, 400),
+    );
+    const backup = backupProvider();
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    const thrown = await captureError(
+      wrapped.sendMessage(MESSAGES, { config: { callSite: "mainAgent" } }),
+    );
+
+    expect(
+      (thrown as { retriesExhausted?: boolean }).retriesExhausted,
+    ).toBeUndefined();
+    expect(primary.calls()).toBe(1);
+    expect(backup.calls()).toBe(0);
   });
 });

--- a/assistant/src/__tests__/fallback-breaker.test.ts
+++ b/assistant/src/__tests__/fallback-breaker.test.ts
@@ -284,6 +284,15 @@ describe("fallback breaker state machine", () => {
     expect(shouldSkipPrimary(UPSTREAM_ROUTE, T0 + 1_000)).toBe(false);
   });
 
+  test("a stale fallback serve cannot re-trip a recovered route", () => {
+    const observation = recordPrimaryFailure(UPSTREAM_ROUTE, T0);
+    recordPrimarySuccess(UPSTREAM_ROUTE, T0 + 1_000);
+
+    recordFallbackServed(UPSTREAM_ROUTE, T0 + 2_000, observation);
+
+    expect(shouldSkipPrimary(UPSTREAM_ROUTE, T0 + 2_000)).toBe(false);
+  });
+
   test("the cooldown lands inside the jitter band and varies between trips", () => {
     const seen = new Set<number>();
     for (let i = 0; i < 40; i += 1) {
@@ -757,6 +766,44 @@ describe("RetryProvider under an open breaker", () => {
     await wrapped.sendMessage(MESSAGES, { config: { callSite: "mainAgent" } });
     expect(primary.calls()).toBe(1);
     expect(backup.calls()).toBe(2);
+  });
+
+  test("a late fallback completion cannot reopen a recovered primary", async () => {
+    const primary = primaryProvider(
+      () => new ProviderError("model not found", UPSTREAM, 404),
+    );
+    let resolveBackupStarted!: () => void;
+    const backupStarted = new Promise<void>((resolve) => {
+      resolveBackupStarted = resolve;
+    });
+    let resolveBackupResponse!: (response: ProviderResponse) => void;
+    const backupResponse = new Promise<ProviderResponse>((resolve) => {
+      resolveBackupResponse = resolve;
+    });
+    const backup: Provider = {
+      name: "anthropic",
+      sendMessage: async () => {
+        resolveBackupStarted();
+        return backupResponse;
+      },
+    };
+    const route = makeRoute(backup);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    const first = wrapped.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+    await backupStarted;
+
+    // A concurrent recovery probe can prove the primary is healthy while the
+    // earlier request is still waiting for its backup response.
+    recordPrimarySuccess(PRIMARY_ROUTE);
+    resolveBackupResponse(okResponse("backup-model"));
+
+    await first;
+    expect(shouldSkipPrimary(PRIMARY_ROUTE)).toBe(false);
   });
 
   test("a retired model diverts only itself, not a healthy model on the same upstream", async () => {

--- a/assistant/src/__tests__/llm-resolver.test.ts
+++ b/assistant/src/__tests__/llm-resolver.test.ts
@@ -303,6 +303,27 @@ describe("resolveCallSiteConfig", () => {
     expect(resolved.effort).toBe("high");
   });
 
+  test("a winning profile's fallbackProfile metadata never leaks into the resolved config", () => {
+    const llm = LLMSchema.parse({
+      profiles: {
+        primary: {
+          provider: "anthropic",
+          model: "claude-opus-4-7",
+          fallbackProfile: "backup",
+        },
+        backup: { provider: "anthropic", model: "claude-sonnet-4-6" },
+      },
+      callSites: {
+        memoryExtraction: { profile: "primary" },
+      },
+    });
+    const resolved = resolveCallSiteConfig("memoryExtraction", llm);
+    expect(resolved.model).toBe("claude-opus-4-7");
+    // `fallbackProfile` is ProfileEntry-only metadata, absent from
+    // `LLMConfigBase`; the resolved config must not carry the key at all.
+    expect(Object.hasOwn(resolved, "fallbackProfile")).toBe(false);
+  });
+
   test("topP defaults to null when no profile or override sets it", () => {
     const llm = LLMSchema.parse({});
     const resolved = resolveCallSiteConfig("mainAgent", llm);

--- a/assistant/src/__tests__/llm-resolver.test.ts
+++ b/assistant/src/__tests__/llm-resolver.test.ts
@@ -305,20 +305,19 @@ describe("resolveCallSiteConfig", () => {
 
   test("a winning profile's fallbackProfile metadata never leaks into the resolved config", () => {
     const llm = LLMSchema.parse({
+      defaultProvider: { provider: "vellum" },
       profiles: {
-        primary: {
-          provider: "anthropic",
-          model: "claude-opus-4-7",
-          fallbackProfile: "backup",
+        "quality-optimized": {
+          source: "managed",
+          fallbackProfile: "quality-optimized-backup",
         },
-        backup: { provider: "anthropic", model: "claude-sonnet-4-6" },
       },
       callSites: {
-        memoryExtraction: { profile: "primary" },
+        memoryExtraction: { profile: "quality-optimized" },
       },
     });
     const resolved = resolveCallSiteConfig("memoryExtraction", llm);
-    expect(resolved.model).toBe("claude-opus-4-7");
+    expect(resolved.model).toBe("gpt-5.6-sol");
     // `fallbackProfile` is ProfileEntry-only metadata, absent from
     // `LLMConfigBase`; the resolved config must not carry the key at all.
     expect(Object.hasOwn(resolved, "fallbackProfile")).toBe(false);

--- a/assistant/src/__tests__/llm-schema-fallback-profile.test.ts
+++ b/assistant/src/__tests__/llm-schema-fallback-profile.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, test } from "bun:test";
 
 import { z } from "zod";
 
-import { DEFAULT_PROFILE_KEYS } from "../config/default-profile-names.js";
+import {
+  BACKUP_PROFILE_KEYS,
+  DEFAULT_PROFILE_KEYS,
+} from "../config/default-profile-names.js";
 import { LLMSchema } from "../config/schemas/llm.js";
 
 describe("LLMSchema fallbackProfile", () => {
@@ -27,6 +30,20 @@ describe("LLMSchema fallbackProfile", () => {
     const result = LLMSchema.safeParse({
       profiles: {
         primary: { fallbackProfile: defaultKey },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("fallbackProfile may reference a managed backup profile key", () => {
+    // Backups resolve from the code catalog without being materialized in
+    // llm.profiles, exactly like the always-available defaults, so a pointer
+    // at one is a valid reference. No `defaultProvider` means the managed
+    // column (the reading an install predating the field gets).
+    const backupKey = BACKUP_PROFILE_KEYS[0];
+    const result = LLMSchema.safeParse({
+      profiles: {
+        primary: { fallbackProfile: backupKey },
       },
     });
     expect(result.success).toBe(true);
@@ -151,6 +168,47 @@ describe("LLMSchema fallbackProfile", () => {
     }
   });
 
+  test("a backup fallbackProfile target is rejected on a non-managed column", () => {
+    // The backups exist only on the managed column, so under a BYOK or
+    // ChatGPT default provider the pointer names a target that can never
+    // resolve, and keeping it would leave the primary silently unprotected.
+    const backupKey = BACKUP_PROFILE_KEYS[0];
+    for (const provider of ["anthropic", "chatgpt"] as const) {
+      const result = LLMSchema.safeParse({
+        defaultProvider: { provider },
+        profiles: {
+          primary: { fallbackProfile: backupKey },
+        },
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const issue = result.error.issues.find((i) =>
+          i.message.includes(`fallbackProfile "${backupKey}"`),
+        );
+        expect(issue?.message).toContain("managed backup profile");
+        expect(issue?.path).toEqual(["profiles", "primary", "fallbackProfile"]);
+      }
+    }
+  });
+
+  test("a user-owned materialized backup entry is a valid target on any column", () => {
+    // Conditioning applies to the code-defined name, not to a user-owned
+    // workspace entry: that entry carries its own body, and with no
+    // code-owned body to lose on a BYOK column it is what the name resolves
+    // to, so a pointer at it stays valid. A `source` other than `managed`,
+    // absent included, is what makes an entry user-owned, matching
+    // `resolveAgainstBody`.
+    const backupKey = BACKUP_PROFILE_KEYS[0];
+    const result = LLMSchema.safeParse({
+      defaultProvider: { provider: "anthropic" },
+      profiles: {
+        primary: { fallbackProfile: backupKey },
+        [backupKey]: { provider: "anthropic", model: "claude-opus-4-7" },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
   test("z.toJSONSchema still generates for LLMSchema (config docs/routes)", () => {
     // Same options as handleGetConfigSchema in
     // runtime/routes/conversation-query-routes.ts. The field must not
@@ -160,5 +218,226 @@ describe("LLMSchema fallbackProfile", () => {
       io: "input",
     });
     expect(json).toBeTruthy();
+  });
+});
+
+describe("LLMSchema backup profile references vs llm.defaultProvider", () => {
+  const backupKey = BACKUP_PROFILE_KEYS[0];
+  const managed = { provider: "vellum" } as const;
+  const nonManaged = [{ provider: "anthropic" }, { provider: "chatgpt" }];
+
+  test("activeProfile naming a backup parses on the managed column", () => {
+    const result = LLMSchema.safeParse({
+      defaultProvider: managed,
+      activeProfile: backupKey,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("activeProfile naming a backup is rejected on a non-managed column", () => {
+    for (const defaultProvider of nonManaged) {
+      const result = LLMSchema.safeParse({
+        defaultProvider,
+        activeProfile: backupKey,
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const issue = result.error.issues.find(
+          (i) => i.path.join(".") === "activeProfile",
+        );
+        expect(issue?.message).toContain("managed backup profile");
+      }
+    }
+  });
+
+  test("advisorProfile naming a backup follows the same split", () => {
+    expect(
+      LLMSchema.safeParse({
+        defaultProvider: managed,
+        advisorProfile: backupKey,
+      }).success,
+    ).toBe(true);
+    for (const defaultProvider of nonManaged) {
+      const result = LLMSchema.safeParse({
+        defaultProvider,
+        advisorProfile: backupKey,
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(
+          result.error.issues.some(
+            (i) => i.path.join(".") === "advisorProfile",
+          ),
+        ).toBe(true);
+      }
+    }
+  });
+
+  test("a call-site pin on a backup follows the same split", () => {
+    expect(
+      LLMSchema.safeParse({
+        defaultProvider: managed,
+        callSites: { recall: { profile: backupKey } },
+      }).success,
+    ).toBe(true);
+    for (const defaultProvider of nonManaged) {
+      const result = LLMSchema.safeParse({
+        defaultProvider,
+        callSites: { recall: { profile: backupKey } },
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const issue = result.error.issues.find(
+          (i) => i.path.join(".") === "callSites.recall.profile",
+        );
+        expect(issue?.message).toContain("managed backup profile");
+      }
+    }
+  });
+
+  test("a mix arm naming a backup follows the same split", () => {
+    const mixConfig = (defaultProvider: { provider: string }) => ({
+      defaultProvider,
+      profiles: {
+        armA: { speed: "fast" },
+        blend: {
+          mix: [
+            { profile: backupKey, weight: 1 },
+            { profile: "armA", weight: 1 },
+          ],
+        },
+      },
+    });
+    expect(LLMSchema.safeParse(mixConfig(managed)).success).toBe(true);
+    for (const defaultProvider of nonManaged) {
+      expect(LLMSchema.safeParse(mixConfig(defaultProvider)).success).toBe(
+        false,
+      );
+    }
+  });
+
+  test("an absent or malformed defaultProvider reads as the managed column", () => {
+    // `DefaultProviderField` catches an invalid value to `undefined`, and an
+    // install predating the field is managed by definition, so both keep
+    // their backups referenceable rather than losing a valid selection.
+    for (const defaultProvider of [undefined, { provider: 42 }, "vellum"]) {
+      const result = LLMSchema.safeParse({
+        defaultProvider,
+        activeProfile: backupKey,
+      });
+      expect(result.success).toBe(true);
+    }
+  });
+
+  test("the default profile keys stay valid on every column", () => {
+    for (const defaultProvider of [managed, ...nonManaged]) {
+      for (const key of DEFAULT_PROFILE_KEYS) {
+        expect(
+          LLMSchema.safeParse({ defaultProvider, activeProfile: key }).success,
+        ).toBe(true);
+      }
+    }
+  });
+
+  // A managed install can persist a thin `{ source: "managed" }` stub for a
+  // backup key: `normalizeManagedProfileWrites` reduces a `config get` ->
+  // `config set` echo of the effective profile list to exactly that. The stub
+  // holds no body of its own, so it must not carry a reference past the
+  // provider gate once the install moves off the managed column.
+  const stub = { source: "managed" } as const;
+
+  test("a managed stub does not keep a backup reference alive off the managed column", () => {
+    for (const defaultProvider of nonManaged) {
+      const result = LLMSchema.safeParse({
+        defaultProvider,
+        profiles: { [backupKey]: stub, primary: { effort: "high" } },
+        activeProfile: backupKey,
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const issue = result.error.issues.find(
+          (i) => i.path.join(".") === "activeProfile",
+        );
+        expect(issue?.message).toContain("managed backup profile");
+      }
+    }
+  });
+
+  test("a managed stub does not keep a call-site pin or mix arm alive either", () => {
+    for (const defaultProvider of nonManaged) {
+      const callSitePin = LLMSchema.safeParse({
+        defaultProvider,
+        profiles: { [backupKey]: stub },
+        callSites: { recall: { profile: backupKey } },
+      });
+      expect(callSitePin.success).toBe(false);
+
+      const mixArm = LLMSchema.safeParse({
+        defaultProvider,
+        profiles: {
+          [backupKey]: stub,
+          armA: { speed: "fast" },
+          blend: {
+            mix: [
+              { profile: backupKey, weight: 1 },
+              { profile: "armA", weight: 1 },
+            ],
+          },
+        },
+      });
+      expect(mixArm.success).toBe(false);
+    }
+  });
+
+  test("a managed stub does not keep a fallbackProfile pointer alive either", () => {
+    for (const defaultProvider of nonManaged) {
+      const result = LLMSchema.safeParse({
+        defaultProvider,
+        profiles: {
+          [backupKey]: stub,
+          primary: { fallbackProfile: backupKey },
+        },
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const issue = result.error.issues.find(
+          (i) => i.path.join(".") === "profiles.primary.fallbackProfile",
+        );
+        expect(issue?.message).toContain("managed backup profile");
+      }
+    }
+  });
+
+  test("a managed stub keeps its references valid on the managed column", () => {
+    // The stub stands for a body that does resolve here, so nothing about it
+    // makes the reference worse than the unmaterialized case.
+    const result = LLMSchema.safeParse({
+      defaultProvider: managed,
+      profiles: {
+        [backupKey]: stub,
+        primary: { fallbackProfile: backupKey },
+      },
+      activeProfile: backupKey,
+      callSites: { recall: { profile: backupKey } },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("a user-owned entry under a backup name keeps its references on every column", () => {
+    for (const defaultProvider of [managed, ...nonManaged]) {
+      const result = LLMSchema.safeParse({
+        defaultProvider,
+        profiles: {
+          [backupKey]: {
+            source: "user",
+            provider: "anthropic",
+            model: "claude-opus-4-7",
+          },
+          primary: { fallbackProfile: backupKey },
+        },
+        activeProfile: backupKey,
+      });
+      expect(result.success).toBe(true);
+    }
   });
 });

--- a/assistant/src/__tests__/llm-schema-fallback-profile.test.ts
+++ b/assistant/src/__tests__/llm-schema-fallback-profile.test.ts
@@ -5,142 +5,68 @@ import { z } from "zod";
 import {
   BACKUP_PROFILE_KEYS,
   DEFAULT_PROFILE_KEYS,
+  FALLBACK_PROFILE_BY_KEY,
 } from "../config/default-profile-names.js";
 import { LLMSchema } from "../config/schemas/llm.js";
 
 describe("LLMSchema fallbackProfile", () => {
-  test("profile with a valid fallbackProfile pointer parses", () => {
+  test.each([...DEFAULT_PROFILE_KEYS])(
+    "accepts the code-owned managed pointer for %s",
+    (profileName) => {
+      const result = LLMSchema.safeParse({
+        defaultProvider: { provider: "vellum" },
+        profiles: {
+          [profileName]: {
+            source: "managed",
+            fallbackProfile: FALLBACK_PROFILE_BY_KEY[profileName],
+          },
+        },
+      });
+      expect(result.success).toBe(true);
+    },
+  );
+
+  test("rejects a user-authored fallbackProfile even when its target exists", () => {
     const result = LLMSchema.safeParse({
       profiles: {
-        primary: { effort: "high", fallbackProfile: "backup" },
+        primary: { fallbackProfile: "backup" },
         backup: { speed: "fast" },
       },
     });
-    expect(result.success).toBe(true);
-    if (result.success) {
-      expect(result.data.profiles["primary"]?.fallbackProfile).toBe("backup");
-    }
-  });
-
-  test("fallbackProfile may reference an always-available default profile key", () => {
-    // Code-defined default profiles resolve without being materialized in
-    // llm.profiles, so they are valid reference targets (same rule as
-    // call-site `profile` references).
-    const defaultKey = DEFAULT_PROFILE_KEYS[0];
-    const result = LLMSchema.safeParse({
-      profiles: {
-        primary: { fallbackProfile: defaultKey },
-      },
-    });
-    expect(result.success).toBe(true);
-  });
-
-  test("fallbackProfile may reference a managed backup profile key", () => {
-    // Backups resolve from the code catalog without being materialized in
-    // llm.profiles, exactly like the always-available defaults, so a pointer
-    // at one is a valid reference. No `defaultProvider` means the managed
-    // column (the reading an install predating the field gets).
-    const backupKey = BACKUP_PROFILE_KEYS[0];
-    const result = LLMSchema.safeParse({
-      profiles: {
-        primary: { fallbackProfile: backupKey },
-      },
-    });
-    expect(result.success).toBe(true);
-  });
-
-  test("dangling fallbackProfile pointer fails superRefine", () => {
-    const result = LLMSchema.safeParse({
-      profiles: {
-        primary: { fallbackProfile: "ghost" },
-      },
-    });
     expect(result.success).toBe(false);
     if (!result.success) {
       const issue = result.error.issues.find((i) =>
-        i.message.includes('fallbackProfile "ghost"'),
-      );
-      expect(issue?.message).toContain("is not defined in llm.profiles");
-      expect(issue?.path).toEqual(["profiles", "primary", "fallbackProfile"]);
-    }
-  });
-
-  test("self-referencing fallbackProfile is rejected", () => {
-    const result = LLMSchema.safeParse({
-      profiles: {
-        primary: { fallbackProfile: "primary" },
-      },
-    });
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      const issue = result.error.issues.find((i) =>
-        i.message.includes("cannot declare itself"),
+        i.message.includes("Automatic fallbacks are code-owned"),
       );
       expect(issue?.path).toEqual(["profiles", "primary", "fallbackProfile"]);
     }
   });
 
-  test("fallbackProfile pointing at a mix profile is rejected", () => {
+  test("rejects a fallbackProfile on a user-owned default-profile shadow", () => {
+    const profileName = DEFAULT_PROFILE_KEYS[0];
     const result = LLMSchema.safeParse({
       profiles: {
-        primary: { fallbackProfile: "blend" },
-        armA: { speed: "fast" },
-        armB: { effort: "high" },
-        blend: {
-          mix: [
-            { profile: "armA", weight: 1 },
-            { profile: "armB", weight: 1 },
-          ],
+        [profileName]: {
+          source: "user",
+          fallbackProfile: FALLBACK_PROFILE_BY_KEY[profileName],
         },
       },
     });
     expect(result.success).toBe(false);
-    if (!result.success) {
-      const issue = result.error.issues.find((i) =>
-        i.message.includes("is a mix profile"),
-      );
-      expect(issue?.path).toEqual(["profiles", "primary", "fallbackProfile"]);
-    }
   });
 
-  test("two-hop fallback chain is rejected (single hop only)", () => {
+  test("rejects a managed default pointing anywhere except its code-owned backup", () => {
+    const profileName = DEFAULT_PROFILE_KEYS[0];
     const result = LLMSchema.safeParse({
       profiles: {
-        primary: { fallbackProfile: "middle" },
-        middle: { fallbackProfile: "last" },
-        last: { speed: "fast" },
-      },
-    });
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      const issue = result.error.issues.find((i) =>
-        i.message.includes("chains are not allowed"),
-      );
-      expect(issue?.path).toEqual(["profiles", "primary", "fallbackProfile"]);
-    }
-  });
-
-  test("mix profile carrying fallbackProfile is rejected", () => {
-    const result = LLMSchema.safeParse({
-      profiles: {
-        armA: { speed: "fast" },
-        armB: { effort: "high" },
-        blend: {
-          mix: [
-            { profile: "armA", weight: 1 },
-            { profile: "armB", weight: 1 },
-          ],
-          fallbackProfile: "armA",
+        [profileName]: {
+          source: "managed",
+          fallbackProfile: "custom-backup",
         },
+        "custom-backup": { speed: "fast" },
       },
     });
     expect(result.success).toBe(false);
-    if (!result.success) {
-      const issue = result.error.issues.find((i) =>
-        i.message.includes('cannot also set "fallbackProfile"'),
-      );
-      expect(issue?.path).toEqual(["profiles", "blend", "fallbackProfile"]);
-    }
   });
 
   test("empty-string fallbackProfile is rejected at field level", () => {
@@ -168,56 +94,47 @@ describe("LLMSchema fallbackProfile", () => {
     }
   });
 
-  test("a backup fallbackProfile target is rejected on a non-managed column", () => {
-    // The backups exist only on the managed column, so under a BYOK or
-    // ChatGPT default provider the pointer names a target that can never
-    // resolve, and keeping it would leave the primary silently unprotected.
-    const backupKey = BACKUP_PROFILE_KEYS[0];
+  test("a code-owned fallback pointer is rejected on a non-managed column", () => {
+    const profileName = DEFAULT_PROFILE_KEYS[0];
     for (const provider of ["anthropic", "chatgpt"] as const) {
       const result = LLMSchema.safeParse({
         defaultProvider: { provider },
         profiles: {
-          primary: { fallbackProfile: backupKey },
+          [profileName]: {
+            source: "managed",
+            fallbackProfile: FALLBACK_PROFILE_BY_KEY[profileName],
+          },
         },
       });
       expect(result.success).toBe(false);
       if (!result.success) {
         const issue = result.error.issues.find((i) =>
-          i.message.includes(`fallbackProfile "${backupKey}"`),
+          i.path.join(".").endsWith("fallbackProfile"),
         );
         expect(issue?.message).toContain("managed backup profile");
-        expect(issue?.path).toEqual(["profiles", "primary", "fallbackProfile"]);
+        expect(issue?.path).toEqual([
+          "profiles",
+          profileName,
+          "fallbackProfile",
+        ]);
       }
     }
   });
 
-  test("a user-owned materialized backup entry is a valid target on any column", () => {
-    // Conditioning applies to the code-defined name, not to a user-owned
-    // workspace entry: that entry carries its own body, and with no
-    // code-owned body to lose on a BYOK column it is what the name resolves
-    // to, so a pointer at it stays valid. A `source` other than `managed`,
-    // absent included, is what makes an entry user-owned, matching
-    // `resolveAgainstBody`.
-    const backupKey = BACKUP_PROFILE_KEYS[0];
-    const result = LLMSchema.safeParse({
-      defaultProvider: { provider: "anthropic" },
-      profiles: {
-        primary: { fallbackProfile: backupKey },
-        [backupKey]: { provider: "anthropic", model: "claude-opus-4-7" },
-      },
-    });
-    expect(result.success).toBe(true);
-  });
-
   test("z.toJSONSchema still generates for LLMSchema (config docs/routes)", () => {
-    // Same options as handleGetConfigSchema in
-    // runtime/routes/conversation-query-routes.ts. The field must not
-    // introduce any callback-bearing zod construct that breaks generation.
     const json = z.toJSONSchema(LLMSchema, {
       unrepresentable: "any",
       io: "input",
     });
-    expect(json).toBeTruthy();
+    expect(json).toMatchObject({
+      properties: {
+        profiles: {
+          additionalProperties: {
+            properties: { fallbackProfile: { readOnly: true } },
+          },
+        },
+      },
+    });
   });
 });
 
@@ -403,7 +320,7 @@ describe("LLMSchema backup profile references vs llm.defaultProvider", () => {
         const issue = result.error.issues.find(
           (i) => i.path.join(".") === "profiles.primary.fallbackProfile",
         );
-        expect(issue?.message).toContain("managed backup profile");
+        expect(issue?.message).toContain("Automatic fallbacks are code-owned");
       }
     }
   });
@@ -415,7 +332,6 @@ describe("LLMSchema backup profile references vs llm.defaultProvider", () => {
       defaultProvider: managed,
       profiles: {
         [backupKey]: stub,
-        primary: { fallbackProfile: backupKey },
       },
       activeProfile: backupKey,
       callSites: { recall: { profile: backupKey } },
@@ -423,7 +339,7 @@ describe("LLMSchema backup profile references vs llm.defaultProvider", () => {
     expect(result.success).toBe(true);
   });
 
-  test("a user-owned entry under a backup name keeps its references on every column", () => {
+  test("a user-owned entry under a backup name cannot enable custom fallback", () => {
     for (const defaultProvider of [managed, ...nonManaged]) {
       const result = LLMSchema.safeParse({
         defaultProvider,
@@ -437,7 +353,7 @@ describe("LLMSchema backup profile references vs llm.defaultProvider", () => {
         },
         activeProfile: backupKey,
       });
-      expect(result.success).toBe(true);
+      expect(result.success).toBe(false);
     }
   });
 });

--- a/assistant/src/__tests__/llm-schema-fallback-profile.test.ts
+++ b/assistant/src/__tests__/llm-schema-fallback-profile.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, test } from "bun:test";
+
+import { z } from "zod";
+
+import { DEFAULT_PROFILE_KEYS } from "../config/default-profile-names.js";
+import { LLMSchema } from "../config/schemas/llm.js";
+
+describe("LLMSchema fallbackProfile", () => {
+  test("profile with a valid fallbackProfile pointer parses", () => {
+    const result = LLMSchema.safeParse({
+      profiles: {
+        primary: { effort: "high", fallbackProfile: "backup" },
+        backup: { speed: "fast" },
+      },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.profiles["primary"]?.fallbackProfile).toBe("backup");
+    }
+  });
+
+  test("fallbackProfile may reference an always-available default profile key", () => {
+    // Code-defined default profiles resolve without being materialized in
+    // llm.profiles, so they are valid reference targets (same rule as
+    // call-site `profile` references).
+    const defaultKey = DEFAULT_PROFILE_KEYS[0];
+    const result = LLMSchema.safeParse({
+      profiles: {
+        primary: { fallbackProfile: defaultKey },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("dangling fallbackProfile pointer fails superRefine", () => {
+    const result = LLMSchema.safeParse({
+      profiles: {
+        primary: { fallbackProfile: "ghost" },
+      },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issue = result.error.issues.find((i) =>
+        i.message.includes('fallbackProfile "ghost"'),
+      );
+      expect(issue?.message).toContain("is not defined in llm.profiles");
+      expect(issue?.path).toEqual(["profiles", "primary", "fallbackProfile"]);
+    }
+  });
+
+  test("self-referencing fallbackProfile is rejected", () => {
+    const result = LLMSchema.safeParse({
+      profiles: {
+        primary: { fallbackProfile: "primary" },
+      },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issue = result.error.issues.find((i) =>
+        i.message.includes("cannot declare itself"),
+      );
+      expect(issue?.path).toEqual(["profiles", "primary", "fallbackProfile"]);
+    }
+  });
+
+  test("fallbackProfile pointing at a mix profile is rejected", () => {
+    const result = LLMSchema.safeParse({
+      profiles: {
+        primary: { fallbackProfile: "blend" },
+        armA: { speed: "fast" },
+        armB: { effort: "high" },
+        blend: {
+          mix: [
+            { profile: "armA", weight: 1 },
+            { profile: "armB", weight: 1 },
+          ],
+        },
+      },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issue = result.error.issues.find((i) =>
+        i.message.includes("is a mix profile"),
+      );
+      expect(issue?.path).toEqual(["profiles", "primary", "fallbackProfile"]);
+    }
+  });
+
+  test("two-hop fallback chain is rejected (single hop only)", () => {
+    const result = LLMSchema.safeParse({
+      profiles: {
+        primary: { fallbackProfile: "middle" },
+        middle: { fallbackProfile: "last" },
+        last: { speed: "fast" },
+      },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issue = result.error.issues.find((i) =>
+        i.message.includes("chains are not allowed"),
+      );
+      expect(issue?.path).toEqual(["profiles", "primary", "fallbackProfile"]);
+    }
+  });
+
+  test("mix profile carrying fallbackProfile is rejected", () => {
+    const result = LLMSchema.safeParse({
+      profiles: {
+        armA: { speed: "fast" },
+        armB: { effort: "high" },
+        blend: {
+          mix: [
+            { profile: "armA", weight: 1 },
+            { profile: "armB", weight: 1 },
+          ],
+          fallbackProfile: "armA",
+        },
+      },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issue = result.error.issues.find((i) =>
+        i.message.includes('cannot also set "fallbackProfile"'),
+      );
+      expect(issue?.path).toEqual(["profiles", "blend", "fallbackProfile"]);
+    }
+  });
+
+  test("empty-string fallbackProfile is rejected at field level", () => {
+    const result = LLMSchema.safeParse({
+      profiles: {
+        primary: { fallbackProfile: "" },
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("profiles without fallbackProfile still parse (back-compat)", () => {
+    const result = LLMSchema.safeParse({
+      profiles: {
+        fast: { speed: "fast", effort: "low" },
+        thorough: { effort: "high", maxTokens: 128000 },
+      },
+      callSites: {
+        mainAgent: { profile: "thorough" },
+      },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.profiles["fast"]?.fallbackProfile).toBeUndefined();
+    }
+  });
+
+  test("z.toJSONSchema still generates for LLMSchema (config docs/routes)", () => {
+    // Same options as handleGetConfigSchema in
+    // runtime/routes/conversation-query-routes.ts. The field must not
+    // introduce any callback-bearing zod construct that breaks generation.
+    const json = z.toJSONSchema(LLMSchema, {
+      unrepresentable: "any",
+      io: "input",
+    });
+    expect(json).toBeTruthy();
+  });
+});

--- a/assistant/src/__tests__/managed-fallback-dispatch.test.ts
+++ b/assistant/src/__tests__/managed-fallback-dispatch.test.ts
@@ -16,11 +16,18 @@ import {
   afterAll,
   afterEach,
   beforeAll,
+  beforeEach,
   describe,
   expect,
   test,
 } from "bun:test";
 
+import {
+  type BreakerRoute,
+  recordFallbackServed,
+  resetFallbackBreaker,
+  shouldSkipPrimary,
+} from "../providers/fallback-breaker.js";
 import { createAdapterFromConnection } from "../providers/inference/adapter-factory.js";
 import type {
   ProviderConnection,
@@ -47,6 +54,19 @@ const requests: UpstreamRequest[] = [];
  * reached on the first attempt instead of after a full retry budget.
  */
 let anthropicMode: "serve" | "retired" = "serve";
+
+/**
+ * Models the anthropic path answers with the retired shape whatever
+ * `anthropicMode` says, so one case can fail a primary pin while its backup pin
+ * keeps serving on the same upstream.
+ */
+const retiredModels = new Set<string>();
+
+/** The primary pin of the breaker case below, as its 404 marks it. */
+const RETIRED_ROUTE: BreakerRoute = {
+  upstream: "anthropic",
+  model: "claude-opus-5",
+};
 
 const ANTHROPIC_PATH = "/v1/runtime-proxy/anthropic";
 const OPENAI_PATH = "/v1/runtime-proxy/openai";
@@ -184,9 +204,10 @@ beforeAll(async () => {
         body,
       });
       if (url.pathname.startsWith(ANTHROPIC_PATH)) {
-        return anthropicMode === "serve"
-          ? anthropicCompletion()
-          : modelRetired();
+        return anthropicMode === "retired" ||
+          retiredModels.has(String(body.model))
+          ? modelRetired()
+          : anthropicCompletion();
       }
       return upstreamUnavailable();
     },
@@ -203,9 +224,17 @@ afterAll(() => {
   server.stop(true);
 });
 
+beforeEach(() => {
+  // A served fallback is remembered for the whole process, and bun shares
+  // module state between test files, so without this a case here would skip
+  // the primary route it means to exercise.
+  resetFallbackBreaker();
+});
+
 afterEach(() => {
   requests.length = 0;
   anthropicMode = "serve";
+  retiredModels.clear();
 });
 
 // ── Tests ───────────────────────────────────────────────────────────────────
@@ -601,5 +630,82 @@ describe("managed fallback dispatch", () => {
     expect((error as { statusCode?: number }).statusCode).toBe(404);
     const models = new Set(requests.map((r) => r.body.model));
     expect(models).toEqual(new Set(["claude-opus-5"]));
+  });
+
+  test("a remembered outage skips the primary, and a probe restores it once it recovers", async () => {
+    // Both pins sit on the same upstream, which is what the breaker is keyed
+    // on: the point here is the route being skipped and probed, not the
+    // cross-provider hop the cases above cover.
+    setConfig("llm", {
+      profiles: {
+        "breaker-primary": {
+          source: "user",
+          provider: "vellum",
+          model: "claude-opus-5",
+          fallbackProfile: "breaker-backup",
+          maxTokens: 1024,
+        },
+        "breaker-backup": {
+          source: "user",
+          provider: "vellum",
+          model: "claude-sonnet-5",
+          maxTokens: 2048,
+        },
+      },
+      activeProfile: "breaker-primary",
+    });
+    retiredModels.add("claude-opus-5");
+
+    const provider = createAdapterFromConnection(
+      vellumConnection,
+      managedAuth(ANTHROPIC_PATH),
+      {
+        model: "claude-opus-5",
+        provider: "anthropic",
+        streamTimeoutMs: 30_000,
+      },
+    );
+    expect(provider).not.toBeNull();
+
+    // The first request discovers the outage the expensive way and escalates.
+    const first: ProviderResponse = await provider!.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+    expect(first.actualInferenceProfile).toBe("breaker-backup");
+    expect(requests.map((r) => r.body.model)).toEqual([
+      "claude-opus-5",
+      "claude-sonnet-5",
+    ]);
+    // A retired pin is remembered for that model, not for the upstream, so the
+    // backup's own model on the same upstream stays available.
+    expect(shouldSkipPrimary(RETIRED_ROUTE)).toBe(true);
+    expect(
+      shouldSkipPrimary({ upstream: "anthropic", model: "claude-sonnet-5" }),
+    ).toBe(false);
+
+    // The second request reaches the backup without touching the dead pin.
+    requests.length = 0;
+    const second: ProviderResponse = await provider!.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+    expect(second.actualInferenceProfile).toBe("breaker-backup");
+    expect(requests.map((r) => r.body.model)).toEqual(["claude-sonnet-5"]);
+
+    // The upstream recovers and the cooldown elapses: re-trip the breaker at a
+    // timestamp older than the longest cooldown it can pick, which is how a
+    // process that has been degraded for a while looks.
+    retiredModels.clear();
+    resetFallbackBreaker();
+    recordFallbackServed(RETIRED_ROUTE, Date.now() - 11 * 60_000);
+    requests.length = 0;
+
+    const third: ProviderResponse = await provider!.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    // The probe went to the primary pin, served, and closed the breaker.
+    expect(requests.map((r) => r.body.model)).toEqual(["claude-opus-5"]);
+    expect(third.actualInferenceProfile).toBeUndefined();
+    expect(shouldSkipPrimary(RETIRED_ROUTE)).toBe(false);
   });
 });

--- a/assistant/src/__tests__/managed-fallback-dispatch.test.ts
+++ b/assistant/src/__tests__/managed-fallback-dispatch.test.ts
@@ -1,0 +1,605 @@
+/**
+ * Managed backup-profile dispatch, end to end against a mocked upstream.
+ *
+ * Everything below the test is production code: the real adapter factory, the
+ * real managed-proxy auth resolution, the real `RetryProvider` escalation, and
+ * the real Anthropic client. Only the upstream is faked, by a local
+ * `Bun.serve` standing in for the platform's runtime proxy, so the assertions
+ * are made on the bytes the backup route actually puts on the wire.
+ *
+ * Deliberately mock-free at the module level: `mock.module` is process-wide in
+ * bun, and stubbing the provider clients here would leak into every other file
+ * that exercises them.
+ */
+
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  test,
+} from "bun:test";
+
+import { createAdapterFromConnection } from "../providers/inference/adapter-factory.js";
+import type {
+  ProviderConnection,
+  ResolvedAuth,
+} from "../providers/inference/auth.js";
+import type { Message, ProviderResponse } from "../providers/types.js";
+import { credentialKey } from "../security/credential-key.js";
+import { setSecureKeyAsync } from "../security/secure-keys.js";
+import { setConfig } from "./helpers/set-config.js";
+
+// ── Mocked upstream ─────────────────────────────────────────────────────────
+
+interface UpstreamRequest {
+  path: string;
+  headers: Record<string, string>;
+  body: Record<string, unknown>;
+}
+
+const requests: UpstreamRequest[] = [];
+
+/**
+ * What the anthropic proxy path does. `retired` is the model rename/retirement
+ * shape: fallback-eligible but not retryable, so the escalation decision is
+ * reached on the first attempt instead of after a full retry budget.
+ */
+let anthropicMode: "serve" | "retired" = "serve";
+
+const ANTHROPIC_PATH = "/v1/runtime-proxy/anthropic";
+const OPENAI_PATH = "/v1/runtime-proxy/openai";
+
+/** A complete Anthropic Messages SSE stream for a one-word reply. */
+function anthropicCompletion(): Response {
+  const events = [
+    {
+      type: "message_start",
+      message: {
+        id: "msg_fallback_01",
+        type: "message",
+        role: "assistant",
+        content: [],
+        model: "claude-opus-5",
+        stop_reason: null,
+        stop_sequence: null,
+        usage: { input_tokens: 7, output_tokens: 1 },
+      },
+    },
+    {
+      type: "content_block_start",
+      index: 0,
+      content_block: { type: "text", text: "" },
+    },
+    {
+      type: "content_block_delta",
+      index: 0,
+      delta: { type: "text_delta", text: "served by the backup" },
+    },
+    { type: "content_block_stop", index: 0 },
+    {
+      type: "message_delta",
+      delta: { stop_reason: "end_turn", stop_sequence: null },
+      usage: { output_tokens: 4 },
+    },
+    { type: "message_stop" },
+  ];
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream({
+    start(controller) {
+      for (const event of events) {
+        controller.enqueue(
+          encoder.encode(
+            `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`,
+          ),
+        );
+      }
+      controller.close();
+    },
+  });
+  return new Response(stream, {
+    headers: { "Content-Type": "text/event-stream" },
+  });
+}
+
+/** The outage the primary route keeps returning. `retry-after: 0` keeps the
+ *  retry loop honest without making the test wait out real backoff. */
+function upstreamUnavailable(): Response {
+  return new Response(
+    JSON.stringify({ error: { message: "upstream unavailable" } }),
+    {
+      status: 503,
+      headers: { "content-type": "application/json", "retry-after": "0" },
+    },
+  );
+}
+
+/** A retired model id, the other outage shape fallback exists for. */
+function modelRetired(): Response {
+  return new Response(
+    JSON.stringify({
+      type: "error",
+      error: { type: "not_found_error", message: "model: unknown model id" },
+    }),
+    { status: 404, headers: { "content-type": "application/json" } },
+  );
+}
+
+let server: ReturnType<typeof Bun.serve>;
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+
+const MESSAGES: Message[] = [
+  { role: "user", content: [{ type: "text", text: "hi" }] },
+];
+
+const ASSISTANT_API_KEY = credentialKey("vellum", "assistant_api_key");
+const BYOK_CREDENTIAL = credentialKey("anthropic", "api_key");
+
+const vellumConnection = {
+  name: "vellum",
+  provider: "vellum",
+  auth: { type: "platform" },
+  label: "Vellum",
+  baseUrl: null,
+  models: null,
+} as unknown as ProviderConnection;
+
+const byokConnection = {
+  name: "anthropic-personal",
+  provider: "anthropic",
+  auth: { type: "api_key", credential: BYOK_CREDENTIAL },
+  label: "Anthropic (personal)",
+  baseUrl: null,
+  models: null,
+} as unknown as ProviderConnection;
+
+function managedAuth(proxyPath: string): ResolvedAuth {
+  return {
+    kind: "header",
+    headers: { Authorization: "Bearer test-assistant-key" },
+    baseUrl: `http://127.0.0.1:${server.port}${proxyPath}`,
+  };
+}
+
+function requestsTo(proxyPath: string): UpstreamRequest[] {
+  return requests.filter((r) => r.path.startsWith(proxyPath));
+}
+
+beforeAll(async () => {
+  server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const url = new URL(req.url);
+      let body: Record<string, unknown> = {};
+      try {
+        body = (await req.json()) as Record<string, unknown>;
+      } catch {
+        // Not every probe carries a JSON body; the path alone is enough.
+      }
+      requests.push({
+        path: url.pathname,
+        headers: Object.fromEntries(req.headers.entries()),
+        body,
+      });
+      if (url.pathname.startsWith(ANTHROPIC_PATH)) {
+        return anthropicMode === "serve"
+          ? anthropicCompletion()
+          : modelRetired();
+      }
+      return upstreamUnavailable();
+    },
+  });
+  // Managed-proxy prerequisites: the platform base URL points at the mock
+  // upstream, so `buildManagedBaseUrl` derives the per-provider proxy paths
+  // above and the backup route resolves its auth for real.
+  setConfig("platform", { baseUrl: `http://127.0.0.1:${server.port}` });
+  await setSecureKeyAsync(ASSISTANT_API_KEY, "test-assistant-key");
+  await setSecureKeyAsync(BYOK_CREDENTIAL, "test-byok-key");
+});
+
+afterAll(() => {
+  server.stop(true);
+});
+
+afterEach(() => {
+  requests.length = 0;
+  anthropicMode = "serve";
+});
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe("managed fallback dispatch", () => {
+  test("a managed quality-optimized outage is served on the backup profile", async () => {
+    setConfig("llm", { activeProfile: "quality-optimized" });
+
+    // The managed adapter for the primary route: the quality profile's own
+    // pin (`gpt-5.6-sol`), whose managed upstream is openai.
+    const provider = createAdapterFromConnection(
+      vellumConnection,
+      managedAuth(OPENAI_PATH),
+      {
+        model: "gpt-5.6-sol",
+        provider: "openai",
+        streamTimeoutMs: 30_000,
+      },
+    );
+    expect(provider).not.toBeNull();
+
+    const response: ProviderResponse = await provider!.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    // The primary was tried and kept failing before anything escalated.
+    expect(requestsTo(OPENAI_PATH).length).toBeGreaterThan(1);
+
+    // The backup profile's pin served the request, through the same managed
+    // connection, on the upstream its own model resolves to.
+    const backup = requestsTo(ANTHROPIC_PATH);
+    expect(backup.length).toBe(1);
+    expect(backup[0].body.model).toBe("claude-opus-5");
+    // The backup profile's own settings win over the failed primary's.
+    expect(backup[0].body.max_tokens).toBe(32000);
+    // `adaptive` is the wire form an adaptive-thinking-only model takes for the
+    // backup profile's `thinking.enabled`.
+    expect(backup[0].body.thinking).toMatchObject({ type: "adaptive" });
+
+    // Degraded traffic is attributed to the backup profile, both on the wire
+    // for the platform's usage events and on the response for the local ledger.
+    expect(backup[0].headers["x-vellum-inference-profile"]).toBe(
+      "quality-optimized-backup",
+    );
+    expect(response.actualInferenceProfile).toBe("quality-optimized-backup");
+    expect(response.actualProvider).toBe("anthropic");
+  });
+
+  test("a BYOK connection never falls back, even on an eligible error", async () => {
+    // Pointers like this never exist on a BYOK column, but seeding one proves
+    // the gate is the connection identity rather than the absence of a target.
+    setConfig("llm", {
+      profiles: {
+        "byok-primary": {
+          source: "user",
+          provider: "anthropic",
+          model: "claude-opus-5",
+          fallbackProfile: "byok-backup",
+          maxTokens: 1024,
+        },
+        "byok-backup": {
+          source: "user",
+          provider: "anthropic",
+          model: "claude-sonnet-5",
+          maxTokens: 2048,
+        },
+      },
+      activeProfile: "byok-primary",
+    });
+    anthropicMode = "retired";
+
+    const provider = createAdapterFromConnection(
+      byokConnection,
+      {
+        kind: "header",
+        headers: { Authorization: "Bearer test-byok-key" },
+        baseUrl: `http://127.0.0.1:${server.port}${ANTHROPIC_PATH}`,
+      },
+      { model: "claude-opus-5", streamTimeoutMs: 30_000 },
+    );
+    expect(provider).not.toBeNull();
+
+    const error = await provider!
+      .sendMessage(MESSAGES, { config: { callSite: "mainAgent" } })
+      .then(
+        () => null,
+        (err: unknown) => err,
+      );
+
+    // The primary's own error surfaces. A BYOK install may hold no credential
+    // for the backup's provider, so an escalation here would leave the vendor's
+    // answer to a foreign route in place of the real failure.
+    expect((error as { statusCode?: number }).statusCode).toBe(404);
+    // Every attempt used the primary's pin: no route was ever escalated.
+    const models = new Set(requests.map((r) => r.body.model));
+    expect(models).toEqual(new Set(["claude-opus-5"]));
+  });
+
+  test("a managed profile with no fallbackProfile rethrows the original error", async () => {
+    setConfig("llm", {
+      profiles: {
+        "managed-no-backup": {
+          source: "user",
+          provider: "anthropic",
+          model: "claude-opus-5",
+          maxTokens: 1024,
+        },
+      },
+      activeProfile: "managed-no-backup",
+    });
+    anthropicMode = "retired";
+
+    const provider = createAdapterFromConnection(
+      vellumConnection,
+      managedAuth(ANTHROPIC_PATH),
+      {
+        model: "claude-opus-5",
+        provider: "anthropic",
+        streamTimeoutMs: 30_000,
+      },
+    );
+    expect(provider).not.toBeNull();
+
+    const error = await provider!
+      .sendMessage(MESSAGES, { config: { callSite: "mainAgent" } })
+      .then(
+        () => null,
+        (err: unknown) => err,
+      );
+
+    // The original upstream failure surfaces unchanged: the callback found no
+    // pointer, so nothing was re-routed and no fallback error replaced it.
+    expect(error).toBeInstanceOf(Error);
+    expect((error as { statusCode?: number }).statusCode).toBe(404);
+    expect((error as { cause?: unknown }).cause).toBeUndefined();
+    const models = new Set(requests.map((r) => r.body.model));
+    expect(models).toEqual(new Set(["claude-opus-5"]));
+  });
+
+  test("the backup adapter serves the model a call-site tweak resolves to", async () => {
+    // A call site's own tuning fragment layers OVER the winning profile, so a
+    // `model` tweak decides the model even when the backup profile is forced.
+    // The adapter has to be built for THAT model's upstream: deriving it from
+    // the backup profile's own pin would send an OpenAI-shaped request through
+    // an Anthropic adapter (or the reverse).
+    setConfig("llm", {
+      profiles: {
+        "tweaked-primary": {
+          source: "user",
+          provider: "vellum",
+          model: "gpt-5.6-sol",
+          fallbackProfile: "tweaked-backup",
+          maxTokens: 1024,
+        },
+        // Deliberately an OpenAI pin, so the backup profile's own model and the
+        // call-site tweak below resolve to different upstreams.
+        "tweaked-backup": {
+          source: "user",
+          provider: "vellum",
+          model: "gpt-5.6-terra",
+          maxTokens: 2048,
+        },
+      },
+      activeProfile: "tweaked-primary",
+      callSites: { mainAgent: { model: "claude-opus-5" } },
+    });
+
+    const provider = createAdapterFromConnection(
+      vellumConnection,
+      managedAuth(OPENAI_PATH),
+      {
+        model: "gpt-5.6-sol",
+        provider: "openai",
+        streamTimeoutMs: 30_000,
+      },
+    );
+    expect(provider).not.toBeNull();
+
+    const response: ProviderResponse = await provider!.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    // The escalation followed the tweak, not the backup profile's own pin: the
+    // request reached the Anthropic upstream carrying the Anthropic model.
+    const backup = requestsTo(ANTHROPIC_PATH);
+    expect(backup.length).toBe(1);
+    expect(backup[0].body.model).toBe("claude-opus-5");
+    // Deriving the upstream from the backup profile's own OpenAI pin instead
+    // would have escalated straight back to the failing OpenAI path, so the
+    // request never reaches Anthropic at all.
+    expect(requestsTo(OPENAI_PATH).length).toBeGreaterThan(0);
+    expect(response.actualProvider).toBe("anthropic");
+    expect(response.actualInferenceProfile).toBe("tweaked-backup");
+  });
+
+  test("a backup routing outside the managed connection is refused", async () => {
+    // The schema allows a pointer at a user-defined profile that carries its
+    // own BYOK provider. Serving it here would authenticate someone's personal
+    // route with the managed credential and bill it as managed traffic, so the
+    // escalation is declined and the primary's failure stands.
+    setConfig("llm", {
+      profiles: {
+        "managed-primary": {
+          source: "user",
+          provider: "vellum",
+          model: "claude-opus-5",
+          fallbackProfile: "byok-target",
+          maxTokens: 1024,
+        },
+        "byok-target": {
+          source: "user",
+          provider: "anthropic",
+          model: "claude-sonnet-5",
+          maxTokens: 2048,
+        },
+      },
+      activeProfile: "managed-primary",
+    });
+    anthropicMode = "retired";
+
+    const provider = createAdapterFromConnection(
+      vellumConnection,
+      managedAuth(ANTHROPIC_PATH),
+      {
+        model: "claude-opus-5",
+        provider: "anthropic",
+        streamTimeoutMs: 30_000,
+      },
+    );
+    expect(provider).not.toBeNull();
+
+    const error = await provider!
+      .sendMessage(MESSAGES, { config: { callSite: "mainAgent" } })
+      .then(
+        () => null,
+        (err: unknown) => err,
+      );
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as { statusCode?: number }).statusCode).toBe(404);
+    // Nothing was re-routed: the backup's model never went on the wire.
+    const models = new Set(requests.map((r) => r.body.model));
+    expect(models).toEqual(new Set(["claude-opus-5"]));
+  });
+
+  test("a managed backup still serves under a call-site provider tweak", async () => {
+    // A call-site fragment pinning a concrete upstream over a managed winner
+    // resolves to that provider while the resolver keeps the managed
+    // connection, so this is managed traffic and must still fall back. The
+    // guard above keys on the connection precisely so this case survives.
+    setConfig("llm", {
+      profiles: {
+        "tweak-primary": {
+          source: "user",
+          provider: "vellum",
+          model: "gpt-5.6-sol",
+          fallbackProfile: "tweak-managed-backup",
+          maxTokens: 1024,
+        },
+        "tweak-managed-backup": {
+          source: "user",
+          provider: "vellum",
+          model: "claude-opus-5",
+          maxTokens: 2048,
+        },
+      },
+      activeProfile: "tweak-primary",
+      callSites: { mainAgent: { provider: "anthropic" } },
+    });
+
+    const provider = createAdapterFromConnection(
+      vellumConnection,
+      managedAuth(OPENAI_PATH),
+      {
+        model: "gpt-5.6-sol",
+        provider: "openai",
+        streamTimeoutMs: 30_000,
+      },
+    );
+    expect(provider).not.toBeNull();
+
+    const response: ProviderResponse = await provider!.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    const backup = requestsTo(ANTHROPIC_PATH);
+    expect(backup.length).toBe(1);
+    expect(backup[0].body.model).toBe("claude-opus-5");
+    expect(response.actualInferenceProfile).toBe("tweak-managed-backup");
+  });
+
+  test("the backup upstream follows the resolved provider, not the model's catalog owner", async () => {
+    // The divergent shape: a call-site fragment pins a concrete upstream while
+    // the backup profile's own model belongs to a different one. Normal
+    // dispatch routes this by the resolved provider (`connection-resolution`
+    // threads it through as `providerOverride` for the managed connection), so
+    // the fallback has to as well. Deriving the upstream from the model instead
+    // sends the request somewhere the primary route never would have.
+    setConfig("llm", {
+      profiles: {
+        "divergent-primary": {
+          source: "user",
+          provider: "vellum",
+          model: "gpt-5.6-sol",
+          fallbackProfile: "divergent-backup",
+          maxTokens: 1024,
+        },
+        // An OpenAI-owned model under an Anthropic call-site pin: the resolved
+        // provider and the model's catalog owner disagree.
+        "divergent-backup": {
+          source: "user",
+          provider: "vellum",
+          model: "gpt-5.6-terra",
+          maxTokens: 2048,
+        },
+      },
+      activeProfile: "divergent-primary",
+      callSites: { mainAgent: { provider: "anthropic" } },
+    });
+
+    const provider = createAdapterFromConnection(
+      vellumConnection,
+      managedAuth(OPENAI_PATH),
+      {
+        model: "gpt-5.6-sol",
+        provider: "openai",
+        streamTimeoutMs: 30_000,
+      },
+    );
+    expect(provider).not.toBeNull();
+
+    const response: ProviderResponse = await provider!.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    // The escalation went to the pinned provider's upstream carrying the
+    // resolved model. Routing by the model's catalog owner would have escalated
+    // straight back onto the failing OpenAI path, so nothing reaches Anthropic.
+    const backup = requestsTo(ANTHROPIC_PATH);
+    expect(backup.length).toBe(1);
+    expect(backup[0].body.model).toBe("gpt-5.6-terra");
+    expect(response.actualProvider).toBe("anthropic");
+    expect(response.actualInferenceProfile).toBe("divergent-backup");
+  });
+
+  test("a backup whose resolved provider cannot front the managed proxy is refused", async () => {
+    // The connection guard passes (the resolver keeps the managed connection),
+    // but the pinned provider is not one the platform proxy serves. There is no
+    // upstream to build an adapter for, so the primary's failure stands rather
+    // than the request being quietly rerouted to the model's catalog owner.
+    setConfig("llm", {
+      profiles: {
+        "unroutable-primary": {
+          source: "user",
+          provider: "vellum",
+          model: "claude-opus-5",
+          fallbackProfile: "unroutable-backup",
+          maxTokens: 1024,
+        },
+        // Named on the managed connection, so the connection guard lets it
+        // through, but `openrouter` is not a managed-routable upstream.
+        "unroutable-backup": {
+          source: "user",
+          provider: "openrouter",
+          provider_connection: "vellum",
+          model: "claude-sonnet-5",
+          maxTokens: 2048,
+        },
+      },
+      activeProfile: "unroutable-primary",
+    });
+    anthropicMode = "retired";
+
+    const provider = createAdapterFromConnection(
+      vellumConnection,
+      managedAuth(ANTHROPIC_PATH),
+      {
+        model: "claude-opus-5",
+        provider: "anthropic",
+        streamTimeoutMs: 30_000,
+      },
+    );
+    expect(provider).not.toBeNull();
+
+    const error = await provider!
+      .sendMessage(MESSAGES, { config: { callSite: "mainAgent" } })
+      .then(
+        () => null,
+        (err: unknown) => err,
+      );
+
+    expect(error).toBeInstanceOf(Error);
+    expect((error as { statusCode?: number }).statusCode).toBe(404);
+    const models = new Set(requests.map((r) => r.body.model));
+    expect(models).toEqual(new Set(["claude-opus-5"]));
+  });
+});

--- a/assistant/src/__tests__/managed-fallback-dispatch.test.ts
+++ b/assistant/src/__tests__/managed-fallback-dispatch.test.ts
@@ -1,15 +1,9 @@
 /**
- * Managed backup-profile dispatch, end to end against a mocked upstream.
+ * Managed backup-profile dispatch against a mocked platform proxy.
  *
- * Everything below the test is production code: the real adapter factory, the
- * real managed-proxy auth resolution, the real `RetryProvider` escalation, and
- * the real Anthropic client. Only the upstream is faked, by a local
- * `Bun.serve` standing in for the platform's runtime proxy, so the assertions
- * are made on the bytes the backup route actually puts on the wire.
- *
- * Deliberately mock-free at the module level: `mock.module` is process-wide in
- * bun, and stubbing the provider clients here would leak into every other file
- * that exercises them.
+ * The primary test path includes `CallSiteRoutingProvider`, connection
+ * selection, the real adapter factory, retry escalation, and provider clients.
+ * Only the remote platform proxy is replaced with a local HTTP server.
  */
 
 import {
@@ -22,9 +16,8 @@ import {
   test,
 } from "bun:test";
 
+import { CallSiteRoutingProvider } from "../providers/call-site-routing.js";
 import {
-  type BreakerRoute,
-  recordFallbackServed,
   resetFallbackBreaker,
   shouldSkipPrimary,
 } from "../providers/fallback-breaker.js";
@@ -33,12 +26,15 @@ import type {
   ProviderConnection,
   ResolvedAuth,
 } from "../providers/inference/auth.js";
-import type { Message, ProviderResponse } from "../providers/types.js";
+import type {
+  Message,
+  Provider,
+  ProviderResponse,
+} from "../providers/types.js";
+import { getManagedUpstream } from "../providers/vellum-model-routing.js";
 import { credentialKey } from "../security/credential-key.js";
 import { setSecureKeyAsync } from "../security/secure-keys.js";
 import { setConfig } from "./helpers/set-config.js";
-
-// ── Mocked upstream ─────────────────────────────────────────────────────────
 
 interface UpstreamRequest {
   path: string;
@@ -47,31 +43,11 @@ interface UpstreamRequest {
 }
 
 const requests: UpstreamRequest[] = [];
-
-/**
- * What the anthropic proxy path does. `retired` is the model rename/retirement
- * shape: fallback-eligible but not retryable, so the escalation decision is
- * reached on the first attempt instead of after a full retry budget.
- */
-let anthropicMode: "serve" | "retired" = "serve";
-
-/**
- * Models the anthropic path answers with the retired shape whatever
- * `anthropicMode` says, so one case can fail a primary pin while its backup pin
- * keeps serving on the same upstream.
- */
-const retiredModels = new Set<string>();
-
-/** The primary pin of the breaker case below, as its 404 marks it. */
-const RETIRED_ROUTE: BreakerRoute = {
-  upstream: "anthropic",
-  model: "claude-opus-5",
-};
+let anthropicMode: "serve" | "retired" | "unavailable" = "serve";
 
 const ANTHROPIC_PATH = "/v1/runtime-proxy/anthropic";
 const OPENAI_PATH = "/v1/runtime-proxy/openai";
 
-/** A complete Anthropic Messages SSE stream for a one-word reply. */
 function anthropicCompletion(): Response {
   const events = [
     {
@@ -123,8 +99,6 @@ function anthropicCompletion(): Response {
   });
 }
 
-/** The outage the primary route keeps returning. `retry-after: 0` keeps the
- *  retry loop honest without making the test wait out real backoff. */
 function upstreamUnavailable(): Response {
   return new Response(
     JSON.stringify({ error: { message: "upstream unavailable" } }),
@@ -135,7 +109,6 @@ function upstreamUnavailable(): Response {
   );
 }
 
-/** A retired model id, the other outage shape fallback exists for. */
 function modelRetired(): Response {
   return new Response(
     JSON.stringify({
@@ -146,9 +119,7 @@ function modelRetired(): Response {
   );
 }
 
-let server: ReturnType<typeof Bun.serve>;
-
-// ── Fixtures ────────────────────────────────────────────────────────────────
+let server: ReturnType<typeof Bun.serve> | undefined;
 
 const MESSAGES: Message[] = [
   { role: "user", content: [{ type: "text", text: "hi" }] },
@@ -176,6 +147,9 @@ const byokConnection = {
 } as unknown as ProviderConnection;
 
 function managedAuth(proxyPath: string): ResolvedAuth {
+  if (server === undefined) {
+    throw new Error("test proxy is not running");
+  }
   return {
     kind: "header",
     headers: { Authorization: "Bearer test-assistant-key" },
@@ -184,11 +158,72 @@ function managedAuth(proxyPath: string): ResolvedAuth {
 }
 
 function requestsTo(proxyPath: string): UpstreamRequest[] {
-  return requests.filter((r) => r.path.startsWith(proxyPath));
+  return requests.filter((request) => request.path.startsWith(proxyPath));
+}
+
+function createManagedAdapter(upstream: string, model: string): Provider {
+  const proxyPath =
+    upstream === "openai"
+      ? OPENAI_PATH
+      : upstream === "anthropic"
+        ? ANTHROPIC_PATH
+        : null;
+  if (proxyPath === null) {
+    throw new Error(`unsupported test upstream: ${upstream}`);
+  }
+  const provider = createAdapterFromConnection(
+    vellumConnection,
+    managedAuth(proxyPath),
+    {
+      model,
+      provider: upstream,
+      streamTimeoutMs: 30_000,
+    },
+  );
+  if (provider === null) {
+    throw new Error(`failed to create ${upstream} test adapter`);
+  }
+  return provider;
+}
+
+/**
+ * Construct the production wrapper order that calls use. The connection
+ * resolver builds the managed adapter for the provider/model selected by the
+ * call-site router, so fallback eligibility sees the original call-site
+ * options while the primary transport matches the resolved route.
+ */
+function createRoutedManagedProvider(): Provider {
+  const defaultProvider = createManagedAdapter("openai", "gpt-5.6-sol");
+  return new CallSiteRoutingProvider(
+    defaultProvider,
+    async (connectionName, expectedProvider, model) => {
+      if (connectionName !== "vellum" || model === undefined) {
+        return null;
+      }
+      const upstream =
+        expectedProvider === "vellum"
+          ? getManagedUpstream(model)
+          : expectedProvider;
+      return upstream === undefined || upstream === null
+        ? null
+        : createManagedAdapter(upstream, model);
+    },
+    defaultProvider.routeAttribution,
+  );
+}
+
+async function captureError(promise: Promise<unknown>): Promise<unknown> {
+  try {
+    await promise;
+  } catch (error) {
+    return error;
+  }
+  throw new Error("expected the promise to reject");
 }
 
 beforeAll(async () => {
   server = Bun.serve({
+    hostname: "127.0.0.1",
     port: 0,
     async fetch(req) {
       const url = new URL(req.url);
@@ -196,7 +231,7 @@ beforeAll(async () => {
       try {
         body = (await req.json()) as Record<string, unknown>;
       } catch {
-        // Not every probe carries a JSON body; the path alone is enough.
+        // The request path is sufficient for non-JSON probes.
       }
       requests.push({
         path: url.pathname,
@@ -204,78 +239,49 @@ beforeAll(async () => {
         body,
       });
       if (url.pathname.startsWith(ANTHROPIC_PATH)) {
-        return anthropicMode === "retired" ||
-          retiredModels.has(String(body.model))
-          ? modelRetired()
+        if (anthropicMode === "retired") {
+          return modelRetired();
+        }
+        return anthropicMode === "unavailable"
+          ? upstreamUnavailable()
           : anthropicCompletion();
       }
       return upstreamUnavailable();
     },
   });
-  // Managed-proxy prerequisites: the platform base URL points at the mock
-  // upstream, so `buildManagedBaseUrl` derives the per-provider proxy paths
-  // above and the backup route resolves its auth for real.
   setConfig("platform", { baseUrl: `http://127.0.0.1:${server.port}` });
   await setSecureKeyAsync(ASSISTANT_API_KEY, "test-assistant-key");
   await setSecureKeyAsync(BYOK_CREDENTIAL, "test-byok-key");
 });
 
 afterAll(() => {
-  server.stop(true);
+  server?.stop(true);
 });
 
 beforeEach(() => {
-  // A served fallback is remembered for the whole process, and bun shares
-  // module state between test files, so without this a case here would skip
-  // the primary route it means to exercise.
   resetFallbackBreaker();
 });
 
 afterEach(() => {
   requests.length = 0;
   anthropicMode = "serve";
-  retiredModels.clear();
 });
 
-// ── Tests ───────────────────────────────────────────────────────────────────
-
 describe("managed fallback dispatch", () => {
-  test("a managed quality-optimized outage is served on the backup profile", async () => {
+  test("a managed default outage is served through the routed backup profile", async () => {
     setConfig("llm", { activeProfile: "quality-optimized" });
+    const provider = createRoutedManagedProvider();
 
-    // The managed adapter for the primary route: the quality profile's own
-    // pin (`gpt-5.6-sol`), whose managed upstream is openai.
-    const provider = createAdapterFromConnection(
-      vellumConnection,
-      managedAuth(OPENAI_PATH),
-      {
-        model: "gpt-5.6-sol",
-        provider: "openai",
-        streamTimeoutMs: 30_000,
-      },
-    );
-    expect(provider).not.toBeNull();
-
-    const response: ProviderResponse = await provider!.sendMessage(MESSAGES, {
+    const response: ProviderResponse = await provider.sendMessage(MESSAGES, {
       config: { callSite: "mainAgent" },
     });
 
-    // The primary was tried and kept failing before anything escalated.
     expect(requestsTo(OPENAI_PATH).length).toBeGreaterThan(1);
-
-    // The backup profile's pin served the request, through the same managed
-    // connection, on the upstream its own model resolves to.
     const backup = requestsTo(ANTHROPIC_PATH);
     expect(backup.length).toBe(1);
     expect(backup[0].body.model).toBe("claude-opus-5");
-    // The backup profile's own settings win over the failed primary's.
     expect(backup[0].body.max_tokens).toBe(32000);
-    // `adaptive` is the wire form an adaptive-thinking-only model takes for the
-    // backup profile's `thinking.enabled`.
     expect(backup[0].body.thinking).toMatchObject({ type: "adaptive" });
-
-    // Degraded traffic is attributed to the backup profile, both on the wire
-    // for the platform's usage events and on the response for the local ledger.
     expect(backup[0].headers["x-vellum-inference-profile"]).toBe(
       "quality-optimized-backup",
     );
@@ -283,429 +289,142 @@ describe("managed fallback dispatch", () => {
     expect(response.actualProvider).toBe("anthropic");
   });
 
-  test("a BYOK connection never falls back, even on an eligible error", async () => {
-    // Pointers like this never exist on a BYOK column, but seeding one proves
-    // the gate is the connection identity rather than the absence of a target.
+  test.each([
+    ["model", "gpt-5.6-sol"],
+    ["provider", "openai"],
+  ] as const)(
+    "a persisted call-site %s pin never falls back",
+    async (field, value) => {
+      setConfig("llm", {
+        activeProfile: "quality-optimized",
+        callSites: { mainAgent: { [field]: value } },
+      });
+      const provider = createRoutedManagedProvider();
+
+      const error = await captureError(
+        provider.sendMessage(MESSAGES, { config: { callSite: "mainAgent" } }),
+      );
+
+      expect((error as { provider?: string }).provider).toBe("openai");
+      expect(requestsTo(OPENAI_PATH).length).toBeGreaterThan(1);
+      expect(requestsTo(ANTHROPIC_PATH)).toHaveLength(0);
+      expect(shouldSkipPrimary({ upstream: "openai" })).toBe(false);
+    },
+  );
+
+  test("a BYOK connection never installs automatic fallback routing", async () => {
     setConfig("llm", {
       profiles: {
         "byok-primary": {
           source: "user",
           provider: "anthropic",
           model: "claude-opus-5",
-          fallbackProfile: "byok-backup",
           maxTokens: 1024,
-        },
-        "byok-backup": {
-          source: "user",
-          provider: "anthropic",
-          model: "claude-sonnet-5",
-          maxTokens: 2048,
         },
       },
       activeProfile: "byok-primary",
     });
     anthropicMode = "retired";
-
     const provider = createAdapterFromConnection(
       byokConnection,
       {
         kind: "header",
         headers: { Authorization: "Bearer test-byok-key" },
-        baseUrl: `http://127.0.0.1:${server.port}${ANTHROPIC_PATH}`,
+        baseUrl: `http://127.0.0.1:${server?.port}${ANTHROPIC_PATH}`,
       },
       { model: "claude-opus-5", streamTimeoutMs: 30_000 },
     );
     expect(provider).not.toBeNull();
 
-    const error = await provider!
-      .sendMessage(MESSAGES, { config: { callSite: "mainAgent" } })
-      .then(
-        () => null,
-        (err: unknown) => err,
-      );
+    const error = await captureError(
+      provider!.sendMessage(MESSAGES, { config: { callSite: "mainAgent" } }),
+    );
 
-    // The primary's own error surfaces. A BYOK install may hold no credential
-    // for the backup's provider, so an escalation here would leave the vendor's
-    // answer to a foreign route in place of the real failure.
     expect((error as { statusCode?: number }).statusCode).toBe(404);
-    // Every attempt used the primary's pin: no route was ever escalated.
-    const models = new Set(requests.map((r) => r.body.model));
-    expect(models).toEqual(new Set(["claude-opus-5"]));
+    expect(new Set(requests.map((request) => request.body.model))).toEqual(
+      new Set(["claude-opus-5"]),
+    );
   });
 
-  test("a managed profile with no fallbackProfile rethrows the original error", async () => {
+  test("a custom managed profile has no automatic fallback contract", async () => {
     setConfig("llm", {
       profiles: {
-        "managed-no-backup": {
+        custom: {
           source: "user",
-          provider: "anthropic",
+          provider: "vellum",
           model: "claude-opus-5",
           maxTokens: 1024,
         },
       },
-      activeProfile: "managed-no-backup",
+      activeProfile: "custom",
     });
     anthropicMode = "retired";
+    const provider = createRoutedManagedProvider();
 
-    const provider = createAdapterFromConnection(
-      vellumConnection,
-      managedAuth(ANTHROPIC_PATH),
-      {
-        model: "claude-opus-5",
-        provider: "anthropic",
-        streamTimeoutMs: 30_000,
-      },
+    const error = await captureError(
+      provider.sendMessage(MESSAGES, { config: { callSite: "mainAgent" } }),
     );
-    expect(provider).not.toBeNull();
 
-    const error = await provider!
-      .sendMessage(MESSAGES, { config: { callSite: "mainAgent" } })
-      .then(
-        () => null,
-        (err: unknown) => err,
-      );
-
-    // The original upstream failure surfaces unchanged: the callback found no
-    // pointer, so nothing was re-routed and no fallback error replaced it.
-    expect(error).toBeInstanceOf(Error);
     expect((error as { statusCode?: number }).statusCode).toBe(404);
-    expect((error as { cause?: unknown }).cause).toBeUndefined();
-    const models = new Set(requests.map((r) => r.body.model));
-    expect(models).toEqual(new Set(["claude-opus-5"]));
+    expect(new Set(requests.map((request) => request.body.model))).toEqual(
+      new Set(["claude-opus-5"]),
+    );
   });
 
-  test("the backup adapter serves the model a call-site tweak resolves to", async () => {
-    // A call site's own tuning fragment layers OVER the winning profile, so a
-    // `model` tweak decides the model even when the backup profile is forced.
-    // The adapter has to be built for THAT model's upstream: deriving it from
-    // the backup profile's own pin would send an OpenAI-shaped request through
-    // an Anthropic adapter (or the reverse).
+  test("a user shadow cannot change the code-owned backup route", async () => {
     setConfig("llm", {
       profiles: {
-        "tweaked-primary": {
+        "quality-optimized-backup": {
           source: "user",
-          provider: "vellum",
-          model: "gpt-5.6-sol",
-          fallbackProfile: "tweaked-backup",
-          maxTokens: 1024,
-        },
-        // Deliberately an OpenAI pin, so the backup profile's own model and the
-        // call-site tweak below resolve to different upstreams.
-        "tweaked-backup": {
-          source: "user",
-          provider: "vellum",
-          model: "gpt-5.6-terra",
-          maxTokens: 2048,
+          provider: "missing-connection-entry",
+          model: "custom-model",
         },
       },
-      activeProfile: "tweaked-primary",
-      callSites: { mainAgent: { model: "claude-opus-5" } },
+      activeProfile: "quality-optimized",
     });
+    const provider = createRoutedManagedProvider();
 
-    const provider = createAdapterFromConnection(
-      vellumConnection,
-      managedAuth(OPENAI_PATH),
-      {
-        model: "gpt-5.6-sol",
-        provider: "openai",
-        streamTimeoutMs: 30_000,
-      },
-    );
-    expect(provider).not.toBeNull();
-
-    const response: ProviderResponse = await provider!.sendMessage(MESSAGES, {
+    const response = await provider.sendMessage(MESSAGES, {
       config: { callSite: "mainAgent" },
     });
 
-    // The escalation followed the tweak, not the backup profile's own pin: the
-    // request reached the Anthropic upstream carrying the Anthropic model.
     const backup = requestsTo(ANTHROPIC_PATH);
-    expect(backup.length).toBe(1);
+    expect(backup).toHaveLength(1);
     expect(backup[0].body.model).toBe("claude-opus-5");
-    // Deriving the upstream from the backup profile's own OpenAI pin instead
-    // would have escalated straight back to the failing OpenAI path, so the
-    // request never reaches Anthropic at all.
-    expect(requestsTo(OPENAI_PATH).length).toBeGreaterThan(0);
-    expect(response.actualProvider).toBe("anthropic");
-    expect(response.actualInferenceProfile).toBe("tweaked-backup");
+    expect(response.actualInferenceProfile).toBe("quality-optimized-backup");
   });
 
-  test("a backup routing outside the managed connection is refused", async () => {
-    // The schema allows a pointer at a user-defined profile that carries its
-    // own BYOK provider. Serving it here would authenticate someone's personal
-    // route with the managed credential and bill it as managed traffic, so the
-    // escalation is declined and the primary's failure stands.
-    setConfig("llm", {
-      profiles: {
-        "managed-primary": {
-          source: "user",
-          provider: "vellum",
-          model: "claude-opus-5",
-          fallbackProfile: "byok-target",
-          maxTokens: 1024,
-        },
-        "byok-target": {
-          source: "user",
-          provider: "anthropic",
-          model: "claude-sonnet-5",
-          maxTokens: 2048,
-        },
-      },
-      activeProfile: "managed-primary",
-    });
-    anthropicMode = "retired";
+  test("a failed backup preserves the primary error and does not count as served", async () => {
+    setConfig("llm", { activeProfile: "quality-optimized" });
+    anthropicMode = "unavailable";
+    const provider = createRoutedManagedProvider();
 
-    const provider = createAdapterFromConnection(
-      vellumConnection,
-      managedAuth(ANTHROPIC_PATH),
-      {
-        model: "claude-opus-5",
-        provider: "anthropic",
-        streamTimeoutMs: 30_000,
-      },
+    const error = await captureError(
+      provider.sendMessage(MESSAGES, { config: { callSite: "mainAgent" } }),
     );
-    expect(provider).not.toBeNull();
 
-    const error = await provider!
-      .sendMessage(MESSAGES, { config: { callSite: "mainAgent" } })
-      .then(
-        () => null,
-        (err: unknown) => err,
-      );
-
-    expect(error).toBeInstanceOf(Error);
-    expect((error as { statusCode?: number }).statusCode).toBe(404);
-    // Nothing was re-routed: the backup's model never went on the wire.
-    const models = new Set(requests.map((r) => r.body.model));
-    expect(models).toEqual(new Set(["claude-opus-5"]));
+    expect((error as { provider?: string }).provider).toBe("openai");
+    expect(requestsTo(OPENAI_PATH).length).toBeGreaterThan(1);
+    expect(requestsTo(ANTHROPIC_PATH).length).toBeGreaterThan(0);
+    expect(shouldSkipPrimary({ upstream: "openai" })).toBe(false);
   });
 
-  test("a managed backup still serves under a call-site provider tweak", async () => {
-    // A call-site fragment pinning a concrete upstream over a managed winner
-    // resolves to that provider while the resolver keeps the managed
-    // connection, so this is managed traffic and must still fall back. The
-    // guard above keys on the connection precisely so this case survives.
-    setConfig("llm", {
-      profiles: {
-        "tweak-primary": {
-          source: "user",
-          provider: "vellum",
-          model: "gpt-5.6-sol",
-          fallbackProfile: "tweak-managed-backup",
-          maxTokens: 1024,
-        },
-        "tweak-managed-backup": {
-          source: "user",
-          provider: "vellum",
-          model: "claude-opus-5",
-          maxTokens: 2048,
-        },
-      },
-      activeProfile: "tweak-primary",
-      callSites: { mainAgent: { provider: "anthropic" } },
-    });
+  test("a served backup opens the breaker for the routed primary", async () => {
+    setConfig("llm", { activeProfile: "quality-optimized" });
+    const provider = createRoutedManagedProvider();
 
-    const provider = createAdapterFromConnection(
-      vellumConnection,
-      managedAuth(OPENAI_PATH),
-      {
-        model: "gpt-5.6-sol",
-        provider: "openai",
-        streamTimeoutMs: 30_000,
-      },
-    );
-    expect(provider).not.toBeNull();
-
-    const response: ProviderResponse = await provider!.sendMessage(MESSAGES, {
+    await provider.sendMessage(MESSAGES, {
       config: { callSite: "mainAgent" },
     });
+    expect(shouldSkipPrimary({ upstream: "openai" })).toBe(true);
 
-    const backup = requestsTo(ANTHROPIC_PATH);
-    expect(backup.length).toBe(1);
-    expect(backup[0].body.model).toBe("claude-opus-5");
-    expect(response.actualInferenceProfile).toBe("tweak-managed-backup");
-  });
-
-  test("the backup upstream follows the resolved provider, not the model's catalog owner", async () => {
-    // The divergent shape: a call-site fragment pins a concrete upstream while
-    // the backup profile's own model belongs to a different one. Normal
-    // dispatch routes this by the resolved provider (`connection-resolution`
-    // threads it through as `providerOverride` for the managed connection), so
-    // the fallback has to as well. Deriving the upstream from the model instead
-    // sends the request somewhere the primary route never would have.
-    setConfig("llm", {
-      profiles: {
-        "divergent-primary": {
-          source: "user",
-          provider: "vellum",
-          model: "gpt-5.6-sol",
-          fallbackProfile: "divergent-backup",
-          maxTokens: 1024,
-        },
-        // An OpenAI-owned model under an Anthropic call-site pin: the resolved
-        // provider and the model's catalog owner disagree.
-        "divergent-backup": {
-          source: "user",
-          provider: "vellum",
-          model: "gpt-5.6-terra",
-          maxTokens: 2048,
-        },
-      },
-      activeProfile: "divergent-primary",
-      callSites: { mainAgent: { provider: "anthropic" } },
-    });
-
-    const provider = createAdapterFromConnection(
-      vellumConnection,
-      managedAuth(OPENAI_PATH),
-      {
-        model: "gpt-5.6-sol",
-        provider: "openai",
-        streamTimeoutMs: 30_000,
-      },
-    );
-    expect(provider).not.toBeNull();
-
-    const response: ProviderResponse = await provider!.sendMessage(MESSAGES, {
-      config: { callSite: "mainAgent" },
-    });
-
-    // The escalation went to the pinned provider's upstream carrying the
-    // resolved model. Routing by the model's catalog owner would have escalated
-    // straight back onto the failing OpenAI path, so nothing reaches Anthropic.
-    const backup = requestsTo(ANTHROPIC_PATH);
-    expect(backup.length).toBe(1);
-    expect(backup[0].body.model).toBe("gpt-5.6-terra");
-    expect(response.actualProvider).toBe("anthropic");
-    expect(response.actualInferenceProfile).toBe("divergent-backup");
-  });
-
-  test("a backup whose resolved provider cannot front the managed proxy is refused", async () => {
-    // The connection guard passes (the resolver keeps the managed connection),
-    // but the pinned provider is not one the platform proxy serves. There is no
-    // upstream to build an adapter for, so the primary's failure stands rather
-    // than the request being quietly rerouted to the model's catalog owner.
-    setConfig("llm", {
-      profiles: {
-        "unroutable-primary": {
-          source: "user",
-          provider: "vellum",
-          model: "claude-opus-5",
-          fallbackProfile: "unroutable-backup",
-          maxTokens: 1024,
-        },
-        // Named on the managed connection, so the connection guard lets it
-        // through, but `openrouter` is not a managed-routable upstream.
-        "unroutable-backup": {
-          source: "user",
-          provider: "openrouter",
-          provider_connection: "vellum",
-          model: "claude-sonnet-5",
-          maxTokens: 2048,
-        },
-      },
-      activeProfile: "unroutable-primary",
-    });
-    anthropicMode = "retired";
-
-    const provider = createAdapterFromConnection(
-      vellumConnection,
-      managedAuth(ANTHROPIC_PATH),
-      {
-        model: "claude-opus-5",
-        provider: "anthropic",
-        streamTimeoutMs: 30_000,
-      },
-    );
-    expect(provider).not.toBeNull();
-
-    const error = await provider!
-      .sendMessage(MESSAGES, { config: { callSite: "mainAgent" } })
-      .then(
-        () => null,
-        (err: unknown) => err,
-      );
-
-    expect(error).toBeInstanceOf(Error);
-    expect((error as { statusCode?: number }).statusCode).toBe(404);
-    const models = new Set(requests.map((r) => r.body.model));
-    expect(models).toEqual(new Set(["claude-opus-5"]));
-  });
-
-  test("a remembered outage skips the primary, and a probe restores it once it recovers", async () => {
-    // Both pins sit on the same upstream, which is what the breaker is keyed
-    // on: the point here is the route being skipped and probed, not the
-    // cross-provider hop the cases above cover.
-    setConfig("llm", {
-      profiles: {
-        "breaker-primary": {
-          source: "user",
-          provider: "vellum",
-          model: "claude-opus-5",
-          fallbackProfile: "breaker-backup",
-          maxTokens: 1024,
-        },
-        "breaker-backup": {
-          source: "user",
-          provider: "vellum",
-          model: "claude-sonnet-5",
-          maxTokens: 2048,
-        },
-      },
-      activeProfile: "breaker-primary",
-    });
-    retiredModels.add("claude-opus-5");
-
-    const provider = createAdapterFromConnection(
-      vellumConnection,
-      managedAuth(ANTHROPIC_PATH),
-      {
-        model: "claude-opus-5",
-        provider: "anthropic",
-        streamTimeoutMs: 30_000,
-      },
-    );
-    expect(provider).not.toBeNull();
-
-    // The first request discovers the outage the expensive way and escalates.
-    const first: ProviderResponse = await provider!.sendMessage(MESSAGES, {
-      config: { callSite: "mainAgent" },
-    });
-    expect(first.actualInferenceProfile).toBe("breaker-backup");
-    expect(requests.map((r) => r.body.model)).toEqual([
-      "claude-opus-5",
-      "claude-sonnet-5",
-    ]);
-    // A retired pin is remembered for that model, not for the upstream, so the
-    // backup's own model on the same upstream stays available.
-    expect(shouldSkipPrimary(RETIRED_ROUTE)).toBe(true);
-    expect(
-      shouldSkipPrimary({ upstream: "anthropic", model: "claude-sonnet-5" }),
-    ).toBe(false);
-
-    // The second request reaches the backup without touching the dead pin.
     requests.length = 0;
-    const second: ProviderResponse = await provider!.sendMessage(MESSAGES, {
-      config: { callSite: "mainAgent" },
-    });
-    expect(second.actualInferenceProfile).toBe("breaker-backup");
-    expect(requests.map((r) => r.body.model)).toEqual(["claude-sonnet-5"]);
-
-    // The upstream recovers and the cooldown elapses: re-trip the breaker at a
-    // timestamp older than the longest cooldown it can pick, which is how a
-    // process that has been degraded for a while looks.
-    retiredModels.clear();
-    resetFallbackBreaker();
-    recordFallbackServed(RETIRED_ROUTE, Date.now() - 11 * 60_000);
-    requests.length = 0;
-
-    const third: ProviderResponse = await provider!.sendMessage(MESSAGES, {
+    const response = await provider.sendMessage(MESSAGES, {
       config: { callSite: "mainAgent" },
     });
 
-    // The probe went to the primary pin, served, and closed the breaker.
-    expect(requests.map((r) => r.body.model)).toEqual(["claude-opus-5"]);
-    expect(third.actualInferenceProfile).toBeUndefined();
-    expect(shouldSkipPrimary(RETIRED_ROUTE)).toBe(false);
+    expect(requestsTo(OPENAI_PATH)).toHaveLength(0);
+    expect(requestsTo(ANTHROPIC_PATH)).toHaveLength(1);
+    expect(response.actualInferenceProfile).toBe("quality-optimized-backup");
   });
 });

--- a/assistant/src/__tests__/managed-profile-guard.test.ts
+++ b/assistant/src/__tests__/managed-profile-guard.test.ts
@@ -286,6 +286,34 @@ describe("PUT /v1/config/llm/profiles/:name — managed profile guard", () => {
     expectNothingCommitted();
   });
 
+  test("PUT on a managed backup profile is rejected as code-owned", async () => {
+    // Backups are code-owned too, and they carry no on-disk entry, so the
+    // code-owned rejection has to win over the availability gate: reporting
+    // "not currently available" would be wrong for a profile the picker
+    // lists and the user can select.
+    seedRawConfig({ llm: { profiles: {} } });
+
+    for (const name of [
+      "balanced-backup",
+      "quality-optimized-backup",
+      "cost-optimized-backup",
+      "latency-optimized-backup",
+    ]) {
+      for (const body of [
+        { label: "Zippy" },
+        { status: "active" as const },
+        { status: null },
+      ]) {
+        await expect(
+          replaceRoute.handler({ pathParams: { name }, body }),
+        ).rejects.toThrow(
+          `Profile "${name}" is code-owned and cannot be edited.`,
+        );
+      }
+    }
+    expectNothingCommitted();
+  });
+
   test("PUT { status: null } on managed profile clears status (back to active-by-absence)", async () => {
     seedRawConfig({
       llm: {

--- a/assistant/src/__tests__/plugin-api-model-profiles.test.ts
+++ b/assistant/src/__tests__/plugin-api-model-profiles.test.ts
@@ -64,12 +64,8 @@ describe("getModelProfiles", () => {
       "balanced",
       "cost-optimized",
       "alpha",
-      "balanced-backup",
-      "cost-optimized-backup",
       "latency-optimized",
-      "latency-optimized-backup",
       "quality-optimized",
-      "quality-optimized-backup",
       "zeta",
     ]);
   });
@@ -99,13 +95,9 @@ describe("getModelProfiles", () => {
       ["beta", false],
       ["blend", true],
       ["balanced", false],
-      ["balanced-backup", false],
       ["cost-optimized", false],
-      ["cost-optimized-backup", false],
       ["latency-optimized", false],
-      ["latency-optimized-backup", false],
       ["quality-optimized", false],
-      ["quality-optimized-backup", false],
     ]);
   });
 
@@ -153,13 +145,9 @@ describe("getModelProfiles", () => {
       ["alpha", false],
       ["beta", true],
       ["balanced", false],
-      ["balanced-backup", false],
       ["cost-optimized", false],
-      ["cost-optimized-backup", false],
       ["latency-optimized", false],
-      ["latency-optimized-backup", false],
       ["quality-optimized", false],
-      ["quality-optimized-backup", false],
     ]);
   });
 
@@ -202,13 +190,9 @@ describe("getModelProfiles", () => {
       ["alpha", false],
       ["beta", true],
       ["balanced", false],
-      ["balanced-backup", false],
       ["cost-optimized", false],
-      ["cost-optimized-backup", false],
       ["latency-optimized", false],
-      ["latency-optimized-backup", false],
       ["quality-optimized", false],
-      ["quality-optimized-backup", false],
     ]);
   });
 
@@ -246,13 +230,9 @@ describe("getModelProfiles", () => {
         .sort(),
     ).toEqual([
       "balanced",
-      "balanced-backup",
       "cost-optimized",
-      "cost-optimized-backup",
       "latency-optimized",
-      "latency-optimized-backup",
       "quality-optimized",
-      "quality-optimized-backup",
     ]);
   });
 });

--- a/assistant/src/__tests__/plugin-api-model-profiles.test.ts
+++ b/assistant/src/__tests__/plugin-api-model-profiles.test.ts
@@ -64,8 +64,12 @@ describe("getModelProfiles", () => {
       "balanced",
       "cost-optimized",
       "alpha",
+      "balanced-backup",
+      "cost-optimized-backup",
       "latency-optimized",
+      "latency-optimized-backup",
       "quality-optimized",
+      "quality-optimized-backup",
       "zeta",
     ]);
   });
@@ -95,9 +99,13 @@ describe("getModelProfiles", () => {
       ["beta", false],
       ["blend", true],
       ["balanced", false],
+      ["balanced-backup", false],
       ["cost-optimized", false],
+      ["cost-optimized-backup", false],
       ["latency-optimized", false],
+      ["latency-optimized-backup", false],
       ["quality-optimized", false],
+      ["quality-optimized-backup", false],
     ]);
   });
 
@@ -145,9 +153,13 @@ describe("getModelProfiles", () => {
       ["alpha", false],
       ["beta", true],
       ["balanced", false],
+      ["balanced-backup", false],
       ["cost-optimized", false],
+      ["cost-optimized-backup", false],
       ["latency-optimized", false],
+      ["latency-optimized-backup", false],
       ["quality-optimized", false],
+      ["quality-optimized-backup", false],
     ]);
   });
 
@@ -190,9 +202,13 @@ describe("getModelProfiles", () => {
       ["alpha", false],
       ["beta", true],
       ["balanced", false],
+      ["balanced-backup", false],
       ["cost-optimized", false],
+      ["cost-optimized-backup", false],
       ["latency-optimized", false],
+      ["latency-optimized-backup", false],
       ["quality-optimized", false],
+      ["quality-optimized-backup", false],
     ]);
   });
 
@@ -230,9 +246,13 @@ describe("getModelProfiles", () => {
         .sort(),
     ).toEqual([
       "balanced",
+      "balanced-backup",
       "cost-optimized",
+      "cost-optimized-backup",
       "latency-optimized",
+      "latency-optimized-backup",
       "quality-optimized",
+      "quality-optimized-backup",
     ]);
   });
 });

--- a/assistant/src/__tests__/provider-usage-tracking.test.ts
+++ b/assistant/src/__tests__/provider-usage-tracking.test.ts
@@ -164,6 +164,62 @@ describe("UsageTrackingProvider", () => {
     });
   });
 
+  test("attributes a fallback-served response to the stamped backup profile", async () => {
+    // RetryProvider's fallback escalation stamps `actualProvider` and
+    // `actualInferenceProfile` on the response it serves from the backup
+    // route. The usage event must follow those stamps, not the original
+    // request options, which still carry the failed primary's resolution.
+    setLlmConfig({
+      profiles: {
+        balanced: {
+          provider: "openai",
+          model: "gpt-5.4-mini",
+        },
+        "backup-profile": {
+          provider: "anthropic",
+          model: "claude-sonnet-4-5",
+        },
+      },
+      activeProfile: "balanced",
+      callSites: {
+        conversationTitle: { profile: "balanced" },
+      },
+      pricingOverrides: [],
+    });
+
+    const provider = new UsageTrackingProvider(
+      makeProvider({
+        content: [{ type: "text", text: "Title" }],
+        model: "claude-sonnet-4-5",
+        actualProvider: "anthropic",
+        actualInferenceProfile: "backup-profile",
+        usage: {
+          inputTokens: 1_000,
+          outputTokens: 2_000,
+        },
+        stopReason: "end_turn",
+      }),
+    );
+
+    await provider.sendMessage(
+      [{ role: "user", content: [{ type: "text", text: "Summarize" }] }],
+      {
+        config: {
+          callSite: "conversationTitle",
+        },
+      },
+    );
+
+    const events = listUsageEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      provider: "anthropic",
+      model: "claude-sonnet-4-5",
+      callSite: "conversationTitle",
+      inferenceProfile: "backup-profile",
+    });
+  });
+
   test("does not record calls without a call site", async () => {
     const provider = new UsageTrackingProvider(
       makeProvider({

--- a/assistant/src/__tests__/retry-fallback-escalation.test.ts
+++ b/assistant/src/__tests__/retry-fallback-escalation.test.ts
@@ -9,7 +9,10 @@ mock.module("../util/retry.js", () => ({
   sleep: async () => {},
 }));
 
-import { resetFallbackBreaker } from "../providers/fallback-breaker.js";
+import {
+  recordFallbackServed,
+  resetFallbackBreaker,
+} from "../providers/fallback-breaker.js";
 import type {
   Message,
   Provider,
@@ -428,29 +431,67 @@ describe("RetryProvider fallback-route escalation", () => {
     expect(route.calls()).toBe(0);
   });
 
-  test("explicit config.model pin + outage-shaped error → callback never invoked, original error rethrown", async () => {
-    // Per-conversation `modelOverride` is a live feature; a pinned
-    // conversation keeps today's retry-then-error behavior. The fallback
-    // must never silently serve a different model against an explicit pin.
-    const finalError = new ProviderError("Service Unavailable", "openai", 503);
-    const primary = failingProvider("openai", () => finalError);
-    const route = makeRoute(backupProvider().provider);
-    const wrapped = new RetryProvider(primary.provider, {
-      resolveFallbackRoute: route.resolveFallbackRoute,
-    });
+  test.each([
+    ["model", "pinned-model"],
+    ["provider", "openai"],
+    ["provider_connection", "vellum"],
+  ] as const)(
+    "explicit config.%s pin + outage-shaped error → callback never invoked, original error rethrown",
+    async (field, value) => {
+      const finalError = new ProviderError(
+        "Service Unavailable",
+        "openai",
+        503,
+      );
+      const primary = failingProvider("openai", () => finalError);
+      const route = makeRoute(backupProvider().provider);
+      const wrapped = new RetryProvider(primary.provider, {
+        resolveFallbackRoute: route.resolveFallbackRoute,
+      });
 
-    const thrown = await captureError(
-      wrapped.sendMessage(MESSAGES, {
-        config: { callSite: "mainAgent", model: "pinned-model" },
-      }),
-    );
+      const thrown = await captureError(
+        wrapped.sendMessage(MESSAGES, {
+          config: { callSite: "mainAgent", [field]: value },
+        }),
+      );
 
-    expect(thrown).toBe(finalError);
-    expect(route.calls()).toBe(0);
-    expect((thrown as { retriesExhausted?: boolean }).retriesExhausted).toBe(
-      true,
-    );
-  });
+      expect(thrown).toBe(finalError);
+      expect(route.calls()).toBe(0);
+      expect((thrown as { retriesExhausted?: boolean }).retriesExhausted).toBe(
+        true,
+      );
+    },
+  );
+
+  test.each([
+    ["model", "pinned-model"],
+    ["provider", "openai"],
+  ] as const)(
+    "persisted call-site %s pin + outage-shaped error → callback never invoked",
+    async (field, value) => {
+      setConfig("llm", {
+        ...LLM_FIXTURE,
+        callSites: { mainAgent: { [field]: value } },
+      });
+      const finalError = new ProviderError(
+        "Service Unavailable",
+        "openai",
+        503,
+      );
+      const primary = failingProvider("openai", () => finalError);
+      const route = makeRoute(backupProvider().provider);
+      const wrapped = new RetryProvider(primary.provider, {
+        resolveFallbackRoute: route.resolveFallbackRoute,
+      });
+
+      const thrown = await captureError(
+        wrapped.sendMessage(MESSAGES, { config: { callSite: "mainAgent" } }),
+      );
+
+      expect(thrown).toBe(finalError);
+      expect(route.calls()).toBe(0);
+    },
+  );
 
   test("callback returns null (no fallbackProfile) → original error rethrown with retriesExhausted tagging", async () => {
     const finalError = new ProviderError("Service Unavailable", "openai", 503);
@@ -580,7 +621,7 @@ describe("RetryProvider fallback-route escalation", () => {
     expect(backup.calls()).toBe(0);
   });
 
-  test("backup also fails → fallback error rethrown with original as cause, no second fallback attempt", async () => {
+  test("backup also fails → original error is preserved, no second fallback attempt", async () => {
     const originalError = new ProviderError("model not found", "openai", 404);
     const primary = failingProvider("openai", () => originalError);
     const fallbackError = new ProviderError("backup down", "anthropic", 500);
@@ -594,8 +635,33 @@ describe("RetryProvider fallback-route escalation", () => {
       wrapped.sendMessage(MESSAGES, { config: { callSite: "mainAgent" } }),
     );
 
-    expect(thrown).toBe(fallbackError);
-    expect((thrown as Error).cause).toBe(originalError);
+    expect(thrown).toBe(originalError);
+    expect((thrown as Error).cause).toBeUndefined();
+    expect(route.calls()).toBe(1);
+    expect(backup.calls()).toBe(1);
+  });
+
+  test("failed recovery probe and backup surface the probe error without retrying the primary", async () => {
+    const originalError = new ProviderError(
+      "Service Unavailable",
+      "openai",
+      503,
+    );
+    const primary = failingProvider("openai", () => originalError);
+    const backupError = new ProviderError("invalid request", "anthropic", 400);
+    const backup = failingProvider("anthropic", () => backupError);
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+    recordFallbackServed({ upstream: "openai" }, Date.now() - 11 * 60_000);
+
+    const thrown = await captureError(
+      wrapped.sendMessage(MESSAGES, { config: { callSite: "mainAgent" } }),
+    );
+
+    expect(thrown).toBe(originalError);
+    expect(primary.calls()).toBe(1);
     expect(route.calls()).toBe(1);
     expect(backup.calls()).toBe(1);
   });

--- a/assistant/src/__tests__/retry-fallback-escalation.test.ts
+++ b/assistant/src/__tests__/retry-fallback-escalation.test.ts
@@ -887,6 +887,119 @@ describe("RetryProvider fallback-route escalation", () => {
     expect(backup.seenToolNames()).toEqual(["read_file", "web_search"]);
   });
 
+  test("a tool-less call site loses the tool_choice paired with the sentinel", async () => {
+    // `AgentLoop` sets `tool_choice: { type: "auto" }` under the same condition
+    // that appends the sentinel, so a call site with no tools of its own sends
+    // the sentinel as its ONLY tool. Filtering it and leaving the tool_choice
+    // behind puts a choice with nothing to choose from on the wire, which
+    // Anthropic rejects outright: a recoverable outage would become a hard 400
+    // on the backup.
+    const primary = failingProvider(
+      "openai",
+      () => new ProviderError("model not found", "openai", 404),
+    );
+    const backup = backupProvider("gemini", { supportsNativeWebSearch: false });
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    await wrapped.sendMessage(MESSAGES, {
+      config: {
+        callSite: "mainAgent",
+        nativeWebSearchSentinel: true,
+        tool_choice: { type: "auto" },
+      },
+      tools: [
+        {
+          name: "web_search",
+          description: "d",
+          input_schema: { type: "object" },
+        },
+      ],
+    });
+
+    expect(backup.calls()).toBe(1);
+    expect(backup.seenToolNames()).toEqual([]);
+    expect(backup.seenConfig().tool_choice).toBeUndefined();
+  });
+
+  test("a tool_choice survives the fallback whenever a tool is left to choose", async () => {
+    // The rule is deliberately narrow. A conversation-level `toolChoice` takes
+    // precedence over the sentinel's `auto` in `AgentLoop`, so it is caller
+    // intent a route change must not quietly discard, and the request it
+    // produces is valid on every wire.
+    const primary = failingProvider(
+      "openai",
+      () => new ProviderError("model not found", "openai", 404),
+    );
+    const backup = backupProvider("gemini", { supportsNativeWebSearch: false });
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    await wrapped.sendMessage(MESSAGES, {
+      config: {
+        callSite: "mainAgent",
+        nativeWebSearchSentinel: true,
+        tool_choice: { type: "tool", name: "read_file" },
+      },
+      tools: [
+        {
+          name: "read_file",
+          description: "d",
+          input_schema: { type: "object" },
+        },
+        {
+          name: "web_search",
+          description: "d",
+          input_schema: { type: "object" },
+        },
+      ],
+    });
+
+    expect(backup.seenToolNames()).toEqual(["read_file"]);
+    expect(backup.seenConfig().tool_choice).toEqual({
+      type: "tool",
+      name: "read_file",
+    });
+  });
+
+  test("a tool_choice survives when the sentinel was never filtered", async () => {
+    // A backup that serves native search keeps the whole list, so nothing about
+    // the caller's config changes either.
+    const primary = failingProvider(
+      "openai",
+      () => new ProviderError("model not found", "openai", 404),
+    );
+    const backup = backupProvider("anthropic", {
+      supportsNativeWebSearch: true,
+    });
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    await wrapped.sendMessage(MESSAGES, {
+      config: {
+        callSite: "mainAgent",
+        nativeWebSearchSentinel: true,
+        tool_choice: { type: "auto" },
+      },
+      tools: [
+        {
+          name: "web_search",
+          description: "d",
+          input_schema: { type: "object" },
+        },
+      ],
+    });
+
+    expect(backup.seenToolNames()).toEqual(["web_search"]);
+    expect(backup.seenConfig().tool_choice).toEqual({ type: "auto" });
+  });
+
   test("the sentinel marker never reaches the provider wire config", async () => {
     const primary = failingProvider(
       "openai",

--- a/assistant/src/__tests__/retry-fallback-escalation.test.ts
+++ b/assistant/src/__tests__/retry-fallback-escalation.test.ts
@@ -9,6 +9,7 @@ mock.module("../util/retry.js", () => ({
   sleep: async () => {},
 }));
 
+import { resetFallbackBreaker } from "../providers/fallback-breaker.js";
 import type {
   Message,
   Provider,
@@ -51,6 +52,9 @@ const LLM_FIXTURE = {
 
 beforeEach(() => {
   setConfig("llm", LLM_FIXTURE);
+  // The circuit breaker remembers a served fallback for the whole process, so
+  // a case that escalates would otherwise make the next case skip its primary.
+  resetFallbackBreaker();
 });
 
 function okResponse(model: string): ProviderResponse {

--- a/assistant/src/__tests__/retry-fallback-escalation.test.ts
+++ b/assistant/src/__tests__/retry-fallback-escalation.test.ts
@@ -79,15 +79,22 @@ function failingProvider(
 }
 
 /** Backup stub that records the options it was sent and serves a response. */
-function backupProvider(name = "anthropic"): {
+function backupProvider(
+  name = "anthropic",
+  opts: { supportsNativeWebSearch?: boolean } = {},
+): {
   provider: Provider;
   calls: () => number;
   seenConfig: () => Record<string, unknown>;
+  seenToolNames: () => string[];
 } {
   let calls = 0;
   let seen: SendMessageOptions | undefined;
   const provider: Provider = {
     name,
+    ...(opts.supportsNativeWebSearch === undefined
+      ? {}
+      : { supportsNativeWebSearch: opts.supportsNativeWebSearch }),
     sendMessage: async (_messages: Message[], options?: SendMessageOptions) => {
       calls += 1;
       seen = options;
@@ -99,6 +106,7 @@ function backupProvider(name = "anthropic"): {
     provider,
     calls: () => calls,
     seenConfig: () => (seen?.config ?? {}) as Record<string, unknown>,
+    seenToolNames: () => (seen?.tools ?? []).map((tool) => tool.name),
   };
 }
 
@@ -773,5 +781,130 @@ describe("RetryProvider fallback-route escalation", () => {
     });
 
     expect(result.actualInferenceProfile).toBe("inner-specific-profile");
+  });
+
+  test("native web search sentinel is dropped when the backup cannot serve it", async () => {
+    // The caller appended the sentinel from the PRIMARY route's capability, so
+    // a backup without server-side search would answer with a tool call
+    // nothing can execute. Degraded mode loses native search, not the turn.
+    const primary = failingProvider(
+      "openai",
+      () => new ProviderError("model not found", "openai", 404),
+    );
+    const backup = backupProvider("gemini", { supportsNativeWebSearch: false });
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    await wrapped.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent", nativeWebSearchSentinel: true },
+      tools: [
+        {
+          name: "read_file",
+          description: "d",
+          input_schema: { type: "object" },
+        },
+        {
+          name: "web_search",
+          description: "d",
+          input_schema: { type: "object" },
+        },
+      ],
+    });
+
+    expect(backup.calls()).toBe(1);
+    expect(backup.seenToolNames()).toEqual(["read_file"]);
+  });
+
+  test("native web search sentinel survives when the backup serves it too", async () => {
+    const primary = failingProvider(
+      "openai",
+      () => new ProviderError("model not found", "openai", 404),
+    );
+    const backup = backupProvider("anthropic", {
+      supportsNativeWebSearch: true,
+    });
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    await wrapped.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent", nativeWebSearchSentinel: true },
+      tools: [
+        {
+          name: "read_file",
+          description: "d",
+          input_schema: { type: "object" },
+        },
+        {
+          name: "web_search",
+          description: "d",
+          input_schema: { type: "object" },
+        },
+      ],
+    });
+
+    expect(backup.seenToolNames()).toEqual(["read_file", "web_search"]);
+  });
+
+  test("an app-executed web_search tool survives the fallback untouched", async () => {
+    // With a search backend such as Brave or the platform search proxy, the
+    // daemon executes `web_search` itself and the caller sets no sentinel
+    // marker. Filtering it by name would strip a capability the backup can
+    // still serve, so the tool list has to carry over unchanged.
+    const primary = failingProvider(
+      "openai",
+      () => new ProviderError("model not found", "openai", 404),
+    );
+    const backup = backupProvider("gemini", { supportsNativeWebSearch: false });
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    await wrapped.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+      tools: [
+        {
+          name: "read_file",
+          description: "d",
+          input_schema: { type: "object" },
+        },
+        {
+          name: "web_search",
+          description: "d",
+          input_schema: { type: "object" },
+        },
+      ],
+    });
+
+    expect(backup.seenToolNames()).toEqual(["read_file", "web_search"]);
+  });
+
+  test("the sentinel marker never reaches the provider wire config", async () => {
+    const primary = failingProvider(
+      "openai",
+      () => new ProviderError("model not found", "openai", 404),
+    );
+    const backup = backupProvider("gemini", { supportsNativeWebSearch: false });
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    await wrapped.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent", nativeWebSearchSentinel: true },
+      tools: [
+        {
+          name: "web_search",
+          description: "d",
+          input_schema: { type: "object" },
+        },
+      ],
+    });
+
+    expect(backup.seenConfig().nativeWebSearchSentinel).toBeUndefined();
   });
 });

--- a/assistant/src/__tests__/retry-fallback-escalation.test.ts
+++ b/assistant/src/__tests__/retry-fallback-escalation.test.ts
@@ -1,0 +1,777 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import * as retryUtil from "../util/retry.js";
+
+// Instant sleep so exhausted-retry cases don't wait out real backoff delays;
+// everything else is the real module.
+mock.module("../util/retry.js", () => ({
+  ...retryUtil,
+  sleep: async () => {},
+}));
+
+import type {
+  Message,
+  Provider,
+  ProviderResponse,
+  SendMessageOptions,
+} from "../providers/types.js";
+import { setConfig } from "./helpers/set-config.js";
+
+const { RetryProvider } = await import("../providers/retry.js");
+const { ContextOverflowError } = await import("../providers/types.js");
+const { ProviderError } = await import("../util/errors.js");
+const { DEFAULT_MAX_RETRIES } = await import("../util/retry.js");
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+
+const MESSAGES: Message[] = [
+  { role: "user", content: [{ type: "text", text: "hi" }] },
+];
+
+// Primary route resolves through the active profile; the fallback forces the
+// backup profile via `overrideProfile` + `forceOverrideProfile`, so the
+// backup's model/maxTokens must win on the re-normalized options.
+const LLM_FIXTURE = {
+  profiles: {
+    "primary-profile": {
+      source: "user",
+      provider: "openai",
+      model: "primary-model",
+      maxTokens: 1111,
+    },
+    "backup-profile": {
+      source: "user",
+      provider: "anthropic",
+      model: "backup-model",
+      maxTokens: 2222,
+    },
+  },
+  activeProfile: "primary-profile",
+};
+
+beforeEach(() => {
+  setConfig("llm", LLM_FIXTURE);
+});
+
+function okResponse(model: string): ProviderResponse {
+  return {
+    content: [{ type: "text", text: "ok" }],
+    model,
+    usage: { inputTokens: 1, outputTokens: 1 },
+    stopReason: "end_turn",
+  } as ProviderResponse;
+}
+
+/** Primary stub that always throws `makeError()`. */
+function failingProvider(
+  name: string,
+  makeError: () => unknown,
+): { provider: Provider; calls: () => number } {
+  let calls = 0;
+  const provider: Provider = {
+    name,
+    sendMessage: async () => {
+      calls += 1;
+      throw makeError();
+    },
+  };
+  return { provider, calls: () => calls };
+}
+
+/** Backup stub that records the options it was sent and serves a response. */
+function backupProvider(name = "anthropic"): {
+  provider: Provider;
+  calls: () => number;
+  seenConfig: () => Record<string, unknown>;
+} {
+  let calls = 0;
+  let seen: SendMessageOptions | undefined;
+  const provider: Provider = {
+    name,
+    sendMessage: async (_messages: Message[], options?: SendMessageOptions) => {
+      calls += 1;
+      seen = options;
+      const config = options?.config as Record<string, unknown> | undefined;
+      return okResponse((config?.model as string | undefined) ?? "unresolved");
+    },
+  };
+  return {
+    provider,
+    calls: () => calls,
+    seenConfig: () => (seen?.config ?? {}) as Record<string, unknown>,
+  };
+}
+
+function makeRoute(
+  provider: Provider,
+  {
+    overrideProfile = "backup-profile",
+    forwardUsageAttributionHeaders = true,
+  }: {
+    overrideProfile?: string;
+    forwardUsageAttributionHeaders?: boolean;
+  } = {},
+): {
+  resolveFallbackRoute: (
+    failedOptions: SendMessageOptions | undefined,
+  ) => Promise<{
+    provider: Provider;
+    overrideProfile: string;
+    forwardUsageAttributionHeaders: boolean;
+  } | null>;
+  calls: () => number;
+} {
+  let calls = 0;
+  return {
+    resolveFallbackRoute: async () => {
+      calls += 1;
+      return { provider, overrideProfile, forwardUsageAttributionHeaders };
+    },
+    calls: () => calls,
+  };
+}
+
+async function captureError(promise: Promise<unknown>): Promise<unknown> {
+  try {
+    await promise;
+  } catch (error) {
+    return error;
+  }
+  throw new Error("expected the promise to reject");
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe("RetryProvider fallback-route escalation", () => {
+  test("retries exhaust on 503 → callback invoked once, backup serves, headers restamped", async () => {
+    const primary = failingProvider(
+      "openai",
+      () => new ProviderError("Service Unavailable", "openai", 503),
+    );
+    const backup = backupProvider();
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      forwardUsageAttributionHeaders: true,
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    const result = await wrapped.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    // Full retry budget burned on the primary before escalating.
+    expect(primary.calls()).toBe(1 + DEFAULT_MAX_RETRIES);
+    expect(route.calls()).toBe(1);
+    expect(backup.calls()).toBe(1);
+    expect(result.model).toBe("backup-model");
+
+    // The re-normalized options carry the backup profile's resolved values...
+    const config = backup.seenConfig();
+    expect(config.model).toBe("backup-model");
+    expect(config.max_tokens).toBe(2222);
+    // ...with routing keys stripped before the fallback provider sees them.
+    expect(config.callSite).toBeUndefined();
+    expect(config.overrideProfile).toBeUndefined();
+    expect(config.forceOverrideProfile).toBeUndefined();
+    // Usage-attribution headers come from the backup resolution so platform
+    // usage events attribute degraded traffic to the backup profile.
+    const headers = config.usageAttributionHeaders as Record<string, string>;
+    expect(headers["X-Vellum-Inference-Profile"]).toBe("backup-profile");
+    expect(headers["X-Vellum-Resolved-Model"]).toBe("backup-model");
+    expect(headers["X-Vellum-Resolved-Provider"]).toBe("anthropic");
+  });
+
+  test("401 invalid_credentials after refresh fails → falls back without burning the retry budget", async () => {
+    const primary = failingProvider(
+      "openai",
+      () =>
+        new ProviderError("Unauthorized", "openai", 401, {
+          reason: "invalid_credentials",
+        }),
+    );
+    const backup = backupProvider();
+    const route = makeRoute(backup.provider);
+    let refreshCalls = 0;
+    const wrapped = new RetryProvider(primary.provider, {
+      credentialSource: "vellum-managed",
+      refreshCredentialProvider: async () => {
+        refreshCalls += 1;
+        return null;
+      },
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    const result = await wrapped.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    // The existing credential-refresh path ran first; the 401 is
+    // non-retryable, so the primary was attempted exactly once.
+    expect(refreshCalls).toBe(1);
+    expect(primary.calls()).toBe(1);
+    expect(route.calls()).toBe(1);
+    expect(result.model).toBe("backup-model");
+  });
+
+  test.each(["byok", "oauth-subscription", "no-auth", undefined] as const)(
+    "401 invalid_credentials on a %s route → callback never invoked, auth error surfaces",
+    async (credentialSource) => {
+      // The credential eligibility case is restricted to `vellum-managed`
+      // routes. A broken personal credential must surface so the user can
+      // fix it, not silently reroute to a differently billed backup.
+      const authError = new ProviderError("Unauthorized", "openai", 401, {
+        reason: "invalid_credentials",
+      });
+      const primary = failingProvider("openai", () => authError);
+      const route = makeRoute(backupProvider().provider);
+      const wrapped = new RetryProvider(primary.provider, {
+        ...(credentialSource !== undefined ? { credentialSource } : {}),
+        resolveFallbackRoute: route.resolveFallbackRoute,
+      });
+
+      const thrown = await captureError(
+        wrapped.sendMessage(MESSAGES, { config: { callSite: "mainAgent" } }),
+      );
+
+      expect(thrown).toBe(authError);
+      expect(primary.calls()).toBe(1);
+      expect(route.calls()).toBe(0);
+    },
+  );
+
+  test("404 model-not-found (non-retryable) → falls back immediately", async () => {
+    const primary = failingProvider(
+      "openai",
+      () => new ProviderError("model not found", "openai", 404),
+    );
+    const backup = backupProvider();
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    const result = await wrapped.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    expect(primary.calls()).toBe(1);
+    expect(route.calls()).toBe(1);
+    expect(result.model).toBe("backup-model");
+  });
+
+  test.each(["unknown", undefined] as const)(
+    "404 with reason %s → status fallback applies, backup serves",
+    async (reason) => {
+      const primary = failingProvider(
+        "openai",
+        () =>
+          new ProviderError("not found", "openai", 404, {
+            ...(reason !== undefined ? { reason } : {}),
+          }),
+      );
+      const backup = backupProvider();
+      const route = makeRoute(backup.provider);
+      const wrapped = new RetryProvider(primary.provider, {
+        resolveFallbackRoute: route.resolveFallbackRoute,
+      });
+
+      const result = await wrapped.sendMessage(MESSAGES, {
+        config: { callSite: "mainAgent" },
+      });
+
+      expect(route.calls()).toBe(1);
+      expect(result.model).toBe("backup-model");
+    },
+  );
+
+  test("404 with provider-classified reason model_not_found → falls back immediately", async () => {
+    const primary = failingProvider(
+      "openai",
+      () =>
+        new ProviderError("model not found", "openai", 404, {
+          reason: "model_not_found",
+        }),
+    );
+    const backup = backupProvider();
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    const result = await wrapped.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    expect(primary.calls()).toBe(1);
+    expect(route.calls()).toBe(1);
+    expect(result.model).toBe("backup-model");
+  });
+
+  test("404 with a definitive non-model reason (bad_request) → callback never invoked", async () => {
+    // Anthropic classifies a 404 without a model signal as `bad_request`: a
+    // missing gateway resource or other deterministic request failure. The
+    // provider-stamped semantic reason takes precedence over the raw status,
+    // so the request must surface its real error instead of switching routes.
+    const requestError = new ProviderError("not found", "anthropic", 404, {
+      reason: "bad_request",
+    });
+    const primary = failingProvider("anthropic", () => requestError);
+    const route = makeRoute(backupProvider().provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    const thrown = await captureError(
+      wrapped.sendMessage(MESSAGES, { config: { callSite: "mainAgent" } }),
+    );
+
+    expect(thrown).toBe(requestError);
+    expect(primary.calls()).toBe(1);
+    expect(route.calls()).toBe(0);
+  });
+
+  test("managed proxy preflight 400 for a retired model → falls back immediately", async () => {
+    const primary = failingProvider(
+      "openai",
+      () =>
+        new ProviderError(
+          "Model 'gpt-old' is not yet supported on the Vellum hosted service.",
+          "openai",
+          400,
+        ),
+    );
+    const backup = backupProvider();
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    const result = await wrapped.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    expect(primary.calls()).toBe(1);
+    expect(route.calls()).toBe(1);
+    expect(result.model).toBe("backup-model");
+  });
+
+  test("plain 400 (request problem) → callback never invoked", async () => {
+    const primary = failingProvider(
+      "openai",
+      () => new ProviderError("invalid request", "openai", 400),
+    );
+    const route = makeRoute(backupProvider().provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    const thrown = await captureError(
+      wrapped.sendMessage(MESSAGES, { config: { callSite: "mainAgent" } }),
+    );
+
+    expect((thrown as InstanceType<typeof ProviderError>).statusCode).toBe(400);
+    expect(route.calls()).toBe(0);
+  });
+
+  test("context overflow → callback never invoked", async () => {
+    const primary = failingProvider(
+      "openai",
+      () => new ContextOverflowError("prompt too long", "openai"),
+    );
+    const route = makeRoute(backupProvider().provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    const thrown = await captureError(
+      wrapped.sendMessage(MESSAGES, { config: { callSite: "mainAgent" } }),
+    );
+
+    expect(thrown).toBeInstanceOf(ContextOverflowError);
+    expect(primary.calls()).toBe(1);
+    expect(route.calls()).toBe(0);
+  });
+
+  test("caller abort → callback never invoked", async () => {
+    const primary = failingProvider(
+      "openai",
+      () =>
+        new ProviderError("Request was aborted.", "openai", undefined, {
+          abortReason: "user_cancelled",
+        }),
+    );
+    const route = makeRoute(backupProvider().provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    const thrown = await captureError(
+      wrapped.sendMessage(MESSAGES, { config: { callSite: "mainAgent" } }),
+    );
+
+    expect((thrown as InstanceType<typeof ProviderError>).abortReason).toBe(
+      "user_cancelled",
+    );
+    expect(primary.calls()).toBe(1);
+    expect(route.calls()).toBe(0);
+  });
+
+  test("explicit config.model pin + outage-shaped error → callback never invoked, original error rethrown", async () => {
+    // Per-conversation `modelOverride` is a live feature; a pinned
+    // conversation keeps today's retry-then-error behavior. The fallback
+    // must never silently serve a different model against an explicit pin.
+    const finalError = new ProviderError("Service Unavailable", "openai", 503);
+    const primary = failingProvider("openai", () => finalError);
+    const route = makeRoute(backupProvider().provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    const thrown = await captureError(
+      wrapped.sendMessage(MESSAGES, {
+        config: { callSite: "mainAgent", model: "pinned-model" },
+      }),
+    );
+
+    expect(thrown).toBe(finalError);
+    expect(route.calls()).toBe(0);
+    expect((thrown as { retriesExhausted?: boolean }).retriesExhausted).toBe(
+      true,
+    );
+  });
+
+  test("callback returns null (no fallbackProfile) → original error rethrown with retriesExhausted tagging", async () => {
+    const finalError = new ProviderError("Service Unavailable", "openai", 503);
+    const primary = failingProvider("openai", () => finalError);
+    let routeCalls = 0;
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: async () => {
+        routeCalls += 1;
+        return null;
+      },
+    });
+
+    const thrown = await captureError(
+      wrapped.sendMessage(MESSAGES, { config: { callSite: "mainAgent" } }),
+    );
+
+    expect(routeCalls).toBe(1);
+    expect(thrown).toBe(finalError);
+    expect((thrown as { retriesExhausted?: boolean }).retriesExhausted).toBe(
+      true,
+    );
+  });
+
+  test("route returned for a disabled backup profile → no send on the backup adapter, original error rethrown", async () => {
+    // A disabled override profile is skipped by winner selection, which
+    // would resolve back to the primary profile while the request still
+    // dispatches on the backup adapter (provider/model mismatch). The guard
+    // must refuse the fallback send and surface the original error.
+    setConfig("llm", {
+      ...LLM_FIXTURE,
+      profiles: {
+        ...LLM_FIXTURE.profiles,
+        "backup-profile": {
+          ...LLM_FIXTURE.profiles["backup-profile"],
+          status: "disabled",
+        },
+      },
+    });
+    const originalError = new ProviderError("model not found", "openai", 404);
+    const primary = failingProvider("openai", () => originalError);
+    const backup = backupProvider();
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    const thrown = await captureError(
+      wrapped.sendMessage(MESSAGES, { config: { callSite: "mainAgent" } }),
+    );
+
+    expect(thrown).toBe(originalError);
+    expect(route.calls()).toBe(1);
+    expect(backup.calls()).toBe(0);
+  });
+
+  test("route returned for an incomplete backup profile (no model) → no send on the backup adapter, original error rethrown", async () => {
+    setConfig("llm", {
+      ...LLM_FIXTURE,
+      profiles: {
+        ...LLM_FIXTURE.profiles,
+        "backup-profile": {
+          source: "user",
+          provider: "anthropic",
+        },
+      },
+    });
+    const originalError = new ProviderError("model not found", "openai", 404);
+    const primary = failingProvider("openai", () => originalError);
+    const backup = backupProvider();
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    const thrown = await captureError(
+      wrapped.sendMessage(MESSAGES, { config: { callSite: "mainAgent" } }),
+    );
+
+    expect(thrown).toBe(originalError);
+    expect(route.calls()).toBe(1);
+    expect(backup.calls()).toBe(0);
+  });
+
+  test("route returned for a mix backup profile → no send on the backup adapter, original error rethrown", async () => {
+    // The fallback schema forbids `fallbackProfile` from referencing a mix,
+    // and RetryProvider must not trust that: a mix backup without a
+    // `selectionSeed` would be re-expanded independently by the apply guard,
+    // the route callback, and the normalization, potentially sending one
+    // arm's model through another arm's provider adapter.
+    setConfig("llm", {
+      profiles: {
+        ...LLM_FIXTURE.profiles,
+        "arm-a": {
+          source: "user",
+          provider: "anthropic",
+          model: "arm-a-model",
+        },
+        "arm-b": {
+          source: "user",
+          provider: "openai",
+          model: "arm-b-model",
+        },
+        "backup-mix": {
+          source: "user",
+          mix: [
+            { profile: "arm-a", weight: 1 },
+            { profile: "arm-b", weight: 1 },
+          ],
+        },
+      },
+      activeProfile: "primary-profile",
+    });
+    const originalError = new ProviderError("model not found", "openai", 404);
+    const primary = failingProvider("openai", () => originalError);
+    const backup = backupProvider();
+    const route = makeRoute(backup.provider, { overrideProfile: "backup-mix" });
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    const thrown = await captureError(
+      wrapped.sendMessage(MESSAGES, { config: { callSite: "mainAgent" } }),
+    );
+
+    expect(thrown).toBe(originalError);
+    expect(route.calls()).toBe(1);
+    expect(backup.calls()).toBe(0);
+  });
+
+  test("backup also fails → fallback error rethrown with original as cause, no second fallback attempt", async () => {
+    const originalError = new ProviderError("model not found", "openai", 404);
+    const primary = failingProvider("openai", () => originalError);
+    const fallbackError = new ProviderError("backup down", "anthropic", 500);
+    const backup = failingProvider("anthropic", () => fallbackError);
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    const thrown = await captureError(
+      wrapped.sendMessage(MESSAGES, { config: { callSite: "mainAgent" } }),
+    );
+
+    expect(thrown).toBe(fallbackError);
+    expect((thrown as Error).cause).toBe(originalError);
+    expect(route.calls()).toBe(1);
+    expect(backup.calls()).toBe(1);
+  });
+
+  test("resolveFallbackRoute unset → behavior unchanged (original error rethrown)", async () => {
+    const finalError = new ProviderError("Service Unavailable", "openai", 503);
+    const primary = failingProvider("openai", () => finalError);
+    const wrapped = new RetryProvider(primary.provider);
+
+    const thrown = await captureError(
+      wrapped.sendMessage(MESSAGES, { config: { callSite: "mainAgent" } }),
+    );
+
+    expect(thrown).toBe(finalError);
+    expect(primary.calls()).toBe(1 + DEFAULT_MAX_RETRIES);
+  });
+
+  test("explicit max_tokens/effort/thinking are cleared so the backup profile's values win", async () => {
+    const primary = failingProvider(
+      "openai",
+      () => new ProviderError("model not found", "openai", 404),
+    );
+    const backup = backupProvider();
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    await wrapped.sendMessage(MESSAGES, {
+      config: {
+        callSite: "mainAgent",
+        max_tokens: 42,
+        effort: "low",
+        thinking: { type: "disabled" },
+      },
+    });
+
+    const config = backup.seenConfig();
+    expect(config.model).toBe("backup-model");
+    // The explicit per-call cap was cleared; the backup profile's resolved
+    // maxTokens applies instead.
+    expect(config.max_tokens).toBe(2222);
+    expect(config.effort).not.toBe("low");
+  });
+
+  test("route with forwardUsageAttributionHeaders false → no X-Vellum-* headers reach the backup adapter, even when the primary forwards them", async () => {
+    // A managed primary (forwarding enabled) falling back to a BYOK or other
+    // third-party adapter must not leak billing metadata: the fallback
+    // normalization follows the ROUTE's policy, not the primary's.
+    const primary = failingProvider(
+      "openai",
+      () => new ProviderError("model not found", "openai", 404),
+    );
+    const backup = backupProvider();
+    const route = makeRoute(backup.provider, {
+      forwardUsageAttributionHeaders: false,
+    });
+    const wrapped = new RetryProvider(primary.provider, {
+      forwardUsageAttributionHeaders: true,
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    const result = await wrapped.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    expect(result.model).toBe("backup-model");
+    expect(backup.seenConfig().usageAttributionHeaders).toBeUndefined();
+  });
+
+  test("route with forwardUsageAttributionHeaders true → headers present and reflect the backup profile, even when the primary does not forward them", async () => {
+    // A non-managed primary (forwarding disabled) falling back to the
+    // managed proxy must include the required attribution headers.
+    const primary = failingProvider(
+      "openai",
+      () => new ProviderError("model not found", "openai", 404),
+    );
+    const backup = backupProvider();
+    const route = makeRoute(backup.provider, {
+      forwardUsageAttributionHeaders: true,
+    });
+    const wrapped = new RetryProvider(primary.provider, {
+      forwardUsageAttributionHeaders: false,
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    const result = await wrapped.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    expect(result.model).toBe("backup-model");
+    const headers = backup.seenConfig().usageAttributionHeaders as Record<
+      string,
+      string
+    >;
+    expect(headers["X-Vellum-Inference-Profile"]).toBe("backup-profile");
+    expect(headers["X-Vellum-Resolved-Model"]).toBe("backup-model");
+    expect(headers["X-Vellum-Resolved-Provider"]).toBe("anthropic");
+  });
+
+  test("fallback response without actualProvider → stamped with the backup provider's name", async () => {
+    // The outer call-site router attributes success by `actualProvider`;
+    // without the stamp it would record the fallback under the failed
+    // primary provider and apply the wrong pricing.
+    const primary = failingProvider(
+      "openai",
+      () => new ProviderError("model not found", "openai", 404),
+    );
+    const backup = backupProvider();
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    const result = await wrapped.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    expect(result.actualProvider).toBe("anthropic");
+  });
+
+  test("fallback response with adapter-set actualProvider → preserved, not overwritten", async () => {
+    const primary = failingProvider(
+      "openai",
+      () => new ProviderError("model not found", "openai", 404),
+    );
+    const backup: Provider = {
+      name: "anthropic",
+      sendMessage: async () => ({
+        ...okResponse("backup-model"),
+        actualProvider: "openrouter/anthropic",
+      }),
+    };
+    const route = makeRoute(backup);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    const result = await wrapped.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    expect(result.actualProvider).toBe("openrouter/anthropic");
+  });
+
+  test("fallback response → stamped with the backup profile key so usage tracking attributes it correctly", async () => {
+    // The outer UsageTrackingProvider resolves `inferenceProfile` from the
+    // ORIGINAL request options, which still carry the failed primary's
+    // resolution. The stamp is what lets the usage event bill the fallback
+    // serve under the backup profile.
+    const primary = failingProvider(
+      "openai",
+      () => new ProviderError("model not found", "openai", 404),
+    );
+    const backup = backupProvider();
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    const result = await wrapped.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    expect(result.actualInferenceProfile).toBe("backup-profile");
+  });
+
+  test("fallback response with a wrapper-set actualInferenceProfile → preserved, not overwritten", async () => {
+    const primary = failingProvider(
+      "openai",
+      () => new ProviderError("model not found", "openai", 404),
+    );
+    const backup: Provider = {
+      name: "anthropic",
+      sendMessage: async () => ({
+        ...okResponse("backup-model"),
+        actualInferenceProfile: "inner-specific-profile",
+      }),
+    };
+    const route = makeRoute(backup);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    const result = await wrapped.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+
+    expect(result.actualInferenceProfile).toBe("inner-specific-profile");
+  });
+});

--- a/assistant/src/__tests__/workspace-migration-147-rename-colliding-backup-profile-names.test.ts
+++ b/assistant/src/__tests__/workspace-migration-147-rename-colliding-backup-profile-names.test.ts
@@ -1,0 +1,476 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  BACKUP_PROFILE_KEYS,
+  DEFAULT_PROFILE_KEYS,
+} from "../config/default-profile-names.js";
+import { LLMSchema } from "../config/schemas/llm.js";
+import { renameCollidingBackupProfileNamesMigration } from "../workspace/migrations/147-rename-colliding-backup-profile-names.js";
+import { WORKSPACE_MIGRATIONS } from "../workspace/migrations/registry.js";
+import {
+  loadCheckpoints,
+  runWorkspaceMigrations,
+} from "../workspace/migrations/runner.js";
+import { assertNotLiveDb } from "./assert-not-live-db.js";
+
+let workspaceDir: string;
+
+function freshWorkspace(): void {
+  workspaceDir = join(
+    tmpdir(),
+    `vellum-migration-147-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(workspaceDir, { recursive: true });
+}
+
+function writeConfig(data: Record<string, unknown>): void {
+  writeFileSync(
+    join(workspaceDir, "config.json"),
+    JSON.stringify(data, null, 2) + "\n",
+  );
+}
+
+function readConfig(): Record<string, any> {
+  return JSON.parse(readFileSync(join(workspaceDir, "config.json"), "utf-8"));
+}
+
+function dbPath(): string {
+  return join(workspaceDir, "data", "db", "assistant.db");
+}
+
+function seedProfilePinTables(rows: {
+  conversations: string[];
+  cronJobs: string[];
+}): void {
+  mkdirSync(join(workspaceDir, "data", "db"), { recursive: true });
+  const db = new Database(join(workspaceDir, "data", "db", "assistant.db"));
+  db.run(
+    `CREATE TABLE conversations (id TEXT PRIMARY KEY, inference_profile TEXT)`,
+  );
+  db.run(
+    `CREATE TABLE cron_jobs (id TEXT PRIMARY KEY, inference_profile TEXT)`,
+  );
+  rows.conversations.forEach((profile, index) => {
+    db.query(
+      `INSERT INTO conversations (id, inference_profile) VALUES (?, ?)`,
+    ).run(`conv-${index}`, profile);
+  });
+  rows.cronJobs.forEach((profile, index) => {
+    db.query(`INSERT INTO cron_jobs (id, inference_profile) VALUES (?, ?)`).run(
+      `job-${index}`,
+      profile,
+    );
+  });
+  db.close();
+}
+
+function readPins(table: string): string[] {
+  const db = new Database(join(workspaceDir, "data", "db", "assistant.db"));
+  try {
+    return (
+      db
+        .query(`SELECT inference_profile AS p FROM ${table} ORDER BY id`)
+        .all() as Array<{ p: string }>
+    ).map((row) => row.p);
+  } finally {
+    db.close();
+  }
+}
+
+beforeEach(() => {
+  freshWorkspace();
+});
+
+afterEach(() => {
+  if (existsSync(workspaceDir)) {
+    assertNotLiveDb(workspaceDir);
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+describe("147-rename-colliding-backup-profile-names migration", () => {
+  test("has correct migration id and is registered", async () => {
+    expect(renameCollidingBackupProfileNamesMigration.id).toBe(
+      "147-rename-colliding-backup-profile-names",
+    );
+    expect(WORKSPACE_MIGRATIONS.map((m) => m.id)).toContain(
+      "147-rename-colliding-backup-profile-names",
+    );
+  });
+
+  test("renames a colliding user profile and rewrites every reference", async () => {
+    writeConfig({
+      llm: {
+        defaultProvider: { provider: "vellum" },
+        profiles: {
+          "balanced-backup": {
+            source: "user",
+            provider: "anthropic",
+            model: "claude-opus-4-7",
+            label: "My Backup",
+          },
+          scratch: { source: "user", fallbackProfile: "balanced-backup" },
+          armA: { source: "user", speed: "fast" },
+          blend: {
+            source: "user",
+            mix: [
+              { profile: "balanced-backup", weight: 1 },
+              { profile: "armA", weight: 1 },
+            ],
+          },
+        },
+        profileOrder: ["balanced", "balanced-backup", "blend"],
+        activeProfile: "balanced-backup",
+        advisorProfile: "balanced-backup",
+        callSites: { recall: { profile: "balanced-backup", maxTokens: 4096 } },
+      },
+    });
+
+    await renameCollidingBackupProfileNamesMigration.run(workspaceDir);
+
+    const llm = readConfig().llm;
+    expect(llm.profiles["balanced-backup"]).toBeUndefined();
+    expect(llm.profiles["balanced-backup-custom"]).toEqual({
+      source: "user",
+      provider: "anthropic",
+      model: "claude-opus-4-7",
+      label: "My Backup",
+    });
+    expect(llm.activeProfile).toBe("balanced-backup-custom");
+    expect(llm.advisorProfile).toBe("balanced-backup-custom");
+    expect(llm.callSites.recall.profile).toBe("balanced-backup-custom");
+    expect(llm.callSites.recall.maxTokens).toBe(4096);
+    expect(llm.profiles.scratch.fallbackProfile).toBe("balanced-backup-custom");
+    expect(llm.profiles.blend.mix[0].profile).toBe("balanced-backup-custom");
+    expect(llm.profiles.blend.mix[1].profile).toBe("armA");
+    expect(llm.profileOrder).toEqual([
+      "balanced",
+      "balanced-backup-custom",
+      "blend",
+    ]);
+  });
+
+  test("the code-owned backup is available under the reserved name afterwards", async () => {
+    writeConfig({
+      llm: {
+        defaultProvider: { provider: "vellum" },
+        profiles: {
+          "balanced-backup": {
+            source: "user",
+            provider: "anthropic",
+            model: "claude-opus-4-7",
+          },
+        },
+        activeProfile: "balanced-backup",
+      },
+    });
+
+    await renameCollidingBackupProfileNamesMigration.run(workspaceDir);
+
+    const llm = readConfig().llm;
+    // The reserved key is free, so it resolves to the code-owned backup body
+    // rather than the user's profile, and the user's selection still points
+    // at their own profile.
+    expect(llm.profiles["balanced-backup"]).toBeUndefined();
+    expect(llm.activeProfile).toBe("balanced-backup-custom");
+    // A reference to the now-free reserved key remains valid on the managed
+    // column, which is what the schema's always-available set encodes.
+    const parsed = LLMSchema.safeParse({
+      ...llm,
+      activeProfile: "balanced-backup",
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  test("the migrated config parses under LLMSchema", async () => {
+    writeConfig({
+      llm: {
+        defaultProvider: { provider: "vellum" },
+        profiles: {
+          "cost-optimized-backup": {
+            source: "user",
+            provider: "anthropic",
+            model: "claude-opus-4-7",
+          },
+          scratch: {
+            source: "user",
+            fallbackProfile: "cost-optimized-backup",
+          },
+        },
+        profileOrder: ["cost-optimized-backup", "scratch"],
+        activeProfile: "cost-optimized-backup",
+        callSites: { recall: { profile: "cost-optimized-backup" } },
+      },
+    });
+
+    await renameCollidingBackupProfileNamesMigration.run(workspaceDir);
+
+    const parsed = LLMSchema.safeParse(readConfig().llm);
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.activeProfile).toBe("cost-optimized-backup-custom");
+    }
+  });
+
+  test("renames every colliding key and keeps suffixing past taken names", async () => {
+    const profiles: Record<string, unknown> = {
+      "balanced-backup-custom": { source: "user", speed: "fast" },
+      "balanced-backup-custom-2": { source: "user", speed: "fast" },
+    };
+    for (const key of BACKUP_PROFILE_KEYS) {
+      profiles[key] = { source: "user", provider: "anthropic" };
+    }
+    writeConfig({ llm: { profiles } });
+
+    await renameCollidingBackupProfileNamesMigration.run(workspaceDir);
+
+    const renamed = readConfig().llm.profiles;
+    expect(renamed["balanced-backup-custom-3"]).toBeDefined();
+    for (const key of BACKUP_PROFILE_KEYS) {
+      expect(renamed[key]).toBeUndefined();
+    }
+    for (const key of BACKUP_PROFILE_KEYS.slice(1)) {
+      expect(renamed[`${key}-custom`]).toBeDefined();
+    }
+  });
+
+  test("never renames onto another reserved code-defined name", async () => {
+    // Contrived: a profile literally named `<backup>-custom` would be a
+    // legitimate rename target, but a reserved name never is.
+    writeConfig({
+      llm: {
+        profiles: Object.fromEntries(
+          [...DEFAULT_PROFILE_KEYS, ...BACKUP_PROFILE_KEYS, "os-beta"].map(
+            (key) => [key, { source: "user", provider: "anthropic" }],
+          ),
+        ),
+      },
+    });
+
+    await renameCollidingBackupProfileNamesMigration.run(workspaceDir);
+
+    const renamed = Object.keys(readConfig().llm.profiles);
+    for (const key of BACKUP_PROFILE_KEYS) {
+      expect(renamed).toContain(`${key}-custom`);
+    }
+    // The user-owned entries on the non-reserved-for-this-migration names are
+    // untouched: only the backup keys became newly reserved.
+    for (const key of [...DEFAULT_PROFILE_KEYS, "os-beta"]) {
+      expect(renamed).toContain(key);
+    }
+  });
+
+  test("leaves managed stubs and non-object values alone", async () => {
+    writeConfig({
+      llm: {
+        profiles: {
+          "balanced-backup": { source: "managed", status: "disabled" },
+          "quality-optimized-backup": "not-a-profile",
+        },
+        activeProfile: "balanced-backup",
+      },
+    });
+
+    await renameCollidingBackupProfileNamesMigration.run(workspaceDir);
+
+    const llm = readConfig().llm;
+    expect(llm.profiles["balanced-backup"]).toEqual({
+      source: "managed",
+      status: "disabled",
+    });
+    expect(llm.profiles["quality-optimized-backup"]).toBe("not-a-profile");
+    expect(llm.activeProfile).toBe("balanced-backup");
+  });
+
+  test("repoints conversation and schedule profile pins", async () => {
+    seedProfilePinTables({
+      conversations: ["balanced-backup", "balanced", "balanced-backup"],
+      cronJobs: ["balanced-backup", "scratch"],
+    });
+    writeConfig({
+      llm: {
+        profiles: {
+          "balanced-backup": { source: "user", provider: "anthropic" },
+          scratch: { source: "user", speed: "fast" },
+        },
+      },
+    });
+
+    await renameCollidingBackupProfileNamesMigration.run(workspaceDir);
+
+    expect(readPins("conversations")).toEqual([
+      "balanced-backup-custom",
+      "balanced",
+      "balanced-backup-custom",
+    ]);
+    expect(readPins("cron_jobs")).toEqual([
+      "balanced-backup-custom",
+      "scratch",
+    ]);
+  });
+
+  test("is a no-op without a collision and idempotent on re-run", async () => {
+    const config = {
+      llm: {
+        defaultProvider: { provider: "vellum" },
+        profiles: {
+          scratch: { source: "user", speed: "fast" },
+        },
+        activeProfile: "balanced",
+        callSites: { recall: { profile: "balanced-backup" } },
+      },
+    };
+    writeConfig(config);
+
+    await renameCollidingBackupProfileNamesMigration.run(workspaceDir);
+    expect(readConfig()).toEqual(config);
+
+    // With a collision, a second run finds nothing left to rename.
+    writeConfig({
+      llm: {
+        profiles: { "balanced-backup": { source: "user", speed: "fast" } },
+        activeProfile: "balanced-backup",
+      },
+    });
+    await renameCollidingBackupProfileNamesMigration.run(workspaceDir);
+    const first = readConfig();
+    await renameCollidingBackupProfileNamesMigration.run(workspaceDir);
+    expect(readConfig()).toEqual(first);
+  });
+
+  test("handles missing config, missing llm block, and invalid JSON", async () => {
+    await expect(
+      renameCollidingBackupProfileNamesMigration.run(workspaceDir),
+    ).resolves.toBeUndefined();
+
+    writeConfig({ theme: "dark" });
+    await renameCollidingBackupProfileNamesMigration.run(workspaceDir);
+    expect(readConfig()).toEqual({ theme: "dark" });
+
+    writeFileSync(join(workspaceDir, "config.json"), "{not json");
+    await expect(
+      renameCollidingBackupProfileNamesMigration.run(workspaceDir),
+    ).resolves.toBeUndefined();
+  });
+
+  test("retries a pin rewrite the database refuses, then completes", async () => {
+    seedProfilePinTables({
+      conversations: ["balanced-backup", "balanced"],
+      cronJobs: ["balanced-backup"],
+    });
+    writeConfig({
+      llm: {
+        profiles: {
+          "balanced-backup": { source: "user", provider: "anthropic" },
+        },
+        activeProfile: "balanced-backup",
+      },
+    });
+
+    // A second connection holding the write lock makes every UPDATE fail with
+    // SQLITE_BUSY until it commits, which is the contention the retry exists
+    // for.
+    const blocker = new Database(dbPath());
+    blocker.run("BEGIN IMMEDIATE");
+    let released = false;
+    const release = setTimeout(() => {
+      blocker.run("COMMIT");
+      blocker.close();
+      released = true;
+    }, 10);
+
+    await renameCollidingBackupProfileNamesMigration.run(workspaceDir);
+    clearTimeout(release);
+
+    // The lock is released from a timer, which can only fire while the
+    // migration is waiting out a backoff: a first attempt that had succeeded
+    // would have finished the run before this point.
+    expect(released).toBe(true);
+    expect(readPins("conversations")).toEqual([
+      "balanced-backup-custom",
+      "balanced",
+    ]);
+    expect(readPins("cron_jobs")).toEqual(["balanced-backup-custom"]);
+    expect(readConfig().llm.activeProfile).toBe("balanced-backup-custom");
+  });
+
+  test("stays unapplied and retries on the next boot when the pins cannot be rewritten", async () => {
+    seedProfilePinTables({
+      conversations: ["balanced-backup"],
+      cronJobs: ["balanced-backup"],
+    });
+    const config = {
+      llm: {
+        profiles: {
+          "balanced-backup": { source: "user", provider: "anthropic" },
+        },
+        activeProfile: "balanced-backup",
+      },
+    };
+    writeConfig(config);
+
+    const blocker = new Database(dbPath());
+    blocker.run("BEGIN IMMEDIATE");
+
+    const firstBoot = await runWorkspaceMigrations(workspaceDir, [
+      renameCollidingBackupProfileNamesMigration,
+    ]);
+
+    // Failed, not completed: the config keeps the old key, so the rename is
+    // still pending and the mapping is still derivable from it.
+    expect(firstBoot).toEqual({ applied: 0, skipped: 0, failed: 1 });
+    expect(
+      loadCheckpoints(workspaceDir).applied[
+        "147-rename-colliding-backup-profile-names"
+      ]?.status,
+    ).toBe("failed");
+    expect(readConfig()).toEqual(config);
+    expect(readPins("conversations")).toEqual(["balanced-backup"]);
+
+    blocker.run("COMMIT");
+    blocker.close();
+
+    const secondBoot = await runWorkspaceMigrations(workspaceDir, [
+      renameCollidingBackupProfileNamesMigration,
+    ]);
+
+    expect(secondBoot).toEqual({ applied: 1, skipped: 0, failed: 0 });
+    expect(readConfig().llm.activeProfile).toBe("balanced-backup-custom");
+    expect(readPins("conversations")).toEqual(["balanced-backup-custom"]);
+    expect(readPins("cron_jobs")).toEqual(["balanced-backup-custom"]);
+  });
+
+  test("touches the database not at all without a collision", async () => {
+    seedProfilePinTables({
+      conversations: ["balanced-backup"],
+      cronJobs: ["scratch"],
+    });
+    writeConfig({
+      llm: {
+        profiles: { scratch: { source: "user", speed: "fast" } },
+        activeProfile: "balanced",
+      },
+    });
+
+    // Holding the write lock for the whole run proves no write is attempted:
+    // one would fail, and a failure now throws.
+    const blocker = new Database(dbPath());
+    blocker.run("BEGIN IMMEDIATE");
+    await renameCollidingBackupProfileNamesMigration.run(workspaceDir);
+    blocker.run("COMMIT");
+    blocker.close();
+
+    expect(readPins("conversations")).toEqual(["balanced-backup"]);
+    expect(readPins("cron_jobs")).toEqual(["scratch"]);
+  });
+});

--- a/assistant/src/__tests__/workspace-migration-147-rename-colliding-backup-profile-names.test.ts
+++ b/assistant/src/__tests__/workspace-migration-147-rename-colliding-backup-profile-names.test.ts
@@ -16,6 +16,7 @@ import {
 } from "../config/default-profile-names.js";
 import { LLMSchema } from "../config/schemas/llm.js";
 import { renameCollidingBackupProfileNamesMigration } from "../workspace/migrations/147-rename-colliding-backup-profile-names.js";
+import { stripUnsupportedFallbackProfilesMigration } from "../workspace/migrations/148-strip-unsupported-fallback-profiles.js";
 import { WORKSPACE_MIGRATIONS } from "../workspace/migrations/registry.js";
 import {
   loadCheckpoints,
@@ -108,7 +109,7 @@ describe("147-rename-colliding-backup-profile-names migration", () => {
     );
   });
 
-  test("renames a colliding user profile and rewrites every reference", async () => {
+  test("renames a colliding user profile and rewrites supported references", async () => {
     writeConfig({
       llm: {
         defaultProvider: { provider: "vellum" },
@@ -192,7 +193,7 @@ describe("147-rename-colliding-backup-profile-names migration", () => {
     expect(parsed.success).toBe(true);
   });
 
-  test("the migrated config parses under LLMSchema", async () => {
+  test("the 147-to-148 migration sequence parses under LLMSchema", async () => {
     writeConfig({
       llm: {
         defaultProvider: { provider: "vellum" },
@@ -214,12 +215,15 @@ describe("147-rename-colliding-backup-profile-names migration", () => {
     });
 
     await renameCollidingBackupProfileNamesMigration.run(workspaceDir);
+    await stripUnsupportedFallbackProfilesMigration.run(workspaceDir);
 
-    const parsed = LLMSchema.safeParse(readConfig().llm);
+    const migrated = readConfig().llm;
+    const parsed = LLMSchema.safeParse(migrated);
     expect(parsed.success).toBe(true);
     if (parsed.success) {
       expect(parsed.data.activeProfile).toBe("cost-optimized-backup-custom");
     }
+    expect(migrated.profiles.scratch.fallbackProfile).toBeUndefined();
   });
 
   test("renames every colliding key and keeps suffixing past taken names", async () => {

--- a/assistant/src/__tests__/workspace-migration-148-strip-unsupported-fallback-profiles.test.ts
+++ b/assistant/src/__tests__/workspace-migration-148-strip-unsupported-fallback-profiles.test.ts
@@ -1,0 +1,167 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { renameCollidingBackupProfileNamesMigration } from "../workspace/migrations/147-rename-colliding-backup-profile-names.js";
+import { stripUnsupportedFallbackProfilesMigration } from "../workspace/migrations/148-strip-unsupported-fallback-profiles.js";
+import { WORKSPACE_MIGRATIONS } from "../workspace/migrations/registry.js";
+import { assertNotLiveDb } from "./assert-not-live-db.js";
+
+let workspaceDir: string;
+
+function writeConfig(data: Record<string, unknown>): void {
+  writeFileSync(
+    join(workspaceDir, "config.json"),
+    JSON.stringify(data, null, 2) + "\n",
+  );
+}
+
+function readConfig(): Record<string, any> {
+  return JSON.parse(readFileSync(join(workspaceDir, "config.json"), "utf-8"));
+}
+
+beforeEach(() => {
+  workspaceDir = join(
+    tmpdir(),
+    `vellum-migration-148-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(workspaceDir, { recursive: true });
+});
+
+afterEach(() => {
+  if (existsSync(workspaceDir)) {
+    assertNotLiveDb(workspaceDir);
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+describe("148-strip-unsupported-fallback-profiles migration", () => {
+  test("has the next migration id and is registered last", () => {
+    expect(stripUnsupportedFallbackProfilesMigration.id).toBe(
+      "148-strip-unsupported-fallback-profiles",
+    );
+    expect(WORKSPACE_MIGRATIONS.at(-1)?.id).toBe(
+      "148-strip-unsupported-fallback-profiles",
+    );
+  });
+
+  test("cleans a legacy pointer after migration 147 rewrites its target", async () => {
+    writeConfig({
+      llm: {
+        profiles: {
+          "balanced-backup": {
+            source: "user",
+            provider: "anthropic",
+            model: "legacy-model",
+          },
+          custom: {
+            source: "user",
+            fallbackProfile: "balanced-backup",
+          },
+        },
+      },
+    });
+
+    await renameCollidingBackupProfileNamesMigration.run(workspaceDir);
+    expect(readConfig().llm.profiles.custom.fallbackProfile).toBe(
+      "balanced-backup-custom",
+    );
+
+    stripUnsupportedFallbackProfilesMigration.run(workspaceDir);
+    expect(readConfig().llm.profiles.custom.fallbackProfile).toBeUndefined();
+
+    const once = readConfig();
+    stripUnsupportedFallbackProfilesMigration.run(workspaceDir);
+    expect(readConfig()).toEqual(once);
+  });
+
+  test("removes every custom pointer and preserves exact managed defaults", () => {
+    writeConfig({
+      llm: {
+        profiles: {
+          balanced: {
+            source: "managed",
+            fallbackProfile: "balanced-backup",
+          },
+          "quality-optimized": {
+            source: "managed",
+            fallbackProfile: "custom-backup",
+          },
+          custom: {
+            source: "user",
+            fallbackProfile: "other-custom",
+          },
+          "managed-custom": {
+            source: "managed",
+            fallbackProfile: "balanced-backup",
+          },
+          cleared: {
+            source: "user",
+            fallbackProfile: null,
+          },
+          untouched: { source: "user", model: "custom-model" },
+        },
+      },
+    });
+
+    stripUnsupportedFallbackProfilesMigration.run(workspaceDir);
+
+    const profiles = readConfig().llm.profiles;
+    expect(profiles.balanced.fallbackProfile).toBe("balanced-backup");
+    expect(profiles["quality-optimized"].fallbackProfile).toBeUndefined();
+    expect(profiles.custom.fallbackProfile).toBeUndefined();
+    expect(profiles["managed-custom"].fallbackProfile).toBeUndefined();
+    expect(profiles.cleared.fallbackProfile).toBeUndefined();
+    expect(profiles.untouched).toEqual({
+      source: "user",
+      model: "custom-model",
+    });
+  });
+
+  test.each(["openai", "chatgpt"] as const)(
+    "strips managed pointers when backups do not resolve under %s",
+    (provider) => {
+      writeConfig({
+        llm: {
+          defaultProvider: { provider },
+          profiles: {
+            balanced: {
+              source: "managed",
+              fallbackProfile: "balanced-backup",
+            },
+            "quality-optimized": {
+              source: "managed",
+              fallbackProfile: "quality-optimized-backup",
+            },
+          },
+        },
+      });
+
+      stripUnsupportedFallbackProfilesMigration.run(workspaceDir);
+
+      const profiles = readConfig().llm.profiles;
+      expect(profiles.balanced.fallbackProfile).toBeUndefined();
+      expect(profiles["quality-optimized"].fallbackProfile).toBeUndefined();
+    },
+  );
+
+  test("handles missing config, missing profiles, and invalid JSON", () => {
+    stripUnsupportedFallbackProfilesMigration.run(workspaceDir);
+
+    writeConfig({ theme: "dark" });
+    stripUnsupportedFallbackProfilesMigration.run(workspaceDir);
+    expect(readConfig()).toEqual({ theme: "dark" });
+
+    writeFileSync(join(workspaceDir, "config.json"), "{not json");
+    expect(() =>
+      stripUnsupportedFallbackProfilesMigration.run(workspaceDir),
+    ).not.toThrow();
+  });
+});

--- a/assistant/src/__tests__/workspace-migration-148-strip-unsupported-fallback-profiles.test.ts
+++ b/assistant/src/__tests__/workspace-migration-148-strip-unsupported-fallback-profiles.test.ts
@@ -43,11 +43,11 @@ afterEach(() => {
 });
 
 describe("148-strip-unsupported-fallback-profiles migration", () => {
-  test("has the next migration id and is registered last", () => {
+  test("has the next migration id and is registered", () => {
     expect(stripUnsupportedFallbackProfilesMigration.id).toBe(
       "148-strip-unsupported-fallback-profiles",
     );
-    expect(WORKSPACE_MIGRATIONS.at(-1)?.id).toBe(
+    expect(WORKSPACE_MIGRATIONS.map((migration) => migration.id)).toContain(
       "148-strip-unsupported-fallback-profiles",
     );
   });

--- a/assistant/src/__tests__/workspace-migration-149-repoint-backup-profile-selections.test.ts
+++ b/assistant/src/__tests__/workspace-migration-149-repoint-backup-profile-selections.test.ts
@@ -1,0 +1,142 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { repointBackupProfileSelectionsMigration } from "../workspace/migrations/149-repoint-backup-profile-selections.js";
+import { WORKSPACE_MIGRATIONS } from "../workspace/migrations/registry.js";
+import { assertNotLiveDb } from "./assert-not-live-db.js";
+
+let workspaceDir: string;
+
+function dbPath(): string {
+  return join(workspaceDir, "data", "db", "assistant.db");
+}
+
+function writeConfig(data: Record<string, unknown>): void {
+  writeFileSync(
+    join(workspaceDir, "config.json"),
+    JSON.stringify(data, null, 2) + "\n",
+  );
+}
+
+function readConfig(): Record<string, any> {
+  return JSON.parse(readFileSync(join(workspaceDir, "config.json"), "utf-8"));
+}
+
+function seedProfilePinTables(): void {
+  mkdirSync(join(workspaceDir, "data", "db"), { recursive: true });
+  const db = new Database(dbPath());
+  db.run(
+    "CREATE TABLE conversations (id TEXT PRIMARY KEY, inference_profile TEXT)",
+  );
+  db.run(
+    "CREATE TABLE cron_jobs (id TEXT PRIMARY KEY, inference_profile TEXT)",
+  );
+  db.query(
+    "INSERT INTO conversations (id, inference_profile) VALUES (?, ?)",
+  ).run("conv-1", "quality-optimized-backup");
+  db.query("INSERT INTO cron_jobs (id, inference_profile) VALUES (?, ?)").run(
+    "job-1",
+    "balanced-backup",
+  );
+  db.close();
+}
+
+function readPins(table: "conversations" | "cron_jobs"): string[] {
+  const db = new Database(dbPath());
+  try {
+    return (
+      db
+        .query(`SELECT inference_profile AS profile FROM ${table} ORDER BY id`)
+        .all() as Array<{ profile: string }>
+    ).map((row) => row.profile);
+  } finally {
+    db.close();
+  }
+}
+
+beforeEach(() => {
+  workspaceDir = join(
+    tmpdir(),
+    `vellum-migration-149-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(workspaceDir, { recursive: true });
+});
+
+afterEach(() => {
+  if (existsSync(workspaceDir)) {
+    assertNotLiveDb(workspaceDir);
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+describe("149-repoint-backup-profile-selections migration", () => {
+  test("is registered as the current migration", () => {
+    expect(repointBackupProfileSelectionsMigration.id).toBe(
+      "149-repoint-backup-profile-selections",
+    );
+    expect(WORKSPACE_MIGRATIONS.at(-1)?.id).toBe(
+      "149-repoint-backup-profile-selections",
+    );
+  });
+
+  test("repoints direct config selections and preserves fallback metadata", async () => {
+    writeConfig({
+      llm: {
+        activeProfile: "balanced-backup",
+        advisorProfile: "quality-optimized-backup",
+        profileOrder: ["balanced", "balanced-backup"],
+        callSites: {
+          mainAgent: { profile: "cost-optimized-backup" },
+        },
+        profiles: {
+          custom: {
+            mix: [{ profile: "latency-optimized-backup", weight: 1 }],
+          },
+          balanced: {
+            source: "managed",
+            fallbackProfile: "balanced-backup",
+          },
+        },
+      },
+    });
+
+    await repointBackupProfileSelectionsMigration.run(workspaceDir);
+
+    const llm = readConfig().llm;
+    expect(llm.activeProfile).toBe("balanced");
+    expect(llm.advisorProfile).toBe("quality-optimized");
+    expect(llm.callSites.mainAgent.profile).toBe("cost-optimized");
+    expect(llm.profiles.custom.mix[0].profile).toBe("latency-optimized");
+    expect(llm.profiles.balanced.fallbackProfile).toBe("balanced-backup");
+    expect(llm.profileOrder).toEqual(["balanced", "balanced-backup"]);
+  });
+
+  test("repoints conversation and schedule pins", async () => {
+    seedProfilePinTables();
+
+    await repointBackupProfileSelectionsMigration.run(workspaceDir);
+
+    expect(readPins("conversations")).toEqual(["quality-optimized"]);
+    expect(readPins("cron_jobs")).toEqual(["balanced"]);
+  });
+
+  test("is idempotent and tolerates a missing config or database", async () => {
+    await expect(
+      repointBackupProfileSelectionsMigration.run(workspaceDir),
+    ).resolves.toBeUndefined();
+
+    writeConfig({ llm: { activeProfile: "balanced" } });
+    const before = readConfig();
+    await repointBackupProfileSelectionsMigration.run(workspaceDir);
+    expect(readConfig()).toEqual(before);
+  });
+});

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -371,6 +371,16 @@ export type AgentEvent =
       cacheReadInputTokens?: number;
       model: string;
       actualProvider?: string;
+      /**
+       * Inference profile that actually governed the call, set only when a
+       * wrapper re-routed the request away from the caller's own resolution
+       * (`RetryProvider`'s fallback-profile escalation). Travels alongside
+       * `actualProvider` so the daemon's usage ledger attributes a degraded
+       * serve to the backup profile that answered rather than to the primary
+       * that failed. Absent on the normal (non-rerouted) path, where the
+       * caller's own resolution is already correct.
+       */
+      actualInferenceProfile?: string;
       providerDurationMs: number;
       rawRequest?: unknown;
       rawResponse?: unknown;
@@ -1819,6 +1829,14 @@ export class AgentLoop {
           cacheReadInputTokens: response.usage.cacheReadInputTokens,
           model: response.model,
           actualProvider: response.actualProvider ?? this.provider.name,
+          // Only present when a wrapper rerouted this call, so the normal
+          // path's event shape stays byte-identical. There is no caller-side
+          // fallback value to fill in: the loop's own profile resolution is
+          // exactly what a reroute invalidates, and the daemon already reads
+          // its own resolution when this is absent.
+          ...(response.actualInferenceProfile !== undefined
+            ? { actualInferenceProfile: response.actualInferenceProfile }
+            : {}),
           providerDurationMs,
           rawRequest: response.rawRequest,
           rawResponse: response.rawResponse,

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -43,7 +43,10 @@ import type {
   ToolDefinition,
   ToolResultContent,
 } from "../providers/types.js";
-import { isContextOverflowError } from "../providers/types.js";
+import {
+  isContextOverflowError,
+  NATIVE_WEB_SEARCH_TOOL_NAME,
+} from "../providers/types.js";
 import { getTool } from "../tools/registry.js";
 import type { SensitiveOutputBinding } from "../tools/sensitive-output-placeholders.js";
 import {
@@ -132,7 +135,7 @@ export interface AgentLoopConfig {
  * `input_schema` is informational — the provider supplies the real schema.
  */
 const NATIVE_WEB_SEARCH_TOOL: ToolDefinition = {
-  name: "web_search",
+  name: NATIVE_WEB_SEARCH_TOOL_NAME,
   description:
     "Search the web for current information to ground your response.",
   input_schema: {
@@ -1465,6 +1468,14 @@ export class AgentLoop {
         } else if (attachNativeWebSearch) {
           // Let the model decide whether to search rather than forcing it.
           providerConfig.tool_choice = { type: "auto" };
+        }
+
+        // Mark the sentinel so a route change downstream can tell it from an
+        // app-executed `web_search` of the same name (see
+        // `SendMessageConfig.nativeWebSearchSentinel`). Only set when true so
+        // the wire config stays byte-identical otherwise.
+        if (attachNativeWebSearch) {
+          providerConfig.nativeWebSearchSentinel = true;
         }
 
         if (this.config.cacheTtl) {

--- a/assistant/src/config/__tests__/default-profile-catalog.test.ts
+++ b/assistant/src/config/__tests__/default-profile-catalog.test.ts
@@ -8,6 +8,7 @@ import {
   getEffectiveProfile,
   getEffectiveProfiles,
   getEffectiveProfilesForProvider,
+  getUserSelectableProfilesForProvider,
   PROFILE_IMPLS,
   resolveDefaultProfileForProvider,
 } from "../default-profile-catalog.js";
@@ -153,6 +154,25 @@ describe("getEffectiveProfiles", () => {
       CODE_DEFAULT_PROFILE_ENTRIES.balanced.model as string,
     );
     expect(after.balanced.model).toBe("claude-sonnet-4-6");
+  });
+});
+
+describe("user-selectable profile view", () => {
+  test("hides managed backups while retaining them in the fallback catalog", () => {
+    const effective = getEffectiveProfilesForProvider(undefined, {
+      provider: "vellum",
+    });
+    const selectable = getUserSelectableProfilesForProvider(undefined, {
+      provider: "vellum",
+    });
+
+    for (const key of DEFAULT_PROFILE_KEYS) {
+      expect(selectable[key]).toBeDefined();
+    }
+    for (const key of BACKUP_PROFILE_KEYS) {
+      expect(effective[key]).toBeDefined();
+      expect(selectable[key]).toBeUndefined();
+    }
   });
 });
 

--- a/assistant/src/config/__tests__/default-profile-catalog.test.ts
+++ b/assistant/src/config/__tests__/default-profile-catalog.test.ts
@@ -12,6 +12,7 @@ import {
   resolveDefaultProfileForProvider,
 } from "../default-profile-catalog.js";
 import {
+  BACKUP_PROFILE_KEYS,
   DEFAULT_PROFILE_KEYS,
   DEFAULT_PROFILE_PROVIDERS,
   OS_BETA_PROFILE_KEY,
@@ -78,7 +79,7 @@ describe("getEffectiveProfiles", () => {
   test("defaults absent from the workspace resolve from the catalog; os-beta stays flag-gated", () => {
     const effective = getEffectiveProfiles(undefined);
     expect(Object.keys(effective).sort()).toEqual(
-      [...DEFAULT_PROFILE_KEYS].sort(),
+      [...DEFAULT_PROFILE_KEYS, ...BACKUP_PROFILE_KEYS].sort(),
     );
     expect(getEffectiveProfile({}, "balanced")?.model).toBe(
       CODE_DEFAULT_PROFILE_ENTRIES.balanced.model as string,
@@ -267,6 +268,40 @@ describe("resolver integration", () => {
       }),
     ).not.toThrow();
   });
+
+  test("a user profile cannot shadow a managed backup profile", () => {
+    // Every backup is code-owned for the same reason `latency-optimized` is:
+    // a backup earns its place by pinning a different upstream than the
+    // primary it backs, and a user shadow can repoint it at the primary's
+    // own provider, so the fallback re-sends into the outage it exists to
+    // route around. `latency-optimized-backup` additionally serves the
+    // live-voice path whenever that primary falls back.
+    for (const key of BACKUP_PROFILE_KEYS) {
+      const llm = LLMSchema.parse({
+        profiles: {
+          [key]: {
+            source: "user",
+            provider: "anthropic",
+            model: "claude-opus-4-6",
+            provider_connection: "anthropic-personal",
+            maxTokens: 32000,
+            effort: "high",
+          },
+        },
+      });
+      const body = CODE_DEFAULT_PROFILE_ENTRIES[key]!;
+      const effective = getEffectiveProfiles(llm.profiles)[key];
+      expect(effective?.model).toBe(body.model);
+      expect(effective?.model).not.toBe("claude-opus-4-6");
+      expect(String(effective?.provider)).toBe("vellum");
+      expect(effective?.provider_connection).toBeUndefined();
+      // Resolution through the managed column agrees with the listing.
+      const resolved = resolveDefaultProfileForProvider(llm.profiles, key, {
+        provider: "vellum",
+      });
+      expect(resolved?.model).toBe(body.model);
+    }
+  });
 });
 
 describe("schema validation", () => {
@@ -299,6 +334,27 @@ describe("schema validation", () => {
     expect(() =>
       LLMSchema.parse({ callSites: { mainAgent: { profile: "no-such" } } }),
     ).toThrow();
+  });
+
+  test("managed backup names are valid references without being materialized", () => {
+    // Backups are listed in the effective catalog and are selectable, but
+    // selecting one persists only the reference: nothing lands in
+    // `llm.profiles`. Unless the schema treats the keys as always-available,
+    // the next load strips the selection and silently reverts it.
+    for (const key of BACKUP_PROFILE_KEYS) {
+      expect(() => LLMSchema.parse({ activeProfile: key })).not.toThrow();
+      expect(() => LLMSchema.parse({ advisorProfile: key })).not.toThrow();
+      expect(() =>
+        LLMSchema.parse({ callSites: { mainAgent: { profile: key } } }),
+      ).not.toThrow();
+    }
+    // The keys stay out of `DEFAULT_PROFILE_KEYS`: that array drives picker
+    // order and the intent x provider matrix.
+    expect(
+      BACKUP_PROFILE_KEYS.some((key) =>
+        (DEFAULT_PROFILE_KEYS as readonly string[]).includes(key),
+      ),
+    ).toBe(false);
   });
 
   test("defaultProvider accepts any default-capable API-key provider and drops the rest", () => {

--- a/assistant/src/config/default-profile-catalog.ts
+++ b/assistant/src/config/default-profile-catalog.ts
@@ -9,15 +9,20 @@ import type { ModelIntent } from "../providers/types.js";
 import { getManagedUpstream } from "../providers/vellum-model-routing.js";
 import { getBalancedModelExperimentArm } from "./balanced-model-experiment.js";
 import {
+  BACKUP_PROFILE_KEYS,
+  type BackupProfileKey,
   DEFAULT_PROFILE_KEYS,
   DEFAULT_PROFILE_PROVIDERS,
   type DefaultProfileKey,
   type DefaultProfileProvider,
+  FALLBACK_PROFILE_BY_KEY,
+  isBackupProfileKey,
   isDefaultProfileProvider,
   OS_BETA_PROFILE_KEY,
 } from "./default-profile-names.js";
 import { resolveDefaultConnectionName } from "./default-provider-resolution.js";
 import {
+  backupProfilesResolveUnderDefaultProvider,
   DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS,
   DEFAULT_PROVIDER_CHOICES,
   type DefaultProviderConfig,
@@ -70,6 +75,13 @@ type ProfileImpls = Record<DefaultProfileKey, DefaultProfileTemplate>;
  * concrete dispatch providers, and the model is what selects the upstream.
  * Overwritten in workspace config on every daemon boot so Vellum can push
  * model/config updates to customers in new releases.
+ *
+ * Each implementation points at its managed backup profile via
+ * `fallbackProfile` (`BACKUP_PROFILE_IMPLS` below): a backup pins a model at
+ * a different upstream provider, so an outage-type failure at the primary's
+ * provider can be served by re-sending on the backup. Vellum column only:
+ * the BYOK and chatgpt columns carry no pointers, since those installs may
+ * hold no credential for the backup's provider.
  */
 const VELLUM_PROFILE_IMPLS: ProfileImpls = {
   balanced: {
@@ -78,6 +90,7 @@ const VELLUM_PROFILE_IMPLS: ProfileImpls = {
     source: "managed",
     label: "Balanced",
     description: "Good balance of quality, cost, and speed",
+    fallbackProfile: FALLBACK_PROFILE_BY_KEY.balanced,
     maxTokens: 32000,
     effort: "high",
     thinking: { enabled: true, streamThinking: true },
@@ -91,6 +104,7 @@ const VELLUM_PROFILE_IMPLS: ProfileImpls = {
     source: "managed",
     label: "Quality",
     description: "High-quality results with the most capable model",
+    fallbackProfile: FALLBACK_PROFILE_BY_KEY["quality-optimized"],
     maxTokens: 32000,
     effort: "high",
     thinking: { enabled: true, streamThinking: true },
@@ -107,6 +121,7 @@ const VELLUM_PROFILE_IMPLS: ProfileImpls = {
     // surface the live model beside the description, so a model name in
     // this copy would go stale the moment the pin moves.
     description: "Cheapest responses, for high-volume work",
+    fallbackProfile: FALLBACK_PROFILE_BY_KEY["cost-optimized"],
     maxTokens: 8192,
     // Explicit reasoning opt-out. OpenAI-compat APIs default reasoning to
     // "medium" when the field is omitted, and effort-driven providers encode
@@ -136,12 +151,87 @@ const VELLUM_PROFILE_IMPLS: ProfileImpls = {
     source: "managed",
     label: "Speed",
     description: "Fastest responses, with reasoning turned off",
+    fallbackProfile: FALLBACK_PROFILE_BY_KEY["latency-optimized"],
     maxTokens: 8192,
     // Explicit reasoning opt-out, matching `cost-optimized` above: this
     // profile advertises reasoning as off, and OpenAI-compat APIs default
     // reasoning to "medium" when the field is omitted, so the opt-out has to
     // be stated rather than implied.
     effort: "none",
+    thinking: { enabled: false, streamThinking: false },
+    contextWindow: {
+      maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS,
+    },
+  },
+};
+
+/**
+ * The managed backup profiles, one per default profile: the route a primary's
+ * `fallbackProfile` pointer names. Vellum column only: backups never
+ * materialize for BYOK or chatgpt installs. Like the primaries, models are
+ * pinned (never intents) and stamped `provider: "vellum"`, so dispatch
+ * derives the upstream from the model. Every backup pins its model at a
+ * DIFFERENT upstream provider than its primary (that cross-provider split is
+ * the entire point), and the module-load validation below enforces
+ * routability.
+ *
+ * Descriptions name the tier they back, never the concrete model: clients
+ * surface the live model beside the description, so a model name in this
+ * copy would go stale the moment a pin moves.
+ */
+const BACKUP_PROFILE_IMPLS: Record<BackupProfileKey, DefaultProfileTemplate> = {
+  "balanced-backup": {
+    model: "claude-sonnet-5",
+    provider: "vellum",
+    source: "managed",
+    label: "Balanced Backup",
+    description: "Automatic backup for the Balanced profile",
+    maxTokens: 32000,
+    effort: "high",
+    thinking: { enabled: true, streamThinking: true },
+    contextWindow: {
+      maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS,
+    },
+  },
+  "quality-optimized-backup": {
+    model: "claude-opus-5",
+    provider: "vellum",
+    source: "managed",
+    label: "Quality Backup",
+    description: "Automatic backup for the Quality profile",
+    maxTokens: 32000,
+    effort: "high",
+    thinking: { enabled: true, streamThinking: true },
+    contextWindow: {
+      maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS,
+    },
+  },
+  "cost-optimized-backup": {
+    model: "gemini-3.1-flash-lite",
+    provider: "vellum",
+    source: "managed",
+    label: "Cost Backup",
+    description: "Automatic backup for the Cost profile",
+    maxTokens: 8192,
+    // Explicit reasoning opt-out, matching the primary Cost profile: OpenAI-
+    // compat APIs default reasoning to "medium" when the field is omitted,
+    // and effort-driven providers encode disabled thinking through this same
+    // knob (see DISABLED_THINKING_USES_EFFORT_PROVIDERS in
+    // providers/retry.ts).
+    effort: "none",
+    thinking: { enabled: false, streamThinking: false },
+    contextWindow: {
+      maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS,
+    },
+  },
+  "latency-optimized-backup": {
+    model: "gemini-3.6-flash",
+    provider: "vellum",
+    source: "managed",
+    label: "Speed Backup",
+    description: "Automatic backup for the Speed profile",
+    maxTokens: 8192,
+    effort: "low",
     thinking: { enabled: false, streamThinking: false },
     contextWindow: {
       maxInputTokens: DEFAULT_CONTEXT_WINDOW_MAX_INPUT_TOKENS,
@@ -335,14 +425,18 @@ export const PROFILE_IMPLS: Record<
 >;
 
 /**
- * Managed profiles, i.e. the `vellum` column keyed by profile name. Keyed by
- * the user-facing defaults only: an internal profile is code-resolved and
- * never listed or ordered.
+ * Managed profiles, i.e. the `vellum` column keyed by profile name, plus the
+ * managed backup profiles. Backups come after the primaries, which is what
+ * places them after the primaries in `profileOrder` presentation: the seeder
+ * inserts missing managed keys in this record's order. Keyed by the
+ * user-facing defaults only: an internal profile is code-resolved and never
+ * listed or ordered.
  */
 export const MANAGED_PROFILE_TEMPLATES: Record<string, DefaultProfileTemplate> =
-  Object.fromEntries(
-    DEFAULT_PROFILE_KEYS.map((key) => [key, PROFILE_IMPLS[key].vellum]),
-  );
+  Object.fromEntries([
+    ...DEFAULT_PROFILE_KEYS.map((key) => [key, PROFILE_IMPLS[key].vellum]),
+    ...BACKUP_PROFILE_KEYS.map((key) => [key, BACKUP_PROFILE_IMPLS[key]]),
+  ]);
 
 /**
  * The values BYOK hatch seeding wrote onto each `custom-*` copy, for the keys
@@ -413,8 +507,23 @@ export const OS_BETA_PROFILE_TEMPLATE: DefaultProfileTemplate = {
  * audible dead air rather than a slow reply. A same-named
  * workspace entry stays on disk and stays listed; it just never governs what
  * this name resolves to.
+ *
+ * All four backups carry the same protection rather than only
+ * `latency-optimized-backup`. The narrow argument covers that one alone: it
+ * serves the live-voice path whenever the primary falls back, so a shadow
+ * reintroduces exactly the dead-air risk the primary's protection exists to
+ * prevent. The broader argument covers all four, and is why the whole set is
+ * here: a backup only earns its place by pinning a model at a different
+ * upstream than the primary it backs (see `BACKUP_PROFILE_IMPLS`), and a
+ * user-owned shadow can silently repoint it at the primary's own provider,
+ * so the fallback re-sends into the outage it exists to route around. A
+ * backup also has no per-provider matrix column, so there is nothing a
+ * workspace overlay could legitimately own on it.
  */
-export const CODE_OWNED_PROFILE_NAMES = new Set<string>(["latency-optimized"]);
+export const CODE_OWNED_PROFILE_NAMES = new Set<string>([
+  "latency-optimized",
+  ...BACKUP_PROFILE_KEYS,
+]);
 
 // All managed profiles, including the flag-gated os-beta, are invariant:
 // their MANAGED-SOURCE entries are read-only to user-facing writes except
@@ -423,6 +532,7 @@ export const CODE_OWNED_PROFILE_NAMES = new Set<string>(["latency-optimized"]);
 // the on-disk entry's `source` being `managed`.
 export const INVARIANT_PROFILE_NAMES = new Set<string>([
   ...DEFAULT_PROFILE_KEYS,
+  ...BACKUP_PROFILE_KEYS,
   OS_BETA_PROFILE_KEY,
 ]);
 
@@ -435,6 +545,7 @@ export const INVARIANT_PROFILE_NAMES = new Set<string>([
 // same-named user profile.
 export const MANAGED_PROFILE_NAMES = new Set<string>([
   ...DEFAULT_PROFILE_KEYS,
+  ...BACKUP_PROFILE_KEYS,
   OS_BETA_PROFILE_KEY,
 ]);
 
@@ -502,6 +613,22 @@ for (const key of DEFAULT_PROFILE_KEYS) {
   }
 }
 
+// Backup profiles get the same eager verification as the vellum column: a
+// pinned model that no managed upstream serves would make the fallback route
+// undispatchable exactly when it is needed. The cross-provider rule (backup
+// upstream differs from the primary's) is asserted in
+// __tests__/default-profile-catalog-fallback.test.ts, arm pins included.
+for (const key of BACKUP_PROFILE_KEYS) {
+  const impl = BACKUP_PROFILE_IMPLS[key];
+  if (impl.model == null || getManagedUpstream(impl.model) === null) {
+    throw new Error(
+      `BACKUP_PROFILE_IMPLS[${key}] references model "${impl.model ?? ""}" ` +
+        `which is not served by any managed upstream. ` +
+        `Update model-catalog.ts or default-profile-catalog.ts.`,
+    );
+  }
+}
+
 // The experiment arms substitute into the managed column at request time, so
 // they need the same routability guarantee as the pins validated above: a
 // LaunchDarkly arm must never select a model no managed upstream serves.
@@ -540,6 +667,10 @@ function buildDefaultProfileEntries(): Record<string, ProfileEntry> {
   const entries: Record<string, ProfileEntry> = {};
   for (const key of DEFAULT_PROFILE_KEYS) {
     const impl = PROFILE_IMPLS[key].vellum;
+    entries[key] = materializeProfile(impl, impl.provider);
+  }
+  for (const key of BACKUP_PROFILE_KEYS) {
+    const impl = BACKUP_PROFILE_IMPLS[key];
     entries[key] = materializeProfile(impl, impl.provider);
   }
   entries[OS_BETA_PROFILE_KEY] = materializeProfile(
@@ -617,6 +748,16 @@ function resolveAgainstBody(
   body: ProfileEntry | undefined,
 ): ProfileEntry | undefined {
   if (body == null) {
+    // A managed stub is the workspace's slot for a code-owned profile, never
+    // a profile of its own, so with no body behind it there is nothing to
+    // resolve. Only a backup name reaches this branch with a stub (the
+    // default keys always have a body), and it reaches it on the columns
+    // where the backups do not exist. Resolving to the stub would list a
+    // profile with no provider or model and let a reference to it look
+    // valid, which is precisely what `LLMSchema` rejects on those columns.
+    if (isBackupProfileKey(name) && workspace?.source === "managed") {
+      return undefined;
+    }
     return workspace;
   }
   if (CODE_OWNED_PROFILE_NAMES.has(name)) {
@@ -706,6 +847,18 @@ function defaultProfileBodyForProvider(
   defaultProvider: DefaultProviderConfig | null,
 ): ProfileEntry | undefined {
   if (!isDefaultProfileKey(name)) {
+    // Backup profiles are companions of the managed (`vellum`) column only:
+    // under a BYOK or chatgpt default provider the primaries carry no
+    // `fallbackProfile` pointers, and the backups must not materialize
+    // either, since the install may hold no credential for the backup's
+    // provider. A null defaultProvider predates `llm.defaultProvider` and
+    // resolves to the managed column, so it keeps its backups.
+    if (
+      isBackupProfileKey(name) &&
+      !backupProfilesResolveUnderDefaultProvider(defaultProvider)
+    ) {
+      return undefined;
+    }
     return CODE_DEFAULT_PROFILE_ENTRIES[name];
   }
   if (defaultProvider == null) {
@@ -752,6 +905,15 @@ function clampMaxTokensToModelCap(body: ProfileEntry): ProfileEntry {
  * available code default, merged per `getEffectiveProfile`. This is the
  * record all runtime readers of `llm.profiles` should consume; the raw
  * workspace record is a write-path concern.
+ *
+ * Deliberately provider-agnostic: it lists the managed backups whatever
+ * `llm.defaultProvider` says, because it resolves names against the passed
+ * catalog alone and never reads config. Any caller that JUDGES AVAILABILITY
+ * (is this name selectable? does this reference still resolve?) must use
+ * `getEffectiveProfilesForProvider` instead, which hides the backups on the
+ * BYOK and ChatGPT columns the same way `resolveDefaultProfileForProvider`
+ * does. Duplicating that conditioning here would fork the rule across two
+ * functions, and the sibling already owns it.
  */
 export function getEffectiveProfiles(
   workspaceProfiles: Record<string, ProfileEntry> | undefined,
@@ -794,7 +956,13 @@ export function getEffectiveProfilesForProvider(
     );
     if (entry != null) {
       effective[name] = entry;
+      continue;
     }
+    // Nothing resolved, so the name must not survive from the workspace
+    // spread above: a backup carrying only a managed stub on a column that
+    // has no backups would otherwise be listed as an available profile with
+    // no provider or model behind it.
+    delete effective[name];
   }
   return effective;
 }

--- a/assistant/src/config/default-profile-catalog.ts
+++ b/assistant/src/config/default-profile-catalog.ts
@@ -428,7 +428,7 @@ export const PROFILE_IMPLS: Record<
 /**
  * Managed profiles, i.e. the `vellum` column keyed by profile name, plus the
  * managed backup profiles. Backups come after the primaries, which is what
- * places them after the primaries in `profileOrder` presentation: the seeder
+ * places them after the primaries in the seeded `profileOrder`: the seeder
  * inserts missing managed keys in this record's order. Keyed by the
  * user-facing defaults only: an internal profile is code-resolved and never
  * listed or ordered.
@@ -907,12 +907,11 @@ function clampMaxTokensToModelCap(body: ProfileEntry): ProfileEntry {
  *
  * Deliberately provider-agnostic: it lists the managed backups whatever
  * `llm.defaultProvider` says, because it resolves names against the passed
- * catalog alone and never reads config. Any caller that JUDGES AVAILABILITY
- * (is this name selectable? does this reference still resolve?) must use
- * `getEffectiveProfilesForProvider` instead, which hides the backups on the
- * BYOK and ChatGPT columns the same way `resolveDefaultProfileForProvider`
- * does. Duplicating that conditioning here would fork the rule across two
- * functions, and the sibling already owns it.
+ * catalog alone and never reads config. Internal resolution and reference
+ * validation use `getEffectiveProfilesForProvider`; user-facing selectors use
+ * `getUserSelectableProfilesForProvider`, which additionally removes backups
+ * from the managed column. Keeping those views separate lets automatic
+ * fallback resolve an internal route without offering it as a direct choice.
  */
 export function getEffectiveProfiles(
   workspaceProfiles: Record<string, ProfileEntry> | undefined,
@@ -964,4 +963,23 @@ export function getEffectiveProfilesForProvider(
     delete effective[name];
   }
   return effective;
+}
+
+/**
+ * The effective profile view used by user-facing selectors. Managed backups
+ * remain in the full effective catalog for automatic fallback resolution, but
+ * are internal routes rather than profiles a user can choose directly.
+ */
+export function getUserSelectableProfilesForProvider(
+  workspaceProfiles: Record<string, ProfileEntry> | undefined,
+  defaultProvider: DefaultProviderConfig | null,
+): Record<string, ProfileEntry> {
+  const selectable = getEffectiveProfilesForProvider(
+    workspaceProfiles,
+    defaultProvider,
+  );
+  for (const name of BACKUP_PROFILE_KEYS) {
+    delete selectable[name];
+  }
+  return selectable;
 }

--- a/assistant/src/config/default-profile-catalog.ts
+++ b/assistant/src/config/default-profile-catalog.ts
@@ -17,6 +17,7 @@ import {
   type DefaultProfileProvider,
   FALLBACK_PROFILE_BY_KEY,
   isBackupProfileKey,
+  isDefaultProfileKey,
   isDefaultProfileProvider,
   OS_BETA_PROFILE_KEY,
 } from "./default-profile-names.js";
@@ -811,9 +812,7 @@ export function resolveDefaultProfileForProvider(
   );
 }
 
-export function isDefaultProfileKey(name: string): name is DefaultProfileKey {
-  return (DEFAULT_PROFILE_KEYS as readonly string[]).includes(name);
-}
+export { isDefaultProfileKey } from "./default-profile-names.js";
 
 /**
  * The implementation of default profile `key` on `provider`: the named matrix

--- a/assistant/src/config/default-profile-names.ts
+++ b/assistant/src/config/default-profile-names.ts
@@ -27,6 +27,43 @@ export const DEFAULT_PROFILE_KEYS = [
 export type DefaultProfileKey = (typeof DEFAULT_PROFILE_KEYS)[number];
 
 /**
+ * Stable keys of the managed backup profiles, one per default profile.
+ * Deliberately NOT part of `DEFAULT_PROFILE_KEYS`: that array drives picker
+ * order and the intent x provider matrix, while backups are companions of
+ * the managed (`vellum`) column only. Each backup pins a model at a
+ * different upstream provider than its primary, so an outage at the
+ * primary's provider can be served by re-sending on the backup (see the
+ * `fallbackProfile` field on `ProfileEntry`).
+ */
+export const BACKUP_PROFILE_KEYS = [
+  "balanced-backup",
+  "quality-optimized-backup",
+  "cost-optimized-backup",
+  "latency-optimized-backup",
+] as const;
+export type BackupProfileKey = (typeof BACKUP_PROFILE_KEYS)[number];
+
+/**
+ * The backup profile each default profile falls back to. Applied to the
+ * managed (`vellum`) column implementations only: BYOK installs may hold no
+ * credential for the backup's provider, so their columns carry no
+ * `fallbackProfile` pointers.
+ */
+export const FALLBACK_PROFILE_BY_KEY: Record<
+  DefaultProfileKey,
+  BackupProfileKey
+> = {
+  balanced: "balanced-backup",
+  "quality-optimized": "quality-optimized-backup",
+  "cost-optimized": "cost-optimized-backup",
+  "latency-optimized": "latency-optimized-backup",
+};
+
+export function isBackupProfileKey(value: string): value is BackupProfileKey {
+  return (BACKUP_PROFILE_KEYS as readonly string[]).includes(value);
+}
+
+/**
  * Flag-gated default profile: only available while the `os-beta` feature
  * flag has reconciled it into the workspace (see `sync-gated-profiles.ts`).
  * Deliberately NOT part of `DEFAULT_PROFILE_KEYS`: it is never

--- a/assistant/src/config/default-profile-names.ts
+++ b/assistant/src/config/default-profile-names.ts
@@ -59,6 +59,10 @@ export const FALLBACK_PROFILE_BY_KEY: Record<
   "latency-optimized": "latency-optimized-backup",
 };
 
+export function isDefaultProfileKey(value: string): value is DefaultProfileKey {
+  return (DEFAULT_PROFILE_KEYS as readonly string[]).includes(value);
+}
+
 export function isBackupProfileKey(value: string): value is BackupProfileKey {
   return (BACKUP_PROFILE_KEYS as readonly string[]).includes(value);
 }

--- a/assistant/src/config/inference-profile-validation.ts
+++ b/assistant/src/config/inference-profile-validation.ts
@@ -1,16 +1,25 @@
-import { getEffectiveProfiles } from "./default-profile-catalog.js";
+import { getEffectiveProfilesForProvider } from "./default-profile-catalog.js";
 import { getConfigReadOnly } from "./loader.js";
 
 /**
  * Validate an inference-profile key against the effective profile catalog
  * (code-defined defaults + workspace `llm.profiles`). Returns a user-facing
  * error message when the key is empty or unknown, or `null` when valid.
+ *
+ * Resolved through the `llm.defaultProvider`-aware view so availability
+ * matches what actually dispatches: the managed backup profiles exist on the
+ * managed column only, so on a BYOK or ChatGPT install they are not
+ * selectable and must not be reported as available.
  */
 export function validateInferenceProfileKey(profile: string): string | null {
   if (!profile.trim()) {
     return "inferenceProfile must be a non-empty string";
   }
-  const profiles = getEffectiveProfiles(getConfigReadOnly().llm?.profiles);
+  const llm = getConfigReadOnly().llm;
+  const profiles = getEffectiveProfilesForProvider(
+    llm?.profiles,
+    llm?.defaultProvider ?? null,
+  );
   const entry = profiles[profile];
   if (entry === undefined) {
     const available = Object.keys(profiles).sort();

--- a/assistant/src/config/inference-profile-validation.ts
+++ b/assistant/src/config/inference-profile-validation.ts
@@ -1,4 +1,4 @@
-import { getEffectiveProfilesForProvider } from "./default-profile-catalog.js";
+import { getUserSelectableProfilesForProvider } from "./default-profile-catalog.js";
 import { getConfigReadOnly } from "./loader.js";
 
 /**
@@ -6,17 +6,17 @@ import { getConfigReadOnly } from "./loader.js";
  * (code-defined defaults + workspace `llm.profiles`). Returns a user-facing
  * error message when the key is empty or unknown, or `null` when valid.
  *
- * Resolved through the `llm.defaultProvider`-aware view so availability
- * matches what actually dispatches: the managed backup profiles exist on the
- * managed column only, so on a BYOK or ChatGPT install they are not
- * selectable and must not be reported as available.
+ * Resolved through the `llm.defaultProvider`-aware user-selectable view so
+ * availability matches what a direct profile pin can choose. Managed backup
+ * routes remain available to automatic fallback resolution but are not
+ * reported as selectable profiles.
  */
 export function validateInferenceProfileKey(profile: string): string | null {
   if (!profile.trim()) {
     return "inferenceProfile must be a non-empty string";
   }
   const llm = getConfigReadOnly().llm;
-  const profiles = getEffectiveProfilesForProvider(
+  const profiles = getUserSelectableProfilesForProvider(
     llm?.profiles,
     llm?.defaultProvider ?? null,
   );

--- a/assistant/src/config/llm-resolver.ts
+++ b/assistant/src/config/llm-resolver.ts
@@ -485,6 +485,7 @@ function winnerConfigFragment(entry: ProfileEntry): Mergeable {
     description: _description,
     status: _status,
     mix: _mix,
+    fallbackProfile: _fallbackProfile,
     ...config
   } = entry;
   return config as Mergeable;

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -622,6 +622,15 @@ export const ProfileEntry = LLMConfigFragment.extend({
    * may accompany `mix`.
    */
   mix: MixSchema.optional(),
+  /**
+   * Name of another profile to fall back to when this profile's model
+   * fails with an outage-type error (retries exhausted, invalid managed
+   * credential, unknown model). Single hop: the referenced profile must
+   * not declare its own fallbackProfile. Managed (`vellum`) profiles
+   * only, since BYOK installs may hold no credential for the backup
+   * provider.
+   */
+  fallbackProfile: z.string().min(1).optional(),
 });
 export type ProfileEntry = z.infer<typeof ProfileEntry>;
 
@@ -670,6 +679,101 @@ const DefaultProviderField = DefaultProviderSchema.optional().catch(undefined);
 // ---------------------------------------------------------------------------
 // Top-level LLM schema
 // ---------------------------------------------------------------------------
+
+/**
+ * Cross-profile integrity checks for `fallbackProfile` pointers: (a) the
+ * referenced profile exists, (b) a profile does not fall back to itself,
+ * (c) the referenced profile is not a mix (a fallback must be a directly
+ * dispatchable route), (d) the referenced profile does not itself set
+ * `fallbackProfile` (fallback is a single hop in v1, never a chain), and
+ * (e) a mix profile carries no `fallbackProfile` of its own (a mix has no
+ * route of its own to fall back from).
+ *
+ * Shared by `LLMSchema.superRefine` (full-config load) and the config write
+ * paths (`commitConfigWrite`), which persist raw config without a
+ * full-schema parse. Accepts a raw or parsed `llm.profiles` record; entries
+ * are read defensively so the raw on-disk shape is safe to pass.
+ */
+export function collectFallbackProfileIssues(
+  profiles: Record<string, unknown> | undefined,
+): { profileName: string; message: string }[] {
+  const issues: { profileName: string; message: string }[] = [];
+  const entries = Object.entries(profiles ?? {});
+  const readEntry = (value: unknown): Record<string, unknown> | null =>
+    value != null && typeof value === "object" && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : null;
+  // The always-available default profiles are code-defined
+  // (`default-profile-catalog.ts`) and resolve whether or not they are
+  // materialized in `llm.profiles`, so their names are always valid
+  // fallback targets (same rule as call-site `profile` references).
+  const profileNames = new Set([
+    ...entries.map(([name]) => name),
+    ...DEFAULT_PROFILE_KEYS,
+  ]);
+  const mixProfileNames = new Set(
+    entries
+      .filter(([, value]) => readEntry(value)?.mix != null)
+      .map(([name]) => name),
+  );
+  for (const [name, value] of entries) {
+    const entry = readEntry(value);
+    const fallback = entry?.fallbackProfile;
+    if (fallback == null) {
+      continue;
+    }
+    // Raw writes (e.g. `config set`) can carry a non-string value the field
+    // schema would reject on the next full parse; flag it here so it never
+    // reaches disk.
+    if (typeof fallback !== "string" || fallback.length === 0) {
+      issues.push({
+        profileName: name,
+        message: `Profile "${name}" declares a fallbackProfile that must be a non-empty string naming another profile.`,
+      });
+      continue;
+    }
+    // (e) A mix carries no route of its own to fall back from.
+    if (entry?.mix != null) {
+      issues.push({
+        profileName: name,
+        message: `Mix profile "${name}" cannot also set "fallbackProfile"; a mix only references other profiles plus metadata.`,
+      });
+      continue;
+    }
+    // (b) No self-reference.
+    if (fallback === name) {
+      issues.push({
+        profileName: name,
+        message: `Profile "${name}" cannot declare itself as its fallbackProfile.`,
+      });
+      continue;
+    }
+    // (a) Referenced profile must exist.
+    if (!profileNames.has(fallback)) {
+      issues.push({
+        profileName: name,
+        message: `Profile "${name}" declares fallbackProfile "${fallback}" which is not defined in llm.profiles.`,
+      });
+      continue;
+    }
+    // (c) A fallback target must be a standard (non-mix) profile.
+    if (mixProfileNames.has(fallback)) {
+      issues.push({
+        profileName: name,
+        message: `Profile "${name}" declares fallbackProfile "${fallback}" which is a mix profile; a fallback must be a standard profile.`,
+      });
+      continue;
+    }
+    // (d) Single hop only: the target must not declare its own fallback.
+    if (readEntry(profiles?.[fallback])?.fallbackProfile != null) {
+      issues.push({
+        profileName: name,
+        message: `Profile "${name}" declares fallbackProfile "${fallback}" which sets its own fallbackProfile; fallback is a single hop, chains are not allowed.`,
+      });
+    }
+  }
+  return issues;
+}
 
 export const LLMSchema = z
   .object({
@@ -776,11 +880,13 @@ export const LLMSchema = z
     // --- Mix profile validation --------------------------------------------
     // Config keys a mix profile must NOT also set (a mix only references other
     // profiles + metadata). Derived from the fragment shape plus the
-    // ProfileEntry-only `provider_connection` so it can't drift if a new config
-    // field is added to `LLMConfigFragment`.
+    // ProfileEntry-only `provider_connection` and `fallbackProfile` (a mix
+    // carries no config of its own, so it has no route to fall back from) so
+    // it can't drift if a new config field is added to `LLMConfigFragment`.
     const MIX_DISALLOWED_CONFIG_KEYS = [
       ...Object.keys(LLMConfigFragment.shape),
       "provider_connection",
+      "fallbackProfile",
     ];
     const mixProfileNames = new Set(
       Object.entries(config.profiles ?? {})
@@ -830,6 +936,19 @@ export const LLMSchema = z
           });
         }
       }
+    }
+
+    // --- fallbackProfile validation ----------------------------------------
+    // Cross-profile fallback rules live in `collectFallbackProfileIssues`
+    // (shared with the config write paths). A mix profile setting
+    // `fallbackProfile` is also rejected by the mix validation above
+    // (MIX_DISALLOWED_CONFIG_KEYS).
+    for (const issue of collectFallbackProfileIssues(config.profiles)) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["profiles", issue.profileName, "fallbackProfile"],
+        message: issue.message,
+      });
     }
   });
 

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -11,8 +11,10 @@ import {
   parseVellumModel,
 } from "../../providers/vellum-model-routing.js";
 import {
+  BACKUP_PROFILE_KEYS,
   DEFAULT_PROFILE_KEYS,
   DEFAULT_PROFILE_PROVIDERS,
+  isBackupProfileKey,
 } from "../default-profile-names.js";
 
 /**
@@ -676,6 +678,92 @@ export type DefaultProviderConfig = z.infer<typeof DefaultProviderSchema>;
  */
 const DefaultProviderField = DefaultProviderSchema.optional().catch(undefined);
 
+/**
+ * Whether the managed backup profiles (`BACKUP_PROFILE_KEYS`) resolve under a
+ * given `llm.defaultProvider`.
+ *
+ * Backups are companions of the managed (`vellum`) column only: on a BYOK or
+ * ChatGPT default provider `defaultProfileBodyForProvider` returns `undefined`
+ * for them, because the install may hold no credential for the backup's
+ * upstream. So a reference to one is a target that can never resolve there,
+ * and the schema must reject it rather than preserve a selection the picker
+ * cannot show.
+ *
+ * Accepts an unknown value so the raw write paths (which validate on-disk
+ * shapes without a full parse) can share the rule. A missing or malformed
+ * value resolves to the managed column: `DefaultProviderField` catches an
+ * invalid value to `undefined`, and an install predating
+ * `llm.defaultProvider` is managed by definition.
+ */
+export function backupProfilesResolveUnderDefaultProvider(
+  defaultProvider: unknown,
+): boolean {
+  const provider =
+    defaultProvider != null &&
+    typeof defaultProvider === "object" &&
+    !Array.isArray(defaultProvider)
+      ? (defaultProvider as Record<string, unknown>).provider
+      : undefined;
+  return typeof provider !== "string" || provider === "vellum";
+}
+
+/**
+ * Why a referenced profile name does not resolve, for the reference error
+ * messages. A backup key under a non-managed default provider gets its own
+ * reason: the name is real and code-defined, it just has no body outside the
+ * managed column, and "not defined in llm.profiles" would send the reader
+ * looking for a missing entry that was never supposed to exist.
+ */
+function unresolvableProfileReason(
+  name: string,
+  backupsResolve: boolean,
+): string {
+  return !backupsResolve &&
+    (BACKUP_PROFILE_KEYS as readonly string[]).includes(name)
+    ? "is a managed backup profile, which resolves only while llm.defaultProvider is the managed provider"
+    : "is not defined in llm.profiles";
+}
+
+/**
+ * The `llm.profiles` keys that are reference targets in their own right,
+ * given whether the managed backups resolve under the current
+ * `llm.defaultProvider`.
+ *
+ * Every on-disk key qualifies but one: a reserved backup name whose entry is
+ * a thin `source: "managed"` stub. The stub is not a profile, it is the
+ * workspace's slot for a code-owned one, and it can reach disk on a managed
+ * install through nothing more than a `config get` -> `config set` round-trip
+ * of the effective profile list (`normalizeManagedProfileWrites` reduces the
+ * echoed body to exactly that stub). Counting it as an ordinary raw key would
+ * let it launder a backup reference past the provider gate: after a switch to
+ * a BYOK or ChatGPT default provider the reference would keep validating
+ * while the code-owned body it stands for has resolved to nothing, leaving a
+ * selection that names a providerless stub.
+ *
+ * A genuinely user-owned entry under a backup name is the opposite case: it
+ * carries its own body, and with no code-owned body to lose on a non-managed
+ * column `resolveAgainstBody` resolves the workspace entry itself. So it
+ * stays a valid target on every column. The `source` test is the same one
+ * the resolver uses, which is what keeps the two in step.
+ */
+function referenceableProfileKeys(
+  profiles: Record<string, unknown> | undefined,
+  backupsResolve: boolean,
+): string[] {
+  return Object.entries(profiles ?? {})
+    .filter(([name, value]) => {
+      if (backupsResolve || !isBackupProfileKey(name)) {
+        return true;
+      }
+      const entry =
+        value != null && typeof value === "object" && !Array.isArray(value)
+          ? (value as Record<string, unknown>)
+          : null;
+      return entry != null && entry.source !== "managed";
+    })
+    .map(([name]) => name);
+}
+
 // ---------------------------------------------------------------------------
 // Top-level LLM schema
 // ---------------------------------------------------------------------------
@@ -693,9 +781,14 @@ const DefaultProviderField = DefaultProviderSchema.optional().catch(undefined);
  * paths (`commitConfigWrite`), which persist raw config without a
  * full-schema parse. Accepts a raw or parsed `llm.profiles` record; entries
  * are read defensively so the raw on-disk shape is safe to pass.
+ *
+ * `defaultProvider` is the sibling `llm.defaultProvider` value (raw or
+ * parsed): it decides whether the managed backups are valid targets, since
+ * they resolve on the managed column alone.
  */
 export function collectFallbackProfileIssues(
   profiles: Record<string, unknown> | undefined,
+  defaultProvider?: unknown,
 ): { profileName: string; message: string }[] {
   const issues: { profileName: string; message: string }[] = [];
   const entries = Object.entries(profiles ?? {});
@@ -706,10 +799,17 @@ export function collectFallbackProfileIssues(
   // The always-available default profiles are code-defined
   // (`default-profile-catalog.ts`) and resolve whether or not they are
   // materialized in `llm.profiles`, so their names are always valid
-  // fallback targets (same rule as call-site `profile` references).
+  // fallback targets (same rule as call-site `profile` references). The
+  // managed backups resolve the same way, but on the managed column only,
+  // so they are valid targets only under a managed `llm.defaultProvider`.
+  // A persisted managed stub for a backup name does not change that, see
+  // `referenceableProfileKeys`.
+  const backupsResolve =
+    backupProfilesResolveUnderDefaultProvider(defaultProvider);
   const profileNames = new Set([
-    ...entries.map(([name]) => name),
+    ...referenceableProfileKeys(profiles, backupsResolve),
     ...DEFAULT_PROFILE_KEYS,
+    ...(backupsResolve ? BACKUP_PROFILE_KEYS : []),
   ]);
   const mixProfileNames = new Set(
     entries
@@ -752,7 +852,7 @@ export function collectFallbackProfileIssues(
     if (!profileNames.has(fallback)) {
       issues.push({
         profileName: name,
-        message: `Profile "${name}" declares fallbackProfile "${fallback}" which is not defined in llm.profiles.`,
+        message: `Profile "${name}" declares fallbackProfile "${fallback}" which ${unresolvableProfileReason(fallback, backupsResolve)}.`,
       });
       continue;
     }
@@ -837,12 +937,29 @@ export const LLMSchema = z
     // The always-available default profiles are code-defined
     // (`default-profile-catalog.ts`) and resolve whether or not they are
     // materialized in `llm.profiles`, so their names are always valid
-    // reference targets. The flag-gated `os-beta` is excluded: it resolves
-    // only while a workspace entry exists, so a reference to it is valid
-    // only when that entry is present in `config.profiles`.
+    // reference targets. The managed backups (`BACKUP_PROFILE_KEYS`) are
+    // code-defined on the same terms and are listed in the effective
+    // catalog, so a selection naming one (`activeProfile`, `advisorProfile`,
+    // a call-site pin) must survive the next load rather than being stripped
+    // back to a default. Backups are scoped to the managed column though, so
+    // they join the set only under a managed `llm.defaultProvider`: on a BYOK
+    // or ChatGPT default provider they have no body to resolve to, and
+    // keeping the reference would strand a selection the picker cannot show.
+    // The flag-gated `os-beta` is excluded: it resolves only while a
+    // workspace entry exists, so a reference to it is valid only when that
+    // entry is present in `config.profiles`. A backup name materialized as a
+    // thin managed stub does not re-enter the set on a non-managed column
+    // either, see `referenceableProfileKeys`.
+    const backupsResolve = backupProfilesResolveUnderDefaultProvider(
+      config.defaultProvider,
+    );
     const profileNames = new Set([
-      ...Object.keys(config.profiles ?? {}),
+      ...referenceableProfileKeys(
+        config.profiles as Record<string, unknown> | undefined,
+        backupsResolve,
+      ),
       ...DEFAULT_PROFILE_KEYS,
+      ...(backupsResolve ? BACKUP_PROFILE_KEYS : []),
     ]);
     for (const [siteId, siteConfig] of Object.entries(config.callSites ?? {})) {
       if (siteConfig?.profile == null) {
@@ -852,7 +969,7 @@ export const LLMSchema = z
         ctx.addIssue({
           code: "custom",
           path: ["callSites", siteId, "profile"],
-          message: `Profile "${siteConfig.profile}" referenced by call site "${siteId}" is not defined in llm.profiles`,
+          message: `Profile "${siteConfig.profile}" referenced by call site "${siteId}" ${unresolvableProfileReason(siteConfig.profile, backupsResolve)}`,
         });
       }
     }
@@ -863,7 +980,7 @@ export const LLMSchema = z
       ctx.addIssue({
         code: "custom",
         path: ["activeProfile"],
-        message: `Profile "${config.activeProfile}" referenced by llm.activeProfile is not defined in llm.profiles`,
+        message: `Profile "${config.activeProfile}" referenced by llm.activeProfile ${unresolvableProfileReason(config.activeProfile, backupsResolve)}`,
       });
     }
     if (
@@ -873,7 +990,7 @@ export const LLMSchema = z
       ctx.addIssue({
         code: "custom",
         path: ["advisorProfile"],
-        message: `Profile "${config.advisorProfile}" referenced by llm.advisorProfile is not defined in llm.profiles`,
+        message: `Profile "${config.advisorProfile}" referenced by llm.advisorProfile ${unresolvableProfileReason(config.advisorProfile, backupsResolve)}`,
       });
     }
 
@@ -923,7 +1040,7 @@ export const LLMSchema = z
           ctx.addIssue({
             code: "custom",
             path: ["profiles", name, "mix", index, "profile"],
-            message: `Mix profile "${name}" references profile "${arm.profile}" which is not defined in llm.profiles.`,
+            message: `Mix profile "${name}" references profile "${arm.profile}" which ${unresolvableProfileReason(arm.profile, backupsResolve)}.`,
           });
           continue;
         }
@@ -943,7 +1060,10 @@ export const LLMSchema = z
     // (shared with the config write paths). A mix profile setting
     // `fallbackProfile` is also rejected by the mix validation above
     // (MIX_DISALLOWED_CONFIG_KEYS).
-    for (const issue of collectFallbackProfileIssues(config.profiles)) {
+    for (const issue of collectFallbackProfileIssues(
+      config.profiles,
+      config.defaultProvider,
+    )) {
       ctx.addIssue({
         code: "custom",
         path: ["profiles", issue.profileName, "fallbackProfile"],

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -14,7 +14,9 @@ import {
   BACKUP_PROFILE_KEYS,
   DEFAULT_PROFILE_KEYS,
   DEFAULT_PROFILE_PROVIDERS,
+  FALLBACK_PROFILE_BY_KEY,
   isBackupProfileKey,
+  isDefaultProfileKey,
 } from "../default-profile-names.js";
 
 /**
@@ -625,14 +627,12 @@ export const ProfileEntry = LLMConfigFragment.extend({
    */
   mix: MixSchema.optional(),
   /**
-   * Name of another profile to fall back to when this profile's model
-   * fails with an outage-type error (retries exhausted, invalid managed
-   * credential, unknown model). Single hop: the referenced profile must
-   * not declare its own fallbackProfile. Managed (`vellum`) profiles
-   * only, since BYOK installs may hold no credential for the backup
-   * provider.
+   * Code-owned backup profile for a Vellum-managed default profile. This is
+   * read-only metadata from the default-profile catalog. Config write paths
+   * reject user-authored values because custom and BYOK fallback routes are
+   * not supported.
    */
-  fallbackProfile: z.string().min(1).optional(),
+  fallbackProfile: z.string().min(1).optional().meta({ readOnly: true }),
 });
 export type ProfileEntry = z.infer<typeof ProfileEntry>;
 
@@ -769,13 +769,10 @@ function referenceableProfileKeys(
 // ---------------------------------------------------------------------------
 
 /**
- * Cross-profile integrity checks for `fallbackProfile` pointers: (a) the
- * referenced profile exists, (b) a profile does not fall back to itself,
- * (c) the referenced profile is not a mix (a fallback must be a directly
- * dispatchable route), (d) the referenced profile does not itself set
- * `fallbackProfile` (fallback is a single hop in v1, never a chain), and
- * (e) a mix profile carries no `fallbackProfile` of its own (a mix has no
- * route of its own to fall back from).
+ * Cross-profile integrity checks for `fallbackProfile` metadata. Only the
+ * exact code-owned mapping on managed default profiles is accepted. The
+ * referenced profile must exist, must not be a mix, and must not declare a
+ * fallback of its own.
  *
  * Shared by `LLMSchema.superRefine` (full-config load) and the config write
  * paths (`commitConfigWrite`), which persist raw config without a
@@ -829,6 +826,16 @@ export function collectFallbackProfileIssues(
       issues.push({
         profileName: name,
         message: `Profile "${name}" declares a fallbackProfile that must be a non-empty string naming another profile.`,
+      });
+      continue;
+    }
+    const expectedFallback = isDefaultProfileKey(name)
+      ? FALLBACK_PROFILE_BY_KEY[name]
+      : undefined;
+    if (entry?.source !== "managed" || fallback !== expectedFallback) {
+      issues.push({
+        profileName: name,
+        message: `Profile "${name}" cannot configure fallbackProfile. Automatic fallbacks are code-owned for Vellum-managed default profiles.`,
       });
       continue;
     }

--- a/assistant/src/config/seed-inference-profiles.ts
+++ b/assistant/src/config/seed-inference-profiles.ts
@@ -9,13 +9,17 @@ import { PROVIDER_CATALOG } from "../providers/model-catalog.js";
 import { credentialKey } from "../security/credential-key.js";
 import { getLogger } from "../util/logger.js";
 import {
-  getEffectiveProfiles,
+  getEffectiveProfilesForProvider,
   MANAGED_PROFILE_NAMES,
   MANAGED_PROFILE_TEMPLATES,
 } from "./default-profile-catalog.js";
 import { loadRawConfig, saveRawConfig } from "./loader.js";
 import { isDispatchableProfile } from "./profile-dispatchability.js";
-import { isDefaultProviderChoice, type ProfileEntry } from "./schemas/llm.js";
+import {
+  type DefaultProviderConfig,
+  isDefaultProviderChoice,
+  type ProfileEntry,
+} from "./schemas/llm.js";
 
 const log = getLogger("seed-inference-profiles");
 
@@ -141,8 +145,13 @@ export function seedInferenceProfiles(
   // Profile lookups below go through the effective view: a default profile
   // resolves from the code catalog whether or not the workspace carries a
   // stub for it, and a stub contributes only its status/label overlays.
-  const effectiveProfiles = getEffectiveProfiles(
+  // Resolved against `llm.defaultProvider` so the managed backups count as
+  // available only on the managed column, matching what the schema accepts
+  // as a reference: an `activeProfile` naming a backup on a BYOK install is
+  // then repaired here rather than preserved as a dangling selection.
+  const effectiveProfiles = getEffectiveProfilesForProvider(
     profiles as Record<string, ProfileEntry>,
+    seedResolutionDefaultProvider(llm),
   ) as Record<string, Record<string, unknown>>;
 
   // Active profile resolution.
@@ -228,6 +237,26 @@ export function seedInferenceProfiles(
   }
 
   saveRawConfig(config);
+}
+
+/**
+ * The `llm.defaultProvider` to resolve the effective catalog against, read
+ * from RAW config. Only a value the matrix can implement is used: a
+ * hand-edited or legacy provider outside `DEFAULT_PROVIDER_CHOICES` has no
+ * column and no verified intent resolution, so materializing against it
+ * could throw and fail the whole boot seed. Such a value falls back to
+ * `null`, which resolves the managed column.
+ */
+function seedResolutionDefaultProvider(
+  llm: Record<string, unknown>,
+): DefaultProviderConfig | null {
+  const raw = readObject(llm.defaultProvider);
+  const provider = readString(raw?.provider);
+  if (provider === undefined || !isDefaultProviderChoice(provider)) {
+    return null;
+  }
+  const connectionName = readString(raw?.connectionName);
+  return { provider, ...(connectionName ? { connectionName } : {}) };
 }
 
 export function readObject(value: unknown): Record<string, unknown> | null {

--- a/assistant/src/context/compactor.ts
+++ b/assistant/src/context/compactor.ts
@@ -76,6 +76,40 @@ const COMPACTION_CALL_SITE: LLMCallSite = "mainAgent";
 const COMPACTION_LOG_CALL_SITE: LLMCallSite = "compactionAgent";
 
 /**
+ * What actually served a compaction call, for attribution on both the request
+ * log and the usage row. A wrapper may reroute the request away from the
+ * caller's resolution (`RetryProvider`'s fallback-profile escalation), in
+ * which case the response carries the provider and profile that answered.
+ *
+ * Single source of truth on purpose: the request log and the usage row must
+ * never disagree about which provider ran, and every result-construction site
+ * below spreads {@link servedAttribution} rather than re-deriving the pair.
+ */
+function servedProvider(
+  response: ProviderResponse,
+  provider: Provider,
+): string {
+  return response.actualProvider ?? provider.name;
+}
+
+function servedAttribution(
+  response: ProviderResponse,
+  provider: Provider,
+): Pick<
+  CompactionRunResult,
+  "summaryActualProvider" | "summaryActualInferenceProfile"
+> {
+  return {
+    summaryActualProvider: servedProvider(response, provider),
+    // Only present on a reroute. Absent leaves `summaryOverrideProfile` in
+    // charge, which is what the caller resolved and what actually ran.
+    ...(response.actualInferenceProfile !== undefined
+      ? { summaryActualInferenceProfile: response.actualInferenceProfile }
+      : {}),
+  };
+}
+
+/**
  * Best-effort: persist a successful compaction LLM call into
  * `llm_request_logs` with `call_site = "compactionAgent"`. The compactor
  * opts out of automatic usage tracking (`usageTracking: "manual"`), so
@@ -100,7 +134,7 @@ function recordCompactionRequestLog(
       JSON.stringify(response.rawRequest),
       JSON.stringify(response.rawResponse),
       undefined,
-      response.actualProvider ?? provider.name,
+      servedProvider(response, provider),
       COMPACTION_LOG_CALL_SITE,
     );
   } catch (err) {
@@ -321,6 +355,22 @@ export interface CompactionRunResult {
   summaryModel: string;
   summaryCallSite?: LLMCallSite;
   summaryOverrideProfile?: string | null;
+  /**
+   * Provider that actually served the summary call: the response's
+   * `actualProvider` when a wrapper rerouted the request, otherwise the
+   * configured provider's name. Set on every path that made a call, so the
+   * usage row's `provider` follows a fallback the way its `model` already
+   * does. Absent only where no call happened (see {@link emptyResult}), where
+   * the caller's own provider stands.
+   */
+  summaryActualProvider?: string;
+  /**
+   * Inference profile that actually governed the summary call, set only when
+   * a wrapper rerouted the request away from `summaryOverrideProfile`
+   * (`RetryProvider`'s fallback-profile escalation). Absent on the normal
+   * path, where `summaryOverrideProfile` is already correct.
+   */
+  summaryActualInferenceProfile?: string;
   summaryCacheCreationInputTokens?: number;
   summaryCacheReadInputTokens?: number;
   summaryRawResponses?: unknown[];
@@ -1052,6 +1102,18 @@ export function buildSummaryMemoryText(
 // Orchestrator
 // ---------------------------------------------------------------------------
 
+/**
+ * A result for every path that compacted nothing: the pre-call bail-outs
+ * (disabled, below threshold, no messages, bad boundary) and the two
+ * provider-error paths, which are spread over with `summaryFailed: true`.
+ *
+ * Deliberately carries no `summaryActualProvider` /
+ * `summaryActualInferenceProfile`: no call was served, so there is nothing to
+ * attribute to, and leaving them absent keeps the caller's own provider and
+ * profile in charge. Nothing is billed either way, since the zero token
+ * counts here make `recordUsage` return before it writes a row. The
+ * call-bearing paths below spread {@link servedAttribution} on top.
+ */
 function emptyResult(
   args: CompactionRunArgs,
   thresholdTokens: number,
@@ -1340,6 +1402,7 @@ export async function runAssistantDrivenCompaction(
       summaryInputTokens: response.usage.inputTokens,
       summaryOutputTokens: response.usage.outputTokens,
       summaryModel: response.model,
+      ...servedAttribution(response, args.provider),
       summaryCacheCreationInputTokens:
         response.usage.cacheCreationInputTokens ?? 0,
       summaryCacheReadInputTokens: response.usage.cacheReadInputTokens ?? 0,
@@ -1378,6 +1441,7 @@ export async function runAssistantDrivenCompaction(
         summaryInputTokens: response.usage.inputTokens,
         summaryOutputTokens: response.usage.outputTokens,
         summaryModel: response.model,
+        ...servedAttribution(response, args.provider),
         summaryCacheCreationInputTokens:
           response.usage.cacheCreationInputTokens ?? 0,
         summaryCacheReadInputTokens: response.usage.cacheReadInputTokens ?? 0,
@@ -1548,6 +1612,7 @@ export async function runAssistantDrivenCompaction(
       summaryInputTokens: response.usage.inputTokens,
       summaryOutputTokens: response.usage.outputTokens,
       summaryModel: response.model,
+      ...servedAttribution(response, args.provider),
       summaryCacheCreationInputTokens:
         response.usage.cacheCreationInputTokens ?? 0,
       summaryCacheReadInputTokens: response.usage.cacheReadInputTokens ?? 0,
@@ -1623,6 +1688,7 @@ export async function runAssistantDrivenCompaction(
     summaryModel: response.model,
     summaryCallSite: COMPACTION_CALL_SITE,
     summaryOverrideProfile: args.overrideProfile ?? null,
+    ...servedAttribution(response, args.provider),
     summaryCacheCreationInputTokens:
       response.usage.cacheCreationInputTokens ?? 0,
     summaryCacheReadInputTokens: response.usage.cacheReadInputTokens ?? 0,
@@ -1808,6 +1874,12 @@ export async function runEmergencyCompaction(
       summaryInputTokens: response.usage.inputTokens,
       summaryOutputTokens: response.usage.outputTokens,
       summaryModel: response.model,
+      // This path bills real tokens, so its provider must follow a reroute
+      // like every other call-bearing path. It is the one such path that sets
+      // no `summaryCallSite`/`summaryOverrideProfile`, which leaves its
+      // profile attribution null; that gap predates this change and is not
+      // widened by it.
+      ...servedAttribution(response, args.provider),
     };
   }
 
@@ -1855,6 +1927,7 @@ export async function runEmergencyCompaction(
     summaryModel: response.model,
     summaryCallSite: COMPACTION_CALL_SITE,
     summaryOverrideProfile: args.overrideProfile ?? null,
+    ...servedAttribution(response, args.provider),
     summaryCacheCreationInputTokens:
       response.usage.cacheCreationInputTokens ?? 0,
     summaryCacheReadInputTokens: response.usage.cacheReadInputTokens ?? 0,

--- a/assistant/src/daemon/conversation-agent-loop-handlers.ts
+++ b/assistant/src/daemon/conversation-agent-loop-handlers.ts
@@ -211,6 +211,15 @@ export interface EventHandlerState {
   firstAssistantText: string;
   /** Most recent resolved provider for the current exchange's usage accounting. */
   exchangeProviderName: string | undefined;
+  /**
+   * Inference profile the most recent LLM call actually ran under, set only
+   * when a wrapper rerouted that call (`RetryProvider`'s fallback-profile
+   * escalation). Overwritten by every call, exactly like
+   * `exchangeProviderName` and `model`, so the ledger row's provider, model,
+   * and profile all describe the same call. `undefined` means the last call
+   * was not rerouted and the conversation's own profile resolution stands.
+   */
+  exchangeInferenceProfile: string | undefined;
   exchangeInputTokens: number;
   exchangeCacheCreationInputTokens: number;
   exchangeCacheReadInputTokens: number;
@@ -578,6 +587,7 @@ export function createEventHandlerState(): EventHandlerState {
     pendingDirectiveDisplayBuffer: "",
     firstAssistantText: "",
     exchangeProviderName: undefined,
+    exchangeInferenceProfile: undefined,
     exchangeInputTokens: 0,
     exchangeCacheCreationInputTokens: 0,
     exchangeCacheReadInputTokens: 0,
@@ -3071,6 +3081,11 @@ function handleUsage(
 ): void {
   const providerName = event.actualProvider ?? deps.ctx.provider.name;
   state.exchangeProviderName = providerName;
+  // Assigned unconditionally, not merged: a later non-rerouted call clearing
+  // this back to `undefined` is correct, because provider and model are being
+  // overwritten from that same call. Keeping a stale profile from an earlier
+  // fallback would reintroduce the very contradiction this field prevents.
+  state.exchangeInferenceProfile = event.actualInferenceProfile;
   state.exchangeLlmCallCount += 1;
   state.exchangeInputTokens += event.inputTokens;
   state.lastCallInputTokens = event.inputTokens;

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -1684,9 +1684,23 @@ export async function runAgentLoopImpl(
         tokens: state.lastCallInputTokens,
         maxTokens: resolveCurrentMaxInputTokens(),
       },
+      // When the turn's last LLM call was rerouted to a backup profile, that
+      // profile is what served the tokens being recorded, so it outranks the
+      // conversation's own resolution, which knows nothing about the
+      // reroute. `provider` and `model` on this same row already follow the
+      // backup (via `state.exchangeProviderName` / `state.model`), so
+      // attributing the profile from the primary would write a row that
+      // contradicts itself. `forceOverrideProfile` floats it above the
+      // call-site profile exactly as the fallback dispatch did.
       {
         callSite: turnCallSite,
-        overrideProfile: resolveCurrentOverrideProfile() ?? null,
+        overrideProfile:
+          state.exchangeInferenceProfile ??
+          resolveCurrentOverrideProfile() ??
+          null,
+        ...(state.exchangeInferenceProfile !== undefined
+          ? { forceOverrideProfile: true }
+          : {}),
       },
       turnCronRunId,
     );
@@ -1975,6 +1989,13 @@ function emitUsage(
   attribution?: {
     callSite: LLMCallSite | null;
     overrideProfile?: string | null;
+    /**
+     * Float `overrideProfile` above the call-site profile, matching how the
+     * dispatch path floated it. Set when the profile being attributed is the
+     * one a reroute actually served under rather than the caller's own
+     * resolution.
+     */
+    forceOverrideProfile?: boolean;
   },
   cronRunId: string | null = null,
 ): void {
@@ -2051,6 +2072,8 @@ export async function applyCompactionResult(
     summaryRawResponses?: unknown[];
     summaryCallSite?: LLMCallSite;
     summaryOverrideProfile?: string | null;
+    summaryActualProvider?: string;
+    summaryActualInferenceProfile?: string;
   },
   onEvent: (msg: AssistantEvent) => void,
   reqId: string | null,
@@ -2125,12 +2148,26 @@ export async function applyCompactionResult(
     result.summaryCacheCreationInputTokens ?? 0,
     result.summaryCacheReadInputTokens ?? 0,
     collapseRawResponses(result.summaryRawResponses),
-    undefined /* providerName */,
+    // The provider that actually served the summary, which follows a fallback
+    // reroute the way `summaryModel` already did. Undefined only where no call
+    // was made, and `emitUsage` then falls back to `ctx.provider.name` exactly
+    // as before.
+    result.summaryActualProvider /* providerName */,
     1 /* llmCallCount */,
     undefined /* contextWindow */,
+    // Same rule as the main-agent row above, applied to the compaction row:
+    // a rerouted summary is attributed to the profile that answered, not to
+    // the one the compactor resolved before the call. The two call sites set
+    // this parameter independently off their own state and never share it.
     {
       callSite: result.summaryCallSite ?? null,
-      overrideProfile: result.summaryOverrideProfile ?? null,
+      overrideProfile:
+        result.summaryActualInferenceProfile ??
+        result.summaryOverrideProfile ??
+        null,
+      ...(result.summaryActualInferenceProfile !== undefined
+        ? { forceOverrideProfile: true }
+        : {}),
     },
     options.cronRunId ?? null,
   );

--- a/assistant/src/daemon/conversation-slash.ts
+++ b/assistant/src/daemon/conversation-slash.ts
@@ -1,5 +1,5 @@
 import type { InterfaceId } from "../channels/types.js";
-import { getEffectiveProfilesForProvider } from "../config/default-profile-catalog.js";
+import { getUserSelectableProfilesForProvider } from "../config/default-profile-catalog.js";
 import { resolveEffectiveContextWindow } from "../config/llm-context-resolution.js";
 import { resolveCallSiteConfig } from "../config/llm-resolver.js";
 import {
@@ -148,7 +148,7 @@ async function resolveModelCommand(
   parse: ModelCommandParse,
 ): Promise<SlashResolution> {
   const config = getConfig();
-  const profiles = getEffectiveProfilesForProvider(
+  const profiles = getUserSelectableProfilesForProvider(
     config.llm.profiles,
     config.llm.defaultProvider ?? null,
   );

--- a/assistant/src/plugin-api/model-profiles.test.ts
+++ b/assistant/src/plugin-api/model-profiles.test.ts
@@ -61,17 +61,13 @@ describe("getModelProfiles", () => {
 
     const result = listProfiles();
     // The code-catalog defaults are always present; the two workspace
-    // entries shadow their catalog counterparts, and the remaining catalog
-    // defaults (managed backups included) sort after the explicit order.
+    // entries shadow their catalog counterparts, and managed backups remain
+    // internal fallback routes rather than picker options.
     expect(result.map((p) => p.key)).toEqual([
       "balanced",
       "quality-optimized",
-      "balanced-backup",
       "cost-optimized",
-      "cost-optimized-backup",
       "latency-optimized",
-      "latency-optimized-backup",
-      "quality-optimized-backup",
     ]);
   });
 
@@ -88,14 +84,10 @@ describe("getModelProfiles", () => {
     const result = listProfiles();
     expect(result.map((p) => p.key).sort()).toEqual([
       "balanced",
-      "balanced-backup",
       "cost-optimized",
-      "cost-optimized-backup",
       "disabled",
       "latency-optimized",
-      "latency-optimized-backup",
       "quality-optimized",
-      "quality-optimized-backup",
     ]);
     const disabled = result.find((p) => p.key === "disabled");
     expect(disabled?.isDisabled).toBe(true);
@@ -131,13 +123,9 @@ describe("getModelProfiles", () => {
       "provider-only",
       "mix",
       "balanced",
-      "balanced-backup",
       "cost-optimized",
-      "cost-optimized-backup",
       "latency-optimized",
-      "latency-optimized-backup",
       "quality-optimized",
-      "quality-optimized-backup",
     ]);
   });
 
@@ -145,13 +133,9 @@ describe("getModelProfiles", () => {
     const result = listProfiles();
     expect(result.map((p) => p.key).sort()).toEqual([
       "balanced",
-      "balanced-backup",
       "cost-optimized",
-      "cost-optimized-backup",
       "latency-optimized",
-      "latency-optimized-backup",
       "quality-optimized",
-      "quality-optimized-backup",
     ]);
     for (const profile of result) {
       expect(profile.isDisabled).toBe(false);

--- a/assistant/src/plugin-api/model-profiles.test.ts
+++ b/assistant/src/plugin-api/model-profiles.test.ts
@@ -62,12 +62,16 @@ describe("getModelProfiles", () => {
     const result = listProfiles();
     // The code-catalog defaults are always present; the two workspace
     // entries shadow their catalog counterparts, and the remaining catalog
-    // default sorts after the explicit order.
+    // defaults (managed backups included) sort after the explicit order.
     expect(result.map((p) => p.key)).toEqual([
       "balanced",
       "quality-optimized",
+      "balanced-backup",
       "cost-optimized",
+      "cost-optimized-backup",
       "latency-optimized",
+      "latency-optimized-backup",
+      "quality-optimized-backup",
     ]);
   });
 
@@ -84,10 +88,14 @@ describe("getModelProfiles", () => {
     const result = listProfiles();
     expect(result.map((p) => p.key).sort()).toEqual([
       "balanced",
+      "balanced-backup",
       "cost-optimized",
+      "cost-optimized-backup",
       "disabled",
       "latency-optimized",
+      "latency-optimized-backup",
       "quality-optimized",
+      "quality-optimized-backup",
     ]);
     const disabled = result.find((p) => p.key === "disabled");
     expect(disabled?.isDisabled).toBe(true);
@@ -123,9 +131,13 @@ describe("getModelProfiles", () => {
       "provider-only",
       "mix",
       "balanced",
+      "balanced-backup",
       "cost-optimized",
+      "cost-optimized-backup",
       "latency-optimized",
+      "latency-optimized-backup",
       "quality-optimized",
+      "quality-optimized-backup",
     ]);
   });
 
@@ -133,9 +145,13 @@ describe("getModelProfiles", () => {
     const result = listProfiles();
     expect(result.map((p) => p.key).sort()).toEqual([
       "balanced",
+      "balanced-backup",
       "cost-optimized",
+      "cost-optimized-backup",
       "latency-optimized",
+      "latency-optimized-backup",
       "quality-optimized",
+      "quality-optimized-backup",
     ]);
     for (const profile of result) {
       expect(profile.isDisabled).toBe(false);

--- a/assistant/src/plugin-api/model-profiles.ts
+++ b/assistant/src/plugin-api/model-profiles.ts
@@ -1,15 +1,15 @@
-import { getEffectiveProfilesForProvider } from "../config/default-profile-catalog.js";
+import { getUserSelectableProfilesForProvider } from "../config/default-profile-catalog.js";
 import { getConfig } from "../config/loader.js";
 import { isDispatchableProfile } from "../config/profile-dispatchability.js";
 import { orderProfileKeys } from "../config/profile-order.js";
 import type { ModelProfileInfo } from "./types.js";
 
 /**
- * List the workspace inference profiles a plugin can route to, in the order the
- * `/model` picker presents them (`llm.profileOrder` first, then the rest
- * alphabetically). Metadata-only entries without a provider, model, or mix are
- * not routing targets, so plugins never see them. Disabled profiles are
- * included and flagged via
+ * List the workspace inference profiles a plugin can route to, in the order a
+ * user-facing model picker presents them (`llm.profileOrder` first, then the
+ * rest alphabetically). Managed backup routes are internal and omitted.
+ * Metadata-only entries without a provider, model, or mix are not routing
+ * targets, so plugins never see them. Disabled profiles are included and flagged via
  * {@link ModelProfileInfo.isDisabled}; weighted "mix" profiles are included and
  * flagged via {@link ModelProfileInfo.isMix}, since a mix is itself a valid
  * routing target (it resolves to one constituent per conversation).
@@ -20,7 +20,7 @@ import type { ModelProfileInfo } from "./types.js";
 export function getModelProfiles(): ModelProfileInfo[] {
   const { llm } = getConfig();
   const { activeProfile } = llm;
-  const profiles = getEffectiveProfilesForProvider(
+  const profiles = getUserSelectableProfilesForProvider(
     llm.profiles,
     llm.defaultProvider ?? null,
   );

--- a/assistant/src/plugins/defaults/compaction/window-manager.ts
+++ b/assistant/src/plugins/defaults/compaction/window-manager.ts
@@ -84,6 +84,10 @@ export interface ContextWindowResult {
   summaryModel: string;
   summaryCallSite?: LLMCallSite;
   summaryOverrideProfile?: string | null;
+  /** See {@link CompactionRunResult.summaryActualProvider}. */
+  summaryActualProvider?: string;
+  /** See {@link CompactionRunResult.summaryActualInferenceProfile}. */
+  summaryActualInferenceProfile?: string;
   summaryCacheCreationInputTokens?: number;
   summaryCacheReadInputTokens?: number;
   summaryRawResponses?: unknown[];

--- a/assistant/src/plugins/defaults/memory/src/memory-v2-routes.ts
+++ b/assistant/src/plugins/defaults/memory/src/memory-v2-routes.ts
@@ -7,7 +7,7 @@ import { join } from "node:path";
 
 import { z } from "zod";
 
-import { getEffectiveProfilesForProvider } from "../../../../config/default-profile-catalog.js";
+import { getUserSelectableProfilesForProvider } from "../../../../config/default-profile-catalog.js";
 import { loadConfig } from "../../../../config/loader.js";
 import { usesConceptPageMemory } from "../../../../config/memory-v3-gate.js";
 import type { AssistantConfig } from "../../../../config/types.js";
@@ -523,7 +523,7 @@ export async function handleSimulateRouter({
   // through (the resolver tolerates missing override-profile references by
   // design, but the playground wants the user to know they typo'd).
   if (profileOverride !== undefined) {
-    const profiles = getEffectiveProfilesForProvider(
+    const profiles = getUserSelectableProfilesForProvider(
       liveConfig.llm?.profiles,
       liveConfig.llm?.defaultProvider ?? null,
     );

--- a/assistant/src/providers/connection-resolution.ts
+++ b/assistant/src/providers/connection-resolution.ts
@@ -52,6 +52,7 @@ import {
 } from "./inference/connections.js";
 import { resolveManagedProxyContext } from "./platform-proxy/context.js";
 import { checkCredentialPresence } from "./provider-availability.js";
+import { dispatchProviderResolvable } from "./provider-resolvability.js";
 import type { ProvidersConfig } from "./registry.js";
 import { resolveProviderFromConnection } from "./registry.js";
 import {
@@ -67,6 +68,7 @@ import {
 } from "./vellum-model-routing.js";
 
 export { ConnectionResolutionError, resolveRoutingIdentity };
+export { dispatchProviderResolvable } from "./provider-resolvability.js";
 
 const log = getLogger("providers/connection-resolution");
 
@@ -116,23 +118,6 @@ export function writableProfileProviderIssue(provider: string): string | null {
     // Unverifiable: fall through to the rejection.
   }
   return `Invalid provider "${provider}". Use a known provider or the name of an existing connection.`;
-}
-
-/**
- * Selection-time predicate for `ResolveCallSiteOpts.isResolvableProvider`:
- * a provider value dispatches when it is a known vendor/identity or names a
- * connection entry row. Permissive on DB unavailability so a transient blip
- * never heals away a valid entry profile; dispatch soft-fails on its own.
- */
-export function dispatchProviderResolvable(provider: string): boolean {
-  if (VALID_CONNECTION_PROVIDERS.includes(provider)) {
-    return true;
-  }
-  try {
-    return getConnection(getDb(), provider) != null;
-  } catch {
-    return true;
-  }
 }
 
 /**

--- a/assistant/src/providers/fallback-breaker.ts
+++ b/assistant/src/providers/fallback-breaker.ts
@@ -67,6 +67,16 @@ export interface BreakerRoute {
   model?: string;
 }
 
+/**
+ * Identifies the breaker state that observed a primary failure. A fallback
+ * completion may arrive after a recovery probe, so it must only update the
+ * state that was current when the primary failed.
+ */
+export interface BreakerObservation {
+  key: string;
+  generation: number;
+}
+
 interface BreakerState {
   /** Timestamps of recent eligible failures, pruned to the failure window. */
   failures: number[];
@@ -76,9 +86,12 @@ interface BreakerState {
   failedProbes: number;
   /** Whether a probe is currently deciding recovery for this entry. */
   probeInFlight: boolean;
+  /** Monotonic identity for this state generation. */
+  generation: number;
 }
 
 const breakers = new Map<string, BreakerState>();
+let nextGeneration = 0;
 
 /**
  * The single entry a write targets. A model-scoped key can never collide with
@@ -107,6 +120,7 @@ function stateFor(key: string): BreakerState {
     openUntil: null,
     failedProbes: 0,
     probeInFlight: false,
+    generation: ++nextGeneration,
   };
   breakers.set(key, created);
   return created;
@@ -177,17 +191,18 @@ function openCovering(
 export function recordPrimaryFailure(
   route: BreakerRoute,
   now: number = Date.now(),
-): void {
+): BreakerObservation {
   const key = keyOf(route);
   const state = stateFor(key);
   if (isOpen(state)) {
-    return;
+    return { key, generation: state.generation };
   }
   state.failures = state.failures.filter((at) => now - at < FAILURE_WINDOW_MS);
   state.failures.push(now);
   if (state.failures.length >= FAILURES_TO_TRIP) {
     trip(key, state, now, "eligible_failures");
   }
+  return { key, generation: state.generation };
 }
 
 /**
@@ -200,10 +215,23 @@ export function recordPrimaryFailure(
 export function recordFallbackServed(
   route: BreakerRoute,
   now: number = Date.now(),
+  observation?: BreakerObservation,
 ): void {
   const key = keyOf(route);
-  const state = stateFor(key);
-  if (isOpen(state)) {
+  const state = observation === undefined ? stateFor(key) : breakers.get(key);
+  if (
+    observation !== undefined &&
+    (state === undefined ||
+      observation.key !== key ||
+      observation.generation !== state.generation)
+  ) {
+    log.info(
+      { route: key, observation, currentGeneration: state?.generation },
+      "Ignoring a stale fallback serve for the fallback breaker",
+    );
+    return;
+  }
+  if (state === undefined || isOpen(state)) {
     return;
   }
   trip(key, state, now, "fallback_served");

--- a/assistant/src/providers/fallback-breaker.ts
+++ b/assistant/src/providers/fallback-breaker.ts
@@ -1,0 +1,361 @@
+/**
+ * Circuit breaker for managed fallback routes.
+ *
+ * Once a backup profile has served a request, the primary route is known to be
+ * down. Paying the full retry budget on every later request only adds latency
+ * to an answer the backup was always going to give, so the breaker remembers
+ * the outage and sends the next requests straight to the backup. Recovery is
+ * request-driven: after a cooldown, exactly one request probes the primary. A
+ * successful probe closes the breaker; a failed one re-trips it with a longer
+ * cooldown.
+ *
+ * Scope
+ * -----
+ * A remembered outage is keyed by the route it was actually observed on, and
+ * the two failure shapes this feature exists for indict different things:
+ *
+ * - An upstream outage (5xx, 429, transport failure, a broken managed
+ *   credential) indicts the whole provider, so it is remembered under the
+ *   upstream name and every model on it skips the primary.
+ * - A retired or renamed model (404, `model_not_found`, the managed proxy's
+ *   preflight 400) indicts one model. Remembering it provider-wide would
+ *   divert healthy profiles on the same upstream to their backups for the
+ *   whole cooldown, and would let a probe of some other healthy model close a
+ *   breaker the retired model still deserves. It is remembered under the
+ *   upstream plus that model instead.
+ *
+ * Reads always name the full route, so a request is skipped when either its
+ * upstream or its exact model is remembered as down.
+ *
+ * The cooldown carries plus or minus 20 percent of jitter so a fleet of daemons
+ * coming out of the same provider outage does not probe a recovering upstream
+ * in the same second.
+ *
+ * State is intentionally process-local and never persisted: the daemon is a
+ * single process, and a restart resets every route to its primary. The worst
+ * case for that choice is one request rediscovering an ongoing outage the
+ * expensive way, which is exactly what the very first request of an outage
+ * already pays.
+ */
+
+import { getLogger } from "../util/logger.js";
+
+const log = getLogger("fallback-breaker");
+
+/** Eligible failures inside this window count toward the trip threshold. */
+const FAILURE_WINDOW_MS = 5 * 60_000;
+
+/** Eligible failures needed to trip when no backup has served yet. */
+const FAILURES_TO_TRIP = 2;
+
+/** Cooldown before the first recovery probe is admitted. */
+const BASE_COOLDOWN_MS = 120_000;
+
+/** Ceiling for the doubling cooldown, so a long outage still gets probed. */
+const MAX_COOLDOWN_MS = 10 * 60_000;
+
+/** Fraction of the cooldown spent on desynchronizing jitter. */
+const COOLDOWN_JITTER = 0.2;
+
+/**
+ * A route the breaker can remember. `model` narrows the entry to a single
+ * model: writes that omit it record an upstream-wide outage, and reads that
+ * include it consult both the upstream entry and the model's own.
+ */
+export interface BreakerRoute {
+  upstream: string;
+  model?: string;
+}
+
+interface BreakerState {
+  /** Timestamps of recent eligible failures, pruned to the failure window. */
+  failures: number[];
+  /** When the current cooldown expires, or null while the breaker is closed. */
+  openUntil: number | null;
+  /** Consecutive failed recovery probes; each one doubles the cooldown. */
+  failedProbes: number;
+  /** Whether a probe is currently deciding recovery for this entry. */
+  probeInFlight: boolean;
+}
+
+const breakers = new Map<string, BreakerState>();
+
+/**
+ * The single entry a write targets. A model-scoped key can never collide with
+ * an upstream name: the separator is a space, which no provider id contains.
+ */
+function keyOf(route: BreakerRoute): string {
+  return route.model === undefined
+    ? route.upstream
+    : `${route.upstream} ${route.model}`;
+}
+
+/** Every entry that governs this route, upstream-wide first. */
+function coveringKeys(route: BreakerRoute): string[] {
+  return route.model === undefined
+    ? [route.upstream]
+    : [route.upstream, keyOf(route)];
+}
+
+function stateFor(key: string): BreakerState {
+  const existing = breakers.get(key);
+  if (existing !== undefined) {
+    return existing;
+  }
+  const created: BreakerState = {
+    failures: [],
+    openUntil: null,
+    failedProbes: 0,
+    probeInFlight: false,
+  };
+  breakers.set(key, created);
+  return created;
+}
+
+/**
+ * Cooldown for the next open period. Doubles per consecutive failed probe and
+ * is capped at {@link MAX_COOLDOWN_MS} both before and after jitter, so the
+ * ceiling holds for the value actually used.
+ */
+function cooldownMs(failedProbes: number): number {
+  const base = Math.min(BASE_COOLDOWN_MS * 2 ** failedProbes, MAX_COOLDOWN_MS);
+  const jittered = base * (1 + (Math.random() * 2 - 1) * COOLDOWN_JITTER);
+  return Math.min(Math.round(jittered), MAX_COOLDOWN_MS);
+}
+
+function trip(
+  key: string,
+  state: BreakerState,
+  now: number,
+  reason: string,
+): void {
+  const cooldown = cooldownMs(state.failedProbes);
+  state.openUntil = now + cooldown;
+  state.failures = [];
+  log.info(
+    {
+      route: key,
+      cooldownMs: cooldown,
+      failedProbes: state.failedProbes,
+      reason,
+    },
+    "Fallback breaker tripped; routing to the backup profile until the cooldown expires",
+  );
+}
+
+/** Whether the entry is open, whatever the cooldown says. */
+function isOpen(
+  state: BreakerState | undefined,
+): state is BreakerState & { openUntil: number } {
+  return state !== undefined && state.openUntil !== null;
+}
+
+/** Open entries governing this route, paired with their keys. */
+function openCovering(
+  route: BreakerRoute,
+): { key: string; state: BreakerState & { openUntil: number } }[] {
+  const open: { key: string; state: BreakerState & { openUntil: number } }[] =
+    [];
+  for (const key of coveringKeys(route)) {
+    const state = breakers.get(key);
+    if (isOpen(state)) {
+      open.push({ key, state });
+    }
+  }
+  return open;
+}
+
+/**
+ * Record an outage-shaped failure of the primary route. Two of them inside
+ * {@link FAILURE_WINDOW_MS} trip the breaker; a single blip does not. A failure
+ * recorded while the entry is already open changes nothing, since only a
+ * recovery probe decides when to close it.
+ *
+ * The caller decides the scope by what it names: pass the upstream alone for
+ * an outage, upstream plus model for a failure that indicts one model.
+ */
+export function recordPrimaryFailure(
+  route: BreakerRoute,
+  now: number = Date.now(),
+): void {
+  const key = keyOf(route);
+  const state = stateFor(key);
+  if (isOpen(state)) {
+    return;
+  }
+  state.failures = state.failures.filter((at) => now - at < FAILURE_WINDOW_MS);
+  state.failures.push(now);
+  if (state.failures.length >= FAILURES_TO_TRIP) {
+    trip(key, state, now, "eligible_failures");
+  }
+}
+
+/**
+ * Record that a backup profile actually served a request the primary could
+ * not. This trips the breaker immediately: unlike a bare failure, a completed
+ * backup serve proves both that the primary is down and that the backup can
+ * carry the traffic, so there is nothing left to learn from the next request
+ * repeating the same discovery. Scoped by what the caller names, as above.
+ */
+export function recordFallbackServed(
+  route: BreakerRoute,
+  now: number = Date.now(),
+): void {
+  const key = keyOf(route);
+  const state = stateFor(key);
+  if (isOpen(state)) {
+    return;
+  }
+  trip(key, state, now, "fallback_served");
+}
+
+/**
+ * Record a successful primary send, clearing any failure history for the route
+ * that served it. Both the upstream entry and this model's own entry are
+ * cleared: the upstream answered, and it answered for this model. Another
+ * model's remembered outage on the same upstream is left alone.
+ */
+export function recordPrimarySuccess(
+  route: BreakerRoute,
+  now: number = Date.now(),
+): void {
+  for (const key of coveringKeys(route)) {
+    const state = breakers.get(key);
+    if (state === undefined) {
+      continue;
+    }
+    if (isOpen(state)) {
+      log.info(
+        { route: key, openForMs: Math.max(0, state.openUntil - now) },
+        "Primary route served a request; closing the fallback breaker",
+      );
+    }
+    breakers.delete(key);
+  }
+}
+
+/**
+ * Whether this request should skip the primary route and go straight to the
+ * backup. True while any entry governing the route is inside its cooldown, and
+ * also while a probe is in flight, so concurrent requests keep using the backup
+ * instead of piling onto a route a single probe is still testing.
+ */
+export function shouldSkipPrimary(
+  route: BreakerRoute,
+  now: number = Date.now(),
+): boolean {
+  return openCovering(route).some(
+    ({ state }) => state.probeInFlight || now < state.openUntil,
+  );
+}
+
+/**
+ * Claim the single recovery probe for a route whose remembered outages have all
+ * cooled down. Returns false for every other caller, including concurrent ones,
+ * which keep skipping the primary via {@link shouldSkipPrimary}.
+ */
+export function tryAcquireRecoveryProbe(
+  route: BreakerRoute,
+  now: number = Date.now(),
+): boolean {
+  const open = openCovering(route);
+  if (open.length === 0) {
+    return false;
+  }
+  if (open.some(({ state }) => state.probeInFlight || now < state.openUntil)) {
+    return false;
+  }
+  for (const { state } of open) {
+    state.probeInFlight = true;
+  }
+  return true;
+}
+
+/**
+ * What a recovery probe learned about the route it tested.
+ *
+ * - `recovered`: the primary served the probe.
+ * - `failing`: it did not, and `failedRoute` names what THIS failure indicts,
+ *   scoped the same way an initial trip is (the whole upstream for an outage,
+ *   one model for a retirement). Null when the failure names nothing the
+ *   breaker can remember, in which case the probed entries simply close.
+ * - `abandoned`: the probe never reached a verdict, because the caller
+ *   cancelled the request. No evidence either way.
+ */
+export type ProbeOutcome =
+  | { verdict: "recovered" }
+  | { verdict: "failing"; failedRoute: BreakerRoute | null }
+  | { verdict: "abandoned" };
+
+/**
+ * Report the outcome of the probe claimed by {@link tryAcquireRecoveryProbe}.
+ *
+ * A probe that reached a verdict closes every entry it was testing. It is the
+ * freshest evidence about those entries and it supersedes whatever opened
+ * them: an upstream that answers a probe with a retired-model 404 is an
+ * upstream that answers, so continuing to divert its healthy models would be
+ * acting on stale evidence. What a failing probe does establish is then
+ * recorded anew under `failedRoute`, carrying the escalated cooldown forward,
+ * so a route that keeps failing the same way still doubles its wait while a
+ * route whose failure changed shape is remembered at its true scope.
+ *
+ * An `abandoned` probe only hands the claim back. A cancelled request never
+ * asked the route anything, so treating it as recovery would delete a breaker
+ * that nothing has retested and send the next request through the full retry
+ * budget of a route still known to be down. The entry keeps its deadline and
+ * its escalation count: the cancellation neither counts as a failed probe nor
+ * restarts the wait, it just leaves the probe due again.
+ */
+export function releaseRecoveryProbe(
+  route: BreakerRoute,
+  outcome: ProbeOutcome,
+  now: number = Date.now(),
+): void {
+  if (outcome.verdict === "abandoned") {
+    for (const key of coveringKeys(route)) {
+      const state = breakers.get(key);
+      if (state === undefined || !state.probeInFlight) {
+        continue;
+      }
+      state.probeInFlight = false;
+      log.info(
+        { route: key, failedProbes: state.failedProbes },
+        "Recovery probe was cancelled before it reached the upstream; the fallback breaker keeps its cooldown",
+      );
+    }
+    return;
+  }
+  // Consecutive failed probes decide the next cooldown, so the count survives
+  // a change of scope: an outage that narrows to one model keeps escalating
+  // rather than restarting at the base wait.
+  let escalation = 0;
+  for (const key of coveringKeys(route)) {
+    const state = breakers.get(key);
+    if (state === undefined || !state.probeInFlight) {
+      continue;
+    }
+    state.probeInFlight = false;
+    escalation = Math.max(escalation, state.failedProbes);
+    if (outcome.verdict === "recovered") {
+      log.info(
+        { route: key, failedProbes: state.failedProbes },
+        "Recovery probe succeeded; closing the fallback breaker",
+      );
+    }
+    breakers.delete(key);
+  }
+  const failedRoute =
+    outcome.verdict === "recovered" ? null : outcome.failedRoute;
+  if (failedRoute === null) {
+    return;
+  }
+  const key = keyOf(failedRoute);
+  const state = stateFor(key);
+  state.failedProbes = Math.max(state.failedProbes, escalation) + 1;
+  trip(key, state, now, "recovery_probe_failed");
+}
+
+/** Test-only: drop every remembered route so state cannot leak between tests. */
+export function resetFallbackBreaker(): void {
+  breakers.clear();
+}

--- a/assistant/src/providers/inference/adapter-factory.ts
+++ b/assistant/src/providers/inference/adapter-factory.ts
@@ -20,7 +20,11 @@
 
 import { resolveDefaultProfileForProvider } from "../../config/default-profile-catalog.js";
 import {
-  resolveCallSiteConfig,
+  FALLBACK_PROFILE_BY_KEY,
+  isDefaultProfileKey,
+} from "../../config/default-profile-names.js";
+import {
+  resolveCallSiteConfigWithProfile,
   selectWinningProfile,
 } from "../../config/llm-resolver.js";
 import { getConfig } from "../../config/loader.js";
@@ -38,6 +42,7 @@ import { OpenAIChatCompletionsProvider } from "../openai/chat-completions-provid
 import { OpenAIResponsesProvider } from "../openai/responses-provider.js";
 import { OpenRouterProvider } from "../openrouter/client.js";
 import { PoolsideProvider } from "../poolside/client.js";
+import { dispatchProviderResolvable } from "../provider-resolvability.js";
 import { RetryProvider } from "../retry.js";
 import { TogetherProvider } from "../together/client.js";
 import type { Provider, SendMessageOptions } from "../types.js";
@@ -342,11 +347,25 @@ export function createAdapterFromConnection(
           overrideProfile: failedConfig?.overrideProfile,
           forceOverrideProfile: failedConfig?.forceOverrideProfile,
           selectionSeed: failedConfig?.selectionSeed,
+          isResolvableProvider: dispatchProviderResolvable,
         });
-        const overrideProfile = winner.entry?.fallbackProfile;
-        if (overrideProfile === undefined) {
+        const primaryProfile =
+          winner.profileName ??
+          (winner.source === "default" ? "balanced" : undefined);
+        if (
+          primaryProfile === undefined ||
+          !isDefaultProfileKey(primaryProfile)
+        ) {
           return null;
         }
+        const expectedFallback = FALLBACK_PROFILE_BY_KEY[primaryProfile];
+        if (
+          winner.entry?.source !== "managed" ||
+          winner.entry.fallbackProfile !== expectedFallback
+        ) {
+          return null;
+        }
+        const overrideProfile = expectedFallback;
         // Resolved the provider-aware way the runtime resolver resolves every
         // profile name: the backups are companions of the managed column and
         // must not materialize under a BYOK or ChatGPT default provider.
@@ -362,25 +381,30 @@ export function createAdapterFromConnection(
           );
           return null;
         }
-        // The model the adapter serves must be the model the request will
-        // actually carry, so it comes from the same resolution the fallback
-        // send runs (`sendOnFallbackRoute` forces this profile through
-        // `normalizeSendMessageOptions`). Building from `backup.model` alone
-        // would ignore a call-site fragment that pins a model, and a pinned
-        // Gemini model on an Anthropic backup would send Gemini wire params to
-        // an Anthropic adapter.
-        const resolvedBackup = resolveCallSiteConfig(callSite, llm, {
-          overrideProfile,
-          forceOverrideProfile: true,
-          selectionSeed: failedConfig?.selectionSeed,
-        });
+        const { config: resolvedBackup, profileName: resolvedBackupProfile } =
+          resolveCallSiteConfigWithProfile(callSite, llm, {
+            overrideProfile,
+            forceOverrideProfile: true,
+            selectionSeed: failedConfig?.selectionSeed,
+            isResolvableProvider: dispatchProviderResolvable,
+          });
+        if (resolvedBackupProfile !== overrideProfile) {
+          log.warn(
+            {
+              connectionName: connection.name,
+              overrideProfile,
+              selectedProfile: resolvedBackupProfile,
+            },
+            "Backup profile is not dispatch-resolvable; keeping the original error",
+          );
+          return null;
+        }
+        // The model the adapter serves must be the model the fallback send
+        // carries, so it comes from the same forced-profile resolution.
         // This callback authenticates the backup with the managed connection
         // it was built for, so it can only serve a backup that routes through
-        // the managed column. The schema permits a pointer at a user-defined
-        // profile carrying its own `provider_connection` or a BYOK `provider`;
-        // serving one here would bill it as managed traffic and authenticate
-        // it with a credential its author never chose, so it is refused and
-        // the original error stands.
+        // the managed column. Refusing any other route keeps managed billing
+        // and credentials from being applied to user-owned traffic.
         // Keyed on the connection, not the provider: a call-site fragment that
         // pins a concrete upstream over a managed winner keeps the managed
         // routing and is stamped with this connection's name by the resolver

--- a/assistant/src/providers/inference/adapter-factory.ts
+++ b/assistant/src/providers/inference/adapter-factory.ts
@@ -18,7 +18,14 @@
  *   3. Register the client in `ADAPTER_FACTORIES` below.
  */
 
+import { resolveDefaultProfileForProvider } from "../../config/default-profile-catalog.js";
+import {
+  resolveCallSiteConfig,
+  selectWinningProfile,
+} from "../../config/llm-resolver.js";
+import { getConfig } from "../../config/loader.js";
 import { normalizeCredentialRef } from "../../security/credential-key.js";
+import { getLogger } from "../../util/logger.js";
 import { AnthropicProvider } from "../anthropic/client.js";
 import { AtlasCloudProvider } from "../atlascloud/client.js";
 import { BasetenProvider } from "../baseten/client.js";
@@ -33,9 +40,14 @@ import { OpenRouterProvider } from "../openrouter/client.js";
 import { PoolsideProvider } from "../poolside/client.js";
 import { RetryProvider } from "../retry.js";
 import { TogetherProvider } from "../together/client.js";
-import type { Provider } from "../types.js";
+import type { Provider, SendMessageOptions } from "../types.js";
 import { UsageTrackingProvider } from "../usage-tracking.js";
-import { isVellumManagedConnection } from "../vellum-model-routing.js";
+import {
+  getManagedUpstream,
+  isVellumManagedConnection,
+  MANAGED_ROUTABLE_PROVIDERS,
+  VELLUM_MANAGED_PROVIDER,
+} from "../vellum-model-routing.js";
 import { VercelAIGatewayProvider } from "../vercel-ai-gateway/client.js";
 import type { ResolvedAuth } from "./auth.js";
 import type { ProviderConnection } from "./auth.js";
@@ -57,6 +69,15 @@ export interface AdapterCreateOpts {
 }
 
 type AdapterFactory = (opts: AdapterCreateOpts) => Provider;
+
+const log = getLogger("adapter-factory");
+
+/** The backup route `RetryProvider` escalates to; see {@link makeFallbackRouteResolver}. */
+interface FallbackRoute {
+  provider: Provider;
+  overrideProfile: string;
+  forwardUsageAttributionHeaders: boolean;
+}
 
 /**
  * Catalog-keyed factory table. Each entry takes a unified
@@ -284,6 +305,176 @@ export function createAdapterFromConnection(
     };
   }
 
+  /**
+   * Resolve the backup-profile route for a request whose primary route just
+   * failed with an outage-shaped error, so `RetryProvider` can serve it on a
+   * different provider instead of surfacing the outage.
+   *
+   * The winning profile of the FAILED call is re-resolved from the same
+   * inputs `normalizeSendMessageOptions` uses (call site plus the request's
+   * own override/seed fields), and its `fallbackProfile` pointer names the
+   * backup. The upstream comes from the backup's resolved provider; only the
+   * `vellum` routing identity carries no upstream of its own, and there the
+   * backup's model determines it.
+   *
+   * Returns a RAW adapter, exactly like `makeCredentialRefresher` above:
+   * `RetryProvider` hands the backup route options it has ALREADY normalized
+   * (call site consumed, wire params resolved from the backup profile, usage
+   * attribution headers stamped). A second `RetryProvider` in between would
+   * re-normalize that call-site-less config and strip those headers, leaving
+   * degraded traffic unattributed on the platform's billing events.
+   *
+   * Never throws: a broken backup lookup must surface the original provider
+   * error, not a new one.
+   */
+  function makeFallbackRouteResolver(): (
+    failedOptions: SendMessageOptions | undefined,
+  ) => Promise<FallbackRoute | null> {
+    return async (failedOptions): Promise<FallbackRoute | null> => {
+      const failedConfig = failedOptions?.config;
+      const callSite = failedConfig?.callSite;
+      if (callSite === undefined) {
+        return null;
+      }
+      try {
+        const { llm } = getConfig();
+        const winner = selectWinningProfile(callSite, llm, {
+          overrideProfile: failedConfig?.overrideProfile,
+          forceOverrideProfile: failedConfig?.forceOverrideProfile,
+          selectionSeed: failedConfig?.selectionSeed,
+        });
+        const overrideProfile = winner.entry?.fallbackProfile;
+        if (overrideProfile === undefined) {
+          return null;
+        }
+        // Resolved the provider-aware way the runtime resolver resolves every
+        // profile name: the backups are companions of the managed column and
+        // must not materialize under a BYOK or ChatGPT default provider.
+        const backup = resolveDefaultProfileForProvider(
+          llm.profiles,
+          overrideProfile,
+          llm.defaultProvider ?? null,
+        );
+        if (backup?.model == null) {
+          log.warn(
+            { connectionName: connection.name, overrideProfile },
+            "Backup profile does not resolve on this default provider; keeping the original error",
+          );
+          return null;
+        }
+        // The model the adapter serves must be the model the request will
+        // actually carry, so it comes from the same resolution the fallback
+        // send runs (`sendOnFallbackRoute` forces this profile through
+        // `normalizeSendMessageOptions`). Building from `backup.model` alone
+        // would ignore a call-site fragment that pins a model, and a pinned
+        // Gemini model on an Anthropic backup would send Gemini wire params to
+        // an Anthropic adapter.
+        const resolvedBackup = resolveCallSiteConfig(callSite, llm, {
+          overrideProfile,
+          forceOverrideProfile: true,
+          selectionSeed: failedConfig?.selectionSeed,
+        });
+        // This callback authenticates the backup with the managed connection
+        // it was built for, so it can only serve a backup that routes through
+        // the managed column. The schema permits a pointer at a user-defined
+        // profile carrying its own `provider_connection` or a BYOK `provider`;
+        // serving one here would bill it as managed traffic and authenticate
+        // it with a credential its author never chose, so it is refused and
+        // the original error stands.
+        // Keyed on the connection, not the provider: a call-site fragment that
+        // pins a concrete upstream over a managed winner keeps the managed
+        // routing and is stamped with this connection's name by the resolver
+        // (see `llm-resolver.ts`), so a concrete `provider` here is still
+        // managed traffic. Only a profile that names a different connection,
+        // or a concrete provider carrying no managed connection at all (a BYOK
+        // winner), routes somewhere this callback cannot authenticate.
+        const backupConnection = resolvedBackup.provider_connection;
+        const routesThroughThisConnection =
+          backupConnection === undefined
+            ? resolvedBackup.provider === VELLUM_MANAGED_PROVIDER
+            : backupConnection === connection.name;
+        if (!routesThroughThisConnection) {
+          log.warn(
+            {
+              connectionName: connection.name,
+              overrideProfile,
+              backupProvider: resolvedBackup.provider,
+              backupConnection,
+            },
+            "Backup profile routes outside the managed connection; keeping the original error",
+          );
+          return null;
+        }
+        // The upstream is the resolved provider, the same way normal dispatch
+        // picks it for this connection: `connection-resolution.ts` threads the
+        // resolved provider through as `providerOverride` for a `vellum`
+        // connection and derives the upstream from the model only when the
+        // provider is the routing-identity sentinel (`resolveRoutingIdentity`,
+        // and the `isVellum && !expectedProvider` branch). Deriving it from the
+        // model here regardless would send a provider-pinned call-site fragment
+        // to a different upstream than a primary send of the same resolution,
+        // and would refuse a managed model the catalog does not list yet even
+        // though normal dispatch serves it. A provider the managed proxy cannot
+        // front (a non-routable id, or another routing identity such as
+        // `chatgpt`) is refused rather than routed.
+        const declaredProvider = resolvedBackup.provider;
+        const upstream =
+          declaredProvider === VELLUM_MANAGED_PROVIDER
+            ? getManagedUpstream(resolvedBackup.model)
+            : MANAGED_ROUTABLE_PROVIDERS.has(declaredProvider)
+              ? declaredProvider
+              : null;
+        if (upstream === null) {
+          log.warn(
+            {
+              connectionName: connection.name,
+              overrideProfile,
+              backupProvider: declaredProvider,
+              backupModel: resolvedBackup.model,
+            },
+            "Backup profile does not resolve to a managed upstream; keeping the original error",
+          );
+          return null;
+        }
+        // Re-resolve auth for the BACKUP upstream: the managed proxy's base URL
+        // is per-upstream, so the primary's resolved auth cannot be reused.
+        const backupAuth = await resolveAuth(
+          effectiveConnectionAuth(connection),
+          upstream,
+          { baseUrl: connection.baseUrl },
+        );
+        if (!backupAuth.ok) {
+          return null;
+        }
+        const backupAdapter = buildConnectionAdapter(
+          connection,
+          backupAuth.resolved,
+          // `useNativeWebSearch` carries over from the primary: it is a
+          // property of this request's web-search config, and every managed
+          // backup pin either supports native search or ignores the flag.
+          { ...opts, model: resolvedBackup.model, provider: upstream },
+        );
+        if (backupAdapter === null) {
+          return null;
+        }
+        return {
+          provider: backupAdapter,
+          overrideProfile,
+          // Always true: this callback is wired only on the managed proxy, so
+          // the backup route runs through it too and its `X-Vellum-*` billing
+          // metadata reaches our own backend, never a third party.
+          forwardUsageAttributionHeaders: true,
+        };
+      } catch (err) {
+        log.warn(
+          { err, connectionName: connection.name, callSite },
+          "Failed to resolve a backup profile route; keeping the original error",
+        );
+        return null;
+      }
+    };
+  }
+
   // Usage-attribution headers (`X-Vellum-*`) are only meaningful when the
   // request is routed through the Vellum-managed proxy. They carry billing
   // metadata for our own backend. Forwarding them to a third-party endpoint
@@ -304,8 +495,15 @@ export function createAdapterFromConnection(
               ? "no-auth"
               : undefined,
       connectionName: connection.name,
+      // Both escalations are managed-route only. A BYOK, oauth-subscription,
+      // or no-auth connection must never fall back: the install may hold no
+      // credential for the backup profile's provider, and only the managed
+      // column carries `fallbackProfile` pointers in the first place.
       ...(isManagedProxy
-        ? { refreshCredentialProvider: makeCredentialRefresher() }
+        ? {
+            refreshCredentialProvider: makeCredentialRefresher(),
+            resolveFallbackRoute: makeFallbackRouteResolver(),
+          }
         : {}),
     }),
   );

--- a/assistant/src/providers/provider-resolvability.ts
+++ b/assistant/src/providers/provider-resolvability.ts
@@ -1,0 +1,20 @@
+import { getDb } from "../persistence/db-connection.js";
+import { VALID_CONNECTION_PROVIDERS } from "./inference/auth.js";
+import { getConnection } from "./inference/connections.js";
+
+/**
+ * Selection-time predicate for `ResolveCallSiteOpts.isResolvableProvider`:
+ * a provider value dispatches when it is a known vendor/identity or names a
+ * connection entry row. Permissive on DB unavailability so a transient blip
+ * never heals away a valid entry profile; dispatch soft-fails on its own.
+ */
+export function dispatchProviderResolvable(provider: string): boolean {
+  if (VALID_CONNECTION_PROVIDERS.includes(provider)) {
+    return true;
+  }
+  try {
+    return getConnection(getDb(), provider) != null;
+  } catch {
+    return true;
+  }
+}

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -39,6 +39,7 @@ import {
   isAdaptiveThinkingOnlyModel,
   isAdaptiveThinkingUnsupportedModel,
 } from "./model-catalog.js";
+import { dispatchProviderResolvable } from "./provider-resolvability.js";
 import {
   isThinkingConfigAdaptive,
   isThinkingConfigDisabled,
@@ -510,19 +511,39 @@ function fallbackErrorType(error: unknown, retriesExhausted: boolean): string {
  * Whether a failed request can be re-routed to a backup profile. Fallback
  * re-resolves the ORIGINAL caller options with the backup profile forced,
  * which requires a `callSite`-bearing config. An explicit per-call
- * `config.model` pin (the live per-conversation `modelOverride` feature)
- * disqualifies the request: the pin wins over any resolved profile model in
- * `normalizeSendMessageOptions`, and silently serving a different model
- * against an explicit pin would violate user intent: a profile user asked
- * for a tier, a pinning user asked for that exact model. Pinned conversations
- * keep today's retry-then-error behavior.
+ * route pin (`model`, `provider`, or `provider_connection`) disqualifies the
+ * request, whether it came from this call or the persisted call-site config.
+ * Silently serving a different route would violate user intent: a profile
+ * user asked for a tier, while a pinning user asked for an exact route. Pinned
+ * calls keep retry-then-error behavior.
  */
+const EXACT_ROUTE_PIN_KEYS = [
+  "model",
+  "provider",
+  "provider_connection",
+] as const;
+
+function hasExactRoutePin(
+  config: Record<string, unknown> | undefined,
+): boolean {
+  return EXACT_ROUTE_PIN_KEYS.some((key) => {
+    const value = config?.[key];
+    return typeof value === "string" && value.trim().length > 0;
+  });
+}
+
 function canReRouteToFallbackProfile(options?: SendMessageOptions): boolean {
   const config = options?.config;
   if (config?.callSite === undefined) {
     return false;
   }
-  return !(typeof config.model === "string" && config.model.trim().length > 0);
+  if (hasExactRoutePin(config)) {
+    return false;
+  }
+  const callSiteConfig = getConfig().llm.callSites?.[config.callSite] as
+    | Record<string, unknown>
+    | undefined;
+  return !hasExactRoutePin(callSiteConfig);
 }
 
 /**
@@ -1428,7 +1449,11 @@ export class RetryProvider implements Provider {
               // with the longer cooldown a repeat outage earns.
               return served;
             }
-            break;
+            // The probe confirmed this route is still down. If the backup
+            // cannot serve, surface that primary failure directly instead of
+            // spending a fresh retry budget on the route the probe just
+            // re-tripped.
+            throw error;
           }
         }
       }
@@ -1766,6 +1791,7 @@ export class RetryProvider implements Provider {
         : selectWinningProfile(callSite, getConfig().llm, {
             overrideProfile: route.overrideProfile,
             ...(selectionSeed !== undefined ? { selectionSeed } : {}),
+            isResolvableProvider: dispatchProviderResolvable,
           });
     if (
       selection === null ||
@@ -1873,14 +1899,20 @@ export class RetryProvider implements Provider {
       }
       return response;
     } catch (fallbackError) {
-      if (
-        originalError !== undefined &&
-        fallbackError instanceof Error &&
-        fallbackError.cause === undefined
-      ) {
-        fallbackError.cause = originalError;
+      if (originalError === undefined) {
+        throw fallbackError;
       }
-      throw fallbackError;
+      log.warn(
+        {
+          provider: this.name,
+          connectionName: this.options.connectionName,
+          fallbackProvider: route.provider.name,
+          overrideProfile: route.overrideProfile,
+          fallbackError,
+        },
+        "Backup profile failed; rethrowing the original provider error",
+      );
+      return null;
     }
   }
 }

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -353,6 +353,53 @@ function isRetryableError(error: unknown): boolean {
   return isRetryableNetworkError(error);
 }
 
+/** Cap server-suggested delays at 60s. */
+const MAX_RETRY_DELAY_MS = 60_000;
+
+/**
+ * How long to wait before the next attempt, and whether the upstream named the
+ * wait itself. A server-provided `Retry-After` wins over exponential backoff,
+ * capped so a pathological header cannot stall a turn.
+ */
+function retryPlan(
+  error: unknown,
+  attempt: number,
+): { delay: number; retryAfterHeader: boolean } {
+  const retryAfter =
+    error instanceof ProviderError ? error.retryAfterMs : undefined;
+  return {
+    delay: Math.min(
+      retryAfter ?? computeRetryDelay(attempt, DEFAULT_BASE_DELAY_MS),
+      MAX_RETRY_DELAY_MS,
+    ),
+    retryAfterHeader: retryAfter !== undefined,
+  };
+}
+
+/** Structured `errorType` for the "Retrying after transient error" logs. */
+function retryErrorType(error: unknown): string {
+  if (error instanceof ProviderError && error.statusCode === 429) {
+    return "rate_limit";
+  }
+  if (
+    error instanceof ProviderError &&
+    error.statusCode !== undefined &&
+    error.statusCode >= 500
+  ) {
+    return `server_error_${error.statusCode}`;
+  }
+  if (isRetryableProviderMessage(error)) {
+    return "provider_overloaded";
+  }
+  if (isRetryableStreamError(error)) {
+    return "stream_corruption";
+  }
+  if (isRetryableTransportAbort(error)) {
+    return "transport_abort";
+  }
+  return "network_error";
+}
+
 /**
  * The managed proxy's preflight guard rejects a model with no billing rate
  * card using a 400 whose body carries this phrase (django
@@ -1072,8 +1119,11 @@ export class RetryProvider implements Provider {
        * the primary: managed-proxy routes pass true, BYOK and other
        * third-party routes pass false. The fallback send normalizes with the
        * returned policy so `X-Vellum-*` billing metadata never leaks to a
-       * third party and is never omitted from the managed proxy. One hop
-       * max; the fallback attempt itself gets no retry loop.
+       * third party and is never omitted from the managed proxy. One hop max:
+       * the returned adapter must be RAW, so the backup can never escalate
+       * again whatever happens to it. Whether the backup send gets a retry
+       * budget depends on which entry point escalated; see
+       * `sendOnFallbackRoute`.
        */
       resolveFallbackRoute?: (
         failedOptions: SendMessageOptions | undefined,
@@ -1157,9 +1207,9 @@ export class RetryProvider implements Provider {
     messages: Message[],
     options?: SendMessageOptions,
   ): Promise<ProviderResponse> {
-    let didRetry = false;
     let retryAttempt = 0;
     let credentialRefreshAttempted = false;
+    let correctiveResendAttempted = false;
     let fallbackAttempted = false;
     let messagesForAttempt = messages;
 
@@ -1205,6 +1255,11 @@ export class RetryProvider implements Provider {
           options,
           undefined,
           false,
+          // The rule this argument encodes: a request gets a retry budget on
+          // the backup only when it has not already spent one. This request
+          // skips the primary outright, so it has spent nothing, and on a
+          // single attempt a lone 429 or mid-stream cut would fail the turn.
+          { backupRetryBudget: true },
         );
         if (served !== null) {
           return served;
@@ -1222,13 +1277,28 @@ export class RetryProvider implements Provider {
           },
           "Probing the primary route for recovery",
         );
-        // One probe, one attempt: no retry loop. A managed credential that
-        // expired during the outage is the exception, because the probe would
-        // otherwise read its own 401 as the outage continuing and the route
-        // could never come back. The refresh is the same one-shot step the
-        // retry loop runs, and it shares the send's budget for it.
+        // One probe, one attempt: no retry loop. Two one-shot repairs are the
+        // exception, both because the probe would otherwise misread its own
+        // failure as the route still being down. A managed credential that
+        // expired during the outage is refreshed, or the route could never come
+        // back. Malformed tool-argument JSON gets the same corrective note the
+        // retry loop appends, because that failure is conditioned on the
+        // request rather than the route.
+        //
+        // The probe ends the moment it reports a verdict. What happens to the
+        // request that carried it then depends on that verdict: an outage sends
+        // it to the backup, and a recovery hands it back to the ordinary retry
+        // loop below, which is now the right place for it because the route it
+        // just cleared is the one that loop sends to.
+        //
+        // Every send the probe makes is counted, repairs included. A repair is
+        // still a send against the primary, so it is what the seed below has to
+        // be built from: a constant would only be right on the path where no
+        // repair ran.
+        let probeSends = 0;
         while (true) {
           try {
+            probeSends += 1;
             const response = await this.inner.sendMessage(
               messagesForAttempt,
               normalizedOptions,
@@ -1255,14 +1325,47 @@ export class RetryProvider implements Provider {
                 continue;
               }
             }
+            // The same one-shot corrective resend the retry loop performs. A
+            // byte-identical resend can reproduce malformed tool-argument JSON
+            // indefinitely, so without the note the probe would report an
+            // outage the route had nothing to do with. Skipped when the hint
+            // has nowhere to go (an assistant prefill tail), since an
+            // unchanged resend would only cost another round trip.
+            if (
+              !correctiveResendAttempted &&
+              isUnparseableToolArgsError(error)
+            ) {
+              correctiveResendAttempted = true;
+              const repaired = withUnparseableToolArgsHint(messages);
+              if (repaired !== messages) {
+                messagesForAttempt = repaired;
+                continue;
+              }
+            }
             // The probe stands in for the whole retry budget while the breaker
             // is open, so a failure the retry loop would have exhausted itself
             // against means the outage continues. Any other failure means the
             // route answered the request, which is all the probe asked.
-            const outage = isFallbackEligibleError(error, {
-              retriesExhausted: true,
-              credentialSource: this.options.credentialSource,
-            });
+            //
+            // A mid-stream corruption is such an answer: every pattern in
+            // `RETRYABLE_STREAM_PATTERNS` requires an absent HTTP status, which
+            // means the upstream accepted the request, returned 200, and
+            // streamed content. The failure is in the bytes it produced, not in
+            // its ability to serve, so it is evidence the primary is HEALTHY
+            // and must not extend a remembered outage that can reach ten
+            // minutes. A 429 is deliberately NOT treated the same way: the
+            // route refused to do the work, no resend repairs it (only waiting
+            // does, which is exactly what the cooldown provides), and reading a
+            // rate limit as recovery would send the whole fleet back to a
+            // primary that rejects every request. Provider-declared
+            // `overloaded` and transport aborts stay outages for the same
+            // reason: neither produced a usable answer.
+            const outage =
+              !isRetryableStreamError(error) &&
+              isFallbackEligibleError(error, {
+                retriesExhausted: true,
+                credentialSource: this.options.credentialSource,
+              });
             // The probe's own error decides what stays remembered, not the
             // scope of the entry it was acquired under: an upstream that
             // answers with a retired-model 404 has stopped being an outage,
@@ -1279,7 +1382,35 @@ export class RetryProvider implements Provider {
             );
             this.attributeCredential(error);
             if (!outage) {
-              throw error;
+              // The route answered, the breaker is closed, and this request is
+              // an ordinary request again. A deterministic rejection (a plain
+              // 400, a classified 404, a context overflow) is the route's real
+              // answer and no resend changes it, so it surfaces as itself.
+              if (!isRetryableError(error)) {
+                throw error;
+              }
+              // Anything still standing here is the stream-corruption family
+              // the exclusion above lets through: exactly the failure the main
+              // loop repairs by resending, against a route that was just
+              // cleared. Throwing it would sacrifice the request that carried
+              // the probe to establish a verdict every LATER request gets to
+              // use, so it falls through into the ordinary loop instead. That
+              // loop also keeps the backup as its last resort, so a primary
+              // that streams corruption all the way through still finishes the
+              // turn somewhere.
+              //
+              // Every send the probe made WAS this request spending its own
+              // attempts, so the loop starts that many attempts in. The loop
+              // retries while `retryAttempt < DEFAULT_MAX_RETRIES`, so seeding
+              // it with `probeSends` leaves `1 + (DEFAULT_MAX_RETRIES -
+              // probeSends)` sends below and `DEFAULT_MAX_RETRIES + 1` in
+              // total, for any number of probe sends: the same budget a request
+              // that never probes gets. Counting sends rather than entries into
+              // this branch is what holds that equality for a probe whose
+              // repairs (a credential refresh, a corrective resend) each cost a
+              // send of their own.
+              retryAttempt = probeSends;
+              break;
             }
             fallbackAttempted = true;
             const served = await this.sendOnFallbackRoute(
@@ -1287,6 +1418,10 @@ export class RetryProvider implements Provider {
               options,
               error,
               true,
+              // The probe is one attempt on the primary, not a retry loop, so
+              // this request has spent no retry budget either. Same reasoning
+              // as the breaker-open skip above.
+              { backupRetryBudget: true },
             );
             if (served !== null) {
               // No trip needed: the failed probe already re-tripped the breaker
@@ -1329,54 +1464,42 @@ export class RetryProvider implements Provider {
             messagesForAttempt = withUnparseableToolArgsHint(messages);
           }
           // Prefer server-provided Retry-After; fall back to exponential backoff.
-          const retryAfter =
-            error instanceof ProviderError ? error.retryAfterMs : undefined;
-          const MAX_RETRY_DELAY_MS = 60_000; // Cap server-suggested delays at 60s
-          const delay = Math.min(
-            retryAfter ??
-              computeRetryDelay(retryAttempt, DEFAULT_BASE_DELAY_MS),
-            MAX_RETRY_DELAY_MS,
-          );
-          const errorType =
-            error instanceof ProviderError && error.statusCode === 429
-              ? "rate_limit"
-              : error instanceof ProviderError &&
-                  error.statusCode !== undefined &&
-                  error.statusCode >= 500
-                ? `server_error_${error.statusCode}`
-                : isRetryableProviderMessage(error)
-                  ? "provider_overloaded"
-                  : isRetryableStreamError(error)
-                    ? "stream_corruption"
-                    : isRetryableTransportAbort(error)
-                      ? "transport_abort"
-                      : "network_error";
+          const { delay, retryAfterHeader } = retryPlan(error, retryAttempt);
           log.warn(
             {
               attempt: retryAttempt + 1,
               maxRetries: DEFAULT_MAX_RETRIES,
               delay,
-              retryAfterHeader: retryAfter !== undefined,
-              errorType,
+              retryAfterHeader,
+              errorType: retryErrorType(error),
               correctiveHint: messagesForAttempt !== messages,
               provider: this.name,
               message: error instanceof Error ? error.message : String(error),
             },
             "Retrying after transient error",
           );
-          didRetry = true;
           retryAttempt++;
           await sleep(delay);
           continue;
         }
 
         // If we exhausted retries on a retryable error, tag the error so
-        // downstream consumers (Sentry capture, etc.) can recognize that the
-        // retry loop already tried its best. The catch-site logic above only
-        // stops retrying when either (a) retries are exhausted, or (b) the
-        // error isn't retryable — so we check the retryable predicate here to
-        // distinguish the two cases.
-        const retriesExhausted = didRetry && isRetryableError(error);
+        // downstream consumers (Sentry capture, escalation eligibility) can
+        // recognize that the retry loop already tried its best. Control
+        // reaches here for two reasons only, and the retryable predicate is
+        // what separates them: either the budget is gone, or the error was
+        // never retryable in the first place.
+        //
+        // Exhaustion is read off the same counter the retry guard above reads,
+        // never off whether this loop happened to perform a retry itself. A
+        // request can arrive here with its budget already consumed elsewhere:
+        // a recovery probe seeds `retryAttempt` with the sends it made, so a
+        // probe that spent the budget on its own repairs leaves the loop below
+        // no retry to perform and would otherwise look like a request that had
+        // never tried at all. Reading the counter keeps the two definitions
+        // from drifting apart however the seed changes.
+        const retriesExhausted =
+          retryAttempt >= DEFAULT_MAX_RETRIES && isRetryableError(error);
         if (retriesExhausted && error instanceof Error) {
           (error as Error & { retriesExhausted?: boolean }).retriesExhausted =
             true;
@@ -1411,6 +1534,12 @@ export class RetryProvider implements Provider {
             options,
             error,
             retriesExhausted,
+            // No budget here: the primary loop above runs to a definitive
+            // verdict before reaching this point, either exhausting its whole
+            // budget against a transient failure or receiving an error no
+            // resend changes. The user has waited through all of that, so the
+            // backup answers once or the turn fails.
+            { backupRetryBudget: false },
           );
           if (fallbackResult !== null) {
             // A completed backup serve is proof the primary is down and the
@@ -1442,32 +1571,126 @@ export class RetryProvider implements Provider {
    * search backend like Brave or the platform search proxy configured, a tool
    * of the same name is app-executed and works on every route, so filtering it
    * would take away a capability the backup can still serve.
+   *
+   * `dropToolChoice` reports that filtering emptied the list. `AgentLoop` sets
+   * `tool_choice: { type: "auto" }` under the same condition that appends the
+   * sentinel, so a tool-less call site with native search enabled carries the
+   * sentinel as its ONLY tool. Filtering it and leaving the paired
+   * `tool_choice` behind would put a choice with nothing to choose from on the
+   * wire. The Anthropic Messages API rejects that (its client spreads
+   * `tool_choice` out of the request config whether or not any `tools`
+   * survived), and the OpenAI Responses API would too if its client did not
+   * happen to gate the field on a non-empty tool list. A recoverable outage
+   * would become a hard 400 on the backup.
+   *
+   * Deliberately narrow: the flag is raised only for an EMPTY filtered list,
+   * the one case that is invalid on the wire. A non-empty list keeps whatever
+   * `tool_choice` the caller set. A conversation-level `toolChoice` takes
+   * precedence over the sentinel's `auto` in `AgentLoop`, so it is caller
+   * intent that a route change must not quietly discard, and the request it
+   * produces is still valid.
    */
   private fallbackTools(
     options: SendMessageOptions | undefined,
     route: { provider: Provider },
-  ): { tools?: ToolDefinition[] } {
+  ): { tools?: ToolDefinition[]; dropToolChoice: boolean } {
     const tools = options?.tools;
     if (
       options?.config?.nativeWebSearchSentinel !== true ||
       tools === undefined ||
       !tools.some((tool) => tool.name === NATIVE_WEB_SEARCH_TOOL_NAME)
     ) {
-      return {};
+      return { dropToolChoice: false };
     }
     const backupServesNativeSearch = route.provider.supportsNativeWebSearchFor
       ? route.provider.supportsNativeWebSearchFor(options)
       : route.provider.supportsNativeWebSearch === true;
     if (backupServesNativeSearch) {
-      return {};
+      return { dropToolChoice: false };
     }
-    return {
-      tools: tools.filter((tool) => tool.name !== NATIVE_WEB_SEARCH_TOOL_NAME),
-    };
+    const filtered = tools.filter(
+      (tool) => tool.name !== NATIVE_WEB_SEARCH_TOOL_NAME,
+    );
+    return { tools: filtered, dropToolChoice: filtered.length === 0 };
   }
 
   /**
-   * Attempt the failed request once on the backup route resolved by
+   * Send on the backup adapter, optionally with a retry budget of its own.
+   *
+   * The one-hop rule is structural rather than conditional here: `route
+   * .provider` is the RAW adapter the route callback built, with no
+   * `RetryProvider` of its own and therefore no `resolveFallbackRoute`, so
+   * nothing this loop calls can escalate to a second backup no matter how many
+   * times it retries.
+   *
+   * `fallbackOptions` is sent verbatim on every attempt, never re-normalized.
+   * `normalizeSendMessageOptions` has already consumed the `callSite` and
+   * stamped the backup route's `usageAttributionHeaders`; running it again over
+   * that now callSite-less config would delete the headers and have no way to
+   * rebuild them, leaving degraded traffic unattributed on the platform's
+   * billing events. This is the same reason the route callback hands back a raw
+   * adapter instead of a wrapped one.
+   */
+  private async sendOnBackupAdapter(
+    route: { provider: Provider },
+    messages: Message[],
+    fallbackOptions: SendMessageOptions | undefined,
+    retryBudget: boolean,
+  ): Promise<ProviderResponse> {
+    let attempt = 0;
+    let didRetry = false;
+    let messagesForAttempt = messages;
+    while (true) {
+      try {
+        return await route.provider.sendMessage(
+          messagesForAttempt,
+          fallbackOptions,
+        );
+      } catch (error) {
+        if (
+          !retryBudget ||
+          attempt >= DEFAULT_MAX_RETRIES ||
+          !isRetryableError(error)
+        ) {
+          // Same tagging contract as the primary loop, so a backup that flapped
+          // its way through the whole budget is recognizable to Sentry capture
+          // as noise no engineering action would change.
+          if (didRetry && isRetryableError(error) && error instanceof Error) {
+            (error as Error & { retriesExhausted?: boolean }).retriesExhausted =
+              true;
+          }
+          throw error;
+        }
+        // Built from the original `messages` each time, so the corrective note
+        // appears exactly once however many attempts fail this way.
+        if (isUnparseableToolArgsError(error)) {
+          messagesForAttempt = withUnparseableToolArgsHint(messages);
+        }
+        const { delay, retryAfterHeader } = retryPlan(error, attempt);
+        log.warn(
+          {
+            attempt: attempt + 1,
+            maxRetries: DEFAULT_MAX_RETRIES,
+            delay,
+            retryAfterHeader,
+            errorType: retryErrorType(error),
+            correctiveHint: messagesForAttempt !== messages,
+            provider: this.name,
+            backupProvider: route.provider.name,
+            connectionName: this.options.connectionName,
+            message: error instanceof Error ? error.message : String(error),
+          },
+          "Retrying the backup route after a transient error",
+        );
+        didRetry = true;
+        attempt++;
+        await sleep(delay);
+      }
+    }
+  }
+
+  /**
+   * Attempt the failed request on the backup route resolved by
    * `resolveFallbackRoute`. Returns null when no backup route applies (the
    * caller rethrows the original error unchanged); throws the fallback
    * error (with the original error attached as `cause`) when the backup
@@ -1476,12 +1699,18 @@ export class RetryProvider implements Provider {
    * `originalError` is undefined when the circuit breaker skipped the primary
    * outright: there is no failure of this request to report or to attach, only
    * the remembered outage of an earlier one.
+   *
+   * `backupRetryBudget` says whether the backup send gets a retry loop of its
+   * own. It is the caller's answer to one question: has this request already
+   * spent a retry budget somewhere? See the three call sites for the reasoning
+   * behind each answer.
    */
   private async sendOnFallbackRoute(
     messages: Message[],
     options: SendMessageOptions | undefined,
     originalError: unknown,
     retriesExhausted: boolean,
+    { backupRetryBudget }: { backupRetryBudget: boolean },
   ): Promise<ProviderResponse | null> {
     let route: {
       provider: Provider;
@@ -1574,12 +1803,22 @@ export class RetryProvider implements Provider {
     delete fallbackConfig.thinking;
     fallbackConfig.overrideProfile = route.overrideProfile;
     fallbackConfig.forceOverrideProfile = true;
+    const { dropToolChoice, ...toolsOverride } = this.fallbackTools(
+      options,
+      route,
+    );
+    // Filtering the sentinel emptied the tool list, so the `tool_choice` the
+    // call site paired with it now names a choice among no tools. See
+    // `fallbackTools` for why that is a hard 400 rather than a no-op.
+    if (dropToolChoice) {
+      delete fallbackConfig.tool_choice;
+    }
     const fallbackOptions = normalizeSendMessageOptions(
       route.provider.name,
       {
         ...options,
         config: fallbackConfig,
-        ...this.fallbackTools(options, route),
+        ...toolsOverride,
       },
       {
         forwardUsageAttributionHeaders:
@@ -1609,10 +1848,11 @@ export class RetryProvider implements Provider {
     );
 
     try {
-      // One hop, one attempt: the fallback send gets no retry loop in v1.
-      const response = await route.provider.sendMessage(
+      const response = await this.sendOnBackupAdapter(
+        route,
         messages,
         fallbackOptions,
+        backupRetryBudget,
       );
       // Stamp the provider that actually served the response. Without this,
       // a backup adapter that does not set `actualProvider` leaves the outer

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -1,4 +1,7 @@
-import { resolveCallSiteConfig } from "../config/llm-resolver.js";
+import {
+  resolveCallSiteConfig,
+  selectWinningProfile,
+} from "../config/llm-resolver.js";
 import { getConfig } from "../config/loader.js";
 import {
   resolveUsageAttribution,
@@ -328,6 +331,123 @@ function isRetryableError(error: unknown): boolean {
     return true;
   }
   return isRetryableNetworkError(error);
+}
+
+/**
+ * The managed proxy's preflight guard rejects a model with no billing rate
+ * card using a 400 whose body carries this phrase (django
+ * `app/runtime_proxy/views.py`). It marks a model rename/retirement incident
+ * (a route problem, not a request problem), so it is fallback-eligible even
+ * though 400s are otherwise final.
+ */
+const MANAGED_PROXY_UNSUPPORTED_MODEL_PATTERN =
+  /is not yet supported on the Vellum hosted service/;
+
+/** Outage-shaped failures that justify switching to a backup profile. */
+function isFallbackEligibleError(
+  error: unknown,
+  opts: {
+    retriesExhausted: boolean;
+    credentialSource?: ProviderCredentialSource;
+  },
+): boolean {
+  // Deterministic request failures and caller-initiated aborts never justify
+  // a different route (same short-circuits as `isRetryableError`): the same
+  // oversized prompt overflows the backup too, and a cancelled request must
+  // stay cancelled.
+  if (isContextOverflowError(error)) {
+    return false;
+  }
+  if (error instanceof ProviderError && error.abortReason !== undefined) {
+    return false;
+  }
+  // (a) The retry loop burned its whole budget on a transient error
+  // (429/5xx/overloaded/network/transport-abort): the primary route is down.
+  if (opts.retriesExhausted && isRetryableError(error)) {
+    return true;
+  }
+  if (!(error instanceof ProviderError)) {
+    return false;
+  }
+  // (b) Invalid managed credential (the invalid-key incident). Applies only
+  // to `vellum-managed` routes, where the platform owns the credential and a
+  // broken key is a platform incident. A BYOK or OAuth-subscription route
+  // with a broken personal credential must surface the auth error so the
+  // user can fix it, not silently reroute to a differently billed backup.
+  // Only reached after `sendMessage`'s credential-refresh path has already
+  // been attempted for managed routes: same status/reason gate as
+  // `shouldRefreshManagedCredential`.
+  if (
+    opts.credentialSource === "vellum-managed" &&
+    (error.statusCode === 401 || error.statusCode === 403) &&
+    (error.reason === undefined ||
+      error.reason === "unknown" ||
+      error.reason === "invalid_credentials")
+  ) {
+    return true;
+  }
+  // (c) Model not found: a provider-classified model_not_found, a 404 with
+  // no definitive classification, or the managed proxy's preflight 400 for a
+  // renamed/retired model. As in `isRetryableError`, a provider-stamped
+  // semantic reason takes precedence over the status fallback: a 404 whose
+  // classifier assigned a definitive non-model reason (Anthropic, for
+  // example, stamps `bad_request` on a 404 without a model signal) marks a
+  // deterministic request/routing failure that a different model route would
+  // not fix, so it must not switch routes. Only an absent or `unknown`
+  // reason falls through to the raw 404 check. `model_restricted` is a
+  // credential/policy denial, not a missing model, so it is deliberately not
+  // fallback-eligible here.
+  if (error.reason === "model_not_found") {
+    return true;
+  }
+  if (
+    error.statusCode === 404 &&
+    (error.reason === undefined || error.reason === "unknown")
+  ) {
+    return true;
+  }
+  if (
+    error.statusCode === 400 &&
+    MANAGED_PROXY_UNSUPPORTED_MODEL_PATTERN.test(error.message)
+  ) {
+    return true;
+  }
+  return false;
+}
+
+/** Structured error class for the "Falling back to backup profile" log. */
+function fallbackErrorType(error: unknown, retriesExhausted: boolean): string {
+  if (retriesExhausted) {
+    return "retries_exhausted";
+  }
+  if (error instanceof ProviderError) {
+    if (error.statusCode === 401 || error.statusCode === 403) {
+      return "invalid_credentials";
+    }
+    if (error.statusCode === 404 || error.statusCode === 400) {
+      return "model_not_found";
+    }
+  }
+  return "unknown";
+}
+
+/**
+ * Whether a failed request can be re-routed to a backup profile. Fallback
+ * re-resolves the ORIGINAL caller options with the backup profile forced,
+ * which requires a `callSite`-bearing config. An explicit per-call
+ * `config.model` pin (the live per-conversation `modelOverride` feature)
+ * disqualifies the request: the pin wins over any resolved profile model in
+ * `normalizeSendMessageOptions`, and silently serving a different model
+ * against an explicit pin would violate user intent: a profile user asked
+ * for a tier, a pinning user asked for that exact model. Pinned conversations
+ * keep today's retry-then-error behavior.
+ */
+function canReRouteToFallbackProfile(options?: SendMessageOptions): boolean {
+  const config = options?.config;
+  if (config?.callSite === undefined) {
+    return false;
+  }
+  return !(typeof config.model === "string" && config.model.trim().length > 0);
 }
 
 /**
@@ -892,6 +1012,29 @@ export class RetryProvider implements Provider {
       credentialSource?: ProviderCredentialSource;
       connectionName?: string;
       refreshCredentialProvider?: () => Promise<Provider | null>;
+      /**
+       * Escalation hook: resolve a backup route (a ready adapter, the backup
+       * profile key, and the backup route's usage-attribution forwarding
+       * policy) for a request whose primary route failed with an
+       * outage-shaped error (see {@link isFallbackEligibleError}). The
+       * callback owns all profile knowledge: it inspects the failed call's
+       * winning profile and returns null when that profile declares no
+       * `fallbackProfile`, mirroring how `refreshCredentialProvider` keeps
+       * this wrapper ignorant of credential storage.
+       * `forwardUsageAttributionHeaders` must describe the BACKUP route, not
+       * the primary: managed-proxy routes pass true, BYOK and other
+       * third-party routes pass false. The fallback send normalizes with the
+       * returned policy so `X-Vellum-*` billing metadata never leaks to a
+       * third party and is never omitted from the managed proxy. One hop
+       * max; the fallback attempt itself gets no retry loop.
+       */
+      resolveFallbackRoute?: (
+        failedOptions: SendMessageOptions | undefined,
+      ) => Promise<{
+        provider: Provider;
+        overrideProfile: string;
+        forwardUsageAttributionHeaders: boolean;
+      } | null>;
     } = {},
   ) {
     this.inner = inner;
@@ -936,6 +1079,7 @@ export class RetryProvider implements Provider {
     let didRetry = false;
     let retryAttempt = 0;
     let credentialRefreshAttempted = false;
+    let fallbackAttempted = false;
     let messagesForAttempt = messages;
 
     const normalizedOptions = normalizeSendMessageOptions(this.name, options, {
@@ -1037,14 +1181,200 @@ export class RetryProvider implements Provider {
         // stops retrying when either (a) retries are exhausted, or (b) the
         // error isn't retryable — so we check the retryable predicate here to
         // distinguish the two cases.
-        if (didRetry && isRetryableError(error) && error instanceof Error) {
+        const retriesExhausted = didRetry && isRetryableError(error);
+        if (retriesExhausted && error instanceof Error) {
           (error as Error & { retriesExhausted?: boolean }).retriesExhausted =
             true;
         }
 
         this.attributeCredential(error);
+
+        // Last resort before rethrowing: escalate an outage-shaped failure to
+        // the backup profile's route when the construction site wired one in.
+        // One hop max; a request pinned to an explicit model never re-routes.
+        if (
+          !fallbackAttempted &&
+          this.options.resolveFallbackRoute !== undefined &&
+          canReRouteToFallbackProfile(options) &&
+          isFallbackEligibleError(error, {
+            retriesExhausted,
+            credentialSource: this.options.credentialSource,
+          })
+        ) {
+          fallbackAttempted = true;
+          const fallbackResult = await this.sendOnFallbackRoute(
+            messages,
+            options,
+            error,
+            retriesExhausted,
+          );
+          if (fallbackResult !== null) {
+            return fallbackResult;
+          }
+        }
+
         throw error;
       }
+    }
+  }
+
+  /**
+   * Attempt the failed request once on the backup route resolved by
+   * `resolveFallbackRoute`. Returns null when no backup route applies (the
+   * caller rethrows the original error unchanged); throws the fallback
+   * error (with the original error attached as `cause`) when the backup
+   * attempt itself fails.
+   */
+  private async sendOnFallbackRoute(
+    messages: Message[],
+    options: SendMessageOptions | undefined,
+    originalError: unknown,
+    retriesExhausted: boolean,
+  ): Promise<ProviderResponse | null> {
+    let route: {
+      provider: Provider;
+      overrideProfile: string;
+      forwardUsageAttributionHeaders: boolean;
+    } | null;
+    try {
+      route = (await this.options.resolveFallbackRoute?.(options)) ?? null;
+    } catch (resolveError) {
+      log.warn(
+        { provider: this.name, resolveError },
+        "Failed to resolve fallback route; rethrowing the original error",
+      );
+      return null;
+    }
+    if (route === null) {
+      return null;
+    }
+
+    // Reject a mix backup profile outright. The fallback schema already
+    // forbids `fallbackProfile` from referencing a mix, but this wrapper must
+    // not trust that: honoring one would require the route callback, the
+    // winner-selection guard below, and the re-normalization to agree on the
+    // same seeded arm, and a request without a `selectionSeed` expands the
+    // mix independently at each of those points, so one arm's model could be
+    // sent through another arm's provider adapter. Treat it as non-applying
+    // and surface the original error.
+    if (getConfig().llm.profiles?.[route.overrideProfile]?.mix != null) {
+      log.warn(
+        {
+          provider: this.name,
+          connectionName: this.options.connectionName,
+          overrideProfile: route.overrideProfile,
+        },
+        "Backup profile is a mix, which fallback routing does not support; rethrowing the original error",
+      );
+      return null;
+    }
+
+    // Guard against a backup profile that does not actually apply: the
+    // resolver skips a disabled, incomplete, or missing override profile and
+    // falls through to the next rung (often the failed primary), while the
+    // request would still dispatch on the backup adapter, producing a
+    // provider/model mismatch. Verify the backup profile wins the winner
+    // selection the re-normalization below will perform; if it does not,
+    // surface the original error instead of sending a mismatched request.
+    const failedConfig = options?.config;
+    const callSite = failedConfig?.callSite;
+    const selectionSeed = failedConfig?.selectionSeed;
+    const selection =
+      callSite === undefined
+        ? null
+        : selectWinningProfile(callSite, getConfig().llm, {
+            overrideProfile: route.overrideProfile,
+            ...(selectionSeed !== undefined ? { selectionSeed } : {}),
+          });
+    if (
+      selection === null ||
+      selection.source !== "override" ||
+      selection.profileName !== route.overrideProfile
+    ) {
+      log.warn(
+        {
+          provider: this.name,
+          connectionName: this.options.connectionName,
+          overrideProfile: route.overrideProfile,
+          selectionSource: selection?.source,
+          selectedProfile: selection?.profileName,
+        },
+        "Backup profile did not apply on re-resolution; rethrowing the original error",
+      );
+      return null;
+    }
+
+    // Re-resolve the ORIGINAL caller options with the backup profile forced
+    // (`resolveCallSiteConfig` floats a forced override to the top of the
+    // selection chain). Explicit per-call `max_tokens`/`effort`/`thinking`
+    // are cleared so the backup profile's resolved values win; the pin gate
+    // in `canReRouteToFallbackProfile` already excluded explicit
+    // `config.model`. Re-normalizing on a callSite-bearing config also
+    // restamps the usage-attribution headers from the backup resolution, so
+    // platform usage events attribute degraded traffic to the backup
+    // profile. Whether those headers are forwarded at all follows the
+    // FALLBACK route's policy, not the primary's: a managed primary falling
+    // back to a third-party adapter must not leak billing metadata, and a
+    // non-managed primary falling back to the managed proxy must include it.
+    const fallbackConfig: Record<string, unknown> = { ...options?.config };
+    delete fallbackConfig.max_tokens;
+    delete fallbackConfig.effort;
+    delete fallbackConfig.thinking;
+    fallbackConfig.overrideProfile = route.overrideProfile;
+    fallbackConfig.forceOverrideProfile = true;
+    const fallbackOptions = normalizeSendMessageOptions(
+      route.provider.name,
+      { ...options, config: fallbackConfig },
+      {
+        forwardUsageAttributionHeaders:
+          route.forwardUsageAttributionHeaders === true,
+      },
+    );
+
+    log.warn(
+      {
+        provider: this.name,
+        connectionName: this.options.connectionName,
+        fallbackProvider: route.provider.name,
+        overrideProfile: route.overrideProfile,
+        errorType: fallbackErrorType(originalError, retriesExhausted),
+        message:
+          originalError instanceof Error
+            ? originalError.message
+            : String(originalError),
+      },
+      "Falling back to backup profile",
+    );
+
+    try {
+      // One hop, one attempt: the fallback send gets no retry loop in v1.
+      const response = await route.provider.sendMessage(
+        messages,
+        fallbackOptions,
+      );
+      // Stamp the provider that actually served the response. Without this,
+      // a backup adapter that does not set `actualProvider` leaves the outer
+      // call-site router recording the success under the failed primary
+      // provider (wrong provider, wrong pricing attribution). Never
+      // overwrite a more specific value the adapter already set.
+      if (response.actualProvider === undefined) {
+        response.actualProvider = route.provider.name;
+      }
+      // Stamp the profile that actually governed the response for the same
+      // reason: the outer `UsageTrackingProvider` resolves attribution from
+      // the ORIGINAL request options, which still carry the failed primary's
+      // resolution, so without this the usage event would bill the fallback
+      // serve under the wrong profile. Never overwrite a more specific value
+      // an inner wrapper already set.
+      if (response.actualInferenceProfile === undefined) {
+        response.actualInferenceProfile = route.overrideProfile;
+      }
+      return response;
+    } catch (fallbackError) {
+      if (fallbackError instanceof Error && fallbackError.cause === undefined) {
+        fallbackError.cause = originalError;
+      }
+      throw fallbackError;
     }
   }
 }

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -38,9 +38,11 @@ import {
 import {
   isContextOverflowError,
   type Message,
+  NATIVE_WEB_SEARCH_TOOL_NAME,
   type Provider,
   type ProviderResponse,
   type SendMessageOptions,
+  type ToolDefinition,
 } from "./types.js";
 import { UNPARSEABLE_TOOL_ARGS_SDK_MESSAGE } from "./unparseable-tool-args.js";
 
@@ -521,17 +523,18 @@ function normalizeSendMessageOptions(
     nextConfig.promptCacheKey = config.selectionSeed;
   }
 
-  // `overrideProfile`, `forceOverrideProfile`, `selectionSeed`, and
-  // `conversationId` are routing/resolution-time concerns (consumed by the
-  // resolver below, `CallSiteRoutingProvider`'s provider selection, and
-  // `UsageTrackingProvider`'s ledger attribution); none is a wire-format
-  // field. Strip unconditionally (after the `openai` promptCacheKey copy
-  // above) so they never leak into provider request bodies even when callers
-  // set them without a `callSite`.
+  // `overrideProfile`, `forceOverrideProfile`, `selectionSeed`,
+  // `conversationId`, and `nativeWebSearchSentinel` are routing/resolution-time
+  // concerns (consumed by the resolver below, `CallSiteRoutingProvider`'s
+  // provider selection, `UsageTrackingProvider`'s ledger attribution, and the
+  // fallback tool filter); none is a wire-format field. Strip unconditionally
+  // (after the `openai` promptCacheKey copy above) so they never leak into
+  // provider request bodies even when callers set them without a `callSite`.
   delete nextConfig.overrideProfile;
   delete nextConfig.forceOverrideProfile;
   delete nextConfig.selectionSeed;
   delete nextConfig.conversationId;
+  delete nextConfig.nativeWebSearchSentinel;
 
   if (config.callSite !== undefined) {
     const resolved = resolveCallSiteConfig(config.callSite, getConfig().llm, {
@@ -1219,6 +1222,44 @@ export class RetryProvider implements Provider {
   }
 
   /**
+   * The `tools` override for the fallback send, or nothing when the original
+   * list carries over unchanged.
+   *
+   * The caller decided whether to append the native web search sentinel from
+   * the PRIMARY route's capability (see `AgentLoop`), so a backup that runs
+   * no server-side search would receive a tool it cannot execute and answer
+   * with a tool call nothing can service. The sentinel is dropped for those
+   * routes: degraded mode loses native search rather than the whole turn.
+   *
+   * Gated on `config.nativeWebSearchSentinel`, never on the name alone: with a
+   * search backend like Brave or the platform search proxy configured, a tool
+   * of the same name is app-executed and works on every route, so filtering it
+   * would take away a capability the backup can still serve.
+   */
+  private fallbackTools(
+    options: SendMessageOptions | undefined,
+    route: { provider: Provider },
+  ): { tools?: ToolDefinition[] } {
+    const tools = options?.tools;
+    if (
+      options?.config?.nativeWebSearchSentinel !== true ||
+      tools === undefined ||
+      !tools.some((tool) => tool.name === NATIVE_WEB_SEARCH_TOOL_NAME)
+    ) {
+      return {};
+    }
+    const backupServesNativeSearch = route.provider.supportsNativeWebSearchFor
+      ? route.provider.supportsNativeWebSearchFor(options)
+      : route.provider.supportsNativeWebSearch === true;
+    if (backupServesNativeSearch) {
+      return {};
+    }
+    return {
+      tools: tools.filter((tool) => tool.name !== NATIVE_WEB_SEARCH_TOOL_NAME),
+    };
+  }
+
+  /**
    * Attempt the failed request once on the backup route resolved by
    * `resolveFallbackRoute`. Returns null when no backup route applies (the
    * caller rethrows the original error unchanged); throws the fallback
@@ -1324,7 +1365,11 @@ export class RetryProvider implements Provider {
     fallbackConfig.forceOverrideProfile = true;
     const fallbackOptions = normalizeSendMessageOptions(
       route.provider.name,
-      { ...options, config: fallbackConfig },
+      {
+        ...options,
+        config: fallbackConfig,
+        ...this.fallbackTools(options, route),
+      },
       {
         forwardUsageAttributionHeaders:
           route.forwardUsageAttributionHeaders === true,

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -25,6 +25,15 @@ import {
   isAnthropicDelegatingGateway,
   isAnthropicModel,
 } from "./anthropic-gateway-shared.js";
+import {
+  type BreakerRoute,
+  recordFallbackServed,
+  recordPrimaryFailure,
+  recordPrimarySuccess,
+  releaseRecoveryProbe,
+  shouldSkipPrimary,
+  tryAcquireRecoveryProbe,
+} from "./fallback-breaker.js";
 import { resolveLogitBiasPreset } from "./inference/logit-bias.js";
 import {
   isAdaptiveThinkingOnlyModel,
@@ -292,6 +301,16 @@ function isRetryableTransportAbort(error: unknown): boolean {
   return RETRYABLE_TRANSPORT_ABORT_PATTERNS.some((p) => p.test(error.message));
 }
 
+/**
+ * A daemon or user cancellation. The provider catch-sites tag these with
+ * `abortReason` exactly when `signal.aborted` was true at the time of failure,
+ * which is what separates them from transport-level aborts: both surface as
+ * "Request was aborted" from the SDK, and only the tag says who stopped it.
+ */
+function isCallerAbort(error: unknown): boolean {
+  return error instanceof ProviderError && error.abortReason !== undefined;
+}
+
 function isRetryableError(error: unknown): boolean {
   // Context overflow is deterministic — retrying the same oversized prompt
   // will never succeed. Short-circuit before the generic 429/5xx check so
@@ -300,12 +319,11 @@ function isRetryableError(error: unknown): boolean {
   if (isContextOverflowError(error)) {
     return false;
   }
-  // Daemon/user-initiated aborts are never retryable. The catch-site tags
-  // these with `abortReason` exactly when `signal.aborted` was true at the
-  // time of failure, so this short-circuits before any message-based pattern
-  // matches — which matters because transport-level aborts (retryable) and
-  // caller-cancels both surface as "Request was aborted" from the SDK.
-  if (error instanceof ProviderError && error.abortReason !== undefined) {
+  // Daemon/user-initiated aborts are never retryable. This short-circuits
+  // before any message-based pattern matches, which matters because
+  // transport-level aborts (retryable) and caller-cancels both surface as
+  // "Request was aborted" from the SDK.
+  if (isCallerAbort(error)) {
     return false;
   }
   // Prefer the provider-stamped semantic reason: a known reason decides
@@ -345,6 +363,37 @@ function isRetryableError(error: unknown): boolean {
 const MANAGED_PROXY_UNSUPPORTED_MODEL_PATTERN =
   /is not yet supported on the Vellum hosted service/;
 
+/**
+ * Whether the failure indicts one model rather than the upstream serving it: a
+ * provider-classified `model_not_found`, a 404 with no definitive
+ * classification, or the managed proxy's preflight 400 for a renamed/retired
+ * model. As in `isRetryableError`, a provider-stamped semantic reason takes
+ * precedence over the status fallback: a 404 whose classifier assigned a
+ * definitive non-model reason (Anthropic, for example, stamps `bad_request` on
+ * a 404 without a model signal) marks a deterministic request/routing failure
+ * that a different model route would not fix. Only an absent or `unknown`
+ * reason falls through to the raw 404 check. `model_restricted` is a
+ * credential/policy denial, not a missing model, so it is deliberately absent.
+ */
+function isModelSpecificError(error: unknown): boolean {
+  if (!(error instanceof ProviderError)) {
+    return false;
+  }
+  if (error.reason === "model_not_found") {
+    return true;
+  }
+  if (
+    error.statusCode === 404 &&
+    (error.reason === undefined || error.reason === "unknown")
+  ) {
+    return true;
+  }
+  return (
+    error.statusCode === 400 &&
+    MANAGED_PROXY_UNSUPPORTED_MODEL_PATTERN.test(error.message)
+  );
+}
+
 /** Outage-shaped failures that justify switching to a backup profile. */
 function isFallbackEligibleError(
   error: unknown,
@@ -360,7 +409,7 @@ function isFallbackEligibleError(
   if (isContextOverflowError(error)) {
     return false;
   }
-  if (error instanceof ProviderError && error.abortReason !== undefined) {
+  if (isCallerAbort(error)) {
     return false;
   }
   // (a) The retry loop burned its whole budget on a transient error
@@ -388,33 +437,10 @@ function isFallbackEligibleError(
   ) {
     return true;
   }
-  // (c) Model not found: a provider-classified model_not_found, a 404 with
-  // no definitive classification, or the managed proxy's preflight 400 for a
-  // renamed/retired model. As in `isRetryableError`, a provider-stamped
-  // semantic reason takes precedence over the status fallback: a 404 whose
-  // classifier assigned a definitive non-model reason (Anthropic, for
-  // example, stamps `bad_request` on a 404 without a model signal) marks a
-  // deterministic request/routing failure that a different model route would
-  // not fix, so it must not switch routes. Only an absent or `unknown`
-  // reason falls through to the raw 404 check. `model_restricted` is a
-  // credential/policy denial, not a missing model, so it is deliberately not
-  // fallback-eligible here.
-  if (error.reason === "model_not_found") {
-    return true;
-  }
-  if (
-    error.statusCode === 404 &&
-    (error.reason === undefined || error.reason === "unknown")
-  ) {
-    return true;
-  }
-  if (
-    error.statusCode === 400 &&
-    MANAGED_PROXY_UNSUPPORTED_MODEL_PATTERN.test(error.message)
-  ) {
-    return true;
-  }
-  return false;
+  // (c) The model is gone (a rename/retirement incident): a different model's
+  // route is exactly what fixes it. See `isModelSpecificError` for which
+  // shapes qualify and which deliberately do not.
+  return isModelSpecificError(error);
 }
 
 /** Structured error class for the "Falling back to backup profile" log. */
@@ -450,6 +476,24 @@ function canReRouteToFallbackProfile(options?: SendMessageOptions): boolean {
     return false;
   }
   return !(typeof config.model === "string" && config.model.trim().length > 0);
+}
+
+/**
+ * The route a failure indicts, or null when it must not be remembered at all.
+ * An outage marks the whole upstream; a retired or renamed model marks only
+ * that model, because diverting every healthy profile on the upstream for one
+ * model's 404 does more damage than the incident. A model-specific failure on
+ * a request whose model cannot be named is not remembered either: naming the
+ * upstream instead would be exactly that over-trip.
+ */
+function failureBreakerRoute(
+  route: BreakerRoute,
+  error: unknown,
+): BreakerRoute | null {
+  if (!isModelSpecificError(error)) {
+    return { upstream: route.upstream };
+  }
+  return route.model === undefined ? null : route;
 }
 
 /**
@@ -1059,6 +1103,40 @@ export class RetryProvider implements Provider {
     );
   }
 
+  /**
+   * Reload the managed credential after an auth rejection and swap the inner
+   * provider for one built around it, so a key rotated out of band is picked
+   * up without a restart. Returns true when a refreshed adapter took over and
+   * the request is worth attempting again. Never throws: a failed reload
+   * leaves the original error to surface.
+   */
+  private async refreshManagedCredential(): Promise<boolean> {
+    try {
+      const refreshed = await this.options.refreshCredentialProvider?.();
+      if (refreshed) {
+        this.inner = refreshed;
+        log.info(
+          {
+            provider: this.name,
+            connectionName: this.options.connectionName,
+          },
+          "Retrying managed inference with refreshed assistant credentials",
+        );
+        return true;
+      }
+    } catch (refreshError) {
+      log.warn(
+        {
+          provider: this.name,
+          connectionName: this.options.connectionName,
+          refreshError,
+        },
+        "Failed to reload managed assistant credentials",
+      );
+    }
+    return false;
+  }
+
   private attributeCredential(error: unknown): void {
     const { credentialSource, connectionName } = this.options;
     if (
@@ -1090,12 +1168,146 @@ export class RetryProvider implements Provider {
         this.options.forwardUsageAttributionHeaders === true,
     });
 
+    // Only a request that can actually take the backup consults the circuit
+    // breaker: it needs a wired escalation hook (BYOK, oauth-subscription, and
+    // no-auth routes have none, so they keep today's behavior exactly) and it
+    // must be re-routable. One gate for reads and writes alike, so a request
+    // that bypasses the breaker can neither be skipped by it nor close a trip
+    // that re-routable traffic still needs.
+    //
+    // The model comes from the resolved options, since a retired model is
+    // remembered per model rather than per upstream.
+    const breakerRoute: BreakerRoute | null =
+      this.options.resolveFallbackRoute !== undefined &&
+      canReRouteToFallbackProfile(options)
+        ? {
+            upstream: this.name,
+            ...(typeof normalizedOptions?.config?.model === "string"
+              ? { model: normalizedOptions.config.model }
+              : {}),
+          }
+        : null;
+
+    if (breakerRoute !== null) {
+      if (shouldSkipPrimary(breakerRoute)) {
+        // The primary is known to be down, so its retry budget would only add
+        // latency to an answer the backup was always going to give.
+        log.info(
+          {
+            provider: this.name,
+            connectionName: this.options.connectionName,
+          },
+          "Skipping the primary route while its fallback breaker is open",
+        );
+        fallbackAttempted = true;
+        const served = await this.sendOnFallbackRoute(
+          messages,
+          options,
+          undefined,
+          false,
+        );
+        if (served !== null) {
+          return served;
+        }
+        // No backup route applies after all (the config changed under the
+        // remembered outage), so the primary is the only route left. The
+        // escalation path below stays disabled: it would resolve the same
+        // options against the same config and get the same nothing.
+      } else if (tryAcquireRecoveryProbe(breakerRoute)) {
+        log.info(
+          {
+            provider: this.name,
+            connectionName: this.options.connectionName,
+            model: breakerRoute.model,
+          },
+          "Probing the primary route for recovery",
+        );
+        // One probe, one attempt: no retry loop. A managed credential that
+        // expired during the outage is the exception, because the probe would
+        // otherwise read its own 401 as the outage continuing and the route
+        // could never come back. The refresh is the same one-shot step the
+        // retry loop runs, and it shares the send's budget for it.
+        while (true) {
+          try {
+            const response = await this.inner.sendMessage(
+              messagesForAttempt,
+              normalizedOptions,
+            );
+            releaseRecoveryProbe(breakerRoute, { verdict: "recovered" });
+            return response;
+          } catch (error) {
+            // A cancelled request asked the route nothing, so the probe has no
+            // verdict to report. Hand the claim back and leave the breaker as
+            // it was: reporting recovery here would delete an entry nothing
+            // retested and send the next request through the full retry budget
+            // of a route still known to be down.
+            if (isCallerAbort(error)) {
+              releaseRecoveryProbe(breakerRoute, { verdict: "abandoned" });
+              this.attributeCredential(error);
+              throw error;
+            }
+            if (
+              !credentialRefreshAttempted &&
+              this.shouldRefreshManagedCredential(error)
+            ) {
+              credentialRefreshAttempted = true;
+              if (await this.refreshManagedCredential()) {
+                continue;
+              }
+            }
+            // The probe stands in for the whole retry budget while the breaker
+            // is open, so a failure the retry loop would have exhausted itself
+            // against means the outage continues. Any other failure means the
+            // route answered the request, which is all the probe asked.
+            const outage = isFallbackEligibleError(error, {
+              retriesExhausted: true,
+              credentialSource: this.options.credentialSource,
+            });
+            // The probe's own error decides what stays remembered, not the
+            // scope of the entry it was acquired under: an upstream that
+            // answers with a retired-model 404 has stopped being an outage,
+            // and a model outage that turns into a 503 has stopped being about
+            // the model.
+            releaseRecoveryProbe(
+              breakerRoute,
+              outage
+                ? {
+                    verdict: "failing",
+                    failedRoute: failureBreakerRoute(breakerRoute, error),
+                  }
+                : { verdict: "recovered" },
+            );
+            this.attributeCredential(error);
+            if (!outage) {
+              throw error;
+            }
+            fallbackAttempted = true;
+            const served = await this.sendOnFallbackRoute(
+              messages,
+              options,
+              error,
+              true,
+            );
+            if (served !== null) {
+              // No trip needed: the failed probe already re-tripped the breaker
+              // with the longer cooldown a repeat outage earns.
+              return served;
+            }
+            break;
+          }
+        }
+      }
+    }
+
     while (true) {
       try {
         const result = await this.inner.sendMessage(
           messagesForAttempt,
           normalizedOptions,
         );
+        if (breakerRoute !== null) {
+          recordPrimarySuccess(breakerRoute);
+        }
         return result;
       } catch (error) {
         if (
@@ -1103,28 +1315,8 @@ export class RetryProvider implements Provider {
           this.shouldRefreshManagedCredential(error)
         ) {
           credentialRefreshAttempted = true;
-          try {
-            const refreshed = await this.options.refreshCredentialProvider?.();
-            if (refreshed) {
-              this.inner = refreshed;
-              log.info(
-                {
-                  provider: this.name,
-                  connectionName: this.options.connectionName,
-                },
-                "Retrying managed inference with refreshed assistant credentials",
-              );
-              continue;
-            }
-          } catch (refreshError) {
-            log.warn(
-              {
-                provider: this.name,
-                connectionName: this.options.connectionName,
-                refreshError,
-              },
-              "Failed to reload managed assistant credentials",
-            );
+          if (await this.refreshManagedCredential()) {
+            continue;
           }
         }
 
@@ -1205,6 +1397,15 @@ export class RetryProvider implements Provider {
           })
         ) {
           fallbackAttempted = true;
+          // What the failure indicts: the whole upstream for an outage, only
+          // this model for a retirement or rename.
+          const failedRoute =
+            breakerRoute === null
+              ? null
+              : failureBreakerRoute(breakerRoute, error);
+          if (failedRoute !== null) {
+            recordPrimaryFailure(failedRoute);
+          }
           const fallbackResult = await this.sendOnFallbackRoute(
             messages,
             options,
@@ -1212,6 +1413,12 @@ export class RetryProvider implements Provider {
             retriesExhausted,
           );
           if (fallbackResult !== null) {
+            // A completed backup serve is proof the primary is down and the
+            // backup can carry the traffic, so later requests skip the retry
+            // budget until a probe says the primary is back.
+            if (failedRoute !== null) {
+              recordFallbackServed(failedRoute);
+            }
             return fallbackResult;
           }
         }
@@ -1265,6 +1472,10 @@ export class RetryProvider implements Provider {
    * caller rethrows the original error unchanged); throws the fallback
    * error (with the original error attached as `cause`) when the backup
    * attempt itself fails.
+   *
+   * `originalError` is undefined when the circuit breaker skipped the primary
+   * outright: there is no failure of this request to report or to attach, only
+   * the remembered outage of an earlier one.
    */
   private async sendOnFallbackRoute(
     messages: Message[],
@@ -1376,17 +1587,23 @@ export class RetryProvider implements Provider {
       },
     );
 
+    const escalationCause =
+      originalError === undefined
+        ? { errorType: "breaker_open" }
+        : {
+            errorType: fallbackErrorType(originalError, retriesExhausted),
+            message:
+              originalError instanceof Error
+                ? originalError.message
+                : String(originalError),
+          };
     log.warn(
       {
         provider: this.name,
         connectionName: this.options.connectionName,
         fallbackProvider: route.provider.name,
         overrideProfile: route.overrideProfile,
-        errorType: fallbackErrorType(originalError, retriesExhausted),
-        message:
-          originalError instanceof Error
-            ? originalError.message
-            : String(originalError),
+        ...escalationCause,
       },
       "Falling back to backup profile",
     );
@@ -1416,7 +1633,11 @@ export class RetryProvider implements Provider {
       }
       return response;
     } catch (fallbackError) {
-      if (fallbackError instanceof Error && fallbackError.cause === undefined) {
+      if (
+        originalError !== undefined &&
+        fallbackError instanceof Error &&
+        fallbackError.cause === undefined
+      ) {
         fallbackError.cause = originalError;
       }
       throw fallbackError;

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -26,6 +26,7 @@ import {
   isAnthropicModel,
 } from "./anthropic-gateway-shared.js";
 import {
+  type BreakerObservation,
   type BreakerRoute,
   recordFallbackServed,
   recordPrimaryFailure,
@@ -1551,8 +1552,9 @@ export class RetryProvider implements Provider {
             breakerRoute === null
               ? null
               : failureBreakerRoute(breakerRoute, error);
+          let failureObservation: BreakerObservation | undefined;
           if (failedRoute !== null) {
-            recordPrimaryFailure(failedRoute);
+            failureObservation = recordPrimaryFailure(failedRoute);
           }
           const fallbackResult = await this.sendOnFallbackRoute(
             messages,
@@ -1571,7 +1573,7 @@ export class RetryProvider implements Provider {
             // backup can carry the traffic, so later requests skip the retry
             // budget until a probe says the primary is back.
             if (failedRoute !== null) {
-              recordFallbackServed(failedRoute);
+              recordFallbackServed(failedRoute, Date.now(), failureObservation);
             }
             return fallbackResult;
           }

--- a/assistant/src/providers/types.ts
+++ b/assistant/src/providers/types.ts
@@ -1,6 +1,16 @@
 import type { ToolDefinition } from "../tools/tool-types.js";
 export type { ToolDefinition };
 
+/**
+ * The tool name that activates provider-native web search. Callers append a
+ * tool under this name only to instances reporting
+ * {@link Provider.supportsNativeWebSearch}; anywhere a request can change
+ * routes after that decision (see `RetryProvider`'s backup-profile
+ * escalation), the tool has to be dropped again when the new route cannot
+ * serve it, or the model answers with a tool call nothing can execute.
+ */
+export const NATIVE_WEB_SEARCH_TOOL_NAME = "web_search";
+
 import type { LLMCallSite } from "../config/schemas/llm.js";
 import {
   ProviderError,
@@ -290,6 +300,18 @@ export interface SendMessageConfig {
    * request.
    */
   forceOverrideProfile?: boolean;
+  /**
+   * True when the caller appended {@link NATIVE_WEB_SEARCH_TOOL_NAME} purely
+   * to activate the route's provider-native web search, rather than passing an
+   * app-executed search tool of the same name (which is what runs when a
+   * search backend like Brave or the platform search proxy is configured).
+   * Only the caller can tell those apart, and a route change after that
+   * decision has to: `RetryProvider` drops the tool on a backup that runs no
+   * native search, and must not touch it when the daemon executes it itself.
+   * A resolution/routing-time concern only; stripped before any provider wire
+   * request.
+   */
+  nativeWebSearchSentinel?: boolean;
   /**
    * Per-conversation seed for deterministic `mix`-profile expansion. The agent
    * loop sets this to the conversation id so every resolver call this send

--- a/assistant/src/providers/types.ts
+++ b/assistant/src/providers/types.ts
@@ -192,6 +192,15 @@ export interface ProviderResponse {
   /** Provider that actually produced this response, which may differ from a wrapper provider name. */
   actualProvider?: string;
   /**
+   * Inference profile key that actually governed this response when a
+   * wrapper re-routed the request away from the caller's own resolution
+   * (`RetryProvider`'s fallback-route escalation). `UsageTrackingProvider`
+   * prefers this over re-resolving from the original request options, so a
+   * successful fallback serve is attributed to the backup profile rather
+   * than the failed primary's. Absent on the normal (non-rerouted) path.
+   */
+  actualInferenceProfile?: string;
+  /**
    * Base URL the provider's HTTP client actually resolved to for this request,
    * read from the live SDK client instance rather than re-derived from config.
    * Lets diagnostics observe the true routing target (e.g. a misrouted host)

--- a/assistant/src/providers/usage-tracking.ts
+++ b/assistant/src/providers/usage-tracking.ts
@@ -66,9 +66,20 @@ export class UsageTrackingProvider implements Provider {
     }
 
     try {
+      // A fallback-serving wrapper (`RetryProvider`'s escalation) stamps the
+      // profile that actually governed the response; prefer it over the
+      // original request's resolution so a degraded serve bills under the
+      // backup profile, not the failed primary's. `forceOverrideProfile`
+      // mirrors how the fallback dispatch floated that profile above the
+      // call-site layers.
+      const appliedOverride =
+        response.actualInferenceProfile ?? config.overrideProfile;
       const attribution = resolveUsageAttribution({
         callSite: config.callSite,
-        overrideProfile: config.overrideProfile,
+        overrideProfile: appliedOverride,
+        ...(response.actualInferenceProfile !== undefined
+          ? { forceOverrideProfile: true }
+          : {}),
       });
       const providerName = response.actualProvider ?? this.inner.name;
       const pricingUsage = buildPricingUsageFromResponse(

--- a/assistant/src/runtime/__tests__/agent-wake.test.ts
+++ b/assistant/src/runtime/__tests__/agent-wake.test.ts
@@ -266,6 +266,7 @@ const recordRequestLogCalls: Array<{
 }> = [];
 const recordUsageCalls: Array<{
   conversationId: string;
+  providerName: string | undefined;
   inputTokens: number;
   outputTokens: number;
   model: string;
@@ -279,7 +280,7 @@ const recordUsageCalls: Array<{
 }> = [];
 mock.module("../../daemon/conversation-usage.js", () => ({
   recordUsage: (
-    ctx: { conversationId: string },
+    ctx: { conversationId: string; providerName?: string },
     inputTokens: number,
     outputTokens: number,
     model: string,
@@ -300,6 +301,7 @@ mock.module("../../daemon/conversation-usage.js", () => ({
   ) => {
     recordUsageCalls.push({
       conversationId: ctx.conversationId,
+      providerName: ctx.providerName,
       inputTokens,
       outputTokens,
       model,
@@ -2982,6 +2984,96 @@ describe("wakeAgentForOpportunity", () => {
     expect(recordUsageCalls[0]).toMatchObject({
       overrideProfile: "source-profile",
       forceOverrideProfile: true,
+      selectionSeed: conversation.conversationId,
+    });
+  });
+
+  test("rerouted wake records usage under the profile that actually served", async () => {
+    // The wake resolved its own profile before the run; the request then hit
+    // an outage-shaped failure and `RetryProvider` escalated to a backup
+    // profile on a different provider, stamping both `actualProvider` and
+    // `actualInferenceProfile` on the response the loop reports.
+    const usageEvent: AgentEvent = {
+      type: "usage",
+      inputTokens: 100,
+      outputTokens: 5,
+      model: "claude-sonnet-5",
+      actualProvider: "anthropic",
+      actualInferenceProfile: "backupProfile",
+      providerDurationMs: 10,
+      rawRequest: { request: "rerouted wake" },
+      rawResponse: { response: "real reply" },
+    };
+    const conversation = makeWakeConversation({
+      baseline: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+      scriptedEvents: [usageEvent],
+      scriptedAssistant: {
+        role: "assistant",
+        content: [{ type: "text", text: "real reply" }],
+      },
+    });
+
+    await wakeAgentForOpportunity(
+      {
+        conversationId: conversation.conversationId,
+        hint: "do reply",
+        source: "unit-test",
+        callSite: "memoryRetrospective",
+      },
+      { resolveTarget: async () => conversation },
+    );
+
+    // All three attribution facets of the row must describe the same call.
+    // Provider and model already followed the backup off the event; the
+    // profile has to follow it too or the row contradicts itself.
+    expect(recordUsageCalls).toHaveLength(1);
+    expect(recordUsageCalls[0]).toMatchObject({
+      providerName: "anthropic",
+      model: "claude-sonnet-5",
+      overrideProfile: "backupProfile",
+      forceOverrideProfile: true,
+      selectionSeed: conversation.conversationId,
+    });
+  });
+
+  test("non-rerouted wake keeps its own profile resolution", async () => {
+    // No reroute: the event carries no `actualInferenceProfile`, so the wake's
+    // own pre-run resolution stands and nothing is floated above the call site.
+    const usageEvent: AgentEvent = {
+      type: "usage",
+      inputTokens: 100,
+      outputTokens: 5,
+      model: "test-model",
+      actualProvider: "test-provider",
+      providerDurationMs: 10,
+      rawRequest: { request: "normal wake" },
+      rawResponse: { response: "real reply" },
+    };
+    const conversation = makeWakeConversation({
+      baseline: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+      scriptedEvents: [usageEvent],
+      scriptedAssistant: {
+        role: "assistant",
+        content: [{ type: "text", text: "real reply" }],
+      },
+    });
+
+    await wakeAgentForOpportunity(
+      {
+        conversationId: conversation.conversationId,
+        hint: "do reply",
+        source: "unit-test",
+        callSite: "memoryRetrospective",
+      },
+      { resolveTarget: async () => conversation },
+    );
+
+    expect(recordUsageCalls).toHaveLength(1);
+    expect(recordUsageCalls[0]).toMatchObject({
+      providerName: "test-provider",
+      model: "test-model",
+      overrideProfile: null,
+      forceOverrideProfile: false,
       selectionSeed: conversation.conversationId,
     });
   });

--- a/assistant/src/runtime/agent-wake.ts
+++ b/assistant/src/runtime/agent-wake.ts
@@ -1125,10 +1125,23 @@ export async function wakeAgentForOpportunity(
             // the conversation-id seed resolves the same mix arm the dispatch
             // path chose. Without these, attribution credits the call-site
             // profile/arm instead of the one that ran.
+            //
+            // A rerouted call (`RetryProvider`'s fallback-profile escalation)
+            // outranks both: the wake resolved `overrideProfile` before the
+            // run and cannot know the request was escalated, while
+            // `providerName` and `model` on this same row already follow the
+            // backup off the event. Attributing the profile from the wake's
+            // own resolution would write a row that contradicts itself. One
+            // row is written per `usage` event, each from that event alone,
+            // so this needs no cross-call state: a later non-rerouted call
+            // writes its own row under the wake's resolution.
             {
               callSite,
-              overrideProfile: overrideProfile ?? null,
-              forceOverrideProfile,
+              overrideProfile:
+                event.actualInferenceProfile ?? overrideProfile ?? null,
+              forceOverrideProfile:
+                event.actualInferenceProfile !== undefined ||
+                forceOverrideProfile,
               selectionSeed: conversationId,
             },
             opts.cronRunId ?? null,

--- a/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
@@ -50,6 +50,7 @@ mock.module("../../../persistence/embeddings/embedding-backend.js", () => ({
   },
 }));
 
+import { BACKUP_PROFILE_KEYS } from "../../../config/default-profile-names.js";
 import { getConfig, loadRawConfig } from "../../../config/loader.js";
 import { LLMConfigBase } from "../../../config/schemas/llm.js";
 import type { ConversationCreateType } from "../../../persistence/conversation-types.js";
@@ -1779,6 +1780,16 @@ describe("config invariant flag enrichment", () => {
     for (const name of ["balanced", "quality-optimized", "latency-optimized"]) {
       expect(profiles[name]!.invariant).toBe(true);
     }
+  });
+
+  test("GET /v1/config hides managed backups from the picker catalog", async () => {
+    const body = await configGetRoute.handler({});
+    const profiles = wireProfiles(body);
+
+    for (const name of BACKUP_PROFILE_KEYS) {
+      expect(profiles).not.toHaveProperty(name);
+    }
+    expect(profiles.balanced).toBeDefined();
   });
 
   test("PATCH /v1/config stamps the flag on the response but never persists it", async () => {

--- a/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
@@ -51,7 +51,7 @@ mock.module("../../../persistence/embeddings/embedding-backend.js", () => ({
 }));
 
 import { getConfig, loadRawConfig } from "../../../config/loader.js";
-import { LLMConfigBase, LLMSchema } from "../../../config/schemas/llm.js";
+import { LLMConfigBase } from "../../../config/schemas/llm.js";
 import type { ConversationCreateType } from "../../../persistence/conversation-types.js";
 import {
   getDb,
@@ -836,7 +836,7 @@ describe("PUT /v1/config/llm/profiles/:name", () => {
     seedRawConfig();
   });
 
-  describe("fallbackProfile cross-profile validation", () => {
+  describe("fallbackProfile write protection", () => {
     beforeEach(() => {
       const llm = rawConfigFixture.llm as {
         profiles: Record<string, Record<string, unknown>>;
@@ -845,141 +845,37 @@ describe("PUT /v1/config/llm/profiles/:name", () => {
         provider: "anthropic",
         model: "claude-sonnet-4-6",
       };
-      llm.profiles.chained = {
-        provider: "anthropic",
-        model: "claude-sonnet-4-6",
-        fallbackProfile: "backup",
-      };
-      llm.profiles.blend = {
-        mix: [
-          { profile: "custom", weight: 1 },
-          { profile: "backup", weight: 1 },
-        ],
-      };
       seedRawConfig();
     });
 
-    test("persists a valid fallbackProfile pointer", async () => {
-      const result = await replaceProfileRoute.handler({
-        pathParams: { name: "custom" },
-        body: {
-          provider: "anthropic",
-          model: "claude-sonnet-4-6",
-          fallbackProfile: "backup",
-        },
-      });
-      expect(result).toEqual({ ok: true });
-      expect(persistedProfile("custom").fallbackProfile).toBe("backup");
-    });
-
-    test("rejects a dangling fallbackProfile pointer without writing", async () => {
+    test("rejects a custom fallbackProfile without writing", async () => {
       await expect(
         replaceProfileRoute.handler({
           pathParams: { name: "custom" },
           body: {
             provider: "anthropic",
             model: "claude-sonnet-4-6",
-            fallbackProfile: "ghost",
+            fallbackProfile: "backup",
           },
         }),
-      ).rejects.toThrow(/fallbackProfile "ghost" which is not defined/);
+      ).rejects.toThrow(/Automatic fallbacks are code-owned/);
       expect(persistedProfile("custom").fallbackProfile).toBeUndefined();
-      // Guard rejects before commitConfigWrite fires any side effects.
       expect(initializeProvidersCalls).toBe(0);
     });
 
-    test("rejects a self-referential fallbackProfile", async () => {
+    test("rejects a custom pointer at a managed backup name", async () => {
       await expect(
         replaceProfileRoute.handler({
           pathParams: { name: "custom" },
           body: {
             provider: "anthropic",
             model: "claude-sonnet-4-6",
-            fallbackProfile: "custom",
+            fallbackProfile: "balanced-backup",
           },
         }),
-      ).rejects.toThrow(/cannot declare itself as its fallbackProfile/);
-    });
-
-    test("rejects a fallbackProfile pointing at a mix profile", async () => {
-      await expect(
-        replaceProfileRoute.handler({
-          pathParams: { name: "custom" },
-          body: {
-            provider: "anthropic",
-            model: "claude-sonnet-4-6",
-            fallbackProfile: "blend",
-          },
-        }),
-      ).rejects.toThrow(/which is a mix profile/);
-    });
-
-    test("rejects a fallbackProfile whose target declares its own fallback (chain)", async () => {
-      await expect(
-        replaceProfileRoute.handler({
-          pathParams: { name: "custom" },
-          body: {
-            provider: "anthropic",
-            model: "claude-sonnet-4-6",
-            fallbackProfile: "chained",
-          },
-        }),
-      ).rejects.toThrow(/chains are not allowed/);
-    });
-
-    test("rejects adding a fallbackProfile to a profile that is itself a fallback target (chain)", async () => {
-      await expect(
-        replaceProfileRoute.handler({
-          pathParams: { name: "backup" },
-          body: {
-            provider: "anthropic",
-            model: "claude-sonnet-4-6",
-            fallbackProfile: "custom",
-          },
-        }),
-      ).rejects.toThrow(
-        /"chained" already declares profile "backup" as its fallbackProfile/,
-      );
-    });
-
-    test("rejects converting a fallback target into a mix profile", async () => {
-      await expect(
-        replaceProfileRoute.handler({
-          pathParams: { name: "backup" },
-          body: {
-            mix: [
-              { profile: "custom", weight: 1 },
-              { profile: "chained", weight: 1 },
-            ],
-          },
-        }),
-      ).rejects.toThrow(/cannot become a mix/);
-    });
-
-    test("clears the profile's own fallbackProfile when converting it to a mix", async () => {
-      // "chained" declares fallbackProfile "backup". Replacing it with a mix
-      // body is an explicit replacement, so the pointer must be dropped: a
-      // persisted entry carrying both `mix` and `fallbackProfile` would be
-      // rejected and stripped on the next full config reload.
-      const result = await replaceProfileRoute.handler({
-        pathParams: { name: "chained" },
-        body: {
-          mix: [
-            { profile: "custom", weight: 1 },
-            { profile: "backup", weight: 1 },
-          ],
-        },
-      });
-      expect(result).toEqual({ ok: true });
-      const saved = persistedProfile("chained");
-      expect(saved.mix).toEqual([
-        { profile: "custom", weight: 1 },
-        { profile: "backup", weight: 1 },
-      ]);
-      expect("fallbackProfile" in saved).toBe(false);
-      // The persisted llm subtree reloads cleanly under the full schema
-      // parse, so the loader will not strip or salvage anything.
-      expect(LLMSchema.safeParse(loadRawConfig().llm).success).toBe(true);
+      ).rejects.toThrow(/Automatic fallbacks are code-owned/);
+      expect(persistedProfile("custom").fallbackProfile).toBeUndefined();
+      expect(initializeProvidersCalls).toBe(0);
     });
   });
 
@@ -1389,7 +1285,7 @@ describe("PUT /v1/config/llm/profiles/:name", () => {
   });
 });
 
-describe("PATCH /v1/config fallbackProfile cross-profile validation", () => {
+describe("PATCH /v1/config fallbackProfile write protection", () => {
   const patchRoute = ROUTES.find((r) => r.operationId === "config_patch")!;
 
   beforeEach(() => {
@@ -1400,81 +1296,33 @@ describe("PATCH /v1/config fallbackProfile cross-profile validation", () => {
         profiles: {
           custom: { provider: "anthropic", model: "claude-sonnet-4-6" },
           backup: { provider: "anthropic", model: "claude-sonnet-4-6" },
-          chained: {
-            provider: "anthropic",
-            model: "claude-sonnet-4-6",
-            fallbackProfile: "backup",
-          },
-          blend: {
-            mix: [
-              { profile: "custom", weight: 1 },
-              { profile: "backup", weight: 1 },
-            ],
-          },
         },
       },
     };
     seedRawConfig();
   });
 
-  test("persists a valid fallbackProfile through the generic patch route", async () => {
-    await patchRoute.handler({
-      body: { llm: { profiles: { custom: { fallbackProfile: "backup" } } } },
-    });
-    expect(persistedProfile("custom").fallbackProfile).toBe("backup");
-  });
-
-  test("rejects a self-referential fallbackProfile without writing", async () => {
+  test("rejects a custom fallbackProfile without writing", async () => {
     await expect(
       patchRoute.handler({
-        body: { llm: { profiles: { custom: { fallbackProfile: "custom" } } } },
+        body: { llm: { profiles: { custom: { fallbackProfile: "backup" } } } },
       }),
-    ).rejects.toThrow(/cannot declare itself as its fallbackProfile/);
-    expect(persistedProfile("custom").fallbackProfile).toBeUndefined();
-    // Rejection fires before commitConfigWrite runs any post-write side
-    // effects.
-    expect(initializeProvidersCalls).toBe(0);
-  });
-
-  test("rejects a dangling fallbackProfile without writing", async () => {
-    await expect(
-      patchRoute.handler({
-        body: { llm: { profiles: { custom: { fallbackProfile: "ghost" } } } },
-      }),
-    ).rejects.toThrow(/fallbackProfile "ghost" which is not defined/);
+    ).rejects.toThrow(/Automatic fallbacks are code-owned/);
     expect(persistedProfile("custom").fallbackProfile).toBeUndefined();
     expect(initializeProvidersCalls).toBe(0);
   });
 
-  test("rejects a fallbackProfile pointing at a mix profile without writing", async () => {
-    await expect(
-      patchRoute.handler({
-        body: { llm: { profiles: { custom: { fallbackProfile: "blend" } } } },
-      }),
-    ).rejects.toThrow(/which is a mix profile/);
-    expect(persistedProfile("custom").fallbackProfile).toBeUndefined();
-    expect(initializeProvidersCalls).toBe(0);
-  });
-
-  test("rejects a fallbackProfile chain without writing", async () => {
+  test("rejects a custom pointer at a managed backup name", async () => {
     await expect(
       patchRoute.handler({
         body: {
-          llm: { profiles: { custom: { fallbackProfile: "chained" } } },
+          llm: {
+            profiles: { custom: { fallbackProfile: "balanced-backup" } },
+          },
         },
       }),
-    ).rejects.toThrow(/chains are not allowed/);
+    ).rejects.toThrow(/Automatic fallbacks are code-owned/);
     expect(persistedProfile("custom").fallbackProfile).toBeUndefined();
-    expect(initializeProvidersCalls).toBe(0);
-  });
-
-  test("rejects adding a fallbackProfile to a mix profile without writing", async () => {
-    await expect(
-      patchRoute.handler({
-        body: { llm: { profiles: { blend: { fallbackProfile: "backup" } } } },
-      }),
-    ).rejects.toThrow(/Mix profile "blend" cannot also set "fallbackProfile"/);
-    expect(persistedProfile("blend").fallbackProfile).toBeUndefined();
     expect(initializeProvidersCalls).toBe(0);
   });
 });

--- a/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
@@ -51,7 +51,7 @@ mock.module("../../../persistence/embeddings/embedding-backend.js", () => ({
 }));
 
 import { getConfig, loadRawConfig } from "../../../config/loader.js";
-import { LLMConfigBase } from "../../../config/schemas/llm.js";
+import { LLMConfigBase, LLMSchema } from "../../../config/schemas/llm.js";
 import type { ConversationCreateType } from "../../../persistence/conversation-types.js";
 import {
   getDb,
@@ -836,6 +836,153 @@ describe("PUT /v1/config/llm/profiles/:name", () => {
     seedRawConfig();
   });
 
+  describe("fallbackProfile cross-profile validation", () => {
+    beforeEach(() => {
+      const llm = rawConfigFixture.llm as {
+        profiles: Record<string, Record<string, unknown>>;
+      };
+      llm.profiles.backup = {
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+      };
+      llm.profiles.chained = {
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+        fallbackProfile: "backup",
+      };
+      llm.profiles.blend = {
+        mix: [
+          { profile: "custom", weight: 1 },
+          { profile: "backup", weight: 1 },
+        ],
+      };
+      seedRawConfig();
+    });
+
+    test("persists a valid fallbackProfile pointer", async () => {
+      const result = await replaceProfileRoute.handler({
+        pathParams: { name: "custom" },
+        body: {
+          provider: "anthropic",
+          model: "claude-sonnet-4-6",
+          fallbackProfile: "backup",
+        },
+      });
+      expect(result).toEqual({ ok: true });
+      expect(persistedProfile("custom").fallbackProfile).toBe("backup");
+    });
+
+    test("rejects a dangling fallbackProfile pointer without writing", async () => {
+      await expect(
+        replaceProfileRoute.handler({
+          pathParams: { name: "custom" },
+          body: {
+            provider: "anthropic",
+            model: "claude-sonnet-4-6",
+            fallbackProfile: "ghost",
+          },
+        }),
+      ).rejects.toThrow(/fallbackProfile "ghost" which is not defined/);
+      expect(persistedProfile("custom").fallbackProfile).toBeUndefined();
+      // Guard rejects before commitConfigWrite fires any side effects.
+      expect(initializeProvidersCalls).toBe(0);
+    });
+
+    test("rejects a self-referential fallbackProfile", async () => {
+      await expect(
+        replaceProfileRoute.handler({
+          pathParams: { name: "custom" },
+          body: {
+            provider: "anthropic",
+            model: "claude-sonnet-4-6",
+            fallbackProfile: "custom",
+          },
+        }),
+      ).rejects.toThrow(/cannot declare itself as its fallbackProfile/);
+    });
+
+    test("rejects a fallbackProfile pointing at a mix profile", async () => {
+      await expect(
+        replaceProfileRoute.handler({
+          pathParams: { name: "custom" },
+          body: {
+            provider: "anthropic",
+            model: "claude-sonnet-4-6",
+            fallbackProfile: "blend",
+          },
+        }),
+      ).rejects.toThrow(/which is a mix profile/);
+    });
+
+    test("rejects a fallbackProfile whose target declares its own fallback (chain)", async () => {
+      await expect(
+        replaceProfileRoute.handler({
+          pathParams: { name: "custom" },
+          body: {
+            provider: "anthropic",
+            model: "claude-sonnet-4-6",
+            fallbackProfile: "chained",
+          },
+        }),
+      ).rejects.toThrow(/chains are not allowed/);
+    });
+
+    test("rejects adding a fallbackProfile to a profile that is itself a fallback target (chain)", async () => {
+      await expect(
+        replaceProfileRoute.handler({
+          pathParams: { name: "backup" },
+          body: {
+            provider: "anthropic",
+            model: "claude-sonnet-4-6",
+            fallbackProfile: "custom",
+          },
+        }),
+      ).rejects.toThrow(
+        /"chained" already declares profile "backup" as its fallbackProfile/,
+      );
+    });
+
+    test("rejects converting a fallback target into a mix profile", async () => {
+      await expect(
+        replaceProfileRoute.handler({
+          pathParams: { name: "backup" },
+          body: {
+            mix: [
+              { profile: "custom", weight: 1 },
+              { profile: "chained", weight: 1 },
+            ],
+          },
+        }),
+      ).rejects.toThrow(/cannot become a mix/);
+    });
+
+    test("clears the profile's own fallbackProfile when converting it to a mix", async () => {
+      // "chained" declares fallbackProfile "backup". Replacing it with a mix
+      // body is an explicit replacement, so the pointer must be dropped: a
+      // persisted entry carrying both `mix` and `fallbackProfile` would be
+      // rejected and stripped on the next full config reload.
+      const result = await replaceProfileRoute.handler({
+        pathParams: { name: "chained" },
+        body: {
+          mix: [
+            { profile: "custom", weight: 1 },
+            { profile: "backup", weight: 1 },
+          ],
+        },
+      });
+      expect(result).toEqual({ ok: true });
+      const saved = persistedProfile("chained");
+      expect(saved.mix).toEqual([
+        { profile: "custom", weight: 1 },
+        { profile: "backup", weight: 1 },
+      ]);
+      expect("fallbackProfile" in saved).toBe(false);
+      // The persisted llm subtree reloads cleanly under the full schema
+      // parse, so the loader will not strip or salvage anything.
+      expect(LLMSchema.safeParse(loadRawConfig().llm).success).toBe(true);
+    });
+  });
+
   test("owns contextWindow maxInputTokens while preserving non-UI profile leaves", async () => {
     const result = await replaceProfileRoute.handler({
       pathParams: { name: "custom" },
@@ -1239,6 +1386,96 @@ describe("PUT /v1/config/llm/profiles/:name", () => {
       expect(initializeProvidersCalls).toBe(1);
       expect(clearEmbeddingBackendCacheCalls).toBe(1);
     });
+  });
+});
+
+describe("PATCH /v1/config fallbackProfile cross-profile validation", () => {
+  const patchRoute = ROUTES.find((r) => r.operationId === "config_patch")!;
+
+  beforeEach(() => {
+    initializeProvidersCalls = 0;
+    clearEmbeddingBackendCacheCalls = 0;
+    rawConfigFixture = {
+      llm: {
+        profiles: {
+          custom: { provider: "anthropic", model: "claude-sonnet-4-6" },
+          backup: { provider: "anthropic", model: "claude-sonnet-4-6" },
+          chained: {
+            provider: "anthropic",
+            model: "claude-sonnet-4-6",
+            fallbackProfile: "backup",
+          },
+          blend: {
+            mix: [
+              { profile: "custom", weight: 1 },
+              { profile: "backup", weight: 1 },
+            ],
+          },
+        },
+      },
+    };
+    seedRawConfig();
+  });
+
+  test("persists a valid fallbackProfile through the generic patch route", async () => {
+    await patchRoute.handler({
+      body: { llm: { profiles: { custom: { fallbackProfile: "backup" } } } },
+    });
+    expect(persistedProfile("custom").fallbackProfile).toBe("backup");
+  });
+
+  test("rejects a self-referential fallbackProfile without writing", async () => {
+    await expect(
+      patchRoute.handler({
+        body: { llm: { profiles: { custom: { fallbackProfile: "custom" } } } },
+      }),
+    ).rejects.toThrow(/cannot declare itself as its fallbackProfile/);
+    expect(persistedProfile("custom").fallbackProfile).toBeUndefined();
+    // Rejection fires before commitConfigWrite runs any post-write side
+    // effects.
+    expect(initializeProvidersCalls).toBe(0);
+  });
+
+  test("rejects a dangling fallbackProfile without writing", async () => {
+    await expect(
+      patchRoute.handler({
+        body: { llm: { profiles: { custom: { fallbackProfile: "ghost" } } } },
+      }),
+    ).rejects.toThrow(/fallbackProfile "ghost" which is not defined/);
+    expect(persistedProfile("custom").fallbackProfile).toBeUndefined();
+    expect(initializeProvidersCalls).toBe(0);
+  });
+
+  test("rejects a fallbackProfile pointing at a mix profile without writing", async () => {
+    await expect(
+      patchRoute.handler({
+        body: { llm: { profiles: { custom: { fallbackProfile: "blend" } } } },
+      }),
+    ).rejects.toThrow(/which is a mix profile/);
+    expect(persistedProfile("custom").fallbackProfile).toBeUndefined();
+    expect(initializeProvidersCalls).toBe(0);
+  });
+
+  test("rejects a fallbackProfile chain without writing", async () => {
+    await expect(
+      patchRoute.handler({
+        body: {
+          llm: { profiles: { custom: { fallbackProfile: "chained" } } },
+        },
+      }),
+    ).rejects.toThrow(/chains are not allowed/);
+    expect(persistedProfile("custom").fallbackProfile).toBeUndefined();
+    expect(initializeProvidersCalls).toBe(0);
+  });
+
+  test("rejects adding a fallbackProfile to a mix profile without writing", async () => {
+    await expect(
+      patchRoute.handler({
+        body: { llm: { profiles: { blend: { fallbackProfile: "backup" } } } },
+      }),
+    ).rejects.toThrow(/Mix profile "blend" cannot also set "fallbackProfile"/);
+    expect(persistedProfile("blend").fallbackProfile).toBeUndefined();
+    expect(initializeProvidersCalls).toBe(0);
   });
 });
 

--- a/assistant/src/runtime/routes/__tests__/inference-profiles-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/inference-profiles-routes.test.ts
@@ -625,6 +625,11 @@ describe("collectProfileReferences", () => {
           source: "user",
           mix: [{ profile: "my-fast", weight: 1 }],
         },
+        "my-primary": {
+          source: "user",
+          provider: "anthropic",
+          fallbackProfile: "my-fast",
+        },
       },
     };
     expect(collectProfileReferences(llm, "my-fast").sort()).toEqual(
@@ -633,6 +638,7 @@ describe("collectProfileReferences", () => {
         "llm.advisorProfile",
         "llm.callSites.memoryExtraction",
         "llm.profiles.my-mix.mix",
+        "llm.profiles.my-primary.fallbackProfile",
       ].sort(),
     );
   });
@@ -674,6 +680,22 @@ describe("DELETE inference/profiles/:name reference guard", () => {
     await expect(
       call("inference_profiles_delete", { pathParams: { name: "my-fast" } }),
     ).rejects.toThrow(/llm\.profiles\.my-mix\.mix/);
+  });
+
+  test("rejects deletion referenced by another profile's fallbackProfile", async () => {
+    setConfig("llm", {
+      profiles: {
+        "my-fast": { source: "user", provider: "anthropic" },
+        "my-primary": {
+          source: "user",
+          provider: "anthropic",
+          fallbackProfile: "my-fast",
+        },
+      },
+    });
+    await expect(
+      call("inference_profiles_delete", { pathParams: { name: "my-fast" } }),
+    ).rejects.toThrow(/llm\.profiles\.my-primary\.fallbackProfile/);
   });
 
   test("rejects deletion referenced by a call site", async () => {

--- a/assistant/src/runtime/routes/__tests__/inference-profiles-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/inference-profiles-routes.test.ts
@@ -64,6 +64,7 @@ mock.module("../../sync/resource-sync-events.js", () => ({
 // ── Real imports (after mocks) ────────────────────────────────────────────────
 
 import { setConfig } from "../../../__tests__/helpers/set-config.js";
+import { BACKUP_PROFILE_KEYS } from "../../../config/default-profile-names.js";
 import { loadRawConfig } from "../../../config/loader.js";
 import { getDb } from "../../../persistence/db-connection.js";
 import { initializeDb } from "../../../persistence/db-init.js";
@@ -728,6 +729,20 @@ describe("DELETE inference/profiles/:name reference guard", () => {
 // ── provider-aware list/get (Finding 2) ───────────────────────────────────────
 
 describe("GET inference/profiles honors llm.defaultProvider", () => {
+  test("omits managed backup routes from the user-facing catalog", async () => {
+    setConfig("llm", { profiles: {} });
+
+    const listed = (await call("inference_profiles_list", {})) as {
+      profiles: Array<{ name: string }>;
+    };
+    const names = new Set(listed.profiles.map((profile) => profile.name));
+
+    for (const key of BACKUP_PROFILE_KEYS) {
+      expect(names.has(key)).toBe(false);
+    }
+    expect(names.has("balanced")).toBe(true);
+  });
+
   test("expands balanced through a BYOK default provider, not the vellum column", async () => {
     setConfig("llm", {
       defaultProvider: { provider: "anthropic" },

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -1408,18 +1408,14 @@ function assertRoutableIdentityEntries(
 }
 
 /**
- * Reject writes that would persist an invalid `fallbackProfile` graph.
- * `LLMSchema.superRefine` enforces the cross-profile fallback rules only on
- * a full-config parse; the write paths (PATCH deep-merge, SET, the profile
- * routes) save raw config without one, so a self-reference, dangling
- * target, mix target, or chain would reach disk and be stripped on the next
- * reload, silently disabling the configured fallback. Checked
- * unconditionally rather than scoped to pointers this write changes:
- * removing a target profile invalidates a pointer the write never touched,
- * and clearing the pointer (write `null`) through these same routes remains
- * the repair path for a hand-edited config.
+ * Reject writes that would persist unsupported `fallbackProfile` metadata.
+ * Automatic fallbacks are code-owned for managed default profiles. The write
+ * paths save raw config without a full-schema parse, so this check keeps a
+ * custom pointer from reaching disk. It runs unconditionally so an existing
+ * hand-edited pointer blocks unrelated rewrites until the user clears it with
+ * `null`.
  */
-function assertValidFallbackProfileGraph(raw: Record<string, unknown>): void {
+function assertCodeOwnedFallbackProfiles(raw: Record<string, unknown>): void {
   const llm = readPlainObject(raw.llm);
   const profiles = readPlainObject(llm?.profiles);
   // The sibling `llm.defaultProvider` decides whether the managed backups are
@@ -1445,7 +1441,7 @@ export async function commitConfigWrite(
   completeChangedCustomProfiles(preWrite, raw);
   assertInvariantProfilesPreserved(preWrite, raw);
   assertRoutableIdentityEntries(preWrite, raw);
-  assertValidFallbackProfileGraph(raw);
+  assertCodeOwnedFallbackProfiles(raw);
 
   // Suppress the file-watcher callback for the duration of the debounce
   // window. Without this, the ConfigWatcher detects the config.json write

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -157,6 +157,7 @@ type LlmContextRouteResult = Omit<LlmContextNormalizationResult, "summary"> & {
 import {
   CODE_OWNED_PROFILE_NAMES,
   getEffectiveProfilesForProvider,
+  getUserSelectableProfilesForProvider,
   INVARIANT_PROFILE_NAMES,
   MANAGED_PROFILE_NAMES,
   resolveDefaultProfileForProvider,
@@ -899,7 +900,7 @@ function overlayEffectiveProfilesForWire(config: unknown): void {
   if (!existingLlm) {
     root.llm = llm;
   }
-  llm.profiles = getEffectiveProfilesForProvider(
+  llm.profiles = getUserSelectableProfilesForProvider(
     readPlainObject(llm.profiles) as Record<string, ProfileEntry> | undefined,
     getConfig().llm.defaultProvider ?? null,
   );

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -1420,8 +1420,14 @@ function assertRoutableIdentityEntries(
  * the repair path for a hand-edited config.
  */
 function assertValidFallbackProfileGraph(raw: Record<string, unknown>): void {
-  const profiles = readPlainObject(readPlainObject(raw.llm)?.profiles);
-  const issues = collectFallbackProfileIssues(profiles ?? undefined);
+  const llm = readPlainObject(raw.llm);
+  const profiles = readPlainObject(llm?.profiles);
+  // The sibling `llm.defaultProvider` decides whether the managed backups are
+  // valid fallback targets: they resolve on the managed column alone.
+  const issues = collectFallbackProfileIssues(
+    profiles ?? undefined,
+    llm?.defaultProvider,
+  );
   if (issues.length > 0) {
     throw new BadRequestError(issues.map((issue) => issue.message).join(" "));
   }
@@ -1743,6 +1749,18 @@ async function handleReplaceInferenceProfile({
   const isManaged =
     MANAGED_PROFILE_NAMES.has(name) &&
     (existingProfile == null || existingProfile.source === "managed");
+  if (CODE_OWNED_PROFILE_NAMES.has(name)) {
+    // A code-owned profile resolves from the catalog whatever the workspace
+    // holds, so even a status re-enable would persist a stub that never
+    // governs anything. Reject the write rather than accept a silent no-op.
+    // Checked ahead of the availability gate below so the code-owned backups,
+    // which are always available yet are not `DEFAULT_PROFILE_KEYS` members,
+    // report why the write is refused rather than claiming they do not exist.
+    throw new BadRequestError(
+      `Profile "${name}" is code-owned and cannot be edited. ` +
+        `Duplicate it to a custom profile to customize.`,
+    );
+  }
   // A flag-gated managed name (`os-beta`) with no materialized entry cannot
   // be patched: it only resolves while the flag reconcile has created its
   // stub, so writing status here would persist an entry that fights the
@@ -1755,15 +1773,6 @@ async function handleReplaceInferenceProfile({
   ) {
     throw new BadRequestError(
       `Profile "${name}" is not currently available and cannot be edited.`,
-    );
-  }
-  if (CODE_OWNED_PROFILE_NAMES.has(name)) {
-    // A code-owned profile resolves from the catalog whatever the workspace
-    // holds, so even a status re-enable would persist a stub that never
-    // governs anything. Reject the write rather than accept a silent no-op.
-    throw new BadRequestError(
-      `Profile "${name}" is code-owned and cannot be edited. ` +
-        `Duplicate it to a custom profile to customize.`,
     );
   }
   if (isManaged) {

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -48,6 +48,7 @@ import {
 import { AssistantConfigSchema } from "../../config/schema.js";
 import { getSchemaAtPath } from "../../config/schema-utils.js";
 import {
+  collectFallbackProfileIssues,
   DefaultProviderSchema,
   LLMConfigBase,
   LLMConfigFragment,
@@ -240,6 +241,13 @@ function replaceInferenceProfileConfig(
   const nextProfile: Record<string, unknown> = { ...existingProfile };
   for (const key of INFERENCE_PROFILE_UI_KEYS) {
     delete nextProfile[key];
+  }
+  // Converting a profile to a mix is an explicit replacement: a mix carries
+  // no model route of its own to fall back from, so an existing
+  // `fallbackProfile` pointer is dropped rather than preserved alongside
+  // `mix` (a combination `LLMSchema` rejects on the next full reload).
+  if (fragment.mix != null) {
+    delete nextProfile.fallbackProfile;
   }
   const fragmentTopLevel = { ...fragment };
   delete fragmentTopLevel.contextWindow;
@@ -1399,6 +1407,26 @@ function assertRoutableIdentityEntries(
   }
 }
 
+/**
+ * Reject writes that would persist an invalid `fallbackProfile` graph.
+ * `LLMSchema.superRefine` enforces the cross-profile fallback rules only on
+ * a full-config parse; the write paths (PATCH deep-merge, SET, the profile
+ * routes) save raw config without one, so a self-reference, dangling
+ * target, mix target, or chain would reach disk and be stripped on the next
+ * reload, silently disabling the configured fallback. Checked
+ * unconditionally rather than scoped to pointers this write changes:
+ * removing a target profile invalidates a pointer the write never touched,
+ * and clearing the pointer (write `null`) through these same routes remains
+ * the repair path for a hand-edited config.
+ */
+function assertValidFallbackProfileGraph(raw: Record<string, unknown>): void {
+  const profiles = readPlainObject(readPlainObject(raw.llm)?.profiles);
+  const issues = collectFallbackProfileIssues(profiles ?? undefined);
+  if (issues.length > 0) {
+    throw new BadRequestError(issues.map((issue) => issue.message).join(" "));
+  }
+}
+
 export async function commitConfigWrite(
   raw: Record<string, unknown>,
   opLabel: string,
@@ -1411,6 +1439,7 @@ export async function commitConfigWrite(
   completeChangedCustomProfiles(preWrite, raw);
   assertInvariantProfilesPreserved(preWrite, raw);
   assertRoutableIdentityEntries(preWrite, raw);
+  assertValidFallbackProfileGraph(raw);
 
   // Suppress the file-watcher callback for the duration of the debounce
   // window. Without this, the ConfigWatcher detects the config.json write
@@ -1808,6 +1837,59 @@ async function handleReplaceInferenceProfile({
         );
       }
     });
+    // A fallback target must stay a standard profile: converting one to a
+    // mix would leave another profile's fallbackProfile pointing at a mix,
+    // which `LLMSchema.superRefine` rejects on the next full reparse.
+    for (const [otherName, other] of Object.entries(existingProfiles)) {
+      if (otherName !== name && other?.fallbackProfile === name) {
+        throw new BadRequestError(
+          `Profile "${otherName}" declares profile "${name}" as its fallbackProfile; a fallback must be a standard profile, so "${name}" cannot become a mix.`,
+        );
+      }
+    }
+  }
+
+  // `fallbackProfile` references another profile by name. As with `mix`, the
+  // cross-profile integrity rules `LLMSchema.superRefine` enforces on
+  // full-config load (target exists, no self-reference, target is not a mix,
+  // single hop) must be checked here against the live profile set; otherwise
+  // a dangling or chained pointer would persist and break the next full
+  // config reparse.
+  if (parsed.data.fallbackProfile != null) {
+    const fallback = parsed.data.fallbackProfile;
+    if (fallback === name) {
+      throw new BadRequestError(
+        `Profile "${name}" cannot declare itself as its fallbackProfile.`,
+      );
+    }
+    const { llm: parsedLlm } = getConfig();
+    const existingProfiles = getEffectiveProfilesForProvider(
+      parsedLlm.profiles,
+      parsedLlm.defaultProvider ?? null,
+    );
+    const target = existingProfiles[fallback];
+    if (target == null) {
+      throw new BadRequestError(
+        `Profile "${name}" declares fallbackProfile "${fallback}" which is not defined.`,
+      );
+    }
+    if (target.mix != null) {
+      throw new BadRequestError(
+        `Profile "${name}" declares fallbackProfile "${fallback}" which is a mix profile; a fallback must be a standard profile.`,
+      );
+    }
+    if (target.fallbackProfile != null) {
+      throw new BadRequestError(
+        `Profile "${name}" declares fallbackProfile "${fallback}" which sets its own fallbackProfile; fallback is a single hop, chains are not allowed.`,
+      );
+    }
+    for (const [otherName, other] of Object.entries(existingProfiles)) {
+      if (otherName !== name && other?.fallbackProfile === name) {
+        throw new BadRequestError(
+          `Profile "${otherName}" already declares profile "${name}" as its fallbackProfile; fallback is a single hop, chains are not allowed.`,
+        );
+      }
+    }
   }
 
   // When the UI sends provider but no provider_connection, derive the connection

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -39,7 +39,7 @@ import {
   supportsHostProxy,
 } from "../../channels/types.js";
 import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
-import { getEffectiveProfilesForProvider } from "../../config/default-profile-catalog.js";
+import { getUserSelectableProfilesForProvider } from "../../config/default-profile-catalog.js";
 import { isHttpAuthDisabled } from "../../config/env.js";
 import { getConfig } from "../../config/loader.js";
 import {
@@ -1559,7 +1559,7 @@ export async function handleSendMessage(
   }
   if (requestedInferenceProfile !== undefined) {
     const { llm } = getConfig();
-    const profiles = getEffectiveProfilesForProvider(
+    const profiles = getUserSelectableProfilesForProvider(
       llm.profiles,
       llm.defaultProvider ?? null,
     );

--- a/assistant/src/runtime/routes/inference-profile-session-handler.ts
+++ b/assistant/src/runtime/routes/inference-profile-session-handler.ts
@@ -14,7 +14,7 @@
 
 import { randomUUID } from "node:crypto";
 
-import { getEffectiveProfilesForProvider } from "../../config/default-profile-catalog.js";
+import { getUserSelectableProfilesForProvider } from "../../config/default-profile-catalog.js";
 import { loadConfig } from "../../config/loader.js";
 import { findConversation } from "../../daemon/conversation-registry.js";
 import {
@@ -153,7 +153,7 @@ export async function setInferenceProfileSession({
 
   // --- Validate profile ---
   const { llm } = loadConfig();
-  const profiles = getEffectiveProfilesForProvider(
+  const profiles = getUserSelectableProfilesForProvider(
     llm?.profiles,
     llm?.defaultProvider ?? null,
   );

--- a/assistant/src/runtime/routes/inference-profiles-routes.ts
+++ b/assistant/src/runtime/routes/inference-profiles-routes.ts
@@ -338,8 +338,9 @@ function fragmentFromBody(
 
 /**
  * Enumerate every live reference to profile `name` in the raw `llm` config
- * block: `activeProfile`, `advisorProfile`, each `callSites.<id>.profile`, and
- * every mix arm (`profiles.<mix>.mix[].profile`). Deleting a profile while any
+ * block: `activeProfile`, `advisorProfile`, each `callSites.<id>.profile`,
+ * every mix arm (`profiles.<mix>.mix[].profile`), and every fallback pointer
+ * (`profiles.<p>.fallbackProfile`). Deleting a profile while any
  * of these point at it would leave a dangling reference that `LLMSchema`'s
  * superRefine rejects on the next load — silently resetting the user's chat
  * model or call-site pins. The delete handler rejects instead.
@@ -369,12 +370,16 @@ export function collectProfileReferences(
   const profiles = asPlainObject(llm.profiles);
   if (profiles) {
     for (const [profileName, profileEntry] of Object.entries(profiles)) {
-      const mix = asPlainObject(profileEntry)?.mix;
+      const entry = asPlainObject(profileEntry);
+      const mix = entry?.mix;
       if (
         Array.isArray(mix) &&
         mix.some((arm) => asPlainObject(arm)?.profile === name)
       ) {
         refs.push(`llm.profiles.${profileName}.mix`);
+      }
+      if (entry?.fallbackProfile === name) {
+        refs.push(`llm.profiles.${profileName}.fallbackProfile`);
       }
     }
   }
@@ -903,7 +908,7 @@ export const ROUTES: RouteDefinition[] = [
       "404": { description: "Profile not found" },
       "409": {
         description:
-          "Profile is still referenced by activeProfile, advisorProfile, a call site, a default-tier override, or a mix arm",
+          "Profile is still referenced by activeProfile, advisorProfile, a call site, a default-tier override, a mix arm, or another profile's fallbackProfile",
       },
     },
     handler: handleDeleteProfile,

--- a/assistant/src/runtime/routes/inference-profiles-routes.ts
+++ b/assistant/src/runtime/routes/inference-profiles-routes.ts
@@ -20,7 +20,7 @@ import { z } from "zod";
 
 import { validateInferenceProfileConfig } from "../../api/constants/profile-config-validation.js";
 import {
-  getEffectiveProfilesForProvider,
+  getUserSelectableProfilesForProvider,
   MANAGED_PROFILE_NAMES,
   resolveDefaultProfileForProvider,
 } from "../../config/default-profile-catalog.js";
@@ -432,7 +432,7 @@ function assertSaneMaxTokens(
 
 async function handleListProfiles() {
   const config = getConfigReadOnly();
-  const effective = getEffectiveProfilesForProvider(
+  const effective = getUserSelectableProfilesForProvider(
     config.llm.profiles,
     config.llm.defaultProvider ?? null,
   );
@@ -767,7 +767,7 @@ async function handleSetActiveProfile({ body = {} }: RouteHandlerArgs) {
   // is rejected here instead of silently stripped on the next config load —
   // which would reset the user's chat-model selection.
   const config = getConfigReadOnly();
-  const effective = getEffectiveProfilesForProvider(
+  const effective = getUserSelectableProfilesForProvider(
     config.llm.profiles,
     config.llm.defaultProvider ?? null,
   );

--- a/assistant/src/runtime/routes/inference-send-routes.ts
+++ b/assistant/src/runtime/routes/inference-send-routes.ts
@@ -7,7 +7,7 @@
 
 import { z } from "zod";
 
-import { getEffectiveProfilesForProvider } from "../../config/default-profile-catalog.js";
+import { getUserSelectableProfilesForProvider } from "../../config/default-profile-catalog.js";
 import type { ResolutionFallbackReason } from "../../config/llm-resolver.js";
 import { selectWinningProfile } from "../../config/llm-resolver.js";
 import { getConfigReadOnly } from "../../config/loader.js";
@@ -42,7 +42,7 @@ async function handleInferenceSend({ body = {} }: RouteHandlerArgs) {
   // Validate --profile against the configured profile catalog.
   if (profile !== undefined) {
     const { llm } = getConfigReadOnly();
-    const profiles = getEffectiveProfilesForProvider(
+    const profiles = getUserSelectableProfilesForProvider(
       llm?.profiles,
       llm?.defaultProvider ?? null,
     );

--- a/assistant/src/runtime/routes/llm-call-sites-routes.ts
+++ b/assistant/src/runtime/routes/llm-call-sites-routes.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 import { CALL_SITE_DEFAULTS } from "../../config/call-site-defaults.js";
-import { getEffectiveProfilesForProvider } from "../../config/default-profile-catalog.js";
+import { getUserSelectableProfilesForProvider } from "../../config/default-profile-catalog.js";
 import { resolveDefaultProfileKey } from "../../config/llm-resolver.js";
 import { loadConfig } from "../../config/loader.js";
 import {
@@ -66,7 +66,7 @@ export type LlmProfilesListResult = z.infer<
 
 async function handleListProfiles(): Promise<LlmProfilesListResult> {
   const { llm } = loadConfig();
-  const profiles = getEffectiveProfilesForProvider(
+  const profiles = getUserSelectableProfilesForProvider(
     llm?.profiles,
     llm?.defaultProvider ?? null,
   );

--- a/assistant/src/tools/workflows/manage-workflows.ts
+++ b/assistant/src/tools/workflows/manage-workflows.ts
@@ -15,7 +15,7 @@
 
 import { z } from "zod";
 
-import { getEffectiveProfilesForProvider } from "../../config/default-profile-catalog.js";
+import { getUserSelectableProfilesForProvider } from "../../config/default-profile-catalog.js";
 import { loadConfig } from "../../config/loader.js";
 import { callerOwnsWorkflowRun } from "../../workflows/capabilities.js";
 import type { WorkflowRun } from "../../workflows/journal-store.js";
@@ -192,7 +192,7 @@ export async function executeManageWorkflows(
       // workspace-wide active profile. Read-only — leaves use this to pick a
       // valid `profile` for `run_workflow` (an unknown profile throws).
       const { llm } = loadConfig();
-      const profiles = getEffectiveProfilesForProvider(
+      const profiles = getUserSelectableProfilesForProvider(
         llm?.profiles,
         llm?.defaultProvider ?? null,
       );

--- a/assistant/src/tools/workflows/run-workflow.test.ts
+++ b/assistant/src/tools/workflows/run-workflow.test.ts
@@ -338,17 +338,13 @@ describe("manage_workflows", () => {
     );
     expect(res.isError).toBe(false);
     const parsed = JSON.parse(res.content);
-    // The effective view always includes the code-catalog defaults,
-    // managed backup profiles included.
+    // The user-selectable view includes the code-catalog defaults and omits
+    // managed backup routes.
     expect(parsed.profiles).toEqual([
       "balanced",
-      "balanced-backup",
       "cost-optimized",
-      "cost-optimized-backup",
       "latency-optimized",
-      "latency-optimized-backup",
       "quality-optimized",
-      "quality-optimized-backup",
     ]);
     expect(parsed.activeProfile).toBe("balanced");
   });

--- a/assistant/src/tools/workflows/run-workflow.test.ts
+++ b/assistant/src/tools/workflows/run-workflow.test.ts
@@ -338,12 +338,17 @@ describe("manage_workflows", () => {
     );
     expect(res.isError).toBe(false);
     const parsed = JSON.parse(res.content);
-    // The effective view always includes the code-catalog defaults.
+    // The effective view always includes the code-catalog defaults,
+    // managed backup profiles included.
     expect(parsed.profiles).toEqual([
       "balanced",
+      "balanced-backup",
       "cost-optimized",
+      "cost-optimized-backup",
       "latency-optimized",
+      "latency-optimized-backup",
       "quality-optimized",
+      "quality-optimized-backup",
     ]);
     expect(parsed.activeProfile).toBe("balanced");
   });

--- a/assistant/src/workspace/migrations/147-rename-colliding-backup-profile-names.ts
+++ b/assistant/src/workspace/migrations/147-rename-colliding-backup-profile-names.ts
@@ -1,0 +1,360 @@
+/**
+ * Workspace migration `147-rename-colliding-backup-profile-names`.
+ *
+ * The four managed backup profile keys (`balanced-backup`,
+ * `quality-optimized-backup`, `cost-optimized-backup`,
+ * `latency-optimized-backup`) became reserved code-owned names. From that
+ * release on, a name in the code-owned set resolves to the code body no
+ * matter what `llm.profiles` holds, so a user-created profile that happens
+ * to carry one of those names is silently replaced in the effective catalog:
+ * the user's own model, provider, and tuning stop being what their
+ * `activeProfile`, call-site pin, mix arm, or `fallbackProfile` reference
+ * routes through.
+ *
+ * This migration runs before the reservation can take effect (workspace
+ * migrations run ahead of the first config load and the profile seeder) and
+ * gives any such profile a fresh key, rewriting every reference to it so the
+ * user keeps both the profile and its wiring:
+ *
+ *   - `llm.profiles` key (insertion order preserved)
+ *   - `llm.activeProfile`, `llm.advisorProfile`
+ *   - `llm.profileOrder` entries
+ *   - `llm.callSites.<site>.profile` pins
+ *   - `llm.profiles.<key>.mix[].profile` arms
+ *   - `llm.profiles.<key>.fallbackProfile` targets
+ *   - `conversations.inference_profile` and `cron_jobs.inference_profile`
+ *     rows (see below)
+ *
+ * The new key is `<name>-custom`, suffixed `-custom-2`, `-custom-3`, ... when
+ * that is taken. Candidates are checked against every existing profile key
+ * AND every reserved code-defined name, so a rename never lands on another
+ * name the catalog owns.
+ *
+ * Only workspace-owned profiles are renamed. An entry whose `source` is
+ * `managed` is a thin stub for a code-owned profile, not a user profile, and
+ * a non-object value under one of these keys is not a profile at all (the
+ * loader strips it); both are left alone.
+ *
+ * The DB rewrite is NOT best effort. A pin the rewrite abandons does not
+ * degrade to the default selection: its old name is now a reserved code-owned
+ * key, so the conversation or schedule silently starts routing through the
+ * managed backup instead of the user's profile. So a database that exists but
+ * cannot be opened or written is retried a bounded number of times with a
+ * short backoff, and a failure that outlives the retries throws. The runner
+ * then records a `failed` checkpoint, and `retryFailedCheckpoint` makes the
+ * next boot re-run the whole migration. An absent database file is a real
+ * state (no pins to strand) and a table the schema does not carry yet is
+ * nothing to rewrite; both are skipped without failing.
+ *
+ * The DB rewrite deliberately runs BEFORE the config write, so a throw leaves
+ * config.json holding the old keys and the next run rebuilds the same
+ * mapping from it.
+ *
+ * Idempotent: after a successful run no workspace-owned profile carries a
+ * reserved backup name, so a re-run finds nothing to rename and writes
+ * nothing. The pin rewrite matches on the old name, so re-running it after a
+ * partial pass is a no-op on the rows already repointed.
+ */
+
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { Database } from "bun:sqlite";
+
+import { getLogger } from "../../util/logger.js";
+import type { WorkspaceMigration } from "./types.js";
+
+const log = getLogger(
+  "workspace-migration-147-rename-colliding-backup-profile-names",
+);
+
+/**
+ * The newly reserved keys this migration clears. Frozen snapshot of
+ * `BACKUP_PROFILE_KEYS` as of 2026-08-21 (migrations are self-contained).
+ */
+const BACKUP_PROFILE_KEYS = [
+  "balanced-backup",
+  "quality-optimized-backup",
+  "cost-optimized-backup",
+  "latency-optimized-backup",
+];
+
+/**
+ * Every code-defined profile name as of 2026-08-21: the default keys, the
+ * backups, and the flag-gated `os-beta`. A renamed profile must not land on
+ * any of them, or the rename would just move the collision.
+ */
+const RESERVED_PROFILE_NAMES = new Set<string>([
+  "balanced",
+  "quality-optimized",
+  "cost-optimized",
+  "latency-optimized",
+  ...BACKUP_PROFILE_KEYS,
+  "os-beta",
+]);
+
+const RENAME_SUFFIX = "-custom";
+
+/** Total attempts at the pin rewrite, the first one included. */
+const DB_ATTEMPTS = 4;
+
+/** First backoff step; each further wait doubles it (50, 100, 200 ms). */
+const DB_RETRY_BASE_DELAY_MS = 50;
+
+export const renameCollidingBackupProfileNamesMigration: WorkspaceMigration = {
+  id: "147-rename-colliding-backup-profile-names",
+  description:
+    "Rename user profiles colliding with the reserved managed backup keys and rewrite their references",
+  // The failure this migration can hit is a database it cannot write, and
+  // both halves of the run are idempotent, so a failed checkpoint is worth
+  // re-running: the config still holds the old keys, the mapping rebuilds
+  // from them, and the pin rewrite matches on the old name.
+  retryFailedCheckpoint: true,
+
+  async run(workspaceDir: string): Promise<void> {
+    const configPath = join(workspaceDir, "config.json");
+    if (!existsSync(configPath)) {
+      return;
+    }
+
+    let config: Record<string, unknown>;
+    try {
+      const parsed = JSON.parse(readFileSync(configPath, "utf-8"));
+      if (!isPlainObject(parsed)) {
+        return;
+      }
+      config = parsed;
+    } catch {
+      return;
+    }
+
+    const llm = asObject(config.llm);
+    const profiles = llm === null ? null : asObject(llm.profiles);
+    if (llm === null || profiles === null) {
+      return;
+    }
+
+    const renames = planRenames(profiles);
+    if (renames.size === 0) {
+      return;
+    }
+
+    // The DB rewrite runs first so an interrupted or failed migration re-runs
+    // with the config still holding the old keys, i.e. with the mapping
+    // intact. A rewrite that cannot be completed throws out of here, which
+    // stops the config rename below rather than stranding the pins.
+    await rewriteDbReferences(workspaceDir, renames);
+
+    llm.profiles = renameProfileKeys(profiles, renames);
+    rewriteConfigReferences(llm, renames);
+
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+    log.info(
+      { renames: Object.fromEntries(renames) },
+      "Renamed user profiles colliding with reserved managed backup keys",
+    );
+  },
+
+  down(_workspaceDir: string): void {
+    // Forward-only: the reserved names cannot be handed back.
+  },
+};
+
+/**
+ * Old key -> new key for every workspace-owned profile sitting on a reserved
+ * backup name. Deterministic: keys are considered in `BACKUP_PROFILE_KEYS`
+ * order and each assigned name is reserved against later candidates, so the
+ * same config always produces the same mapping.
+ */
+function planRenames(profiles: Record<string, unknown>): Map<string, string> {
+  const renames = new Map<string, string>();
+  const taken = new Set<string>([
+    ...Object.keys(profiles),
+    ...RESERVED_PROFILE_NAMES,
+  ]);
+
+  for (const key of BACKUP_PROFILE_KEYS) {
+    if (!(key in profiles)) {
+      continue;
+    }
+    const entry = asObject(profiles[key]);
+    if (entry === null) {
+      log.warn(
+        { profile: key },
+        "Left a non-object value under a reserved backup key; it is not a profile to preserve",
+      );
+      continue;
+    }
+    if (entry.source === "managed") {
+      // A managed stub is the workspace's overlay slot for a code-owned
+      // profile, not a user profile. Backups take no overlay, so the stub is
+      // inert; renaming it would manufacture a phantom user profile.
+      continue;
+    }
+    let candidate = `${key}${RENAME_SUFFIX}`;
+    let counter = 2;
+    while (taken.has(candidate)) {
+      candidate = `${key}${RENAME_SUFFIX}-${counter}`;
+      counter += 1;
+    }
+    taken.add(candidate);
+    renames.set(key, candidate);
+  }
+
+  return renames;
+}
+
+/** Rebuild the profiles record with the renamed keys, preserving order. */
+function renameProfileKeys(
+  profiles: Record<string, unknown>,
+  renames: Map<string, string>,
+): Record<string, unknown> {
+  const renamed: Record<string, unknown> = {};
+  for (const [name, value] of Object.entries(profiles)) {
+    renamed[renames.get(name) ?? name] = value;
+  }
+  return renamed;
+}
+
+/** Point every config reference at the renamed key. */
+function rewriteConfigReferences(
+  llm: Record<string, unknown>,
+  renames: Map<string, string>,
+): void {
+  for (const field of ["activeProfile", "advisorProfile"]) {
+    const current = llm[field];
+    if (typeof current === "string" && renames.has(current)) {
+      llm[field] = renames.get(current);
+    }
+  }
+
+  if (Array.isArray(llm.profileOrder)) {
+    llm.profileOrder = (llm.profileOrder as unknown[]).map((name) =>
+      typeof name === "string" ? (renames.get(name) ?? name) : name,
+    );
+  }
+
+  const callSites = asObject(llm.callSites);
+  if (callSites !== null) {
+    for (const value of Object.values(callSites)) {
+      const site = asObject(value);
+      if (
+        site !== null &&
+        typeof site.profile === "string" &&
+        renames.has(site.profile)
+      ) {
+        site.profile = renames.get(site.profile);
+      }
+    }
+  }
+
+  const profiles = asObject(llm.profiles);
+  if (profiles === null) {
+    return;
+  }
+  for (const value of Object.values(profiles)) {
+    const entry = asObject(value);
+    if (entry === null) {
+      continue;
+    }
+    if (
+      typeof entry.fallbackProfile === "string" &&
+      renames.has(entry.fallbackProfile)
+    ) {
+      entry.fallbackProfile = renames.get(entry.fallbackProfile);
+    }
+    if (!Array.isArray(entry.mix)) {
+      continue;
+    }
+    for (const armValue of entry.mix as unknown[]) {
+      const arm = asObject(armValue);
+      if (
+        arm !== null &&
+        typeof arm.profile === "string" &&
+        renames.has(arm.profile)
+      ) {
+        arm.profile = renames.get(arm.profile);
+      }
+    }
+  }
+}
+
+/**
+ * Repoint the profile pins stored outside config.json: the sticky
+ * per-conversation profile and the per-schedule profile.
+ *
+ * Retried as a whole rather than per statement: opening the database, reading
+ * `sqlite_master` and running the updates all fail the same way under write
+ * contention (`SQLITE_BUSY` from a second connection), and every step is
+ * idempotent, so re-running the block is the simplest recovery that cannot
+ * double-apply. A failure that outlives the attempts throws, which fails the
+ * migration for `retryFailedCheckpoint` to pick up on the next boot.
+ */
+async function rewriteDbReferences(
+  workspaceDir: string,
+  renames: Map<string, string>,
+): Promise<void> {
+  const dbPath = join(workspaceDir, "data", "db", "assistant.db");
+  if (!existsSync(dbPath)) {
+    // No database yet, so there are no pins that could be stranded.
+    return;
+  }
+  await withDbRetry(() => {
+    const db = new Database(dbPath);
+    try {
+      for (const table of ["conversations", "cron_jobs"]) {
+        const present = db
+          .query(
+            `SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?`,
+          )
+          .get(table);
+        if (!present) {
+          // A workspace whose schema does not carry this table holds no pins
+          // in it. Nothing to rewrite, and nothing to fail over.
+          log.info({ table }, "No profile pin table to repoint");
+          continue;
+        }
+        for (const [from, to] of renames) {
+          db.query(
+            `UPDATE ${table} SET inference_profile = ? WHERE inference_profile = ?`,
+          ).run(to, from);
+        }
+      }
+    } finally {
+      db.close();
+    }
+  });
+}
+
+/**
+ * Run the pin rewrite, retrying a transient database failure with a short
+ * doubling backoff. Rethrows once the attempts are spent so the caller stops
+ * before the config rename.
+ */
+async function withDbRetry(attempt: () => void): Promise<void> {
+  for (let index = 0; ; index += 1) {
+    try {
+      attempt();
+      return;
+    } catch (err) {
+      if (index >= DB_ATTEMPTS - 1) {
+        throw new Error(
+          `Could not repoint conversation and schedule profile pins after ${DB_ATTEMPTS} attempts; leaving the config unrenamed so the next boot retries`,
+          { cause: err },
+        );
+      }
+      log.warn(
+        { err, attempt: index },
+        "Could not repoint profile pins; retrying",
+      );
+      await Bun.sleep(DB_RETRY_BASE_DELAY_MS * 2 ** index);
+    }
+  }
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function asObject(value: unknown): Record<string, unknown> | null {
+  return isPlainObject(value) ? value : null;
+}

--- a/assistant/src/workspace/migrations/148-strip-unsupported-fallback-profiles.ts
+++ b/assistant/src/workspace/migrations/148-strip-unsupported-fallback-profiles.ts
@@ -1,0 +1,117 @@
+/**
+ * Workspace migration `148-strip-unsupported-fallback-profiles`.
+ *
+ * Automatic model fallbacks are code-owned metadata on the four managed
+ * default profiles. Earlier builds accepted custom `fallbackProfile` values
+ * in raw workspace config, including pointers rewritten by migration 147.
+ * Those values cannot be executed under the managed-only fallback contract
+ * and would make later config writes fail validation.
+ *
+ * This migration removes every persisted pointer except the exact managed
+ * default mapping while managed backups resolve under the selected provider.
+ * It runs before config parsing, so legacy values are cleaned up without
+ * depending on schema salvage. The operation is idempotent: a second run
+ * finds no unsupported fields and writes nothing.
+ */
+
+import { readFileSync, renameSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { getLogger } from "../../util/logger.js";
+import type { WorkspaceMigration } from "./types.js";
+
+const log = getLogger(
+  "workspace-migration-148-strip-unsupported-fallback-profiles",
+);
+
+/** Frozen snapshot of the code-owned fallback mapping as of 2026-08-24. */
+const CODE_OWNED_FALLBACKS: Record<string, string> = {
+  balanced: "balanced-backup",
+  "quality-optimized": "quality-optimized-backup",
+  "cost-optimized": "cost-optimized-backup",
+  "latency-optimized": "latency-optimized-backup",
+};
+
+export const stripUnsupportedFallbackProfilesMigration: WorkspaceMigration = {
+  id: "148-strip-unsupported-fallback-profiles",
+  description:
+    "Remove custom fallback profile pointers outside the managed default contract",
+  // A transient config write failure must not leave an unsupported pointer
+  // behind permanently; the next boot can safely repeat this idempotent pass.
+  retryFailedCheckpoint: true,
+
+  run(workspaceDir: string): void {
+    const configPath = join(workspaceDir, "config.json");
+    let config: Record<string, unknown>;
+    try {
+      const parsed = JSON.parse(readFileSync(configPath, "utf-8"));
+      if (!isPlainObject(parsed)) {
+        return;
+      }
+      config = parsed;
+    } catch {
+      return;
+    }
+
+    const llm = asObject(config.llm);
+    const profiles = llm === null ? null : asObject(llm.profiles);
+    if (llm === null || profiles === null) {
+      return;
+    }
+    const backupsResolve = backupProfilesResolveUnderDefaultProvider(
+      llm.defaultProvider,
+    );
+
+    const strippedProfiles: string[] = [];
+    for (const [name, value] of Object.entries(profiles)) {
+      const entry = asObject(value);
+      if (
+        entry === null ||
+        !Object.prototype.hasOwnProperty.call(entry, "fallbackProfile")
+      ) {
+        continue;
+      }
+      const isCodeOwnedMapping =
+        backupsResolve &&
+        entry.source === "managed" &&
+        entry.fallbackProfile === CODE_OWNED_FALLBACKS[name];
+      if (isCodeOwnedMapping) {
+        continue;
+      }
+      delete entry.fallbackProfile;
+      strippedProfiles.push(name);
+    }
+
+    if (strippedProfiles.length === 0) {
+      return;
+    }
+    const tempPath = `${configPath}.tmp`;
+    writeFileSync(tempPath, JSON.stringify(config, null, 2) + "\n", "utf-8");
+    renameSync(tempPath, configPath);
+    log.info(
+      { profiles: strippedProfiles },
+      "Removed unsupported custom fallback profile pointers",
+    );
+  },
+
+  down(_workspaceDir: string): void {
+    // Forward-only: unsupported fallback pointers cannot be restored safely.
+  },
+};
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function asObject(value: unknown): Record<string, unknown> | null {
+  return isPlainObject(value) ? value : null;
+}
+
+function backupProfilesResolveUnderDefaultProvider(
+  defaultProvider: unknown,
+): boolean {
+  const provider = isPlainObject(defaultProvider)
+    ? defaultProvider.provider
+    : undefined;
+  return typeof provider !== "string" || provider === "vellum";
+}

--- a/assistant/src/workspace/migrations/149-repoint-backup-profile-selections.ts
+++ b/assistant/src/workspace/migrations/149-repoint-backup-profile-selections.ts
@@ -1,0 +1,204 @@
+/**
+ * Workspace migration `149-repoint-backup-profile-selections`.
+ *
+ * Managed backup profiles are internal failover routes. Earlier builds let
+ * users select those names directly, so existing workspaces can retain them
+ * in active, advisor, call-site, mix, conversation, or schedule references.
+ * Repoint those direct selections to their corresponding primary profile
+ * before the user-facing catalog hides the backups. Automatic fallback
+ * metadata is preserved: a primary's `fallbackProfile` still names its
+ * internal backup route.
+ */
+
+import { existsSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { Database } from "bun:sqlite";
+
+import { FALLBACK_PROFILE_BY_KEY } from "../../config/default-profile-names.js";
+import { getLogger } from "../../util/logger.js";
+import type { WorkspaceMigration } from "./types.js";
+
+const log = getLogger(
+  "workspace-migration-149-repoint-backup-profile-selections",
+);
+
+/** Mapping of every managed backup to its direct-selectable primary. */
+const BACKUP_TO_PRIMARY: Record<string, string> = Object.fromEntries(
+  Object.entries(FALLBACK_PROFILE_BY_KEY).map(([primary, backup]) => [
+    backup,
+    primary,
+  ]),
+);
+
+const PROFILE_PIN_TABLES = ["conversations", "cron_jobs"] as const;
+const DB_ATTEMPTS = 4;
+const DB_RETRY_BASE_DELAY_MS = 50;
+
+export const repointBackupProfileSelectionsMigration: WorkspaceMigration = {
+  id: "149-repoint-backup-profile-selections",
+  description:
+    "Repoint direct selections of managed backup profiles to their primaries",
+  retryFailedCheckpoint: true,
+
+  async run(workspaceDir: string): Promise<void> {
+    const configPath = join(workspaceDir, "config.json");
+    const config = readConfig(configPath);
+    const llm = config === null ? null : asObject(config.llm);
+    const configChanged = llm !== null && rewriteConfigReferences(llm);
+
+    // Rewrite database pins before config.json. If the database cannot be
+    // updated, leaving config untouched lets the next boot retry the same
+    // migration without stranding a direct selection.
+    await rewriteDbReferences(workspaceDir);
+
+    if (config !== null && configChanged) {
+      const tempPath = `${configPath}.tmp`;
+      writeFileSync(tempPath, JSON.stringify(config, null, 2) + "\n", "utf-8");
+      renameSync(tempPath, configPath);
+      log.info("Repointed direct backup-profile selections to primaries");
+    }
+  },
+
+  down(_workspaceDir: string): void {
+    // Forward-only: restoring a backup selection would make it unreachable
+    // from the user-facing profile catalog.
+  },
+};
+
+function readConfig(path: string): Record<string, unknown> | null {
+  if (!existsSync(path)) {
+    return null;
+  }
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(path, "utf-8"));
+    return isPlainObject(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Rewrite config references that represent direct user profile choices. */
+function rewriteConfigReferences(llm: Record<string, unknown>): boolean {
+  let changed = false;
+
+  for (const field of ["activeProfile", "advisorProfile"] as const) {
+    const current = llm[field];
+    const replacement = remapProfileName(current);
+    if (replacement !== current) {
+      llm[field] = replacement;
+      changed = true;
+    }
+  }
+
+  const callSites = asObject(llm.callSites);
+  if (callSites !== null) {
+    for (const value of Object.values(callSites)) {
+      const site = asObject(value);
+      if (site === null) {
+        continue;
+      }
+      const replacement = remapProfileName(site.profile);
+      if (replacement !== site.profile) {
+        site.profile = replacement;
+        changed = true;
+      }
+    }
+  }
+
+  const profiles = asObject(llm.profiles);
+  if (profiles === null) {
+    return changed;
+  }
+  for (const value of Object.values(profiles)) {
+    const entry = asObject(value);
+    if (entry === null || !Array.isArray(entry.mix)) {
+      continue;
+    }
+    for (const armValue of entry.mix as unknown[]) {
+      const arm = asObject(armValue);
+      if (arm === null) {
+        continue;
+      }
+      const replacement = remapProfileName(arm.profile);
+      if (replacement !== arm.profile) {
+        arm.profile = replacement;
+        changed = true;
+      }
+    }
+  }
+
+  return changed;
+}
+
+function remapProfileName(value: unknown): unknown {
+  if (typeof value !== "string") {
+    return value;
+  }
+  return BACKUP_TO_PRIMARY[value] ?? value;
+}
+
+/** Rewrite conversation and schedule pins, retrying transient DB contention. */
+async function rewriteDbReferences(workspaceDir: string): Promise<void> {
+  const path = join(workspaceDir, "data", "db", "assistant.db");
+  if (!existsSync(path)) {
+    return;
+  }
+
+  await withDbRetry(() => {
+    const db = new Database(path);
+    try {
+      for (const table of PROFILE_PIN_TABLES) {
+        if (!tableHasColumn(db, table, "inference_profile")) {
+          continue;
+        }
+        for (const [backup, primary] of Object.entries(BACKUP_TO_PRIMARY)) {
+          db.query(
+            `UPDATE ${table} SET inference_profile = ? WHERE inference_profile = ?`,
+          ).run(primary, backup);
+        }
+      }
+    } finally {
+      db.close();
+    }
+  });
+}
+
+function tableHasColumn(
+  db: Database,
+  table: (typeof PROFILE_PIN_TABLES)[number],
+  column: string,
+): boolean {
+  const rows = db.query(`PRAGMA table_info(${table})`).all() as Array<{
+    name?: unknown;
+  }>;
+  return rows.some((row) => row.name === column);
+}
+
+async function withDbRetry(attempt: () => void): Promise<void> {
+  for (let index = 0; ; index += 1) {
+    try {
+      attempt();
+      return;
+    } catch (err) {
+      if (index >= DB_ATTEMPTS - 1) {
+        throw new Error(
+          `Could not repoint backup-profile selections after ${DB_ATTEMPTS} attempts`,
+          { cause: err },
+        );
+      }
+      log.warn(
+        { err, attempt: index },
+        "Could not repoint backup-profile selections; retrying",
+      );
+      await Bun.sleep(DB_RETRY_BASE_DELAY_MS * 2 ** index);
+    }
+  }
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function asObject(value: unknown): Record<string, unknown> | null {
+  return isPlainObject(value) ? value : null;
+}

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -144,6 +144,7 @@ import { repairDeprecatedCodexModelIdMigration } from "./143-repair-deprecated-c
 import { convertStrandedSubscriptionOpenaiProfilesMigration } from "./144-convert-stranded-subscription-openai-profiles.js";
 import { collapseProfileBindingsToEntriesMigration } from "./145-collapse-profile-bindings-to-entries.js";
 import { repairRetiredFireworksDeepseekFlashModelIdMigration } from "./146-repair-retired-fireworks-deepseek-flash-model-id.js";
+import { renameCollidingBackupProfileNamesMigration } from "./147-rename-colliding-backup-profile-names.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -303,4 +304,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   convertStrandedSubscriptionOpenaiProfilesMigration,
   collapseProfileBindingsToEntriesMigration,
   repairRetiredFireworksDeepseekFlashModelIdMigration,
+  renameCollidingBackupProfileNamesMigration,
 ];

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -146,6 +146,7 @@ import { collapseProfileBindingsToEntriesMigration } from "./145-collapse-profil
 import { repairRetiredFireworksDeepseekFlashModelIdMigration } from "./146-repair-retired-fireworks-deepseek-flash-model-id.js";
 import { renameCollidingBackupProfileNamesMigration } from "./147-rename-colliding-backup-profile-names.js";
 import { stripUnsupportedFallbackProfilesMigration } from "./148-strip-unsupported-fallback-profiles.js";
+import { repointBackupProfileSelectionsMigration } from "./149-repoint-backup-profile-selections.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -307,4 +308,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   repairRetiredFireworksDeepseekFlashModelIdMigration,
   renameCollidingBackupProfileNamesMigration,
   stripUnsupportedFallbackProfilesMigration,
+  repointBackupProfileSelectionsMigration,
 ];

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -145,6 +145,7 @@ import { convertStrandedSubscriptionOpenaiProfilesMigration } from "./144-conver
 import { collapseProfileBindingsToEntriesMigration } from "./145-collapse-profile-bindings-to-entries.js";
 import { repairRetiredFireworksDeepseekFlashModelIdMigration } from "./146-repair-retired-fireworks-deepseek-flash-model-id.js";
 import { renameCollidingBackupProfileNamesMigration } from "./147-rename-colliding-backup-profile-names.js";
+import { stripUnsupportedFallbackProfilesMigration } from "./148-strip-unsupported-fallback-profiles.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -305,4 +306,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   collapseProfileBindingsToEntriesMigration,
   repairRetiredFireworksDeepseekFlashModelIdMigration,
   renameCollidingBackupProfileNamesMigration,
+  stripUnsupportedFallbackProfilesMigration,
 ];


### PR DESCRIPTION
## What this does

Each managed default profile (Balanced, Quality, Cost, Speed) has a code-owned backup profile on a different provider. When a managed request fails with an outage-shaped error, the assistant retries the primary when appropriate, then escalates once to the backup instead of surfacing the failure. A process-local circuit breaker remembers known-down routes, skips wasted primary latency, and admits one recovery probe after cooldown.

The rollout is motivated by invalid-credential outages and model retirement incidents where healthy models at other providers were available.

Design doc: https://www.notion.so/vellum-ai/Fallbacks-3c09035c57bd8077bed8e889aac422c1

## Backup pairs

| Profile | Primary | Backup |
| --- | --- | --- |
| Quality | gpt-5.6-sol (OpenAI) | claude-opus-5 (Anthropic) |
| Balanced | gpt-5.6-luna (OpenAI) | claude-sonnet-5 (Anthropic) |
| Speed | gpt-5.6-luna (OpenAI) | gemini-3.6-flash (Google) |
| Cost | deepseek-v4-flash (Fireworks) | gemini-3.1-flash-lite (Google) |

Every pair crosses provider families, and the pairs are split across two backup vendors so an OpenAI outage does not dogpile one of them.

## Scope and safety invariants

- **Managed (`vellum`) routes only.** BYOK, OAuth-subscription, and no-auth connections never receive the escalation callback. A backup naming a different connection or a non-managed provider is refused rather than authenticated with the managed credential.
- **Code-owned fallback contract.** Only the exact managed default-to-backup mapping is accepted. Custom, BYOK, mix, chained, and unsupported-provider pointers are rejected or stripped by validation and migrations.
- **Explicit route pins do not reroute.** Conversations with a model, provider, or provider-connection pin keep retry-then-error behavior because silently changing the requested route violates user intent.
- **One hop, and structurally so.** The backup adapter is raw, so it has no escalation callback and cannot chain.
- **Dispatch-safe resolution.** Fallback routing reuses the dispatch resolvability predicate, forces the backup profile through the normal resolver, and restamps usage attribution for the profile that served.
- **Breaker recovery is race-safe.** A delayed fallback completion carries the primary-failure generation and cannot reopen a route that a newer probe already proved healthy.

## Implementation PRs

| PR | What | Status |
| --- | --- | --- |
| #41164 | RetryProvider escalation hook | Merged |
| #41165 | `fallbackProfile` schema field and cross-profile validation | Merged |
| #41174 | Managed backup profiles and collision migration | Merged |
| #41207 | Managed adapter wiring | Merged |
| #41236 | Circuit breaker with probe recovery | Merged |
| #41250 | Usage-ledger attribution for degraded turns | Merged |
| #41253 | Breaker-open retry budget and probe verdict corrections | Merged |
| #41275 | Managed fallback contract, route safety, and migration cleanup | Merged into this feature branch |
| #41284 | Stale fallback breaker update guard | Merged into this feature branch |
| #41289 | User-facing backup-profile filtering | Open, stacked on this feature branch |

Companion, independent, targets platform `main`: vellum-ai/vellum-assistant-platform#10058 guards that the four backup models keep their billing rate cards, since the rate card doubles as the runtime-proxy allowlist.

## Decisions this needs from a human

1. **There is no off switch.** Backups are code-owned with no toggle, flag, or per-profile opt-out. A customer with a single-vendor requirement is silently routed to another vendor during an outage, at a different price, remediable only by rollback.
2. **Backup profiles are internal routes.** They remain in the full runtime catalog for automatic fallback, but are omitted from `/model`, Settings, and direct profile-selection lists. The seeder still keeps their keys in `profileOrder`, including on BYOK installs where they do not resolve.

## Verification still outstanding

These checks require a live environment:

1. **Live-voice latency for the Speed backup.** `latency-optimized` also drives the live-voice turn detector; a verdict slower than `endpointDecisionTimeoutMs` is audible dead air. `gemini-3.6-flash` has not been measured through the managed proxy. If it misses, `claude-haiku-4-5` keeps the cross-provider split.
2. **A `vel`-environment fallback smoke test.** The integration tests drive mocked upstreams, proving what the assistant puts on the wire but not that the real managed proxy accepts a backup-upstream request with re-resolved auth or that the platform usage event lands on the backup profile.

## Remaining follow-ups

These are tracked, non-blocking follow-ups:

- Nothing guards the **backup** route, so a double outage has no memory and waits through the backup retry budget before failing.
- A probe that spent repairs grants the backup a full retry budget, so one request can make six total attempts instead of five. This affects latency and cost only.
- The backup retry loop duplicates the primary loop. There is no known live defect, but shared retry plumbing would reduce drift risk.
- Several ledger writers repeat served-attribution precedence logic. A shared helper would make future writers correct by construction.

## Testing

The constituent PRs include focused schema, catalog, resolver, routing, breaker, migration, usage-attribution, and retry suites. The two feature-branch hardening PRs also passed the assistant type check, lint, focused fallback tests, call-site tests, formatting checks, and pre-push hooks.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41262" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/devin-review-badge-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
