### PR TITLE
feat(gateway): record device identity when a pairing code is exchanged

### DIFF
--- a/gateway/src/__tests__/remote-web-pairing-token.test.ts
+++ b/gateway/src/__tests__/remote-web-pairing-token.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 
 import { eq } from "drizzle-orm";
 
+import { MAX_PAIRING_USER_AGENT_CHARS } from "../auth/device-identity-text.js";
 import { initSigningKey } from "../auth/token-service.js";
 
 import {
@@ -55,10 +56,13 @@ const GUARDIAN_ID = "guardian-001";
 
 let testRoot: string;
 
-function makeTokenRequest(body: unknown): Request {
+function makeTokenRequest(
+  body: unknown,
+  headers: Record<string, string> = {},
+): Request {
   return new Request("https://paired.example.com/v1/remote-web/pairing-token", {
     method: "POST",
-    headers: { "content-type": "application/json" },
+    headers: { "content-type": "application/json", ...headers },
     body: JSON.stringify(body),
   });
 }
@@ -744,5 +748,148 @@ describe("remote web pairing token exchange", () => {
     });
     expect(activeTokens()).toHaveLength(0);
     expect(activeRefreshTokens()).toHaveLength(0);
+  });
+
+  test("a missing deviceCode returns the deviceCode is required 400", async () => {
+    const res = await handleRemoteWebPairingToken(
+      makeTokenRequest({ clientReportedName: "Noa's iPhone" }),
+    );
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      error: { code: "BAD_REQUEST", message: "deviceCode is required" },
+    });
+    expect(activeTokens()).toHaveLength(0);
+  });
+
+  test("exchange request's User-Agent is persisted on both minted rows", async () => {
+    const challenge = createRemoteWebPairingChallenge(
+      PUBLIC_BASE_URL,
+      TEST_REQUESTER,
+    );
+    expect(approveRemoteWebPairingChallenge(challenge.userCode).status).toBe(
+      "approved",
+    );
+
+    const res = await handleRemoteWebPairingToken(
+      makeTokenRequest(
+        { deviceCode: challenge.deviceCode },
+        { "user-agent": "ExchangeApp/2.0" },
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    expect(activeTokens()[0].pairingUserAgent).toBe("ExchangeApp/2.0");
+    expect(activeRefreshTokens()[0].pairingUserAgent).toBe("ExchangeApp/2.0");
+  });
+
+  test("exchange with no User-Agent header persists null and still succeeds", async () => {
+    const challenge = createRemoteWebPairingChallenge(
+      PUBLIC_BASE_URL,
+      TEST_REQUESTER,
+    );
+    expect(approveRemoteWebPairingChallenge(challenge.userCode).status).toBe(
+      "approved",
+    );
+
+    const res = await handleRemoteWebPairingToken(
+      makeTokenRequest({ deviceCode: challenge.deviceCode }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(activeTokens()[0].pairingUserAgent).toBeNull();
+    expect(activeRefreshTokens()[0].pairingUserAgent).toBeNull();
+  });
+
+  test("a clientReportedName in the exchange body is persisted", async () => {
+    const challenge = createRemoteWebPairingChallenge(
+      PUBLIC_BASE_URL,
+      TEST_REQUESTER,
+    );
+    expect(approveRemoteWebPairingChallenge(challenge.userCode).status).toBe(
+      "approved",
+    );
+
+    const res = await handleRemoteWebPairingToken(
+      makeTokenRequest({
+        deviceCode: challenge.deviceCode,
+        clientReportedName: "Noa's iPhone",
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(activeTokens()[0].clientReportedName).toBe("Noa's iPhone");
+    expect(activeRefreshTokens()[0].clientReportedName).toBe("Noa's iPhone");
+  });
+
+  test("a non-string clientReportedName still exchanges with the field null", async () => {
+    const challenge = createRemoteWebPairingChallenge(
+      PUBLIC_BASE_URL,
+      TEST_REQUESTER,
+    );
+    expect(approveRemoteWebPairingChallenge(challenge.userCode).status).toBe(
+      "approved",
+    );
+
+    const res = await handleRemoteWebPairingToken(
+      makeTokenRequest({
+        deviceCode: challenge.deviceCode,
+        clientReportedName: 12345,
+      }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(activeTokens()[0].clientReportedName).toBeNull();
+    expect(activeRefreshTokens()[0].clientReportedName).toBeNull();
+  });
+
+  test("a body over the raised cap returns PAYLOAD_TOO_LARGE", async () => {
+    const challenge = createRemoteWebPairingChallenge(
+      PUBLIC_BASE_URL,
+      TEST_REQUESTER,
+    );
+    expect(approveRemoteWebPairingChallenge(challenge.userCode).status).toBe(
+      "approved",
+    );
+
+    const bodyObj = {
+      deviceCode: challenge.deviceCode,
+      clientReportedName: "A".repeat(1100),
+    };
+    const bodyStr = JSON.stringify(bodyObj);
+    const res = await handleRemoteWebPairingToken(
+      makeTokenRequest(bodyObj, {
+        "content-length": String(bodyStr.length),
+      }),
+    );
+
+    expect(res.status).toBe(413);
+    expect(await res.json()).toEqual({
+      error: { code: "PAYLOAD_TOO_LARGE", message: "request body too large" },
+    });
+    expect(activeTokens()).toHaveLength(0);
+  });
+
+  test("an over-long User-Agent header is stored truncated", async () => {
+    const challenge = createRemoteWebPairingChallenge(
+      PUBLIC_BASE_URL,
+      TEST_REQUESTER,
+    );
+    expect(approveRemoteWebPairingChallenge(challenge.userCode).status).toBe(
+      "approved",
+    );
+
+    const longUserAgent = "A".repeat(MAX_PAIRING_USER_AGENT_CHARS + 100);
+    const res = await handleRemoteWebPairingToken(
+      makeTokenRequest(
+        { deviceCode: challenge.deviceCode },
+        { "user-agent": longUserAgent },
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    const expected = "A".repeat(MAX_PAIRING_USER_AGENT_CHARS);
+    expect(activeTokens()[0].pairingUserAgent).toBe(expected);
+    expect(activeRefreshTokens()[0].pairingUserAgent).toBe(expected);
   });
 });

--- a/gateway/src/http/route-helpers.ts
+++ b/gateway/src/http/route-helpers.ts
@@ -45,3 +45,52 @@ export async function readJsonStringField(
 
   return value ?? errorResponse("BAD_REQUEST", `${field} is required`, 400);
 }
+
+/**
+ * Read a JSON request body under a byte cap and extract one required plus
+ * several optional string fields in a single pass (the body stream can only
+ * be consumed once, so this can't just call {@link readJsonStringField}
+ * repeatedly). Same error shapes as {@link readJsonStringField}: 413 for an
+ * oversized body, 400 for an unreadable body, invalid JSON, or a missing
+ * required field. A missing or non-string optional field resolves to `null`,
+ * never an error.
+ */
+export async function readJsonStringFields<K extends string>(
+  req: Request,
+  maxBytes: number,
+  required: K,
+  optional: readonly string[],
+): Promise<{ [key: string]: string | null } | Response> {
+  const rawBody = await readLimitedBody(req, maxBytes);
+  if (rawBody.status === "too_large") {
+    return errorResponse("PAYLOAD_TOO_LARGE", "request body too large", 413);
+  }
+  if (rawBody.status === "unreadable") {
+    return errorResponse("BAD_REQUEST", "failed to read request body", 400);
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = JSON.parse(rawBody.text) as Record<string, unknown>;
+  } catch {
+    return errorResponse("BAD_REQUEST", "invalid JSON body", 400);
+  }
+
+  const extract = (field: string): string | null => {
+    const raw = body[field];
+    return typeof raw === "string" && raw.trim() ? raw : null;
+  };
+
+  const requiredValue = extract(required);
+  if (requiredValue === null) {
+    return errorResponse("BAD_REQUEST", `${required} is required`, 400);
+  }
+
+  const fields: { [key: string]: string | null } = {
+    [required]: requiredValue,
+  };
+  for (const field of optional) {
+    fields[field] = extract(field);
+  }
+  return fields;
+}

--- a/gateway/src/http/routes/remote-web-pairing-token.ts
+++ b/gateway/src/http/routes/remote-web-pairing-token.ts
@@ -19,9 +19,9 @@ import {
   remoteWebRefreshCookiePathForPublicBaseUrl,
 } from "../browser-auth-cookies.js";
 import { errorResponse } from "../loopback-guard.js";
-import { methodNotAllowed, readJsonStringField } from "../route-helpers.js";
+import { methodNotAllowed, readJsonStringFields } from "../route-helpers.js";
 
-const MAX_TOKEN_BODY_BYTES = 512;
+const MAX_TOKEN_BODY_BYTES = 1024;
 const REMOTE_WEB_PLATFORM = "web";
 
 /** Token-exchange JSON responses, errors included, are never cacheable. */
@@ -47,14 +47,17 @@ export async function handleRemoteWebPairingToken(
     return methodNotAllowed("POST");
   }
 
-  const deviceCode = await readJsonStringField(
+  const fields = await readJsonStringFields(
     req,
     MAX_TOKEN_BODY_BYTES,
     "deviceCode",
+    ["clientReportedName"],
   );
-  if (deviceCode instanceof Response) {
-    return noStore(deviceCode);
+  if (fields instanceof Response) {
+    return noStore(fields);
   }
+  const deviceCode = fields.deviceCode as string;
+  const clientReportedName = fields.clientReportedName;
 
   const challenge = claimRemoteWebPairingChallengeExchange(deviceCode);
   if (challenge.status === "pending") {
@@ -79,6 +82,11 @@ export async function handleRemoteWebPairingToken(
   const refreshCookiePath = remoteWebRefreshCookiePathForPublicBaseUrl(
     challenge.publicBaseUrl,
   );
+  // The exchange request's own User-Agent, not the challenge's stored
+  // requesterUserAgent: in the app-handoff flow the phone's browser mints
+  // the code but the app performs the exchange and holds the credential, so
+  // the exchange request is the one that observed the actual device.
+  const exchangeUserAgent = req.headers.get("user-agent");
   let guardianPrincipalId: string;
   let pair: ReturnType<typeof mintAndRecordBrowserTokenPair>;
   try {
@@ -87,6 +95,10 @@ export async function handleRemoteWebPairingToken(
       guardianPrincipalId,
       platform: REMOTE_WEB_PLATFORM,
       browserRefreshCookiePath: refreshCookiePath,
+      identity: {
+        pairingUserAgent: exchangeUserAgent,
+        clientReportedName,
+      },
     });
   } catch (err) {
     // Release so the approved code stays exchangeable after the failure is


### PR DESCRIPTION
## Summary
- Add readJsonStringFields (a sibling of readJsonStringField) supporting one required plus multiple optional string fields
- The remote-web pairing-token exchange now reads the exchange request's own User-Agent and an optional clientReportedName, passing both into mintAndRecordBrowserTokenPair as identity
- MAX_TOKEN_BODY_BYTES raised from 512 to 1024 to fit the new optional field

Part of plan: paired-device-names.md (PR 13 of 15)