### PR TITLE
feat(billing): add Manage Subscription to the plan card for paid Pro subs

### DIFF
--- a/clients/web/src/domains/settings/components/plan-card.test.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.test.tsx
@@ -1,7 +1,8 @@
 /**
  * Tests for the PlanCard: verifies the plan name, renewal text, the header's
- * "View All Plans" button, and the side-by-side current / next plan tiles
- * render correctly, plus the header button's navigation wiring. The card shows
+ * "View All Plans" and paid-only "Manage Subscription" buttons, and the
+ * side-by-side current / next plan tiles render correctly, plus the header
+ * buttons' navigation wiring. The card shows
  * no credit bundle label and no invoices button; invoices render in an inline
  * table on the billing page.
  *
@@ -494,6 +495,20 @@ describe("PlanCard", () => {
     expect(html).toContain("View All Plans");
   });
 
+  test("a base plan shows no Manage Subscription button", () => {
+    const html = renderCard(baseSubscription(), basePlansResponse());
+    expect(html).not.toContain("plan-card-manage-subscription-button");
+    expect(html).not.toContain("Manage Subscription");
+  });
+
+  test("a paid Pro plan shows Manage Subscription beside View All Plans", () => {
+    const html = renderCard(proMightySubscription(), plansWithSuper());
+    expect(html).toContain("plan-card-manage-subscription-button");
+    expect(html).toContain("Manage Subscription");
+    expect(html).toContain("plan-card-plans-button");
+    expect(html).toContain("View All Plans");
+  });
+
   test("does not render the invoices button (moved to inline table)", () => {
     const html = renderCard(baseSubscription(), basePlansResponse());
     expect(html).not.toContain("plan-card-invoices-button");
@@ -726,6 +741,38 @@ describe("PlanCard action button", () => {
       expect(navigateArgs).toEqual([[routes.plans, undefined]]);
     });
     expect(onManage).not.toHaveBeenCalled();
+  });
+
+  test("a Pro user's Manage Subscription click opens the plan-aware takeover", async () => {
+    const onManage = mock(() => {});
+    const { findByTestId } = renderCardInteractive(
+      proMightySubscription(),
+      plansWithSuper(),
+      onManage,
+    );
+
+    fireEvent.click(await findByTestId("plan-card-manage-subscription-button"));
+
+    await waitFor(() => {
+      expect(navigateArgs).toEqual([[routes.plans, undefined]]);
+    });
+    expect(onManage).not.toHaveBeenCalled();
+  });
+
+  test("an empty catalog's Manage Subscription falls back to onManage", async () => {
+    const onManage = mock(() => {});
+    const { findByTestId } = renderCardInteractive(
+      proMightySubscription(),
+      emptyCatalogPlans(),
+      onManage,
+    );
+
+    fireEvent.click(await findByTestId("plan-card-manage-subscription-button"));
+
+    await waitFor(() => {
+      expect(onManage).toHaveBeenCalledTimes(1);
+    });
+    expect(navigateArgs).toEqual([]);
   });
 
   test("an empty catalog falls back to onManage (AdjustPlanModal)", async () => {

--- a/clients/web/src/domains/settings/components/plan-card.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.tsx
@@ -577,7 +577,11 @@ export function PlanCard({ onManage, onTierUpgraded }: PlanCardProps) {
               </Typography>
             )}
           </div>
-          <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
+          {/* No shrink-0: the group must be able to compress so the nowrap
+              buttons wrap onto a second row at phone widths instead of
+              pushing past the card (the es/ru labels are long). Its floor is
+              the widest single button, same as the lone button had. */}
+          <div className="flex flex-wrap items-center justify-end gap-2">
             {!isFreePlan && (
               <Button
                 variant="outlined"

--- a/clients/web/src/domains/settings/components/plan-card.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.tsx
@@ -577,10 +577,10 @@ export function PlanCard({ onManage, onTierUpgraded }: PlanCardProps) {
               </Typography>
             )}
           </div>
-          {/* No shrink-0: the group must be able to compress so the nowrap
-              buttons wrap onto a second row at phone widths instead of
-              pushing past the card (the es/ru labels are long). Its floor is
-              the widest single button, same as the lone button had. */}
+          {/* The buttons never break their labels, so the group must stay
+              free to shrink and wrap them onto a second row at phone widths;
+              a fixed-width group would push the long es/ru labels past the
+              card. */}
           <div className="flex flex-wrap items-center justify-end gap-2">
             {!isFreePlan && (
               <Button

--- a/clients/web/src/domains/settings/components/plan-card.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.tsx
@@ -456,6 +456,12 @@ export function PlanCard({ onManage, onTierUpgraded }: PlanCardProps) {
     (currentPlan.id === "base" ||
       isCleanPin(subscription.package) ||
       isPackageSwitchEligible(subscription));
+  // Shared by both header buttons: "Manage Subscription" is the name a paid
+  // Pro user scans for, but it leads to the same surface as "View All Plans",
+  // which is where a sub is changed or cancelled.
+  const handlePlansClick = canOpenPlansTakeover
+    ? () => navigate(routes.plans)
+    : onManage;
   // The next tile's one-click switch is offered to any switch-eligible Pro sub
   // (a clean pin, a customized pin, or an unpinned Custom sub), inheriting the
   // shared eligibility gate. The confirm copy adapts to the sub's state via
@@ -571,16 +577,24 @@ export function PlanCard({ onManage, onTierUpgraded }: PlanCardProps) {
               </Typography>
             )}
           </div>
-          <Button
-            variant="outlined"
-            onClick={
-              canOpenPlansTakeover ? () => navigate(routes.plans) : onManage
-            }
-            data-testid="plan-card-plans-button"
-            className="shrink-0"
-          >
-            {t("planCard.viewAllPlans")}
-          </Button>
+          <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
+            {!isFreePlan && (
+              <Button
+                variant="outlined"
+                onClick={handlePlansClick}
+                data-testid="plan-card-manage-subscription-button"
+              >
+                {t("planCard.manageSubscription")}
+              </Button>
+            )}
+            <Button
+              variant="outlined"
+              onClick={handlePlansClick}
+              data-testid="plan-card-plans-button"
+            >
+              {t("planCard.viewAllPlans")}
+            </Button>
+          </div>
         </div>
         <div className="flex flex-col gap-2 lg:flex-row lg:items-stretch">
           <PlanTile

--- a/clients/web/src/i18n/locales/en/settings.json
+++ b/clients/web/src/i18n/locales/en/settings.json
@@ -1282,6 +1282,7 @@
     "heading": "Plan",
     "loadError": "Failed to load plan.",
     "loading": "Loading plan...",
+    "manageSubscription": "Manage Subscription",
     "nextPlan": "Next Plan",
     "powerUp": "Power Up",
     "powerUpFor": "Power Up for +{amount}/month",

--- a/clients/web/src/i18n/locales/es/settings.json
+++ b/clients/web/src/i18n/locales/es/settings.json
@@ -1282,6 +1282,7 @@
     "heading": "Plan",
     "loadError": "No se pudo cargar el plan.",
     "loading": "Cargando plan...",
+    "manageSubscription": "Gestionar suscripción",
     "nextPlan": "Siguiente plan",
     "powerUp": "Potenciar",
     "powerUpFor": "Potenciar por +{amount}/mes",

--- a/clients/web/src/i18n/locales/ru/settings.json
+++ b/clients/web/src/i18n/locales/ru/settings.json
@@ -1282,6 +1282,7 @@
     "heading": "План",
     "loadError": "Не удалось загрузить план.",
     "loading": "Загрузка плана...",
+    "manageSubscription": "Управление подпиской",
     "nextPlan": "Следующий план",
     "powerUp": "Усилить",
     "powerUpFor": "Усилить за +{amount}/мес",


### PR DESCRIPTION
## Summary
- Adds a Manage Subscription button to the top right of the billing and usage page's plan card, shown only when the org is on a paid Pro plan (any package, including Custom subs); base/free plans see only View All Plans.
- The button shares the View All Plans wiring: it opens the plans takeover when available and falls back to the manage modal (AdjustPlanModal) when the takeover cannot act on the sub.
- Adds the planCard.manageSubscription copy to the en/es/ru catalogs and covers the new button with render and click-wiring tests.

## Original prompt
When a user is on any paid pro plan, add a manage subscription button to the top right of the current plan card on the billing and usage settings page. This should do the same as the view all plans button.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41268" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->