### PR TITLE
fix(voice): revalidate deep-link starts after awaits and align the draft mint

### DIFF
--- a/clients/web/src/domains/chat/voice/live-voice/start-voice-request.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/start-voice-request.test.ts
@@ -163,6 +163,7 @@ beforeEach(() => {
   useConversationStore
     .getState()
     .setActiveConversationId(PRIOR_CONVERSATION_ID);
+  useViewerStore.getState().reset();
   useViewerStore.getState().setMainView("app");
   navigate.mockClear();
   starter.mockClear();
@@ -261,6 +262,24 @@ describe("starting a session", () => {
     requestVoiceStart(navigate);
     await flushDrain();
 
+    expect(useViewerStore.getState().mainView).toBe("chat");
+  });
+
+  test("leaves no side panel from the previous conversation on the fresh draft", async () => {
+    // A files panel is one message's attachments, so it belongs to the thread
+    // the app was left on. Carried into a conversation with no messages at all
+    // it shows the new call someone else's payload.
+    identityHydrated();
+    registerStarter();
+    useViewerStore.getState().openMessageFiles({
+      messageId: "msg-prior",
+      attachments: [],
+    });
+
+    requestVoiceStart(navigate);
+    await flushDrain();
+
+    expect(useViewerStore.getState().activeMessageFiles).toBeNull();
     expect(useViewerStore.getState().mainView).toBe("chat");
   });
 
@@ -572,5 +591,107 @@ describe("entry guards", () => {
 
     expect(starter).not.toHaveBeenCalled();
     expect(isParked()).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The app moving on while the preflight is in flight
+// ---------------------------------------------------------------------------
+
+/**
+ * The preflight is a network round trip, and the whole tail of the drain runs
+ * after it: minting a conversation, navigating onto it, starting a session on
+ * the assistant that was active when the drain began. A user is free to do
+ * anything at all in that window, so every one of those three has to be
+ * decided on state re-read afterwards rather than on what the drain captured.
+ */
+describe("state read before the preflight is re-read after it", () => {
+  /**
+   * Park a request and run the drain as far as the preflight, which is held
+   * open until the returned `release` is called. Awaits the two microtasks the
+   * drain needs to get there, so callers change state with it genuinely
+   * in flight.
+   */
+  async function drainBlockedOnPreflight(): Promise<{
+    drain: Promise<void>;
+    release: () => void;
+  }> {
+    let release: () => void = () => {};
+    preflightLiveVoice.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          release = () => resolve(preflightVerdict);
+        }),
+    );
+    usePendingDeepLinkStore.getState().setPendingVoiceStart();
+    const drain = drainPendingVoiceStart(navigate);
+    await Promise.resolve();
+    await Promise.resolve();
+    return { drain, release: () => release() };
+  }
+
+  test("a session started from the composer mid-preflight spends the press", async () => {
+    // The user got to the chat and pressed the voice button themselves. That
+    // session is the one they are in: starting is refused anyway, and the
+    // navigation would walk the app off the composer that owns it.
+    identityHydrated();
+    registerStarter();
+    const { drain, release } = await drainBlockedOnPreflight();
+
+    useLiveVoiceStore
+      .getState()
+      .setSessionContext("assistant-1", "conv-composer");
+    useLiveVoiceStore.getState().setState("listening");
+    release();
+    await drain;
+
+    expect(starter).not.toHaveBeenCalled();
+    expect(navigate).not.toHaveBeenCalled();
+    expect(useConversationStore.getState().activeConversationId).toBe(
+      PRIOR_CONVERSATION_ID,
+    );
+    expect(isParked()).toBe(false);
+  });
+
+  test("an assistant switched mid-preflight leaves the request parked", async () => {
+    // Both the eligibility gate and the verdict answered for the assistant the
+    // user has just left, so neither authorizes a start on the one they moved
+    // to. Nothing was minted or navigated, so the press survives for a drain
+    // that can run both gates against whoever is active then.
+    identityHydrated();
+    registerStarter();
+    const { drain, release } = await drainBlockedOnPreflight();
+
+    useResolvedAssistantsStore.setState({ activeAssistantId: "assistant-2" });
+    release();
+    await drain;
+
+    expect(starter).not.toHaveBeenCalled();
+    expect(navigate).not.toHaveBeenCalled();
+    expect(useConversationStore.getState().activeConversationId).toBe(
+      PRIOR_CONVERSATION_ID,
+    );
+    expect(isParked()).toBe(true);
+
+    // Back on the assistant the press was made for, the next drain serves it.
+    useResolvedAssistantsStore.setState({ activeAssistantId: "assistant-1" });
+    await drainPendingVoiceStart(navigate);
+    expectStartedOnFreshDraft();
+  });
+
+  test("a verdict about the assistant the user left publishes no notice", async () => {
+    // The notice is drawn against whatever conversation is on screen, which by
+    // now belongs to another assistant, so it would read as that assistant's
+    // voice being unconfigured.
+    identityHydrated();
+    registerStarter();
+    preflightVerdict = { status: "not-ready", userMessage: "Set up a voice." };
+    const { drain, release } = await drainBlockedOnPreflight();
+
+    useResolvedAssistantsStore.setState({ activeAssistantId: "assistant-2" });
+    release();
+    await drain;
+
+    expect(useLiveVoiceStore.getState().configNotice).toBeNull();
   });
 });

--- a/clients/web/src/domains/chat/voice/live-voice/start-voice-request.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/start-voice-request.ts
@@ -181,10 +181,11 @@ export async function drainPendingVoiceStart(
     return;
   }
   const assistantId = useResolvedAssistantsStore.getState().activeAssistantId;
-  // Every remaining branch is a decision rather than a race, so each of them
-  // spends the request. The consume itself stays at the bottom, below the last
-  // await, so the one thing that can still become true — a controller that has
-  // not registered yet — leaves the request parked rather than losing it.
+  // Every branch from here that is a decision rather than a race spends the
+  // request. The consume itself stays at the bottom, below the last await, so
+  // the things that can still become true (a controller that has not
+  // registered yet, an assistant switched away from mid-preflight) leave the
+  // request parked rather than losing it.
   const consume = (): boolean =>
     usePendingDeepLinkStore
       .getState()
@@ -213,6 +214,30 @@ export async function drainPendingVoiceStart(
     return;
   }
   const readiness = await voiceReadiness(assistantId);
+  // Everything below decides on state read before a network round trip, so
+  // re-read it first. This is the same re-check the composer's voice button
+  // runs across its own preflight, and for the same reason: the tail of this
+  // drain navigates and mints, and doing either against state the app has
+  // moved on from walks the user away from what they are actually doing. The
+  // notice waits until after the guards too, so an answer about the assistant
+  // the user left never surfaces against the one they moved to.
+  //
+  // A session started from the composer mid-preflight is the session the user
+  // is in, so the press is spent exactly as `startVoiceFromSurface` spends one
+  // it finds already running: the starter would refuse a second anyway, and
+  // navigating would only leave the composer that owns it.
+  if (isLiveVoiceSessionActive(useLiveVoiceStore.getState().state)) {
+    consume();
+    return;
+  }
+  // A switch to another assistant mid-preflight, on the other hand, is a race
+  // rather than a decision: both the eligibility gate and this verdict answered
+  // for an assistant that is no longer the one a fresh start means. Nothing has
+  // been navigated or minted yet, so the request stays parked and the next
+  // drain runs both against whoever is active by then.
+  if (useResolvedAssistantsStore.getState().activeAssistantId !== assistantId) {
+    return;
+  }
   publishConfigNotice(readiness.notice);
   if (!readiness.allowed) {
     consume();

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
@@ -2382,27 +2382,16 @@ describe("draft materialization", () => {
     });
   }
 
-  test("a dispatched turn whose row reaches the list stops being a draft", async () => {
-    // The composer's voice button starts on whatever key it is bound to, and a
-    // new chat's key is a client-minted draft, so this covers that route as
-    // much as the deep-link drain's freshly minted one.
+  // What reconciliation does with a list is `use-materialized-draft-reconcile`'s
+  // own test's subject. What a voice session adds is a turn that can be
+  // cancelled before it dispatches, so that is the only case tested here.
+  test("a turn cancelled before its row exists leaves the draft intact", async () => {
     useConversationStore.getState().registerDraftConversationId("conv-draft");
     const h = renderController();
     await startOn(h, "conv-draft");
     await emitThinking(h);
     // The frame alone is a promise of a turn, not a row.
     expect(isDraft("conv-draft")).toBe(true);
-
-    reconcileMaterializedDrafts(["conv-draft"]);
-
-    expect(isDraft("conv-draft")).toBe(false);
-  });
-
-  test("a turn cancelled before its row exists leaves the draft intact", async () => {
-    useConversationStore.getState().registerDraftConversationId("conv-draft");
-    const h = renderController();
-    await startOn(h, "conv-draft");
-    await emitThinking(h);
 
     await act(async () => {
       await h.view.result.current.stop();
@@ -2412,19 +2401,6 @@ describe("draft materialization", () => {
     reconcileMaterializedDrafts(["conv-unrelated"]);
 
     expect(isDraft("conv-draft")).toBe(true);
-  });
-
-  test("a materialized row clears only its own key", async () => {
-    useConversationStore.getState().registerDraftConversationId("conv-draft");
-    useConversationStore.getState().registerDraftConversationId("conv-other");
-    const h = renderController();
-    await startOn(h, "conv-draft");
-    await emitThinking(h);
-
-    reconcileMaterializedDrafts(["conv-draft"]);
-
-    expect(isDraft("conv-draft")).toBe(false);
-    expect(isDraft("conv-other")).toBe(true);
   });
 });
 

--- a/clients/web/src/domains/chat/voice/voice-draft-conversation.ts
+++ b/clients/web/src/domains/chat/voice/voice-draft-conversation.ts
@@ -13,23 +13,34 @@
  * outside the chat is a new call), while push-to-talk dictates into whatever
  * conversation is already selected and only mints when none is.
  *
- * `setMainView("chat")` is part of the mint rather than a step after it. On
- * desktop the composer counts as on screen only while the main view is the
- * chat ({@link useComposerOnScreen}), so a draft minted behind the app viewer
- * would be a conversation with no composer to speak into.
+ * Bringing the chat on screen is part of the mint rather than a step after it.
+ * On desktop the composer counts as on screen only while the main view is not
+ * the fullscreen app viewer ({@link useComposerOnScreen}), so a draft minted
+ * behind that viewer would be a conversation with no composer to speak into.
+ * It goes through {@link revealConversationView} for the same reason every
+ * other new-conversation path does: an app already open on a wide viewport
+ * keeps its side-by-side layout with the draft as the chat pane, and
+ * `app-editing` still counts as on screen, so the voice room opens either way.
  */
 
 import { createDraftConversationId } from "@/domains/chat/utils/conversation-selection";
 import { useConversationStore } from "@/stores/conversation-store";
 import { useViewerStore } from "@/stores/viewer-store";
+import { revealConversationView } from "@/utils/conversation-navigation";
 
 /**
- * Mint a fresh draft conversation, select it, and put the chat on screen.
+ * Mint a fresh draft conversation, select it, and bring the chat on screen.
  * Returns the draft's id, which is the key its composer is bound to.
+ *
+ * The transcript side panels are cleared with it, exactly as
+ * {@link navigateToNewConversation} does: a files or tool-detail panel opened
+ * against the previous conversation is about messages this draft does not
+ * have, so carrying it over shows the new chat someone else's payload.
  */
 export function mintVoiceDraftConversation(): string {
   const draftId = createDraftConversationId();
   useConversationStore.getState().setActiveConversationId(draftId);
-  useViewerStore.getState().setMainView("chat");
+  useViewerStore.getState().clearTranscriptPanelPayloads();
+  revealConversationView(draftId);
   return draftId;
 }

--- a/clients/web/src/domains/chat/voice/voice-room/use-is-voice-room-visible.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/use-is-voice-room-visible.test.tsx
@@ -59,6 +59,11 @@ mock.module("@/hooks/use-is-mobile", () => ({
 
 mock.module("@/utils/conversation-navigation", () => ({
   navigateToConversation: () => {},
+  // What the draft mint calls to bring the chat on screen. Stood in with the
+  // plain reveal the real one falls through to, since no app is open here.
+  revealConversationView: () => {
+    useViewerStore.getState().setMainView("chat");
+  },
 }));
 
 mock.module("@/hooks/use-assistant-avatar", () => ({

--- a/clients/web/src/hooks/use-global-deep-link-consumer.test.tsx
+++ b/clients/web/src/hooks/use-global-deep-link-consumer.test.tsx
@@ -43,7 +43,10 @@ import { stubViewportAxes } from "@/hooks/viewport-axes.test-helper";
 let mockPathname: string = routes.assistant;
 let mockSearch = "";
 const navigateMock = mock(
-  (to: string | { pathname: string; search?: string; hash?: string }) => {
+  (
+    to: string | { pathname: string; search?: string; hash?: string },
+    _options?: { replace?: boolean },
+  ) => {
     const path = typeof to === "string" ? to : to.pathname;
     mockPathname = path.split("?")[0] ?? path;
     return undefined;


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for ios-widgets-v2.md: the drain revalidates session and assistant state after its network await, the fresh-draft mint clears transcript panels and reveals the conversation like its sibling paths, and duplicated reconcile test coverage is consolidated.