### PR TITLE
fix(providers): ignore stale fallback breaker updates

### DIFF
--- a/assistant/src/__tests__/fallback-breaker.test.ts
+++ b/assistant/src/__tests__/fallback-breaker.test.ts
@@ -284,6 +284,15 @@ describe("fallback breaker state machine", () => {
     expect(shouldSkipPrimary(UPSTREAM_ROUTE, T0 + 1_000)).toBe(false);
   });
 
+  test("a stale fallback serve cannot re-trip a recovered route", () => {
+    const observation = recordPrimaryFailure(UPSTREAM_ROUTE, T0);
+    recordPrimarySuccess(UPSTREAM_ROUTE, T0 + 1_000);
+
+    recordFallbackServed(UPSTREAM_ROUTE, T0 + 2_000, observation);
+
+    expect(shouldSkipPrimary(UPSTREAM_ROUTE, T0 + 2_000)).toBe(false);
+  });
+
   test("the cooldown lands inside the jitter band and varies between trips", () => {
     const seen = new Set<number>();
     for (let i = 0; i < 40; i += 1) {
@@ -757,6 +766,44 @@ describe("RetryProvider under an open breaker", () => {
     await wrapped.sendMessage(MESSAGES, { config: { callSite: "mainAgent" } });
     expect(primary.calls()).toBe(1);
     expect(backup.calls()).toBe(2);
+  });
+
+  test("a late fallback completion cannot reopen a recovered primary", async () => {
+    const primary = primaryProvider(
+      () => new ProviderError("model not found", UPSTREAM, 404),
+    );
+    let resolveBackupStarted!: () => void;
+    const backupStarted = new Promise<void>((resolve) => {
+      resolveBackupStarted = resolve;
+    });
+    let resolveBackupResponse!: (response: ProviderResponse) => void;
+    const backupResponse = new Promise<ProviderResponse>((resolve) => {
+      resolveBackupResponse = resolve;
+    });
+    const backup: Provider = {
+      name: "anthropic",
+      sendMessage: async () => {
+        resolveBackupStarted();
+        return backupResponse;
+      },
+    };
+    const route = makeRoute(backup);
+    const wrapped = new RetryProvider(primary.provider, {
+      resolveFallbackRoute: route.resolveFallbackRoute,
+    });
+
+    const first = wrapped.sendMessage(MESSAGES, {
+      config: { callSite: "mainAgent" },
+    });
+    await backupStarted;
+
+    // A concurrent recovery probe can prove the primary is healthy while the
+    // earlier request is still waiting for its backup response.
+    recordPrimarySuccess(PRIMARY_ROUTE);
+    resolveBackupResponse(okResponse("backup-model"));
+
+    await first;
+    expect(shouldSkipPrimary(PRIMARY_ROUTE)).toBe(false);
   });
 
   test("a retired model diverts only itself, not a healthy model on the same upstream", async () => {

--- a/assistant/src/providers/fallback-breaker.ts
+++ b/assistant/src/providers/fallback-breaker.ts
@@ -67,6 +67,16 @@ export interface BreakerRoute {
   model?: string;
 }
 
+/**
+ * Identifies the breaker state that observed a primary failure. A fallback
+ * completion may arrive after a recovery probe, so it must only update the
+ * state that was current when the primary failed.
+ */
+export interface BreakerObservation {
+  key: string;
+  generation: number;
+}
+
 interface BreakerState {
   /** Timestamps of recent eligible failures, pruned to the failure window. */
   failures: number[];
@@ -76,9 +86,12 @@ interface BreakerState {
   failedProbes: number;
   /** Whether a probe is currently deciding recovery for this entry. */
   probeInFlight: boolean;
+  /** Monotonic identity for this state generation. */
+  generation: number;
 }
 
 const breakers = new Map<string, BreakerState>();
+let nextGeneration = 0;
 
 /**
  * The single entry a write targets. A model-scoped key can never collide with
@@ -107,6 +120,7 @@ function stateFor(key: string): BreakerState {
     openUntil: null,
     failedProbes: 0,
     probeInFlight: false,
+    generation: ++nextGeneration,
   };
   breakers.set(key, created);
   return created;
@@ -177,17 +191,18 @@ function openCovering(
 export function recordPrimaryFailure(
   route: BreakerRoute,
   now: number = Date.now(),
-): void {
+): BreakerObservation {
   const key = keyOf(route);
   const state = stateFor(key);
   if (isOpen(state)) {
-    return;
+    return { key, generation: state.generation };
   }
   state.failures = state.failures.filter((at) => now - at < FAILURE_WINDOW_MS);
   state.failures.push(now);
   if (state.failures.length >= FAILURES_TO_TRIP) {
     trip(key, state, now, "eligible_failures");
   }
+  return { key, generation: state.generation };
 }
 
 /**
@@ -200,10 +215,23 @@ export function recordPrimaryFailure(
 export function recordFallbackServed(
   route: BreakerRoute,
   now: number = Date.now(),
+  observation?: BreakerObservation,
 ): void {
   const key = keyOf(route);
-  const state = stateFor(key);
-  if (isOpen(state)) {
+  const state = observation === undefined ? stateFor(key) : breakers.get(key);
+  if (
+    observation !== undefined &&
+    (state === undefined ||
+      observation.key !== key ||
+      observation.generation !== state.generation)
+  ) {
+    log.info(
+      { route: key, observation, currentGeneration: state?.generation },
+      "Ignoring a stale fallback serve for the fallback breaker",
+    );
+    return;
+  }
+  if (state === undefined || isOpen(state)) {
     return;
   }
   trip(key, state, now, "fallback_served");

--- a/assistant/src/providers/retry.ts
+++ b/assistant/src/providers/retry.ts
@@ -26,6 +26,7 @@ import {
   isAnthropicModel,
 } from "./anthropic-gateway-shared.js";
 import {
+  type BreakerObservation,
   type BreakerRoute,
   recordFallbackServed,
   recordPrimaryFailure,
@@ -1551,8 +1552,9 @@ export class RetryProvider implements Provider {
             breakerRoute === null
               ? null
               : failureBreakerRoute(breakerRoute, error);
+          let failureObservation: BreakerObservation | undefined;
           if (failedRoute !== null) {
-            recordPrimaryFailure(failedRoute);
+            failureObservation = recordPrimaryFailure(failedRoute);
           }
           const fallbackResult = await this.sendOnFallbackRoute(
             messages,
@@ -1571,7 +1573,7 @@ export class RetryProvider implements Provider {
             // backup can carry the traffic, so later requests skip the retry
             // budget until a probe says the primary is back.
             if (failedRoute !== null) {
-              recordFallbackServed(failedRoute);
+              recordFallbackServed(failedRoute, Date.now(), failureObservation);
             }
             return fallbackResult;
           }


### PR DESCRIPTION
## Summary

- attach a generation token to primary-failure observations
- ignore delayed fallback completions after a newer recovery cleared the route
- add state-machine and RetryProvider race regressions

## Original prompt

This is PR 2 in the managed model-fallback rollout. Harden circuit-breaker recovery so an in-flight fallback cannot reopen a primary route that a later recovery probe already proved healthy.

## Validation

- `cd assistant && bun test src/__tests__/fallback-breaker.test.ts src/__tests__/retry-fallback-escalation.test.ts`
- `cd assistant && bun test src/__tests__/retry-backoff.test.ts src/__tests__/retry-after-extraction.test.ts src/providers/__tests__/retry-callsite.test.ts`
- `cd assistant && bunx prettier --check src/providers/fallback-breaker.ts src/providers/retry.ts src/__tests__/fallback-breaker.test.ts`
- `cd assistant && bunx tsc --noEmit`
- commit and pre-push hooks: lint and type check passed
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41284" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->