### PR TITLE
Keep read-only profile fields out of config PATCH bodies

### DIFF
--- a/.github/workflows/ci-main-web.yaml
+++ b/.github/workflows/ci-main-web.yaml
@@ -10,6 +10,9 @@ on:
       - 'patches/**'
       - 'clients/web/**'
       - 'assistant/src/api/**'
+      # `openapi-ts` generates the web's daemon client from this spec, so a
+      # schema change here can break the web build with no web file touched.
+      - 'assistant/openapi.yaml'
       - 'packages/design-library/**'
       - 'packages/local-mode/**'
       - 'packages/environments/**'

--- a/.github/workflows/pr-web.yaml
+++ b/.github/workflows/pr-web.yaml
@@ -9,6 +9,9 @@ on:
       - 'patches/**'
       - 'clients/web/**'
       - 'assistant/src/api/**'
+      # `openapi-ts` generates the web's daemon client from this spec, so a
+      # schema change here can break the web build with no web file touched.
+      - 'assistant/openapi.yaml'
       - 'packages/design-library/**'
       - 'packages/local-mode/**'
       - 'packages/environments/**'

--- a/clients/web/src/components/profile-quick-add-provider.tsx
+++ b/clients/web/src/components/profile-quick-add-provider.tsx
@@ -39,7 +39,7 @@ import {
 } from "react";
 
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
-import type { ProfilePatchEntry } from "@/generated/daemon/types.gen";
+import type { ProfilePatchEntryWritable } from "@/generated/daemon/types.gen";
 import { ProfileEditorModal } from "@/domains/settings/ai/profile-editor-modal";
 import { configGet, configPatch } from "@/generated/daemon/sdk.gen";
 import {
@@ -136,7 +136,7 @@ export function ProfileQuickAddProvider({ children }: { children: ReactNode }) {
   // new name, dropping every existing profile's position. Reading the latest
   // config here keeps the append authoritative regardless of stale inputs.
   const handleSave = useCallback(
-    async (name: string, entry: ProfilePatchEntry) => {
+    async (name: string, entry: ProfilePatchEntryWritable) => {
       if (!assistantId) {
         return;
       }

--- a/clients/web/src/domains/settings/ai/profile-editor-modal.tsx
+++ b/clients/web/src/domains/settings/ai/profile-editor-modal.tsx
@@ -11,7 +11,7 @@ import {
   type ProfileEditorMode,
 } from "@/domains/settings/ai/use-profile-editor";
 import type {
-  ProfilePatchEntry,
+  ProfilePatchEntryWritable,
   ProviderConnection,
 } from "@/generated/daemon/types.gen";
 
@@ -44,7 +44,7 @@ export interface ProfileEditorModalProps {
   /** See `UseProfileEditorArgs.onSave` for the merge/replace contract. */
   onSave: (
     name: string,
-    entry: ProfilePatchEntry,
+    entry: ProfilePatchEntryWritable,
     options?: { mode?: "merge" | "replace" },
   ) => Promise<void>;
   onCancel: () => void;

--- a/clients/web/src/domains/settings/ai/use-profile-actions.ts
+++ b/clients/web/src/domains/settings/ai/use-profile-actions.ts
@@ -11,7 +11,7 @@ import {
 import { captureError } from "@/lib/sentry/capture-error";
 import { useSupportsActiveProfileRoute } from "@/lib/backwards-compat/use-supports-active-profile-route";
 import { badRequestMessage } from "@/utils/api-errors";
-import type { ConfigPatchRequest } from "@/generated/daemon/types.gen";
+import type { ConfigPatchRequestWritable } from "@/generated/daemon/types.gen";
 
 const MAKE_ACTIVE_ERROR_CONTEXT = "settings-ai-profile-make-active";
 const MAKE_ACTIVE_ERROR_MESSAGE =
@@ -34,7 +34,7 @@ export interface ProfileActions {
   ) => Promise<void>;
   /** Arbitrary `llm` patch used by the blocked-delete reassign step. */
   patchLlm: (
-    llm: NonNullable<ConfigPatchRequest["llm"]>,
+    llm: NonNullable<ConfigPatchRequestWritable["llm"]>,
     errorContext: string,
     errorMessage: string,
   ) => Promise<void>;
@@ -74,7 +74,7 @@ export function useProfileActions(assistantId: string): ProfileActions {
   });
 
   async function patchLlm(
-    llm: NonNullable<ConfigPatchRequest["llm"]>,
+    llm: NonNullable<ConfigPatchRequestWritable["llm"]>,
     errorContext: string,
     errorMessage: string,
   ): Promise<void> {

--- a/clients/web/src/domains/settings/ai/use-profile-delete-flow.ts
+++ b/clients/web/src/domains/settings/ai/use-profile-delete-flow.ts
@@ -20,7 +20,7 @@ import {
 import type {
   CallSiteOverrideDraft,
   ConfigGetResponse,
-  ConfigPatchRequest,
+  ConfigPatchRequestWritable,
 } from "@/generated/daemon/types.gen";
 import { captureError } from "@/lib/sentry/capture-error";
 import { badRequestMessage } from "@/utils/api-errors";
@@ -306,7 +306,7 @@ export function useProfileDeleteFlow(
       }
     }
 
-    const llmPatch: NonNullable<ConfigPatchRequest["llm"]> = {};
+    const llmPatch: NonNullable<ConfigPatchRequestWritable["llm"]> = {};
     if (blocked.isActive) {
       llmPatch.activeProfile = replacement;
     }

--- a/clients/web/src/domains/settings/ai/use-profile-editor.ts
+++ b/clients/web/src/domains/settings/ai/use-profile-editor.ts
@@ -43,7 +43,7 @@ import {
 import type {
   ConnectionProvider,
   ProfileEntry,
-  ProfilePatchEntry,
+  ProfilePatchEntryWritable,
   ProfileStatus,
   ProviderConnection,
 } from "@/generated/daemon/types.gen";
@@ -100,7 +100,7 @@ export interface UseProfileEditorArgs {
    */
   onSave: (
     name: string,
-    entry: ProfilePatchEntry,
+    entry: ProfilePatchEntryWritable,
     options?: { mode?: "merge" | "replace" },
   ) => Promise<void>;
 }
@@ -684,7 +684,7 @@ export function useProfileEditor({
     setSaving(true);
     setSaveError(null);
     try {
-      const entry: ProfilePatchEntry = {};
+      const entry: ProfilePatchEntryWritable = {};
       // Stale bindings are auto-cleared on save; when providerConnection is
       // empty and there's exactly one available connection, resolve to that
       // connection's name so profiles always persist with an explicit binding.

--- a/clients/web/src/domains/settings/ai/use-profile-save.ts
+++ b/clients/web/src/domains/settings/ai/use-profile-save.ts
@@ -9,7 +9,21 @@ import { t } from "@/i18n";
 import { captureError } from "@/lib/sentry/capture-error";
 import { configGetOptions } from "@/generated/daemon/@tanstack/react-query.gen";
 import { inferenceProfilesByNameValidatePost } from "@/generated/daemon/sdk.gen";
-import type { ProfilePatchEntry } from "@/generated/daemon/types.gen";
+import type {
+  ProfileEntry,
+  ProfilePatchEntryWritable,
+} from "@/generated/daemon/types.gen";
+
+/**
+ * Drop the server-owned fields a config PATCH may not carry. `fallbackProfile`
+ * is set by the daemon from its own table and rejected on the way back in, so
+ * an entry read out of the config document has to be stripped before it can be
+ * re-sent.
+ */
+function toWritableEntry(entry: ProfileEntry): ProfilePatchEntryWritable {
+  const { fallbackProfile: _fallbackProfile, ...writable } = entry;
+  return writable;
+}
 
 /**
  * Probe the just-saved profile with one minimal request and surface a
@@ -67,7 +81,7 @@ export interface ProfileSave {
    */
   saveProfile: (
     name: string,
-    entry: ProfilePatchEntry,
+    entry: ProfilePatchEntryWritable,
     options?: { mode?: "merge" | "replace" },
   ) => Promise<void>;
   isPending: boolean;
@@ -91,7 +105,7 @@ export function useProfileSave(
 
   async function saveProfile(
     name: string,
-    entry: ProfilePatchEntry,
+    entry: ProfilePatchEntryWritable,
     options?: { mode?: "merge" | "replace" },
   ) {
     const saveMode = options?.mode ?? "replace";
@@ -107,7 +121,7 @@ export function useProfileSave(
     }
 
     const llmPatch: {
-      profiles: Record<string, ProfilePatchEntry>;
+      profiles: Record<string, ProfilePatchEntryWritable>;
       profileOrder?: string[];
     } = { profiles: { [name]: entry } };
     if (isNew) {
@@ -136,7 +150,9 @@ export function useProfileSave(
           await configMutation
             .mutateAsync({
               path: { assistant_id: assistantId },
-              body: { llm: { profiles: { [name]: oldEntry } } },
+              body: {
+                llm: { profiles: { [name]: toWritableEntry(oldEntry) } },
+              },
             })
             .catch(() => {
               /* rollback failed - original error still propagates */


### PR DESCRIPTION
**Web type check is failing on `main` right now**, and has been since #41262 merged. Every open web PR fails the same way. This unblocks them.

## What broke

#41262 marked `fallbackProfile` as `readOnly` in the daemon schema and in `assistant/openapi.yaml`. `openapi-ts` responds to `readOnly` by emitting a separate request type (`ProfilePatchEntryWritable`, `ConfigPatchRequestWritable`) in which that field can only be `null`. The profile write path was passing read-side entry types into config PATCH bodies, so it stopped type-checking: 6 errors across `use-profile-save.ts`, `use-profile-actions.ts`, and `profile-quick-add-provider.tsx`.

The `readOnly` marking is right, so the fix is on the web side.

## The fix

The write path now states the request types it actually sends.

Every site but one is user-authored: `use-profile-editor.ts` builds its entry field by field, and `fallbackProfile` appears nowhere in `clients/web/src` outside generated code, so those are type-only changes with no emitted-JS difference. The `onSave` prop is a property-position function type, so `strictFunctionTypes` makes the parameter contravariant and the whole editor chain has to move together.

The exception is the rollback in `use-profile-save.ts`, which re-sends an entry read back out of the config document. That one is stripped through a small local `toWritableEntry`, and it is a real fix rather than a cast: `assistant/src/config/schemas/llm.ts` rejects a client-sent `fallbackProfile` unless the profile is `source: "managed"` and the value equals the code-owned `FALLBACK_PROFILE_BY_KEY` entry, so the rollback PATCH could 400 at precisely the moment it is needed to restore a profile. This is the only runtime behavior change in the PR, and it can only turn a rejection into a success.

## Why CI let it through

`assistant/openapi.yaml` is the spec `openapi-ts` generates the web's daemon client from, but neither `pr-web.yaml` nor `ci-main-web.yaml` listed it in their path filters. #41262 changed no file under `clients/web/`, so the web checks never ran on it, and no post-merge web run has happened on main since. Both filters now include the spec, alongside the existing `meta/llm-provider-catalog.json` entry that exists for the same class of reason.

## Testing

- `bunx tsc --noEmit` in `clients/web`: clean (was 6 errors on this same base).
- `bunx eslint` and `bunx prettier --check` on the six changed source files: clean.
- Every existing test covering the changed files, each run individually: `profile-quick-add-provider` (8), `providers` (3), `composer-settings-menu` (50), `profile-editor-modal` (71), `profile-detail-panel` (3), `profiles-section` (18), `use-profile-delete-flow` (17), `profile-editor-provider-section` (5), `profile-advanced-params` (24). All pass. No test references `patchLlm` or `ConfigPatchRequest`.
- Both workflow files parse as YAML.
- Not manually QA'd against a live daemon. The path worth a look before trusting it in anger: Settings > AI, edit an existing profile, force the recreate to fail, and confirm the rollback restores the profile.

cc @emmiekehoe since this is the other half of #41262.

🤖 Generated with [Claude Code](https://claude.com/claude-code)