### PR TITLE
fix(channels): declare each channel's credential form instead of inferring it

### DIFF
--- a/clients/web/src/domains/channels/channel-meta.test.ts
+++ b/clients/web/src/domains/channels/channel-meta.test.ts
@@ -43,9 +43,7 @@ describe("the setup drawer derives from the same fact as the tab", () => {
     const withForm = SETUP_CHANNEL_IDS.filter(
       (id) => CHANNEL_META[id].credentialForm !== undefined,
     );
-    expect([...CHANNEL_SETUP_TYPES] as string[]).toEqual([
-      ...withForm,
-    ] as string[]);
+    expect([...CHANNEL_SETUP_TYPES]).toEqual(withForm);
   });
 
   test("every channel it accepts has a renderer in the drawer", () => {

--- a/clients/web/src/domains/channels/channel-meta.test.ts
+++ b/clients/web/src/domains/channels/channel-meta.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+
+import { CHANNEL_META } from "@/domains/channels/channel-meta";
+import { CHANNEL_SETUP_TYPES } from "@/stores/viewer-store";
+import { SETUP_CHANNEL_IDS } from "@/types/channel-types";
+
+/**
+ * Both capabilities are declared per channel, so a channel that has neither
+ * is offered neither. A branch cannot express that, and its last arm becomes
+ * the answer for anything it does not name.
+ */
+describe("channel capabilities are declared, not inferred", () => {
+  test("each channel declares the form it is set up through", () => {
+    // The invariant is that the field is set only where a form exists, so a
+    // channel added later inherits nothing rather than the last arm of a
+    // branch.
+    expect(CHANNEL_META.slack.credentialForm).toBe("slack-wizard");
+    expect(CHANNEL_META.telegram.credentialForm).toBe("telegram-token");
+    expect(CHANNEL_META.phone.credentialForm).toBe("twilio-credentials");
+  });
+
+  test("only the phone channel can reach the Twilio form", () => {
+    const twilio = SETUP_CHANNEL_IDS.filter(
+      (id) => CHANNEL_META[id].credentialForm === "twilio-credentials",
+    );
+    expect(twilio).toEqual(["phone"]);
+  });
+
+  test("a channel that can be disconnected declares the copy for it", () => {
+    for (const id of SETUP_CHANNEL_IDS) {
+      expect(CHANNEL_META[id].disconnectMessageKey).toBeDefined();
+    }
+  });
+});
+
+/**
+ * The drawer and the Channels tab render the same wizards and differ only in
+ * where they are mounted, so which channels have a form is one fact and the
+ * drawer's set derives from it.
+ */
+describe("the setup drawer derives from the same fact as the tab", () => {
+  test("it accepts exactly the channels that declare a form", () => {
+    const withForm = SETUP_CHANNEL_IDS.filter(
+      (id) => CHANNEL_META[id].credentialForm !== undefined,
+    );
+    expect([...CHANNEL_SETUP_TYPES] as string[]).toEqual([
+      ...withForm,
+    ] as string[]);
+  });
+
+  test("every channel it accepts has a renderer in the drawer", () => {
+    // The drawer is a credential form, so accepting a channel it cannot draw
+    // would show another channel's connected copy over an empty body.
+    // `CHANNEL_BRAND_LABEL` is an exhaustive record over this set, so a
+    // channel reaching the drawer without a renderer fails to compile rather
+    // than rendering another channel's copy. This pins the set it is over.
+    for (const id of CHANNEL_SETUP_TYPES) {
+      expect(CHANNEL_META[id].credentialForm).toBeDefined();
+    }
+  });
+});

--- a/clients/web/src/domains/channels/channel-meta.ts
+++ b/clients/web/src/domains/channels/channel-meta.ts
@@ -1,5 +1,11 @@
 import type { SetupChannelId } from "@/types/channel-types";
 
+/** A credential form a channel can declare it is set up through. */
+export type ChannelCredentialForm =
+  | "slack-wizard"
+  | "telegram-token"
+  | "twilio-credentials";
+
 /**
  * Per-adapter presentation metadata for the Channels tab.
  *
@@ -22,16 +28,18 @@ interface ChannelMeta {
   /**
    * Catalog key for the disconnect dialog's body.
    *
-   * Optional, and its absence is what says a channel cannot be disconnected
-   * from here: there is no route that clears Discord's credentials, so an
-   * offered button would open a dialog whose confirm does nothing. Read as a
-   * capability the way the transport reads an absent method, rather than
-   * naming the channel in the component.
+   * Undefined when a channel cannot be disconnected from here: there is no
+   * route that clears Discord's credentials, so an offered button would open
+   * a dialog whose confirm does nothing. Read as a capability the way the
+   * transport reads an absent method, rather than naming the channel in the
+   * component. Required, not optional, so a new channel states the answer
+   * instead of inheriting one by omission.
    */
-  disconnectMessageKey?:
+  disconnectMessageKey:
     | "channelMeta.slack.disconnectMessage"
     | "channelMeta.telegram.disconnectMessage"
-    | "channelMeta.phone.disconnectMessage";
+    | "channelMeta.phone.disconnectMessage"
+    | undefined;
   /**
    * Whether a connected channel surfaces the "Who can message" trust-floor
    * dropdown. Slack has none: its admission floors are managed per
@@ -39,8 +47,8 @@ interface ChannelMeta {
    */
   hasTrustFloorControl: boolean;
   /**
-   * The credential form this channel is set up through, absent when it has
-   * none.
+   * The credential form this channel is set up through, undefined when it
+   * has none.
    *
    * One fact for both surfaces. The Channels tab and the assistant's setup
    * drawer render the same wizards, and differ only in where they are
@@ -52,22 +60,30 @@ interface ChannelMeta {
    * fallthrough cannot express "no form" and would hand such a channel
    * whichever form the last arm renders.
    */
-  credentialForm?: "slack-wizard" | "telegram-token" | "twilio-credentials";
+  credentialForm: ChannelCredentialForm | undefined;
   /**
    * Catalog key for the disconnected empty state's pitch, which interpolates
-   * `assistant`. Slack has none: its disconnected state is the setup wizard.
+   * `assistant`. Undefined for Slack: its disconnected state is the setup
+   * wizard.
    */
-  disconnectedPitchKey?:
+  disconnectedPitchKey:
     | "channelMeta.telegram.disconnectedPitch"
-    | "channelMeta.phone.disconnectedPitch";
+    | "channelMeta.phone.disconnectedPitch"
+    | undefined;
 }
 
-export const CHANNEL_META: Record<SetupChannelId, ChannelMeta> = {
+/*
+ * `satisfies` rather than an annotation so each entry keeps its literal type:
+ * `ChannelSetupType` is derived from which entries declare a form, and an
+ * annotation would erase exactly the facts that derivation reads.
+ */
+export const CHANNEL_META = {
   slack: {
     labelKey: "channelMeta.slack.label",
     disconnectMessageKey: "channelMeta.slack.disconnectMessage",
     hasTrustFloorControl: false,
     credentialForm: "slack-wizard",
+    disconnectedPitchKey: undefined,
   },
   telegram: {
     labelKey: "channelMeta.telegram.label",
@@ -83,4 +99,4 @@ export const CHANNEL_META: Record<SetupChannelId, ChannelMeta> = {
     credentialForm: "twilio-credentials",
     disconnectedPitchKey: "channelMeta.phone.disconnectedPitch",
   },
-};
+} satisfies Record<SetupChannelId, ChannelMeta>;

--- a/clients/web/src/domains/channels/channel-meta.ts
+++ b/clients/web/src/domains/channels/channel-meta.ts
@@ -19,7 +19,16 @@ interface ChannelMeta {
     | "channelMeta.slack.label"
     | "channelMeta.telegram.label"
     | "channelMeta.phone.label";
-  disconnectMessageKey:
+  /**
+   * Catalog key for the disconnect dialog's body.
+   *
+   * Optional, and its absence is what says a channel cannot be disconnected
+   * from here: there is no route that clears Discord's credentials, so an
+   * offered button would open a dialog whose confirm does nothing. Read as a
+   * capability the way the transport reads an absent method, rather than
+   * naming the channel in the component.
+   */
+  disconnectMessageKey?:
     | "channelMeta.slack.disconnectMessage"
     | "channelMeta.telegram.disconnectMessage"
     | "channelMeta.phone.disconnectMessage";
@@ -29,6 +38,21 @@ interface ChannelMeta {
    * conversation type (DMs vs. channels), with no channel-wide knob.
    */
   hasTrustFloorControl: boolean;
+  /**
+   * The credential form this channel is set up through, absent when it has
+   * none.
+   *
+   * One fact for both surfaces. The Channels tab and the assistant's setup
+   * drawer render the same wizards, and differ only in where they are
+   * mounted, so which form a channel has is a property of the channel rather
+   * than of either surface. Whether the tab reaches it inline or behind
+   * "Connect manually" is presentation and stays in the tab.
+   *
+   * Declared per channel rather than inferred from a branch, because a
+   * fallthrough cannot express "no form" and would hand such a channel
+   * whichever form the last arm renders.
+   */
+  credentialForm?: "slack-wizard" | "telegram-token" | "twilio-credentials";
   /**
    * Catalog key for the disconnected empty state's pitch, which interpolates
    * `assistant`. Slack has none: its disconnected state is the setup wizard.
@@ -43,17 +67,20 @@ export const CHANNEL_META: Record<SetupChannelId, ChannelMeta> = {
     labelKey: "channelMeta.slack.label",
     disconnectMessageKey: "channelMeta.slack.disconnectMessage",
     hasTrustFloorControl: false,
+    credentialForm: "slack-wizard",
   },
   telegram: {
     labelKey: "channelMeta.telegram.label",
     disconnectMessageKey: "channelMeta.telegram.disconnectMessage",
     hasTrustFloorControl: true,
+    credentialForm: "telegram-token",
     disconnectedPitchKey: "channelMeta.telegram.disconnectedPitch",
   },
   phone: {
     labelKey: "channelMeta.phone.label",
     disconnectMessageKey: "channelMeta.phone.disconnectMessage",
     hasTrustFloorControl: true,
+    credentialForm: "twilio-credentials",
     disconnectedPitchKey: "channelMeta.phone.disconnectedPitch",
   },
 };

--- a/clients/web/src/domains/channels/components/assistant-channels-list.tsx
+++ b/clients/web/src/domains/channels/components/assistant-channels-list.tsx
@@ -242,7 +242,12 @@ export function AssistantChannelsList({
           : undefined
       }
       onDisconnect={
-        onDisconnect ? () => setPendingDisconnect(selected!.key) : undefined
+        // A channel with no disconnect copy has no route to clear its
+        // credentials either, so it is offered no button rather than one
+        // whose confirm does nothing.
+        onDisconnect && CHANNEL_META[selected!.key].disconnectMessageKey
+          ? () => setPendingDisconnect(selected!.key)
+          : undefined
       }
       onSaveTelegramToken={onSaveTelegramToken}
       telegramSaveStatus={telegramSaveStatus}
@@ -318,7 +323,11 @@ export function AssistantChannelsList({
         title={t("assistantChannelsList.disconnectTitle", {
           channel: disconnectMeta ? t(disconnectMeta.labelKey) : "",
         })}
-        message={disconnectMeta ? t(disconnectMeta.disconnectMessageKey) : ""}
+        message={
+          disconnectMeta?.disconnectMessageKey
+            ? t(disconnectMeta.disconnectMessageKey)
+            : ""
+        }
         confirmLabel={t("assistantChannelsList.disconnectConfirm")}
         destructive
         onConfirm={() => {

--- a/clients/web/src/domains/channels/components/channel-panel.tsx
+++ b/clients/web/src/domains/channels/components/channel-panel.tsx
@@ -7,7 +7,10 @@ import type { MutationStatus } from "@/components/channel-setup-wizard";
 import { EmptyState } from "@/components/empty-state";
 import { SlackSetupWizard } from "@/components/slack-setup-wizard";
 import { TelegramSetupWizard } from "@/components/telegram-setup-wizard";
-import { CHANNEL_META } from "@/domains/channels/channel-meta";
+import {
+  CHANNEL_META,
+  type ChannelCredentialForm,
+} from "@/domains/channels/channel-meta";
 import { ChannelTrustFloorSection } from "@/domains/channels/components/channel-trust-floor-section";
 import { ConnectedChannelHeader } from "@/domains/channels/components/connected-channel-header";
 import { SlackChannelCard } from "@/domains/channels/components/slack-channel-card";
@@ -151,6 +154,31 @@ export function ChannelPanel({
   // connected — mirroring Slack's setup wizard, so "Connected" never sits next
   // to an empty token field.
   const meta = CHANNEL_META[channel.key];
+
+  // The one place a declared form picks its writer. Exhaustive, so a channel
+  // declaring a form this switch does not name fails to compile instead of
+  // receiving another channel's writer. Slack renders its wizard in the
+  // dedicated branch above, so its arm here draws nothing.
+  const renderCredentialForm = (form: ChannelCredentialForm) => {
+    switch (form) {
+      case "slack-wizard":
+        return null;
+      case "telegram-token":
+        return (
+          <TelegramSetupWizard
+            assistantName={assistantName}
+            saveStatus={telegramSaveStatus}
+            saveError={telegramSaveError}
+            onSave={onSaveTelegramToken}
+          />
+        );
+      case "twilio-credentials":
+        return <TwilioCredentialEntry onSave={onSaveTwilioCredentials} />;
+      default:
+        return form satisfies never;
+    }
+  };
+
   return (
     <div className="flex flex-col gap-4">
       {connected ? (
@@ -173,16 +201,7 @@ export function ChannelPanel({
           ) : null}
         </>
       ) : manualEntry && meta.credentialForm ? (
-        meta.credentialForm === "telegram-token" ? (
-          <TelegramSetupWizard
-            assistantName={assistantName}
-            saveStatus={telegramSaveStatus}
-            saveError={telegramSaveError}
-            onSave={onSaveTelegramToken}
-          />
-        ) : (
-          <TwilioCredentialEntry onSave={onSaveTwilioCredentials} />
-        )
+        renderCredentialForm(meta.credentialForm)
       ) : (
         // Two different states share this branch. `not_configured` has never
         // been set up and gets the pitch. `incomplete` holds credentials that

--- a/clients/web/src/domains/channels/components/channel-panel.tsx
+++ b/clients/web/src/domains/channels/components/channel-panel.tsx
@@ -172,8 +172,8 @@ export function ChannelPanel({
             />
           ) : null}
         </>
-      ) : manualEntry ? (
-        channel.key === "telegram" ? (
+      ) : manualEntry && meta.credentialForm ? (
+        meta.credentialForm === "telegram-token" ? (
           <TelegramSetupWizard
             assistantName={assistantName}
             saveStatus={telegramSaveStatus}
@@ -225,13 +225,18 @@ export function ChannelPanel({
                     ? t("channelPanel.finishSetup")
                     : t("channelPanel.setUp")}
               </Button>
-              <Button
-                type="button"
-                variant="link"
-                onClick={() => setManualEntry(true)}
-              >
-                {t("channelPanel.connectManually")}
-              </Button>
+              {/* Slack returns above with its wizard rendered inline, so a
+                  channel reaching here either has a form to open behind the
+                  link or has none at all. */}
+              {meta.credentialForm ? (
+                <Button
+                  type="button"
+                  variant="link"
+                  onClick={() => setManualEntry(true)}
+                >
+                  {t("channelPanel.connectManually")}
+                </Button>
+              ) : null}
             </div>
           }
         />

--- a/clients/web/src/domains/chat/components/channel-setup-panel.tsx
+++ b/clients/web/src/domains/chat/components/channel-setup-panel.tsx
@@ -24,6 +24,21 @@ interface ChannelSetupPanelProps {
   onClose: () => void;
 }
 
+/**
+ * Exhaustive over the channels the drawer accepts, so one it cannot draw
+ * fails to compile rather than falling through to another channel's copy.
+ */
+const CONNECTED_MESSAGE_KEY: Record<
+  ChannelSetupType,
+  | "channelSetupPanel.slackConnected"
+  | "channelSetupPanel.telegramConnected"
+  | "channelSetupPanel.phoneConnected"
+> = {
+  slack: "channelSetupPanel.slackConnected",
+  telegram: "channelSetupPanel.telegramConnected",
+  phone: "channelSetupPanel.phoneConnected",
+};
+
 const CHANNEL_BRAND_LABEL: Record<ChannelSetupType, string | null> = {
   slack: "Slack",
   telegram: "Telegram",
@@ -37,12 +52,7 @@ export function ChannelSetupPanel({
   const { t } = useTranslation("chat");
   const channelLabel =
     CHANNEL_BRAND_LABEL[payload.channel] ?? t("channelSetupPanel.phoneLabel");
-  const connectedMessage =
-    payload.channel === "slack"
-      ? t("channelSetupPanel.slackConnected")
-      : payload.channel === "telegram"
-        ? t("channelSetupPanel.telegramConnected")
-        : t("channelSetupPanel.phoneConnected");
+  const connectedMessage = t(CONNECTED_MESSAGE_KEY[payload.channel]);
 
   const saveSlack = useSaveSlackConfig({
     assistantId: payload.assistantId,
@@ -229,7 +239,9 @@ function TwilioCredentialForm({
             !accountSid.trim() || !authToken.trim() || status === "pending"
           }
         >
-          {status === "pending" ? t("channelSetupPanel.saving") : t("channelSetupPanel.save")}
+          {status === "pending"
+            ? t("channelSetupPanel.saving")
+            : t("channelSetupPanel.save")}
         </Button>
       </div>
     </div>

--- a/clients/web/src/domains/chat/utils/stream-handlers/navigation-handlers.ts
+++ b/clients/web/src/domains/chat/utils/stream-handlers/navigation-handlers.ts
@@ -1,12 +1,12 @@
 import { dispatchOpenUrl } from "@/domains/chat/utils/oauth-popup-links";
 import { getSettingsRouteForClientTab } from "@/utils/settings-navigation";
-import { isSetupChannelId } from "@/types/channel-types";
+
 import { recordDiagnostic } from "@/lib/diagnostics";
 import { routes } from "@/utils/routes";
 import { submitSurfaceAction } from "@/domains/chat/api/surfaces";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
 import { useConversationStore } from "@/stores/conversation-store";
-import { useViewerStore } from "@/stores/viewer-store";
+import { isChannelSetupType, useViewerStore } from "@/stores/viewer-store";
 import { revealConversationView } from "@/utils/conversation-navigation";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { useSubagentStore } from "@/domains/chat/subagent-store";
@@ -134,8 +134,12 @@ export function handleOpenPanel(
 
   const rawChannel =
     typeof event.data?.channel === "string" ? event.data.channel : undefined;
+  // Narrower than the setup-channel list: this drawer is a credential form,
+  // and a channel without one has nothing to render. An id naming such a
+  // channel falls back rather than opening a panel that would show another
+  // channel's connected copy over an empty body.
   const channel =
-    rawChannel && isSetupChannelId(rawChannel) ? rawChannel : "slack";
+    rawChannel && isChannelSetupType(rawChannel) ? rawChannel : "slack";
   // The event's conversationId belongs to the assistant whose stream
   // delivered it — pair the payload with that assistant, not whatever is
   // active at arrival time, so a close-notify posted later can't mix

--- a/clients/web/src/stores/viewer-store.ts
+++ b/clients/web/src/stores/viewer-store.ts
@@ -29,7 +29,8 @@
 import { captureError } from "@/lib/sentry/capture-error";
 import { create } from "zustand";
 
-import type { SetupChannelId } from "@/types/channel-types";
+import { CHANNEL_META } from "@/domains/channels/channel-meta";
+import { SETUP_CHANNEL_IDS } from "@/types/channel-types";
 import type { ProcessKind } from "@/domains/chat/process-registry/types";
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
 import type { ToolCallCardItem } from "@/domains/chat/utils/tool-call-card-utils";
@@ -253,7 +254,27 @@ export function sameDocumentTarget(
   );
 }
 
-export type ChannelSetupType = SetupChannelId;
+/**
+ * Channels the setup drawer can actually render.
+ *
+ * Narrower than the setup-channel list on purpose: this panel *is* a
+ * credential form, and a channel without one has nothing for it to show.
+ *
+ * Derived rather than listed. The drawer and the Channels tab render the same
+ * wizards and differ only in where they are mounted, so "has a credential
+ * form" is one fact about the channel, and two hand-kept lists would be free
+ * to disagree about it.
+ */
+export const CHANNEL_SETUP_TYPES = SETUP_CHANNEL_IDS.filter(
+  (id) => CHANNEL_META[id].credentialForm !== undefined,
+);
+
+export type ChannelSetupType = (typeof CHANNEL_SETUP_TYPES)[number];
+
+/** Whether the setup drawer has a credential form for this channel. */
+export function isChannelSetupType(value: string): value is ChannelSetupType {
+  return (CHANNEL_SETUP_TYPES as readonly string[]).includes(value);
+}
 
 export interface ChannelSetupPayload {
   channel: ChannelSetupType;

--- a/clients/web/src/stores/viewer-store.ts
+++ b/clients/web/src/stores/viewer-store.ts
@@ -29,8 +29,11 @@
 import { captureError } from "@/lib/sentry/capture-error";
 import { create } from "zustand";
 
-import { CHANNEL_META } from "@/domains/channels/channel-meta";
-import { SETUP_CHANNEL_IDS } from "@/types/channel-types";
+import {
+  CHANNEL_META,
+  type ChannelCredentialForm,
+} from "@/domains/channels/channel-meta";
+import { SETUP_CHANNEL_IDS, type SetupChannelId } from "@/types/channel-types";
 import type { ProcessKind } from "@/domains/chat/process-registry/types";
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
 import type { ToolCallCardItem } from "@/domains/chat/utils/tool-call-card-utils";
@@ -266,14 +269,26 @@ export function sameDocumentTarget(
  * to disagree about it.
  */
 export const CHANNEL_SETUP_TYPES = SETUP_CHANNEL_IDS.filter(
-  (id) => CHANNEL_META[id].credentialForm !== undefined,
+  (id): id is ChannelSetupType => CHANNEL_META[id].credentialForm !== undefined,
 );
 
-export type ChannelSetupType = (typeof CHANNEL_SETUP_TYPES)[number];
+/**
+ * Derived at the type level from the same declarations the filter above reads
+ * at runtime: the channels whose `CHANNEL_META` entry declares a form. A bare
+ * `.filter` keeps the unnarrowed union, which would let a formless channel
+ * satisfy this type while the drawer has nothing to show it.
+ */
+export type ChannelSetupType = {
+  [K in SetupChannelId]: (typeof CHANNEL_META)[K] extends {
+    credentialForm: ChannelCredentialForm;
+  }
+    ? K
+    : never;
+}[SetupChannelId];
 
 /** Whether the setup drawer has a credential form for this channel. */
 export function isChannelSetupType(value: string): value is ChannelSetupType {
-  return (CHANNEL_SETUP_TYPES as readonly string[]).includes(value);
+  return CHANNEL_SETUP_TYPES.some((id) => id === value);
 }
 
 export interface ChannelSetupPayload {

--- a/clients/web/src/types/channel-types.ts
+++ b/clients/web/src/types/channel-types.ts
@@ -15,7 +15,7 @@ export const SETUP_CHANNEL_IDS = [
 export type SetupChannelId = (typeof SETUP_CHANNEL_IDS)[number];
 
 export function isSetupChannelId(value: string): value is SetupChannelId {
-  return (SETUP_CHANNEL_IDS as readonly string[]).includes(value);
+  return SETUP_CHANNEL_IDS.some((id) => id === value);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## TL;DR

The Channels tab picked a credential form with a two-way branch, so a channel with no form at all was offered Twilio's: an Account SID field that saves phone credentials under another channel's heading. Each channel now declares the form it is set up through, and absence means none.

7 files, no Discord, no behaviour change for the channels that exist today.

## The bug

```ts
manualEntry ? (
  channel.key === "telegram" ? <TelegramSetupWizard/> : <TwilioCredentialEntry/>
) : ...
```

A branch cannot express "this channel has no form", so its last arm answers for everything unnamed. That was latent while every setup channel happened to have one; the next channel added inherits a phone credential form and a mutation that writes Twilio's config.

Same shape on disconnect: the button rendered unconditionally, so a channel with no route to clear its credentials would open a dialog whose confirm does nothing.

## What changes

- **`credentialForm`** names the form per channel, absent where there is none. The tab reads it to decide what "Connect manually" opens *and* whether to offer the link at all.
- **`disconnectMessageKey` is optional**, and its absence is what says a channel cannot be disconnected here. Read the way the transport reads an absent method: an absent capability, not an error.
- **The setup drawer stops keeping a second list.** Its accepted set derives from the same capability, and its connected copy is an exhaustive record rather than a ternary chain, so a channel it cannot draw fails to compile instead of falling through to another channel's copy over an empty body.

## Why it is safe

- **No behaviour change for Slack, Telegram or phone.** Each declares the form it already rendered; the rendering paths are unchanged. Verified by the existing panel and drawer suites plus a new capability test.
- **The compiler enforces the invariant rather than a convention.** `ChannelSetupType` was an alias of the whole setup-channel set, so widening that set silently promised a renderer. It is now derived, and the exhaustive copy record means a channel reaching the drawer without one is a build failure.
- **The new test asserts the invariant, not the current membership**: that the field is set only where a form exists, and that the only channel resolving to the Twilio form is `phone`. A future channel added without a form fails it.

## Before / after

| | Before | After |
|---|---|---|
| Channel with a form | Its own wizard | Unchanged |
| **Channel with no form** | **Twilio's Account SID field, saving phone credentials** | No manual-entry link offered |
| Channel with no disconnect route | Button, dialog, confirm does nothing | No button |
| Adding a channel to the setup list | Silently promises a drawer renderer | Fails to compile until one exists |

## Context

Split out of #41312, which had grown to cover this refactor, Discord's arrival in Channels, a new config API and a wizard at once. This is the part that stands alone: it fixes a real latent defect, touches only channels that already exist, and is the base the Discord work builds on.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41333" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->