### PR TITLE
feat(tools): block assistant rm of required workspace files

### DIFF
--- a/assistant/src/permissions/workspace-policy.ts
+++ b/assistant/src/permissions/workspace-policy.ts
@@ -223,7 +223,7 @@ function executableSinkDirs(): string[] {
  * against this predicate). A write to any of them rewrites the assistant's
  * standing instructions, per-user context, or per-channel context.
  */
-const PROMPT_SURFACE_FILES = [
+export const PROMPT_SURFACE_FILES = [
   "IDENTITY.md",
   "SOUL.md",
   "VOICE.md",
@@ -237,8 +237,8 @@ const PROMPT_SURFACE_FILES = [
   // system section, so the drift guard cannot see it — this entry is the
   // coverage.
   "NOW.md",
-];
-const PROMPT_SURFACE_DIRS = ["users", "channels"];
+] as const;
+export const PROMPT_SURFACE_DIRS = ["users", "channels"] as const;
 
 // `memory/**` is deliberately data-plane, not control-plane: memory pages
 // inject into guardian sessions as past-record rather than standing

--- a/assistant/src/tools/protected-workspace-delete-policy.test.ts
+++ b/assistant/src/tools/protected-workspace-delete-policy.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  PROMPT_SURFACE_DIRS,
+  PROMPT_SURFACE_FILES,
+} from "../permissions/workspace-policy.js";
+import {
+  commandDeletesProtectedWorkspaceFile,
+  enforceProtectedWorkspaceDeletePolicy,
+  isProtectedFromDeleteRelPath,
+  PROTECTED_FROM_DELETE_DIRS,
+  PROTECTED_FROM_DELETE_FILES,
+} from "./protected-workspace-delete-policy.js";
+
+const WS = "/workspace";
+
+function deniedTarget(command: string): string | null {
+  const result = commandDeletesProtectedWorkspaceFile(command, WS);
+  return result.denied ? result.target : null;
+}
+
+describe("allowlist coverage", () => {
+  test("includes every prompt-surface file and directory", () => {
+    for (const file of PROMPT_SURFACE_FILES) {
+      expect(PROTECTED_FROM_DELETE_FILES).toContain(file);
+    }
+    for (const dir of PROMPT_SURFACE_DIRS) {
+      expect(PROTECTED_FROM_DELETE_DIRS).toContain(dir);
+    }
+    expect(PROTECTED_FROM_DELETE_FILES).toContain("config.json");
+  });
+});
+
+describe("isProtectedFromDeleteRelPath", () => {
+  test("covers config and prompt-surface files", () => {
+    expect(isProtectedFromDeleteRelPath("config.json")).toBe(true);
+    expect(isProtectedFromDeleteRelPath("SOUL.md")).toBe(true);
+    expect(isProtectedFromDeleteRelPath("IDENTITY.md")).toBe(true);
+    expect(isProtectedFromDeleteRelPath("users/alice.md")).toBe(true);
+    expect(isProtectedFromDeleteRelPath("channels/general.md")).toBe(true);
+    expect(isProtectedFromDeleteRelPath("ui/theme.json")).toBe(true);
+  });
+
+  test("does not cover ordinary workspace files", () => {
+    expect(isProtectedFromDeleteRelPath("scratch/notes.md")).toBe(false);
+    expect(isProtectedFromDeleteRelPath("data/home-feed.json")).toBe(false);
+    expect(isProtectedFromDeleteRelPath("journal/2026-08-24.md")).toBe(false);
+  });
+});
+
+describe("commandDeletesProtectedWorkspaceFile", () => {
+  test("allows deletes outside the allowlist", () => {
+    expect(deniedTarget("rm scratch/notes.md")).toBeNull();
+    expect(deniedTarget("rm -rf scratch/agentboard")).toBeNull();
+    expect(deniedTarget("rm /tmp/config.json")).toBeNull();
+    expect(deniedTarget("rm data/credentials/metadata.json")).toBeNull();
+    expect(deniedTarget("ls config.json")).toBeNull();
+    expect(deniedTarget("cat SOUL.md && rm scratch/foo")).toBeNull();
+  });
+
+  test("blocks rm of config.json in the usual spellings", () => {
+    expect(deniedTarget("rm config.json")).toBe("config.json");
+    expect(deniedTarget("rm -f config.json")).toBe("config.json");
+    expect(deniedTarget("rm ./config.json")).toBe("config.json");
+    expect(deniedTarget("rm /workspace/config.json")).toBe("config.json");
+    expect(deniedTarget("rm -- config.json")).toBe("config.json");
+  });
+
+  test("blocks rm of prompt-surface files", () => {
+    expect(deniedTarget("rm SOUL.md")).toBe("SOUL.md");
+    expect(deniedTarget("rm IDENTITY.md HEARTBEAT.md")).toBe("IDENTITY.md");
+    expect(deniedTarget("rm users/default.md")).toBe("users/default.md");
+    expect(deniedTarget("rm -rf users")).toBe("users");
+  });
+
+  test("blocks wrappers around rm", () => {
+    expect(deniedTarget("sudo rm config.json")).toBe("config.json");
+    expect(deniedTarget("command rm -f SOUL.md")).toBe("SOUL.md");
+    expect(deniedTarget("env FOO=1 rm NOW.md")).toBe("NOW.md");
+    expect(deniedTarget("timeout 10 rm config.json")).toBe("config.json");
+  });
+
+  test("blocks unlink, git rm, and mv-away", () => {
+    expect(deniedTarget("unlink config.json")).toBe("config.json");
+    expect(deniedTarget("git rm SOUL.md")).toBe("SOUL.md");
+    expect(deniedTarget("mv config.json /tmp/config.json.bak")).toBe(
+      "config.json",
+    );
+  });
+
+  test("allows git rm --cached (index only)", () => {
+    expect(deniedTarget("git rm --cached config.json")).toBeNull();
+  });
+
+  test("blocks workspace-root wipes", () => {
+    expect(deniedTarget("rm -rf .")).not.toBeNull();
+    expect(deniedTarget("rm -rf /workspace")).not.toBeNull();
+    expect(deniedTarget("rm -rf /workspace/")).not.toBeNull();
+    expect(deniedTarget("rm -rf *")).not.toBeNull();
+    expect(deniedTarget("rm *")).not.toBeNull();
+  });
+
+  test("does not treat filesystem root as the workspace", () => {
+    expect(deniedTarget("rm -rf /")).toBeNull();
+  });
+
+  test("blocks find -delete of the workspace root", () => {
+    expect(deniedTarget("find . -name '*.md' -delete")).not.toBeNull();
+    expect(deniedTarget("find /workspace -delete")).not.toBeNull();
+  });
+
+  test("allows find -delete under scratch", () => {
+    expect(deniedTarget("find scratch -name '*.tmp' -delete")).toBeNull();
+  });
+
+  test("inspects every segment of a compound command", () => {
+    expect(deniedTarget("ls && rm config.json")).toBe("config.json");
+    expect(deniedTarget("rm scratch/a && rm SOUL.md")).toBe("SOUL.md");
+  });
+});
+
+describe("enforceProtectedWorkspaceDeletePolicy", () => {
+  test("ignores non-shell tools", () => {
+    const result = enforceProtectedWorkspaceDeletePolicy(
+      "file_write",
+      { path: "config.json", content: "{}" },
+      WS,
+    );
+    expect(result.denied).toBe(false);
+  });
+
+  test("blocks bash and host_bash", () => {
+    const bash = enforceProtectedWorkspaceDeletePolicy(
+      "bash",
+      { command: "rm config.json" },
+      WS,
+    );
+    const host = enforceProtectedWorkspaceDeletePolicy(
+      "host_bash",
+      { command: "rm /workspace/SOUL.md" },
+      WS,
+    );
+    expect(bash.denied).toBe(true);
+    expect(host.denied).toBe(true);
+    if (bash.denied) {
+      expect(bash.reason).toContain("config.json");
+    }
+  });
+
+  test("tells the model how to proceed", () => {
+    const result = enforceProtectedWorkspaceDeletePolicy(
+      "bash",
+      { command: "rm -rf /workspace" },
+      WS,
+    );
+    expect(result.denied).toBe(true);
+    if (result.denied) {
+      expect(result.reason).toContain("workspace root");
+      expect(result.reason).not.toContain("daemon");
+    }
+  });
+});

