### PR TITLE
fix(providers): protect Gemini from JSON Schema tool refs

### DIFF
--- a/assistant/src/providers/openai/__tests__/orphan-tool-result-guard.test.ts
+++ b/assistant/src/providers/openai/__tests__/orphan-tool-result-guard.test.ts
@@ -145,7 +145,7 @@ const ID_SHAPES = [
 ] as const;
 
 /** History whose tool_result is paired with a preceding tool_use. */
-function pairedHistory(id: string): Message[] {
+function pairedHistory(id: string, result = "file contents"): Message[] {
   return [
     { role: "user", content: [{ type: "text", text: "Read the file" }] },
     {
@@ -165,7 +165,7 @@ function pairedHistory(id: string): Message[] {
         {
           type: "tool_result",
           tool_use_id: id,
-          content: "file contents",
+          content: result,
         },
       ],
     },
@@ -382,6 +382,38 @@ describe("OpenAIChatCompletionsProvider orphan tool_result guard", () => {
         content: "real output",
       },
     ]);
+  });
+
+  test("keeps JSON Schema references opaque for Gemini-compatible gateways", async () => {
+    const provider = makeProvider();
+    const stub = stubChatCreate(provider);
+    const schemaResult = JSON.stringify({
+      $defs: { LLMProvider: { type: "string" } },
+      properties: {
+        provider: { $ref: "#/$defs/LLMProvider" },
+      },
+    });
+
+    await provider.sendMessage(pairedHistory("call_schema", schemaResult));
+
+    const sent = stub.messages();
+    const toolMessage = sent.find((message) => message.role === "tool");
+    expect(toolMessage).toBeDefined();
+    expect(JSON.parse(toolMessage!.content as string)).toEqual({
+      output: schemaResult,
+    });
+  });
+
+  test("leaves ordinary JSON tool results unchanged", async () => {
+    const provider = makeProvider();
+    const stub = stubChatCreate(provider);
+    const ordinaryResult = JSON.stringify({ status: "ok", count: 3 });
+
+    await provider.sendMessage(pairedHistory("call_json", ordinaryResult));
+
+    const sent = stub.messages();
+    const toolMessage = sent.find((message) => message.role === "tool");
+    expect(toolMessage?.content).toBe(ordinaryResult);
   });
 });
 

--- a/assistant/src/providers/openai/chat-completions-provider.ts
+++ b/assistant/src/providers/openai/chat-completions-provider.ts
@@ -242,6 +242,60 @@ function isClientErrorStatus(error: unknown): boolean {
 }
 
 /**
+ * True when a parsed tool result contains a local JSON Schema reference.
+ *
+ * Gemini reserves `$ref` fields inside structured function responses for
+ * multimodal part references. OpenAI-compatible gateways can JSON-decode tool
+ * message content before translating it to Gemini, which makes a JSON Schema
+ * result look like one of those references and causes an INVALID_ARGUMENT.
+ */
+function containsLocalJsonSchemaReference(value: unknown): boolean {
+  const pending: unknown[] = [value];
+  while (pending.length > 0) {
+    const current = pending.pop();
+    if (Array.isArray(current)) {
+      pending.push(...current);
+      continue;
+    }
+    if (current === null || typeof current !== "object") {
+      continue;
+    }
+
+    const record = current as Record<string, unknown>;
+    const ref = record.$ref;
+    if (typeof ref === "string" && (ref === "#" || ref.startsWith("#/"))) {
+      return true;
+    }
+    pending.push(...Object.values(record));
+  }
+  return false;
+}
+
+/**
+ * Keep JSON Schema tool results opaque across OpenAI-compatible gateways.
+ *
+ * The outer object is intentionally valid JSON so gateways that decode tool
+ * content produce `{ output: string }`; the schema's `$ref` remains inside the
+ * string and cannot be interpreted as a Gemini multimodal part reference.
+ */
+function protectJsonSchemaToolResult(payload: string): string {
+  if (!payload.includes('"$ref"')) {
+    return payload;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(payload);
+  } catch {
+    return payload;
+  }
+
+  return containsLocalJsonSchemaReference(parsed)
+    ? JSON.stringify({ output: payload })
+    : payload;
+}
+
+/**
  * True when the request carried an explicit reasoning opt-out (`"none"` sent
  * as flat `reasoning_effort` or nested `reasoning.effort`) and the provider
  * rejected it with a 4xx that names the reasoning field. Reasoning-only
@@ -1292,7 +1346,7 @@ export class OpenAIChatCompletionsProvider implements Provider {
           result.push({
             role: "tool",
             tool_call_id: tr.tool_use_id,
-            content: serialized.payload,
+            content: protectJsonSchemaToolResult(serialized.payload),
           });
         }
 


### PR DESCRIPTION
## Summary
- wrap JSON Schema tool results containing local `$ref` pointers as opaque output strings on Chat Completions
- preserve ordinary JSON payloads unchanged and cover the regression with focused tests

## Original prompt
Fix Gemini/OpenRouter 400 INVALID_ARGUMENT failures when conversation history includes a tool result containing JSON Schema references such as `#/$defs/LLMProvider`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41287" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->