### PR TITLE
feat(gateway): return device identity from the devices list

### DIFF
--- a/gateway/src/__tests__/devices.test.ts
+++ b/gateway/src/__tests__/devices.test.ts
@@ -252,6 +252,41 @@ describe("GET /v1/devices", () => {
     expect(a?.platform).toBe("cli");
   });
 
+  test("surfaces pairingUserAgent and clientReportedName, alongside a correct lastUsedAt", async () => {
+    seedActor({
+      device: "device-A",
+      pairingUserAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
+      clientReportedName: "Noa's MacBook Pro",
+      lastUsedAt: 1_700_000_000_000,
+    });
+    seedActor({ device: "device-B" });
+
+    const res = await handleListDevices(listRequest(), LOOPBACK_IP);
+    const body = (await res.json()) as {
+      devices: {
+        hashedDeviceId: string;
+        pairingUserAgent: string | null;
+        clientReportedName: string | null;
+        lastUsedAt: number | null;
+      }[];
+    };
+
+    const a = body.devices.find(
+      (d) => d.hashedDeviceId === hashToken("device-A"),
+    );
+    expect(a?.pairingUserAgent).toBe(
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
+    );
+    expect(a?.clientReportedName).toBe("Noa's MacBook Pro");
+    expect(a?.lastUsedAt).toBe(1_700_000_000_000);
+
+    const b = body.devices.find(
+      (d) => d.hashedDeviceId === hashToken("device-B"),
+    );
+    expect(b).toHaveProperty("pairingUserAgent", null);
+    expect(b).toHaveProperty("clientReportedName", null);
+  });
+
   test("surfaces lastUsedAt from the actor token row", async () => {
     seedActor({ device: "device-A", lastUsedAt: 1_700_000_000_000 });
 

--- a/gateway/src/http/routes/devices.ts
+++ b/gateway/src/http/routes/devices.ts
@@ -51,6 +51,8 @@ export async function handleListDevices(
     .select({
       hashedDeviceId: actorTokenRecords.hashedDeviceId,
       platform: actorTokenRecords.platform,
+      pairingUserAgent: actorTokenRecords.pairingUserAgent,
+      clientReportedName: actorTokenRecords.clientReportedName,
       issuedAt: actorTokenRecords.issuedAt,
       expiresAt: actorTokenRecords.expiresAt,
     })
@@ -85,6 +87,8 @@ export async function handleListDevices(
   const devices = tokens.map((t) => ({
     hashedDeviceId: t.hashedDeviceId,
     platform: t.platform,
+    pairingUserAgent: t.pairingUserAgent ?? null,
+    clientReportedName: t.clientReportedName ?? null,
     issuedAt: t.issuedAt,
     expiresAt: t.expiresAt ?? null,
     lastUsedAt: lastUsedByDevice.get(t.hashedDeviceId) ?? null,


### PR DESCRIPTION
## Summary
- GET /v1/devices now includes pairingUserAgent and clientReportedName on every active row
- Both normalized to null when absent, present as keys
- The separate max(lastUsedAt) aggregation query is untouched

Part of plan: paired-device-names.md (PR 10 of 15)