### PR TITLE
fix(channels): let someone see the floor Discord is already enforcing

### DIFF
--- a/clients/web/src/lib/channel-admission-policy/types.ts
+++ b/clients/web/src/lib/channel-admission-policy/types.ts
@@ -31,11 +31,7 @@ export const INTERNAL_CHANNELS = new Set<string>(["platform", "a2a"]);
  * them into the UI. Mirrors `ADMISSION_POLICY_HIDDEN_CHANNELS` in
  * `packages/gateway-client/src/admission-policy-contract.ts`.
  */
-export const HIDDEN_CHANNELS = new Set<string>([
-  "vellum",
-  "whatsapp",
-  "discord",
-]);
+export const HIDDEN_CHANNELS = new Set<string>(["vellum", "whatsapp"]);
 
 export function isHiddenChannel(channelType: string): boolean {
   return HIDDEN_CHANNELS.has(channelType);

--- a/gateway/AGENTS.md
+++ b/gateway/AGENTS.md
@@ -179,7 +179,7 @@ A default row per enforced channel is **seeded at startup** (`seedAdmissionPolic
 
 For exempt ids, `PUT /v1/assistants/:id/channel-admission-policy/:channelType` returns **403**, the GET list omits them, and the runtime short-circuits `admitted: true` in `admission-policy.ts` (defense in depth). Codex finding from #35006 review: exemption checks must live in _both_ the gateway route handler AND the runtime stage — single-side enforcement creates a misuse wedge.
 
-**Hidden channels** (`ADMISSION_POLICY_HIDDEN_CHANNELS` = `vellum`, `whatsapp`, `discord`) — managed automatically, **not** user-configurable, but (unlike exempt channels) **still enforced at runtime**:
+**Hidden channels** (`ADMISSION_POLICY_HIDDEN_CHANNELS` = `vellum`, `whatsapp`) are managed automatically and **not** user-configurable, but (unlike exempt channels) are **still enforced at runtime**:
 
 - The GET list omits them, and `PUT`/`DELETE` return **403** (`isAdmissionPolicyHiddenChannel`).
 - They are **not** exempt — the runtime still evaluates rank-vs-floor, so a real inbound channel like `whatsapp` keeps its admission floor.

--- a/gateway/src/__tests__/seed-admission-policy.test.ts
+++ b/gateway/src/__tests__/seed-admission-policy.test.ts
@@ -55,21 +55,21 @@ describe("seedAdmissionPolicyDefaults", () => {
     expect(store.get("email")).toBe("trusted_contacts");
   });
 
-  test("picks up discord generically — enforced, hidden, pinned at the default floor", () => {
+  test("picks up discord generically: enforced at the default floor, and settable", () => {
     // Discord carries no entry in CHANNEL_ADMISSION_DEFAULTS and no special
     // casing in the seed: adding it to CHANNEL_IDS is enough to give it a
     // floor, so a channel id can never reach ingress unenforced.
     seedAdmissionPolicyDefaults(store);
 
-    // Enforced — not skipped as exempt — at the universal default.
+    // Enforced rather than skipped as exempt, at the universal default.
     expect(store.get("discord")).toBe("trusted_contacts");
 
-    // Hidden: Discord is absent from the Channel Trust Floors list, so the
-    // seed re-pins any row rather than leaving a floor the user cannot see or
-    // reset.
-    store.set("discord", "strangers", "drifted row");
+    // Not hidden: Discord appears in the Channel Trust Floors list, so a floor
+    // the user set is theirs and the seed must leave it alone. Re-pinning it
+    // exists for channels with no row to reset from, which Discord has.
+    store.set("discord", "strangers", "user widened the floor");
     seedAdmissionPolicyDefaults(store);
-    expect(store.get("discord")).toBe("trusted_contacts");
+    expect(store.get("discord")).toBe("strangers");
   });
 
   test("resets a stranded hidden-channel row back to its default", () => {

--- a/packages/gateway-client/src/admission-policy-contract.ts
+++ b/packages/gateway-client/src/admission-policy-contract.ts
@@ -81,16 +81,10 @@ export function isAdmissionPolicyExemptChannel(channelType: string): boolean {
  *
  * `vellum` is the local desktop/web client surface; the guardian is always
  * max-rank there, so the seed default admits them regardless of the floor.
- *
- * `discord` has no ingress implementation, so there is nothing for a floor to
- * gate and nothing for the user to configure. Hiding keeps it pinned at the
- * seed default rather than offering a Channel Trust Floors row for a channel
- * that receives nothing.
  */
 export const ADMISSION_POLICY_HIDDEN_CHANNELS: ReadonlySet<string> = new Set([
   "vellum",
   "whatsapp",
-  "discord",
 ]);
 
 export function isAdmissionPolicyHiddenChannel(channelType: string): boolean {


### PR DESCRIPTION
## TL;DR

Discord's admission floor has been enforced on live traffic since ingress landed, with no row anywhere to see or change it. The commit that hid it said in its own message to remove the hide "in the slice that lands ingress"; that slice merged three hours later and the removal was missed. This is that removal.

Part of LUM-3102, which names this as item 3 of what stands between Discord and parity.

## Why it was hidden, and why that reason has expired

[#39224](https://github.com/vellum-ai/vellum-assistant/pull/39224) added `discord` to the canonical channel vocabulary, vocabulary only, before any ingress existed. That put it straight into the Channel Trust Floors list, because the GET handler builds from `CHANNEL_IDS` minus the exempt and hidden sets, so settings offered a configurable row for a channel that could not receive anything. Hiding was the right call, and hidden rather than exempt was the right bucket: exempt short-circuits the admission check, and the floor had to keep being enforced so the id could never reach ingress ungated.

That PR's own message said what came next:

> Remove discord from `ADMISSION_POLICY_HIDDEN_CHANNELS` (and the web mirror) in the slice that lands ingress, and the row appears with a floor already seeded.

[#39288](https://github.com/vellum-ai/vellum-assistant/pull/39288) landed the gateway socket and the inbound wiring the same afternoon. Nobody removed it. The docstring still gives the original reason, which now reads as a claim about the code that is no longer true: "`discord` has no ingress implementation, so there is nothing for a floor to gate".

## What that has meant

Hiding does not exempt. `handleInbound` calls `resolveAdmissionPolicy(event.sourceChannel)` for every inbound event, and that resolver short-circuits only for the two exempt channels, `platform` and `a2a`. So Discord has been gated the whole time at `trusted_contacts`, the shared default it picks up from the seed.

The seed then goes further: for a hidden channel it deliberately **overwrites** a drifted row on every startup, so a stale floor cannot strand a channel nobody can reset. Written for channels with nothing to gate; applied to a live one, it means even a hand-edited row would not survive a restart.

The shape of that in a Discord server: the assistant answers the people it already knows, silently ignores everyone else, and nothing in the product explains why.

## Why it is safe

- **Not a change to enforcement.** The floor was already enforced and stays enforced at the same seeded value. This changes who can see and set it, not what is admitted today.
- **Degrades safely in both directions of version skew.** The web client keeps a mirror of the hidden set as a deliberate double-filter, so an older web client against a newer gateway still filters the row out, and a newer web client against an older gateway never receives it. Neither combination shows a broken row.
- **No new surface.** `PUT`/`DELETE` for this channel already existed and returned 403 only because of the hidden check; they now behave as they do for Slack and Telegram, through the same validated path.
- **The test flips back to what it originally pinned.** [#39224](https://github.com/vellum-ai/vellum-assistant/pull/39224) added a test asserting Discord was picked up generically and left user-configurable, then flipped it to assert re-pinning when the hide went in. It asserts the original invariant again: a floor the user set is theirs, and the seed leaves it alone.

## Before / after

| | Before | After |
|---|---|---|
| Is Discord's floor enforced? | Yes, at `trusted_contacts` | Yes, at `trusted_contacts` |
| Can someone see it? | No row in Channel Trust Floors | A row, like Slack and Telegram |
| Can someone change it? | No, and a hand-edited row was overwritten on every restart | Yes, and it survives restarts |
| A stranger messaging the bot in a server | Dropped, with nothing to explain it | Dropped, with a visible setting that says so and can be widened |

## What this deliberately does not do

The other control LUM-3102 names is still missing: `allowedChannelIds` appears in no web or route file, so the Discord channel allow-list remains config-file-only and fail-closed from empty. That issue's suggested order puts the allow-list control before the setup wizard, which is right, since a wizard should not walk someone into a half-control. It is not a reason to keep enforcing an invisible floor in the meantime, which is why this lands on its own.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41291" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->