### PR TITLE
feat(web): give a document a header, and a way to rename it

### DIFF
--- a/clients/web/src/domains/chat/components/chat-content-layout.tsx
+++ b/clients/web/src/domains/chat/components/chat-content-layout.tsx
@@ -454,6 +454,14 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
             assistantId={assistantId}
             surfaceId={openedDocumentState.surfaceId}
             conversationId={openedDocumentState.conversationId}
+            onRenamed={(documentName) =>
+              useViewerStore
+                .getState()
+                .renameOpenedDocument(
+                  openedDocumentState.surfaceId,
+                  documentName,
+                )
+            }
             onSubmitFeedback={() => {
               const prompt = `Please review and address my comments on "${openedDocumentState.documentName}".`;
               navigate(

--- a/clients/web/src/domains/chat/components/conversation-assets-pill.tsx
+++ b/clients/web/src/domains/chat/components/conversation-assets-pill.tsx
@@ -301,13 +301,20 @@ export function ConversationAssetsPill({
     <>
       <Popover.Root open={open} onOpenChange={handleOpenChange}>
         <Popover.Trigger asChild>{trigger}</Popover.Trigger>
+        {/*
+          The popover keeps its own `p-2` inset and the heading takes the
+          same `px-2 py-1.5` a `Menu.Label` does, which puts the heading on
+          the column the rows' icons start from. Hand-rolled padding had the
+          heading inset 12px against rows inset 16px, and a 4px gap under it
+          against 8px everywhere else.
+        */}
         <Popover.Content
           side="bottom"
           align="center"
           sideOffset={8}
-          className="w-60 p-0"
+          className="w-60"
         >
-          <div className="px-3 pt-3 pb-1">
+          <div className="px-2 py-1.5">
             <Typography
               variant="label-small-default"
               className="text-[var(--content-tertiary)]"
@@ -315,9 +322,7 @@ export function ConversationAssetsPill({
               {t("conversationAssets.heading")}
             </Typography>
           </div>
-          <div className="max-h-[240px] overflow-y-auto px-2 pb-2">
-            {assetItems}
-          </div>
+          <div className="max-h-[240px] overflow-y-auto">{assetItems}</div>
         </Popover.Content>
       </Popover.Root>
       <DeleteAppDialog

--- a/clients/web/src/domains/chat/components/conversation-assets-pill.tsx
+++ b/clients/web/src/domains/chat/components/conversation-assets-pill.tsx
@@ -302,11 +302,11 @@ export function ConversationAssetsPill({
       <Popover.Root open={open} onOpenChange={handleOpenChange}>
         <Popover.Trigger asChild>{trigger}</Popover.Trigger>
         {/*
-          The popover keeps its own `p-2` inset and the heading takes the
-          same `px-2 py-1.5` a `Menu.Label` does, which puts the heading on
-          the column the rows' icons start from. Hand-rolled padding had the
-          heading inset 12px against rows inset 16px, and a 4px gap under it
-          against 8px everywhere else.
+          The popover keeps its own `p-2` inset and the heading sits at
+          `px-2`, which is the column the rows' icons start from. Its own
+          vertical padding is only what separates it from the first row: the
+          label is 10px on a `line-height: 1`, and the popover's inset above
+          and the row's 8px of padding below already carry the rest.
         */}
         <Popover.Content
           side="bottom"
@@ -314,7 +314,7 @@ export function ConversationAssetsPill({
           sideOffset={8}
           className="w-60"
         >
-          <div className="px-2 py-1.5">
+          <div className="px-2 pb-1">
             <Typography
               variant="label-small-default"
               className="text-[var(--content-tertiary)]"

--- a/clients/web/src/domains/chat/components/document-card.tsx
+++ b/clients/web/src/domains/chat/components/document-card.tsx
@@ -1,6 +1,7 @@
 /**
- * The card that stands for a document in the transcript: a bordered row naming
- * the document, with an "opens it" affordance.
+ * The affordance that stands for a document in the transcript: a primary
+ * button naming it, a document glyph on the left and a chevron on the right,
+ * held in its active state while that document is the one on screen.
  *
  * A document reaches the transcript two ways: the daemon's inline
  * `document_preview` surface (`DocumentPreviewSurface`) and the
@@ -9,8 +10,8 @@
  * the two cannot drift into looking like different kinds of thing.
  */
 
-import { ArrowUpRight, FileText } from "lucide-react";
-import type { KeyboardEvent } from "react";
+import { Button } from "@vellumai/design-library";
+import { ChevronRight, FileText } from "lucide-react";
 
 export interface DocumentCardProps {
   /** Title to show for the document. */
@@ -21,6 +22,8 @@ export interface DocumentCardProps {
   content?: string;
   /** Opens the document. Omitted for a card that is not actionable. */
   onOpen?: () => void;
+  /** The document is the one the viewer is currently showing. */
+  isOpen?: boolean;
   /** Accessible name for the open gesture. */
   ariaLabel?: string;
   testId?: string;
@@ -31,50 +34,42 @@ export function DocumentCard({
   mimeType,
   content,
   onOpen,
+  isOpen = false,
   ariaLabel,
   testId,
 }: DocumentCardProps) {
-  const handleKeyDown = (e: KeyboardEvent) => {
-    if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault();
-      onOpen?.();
-    }
-  };
-
   return (
-    <div className="max-w-sm">
-      <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-lift)] p-4">
-        <div
-          role={onOpen ? "button" : undefined}
-          tabIndex={onOpen ? 0 : undefined}
+    <div className="flex max-w-sm flex-col gap-2">
+      <div className="flex min-w-0 items-center gap-2">
+        <Button
+          variant="primary"
+          active={isOpen}
+          aria-pressed={onOpen ? isOpen : undefined}
           aria-label={onOpen ? ariaLabel : undefined}
           data-testid={testId}
+          disabled={!onOpen}
           onClick={onOpen}
-          onKeyDown={onOpen ? handleKeyDown : undefined}
-          className={onOpen ? "-m-2 cursor-pointer rounded-lg p-2" : undefined}
+          leftIcon={<FileText />}
+          rightIcon={<ChevronRight />}
+          className="min-w-0 max-w-full"
         >
-          <div className="flex items-center gap-2">
-            <FileText className="h-4 w-4 shrink-0 text-[var(--content-quiet)]" />
-            <h3 className="min-w-0 truncate text-title-small text-[var(--content-strong)]">
-              {documentName}
-            </h3>
-            {mimeType && (
-              <span className="rounded-full bg-[var(--tag-bg-neutral)] px-2 py-0.5 text-body-small-default text-[var(--content-tertiary)]">
-                {mimeType}
-              </span>
-            )}
-            {onOpen && (
-              <ArrowUpRight className="ml-auto h-3.5 w-3.5 shrink-0 text-[var(--content-faint)]" />
-            )}
-          </div>
-
-          {content && (
-            <pre className="mt-3 max-h-60 overflow-auto whitespace-pre-wrap rounded-md bg-[var(--surface-sunken)] p-3 text-body-small-default text-[var(--content-default)]">
-              {content}
-            </pre>
-          )}
-        </div>
+          {/* The button lays its label out as a flex item that will not
+              shrink on its own, so a long document name would push the
+              chevron out of the row rather than ellipsing. */}
+          <span className="min-w-0 truncate">{documentName}</span>
+        </Button>
+        {mimeType && (
+          <span className="shrink-0 rounded-full bg-[var(--tag-bg-neutral)] px-2 py-0.5 text-body-small-default text-[var(--content-tertiary)]">
+            {mimeType}
+          </span>
+        )}
       </div>
+
+      {content && (
+        <pre className="max-h-60 overflow-auto whitespace-pre-wrap rounded-md border border-[var(--border-subtle)] bg-[var(--surface-sunken)] p-3 text-body-small-default text-[var(--content-default)]">
+          {content}
+        </pre>
+      )}
     </div>
   );
 }

--- a/clients/web/src/domains/chat/components/document-viewer-container.test.tsx
+++ b/clients/web/src/domains/chat/components/document-viewer-container.test.tsx
@@ -1,6 +1,6 @@
 /**
- * Tests for the document viewer's autosave: where a pending edit goes when the
- * container is taken down, and what it refreshes once it lands.
+ * Tests for the document viewer's writes: where a pending edit goes when the
+ * container is taken down, and what a rename sends along with the new title.
  *
  * The editor and the comment panel are stubbed. What this covers is the
  * container's own job (debounce, flush, cache invalidation), not Tiptap's.
@@ -14,6 +14,7 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 
@@ -59,7 +60,9 @@ interface RenderResult {
   unmount: () => void;
 }
 
-function renderViewer(): RenderResult {
+function renderViewer(
+  props: { onRenamed?: (documentName: string) => void } = {},
+): RenderResult {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
@@ -73,6 +76,7 @@ function renderViewer(): RenderResult {
       onClose={() => {}}
       surfaceId="surf-1"
       conversationId="conv-1"
+      onRenamed={props.onRenamed}
     />,
     {
       wrapper: ({ children }: { children: ReactNode }) => (
@@ -96,7 +100,22 @@ async function typeIntoEditor(): Promise<void> {
 afterEach(() => {
   cleanup();
   saveDocumentContent.mockClear();
+  // Radix locks body pointer events while a menu is open; a test that leaves
+  // one open must not disable pointers for the next one.
+  document.body.style.pointerEvents = "";
 });
+
+/** Walk the overflow menu into the rename dialog and submit `name`. */
+async function renameTo(name: string): Promise<void> {
+  const user = userEvent.setup();
+  await user.click(screen.getByRole("button", { name: "Document options" }));
+  await user.click(await screen.findByRole("menuitem", { name: "Rename" }));
+
+  const input = await screen.findByLabelText("Name");
+  await user.clear(input);
+  await user.type(input, name);
+  await user.click(screen.getByRole("button", { name: "Save" }));
+}
 
 describe("DocumentViewerContainer autosave", () => {
   test("an edit still pending when the container goes away is flushed", async () => {
@@ -132,6 +151,52 @@ describe("DocumentViewerContainer autosave", () => {
     const { unmount } = renderViewer();
     unmount();
 
+    expect(saveDocumentContent).not.toHaveBeenCalled();
+  });
+});
+
+describe("DocumentViewerContainer rename", () => {
+  test("the rename writes the new title with the body the editor holds", async () => {
+    const onRenamed = mock((_documentName: string) => {});
+    renderViewer({ onRenamed });
+    await typeIntoEditor();
+
+    await renameTo("meeting notes");
+
+    // The caller takes the name straight away, the way a conversation rename
+    // does, rather than after the round trip.
+    expect(onRenamed).toHaveBeenCalledTimes(1);
+    expect(onRenamed.mock.calls[0]![0]).toBe("meeting notes");
+
+    await waitFor(() => expect(saveDocumentContent).toHaveBeenCalledTimes(1));
+    expect(saveDocumentContent.mock.calls[0]![0]).toEqual({
+      source: "document",
+      assistantId: "asst-1",
+      surfaceId: "surf-1",
+      conversationId: "conv-1",
+      title: "meeting notes",
+    });
+    // The edit was still inside the debounce window: the rename carries it
+    // instead of leaving it to a save that would restore the old title.
+    expect(saveDocumentContent.mock.calls[0]![1]).toBe("edited body");
+  });
+
+  test("the folded-in edit is not written a second time by the dead timer", async () => {
+    renderViewer();
+    await typeIntoEditor();
+    await renameTo("meeting notes");
+
+    await new Promise((resolve) => setTimeout(resolve, 1200));
+    expect(saveDocumentContent).toHaveBeenCalledTimes(1);
+  });
+
+  test("the name it already has is not a rename, and writes nothing", async () => {
+    const onRenamed = mock((_documentName: string) => {});
+    renderViewer({ onRenamed });
+
+    await renameTo("notes.md");
+
+    expect(onRenamed).not.toHaveBeenCalled();
     expect(saveDocumentContent).not.toHaveBeenCalled();
   });
 });

--- a/clients/web/src/domains/chat/components/document-viewer-container.tsx
+++ b/clients/web/src/domains/chat/components/document-viewer-container.tsx
@@ -8,6 +8,8 @@ import { useTranslation } from "@/i18n";
  * selection are wired via React props/callbacks (no iframe postMessage).
  *
  * One backing store: a document surface in the daemon's document database.
+ * Both the autosave and the rename write through it, so the title the header
+ * shows and the body the editor holds are always sent together.
  */
 
 import {
@@ -21,14 +23,18 @@ import {
   type Ref,
 } from "react";
 
+import { useQueryClient } from "@tanstack/react-query";
+
 import { LazyBoundary } from "@/components/lazy-boundary";
-import { Button, Typography } from "@vellumai/design-library";
+import { ActionMenu, Button, toast, Typography } from "@vellumai/design-library";
 import {
   Check,
   Download,
+  Ellipsis,
   FileText,
   Loader2,
   MessageSquareText,
+  PencilLine,
   X,
 } from "lucide-react";
 
@@ -37,11 +43,15 @@ import {
   fetchComments,
 } from "@/domains/chat/api/document-comments";
 import {
+  markdownWordCount,
   saveDocumentContent,
   type DocumentSaveTarget,
 } from "@/domains/chat/api/document-save";
+import { NameInputDialog } from "@/domains/chat/components/name-input-dialog";
 import type { CommentAnchor } from "@/domains/chat/utils/tiptap-position-map";
+import { documentsGetQueryKey } from "@/generated/daemon/@tanstack/react-query.gen";
 import type { DocumentsByIdCommentsPostResponse } from "@/generated/daemon/types.gen";
+import { captureError } from "@/lib/sentry/capture-error";
 import {
   DocumentCommentPanel,
   type DocumentCommentPanelHandle,
@@ -77,6 +87,14 @@ export interface DocumentViewerContainerProps {
   conversationId: string;
   onExport?: () => void;
   onSubmitFeedback?: () => void;
+  /**
+   * The document was retitled to `documentName`. The write has already been
+   * sent; this is how the caller holding the name (the viewer store for the
+   * chat drawer, page state for the standalone route) adopts it. Called a
+   * second time with the previous name when that write fails, so an
+   * optimistic rename rolls back the way a conversation rename does.
+   */
+  onRenamed?: (documentName: string) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -113,8 +131,10 @@ export function DocumentViewerContainer({
   conversationId,
   onExport,
   onSubmitFeedback,
+  onRenamed,
 }: DocumentViewerContainerProps) {
   const { t } = useTranslation("chat");
+  const queryClient = useQueryClient();
   // Where autosave writes.
   const saveTarget: DocumentSaveTarget = {
     source: "document",
@@ -138,6 +158,11 @@ export function DocumentViewerContainer({
   const [saveStatus, setSaveStatus] = useState<"idle" | "saving" | "saved">(
     "idle",
   );
+  const [renameOpen, setRenameOpen] = useState(false);
+  // What the header's status line says when nothing is being saved. Derived
+  // from the editor's live markdown rather than the documents list, so it
+  // counts what is on screen while it is being typed.
+  const [wordCount, setWordCount] = useState(() => markdownWordCount(content));
 
   const commentPanelRef = useRef<DocumentCommentPanelHandle>(null);
   const saveTimerRef = useRef<ReturnType<typeof setTimeout>>(null);
@@ -151,6 +176,11 @@ export function DocumentViewerContainer({
   // markdown rides along so the unmount flush below has something to write.
   const saveTargetRef = useRef(saveTarget);
   const pendingMarkdownRef = useRef<string | null>(null);
+  // The last markdown the editor produced, kept past the save that wrote it.
+  // A rename posts the body along with the title, and the `content` prop is
+  // the snapshot the document loaded with: it does not follow the user's
+  // typing, so posting it would undo every edit already saved.
+  const latestMarkdownRef = useRef<string | null>(null);
   useLayoutEffect(() => {
     saveTargetRef.current = saveTarget;
   });
@@ -180,6 +210,8 @@ export function DocumentViewerContainer({
         clearTimeout(savedFadeRef.current);
       }
       pendingMarkdownRef.current = markdown;
+      latestMarkdownRef.current = markdown;
+      setWordCount(markdownWordCount(markdown));
       setSaveStatus("saving");
       saveTimerRef.current = setTimeout(() => {
         saveTimerRef.current = null;
@@ -322,6 +354,82 @@ export function DocumentViewerContainer({
   }, []);
 
   // -------------------------------------------------------------------------
+  // Rename
+  // -------------------------------------------------------------------------
+
+  /**
+   * Retitle the document. The documents API is an upsert keyed by surface, so
+   * the rename is the same write autosave makes, with a different title on it:
+   * there is no title-only endpoint to reach for.
+   *
+   * Optimistic, the way the conversation rename is: the caller adopts the new
+   * name immediately and takes the old one back if the write fails.
+   */
+  const handleRenameSubmit = useCallback(
+    (nextTitle: string) => {
+      setRenameOpen(false);
+      const title = nextTitle.trim();
+      const previousTitle = documentName;
+      if (title === "" || title === previousTitle) {
+        return;
+      }
+
+      // A debounced edit is still owed a write, and it would carry the old
+      // title. Fold it into the rename rather than racing it: this write
+      // sends the same markdown.
+      if (saveTimerRef.current) {
+        clearTimeout(saveTimerRef.current);
+        saveTimerRef.current = null;
+      }
+      if (savedFadeRef.current) {
+        clearTimeout(savedFadeRef.current);
+      }
+      pendingMarkdownRef.current = null;
+
+      onRenamed?.(title);
+      setSaveStatus("saving");
+      void saveDocumentContent(
+        { ...saveTargetRef.current, title },
+        latestMarkdownRef.current ?? content,
+      ).then(
+        () => {
+          setSaveStatus("saved");
+          savedFadeRef.current = setTimeout(() => setSaveStatus("idle"), 2000);
+          // The name is read from the documents list by the transcript card,
+          // the assets pill, and the Library. The conversation-scoped list and
+          // the assistant-wide one are separate cache entries; both carry it.
+          void queryClient.invalidateQueries({
+            queryKey: documentsGetQueryKey({
+              path: { assistant_id: assistantId },
+              query: { conversationId },
+            }),
+          });
+          void queryClient.invalidateQueries({
+            queryKey: documentsGetQueryKey({
+              path: { assistant_id: assistantId },
+            }),
+          });
+        },
+        (err: unknown) => {
+          setSaveStatus("idle");
+          onRenamed?.(previousTitle);
+          toast.error(t("documentViewerContainer.renameFailed"));
+          captureError(err, { context: "renameDocument" });
+        },
+      );
+    },
+    [
+      assistantId,
+      content,
+      conversationId,
+      documentName,
+      onRenamed,
+      queryClient,
+      t,
+    ],
+  );
+
+  // -------------------------------------------------------------------------
   // Sync anchors when panel opens
   // -------------------------------------------------------------------------
 
@@ -354,63 +462,99 @@ export function DocumentViewerContainer({
 
   return (
     <div className="flex h-full flex-col overflow-hidden rounded-xl border border-[var(--border-base)] bg-[var(--surface-overlay)]">
-      {/* Navbar */}
-      <div className="flex shrink-0 items-center gap-2 border-b border-[var(--border-base)] px-4 py-2">
-        <FileText size={16} style={{ color: "var(--content-secondary)" }} />
-        <Typography
-          variant="title-small"
-          className="min-w-0 flex-1 truncate text-[var(--content-emphasised)]"
-        >
-          {documentName}
-        </Typography>
-
-        {saveStatus !== "idle" ? (
+      {/*
+        Header. The document's identity sits in a two-line block (name over a
+        status line) so the panel opens with a heading rather than a strip of
+        controls. Everything the document can do rides in one design-library
+        overflow menu beside it, which leaves the header two affordances: the
+        menu and the way out. Comments are in there as well, because the panel
+        they open is its own answer about whether it is showing.
+      */}
+      <header className="flex shrink-0 items-start gap-3 border-b border-[var(--border-base)] bg-[var(--surface-lift)] px-4 py-3">
+        <FileText
+          size={16}
+          className="mt-1 shrink-0"
+          style={{ color: "var(--content-secondary)" }}
+        />
+        <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+          {/* `title-small` sets `line-height: 1`, which `truncate` then crops
+              descenders against. Give the line the room the font needs. */}
+          <Typography
+            variant="title-small"
+            className="truncate leading-normal text-[var(--content-emphasised)]"
+          >
+            {documentName}
+          </Typography>
           <span className="flex items-center gap-1 text-[var(--content-tertiary)]">
             {saveStatus === "saving" ? (
-              <Loader2 size={12} className="animate-spin" />
-            ) : (
-              <Check size={12} />
-            )}
+              <Loader2 size={12} className="shrink-0 animate-spin" />
+            ) : null}
+            {saveStatus === "saved" ? <Check size={12} className="shrink-0" /> : null}
             <Typography
               variant="label-small-default"
-              className="text-[var(--content-tertiary)]"
+              className="truncate text-[var(--content-tertiary)]"
             >
-              {saveStatus === "saving" ? t("documentViewerContainer.saving") : t("documentViewerContainer.saved")}
+              {saveStatus === "saving"
+                ? t("documentViewerContainer.saving")
+                : saveStatus === "saved"
+                  ? t("documentViewerContainer.saved")
+                  : t("documentViewerContainer.wordCount", {
+                      count: wordCount,
+                    })}
             </Typography>
           </span>
-        ) : null}
+        </div>
 
-        {onExport ? (
-          <Button
-            variant="ghost"
-            size="compact"
-            leftIcon={<Download />}
-            onClick={onExport}
+        <ActionMenu.Root>
+          <ActionMenu.Trigger>
+            <Button
+              variant="ghost"
+              iconOnly={<Ellipsis />}
+              aria-label={t("documentViewerContainer.menuAria")}
+              tooltip={t("documentViewerContainer.menuAria")}
+            />
+          </ActionMenu.Trigger>
+          <ActionMenu.Content
+            title={t("documentViewerContainer.menuAria")}
+            align="end"
           >
-            {t("documentViewerContainer.export")}
-          </Button>
-        ) : null}
-
-        <Button
-          variant={commentsPanelOpen ? "outlined" : "ghost"}
-          size="compact"
-          leftIcon={<MessageSquareText />}
-          onClick={toggleComments}
-          aria-label={commentsPanelOpen ? t("documentViewerContainer.closeCommentsAria") : t("documentViewerContainer.openCommentsAria")}
-          aria-pressed={commentsPanelOpen}
-        >
-          {t("documentViewerContainer.comments")}
-        </Button>
+            <ActionMenu.Item
+              icon={MessageSquareText}
+              label={commentsPanelOpen ? t("documentViewerContainer.hideComments") : t("documentViewerContainer.comments")}
+              onSelect={toggleComments}
+            />
+            <ActionMenu.Item
+              icon={PencilLine}
+              label={t("documentViewerContainer.rename")}
+              onSelect={() => setRenameOpen(true)}
+            />
+            {onExport ? (
+              <ActionMenu.Item
+                icon={Download}
+                label={t("documentViewerContainer.export")}
+                onSelect={onExport}
+              />
+            ) : null}
+          </ActionMenu.Content>
+        </ActionMenu.Root>
 
         <Button
           variant="ghost"
-          size="compact"
           iconOnly={<X />}
           onClick={onClose}
           aria-label={t("documentViewerContainer.closeDocumentAria")}
           tooltip={t("documentViewerContainer.close")}
         />
-      </div>
+      </header>
+
+      <NameInputDialog
+        open={renameOpen}
+        title={t("documentViewerContainer.renameTitle")}
+        submitLabel={t("documentViewerContainer.renameSave")}
+        initialValue={documentName}
+        onSubmit={handleRenameSubmit}
+        onCancel={() => setRenameOpen(false)}
+      />
 
       {/* Body: editor + optional comment panel */}
       <div className="relative flex min-h-0 flex-1">

--- a/clients/web/src/domains/chat/components/local-file/open-local-file.ts
+++ b/clients/web/src/domains/chat/components/local-file/open-local-file.ts
@@ -189,6 +189,19 @@ export function isDocumentOpen(
 }
 
 /**
+ * Reactive form of {@link isDocumentOpen}, composed over atomic selectors so
+ * an affordance only re-renders when the view or the opened document changes.
+ */
+export function useIsDocumentOpen(surfaceId: string | null): boolean {
+  const mainView = useViewerStore.use.mainView();
+  const openedDocument = useViewerStore.use.openedDocumentState();
+  if (surfaceId === null) {
+    return false;
+  }
+  return isDocumentOpen(mainView, openedDocument, surfaceId);
+}
+
+/**
  * The document surface the drawer is showing, or `null` when it shows nothing
  * or a read-only preview. The identity behind {@link isDocumentOpen}, for
  * callers that need to know *which* document rather than ask about one.

--- a/clients/web/src/domains/chat/components/mobile-document-overlay.tsx
+++ b/clients/web/src/domains/chat/components/mobile-document-overlay.tsx
@@ -1,7 +1,10 @@
 import { DocumentViewerContainer } from "@/domains/chat/components/document-viewer-container";
 import { FilePreviewContainer } from "@/domains/chat/components/local-file/preview/file-preview-container";
 import { useMobileOverlayViewportStyle } from "@/hooks/use-mobile-overlay-viewport-style";
-import type { OpenedDocumentState } from "@/stores/viewer-store";
+import {
+  useViewerStore,
+  type OpenedDocumentState,
+} from "@/stores/viewer-store";
 
 interface MobileDocumentOverlayProps {
   /** When `null`, the overlay renders nothing. */
@@ -64,6 +67,11 @@ export function MobileDocumentOverlay({
         assistantId={assistantId}
         surfaceId={openedDocumentState.surfaceId}
         conversationId={openedDocumentState.conversationId}
+        onRenamed={(documentName) =>
+          useViewerStore
+            .getState()
+            .renameOpenedDocument(openedDocumentState.surfaceId, documentName)
+        }
         onSubmitFeedback={onSubmitFeedback}
       />
     </div>

--- a/clients/web/src/domains/chat/components/surfaces/document-preview-surface.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/document-preview-surface.tsx
@@ -2,6 +2,7 @@ import type { Surface } from "@/domains/chat/types/types";
 import { useTranslation } from "@/i18n";
 
 import { DocumentCard } from "@/domains/chat/components/document-card";
+import { useIsDocumentOpen } from "@/domains/chat/components/local-file/open-local-file";
 
 interface DocumentPreviewSurfaceData {
   documentName: string;
@@ -47,6 +48,7 @@ export function DocumentPreviewSurface({
   const openAction = surface.actions?.[0];
   const openDocument = onOpenDocument;
   const documentSurfaceId = data.documentSurfaceId;
+  const isOpen = useIsDocumentOpen(documentSurfaceId === "" ? null : documentSurfaceId);
 
   const handleOpen = openAction
     ? () => onAction(surface.surfaceId, openAction.id)
@@ -57,6 +59,7 @@ export function DocumentPreviewSurface({
   return (
     <DocumentCard
       documentName={data.documentName}
+      isOpen={isOpen}
       mimeType={data.mimeType}
       content={data.content}
       onOpen={handleOpen}

--- a/clients/web/src/domains/chat/document-viewer-page.tsx
+++ b/clients/web/src/domains/chat/document-viewer-page.tsx
@@ -233,6 +233,7 @@ export function DocumentViewerPage() {
         documentName={doc.title}
         content={doc.content}
         onClose={handleClose}
+        onRenamed={(title) => setDoc((prev) => (prev ? { ...prev, title } : prev))}
         onExport={handleExport}
         onSubmitFeedback={handleSubmitFeedback}
         handleRef={viewerRef}

--- a/clients/web/src/domains/chat/transcript/document-reopen-link.test.tsx
+++ b/clients/web/src/domains/chat/transcript/document-reopen-link.test.tsx
@@ -196,6 +196,24 @@ describe("DocumentReopenLink", () => {
     expect(screen.getByText("Quarterly notes")).toBeTruthy();
   });
 
+  test("reads as pressed while its own document is open", () => {
+    openDocument(SURFACE_ID);
+    renderLink([{ surfaceId: SURFACE_ID, title: "Quarterly notes" }]);
+
+    expect(
+      screen.getByTestId("document-reopen-link").getAttribute("aria-pressed"),
+    ).toBe("true");
+  });
+
+  test("reads as unpressed while a different document is open", () => {
+    openDocument("surf-other");
+    renderLink([{ surfaceId: SURFACE_ID, title: "Quarterly notes" }]);
+
+    expect(
+      screen.getByTestId("document-reopen-link").getAttribute("aria-pressed"),
+    ).toBe("false");
+  });
+
   test("stays visible while a different document is open", () => {
     openDocument("surf-other");
     renderLink([{ surfaceId: SURFACE_ID, title: "Quarterly notes" }]);

--- a/clients/web/src/domains/chat/transcript/document-reopen-link.tsx
+++ b/clients/web/src/domains/chat/transcript/document-reopen-link.tsx
@@ -28,6 +28,7 @@
 import { useQuery } from "@tanstack/react-query";
 
 import { DocumentCard } from "@/domains/chat/components/document-card";
+import { useIsDocumentOpen } from "@/domains/chat/components/local-file/open-local-file";
 import { documentsGetOptions } from "@/generated/daemon/@tanstack/react-query.gen";
 import type { DocumentsGetResponse } from "@/generated/daemon/types.gen";
 import { useTranslation } from "@/i18n";
@@ -134,6 +135,7 @@ export function DocumentReopenLink({
     assistantId,
     conversationId,
   );
+  const isOpen = useIsDocumentOpen(surfaceId);
 
   if (displayName == null) {
     return null;
@@ -142,6 +144,7 @@ export function DocumentReopenLink({
   return (
     <DocumentCard
       documentName={displayName}
+      isOpen={isOpen}
       onOpen={() => onOpenDocument(surfaceId)}
       ariaLabel={t("documentReopenLink.openAria", { name: displayName })}
       testId="document-reopen-link"

--- a/clients/web/src/i18n/locales/en/chat.json
+++ b/clients/web/src/i18n/locales/en/chat.json
@@ -577,13 +577,18 @@
   },
   "documentViewerContainer": {
     "close": "Close",
-    "closeCommentsAria": "Close comments",
     "closeDocumentAria": "Close document",
     "comments": "Comments",
     "export": "Export",
-    "openCommentsAria": "Open comments",
+    "hideComments": "Hide comments",
+    "menuAria": "Document options",
+    "rename": "Rename",
+    "renameFailed": "Could not rename the document.",
+    "renameSave": "Save",
+    "renameTitle": "Rename document",
     "saved": "Saved",
-    "saving": "Saving…"
+    "saving": "Saving…",
+    "wordCount": "{count, plural, one {# word} other {# words}}"
   },
   "documentViewerPage": {
     "notFound": "Document not found."

--- a/clients/web/src/i18n/locales/es/chat.json
+++ b/clients/web/src/i18n/locales/es/chat.json
@@ -577,13 +577,18 @@
   },
   "documentViewerContainer": {
     "close": "Cerrar",
-    "closeCommentsAria": "Cerrar comentarios",
     "closeDocumentAria": "Cerrar documento",
     "comments": "Comentarios",
     "export": "Exportar",
-    "openCommentsAria": "Abrir comentarios",
+    "hideComments": "Ocultar comentarios",
+    "menuAria": "Opciones del documento",
+    "rename": "Cambiar nombre",
+    "renameFailed": "No se pudo cambiar el nombre del documento.",
+    "renameSave": "Guardar",
+    "renameTitle": "Cambiar el nombre del documento",
     "saved": "Guardado",
-    "saving": "Guardando…"
+    "saving": "Guardando…",
+    "wordCount": "{count, plural, one {# palabra} other {# palabras}}"
   },
   "documentViewerPage": {
     "notFound": "Documento no encontrado."

--- a/clients/web/src/stores/viewer-store.ts
+++ b/clients/web/src/stores/viewer-store.ts
@@ -571,6 +571,13 @@ export interface ViewerActions {
     content: string,
     mode: string,
   ) => void;
+  /**
+   * Retitle the open document. The viewer writes the new title through the
+   * documents API and calls this so the drawer, the autosave target, and the
+   * mobile overlay all read the name the user just gave it, rather than
+   * waiting for the next load.
+   */
+  renameOpenedDocument: (surfaceId: string, documentName: string) => void;
   handleDocumentLoadFailed: () => void;
   closeDocument: () => void;
 
@@ -1120,6 +1127,16 @@ const useViewerStoreBase = create<ViewerStore>()((set, get) => ({
     }
     const newContent = mode === "append" ? prev.content + content : content;
     set({ openedDocumentState: { ...prev, content: newContent } });
+  },
+
+  renameOpenedDocument: (surfaceId, documentName) => {
+    const prev = get().openedDocumentState;
+    // A workspace-file preview is named by its path, which nothing renames
+    // from here, so only a document surface answers to this.
+    if (!prev || prev.source !== "document" || prev.surfaceId !== surfaceId) {
+      return;
+    }
+    set({ openedDocumentState: { ...prev, documentName } });
   },
 
   handleDocumentLoadFailed: () => {

--- a/packages/design-library/src/components/button.stories.tsx
+++ b/packages/design-library/src/components/button.stories.tsx
@@ -126,6 +126,7 @@ export const FullWidth: Story = {
 export const Active: Story = {
   render: () => (
     <div style={{ display: "flex", gap: "0.5rem", alignItems: "center" }}>
+      <Button active>Primary active</Button>
       <Button variant="ghost" active>Ghost active</Button>
       <Button variant="outlined" active>Outlined active</Button>
     </div>

--- a/packages/design-library/src/components/button.tsx
+++ b/packages/design-library/src/components/button.tsx
@@ -155,6 +155,19 @@ const buttonVariants = cva(
         class: "touch-mobile:h-10 touch-mobile:w-10",
       },
       {
+        // A primary button that stands for something currently open or
+        // selected holds its own pressed tone instead of springing back to
+        // the resting fill, which is the same move `ghost` and `outlined`
+        // make one step further out.
+        variant: "primary",
+        active: true,
+        class: [
+          "bg-[var(--primary-active)]",
+          "hover:bg-[var(--primary-active)]",
+          "active:bg-[var(--primary-active)]",
+        ].join(" "),
+      },
+      {
         variant: "ghost",
         active: true,
         class: [
@@ -244,6 +257,12 @@ export interface ButtonProps
    */
   iconOnly?: Exclude<ReactNode, boolean> | false;
   fullWidth?: boolean;
+  /**
+   * Paints the button as the thing currently open or selected: `primary`,
+   * `ghost`, and `outlined` each hold their own pressed tone rather than
+   * springing back on mouse-out. Pair it with `aria-pressed` so the state is
+   * announced and not only drawn.
+   */
   active?: boolean;
   /**
    * When `true` (default), icon-only buttons grow to a larger circular tap


### PR DESCRIPTION
The document surfaces in chat were three different kinds of thing: a bordered card in the transcript, a strip of controls standing in for the viewer's header, and no way to retitle a document short of asking the assistant to do it.

## The transcript affordance

Now a primary `Button` with a document glyph on the left and a chevron on the right, held in its active state while that document is the one on screen, so the row that names a document and the panel showing it agree about what is open. `useIsDocumentOpen` is the reactive twin of the `isDocumentOpen` predicate that was already there, sitting beside `useIsWorkspaceFileOpen`.

`active` only had compound variants for `ghost` and `outlined`, so it drew nothing on a primary button. Primary now holds `--primary-active` on mouse-out, the way the other two hold their own pressed tones.

The name also stopped cropping its descenders: `text-title-small` sets `line-height: 1`, and `truncate` clips whatever hangs below it, so the tail of a *g* was being cut off. Same pair existed in the viewer's title.

## The viewer header

The name over a status line carrying the word count, or the save state while a write is in flight (that replaces the floating save chip). Everything the document can do rides in one `ActionMenu` beside it (comments, rename, export), which leaves the header two affordances: the menu and the way out.

## Rename

Writes through the documents upsert, which is what autosave uses and the only endpoint carrying a title. Two things that matter there:

- It posts the editor's latest markdown, not the `content` prop. That prop is the load-time snapshot and does not follow typing, so posting it would undo every edit already saved.
- It cancels the debounced save first and folds that edit into the rename write, so a pending save cannot land afterward and restore the old name.

Optimistic like the conversation rename: the caller adopts the name immediately (viewer store for the chat drawer and mobile overlay, page state for the standalone route) and takes the old one back with a toast if the write fails. Both documents-list cache entries are invalidated so the transcript button, the assets pill, and the Library follow.

## Also

The assets popover heading sits on the column the rows start from instead of 4px inside it, taking the `px-2 py-1.5` a `Menu.Label` uses inside the popover's own `p-2`.

## Testing

- Five new tests: rename writes the new title with the body the editor holds, the folded-in edit is not written twice, and the transcript button reads as pressed / unpressed against the viewer store.
- `bunx tsc --noEmit`, `bun run lint`, `bun run build`, the design library's own button tests, and every affected suite pass. The full `bun run test:ci` sweep was still running when this went up.

Worth a look in review: the rename write path in `document-viewer-container.tsx`, and the new `primary` + `active` compound variant, which is a shared-package change (it is inert for existing callers, since `active` on a primary button previously drew nothing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
