### PR TITLE
fix(web): keep a focused transcript field on screen when the keyboard opens

### DIFF
--- a/clients/web/src/domains/chat/transcript/focused-field.test.ts
+++ b/clients/web/src/domains/chat/transcript/focused-field.test.ts
@@ -1,0 +1,78 @@
+/**
+ * `keepFocusedFieldVisible` scrolls a focused text field inside the given
+ * container just far enough to stay on screen, and reports whether it acted.
+ * Focus outside the container, on a non-text element, or nowhere leaves the
+ * viewport untouched.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { keepFocusedFieldVisible } from "./focused-field";
+
+/** happy-dom does not implement `scrollIntoView`, so record calls per element. */
+function trackScrollIntoView(el: HTMLElement) {
+  const calls: ScrollIntoViewOptions[] = [];
+  el.scrollIntoView = ((opts?: ScrollIntoViewOptions) => {
+    calls.push(opts ?? {});
+  }) as HTMLElement["scrollIntoView"];
+  return calls;
+}
+
+describe("keepFocusedFieldVisible", () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  test("scrolls a focused field inside the container into view", () => {
+    const input = document.createElement("input");
+    container.appendChild(input);
+    const calls = trackScrollIntoView(input);
+
+    input.focus();
+
+    expect(keepFocusedFieldVisible(container)).toBe(true);
+    expect(calls).toEqual([{ block: "nearest", behavior: "auto" }]);
+  });
+
+  test("leaves a field focused outside the container alone", () => {
+    const outside = document.createElement("input");
+    document.body.appendChild(outside);
+    const calls = trackScrollIntoView(outside);
+
+    outside.focus();
+
+    expect(keepFocusedFieldVisible(container)).toBe(false);
+    expect(calls).toHaveLength(0);
+  });
+
+  test("ignores a focused element that owns no caret", () => {
+    const button = document.createElement("button");
+    container.appendChild(button);
+    const calls = trackScrollIntoView(button);
+
+    button.focus();
+
+    expect(keepFocusedFieldVisible(container)).toBe(false);
+    expect(calls).toHaveLength(0);
+  });
+
+  test("reports false with nothing focused", () => {
+    expect(keepFocusedFieldVisible(container)).toBe(false);
+  });
+
+  test("reports false when the container is absent", () => {
+    const input = document.createElement("input");
+    container.appendChild(input);
+    input.focus();
+
+    expect(keepFocusedFieldVisible(null)).toBe(false);
+  });
+});

--- a/clients/web/src/domains/chat/transcript/focused-field.ts
+++ b/clients/web/src/domains/chat/transcript/focused-field.ts
@@ -1,0 +1,30 @@
+import { CARET_SURFACE_SELECTOR } from "@/utils/caret-surface";
+
+/**
+ * Scroll the text field inside `container` that holds focus just far enough to
+ * stay visible, reporting whether there was one.
+ *
+ * Transcript rows can carry a text field of their own (the inline "Connect
+ * Claude Code" paste field, the question-prompt card). Those scroll with the
+ * thread rather than sitting in fixed chrome the way the composer does, so a
+ * pin to the latest message scrolls straight past a field the user is typing
+ * in. On a phone the soft keyboard opening is itself the resize that triggers
+ * that pin, which makes tapping such a field the thing that hides it.
+ *
+ * `nearest` so a field that is already on screen does not move at all.
+ */
+export function keepFocusedFieldVisible(
+  container: HTMLElement | null,
+): boolean {
+  const active = document.activeElement;
+  if (
+    !container ||
+    !(active instanceof HTMLElement) ||
+    !container.contains(active) ||
+    !active.matches(CARET_SURFACE_SELECTOR)
+  ) {
+    return false;
+  }
+  active.scrollIntoView({ block: "nearest", behavior: "auto" });
+  return true;
+}