--- a/assistant/src/tools/protected-workspace-delete-policy.ts
+++ b/assistant/src/tools/protected-workspace-delete-policy.ts
@@ -1,0 +1,400 @@
+/**
+ * Hard-deny deletes of workspace files the assistant must not remove.
+ *
+ * Prompt surfaces stay editable in place (file_write / file_edit). Deleting
+ * them (or config.json) is a footgun: the config loader rewrites schema
+ * defaults when config.json is gone, and identity files re-seed from
+ * templates. This is not an adversarial sandbox. It covers the shell
+ * tools the model actually uses for cleanup (`rm`, `unlink`, `git rm`,
+ * `find -delete`, and a workspace-root wipe).
+ */
+
+import { basename, relative, resolve, sep } from "node:path";
+
+import {
+  PROMPT_SURFACE_DIRS,
+  PROMPT_SURFACE_FILES,
+  resolveSandboxBase,
+} from "../permissions/workspace-policy.js";
+
+const SHELL_TOOLS = new Set(["bash", "host_bash"]);
+
+/**
+ * Workspace-relative files that must survive an assistant `rm`. Prompt
+ * surfaces match {@link PROMPT_SURFACE_FILES}. `config.json` is runtime
+ * state: the loader writes schema defaults when it is missing.
+ */
+export const PROTECTED_FROM_DELETE_FILES = [
+  "config.json",
+  ...PROMPT_SURFACE_FILES,
+  "USER.md",
+  "ui/theme.json",
+] as const;
+
+export const PROTECTED_FROM_DELETE_DIRS = PROMPT_SURFACE_DIRS;
+
+const WRAPPER_COMMANDS = new Set([
+  "sudo",
+  "doas",
+  "command",
+  "nice",
+  "nohup",
+  "time",
+  "stdbuf",
+  "ionice",
+  "then",
+  "builtin",
+]);
+
+export type ProtectedDeleteDenial = {
+  denied: true;
+  reason: string;
+  target: string;
+};
+
+export type ProtectedDeleteResult =
+  | { denied: false }
+  | ProtectedDeleteDenial;
+
+function tokenize(segment: string): string[] {
+  const tokens: string[] = [];
+  const re = /"([^"]*)"|'([^']*)'|(\S+)/g;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(segment)) !== null) {
+    const token = match[1] ?? match[2] ?? match[3] ?? "";
+    if (token.length > 0) {
+      tokens.push(token);
+    }
+  }
+  return tokens;
+}
+
+function splitSegments(command: string): string[] {
+  return command.split(/(?:&&|\|\||;|\n|\|)/);
+}
+
+function peelWrappers(tokens: string[]): string[] {
+  let i = 0;
+  while (i < tokens.length) {
+    const token = tokens[i];
+    if (token === undefined) {
+      break;
+    }
+    if (token === "sudo" || token === "doas") {
+      i += 1;
+      while (i < tokens.length && (tokens[i] ?? "").startsWith("-")) {
+        i += 1;
+      }
+      continue;
+    }
+    if (token === "command" || token === "builtin") {
+      i += 1;
+      while (i < tokens.length && (tokens[i] ?? "").startsWith("-")) {
+        i += 1;
+      }
+      continue;
+    }
+    if (token === "env") {
+      i += 1;
+      while (i < tokens.length) {
+        const next = tokens[i] ?? "";
+        if (next.startsWith("-") || next.includes("=")) {
+          i += 1;
+          continue;
+        }
+        break;
+      }
+      continue;
+    }
+    if (token === "timeout") {
+      i += 1;
+      while (i < tokens.length) {
+        const next = tokens[i] ?? "";
+        if (next.startsWith("-") || /^\d/.test(next)) {
+          i += 1;
+          continue;
+        }
+        break;
+      }
+      continue;
+    }
+    if (WRAPPER_COMMANDS.has(token)) {
+      i += 1;
+      while (i < tokens.length && (tokens[i] ?? "").startsWith("-")) {
+        i += 1;
+      }
+      continue;
+    }
+    break;
+  }
+  return tokens.slice(i);
+}
+
+function isRecursiveFlag(arg: string): boolean {
+  if (arg === "-r" || arg === "-R" || arg === "--recursive") {
+    return true;
+  }
+  if (arg.startsWith("--")) {
+    return false;
+  }
+  if (!arg.startsWith("-") || arg.length < 2) {
+    return false;
+  }
+  return arg.includes("r") || arg.includes("R");
+}
+
+function collectPositionalArgs(args: string[]): {
+  paths: string[];
+  recursive: boolean;
+  cachedOnly: boolean;
+} {
+  const paths: string[] = [];
+  let recursive = false;
+  let cachedOnly = false;
+  let endFlags = false;
+  for (const arg of args) {
+    if (!endFlags && arg === "--") {
+      endFlags = true;
+      continue;
+    }
+    if (!endFlags && arg.startsWith("-")) {
+      if (isRecursiveFlag(arg)) {
+        recursive = true;
+      }
+      if (arg === "--cached") {
+        cachedOnly = true;
+      }
+      continue;
+    }
+    paths.push(arg);
+  }
+  return { paths, recursive, cachedOnly };
+}
+
+function posixRelative(from: string, to: string): string {
+  return relative(from, to).split("\\").join("/");
+}
+
+function isProtectedFile(
+  rawPath: string,
+  workspaceRoot: string,
+): string | null {
+  const resolved = resolveSandboxBase(rawPath, workspaceRoot);
+  const rel = posixRelative(resolve(workspaceRoot), resolved);
+  if (rel === "" || rel.startsWith("..")) {
+    return null;
+  }
+  if ((PROTECTED_FROM_DELETE_FILES as readonly string[]).includes(rel)) {
+    return rel;
+  }
+  const top = rel.split("/")[0];
+  if (
+    top !== undefined &&
+    (PROTECTED_FROM_DELETE_DIRS as readonly string[]).includes(top)
+  ) {
+    return rel;
+  }
+  return null;
+}
+
+function stripTrailingSlashes(path: string): string {
+  if (path === "/") {
+    return "/";
+  }
+  const trimmed = path.replace(/\/+$/, "");
+  return trimmed.length > 0 ? trimmed : "/";
+}
+
+function isWorkspaceWideTarget(rawPath: string, workspaceRoot: string): boolean {
+  const trimmed = stripTrailingSlashes(rawPath);
+  if (trimmed === "/" || trimmed === "") {
+    return false;
+  }
+  if (
+    trimmed === "." ||
+    trimmed === "*" ||
+    trimmed === "./*" ||
+    trimmed === "./**" ||
+    trimmed === "/workspace" ||
+    trimmed === "/workspace/*"
+  ) {
+    return true;
+  }
+  const withoutGlob = stripTrailingSlashes(trimmed.replace(/\/\*$/, ""));
+  if (withoutGlob === "/") {
+    return false;
+  }
+  const resolved = resolveSandboxBase(withoutGlob, workspaceRoot);
+  return resolve(resolved) === resolve(workspaceRoot);
+}
+
+function denial(target: string): ProtectedDeleteDenial {
+  if (target === "." || target === "/workspace" || target.endsWith("/*")) {
+    return {
+      denied: true,
+      target,
+      reason:
+        "Cannot delete the workspace root. That would remove required assistant state such as config.json and SOUL.md. Delete specific non-protected paths instead.",
+    };
+  }
+  return {
+    denied: true,
+    target,
+    reason: `Cannot delete ${basename(target)}. That file is required assistant state. Edit it in place, or change config.json through Settings.`,
+  };
+}
+
+function inspectRmLike(
+  paths: string[],
+  workspaceRoot: string,
+  options: { recursive: boolean; cachedOnly: boolean },
+): ProtectedDeleteResult {
+  if (options.cachedOnly) {
+    return { denied: false };
+  }
+  for (const path of paths) {
+    if (isWorkspaceWideTarget(path, workspaceRoot)) {
+      return denial(path);
+    }
+    const hit = isProtectedFile(path, workspaceRoot);
+    if (hit) {
+      return denial(hit);
+    }
+  }
+  return { denied: false };
+}
+
+function inspectFind(
+  tokens: string[],
+  workspaceRoot: string,
+): ProtectedDeleteResult {
+  const deletes =
+    tokens.includes("-delete") ||
+    tokens.some(
+      (token, index) => token === "-exec" && tokens[index + 1] === "rm",
+    );
+  if (!deletes) {
+    return { denied: false };
+  }
+  const searchPaths: string[] = [];
+  for (let i = 1; i < tokens.length; i += 1) {
+    const token = tokens[i];
+    if (token === undefined) {
+      break;
+    }
+    if (token.startsWith("-")) {
+      break;
+    }
+    searchPaths.push(token);
+  }
+  if (searchPaths.length === 0) {
+    searchPaths.push(".");
+  }
+  return inspectRmLike(searchPaths, workspaceRoot, {
+    recursive: true,
+    cachedOnly: false,
+  });
+}
+
+function inspectGitRm(
+  tokens: string[],
+  workspaceRoot: string,
+): ProtectedDeleteResult {
+  const rmIndex = tokens.findIndex((token) => token === "rm");
+  if (rmIndex === -1) {
+    return { denied: false };
+  }
+  const collected = collectPositionalArgs(tokens.slice(rmIndex + 1));
+  return inspectRmLike(collected.paths, workspaceRoot, {
+    recursive: collected.recursive,
+    cachedOnly: collected.cachedOnly,
+  });
+}
+
+function inspectSegment(
+  segment: string,
+  workspaceRoot: string,
+): ProtectedDeleteResult {
+  const peeled = peelWrappers(tokenize(segment));
+  if (peeled.length === 0) {
+    return { denied: false };
+  }
+  const verb = peeled[0];
+  if (verb === "rm" || verb === "unlink" || verb === "rmdir") {
+    const collected = collectPositionalArgs(peeled.slice(1));
+    return inspectRmLike(collected.paths, workspaceRoot, {
+      recursive: collected.recursive || verb === "rmdir",
+      cachedOnly: false,
+    });
+  }
+  if (verb === "mv") {
+    const collected = collectPositionalArgs(peeled.slice(1));
+    if (collected.paths.length >= 1) {
+      const source = collected.paths[0];
+      if (source !== undefined) {
+        const hit = isProtectedFile(source, workspaceRoot);
+        if (hit) {
+          return denial(hit);
+        }
+      }
+    }
+    return { denied: false };
+  }
+  if (verb === "git") {
+    return inspectGitRm(peeled.slice(1), workspaceRoot);
+  }
+  if (verb === "find") {
+    return inspectFind(peeled, workspaceRoot);
+  }
+  return { denied: false };
+}
+
+/**
+ * Whether a shell command would delete a protected workspace file or wipe
+ * the workspace root.
+ */
+export function commandDeletesProtectedWorkspaceFile(
+  command: string,
+  workspaceRoot: string,
+): ProtectedDeleteResult {
+  if (!workspaceRoot) {
+    return { denied: false };
+  }
+  for (const segment of splitSegments(command)) {
+    const result = inspectSegment(segment.trim(), workspaceRoot);
+    if (result.denied) {
+      return result;
+    }
+  }
+  return { denied: false };
+}
+
+/**
+ * Enforce the delete allowlist on bash / host_bash. Other tools are ignored.
+ */
+export function enforceProtectedWorkspaceDeletePolicy(
+  toolName: string,
+  input: Record<string, unknown>,
+  workspaceRoot: string,
+): ProtectedDeleteResult {
+  if (!SHELL_TOOLS.has(toolName)) {
+    return { denied: false };
+  }
+  const command = input.command;
+  if (typeof command !== "string" || command.length === 0) {
+    return { denied: false };
+  }
+  return commandDeletesProtectedWorkspaceFile(command, workspaceRoot);
+}
+
+export function isProtectedFromDeleteRelPath(relPath: string): boolean {
+  const normalized = relPath.split(sep).join("/");
+  if ((PROTECTED_FROM_DELETE_FILES as readonly string[]).includes(normalized)) {
+    return true;
+  }
+  const top = normalized.split("/")[0];
+  return (
+    top !== undefined &&
+    (PROTECTED_FROM_DELETE_DIRS as readonly string[]).includes(top)
+  );
+}

