### PR TITLE
fix(web): reactivate subscriptions via the new endpoint instead of the Stripe portal

### DIFF
--- a/clients/web/src/domains/settings/billing/use-cancel-subscription.ts
+++ b/clients/web/src/domains/settings/billing/use-cancel-subscription.ts
@@ -1,37 +1,26 @@
-import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "@vellumai/design-library/components/toast";
 
+import { useSubscriptionAction } from "@/domains/settings/billing/use-subscription-action";
 import { formatGraceDate } from "@/domains/settings/hooks/use-billing-portal-session";
-import {
-  organizationsBillingSubscriptionRetrieveQueryKey,
-  useOrganizationsBillingSubscriptionCancelCreateMutation,
-} from "@/generated/api/@tanstack/react-query.gen";
+import { useOrganizationsBillingSubscriptionCancelCreateMutation } from "@/generated/api/@tanstack/react-query.gen";
 import type { SubscriptionCancelResponse } from "@/generated/api/types.gen";
 import { t } from "@/i18n";
 
-import { extractMutationError } from "@/domains/settings/components/adjust-plan-utils";
-
 /**
  * Shared wiring for the "Downgrade to Base" confirms (adjust-plan modal, plans
- * takeover). Posts to the subscription-cancel endpoint, which schedules the Pro
- * sub to end at the current period boundary server-side (no Stripe portal
- * round-trip), then invalidates the subscription read so the pending state
- * (`cancel_at_period_end` / `cancel_at`) surfaces everywhere, and toasts the
- * end date. A `no_op` (cancellation already pending, e.g. scheduled earlier via
- * the portal) reads the same to the user, so it shares the success toast.
- * Errors toast and resolve null so the confirm UI can stay open for a retry.
+ * takeover). Posts to the subscription-cancel endpoint, which schedules the
+ * Pro sub to end at the current period boundary server-side, and toasts the
+ * end date. A `no_op` (cancellation already pending, e.g. scheduled earlier
+ * via the portal) reads the same to the user, so it shares the success toast.
  */
 export function useCancelSubscription() {
-  const queryClient = useQueryClient();
   const mutation = useOrganizationsBillingSubscriptionCancelCreateMutation();
+  const runSubscriptionAction = useSubscriptionAction();
 
-  const cancelSubscription =
-    async (): Promise<SubscriptionCancelResponse | null> => {
-      try {
-        const result = await mutation.mutateAsync({});
-        await queryClient.invalidateQueries({
-          queryKey: organizationsBillingSubscriptionRetrieveQueryKey(),
-        });
+  const cancelSubscription = (): Promise<SubscriptionCancelResponse | null> =>
+    runSubscriptionAction({
+      mutateAsync: () => mutation.mutateAsync({}),
+      onSuccess: (result) => {
         const date = result.cancel_at
           ? formatGraceDate(result.cancel_at)
           : t("settings:useCancelSubscription.endOfBillingPeriod");
@@ -39,18 +28,11 @@ export function useCancelSubscription() {
           t("settings:useCancelSubscription.canceledToast", { date }),
           { id: "subscription-cancel" },
         );
-        return result;
-      } catch (error) {
-        toast.error(
-          extractMutationError(
-            error,
-            t("settings:useCancelSubscription.cancelFailedToast"),
-          ),
-          { id: "subscription-cancel-error" },
-        );
-        return null;
-      }
-    };
+      },
+      errorToastId: "subscription-cancel-error",
+      errorFallback: () =>
+        t("settings:useCancelSubscription.cancelFailedToast"),
+    });
 
   return { cancelSubscription, isPending: mutation.isPending };
 }

