### PR TITLE
fix(live-voice): guarantee the session slot always comes back (LUM-3440)

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -17188,6 +17188,33 @@ paths:
                 required:
                   - status
                 additionalProperties: false
+  /v1/live-voice/session/end:
+    post:
+      operationId: livevoice_session_end_post
+      summary: End the active live voice session
+      description:
+        Release the daemon's single live-voice session slot, whichever client holds it. Reports whether a session
+        was actually ended; a slot already tearing down reports false, since that teardown releases it on its own.
+      tags:
+        - live-voice
+      responses:
+        "200":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ended:
+                    type: boolean
+                  sessionId:
+                    anyOf:
+                      - type: string
+                      - type: "null"
+                required:
+                  - ended
+                  - sessionId
+                additionalProperties: false
   /v1/llm-request-logs/{id}/context:
     get:
       operationId: llmrequestlogs_by_id_context_get

--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -17193,8 +17193,9 @@ paths:
       operationId: livevoice_session_end_post
       summary: End the active live voice session
       description:
-        Release the daemon's single live-voice session slot, whichever client holds it. Reports whether a session
-        was actually ended; a slot already tearing down reports false, since that teardown releases it on its own.
+        Release the assistant's single live-voice session slot, whichever client holds it. Reports whether a
+        session was actually ended; a slot already tearing down reports false, since that teardown releases it on its
+        own.
       tags:
         - live-voice
       responses:

--- a/assistant/src/live-voice/__tests__/live-voice-connection.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-connection.test.ts
@@ -115,6 +115,31 @@ describe("createLiveVoiceConnection", () => {
     ]);
   });
 
