### PR TITLE
Map avatars to eyes-on-color app icon names

### DIFF
--- a/clients/web/src/components/avatar/app-icon-match-prompt.test.tsx
+++ b/clients/web/src/components/avatar/app-icon-match-prompt.test.tsx
@@ -43,9 +43,9 @@ const TRAITS = {
   eyeStyle: "curious",
   color: "cosmic-purple",
 };
-const ICON = "avatar-blob-curious-cosmic-purple";
+const ICON = "avatar-eyes-curious-cosmic-purple";
 const OTHER_TRAITS = { ...TRAITS, color: "moss" };
-const OTHER_ICON = "avatar-blob-curious-moss";
+const OTHER_ICON = "avatar-eyes-curious-moss";
 
 const CHARACTER: AvatarState = {
   kind: "character",

--- a/clients/web/src/domains/settings/components/app-icon-card.test.tsx
+++ b/clients/web/src/domains/settings/components/app-icon-card.test.tsx
@@ -16,9 +16,9 @@ const TRAITS = {
   eyeStyle: "curious",
   color: "cosmic-purple",
 };
-const ICON = "avatar-blob-curious-cosmic-purple";
+const ICON = "avatar-eyes-curious-cosmic-purple";
 /** One of ours, applied for an avatar the assistant no longer wears. */
-const STALE_ICON = "avatar-blob-curious-moss";
+const STALE_ICON = "avatar-eyes-curious-moss";
 
 const CHARACTER: AvatarState = {
   kind: "character",

--- a/clients/web/src/hooks/use-app-icon-sync.test.tsx
+++ b/clients/web/src/hooks/use-app-icon-sync.test.tsx
@@ -19,7 +19,7 @@ const TRAITS = {
   eyeStyle: "curious",
   color: "cosmic-purple",
 };
-const ICON = "avatar-blob-curious-cosmic-purple";
+const ICON = "avatar-eyes-curious-cosmic-purple";
 
 const CHARACTER: AvatarState = {
   kind: "character",

--- a/clients/web/src/utils/avatar-app-icon.test.ts
+++ b/clients/web/src/utils/avatar-app-icon.test.ts
@@ -16,6 +16,8 @@ import type { AvatarState } from "@/types/avatar";
  *   2. The name format itself, which is shared with the icon bundle generator:
  *      the bundles are emitted under exactly these names, so changing the
  *      literal below without regenerating them silently breaks every install.
+ *      `clients/ios/scripts/__tests__/generate-avatar-icons.test.ts` pins the
+ *      same literal from the generator's side.
  */
 
 /** A character avatar by default; `overrides` swaps in the other kinds. */
@@ -41,7 +43,17 @@ describe("appIconNameForAvatar", () => {
         color: "green",
       }),
     );
-    expect(name).toBe("avatar-blob-grumpy-green");
+    expect(name).toBe("avatar-eyes-grumpy-green");
+  });
+
+  test("body shape does not reach the name", () => {
+    const blob = appIconNameForAvatar(
+      avatarState({ bodyShape: "blob", eyeStyle: "grumpy", color: "green" }),
+    );
+    const nebula = appIconNameForAvatar(
+      avatarState({ bodyShape: "nebula", eyeStyle: "grumpy", color: "green" }),
+    );
+    expect(nebula).toBe(blob);
   });
 
   test("an uploaded image avatar has no icon, even with stale traits", () => {
@@ -76,13 +88,21 @@ describe("appIconNameForAvatar", () => {
     const state = avatarState(malformed as AvatarState["traits"]);
     expect(appIconNameForAvatar(state)).toBeNull();
   });
+
+  // A character always carries all three traits, so traits missing the one the
+  // name leaves out are as malformed as any other.
+  test("traits without a body shape have no icon", () => {
+    const malformed = { eyeStyle: "grumpy", color: "green" } as unknown;
+    const state = avatarState(malformed as AvatarState["traits"]);
+    expect(appIconNameForAvatar(state)).toBeNull();
+  });
 });
 
 describe("resolveAppIconTarget", () => {
   const supportedShell = {
     supported: true,
     current: null,
-    available: ["avatar-blob-grumpy-green"],
+    available: ["avatar-eyes-grumpy-green"],
   };
 
   test("a bundled icon resolves to an available match", () => {
@@ -95,7 +115,7 @@ describe("resolveAppIconTarget", () => {
       supportedShell,
     );
     expect(result).toEqual({
-      target: "avatar-blob-grumpy-green",
+      target: "avatar-eyes-grumpy-green",
       availableMatch: true,
     });
   });
@@ -110,7 +130,7 @@ describe("resolveAppIconTarget", () => {
       supportedShell,
     );
     expect(result).toEqual({
-      target: "avatar-nebula-smitten-chartreuse",
+      target: "avatar-eyes-smitten-chartreuse",
       availableMatch: false,
     });
   });
@@ -125,7 +145,7 @@ describe("resolveAppIconTarget", () => {
       { ...supportedShell, supported: false },
     );
     expect(result).toEqual({
-      target: "avatar-blob-grumpy-green",
+      target: "avatar-eyes-grumpy-green",
       availableMatch: false,
     });
   });

--- a/clients/web/src/utils/avatar-app-icon.ts
+++ b/clients/web/src/utils/avatar-app-icon.ts
@@ -5,10 +5,12 @@ import type { AvatarState } from "@/types/avatar";
 /**
  * Maps an assistant avatar onto the name of a bundled iOS alternate app icon.
  *
- * The iOS shell ships one alternate icon per character combination, named
- * `avatar-<bodyShape>-<eyeStyle>-<color>` by the icon bundle generator. That
- * name is the wire contract between the generated bundles and the runtime, so
- * it is produced in exactly one place: `appIconNameForAvatar`.
+ * The iOS shell ships one alternate icon per eyes-on-color combination, named
+ * `avatar-eyes-<eyeStyle>-<color>` by the icon bundle generator. Body shape is
+ * not part of an icon, so it is not part of the name, and every avatar that
+ * shares an eye style and a color maps to the same icon. That name is the wire
+ * contract between the generated bundles and the runtime, so it is produced in
+ * exactly one place: `appIconNameForAvatar`.
  */
 
 /** A resolved icon target plus whether the installed shell can apply it. */
@@ -20,14 +22,15 @@ export interface AppIconTarget {
 }
 
 /** The namespace every icon this feature applies is emitted under. */
-const AVATAR_ICON_PREFIX = "avatar-";
+const AVATAR_ICON_PREFIX = "avatar-eyes-";
 
 /**
  * The single chokepoint for the invariant that only character avatars have an
  * app icon. Uploaded images, AI-generated avatars, and "no avatar" all return
  * null here, so nothing downstream can offer or apply an icon for them, and a
  * character state with malformed traits returns null rather than a name built
- * from `undefined`.
+ * from `undefined`. A character's traits always carry all three, so the guard
+ * stays whole even though the name is built from two of them.
  */
 export function appIconNameForAvatar(state: AvatarState | null): string | null {
   if (state === null || state.kind !== "character") {
@@ -37,7 +40,7 @@ export function appIconNameForAvatar(state: AvatarState | null): string | null {
   if (!isCharacterTraits(traits)) {
     return null;
   }
-  return `${AVATAR_ICON_PREFIX}${traits.bodyShape}-${traits.eyeStyle}-${traits.color}`;
+  return `${AVATAR_ICON_PREFIX}${traits.eyeStyle}-${traits.color}`;
 }
 
 /**


### PR DESCRIPTION
## Summary

- `appIconNameForAvatar` now emits `avatar-eyes-<eyeStyle>-<color>`, matching the eyes-on-color icon catalog. Body shape is not part of an icon, so it is no longer part of the name, and avatars that share an eye style and a color map to the same icon.
- The character-only chokepoint is unchanged: uploaded images, AI-generated avatars, "no avatar", and malformed traits still resolve to `null`, and the `isCharacterTraits` guard still requires all three traits, since a character's recipe always carries all three.
- `AVATAR_ICON_PREFIX` tightens to `avatar-eyes-`, so `isAvatarAppIcon` recognizes exactly the names this feature emits. `resolveAppIconTarget` keeps validating the resolved name against the shell's native `available` list, which is what makes a version-skewed name a no-op rather than a failed swap.
- The wire-contract test pins `avatar-eyes-grumpy-green` and now names the generator-side test that pins the same literal (`clients/ios/scripts/__tests__/generate-avatar-icons.test.ts`). Two new cases pin the design decision directly: two body shapes over one eye style and color produce one name, and traits missing a body shape are still rejected.
- The hook, prompt, and settings-card suites each derived their `ICON` fixture from the same three-trait format, so those literals move to the new format too. No production code outside `avatar-app-icon.ts` changed, and the `setAppIcon(` call-site scan test is untouched and passing. `src/stores/app-icon-store.test.ts` keeps its literal: it never routes through the mapper and treats the name as opaque.

## Verification

- `bun run test:ci` over the mapper, hook, prompt, card, store, and runtime app-icon suites: 6 passed, 0 failed.
- Scoped eslint and prettier clean on all five changed files.
- `bunx tsc --noEmit` reports only pre-existing worktree-env noise (stale generated SDK and `@vellumai/*` symlinks resolving to the main checkout); no error touches any app-icon file.

Part of plan: ios-eyes-icon-rebrand.md (PR 3)