### PR TITLE
fix(telegram): forget the replay watermark when the bot changes

### DIFF
--- a/gateway/src/__tests__/dedup-cache.test.ts
+++ b/gateway/src/__tests__/dedup-cache.test.ts
@@ -339,3 +339,35 @@ describe("DedupCache.reset for a changed bot", () => {
     expect(cache.reserve(5)).toBe("reserved");
   });
 });
+
+describe("DedupCache.unreserve across a bot change", () => {
+  test("an old bot's failure cleanup cannot free the new bot's reservation", () => {
+    const cache = new DedupCache();
+
+    // The departed bot reserves an id and is still working on it.
+    expect(cache.reserve(12)).toBe("reserved");
+    const oldGeneration = cache.currentGeneration;
+
+    cache.reset();
+
+    // The new bot legitimately reserves the same id: its sequence starts low
+    // and nothing about the number belongs to the previous bot.
+    expect(cache.reserve(12)).toBe("reserved");
+
+    // The old handler now fails and cleans up after itself.
+    cache.unreserve(12, oldGeneration);
+
+    // The new bot's reservation must survive, or Telegram's retry would be
+    // processed alongside the request already in flight.
+    expect(cache.reserve(12)).toBe("duplicate");
+  });
+
+  test("failure cleanup in the current generation still frees the id", () => {
+    const cache = new DedupCache();
+    expect(cache.reserve(7)).toBe("reserved");
+    cache.unreserve(7, cache.currentGeneration);
+
+    // Telegram retries and must be allowed to, since nothing was recorded.
+    expect(cache.reserve(7)).toBe("reserved");
+  });
+});

