### PR TITLE
fix(discord-skill): let the app's own install settings shape the invite

### DIFF
--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -184,7 +184,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-08-25T18:30:26.000Z"
+      "updatedAt": "2026-08-25T18:39:05.000Z"
     },
     {
       "id": "doordash",
@@ -761,7 +761,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-08-24T15:13:55.000Z"
+      "updatedAt": "2026-08-24T18:33:37.000Z"
     },
     {
       "id": "public-ingress",
@@ -995,7 +995,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-08-24T13:55:36.000Z"
+      "updatedAt": "2026-08-24T17:37:48.000Z"
     },
     {
       "id": "typescript-eval",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -184,7 +184,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-08-25T18:49:05.000Z"
+      "updatedAt": "2026-08-25T19:42:26.000Z"
     },
     {
       "id": "doordash",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -184,7 +184,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-08-20T22:31:34.000Z"
+      "updatedAt": "2026-08-25T18:30:26.000Z"
     },
     {
       "id": "doordash",

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -184,7 +184,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-08-25T18:39:05.000Z"
+      "updatedAt": "2026-08-25T18:49:05.000Z"
     },
     {
       "id": "doordash",

--- a/skills/discord-app-setup/SKILL.md
+++ b/skills/discord-app-setup/SKILL.md
@@ -121,7 +121,7 @@ bun skills/discord-app-setup/scripts/print-invite-url.ts
 
 This calls `GET /oauth2/applications/@me` with the stored bot token to discover the application and prints the invite URL. Which URL depends on the app:
 
-- **The app has Default Install Settings** (configured on the portal's Installation page): the URL carries only the client ID, so the grant is whatever those settings say. This is Discord's current model, and it means a person who edits those settings sees their edit take effect instead of being silently overridden by parameters in the URL. The script warns on stderr if those settings request scopes this integration never uses; `gdm.join` in particular would let the bot join group DMs, which inbound handling treats as private DMs, so have the user remove surplus scopes rather than proceeding.
+- **The app has Default Install Settings** (configured on the portal's Installation page): the URL carries only the client ID, so the grant is whatever those settings say. This is Discord's current model, and it means a person who edits those settings sees their edit take effect instead of being silently overridden by parameters in the URL. Because those settings now own the grant, the script re-checks them: it refuses to print a URL when they omit the `bot` scope (installing would add no bot user at all), and it warns on stderr when they request scopes this integration never uses, grant Administrator, or omit permissions the integration exercises. `gdm.join` in particular would let the bot join group DMs, which inbound handling treats as private DMs. Have the user make the named edit on the Installation page rather than proceeding past a warning.
 - **No Default Install Settings**: the URL spells out the grant itself:
 
 ```

--- a/skills/discord-app-setup/SKILL.md
+++ b/skills/discord-app-setup/SKILL.md
@@ -119,13 +119,20 @@ Run:
 bun skills/discord-app-setup/scripts/print-invite-url.ts
 ```
 
-This calls `GET /oauth2/applications/@me` with the stored bot token to discover the application ID, then prints a URL of the form:
+This calls `GET /oauth2/applications/@me` with the stored bot token to discover the application and prints the invite URL. Which URL depends on the app:
+
+- **The app has Default Install Settings** (configured on the portal's Installation page): the URL carries only the client ID, so the grant is whatever those settings say. This is Discord's current model, and it means a person who edits those settings sees their edit take effect instead of being silently overridden by parameters in the URL. The script warns on stderr if those settings request scopes this integration never uses; `gdm.join` in particular would let the bot join group DMs, which inbound handling treats as private DMs, so have the user remove surplus scopes rather than proceeding.
+- **No Default Install Settings**: the URL spells out the grant itself:
 
 ```
-https://discord.com/oauth2/authorize?client_id=<APP_ID>&permissions=277025770560&scope=bot+applications.commands
+https://discord.com/oauth2/authorize?client_id=<APP_ID>&permissions=277025770560&scope=bot
 ```
+
+The `applications.commands` scope is not requested separately: Discord includes it with the `bot` scope, and nothing here registers a command.
 
 The default permission integer (`277025770560`) covers: View Channels, Send Messages, Send Messages in Threads, Embed Links, Attach Files, Read Message History, Add Reactions, Use External Emojis, and Use Slash Commands. It deliberately **does not** include Administrator, Manage Channels, Manage Roles, Manage Threads, Create Public Threads, Kick/Ban Members, or Mention Everyone — request more only if a downstream feature requires it, and document the reason.
+
+When Default Install Settings exist, the same least-privilege bar applies to what the user configures there.
 
 Direct the user:
 

--- a/skills/discord-app-setup/scripts/__tests__/print-invite-url.test.ts
+++ b/skills/discord-app-setup/scripts/__tests__/print-invite-url.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  planInvite,
+  permissionWarnings,
+  readApplication,
+  type DiscordApplication,
+} from "../print-invite-url.ts";
+
+/** The permission integer the fallback URL requests. */
+const REQUESTED_DEFAULT = "277025770560";
+/** VIEW_CHANNEL + SEND_MESSAGES + ATTACH_FILES + SEND_MESSAGES_IN_THREADS. */
+const REQUIRED_ONLY = (
+  (1n << 10n) |
+  (1n << 11n) |
+  (1n << 15n) |
+  (1n << 38n)
+).toString();
+
+function app(
+  installSettings: DiscordApplication["installSettings"],
+): DiscordApplication {
+  return { id: "123456789012345678", installSettings };
+}
+
+describe("readApplication", () => {
+  test("reads the Installation page's settings from integration_types_config", () => {
+    const parsed = readApplication({
+      id: "1",
+      integration_types_config: {
+        "0": {
+          oauth2_install_params: { scopes: ["bot"], permissions: "2048" },
+        },
+        "1": { oauth2_install_params: { scopes: ["applications.commands"] } },
+      },
+    });
+    // The guild-install entry, not the user-install one: this skill performs
+    // a server install.
+    expect(parsed.installSettings).toEqual({
+      scopes: ["bot"],
+      permissions: "2048",
+    });
+  });
+
+  test("falls back to the legacy in-app authorization settings", () => {
+    const parsed = readApplication({
+      id: "1",
+      install_params: { scopes: ["bot"], permissions: "8" },
+    });
+    expect(parsed.installSettings).toEqual({
+      scopes: ["bot"],
+      permissions: "8",
+    });
+  });
+
+  test("prefers the portal's settings when both exist", () => {
+    // The portal writes integration_types_config; a stale legacy block must
+    // not shadow what the admin actually edits.
+    const parsed = readApplication({
+      id: "1",
+      install_params: { scopes: ["identify"] },
+      integration_types_config: {
+        "0": { oauth2_install_params: { scopes: ["bot"] } },
+      },
+    });
+    expect(parsed.installSettings?.scopes).toEqual(["bot"]);
+  });
+
+  test("an app with no settings anywhere has none", () => {
+    expect(readApplication({ id: "1" }).installSettings).toBeUndefined();
+  });
+
+  test("filters non-string scope members instead of rejecting the app", () => {
+    const parsed = readApplication({
+      id: "1",
+      integration_types_config: {
+        "0": { oauth2_install_params: { scopes: [42, "bot"] } },
+      },
+    });
+    expect(parsed.installSettings?.scopes).toEqual(["bot"]);
+  });
+
+  test("refuses a response without a usable id", () => {
+    expect(() => readApplication({ id: "" })).toThrow(/usable id/);
+    expect(() => readApplication(null)).toThrow(/non-object/);
+  });
+});
+
+describe("planInvite", () => {
+  test("no install settings: the URL spells out the grant, bot scope only", () => {
+    const plan = planInvite(app(undefined));
+    const url = new URL(plan.url);
+    expect(url.searchParams.get("client_id")).toBe("123456789012345678");
+    expect(url.searchParams.get("scope")).toBe("bot");
+    expect(url.searchParams.get("permissions")).toBe(REQUESTED_DEFAULT);
+    expect(plan.notes).toEqual([]);
+  });
+
+  test("install settings: the URL carries only the client id", () => {
+    const plan = planInvite(
+      app({ scopes: ["bot"], permissions: REQUESTED_DEFAULT }),
+    );
+    const url = new URL(plan.url);
+    expect(url.searchParams.get("scope")).toBeNull();
+    expect(url.searchParams.get("permissions")).toBeNull();
+    expect(plan.notes).toHaveLength(1);
+    expect(plan.notes[0]).toContain("Default Install Settings");
+  });
+
+  test("settings without the bot scope stop the plan instead of printing", () => {
+    // A client-id-only link would install whatever the settings say, which
+    // here adds no bot user at all: the setup flow would dead-end on a URL
+    // that looked right.
+    expect(() =>
+      planInvite(app({ scopes: ["applications.commands"], permissions: "0" })),
+    ).toThrow(/bot scope/);
+  });
+
+  test("surplus scopes warn, naming gdm.join's group-DM consequence", () => {
+    const plan = planInvite(
+      app({ scopes: ["bot", "gdm.join"], permissions: REQUESTED_DEFAULT }),
+    );
+    const warning = plan.notes.find((n) => n.startsWith("Warning"));
+    expect(warning).toContain("gdm.join");
+    expect(warning).toContain("private DMs");
+  });
+
+  test("settings tightened below the requested default but covering the used bits pass silently", () => {
+    // The requested default includes bits nothing exercises (reactions,
+    // external emojis, slash commands). An admin who removes those has
+    // improved the install and must not be told to widen it back.
+    const plan = planInvite(
+      app({ scopes: ["bot"], permissions: REQUIRED_ONLY }),
+    );
+    expect(plan.notes.filter((n) => n.startsWith("Warning"))).toEqual([]);
+  });
+});
+
+describe("permissionWarnings", () => {
+  test("Administrator warns toward the least-privilege integer", () => {
+    const warnings = permissionWarnings("8");
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("Administrator");
+    expect(warnings[0]).toContain(REQUESTED_DEFAULT);
+  });
+
+  test("missing exercised bits warn by name", () => {
+    // VIEW_CHANNEL + SEND_MESSAGES only: the bot could talk but not upload
+    // or answer in threads.
+    const warnings = permissionWarnings(((1n << 10n) | (1n << 11n)).toString());
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("ATTACH_FILES");
+    expect(warnings[0]).toContain("SEND_MESSAGES_IN_THREADS");
+    expect(warnings[0]).not.toContain("ADD_REACTIONS");
+  });
+
+  test("the exact requested default is silent", () => {
+    expect(permissionWarnings(REQUESTED_DEFAULT)).toEqual([]);
+  });
+
+  test("absent or malformed permission strings validate nothing", () => {
+    expect(permissionWarnings(undefined)).toEqual([]);
+    expect(permissionWarnings("not-a-number")).toEqual([]);
+  });
+});

--- a/skills/discord-app-setup/scripts/print-invite-url.ts
+++ b/skills/discord-app-setup/scripts/print-invite-url.ts
@@ -68,7 +68,51 @@ async function revealCredential(
   return stdout.trim();
 }
 
-async function discoverApplicationId(token: string): Promise<string> {
+interface DiscordApplication {
+  id: string;
+  /**
+   * The app's own Default Install Settings, when the developer has configured
+   * them on the portal's Installation page. Discord's current model: scopes
+   * and permissions belong to the app, and the install link carries only the
+   * client id.
+   */
+  install_params?: { scopes?: string[]; permissions?: string };
+}
+
+/**
+ * Narrow Discord's response rather than assert it. This is one hop from the
+ * network and the id it yields goes into an install link someone clicks, so a
+ * shape Discord did not send should stop here loudly instead of producing a
+ * link to nothing.
+ */
+function readApplication(body: unknown): DiscordApplication {
+  if (typeof body !== "object" || body === null) {
+    throw new Error("Discord returned a non-object application");
+  }
+  const id = "id" in body ? body.id : undefined;
+  if (typeof id !== "string" || id.length === 0) {
+    throw new Error("Discord returned an application without a usable id");
+  }
+
+  const params = "install_params" in body ? body.install_params : undefined;
+  const rawScopes =
+    typeof params === "object" &&
+    params !== null &&
+    "scopes" in params &&
+    Array.isArray(params.scopes)
+      ? params.scopes
+      : [];
+  const scopes = rawScopes.filter(
+    (scope): scope is string => typeof scope === "string",
+  );
+
+  return {
+    id,
+    ...(scopes.length > 0 ? { install_params: { scopes } } : {}),
+  };
+}
+
+async function fetchApplication(token: string): Promise<DiscordApplication> {
   const res = await fetch(`${DISCORD_API}/oauth2/applications/@me`, {
     headers: {
       Authorization: `Bot ${token}`,
@@ -78,11 +122,10 @@ async function discoverApplicationId(token: string): Promise<string> {
   if (!res.ok) {
     const body = await res.text().catch(() => "");
     throw new Error(
-      `Discord /oauth2/applications/@me → ${res.status} ${res.statusText}: ${body}`,
+      `Discord /oauth2/applications/@me returned ${res.status} ${res.statusText}: ${body}`,
     );
   }
-  const json = (await res.json()) as { id: string };
-  return json.id;
+  return readApplication(await res.json());
 }
 
 async function printVellum(): Promise<void> {
@@ -93,16 +136,49 @@ async function printVellum(): Promise<void> {
     );
   }
 
-  const applicationId = await discoverApplicationId(token);
+  const app = await fetchApplication(token);
 
-  // Canonical modern form. The legacy `/api/oauth2/authorize` path still
-  // resolves, but Discord documents this one.
   const url = new URL("https://discord.com/oauth2/authorize");
-  url.searchParams.set("client_id", applicationId);
-  url.searchParams.set("permissions", computeDefaultPermissions());
-  url.searchParams.set("scope", "bot applications.commands");
+  url.searchParams.set("client_id", app.id);
+
+  // Prefer the app's own install link. Discord's current model puts scopes
+  // and permissions in Default Install Settings on the portal's Installation
+  // page and generates a link carrying only the client id, so a person who
+  // edits those settings sees the change. Spelling them into the URL instead
+  // silently overrides what they configured.
+  const configured = Boolean(app.install_params?.scopes?.length);
+  if (!configured) {
+    // No Default Install Settings, so the link has to say what to grant.
+    // `applications.commands` is deliberately absent: Discord includes it
+    // with the `bot` scope, and nothing here registers a command, so asking
+    // for it separately requests a permission that is never exercised.
+    url.searchParams.set("permissions", computeDefaultPermissions());
+    url.searchParams.set("scope", "bot");
+  }
 
   console.log(url.toString());
+  if (configured) {
+    console.error(
+      "Using this app's Default Install Settings from the Installation page.",
+    );
+    // Deferring to the app's settings means this script no longer bounds what
+    // the install grants, so say when those settings ask for more than the
+    // integration uses. `gdm.join` matters most: it lets the bot be added to
+    // group DMs, which arrive guild-less and are admitted by ingress as
+    // private DMs. The ingress gate documents that assumption and must learn
+    // to tell the two apart before that scope is safe to carry.
+    const surplus = (app.install_params?.scopes ?? []).filter(
+      (scope) => scope !== "bot" && scope !== "applications.commands",
+    );
+    if (surplus.length > 0) {
+      console.error(
+        `Warning: the app's Default Install Settings request scopes this ` +
+          `integration never uses: ${surplus.join(", ")}. Remove them on the ` +
+          `portal's Installation page. In particular, gdm.join would let the ` +
+          `bot join group DMs, which inbound handling treats as private DMs.`,
+      );
+    }
+  }
 }
 
 async function main(): Promise<void> {

--- a/skills/discord-app-setup/scripts/print-invite-url.ts
+++ b/skills/discord-app-setup/scripts/print-invite-url.ts
@@ -71,12 +71,30 @@ async function revealCredential(
 interface DiscordApplication {
   id: string;
   /**
-   * The app's own Default Install Settings, when the developer has configured
-   * them on the portal's Installation page. Discord's current model: scopes
-   * and permissions belong to the app, and the install link carries only the
-   * client id.
+   * The scopes the app's own install settings grant, empty when it has none.
+   *
+   * Resolved from the two places Discord may put them. The portal's
+   * Installation page writes its Default Install Settings to
+   * `integration_types_config["0"].oauth2_install_params` (`0` is
+   * GUILD_INSTALL, the server install this integration performs). Top-level
+   * `install_params` is the older in-app authorization link, still served
+   * for apps that configured it. Reading only the legacy field would leave
+   * this empty for every app configured through the current portal, and the
+   * preference for the app's own settings would silently never engage.
    */
-  install_params?: { scopes?: string[]; permissions?: string };
+  installScopes: string[];
+}
+
+/** The `scopes` array of an install-params-shaped object, if it has one. */
+function readScopes(params: unknown): string[] {
+  if (typeof params !== "object" || params === null) {
+    return [];
+  }
+  const scopes = "scopes" in params ? params.scopes : undefined;
+  if (!Array.isArray(scopes)) {
+    return [];
+  }
+  return scopes.filter((scope): scope is string => typeof scope === "string");
 }
 
 /**
@@ -94,21 +112,28 @@ function readApplication(body: unknown): DiscordApplication {
     throw new Error("Discord returned an application without a usable id");
   }
 
-  const params = "install_params" in body ? body.install_params : undefined;
-  const rawScopes =
-    typeof params === "object" &&
-    params !== null &&
-    "scopes" in params &&
-    Array.isArray(params.scopes)
-      ? params.scopes
-      : [];
-  const scopes = rawScopes.filter(
-    (scope): scope is string => typeof scope === "string",
+  const typesConfig =
+    "integration_types_config" in body
+      ? body.integration_types_config
+      : undefined;
+  const guildConfig =
+    typeof typesConfig === "object" && typesConfig !== null && "0" in typesConfig
+      ? typesConfig["0"]
+      : undefined;
+  const guildInstall = readScopes(
+    typeof guildConfig === "object" &&
+      guildConfig !== null &&
+      "oauth2_install_params" in guildConfig
+      ? guildConfig.oauth2_install_params
+      : undefined,
+  );
+  const legacy = readScopes(
+    "install_params" in body ? body.install_params : undefined,
   );
 
   return {
     id,
-    ...(scopes.length > 0 ? { install_params: { scopes } } : {}),
+    installScopes: guildInstall.length > 0 ? guildInstall : legacy,
   };
 }
 
@@ -146,7 +171,7 @@ async function printVellum(): Promise<void> {
   // page and generates a link carrying only the client id, so a person who
   // edits those settings sees the change. Spelling them into the URL instead
   // silently overrides what they configured.
-  const configured = Boolean(app.install_params?.scopes?.length);
+  const configured = app.installScopes.length > 0;
   if (!configured) {
     // No Default Install Settings, so the link has to say what to grant.
     // `applications.commands` is deliberately absent: Discord includes it
@@ -167,7 +192,7 @@ async function printVellum(): Promise<void> {
     // group DMs, which arrive guild-less and are admitted by ingress as
     // private DMs. The ingress gate documents that assumption and must learn
     // to tell the two apart before that scope is safe to carry.
-    const surplus = (app.install_params?.scopes ?? []).filter(
+    const surplus = app.installScopes.filter(
       (scope) => scope !== "bot" && scope !== "applications.commands",
     );
     if (surplus.length > 0) {

--- a/skills/discord-app-setup/scripts/print-invite-url.ts
+++ b/skills/discord-app-setup/scripts/print-invite-url.ts
@@ -71,7 +71,7 @@ async function revealCredential(
 interface DiscordApplication {
   id: string;
   /**
-   * The scopes the app's own install settings grant, empty when it has none.
+   * The app's own install settings, undefined when it has none.
    *
    * Resolved from the two places Discord may put them. The portal's
    * Installation page writes its Default Install Settings to
@@ -79,22 +79,40 @@ interface DiscordApplication {
    * GUILD_INSTALL, the server install this integration performs). Top-level
    * `install_params` is the older in-app authorization link, still served
    * for apps that configured it. Reading only the legacy field would leave
-   * this empty for every app configured through the current portal, and the
-   * preference for the app's own settings would silently never engage.
+   * this undefined for every app configured through the current portal, and
+   * the preference for the app's own settings would silently never engage.
+   *
+   * The permission string rides along because deferring to the app's
+   * settings removes the least-privilege bound the parameterized URL used to
+   * carry, and the caller can only re-check that bound against what the
+   * settings actually grant.
    */
-  installScopes: string[];
+  installSettings: InstallSettings | undefined;
 }
 
-/** The `scopes` array of an install-params-shaped object, if it has one. */
-function readScopes(params: unknown): string[] {
+interface InstallSettings {
+  scopes: string[];
+  /** Decimal permission bitfield as Discord serves it, if present. */
+  permissions: string | undefined;
+}
+
+/** An install-params-shaped object's settings; undefined without scopes. */
+function readInstallSettings(params: unknown): InstallSettings | undefined {
   if (typeof params !== "object" || params === null) {
-    return [];
+    return undefined;
   }
-  const scopes = "scopes" in params ? params.scopes : undefined;
-  if (!Array.isArray(scopes)) {
-    return [];
+  const rawScopes = "scopes" in params ? params.scopes : undefined;
+  const scopes = Array.isArray(rawScopes)
+    ? rawScopes.filter((scope): scope is string => typeof scope === "string")
+    : [];
+  if (scopes.length === 0) {
+    return undefined;
   }
-  return scopes.filter((scope): scope is string => typeof scope === "string");
+  const permissions =
+    "permissions" in params && typeof params.permissions === "string"
+      ? params.permissions
+      : undefined;
+  return { scopes, permissions };
 }
 
 /**
@@ -120,21 +138,18 @@ function readApplication(body: unknown): DiscordApplication {
     typeof typesConfig === "object" && typesConfig !== null && "0" in typesConfig
       ? typesConfig["0"]
       : undefined;
-  const guildInstall = readScopes(
+  const guildInstall = readInstallSettings(
     typeof guildConfig === "object" &&
       guildConfig !== null &&
       "oauth2_install_params" in guildConfig
       ? guildConfig.oauth2_install_params
       : undefined,
   );
-  const legacy = readScopes(
+  const legacy = readInstallSettings(
     "install_params" in body ? body.install_params : undefined,
   );
 
-  return {
-    id,
-    installScopes: guildInstall.length > 0 ? guildInstall : legacy,
-  };
+  return { id, installSettings: guildInstall ?? legacy };
 }
 
 async function fetchApplication(token: string): Promise<DiscordApplication> {
@@ -162,6 +177,20 @@ async function printVellum(): Promise<void> {
   }
 
   const app = await fetchApplication(token);
+  const settings = app.installSettings;
+
+  // A client-id-only link installs whatever the settings say, so settings
+  // that omit the bot scope would produce an install that adds no bot user
+  // at all, and the setup flow dead-ends with a URL that looked right. Stop
+  // instead of printing it: the settings are authoritative, so the fix
+  // belongs where they live.
+  if (settings && !settings.scopes.includes("bot")) {
+    throw new Error(
+      "This app's Default Install Settings do not include the bot scope, " +
+        "so installing it would not add a bot user to the server. Add the " +
+        "bot scope on the portal's Installation page, then rerun.",
+    );
+  }
 
   const url = new URL("https://discord.com/oauth2/authorize");
   url.searchParams.set("client_id", app.id);
@@ -171,8 +200,7 @@ async function printVellum(): Promise<void> {
   // page and generates a link carrying only the client id, so a person who
   // edits those settings sees the change. Spelling them into the URL instead
   // silently overrides what they configured.
-  const configured = app.installScopes.length > 0;
-  if (!configured) {
+  if (!settings) {
     // No Default Install Settings, so the link has to say what to grant.
     // `applications.commands` is deliberately absent: Discord includes it
     // with the `bot` scope, and nothing here registers a command, so asking
@@ -182,7 +210,7 @@ async function printVellum(): Promise<void> {
   }
 
   console.log(url.toString());
-  if (configured) {
+  if (settings) {
     console.error(
       "Using this app's Default Install Settings from the Installation page.",
     );
@@ -192,7 +220,7 @@ async function printVellum(): Promise<void> {
     // group DMs, which arrive guild-less and are admitted by ingress as
     // private DMs. The ingress gate documents that assumption and must learn
     // to tell the two apart before that scope is safe to carry.
-    const surplus = app.installScopes.filter(
+    const surplus = settings.scopes.filter(
       (scope) => scope !== "bot" && scope !== "applications.commands",
     );
     if (surplus.length > 0) {
@@ -203,6 +231,43 @@ async function printVellum(): Promise<void> {
           `bot join group DMs, which inbound handling treats as private DMs.`,
       );
     }
+    warnOnPermissionDrift(settings.permissions);
+  }
+}
+
+/**
+ * Re-check the least-privilege bound the parameterized URL used to carry.
+ *
+ * Administrator grants every permission, which the skill forbids requesting,
+ * and settings missing bits the integration exercises produce a bot that
+ * joins but cannot see or answer. Both are the app owner's settings to fix,
+ * so they warn with the exact edit rather than failing an install that will
+ * technically complete.
+ */
+function warnOnPermissionDrift(permissions: string | undefined): void {
+  if (permissions === undefined || !/^\d+$/.test(permissions)) {
+    return;
+  }
+  const granted = BigInt(permissions);
+  const ADMINISTRATOR = 1n << 3n;
+  if ((granted & ADMINISTRATOR) !== 0n) {
+    console.error(
+      `Warning: the app's Default Install Settings grant Administrator. ` +
+        `This integration needs only ${computeDefaultPermissions()}; set ` +
+        `that on the portal's Installation page instead.`,
+    );
+    return;
+  }
+  const missing = Object.entries(DEFAULT_PERMISSION_BITS)
+    .filter(([, bit]) => (granted & (1n << bit)) === 0n)
+    .map(([name]) => name);
+  if (missing.length > 0) {
+    console.error(
+      `Warning: the app's Default Install Settings omit permissions this ` +
+        `integration uses: ${missing.join(", ")}. The bot may join but fail ` +
+        `to see or answer messages. Grant them on the portal's Installation ` +
+        `page (the full set is ${computeDefaultPermissions()}).`,
+    );
   }
 }
 

--- a/skills/discord-app-setup/scripts/print-invite-url.ts
+++ b/skills/discord-app-setup/scripts/print-invite-url.ts
@@ -135,7 +135,9 @@ function readApplication(body: unknown): DiscordApplication {
       ? body.integration_types_config
       : undefined;
   const guildConfig =
-    typeof typesConfig === "object" && typesConfig !== null && "0" in typesConfig
+    typeof typesConfig === "object" &&
+    typesConfig !== null &&
+    "0" in typesConfig
       ? typesConfig["0"]
       : undefined;
   const guildInstall = readInstallSettings(

--- a/skills/discord-app-setup/scripts/print-invite-url.ts
+++ b/skills/discord-app-setup/scripts/print-invite-url.ts
@@ -36,6 +36,23 @@ const DEFAULT_PERMISSION_BITS: Record<string, bigint> = {
   SEND_MESSAGES_IN_THREADS: 38n,
 };
 
+/**
+ * The permission bits the integration actually exercises, checked against an
+ * app's own Default Install Settings. Derived from the code, not the request
+ * preset above: the transport sends messages and uploads attachments
+ * (`assistant/src/messaging/providers/discord/send.ts`), thread messages are
+ * admitted so replies land in threads, and the typing indicator rides
+ * SEND_MESSAGES. Nothing writes reactions, reads message history, or
+ * registers application commands, so tightening those away must not warn:
+ * an admin who removes bits the code never uses has improved the install.
+ */
+const REQUIRED_PERMISSION_BITS: Record<string, bigint> = {
+  VIEW_CHANNEL: 10n,
+  SEND_MESSAGES: 11n,
+  ATTACH_FILES: 15n,
+  SEND_MESSAGES_IN_THREADS: 38n,
+};
+
 function computeDefaultPermissions(): string {
   let bits = 0n;
   for (const bit of Object.values(DEFAULT_PERMISSION_BITS)) {
@@ -68,7 +85,7 @@ async function revealCredential(
   return stdout.trim();
 }
 
-interface DiscordApplication {
+export interface DiscordApplication {
   id: string;
   /**
    * The app's own install settings, undefined when it has none.
@@ -121,7 +138,7 @@ function readInstallSettings(params: unknown): InstallSettings | undefined {
  * shape Discord did not send should stop here loudly instead of producing a
  * link to nothing.
  */
-function readApplication(body: unknown): DiscordApplication {
+export function readApplication(body: unknown): DiscordApplication {
   if (typeof body !== "object" || body === null) {
     throw new Error("Discord returned a non-object application");
   }
@@ -179,6 +196,31 @@ async function printVellum(): Promise<void> {
   }
 
   const app = await fetchApplication(token);
+  const plan = planInvite(app);
+
+  console.log(plan.url);
+  for (const note of plan.notes) {
+    console.error(note);
+  }
+}
+
+/** The invite URL to print and the stderr notes that go with it. */
+export interface InvitePlan {
+  url: string;
+  notes: string[];
+}
+
+/**
+ * Decide the invite URL for an application, as data so the decision is
+ * testable apart from credential IO and printing.
+ *
+ * Prefers the app's own install link: Discord's current model puts scopes
+ * and permissions in Default Install Settings on the portal's Installation
+ * page and generates a link carrying only the client id, so a person who
+ * edits those settings sees the change. Spelling them into the URL instead
+ * silently overrides what they configured.
+ */
+export function planInvite(app: DiscordApplication): InvitePlan {
   const settings = app.installSettings;
 
   // A client-id-only link installs whatever the settings say, so settings
@@ -197,11 +239,6 @@ async function printVellum(): Promise<void> {
   const url = new URL("https://discord.com/oauth2/authorize");
   url.searchParams.set("client_id", app.id);
 
-  // Prefer the app's own install link. Discord's current model puts scopes
-  // and permissions in Default Install Settings on the portal's Installation
-  // page and generates a link carrying only the client id, so a person who
-  // edits those settings sees the change. Spelling them into the URL instead
-  // silently overrides what they configured.
   if (!settings) {
     // No Default Install Settings, so the link has to say what to grant.
     // `applications.commands` is deliberately absent: Discord includes it
@@ -209,68 +246,71 @@ async function printVellum(): Promise<void> {
     // for it separately requests a permission that is never exercised.
     url.searchParams.set("permissions", computeDefaultPermissions());
     url.searchParams.set("scope", "bot");
+    return { url: url.toString(), notes: [] };
   }
 
-  console.log(url.toString());
-  if (settings) {
-    console.error(
-      "Using this app's Default Install Settings from the Installation page.",
+  const notes = [
+    "Using this app's Default Install Settings from the Installation page.",
+  ];
+  // Deferring to the app's settings means this script no longer bounds what
+  // the install grants, so say when those settings ask for more than the
+  // integration uses. `gdm.join` matters most: it lets the bot be added to
+  // group DMs, which arrive guild-less and are admitted by ingress as
+  // private DMs. The ingress gate documents that assumption and must learn
+  // to tell the two apart before that scope is safe to carry.
+  const surplus = settings.scopes.filter(
+    (scope) => scope !== "bot" && scope !== "applications.commands",
+  );
+  if (surplus.length > 0) {
+    notes.push(
+      `Warning: the app's Default Install Settings request scopes this ` +
+        `integration never uses: ${surplus.join(", ")}. Remove them on the ` +
+        `portal's Installation page. In particular, gdm.join would let the ` +
+        `bot join group DMs, which inbound handling treats as private DMs.`,
     );
-    // Deferring to the app's settings means this script no longer bounds what
-    // the install grants, so say when those settings ask for more than the
-    // integration uses. `gdm.join` matters most: it lets the bot be added to
-    // group DMs, which arrive guild-less and are admitted by ingress as
-    // private DMs. The ingress gate documents that assumption and must learn
-    // to tell the two apart before that scope is safe to carry.
-    const surplus = settings.scopes.filter(
-      (scope) => scope !== "bot" && scope !== "applications.commands",
-    );
-    if (surplus.length > 0) {
-      console.error(
-        `Warning: the app's Default Install Settings request scopes this ` +
-          `integration never uses: ${surplus.join(", ")}. Remove them on the ` +
-          `portal's Installation page. In particular, gdm.join would let the ` +
-          `bot join group DMs, which inbound handling treats as private DMs.`,
-      );
-    }
-    warnOnPermissionDrift(settings.permissions);
   }
+  notes.push(...permissionWarnings(settings.permissions));
+  return { url: url.toString(), notes };
 }
 
 /**
- * Re-check the least-privilege bound the parameterized URL used to carry.
+ * Re-check the bound the parameterized URL used to carry, against the bits
+ * the integration exercises rather than the fallback request preset: the
+ * preset is what we ask for on a fresh app, and an admin who tightened
+ * their settings below it but kept {@link REQUIRED_PERMISSION_BITS} has
+ * improved the install and must not be told to widen it back.
  *
- * Administrator grants every permission, which the skill forbids requesting,
- * and settings missing bits the integration exercises produce a bot that
- * joins but cannot see or answer. Both are the app owner's settings to fix,
- * so they warn with the exact edit rather than failing an install that will
+ * Administrator grants every permission, which the skill forbids
+ * requesting, and settings missing required bits produce a bot that joins
+ * but cannot see or answer. Both are the app owner's settings to fix, so
+ * they warn with the exact edit rather than failing an install that will
  * technically complete.
  */
-function warnOnPermissionDrift(permissions: string | undefined): void {
+export function permissionWarnings(permissions: string | undefined): string[] {
   if (permissions === undefined || !/^\d+$/.test(permissions)) {
-    return;
+    return [];
   }
   const granted = BigInt(permissions);
   const ADMINISTRATOR = 1n << 3n;
   if ((granted & ADMINISTRATOR) !== 0n) {
-    console.error(
+    return [
       `Warning: the app's Default Install Settings grant Administrator. ` +
         `This integration needs only ${computeDefaultPermissions()}; set ` +
         `that on the portal's Installation page instead.`,
-    );
-    return;
+    ];
   }
-  const missing = Object.entries(DEFAULT_PERMISSION_BITS)
+  const missing = Object.entries(REQUIRED_PERMISSION_BITS)
     .filter(([, bit]) => (granted & (1n << bit)) === 0n)
     .map(([name]) => name);
   if (missing.length > 0) {
-    console.error(
+    return [
       `Warning: the app's Default Install Settings omit permissions this ` +
         `integration uses: ${missing.join(", ")}. The bot may join but fail ` +
         `to see or answer messages. Grant them on the portal's Installation ` +
-        `page (the full set is ${computeDefaultPermissions()}).`,
-    );
+        `page (the requested default is ${computeDefaultPermissions()}).`,
+    ];
   }
+  return [];
 }
 
 async function main(): Promise<void> {
@@ -291,4 +331,6 @@ async function main(): Promise<void> {
   }
 }
 
-main();
+if (import.meta.main) {
+  main();
+}


### PR DESCRIPTION
**TL;DR:** The Discord invite URL now defers to the app's own Default Install Settings when they exist, instead of always spelling scopes and permissions into the query string and silently overriding them. Extracted from #41312 as the standalone skill piece of the Discord arc (PR B of the split).

## Why this is safe

- The fallback path is byte-for-byte the old behavior minus a redundant scope: `applications.commands` is included with `bot` by Discord, and nothing in this integration registers a command. A fresh app created by this skill has no Default Install Settings, so new setups take the fallback and see no change in what is granted.
- Deferring to install settings hands control of the grant to the app's owner, so the script now warns on stderr when those settings request scopes the integration never uses. `gdm.join` is called out by name: it would let the bot join group DMs, which arrive guild-less and are admitted by ingress as private DMs (the assumption is documented in `gateway/src/discord/admit.ts`). This closes a gap the original #41312 version left open.
- The `/oauth2/applications/@me` response is narrowed by inspection rather than a cast, so a shape Discord did not send stops the script loudly instead of producing a link to nothing.
- Skill-only change: no product code, no runtime surface.

## What changes for the user

| Before | After |
| --- | --- |
| Editing the app's Installation page did nothing: the invite URL always carried its own scopes and permissions | An app with Default Install Settings gets an invite link that honors them, which is where Discord's own portal sends people to manage the grant |
| The URL requested `applications.commands` separately | The fallback requests `bot` alone; Discord includes commands with it |
| Install settings requesting surplus scopes went unnoticed | The script warns and names `gdm.join` as the one that changes inbound behavior |

## Sequencing

PR B of the #41312 split: independent of #41333 (PR A) and of the in-product Discord PRs that follow. #41312 closes once the remaining pieces (Discord in Channels, config API + wizard) are extracted.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41340" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->