### PR TITLE
fix(profiles): hide managed backups from user selectors

### DIFF
--- a/assistant/src/__tests__/conversation-slash.test.ts
+++ b/assistant/src/__tests__/conversation-slash.test.ts
@@ -36,6 +36,7 @@ describe("/model list", () => {
     expect(message).toContain("`balanced`");
     expect(message).toContain("`quality-optimized`");
     expect(message).toContain("`cost-optimized`");
+    expect(message).not.toContain("`balanced-backup`");
   });
 
   test("default profile descriptions follow the default provider's column", async () => {
@@ -71,6 +72,14 @@ describe("/model list", () => {
 });
 
 describe("/model switch", () => {
+  test("rejects a managed backup profile as a direct selection", async () => {
+    const result = await resolveSlash("/model balanced-backup");
+    expect(result.kind).toBe("unknown");
+    expect((result as { message: string }).message).toContain(
+      "Profile `balanced-backup` not found",
+    );
+  });
+
   test("rejects an unknown profile with the available set", async () => {
     const result = await resolveSlash("/model nope");
     expect(result.kind).toBe("unknown");

--- a/assistant/src/__tests__/plugin-api-model-profiles.test.ts
+++ b/assistant/src/__tests__/plugin-api-model-profiles.test.ts
@@ -64,12 +64,8 @@ describe("getModelProfiles", () => {
       "balanced",
       "cost-optimized",
       "alpha",
-      "balanced-backup",
-      "cost-optimized-backup",
       "latency-optimized",
-      "latency-optimized-backup",
       "quality-optimized",
-      "quality-optimized-backup",
       "zeta",
     ]);
   });
@@ -99,13 +95,9 @@ describe("getModelProfiles", () => {
       ["beta", false],
       ["blend", true],
       ["balanced", false],
-      ["balanced-backup", false],
       ["cost-optimized", false],
-      ["cost-optimized-backup", false],
       ["latency-optimized", false],
-      ["latency-optimized-backup", false],
       ["quality-optimized", false],
-      ["quality-optimized-backup", false],
     ]);
   });
 
@@ -153,13 +145,9 @@ describe("getModelProfiles", () => {
       ["alpha", false],
       ["beta", true],
       ["balanced", false],
-      ["balanced-backup", false],
       ["cost-optimized", false],
-      ["cost-optimized-backup", false],
       ["latency-optimized", false],
-      ["latency-optimized-backup", false],
       ["quality-optimized", false],
-      ["quality-optimized-backup", false],
     ]);
   });
 
@@ -202,13 +190,9 @@ describe("getModelProfiles", () => {
       ["alpha", false],
       ["beta", true],
       ["balanced", false],
-      ["balanced-backup", false],
       ["cost-optimized", false],
-      ["cost-optimized-backup", false],
       ["latency-optimized", false],
-      ["latency-optimized-backup", false],
       ["quality-optimized", false],
-      ["quality-optimized-backup", false],
     ]);
   });
 
@@ -246,13 +230,9 @@ describe("getModelProfiles", () => {
         .sort(),
     ).toEqual([
       "balanced",
-      "balanced-backup",
       "cost-optimized",
-      "cost-optimized-backup",
       "latency-optimized",
-      "latency-optimized-backup",
       "quality-optimized",
-      "quality-optimized-backup",
     ]);
   });
 });

