### PR TITLE
feat(ios): keep the eyes on the quiet card and center row glyphs on their text

### DIFF
--- a/clients/ios/App/VoiceActivity/Widgets/CatchUpWidget.swift
+++ b/clients/ios/App/VoiceActivity/Widgets/CatchUpWidget.swift
@@ -194,14 +194,23 @@ struct CatchUpRow: View {
     static let leadingInset: CGFloat = 8
     private static let textTopInset: CGFloat = 6
     private static let glyphSize: CGFloat = 12
-    private static let glyphTopInset: CGFloat = 12.5
     private static let glyphTextGap: CGFloat = 7
+
+    /// Where the glyph hangs, by how much text ends up beside it.
+    ///
+    /// It centers against the lines the row actually draws, which is not one
+    /// number: the design's two-line row puts the glyph's middle between the
+    /// title and the subtitle, and a row carrying no subtitle has only the
+    /// title to center on. Left at the two-line inset, the glyph on a
+    /// title-only row hangs below the words instead of beside them.
+    private static let glyphTwoLineTopInset: CGFloat = 12.5
+    private static let glyphTitleOnlyTopInset: CGFloat = 7
 
     var body: some View {
         HStack(alignment: .top, spacing: Self.glyphTextGap * scale) {
             statusGlyph
                 .frame(width: Self.glyphSize * scale, height: Self.glyphSize * scale)
-                .padding(.top, Self.glyphTopInset * scale)
+                .padding(.top, glyphTopInset * scale)
             VStack(alignment: .leading, spacing: 2 * scale) {
                 Text(conversation.title)
                     .font(.system(size: 12 * scale, weight: .medium))
@@ -209,7 +218,7 @@ struct CatchUpRow: View {
                     .lineLimit(1)
                     .truncationMode(.tail)
                     .privacySensitive()
-                if let subtitle = conversation.subtitle, !subtitle.isEmpty {
+                if let subtitle = renderedSubtitle {
                     Text(subtitle)
                         .font(.system(size: 7 * scale, weight: .medium))
                         .foregroundStyle(WidgetTheme.textSecondary)
@@ -223,6 +232,25 @@ struct CatchUpRow: View {
         .padding(.leading, Self.leadingInset * scale)
         .frame(maxWidth: .infinity, alignment: .topLeading)
         .frame(height: height, alignment: .top)
+    }
+
+    /// The subtitle this row draws, which is not quite the one the snapshot
+    /// carries: a group the producer sent as an empty string is a subtitle with
+    /// nothing in it to draw.
+    ///
+    /// The one owner of that question, because the glyph's inset asks it too
+    /// and the two cannot be allowed to answer differently: a glyph centered
+    /// for a line the row never drew is exactly the misalignment this avoids.
+    private var renderedSubtitle: String? {
+        guard let subtitle = conversation.subtitle, !subtitle.isEmpty else {
+            return nil
+        }
+        return subtitle
+    }
+
+    /// Where the glyph hangs for the text beside it. See the inset pair above.
+    private var glyphTopInset: CGFloat {
+        renderedSubtitle == nil ? Self.glyphTitleOnlyTopInset : Self.glyphTwoLineTopInset
     }
 
     /// Working beats unread, and staleness beats working.

--- a/clients/ios/App/VoiceActivity/Widgets/QuickActionsWidget.swift
+++ b/clients/ios/App/VoiceActivity/Widgets/QuickActionsWidget.swift
@@ -36,13 +36,15 @@ struct QuickActionsWidget: Widget {
     }
 }
 
-/// The card: the two actions along the bottom, and, only while something is
-/// unread, the assistant glancing at the count across the top.
+/// The card: the two actions along the bottom, the assistant across the top,
+/// and the count beside it while something is waiting.
 ///
-/// The mark and the chip arrive together or not at all. A quiet card is just
-/// the buttons, which is what makes the face appearing mean something: eyes on
-/// the card are the assistant saying there is something to look at, not
-/// decoration that was always there.
+/// The face is always drawn. It is the account's avatar rather than a
+/// notification, so the card wears it whatever the snapshot says, and the chip
+/// is the piece that arrives with unreads. That is also what decides where the
+/// mark sits: a quiet card rests it near the middle, and a card carrying a
+/// count moves it to the leading margin to leave the chip the other end of the
+/// row.
 ///
 /// There is no empty state and no signed-out state to draw: the buttons are
 /// what the widget is, and they work with nothing synced at all. The chip and
@@ -77,6 +79,13 @@ struct QuickActionsWidgetView: View {
     /// nudge the eyes sit in from the leading margin.
     private static let markInset: CGFloat = 13
     private static let markLeadingInset: CGFloat = 2
+
+    /// How far right of the card's center the quiet mark rests, on the design
+    /// canvas. The design does not sit the pair on the center line: it settles
+    /// it a nudge past, leaning the composition into the rightward glance the
+    /// pupils already have, so the face reads as looking across the card rather
+    /// than as a mark parked in the middle of it.
+    private static let quietMarkCenterOffset: CGFloat = 11.5
 
     private static let chipHeight: CGFloat = 31
 
@@ -131,6 +140,8 @@ struct QuickActionsWidgetView: View {
                     let markWidth = contentWidth - Self.chipAllowance(for: count, scale: scale)
                         - Self.markChipGap * scale
                     markRow(count: count, markWidth: markWidth, scale: scale)
+                } else {
+                    quietMarkRow(scale: scale)
                 }
                 Spacer(minLength: 0)
                 controlRow(diameter: Self.controlDiameter * scale, scale: scale)
@@ -144,11 +155,33 @@ struct QuickActionsWidgetView: View {
     /// across the top of the card rather than two things dropped on it.
     private func markRow(count: Int, markWidth: CGFloat, scale: CGFloat) -> some View {
         HStack(alignment: .top, spacing: 0) {
-            avatarMark(markWidth: markWidth, scale: scale)
-                .padding(.leading, Self.markLeadingInset * scale)
+            avatarMark(
+                eyeHeight: fittedEyeHeight(in: markWidth, scale: scale),
+                imageSize: fittedImageSize(in: markWidth, scale: scale),
+                scale: scale
+            )
+            .padding(.leading, Self.markLeadingInset * scale)
             Spacer(minLength: 0)
             unreadChip(count: count, scale: scale)
         }
+        .padding(.top, Self.markInset * scale)
+    }
+
+    /// The mark alone, at the size the design draws it when nothing shares the
+    /// row with it.
+    ///
+    /// Nothing is competing for the width here, so the mark takes its full size
+    /// rather than the fitted one, and it is placed from the card's center
+    /// instead of from a margin: what the design lines the pair up against is
+    /// the card, not the edge the chip layout hangs it off.
+    private func quietMarkRow(scale: CGFloat) -> some View {
+        avatarMark(
+            eyeHeight: WidgetAvatarEyes.defaultEyeHeight * scale,
+            imageSize: Self.avatarImageSize * scale,
+            scale: scale
+        )
+        .frame(maxWidth: .infinity)
+        .offset(x: Self.quietMarkCenterOffset * scale)
         .padding(.top, Self.markInset * scale)
     }
 
@@ -169,16 +202,20 @@ struct QuickActionsWidgetView: View {
     /// The assistant, however this account's assistant can be drawn: its own
     /// photo where there is one, and the eyes the kit draws where the card is
     /// already wearing its color.
+    ///
+    /// Both sizes are the caller's because the two rows size the mark
+    /// differently, while which of the two marks to draw is a fact about the
+    /// account and belongs in one place.
     @ViewBuilder
-    private func avatarMark(markWidth: CGFloat, scale: CGFloat) -> some View {
+    private func avatarMark(eyeHeight: CGFloat, imageSize: CGFloat, scale: CGFloat) -> some View {
         if entry.avatarKind == .image, let image = entry.avatarImage {
             WidgetAvatarImageView(
                 image: image,
-                size: fittedImageSize(in: markWidth, scale: scale),
+                size: imageSize,
                 cornerRadius: Self.avatarImageCornerRadius * scale
             )
         } else {
-            WidgetAvatarEyes(eyeHeight: fittedEyeHeight(in: markWidth, scale: scale))
+            WidgetAvatarEyes(eyeHeight: eyeHeight)
         }
     }
 
@@ -238,9 +275,14 @@ struct QuickActionsWidgetView: View {
         palette.controlFill(onWhite: Self.controlFillOnWhite, onDark: Self.controlFillOnDark)
     }
 
-    /// The number for the unread chip, or nil when there is no chip or mark to
-    /// draw: nothing unread, nothing synced, or a snapshot old enough that the
-    /// count is a claim about an inbox from half an hour ago.
+    /// The number for the unread chip, or nil when there is no chip to draw:
+    /// nothing unread, nothing synced, or a snapshot old enough that the count
+    /// is a claim about an inbox from half an hour ago.
+    ///
+    /// It gates the chip and the row layout built around it, and nothing else.
+    /// The mark is drawn either way: the eyes are which assistant this account
+    /// has rather than a claim about right now, so a snapshot too old to count
+    /// with is still new enough to say whose face it is.
     ///
     /// `CatchUpRow` keeps its unread dot past that same threshold, and the two
     /// are consistent rather than in tension. A dot says "this conversation
@@ -309,6 +351,16 @@ private func previewCharacterAvatar(accentHex: String) -> WidgetSnapshotAvatar {
             // to come out dark, or the card is white on yellow.
             previewCard(previewEntry(unread: 12, avatar: previewCharacterAvatar(accentHex: "#F2C94C")))
         }
+    }
+}
+
+#Preview("Stale, was unread") {
+    // The count is a claim about now and drops; the face is not and stays. The
+    // card should be indistinguishable from a quiet one.
+    previewAppearances {
+        previewCard(
+            previewEntry(unread: 3, avatar: previewCharacterAvatar(accentHex: "#0E9B8B"), isStale: true)
+        )
     }
 }
 

--- a/clients/ios/App/VoiceActivity/Widgets/WidgetAvatarRendering.swift
+++ b/clients/ios/App/VoiceActivity/Widgets/WidgetAvatarRendering.swift
@@ -591,10 +591,15 @@ func previewWidgetCard<Content: View, Background: View>(
 /// A snapshot carrying exactly what a preview needs to say: the two counts and
 /// the avatar. Shared with the widgets built out of the kit, none of which
 /// previews a conversation list.
+///
+/// Staleness is a parameter because the cards disagree about what it costs
+/// them: it drops a count and keeps an avatar, so a preview is the only place
+/// the two are visible side by side.
 func previewEntry(
     unread: Int = 0,
     inProgress: Int = 0,
-    avatar: WidgetSnapshotAvatar? = nil
+    avatar: WidgetSnapshotAvatar? = nil,
+    isStale: Bool = false
 ) -> SnapshotEntry {
     SnapshotEntry(
         date: Date(),
@@ -606,7 +611,7 @@ func previewEntry(
             conversations: [],
             avatar: avatar
         ),
-        isStale: false
+        isStale: isStale
     )
 }
 


### PR DESCRIPTION
## Summary
Two design updates from device QA against the latest mocks:

- **The tinted small widget always wears its face.** The quiet (nothing-unread) card no longer hides the eyes: the pair draws at full 33pt size, resting a nudge right of the card's center per the design (pair spans x 61..122 on the 160pt canvas), leaning into the pupils' own rightward glance. The chip is what arrives with unreads, and its row layout (eyes at the leading margin, chip trailing) is unchanged. Staleness now drops only the count, never the face: the eyes are which assistant the account has, not a claim about right now. Custom-photo avatars follow the same quiet placement.
- **Catch Up rows center their status glyph on the text they actually draw.** The 12.5pt glyph inset is mock-exact for two-line rows but left the icon ~5pt below a lone title on subtitle-less rows. Such rows now use a 7pt inset so the glyph centers on the title line; a single `renderedSubtitle` owner drives both the subtitle text and the inset so they cannot disagree.

## Verification
- Extension-wide `swiftc -typecheck` passes with and without `-D DEBUG`, re-run after rebasing onto main post-#41326.
- Quiet-mark geometry verified numerically: eye pair lands exactly at 61..122 on the design canvas; the 44pt photo mark stays inside the content box; mark (y 29..62) and controls (y 84..145) never collide.
- Glyph math: at the 12pt title's line height the old inset put the glyph center 5.3pt low; the 7pt inset lands within 0.25pt of the title's center.
- New previews: the stale-was-unread card (face stays, count drops) via an `isStale` parameter on the shared preview entry.

## Device QA checklist
- Quiet card: full-size eyes slightly right of center, both appearances, and on the tinted Home Screen (cutout pupils).
- Unread card: unchanged layout (eyes leading, chip trailing).
- Stale snapshot: face stays, chip gone.
- Catch Up: title-only rows align icon and title; two-line rows unchanged; a mixed list moves only the glyphs, never the titles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)