### PR TITLE
fix(ios): match the Home Screen widgets to the mocks

### DIFF
--- a/clients/ios/App/VoiceActivity/Widgets/CatchUpWidget.swift
+++ b/clients/ios/App/VoiceActivity/Widgets/CatchUpWidget.swift
@@ -98,15 +98,32 @@ struct CatchUpWidgetView: View {
         }
     }
 
+    /// The number of rows the card is laid out for. The producer sends at most
+    /// this many; a snapshot carrying more is malformed, and drawing its
+    /// overflow would push rows off the card.
+    private static let maxRows = 3
+
     /// The rows, flush against each other: the space between one title and the
     /// next belongs to the row that owns it, so the list keeps one rhythm
     /// whether or not a row carries a subtitle.
+    ///
+    /// Each row is drawn at its design height, except that the full count of
+    /// rows must fit in what the header leaves: the design's own three rows
+    /// overrun the content box by two points, so the rows give that sliver
+    /// back rather than lean into the margin the card cannot spare on every
+    /// device.
     private func rowList(scale: CGFloat) -> some View {
-        VStack(alignment: .leading, spacing: 0) {
-            ForEach(entry.conversations, id: \.id) { conversation in
-                linkedRow(for: conversation, scale: scale)
+        GeometryReader { proxy in
+            let rows = Array(entry.conversations.prefix(Self.maxRows))
+            let height = min(
+                CatchUpRow.designHeight * scale,
+                proxy.size.height / CGFloat(max(1, rows.count))
+            )
+            VStack(alignment: .leading, spacing: 0) {
+                ForEach(rows, id: \.id) { conversation in
+                    linkedRow(for: conversation, height: height, scale: scale)
+                }
             }
-            Spacer(minLength: 0)
         }
     }
 
@@ -117,8 +134,17 @@ struct CatchUpWidgetView: View {
     /// production app), and the titles are still true, so the widget loses a
     /// tap target rather than its content.
     @ViewBuilder
-    private func linkedRow(for conversation: WidgetSnapshotConversation, scale: CGFloat) -> some View {
-        let row = CatchUpRow(conversation: conversation, isStale: entry.isStale, scale: scale)
+    private func linkedRow(
+        for conversation: WidgetSnapshotConversation,
+        height: CGFloat,
+        scale: CGFloat
+    ) -> some View {
+        let row = CatchUpRow(
+            conversation: conversation,
+            isStale: entry.isStale,
+            height: height,
+            scale: scale
+        )
         if let url = ThreadDeepLink(threadId: conversation.id).url() {
             Link(destination: url) { row }
         } else {
@@ -151,13 +177,19 @@ struct CatchUpRow: View {
     /// about work in flight. See ``SnapshotProvider/staleAfter``.
     let isStale: Bool
 
+    /// The height the owner resolved for this row: the design height, shaved
+    /// by up to a point when the full list has to fit the space under the
+    /// header.
+    let height: CGFloat
+
     /// The owning card's ratio to the size it was designed at. Every dimension
     /// below is a design value multiplied by it.
     let scale: CGFloat
 
-    /// The row's height, and where its pieces sit in it. The text block hangs
-    /// from a fixed top inset rather than centering, so a row without a
-    /// subtitle keeps its title on the same line as its neighbors'.
+    /// The row's height when nothing constrains it, and where its pieces sit
+    /// in it. The text block hangs from a fixed top inset rather than
+    /// centering, so a row without a subtitle keeps its title on the same
+    /// line as its neighbors'.
     static let designHeight: CGFloat = 37
     static let leadingInset: CGFloat = 8
     private static let textTopInset: CGFloat = 6
@@ -190,7 +222,7 @@ struct CatchUpRow: View {
         }
         .padding(.leading, Self.leadingInset * scale)
         .frame(maxWidth: .infinity, alignment: .topLeading)
-        .frame(height: Self.designHeight * scale, alignment: .top)
+        .frame(height: height, alignment: .top)
     }
 
     /// Working beats unread, and staleness beats working.

--- a/clients/ios/App/VoiceActivity/Widgets/CatchUpWidget.swift
+++ b/clients/ios/App/VoiceActivity/Widgets/CatchUpWidget.swift
@@ -38,6 +38,13 @@ struct CatchUpWidget: Widget {
 struct CatchUpWidgetView: View {
     let entry: SnapshotEntry
 
+    /// The card every dimension below is designed on. Widget families render
+    /// at slightly different sizes per device, so the layout multiplies its
+    /// measurements by the ratio between the two and keeps the design's
+    /// proportions everywhere instead of gaining margin on large phones and
+    /// clipping on small ones.
+    private static let designSize = CGSize(width: 339, height: 161)
+
     /// Width of the action column, sized to the two tiles rather than to a
     /// share of the widget, so the rows beside it get every remaining point.
     private static let actionColumnWidth: CGFloat = 71
@@ -47,52 +54,60 @@ struct CatchUpWidgetView: View {
     /// rows it is laid out for.
     private static let contentMargin: CGFloat = 16
 
+    /// Gap between the action column and the rows, and between the two tiles.
+    private static let columnGap: CGFloat = 14
+    private static let tileGap: CGFloat = 7
+
+    /// The header hangs slightly below the top margin and slightly into the
+    /// row column, so it reads as a label on the list rather than as a row.
+    private static let headerTopInset: CGFloat = 3
+    private static let headerLeadingInset: CGFloat = 4
+    private static let headerBottomGap: CGFloat = 5
+
     var body: some View {
-        HStack(alignment: .top, spacing: 14) {
-            VStack(spacing: 7) {
-                WidgetActionTile.newChat(accent: entry.softAccent, avatarImage: entry.avatarImage)
-                WidgetActionTile.voice
-            }
-            .frame(width: Self.actionColumnWidth)
-
-            VStack(alignment: .leading, spacing: 0) {
-                Text("Catch up:")
-                    .font(.system(size: 10))
-                    .foregroundStyle(WidgetTheme.textSecondary)
-                    .padding(.bottom, 5)
-                if entry.conversations.isEmpty {
-                    emptyPrompt
-                    Spacer(minLength: 0)
-                } else {
-                    rowList
+        GeometryReader { geo in
+            let scale = min(
+                geo.size.width / Self.designSize.width,
+                geo.size.height / Self.designSize.height
+            )
+            HStack(alignment: .top, spacing: Self.columnGap * scale) {
+                VStack(spacing: Self.tileGap * scale) {
+                    WidgetActionTile.newChat(accent: entry.softAccent, avatarImage: entry.avatarImage, scale: scale)
+                    WidgetActionTile.voice(scale: scale)
                 }
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-        }
-        .padding(Self.contentMargin)
-    }
+                .frame(width: Self.actionColumnWidth * scale)
 
-    /// The rows, sized to the space left under the header rather than to a
-    /// fixed height: the medium widget is 148pt tall on a 4.7-inch phone, which
-    /// is too short for three rows at the height the taller phones draw them.
-    private var rowList: some View {
-        GeometryReader { proxy in
-            let height = rowHeight(fitting: proxy.size.height)
-            VStack(alignment: .leading, spacing: 0) {
-                ForEach(entry.conversations, id: \.id) { conversation in
-                    linkedRow(for: conversation, height: height)
+                VStack(alignment: .leading, spacing: 0) {
+                    Text("Catch up:")
+                        .font(.system(size: 10 * scale))
+                        .foregroundStyle(WidgetTheme.textSecondary)
+                        .padding(.top, Self.headerTopInset * scale)
+                        .padding(.leading, Self.headerLeadingInset * scale)
+                        .padding(.bottom, Self.headerBottomGap * scale)
+                    if entry.conversations.isEmpty {
+                        emptyPrompt(scale: scale)
+                        Spacer(minLength: 0)
+                    } else {
+                        rowList(scale: scale)
+                    }
                 }
-                Spacer(minLength: 0)
+                .frame(maxWidth: .infinity, alignment: .leading)
             }
+            .padding(Self.contentMargin * scale)
+            .frame(width: geo.size.width, height: geo.size.height, alignment: .top)
         }
     }
 
-    /// The rows split the available height evenly, capped so a tall widget does
-    /// not stretch them past the height they are designed at, and floored so a
-    /// short one keeps them legible instead of collapsing the subtitle.
-    private func rowHeight(fitting available: CGFloat) -> CGFloat {
-        let share = available / CGFloat(max(1, entry.conversations.count))
-        return min(CatchUpRow.preferredHeight, max(CatchUpRow.minimumHeight, share))
+    /// The rows, flush against each other: the space between one title and the
+    /// next belongs to the row that owns it, so the list keeps one rhythm
+    /// whether or not a row carries a subtitle.
+    private func rowList(scale: CGFloat) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ForEach(entry.conversations, id: \.id) { conversation in
+                linkedRow(for: conversation, scale: scale)
+            }
+            Spacer(minLength: 0)
+        }
     }
 
     /// The row, wrapped in a `Link` when this build declares a URL scheme.
@@ -102,8 +117,8 @@ struct CatchUpWidgetView: View {
     /// production app), and the titles are still true, so the widget loses a
     /// tap target rather than its content.
     @ViewBuilder
-    private func linkedRow(for conversation: WidgetSnapshotConversation, height: CGFloat) -> some View {
-        let row = CatchUpRow(conversation: conversation, isStale: entry.isStale, height: height)
+    private func linkedRow(for conversation: WidgetSnapshotConversation, scale: CGFloat) -> some View {
+        let row = CatchUpRow(conversation: conversation, isStale: entry.isStale, scale: scale)
         if let url = ThreadDeepLink(threadId: conversation.id).url() {
             Link(destination: url) { row }
         } else {
@@ -116,9 +131,10 @@ struct CatchUpWidgetView: View {
     /// older than the sync) and nothing to sync (no conversations yet) both
     /// end with opening the app. The actions beside it stay live, so the
     /// widget is still a way in.
-    private var emptyPrompt: some View {
-        WidgetPromptText("Open Vellum to see your recent chats.", size: 11)
-            .padding(.top, 2)
+    private func emptyPrompt(scale: CGFloat) -> some View {
+        WidgetPromptText("Open Vellum to see your recent chats.", size: 11 * scale)
+            .padding(.top, 2 * scale)
+            .padding(.leading, CatchUpRow.leadingInset * scale)
     }
 }
 
@@ -135,41 +151,46 @@ struct CatchUpRow: View {
     /// about work in flight. See ``SnapshotProvider/staleAfter``.
     let isStale: Bool
 
-    /// Rows sit flush against each other, so the space between a title and the
-    /// next one belongs to the row that owns it rather than to a gap the eye
-    /// has to assign. The owner picks the height from what the widget has room
-    /// for, between ``minimumHeight`` and ``preferredHeight``.
-    let height: CGFloat
+    /// The owning card's ratio to the size it was designed at. Every dimension
+    /// below is a design value multiplied by it.
+    let scale: CGFloat
 
-    /// The height a row is drawn at when the widget has the room, and the floor
-    /// it stops shrinking at when it does not: below the floor the title and
-    /// subtitle stop clearing their own line heights.
-    static let preferredHeight: CGFloat = 37
-    static let minimumHeight: CGFloat = 31
+    /// The row's height, and where its pieces sit in it. The text block hangs
+    /// from a fixed top inset rather than centering, so a row without a
+    /// subtitle keeps its title on the same line as its neighbors'.
+    static let designHeight: CGFloat = 37
+    static let leadingInset: CGFloat = 8
+    private static let textTopInset: CGFloat = 6
+    private static let glyphSize: CGFloat = 12
+    private static let glyphTopInset: CGFloat = 12.5
+    private static let glyphTextGap: CGFloat = 7
 
     var body: some View {
-        HStack(spacing: 7) {
+        HStack(alignment: .top, spacing: Self.glyphTextGap * scale) {
             statusGlyph
-                .frame(width: 12, height: 12)
-            VStack(alignment: .leading, spacing: 2) {
+                .frame(width: Self.glyphSize * scale, height: Self.glyphSize * scale)
+                .padding(.top, Self.glyphTopInset * scale)
+            VStack(alignment: .leading, spacing: 2 * scale) {
                 Text(conversation.title)
-                    .font(.system(size: 13, weight: .semibold))
+                    .font(.system(size: 12 * scale, weight: .medium))
                     .foregroundStyle(WidgetTheme.textPrimary)
                     .lineLimit(1)
                     .truncationMode(.tail)
                     .privacySensitive()
                 if let subtitle = conversation.subtitle, !subtitle.isEmpty {
                     Text(subtitle)
-                        .font(.system(size: 9, weight: .medium))
+                        .font(.system(size: 7 * scale, weight: .medium))
                         .foregroundStyle(WidgetTheme.textSecondary)
                         .lineLimit(1)
                         .truncationMode(.tail)
                         .privacySensitive()
                 }
             }
+            .padding(.top, Self.textTopInset * scale)
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .frame(height: height)
+        .padding(.leading, Self.leadingInset * scale)
+        .frame(maxWidth: .infinity, alignment: .topLeading)
+        .frame(height: Self.designHeight * scale, alignment: .top)
     }
 
     /// Working beats unread, and staleness beats working.
@@ -188,7 +209,7 @@ struct CatchUpRow: View {
     private var statusGlyph: some View {
         if conversation.isProcessing && !isStale {
             Image(systemName: "ellipsis")
-                .font(.system(size: 11, weight: .bold))
+                .font(.system(size: 11 * scale, weight: .bold))
                 .foregroundStyle(WidgetTheme.textSecondary)
                 .accessibilityLabel("Working")
         } else if conversation.hasUnseen {
@@ -196,8 +217,8 @@ struct CatchUpRow: View {
                 .overlay(alignment: .topTrailing) {
                     Circle()
                         .fill(WidgetTheme.unseenIndicator)
-                        .frame(width: 4, height: 4)
-                        .offset(x: 1, y: -1)
+                        .frame(width: 4 * scale, height: 4 * scale)
+                        .offset(x: 1 * scale, y: -1 * scale)
                 }
                 .accessibilityLabel("Unread")
         } else {
@@ -208,7 +229,7 @@ struct CatchUpRow: View {
 
     private var bubble: some View {
         Image(systemName: "bubble.left")
-            .font(.system(size: 11))
+            .font(.system(size: 11 * scale))
             .foregroundStyle(WidgetTheme.textPrimary)
     }
 }

--- a/clients/ios/App/VoiceActivity/Widgets/QuickActionsWidget.swift
+++ b/clients/ios/App/VoiceActivity/Widgets/QuickActionsWidget.swift
@@ -2,8 +2,8 @@ import SwiftUI
 import WidgetKit
 
 /// The small Home Screen widget: the two most physical ways to start
-/// something, on a card painted in the assistant's own colors, plus a count of
-/// what is waiting.
+/// something, on a card painted in the assistant's own colors, plus the
+/// assistant looking up when something is waiting.
 ///
 /// Small only. Every action here is one tap target and none of them grow with
 /// more room, so a medium instance would be the same buttons with half a card
@@ -36,15 +36,26 @@ struct QuickActionsWidget: Widget {
     }
 }
 
-/// The card: the assistant looking back from the top, the two actions along
-/// the bottom, and the unread count tucked into the corner the mark leaves
-/// empty.
+/// The card: the two actions along the bottom, and, only while something is
+/// unread, the assistant glancing at the count across the top.
+///
+/// The mark and the chip arrive together or not at all. A quiet card is just
+/// the buttons, which is what makes the face appearing mean something: eyes on
+/// the card are the assistant saying there is something to look at, not
+/// decoration that was always there.
 ///
 /// There is no empty state and no signed-out state to draw: the buttons are
 /// what the widget is, and they work with nothing synced at all. The chip and
 /// the colors are what read the snapshot, so a missing snapshot costs the
 /// widget its theming and its count and nothing else.
 struct QuickActionsWidgetView: View {
+    /// The card every dimension below is designed on. Widget families render
+    /// at slightly different sizes per device, so the layout multiplies its
+    /// measurements by the ratio between the two and keeps the design's
+    /// proportions everywhere instead of gaining margin on large phones and
+    /// clipping on small ones.
+    private static let designSize = CGSize(width: 160, height: 161)
+
     /// The widget disables the system content margins and draws this one
     /// instead: the controls are laid out flush to the card's own margin, and
     /// the default insets would leave them a card too small to hold them.
@@ -62,15 +73,17 @@ struct QuickActionsWidgetView: View {
     private static let avatarImageSize: CGFloat = 44
     private static let avatarImageCornerRadius: CGFloat = 15
 
-    /// Space above the mark and the chip, inside the card's margin.
+    /// Space above the mark and the chip, inside the card's margin, and the
+    /// nudge the eyes sit in from the leading margin.
     private static let markInset: CGFloat = 13
+    private static let markLeadingInset: CGFloat = 2
 
     private static let chipHeight: CGFloat = 31
 
     /// The chip's fill: a wash of the dark the card is missing, rather than a
     /// pale pill placed on top of it. Same treatment over an accent as over a
     /// blurred photo, since both are surfaces the chip has to sink into.
-    private static let chipFill = Color.black.opacity(0.16)
+    private static let chipFill = Color.black.opacity(0.10)
 
     /// How strongly a control's fill washes the card, by how bright the color
     /// doing the washing is. A white wash lifts a dark card further than a
@@ -79,116 +92,111 @@ struct QuickActionsWidgetView: View {
     private static let controlFillOnWhite = 0.14
     private static let controlFillOnDark = 0.10
 
+    /// Width the chip needs at this count, from its fixed parts (the bubble,
+    /// the gaps, the padding) plus a digit's worth of count text per glyph.
+    /// Estimated rather than measured so the eyes can be sized in the same
+    /// pass that lays them out; the design draws full-height eyes beside a
+    /// one-digit chip, and only wider counts buy width from the eyes.
+    private static func chipAllowance(for count: Int, scale: CGFloat) -> CGFloat {
+        let glyphs = count > 99 ? 3 : String(count).count
+        return (45 + 9.5 * CGFloat(glyphs)) * scale
+    }
+
+    /// The least space between the mark and the chip before the mark gives
+    /// way.
+    private static let markChipGap: CGFloat = 12
+
     let entry: SnapshotEntry
 
     var body: some View {
         GeometryReader { geo in
+            let scale = min(
+                geo.size.width / Self.designSize.width,
+                geo.size.height / Self.designSize.height
+            )
             VStack(spacing: 0) {
-                markRow(width: geo.size.width)
+                if let count = unreadCount {
+                    let contentWidth = geo.size.width - Self.contentMargin * scale * 2
+                    let markWidth = contentWidth - Self.chipAllowance(for: count, scale: scale)
+                        - Self.markChipGap * scale
+                    markRow(count: count, markWidth: markWidth, scale: scale)
+                }
                 Spacer(minLength: 0)
-                controlRow(
-                    diameter: min(
-                        Self.controlDiameter,
-                        (geo.size.width - Self.controlGap) / 2
-                    )
-                )
+                controlRow(diameter: Self.controlDiameter * scale, scale: scale)
             }
+            .padding(Self.contentMargin * scale)
             .frame(width: geo.size.width, height: geo.size.height)
         }
-        .padding(Self.contentMargin)
     }
 
-    /// The mark, and the chip when there is something to count.
-    ///
-    /// The mark sits centered until the chip arrives and then moves to the left
-    /// margin. A chip in the corner over centered eyes reads as two things
-    /// dropped on a card; the two at opposite margins read as one row across
-    /// the top of it.
-    private func markRow(width: CGFloat) -> some View {
+    /// The mark at the leading margin, the chip at the trailing one: one row
+    /// across the top of the card rather than two things dropped on it.
+    private func markRow(count: Int, markWidth: CGFloat, scale: CGFloat) -> some View {
         HStack(alignment: .top, spacing: 0) {
-            if unreadCount == nil {
-                Spacer(minLength: 0)
-            }
-            avatarMark(width: width)
+            avatarMark(markWidth: markWidth, scale: scale)
+                .padding(.leading, Self.markLeadingInset * scale)
             Spacer(minLength: 0)
-            unreadChip
+            unreadChip(count: count, scale: scale)
         }
-        .padding(.top, Self.markInset)
+        .padding(.top, Self.markInset * scale)
     }
 
     /// Height the eyes can afford beside the chip. The pair's own width is its
     /// height times ``WidgetAvatarEyes/pairAspect``, so what the chip does not
-    /// take decides how tall they can be; on compact cards the eyes give way so
-    /// the row never compresses either mark.
-    private func fittedEyeHeight(in width: CGFloat) -> CGFloat {
-        guard unreadCount != nil else {
-            return WidgetAvatarEyes.defaultEyeHeight
-        }
-        let available = (width - Self.chipAllowance) / WidgetAvatarEyes.pairAspect
-        return min(WidgetAvatarEyes.defaultEyeHeight, max(24, available))
+    /// take decides how tall they can be; wide counts shrink the eyes rather
+    /// than compress the row.
+    private func fittedEyeHeight(in markWidth: CGFloat, scale: CGFloat) -> CGFloat {
+        let available = markWidth / WidgetAvatarEyes.pairAspect
+        return min(WidgetAvatarEyes.defaultEyeHeight * scale, max(24 * scale, available))
     }
 
     /// The photo mark under the same constraint as the eyes.
-    private func fittedImageSize(in width: CGFloat) -> CGFloat {
-        guard unreadCount != nil else {
-            return Self.avatarImageSize
-        }
-        return min(Self.avatarImageSize, max(24, width - Self.chipAllowance))
+    private func fittedImageSize(in markWidth: CGFloat, scale: CGFloat) -> CGFloat {
+        min(Self.avatarImageSize * scale, max(24 * scale, markWidth))
     }
-
-    /// Width the chip's widest form, the collapsed `99+`, can occupy: the 16pt
-    /// bubble, the 15pt count, and the padding around both.
-    private static let chipAllowance: CGFloat = 73
 
     /// The assistant, however this account's assistant can be drawn: its own
     /// photo where there is one, and the eyes the kit draws where the card is
     /// already wearing its color.
     @ViewBuilder
-    private func avatarMark(width: CGFloat) -> some View {
+    private func avatarMark(markWidth: CGFloat, scale: CGFloat) -> some View {
         if entry.avatarKind == .image, let image = entry.avatarImage {
             WidgetAvatarImageView(
                 image: image,
-                size: fittedImageSize(in: width),
-                cornerRadius: Self.avatarImageCornerRadius
+                size: fittedImageSize(in: markWidth, scale: scale),
+                cornerRadius: Self.avatarImageCornerRadius * scale
             )
         } else {
-            WidgetAvatarEyes(eyeHeight: fittedEyeHeight(in: width))
+            WidgetAvatarEyes(eyeHeight: fittedEyeHeight(in: markWidth, scale: scale))
         }
     }
 
-    /// How many conversations are waiting, when that is worth saying.
+    /// How many conversations are waiting.
     ///
     /// The number is `.privacySensitive()` while the glyph beside it is not, so
     /// a locked device still shows that something arrived without spelling out
     /// how far behind its owner is. Counts above two digits collapse to `99+`:
     /// past that the exact figure stops being information and the chip would
     /// grow into the mark across from it.
-    @ViewBuilder
-    private var unreadChip: some View {
-        if let count = unreadCount {
-            HStack(spacing: 4) {
-                WidgetUnreadMark(isFilled: true, size: 16)
-                Text(count > 99 ? "99+" : "\(count)")
-                    .font(.system(size: 15, weight: .semibold))
-                    .privacySensitive()
-            }
-            .foregroundStyle(palette.onSurface)
-            .padding(.horizontal, 9)
-            .frame(height: Self.chipHeight)
-            .background(Self.chipFill, in: Capsule())
-            .accessibilityElement(children: .ignore)
-            .accessibilityLabel("\(count) unread")
+    private func unreadChip(count: Int, scale: CGFloat) -> some View {
+        HStack(spacing: 5 * scale) {
+            WidgetUnreadMark(isFilled: false, size: 16 * scale)
+            Text(count > 99 ? "99+" : "\(count)")
+                .font(.system(size: 16 * scale, weight: .medium))
+                .privacySensitive()
         }
+        .foregroundStyle(palette.onSurface)
+        .padding(.horizontal, 10 * scale)
+        .frame(height: Self.chipHeight * scale)
+        .background(Self.chipFill, in: Capsule())
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(count) unread")
     }
 
     /// The pair the card is built around, sized to the margins so they land in
-    /// the same place whatever the avatar above them turns out to be. The
-    /// diameter follows the card's width on compact widgets, where two full
-    /// 61pt circles plus their gap would overrun the margins, and the row's
-    /// own height is the resolved diameter so the column never reserves more
-    /// than it draws.
-    private func controlRow(diameter: CGFloat) -> some View {
-        HStack(spacing: Self.controlGap) {
+    /// the same place whatever sits above them.
+    private func controlRow(diameter: CGFloat, scale: CGFloat) -> some View {
+        HStack(spacing: Self.controlGap * scale) {
             CircleActionButton(
                 intent: OpenCameraIntent(),
                 icon: Image(systemName: "camera.fill"),
@@ -219,9 +227,9 @@ struct QuickActionsWidgetView: View {
         palette.controlFill(onWhite: Self.controlFillOnWhite, onDark: Self.controlFillOnDark)
     }
 
-    /// The number for the unread chip, or nil when there is no chip to draw:
-    /// nothing unread, nothing synced, or a snapshot old enough that the count
-    /// is a claim about an inbox from half an hour ago.
+    /// The number for the unread chip, or nil when there is no chip or mark to
+    /// draw: nothing unread, nothing synced, or a snapshot old enough that the
+    /// count is a claim about an inbox from half an hour ago.
     ///
     /// `CatchUpRow` keeps its unread dot past that same threshold, and the two
     /// are consistent rather than in tension. A dot says "this conversation

--- a/clients/ios/App/VoiceActivity/Widgets/StatusWidget.swift
+++ b/clients/ios/App/VoiceActivity/Widgets/StatusWidget.swift
@@ -45,15 +45,21 @@ struct StatusWidget: Widget {
 struct StatusWidgetView: View {
     let entry: SnapshotEntry
 
+    /// The card every dimension below is designed on. Widget families render
+    /// at slightly different sizes per device, so the layout multiplies its
+    /// measurements by the ratio between the two and keeps the design's
+    /// proportions everywhere instead of gaining margin on large phones and
+    /// clipping on small ones.
+    private static let designSize = CGSize(width: 160, height: 161)
+
     /// The widget disables the system content margins and draws this one
     /// instead: the layout is drawn at these margins, and the system's own
     /// inset would leave the controls short of the size they are specified at.
     private static let contentMargin: CGFloat = 16
 
-    /// The height a control is drawn at where the family has room for it, and
-    /// the gap between the card's two bands. A shorter widget splits what it
-    /// has between the bands rather than overflowing its margins.
-    private static let preferredControlHeight: CGFloat = 61
+    /// The height of a control band, and the minimum gap between the card's
+    /// two bands.
+    private static let controlHeight: CGFloat = 61
     private static let bandGap: CGFloat = 7
 
     /// Gap inside a band: between the two circles, and between the two tiles.
@@ -63,26 +69,32 @@ struct StatusWidgetView: View {
     /// Gap between the two count lines, and the column their glyphs sit in.
     /// The column is wide enough for the wider of the two, so the counts start
     /// at the same place whichever lines are drawn.
-    private static let countGap: CGFloat = 12
-    private static let glyphColumnWidth: CGFloat = 20
+    private static let countGap: CGFloat = 16
+    private static let glyphColumnWidth: CGFloat = 17
+    private static let countGlyphGap: CGFloat = 7
+    private static let countTextSize: CGFloat = 14
 
     var body: some View {
         GeometryReader { proxy in
-            let control = Self.controlHeight(fitting: proxy.size)
+            let scale = min(
+                proxy.size.width / Self.designSize.width,
+                proxy.size.height / Self.designSize.height
+            )
+            let control = Self.controlHeight * scale
             VStack(spacing: 0) {
                 if isActive {
-                    counts
-                    Spacer(minLength: Self.bandGap)
-                    actionTiles(height: control)
+                    counts(scale: scale)
+                    Spacer(minLength: Self.bandGap * scale)
+                    actionTiles(height: control, scale: scale)
                 } else {
-                    circles(diameter: control)
-                    Spacer(minLength: Self.bandGap)
-                    chatPill(height: control)
+                    circles(diameter: control, scale: scale)
+                    Spacer(minLength: Self.bandGap * scale)
+                    chatPill(height: control, scale: scale)
                 }
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .padding(Self.contentMargin * scale)
+            .frame(width: proxy.size.width, height: proxy.size.height)
         }
-        .padding(Self.contentMargin)
     }
 
     /// Whether there is anything to report.
@@ -99,22 +111,10 @@ struct StatusWidgetView: View {
         return snapshot.unreadCount > 0 || snapshot.inProgressCount > 0
     }
 
-    /// The height of one control, capped at the size the card is laid out for
-    /// and otherwise cut to whichever dimension runs out first.
-    ///
-    /// Both states stack two bands of controls, or one band under the counts,
-    /// so the same number sizes the circles, the pill and the tiles. Deriving
-    /// it rather than fixing it is what keeps the card inside its margins on
-    /// the smaller phones, where a small widget is a good deal short of the
-    /// size this is drawn at.
-    private static func controlHeight(fitting size: CGSize) -> CGFloat {
-        min(preferredControlHeight, (size.height - bandGap) / 2, (size.width - circleGap) / 2)
-    }
-
     /// The two most physical actions, as circles: a shape the eye separates
     /// from the wide pill under them before it reads either one.
-    private func circles(diameter: CGFloat) -> some View {
-        HStack(spacing: Self.circleGap) {
+    private func circles(diameter: CGFloat, scale: CGFloat) -> some View {
+        HStack(spacing: Self.circleGap * scale) {
             CircleActionButton(
                 intent: OpenCameraIntent(),
                 icon: Image(systemName: "camera.fill"),
@@ -137,7 +137,7 @@ struct StatusWidgetView: View {
     /// Chat, given the whole width because it is the action most people want
     /// most often, and the pill is the only shape on a small widget that can
     /// say so.
-    private func chatPill(height: CGFloat) -> some View {
+    private func chatPill(height: CGFloat, scale: CGFloat) -> some View {
         PillActionButton(
             intent: OpenNewChatIntent(),
             icon: Image("VellumV"),
@@ -145,28 +145,29 @@ struct StatusWidgetView: View {
             fill: entry.softAccent.fill,
             tint: entry.softAccent.onFill,
             height: height,
-            avatarImage: entry.avatarImage
+            avatarImage: entry.avatarImage,
+            scale: scale
         )
     }
 
     /// The pair the readout state ends on. Voice keeps the neutral fill, so the
     /// two read as a primary action and a secondary one.
-    private func actionTiles(height: CGFloat) -> some View {
-        HStack(spacing: Self.tileGap) {
-            WidgetActionTile.newChat(accent: entry.softAccent, avatarImage: entry.avatarImage)
-            WidgetActionTile.voice
+    private func actionTiles(height: CGFloat, scale: CGFloat) -> some View {
+        HStack(spacing: Self.tileGap * scale) {
+            WidgetActionTile.newChat(accent: entry.softAccent, avatarImage: entry.avatarImage, scale: scale)
+            WidgetActionTile.voice(scale: scale)
         }
         .frame(height: height)
     }
 
     /// The counts, each dropping its line rather than printing "0".
-    private var counts: some View {
-        VStack(alignment: .leading, spacing: Self.countGap) {
+    private func counts(scale: CGFloat) -> some View {
+        VStack(alignment: .leading, spacing: Self.countGap * scale) {
             if let count = entry.snapshot?.unreadCount, count > 0 {
-                countLine(glyph: unreadGlyph, text: "\(count) unread")
+                countLine(glyph: unreadGlyph(scale: scale), text: "\(count) unread", scale: scale)
             }
             if let count = entry.snapshot?.inProgressCount, count > 0 {
-                countLine(glyph: inProgressGlyph, text: "\(count) in progress")
+                countLine(glyph: inProgressGlyph(scale: scale), text: "\(count) in progress", scale: scale)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -178,13 +179,13 @@ struct StatusWidgetView: View {
     /// The line is `.privacySensitive()` while the glyph beside it is not,
     /// matching the Quick Actions chip: a locked device still shows that
     /// something is waiting without spelling out how far behind its owner is.
-    private func countLine(glyph: some View, text: String) -> some View {
-        HStack(spacing: 7) {
+    private func countLine(glyph: some View, text: String, scale: CGFloat) -> some View {
+        HStack(spacing: Self.countGlyphGap * scale) {
             glyph
-                .frame(width: Self.glyphColumnWidth, alignment: .leading)
+                .frame(width: Self.glyphColumnWidth * scale, alignment: .leading)
                 .accessibilityHidden(true)
             Text(text)
-                .font(.system(size: 14, weight: .semibold))
+                .font(.system(size: Self.countTextSize * scale, weight: .medium))
                 .foregroundStyle(WidgetTheme.textPrimary)
                 .lineLimit(1)
                 .minimumScaleFactor(0.8)
@@ -194,16 +195,16 @@ struct StatusWidgetView: View {
 
     /// The outline bubble, since this card is the white one, in the primary
     /// text color the line beside it is drawn in.
-    private var unreadGlyph: some View {
-        WidgetUnreadMark(isFilled: false, size: 16)
+    private func unreadGlyph(scale: CGFloat) -> some View {
+        WidgetUnreadMark(isFilled: false, size: 16 * scale)
             .foregroundStyle(WidgetTheme.textPrimary)
     }
 
     /// The dots a Catch Up row marks a turn in flight with, at the size this
     /// card's lines are drawn at.
-    private var inProgressGlyph: some View {
+    private func inProgressGlyph(scale: CGFloat) -> some View {
         Image(systemName: "ellipsis")
-            .font(.system(size: 16, weight: .bold))
+            .font(.system(size: 16 * scale, weight: .bold))
             .foregroundStyle(WidgetTheme.textSecondary)
     }
 }

--- a/clients/ios/App/VoiceActivity/Widgets/WidgetActionControls.swift
+++ b/clients/ios/App/VoiceActivity/Widgets/WidgetActionControls.swift
@@ -16,12 +16,13 @@ import UIKit
 /// `openAppWhenRun`, so the system performs them in the app process; the appex
 /// only needs the types to exist.
 struct WidgetActionTile<ActionIntent: AppIntent>: View {
-    /// Close to the squircle the system clips the widget itself with, so a tile
-    /// reads as a smaller instance of the card it sits on rather than as a chip
-    /// placed on top of it.
-    private static var cornerRadius: CGFloat { 19 }
+    /// A corner tighter than the widget's own squircle, so the tile reads as a
+    /// control on the card rather than as a second card.
+    private static var cornerRadius: CGFloat { 12 }
 
-    private static var iconSize: CGFloat { 22 }
+    private static var iconSize: CGFloat { 24 }
+
+    private static var labelSize: CGFloat { 8 }
 
     let intent: ActionIntent
     let icon: Image
@@ -35,17 +36,22 @@ struct WidgetActionTile<ActionIntent: AppIntent>: View {
     /// fresh install.
     var avatarImage: UIImage? = nil
 
+    /// The owning card's ratio to the size it was designed at, so the tile
+    /// keeps its share of a card that renders larger or smaller than the
+    /// design. See the design-size note on each widget view.
+    var scale: CGFloat = 1
+
     var body: some View {
         Button(intent: intent) {
-            VStack(spacing: 4) {
+            VStack(spacing: 4 * scale) {
                 glyph
                 Text(title)
-                    .font(.system(size: 9, weight: .medium))
+                    .font(.system(size: Self.labelSize * scale, weight: .medium))
                     .foregroundStyle(WidgetTheme.textPrimary)
                     .lineLimit(1)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(fill, in: RoundedRectangle(cornerRadius: Self.cornerRadius))
+            .background(fill, in: RoundedRectangle(cornerRadius: Self.cornerRadius * scale))
         }
         .buttonStyle(.plain)
         .accessibilityLabel(title)
@@ -56,10 +62,10 @@ struct WidgetActionTile<ActionIntent: AppIntent>: View {
     @ViewBuilder
     private var glyph: some View {
         if let avatarImage {
-            WidgetAvatarImageView(image: avatarImage, size: Self.iconSize)
+            WidgetAvatarImageView(image: avatarImage, size: Self.iconSize * scale)
         } else {
             icon
-                .font(.system(size: Self.iconSize))
+                .font(.system(size: Self.iconSize * scale))
                 .foregroundStyle(tint)
         }
     }
@@ -73,14 +79,15 @@ extension WidgetActionTile where ActionIntent == OpenNewChatIntent {
     /// The accent themes the tile and the avatar replaces its mark, both from
     /// the snapshot, so the tile that starts a chat with the assistant looks
     /// like that assistant.
-    static func newChat(accent: WidgetSoftAccent, avatarImage: UIImage? = nil) -> Self {
+    static func newChat(accent: WidgetSoftAccent, avatarImage: UIImage? = nil, scale: CGFloat = 1) -> Self {
         WidgetActionTile(
             intent: OpenNewChatIntent(),
             icon: Image("VellumV"),
             title: "New Chat",
             fill: accent.fill,
             tint: accent.onFill,
-            avatarImage: avatarImage
+            avatarImage: avatarImage,
+            scale: scale
         )
     }
 }
@@ -89,13 +96,14 @@ extension WidgetActionTile where ActionIntent == StartNewVoiceConversationIntent
     /// The Voice tile, the secondary half of the pair. Neutral fill against
     /// ``newChat``'s tinted one, so the two read as a primary action and a
     /// secondary one rather than as two peers.
-    static var voice: Self {
+    static func voice(scale: CGFloat = 1) -> Self {
         WidgetActionTile(
             intent: StartNewVoiceConversationIntent(),
             icon: Image(systemName: "waveform"),
             title: "Voice",
             fill: WidgetTheme.voiceFill,
-            tint: WidgetTheme.textPrimary
+            tint: WidgetTheme.textPrimary,
+            scale: scale
         )
     }
 }
@@ -136,12 +144,16 @@ struct PillActionButton<ActionIntent: AppIntent>: View {
     /// See ``WidgetActionTile/avatarImage``.
     var avatarImage: UIImage? = nil
 
+    /// See ``WidgetActionTile/scale``. The glyph already follows the height;
+    /// this scales the word beside it.
+    var scale: CGFloat = 1
+
     var body: some View {
         Button(intent: intent) {
-            HStack(spacing: 6) {
+            HStack(spacing: 6 * scale) {
                 glyph
                 Text(title)
-                    .font(.system(size: 15, weight: .semibold))
+                    .font(.system(size: 15 * scale, weight: .semibold))
             }
             .foregroundStyle(tint)
             .frame(maxWidth: .infinity)
@@ -180,12 +192,14 @@ struct WidgetUnreadMark: View {
     /// wants the filled one; a white card wants the outline its rows draw.
     let isFilled: Bool
 
-    /// Point size of the bubble. The dot rides its corner at a fixed size
-    /// rather than scaling with it, so the alert stays the same alert whichever
-    /// card carries it.
+    /// Point size of the bubble. The dot rides its corner at the design's
+    /// share of it, so the mark scales as one piece: every card draws the
+    /// bubble at the same 16pt design size, and a dot fixed in points would
+    /// drift off the corner on the devices that render a card larger.
     let size: CGFloat
 
-    private static let dotDiameter: CGFloat = 6
+    private var dotDiameter: CGFloat { size * 0.375 }
+    private var dotNudge: CGFloat { size * 0.0625 }
 
     var body: some View {
         Image(systemName: isFilled ? "bubble.left.fill" : "bubble.left")
@@ -193,8 +207,8 @@ struct WidgetUnreadMark: View {
             .overlay(alignment: .topTrailing) {
                 Circle()
                     .fill(WidgetTheme.unseenIndicator)
-                    .frame(width: Self.dotDiameter, height: Self.dotDiameter)
-                    .offset(x: 2, y: -2)
+                    .frame(width: dotDiameter, height: dotDiameter)
+                    .offset(x: dotNudge, y: -dotNudge)
             }
     }
 }

--- a/clients/ios/App/VoiceActivity/Widgets/WidgetAvatarRendering.swift
+++ b/clients/ios/App/VoiceActivity/Widgets/WidgetAvatarRendering.swift
@@ -131,11 +131,14 @@ struct WidgetAvatarEyes: View {
     /// Gap between the two, as a share of eye height.
     private static let gapRatio: CGFloat = 5.0 / 33.0
 
-    /// Pupil diameter and how far it sits off the bottom of the white, both as
-    /// a share of eye height. Pupils sit low, which is the whole trick:
-    /// centered dots read as punctuation, low ones read as a face looking back.
-    private static let pupilRatio: CGFloat = 0.41
-    private static let pupilInsetRatio: CGFloat = 0.18
+    /// The pupil's box and where it sits in the white, as shares of eye
+    /// height. It fills most of the eye and presses against the right edge,
+    /// which is the whole trick: small centered dots read as punctuation, a
+    /// heavy sideways pair reads as a face caught mid-glance.
+    private static let pupilWidthRatio: CGFloat = 18.0 / 33.0
+    private static let pupilHeightRatio: CGFloat = 21.5 / 33.0
+    private static let pupilOffsetXRatio: CGFloat = 9.0 / 33.0
+    private static let pupilOffsetYRatio: CGFloat = 6.5 / 33.0
 
     /// The height the pair is drawn at where the card has room for it.
     static let defaultEyeHeight: CGFloat = 33
@@ -156,15 +159,88 @@ struct WidgetAvatarEyes: View {
     }
 
     private var eye: some View {
-        Ellipse()
+        AvatarEyeScleraShape()
             .fill(WidgetTheme.avatarSclera)
             .frame(width: eyeHeight * Self.widthRatio, height: eyeHeight)
-            .overlay(alignment: .bottom) {
-                Circle()
+            .overlay(alignment: .topLeading) {
+                AvatarEyePupilShape()
                     .fill(WidgetTheme.avatarPupil)
-                    .frame(width: eyeHeight * Self.pupilRatio, height: eyeHeight * Self.pupilRatio)
-                    .padding(.bottom, eyeHeight * Self.pupilInsetRatio)
+                    .frame(
+                        width: eyeHeight * Self.pupilWidthRatio,
+                        height: eyeHeight * Self.pupilHeightRatio
+                    )
+                    .offset(
+                        x: eyeHeight * Self.pupilOffsetXRatio,
+                        y: eyeHeight * Self.pupilOffsetYRatio
+                    )
             }
+    }
+}
+
+/// The white of one eye: a hand-drawn egg rather than a true ellipse, its long
+/// axis tilted a few degrees, traced from the character mark the product draws
+/// so the widget's stand-in is recognizably the same face. Control points are
+/// in the 28x33 box the mark is designed in and scale with the rect.
+private struct AvatarEyeScleraShape: Shape {
+    func path(in rect: CGRect) -> Path {
+        let w = rect.width / 28
+        let h = rect.height / 33
+        var path = Path()
+        path.move(to: CGPoint(x: 13.34 * w, y: 0.02 * h))
+        path.addCurve(
+            to: CGPoint(x: 27.98 * w, y: 15.71 * h),
+            control1: CGPoint(x: 21.06 * w, y: -0.41 * h),
+            control2: CGPoint(x: 27.61 * w, y: 6.61 * h)
+        )
+        path.addCurve(
+            to: CGPoint(x: 14.69 * w, y: 32.98 * h),
+            control1: CGPoint(x: 28.36 * w, y: 24.80 * h),
+            control2: CGPoint(x: 22.41 * w, y: 32.53 * h)
+        )
+        path.addCurve(
+            to: CGPoint(x: 0.02 * w, y: 17.30 * h),
+            control1: CGPoint(x: 6.96 * w, y: 33.43 * h),
+            control2: CGPoint(x: 0.39 * w, y: 26.40 * h)
+        )
+        path.addCurve(
+            to: CGPoint(x: 13.34 * w, y: 0.02 * h),
+            control1: CGPoint(x: -0.36 * w, y: 8.19 * h),
+            control2: CGPoint(x: 5.61 * w, y: 0.45 * h)
+        )
+        path.closeSubpath()
+        return path
+    }
+}
+
+/// The pupil, the same egg at a steeper tilt, in its own 18x21 design box.
+private struct AvatarEyePupilShape: Shape {
+    func path(in rect: CGRect) -> Path {
+        let w = rect.width / 18
+        let h = rect.height / 21
+        var path = Path()
+        path.move(to: CGPoint(x: 7.77 * w, y: 0.10 * h))
+        path.addCurve(
+            to: CGPoint(x: 17.92 * w, y: 9.09 * h),
+            control1: CGPoint(x: 12.70 * w, y: -0.70 * h),
+            control2: CGPoint(x: 17.25 * w, y: 3.33 * h)
+        )
+        path.addCurve(
+            to: CGPoint(x: 10.18 * w, y: 20.91 * h),
+            control1: CGPoint(x: 18.59 * w, y: 14.85 * h),
+            control2: CGPoint(x: 15.12 * w, y: 20.14 * h)
+        )
+        path.addCurve(
+            to: CGPoint(x: 0.08 * w, y: 11.91 * h),
+            control1: CGPoint(x: 5.27 * w, y: 21.67 * h),
+            control2: CGPoint(x: 0.75 * w, y: 17.64 * h)
+        )
+        path.addCurve(
+            to: CGPoint(x: 7.77 * w, y: 0.10 * h),
+            control1: CGPoint(x: -0.58 * w, y: 6.17 * h),
+            control2: CGPoint(x: 2.85 * w, y: 0.89 * h)
+        )
+        path.closeSubpath()
+        return path
     }
 }
 


### PR DESCRIPTION
## Summary
- Rebuild the avatar eyes from the mock's own vectors: an egg-shaped sclera with a large oval pupil pressed against its right edge, and draw the mark only while something is unread. A quiet Quick Actions card is just the two buttons; the eyes appearing beside the chip is what says there is something to look at.
- Restyle the unread chip to the mock: outline bubble with the amber dot, 16pt medium count, black-10% capsule, and a width allowance sized by digit count so one-digit counts keep full-height 33pt eyes.
- Scale each widget's whole layout and type by `min(width / designWidth, height / designHeight)` from its design canvas (160x161 small, 339x161 medium), so the cards keep the mock's proportions at every rendered size instead of capping at mock pixels and coming out visually small on the larger phones.
- Match Catch Up rows to the mock: 12pt medium titles, 7pt subtitles, text top-anchored at the row's 6pt inset so subtitle-less rows keep the same title rhythm, and the 8pt leading inset and header offsets.
- Match the action tiles to the mock: corner radius 19 -> 12, icons 22 -> 24, labels 9 -> 8; the Status readout picks up the mock's 16pt line gap and medium weight.

## Verification
- `swiftc -typecheck` over `VoiceActivity` + `App/Shared` passes with and without `-D DEBUG`.
- No remaining consumers of the changed control APIs outside the widget files.

## Device QA checklist
- Quick Actions: no eyes or chip when nothing is unread; eyes + chip at full size for a one-digit count; eyes give way gracefully at 99+.
- Eyes read as the character's sideways glance (large pupil against the right edge), light and dark.
- Catch Up: even title rhythm across rows with and without subtitles; tiles with 24pt icons and legible 8pt labels.
- Status readout: 16pt gap between the two count lines; tiles match Catch Up's.
- SE-class widget sizes: everything shrinks proportionally without clipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)