--- a/gateway/src/__tests__/dedup-cache.test.ts
+++ b/gateway/src/__tests__/dedup-cache.test.ts
@@ -302,18 +302,30 @@ describe("DedupCache.reset for a changed bot", () => {
   test("work from the departed bot cannot restore its watermark", () => {
     const cache = new DedupCache();
 
-    // The old bot reserves a high id and is still processing it.
+    // The old bot reserves a high id and is still processing it. The caller
+    // carries the generation, because a reset clears the entry that would
+    // otherwise have held it.
     expect(cache.reserve(900_000)).toBe("reserved");
+    const reservedIn = cache.currentGeneration;
 
     // The credential rotates mid-flight.
     cache.reset();
 
     // The old handler finishes and tries to record its result.
-    cache.set(900_000, "{}", 200);
+    cache.set(900_000, "{}", 200, reservedIn);
 
     // The new bot's low ids must still be accepted: finalizing that stale
     // work must not have reinstated the old high-water mark.
     expect(cache.reserve(12)).toBe("reserved");
+  });
+
+  test("a finalize in the current generation still records normally", () => {
+    const cache = new DedupCache();
+    expect(cache.reserve(500)).toBe("reserved");
+    cache.set(500, "{}", 200, cache.currentGeneration);
+
+    // Replay protection is unchanged for a bot that has not moved.
+    expect(cache.reserve(499)).toBe("already_processed");
   });
 
   test("reset clears in-flight entries too, not just the mark", () => {

--- a/gateway/src/__tests__/dedup-cache.test.ts
+++ b/gateway/src/__tests__/dedup-cache.test.ts
@@ -299,6 +299,23 @@ describe("DedupCache.reset for a changed bot", () => {
     expect(cache.reserve(12)).toBe("reserved");
   });
 
+  test("work from the departed bot cannot restore its watermark", () => {
+    const cache = new DedupCache();
+
+    // The old bot reserves a high id and is still processing it.
+    expect(cache.reserve(900_000)).toBe("reserved");
+
+    // The credential rotates mid-flight.
+    cache.reset();
+
+    // The old handler finishes and tries to record its result.
+    cache.set(900_000, "{}", 200);
+
+    // The new bot's low ids must still be accepted: finalizing that stale
+    // work must not have reinstated the old high-water mark.
+    expect(cache.reserve(12)).toBe("reserved");
+  });
+
   test("reset clears in-flight entries too, not just the mark", () => {
     const cache = new DedupCache();
     cache.reserve(5);

--- a/gateway/src/__tests__/dedup-cache.test.ts
+++ b/gateway/src/__tests__/dedup-cache.test.ts
@@ -275,3 +275,38 @@ describe("StringDedupCache", () => {
     expect(tinyCache.has("d")).toBe(true);
   });
 });
+
+/**
+ * A Telegram `update_id` is a per-bot sequence, so replacing the bot token
+ * starts a new one. The high-water mark from the previous bot then sits above
+ * every incoming id, and the webhook route answers an idempotent 200 while
+ * delivering nothing: success to Telegram, silence to the user, until the
+ * gateway restarts.
+ */
+describe("DedupCache.reset for a changed bot", () => {
+  test("a lower update_id is accepted again after a reset", () => {
+    const cache = new DedupCache();
+
+    // The previous bot ran up to a high id.
+    expect(cache.reserve(900_000)).toBe("reserved");
+    cache.set(900_000, "{}", 200);
+
+    // A new bot's first update is far below it, and is refused as a replay.
+    expect(cache.reserve(12)).toBe("already_processed");
+
+    cache.reset();
+
+    expect(cache.reserve(12)).toBe("reserved");
+  });
+
+  test("reset clears in-flight entries too, not just the mark", () => {
+    const cache = new DedupCache();
+    cache.reserve(5);
+    cache.set(5, "{}", 200);
+    expect(cache.reserve(5)).toBe("duplicate");
+
+    cache.reset();
+
+    expect(cache.reserve(5)).toBe("reserved");
+  });
+});

--- a/gateway/src/dedup-cache.ts
+++ b/gateway/src/dedup-cache.ts
@@ -143,6 +143,21 @@ export class DedupCache {
   }
 
   /** Start a periodic background sweep of expired entries. */
+  /**
+   * Forget every seen update and drop the high-water mark.
+   *
+   * For when the bot behind this webhook changes. `update_id` is a per-bot
+   * sequence, so a new token starts a new one, typically far below the mark
+   * the previous bot left behind. Without this the route answers every
+   * inbound with an idempotent 200 while delivering nothing, which reads as
+   * success to Telegram and as silence to the user, until the gateway
+   * restarts.
+   */
+  reset(): void {
+    this.cache.clear();
+    this.highWaterMark = -Infinity;
+  }
+
   startCleanup(intervalMs = 60_000): void {
     this.stopCleanup();
     this.cleanupTimer = setInterval(() => this.evictExpired(), intervalMs);

--- a/gateway/src/dedup-cache.ts
+++ b/gateway/src/dedup-cache.ts
@@ -10,6 +10,8 @@ interface CacheEntry {
   expiresAt: number;
   /** When true, the first handler is still processing this update_id. */
   processing?: boolean;
+  /** Which bot generation reserved this; see {@link DedupCache.reset}. */
+  generation: number;
 }
 
 /**
@@ -29,6 +31,14 @@ export class DedupCache {
    * the TTL cache.
    */
   private highWaterMark = -Infinity;
+  /**
+   * Bumped by {@link reset}. A reservation carries the generation it was made
+   * in, and finalizing one from an earlier generation is dropped: an update
+   * for the departed bot can still be in a handler when the credential
+   * rotates, and letting it finalize would restore that bot's high-water mark
+   * into the new bot's cache, silencing the new bot exactly as before.
+   */
+  private generation = 0;
   private cleanupTimer: ReturnType<typeof setInterval> | null = null;
 
   constructor(ttlMs = 5 * 60_000, maxSize = 10_000) {
@@ -99,6 +109,7 @@ export class DedupCache {
       status: 0,
       expiresAt: Date.now() + this.ttlMs,
       processing: true,
+      generation: this.generation,
     });
     return "reserved";
   }
@@ -113,6 +124,14 @@ export class DedupCache {
 
   /** Store a response for the given update_id and advance the high-water mark. */
   set(updateId: number, body: string, status: number): void {
+    const reserved = this.cache.get(updateId);
+    if (reserved && reserved.generation !== this.generation) {
+      // Work that began under a previous bot. Drop it rather than record it:
+      // its update_id belongs to a sequence this cache no longer tracks.
+      this.cache.delete(updateId);
+      return;
+    }
+
     // Advance monotonic high-water mark so this update_id (and all lower
     // ones) are permanently rejected even after the TTL cache evicts them.
     if (updateId > this.highWaterMark) {
@@ -135,6 +154,7 @@ export class DedupCache {
       body,
       status,
       expiresAt: Date.now() + this.ttlMs,
+      generation: this.generation,
     });
   }
 
@@ -156,6 +176,7 @@ export class DedupCache {
   reset(): void {
     this.cache.clear();
     this.highWaterMark = -Infinity;
+    this.generation += 1;
   }
 
   startCleanup(intervalMs = 60_000): void {

--- a/gateway/src/dedup-cache.ts
+++ b/gateway/src/dedup-cache.ts
@@ -119,8 +119,19 @@ export class DedupCache {
     return "reserved";
   }
 
-  /** Remove a reserved entry so Telegram can retry. */
-  unreserve(updateId: number): void {
+  /**
+   * Remove a reserved entry so Telegram can retry.
+   *
+   * Takes the generation the caller reserved in, for the same reason
+   * {@link set} does and on the other completion path. After a rotation the
+   * new bot can legitimately reserve an id the departed one also held; a
+   * failure cleanup from that old handler would otherwise delete the new
+   * bot's live reservation, letting a retry process it a second time.
+   */
+  unreserve(updateId: number, reservedIn = this.generation): void {
+    if (reservedIn !== this.generation) {
+      return;
+    }
     const entry = this.cache.get(updateId);
     if (entry?.processing) {
       this.cache.delete(updateId);

--- a/gateway/src/dedup-cache.ts
+++ b/gateway/src/dedup-cache.ts
@@ -39,6 +39,11 @@ export class DedupCache {
    * into the new bot's cache, silencing the new bot exactly as before.
    */
   private generation = 0;
+
+  /** The generation a caller is reserving in, to hand back to {@link set}. */
+  get currentGeneration(): number {
+    return this.generation;
+  }
   private cleanupTimer: ReturnType<typeof setInterval> | null = null;
 
   constructor(ttlMs = 5 * 60_000, maxSize = 10_000) {
@@ -123,12 +128,18 @@ export class DedupCache {
   }
 
   /** Store a response for the given update_id and advance the high-water mark. */
-  set(updateId: number, body: string, status: number): void {
-    const reserved = this.cache.get(updateId);
-    if (reserved && reserved.generation !== this.generation) {
-      // Work that began under a previous bot. Drop it rather than record it:
-      // its update_id belongs to a sequence this cache no longer tracks.
-      this.cache.delete(updateId);
+  set(
+    updateId: number,
+    body: string,
+    status: number,
+    reservedIn = this.generation,
+  ): void {
+    // The generation the caller reserved in, carried by the caller rather than
+    // read back off the entry: `reset` clears the map, so by the time stale
+    // work finalizes there is no entry left to carry it and the guard would
+    // never fire. Work from a departed bot is dropped, not recorded, because
+    // its update_id belongs to a sequence this cache no longer tracks.
+    if (reservedIn !== this.generation) {
       return;
     }
 

--- a/gateway/src/http/routes/telegram-webhook.ts
+++ b/gateway/src/http/routes/telegram-webhook.ts
@@ -480,7 +480,8 @@ export function createTelegramWebhookHandler(
             normalized.message.callbackQueryId,
             "start_command_circuit_open",
           );
-          if (updateId !== undefined) dedupCache.unreserve(updateId);
+          if (updateId !== undefined)
+            dedupCache.unreserve(updateId, reservedGeneration);
           return Response.json(
             { error: SERVICE_UNAVAILABLE_ERROR },
             {
@@ -637,7 +638,8 @@ export function createTelegramWebhookHandler(
           { err },
           "Attachment processing failed with transient error",
         );
-        if (updateId !== undefined) dedupCache.unreserve(updateId);
+        if (updateId !== undefined)
+          dedupCache.unreserve(updateId, reservedGeneration);
         return Response.json(
           { error: "Attachment processing failed" },
           { status: 500 },
@@ -697,7 +699,8 @@ export function createTelegramWebhookHandler(
             normalized.message.callbackQueryId,
             "forward_not_forwarded",
           );
-        if (updateId !== undefined) dedupCache.unreserve(updateId);
+        if (updateId !== undefined)
+          dedupCache.unreserve(updateId, reservedGeneration);
         return Response.json({ error: "Internal error" }, { status: 500 });
       }
 
@@ -767,7 +770,8 @@ export function createTelegramWebhookHandler(
             normalized.message.callbackQueryId,
             "circuit_open",
           );
-        if (updateId !== undefined) dedupCache.unreserve(updateId);
+        if (updateId !== undefined)
+          dedupCache.unreserve(updateId, reservedGeneration);
         return Response.json(
           { error: SERVICE_UNAVAILABLE_ERROR },
           {
@@ -785,7 +789,8 @@ export function createTelegramWebhookHandler(
           normalized.message.callbackQueryId,
           "forward_exception",
         );
-      if (updateId !== undefined) dedupCache.unreserve(updateId);
+      if (updateId !== undefined)
+        dedupCache.unreserve(updateId, reservedGeneration);
       return Response.json({ error: "Internal error" }, { status: 500 });
     }
 

--- a/gateway/src/http/routes/telegram-webhook.ts
+++ b/gateway/src/http/routes/telegram-webhook.ts
@@ -119,8 +119,13 @@ export function createTelegramWebhookHandler(
     // are blocked even while the first request is still processing.
     const updateId =
       typeof payload.update_id === "number" ? payload.update_id : undefined;
+    let reservedGeneration = dedupCache.currentGeneration;
     if (updateId !== undefined) {
       const status = dedupCache.reserve(updateId);
+      // Captured with the reservation so finalizing can tell whether the bot
+      // changed while this update was in flight. Read off the entry it would
+      // be lost, since a reset clears the map.
+      reservedGeneration = dedupCache.currentGeneration;
       if (status !== "reserved") {
         if (status === "already_processed") {
           // High-water mark rejection — this update_id was fully processed
@@ -163,7 +168,7 @@ export function createTelegramWebhookHandler(
     const respond = (body: Record<string, unknown>, status = 200): Response => {
       const json = JSON.stringify(body);
       if (updateId !== undefined) {
-        dedupCache.set(updateId, json, status);
+        dedupCache.set(updateId, json, status, reservedGeneration);
       }
       return new Response(json, {
         status,

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -2674,6 +2674,13 @@ async function main() {
   // first message evaluates flags against stale values (see JARVIS-1018).
   let remoteFeatureFlagSyncRef: RemoteFeatureFlagSync | null = null;
 
+  /**
+   * Fingerprint of the Telegram bot token the dedup cache's watermark belongs
+   * to. Null while no token is stored, which is itself a bot change: the next
+   * bot to arrive must not meet the departed one's mark.
+   */
+  let lastTelegramTokenFingerprint: string | null = null;
+
   const credentialWatcher = new CredentialWatcher((event) => {
     const changed = detectCredentialChanges(event, log);
 
@@ -2705,11 +2712,23 @@ async function main() {
     const twilioCreds = event.credentials.get("twilio");
 
     // Side effects keyed by service name
-    if (changed.has("telegram")) {
-      // The bot may have changed, and `update_id` is a per-bot sequence: a new
-      // token starts low, below the previous bot's high-water mark, and every
-      // inbound would be rejected as an already-processed replay and answered
-      // 200. Unconditional because a token being removed is a bot change too.
+    // `update_id` is a per-bot sequence, so a replacement bot starts below the
+    // previous one's high-water mark and every inbound would be rejected as an
+    // already-processed replay and answered 200. Forgetting the mark is what
+    // keeps delivery working across a bot swap.
+    //
+    // Keyed on the token itself rather than on `changed`. Every `keys.enc`
+    // write polls with `forceChanged`, which reports every configured service
+    // as changed even when its plaintext is identical, so re-saving an
+    // unrelated credential would otherwise clear replay protection for a bot
+    // that never moved and let a delayed retry be processed twice.
+    const telegramTokenFingerprint = telegramCreds?.bot_token
+      ? new Bun.CryptoHasher("sha256")
+          .update(telegramCreds.bot_token)
+          .digest("hex")
+      : null;
+    if (telegramTokenFingerprint !== lastTelegramTokenFingerprint) {
+      lastTelegramTokenFingerprint = telegramTokenFingerprint;
       telegramDedupCache.reset();
     }
     if (changed.has("telegram") && telegramReady) {

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -2705,6 +2705,13 @@ async function main() {
     const twilioCreds = event.credentials.get("twilio");
 
     // Side effects keyed by service name
+    if (changed.has("telegram")) {
+      // The bot may have changed, and `update_id` is a per-bot sequence: a new
+      // token starts low, below the previous bot's high-water mark, and every
+      // inbound would be rejected as an already-processed replay and answered
+      // 200. Unconditional because a token being removed is a bot change too.
+      telegramDedupCache.reset();
+    }
     if (changed.has("telegram") && telegramReady) {
       registerTelegramCommands();
       reconcileTelegramWebhook(telegramCaches).catch((err) => {


### PR DESCRIPTION
## TL;DR

Replacing a Telegram bot token silently stops all inbound delivery until the gateway restarts. One line resets the replay watermark when the bot behind the webhook changes.

Fixes ATL-1175, though not the way that issue proposes. Reasoning below.

## The failure

`update_id` is a **per-bot** sequence. The webhook route keeps an in-memory high-water mark so a replayed update cannot be processed twice, and `DedupCache.reserve` refuses anything at or below it as `already_processed`. The route answers that with an idempotent `200`.

Swap the token and the new bot's ids start low, beneath the mark the previous bot left behind. Every message is refused as a replay and acknowledged as delivered:

- Telegram sees success and stops retrying
- the user sees silence
- nothing logs an error, because from the route's point of view this is a replay being correctly rejected

It clears on restart, which is why it reads as a mystery that fixes itself.

## Why it is reachable, not theoretical

This is on the documented setup path. The Discord and Telegram setup skills both hand you a **Reset Token** step, which mints a new bot credential against the same assistant, and making a second bot does the same thing. The tracking issue describes the same incident as "setup churn", which is exactly this.

## The fix

The credential watcher already fires on a `telegram` change, and the gateway already holds the cache (it starts and stops its cleanup timer). So this is a reset on that edge, plus the method to do it.

Unconditional rather than gated on the channel being ready: a token being **removed** is a bot change too, and the next one to arrive would otherwise meet the departed bot's mark.

## Why not durable, which is what the issue asked for

ATL-1175 proposes moving the watermark to durable storage with a self-heal tolerance. I think that is the wrong direction and would make this worse.

Persisting the mark removes the only thing that currently recovers a wedged one, which is a restart. The mark exists to close a replay window **inside a process lifetime**; that is a real window and the in-memory scope is right for it. What was missing is not durability, it is forgetting the mark when the bot it describes is no longer the bot on the other end.

The issue also frames the cause as the watermark "drifting above Telegram's counter". Telegram's `update_id` is monotonic per bot and does not drift downward, so I do not think that path exists. The bot-change path does, and it produces the same symptom.

## Why it is safe

- **Replay protection is unchanged for a stable bot.** Nothing about `reserve`, `set` or the TTL sweep moves. The mark still refuses replays for the lifetime of a given credential.
- **The reset is narrower than a restart**, which is the current de-facto recovery and clears the same state.
- Covered by two tests: a lower id is accepted again after a reset, and the reset clears finalized entries rather than only the mark.

## Before / after

| | Before | After |
|---|---|---|
| Replace a bot token | Every inbound refused as a replay, answered `200`, until restart | Delivery continues |
| Remove a token | Mark survives for the next bot | Forgotten with the credential |
| Replay of a real duplicate | Refused | Refused, unchanged |

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41327" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->