### PR TITLE
fix(ios): avatar-dynamic Catch Up tile, mock-size chip glyph, and kit consolidation

### DIFF
--- a/clients/ios/App/App/Shared/CSSHexColor.swift
+++ b/clients/ios/App/App/Shared/CSSHexColor.swift
@@ -107,18 +107,21 @@ func canonicalCSSHex(_ raw: String) -> String? {
     return "#" + digits
 }
 
-/// Near-black ground that avatar-tinted full-bleed surfaces blend over.
-/// `SURFACE_GROUND` in `avatar-tone.ts`.
-let avatarSurfaceGround = "#151515"
-
 /// Multiply every channel of `hex` by `factor`, clamping to the 0-255 range.
 ///
 /// Mirrors `darkenHex` in `clients/web/src/utils/avatar-tone.ts`, the way
 /// ``UIColor/contrastingForeground`` mirrors that file's `contrastForeground`.
 /// It is how a surface painted with an avatar accent gets its dark-appearance
 /// variant: one hex arrives in the snapshot, and both appearances have to come
-/// out of it. A string this file cannot read comes back unchanged, as it does
-/// on the web, so the caller's own fallback still has something to reject.
+/// out of it.
+///
+/// The grammar is deliberately a superset of the web's. `avatar-tone.ts` reads
+/// `#RRGGBB` only, while this reads every spelling ``canonicalCSSHex(_:)``
+/// accepts and drops the alpha an 8-digit one carries, because what comes out
+/// is a card surface and a translucent card is not one. ``WidgetAvatarPalette``
+/// squares its light side with that by forcing alpha there too. A string
+/// neither side can read comes back unchanged, so the caller's own fallback
+/// still has something to reject.
 func darkenHex(_ hex: String, _ factor: Double) -> String {
     guard let channels = hexChannels(hex) else {
         return hex
@@ -141,14 +144,6 @@ func blendHex(base: String, overlay: String, alpha: Double) -> String {
         return Int((Double(from) * (1 - a) + Double(to) * a).rounded())
     }
     return hexString(r: mix(b.r, o.r), g: mix(b.g, o.g), b: mix(b.b, o.b))
-}
-
-/// Deep full-bleed surface for an avatar accent: the accent washed over
-/// ``avatarSurfaceGround``. Mirrors `avatarSurfaceHex` in `avatar-tone.ts`,
-/// 0.14 and all, so a native surface lands on the same ground the takeover
-/// paints behind the same avatar.
-func avatarSurfaceHex(_ accentHex: String) -> String {
-    return blendHex(base: avatarSurfaceGround, overlay: accentHex, alpha: 0.14)
 }
 
 /// The red, green and blue channels of a CSS hex color as 0-255 integers, or

--- a/clients/ios/App/VoiceActivity/Widgets/CatchUpWidget.swift
+++ b/clients/ios/App/VoiceActivity/Widgets/CatchUpWidget.swift
@@ -50,7 +50,7 @@ struct CatchUpWidgetView: View {
     var body: some View {
         HStack(alignment: .top, spacing: 14) {
             VStack(spacing: 7) {
-                WidgetActionTile.newChat
+                WidgetActionTile.newChat(accent: entry.softAccent, avatarImage: entry.avatarImage)
                 WidgetActionTile.voice
             }
             .frame(width: Self.actionColumnWidth)

--- a/clients/ios/App/VoiceActivity/Widgets/QuickActionsWidget.swift
+++ b/clients/ios/App/VoiceActivity/Widgets/QuickActionsWidget.swift
@@ -56,9 +56,6 @@ struct QuickActionsWidgetView: View {
     private static let controlDiameter: CGFloat = 61
     private static let controlGap: CGFloat = 6
 
-    /// Height of one eye, sizing the pair the kit draws.
-    private static let eyeHeight: CGFloat = 33
-
     /// The avatar's slot when the avatar is a photo rather than a face to
     /// draw. Larger than the eyes are tall, because a picture needs area to
     /// read as a face where two ovals need only their outline.
@@ -119,17 +116,16 @@ struct QuickActionsWidgetView: View {
         .padding(.top, Self.markInset)
     }
 
-    /// Height the eyes can afford beside the chip. The chip's widest form,
-    /// the collapsed `99+`, needs about 66 points, and the pair's own width
-    /// is its height times the pair's aspect; on compact cards the eyes give
-    /// way so the row never compresses either mark.
+    /// Height the eyes can afford beside the chip. The pair's own width is its
+    /// height times ``WidgetAvatarEyes/pairAspect``, so what the chip does not
+    /// take decides how tall they can be; on compact cards the eyes give way so
+    /// the row never compresses either mark.
     private func fittedEyeHeight(in width: CGFloat) -> CGFloat {
         guard unreadCount != nil else {
-            return Self.eyeHeight
+            return WidgetAvatarEyes.defaultEyeHeight
         }
-        let pairAspect: CGFloat = 61 / 33
-        let available = (width - Self.chipAllowance) / pairAspect
-        return min(Self.eyeHeight, max(24, available))
+        let available = (width - Self.chipAllowance) / WidgetAvatarEyes.pairAspect
+        return min(WidgetAvatarEyes.defaultEyeHeight, max(24, available))
     }
 
     /// The photo mark under the same constraint as the eyes.
@@ -140,8 +136,9 @@ struct QuickActionsWidgetView: View {
         return min(Self.avatarImageSize, max(24, width - Self.chipAllowance))
     }
 
-    /// Width the chip's widest form, the collapsed `99+`, can occupy.
-    private static let chipAllowance: CGFloat = 66
+    /// Width the chip's widest form, the collapsed `99+`, can occupy: the 16pt
+    /// bubble, the 15pt count, and the padding around both.
+    private static let chipAllowance: CGFloat = 73
 
     /// The assistant, however this account's assistant can be drawn: its own
     /// photo where there is one, and the eyes the kit draws where the card is
@@ -170,14 +167,7 @@ struct QuickActionsWidgetView: View {
     private var unreadChip: some View {
         if let count = unreadCount {
             HStack(spacing: 4) {
-                Image(systemName: "bubble.left.fill")
-                    .font(.system(size: 12))
-                    .overlay(alignment: .topTrailing) {
-                        Circle()
-                            .fill(WidgetTheme.unseenIndicator)
-                            .frame(width: 6, height: 6)
-                            .offset(x: 2, y: -2)
-                    }
+                WidgetUnreadMark(isFilled: true, size: 16)
                 Text(count > 99 ? "99+" : "\(count)")
                     .font(.system(size: 15, weight: .semibold))
                     .privacySensitive()
@@ -272,27 +262,14 @@ struct QuickActionsCardBackground: View {
 
 #if DEBUG
 
-/// The card at the size the small family draws it, in both appearances.
+/// This widget's card: the shared wrapper over the avatar background, which is
+/// what the widget itself paints its container with.
 private func previewCard(_ entry: SnapshotEntry) -> some View {
-    QuickActionsWidgetView(entry: entry)
-        .frame(width: 160, height: 161)
-        .background { QuickActionsCardBackground(entry: entry) }
-        .clipShape(RoundedRectangle(cornerRadius: 22, style: .continuous))
-}
-
-private func previewEntry(unreadCount: Int, avatar: WidgetSnapshotAvatar?) -> SnapshotEntry {
-    SnapshotEntry(
-        date: Date(),
-        snapshot: WidgetSnapshot(
-            schemaVersion: WidgetSnapshot.currentSchemaVersion,
-            generatedAt: Date(),
-            unreadCount: unreadCount,
-            inProgressCount: 0,
-            conversations: [],
-            avatar: avatar
-        ),
-        isStale: false
-    )
+    previewWidgetCard {
+        QuickActionsWidgetView(entry: entry)
+    } background: {
+        QuickActionsCardBackground(entry: entry)
+    }
 }
 
 private func previewCharacterAvatar(accentHex: String) -> WidgetSnapshotAvatar {
@@ -301,17 +278,17 @@ private func previewCharacterAvatar(accentHex: String) -> WidgetSnapshotAvatar {
 
 #Preview("Character, nothing unread") {
     previewAppearances {
-        previewCard(previewEntry(unreadCount: 0, avatar: previewCharacterAvatar(accentHex: "#0E9B8B")))
+        previewCard(previewEntry(unread: 0, avatar: previewCharacterAvatar(accentHex: "#0E9B8B")))
     }
 }
 
 #Preview("Character, unread") {
     previewAppearances {
         HStack(spacing: 12) {
-            previewCard(previewEntry(unreadCount: 3, avatar: previewCharacterAvatar(accentHex: "#0E9B8B")))
+            previewCard(previewEntry(unread: 3, avatar: previewCharacterAvatar(accentHex: "#0E9B8B")))
             // The light one: its glyphs, chip text and control fills all have
             // to come out dark, or the card is white on yellow.
-            previewCard(previewEntry(unreadCount: 12, avatar: previewCharacterAvatar(accentHex: "#F2C94C")))
+            previewCard(previewEntry(unread: 12, avatar: previewCharacterAvatar(accentHex: "#F2C94C")))
         }
     }
 }
@@ -323,15 +300,15 @@ private func previewCharacterAvatar(accentHex: String) -> WidgetSnapshotAvatar {
         imageData: previewAvatarPhoto().pngData()
     )
     previewAppearances {
-        previewCard(previewEntry(unreadCount: 5, avatar: avatar))
+        previewCard(previewEntry(unread: 5, avatar: avatar))
     }
 }
 
 #Preview("No avatar") {
     previewAppearances {
         HStack(spacing: 12) {
-            previewCard(previewEntry(unreadCount: 0, avatar: nil))
-            previewCard(previewEntry(unreadCount: 128, avatar: nil))
+            previewCard(previewEntry(unread: 0, avatar: nil))
+            previewCard(previewEntry(unread: 128, avatar: nil))
         }
     }
 }

--- a/clients/ios/App/VoiceActivity/Widgets/StatusWidget.swift
+++ b/clients/ios/App/VoiceActivity/Widgets/StatusWidget.swift
@@ -99,18 +99,6 @@ struct StatusWidgetView: View {
         return snapshot.unreadCount > 0 || snapshot.inProgressCount > 0
     }
 
-    /// The accent theming the New Chat surfaces.
-    ///
-    /// Only a character avatar carries one: an uploaded photo has no accent by
-    /// design, and an account with nothing synced has none to read. Both fall
-    /// through to the static tokens inside ``WidgetSoftAccent``.
-    private var softAccent: WidgetSoftAccent {
-        guard entry.avatarKind == .character else {
-            return WidgetSoftAccent(accentHex: nil)
-        }
-        return WidgetSoftAccent(accentHex: entry.snapshot?.avatar?.accentHex)
-    }
-
     /// The height of one control, capped at the size the card is laid out for
     /// and otherwise cut to whichever dimension runs out first.
     ///
@@ -154,8 +142,8 @@ struct StatusWidgetView: View {
             intent: OpenNewChatIntent(),
             icon: Image("VellumV"),
             title: "Chat",
-            fill: softAccent.fill,
-            tint: softAccent.onFill,
+            fill: entry.softAccent.fill,
+            tint: entry.softAccent.onFill,
             height: height,
             avatarImage: entry.avatarImage
         )
@@ -165,7 +153,7 @@ struct StatusWidgetView: View {
     /// two read as a primary action and a secondary one.
     private func actionTiles(height: CGFloat) -> some View {
         HStack(spacing: Self.tileGap) {
-            WidgetActionTile.newChat(accent: softAccent, avatarImage: entry.avatarImage)
+            WidgetActionTile.newChat(accent: entry.softAccent, avatarImage: entry.avatarImage)
             WidgetActionTile.voice
         }
         .frame(height: height)
@@ -204,18 +192,11 @@ struct StatusWidgetView: View {
         }
     }
 
-    /// A bubble wearing the same unseen dot the Catch Up rows mark a
-    /// conversation with, so the two widgets say "unread" the same way.
+    /// The outline bubble, since this card is the white one, in the primary
+    /// text color the line beside it is drawn in.
     private var unreadGlyph: some View {
-        Image(systemName: "bubble.left")
-            .font(.system(size: 16))
+        WidgetUnreadMark(isFilled: false, size: 16)
             .foregroundStyle(WidgetTheme.textPrimary)
-            .overlay(alignment: .topTrailing) {
-                Circle()
-                    .fill(WidgetTheme.unseenIndicator)
-                    .frame(width: 6, height: 6)
-                    .offset(x: 2, y: -1)
-            }
     }
 
     /// The dots a Catch Up row marks a turn in flight with, at the size this
@@ -229,78 +210,44 @@ struct StatusWidgetView: View {
 
 #if DEBUG
 
-/// The widget's own card at the size the layout is specified at, so a preview
-/// shows the controls landing on their margins rather than a view floating in
-/// a canvas.
-private struct StatusWidgetPreviewCard: View {
-    let entry: SnapshotEntry
-
-    var body: some View {
+/// This widget's card: the shared wrapper over the flat surface token, which is
+/// what the widget itself paints its container with.
+private func statusPreviewCard(_ entry: SnapshotEntry) -> some View {
+    previewWidgetCard {
         StatusWidgetView(entry: entry)
-            .frame(width: 161, height: 161)
-            .background(WidgetTheme.surface)
-            .clipShape(RoundedRectangle(cornerRadius: 22, style: .continuous))
-    }
-}
-
-/// A snapshot carrying exactly what a preview needs to say and nothing else:
-/// this widget renders no conversations.
-private func previewEntry(
-    unread: Int = 0,
-    inProgress: Int = 0,
-    avatar: WidgetSnapshotAvatar? = nil
-) -> SnapshotEntry {
-    SnapshotEntry(
-        date: Date(),
-        snapshot: WidgetSnapshot(
-            schemaVersion: WidgetSnapshot.currentSchemaVersion,
-            generatedAt: Date(),
-            unreadCount: unread,
-            inProgressCount: inProgress,
-            conversations: [],
-            avatar: avatar
-        ),
-        isStale: false
-    )
-}
-
-/// A stand-in avatar, drawn rather than shipped so the previews cost the
-/// extension no asset.
-private func previewAvatarData() -> Data {
-    let size = CGSize(width: 96, height: 96)
-    return UIGraphicsImageRenderer(size: size).pngData { context in
-        (UIColor(cssHex: "#3B6EA5") ?? .systemBlue).setFill()
-        context.fill(CGRect(origin: .zero, size: size))
-        (UIColor(cssHex: "#F2F2F2") ?? .white).setFill()
-        context.cgContext.fillEllipse(in: CGRect(x: 20, y: 30, width: 22, height: 28))
-        context.cgContext.fillEllipse(in: CGRect(x: 54, y: 30, width: 22, height: 28))
+    } background: {
+        WidgetTheme.surface
     }
 }
 
 #Preview("Idle") {
     previewAppearances {
-        StatusWidgetPreviewCard(entry: previewEntry())
+        statusPreviewCard(previewEntry())
     }
 }
 
 #Preview("Active") {
     previewAppearances {
-        StatusWidgetPreviewCard(entry: previewEntry(unread: 3, inProgress: 2))
+        statusPreviewCard(previewEntry(unread: 3, inProgress: 2))
     }
 }
 
 #Preview("Active, unread only") {
     previewAppearances {
-        StatusWidgetPreviewCard(entry: previewEntry(unread: 1))
+        statusPreviewCard(previewEntry(unread: 1))
     }
 }
 
 #Preview("Custom avatar") {
-    let avatar = WidgetSnapshotAvatar(kind: "image", accentHex: nil, imageData: previewAvatarData())
+    let avatar = WidgetSnapshotAvatar(
+        kind: "image",
+        accentHex: nil,
+        imageData: previewAvatarPhoto().pngData()
+    )
     previewAppearances {
         HStack(spacing: 12) {
-            StatusWidgetPreviewCard(entry: previewEntry(avatar: avatar))
-            StatusWidgetPreviewCard(entry: previewEntry(unread: 3, inProgress: 2, avatar: avatar))
+            statusPreviewCard(previewEntry(avatar: avatar))
+            statusPreviewCard(previewEntry(unread: 3, inProgress: 2, avatar: avatar))
         }
     }
 }
@@ -311,12 +258,12 @@ private func previewAvatarData() -> Data {
     let avatar = WidgetSnapshotAvatar(
         kind: "character",
         accentHex: "#F2C94C",
-        imageData: previewAvatarData()
+        imageData: previewAvatarPhoto().pngData()
     )
     previewAppearances {
         HStack(spacing: 12) {
-            StatusWidgetPreviewCard(entry: previewEntry(avatar: avatar))
-            StatusWidgetPreviewCard(entry: previewEntry(unread: 3, inProgress: 2, avatar: avatar))
+            statusPreviewCard(previewEntry(avatar: avatar))
+            statusPreviewCard(previewEntry(unread: 3, inProgress: 2, avatar: avatar))
         }
     }
 }

--- a/clients/ios/App/VoiceActivity/Widgets/WidgetActionControls.swift
+++ b/clients/ios/App/VoiceActivity/Widgets/WidgetActionControls.swift
@@ -2,11 +2,11 @@ import AppIntents
 import SwiftUI
 import UIKit
 
-// The controls every Vellum Home Screen widget builds its actions out of: a
-// tile, a circle, a pill, and the secondary line of text that stands in when
-// there is nothing to list. They live here rather than beside whichever widget
-// reached for them first, because a control that lives in one widget's file is
-// a control the next widget copies.
+// The pieces every Vellum Home Screen widget builds itself out of: a tile, a
+// circle, a pill, the unread mark, and the secondary line of text that stands
+// in when there is nothing to list. They live here rather than beside whichever
+// widget reached for them first, because a control that lives in one widget's
+// file is a control the next widget copies.
 
 /// One tile in an action column: a glyph over a word, filling a rounded
 /// square, wired to an App Intent.
@@ -66,12 +66,6 @@ struct WidgetActionTile<ActionIntent: AppIntent>: View {
 }
 
 extension WidgetActionTile where ActionIntent == OpenNewChatIntent {
-    /// The New Chat tile on the static tokens, for the widgets with no avatar
-    /// in hand to theme it with.
-    static var newChat: Self {
-        newChat(accent: WidgetSoftAccent(accentHex: nil))
-    }
-
     /// The New Chat tile, spelled once so the widgets offering it cannot drift
     /// into different wording, glyphs or colors. The frame around it stays with
     /// the caller: the column and the row size their tiles differently.
@@ -171,6 +165,38 @@ struct PillActionButton<ActionIntent: AppIntent>: View {
     }
 
     private var iconSize: CGFloat { height * 0.4 }
+}
+
+/// The mark a widget says "something is waiting" with: a speech bubble wearing
+/// the unseen dot in its top-right corner.
+///
+/// One view rather than one per card, so the dot lands in the same place on
+/// each of them. It carries no foreground of its own: the bubble takes the
+/// color of whatever it is drawn on, while the dot keeps
+/// ``WidgetTheme/unseenIndicator`` on every surface, which is what makes it
+/// read as an alert rather than as more chrome.
+struct WidgetUnreadMark: View {
+    /// Whether the bubble is solid. A card painted in the assistant's own color
+    /// wants the filled one; a white card wants the outline its rows draw.
+    let isFilled: Bool
+
+    /// Point size of the bubble. The dot rides its corner at a fixed size
+    /// rather than scaling with it, so the alert stays the same alert whichever
+    /// card carries it.
+    let size: CGFloat
+
+    private static let dotDiameter: CGFloat = 6
+
+    var body: some View {
+        Image(systemName: isFilled ? "bubble.left.fill" : "bubble.left")
+            .font(.system(size: size))
+            .overlay(alignment: .topTrailing) {
+                Circle()
+                    .fill(WidgetTheme.unseenIndicator)
+                    .frame(width: Self.dotDiameter, height: Self.dotDiameter)
+                    .offset(x: 2, y: -2)
+            }
+    }
 }
 
 /// The quiet line a widget prints when it has nothing to list: an empty state,

--- a/clients/ios/App/VoiceActivity/Widgets/WidgetAvatarRendering.swift
+++ b/clients/ios/App/VoiceActivity/Widgets/WidgetAvatarRendering.swift
@@ -55,18 +55,11 @@ struct WidgetAvatarPalette {
     /// palette and the static one agree wherever they overlap.
     private static let darkSurfaceFactor = 0.79
 
-    /// Opacity a control's fill sits at on the card, matching
-    /// ``WidgetTheme/onBrandFill``.
-    private static let controlFillOpacity = 0.22
-
     /// The card behind everything.
     let surface: Color
 
     /// Glyphs and text drawn on ``surface``.
     let onSurface: Color
-
-    /// A control's fill on ``surface``: ``onSurface`` at low opacity.
-    let controlFill: Color
 
     /// ``onSurface`` resolved for each appearance, so a card mixing its own
     /// fill can ask how bright the color it would be washing with is.
@@ -82,7 +75,6 @@ struct WidgetAvatarPalette {
         else {
             surface = WidgetTheme.brandCardSurface
             onSurface = WidgetTheme.onBrand
-            controlFill = WidgetTheme.onBrandFill
             // The brand card is a deep green in both appearances, so what sits
             // on it is white in both.
             resolvedOnSurface = (.white, .white)
@@ -96,15 +88,12 @@ struct WidgetAvatarPalette {
         let darkOn = dark.contrastingForeground
         surface = WidgetTheme.appearanceDynamic(light: light, dark: dark)
         onSurface = WidgetTheme.appearanceDynamic(light: lightOn, dark: darkOn)
-        controlFill = WidgetTheme.appearanceDynamic(
-            light: lightOn.withAlphaComponent(Self.controlFillOpacity),
-            dark: darkOn.withAlphaComponent(Self.controlFillOpacity)
-        )
         resolvedOnSurface = (lightOn, darkOn)
     }
 
-    /// ``controlFill`` at a weight the caller picks, for a card whose controls
-    /// read lighter than the default.
+    /// A control's fill on ``surface``: ``onSurface`` at the weight the caller
+    /// picks, so the action circles and the chip read as cut out of the card
+    /// rather than as a second color placed on top of it.
     ///
     /// Two weights rather than one because ``onSurface`` comes out white over
     /// some accents and near-black over others, and one opacity does not read
@@ -148,7 +137,15 @@ struct WidgetAvatarEyes: View {
     private static let pupilRatio: CGFloat = 0.41
     private static let pupilInsetRatio: CGFloat = 0.18
 
-    var eyeHeight: CGFloat = 33
+    /// The height the pair is drawn at where the card has room for it.
+    static let defaultEyeHeight: CGFloat = 33
+
+    /// The pair's width as a share of its height: two eyes and the gap between
+    /// them. Published because a card fitting the pair beside something else
+    /// picks a height and has to know how wide that comes out.
+    static let pairAspect: CGFloat = widthRatio * 2 + gapRatio
+
+    var eyeHeight: CGFloat = WidgetAvatarEyes.defaultEyeHeight
 
     var body: some View {
         HStack(spacing: eyeHeight * Self.gapRatio) {
@@ -216,15 +213,16 @@ struct BlurredAvatarBackground: View {
     /// clip trims the excess; otherwise the perimeter fades into the ground.
     private static let overscan: CGFloat = blurRadius * 2
 
+    /// The near-black under the photo, and the whole card when there is no
+    /// photo to blur. Hue-neutral, which is all an uploaded photo can offer: it
+    /// carries no accent by design. `SURFACE_GROUND` in
+    /// `clients/web/src/utils/avatar-tone.ts`.
+    private static let groundHex = "#151515"
+
     /// The photo, absent when the snapshot carries none and when its bytes do
     /// not form an image. Both fall through to the ground below, which is what
     /// makes this safe to hand a card's whole background to.
     let image: UIImage?
-
-    /// Tints the ground for the case where there is no photo to blur, the way
-    /// the takeover tints its own. Nil leaves the ground hue-neutral, which is
-    /// all an uploaded photo can offer: it carries no accent by design.
-    var accentHex: String? = nil
 
     var body: some View {
         ground
@@ -252,8 +250,7 @@ struct BlurredAvatarBackground: View {
     }
 
     private var ground: Color {
-        let hex = accentHex.map(avatarSurfaceHex) ?? avatarSurfaceGround
-        return Color(cssHex: hex) ?? .black
+        Color(cssHex: Self.groundHex) ?? .black
     }
 }
 
@@ -280,15 +277,32 @@ extension SnapshotEntry {
         snapshot?.avatar?.imageData.flatMap(UIImage.init(data:))
     }
 
-    /// The colors to theme this rendering with, already fallen back to the
-    /// static brand card when there is no accent. Only a character avatar
-    /// themes the card: any other kind keeps the static palette even if a
-    /// malformed or newer-schema snapshot carries an accent alongside it.
-    var avatarPalette: WidgetAvatarPalette {
+    /// The accent this rendering themes itself with, or `nil` to keep the
+    /// static tokens.
+    ///
+    /// The one owner of the rule that only a character avatar carries an
+    /// accent: an uploaded photo has none by design, an account with nothing
+    /// synced has none to read, and any other kind keeps the static palette
+    /// even if a malformed or newer-schema snapshot carries an accent
+    /// alongside it. Both palettes below read the gate from here so a card and
+    /// the controls on it cannot disagree about which accounts are themed.
+    var themeAccentHex: String? {
         guard avatarKind == .character else {
-            return WidgetAvatarPalette(accentHex: nil)
+            return nil
         }
-        return WidgetAvatarPalette(accentHex: snapshot?.avatar?.accentHex)
+        return snapshot?.avatar?.accentHex
+    }
+
+    /// The colors to paint a full-bleed card with, already fallen back to the
+    /// static brand card when there is no accent.
+    var avatarPalette: WidgetAvatarPalette {
+        WidgetAvatarPalette(accentHex: themeAccentHex)
+    }
+
+    /// The wash theming a New Chat surface on a light card, already fallen back
+    /// to the static tokens when there is no accent.
+    var softAccent: WidgetSoftAccent {
+        WidgetSoftAccent(accentHex: themeAccentHex)
     }
 }
 
@@ -301,19 +315,20 @@ private struct WidgetAvatarKitPreviewCard: View {
     let palette: WidgetAvatarPalette
 
     var body: some View {
-        VStack(spacing: 10) {
-            WidgetAvatarEyes(eyeHeight: 26)
-            Text(title)
-                .font(.system(size: 11, weight: .semibold))
-                .foregroundStyle(palette.onSurface)
-            HStack(spacing: 8) {
-                controlCircle("camera.fill")
-                controlCircle("waveform")
+        previewWidgetCard(width: 150, height: 150) {
+            VStack(spacing: 10) {
+                WidgetAvatarEyes(eyeHeight: 26)
+                Text(title)
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(palette.onSurface)
+                HStack(spacing: 8) {
+                    controlCircle("camera.fill")
+                    controlCircle("waveform")
+                }
             }
+        } background: {
+            palette.surface
         }
-        .frame(width: 150, height: 150)
-        .background(palette.surface)
-        .clipShape(RoundedRectangle(cornerRadius: 22, style: .continuous))
     }
 
     private func controlCircle(_ symbol: String) -> some View {
@@ -321,7 +336,7 @@ private struct WidgetAvatarKitPreviewCard: View {
             .font(.system(size: 15))
             .foregroundStyle(palette.onSurface)
             .frame(width: 38, height: 38)
-            .background(palette.controlFill, in: Circle())
+            .background(palette.controlFill(onWhite: 0.14, onDark: 0.10), in: Circle())
     }
 }
 
@@ -355,6 +370,46 @@ func previewAvatarPhoto() -> UIImage {
     }
 }
 
+/// A card at the size a widget is drawn at, clipped the way the system clips
+/// one, so a preview shows a layout landing on its own margins rather than a
+/// view floating in a canvas.
+///
+/// The background is the caller's: one widget paints the flat surface token and
+/// the next paints the avatar over the widget's whole bounds.
+func previewWidgetCard<Content: View, Background: View>(
+    width: CGFloat = 161,
+    height: CGFloat = 161,
+    @ViewBuilder content: () -> Content,
+    @ViewBuilder background: () -> Background
+) -> some View {
+    content()
+        .frame(width: width, height: height)
+        .background { background() }
+        .clipShape(RoundedRectangle(cornerRadius: 22, style: .continuous))
+}
+
+/// A snapshot carrying exactly what a preview needs to say: the two counts and
+/// the avatar. Shared with the widgets built out of the kit, none of which
+/// previews a conversation list.
+func previewEntry(
+    unread: Int = 0,
+    inProgress: Int = 0,
+    avatar: WidgetSnapshotAvatar? = nil
+) -> SnapshotEntry {
+    SnapshotEntry(
+        date: Date(),
+        snapshot: WidgetSnapshot(
+            schemaVersion: WidgetSnapshot.currentSchemaVersion,
+            generatedAt: Date(),
+            unreadCount: unread,
+            inProgressCount: inProgress,
+            conversations: [],
+            avatar: avatar
+        ),
+        isStale: false
+    )
+}
+
 #Preview("Character accents") {
     previewAppearances {
         HStack(spacing: 12) {
@@ -375,12 +430,11 @@ func previewAvatarPhoto() -> UIImage {
 #Preview("Custom image") {
     let photo = previewAvatarPhoto()
     previewAppearances {
-        ZStack {
-            BlurredAvatarBackground(image: photo)
+        previewWidgetCard(width: 150, height: 150) {
             WidgetAvatarImageView(image: photo, size: 44, cornerRadius: 14)
+        } background: {
+            BlurredAvatarBackground(image: photo)
         }
-        .frame(width: 150, height: 150)
-        .clipShape(RoundedRectangle(cornerRadius: 22, style: .continuous))
     }
 }
 

--- a/clients/ios/App/VoiceActivity/Widgets/WidgetTheme.swift
+++ b/clients/ios/App/VoiceActivity/Widgets/WidgetTheme.swift
@@ -51,7 +51,8 @@ enum WidgetTheme {
     /// chrome, and so it survives sitting on the green tile's neighbours.
     static let unseenIndicator = dynamic(light: "#FFB200", dark: "#FFC13D")
 
-    /// The whole card, for the Quick Actions widget's brand appearance.
+    /// The whole card for an account carrying no accent to paint it with: the
+    /// surface ``WidgetAvatarPalette`` falls back to.
     ///
     /// Deepened for dark mode where ``brand`` is lightened, because the two
     /// play opposite roles: `brand` is drawn *on* `surface` and has to separate
@@ -63,17 +64,6 @@ enum WidgetTheme {
     /// dynamic: the card underneath is a deep green in both appearances, so
     /// this answers to the card rather than to the Home Screen behind it.
     static let onBrand = fixed("#FFFFFF")
-
-    /// A control's fill on ``brandCardSurface``: ``onBrand`` at low opacity, so
-    /// the action circles and the unread chip read as cut out of the green
-    /// rather than as a second color placed on top of it, and the card stays
-    /// one block.
-    static let onBrandFill = onBrand.opacity(0.22)
-
-    /// The assistant mark's body on the brand card, lighter than the card it
-    /// sits on. That contrast is the only reason it is a separate value: a
-    /// brand-green mark on a brand-green card is not a mark.
-    static let avatarBody = fixed("#7FD7C8")
 
     /// The mark's eye whites and pupils, carrying the values the product's
     /// avatar compositor draws with so the widget's stand-in is recognizably


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for ios-widgets-v2.md: Catch Up's New Chat tile picks up the avatar theming the other widgets have, the unread chip glyph matches the mock, and the widget kit sheds dead tokens, unused seams, and duplicated preview/glyph/geometry code.