### PR TITLE
fix(memory): accept any completed no-findings reply as a reviewed retrospective window

### DIFF
--- a/assistant/src/cli/commands/memory/memory-retrospective.ts
+++ b/assistant/src/cli/commands/memory/memory-retrospective.ts
@@ -169,6 +169,7 @@ function renderOutcome(outcome: MemoryRetrospectiveOutcome): void {
     case "invoked":
       log.info(
         `Retrospective invoked.\n` +
+          `  outcome:           ${outcome.noFindings ? "reviewed, nothing new to save" : "saved to memory"}\n` +
           `  fork conversation: ${outcome.backgroundConversationId}\n` +
           `  cutoff message:    ${outcome.cutoffMessageId}\n` +
           `  new messages:      ${outcome.newMessageCount}` +

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-job.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-job.test.ts
@@ -853,7 +853,7 @@ describe("memoryRetrospectiveJob", () => {
           outcome: "no_usable_output",
           // The failure reason names what was missing, so an operator reading
           // the job row can tell a lost write from an unfinished review.
-          reason: "run committed neither a memory write nor a reply",
+          reason: "run committed neither a memory write nor a concluding reply",
         },
       },
     ]);
@@ -1105,6 +1105,39 @@ describe("memoryRetrospectiveJob", () => {
       ]);
     },
   );