--- a/clients/web/src/domains/settings/billing/use-reactivate-subscription.ts
+++ b/clients/web/src/domains/settings/billing/use-reactivate-subscription.ts
@@ -1,0 +1,53 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "@vellumai/design-library/components/toast";
+
+import {
+  organizationsBillingSubscriptionRetrieveQueryKey,
+  useOrganizationsBillingSubscriptionReactivateCreateMutation,
+} from "@/generated/api/@tanstack/react-query.gen";
+import type { SubscriptionReactivateResponse } from "@/generated/api/types.gen";
+import { t } from "@/i18n";
+
+import { extractMutationError } from "@/domains/settings/components/adjust-plan-utils";
+
+/**
+ * Shared wiring for the reactivate CTAs (grace-period banner, adjust-plan
+ * modal's "Keep your Plan"). Posts to the subscription-reactivate endpoint,
+ * which removes the pending cancellation server-side (no Stripe portal
+ * round-trip), then invalidates the subscription read so the cleared
+ * `cancel_at_period_end` / `cancel_at` state surfaces everywhere, and toasts.
+ * A `no_op` (no cancellation pending, e.g. already reactivated elsewhere)
+ * reads the same to the user, so it shares the success toast. Errors toast
+ * and resolve null so the CTA stays available for a retry.
+ */
+export function useReactivateSubscription() {
+  const queryClient = useQueryClient();
+  const mutation =
+    useOrganizationsBillingSubscriptionReactivateCreateMutation();
+
+  const reactivateSubscription =
+    async (): Promise<SubscriptionReactivateResponse | null> => {
+      try {
+        const result = await mutation.mutateAsync({});
+        await queryClient.invalidateQueries({
+          queryKey: organizationsBillingSubscriptionRetrieveQueryKey(),
+        });
+        toast.success(
+          t("settings:useReactivateSubscription.reactivatedToast"),
+          { id: "subscription-reactivate" },
+        );
+        return result;
+      } catch (error) {
+        toast.error(
+          extractMutationError(
+            error,
+            t("settings:useReactivateSubscription.reactivateFailedToast"),
+          ),
+          { id: "subscription-reactivate-error" },
+        );
+        return null;
+      }
+    };
+
+  return { reactivateSubscription, isPending: mutation.isPending };
+}

--- a/clients/web/src/domains/settings/billing/use-reactivate-subscription.ts
+++ b/clients/web/src/domains/settings/billing/use-reactivate-subscription.ts
@@ -1,53 +1,36 @@
-import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "@vellumai/design-library/components/toast";
 
-import {
-  organizationsBillingSubscriptionRetrieveQueryKey,
-  useOrganizationsBillingSubscriptionReactivateCreateMutation,
-} from "@/generated/api/@tanstack/react-query.gen";
+import { useSubscriptionAction } from "@/domains/settings/billing/use-subscription-action";
+import { useOrganizationsBillingSubscriptionReactivateCreateMutation } from "@/generated/api/@tanstack/react-query.gen";
 import type { SubscriptionReactivateResponse } from "@/generated/api/types.gen";
 import { t } from "@/i18n";
-
-import { extractMutationError } from "@/domains/settings/components/adjust-plan-utils";
 
 /**
  * Shared wiring for the reactivate CTAs (grace-period banner, adjust-plan
  * modal's "Keep your Plan"). Posts to the subscription-reactivate endpoint,
- * which removes the pending cancellation server-side (no Stripe portal
- * round-trip), then invalidates the subscription read so the cleared
- * `cancel_at_period_end` / `cancel_at` state surfaces everywhere, and toasts.
- * A `no_op` (no cancellation pending, e.g. already reactivated elsewhere)
- * reads the same to the user, so it shares the success toast. Errors toast
- * and resolve null so the CTA stays available for a retry.
+ * which removes the pending cancellation server-side. A `no_op` (no
+ * cancellation pending, e.g. already reactivated elsewhere) reads the same to
+ * the user, so it shares the success toast.
  */
 export function useReactivateSubscription() {
-  const queryClient = useQueryClient();
   const mutation =
     useOrganizationsBillingSubscriptionReactivateCreateMutation();
+  const runSubscriptionAction = useSubscriptionAction();
 
   const reactivateSubscription =
-    async (): Promise<SubscriptionReactivateResponse | null> => {
-      try {
-        const result = await mutation.mutateAsync({});
-        await queryClient.invalidateQueries({
-          queryKey: organizationsBillingSubscriptionRetrieveQueryKey(),
-        });
-        toast.success(
-          t("settings:useReactivateSubscription.reactivatedToast"),
-          { id: "subscription-reactivate" },
-        );
-        return result;
-      } catch (error) {
-        toast.error(
-          extractMutationError(
-            error,
-            t("settings:useReactivateSubscription.reactivateFailedToast"),
-          ),
-          { id: "subscription-reactivate-error" },
-        );
-        return null;
-      }
-    };
+    (): Promise<SubscriptionReactivateResponse | null> =>
+      runSubscriptionAction({
+        mutateAsync: () => mutation.mutateAsync({}),
+        onSuccess: () => {
+          toast.success(
+            t("settings:useReactivateSubscription.reactivatedToast"),
+            { id: "subscription-reactivate" },
+          );
+        },
+        errorToastId: "subscription-reactivate-error",
+        errorFallback: () =>
+          t("settings:useReactivateSubscription.reactivateFailedToast"),
+      });
 
   return { reactivateSubscription, isPending: mutation.isPending };
 }

