### PR TITLE
fix(web): gate plans-page and custom-plan-modal credit wording behind obscure-credits

### DIFF
--- a/clients/web/src/domains/settings/billing/plans/custom-plan-diff.ts
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-diff.ts
@@ -33,6 +33,12 @@ export type CreditChoice = CreditTierEnum | typeof NO_EXTRA_CREDITS;
 export const NO_CREDITS_LABEL = "No extra credits";
 
 /**
+ * The sentinel's wording on the `obscure-credits` surfaces, which never name
+ * credits; the catalog options around it are already usage bundles.
+ */
+export const NO_USAGE_LABEL = "No extra usage";
+
+/**
  * Sentinel for the baseline machine. `MachineTierEnum` names only the paid
  * tiers, so the small machine a package with no tier runs on has no value to
  * carry: it is `null` on the wire. Same note as above: `Select`'s `null`
@@ -81,8 +87,15 @@ export function computeCustomPlanDiff(input: {
   machineTier: MachineChoice | "";
   storageTier: StorageTierEnum | "";
   creditChoice: CreditChoice | "";
+  /**
+   * Wording for the no-bundle sentinel's recap row (and its struck-through
+   * previous value). Defaults to the credits wording; the `obscure-credits`
+   * surfaces pass `NO_USAGE_LABEL` instead.
+   */
+  noBundleLabel?: string;
 }): CustomPlanDiff {
   const { proPlan, seed, machineTier, storageTier, creditChoice } = input;
+  const noBundleLabel = input.noBundleLabel ?? NO_CREDITS_LABEL;
 
   // Resolve against the full catalog, legacy tiers included: a tier a
   // subscriber still holds has to price and label even where the modal no
@@ -177,7 +190,7 @@ export function computeCustomPlanDiff(input: {
   // "No extra credits" would be affirmatively false for a sub paying for one.
   const selectedCreditLabel =
     creditChoice === NO_EXTRA_CREDITS
-      ? NO_CREDITS_LABEL
+      ? noBundleLabel
       : selectedCredit != null
         ? // The catalog label ("Mighty Usage") is the bundle's Stripe product
           // name, so the row matches the invoice line.
@@ -191,7 +204,7 @@ export function computeCustomPlanDiff(input: {
       seed != null && (seed.creditTier ?? NO_EXTRA_CREDITS) !== creditChoice;
     const previousCreditLabel =
       seed?.creditTier == null
-        ? NO_CREDITS_LABEL
+        ? noBundleLabel
         : seedCredit != null
           ? seedCredit.label
           : undefined;

--- a/clients/web/src/domains/settings/billing/plans/custom-plan-diff.ts
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-diff.ts
@@ -33,12 +33,6 @@ export type CreditChoice = CreditTierEnum | typeof NO_EXTRA_CREDITS;
 export const NO_CREDITS_LABEL = "No extra credits";
 
 /**
- * The sentinel's wording on the `obscure-credits` surfaces, which never name
- * credits; the catalog options around it are already usage bundles.
- */
-export const NO_USAGE_LABEL = "No extra usage";
-
-/**
  * Sentinel for the baseline machine. `MachineTierEnum` names only the paid
  * tiers, so the small machine a package with no tier runs on has no value to
  * carry: it is `null` on the wire. Same note as above: `Select`'s `null`
@@ -90,7 +84,7 @@ export function computeCustomPlanDiff(input: {
   /**
    * Wording for the no-bundle sentinel's recap row (and its struck-through
    * previous value). Defaults to the credits wording; the `obscure-credits`
-   * surfaces pass `NO_USAGE_LABEL` instead.
+   * surfaces pass the localized `customPlanModal.noExtraUsage` copy instead.
    */
   noBundleLabel?: string;
 }): CustomPlanDiff {

--- a/clients/web/src/domains/settings/billing/plans/custom-plan-modal.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-modal.test.tsx
@@ -20,7 +20,13 @@
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  waitFor,
+} from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter, useLocation } from "react-router";
 
@@ -34,6 +40,7 @@ import * as sdkGen from "@/generated/api/sdk.gen";
 import * as browserRuntime from "@/runtime/browser";
 import * as nativeAuth from "@/runtime/native-auth";
 import * as platformGate from "@/hooks/use-platform-gate";
+import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import {
   organizationsBillingPlansRetrieveQueryKey,
   organizationsBillingSubscriptionOnboardingRetrieveQueryKey,
@@ -1074,5 +1081,63 @@ describe("CustomPlanModal — Pro plan holding a deprecated (legacy) credit bund
     selectOption("Machine size", "Medium machine (2.5 vCPU, 5 GiB)");
 
     expect(deltaLine()).toBeNull();
+  });
+});
+
+/** Drives the `obscure-credits` client flag the way the app's LD sync does. */
+function setObscureCredits(value: boolean): void {
+  act(() => {
+    useClientFeatureFlagStore
+      .getState()
+      .setFlags({ obscureCredits: value }, null);
+  });
+}
+
+describe("CustomPlanModal: obscure-credits flag", () => {
+  afterEach(() => {
+    setObscureCredits(false);
+  });
+
+  test("flag on: the bundle picker's chrome reads as usage, not credits", () => {
+    setObscureCredits(true);
+    const { getByRole, getByText } = renderPage(freeSubscription());
+
+    fireEvent.click(getByRole("button", { name: "Configure" }));
+
+    // Label, trigger aria-label, placeholder, and docs aria-label all use the
+    // usage wording; the catalog options themselves are untouched.
+    getByText("Add a usage bundle:");
+    const trigger = selectTrigger("Usage bundle");
+    expect(trigger.textContent).toContain("Select a usage bundle");
+    expect(docsLink(CREDIT_DOCS_URL).getAttribute("aria-label")).toBe(
+      "Learn more about usage bundles",
+    );
+
+    // The sentinel option and its recap row follow suit.
+    selectOption("Usage bundle", "No extra usage");
+    expect(recapRows()).toContain("No extra usage");
+  });
+
+  test("flag on: a seeded no-bundle Pro sub strikes through the usage wording", () => {
+    setObscureCredits(true);
+    const { getByRole } = renderPage(proMightySubscription());
+
+    fireEvent.click(getByRole("button", { name: "Configure" }));
+    selectOption("Usage bundle", "50 credits");
+
+    // The previous "none" value is struck with the same usage wording the
+    // sentinel row uses, so the recap never mixes the two vocabularies.
+    expect(strikethroughs()).toEqual(["No extra usage"]);
+  });
+
+  test("flag off: the picker keeps its credits wording", () => {
+    const { getByRole, getByText } = renderPage(freeSubscription());
+
+    fireEvent.click(getByRole("button", { name: "Configure" }));
+
+    getByText("Bundle some credits:");
+    selectTrigger("Credit bundle");
+    selectOption("Credit bundle", "No extra credits");
+    expect(recapRows()).toContain("No extra credits");
   });
 });

