### PR TITLE
fix(providers): constrain managed fallback routing

### DIFF
--- a/assistant/openapi.yaml
+++ b/assistant/openapi.yaml
@@ -5153,6 +5153,7 @@ paths:
                       - profile
                       - weight
                 fallbackProfile:
+                  readOnly: true
                   type: string
                   minLength: 1
       responses:
@@ -34637,7 +34638,8 @@ components:
             - type: "null"
         fallbackProfile:
           anyOf:
-            - type: string
+            - readOnly: true
+              type: string
               minLength: 1
             - type: "null"
       additionalProperties: {}
@@ -35410,6 +35412,7 @@ components:
               - weight
             additionalProperties: false
         fallbackProfile:
+          readOnly: true
           type: string
           minLength: 1
         supportsVision:

--- a/assistant/src/__tests__/llm-resolver.test.ts
+++ b/assistant/src/__tests__/llm-resolver.test.ts
@@ -305,20 +305,19 @@ describe("resolveCallSiteConfig", () => {
 
   test("a winning profile's fallbackProfile metadata never leaks into the resolved config", () => {
     const llm = LLMSchema.parse({
+      defaultProvider: { provider: "vellum" },
       profiles: {
-        primary: {
-          provider: "anthropic",
-          model: "claude-opus-4-7",
-          fallbackProfile: "backup",
+        "quality-optimized": {
+          source: "managed",
+          fallbackProfile: "quality-optimized-backup",
         },
-        backup: { provider: "anthropic", model: "claude-sonnet-4-6" },
       },
       callSites: {
-        memoryExtraction: { profile: "primary" },
+        memoryExtraction: { profile: "quality-optimized" },
       },
     });
     const resolved = resolveCallSiteConfig("memoryExtraction", llm);
-    expect(resolved.model).toBe("claude-opus-4-7");
+    expect(resolved.model).toBe("gpt-5.6-sol");
     // `fallbackProfile` is ProfileEntry-only metadata, absent from
     // `LLMConfigBase`; the resolved config must not carry the key at all.
     expect(Object.hasOwn(resolved, "fallbackProfile")).toBe(false);

--- a/assistant/src/__tests__/llm-schema-fallback-profile.test.ts
+++ b/assistant/src/__tests__/llm-schema-fallback-profile.test.ts
@@ -5,142 +5,68 @@ import { z } from "zod";
 import {
   BACKUP_PROFILE_KEYS,
   DEFAULT_PROFILE_KEYS,
+  FALLBACK_PROFILE_BY_KEY,
 } from "../config/default-profile-names.js";
 import { LLMSchema } from "../config/schemas/llm.js";
 
 describe("LLMSchema fallbackProfile", () => {
-  test("profile with a valid fallbackProfile pointer parses", () => {
+  test.each([...DEFAULT_PROFILE_KEYS])(
+    "accepts the code-owned managed pointer for %s",
+    (profileName) => {
+      const result = LLMSchema.safeParse({
+        defaultProvider: { provider: "vellum" },
+        profiles: {
+          [profileName]: {
+            source: "managed",
+            fallbackProfile: FALLBACK_PROFILE_BY_KEY[profileName],
+          },
+        },
+      });
+      expect(result.success).toBe(true);
+    },
+  );
+
+  test("rejects a user-authored fallbackProfile even when its target exists", () => {
     const result = LLMSchema.safeParse({
       profiles: {
-        primary: { effort: "high", fallbackProfile: "backup" },
+        primary: { fallbackProfile: "backup" },
         backup: { speed: "fast" },
       },
     });
-    expect(result.success).toBe(true);
-    if (result.success) {
-      expect(result.data.profiles["primary"]?.fallbackProfile).toBe("backup");
-    }
-  });
-
-  test("fallbackProfile may reference an always-available default profile key", () => {
-    // Code-defined default profiles resolve without being materialized in
-    // llm.profiles, so they are valid reference targets (same rule as
-    // call-site `profile` references).
-    const defaultKey = DEFAULT_PROFILE_KEYS[0];
-    const result = LLMSchema.safeParse({
-      profiles: {
-        primary: { fallbackProfile: defaultKey },
-      },
-    });
-    expect(result.success).toBe(true);
-  });
-
-  test("fallbackProfile may reference a managed backup profile key", () => {
-    // Backups resolve from the code catalog without being materialized in
-    // llm.profiles, exactly like the always-available defaults, so a pointer
-    // at one is a valid reference. No `defaultProvider` means the managed
-    // column (the reading an install predating the field gets).
-    const backupKey = BACKUP_PROFILE_KEYS[0];
-    const result = LLMSchema.safeParse({
-      profiles: {
-        primary: { fallbackProfile: backupKey },
-      },
-    });
-    expect(result.success).toBe(true);
-  });
-
-  test("dangling fallbackProfile pointer fails superRefine", () => {
-    const result = LLMSchema.safeParse({
-      profiles: {
-        primary: { fallbackProfile: "ghost" },
-      },
-    });
     expect(result.success).toBe(false);
     if (!result.success) {
       const issue = result.error.issues.find((i) =>
-        i.message.includes('fallbackProfile "ghost"'),
-      );
-      expect(issue?.message).toContain("is not defined in llm.profiles");
-      expect(issue?.path).toEqual(["profiles", "primary", "fallbackProfile"]);
-    }
-  });
-
-  test("self-referencing fallbackProfile is rejected", () => {
-    const result = LLMSchema.safeParse({
-      profiles: {
-        primary: { fallbackProfile: "primary" },
-      },
-    });
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      const issue = result.error.issues.find((i) =>
-        i.message.includes("cannot declare itself"),
+        i.message.includes("Automatic fallbacks are code-owned"),
       );
       expect(issue?.path).toEqual(["profiles", "primary", "fallbackProfile"]);
     }
   });
 
-  test("fallbackProfile pointing at a mix profile is rejected", () => {
+  test("rejects a fallbackProfile on a user-owned default-profile shadow", () => {
+    const profileName = DEFAULT_PROFILE_KEYS[0];
     const result = LLMSchema.safeParse({
       profiles: {
-        primary: { fallbackProfile: "blend" },
-        armA: { speed: "fast" },
-        armB: { effort: "high" },
-        blend: {
-          mix: [
-            { profile: "armA", weight: 1 },
-            { profile: "armB", weight: 1 },
-          ],
+        [profileName]: {
+          source: "user",
+          fallbackProfile: FALLBACK_PROFILE_BY_KEY[profileName],
         },
       },
     });
     expect(result.success).toBe(false);
-    if (!result.success) {
-      const issue = result.error.issues.find((i) =>
-        i.message.includes("is a mix profile"),
-      );
-      expect(issue?.path).toEqual(["profiles", "primary", "fallbackProfile"]);
-    }
   });
 
-  test("two-hop fallback chain is rejected (single hop only)", () => {
+  test("rejects a managed default pointing anywhere except its code-owned backup", () => {
+    const profileName = DEFAULT_PROFILE_KEYS[0];
     const result = LLMSchema.safeParse({
       profiles: {
-        primary: { fallbackProfile: "middle" },
-        middle: { fallbackProfile: "last" },
-        last: { speed: "fast" },
-      },
-    });
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      const issue = result.error.issues.find((i) =>
-        i.message.includes("chains are not allowed"),
-      );
-      expect(issue?.path).toEqual(["profiles", "primary", "fallbackProfile"]);
-    }
-  });
-
-  test("mix profile carrying fallbackProfile is rejected", () => {
-    const result = LLMSchema.safeParse({
-      profiles: {
-        armA: { speed: "fast" },
-        armB: { effort: "high" },
-        blend: {
-          mix: [
-            { profile: "armA", weight: 1 },
-            { profile: "armB", weight: 1 },
-          ],
-          fallbackProfile: "armA",
+        [profileName]: {
+          source: "managed",
+          fallbackProfile: "custom-backup",
         },
+        "custom-backup": { speed: "fast" },
       },
     });
     expect(result.success).toBe(false);
-    if (!result.success) {
-      const issue = result.error.issues.find((i) =>
-        i.message.includes('cannot also set "fallbackProfile"'),
-      );
-      expect(issue?.path).toEqual(["profiles", "blend", "fallbackProfile"]);
-    }
   });
 
   test("empty-string fallbackProfile is rejected at field level", () => {
@@ -168,56 +94,47 @@ describe("LLMSchema fallbackProfile", () => {
     }
   });
 
-  test("a backup fallbackProfile target is rejected on a non-managed column", () => {
-    // The backups exist only on the managed column, so under a BYOK or
-    // ChatGPT default provider the pointer names a target that can never
-    // resolve, and keeping it would leave the primary silently unprotected.
-    const backupKey = BACKUP_PROFILE_KEYS[0];
+  test("a code-owned fallback pointer is rejected on a non-managed column", () => {
+    const profileName = DEFAULT_PROFILE_KEYS[0];
     for (const provider of ["anthropic", "chatgpt"] as const) {
       const result = LLMSchema.safeParse({
         defaultProvider: { provider },
         profiles: {
-          primary: { fallbackProfile: backupKey },
+          [profileName]: {
+            source: "managed",
+            fallbackProfile: FALLBACK_PROFILE_BY_KEY[profileName],
+          },
         },
       });
       expect(result.success).toBe(false);
       if (!result.success) {
         const issue = result.error.issues.find((i) =>
-          i.message.includes(`fallbackProfile "${backupKey}"`),
+          i.path.join(".").endsWith("fallbackProfile"),
         );
         expect(issue?.message).toContain("managed backup profile");
-        expect(issue?.path).toEqual(["profiles", "primary", "fallbackProfile"]);
+        expect(issue?.path).toEqual([
+          "profiles",
+          profileName,
+          "fallbackProfile",
+        ]);
       }
     }
   });
 
-  test("a user-owned materialized backup entry is a valid target on any column", () => {
-    // Conditioning applies to the code-defined name, not to a user-owned
-    // workspace entry: that entry carries its own body, and with no
-    // code-owned body to lose on a BYOK column it is what the name resolves
-    // to, so a pointer at it stays valid. A `source` other than `managed`,
-    // absent included, is what makes an entry user-owned, matching
-    // `resolveAgainstBody`.
-    const backupKey = BACKUP_PROFILE_KEYS[0];
-    const result = LLMSchema.safeParse({
-      defaultProvider: { provider: "anthropic" },
-      profiles: {
-        primary: { fallbackProfile: backupKey },
-        [backupKey]: { provider: "anthropic", model: "claude-opus-4-7" },
-      },
-    });
-    expect(result.success).toBe(true);
-  });
-
   test("z.toJSONSchema still generates for LLMSchema (config docs/routes)", () => {
-    // Same options as handleGetConfigSchema in
-    // runtime/routes/conversation-query-routes.ts. The field must not
-    // introduce any callback-bearing zod construct that breaks generation.
     const json = z.toJSONSchema(LLMSchema, {
       unrepresentable: "any",
       io: "input",
     });
-    expect(json).toBeTruthy();
+    expect(json).toMatchObject({
+      properties: {
+        profiles: {
+          additionalProperties: {
+            properties: { fallbackProfile: { readOnly: true } },
+          },
+        },
+      },
+    });
   });
 });
 
@@ -403,7 +320,7 @@ describe("LLMSchema backup profile references vs llm.defaultProvider", () => {
         const issue = result.error.issues.find(
           (i) => i.path.join(".") === "profiles.primary.fallbackProfile",
         );
-        expect(issue?.message).toContain("managed backup profile");
+        expect(issue?.message).toContain("Automatic fallbacks are code-owned");
       }
     }
   });
@@ -415,7 +332,6 @@ describe("LLMSchema backup profile references vs llm.defaultProvider", () => {
       defaultProvider: managed,
       profiles: {
         [backupKey]: stub,
-        primary: { fallbackProfile: backupKey },
       },
       activeProfile: backupKey,
       callSites: { recall: { profile: backupKey } },
@@ -423,7 +339,7 @@ describe("LLMSchema backup profile references vs llm.defaultProvider", () => {
     expect(result.success).toBe(true);
   });
 
-  test("a user-owned entry under a backup name keeps its references on every column", () => {
+  test("a user-owned entry under a backup name cannot enable custom fallback", () => {
     for (const defaultProvider of [managed, ...nonManaged]) {
       const result = LLMSchema.safeParse({
         defaultProvider,
@@ -437,7 +353,7 @@ describe("LLMSchema backup profile references vs llm.defaultProvider", () => {
         },
         activeProfile: backupKey,
       });
-      expect(result.success).toBe(true);
+      expect(result.success).toBe(false);
     }
   });
 });

--- a/assistant/src/__tests__/managed-fallback-dispatch.test.ts
+++ b/assistant/src/__tests__/managed-fallback-dispatch.test.ts
@@ -1,15 +1,9 @@
 /**
- * Managed backup-profile dispatch, end to end against a mocked upstream.
+ * Managed backup-profile dispatch against a mocked platform proxy.
  *
- * Everything below the test is production code: the real adapter factory, the
- * real managed-proxy auth resolution, the real `RetryProvider` escalation, and
- * the real Anthropic client. Only the upstream is faked, by a local
- * `Bun.serve` standing in for the platform's runtime proxy, so the assertions
- * are made on the bytes the backup route actually puts on the wire.
- *
- * Deliberately mock-free at the module level: `mock.module` is process-wide in
- * bun, and stubbing the provider clients here would leak into every other file
- * that exercises them.
+ * The primary test path includes `CallSiteRoutingProvider`, connection
+ * selection, the real adapter factory, retry escalation, and provider clients.
+ * Only the remote platform proxy is replaced with a local HTTP server.
  */
 
 import {
@@ -22,9 +16,8 @@ import {
   test,
 } from "bun:test";
 
+import { CallSiteRoutingProvider } from "../providers/call-site-routing.js";
 import {
-  type BreakerRoute,
-  recordFallbackServed,
   resetFallbackBreaker,
   shouldSkipPrimary,
 } from "../providers/fallback-breaker.js";
@@ -33,12 +26,15 @@ import type {
   ProviderConnection,
   ResolvedAuth,
 } from "../providers/inference/auth.js";
-import type { Message, ProviderResponse } from "../providers/types.js";
+import type {
+  Message,
+  Provider,
+  ProviderResponse,
+} from "../providers/types.js";
+import { getManagedUpstream } from "../providers/vellum-model-routing.js";
 import { credentialKey } from "../security/credential-key.js";
 import { setSecureKeyAsync } from "../security/secure-keys.js";
 import { setConfig } from "./helpers/set-config.js";
-
-// ── Mocked upstream ─────────────────────────────────────────────────────────
 
 interface UpstreamRequest {
   path: string;
@@ -47,31 +43,11 @@ interface UpstreamRequest {
 }
 
 const requests: UpstreamRequest[] = [];
-
-/**
- * What the anthropic proxy path does. `retired` is the model rename/retirement
- * shape: fallback-eligible but not retryable, so the escalation decision is
- * reached on the first attempt instead of after a full retry budget.
- */
-let anthropicMode: "serve" | "retired" = "serve";
-
-/**
- * Models the anthropic path answers with the retired shape whatever
- * `anthropicMode` says, so one case can fail a primary pin while its backup pin
- * keeps serving on the same upstream.
- */
-const retiredModels = new Set<string>();
-
-/** The primary pin of the breaker case below, as its 404 marks it. */
-const RETIRED_ROUTE: BreakerRoute = {
-  upstream: "anthropic",
-  model: "claude-opus-5",
-};
+let anthropicMode: "serve" | "retired" | "unavailable" = "serve";
 
 const ANTHROPIC_PATH = "/v1/runtime-proxy/anthropic";
 const OPENAI_PATH = "/v1/runtime-proxy/openai";
 
-/** A complete Anthropic Messages SSE stream for a one-word reply. */
 function anthropicCompletion(): Response {
   const events = [
     {
@@ -123,8 +99,6 @@ function anthropicCompletion(): Response {
   });
 }
 
-/** The outage the primary route keeps returning. `retry-after: 0` keeps the
- *  retry loop honest without making the test wait out real backoff. */
 function upstreamUnavailable(): Response {
   return new Response(
     JSON.stringify({ error: { message: "upstream unavailable" } }),
@@ -135,7 +109,6 @@ function upstreamUnavailable(): Response {
   );
 }
 
-/** A retired model id, the other outage shape fallback exists for. */
 function modelRetired(): Response {
   return new Response(
     JSON.stringify({
@@ -146,9 +119,7 @@ function modelRetired(): Response {
   );
 }
 
-let server: ReturnType<typeof Bun.serve>;
-
-// ── Fixtures ────────────────────────────────────────────────────────────────
+let server: ReturnType<typeof Bun.serve> | undefined;
 
 const MESSAGES: Message[] = [
   { role: "user", content: [{ type: "text", text: "hi" }] },
@@ -176,6 +147,9 @@ const byokConnection = {
 } as unknown as ProviderConnection;
 
 function managedAuth(proxyPath: string): ResolvedAuth {
+  if (server === undefined) {
+    throw new Error("test proxy is not running");
+  }
   return {
     kind: "header",
     headers: { Authorization: "Bearer test-assistant-key" },
@@ -184,11 +158,72 @@ function managedAuth(proxyPath: string): ResolvedAuth {
 }
 
 function requestsTo(proxyPath: string): UpstreamRequest[] {
-  return requests.filter((r) => r.path.startsWith(proxyPath));
+  return requests.filter((request) => request.path.startsWith(proxyPath));
+}
+
+function createManagedAdapter(upstream: string, model: string): Provider {
+  const proxyPath =
+    upstream === "openai"
+      ? OPENAI_PATH
+      : upstream === "anthropic"
+        ? ANTHROPIC_PATH
+        : null;
+  if (proxyPath === null) {
+    throw new Error(`unsupported test upstream: ${upstream}`);
+  }
+  const provider = createAdapterFromConnection(
+    vellumConnection,
+    managedAuth(proxyPath),
+    {
+      model,
+      provider: upstream,
+      streamTimeoutMs: 30_000,
+    },
+  );
+  if (provider === null) {
+    throw new Error(`failed to create ${upstream} test adapter`);
+  }
+  return provider;
+}
+
+/**
+ * Construct the production wrapper order that calls use. The connection
+ * resolver builds the managed adapter for the provider/model selected by the
+ * call-site router, so fallback eligibility sees the original call-site
+ * options while the primary transport matches the resolved route.
+ */
+function createRoutedManagedProvider(): Provider {
+  const defaultProvider = createManagedAdapter("openai", "gpt-5.6-sol");
+  return new CallSiteRoutingProvider(
+    defaultProvider,
+    async (connectionName, expectedProvider, model) => {
+      if (connectionName !== "vellum" || model === undefined) {
+        return null;
+      }
+      const upstream =
+        expectedProvider === "vellum"
+          ? getManagedUpstream(model)
+          : expectedProvider;
+      return upstream === undefined || upstream === null
+        ? null
+        : createManagedAdapter(upstream, model);
+    },
+    defaultProvider.routeAttribution,
+  );
+}
+
+async function captureError(promise: Promise<unknown>): Promise<unknown> {
+  try {
+    await promise;
+  } catch (error) {
+    return error;
+  }
+  throw new Error("expected the promise to reject");
 }
 
 beforeAll(async () => {
   server = Bun.serve({
+    hostname: "127.0.0.1",
     port: 0,
     async fetch(req) {
       const url = new URL(req.url);
@@ -196,7 +231,7 @@ beforeAll(async () => {
       try {
         body = (await req.json()) as Record<string, unknown>;
       } catch {
-        // Not every probe carries a JSON body; the path alone is enough.
+        // The request path is sufficient for non-JSON probes.
       }
       requests.push({
         path: url.pathname,
@@ -204,78 +239,49 @@ beforeAll(async () => {
         body,
       });
       if (url.pathname.startsWith(ANTHROPIC_PATH)) {
-        return anthropicMode === "retired" ||
-          retiredModels.has(String(body.model))
-          ? modelRetired()
+        if (anthropicMode === "retired") {
+          return modelRetired();
+        }
+        return anthropicMode === "unavailable"
+          ? upstreamUnavailable()
           : anthropicCompletion();
       }
       return upstreamUnavailable();
     },
   });
-  // Managed-proxy prerequisites: the platform base URL points at the mock
-  // upstream, so `buildManagedBaseUrl` derives the per-provider proxy paths
-  // above and the backup route resolves its auth for real.
   setConfig("platform", { baseUrl: `http://127.0.0.1:${server.port}` });
   await setSecureKeyAsync(ASSISTANT_API_KEY, "test-assistant-key");
   await setSecureKeyAsync(BYOK_CREDENTIAL, "test-byok-key");
 });
 
 afterAll(() => {
-  server.stop(true);
+  server?.stop(true);
 });
 
 beforeEach(() => {
-  // A served fallback is remembered for the whole process, and bun shares
-  // module state between test files, so without this a case here would skip
-  // the primary route it means to exercise.
   resetFallbackBreaker();
 });
 
 afterEach(() => {
   requests.length = 0;
   anthropicMode = "serve";
-  retiredModels.clear();
 });
 
-// ── Tests ───────────────────────────────────────────────────────────────────
-
 describe("managed fallback dispatch", () => {
-  test("a managed quality-optimized outage is served on the backup profile", async () => {
+  test("a managed default outage is served through the routed backup profile", async () => {
     setConfig("llm", { activeProfile: "quality-optimized" });
+    const provider = createRoutedManagedProvider();
 
-    // The managed adapter for the primary route: the quality profile's own
-    // pin (`gpt-5.6-sol`), whose managed upstream is openai.
-    const provider = createAdapterFromConnection(
-      vellumConnection,
-      managedAuth(OPENAI_PATH),
-      {
-        model: "gpt-5.6-sol",
-        provider: "openai",
-        streamTimeoutMs: 30_000,
-      },
-    );
-    expect(provider).not.toBeNull();
-
-    const response: ProviderResponse = await provider!.sendMessage(MESSAGES, {
+    const response: ProviderResponse = await provider.sendMessage(MESSAGES, {
       config: { callSite: "mainAgent" },
     });
 
-    // The primary was tried and kept failing before anything escalated.
     expect(requestsTo(OPENAI_PATH).length).toBeGreaterThan(1);
-
-    // The backup profile's pin served the request, through the same managed
-    // connection, on the upstream its own model resolves to.
     const backup = requestsTo(ANTHROPIC_PATH);
     expect(backup.length).toBe(1);
     expect(backup[0].body.model).toBe("claude-opus-5");
-    // The backup profile's own settings win over the failed primary's.
     expect(backup[0].body.max_tokens).toBe(32000);
-    // `adaptive` is the wire form an adaptive-thinking-only model takes for the
-    // backup profile's `thinking.enabled`.
     expect(backup[0].body.thinking).toMatchObject({ type: "adaptive" });
-
-    // Degraded traffic is attributed to the backup profile, both on the wire
-    // for the platform's usage events and on the response for the local ledger.
     expect(backup[0].headers["x-vellum-inference-profile"]).toBe(
       "quality-optimized-backup",
     );
@@ -283,429 +289,142 @@ describe("managed fallback dispatch", () => {
     expect(response.actualProvider).toBe("anthropic");
   });
 
-  test("a BYOK connection never falls back, even on an eligible error", async () => {
-    // Pointers like this never exist on a BYOK column, but seeding one proves
-    // the gate is the connection identity rather than the absence of a target.
+  test.each([
+    ["model", "gpt-5.6-sol"],
+    ["provider", "openai"],
+  ] as const)(
+    "a persisted call-site %s pin never falls back",
+    async (field, value) => {
+      setConfig("llm", {
+        activeProfile: "quality-optimized",
+        callSites: { mainAgent: { [field]: value } },
+      });
+      const provider = createRoutedManagedProvider();
+
+      const error = await captureError(
+        provider.sendMessage(MESSAGES, { config: { callSite: "mainAgent" } }),
+      );
+
+      expect((error as { provider?: string }).provider).toBe("openai");
+      expect(requestsTo(OPENAI_PATH).length).toBeGreaterThan(1);
+      expect(requestsTo(ANTHROPIC_PATH)).toHaveLength(0);
+      expect(shouldSkipPrimary({ upstream: "openai" })).toBe(false);
+    },
+  );
+
+  test("a BYOK connection never installs automatic fallback routing", async () => {
     setConfig("llm", {
       profiles: {
         "byok-primary": {
           source: "user",
           provider: "anthropic",
           model: "claude-opus-5",
-          fallbackProfile: "byok-backup",
           maxTokens: 1024,
-        },
-        "byok-backup": {
-          source: "user",
-          provider: "anthropic",
-          model: "claude-sonnet-5",
-          maxTokens: 2048,
         },
       },
       activeProfile: "byok-primary",
     });
     anthropicMode = "retired";
-
     const provider = createAdapterFromConnection(
       byokConnection,
       {
         kind: "header",
         headers: { Authorization: "Bearer test-byok-key" },
-        baseUrl: `http://127.0.0.1:${server.port}${ANTHROPIC_PATH}`,
+        baseUrl: `http://127.0.0.1:${server?.port}${ANTHROPIC_PATH}`,
       },
       { model: "claude-opus-5", streamTimeoutMs: 30_000 },
     );
     expect(provider).not.toBeNull();
 
-    const error = await provider!
-      .sendMessage(MESSAGES, { config: { callSite: "mainAgent" } })
-      .then(
-        () => null,
-        (err: unknown) => err,
-      );
+    const error = await captureError(
+      provider!.sendMessage(MESSAGES, { config: { callSite: "mainAgent" } }),
+    );
 
-    // The primary's own error surfaces. A BYOK install may hold no credential
-    // for the backup's provider, so an escalation here would leave the vendor's
-    // answer to a foreign route in place of the real failure.
     expect((error as { statusCode?: number }).statusCode).toBe(404);
-    // Every attempt used the primary's pin: no route was ever escalated.
-    const models = new Set(requests.map((r) => r.body.model));
-    expect(models).toEqual(new Set(["claude-opus-5"]));
+    expect(new Set(requests.map((request) => request.body.model))).toEqual(
+      new Set(["claude-opus-5"]),
+    );
   });
 
-  test("a managed profile with no fallbackProfile rethrows the original error", async () => {
+  test("a custom managed profile has no automatic fallback contract", async () => {
     setConfig("llm", {
       profiles: {
-        "managed-no-backup": {
+        custom: {
           source: "user",
-          provider: "anthropic",
+          provider: "vellum",
           model: "claude-opus-5",
           maxTokens: 1024,
         },
       },
-      activeProfile: "managed-no-backup",
+      activeProfile: "custom",
     });
     anthropicMode = "retired";
+    const provider = createRoutedManagedProvider();
 
-    const provider = createAdapterFromConnection(
-      vellumConnection,
-      managedAuth(ANTHROPIC_PATH),
-      {
-        model: "claude-opus-5",
-        provider: "anthropic",
-        streamTimeoutMs: 30_000,
-      },
+    const error = await captureError(
+      provider.sendMessage(MESSAGES, { config: { callSite: "mainAgent" } }),
     );
-    expect(provider).not.toBeNull();
 
-    const error = await provider!
-      .sendMessage(MESSAGES, { config: { callSite: "mainAgent" } })
-      .then(
-        () => null,
-        (err: unknown) => err,
-      );
-
-    // The original upstream failure surfaces unchanged: the callback found no
-    // pointer, so nothing was re-routed and no fallback error replaced it.
-    expect(error).toBeInstanceOf(Error);
     expect((error as { statusCode?: number }).statusCode).toBe(404);
-    expect((error as { cause?: unknown }).cause).toBeUndefined();
-    const models = new Set(requests.map((r) => r.body.model));
-    expect(models).toEqual(new Set(["claude-opus-5"]));
+    expect(new Set(requests.map((request) => request.body.model))).toEqual(
+      new Set(["claude-opus-5"]),
+    );
   });
 
-  test("the backup adapter serves the model a call-site tweak resolves to", async () => {
-    // A call site's own tuning fragment layers OVER the winning profile, so a
-    // `model` tweak decides the model even when the backup profile is forced.
-    // The adapter has to be built for THAT model's upstream: deriving it from
-    // the backup profile's own pin would send an OpenAI-shaped request through
-    // an Anthropic adapter (or the reverse).
+  test("a user shadow cannot change the code-owned backup route", async () => {
     setConfig("llm", {
       profiles: {
-        "tweaked-primary": {
+        "quality-optimized-backup": {
           source: "user",
-          provider: "vellum",
-          model: "gpt-5.6-sol",
-          fallbackProfile: "tweaked-backup",
-          maxTokens: 1024,
-        },
-        // Deliberately an OpenAI pin, so the backup profile's own model and the
-        // call-site tweak below resolve to different upstreams.
-        "tweaked-backup": {
-          source: "user",
-          provider: "vellum",
-          model: "gpt-5.6-terra",
-          maxTokens: 2048,
+          provider: "missing-connection-entry",
+          model: "custom-model",
         },
       },
-      activeProfile: "tweaked-primary",
-      callSites: { mainAgent: { model: "claude-opus-5" } },
+      activeProfile: "quality-optimized",
     });
+    const provider = createRoutedManagedProvider();
 
-    const provider = createAdapterFromConnection(
-      vellumConnection,
-      managedAuth(OPENAI_PATH),
-      {
-        model: "gpt-5.6-sol",
-        provider: "openai",
-        streamTimeoutMs: 30_000,
-      },
-    );
-    expect(provider).not.toBeNull();
-
-    const response: ProviderResponse = await provider!.sendMessage(MESSAGES, {
+    const response = await provider.sendMessage(MESSAGES, {
       config: { callSite: "mainAgent" },
     });
 
-    // The escalation followed the tweak, not the backup profile's own pin: the
-    // request reached the Anthropic upstream carrying the Anthropic model.
     const backup = requestsTo(ANTHROPIC_PATH);
-    expect(backup.length).toBe(1);
+    expect(backup).toHaveLength(1);
     expect(backup[0].body.model).toBe("claude-opus-5");
-    // Deriving the upstream from the backup profile's own OpenAI pin instead
-    // would have escalated straight back to the failing OpenAI path, so the
-    // request never reaches Anthropic at all.
-    expect(requestsTo(OPENAI_PATH).length).toBeGreaterThan(0);
-    expect(response.actualProvider).toBe("anthropic");
-    expect(response.actualInferenceProfile).toBe("tweaked-backup");
+    expect(response.actualInferenceProfile).toBe("quality-optimized-backup");
   });
 
-  test("a backup routing outside the managed connection is refused", async () => {
-    // The schema allows a pointer at a user-defined profile that carries its
-    // own BYOK provider. Serving it here would authenticate someone's personal
-    // route with the managed credential and bill it as managed traffic, so the
-    // escalation is declined and the primary's failure stands.
-    setConfig("llm", {
-      profiles: {
-        "managed-primary": {
-          source: "user",
-          provider: "vellum",
-          model: "claude-opus-5",
-          fallbackProfile: "byok-target",
-          maxTokens: 1024,
-        },
-        "byok-target": {
-          source: "user",
-          provider: "anthropic",
-          model: "claude-sonnet-5",
-          maxTokens: 2048,
-        },
-      },
-      activeProfile: "managed-primary",
-    });
-    anthropicMode = "retired";
+  test("a failed backup preserves the primary error and does not count as served", async () => {
+    setConfig("llm", { activeProfile: "quality-optimized" });
+    anthropicMode = "unavailable";
+    const provider = createRoutedManagedProvider();
 
-    const provider = createAdapterFromConnection(
-      vellumConnection,
-      managedAuth(ANTHROPIC_PATH),
-      {
-        model: "claude-opus-5",
-        provider: "anthropic",
-        streamTimeoutMs: 30_000,
-      },
+    const error = await captureError(
+      provider.sendMessage(MESSAGES, { config: { callSite: "mainAgent" } }),
     );
-    expect(provider).not.toBeNull();
 
-    const error = await provider!
-      .sendMessage(MESSAGES, { config: { callSite: "mainAgent" } })
-      .then(
-        () => null,
-        (err: unknown) => err,
-      );
-
-    expect(error).toBeInstanceOf(Error);
-    expect((error as { statusCode?: number }).statusCode).toBe(404);
-    // Nothing was re-routed: the backup's model never went on the wire.
-    const models = new Set(requests.map((r) => r.body.model));
-    expect(models).toEqual(new Set(["claude-opus-5"]));
+    expect((error as { provider?: string }).provider).toBe("openai");
+    expect(requestsTo(OPENAI_PATH).length).toBeGreaterThan(1);
+    expect(requestsTo(ANTHROPIC_PATH).length).toBeGreaterThan(0);
+    expect(shouldSkipPrimary({ upstream: "openai" })).toBe(false);
   });
 
-  test("a managed backup still serves under a call-site provider tweak", async () => {
-    // A call-site fragment pinning a concrete upstream over a managed winner
-    // resolves to that provider while the resolver keeps the managed
-    // connection, so this is managed traffic and must still fall back. The
-    // guard above keys on the connection precisely so this case survives.
-    setConfig("llm", {
-      profiles: {
-        "tweak-primary": {
-          source: "user",
-          provider: "vellum",
-          model: "gpt-5.6-sol",
-          fallbackProfile: "tweak-managed-backup",
-          maxTokens: 1024,
-        },
-        "tweak-managed-backup": {
-          source: "user",
-          provider: "vellum",
-          model: "claude-opus-5",
-          maxTokens: 2048,
-        },
-      },
-      activeProfile: "tweak-primary",
-      callSites: { mainAgent: { provider: "anthropic" } },
-    });
+  test("a served backup opens the breaker for the routed primary", async () => {
+    setConfig("llm", { activeProfile: "quality-optimized" });
+    const provider = createRoutedManagedProvider();
 
-    const provider = createAdapterFromConnection(
-      vellumConnection,
-      managedAuth(OPENAI_PATH),
-      {
-        model: "gpt-5.6-sol",
-        provider: "openai",
-        streamTimeoutMs: 30_000,
-      },
-    );
-    expect(provider).not.toBeNull();
-
-    const response: ProviderResponse = await provider!.sendMessage(MESSAGES, {
+    await provider.sendMessage(MESSAGES, {
       config: { callSite: "mainAgent" },
     });
+    expect(shouldSkipPrimary({ upstream: "openai" })).toBe(true);
 
-    const backup = requestsTo(ANTHROPIC_PATH);
-    expect(backup.length).toBe(1);
-    expect(backup[0].body.model).toBe("claude-opus-5");
-    expect(response.actualInferenceProfile).toBe("tweak-managed-backup");
-  });
-
-  test("the backup upstream follows the resolved provider, not the model's catalog owner", async () => {
-    // The divergent shape: a call-site fragment pins a concrete upstream while
-    // the backup profile's own model belongs to a different one. Normal
-    // dispatch routes this by the resolved provider (`connection-resolution`
-    // threads it through as `providerOverride` for the managed connection), so
-    // the fallback has to as well. Deriving the upstream from the model instead
-    // sends the request somewhere the primary route never would have.
-    setConfig("llm", {
-      profiles: {
-        "divergent-primary": {
-          source: "user",
-          provider: "vellum",
-          model: "gpt-5.6-sol",
-          fallbackProfile: "divergent-backup",
-          maxTokens: 1024,
-        },
-        // An OpenAI-owned model under an Anthropic call-site pin: the resolved
-        // provider and the model's catalog owner disagree.
-        "divergent-backup": {
-          source: "user",
-          provider: "vellum",
-          model: "gpt-5.6-terra",
-          maxTokens: 2048,
-        },
-      },
-      activeProfile: "divergent-primary",
-      callSites: { mainAgent: { provider: "anthropic" } },
-    });
-
-    const provider = createAdapterFromConnection(
-      vellumConnection,
-      managedAuth(OPENAI_PATH),
-      {
-        model: "gpt-5.6-sol",
-        provider: "openai",
-        streamTimeoutMs: 30_000,
-      },
-    );
-    expect(provider).not.toBeNull();
-
-    const response: ProviderResponse = await provider!.sendMessage(MESSAGES, {
-      config: { callSite: "mainAgent" },
-    });
-
-    // The escalation went to the pinned provider's upstream carrying the
-    // resolved model. Routing by the model's catalog owner would have escalated
-    // straight back onto the failing OpenAI path, so nothing reaches Anthropic.
-    const backup = requestsTo(ANTHROPIC_PATH);
-    expect(backup.length).toBe(1);
-    expect(backup[0].body.model).toBe("gpt-5.6-terra");
-    expect(response.actualProvider).toBe("anthropic");
-    expect(response.actualInferenceProfile).toBe("divergent-backup");
-  });
-
-  test("a backup whose resolved provider cannot front the managed proxy is refused", async () => {
-    // The connection guard passes (the resolver keeps the managed connection),
-    // but the pinned provider is not one the platform proxy serves. There is no
-    // upstream to build an adapter for, so the primary's failure stands rather
-    // than the request being quietly rerouted to the model's catalog owner.
-    setConfig("llm", {
-      profiles: {
-        "unroutable-primary": {
-          source: "user",
-          provider: "vellum",
-          model: "claude-opus-5",
-          fallbackProfile: "unroutable-backup",
-          maxTokens: 1024,
-        },
-        // Named on the managed connection, so the connection guard lets it
-        // through, but `openrouter` is not a managed-routable upstream.
-        "unroutable-backup": {
-          source: "user",
-          provider: "openrouter",
-          provider_connection: "vellum",
-          model: "claude-sonnet-5",
-          maxTokens: 2048,
-        },
-      },
-      activeProfile: "unroutable-primary",
-    });
-    anthropicMode = "retired";
-
-    const provider = createAdapterFromConnection(
-      vellumConnection,
-      managedAuth(ANTHROPIC_PATH),
-      {
-        model: "claude-opus-5",
-        provider: "anthropic",
-        streamTimeoutMs: 30_000,
-      },
-    );
-    expect(provider).not.toBeNull();
-
-    const error = await provider!
-      .sendMessage(MESSAGES, { config: { callSite: "mainAgent" } })
-      .then(
-        () => null,
-        (err: unknown) => err,
-      );
-
-    expect(error).toBeInstanceOf(Error);
-    expect((error as { statusCode?: number }).statusCode).toBe(404);
-    const models = new Set(requests.map((r) => r.body.model));
-    expect(models).toEqual(new Set(["claude-opus-5"]));
-  });
-
-  test("a remembered outage skips the primary, and a probe restores it once it recovers", async () => {
-    // Both pins sit on the same upstream, which is what the breaker is keyed
-    // on: the point here is the route being skipped and probed, not the
-    // cross-provider hop the cases above cover.
-    setConfig("llm", {
-      profiles: {
-        "breaker-primary": {
-          source: "user",
-          provider: "vellum",
-          model: "claude-opus-5",
-          fallbackProfile: "breaker-backup",
-          maxTokens: 1024,
-        },
-        "breaker-backup": {
-          source: "user",
-          provider: "vellum",
-          model: "claude-sonnet-5",
-          maxTokens: 2048,
-        },
-      },
-      activeProfile: "breaker-primary",
-    });
-    retiredModels.add("claude-opus-5");
-
-    const provider = createAdapterFromConnection(
-      vellumConnection,
-      managedAuth(ANTHROPIC_PATH),
-      {
-        model: "claude-opus-5",
-        provider: "anthropic",
-        streamTimeoutMs: 30_000,
-      },
-    );
-    expect(provider).not.toBeNull();
-
-    // The first request discovers the outage the expensive way and escalates.
-    const first: ProviderResponse = await provider!.sendMessage(MESSAGES, {
-      config: { callSite: "mainAgent" },
-    });
-    expect(first.actualInferenceProfile).toBe("breaker-backup");
-    expect(requests.map((r) => r.body.model)).toEqual([
-      "claude-opus-5",
-      "claude-sonnet-5",
-    ]);
-    // A retired pin is remembered for that model, not for the upstream, so the
-    // backup's own model on the same upstream stays available.
-    expect(shouldSkipPrimary(RETIRED_ROUTE)).toBe(true);
-    expect(
-      shouldSkipPrimary({ upstream: "anthropic", model: "claude-sonnet-5" }),
-    ).toBe(false);
-
-    // The second request reaches the backup without touching the dead pin.
     requests.length = 0;
-    const second: ProviderResponse = await provider!.sendMessage(MESSAGES, {
-      config: { callSite: "mainAgent" },
-    });
-    expect(second.actualInferenceProfile).toBe("breaker-backup");
-    expect(requests.map((r) => r.body.model)).toEqual(["claude-sonnet-5"]);
-
-    // The upstream recovers and the cooldown elapses: re-trip the breaker at a
-    // timestamp older than the longest cooldown it can pick, which is how a
-    // process that has been degraded for a while looks.
-    retiredModels.clear();
-    resetFallbackBreaker();
-    recordFallbackServed(RETIRED_ROUTE, Date.now() - 11 * 60_000);
-    requests.length = 0;
-
-    const third: ProviderResponse = await provider!.sendMessage(MESSAGES, {
+    const response = await provider.sendMessage(MESSAGES, {
       config: { callSite: "mainAgent" },
     });
 
-    // The probe went to the primary pin, served, and closed the breaker.
-    expect(requests.map((r) => r.body.model)).toEqual(["claude-opus-5"]);
-    expect(third.actualInferenceProfile).toBeUndefined();
-    expect(shouldSkipPrimary(RETIRED_ROUTE)).toBe(false);
+    expect(requestsTo(OPENAI_PATH)).toHaveLength(0);
+    expect(requestsTo(ANTHROPIC_PATH)).toHaveLength(1);
+    expect(response.actualInferenceProfile).toBe("quality-optimized-backup");
   });
 });

--- a/assistant/src/__tests__/retry-fallback-escalation.test.ts
+++ b/assistant/src/__tests__/retry-fallback-escalation.test.ts
@@ -428,29 +428,67 @@ describe("RetryProvider fallback-route escalation", () => {
     expect(route.calls()).toBe(0);
   });
 
-  test("explicit config.model pin + outage-shaped error → callback never invoked, original error rethrown", async () => {
-    // Per-conversation `modelOverride` is a live feature; a pinned
-    // conversation keeps today's retry-then-error behavior. The fallback
-    // must never silently serve a different model against an explicit pin.
-    const finalError = new ProviderError("Service Unavailable", "openai", 503);
-    const primary = failingProvider("openai", () => finalError);
-    const route = makeRoute(backupProvider().provider);
-    const wrapped = new RetryProvider(primary.provider, {
-      resolveFallbackRoute: route.resolveFallbackRoute,
-    });
+  test.each([
+    ["model", "pinned-model"],
+    ["provider", "openai"],
+    ["provider_connection", "vellum"],
+  ] as const)(
+    "explicit config.%s pin + outage-shaped error → callback never invoked, original error rethrown",
+    async (field, value) => {
+      const finalError = new ProviderError(
+        "Service Unavailable",
+        "openai",
+        503,
+      );
+      const primary = failingProvider("openai", () => finalError);
+      const route = makeRoute(backupProvider().provider);
+      const wrapped = new RetryProvider(primary.provider, {
+        resolveFallbackRoute: route.resolveFallbackRoute,
+      });
 
-    const thrown = await captureError(
-      wrapped.sendMessage(MESSAGES, {
-        config: { callSite: "mainAgent", model: "pinned-model" },
-      }),
-    );
+      const thrown = await captureError(
+        wrapped.sendMessage(MESSAGES, {
+          config: { callSite: "mainAgent", [field]: value },
+        }),
+      );
 
-    expect(thrown).toBe(finalError);
-    expect(route.calls()).toBe(0);
-    expect((thrown as { retriesExhausted?: boolean }).retriesExhausted).toBe(
-      true,
-    );
-  });
+      expect(thrown).toBe(finalError);
+      expect(route.calls()).toBe(0);
+      expect((thrown as { retriesExhausted?: boolean }).retriesExhausted).toBe(
+        true,
+      );
+    },
+  );
+
+  test.each([
+    ["model", "pinned-model"],
+    ["provider", "openai"],
+  ] as const)(
+    "persisted call-site %s pin + outage-shaped error → callback never invoked",
+    async (field, value) => {
+      setConfig("llm", {
+        ...LLM_FIXTURE,
+        callSites: { mainAgent: { [field]: value } },
+      });
+      const finalError = new ProviderError(
+        "Service Unavailable",
+        "openai",
+        503,
+      );
+      const primary = failingProvider("openai", () => finalError);
+      const route = makeRoute(backupProvider().provider);
+      const wrapped = new RetryProvider(primary.provider, {
+        resolveFallbackRoute: route.resolveFallbackRoute,
+      });
+
+      const thrown = await captureError(
+        wrapped.sendMessage(MESSAGES, { config: { callSite: "mainAgent" } }),
+      );
+
+      expect(thrown).toBe(finalError);
+      expect(route.calls()).toBe(0);
+    },
+  );
 
   test("callback returns null (no fallbackProfile) → original error rethrown with retriesExhausted tagging", async () => {
     const finalError = new ProviderError("Service Unavailable", "openai", 503);
@@ -580,7 +618,7 @@ describe("RetryProvider fallback-route escalation", () => {
     expect(backup.calls()).toBe(0);
   });
 
-  test("backup also fails → fallback error rethrown with original as cause, no second fallback attempt", async () => {
+  test("backup also fails → original error is preserved, no second fallback attempt", async () => {
     const originalError = new ProviderError("model not found", "openai", 404);
     const primary = failingProvider("openai", () => originalError);
     const fallbackError = new ProviderError("backup down", "anthropic", 500);
@@ -594,8 +632,8 @@ describe("RetryProvider fallback-route escalation", () => {
       wrapped.sendMessage(MESSAGES, { config: { callSite: "mainAgent" } }),
     );
 
-    expect(thrown).toBe(fallbackError);
-    expect((thrown as Error).cause).toBe(originalError);
+    expect(thrown).toBe(originalError);
+    expect((thrown as Error).cause).toBeUndefined();
     expect(route.calls()).toBe(1);
     expect(backup.calls()).toBe(1);
   });

--- a/assistant/src/__tests__/retry-fallback-escalation.test.ts
+++ b/assistant/src/__tests__/retry-fallback-escalation.test.ts
@@ -9,7 +9,10 @@ mock.module("../util/retry.js", () => ({
   sleep: async () => {},
 }));
 
-import { resetFallbackBreaker } from "../providers/fallback-breaker.js";
+import {
+  recordFallbackServed,
+  resetFallbackBreaker,
+} from "../providers/fallback-breaker.js";
 import type {
   Message,
   Provider,
@@ -634,6 +637,31 @@ describe("RetryProvider fallback-route escalation", () => {
 
     expect(thrown).toBe(originalError);
     expect((thrown as Error).cause).toBeUndefined();
+    expect(route.calls()).toBe(1);
+    expect(backup.calls()).toBe(1);
+  });
+
+  test("failed recovery probe and backup surface the probe error without retrying the primary", async () => {
+    const originalError = new ProviderError(
+      "Service Unavailable",
+      "openai",
+      503,
+    );
+    const primary = failingProvider("openai", () => originalError);
+    const backupError = new ProviderError("invalid request", "anthropic", 400);
+    const backup = failingProvider("anthropic", () => backupError);
+    const route = makeRoute(backup.provider);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+    recordFallbackServed({ upstream: "openai" }, Date.now() - 11 * 60_000);
+
+    const thrown = await captureError(
+      wrapped.sendMessage(MESSAGES, { config: { callSite: "mainAgent" } }),
+    );
+
+    expect(thrown).toBe(originalError);
+    expect(primary.calls()).toBe(1);
     expect(route.calls()).toBe(1);
     expect(backup.calls()).toBe(1);
   });

--- a/assistant/src/__tests__/workspace-migration-147-rename-colliding-backup-profile-names.test.ts
+++ b/assistant/src/__tests__/workspace-migration-147-rename-colliding-backup-profile-names.test.ts
@@ -108,7 +108,7 @@ describe("147-rename-colliding-backup-profile-names migration", () => {
     );
   });
 
-  test("renames a colliding user profile and rewrites every reference", async () => {
+  test("renames a colliding user profile and rewrites supported references", async () => {
     writeConfig({
       llm: {
         defaultProvider: { provider: "vellum" },
@@ -150,7 +150,7 @@ describe("147-rename-colliding-backup-profile-names migration", () => {
     expect(llm.advisorProfile).toBe("balanced-backup-custom");
     expect(llm.callSites.recall.profile).toBe("balanced-backup-custom");
     expect(llm.callSites.recall.maxTokens).toBe(4096);
-    expect(llm.profiles.scratch.fallbackProfile).toBe("balanced-backup-custom");
+    expect(llm.profiles.scratch.fallbackProfile).toBeUndefined();
     expect(llm.profiles.blend.mix[0].profile).toBe("balanced-backup-custom");
     expect(llm.profiles.blend.mix[1].profile).toBe("armA");
     expect(llm.profileOrder).toEqual([

--- a/assistant/src/__tests__/workspace-migration-147-rename-colliding-backup-profile-names.test.ts
+++ b/assistant/src/__tests__/workspace-migration-147-rename-colliding-backup-profile-names.test.ts
@@ -16,6 +16,7 @@ import {
 } from "../config/default-profile-names.js";
 import { LLMSchema } from "../config/schemas/llm.js";
 import { renameCollidingBackupProfileNamesMigration } from "../workspace/migrations/147-rename-colliding-backup-profile-names.js";
+import { stripUnsupportedFallbackProfilesMigration } from "../workspace/migrations/148-strip-unsupported-fallback-profiles.js";
 import { WORKSPACE_MIGRATIONS } from "../workspace/migrations/registry.js";
 import {
   loadCheckpoints,
@@ -150,7 +151,7 @@ describe("147-rename-colliding-backup-profile-names migration", () => {
     expect(llm.advisorProfile).toBe("balanced-backup-custom");
     expect(llm.callSites.recall.profile).toBe("balanced-backup-custom");
     expect(llm.callSites.recall.maxTokens).toBe(4096);
-    expect(llm.profiles.scratch.fallbackProfile).toBeUndefined();
+    expect(llm.profiles.scratch.fallbackProfile).toBe("balanced-backup-custom");
     expect(llm.profiles.blend.mix[0].profile).toBe("balanced-backup-custom");
     expect(llm.profiles.blend.mix[1].profile).toBe("armA");
     expect(llm.profileOrder).toEqual([
@@ -192,7 +193,7 @@ describe("147-rename-colliding-backup-profile-names migration", () => {
     expect(parsed.success).toBe(true);
   });
 
-  test("the migrated config parses under LLMSchema", async () => {
+  test("the 147-to-148 migration sequence parses under LLMSchema", async () => {
     writeConfig({
       llm: {
         defaultProvider: { provider: "vellum" },
@@ -214,12 +215,15 @@ describe("147-rename-colliding-backup-profile-names migration", () => {
     });
 
     await renameCollidingBackupProfileNamesMigration.run(workspaceDir);
+    await stripUnsupportedFallbackProfilesMigration.run(workspaceDir);
 
-    const parsed = LLMSchema.safeParse(readConfig().llm);
+    const migrated = readConfig().llm;
+    const parsed = LLMSchema.safeParse(migrated);
     expect(parsed.success).toBe(true);
     if (parsed.success) {
       expect(parsed.data.activeProfile).toBe("cost-optimized-backup-custom");
     }
+    expect(migrated.profiles.scratch.fallbackProfile).toBeUndefined();
   });
 
   test("renames every colliding key and keeps suffixing past taken names", async () => {

--- a/assistant/src/__tests__/workspace-migration-148-strip-unsupported-fallback-profiles.test.ts
+++ b/assistant/src/__tests__/workspace-migration-148-strip-unsupported-fallback-profiles.test.ts
@@ -125,6 +125,33 @@ describe("148-strip-unsupported-fallback-profiles migration", () => {
     });
   });
 
+  test.each(["openai", "chatgpt"] as const)(
+    "strips managed pointers when backups do not resolve under %s",
+    (provider) => {
+      writeConfig({
+        llm: {
+          defaultProvider: { provider },
+          profiles: {
+            balanced: {
+              source: "managed",
+              fallbackProfile: "balanced-backup",
+            },
+            "quality-optimized": {
+              source: "managed",
+              fallbackProfile: "quality-optimized-backup",
+            },
+          },
+        },
+      });
+
+      stripUnsupportedFallbackProfilesMigration.run(workspaceDir);
+
+      const profiles = readConfig().llm.profiles;
+      expect(profiles.balanced.fallbackProfile).toBeUndefined();
+      expect(profiles["quality-optimized"].fallbackProfile).toBeUndefined();
+    },
+  );
+
   test("handles missing config, missing profiles, and invalid JSON", () => {
     stripUnsupportedFallbackProfilesMigration.run(workspaceDir);
 

--- a/assistant/src/__tests__/workspace-migration-148-strip-unsupported-fallback-profiles.test.ts
+++ b/assistant/src/__tests__/workspace-migration-148-strip-unsupported-fallback-profiles.test.ts
@@ -1,0 +1,140 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { renameCollidingBackupProfileNamesMigration } from "../workspace/migrations/147-rename-colliding-backup-profile-names.js";
+import { stripUnsupportedFallbackProfilesMigration } from "../workspace/migrations/148-strip-unsupported-fallback-profiles.js";
+import { WORKSPACE_MIGRATIONS } from "../workspace/migrations/registry.js";
+import { assertNotLiveDb } from "./assert-not-live-db.js";
+
+let workspaceDir: string;
+
+function writeConfig(data: Record<string, unknown>): void {
+  writeFileSync(
+    join(workspaceDir, "config.json"),
+    JSON.stringify(data, null, 2) + "\n",
+  );
+}
+
+function readConfig(): Record<string, any> {
+  return JSON.parse(readFileSync(join(workspaceDir, "config.json"), "utf-8"));
+}
+
+beforeEach(() => {
+  workspaceDir = join(
+    tmpdir(),
+    `vellum-migration-148-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(workspaceDir, { recursive: true });
+});
+
+afterEach(() => {
+  if (existsSync(workspaceDir)) {
+    assertNotLiveDb(workspaceDir);
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+describe("148-strip-unsupported-fallback-profiles migration", () => {
+  test("has the next migration id and is registered last", () => {
+    expect(stripUnsupportedFallbackProfilesMigration.id).toBe(
+      "148-strip-unsupported-fallback-profiles",
+    );
+    expect(WORKSPACE_MIGRATIONS.at(-1)?.id).toBe(
+      "148-strip-unsupported-fallback-profiles",
+    );
+  });
+
+  test("cleans a legacy pointer after migration 147 rewrites its target", async () => {
+    writeConfig({
+      llm: {
+        profiles: {
+          "balanced-backup": {
+            source: "user",
+            provider: "anthropic",
+            model: "legacy-model",
+          },
+          custom: {
+            source: "user",
+            fallbackProfile: "balanced-backup",
+          },
+        },
+      },
+    });
+
+    await renameCollidingBackupProfileNamesMigration.run(workspaceDir);
+    expect(readConfig().llm.profiles.custom.fallbackProfile).toBe(
+      "balanced-backup-custom",
+    );
+
+    stripUnsupportedFallbackProfilesMigration.run(workspaceDir);
+    expect(readConfig().llm.profiles.custom.fallbackProfile).toBeUndefined();
+
+    const once = readConfig();
+    stripUnsupportedFallbackProfilesMigration.run(workspaceDir);
+    expect(readConfig()).toEqual(once);
+  });
+
+  test("removes every custom pointer and preserves exact managed defaults", () => {
+    writeConfig({
+      llm: {
+        profiles: {
+          balanced: {
+            source: "managed",
+            fallbackProfile: "balanced-backup",
+          },
+          "quality-optimized": {
+            source: "managed",
+            fallbackProfile: "custom-backup",
+          },
+          custom: {
+            source: "user",
+            fallbackProfile: "other-custom",
+          },
+          "managed-custom": {
+            source: "managed",
+            fallbackProfile: "balanced-backup",
+          },
+          cleared: {
+            source: "user",
+            fallbackProfile: null,
+          },
+          untouched: { source: "user", model: "custom-model" },
+        },
+      },
+    });
+
+    stripUnsupportedFallbackProfilesMigration.run(workspaceDir);
+
+    const profiles = readConfig().llm.profiles;
+    expect(profiles.balanced.fallbackProfile).toBe("balanced-backup");
+    expect(profiles["quality-optimized"].fallbackProfile).toBeUndefined();
+    expect(profiles.custom.fallbackProfile).toBeUndefined();
+    expect(profiles["managed-custom"].fallbackProfile).toBeUndefined();
+    expect(profiles.cleared.fallbackProfile).toBeUndefined();
+    expect(profiles.untouched).toEqual({
+      source: "user",
+      model: "custom-model",
+    });
+  });
+
+  test("handles missing config, missing profiles, and invalid JSON", () => {
+    stripUnsupportedFallbackProfilesMigration.run(workspaceDir);
+
+    writeConfig({ theme: "dark" });
+    stripUnsupportedFallbackProfilesMigration.run(workspaceDir);
+    expect(readConfig()).toEqual({ theme: "dark" });
+
+    writeFileSync(join(workspaceDir, "config.json"), "{not json");
+    expect(() =>
+      stripUnsupportedFallbackProfilesMigration.run(workspaceDir),
+    ).not.toThrow();
+  });
+});

--- a/assistant/src/config/default-profile-catalog.ts
+++ b/assistant/src/config/default-profile-catalog.ts
@@ -17,6 +17,7 @@ import {
   type DefaultProfileProvider,
   FALLBACK_PROFILE_BY_KEY,
   isBackupProfileKey,
+  isDefaultProfileKey,
   isDefaultProfileProvider,
   OS_BETA_PROFILE_KEY,
 } from "./default-profile-names.js";
@@ -811,9 +812,7 @@ export function resolveDefaultProfileForProvider(
   );
 }
 
-export function isDefaultProfileKey(name: string): name is DefaultProfileKey {
-  return (DEFAULT_PROFILE_KEYS as readonly string[]).includes(name);
-}
+export { isDefaultProfileKey } from "./default-profile-names.js";
 
 /**
  * The implementation of default profile `key` on `provider`: the named matrix

--- a/assistant/src/config/default-profile-names.ts
+++ b/assistant/src/config/default-profile-names.ts
@@ -59,6 +59,10 @@ export const FALLBACK_PROFILE_BY_KEY: Record<
   "latency-optimized": "latency-optimized-backup",
 };
 
+export function isDefaultProfileKey(value: string): value is DefaultProfileKey {
+  return (DEFAULT_PROFILE_KEYS as readonly string[]).includes(value);
+}
+
 export function isBackupProfileKey(value: string): value is BackupProfileKey {
   return (BACKUP_PROFILE_KEYS as readonly string[]).includes(value);
 }

--- a/assistant/src/config/schemas/llm.ts
+++ b/assistant/src/config/schemas/llm.ts
@@ -14,7 +14,9 @@ import {
   BACKUP_PROFILE_KEYS,
   DEFAULT_PROFILE_KEYS,
   DEFAULT_PROFILE_PROVIDERS,
+  FALLBACK_PROFILE_BY_KEY,
   isBackupProfileKey,
+  isDefaultProfileKey,
 } from "../default-profile-names.js";
 
 /**
@@ -625,14 +627,12 @@ export const ProfileEntry = LLMConfigFragment.extend({
    */
   mix: MixSchema.optional(),
   /**
-   * Name of another profile to fall back to when this profile's model
-   * fails with an outage-type error (retries exhausted, invalid managed
-   * credential, unknown model). Single hop: the referenced profile must
-   * not declare its own fallbackProfile. Managed (`vellum`) profiles
-   * only, since BYOK installs may hold no credential for the backup
-   * provider.
+   * Code-owned backup profile for a Vellum-managed default profile. This is
+   * read-only metadata from the default-profile catalog. Config write paths
+   * reject user-authored values because custom and BYOK fallback routes are
+   * not supported.
    */
-  fallbackProfile: z.string().min(1).optional(),
+  fallbackProfile: z.string().min(1).optional().meta({ readOnly: true }),
 });
 export type ProfileEntry = z.infer<typeof ProfileEntry>;
 
@@ -769,13 +769,10 @@ function referenceableProfileKeys(
 // ---------------------------------------------------------------------------
 
 /**
- * Cross-profile integrity checks for `fallbackProfile` pointers: (a) the
- * referenced profile exists, (b) a profile does not fall back to itself,
- * (c) the referenced profile is not a mix (a fallback must be a directly
- * dispatchable route), (d) the referenced profile does not itself set
- * `fallbackProfile` (fallback is a single hop in v1, never a chain), and
- * (e) a mix profile carries no `fallbackProfile` of its own (a mix has no
- * route of its own to fall back from).
+ * Cross-profile integrity checks for `fallbackProfile` metadata. Only the
+ * exact code-owned mapping on managed default profiles is accepted. The
+ * referenced profile must exist, must not be a mix, and must not declare a
+ * fallback of its own.
  *
  * Shared by `LLMSchema.superRefine` (full-config load) and the config write
  * paths (`commitConfigWrite`), which persist raw config without a
@@ -829,6 +826,16 @@ export function collectFallbackProfileIssues(
       issues.push({
         profileName: name,
         message: `Profile "${name}" declares a fallbackProfile that must be a non-empty string naming another profile.`,
+      });
+      continue;
+    }
+    const expectedFallback = isDefaultProfileKey(name)
+      ? FALLBACK_PROFILE_BY_KEY[name]
+      : undefined;
+    if (entry?.source !== "managed" || fallback !== expectedFallback) {
+      issues.push({
+        profileName: name,
+        message: `Profile "${name}" cannot configure fallbackProfile. Automatic fallbacks are code-owned for Vellum-managed default profiles.`,
       });
       continue;
     }

--- a/assistant/src/providers/connection-resolution.ts
+++ b/assistant/src/providers/connection-resolution.ts
@@ -52,6 +52,7 @@ import {
 } from "./inference/connections.js";
 import { resolveManagedProxyContext } from "./platform-proxy/context.js";
 import { checkCredentialPresence } from "./provider-availability.js";
+import { dispatchProviderResolvable } from "./provider-resolvability.js";
 import type { ProvidersConfig } from "./registry.js";
 import { resolveProviderFromConnection } from "./registry.js";
 import {
@@ -67,6 +68,7 @@ import {
 } from "./vellum-model-routing.js";
 
 export { ConnectionResolutionError, resolveRoutingIdentity };
+export { dispatchProviderResolvable } from "./provider-resolvability.js";
 
 const log = getLogger("providers/connection-resolution");
 
@@ -116,23 +118,6 @@ export function writableProfileProviderIssue(provider: string): string | null {
     // Unverifiable: fall through to the rejection.
   }
   return `Invalid provider "${provider}". Use a known provider or the name of an existing connection.`;
-}
-
-/**
- * Selection-time predicate for `ResolveCallSiteOpts.isResolvableProvider`:
- * a provider value dispatches when it is a known vendor/identity or names a
- * connection entry row. Permissive on DB unavailability so a transient blip
- * never heals away a valid entry profile; dispatch soft-fails on its own.
- */
-export function dispatchProviderResolvable(provider: string): boolean {
-  if (VALID_CONNECTION_PROVIDERS.includes(provider)) {
-    return true;
-  }
-  try {
-    return getConnection(getDb(), provider) != null;
-  } catch {
-    return true;
-  }
 }
 
 /**

--- a/assistant/src/providers/inference/adapter-factory.ts
+++ b/assistant/src/providers/inference/adapter-factory.ts
@@ -20,7 +20,11 @@
 
 import { resolveDefaultProfileForProvider } from "../../config/default-profile-catalog.js";
 import {
-  resolveCallSiteConfig,
+  FALLBACK_PROFILE_BY_KEY,
+  isDefaultProfileKey,
+} from "../../config/default-profile-names.js";
+import {
+  resolveCallSiteConfigWithProfile,
   selectWinningProfile,
 } from "../../config/llm-resolver.js";
 import { getConfig } from "../../config/loader.js";
@@ -38,6 +42,7 @@ import { OpenAIChatCompletionsProvider } from "../openai/chat-completions-provid
 import { OpenAIResponsesProvider } from "../openai/responses-provider.js";
 import { OpenRouterProvider } from "../openrouter/client.js";
 import { PoolsideProvider } from "../poolside/client.js";
+import { dispatchProviderResolvable } from "../provider-resolvability.js";
 import { RetryProvider } from "../retry.js";
 import { TogetherProvider } from "../together/client.js";
 import type { Provider, SendMessageOptions } from "../types.js";
@@ -342,11 +347,25 @@ export function createAdapterFromConnection(
           overrideProfile: failedConfig?.overrideProfile,
           forceOverrideProfile: failedConfig?.forceOverrideProfile,
           selectionSeed: failedConfig?.selectionSeed,
+          isResolvableProvider: dispatchProviderResolvable,
         });
-        const overrideProfile = winner.entry?.fallbackProfile;
-        if (overrideProfile === undefined) {
+        const primaryProfile =
+          winner.profileName ??
+          (winner.source === "default" ? "balanced" : undefined);
+        if (
+          primaryProfile === undefined ||
+          !isDefaultProfileKey(primaryProfile)
+        ) {
           return null;
         }
+        const expectedFallback = FALLBACK_PROFILE_BY_KEY[primaryProfile];
+        if (
+          winner.entry?.source !== "managed" ||
+          winner.entry.fallbackProfile !== expectedFallback
+        ) {
+          return null;
+        }
+        const overrideProfile = expectedFallback;
         // Resolved the provider-aware way the runtime resolver resolves every
         // profile name: the backups are companions of the managed column and
         // must not materialize under a BYOK or ChatGPT default provider.
@@ -362,25 +381,30 @@ export function createAdapterFromConnection(
           );
           return null;
         }
-        // The model the adapter serves must be the model the request will
-        // actually carry, so it comes from the same resolution the fallback
-        // send runs (`sendOnFallbackRoute` forces this profile through
-        // `normalizeSendMessageOptions`). Building from `backup.model` alone
-        // would ignore a call-site fragment that pins a model, and a pinned
-        // Gemini model on an Anthropic backup would send Gemini wire params to
-        // an Anthropic adapter.
-        const resolvedBackup = resolveCallSiteConfig(callSite, llm, {
-          overrideProfile,
-          forceOverrideProfile: true,
-          selectionSeed: failedConfig?.selectionSeed,
-        });
+        const { config: resolvedBackup, profileName: resolvedBackupProfile } =
+          resolveCallSiteConfigWithProfile(callSite, llm, {
+            overrideProfile,
+            forceOverrideProfile: true,
+            selectionSeed: failedConfig?.selectionSeed,
+            isResolvableProvider: dispatchProviderResolvable,
+          });
+        if (resolvedBackupProfile !== overrideProfile) {
+          log.warn(
+            {
+              connectionName: connection.name,
+              overrideProfile,
+              selectedProfile: resolvedBackupProfile,
+            },
+            "Backup profile is not dispatch-resolvable; keeping the original error",
+          );
+          return null;
+        }
+        // The model the adapter serves must be the model the fallback send
+        // carries, so it comes from the same forced-profile resolution.
         // This callback authenticates the backup with the managed connection
         // it was built for, so it can only serve a backup that routes through
-        // the managed column. The schema permits a pointer at a user-defined
-        // profile carrying its own `provider_connection` or a BYOK `provider`;
-        // serving one here would bill it as managed traffic and authenticate
-        // it with a credential its author never chose, so it is refused and
-        // the original error stands.
+        // the managed column. Refusing any other route keeps managed billing
+        // and credentials from being applied to user-owned traffic.
         // Keyed on the connection, not the provider: a call-site fragment that
         // pins a concrete upstream over a managed winner keeps the managed
         // routing and is stamped with this connection's name by the resolver

--- a/assistant/src/providers/provider-resolvability.ts
+++ b/assistant/src/providers/provider-resolvability.ts
@@ -1,0 +1,20 @@
+import { getDb } from "../persistence/db-connection.js";
+import { VALID_CONNECTION_PROVIDERS } from "./inference/auth.js";
+import { getConnection } from "./inference/connections.js";
+
+/**
+ * Selection-time predicate for `ResolveCallSiteOpts.isResolvableProvider`:
+ * a provider value dispatches when it is a known vendor/identity or names a
+ * connection entry row. Permissive on DB unavailability so a transient blip
+ * never heals away a valid entry profile; dispatch soft-fails on its own.
+ */
+export function dispatchProviderResolvable(provider: string): boolean {
+  if (VALID_CONNECTION_PROVIDERS.includes(provider)) {
+    return true;
+  }
+  try {
+    return getConnection(getDb(), provider) != null;
+  } catch {
+    return true;
+  }
+}

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -39,6 +39,7 @@ import {
   isAdaptiveThinkingOnlyModel,
   isAdaptiveThinkingUnsupportedModel,
 } from "./model-catalog.js";
+import { dispatchProviderResolvable } from "./provider-resolvability.js";
 import {
   isThinkingConfigAdaptive,
   isThinkingConfigDisabled,
@@ -510,19 +511,39 @@ function fallbackErrorType(error: unknown, retriesExhausted: boolean): string {
  * Whether a failed request can be re-routed to a backup profile. Fallback
  * re-resolves the ORIGINAL caller options with the backup profile forced,
  * which requires a `callSite`-bearing config. An explicit per-call
- * `config.model` pin (the live per-conversation `modelOverride` feature)
- * disqualifies the request: the pin wins over any resolved profile model in
- * `normalizeSendMessageOptions`, and silently serving a different model
- * against an explicit pin would violate user intent: a profile user asked
- * for a tier, a pinning user asked for that exact model. Pinned conversations
- * keep today's retry-then-error behavior.
+ * route pin (`model`, `provider`, or `provider_connection`) disqualifies the
+ * request, whether it came from this call or the persisted call-site config.
+ * Silently serving a different route would violate user intent: a profile
+ * user asked for a tier, while a pinning user asked for an exact route. Pinned
+ * calls keep retry-then-error behavior.
  */
+const EXACT_ROUTE_PIN_KEYS = [
+  "model",
+  "provider",
+  "provider_connection",
+] as const;
+
+function hasExactRoutePin(
+  config: Record<string, unknown> | undefined,
+): boolean {
+  return EXACT_ROUTE_PIN_KEYS.some((key) => {
+    const value = config?.[key];
+    return typeof value === "string" && value.trim().length > 0;
+  });
+}
+
 function canReRouteToFallbackProfile(options?: SendMessageOptions): boolean {
   const config = options?.config;
   if (config?.callSite === undefined) {
     return false;
   }
-  return !(typeof config.model === "string" && config.model.trim().length > 0);
+  if (hasExactRoutePin(config)) {
+    return false;
+  }
+  const callSiteConfig = getConfig().llm.callSites?.[config.callSite] as
+    | Record<string, unknown>
+    | undefined;
+  return !hasExactRoutePin(callSiteConfig);
 }
 
 /**
@@ -1766,6 +1787,7 @@ export class RetryProvider implements Provider {
         : selectWinningProfile(callSite, getConfig().llm, {
             overrideProfile: route.overrideProfile,
             ...(selectionSeed !== undefined ? { selectionSeed } : {}),
+            isResolvableProvider: dispatchProviderResolvable,
           });
     if (
       selection === null ||
@@ -1873,14 +1895,20 @@ export class RetryProvider implements Provider {
       }
       return response;
     } catch (fallbackError) {
-      if (
-        originalError !== undefined &&
-        fallbackError instanceof Error &&
-        fallbackError.cause === undefined
-      ) {
-        fallbackError.cause = originalError;
+      if (originalError === undefined) {
+        throw fallbackError;
       }
-      throw fallbackError;
+      log.warn(
+        {
+          provider: this.name,
+          connectionName: this.options.connectionName,
+          fallbackProvider: route.provider.name,
+          overrideProfile: route.overrideProfile,
+          fallbackError,
+        },
+        "Backup profile failed; rethrowing the original provider error",
+      );
+      return null;
     }
   }
 }

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -1449,7 +1449,11 @@ export class RetryProvider implements Provider {
               // with the longer cooldown a repeat outage earns.
               return served;
             }
-            break;
+            // The probe confirmed this route is still down. If the backup
+            // cannot serve, surface that primary failure directly instead of
+            // spending a fresh retry budget on the route the probe just
+            // re-tripped.
+            throw error;
           }
         }
       }

--- a/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
@@ -51,7 +51,7 @@ mock.module("../../../persistence/embeddings/embedding-backend.js", () => ({
 }));
 
 import { getConfig, loadRawConfig } from "../../../config/loader.js";
-import { LLMConfigBase, LLMSchema } from "../../../config/schemas/llm.js";
+import { LLMConfigBase } from "../../../config/schemas/llm.js";
 import type { ConversationCreateType } from "../../../persistence/conversation-types.js";
 import {
   getDb,
@@ -836,7 +836,7 @@ describe("PUT /v1/config/llm/profiles/:name", () => {
     seedRawConfig();
   });
 
-  describe("fallbackProfile cross-profile validation", () => {
+  describe("fallbackProfile write protection", () => {
     beforeEach(() => {
       const llm = rawConfigFixture.llm as {
         profiles: Record<string, Record<string, unknown>>;
@@ -845,141 +845,37 @@ describe("PUT /v1/config/llm/profiles/:name", () => {
         provider: "anthropic",
         model: "claude-sonnet-4-6",
       };
-      llm.profiles.chained = {
-        provider: "anthropic",
-        model: "claude-sonnet-4-6",
-        fallbackProfile: "backup",
-      };
-      llm.profiles.blend = {
-        mix: [
-          { profile: "custom", weight: 1 },
-          { profile: "backup", weight: 1 },
-        ],
-      };
       seedRawConfig();
     });
 
-    test("persists a valid fallbackProfile pointer", async () => {
-      const result = await replaceProfileRoute.handler({
-        pathParams: { name: "custom" },
-        body: {
-          provider: "anthropic",
-          model: "claude-sonnet-4-6",
-          fallbackProfile: "backup",
-        },
-      });
-      expect(result).toEqual({ ok: true });
-      expect(persistedProfile("custom").fallbackProfile).toBe("backup");
-    });
-
-    test("rejects a dangling fallbackProfile pointer without writing", async () => {
+    test("rejects a custom fallbackProfile without writing", async () => {
       await expect(
         replaceProfileRoute.handler({
           pathParams: { name: "custom" },
           body: {
             provider: "anthropic",
             model: "claude-sonnet-4-6",
-            fallbackProfile: "ghost",
+            fallbackProfile: "backup",
           },
         }),
-      ).rejects.toThrow(/fallbackProfile "ghost" which is not defined/);
+      ).rejects.toThrow(/Automatic fallbacks are code-owned/);
       expect(persistedProfile("custom").fallbackProfile).toBeUndefined();
-      // Guard rejects before commitConfigWrite fires any side effects.
       expect(initializeProvidersCalls).toBe(0);
     });
 
-    test("rejects a self-referential fallbackProfile", async () => {
+    test("rejects a custom pointer at a managed backup name", async () => {
       await expect(
         replaceProfileRoute.handler({
           pathParams: { name: "custom" },
           body: {
             provider: "anthropic",
             model: "claude-sonnet-4-6",
-            fallbackProfile: "custom",
+            fallbackProfile: "balanced-backup",
           },
         }),
-      ).rejects.toThrow(/cannot declare itself as its fallbackProfile/);
-    });
-
-    test("rejects a fallbackProfile pointing at a mix profile", async () => {
-      await expect(
-        replaceProfileRoute.handler({
-          pathParams: { name: "custom" },
-          body: {
-            provider: "anthropic",
-            model: "claude-sonnet-4-6",
-            fallbackProfile: "blend",
-          },
-        }),
-      ).rejects.toThrow(/which is a mix profile/);
-    });
-
-    test("rejects a fallbackProfile whose target declares its own fallback (chain)", async () => {
-      await expect(
-        replaceProfileRoute.handler({
-          pathParams: { name: "custom" },
-          body: {
-            provider: "anthropic",
-            model: "claude-sonnet-4-6",
-            fallbackProfile: "chained",
-          },
-        }),
-      ).rejects.toThrow(/chains are not allowed/);
-    });
-
-    test("rejects adding a fallbackProfile to a profile that is itself a fallback target (chain)", async () => {
-      await expect(
-        replaceProfileRoute.handler({
-          pathParams: { name: "backup" },
-          body: {
-            provider: "anthropic",
-            model: "claude-sonnet-4-6",
-            fallbackProfile: "custom",
-          },
-        }),
-      ).rejects.toThrow(
-        /"chained" already declares profile "backup" as its fallbackProfile/,
-      );
-    });
-
-    test("rejects converting a fallback target into a mix profile", async () => {
-      await expect(
-        replaceProfileRoute.handler({
-          pathParams: { name: "backup" },
-          body: {
-            mix: [
-              { profile: "custom", weight: 1 },
-              { profile: "chained", weight: 1 },
-            ],
-          },
-        }),
-      ).rejects.toThrow(/cannot become a mix/);
-    });
-
-    test("clears the profile's own fallbackProfile when converting it to a mix", async () => {
-      // "chained" declares fallbackProfile "backup". Replacing it with a mix
-      // body is an explicit replacement, so the pointer must be dropped: a
-      // persisted entry carrying both `mix` and `fallbackProfile` would be
-      // rejected and stripped on the next full config reload.
-      const result = await replaceProfileRoute.handler({
-        pathParams: { name: "chained" },
-        body: {
-          mix: [
-            { profile: "custom", weight: 1 },
-            { profile: "backup", weight: 1 },
-          ],
-        },
-      });
-      expect(result).toEqual({ ok: true });
-      const saved = persistedProfile("chained");
-      expect(saved.mix).toEqual([
-        { profile: "custom", weight: 1 },
-        { profile: "backup", weight: 1 },
-      ]);
-      expect("fallbackProfile" in saved).toBe(false);
-      // The persisted llm subtree reloads cleanly under the full schema
-      // parse, so the loader will not strip or salvage anything.
-      expect(LLMSchema.safeParse(loadRawConfig().llm).success).toBe(true);
+      ).rejects.toThrow(/Automatic fallbacks are code-owned/);
+      expect(persistedProfile("custom").fallbackProfile).toBeUndefined();
+      expect(initializeProvidersCalls).toBe(0);
     });
   });
 
@@ -1389,7 +1285,7 @@ describe("PUT /v1/config/llm/profiles/:name", () => {
   });
 });
 
-describe("PATCH /v1/config fallbackProfile cross-profile validation", () => {
+describe("PATCH /v1/config fallbackProfile write protection", () => {
   const patchRoute = ROUTES.find((r) => r.operationId === "config_patch")!;
 
   beforeEach(() => {
@@ -1400,81 +1296,33 @@ describe("PATCH /v1/config fallbackProfile cross-profile validation", () => {
         profiles: {
           custom: { provider: "anthropic", model: "claude-sonnet-4-6" },
           backup: { provider: "anthropic", model: "claude-sonnet-4-6" },
-          chained: {
-            provider: "anthropic",
-            model: "claude-sonnet-4-6",
-            fallbackProfile: "backup",
-          },
-          blend: {
-            mix: [
-              { profile: "custom", weight: 1 },
-              { profile: "backup", weight: 1 },
-            ],
-          },
         },
       },
     };
     seedRawConfig();
   });
 
-  test("persists a valid fallbackProfile through the generic patch route", async () => {
-    await patchRoute.handler({
-      body: { llm: { profiles: { custom: { fallbackProfile: "backup" } } } },
-    });
-    expect(persistedProfile("custom").fallbackProfile).toBe("backup");
-  });
-
-  test("rejects a self-referential fallbackProfile without writing", async () => {
+  test("rejects a custom fallbackProfile without writing", async () => {
     await expect(
       patchRoute.handler({
-        body: { llm: { profiles: { custom: { fallbackProfile: "custom" } } } },
+        body: { llm: { profiles: { custom: { fallbackProfile: "backup" } } } },
       }),
-    ).rejects.toThrow(/cannot declare itself as its fallbackProfile/);
-    expect(persistedProfile("custom").fallbackProfile).toBeUndefined();
-    // Rejection fires before commitConfigWrite runs any post-write side
-    // effects.
-    expect(initializeProvidersCalls).toBe(0);
-  });
-
-  test("rejects a dangling fallbackProfile without writing", async () => {
-    await expect(
-      patchRoute.handler({
-        body: { llm: { profiles: { custom: { fallbackProfile: "ghost" } } } },
-      }),
-    ).rejects.toThrow(/fallbackProfile "ghost" which is not defined/);
+    ).rejects.toThrow(/Automatic fallbacks are code-owned/);
     expect(persistedProfile("custom").fallbackProfile).toBeUndefined();
     expect(initializeProvidersCalls).toBe(0);
   });
 
-  test("rejects a fallbackProfile pointing at a mix profile without writing", async () => {
-    await expect(
-      patchRoute.handler({
-        body: { llm: { profiles: { custom: { fallbackProfile: "blend" } } } },
-      }),
-    ).rejects.toThrow(/which is a mix profile/);
-    expect(persistedProfile("custom").fallbackProfile).toBeUndefined();
-    expect(initializeProvidersCalls).toBe(0);
-  });
-
-  test("rejects a fallbackProfile chain without writing", async () => {
+  test("rejects a custom pointer at a managed backup name", async () => {
     await expect(
       patchRoute.handler({
         body: {
-          llm: { profiles: { custom: { fallbackProfile: "chained" } } },
+          llm: {
+            profiles: { custom: { fallbackProfile: "balanced-backup" } },
+          },
         },
       }),
-    ).rejects.toThrow(/chains are not allowed/);
+    ).rejects.toThrow(/Automatic fallbacks are code-owned/);
     expect(persistedProfile("custom").fallbackProfile).toBeUndefined();
-    expect(initializeProvidersCalls).toBe(0);
-  });
-
-  test("rejects adding a fallbackProfile to a mix profile without writing", async () => {
-    await expect(
-      patchRoute.handler({
-        body: { llm: { profiles: { blend: { fallbackProfile: "backup" } } } },
-      }),
-    ).rejects.toThrow(/Mix profile "blend" cannot also set "fallbackProfile"/);
-    expect(persistedProfile("blend").fallbackProfile).toBeUndefined();
     expect(initializeProvidersCalls).toBe(0);
   });
 });

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -1408,18 +1408,14 @@ function assertRoutableIdentityEntries(
 }
 
 /**
- * Reject writes that would persist an invalid `fallbackProfile` graph.
- * `LLMSchema.superRefine` enforces the cross-profile fallback rules only on
- * a full-config parse; the write paths (PATCH deep-merge, SET, the profile
- * routes) save raw config without one, so a self-reference, dangling
- * target, mix target, or chain would reach disk and be stripped on the next
- * reload, silently disabling the configured fallback. Checked
- * unconditionally rather than scoped to pointers this write changes:
- * removing a target profile invalidates a pointer the write never touched,
- * and clearing the pointer (write `null`) through these same routes remains
- * the repair path for a hand-edited config.
+ * Reject writes that would persist unsupported `fallbackProfile` metadata.
+ * Automatic fallbacks are code-owned for managed default profiles. The write
+ * paths save raw config without a full-schema parse, so this check keeps a
+ * custom pointer from reaching disk. It runs unconditionally so an existing
+ * hand-edited pointer blocks unrelated rewrites until the user clears it with
+ * `null`.
  */
-function assertValidFallbackProfileGraph(raw: Record<string, unknown>): void {
+function assertCodeOwnedFallbackProfiles(raw: Record<string, unknown>): void {
   const llm = readPlainObject(raw.llm);
   const profiles = readPlainObject(llm?.profiles);
   // The sibling `llm.defaultProvider` decides whether the managed backups are
@@ -1445,7 +1441,7 @@ export async function commitConfigWrite(
   completeChangedCustomProfiles(preWrite, raw);
   assertInvariantProfilesPreserved(preWrite, raw);
   assertRoutableIdentityEntries(preWrite, raw);
-  assertValidFallbackProfileGraph(raw);
+  assertCodeOwnedFallbackProfiles(raw);
 
   // Suppress the file-watcher callback for the duration of the debounce
   // window. Without this, the ConfigWatcher detects the config.json write

--- a/assistant/src/workspace/migrations/147-rename-colliding-backup-profile-names.ts
+++ b/assistant/src/workspace/migrations/147-rename-colliding-backup-profile-names.ts
@@ -8,22 +8,24 @@
  * matter what `llm.profiles` holds, so a user-created profile that happens
  * to carry one of those names is silently replaced in the effective catalog:
  * the user's own model, provider, and tuning stop being what their
- * `activeProfile`, call-site pin, mix arm, or `fallbackProfile` reference
- * routes through.
+ * `activeProfile`, call-site pin, or mix arm routes through.
  *
  * This migration runs before the reservation can take effect (workspace
  * migrations run ahead of the first config load and the profile seeder) and
- * gives any such profile a fresh key, rewriting every reference to it so the
- * user keeps both the profile and its wiring:
+ * gives any such profile a fresh key, rewriting supported references to it so
+ * the user keeps both the profile and its wiring:
  *
  *   - `llm.profiles` key (insertion order preserved)
  *   - `llm.activeProfile`, `llm.advisorProfile`
  *   - `llm.profileOrder` entries
  *   - `llm.callSites.<site>.profile` pins
  *   - `llm.profiles.<key>.mix[].profile` arms
- *   - `llm.profiles.<key>.fallbackProfile` targets
  *   - `conversations.inference_profile` and `cron_jobs.inference_profile`
  *     rows (see below)
+ *
+ * A user-authored `fallbackProfile` targeting the colliding name is removed.
+ * Automatic fallbacks are code-owned metadata for managed defaults, so a
+ * custom pointer cannot be preserved as executable configuration.
  *
  * The new key is `<name>-custom`, suffixed `-custom-2`, `-custom-3`, ... when
  * that is taken. Candidates are checked against every existing profile key
@@ -260,7 +262,7 @@ function rewriteConfigReferences(
       typeof entry.fallbackProfile === "string" &&
       renames.has(entry.fallbackProfile)
     ) {
-      entry.fallbackProfile = renames.get(entry.fallbackProfile);
+      delete entry.fallbackProfile;
     }
     if (!Array.isArray(entry.mix)) {
       continue;

--- a/assistant/src/workspace/migrations/147-rename-colliding-backup-profile-names.ts
+++ b/assistant/src/workspace/migrations/147-rename-colliding-backup-profile-names.ts
@@ -8,24 +8,22 @@
  * matter what `llm.profiles` holds, so a user-created profile that happens
  * to carry one of those names is silently replaced in the effective catalog:
  * the user's own model, provider, and tuning stop being what their
- * `activeProfile`, call-site pin, or mix arm routes through.
+ * `activeProfile`, call-site pin, mix arm, or `fallbackProfile` reference
+ * routes through.
  *
  * This migration runs before the reservation can take effect (workspace
  * migrations run ahead of the first config load and the profile seeder) and
- * gives any such profile a fresh key, rewriting supported references to it so
- * the user keeps both the profile and its wiring:
+ * gives any such profile a fresh key, rewriting every reference to it so the
+ * user keeps both the profile and its wiring:
  *
  *   - `llm.profiles` key (insertion order preserved)
  *   - `llm.activeProfile`, `llm.advisorProfile`
  *   - `llm.profileOrder` entries
  *   - `llm.callSites.<site>.profile` pins
  *   - `llm.profiles.<key>.mix[].profile` arms
+ *   - `llm.profiles.<key>.fallbackProfile` targets
  *   - `conversations.inference_profile` and `cron_jobs.inference_profile`
  *     rows (see below)
- *
- * A user-authored `fallbackProfile` targeting the colliding name is removed.
- * Automatic fallbacks are code-owned metadata for managed defaults, so a
- * custom pointer cannot be preserved as executable configuration.
  *
  * The new key is `<name>-custom`, suffixed `-custom-2`, `-custom-3`, ... when
  * that is taken. Candidates are checked against every existing profile key
@@ -262,7 +260,7 @@ function rewriteConfigReferences(
       typeof entry.fallbackProfile === "string" &&
       renames.has(entry.fallbackProfile)
     ) {
-      delete entry.fallbackProfile;
+      entry.fallbackProfile = renames.get(entry.fallbackProfile);
     }
     if (!Array.isArray(entry.mix)) {
       continue;

--- a/assistant/src/workspace/migrations/148-strip-unsupported-fallback-profiles.ts
+++ b/assistant/src/workspace/migrations/148-strip-unsupported-fallback-profiles.ts
@@ -8,12 +8,13 @@
  * and would make later config writes fail validation.
  *
  * This migration removes every persisted pointer except the exact managed
- * default mapping. It runs before config parsing, so legacy values are cleaned
- * up without depending on schema salvage. The operation is idempotent: a
- * second run finds no unsupported fields and writes nothing.
+ * default mapping while managed backups resolve under the selected provider.
+ * It runs before config parsing, so legacy values are cleaned up without
+ * depending on schema salvage. The operation is idempotent: a second run
+ * finds no unsupported fields and writes nothing.
  */
 
-import { readFileSync, writeFileSync } from "node:fs";
+import { readFileSync, renameSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 import { getLogger } from "../../util/logger.js";
@@ -54,9 +55,12 @@ export const stripUnsupportedFallbackProfilesMigration: WorkspaceMigration = {
 
     const llm = asObject(config.llm);
     const profiles = llm === null ? null : asObject(llm.profiles);
-    if (profiles === null) {
+    if (llm === null || profiles === null) {
       return;
     }
+    const backupsResolve = backupProfilesResolveUnderDefaultProvider(
+      llm.defaultProvider,
+    );
 
     const strippedProfiles: string[] = [];
     for (const [name, value] of Object.entries(profiles)) {
@@ -68,6 +72,7 @@ export const stripUnsupportedFallbackProfilesMigration: WorkspaceMigration = {
         continue;
       }
       const isCodeOwnedMapping =
+        backupsResolve &&
         entry.source === "managed" &&
         entry.fallbackProfile === CODE_OWNED_FALLBACKS[name];
       if (isCodeOwnedMapping) {
@@ -80,7 +85,9 @@ export const stripUnsupportedFallbackProfilesMigration: WorkspaceMigration = {
     if (strippedProfiles.length === 0) {
       return;
     }
-    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+    const tempPath = `${configPath}.tmp`;
+    writeFileSync(tempPath, JSON.stringify(config, null, 2) + "\n", "utf-8");
+    renameSync(tempPath, configPath);
     log.info(
       { profiles: strippedProfiles },
       "Removed unsupported custom fallback profile pointers",
@@ -98,4 +105,13 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 
 function asObject(value: unknown): Record<string, unknown> | null {
   return isPlainObject(value) ? value : null;
+}
+
+function backupProfilesResolveUnderDefaultProvider(
+  defaultProvider: unknown,
+): boolean {
+  const provider = isPlainObject(defaultProvider)
+    ? defaultProvider.provider
+    : undefined;
+  return typeof provider !== "string" || provider === "vellum";
 }

--- a/assistant/src/workspace/migrations/148-strip-unsupported-fallback-profiles.ts
+++ b/assistant/src/workspace/migrations/148-strip-unsupported-fallback-profiles.ts
@@ -35,6 +35,9 @@ export const stripUnsupportedFallbackProfilesMigration: WorkspaceMigration = {
   id: "148-strip-unsupported-fallback-profiles",
   description:
     "Remove custom fallback profile pointers outside the managed default contract",
+  // A transient config write failure must not leave an unsupported pointer
+  // behind permanently; the next boot can safely repeat this idempotent pass.
+  retryFailedCheckpoint: true,
 
   run(workspaceDir: string): void {
     const configPath = join(workspaceDir, "config.json");

--- a/assistant/src/workspace/migrations/148-strip-unsupported-fallback-profiles.ts
+++ b/assistant/src/workspace/migrations/148-strip-unsupported-fallback-profiles.ts
@@ -1,0 +1,98 @@
+/**
+ * Workspace migration `148-strip-unsupported-fallback-profiles`.
+ *
+ * Automatic model fallbacks are code-owned metadata on the four managed
+ * default profiles. Earlier builds accepted custom `fallbackProfile` values
+ * in raw workspace config, including pointers rewritten by migration 147.
+ * Those values cannot be executed under the managed-only fallback contract
+ * and would make later config writes fail validation.
+ *
+ * This migration removes every persisted pointer except the exact managed
+ * default mapping. It runs before config parsing, so legacy values are cleaned
+ * up without depending on schema salvage. The operation is idempotent: a
+ * second run finds no unsupported fields and writes nothing.
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { getLogger } from "../../util/logger.js";
+import type { WorkspaceMigration } from "./types.js";
+
+const log = getLogger(
+  "workspace-migration-148-strip-unsupported-fallback-profiles",
+);
+
+/** Frozen snapshot of the code-owned fallback mapping as of 2026-08-24. */
+const CODE_OWNED_FALLBACKS: Record<string, string> = {
+  balanced: "balanced-backup",
+  "quality-optimized": "quality-optimized-backup",
+  "cost-optimized": "cost-optimized-backup",
+  "latency-optimized": "latency-optimized-backup",
+};
+
+export const stripUnsupportedFallbackProfilesMigration: WorkspaceMigration = {
+  id: "148-strip-unsupported-fallback-profiles",
+  description:
+    "Remove custom fallback profile pointers outside the managed default contract",
+
+  run(workspaceDir: string): void {
+    const configPath = join(workspaceDir, "config.json");
+    let config: Record<string, unknown>;
+    try {
+      const parsed = JSON.parse(readFileSync(configPath, "utf-8"));
+      if (!isPlainObject(parsed)) {
+        return;
+      }
+      config = parsed;
+    } catch {
+      return;
+    }
+
+    const llm = asObject(config.llm);
+    const profiles = llm === null ? null : asObject(llm.profiles);
+    if (profiles === null) {
+      return;
+    }
+
+    const strippedProfiles: string[] = [];
+    for (const [name, value] of Object.entries(profiles)) {
+      const entry = asObject(value);
+      if (
+        entry === null ||
+        !Object.prototype.hasOwnProperty.call(entry, "fallbackProfile")
+      ) {
+        continue;
+      }
+      const isCodeOwnedMapping =
+        entry.source === "managed" &&
+        entry.fallbackProfile === CODE_OWNED_FALLBACKS[name];
+      if (isCodeOwnedMapping) {
+        continue;
+      }
+      delete entry.fallbackProfile;
+      strippedProfiles.push(name);
+    }
+
+    if (strippedProfiles.length === 0) {
+      return;
+    }
+    writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n");
+    log.info(
+      { profiles: strippedProfiles },
+      "Removed unsupported custom fallback profile pointers",
+    );
+  },
+
+  down(_workspaceDir: string): void {
+    // Forward-only: unsupported fallback pointers cannot be restored safely.
+  },
+};
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function asObject(value: unknown): Record<string, unknown> | null {
+  return isPlainObject(value) ? value : null;
+}

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -145,6 +145,7 @@ import { convertStrandedSubscriptionOpenaiProfilesMigration } from "./144-conver
 import { collapseProfileBindingsToEntriesMigration } from "./145-collapse-profile-bindings-to-entries.js";
 import { repairRetiredFireworksDeepseekFlashModelIdMigration } from "./146-repair-retired-fireworks-deepseek-flash-model-id.js";
 import { renameCollidingBackupProfileNamesMigration } from "./147-rename-colliding-backup-profile-names.js";
+import { stripUnsupportedFallbackProfilesMigration } from "./148-strip-unsupported-fallback-profiles.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -305,4 +306,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   collapseProfileBindingsToEntriesMigration,
   repairRetiredFireworksDeepseekFlashModelIdMigration,
   renameCollidingBackupProfileNamesMigration,
+  stripUnsupportedFallbackProfilesMigration,
 ];


### PR DESCRIPTION
## Summary

- limit automatic model fallback to code-owned Vellum-managed defaults and reject custom fallbackProfile writes
- preserve exact request and call-site pins and reuse dispatch resolvability for fallback routing
- exercise the full call-site routing path and preserve primary errors when backups fail

## Original prompt

Address the correctness and configuration-contract issues found while reviewing the model-fallback rollup before it can be merged.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41275" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->