### PR TITLE
test(live-voice): allow timer slack on flux commit-latency floors

### DIFF
--- a/assistant/src/live-voice/__tests__/live-voice-flux-turn-end.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-flux-turn-end.test.ts
@@ -410,7 +410,10 @@ describe("LiveVoiceSession Flux end-of-turn", () => {
     await waitFor(() => turnCalls.length === 1);
 
     const metricsFrame = await waitForTurnMetrics(frames);
-    expect(metricsFrame.endpointCommitLatencyMs).toBeGreaterThanOrEqual(250);
+    // Date.now() vs setTimeout can undershoot the sleep by a millisecond on
+    // a loaded runner. The assertion is that the speech-stop anchor saw the
+    // pause, not that the timer is exact.
+    expect(metricsFrame.endpointCommitLatencyMs).toBeGreaterThanOrEqual(240);
 
     await session.close("client_end");
   });
@@ -435,7 +438,10 @@ describe("LiveVoiceSession Flux end-of-turn", () => {
     // the two arms one population rather than two.
     const metricsFrame = await waitForTurnMetrics(frames);
     expect(metricsFrame.endpointDecisionSource).toBeUndefined();
-    expect(metricsFrame.endpointCommitLatencyMs).toBeGreaterThanOrEqual(40);
+    // The silence timer is 40 ms. CI clock jitter can report 39. The
+    // assertion is that the front-door path recorded a silence-scale
+    // latency, not that setTimeout fired on the exact millisecond.
+    expect(metricsFrame.endpointCommitLatencyMs).toBeGreaterThanOrEqual(30);
 
     await session.close("client_end");
   });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan

The [v0.11.6 Release `ci-assistant` job](https://github.com/vellum-ai/vellum-assistant/actions/runs/32851711562/job/97814140760) failed `live-voice-flux-turn-end.test.ts`. The front-door commit-latency assertion required `>= 40` ms (the silence threshold) and CI reported `39`.

#41310 already landed on `main` and deleted the live OpenRouter rate check, so the catalog half of the original change is gone. This PR is only the flux flake: 10 ms of `Date.now()` / `setTimeout` slack so a 1 ms undershoot does not fail the suite.

## Test plan

- `cd assistant && bun test src/live-voice/__tests__/live-voice-flux-turn-end.test.ts`

## Risk

Test-only. No runtime, catalog, or billing change.

## CLI verb checklist

Not applicable. No new routes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5450d17c-d67e-41cb-bd97-70554f8a7208?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5450d17c-d67e-41cb-bd97-70554f8a7208&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

