### PR TITLE
feat(contracts): allow a client-reported device name on pairing-token

### DIFF
--- a/packages/service-contracts/src/remote-web-pairing.ts
+++ b/packages/service-contracts/src/remote-web-pairing.ts
@@ -132,6 +132,12 @@ export interface RemoteWebPairingRequestDenyResponse {
 export interface RemoteWebPairingTokenRequest {
   /** The `deviceCode` from the challenge. */
   deviceCode: string;
+  /**
+   * Optional self-reported device name, for example "Vellum iOS app". The gateway
+   * stores it verbatim (capped) and never trusts it for authorization. Absent from
+   * clients that predate this field.
+   */
+  clientReportedName?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add optional clientReportedName field to RemoteWebPairingTokenRequest
- Type-only change; gateway handler and web client wiring land in PR 13

Part of plan: paired-device-names.md (PR 4 of 15)