--- a/assistant/src/__tests__/workspace-migration-148-strip-unsupported-fallback-profiles.test.ts
+++ b/assistant/src/__tests__/workspace-migration-148-strip-unsupported-fallback-profiles.test.ts
@@ -43,11 +43,11 @@ afterEach(() => {
 });
 
 describe("148-strip-unsupported-fallback-profiles migration", () => {
-  test("has the next migration id and is registered last", () => {
+  test("has the next migration id and is registered", () => {
     expect(stripUnsupportedFallbackProfilesMigration.id).toBe(
       "148-strip-unsupported-fallback-profiles",
     );
-    expect(WORKSPACE_MIGRATIONS.at(-1)?.id).toBe(
+    expect(WORKSPACE_MIGRATIONS.map((migration) => migration.id)).toContain(
       "148-strip-unsupported-fallback-profiles",
     );
   });

--- a/assistant/src/__tests__/workspace-migration-149-repoint-backup-profile-selections.test.ts
+++ b/assistant/src/__tests__/workspace-migration-149-repoint-backup-profile-selections.test.ts
@@ -1,0 +1,142 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { repointBackupProfileSelectionsMigration } from "../workspace/migrations/149-repoint-backup-profile-selections.js";
+import { WORKSPACE_MIGRATIONS } from "../workspace/migrations/registry.js";
+import { assertNotLiveDb } from "./assert-not-live-db.js";
+
+let workspaceDir: string;
+
+function dbPath(): string {
+  return join(workspaceDir, "data", "db", "assistant.db");
+}
+
+function writeConfig(data: Record<string, unknown>): void {
+  writeFileSync(
+    join(workspaceDir, "config.json"),
+    JSON.stringify(data, null, 2) + "\n",
+  );
+}
+
+function readConfig(): Record<string, any> {
+  return JSON.parse(readFileSync(join(workspaceDir, "config.json"), "utf-8"));
+}
+
+function seedProfilePinTables(): void {
+  mkdirSync(join(workspaceDir, "data", "db"), { recursive: true });
+  const db = new Database(dbPath());
+  db.run(
+    "CREATE TABLE conversations (id TEXT PRIMARY KEY, inference_profile TEXT)",
+  );
+  db.run(
+    "CREATE TABLE cron_jobs (id TEXT PRIMARY KEY, inference_profile TEXT)",
+  );
+  db.query(
+    "INSERT INTO conversations (id, inference_profile) VALUES (?, ?)",
+  ).run("conv-1", "quality-optimized-backup");
+  db.query("INSERT INTO cron_jobs (id, inference_profile) VALUES (?, ?)").run(
+    "job-1",
+    "balanced-backup",
+  );
+  db.close();
+}
+
+function readPins(table: "conversations" | "cron_jobs"): string[] {
+  const db = new Database(dbPath());
+  try {
+    return (
+      db
+        .query(`SELECT inference_profile AS profile FROM ${table} ORDER BY id`)
+        .all() as Array<{ profile: string }>
+    ).map((row) => row.profile);
+  } finally {
+    db.close();
+  }
+}
+
+beforeEach(() => {
+  workspaceDir = join(
+    tmpdir(),
+    `vellum-migration-149-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(workspaceDir, { recursive: true });
+});
+
+afterEach(() => {
+  if (existsSync(workspaceDir)) {
+    assertNotLiveDb(workspaceDir);
+    rmSync(workspaceDir, { recursive: true, force: true });
+  }
+});
+
+describe("149-repoint-backup-profile-selections migration", () => {
+  test("is registered as the current migration", () => {
+    expect(repointBackupProfileSelectionsMigration.id).toBe(
+      "149-repoint-backup-profile-selections",
+    );
+    expect(WORKSPACE_MIGRATIONS.at(-1)?.id).toBe(
+      "149-repoint-backup-profile-selections",
+    );
+  });
+
+  test("repoints direct config selections and preserves fallback metadata", async () => {
+    writeConfig({
+      llm: {
+        activeProfile: "balanced-backup",
+        advisorProfile: "quality-optimized-backup",
+        profileOrder: ["balanced", "balanced-backup"],
+        callSites: {
+          mainAgent: { profile: "cost-optimized-backup" },
+        },
+        profiles: {
+          custom: {
+            mix: [{ profile: "latency-optimized-backup", weight: 1 }],
+          },
+          balanced: {
+            source: "managed",
+            fallbackProfile: "balanced-backup",
+          },
+        },
+      },
+    });
+
+    await repointBackupProfileSelectionsMigration.run(workspaceDir);
+
+    const llm = readConfig().llm;
+    expect(llm.activeProfile).toBe("balanced");
+    expect(llm.advisorProfile).toBe("quality-optimized");
+    expect(llm.callSites.mainAgent.profile).toBe("cost-optimized");
+    expect(llm.profiles.custom.mix[0].profile).toBe("latency-optimized");
+    expect(llm.profiles.balanced.fallbackProfile).toBe("balanced-backup");
+    expect(llm.profileOrder).toEqual(["balanced", "balanced-backup"]);
+  });
+
+  test("repoints conversation and schedule pins", async () => {
+    seedProfilePinTables();
+
+    await repointBackupProfileSelectionsMigration.run(workspaceDir);
+
+    expect(readPins("conversations")).toEqual(["quality-optimized"]);
+    expect(readPins("cron_jobs")).toEqual(["balanced"]);
+  });
+
+  test("is idempotent and tolerates a missing config or database", async () => {
+    await expect(
+      repointBackupProfileSelectionsMigration.run(workspaceDir),
+    ).resolves.toBeUndefined();
+
+    writeConfig({ llm: { activeProfile: "balanced" } });
+    const before = readConfig();
+    await repointBackupProfileSelectionsMigration.run(workspaceDir);
+    expect(readConfig()).toEqual(before);
+  });
+});

--- a/assistant/src/config/__tests__/default-profile-catalog.test.ts
+++ b/assistant/src/config/__tests__/default-profile-catalog.test.ts
@@ -8,6 +8,7 @@ import {
   getEffectiveProfile,
   getEffectiveProfiles,
   getEffectiveProfilesForProvider,
+  getUserSelectableProfilesForProvider,
   PROFILE_IMPLS,
   resolveDefaultProfileForProvider,
 } from "../default-profile-catalog.js";
@@ -153,6 +154,25 @@ describe("getEffectiveProfiles", () => {
       CODE_DEFAULT_PROFILE_ENTRIES.balanced.model as string,
     );
     expect(after.balanced.model).toBe("claude-sonnet-4-6");
+  });
+});
+
+describe("user-selectable profile view", () => {
+  test("hides managed backups while retaining them in the fallback catalog", () => {
+    const effective = getEffectiveProfilesForProvider(undefined, {
+      provider: "vellum",
+    });
+    const selectable = getUserSelectableProfilesForProvider(undefined, {
+      provider: "vellum",
+    });
+
+    for (const key of DEFAULT_PROFILE_KEYS) {
+      expect(selectable[key]).toBeDefined();
+    }
+    for (const key of BACKUP_PROFILE_KEYS) {
+      expect(effective[key]).toBeDefined();
+      expect(selectable[key]).toBeUndefined();
+    }
   });
 });
 

--- a/assistant/src/config/default-profile-catalog.ts
+++ b/assistant/src/config/default-profile-catalog.ts
@@ -428,7 +428,7 @@ export const PROFILE_IMPLS: Record<
 /**
  * Managed profiles, i.e. the `vellum` column keyed by profile name, plus the
  * managed backup profiles. Backups come after the primaries, which is what
- * places them after the primaries in `profileOrder` presentation: the seeder
+ * places them after the primaries in the seeded `profileOrder`: the seeder
  * inserts missing managed keys in this record's order. Keyed by the
  * user-facing defaults only: an internal profile is code-resolved and never
  * listed or ordered.
@@ -907,12 +907,11 @@ function clampMaxTokensToModelCap(body: ProfileEntry): ProfileEntry {
  *
  * Deliberately provider-agnostic: it lists the managed backups whatever
  * `llm.defaultProvider` says, because it resolves names against the passed
- * catalog alone and never reads config. Any caller that JUDGES AVAILABILITY
- * (is this name selectable? does this reference still resolve?) must use
- * `getEffectiveProfilesForProvider` instead, which hides the backups on the
- * BYOK and ChatGPT columns the same way `resolveDefaultProfileForProvider`
- * does. Duplicating that conditioning here would fork the rule across two
- * functions, and the sibling already owns it.
+ * catalog alone and never reads config. Internal resolution and reference
+ * validation use `getEffectiveProfilesForProvider`; user-facing selectors use
+ * `getUserSelectableProfilesForProvider`, which additionally removes backups
+ * from the managed column. Keeping those views separate lets automatic
+ * fallback resolve an internal route without offering it as a direct choice.
  */
 export function getEffectiveProfiles(
   workspaceProfiles: Record<string, ProfileEntry> | undefined,
@@ -964,4 +963,23 @@ export function getEffectiveProfilesForProvider(
     delete effective[name];
   }
   return effective;
+}
+
+/**
+ * The effective profile view used by user-facing selectors. Managed backups
+ * remain in the full effective catalog for automatic fallback resolution, but
+ * are internal routes rather than profiles a user can choose directly.
+ */
+export function getUserSelectableProfilesForProvider(
+  workspaceProfiles: Record<string, ProfileEntry> | undefined,
+  defaultProvider: DefaultProviderConfig | null,
+): Record<string, ProfileEntry> {
+  const selectable = getEffectiveProfilesForProvider(
+    workspaceProfiles,
+    defaultProvider,
+  );
+  for (const name of BACKUP_PROFILE_KEYS) {
+    delete selectable[name];
+  }
+  return selectable;
 }

--- a/assistant/src/config/inference-profile-validation.ts
+++ b/assistant/src/config/inference-profile-validation.ts
@@ -1,4 +1,4 @@
-import { getEffectiveProfilesForProvider } from "./default-profile-catalog.js";
+import { getUserSelectableProfilesForProvider } from "./default-profile-catalog.js";
 import { getConfigReadOnly } from "./loader.js";
 
 /**
@@ -6,17 +6,17 @@ import { getConfigReadOnly } from "./loader.js";
  * (code-defined defaults + workspace `llm.profiles`). Returns a user-facing
  * error message when the key is empty or unknown, or `null` when valid.
  *
- * Resolved through the `llm.defaultProvider`-aware view so availability
- * matches what actually dispatches: the managed backup profiles exist on the
- * managed column only, so on a BYOK or ChatGPT install they are not
- * selectable and must not be reported as available.
+ * Resolved through the `llm.defaultProvider`-aware user-selectable view so
+ * availability matches what a direct profile pin can choose. Managed backup
+ * routes remain available to automatic fallback resolution but are not
+ * reported as selectable profiles.
  */
 export function validateInferenceProfileKey(profile: string): string | null {
   if (!profile.trim()) {
     return "inferenceProfile must be a non-empty string";
   }
   const llm = getConfigReadOnly().llm;
-  const profiles = getEffectiveProfilesForProvider(
+  const profiles = getUserSelectableProfilesForProvider(
     llm?.profiles,
     llm?.defaultProvider ?? null,
   );

--- a/assistant/src/daemon/conversation-slash.ts
+++ b/assistant/src/daemon/conversation-slash.ts
@@ -1,5 +1,5 @@
 import type { InterfaceId } from "../channels/types.js";
-import { getEffectiveProfilesForProvider } from "../config/default-profile-catalog.js";
+import { getUserSelectableProfilesForProvider } from "../config/default-profile-catalog.js";
 import { resolveEffectiveContextWindow } from "../config/llm-context-resolution.js";
 import { resolveCallSiteConfig } from "../config/llm-resolver.js";
 import {
@@ -148,7 +148,7 @@ async function resolveModelCommand(
   parse: ModelCommandParse,
 ): Promise<SlashResolution> {
   const config = getConfig();
-  const profiles = getEffectiveProfilesForProvider(
+  const profiles = getUserSelectableProfilesForProvider(
     config.llm.profiles,
     config.llm.defaultProvider ?? null,
   );

--- a/assistant/src/plugin-api/model-profiles.test.ts
+++ b/assistant/src/plugin-api/model-profiles.test.ts
@@ -61,17 +61,13 @@ describe("getModelProfiles", () => {
 
     const result = listProfiles();
     // The code-catalog defaults are always present; the two workspace
-    // entries shadow their catalog counterparts, and the remaining catalog
-    // defaults (managed backups included) sort after the explicit order.
+    // entries shadow their catalog counterparts, and managed backups remain
+    // internal fallback routes rather than picker options.
     expect(result.map((p) => p.key)).toEqual([
       "balanced",
       "quality-optimized",
-      "balanced-backup",
       "cost-optimized",
-      "cost-optimized-backup",
       "latency-optimized",
-      "latency-optimized-backup",
-      "quality-optimized-backup",
     ]);
   });
 
@@ -88,14 +84,10 @@ describe("getModelProfiles", () => {
     const result = listProfiles();
     expect(result.map((p) => p.key).sort()).toEqual([
       "balanced",
-      "balanced-backup",
       "cost-optimized",
-      "cost-optimized-backup",
       "disabled",
       "latency-optimized",
-      "latency-optimized-backup",
       "quality-optimized",
-      "quality-optimized-backup",
     ]);
     const disabled = result.find((p) => p.key === "disabled");
     expect(disabled?.isDisabled).toBe(true);
@@ -131,13 +123,9 @@ describe("getModelProfiles", () => {
       "provider-only",
       "mix",
       "balanced",
-      "balanced-backup",
       "cost-optimized",
-      "cost-optimized-backup",
       "latency-optimized",
-      "latency-optimized-backup",
       "quality-optimized",
-      "quality-optimized-backup",
     ]);
   });
 
@@ -145,13 +133,9 @@ describe("getModelProfiles", () => {
     const result = listProfiles();
     expect(result.map((p) => p.key).sort()).toEqual([
       "balanced",
-      "balanced-backup",
       "cost-optimized",
-      "cost-optimized-backup",
       "latency-optimized",
-      "latency-optimized-backup",
       "quality-optimized",
-      "quality-optimized-backup",
     ]);
     for (const profile of result) {
       expect(profile.isDisabled).toBe(false);

--- a/assistant/src/plugin-api/model-profiles.ts
+++ b/assistant/src/plugin-api/model-profiles.ts
@@ -1,15 +1,15 @@
-import { getEffectiveProfilesForProvider } from "../config/default-profile-catalog.js";
+import { getUserSelectableProfilesForProvider } from "../config/default-profile-catalog.js";
 import { getConfig } from "../config/loader.js";
 import { isDispatchableProfile } from "../config/profile-dispatchability.js";
 import { orderProfileKeys } from "../config/profile-order.js";
 import type { ModelProfileInfo } from "./types.js";
 
 /**
- * List the workspace inference profiles a plugin can route to, in the order the
- * `/model` picker presents them (`llm.profileOrder` first, then the rest
- * alphabetically). Metadata-only entries without a provider, model, or mix are
- * not routing targets, so plugins never see them. Disabled profiles are
- * included and flagged via
+ * List the workspace inference profiles a plugin can route to, in the order a
+ * user-facing model picker presents them (`llm.profileOrder` first, then the
+ * rest alphabetically). Managed backup routes are internal and omitted.
+ * Metadata-only entries without a provider, model, or mix are not routing
+ * targets, so plugins never see them. Disabled profiles are included and flagged via
  * {@link ModelProfileInfo.isDisabled}; weighted "mix" profiles are included and
  * flagged via {@link ModelProfileInfo.isMix}, since a mix is itself a valid
  * routing target (it resolves to one constituent per conversation).
@@ -20,7 +20,7 @@ import type { ModelProfileInfo } from "./types.js";
 export function getModelProfiles(): ModelProfileInfo[] {
   const { llm } = getConfig();
   const { activeProfile } = llm;
-  const profiles = getEffectiveProfilesForProvider(
+  const profiles = getUserSelectableProfilesForProvider(
     llm.profiles,
     llm.defaultProvider ?? null,
   );

--- a/assistant/src/plugins/defaults/memory/src/memory-v2-routes.ts
+++ b/assistant/src/plugins/defaults/memory/src/memory-v2-routes.ts
@@ -7,7 +7,7 @@ import { join } from "node:path";
 
 import { z } from "zod";
 
-import { getEffectiveProfilesForProvider } from "../../../../config/default-profile-catalog.js";
+import { getUserSelectableProfilesForProvider } from "../../../../config/default-profile-catalog.js";
 import { loadConfig } from "../../../../config/loader.js";
 import { usesConceptPageMemory } from "../../../../config/memory-v3-gate.js";
 import type { AssistantConfig } from "../../../../config/types.js";
@@ -523,7 +523,7 @@ export async function handleSimulateRouter({
   // through (the resolver tolerates missing override-profile references by
   // design, but the playground wants the user to know they typo'd).
   if (profileOverride !== undefined) {
-    const profiles = getEffectiveProfilesForProvider(
+    const profiles = getUserSelectableProfilesForProvider(
       liveConfig.llm?.profiles,
       liveConfig.llm?.defaultProvider ?? null,
     );

--- a/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/conversation-query-routes.test.ts
@@ -50,6 +50,7 @@ mock.module("../../../persistence/embeddings/embedding-backend.js", () => ({
   },
 }));
 
+import { BACKUP_PROFILE_KEYS } from "../../../config/default-profile-names.js";
 import { getConfig, loadRawConfig } from "../../../config/loader.js";
 import { LLMConfigBase } from "../../../config/schemas/llm.js";
 import type { ConversationCreateType } from "../../../persistence/conversation-types.js";
@@ -1779,6 +1780,16 @@ describe("config invariant flag enrichment", () => {
     for (const name of ["balanced", "quality-optimized", "latency-optimized"]) {
       expect(profiles[name]!.invariant).toBe(true);
     }
+  });
+
+  test("GET /v1/config hides managed backups from the picker catalog", async () => {
+    const body = await configGetRoute.handler({});
+    const profiles = wireProfiles(body);
+
+    for (const name of BACKUP_PROFILE_KEYS) {
+      expect(profiles).not.toHaveProperty(name);
+    }
+    expect(profiles.balanced).toBeDefined();
   });
 
   test("PATCH /v1/config stamps the flag on the response but never persists it", async () => {

--- a/assistant/src/runtime/routes/__tests__/inference-profiles-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/inference-profiles-routes.test.ts
@@ -64,6 +64,7 @@ mock.module("../../sync/resource-sync-events.js", () => ({
 // ── Real imports (after mocks) ────────────────────────────────────────────────
 
 import { setConfig } from "../../../__tests__/helpers/set-config.js";
+import { BACKUP_PROFILE_KEYS } from "../../../config/default-profile-names.js";
 import { loadRawConfig } from "../../../config/loader.js";
 import { getDb } from "../../../persistence/db-connection.js";
 import { initializeDb } from "../../../persistence/db-init.js";
@@ -728,6 +729,20 @@ describe("DELETE inference/profiles/:name reference guard", () => {
 // ── provider-aware list/get (Finding 2) ───────────────────────────────────────
 
 describe("GET inference/profiles honors llm.defaultProvider", () => {
+  test("omits managed backup routes from the user-facing catalog", async () => {
+    setConfig("llm", { profiles: {} });
+
+    const listed = (await call("inference_profiles_list", {})) as {
+      profiles: Array<{ name: string }>;
+    };
+    const names = new Set(listed.profiles.map((profile) => profile.name));
+
+    for (const key of BACKUP_PROFILE_KEYS) {
+      expect(names.has(key)).toBe(false);
+    }
+    expect(names.has("balanced")).toBe(true);
+  });
+
   test("expands balanced through a BYOK default provider, not the vellum column", async () => {
     setConfig("llm", {
       defaultProvider: { provider: "anthropic" },

--- a/assistant/src/runtime/routes/conversation-query-routes.ts
+++ b/assistant/src/runtime/routes/conversation-query-routes.ts
@@ -157,6 +157,7 @@ type LlmContextRouteResult = Omit<LlmContextNormalizationResult, "summary"> & {
 import {
   CODE_OWNED_PROFILE_NAMES,
   getEffectiveProfilesForProvider,
+  getUserSelectableProfilesForProvider,
   INVARIANT_PROFILE_NAMES,
   MANAGED_PROFILE_NAMES,
   resolveDefaultProfileForProvider,
@@ -899,7 +900,7 @@ function overlayEffectiveProfilesForWire(config: unknown): void {
   if (!existingLlm) {
     root.llm = llm;
   }
-  llm.profiles = getEffectiveProfilesForProvider(
+  llm.profiles = getUserSelectableProfilesForProvider(
     readPlainObject(llm.profiles) as Record<string, ProfileEntry> | undefined,
     getConfig().llm.defaultProvider ?? null,
   );

--- a/assistant/src/runtime/routes/conversation-routes.ts
+++ b/assistant/src/runtime/routes/conversation-routes.ts
@@ -39,7 +39,7 @@ import {
   supportsHostProxy,
 } from "../../channels/types.js";
 import { isAssistantFeatureFlagEnabled } from "../../config/assistant-feature-flags.js";
-import { getEffectiveProfilesForProvider } from "../../config/default-profile-catalog.js";
+import { getUserSelectableProfilesForProvider } from "../../config/default-profile-catalog.js";
 import { isHttpAuthDisabled } from "../../config/env.js";
 import { getConfig } from "../../config/loader.js";
 import {
@@ -1559,7 +1559,7 @@ export async function handleSendMessage(
   }
   if (requestedInferenceProfile !== undefined) {
     const { llm } = getConfig();
-    const profiles = getEffectiveProfilesForProvider(
+    const profiles = getUserSelectableProfilesForProvider(
       llm.profiles,
       llm.defaultProvider ?? null,
     );

--- a/assistant/src/runtime/routes/inference-profile-session-handler.ts
+++ b/assistant/src/runtime/routes/inference-profile-session-handler.ts
@@ -14,7 +14,7 @@
 
 import { randomUUID } from "node:crypto";
 
-import { getEffectiveProfilesForProvider } from "../../config/default-profile-catalog.js";
+import { getUserSelectableProfilesForProvider } from "../../config/default-profile-catalog.js";
 import { loadConfig } from "../../config/loader.js";
 import { findConversation } from "../../daemon/conversation-registry.js";
 import {
@@ -153,7 +153,7 @@ export async function setInferenceProfileSession({
 
   // --- Validate profile ---
   const { llm } = loadConfig();
-  const profiles = getEffectiveProfilesForProvider(
+  const profiles = getUserSelectableProfilesForProvider(
     llm?.profiles,
     llm?.defaultProvider ?? null,
   );

--- a/assistant/src/runtime/routes/inference-profiles-routes.ts
+++ b/assistant/src/runtime/routes/inference-profiles-routes.ts
@@ -20,7 +20,7 @@ import { z } from "zod";
 
 import { validateInferenceProfileConfig } from "../../api/constants/profile-config-validation.js";
 import {
-  getEffectiveProfilesForProvider,
+  getUserSelectableProfilesForProvider,
   MANAGED_PROFILE_NAMES,
   resolveDefaultProfileForProvider,
 } from "../../config/default-profile-catalog.js";
@@ -432,7 +432,7 @@ function assertSaneMaxTokens(
 
 async function handleListProfiles() {
   const config = getConfigReadOnly();
-  const effective = getEffectiveProfilesForProvider(
+  const effective = getUserSelectableProfilesForProvider(
     config.llm.profiles,
     config.llm.defaultProvider ?? null,
   );
@@ -767,7 +767,7 @@ async function handleSetActiveProfile({ body = {} }: RouteHandlerArgs) {
   // is rejected here instead of silently stripped on the next config load —
   // which would reset the user's chat-model selection.
   const config = getConfigReadOnly();
-  const effective = getEffectiveProfilesForProvider(
+  const effective = getUserSelectableProfilesForProvider(
     config.llm.profiles,
     config.llm.defaultProvider ?? null,
   );

--- a/assistant/src/runtime/routes/inference-send-routes.ts
+++ b/assistant/src/runtime/routes/inference-send-routes.ts
@@ -7,7 +7,7 @@
 
 import { z } from "zod";
 
-import { getEffectiveProfilesForProvider } from "../../config/default-profile-catalog.js";
+import { getUserSelectableProfilesForProvider } from "../../config/default-profile-catalog.js";
 import type { ResolutionFallbackReason } from "../../config/llm-resolver.js";
 import { selectWinningProfile } from "../../config/llm-resolver.js";
 import { getConfigReadOnly } from "../../config/loader.js";
@@ -42,7 +42,7 @@ async function handleInferenceSend({ body = {} }: RouteHandlerArgs) {
   // Validate --profile against the configured profile catalog.
   if (profile !== undefined) {
     const { llm } = getConfigReadOnly();
-    const profiles = getEffectiveProfilesForProvider(
+    const profiles = getUserSelectableProfilesForProvider(
       llm?.profiles,
       llm?.defaultProvider ?? null,
     );

--- a/assistant/src/runtime/routes/llm-call-sites-routes.ts
+++ b/assistant/src/runtime/routes/llm-call-sites-routes.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 import { CALL_SITE_DEFAULTS } from "../../config/call-site-defaults.js";
-import { getEffectiveProfilesForProvider } from "../../config/default-profile-catalog.js";
+import { getUserSelectableProfilesForProvider } from "../../config/default-profile-catalog.js";
 import { resolveDefaultProfileKey } from "../../config/llm-resolver.js";
 import { loadConfig } from "../../config/loader.js";
 import {
@@ -66,7 +66,7 @@ export type LlmProfilesListResult = z.infer<
 
 async function handleListProfiles(): Promise<LlmProfilesListResult> {
   const { llm } = loadConfig();
-  const profiles = getEffectiveProfilesForProvider(
+  const profiles = getUserSelectableProfilesForProvider(
     llm?.profiles,
     llm?.defaultProvider ?? null,
   );

--- a/assistant/src/tools/workflows/manage-workflows.ts
+++ b/assistant/src/tools/workflows/manage-workflows.ts
@@ -15,7 +15,7 @@
 
 import { z } from "zod";
 
-import { getEffectiveProfilesForProvider } from "../../config/default-profile-catalog.js";
+import { getUserSelectableProfilesForProvider } from "../../config/default-profile-catalog.js";
 import { loadConfig } from "../../config/loader.js";
 import { callerOwnsWorkflowRun } from "../../workflows/capabilities.js";
 import type { WorkflowRun } from "../../workflows/journal-store.js";
@@ -192,7 +192,7 @@ export async function executeManageWorkflows(
       // workspace-wide active profile. Read-only — leaves use this to pick a
       // valid `profile` for `run_workflow` (an unknown profile throws).
       const { llm } = loadConfig();
-      const profiles = getEffectiveProfilesForProvider(
+      const profiles = getUserSelectableProfilesForProvider(
         llm?.profiles,
         llm?.defaultProvider ?? null,
       );

--- a/assistant/src/tools/workflows/run-workflow.test.ts
+++ b/assistant/src/tools/workflows/run-workflow.test.ts
@@ -338,17 +338,13 @@ describe("manage_workflows", () => {
     );
     expect(res.isError).toBe(false);
     const parsed = JSON.parse(res.content);
-    // The effective view always includes the code-catalog defaults,
-    // managed backup profiles included.
+    // The user-selectable view includes the code-catalog defaults and omits
+    // managed backup routes.
     expect(parsed.profiles).toEqual([
       "balanced",
-      "balanced-backup",
       "cost-optimized",
-      "cost-optimized-backup",
       "latency-optimized",
-      "latency-optimized-backup",
       "quality-optimized",
-      "quality-optimized-backup",
     ]);
     expect(parsed.activeProfile).toBe("balanced");
   });

--- a/assistant/src/workspace/migrations/149-repoint-backup-profile-selections.ts
+++ b/assistant/src/workspace/migrations/149-repoint-backup-profile-selections.ts
@@ -1,0 +1,204 @@
+/**
+ * Workspace migration `149-repoint-backup-profile-selections`.
+ *
+ * Managed backup profiles are internal failover routes. Earlier builds let
+ * users select those names directly, so existing workspaces can retain them
+ * in active, advisor, call-site, mix, conversation, or schedule references.
+ * Repoint those direct selections to their corresponding primary profile
+ * before the user-facing catalog hides the backups. Automatic fallback
+ * metadata is preserved: a primary's `fallbackProfile` still names its
+ * internal backup route.
+ */
+
+import { existsSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { Database } from "bun:sqlite";
+
+import { FALLBACK_PROFILE_BY_KEY } from "../../config/default-profile-names.js";
+import { getLogger } from "../../util/logger.js";
+import type { WorkspaceMigration } from "./types.js";
+
+const log = getLogger(
+  "workspace-migration-149-repoint-backup-profile-selections",
+);
+
+/** Mapping of every managed backup to its direct-selectable primary. */
+const BACKUP_TO_PRIMARY: Record<string, string> = Object.fromEntries(
+  Object.entries(FALLBACK_PROFILE_BY_KEY).map(([primary, backup]) => [
+    backup,
+    primary,
+  ]),
+);
+
+const PROFILE_PIN_TABLES = ["conversations", "cron_jobs"] as const;
+const DB_ATTEMPTS = 4;
+const DB_RETRY_BASE_DELAY_MS = 50;
+
+export const repointBackupProfileSelectionsMigration: WorkspaceMigration = {
+  id: "149-repoint-backup-profile-selections",
+  description:
+    "Repoint direct selections of managed backup profiles to their primaries",
+  retryFailedCheckpoint: true,
+
+  async run(workspaceDir: string): Promise<void> {
+    const configPath = join(workspaceDir, "config.json");
+    const config = readConfig(configPath);
+    const llm = config === null ? null : asObject(config.llm);
+    const configChanged = llm !== null && rewriteConfigReferences(llm);
+
+    // Rewrite database pins before config.json. If the database cannot be
+    // updated, leaving config untouched lets the next boot retry the same
+    // migration without stranding a direct selection.
+    await rewriteDbReferences(workspaceDir);
+
+    if (config !== null && configChanged) {
+      const tempPath = `${configPath}.tmp`;
+      writeFileSync(tempPath, JSON.stringify(config, null, 2) + "\n", "utf-8");
+      renameSync(tempPath, configPath);
+      log.info("Repointed direct backup-profile selections to primaries");
+    }
+  },
+
+  down(_workspaceDir: string): void {
+    // Forward-only: restoring a backup selection would make it unreachable
+    // from the user-facing profile catalog.
+  },
+};
+
+function readConfig(path: string): Record<string, unknown> | null {
+  if (!existsSync(path)) {
+    return null;
+  }
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(path, "utf-8"));
+    return isPlainObject(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Rewrite config references that represent direct user profile choices. */
+function rewriteConfigReferences(llm: Record<string, unknown>): boolean {
+  let changed = false;
+
+  for (const field of ["activeProfile", "advisorProfile"] as const) {
+    const current = llm[field];
+    const replacement = remapProfileName(current);
+    if (replacement !== current) {
+      llm[field] = replacement;
+      changed = true;
+    }
+  }
+
+  const callSites = asObject(llm.callSites);
+  if (callSites !== null) {
+    for (const value of Object.values(callSites)) {
+      const site = asObject(value);
+      if (site === null) {
+        continue;
+      }
+      const replacement = remapProfileName(site.profile);
+      if (replacement !== site.profile) {
+        site.profile = replacement;
+        changed = true;
+      }
+    }
+  }
+
+  const profiles = asObject(llm.profiles);
+  if (profiles === null) {
+    return changed;
+  }
+  for (const value of Object.values(profiles)) {
+    const entry = asObject(value);
+    if (entry === null || !Array.isArray(entry.mix)) {
+      continue;
+    }
+    for (const armValue of entry.mix as unknown[]) {
+      const arm = asObject(armValue);
+      if (arm === null) {
+        continue;
+      }
+      const replacement = remapProfileName(arm.profile);
+      if (replacement !== arm.profile) {
+        arm.profile = replacement;
+        changed = true;
+      }
+    }
+  }
+
+  return changed;
+}
+
+function remapProfileName(value: unknown): unknown {
+  if (typeof value !== "string") {
+    return value;
+  }
+  return BACKUP_TO_PRIMARY[value] ?? value;
+}
+
+/** Rewrite conversation and schedule pins, retrying transient DB contention. */
+async function rewriteDbReferences(workspaceDir: string): Promise<void> {
+  const path = join(workspaceDir, "data", "db", "assistant.db");
+  if (!existsSync(path)) {
+    return;
+  }
+
+  await withDbRetry(() => {
+    const db = new Database(path);
+    try {
+      for (const table of PROFILE_PIN_TABLES) {
+        if (!tableHasColumn(db, table, "inference_profile")) {
+          continue;
+        }
+        for (const [backup, primary] of Object.entries(BACKUP_TO_PRIMARY)) {
+          db.query(
+            `UPDATE ${table} SET inference_profile = ? WHERE inference_profile = ?`,
+          ).run(primary, backup);
+        }
+      }
+    } finally {
+      db.close();
+    }
+  });
+}
+
+function tableHasColumn(
+  db: Database,
+  table: (typeof PROFILE_PIN_TABLES)[number],
+  column: string,
+): boolean {
+  const rows = db.query(`PRAGMA table_info(${table})`).all() as Array<{
+    name?: unknown;
+  }>;
+  return rows.some((row) => row.name === column);
+}
+
+async function withDbRetry(attempt: () => void): Promise<void> {
+  for (let index = 0; ; index += 1) {
+    try {
+      attempt();
+      return;
+    } catch (err) {
+      if (index >= DB_ATTEMPTS - 1) {
+        throw new Error(
+          `Could not repoint backup-profile selections after ${DB_ATTEMPTS} attempts`,
+          { cause: err },
+        );
+      }
+      log.warn(
+        { err, attempt: index },
+        "Could not repoint backup-profile selections; retrying",
+      );
+      await Bun.sleep(DB_RETRY_BASE_DELAY_MS * 2 ** index);
+    }
+  }
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function asObject(value: unknown): Record<string, unknown> | null {
+  return isPlainObject(value) ? value : null;
+}

--- a/assistant/src/workspace/migrations/registry.ts
+++ b/assistant/src/workspace/migrations/registry.ts
@@ -146,6 +146,7 @@ import { collapseProfileBindingsToEntriesMigration } from "./145-collapse-profil
 import { repairRetiredFireworksDeepseekFlashModelIdMigration } from "./146-repair-retired-fireworks-deepseek-flash-model-id.js";
 import { renameCollidingBackupProfileNamesMigration } from "./147-rename-colliding-backup-profile-names.js";
 import { stripUnsupportedFallbackProfilesMigration } from "./148-strip-unsupported-fallback-profiles.js";
+import { repointBackupProfileSelectionsMigration } from "./149-repoint-backup-profile-selections.js";
 import { migrateToWorkspaceVolumeMigration } from "./migrate-to-workspace-volume.js";
 import type { WorkspaceMigration } from "./types.js";
 
@@ -307,4 +308,5 @@ export const WORKSPACE_MIGRATIONS: WorkspaceMigration[] = [
   repairRetiredFireworksDeepseekFlashModelIdMigration,
   renameCollidingBackupProfileNamesMigration,
   stripUnsupportedFallbackProfilesMigration,
+  repointBackupProfileSelectionsMigration,
 ];


### PR DESCRIPTION
## Summary
- Add a user-selectable profile view that omits managed backup routes while preserving the full internal fallback catalog.
- Hide backups from config responses, Settings and call-site profile lists, `/model`, plugin profile listings, and direct user profile selection validation.
- Add workspace migration 149 to repoint legacy direct selections in `activeProfile`, `advisorProfile`, call-site and mix references, conversation pins, and schedule pins to their primary profiles.
- Preserve `fallbackProfile` metadata so managed backups remain available for automatic failover.
- Add regression coverage for user-facing catalogs, migration behavior, and the updated workflow and plugin expectations.

## Verification
- Assistant typecheck and lint pass locally.
- PR CI passes, including Test, Type Check, Lint, OpenAPI, and Windows Electron checks.

## Original prompt
Ensure backup profiles are hidden from `/model` and Settings while remaining available internally for automatic fallback.