### PR TITLE
feat(gateway): record device identity columns on actor token tables

### DIFF
--- a/gateway/src/__tests__/devices.test.ts
+++ b/gateway/src/__tests__/devices.test.ts
@@ -46,6 +46,8 @@ function seedActor(opts: {
   principal?: string;
   status?: "active" | "revoked";
   platform?: string;
+  pairingUserAgent?: string;
+  clientReportedName?: string;
   lastUsedAt?: number;
   updatedAt?: number;
 }): void {
@@ -60,6 +62,8 @@ function seedActor(opts: {
       guardianPrincipalId: principal,
       hashedDeviceId: hashToken(opts.device),
       platform: opts.platform ?? "cli",
+      pairingUserAgent: opts.pairingUserAgent,
+      clientReportedName: opts.clientReportedName,
       status: opts.status ?? "active",
       issuedAt: now,
       expiresAt: now + 86_400_000,
@@ -183,6 +187,48 @@ afterEach(() => {
   } catch {
     /* best effort */
   }
+});
+
+describe("actorTokenRecords device identity columns", () => {
+  test("round-trips pairingUserAgent and clientReportedName", () => {
+    seedActor({
+      device: "device-identity-populated",
+      pairingUserAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
+      clientReportedName: "Noa's MacBook Pro",
+    });
+
+    const row = getGatewayDb()
+      .select()
+      .from(actorTokenRecords)
+      .where(
+        eq(
+          actorTokenRecords.hashedDeviceId,
+          hashToken("device-identity-populated"),
+        ),
+      )
+      .get();
+    expect(row?.pairingUserAgent).toBe(
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
+    );
+    expect(row?.clientReportedName).toBe("Noa's MacBook Pro");
+  });
+
+  test("leaves pairingUserAgent and clientReportedName null when omitted", () => {
+    seedActor({ device: "device-identity-omitted" });
+
+    const row = getGatewayDb()
+      .select()
+      .from(actorTokenRecords)
+      .where(
+        eq(
+          actorTokenRecords.hashedDeviceId,
+          hashToken("device-identity-omitted"),
+        ),
+      )
+      .get();
+    expect(row?.pairingUserAgent).toBeNull();
+    expect(row?.clientReportedName).toBeNull();
+  });
 });
 
 describe("GET /v1/devices", () => {

--- a/gateway/src/db/schema.ts
+++ b/gateway/src/db/schema.ts
@@ -270,6 +270,9 @@ export const actorTokenRecords = sqliteTable(
     guardianPrincipalId: text("guardian_principal_id").notNull(),
     hashedDeviceId: text("hashed_device_id").notNull(),
     platform: text("platform").notNull(),
+    // Siblings of platform so rotation carries them forward. Raw, never parsed here.
+    pairingUserAgent: text("pairing_user_agent"),
+    clientReportedName: text("client_reported_name"),
     status: text("status").notNull().default("active"),
     issuedAt: integer("issued_at").notNull(),
     expiresAt: integer("expires_at"),
@@ -305,6 +308,8 @@ export const actorRefreshTokenRecords = sqliteTable(
     guardianPrincipalId: text("guardian_principal_id").notNull(),
     hashedDeviceId: text("hashed_device_id").notNull(),
     platform: text("platform").notNull(),
+    pairingUserAgent: text("pairing_user_agent"),
+    clientReportedName: text("client_reported_name"),
     status: text("status").notNull().default("active"),
     issuedAt: integer("issued_at").notNull(),
     absoluteExpiresAt: integer("absolute_expires_at").notNull(),


### PR DESCRIPTION
## Summary
- Add nullable pairing_user_agent and client_reported_name columns to actorTokenRecords and actorRefreshTokenRecords
- Add tests proving the columns are genuinely nullable and round-trip correctly

Part of plan: paired-device-names.md (PR 1 of 15)