--- a/assistant/src/tools/tool-approval-handler.ts
+++ b/assistant/src/tools/tool-approval-handler.ts
@@ -55,6 +55,7 @@ import {
   type ToolContext,
   type ToolExecutionResult,
 } from "./types.js";
+import { enforceProtectedWorkspaceDeletePolicy } from "./protected-workspace-delete-policy.js";
 import { enforceVerificationControlPlanePolicy } from "./verification-control-plane-policy.js";
 
 const log = getLogger("tool-approval-handler");
@@ -774,6 +775,35 @@ export class ToolApprovalHandler {
       return {
         allowed: false,
         result: { content: guardianCheck.reason!, isError: true },
+      };
+    }
+
+    const protectedDelete = enforceProtectedWorkspaceDeletePolicy(
+      name,
+      input,
+      context.workingDir,
+    );
+    if (protectedDelete.denied) {
+      log.warn(
+        {
+          toolName: name,
+          conversationId: context.conversationId,
+          target: protectedDelete.target,
+          reason: "protected_workspace_delete",
+        },
+        "Protected workspace file delete blocked",
+      );
+      this.auditGateDenied(
+        context,
+        name,
+        input,
+        riskLevel,
+        startTime,
+        protectedDelete.reason,
+      );
+      return {
+        allowed: false,
+        result: { content: protectedDelete.reason, isError: true },
       };
     }
 