--- a/clients/web/src/domains/settings/billing/use-subscription-action.ts
+++ b/clients/web/src/domains/settings/billing/use-subscription-action.ts
@@ -1,0 +1,43 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { toast } from "@vellumai/design-library/components/toast";
+
+import { organizationsBillingSubscriptionRetrieveQueryKey } from "@/generated/api/@tanstack/react-query.gen";
+
+import { extractMutationError } from "@/domains/settings/components/adjust-plan-utils";
+
+interface SubscriptionActionConfig<TResult> {
+  mutateAsync: () => Promise<TResult>;
+  /** Toasts the outcome; runs after the subscription read is invalidated. */
+  onSuccess: (result: TResult) => void;
+  errorToastId: string;
+  errorFallback: () => string;
+}
+
+/**
+ * Common pipeline for the direct subscription actions (cancel, reactivate):
+ * post the endpoint, invalidate the subscription read so the changed
+ * `cancel_at_period_end` / `cancel_at` state surfaces everywhere, hand the
+ * result to the action's success toast, and toast + resolve null on error so
+ * the calling UI can stay open for a retry.
+ */
+export function useSubscriptionAction() {
+  const queryClient = useQueryClient();
+
+  return async <TResult>(
+    config: SubscriptionActionConfig<TResult>,
+  ): Promise<TResult | null> => {
+    try {
+      const result = await config.mutateAsync();
+      await queryClient.invalidateQueries({
+        queryKey: organizationsBillingSubscriptionRetrieveQueryKey(),
+      });
+      config.onSuccess(result);
+      return result;
+    } catch (error) {
+      toast.error(extractMutationError(error, config.errorFallback()), {
+        id: config.errorToastId,
+      });
+      return null;
+    }
+  };
+}

--- a/clients/web/src/domains/settings/components/adjust-plan-modal.tsx
+++ b/clients/web/src/domains/settings/components/adjust-plan-modal.tsx
@@ -98,8 +98,8 @@ function AdjustPlanModalContent({
   );
   const portalSnapshot = buildPortalReturnSnapshot(subscriptionQuery.data);
   // "Keep your Plan" posts the reactivate endpoint and the cancellation posts
-  // the cancel endpoint; the portal is the cancel fallback for subscriptions
-  // the cancel endpoint rejects.
+  // the cancel endpoint; the portal is the fallback for subscriptions those
+  // endpoints reject (non-entitlement status).
   const portalMutation = useBillingPortalSession(portalSnapshot);
   const { reactivateSubscription, isPending: reactivatePending } =
     useReactivateSubscription();
@@ -714,7 +714,15 @@ function AdjustPlanModalContent({
                             onDowngradeClick={() =>
                               setView("downgrade-confirm")
                             }
-                            onKeepPlan={() => void reactivateSubscription()}
+                            onKeepPlan={() => {
+                              if (
+                                !isDirectCancelEligible(subscriptionQuery.data)
+                              ) {
+                                portalMutation.mutate({});
+                                return;
+                              }
+                              void reactivateSubscription();
+                            }}
                           />
                         );
                       })}

--- a/clients/web/src/domains/settings/components/adjust-plan-modal.tsx
+++ b/clients/web/src/domains/settings/components/adjust-plan-modal.tsx
@@ -7,6 +7,7 @@ import { captureTakeoverAvatarStash } from "@/lib/billing/takeover-avatar-stash"
 import { proPackageDisplayName } from "@/domains/settings/billing/package-types";
 import { currentPlanFeatures } from "@/domains/settings/billing/plan-spec";
 import { useCancelSubscription } from "@/domains/settings/billing/use-cancel-subscription";
