### PR TITLE
feat(ios): state-adaptive light widget (idle quick actions, active status readout)

### DIFF
--- a/clients/ios/App/VoiceActivity/Widgets/StatusWidget.swift
+++ b/clients/ios/App/VoiceActivity/Widgets/StatusWidget.swift
@@ -1,12 +1,14 @@
 import SwiftUI
+import UIKit
 import WidgetKit
 
-/// The small Home Screen widget: how much is waiting, and the two ways in.
+/// The small Home Screen widget, in the two states it has: what is waiting when
+/// something is, and the ways in when nothing is.
 ///
-/// Small only. Two numbers over two buttons is what the family fits, and it is
-/// the whole idea: this is the widget for someone who wants the count without
-/// the list, so a medium version would just be the Catch Up widget with its
-/// rows deleted.
+/// Small only. Two numbers over two buttons, or three buttons on their own, is
+/// what the family fits, and it is the whole idea: this is the widget for
+/// someone who wants the count without the list, so a medium version would just
+/// be the Catch Up widget with its rows deleted.
 ///
 /// It declares no `widgetURL`, deliberately. A tap outside the buttons should
 /// land the user wherever they left off, which is what a widget carrying no URL
@@ -24,70 +26,162 @@ struct StatusWidget: Widget {
                 .containerBackground(WidgetTheme.surface, for: .widget)
         }
         .configurationDisplayName("Status")
-        .description("See how much is unread or still working in Vellum, and start a new chat or voice session.")
+        .description("See what is unread or still working in Vellum, with camera, voice and chat a tap away when nothing is waiting.")
         .supportedFamilies([.systemSmall])
+        .contentMarginsDisabled()
     }
 }
 
