### PR TITLE
fix(web): hold the voice-room avatar still while it responds (LUM-3455)

### DIFF
--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
@@ -406,10 +406,11 @@ export interface LiveVoiceState {
    * Provider for the assistant's TTS *output* amplitude in [0, 1], registered
    * by the controller from the active session's {@link LiveVoiceAudioPlayer}
    * (its output-bus analyser). `null` when there is no session, or on a context
-   * that can't meter. Read via {@link getLiveVoiceOutputAmplitude}; the room
-   * avatar routes between this and the mic amplitude by phase — see
-   * {@link getLiveVoiceAvatarAmplitude}. A registered provider (like `controls`)
-   * so a non-`speaking` read costs nothing and it clears on session reset.
+   * that can't meter. Read via {@link getLiveVoiceOutputAmplitude} by the room's
+   * `responding` band and the output meters on the composer bar and the pill;
+   * the mic amplitude behind `listening` is a separate field. A registered
+   * provider (like `controls`) so a non-`speaking` read costs nothing and it
+   * clears on session reset.
    */
   outputAmplitudeProvider: (() => number) | null;
   /**

--- a/clients/web/src/domains/chat/voice/live-voice/tts-playback.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/tts-playback.test.ts
@@ -595,7 +595,7 @@ describe("LiveVoiceAudioPlayer", () => {
     });
   });
 
-  test("reading the output level leaves the avatar's meter untouched", () => {
+  test("reading the output level leaves the band's meter untouched", () => {
     const { player: metered, ctx: meteredCtx } = makeMeteringPlayer();
     meteredCtx.level = 0.05;
     metered.enqueue(chunk(new Array(24000).fill(8000)));
@@ -604,11 +604,11 @@ describe("LiveVoiceAudioPlayer", () => {
     const instant = metered.readOutputLevel();
     expect(instant).toBeGreaterThan(0);
 
-    // Two consumers on different cadences share this player. The avatar's
-    // meter is a stateful EMA advanced by every call, so the measurement path
-    // must not read through it: otherwise the probe would drag the avatar's
-    // level around, and its own numbers would depend on whether the avatar is
-    // mounted at all.
+    // Two consumers on different cadences share this player. The band's meter
+    // is a stateful EMA advanced by every call, so the measurement path must
+    // not read through it: otherwise the probe would drag the band's level
+    // around, and its own numbers would depend on whether the band is mounted
+    // at all.
     const first = metered.getOutputAmplitude();
     metered.readOutputLevel();
     metered.readOutputLevel();

--- a/clients/web/src/domains/chat/voice/live-voice/tts-playback.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/tts-playback.ts
@@ -89,20 +89,20 @@ const CONTAINER_MIME_TYPES: ReadonlySet<string> = new Set([
 const RAW_PCM_MIME_TYPE = "audio/pcm";
 
 /**
- * Output-amplitude metering tuning for the voice-room avatar's speaking pulse
+ * Output-amplitude metering tuning for the assistant's own band
  * (see {@link LiveVoiceAudioPlayer.getOutputAmplitude}). Speech RMS sits around
  * 0.05–0.2, so `GAIN` lifts it into a visible range; `SMOOTHING` is the EMA
- * weight toward each new read (~60 Hz from the avatar's rAF); `DECAY` eases the
- * pulse back to rest between turns. These are the visual-feel knobs.
+ * weight toward each new read (~60 Hz from the band's rAF); `DECAY` eases the
+ * band back to rest between turns. These are the visual-feel knobs.
  */
 /*
  * What must match the capture path (`pcm-capture.ts`) is the *mapped* 0–1
  * range, not the constants: the two meters measure different things. That one
  * is a microphone in a room, this one is the output bus, and their raw RMS
  * ranges are nowhere near each other — so identical gains would be the bug,
- * not the fix. Both feed the same visuals (the room's wave band, the
- * responding rings, the avatar), so what a surface tuned against one signal
- * needs is for the other to arrive on the same scale.
+ * not the fix. Both feed the same visuals (the room's two bands, the composer
+ * bar and the pill), so what a surface tuned against one signal needs is for
+ * the other to arrive on the same scale.
  *
  * The original gain of 4 came from an assumed speech RMS of 0.05–0.2. Measured
  * against the rendered band, this path actually sits an order of magnitude
@@ -170,8 +170,9 @@ export interface AudioContextLike {
   createMediaStreamDestination?(): MediaStreamAudioDestinationNode;
   /**
    * Create an analyser tapping the output bus for amplitude metering (drives
-   * the voice-room avatar's TTS-reactive pulse). Optional so lightweight test
-   * contexts can omit it — the player then degrades to no metering
+   * the voice room's responding band and the composer bar's output meter).
+   * Optional so lightweight test contexts can omit it; the player then
+   * degrades to no metering
    * ({@link LiveVoiceAudioPlayer.getOutputAmplitude} returns 0).
    */
   createAnalyser?(): AnalyserNode;
@@ -340,8 +341,8 @@ export class LiveVoiceAudioPlayer {
    *
    * Deliberately AFTER the analyser: muting is about the user's ears, not
    * about what is true. The assistant is still speaking while muted, so the
-   * room's bands and the avatar's reaction keep showing that it is, and the
-   * user can see the reply land rather than watching a dead screen.
+   * room's bands keep showing that it is, and the user can see the reply land
+   * rather than watching a dead screen.
    */
   private outputGain: GainNode | null = null;
 
@@ -518,8 +519,8 @@ export class LiveVoiceAudioPlayer {
     source.buffer = buffer;
 
     // Route through the metering analyser when present (so output amplitude can
-    // drive the room avatar), then the mute gain, then the destination. Each
-    // stage is optional, so fall through to whichever exists.
+    // drive the room's responding band), then the mute gain, then the
+    // destination. Each stage is optional, so fall through to whichever exists.
     source.connect(
       this.analyser ??
         this.outputGain ??
@@ -851,11 +852,11 @@ export class LiveVoiceAudioPlayer {
   /**
    * Current smoothed output amplitude in [0, 1], read from the output-bus
    * analyser — the RMS of the audio the assistant is speaking right now. Drives
-   * the voice-room avatar's `responding` pulse (the mic amplitude that drives
-   * `listening` is near-silent while the assistant speaks, which is why the
-   * avatar previously looked inverted — see JARVIS-1267).
+   * the voice room's `responding` band, and the output meters on the composer
+   * bar and the title-bar pill. It has to come off the output bus: the mic
+   * amplitude behind `listening` is near-silent while the assistant speaks.
    *
-   * Polled ~60 Hz from the avatar's rAF loop: it EMA-smooths so the avatar
+   * Polled ~60 Hz from the band's rAF loop: it EMA-smooths so the band
    * breathes rather than jitters, and decays toward rest when nothing is
    * playing. Returns 0 with no analyser (test mock).
    */
@@ -867,7 +868,7 @@ export class LiveVoiceAudioPlayer {
     }
 
     if (!this.playingState) {
-      // Nothing scheduled — ease back to rest so the avatar settles between
+      // Nothing scheduled: ease back to rest so the band settles between
       // turns instead of holding the last speaking level.
       this.smoothedOutputAmplitude *= OUTPUT_AMPLITUDE_DECAY;
       return this.smoothedOutputAmplitude;
@@ -887,8 +888,8 @@ export class LiveVoiceAudioPlayer {
    * Separate from {@link getOutputAmplitude} because that one is a stateful EMA
    * tuned for a single ~60 Hz rAF consumer: every call advances its smoothing,
    * so a second caller on a different cadence would both perturb what the
-   * avatar displays and make its own readings depend on whether the avatar
-   * happens to be mounted. A measurement has to be independent of who else is
+   * band displays and make its own readings depend on whether the band happens
+   * to be mounted. A measurement has to be independent of who else is
    * looking.
    */
   readOutputLevel(): number {

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -711,10 +711,11 @@ export function useLiveVoice(
       // A reconnect built a new player (or reused the standby one) while the
       // store still carries the user's mute; make the graph agree with it.
       player.setOutputMuted(useLiveVoiceStore.getState().outputMuted);
-      // Route the room avatar's `responding` pulse to real TTS output. The mic
-      // amplitude (the only prior source) is near-silent while the assistant
-      // speaks, so the avatar looked inverted — pulsing on the user's voice, not
-      // the assistant's. Cleared by the store reset in teardown()/stop().
+      // The assistant's own voice, for every surface that draws it: the voice
+      // room's responding band, the composer bar and the title-bar pill. It has
+      // to come off the output bus rather than the mic, which is near-silent
+      // while the assistant speaks. Cleared by the store reset in
+      // teardown()/stop().
       store.setOutputAmplitudeProvider(() => player.getOutputAmplitude());
       // Feed the voice-room transcript's spoken-word cursor: it maps the
       // player's played/total seconds onto the caption's words each animation

--- a/clients/web/src/domains/chat/voice/voice-room/voice-avatar.stories.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-avatar.stories.tsx
@@ -36,16 +36,15 @@ import {
 
 /**
  * Iteration harness for the live-voice room's avatar + state animations. Scrub
- * `visual` through every session phase and drive the audio-reactive visuals
- * with the `amplitude` slider or the `oscillate` "simulated speech" toggle — no
- * live mic / STT / TTS session required.
+ * `visual` through every session phase and drive the bands with the
+ * `amplitude` slider or the `oscillate` "simulated speech" toggle, with no live
+ * mic / STT / TTS session required.
  *
- * `listening` renders the top-edge waves (energy coming *in* from the user)
- * and the avatar stays at rest; `responding` radiates the concentric rings from
- * behind the avatar (energy going *out*, the same treatment the color look's
- * eyes use). Wave `waveStyle` (fill / line) and `palette` (aurora / accent) are
- * the design knobs. `realAvatar` swaps the "V" fallback for a real bundled
- * character.
+ * Both voices are bands at the room's floor: `listening` rides the mic in pale
+ * ink, `responding` rides the TTS in dark. The centerpiece is still through
+ * both, so the ink says whose turn it is. Wave `waveStyle` (fill / line) and
+ * `palette` (aurora / accent) are the design knobs. `realAvatar` swaps the "V"
+ * fallback for a real bundled character.
  *
  * Nothing hits the network: the real avatar is seeded into the query cache
  * below, on the room's own deep-dark `data-theme="dark"` void.
@@ -157,8 +156,8 @@ interface RoomSceneProps {
 /**
  * The room an assistant with an uploaded image gets: the field color sampled
  * out of that image, the same voice bands and caption every look draws, and the
- * image itself in the centerpiece the eyes would otherwise hold. One amplitude
- * source drives the avatar and the bands together.
+ * image itself in the centerpiece the eyes would otherwise hold. The amplitude
+ * source drives the bands; the centerpiece holds still under them.
  *
  * `fieldHex: null` is the other thing this scene shows: the room before the
  * sample lands (or after it fails), which is the deep-dark ambient void with
@@ -276,8 +275,8 @@ interface ColorLookSceneProps {
 
 /**
  * The color-with-eyes look for one avatar: the Introduction-step grow entrance
- * (body springs to fill, color fades in, eyes grow into place), the mic
- * waveform behind the eyes while `listening`, all in a measured box so the
+ * (body springs to fill, color fades in, eyes grow into place), the mic band
+ * rising from the floor while `listening`, all in a measured box so the
  * geometry sizes against the story frame rather than the window. The whole
  * look remounts (replaying the entrance) whenever `replay` or any trait knob
  * changes.

--- a/clients/web/src/domains/chat/voice/voice-room/voice-avatar.stories.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-avatar.stories.tsx
@@ -229,7 +229,6 @@ function RoomScene({
         <VoiceAvatar
           assistantId={realAvatar ? SAMPLE_ASSISTANT_ID : null}
           visual={visual}
-          getAmplitude={getAmplitude}
           size={size}
         />
       </div>

--- a/clients/web/src/domains/chat/voice/voice-room/voice-avatar.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-avatar.test.tsx
@@ -19,7 +19,7 @@ import type { VoiceAvatarVisual } from "./voice-avatar-state";
 // The avatar query pulls React Query and the daemon graph; the phase classes
 // are what this file is about. Both factories are typed against the module
 // they replace, so a stub that drifts from the real shape is a type error
-// rather than a green suite testing behavior the app no longer has.
+// rather than a green suite testing a shape the app does not have.
 mock.module(
   "@/hooks/use-assistant-avatar",
   (): Partial<typeof AssistantAvatarModule> => ({

--- a/clients/web/src/domains/chat/voice/voice-room/voice-avatar.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-avatar.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * The voice room's centered avatar expresses the session phase and nothing
+ * else. It used to ride the TTS output through a per-frame custom property,
+ * which put the assistant's voice on screen twice once the floor band existed,
+ * so these pin that it reads no audio at all: no frame loop, no amplitude
+ * property, whatever phase it is in.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+
+import { cleanup, render, screen } from "@testing-library/react";
+
+import type { VoiceAvatarVisual } from "./voice-avatar-state";
+
+// The avatar query pulls React Query and the daemon graph; the phase classes
+// are what this file is about.
+mock.module("@/hooks/use-assistant-avatar", () => ({
+  useAssistantAvatar: () => ({
+    components: null,
+    traits: null,
+    customImageUrl: null,
+  }),
+}));
+
+mock.module("@/components/avatar/chat-avatar", () => ({
+  ChatAvatar: () => <div data-testid="chat-avatar" />,
+}));
+
+const { VoiceAvatar } = await import("./voice-avatar");
+
+const VISUALS: VoiceAvatarVisual[] = [
+  "idle",
+  "listening",
+  "thinking",
+  "responding",
+  "reconnecting",
+];
+
+/** The node carrying the phase class, found by that class rather than by
+ *  nesting, so the assertions do not double as a DOM-shape test. */
+function avatarNode(): HTMLElement {
+  const node = document.querySelector<HTMLElement>(".voice-avatar");
+  if (!node) {
+    throw new Error("avatar node missing");
+  }
+  return node;
+}
+
+let rafSpy: ReturnType<typeof spyOn>;
+
+beforeEach(() => {
+  rafSpy = spyOn(window, "requestAnimationFrame");
+});
+
+afterEach(() => {
+  rafSpy.mockRestore();
+  cleanup();
+});
+
+describe("VoiceAvatar", () => {
+  test("carries the phase as a class, in every phase", () => {
+    for (const visual of VISUALS) {
+      render(<VoiceAvatar assistantId="assistant-1" visual={visual} />);
+      expect(avatarNode().className).toContain(`voice-avatar--${visual}`);
+      cleanup();
+    }
+  });
+
+  test("schedules no frame loop while responding", () => {
+    // A rAF here would only ever be an amplitude poll: the phase treatments are
+    // CSS loops, and the entry spring belongs to the room.
+    render(<VoiceAvatar assistantId="assistant-1" visual="responding" />);
+    expect(rafSpy).not.toHaveBeenCalled();
+  });
+
+  test("writes no amplitude property in any phase", () => {
+    for (const visual of VISUALS) {
+      render(<VoiceAvatar assistantId="assistant-1" visual={visual} />);
+      expect(avatarNode().style.getPropertyValue("--voice-amp")).toBe("");
+      cleanup();
+    }
+  });
+
+  test("renders the fallback avatar with no assistant", () => {
+    render(<VoiceAvatar assistantId={null} visual="idle" />);
+    expect(screen.getByTestId("chat-avatar")).toBeTruthy();
+  });
+});

--- a/clients/web/src/domains/chat/voice/voice-room/voice-avatar.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-avatar.test.tsx
@@ -7,23 +7,40 @@
 
 import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 
+import { memo } from "react";
+
 import { cleanup, render, screen } from "@testing-library/react";
+
+import type * as ChatAvatarModule from "@/components/avatar/chat-avatar";
+import type * as AssistantAvatarModule from "@/hooks/use-assistant-avatar";
 
 import type { VoiceAvatarVisual } from "./voice-avatar-state";
 
 // The avatar query pulls React Query and the daemon graph; the phase classes
-// are what this file is about.
-mock.module("@/hooks/use-assistant-avatar", () => ({
-  useAssistantAvatar: () => ({
-    components: null,
-    traits: null,
-    customImageUrl: null,
+// are what this file is about. Both factories are typed against the module
+// they replace, so a stub that drifts from the real shape is a type error
+// rather than a green suite testing behavior the app no longer has.
+mock.module(
+  "@/hooks/use-assistant-avatar",
+  (): Partial<typeof AssistantAvatarModule> => ({
+    useAssistantAvatar: () => ({
+      components: null,
+      traits: null,
+      customImageUrl: null,
+      isLoading: false,
+      invalidate: () => {},
+    }),
   }),
-}));
+);
 
-mock.module("@/components/avatar/chat-avatar", () => ({
-  ChatAvatar: () => <div data-testid="chat-avatar" />,
-}));
+// `memo` because the real export is one, and the phase classes live on the
+// wrapper above this, so the avatar itself only has to be findable.
+mock.module(
+  "@/components/avatar/chat-avatar",
+  (): Partial<typeof ChatAvatarModule> => ({
+    ChatAvatar: memo(() => <div data-testid="chat-avatar" />),
+  }),
+);
 
 const { VoiceAvatar } = await import("./voice-avatar");
 

--- a/clients/web/src/domains/chat/voice/voice-room/voice-avatar.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-avatar.test.tsx
@@ -1,9 +1,8 @@
 /**
  * The voice room's centered avatar expresses the session phase and nothing
- * else. It used to ride the TTS output through a per-frame custom property,
- * which put the assistant's voice on screen twice once the floor band existed,
- * so these pin that it reads no audio at all: no frame loop, no amplitude
- * property, whatever phase it is in.
+ * else. The assistant's voice is drawn as a band at the room's floor, so an
+ * avatar that tracked it too would put one signal on screen twice. These pin
+ * that it reads no audio in any phase: no frame loop, no amplitude property.
  */
 
 import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";

--- a/clients/web/src/domains/chat/voice/voice-room/voice-avatar.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-avatar.tsx
@@ -1,6 +1,3 @@
-import { useReducedMotion } from "motion/react";
-import { useEffect, useLayoutEffect, useRef } from "react";
-
 import { ChatAvatar } from "@/components/avatar/chat-avatar";
 import { useAssistantAvatar } from "@/hooks/use-assistant-avatar";
 
@@ -13,24 +10,8 @@ export interface VoiceAvatarProps {
   assistantId: string | null;
   /** Current visual mode, derived from the live-voice session phase. */
   visual: VoiceAvatarVisual;
-  /**
-   * Amplitude source (0–1), polled inside a rAF loop for the audio-reactive
-   * visuals so amplitude never flows through React state/props.
-   */
-  getAmplitude: () => number;
   /** Rendered avatar diameter in px. */
   size?: number;
-}
-
-/**
- * Visuals whose scale rides live amplitude via the rAF loop. Only `responding`
- * (the assistant is speaking): the avatar emits an outward pulse on its own TTS
- * output. `listening` deliberately stays at rest — the user's voice is expressed
- * by the bottom waves coming *in* (see voice-listening-waves.tsx), not by
- * scaling the avatar.
- */
-function isAudioReactive(visual: VoiceAvatarVisual): boolean {
-  return visual === "responding";
 }
 
 /**
@@ -45,81 +26,31 @@ function isAudioReactive(visual: VoiceAvatarVisual): boolean {
  * place rather than the whole avatar re-popping. The one-time entry spring is
  * owned by the room wrapper (see `voice-room.tsx`), not here.
  *
- * For the audio-reactive visuals a requestAnimationFrame loop polls
- * `getAmplitude()` and writes the `--voice-amp` custom property on the outer
- * `.voice-avatar` node — never through React state, so per-sample updates cause
- * no re-render. It's written on the outer node (not the `__amp` child) so the
- * `::after` emanation ring can read it: only `responding` is reactive, and its
- * TTS-output amplitude drives the color emanating outward (see index.css).
- * Reduced-motion users get the static avatar (CSS loops disabled).
+ * Nothing here reads audio. Both halves of a turn are drawn as bands at the
+ * room's floor, so the avatar states are the session's phase and the bands are
+ * its voice: `listening` and `responding` differ by which band is up, not by
+ * anything the avatar does. Reduced-motion users get the static avatar (CSS
+ * loops disabled).
  */
 export function VoiceAvatar({
   assistantId,
   visual,
-  getAmplitude,
   size = DEFAULT_SIZE,
 }: VoiceAvatarProps) {
-  const reduce = useReducedMotion();
   const { components, traits, customImageUrl } =
     useAssistantAvatar(assistantId);
 
-  const ampRef = useRef<HTMLDivElement | null>(null);
-  // Keep the latest amplitude source without re-initializing the rAF loop.
-  const getAmplitudeRef = useRef(getAmplitude);
-  useLayoutEffect(() => {
-    getAmplitudeRef.current = getAmplitude;
-  }, [getAmplitude]);
-
-  const audioReactive = isAudioReactive(visual);
-
-  useEffect(() => {
-    const node = ampRef.current;
-    if (!node) {
-      return;
-    }
-    // Non-reactive visuals (or reduced motion) sit at rest.
-    if (reduce || !audioReactive) {
-      node.style.setProperty("--voice-amp", "0");
-      return;
-    }
-
-    let rafId = 0;
-    let lastWritten = "";
-    const tick = () => {
-      const amp = Math.min(1, Math.max(0, getAmplitudeRef.current()));
-      const next = amp.toFixed(3);
-      // Skip the style write (and its recalc) when the rounded value is
-      // unchanged — amplitude often holds flat between frames.
-      if (next !== lastWritten) {
-        lastWritten = next;
-        node.style.setProperty("--voice-amp", next);
-      }
-      rafId = requestAnimationFrame(tick);
-    };
-    rafId = requestAnimationFrame(tick);
-    return () => {
-      cancelAnimationFrame(rafId);
-      node.style.setProperty("--voice-amp", "0");
-    };
-    // Re-runs on any visual change to start/stop the loop at the audio-reactive
-    // boundary; the avatar node itself is stable, so this only (re)attaches the
-    // rAF, it never remounts the avatar.
-  }, [visual, audioReactive, reduce]);
-
   return (
     <div
-      ref={ampRef}
       className={`voice-avatar voice-avatar--${visual}`}
       style={{ width: size, height: size }}
     >
-      <div className="voice-avatar__amp">
-        <ChatAvatar
-          components={components}
-          traits={traits}
-          customImageUrl={customImageUrl}
-          size={size}
-        />
-      </div>
+      <ChatAvatar
+        components={components}
+        traits={traits}
+        customImageUrl={customImageUrl}
+        size={size}
+      />
     </div>
   );
 }

--- a/clients/web/src/domains/chat/voice/voice-room/voice-avatar.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-avatar.tsx
@@ -17,14 +17,15 @@ export interface VoiceAvatarProps {
 /**
  * The large, state-driven assistant avatar at the center of the live-voice
  * room. Resolves the real assistant avatar (character / custom image / "V"
- * fallback) via {@link useAssistantAvatar} and expresses the session phase
- * through a continuous per-visual CSS loop (see `.voice-avatar-*` in
- * index.css).
+ * fallback) via {@link useAssistantAvatar} and carries the session phase as a
+ * `voice-avatar--<visual>` class, which idle, listening, thinking and
+ * reconnecting each answer with a CSS loop (see `.voice-avatar-*` in
+ * index.css). `responding` has no loop: it holds still.
  *
- * The avatar node stays mounted for the whole session: a visual change only
- * swaps the `voice-avatar--<visual>` class, so the CSS loop cross-fades in
- * place rather than the whole avatar re-popping. The one-time entry spring is
- * owned by the room wrapper (see `voice-room.tsx`), not here.
+ * The avatar node stays mounted for the whole session, so a visual change only
+ * swaps that class and the loops cross-fade in place rather than the whole
+ * avatar re-popping. The one-time entry spring is owned by the room wrapper
+ * (see `voice-room.tsx`), not here.
  *
  * Nothing here reads audio. Both halves of a turn are drawn as bands at the
  * room's floor, so the avatar states are the session's phase and the bands are

--- a/clients/web/src/domains/chat/voice/voice-room/voice-listening-waves.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-listening-waves.tsx
@@ -1,15 +1,16 @@
 /**
  * Listening-state waves for the voice room: layered sine waves that swell as
- * the user speaks — the visual language of energy coming *in* (the user's
- * voice arriving), the counterpart to the assistant's outward `responding`
- * pulse on the avatar. `placement` anchors the band: `top` sweeps in from the
- * ceiling edge (both looks — above the centerpiece, leaving it clear), `bottom`
- * rises from the floor edge, `center` is a symmetric band around the middle.
+ * the user speaks. Its counterpart is the assistant's own band, the same
+ * geometry fed the TTS output in the opposite ink, so a turn changing hands
+ * changes the ink rather than the visual language. `placement` anchors the
+ * band: the room draws both voices at `bottom`, rising from the floor edge and
+ * leaving the centerpiece clear; `top` sweeps in from the ceiling edge and
+ * `center` is a symmetric band around the middle.
  *
- * The waves always drift horizontally (a slow CSS loop); the user's live mic
- * amplitude drives how high they rise and how bright they are, written
- * imperatively to `--voice-amp` from a requestAnimationFrame loop — never React
- * state, matching `voice-avatar.tsx`. The polled amplitude is near-instant RMS
+ * The waves always drift horizontally (a slow CSS loop); the live amplitude
+ * drives how high they rise and how bright they are, written imperatively to
+ * `--voice-amp` from a requestAnimationFrame loop rather than through React
+ * state. The polled amplitude is near-instant RMS
  * (see `createAmplitudeSmoother`), so the loop runs it through a VU-meter-style
  * attack/release smoother before writing — raw, it jerks the waves' large
  * vertical travel every frame. Purely decorative; the cyan→indigo accent is a

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -827,11 +827,6 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
           <VoiceAvatar
             assistantId={assistantId}
             visual={visual}
-            // Only the `responding` avatar is audio-reactive, and it always
-            // rides TTS output — so the output amplitude is the sole source
-            // here. The user's voice is expressed by the bottom waves in
-            // `listening`, not by the avatar.
-            getAmplitude={getLiveVoiceOutputAmplitude}
             size={AVATAR_SIZE}
           />
         </motion.div>

--- a/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-room.tsx
@@ -816,9 +816,11 @@ function VoiceRoomOverlay({ variant }: { variant: VoiceRoomVariant }) {
 
       {/* The centerpiece for every assistant without eyes: an uploaded image,
           or none resolved yet. It springs to center once on entry (the wrapper
-          owns the one-time entry spring); per-state expression is the avatar's
-          own CSS loop, which cross-fades in place without re-popping. A
-          character look has no centered figure: its eyes are the cast. */}
+          owns the one-time entry spring); the phases that express themselves on
+          the avatar do it through its own CSS loop, cross-fading in place
+          without re-popping, and `responding` holds still while the band at the
+          floor carries the turn. A character look has no centered figure: its
+          eyes are the cast. */}
       {!camera.native && !look?.art ? (
         <motion.div
           className="relative z-0"

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -946,22 +946,19 @@ html[data-page-transition="pop"]::view-transition-new(root) {
 
 /* ─── Live-voice room avatar ─────────────────────────────────────────────────
  * State-driven animation for the enlarged assistant avatar in the voice room.
- * Each live-voice visual (idle / listening / thinking / responding /
- * reconnecting) gets one continuous CSS loop here; the discrete enter/scale
- * transition when the visual changes is a motion spring at the call site. Only
- * the `responding` visual rides live amplitude (the assistant's TTS output),
- * fed imperatively through the `--voice-amp` custom property by a
- * requestAnimationFrame loop — never React state. `listening` stays at rest;
- * the user's voice is expressed by the top-edge waves coming in (see
- * voice-listening-waves.tsx). See voice-avatar.tsx.
+ * Each live-voice visual (idle / listening / thinking / reconnecting) gets one
+ * continuous CSS loop here; the discrete enter/scale transition when the visual
+ * changes is a motion spring at the call site. See voice-avatar.tsx.
  *
- * The sonar ripple's cyan→indigo gradient is a deliberate decorative accent
- * that stays constant across all themes (like a data-viz series or annotation
+ * No loop rides audio. Both voices are drawn as bands at the room's floor (see
+ * voice-listening-waves.tsx), so an avatar that answered the same signal would
+ * say the same thing twice; `responding` holds the avatar still and lets the
+ * band carry the turn.
+ *
+ * The idle ring's cyan→indigo gradient is a deliberate decorative accent that
+ * stays constant across all themes (like a data-viz series or annotation
  * overlay), so it is expressed as fixed rgba rather than a theme token. */
 .voice-avatar {
-  /* Live amplitude (0–1) written per frame on this outer node for `responding`
-   * only, so the ::after emanation ring can read it. Defaults to 0. */
-  --voice-amp: 0;
   position: relative;
   display: inline-flex;
   align-items: center;
@@ -969,15 +966,8 @@ html[data-page-transition="pop"]::view-transition-new(root) {
   transform-origin: center;
 }
 
-/* Passive wrapper around the avatar. Body motion now lives on the state class
- * (a slight constant pulse); amplitude drives the ::after emanation, not this
- * layer, so the avatar body no longer scales with audio. */
-.voice-avatar__amp {
-  display: inline-flex;
-}
-
-/* Decorative ring layer: idle (invitation pulse) and responding (color
- * emanating outward). Inert until a visual class animates it. */
+/* Decorative ring layer for the idle invitation pulse. Inert until a visual
+ * class animates it. */
 .voice-avatar::after {
   content: "";
   position: absolute;
@@ -1034,36 +1024,8 @@ html[data-page-transition="pop"]::view-transition-new(root) {
   animation: voice-avatar-think-glow 2.6s ease-in-out infinite;
 }
 
-/* Responding — the avatar is speaking: a slight baseline bounce (the "pulse")
- * plus color emanating outward from it (the ::after ring), whose intensity
- * rides live TTS-output amplitude via `--voice-amp`. Energy going *out*, the
- * counterpart to listening's waves coming in. */
-@keyframes voice-avatar-respond-bounce {
-  0%, 100% { transform: scale(1); }
-  50% { transform: scale(1.03); }
-}
-
-.voice-avatar--responding {
-  animation: voice-avatar-respond-bounce 1.4s ease-in-out infinite;
-}
-
-/* The emanation itself: a ring continuously swelling out and fading (the
- * "emanating" motion); its color intensity scales with `--voice-amp` so louder
- * speech radiates more strongly, and it fades to nothing in the gaps. */
-@keyframes voice-avatar-emanate {
-  0% { opacity: 0.75; transform: scale(0.92); }
-  100% { opacity: 0; transform: scale(1.55); }
-}
-
-.voice-avatar--responding::after {
-  background: radial-gradient(
-    circle,
-    rgba(34, 211, 238, calc(0.12 + var(--voice-amp) * 0.5)) 0%,
-    rgba(99, 102, 241, calc(0.08 + var(--voice-amp) * 0.34)) 58%,
-    rgba(99, 102, 241, 0) 72%
-  );
-  animation: voice-avatar-emanate 1.6s ease-out infinite;
-}
+/* Responding has no loop of its own: the band at the floor is the assistant's
+ * voice, so the avatar holds still under it. */
 
 /* Reconnecting — dimmed, slow pulse, distinct from idle-breathe (full opacity)
  * and think-glow (brightens rather than dims). */
@@ -1080,12 +1042,10 @@ html[data-page-transition="pop"]::view-transition-new(root) {
   .voice-avatar--idle,
   .voice-avatar--listening,
   .voice-avatar--thinking,
-  .voice-avatar--responding,
   .voice-avatar--reconnecting {
     animation: none;
   }
-  .voice-avatar--idle::after,
-  .voice-avatar--responding::after {
+  .voice-avatar--idle::after {
     animation: none;
     opacity: 0;
   }

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -1113,11 +1113,11 @@ html[data-page-transition="pop"]::view-transition-new(root) {
 
 /* ─── Live-voice listening waves ─────────────────────────────────────────────
  * The `listening` visual language: layered sine waves along the bottom edge,
- * the user's voice arriving as energy coming *in* — distinct from `responding`,
- * where the avatar itself emits an outward pulse. The waves always drift
- * horizontally; live mic amplitude (`--voice-amp`, written per frame by a rAF
- * loop — never React state) lifts them up the screen and brightens them as the
- * user speaks. Cyan→indigo is a fixed decorative accent, matching the listening
+ * the user's voice arriving as energy coming *in*. `responding` answers from
+ * the same edge in the opposite ink, so the two are told apart by color rather
+ * than by position. The waves always drift horizontally; live amplitude
+ * (`--voice-amp`, written per frame by a rAF loop rather than through React
+ * state) lifts them up the screen and brightens them as the voice carries. Cyan→indigo is a fixed decorative accent, matching the listening
  * sonar, not a theme token. See voice-listening-waves.tsx. */
 .voice-listening-waves {
   --voice-amp: 0;


### PR DESCRIPTION
## Summary

- The centered custom-image avatar holds still while the assistant speaks. Its `::after` emanation ring rode the live TTS amplitude and its 1.4s bounce ran underneath, so every syllable flashed the avatar while the floor band was already drawing the same signal. The band is now the only thing carrying the assistant's turn.
- With that CSS gone nothing reads the avatar's `--voice-amp`, so the per-frame rAF loop, the `getAmplitude` prop and the `.voice-avatar__amp` wrapper are all deleted rather than left as an unread path. The avatar's other phases (idle invite ring, listening breath, thinking glow, reconnecting dim) are untouched.
- The character eyes keep their own responding reaction (`use-reactive-eyes.ts`), which is deliberately out of scope: it is a few-percent gesture on the eye group, not a full-avatar flash.

## Original prompt

Alex tried the unified voice room from LUM-3437 and found the custom-image avatar "flashing with the output" while responding. Since that PR the assistant's voice is a band at the room's floor, so the avatar expressing it too is double-signalling. Scope was chosen as the image avatar only, leaving the character eyes' subtler reaction alone.

## Verification

- `bun test` file by file on the touched suites: the new `voice-avatar.test.tsx` (4), `voice-room.test.tsx` (104), `use-custom-avatar-field.test.tsx` (6). The new tests fail against the previous component (a frame loop is scheduled while responding) and pass against this one.
- eslint clean on the touched files. Local `tsc` reports one pre-existing error in `chat-layout.tsx` (`togglePinConversation`) that comes from the worktree resolving `@vellumai/ipc-contract` to the main checkout's branch, not from this change; the branch's own `packages/ipc-contract/src/types.ts` declares it.
- Storybook `Chat/Voice/VoiceAvatar` → "Custom Image: States": responding is now a still avatar over the sampled field with the dark band at the floor, and the other four phases render as before.

## Worth a look

Responding is now fully still, while listening keeps its soft 3s breathing loop. If a long response reads as frozen rather than calm, the smallest follow-up is to give responding that same breath, which is constant rather than audio-driven and so would not bring the flashing back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XJXLNGL5SF2pFPNEhhmLpC