### PR TITLE
feat(web): finish i18n ratchet with src/** enforcement

### DIFF
--- a/clients/web/docs/I18N.md
+++ b/clients/web/docs/I18N.md
@@ -164,9 +164,9 @@ a space or starts with a capital, so `label="Save changes"` and
 `submitLabel="Complete signup"` are caught while `variant="primary"` and
 `tone="error"` stay quiet. An allowlist of prop names
 could only ever cover props someone had thought of, and three converted domains
-kept shipping English through bespoke props like `toggleAriaLabel`. It is enabled **only for the paths in
-`i18nEnforcedPaths`** in [`eslint.config.mjs`](../eslint.config.mjs), and that
-list grows as areas are converted.
+kept shipping English through bespoke props like `toggleAriaLabel`. It is enabled for **`src/**/*.{ts,tsx}`** (generated code excluded) in
+[`eslint.config.mjs`](../eslint.config.mjs). That glob is the record that the
+cutover for this rule has reached the whole web `src` tree.
 
 **A string the component assembles is read differently,** whether it was built
 with a template or with `+`, because that is the shape this guide calls the
@@ -191,22 +191,16 @@ The bag is read where it is written out at the call: `{ ...base, description:
 as a variable is not, and neither is an `action` that is one, since the rule
 reads the call rather than following values to where they were built.
 
-To convert an area: move its copy into the right namespace, read it with `t()`,
-add the glob, and run `bun run lint` until it is quiet.
+When adding copy in `src/`: put it in the right namespace, read it with `t()`,
+and run `bun run lint` until it is quiet. Never shrink `i18nEnforcedPaths` to
+silence a violation.
 
-- Never add a path that still has violations in it.
-- Never widen a glob to make an error go away.
-
-**A clean lint run is not proof a domain is fully translated.** The rule reads
+**A clean lint run is not proof the app is fully translated.** The rule reads
 JSX, so copy that reaches the screen from somewhere else is invisible to it:
 string literals in `.ts` data modules (channel metadata, option lists, enum
 labels), messages passed to `setError()` or returned by a helper, arrays of
-literals, and any toast options assembled somewhere other than the call. Adding a glob records that the JSX is converted, nothing more. When
-you convert a domain, read its non-JSX modules too.
-
-The list is the record of how far the cutover has reached. Scoping it this way
-is deliberate: switched on repo-wide it would report thousands of pre-existing
-literals at once, and a rule that noisy gets disabled rather than obeyed.
+literals, and any toast options assembled somewhere other than the call. Fix
+those modules when you touch them; the ratchet alone does not catch them.
 
 **The escape hatch,** for copy that genuinely must not be translated: brand
 names, code identifiers, protocol tokens. Always with a reason:

--- a/clients/web/eslint-rules/no-untranslated-strings.mjs
+++ b/clients/web/eslint-rules/no-untranslated-strings.mjs
@@ -6,8 +6,8 @@
  * translators, cannot pluralize outside English, and silently reverts a screen
  * to English-only the moment someone edits it.
  *
- * This rule is enabled for `src/**/*.{ts,tsx}` via `i18nEnforcedPaths` in
- * `eslint.config.mjs` (generated code excluded). A clean lint is not proof
+ * This rule is enabled for all of `src/` (except generated) via
+ * `i18nEnforcedPaths` in `eslint.config.mjs`. A clean lint is not proof
  * every user-facing string is translated: the rule reads JSX, toast call
  * sites, and copy-shaped props, not every helper return value. See
  * `docs/I18N.md`.

--- a/clients/web/eslint-rules/no-untranslated-strings.mjs
+++ b/clients/web/eslint-rules/no-untranslated-strings.mjs
@@ -6,12 +6,11 @@
  * translators, cannot pluralize outside English, and silently reverts a screen
  * to English-only the moment someone edits it.
  *
- * This rule is scoped, not global. `eslint.config.mjs` enables it only for the
- * paths listed in `i18nEnforcedPaths`, which grows as areas are converted.
- * That is deliberate: switched on repo-wide it would report thousands of
- * pre-existing literals at once, and a rule that noisy gets disabled rather
- * than obeyed. Scoped, a converted area cannot regress, and the list doubles as
- * the record of how far the cutover has reached.
+ * This rule is enabled for `src/**/*.{ts,tsx}` via `i18nEnforcedPaths` in
+ * `eslint.config.mjs` (generated code excluded). A clean lint is not proof
+ * every user-facing string is translated: the rule reads JSX, toast call
+ * sites, and copy-shaped props, not every helper return value. See
+ * `docs/I18N.md`.
  *
  * What it reports:
  * - JSX text children that contain a word character

--- a/clients/web/eslint.config.mjs
+++ b/clients/web/eslint.config.mjs
@@ -191,9 +191,7 @@ const authBoundaryAllowedPaths = [
  * noise, which is how these rules die.
  */
 const i18nEnforcedPaths = [
-  "src/components/**/*.{ts,tsx}",
-  "src/hooks/**/*.{ts,tsx}",
-  "src/domains/**/*.{ts,tsx}",
+  "src/**/*.{ts,tsx}",
 ];
 
 /**
@@ -292,18 +290,15 @@ const eslintConfig = defineConfig([
   // -----------------------------------------------------------------------
   // i18n cutover ratchet
   //
-  // `local/no-untranslated-strings` is enabled only for the paths below, and
-  // the list grows as areas are converted. Repo-wide it would report thousands
-  // of pre-existing literals in one go, and a rule that noisy gets disabled
-  // rather than obeyed. Scoped, an area that has been converted cannot
-  // regress, and this list is the record of how far the cutover has reached.
+  // `local/no-untranslated-strings` covers all of `src/` (except generated).
+  // Domains, hooks, and components were converted first; the remaining
+  // stores/root routes followed so this glob could widen without a flood of
+  // pre-existing literals. A clean lint here is not proof every user-facing
+  // string is translated: the rule reads JSX, toast call sites, and
+  // copy-shaped props, not every helper return value. See `docs/I18N.md`.
   //
-  // To convert an area: move its copy into the namespace that owns it (see
-  // `src/i18n/namespaces.ts`), read it with `t()`, add the glob here, and run
-  // `bun run lint` until it is quiet. Never add a path with violations still
-  // in it, and never widen a glob to make an error go away.
-  //
-  // See `clients/web/docs/I18N.md`.
+  // Never shrink this glob to silence a violation. Fix the copy, or add an
+  // eslint-disable with a reason for brand names / protocol tokens.
   {
     files: i18nEnforcedPaths,
     rules: {

--- a/clients/web/eslint.config.mjs
+++ b/clients/web/eslint.config.mjs
@@ -185,10 +185,9 @@ const authBoundaryAllowedPaths = [
 /**
  * Paths where user-facing copy must come from a translation catalog.
  *
- * Append to this list as each area is converted. Entries are globs relative to
- * `clients/web/`. Keep them as narrow as the conversion actually was: a
- * directory glob added before its files are converted turns the ratchet into
- * noise, which is how these rules die.
+ * Covers all of `src/` (generated excluded via `globalIgnores`). Entries are
+ * globs relative to `clients/web/`. Never shrink this list to silence a
+ * violation; fix the copy or add an eslint-disable with a reason.
  */
 const i18nEnforcedPaths = [
   "src/**/*.{ts,tsx}",

--- a/clients/web/src/assistant/switch-service.ts
+++ b/clients/web/src/assistant/switch-service.ts
@@ -7,6 +7,7 @@ import {
   loadLockfile,
   removePairedAssistantFromLockfile,
 } from "@/lib/local-mode";
+import { t } from "@/i18n";
 import { useAuthStore } from "@/stores/auth-store";
 import {
   useResolvedAssistantsStore,
@@ -46,7 +47,7 @@ export async function switchToAssistant(
       await useAuthStore.getState().connectPairedAssistant(assistantId);
     } catch (err) {
       console.error("switchToAssistant.connectPairedAssistant failed", err);
-      return { ok: false, error: "Failed to connect to the assistant." };
+      return { ok: false, error: t("assistantConnect.failed") };
     }
     return { ok: true };
   }

--- a/clients/web/src/home-page-route.tsx
+++ b/clients/web/src/home-page-route.tsx
@@ -11,6 +11,7 @@ import {
   useScheduledConversationListQuery,
 } from "@/hooks/conversation-queries";
 import { useIsMobile } from "@/hooks/use-is-mobile";
+import { useTranslation } from "@/i18n";
 import { mergeConversationLists } from "@/utils/conversation-cache";
 import { navigateToConversation } from "@/utils/conversation-navigation";
 import { Typography } from "@vellumai/design-library";
@@ -18,6 +19,7 @@ import { Typography } from "@vellumai/design-library";
 export function HomePageRoute() {
   const navigate = useNavigate();
   const location = useLocation();
+  const { t } = useTranslation("home");
   const assistantId = useActiveAssistantId();
   // Set when a notification row in the bell popover routed here — the page
   // opens that item's detail drawer on arrival.
@@ -58,7 +60,7 @@ export function HomePageRoute() {
           variant="body-medium-default"
           className="text-[var(--content-secondary)]"
         >
-          Activity
+          {t("homeTopHeader.title")}
         </Typography>,
       );
     } else {
@@ -67,7 +69,7 @@ export function HomePageRoute() {
     return () => {
       setTopBarCenter(null);
     };
-  }, [isMobile, setTopBarCenter]);
+  }, [isMobile, setTopBarCenter, t]);
 
   return (
     <HomePage

--- a/clients/web/src/i18n/locales/en/common.json
+++ b/clients/web/src/i18n/locales/en/common.json
@@ -63,6 +63,12 @@
   "appViewerContainer": {
     "exitFullscreen": "Exit fullscreen"
   },
+  "assistantConnect": {
+    "failed": "Failed to connect to the assistant."
+  },
+  "assistantFeatureFlagStore": {
+    "updateFailed": "Couldn't update \"{label}\". Your change was reverted."
+  },
   "avatarManagementModal": {
     "body": "Body",
     "color": "Color",
@@ -188,6 +194,13 @@
     "message": "\"{appName}\" uses backend services that won't work on a static Vercel page. Your assistant can deploy it properly with serverless functions.",
     "messageNamed": "\"{appName}\" uses backend services that won't work on a static Vercel page. {assistantName} can deploy it properly with serverless functions.",
     "title": "This app needs a full deploy"
+  },
+  "deployStore": {
+    "appExported": "App exported",
+    "deployFailed": "Failed to deploy",
+    "deployedToVercel": "Deployed to Vercel",
+    "open": "Open",
+    "shareFailed": "Failed to share app"
   },
   "detailPanelStopButton": {
     "tooltip": "Stop"
@@ -333,6 +346,9 @@
   },
   "rootHydrateFallback": {
     "loadingAria": "Loading"
+  },
+  "rootLayout": {
+    "unnamedAssistant": "the assistant"
   },
   "routeErrorBoundary": {
     "chunkFailBody": "This section couldn't load. Likely a network blip or a stale version. Reload the page to try again.",

--- a/clients/web/src/i18n/locales/es/common.json
+++ b/clients/web/src/i18n/locales/es/common.json
@@ -63,6 +63,12 @@
   "appViewerContainer": {
     "exitFullscreen": "Salir de pantalla completa"
   },
+  "assistantConnect": {
+    "failed": "No se pudo conectar con el asistente."
+  },
+  "assistantFeatureFlagStore": {
+    "updateFailed": "No se pudo actualizar \"{label}\". Se revirtió el cambio."
+  },
   "avatarManagementModal": {
     "body": "Cuerpo",
     "color": "Color",
@@ -188,6 +194,13 @@
     "message": "\"{appName}\" usa servicios de backend que no funcionarán en una página estática de Vercel. Tu asistente puede desplegarla correctamente con funciones serverless.",
     "messageNamed": "\"{appName}\" usa servicios de backend que no funcionarán en una página estática de Vercel. {assistantName} puede desplegarla correctamente con funciones serverless.",
     "title": "Esta app necesita un despliegue completo"
+  },
+  "deployStore": {
+    "appExported": "Aplicación exportada",
+    "deployFailed": "No se pudo desplegar",
+    "deployedToVercel": "Desplegada en Vercel",
+    "open": "Abrir",
+    "shareFailed": "No se pudo compartir la aplicación"
   },
   "detailPanelStopButton": {
     "tooltip": "Detener"
@@ -333,6 +346,9 @@
   },
   "rootHydrateFallback": {
     "loadingAria": "Cargando"
+  },
+  "rootLayout": {
+    "unnamedAssistant": "el asistente"
   },
   "routeErrorBoundary": {
     "chunkFailBody": "Esta sección no se pudo cargar. Probablemente un fallo de red o una versión antigua. Recarga la página para intentarlo de nuevo.",

--- a/clients/web/src/i18n/locales/ru/common.json
+++ b/clients/web/src/i18n/locales/ru/common.json
@@ -2,6 +2,12 @@
   "addCreditsModal": {
     "configureAutoReload": "Настроить автопополнение"
   },
+  "assistantConnect": {
+    "failed": "Не удалось подключиться к ассистенту."
+  },
+  "assistantFeatureFlagStore": {
+    "updateFailed": "Не удалось обновить «{label}». Изменение отменено."
+  },
   "companionIntro": {
     "ariaLabel": "Знакомство с компаньоном",
     "meet": {
@@ -25,6 +31,13 @@
     "next": "Далее",
     "done": "Понятно"
   },
+  "deployStore": {
+    "appExported": "Приложение экспортировано",
+    "deployFailed": "Не удалось опубликовать",
+    "deployedToVercel": "Опубликовано на Vercel",
+    "open": "Открыть",
+    "shareFailed": "Не удалось поделиться приложением"
+  },
   "detailPanelStopButton": {
     "tooltip": "Стоп"
   },
@@ -42,6 +55,9 @@
     "bodyNoUpgrade": "Ассистент усердно работает и приближается к пределу доступных ресурсов.",
     "upgrade": "Обновить план",
     "dontShowAgain": "Больше не показывать"
+  },
+  "rootLayout": {
+    "unnamedAssistant": "ассистент"
   },
   "sectionActionsButton": {
     "ariaLabel": "Действия: {name}"

--- a/clients/web/src/root-layout.tsx
+++ b/clients/web/src/root-layout.tsx
@@ -94,6 +94,7 @@ import {
 import { CreateAssistantDialog } from "@/components/create-assistant-dialog";
 import { RemoveFromDeviceDialog } from "@/components/remove-from-device-dialog";
 import { RetireConfirmDialog } from "@/components/retire-confirm-dialog";
+import { useTranslation } from "@/i18n";
 import { toast } from "@vellumai/design-library/components/toast";
 
 /**
@@ -122,6 +123,7 @@ import { toast } from "@vellumai/design-library/components/toast";
  */
 export function RootLayout() {
   useAppTheme();
+  const { t } = useTranslation();
   const keyboardOpen = useKeyboardOpen();
   const visibleViewport = useVisibleViewport();
 
@@ -268,7 +270,7 @@ export function RootLayout() {
           .connectLocalAssistant(id)
           .catch((err: unknown) => {
             console.error("rePair.connectLocalAssistant failed", err);
-            toast.error("Failed to connect to the assistant.");
+            toast.error(t("assistantConnect.failed"));
             void navigate(routes.selectAssistant);
           });
       }
@@ -588,7 +590,7 @@ export function RootLayout() {
         kind="paired"
         assistantName={
           (removePairedId && getLockfileAssistant(removePairedId)?.name) ||
-          "the assistant"
+          t("rootLayout.unnamedAssistant")
         }
         isPending={removePairedPending}
         onConfirm={() => void handleConfirmRemovePaired()}

--- a/clients/web/src/stores/assistant-feature-flag-store.ts
+++ b/clients/web/src/stores/assistant-feature-flag-store.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 
 import { createSelectors } from "@/utils/create-selectors";
 import { assistantFeatureFlagsPatch } from "@/generated/gateway/sdk.gen";
+import { t } from "@/i18n";
 import {
   ASSISTANT_FLAG_DEFAULTS,
   ASSISTANT_STRING_FLAG_DEFAULTS,
@@ -144,7 +145,9 @@ const useAssistantFeatureFlagStoreBase = create<AssistantFeatureFlagStore>()((
           return { [key]: confirmedValue };
         });
         toast.error(
-          `Couldn't update "${getFlagDefinition(key)?.label ?? key}". Your change was reverted.`,
+          t("assistantFeatureFlagStore.updateFailed", {
+            label: getFlagDefinition(key)?.label ?? key,
+          }),
         );
       };
       const flagKey = storeKeyToFlagKey(key);
@@ -219,7 +222,9 @@ const useAssistantFeatureFlagStoreBase = create<AssistantFeatureFlagStore>()((
           };
         });
         toast.error(
-          `Couldn't update "${getFlagDefinition(key)?.label ?? key}". Your change was reverted.`,
+          t("assistantFeatureFlagStore.updateFailed", {
+            label: getFlagDefinition(key)?.label ?? key,
+          }),
         );
       };
       const flagKey = storeKeyToFlagKey(key);

--- a/clients/web/src/stores/deploy-store.ts
+++ b/clients/web/src/stores/deploy-store.ts
@@ -16,6 +16,7 @@ import { create } from "zustand";
 
 import { integrationsVercelConfigGet } from "@/generated/daemon/sdk.gen";
 import type { AppsByIdPublishPostResponse } from "@/generated/daemon/types.gen";
+import { t } from "@/i18n";
 import { createSelectors } from "@/utils/create-selectors";
 import { publishApp } from "@/utils/publish-app";
 import { shareApp as shareAppApi } from "@/utils/share-app";
@@ -78,15 +79,15 @@ function isCredentialError(result: AppsByIdPublishPostResponse): boolean {
 
 function showPublishResultToast(result: AppsByIdPublishPostResponse): void {
   if (result.publicUrl) {
-    toast.success("Deployed to Vercel", {
+    toast.success(t("deployStore.deployedToVercel"), {
       description: result.publicUrl,
       action: {
-        label: "Open",
+        label: t("deployStore.open"),
         onClick: () => window.open(result.publicUrl, "_blank"),
       },
     });
   } else {
-    toast.success("Deployed to Vercel");
+    toast.success(t("deployStore.deployedToVercel"));
   }
 }
 
@@ -116,9 +117,11 @@ const useDeployStoreBase = create<DeployStore>()((set, get) => ({
     set({ isSharing: true });
     try {
       await shareAppApi(assistantId, appId, appName);
-      toast.success("App exported", { description: `${appName}.vellum` });
+      toast.success(t("deployStore.appExported"), {
+        description: `${appName}.vellum`,
+      });
     } catch (err) {
-      toast.error("Failed to share app", {
+      toast.error(t("deployStore.shareFailed"), {
         description: err instanceof Error ? err.message : undefined,
       });
     } finally {
@@ -162,13 +165,15 @@ const useDeployStoreBase = create<DeployStore>()((set, get) => ({
             isDeploying: false,
           });
         } else {
-          toast.error("Failed to deploy", { description: result.error });
+          toast.error(t("deployStore.deployFailed"), {
+            description: result.error,
+          });
         }
       } else {
         showPublishResultToast(result);
       }
     } catch (err) {
-      toast.error("Failed to deploy", {
+      toast.error(t("deployStore.deployFailed"), {
         description: err instanceof Error ? err.message : undefined,
       });
     } finally {
@@ -186,12 +191,14 @@ const useDeployStoreBase = create<DeployStore>()((set, get) => ({
     try {
       const result = await publishApp(assistantId, pendingDeployAppId);
       if (!result.success) {
-        toast.error("Failed to deploy", { description: result.error });
+        toast.error(t("deployStore.deployFailed"), {
+          description: result.error,
+        });
       } else {
         showPublishResultToast(result);
       }
     } catch (err) {
-      toast.error("Failed to deploy", {
+      toast.error(t("deployStore.deployFailed"), {
         description: err instanceof Error ? err.message : undefined,
       });
     } finally {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Clears the last `local/no-untranslated-strings` hits outside domains/hooks/components and widens enforcement to all of `clients/web/src/**` (generated excluded).

### Changes

- Catalogued copy in `deploy-store`, `assistant-feature-flag-store`, `root-layout`, and `home-page-route` (`common` / existing `home:homeTopHeader.title`)
- Shared `assistantConnect.failed` with `switch-service` (same user-facing error)
- Set `i18nEnforcedPaths` to `src/**/*.{ts,tsx}`
- Updated `I18N.md` and the rule docstring to match (clean lint is not full translation coverage)
- **CI fix:** removed a `*/` sequence from the rule’s block comment that broke ESLint module parse

### Verification

- `bunx eslint src` → 0 `no-untranslated-strings` errors
- `bun test eslint-rules/no-untranslated-strings.test.mjs`
- `bun test src/i18n/catalogs.test.ts src/assistant/switch-service.test.ts src/stores/deploy-store.test.ts src/stores/assistant-feature-flag-store.test.ts`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b7f2993b-c41a-4c7d-8427-a880d12f5a8a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b7f2993b-c41a-4c7d-8427-a880d12f5a8a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