+  test("drops a pending start when its transport closes mid-wait", async () => {
+    const { sessions } = installFakeManager((_session, ctx) =>
+      ctx.sessionId === "session-1"
+        ? { close: mock(() => new Promise<void>(() => {})) }
+        : {},
+    );
+    const first = createConnection();
+    const second = createConnection();
+
+    await first.connection.handleMessage(START_MESSAGE);
+    // The first transport goes away and its session begins a teardown that
+    // never finishes, so the next start has to wait for the slot.
+    first.connection.release();
+
+    const pending = second.connection.handleMessage(START_MESSAGE);
+    await Promise.resolve();
+    second.connection.release();
+    await pending;
+
+    // No session was built for the socket that is already gone.
+    expect(sessions).toHaveLength(1);
+    expect(second.connection.sessionId).toBeUndefined();
+    expect(second.frames).toEqual([]);
+  });
+
   test("assigns monotonically increasing sequence numbers", async () => {
     installFakeManager();
     const { connection, frames } = createConnection();

--- a/assistant/src/live-voice/__tests__/live-voice-session-manager.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-session-manager.test.ts
@@ -6,6 +6,7 @@ import {
   type LiveVoiceSessionFactoryContext,
   LiveVoiceSessionManager,
   LiveVoiceSessionStartupError,
+  type LiveVoiceSlotEvent,
 } from "../live-voice-session-manager.js";
 import type {
   LiveVoiceClientFrame,
@@ -328,7 +329,7 @@ describe("LiveVoiceSessionManager", () => {
     expect(manager.activeSessionId).toBe("session-1");
   });
 
-  test("holds the session lock until close completes", async () => {
+  test("makes a start that arrives mid-close wait for the slot", async () => {
     const sessions: TestSession[] = [];
     let resolveClose: (() => void) | undefined;
     const manager = new LiveVoiceSessionManager({
@@ -349,28 +350,28 @@ describe("LiveVoiceSessionManager", () => {
     });
     const first = createSink();
     const second = createSink();
-    const third = createSink();
 
     await manager.startSession(START_FRAME, first.sink);
     const releasePromise = manager.releaseSession("session-1", "client_end");
-    const concurrent = await manager.startSession(START_FRAME, second.sink);
+    // The reconnect: a fresh transport asking for a session while the previous
+    // one is still unwinding. It must not be told the dying session is active.
+    const concurrent = manager.startSession(START_FRAME, second.sink);
     const concurrentDispatch = await manager.handleClientFrame("session-1", {
       type: "interrupt",
     });
 
-    expect(concurrent).toEqual({
-      status: "busy",
-      activeSessionId: "session-1",
-      frame: { type: "busy", seq: 1, activeSessionId: "session-1" },
-    });
     expect(concurrentDispatch).toEqual({ status: "not_found" });
+    // The lock still holds: no second session exists alongside the closing one.
     expect(sessions).toHaveLength(1);
+    expect(second.frames).toEqual([]);
 
     resolveClose?.();
     await releasePromise;
 
-    const next = await manager.startSession(START_FRAME, third.sink);
-    expect(next).toEqual({ status: "accepted", sessionId: "session-2" });
+    expect(await concurrent).toEqual({
+      status: "accepted",
+      sessionId: "session-2",
+    });
     expect(manager.activeSessionId).toBe("session-2");
   });
 
@@ -391,5 +392,157 @@ describe("LiveVoiceSessionManager", () => {
       expect(importPath).not.toContain("tts");
       expect(importPath).not.toContain("conversation");
     }
+  });
+});
+
+/**
+ * Closure assurance (LUM-3440): the slot must come back on its own from every
+ * way a session can stop being usable, because the client whose transport
+ * died cannot ask for it back and a user who force-quits the app does not get
+ * a second chance either.
+ */
+describe("LiveVoiceSessionManager slot reclamation", () => {
+  const SERVER_VAD_START = {
+    ...START_FRAME,
+    turnDetection: "server_vad",
+  } as const satisfies LiveVoiceClientStartFrame;
+
+  const sleep = (ms: number) =>
+    new Promise((resolve) => setTimeout(resolve, ms));
+
+  test("frees the slot when a session's close never finishes", async () => {
+    const events: LiveVoiceSlotEvent[] = [];
+    const sessions: TestSession[] = [];
+    const manager = new LiveVoiceSessionManager({
+      createSessionId: mock(() => `session-${sessions.length + 1}`),
+      closeTimeoutMs: 25,
+      createSession: () => {
+        const session = createTestSession({
+          // A teardown that hangs — the shape of a close awaiting a
+          // continuation delivery or a provider that never answers.
+          close: mock(() => new Promise<void>(() => {})),
+        });
+        sessions.push(session);
+        return session;
+      },
+      onSlotEvent: (event) => events.push(event),
+    });
+
+    await manager.startSession(START_FRAME, createSink().sink);
+    await manager.releaseSession("session-1", "websocket_close");
+
+    expect(manager.activeSessionId).toBeNull();
+    expect(events).toEqual([
+      {
+        kind: "close_timed_out",
+        sessionId: "session-1",
+        reason: "websocket_close",
+        timeoutMs: 25,
+      },
+    ]);
+
+    // The whole point: the next session starts instead of being told the
+    // wedged one is still active.
+    const next = await manager.startSession(START_FRAME, createSink().sink);
+    expect(next).toEqual({ status: "accepted", sessionId: "session-2" });
+  });
+
+  test("releases a server_vad session whose client goes silent", async () => {
+    const events: LiveVoiceSlotEvent[] = [];
+    const session = createTestSession();
+    const manager = new LiveVoiceSessionManager({
+      createSessionId: () => "session-1",
+      clientSilenceTimeoutMs: 30,
+      createSession: () => session,
+      onSlotEvent: (event) => events.push(event),
+    });
+
+    await manager.startSession(SERVER_VAD_START, createSink().sink);
+    expect(manager.activeSessionId).toBe("session-1");
+
+    await sleep(90);
+
+    expect(manager.activeSessionId).toBeNull();
+    expect(session.closeReasons).toEqual(["client_timeout"]);
+    expect(events).toEqual([
+      {
+        kind: "client_silence_timeout",
+        sessionId: "session-1",
+        timeoutMs: 30,
+      },
+    ]);
+  });
+
+  test("hangs up the transport it reclaimed the slot from", async () => {
+    const session = createTestSession();
+    const manager = new LiveVoiceSessionManager({
+      createSessionId: () => "session-1",
+      clientSilenceTimeoutMs: 30,
+      createSession: () => session,
+    });
+    const closeTransport = mock(() => {});
+    const { sink } = createSink();
+
+    await manager.startSession(SERVER_VAD_START, { ...sink, closeTransport });
+    await sleep(90);
+
+    // Reclaiming the slot alone would leave the client streaming into a
+    // session that no longer exists, and every socket out to it open.
+    expect(closeTransport).toHaveBeenCalledTimes(1);
+    expect(session.closeReasons).toEqual(["client_timeout"]);
+  });
+
+  test("inbound audio pushes the silence deadline out", async () => {
+    const session = createTestSession();
+    const manager = new LiveVoiceSessionManager({
+      createSessionId: () => "session-1",
+      clientSilenceTimeoutMs: 60,
+      createSession: () => session,
+    });
+
+    await manager.startSession(SERVER_VAD_START, createSink().sink);
+    await sleep(40);
+    await manager.handleBinaryAudio("session-1", new Uint8Array([1, 2, 3]));
+    // Past the original deadline: only the refresh keeps this session alive.
+    await sleep(40);
+
+    expect(manager.activeSessionId).toBe("session-1");
+    expect(session.closeReasons).toEqual([]);
+  });
+
+  test("leaves a manual session alone — its silence is not evidence", async () => {
+    const session = createTestSession();
+    const manager = new LiveVoiceSessionManager({
+      createSessionId: () => "session-1",
+      clientSilenceTimeoutMs: 20,
+      createSession: () => session,
+    });
+
+    await manager.startSession(
+      { ...START_FRAME, turnDetection: "manual" },
+      createSink().sink,
+    );
+    await sleep(70);
+
+    expect(manager.activeSessionId).toBe("session-1");
+    expect(session.closeReasons).toEqual([]);
+  });
+
+  test("ends the active session on request, whoever holds it", async () => {
+    const session = createTestSession();
+    const manager = new LiveVoiceSessionManager({
+      createSessionId: () => "session-1",
+      createSession: () => session,
+    });
+
+    expect(await manager.endActiveSession()).toEqual({ released: false });
+
+    await manager.startSession(START_FRAME, createSink().sink);
+    expect(await manager.endActiveSession()).toEqual({
+      released: true,
+      sessionId: "session-1",
+    });
+    expect(session.closeReasons).toEqual(["forced_end"]);
+    expect(manager.activeSessionId).toBeNull();
   });
 });

--- a/assistant/src/live-voice/__tests__/live-voice-session-manager.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-session-manager.test.ts
@@ -418,7 +418,7 @@ describe("LiveVoiceSessionManager slot reclamation", () => {
       closeTimeoutMs: 25,
       createSession: () => {
         const session = createTestSession({
-          // A teardown that hangs — the shape of a close awaiting a
+          // A teardown that hangs: the shape of a close awaiting a
           // continuation delivery or a provider that never answers.
           close: mock(() => new Promise<void>(() => {})),
         });
@@ -510,7 +510,7 @@ describe("LiveVoiceSessionManager slot reclamation", () => {
     expect(session.closeReasons).toEqual([]);
   });
 
-  test("leaves a manual session alone — its silence is not evidence", async () => {
+  test("leaves a manual session alone, its silence is not evidence", async () => {
     const session = createTestSession();
     const manager = new LiveVoiceSessionManager({
       createSessionId: () => "session-1",
@@ -526,6 +526,55 @@ describe("LiveVoiceSessionManager slot reclamation", () => {
 
     expect(manager.activeSessionId).toBe("session-1");
     expect(session.closeReasons).toEqual([]);
+  });
+
+  test("abandons a start whose transport went away while it waited", async () => {
+    const sessions: TestSession[] = [];
+    const manager = new LiveVoiceSessionManager({
+      createSessionId: mock(() => `session-${sessions.length + 1}`),
+      createSession: () => {
+        const session = createTestSession({
+          close: mock(() => new Promise<void>(() => {})),
+        });
+        sessions.push(session);
+        return session;
+      },
+    });
+    const second = createSink();
+
+    await manager.startSession(START_FRAME, createSink().sink);
+    void manager.releaseSession("session-1", "transport_closed");
+
+    const abort = new AbortController();
+    const pending = manager.startSession(START_FRAME, second.sink, {
+      signal: abort.signal,
+    });
+    await sleep(0);
+    // The socket that asked gave up while the outgoing slot was still
+    // unwinding. Building its session anyway would hand the slot to nobody.
+    abort.abort();
+
+    expect(await pending).toEqual({ status: "aborted" });
+    expect(sessions).toHaveLength(1);
+    expect(second.frames).toEqual([]);
+  });
+
+  test("hangs up the transport when the slot is force-ended", async () => {
+    const session = createTestSession();
+    const manager = new LiveVoiceSessionManager({
+      createSessionId: () => "session-1",
+      createSession: () => session,
+    });
+    const closeTransport = mock(() => {});
+    const { sink } = createSink();
+
+    await manager.startSession(START_FRAME, { ...sink, closeTransport });
+    await manager.endActiveSession();
+
+    // Otherwise the client whose session was ended from elsewhere keeps
+    // showing an active call until it happens to send another frame.
+    expect(closeTransport).toHaveBeenCalledTimes(1);
+    expect(session.closeReasons).toEqual(["forced_end"]);
   });
 
   test("ends the active session on request, whoever holds it", async () => {

--- a/assistant/src/live-voice/live-voice-connection.ts
+++ b/assistant/src/live-voice/live-voice-connection.ts
@@ -19,6 +19,7 @@
  *
  *     const connection = createLiveVoiceConnection({
  *       send: (frame) => socket.send(JSON.stringify(frame)),
+ *       close: () => socket.close(),
  *     });
  *     socket.on("message", (msg) => void connection.handleMessage(msg));
  *     socket.on("close", () => connection.release());
@@ -66,13 +67,22 @@ export interface LiveVoiceConnection {
   release(reason?: LiveVoiceSessionCloseReason): void;
 }
 
-/** Create a live voice connection bound to the caller's `send` transport. */
+/**
+ * Create a live voice connection bound to the caller's `send` transport.
+ *
+ * `close` is how the daemon hangs up. It is optional only because a transport
+ * may not be able to (an in-process pipe), but a real one should always pass
+ * it: without it, a session the daemon reclaims from an absent client leaves
+ * the transport open behind it.
+ */
 export function createLiveVoiceConnection(options: {
   send: LiveVoiceFrameSender;
+  close?: () => void;
 }): LiveVoiceConnection {
   return new LiveVoiceConnectionImpl(
     options.send,
     getLiveVoiceSessionManager(),
+    options.close,
   );
 }
 
@@ -83,6 +93,7 @@ class LiveVoiceConnectionImpl implements LiveVoiceConnection {
   constructor(
     private readonly send: LiveVoiceFrameSender,
     private readonly manager: LiveVoiceSessionManager,
+    private readonly closeTransport?: () => void,
   ) {}
 
   get sessionId(): string | undefined {
@@ -172,6 +183,7 @@ class LiveVoiceConnectionImpl implements LiveVoiceConnection {
         sendFrame: (serverFrame) => {
           this.sendFrame(serverFrame);
         },
+        ...(this.closeTransport ? { closeTransport: this.closeTransport } : {}),
       });
       if (result.status === "accepted") {
         this.activeSessionId = result.sessionId;

--- a/assistant/src/live-voice/live-voice-connection.ts
+++ b/assistant/src/live-voice/live-voice-connection.ts
@@ -27,8 +27,11 @@
 
 import { getLogger } from "../util/logger.js";
 import { getLiveVoiceSessionManager } from "./live-voice-manager.js";
-import type { LiveVoiceSessionManager } from "./live-voice-session-manager.js";
-import type { LiveVoiceSessionCloseReason } from "./live-voice-session-manager.js";
+import type {
+  LiveVoiceSessionCloseReason,
+  LiveVoiceSessionManager,
+  LiveVoiceStartSessionResult,
+} from "./live-voice-session-manager.js";
 import {
   type LiveVoiceClientFrame,
   type LiveVoiceProtocolError,
@@ -89,6 +92,12 @@ export function createLiveVoiceConnection(options: {
 class LiveVoiceConnectionImpl implements LiveVoiceConnection {
   private activeSessionId: string | undefined;
   private lastSeq = 0;
+  /**
+   * A `start` still waiting on the manager. It holds no session id yet, so
+   * without this handle a transport that closes mid-wait has nothing to
+   * release and the start would go on to build a session for a dead socket.
+   */
+  private pendingStart: AbortController | null = null;
 
   constructor(
     private readonly send: LiveVoiceFrameSender,
@@ -147,6 +156,8 @@ class LiveVoiceConnectionImpl implements LiveVoiceConnection {
   }
 
   release(reason: LiveVoiceSessionCloseReason = "transport_closed"): void {
+    this.pendingStart?.abort();
+    this.pendingStart = null;
     const sessionId = this.activeSessionId;
     this.activeSessionId = undefined;
     if (!sessionId) {
@@ -179,12 +190,27 @@ class LiveVoiceConnectionImpl implements LiveVoiceConnection {
         this.activeSessionId = undefined;
       }
 
-      const result = await this.manager.startSession(frame, {
-        sendFrame: (serverFrame) => {
-          this.sendFrame(serverFrame);
-        },
-        ...(this.closeTransport ? { closeTransport: this.closeTransport } : {}),
-      });
+      const pending = new AbortController();
+      this.pendingStart = pending;
+      let result: LiveVoiceStartSessionResult;
+      try {
+        result = await this.manager.startSession(
+          frame,
+          {
+            sendFrame: (serverFrame) => {
+              this.sendFrame(serverFrame);
+            },
+            ...(this.closeTransport
+              ? { closeTransport: this.closeTransport }
+              : {}),
+          },
+          { signal: pending.signal },
+        );
+      } finally {
+        if (this.pendingStart === pending) {
+          this.pendingStart = null;
+        }
+      }
       if (result.status === "accepted") {
         this.activeSessionId = result.sessionId;
       }

--- a/assistant/src/live-voice/live-voice-manager.ts
+++ b/assistant/src/live-voice/live-voice-manager.ts
@@ -65,13 +65,13 @@ export function getLiveVoiceSessionManager(): LiveVoiceSessionManager {
               reason: event.reason,
               timeoutMs: event.timeoutMs,
             },
-            "Live voice session close overran its budget — freeing the slot anyway",
+            "Live voice session close overran its budget, freeing the slot anyway",
           );
           return;
         }
         log.warn(
           { sessionId: event.sessionId, timeoutMs: event.timeoutMs },
-          "Live voice client went silent — releasing the session",
+          "Live voice client went silent, releasing the session",
         );
       },
     });

--- a/assistant/src/live-voice/live-voice-manager.ts
+++ b/assistant/src/live-voice/live-voice-manager.ts
@@ -11,9 +11,12 @@
 
 import { createRequire } from "node:module";
 
+import { getLogger } from "../util/logger.js";
 import { LiveVoiceSessionManager } from "./live-voice-session-manager.js";
 
 const require = createRequire(import.meta.url);
+
+const log = getLogger("live-voice-manager");
 
 type LiveVoiceSessionFactory =
   typeof import("./live-voice-session.js").createLiveVoiceSession;
@@ -48,6 +51,28 @@ export function getLiveVoiceSessionManager(): LiveVoiceSessionManager {
             require("./live-voice-session.js") as typeof import("./live-voice-session.js")
           ).createLiveVoiceSession;
         return createSession(context);
+      },
+      // The manager reclaims a slot on its own only when a session stopped
+      // behaving: either its teardown overran the close budget, or its client
+      // went silent on a mode that streams continuously. Both end somebody's
+      // call without them asking, and neither leaves a trace anywhere else, so
+      // they are logged at warn.
+      onSlotEvent: (event) => {
+        if (event.kind === "close_timed_out") {
+          log.warn(
+            {
+              sessionId: event.sessionId,
+              reason: event.reason,
+              timeoutMs: event.timeoutMs,
+            },
+            "Live voice session close overran its budget — freeing the slot anyway",
+          );
+          return;
+        }
+        log.warn(
+          { sessionId: event.sessionId, timeoutMs: event.timeoutMs },
+          "Live voice client went silent — releasing the session",
+        );
       },
     });
   }

--- a/assistant/src/live-voice/live-voice-session-manager.ts
+++ b/assistant/src/live-voice/live-voice-session-manager.ts
@@ -24,7 +24,7 @@ export type LiveVoiceSessionCloseReason =
  * on it and frees the slot anyway.
  *
  * `close()` is not a formality: it delivers a pending continuation into the
- * conversation, aborts an in-flight assistant turn, and flushes metrics — all
+ * conversation, aborts an in-flight assistant turn, and flushes metrics, all
  * of which reach the network. Awaiting it unbounded is what turned a single
  * wedged teardown into a daemon that could never run live voice again, because
  * a closing session still reads as the active one to the busy check while
@@ -36,7 +36,7 @@ export const DEFAULT_LIVE_VOICE_CLOSE_TIMEOUT_MS = 10_000;
  * How long a `server_vad` session may go without a single inbound frame
  * before the manager assumes its client is gone and releases the slot.
  *
- * The daemon's WebSocket peer is the gateway, not the client — a half-open
+ * The daemon's WebSocket peer is the gateway, not the client. A half-open
  * transport anywhere further out (a phone that left the network mid-call, a
  * dropped velay tunnel) delivers no close event here, so transport liveness
  * proves nothing about whether anyone is still on the call. Inbound frames do:
@@ -56,10 +56,11 @@ export interface LiveVoiceSession {
 export interface LiveVoiceServerFrameSink {
   sendFrame(frame: LiveVoiceServerFrame): MaybePromise<void>;
   /**
-   * Hang up the transport this session runs on. Optional, and called only
-   * when the manager reclaims a slot on its own: reclaiming without hanging up
-   * leaves a client streaming into a session that no longer exists, and leaves
-   * every socket in the chain out to it open with nothing behind them.
+   * Hang up the transport this session runs on. Optional, and called when the
+   * slot is taken back rather than given up (the silence watchdog, or a forced
+   * end). Reclaiming without hanging up leaves a client streaming into a
+   * session that no longer exists, still showing an active call, with every
+   * socket in the chain out to it open and nothing behind them.
    */
   closeTransport?(): void;
 }
@@ -116,6 +117,46 @@ export interface LiveVoiceSessionManagerOptions {
   onSlotEvent?: (event: LiveVoiceSlotEvent) => void;
 }
 
+/**
+ * Close reasons where the manager took the slot back rather than its owner
+ * handing it over. Only these hang up the transport: a session that ended
+ * because its own socket closed has no transport left to close, and one that
+ * failed post-`ready` deliberately keeps the socket so the client can start
+ * again on it.
+ */
+const RECLAIMED_CLOSE_REASONS: ReadonlySet<LiveVoiceSessionCloseReason> =
+  new Set(["client_timeout", "forced_end"]);
+
+/**
+ * Read through a call so the check is not narrowed away: an abort that lands
+ * while the manager awaits the outgoing slot is exactly the one that matters,
+ * and it happens after the first read.
+ */
+function isAborted(signal?: AbortSignal): boolean {
+  return signal?.aborted === true;
+}
+
+/**
+ * Resolve when the closing session lets go of the slot, or as soon as the
+ * waiting transport aborts, whichever happens first.
+ */
+function waitForSlotRelease(
+  released: Promise<void>,
+  signal?: AbortSignal,
+): Promise<void> {
+  if (signal === undefined) {
+    return released;
+  }
+  return new Promise<void>((resolve) => {
+    const settle = () => {
+      signal.removeEventListener("abort", settle);
+      resolve();
+    };
+    signal.addEventListener("abort", settle, { once: true });
+    void released.then(settle, settle);
+  });
+}
+
 export class LiveVoiceSessionStartupError extends Error {
   constructor(message: string) {
     super(message);
@@ -127,6 +168,13 @@ export type LiveVoiceStartSessionResult =
   | {
       status: "accepted";
       sessionId: string;
+    }
+  | {
+      /**
+       * The transport that asked went away before the session could be
+       * created. Nothing was started and nothing needs releasing.
+       */
+      status: "aborted";
     }
   | {
       status: "failed";
@@ -193,7 +241,13 @@ export class LiveVoiceSessionManager {
   async startSession(
     startFrame: LiveVoiceClientStartFrame,
     sink: LiveVoiceServerFrameSink,
+    options: { signal?: AbortSignal } = {},
   ): Promise<LiveVoiceStartSessionResult> {
+    const signal = options.signal;
+    if (isAborted(signal)) {
+      return { status: "aborted" };
+    }
+
     // A slot that is already tearing down is not a reason to turn a client
     // away, it is a reason to wait: the client asking is usually the same one
     // whose transport just died, reconnecting a second or two later, and its
@@ -201,13 +255,21 @@ export class LiveVoiceSessionManager {
     // continuation and unwinds an in-flight turn). Answering `busy` there is
     // what turned a recoverable blip into "Another live-voice session is
     // active." with nothing behind it (LUM-3440). Waiting keeps the invariant
-    // that matters — one session's audio devices are never live alongside the
-    // next one's — and the wait is bounded by the close budget.
+    // that matters (one session's audio devices are never live alongside the
+    // next one's), and the wait is bounded by the close budget.
     const closingSession = this.activeSession?.closing
       ? this.activeSession
       : null;
     if (closingSession !== null) {
-      await closingSession.released;
+      await waitForSlotRelease(closingSession.released, signal);
+      // The wait can outlive the transport that asked (its own connect
+      // timeout is the same order as the close budget, and the user can give
+      // up sooner). Building a session for a socket that is gone would hand
+      // the slot to nobody, which is the failure this change exists to
+      // remove, so the caller aborts and the start is abandoned here.
+      if (isAborted(signal)) {
+        return { status: "aborted" };
+      }
     }
 
     const existingSessionId = this.activeSessionId;
@@ -257,8 +319,8 @@ export class LiveVoiceSessionManager {
     // Armed before `start()` rather than after it, so the watchdog also covers
     // a startup that hangs: a provider dial with no timeout of its own would
     // otherwise hold the slot with no session to release and no frame to
-    // explain it. Nothing refreshes the deadline during startup — the
-    // transport rejects client audio until `start` resolves — so the first
+    // explain it. Nothing refreshes the deadline during startup, since the
+    // transport rejects client audio until `start` resolves, so the first
     // window is startup plus the client's first frame.
     this.armClientSilenceWatchdog(active, startFrame);
 
@@ -330,6 +392,9 @@ export class LiveVoiceSessionManager {
 
     active.closing = true;
     this.clearClientSilenceWatchdog(active);
+    if (RECLAIMED_CLOSE_REASONS.has(reason)) {
+      this.hangUpTransport(active);
+    }
     try {
       await this.closeWithinBudget(active, reason);
     } finally {
@@ -348,7 +413,7 @@ export class LiveVoiceSessionManager {
    * transport is gone (so `end` cannot be sent) but the slot is still claimed,
    * which is the "Another live-voice session is active." dead end. Reports
    * `released: false` when nothing holds the slot, including when the holder
-   * is already closing — that teardown frees the slot on its own budget.
+   * is already closing, since that teardown frees the slot on its own budget.
    */
   async endActiveSession(
     reason: LiveVoiceSessionCloseReason = "forced_end",
@@ -391,7 +456,7 @@ export class LiveVoiceSessionManager {
    *
    * A teardown that overruns is abandoned rather than cancelled: it keeps
    * unwinding in the background (the session has already marked itself closed,
-   * so it cannot resurrect), while the caller — and the next client — stop
+   * so it cannot resurrect), while the caller (and the next client) stop
    * waiting on it. Freeing the slot early can leave the outgoing session's
    * providers briefly overlapping the next one's, which is a degraded call;
    * holding it forever is no call at all, ever again, until the daemon
@@ -465,12 +530,6 @@ export class LiveVoiceSessionManager {
         sessionId: active.sessionId,
         timeoutMs: this.clientSilenceTimeoutMs,
       });
-      try {
-        active.sink.closeTransport?.();
-      } catch {
-        // A transport that cannot be closed is exactly the case the watchdog
-        // exists for; reclaiming the slot still has to happen.
-      }
       void this.releaseSession(active.sessionId, "client_timeout").catch(() => {
         // Best-effort reclamation; the slot is dropped either way.
       });
@@ -479,13 +538,22 @@ export class LiveVoiceSessionManager {
     active.silenceTimer = timer;
   }
 
-  /** Push the watchdog deadline out — the client is demonstrably still there. */
+  /** Push the watchdog deadline out: the client is demonstrably still there. */
   private noteClientActivity(active: ActiveLiveVoiceSession): void {
     if (active.silenceTimer === null) {
       return;
     }
     clearTimeout(active.silenceTimer);
     this.scheduleClientSilenceWatchdog(active);
+  }
+
+  private hangUpTransport(active: ActiveLiveVoiceSession): void {
+    try {
+      active.sink.closeTransport?.();
+    } catch {
+      // A transport that cannot be hung up is exactly the case the watchdog
+      // exists for. Reclaiming the slot still has to happen.
+    }
   }
 
   private clearClientSilenceWatchdog(active: ActiveLiveVoiceSession): void {

--- a/assistant/src/live-voice/live-voice-session-manager.ts
+++ b/assistant/src/live-voice/live-voice-session-manager.ts
@@ -15,7 +15,36 @@ export type LiveVoiceSessionCloseReason =
   | "error"
   | "websocket_close"
   | "transport_closed"
+  | "client_timeout"
+  | "forced_end"
   | "manager_shutdown";
+
+/**
+ * How long a session's own teardown may run before the manager stops waiting
+ * on it and frees the slot anyway.
+ *
+ * `close()` is not a formality: it delivers a pending continuation into the
+ * conversation, aborts an in-flight assistant turn, and flushes metrics — all
+ * of which reach the network. Awaiting it unbounded is what turned a single
+ * wedged teardown into a daemon that could never run live voice again, because
+ * a closing session still reads as the active one to the busy check while
+ * being un-releasable by any retry (LUM-3440).
+ */
+export const DEFAULT_LIVE_VOICE_CLOSE_TIMEOUT_MS = 10_000;
+
+/**
+ * How long a `server_vad` session may go without a single inbound frame
+ * before the manager assumes its client is gone and releases the slot.
+ *
+ * The daemon's WebSocket peer is the gateway, not the client — a half-open
+ * transport anywhere further out (a phone that left the network mid-call, a
+ * dropped velay tunnel) delivers no close event here, so transport liveness
+ * proves nothing about whether anyone is still on the call. Inbound frames do:
+ * a `server_vad` client streams PCM continuously by construction (muted turns
+ * send silence rather than nothing, so the server VAD is never starved), so a
+ * full minute of wire silence means the client is gone, not quiet.
+ */
+export const DEFAULT_LIVE_VOICE_CLIENT_SILENCE_TIMEOUT_MS = 60_000;
 
 export interface LiveVoiceSession {
   start(): MaybePromise<void>;
@@ -26,6 +55,13 @@ export interface LiveVoiceSession {
 
 export interface LiveVoiceServerFrameSink {
   sendFrame(frame: LiveVoiceServerFrame): MaybePromise<void>;
+  /**
+   * Hang up the transport this session runs on. Optional, and called only
+   * when the manager reclaims a slot on its own: reclaiming without hanging up
+   * leaves a client streaming into a session that no longer exists, and leaves
+   * every socket in the chain out to it open with nothing behind them.
+   */
+  closeTransport?(): void;
 }
 
 export interface LiveVoiceSessionFactoryContext {
@@ -45,9 +81,39 @@ export type LiveVoiceSessionFactory = (
   context: LiveVoiceSessionFactoryContext,
 ) => LiveVoiceSession;
 
+/**
+ * A slot the manager reclaimed on the session's behalf rather than at its
+ * owner's request. Both mean a live voice session ended without anyone asking
+ * it to, so both are worth a log line and a metric: they are the only evidence
+ * that would explain a user who suddenly could not talk, and (for
+ * `close_timed_out`) the only warning that a teardown path has started
+ * hanging.
+ */
+export type LiveVoiceSlotEvent =
+  | {
+      kind: "close_timed_out";
+      sessionId: string;
+      reason: LiveVoiceSessionCloseReason;
+      timeoutMs: number;
+    }
+  | {
+      kind: "client_silence_timeout";
+      sessionId: string;
+      timeoutMs: number;
+    };
+
 export interface LiveVoiceSessionManagerOptions {
   createSession: LiveVoiceSessionFactory;
   createSessionId?: () => string;
+  /** Overrides {@link DEFAULT_LIVE_VOICE_CLOSE_TIMEOUT_MS}; `0` disables. */
+  closeTimeoutMs?: number;
+  /**
+   * Overrides {@link DEFAULT_LIVE_VOICE_CLIENT_SILENCE_TIMEOUT_MS}; `0`
+   * disables the watchdog.
+   */
+  clientSilenceTimeoutMs?: number;
+  /** Reports a slot the manager reclaimed itself. */
+  onSlotEvent?: (event: LiveVoiceSlotEvent) => void;
 }
 
 export class LiveVoiceSessionStartupError extends Error {
@@ -93,17 +159,31 @@ export type LiveVoiceSessionReleaseResult =
 interface ActiveLiveVoiceSession {
   sessionId: string;
   session: LiveVoiceSession;
+  sink: LiveVoiceServerFrameSink;
   closing: boolean;
+  silenceTimer: ReturnType<typeof setTimeout> | null;
+  /** Resolves once this session has let go of the slot, however it went. */
+  readonly released: Promise<void>;
+  resolveReleased: () => void;
 }
 
 export class LiveVoiceSessionManager {
   private readonly createSession: LiveVoiceSessionFactory;
   private readonly createSessionId: () => string;
+  private readonly closeTimeoutMs: number;
+  private readonly clientSilenceTimeoutMs: number;
+  private readonly onSlotEvent: (event: LiveVoiceSlotEvent) => void;
   private activeSession: ActiveLiveVoiceSession | null = null;
 
   constructor(options: LiveVoiceSessionManagerOptions) {
     this.createSession = options.createSession;
     this.createSessionId = options.createSessionId ?? randomUUID;
+    this.closeTimeoutMs =
+      options.closeTimeoutMs ?? DEFAULT_LIVE_VOICE_CLOSE_TIMEOUT_MS;
+    this.clientSilenceTimeoutMs =
+      options.clientSilenceTimeoutMs ??
+      DEFAULT_LIVE_VOICE_CLIENT_SILENCE_TIMEOUT_MS;
+    this.onSlotEvent = options.onSlotEvent ?? (() => {});
   }
 
   get activeSessionId(): string | null {
@@ -114,6 +194,22 @@ export class LiveVoiceSessionManager {
     startFrame: LiveVoiceClientStartFrame,
     sink: LiveVoiceServerFrameSink,
   ): Promise<LiveVoiceStartSessionResult> {
+    // A slot that is already tearing down is not a reason to turn a client
+    // away, it is a reason to wait: the client asking is usually the same one
+    // whose transport just died, reconnecting a second or two later, and its
+    // old session's close can easily outlast that gap (it delivers a pending
+    // continuation and unwinds an in-flight turn). Answering `busy` there is
+    // what turned a recoverable blip into "Another live-voice session is
+    // active." with nothing behind it (LUM-3440). Waiting keeps the invariant
+    // that matters — one session's audio devices are never live alongside the
+    // next one's — and the wait is bounded by the close budget.
+    const closingSession = this.activeSession?.closing
+      ? this.activeSession
+      : null;
+    if (closingSession !== null) {
+      await closingSession.released;
+    }
+
     const existingSessionId = this.activeSessionId;
     if (existingSessionId !== null) {
       const busySequencer = createLiveVoiceServerFrameSequencer();
@@ -144,7 +240,27 @@ export class LiveVoiceSessionManager {
       },
     };
     const session = this.createSession(context);
-    this.activeSession = { sessionId, session, closing: false };
+    let resolveReleased = (): void => {};
+    const released = new Promise<void>((resolve) => {
+      resolveReleased = resolve;
+    });
+    const active: ActiveLiveVoiceSession = {
+      sessionId,
+      session,
+      sink,
+      closing: false,
+      silenceTimer: null,
+      released,
+      resolveReleased,
+    };
+    this.activeSession = active;
+    // Armed before `start()` rather than after it, so the watchdog also covers
+    // a startup that hangs: a provider dial with no timeout of its own would
+    // otherwise hold the slot with no session to release and no frame to
+    // explain it. Nothing refreshes the deadline during startup — the
+    // transport rejects client audio until `start` resolves — so the first
+    // window is startup plus the client's first frame.
+    this.armClientSilenceWatchdog(active, startFrame);
 
     try {
       await session.start();
@@ -167,6 +283,7 @@ export class LiveVoiceSessionManager {
     if (active === null) {
       return { status: "not_found" };
     }
+    this.noteClientActivity(active);
 
     try {
       await active.session.handleClientFrame(frame);
@@ -190,6 +307,7 @@ export class LiveVoiceSessionManager {
     if (active === null) {
       return { status: "not_found" };
     }
+    this.noteClientActivity(active);
 
     try {
       await active.session.handleBinaryAudio(chunk);
@@ -211,14 +329,35 @@ export class LiveVoiceSessionManager {
     }
 
     active.closing = true;
+    this.clearClientSilenceWatchdog(active);
     try {
-      await active.session.close(reason);
+      await this.closeWithinBudget(active, reason);
     } finally {
       if (this.activeSession === active) {
         this.activeSession = null;
       }
+      active.resolveReleased();
     }
     return { released: true, sessionId };
+  }
+
+  /**
+   * Release whatever session currently holds the slot, whoever owns it.
+   *
+   * The recovery path for a client that has no other way back: its own
+   * transport is gone (so `end` cannot be sent) but the slot is still claimed,
+   * which is the "Another live-voice session is active." dead end. Reports
+   * `released: false` when nothing holds the slot, including when the holder
+   * is already closing — that teardown frees the slot on its own budget.
+   */
+  async endActiveSession(
+    reason: LiveVoiceSessionCloseReason = "forced_end",
+  ): Promise<LiveVoiceSessionReleaseResult> {
+    const sessionId = this.activeSessionId;
+    if (sessionId === null) {
+      return { released: false };
+    }
+    return await this.releaseSession(sessionId, reason);
   }
 
   /**
@@ -244,6 +383,115 @@ export class LiveVoiceSessionManager {
       await this.releaseSession(sessionId, "error");
     } catch {
       // The original session error is more useful to callers than a cleanup error.
+    }
+  }
+
+  /**
+   * Await the session's teardown, but only for as long as the close budget.
+   *
+   * A teardown that overruns is abandoned rather than cancelled: it keeps
+   * unwinding in the background (the session has already marked itself closed,
+   * so it cannot resurrect), while the caller — and the next client — stop
+   * waiting on it. Freeing the slot early can leave the outgoing session's
+   * providers briefly overlapping the next one's, which is a degraded call;
+   * holding it forever is no call at all, ever again, until the daemon
+   * restarts.
+   */
+  private async closeWithinBudget(
+    active: ActiveLiveVoiceSession,
+    reason: LiveVoiceSessionCloseReason,
+  ): Promise<void> {
+    const closed = Promise.resolve(active.session.close(reason));
+    // The race below stops awaiting `closed` on a timeout, so anchor a handler
+    // now: an abandoned teardown that rejects later must not surface as an
+    // unhandled rejection.
+    closed.catch(() => {});
+
+    if (this.closeTimeoutMs <= 0) {
+      await closed;
+      return;
+    }
+
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const budget = new Promise<"timed_out">((resolve) => {
+      timer = setTimeout(() => resolve("timed_out"), this.closeTimeoutMs);
+      timer.unref?.();
+    });
+    try {
+      const outcome = await Promise.race([
+        closed.then(() => "closed" as const),
+        budget,
+      ]);
+      if (outcome === "timed_out") {
+        this.onSlotEvent({
+          kind: "close_timed_out",
+          sessionId: active.sessionId,
+          reason,
+          timeoutMs: this.closeTimeoutMs,
+        });
+      }
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  /**
+   * Start the client-silence watchdog for a session whose mode guarantees a
+   * continuous inbound stream. A `manual` session legitimately sits idle
+   * between push-to-talk segments, so wire silence says nothing about its
+   * client and it gets no watchdog.
+   */
+  private armClientSilenceWatchdog(
+    active: ActiveLiveVoiceSession,
+    startFrame: LiveVoiceClientStartFrame,
+  ): void {
+    if (
+      this.clientSilenceTimeoutMs <= 0 ||
+      startFrame.turnDetection !== "server_vad"
+    ) {
+      return;
+    }
+    this.scheduleClientSilenceWatchdog(active);
+  }
+
+  private scheduleClientSilenceWatchdog(active: ActiveLiveVoiceSession): void {
+    const timer = setTimeout(() => {
+      active.silenceTimer = null;
+      if (this.activeSession !== active || active.closing) {
+        return;
+      }
+      this.onSlotEvent({
+        kind: "client_silence_timeout",
+        sessionId: active.sessionId,
+        timeoutMs: this.clientSilenceTimeoutMs,
+      });
+      try {
+        active.sink.closeTransport?.();
+      } catch {
+        // A transport that cannot be closed is exactly the case the watchdog
+        // exists for; reclaiming the slot still has to happen.
+      }
+      void this.releaseSession(active.sessionId, "client_timeout").catch(() => {
+        // Best-effort reclamation; the slot is dropped either way.
+      });
+    }, this.clientSilenceTimeoutMs);
+    timer.unref?.();
+    active.silenceTimer = timer;
+  }
+
+  /** Push the watchdog deadline out — the client is demonstrably still there. */
+  private noteClientActivity(active: ActiveLiveVoiceSession): void {
+    if (active.silenceTimer === null) {
+      return;
+    }
+    clearTimeout(active.silenceTimer);
+    this.scheduleClientSilenceWatchdog(active);
+  }
+
+  private clearClientSilenceWatchdog(active: ActiveLiveVoiceSession): void {
+    if (active.silenceTimer !== null) {
+      clearTimeout(active.silenceTimer);
+      active.silenceTimer = null;
     }
   }
 }

--- a/assistant/src/runtime/http-server.ts
+++ b/assistant/src/runtime/http-server.ts
@@ -336,6 +336,12 @@ export class RuntimeHttpServer {
                 send: (frame) => {
                   ws.send(JSON.stringify(frame));
                 },
+                // Lets the daemon hang up on a client that stopped answering.
+                // A normal close (not a retryable one) so the client ends the
+                // call rather than reconnecting into a session that is gone.
+                close: () => {
+                  ws.close(1000, "Live voice session released");
+                },
               }),
             );
             log.info("Live voice WebSocket opened");

--- a/assistant/src/runtime/routes/live-voice-routes.test.ts
+++ b/assistant/src/runtime/routes/live-voice-routes.test.ts
@@ -1,11 +1,14 @@
 /**
- * Tests for the live-voice preflight route.
+ * Tests for the live-voice preflight and session-end routes.
  *
  * The handler must run managed-speech defaulting first, then return the
  * live-voice credential readiness verdict verbatim:
  * - ready → { status: "ready" }
  * - not-ready → passes through the missing gaps + userMessage
  * - defaulting is invoked BEFORE readiness is resolved
+ *
+ * The session-end route is the out-of-band recovery path (LUM-3440): it
+ * reports whether it actually reclaimed the daemon's single live-voice slot.
  *
  * NOTE: `bun mock.module` leaks across files. Run this file on its own
  * (`bun test <thisfile>`) — a multi-file run may report a spurious failure.
@@ -14,9 +17,11 @@
 import { describe, expect, mock, test } from "bun:test";
 
 import type { LiveVoiceCredentialReadiness } from "../../live-voice/live-voice-credential-preflight.js";
+import type { LiveVoiceSessionReleaseResult } from "../../live-voice/live-voice-session-manager.js";
 
 const calls: string[] = [];
 let readiness: LiveVoiceCredentialReadiness = { status: "ready" };
+let releaseResult: LiveVoiceSessionReleaseResult = { released: false };
 
 mock.module("../../config/managed-speech-defaults.js", () => ({
   maybeDefaultSpeechToManaged: async () => {
@@ -31,10 +36,23 @@ mock.module("../../live-voice/live-voice-credential-preflight.js", () => ({
   },
 }));
 
+mock.module("../../live-voice/live-voice-manager.js", () => ({
+  getLiveVoiceSessionManager: () => ({
+    endActiveSession: async () => {
+      calls.push("endActiveSession");
+      return releaseResult;
+    },
+  }),
+}));
+
 const { ROUTES } = await import("./live-voice-routes.js");
 
 const preflightRoute = ROUTES.find(
   (r) => r.operationId === "live_voice_preflight_post",
+)!;
+
+const sessionEndRoute = ROUTES.find(
+  (r) => r.operationId === "live_voice_session_end_post",
 )!;
 
 describe("live_voice_preflight_post", () => {
@@ -69,5 +87,26 @@ describe("live_voice_preflight_post", () => {
     await preflightRoute.handler({});
 
     expect(calls).toEqual(["default", "resolve"]);
+  });
+});
+
+describe("live_voice_session_end_post", () => {
+  test("reports the session it reclaimed", async () => {
+    calls.length = 0;
+    releaseResult = { released: true, sessionId: "session-1" };
+
+    const result = await sessionEndRoute.handler({});
+
+    expect(result).toEqual({ ended: true, sessionId: "session-1" });
+    expect(calls).toEqual(["endActiveSession"]);
+  });
+
+  test("reports no session rather than failing when the slot is free", async () => {
+    calls.length = 0;
+    releaseResult = { released: false };
+
+    const result = await sessionEndRoute.handler({});
+
+    expect(result).toEqual({ ended: false, sessionId: null });
   });
 });

--- a/assistant/src/runtime/routes/live-voice-routes.ts
+++ b/assistant/src/runtime/routes/live-voice-routes.ts
@@ -6,7 +6,7 @@
  * session. Lets the web client verify voice is configured BEFORE opening the
  * voice-room WebSocket, instead of opening it and reacting to an error frame.
  *
- * POST /v1/live-voice/session/end — release whatever session holds the
+ * POST /v1/live-voice/session/end releases whatever session holds the
  * daemon's single live-voice slot. The out-of-band half of session closure:
  * the in-band `end` frame needs a working transport, and the case that needs
  * ending most is the one where the transport is already gone.
@@ -88,7 +88,7 @@ export const ROUTES: RouteDefinition[] = [
     },
     summary: "End the active live voice session",
     description:
-      "Release the daemon's single live-voice session slot, whichever client holds it. Reports whether a session was actually ended; a slot already tearing down reports false, since that teardown releases it on its own.",
+      "Release the assistant's single live-voice session slot, whichever client holds it. Reports whether a session was actually ended; a slot already tearing down reports false, since that teardown releases it on its own.",
     tags: ["live-voice"],
     responseBody: z.object({
       ended: z.boolean(),

--- a/assistant/src/runtime/routes/live-voice-routes.ts
+++ b/assistant/src/runtime/routes/live-voice-routes.ts
@@ -5,6 +5,11 @@
  * then report whether the daemon can run both audio legs of a live voice
  * session. Lets the web client verify voice is configured BEFORE opening the
  * voice-room WebSocket, instead of opening it and reacting to an error frame.
+ *
+ * POST /v1/live-voice/session/end — release whatever session holds the
+ * daemon's single live-voice slot. The out-of-band half of session closure:
+ * the in-band `end` frame needs a working transport, and the case that needs
+ * ending most is the one where the transport is already gone.
  */
 
 import { z } from "zod";
@@ -24,6 +29,17 @@ async function handleLiveVoicePreflight() {
 
   await maybeDefaultSpeechToManaged();
   return resolveLiveVoiceCredentialReadiness();
+}
+
+async function handleLiveVoiceSessionEnd() {
+  const { getLiveVoiceSessionManager } =
+    await import("../../live-voice/live-voice-manager.js");
+
+  const result = await getLiveVoiceSessionManager().endActiveSession();
+  return {
+    ended: result.released,
+    sessionId: result.released ? result.sessionId : null,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -61,5 +77,23 @@ export const ROUTES: RouteDefinition[] = [
       userMessage: z.string().optional(),
     }),
     handler: handleLiveVoicePreflight,
+  },
+  {
+    operationId: "live_voice_session_end_post",
+    endpoint: "live-voice/session/end",
+    method: "POST",
+    policy: {
+      requiredScopes: ["chat.write"],
+      allowedPrincipalTypes: ACTOR_PRINCIPALS,
+    },
+    summary: "End the active live voice session",
+    description:
+      "Release the daemon's single live-voice session slot, whichever client holds it. Reports whether a session was actually ended; a slot already tearing down reports false, since that teardown releases it on its own.",
+    tags: ["live-voice"],
+    responseBody: z.object({
+      ended: z.boolean(),
+      sessionId: z.string().nullable(),
+    }),
+    handler: handleLiveVoiceSessionEnd,
   },
 ];


### PR DESCRIPTION
Fixes LUM-3440.

Live voice runs one session per daemon, and the slot was only ever released by the transport that owned it. That left three ways to end up permanently unable to talk, with no recovery short of a daemon restart. Force-quitting the app does not help, because the daemon is the one holding on.

## What was broken

**1. A hung teardown wedged the slot forever.** `releaseSession` awaited `session.close()` unbounded, and that close delivers a pending continuation into the conversation, unwinds an in-flight turn, and flushes metrics, all over the network. During that await the session still read as active to the busy check, while `findActiveSession` refused to release it (`closing: true`). Nothing could clear it: not a new socket, not force-quitting, only a restart. This matches the report (15+ min session, so the most state to unwind, then a WS error, then blocked with force-quit no help).

**2. A vanished client kept its session alive.** The daemon's WebSocket peer is the gateway, not the phone, so a half-open transport further out (velay drop, phone off the network) delivers no close event here. Transport liveness proves nothing about whether anyone is still on the call.

**3. The reconnect raced its own close.** The client auto-reconnects 1.2s after a retryable close and sends a fresh `start`. A close slower than that answered `busy`, giving "Another live-voice session is active." as a dead end with the reconnect budget spent.

## What changed

- **Bounded close** (10s): the slot is dropped whether or not the teardown finishes. An overrunning close is abandoned to keep unwinding in the background, not cancelled, since the session has already marked itself closed and cannot resurrect.
- **Client-silence watchdog** (60s), armed for `server_vad` sessions only. That mode streams PCM continuously by construction (muted turns send silence rather than nothing), so a minute of wire silence is real evidence the client is gone. `manual` legitimately idles between push-to-talk segments and gets no watchdog. Armed before `start()`, so a startup that hangs cannot wedge the slot either.
- **The daemon hangs up** when it takes a slot back, via a new optional `closeTransport` on the frame sink. Reclaiming alone would leave a client streaming into a session that no longer exists, still showing an active call, with every socket in the chain open behind it.
- **A start that arrives mid-close waits** for the slot instead of being told the dying session is active. It carries an `AbortSignal` so a transport that gives up during the wait abandons the start rather than building a session for a dead socket. This keeps the invariant that actually matters (one session's audio devices are never live alongside the next one's) without dead-ending the reconnect.
- **`POST /v1/live-voice/session/end`**, the out-of-band recovery path. The in-band `end` frame needs a working transport, and the session that most needs ending is the one whose transport is already gone.

Both self-reclaim paths log at warn and carry their own close reason (`client_timeout`, `forced_end`), so they land in session-end telemetry as `ended_client_timeout` / `ended_forced_end`. This failure mode has been completely invisible until now.

## Testing

464 live-voice tests plus route tests pass; tsc and eslint clean; `openapi.yaml` regenerated. New coverage: slot freed when a close never finishes, silent `server_vad` client reclaimed, transport hung up on reclaim and on forced end, inbound audio pushes the deadline out, `manual` left alone, mid-close start waits then starts, mid-close start abandoned when its transport closes (manager and connection level), session-end route.

## Not in scope

The client-side busy surface is still a message with no button. That is LUM-3421 ("no way to find or reclaim the session"), and the new endpoint is what it needs to become an action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XM48TAn9HxZHjjivssGvJR