+import { useReactivateSubscription } from "@/domains/settings/billing/use-reactivate-subscription";
 import {
   buildPortalReturnSnapshot,
   formatGraceDate,
@@ -96,9 +97,12 @@ function AdjustPlanModalContent({
     organizationsBillingSubscriptionChangeCreditTierCreateMutation(),
   );
   const portalSnapshot = buildPortalReturnSnapshot(subscriptionQuery.data);
-  // The portal is still where "Keep your Plan" reactivates a pending
-  // cancellation; the cancellation itself posts the cancel endpoint directly.
+  // "Keep your Plan" and the cancellation both post their endpoints directly;
+  // the portal remains only as the cancel fallback for subscriptions the
+  // cancel endpoint rejects.
   const portalMutation = useBillingPortalSession(portalSnapshot);
+  const { reactivateSubscription, isPending: reactivatePending } =
+    useReactivateSubscription();
   const { cancelSubscription, isPending: cancelPending } =
     useCancelSubscription();
   const [view, setView] = useState<"plans" | "downgrade-confirm">("plans");
@@ -702,13 +706,15 @@ function AdjustPlanModalContent({
                             creditChanged={creditChanged}
                             tierChangeError={tierChangeError}
                             upgradePending={upgradeMutation.isPending}
-                            portalPending={portalMutation.isPending}
+                            billingActionPending={
+                              portalMutation.isPending || reactivatePending
+                            }
                             onUpgrade={handleUpgrade}
                             onApplyTierChange={handleApplyTierChange}
                             onDowngradeClick={() =>
                               setView("downgrade-confirm")
                             }
-                            onKeepPlan={() => portalMutation.mutate({})}
+                            onKeepPlan={() => void reactivateSubscription()}
                           />
                         );
                       })}