--- a/assistant/src/tools/tool-approval-handler.ts
+++ b/assistant/src/tools/tool-approval-handler.ts
@@ -41,6 +41,7 @@ import { getLogger } from "../util/logger.js";
 import { resolveExecutionTarget } from "./execution-target.js";
 import { safeTimeoutMs } from "./execution-timeout.js";
 import { channelCoordinatesFromToolContext } from "./policy-context.js";
+import { enforceProtectedWorkspaceDeletePolicy } from "./protected-workspace-delete-policy.js";
 import { getAllTools, getTool, getToolOwner } from "./registry.js";
 import { isSideEffectTool } from "./side-effects.js";
 import { parseToolInput } from "./tool-input-schemas.js";
@@ -55,7 +56,6 @@ import {
   type ToolContext,
   type ToolExecutionResult,
 } from "./types.js";
-import { enforceProtectedWorkspaceDeletePolicy } from "./protected-workspace-delete-policy.js";
 import { enforceVerificationControlPlanePolicy } from "./verification-control-plane-policy.js";
 
 const log = getLogger("tool-approval-handler");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan

A managed user deleted required workspace state (including `config.json` and `SOUL.md`) through an assistant cleanup turn. `config.json` must never be removed by the assistant: the loader rewrites schema defaults when it is missing. Same class of files: identity and prompt-surface markdown.

