### PR TITLE
fix(chat): keep a background job's title when there is nothing to retitle from

### DIFF
--- a/assistant/src/__tests__/conversation-title-service.test.ts
+++ b/assistant/src/__tests__/conversation-title-service.test.ts
@@ -462,6 +462,103 @@ describe("conversation-title-service", () => {
     expect(result).toEqual({ title: "Existing Title", updated: false });
   });
 
+  test.each([
+    ["an image-only prompt", ""],
+    ["a whitespace-only prompt", "   \n  "],
+    ["a thinking-tags-only prompt", "<thinking>untitled</thinking>"],
+  ])(
+    "keeps a background job's deterministic title through %s",
+    async (_label, userMessage) => {
+      // A background conversation carries a deterministic bootstrap title
+      // naming its job. A follow-up with no text to title from must leave it
+      // alone rather than have the model invent an unrelated topic.
+      mockGetConversation.mockImplementation(() => ({
+        title: "Memory consolidation",
+        isAutoTitle: AUTO_TITLE_DETERMINISTIC,
+      }));
+
+      const provider = makeProvider();
+
+      const result = await generateAndPersistConversationTitle({
+        conversationId: "conv-1",
+        provider,
+        userMessage,
+      });
+
+      expect(provider.sendMessage).not.toHaveBeenCalled();
+      expect(mockUpdateConversationTitle).not.toHaveBeenCalled();
+      expect(mockPublishConversationTitleChanged).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        title: "Memory consolidation",
+        updated: false,
+      });
+    },
+  );
+
+  test("replaces the loading placeholder when a prompt has no text", async () => {
+    // Same skipped LLM call, but a conversation still on the loading
+    // placeholder has no title worth keeping, so it settles on a
+    // deterministic one the stop hook can still upgrade.
+    const provider = makeProvider();
+
+    const result = await generateAndPersistConversationTitle({
+      conversationId: "conv-1",
+      provider,
+      userMessage: "",
+    });
+
+    expect(provider.sendMessage).not.toHaveBeenCalled();
+    expect(result).toEqual({ title: "Untitled Conversation", updated: true });
+    expect(mockUpdateConversationTitle).toHaveBeenCalledWith(
+      "conv-1",
+      "Untitled Conversation",
+      AUTO_TITLE_DETERMINISTIC,
+    );
+  });
+
+  test("keeps a background job's deterministic title when the model declines", async () => {
+    // The model answered with prose the normalizer rejects, so there is no
+    // generated title. Settling for "Untitled Conversation" would name the
+    // job's work less well than the bootstrap title already does.
+    mockGetConversation.mockImplementation(() => ({
+      title: "Memory consolidation",
+      isAutoTitle: AUTO_TITLE_DETERMINISTIC,
+    }));
+
+    const provider = makeProvider(async () =>
+      textResponse("I need to generate a title for this conversation"),
+    );
+
+    const result = await generateAndPersistConversationTitle({
+      conversationId: "conv-1",
+      provider,
+      userMessage: "what did you consolidate?",
+    });
+
+    expect(provider.sendMessage).toHaveBeenCalledTimes(1);
+    expect(mockUpdateConversationTitle).not.toHaveBeenCalled();
+    expect(result).toEqual({ title: "Memory consolidation", updated: false });
+  });
+
+  test("still generates when only creation metadata describes the topic", async () => {
+    // Voice call sites pass context hints and no user message. Those carry a
+    // topic, so the skip must not swallow them.
+    const provider = makeProvider(async () => toolResponse("Inbound Call"));
+
+    const result = await generateAndPersistConversationTitle({
+      conversationId: "conv-1",
+      provider,
+      context: {
+        origin: "voice_inbound",
+        sourceChannel: "phone",
+        systemHint: "Inbound call",
+      },
+    });
+
+    expect(provider.sendMessage).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ title: "Inbound Call", updated: true });
+  });
+
   test("title prompt content does not contain generation instructions", async () => {
     const provider = makeProvider();
 

--- a/assistant/src/persistence/conversation-title-service.ts
+++ b/assistant/src/persistence/conversation-title-service.ts
@@ -146,22 +146,22 @@ export function deriveDeterministicTitle(context: TitleContext): string {
  * inbound whose only content is a guardian access-request card: without this
  * the sidebar shows a permanent "Generating title…". Persisted as
  * `AUTO_TITLE_DETERMINISTIC` so a later genuine turn can still upgrade it, and
- * broadcast so connected clients converge. Returns the title as persisted, or
- * null when the current one was left in place.
+ * broadcast so connected clients converge. Returns the title the conversation
+ * carries once it settles, and whether this call is what set it.
  */
 export function applyDeterministicTitleIfReplaceable(
   conversationId: string,
   title: string,
-): string | null {
+): { title: string; updated: boolean } {
   const conversation = getConversation(conversationId);
   if (conversation && !isReplaceableTitle(conversation.title)) {
-    return null;
+    return { title: conversation.title!, updated: false };
   }
   const cleaned =
     truncateTitle(title.replace(/\s+/g, " ").trim()) || UNTITLED_FALLBACK;
   updateConversationTitle(conversationId, cleaned, AUTO_TITLE_DETERMINISTIC);
   publishConversationTitleChanged(conversationId, cleaned);
-  return cleaned;
+  return { title: cleaned, updated: true };
 }
 
 // ── Title generation ─────────────────────────────────────────────────
@@ -235,32 +235,21 @@ export async function generateAndPersistConversationTitle(
 }
 
 /**
- * Settle a conversation on a title derived from its creation context when no
- * LLM title is available: the provider is unreachable, the model declined, or
- * the prompt had no text to title from.
- *
- * Applies only while the current title is still a placeholder, so a background
- * job's bootstrap title (or a custom rename that landed while the request was
- * in flight) is never traded for one that names the work less well. Persisted
- * as `AUTO_TITLE_DETERMINISTIC`, so a later generation pass can still upgrade
- * it and a conversation never sits on the loading placeholder for good.
+ * Settle a conversation on a title derived from its creation context, for the
+ * outcomes that produce no LLM title: the provider is unreachable, the model
+ * declined, or the prompt had no text to title from. Clearing a loading
+ * placeholder is worth doing; overwriting a title that already names the work
+ * (a background job's bootstrap title) is not, which is why this defers to
+ * `applyDeterministicTitleIfReplaceable` rather than writing directly.
  */
 function settleForDeterministicTitle(
   conversationId: string,
   context: TitleContext | undefined,
 ): { title: string; updated: boolean } {
-  const fallback = deriveFallbackTitle(context) ?? UNTITLED_FALLBACK;
-  const applied = applyDeterministicTitleIfReplaceable(
+  return applyDeterministicTitleIfReplaceable(
     conversationId,
-    fallback,
+    deriveFallbackTitle(context) ?? UNTITLED_FALLBACK,
   );
-  if (applied !== null) {
-    return { title: applied, updated: true };
-  }
-  return {
-    title: getConversation(conversationId)?.title ?? fallback,
-    updated: false,
-  };
 }
 
 // ── Serial title-generation queue ────────────────────────────────────
@@ -550,8 +539,8 @@ function buildTitlePrompt(
     }
   }
 
-  // Trim after stripping so a turn whose only content was thinking tags reads
-  // as no text at all, the same as an image-only or whitespace-only prompt.
+  // Trim after stripping so a turn carrying nothing but thinking tags reads as
+  // no text at all, the same as an image-only or whitespace-only prompt.
   const userText = userMessage ? stripThinkingTags(userMessage).trim() : "";
   if (userText) {
     parts.push(`User: ${userText}`);

--- a/assistant/src/persistence/conversation-title-service.ts
+++ b/assistant/src/persistence/conversation-title-service.ts
@@ -146,21 +146,22 @@ export function deriveDeterministicTitle(context: TitleContext): string {
  * inbound whose only content is a guardian access-request card: without this
  * the sidebar shows a permanent "Generating title…". Persisted as
  * `AUTO_TITLE_DETERMINISTIC` so a later genuine turn can still upgrade it, and
- * broadcast so connected clients converge. Returns whether the title changed.
+ * broadcast so connected clients converge. Returns the title as persisted, or
+ * null when the current one was left in place.
  */
 export function applyDeterministicTitleIfReplaceable(
   conversationId: string,
   title: string,
-): boolean {
+): string | null {
   const conversation = getConversation(conversationId);
   if (conversation && !isReplaceableTitle(conversation.title)) {
-    return false;
+    return null;
   }
   const cleaned =
     truncateTitle(title.replace(/\s+/g, " ").trim()) || UNTITLED_FALLBACK;
   updateConversationTitle(conversationId, cleaned, AUTO_TITLE_DETERMINISTIC);
   publishConversationTitleChanged(conversationId, cleaned);
-  return true;
+  return cleaned;
 }
 
 // ── Title generation ─────────────────────────────────────────────────
@@ -195,19 +196,21 @@ export async function generateAndPersistConversationTitle(
     return { title: conversation.title!, updated: false };
   }
 
+  const prompt = buildTitlePrompt(context, userMessage, assistantResponse);
+  // A prompt carrying no text gives the model nothing to title from: an
+  // image-only turn submits an empty prompt, and the forced title tool makes
+  // the model fabricate a topic rather than decline.
+  if (prompt.trim() === "") {
+    return settleForDeterministicTitle(conversationId, context);
+  }
+
   const provider =
     params.provider ?? (await getConfiguredProvider("conversationTitle"));
   if (!provider) {
-    // No provider available — fall back to context-derived title or untitled.
-    // Deterministic, so keep it upgradeable by a later generation pass.
-    const fallback = deriveFallbackTitle(context) ?? UNTITLED_FALLBACK;
-    updateConversationTitle(conversationId, fallback, AUTO_TITLE_DETERMINISTIC);
-    publishConversationTitleChanged(conversationId, fallback);
     logRetryableFallback(params, "no_provider");
-    return { title: fallback, updated: true };
+    return settleForDeterministicTitle(conversationId, context);
   }
 
-  const prompt = buildTitlePrompt(context, userMessage, assistantResponse);
   const title = await generateTitleViaLLM(
     provider,
     prompt,
@@ -227,21 +230,37 @@ export async function generateAndPersistConversationTitle(
     return { title, updated: true };
   }
 
-  // No text in response — use fallback
-  // Re-check replaceability before persisting (race guard — same as the
-  // text-response path above). A concurrent custom rename may have landed
-  // while the LLM request was in-flight; writing unconditionally would
-  // clobber the user's intent.
-  const currentForFallback = getConversation(conversationId);
-  if (currentForFallback && !canReplaceTitle(currentForFallback)) {
-    return { title: currentForFallback.title!, updated: false };
-  }
-
-  const fallback = deriveFallbackTitle(context) ?? UNTITLED_FALLBACK;
-  updateConversationTitle(conversationId, fallback, AUTO_TITLE_DETERMINISTIC);
-  publishConversationTitleChanged(conversationId, fallback);
   logRetryableFallback(params, "empty_output");
-  return { title: fallback, updated: true };
+  return settleForDeterministicTitle(conversationId, context);
+}
+
+/**
+ * Settle a conversation on a title derived from its creation context when no
+ * LLM title is available: the provider is unreachable, the model declined, or
+ * the prompt had no text to title from.
+ *
+ * Applies only while the current title is still a placeholder, so a background
+ * job's bootstrap title (or a custom rename that landed while the request was
+ * in flight) is never traded for one that names the work less well. Persisted
+ * as `AUTO_TITLE_DETERMINISTIC`, so a later generation pass can still upgrade
+ * it and a conversation never sits on the loading placeholder for good.
+ */
+function settleForDeterministicTitle(
+  conversationId: string,
+  context: TitleContext | undefined,
+): { title: string; updated: boolean } {
+  const fallback = deriveFallbackTitle(context) ?? UNTITLED_FALLBACK;
+  const applied = applyDeterministicTitleIfReplaceable(
+    conversationId,
+    fallback,
+  );
+  if (applied !== null) {
+    return { title: applied, updated: true };
+  }
+  return {
+    title: getConversation(conversationId)?.title ?? fallback,
+    updated: false,
+  };
 }
 
 // ── Serial title-generation queue ────────────────────────────────────
@@ -531,11 +550,17 @@ function buildTitlePrompt(
     }
   }
 
-  if (userMessage) {
-    parts.push(`User: ${stripThinkingTags(userMessage)}`);
+  // Trim after stripping so a turn whose only content was thinking tags reads
+  // as no text at all, the same as an image-only or whitespace-only prompt.
+  const userText = userMessage ? stripThinkingTags(userMessage).trim() : "";
+  if (userText) {
+    parts.push(`User: ${userText}`);
   }
-  if (assistantResponse) {
-    parts.push(`Assistant: ${stripThinkingTags(assistantResponse)}`);
+  const assistantText = assistantResponse
+    ? stripThinkingTags(assistantResponse).trim()
+    : "";
+  if (assistantText) {
+    parts.push(`Assistant: ${assistantText}`);
   }
 
   return parts.join("\n");


### PR DESCRIPTION
## TL;DR

A background conversation keeps the deterministic title that names its job when a follow-up gives the title model nothing to work with. An image-only message no longer causes an invented rename, and a failed or rejected title generation no longer overwrites the job title with "Untitled Conversation".

Fixes LUM-3461

## What was happening

Background and scheduled conversations bootstrap with a deterministic title derived from the job's `systemHint` (for example "Memory consolidation"), marked `AUTO_TITLE_DETERMINISTIC`. That marker deliberately keeps the title replaceable: a human who opens the conversation and actually talks upgrades it to a generated title. That upgrade is intended behavior and stays.

Two paths took the opening without ever having a topic to name:

1. **An image-only follow-up.** The send route accepts a message with attachments and no text, so the prompt reaching the title hook is the empty string. `buildTitlePrompt` produced an empty prompt, and the title model, forced to call the title tool, invented a topic instead of declining. The reproduced case renamed a `memory_v2_consolidation` run to "Snowflake Setup". The regeneration path already guards exactly this case, with a comment naming the fabrication failure mode; the initial-generation path never got the same guard.
2. **No title coming back at all.** When the provider is unavailable, or the model's output is rejected as prose or a meta-failure, the fallback wrote a context-derived title (just "Untitled Conversation" for the title hook, which passes no context). Its race guard admitted deterministic titles, so it overwrote the job title with a strictly less descriptive one. No image required.

## What changed

- `generateAndPersistConversationTitle` builds the prompt before resolving a provider and returns early when the prompt carries no text. No LLM call, no wasted round trip.
- Both no-title outcomes now route through one `settleForDeterministicTitle` helper. It applies a context-derived title only while the current one is still a placeholder (`isReplaceableTitle`), so a bootstrap job title, or a custom rename that landed mid-flight, is never traded for something that names the work less well. This replaces the hand-rolled race guard the empty-output path carried.
- `buildTitlePrompt` trims after stripping thinking tags, so a whitespace-only turn, or one whose entire content was thinking tags, reads as no text rather than as a prompt with an empty body.
- `applyDeterministicTitleIfReplaceable` returns the title as persisted (or null) instead of a boolean, so callers report the truncated value that actually landed. Its one existing caller ignores the return.

Conversations still sitting on the loading placeholder keep settling on a deterministic title, so nothing regresses into a permanent "Generating title...". Because that title stays `AUTO_TITLE_DETERMINISTIC`, the stop hook's retry still upgrades it once the turn has real content.

## Before and after

| Situation | Before | After |
| --- | --- | --- |
| Background job, user sends an image with no text | Job title replaced by an invented topic | Job title kept |
| Background job, user sends a real text message | Retitled from that message | Unchanged: still retitled |
| Background job, title generation fails or is rejected | Job title replaced by "Untitled Conversation" | Job title kept |
| New chat opened with an image and no text | Title generation runs on an empty prompt | Skipped; settles on "Untitled Conversation", then the stop hook retitles from the turn's real content |
| Voice call conversation (metadata hints, no user message) | Generated from the hints | Unchanged |

## Why it is safe

The narrowing is confined to the case where there is nothing to title from. Every path that has real input behaves exactly as before, including the intended upgrade of a background job's title by a genuine user message. The new guard cannot fire on a prompt that carries any text, and the fallback change only ever declines to overwrite, never writes something new.

Tests cover both defects: a background conversation keeps its deterministic title across image-only, whitespace-only, and thinking-tags-only prompts, and across a declined generation. A companion test asserts the guard does not over-fire on voice call sites, which pass creation metadata and no user message. Each new test fails on the current main behavior for the reason it names, except the voice one, which exists to catch over-firing.

## Considered and not changed

- **The interactive-turn carve-out in `user-prompt-submit.ts`.** LUM-3461 reads it as the bug, but it is deliberate: #34632 made background titles deterministic to cut title LLM calls and kept them replaceable so a human who engages gets a real title. A text message from a person is a topic worth titling from. The defect is only the topicless case, which is what this PR fixes.
- **The guard is in the service, not the hook.** Every caller of the generation primitive is protected, and it mirrors where the regeneration path already guards. Adding a second copy in the hook would duplicate the rule.
- **The `queueGenerateConversationTitle` catch path** still only clears the exact `GENERATING_TITLE` placeholder after a thrown error. It is deliberately narrower than the settle helper, and its outcome for a background conversation is already correct: it declines to write.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41334" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->