### PR TITLE
fix(web): keep a collapsed sidebar section collapsed while its menu is open

### DIFF
--- a/clients/web/src/domains/chat/components/sidebar-section-card.tsx
+++ b/clients/web/src/domains/chat/components/sidebar-section-card.tsx
@@ -149,7 +149,7 @@ export function SidebarSectionCard({
           : "rounded-[18px]",
         "has-[>[data-state=open]]:w-full",
         /* `width` toggles between the measured `--section-collapsed-width`
-           (a real length - see the `ResizeObserver` above) and a percentage,
+           (a real length - see the layout effect above) and a percentage,
            not a length and a sizing keyword, so an ordinary transition
            interpolates it exactly like it would `border-radius`.
 

--- a/clients/web/src/domains/chat/components/sidebar-section-card.tsx
+++ b/clients/web/src/domains/chat/components/sidebar-section-card.tsx
@@ -118,11 +118,16 @@ export function SidebarSectionCard({
            matching horizontal inset directly (see
            `CollapsibleNavSection.Section`'s Content). */
         /* Collapsed, a section is a pill that hugs its own header: nothing
-           inside it needs the full rail width. Its own `Collapsible.Item`
-           descendant carries Radix's `data-state`, so `has-[]` reads that
-           state directly rather than this component tracking open/closed
-           itself. Open, it becomes a full-width rounded rect to hold its
-           row list.
+           inside it needs the full rail width. Its own `Collapsible.Item` is
+           the card's only direct child and carries Radix's `data-state`, so
+           `has-[>...]` reads that state directly rather than this component
+           tracking open/closed itself. The child combinator is load-bearing:
+           the header's menu triggers (the "..." Popover/BottomSheet, the
+           right-click ContextMenu on the whole header) are deeper descendants
+           that also carry `data-state=open` while their menu is up, and an
+           unscoped `has-[]` would widen a collapsed pill into an empty
+           full-width box just for opening its actions menu. Open, it becomes
+           a full-width rounded rect to hold its row list.
 
            Radius is the same 18px number in both states - half the pill's
            own 36px height, which is what makes a 36px-tall box read as
@@ -142,7 +147,7 @@ export function SidebarSectionCard({
         overlayCards
           ? "rounded-[16px] border-0 pt-3 pr-3 pb-3 pl-2"
           : "rounded-[18px]",
-        "has-[[data-state=open]]:w-full",
+        "has-[>[data-state=open]]:w-full",
         /* `width` toggles between the measured `--section-collapsed-width`
            (a real length - see the `ResizeObserver` above) and a percentage,
            not a length and a sizing keyword, so an ordinary transition
@@ -164,7 +169,7 @@ export function SidebarSectionCard({
              now-visible content would sit at full width inside a box still
              catching up to it. */
         "transition-[width] duration-[100ms]",
-        "has-[[data-state=open]]:ease-[step-start]",
+        "has-[>[data-state=open]]:ease-[step-start]",
         "ease-[var(--anim-ease-out)]",
         /* Only the bottom-most section ever claims leftover flex space (see
            `isLast` on `ConversationRowList`): flex-grow has no notion of
@@ -173,7 +178,7 @@ export function SidebarSectionCard({
            size as a busy one beside it. */
         !section.unbounded &&
           section.isLast &&
-          "has-[[data-state=open]]:flex has-[[data-state=open]]:min-h-0 has-[[data-state=open]]:flex-1 has-[[data-state=open]]:flex-col",
+          "has-[>[data-state=open]]:flex has-[>[data-state=open]]:min-h-0 has-[>[data-state=open]]:flex-1 has-[>[data-state=open]]:flex-col",
         /* The card is the drag handle, so it says so. Every interactive thing
            inside it sets its own `cursor-pointer`, which wins wherever one is
            actually under the pointer - so the grab cursor shows on the card's


### PR DESCRIPTION
## TL;DR

A collapsed sidebar section no longer snaps to full width (as an empty open section) when its overflow/actions menu opens. The card's `has-[[data-state=open]]` selectors matched *any* descendant carrying Radix's `data-state=open`, which includes the header's "…" Popover/BottomSheet trigger and the right-click ContextMenu trigger, not just the section's own `Collapsible.Item`. The selectors are now scoped to the card's direct child, which is exactly that `Collapsible.Item`.

Fixes LUM-3184.

## What changes for the user

| Interaction | Before | After |
|---|---|---|
| Open the "…" menu on a collapsed section | Pill snaps to full rail width, looks like an empty open section, snaps back when the menu closes | Pill stays a pill; the menu floats over it |
| Right-click a collapsed section's header | Same width snap | Pill stays a pill |
| Click a section header to expand/collapse | Expands to full width / collapses to pill | Unchanged |

## Why it's safe

- CSS-only change: three Tailwind `has-[…]` variants gain a child combinator (`has-[>[data-state=open]]`), plus the comment explaining why it's load-bearing. No TS/logic changes.
- The `Collapsible.Item` is the card's only direct child (`Card.Root` renders its children directly into the `data-slot="card"` element), so the scoped selector reads the section's own open state and nothing else. Verified in the live DOM in Storybook.
- Verified in Storybook (`CollapsedGroup` story, which renders the real `GroupActionsMenu`):
  - Collapsed pill = 161.6px; opening the "…" popover leaves it at 161.6px with the popover open and `popover-trigger` carrying `data-state=open` inside the card (the previously-matching condition).
  - Same for the right-click context menu (header carries `data-state=open`).
  - Clicking the header still expands the card to full rail width (248px = parent width) and collapses back.
- `tsc --noEmit` and `bun run lint` clean; repo-wide grep shows no other use of the unscoped `has-[[data-state` pattern.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41367" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->