### PR TITLE
fix(openrouter): align DeepSeek rates with the live OpenRouter card

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2744,7 +2744,7 @@ jobs:
   ci-gateway:
     needs: extract-version
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/assistant/src/providers/model-catalog.ts
+++ b/assistant/src/providers/model-catalog.ts
@@ -1461,9 +1461,9 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         supportsVision: false,
         supportsToolUse: true,
         pricing: {
-          inputPer1mTokens: 0.790308,
-          outputPer1mTokens: 1.580616,
-          cacheReadPer1mTokens: 0.065859,
+          inputPer1mTokens: 0.579072,
+          outputPer1mTokens: 1.158144,
+          cacheReadPer1mTokens: 0.048256,
         },
       },
       {
@@ -1476,9 +1476,9 @@ const RAW_PROVIDER_CATALOG: ProviderCatalogEntry[] = [
         supportsVision: false,
         supportsToolUse: true,
         pricing: {
-          inputPer1mTokens: 0.088606,
-          outputPer1mTokens: 0.177212,
-          cacheReadPer1mTokens: 0.0177212,
+          inputPer1mTokens: 0.0854,
+          outputPer1mTokens: 0.1708,
+          cacheReadPer1mTokens: 0.01708,
         },
       },
       // Qwen

--- a/meta/llm-provider-catalog.json
+++ b/meta/llm-provider-catalog.json
@@ -1347,9 +1347,9 @@
           "supportsVision": false,
           "supportsToolUse": true,
           "pricing": {
-            "inputPer1mTokens": 0.790308,
-            "outputPer1mTokens": 1.580616,
-            "cacheReadPer1mTokens": 0.065859
+            "inputPer1mTokens": 0.579072,
+            "outputPer1mTokens": 1.158144,
+            "cacheReadPer1mTokens": 0.048256
           }
         },
         {
@@ -1364,9 +1364,9 @@
           "supportsVision": false,
           "supportsToolUse": true,
           "pricing": {
-            "inputPer1mTokens": 0.088606,
-            "outputPer1mTokens": 0.177212,
-            "cacheReadPer1mTokens": 0.0177212
+            "inputPer1mTokens": 0.0854,
+            "outputPer1mTokens": 0.1708,
+            "cacheReadPer1mTokens": 0.01708
           }
         },
         {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan
The [v0.11.6 staging Release](https://github.com/vellum-ai/vellum-assistant/actions/runs/32845437229) failed. Two jobs were red:

1. `ci-assistant` failed `openrouter-catalog-parity.test.ts`. OpenRouter repriced `deepseek/deepseek-v4-pro` and `deepseek/deepseek-v4-flash` again after #41297, so the live card is more than 2% off the catalog.
2. `ci-gateway` hit the Release workflow's 5-minute timeout during Test. The dedicated gateway workflow and `dev-release.yaml` already allow 10 minutes. The Test step had been running for 4m44s when the job was cancelled.

Image-manifest jobs then failed because those CI jobs did not succeed.

This follows the same catalog-sync approach as #41297: write the live OpenRouter per-1M rates into the `openrouter` block and regenerate `meta/llm-provider-catalog.json`. The vercel-ai-gateway DeepSeek entry is a different card and stays untouched.

The timeout change is only in `release.yml` `ci-gateway`, matching `ci-main-gateway.yaml` / `dev-release.yaml`.

## Test plan
- Live OpenRouter `/api/v1/models` fetch: only these two ids drift against current `main`.
- `cd assistant && bun test src/__tests__/openrouter-catalog-parity.test.ts`
- `cd assistant && bun test src/__tests__/llm-catalog-parity.test.ts`
- `cd assistant && bun run sync:llm-catalog -- --check`

## After merge
Recut the release branch from `main` (do not promote). The existing `release/v0.11.6` cut already includes #41297 and will stay red until this lands and the branch is recut:

```bash
gh workflow run create-release-branch.yml \
  --repo vellum-ai/vellum-assistant \
  --ref main \
  --field bump=patch
```

## Risk
Low. Catalog numbers are display/estimate rates for OpenRouter BYOK. No schema, billing, or hosted-model rate-card change. The gateway timeout bump only affects Release CI budget, not the suite.

## CLI verb checklist
Not applicable. No new routes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ee6dc65e-1862-444e-814d-0d00efccd736?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ee6dc65e-1862-444e-814d-0d00efccd736&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

