### PR TITLE
fix(web): keep the swipe row's clip off the box a list lays out

### DIFF
--- a/clients/web/src/components/swipe-action-reveal.test.tsx
+++ b/clients/web/src/components/swipe-action-reveal.test.tsx
@@ -64,6 +64,24 @@ describe("SwipeActionReveal", () => {
     );
   });
 
+  test("the row a list lays out is not the element that clips", () => {
+    const html = renderToStaticMarkup(
+      <SwipeActionReveal enabled={true} trailingActions={[noopAction]}>
+        <div>Row content</div>
+      </SwipeActionReveal>,
+    );
+
+    // A flex or grid item whose overflow is not `visible` has its automatic
+    // minimum size resolved to zero rather than to its content, so a container
+    // that is out of room squashes it away entirely: to a border in a capped
+    // column, to nothing at all in a row. The root is what a list lays out, so
+    // the clip that hides the action layers has to sit inside it.
+    const root = html.slice(0, html.indexOf(">") + 1);
+    expect(root).toContain('data-slot="swipe-action-row"');
+    expect(root).not.toContain("overflow-hidden");
+    expect(html).toContain("overflow-hidden");
+  });
+
   test("renders leading and trailing action buttons", () => {
     const leadingAction: SwipeAction = {
       id: "pin",

--- a/clients/web/src/components/swipe-action-reveal.test.tsx
+++ b/clients/web/src/components/swipe-action-reveal.test.tsx
@@ -76,10 +76,13 @@ describe("SwipeActionReveal", () => {
     // that is out of room squashes it away entirely: to a border in a capped
     // column, to nothing at all in a row. The root is what a list lays out, so
     // the clip that hides the action layers has to sit inside it.
-    const root = html.slice(0, html.indexOf(">") + 1);
-    expect(root).toContain('data-slot="swipe-action-row"');
-    expect(root).not.toContain("overflow-hidden");
-    expect(html).toContain("overflow-hidden");
+    const host = document.createElement("div");
+    host.innerHTML = html;
+    const root = host.firstElementChild;
+
+    expect(root?.getAttribute("data-slot")).toBe("swipe-action-row");
+    expect(root?.className).not.toContain("overflow-hidden");
+    expect(root?.firstElementChild?.className).toContain("overflow-hidden");
   });
 
   test("renders leading and trailing action buttons", () => {

--- a/clients/web/src/components/swipe-action-reveal.tsx
+++ b/clients/web/src/components/swipe-action-reveal.tsx
@@ -157,7 +157,7 @@ export const SwipeActionReveal = forwardRef<
       // to leave a row's own swipe actions alone. Only the armed branch carries
       // it: with no actions there is nothing to yield to.
       data-slot="swipe-action-row"
-      className={cn("relative", className)}
+      className={className}
       // Spread injected props first so our swipe-specific touch handlers
       // take precedence if there is ever a key collision.
       {...rest}
@@ -170,10 +170,8 @@ export const SwipeActionReveal = forwardRef<
       onTouchEnd={onTouchEnd}
       onTouchCancel={onTouchCancel}
     >
-      {/* The layer box: the positioning context the action layers resolve
-          against, and the one thing that clips. `rounded-[inherit]` takes
-          whatever radius the caller put on the root, so a revealed action is
-          cut to the row's own corners. */}
+      {/* The layer box. `rounded-[inherit]` takes whatever radius the caller
+          put on the root, so a revealed action is cut to the row's corners. */}
       <div className="relative overflow-hidden rounded-[inherit]">
         {/* Trailing actions (right side, revealed on swipe-left) */}
         {trailingActions && trailingActions.length > 0 ? (

--- a/clients/web/src/components/swipe-action-reveal.tsx
+++ b/clients/web/src/components/swipe-action-reveal.tsx
@@ -83,8 +83,15 @@ export interface SwipeActionRevealProps extends ComponentPropsWithoutRef<"div"> 
  * with no swipe affordance.
  *
  * The content layer sits in a `transform: translateX()` above two absolutely
- * positioned action layers. `overflow: hidden` on the container clips the
+ * positioned action layers. `overflow: hidden` on the layer box clips the
  * action layers so they're invisible until the content slides away.
+ *
+ * That clip lives one level inside the root rather than on it, because the
+ * root is what a list lays out: a flex or grid item whose overflow is not
+ * `visible` has its automatic minimum size resolved to zero instead of to its
+ * content, so a clipping root can be squashed to nothing by a container that
+ * is out of room. Keeping the clip off the root leaves a swipe row sizing
+ * exactly like a row without one, in either axis and whatever the container.
  *
  * Modeled on the swipe patterns in {@link use-gallery-swipe} and
  * {@link use-edge-swipe}. Action button styling follows the iOS Mail
@@ -150,7 +157,7 @@ export const SwipeActionReveal = forwardRef<
       // to leave a row's own swipe actions alone. Only the armed branch carries
       // it: with no actions there is nothing to yield to.
       data-slot="swipe-action-row"
-      className={cn("relative overflow-hidden", className)}
+      className={cn("relative", className)}
       // Spread injected props first so our swipe-specific touch handlers
       // take precedence if there is ever a key collision.
       {...rest}
@@ -163,64 +170,70 @@ export const SwipeActionReveal = forwardRef<
       onTouchEnd={onTouchEnd}
       onTouchCancel={onTouchCancel}
     >
-      {/* Trailing actions (right side, revealed on swipe-left) */}
-      {trailingActions && trailingActions.length > 0 ? (
-        <div
-          className="absolute inset-y-0 right-0 flex"
-          aria-hidden={offset >= 0}
-          // Remove hidden actions from tab order — they're only reachable
-          // after a swipe reveals them. Without this, tab navigation
-          // lands on invisible buttons behind the content layer.
-          style={offset >= 0 ? { pointerEvents: "none" } : undefined}
-        >
-          {trailingActions.map((action) => (
-            <SwipeActionButton
-              key={action.id}
-              action={action}
-              onAfterSelect={close}
-              hidden={offset >= 0}
-            />
-          ))}
-        </div>
-      ) : null}
+      {/* The layer box: the positioning context the action layers resolve
+          against, and the one thing that clips. `rounded-[inherit]` takes
+          whatever radius the caller put on the root, so a revealed action is
+          cut to the row's own corners. */}
+      <div className="relative overflow-hidden rounded-[inherit]">
+        {/* Trailing actions (right side, revealed on swipe-left) */}
+        {trailingActions && trailingActions.length > 0 ? (
+          <div
+            className="absolute inset-y-0 right-0 flex"
+            aria-hidden={offset >= 0}
+            // Remove hidden actions from tab order: they're only reachable
+            // after a swipe reveals them. Without this, tab navigation
+            // lands on invisible buttons behind the content layer.
+            style={offset >= 0 ? { pointerEvents: "none" } : undefined}
+          >
+            {trailingActions.map((action) => (
+              <SwipeActionButton
+                key={action.id}
+                action={action}
+                onAfterSelect={close}
+                hidden={offset >= 0}
+              />
+            ))}
+          </div>
+        ) : null}
 
-      {/* Leading actions (left side, revealed on swipe-right) */}
-      {leadingActions && leadingActions.length > 0 ? (
-        <div
-          className="absolute inset-y-0 left-0 flex"
-          aria-hidden={offset <= 0}
-          style={offset <= 0 ? { pointerEvents: "none" } : undefined}
-        >
-          {leadingActions.map((action) => (
-            <SwipeActionButton
-              key={action.id}
-              action={action}
-              onAfterSelect={close}
-              hidden={offset <= 0}
-            />
-          ))}
-        </div>
-      ) : null}
+        {/* Leading actions (left side, revealed on swipe-right) */}
+        {leadingActions && leadingActions.length > 0 ? (
+          <div
+            className="absolute inset-y-0 left-0 flex"
+            aria-hidden={offset <= 0}
+            style={offset <= 0 ? { pointerEvents: "none" } : undefined}
+          >
+            {leadingActions.map((action) => (
+              <SwipeActionButton
+                key={action.id}
+                action={action}
+                onAfterSelect={close}
+                hidden={offset <= 0}
+              />
+            ))}
+          </div>
+        ) : null}
 
-      {/* Content layer, sliding over the action layers. Its fill has to be
-          opaque so the actions stay hidden until a swipe reveals them, and it
-          has to match whatever surface the row sits on or the row reads as a
-          differently-coloured band. `--swipe-reveal-bg` lets that surface name
-          itself (the sidebar's section card publishes its own), falling back
-          to the panel surface a row rests on elsewhere. */}
-      <div
-        className={cn(
-          "relative bg-[var(--swipe-reveal-bg,var(--surface-overlay))] transition-transform",
-          isDragging && "transition-none",
-        )}
-        style={{
-          transform: `translateX(${offset}px)`,
-          // Ensure the content layer paints above the action layers so they're
-          // hidden until swiped. z-10 is enough since actions are auto-positioned.
-          zIndex: 1,
-        }}
-      >
-        {children}
+        {/* Content layer, sliding over the action layers. Its fill has to be
+            opaque so the actions stay hidden until a swipe reveals them, and it
+            has to match whatever surface the row sits on or the row reads as a
+            differently-coloured band. `--swipe-reveal-bg` lets that surface name
+            itself (the sidebar's section card publishes its own), falling back
+            to the panel surface a row rests on elsewhere. */}
+        <div
+          className={cn(
+            "relative bg-[var(--swipe-reveal-bg,var(--surface-overlay))] transition-transform",
+            isDragging && "transition-none",
+          )}
+          style={{
+            transform: `translateX(${offset}px)`,
+            // Ensure the content layer paints above the action layers so they're
+            // hidden until swiped. z-10 is enough since actions are auto-positioned.
+            zIndex: 1,
+          }}
+        >
+          {children}
+        </div>
       </div>
     </div>
   );

--- a/clients/web/src/domains/home/home-recap-row.tsx
+++ b/clients/web/src/domains/home/home-recap-row.tsx
@@ -294,15 +294,10 @@ export function HomeRecapRow({
       onOpenChange={longPress.onOpenChange}
     >
       <div {...longPress.wrapperProps}>
-        {/* `shrink-0`: the swipe branch clips its own overflow, which zeroes a
-            flex item's automatic minimum size, and the long-press wrapper is
-            `display: contents`, so this element is the flex item a list sizes.
-            Without it a height-capped column (the notifications bell's list)
-            squashes every row down to its border instead of scrolling. */}
         <SwipeActionReveal
           leadingActions={swipeActionsFor(actions, "leading")}
           trailingActions={swipeActionsFor(actions, "trailing")}
-          className="shrink-0 rounded-[var(--radius-lg)]"
+          className="rounded-[var(--radius-lg)]"
         >
           {card}
         </SwipeActionReveal>


### PR DESCRIPTION
## TL;DR

`SwipeActionReveal` clipped its own root, and the root is the box a list lays
out. That let any container short on room squash a swipe row to nothing. The
clip moves one level in, so the row sizes like a row with no swipe wrapper at
all. Reverts the `shrink-0` patch from #41259, which guarded one consumer on
one axis.

Related to [LUM-3438](https://linear.app/vellum/issue/LUM-3438/ios-tf-notifications-bug-dev-202608210733)

## The actual defect

A flex or grid item whose overflow is not `visible` has its automatic minimum
size resolved to zero rather than to its content. The armed branch of
`SwipeActionReveal` carried `relative overflow-hidden` on its root, and that
root is what a list hands its space to, so a container out of room could shrink
a swipe row to nothing on either axis.

#41259 pinned `shrink-0` on `HomeRecapRow`, which is the surface where this was
actually firing. That was too narrow: it covered one of four consumers, and
`flex-shrink: 0` is a behaviour change rather than a restoration, since a row
without a swipe wrapper does shrink when its container is a row and space is
tight.

Moving the clip to a layer box inside the root fixes the cause. The root stops
clipping, so its automatic minimum size is content-based again; the layer box
still clips the action layers, and takes the root's radius via
`rounded-[inherit]` so a revealed action is cut to the row's own corners.

## Before / after

| | Before | After |
| -- | -- | -- |
| Any swipe row in a height-capped flex column | Collapses to its border, and the list stops scrolling | Full height, list scrolls |
| Any swipe row in a width-constrained flex row | Collapses to zero width | Keeps its width |
| Notification rows in the bell | Fixed in #41259 by a row-level `shrink-0` | Same result, from the component, with the patch removed |
| Revealed swipe action | Clipped to the row's rounded corners | Unchanged |

## What was measured

Candidates against a plain row with no swipe wrapper as the baseline, in a
capped column (12 rows, 200px) and a horizontal strip (6 rows, 320px):

| variant | column | row |
| -- | -- | -- |
| baseline, no clip | 50px, scrolls | 200px wide |
| clip on the root (before) | 9.3px, no scroll | 0px wide |
| `shrink-0` on the root | 50px, scrolls | 200px, but shrink frozen |
| `min-height: min-content` | 50px, scrolls | 0px wide |
| clip in a layer box (this PR) | 50px, scrolls | 200px wide |

Then with the real components at a coarse-pointer viewport, rendering
`HomeRecapRow` in the bell's list shape with no `shrink-0` anywhere: root
computes `overflow: visible` with a 12px radius, the layer box computes
`overflow: hidden` with the same 12px inherited, rows measure 73px, and the
list scrolls (1126px of content in a 300px box). Revealing an action still
paints it cut to the row's corners.

## Why this is safe

- The extra box is a plain block: auto width and height, so it changes no
  geometry. `data-slot="swipe-action-row"` stays on the root, which is what
  `use-swipe-close-drawer` matches with `closest()`.
- Nothing in CSS targets the row's internals, and no other test queries them.
- The passthrough (fine-pointer) branch is untouched: it has no action layers,
  so it has nothing to clip.
- The three other consumers (conversation rows, pinned app tiles, library
  cards) render identically today. None of them was visibly broken, because in
  each case an intervening block box or an explicit grid track floor happened
  to keep the clipped root out of a constrained flex context. That protection
  was accidental, which is the point of fixing it at the component.

## Test

`swipe-action-reveal.test.tsx` already asserts on rendered markup, so the
invariant goes there: the root carries the slot and does not carry
`overflow-hidden`, while the tree still clips somewhere. That fails against the
previous implementation. Local test runs are blocked by the standing rule, so
this one runs in CI.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41263" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->