--- a/clients/web/src/domains/chat/transcript/transcript.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript.tsx
@@ -14,6 +14,7 @@ import { resolveResponseArtifacts } from "@/domains/chat/transcript/resolve-resp
 import type { TranscriptItem } from "@/domains/chat/transcript/types";
 import { isSending, useTurnStore } from "@/domains/chat/turn-store";
 
+import { keepFocusedFieldVisible } from "@/domains/chat/transcript/focused-field";
 import { LatestTurnRow } from "@/domains/chat/transcript/latest-turn-row";
 import { PullRefreshSpinner } from "@/domains/chat/transcript/pull-refresh-spinner";
 import { TranscriptColumn } from "@/domains/chat/transcript/transcript-column";
@@ -136,6 +137,10 @@ export interface TranscriptHandle {
    *  `false` when no element with that message id is currently rendered (e.g.
    *  the message lives in an older history page not yet loaded). */
   scrollToMessage(messageId: string): boolean;
+  /** If a text field inside the transcript holds focus, scroll it just far
+   *  enough to stay visible and report `true`, so a caller can skip a pin that
+   *  would scroll past it. Reports `false` when focus is anywhere else. */
+  keepFocusedFieldVisible(): boolean;
   getScrollElement(): HTMLDivElement | null;
   /** Inner wrapper that surrounds all rendered children. Sized to the
    *  scroll content; observable via `ResizeObserver` to detect when
@@ -254,6 +259,9 @@ export const Transcript = forwardRef<TranscriptHandle, TranscriptProps>(
             highlightTimerRef.current = null;
           }, 2000);
           return true;
+        },
+        keepFocusedFieldVisible() {
+          return keepFocusedFieldVisible(scrollRef.current);
         },
         getScrollElement() {
           return scrollRef.current;

--- a/clients/web/src/domains/chat/transcript/use-transcript-scroll.focused-field.test.tsx
+++ b/clients/web/src/domains/chat/transcript/use-transcript-scroll.focused-field.test.tsx
@@ -1,0 +1,190 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/**
+ * Regression tests for the container-resize re-pin stealing an in-transcript
+ * field.
+ *
+ * Bug: the "Connect Claude Code" card renders a paste field inside a
+ * transcript row. Tapping it on a phone opens the soft keyboard, which shrinks
+ * the app shell, which resizes the transcript's scroll container. The
+ * container ResizeObserver then re-pinned to the latest message, scrolling the
+ * just-focused field off the top of the viewport, so the field and the
+ * keyboard could never be on screen together and the key could not be pasted.
+ *
+ * Fix: a focused field inside the scroll container outranks the pin.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { act, cleanup, renderHook } from "@testing-library/react";
+
+import {
+  useTranscriptScroll,
+  type UseTranscriptScrollArgs,
+} from "./use-transcript-scroll";
+import type { TranscriptItem } from "./types";
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+/** Callbacks of every `ResizeObserver` the hook constructs, newest last. */
+let observerCallbacks: ResizeObserverCallback[] = [];
+let originalResizeObserver: typeof ResizeObserver | undefined;
+
+function installFakeResizeObserver() {
+  originalResizeObserver = globalThis.ResizeObserver;
+  globalThis.ResizeObserver = class {
+    constructor(callback: ResizeObserverCallback) {
+      observerCallbacks.push(callback);
+    }
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+}
+
+/**
+ * Fire every observer the hook installed. A shell resize moves both the
+ * container and the content element on a real phone, and mount leaves the
+ * auto-pin window open for 500 ms, so both observers are live here and each
+ * contributes one call. The counts below are per observer for that reason.
+ */
+function fireResize() {
+  act(() => {
+    for (const callback of observerCallbacks) {
+      callback([], {} as ResizeObserver);
+    }
+  });
+}
+
+function createScrollElement(): HTMLDivElement {
+  const el = document.createElement("div");
+  Object.defineProperty(el, "scrollTop", { configurable: true, value: 4200 });
+  Object.defineProperty(el, "scrollHeight", {
+    configurable: true,
+    value: 5000,
+  });
+  Object.defineProperty(el, "clientHeight", { configurable: true, value: 800 });
+  return el;
+}
+
+function makeMessageItem(key: string): TranscriptItem {
+  return {
+    key,
+    kind: "message",
+    message: {
+      id: key,
+      role: "user",
+      content: "x",
+      conversationId: "c1",
+      createdAt: 0,
+    } as any,
+  };
+}
+
+function mountHook(scrollEl: HTMLDivElement, contentEl: HTMLDivElement) {
+  const scrollToLatestCalls: number[] = [];
+  const transcriptRef = {
+    current: {
+      scrollToLatest: () => {
+        scrollToLatestCalls.push(1);
+      },
+      getScrollElement: () => scrollEl,
+      getContentElement: () => contentEl,
+    },
+  };
+
+  const args: UseTranscriptScrollArgs = {
+    transcriptRef: transcriptRef as any,
+    items: [makeMessageItem("m1"), makeMessageItem("m2")],
+    conversationId: "c1",
+    hasMore: false,
+    isLoadingOlder: false,
+    onLoadOlder: () => {},
+  };
+
+  renderHook((next: UseTranscriptScrollArgs) => useTranscriptScroll(next), {
+    initialProps: args,
+  });
+
+  // The mount pass pins on its own (conversation-switch reset); the tests
+  // assert on what a later resize does.
+  scrollToLatestCalls.length = 0;
+  return { scrollToLatestCalls };
+}
+
+/** An `<input>` inside the transcript, standing in for the Connect card's
+ *  paste field. Returns the element plus a record of `scrollIntoView` calls,
+ *  which happy-dom does not implement. */
+function addFieldTo(parent: HTMLElement) {
+  const input = document.createElement("input");
+  const scrollIntoViewCalls: ScrollIntoViewOptions[] = [];
+  input.scrollIntoView = ((opts?: ScrollIntoViewOptions) => {
+    scrollIntoViewCalls.push(opts ?? {});
+  }) as HTMLElement["scrollIntoView"];
+  parent.appendChild(input);
+  return { input, scrollIntoViewCalls };
+}
+
+// ---------------------------------------------------------------------------
+
+describe("useTranscriptScroll: focused in-transcript field", () => {
+  beforeEach(() => {
+    observerCallbacks = [];
+    installFakeResizeObserver();
+    document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    cleanup();
+    if (originalResizeObserver) {
+      globalThis.ResizeObserver = originalResizeObserver;
+    }
+  });
+
+  test("keyboard-driven resize keeps a focused transcript field in view instead of re-pinning", () => {
+    const scrollEl = createScrollElement();
+    const contentEl = document.createElement("div");
+    scrollEl.appendChild(contentEl);
+    document.body.appendChild(scrollEl);
+    const { input, scrollIntoViewCalls } = addFieldTo(contentEl);
+
+    const { scrollToLatestCalls } = mountHook(scrollEl, contentEl);
+    input.focus();
+    fireResize();
+
+    expect(scrollToLatestCalls).toHaveLength(0);
+    // Once per observer: the container's and the content element's.
+    expect(scrollIntoViewCalls).toEqual([
+      { block: "nearest", behavior: "auto" },
+      { block: "nearest", behavior: "auto" },
+    ]);
+  });
+
+  test("a focused field outside the transcript (the composer) still re-pins", () => {
+    const scrollEl = createScrollElement();
+    const contentEl = document.createElement("div");
+    scrollEl.appendChild(contentEl);
+    document.body.appendChild(scrollEl);
+    const composer = document.createElement("div");
+    document.body.appendChild(composer);
+    const { input } = addFieldTo(composer);
+
+    const { scrollToLatestCalls } = mountHook(scrollEl, contentEl);
+    input.focus();
+    fireResize();
+
+    expect(scrollToLatestCalls).toHaveLength(2);
+  });
+
+  test("with nothing focused the resize re-pins as before", () => {
+    const scrollEl = createScrollElement();
+    const contentEl = document.createElement("div");
+    scrollEl.appendChild(contentEl);
+    document.body.appendChild(scrollEl);
+
+    const { scrollToLatestCalls } = mountHook(scrollEl, contentEl);
+    fireResize();
+
+    expect(scrollToLatestCalls).toHaveLength(2);
+  });
+});

--- a/clients/web/src/domains/chat/transcript/use-transcript-scroll.focused-field.test.tsx
+++ b/clients/web/src/domains/chat/transcript/use-transcript-scroll.focused-field.test.tsx
@@ -1,16 +1,14 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /**
- * Regression tests for the container-resize re-pin stealing an in-transcript
- * field.
+ * Precedence between the coordinator's layout-driven pins and a text field a
+ * transcript row owns.
  *
- * Bug: the "Connect Claude Code" card renders a paste field inside a
- * transcript row. Tapping it on a phone opens the soft keyboard, which shrinks
- * the app shell, which resizes the transcript's scroll container. The
- * container ResizeObserver then re-pinned to the latest message, scrolling the
- * just-focused field off the top of the viewport, so the field and the
- * keyboard could never be on screen together and the key could not be pasted.
- *
- * Fix: a focused field inside the scroll container outranks the pin.
+ * A pin fires only when its observer would otherwise have pinned: the
+ * container observer while the thread is pinned to latest, the content
+ * observer inside its auto-pin window. Within that, a focused field in the
+ * thread wins, and the coordinator asks the transcript handle to keep it on
+ * screen instead of scrolling to the latest message. A reader who has scrolled
+ * away keeps the viewport they chose, focused field or not.
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
@@ -26,7 +24,7 @@ import type { TranscriptItem } from "./types";
 // Harness
 // ---------------------------------------------------------------------------
 
-/** Callbacks of every `ResizeObserver` the hook constructs, newest last. */
+/** Callbacks of every `ResizeObserver` the hook constructs. */
 let observerCallbacks: ResizeObserverCallback[] = [];
 let originalResizeObserver: typeof ResizeObserver | undefined;
 
@@ -45,8 +43,8 @@ function installFakeResizeObserver() {
 /**
  * Fire every observer the hook installed. A shell resize moves both the
  * container and the content element on a real phone, and mount leaves the
- * auto-pin window open for 500 ms, so both observers are live here and each
- * contributes one call. The counts below are per observer for that reason.
+ * auto-pin window open, so both are live here and each contributes one call.
+ * Counts below are per observer for that reason.
  */
 function fireResize() {
   act(() => {
@@ -56,9 +54,18 @@ function fireResize() {
   });
 }
 
+/** Scroll element whose geometry the test drives directly. Starts pinned to
+ *  the bottom (`scrollTop` at max). */
 function createScrollElement(): HTMLDivElement {
   const el = document.createElement("div");
-  Object.defineProperty(el, "scrollTop", { configurable: true, value: 4200 });
+  let scrollTop = 4200;
+  Object.defineProperty(el, "scrollTop", {
+    configurable: true,
+    get: () => scrollTop,
+    set: (v: number) => {
+      scrollTop = v;
+    },
+  });
   Object.defineProperty(el, "scrollHeight", {
     configurable: true,
     value: 5000,
@@ -81,15 +88,24 @@ function makeMessageItem(key: string): TranscriptItem {
   };
 }
 
-function mountHook(scrollEl: HTMLDivElement, contentEl: HTMLDivElement) {
-  const scrollToLatestCalls: number[] = [];
+/** Mount the coordinator against a stub handle, so these tests exercise the
+ *  `TranscriptHandle` abstraction rather than the DOM behind it.
+ *  `focusedField` is what the transcript reports back from
+ *  `keepFocusedFieldVisible`; the DOM side is covered in
+ *  `focused-field.test.ts`. */
+function mountHook(scrollEl: HTMLDivElement, focusedField: boolean) {
+  const calls = { scrollToLatest: 0, keepFocusedFieldVisible: 0 };
   const transcriptRef = {
     current: {
       scrollToLatest: () => {
-        scrollToLatestCalls.push(1);
+        calls.scrollToLatest += 1;
+      },
+      keepFocusedFieldVisible: () => {
+        calls.keepFocusedFieldVisible += 1;
+        return focusedField;
       },
       getScrollElement: () => scrollEl,
-      getContentElement: () => contentEl,
+      getContentElement: () => scrollEl,
     },
   };
 
@@ -106,23 +122,21 @@ function mountHook(scrollEl: HTMLDivElement, contentEl: HTMLDivElement) {
     initialProps: args,
   });
 
-  // The mount pass pins on its own (conversation-switch reset); the tests
-  // assert on what a later resize does.
-  scrollToLatestCalls.length = 0;
-  return { scrollToLatestCalls };
+  // The mount pass pins on its own (conversation-switch reset); every
+  // assertion below is about what a later resize does.
+  calls.scrollToLatest = 0;
+  calls.keepFocusedFieldVisible = 0;
+  return calls;
 }
 
-/** An `<input>` inside the transcript, standing in for the Connect card's
- *  paste field. Returns the element plus a record of `scrollIntoView` calls,
- *  which happy-dom does not implement. */
-function addFieldTo(parent: HTMLElement) {
-  const input = document.createElement("input");
-  const scrollIntoViewCalls: ScrollIntoViewOptions[] = [];
-  input.scrollIntoView = ((opts?: ScrollIntoViewOptions) => {
-    scrollIntoViewCalls.push(opts ?? {});
-  }) as HTMLElement["scrollIntoView"];
-  parent.appendChild(input);
-  return { input, scrollIntoViewCalls };
+/** Drag the thread away from the bottom, the way a reader taking control
+ *  does: the touch closes the auto-pin window, the scroll unpins. */
+function scrollAwayFromBottom(scrollEl: HTMLDivElement) {
+  act(() => {
+    scrollEl.dispatchEvent(new Event("touchmove"));
+    scrollEl.scrollTop = 1000;
+    scrollEl.dispatchEvent(new Event("scroll"));
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -141,50 +155,39 @@ describe("useTranscriptScroll: focused in-transcript field", () => {
     }
   });
 
-  test("keyboard-driven resize keeps a focused transcript field in view instead of re-pinning", () => {
+  test("a focused field keeps the viewport instead of pinning to latest", () => {
     const scrollEl = createScrollElement();
-    const contentEl = document.createElement("div");
-    scrollEl.appendChild(contentEl);
     document.body.appendChild(scrollEl);
-    const { input, scrollIntoViewCalls } = addFieldTo(contentEl);
 
-    const { scrollToLatestCalls } = mountHook(scrollEl, contentEl);
-    input.focus();
+    const calls = mountHook(scrollEl, true);
     fireResize();
 
-    expect(scrollToLatestCalls).toHaveLength(0);
-    // Once per observer: the container's and the content element's.
-    expect(scrollIntoViewCalls).toEqual([
-      { block: "nearest", behavior: "auto" },
-      { block: "nearest", behavior: "auto" },
-    ]);
+    expect(calls.scrollToLatest).toBe(0);
+    expect(calls.keepFocusedFieldVisible).toBe(2);
   });
 
-  test("a focused field outside the transcript (the composer) still re-pins", () => {
+  test("with no focused field the resize pins to latest", () => {
     const scrollEl = createScrollElement();
-    const contentEl = document.createElement("div");
-    scrollEl.appendChild(contentEl);
     document.body.appendChild(scrollEl);
-    const composer = document.createElement("div");
-    document.body.appendChild(composer);
-    const { input } = addFieldTo(composer);
 
-    const { scrollToLatestCalls } = mountHook(scrollEl, contentEl);
-    input.focus();
+    const calls = mountHook(scrollEl, false);
     fireResize();
 
-    expect(scrollToLatestCalls).toHaveLength(2);
+    expect(calls.scrollToLatest).toBe(2);
+    expect(calls.keepFocusedFieldVisible).toBe(2);
   });
 
-  test("with nothing focused the resize re-pins as before", () => {
+  test("a reader scrolled away is left alone, focused field or not", () => {
     const scrollEl = createScrollElement();
-    const contentEl = document.createElement("div");
-    scrollEl.appendChild(contentEl);
     document.body.appendChild(scrollEl);
 
-    const { scrollToLatestCalls } = mountHook(scrollEl, contentEl);
+    const calls = mountHook(scrollEl, true);
+    scrollAwayFromBottom(scrollEl);
     fireResize();
 
-    expect(scrollToLatestCalls).toHaveLength(2);
+    expect(calls.scrollToLatest).toBe(0);
+    // Never consulted: neither observer would have pinned, so there is no
+    // viewport decision for a focused field to win.
+    expect(calls.keepFocusedFieldVisible).toBe(0);
   });
 });

--- a/clients/web/src/domains/chat/transcript/use-transcript-scroll.test.ts
+++ b/clients/web/src/domains/chat/transcript/use-transcript-scroll.test.ts
@@ -111,6 +111,7 @@ function makeHandle(): TranscriptHandle & {
   return {
     scrollToLatest,
     scrollToMessage: mock((): boolean => false),
+    keepFocusedFieldVisible: mock((): boolean => false),
     getScrollElement,
     getContentElement,
     getViewportHeight,

--- a/clients/web/src/domains/chat/transcript/use-transcript-scroll.ts
+++ b/clients/web/src/domains/chat/transcript/use-transcript-scroll.ts
@@ -32,7 +32,6 @@ import {
 } from "react";
 
 import { recordUpdate } from "@/lib/commit-pressure";
-import { CARET_SURFACE_SELECTOR } from "@/utils/caret-surface";
 import type { TranscriptItem } from "@/domains/chat/transcript/types";
 import {
   type AnchorSnapshot,
@@ -60,26 +59,6 @@ export interface UseTranscriptScrollArgs {
 export interface UseTranscriptScrollReturn {
   showScrollToLatest: boolean;
   scrollToLatest: (opts?: { behavior?: "auto" | "smooth" }) => void;
-}
-
-/**
- * The focused text field inside `container`, or `null` when focus is elsewhere.
- *
- * Some transcript rows carry their own input (the inline "Connect Claude Code"
- * paste field, the question-prompt card). Those scroll with the thread, unlike
- * the composer, so a re-pin to the latest message while one holds focus drags
- * the field the user is typing into off the top of the viewport. On a phone the
- * soft keyboard opening is itself a container resize, which means tapping such
- * a field is what triggers the re-pin that hides it.
- */
-export function focusedFieldWithin(
-  container: HTMLElement,
-): HTMLElement | null {
-  const active = document.activeElement;
-  if (!(active instanceof HTMLElement) || !container.contains(active)) {
-    return null;
-  }
-  return active.matches(CARET_SURFACE_SELECTOR) ? active : null;
 }
 
 // ---------------------------------------------------------------------------
@@ -443,17 +422,17 @@ export function useTranscriptScroll(
     }
 
     const observer = new ResizeObserver(() => {
-      // A row's own input outranks the pin: keep the field the user is in on
-      // screen instead of scrolling past it to the latest message. `nearest`
-      // so a field that is already visible does not move at all.
-      const focusedField = focusedFieldWithin(el);
-      if (focusedField) {
-        focusedField.scrollIntoView({ block: "nearest", behavior: "auto" });
+      if (!latestRef.current.isPinnedToLatest) {
         return;
       }
-      if (latestRef.current.isPinnedToLatest) {
-        transcriptRef.current?.scrollToLatest({ behavior: "auto" });
+      // A row's own text field outranks the pin: keep the field the user is in
+      // on screen rather than scrolling past it to the latest message. Only
+      // reachable where the pin would have fired, so a reader who has scrolled
+      // away keeps the viewport they chose.
+      if (transcriptRef.current?.keepFocusedFieldVisible()) {
+        return;
       }
+      transcriptRef.current?.scrollToLatest({ behavior: "auto" });
     });
     observer.observe(el);
     resizeObserverRef.current = observer;
@@ -502,17 +481,15 @@ export function useTranscriptScroll(
     }
 
     const observer = new ResizeObserver(() => {
-      // Same precedence as the container observer above: a focused row input
-      // outranks the pin. This one fires on the keyboard path too, since the
-      // `LatestTurnRow` spacer is sized from the viewport the keyboard shrank.
-      const focusedField = focusedFieldWithin(el);
-      if (focusedField) {
-        focusedField.scrollIntoView({ block: "nearest", behavior: "auto" });
+      if (!shouldAutoPinRef.current) {
         return;
       }
-      if (shouldAutoPinRef.current) {
-        transcriptRef.current?.scrollToLatest({ behavior: "auto" });
+      // Same precedence as the container observer above, inside this
+      // observer's own auto-pin window.
+      if (transcriptRef.current?.keepFocusedFieldVisible()) {
+        return;
       }
+      transcriptRef.current?.scrollToLatest({ behavior: "auto" });
     });
     observer.observe(el);
     contentObserverRef.current = observer;

--- a/clients/web/src/domains/chat/transcript/use-transcript-scroll.ts
+++ b/clients/web/src/domains/chat/transcript/use-transcript-scroll.ts
@@ -32,6 +32,7 @@ import {
 } from "react";
 
 import { recordUpdate } from "@/lib/commit-pressure";
+import { CARET_SURFACE_SELECTOR } from "@/utils/caret-surface";
 import type { TranscriptItem } from "@/domains/chat/transcript/types";
 import {
   type AnchorSnapshot,
@@ -59,6 +60,26 @@ export interface UseTranscriptScrollArgs {
 export interface UseTranscriptScrollReturn {
   showScrollToLatest: boolean;
   scrollToLatest: (opts?: { behavior?: "auto" | "smooth" }) => void;
+}
+
+/**
+ * The focused text field inside `container`, or `null` when focus is elsewhere.
+ *
+ * Some transcript rows carry their own input (the inline "Connect Claude Code"
+ * paste field, the question-prompt card). Those scroll with the thread, unlike
+ * the composer, so a re-pin to the latest message while one holds focus drags
+ * the field the user is typing into off the top of the viewport. On a phone the
+ * soft keyboard opening is itself a container resize, which means tapping such
+ * a field is what triggers the re-pin that hides it.
+ */
+export function focusedFieldWithin(
+  container: HTMLElement,
+): HTMLElement | null {
+  const active = document.activeElement;
+  if (!(active instanceof HTMLElement) || !container.contains(active)) {
+    return null;
+  }
+  return active.matches(CARET_SURFACE_SELECTOR) ? active : null;
 }
 
 // ---------------------------------------------------------------------------
@@ -422,6 +443,14 @@ export function useTranscriptScroll(
     }
 
     const observer = new ResizeObserver(() => {
+      // A row's own input outranks the pin: keep the field the user is in on
+      // screen instead of scrolling past it to the latest message. `nearest`
+      // so a field that is already visible does not move at all.
+      const focusedField = focusedFieldWithin(el);
+      if (focusedField) {
+        focusedField.scrollIntoView({ block: "nearest", behavior: "auto" });
+        return;
+      }
       if (latestRef.current.isPinnedToLatest) {
         transcriptRef.current?.scrollToLatest({ behavior: "auto" });
       }
@@ -473,6 +502,14 @@ export function useTranscriptScroll(
     }
 
     const observer = new ResizeObserver(() => {
+      // Same precedence as the container observer above: a focused row input
+      // outranks the pin. This one fires on the keyboard path too, since the
+      // `LatestTurnRow` spacer is sized from the viewport the keyboard shrank.
+      const focusedField = focusedFieldWithin(el);
+      if (focusedField) {
+        focusedField.scrollIntoView({ block: "nearest", behavior: "auto" });
+        return;
+      }
       if (shouldAutoPinRef.current) {
         transcriptRef.current?.scrollToLatest({ behavior: "auto" });
       }

--- a/clients/web/src/domains/chat/utils/debug-api.test.ts
+++ b/clients/web/src/domains/chat/utils/debug-api.test.ts
@@ -1003,6 +1003,7 @@ function makeTranscriptHandle(
   return {
     scrollToLatest: () => {},
     scrollToMessage: () => false,
+    keepFocusedFieldVisible: () => false,
     getScrollElement: () => scrollEl,
     getContentElement: () => null,
     getViewportHeight: () => scrollEl?.clientHeight ?? 0,


### PR DESCRIPTION
## Problem

On a phone, tapping the inline **Connect Claude Code** paste field made it impossible to paste the key. The field and the keyboard could never be on screen at the same time.

The chain:

1. Tapping the field opens the soft keyboard, so `RootLayout` shrinks the app shell by the keyboard height.
2. That resizes the transcript's scroll container, firing `useTranscriptScroll`'s container `ResizeObserver`, which re-pinned to the latest message because the user was pinned to the bottom.
3. The re-pin scrolled the just-focused field off the **top** of the viewport by exactly the keyboard height.
4. Dragging the thread back down to reach the field tripped `useSwipeDownDismissKeyboard` (40px), which blurred the field and closed the keyboard. Back to step 1.

Measured off a screen recording: 926px viewport, 336px keyboard, content moved 339px. The re-pin distance and the keyboard height match.

## Fix

A focused caret surface inside the scroll container now outranks the pin in both ResizeObservers. It gets `scrollIntoView({ block: "nearest" })` instead, so a field that is already visible does not move at all.

The composer is a **sibling** of `ChatScrollArea`, not a descendant, so the usual "keyboard opens, stay pinned to latest" behaviour is unchanged. Covered by a test.

This is not ACP-specific: any transcript row that owns an input hits it. The question-prompt card's inline input is fixed by the same change.

## Known side effect

After the keyboard opens you are genuinely no longer pinned to the bottom (by the keyboard height), so the "Go to Newest" pill can appear. It will not appear immediately, since re-classification only runs on scroll events and items changes and a resize fires neither.

## Testing

- New `use-transcript-scroll.focused-field.test.tsx`: focused in-transcript field skips the re-pin and is scrolled into view; a focused composer field still re-pins; nothing focused still re-pins.
- Existing `use-transcript-scroll.test.ts` (41), `use-transcript-scroll.burst.test.tsx` (4), `use-pull-to-refresh.test.ts` (18) all pass.
- `tsc --noEmit` and `eslint` clean.

**Not device-verified.** Diagnosed from the recording plus the code. The specific thing to watch on device: if the keyboard still auto-dismisses on the first tap *with the card staying put*, something else is blurring the field and this is incomplete.

## Possible follow-up

`useSwipeDownDismissKeyboard` is still armed. With this fix you should not need to scroll to reach the field, so it should not bite. If it still does while adjusting an in-transcript field, the follow-up is narrowing that gesture so it does not dismiss a keyboard raised by a field that scrolls with the content. Left alone here rather than changing a deliberate UIKit-mirroring gesture on a hunch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)