### PR TITLE
web: add ChooserAvatarChip for rendering assistant avatars in list rows

### DIFF
--- a/clients/web/src/components/avatar/chooser-avatar-chip.test.tsx
+++ b/clients/web/src/components/avatar/chooser-avatar-chip.test.tsx
@@ -23,6 +23,12 @@ const TRAITS: CharacterTraits = {
   color: BUNDLED_COMPONENTS.colors[0]!.id,
 };
 
+const UNKNOWN_TRAITS: CharacterTraits = {
+  bodyShape: "no-such-body",
+  eyeStyle: "no-such-eyes",
+  color: "no-such-color",
+};
+
 const fallback = <span data-testid="fallback">V</span>;
 
 describe("ChooserAvatarChip", () => {
@@ -76,6 +82,33 @@ describe("ChooserAvatarChip", () => {
     expect(img?.getAttribute("alt")).toBe("Assistant avatar");
     expect(img?.className).toContain("rounded-full");
     expect(img?.style.width).toBe("48px");
+  });
+
+  test("unknown trait ids fall through to the image", () => {
+    const { container } = render(
+      <ChooserAvatarChip
+        traits={UNKNOWN_TRAITS}
+        imageUrl="https://example.test/a.png"
+        fallback={fallback}
+      />,
+    );
+    expect(container.querySelector("svg")).toBeNull();
+    expect(container.querySelector("img")?.getAttribute("src")).toBe(
+      "https://example.test/a.png",
+    );
+  });
+
+  test("unknown trait ids with no image render the fallback", () => {
+    const { container, queryByTestId } = render(
+      <ChooserAvatarChip
+        traits={UNKNOWN_TRAITS}
+        imageUrl={null}
+        fallback={fallback}
+      />,
+    );
+    expect(queryByTestId("fallback")).not.toBeNull();
+    expect(container.querySelector("svg")).toBeNull();
+    expect(container.querySelector("img")).toBeNull();
   });
 
   test("renders the fallback when there is no avatar", () => {

--- a/clients/web/src/components/avatar/chooser-avatar-chip.test.tsx
+++ b/clients/web/src/components/avatar/chooser-avatar-chip.test.tsx
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, render } from "@testing-library/react";
+
+import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
+import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
+import type * as BundledHookModule from "@/utils/use-bundled-avatar-components";
+
+const componentsRef: { value: CharacterComponents | null } = { value: null };
+
+mock.module(
+  "@/utils/use-bundled-avatar-components",
+  (): Partial<typeof BundledHookModule> => ({
+    useBundledAvatarComponents: () => componentsRef.value,
+  }),
+);
+
+const { ChooserAvatarChip } =
+  await import("@/components/avatar/chooser-avatar-chip");
+
+const TRAITS: CharacterTraits = {
+  bodyShape: BUNDLED_COMPONENTS.bodyShapes[0]!.id,
+  eyeStyle: BUNDLED_COMPONENTS.eyeStyles[0]!.id,
+  color: BUNDLED_COMPONENTS.colors[0]!.id,
+};
+
+const fallback = <span data-testid="fallback">V</span>;
+
+describe("ChooserAvatarChip", () => {
+  beforeEach(() => {
+    componentsRef.value = BUNDLED_COMPONENTS;
+  });
+
+  afterEach(cleanup);
+
+  test("renders the character SVG once components resolve", () => {
+    componentsRef.value = null;
+    const { container, rerender, queryByTestId } = render(
+      <ChooserAvatarChip traits={TRAITS} imageUrl={null} fallback={fallback} />,
+    );
+    expect(queryByTestId("fallback")).not.toBeNull();
+    expect(container.querySelector("svg")).toBeNull();
+
+    componentsRef.value = BUNDLED_COMPONENTS;
+    rerender(
+      <ChooserAvatarChip traits={TRAITS} imageUrl={null} fallback={fallback} />,
+    );
+    expect(queryByTestId("fallback")).toBeNull();
+    expect(container.querySelector("svg")).not.toBeNull();
+  });
+
+  test("character outranks image and honors size", () => {
+    const { container } = render(
+      <ChooserAvatarChip
+        traits={TRAITS}
+        imageUrl="https://example.test/a.png"
+        size={32}
+        fallback={fallback}
+      />,
+    );
+    expect(container.querySelector("img")).toBeNull();
+    const root = container.firstElementChild as HTMLElement;
+    expect(root.style.width).toBe("32px");
+    expect(root.style.height).toBe("32px");
+  });
+
+  test("renders the image when there are no traits", () => {
+    const { container } = render(
+      <ChooserAvatarChip
+        traits={null}
+        imageUrl="https://example.test/a.png"
+        fallback={fallback}
+      />,
+    );
+    const img = container.querySelector("img");
+    expect(img?.getAttribute("src")).toBe("https://example.test/a.png");
+    expect(img?.getAttribute("alt")).toBe("Assistant avatar");
+    expect(img?.className).toContain("rounded-full");
+    expect(img?.style.width).toBe("48px");
+  });
+
+  test("renders the fallback when there is no avatar", () => {
+    const { container, queryByTestId } = render(
+      <ChooserAvatarChip traits={null} imageUrl={null} fallback={fallback} />,
+    );
+    expect(queryByTestId("fallback")).not.toBeNull();
+    expect(container.querySelector("img")).toBeNull();
+    expect(container.querySelector("svg")).toBeNull();
+  });
+});

--- a/clients/web/src/components/avatar/chooser-avatar-chip.tsx
+++ b/clients/web/src/components/avatar/chooser-avatar-chip.tsx
@@ -1,0 +1,65 @@
+/**
+ * Avatar for an assistant row in a chooser list: character traits, else the
+ * uploaded image, else the caller's `fallback`. Traits outrank the image to
+ * match `ChatAvatar`. The fallback also stands in while the lazily loaded
+ * character components resolve, so the row never goes blank.
+ */
+
+import type { ReactNode } from "react";
+
+import { AvatarRenderer } from "@/components/avatar-renderer";
+import { useTranslation } from "@/i18n";
+import type { CharacterTraits } from "@/types/avatar";
+import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";
+
+export interface ChooserAvatarChipProps {
+  traits: CharacterTraits | null;
+  imageUrl: string | null;
+  /** Pixel size. Defaults to 48, the chooser card icon slot. */
+  size?: number;
+  /** Rendered when there is no avatar, or while the character chunk loads. */
+  fallback: ReactNode;
+  className?: string;
+}
+
+export function ChooserAvatarChip({
+  traits,
+  imageUrl,
+  size = 48,
+  fallback,
+  className,
+}: ChooserAvatarChipProps) {
+  const { t } = useTranslation();
+  const components = useBundledAvatarComponents();
+
+  if (traits) {
+    if (!components) {
+      return fallback;
+    }
+    return (
+      <AvatarRenderer
+        components={components}
+        bodyShapeId={traits.bodyShape}
+        eyeStyleId={traits.eyeStyle}
+        colorId={traits.color}
+        size={size}
+        className={className}
+      />
+    );
+  }
+
+  if (imageUrl) {
+    return (
+      <img
+        src={imageUrl}
+        alt={t("chooserAvatarChip.alt")}
+        width={size}
+        height={size}
+        className={`rounded-full object-cover ${className ?? ""}`.trim()}
+        style={{ width: size, height: size, flexShrink: 0 }}
+      />
+    );
+  }
+
+  return fallback;
+}

--- a/clients/web/src/components/avatar/chooser-avatar-chip.tsx
+++ b/clients/web/src/components/avatar/chooser-avatar-chip.tsx
@@ -2,7 +2,9 @@
  * Avatar for an assistant row in a chooser list: character traits, else the
  * uploaded image, else the caller's `fallback`. Traits outrank the image to
  * match `ChatAvatar`. The fallback also stands in while the lazily loaded
- * character components resolve, so the row never goes blank.
+ * character components resolve, so the row never goes blank. Traits whose ids
+ * are missing from the palette (legacy or hand-written sidecars) fall through
+ * to the image, then the fallback.
  */
 
 import type { ReactNode } from "react";
@@ -10,6 +12,7 @@ import type { ReactNode } from "react";
 import { AvatarRenderer } from "@/components/avatar-renderer";
 import { useTranslation } from "@/i18n";
 import type { CharacterTraits } from "@/types/avatar";
+import { canResolveDefinitions } from "@/utils/avatar-svg-compositor";
 import { useBundledAvatarComponents } from "@/utils/use-bundled-avatar-components";
 
 export interface ChooserAvatarChipProps {
@@ -36,16 +39,24 @@ export function ChooserAvatarChip({
     if (!components) {
       return fallback;
     }
-    return (
-      <AvatarRenderer
-        components={components}
-        bodyShapeId={traits.bodyShape}
-        eyeStyleId={traits.eyeStyle}
-        colorId={traits.color}
-        size={size}
-        className={className}
-      />
+    const renderable = canResolveDefinitions(
+      components,
+      traits.bodyShape,
+      traits.eyeStyle,
+      traits.color,
     );
+    if (renderable) {
+      return (
+        <AvatarRenderer
+          components={components}
+          bodyShapeId={traits.bodyShape}
+          eyeStyleId={traits.eyeStyle}
+          colorId={traits.color}
+          size={size}
+          className={className}
+        />
+      );
+    }
   }
 
   if (imageUrl) {

--- a/clients/web/src/i18n/locales/en/common.json
+++ b/clients/web/src/i18n/locales/en/common.json
@@ -101,6 +101,9 @@
     "alt": "Assistant avatar",
     "fallbackLetter": "V"
   },
+  "chooserAvatarChip": {
+    "alt": "Assistant avatar"
+  },
   "collapsibleNavSection": {
     "actionsTitle": "{title} actions"
   },

--- a/clients/web/src/i18n/locales/es/common.json
+++ b/clients/web/src/i18n/locales/es/common.json
@@ -101,6 +101,9 @@
     "alt": "Avatar del asistente",
     "fallbackLetter": "V"
   },
+  "chooserAvatarChip": {
+    "alt": "Avatar del asistente"
+  },
   "collapsibleNavSection": {
     "actionsTitle": "Acciones de {title}"
   },

--- a/clients/web/src/utils/avatar-svg-compositor.ts
+++ b/clients/web/src/utils/avatar-svg-compositor.ts
@@ -122,6 +122,21 @@ export function resolveDefinitions(
   return { bodyShape, eyeStyle, color };
 }
 
+/** True when every trait id resolves against `components`. */
+export function canResolveDefinitions(
+  components: CharacterComponents,
+  bodyShapeId: string,
+  eyeStyleId: string | null | undefined,
+  colorId: string,
+): boolean {
+  try {
+    resolveDefinitions(components, bodyShapeId, eyeStyleId, colorId);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function escapeAttr(s: string): string {
   return s
     .replace(/&/g, "&amp;")


### PR DESCRIPTION
## Summary
- Add `ChooserAvatarChip` (`clients/web/src/components/avatar/chooser-avatar-chip.tsx`), a purely presentational avatar for chooser list rows: renders the character via `AvatarRenderer` from saved traits, else the uploaded image as a `rounded-full object-cover` `<img>` (mirrors `ChatAvatar`), else the caller's `fallback`.
- Character components come from the module-cached `useBundledAvatarComponents()` lazy chunk (no network); the `fallback` stands in while it loads.
- `resolveAvatarRender` was deliberately not used: it synthesizes a default character when both traits and image are null, whereas this chip must return the caller's fallback verbatim.
- Add `chooserAvatarChip.alt` to `en` and `es` `common.json`.
- Colocated bun:test + happy-dom tests cover loading state, character SVG once components resolve, image branch, and fallback; the bundled-components hook is mocked as `Partial<typeof Module>`.

Part of plan: chooser-assistant-avatars.md (PR 1 of 11)