### PR TITLE
feat(channels): report whether Discord is actually delivering

### DIFF
--- a/assistant/src/__tests__/channel-readiness-discord.test.ts
+++ b/assistant/src/__tests__/channel-readiness-discord.test.ts
@@ -70,7 +70,9 @@ beforeEach(() => {
   mockSecureKeys = {};
   askedChannels = [];
   socketHealth = { channel: "discord", status: "connected" };
-  admittedChannelCount = 1;
+  // The default install state: fail-closed and empty, admitting nothing until
+  // someone lists channel ids. Tests that need admission say so.
+  admittedChannelCount = 0;
 });
 
 async function runDiscordProbe() {
@@ -93,12 +95,23 @@ describe("discord readiness", () => {
     expect(askedChannels).toEqual(["discord"]);
   });
 
-  test("reports a missing bot token", async () => {
+  test("a fresh install has neither a token nor an allow-list", async () => {
     const [snapshot] = await runDiscordProbe();
 
-    const credential = findCheck(snapshot, "bot_token");
-    expect(credential.passed).toBe(false);
+    expect(findCheck(snapshot, "bot_token").passed).toBe(false);
+    expect(findCheck(snapshot, "guild_admission").passed).toBe(false);
+    // Nothing configured at all, which is a different report from a channel
+    // half set up: no step has been taken rather than one left undone.
     expect(snapshot.setupStatus).toBe("not_configured");
+  });
+
+  test("an allow-list without a token is half set up", async () => {
+    admittedChannelCount = 3;
+
+    const [snapshot] = await runDiscordProbe();
+
+    expect(findCheck(snapshot, "bot_token").passed).toBe(false);
+    expect(snapshot.setupStatus).toBe("incomplete");
   });
 
   test("a token, a live connection and an allow-list read as ready", async () => {
@@ -169,6 +182,9 @@ describe("discord readiness", () => {
 
   test("a dead socket reads as configured and failing, not unconfigured", async () => {
     mockSecureKeys[credentialKey("discord_channel", "bot_token")] = "bot-fake";
+    // Setup has to be finished for this to isolate the socket: an empty
+    // allow-list would leave it incomplete for a reason that is not the socket.
+    admittedChannelCount = 1;
     socketHealth = { channel: "discord", status: "disconnected" };
 
     const [snapshot] = await runDiscordProbe();

--- a/assistant/src/__tests__/channel-readiness-discord.test.ts
+++ b/assistant/src/__tests__/channel-readiness-discord.test.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { credentialKey } from "../security/credential-key.js";
+
+let mockSecureKeys: Record<string, string>;
+
+mock.module("../security/secure-keys.js", () => ({
+  getSecureKeyAsync: async (key: string) => mockSecureKeys[key] ?? null,
+  setSecureKeyAsync: async (key: string, value: string) => {
+    mockSecureKeys[key] = value;
+    return true;
+  },
+  deleteSecureKeyAsync: async (key: string) => {
+    delete mockSecureKeys[key];
+    return true;
+  },
+}));
+
+mock.module("../calls/twilio-rest.js", () => ({
+  hasTwilioCredentials: () => false,
+}));
+
+mock.module("../calls/twilio-config.js", () => ({
+  resolveTwilioPhoneNumber: () => undefined,
+}));
+
+mock.module("./channel-invite-transports/whatsapp.js", () => ({
+  resolveWhatsAppDisplayNumber: () => undefined,
+}));
+
+type SocketHealth = {
+  channel: string;
+  status: "connected" | "disconnected" | "not_configured" | "unsupported";
+  lastLivenessAt?: number;
+};
+
+/**
+ * Every channel the socket-health reader was asked about, in order.
+ *
+ * The reader takes the channel as an argument and one function now serves
+ * every socket-backed channel, so a probe naming the wrong one would report a
+ * different channel's connection as its own and no type would notice.
+ */
+let askedChannels: string[];
+let socketHealth: SocketHealth | Error;
+
+mock.module("../channels/gateway-channel-socket-health.js", () => ({
+  readChannelSocketHealth: async (channel: string) => {
+    askedChannels.push(channel);
+    if (socketHealth instanceof Error) {
+      throw socketHealth;
+    }
+    return socketHealth;
+  },
+}));
+
+beforeEach(() => {
+  mockSecureKeys = {};
+  askedChannels = [];
+  socketHealth = { channel: "discord", status: "connected" };
+});
+
+async function runDiscordProbe() {
+  const { createReadinessService } =
+    await import("../runtime/channel-readiness-service.js");
+  return createReadinessService().getReadiness("discord", false);
+}
+
+function findCheck(
+  snapshot: Awaited<ReturnType<typeof runDiscordProbe>>[number],
+  name: string,
+) {
+  return snapshot.localChecks.find((c) => c.name === name)!;
+}
+
+describe("discord readiness", () => {
+  test("asks the gateway about Discord's own socket", async () => {
+    await runDiscordProbe();
+
+    expect(askedChannels).toEqual(["discord"]);
+  });
+
+  test("reports a missing bot token", async () => {
+    const [snapshot] = await runDiscordProbe();
+
+    const credential = findCheck(snapshot, "bot_token");
+    expect(credential.passed).toBe(false);
+    expect(snapshot.setupStatus).toBe("not_configured");
+  });
+
+  test("a stored token and a live connection read as ready", async () => {
+    mockSecureKeys[credentialKey("discord_channel", "bot_token")] = "bot-fake";
+    socketHealth = {
+      channel: "discord",
+      status: "connected",
+      lastLivenessAt: Date.parse("2026-08-21T17:00:00.000Z"),
+    };
+
+    const [snapshot] = await runDiscordProbe();
+
+    expect(findCheck(snapshot, "bot_token").passed).toBe(true);
+    const delivery = findCheck(snapshot, "inbound_delivery");
+    expect(delivery.passed).toBe(true);
+    expect(delivery.message).toContain("Discord");
+    expect(delivery.message).toContain("2026-08-21T17:00:00.000Z");
+    expect(snapshot.ready).toBe(true);
+  });
+
+  test("a dead socket reads as configured and failing, not unconfigured", async () => {
+    mockSecureKeys[credentialKey("discord_channel", "bot_token")] = "bot-fake";
+    socketHealth = { channel: "discord", status: "disconnected" };
+
+    const [snapshot] = await runDiscordProbe();
+
+    // The distinction the operational kind exists for: setup finished, and the
+    // channel is down. Reporting it as unconfigured would send someone back
+    // through a setup flow that has nothing left to do.
+    expect(snapshot.setupStatus).toBe("ready");
+    expect(snapshot.health).toBe("failing");
+    expect(snapshot.ready).toBe(false);
+    expect(findCheck(snapshot, "inbound_delivery").message).toMatch(
+      /not reaching this assistant/i,
+    );
+  });
+
+  test("an unreachable gateway is indeterminate, never a fault", async () => {
+    mockSecureKeys[credentialKey("discord_channel", "bot_token")] = "bot-fake";
+    socketHealth = new Error("gateway down");
+
+    const [snapshot] = await runDiscordProbe();
+
+    const delivery = findCheck(snapshot, "inbound_delivery");
+    expect(delivery.passed).toBe(true);
+    expect(delivery.indeterminate).toBe(true);
+    // Not evidence of a fault, so it may not show the channel as broken, and
+    // not evidence of delivery either, so it may not make it ready.
+    expect(snapshot.health).not.toBe("failing");
+  });
+
+  test("Discord runs no remote checks, so nothing calls out to it", async () => {
+    mockSecureKeys[credentialKey("discord_channel", "bot_token")] = "bot-fake";
+
+    const { createReadinessService } =
+      await import("../runtime/channel-readiness-service.js");
+    const [snapshot] = await createReadinessService().getReadiness(
+      "discord",
+      true,
+    );
+
+    // One bot token serves both the gateway connection and the sends, so a
+    // live socket already proves the credential a send would use.
+    expect(snapshot.remoteChecks ?? []).toEqual([]);
+  });
+});

--- a/assistant/src/__tests__/channel-readiness-discord.test.ts
+++ b/assistant/src/__tests__/channel-readiness-discord.test.ts
@@ -37,9 +37,9 @@ type SocketHealth = {
 /**
  * Every channel the socket-health reader was asked about, in order.
  *
- * The reader takes the channel as an argument and one function now serves
- * every socket-backed channel, so a probe naming the wrong one would report a
- * different channel's connection as its own and no type would notice.
+ * The reader takes the channel as an argument and one function serves every
+ * socket-backed channel, so a probe naming the wrong one reports a different
+ * channel's connection as its own and no type notices.
  */
 let askedChannels: string[];
 let socketHealth: SocketHealth | Error;

--- a/assistant/src/__tests__/channel-readiness-discord.test.ts
+++ b/assistant/src/__tests__/channel-readiness-discord.test.ts
@@ -44,6 +44,18 @@ type SocketHealth = {
 let askedChannels: string[];
 let socketHealth: SocketHealth | Error;
 
+/** How many channels the gateway reports on Discord's allow-list. */
+let admittedChannelCount: number | Error;
+
+mock.module("../channels/gateway-discord-admission.js", () => ({
+  readDiscordAdmission: async () => {
+    if (admittedChannelCount instanceof Error) {
+      throw admittedChannelCount;
+    }
+    return { admittedChannelCount };
+  },
+}));
+
 mock.module("../channels/gateway-channel-socket-health.js", () => ({
   readChannelSocketHealth: async (channel: string) => {
     askedChannels.push(channel);
@@ -58,6 +70,7 @@ beforeEach(() => {
   mockSecureKeys = {};
   askedChannels = [];
   socketHealth = { channel: "discord", status: "connected" };
+  admittedChannelCount = 1;
 });
 
 async function runDiscordProbe() {
@@ -88,8 +101,9 @@ describe("discord readiness", () => {
     expect(snapshot.setupStatus).toBe("not_configured");
   });
 
-  test("a stored token and a live connection read as ready", async () => {
+  test("a token, a live connection and an allow-list read as ready", async () => {
     mockSecureKeys[credentialKey("discord_channel", "bot_token")] = "bot-fake";
+    admittedChannelCount = 2;
     socketHealth = {
       channel: "discord",
       status: "connected",
@@ -103,7 +117,54 @@ describe("discord readiness", () => {
     expect(delivery.passed).toBe(true);
     expect(delivery.message).toContain("Discord");
     expect(delivery.message).toContain("2026-08-21T17:00:00.000Z");
+    expect(findCheck(snapshot, "guild_admission").message).toContain(
+      "2 channels",
+    );
     expect(snapshot.ready).toBe(true);
+  });
+
+  test("an empty allow-list is unfinished setup, not a live channel", async () => {
+    mockSecureKeys[credentialKey("discord_channel", "bot_token")] = "bot-fake";
+    admittedChannelCount = 0;
+
+    const [snapshot] = await runDiscordProbe();
+
+    // A connected socket that admits nothing still drops every guild message,
+    // so claiming ready here would promise delivery the gate is refusing.
+    const admission = findCheck(snapshot, "guild_admission");
+    expect(admission.passed).toBe(false);
+    expect(snapshot.setupStatus).toBe("incomplete");
+    expect(snapshot.ready).toBe(false);
+
+    // And it is a setup step rather than an outage: direct messages carry no
+    // guild and never meet this gate, so the connection itself is fine.
+    expect(snapshot.health).not.toBe("failing");
+    expect(findCheck(snapshot, "inbound_delivery").passed).toBe(true);
+  });
+
+  test("one admitted channel reads in the singular", async () => {
+    mockSecureKeys[credentialKey("discord_channel", "bot_token")] = "bot-fake";
+    admittedChannelCount = 1;
+
+    const [snapshot] = await runDiscordProbe();
+
+    expect(findCheck(snapshot, "guild_admission").message).toContain(
+      "1 channel",
+    );
+    expect(findCheck(snapshot, "guild_admission").message).not.toContain(
+      "1 channels",
+    );
+  });
+
+  test("an unreachable gateway does not claim the allow-list is empty", async () => {
+    mockSecureKeys[credentialKey("discord_channel", "bot_token")] = "bot-fake";
+    admittedChannelCount = new Error("gateway down");
+
+    const [snapshot] = await runDiscordProbe();
+
+    const admission = findCheck(snapshot, "guild_admission");
+    expect(admission.passed).toBe(true);
+    expect(admission.indeterminate).toBe(true);
   });
 
   test("a dead socket reads as configured and failing, not unconfigured", async () => {

--- a/assistant/src/channels/gateway-discord-admission.ts
+++ b/assistant/src/channels/gateway-discord-admission.ts
@@ -1,0 +1,32 @@
+/**
+ * Daemon-side reader for how much Discord admits.
+ *
+ * The gateway owns the allow-list and the drop decision it feeds; the
+ * readiness surface that reports channel setup to the user lives here. This is
+ * the relay between them, and it exists for the same reason the socket-health
+ * relay does: the fact lives on one side of the boundary and is reported from
+ * the other.
+ */
+
+import {
+  type DiscordAdmissionIpcResponse,
+  DiscordAdmissionIpcResponseSchema,
+} from "@vellumai/gateway-client/gateway-ipc-contracts";
+
+import { ipcCallPersistentValidated } from "../ipc/gateway-validated-call.js";
+
+/**
+ * Ask the gateway how many channels Discord's allow-list admits.
+ *
+ * Throws on transport failure rather than reporting zero: an unreachable
+ * gateway is a fact about the gateway, and answering zero would tell an
+ * operator their allow-list is empty when nobody looked. Callers treat a throw
+ * as indeterminate.
+ */
+export async function readDiscordAdmission(): Promise<DiscordAdmissionIpcResponse> {
+  return ipcCallPersistentValidated(
+    "discord_admission",
+    {},
+    DiscordAdmissionIpcResponseSchema,
+  );
+}

--- a/assistant/src/runtime/channel-readiness-service.ts
+++ b/assistant/src/runtime/channel-readiness-service.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 
 import { resolveTwilioPhoneNumber } from "../calls/twilio-config.js";
 import { hasTwilioCredentials } from "../calls/twilio-rest.js";
+import { CHANNEL_METADATA } from "../channels/types.js";
 import { getNestedValue, loadRawConfig } from "../config/loader.js";
 import { hasWebhookRoutingConfigured } from "../config/webhook-routing.js";
 import { credentialKey } from "../security/credential-key.js";
@@ -365,9 +366,11 @@ const whatsappProbe: ChannelProbe = {
 /**
  * Ask the gateway whether a socket-backed channel's connection is receiving.
  *
- * One function for every such channel, matching the IPC route it reads: the
- * question and the answer are the same wherever a socket carries inbound, and
- * only the name in the message differs.
+ * One function for every such channel, matching the IPC route it reads, which
+ * is keyed by channel for the same reason: the question and the answer are the
+ * same wherever a socket carries inbound. A channel whose ingress is not a
+ * gateway-owned socket answers `unsupported`, which reads as indeterminate
+ * rather than a fault, so asking is always safe.
  *
  * Distinct from the credential checks: valid tokens establish that the
  * provider would accept us, not that anything is arriving. A socket can be
@@ -397,9 +400,12 @@ const whatsappProbe: ChannelProbe = {
  * meaning.
  */
 async function checkSocketInboundDelivery(
-  channel: "slack" | "discord",
-  label: string,
+  channel: ChannelId,
 ): Promise<ReadinessCheckResult> {
+  // The channel's own display name, so a socket-backed channel added later
+  // needs no string decision here. Falls back to the id for a channel with no
+  // metadata entry, which is every channel clients are not offered.
+  const label = CHANNEL_METADATA[channel]?.label ?? channel;
   // Imported here rather than at module scope, matching the Telegram probe:
   // the gateway IPC client pulls in a module graph that unrelated consumers of
   // this service should not have to mock.
@@ -463,7 +469,7 @@ const slackProbe: ChannelProbe = {
         "app_token",
         "Slack app token",
       ),
-      await checkSocketInboundDelivery("slack", "Slack Socket Mode"),
+      await checkSocketInboundDelivery("slack"),
     ];
   },
   async runRemoteChecks(): Promise<ReadinessCheckResult[]> {
@@ -569,7 +575,7 @@ const discordProbe: ChannelProbe = {
         "bot_token",
         "Discord bot token",
       ),
-      await checkSocketInboundDelivery("discord", "The Discord gateway"),
+      await checkSocketInboundDelivery("discord"),
     ];
   },
 };

--- a/assistant/src/runtime/channel-readiness-service.ts
+++ b/assistant/src/runtime/channel-readiness-service.ts
@@ -548,6 +548,44 @@ const slackProbe: ChannelProbe = {
   },
 };
 
+/**
+ * Whether Discord admits anything in the guilds it has joined.
+ *
+ * A configuration check rather than an operational one, and the distinction
+ * carries the meaning. An empty allow-list is a setup step nobody finished,
+ * not a channel that broke: direct messages reach the assistant either way,
+ * because a message with no guild never meets this gate. Reporting it as
+ * failing health would send an operator to look for an outage that is not
+ * there, and reporting it as ready would claim delivery while every guild
+ * message is dropped.
+ *
+ * An unreachable gateway is indeterminate, matching the socket check beside
+ * it: nobody looked, so nothing is claimed either way.
+ */
+async function checkDiscordGuildAdmission(): Promise<ReadinessCheckResult> {
+  const { readDiscordAdmission } =
+    await import("../channels/gateway-discord-admission.js");
+
+  let admitted;
+  try {
+    admitted = (await readDiscordAdmission()).admittedChannelCount;
+  } catch {
+    return {
+      name: "guild_admission",
+      passed: true,
+      message: "Could not reach the gateway to read Discord's allow-list",
+      indeterminate: true,
+    };
+  }
+
+  return check(
+    "guild_admission",
+    admitted > 0,
+    `Discord may act in ${admitted} channel${admitted === 1 ? "" : "s"}`,
+    "Discord is in no channel's allow-list, so every guild message is dropped. Add channel ids to `discord.allowedChannelIds`",
+  );
+}
+
 // ── Discord Probe ───────────────────────────────────────────────────────────
 
 /**
@@ -576,6 +614,7 @@ const discordProbe: ChannelProbe = {
         "Discord bot token",
       ),
       await checkSocketInboundDelivery("discord"),
+      await checkDiscordGuildAdmission(),
     ];
   },
 };

--- a/assistant/src/runtime/channel-readiness-service.ts
+++ b/assistant/src/runtime/channel-readiness-service.ts
@@ -772,7 +772,13 @@ export class ChannelReadinessService {
 
 // ── Factory ─────────────────────────────────────────────────────────────────
 
-/** Create a service instance with built-in Voice, Telegram, Email, WhatsApp, and Slack probes registered. */
+/**
+ * A service with every built-in probe registered.
+ *
+ * The registrations below are the list; naming them here as well gives the set
+ * a second home that drifts the moment a channel is added, which is what it
+ * did.
+ */
 export function createReadinessService(): ChannelReadinessService {
   const service = new ChannelReadinessService();
   service.registerProbe(voiceProbe);

--- a/assistant/src/runtime/channel-readiness-service.ts
+++ b/assistant/src/runtime/channel-readiness-service.ts
@@ -363,11 +363,15 @@ const whatsappProbe: ChannelProbe = {
 // ── Slack Probe ─────────────────────────────────────────────────────────────
 
 /**
- * Ask the gateway whether Slack's Socket Mode connection is receiving.
+ * Ask the gateway whether a socket-backed channel's connection is receiving.
  *
- * Distinct from the credential checks: valid tokens and a reachable
- * `auth.test` establish that Slack would accept us, not that anything is
- * arriving. A socket can be open at the transport layer and deliver nothing.
+ * One function for every such channel, matching the IPC route it reads: the
+ * question and the answer are the same wherever a socket carries inbound, and
+ * only the name in the message differs.
+ *
+ * Distinct from the credential checks: valid tokens establish that the
+ * provider would accept us, not that anything is arriving. A socket can be
+ * open at the transport layer and deliver nothing.
  *
  * Three outcomes, matching the Telegram probe:
  *
@@ -392,7 +396,10 @@ const whatsappProbe: ChannelProbe = {
  * to die and recover. Placement is a cost decision here; `kind` carries the
  * meaning.
  */
-async function checkSlackInboundDelivery(): Promise<ReadinessCheckResult> {
+async function checkSocketInboundDelivery(
+  channel: "slack" | "discord",
+  label: string,
+): Promise<ReadinessCheckResult> {
   // Imported here rather than at module scope, matching the Telegram probe:
   // the gateway IPC client pulls in a module graph that unrelated consumers of
   // this service should not have to mock.
@@ -401,13 +408,13 @@ async function checkSlackInboundDelivery(): Promise<ReadinessCheckResult> {
 
   let health;
   try {
-    health = await readChannelSocketHealth("slack");
+    health = await readChannelSocketHealth(channel);
   } catch {
     return {
       name: "inbound_delivery",
       kind: "operational",
       passed: true,
-      message: "Could not reach the gateway to read the Slack connection state",
+      message: `Could not reach the gateway to read the ${label} connection state`,
       indeterminate: true,
     };
   }
@@ -419,8 +426,8 @@ async function checkSlackInboundDelivery(): Promise<ReadinessCheckResult> {
       passed: true,
       message:
         health.status === "not_configured"
-          ? "Slack Socket Mode is not running, because its credentials are not configured"
-          : "Slack does not report a gateway-owned socket",
+          ? `${label} is not connected, because its credentials are not configured`
+          : `${label} does not report a gateway-owned socket`,
       indeterminate: true,
     };
   }
@@ -433,8 +440,8 @@ async function checkSlackInboundDelivery(): Promise<ReadinessCheckResult> {
     ...check(
       "inbound_delivery",
       health.status === "connected",
-      `Slack is delivering to this assistant (${lastProof})`,
-      "Slack Socket Mode holds no live connection, so inbound messages are not reaching this assistant",
+      `${label} is delivering to this assistant (${lastProof})`,
+      `${label} holds no live connection, so inbound messages are not reaching this assistant`,
     ),
     kind: "operational",
   };
@@ -456,7 +463,7 @@ const slackProbe: ChannelProbe = {
         "app_token",
         "Slack app token",
       ),
-      await checkSlackInboundDelivery(),
+      await checkSocketInboundDelivery("slack", "Slack Socket Mode"),
     ];
   },
   async runRemoteChecks(): Promise<ReadinessCheckResult[]> {
@@ -532,6 +539,38 @@ const slackProbe: ChannelProbe = {
         ),
       ];
     }
+  },
+};
+
+// ── Discord Probe ───────────────────────────────────────────────────────────
+
+/**
+ * Discord readiness.
+ *
+ * One credential and one socket, which is the whole of it. Discord holds a
+ * Gateway connection rather than receiving webhooks, so there is no ingress
+ * routing to check: nothing has to reach this deployment from outside for
+ * inbound to work.
+ *
+ * No remote check either, and that is a decision rather than an omission. The
+ * remote bucket exists to ask a provider whether it would accept us, which for
+ * Slack is worth asking separately because its socket authenticates with a
+ * different token than its sends. Discord uses one bot token for both, so a
+ * live Gateway connection already proves the token the sends will use, and a
+ * call to `GET /users/@me` would restate it a cache interval later.
+ */
+const discordProbe: ChannelProbe = {
+  channel: "discord",
+  async runLocalChecks(): Promise<ReadinessCheckResult[]> {
+    return [
+      await checkCredential(
+        "bot_token",
+        "discord_channel",
+        "bot_token",
+        "Discord bot token",
+      ),
+      await checkSocketInboundDelivery("discord", "The Discord gateway"),
+    ];
   },
 };
 
@@ -735,5 +774,6 @@ export function createReadinessService(): ChannelReadinessService {
   service.registerProbe(emailProbe);
   service.registerProbe(whatsappProbe);
   service.registerProbe(slackProbe);
+  service.registerProbe(discordProbe);
   return service;
 }

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -228,7 +228,10 @@ import { inviteRoutes } from "./ipc/invite-handlers.js";
 import { verificationSessionRoutes } from "./ipc/verification-session-handlers.js";
 import { guardianRequestRoutes } from "./ipc/guardian-request-handlers.js";
 import { featureFlagRoutes } from "./ipc/feature-flag-handlers.js";
-import { admissionPolicyRoutes } from "./ipc/admission-policy-handlers.js";
+import {
+  admissionPolicyRoutes,
+  createDiscordAdmissionRoutes,
+} from "./ipc/admission-policy-handlers.js";
 import { channelPermissionRoutes } from "./ipc/channel-permission-handlers.js";
 import { trustVerdictRoutes } from "./ipc/trust-verdict-handlers.js";
 import { guardianDeliveryRoutes } from "./ipc/guardian-delivery-handlers.js";
@@ -2889,6 +2892,7 @@ async function main() {
     ...slackThreadRoutes,
     ...thresholdRoutes,
     ...admissionPolicyRoutes,
+    ...createDiscordAdmissionRoutes(configFileCache),
     ...channelPermissionRoutes,
     ...trustVerdictRoutes,
     ...guardianDeliveryRoutes,

--- a/gateway/src/ipc/admission-policy-handlers.ts
+++ b/gateway/src/ipc/admission-policy-handlers.ts
@@ -8,6 +8,8 @@
 
 import { z } from "zod";
 
+import type { ConfigFileCache } from "../config-file-cache.js";
+import { readDiscordAllowedChannelIds } from "../discord/allowed-channels.js";
 import { resolveAdmissionPolicy } from "../risk/admission-policy-cache.js";
 import type { IpcRoute } from "./server.js";
 
@@ -25,3 +27,24 @@ export const admissionPolicyRoutes: IpcRoute[] = [
     },
   },
 ];
+
+/**
+ * How many channels Discord's allow-list admits.
+ *
+ * Read through the same helper the gate reads, so the number the readiness
+ * surface reports and the number the drop decision uses cannot disagree about
+ * what an empty or comma-separated setting means.
+ */
+export function createDiscordAdmissionRoutes(
+  configFileCache: ConfigFileCache,
+): IpcRoute[] {
+  return [
+    {
+      method: "discord_admission",
+      handler: () => ({
+        admittedChannelCount:
+          readDiscordAllowedChannelIds(configFileCache).size,
+      }),
+    },
+  ];
+}

--- a/packages/gateway-client/src/gateway-ipc-contracts.ts
+++ b/packages/gateway-client/src/gateway-ipc-contracts.ts
@@ -555,3 +555,24 @@ export const ChannelSocketHealthIpcResponseSchema = z.object({
 export type ChannelSocketHealthIpcResponse = z.infer<
   typeof ChannelSocketHealthIpcResponseSchema
 >;
+
+/**
+ * Whether Discord admits anything in the guilds it has joined.
+ *
+ * Discord's allow-list is fail-closed and lives in gateway-owned config: an
+ * absent or empty setting admits nothing, because being invited to a guild is
+ * not consent to every channel in it. The daemon owns the readiness surface
+ * that reports this, so the count has to cross the boundary, the same way a
+ * socket's liveness does.
+ *
+ * Discord-shaped rather than channel-keyed, because Discord is the only
+ * channel with an allow-list. A second one generalizes this.
+ */
+export const DiscordAdmissionIpcResponseSchema = z.object({
+  /** How many channel ids the bot may act in. Zero admits no guild message. */
+  admittedChannelCount: z.number().int().nonnegative(),
+});
+
+export type DiscordAdmissionIpcResponse = z.infer<
+  typeof DiscordAdmissionIpcResponseSchema
+>;


### PR DESCRIPTION
## TL;DR

Discord had no readiness probe, so nothing could answer "is Discord configured, and is it actually delivering?" — not the CLI, not the API, not any client downstream. It has one now.

## Everything it needs was already built

This is a twenty-line gap in a chain that was otherwise complete:

- The gateway's Discord client implements `getConnectionHealth()`.
- It is registered on the `channel_socket_health` IPC route, beside Slack's.
- The daemon's `readChannelSocketHealth(channel)` already takes the channel as an argument.
- The route's own docstring says it is "keyed by channel rather than split per channel, because the question and the answer are the same for every socket transport."

Only the daemon-side probe was missing.

## The seam

`checkSlackInboundDelivery` becomes `checkSocketInboundDelivery(channel, label)`, which is what the route it reads already assumed. Slack's wording is unchanged; Discord passes its own label. One function for every socket-backed channel rather than one per channel, so the next one costs a call rather than a copy.

## Two deliberate absences

**No remote check.** The remote bucket exists to ask a provider whether it would accept us. That is worth asking separately for Slack because its socket authenticates with an `app_token` while its sends use a `bot_token`. Discord uses one bot token for both, so a live Gateway connection already proves the credential a send would use, and `GET /users/@me` would restate it a cache interval later.

**No ingress check.** Discord holds a Gateway connection rather than receiving webhooks, so nothing has to reach this deployment from outside for inbound to work. `checkIngress` would be asking about routing Discord does not use.

## Before and after

| | Before | After |
| --- | --- | --- |
| `channels readiness` for Discord | No snapshot at all | Credential + live-connection checks |
| A stored token, live socket | nothing | ready |
| A stored token, dead socket | nothing | configured, health failing |
| Gateway unreachable | nothing | indeterminate, never a fault |

## Testing

Six cases, including the one the parameterization makes possible and no type would catch: **a probe asking about another channel's socket.** The existing Slack test mocks the reader while ignoring its channel argument, so nothing there would notice. The new test captures every channel asked about and asserts Discord's probe asks only about Discord.

The rest cover the three-outcome discipline the Slack and Telegram probes established: a dead socket is configured-and-failing rather than unconfigured, and an unreachable gateway is indeterminate, so it neither marks the channel broken nor makes it ready.

## What this does not do

It does not add Discord to the standalone Channels page. `SETUP_CHANNEL_IDS` and the setup-prompt maps are a hand-kept fourth copy of a channel list, and the daemon already serves everything they hold, including the setup prompts. Threading Discord through them would be the fifth patch of that seam; deriving that page from `/v1/channels/available` joined with readiness removes the lists entirely and makes the next channel cost nothing. That is the follow-up this probe unblocks.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41266" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->