### PR TITLE
feat(gateway): cap device identity text at store time

### DIFF
--- a/gateway/src/__tests__/device-identity-text.test.ts
+++ b/gateway/src/__tests__/device-identity-text.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  capDeviceIdentityText,
+  MAX_CLIENT_REPORTED_NAME_CHARS,
+  MAX_PAIRING_USER_AGENT_CHARS,
+} from "../auth/device-identity-text.js";
+
+describe("capDeviceIdentityText", () => {
+  test("null passes through as null", () => {
+    expect(capDeviceIdentityText(null, MAX_CLIENT_REPORTED_NAME_CHARS)).toBe(
+      null,
+    );
+  });
+
+  test("undefined passes through as null", () => {
+    expect(
+      capDeviceIdentityText(undefined, MAX_CLIENT_REPORTED_NAME_CHARS),
+    ).toBe(null);
+  });
+
+  test("whitespace-only value becomes null", () => {
+    expect(
+      capDeviceIdentityText("   ", MAX_CLIENT_REPORTED_NAME_CHARS),
+    ).toBe(null);
+  });
+
+  test("trims surrounding whitespace", () => {
+    expect(
+      capDeviceIdentityText("  Noa's iPhone  ", MAX_CLIENT_REPORTED_NAME_CHARS),
+    ).toBe("Noa's iPhone");
+  });
+
+  test("strips control characters including an embedded newline", () => {
+    const withNewline = "Noa's" + String.fromCharCode(10) + "iPhone";
+    expect(
+      capDeviceIdentityText(withNewline, MAX_CLIENT_REPORTED_NAME_CHARS),
+    ).toBe("Noa'siPhone");
+  });
+
+  test("strips an ESC control character", () => {
+    const withEsc = "evil" + String.fromCharCode(27) + "[31mname";
+    expect(capDeviceIdentityText(withEsc, MAX_CLIENT_REPORTED_NAME_CHARS)).toBe(
+      "evil[31mname",
+    );
+  });
+
+  test("value at exactly maxChars is unchanged", () => {
+    const value = "a".repeat(MAX_CLIENT_REPORTED_NAME_CHARS);
+    const result = capDeviceIdentityText(value, MAX_CLIENT_REPORTED_NAME_CHARS);
+    expect(result).toBe(value);
+    expect(result?.length).toBe(MAX_CLIENT_REPORTED_NAME_CHARS);
+  });
+
+  test("over-length User-Agent is truncated to exactly the max", () => {
+    const value = "u".repeat(600);
+    const result = capDeviceIdentityText(value, MAX_PAIRING_USER_AGENT_CHARS);
+    expect(result?.length).toBe(MAX_PAIRING_USER_AGENT_CHARS);
+    expect(result).toBe("u".repeat(MAX_PAIRING_USER_AGENT_CHARS));
+  });
+
+  test("a normal short value is returned unchanged", () => {
+    expect(
+      capDeviceIdentityText("Chrome on macOS", MAX_CLIENT_REPORTED_NAME_CHARS),
+    ).toBe("Chrome on macOS");
+  });
+});

--- a/gateway/src/auth/device-identity-text.ts
+++ b/gateway/src/auth/device-identity-text.ts
@@ -1,0 +1,37 @@
+// Store-time caps for device identity text. Both pairing_user_agent (an
+// observation) and client_reported_name (an assertion) are attacker-controlled
+// text: a device that can name itself can name itself deceptively, so callers
+// must cap and sanitize before persisting.
+
+export const MAX_PAIRING_USER_AGENT_CHARS = 512;
+export const MAX_CLIENT_REPORTED_NAME_CHARS = 64;
+
+// Strips ASCII control characters (codepoints 0-31, plus DEL at 127) so a
+// stored value cannot inject line breaks into anything that later renders
+// or logs it.
+function stripControlChars(value: string): string {
+  let out = "";
+  for (const ch of value) {
+    const code = ch.codePointAt(0) ?? 0;
+    if (code <= 31 || code === 127) {
+      continue;
+    }
+    out += ch;
+  }
+  return out;
+}
+
+export function capDeviceIdentityText(
+  value: string | null | undefined,
+  maxChars: number,
+): string | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  const trimmed = value.trim();
+  if (trimmed === "") {
+    return null;
+  }
+  const stripped = stripControlChars(trimmed);
+  return stripped.slice(0, maxChars);
+}


### PR DESCRIPTION
## Summary
- Add capDeviceIdentityText helper: trims, strips control chars, caps length
- Add MAX_PAIRING_USER_AGENT_CHARS (512) and MAX_CLIENT_REPORTED_NAME_CHARS (64) constants
- Dependency-free module, no DB or logger imports

Part of plan: paired-device-names.md (PR 2 of 15)