### PR TITLE
fix(web): Android keyboard squishes the app into a header-height strip

### DIFF
--- a/clients/web/src/hooks/use-visible-viewport.test.ts
+++ b/clients/web/src/hooks/use-visible-viewport.test.ts
@@ -530,6 +530,22 @@ describe("window resizes", () => {
     expect(readVisibleViewport()?.keyboardHeight).toBe(0);
   });
 
+  test("falls back to the measurement on Android before any announcement", () => {
+    // GIVEN the Android shell with a keyboard raised before the plugin
+    // listeners could announce it
+    stubIsNativeMobile = true;
+    stubIsNativeAndroid = true;
+    renderHook(() => useVisibleViewport());
+
+    // WHEN the frame shrinks with nothing announced
+    resizeWindowTo(REFERENCE_HEIGHT - KEYBOARD_HEIGHT);
+
+    // THEN the reference delta still reports the keyboard
+    const viewport = readVisibleViewport();
+    expect(viewport?.height).toBe(REFERENCE_HEIGHT - KEYBOARD_HEIGHT);
+    expect(viewport?.keyboardHeight).toBe(KEYBOARD_HEIGHT);
+  });
+
   test("rebases with the composer focused when no keyboard was announced", () => {
     // GIVEN a composer holding focus with nothing announced, which is what a
     // hardware keyboard on a tablet looks like: focus with no soft keyboard

--- a/clients/web/src/hooks/use-visible-viewport.test.ts
+++ b/clients/web/src/hooks/use-visible-viewport.test.ts
@@ -50,8 +50,10 @@ mock.module("@/runtime/native-keyboard", () => ({
 // there is a shrink ambiguous, so only there does the reference wait for an
 // announcement before trusting that no keyboard is up.
 let stubIsNativeMobile = false;
+let stubIsNativeAndroid = false;
 mock.module("@/runtime/platform-detection", () => ({
   isNativeMobile: () => stubIsNativeMobile,
+  isNativeAndroid: () => stubIsNativeAndroid,
 }));
 
 const { holdVisibleViewport, readVisibleViewport, useVisibleViewport } =
@@ -110,6 +112,7 @@ function announce(keyboardHeight: number, visible = keyboardHeight > 0): void {
 
 beforeEach(() => {
   stubIsNativeMobile = false;
+  stubIsNativeAndroid = false;
   Object.defineProperty(window, "matchMedia", {
     configurable: true,
     writable: true,
@@ -499,6 +502,32 @@ describe("window resizes", () => {
     // THEN the keyboard-free reference survives it, so the shell keeps sizing
     // for the keyboard the user is looking at
     expect(readVisibleViewport()?.keyboardHeight).toBe(KEYBOARD_HEIGHT);
+  });
+
+  test("sizes the Android shell to its frame when the resize precedes the announcement", () => {
+    // GIVEN the Android shell, whose `adjustResize` frame shrink lands before
+    // the plugin announces the keyboard, after an earlier keyboard session
+    stubIsNativeMobile = true;
+    stubIsNativeAndroid = true;
+    renderHook(() => useVisibleViewport());
+    announce(KEYBOARD_HEIGHT);
+    announce(0, false);
+
+    // WHEN the keyboard comes up again: the frame shrinks first, then the
+    // announcement follows
+    resizeWindowTo(REFERENCE_HEIGHT - KEYBOARD_HEIGHT);
+    announce(KEYBOARD_HEIGHT);
+
+    // THEN the shell is sized to the frame that already fits above the
+    // keyboard, not to that frame minus the keyboard a second time
+    const viewport = readVisibleViewport();
+    expect(viewport?.height).toBe(REFERENCE_HEIGHT - KEYBOARD_HEIGHT);
+    expect(viewport?.keyboardHeight).toBe(KEYBOARD_HEIGHT);
+
+    // AND a dismissal reads as no keyboard once the frame grows back
+    announce(0, false);
+    resizeWindowTo(REFERENCE_HEIGHT);
+    expect(readVisibleViewport()?.keyboardHeight).toBe(0);
   });
 
   test("rebases with the composer focused when no keyboard was announced", () => {

--- a/clients/web/src/hooks/use-visible-viewport.ts
+++ b/clients/web/src/hooks/use-visible-viewport.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 
 import { subscribeNativeKeyboardHeight } from "@/runtime/native-keyboard";
-import { isNativeMobile } from "@/runtime/platform-detection";
+import { isNativeAndroid, isNativeMobile } from "@/runtime/platform-detection";
 
 /**
  * Threshold (in px) below which an `innerHeight − visualViewport.height` delta
@@ -299,6 +299,23 @@ export function readVisibleViewport(): VisibleViewport | null {
   // so they cannot outlive the orientation they were taken in.
   if (heldViewport) {
     return heldViewport;
+  }
+
+  // The Android shell (`adjustResize`) shrinks the web view before the plugin
+  // announces the keyboard: `keyboardWillShow` fires from the insets animation
+  // `onStart`, after layout. The `window` resize therefore reaches the rebase
+  // above with nothing announced yet and moves the reference onto the shrunk
+  // frame, and the announcement that follows then subtracts the keyboard from
+  // that frame a second time, leaving a strip the height of the header. The
+  // frame already fits above the keyboard there, so the measurement is the
+  // height and the announcement is the only thing that knows a keyboard is up.
+  if (isNativeAndroid()) {
+    return {
+      height: vv.height,
+      keyboardHeight: nativeKeyboardVisible ? anticipatedKeyboardHeight : 0,
+      offsetTop: 0,
+      offsetLeft: 0,
+    };
   }
 
   // Update the reference whenever the viewport grows (keyboard dismissed,

--- a/clients/web/src/hooks/use-visible-viewport.ts
+++ b/clients/web/src/hooks/use-visible-viewport.ts
@@ -308,14 +308,18 @@ export function readVisibleViewport(): VisibleViewport | null {
   // frame, and the announcement that follows then subtracts the keyboard from
   // that frame a second time, leaving a strip the height of the header. The
   // frame already fits above the keyboard there, so the measurement is the
-  // height and the announcement is the only thing that knows a keyboard is up.
+  // height and the announcement says whether a keyboard is up. Until one has
+  // arrived (a keyboard raised during listener registration, or a shell built
+  // before the plugin) the reference delta still stands in: the rebase above
+  // leaves the reference alone on a native shell that has heard nothing.
   if (isNativeAndroid()) {
-    return {
-      height: vv.height,
-      keyboardHeight: nativeKeyboardVisible ? anticipatedKeyboardHeight : 0,
-      offsetTop: 0,
-      offsetLeft: 0,
-    };
+    let keyboardHeight = 0;
+    if (nativeKeyboardVisible) {
+      keyboardHeight = anticipatedKeyboardHeight;
+    } else if (!sawKeyboardAnnouncement) {
+      keyboardHeight = Math.max(0, referenceInnerHeight - vv.height);
+    }
+    return { height: vv.height, keyboardHeight, offsetTop: 0, offsetLeft: 0 };
   }
 
   // Update the reference whenever the viewport grows (keyboard dismissed,


### PR DESCRIPTION
## Summary
- On Android, `@capacitor/keyboard` fires `keyboardWillShow` from the insets animation `onStart`, i.e. after `adjustResize` has already shrunk the WebView. The `window` resize reached `useVisibleViewport` with nothing announced yet, so `rebaseReferenceForWindowResize` moved the keyboard-free reference onto the shrunk frame; the announcement then subtracted the keyboard from that frame a second time, leaving a strip the height of the header (only after the first keyboard session, which the `sawKeyboardAnnouncement` guard protects).
- `readVisibleViewport` now short-circuits on the Android shell: the frame already fits above the keyboard, so `visualViewport.height` is the height and the plugin announcement is the keyboard height / open state. iOS and browser paths are untouched.
- Adds a regression test replaying the Android ordering (resize first, announcement second).

## Original prompt
On Android, tapping the composer input in a new conversation squishes the whole app into a ~10px strip (keyboard resize bug). Find and fix the keyboard/viewport resize handling.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41330" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->