### PR TITLE
Consolidate boot-critical chunks: 339 requests down to 9

### DIFF
--- a/clients/web/vite.config.ts
+++ b/clients/web/vite.config.ts
@@ -19,6 +19,21 @@ const ASSISTANT_API_SRC = path.resolve(
   "../../assistant/src/api",
 );
 
+/**
+ * Chunk-group predicate matching a module by the package directory that owns
+ * it. The trailing separator is what keeps `react` from also capturing
+ * `react-dom`, `react-router`, `react-markdown`, and friends.
+ */
+function inPackages(...names: string[]): (id: string) => boolean {
+  const escaped = names.map((name) =>
+    name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"),
+  );
+  const pattern = new RegExp(
+    `[\\\\/]node_modules[\\\\/](?:${escaped.join("|")})[\\\\/]`,
+  );
+  return (id: string) => pattern.test(id);
+}
+
 // Keep in sync with PLATFORM_MODE_TRUTHY in src/lib/local-mode.ts
 const PLATFORM_MODE_TRUTHY = new Set(["1", "true", "yes"]);
 function isPlatformMode(raw: string | undefined): boolean {
@@ -195,6 +210,60 @@ export default defineConfig(({ mode }) => {
       // reach the deployed artifact. Without the token, skip generation
       // entirely to avoid shipping maps in non-Sentry builds.
       sourcemap: sentryUploadEnabled ? "hidden" : false,
+      // Chunking is tuned for a cold cache on a phone, which is what every
+      // deploy hands users. Automatic splitting emitted 335 boot-critical
+      // files, 260 of them under 5 kB, and the browser opens all of them at
+      // once because `index.html` modulepreloads every one. The request
+      // storm, not the byte count, is what made cold boot slow: these groups
+      // take boot from 339 JS requests to 9.
+      //
+      // INVARIANT when editing these groups: boot-critical bytes must not
+      // grow. Boot-critical is the entry script plus every modulepreload
+      // target in `dist/index.html`. Every group is tagged `$initial`, which
+      // restricts it to modules statically reachable from the entry, so
+      // lazy-only code (pdfjs, xterm, tiptap, per-route pages) can never be
+      // merged into something boot has to fetch. Dropping a `$initial` tag,
+      // or adding an untagged group, is how that gets broken. A build should
+      // leave 4 modulepreload links in `dist/index.html` and no lazy-only
+      // package in the chunks they point at.
+      //
+      // The lazy side is deliberately left to automatic chunking. Collapsing
+      // it too with an `entriesAware` group does reach ~25 total files, but
+      // some of those builds deadlock the dynamic-import runtime and render
+      // a blank page with no build warning and no console error, and which
+      // builds break is not stable across runs of the same config.
+      rolldownOptions: {
+        output: {
+          codeSplitting: {
+            groups: [
+              {
+                name: "react",
+                test: inPackages(
+                  "react",
+                  "react-dom",
+                  "react-router",
+                  "scheduler",
+                ),
+                tags: ["$initial"],
+                priority: 50,
+              },
+              {
+                name: "icons",
+                test: inPackages("lucide-react"),
+                tags: ["$initial"],
+                priority: 45,
+              },
+              {
+                name: "vendor",
+                test: /[\\/]node_modules[\\/]/,
+                tags: ["$initial"],
+                priority: 40,
+              },
+              { name: "app", tags: ["$initial"], priority: 30 },
+            ],
+          },
+        },
+      },
     },
   };
 });

