### PR TITLE
feat(local-mode): pass device identity fields through the devices contract

### DIFF
--- a/packages/electron-desktop/src/local-mode.test.ts
+++ b/packages/electron-desktop/src/local-mode.test.ts
@@ -779,7 +779,12 @@ describe("vellum:localMode:listDevices handler", () => {
       Buffer.from(JSON.stringify({ devices: [device] })),
     );
     lastChild.emit("close", 0);
-    expect(await pending).toEqual({ ok: true, devices: [device] });
+    expect(await pending).toEqual({
+      ok: true,
+      devices: [
+        { ...device, pairingUserAgent: null, clientReportedName: null },
+      ],
+    });
   });
 
   test("a non-zero exit resolves to a failure carrying the CLI's stderr", async () => {

--- a/packages/ipc-contract/src/bridge.ts
+++ b/packages/ipc-contract/src/bridge.ts
@@ -96,6 +96,10 @@ export interface LocalPairedDeviceRecord {
   issuedAt: number | null;
   expiresAt: number | null;
   lastUsedAt: number | null;
+  /** Raw User-Agent observed when this device paired, or null. */
+  pairingUserAgent?: string | null;
+  /** Name the device reported for itself when pairing, or null. */
+  clientReportedName?: string | null;
   /** True when this row is the hosting machine's own guardian credential. */
   isCurrentHost?: boolean;
 }

--- a/packages/local-mode/src/devices.test.ts
+++ b/packages/local-mode/src/devices.test.ts
@@ -49,6 +49,8 @@ describe("runDevicesList", () => {
               issuedAt: 1000,
               expiresAt: 2000,
               lastUsedAt: 1500,
+              pairingUserAgent: "Vellum/1.0 iOS",
+              clientReportedName: "Noa's iPhone",
             },
           ],
         }),
@@ -65,6 +67,8 @@ describe("runDevicesList", () => {
           issuedAt: 1000,
           expiresAt: 2000,
           lastUsedAt: 1500,
+          pairingUserAgent: "Vellum/1.0 iOS",
+          clientReportedName: "Noa's iPhone",
         },
       ],
     });
@@ -103,6 +107,64 @@ describe("runDevicesList", () => {
           issuedAt: null,
           expiresAt: null,
           lastUsedAt: null,
+          pairingUserAgent: null,
+          clientReportedName: null,
+        },
+      ],
+    });
+  });
+
+  test("non-string pairingUserAgent and clientReportedName parse to null without failing the record", async () => {
+    const pending = runDevicesList(invocation, "asst-42");
+    lastChild.stdout.emit(
+      "data",
+      Buffer.from(
+        JSON.stringify({
+          devices: [
+            {
+              hashedDeviceId: "hash-c",
+              platform: "android",
+              issuedAt: 1000,
+              expiresAt: 2000,
+              lastUsedAt: 1500,
+              pairingUserAgent: 42,
+              clientReportedName: { nested: true },
+            },
+            {
+              hashedDeviceId: "hash-d",
+              platform: "android",
+              issuedAt: 1000,
+              expiresAt: 2000,
+              lastUsedAt: 1500,
+              pairingUserAgent: null,
+              clientReportedName: null,
+            },
+          ],
+        }),
+      ),
+    );
+    lastChild.emit("close", 0);
+
+    expect(await pending).toEqual({
+      ok: true,
+      devices: [
+        {
+          hashedDeviceId: "hash-c",
+          platform: "android",
+          issuedAt: 1000,
+          expiresAt: 2000,
+          lastUsedAt: 1500,
+          pairingUserAgent: null,
+          clientReportedName: null,
+        },
+        {
+          hashedDeviceId: "hash-d",
+          platform: "android",
+          issuedAt: 1000,
+          expiresAt: 2000,
+          lastUsedAt: 1500,
+          pairingUserAgent: null,
+          clientReportedName: null,
         },
       ],
     });

--- a/packages/local-mode/src/devices.ts
+++ b/packages/local-mode/src/devices.ts
@@ -16,6 +16,10 @@ export interface DeviceRecord {
   issuedAt: number | null;
   expiresAt: number | null;
   lastUsedAt: number | null;
+  /** Raw User-Agent observed when this device paired, or null. */
+  pairingUserAgent?: string | null;
+  /** Name the device reported for itself when pairing, or null. */
+  clientReportedName?: string | null;
   /** True when this row is the hosting machine's own guardian credential. */
   isCurrentHost?: boolean;
 }
@@ -104,6 +108,10 @@ function toTimestamp(value: unknown): number | null {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
 
+function toText(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
 function parseDeviceRecords(stdout: string): DeviceRecord[] | null {
   let parsed: unknown;
   try {
@@ -130,6 +138,8 @@ function parseDeviceRecords(stdout: string): DeviceRecord[] | null {
       issuedAt,
       expiresAt,
       lastUsedAt,
+      pairingUserAgent,
+      clientReportedName,
       isCurrentHost,
     } = entry as Record<string, unknown>;
     if (typeof hashedDeviceId !== "string" || typeof platform !== "string") {
@@ -141,6 +151,8 @@ function parseDeviceRecords(stdout: string): DeviceRecord[] | null {
       issuedAt: toTimestamp(issuedAt),
       expiresAt: toTimestamp(expiresAt),
       lastUsedAt: toTimestamp(lastUsedAt),
+      pairingUserAgent: toText(pairingUserAgent),
+      clientReportedName: toText(clientReportedName),
       // Tolerant passthrough: only a literal `true` survives.
       ...(isCurrentHost === true ? { isCurrentHost: true } : {}),
     });


### PR DESCRIPTION
## Summary
- Add optional pairingUserAgent and clientReportedName to LocalPairedDeviceRecord and DeviceRecord
- Widen parseDeviceRecords' field whitelist to pass both through tolerantly
- No host call site changes needed; all three pass runDevicesList's result verbatim

Part of plan: paired-device-names.md (PR 6 of 15)