### PR TITLE
feat(gateway): device-bound branch on the remote-web pairing token exchange

### DIFF
--- a/gateway/src/__tests__/remote-web-pairing-token.test.ts
+++ b/gateway/src/__tests__/remote-web-pairing-token.test.ts
@@ -33,6 +33,8 @@ const {
   contacts,
   contactChannels,
 } = await import("../db/schema.js");
+const { rotateBrowserCredentialsByRefreshToken } =
+  await import("../auth/guardian-refresh.js");
 const { handleGuardianRefresh } =
   await import("../http/routes/guardian-refresh.js");
 const { handleRemoteWebPairingToken } =
@@ -248,6 +250,7 @@ describe("remote web pairing token exchange", () => {
     expect(typeof body.refreshAfter).toBe("string");
     expect(body.guardianId).toBe(GUARDIAN_ID);
     expect(body.refreshToken).toBeUndefined();
+    expect(body.refreshTokenExpiresAt).toBeUndefined();
     expect(body.deviceId).toBeUndefined();
 
     const cookies = setCookies(res);
@@ -717,6 +720,128 @@ describe("remote web pairing token exchange", () => {
       resetGuardianIntegrityReporterForTesting();
       bustGuardianIntegrityCache();
     }
+  });
+
+  test("deviceId exchange returns the refresh token in the body with no cookie", async () => {
+    const challenge = createRemoteWebPairingChallenge(
+      `${PUBLIC_BASE_URL}/assistant-123`,
+      TEST_REQUESTER,
+    );
+    expect(approveRemoteWebPairingChallenge(challenge.userCode).status).toBe(
+      "approved",
+    );
+
+    const res = await handleRemoteWebPairingToken(
+      makeTokenRequest({
+        deviceCode: challenge.deviceCode,
+        deviceId: "importer-device",
+        platform: "cli",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    expect(setCookies(res)).toHaveLength(0);
+
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.status).toBe("approved");
+    expect(typeof body.accessToken).toBe("string");
+    expect(typeof body.refreshToken).toBe("string");
+    expect(typeof body.refreshTokenExpiresAt).toBe("string");
+    expect(typeof body.refreshAfter).toBe("string");
+    expect(body.guardianId).toBe(GUARDIAN_ID);
+
+    const hashedDeviceId = hashToken("importer-device");
+    const tokens = activeTokens();
+    expect(tokens).toHaveLength(1);
+    expect(tokens[0].hashedDeviceId).toBe(hashedDeviceId);
+    expect(tokens[0].platform).toBe("cli");
+
+    const refreshTokens = activeRefreshTokens();
+    expect(refreshTokens).toHaveLength(1);
+    expect(refreshTokens[0].tokenHash).toBe(
+      hashToken(body.refreshToken as string),
+    );
+    expect(refreshTokens[0].hashedDeviceId).toBe(hashedDeviceId);
+    expect(refreshTokens[0].platform).toBe("cli");
+    expect(refreshTokens[0].browserRefreshCookiePath).toBeNull();
+  });
+
+  test("only allowlisted platforms are recorded, defaulting to desktop", async () => {
+    const cases: unknown[] = [
+      "android",
+      undefined,
+      "not-a-platform",
+      { evil: true },
+    ];
+    const expected = ["android", "desktop", "desktop", "desktop"];
+
+    for (const [index, platform] of cases.entries()) {
+      const challenge = createRemoteWebPairingChallenge(
+        PUBLIC_BASE_URL,
+        TEST_REQUESTER,
+      );
+      expect(approveRemoteWebPairingChallenge(challenge.userCode).status).toBe(
+        "approved",
+      );
+      const deviceId = `device-${index}`;
+
+      const res = await handleRemoteWebPairingToken(
+        makeTokenRequest({
+          deviceCode: challenge.deviceCode,
+          deviceId,
+          platform,
+        }),
+      );
+
+      expect(res.status).toBe(200);
+      const record = activeRefreshTokens().find(
+        (token) => token.hashedDeviceId === hashToken(deviceId),
+      );
+      expect(record?.platform).toBe(expected[index]);
+    }
+  });
+
+  test("device-bound pairing refreshes by device id, never by cookie", async () => {
+    const challenge = createRemoteWebPairingChallenge(
+      PUBLIC_BASE_URL,
+      TEST_REQUESTER,
+    );
+    expect(approveRemoteWebPairingChallenge(challenge.userCode).status).toBe(
+      "approved",
+    );
+
+    const exchange = await handleRemoteWebPairingToken(
+      makeTokenRequest({
+        deviceCode: challenge.deviceCode,
+        deviceId: "importer-device",
+      }),
+    );
+    const { refreshToken } = (await exchange.json()) as {
+      refreshToken: string;
+    };
+
+    // No browser cookie path was recorded, so the cookie rotation refuses it.
+    expect(rotateBrowserCredentialsByRefreshToken({ refreshToken })).toEqual({
+      ok: false,
+      error: "refresh_invalid",
+    });
+    expect(activeRefreshTokens()[0].tokenHash).toBe(hashToken(refreshToken));
+
+    const refresh = await handleGuardianRefresh(
+      makeDeviceRefreshRequest({ refreshToken, deviceId: "importer-device" }),
+    );
+
+    expect(refresh.status).toBe(200);
+    expect(setCookies(refresh)).toHaveLength(0);
+    const body = (await refresh.json()) as Record<string, unknown>;
+    expect(typeof body.accessToken).toBe("string");
+    expect(typeof body.refreshToken).toBe("string");
+    expect(body.refreshToken).not.toBe(refreshToken);
+    expect(activeRefreshTokens()).toHaveLength(1);
+    expect(activeRefreshTokens()[0].tokenHash).toBe(
+      hashToken(body.refreshToken as string),
+    );
   });
 
   test("expired device code does not mint credentials", async () => {

--- a/gateway/src/http/route-helpers.ts
+++ b/gateway/src/http/route-helpers.ts
@@ -1,7 +1,7 @@
 /**
  * Shared scaffolding for hand-rolled HTTP route handlers (the pairing family):
- * the 405 method guard and the read-body-then-extract-one-string-field flow,
- * so each route doesn't re-implement them with drifting error shapes.
+ * the 405 method guard and the read-body-then-extract-fields flow, so each
+ * route doesn't re-implement them with drifting error shapes.
  */
 
 import { errorResponse } from "./loopback-guard.js";
@@ -16,6 +16,47 @@ export function methodNotAllowed(allow: string): Response {
 }
 
 /**
+ * Read a JSON request body under a byte cap. Returns the decoded object, or
+ * the error `Response` to send: 413 for an oversized body, 400 for an
+ * unreadable body or one that isn't a JSON object.
+ */
+export async function readJsonObjectBody(
+  req: Request,
+  maxBytes: number,
+): Promise<Record<string, unknown> | Response> {
+  const rawBody = await readLimitedBody(req, maxBytes);
+  if (rawBody.status === "too_large") {
+    return errorResponse("PAYLOAD_TOO_LARGE", "request body too large", 413);
+  }
+  if (rawBody.status === "unreadable") {
+    return errorResponse("BAD_REQUEST", "failed to read request body", 400);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawBody.text);
+  } catch {
+    return errorResponse("BAD_REQUEST", "invalid JSON body", 400);
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return errorResponse("BAD_REQUEST", "invalid JSON body", 400);
+  }
+  return parsed as Record<string, unknown>;
+}
+
+/**
+ * One non-blank string field of a decoded JSON body, or null. Returns the raw
+ * (untrimmed) value.
+ */
+export function jsonStringField(
+  body: Record<string, unknown>,
+  field: string,
+): string | null {
+  const raw = body[field];
+  return typeof raw === "string" && raw.trim() ? raw : null;
+}
+
+/**
  * Read a JSON request body under a byte cap and extract one required string
  * field. Returns the raw (untrimmed) field value, or the error `Response` to
  * send: 413 for an oversized body, 400 for an unreadable body, invalid JSON,
@@ -26,22 +67,12 @@ export async function readJsonStringField(
   maxBytes: number,
   field: string,
 ): Promise<string | Response> {
-  const rawBody = await readLimitedBody(req, maxBytes);
-  if (rawBody.status === "too_large") {
-    return errorResponse("PAYLOAD_TOO_LARGE", "request body too large", 413);
+  const body = await readJsonObjectBody(req, maxBytes);
+  if (body instanceof Response) {
+    return body;
   }
-  if (rawBody.status === "unreadable") {
-    return errorResponse("BAD_REQUEST", "failed to read request body", 400);
-  }
-
-  let value: string | null = null;
-  try {
-    const body = JSON.parse(rawBody.text) as Record<string, unknown>;
-    const raw = body[field];
-    value = typeof raw === "string" && raw.trim() ? raw : null;
-  } catch {
-    return errorResponse("BAD_REQUEST", "invalid JSON body", 400);
-  }
-
-  return value ?? errorResponse("BAD_REQUEST", `${field} is required`, 400);
+  return (
+    jsonStringField(body, field) ??
+    errorResponse("BAD_REQUEST", `${field} is required`, 400)
+  );
 }

--- a/gateway/src/http/routes/remote-web-pairing-token.ts
+++ b/gateway/src/http/routes/remote-web-pairing-token.ts
@@ -1,12 +1,19 @@
 import type {
+  RemoteWebPairingPlatform,
   RemoteWebPairingTokenApprovedResponse,
   RemoteWebPairingTokenPendingResponse,
 } from "@vellumai/service-contracts/remote-web-pairing";
+import {
+  DEFAULT_REMOTE_WEB_PAIRING_PLATFORM,
+  REMOTE_WEB_PAIRING_PLATFORMS,
+} from "@vellumai/service-contracts/remote-web-pairing";
 
+import type { RefreshableTokenPair } from "../../auth/guardian-bootstrap.js";
 import {
   ensureVellumGuardianBinding,
   getExternalAssistantId,
   mintAndRecordBrowserTokenPair,
+  mintAndRecordDeviceBoundTokenPair,
   VellumGuardianMintRefusedError,
 } from "../../auth/guardian-bootstrap.js";
 import {
@@ -19,10 +26,26 @@ import {
   remoteWebRefreshCookiePathForPublicBaseUrl,
 } from "../browser-auth-cookies.js";
 import { errorResponse } from "../loopback-guard.js";
-import { methodNotAllowed, readJsonStringField } from "../route-helpers.js";
+import {
+  jsonStringField,
+  methodNotAllowed,
+  readJsonObjectBody,
+} from "../route-helpers.js";
 
 const MAX_TOKEN_BODY_BYTES = 512;
 const REMOTE_WEB_PLATFORM = "web";
+
+/**
+ * The requested platform, coerced to a known value. Unlike loopback `/v1/pair`,
+ * this route is publicly reachable and its platform renders verbatim in the
+ * host's paired-devices list, so an unrecognized value never reaches the DB.
+ */
+function resolveDevicePlatform(raw: unknown): RemoteWebPairingPlatform {
+  const known = REMOTE_WEB_PAIRING_PLATFORMS.find(
+    (platform) => platform === raw,
+  );
+  return known ?? DEFAULT_REMOTE_WEB_PAIRING_PLATFORM;
+}
 
 /** Token-exchange JSON responses, errors included, are never cacheable. */
 function noStore(res: Response): Response {
@@ -47,14 +70,18 @@ export async function handleRemoteWebPairingToken(
     return methodNotAllowed("POST");
   }
 
-  const deviceCode = await readJsonStringField(
-    req,
-    MAX_TOKEN_BODY_BYTES,
-    "deviceCode",
-  );
-  if (deviceCode instanceof Response) {
-    return noStore(deviceCode);
+  const body = await readJsonObjectBody(req, MAX_TOKEN_BODY_BYTES);
+  if (body instanceof Response) {
+    return noStore(body);
   }
+  const deviceCode = jsonStringField(body, "deviceCode");
+  if (!deviceCode) {
+    return noStore(errorResponse("BAD_REQUEST", "deviceCode is required", 400));
+  }
+  // Sent by a trusted host exchanging for itself, never by a browser. The
+  // device code is the credential either way; the id only selects per-device
+  // revocability and body-delivered refresh.
+  const deviceId = jsonStringField(body, "deviceId");
 
   const challenge = claimRemoteWebPairingChallengeExchange(deviceCode);
   if (challenge.status === "pending") {
@@ -76,18 +103,29 @@ export async function handleRemoteWebPairingToken(
     return invalidDeviceCodeResponse();
   }
 
-  const refreshCookiePath = remoteWebRefreshCookiePathForPublicBaseUrl(
-    challenge.publicBaseUrl,
-  );
   let guardianPrincipalId: string;
-  let pair: ReturnType<typeof mintAndRecordBrowserTokenPair>;
+  let pair: RefreshableTokenPair;
+  // Set on the browser path only: a device-bound pairing carries its refresh
+  // token in the body, so there is no cookie to scope.
+  let refreshCookiePath: string | null = null;
   try {
     guardianPrincipalId = await ensureVellumGuardianBinding();
-    pair = mintAndRecordBrowserTokenPair({
-      guardianPrincipalId,
-      platform: REMOTE_WEB_PLATFORM,
-      browserRefreshCookiePath: refreshCookiePath,
-    });
+    if (deviceId) {
+      pair = mintAndRecordDeviceBoundTokenPair({
+        guardianPrincipalId,
+        deviceId,
+        platform: resolveDevicePlatform(body.platform),
+      });
+    } else {
+      refreshCookiePath = remoteWebRefreshCookiePathForPublicBaseUrl(
+        challenge.publicBaseUrl,
+      );
+      pair = mintAndRecordBrowserTokenPair({
+        guardianPrincipalId,
+        platform: REMOTE_WEB_PLATFORM,
+        browserRefreshCookiePath: refreshCookiePath,
+      });
+    }
   } catch (err) {
     // Release so the approved code stays exchangeable after the failure is
     // repaired (mint refusal) or retried (transient DB error).
@@ -112,14 +150,6 @@ export async function handleRemoteWebPairingToken(
   completeRemoteWebPairingChallengeExchange(deviceCode);
 
   const headers = new Headers({ "Cache-Control": "no-store" });
-  for (const cookie of buildRemoteWebBrowserAuthCookies({
-    refreshToken: pair.refreshToken,
-    refreshTokenExpiresAtMs: pair.refreshTokenExpiresAt,
-    refreshCookiePath,
-  })) {
-    headers.append("Set-Cookie", cookie);
-  }
-
   const approved: RemoteWebPairingTokenApprovedResponse = {
     status: "approved",
     accessToken: pair.accessToken,
@@ -128,5 +158,21 @@ export async function handleRemoteWebPairingToken(
     guardianId: guardianPrincipalId,
     assistantId: getExternalAssistantId(),
   };
+
+  if (refreshCookiePath) {
+    for (const cookie of buildRemoteWebBrowserAuthCookies({
+      refreshToken: pair.refreshToken,
+      refreshTokenExpiresAtMs: pair.refreshTokenExpiresAt,
+      refreshCookiePath,
+    })) {
+      headers.append("Set-Cookie", cookie);
+    }
+  } else {
+    approved.refreshToken = pair.refreshToken;
+    approved.refreshTokenExpiresAt = new Date(
+      pair.refreshTokenExpiresAt,
+    ).toISOString();
+  }
+
   return Response.json(approved, { headers });
 }

--- a/packages/service-contracts/src/remote-web-pairing.ts
+++ b/packages/service-contracts/src/remote-web-pairing.ts
@@ -10,7 +10,7 @@
  *   - `POST /v1/remote-web/pairing-verification`  approve by user code
  *       (`gateway/src/http/routes/remote-web-pairing-verification.ts`)
  *   - `POST /v1/remote-web/pairing-token`         poll + exchange device code
- *       (`gateway/src/http/routes/remote-web-pairing-token.ts`) — a browser
+ *       (`gateway/src/http/routes/remote-web-pairing-token.ts`): a browser
  *        receives its refresh token as an `HttpOnly` cookie; a request that
  *        carries a `deviceId` receives a device-bound one in the body instead
  *   - `GET  /v1/remote-web/pairing-requests`          list pending challenges

--- a/packages/service-contracts/src/remote-web-pairing.ts
+++ b/packages/service-contracts/src/remote-web-pairing.ts
@@ -10,7 +10,9 @@
  *   - `POST /v1/remote-web/pairing-verification`  approve by user code
  *       (`gateway/src/http/routes/remote-web-pairing-verification.ts`)
  *   - `POST /v1/remote-web/pairing-token`         poll + exchange device code
- *       (`gateway/src/http/routes/remote-web-pairing-token.ts`)
+ *       (`gateway/src/http/routes/remote-web-pairing-token.ts`) — a browser
+ *        receives its refresh token as an `HttpOnly` cookie; a request that
+ *        carries a `deviceId` receives a device-bound one in the body instead
  *   - `GET  /v1/remote-web/pairing-requests`          list pending challenges
  *       (loopback-only)
  *   - `POST /v1/remote-web/pairing-requests/approve`  approve by request id
@@ -128,10 +130,37 @@ export interface RemoteWebPairingRequestDenyResponse {
   status: "denied";
 }
 
+/**
+ * Platforms a device-bound pairing exchange may declare for itself. The value
+ * is what the host's `Paired devices` list renders for the new pairing.
+ */
+export const REMOTE_WEB_PAIRING_PLATFORMS = [
+  "cli",
+  "desktop",
+  "ios",
+  "android",
+] as const;
+
+export type RemoteWebPairingPlatform =
+  (typeof REMOTE_WEB_PAIRING_PLATFORMS)[number];
+
+/** Platform recorded when an exchange names none the gateway recognizes. */
+export const DEFAULT_REMOTE_WEB_PAIRING_PLATFORM: RemoteWebPairingPlatform =
+  "desktop";
+
 /** `POST /v1/remote-web/pairing-token` request body. */
 export interface RemoteWebPairingTokenRequest {
   /** The `deviceCode` from the challenge. */
   deviceCode: string;
+  /**
+   * Client-generated device id, sent only by a trusted host completing the
+   * exchange for itself. It switches the gateway to a device-bound, per-device
+   * revocable credential whose refresh token comes back in the response body.
+   * Browsers omit it and keep the cookie delivery.
+   */
+  deviceId?: string;
+  /** Platform to record for the device. Ignored without a `deviceId`. */
+  platform?: RemoteWebPairingPlatform;
 }
 
 /**
@@ -148,8 +177,9 @@ export interface RemoteWebPairingTokenPendingResponse {
 
 /**
  * `POST /v1/remote-web/pairing-token` approved response body (200) — carries
- * the minted browser session credentials. The refresh token is delivered out
- * of band as an `HttpOnly` cookie, not in this body.
+ * the minted session credentials. A browser exchange (no `deviceId`) receives
+ * its refresh token out of band as an `HttpOnly` cookie and so omits the two
+ * refresh fields below; a device-bound exchange receives it here instead.
  */
 export interface RemoteWebPairingTokenApprovedResponse {
   status: "approved";
@@ -160,6 +190,10 @@ export interface RemoteWebPairingTokenApprovedResponse {
   refreshAfter: string;
   guardianId: string;
   assistantId: string;
+  /** Device-bound refresh token, present only for a `deviceId` exchange. */
+  refreshToken?: string;
+  /** ISO-8601 instant the device-bound refresh token expires. */
+  refreshTokenExpiresAt?: string;
 }
 
 /** Union of the two terminal `pairing-token` response bodies. */


### PR DESCRIPTION
## Summary
- `/v1/remote-web/pairing-token` accepts optional `deviceId`/`platform`; with a `deviceId` it mints a device-bound token pair and returns the refresh token in the body instead of an HttpOnly cookie.
- `platform` is validated against cli/desktop/ios/android (default `desktop`) and renders in the Paired devices list.
- Absent `deviceId`, the browser response is byte-identical to today.

## Notes for review
- The route is already `auth: "none"` and edge-reachable by design — the device code *is* the credential, so letting its holder choose body delivery grants no new authority. Refresh works because `rotateCredentials` matches on `hashedDeviceId`, and the client-generated `deviceId` never leaves the importing machine.
- `platform` is client-supplied text that `paired-devices-section.tsx` renders verbatim, hence the allowlist (loopback `/v1/pair` accepts any string because it is not publicly reachable).
- `route-helpers.ts`: `readJsonStringField` now delegates to a new shared `readJsonObjectBody` + `jsonStringField`, since this route needs three fields off one body read. One behavior change for the four pairing routes: a body that parses but is not a JSON object now returns 400 `invalid JSON body` rather than 400 `<field> is required`.

Part of plan: zesty-wandering-nygaard.md (PR 1 of 7)