### PR TITLE
Stop the mobile hello slicing the top of the avatar's head

### DIFF
--- a/clients/web/src/domains/chat/components/composer-peek.tsx
+++ b/clients/web/src/domains/chat/components/composer-peek.tsx
@@ -470,7 +470,13 @@ export function ComposerPeek({
       )
     : INTRO_HIDDEN_FRAC_FALLBACK;
   const introBelowPx = peekSize * (1 - introHiddenFrac);
-  const introClipHeight = Math.min(introBelowPx, PEEK_EXPOSED_MAX_PX);
+  // Plus the same headroom the focus peek reserves, on the far side from the
+  // rim. `AnimatedAvatar` fills its viewBox edge to edge and lets the breathe
+  // and the idle twitch draw past it, so a column ending exactly at the
+  // avatar's far edge slices that overshoot flat. Mirrored here, so the edge
+  // that gets cut is the crown of the head.
+  const introClipHeight =
+    Math.min(introBelowPx, PEEK_EXPOSED_MAX_PX) + CLIP_HEADROOM;
   const introHidePx = -(introBelowPx + 8);
   const introX = Math.min(
     rect.width - peekSize / 2 - 16,


### PR DESCRIPTION
Reported from an iPhone build: on the new-chat empty state, the avatar peeking out below the composer has its far edge cut off square.

## Why it happens

`AnimatedAvatar` fills its viewBox edge to edge and deliberately lets the breathe pulse and the idle twitch draw outside it, which is why it sets `overflow: visible` on its own `<svg>`:

> The body fills the viewBox edge to edge, so the busy wobble (±6%) and the idle twitch draw past it and would otherwise be clipped flat.

The focus peek already accounts for that. Its clip column is `peekExposedPx + CLIP_HEADROOM`, and the 14px of slack sits on the far side from the rim, which is where the overshoot goes.

The native mobile hello had none. `introClipHeight` was exactly `introBelowPx`, so the avatar's far edge landed flush against the `overflow-hidden` boundary and the overshoot was cut off square on every frame. Because the hello hangs mirrored off the input's bottom rim, the edge being sliced is the crown of the head, which is what makes it read as a clipped asset instead of a character leaning out from behind the card.

## The fix

Give that column the same headroom the focus peek reserves, on the same far side. One expression.

Nothing else moves. The column is a `pointer-events-none` portal below the card, so 14 extra pixels change no layout. The retracted position still tucks the whole visible band back behind the rim (`introHidePx` is measured off `introBelowPx`, not the column). The `PEEK_EXPOSED_MAX_PX` cap on the visible slab is untouched, and by construction it cannot bind anyway: `peekSize` is already sized so `peekSize * peekExposedFrac <= PEEK_EXPOSED_MAX_PX`, and the intro's exposed fraction is that same expression with a lower floor.

## What this does not change

The hello's choreography is untouched: it still rises from behind the input's bottom edge, upside down and anchored at 85% of the card width, holds 3s, and tucks back up before the focus peek takes over. If the position or the whole intro is what should change, that is a separate call.

One thing worth a look on a device while this is in hand: with the keyboard open the empty-state composer bottom-docks, and the strip the hello occupies can fall under the keyboard band. That is a different problem from this crop and is not addressed here.

## Testing

- `bunx eslint`, `bunx prettier --check`, and `bunx tsc --noEmit`: clean.
- `use-chat-empty-state.test.tsx` (24) and `chat-body.test.tsx` (47): pass.
- No test added. The peek's geometry is inline in a component driven by `getBoundingClientRect` on a portal, and happy-dom resolves no layout, so a unit test here would assert the arithmetic back to itself rather than the appearance. `ComposerPeek` has no existing geometry test or story for the same reason.
- Needs device QA: this is a visual fix and I have not seen it render on a phone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)