### PR TITLE
fix(gateway): accept Linq X-Webhook headers when spec names are dropped

### DIFF
--- a/gateway/src/channels/ingress-verification.test.ts
+++ b/gateway/src/channels/ingress-verification.test.ts
@@ -441,6 +441,17 @@ describe("standard-webhooks verification", () => {
     };
   }
 
+  function signLegacy(
+    body: string,
+    opts: { timestamp?: string; key?: Buffer | string } = {},
+  ): string {
+    const timestamp = opts.timestamp ?? TS;
+    const key = opts.key ?? KEY_BYTES;
+    return createHmac("sha256", key)
+      .update(`${timestamp}.${body}`, "utf8")
+      .digest("hex");
+  }
+
   it("accepts a delivery signed the spec's way", () => {
     expect(
       verify(STANDARD_WEBHOOKS, headers(sign(BODY)), BODY, { secret: WHSEC }),
@@ -507,6 +518,102 @@ describe("standard-webhooks verification", () => {
         { secret: WHSEC },
       ),
     ).toEqual({ ok: false, reason: "missing_payload_header" });
+  });
+
+  it("accepts Linq's X-Webhook headers when the spec names are absent", () => {
+    expect(
+      verify(
+        STANDARD_WEBHOOKS,
+        {
+          "X-Webhook-Timestamp": TS,
+          "X-Webhook-Signature": signLegacy(BODY),
+        },
+        BODY,
+        { secret: WHSEC },
+      ),
+    ).toEqual({ ok: true });
+  });
+
+  it("accepts a legacy digest keyed by the secret string itself", () => {
+    expect(
+      verify(
+        STANDARD_WEBHOOKS,
+        {
+          "X-Webhook-Timestamp": TS,
+          "X-Webhook-Signature": signLegacy(BODY, { key: WHSEC }),
+        },
+        BODY,
+        { secret: WHSEC },
+      ),
+    ).toEqual({ ok: true });
+  });
+
+  it("accepts a sha256= prefix on the legacy hex digest", () => {
+    expect(
+      verify(
+        STANDARD_WEBHOOKS,
+        {
+          "X-Webhook-Timestamp": TS,
+          "X-Webhook-Signature": `sha256=${signLegacy(BODY)}`,
+        },
+        BODY,
+        { secret: WHSEC },
+      ),
+    ).toEqual({ ok: true });
+  });
+
+  it("rejects a stale legacy timestamp", () => {
+    const stale = String(
+      Math.floor(NOW_MS / 1000) - STANDARD_WEBHOOKS_TOLERANCE_SECONDS - 1,
+    );
+    expect(
+      verify(
+        STANDARD_WEBHOOKS,
+        {
+          "X-Webhook-Timestamp": stale,
+          "X-Webhook-Signature": signLegacy(BODY, { timestamp: stale }),
+        },
+        BODY,
+        { secret: WHSEC },
+      ),
+    ).toEqual({ ok: false, reason: "stale_timestamp" });
+  });
+
+  it("rejects a wrong legacy digest", () => {
+    expect(
+      verify(
+        STANDARD_WEBHOOKS,
+        {
+          "X-Webhook-Timestamp": TS,
+          "X-Webhook-Signature": signLegacy(BODY, { key: "other-secret" }),
+        },
+        BODY,
+        { secret: WHSEC },
+      ),
+    ).toEqual({ ok: false, reason: "bad_signature" });
+  });
+
+  it("does not fall through to legacy when a spec signature is present", () => {
+    expect(
+      verify(
+        STANDARD_WEBHOOKS,
+        {
+          "webhook-id": MSG_ID,
+          "webhook-timestamp": TS,
+          "webhook-signature": "v1,AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "X-Webhook-Timestamp": TS,
+          "X-Webhook-Signature": signLegacy(BODY),
+        },
+        BODY,
+        { secret: WHSEC },
+      ),
+    ).toEqual({ ok: false, reason: "bad_signature" });
+  });
+
+  it("reports missing_signature when neither header set arrives", () => {
+    expect(
+      verify(STANDARD_WEBHOOKS, {}, BODY, { secret: WHSEC }),
+    ).toEqual({ ok: false, reason: "missing_signature" });
   });
 
   it("changes the digest when the secret field changes", () => {

--- a/gateway/src/channels/ingress-verification.ts
+++ b/gateway/src/channels/ingress-verification.ts
@@ -132,6 +132,12 @@ export const HmacVerificationSchema = z
  * reconstructing those rules as an `hmac` payload list, which cannot decode
  * the secret or accept multiple signatures.
  *
+ * When `webhook-signature` is absent, the same kind also accepts Linq's
+ * deprecated `X-Webhook-Signature` / `X-Webhook-Timestamp` pair (hex
+ * HMAC-SHA256 of `{timestamp}.{raw body}`). Those names survive hops that
+ * drop the unprefixed spec headers. The spec headers win whenever they
+ * arrive.
+ *
  * Replay window is five minutes, matching the spec's default.
  */
 export const StandardWebhooksVerificationSchema = z
@@ -238,12 +244,110 @@ function standardWebhooksKey(secret: string): Buffer | null {
   return key.length > 0 ? key : null;
 }
 
+/** Unix-seconds freshness used by both Standard Webhooks header sets. */
+function readUnixSecondsTimestamp(
+  timestamp: string,
+  nowMs: number,
+): { timestamp: string } | { reason: VerificationRejection } {
+  if (!/^-?\d+$/.test(timestamp)) {
+    return { reason: "missing_timestamp" };
+  }
+  const seconds = Number(timestamp);
+  if (!Number.isSafeInteger(seconds)) {
+    return { reason: "missing_timestamp" };
+  }
+  if (
+    Math.abs(nowMs - seconds * 1000) >
+    STANDARD_WEBHOOKS_TOLERANCE_SECONDS * 1000
+  ) {
+    return { reason: "stale_timestamp" };
+  }
+  return { timestamp };
+}
+
+/**
+ * HMAC keys a Linq legacy digest may have been made with.
+ *
+ * The spec path always decodes a `whsec_` secret. The deprecated hex
+ * signature has been produced with those same key bytes and with the
+ * secret string as UTF-8, so both are tried.
+ */
+function linqLegacyKeys(secret: string): Buffer[] {
+  const keys: Buffer[] = [];
+  const decoded = standardWebhooksKey(secret);
+  if (decoded) {
+    keys.push(decoded);
+  }
+  const utf8 = Buffer.from(secret, "utf8");
+  if (utf8.length > 0 && !(decoded && decoded.equals(utf8))) {
+    keys.push(utf8);
+  }
+  return keys;
+}
+
+/**
+ * Linq's deprecated header pair, still sent on every delivery.
+ *
+ * Signed content is `{timestamp}.{raw body}`. The digest is hex HMAC-SHA256,
+ * optionally prefixed `sha256=`. Replay window matches the spec.
+ */
+function verifyLinqLegacyWebhooks(opts: {
+  headers: Headers;
+  body: Uint8Array;
+  secret: string;
+  nowMs: number;
+}): VerificationResult {
+  const { headers, body, secret, nowMs } = opts;
+  const signatureHeader = headers.get("x-webhook-signature");
+  if (!signatureHeader) {
+    return { ok: false, reason: "missing_signature" };
+  }
+  const stamped = headers.get("x-webhook-timestamp");
+  if (stamped === null) {
+    return { ok: false, reason: "missing_timestamp" };
+  }
+  const freshness = readUnixSecondsTimestamp(stamped, nowMs);
+  if ("reason" in freshness) {
+    return { ok: false, reason: freshness.reason };
+  }
+
+  const presented = signatureHeader.startsWith("sha256=")
+    ? signatureHeader.slice("sha256=".length)
+    : signatureHeader;
+  const digest = decodeDigest(presented, "hex");
+  if (!digest) {
+    return { ok: false, reason: "malformed_signature" };
+  }
+
+  const signedContent = Buffer.concat([
+    Buffer.from(`${freshness.timestamp}.`, "utf8"),
+    Buffer.from(body),
+  ]);
+  const keys = linqLegacyKeys(secret);
+  if (keys.length === 0) {
+    return { ok: false, reason: "missing_signature" };
+  }
+
+  for (const key of keys) {
+    const expected = createHmac("sha256", key).update(signedContent).digest();
+    if (digest.length !== expected.length) {
+      continue;
+    }
+    if (timingSafeEqual(digest, expected)) {
+      return { ok: true };
+    }
+  }
+
+  return { ok: false, reason: "bad_signature" };
+}
+
 /**
  * Verify a Standard Webhooks delivery.
  *
  * Headers are looked up case-insensitively (`Headers.get`). The signed
  * content is `{webhook-id}.{webhook-timestamp}.{raw body}`. Any `v1,`
- * signature in the space-separated header is enough.
+ * signature in the space-separated header is enough. When that header is
+ * absent, Linq's `X-Webhook-*` pair is checked instead.
  */
 function verifyStandardWebhooks(opts: {
   headers: Headers;
@@ -256,12 +360,13 @@ function verifyStandardWebhooks(opts: {
     return { ok: false, reason: "missing_signature" };
   }
 
-  const msgId = headers.get("webhook-id");
-  const timestamp = headers.get("webhook-timestamp");
   const signatureHeader = headers.get("webhook-signature");
   if (!signatureHeader) {
-    return { ok: false, reason: "missing_signature" };
+    return verifyLinqLegacyWebhooks({ headers, body, secret, nowMs });
   }
+
+  const msgId = headers.get("webhook-id");
+  const timestamp = headers.get("webhook-timestamp");
   if (msgId === null) {
     return { ok: false, reason: "missing_payload_header" };
   }
@@ -269,15 +374,9 @@ function verifyStandardWebhooks(opts: {
     return { ok: false, reason: "missing_timestamp" };
   }
 
-  if (!/^-?\d+$/.test(timestamp)) {
-    return { ok: false, reason: "missing_timestamp" };
-  }
-  const stampedMs = Number(timestamp) * 1000;
-  if (!Number.isSafeInteger(Number(timestamp))) {
-    return { ok: false, reason: "missing_timestamp" };
-  }
-  if (Math.abs(nowMs - stampedMs) > STANDARD_WEBHOOKS_TOLERANCE_SECONDS * 1000) {
-    return { ok: false, reason: "stale_timestamp" };
+  const freshness = readUnixSecondsTimestamp(timestamp, nowMs);
+  if ("reason" in freshness) {
+    return { ok: false, reason: freshness.reason };
   }
 
   const key = standardWebhooksKey(secret);
@@ -286,7 +385,7 @@ function verifyStandardWebhooks(opts: {
   }
 
   const signedContent = Buffer.concat([
-    Buffer.from(`${msgId}.${timestamp}.`, "utf8"),
+    Buffer.from(`${msgId}.${freshness.timestamp}.`, "utf8"),
     Buffer.from(body),
   ]);
   const expected = createHmac("sha256", key).update(signedContent).digest();

--- a/gateway/src/channels/plugin-ingress.ts
+++ b/gateway/src/channels/plugin-ingress.ts
@@ -141,8 +141,9 @@ export const IngressRouteSchema = z.object({
    * That is right for a caller Vellum controls and wrong for every other one
    * — Comms signs `X-Osis-Signature`, Photon signs `X-Spectrum-Signature` over
    * a timestamped preamble, and Linq signs Standard Webhooks
-   * (`webhook-id` / `webhook-timestamp` / `webhook-signature`). None of
-   * those callers can be asked to sign ours.
+   * (`webhook-id` / `webhook-timestamp` / `webhook-signature`), still
+   * emitting `X-Webhook-Signature` / `X-Webhook-Timestamp` on the same
+   * delivery. None of those callers can be asked to sign ours.
    *
    * Present, the route is verified by the descriptor instead. `hmac` is a
    * single engine that reads the vendor's parts as data. `standard-webhooks`

--- a/gateway/src/http/routes/plugin-webhook.test.ts
+++ b/gateway/src/http/routes/plugin-webhook.test.ts
@@ -1005,6 +1005,34 @@ describe("standard-webhooks verification", () => {
     expect(calls).toEqual([]);
   });
 
+  it("forwards a delivery signed with Linq's X-Webhook headers", async () => {
+    const { calls, fetchImpl } = recordingFetch();
+    const handle = createPluginWebhookHandler({
+      config: CONFIG,
+      credentials: STANDARD_CREDENTIALS,
+      resolve: () => approvedWith([STANDARD]),
+      fetchImpl,
+    });
+
+    const body = '{"event_type":"message.received"}';
+    const timestamp = String(Math.floor(Date.now() / 1000));
+    const signature = createHmac("sha256", KEY_BYTES)
+      .update(`${timestamp}.${body}`, "utf8")
+      .digest("hex");
+    const res = await handle(
+      vendorPost(body, {
+        "X-Webhook-Timestamp": timestamp,
+        "X-Webhook-Signature": signature,
+      }),
+      "meeting-bot",
+      "realtime",
+    );
+
+    expect(res.status).toBe(200);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.body).toBe(body);
+  });
+
   it("409s when the Standard Webhooks secret field holds nothing", async () => {
     const { calls, fetchImpl } = recordingFetch();
     const handle = createPluginWebhookHandler({

--- a/gateway/src/http/routes/plugin-webhook.ts
+++ b/gateway/src/http/routes/plugin-webhook.ts
@@ -303,6 +303,13 @@ export function createPluginWebhookHandler(deps: PluginWebhookHandlerDeps) {
           signer: route.signer,
           scheme: verification?.kind ?? "vellum",
           rejection,
+          signatureHeaders: {
+            "webhook-signature": req.headers.has("webhook-signature"),
+            "webhook-id": req.headers.has("webhook-id"),
+            "webhook-timestamp": req.headers.has("webhook-timestamp"),
+            "x-webhook-signature": req.headers.has("x-webhook-signature"),
+            "x-webhook-timestamp": req.headers.has("x-webhook-timestamp"),
+          },
         },
         "Plugin webhook signature verification failed",
       );

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -761,7 +761,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-08-24T15:13:55.000Z"
+      "updatedAt": "2026-08-25T18:27:28.000Z"
     },
     {
       "id": "public-ingress",
@@ -995,7 +995,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-08-24T13:55:36.000Z"
+      "updatedAt": "2026-08-24T17:37:48.000Z"
     },
     {
       "id": "typescript-eval",

--- a/skills/plugin-builder/references/channels.md
+++ b/skills/plugin-builder/references/channels.md
@@ -75,7 +75,7 @@ A vendor that signs `X-Example-Signature` has its own scheme. Declare `verificat
 }
 ```
 
-A vendor that adopted [Standard Webhooks](https://www.standardwebhooks.com/) (`webhook-id`, `webhook-timestamp`, `webhook-signature: v1,<base64>`, `whsec_` secret) declares that complete scheme instead. The signed content, key encoding, and five-minute replay window are fixed by the spec, so they are not listed as HMAC parts:
+A vendor that adopted [Standard Webhooks](https://www.standardwebhooks.com/) (`webhook-id`, `webhook-timestamp`, `webhook-signature: v1,<base64>`, `whsec_` secret) declares that complete scheme instead. The signed content, key encoding, and five-minute replay window are fixed by the spec, so they are not listed as HMAC parts. When `webhook-signature` is absent, the gateway also accepts Linq's deprecated `X-Webhook-Signature` / `X-Webhook-Timestamp` pair (hex HMAC-SHA256 of `{timestamp}.{raw body}`), which survives hops that drop the unprefixed spec names:
 
 ```json
 {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan

Linq inbound to a managed assistant 403s with `rejection: missing_signature`. The route is approved and `linq_webhook_secret` is present. The gateway only read Standard Webhooks `webhook-signature` / `webhook-id` / `webhook-timestamp`. Those unprefixed names are dropped on the platform callback hop. Photon and Comms keep working because they sign `X-Spectrum-*` / `X-Osis-*`.

Linq still sends its deprecated pair on every delivery:

- `X-Webhook-Timestamp` (unix seconds)
- `X-Webhook-Signature` (hex HMAC-SHA256 of `{timestamp}.{raw body}`)

This PR verifies that pair when `webhook-signature` is absent. Spec headers still win when they arrive. The HMAC key is tried as decoded `whsec_` bytes and as the secret string itself. The five-minute replay window is unchanged.

A platform change that forwards `webhook-*` is still the hop-level fix. This unblocks Linq without waiting on that.

## Test plan

- `cd gateway && bun test src/channels/ingress-verification.test.ts src/http/routes/plugin-webhook.test.ts`
- After deploy, retry the same Linq `message.received` callback. Expect 2xx instead of 403 `missing_signature`. If it 403s with `bad_signature`, the surviving hex digest is a different encoding than `{timestamp}.{body}`.

## CLI verb checklist

No new IPC routes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e4962d4e-2ec1-41e9-a672-94c27c721e8c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e4962d4e-2ec1-41e9-a672-94c27c721e8c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