--- a/clients/web/src/domains/settings/billing/plans/custom-plan-modal.tsx
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-modal.tsx
@@ -39,7 +39,6 @@ import {
   computeCustomPlanDiff,
   NO_CREDITS_LABEL,
   NO_EXTRA_CREDITS,
-  NO_USAGE_LABEL,
 } from "./custom-plan-diff";
 import {
   CREDIT_DOCS_URL,
@@ -153,7 +152,9 @@ export function CustomPlanModal({
   // sentinel row) never names credits. The options themselves need no swap:
   // the catalog labels are already the usage bundles' Stripe product names.
   const obscureCredits = useObscureCredits();
-  const noBundleLabel = obscureCredits ? NO_USAGE_LABEL : NO_CREDITS_LABEL;
+  const noBundleLabel = obscureCredits
+    ? t("customPlanModal.noExtraUsage")
+    : NO_CREDITS_LABEL;
   const bundlePickerCopy = obscureCredits
     ? {
         label: t("customPlanModal.usageBundleLabel"),

--- a/clients/web/src/domains/settings/billing/plans/custom-plan-modal.tsx
+++ b/clients/web/src/domains/settings/billing/plans/custom-plan-modal.tsx
@@ -20,6 +20,7 @@ import type {
   StorageTier,
   StorageTierEnum,
 } from "@/generated/api/types.gen";
+import { useObscureCredits } from "@/hooks/use-obscure-credits-flag";
 import { useTranslation } from "@/i18n";
 import { handleNativeAnchorClick } from "@/utils/native-anchor";
 import { Button } from "@vellumai/design-library/components/button";
@@ -38,6 +39,7 @@ import {
   computeCustomPlanDiff,
   NO_CREDITS_LABEL,
   NO_EXTRA_CREDITS,
+  NO_USAGE_LABEL,
 } from "./custom-plan-diff";
 import {
   CREDIT_DOCS_URL,
@@ -147,6 +149,24 @@ export function CustomPlanModal({
   onContinue,
 }: CustomPlanModalProps) {
   const { t } = useTranslation("settings");
+  // Under `obscure-credits` the bundle picker's chrome (label, placeholder,
+  // sentinel row) never names credits. The options themselves need no swap:
+  // the catalog labels are already the usage bundles' Stripe product names.
+  const obscureCredits = useObscureCredits();
+  const noBundleLabel = obscureCredits ? NO_USAGE_LABEL : NO_CREDITS_LABEL;
+  const bundlePickerCopy = obscureCredits
+    ? {
+        label: t("customPlanModal.usageBundleLabel"),
+        docsLabel: t("customPlanModal.usageBundleDocsAriaLabel"),
+        ariaLabel: t("customPlanModal.usageBundleAriaLabel"),
+        placeholder: t("customPlanModal.usageBundlePlaceholder"),
+      }
+    : {
+        label: t("customPlanModal.creditsLabel"),
+        docsLabel: t("customPlanModal.creditsDocsAriaLabel"),
+        ariaLabel: t("customPlanModal.creditBundleAriaLabel"),
+        placeholder: t("customPlanModal.creditBundlePlaceholder"),
+      };
 
   // A Pro reconfigure seeds the current tiers so the default is a no-op; base
   // checkout passes none and leaves every dimension empty. A baseline machine
@@ -247,7 +267,7 @@ export function CustomPlanModal({
   const creditOptions: SelectOption<CreditChoice>[] = [
     {
       value: NO_EXTRA_CREDITS,
-      label: NO_CREDITS_LABEL,
+      label: noBundleLabel,
       icon: <Coins className="h-4 w-4" aria-hidden />,
     },
     ...selectableCreditTiers.map((t) => ({
@@ -330,8 +350,16 @@ export function CustomPlanModal({
         machineTier,
         storageTier,
         creditChoice,
+        noBundleLabel,
       }),
-    [proPlan, initialSelection, machineTier, storageTier, creditChoice],
+    [
+      proPlan,
+      initialSelection,
+      machineTier,
+      storageTier,
+      creditChoice,
+      noBundleLabel,
+    ],
   );
 
   const handleContinue = () => {
@@ -419,14 +447,14 @@ export function CustomPlanModal({
 
               <div className="flex flex-col gap-1">
                 <PickerLabel
-                  label={t("customPlanModal.creditsLabel")}
+                  label={bundlePickerCopy.label}
                   docsUrl={CREDIT_DOCS_URL}
-                  docsLabel={t("customPlanModal.creditsDocsAriaLabel")}
+                  docsLabel={bundlePickerCopy.docsLabel}
                   learnMore={t("customPlanModal.learnMore")}
                 />
                 <Select<CreditChoice>
-                  aria-label={t("customPlanModal.creditBundleAriaLabel")}
-                  placeholder={t("customPlanModal.creditBundlePlaceholder")}
+                  aria-label={bundlePickerCopy.ariaLabel}
+                  placeholder={bundlePickerCopy.placeholder}
                   value={creditChoice}
                   onChange={setCreditChoice}
                   options={creditOptions}

--- a/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.test.tsx
@@ -37,6 +37,7 @@ import * as platformGateMod from "@/hooks/use-platform-gate";
 import * as platformDetection from "@/runtime/platform-detection";
 import * as toastMod from "@vellumai/design-library/components/toast";
 import { avatarQueryKey } from "@/hooks/use-assistant-avatar";
+import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
 import { routes } from "@/utils/routes";
@@ -1637,5 +1638,49 @@ describe("PlansPage — Pro custom plan (change-tier)", () => {
     expect(getByTestId("loc").textContent).toBe("/assistant/plans");
     expect(machineTierCall).toBeNull();
     expect(upgradeCall).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// obscure-credits flag: the package rows never name a credit amount
+// ---------------------------------------------------------------------------
+
+/** Drives the `obscure-credits` client flag the way the app's LD sync does. */
+function setObscureCredits(value: boolean): void {
+  act(() => {
+    useClientFeatureFlagStore
+      .getState()
+      .setFlags({ obscureCredits: value }, null);
+  });
+}
+
+describe("PlansPage: obscure-credits flag", () => {
+  afterEach(() => {
+    setObscureCredits(false);
+  });
+
+  test("flag on: every package row reads as the package's usage, never as credits", async () => {
+    setObscureCredits(true);
+    const { findByText, getByText, queryByText, container } =
+      renderInteractive(freeSubscription());
+
+    // The name-derived usage rows, matching the plan card's obscured chip.
+    await findByText("Mighty usage, reset monthly");
+    getByText("Super usage, reset monthly");
+    getByText("Ultra usage, reset monthly");
+    // The obscured wording wins even though the fixtures carry a usage_label.
+    expect(queryByText("Mighty Usage included")).toBeNull();
+    // No card names a credit amount.
+    expect(container.textContent).not.toContain("in credits included");
+  });
+
+  test("flag on: a package with no usage_label still never falls back to credits", async () => {
+    setObscureCredits(true);
+    const { findByText, container } = renderInteractive(freeSubscription(), {
+      plans: plansWith([makeProPackage({ usage_label: null })]),
+    });
+
+    await findByText("Mighty usage, reset monthly");
+    expect(container.textContent).not.toContain("in credits included");
   });
 });

--- a/clients/web/src/domains/settings/billing/plans/plans-page.tsx
+++ b/clients/web/src/domains/settings/billing/plans/plans-page.tsx
@@ -30,9 +30,7 @@ import { PRICING_DOCS_URL } from "@/domains/settings/billing/plans/docs-links";
 import { FreeDowngradeConfirmModal } from "@/domains/settings/billing/plans/free-downgrade-confirm-modal";
 import { PackageSwitchConfirmModal } from "@/domains/settings/billing/plans/package-switch-confirm-modal";
 import { PlanColumnCard } from "@/domains/settings/billing/plans/plan-column-card";
-import {
-  getPlanTierCopy,
-} from "@/domains/settings/billing/plans/plans-copy";
+import { getPlanTierCopy } from "@/domains/settings/billing/plans/plans-copy";
 import { Trans, useTranslation } from "@/i18n";
 import {
   BillingOnboardingModal,
@@ -69,6 +67,7 @@ import type {
   SubscriptionUpgradeRequestRequest,
 } from "@/generated/api/types.gen";
 import { useIsOrgReady } from "@/hooks/use-is-org-ready";
+import { useObscureCredits } from "@/hooks/use-obscure-credits-flag";
 import {
   useActiveAssistantIsPlatformHosted,
   useActiveAssistantLifecycleIsLoading,
@@ -124,19 +123,27 @@ function packageFeatures(
   pkg: ProPackage,
   extra: readonly string[],
   translate: SettingsTranslate,
+  obscureCredits: boolean,
 ): string[] {
   const credits = pkg.credits_usd ?? FREE_CREDITS_USD;
   return [
     machineComputerLabel(pkg, translate),
     translate("plansPage.featureStorage", { gib: pkg.storage_gib }),
-    // The catalog's `usage_label` ("Mighty Usage") matches the bundle's
-    // Stripe product and thus the invoice; the amount wording covers a
-    // package with no usage label.
-    pkg.usage_label != null
-      ? translate("plansPage.featureUsageIncluded", { label: pkg.usage_label })
-      : translate("plansPage.featureCreditsIncluded", {
-          amount: formatDollars(credits * 100),
-        }),
+    // Under `obscure-credits` the bundle row never names a credit amount: it
+    // reads as the package's own usage allowance, derived from the package
+    // name the way the plan card's chip is, so it holds even when the catalog
+    // carries no `usage_label`. Otherwise the catalog's `usage_label`
+    // ("Mighty Usage") matches the bundle's Stripe product and thus the
+    // invoice; the amount wording covers a package with no usage label.
+    obscureCredits
+      ? translate("plansPage.featureUsage", { name: pkg.name })
+      : pkg.usage_label != null
+        ? translate("plansPage.featureUsageIncluded", {
+            label: pkg.usage_label,
+          })
+        : translate("plansPage.featureCreditsIncluded", {
+            amount: formatDollars(credits * 100),
+          }),
     ...extra,
   ];
 }
@@ -163,6 +170,7 @@ function PlansPageContent() {
   const [searchParams, setSearchParams] = useSearchParams();
   const queryClient = useQueryClient();
   const electron = isElectron();
+  const obscureCredits = useObscureCredits();
 
   const platformGate = usePlatformGate({ platformHostedOnly: true });
   const isPlatformHosted = useActiveAssistantIsPlatformHosted();
@@ -391,10 +399,7 @@ function PlansPageContent() {
       }
     } catch (error) {
       toast.error(
-        extractMutationError(
-          error,
-          t("plansPage.checkoutFailedToast"),
-        ),
+        extractMutationError(error, t("plansPage.checkoutFailedToast")),
       );
     } finally {
       setPending(false);
@@ -788,7 +793,9 @@ function PlansPageContent() {
             name="Base"
             tagline={freeCopy?.tagline ?? ""}
             priceLabel={t("plansPage.freePriceLabel")}
-            priceCaption={freeCopy?.priceCaption ?? t("plansPage.foreverCaption")}
+            priceCaption={
+              freeCopy?.priceCaption ?? t("plansPage.foreverCaption")
+            }
             ctaLabel={
               freeRelation === "downgrade"
                 ? t("plansPage.downgradeTo", { name: "Base" })
@@ -819,7 +826,12 @@ function PlansPageContent() {
                     ? t("plansPage.downgradeTo", { name: pkg.name })
                     : (copy?.cta ?? pkg.name)
                 }
-                features={packageFeatures(pkg, copy?.extraFeatures ?? [], t)}
+                features={packageFeatures(
+                  pkg,
+                  copy?.extraFeatures ?? [],
+                  t,
+                  obscureCredits,
+                )}
                 recommended={copy?.recommended}
                 tone={copy?.recommended ? "light" : "dark"}
                 isCurrent={currentTierKey === pkg.key}

--- a/clients/web/src/i18n/locales/en/settings.json
+++ b/clients/web/src/i18n/locales/en/settings.json
@@ -550,6 +550,10 @@
     "subtitle": "Just better.",
     "title": "Create a custom plan",
     "totalBilledMonthly": "Total · Billed monthly",
+    "usageBundleAriaLabel": "Usage bundle",
+    "usageBundleDocsAriaLabel": "Learn more about usage bundles",
+    "usageBundleLabel": "Add a usage bundle:",
+    "usageBundlePlaceholder": "Select a usage bundle",
     "yourSelection": "Your selection:"
   },
   "customPlanRow": {
@@ -1330,6 +1334,7 @@
     "featureComputer": "{machine} Computer",
     "featureCreditsIncluded": "{amount} in credits included",
     "featureStorage": "{gib} GB Storage",
+    "featureUsage": "{name} usage, reset monthly",
     "featureUsageIncluded": "{label} included",
     "foreverCaption": "Forever",
     "freeFeaturePayAsYouGo": "Pay-as-you-go credits",

--- a/clients/web/src/i18n/locales/en/settings.json
+++ b/clients/web/src/i18n/locales/en/settings.json
@@ -542,6 +542,7 @@
     "machineSizeDocsAriaLabel": "Learn more about machine sizes",
     "machineSizeLabel": "Select a machine size:",
     "machineSizePlaceholder": "Select a machine size",
+    "noExtraUsage": "No extra usage",
     "recap": "Recap",
     "storageAriaLabel": "Storage",
     "storageDocsAriaLabel": "Learn more about storage",

--- a/clients/web/src/i18n/locales/es/settings.json
+++ b/clients/web/src/i18n/locales/es/settings.json
@@ -550,6 +550,10 @@
     "subtitle": "Simplemente mejor.",
     "title": "Crear un plan personalizado",
     "totalBilledMonthly": "Total · Facturación mensual",
+    "usageBundleAriaLabel": "Paquete de uso",
+    "usageBundleDocsAriaLabel": "Más información sobre paquetes de uso",
+    "usageBundleLabel": "Añade un paquete de uso:",
+    "usageBundlePlaceholder": "Selecciona un paquete de uso",
     "yourSelection": "Tu selección:"
   },
   "customPlanRow": {
@@ -1330,6 +1334,7 @@
     "featureComputer": "Ordenador {machine}",
     "featureCreditsIncluded": "{amount} en créditos incluidos",
     "featureStorage": "{gib} GB de almacenamiento",
+    "featureUsage": "Uso de {name}, se restablece cada mes",
     "featureUsageIncluded": "{label} incluido",
     "foreverCaption": "Para siempre",
     "freeFeaturePayAsYouGo": "Créditos de pago por uso",

--- a/clients/web/src/i18n/locales/es/settings.json
+++ b/clients/web/src/i18n/locales/es/settings.json
@@ -542,6 +542,7 @@
     "machineSizeDocsAriaLabel": "Más información sobre tamaños de máquina",
     "machineSizeLabel": "Selecciona un tamaño de máquina:",
     "machineSizePlaceholder": "Selecciona un tamaño de máquina",
+    "noExtraUsage": "Sin uso adicional",
     "recap": "Resumen",
     "storageAriaLabel": "Almacenamiento",
     "storageDocsAriaLabel": "Más información sobre almacenamiento",

--- a/clients/web/src/i18n/locales/ru/settings.json
+++ b/clients/web/src/i18n/locales/ru/settings.json
@@ -550,6 +550,10 @@
     "subtitle": "Просто лучше.",
     "title": "Сборка плана",
     "totalBilledMonthly": "Итого · Ежемесячная оплата",
+    "usageBundleAriaLabel": "Пакет использования",
+    "usageBundleDocsAriaLabel": "Подробнее о пакетах использования",
+    "usageBundleLabel": "Добавить пакет использования:",
+    "usageBundlePlaceholder": "Выбор пакета использования",
     "yourSelection": "Выбор:"
   },
   "customPlanRow": {
@@ -1330,6 +1334,7 @@
     "featureComputer": "Компьютер {machine}",
     "featureCreditsIncluded": "Входит {amount} кредитами",
     "featureStorage": "{gib} ГБ хранилища",
+    "featureUsage": "Использование {name}, сброс каждый месяц",
     "featureUsageIncluded": "Входит {label}",
     "foreverCaption": "Навсегда",
     "freeFeaturePayAsYouGo": "Кредиты по мере использования",

--- a/clients/web/src/i18n/locales/ru/settings.json
+++ b/clients/web/src/i18n/locales/ru/settings.json
@@ -542,6 +542,7 @@
     "machineSizeDocsAriaLabel": "Подробнее о размерах машин",
     "machineSizeLabel": "Выбор размера машины:",
     "machineSizePlaceholder": "Выбор размера машины",
+    "noExtraUsage": "Без дополнительного использования",
     "recap": "Итого",
     "storageAriaLabel": "Хранилище",
     "storageDocsAriaLabel": "Подробнее о хранилище",


### PR DESCRIPTION
## Summary
- With the `obscure-credits` flag on, the View Plans takeover's package feature rows now render a name-derived usage row ("Mighty usage, reset monthly") instead of "$X in credits included". The obscured wording wins even over the catalog's `usage_label`, mirroring the billing plan card's chip, so it holds for catalogs that do not carry the label yet.
- The custom plan modal's bundle picker chrome (label, placeholder, aria-labels, docs link label) and the "No extra credits" sentinel (dropdown option, recap row, and its strikethrough) swap to usage wording under the flag. The dropdown's catalog options are untouched: their labels are already the usage bundles' Stripe product names.
- Adds the en/es/ru catalog keys and flag-on/flag-off tests for both surfaces.

## Original prompt
On the View All Plans page, the per-package line items still read as credits ("$X in credits included") even when the obscuring-credits feature flag is on; they should read as usage ("Mighty usage" etc.). The custom plan modal likewise shows credit messaging even though all of its options are usage bundles. Both surfaces should follow the obscuring-credits feature flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VrK2YgzbxTFYfHDVcfbtZq
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41286" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->