### PR TITLE
chore(web): remove the dead isPluginChannelKey helper

### DIFF
--- a/clients/web/src/types/channel-types.ts
+++ b/clients/web/src/types/channel-types.ts
@@ -55,8 +55,8 @@ export interface AssistantChannelState {
  * Kept apart from {@link AssistantChannelState} rather than widened into it:
  * the built-in adapters carry a readiness snapshot, a credential form, a
  * disconnect path and a trust floor, and a plugin channel has none of those
- * here. Its id is namespaced (`plugin:<name>`), so the two sets cannot
- * collide in a selection key.
+ * here. Its {@link PluginChannelSummary.key} is namespaced, so the two sets
+ * cannot collide in a selection key.
  */
 export interface PluginChannelSummary {
   /** Directory name of the declaring plugin. */
@@ -84,7 +84,3 @@ export function pluginChannelKey(plugin: string): string {
 
 /** Key of whichever row the Channels rail has selected. */
 export type ChannelRowKey = SetupChannelId | string;
-
-export function isPluginChannelKey(key: string): boolean {
-  return key.startsWith("plugin:");
-}


### PR DESCRIPTION
## TL;DR

`isPluginChannelKey` in `clients/web/src/types/channel-types.ts` had no callers and tested a prefix that no longer exists. Removed it, plus the one stale sentence that described plugin channel keys with the old prefix. No behavior change: a function nothing imports cannot have any.

Investigation for LUM-3460.

## What I verified

The ticket asked me to confirm the helper is dead before removing it, and to stop and report if anything actually needs a predicate. Both checks came back clean.

**It has no callers.** `isPluginChannelKey` appears exactly once in the repo, at its own definition. Not in `src/`, not in tests, not in docs, and `src/types/channel-types.ts` is imported directly by name everywhere (no barrel re-export that could hide a consumer). It never had a caller: it arrived in #40352 already unused, and `git log -S` across all refs shows that single commit.

**Nothing in flight uses it.** Checked every open PR, and specifically #41312, the other open PR touching this surface. Definition only, no callers there either.

**It was already broken.** #40444 renamed plugin channel keys from `plugin:<name>` to `plugins-<name>` and updated `PLUGIN_CHANNEL_KEY_PREFIX`, but not this helper, which still tested `key.startsWith("plugin:")`. Had anything called it, it would have returned false for every real key.

**Nothing needs the predicate.** This is the part worth stating, since a dead helper can still mark a real gap. It does not here. The rail never asks "does this key look like a plugin's". Plugin channels arrive as their own array from `usePluginChannels`, render through their own `PluginRow`, and the selected one is resolved by membership in `assistant-channels-list.tsx`:

```ts
const selectedPlugin = pluginChannels.find((c) => c.key === selectedAdapter);
```

Membership is strictly better than a prefix test here, and the code says so: it also handles a plugin uninstalled while its channel is selected, where the lookup falls through to the adapters rather than leaving the panel empty. A string test would still claim the key was a plugin's after the plugin was gone.

The four behaviors the ticket asked about are all prefix-free, so removal cannot reach them: **list** maps the `pluginChannels` array, **select** passes `channel.key` straight through, **deep-link** reads the `channelId` route param verbatim in `use-channel-route-selection.ts`, and **open** is the membership lookup above.

## What changes for the user

| | Before | After |
|---|---|---|
| Listing plugin channels in the rail | Works | Unchanged |
| Selecting one | Works | Unchanged |
| Deep-linking to `/assistant/channels/plugins-<name>` | Works | Unchanged |
| Opening its panel | Works | Unchanged |
| Uninstalling a plugin while its channel is selected | Falls back to the adapters | Unchanged |

Nothing. The helper was unreachable, so no user-facing path ran through it.

## Why this is safe

Removing an export that nothing imports is checked by the compiler: a missed consumer is a build failure, not a silent runtime break. `tsc --noEmit` passes clean across the web client, as do eslint and the pinned prettier.

## The docstring fix

`PluginChannelSummary`'s docstring still read "Its id is namespaced (`plugin:<name>`)", stale twice over: wrong prefix, and it called the namespaced value the "id" when the namespaced field is `key` (`plugin` holds the bare directory name).

Rather than correct the literal, I removed it. Spelling the prefix out in both `PLUGIN_CHANNEL_KEY_PREFIX` and the prose is precisely what let the two drift apart at the rename, and correcting the copy in place would leave the same trap set for the next rename. The docstring now points at the `key` field, whose own docstring already explains the namespacing.

## Why the surrounding structure stays as it is

The rail keeps two lists: built-ins from the local `SETUP_CHANNEL_IDS` union plus readiness, and plugin channels read from `/v1/channels/available`. It would be easy to read that as duplication and to "fix" it by rendering the availability route directly. That would be wrong, and the reason is worth writing down so the next reader does not try it.

The local union is a shipping gate. A channel stays invisible until someone deliberately adds its id, and the compiler then names every other thing that has to be filled in before it can appear: presentation metadata, a readiness probe, an admission-policy entry, a setup wizard. Rendering the availability route directly would delete that gate and surface a channel the moment the daemon knew about it, whether or not this client could actually set it up or report on it honestly.

The plugin list cannot work that way for the opposite reason: a plugin's channel id is workspace state, so it can never be a member of a literal union, and it needs no per-channel client implementation because it renders one generic panel.

So the two lists answer two genuinely different questions, and the namespaced key exists to keep their key spaces apart. `isPluginChannelKey` was a leftover from that apparatus, not evidence against it.

## Testing

Typecheck, lint and format pass. The rail and panel suites (`channel-adapter-list.test.tsx`, `plugin-channel-panel.test.tsx`) cover the list/select/open paths and neither references the helper; I could not run them locally under the standing no-local-tests rule, so CI is the signal.
