### PR TITLE
fix(voice,widgets): re-drain parked voice starts on assistant switch, let encode failures retry

### DIFF
--- a/clients/web/src/domains/chat/hooks/use-native-widget-snapshot-sync.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-native-widget-snapshot-sync.test.tsx
@@ -53,10 +53,12 @@
  * the plugin's write replaces the App Group record whole, so a first sync taken
  * while it loads wipes a themed avatar off every widget until a second one
  * repaints it. The encode behind it is the memo `avatar-island-encode` shares
- * with the Live Activity mirror, so these tests thread their stub through its
- * injection seam rather than restating its caching here: an encode that
- * resolves to nothing is a fact about the avatar and is cached, while one that
- * throws is the encoder failing and must be retried.
+ * with the Live Activity mirror, so these tests thread a stub through its
+ * injection seam rather than restating its caching here. The stub goes in at
+ * the rasterizer, below the ladder, because the distinction under test is one
+ * the ladder draws: a rung that comes back over budget is a fact about the
+ * avatar and is cached, while a draw that fails at all is the encoder failing
+ * and has to reject its way out to the memo so the next read retries it.
  */
 
 import {
@@ -184,6 +186,14 @@ let encodeOutcome: "bytes" | "nothing-fits" | "throws" = "bytes";
 let encodeCalls = 0;
 /** Long enough that a dedup key carrying it would be unmistakable. */
 const AVATAR_BASE64 = "Zm9vYmFy".repeat(2_000);
+/**
+ * The pixels behind it. "foobar" base64s to "Zm9vYmFy" and is a whole number of
+ * base64 groups, so the repeats line up and the encoder's own base64 of these
+ * bytes is exactly the string above.
+ */
+const AVATAR_BYTES = new TextEncoder().encode("foobar".repeat(2_000));
+/** Past the widget's 64KB budget, so every rung of the ladder misses. */
+const OVERSIZED_BYTES = new Uint8Array(100_000);
 
 /** What the query serves from the next render on, without waking subscribers. */
 function setAvatar(data: AvatarData, isLoading = false): void {
@@ -216,22 +226,39 @@ mock.module("@/hooks/use-assistant-avatar", () => ({
   },
 }));
 
-/** Stands in for the canvas draw, which happy-dom has no canvas for. */
-const stubEncode = async (): Promise<string | null> => {
-  encodeCalls++;
-  if (encodeOutcome === "throws") {
-    throw new Error("canvas unavailable");
-  }
-  return encodeOutcome === "bytes" ? AVATAR_BASE64 : null;
-};
-
 const realAvatarIslandEncode = await import("@/utils/avatar-island-encode");
 // Held before the mock is installed. `mock.module` updates live bindings, so a
 // wrapper that reached back through the namespace object at call time would
 // find itself rather than the real implementation.
+const realEncodeAvatarForIsland = realAvatarIslandEncode.encodeAvatarForIsland;
 const realMemoizedAvatarEncode = realAvatarIslandEncode.memoizedAvatarEncode;
 const resetAvatarEncodeMemo =
   realAvatarIslandEncode.__resetAvatarEncodeMemoForTesting;
+
+/**
+ * Stands in for the canvas draw, which happy-dom has no canvas for.
+ *
+ * Stubbed at the RASTERIZER rather than at the encoder, so the real ladder runs
+ * above it. Whether a failed draw is retried and a too-large one is cached is
+ * decided by how `encodeAvatarForIsland` classifies each, and a stub installed
+ * over that would be answering for the very thing under test.
+ */
+const stubRasterize = async (): Promise<Uint8Array | null> => {
+  if (encodeOutcome === "throws") {
+    throw new Error("canvas unavailable");
+  }
+  return encodeOutcome === "bytes" ? AVATAR_BYTES : OVERSIZED_BYTES;
+};
+
+/** That ladder, counted, so a re-encode after a dropped slot is visible. */
+const stubEncode = (
+  render: Parameters<typeof realEncodeAvatarForIsland>[0],
+  maxBytes?: number,
+): Promise<string | null> => {
+  encodeCalls++;
+  return realEncodeAvatarForIsland(render, maxBytes, stubRasterize);
+};
+
 mock.module("@/utils/avatar-island-encode", () => ({
   ...realAvatarIslandEncode,
   encodeAvatarForIsland: stubEncode,
@@ -1330,7 +1357,9 @@ describe("useNativeWidgetSnapshotSync", () => {
     // A canvas the shell would not hand over, or a blob URL revoked mid-draw:
     // transient, and cached as `no avatar` it would strip the face off every
     // later snapshot in the run, heartbeats included. The avatar object is the
-    // same across both renders, so only a dropped memo can produce a retry.
+    // same across both renders, so only a dropped memo can produce a retry, and
+    // the drop only happens if the failed draw rejects all the way out of the
+    // ladder rather than being flattened into a null the memo would cache.
     encodeOutcome = "throws";
     const avatar = characterAvatar("orange");
     setAvatar(avatar);

--- a/clients/web/src/domains/chat/hooks/use-native-widget-snapshot-sync.ts
+++ b/clients/web/src/domains/chat/hooks/use-native-widget-snapshot-sync.ts
@@ -102,11 +102,12 @@ interface SnapshotAvatarFingerprint {
  * the first read since it changed.
  *
  * The encode is a canvas draw memoized at module scope by
- * {@link memoizedAvatarEncode}, shared with the Live Activity mirror, so a
- * session that drives both native surfaces pays it once per avatar. An encode
- * that fails or fits nothing is an avatar-less snapshot, never a missing one:
- * the counts and the rows are what the widgets are for. Only a failure is
- * retried, and the memo owns that distinction.
+ * {@link memoizedAvatarEncode}, shared with the Live Activity mirror for one
+ * owner of the caching and failure rules rather than one draw across both: the
+ * mirror resolves its own render and reads at its own budget, so each surface
+ * encodes separately. An encode that fails or fits nothing is an avatar-less
+ * snapshot, never a missing one: the counts and the rows are what the widgets
+ * are for. Only a failure is retried, and the memo owns that distinction.
  *
  * `source` and `accentHex` are resolved reactively by the hook rather than read
  * back from the two imperative publishers in `RootLayout`. Those are written by

--- a/clients/web/src/domains/chat/voice/live-voice/start-voice-request.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/start-voice-request.ts
@@ -139,7 +139,8 @@ export function startVoiceFromSurface(navigate: VoiceStartNavigate): void {
 /**
  * Start a parked start-voice request, if there is one and a starter exists.
  * Called by {@link useLiveVoiceSessionController} right after it registers its
- * starter, and by {@link requestVoiceStart} for the warm path.
+ * starter and again whenever the active assistant changes, and by
+ * {@link requestVoiceStart} for the warm path.
  * A no-op when nothing is parked, so the repeat calls are free.
  *
  * **The park is consumed last.** Everything before the consume is a *precondition
@@ -234,7 +235,9 @@ export async function drainPendingVoiceStart(
   // rather than a decision: both the eligibility gate and this verdict answered
   // for an assistant that is no longer the one a fresh start means. Nothing has
   // been navigated or minted yet, so the request stays parked and the next
-  // drain runs both against whoever is active by then.
+  // drain runs both against whoever is active by then. That next drain is the
+  // switch itself: `useLiveVoiceSessionController` runs one on every change of
+  // active assistant, so the repark is a retry rather than a wait for the TTL.
   if (useResolvedAssistantsStore.getState().activeAssistantId !== assistantId) {
     return;
   }

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-activity-mirror.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-activity-mirror.ts
@@ -133,12 +133,13 @@ function toActivityContent(
  * The island avatar for the current assistant, encoding it on first use.
  *
  * The memo is shared with the Home Screen widget snapshot, which rasterizes the
- * same source through the same ladder at a budget of its own, so a session that
- * drives both surfaces pays the canvas draw once per avatar rather than once
- * per surface. What reaches the island is unchanged: the memo is keyed on the
- * source's identity, exactly as this module's own cache was, and holds a
- * separate slot per budget so an island can never be handed the widgets' larger
- * encode and fail to start on it.
+ * same source through the same ladder at a budget of its own. Sharing it buys
+ * one owner of the caching rules and the failure semantics rather than one
+ * draw for both surfaces: the two run separate encodes, since each resolves its
+ * own render and reads at its own budget. What reaches the island is unchanged:
+ * the memo is keyed on the source's identity, exactly as this module's own
+ * cache was, and holds a separate slot per budget so an island can never be
+ * handed the widgets' larger encode and fail to start on it.
  */
 async function islandAvatarBase64(): Promise<string | undefined> {
   const source = getIslandAvatarSource();

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.test.tsx
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.test.tsx
@@ -68,8 +68,11 @@ const actualPlatformDetection = await import("@/runtime/platform-detection");
 
 // Voice entry preflights readiness before a session opens; stub it ready so
 // the controller's drain tests stay about the starter. See `voice-entry-guards`.
+// A mock rather than a literal so a case can hold the round trip open and move
+// the app underneath a drain, which is the only way to reach the repark.
+const preflightLiveVoice = mock(async () => ({ status: "ready" }));
 mock.module("@/domains/chat/voice/live-voice/live-voice-preflight-api", () => ({
-  preflightLiveVoice: async () => ({ status: "ready" }),
+  preflightLiveVoice,
 }));
 
 mock.module("@/runtime/platform-detection", () => ({
@@ -206,6 +209,8 @@ beforeEach(() => {
   interruptionHandlers = [];
   onNativeAndroid = false;
   onNativeIOS = false;
+  preflightLiveVoice.mockClear();
+  preflightLiveVoice.mockImplementation(async () => ({ status: "ready" }));
   activateVoiceAudioSession.mockClear();
   activateVoiceAudioSession.mockImplementation(async () => true);
   deactivateVoiceAudioSession.mockClear();
@@ -313,6 +318,111 @@ describe("starter registration", () => {
     });
 
     expect(h.clients).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Re-draining a parked start when the active assistant changes
+// ---------------------------------------------------------------------------
+
+/**
+ * The drain has two triggers, and only the second serves a reparked request.
+ *
+ * `drainPendingVoiceStart` leaves the request parked when the active assistant
+ * changed while its preflight was in flight, because the eligibility gate and
+ * the readiness verdict both answered for the assistant the user has just left.
+ * The starter-registration effect above cannot run that next drain: it is keyed
+ * on the starter's identity, which a switch does not touch. So the switch runs
+ * it, and a press the user really made is served on the assistant they moved to
+ * rather than sitting until its TTL takes it.
+ */
+describe("re-draining on an assistant switch", () => {
+  /** Resolved, active, and new enough to serve live voice. */
+  function activeAssistant(assistantId: string): void {
+    useAssistantIdentityStore.setState({ assistantId, version: "0.10.12" });
+    useResolvedAssistantsStore.setState({ activeAssistantId: assistantId });
+  }
+
+  /**
+   * Let the fire-and-forget drains run out. They cannot be awaited by design,
+   * and each one awaits the version resolution, the preflight, and the start.
+   */
+  async function flushDrains(): Promise<void> {
+    await act(async () => {
+      for (let i = 0; i < 12; i++) {
+        await Promise.resolve();
+      }
+    });
+  }
+
+  test("a request reparked mid-preflight starts on the assistant switched to", async () => {
+    activeAssistant("assistant-1");
+    usePendingDeepLinkStore.getState().setPendingVoiceStart();
+    let releasePreflight: () => void = () => {};
+    preflightLiveVoice.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          releasePreflight = () => {
+            resolve({ status: "ready" });
+          };
+        }),
+    );
+
+    // The mount's drain gets as far as the held preflight and no further.
+    const h = renderPersistentController();
+    await flushDrains();
+    expect(h.clients).toHaveLength(0);
+
+    // The user switches assistants with that preflight still open, so the drain
+    // reparks when it resumes.
+    act(() => {
+      activeAssistant("assistant-2");
+      releasePreflight();
+    });
+    await flushDrains();
+
+    const draftId =
+      useConversationStore.getState().activeConversationId ?? undefined;
+    expect(draftId).toBeDefined();
+    expect(h.clients).toHaveLength(1);
+    expect(h.lastClient().connectArgs).toEqual({
+      assistantId: "assistant-2",
+      conversationId: draftId,
+      turnDetection: "server_vad",
+    });
+    // Spent, rather than left parked for the TTL to throw away.
+    expect(usePendingDeepLinkStore.getState().pendingVoiceStartAt).toBeNull();
+  });
+
+  test("a switch with nothing parked starts nothing", async () => {
+    activeAssistant("assistant-1");
+    const h = renderPersistentController();
+    await flushDrains();
+
+    act(() => {
+      activeAssistant("assistant-2");
+    });
+    await flushDrains();
+
+    expect(h.clients).toHaveLength(0);
+    expect(useLiveVoiceStore.getState().state).toBe("idle");
+  });
+
+  test("a switch after the request was served starts no second session", async () => {
+    // The park is one-shot, so the trigger cannot turn every later switch into
+    // a session the user never asked for.
+    activeAssistant("assistant-1");
+    usePendingDeepLinkStore.getState().setPendingVoiceStart();
+    const h = renderPersistentController();
+    await flushDrains();
+    expect(h.clients).toHaveLength(1);
+
+    act(() => {
+      activeAssistant("assistant-2");
+    });
+    await flushDrains();
+
+    expect(h.clients).toHaveLength(1);
   });
 });
 

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.ts
@@ -20,7 +20,8 @@
  * - `starter` — registered here for the lifetime of the mount; the composer's
  *   entry-point mic calls it to start a session. Registering it also drains any
  *   start-voice deep link parked before this mount (see
- *   `start-voice-request.ts`).
+ *   `start-voice-request.ts`), as does a change of active assistant, which is
+ *   the other thing that can make a parked request drainable.
  * - `controls` (stop/release/interrupt) — registered per-session by
  *   {@link useLiveVoice} itself.
  * - `state`/`error`/transcripts/amplitude — observable session state.
@@ -53,6 +54,7 @@ import {
   subscribeVoiceAudioInterruptions,
 } from "@/runtime/native-audio-session";
 import { isNativeAndroid } from "@/runtime/platform-detection";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 
 /** Injectable primitive factories, for tests. */
 export type UseLiveVoiceSessionControllerOptions = Pick<
@@ -209,6 +211,29 @@ export function useLiveVoiceSessionController(
       useLiveVoiceStore.getState().setStarter(null);
     };
   }, [start, prewarmPlayback, cancelPrewarmedPlayback]);
+
+  // The drain's second trigger, and the only one a parked request has once the
+  // starter is registered: the effect above runs on the starter's identity, not
+  // on anything the drain gates against. `drainPendingVoiceStart` reparks when
+  // the active assistant changed under a preflight, because the eligibility
+  // gate and the readiness verdict both answered for the assistant the user
+  // just left, and without this that request would sit until its TTL took it.
+  //
+  // Subscribed rather than selected, so a switch never re-renders the mounting
+  // layout, matching `observeAudioState: false` above. Nothing here starts a
+  // session on its own: a drain with nothing parked returns immediately, and
+  // the park is one-shot, so a drain that overlaps one already in flight loses
+  // the consume and stops.
+  useEffect(() => {
+    return useResolvedAssistantsStore.subscribe((state, prevState) => {
+      if (state.activeAssistantId === prevState.activeAssistantId) {
+        return;
+      }
+      void drainPendingVoiceStart((to, navigateOptions) =>
+        navigateRef.current(to, navigateOptions),
+      );
+    });
+  }, []);
 
   useNativeAudioSessionLifecycle();
   useLiveActivityMirror();

--- a/clients/web/src/utils/avatar-island-encode.test.ts
+++ b/clients/web/src/utils/avatar-island-encode.test.ts
@@ -73,7 +73,9 @@ describe("encodeAvatarForIsland", () => {
     byteSizes["128:image/png"] = 900;
 
     expect(await encode(CHARACTER)).not.toBeNull();
-    expect(attempts).toEqual([{ size: 128, type: "image/png", quality: undefined }]);
+    expect(attempts).toEqual([
+      { size: 128, type: "image/png", quality: undefined },
+    ]);
   });
 
   // The measured shape for the default character avatar: 128px PNG is 6860
@@ -143,11 +145,30 @@ describe("encodeAvatarForIsland", () => {
   });
 
   // An undrawable source fails identically at every size, so retrying the
-  // whole ladder would just be five more failures.
+  // whole ladder would just be seven more failures.
   test("gives up immediately when the source will not draw", async () => {
     throwOnDraw = true;
 
-    expect(await encode(IMAGE)).toBeNull();
+    await expect(encode(IMAGE)).rejects.toThrow("source failed to load");
+    expect(attempts).toHaveLength(1);
+  });
+
+  // The line the memo's caching depends on. Null is a fact about the avatar
+  // (nothing to draw, nothing that fits), and only a fact may be cached; a draw
+  // that failed says nothing about the avatar, so it has to arrive as a
+  // rejection or one bad canvas pins "no avatar" for the whole session.
+  test("rejects a failed draw rather than reporting it as nothing to send", async () => {
+    throwOnDraw = true;
+
+    await expect(encode(CHARACTER)).rejects.toThrow();
+  });
+
+  // The rasterizer's other failure: a 2d context the shell would not give up,
+  // or a `toBlob` that produced no blob. Same class as a throw, and no later
+  // rung draws on a canvas the first one could not get.
+  test("rejects when the rasterizer hands back no bytes", async () => {
+    // `byteSizes` is empty, so the stub returns null for the first rung.
+    await expect(encode(CHARACTER)).rejects.toThrow();
     expect(attempts).toHaveLength(1);
   });
 
@@ -274,5 +295,54 @@ describe("memoizedAvatarEncode", () => {
     // A fresh identity, so a caller keying a payload on the avatar can tell the
     // retry apart from the attempt that carried nothing.
     expect(retried.revision).not.toBe(failed.revision);
+  });
+
+  /**
+   * The two halves meeting. The cases above stub the encoder, so they pin the
+   * memo's rule and nothing else; the memo's rule is only worth as much as the
+   * encoder's classification of what happened, so these run the REAL ladder
+   * over the stub rasterizer at the top of this file.
+   */
+  const realMemo = (render: AvatarRender) =>
+    memoizedAvatarEncode(render, ISLAND_AVATAR_MAX_BYTES, (r, maxBytes) =>
+      encodeAvatarForIsland(r, maxBytes, rasterize as never),
+    );
+
+  test("drops the slot when the rasterizer fails, so the next read draws again", async () => {
+    // The whole point of the classification: one transient canvas failure used
+    // to resolve null, which the memo cached, and the session went avatar-less
+    // from there.
+    const render = source();
+    throwOnDraw = true;
+
+    const failed = realMemo(render);
+    // Still resolved rather than rejected at the caller: the payload goes out
+    // without a face rather than not at all.
+    expect(await failed.pending).toBeNull();
+    expect(attempts).toHaveLength(1);
+
+    throwOnDraw = false;
+    byteSizes["128:image/png"] = 900;
+    const retried = realMemo(render);
+    expect(await retried.pending).not.toBeNull();
+    expect(retried.revision).not.toBe(failed.revision);
+  });
+
+  test("keeps the slot for an avatar that fits no rung, which is not a failure", async () => {
+    const render = source();
+    for (const size of [128, 96, 64, 48, 40, 32]) {
+      byteSizes[`${size}:image/png`] = 99000;
+    }
+    byteSizes["64:image/jpeg"] = 99000;
+    byteSizes["48:image/jpeg"] = 99000;
+
+    expect(await realMemo(render).pending).toBeNull();
+    expect(attempts).toHaveLength(8);
+
+    const cached = realMemo(render);
+    expect(cached.pending).toBeNull();
+    expect(cached.base64).toBeNull();
+    // No second walk of the ladder: the verdict is a fact about the source.
+    expect(attempts).toHaveLength(8);
   });
 });

--- a/clients/web/src/utils/avatar-island-encode.ts
+++ b/clients/web/src/utils/avatar-island-encode.ts
@@ -35,9 +35,11 @@
  * The widget snapshot rasterizes the same avatar from the same source through
  * the same ladder, differing only in the budget it can afford (an App Group
  * write rather than an ActivityKit attribute). Both surfaces therefore share
- * {@link memoizedAvatarEncode}, so a session pays the canvas draw once per
- * avatar however many of them ask for it, and the caching rules live in one
- * place rather than being restated per consumer.
+ * {@link memoizedAvatarEncode}. Not to draw once for both: slots are keyed per
+ * budget, and each surface resolves an {@link AvatarRender} of its own, so the
+ * two genuinely encode separately. What they share is an owner. One place
+ * decides what is cached, what is retried, and what a failed encode costs the
+ * payload, instead of each consumer restating those rules and drifting.
  */
 
 import { rasterizeAvatar } from "@/utils/avatar-raster";
@@ -103,11 +105,24 @@ function toBase64(bytes: Uint8Array): string {
  * Rasterize `render` as small as it needs to be to fit `maxBytes`, returning
  * base64 or null.
  *
- * Null means "show the accent glyph instead", and is the right answer for a
- * `none` avatar, a source that fails to draw, and an avatar that will not fit
- * at any rung. Every caller must treat it as ordinary rather than as an error:
- * the Live Activity is a flourish, and none of these cases should cost the
- * user their island.
+ * **Null is a fact about the avatar, not a failure to encode it.** Exactly two
+ * cases resolve null: a `none` avatar, and one whose smallest rung is still
+ * over budget. Both mean "show the accent glyph instead" and are ordinary
+ * rather than errors, because the Live Activity is a flourish and neither
+ * should cost the user their island. Both are also stable, so a caller may
+ * cache them.
+ *
+ * **An operational failure REJECTS.** The rasterizer throwing (a revoked blob
+ * URL, a cross-origin upload) and the rasterizer handing back no bytes at all
+ * (a 2d context the shell would not give up, a `toBlob` that produced nothing)
+ * say nothing about the avatar and may not be cached as if they did. Keeping
+ * the two apart at this seam is what lets {@link memoizedAvatarEncode} hold one
+ * for the session and retry the other; collapsing both into null pinned "no
+ * avatar" on the whole session after a single transient canvas failure.
+ *
+ * A rejection leaves the ladder rather than stepping down it: every rung draws
+ * the same source through the same canvas, so a draw that failed once fails the
+ * same way seven more times.
  */
 export async function encodeAvatarForIsland(
   render: AvatarRender,
@@ -123,21 +138,16 @@ export async function encodeAvatarForIsland(
   const src = render.kind === "character" ? render.dataUri : render.url;
 
   for (const candidate of CANDIDATES) {
-    let bytes: Uint8Array | null;
-    try {
-      bytes = await rasterize(
-        src,
-        candidate.size,
-        candidate.type,
-        candidate.quality,
-      );
-    } catch {
-      // The source itself will not draw (a revoked blob URL, a cross-origin
-      // upload). No later rung can fix that, so stop rather than retry it
-      // five more times.
-      return null;
+    const bytes = await rasterize(
+      src,
+      candidate.size,
+      candidate.type,
+      candidate.quality,
+    );
+    if (bytes === null) {
+      throw new Error("avatar rasterizer produced no bytes");
     }
-    if (bytes && bytes.byteLength <= maxBytes) {
+    if (bytes.byteLength <= maxBytes) {
       return toBase64(bytes);
     }
   }
@@ -172,10 +182,10 @@ interface AvatarEncodeSlot extends AvatarEncodeMemo {
 /**
  * The last encode per byte budget, each slot holding the source it came from.
  *
- * Module scope, so the canvas draw is paid once per avatar however many native
- * surfaces ask for it and however often they re-render. The key inside a slot
- * is the resolved {@link AvatarRender}, a stable object recomputed only when
- * the avatar itself changes, so identity comparison is enough and there is
+ * Module scope, so a surface pays the canvas draw once per avatar however often
+ * it re-renders, and a slot outlives the effect that filled it. The key inside
+ * a slot is the resolved {@link AvatarRender}, a stable object recomputed only
+ * when the avatar itself changes, so identity comparison is enough and there is
  * nothing to invalidate.
  *
  * Kept per budget rather than one slot for every caller, because the ceilings


### PR DESCRIPTION
## Summary
Fixes review findings on the remediation round: an assistant switch now re-drains a parked voice start instead of letting it expire, operational rasterize failures reach the encode memo's retry branch while oversized avatars still cache as null, and the shared-cache comments state the actual win.