### PR TITLE
refactor(runtime): one name for the plan a reply carries

### DIFF
--- a/assistant/src/runtime/slack-reply-session.ts
+++ b/assistant/src/runtime/slack-reply-session.ts
@@ -22,7 +22,6 @@ import {
   hasDeliverableAssistantText,
   NO_RESPONSE_INLINE_RE,
 } from "./no-response.js";
-import type { TaskProgressData } from "./task-progress.js";
 import {
   getTaskProgressDataFromToolInput,
   mergeTaskProgressData,
@@ -157,7 +156,7 @@ export function createSlackReplySession(params: {
   // `renderHistoryContent`'s `joinWithSpacing` on the durable delivery path).
   let pendingSegmentBoundary = false;
 
-  let activeProgress: TaskProgressData | undefined;
+  let activeProgress: StreamPlan | undefined;
   // Fingerprint of the plan state last delivered to Slack, so progress that
   // advances without new body text still flushes as a task-only append.
   let deliveredProgressKey: string | undefined;

--- a/assistant/src/runtime/task-progress.ts
+++ b/assistant/src/runtime/task-progress.ts
@@ -2,16 +2,6 @@ import type { StreamPlan, StreamPlanStep } from "@vellumai/gateway-client";
 
 import { coerceSurfaceDataRecord } from "../api/surfaces.js";
 
-/**
- * A `task_progress` surface, read into the plan shape a growing reply carries.
- *
- * Aliases rather than redeclares: the outbound contract already names this
- * shape, every channel that draws a plan receives it, and a second definition
- * here would be the same fields under a second name waiting to drift.
- */
-export type TaskProgressStep = StreamPlanStep;
-export type TaskProgressData = StreamPlan;
-
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -19,7 +9,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 /** Read a `task_progress` surface payload into typed steps, if it is one. */
 export function getTaskProgressDataFromSurfaceData(
   data: unknown,
-): TaskProgressData | undefined {
+): StreamPlan | undefined {
   if (!isRecord(data)) {
     return undefined;
   }
@@ -29,12 +19,12 @@ export function getTaskProgressDataFromSurfaceData(
   return parseTaskProgressData(data.templateData);
 }
 
-function parseTaskProgressData(value: unknown): TaskProgressData | undefined {
+function parseTaskProgressData(value: unknown): StreamPlan | undefined {
   if (!isRecord(value) || !Array.isArray(value.steps)) {
     return undefined;
   }
 
-  const steps = value.steps.flatMap((step): TaskProgressStep[] => {
+  const steps = value.steps.flatMap((step): StreamPlanStep[] => {
     if (!isRecord(step)) {
       return [];
     }
@@ -83,7 +73,7 @@ function parseTaskProgressData(value: unknown): TaskProgressData | undefined {
  */
 export function getTaskProgressDataFromToolInput(
   input: unknown,
-): TaskProgressData | undefined {
+): StreamPlan | undefined {
   const record = coerceSurfaceDataRecord(input);
   return (
     getTaskProgressDataFromSurfaceData(record) ??
@@ -97,9 +87,9 @@ export function getTaskProgressDataFromToolInput(
  * `templateData` update is merged over the existing steps.
  */
 export function mergeTaskProgressData(
-  existing: TaskProgressData | undefined,
+  existing: StreamPlan | undefined,
   data: unknown,
-): TaskProgressData | undefined {
+): StreamPlan | undefined {
   if (!isRecord(data)) {
     return existing;
   }


### PR DESCRIPTION
## TL;DR

One shape, one name. `task-progress.ts` re-exported the outbound plan contract under a second name, and `slack-reply-session.ts` ended up importing both names for the same type in the same file. This deletes the aliases and uses the contract's own name.

## What was wrong

`task-progress.ts` reads a `task_progress` surface into the plan shape a growing reply carries. That shape is already named by the outbound contract, so the module aliased it:

```ts
export type TaskProgressStep = StreamPlanStep;
export type TaskProgressData = StreamPlan;
```

Two consequences:

- `TaskProgressStep` had no readers anywhere in the repo.
- `slack-reply-session.ts` imported `StreamPlan` (line 1) *and* `TaskProgressData` (line 25). It declared `activeProgress` as one and typed its own `progressKey` helper against the other, which is one type wearing two names inside a single function.

## Why it is safe

Both were `export type X = Y` aliases, so this is a rename with no runtime component and no shape change. Every reader is in the two files touched; `git grep` confirms no other module referenced either name. The function names are deliberately unchanged, because reading a `task_progress` surface is genuinely what they do; only the type they return is renamed to the contract's own name. Typecheck and lint pass.

## Before / after

| | Before | After |
|---|---|---|
| What a channel receives when the model draws a plan | The plan, unchanged | The plan, unchanged |
| What a reader of `task-progress.ts` sees | Two names for one shape, one of them unused | The contract's name |

Nothing user-visible changes.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41290" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->