### PR TITLE
fix(web): gate the provisioning takeover's credit chips behind obscure-credits

### DIFF
--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.test.tsx
@@ -9,6 +9,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
+  act,
   cleanup,
   fireEvent,
   render,
@@ -20,6 +21,7 @@ import * as motionReact from "motion/react";
 import { organizationsBillingPlansRetrieveQueryKey } from "@/generated/api/@tanstack/react-query.gen";
 import type { PlanListResponse } from "@/generated/api/types.gen";
 import * as assistantAvatarMod from "@/hooks/use-assistant-avatar";
+import { useClientFeatureFlagStore } from "@/stores/client-feature-flag-store";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
 import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
@@ -112,7 +114,7 @@ function plansResponse(): PlanListResponse {
         credit_tiers: [
           {
             tier: "credits_50",
-            label: "$50 credits/mo",
+            label: "Mighty Usage",
             credits_usd: 50,
             price_cents: 5000,
             lookup_key: "credits_50_key",
@@ -1385,5 +1387,105 @@ describe("ProvisioningState phase hold", () => {
       timeout: 1000,
     });
     expect(reported).toEqual(["WAITING", "DONE"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// obscure-credits flag: the chips name usage bundles, never a credit amount
+// ---------------------------------------------------------------------------
+
+/** Drives the `obscure-credits` client flag the way the app's LD sync does. */
+function setObscureCredits(value: boolean): void {
+  act(() => {
+    useClientFeatureFlagStore
+      .getState()
+      .setFlags({ obscureCredits: value }, null);
+  });
+}
+
+describe("obscure-credits flag", () => {
+  beforeEach(() => {
+    setObscureCredits(true);
+  });
+
+  afterEach(() => {
+    setObscureCredits(false);
+  });
+
+  test("the resize credits chip names the bundles, not monthly rates", () => {
+    const { getByTestId } = renderState({
+      state: "WAITING",
+      creditsChange: { fromTier: null, toTier: "credits_50" },
+    });
+
+    const chip = getByTestId("chip-credits");
+    expect(within(chip).getByText("Usage")).toBeTruthy();
+    expect(chip.textContent).toContain("No extra usage");
+    expect(chip.textContent).toContain("Mighty Usage");
+    expect(chip.textContent).not.toContain("$");
+  });
+
+  test("a dropped bundle reads down to the no-extra-usage sentinel", () => {
+    const { getByTestId } = renderState({
+      state: "NOT_APPLICABLE",
+      creditsChange: { fromTier: "credits_50", toTier: null },
+    });
+
+    const chip = getByTestId("chip-credits");
+    expect(chip.textContent).toContain("Mighty Usage");
+    expect(chip.textContent).toContain("No extra usage");
+    expect(chip.textContent).not.toContain("$");
+  });
+
+  test("a checkout credits chip reads as bundles too", () => {
+    const { getByTestId, queryByText } = renderState({
+      state: "WAITING",
+      intent: { kind: "package", packageKey: "mighty", savedAt: Date.now() },
+    });
+
+    const chip = getByTestId("chip-credits");
+    expect(chip.textContent).toContain("No extra usage");
+    expect(chip.textContent).toContain("Mighty Usage");
+    expect(queryByText("$0/mo")).toBeNull();
+    expect(queryByText("Credits")).toBeNull();
+  });
+
+  test("a from-side the catalog can't label is left unstated", () => {
+    // credits_25 is absent from the fixture catalog: its key still prices the
+    // off-flag rate, but under the flag there is no wording to show for it.
+    const { getByTestId } = renderState({
+      state: "WAITING",
+      creditsChange: { fromTier: "credits_25", toTier: "credits_50" },
+    });
+
+    const chip = getByTestId("chip-credits");
+    expect(chip.textContent).toContain("Mighty Usage");
+    expect(chip.textContent).not.toContain("25");
+    expect(chip.querySelector(".lucide-arrow-right")).toBeNull();
+  });
+
+  test("a to-side the catalog can't label drops the chip, not the disguise", () => {
+    const { queryByTestId } = renderState({
+      state: "WAITING",
+      creditsChange: { fromTier: "credits_50", toTier: "credits_25" },
+    });
+
+    expect(queryByTestId("chip-credits")).toBeNull();
+  });
+
+  test("the confirming custom-intent chip names the bundle, not a count", () => {
+    const { getByText, queryByText } = renderState({
+      state: "CONFIRMING",
+      intent: {
+        kind: "custom",
+        machineTier: "medium",
+        storageTier: "s",
+        creditTier: "credits_50",
+        savedAt: Date.now(),
+      },
+    });
+
+    expect(getByText("Mighty Usage")).toBeTruthy();
+    expect(queryByText("50 credits")).toBeNull();
   });
 });

--- a/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/provisioning-state.tsx
@@ -18,6 +18,7 @@ import {
 import { ChatAvatar } from "@/components/avatar/chat-avatar";
 import { formatMonthly } from "@/domains/settings/components/tier-pricing";
 import type { MachineSizeEnum } from "@/generated/api/types.gen";
+import { useObscureCredits } from "@/hooks/use-obscure-credits-flag";
 import type { CheckoutIntent } from "@/lib/billing/checkout-intent";
 import { MACHINE_TIER_LABEL } from "@/lib/billing/machine-sizes";
 import type { ProvisioningDimensionFlags } from "@/lib/billing/provisioning-targets";
@@ -34,6 +35,7 @@ import type {
 import { SERIF_HEADING_STYLE } from "./primitives";
 import {
   buildResourceChanges,
+  type CreditsChipContent,
   type ResourceChangeKey,
 } from "./resource-changes";
 import { TakeoverBackdrop } from "./takeover-backdrop";
@@ -41,6 +43,7 @@ import { takeoverCopy, type TakeoverDirection } from "./takeover-copy";
 import {
   useProvisioningCredits,
   useResizeCreditsChange,
+  type CreditsChange,
   type CreditTierChange,
 } from "./use-provisioning-credits";
 import { useTakeoverSurface } from "./use-takeover-surface";
@@ -469,11 +472,49 @@ function chipDone(
   return landed?.[key] === true;
 }
 
+type SettingsTranslate = ReturnType<typeof useTranslation<"settings">>["t"];
+
+/**
+ * The credits chip's strings. Off the flag, a from-to pair of monthly rates
+ * ("$0/mo" → "$50/mo"). Under `obscure-credits` no amount may render: each
+ * side names its bundle by catalog label, the no-bundle side reads as the "No
+ * extra usage" sentinel, and a side the catalog can't label is left unstated:
+ * an unstated from-side just drops the arrow, an unstated to-side drops the
+ * whole chip rather than asserting a bundle it cannot name. The row label
+ * swaps to "Usage" so the chip never introduces credits as a concept.
+ */
+function creditsChipContent(
+  credits: CreditsChange | null,
+  obscureCredits: boolean,
+  t: SettingsTranslate,
+): CreditsChipContent | null {
+  if (credits == null) {
+    return null;
+  }
+  if (!obscureCredits) {
+    return {
+      from: formatMonthly(credits.fromUsd * 100),
+      to: formatMonthly(credits.toUsd * 100),
+    };
+  }
+  const noExtraUsage = t("provisioningState.noExtraUsage");
+  const to = credits.toLabel === null ? noExtraUsage : credits.toLabel;
+  if (to == null) {
+    return null;
+  }
+  return {
+    label: t("provisioningState.usageLabel"),
+    from: credits.fromLabel === null ? noExtraUsage : credits.fromLabel,
+    to,
+  };
+}
+
 /**
  * The takeover's resource chips: every applicable change as a `{current} ->
  * {new}` chip (machine and storage from `targets`, `fromSnapshot` and the
  * display-only `machineFloor`; credits as a from-to monthly rate, `$0/mo` on
- * the from-side for a base-to-pro checkout).
+ * the from-side for a base-to-pro checkout, or as `creditsChipContent`'s
+ * obscured bundle names when the flag is on).
  *
  * All of them render together from the first paint of the wait, each carrying
  * its own progress: dimmed with a spinner while its dimension is still moving,
@@ -515,6 +556,7 @@ function ResourceChangeChips({
   creditsOnly?: boolean;
 }) {
   const { t } = useTranslation("settings");
+  const obscureCredits = useObscureCredits();
   // Checkout reads the stashed intent, an in-place change carries its own
   // tiers, and a takeover runs in exactly one of those modes, so at most one of
   // these resolves.
@@ -525,13 +567,7 @@ function ResourceChangeChips({
     targets,
     fromSnapshot,
     machineFloor,
-    credits:
-      credits != null
-        ? {
-            from: formatMonthly(credits.fromUsd * 100),
-            to: formatMonthly(credits.toUsd * 100),
-          }
-        : null,
+    credits: creditsChipContent(credits, obscureCredits, t),
   });
   const changes = creditsOnly
     ? built.filter((change) => change.key === "credits")
@@ -577,9 +613,19 @@ function ResourceChangeChips({
   );
 }
 
-/** CONFIRMING chips: derived from the stashed intent before any API data lands. */
+/**
+ * CONFIRMING chips: derived from the stashed intent before any API data lands.
+ * The one exception is the custom intent's bundle chip under `obscure-credits`:
+ * its wording is the bundle's catalog label rather than a credit count, so it
+ * waits on the plan catalog (usually already cached by the page that stashed
+ * the intent) and is simply absent until that resolves.
+ */
 function IntentChips({ intent }: { intent: CheckoutIntent }) {
   const { t } = useTranslation("settings");
+  const obscureCredits = useObscureCredits();
+  const credits = useProvisioningCredits(
+    obscureCredits && intent.kind === "custom" ? intent : null,
+  );
   if (intent.kind === "package") {
     const name =
       intent.packageKey.charAt(0).toUpperCase() + intent.packageKey.slice(1);
@@ -614,13 +660,16 @@ function IntentChips({ intent }: { intent: CheckoutIntent }) {
           to={intent.storageTier.toUpperCase()}
         />
       )}
-      {intent.creditTier != null && (
-        <TextChip
-          label={t("provisioningState.creditsChip", {
-            count: intent.creditTier.replace("credits_", ""),
-          })}
-        />
-      )}
+      {intent.creditTier != null &&
+        (obscureCredits ? (
+          credits?.toLabel != null && <TextChip label={credits.toLabel} />
+        ) : (
+          <TextChip
+            label={t("provisioningState.creditsChip", {
+              count: intent.creditTier.replace("credits_", ""),
+            })}
+          />
+        ))}
     </ChipRow>
   );
 }

--- a/clients/web/src/domains/settings/billing/pro-onboarding/resource-changes.test.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/resource-changes.test.ts
@@ -105,6 +105,23 @@ describe("buildResourceChanges", () => {
     expect(changes.map((c) => c.key)).toEqual(["credits"]);
   });
 
+  test("takes the credits label override the obscured wording passes", () => {
+    const changes = buildResourceChanges({
+      targets: { machineSize: null, storageGib: null },
+      fromSnapshot: { machineSize: null, storageGib: null },
+      credits: { label: "Usage", from: "No extra usage", to: "Mighty Usage" },
+    });
+
+    expect(changes).toEqual([
+      {
+        key: "credits",
+        label: "Usage",
+        from: "No extra usage",
+        to: "Mighty Usage",
+      },
+    ]);
+  });
+
   test("keeps a storage-only change free of a machine row", () => {
     const changes = buildResourceChanges({
       targets: { machineSize: "medium", storageGib: 50 },

--- a/clients/web/src/domains/settings/billing/pro-onboarding/resource-changes.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/resource-changes.ts
@@ -13,6 +13,17 @@ export interface ResourceChange {
 }
 
 /**
+ * The credits chip's pre-worded strings: monthly rates by default, bundle
+ * names under `obscure-credits`, which also overrides the row label ("Usage")
+ * and may leave the from-side unstated when the catalog can't word it.
+ */
+export interface CreditsChipContent {
+  label?: string;
+  from?: string;
+  to: string;
+}
+
+/**
  * Flattens the provisioning targets into the ordered list of resource changes
  * the takeover rotates through, each as a current→new pair. Order is fixed at
  * machine → storage → credits to mirror the chip order in provisioning-state.
@@ -46,7 +57,7 @@ export function buildResourceChanges(input: {
   targets: ProvisioningDimensions;
   fromSnapshot: ProvisioningDimensions;
   machineFloor?: MachineSizeEnum | null;
-  credits: { from: string; to: string } | null;
+  credits: CreditsChipContent | null;
 }): ResourceChange[] {
   const { targets, fromSnapshot, machineFloor, credits } = input;
   const changes: ResourceChange[] = [];
@@ -95,7 +106,7 @@ export function buildResourceChanges(input: {
   if (credits != null) {
     changes.push({
       key: "credits",
-      label: "Credits",
+      label: credits.label ?? "Credits",
       from: credits.from,
       to: credits.to,
     });

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-provisioning-credits.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-provisioning-credits.test.tsx
@@ -32,7 +32,12 @@ mock.module("@/hooks/use-is-org-ready", () => ({
 const { useProvisioningCredits, useResizeCreditsChange } =
   await import("./use-provisioning-credits");
 
-/** A pro-plan catalog with a `credits_50` tier and a Mighty package on it. */
+/**
+ * A pro-plan catalog with a `credits_50` tier and a Mighty package on it. The
+ * tier label is a usage bundle's Stripe product name, amount-free like the
+ * real catalog's, and deliberately distinct from the package's `usage_label`
+ * so the label-precedence assertions can tell the two apart.
+ */
 function plansResponse(): PlanListResponse {
   return {
     plans: [
@@ -48,7 +53,7 @@ function plansResponse(): PlanListResponse {
         credit_tiers: [
           {
             tier: "credits_50",
-            label: "$50 credits/mo",
+            label: "Mighty Usage Monthly",
             credits_usd: 50,
             price_cents: 5000,
             lookup_key: "credits_50_key",
@@ -175,7 +180,7 @@ describe("useProvisioningCredits", () => {
       fromUsd: 0,
       toUsd: 50,
       fromLabel: null,
-      // The customer-facing usage_label wins over the dollar-y tier label.
+      // The customer-facing usage_label wins over the tier label.
       toLabel: "Mighty Usage",
     });
   });
@@ -190,7 +195,7 @@ describe("useProvisioningCredits", () => {
       fromUsd: 0,
       toUsd: 50,
       fromLabel: null,
-      toLabel: "$50 credits/mo",
+      toLabel: "Mighty Usage Monthly",
     });
   });
 
@@ -235,7 +240,7 @@ describe("useProvisioningCredits", () => {
       fromUsd: 0,
       toUsd: 50,
       fromLabel: null,
-      toLabel: "$50 credits/mo",
+      toLabel: "Mighty Usage Monthly",
     });
   });
 
@@ -274,7 +279,7 @@ describe("useResizeCreditsChange", () => {
       fromUsd: 0,
       toUsd: 50,
       fromLabel: null,
-      toLabel: "$50 credits/mo",
+      toLabel: "Mighty Usage Monthly",
     });
   });
 
@@ -285,7 +290,7 @@ describe("useResizeCreditsChange", () => {
     ).toEqual({
       fromUsd: 50,
       toUsd: 0,
-      fromLabel: "$50 credits/mo",
+      fromLabel: "Mighty Usage Monthly",
       toLabel: null,
     });
   });
@@ -303,7 +308,7 @@ describe("useResizeCreditsChange", () => {
       toUsd: 50,
       // No catalog entry to word the held tier, so its label side is absent.
       fromLabel: undefined,
-      toLabel: "$50 credits/mo",
+      toLabel: "Mighty Usage Monthly",
     });
   });
 

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-provisioning-credits.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-provisioning-credits.test.tsx
@@ -13,6 +13,7 @@ import { organizationsBillingPlansRetrieveQueryKey } from "@/generated/api/@tans
 import type {
   CreditTierEnum,
   PlanListResponse,
+  ProPlan,
 } from "@/generated/api/types.gen";
 import type { CheckoutIntent } from "@/lib/billing/checkout-intent";
 
@@ -170,7 +171,12 @@ describe("useProvisioningCredits", () => {
         { kind: "package", packageKey: "mighty", savedAt: 0 },
         plansResponse(),
       ),
-    ).toEqual({ fromUsd: 0, toUsd: 50 });
+    ).toEqual({
+      fromUsd: 0,
+      toUsd: 50,
+      fromLabel: null,
+      toLabel: "$50 credits/mo",
+    });
   });
 
   test("falls back to the package's credit tier when it carries no credits_usd", () => {
@@ -179,7 +185,28 @@ describe("useProvisioningCredits", () => {
         { kind: "package", packageKey: "tierless", savedAt: 0 },
         plansResponse(),
       ),
-    ).toEqual({ fromUsd: 0, toUsd: 50 });
+    ).toEqual({
+      fromUsd: 0,
+      toUsd: 50,
+      fromLabel: null,
+      toLabel: "$50 credits/mo",
+    });
+  });
+
+  test("labels from the package's usage_label when its tier is missing from the catalog", () => {
+    const plans = plansResponse();
+    (plans.plans[0] as ProPlan).credit_tiers = [];
+    expect(
+      renderCredits(
+        { kind: "package", packageKey: "mighty", savedAt: 0 },
+        plans,
+      ),
+    ).toEqual({
+      fromUsd: 0,
+      toUsd: 50,
+      fromLabel: null,
+      toLabel: "Mighty Usage",
+    });
   });
 
   test("returns null for an unknown package key", () => {
@@ -203,7 +230,12 @@ describe("useProvisioningCredits", () => {
         },
         plansResponse(),
       ),
-    ).toEqual({ fromUsd: 0, toUsd: 50 });
+    ).toEqual({
+      fromUsd: 0,
+      toUsd: 50,
+      fromLabel: null,
+      toLabel: "$50 credits/mo",
+    });
   });
 
   test("returns null for a custom intent without credits", () => {
@@ -237,14 +269,24 @@ describe("useResizeCreditsChange", () => {
   test("resolves both sides from the catalog", () => {
     expect(
       renderChange({ fromTier: null, toTier: "credits_50" }, plansResponse()),
-    ).toEqual({ fromUsd: 0, toUsd: 50 });
+    ).toEqual({
+      fromUsd: 0,
+      toUsd: 50,
+      fromLabel: null,
+      toLabel: "$50 credits/mo",
+    });
   });
 
   test("reads a dropped bundle as a move down to $0", () => {
     // "No extra credits" is a real endpoint of the change, not a missing side.
     expect(
       renderChange({ fromTier: "credits_50", toTier: null }, plansResponse()),
-    ).toEqual({ fromUsd: 50, toUsd: 0 });
+    ).toEqual({
+      fromUsd: 50,
+      toUsd: 0,
+      fromLabel: "$50 credits/mo",
+      toLabel: null,
+    });
   });
 
   test("reads a held tier the catalog no longer lists off its key", () => {
@@ -255,7 +297,13 @@ describe("useResizeCreditsChange", () => {
         { fromTier: "credits_115", toTier: "credits_50" },
         plansResponse(),
       ),
-    ).toEqual({ fromUsd: 115, toUsd: 50 });
+    ).toEqual({
+      fromUsd: 115,
+      toUsd: 50,
+      // No catalog entry to word the held tier, so its label side is absent.
+      fromLabel: undefined,
+      toLabel: "$50 credits/mo",
+    });
   });
 
   test("omits the chip when a tier carries no resolvable amount", () => {

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-provisioning-credits.test.tsx
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-provisioning-credits.test.tsx
@@ -175,7 +175,8 @@ describe("useProvisioningCredits", () => {
       fromUsd: 0,
       toUsd: 50,
       fromLabel: null,
-      toLabel: "$50 credits/mo",
+      // The customer-facing usage_label wins over the dollar-y tier label.
+      toLabel: "Mighty Usage",
     });
   });
 

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-provisioning-credits.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-provisioning-credits.ts
@@ -105,9 +105,10 @@ export function useProvisioningCredits(
     const pkg = proPlan.packages.find((p) => p.key === intent.packageKey);
     const tier = findCreditTier(proPlan, pkg?.credit_tier);
     toUsd = pkg?.credits_usd ?? tier?.credits_usd;
-    // The tier's catalog label is preferred over the package's own usage
-    // label, matching the invoice line; they name the same bundle either way.
-    toLabel = tier?.label ?? pkg?.usage_label ?? undefined;
+    // The package's customer-facing usage_label is preferred: a tier label
+    // can be dollar-denominated ("$50 credits/mo"), which the obscured chip
+    // must never render. The tier label covers a package without one.
+    toLabel = pkg?.usage_label ?? tier?.label ?? undefined;
   } else {
     const tier = findCreditTier(proPlan, intent.creditTier);
     toUsd = tier?.credits_usd;

--- a/clients/web/src/domains/settings/billing/pro-onboarding/use-provisioning-credits.ts
+++ b/clients/web/src/domains/settings/billing/pro-onboarding/use-provisioning-credits.ts
@@ -9,10 +9,18 @@ import { creditTierKeyUsd, findCreditTier } from "@/lib/billing/credit-tiers";
 /**
  * A credit bundle change as monthly dollar amounts. Both sides always carry a
  * number: "No extra credits" is $0, not an absent side.
+ *
+ * Each side also carries the bundle's catalog label ("Mighty Usage", the
+ * Stripe product name, so it matches the invoice line), which the
+ * `obscure-credits` rendering shows in place of the dollar rate. `null` marks
+ * the explicit no-bundle side, worded by the caller; `undefined` a bundle the
+ * catalog can't label, which the obscured chip leaves unstated.
  */
 export interface CreditsChange {
   fromUsd: number;
   toUsd: number;
+  fromLabel: string | null | undefined;
+  toLabel: string | null | undefined;
 }
 
 /**
@@ -60,6 +68,23 @@ function creditTierUsd(
 }
 
 /**
+ * The catalog label for a tier, with the same null-tier reading as
+ * `creditTierUsd`: a null tier is the explicit "No extra credits" choice
+ * (`null` here), and a tier the catalog doesn't list has no label to give
+ * (`undefined`); unlike the dollars, a key like `credits_115` carries no
+ * wording to fall back to.
+ */
+function creditTierLabel(
+  proPlan: ProPlan | undefined,
+  tier: CreditTierEnum | null,
+): string | null | undefined {
+  if (tier == null) {
+    return null;
+  }
+  return findCreditTier(proPlan, tier)?.label;
+}
+
+/**
  * The credits a post-Stripe checkout buys, as a from-to dollar pair. The base
  * plan bundles none, so the from-side is $0. Returns null while the catalog
  * loads, when the intent carries no credits, or when the amount can't be
@@ -75,16 +100,23 @@ export function useProvisioningCredits(
   }
 
   let toUsd: number | null | undefined;
+  let toLabel: string | null | undefined;
   if (intent.kind === "package") {
     const pkg = proPlan.packages.find((p) => p.key === intent.packageKey);
-    toUsd =
-      pkg?.credits_usd ??
-      findCreditTier(proPlan, pkg?.credit_tier)?.credits_usd;
+    const tier = findCreditTier(proPlan, pkg?.credit_tier);
+    toUsd = pkg?.credits_usd ?? tier?.credits_usd;
+    // The tier's catalog label is preferred over the package's own usage
+    // label, matching the invoice line; they name the same bundle either way.
+    toLabel = tier?.label ?? pkg?.usage_label ?? undefined;
   } else {
-    toUsd = findCreditTier(proPlan, intent.creditTier)?.credits_usd;
+    const tier = findCreditTier(proPlan, intent.creditTier);
+    toUsd = tier?.credits_usd;
+    toLabel = tier?.label;
   }
 
-  return toUsd != null ? { fromUsd: 0, toUsd } : null;
+  // The base plan bundles no credits, so the from-side is the explicit
+  // no-bundle choice, not an unlabelled one.
+  return toUsd != null ? { fromUsd: 0, toUsd, fromLabel: null, toLabel } : null;
 }
 
 /**
@@ -107,5 +139,10 @@ export function useResizeCreditsChange(
   if (fromUsd == null || toUsd == null) {
     return null;
   }
-  return { fromUsd, toUsd };
+  return {
+    fromUsd,
+    toUsd,
+    fromLabel: creditTierLabel(proPlan, change.fromTier),
+    toLabel: creditTierLabel(proPlan, change.toTier),
+  };
 }

--- a/clients/web/src/i18n/locales/en/settings.json
+++ b/clients/web/src/i18n/locales/en/settings.json
@@ -1651,6 +1651,7 @@
     "dimensionsComplete": "{dimensions} complete",
     "goToBilling": "Go to billing",
     "machineLabel": "Machine",
+    "noExtraUsage": "No extra usage",
     "packageChip": "{name} package",
     "planReadyStatus": "Your plan is ready",
     "retryInBackground": "Retry in the background",
@@ -1661,6 +1662,7 @@
     "storageLabel": "Storage",
     "takingLongerStatus": "This is taking longer than expected",
     "tryAgain": "Try again",
+    "usageLabel": "Usage",
     "waitingCaptionLong": "Still working. This can take a minute or two.",
     "waitingCaptionShort": "This might take a couple seconds."
   },

--- a/clients/web/src/i18n/locales/es/settings.json
+++ b/clients/web/src/i18n/locales/es/settings.json
@@ -1651,6 +1651,7 @@
     "dimensionsComplete": "{dimensions} completado",
     "goToBilling": "Ir a facturación",
     "machineLabel": "Máquina",
+    "noExtraUsage": "Sin uso adicional",
     "packageChip": "paquete {name}",
     "planReadyStatus": "Tu plan está listo",
     "retryInBackground": "Reintentar en segundo plano",
@@ -1661,6 +1662,7 @@
     "storageLabel": "Almacenamiento",
     "takingLongerStatus": "Esto está tardando más de lo esperado",
     "tryAgain": "Intentar de nuevo",
+    "usageLabel": "Uso",
     "waitingCaptionLong": "Seguimos trabajando. Esto puede tardar uno o dos minutos.",
     "waitingCaptionShort": "Esto puede tardar unos segundos."
   },

--- a/clients/web/src/i18n/locales/ru/settings.json
+++ b/clients/web/src/i18n/locales/ru/settings.json
@@ -1651,6 +1651,7 @@
     "dimensionsComplete": "{dimensions} готово",
     "goToBilling": "К оплате",
     "machineLabel": "Машина",
+    "noExtraUsage": "Без дополнительного использования",
     "packageChip": "пакет {name}",
     "planReadyStatus": "План готов",
     "retryInBackground": "Повторить в фоне",
@@ -1661,6 +1662,7 @@
     "storageLabel": "Хранилище",
     "takingLongerStatus": "Это занимает больше времени, чем ожидалось",
     "tryAgain": "Попробовать снова",
+    "usageLabel": "Использование",
     "waitingCaptionLong": "Ещё работаем. Это может занять минуту или две.",
     "waitingCaptionShort": "Это может занять пару секунд."
   },


### PR DESCRIPTION
## Summary
- With the obscure-credits flag on, the plan-change/resize takeover's credits chip no longer shows monthly dollar rates ("$0/mo -> $50/mo"): it names the usage bundles instead ("No extra usage -> Mighty Usage") under a "Usage" row label, using the tier's catalog label the way the custom plan modal's recap does. A side the catalog can't label is left unstated rather than shown as an amount (an unstated to-side drops the whole chip).
- The CONFIRMING phase's custom-intent chip likewise swaps its "{count} credits" wording for the bundle's catalog label under the flag, resolving it from the (typically already cached) plan catalog.
- The provisioning credits hooks now return each side's catalog label alongside the dollars; new provisioningState.noExtraUsage and provisioningState.usageLabel keys land in en/es/ru; tests cover both flag states. Off the flag every phase renders exactly what it does today.

## Original prompt
after a user upgrades their pro plan or changes we show a screen while their assistant is resizing/restarting. That screen shows the change in credits in some cases but it is showing an actual dollar amount instead of something like "free usage -> mighty usage"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KZrPsHUsQL25gbh8MTB38Q
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41302" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->