### PR TITLE
Reduce the Doctor header to two icon buttons

### DIFF
--- a/clients/web/src/components/detail-panel-stop-button.tsx
+++ b/clients/web/src/components/detail-panel-stop-button.tsx
@@ -1,7 +1,7 @@
 /**
- * Icon-only danger "Stop" control for detail-panel headers (subagent,
- * workflow, background task, ACP run). A bordered square button holding a
- * square glyph, the shared right-aligned header control. Keeping every panel
+ * Icon-only danger "Stop" control for panel headers (subagent, workflow,
+ * background task, ACP run, Doctor session). A bordered square button holding
+ * a square glyph, the shared right-aligned header control. Keeping every panel
  * on this one component stops their headers from drifting apart.
  *
  * Corner radius and glyph size are both the design-library defaults (no
@@ -36,7 +36,7 @@ export function DetailPanelStopButton({
   ariaLabel,
   disabled,
 }: DetailPanelStopButtonProps) {
-  const { t } = useTranslation("chat");
+  const { t } = useTranslation();
   return (
     <Button
       variant="dangerOutline"

--- a/clients/web/src/domains/chat/components/acp-run-chat-view/acp-run-chat-view.tsx
+++ b/clients/web/src/domains/chat/components/acp-run-chat-view/acp-run-chat-view.tsx
@@ -52,7 +52,7 @@ import { CommandOutputView } from "@/domains/chat/components/acp-run-chat-view/c
 import { FileDiffView } from "@/domains/chat/components/acp-run-chat-view/file-diff-view";
 import { useStickToBottom } from "@/domains/chat/components/acp-run-chat-view/use-stick-to-bottom";
 import { AcpAgentIcon } from "@/domains/chat/components/acp-run-inline-card/acp-agent-icon";
-import { DetailPanelStopButton } from "@/domains/chat/components/detail-panel-stop-button";
+import { DetailPanelStopButton } from "@/components/detail-panel-stop-button";
 import {
   AnimatedMetricCard,
   formatNumber,

--- a/clients/web/src/domains/chat/components/background-task-detail-panel/background-task-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/background-task-detail-panel/background-task-detail-panel.tsx
@@ -14,7 +14,7 @@ import { Typography } from "@vellumai/design-library";
 
 import { BackgroundTaskStatusBadge } from "@/domains/chat/components/background-task-status-badge";
 import { backgroundTaskGlyph } from "@/domains/chat/components/background-task-glyph";
-import { DetailPanelStopButton } from "@/domains/chat/components/detail-panel-stop-button";
+import { DetailPanelStopButton } from "@/components/detail-panel-stop-button";
 import { DetailShell } from "@/components/detail-shell";
 import {
   CodeBlock,

--- a/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/subagent-detail-panel.tsx
@@ -33,7 +33,7 @@ import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-component
 import { Button, Typography } from "@vellumai/design-library";
 
 import { ChatMarkdownMessage } from "@/domains/chat/components/chat-markdown-message";
-import { DetailPanelStopButton } from "@/domains/chat/components/detail-panel-stop-button";
+import { DetailPanelStopButton } from "@/components/detail-panel-stop-button";
 import { SubagentPhaseTimeline } from "@/domains/chat/components/subagent-phase-timeline";
 import {
   deriveStepLabelFromName,

--- a/clients/web/src/domains/chat/components/workflow-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/workflow-detail-panel.tsx
@@ -13,7 +13,7 @@ import { motion, useReducedMotion } from "motion/react";
 
 import { AvatarRenderer } from "@/components/avatar-renderer";
 import { DetailShell } from "@/components/detail-shell";
-import { DetailPanelStopButton } from "@/domains/chat/components/detail-panel-stop-button";
+import { DetailPanelStopButton } from "@/components/detail-panel-stop-button";
 import {
   AnimatedMetricCard,
   formatNumber,

--- a/clients/web/src/domains/settings/components/panels/doctor-panel.tsx
+++ b/clients/web/src/domains/settings/components/panels/doctor-panel.tsx
@@ -1,9 +1,10 @@
-import { ArrowUp, ChevronDown, Loader2, Play, Square } from "lucide-react";
+import { ArrowUp, ChevronDown, Loader2, Play } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { Button } from "@vellumai/design-library/components/button";
 
+import { DetailPanelStopButton } from "@/components/detail-panel-stop-button";
 import { ShareFeedbackModal } from "@/components/share-feedback-modal";
 import type { FeedbackReason } from "@/components/share-feedback-types";
 import { AssistantBackups } from "@/domains/settings/components/assistant-backups";
@@ -685,14 +686,10 @@ export function DoctorPanel() {
             onCopySession={entries.length > 0 ? handleCopySession : undefined}
           />
           {isSessionActive && (
-            <button
-              type="button"
-              onClick={handleEndSession}
-              className="flex cursor-pointer items-center gap-1.5 rounded border border-[var(--system-negative-strong)] px-3 py-1.5 text-body-small-default text-[var(--system-negative-strong)] transition-colors hover:bg-[var(--system-negative-weak)] disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              <Square className="h-3 w-3" />
-              {t("doctorPanel.endSession")}
-            </button>
+            <DetailPanelStopButton
+              onStop={handleEndSession}
+              ariaLabel={t("doctorPanel.endSession")}
+            />
           )}
         </div>
       </div>

--- a/clients/web/src/domains/settings/components/panels/doctor-session-menu.tsx
+++ b/clients/web/src/domains/settings/components/panels/doctor-session-menu.tsx
@@ -47,7 +47,10 @@ export function DoctorSessionMenu({
       <ActionMenu.Trigger asChild>
         <Button
           variant="ghost"
-          size="compact"
+          size="regular"
+          // Without this a ghost icon-only button paints a filled circle on a
+          // touch surface, which is the chrome the header is trying to shed.
+          expandOnMobile={false}
           iconOnly={<EllipsisVertical />}
           aria-label={title}
         />

--- a/clients/web/src/i18n/locales/en/chat.json
+++ b/clients/web/src/i18n/locales/en/chat.json
@@ -553,9 +553,6 @@
     "title": "Delete conversation",
     "untitled": "Untitled"
   },
-  "detailPanelStopButton": {
-    "tooltip": "Stop"
-  },
   "documentAssetActions": {
     "pdfDownloadFailed": "Failed to download PDF"
   },

--- a/clients/web/src/i18n/locales/en/common.json
+++ b/clients/web/src/i18n/locales/en/common.json
@@ -189,6 +189,9 @@
     "messageNamed": "\"{appName}\" uses backend services that won't work on a static Vercel page. {assistantName} can deploy it properly with serverless functions.",
     "title": "This app needs a full deploy"
   },
+  "detailPanelStopButton": {
+    "tooltip": "Stop"
+  },
   "detailPrimitives": {
     "copied": "Copied",
     "copy": "Copy"

--- a/clients/web/src/i18n/locales/es/chat.json
+++ b/clients/web/src/i18n/locales/es/chat.json
@@ -553,9 +553,6 @@
     "title": "Eliminar conversación",
     "untitled": "Sin título"
   },
-  "detailPanelStopButton": {
-    "tooltip": "Detener"
-  },
   "documentAssetActions": {
     "pdfDownloadFailed": "No se pudo descargar el PDF"
   },

--- a/clients/web/src/i18n/locales/es/common.json
+++ b/clients/web/src/i18n/locales/es/common.json
@@ -189,6 +189,9 @@
     "messageNamed": "\"{appName}\" usa servicios de backend que no funcionarán en una página estática de Vercel. {assistantName} puede desplegarla correctamente con funciones serverless.",
     "title": "Esta app necesita un despliegue completo"
   },
+  "detailPanelStopButton": {
+    "tooltip": "Detener"
+  },
   "detailPrimitives": {
     "copied": "Copiado",
     "copy": "Copiar"

--- a/clients/web/src/i18n/locales/ru/chat.json
+++ b/clients/web/src/i18n/locales/ru/chat.json
@@ -227,9 +227,6 @@
     "title": "Удалить диалог",
     "untitled": "Без названия"
   },
-  "detailPanelStopButton": {
-    "tooltip": "Стоп"
-  },
   "documentAssetActions": {
     "pdfDownloadFailed": "Не удалось скачать PDF"
   },

--- a/clients/web/src/i18n/locales/ru/common.json
+++ b/clients/web/src/i18n/locales/ru/common.json
@@ -25,6 +25,9 @@
     "next": "Далее",
     "done": "Понятно"
   },
+  "detailPanelStopButton": {
+    "tooltip": "Стоп"
+  },
   "notFound": {
     "badge": "Ошибка 404",
     "title": "Страница не найдена",


### PR DESCRIPTION
Follow-up to #41328, now that it has landed.

## What

1. **The overflow trigger is a bare icon with no background.** It was already `variant="ghost"`, which paints nothing at rest on a pointer surface, but the design library's `expandOnMobile` compound variant gives a ghost icon-only button a filled `--surface-lift` circle on touch-mobile. `expandOnMobile={false}` drops that, and `size="regular"` keeps the target at 32px rather than falling to the 24px `compact` box along with it.
2. **End Session is now the same icon-only outlined stop control the ACP run uses**, in place of a hand-rolled bordered button with a text label.

## How the ACP match works

The ACP run header does not write that button inline; it renders the shared `DetailPanelStopButton`: `variant="dangerOutline"`, icon-only `Square`, plus a hover override that holds the glyph at `--system-negative-strong` so contrast survives the weak fill. The subagent, workflow, and background-task headers use it too.

Reusing it rather than copying it means promoting the file from `domains/chat/components/detail-panel-stop-button.tsx` to `components/detail-panel-stop-button.tsx`: a `domains/settings` import of a `domains/chat` module is the coupling `no-cross-domain-imports` exists to stop, and `docs/CONVENTIONS.md` prescribes lifting shared code to a top-level shared directory instead. The four existing call sites follow the move, and the tooltip key moves from the `chat` namespace to `common` (en, es, ru).

## Note on mobile sizing

On a touch surface the stop button still grows to 40px (`expandOnMobile` default, unchanged, matching ACP) while the ghost trigger stays 32px. They match on desktop. Easy to equalize if the difference reads wrong on device; the alternative is overriding the design library's touch-mobile background classes at the call site, which seemed worse than a small size difference between a boxed control and a borderless one.

## Testing

- `doctor-session-menu`, `acp-run-chat-view`, `subagent-detail-panel`, `workflow-detail-panel`, `background-task-detail-panel`, `src/i18n/catalogs.test.ts`: all pass.
- `bunx eslint` on the touched files and `bun run audit:cross-domain:check`: clean.
- `bunx tsc --noEmit` reports 6 errors in the inference-profile files (`use-profile-save.ts`, `profile-quick-add-provider.tsx`). They reproduce on a clean `origin/main` checkout in the same worktree and none of those files are touched here.
- No test added for the two prop changes: their only observable effect is Tailwind class strings, which happy-dom does not resolve into styles, so the test would assert the implementation rather than the appearance. This one needs eyes on a device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)