### PR TITLE
fix(widgets): gate snapshots on avatar readiness, retry failed encodes, share the encode cache

### DIFF
--- a/clients/web/src/domains/chat/components/chat-attachments/use-camera-deep-link.tsx
+++ b/clients/web/src/domains/chat/components/chat-attachments/use-camera-deep-link.tsx
@@ -85,9 +85,7 @@ export function useCameraDeepLink({
       return;
     }
     const consume = () =>
-      usePendingDeepLinkStore
-        .getState()
-        .consumePendingCamera(PENDING_CAMERA_TTL_MS);
+      usePendingDeepLinkStore.getState().consumePendingCamera();
     // Spent whatever the age: an expired park is not left behind for a later
     // mount to drain.
     if (Date.now() - pendingCamera.parkedAt > PENDING_CAMERA_TTL_MS) {

--- a/clients/web/src/domains/chat/hooks/use-native-widget-snapshot-sync.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-native-widget-snapshot-sync.test.tsx
@@ -46,6 +46,17 @@
  * its own copies from a parent effect, which React runs after this layout's,
  * and a snapshot that read those back would pin the previous assistant's face
  * in the dedup key across an in-SPA switch into a cached destination.
+ *
+ * The avatar query is therefore in the resolution guard too, on this side of
+ * the call rather than in the flag the caller passes. It settles after the
+ * conversation list often enough to be the ordinary case on a cold launch, and
+ * the plugin's write replaces the App Group record whole, so a first sync taken
+ * while it loads wipes a themed avatar off every widget until a second one
+ * repaints it. The encode behind it is the memo `avatar-island-encode` shares
+ * with the Live Activity mirror, so these tests thread their stub through its
+ * injection seam rather than restating its caching here: an encode that
+ * resolves to nothing is a fact about the avatar and is cached, while one that
+ * throws is the encoder failing and must be retried.
  */
 
 import {
@@ -159,16 +170,29 @@ const NO_AVATAR: AvatarData = {
   traits: null,
   customImageUrl: null,
 };
-let avatarData: AvatarData = NO_AVATAR;
+/**
+ * The query's whole return, loading flag included: the hook holds its first
+ * sync until that flag clears, so it is state a test drives rather than a
+ * constant.
+ */
+let avatarState: { data: AvatarData; isLoading: boolean } = {
+  data: NO_AVATAR,
+  isLoading: false,
+};
 const avatarListeners = new Set<() => void>();
 let encodeOutcome: "bytes" | "nothing-fits" | "throws" = "bytes";
 let encodeCalls = 0;
 /** Long enough that a dedup key carrying it would be unmistakable. */
 const AVATAR_BASE64 = "Zm9vYmFy".repeat(2_000);
 
+/** What the query serves from the next render on, without waking subscribers. */
+function setAvatar(data: AvatarData, isLoading = false): void {
+  avatarState = { data, isLoading };
+}
+
 /** Serve a new avatar the way a settling query does, waking its subscribers. */
 function publishAvatar(next: AvatarData): void {
-  avatarData = next;
+  setAvatar(next);
   for (const listener of avatarListeners) {
     listener();
   }
@@ -187,21 +211,38 @@ mock.module("@/hooks/use-assistant-avatar", () => ({
   // The assistant id is ignored: one avatar is served at a time, which is what
   // the real query does too once the active assistant's entry settles.
   useAssistantAvatar: () => {
-    const data = useSyncExternalStore(subscribeAvatar, () => avatarData);
-    return { ...data, isLoading: false, invalidate: () => {} };
+    const state = useSyncExternalStore(subscribeAvatar, () => avatarState);
+    return { ...state.data, isLoading: state.isLoading, invalidate: () => {} };
   },
 }));
 
+/** Stands in for the canvas draw, which happy-dom has no canvas for. */
+const stubEncode = async (): Promise<string | null> => {
+  encodeCalls++;
+  if (encodeOutcome === "throws") {
+    throw new Error("canvas unavailable");
+  }
+  return encodeOutcome === "bytes" ? AVATAR_BASE64 : null;
+};
+
 const realAvatarIslandEncode = await import("@/utils/avatar-island-encode");
+// Held before the mock is installed. `mock.module` updates live bindings, so a
+// wrapper that reached back through the namespace object at call time would
+// find itself rather than the real implementation.
+const realMemoizedAvatarEncode = realAvatarIslandEncode.memoizedAvatarEncode;
+const resetAvatarEncodeMemo =
+  realAvatarIslandEncode.__resetAvatarEncodeMemoForTesting;
 mock.module("@/utils/avatar-island-encode", () => ({
   ...realAvatarIslandEncode,
-  encodeAvatarForIsland: async () => {
-    encodeCalls++;
-    if (encodeOutcome === "throws") {
-      throw new Error("canvas unavailable");
-    }
-    return encodeOutcome === "bytes" ? AVATAR_BASE64 : null;
-  },
+  encodeAvatarForIsland: stubEncode,
+  // The REAL memo with the stub threaded through its injection seam, rather
+  // than a second memo written here: what these tests claim about caching and
+  // about retrying a failed encode is the shared helper's behavior, so it has
+  // to be the shared helper that answers for it.
+  memoizedAvatarEncode: (
+    source: Parameters<typeof realMemoizedAvatarEncode>[0],
+    maxBytes?: number,
+  ) => realMemoizedAvatarEncode(source, maxBytes, stubEncode),
 }));
 
 /**
@@ -345,10 +386,14 @@ beforeEach(() => {
   persistedAssistantId = null;
   podIsServing = true;
   armedTimers = [];
-  avatarData = NO_AVATAR;
+  setAvatar(NO_AVATAR);
   avatarListeners.clear();
   encodeOutcome = "bytes";
   encodeCalls = 0;
+  // The memo is module scope and shared with the Live Activity mirror, so a
+  // slot left by an earlier case (or an earlier file in the run) would answer
+  // for an avatar this one never encoded.
+  resetAvatarEncodeMemo();
   useConversationStore.setState({ processingConversationIds: new Set() });
 
   globalThis.setInterval = ((handler: () => void, delay: number) => {
@@ -1124,7 +1169,7 @@ describe("useNativeWidgetSnapshotSync", () => {
   });
 
   it("carries a character avatar's rendered accent and encoded face", async () => {
-    avatarData = characterAvatar("orange");
+    setAvatar(characterAvatar("orange"));
     render({
       conversations: [conversation("c1", { title: "Groceries" })],
       conversationGroups: NO_GROUPS,
@@ -1143,7 +1188,7 @@ describe("useNativeWidgetSnapshotSync", () => {
   it("carries a custom image with no accent to match", async () => {
     // The rendered accent is null for an uploaded avatar by construction, and
     // the widget blurs the photo for its background instead.
-    avatarData = imageAvatar("blob:avatar-1");
+    setAvatar(imageAvatar("blob:avatar-1"));
     render({
       conversations: [conversation("c1")],
       conversationGroups: NO_GROUPS,
@@ -1179,7 +1224,7 @@ describe("useNativeWidgetSnapshotSync", () => {
     // Both ways it can fail: nothing fit the budget, and the raster threw. The
     // widgets are for the counts and the rows, so neither may cost a snapshot.
     encodeOutcome = "nothing-fits";
-    avatarData = characterAvatar("orange");
+    setAvatar(characterAvatar("orange"));
     const { rerender } = render({
       conversations: [conversation("c1", { title: "Groceries" })],
       conversationGroups: NO_GROUPS,
@@ -1194,7 +1239,7 @@ describe("useNativeWidgetSnapshotSync", () => {
     expect(syncedSnapshots[0]?.conversations).toHaveLength(1);
 
     encodeOutcome = "throws";
-    avatarData = characterAvatar("orange");
+    setAvatar(characterAvatar("orange"));
     rerender({
       conversations: [conversation("c1", { title: "Groceries" })],
       conversationGroups: NO_GROUPS,
@@ -1206,10 +1251,142 @@ describe("useNativeWidgetSnapshotSync", () => {
     expect(syncedSnapshots[1]?.conversations).toHaveLength(1);
   });
 
+  it("holds the first sync until the avatar query settles", async () => {
+    // The cold launch this closes: the avatar query routinely settles after the
+    // conversation list, and the plugin replaces the App Group record whole, so
+    // a first sync taken on the loading state would ship `kind: "none"`, wipe
+    // the themed avatar the previous run left behind, and flash every widget to
+    // the brand palette until a second sync repainted it.
+    setAvatar(NO_AVATAR, true);
+    const { rerender } = render({
+      conversations: [conversation("c1", { title: "Groceries" })],
+      conversationGroups: NO_GROUPS,
+      inputsResolved: true,
+    });
+    await settle();
+    expect(syncedSnapshots).toHaveLength(0);
+
+    // Nothing about the conversations moves: the avatar arriving is the event.
+    act(() => {
+      publishAvatar(characterAvatar("orange"));
+    });
+    await settle();
+
+    expect(syncedSnapshots).toHaveLength(1);
+    expect(syncedSnapshots[0]?.avatar).toEqual({
+      kind: "character",
+      accentHex: ORANGE_HEX,
+      imageBase64: AVATAR_BASE64,
+    });
+    expect(syncedSnapshots[0]?.conversations).toHaveLength(1);
+
+    // A later render of the same data is deduped, so the held sync cost nothing
+    // beyond the wait.
+    rerender({
+      conversations: [conversation("c1", { title: "Groceries" })],
+      conversationGroups: NO_GROUPS,
+      inputsResolved: true,
+    });
+    expect(syncedSnapshots).toHaveLength(1);
+  });
+
+  it("arms no heartbeat while the avatar query is still loading", () => {
+    // The heartbeat asserts the snapshot is current, and a run that has not
+    // sent one yet has no freshness to keep.
+    setAvatar(NO_AVATAR, true);
+    const { rerender } = render({
+      conversations: [conversation("c1", { title: "Groceries" })],
+      conversationGroups: NO_GROUPS,
+      inputsResolved: true,
+    });
+    expect(liveHeartbeats()).toHaveLength(0);
+
+    act(() => {
+      publishAvatar(characterAvatar("orange"));
+    });
+    rerender({
+      conversations: [conversation("c1", { title: "Groceries" })],
+      conversationGroups: NO_GROUPS,
+      inputsResolved: true,
+    });
+    expect(liveHeartbeats()).toHaveLength(1);
+  });
+
+  it("does not wait on an avatar query with no assistant to load one for", () => {
+    // The query is gated off before an assistant resolves, so waiting on it
+    // would hold every signed-out session's snapshot forever.
+    setAvatar(NO_AVATAR, true);
+    render({
+      assistantId: null,
+      conversations: [conversation("c1", { title: "Groceries" })],
+      conversationGroups: NO_GROUPS,
+      inputsResolved: true,
+    });
+    expect(syncedSnapshots).toHaveLength(1);
+    expect(syncedAssistantIds).toEqual([null]);
+  });
+
+  it("retries an avatar encode that threw rather than pinning the session", async () => {
+    // A canvas the shell would not hand over, or a blob URL revoked mid-draw:
+    // transient, and cached as `no avatar` it would strip the face off every
+    // later snapshot in the run, heartbeats included. The avatar object is the
+    // same across both renders, so only a dropped memo can produce a retry.
+    encodeOutcome = "throws";
+    const avatar = characterAvatar("orange");
+    setAvatar(avatar);
+    const { rerender } = render({
+      conversations: [conversation("c1", { title: "Groceries" })],
+      conversationGroups: NO_GROUPS,
+      inputsResolved: true,
+    });
+    await settle();
+    expect(syncedSnapshots).toHaveLength(1);
+    expect(syncedSnapshots[0]?.avatar.imageBase64).toBeNull();
+
+    encodeOutcome = "bytes";
+    rerender({
+      conversations: [conversation("c1", { title: "Groceries" })],
+      conversationGroups: NO_GROUPS,
+      inputsResolved: true,
+    });
+    await settle();
+
+    expect(encodeCalls).toBe(2);
+    expect(syncedSnapshots).toHaveLength(2);
+    expect(syncedSnapshots[1]?.avatar).toEqual({
+      kind: "character",
+      accentHex: ORANGE_HEX,
+      imageBase64: AVATAR_BASE64,
+    });
+  });
+
+  it("caches an avatar that legitimately encodes to nothing", async () => {
+    // Nothing fitting any rung is a fact about the source, not a failure, so
+    // it must not cost a canvas draw on every render that follows.
+    encodeOutcome = "nothing-fits";
+    setAvatar(characterAvatar("orange"));
+    const { rerender } = render({
+      conversations: [conversation("c1", { title: "Groceries" })],
+      conversationGroups: NO_GROUPS,
+      inputsResolved: true,
+    });
+    await settle();
+    expect(encodeCalls).toBe(1);
+
+    rerender({
+      conversations: [conversation("c1", { title: "Groceries" })],
+      conversationGroups: NO_GROUPS,
+      inputsResolved: true,
+    });
+    await settle();
+    expect(encodeCalls).toBe(1);
+    expect(syncedSnapshots).toHaveLength(1);
+  });
+
   it("re-sends unchanged conversations when the avatar changes", async () => {
     // One photo swapped for another changes neither the kind nor the accent, so
     // only the identity the key carries can tell the snapshots apart.
-    avatarData = imageAvatar("blob:avatar-1");
+    setAvatar(imageAvatar("blob:avatar-1"));
     const { rerender } = render({
       conversations: [conversation("c1", { title: "Groceries" })],
       conversationGroups: NO_GROUPS,
@@ -1218,7 +1395,7 @@ describe("useNativeWidgetSnapshotSync", () => {
     await settle();
     expect(syncedSnapshots).toHaveLength(1);
 
-    avatarData = imageAvatar("blob:avatar-2");
+    setAvatar(imageAvatar("blob:avatar-2"));
     rerender({
       conversations: [conversation("c1", { title: "Groceries" })],
       conversationGroups: NO_GROUPS,
@@ -1242,7 +1419,7 @@ describe("useNativeWidgetSnapshotSync", () => {
     // The wait on the canvas draw is the one window in which a switch can
     // overtake a snapshot. Letting it land would put the departed assistant's
     // rows straight back on a Home Screen that was just cleared.
-    avatarData = characterAvatar("orange");
+    setAvatar(characterAvatar("orange"));
     const { rerender } = render({
       conversations: [conversation("c1", { title: "Groceries" })],
       conversationGroups: NO_GROUPS,
@@ -1264,7 +1441,7 @@ describe("useNativeWidgetSnapshotSync", () => {
   });
 
   it("keeps the avatar's bytes out of the dedup key", async () => {
-    avatarData = characterAvatar("orange");
+    setAvatar(characterAvatar("orange"));
     const serialized = recordSerialized(() => {
       const { rerender } = render({
         conversations: [conversation("c1", { title: "Groceries" })],
@@ -1298,7 +1475,7 @@ describe("useNativeWidgetSnapshotSync", () => {
     // already-cached destination is that commit, and the dedup key would then
     // pin the previous assistant's face until the heartbeat. Reading the avatar
     // reactively is what makes the change its own trigger.
-    avatarData = characterAvatar("orange");
+    setAvatar(characterAvatar("orange"));
     render({
       conversations: [conversation("c1", { title: "Groceries" })],
       conversationGroups: NO_GROUPS,
@@ -1330,7 +1507,7 @@ describe("useNativeWidgetSnapshotSync", () => {
   it("beats with the avatar the session currently has", async () => {
     // The tick shares the send path, so it carries whatever the avatar is now
     // rather than what the last data sync happened to encode.
-    avatarData = characterAvatar("orange");
+    setAvatar(characterAvatar("orange"));
     render({
       conversations: [conversation("c1", { title: "Groceries" })],
       conversationGroups: NO_GROUPS,

--- a/clients/web/src/domains/chat/hooks/use-native-widget-snapshot-sync.ts
+++ b/clients/web/src/domains/chat/hooks/use-native-widget-snapshot-sync.ts
@@ -23,7 +23,10 @@ import type {
   Conversation,
   ConversationGroup,
 } from "@/types/conversation-types";
-import { encodeAvatarForIsland } from "@/utils/avatar-island-encode";
+import {
+  memoizedAvatarEncode,
+  type AvatarEncodeMemo,
+} from "@/utils/avatar-island-encode";
 import { resolveAvatarRender, type AvatarRender } from "@/utils/avatar-render";
 import { activeConversationsByRecency } from "@/utils/conversation-order";
 
@@ -54,13 +57,14 @@ export const WIDGET_SNAPSHOT_HEARTBEAT_MS = 15 * 60 * 1000;
 /**
  * Byte ceiling for the avatar image a snapshot carries.
  *
- * Deliberately not the Live Activity's ceiling
- * ({@link encodeAvatarForIsland}'s default): that one is ActivityKit's
- * attribute budget, where going over costs the whole activity, so it is
- * measured in single kilobytes. This payload is a UserDefaults write into an
- * App Group, and a widget draws the avatar far larger than an island does, so
- * the budget is set by what is worth writing rather than by what will start.
- * The shell rejects anything past its own cap, which sits above this one.
+ * Deliberately not the Live Activity's ceiling, which the shared encoder takes
+ * as its default: that one is ActivityKit's attribute budget, where going over
+ * costs the whole activity, so it is measured in single kilobytes. The two
+ * budgets are why {@link memoizedAvatarEncode} caches per budget rather than
+ * per avatar alone. This payload is a UserDefaults write into an App Group, and
+ * a widget draws the avatar far larger than an island does, so the budget is
+ * set by what is worth writing rather than by what will start. The shell
+ * rejects anything past its own cap, which sits above this one.
  */
 const WIDGET_AVATAR_MAX_BYTES = 64_000;
 
@@ -68,9 +72,9 @@ const WIDGET_AVATAR_MAX_BYTES = 64_000;
  * Size the character avatar is composited at before it is rasterized.
  *
  * The composited SVG is resolution-independent, so this only caps the top of
- * {@link encodeAvatarForIsland}'s ladder rather than setting the size a widget
- * draws. Matches what `useIslandAvatarSource` composites for the Live Activity,
- * so the two native surfaces rasterize the same source.
+ * the encoder's ladder rather than setting the size a widget draws. Matches
+ * what `useIslandAvatarSource` composites for the Live Activity, so the two
+ * native surfaces rasterize the same source.
  */
 const AVATAR_SOURCE_SIZE = 128;
 
@@ -94,30 +98,15 @@ interface SnapshotAvatarFingerprint {
 }
 
 /**
- * The avatar last encoded for a snapshot, keyed by the render it came from.
- *
- * Module scope, mirroring `use-live-activity-mirror.ts`: the encode is a canvas
- * draw, and the key is the resolved `AvatarRender`, a stable object recomputed
- * only when the avatar itself changes, so identity comparison is enough and
- * there is nothing to invalidate. The resolved bytes are kept beside the
- * promise so only the first snapshot after a change has anything to wait for.
- */
-interface AvatarEncode {
-  source: AvatarRender;
-  /** Distinguishes one encode from the next inside the dedup key. */
-  revision: number;
-  /** Null while `encoding` is unsettled, and when nothing fit the budget. */
-  base64: string | null;
-  /** The encode in flight, or null when there is nothing to wait for. */
-  encoding: Promise<string | null> | null;
-}
-
-let avatarEncode: AvatarEncode | null = null;
-let avatarEncodes = 0;
-
-/**
  * The avatar the next snapshot should carry, starting its encode if this is
  * the first read since it changed.
+ *
+ * The encode is a canvas draw memoized at module scope by
+ * {@link memoizedAvatarEncode}, shared with the Live Activity mirror, so a
+ * session that drives both native surfaces pays it once per avatar. An encode
+ * that fails or fits nothing is an avatar-less snapshot, never a missing one:
+ * the counts and the rows are what the widgets are for. Only a failure is
+ * retried, and the memo owns that distinction.
  *
  * `source` and `accentHex` are resolved reactively by the hook rather than read
  * back from the two imperative publishers in `RootLayout`. Those are written by
@@ -132,12 +121,9 @@ function snapshotAvatar(
   accentHex: string | null,
 ): {
   fingerprint: SnapshotAvatarFingerprint;
-  encode: AvatarEncode;
+  encode: AvatarEncodeMemo;
 } {
-  if (avatarEncode === null || avatarEncode.source !== source) {
-    avatarEncode = startAvatarEncode(source);
-  }
-  const encode = avatarEncode;
+  const encode = memoizedAvatarEncode(source, WIDGET_AVATAR_MAX_BYTES);
   return {
     fingerprint: {
       kind: source.kind,
@@ -146,30 +132,6 @@ function snapshotAvatar(
     },
     encode,
   };
-}
-
-/** Start encoding `source`, or record that there is nothing to encode. */
-function startAvatarEncode(source: AvatarRender): AvatarEncode {
-  avatarEncodes += 1;
-  const encode: AvatarEncode = {
-    source,
-    revision: avatarEncodes,
-    base64: null,
-    encoding: null,
-  };
-  if (source.kind === "none") {
-    return encode;
-  }
-  // An encode that fails or fits nothing is an avatar-less snapshot, never a
-  // missing one: the counts and the rows are what the widgets are for.
-  encode.encoding = encodeAvatarForIsland(source, WIDGET_AVATAR_MAX_BYTES)
-    .catch(() => null)
-    .then((base64) => {
-      encode.base64 = base64;
-      encode.encoding = null;
-      return base64;
-    });
-  return encode;
 }
 
 /** The dedup key: everything a snapshot says, with the avatar as an identity. */
@@ -288,6 +250,17 @@ function snapshotKey(
  * *successful* queries does sync: genuinely having no conversations should
  * empty the widgets.
  *
+ * The avatar query is held to the same standard, and it is not the caller's to
+ * pass: this hook subscribes to it directly, so it applies that half itself.
+ * A first load in flight serves the null avatar, and it routinely settles after
+ * the conversation list does, so a gate that watched only the conversations
+ * would ship `kind: "none"` as the run's first snapshot. The plugin replaces
+ * the App Group record whole, so that write wipes the themed avatar a previous
+ * run left behind and every widget flashes to the brand palette until a second
+ * sync repaints it. Only the FIRST load holds: an errored avatar query, a
+ * gated-off one, and a background refetch all report resolved, because none of
+ * them has an avatar arriving that waiting would find.
+ *
  * That preservation is scoped to ONE assistant. A snapshot describes the
  * assistant it was built from, so an in-SPA switch
  * (`switchToResolvedAssistant`) invalidates it outright: the new assistant's
@@ -402,6 +375,18 @@ export function useNativeWidgetSnapshotSync(
     avatar.traits,
     avatar.customImageUrl,
   );
+  // The avatar query is in the resolution guard alongside the conversation
+  // queries the caller passes, and holds a sync the same way they do. It serves
+  // the null avatar while it loads and settles after them often enough to be
+  // the ordinary cold launch, so a gate without it would blank the widgets'
+  // avatar on the first write of every run.
+  //
+  // `isLoading` is the first load alone. An errored query, one gated off for
+  // want of an active assistant, and a background refetch all report false,
+  // which is right for each: none has an avatar arriving that waiting would
+  // find, and the last still has the one the app is drawing.
+  const avatarResolved = assistantId === null || !avatar.isLoading;
+  const snapshotResolved = inputsResolved && avatarResolved;
 
   // The one way to the bridge, shared by data syncs and the heartbeat so a
   // heartbeat cannot corrupt the bookkeeping a data sync depends on.
@@ -455,11 +440,11 @@ export function useNativeWidgetSnapshotSync(
       // Only the first snapshot after an avatar change waits on the canvas
       // draw; every later one reads the bytes it left behind and stays
       // synchronous with the render that fired it.
-      if (encode.encoding === null) {
+      if (encode.pending === null) {
         write(encode.base64);
         return;
       }
-      void encode.encoding.then(write);
+      void encode.pending.then(write);
     },
     [],
   );
@@ -513,7 +498,7 @@ export function useNativeWidgetSnapshotSync(
       syncAttemptRef.current += 1;
     }
 
-    if (!inputsResolved) {
+    if (!snapshotResolved) {
       // Only on a switch: a pending or errored query for the SAME assistant
       // still keeps its last-known-good snapshot.
       if (switchedAssistant) {
@@ -572,7 +557,7 @@ export function useNativeWidgetSnapshotSync(
     conversationGroups,
     processingConversationIds,
     unreadCount,
-    inputsResolved,
+    snapshotResolved,
     avatarSource,
     avatarAccentHex,
     sendSnapshot,
@@ -593,7 +578,11 @@ export function useNativeWidgetSnapshotSync(
   // `generatedAt` through the effect above, so restarting the window from that
   // write is what the timer would be counting from anyway.
   useEffect(() => {
-    if (!isWidgetSnapshotSyncAvailable() || !inputsResolved || !inputsAreLive) {
+    if (
+      !isWidgetSnapshotSyncAvailable() ||
+      !snapshotResolved ||
+      !inputsAreLive
+    ) {
       return;
     }
     const heartbeat = setInterval(() => {
@@ -613,7 +602,7 @@ export function useNativeWidgetSnapshotSync(
     };
   }, [
     assistantId,
-    inputsResolved,
+    snapshotResolved,
     inputsAreLive,
     avatarSource,
     avatarAccentHex,

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-activity-mirror.test.tsx
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-activity-mirror.test.tsx
@@ -79,14 +79,29 @@ const unregisterLiveActivityPushToken = mock(
 // the module here in order to wrap it deadlocks module init.
 let encodeGate: Promise<void> | null = null;
 
+const gatedEncode = async (): Promise<string | null> => {
+  if (encodeGate) {
+    await encodeGate;
+  }
+  return null;
+};
+
 mock.module("@/utils/avatar-island-encode", () => ({
   ISLAND_AVATAR_MAX_BYTES: 2000,
-  encodeAvatarForIsland: async () => {
-    if (encodeGate) {
-      await encodeGate;
-    }
-    return null;
-  },
+  encodeAvatarForIsland: gatedEncode,
+  // The mirror reads its avatar through the shared memo. Its caching is the
+  // encoder module's to pin; what these tests need from it is the gate, and one
+  // uncached encode per read is what the real memo does here anyway, since the
+  // source stub below hands back a fresh object every call.
+  memoizedAvatarEncode: () => ({
+    revision: 1,
+    base64: null,
+    pending: gatedEncode(),
+  }),
+  // Nothing is cached above, but the surface has to stay complete:
+  // `mock.module` is process-global in bun, so a missing export would fail to
+  // resolve for any later test file in the run that imports it.
+  __resetAvatarEncodeMemoForTesting: () => {},
 }));
 
 mock.module("@/hooks/use-island-avatar-source", () => ({

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-activity-mirror.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-activity-mirror.ts
@@ -73,8 +73,7 @@ import {
   startVoiceActivity,
   updateVoiceActivity,
 } from "@/runtime/desktop-voice-activity";
-import { encodeAvatarForIsland } from "@/utils/avatar-island-encode";
-import type { AvatarRender } from "@/utils/avatar-render";
+import { memoizedAvatarEncode } from "@/utils/avatar-island-encode";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 import { assistantDisplayName } from "@/utils/assistant-display-name";
 
@@ -131,28 +130,24 @@ function toActivityContent(
 }
 
 /**
- * The last avatar encoded for the island, keyed by the source it came from.
+ * The island avatar for the current assistant, encoding it on first use.
  *
- * Module scope, so a user who starts several sessions pays the canvas draw
- * once. The key is the resolved {@link AvatarRender}, which is a stable object
- * per avatar (republished only when the avatar itself changes), so identity
- * comparison is enough and there is nothing to invalidate.
+ * The memo is shared with the Home Screen widget snapshot, which rasterizes the
+ * same source through the same ladder at a budget of its own, so a session that
+ * drives both surfaces pays the canvas draw once per avatar rather than once
+ * per surface. What reaches the island is unchanged: the memo is keyed on the
+ * source's identity, exactly as this module's own cache was, and holds a
+ * separate slot per budget so an island can never be handed the widgets' larger
+ * encode and fail to start on it.
  */
-let encodedAvatar: {
-  source: AvatarRender | null;
-  base64: string | null;
-} | null = null;
-
-/** The island avatar for the current assistant, encoding it on first use. */
 async function islandAvatarBase64(): Promise<string | undefined> {
   const source = getIslandAvatarSource();
   if (source === null) {
     return undefined;
   }
-  if (encodedAvatar?.source !== source) {
-    encodedAvatar = { source, base64: await encodeAvatarForIsland(source) };
-  }
-  return encodedAvatar.base64 ?? undefined;
+  const encode = memoizedAvatarEncode(source);
+  const base64 = encode.pending === null ? encode.base64 : await encode.pending;
+  return base64 ?? undefined;
 }
 
 /**

--- a/clients/web/src/stores/pending-deep-link-store.ts
+++ b/clients/web/src/stores/pending-deep-link-store.ts
@@ -131,14 +131,17 @@ export interface PendingDeepLinkActions {
    */
   setPendingCamera: (targetConversationId: string) => void;
   /**
-   * Read and clear the parked camera request. Returns `false` when none was
-   * parked, and when the parked one is older than `maxAgeMs`: a park that was
+   * Spend the parked camera request, whatever it was. Returns nothing, unlike
+   * `consumePendingVoiceStart`: the drain (`useCameraDeepLink`) subscribes to
+   * `pendingCamera` and so already holds the park it is spending, and every
+   * decision about one is its own. It owns the age bound, since a park that was
    * never drained (its navigation bounced off a route guard, say) must not
-   * throw the camera open minutes later. Either way the park is cleared. The
-   * age bound belongs to the drain site, as with the voice start, and so does
-   * the address check: only the drain knows which conversation it is bound to.
+   * throw the camera open minutes later; it owns the address check, since only
+   * the drain knows which conversation it is bound to; and it gives way to a
+   * running call. All three spend the request, so what is left here is the
+   * one-shot clear they share.
    */
-  consumePendingCamera: (maxAgeMs: number) => boolean;
+  consumePendingCamera: () => void;
 }
 
 export type PendingDeepLinkStore = PendingDeepLinkState &
@@ -179,13 +182,10 @@ const usePendingDeepLinkStoreBase = create<PendingDeepLinkStore>()(
     },
     setPendingCamera: (targetConversationId) =>
       set({ pendingCamera: { targetConversationId, parkedAt: Date.now() } }),
-    consumePendingCamera: (maxAgeMs) => {
-      const parked = get().pendingCamera;
-      if (parked === null) {
-        return false;
+    consumePendingCamera: () => {
+      if (get().pendingCamera !== null) {
+        set({ pendingCamera: null });
       }
-      set({ pendingCamera: null });
-      return Date.now() - parked.parkedAt <= maxAgeMs;
     },
   }),
 );

--- a/clients/web/src/utils/avatar-island-encode.test.ts
+++ b/clients/web/src/utils/avatar-island-encode.test.ts
@@ -15,9 +15,12 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 
 import {
+  __resetAvatarEncodeMemoForTesting,
   encodeAvatarForIsland,
   ISLAND_AVATAR_MAX_BYTES,
+  memoizedAvatarEncode,
 } from "@/utils/avatar-island-encode";
+import type { AvatarRender } from "@/utils/avatar-render";
 
 /** Recorded rasterize attempts, in order, so the ladder's walk is assertable. */
 let attempts: Array<{ size: number; type: string; quality?: number }> = [];
@@ -154,5 +157,122 @@ describe("encodeAvatarForIsland", () => {
   test("stays under the measured ActivityKit ceiling, not the documented one", () => {
     expect(ISLAND_AVATAR_MAX_BYTES).toBeLessThan(3366);
     expect(ISLAND_AVATAR_MAX_BYTES).toBeGreaterThanOrEqual(1997);
+  });
+});
+
+/**
+ * The memo both native surfaces read through: the Live Activity at
+ * ActivityKit's ceiling and the Home Screen widget snapshot at its own, larger
+ * one. The encoder is injected here the way the rasterizer is above, so these
+ * cases are about what is cached rather than about the ladder.
+ */
+describe("memoizedAvatarEncode", () => {
+  /** A fresh character render, so each case starts on a cache miss. */
+  const source = (): AvatarRender => ({
+    kind: "character",
+    svg: "<svg/>",
+    dataUri: "data:image/svg+xml,%3Csvg/%3E",
+  });
+
+  const WIDGET_BUDGET = 64_000;
+
+  let encodeCalls = 0;
+  let encodeOutcome: "bytes" | "nothing-fits" | "throws" = "bytes";
+
+  const encode = async (): Promise<string | null> => {
+    encodeCalls += 1;
+    if (encodeOutcome === "throws") {
+      throw new Error("canvas unavailable");
+    }
+    return encodeOutcome === "bytes" ? "Zm9vYmFy" : null;
+  };
+
+  const memo = (render: AvatarRender, maxBytes = ISLAND_AVATAR_MAX_BYTES) =>
+    memoizedAvatarEncode(render, maxBytes, encode);
+
+  beforeEach(() => {
+    __resetAvatarEncodeMemoForTesting();
+    encodeCalls = 0;
+    encodeOutcome = "bytes";
+  });
+
+  test("encodes an avatar once however many surfaces ask for it", async () => {
+    const render = source();
+
+    const first = memo(render);
+    expect(await first.pending).toBe("Zm9vYmFy");
+
+    const second = memo(render);
+    expect(second.pending).toBeNull();
+    expect(second.base64).toBe("Zm9vYmFy");
+    expect(second.revision).toBe(first.revision);
+    expect(encodeCalls).toBe(1);
+  });
+
+  test("gives each budget its own slot", async () => {
+    // One slot for both would let a widget-sized encode reach the island, which
+    // is not a larger avatar but an activity that never starts.
+    const render = source();
+
+    const island = memo(render);
+    const widget = memo(render, WIDGET_BUDGET);
+    await Promise.all([island.pending, widget.pending]);
+
+    expect(encodeCalls).toBe(2);
+    expect(widget.revision).not.toBe(island.revision);
+    // And the island's slot survived the widget's, so neither evicts the other.
+    expect(memo(render).revision).toBe(island.revision);
+    expect(encodeCalls).toBe(2);
+  });
+
+  test("a new avatar is a new encode with an identity of its own", async () => {
+    const first = memo(source());
+    await first.pending;
+    const second = memo(source());
+    await second.pending;
+
+    expect(encodeCalls).toBe(2);
+    expect(second.revision).not.toBe(first.revision);
+  });
+
+  test("caches an avatar that fits no rung, which is a fact about the source", async () => {
+    encodeOutcome = "nothing-fits";
+    const render = source();
+
+    expect(await memo(render).pending).toBeNull();
+    expect(memo(render).base64).toBeNull();
+    expect(encodeCalls).toBe(1);
+  });
+
+  test("never reaches the encoder for an assistant with no avatar", () => {
+    const render: AvatarRender = { kind: "none" };
+
+    const result = memo(render);
+
+    // Settled on the spot, so a caller with nothing to draw stays synchronous.
+    expect(result.pending).toBeNull();
+    expect(result.base64).toBeNull();
+    expect(encodeCalls).toBe(0);
+  });
+
+  test("retries an encode that threw instead of caching the failure", async () => {
+    // The encoder failing (a canvas the shell would not hand over, a blob URL
+    // revoked mid-draw) is transient, and cached it would leave every later
+    // payload in the session avatar-less.
+    encodeOutcome = "throws";
+    const render = source();
+
+    const failed = memo(render);
+    // Resolved rather than rejected: a surface is worth more than the face on
+    // it, so callers get an avatar-less payload rather than an error.
+    expect(await failed.pending).toBeNull();
+
+    encodeOutcome = "bytes";
+    const retried = memo(render);
+    expect(await retried.pending).toBe("Zm9vYmFy");
+    expect(encodeCalls).toBe(2);
+    // A fresh identity, so a caller keying a payload on the avatar can tell the
+    // retry apart from the attempt that carried nothing.
+    expect(retried.revision).not.toBe(failed.revision);
   });
 });

--- a/clients/web/src/utils/avatar-island-encode.ts
+++ b/clients/web/src/utils/avatar-island-encode.ts
@@ -29,6 +29,15 @@
  * as it looks like it should. Rather than pick a lowest common denominator,
  * try candidates from best to worst and take the first that fits. See
  * {@link CANDIDATES} for the measured sizes the ladder is built around.
+ *
+ * ## Why the Home Screen widgets are here too
+ *
+ * The widget snapshot rasterizes the same avatar from the same source through
+ * the same ladder, differing only in the budget it can afford (an App Group
+ * write rather than an ActivityKit attribute). Both surfaces therefore share
+ * {@link memoizedAvatarEncode}, so a session pays the canvas draw once per
+ * avatar however many of them ask for it, and the caching rules live in one
+ * place rather than being restated per consumer.
  */
 
 import { rasterizeAvatar } from "@/utils/avatar-raster";
@@ -133,4 +142,112 @@ export async function encodeAvatarForIsland(
     }
   }
   return null;
+}
+
+/**
+ * One memoized encode: the bytes for an avatar at a budget, plus the work still
+ * in flight when this is the first read since that avatar changed.
+ */
+export interface AvatarEncodeMemo {
+  /**
+   * Distinguishes one encode from the next. A caller that keys a payload on the
+   * avatar can carry this instead of the bytes, which are tens of kilobytes at
+   * a widget's budget and would otherwise be re-serialized on every render.
+   */
+  revision: number;
+  /**
+   * The encoded bytes, or null both while {@link pending} is unsettled and when
+   * there is legitimately nothing to send (no avatar, or nothing fit).
+   */
+  base64: string | null;
+  /** The encode still running, or null when there is nothing to wait for. */
+  pending: Promise<string | null> | null;
+}
+
+/** An {@link AvatarEncodeMemo} with the source it is cached against. */
+interface AvatarEncodeSlot extends AvatarEncodeMemo {
+  source: AvatarRender;
+}
+
+/**
+ * The last encode per byte budget, each slot holding the source it came from.
+ *
+ * Module scope, so the canvas draw is paid once per avatar however many native
+ * surfaces ask for it and however often they re-render. The key inside a slot
+ * is the resolved {@link AvatarRender}, a stable object recomputed only when
+ * the avatar itself changes, so identity comparison is enough and there is
+ * nothing to invalidate.
+ *
+ * Kept per budget rather than one slot for every caller, because the ceilings
+ * come from unrelated limits (ActivityKit's attribute budget against an App
+ * Group write). Serving a widget-sized encode to a Live Activity is not a
+ * larger avatar, it is no island at all.
+ */
+const encodeSlots = new Map<number, AvatarEncodeSlot>();
+let encodeRevisions = 0;
+
+/**
+ * The encoded avatar for `render` at `maxBytes`, starting the encode if this is
+ * the first read since the avatar changed.
+ *
+ * A `none` avatar resolves without touching the encoder, so a caller with
+ * nothing to draw stays synchronous with whatever triggered it.
+ *
+ * An encode that RESOLVES null is cached: no avatar, and an avatar that fit no
+ * rung, are both stable facts about the source. An encode that THROWS is not
+ * cached, and its slot is dropped so the next read starts over. The failure is
+ * the encoder rather than the avatar (a canvas the shell would not hand over, a
+ * blob URL revoked mid-draw), and caching it would leave every later payload in
+ * the session avatar-less. Either way this read still resolves null: a surface
+ * is worth more than the face on it.
+ */
+export function memoizedAvatarEncode(
+  render: AvatarRender,
+  maxBytes: number = ISLAND_AVATAR_MAX_BYTES,
+  // Injected for the same reason `rasterize` is above: tests reach the encoder
+  // without `mock.module` replacing this module for every file in the process.
+  encode: typeof encodeAvatarForIsland = encodeAvatarForIsland,
+): AvatarEncodeMemo {
+  const cached = encodeSlots.get(maxBytes);
+  if (cached !== undefined && cached.source === render) {
+    return cached;
+  }
+  encodeRevisions += 1;
+  const slot: AvatarEncodeSlot = {
+    source: render,
+    revision: encodeRevisions,
+    base64: null,
+    pending: null,
+  };
+  encodeSlots.set(maxBytes, slot);
+  if (render.kind === "none") {
+    return slot;
+  }
+  slot.pending = encode(render, maxBytes).then(
+    (base64) => {
+      slot.base64 = base64;
+      slot.pending = null;
+      return base64;
+    },
+    () => {
+      // Dropped only while it is still the current slot: a newer avatar has
+      // its own encode running, and evicting that would restart it.
+      if (encodeSlots.get(maxBytes) === slot) {
+        encodeSlots.delete(maxBytes);
+      }
+      slot.pending = null;
+      return null;
+    },
+  );
+  return slot;
+}
+
+/**
+ * Drop every memoized encode. Not intended for production callers: the cache is
+ * module scope, so tests sharing a process would otherwise inherit each other's
+ * slots and revisions.
+ */
+export function __resetAvatarEncodeMemoForTesting(): void {
+  encodeSlots.clear();
+  encodeRevisions = 0;
 }


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for ios-widgets-v2.md: the first sync waits for the avatar query so a cold launch never wipes the themed widgets, failed encodes retry instead of pinning an avatar-less session, one shared memoized encoder serves both the widget and Live Activity paths, and the camera park's TTL has a single owner.