### PR TITLE
fix(openrouter): align three drifted rates with the live OpenRouter card

### DIFF
--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -1461,9 +1461,9 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         supportsVision: false,
         supportsToolUse: true,
         pricing: {
-          inputPer1mTokens: 0.522174,
-          outputPer1mTokens: 1.044348,
-          cacheReadPer1mTokens: 0.0435145,
+          inputPer1mTokens: 0.790308,
+          outputPer1mTokens: 1.580616,
+          cacheReadPer1mTokens: 0.065859,
         },
       },
       {
@@ -1476,9 +1476,9 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         supportsVision: false,
         supportsToolUse: true,
         pricing: {
-          inputPer1mTokens: 0.056,
-          outputPer1mTokens: 0.112,
-          cacheReadPer1mTokens: 0.0112,
+          inputPer1mTokens: 0.088606,
+          outputPer1mTokens: 0.177212,
+          cacheReadPer1mTokens: 0.0177212,
         },
       },
       // Qwen
@@ -1703,9 +1703,9 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         supportsVision: false,
         supportsToolUse: true,
         pricing: {
-          inputPer1mTokens: 0.966,
-          outputPer1mTokens: 3.036,
-          cacheReadPer1mTokens: 0.1932,
+          inputPer1mTokens: 1.19,
+          outputPer1mTokens: 3.74,
+          cacheReadPer1mTokens: 0.221,
         },
       },
       // Mistral

--- a/meta/llm-provider-catalog.json
+++ b/meta/llm-provider-catalog.json
@@ -1347,9 +1347,9 @@
           "supportsVision": false,
           "supportsToolUse": true,
           "pricing": {
-            "inputPer1mTokens": 0.522174,
-            "outputPer1mTokens": 1.044348,
-            "cacheReadPer1mTokens": 0.0435145
+            "inputPer1mTokens": 0.790308,
+            "outputPer1mTokens": 1.580616,
+            "cacheReadPer1mTokens": 0.065859
           }
         },
         {
@@ -1364,9 +1364,9 @@
           "supportsVision": false,
           "supportsToolUse": true,
           "pricing": {
-            "inputPer1mTokens": 0.056,
-            "outputPer1mTokens": 0.112,
-            "cacheReadPer1mTokens": 0.0112
+            "inputPer1mTokens": 0.088606,
+            "outputPer1mTokens": 0.177212,
+            "cacheReadPer1mTokens": 0.0177212
           }
         },
         {
@@ -1632,9 +1632,9 @@
           "supportsVision": false,
           "supportsToolUse": true,
           "pricing": {
-            "inputPer1mTokens": 0.966,
-            "outputPer1mTokens": 3.036,
-            "cacheReadPer1mTokens": 0.1932
+            "inputPer1mTokens": 1.19,
+            "outputPer1mTokens": 3.74,
+            "cacheReadPer1mTokens": 0.221
           }
         },
         {


### PR DESCRIPTION
## TL;DR

OpenRouter raised prices on three models. `openrouter-catalog-parity.test.ts` fetches their live card and fails the build on more than 2% drift, so this is currently failing on **every** open PR regardless of what the PR changes. This brings the catalog back in line.

Same shape as [#41208](https://github.com/vellum-ai/vellum-assistant/pull/41208) and [#41254](https://github.com/vellum-ai/vellum-assistant/pull/41254).

## What moved

| Model | input | output | cache read |
|---|---|---|---|
| `deepseek/deepseek-v4-pro` | 0.522174 to **0.790308** | 1.044348 to **1.580616** | 0.0435145 to **0.065859** |
| `deepseek/deepseek-v4-flash` | 0.056 to **0.088606** | 0.112 to **0.177212** | 0.0112 to **0.0177212** |
| `z-ai/glm-5.2` | 0.966 to **1.19** | 3.036 to **3.74** | 0.1932 to **0.221** |

All three are increases, the DeepSeek pair by about 58% and GLM by about 23%.

## Why it is safe

Values are read from `https://openrouter.ai/api/v1/models` and scaled from the card's per-token prices to per-million, so they land on the published number exactly rather than merely inside the 2% window. Nothing but the `openrouter` block's rates changes: no ids, no capability flags, no context windows, and no other provider.

These figures are what cost estimates are computed from, so before this the estimate for those three models was low by the same margin.

## Before / after

| | Before | After |
|---|---|---|
| CI on any open PR | Test job fails on catalog parity | Passes |
| Cost shown for these three models | Understated, by 23% to 58% | Matches what OpenRouter charges |

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41294" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->