### PR TITLE
feat(cli): add -d/--detach to vellum tunnel

### DIFF
--- a/cli/src/__tests__/detached-process.test.ts
+++ b/cli/src/__tests__/detached-process.test.ts
@@ -1,0 +1,152 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
+import * as childProcess from "node:child_process";
+import type { ChildProcess } from "node:child_process";
+import { EventEmitter } from "node:events";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const realChildProcess = { ...childProcess };
+
+function makeFakeChild(pid: number): ChildProcess {
+  const emitter = new EventEmitter();
+  return Object.assign(emitter, {
+    stdout: null,
+    stderr: null,
+    killed: false,
+    kill: () => true,
+    unref: () => {},
+    pid,
+  }) as unknown as ChildProcess;
+}
+
+const spawnMock = mock((..._args: unknown[]) => makeFakeChild(1111));
+
+beforeAll(() => {
+  mock.module("node:child_process", () => ({
+    ...realChildProcess,
+    spawn: spawnMock,
+  }));
+});
+
+afterAll(() => {
+  mock.module("node:child_process", () => realChildProcess);
+});
+
+const { relaunchDetached } = await import("../lib/detached-process.js");
+
+const originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
+const tempDirs: string[] = [];
+
+describe("relaunchDetached", () => {
+  beforeEach(() => {
+    spawnMock.mockClear();
+    const configHome = mkdtempSync(join(tmpdir(), "vellum-detached-xdg-"));
+    tempDirs.push(configHome);
+    process.env.XDG_CONFIG_HOME = configHome;
+  });
+
+  afterEach(() => {
+    if (originalXdgConfigHome === undefined) {
+      delete process.env.XDG_CONFIG_HOME;
+    } else {
+      process.env.XDG_CONFIG_HOME = originalXdgConfigHome;
+    }
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("spawns the current binary detached with the given args and reports readiness", async () => {
+    spawnMock.mockImplementationOnce(() => makeFakeChild(2222));
+
+    const result = await relaunchDetached({
+      args: ["tunnel", "--provider", "ngrok"],
+      logFile: "relaunch-ready.log",
+      timeoutMs: 1000,
+      pollIntervalMs: 10,
+      isReady: () => true,
+    });
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const [cmd, args, opts] = spawnMock.mock.calls[0] as unknown as [
+      string,
+      string[],
+      Record<string, unknown>,
+    ];
+    expect(cmd).toBe(process.execPath);
+    expect(args).toContain("tunnel");
+    expect(args).toContain("--provider");
+    expect(args).toContain("ngrok");
+    expect(opts.detached).toBe(true);
+
+    expect(result.ready).toBe(true);
+    expect(result.exitCode).toBeUndefined();
+    expect(result.child.pid).toBe(2222);
+    expect(result.logPath.endsWith("relaunch-ready.log")).toBe(true);
+  });
+
+  test("passes the resolved log path into isReady", async () => {
+    spawnMock.mockImplementationOnce(() => makeFakeChild(3333));
+    const seenPaths: string[] = [];
+
+    const result = await relaunchDetached({
+      args: ["tunnel"],
+      logFile: "relaunch-logpath.log",
+      timeoutMs: 1000,
+      pollIntervalMs: 10,
+      isReady: (logPath) => {
+        seenPaths.push(logPath);
+        return true;
+      },
+    });
+
+    expect(seenPaths).toEqual([result.logPath]);
+  });
+
+  test("stops polling and reports the exit code once the child exits before readiness", async () => {
+    spawnMock.mockImplementationOnce(() => {
+      const child = makeFakeChild(4444);
+      // Listeners attach synchronously right after spawn() returns; defer the
+      // exit so they're in place before it fires.
+      setTimeout(() => (child as unknown as EventEmitter).emit("exit", 7), 0);
+      return child;
+    });
+
+    const result = await relaunchDetached({
+      args: ["tunnel"],
+      logFile: "relaunch-exit.log",
+      timeoutMs: 1000,
+      pollIntervalMs: 10,
+      isReady: () => false,
+    });
+
+    expect(result.ready).toBe(false);
+    expect(result.exitCode).toBe(7);
+  });
+
+  test("gives up once timeoutMs elapses with no readiness and no exit", async () => {
+    spawnMock.mockImplementationOnce(() => makeFakeChild(5555));
+
+    const result = await relaunchDetached({
+      args: ["tunnel"],
+      logFile: "relaunch-timeout.log",
+      timeoutMs: 60,
+      pollIntervalMs: 10,
+      isReady: () => false,
+    });
+
+    expect(result.ready).toBe(false);
+    expect(result.exitCode).toBeUndefined();
+    expect(result.child.pid).toBe(5555);
+  });
+});

--- a/cli/src/__tests__/tunnel.test.ts
+++ b/cli/src/__tests__/tunnel.test.ts
@@ -1472,6 +1472,12 @@ describe("tunnel --detach", () => {
 
   const spawnMock = mock((..._args: unknown[]) => makeFakeChild(9999));
 
+  // spawnDetachedTunnel() scopes the log filename to its own (parent) pid,
+  // which in-process is this test runner's pid.
+  function detachedLogPath(): string {
+    return join(getLogDir(), `tunnel-${process.pid}.log`);
+  }
+
   beforeAll(() => {
     mock.module("node:child_process", () => ({
       ...realChildProcess,
@@ -1516,7 +1522,7 @@ describe("tunnel --detach", () => {
     // the moment it is spawned.
     spawnMock.mockImplementationOnce(() => {
       appendFileSync(
-        join(getLogDir(), "tunnel.log"),
+        detachedLogPath(),
         "Tunnel established: https://foo.ngrok.app\n",
       );
       return makeFakeChild(9999);
@@ -1541,8 +1547,8 @@ describe("tunnel --detach", () => {
     expect(logs).toContain("Running in background (pid 9999)");
     expect(logs).toContain("Stop with: kill 9999");
 
-    // The parent hands the actual tunnel workflow off to the child — it
-    // never runs the provider or edge setup itself.
+    // The parent hands the actual tunnel workflow off to the child: it never
+    // runs the provider or edge setup itself.
     expect(runNgrokTunnelMock).not.toHaveBeenCalled();
     expect(ensureTunnelEdgeMock).not.toHaveBeenCalled();
   });
@@ -1551,7 +1557,7 @@ describe("tunnel --detach", () => {
     process.argv = ["bun", "vellum", "tunnel", "-d"];
     spawnMock.mockImplementationOnce(() => {
       appendFileSync(
-        join(getLogDir(), "tunnel.log"),
+        detachedLogPath(),
         "Tunnel established: https://tailnet.example.ts.net\n",
       );
       return makeFakeChild(1234);
@@ -1586,5 +1592,33 @@ describe("tunnel --detach", () => {
     expect(exited).toBe(true);
     expect(errors).toContain("exited during startup (exit code 1)");
     expect(runNgrokTunnelMock).not.toHaveBeenCalled();
+  });
+
+  test("an adopted ngrok tunnel gets an accurate stop message, not a false kill claim", async () => {
+    process.argv = [
+      "bun",
+      "vellum",
+      "tunnel",
+      "--provider",
+      "ngrok",
+      "--detach",
+    ];
+    spawnMock.mockImplementationOnce(() => {
+      appendFileSync(
+        detachedLogPath(),
+        "Found existing ngrok tunnel: https://already-up.ngrok.app\n",
+      );
+      return makeFakeChild(5555);
+    });
+
+    const logs = await runTunnelCapturingLogs();
+
+    expect(logs).toContain("Tunnel established: https://already-up.ngrok.app");
+    expect(logs).toContain("Running in background (pid 5555)");
+    // The supervisor did not spawn this ngrok agent, so killing it must not
+    // be advertised as the way to stop the tunnel.
+    expect(logs).not.toContain("Stop with: kill 5555");
+    expect(logs).toContain("only");
+    expect(logs).toContain("stops this supervisor, not the ngrok tunnel");
   });
 });

--- a/cli/src/__tests__/tunnel.test.ts
+++ b/cli/src/__tests__/tunnel.test.ts
@@ -13,6 +13,7 @@ import * as childProcess from "node:child_process";
 import type { ChildProcess } from "node:child_process";
 import { EventEmitter } from "node:events";
 import {
+  appendFileSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -28,6 +29,7 @@ import * as cloudflareTunnel from "../lib/cloudflare-tunnel.js";
 import * as ngrok from "../lib/ngrok.js";
 import * as nginxIngress from "../lib/nginx-ingress.js";
 import * as tailscaleTunnel from "../lib/tailscale-tunnel.js";
+import { getLogDir } from "../lib/xdg-log.js";
 import type { AssistantEntry } from "../lib/assistant-config.js";
 
 const realCloudflareTunnel = { ...cloudflareTunnel };
@@ -1450,5 +1452,139 @@ describe("ngrok --domain spawn args", () => {
     ) as { ingress: { publicBaseUrl?: string; ngrok?: { domain?: string } } };
     expect(config.ingress.publicBaseUrl).toBe("https://foo.ngrok.app");
     expect(config.ingress.ngrok?.domain).toBe("foo.ngrok.app");
+  });
+});
+
+describe("tunnel --detach", () => {
+  const originalXdgConfigHome = process.env.XDG_CONFIG_HOME;
+
+  function makeFakeChild(pid: number): ChildProcess {
+    const emitter = new EventEmitter();
+    return Object.assign(emitter, {
+      stdout: null,
+      stderr: null,
+      killed: false,
+      kill: () => true,
+      unref: () => {},
+      pid,
+    }) as unknown as ChildProcess;
+  }
+
+  const spawnMock = mock((..._args: unknown[]) => makeFakeChild(9999));
+
+  beforeAll(() => {
+    mock.module("node:child_process", () => ({
+      ...realChildProcess,
+      spawn: spawnMock,
+    }));
+  });
+
+  afterAll(() => {
+    mock.module("node:child_process", () => realChildProcess);
+  });
+
+  beforeEach(() => {
+    spawnMock.mockClear();
+    const configHome = mkdtempSync(join(tmpdir(), "vellum-tunnel-xdg-"));
+    tempDirs.push(configHome);
+    process.env.XDG_CONFIG_HOME = configHome;
+    writeLockfile(makeLocalEntry());
+  });
+
+  afterEach(() => {
+    if (originalXdgConfigHome === undefined) {
+      delete process.env.XDG_CONFIG_HOME;
+    } else {
+      process.env.XDG_CONFIG_HOME = originalXdgConfigHome;
+    }
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("--detach re-invokes without the flag as a detached child and reports readiness", async () => {
+    process.argv = [
+      "bun",
+      "vellum",
+      "tunnel",
+      "--provider",
+      "ngrok",
+      "--detach",
+    ];
+
+    // Simulate the detached child writing its readiness line to the log file
+    // the moment it is spawned.
+    spawnMock.mockImplementationOnce(() => {
+      appendFileSync(
+        join(getLogDir(), "tunnel.log"),
+        "Tunnel established: https://foo.ngrok.app\n",
+      );
+      return makeFakeChild(9999);
+    });
+
+    const logs = await runTunnelCapturingLogs();
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const [, args, opts] = spawnMock.mock.calls[0] as unknown as [
+      string,
+      string[],
+      Record<string, unknown>,
+    ];
+    expect(args).toContain("tunnel");
+    expect(args).toContain("--provider");
+    expect(args).toContain("ngrok");
+    expect(args).not.toContain("--detach");
+    expect(args).not.toContain("-d");
+    expect(opts.detached).toBe(true);
+
+    expect(logs).toContain("Tunnel established: https://foo.ngrok.app");
+    expect(logs).toContain("Running in background (pid 9999)");
+    expect(logs).toContain("Stop with: kill 9999");
+
+    // The parent hands the actual tunnel workflow off to the child — it
+    // never runs the provider or edge setup itself.
+    expect(runNgrokTunnelMock).not.toHaveBeenCalled();
+    expect(ensureTunnelEdgeMock).not.toHaveBeenCalled();
+  });
+
+  test("-d is equivalent to --detach", async () => {
+    process.argv = ["bun", "vellum", "tunnel", "-d"];
+    spawnMock.mockImplementationOnce(() => {
+      appendFileSync(
+        join(getLogDir(), "tunnel.log"),
+        "Tunnel established: https://tailnet.example.ts.net\n",
+      );
+      return makeFakeChild(1234);
+    });
+
+    await runTunnelCapturingLogs();
+
+    const [, args] = spawnMock.mock.calls[0] as unknown as [string, string[]];
+    expect(args).not.toContain("-d");
+    expect(args).not.toContain("--detach");
+  });
+
+  test("reports an early child exit instead of hanging", async () => {
+    process.argv = [
+      "bun",
+      "vellum",
+      "tunnel",
+      "--provider",
+      "ngrok",
+      "--detach",
+    ];
+    spawnMock.mockImplementationOnce(() => {
+      const child = makeFakeChild(4242);
+      // Listeners attach synchronously right after spawn() returns; defer the
+      // exit so they're in place before it fires.
+      setTimeout(() => (child as unknown as EventEmitter).emit("exit", 1), 0);
+      return child;
+    });
+
+    const { exited, errors } = await runTunnelExpectingExit1();
+
+    expect(exited).toBe(true);
+    expect(errors).toContain("exited during startup (exit code 1)");
+    expect(runNgrokTunnelMock).not.toHaveBeenCalled();
   });
 });

--- a/cli/src/commands/client.ts
+++ b/cli/src/commands/client.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { closeSync, existsSync } from "node:fs";
+import { existsSync } from "node:fs";
 import path from "node:path";
 
 import {
@@ -72,11 +72,10 @@ import {
 } from "../lib/platform-client";
 import { tuiLog } from "../lib/tui-log";
 import { loopbackSafeFetch } from "../lib/loopback-fetch.js";
+import { relaunchDetached } from "../lib/detached-process.js";
 import { probePort } from "../lib/port-probe.js";
 import { openBrowser } from "../lib/open-browser";
-import { isCompiledCli } from "../lib/local.js";
 import { findWebDistDir } from "../lib/web-dist.js";
-import { getLogDir, openLogFile, resetLogFile } from "../lib/xdg-log.js";
 
 const SUPPORTED_INTERFACES = ["cli", "web"] as const;
 type SupportedInterface = (typeof SUPPORTED_INTERFACES)[number];
@@ -1140,53 +1139,24 @@ async function spawnBackgroundWebInterface(
   }
   childArgs.push("--port", String(port));
 
-  // A compiled binary re-invokes itself; under plain bun (source tree, npm
-  // install) the entry script is argv[1].
-  const spawnArgs = isCompiledCli()
-    ? childArgs
-    : [process.argv[1], ...childArgs];
-
-  resetLogFile(WEB_BACKGROUND_LOG_FILE);
-  const fd = openLogFile(WEB_BACKGROUND_LOG_FILE);
-  const child = spawn(process.execPath, spawnArgs, {
-    detached: true,
-    stdio: ["ignore", fd, fd],
-  });
-  if (typeof fd === "number") {
-    closeSync(fd);
-  }
-  child.unref();
-
-  const logPath = path.join(getLogDir(), WEB_BACKGROUND_LOG_FILE);
-
   // Don't report success until the child is actually serving: watch for an
   // early exit (e.g. missing @vellumai/web assets, port lost to the TOCTOU
   // window) and poll the port until it accepts connections.
-  let exit: { code: number | null } | undefined;
-  child.on("error", () => {
-    exit = { code: null };
-  });
-  child.on("exit", (code) => {
-    exit = { code };
+  const { child, logPath, ready, exitCode } = await relaunchDetached({
+    args: childArgs,
+    logFile: WEB_BACKGROUND_LOG_FILE,
+    timeoutMs: WEB_BACKGROUND_START_TIMEOUT_MS,
+    isReady: () => probePort(port, "127.0.0.1"),
+    pollIntervalMs: 200,
   });
 
-  const deadline = Date.now() + WEB_BACKGROUND_START_TIMEOUT_MS;
-  let listening = false;
-  while (Date.now() < deadline && !exit) {
-    if (await probePort(port, "127.0.0.1")) {
-      listening = true;
-      break;
-    }
-    await new Promise((resolve) => setTimeout(resolve, 200));
-  }
-
-  if (exit) {
+  if (exitCode !== undefined) {
     console.error(
-      `Web interface exited during startup${exit.code !== null ? ` (exit code ${exit.code})` : ""}. Logs: ${logPath}`,
+      `Web interface exited during startup${exitCode !== null ? ` (exit code ${exitCode})` : ""}. Logs: ${logPath}`,
     );
     process.exit(1);
   }
-  if (!listening) {
+  if (!ready) {
     // Kill the detached child (its whole process group — the Vite path spawns
     // grandchildren) so a slow startup can't bind the port and linger after
     // we've reported failure.

--- a/cli/src/commands/tunnel.ts
+++ b/cli/src/commands/tunnel.ts
@@ -1,5 +1,4 @@
-import { spawn } from "node:child_process";
-import { closeSync, readFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import { join } from "path";
 
 import { TUNNEL_PROVIDERS } from "@vellumai/service-contracts/ingress";
@@ -12,13 +11,13 @@ import {
 } from "../lib/assistant-config";
 import { parseAssistantTargetArg } from "../lib/assistant-target-args.js";
 import { runCloudflareTunnel } from "../lib/cloudflare-tunnel.js";
+import { relaunchDetached } from "../lib/detached-process.js";
 import {
   getDefaultWorkspaceDir,
   isLocalContainerEntry,
   parseGatewayPortFromEntryUrls,
   saveNgrokDomain,
 } from "../lib/ingress-config.js";
-import { isCompiledCli } from "../lib/local.js";
 import {
   ensureTunnelEdge,
   formatEdgeMode,
@@ -27,7 +26,6 @@ import {
 import { hasWebhookIntegrationsConfigured, runNgrokTunnel } from "../lib/ngrok";
 import { STALE_CLI_UPDATE_HINT } from "../lib/stale-cli-hint.js";
 import { runTailscaleTunnel } from "../lib/tailscale-tunnel.js";
-import { getLogDir, openLogFile, resetLogFile } from "../lib/xdg-log.js";
 
 // `vellum` is the managed option this command owns; the local providers come
 // from the shared registry so validation here cannot drift from what the
@@ -376,11 +374,10 @@ const TUNNEL_ADOPTED_RE = /Found existing ngrok tunnel: (\S+)/;
 
 /**
  * Re-invoke `vellum tunnel` (without `-d`/`--detach`) as a detached background
- * process, redirecting its stdout/stderr to a log file. Same idiom as
- * `spawnBackgroundWebInterface` in `client.ts`. This process then waits for
- * the child to either print its "Tunnel established"/"Found existing ngrok
- * tunnel" line (readiness) or exit early (failure) before returning, so a
- * misconfigured provider still fails loudly in the terminal that ran `-d`.
+ * process via `relaunchDetached`, waiting for the child to either print its
+ * "Tunnel established"/"Found existing ngrok tunnel" line (readiness) or
+ * exit early (failure), so a misconfigured provider still fails loudly in
+ * the terminal that ran `-d`.
  *
  * The log filename is scoped to this (parent) process's pid so concurrent
  * `-d` runs (e.g. tunneling two different local assistants at once) don't
@@ -395,69 +392,48 @@ async function spawnDetachedTunnel(): Promise<void> {
     childArgs.push(arg);
   }
 
-  const spawnArgs = isCompiledCli()
-    ? childArgs
-    : [process.argv[1], ...childArgs];
-
-  const logFile = `tunnel-${process.pid}.log`;
-  resetLogFile(logFile);
-  const fd = openLogFile(logFile);
-  const child = spawn(process.execPath, spawnArgs, {
-    detached: true,
-    stdio: ["ignore", fd, fd],
-  });
-  if (typeof fd === "number") {
-    closeSync(fd);
-  }
-  child.unref();
-
-  const logPath = join(getLogDir(), logFile);
-
-  let exit: { code: number | null } | undefined;
-  child.on("error", () => {
-    exit = { code: null };
-  });
-  child.on("exit", (code) => {
-    exit = { code };
-  });
-
-  const deadline = Date.now() + TUNNEL_BACKGROUND_START_TIMEOUT_MS;
   let publicUrl: string | undefined;
   let adopted = false;
-  while (Date.now() < deadline && !exit) {
-    let logText = "";
-    try {
-      logText = readFileSync(logPath, "utf-8");
-    } catch {
-      // Log file not written yet. Keep polling.
-    }
-    const established = TUNNEL_ESTABLISHED_RE.exec(logText);
-    const adoptedMatch = TUNNEL_ADOPTED_RE.exec(logText);
-    if (established) {
-      publicUrl = established[1];
-      break;
-    }
-    if (adoptedMatch) {
-      publicUrl = adoptedMatch[1];
-      adopted = true;
-      break;
-    }
-    await new Promise((resolve) => setTimeout(resolve, 250));
-  }
 
-  if (exit) {
+  const { child, logPath, ready, exitCode } = await relaunchDetached({
+    args: childArgs,
+    logFile: `tunnel-${process.pid}.log`,
+    timeoutMs: TUNNEL_BACKGROUND_START_TIMEOUT_MS,
+    isReady: (logPath) => {
+      let logText = "";
+      try {
+        logText = readFileSync(logPath, "utf-8");
+      } catch {
+        // Log file not written yet. Keep polling.
+      }
+      const established = TUNNEL_ESTABLISHED_RE.exec(logText);
+      if (established) {
+        publicUrl = established[1];
+        return true;
+      }
+      const adoptedMatch = TUNNEL_ADOPTED_RE.exec(logText);
+      if (adoptedMatch) {
+        publicUrl = adoptedMatch[1];
+        adopted = true;
+        return true;
+      }
+      return false;
+    },
+  });
+
+  if (exitCode !== undefined) {
     console.error(
-      `Error: tunnel process exited during startup${exit.code !== null ? ` (exit code ${exit.code})` : ""}. Logs: ${logPath}`,
+      `Error: tunnel process exited during startup${exitCode !== null ? ` (exit code ${exitCode})` : ""}. Logs: ${logPath}`,
     );
     process.exit(1);
   }
 
-  if (publicUrl) {
-    console.log(`Tunnel established: ${publicUrl}`);
-  } else {
+  if (!ready) {
     console.log(
       `Tunnel is still starting up after ${TUNNEL_BACKGROUND_START_TIMEOUT_MS / 1000}s. Check progress: ${logPath}`,
     );
+  } else if (publicUrl) {
+    console.log(`Tunnel established: ${publicUrl}`);
   }
   console.log(`Running in background (pid ${child.pid}). Logs: ${logPath}`);
   if (adopted) {

--- a/cli/src/commands/tunnel.ts
+++ b/cli/src/commands/tunnel.ts
@@ -356,26 +356,33 @@ function guardTailnetOnlyWebhookIngress(
   process.exit(1);
 }
 
-const TUNNEL_BACKGROUND_LOG_FILE = "tunnel.log";
 // Generous cap so a slow provider handshake (e.g. cloudflared's own ~30s
 // quick-tunnel timeout) still counts as a successful, if slow, start.
 const TUNNEL_BACKGROUND_START_TIMEOUT_MS = 35_000;
-// Matches both the "just established" line every provider prints and ngrok's
-// "found an already-running agent" adoption line.
-const TUNNEL_READY_RE = /(?:Tunnel established|Found existing ngrok tunnel): (\S+)/;
+// Matches the "just established" line every provider prints, or ngrok's
+// "found an already-running agent" adoption line (captured separately since
+// that case does not own the tunnel it adopted).
+const TUNNEL_ESTABLISHED_RE = /Tunnel established: (\S+)/;
+const TUNNEL_ADOPTED_RE = /Found existing ngrok tunnel: (\S+)/;
 
 /**
  * Re-invoke `vellum tunnel` (without `-d`/`--detach`) as a detached background
- * process, redirecting its stdout/stderr to a log file — same idiom as
+ * process, redirecting its stdout/stderr to a log file. Same idiom as
  * `spawnBackgroundWebInterface` in `client.ts`. This process then waits for
  * the child to either print its "Tunnel established"/"Found existing ngrok
  * tunnel" line (readiness) or exit early (failure) before returning, so a
  * misconfigured provider still fails loudly in the terminal that ran `-d`.
+ *
+ * The log filename is scoped to this (parent) process's pid so concurrent
+ * `-d` runs (e.g. tunneling two different local assistants at once) don't
+ * truncate and read each other's readiness output.
  */
 async function spawnDetachedTunnel(): Promise<void> {
   const childArgs: string[] = ["tunnel"];
   for (const arg of process.argv.slice(3)) {
-    if (arg === "-d" || arg === "--detach") continue;
+    if (arg === "-d" || arg === "--detach") {
+      continue;
+    }
     childArgs.push(arg);
   }
 
@@ -383,8 +390,9 @@ async function spawnDetachedTunnel(): Promise<void> {
     ? childArgs
     : [process.argv[1], ...childArgs];
 
-  resetLogFile(TUNNEL_BACKGROUND_LOG_FILE);
-  const fd = openLogFile(TUNNEL_BACKGROUND_LOG_FILE);
+  const logFile = `tunnel-${process.pid}.log`;
+  resetLogFile(logFile);
+  const fd = openLogFile(logFile);
   const child = spawn(process.execPath, spawnArgs, {
     detached: true,
     stdio: ["ignore", fd, fd],
@@ -394,7 +402,7 @@ async function spawnDetachedTunnel(): Promise<void> {
   }
   child.unref();
 
-  const logPath = join(getLogDir(), TUNNEL_BACKGROUND_LOG_FILE);
+  const logPath = join(getLogDir(), logFile);
 
   let exit: { code: number | null } | undefined;
   child.on("error", () => {
@@ -406,16 +414,23 @@ async function spawnDetachedTunnel(): Promise<void> {
 
   const deadline = Date.now() + TUNNEL_BACKGROUND_START_TIMEOUT_MS;
   let publicUrl: string | undefined;
+  let adopted = false;
   while (Date.now() < deadline && !exit) {
     let logText = "";
     try {
       logText = readFileSync(logPath, "utf-8");
     } catch {
-      // Log file not written yet — keep polling.
+      // Log file not written yet. Keep polling.
     }
-    const match = TUNNEL_READY_RE.exec(logText);
-    if (match) {
-      publicUrl = match[1];
+    const established = TUNNEL_ESTABLISHED_RE.exec(logText);
+    const adoptedMatch = TUNNEL_ADOPTED_RE.exec(logText);
+    if (established) {
+      publicUrl = established[1];
+      break;
+    }
+    if (adoptedMatch) {
+      publicUrl = adoptedMatch[1];
+      adopted = true;
       break;
     }
     await new Promise((resolve) => setTimeout(resolve, 250));
@@ -436,7 +451,15 @@ async function spawnDetachedTunnel(): Promise<void> {
     );
   }
   console.log(`Running in background (pid ${child.pid}). Logs: ${logPath}`);
-  console.log(`Stop with: kill ${child.pid}`);
+  if (adopted) {
+    console.log(
+      `That ngrok agent was already running outside this command, so \`kill ${child.pid}\` only ` +
+        "stops this supervisor, not the ngrok tunnel or its saved ingress URL. Stop the ngrok agent " +
+        "directly to end the tunnel.",
+    );
+  } else {
+    console.log(`Stop with: kill ${child.pid}`);
+  }
 }
 
 export async function tunnel(): Promise<void> {

--- a/cli/src/commands/tunnel.ts
+++ b/cli/src/commands/tunnel.ts
@@ -1,3 +1,5 @@
+import { spawn } from "node:child_process";
+import { closeSync, readFileSync } from "node:fs";
 import { join } from "path";
 
 import { TUNNEL_PROVIDERS } from "@vellumai/service-contracts/ingress";
@@ -16,6 +18,7 @@ import {
   parseGatewayPortFromEntryUrls,
   saveNgrokDomain,
 } from "../lib/ingress-config.js";
+import { isCompiledCli } from "../lib/local.js";
 import {
   ensureTunnelEdge,
   formatEdgeMode,
@@ -24,6 +27,7 @@ import {
 import { hasWebhookIntegrationsConfigured, runNgrokTunnel } from "../lib/ngrok";
 import { STALE_CLI_UPDATE_HINT } from "../lib/stale-cli-hint.js";
 import { runTailscaleTunnel } from "../lib/tailscale-tunnel.js";
+import { getLogDir, openLogFile, resetLogFile } from "../lib/xdg-log.js";
 
 // `vellum` is the managed option this command owns; the local providers come
 // from the shared registry so validation here cannot drift from what the
@@ -41,6 +45,7 @@ interface TunnelArgs {
   providerExplicit: boolean;
   domain: string | null;
   clearDomain: boolean;
+  detach: boolean;
 }
 
 const FLAGS_WITH_VALUES = ["--provider", "--domain"] as const;
@@ -51,6 +56,7 @@ function parseArgs(): TunnelArgs {
   let providerExplicit = false;
   let domain: string | null = null;
   let clearDomain = false;
+  let detach = false;
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
@@ -100,6 +106,12 @@ function parseArgs(): TunnelArgs {
       console.log(
         "                                without one. Cannot be combined with --domain.",
       );
+      console.log(
+        "  -d, --detach                  Run the tunnel in the background and return immediately.",
+      );
+      console.log(
+        "                                Logs go to the CLI log directory; stop it with `kill <pid>`.",
+      );
       console.log("");
       console.log("Providers:");
       console.log(
@@ -136,6 +148,7 @@ function parseArgs(): TunnelArgs {
       console.log("  $ vellum tunnel --provider ngrok --clear-domain");
       console.log("  $ vellum tunnel --provider cloudflare");
       console.log("  $ vellum tunnel my-assistant --provider tailscale");
+      console.log("  $ vellum tunnel --provider ngrok --detach");
       process.exit(0);
     } else if (arg === "--provider") {
       const next = args[i + 1];
@@ -169,6 +182,8 @@ function parseArgs(): TunnelArgs {
       i++;
     } else if (arg === "--clear-domain") {
       clearDomain = true;
+    } else if (arg === "-d" || arg === "--detach") {
+      detach = true;
     } else if (arg.startsWith("-")) {
       console.error(`Error: Unknown option '${arg}'.`);
       process.exit(1);
@@ -201,7 +216,14 @@ function parseArgs(): TunnelArgs {
     process.exit(1);
   }
 
-  return { assistantName, provider, providerExplicit, domain, clearDomain };
+  return {
+    assistantName,
+    provider,
+    providerExplicit,
+    domain,
+    clearDomain,
+    detach,
+  };
 }
 
 /** A tunnelable assistant plus the gateway port and workspace the edge fronts. */
@@ -334,9 +356,103 @@ function guardTailnetOnlyWebhookIngress(
   process.exit(1);
 }
 
+const TUNNEL_BACKGROUND_LOG_FILE = "tunnel.log";
+// Generous cap so a slow provider handshake (e.g. cloudflared's own ~30s
+// quick-tunnel timeout) still counts as a successful, if slow, start.
+const TUNNEL_BACKGROUND_START_TIMEOUT_MS = 35_000;
+// Matches both the "just established" line every provider prints and ngrok's
+// "found an already-running agent" adoption line.
+const TUNNEL_READY_RE = /(?:Tunnel established|Found existing ngrok tunnel): (\S+)/;
+
+/**
+ * Re-invoke `vellum tunnel` (without `-d`/`--detach`) as a detached background
+ * process, redirecting its stdout/stderr to a log file — same idiom as
+ * `spawnBackgroundWebInterface` in `client.ts`. This process then waits for
+ * the child to either print its "Tunnel established"/"Found existing ngrok
+ * tunnel" line (readiness) or exit early (failure) before returning, so a
+ * misconfigured provider still fails loudly in the terminal that ran `-d`.
+ */
+async function spawnDetachedTunnel(): Promise<void> {
+  const childArgs: string[] = ["tunnel"];
+  for (const arg of process.argv.slice(3)) {
+    if (arg === "-d" || arg === "--detach") continue;
+    childArgs.push(arg);
+  }
+
+  const spawnArgs = isCompiledCli()
+    ? childArgs
+    : [process.argv[1], ...childArgs];
+
+  resetLogFile(TUNNEL_BACKGROUND_LOG_FILE);
+  const fd = openLogFile(TUNNEL_BACKGROUND_LOG_FILE);
+  const child = spawn(process.execPath, spawnArgs, {
+    detached: true,
+    stdio: ["ignore", fd, fd],
+  });
+  if (typeof fd === "number") {
+    closeSync(fd);
+  }
+  child.unref();
+
+  const logPath = join(getLogDir(), TUNNEL_BACKGROUND_LOG_FILE);
+
+  let exit: { code: number | null } | undefined;
+  child.on("error", () => {
+    exit = { code: null };
+  });
+  child.on("exit", (code) => {
+    exit = { code };
+  });
+
+  const deadline = Date.now() + TUNNEL_BACKGROUND_START_TIMEOUT_MS;
+  let publicUrl: string | undefined;
+  while (Date.now() < deadline && !exit) {
+    let logText = "";
+    try {
+      logText = readFileSync(logPath, "utf-8");
+    } catch {
+      // Log file not written yet — keep polling.
+    }
+    const match = TUNNEL_READY_RE.exec(logText);
+    if (match) {
+      publicUrl = match[1];
+      break;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+
+  if (exit) {
+    console.error(
+      `Error: tunnel process exited during startup${exit.code !== null ? ` (exit code ${exit.code})` : ""}. Logs: ${logPath}`,
+    );
+    process.exit(1);
+  }
+
+  if (publicUrl) {
+    console.log(`Tunnel established: ${publicUrl}`);
+  } else {
+    console.log(
+      `Tunnel is still starting up after ${TUNNEL_BACKGROUND_START_TIMEOUT_MS / 1000}s. Check progress: ${logPath}`,
+    );
+  }
+  console.log(`Running in background (pid ${child.pid}). Logs: ${logPath}`);
+  console.log(`Stop with: kill ${child.pid}`);
+}
+
 export async function tunnel(): Promise<void> {
-  const { assistantName, provider, providerExplicit, domain, clearDomain } =
-    parseArgs();
+  const {
+    assistantName,
+    provider,
+    providerExplicit,
+    domain,
+    clearDomain,
+    detach,
+  } = parseArgs();
+
+  if (detach) {
+    await spawnDetachedTunnel();
+    return;
+  }
 
   if (provider === "vellum") {
     throw new Error(

--- a/cli/src/commands/tunnel.ts
+++ b/cli/src/commands/tunnel.ts
@@ -107,10 +107,19 @@ function parseArgs(): TunnelArgs {
         "                                without one. Cannot be combined with --domain.",
       );
       console.log(
-        "  -d, --detach                  Run the tunnel in the background and return immediately.",
+        `  -d, --detach                  Run the tunnel in the background. Waits up to ${TUNNEL_BACKGROUND_START_TIMEOUT_MS / 1000}s for the`,
       );
       console.log(
-        "                                Logs go to the CLI log directory; stop it with `kill <pid>`.",
+        "                                initial established/failed status before returning; logs go to",
+      );
+      console.log(
+        "                                the CLI log directory. Stop it with `kill <pid>`, except when it",
+      );
+      console.log(
+        "                                adopted an already-running ngrok tunnel (started outside this",
+      );
+      console.log(
+        "                                command): killing the supervisor then leaves that tunnel running.",
       );
       console.log("");
       console.log("Providers:");

--- a/cli/src/lib/detached-process.ts
+++ b/cli/src/lib/detached-process.ts
@@ -1,0 +1,81 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { closeSync } from "node:fs";
+import { join } from "node:path";
+
+import { isCompiledCli } from "./local.js";
+import { getLogDir, openLogFile, resetLogFile } from "./xdg-log.js";
+
+export interface RelaunchDetachedOptions {
+  /** argv for the re-invoked CLI command, e.g. ["tunnel", "--provider", "ngrok"]. */
+  args: string[];
+  /** Log file basename under the XDG log dir; truncated before spawn. */
+  logFile: string;
+  /**
+   * Polled (with the resolved log path) until it resolves truthy, the child
+   * exits, or timeoutMs elapses.
+   */
+  isReady: (logPath: string) => Promise<boolean> | boolean;
+  timeoutMs: number;
+  pollIntervalMs?: number;
+}
+
+export interface DetachedRelaunchResult {
+  child: ChildProcess;
+  logPath: string;
+  /** True once `isReady` returned truthy before the child exited or the timeout elapsed. */
+  ready: boolean;
+  /** The child's exit code, or `null` for a spawn error. Undefined while still running. */
+  exitCode: number | null | undefined;
+}
+
+/**
+ * Re-invoke the current CLI binary with `args` as a detached background
+ * process, redirecting stdout/stderr to `logFile` in the XDG log dir, then
+ * poll `isReady` until it succeeds, the child exits, or `timeoutMs` elapses.
+ *
+ * Shared by every command that offers a detached/background mode (e.g.
+ * `vellum tunnel -d`, `vellum client --interface web --background`) so the
+ * spawn/log/poll mechanics live in one place; each caller supplies its own
+ * readiness check and decides how to react to a timeout or early exit.
+ */
+export async function relaunchDetached(
+  opts: RelaunchDetachedOptions,
+): Promise<DetachedRelaunchResult> {
+  const spawnArgs = isCompiledCli()
+    ? opts.args
+    : [process.argv[1], ...opts.args];
+
+  resetLogFile(opts.logFile);
+  const fd = openLogFile(opts.logFile);
+  const child = spawn(process.execPath, spawnArgs, {
+    detached: true,
+    stdio: ["ignore", fd, fd],
+  });
+  if (typeof fd === "number") {
+    closeSync(fd);
+  }
+  child.unref();
+
+  const logPath = join(getLogDir(), opts.logFile);
+
+  let exitCode: number | null | undefined;
+  child.on("error", () => {
+    exitCode = null;
+  });
+  child.on("exit", (code) => {
+    exitCode = code;
+  });
+
+  const deadline = Date.now() + opts.timeoutMs;
+  const pollIntervalMs = opts.pollIntervalMs ?? 250;
+  let ready = false;
+  while (Date.now() < deadline && exitCode === undefined) {
+    if (await opts.isReady(logPath)) {
+      ready = true;
+      break;
+    }
+    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+  }
+
+  return { child, logPath, ready, exitCode };
+}


### PR DESCRIPTION
## Summary
- Adds a `-d`/`--detach` flag to `vellum tunnel` that re-invokes the tunnel command as a detached background process (same idiom `client.ts` already uses for `--interface web --background`), so the terminal isn't blocked while the tunnel (ngrok/cloudflare/tailscale) stays up.
- The foreground process waits for the child to either print its "Tunnel established"/"Found existing ngrok tunnel" readiness line or exit early, then reports the public URL, pid, log file path, and a `kill <pid>` stop instruction — so a misconfigured provider still fails loudly in the terminal that ran `-d`.
- Logs go to the CLI's XDG log directory (`tunnel.log`), matching the existing background-process log convention.

## Original prompt
Add a `-d` option to the `vellum tunnel` CLI so it's possible to run the tunnel in the background instead of blocking the terminal until Ctrl+C.