### PR TITLE
feat(gateway): persist device identity on minted credentials

### DIFF
--- a/gateway/src/__tests__/devices.test.ts
+++ b/gateway/src/__tests__/devices.test.ts
@@ -30,7 +30,10 @@ const {
   contacts,
   contactChannels,
 } = await import("../db/schema.js");
-const { hashToken } = await import("../auth/guardian-bootstrap.js");
+const { hashToken, mintAndRecordDeviceBoundTokenPair } =
+  await import("../auth/guardian-bootstrap.js");
+const { MAX_PAIRING_USER_AGENT_CHARS } =
+  await import("../auth/device-identity-text.js");
 const { handleListDevices, handleRevokeDevice } =
   await import("../http/routes/devices.js");
 
@@ -228,6 +231,87 @@ describe("actorTokenRecords device identity columns", () => {
       .get();
     expect(row?.pairingUserAgent).toBeNull();
     expect(row?.clientReportedName).toBeNull();
+  });
+});
+
+describe("mintAndRecordDeviceBoundTokenPair identity persistence", () => {
+  function actorRow(device: string) {
+    return getGatewayDb()
+      .select()
+      .from(actorTokenRecords)
+      .where(eq(actorTokenRecords.hashedDeviceId, hashToken(device)))
+      .get();
+  }
+
+  function refreshRow(device: string) {
+    return getGatewayDb()
+      .select()
+      .from(actorRefreshTokenRecords)
+      .where(eq(actorRefreshTokenRecords.hashedDeviceId, hashToken(device)))
+      .get();
+  }
+
+  test("writes identity to both the actor-token row and the refresh-token row", () => {
+    mintAndRecordDeviceBoundTokenPair({
+      guardianPrincipalId: GUARDIAN_ID,
+      deviceId: "mint-device-with-identity",
+      platform: "cli",
+      identity: {
+        pairingUserAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
+        clientReportedName: "Noa's MacBook Pro",
+      },
+    });
+
+    const access = actorRow("mint-device-with-identity");
+    expect(access?.pairingUserAgent).toBe(
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
+    );
+    expect(access?.clientReportedName).toBe("Noa's MacBook Pro");
+
+    const refresh = refreshRow("mint-device-with-identity");
+    expect(refresh?.pairingUserAgent).toBe(
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
+    );
+    expect(refresh?.clientReportedName).toBe("Noa's MacBook Pro");
+  });
+
+  test("writes null to both columns on both tables when identity is omitted", () => {
+    mintAndRecordDeviceBoundTokenPair({
+      guardianPrincipalId: GUARDIAN_ID,
+      deviceId: "mint-device-without-identity",
+      platform: "cli",
+    });
+
+    const access = actorRow("mint-device-without-identity");
+    expect(access?.pairingUserAgent).toBeNull();
+    expect(access?.clientReportedName).toBeNull();
+
+    const refresh = refreshRow("mint-device-without-identity");
+    expect(refresh?.pairingUserAgent).toBeNull();
+    expect(refresh?.clientReportedName).toBeNull();
+  });
+
+  test("truncates an over-length User-Agent to MAX_PAIRING_USER_AGENT_CHARS", () => {
+    const overLongUserAgent = "A".repeat(600);
+    expect(overLongUserAgent.length).toBe(600);
+
+    mintAndRecordDeviceBoundTokenPair({
+      guardianPrincipalId: GUARDIAN_ID,
+      deviceId: "mint-device-long-user-agent",
+      platform: "cli",
+      identity: { pairingUserAgent: overLongUserAgent },
+    });
+
+    const access = actorRow("mint-device-long-user-agent");
+    expect(access?.pairingUserAgent?.length).toBe(MAX_PAIRING_USER_AGENT_CHARS);
+    expect(access?.pairingUserAgent).toBe(
+      "A".repeat(MAX_PAIRING_USER_AGENT_CHARS),
+    );
+
+    const refresh = refreshRow("mint-device-long-user-agent");
+    expect(refresh?.pairingUserAgent?.length).toBe(
+      MAX_PAIRING_USER_AGENT_CHARS,
+    );
   });
 });
 