--- a/clients/web/src/domains/settings/components/adjust-plan-modal.tsx
+++ b/clients/web/src/domains/settings/components/adjust-plan-modal.tsx
@@ -97,9 +97,9 @@ function AdjustPlanModalContent({
     organizationsBillingSubscriptionChangeCreditTierCreateMutation(),
   );
   const portalSnapshot = buildPortalReturnSnapshot(subscriptionQuery.data);
-  // "Keep your Plan" and the cancellation both post their endpoints directly;
-  // the portal remains only as the cancel fallback for subscriptions the
-  // cancel endpoint rejects.
+  // "Keep your Plan" posts the reactivate endpoint and the cancellation posts
+  // the cancel endpoint; the portal is the cancel fallback for subscriptions
+  // the cancel endpoint rejects.
   const portalMutation = useBillingPortalSession(portalSnapshot);
   const { reactivateSubscription, isPending: reactivatePending } =
     useReactivateSubscription();

--- a/clients/web/src/domains/settings/components/adjust-plan-utils.ts
+++ b/clients/web/src/domains/settings/components/adjust-plan-utils.ts
@@ -51,9 +51,11 @@ export function isPackageSwitchEligible(
 /**
  * Whether the sub can be cancelled in-app via the subscription-cancel
  * endpoint, which 403s without an active Pro subscription (the backend's
- * `is_pro_active` gate, mirrored by TIER_CHANGE_ELIGIBLE_STATUSES). A Pro sub
- * in any other status (`unpaid`, `incomplete`, `paused`, ...) falls back to
- * cancelling through the Stripe billing portal, which still accepts it.
+ * `is_pro_active` gate, mirrored by TIER_CHANGE_ELIGIBLE_STATUSES). The
+ * subscription-reactivate endpoint shares the same gate, so the reactivate
+ * CTAs use this predicate too. A Pro sub in any other status (`unpaid`,
+ * `incomplete`, `paused`, ...) falls back to cancelling or reactivating
+ * through the Stripe billing portal, which still accepts it.
  */
 export function isDirectCancelEligible(
   subscription: SubscriptionResponse | undefined,

--- a/clients/web/src/domains/settings/components/grace-period-banner.test.tsx
+++ b/clients/web/src/domains/settings/components/grace-period-banner.test.tsx
@@ -40,9 +40,12 @@ function gracePeriodSubscription(): SubscriptionResponse {
 
 // The reactivate endpoint clears the pending cancellation server-side; the
 // retrieve mock serves the post-invalidate refetch with whatever state the
-// "server" currently holds.
+// "server" currently holds. The portal-session mock backs the fallback for
+// subscriptions the reactivate endpoint rejects.
+const PORTAL_URL = "https://stripe.test/portal/session";
 let serverSubscription = gracePeriodSubscription();
 let reactivateCalls = 0;
+let portalCalls = 0;
 mock.module("@/generated/api/sdk.gen", () => ({
   ...sdkGen,
   organizationsBillingSubscriptionReactivateCreate: () => {
@@ -59,17 +62,24 @@ mock.module("@/generated/api/sdk.gen", () => ({
   },
   organizationsBillingSubscriptionRetrieve: () =>
     Promise.resolve({ data: serverSubscription, response: { ok: true } }),
+  organizationsBillingPortalSessionCreate: () => {
+    portalCalls += 1;
+    return Promise.resolve({
+      data: { portal_url: PORTAL_URL },
+      response: { ok: true },
+    });
+  },
 }));
 
 const { GracePeriodBanner } = await import("./grace-period-banner");
 
-function renderBanner() {
+function renderBanner(subscription: SubscriptionResponse = serverSubscription) {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false, staleTime: Infinity } },
   });
   client.setQueryData(
     organizationsBillingSubscriptionRetrieveQueryKey(),
-    gracePeriodSubscription(),
+    subscription,
   );
   return render(
     <QueryClientProvider client={client}>
@@ -82,6 +92,7 @@ beforeEach(() => {
   nativeAndroid = false;
   openedUrl = null;
   reactivateCalls = 0;
+  portalCalls = 0;
   serverSubscription = gracePeriodSubscription();
 });
 
@@ -100,6 +111,18 @@ describe("GracePeriodBanner Reactivate", () => {
       expect(queryByTestId("grace-period-banner")).toBeNull(),
     );
     expect(openedUrl).toBeNull();
+    expect(portalCalls).toBe(0);
+  });
+
+  test("opens the Stripe portal for subscriptions the endpoint rejects", async () => {
+    serverSubscription = { ...gracePeriodSubscription(), status: "unpaid" };
+    const { getByTestId } = renderBanner();
+
+    fireEvent.click(getByTestId("grace-period-reactivate-button"));
+
+    await waitFor(() => expect(openedUrl).toBe(PORTAL_URL));
+    expect(portalCalls).toBe(1);
+    expect(reactivateCalls).toBe(0);
   });
 
   test("native Android opens the web billing page instead of the endpoint", async () => {
@@ -114,5 +137,6 @@ describe("GracePeriodBanner Reactivate", () => {
       ),
     );
     expect(reactivateCalls).toBe(0);
+    expect(portalCalls).toBe(0);
   });
 });

--- a/clients/web/src/domains/settings/components/grace-period-banner.test.tsx
+++ b/clients/web/src/domains/settings/components/grace-period-banner.test.tsx
@@ -94,8 +94,8 @@ describe("GracePeriodBanner Reactivate", () => {
     fireEvent.click(getByTestId("grace-period-reactivate-button"));
 
     await waitFor(() => expect(reactivateCalls).toBe(1));
-    // The hook invalidates the subscription read; the refetched state no
-    // longer has a pending cancellation, so the banner unmounts.
+    // The hook invalidates the subscription read; the refetched state has no
+    // pending cancellation, so the banner unmounts.
     await waitFor(() =>
       expect(queryByTestId("grace-period-banner")).toBeNull(),
     );

--- a/clients/web/src/domains/settings/components/grace-period-banner.test.tsx
+++ b/clients/web/src/domains/settings/components/grace-period-banner.test.tsx
@@ -24,21 +24,6 @@ mock.module("@/runtime/browser", () => ({
   openUrlFinishedListener: () => () => {},
 }));
 
-const PORTAL_URL = "https://stripe.test/portal/session";
-let portalCalls = 0;
-mock.module("@/generated/api/sdk.gen", () => ({
-  ...sdkGen,
-  organizationsBillingPortalSessionCreate: () => {
-    portalCalls += 1;
-    return Promise.resolve({
-      data: { portal_url: PORTAL_URL },
-      response: { ok: true },
-    });
-  },
-}));
-
-const { GracePeriodBanner } = await import("./grace-period-banner");
-
 function gracePeriodSubscription(): SubscriptionResponse {
   return {
     plan_id: "pro",
@@ -52,6 +37,31 @@ function gracePeriodSubscription(): SubscriptionResponse {
     entitlements: { managed_email: false, phone_number: false },
   };
 }
+
+// The reactivate endpoint clears the pending cancellation server-side; the
+// retrieve mock serves the post-invalidate refetch with whatever state the
+// "server" currently holds.
+let serverSubscription = gracePeriodSubscription();
+let reactivateCalls = 0;
+mock.module("@/generated/api/sdk.gen", () => ({
+  ...sdkGen,
+  organizationsBillingSubscriptionReactivateCreate: () => {
+    reactivateCalls += 1;
+    serverSubscription = {
+      ...serverSubscription,
+      cancel_at_period_end: false,
+      cancel_at: null,
+    };
+    return Promise.resolve({
+      data: { status: "ok", current_period_end: "2026-09-01T00:00:00Z" },
+      response: { ok: true },
+    });
+  },
+  organizationsBillingSubscriptionRetrieve: () =>
+    Promise.resolve({ data: serverSubscription, response: { ok: true } }),
+}));
+
+const { GracePeriodBanner } = await import("./grace-period-banner");
 
 function renderBanner() {
   const client = new QueryClient({
@@ -71,22 +81,28 @@ function renderBanner() {
 beforeEach(() => {
   nativeAndroid = false;
   openedUrl = null;
-  portalCalls = 0;
+  reactivateCalls = 0;
+  serverSubscription = gracePeriodSubscription();
 });
 
 afterEach(cleanup);
 
 describe("GracePeriodBanner Reactivate", () => {
-  test("opens the Stripe billing portal off Android", async () => {
-    const { getByTestId } = renderBanner();
+  test("posts the reactivate endpoint and clears the banner", async () => {
+    const { getByTestId, queryByTestId } = renderBanner();
 
     fireEvent.click(getByTestId("grace-period-reactivate-button"));
 
-    await waitFor(() => expect(openedUrl).toBe(PORTAL_URL));
-    expect(portalCalls).toBe(1);
+    await waitFor(() => expect(reactivateCalls).toBe(1));
+    // The hook invalidates the subscription read; the refetched state no
+    // longer has a pending cancellation, so the banner unmounts.
+    await waitFor(() =>
+      expect(queryByTestId("grace-period-banner")).toBeNull(),
+    );
+    expect(openedUrl).toBeNull();
   });
 
-  test("native Android opens the web billing page instead of a portal session", async () => {
+  test("native Android opens the web billing page instead of the endpoint", async () => {
     nativeAndroid = true;
     const { getByTestId } = renderBanner();
 
@@ -97,6 +113,6 @@ describe("GracePeriodBanner Reactivate", () => {
         `${window.location.origin}/assistant/settings/usage?tab=billing`,
       ),
     );
-    expect(portalCalls).toBe(0);
+    expect(reactivateCalls).toBe(0);
   });
 });

--- a/clients/web/src/domains/settings/components/grace-period-banner.tsx
+++ b/clients/web/src/domains/settings/components/grace-period-banner.tsx
@@ -1,11 +1,15 @@
 import { Loader2 } from "lucide-react";
+import { useMemo } from "react";
 
 import { useQuery } from "@tanstack/react-query";
 
 import { useReactivateSubscription } from "@/domains/settings/billing/use-reactivate-subscription";
+import { isDirectCancelEligible } from "@/domains/settings/components/adjust-plan-utils";
 import {
+  buildPortalReturnSnapshot,
   formatGraceDate,
   getEffectiveCancelDate,
+  useBillingPortalSession,
 } from "@/domains/settings/hooks/use-billing-portal-session";
 import { organizationsBillingSubscriptionRetrieveOptions } from "@/generated/api/@tanstack/react-query.gen";
 import { useTranslation } from "@/i18n";
@@ -20,9 +24,11 @@ import { Notice } from "@vellumai/design-library/components/notice";
  * subscription is mid-grace-period, i.e. cancellation has been scheduled,
  * either via `cancel_at_period_end=true` or via an explicit `cancel_at`
  * timestamp set by Stripe (the Customer Portal uses the latter). The
- * "Reactivate" CTA posts the subscription-reactivate endpoint directly (no
- * Stripe portal round-trip); the shared hook invalidates the subscription
- * read, so the banner clears itself once the cancellation is removed.
+ * "Reactivate" CTA posts the subscription-reactivate endpoint directly; the
+ * shared hook invalidates the subscription read, so the banner clears itself
+ * once the cancellation is removed. A Pro sub the endpoint rejects
+ * (non-entitlement status) keeps the Stripe portal handoff, which can still
+ * reactivate it.
  */
 export function GracePeriodBanner() {
   const { t } = useTranslation("settings");
@@ -31,7 +37,11 @@ export function GracePeriodBanner() {
   const isNativeAndroid = useIsNativeAndroid();
   const { data } = useQuery(organizationsBillingSubscriptionRetrieveOptions());
 
-  const { reactivateSubscription, isPending } = useReactivateSubscription();
+  const snapshot = useMemo(() => buildPortalReturnSnapshot(data), [data]);
+  const portalMutation = useBillingPortalSession(snapshot);
+  const { reactivateSubscription, isPending: reactivatePending } =
+    useReactivateSubscription();
+  const isPending = reactivatePending || portalMutation.isPending;
 
   if (
     !data ||
@@ -58,6 +68,10 @@ export function GracePeriodBanner() {
           onClick={() => {
             if (isNativeAndroid) {
               openBillingPathInBrowser(routes.settings.usageBilling);
+              return;
+            }
+            if (!isDirectCancelEligible(data)) {
+              portalMutation.mutate({});
               return;
             }
             void reactivateSubscription();

--- a/clients/web/src/domains/settings/components/grace-period-banner.tsx
+++ b/clients/web/src/domains/settings/components/grace-period-banner.tsx
@@ -1,13 +1,11 @@
 import { Loader2 } from "lucide-react";
-import { useMemo } from "react";
 
 import { useQuery } from "@tanstack/react-query";
 
+import { useReactivateSubscription } from "@/domains/settings/billing/use-reactivate-subscription";
 import {
-  buildPortalReturnSnapshot,
   formatGraceDate,
   getEffectiveCancelDate,
-  useBillingPortalSession,
 } from "@/domains/settings/hooks/use-billing-portal-session";
 import { organizationsBillingSubscriptionRetrieveOptions } from "@/generated/api/@tanstack/react-query.gen";
 import { useTranslation } from "@/i18n";
@@ -19,23 +17,21 @@ import { Notice } from "@vellumai/design-library/components/notice";
 
 /**
  * In-flow banner shown on the billing settings surface when the org's Pro
- * subscription is mid-grace-period — i.e. cancellation has been scheduled,
+ * subscription is mid-grace-period, i.e. cancellation has been scheduled,
  * either via `cancel_at_period_end=true` or via an explicit `cancel_at`
  * timestamp set by Stripe (the Customer Portal uses the latter). The
- * "Reactivate" CTA fires the Stripe Customer Portal mutation; Stripe handles
- * reactivation natively. We capture a pre-redirect snapshot so the
- * post-portal-return toast can diff old → new state.
+ * "Reactivate" CTA posts the subscription-reactivate endpoint directly (no
+ * Stripe portal round-trip); the shared hook invalidates the subscription
+ * read, so the banner clears itself once the cancellation is removed.
  */
 export function GracePeriodBanner() {
   const { t } = useTranslation("settings");
   // Native Android reactivates on the web app's billing page in the browser
-  // instead of opening a portal session from the app.
+  // instead of managing the subscription from inside the app.
   const isNativeAndroid = useIsNativeAndroid();
   const { data } = useQuery(organizationsBillingSubscriptionRetrieveOptions());
 
-  const snapshot = useMemo(() => buildPortalReturnSnapshot(data), [data]);
-
-  const portalMutation = useBillingPortalSession(snapshot);
+  const { reactivateSubscription, isPending } = useReactivateSubscription();
 
   if (
     !data ||
@@ -64,13 +60,11 @@ export function GracePeriodBanner() {
               openBillingPathInBrowser(routes.settings.usageBilling);
               return;
             }
-            portalMutation.mutate({});
+            void reactivateSubscription();
           }}
-          disabled={portalMutation.isPending}
+          disabled={isPending}
           leftIcon={
-            portalMutation.isPending ? (
-              <Loader2 className="animate-spin" />
-            ) : undefined
+            isPending ? <Loader2 className="animate-spin" /> : undefined
           }
           data-testid="grace-period-reactivate-button"
         >

--- a/clients/web/src/domains/settings/components/plan-card-content.tsx
+++ b/clients/web/src/domains/settings/components/plan-card-content.tsx
@@ -58,7 +58,7 @@ export interface PlanCardContentProps {
   creditChanged: boolean;
   tierChangeError: string | null;
   upgradePending: boolean;
-  portalPending: boolean;
+  billingActionPending: boolean;
   onUpgrade: () => void;
   onApplyTierChange: () => void;
   onDowngradeClick: () => void;
@@ -99,7 +99,7 @@ export function PlanCardContent({
   creditChanged,
   tierChangeError,
   upgradePending,
-  portalPending,
+  billingActionPending,
   onUpgrade,
   onApplyTierChange,
   onDowngradeClick,
@@ -367,7 +367,7 @@ export function PlanCardContent({
                 variant="outlined"
                 className="w-full"
                 onClick={onDowngradeClick}
-                disabled={portalPending}
+                disabled={billingActionPending}
                 data-testid="modal-downgrade-to-base-button"
               >
                 {t("planCardContent.downgradeToBase")}
@@ -381,7 +381,7 @@ export function PlanCardContent({
                 variant="outlined"
                 className="w-full"
                 onClick={onKeepPlan}
-                disabled={portalPending}
+                disabled={billingActionPending}
                 data-testid="modal-keep-plan-button"
               >
                 {t("planCardContent.keepPlan")}

--- a/clients/web/src/i18n/locales/en/settings.json
+++ b/clients/web/src/i18n/locales/en/settings.json
@@ -2135,6 +2135,10 @@
     "deleteInUseToast": "This provider is in use by a profile or as the default provider. Update those settings before deleting it.",
     "setDefaultFailedToast": "Failed to set the default provider. Please try again."
   },
+  "useReactivateSubscription": {
+    "reactivateFailedToast": "Couldn't reactivate your subscription. Please try again.",
+    "reactivatedToast": "Pro plan reactivated."
+  },
   "useSystemTasks": {
     "consolidationAlreadyQueued": "Consolidation already queued or running.",
     "consolidationQueued": "Consolidation queued.",

--- a/clients/web/src/i18n/locales/es/settings.json
+++ b/clients/web/src/i18n/locales/es/settings.json
@@ -2135,6 +2135,10 @@
     "deleteInUseToast": "Este proveedor está en uso en un perfil o como proveedor predeterminado. Actualiza esas configuraciones antes de eliminarlo.",
     "setDefaultFailedToast": "No se pudo establecer el proveedor predeterminado. Inténtalo de nuevo."
   },
+  "useReactivateSubscription": {
+    "reactivateFailedToast": "No se pudo reactivar tu suscripción. Inténtalo de nuevo.",
+    "reactivatedToast": "Plan Pro reactivado."
+  },
   "useSystemTasks": {
     "consolidationAlreadyQueued": "La consolidación ya está en cola o en ejecución.",
     "consolidationQueued": "Consolidación en cola.",

--- a/clients/web/src/i18n/locales/ru/settings.json
+++ b/clients/web/src/i18n/locales/ru/settings.json
@@ -2135,6 +2135,10 @@
     "deleteInUseToast": "Этот провайдер используется в профиле или как провайдер по умолчанию. Сначала обновление этих настроек, потом удаление.",
     "setDefaultFailedToast": "Не удалось назначить провайдера по умолчанию. Повторите попытку."
   },
+  "useReactivateSubscription": {
+    "reactivateFailedToast": "Не удалось возобновить подписку. Повторите попытку.",
+    "reactivatedToast": "План Pro снова активен."
+  },
   "useSystemTasks": {
     "consolidationAlreadyQueued": "Консолидация уже в очереди или выполняется.",
     "consolidationQueued": "Консолидация в очереди.",


### PR DESCRIPTION
## Summary
- Add a shared `useReactivateSubscription` hook that posts the new `/v1/organizations/billing/subscription/reactivate/` endpoint, invalidates the subscription read on success so the pending-cancellation state clears everywhere, and toasts the outcome.
- Wire the grace-period banner's Reactivate button and the adjust-plan modal's "Keep your Plan" CTA to the hook instead of opening a Stripe billing portal session; the portal remains only as the cancel fallback for subscriptions the cancel endpoint rejects. The native Android handoff to the web billing page is unchanged.
- Update the grace-period banner tests to assert the endpoint is posted and the banner clears after the invalidated refetch, and add the en/es/ru toast strings.

## Original prompt
PR #41314 synced the platform OpenAPI spec and brought in the new subscription reactivation endpoint (the server-side equivalent of clicking "Do not cancel" in the Stripe Customer Portal). When a user cancels their Pro subscription we show a Reactivate button, which until now handed off to the Stripe billing portal. The ask was to post the new endpoint directly instead, and to make sure the UI reflects the reactivated state after the user clicks the button.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41317" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->