### PR TITLE
refactor(service-contracts): one pairing-address parser

### DIFF
--- a/clients/web/src/domains/onboarding/components/add-remote-origin-dialog.tsx
+++ b/clients/web/src/domains/onboarding/components/add-remote-origin-dialog.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { Button } from "@vellumai/design-library/components/button";
 import { Input } from "@vellumai/design-library/components/input";
 import { Modal } from "@vellumai/design-library/components/modal";
+import { normalizePairingBaseUrl } from "@vellumai/service-contracts/remote-web-pairing";
 
 import {
   normalizeOriginUrl,
@@ -13,23 +14,6 @@ import {
 import { useTranslation } from "@/i18n";
 
 const ADD_FAILED_COPY = "Failed to add the assistant. Please try again.";
-
-/**
- * Drop the app-route tail from an address a user is likely to have copied
- * out of their browser, so both `<base>/assistant/pair` (what the pairing
- * page shows) and `<base>/assistant` reduce to the public base the store
- * remembers. A Velay path prefix survives because it is a different
- * segment: `https://host/assistant-123/assistant/pair` yields
- * `https://host/assistant-123`.
- */
-function stripAppRouteSuffix(base: string): string {
-  for (const route of ["/assistant/pair", "/assistant"]) {
-    if (base.endsWith(route)) {
-      return base.slice(0, -route.length);
-    }
-  }
-  return base;
-}
 
 interface AddRemoteOriginDialogProps {
   open: boolean;
@@ -78,10 +62,12 @@ function AddRemoteOriginDialog({
     if (!url.trim() || pending) {
       return;
     }
+    // Reduce an address copied out of a browser to the public base the store
+    // remembers: the app-route tail is dropped, a path prefix survives
+    // (`https://host/assistant-123/assistant/pair` yields
+    // `https://host/assistant-123`).
     const parsed = normalizeOriginUrl(url);
-    // Re-normalize: stripping the route tail can leave a bare origin.
-    const normalized =
-      parsed === null ? null : normalizeOriginUrl(stripAppRouteSuffix(parsed));
+    const normalized = parsed === null ? null : normalizePairingBaseUrl(parsed);
     if (normalized === null) {
       setError(
         "Enter the full https address, like https://example.com/assistant-1.",

--- a/clients/web/src/lib/auth/remote-gateway-session.ts
+++ b/clients/web/src/lib/auth/remote-gateway-session.ts
@@ -12,6 +12,11 @@ import {
 } from "@/lib/auth/gateway-session";
 import { setSelfHostedConnection } from "@/lib/self-hosted/connection";
 
+export {
+  parseRemoteWebPairingParams,
+  type RemoteWebPairingParams,
+} from "@vellumai/service-contracts/remote-web-pairing";
+
 const PAIRING_TOKEN_PATH = "/v1/remote-web/pairing-token";
 const PAIRING_CHALLENGE_PATH = "/v1/remote-web/pairing-challenge";
 const GUARDIAN_REFRESH_PATH = "/v1/guardian/refresh";
@@ -34,11 +39,6 @@ type RefreshLockRecord = {
 
 let remoteGatewayRefreshAfterMs = 0;
 let refreshRemoteGatewaySessionPromise: Promise<boolean> | null = null;
-
-export interface RemoteWebPairingParams {
-  deviceCode: string | null;
-  userCode: string | null;
-}
 
 /**
  * Credential fields {@link activateRemoteGatewaySession} consumes. Broader than
@@ -71,45 +71,6 @@ export class RemoteWebPairingError extends Error {
 function errorBodyCode(body: unknown): string | null {
   const code = (body as { error?: { code?: unknown } } | null)?.error?.code;
   return typeof code === "string" ? code : null;
-}
-
-function stringParam(
-  params: URLSearchParams,
-  ...names: string[]
-): string | null {
-  for (const name of names) {
-    const value = params.get(name)?.trim();
-    if (value) {
-      return value;
-    }
-  }
-  return null;
-}
-
-function paramsFromUrl(url: URL): URLSearchParams {
-  const merged = new URLSearchParams(url.search);
-  const hash = url.hash.startsWith("#") ? url.hash.slice(1) : url.hash;
-  if (hash) {
-    const hashParams = new URLSearchParams(hash);
-    for (const [key, value] of hashParams) {
-      if (!merged.has(key)) {
-        merged.set(key, value);
-      }
-    }
-  }
-  return merged;
-}
-
-export function parseRemoteWebPairingParams(
-  value: string | URL,
-): RemoteWebPairingParams {
-  const url =
-    typeof value === "string" ? new URL(value, window.location.origin) : value;
-  const params = paramsFromUrl(url);
-  return {
-    deviceCode: stringParam(params, "deviceCode", "device_code"),
-    userCode: stringParam(params, "userCode", "user_code"),
-  };
 }
 
 export function remoteGatewayPublicPathPrefix(

--- a/packages/service-contracts/src/__tests__/remote-web-pairing.test.ts
+++ b/packages/service-contracts/src/__tests__/remote-web-pairing.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  buildRemoteWebPairingUrl,
+  parsePairingAddress,
+  parseRemoteWebPairingParams,
+  type PublicBaseUrlRejection,
+} from "../remote-web-pairing.js";
+
+describe("parseRemoteWebPairingParams", () => {
+  test("reads snake_case fragment parameters", () => {
+    expect(
+      parseRemoteWebPairingParams(
+        "https://assistant.example.com/assistant/pair#device_code=device-1&user_code=ABCD-EFGH",
+      ),
+    ).toEqual({ deviceCode: "device-1", userCode: "ABCD-EFGH" });
+  });
+
+  test("reads camelCase query parameters", () => {
+    expect(
+      parseRemoteWebPairingParams(
+        "https://assistant.example.com/assistant/pair?deviceCode=device-2&userCode=WXYZ-1234",
+      ),
+    ).toEqual({ deviceCode: "device-2", userCode: "WXYZ-1234" });
+  });
+
+  test("accepts a relative link", () => {
+    expect(
+      parseRemoteWebPairingParams("/assistant/pair#device_code=device-3"),
+    ).toEqual({ deviceCode: "device-3", userCode: null });
+  });
+
+  test("reports null when no codes are present", () => {
+    expect(
+      parseRemoteWebPairingParams("https://assistant.example.com/assistant"),
+    ).toEqual({ deviceCode: null, userCode: null });
+  });
+});
+
+describe("parsePairingAddress", () => {
+  test("splits a pairing link into its base and device code", () => {
+    const link = buildRemoteWebPairingUrl({
+      verificationUri: "https://assistant.example.com/assistant/pair",
+      deviceCode: "device-1",
+    });
+
+    expect(parsePairingAddress(link)).toEqual({
+      ok: true,
+      publicBaseUrl: "https://assistant.example.com",
+      deviceCode: "device-1",
+    });
+  });
+
+  test("accepts the device code in the query string", () => {
+    expect(
+      parsePairingAddress(
+        "https://assistant.example.com/assistant/pair?deviceCode=device-2",
+      ),
+    ).toEqual({
+      ok: true,
+      publicBaseUrl: "https://assistant.example.com",
+      deviceCode: "device-2",
+    });
+  });
+
+  test("preserves a path prefix while dropping the app-route suffix", () => {
+    expect(
+      parsePairingAddress(
+        "https://host.example.com/assistant-123/assistant/pair#device_code=device-3",
+      ),
+    ).toEqual({
+      ok: true,
+      publicBaseUrl: "https://host.example.com/assistant-123",
+      deviceCode: "device-3",
+    });
+  });
+
+  test("drops a trailing app-route suffix from a bare address", () => {
+    expect(
+      parsePairingAddress("https://assistant.example.com/assistant/pair"),
+    ).toEqual({
+      ok: true,
+      publicBaseUrl: "https://assistant.example.com",
+      deviceCode: null,
+    });
+  });
+
+  test("accepts a bare address with no device code", () => {
+    expect(parsePairingAddress("https://assistant.example.com")).toEqual({
+      ok: true,
+      publicBaseUrl: "https://assistant.example.com",
+      deviceCode: null,
+    });
+  });
+
+  test.each<[string, PublicBaseUrlRejection]>([
+    ["not a url", "unparseable"],
+    ["https://localhost:3000", "loopback"],
+    ["https://127.0.0.1:3000", "loopback"],
+    ["http://assistant.example.com", "non-https"],
+    ["https://login.tailscale.com/admin/invite/abc123", "service-website"],
+  ])("rejects %s", (raw, reason) => {
+    expect(parsePairingAddress(raw)).toEqual({ ok: false, reason });
+  });
+});

--- a/packages/service-contracts/src/remote-web-pairing.ts
+++ b/packages/service-contracts/src/remote-web-pairing.ts
@@ -324,3 +324,89 @@ export function buildRemoteWebPairingUrl(
   }).toString();
   return url.toString();
 }
+
+/**
+ * Base that makes a relative pairing link parseable. Only the query and
+ * fragment are read off the result, so it never reaches a caller.
+ */
+const RELATIVE_PAIRING_LINK_BASE = "https://pairing.invalid";
+
+/** The device/user codes a pairing link can carry. */
+export interface RemoteWebPairingParams {
+  deviceCode: string | null;
+  userCode: string | null;
+}
+
+function firstParam(
+  params: URLSearchParams,
+  ...names: string[]
+): string | null {
+  for (const name of names) {
+    const value = params.get(name)?.trim();
+    if (value) {
+      return value;
+    }
+  }
+  return null;
+}
+
+/**
+ * Query parameters merged with fragment parameters, query winning on a clash.
+ * Pairing links carry the device code in the fragment so it never reaches the
+ * wire, but hand-assembled links put it in the query.
+ */
+function pairingLinkParams(url: URL): URLSearchParams {
+  const merged = new URLSearchParams(url.search);
+  const hash = url.hash.startsWith("#") ? url.hash.slice(1) : url.hash;
+  for (const [key, value] of new URLSearchParams(hash)) {
+    if (!merged.has(key)) {
+      merged.set(key, value);
+    }
+  }
+  return merged;
+}
+
+/**
+ * Read the pairing codes off a link, accepting either casing (`device_code` /
+ * `deviceCode`) from either the query string or the fragment. Relative values
+ * are accepted so a router can pass `pathname + search + hash` straight in.
+ */
+export function parseRemoteWebPairingParams(
+  value: string | URL,
+): RemoteWebPairingParams {
+  const url =
+    typeof value === "string"
+      ? new URL(value, RELATIVE_PAIRING_LINK_BASE)
+      : value;
+  const params = pairingLinkParams(url);
+  return {
+    deviceCode: firstParam(params, "deviceCode", "device_code"),
+    userCode: firstParam(params, "userCode", "user_code"),
+  };
+}
+
+/** Outcome of {@link parsePairingAddress}. */
+export type ParsePairingAddressResult =
+  | { ok: true; publicBaseUrl: string; deviceCode: string | null }
+  | { ok: false; reason: PublicBaseUrlRejection };
+
+/**
+ * The inverse of {@link buildRemoteWebPairingUrl}: what a pasted pairing
+ * address means. A full pairing link yields its base plus the device code it
+ * carries; a bare `https://host` address yields a null device code, leaving
+ * the caller to mint its own challenge. The base goes through
+ * {@link resolvePublicBaseUrl}, so loopback, non-https, and tunnel-vendor
+ * websites are refused with the same reasons every other pairing surface
+ * reports.
+ */
+export function parsePairingAddress(raw: string): ParsePairingAddressResult {
+  const resolved = resolvePublicBaseUrl(raw);
+  if (!resolved.ok) {
+    return resolved;
+  }
+  return {
+    ok: true,
+    publicBaseUrl: resolved.url,
+    deviceCode: parseRemoteWebPairingParams(raw).deviceCode,
+  };
+}


### PR DESCRIPTION
## Summary
- Adds `parsePairingAddress` to `@vellumai/service-contracts` — the inverse of `buildRemoteWebPairingUrl`, so every surface parses a pasted pairing link or bare assistant URL identically.
- Moves `parseRemoteWebPairingParams` out of the web client into service-contracts, re-exported so the pairing page is unchanged.
- Deletes the hand-rolled `stripAppRouteSuffix` duplicate of `normalizePairingBaseUrl`.

Part of plan: zesty-wandering-nygaard.md (PR 2 of 7)