### PR TITLE
fix(web): show one plan-card header button per plan

### DIFF
--- a/clients/web/src/domains/settings/components/plan-card.test.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.test.tsx
@@ -1,8 +1,8 @@
 /**
- * Tests for the PlanCard: verifies the plan name, renewal text, the header's
- * "View All Plans" and paid-only "Manage Subscription" buttons, and the
- * side-by-side current / next plan tiles render correctly, plus the header
- * buttons' navigation wiring. The card shows
+ * Tests for the PlanCard: verifies the plan name, renewal text, the single
+ * header button (base-only "View All Plans" or paid-only "Manage
+ * Subscription"), and the side-by-side current / next plan tiles render
+ * correctly, plus the header button's navigation wiring. The card shows
  * no credit bundle label and no invoices button; invoices render in an inline
  * table on the billing page.
  *
@@ -501,12 +501,12 @@ describe("PlanCard", () => {
     expect(html).not.toContain("Manage Subscription");
   });
 
-  test("a paid Pro plan shows Manage Subscription beside View All Plans", () => {
+  test("a paid Pro plan shows only the Manage Subscription button", () => {
     const html = renderCard(proMightySubscription(), plansWithSuper());
     expect(html).toContain("plan-card-manage-subscription-button");
     expect(html).toContain("Manage Subscription");
-    expect(html).toContain("plan-card-plans-button");
-    expect(html).toContain("View All Plans");
+    expect(html).not.toContain("plan-card-plans-button");
+    expect(html).not.toContain("View All Plans");
   });
 
   test("does not render the invoices button (moved to inline table)", () => {
@@ -707,24 +707,6 @@ describe("PlanCard", () => {
 });
 
 describe("PlanCard action button", () => {
-  test("a Pro user's View All Plans click opens the plan-aware takeover", async () => {
-    const onManage = mock(() => {});
-    const { findByTestId } = renderCardInteractive(
-      proMightySubscription(),
-      plansWithSuper(),
-      onManage,
-    );
-
-    fireEvent.click(await findByTestId("plan-card-plans-button"));
-
-    // navigate() fires from the click handler; await it so the assertion never
-    // races the handler's commit in the CI runner.
-    await waitFor(() => {
-      expect(navigateArgs).toEqual([[routes.plans, undefined]]);
-    });
-    expect(onManage).not.toHaveBeenCalled();
-  });
-
   test("a base user's View All Plans click opens the plans takeover", async () => {
     const onManage = mock(() => {});
     const { findByTestId } = renderCardInteractive(
@@ -775,10 +757,10 @@ describe("PlanCard action button", () => {
     expect(navigateArgs).toEqual([]);
   });
 
-  test("an empty catalog falls back to onManage (AdjustPlanModal)", async () => {
+  test("a base user's empty catalog falls back to onManage (AdjustPlanModal)", async () => {
     const onManage = mock(() => {});
     const { findByTestId } = renderCardInteractive(
-      proMightySubscription(),
+      baseSubscription(),
       emptyCatalogPlans(),
       onManage,
     );
@@ -793,7 +775,7 @@ describe("PlanCard action button", () => {
     expect(navigateArgs).toEqual([]);
   });
 
-  test("a customized Pro sub's View All Plans opens the plans takeover", async () => {
+  test("a customized Pro sub's Manage Subscription opens the plans takeover", async () => {
     const onManage = mock(() => {});
     // A customized pin routes to the takeover alongside every other Pro sub; the
     // takeover's own CTAs handle the customized state's transitions.
@@ -810,7 +792,7 @@ describe("PlanCard action button", () => {
       onManage,
     );
 
-    fireEvent.click(await findByTestId("plan-card-plans-button"));
+    fireEvent.click(await findByTestId("plan-card-manage-subscription-button"));
 
     await waitFor(() => {
       expect(navigateArgs).toEqual([[routes.plans, undefined]]);
@@ -829,7 +811,7 @@ describe("PlanCard action button", () => {
       onManage,
     );
 
-    fireEvent.click(await findByTestId("plan-card-plans-button"));
+    fireEvent.click(await findByTestId("plan-card-manage-subscription-button"));
 
     await waitFor(() => {
       expect(navigateArgs).toEqual([[routes.plans, undefined]]);
@@ -837,7 +819,7 @@ describe("PlanCard action button", () => {
     expect(onManage).not.toHaveBeenCalled();
   });
 
-  test("a from-scratch custom Pro sub's View All Plans opens the takeover", async () => {
+  test("a from-scratch custom Pro sub's Manage Subscription opens the takeover", async () => {
     const onManage = mock(() => {});
     // A Pro sub built from scratch — no stock lineage, pinned but customized —
     // routes to the takeover like every other Pro sub with a live catalog.
@@ -854,7 +836,7 @@ describe("PlanCard action button", () => {
       onManage,
     );
 
-    fireEvent.click(await findByTestId("plan-card-plans-button"));
+    fireEvent.click(await findByTestId("plan-card-manage-subscription-button"));
 
     await waitFor(() => {
       expect(navigateArgs).toEqual([[routes.plans, undefined]]);
@@ -862,7 +844,7 @@ describe("PlanCard action button", () => {
     expect(onManage).not.toHaveBeenCalled();
   });
 
-  test("a cancelling custom Pro sub's View All Plans stays on the fallback", async () => {
+  test("a cancelling custom Pro sub's Manage Subscription stays on the fallback", async () => {
     const onManage = mock(() => {});
     // A customized/unpinned sub pending cancellation keeps the manage modal,
     // which surfaces the cancellation state and the "Keep your Plan" action; the
@@ -881,7 +863,7 @@ describe("PlanCard action button", () => {
       onManage,
     );
 
-    fireEvent.click(await findByTestId("plan-card-plans-button"));
+    fireEvent.click(await findByTestId("plan-card-manage-subscription-button"));
 
     await waitFor(() => {
       expect(onManage).toHaveBeenCalledTimes(1);
@@ -901,7 +883,7 @@ describe("PlanCard action button", () => {
       onManage,
     );
 
-    fireEvent.click(await findByTestId("plan-card-plans-button"));
+    fireEvent.click(await findByTestId("plan-card-manage-subscription-button"));
 
     await waitFor(() => {
       expect(navigateArgs).toEqual([[routes.plans, undefined]]);
@@ -909,7 +891,7 @@ describe("PlanCard action button", () => {
     expect(onManage).not.toHaveBeenCalled();
   });
 
-  test("an unpaid custom Pro sub's View All Plans stays on the fallback", async () => {
+  test("an unpaid custom Pro sub's Manage Subscription stays on the fallback", async () => {
     const onManage = mock(() => {});
     // A custom sub in a non-entitlement status (e.g. unpaid) is switch-ineligible,
     // so it keeps the manage modal — the takeover would bounce every CTA back to
@@ -928,7 +910,7 @@ describe("PlanCard action button", () => {
       onManage,
     );
 
-    fireEvent.click(await findByTestId("plan-card-plans-button"));
+    fireEvent.click(await findByTestId("plan-card-manage-subscription-button"));
 
     await waitFor(() => {
       expect(onManage).toHaveBeenCalledTimes(1);

--- a/clients/web/src/domains/settings/components/plan-card.tsx
+++ b/clients/web/src/domains/settings/components/plan-card.tsx
@@ -456,9 +456,9 @@ export function PlanCard({ onManage, onTierUpgraded }: PlanCardProps) {
     (currentPlan.id === "base" ||
       isCleanPin(subscription.package) ||
       isPackageSwitchEligible(subscription));
-  // Shared by both header buttons: "Manage Subscription" is the name a paid
-  // Pro user scans for, but it leads to the same surface as "View All Plans",
-  // which is where a sub is changed or cancelled.
+  // Shared by both header button variants: "Manage Subscription" is the name
+  // a paid Pro user scans for, but it leads to the same surface as the base
+  // plan's "View All Plans", which is where a sub is changed or cancelled.
   const handlePlansClick = canOpenPlansTakeover
     ? () => navigate(routes.plans)
     : onManage;
@@ -577,28 +577,22 @@ export function PlanCard({ onManage, onTierUpgraded }: PlanCardProps) {
               </Typography>
             )}
           </div>
-          {/* The buttons never break their labels, so the group must stay
-              free to shrink and wrap them onto a second row at phone widths;
-              a fixed-width group would push the long es/ru labels past the
-              card. */}
-          <div className="flex flex-wrap items-center justify-end gap-2">
-            {!isFreePlan && (
-              <Button
-                variant="outlined"
-                onClick={handlePlansClick}
-                data-testid="plan-card-manage-subscription-button"
-              >
-                {t("planCard.manageSubscription")}
-              </Button>
-            )}
-            <Button
-              variant="outlined"
-              onClick={handlePlansClick}
-              data-testid="plan-card-plans-button"
-            >
-              {t("planCard.viewAllPlans")}
-            </Button>
-          </div>
+          {/* The button never breaks its label, so it must stay free to
+              shrink; a fixed-width slot would push the long es/ru labels past
+              the card. */}
+          <Button
+            variant="outlined"
+            onClick={handlePlansClick}
+            data-testid={
+              isFreePlan
+                ? "plan-card-plans-button"
+                : "plan-card-manage-subscription-button"
+            }
+          >
+            {isFreePlan
+              ? t("planCard.viewAllPlans")
+              : t("planCard.manageSubscription")}
+          </Button>
         </div>
         <div className="flex flex-col gap-2 lg:flex-row lg:items-stretch">
           <PlanTile


### PR DESCRIPTION
## Summary
- The billing & usage plan card now renders exactly one header button: "Manage Subscription" for a paid (Pro) subscription and "View All Plans" for the base plan, instead of showing both to Pro subscribers.
- Both labels keep the shared click handler, so routing is unchanged: the plans takeover when the catalog allows it, otherwise the manage-modal fallback.
- Updated the PlanCard tests: Pro-sub navigation tests now click the Manage Subscription button, the empty-catalog fallback test moved to a base user, and the duplicate Pro "View All Plans" click test was removed.

## Original prompt
On the billing & usage settings page, a subscribed user's plan card showed both a "Manage Subscription" button and a "View All Plans" button. The request was to show only one of them based on the plan: only "Manage Subscription" for a user subscribed to a Pro plan, and only "View All Plans" for a user on the base plan.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41301" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->