This adds a hard deny on `bash` / `host_bash` (same pre-exec gate as the verification control-plane policy), not a new approval mode.

Allowlist (workspace-relative):
- `config.json`
- prompt-surface files from `PROMPT_SURFACE_FILES` (`IDENTITY.md`, `SOUL.md`, `VOICE.md`, `BOOTSTRAP.md`, `HEARTBEAT.md`, `NOW.md`)
- `USER.md`, `ui/theme.json`
- anything under `users/` or `channels/`

Also blocked: workspace-root wipes (`rm -rf .`, `rm -rf /workspace`, `rm *`), `unlink`, `git rm` (not `--cached`), `mv` away, and `find -delete` of `.` / `/workspace`.

In-place `file_write` / `file_edit` is unchanged. `data/credentials/metadata.json` is not in this list.

This is a footgun guard, not an adversarial sandbox. `python -c os.remove(...)` and similar still work.

## Test plan

- `cd assistant && bun test src/tools/protected-workspace-delete-policy.test.ts`
- `cd assistant && bun test src/__tests__/tool-approval-handler.test.ts`
- `cd assistant && bun test src/__tests__/workspace-policy.test.ts`
- `cd assistant && bunx tsc --noEmit`

## Risk

Medium. False positives would block legitimate deletes of similarly named files only when they resolve to the workspace allowlist paths. `rm -rf /` is intentionally not treated as a workspace wipe (risk classification still covers it). Review the allowlist and the shell heuristic in `protected-workspace-delete-policy.ts`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e70fb5e2-c71e-40c3-8b34-795cd923de90?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e70fb5e2-c71e-40c3-8b34-795cd923de90&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

