### PR TITLE
feat(web): resolve a browser and OS from a stored User-Agent

### DIFF
--- a/clients/web/src/domains/settings/pair-device/device-label.test.ts
+++ b/clients/web/src/domains/settings/pair-device/device-label.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test";
+
+import { labelFromUserAgent } from "./device-label";
+
+describe("labelFromUserAgent", () => {
+  test("desktop Chrome on macOS", () => {
+    expect(
+      labelFromUserAgent(
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36",
+      ),
+    ).toEqual({ browser: "Chrome", os: "macOS" });
+  });
+
+  test("desktop Chrome on Windows", () => {
+    expect(
+      labelFromUserAgent(
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36",
+      ),
+    ).toEqual({ browser: "Chrome", os: "Windows" });
+  });
+
+  test("Firefox on Linux", () => {
+    expect(
+      labelFromUserAgent(
+        "Mozilla/5.0 (X11; Linux x86_64; rv:129.0) Gecko/20100101 Firefox/129.0",
+      ),
+    ).toEqual({ browser: "Firefox", os: "Linux" });
+  });
+
+  test("Edge on Windows is not reported as Chrome", () => {
+    expect(
+      labelFromUserAgent(
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36 Edg/128.0.0.0",
+      ),
+    ).toEqual({ browser: "Edge", os: "Windows" });
+  });
+
+  test("Safari on macOS", () => {
+    expect(
+      labelFromUserAgent(
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Safari/605.1.15",
+      ),
+    ).toEqual({ browser: "Safari", os: "macOS" });
+  });
+
+  test("mobile Safari on iPhone reports OS iPhone, not macOS", () => {
+    expect(
+      labelFromUserAgent(
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1",
+      ),
+    ).toEqual({ browser: "Safari", os: "iPhone" });
+  });
+
+  test("Chrome on Android", () => {
+    expect(
+      labelFromUserAgent(
+        "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Mobile Safari/537.36",
+      ),
+    ).toEqual({ browser: "Chrome", os: "Android" });
+  });
+
+  test("iPad user agent", () => {
+    expect(
+      labelFromUserAgent(
+        "Mozilla/5.0 (iPad; CPU OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1",
+      ),
+    ).toEqual({ browser: "Safari", os: "iPad" });
+  });
+
+  test("iOS WKWebView user agent with no Safari/ token still resolves OS", () => {
+    expect(
+      labelFromUserAgent(
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148",
+      ),
+    ).toEqual({ browser: null, os: "iPhone" });
+  });
+
+  test("garbage string yields null, not a partially-empty object", () => {
+    expect(labelFromUserAgent("not a real user agent string 12345")).toBeNull();
+  });
+
+  test("empty string yields null", () => {
+    expect(labelFromUserAgent("")).toBeNull();
+  });
+
+  test("null input yields null", () => {
+    expect(labelFromUserAgent(null)).toBeNull();
+  });
+
+  test("undefined input yields null", () => {
+    expect(labelFromUserAgent(undefined)).toBeNull();
+  });
+});

--- a/clients/web/src/domains/settings/pair-device/device-label.ts
+++ b/clients/web/src/domains/settings/pair-device/device-label.ts
@@ -1,0 +1,84 @@
+/**
+ * Parses a stored (server-recorded) User-Agent string into a browser and OS
+ * label, e.g. "Chrome" on "macOS".
+ *
+ * This is deliberately NOT built on top of `@/runtime/platform-detection.ts`.
+ * That module reads `navigator` to describe the browser it is currently
+ * running in; it cannot parse an arbitrary User-Agent string captured from a
+ * different device at pairing time. Do not "deduplicate" the two: they solve
+ * different problems.
+ *
+ * Returns structured parts rather than a composed sentence so the caller can
+ * compose the final label with an ICU message (i18n stays out of this file).
+ */
+
+export interface DeviceUserAgentParts {
+  browser: string | null;
+  os: string | null;
+}
+
+function detectOS(userAgent: string): string | null {
+  if (/iPhone|iPod/.test(userAgent)) {
+    return "iPhone";
+  }
+  if (/iPad/.test(userAgent)) {
+    return "iPad";
+  }
+  if (/Android/.test(userAgent)) {
+    return "Android";
+  }
+  if (/Macintosh|Mac OS X/.test(userAgent)) {
+    return "macOS";
+  }
+  if (/Windows/.test(userAgent)) {
+    return "Windows";
+  }
+  if (/CrOS/.test(userAgent)) {
+    return "ChromeOS";
+  }
+  if (/Linux/.test(userAgent)) {
+    return "Linux";
+  }
+  return null;
+}
+
+function detectBrowser(userAgent: string): string | null {
+  if (/Edg\//.test(userAgent)) {
+    return "Edge";
+  }
+  if (/OPR\//.test(userAgent)) {
+    return "Opera";
+  }
+  if (/Firefox\//.test(userAgent)) {
+    return "Firefox";
+  }
+  if (/Chrome\/|CriOS\//.test(userAgent)) {
+    return "Chrome";
+  }
+  if (/Safari\//.test(userAgent)) {
+    return "Safari";
+  }
+  return null;
+}
+
+/**
+ * Resolves a stored User-Agent into a browser and OS, or `null` if the input
+ * is blank or neither could be identified. Never returns a partially-empty
+ * object; callers that get `null` should fall back to a platform label.
+ */
+export function labelFromUserAgent(
+  userAgent: string | null | undefined,
+): DeviceUserAgentParts | null {
+  if (!userAgent || userAgent.trim() === "") {
+    return null;
+  }
+
+  const os = detectOS(userAgent);
+  const browser = detectBrowser(userAgent);
+
+  if (os === null && browser === null) {
+    return null;
+  }
+
+  return { browser, os };
+}


### PR DESCRIPTION
## Summary
- Add labelFromUserAgent: parses a stored User-Agent into structured {browser, os} parts
- Returns null (not a partial object) when nothing recognizable is found
- Deliberately independent of navigator-based platform-detection.ts

Part of plan: paired-device-names.md (PR 3 of 15)