### PR TITLE
feat(cli): show device identity in vellum devices

### DIFF
--- a/cli/src/__tests__/devices.test.ts
+++ b/cli/src/__tests__/devices.test.ts
@@ -147,6 +147,8 @@ describe("vellum devices", () => {
               issuedAt: 1_700_000_000_000,
               expiresAt: 1_800_000_000_000,
               lastUsedAt: 1_750_000_000_000,
+              clientReportedName: "Alice's Laptop",
+              pairingUserAgent: "vellum-cli/1.2.3 (darwin)",
             },
             {
               hashedDeviceId: "hashBBB222",
@@ -171,6 +173,13 @@ describe("vellum devices", () => {
     expect(logs).toContain("cli");
     expect(logs).toContain("webview");
     expect(logs).toContain("never");
+    // Reported name + user agent print verbatim when present.
+    expect(logs).toContain("Alice's Laptop");
+    expect(logs).toContain("vellum-cli/1.2.3 (darwin)");
+    // Missing fields print plain-word placeholders, not a dash or "undefined".
+    expect(logs).toContain("not reported");
+    expect(logs).toContain("not recorded");
+    expect(logs).not.toContain("undefined");
 
     expect(fetchCalls).toHaveLength(1);
     const call = fetchCalls[0];
@@ -377,6 +386,8 @@ describe("vellum devices", () => {
         issuedAt: 1_700_000_000_000,
         expiresAt: 1_800_000_000_000,
         lastUsedAt: null,
+        clientReportedName: "Alice's Laptop",
+        pairingUserAgent: "vellum-cli/1.2.3 (darwin)",
       },
     ];
     stubFetch((url) =>
@@ -392,6 +403,7 @@ describe("vellum devices", () => {
     expect(errors).toBe("");
     // Exactly one line on stdout, parseable, and zero prose.
     expect(logs).not.toContain("\n");
+    // Round-trips clientReportedName/pairingUserAgent with no writer change.
     expect(JSON.parse(logs)).toEqual({ devices: records });
     expect(logs).not.toContain("Devices paired to");
   });

--- a/cli/src/commands/devices.ts
+++ b/cli/src/commands/devices.ts
@@ -165,6 +165,10 @@ async function listDevices(
   for (const device of devices) {
     console.log(`  ${device.hashedDeviceId}`);
     console.log(`    platform:   ${device.platform}`);
+    console.log(
+      `    name:       ${device.clientReportedName || "not reported"}`,
+    );
+    console.log(`    user agent: ${device.pairingUserAgent || "not recorded"}`);
     console.log(`    issued:     ${formatTimestamp(device.issuedAt, "—")}`);
     console.log(`    expires:    ${formatTimestamp(device.expiresAt, "—")}`);
     console.log(


### PR DESCRIPTION
## Summary
- vellum devices <id> now prints a name and user agent line per device
- Missing fields print plain-word placeholders (not reported / not recorded), not a dash
- --json output unchanged, already round-trips whatever DeviceRecord carries

Part of plan: paired-device-names.md (PR 11 of 15)