-/// The readout on top, the actions along the bottom.
+/// One card that swaps what it is for: a readout when the account has something
+/// waiting, a launcher when it does not.
+///
+/// A count is worth a small widget's card only while there is a count. A card
+/// printing "All caught up." over two buttons spends most of itself saying
+/// nothing, so the space goes instead to the three things people open the app
+/// to do.
+///
+/// Both states are laid out on the same margins and the same two bands, so the
+/// flip changes what the card offers rather than where it draws.
 struct StatusWidgetView: View {
     let entry: SnapshotEntry
 
-    /// Height of the action row, so the tiles claim a fixed strip rather than
-    /// growing into the readout above them: both tiles fill whatever frame
-    /// they are handed.
-    private static let actionRowHeight: CGFloat = 54
+    /// The widget disables the system content margins and draws this one
+    /// instead: the layout is drawn at these margins, and the system's own
+    /// inset would leave the controls short of the size they are specified at.
+    private static let contentMargin: CGFloat = 16
+
+    /// The height a control is drawn at where the family has room for it, and
+    /// the gap between the card's two bands. A shorter widget splits what it
+    /// has between the bands rather than overflowing its margins.
+    private static let preferredControlHeight: CGFloat = 61
+    private static let bandGap: CGFloat = 7
+
+    /// Gap inside a band: between the two circles, and between the two tiles.
+    private static let circleGap: CGFloat = 6
+    private static let tileGap: CGFloat = 8
+
+    /// Gap between the two count lines, and the column their glyphs sit in.
+    /// The column is wide enough for the wider of the two, so the counts start
+    /// at the same place whichever lines are drawn.
+    private static let countGap: CGFloat = 12
+    private static let glyphColumnWidth: CGFloat = 20
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            readout
-            Spacer(minLength: 0)
-            HStack(spacing: 7) {
-                WidgetActionTile.newChat
-                WidgetActionTile.voice
-            }
-            .frame(height: Self.actionRowHeight)
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-    }
-
-    /// The counts, or the one sentence that stands in for them.
-    ///
-    /// A count of zero drops its line rather than printing "0", and two zeroes
-    /// are said once instead of twice.
-    ///
-    /// Staleness drops both lines, not just the perishable one. On a widget
-    /// that is nothing but a readout, a lone "2 unread" also asserts that
-    /// nothing is running, which an aged snapshot cannot know. The Catch Up
-    /// rows keep their unread markers past the same threshold because each one
-    /// hangs off a conversation the reader recognizes; a bare number has
-    /// nothing to qualify it.
-    ///
-    /// The three prompts that stand in for the counts are three different
-    /// facts rather than spare wordings of one: nothing has ever synced, the
-    /// snapshot is too old to read as a status, or there is genuinely nothing
-    /// waiting. The buttons below stay live in all three, so the widget is
-    /// still a way in when it has nothing to report.
-    @ViewBuilder
-    private var readout: some View {
-        if let snapshot = entry.snapshot {
-            if entry.isStale {
-                WidgetPromptText("Open Vellum for the latest.")
-            } else if snapshot.unreadCount <= 0, snapshot.inProgressCount <= 0 {
-                WidgetPromptText("All caught up.")
-            } else {
-                VStack(alignment: .leading, spacing: 6) {
-                    if snapshot.unreadCount > 0 {
-                        countLine(icon: "bubble.left", text: "\(snapshot.unreadCount) unread")
-                    }
-                    if snapshot.inProgressCount > 0 {
-                        countLine(icon: "ellipsis.bubble", text: "\(snapshot.inProgressCount) in progress")
-                    }
+        GeometryReader { proxy in
+            let control = Self.controlHeight(fitting: proxy.size)
+            VStack(spacing: 0) {
+                if isActive {
+                    counts
+                    Spacer(minLength: Self.bandGap)
+                    actionTiles(height: control)
+                } else {
+                    circles(diameter: control)
+                    Spacer(minLength: Self.bandGap)
+                    chatPill(height: control)
                 }
             }
-        } else {
-            WidgetPromptText("Open Vellum to see what is waiting.")
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
+        .padding(Self.contentMargin)
+    }
+
+    /// Whether there is anything to report.
+    ///
+    /// A stale snapshot is not. Its counts are claims about an inbox from half
+    /// an hour ago, and on a card that is nothing but a readout, a lone
+    /// "2 unread" also asserts that nothing is running, which an aged snapshot
+    /// cannot know. The launcher is a true thing to show in their place, and a
+    /// more useful one than a sentence apologizing for the counts.
+    private var isActive: Bool {
+        guard !entry.isStale, let snapshot = entry.snapshot else {
+            return false
+        }
+        return snapshot.unreadCount > 0 || snapshot.inProgressCount > 0
+    }
+
+    /// The accent theming the New Chat surfaces.
+    ///
+    /// Only a character avatar carries one: an uploaded photo has no accent by
+    /// design, and an account with nothing synced has none to read. Both fall
+    /// through to the static tokens inside ``WidgetSoftAccent``.
+    private var softAccent: WidgetSoftAccent {
+        guard entry.avatarKind == .character else {
+            return WidgetSoftAccent(accentHex: nil)
+        }
+        return WidgetSoftAccent(accentHex: entry.snapshot?.avatar?.accentHex)
+    }
+
+    /// The height of one control, capped at the size the card is laid out for
+    /// and otherwise cut to whichever dimension runs out first.
+    ///
+    /// Both states stack two bands of controls, or one band under the counts,
+    /// so the same number sizes the circles, the pill and the tiles. Deriving
+    /// it rather than fixing it is what keeps the card inside its margins on
+    /// the smaller phones, where a small widget is a good deal short of the
+    /// size this is drawn at.
+    private static func controlHeight(fitting size: CGSize) -> CGFloat {
+        min(preferredControlHeight, (size.height - bandGap) / 2, (size.width - circleGap) / 2)
+    }
+
+    /// The two most physical actions, as circles: a shape the eye separates
+    /// from the wide pill under them before it reads either one.
+    private func circles(diameter: CGFloat) -> some View {
+        HStack(spacing: Self.circleGap) {
+            CircleActionButton(
+                intent: OpenCameraIntent(),
+                icon: Image(systemName: "camera.fill"),
+                label: "Take a photo",
+                fill: WidgetTheme.voiceFill,
+                tint: WidgetTheme.textPrimary,
+                diameter: diameter
+            )
+            CircleActionButton(
+                intent: StartNewVoiceConversationIntent(),
+                icon: Image(systemName: "waveform"),
+                label: "New voice conversation",
+                fill: WidgetTheme.voiceFill,
+                tint: WidgetTheme.textPrimary,
+                diameter: diameter
+            )
+        }
+    }
+
+    /// Chat, given the whole width because it is the action most people want
+    /// most often, and the pill is the only shape on a small widget that can
+    /// say so.
+    private func chatPill(height: CGFloat) -> some View {
+        PillActionButton(
+            intent: OpenNewChatIntent(),
+            icon: Image("VellumV"),
+            title: "Chat",
+            fill: softAccent.fill,
+            tint: softAccent.onFill,
+            height: height,
+            avatarImage: entry.avatarImage
+        )
+    }
+
+    /// The pair the readout state ends on. Voice keeps the neutral fill, so the
+    /// two read as a primary action and a secondary one.
+    private func actionTiles(height: CGFloat) -> some View {
+        HStack(spacing: Self.tileGap) {
+            WidgetActionTile.newChat(accent: softAccent, avatarImage: entry.avatarImage)
+            WidgetActionTile.voice
+        }
+        .frame(height: height)
+    }
+
+    /// The counts, each dropping its line rather than printing "0".
+    private var counts: some View {
+        VStack(alignment: .leading, spacing: Self.countGap) {
+            if let count = entry.snapshot?.unreadCount, count > 0 {
+                countLine(glyph: unreadGlyph, text: "\(count) unread")
+            }
+            if let count = entry.snapshot?.inProgressCount, count > 0 {
+                countLine(glyph: inProgressGlyph, text: "\(count) in progress")
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     /// The glyph is decorative: the text beside it already says everything
@@ -96,12 +190,10 @@ struct StatusWidgetView: View {
     /// The line is `.privacySensitive()` while the glyph beside it is not,
     /// matching the Quick Actions chip: a locked device still shows that
     /// something is waiting without spelling out how far behind its owner is.
-    private func countLine(icon: String, text: String) -> some View {
-        HStack(spacing: 6) {
-            Image(systemName: icon)
-                .font(.system(size: 12))
-                .foregroundStyle(WidgetTheme.brand)
-                .frame(width: 14)
+    private func countLine(glyph: some View, text: String) -> some View {
+        HStack(spacing: 7) {
+            glyph
+                .frame(width: Self.glyphColumnWidth, alignment: .leading)
                 .accessibilityHidden(true)
             Text(text)
                 .font(.system(size: 14, weight: .semibold))
@@ -111,4 +203,138 @@ struct StatusWidgetView: View {
                 .privacySensitive()
         }
     }
+
+    /// A bubble wearing the same unseen dot the Catch Up rows mark a
+    /// conversation with, so the two widgets say "unread" the same way.
+    private var unreadGlyph: some View {
+        Image(systemName: "bubble.left")
+            .font(.system(size: 16))
+            .foregroundStyle(WidgetTheme.textPrimary)
+            .overlay(alignment: .topTrailing) {
+                Circle()
+                    .fill(WidgetTheme.unseenIndicator)
+                    .frame(width: 6, height: 6)
+                    .offset(x: 2, y: -1)
+            }
+    }
+
+    /// The dots a Catch Up row marks a turn in flight with, at the size this
+    /// card's lines are drawn at.
+    private var inProgressGlyph: some View {
+        Image(systemName: "ellipsis")
+            .font(.system(size: 16, weight: .bold))
+            .foregroundStyle(WidgetTheme.textSecondary)
+    }
 }
+
+#if DEBUG
+
+/// The widget's own card at the size the layout is specified at, so a preview
+/// shows the controls landing on their margins rather than a view floating in
+/// a canvas.
+private struct StatusWidgetPreviewCard: View {
+    let entry: SnapshotEntry
+
+    var body: some View {
+        StatusWidgetView(entry: entry)
+            .frame(width: 161, height: 161)
+            .background(WidgetTheme.surface)
+            .clipShape(RoundedRectangle(cornerRadius: 22, style: .continuous))
+    }
+}
+
+/// The same content in both appearances, side by side: every color on this card
+/// resolves per appearance, so a preview showing one of them is half a preview.
+private func previewAppearances<Content: View>(
+    @ViewBuilder _ content: @escaping () -> Content
+) -> some View {
+    HStack(spacing: 16) {
+        ForEach([ColorScheme.light, ColorScheme.dark], id: \.self) { scheme in
+            content()
+                .padding(12)
+                .background(scheme == .dark ? Color.black : Color(white: 0.92))
+                .environment(\.colorScheme, scheme)
+        }
+    }
+    .padding()
+}
+
+/// A snapshot carrying exactly what a preview needs to say and nothing else:
+/// this widget renders no conversations.
+private func previewEntry(
+    unread: Int = 0,
+    inProgress: Int = 0,
+    avatar: WidgetSnapshotAvatar? = nil
+) -> SnapshotEntry {
+    SnapshotEntry(
+        date: Date(),
+        snapshot: WidgetSnapshot(
+            schemaVersion: WidgetSnapshot.currentSchemaVersion,
+            generatedAt: Date(),
+            unreadCount: unread,
+            inProgressCount: inProgress,
+            conversations: [],
+            avatar: avatar
+        ),
+        isStale: false
+    )
+}
+
+/// A stand-in avatar, drawn rather than shipped so the previews cost the
+/// extension no asset.
+private func previewAvatarData() -> Data {
+    let size = CGSize(width: 96, height: 96)
+    return UIGraphicsImageRenderer(size: size).pngData { context in
+        (UIColor(cssHex: "#3B6EA5") ?? .systemBlue).setFill()
+        context.fill(CGRect(origin: .zero, size: size))
+        (UIColor(cssHex: "#F2F2F2") ?? .white).setFill()
+        context.cgContext.fillEllipse(in: CGRect(x: 20, y: 30, width: 22, height: 28))
+        context.cgContext.fillEllipse(in: CGRect(x: 54, y: 30, width: 22, height: 28))
+    }
+}
+
+#Preview("Idle") {
+    previewAppearances {
+        StatusWidgetPreviewCard(entry: previewEntry())
+    }
+}
+
+#Preview("Active") {
+    previewAppearances {
+        StatusWidgetPreviewCard(entry: previewEntry(unread: 3, inProgress: 2))
+    }
+}
+
+#Preview("Active, unread only") {
+    previewAppearances {
+        StatusWidgetPreviewCard(entry: previewEntry(unread: 1))
+    }
+}
+
+#Preview("Custom avatar") {
+    let avatar = WidgetSnapshotAvatar(kind: "image", accentHex: nil, imageData: previewAvatarData())
+    previewAppearances {
+        HStack(spacing: 12) {
+            StatusWidgetPreviewCard(entry: previewEntry(avatar: avatar))
+            StatusWidgetPreviewCard(entry: previewEntry(unread: 3, inProgress: 2, avatar: avatar))
+        }
+    }
+}
+
+#Preview("Character accent") {
+    // The light accent is the one worth looking at: its wash has to stay a pale
+    // card with the word still legible on it.
+    let avatar = WidgetSnapshotAvatar(
+        kind: "character",
+        accentHex: "#F2C94C",
+        imageData: previewAvatarData()
+    )
+    previewAppearances {
+        HStack(spacing: 12) {
+            StatusWidgetPreviewCard(entry: previewEntry(avatar: avatar))
+            StatusWidgetPreviewCard(entry: previewEntry(unread: 3, inProgress: 2, avatar: avatar))
+        }
+    }
+}
+
+#endif

--- a/clients/ios/App/VoiceActivity/Widgets/StatusWidget.swift
+++ b/clients/ios/App/VoiceActivity/Widgets/StatusWidget.swift
@@ -243,22 +243,6 @@ private struct StatusWidgetPreviewCard: View {
     }
 }
 
-/// The same content in both appearances, side by side: every color on this card
-/// resolves per appearance, so a preview showing one of them is half a preview.
-private func previewAppearances<Content: View>(
-    @ViewBuilder _ content: @escaping () -> Content
-) -> some View {
-    HStack(spacing: 16) {
-        ForEach([ColorScheme.light, ColorScheme.dark], id: \.self) { scheme in
-            content()
-                .padding(12)
-                .background(scheme == .dark ? Color.black : Color(white: 0.92))
-                .environment(\.colorScheme, scheme)
-        }
-    }
-    .padding()
-}
-
 /// A snapshot carrying exactly what a preview needs to say and nothing else:
 /// this widget renders no conversations.
 private func previewEntry(

--- a/clients/ios/App/VoiceActivity/Widgets/WidgetActionControls.swift
+++ b/clients/ios/App/VoiceActivity/Widgets/WidgetActionControls.swift
@@ -16,9 +16,10 @@ import UIKit
 /// `openAppWhenRun`, so the system performs them in the app process; the appex
 /// only needs the types to exist.
 struct WidgetActionTile<ActionIntent: AppIntent>: View {
-    /// Matched to the squircle the system clips the widget itself with, so a
-    /// tile reads as a smaller instance of the card it sits on.
-    private static var cornerRadius: CGFloat { 14 }
+    /// Close to the squircle the system clips the widget itself with, so a tile
+    /// reads as a smaller instance of the card it sits on rather than as a chip
+    /// placed on top of it.
+    private static var cornerRadius: CGFloat { 19 }
 
     private static var iconSize: CGFloat { 22 }
 
@@ -65,16 +66,27 @@ struct WidgetActionTile<ActionIntent: AppIntent>: View {
 }
 
 extension WidgetActionTile where ActionIntent == OpenNewChatIntent {
+    /// The New Chat tile on the static tokens, for the widgets with no avatar
+    /// in hand to theme it with.
+    static var newChat: Self {
+        newChat(accent: WidgetSoftAccent(accentHex: nil))
+    }
+
     /// The New Chat tile, spelled once so the widgets offering it cannot drift
     /// into different wording, glyphs or colors. The frame around it stays with
     /// the caller: the column and the row size their tiles differently.
-    static var newChat: Self {
+    ///
+    /// The accent themes the tile and the avatar replaces its mark, both from
+    /// the snapshot, so the tile that starts a chat with the assistant looks
+    /// like that assistant.
+    static func newChat(accent: WidgetSoftAccent, avatarImage: UIImage? = nil) -> Self {
         WidgetActionTile(
             intent: OpenNewChatIntent(),
             icon: Image("VellumV"),
             title: "New Chat",
-            fill: WidgetTheme.newChatFill,
-            tint: WidgetTheme.brand
+            fill: accent.fill,
+            tint: accent.onFill,
+            avatarImage: avatarImage
         )
     }
 }

--- a/clients/ios/App/VoiceActivity/Widgets/WidgetAvatarRendering.swift
+++ b/clients/ios/App/VoiceActivity/Widgets/WidgetAvatarRendering.swift
@@ -299,7 +299,7 @@ private struct WidgetAvatarKitPreviewCard: View {
 
 /// The same content in both appearances, side by side: every value in this file
 /// resolves per appearance, so a preview showing one of them is half a preview.
-private func previewAppearances<Content: View>(
+func previewAppearances<Content: View>(
     @ViewBuilder _ content: @escaping () -> Content
 ) -> some View {
     HStack(spacing: 16) {
@@ -315,7 +315,7 @@ private func previewAppearances<Content: View>(
 
 /// A stand-in photo, drawn rather than shipped so the previews cost the
 /// extension no asset.
-private func previewAvatarPhoto() -> UIImage {
+func previewAvatarPhoto() -> UIImage {
     let size = CGSize(width: 120, height: 120)
     return UIGraphicsImageRenderer(size: size).image { context in
         (UIColor(cssHex: "#3B6EA5") ?? .systemBlue).setFill()

--- a/clients/ios/App/VoiceActivity/Widgets/WidgetTheme.swift
+++ b/clients/ios/App/VoiceActivity/Widgets/WidgetTheme.swift
@@ -15,14 +15,25 @@ import UIKit
 /// is in, and a white card on a dark Home Screen would be the brightest thing
 /// on the display.
 enum WidgetTheme {
-    /// The card the whole widget sits on, passed to `containerBackground`.
-    static let surface = dynamic(light: "#FFFFFF", dark: "#1C1C1E")
+    /// ``surface`` as the hex pair it is built from, so a color washed *into*
+    /// the card blends over the same value the card is painted with. See
+    /// ``WidgetSoftAccent``.
+    fileprivate static let surfaceLightHex = "#FFFFFF"
+    fileprivate static let surfaceDarkHex = "#1C1C1E"
 
-    /// Fill behind the New Chat action, tinted toward the brand green.
+    /// The card the whole widget sits on, passed to `containerBackground`.
+    static let surface = dynamic(light: surfaceLightHex, dark: surfaceDarkHex)
+
+    /// Fill behind the New Chat action for an account carrying no avatar
+    /// accent to wash in: the brand green's own share of the card. See
+    /// ``WidgetSoftAccent``, which lands on exactly these values for the
+    /// default teal.
     static let newChatFill = dynamic(light: "#E6F5F3", dark: "#123832")
 
-    /// Fill behind the Voice action: neutral, so the two tiles read as a
-    /// primary action and a secondary one rather than as two peers.
+    /// The neutral fill behind a secondary control: the Voice tile beside the
+    /// tinted New Chat one, and the camera and voice circles on the light
+    /// card. Neutral so the tinted surface beside it reads as the primary
+    /// action rather than as one of two peers.
     static let voiceFill = dynamic(light: "#F6F5F4", dark: "#2C2C2E")
 
     /// Vellum green. Lightened in dark mode, where the light-mode value does
@@ -97,5 +108,58 @@ enum WidgetTheme {
     /// ``dynamic(light:dark:)``.
     private static func fixed(_ hex: String) -> Color {
         Color(uiColor: UIColor(cssHex: hex) ?? .gray)
+    }
+}
+
+/// The pale card a New Chat surface sits on, and the color drawn on it.
+///
+/// The accent arrives as one hex and has to produce a fill for both
+/// appearances, so it is washed into ``WidgetTheme/surface`` rather than used
+/// neat: a saturated block would swallow the light card it is a control on.
+/// This is the light-card counterpart to ``WidgetAvatarPalette``, which paints
+/// a whole card with the same accent.
+///
+/// The foreground is the card's own text color rather than the accent, because
+/// a wash this thin barely moves the surface's luminance: an accent legible on
+/// its own block can be invisible at a tenth of it, and half the palette would
+/// come out unreadable. The accentless fallback keeps the brand green, which is
+/// what the tile has always drawn its mark in.
+struct WidgetSoftAccent {
+    /// The accent's share of the light card. Calibrated on the brand green: at
+    /// this share `#0E9B8B` over the light surface lands exactly on
+    /// ``WidgetTheme/newChatFill``'s light value, so an account whose avatar is
+    /// the default teal gets the same tile as an account with no avatar at all.
+    private static let lightWash = 0.105
+
+    /// The accent's share of the dark card. Heavier because the wash runs the
+    /// other way there, lifting a near-black surface instead of tinting a white
+    /// one, and at this share the brand green lands within a shade of
+    /// ``WidgetTheme/newChatFill``'s hand-picked dark value.
+    private static let darkWash = 0.22
+
+    /// The card behind the mark and the word.
+    let fill: Color
+
+    /// The mark and the word drawn on ``fill``.
+    let onFill: Color
+
+    /// The wash for an avatar accent, or the static tokens when there is no
+    /// accent to work from and when the one on offer is unreadable.
+    init(accentHex: String?) {
+        guard let accentHex,
+              let canonical = canonicalCSSHex(accentHex),
+              let light = UIColor(
+                  cssHex: blendHex(base: WidgetTheme.surfaceLightHex, overlay: canonical, alpha: Self.lightWash)
+              ),
+              let dark = UIColor(
+                  cssHex: blendHex(base: WidgetTheme.surfaceDarkHex, overlay: canonical, alpha: Self.darkWash)
+              )
+        else {
+            fill = WidgetTheme.newChatFill
+            onFill = WidgetTheme.brand
+            return
+        }
+        fill = WidgetTheme.appearanceDynamic(light: light, dark: dark)
+        onFill = WidgetTheme.textPrimary
     }
 }

--- a/clients/ios/App/VoiceActivity/Widgets/WidgetTheme.swift
+++ b/clients/ios/App/VoiceActivity/Widgets/WidgetTheme.swift
@@ -122,8 +122,8 @@ enum WidgetTheme {
 /// The foreground is the card's own text color rather than the accent, because
 /// a wash this thin barely moves the surface's luminance: an accent legible on
 /// its own block can be invisible at a tenth of it, and half the palette would
-/// come out unreadable. The accentless fallback keeps the brand green, which is
-/// what the tile has always drawn its mark in.
+/// come out unreadable. The accentless fallback draws the mark in the brand
+/// green.
 struct WidgetSoftAccent {
     /// The accent's share of the light card. Calibrated on the brand green: at
     /// this share `#0E9B8B` over the light surface lands exactly on


### PR DESCRIPTION
## Summary
- The Status widget becomes a light adaptive card: a camera/voice/Chat launcher when nothing is pending, the unread and in-progress readout when something is
- New Chat surfaces carry the real avatar with the brand mark as fallback, and the shared action tiles take on the light fills and radius
- Stale snapshots fall back to the launcher instead of stale counts

Part of plan: ios-widgets-v2.md (PR 7 of 7)