### PR TITLE
feat(ios): survive the tinted Home Screen in the widgets

### DIFF
--- a/clients/ios/App/VoiceActivity/Widgets/CatchUpWidget.swift
+++ b/clients/ios/App/VoiceActivity/Widgets/CatchUpWidget.swift
@@ -247,10 +247,15 @@ struct CatchUpRow: View {
         } else if conversation.hasUnseen {
             bubble
                 .overlay(alignment: .topTrailing) {
+                    // Accentable for the reason ``WidgetUnreadMark``'s dot is:
+                    // this row draws the same mark at row scale, and a dot left
+                    // out of the tint would flatten into the white bubble it
+                    // rides and stop marking anything.
                     Circle()
                         .fill(WidgetTheme.unseenIndicator)
                         .frame(width: 4 * scale, height: 4 * scale)
                         .offset(x: 1 * scale, y: -1 * scale)
+                        .widgetAccentable()
                 }
                 .accessibilityLabel("Unread")
         } else {

--- a/clients/ios/App/VoiceActivity/Widgets/QuickActionsWidget.swift
+++ b/clients/ios/App/VoiceActivity/Widgets/QuickActionsWidget.swift
@@ -83,6 +83,11 @@ struct QuickActionsWidgetView: View {
     /// The chip's fill: a wash of the dark the card is missing, rather than a
     /// pale pill placed on top of it. Same treatment over an accent as over a
     /// blurred photo, since both are surfaces the chip has to sink into.
+    ///
+    /// It has a flattened counterpart because a dark wash stops working once
+    /// the card underneath is the system's own dark material: there is no light
+    /// left to take away, and the chip would read as nothing at all. See
+    /// ``WidgetFlattenedFill``.
     private static let chipFill = Color.black.opacity(0.10)
 
     /// How strongly a control's fill washes the card, by how bright the color
@@ -107,6 +112,12 @@ struct QuickActionsWidgetView: View {
     private static let markChipGap: CGFloat = 12
 
     let entry: SnapshotEntry
+
+    @Environment(\.widgetRenderingMode) private var renderingMode
+
+    /// Whether the system is drawing the widget in one of its monochrome modes.
+    /// See the note at the top of `WidgetActionControls.swift`.
+    private var isFlattened: Bool { renderingMode != .fullColor }
 
     var body: some View {
         GeometryReader { geo in
@@ -188,7 +199,7 @@ struct QuickActionsWidgetView: View {
         .foregroundStyle(palette.onSurface)
         .padding(.horizontal, 10 * scale)
         .frame(height: Self.chipHeight * scale)
-        .background(Self.chipFill, in: Capsule())
+        .background(isFlattened ? WidgetFlattenedFill.chip : Self.chipFill, in: Capsule())
         .accessibilityElement(children: .ignore)
         .accessibilityLabel("\(count) unread")
     }
@@ -317,6 +328,20 @@ private func previewCharacterAvatar(accentHex: String) -> WidgetSnapshotAvatar {
         HStack(spacing: 12) {
             previewCard(previewEntry(unread: 0, avatar: nil))
             previewCard(previewEntry(unread: 128, avatar: nil))
+        }
+    }
+}
+
+#Preview("Flattened") {
+    // The chip and the two circles have to stay visible as shapes once the card
+    // under them is the system's own material rather than the accent.
+    previewFlattened {
+        previewWidgetCard {
+            QuickActionsWidgetView(
+                entry: previewEntry(unread: 3, avatar: previewCharacterAvatar(accentHex: "#0E9B8B"))
+            )
+        } background: {
+            previewFlattenedGround
         }
     }
 }

--- a/clients/ios/App/VoiceActivity/Widgets/StatusWidget.swift
+++ b/clients/ios/App/VoiceActivity/Widgets/StatusWidget.swift
@@ -136,7 +136,9 @@ struct StatusWidgetView: View {
 
     /// Chat, given the whole width because it is the action most people want
     /// most often, and the pill is the only shape on a small widget that can
-    /// say so.
+    /// say so. It carries the accent for the same reason it gets the width, and
+    /// on a themed Home Screen it carries the user's tint in the accent's
+    /// place, so the circles above it keep reading as the secondary pair.
     private func chatPill(height: CGFloat, scale: CGFloat) -> some View {
         PillActionButton(
             intent: OpenNewChatIntent(),
@@ -145,6 +147,7 @@ struct StatusWidgetView: View {
             fill: entry.softAccent.fill,
             tint: entry.softAccent.onFill,
             height: height,
+            carriesAccent: true,
             avatarImage: entry.avatarImage,
             scale: scale
         )

--- a/clients/ios/App/VoiceActivity/Widgets/StatusWidget.swift
+++ b/clients/ios/App/VoiceActivity/Widgets/StatusWidget.swift
@@ -253,6 +253,26 @@ private func statusPreviewCard(_ entry: SnapshotEntry) -> some View {
     }
 }
 
+#Preview("Flattened") {
+    // The only card that draws all four controls, so it is where the flattened
+    // fills are worth looking at: both states, since the tiles and the pill are
+    // on opposite sides of the flip.
+    previewFlattened {
+        HStack(spacing: 12) {
+            previewWidgetCard {
+                StatusWidgetView(entry: previewEntry())
+            } background: {
+                previewFlattenedGround
+            }
+            previewWidgetCard {
+                StatusWidgetView(entry: previewEntry(unread: 3, inProgress: 2))
+            } background: {
+                previewFlattenedGround
+            }
+        }
+    }
+}
+
 #Preview("Character accent") {
     // The light accent is the one worth looking at: its wash has to stay a pale
     // card with the word still legible on it.

--- a/clients/ios/App/VoiceActivity/Widgets/WidgetActionControls.swift
+++ b/clients/ios/App/VoiceActivity/Widgets/WidgetActionControls.swift
@@ -210,6 +210,12 @@ struct PillActionButton<ActionIntent: AppIntent>: View {
     let tint: Color
     let height: CGFloat
 
+    /// See ``WidgetActionTile/carriesAccent``. The pill is the idle card's
+    /// primary action the way the New Chat tile is the active card's, so both
+    /// states hand the tint to the control doing that job and the flip between
+    /// them does not move the user's own color onto something else.
+    var carriesAccent: Bool = false
+
     /// See ``WidgetActionTile/avatarImage``.
     var avatarImage: UIImage? = nil
 
@@ -233,10 +239,25 @@ struct PillActionButton<ActionIntent: AppIntent>: View {
             .foregroundStyle(tint)
             .frame(maxWidth: .infinity)
             .frame(height: height)
-            .background(isFlattened ? WidgetFlattenedFill.pill : fill, in: Capsule())
+            .background { ground }
         }
         .buttonStyle(.plain)
         .accessibilityLabel(title)
+    }
+
+    /// The pill's ground, its own shape view for the reason the tile's is:
+    /// `widgetAccentable()` tints everything beneath it, so a pill that marked
+    /// its button would sink the glyph and the word into the ground behind
+    /// them. Marking the shape alone leaves them in the default group, legible
+    /// against the tint.
+    @ViewBuilder
+    private var ground: some View {
+        let shape = Capsule().fill(isFlattened ? WidgetFlattenedFill.pill : fill)
+        if carriesAccent {
+            shape.widgetAccentable()
+        } else {
+            shape
+        }
     }
 
     /// The glyph is sized off the pill's height either way, so swapping the

--- a/clients/ios/App/VoiceActivity/Widgets/WidgetActionControls.swift
+++ b/clients/ios/App/VoiceActivity/Widgets/WidgetActionControls.swift
@@ -1,12 +1,40 @@
 import AppIntents
 import SwiftUI
 import UIKit
+import WidgetKit
 
 // The pieces every Vellum Home Screen widget builds itself out of: a tile, a
 // circle, a pill, the unread mark, and the secondary line of text that stands
 // in when there is nothing to list. They live here rather than beside whichever
 // widget reached for them first, because a control that lives in one widget's
 // file is a control the next widget copies.
+//
+// Each control that carries a fill also knows what to do when the system
+// flattens the widget: a themed Home Screen, StandBy, or the lock screen. In
+// those modes WidgetKit throws away every color a widget sets and redraws it in
+// two monochrome groups, keeping only each view's alpha, so a fill picked to
+// sit on a white card comes out either as an opaque block that swallows the
+// glyph on it or as a wash too faint to see. The controls answer by swapping to
+// a translucent white, which survives the flattening as the same soft ground it
+// was drawn as.
+
+/// The grounds a control draws on once WidgetKit flattens the widget.
+///
+/// White rather than the control's own color because only alpha survives the
+/// flattening: a translucent white is the one way to ask for the soft ground
+/// the full-color card gets and be given it. The weights differ by shape rather
+/// than by accident, since a small round ground has less area to make the same
+/// wash felt with than a tile does.
+///
+/// Collected here rather than spelled at each use for the reason
+/// ``WidgetTheme`` collects the full-color palette: four controls picking their
+/// own number is four controls drifting apart.
+enum WidgetFlattenedFill {
+    static let tile = Color.white.opacity(0.12)
+    static let circle = Color.white.opacity(0.14)
+    static let pill = Color.white.opacity(0.12)
+    static let chip = Color.white.opacity(0.12)
+}
 
 /// One tile in an action column: a glyph over a word, filling a rounded
 /// square, wired to an App Intent.
@@ -30,6 +58,12 @@ struct WidgetActionTile<ActionIntent: AppIntent>: View {
     let fill: Color
     let tint: Color
 
+    /// Whether this tile is the one that wears the user's own tint on a themed
+    /// Home Screen. At most one tile per card claims it, so the pair keeps the
+    /// primary-and-secondary reading it has in full color instead of coming out
+    /// as two identical blocks.
+    var carriesAccent: Bool = false
+
     /// The user's avatar, drawn in place of ``icon`` when the snapshot carries
     /// one. Optional because the tiles standing for an action rather than for
     /// the assistant keep their symbol, and because nothing has synced yet on a
@@ -41,6 +75,12 @@ struct WidgetActionTile<ActionIntent: AppIntent>: View {
     /// design. See the design-size note on each widget view.
     var scale: CGFloat = 1
 
+    @Environment(\.widgetRenderingMode) private var renderingMode
+
+    /// Whether the system is drawing the widget in one of its monochrome modes.
+    /// See the note at the top of this file.
+    private var isFlattened: Bool { renderingMode != .fullColor }
+
     var body: some View {
         Button(intent: intent) {
             VStack(spacing: 4 * scale) {
@@ -51,10 +91,30 @@ struct WidgetActionTile<ActionIntent: AppIntent>: View {
                     .lineLimit(1)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(fill, in: RoundedRectangle(cornerRadius: Self.cornerRadius * scale))
+            .background { ground }
         }
         .buttonStyle(.plain)
         .accessibilityLabel(title)
+    }
+
+    /// The tile's ground, drawn as its own shape view rather than handed to
+    /// `background(_:in:)`, because that is what lets `widgetAccentable()` be
+    /// scoped to it. The modifier tints everything beneath it, so a tile that
+    /// marked its button would hand the glyph and the word the same tint as the
+    /// ground behind them and leave the reader a blank square.
+    ///
+    /// Marking the shape is harmless in full color, where nothing consults it,
+    /// so the accent-carrying tile claims it in every mode rather than only in
+    /// the one where it matters.
+    @ViewBuilder
+    private var ground: some View {
+        let shape = RoundedRectangle(cornerRadius: Self.cornerRadius * scale)
+            .fill(isFlattened ? WidgetFlattenedFill.tile : fill)
+        if carriesAccent {
+            shape.widgetAccentable()
+        } else {
+            shape
+        }
     }
 
     /// A symbol takes its size from the font and its color from the tile's
@@ -78,7 +138,9 @@ extension WidgetActionTile where ActionIntent == OpenNewChatIntent {
     ///
     /// The accent themes the tile and the avatar replaces its mark, both from
     /// the snapshot, so the tile that starts a chat with the assistant looks
-    /// like that assistant.
+    /// like that assistant. On a themed Home Screen there is no accent to read,
+    /// so this is also the tile that carries the user's own tint, which is the
+    /// same job by the only means that mode leaves.
     static func newChat(accent: WidgetSoftAccent, avatarImage: UIImage? = nil, scale: CGFloat = 1) -> Self {
         WidgetActionTile(
             intent: OpenNewChatIntent(),
@@ -86,6 +148,7 @@ extension WidgetActionTile where ActionIntent == OpenNewChatIntent {
             title: "New Chat",
             fill: accent.fill,
             tint: accent.onFill,
+            carriesAccent: true,
             avatarImage: avatarImage,
             scale: scale
         )
@@ -119,13 +182,19 @@ struct CircleActionButton<ActionIntent: AppIntent>: View {
     let tint: Color
     let diameter: CGFloat
 
+    @Environment(\.widgetRenderingMode) private var renderingMode
+
+    /// Whether the system is drawing the widget in one of its monochrome modes.
+    /// See the note at the top of this file.
+    private var isFlattened: Bool { renderingMode != .fullColor }
+
     var body: some View {
         Button(intent: intent) {
             icon
                 .font(.system(size: diameter * 0.4))
                 .foregroundStyle(tint)
                 .frame(width: diameter, height: diameter)
-                .background(fill, in: Circle())
+                .background(isFlattened ? WidgetFlattenedFill.circle : fill, in: Circle())
         }
         .buttonStyle(.plain)
         .accessibilityLabel(label)
@@ -148,6 +217,12 @@ struct PillActionButton<ActionIntent: AppIntent>: View {
     /// this scales the word beside it.
     var scale: CGFloat = 1
 
+    @Environment(\.widgetRenderingMode) private var renderingMode
+
+    /// Whether the system is drawing the widget in one of its monochrome modes.
+    /// See the note at the top of this file.
+    private var isFlattened: Bool { renderingMode != .fullColor }
+
     var body: some View {
         Button(intent: intent) {
             HStack(spacing: 6 * scale) {
@@ -158,7 +233,7 @@ struct PillActionButton<ActionIntent: AppIntent>: View {
             .foregroundStyle(tint)
             .frame(maxWidth: .infinity)
             .frame(height: height)
-            .background(fill, in: Capsule())
+            .background(isFlattened ? WidgetFlattenedFill.pill : fill, in: Capsule())
         }
         .buttonStyle(.plain)
         .accessibilityLabel(title)
@@ -187,6 +262,12 @@ struct PillActionButton<ActionIntent: AppIntent>: View {
 /// color of whatever it is drawn on, while the dot keeps
 /// ``WidgetTheme/unseenIndicator`` on every surface, which is what makes it
 /// read as an alert rather than as more chrome.
+///
+/// The dot is the mark's one accentable piece, so on a themed Home Screen it
+/// comes out in the user's tint while the bubble around it stays white. Amber
+/// is what the alert reading wants and what the flattening will not grant, but
+/// the dot's real job is to separate from the bubble it rides, and a tint the
+/// bubble does not share does that as well as amber did.
 struct WidgetUnreadMark: View {
     /// Whether the bubble is solid. A card painted in the assistant's own color
     /// wants the filled one; a white card wants the outline its rows draw.
@@ -209,6 +290,7 @@ struct WidgetUnreadMark: View {
                     .fill(WidgetTheme.unseenIndicator)
                     .frame(width: dotDiameter, height: dotDiameter)
                     .offset(x: dotNudge, y: -dotNudge)
+                    .widgetAccentable()
             }
     }
 }

--- a/clients/ios/App/VoiceActivity/Widgets/WidgetAvatarRendering.swift
+++ b/clients/ios/App/VoiceActivity/Widgets/WidgetAvatarRendering.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import UIKit
+import WidgetKit
 
 // Everything a Vellum Home Screen widget needs to draw the user's own
 // assistant rather than a fixed brand mark: the colors derived from its
@@ -135,10 +136,14 @@ struct WidgetAvatarEyes: View {
     /// height. It fills most of the eye and presses against the right edge,
     /// which is the whole trick: small centered dots read as punctuation, a
     /// heavy sideways pair reads as a face caught mid-glance.
-    private static let pupilWidthRatio: CGFloat = 18.0 / 33.0
-    private static let pupilHeightRatio: CGFloat = 21.5 / 33.0
-    private static let pupilOffsetXRatio: CGFloat = 9.0 / 33.0
-    private static let pupilOffsetYRatio: CGFloat = 6.5 / 33.0
+    ///
+    /// Readable to the rest of the file because ``AvatarEyeCutoutShape`` has to
+    /// place the same box, and a hole drawn from a second set of numbers is a
+    /// hole that stops matching the pupil it stands in for.
+    fileprivate static let pupilWidthRatio: CGFloat = 18.0 / 33.0
+    fileprivate static let pupilHeightRatio: CGFloat = 21.5 / 33.0
+    fileprivate static let pupilOffsetXRatio: CGFloat = 9.0 / 33.0
+    fileprivate static let pupilOffsetYRatio: CGFloat = 6.5 / 33.0
 
     /// The height the pair is drawn at where the card has room for it.
     static let defaultEyeHeight: CGFloat = 33
@@ -150,6 +155,13 @@ struct WidgetAvatarEyes: View {
 
     var eyeHeight: CGFloat = WidgetAvatarEyes.defaultEyeHeight
 
+    @Environment(\.widgetRenderingMode) private var renderingMode
+
+    /// Whether the system is drawing the widget in one of its monochrome modes:
+    /// a themed Home Screen, StandBy, or the lock screen. See the note on
+    /// ``cutoutEye``.
+    private var isFlattened: Bool { renderingMode != .fullColor }
+
     var body: some View {
         HStack(spacing: eyeHeight * Self.gapRatio) {
             eye
@@ -158,7 +170,36 @@ struct WidgetAvatarEyes: View {
         .accessibilityHidden(true)
     }
 
+    /// The face is drawn two different ways for one reason: a dark pupil laid
+    /// over a light white is a pair of colors, and a flattened widget has no
+    /// colors to lay over each other.
+    @ViewBuilder
     private var eye: some View {
+        if isFlattened {
+            cutoutEye
+        } else {
+            layeredEye
+        }
+    }
+
+    /// The eye as one figure with the pupil punched out of it.
+    ///
+    /// WidgetKit's flattened modes redraw every view in one of two monochrome
+    /// groups and keep only its alpha, so the sclera and the pupil come out the
+    /// same white and the face loses its gaze entirely. Filling both paths as a
+    /// single even-odd figure gives the pupil back as a hole, and the dark card
+    /// the system substitutes for the widget's own shows through it, which is
+    /// the one dark the extension is still allowed.
+    private var cutoutEye: some View {
+        AvatarEyeCutoutShape()
+            .fill(WidgetTheme.avatarSclera, style: FillStyle(eoFill: true))
+            .frame(width: eyeHeight * Self.widthRatio, height: eyeHeight)
+    }
+
+    /// The eye as the compositor draws it: a real pupil in its real color, on
+    /// its own layer. A hole would be wrong here, since what shows through is
+    /// the assistant's accent rather than anything a pupil should be.
+    private var layeredEye: some View {
         AvatarEyeScleraShape()
             .fill(WidgetTheme.avatarSclera)
             .frame(width: eyeHeight * Self.widthRatio, height: eyeHeight)
@@ -244,6 +285,38 @@ private struct AvatarEyePupilShape: Shape {
     }
 }
 
+/// Both eye paths in one figure: the white, and the pupil inside it, for a
+/// caller that fills them even-odd so the pupil comes out as a hole.
+///
+/// It composes the same two shapes rather than redrawing either, and it places
+/// the pupil from ``WidgetAvatarEyes``' own ratios, so the hole lands exactly
+/// where the layered rendering paints the pupil and the two treatments stay the
+/// same face.
+private struct AvatarEyeCutoutShape: Shape {
+    func path(in rect: CGRect) -> Path {
+        // Every ratio is a share of eye height, which is this rect's height:
+        // the pupil is sized and placed against the eye's own scale, the way
+        // the layered rendering sizes and offsets it.
+        let eyeHeight = rect.height
+        let pupilSize = CGSize(
+            width: eyeHeight * WidgetAvatarEyes.pupilWidthRatio,
+            height: eyeHeight * WidgetAvatarEyes.pupilHeightRatio
+        )
+        // Both shapes trace from their box's own top-left and neither reads its
+        // rect's origin, so the pupil is drawn at zero and moved into place
+        // rather than handed an offset rect it would ignore.
+        let pupil = AvatarEyePupilShape()
+            .path(in: CGRect(origin: .zero, size: pupilSize))
+            .offsetBy(
+                dx: rect.minX + eyeHeight * WidgetAvatarEyes.pupilOffsetXRatio,
+                dy: rect.minY + eyeHeight * WidgetAvatarEyes.pupilOffsetYRatio
+            )
+        var path = AvatarEyeScleraShape().path(in: rect)
+        path.addPath(pupil)
+        return path
+    }
+}
+
 /// The avatar itself, from the raster the snapshot carries.
 ///
 /// Filled rather than fitted, and clipped, because every slot that shows this
@@ -258,9 +331,34 @@ struct WidgetAvatarImageView: View {
     let size: CGFloat
     var cornerRadius: CGFloat? = nil
 
+    /// The photo is told how to survive a flattened widget before anything else
+    /// is done to it.
+    ///
+    /// Left alone, WidgetKit resolves a bitmap in those modes by its luminance
+    /// and hands back a silhouette: a face becomes a blob. Asking for a
+    /// desaturated accent keeps the picture's own shading and only drains its
+    /// color, which is the difference between a mark someone recognizes and one
+    /// they do not. It changes nothing in full color, where the mode is never
+    /// consulted.
+    ///
+    /// The modifier arrived in iOS 18 and this extension still runs on 17,
+    /// where the plain image is the only option and the silhouette is what that
+    /// OS was always going to draw. The availability branch wraps the whole
+    /// chain rather than the image alone, so `scaledToFill` reads its ratio off
+    /// the photo directly instead of through a conditional in between.
+    @ViewBuilder
     var body: some View {
-        Image(uiImage: image)
-            .resizable()
+        if #available(iOS 18.0, *) {
+            shaped(Image(uiImage: image).resizable().widgetAccentedRenderingMode(.accentedDesaturated))
+        } else {
+            shaped(Image(uiImage: image).resizable())
+        }
+    }
+
+    /// Everything the mark's slot asks of the photo: filled to the slot,
+    /// clipped to its corner, and redacted on a locked device.
+    private func shaped(_ photo: some View) -> some View {
+        photo
             .scaledToFill()
             .frame(width: size, height: size)
             .clipShape(RoundedRectangle(cornerRadius: cornerRadius ?? size / 2, style: .continuous))
@@ -434,6 +532,32 @@ func previewAppearances<Content: View>(
     .padding()
 }
 
+/// The same content as a flattened widget draws it, for the previews checking
+/// what a themed Home Screen does to a card.
+///
+/// Only half the story, and deliberately so: setting the environment key runs
+/// the flattened code paths, but the canvas cannot perform the recoloring
+/// WidgetKit does afterwards. What a preview like this proves is that the
+/// translucent fills and the cut-out pupils are drawn at all; how they come out
+/// once the system has tinted them takes a device.
+func previewFlattened<Content: View>(
+    @ViewBuilder _ content: @escaping () -> Content
+) -> some View {
+    content()
+        .environment(\.widgetRenderingMode, .accented)
+        .padding(12)
+        .background(Color.black)
+        .padding()
+}
+
+/// The ground a flattened preview stands its card on, in place of the dark
+/// material WidgetKit substitutes for a widget's own background in these modes.
+///
+/// A preview that kept painting the accent would be checking the fills against
+/// a surface the device is not going to draw, and the pupil holes would show
+/// teal rather than the dark they are cut to reveal.
+let previewFlattenedGround = Color(white: 0.13)
+
 /// A stand-in photo, drawn rather than shipped so the previews cost the
 /// extension no asset. Shared with the widgets built out of the kit.
 func previewAvatarPhoto() -> UIImage {
@@ -520,6 +644,18 @@ func previewEntry(
             title: "Fallback",
             palette: WidgetAvatarPalette(accentHex: nil)
         )
+    }
+}
+
+#Preview("Flattened") {
+    // The eyes are the thing to look at: the pupils have to be holes the ground
+    // shows through rather than a second white laid on the first.
+    previewFlattened {
+        previewWidgetCard(width: 150, height: 150) {
+            WidgetAvatarEyes(eyeHeight: 42)
+        } background: {
+            previewFlattenedGround
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
Adopts WidgetKit's flattened rendering modes (iOS 18 tinted Home Screen, StandBy, lock screen), where the system discards every color a widget sets and redraws views in two monochrome groups keeping only alpha. Today that flattens the action tiles into opaque tinted blocks that swallow their icons and labels, and would flatten the eyes into two blank whites.

- Controls (tile, circle, pill, chip) swap their fills for translucent white (`WidgetFlattenedFill`) when flattened, so alpha carries the shape and the glyphs on top stay legible.
- The New Chat tile's ground and the unseen dots are marked `.widgetAccentable()` (leaf-scoped, never the content subtree), so they deliberately carry the user's tint; documented no-op in full color.
- The eyes render as a single even-odd figure when flattened: the pupil becomes a punched hole and the system's dark card shows through, preserving the sideways glance that two overlaid monochrome layers would erase. Full color keeps the real two-layer pupil.
- Avatar photos get `widgetAccentedRenderingMode(.accentedDesaturated)` under an `#available(iOS 18.0, *)` guard, rendering as a desaturated picture instead of a luminance silhouette; iOS 17 keeps today's behavior.
- Catch Up's hand-rolled row dot gets the same accentable treatment as the shared mark, so the medium widget's unread indicator survives too.

## Verification
- Extension-wide `swiftc -typecheck` passes with and without `-D DEBUG` (run by the implementer, independently re-run, and re-run again after rebasing onto main post-#41318).
- Cutout geometry verified numerically: the hole's bounding box is identical to the layered pupil's `(9.0, 6.5, 18.0, 21.5)` at the default eye height, and every pupil sample lies inside the sclera.
- `#Preview("Flattened")` per surface exercises the flattened code paths; the system's actual recoloring only shows on a device.

## Device QA checklist
- Tinted Home Screen: tiles show icon + label on soft washes; New Chat tile and unread dots pick up the tint; eyes read as eyes (dark pupils via the cutout); avatar photo tiles show a desaturated face, not a blob.
- StandBy and lock-screen contexts get the same flattened treatment.
- Full-color Home Screen: pixel-identical to #41318 (every new branch is gated).
- Known follow-up, deliberately out of scope: primary and secondary text flatten to the same white, so text hierarchy (headers, subtitles) collapses in tinted mode; fixing it means alpha on the secondary token when flattened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)