+
+  test("narration followed by an empty final response has not concluded and does not advance", async () => {
+    // The reply that proves an empty-handed review must be the run's final
+    // word: text that went live mid-run followed by an empty last response
+    // is an unfinished review, not a conclusion.
+    mockWakeResult = { invoked: true, exitReason: "no_tool_calls" };
+    messagesByConversationId["fork-conv-1"] = [
+      {
+        role: "assistant",
+        content: JSON.stringify([
+          { type: "text", text: "Let me look through the window carefully." },
+        ]),
+        createdAt: Date.parse("2026-05-11T10:20:00Z"),
+        metadata: null,
+      },
+      {
+        role: "assistant",
+        content: JSON.stringify([]),
+        createdAt: Date.parse("2026-05-11T10:20:05Z"),
+        metadata: null,
+      },
+    ];
+
+    const outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    expect(outcome.kind).toBe("no_usable_output");
+    if (outcome.kind === "no_usable_output") {
+      expect(outcome.reason).toBe(
+        "run committed neither a memory write nor a concluding reply",
+      );
+    }
+    expect(stateUpserts).toHaveLength(0);
+  });
 
   test("a run whose only text is whitespace has committed nothing and does not advance", async () => {
     mockWakeResult = { invoked: true, exitReason: "no_tool_calls" };

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-job.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-job.test.ts
@@ -2,6 +2,7 @@ import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+import type { AgentLoopExitReason } from "../../../../hooks/types.js";
 import { getWorkspaceDir } from "../paths.js";
 
 // ---------------------------------------------------------------------------
@@ -48,7 +49,14 @@ let priorRetroId: string | null = null;
 let priorRetroOwnerId = "src-conv-1";
 let priorRetroMessages: Array<{ role: string; content: string }> = [];
 
-let mockWakeResult: { invoked: boolean; reason?: string } = { invoked: true };
+// `exitReason` mirrors what the real wake reports for a completed run: the
+// model answered without asking for another tool. The finalizer reads it to
+// tell a finished review from one something else cut short.
+let mockWakeResult: {
+  invoked: boolean;
+  reason?: string;
+  exitReason?: AgentLoopExitReason;
+} = { invoked: true, exitReason: "no_tool_calls" };
 let mockWakeThrows: Error | null = null;
 let wakeCalls: Array<{
   conversationId: string;
@@ -481,7 +489,7 @@ describe("memoryRetrospectiveJob", () => {
     priorRetroId = null;
     priorRetroOwnerId = "src-conv-1";
     priorRetroMessages = [];
-    mockWakeResult = { invoked: true };
+    mockWakeResult = { invoked: true, exitReason: "no_tool_calls" };
     mockWakeThrows = null;
     wakeCalls = [];
     deletedConversationIds = [];
@@ -822,7 +830,7 @@ describe("memoryRetrospectiveJob", () => {
   // -------------------------------------------------------------------------
 
   test("invoked wake with NO persisted run output: no_usable_output, cursor and log untouched, window retryable", async () => {
-    mockWakeResult = { invoked: true };
+    mockWakeResult = { invoked: true, exitReason: "no_tool_calls" };
     // The fork persisted nothing (e.g. a swallowed provider rejection or a
     // zero-output max-tokens stop).
     messagesByConversationId["fork-conv-1"] = [];
@@ -843,14 +851,19 @@ describe("memoryRetrospectiveJob", () => {
         value: 1,
         detail: {
           outcome: "no_usable_output",
-          reason: "run persisted no memory-writing tool call",
+          // The failure reason names what was missing, so an operator reading
+          // the job row can tell a lost write from an unfinished review.
+          reason: "run committed neither a memory write nor a reply",
         },
       },
     ]);
   });
 
-  test("invoked wake whose run persisted only analysis text (no tool calls): no_usable_output, prior retrospective preserved", async () => {
-    mockWakeResult = { invoked: true };
+  test("a run whose reply reads as a conclusion but that the provider cut short: no_usable_output, prior retrospective preserved", async () => {
+    // Same persisted text as a finished review, but the loop ended on the
+    // output-token ceiling rather than on the model's own stop, so the reply
+    // is a fragment of a review, not a verdict on the window.
+    mockWakeResult = { invoked: true, exitReason: "max_tokens_reached" };
     priorRetroId = "prior-retro-1";
     messagesByConversationId["fork-conv-1"] = [
       {
@@ -866,14 +879,38 @@ describe("memoryRetrospectiveJob", () => {
     const outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
 
     expect(outcome.kind).toBe("no_usable_output");
+    if (outcome.kind === "no_usable_output") {
+      expect(outcome.reason).toBe(
+        "run replied without saving anything, but ended on max_tokens_reached rather than a completed review",
+      );
+    }
     expect(stateUpserts).toHaveLength(0);
     // Only this run's own fork is deleted; the prior retrospective (the
     // dedup baseline for the retry) is preserved.
     expect(deletedConversationIds).toEqual(["fork-conv-1"]);
   });
 
-  test("run-message load failure classifies as no_usable_output (fail-closed), not success", async () => {
+  test("a run the loop never reported a terminal exit for cannot advance on a reply alone", async () => {
+    // A checkpoint handoff runs no terminal exit event, so the run resumes
+    // elsewhere and this fork holds an unfinished review.
     mockWakeResult = { invoked: true };
+    messagesByConversationId["fork-conv-1"] = [
+      {
+        role: "assistant",
+        content: JSON.stringify([{ type: "text", text: "Nothing to save." }]),
+        createdAt: Date.parse("2026-05-11T10:20:00Z"),
+        metadata: null,
+      },
+    ];
+
+    const outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+    expect(outcome.kind).toBe("no_usable_output");
+    expect(stateUpserts).toHaveLength(0);
+  });
+
+  test("run-message load failure classifies as no_usable_output (fail-closed), not success", async () => {
+    mockWakeResult = { invoked: true, exitReason: "no_tool_calls" };
     // Fork-kind conversation with no stamps and no leading instruction row:
     // `loadRetrospectiveRunMessages` returns null (indeterminate).
     conversationOverrides["fork-conv-1"] = {
@@ -896,7 +933,7 @@ describe("memoryRetrospectiveJob", () => {
   });
 
   test("checkpoint-persisted saves on a fork-kind tail count as usable output (rebase-after-live cannot fake no-output)", async () => {
-    mockWakeResult = { invoked: true };
+    mockWakeResult = { invoked: true, exitReason: "no_tool_calls" };
     conversationOverrides["fork-conv-1"] = {
       source: "memory-retrospective-fork",
       forkParentMessageId: null,
@@ -945,7 +982,7 @@ describe("memoryRetrospectiveJob", () => {
   });
 
   test("scaffold_managed_skill counts as durable work even with zero remembers", async () => {
-    mockWakeResult = { invoked: true };
+    mockWakeResult = { invoked: true, exitReason: "no_tool_calls" };
     messagesByConversationId["fork-conv-1"] = [
       {
         role: "assistant",
@@ -982,7 +1019,7 @@ describe("memoryRetrospectiveJob", () => {
   });
 
   test("a remember whose execution FAILED (is_error tool_result) is not durable evidence and its facts stay out of the log", async () => {
-    mockWakeResult = { invoked: true };
+    mockWakeResult = { invoked: true, exitReason: "no_tool_calls" };
     messagesByConversationId["fork-conv-1"] = [
       {
         role: "assistant",
@@ -1023,41 +1060,58 @@ describe("memoryRetrospectiveJob", () => {
     expect(lastRunAtBumps).toHaveLength(1);
   });
 
-  test("explicit no-findings reply advances the cursor without fabricating a memory write", async () => {
-    mockWakeResult = { invoked: true };
+  // A finished review that found nothing advances on the SHAPE of the run,
+  // never on the wording of the reply. Each phrasing below is a correct
+  // conclusion the model reached on its own; the window it reviewed is
+  // consumed, and the health counter records which kind of success it was.
+  test.each([
+    "Nothing new to save.",
+    "Nothing new to save beyond those two facts.",
+    "Nothing else new to save.",
+    "Done.",
+    "I reviewed the window. Nothing new to save. Here is my reasoning about why each item was already covered by prior passes.",
+  ])(
+    "a completed review that saved nothing advances the cursor: %s",
+    async (reply) => {
+      mockWakeResult = { invoked: true, exitReason: "no_tool_calls" };
+      messagesByConversationId["fork-conv-1"] = [
+        {
+          role: "assistant",
+          content: JSON.stringify([{ type: "text", text: reply }]),
+          createdAt: Date.parse("2026-05-11T10:20:00Z"),
+          metadata: null,
+        },
+      ];
+
+      const outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
+
+      expect(outcome.kind).toBe("invoked");
+      if (outcome.kind === "invoked") {
+        expect(outcome.noFindings).toBe(true);
+      }
+      expect(stateUpserts).toHaveLength(1);
+      expect(stateUpserts[0]!.lastProcessedMessageId).toBe("m3");
+      expect(stateUpserts[0]!.rememberedLog).toEqual([]);
+      expect(
+        watchdogEvents.filter(
+          (e) => e.checkName === "memory_retrospective_run",
+        ),
+      ).toEqual([
+        {
+          checkName: "memory_retrospective_run",
+          value: 1,
+          detail: { outcome: "invoked", noFindings: true },
+        },
+      ]);
+    },
+  );
+
+  test("a run whose only text is whitespace has committed nothing and does not advance", async () => {
+    mockWakeResult = { invoked: true, exitReason: "no_tool_calls" };
     messagesByConversationId["fork-conv-1"] = [
       {
         role: "assistant",
-        content: JSON.stringify([
-          { type: "text", text: "Nothing new to save." },
-        ]),
-        createdAt: Date.parse("2026-05-11T10:20:00Z"),
-        metadata: null,
-      },
-    ];
-
-    const outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
-
-    // A reviewed-and-no-findings pass is a legitimate success: the mandated
-    // exact reply is the positive persisted artifact, the cursor advances,
-    // and the remembered log gains nothing.
-    expect(outcome.kind).toBe("invoked");
-    expect(stateUpserts).toHaveLength(1);
-    expect(stateUpserts[0]!.lastProcessedMessageId).toBe("m3");
-    expect(stateUpserts[0]!.rememberedLog).toEqual([]);
-  });
-
-  test("analysis prose that merely mentions the no-findings phrase does not advance", async () => {
-    mockWakeResult = { invoked: true };
-    messagesByConversationId["fork-conv-1"] = [
-      {
-        role: "assistant",
-        content: JSON.stringify([
-          {
-            type: "text",
-            text: "I reviewed the window. Nothing new to save. Here is my reasoning about why each item was already covered by prior passes.",
-          },
-        ]),
+        content: JSON.stringify([{ type: "text", text: "   \n  " }]),
         createdAt: Date.parse("2026-05-11T10:20:00Z"),
         metadata: null,
       },
@@ -1069,8 +1123,8 @@ describe("memoryRetrospectiveJob", () => {
     expect(stateUpserts).toHaveLength(0);
   });
 
-  test("no-findings reply cannot advance a run that attempted a save and failed", async () => {
-    mockWakeResult = { invoked: true };
+  test("a spoken conclusion cannot advance a run that attempted a save and failed", async () => {
+    mockWakeResult = { invoked: true, exitReason: "no_tool_calls" };
     messagesByConversationId["fork-conv-1"] = [
       {
         role: "assistant",
@@ -1112,13 +1166,18 @@ describe("memoryRetrospectiveJob", () => {
 
     // The run demonstrably had findings (it attempted a save); the failed
     // write must stay retryable rather than being papered over by a
-    // no-findings claim.
+    // no-findings claim, and the job row must say a write was lost.
     expect(outcome.kind).toBe("no_usable_output");
+    if (outcome.kind === "no_usable_output") {
+      expect(outcome.reason).toBe(
+        "run attempted 1 memory write(s), none of which persisted a successful result",
+      );
+    }
     expect(stateUpserts).toHaveLength(0);
   });
 
   test("a remember tool_use with NO persisted tool_result is not durable evidence", async () => {
-    mockWakeResult = { invoked: true };
+    mockWakeResult = { invoked: true, exitReason: "no_tool_calls" };
     messagesByConversationId["fork-conv-1"] = [
       {
         role: "assistant",
@@ -1142,7 +1201,7 @@ describe("memoryRetrospectiveJob", () => {
   });
 
   test("retry after a no_usable_output run advances only once durable output exists", async () => {
-    mockWakeResult = { invoked: true };
+    mockWakeResult = { invoked: true, exitReason: "no_tool_calls" };
     messagesByConversationId["fork-conv-1"] = [];
 
     const first = await memoryRetrospectiveJob(makeJob(), stubConfig);

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-prompt.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-prompt.test.ts
@@ -3,13 +3,20 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
 
-import { MEMORY_RETROSPECTIVE_NO_FINDINGS_TEXT } from "../memory-retrospective-constants.js";
 import {
   buildForkInstruction,
   type ForkInstructionArgs,
   RETROSPECTIVE_INSTRUCTION_TEMPLATE,
 } from "../memory-retrospective-prompt.js";
 import { getWorkspaceDir } from "../paths.js";
+
+/**
+ * The mandate sentence as the prompt module builds it. Spelled out here
+ * rather than imported so a reworded prompt fails these expectations instead
+ * of silently agreeing with itself.
+ */
+const NO_FINDINGS_MANDATE =
+  "If nothing new is worth saving, say so briefly and stop.";
 
 function makeArgs(
   overrides: Partial<ForkInstructionArgs> = {},
@@ -48,7 +55,7 @@ Two dedup sources to skip:
 1. Anything semantically captured in <already_remembered> above (from prior retrospective passes).
 2. Anything you already called \`remember\` on inline within your review window — those appear as \`tool_use\` blocks with \`name: "remember"\` in your history.
 
-For everything else in your review window, use the \`remember\` tool on facts, plans, decisions, preferences, names, dates, felt moments, corrections, commitments, or anything else concrete and worth carrying forward. When several facts are worth saving, pass them all as an array to a single \`remember\` call rather than calling it once per fact. If nothing new is worth saving, reply with exactly "Nothing new to save." and stop.
+For everything else in your review window, use the \`remember\` tool on facts, plans, decisions, preferences, names, dates, felt moments, corrections, commitments, or anything else concrete and worth carrying forward. When several facts are worth saving, pass them all as an array to a single \`remember\` call rather than calling it once per fact. If nothing new is worth saving, say so briefly and stop.
 `);
   });
 
@@ -119,11 +126,7 @@ For everything else in your review window, use the \`remember\` tool on facts, p
   test("proc-to-skills inactive: no authoring section, instruction ends at the remember guidance", () => {
     const out = buildForkInstruction(makeArgs());
     expect(out).not.toContain("PROCEDURE");
-    expect(
-      out.endsWith(
-        'If nothing new is worth saving, reply with exactly "Nothing new to save." and stop.\n',
-      ),
-    ).toBe(true);
+    expect(out.endsWith(`${NO_FINDINGS_MANDATE}\n`)).toBe(true);
   });
 
   test("bundled template carries each placeholder exactly once", () => {
@@ -176,17 +179,13 @@ describe("promptOverridePath", () => {
     writeFileSync(overridePath, "Just remember the good parts.\n");
     expect(
       buildForkInstruction(makeArgs({ promptOverridePath: overridePath })),
-    ).toBe(
-      "Just remember the good parts.\n\n\n" +
-        `If nothing new is worth saving, reply with exactly "${MEMORY_RETROSPECTIVE_NO_FINDINGS_TEXT}" and stop.`,
-    );
+    ).toBe(`Just remember the good parts.\n\n\n${NO_FINDINGS_MANDATE}`);
   });
 
-  test("an override that drops the no-findings mandate still carries the finalizer's exact-reply contract", () => {
-    // The finalizer advances a no-findings window only on a persisted reply
-    // that trims to exactly MEMORY_RETROSPECTIVE_NO_FINDINGS_TEXT. An
-    // override author who never read that code would otherwise stall every
-    // no-findings window forever, so the mandate must survive any override.
+  test("an override that tells a no-findings pass to stay silent still carries the reply mandate", () => {
+    // A pass that saves nothing advances only on a committed reply, so an
+    // override telling it to do nothing would stall every no-findings window
+    // forever. The mandate must survive any override.
     const overridePath = join(dir, "mandate-free.md");
     writeFileSync(
       overridePath,
@@ -195,13 +194,7 @@ describe("promptOverridePath", () => {
     const out = buildForkInstruction(
       makeArgs({ promptOverridePath: overridePath }),
     );
-    expect(out).toContain(
-      `reply with exactly "${MEMORY_RETROSPECTIVE_NO_FINDINGS_TEXT}"`,
-    );
-    // The mandate references the same constant the finalizer compares
-    // against, so the two cannot drift; guard the constant's exact value here
-    // to make an accidental rewording loud.
-    expect(MEMORY_RETROSPECTIVE_NO_FINDINGS_TEXT).toBe("Nothing new to save.");
+    expect(out.endsWith(NO_FINDINGS_MANDATE)).toBe(true);
   });
 
   test("missing override file falls back to the bundled rendering", () => {
@@ -227,12 +220,9 @@ describe("promptOverridePath", () => {
   });
 });
 
-// The finalizer's explicit-no-findings gate matches persisted assistant text
-// against MEMORY_RETROSPECTIVE_NO_FINDINGS_TEXT by strict equality, and the
-// bundled instruction is what teaches the model to emit it. This guard fails
-// if either side drifts.
-test("bundled template mandates the exact no-findings sentinel the finalizer matches", () => {
-  expect(RETROSPECTIVE_INSTRUCTION_TEMPLATE).toContain(
-    `reply with exactly "${MEMORY_RETROSPECTIVE_NO_FINDINGS_TEXT}" and stop.`,
-  );
+// A pass that saves nothing advances its window only if it replies at all,
+// and the bundled instruction is what asks for that reply. The wording is
+// free; a template that stopped asking for a reply is not.
+test("bundled template asks a no-findings pass to answer rather than stay silent", () => {
+  expect(RETROSPECTIVE_INSTRUCTION_TEMPLATE).toContain(NO_FINDINGS_MANDATE);
 });

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-provider-path.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-provider-path.test.ts
@@ -17,9 +17,9 @@
  *   - `invoked: true` alone must therefore NOT advance
  *     `memory_retrospective_state`: the handler re-reads the fork's persisted
  *     rows (`collectRetrospectiveRunEvidence` → `loadRetrospectiveRunMessages`
- *     → `getMessages`) and only advances when a durable memory-writing
- *     `tool_use` (`remember` / `scaffold_managed_skill`) was persisted by THIS
- *     run.
+ *     → `getMessages`) and only advances when THIS run persisted a durable
+ *     memory-writing `tool_use` (`remember` / `scaffold_managed_skill`) or
+ *     replied and stopped on its own (a completed no-findings review).
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
@@ -481,16 +481,20 @@ describe("memoryRetrospectiveJob through the real wake + real agent loop", () =>
     expect(lastRunAtBumps).toHaveLength(0);
   });
 
-  test("clean empty reply through the real loop does not advance", async () => {
-    // Scenario C: the model answers with analysis text and no tool calls.
-    // The wake persists the text tail (visible output), but with zero
-    // durable memory-writing tool calls the gate must refuse to advance.
+  test("a text-only conclusion through the real loop advances as a no-findings pass", async () => {
+    // Scenario C: the model answers in its own words and stops without any
+    // tool call. The real loop exits on `no_tool_calls`, so the committed
+    // reply is a finished empty-handed review and the window is consumed.
     providerImpl = async () => textOnlyResponse("Nothing worth saving.");
 
     const outcome = await memoryRetrospectiveJob(makeJob(), stubConfig);
 
-    expect(outcome.kind).toBe("no_usable_output");
+    expect(outcome.kind).toBe("invoked");
+    if (outcome.kind === "invoked") {
+      expect(outcome.noFindings).toBe(true);
+    }
     expect(providerCalls.length).toBeGreaterThanOrEqual(1);
-    expect(stateUpserts).toHaveLength(0);
+    expect(stateUpserts).toHaveLength(1);
+    expect(stateUpserts[0]!.rememberedLog).toEqual([]);
   });
 });

--- a/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-wake-chain.test.ts
+++ b/assistant/src/plugins/defaults/memory/__tests__/memory-retrospective-wake-chain.test.ts
@@ -24,7 +24,9 @@
  * 2. The failed window stays retryable: a later run over the same window
  *    succeeds and advances state.
  * 3. A usable-output control advances state (cursor, remembered log) and
- *    GCs the superseded prior retrospective.
+ *    GCs the superseded prior retrospective, and a pass that reviewed its
+ *    window and had nothing to save advances it too, in whatever words the
+ *    model chose.
  * 4. A run whose checkpoint went live before a later rejection stays
  *    `invoked: true` (its side effects landed and are honored).
  */
@@ -409,9 +411,8 @@ describe("memory retrospective wake state chain (real AgentLoop)", () => {
     expect(listRetroForksOf(fixture.sourceId)).toEqual([fixture.priorRetroId]);
 
     // (2) The window stays retryable: the same slice succeeds on retry.
-    // The finalizer's usable-output gate accepts free text only when it is
-    // exactly the mandated no-findings sentinel; a verified remember write
-    // is the other accepted evidence. Use the sentinel for the control.
+    // The finalizer accepts a text-only reply as a completed empty-handed
+    // review; a verified remember write is the other accepted evidence.
     providerScript = [{ response: textResponse("Nothing new to save.") }];
     providerCallCount = 0;
     const retry = await runForkBasedRetrospective(
@@ -472,6 +473,31 @@ describe("memory retrospective wake state chain (real AgentLoop)", () => {
     ).toBe(fixture.newMessageId);
   });
 
+  test("a paraphrased empty-handed conclusion consumes the window", async () => {
+    const fixture = await stageChainFixture();
+
+    // The instruction asks a pass with nothing to save to say so; it does not
+    // dictate the sentence. The real loop ends this run on `no_tool_calls`,
+    // which is what proves the model reached its own conclusion.
+    providerScript = [
+      { response: textResponse("Nothing further to save, all covered above.") },
+    ];
+
+    const outcome = await runForkBasedRetrospective(
+      fixture.sourceId,
+      chainConfig,
+    );
+
+    expect(outcome.kind).toBe("invoked");
+    if (outcome.kind === "invoked") {
+      expect(outcome.noFindings).toBe(true);
+    }
+    const state = getRetrospectiveState(fixture.sourceId);
+    expect(state?.lastProcessedMessageId).toBe(fixture.newMessageId);
+    // A pass that saved nothing adds nothing to the dedup baseline.
+    expect(state?.rememberedLog).toEqual([PRIOR_FACT]);
+  });
+
   test("usable-output control: cursor advances, remembered log grows, prior retrospective is GC'd", async () => {
     const fixture = await stageChainFixture();
 
@@ -488,6 +514,7 @@ describe("memory retrospective wake state chain (real AgentLoop)", () => {
     expect(outcome.kind).toBe("invoked");
     if (outcome.kind === "invoked") {
       expect(outcome.cutoffMessageId).toBe(fixture.newMessageId);
+      expect(outcome.noFindings).toBe(false);
     }
 
     // (3) Real finalization against real rows: cursor advanced, this run's

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-constants.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-constants.ts
@@ -78,14 +78,3 @@ export const MEMORY_RETROSPECTIVE_ORIGIN = "memory_retrospective";
  * set from turn 1, and matched by the permission checker's origin-scoped grant.
  */
 export const SKILL_MANAGEMENT_SKILL_ID = "skill-management";
-
-/**
- * The exact reply the fork instruction mandates when a reviewed window
- * contains nothing worth saving. The finalizer treats a persisted assistant
- * text block that trims to exactly this phrase (with no memory-writing tool
- * attempts in the run) as the positive artifact of a legitimate no-findings
- * review, advancing the cursor without fabricating a memory write. Compared
- * by strict whole-block equality so analysis prose that merely mentions the
- * phrase does not qualify.
- */
-export const MEMORY_RETROSPECTIVE_NO_FINDINGS_TEXT = "Nothing new to save.";

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-job.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-job.ts
@@ -42,6 +42,7 @@
 
 import {
   addMessage,
+  type AgentLoopExitReason,
   type ContentBlock,
   type ConversationRow,
   deleteConversation,
@@ -88,7 +89,6 @@ import {
   MEMORY_RETROSPECTIVE_FORK_SOURCE,
   MEMORY_RETROSPECTIVE_GROUP_ID,
   MEMORY_RETROSPECTIVE_INSTRUCTION_KIND,
-  MEMORY_RETROSPECTIVE_NO_FINDINGS_TEXT,
   MEMORY_RETROSPECTIVE_ORIGIN,
   MEMORY_RETROSPECTIVE_SOURCE,
   SKILL_MANAGEMENT_SKILL_ID,
@@ -128,6 +128,14 @@ export const STALE_SOURCE_PROCESSING_OVERRIDE_MS = 6 * 60 * 60 * 1000;
 /** Watchdog check_name for the per-run retrospective outcome counter. */
 const MEMORY_RETROSPECTIVE_RUN_CHECK_NAME = "memory_retrospective_run";
 
+/**
+ * The agent-loop exit that means the MODEL ended the run: it answered without
+ * asking for another tool. Under every other exit something ended the run for
+ * it, so whatever it had said by then is a fragment of a review rather than a
+ * verdict on the window.
+ */
+const MODEL_DRIVEN_STOP_EXIT_REASON: AgentLoopExitReason = "no_tool_calls";
+
 export type MemoryRetrospectiveOutcome =
   | { kind: "disabled" }
   | { kind: "no_new_messages" }
@@ -142,6 +150,12 @@ export type MemoryRetrospectiveOutcome =
       cutoffMessageId: string;
       newMessageCount: number;
       followUpJobIds: string[];
+      /**
+       * The pass reviewed its window and had nothing durable to save, so it
+       * advanced the cursor without writing a memory. Separates the two
+       * shapes a healthy run takes, which the outcome kind alone conflates.
+       */
+      noFindings: boolean;
     };
 
 export async function memoryRetrospectiveJob(
@@ -176,14 +190,20 @@ export async function memoryRetrospectiveJob(
   // resolved model) is visible without log access. The emitter itself
   // never throws — the run's outcome must reach the jobs worker
   // regardless.
-  const emitRunOutcome = (outcome: string, reason?: string): void => {
+  const emitRunOutcome = (
+    outcome: string,
+    detail?: { reason?: string; noFindings?: boolean },
+  ): void => {
     try {
       recordWatchdogEvent({
         checkName: MEMORY_RETROSPECTIVE_RUN_CHECK_NAME,
         value: 1,
         detail: {
           outcome,
-          ...(reason ? { reason: reason.slice(0, 200) } : {}),
+          ...(detail?.reason ? { reason: detail.reason.slice(0, 200) } : {}),
+          ...(detail?.noFindings !== undefined
+            ? { noFindings: detail.noFindings }
+            : {}),
         },
       });
     } catch {
@@ -199,15 +219,17 @@ export async function memoryRetrospectiveJob(
       enforceUserActivityGate: true,
     });
   } catch (err) {
-    emitRunOutcome("error", err instanceof Error ? err.message : String(err));
+    emitRunOutcome("error", {
+      reason: err instanceof Error ? err.message : String(err),
+    });
     throw err;
   }
-  emitRunOutcome(
-    outcome.kind,
-    outcome.kind === "wake_failed" || outcome.kind === "no_usable_output"
-      ? outcome.reason
-      : undefined,
-  );
+  emitRunOutcome(outcome.kind, {
+    ...(outcome.kind === "wake_failed" || outcome.kind === "no_usable_output"
+      ? { reason: outcome.reason }
+      : {}),
+    ...(outcome.kind === "invoked" ? { noFindings: outcome.noFindings } : {}),
+  });
   return outcome;
 }
 
@@ -493,6 +515,7 @@ export async function runForkBasedRetrospective(
   // persisted message — the wake's hint sandwich would only duplicate it.
   let wakeSucceeded = false;
   let failureReason: string | undefined;
+  let wakeExitReason: AgentLoopExitReason | undefined;
   let threw: unknown;
   try {
     const result = await wakeAgentForOpportunity({
@@ -562,6 +585,7 @@ export async function runForkBasedRetrospective(
     });
     wakeSucceeded = result.invoked;
     failureReason = result.reason;
+    wakeExitReason = result.exitReason;
   } catch (err) {
     threw = err;
     failureReason = err instanceof Error ? err.message : String(err);
@@ -576,15 +600,20 @@ export async function runForkBasedRetrospective(
     // went live, not that the run produced anything. The agent loop swallows
     // provider rejections into a normal no-output return, an exhausted output
     // budget can stop a run before any visible text or tool call, and a
-    // model may reply with analysis (or nothing) without saving. Advancement
-    // past the window therefore requires POSITIVE evidence from THIS run,
-    // one of:
+    // model may stop mid-review without saving. Advancement past the window
+    // therefore requires POSITIVE evidence from THIS run, one of:
     //   - a memory-writing tool call on the fork's post-boundary tail whose
     //     execution verifiably succeeded (matching non-error tool_result), or
-    //   - the explicit no-findings reply the instruction mandates (an
-    //     assistant text block that is exactly the sentinel phrase), with no
-    //     memory-writing tool attempts at all; a run that attempted a save
-    //     and failed cannot advance by also claiming no findings.
+    //   - a reviewed-and-nothing-to-save pass: the model answered in its own
+    //     words (a committed assistant text block), attempted no memory
+    //     write at all, and the loop ended because IT stopped asking for
+    //     tools rather than because something cut the run short. A run that
+    //     attempted a save and failed cannot advance by talking instead, and
+    //     a run the provider or the output ceiling ended mid-review has not
+    //     reviewed its window.
+    // The proof of an empty-handed review is the shape of the run, never the
+    // wording of the reply: a model that reaches its own end with nothing to
+    // write has reviewed the window, in whatever words it says so.
     // The evidence read is run-specific by construction
     // (`loadRetrospectiveRunMessages` scopes to rows after the fork
     // boundary), so a prior run's persisted saves can never satisfy it, and
@@ -596,8 +625,9 @@ export async function runForkBasedRetrospective(
     // remains retryable.
     const runEvidence = await collectRetrospectiveRunEvidence(forkId);
     const reviewedNoFindings =
-      runEvidence.explicitNoFindings &&
-      runEvidence.durableToolAttemptCount === 0;
+      runEvidence.committedTextReply &&
+      runEvidence.durableToolAttemptCount === 0 &&
+      wakeExitReason === MODEL_DRIVEN_STOP_EXIT_REASON;
     if (runEvidence.durableToolCallCount === 0 && !reviewedNoFindings) {
       log.warn(
         {
@@ -605,9 +635,12 @@ export async function runForkBasedRetrospective(
           forkId,
           newMessageCount: newMessages.length,
           durableToolAttempts: runEvidence.durableToolAttemptCount,
+          committedTextReply: runEvidence.committedTextReply,
+          exitReason: wakeExitReason ?? null,
         },
-        "memory-retrospective (fork): run produced neither a verified durable write nor an explicit no-findings reply; leaving window retryable",
+        "memory-retrospective (fork): run produced neither a verified durable write nor a completed empty-handed review; leaving window retryable",
       );
+      failureReason = describeUnusableRun(runEvidence, wakeExitReason);
     } else {
       return await finalizeSuccessfulRetrospective({
         config,
@@ -618,11 +651,11 @@ export async function runForkBasedRetrospective(
         prior,
         priorRemembers,
         runRemembers: runEvidence.remembers,
+        noFindings: reviewedNoFindings,
         logFields: {
           kind: "fork",
           windowStartTimestamp,
           durationMs: Date.now() - startedAtMs,
-          noFindings: reviewedNoFindings,
         },
       });
     }
@@ -642,17 +675,40 @@ export async function runForkBasedRetrospective(
   }
 
   if (wakeSucceeded) {
+    // Reached only through the evidence gate above, which set `failureReason`
+    // to why the run could not consume its window.
     return {
       kind: "no_usable_output",
-      reason: failureReason ?? "run persisted no memory-writing tool call",
+      reason: failureReason,
       conversationId: forkId,
     };
   }
+
   return {
     kind: "wake_failed",
     reason: failureReason,
     conversationId: forkId,
   };
+}
+
+/**
+ * Why a run that went live still could not consume its window, phrased for
+ * the job row's `last_error` and the CLI. The distinction it draws is the one
+ * an operator needs: a lost memory write reads differently from a review that
+ * never reached a conclusion, and the fork is deleted on failure, so this
+ * string is what survives the run.
+ */
+function describeUnusableRun(
+  evidence: { durableToolAttemptCount: number; committedTextReply: boolean },
+  exitReason: AgentLoopExitReason | undefined,
+): string {
+  if (evidence.durableToolAttemptCount > 0) {
+    return `run attempted ${evidence.durableToolAttemptCount} memory write(s), none of which persisted a successful result`;
+  }
+  if (!evidence.committedTextReply) {
+    return "run committed neither a memory write nor a reply";
+  }
+  return `run replied without saving anything, but ended on ${exitReason ?? "no terminal exit"} rather than a completed review`;
 }
 
 function enqueueFollowUpJobs(): string[] {
@@ -862,6 +918,8 @@ async function finalizeSuccessfulRetrospective(args: {
    * advancement is exactly the evidence folded into the log.
    */
   runRemembers: string[];
+  /** Whether the run advanced on a reviewed-and-nothing-to-save pass. */
+  noFindings: boolean;
   /** Per-kind extras for the success log line (e.g. `kind`, fork anchor). */
   logFields: Record<string, unknown>;
 }): Promise<MemoryRetrospectiveOutcome> {
@@ -874,6 +932,7 @@ async function finalizeSuccessfulRetrospective(args: {
     prior,
     priorRemembers,
     runRemembers,
+    noFindings,
     logFields,
   } = args;
 
@@ -901,6 +960,7 @@ async function finalizeSuccessfulRetrospective(args: {
       cutoffMessageId,
       newMessageCount,
       priorRememberCount: priorRemembers.length,
+      noFindings,
       ...logFields,
     },
     "memory-retrospective invoked",
@@ -911,6 +971,7 @@ async function finalizeSuccessfulRetrospective(args: {
     cutoffMessageId,
     newMessageCount,
     followUpJobIds,
+    noFindings,
   };
 }
 
@@ -1119,12 +1180,12 @@ async function collectRetrospectiveRunEvidence(
   /** Memory-writing tool calls the run attempted, regardless of outcome. */
   durableToolAttemptCount: number;
   /**
-   * The run replied with exactly the mandated no-findings sentinel text
-   * ({@link MEMORY_RETROSPECTIVE_NO_FINDINGS_TEXT}) in a persisted assistant
-   * text block. Strict whole-block equality: prose that merely mentions the
-   * phrase does not qualify, so an analysis-only reply stays unusable.
+   * The run answered in its own words: a persisted assistant text block with
+   * non-whitespace content. Any wording qualifies, so a pass that found
+   * nothing durable proves it reviewed the window by replying at all, not by
+   * reproducing a phrase.
    */
-  explicitNoFindings: boolean;
+  committedTextReply: boolean;
 }> {
   const conv = await getConversation(conversationId);
   const runMessages = await loadRetrospectiveRunMessages(
@@ -1136,7 +1197,7 @@ async function collectRetrospectiveRunEvidence(
       remembers: [],
       durableToolCallCount: 0,
       durableToolAttemptCount: 0,
-      explicitNoFindings: false,
+      committedTextReply: false,
     };
   }
   const succeededIds = collectSuccessfulToolResultIds(runMessages);
@@ -1144,18 +1205,19 @@ async function collectRetrospectiveRunEvidence(
     remembers: extractRememberContents(runMessages, succeededIds),
     durableToolCallCount: countDurableToolUses(runMessages, succeededIds),
     durableToolAttemptCount: countDurableToolUses(runMessages, null),
-    explicitNoFindings: hasExplicitNoFindingsReply(runMessages),
+    committedTextReply: hasCommittedTextReply(runMessages),
   };
 }
 
 /**
  * Whether any persisted assistant row on the run's tail carries a text block
- * that is exactly the no-findings sentinel (after trimming). The instruction
- * template mandates this exact reply for a reviewed-and-nothing-to-save
- * pass, making it the positive persisted artifact that distinguishes a
- * legitimate no-findings review from an empty or unusable response.
+ * with non-whitespace content. Paired with a model-driven stop and zero
+ * memory-write attempts, that reply is the persisted artifact of a pass that
+ * read its window and had nothing to save: the model spoke and then chose to
+ * end the run. It separates such a pass from a response that committed
+ * nothing at all (thinking-only output, an empty content array).
  */
-function hasExplicitNoFindingsReply(messages: MessageLike[]): boolean {
+function hasCommittedTextReply(messages: MessageLike[]): boolean {
   for (const msg of messages) {
     if (msg.role !== "assistant") {
       continue;
@@ -1179,7 +1241,7 @@ function hasExplicitNoFindingsReply(messages: MessageLike[]): boolean {
       if (
         b.type === "text" &&
         typeof b.text === "string" &&
-        b.text.trim() === MEMORY_RETROSPECTIVE_NO_FINDINGS_TEXT
+        b.text.trim() !== ""
       ) {
         return true;
       }

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-job.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-job.ts
@@ -604,13 +604,14 @@ export async function runForkBasedRetrospective(
     // therefore requires POSITIVE evidence from THIS run, one of:
     //   - a memory-writing tool call on the fork's post-boundary tail whose
     //     execution verifiably succeeded (matching non-error tool_result), or
-    //   - a reviewed-and-nothing-to-save pass: the model answered in its own
-    //     words (a committed assistant text block), attempted no memory
-    //     write at all, and the loop ended because IT stopped asking for
-    //     tools rather than because something cut the run short. A run that
-    //     attempted a save and failed cannot advance by talking instead, and
-    //     a run the provider or the output ceiling ended mid-review has not
-    //     reviewed its window.
+    //   - a reviewed-and-nothing-to-save pass: the model ENDED the run by
+    //     answering in its own words (its final assistant row carries text),
+    //     attempted no memory write at all, and the loop ended because IT
+    //     stopped asking for tools rather than because something cut the run
+    //     short. A run that attempted a save and failed cannot advance by
+    //     talking instead, a run whose narration went live but whose final
+    //     response was empty has not concluded, and a run the provider or
+    //     the output ceiling ended mid-review has not reviewed its window.
     // The proof of an empty-handed review is the shape of the run, never the
     // wording of the reply: a model that reaches its own end with nothing to
     // write has reviewed the window, in whatever words it says so.
@@ -706,7 +707,7 @@ function describeUnusableRun(
     return `run attempted ${evidence.durableToolAttemptCount} memory write(s), none of which persisted a successful result`;
   }
   if (!evidence.committedTextReply) {
-    return "run committed neither a memory write nor a reply";
+    return "run committed neither a memory write nor a concluding reply";
   }
   return `run replied without saving anything, but ended on ${exitReason ?? "no terminal exit"} rather than a completed review`;
 }
@@ -1180,10 +1181,12 @@ async function collectRetrospectiveRunEvidence(
   /** Memory-writing tool calls the run attempted, regardless of outcome. */
   durableToolAttemptCount: number;
   /**
-   * The run answered in its own words: a persisted assistant text block with
-   * non-whitespace content. Any wording qualifies, so a pass that found
-   * nothing durable proves it reviewed the window by replying at all, not by
-   * reproducing a phrase.
+   * The run ENDED by answering in its own words: the last persisted
+   * assistant row carries a text block with non-whitespace content. Any
+   * wording qualifies, so a pass that found nothing durable proves it
+   * reviewed the window by replying, not by reproducing a phrase; but the
+   * reply must be the run's final word, so narration followed by an empty
+   * last response does not qualify.
    */
   committedTextReply: boolean;
 }> {
@@ -1210,42 +1213,29 @@ async function collectRetrospectiveRunEvidence(
 }
 
 /**
- * Whether any persisted assistant row on the run's tail carries a text block
- * with non-whitespace content. Paired with a model-driven stop and zero
- * memory-write attempts, that reply is the persisted artifact of a pass that
- * read its window and had nothing to save: the model spoke and then chose to
- * end the run. It separates such a pass from a response that committed
- * nothing at all (thinking-only output, an empty content array).
+ * Whether the LAST persisted assistant row on the run's tail carries a text
+ * block with non-whitespace content. Paired with a model-driven stop and
+ * zero memory-write attempts, that closing reply is the persisted artifact
+ * of a pass that read its window and had nothing to save: the model spoke
+ * and then chose to end the run. Reading only the final row separates it
+ * from a run whose narration went live but whose actual conclusion was
+ * empty, as well as from a response that committed nothing at all
+ * (thinking-only output, an empty content array).
  */
 function hasCommittedTextReply(messages: MessageLike[]): boolean {
-  for (const msg of messages) {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i]!;
     if (msg.role !== "assistant") {
       continue;
     }
-    let blocks: unknown = msg.content;
-    if (typeof blocks === "string") {
-      try {
-        blocks = JSON.parse(blocks);
-      } catch {
-        continue;
-      }
+    const blocks = parseMessageBlocks(msg);
+    if (blocks === null) {
+      return false;
     }
-    if (!Array.isArray(blocks)) {
-      continue;
-    }
-    for (const block of blocks) {
-      if (!block || typeof block !== "object") {
-        continue;
-      }
-      const b = block as Record<string, unknown>;
-      if (
-        b.type === "text" &&
-        typeof b.text === "string" &&
-        b.text.trim() !== ""
-      ) {
-        return true;
-      }
-    }
+    return blocks.some(
+      (b) =>
+        b.type === "text" && typeof b.text === "string" && b.text.trim() !== "",
+    );
   }
   return false;
 }
@@ -1261,22 +1251,7 @@ function collectSuccessfulToolResultIds(messages: MessageLike[]): Set<string> {
     if (msg.role !== "user") {
       continue;
     }
-    let blocks: unknown = msg.content;
-    if (typeof blocks === "string") {
-      try {
-        blocks = JSON.parse(blocks);
-      } catch {
-        continue;
-      }
-    }
-    if (!Array.isArray(blocks)) {
-      continue;
-    }
-    for (const block of blocks) {
-      if (!block || typeof block !== "object") {
-        continue;
-      }
-      const b = block as Record<string, unknown>;
+    for (const b of parseMessageBlocks(msg) ?? []) {
       // guard:allow-tool-result-only: success evidence for locally-executed
       // durable memory tools; server-side web_search_tool_result never
       // corresponds to a durable write and carries no is_error flag.
@@ -1308,22 +1283,7 @@ function countDurableToolUses(
     if (msg.role !== "assistant") {
       continue;
     }
-    let blocks: unknown = msg.content;
-    if (typeof blocks === "string") {
-      try {
-        blocks = JSON.parse(blocks);
-      } catch {
-        continue;
-      }
-    }
-    if (!Array.isArray(blocks)) {
-      continue;
-    }
-    for (const block of blocks) {
-      if (!block || typeof block !== "object") {
-        continue;
-      }
-      const b = block as Record<string, unknown>;
+    for (const b of parseMessageBlocks(msg) ?? []) {
       if (
         b.type === "tool_use" &&
         DURABLE_RETROSPECTIVE_TOOLS.has(String(b.name)) &&
@@ -1343,6 +1303,32 @@ interface MessageLike {
 }
 
 /**
+ * Parse a message row's content into its block objects, or `null` when the
+ * content is malformed (unparseable JSON, not an array). Non-object entries
+ * are dropped. Every evidence reader in this module goes through this so
+ * malformed rows degrade the same way everywhere: skipped, not propagated.
+ */
+function parseMessageBlocks(
+  msg: MessageLike,
+): Record<string, unknown>[] | null {
+  let blocks: unknown = msg.content;
+  if (typeof blocks === "string") {
+    try {
+      blocks = JSON.parse(blocks);
+    } catch {
+      return null;
+    }
+  }
+  if (!Array.isArray(blocks)) {
+    return null;
+  }
+  return blocks.filter(
+    (block): block is Record<string, unknown> =>
+      typeof block === "object" && block !== null,
+  );
+}
+
+/**
  * Scan an array of message rows for `tool_use` blocks where `name` is
  * `"remember"` and return the `input.content` strings in order. Robust to
  * malformed content JSON — unparseable rows are skipped, not propagated.
@@ -1356,22 +1342,7 @@ function extractRememberContents(
     if (msg.role !== "assistant") {
       continue;
     }
-    let blocks: unknown = msg.content;
-    if (typeof blocks === "string") {
-      try {
-        blocks = JSON.parse(blocks);
-      } catch {
-        continue;
-      }
-    }
-    if (!Array.isArray(blocks)) {
-      continue;
-    }
-    for (const block of blocks) {
-      if (!block || typeof block !== "object") {
-        continue;
-      }
-      const b = block as Record<string, unknown>;
+    for (const b of parseMessageBlocks(msg) ?? []) {
       if (b.type !== "tool_use") {
         continue;
       }

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-prompt.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-prompt.ts
@@ -150,8 +150,8 @@ export interface ForkInstructionArgs {
  * the shared {@link loadPromptOverride}), else the bundled
  * {@link RETROSPECTIVE_INSTRUCTION_TEMPLATE}; both get the same placeholder
  * substitution. An override additionally gets the no-findings mandate
- * appended after its body: the exact-reply sentinel is the finalizer's
- * advancement contract, so it holds regardless of what the override says.
+ * appended after its body: a no-findings pass advances only by replying,
+ * so the ask-for-a-reply holds regardless of what the override says.
  */
 export function buildForkInstruction({
   windowStartTimestamp,

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-prompt.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-prompt.ts
@@ -27,7 +27,6 @@
  */
 
 import { getLogger } from "./logging.js";
-import { MEMORY_RETROSPECTIVE_NO_FINDINGS_TEXT } from "./memory-retrospective-constants.js";
 import { getWorkspaceDir } from "./paths.js";
 import { loadPromptOverride } from "./prompt-override.js";
 
@@ -45,11 +44,13 @@ function neutralizeSentinels(s: string): string {
 }
 
 /**
- * The sentence mandating the exact no-findings reply. Built from
- * {@link MEMORY_RETROSPECTIVE_NO_FINDINGS_TEXT} so the instruction and the
- * finalizer's acceptance check can never drift apart.
+ * The sentence asking a pass that found nothing to say so and stop. The
+ * finalizer reads the SHAPE of such a run (a committed reply, no memory-write
+ * attempts, a model-driven stop), so the wording is free; what the sentence
+ * buys is a run that answers at all rather than committing nothing.
  */
-const NO_FINDINGS_MANDATE = `If nothing new is worth saving, reply with exactly "${MEMORY_RETROSPECTIVE_NO_FINDINGS_TEXT}" and stop.`;
+const NO_FINDINGS_MANDATE =
+  "If nothing new is worth saving, say so briefly and stop.";
 
 /**
  * Bundled fork-instruction template. Exported so tests (and any future
@@ -199,12 +200,11 @@ export function buildForkInstruction({
   if (override == null) {
     return rendered;
   }
-  // The finalizer recognizes a no-findings review only by the exact
-  // MEMORY_RETROSPECTIVE_NO_FINDINGS_TEXT reply, so the mandate is part of
-  // the advancement contract, not prompt styling: an override body that
-  // drops it would leave every no-findings window permanently retryable.
-  // Appended outside the override so a custom prompt cannot break the
-  // contract.
+  // A pass that saves nothing advances only on a committed reply, so the
+  // mandate is part of the advancement contract, not prompt styling: an
+  // override body that leaves a no-findings pass free to answer with nothing
+  // at all would leave those windows permanently retryable. Appended outside
+  // the override so a custom prompt cannot break the contract.
   return `${rendered}\n\n${NO_FINDINGS_MANDATE}`;
 }
 

--- a/assistant/src/runtime/__tests__/agent-wake.test.ts
+++ b/assistant/src/runtime/__tests__/agent-wake.test.ts
@@ -1750,7 +1750,13 @@ describe("wakeAgentForOpportunity", () => {
       { resolveTarget: async () => conversation },
     );
 
-    expect(result).toEqual({ invoked: true, producedToolCalls: false });
+    // The result carries how the run ended, so a caller that treats output as
+    // a finished answer can see that something else ended this one.
+    expect(result).toEqual({
+      invoked: true,
+      producedToolCalls: false,
+      exitReason: "error",
+    });
     // The checkpoint's flush pushed + persisted the partial tail.
     expect(conversation.pushedMessages.length).toBeGreaterThan(0);
     expect(conversation.persistedTailCalls.length).toBeGreaterThan(0);
@@ -1772,7 +1778,11 @@ describe("wakeAgentForOpportunity", () => {
       { resolveTarget: async () => conversation },
     );
 
-    expect(result).toEqual({ invoked: true, producedToolCalls: false });
+    expect(result).toEqual({
+      invoked: true,
+      producedToolCalls: false,
+      exitReason: "no_tool_calls",
+    });
   });
 
   test("reports no_output on a clean empty reply when the caller requires usable output", async () => {

--- a/assistant/src/runtime/agent-wake.ts
+++ b/assistant/src/runtime/agent-wake.ts
@@ -1065,6 +1065,10 @@ export async function wakeAgentForOpportunity(
     // catch turns provider rejections and unhandled throws into a graceful
     // no-output stop instead of rethrowing).
     let terminalExitReason: AgentLoopExitReason | null = null;
+    // The `exitReason` field for an `invoked: true` result: present exactly
+    // when the loop reported a terminal exit.
+    const exitReasonField = (): { exitReason?: AgentLoopExitReason } =>
+      terminalExitReason !== null ? { exitReason: terminalExitReason } : {};
     const persistLog = (record: PendingLog): void => {
       try {
         recordRequestLog(
@@ -1575,9 +1579,7 @@ export async function wakeAgentForOpportunity(
         return {
           invoked: true,
           producedToolCalls: false,
-          ...(terminalExitReason !== null
-            ? { exitReason: terminalExitReason }
-            : {}),
+          ...exitReasonField(),
         };
       } finally {
         // Restore the pre-wake values so a queued user turn or background read
@@ -1678,9 +1680,7 @@ export async function wakeAgentForOpportunity(
         return {
           invoked: true,
           producedToolCalls: false,
-          ...(terminalExitReason !== null
-            ? { exitReason: terminalExitReason }
-            : {}),
+          ...exitReasonField(),
         };
       }
 
@@ -1716,13 +1716,7 @@ export async function wakeAgentForOpportunity(
       });
       drainedInTry = true;
 
-      return {
-        invoked: true,
-        producedToolCalls,
-        ...(terminalExitReason !== null
-          ? { exitReason: terminalExitReason }
-          : {}),
-      };
+      return { invoked: true, producedToolCalls, ...exitReasonField() };
     } finally {
       // Put the conversation's resting trust back on every exit path.
       restorePersistentWakeTrust();

--- a/assistant/src/runtime/agent-wake.ts
+++ b/assistant/src/runtime/agent-wake.ts
@@ -459,6 +459,20 @@ export interface WakeResult {
   producedToolCalls: boolean;
   /** Present only when `invoked: false`; identifies why the wake was skipped. */
   reason?: WakeSkipReason;
+  /**
+   * How the agent loop terminated, from its `agent_loop_exit` event. Set on
+   * `invoked: true` results whose loop reported a terminal exit, and absent
+   * when it reported none (a checkpoint handoff, whose run resumes
+   * separately).
+   *
+   * `"no_tool_calls"` is the model-driven stop: the run finished because the
+   * assistant answered without asking for another tool. Every other reason
+   * means something ended the run for it (cancellation, an output-token
+   * ceiling, an unhandled error), so a caller reading the run's output as a
+   * complete conclusion has to tell them apart: the memory retrospective
+   * accepts a reviewed-nothing-to-save pass only on a model-driven stop.
+   */
+  exitReason?: AgentLoopExitReason;
 }
 
 /**
@@ -1558,7 +1572,13 @@ export async function wakeAgentForOpportunity(
             reason: "run_error" as const,
           };
         }
-        return { invoked: true, producedToolCalls: false };
+        return {
+          invoked: true,
+          producedToolCalls: false,
+          ...(terminalExitReason !== null
+            ? { exitReason: terminalExitReason }
+            : {}),
+        };
       } finally {
         // Restore the pre-wake values so a queued user turn or background read
         // never observes the wake's stamps. (`runAgentLoopImpl` re-stamps both
@@ -1655,7 +1675,13 @@ export async function wakeAgentForOpportunity(
         // since checkpoints only fire after tool turns and there were
         // none.) The finally still kicks the queue drain so a racy queued
         // message isn't stranded.
-        return { invoked: true, producedToolCalls: false };
+        return {
+          invoked: true,
+          producedToolCalls: false,
+          ...(terminalExitReason !== null
+            ? { exitReason: terminalExitReason }
+            : {}),
+        };
       }
 
       tailMessageCount = tailMessages.length;
@@ -1690,7 +1716,13 @@ export async function wakeAgentForOpportunity(
       });
       drainedInTry = true;
 
-      return { invoked: true, producedToolCalls };
+      return {
+        invoked: true,
+        producedToolCalls,
+        ...(terminalExitReason !== null
+          ? { exitReason: terminalExitReason }
+          : {}),
+      };
     } finally {
       // Put the conversation's resting trust back on every exit path.
       restorePersistentWakeTrust();

--- a/assistant/src/runtime/routes/wake-conversation-routes.ts
+++ b/assistant/src/runtime/routes/wake-conversation-routes.ts
@@ -94,7 +94,7 @@ export const ROUTES: RouteDefinition[] = [
           ? (getSchedule(scheduleId)?.inferenceProfile ?? null)
           : null;
 
-      return wakeAgentForOpportunity({
+      const result = await wakeAgentForOpportunity({
         conversationId,
         hint,
         source,
@@ -108,6 +108,13 @@ export const ROUTES: RouteDefinition[] = [
           ? { untrustedOutput: { content: externalContent, source: "webhook" } }
           : {}),
       });
+      // Pin the wire shape to the declared responseBody: WakeResult carries
+      // in-process diagnostics (exitReason) beyond this route's contract.
+      return {
+        invoked: result.invoked,
+        producedToolCalls: result.producedToolCalls,
+        ...(result.reason !== undefined ? { reason: result.reason } : {}),
+      };
     },
   },
 ];


### PR DESCRIPTION
Fixes LUM-3367

## TL;DR

A memory retrospective that reviewed its window and correctly concluded "nothing new to save" only counted as a success if its reply was byte-identical to the sentinel `Nothing new to save.`. Any equivalent phrasing was recorded as a failure, so the window never advanced and re-queued forever. The finalizer now judges the **shape of the run** (a committed reply as the run's final word + zero memory-write attempts + a model-driven stop) instead of the wording of the reply, and the sentinel is gone.

## What changes for the user

| Before | After |
| -- | -- |
| A retrospective pass that found nothing but phrased it as e.g. "Nothing else new to save." or "Done." was logged as a failure and retried forever, burning tokens on every retry | Any completed empty-handed review advances the window, whatever words the model chose |
| Retrospective failure metrics looked like memory loss (~10% of runs on the measured workspace were these false failures) | The failure bucket contains only real failures; healthy no-findings passes are counted as successes with a `noFindings` marker on the watchdog event, log line, outcome, and CLI output |
| `last_error` was one constant string, so a lost write and a phrasing miss were indistinguishable after the fact (the fork is deleted on failure) | `no_usable_output` reasons say which it was: "attempted N memory write(s), none persisted", "committed neither a memory write nor a concluding reply", or "replied but ended on <exit> rather than a completed review" |
| The prompt mandated reproducing an exact sentence, which occasionally got saved *as* a memory (JARVIS-1515) | The prompt asks the pass to "say so briefly and stop"; there is no magic phrase to leak |

## How it works

The gate needed a way to distinguish "the model finished its review and had nothing to write" from "something cut the run short after it happened to emit text". That signal already exists: the agent loop's terminal `agent_loop_exit` reason. `WakeResult` now carries it (`exitReason`, set on `invoked: true` when the loop reported a terminal exit), and the retrospective accepts a no-findings pass only on `no_tool_calls`, the model-driven stop. This also aligns with the repo's Assistant-Driven Judgement rule: the model's own conclusion, not a string match, decides.

Fail-closed behavior is preserved in every direction:

- a run that **attempted** a save whose execution failed still cannot advance by talking instead (unchanged);
- a run ended by the provider, cancellation, or the output-token ceiling mid-review fails and stays retryable, even if its persisted text reads like a conclusion (new: previously such a run could advance if it happened to emit the exact sentinel before dying);
- thinking-only / empty-content runs still fail via `requireUsableOutput` (unchanged);
- a wake with no terminal exit event (checkpoint handoff) cannot advance on text (new);
- narration that went live mid-run followed by an empty final response is not a conclusion (new).

## Alternatives considered

A "model-owned explicit outcome" instead of shape-evidence was considered and rejected: an exact reply string is the LUM-3367 bug itself (55 of 73 correct conclusions failed it); a dedicated outcome tool conflicts with the no-new-tool-registrations direction (`assistant/src/tools/AGENTS.md`) and the wake's pinned wire tool surface (cache parity); extending `remember`'s schema with a "nothing new" form mutates a wire-visible tool every surface uses for one background caller's bookkeeping. Semantic parsing of the reply is the string-matching anti-pattern the Assistant-Driven Judgement rule (root `AGENTS.md`) forbids. The final-reply + zero-attempts + model-driven-stop shape is the model-owned outcome: the model concluded in its own words and chose to end the run.

## Why this is safe

- The strict-sentinel path was a subset of the new acceptance: every run that advanced before still advances (exact sentinel text = committed reply, and a text-only reply exits `no_tool_calls`). The change only reclassifies runs that were previously false failures, plus tightens the cut-short case above.
- `exitReason` is additive on `WakeResult`; no other caller reads it, and no caller's existing fields change.
- The `memory_retrospective_run` watchdog contract keeps its check name and outcome buckets; `noFindings` is an added detail key.
- Covered at three levels: unit tests over the finalizer gate (paraphrased replies advance; max-tokens/mixed/whitespace/no-exit runs do not), the real-`AgentLoop` provider-path and wake-chain suites (a paraphrased conclusion consumes the window end to end), and the agent-wake tests asserting `exitReason` propagation.

## Measured impact (from the ticket)

On the dogfood workspace, 2026-08-10 → 08-19: 64 logged failures, of which 57 had `durableToolAttempts: 0` — correct no-findings conclusions stuck in permanent re-queue. Real health split once replies are read: 84.3% wrote / 10.2% correct-nothing-new / 5.5% failed.

## Existing failed windows

No migration needed. The dead-lettered job rows stay as historical records (the queue never retries them by design); the stuck state is just a cursor that never advanced, with all unsaved material still in front of it. On the next trigger or sweep pass an active conversation's window is re-enqueued and the first completed pass consumes it; windows on dormant conversations wait for activity, per the pre-existing lookback gate.

## Deferred

- LUM-3005 (whether a retrospective should fire at all) and JARVIS-1553 (sustained failure surfaces nothing) are adjacent and untouched.