--- a/gateway/src/auth/guardian-bootstrap.ts
+++ b/gateway/src/auth/guardian-bootstrap.ts
@@ -27,6 +27,11 @@ import { getLogger } from "../logger.js";
 import { deleteContactIfOrphaned } from "../verification/contact-helpers.js";
 
 import {
+  capDeviceIdentityText,
+  MAX_CLIENT_REPORTED_NAME_CHARS,
+  MAX_PAIRING_USER_AGENT_CHARS,
+} from "./device-identity-text.js";
+import {
   bustGuardianIntegrityCache,
   guardianIntegrityState,
   hasEvidenceOfPriorGuardian,
@@ -646,6 +651,17 @@ export function revokeRefreshTokensByDevice(
 }
 
 /**
+ * Device identity observed/asserted at mint time, carried as one unit so it
+ * travels through the minting signatures as a pair rather than two loose
+ * parameters. Capping happens at the store boundary (inside the mint
+ * functions below), not here, so no caller can bypass it.
+ */
+export interface DeviceIdentityInput {
+  pairingUserAgent?: string | null;
+  clientReportedName?: string | null;
+}
+
+/**
  * Mint a JWT access token and persist its hash in the gateway DB.
  */
 function mintAccessToken(
@@ -653,6 +669,7 @@ function mintAccessToken(
   hashedDeviceId: string,
   platform: string,
   ttlSeconds: number = ACCESS_TOKEN_TTL_SECONDS,
+  identity?: DeviceIdentityInput,
 ): { token: string; expiresAt: number } {
   const externalAssistantId = getExternalAssistantId();
   const sub = `actor:${externalAssistantId}:${guardianPrincipalId}`;
@@ -677,6 +694,14 @@ function mintAccessToken(
       guardianPrincipalId,
       hashedDeviceId,
       platform,
+      pairingUserAgent: capDeviceIdentityText(
+        identity?.pairingUserAgent,
+        MAX_PAIRING_USER_AGENT_CHARS,
+      ),
+      clientReportedName: capDeviceIdentityText(
+        identity?.clientReportedName,
+        MAX_CLIENT_REPORTED_NAME_CHARS,
+      ),
       status: "active",
       issuedAt: now,
       expiresAt,
@@ -696,6 +721,7 @@ function mintRefreshToken(
   hashedDeviceId: string,
   platform: string,
   options: { browserRefreshCookiePath?: string } = {},
+  identity?: DeviceIdentityInput,
 ): {
   refreshToken: string;
   refreshTokenExpiresAt: number;
@@ -717,6 +743,14 @@ function mintRefreshToken(
       guardianPrincipalId,
       hashedDeviceId,
       platform,
+      pairingUserAgent: capDeviceIdentityText(
+        identity?.pairingUserAgent,
+        MAX_PAIRING_USER_AGENT_CHARS,
+      ),
+      clientReportedName: capDeviceIdentityText(
+        identity?.clientReportedName,
+        MAX_CLIENT_REPORTED_NAME_CHARS,
+      ),
       status: "active",
       issuedAt: now,
       absoluteExpiresAt,
@@ -749,6 +783,7 @@ export function mintAndRecordDeviceBoundTokenPair(params: {
   guardianPrincipalId: string;
   deviceId: string;
   platform: string;
+  identity?: DeviceIdentityInput;
 }): DeviceBoundTokenPair {
   const hashedDeviceId = hashToken(params.deviceId);
 
@@ -759,11 +794,15 @@ export function mintAndRecordDeviceBoundTokenPair(params: {
     params.guardianPrincipalId,
     hashedDeviceId,
     params.platform,
+    ACCESS_TOKEN_TTL_SECONDS,
+    params.identity,
   );
   const refresh = mintRefreshToken(
     params.guardianPrincipalId,
     hashedDeviceId,
     params.platform,
+    {},
+    params.identity,
   );
 
   return {
@@ -784,6 +823,7 @@ export function mintAndRecordBrowserTokenPair(params: {
   guardianPrincipalId: string;
   platform: string;
   browserRefreshCookiePath: string;
+  identity?: DeviceIdentityInput;
 }): RefreshableTokenPair {
   const internalBinding = randomBytes(32).toString("base64url");
   const hashedDeviceId = hashToken(internalBinding);
@@ -792,12 +832,15 @@ export function mintAndRecordBrowserTokenPair(params: {
     params.guardianPrincipalId,
     hashedDeviceId,
     params.platform,
+    ACCESS_TOKEN_TTL_SECONDS,
+    params.identity,
   );
   const refresh = mintRefreshToken(
     params.guardianPrincipalId,
     hashedDeviceId,
     params.platform,
     { browserRefreshCookiePath: params.browserRefreshCookiePath },
+    params.identity,
   );
 
   return {


### PR DESCRIPTION
## Summary
- Add optional identity parameter (pairingUserAgent, clientReportedName) to the bootstrap minting functions
- Capped values written to both actor-token and refresh-token rows at the store boundary
- Existing callers unaffected; PRs 13-15 will pass real values

Part of plan: paired-device-names.md (PR 7 of 15)