--- a/clients/web/vite.config.ts
+++ b/clients/web/vite.config.ts
@@ -211,11 +211,10 @@ export default defineConfig(({ mode }) => {
       // entirely to avoid shipping maps in non-Sentry builds.
       sourcemap: sentryUploadEnabled ? "hidden" : false,
       // Chunking is tuned for a cold cache on a phone, which is what every
-      // deploy hands users. Automatic splitting emitted 335 boot-critical
-      // files, 260 of them under 5 kB, and the browser opens all of them at
-      // once because `index.html` modulepreloads every one. The request
-      // storm, not the byte count, is what made cold boot slow: these groups
-      // take boot from 339 JS requests to 9.
+      // deploy hands users: `index.html` modulepreloads the whole boot
+      // graph, and hundreds of tiny chunks fetched at once stall a congested
+      // mobile connection far more than the same bytes in a few files. These
+      // groups collapse the boot graph to a handful of requests.
       //
       // INVARIANT when editing these groups: boot-critical bytes must not
       // grow. Boot-critical is the entry script plus every modulepreload
@@ -223,15 +222,15 @@ export default defineConfig(({ mode }) => {
       // restricts it to modules statically reachable from the entry, so
       // lazy-only code (pdfjs, xterm, tiptap, per-route pages) can never be
       // merged into something boot has to fetch. Dropping a `$initial` tag,
-      // or adding an untagged group, is how that gets broken. A build should
-      // leave 4 modulepreload links in `dist/index.html` and no lazy-only
-      // package in the chunks they point at.
+      // or adding an untagged group, is how that gets broken. A healthy
+      // build leaves a single-digit modulepreload count in `dist/index.html`
+      // and no lazy-only package in the chunks it points at.
       //
       // The lazy side is deliberately left to automatic chunking. Collapsing
-      // it too with an `entriesAware` group does reach ~25 total files, but
-      // some of those builds deadlock the dynamic-import runtime and render
-      // a blank page with no build warning and no console error, and which
-      // builds break is not stable across runs of the same config.
+      // it too with an `entriesAware` group can deadlock the dynamic-import
+      // runtime into a blank page with no build warning and no console
+      // error, and which builds break is not stable across runs of the same
+      // config.
       rolldownOptions: {
         output: {
           codeSplitting: {


### PR DESCRIPTION
## Why

The 2026-08-24 iOS cold-boot investigation measured 30+ seconds from tap to usable app. Root cause: the build emits ~335 boot-critical chunks (260 of them under 5 kB) and `index.html` modulepreloads every one, so a cold cache (which every dev deploy creates, since all hashes change) opens hundreds of concurrent streams over one congested mobile connection. Individual small chunks stalled 10-29 s behind the storm. The request count, not the byte count, was the bottleneck.

## What

Four `$initial`-tagged `codeSplitting` groups in `vite.config.ts` (Vite 8 / Rolldown; `advancedChunks` and `rollupOptions` are deprecated in favor of `codeSplitting` / `rolldownOptions` per the installed types and Vite's own build warning):

- `react` (react, react-dom, react-router, scheduler): the most stable bytes, best long-term cache hit rate
- `icons` (lucide-react): collapses ~100 per-icon files
- `vendor`: remaining statically-reachable third-party code
- `app`: first-party boot code

The `$initial` tag is the structural lazy-leak guard: every group is restricted to modules statically reachable from the entry, so lazy-only code (pdfjs, tiptap, xterm, per-route pages) cannot be merged into anything boot fetches. The lazy side deliberately keeps automatic splitting: collapsing it too (via `entriesAware`) reached ~25 total files but nondeterministically produced builds whose dynamic-import runtime deadlocks into a blank page with no build warning and no console error. The config comment records both the invariant and that hazard.

## Measurements (platform-mode build, headless-Chromium boot against `vite preview`)

| | baseline | this PR |
|---|---|---|
| Real boot JS requests | **339** | **9** |
| modulepreload links | 334 | 4 |
| Boot-critical gzip | 1252.4 kB | **1123.1 kB (-10.3%)** |
| Total JS files | 547 | 217 |
| Total gzip | 2390.9 kB | 2233.7 kB |

Lazy placement verified byte-for-byte against baseline (pdfjs, katex, xterm, tiptap/prosemirror, micromark, stripe, jszip, logrocket, qrcode signatures; all within 0.1%, none entered the boot set). `share-feedback-modal` stays its own non-preloaded chunk. Smoke test: preview build mounts React and renders the login screen identically to baseline with zero module-load errors.

## Risks

- The `index` chunk is one 2.1 MB raw file: same boot bytes as before in one request, but any boot-graph change re-hashes it, so prod users re-download it each deploy (they previously re-downloaded most of the graph anyway).
- The `$initial` invariant is load-bearing; the config comment states the check (4 modulepreloads in `dist/index.html`, no lazy-only package inside them).
- Two pre-existing `INEFFECTIVE_DYNAMIC_IMPORT` warnings (`avatar-bundled-components`, `native-file`) surfaced by the merge; both were already boot-critical before. Follow-up candidates.

## Follow-up measurement plan

After this deploys to dev: compare `client_boot.*` (ttfb through `react_mount` / `chat_interactive`) in `telemetry.watchdog_raw` before vs after the deploy for surface `ios_native`, and repeat the on-device cold-boot test that produced the 30 s report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)