### PR TITLE
fix(openrouter): align DeepSeek and GLM rates with the live OpenRouter card

### DIFF
--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -1461,9 +1461,9 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         supportsVision: false,
         supportsToolUse: true,
         pricing: {
-          inputPer1mTokens: 0.522174,
-          outputPer1mTokens: 1.044348,
-          cacheReadPer1mTokens: 0.0435145,
+          inputPer1mTokens: 0.790308,
+          outputPer1mTokens: 1.580616,
+          cacheReadPer1mTokens: 0.065859,
         },
       },
       {
@@ -1476,9 +1476,9 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         supportsVision: false,
         supportsToolUse: true,
         pricing: {
-          inputPer1mTokens: 0.056,
-          outputPer1mTokens: 0.112,
-          cacheReadPer1mTokens: 0.0112,
+          inputPer1mTokens: 0.088606,
+          outputPer1mTokens: 0.177212,
+          cacheReadPer1mTokens: 0.0177212,
         },
       },
       // Qwen
@@ -1703,9 +1703,9 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         supportsVision: false,
         supportsToolUse: true,
         pricing: {
-          inputPer1mTokens: 0.966,
-          outputPer1mTokens: 3.036,
-          cacheReadPer1mTokens: 0.1932,
+          inputPer1mTokens: 1.19,
+          outputPer1mTokens: 3.74,
+          cacheReadPer1mTokens: 0.221,
         },
       },
       // Mistral

--- a/meta/llm-provider-catalog.json
+++ b/meta/llm-provider-catalog.json
@@ -1347,9 +1347,9 @@
           "supportsVision": false,
           "supportsToolUse": true,
           "pricing": {
-            "inputPer1mTokens": 0.522174,
-            "outputPer1mTokens": 1.044348,
-            "cacheReadPer1mTokens": 0.0435145
+            "inputPer1mTokens": 0.790308,
+            "outputPer1mTokens": 1.580616,
+            "cacheReadPer1mTokens": 0.065859
           }
         },
         {
@@ -1364,9 +1364,9 @@
           "supportsVision": false,
           "supportsToolUse": true,
           "pricing": {
-            "inputPer1mTokens": 0.056,
-            "outputPer1mTokens": 0.112,
-            "cacheReadPer1mTokens": 0.0112
+            "inputPer1mTokens": 0.088606,
+            "outputPer1mTokens": 0.177212,
+            "cacheReadPer1mTokens": 0.0177212
           }
         },
         {
@@ -1632,9 +1632,9 @@
           "supportsVision": false,
           "supportsToolUse": true,
           "pricing": {
-            "inputPer1mTokens": 0.966,
-            "outputPer1mTokens": 3.036,
-            "cacheReadPer1mTokens": 0.1932
+            "inputPer1mTokens": 1.19,
+            "outputPer1mTokens": 3.74,
+            "cacheReadPer1mTokens": 0.221
           }
         },
         {


### PR DESCRIPTION
## TL;DR

OpenRouter repriced three models overnight. `main` has been red since 00:07 UTC on a single assertion in the live OpenRouter drift check, and every commit pushed since fails the same way. This updates the nine affected rates so the tree goes green again.

Nobody's code caused this. The check compares our hardcoded rates against `https://openrouter.ai/api/v1/models` on every run, so an upstream reprice fails the build on its own schedule.

## What changed

Nine numbers in the `openrouter` block, plus the regenerated JSON mirror.

| model | field | before | after |
| -- | -- | -- | -- |
| `deepseek/deepseek-v4-pro` | input / output / cache read | 0.522174 / 1.044348 / 0.0435145 | 0.790308 / 1.580616 / 0.065859 |
| `deepseek/deepseek-v4-flash` | input / output / cache read | 0.056 / 0.112 / 0.0112 | 0.088606 / 0.177212 / 0.0177212 |
| `z-ai/glm-5.2` | input / output / cache read | 0.966 / 3.036 / 0.1932 | 1.19 / 3.74 / 0.221 |

## What changes for the user

Cost estimates for these three models go up, because the models themselves got more expensive upstream. Nothing else moves.

The catalog rates feed conversation usage and cost display only. They are not what anyone is billed: OpenRouter users pay OpenRouter directly on their own key. So the practical effect is that a number we show stops being wrong.

## Why this is safe

- Data only. No logic, no types, no control flow.
- Every value was read from the live card and re-verified after the edit. A local replay of the drift check reports no remaining drift across all 44 `openrouter` models.
- The `vercel-ai-gateway` block carries its own `deepseek-v4-flash` entry at different rates. It is deliberately untouched, since the drift check only covers the `openrouter` provider.
- `bun run sync:llm-catalog -- --check` reports the JSON mirror up to date. `tsc --noEmit` is clean.
- The two hermetic cache-flag guards in `llm-catalog-parity.test.ts` still hold: all three models keep `supportsCaching: true` with a positive cache-read rate.

Every value here was read verbatim from the live card, not derived. For the record, since the multipliers are not uniform across the board:

| model | input/output multiplier | cache-read multiplier | cache-read as a fraction of input |
| -- | -- | -- | -- |
| `deepseek/deepseek-v4-pro` | x1.51349 | x1.51349 | 1/12 |
| `deepseek/deepseek-v4-flash` | x1.58225 | x1.58225 | 1/5 |
| `z-ai/glm-5.2` | x1.23188 | x1.14389 | 0.18571 |

The DeepSeek pair rescaled uniformly. GLM-5.2 did not: its cache-read moved less than its base, so its cache discount narrowed as well. Each vendor sets its own cache ratio and none of them is obliged to hold it across a reprice, so `0.221` is what the card says rather than what a uniform rescale would predict (`0.238`). Either way this is an upstream move, not a correction of anything we entered wrong.

## What this deliberately does not fix

This is the third time in roughly twelve hours that this check has taken `main` or an open PR down: #41208 introduced it, #41254 fixed a MiniMax reprice five hours later, and this is the third. Patching rates by hand each time is not a fix, it is a treadmill.

That is deferred to a follow-up rather than bundled here, because `main` is red right now and this half should be reviewable in ten seconds. The follow-up moves the live comparison off the merge gate and onto a schedule that opens a PR instead of failing a build.
