### PR TITLE
style(web): flatten the in-chat choice surface

### DIFF
--- a/clients/web/src/domains/chat/components/surfaces/choice-surface.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/choice-surface.tsx
@@ -140,7 +140,9 @@ export function ChoiceSurface({
   };
 
   return (
-    <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-lift)] p-4">
+    // No panel chrome or padding around the options: the rows carry their own
+    // raised surface, so an outer inset only nested one box inside another.
+    <div>
       {surface.title && (
         <div className="text-title-small text-[var(--content-strong)]">
           {surface.title}
@@ -154,7 +156,7 @@ export function ChoiceSurface({
         />
       )}
 
-      <div className="mt-3 grid gap-2">
+      <div className="grid gap-2 [&:not(:first-child)]:mt-3">
         {options.map((option) => {
           const selected = selectedIds.has(option.id);
           const optionSubmitting = submitting === option.id;
@@ -166,17 +168,21 @@ export function ChoiceSurface({
               disabled={submitting !== null}
               onClick={() => toggleOption(option)}
               className={[
-                "group flex w-full items-start gap-3 rounded-lg border p-3 text-left transition-colors",
+                // Borderless: the row reads as a row because it sits one step
+                // up the surface ladder from the chat background
+                // (`--background` == `--surface-base`), not because of an
+                // outline. Hover takes the ladder's next step.
+                "group flex w-full cursor-pointer items-center gap-3 rounded-lg p-3 text-left transition-colors disabled:cursor-default",
                 option.recommended
-                  ? "border-[var(--primary-base)] bg-[var(--primary-base)]/10"
-                  : "border-[var(--border-element)] bg-[var(--surface-base)] hover:bg-[var(--surface-hover)]",
+                  ? "bg-[var(--primary-base)]/10"
+                  : "bg-[var(--surface-overlay)] hover:bg-[var(--surface-active)]",
                 selected ? "ring-1 ring-[var(--primary-base)]" : "",
                 submitting !== null ? "opacity-70" : "",
               ].join(" ")}
             >
               <span
                 className={[
-                  "mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full border",
+                  "flex h-5 w-5 shrink-0 items-center justify-center rounded-full border",
                   selected
                     ? "border-[var(--primary-base)] bg-[var(--primary-base)] text-[var(--content-inset)]"
                     : option.recommended
@@ -218,7 +224,7 @@ export function ChoiceSurface({
             type="button"
             disabled={selectedOptions.length === 0 || submitting !== null}
             onClick={handleSubmit}
-            className="inline-flex items-center gap-2 rounded-lg bg-[var(--primary-base)] px-4 py-2 text-body-medium-default text-[var(--content-inset)] transition-opacity hover:opacity-90 disabled:opacity-50"
+            className="inline-flex cursor-pointer items-center gap-2 rounded-lg bg-[var(--primary-base)] px-4 py-2 text-body-medium-default text-[var(--content-inset)] transition-opacity hover:opacity-90 disabled:cursor-default disabled:opacity-50"
           >
             {submitting === "submit" && (
               <Loader2 className="h-4 w-4 animate-spin" />


### PR DESCRIPTION
The choice surface wrapped its options in a bordered `--surface-lift` panel with `p-4`, so each option row sat in a box inside a box. Drop the panel and its padding, and let the rows carry the shape themselves:

- Options lose their border and move one step up the surface ladder from the chat background (`--background` == `--surface-base`), landing on `--surface-overlay`. Hover moves to `--surface-active`, the ladder's hover partner; the old `--surface-hover` wash would have read as darker than the new resting fill.
- Rows center their radio and label vertically (`items-center`, minus the `mt-0.5` nudge that only made sense under `items-start`).
- Option and submit buttons get `cursor-pointer`, with `cursor-default` back when disabled.
- The options grid only takes its top margin when a title or description renders above it, so a bare choice list starts flush.

<!-- PR title format: type(scope): description -->
<!-- Examples: feat(slack): add user token support, fix(cli): handle missing config, docs(architecture): update API table -->

## Prompt / plan
<!-- What prompt or plan was used to generate this code? Link to a plan file, paste the prompt, or describe the approach. -->

## Test plan
<!-- How was this change verified? e.g. unit tests, manual testing, CI checks -->

## CLI verb checklist
<!-- For PRs that add a new IPC route under assistant/src/runtime/routes/: -->
<!-- - [ ] Does this route need an `assistant` CLI verb? If yes, add a thin -->
<!--       wrapper in assistant/src/cli/commands/ via registerCommand (same -->
<!--       PR or a follow-up). -->
<!-- - [ ] If no, leave a one-line note explaining why (e.g. internal-only, -->
<!--       composed by another command). -->
<!-- Delete this section if your PR does not add any new routes. -->
