### PR TITLE
fix(gateway): keep device identity across credential rotation

### DIFF
--- a/gateway/src/__tests__/refresh-device-binding.test.ts
+++ b/gateway/src/__tests__/refresh-device-binding.test.ts
@@ -39,6 +39,10 @@ function insertRefreshRecord(
   rawToken: string,
   deviceId: string,
   status: "active" | "rotated" | "revoked" = "active",
+  identity: {
+    pairingUserAgent: string | null;
+    clientReportedName: string | null;
+  } | null = null,
 ) {
   const now = Date.now();
   getGatewayDb()
@@ -50,6 +54,8 @@ function insertRefreshRecord(
       guardianPrincipalId: PRINCIPAL,
       hashedDeviceId: hashToken(deviceId),
       platform: "cli",
+      pairingUserAgent: identity?.pairingUserAgent ?? null,
+      clientReportedName: identity?.clientReportedName ?? null,
       status,
       issuedAt: now,
       absoluteExpiresAt: now + 365 * 86_400_000,
@@ -321,5 +327,110 @@ describe("rotateCredentials activity history", () => {
 
     const rows = getGatewayDb().select().from(actorTokenRecords).all();
     expect(rows.map((r) => r.lastUsedAt)).toEqual([null, null]);
+  });
+});
+
+describe("rotateCredentials device identity carry-forward", () => {
+  // Regression for #41228: lastUsedAt lived on one table only and rotation
+  // reset it, costing two remediation rounds. pairingUserAgent and
+  // clientReportedName must survive rotation the same way platform does.
+  const USER_AGENT = "Vellum-CLI/1.2.3 (Macintosh; Darwin)";
+  const REPORTED_NAME = "Noa's MacBook Pro";
+
+  function findActorTokenRow(rawToken: string) {
+    return getGatewayDb()
+      .select()
+      .from(actorTokenRecords)
+      .all()
+      .find((r) => r.tokenHash === hashToken(rawToken));
+  }
+
+  function findRefreshTokenRow(rawToken: string) {
+    return getGatewayDb()
+      .select()
+      .from(actorRefreshTokenRecords)
+      .all()
+      .find((r) => r.tokenHash === hashToken(rawToken));
+  }
+
+  test("carries pairingUserAgent and clientReportedName onto the new actor-token and refresh-token rows after one rotation", () => {
+    insertRefreshRecord("rt-identity", DEVICE_A, "active", {
+      pairingUserAgent: USER_AGENT,
+      clientReportedName: REPORTED_NAME,
+    });
+
+    const result = rotateCredentials({
+      refreshToken: "rt-identity",
+      hashedDeviceId: hashToken(DEVICE_A),
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+
+    const newActorRow = findActorTokenRow(result.result.accessToken);
+    expect(newActorRow?.pairingUserAgent).toBe(USER_AGENT);
+    expect(newActorRow?.clientReportedName).toBe(REPORTED_NAME);
+
+    const newRefreshRow = findRefreshTokenRow(result.result.refreshToken);
+    expect(newRefreshRow?.pairingUserAgent).toBe(USER_AGENT);
+    expect(newRefreshRow?.clientReportedName).toBe(REPORTED_NAME);
+  });
+
+  test("keeps the identity intact across two consecutive rotations", () => {
+    insertRefreshRecord("rt-identity-hop1", DEVICE_A, "active", {
+      pairingUserAgent: USER_AGENT,
+      clientReportedName: REPORTED_NAME,
+    });
+
+    const first = rotateCredentials({
+      refreshToken: "rt-identity-hop1",
+      hashedDeviceId: hashToken(DEVICE_A),
+    });
+    expect(first.ok).toBe(true);
+    if (!first.ok) {
+      return;
+    }
+
+    const second = rotateCredentials({
+      refreshToken: first.result.refreshToken,
+      hashedDeviceId: hashToken(DEVICE_A),
+    });
+    expect(second.ok).toBe(true);
+    if (!second.ok) {
+      return;
+    }
+
+    const newActorRow = findActorTokenRow(second.result.accessToken);
+    expect(newActorRow?.pairingUserAgent).toBe(USER_AGENT);
+    expect(newActorRow?.clientReportedName).toBe(REPORTED_NAME);
+
+    const newRefreshRow = findRefreshTokenRow(second.result.refreshToken);
+    expect(newRefreshRow?.pairingUserAgent).toBe(USER_AGENT);
+    expect(newRefreshRow?.clientReportedName).toBe(REPORTED_NAME);
+  });
+
+  test("a null stored identity rotates cleanly and stays null", () => {
+    insertRefreshRecord("rt-no-identity", DEVICE_A, "active", {
+      pairingUserAgent: null,
+      clientReportedName: null,
+    });
+
+    const result = rotateCredentials({
+      refreshToken: "rt-no-identity",
+      hashedDeviceId: hashToken(DEVICE_A),
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+
+    const newActorRow = findActorTokenRow(result.result.accessToken);
+    expect(newActorRow?.pairingUserAgent).toBeNull();
+    expect(newActorRow?.clientReportedName).toBeNull();
+
+    const newRefreshRow = findRefreshTokenRow(result.result.refreshToken);
+    expect(newRefreshRow?.pairingUserAgent).toBeNull();
+    expect(newRefreshRow?.clientReportedName).toBeNull();
   });
 });

--- a/gateway/src/auth/guardian-refresh.ts
+++ b/gateway/src/auth/guardian-refresh.ts
@@ -137,6 +137,8 @@ function mintAccessToken(
   guardianPrincipalId: string,
   hashedDeviceId: string,
   platform: string,
+  pairingUserAgent: string | null,
+  clientReportedName: string | null,
 ): { token: string; expiresAt: number } {
   const externalAssistantId = getExternalAssistantId();
   const sub = `actor:${externalAssistantId}:${guardianPrincipalId}`;
@@ -161,6 +163,8 @@ function mintAccessToken(
       guardianPrincipalId,
       hashedDeviceId,
       platform,
+      pairingUserAgent,
+      clientReportedName,
       status: "active",
       issuedAt: now,
       expiresAt,
@@ -176,6 +180,8 @@ function mintRefreshTokenInFamily(params: {
   guardianPrincipalId: string;
   hashedDeviceId: string;
   platform: string;
+  pairingUserAgent: string | null;
+  clientReportedName: string | null;
   familyId: string;
   absoluteExpiresAt: number;
   browserRefreshCookiePath?: string;
@@ -198,6 +204,8 @@ function mintRefreshTokenInFamily(params: {
       guardianPrincipalId: params.guardianPrincipalId,
       hashedDeviceId: params.hashedDeviceId,
       platform: params.platform,
+      pairingUserAgent: params.pairingUserAgent,
+      clientReportedName: params.clientReportedName,
       status: "active",
       issuedAt: now,
       absoluteExpiresAt: params.absoluteExpiresAt,
@@ -288,12 +296,16 @@ function rotateRefreshTokenRecord(
       record.guardianPrincipalId,
       record.hashedDeviceId,
       record.platform,
+      record.pairingUserAgent,
+      record.clientReportedName,
     );
 
     const refresh = mintRefreshTokenInFamily({
       guardianPrincipalId: record.guardianPrincipalId,
       hashedDeviceId: record.hashedDeviceId,
       platform: record.platform,
+      pairingUserAgent: record.pairingUserAgent,
+      clientReportedName: record.clientReportedName,
       familyId: record.familyId,
       absoluteExpiresAt: record.absoluteExpiresAt,
       browserRefreshCookiePath: record.browserRefreshCookiePath ?? undefined,


### PR DESCRIPTION
## Summary
- rotateRefreshTokenRecord now carries pairingUserAgent and clientReportedName forward from the rotating record, mirroring how platform already survives rotation
- Add mandatory carry-forward regression tests (single and double rotation), plus a null-identity rotation test

Part of plan: paired-device-names.md (PR 8 of 15)