### PR TITLE
electron: add localMode.readAssistantAvatar reading the workspace avatar off disk

### DIFF
--- a/assistant/Dockerfile
+++ b/assistant/Dockerfile
@@ -117,6 +117,7 @@ RUN ln -sf /usr/local/bin/bun /usr/local/bin/bunx
 COPY --from=builder /app /app
 
 # Copy source after installing dependencies for better layer caching.
+COPY packages/avatar-manifest /app/packages/avatar-manifest
 COPY packages/ces-client /app/packages/ces-client
 COPY packages/service-contracts /app/packages/service-contracts
 COPY packages/credential-storage /app/packages/credential-storage

--- a/assistant/knip.json
+++ b/assistant/knip.json
@@ -15,6 +15,7 @@
   "ignore": ["src/config/preloaded-apps/**"],
   "ignoreDependencies": [
     "@microsoft/api-extractor",
+    "@vellumai/avatar-manifest",
     "@vellumai/ces-client",
     "@vellumai/credential-storage",
     "@vellumai/egress-proxy",

--- a/assistant/package.json
+++ b/assistant/package.json
@@ -43,6 +43,7 @@
     "@qdrant/js-client-rest": "1.17.0",
     "@resvg/resvg-js": "2.6.2",
     "@slack/types": "2.22.0",
+    "@vellumai/avatar-manifest": "workspace:*",
     "@vellumai/ces-client": "workspace:*",
     "@vellumai/credential-storage": "workspace:*",
     "@vellumai/egress-proxy": "workspace:*",
@@ -85,6 +86,7 @@
     "node": ">=20.12.0"
   },
   "bundledDependencies": [
+    "@vellumai/avatar-manifest",
     "@vellumai/ces-client",
     "@vellumai/credential-storage",
     "@vellumai/service-contracts",

--- a/assistant/src/avatar/avatar-manifest.ts
+++ b/assistant/src/avatar/avatar-manifest.ts
@@ -17,66 +17,26 @@ import {
 } from "node:fs";
 import { join } from "node:path";
 
-import { getLogger } from "../util/logger.js";
 import {
   AVATAR_IMAGE_FILENAME,
   AVATAR_MANIFEST_FILENAME,
-  getAvatarDir,
-} from "../util/platform.js";
-import { type CharacterTraits, TRAITS_FILENAME } from "./traits-png-sync.js";
+  AVATAR_TRAITS_FILENAME,
+  type AvatarImageMeta,
+  type AvatarKind,
+  type AvatarSource,
+  type AvatarState,
+  type CharacterTraits,
+  deriveAvatarFromLegacyFiles,
+  parseAvatarManifest,
+} from "@vellumai/avatar-manifest";
+
+import { getLogger } from "../util/logger.js";
+import { getAvatarDir } from "../util/platform.js";
 
 const log = getLogger("avatar-manifest");
 
-export type AvatarKind = "character" | "image" | "none";
-export type AvatarSource = "builder" | "upload" | "ai";
-
-export interface AvatarImageMeta {
-  updatedAt: string;
-  etag: string;
-}
-
-export interface AvatarState {
-  kind: AvatarKind;
-  traits: CharacterTraits | null;
-  source: AvatarSource | null;
-  image: AvatarImageMeta | null;
-}
-
-const AVATAR_KINDS: ReadonlySet<string> = new Set<AvatarKind>([
-  "character",
-  "image",
-  "none",
-]);
-
-/** Narrows an unknown value to valid CharacterTraits (presence check only). */
-function isValidTraits(value: unknown): value is CharacterTraits {
-  if (!value || typeof value !== "object") {
-    return false;
-  }
-  const t = value as Record<string, unknown>;
-  return (
-    typeof t.bodyShape === "string" &&
-    !!t.bodyShape &&
-    typeof t.eyeStyle === "string" &&
-    !!t.eyeStyle &&
-    typeof t.color === "string" &&
-    !!t.color
-  );
-}
-
-/** Narrows an unknown value to valid AvatarImageMeta (presence check only). */
-function isValidImageMeta(value: unknown): value is AvatarImageMeta {
-  if (!value || typeof value !== "object") {
-    return false;
-  }
-  const m = value as Record<string, unknown>;
-  return (
-    typeof m.updatedAt === "string" &&
-    !!m.updatedAt &&
-    typeof m.etag === "string" &&
-    !!m.etag
-  );
-}
+export type { AvatarImageMeta, AvatarKind, AvatarSource, AvatarState };
+export type { CharacterTraits };
 
 /**
  * Reads and validates the avatar manifest. Returns `null` when the manifest is
@@ -93,32 +53,9 @@ export function readManifest(
   }
 
   try {
-    const parsed = JSON.parse(readFileSync(manifestPath, "utf-8")) as unknown;
-    if (!parsed || typeof parsed !== "object") {
-      return null;
-    }
-    const obj = parsed as Record<string, unknown>;
-    if (typeof obj.kind !== "string" || !AVATAR_KINDS.has(obj.kind)) {
-      return null;
-    }
-    const kind = obj.kind as AvatarKind;
-
-    // Reject partial manifests: a valid `kind` with a missing/malformed payload
-    // would otherwise short-circuit the legacy fallback and surface an avatar
-    // with null traits/image.
-    if (kind === "character" && !isValidTraits(obj.traits)) {
-      return null;
-    }
-    if (kind === "image" && !isValidImageMeta(obj.image)) {
-      return null;
-    }
-
-    return {
-      kind,
-      traits: (obj.traits as CharacterTraits | null) ?? null,
-      source: (obj.source as AvatarSource | null) ?? null,
-      image: (obj.image as AvatarImageMeta | null) ?? null,
-    };
+    return parseAvatarManifest(
+      JSON.parse(readFileSync(manifestPath, "utf-8")) as unknown,
+    );
   } catch (err) {
     log.warn({ err }, "Failed to read avatar manifest — treating as absent");
     return null;
@@ -167,24 +104,16 @@ export function computeImageMeta(imagePath: string): AvatarImageMeta {
  * Used by the read handlers to self-heal once on a manifest-miss: the derived
  * state is persisted via `writeManifest` so subsequent reads are manifest-only.
  *
- * Inference is **traits-first**: whenever a valid `character-traits.json`
- * exists, the result is `character` regardless of whether a PNG is also
- * present. We deliberately do NOT compare mtimes to break the both-present
- * tie, because the builder writes the rendered PNG *after* the traits file
- * (see traits-png-sync.ts), so the PNG is always newer even when the
- * character is the source of truth. Comparing mtimes would misclassify a
- * builder-generated character as an uploaded image.
+ * Inference is traits-first (see `deriveAvatarFromLegacyFiles`).
  */
 export function deriveStateFromLegacyFiles(
   avatarDir: string = getAvatarDir(),
 ): AvatarState {
-  const traitsPath = join(avatarDir, TRAITS_FILENAME);
+  const traitsPath = join(avatarDir, AVATAR_TRAITS_FILENAME);
+  let traitsJson: unknown;
   if (existsSync(traitsPath)) {
     try {
-      const traits = JSON.parse(readFileSync(traitsPath, "utf-8")) as unknown;
-      if (isValidTraits(traits)) {
-        return { kind: "character", traits, source: null, image: null };
-      }
+      traitsJson = JSON.parse(readFileSync(traitsPath, "utf-8")) as unknown;
     } catch (err) {
       log.warn(
         { err },
@@ -194,14 +123,26 @@ export function deriveStateFromLegacyFiles(
   }
 
   const imagePath = join(avatarDir, AVATAR_IMAGE_FILENAME);
-  if (existsSync(imagePath)) {
-    return {
-      kind: "image",
-      traits: null,
-      source: null,
-      image: computeImageMeta(imagePath),
-    };
+  const derived = deriveAvatarFromLegacyFiles({
+    traitsJson,
+    hasImage: existsSync(imagePath),
+  });
+  switch (derived.kind) {
+    case "character":
+      return {
+        kind: "character",
+        traits: derived.traits,
+        source: null,
+        image: null,
+      };
+    case "image":
+      return {
+        kind: "image",
+        traits: null,
+        source: null,
+        image: computeImageMeta(imagePath),
+      };
+    case "none":
+      return { kind: "none", traits: null, source: null, image: null };
   }
-
-  return { kind: "none", traits: null, source: null, image: null };
 }

--- a/assistant/src/avatar/avatar-store.ts
+++ b/assistant/src/avatar/avatar-store.ts
@@ -15,13 +15,13 @@ import { randomUUID } from "node:crypto";
 import { mkdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
-import { getLogger } from "../util/logger.js";
 import {
   AVATAR_IMAGE_FILENAME,
   AVATAR_MANIFEST_FILENAME,
-  getAvatarDir,
-  getAvatarImagePath,
-} from "../util/platform.js";
+} from "@vellumai/avatar-manifest";
+
+import { getLogger } from "../util/logger.js";
+import { getAvatarDir, getAvatarImagePath } from "../util/platform.js";
 import {
   type AvatarSource,
   computeImageMeta,

--- a/assistant/src/avatar/resvg-lazy.test.ts
+++ b/assistant/src/avatar/resvg-lazy.test.ts
@@ -33,7 +33,6 @@ mock.module("../util/logger.js", () => ({
 }));
 
 mock.module("../util/platform.js", () => ({
-  AVATAR_IMAGE_FILENAME: "avatar-image.png",
   getAvatarDir: () => "/tmp/vellum-test-avatar-never-written",
 }));
 

--- a/assistant/src/avatar/traits-png-sync.ts
+++ b/assistant/src/avatar/traits-png-sync.ts
@@ -2,8 +2,14 @@ import { randomUUID } from "node:crypto";
 import { mkdirSync, renameSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
+import {
+  AVATAR_IMAGE_FILENAME,
+  AVATAR_TRAITS_FILENAME,
+  type CharacterTraits,
+} from "@vellumai/avatar-manifest";
+
 import { getLogger } from "../util/logger.js";
-import { AVATAR_IMAGE_FILENAME, getAvatarDir } from "../util/platform.js";
+import { getAvatarDir } from "../util/platform.js";
 import { renderCharacterAscii } from "./ascii-renderer.js";
 import { getCharacterComponents } from "./character-components.js";
 import { renderCharacterPng } from "./png-renderer.js";
@@ -12,16 +18,12 @@ import { isResvgAvailable } from "./resvg-lazy.js";
 const log = getLogger("traits-png-sync");
 
 /** Sidecar filename for the persisted character traits JSON. */
-export const TRAITS_FILENAME = "character-traits.json";
+export const TRAITS_FILENAME = AVATAR_TRAITS_FILENAME;
 
 /** Sidecar filename for the rendered ASCII art. */
 export const ASCII_FILENAME = "character-ascii.txt";
 
-export interface CharacterTraits {
-  bodyShape: string;
-  eyeStyle: string;
-  color: string;
-}
+export type { CharacterTraits } from "@vellumai/avatar-manifest";
 
 export type TraitsSyncResult =
   | { ok: true; asciiWritten: boolean }

--- a/assistant/src/background-wake/wake-intent-hooks.test.ts
+++ b/assistant/src/background-wake/wake-intent-hooks.test.ts
@@ -82,7 +82,6 @@ mock.module("../util/platform.js", () => ({
   getSandboxWorkingDir: () => testWorkspaceDir,
   getSoundsDir: () => workspacePath("data", "sounds"),
   getAvatarDir: () => workspacePath("data", "avatar"),
-  AVATAR_IMAGE_FILENAME: "avatar-image.png",
   getAvatarImagePath: () => workspacePath("data", "avatar", "avatar-image.png"),
   getXdgVellumConfigDirName: () => ".vellum",
   getProfilerRootDir: () => workspacePath("data", "profiler"),

--- a/assistant/src/daemon/config-watcher.ts
+++ b/assistant/src/daemon/config-watcher.ts
@@ -15,6 +15,8 @@ import {
 } from "node:fs";
 import { basename, join } from "node:path";
 
+import { AVATAR_IMAGE_FILENAME } from "@vellumai/avatar-manifest";
+
 import { getConfig, invalidateConfigCache } from "../config/loader.js";
 import type { MemoryCleanupConfig } from "../config/schemas/memory-lifecycle.js";
 import { resetCleanupScheduleThrottle } from "../persistence/cleanup-schedule-state.js";
@@ -37,7 +39,6 @@ import { WORKSPACE_THEME_RELATIVE_PATH } from "../theme/workspace-theme.js";
 import { DebouncerMap } from "../util/debounce.js";
 import { getLogger } from "../util/logger.js";
 import {
-  AVATAR_IMAGE_FILENAME,
   getAvatarDir,
   getSignalsDir,
   getSoundsDir,

--- a/assistant/src/heartbeat/__tests__/heartbeat-service.test.ts
+++ b/assistant/src/heartbeat/__tests__/heartbeat-service.test.ts
@@ -75,7 +75,6 @@ mock.module("../../util/platform.js", () => ({
   getSandboxWorkingDir: () => join(workspaceDir ?? fallbackDir, "sandbox/work"),
   getSoundsDir: () => join(workspaceDir ?? fallbackDir, "sounds"),
   getAvatarDir: () => join(workspaceDir ?? fallbackDir, "avatar"),
-  AVATAR_IMAGE_FILENAME: "avatar-image.png",
   getAvatarImagePath: () =>
     join(workspaceDir ?? fallbackDir, "avatar/avatar-image.png"),
 

--- a/assistant/src/util/platform.ts
+++ b/assistant/src/util/platform.ts
@@ -2,6 +2,11 @@ import { chmodSync, existsSync, mkdirSync, realpathSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { basename, dirname, join, sep } from "node:path";
 
+import {
+  AVATAR_IMAGE_FILENAME,
+  AVATAR_MANIFEST_FILENAME,
+  resolveAvatarDir,
+} from "@vellumai/avatar-manifest";
 import { SEEDS } from "@vellumai/environments";
 
 import { getWorkspaceDirOverride } from "../config/env-registry.js";
@@ -160,19 +165,13 @@ export function getSoundsDir(): string {
 
 /** Returns the avatar directory ($VELLUM_WORKSPACE_DIR/data/avatar). */
 export function getAvatarDir(): string {
-  return join(getWorkspaceDir(), "data", "avatar");
+  return resolveAvatarDir(getWorkspaceDir());
 }
-
-/** Canonical filename for the custom avatar PNG. */
-export const AVATAR_IMAGE_FILENAME = "avatar-image.png";
 
 /** Returns the canonical avatar image path ($VELLUM_WORKSPACE_DIR/data/avatar/avatar-image.png). */
 export function getAvatarImagePath(): string {
   return join(getAvatarDir(), AVATAR_IMAGE_FILENAME);
 }
-
-/** Canonical filename for the avatar state manifest. */
-export const AVATAR_MANIFEST_FILENAME = "avatar.json";
 
 /** Returns the canonical avatar manifest path ($VELLUM_WORKSPACE_DIR/data/avatar/avatar.json). */
 export function getAvatarManifestPath(): string {

--- a/bun.lock
+++ b/bun.lock
@@ -20,6 +20,7 @@
         "@qdrant/js-client-rest": "1.17.0",
         "@resvg/resvg-js": "2.6.2",
         "@slack/types": "2.22.0",
+        "@vellumai/avatar-manifest": "workspace:*",
         "@vellumai/ces-client": "workspace:*",
         "@vellumai/credential-storage": "workspace:*",
         "@vellumai/egress-proxy": "workspace:*",
@@ -391,6 +392,14 @@
         "typescript": "5.9.3",
       },
     },
+    "packages/avatar-manifest": {
+      "name": "@vellumai/avatar-manifest",
+      "version": "0.0.1",
+      "devDependencies": {
+        "@types/bun": "1.3.11",
+        "typescript": "5.9.3",
+      },
+    },
     "packages/ces-client": {
       "name": "@vellumai/ces-client",
       "version": "0.0.1",
@@ -505,6 +514,7 @@
       "name": "@vellumai/electron-desktop",
       "version": "0.0.1",
       "dependencies": {
+        "@vellumai/avatar-manifest": "workspace:*",
         "@vellumai/electron-utils": "workspace:*",
         "@vellumai/ipc-contract": "workspace:*",
         "@vellumai/local-mode": "workspace:*",
@@ -1838,6 +1848,8 @@
     "@vellumai/assistant-api": ["@vellumai/assistant-api@workspace:assistant/src/api"],
 
     "@vellumai/assistant-client": ["@vellumai/assistant-client@workspace:packages/assistant-client"],
+
+    "@vellumai/avatar-manifest": ["@vellumai/avatar-manifest@workspace:packages/avatar-manifest"],
 
     "@vellumai/ces-client": ["@vellumai/ces-client@workspace:packages/ces-client"],
 
@@ -4375,6 +4387,8 @@
 
     "@unrs/resolver-binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
 
+    "@vellumai/avatar-manifest/@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
+
     "@vellumai/ces-client/@types/bun": ["@types/bun@1.2.4", "", { "dependencies": { "bun-types": "1.2.4" } }, "sha512-QtuV5OMR8/rdKJs213iwXDpfVvnskPXY/S0ZiFbsTjQZycuqPbMW8Gf/XhLfwE5njW8sxI2WjISURXPlHypMFA=="],
 
     "@vellumai/ces-client/typescript": ["typescript@5.7.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw=="],
@@ -5025,6 +5039,8 @@
 
     "@unrs/resolver-binding-wasm32-wasi/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
 
+    "@vellumai/avatar-manifest/@types/bun/bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
+
     "@vellumai/ces-client/@types/bun/bun-types": ["bun-types@1.2.4", "", { "dependencies": { "@types/node": "*", "@types/ws": "~8.5.10" } }, "sha512-nDPymR207ZZEoWD4AavvEaa/KZe/qlrbMSchqpQwovPZCKc7pwMoENjEtHgMKaAjJhy+x6vfqSBA1QU3bJgs0Q=="],
 
     "@vellumai/cli/@types/bun/bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
@@ -5515,6 +5531,8 @@
 
     "@tailwindcss/postcss/@tailwindcss/oxide/@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "@vellumai/avatar-manifest/@types/bun/bun-types/@types/node": ["@types/node@26.1.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw=="],
+
     "@vellumai/ces-client/@types/bun/bun-types/@types/node": ["@types/node@26.1.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw=="],
 
     "@vellumai/ces-client/@types/bun/bun-types/@types/ws": ["@types/ws@8.5.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-bd/YFLW+URhBzMXurx7lWByOu+xzU9+kb3RboOteXYDfW+tr+JZa99OyNmPINEGB/ahzKrEuc8rcv4gnpJmxTw=="],
@@ -5954,6 +5972,8 @@
     "temp/rimraf/glob/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
     "@tailwindcss/postcss/@tailwindcss/oxide/@tailwindcss/oxide-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
+
+    "@vellumai/avatar-manifest/@types/bun/bun-types/@types/node/undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 
     "@vellumai/ces-client/@types/bun/bun-types/@types/node/undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "credential-executor",
     "gateway",
     "packages/assistant-client",
+    "packages/avatar-manifest",
     "packages/ces-client",
     "packages/credential-storage",
     "packages/design-library",

--- a/packages/avatar-manifest/package.json
+++ b/packages/avatar-manifest/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@vellumai/avatar-manifest",
+  "version": "0.0.1",
+  "private": true,
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "bunx tsc --noEmit",
+    "test": "bun test src/"
+  },
+  "devDependencies": {
+    "@types/bun": "1.3.11",
+    "typescript": "5.9.3"
+  }
+}

--- a/packages/avatar-manifest/src/__tests__/manifest.test.ts
+++ b/packages/avatar-manifest/src/__tests__/manifest.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  deriveAvatarFromLegacyFiles,
+  parseAvatarManifest,
+  resolveAvatarFromFiles,
+} from "../manifest.js";
+
+const traits = { bodyShape: "round", eyeStyle: "dot", color: "#abc" };
+const image = { updatedAt: "2026-01-01T00:00:00.000Z", etag: "abc" };
+
+describe("parseAvatarManifest", () => {
+  test("accepts a character manifest", () => {
+    expect(
+      parseAvatarManifest({ kind: "character", traits, source: "builder" }),
+    ).toEqual({ kind: "character", traits, source: "builder", image: null });
+  });
+
+  test("accepts an image manifest", () => {
+    expect(parseAvatarManifest({ kind: "image", image })).toEqual({
+      kind: "image",
+      traits: null,
+      source: null,
+      image,
+    });
+  });
+
+  test("accepts kind none without a payload", () => {
+    expect(parseAvatarManifest({ kind: "none" })).toEqual({
+      kind: "none",
+      traits: null,
+      source: null,
+      image: null,
+    });
+  });
+
+  test.each([
+    ["non-object", "nope"],
+    ["missing kind", {}],
+    ["invalid kind", { kind: "sprite", traits }],
+    ["character without traits", { kind: "character" }],
+    [
+      "character with incomplete traits",
+      { kind: "character", traits: { bodyShape: "round" } },
+    ],
+    ["image without meta", { kind: "image" }],
+    ["image with empty etag", { kind: "image", image: { ...image, etag: "" } }],
+  ])("rejects %s", (_label, value) => {
+    expect(parseAvatarManifest(value)).toBeNull();
+  });
+});
+
+describe("deriveAvatarFromLegacyFiles", () => {
+  test("valid traits win over a present image", () => {
+    expect(
+      deriveAvatarFromLegacyFiles({ traitsJson: traits, hasImage: true }),
+    ).toEqual({ kind: "character", traits });
+  });
+
+  test("invalid traits fall back to the image", () => {
+    expect(
+      deriveAvatarFromLegacyFiles({
+        traitsJson: { bodyShape: 1 },
+        hasImage: true,
+      }),
+    ).toEqual({ kind: "image" });
+  });
+
+  test("nothing usable yields none", () => {
+    expect(
+      deriveAvatarFromLegacyFiles({ traitsJson: undefined, hasImage: false }),
+    ).toEqual({ kind: "none" });
+  });
+});
+
+describe("resolveAvatarFromFiles", () => {
+  test("a valid manifest decides regardless of sidecars", () => {
+    expect(
+      resolveAvatarFromFiles({
+        manifestJson: { kind: "none" },
+        traitsJson: traits,
+        hasImage: true,
+      }),
+    ).toEqual({ kind: "none" });
+    expect(
+      resolveAvatarFromFiles({
+        manifestJson: { kind: "image", image },
+        traitsJson: traits,
+        hasImage: true,
+      }),
+    ).toEqual({ kind: "image", image });
+  });
+
+  test("a partial image manifest falls back to traits-first derivation", () => {
+    expect(
+      resolveAvatarFromFiles({
+        manifestJson: { kind: "image" },
+        traitsJson: traits,
+        hasImage: true,
+      }),
+    ).toEqual({ kind: "character", traits });
+  });
+
+  test("a legacy image carries no manifest metadata", () => {
+    expect(
+      resolveAvatarFromFiles({
+        manifestJson: undefined,
+        traitsJson: undefined,
+        hasImage: true,
+      }),
+    ).toEqual({ kind: "image", image: null });
+  });
+});

--- a/packages/avatar-manifest/src/__tests__/read.test.ts
+++ b/packages/avatar-manifest/src/__tests__/read.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { readWorkspaceAvatar } from "../read.js";
+
+const traits = { bodyShape: "round", eyeStyle: "dot", color: "#abc" };
+
+describe("readWorkspaceAvatar", () => {
+  let workspaceDir: string;
+  let avatarDir: string;
+
+  const write = (name: string, contents: string): void => {
+    mkdirSync(avatarDir, { recursive: true });
+    writeFileSync(join(avatarDir, name), contents);
+  };
+
+  beforeEach(() => {
+    workspaceDir = mkdtempSync(join(tmpdir(), "avatar-manifest-"));
+    avatarDir = join(workspaceDir, "data", "avatar");
+  });
+
+  afterEach(() => {
+    rmSync(workspaceDir, { recursive: true, force: true });
+  });
+
+  test("missing avatar dir yields none", () => {
+    expect(readWorkspaceAvatar(workspaceDir)).toEqual({ kind: "none" });
+  });
+
+  test("manifest character returns its traits", () => {
+    write("avatar.json", JSON.stringify({ kind: "character", traits }));
+    write("avatar-image.png", "png");
+    expect(readWorkspaceAvatar(workspaceDir)).toEqual({
+      kind: "character",
+      traits,
+    });
+  });
+
+  test("image resolves to the PNG path", () => {
+    write("avatar-image.png", "png");
+    expect(readWorkspaceAvatar(workspaceDir)).toEqual({
+      kind: "image",
+      imagePath: join(avatarDir, "avatar-image.png"),
+    });
+  });
+
+  test("corrupt manifest falls back to the traits sidecar", () => {
+    write("avatar.json", "{ not json");
+    write("character-traits.json", JSON.stringify(traits));
+    expect(readWorkspaceAvatar(workspaceDir)).toEqual({
+      kind: "character",
+      traits,
+    });
+  });
+});

--- a/packages/avatar-manifest/src/index.ts
+++ b/packages/avatar-manifest/src/index.ts
@@ -1,0 +1,35 @@
+/**
+ * @vellumai/avatar-manifest: the single source of truth for the on-disk
+ * avatar layout of an assistant workspace (`<workspace>/data/avatar`) and
+ * how its files resolve to an avatar.
+ *
+ * The daemon owns the files (it writes the manifest and sidecars); hosts
+ * such as the desktop app read them directly so a sleeping assistant still
+ * has an avatar in the chooser. Both go through the parsing and legacy
+ * derivation here so they cannot disagree. Leaf package: node builtins only.
+ */
+export {
+  AVATAR_DIR_SEGMENTS,
+  AVATAR_IMAGE_FILENAME,
+  AVATAR_MANIFEST_FILENAME,
+  AVATAR_TRAITS_FILENAME,
+  resolveAvatarDir,
+} from "./layout.js";
+export {
+  deriveAvatarFromLegacyFiles,
+  isValidAvatarImageMeta,
+  isValidCharacterTraits,
+  parseAvatarManifest,
+  resolveAvatarFromFiles,
+} from "./manifest.js";
+export type {
+  AvatarImageMeta,
+  AvatarKind,
+  AvatarSource,
+  AvatarState,
+  CharacterTraits,
+  LegacyAvatarDerivation,
+  ResolvedAvatar,
+} from "./manifest.js";
+export { readWorkspaceAvatar } from "./read.js";
+export type { WorkspaceAvatar } from "./read.js";

--- a/packages/avatar-manifest/src/layout.ts
+++ b/packages/avatar-manifest/src/layout.ts
@@ -1,0 +1,18 @@
+import { join } from "node:path";
+
+/** Path segments of the avatar directory below the workspace directory. */
+export const AVATAR_DIR_SEGMENTS: readonly string[] = ["data", "avatar"];
+
+/** Avatar state manifest. */
+export const AVATAR_MANIFEST_FILENAME = "avatar.json";
+
+/** Legacy sidecar holding the persisted character traits. */
+export const AVATAR_TRAITS_FILENAME = "character-traits.json";
+
+/** The avatar PNG (uploaded, or rendered from the character traits). */
+export const AVATAR_IMAGE_FILENAME = "avatar-image.png";
+
+/** The avatar directory for a workspace (`<workspace>/data/avatar`). */
+export function resolveAvatarDir(workspaceDir: string): string {
+  return join(workspaceDir, ...AVATAR_DIR_SEGMENTS);
+}

--- a/packages/avatar-manifest/src/manifest.ts
+++ b/packages/avatar-manifest/src/manifest.ts
@@ -1,0 +1,140 @@
+export type AvatarKind = "character" | "image" | "none";
+export type AvatarSource = "builder" | "upload" | "ai";
+
+export interface CharacterTraits {
+  bodyShape: string;
+  eyeStyle: string;
+  color: string;
+}
+
+export interface AvatarImageMeta {
+  updatedAt: string;
+  etag: string;
+}
+
+/** The persisted manifest (`avatar.json`). */
+export interface AvatarState {
+  kind: AvatarKind;
+  traits: CharacterTraits | null;
+  source: AvatarSource | null;
+  image: AvatarImageMeta | null;
+}
+
+const AVATAR_KINDS: ReadonlySet<string> = new Set<AvatarKind>([
+  "character",
+  "image",
+  "none",
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object";
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
+/** Narrows an unknown value to valid CharacterTraits (presence check only). */
+export function isValidCharacterTraits(
+  value: unknown,
+): value is CharacterTraits {
+  return (
+    isRecord(value) &&
+    isNonEmptyString(value.bodyShape) &&
+    isNonEmptyString(value.eyeStyle) &&
+    isNonEmptyString(value.color)
+  );
+}
+
+/** Narrows an unknown value to valid AvatarImageMeta (presence check only). */
+export function isValidAvatarImageMeta(
+  value: unknown,
+): value is AvatarImageMeta {
+  return (
+    isRecord(value) &&
+    isNonEmptyString(value.updatedAt) &&
+    isNonEmptyString(value.etag)
+  );
+}
+
+/**
+ * Validates a parsed `avatar.json`. Returns `null` for a non-object, an
+ * invalid or missing `kind`, or a valid `kind` whose per-kind payload is
+ * missing or malformed, so callers fall back to legacy derivation instead
+ * of surfacing an avatar with null traits/image.
+ */
+export function parseAvatarManifest(value: unknown): AvatarState | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+  if (typeof value.kind !== "string" || !AVATAR_KINDS.has(value.kind)) {
+    return null;
+  }
+  const kind = value.kind as AvatarKind;
+  if (kind === "character" && !isValidCharacterTraits(value.traits)) {
+    return null;
+  }
+  if (kind === "image" && !isValidAvatarImageMeta(value.image)) {
+    return null;
+  }
+  return {
+    kind,
+    traits: (value.traits as CharacterTraits | null) ?? null,
+    source: (value.source as AvatarSource | null) ?? null,
+    image: (value.image as AvatarImageMeta | null) ?? null,
+  };
+}
+
+export type LegacyAvatarDerivation =
+  | { kind: "character"; traits: CharacterTraits }
+  | { kind: "image" }
+  | { kind: "none" };
+
+/**
+ * Derives the avatar from the legacy sidecar files when there is no usable
+ * manifest. Traits-first: valid traits win even when the PNG also exists,
+ * because the builder writes the rendered PNG after the traits file, so
+ * mtimes cannot tell a built character from an uploaded image.
+ */
+export function deriveAvatarFromLegacyFiles(input: {
+  traitsJson: unknown;
+  hasImage: boolean;
+}): LegacyAvatarDerivation {
+  if (isValidCharacterTraits(input.traitsJson)) {
+    return { kind: "character", traits: input.traitsJson };
+  }
+  return input.hasImage ? { kind: "image" } : { kind: "none" };
+}
+
+export type ResolvedAvatar =
+  | { kind: "character"; traits: CharacterTraits }
+  | { kind: "image"; image: AvatarImageMeta | null }
+  | { kind: "none" };
+
+/**
+ * Resolves the avatar from the parsed avatar files: the manifest when it is
+ * valid, otherwise the legacy derivation. `image` carries the manifest's
+ * metadata when the manifest decided, and is null for a legacy PNG.
+ */
+export function resolveAvatarFromFiles(input: {
+  manifestJson: unknown;
+  traitsJson: unknown;
+  hasImage: boolean;
+}): ResolvedAvatar {
+  const manifest = parseAvatarManifest(input.manifestJson);
+  if (manifest) {
+    switch (manifest.kind) {
+      case "character":
+        return {
+          kind: "character",
+          traits: manifest.traits as CharacterTraits,
+        };
+      case "image":
+        return { kind: "image", image: manifest.image };
+      case "none":
+        return { kind: "none" };
+    }
+  }
+  const legacy = deriveAvatarFromLegacyFiles(input);
+  return legacy.kind === "image" ? { kind: "image", image: null } : legacy;
+}

--- a/packages/avatar-manifest/src/read.ts
+++ b/packages/avatar-manifest/src/read.ts
@@ -1,0 +1,39 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  AVATAR_IMAGE_FILENAME,
+  AVATAR_MANIFEST_FILENAME,
+  AVATAR_TRAITS_FILENAME,
+  resolveAvatarDir,
+} from "./layout.js";
+import { type CharacterTraits, resolveAvatarFromFiles } from "./manifest.js";
+
+export type WorkspaceAvatar =
+  | { kind: "character"; traits: CharacterTraits }
+  | { kind: "image"; imagePath: string }
+  | { kind: "none" };
+
+function readJsonFile(filePath: string): unknown {
+  try {
+    return JSON.parse(readFileSync(filePath, "utf-8")) as unknown;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Reads the avatar of a workspace directly off disk. Unreadable or corrupt
+ * files count as absent. For an image avatar the caller reads the PNG at
+ * `imagePath` itself, applying its own size policy; the file may be missing.
+ */
+export function readWorkspaceAvatar(workspaceDir: string): WorkspaceAvatar {
+  const avatarDir = resolveAvatarDir(workspaceDir);
+  const imagePath = join(avatarDir, AVATAR_IMAGE_FILENAME);
+  const resolved = resolveAvatarFromFiles({
+    manifestJson: readJsonFile(join(avatarDir, AVATAR_MANIFEST_FILENAME)),
+    traitsJson: readJsonFile(join(avatarDir, AVATAR_TRAITS_FILENAME)),
+    hasImage: existsSync(imagePath),
+  });
+  return resolved.kind === "image" ? { kind: "image", imagePath } : resolved;
+}

--- a/packages/avatar-manifest/tsconfig.json
+++ b/packages/avatar-manifest/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "types": ["bun"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/electron-desktop/package.json
+++ b/packages/electron-desktop/package.json
@@ -87,6 +87,7 @@
     "test": "bun scripts/run-tests.ts"
   },
   "dependencies": {
+    "@vellumai/avatar-manifest": "workspace:*",
     "@vellumai/electron-utils": "workspace:*",
     "@vellumai/ipc-contract": "workspace:*",
     "@vellumai/local-mode": "workspace:*",

--- a/packages/electron-desktop/src/local-mode-bridge.ts
+++ b/packages/electron-desktop/src/local-mode-bridge.ts
@@ -15,6 +15,8 @@ export const createLocalModeBridge = (
     ipc.invoke("vellum:localMode:hatch", species, remote),
   listDevices: (assistantId) =>
     ipc.invoke("vellum:localMode:listDevices", assistantId),
+  readAssistantAvatar: (assistantId) =>
+    ipc.invoke("vellum:localMode:readAssistantAvatar", assistantId),
   readLockfile: () => ipc.invoke("vellum:localMode:readLockfile"),
   renameLockfileAssistant: (assistantId, name) =>
     ipc.invoke("vellum:localMode:renameLockfileAssistant", assistantId, name),

--- a/packages/electron-desktop/src/local-mode.test.ts
+++ b/packages/electron-desktop/src/local-mode.test.ts
@@ -1310,3 +1310,153 @@ describe("vellum:localMode:guardianToken handler", () => {
     expect(spawnArgs).toHaveLength(0);
   });
 });
+
+describe("vellum:localMode:readAssistantAvatar handler", () => {
+  type AvatarResult =
+    | { ok: true; avatar: Record<string, unknown> | null }
+    | { ok: false; error: string };
+  const readAssistantAvatar = (assistantId?: unknown): AvatarResult =>
+    handlers["vellum:localMode:readAssistantAvatar"](
+      allowedEvent,
+      assistantId,
+    ) as AvatarResult;
+
+  const traits = { bodyShape: "round", eyeStyle: "dot", color: "#abc" };
+  const png = Buffer.from("89504e470d0a1a0a", "hex");
+  let instanceDir: string;
+  let avatarDir: string;
+
+  const writeLockfileEntry = (resources?: Record<string, unknown>): void => {
+    fs.writeFileSync(
+      lockfilePath,
+      JSON.stringify({
+        assistants: [
+          {
+            assistantId: "asst-1",
+            cloud: "local",
+            runtimeUrl: "http://127.0.0.1:1",
+            resources,
+          },
+        ],
+        activeAssistant: "asst-1",
+      }),
+    );
+  };
+  const writeAvatarFile = (name: string, contents: string | Buffer): void => {
+    fs.mkdirSync(avatarDir, { recursive: true });
+    fs.writeFileSync(path.join(avatarDir, name), contents);
+  };
+
+  beforeEach(() => {
+    instanceDir = fs.mkdtempSync(path.join(os.tmpdir(), "vellum-instance-"));
+    avatarDir = path.join(instanceDir, ".vellum", "workspace", "data", "avatar");
+    writeLockfileEntry({ instanceDir, gatewayPort: 1, daemonPort: 2 });
+  });
+
+  afterEach(() => {
+    fs.rmSync(instanceDir, { recursive: true, force: true });
+    fs.rmSync(lockfilePath, { force: true });
+  });
+
+  test("manifest character returns its traits even when a raster exists", () => {
+    writeAvatarFile("avatar.json", JSON.stringify({ kind: "character", traits }));
+    writeAvatarFile("avatar-image.png", png);
+
+    expect(readAssistantAvatar("asst-1")).toEqual({
+      ok: true,
+      avatar: { kind: "character", traits },
+    });
+  });
+
+  test("manifest image returns the PNG base64", () => {
+    writeAvatarFile("avatar.json", JSON.stringify({ kind: "image" }));
+    writeAvatarFile("avatar-image.png", png);
+
+    expect(readAssistantAvatar("asst-1")).toEqual({
+      ok: true,
+      avatar: { kind: "image", imageBase64: png.toString("base64") },
+    });
+  });
+
+  test("manifest none yields null despite sidecar files", () => {
+    writeAvatarFile("avatar.json", JSON.stringify({ kind: "none" }));
+    writeAvatarFile("character-traits.json", JSON.stringify(traits));
+    writeAvatarFile("avatar-image.png", png);
+
+    expect(readAssistantAvatar("asst-1")).toEqual({ ok: true, avatar: null });
+  });
+
+  test("legacy: traits file wins over the raster", () => {
+    writeAvatarFile("character-traits.json", JSON.stringify(traits));
+    writeAvatarFile("avatar-image.png", png);
+
+    expect(readAssistantAvatar("asst-1")).toEqual({
+      ok: true,
+      avatar: { kind: "character", traits },
+    });
+  });
+
+  test("legacy: PNG alone yields image", () => {
+    writeAvatarFile("avatar-image.png", png);
+
+    expect(readAssistantAvatar("asst-1")).toEqual({
+      ok: true,
+      avatar: { kind: "image", imageBase64: png.toString("base64") },
+    });
+  });
+
+  test("empty avatar dir yields null", () => {
+    fs.mkdirSync(avatarDir, { recursive: true });
+
+    expect(readAssistantAvatar("asst-1")).toEqual({ ok: true, avatar: null });
+  });
+
+  test("missing lockfile entry yields null", () => {
+    expect(readAssistantAvatar("asst-gone")).toEqual({ ok: true, avatar: null });
+  });
+
+  test("entry without an instanceDir yields null", () => {
+    writeLockfileEntry({ gatewayPort: 1, daemonPort: 2 });
+
+    expect(readAssistantAvatar("asst-1")).toEqual({ ok: true, avatar: null });
+  });
+
+  test("oversized image yields null", () => {
+    writeAvatarFile("avatar.json", JSON.stringify({ kind: "image" }));
+    writeAvatarFile("avatar-image.png", Buffer.alloc(5 * 1024 * 1024 + 1));
+
+    expect(readAssistantAvatar("asst-1")).toEqual({ ok: true, avatar: null });
+  });
+
+  test("malformed manifest falls back to legacy inference", () => {
+    writeAvatarFile("avatar.json", "{ not json");
+    writeAvatarFile("character-traits.json", JSON.stringify(traits));
+
+    expect(readAssistantAvatar("asst-1")).toEqual({
+      ok: true,
+      avatar: { kind: "character", traits },
+    });
+  });
+
+  test("manifest character with malformed traits is treated as absent", () => {
+    writeAvatarFile(
+      "avatar.json",
+      JSON.stringify({ kind: "character", traits: { bodyShape: "round" } }),
+    );
+
+    expect(readAssistantAvatar("asst-1")).toEqual({ ok: true, avatar: null });
+
+    writeAvatarFile("avatar-image.png", png);
+    expect(readAssistantAvatar("asst-1")).toEqual({
+      ok: true,
+      avatar: { kind: "image", imageBase64: png.toString("base64") },
+    });
+  });
+
+  test("missing assistantId is a structured error", () => {
+    expect(readAssistantAvatar(undefined)).toEqual({
+      ok: false,
+      error: "Missing assistantId",
+    });
+  });
+});

--- a/packages/electron-desktop/src/local-mode.test.ts
+++ b/packages/electron-desktop/src/local-mode.test.ts
@@ -1322,11 +1322,15 @@ describe("vellum:localMode:readAssistantAvatar handler", () => {
     ) as AvatarResult;
 
   const traits = { bodyShape: "round", eyeStyle: "dot", color: "#abc" };
+  const imageMeta = { updatedAt: "2026-01-01T00:00:00.000Z", etag: "abc" };
   const png = Buffer.from("89504e470d0a1a0a", "hex");
   let instanceDir: string;
   let avatarDir: string;
 
-  const writeLockfileEntry = (resources?: Record<string, unknown>): void => {
+  const writeLockfileEntry = (
+    resources?: Record<string, unknown>,
+    extra: Record<string, unknown> = {},
+  ): void => {
     fs.writeFileSync(
       lockfilePath,
       JSON.stringify({
@@ -1336,6 +1340,7 @@ describe("vellum:localMode:readAssistantAvatar handler", () => {
             cloud: "local",
             runtimeUrl: "http://127.0.0.1:1",
             resources,
+            ...extra,
           },
         ],
         activeAssistant: "asst-1",
@@ -1349,7 +1354,13 @@ describe("vellum:localMode:readAssistantAvatar handler", () => {
 
   beforeEach(() => {
     instanceDir = fs.mkdtempSync(path.join(os.tmpdir(), "vellum-instance-"));
-    avatarDir = path.join(instanceDir, ".vellum", "workspace", "data", "avatar");
+    avatarDir = path.join(
+      instanceDir,
+      ".vellum",
+      "workspace",
+      "data",
+      "avatar",
+    );
     writeLockfileEntry({ instanceDir, gatewayPort: 1, daemonPort: 2 });
   });
 
@@ -1359,7 +1370,10 @@ describe("vellum:localMode:readAssistantAvatar handler", () => {
   });
 
   test("manifest character returns its traits even when a raster exists", () => {
-    writeAvatarFile("avatar.json", JSON.stringify({ kind: "character", traits }));
+    writeAvatarFile(
+      "avatar.json",
+      JSON.stringify({ kind: "character", traits }),
+    );
     writeAvatarFile("avatar-image.png", png);
 
     expect(readAssistantAvatar("asst-1")).toEqual({
@@ -1369,7 +1383,10 @@ describe("vellum:localMode:readAssistantAvatar handler", () => {
   });
 
   test("manifest image returns the PNG base64", () => {
-    writeAvatarFile("avatar.json", JSON.stringify({ kind: "image" }));
+    writeAvatarFile(
+      "avatar.json",
+      JSON.stringify({ kind: "image", image: imageMeta }),
+    );
     writeAvatarFile("avatar-image.png", png);
 
     expect(readAssistantAvatar("asst-1")).toEqual({
@@ -1412,7 +1429,10 @@ describe("vellum:localMode:readAssistantAvatar handler", () => {
   });
 
   test("missing lockfile entry yields null", () => {
-    expect(readAssistantAvatar("asst-gone")).toEqual({ ok: true, avatar: null });
+    expect(readAssistantAvatar("asst-gone")).toEqual({
+      ok: true,
+      avatar: null,
+    });
   });
 
   test("entry without an instanceDir yields null", () => {
@@ -1421,8 +1441,21 @@ describe("vellum:localMode:readAssistantAvatar handler", () => {
     expect(readAssistantAvatar("asst-1")).toEqual({ ok: true, avatar: null });
   });
 
+  test("legacy lockfile entry with only baseDataDir resolves", () => {
+    writeLockfileEntry(undefined, { baseDataDir: instanceDir });
+    writeAvatarFile("character-traits.json", JSON.stringify(traits));
+
+    expect(readAssistantAvatar("asst-1")).toEqual({
+      ok: true,
+      avatar: { kind: "character", traits },
+    });
+  });
+
   test("oversized image yields null", () => {
-    writeAvatarFile("avatar.json", JSON.stringify({ kind: "image" }));
+    writeAvatarFile(
+      "avatar.json",
+      JSON.stringify({ kind: "image", image: imageMeta }),
+    );
     writeAvatarFile("avatar-image.png", Buffer.alloc(5 * 1024 * 1024 + 1));
 
     expect(readAssistantAvatar("asst-1")).toEqual({ ok: true, avatar: null });
@@ -1430,6 +1463,30 @@ describe("vellum:localMode:readAssistantAvatar handler", () => {
 
   test("malformed manifest falls back to legacy inference", () => {
     writeAvatarFile("avatar.json", "{ not json");
+    writeAvatarFile("character-traits.json", JSON.stringify(traits));
+
+    expect(readAssistantAvatar("asst-1")).toEqual({
+      ok: true,
+      avatar: { kind: "character", traits },
+    });
+  });
+
+  test("manifest image without image metadata falls back to legacy inference", () => {
+    writeAvatarFile("avatar.json", JSON.stringify({ kind: "image" }));
+    writeAvatarFile("character-traits.json", JSON.stringify(traits));
+    writeAvatarFile("avatar-image.png", png);
+
+    expect(readAssistantAvatar("asst-1")).toEqual({
+      ok: true,
+      avatar: { kind: "character", traits },
+    });
+  });
+
+  test("manifest image with malformed image metadata falls back to legacy inference", () => {
+    writeAvatarFile(
+      "avatar.json",
+      JSON.stringify({ kind: "image", image: { updatedAt: "" } }),
+    );
     writeAvatarFile("character-traits.json", JSON.stringify(traits));
 
     expect(readAssistantAvatar("asst-1")).toEqual({

--- a/packages/electron-desktop/src/local-mode.ts
+++ b/packages/electron-desktop/src/local-mode.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { z } from "zod";
 
+import { readWorkspaceAvatar } from "@vellumai/avatar-manifest";
 import {
   connectImport,
   getGuardianAccessToken,
@@ -324,30 +325,9 @@ export async function getPairedGuardianAccessToken(
   );
 }
 
-// Workspace avatar layout, mirroring `assistant/src/util/platform.ts` and
-// `assistant/src/avatar/`. Read directly off disk so a sleeping sibling
-// assistant still has an avatar in the chooser.
-const AVATAR_MANIFEST_FILENAME = "avatar.json";
-const AVATAR_TRAITS_FILENAME = "character-traits.json";
-const AVATAR_IMAGE_FILENAME = "avatar-image.png";
 const AVATAR_IMAGE_MAX_BYTES = 5 * 1024 * 1024;
 
-const characterTraitsSchema = z.object({
-  bodyShape: z.string().min(1),
-  eyeStyle: z.string().min(1),
-  color: z.string().min(1),
-});
-
-function readJsonFile(filePath: string): unknown {
-  try {
-    return JSON.parse(fs.readFileSync(filePath, "utf-8")) as unknown;
-  } catch {
-    return undefined;
-  }
-}
-
-function readAvatarImage(avatarDir: string): LocalAssistantAvatar | null {
-  const imagePath = path.join(avatarDir, AVATAR_IMAGE_FILENAME);
+function readAvatarImage(imagePath: string): LocalAssistantAvatar | null {
   try {
     const stats = fs.statSync(imagePath);
     if (!stats.isFile() || stats.size > AVATAR_IMAGE_MAX_BYTES) {
@@ -362,51 +342,8 @@ function readAvatarImage(avatarDir: string): LocalAssistantAvatar | null {
   }
 }
 
-// Mirrors the daemon's `readManifest` validation in
-// `assistant/src/avatar/avatar-manifest.ts` (the packages cannot import each
-// other): a valid `kind` with a missing or malformed per-kind payload is
-// rejected as a whole so the legacy fallback still runs.
-const avatarManifestSchema = z.discriminatedUnion("kind", [
-  z.object({ kind: z.literal("character"), traits: characterTraitsSchema }),
-  z.object({
-    kind: z.literal("image"),
-    image: z.object({ updatedAt: z.string().min(1), etag: z.string().min(1) }),
-  }),
-  z.object({ kind: z.literal("none") }),
-]);
-
-function toCharacterAvatar(traits: unknown): LocalAssistantAvatar | null {
-  const parsed = characterTraitsSchema.safeParse(traits);
-  return parsed.success ? { kind: "character", traits: parsed.data } : null;
-}
-
-/**
- * Manifest first, then the legacy traits-first inference from
- * `deriveStateFromLegacyFiles`: a traits file always wins over the PNG
- * because character builds write the raster too. A corrupt or partial
- * manifest is treated as absent, as the daemon's `readManifest` does.
- */
-function readWorkspaceAvatar(avatarDir: string): LocalAssistantAvatar | null {
-  const manifest = avatarManifestSchema.safeParse(
-    readJsonFile(path.join(avatarDir, AVATAR_MANIFEST_FILENAME)),
-  );
-  if (manifest.success) {
-    switch (manifest.data.kind) {
-      case "character":
-        return { kind: "character", traits: manifest.data.traits };
-      case "image":
-        return readAvatarImage(avatarDir);
-      case "none":
-        return null;
-    }
-  }
-  return (
-    toCharacterAvatar(
-      readJsonFile(path.join(avatarDir, AVATAR_TRAITS_FILENAME)),
-    ) ?? readAvatarImage(avatarDir)
-  );
-}
-
+// Read directly off disk so a sleeping sibling assistant still has an
+// avatar in the chooser.
 function readAssistantAvatar(
   lockfilePaths: string[],
   assistantId: string,
@@ -415,14 +352,17 @@ function readAssistantAvatar(
   if (!instanceDir) {
     return { ok: true, avatar: null };
   }
-  const avatarDir = path.join(
-    instanceDir,
-    ".vellum",
-    "workspace",
-    "data",
-    "avatar",
+  const avatar = readWorkspaceAvatar(
+    path.join(instanceDir, ".vellum", "workspace"),
   );
-  return { ok: true, avatar: readWorkspaceAvatar(avatarDir) };
+  switch (avatar.kind) {
+    case "character":
+      return { ok: true, avatar: { kind: "character", traits: avatar.traits } };
+    case "image":
+      return { ok: true, avatar: readAvatarImage(avatar.imagePath) };
+    case "none":
+      return { ok: true, avatar: null };
+  }
 }
 
 // A persisted assistant entry as it crosses the IPC boundary. The

--- a/packages/electron-desktop/src/local-mode.ts
+++ b/packages/electron-desktop/src/local-mode.ts
@@ -13,6 +13,7 @@ import {
   getLockfileData,
   getLocalAssistantStatus,
   replacePlatformAssistants,
+  resolveLockfileInstanceDir,
   runDevicesList,
   runDevicesRevoke,
   runHatch,
@@ -361,6 +362,19 @@ function readAvatarImage(avatarDir: string): LocalAssistantAvatar | null {
   }
 }
 
+// Mirrors the daemon's `readManifest` validation in
+// `assistant/src/avatar/avatar-manifest.ts` (the packages cannot import each
+// other): a valid `kind` with a missing or malformed per-kind payload is
+// rejected as a whole so the legacy fallback still runs.
+const avatarManifestSchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("character"), traits: characterTraitsSchema }),
+  z.object({
+    kind: z.literal("image"),
+    image: z.object({ updatedAt: z.string().min(1), etag: z.string().min(1) }),
+  }),
+  z.object({ kind: z.literal("none") }),
+]);
+
 function toCharacterAvatar(traits: unknown): LocalAssistantAvatar | null {
   const parsed = characterTraitsSchema.safeParse(traits);
   return parsed.success ? { kind: "character", traits: parsed.data } : null;
@@ -373,18 +387,17 @@ function toCharacterAvatar(traits: unknown): LocalAssistantAvatar | null {
  * manifest is treated as absent, as the daemon's `readManifest` does.
  */
 function readWorkspaceAvatar(avatarDir: string): LocalAssistantAvatar | null {
-  const manifest = readJsonFile(path.join(avatarDir, AVATAR_MANIFEST_FILENAME));
-  if (manifest && typeof manifest === "object") {
-    const { kind, traits } = manifest as Record<string, unknown>;
-    const character = kind === "character" ? toCharacterAvatar(traits) : null;
-    if (character) {
-      return character;
-    }
-    if (kind === "image") {
-      return readAvatarImage(avatarDir);
-    }
-    if (kind === "none") {
-      return null;
+  const manifest = avatarManifestSchema.safeParse(
+    readJsonFile(path.join(avatarDir, AVATAR_MANIFEST_FILENAME)),
+  );
+  if (manifest.success) {
+    switch (manifest.data.kind) {
+      case "character":
+        return { kind: "character", traits: manifest.data.traits };
+      case "image":
+        return readAvatarImage(avatarDir);
+      case "none":
+        return null;
     }
   }
   return (
@@ -398,13 +411,7 @@ function readAssistantAvatar(
   lockfilePaths: string[],
   assistantId: string,
 ): LocalReadAssistantAvatarResult {
-  const lockfile = getLockfileData(lockfilePaths);
-  if (!lockfile.ok) {
-    return { ok: true, avatar: null };
-  }
-  const instanceDir = lockfile.data.assistants.find(
-    (entry) => entry.assistantId === assistantId,
-  )?.resources?.instanceDir;
+  const instanceDir = resolveLockfileInstanceDir(lockfilePaths, assistantId);
   if (!instanceDir) {
     return { ok: true, avatar: null };
   }

--- a/packages/electron-desktop/src/local-mode.ts
+++ b/packages/electron-desktop/src/local-mode.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+import path from "node:path";
 import { z } from "zod";
 
 import {
@@ -28,8 +30,10 @@ import {
   type WakeOptions,
 } from "@vellumai/local-mode";
 import type {
+  LocalAssistantAvatar,
   LocalConnectImportResult,
   LocalListDevicesResult,
+  LocalReadAssistantAvatarResult,
   LocalRevokeDeviceResult,
 } from "@vellumai/ipc-contract";
 import { capabilityToken } from "./capability-registry";
@@ -319,6 +323,101 @@ export async function getPairedGuardianAccessToken(
   );
 }
 
+// Workspace avatar layout, mirroring `assistant/src/util/platform.ts` and
+// `assistant/src/avatar/`. Read directly off disk so a sleeping sibling
+// assistant still has an avatar in the chooser.
+const AVATAR_MANIFEST_FILENAME = "avatar.json";
+const AVATAR_TRAITS_FILENAME = "character-traits.json";
+const AVATAR_IMAGE_FILENAME = "avatar-image.png";
+const AVATAR_IMAGE_MAX_BYTES = 5 * 1024 * 1024;
+
+const characterTraitsSchema = z.object({
+  bodyShape: z.string().min(1),
+  eyeStyle: z.string().min(1),
+  color: z.string().min(1),
+});
+
+function readJsonFile(filePath: string): unknown {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, "utf-8")) as unknown;
+  } catch {
+    return undefined;
+  }
+}
+
+function readAvatarImage(avatarDir: string): LocalAssistantAvatar | null {
+  const imagePath = path.join(avatarDir, AVATAR_IMAGE_FILENAME);
+  try {
+    const stats = fs.statSync(imagePath);
+    if (!stats.isFile() || stats.size > AVATAR_IMAGE_MAX_BYTES) {
+      return null;
+    }
+    return {
+      kind: "image",
+      imageBase64: fs.readFileSync(imagePath).toString("base64"),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function toCharacterAvatar(traits: unknown): LocalAssistantAvatar | null {
+  const parsed = characterTraitsSchema.safeParse(traits);
+  return parsed.success ? { kind: "character", traits: parsed.data } : null;
+}
+
+/**
+ * Manifest first, then the legacy traits-first inference from
+ * `deriveStateFromLegacyFiles`: a traits file always wins over the PNG
+ * because character builds write the raster too. A corrupt or partial
+ * manifest is treated as absent, as the daemon's `readManifest` does.
+ */
+function readWorkspaceAvatar(avatarDir: string): LocalAssistantAvatar | null {
+  const manifest = readJsonFile(path.join(avatarDir, AVATAR_MANIFEST_FILENAME));
+  if (manifest && typeof manifest === "object") {
+    const { kind, traits } = manifest as Record<string, unknown>;
+    const character = kind === "character" ? toCharacterAvatar(traits) : null;
+    if (character) {
+      return character;
+    }
+    if (kind === "image") {
+      return readAvatarImage(avatarDir);
+    }
+    if (kind === "none") {
+      return null;
+    }
+  }
+  return (
+    toCharacterAvatar(
+      readJsonFile(path.join(avatarDir, AVATAR_TRAITS_FILENAME)),
+    ) ?? readAvatarImage(avatarDir)
+  );
+}
+
+function readAssistantAvatar(
+  lockfilePaths: string[],
+  assistantId: string,
+): LocalReadAssistantAvatarResult {
+  const lockfile = getLockfileData(lockfilePaths);
+  if (!lockfile.ok) {
+    return { ok: true, avatar: null };
+  }
+  const instanceDir = lockfile.data.assistants.find(
+    (entry) => entry.assistantId === assistantId,
+  )?.resources?.instanceDir;
+  if (!instanceDir) {
+    return { ok: true, avatar: null };
+  }
+  const avatarDir = path.join(
+    instanceDir,
+    ".vellum",
+    "workspace",
+    "data",
+    "avatar",
+  );
+  return { ok: true, avatar: readWorkspaceAvatar(avatarDir) };
+}
+
 // A persisted assistant entry as it crosses the IPC boundary. The
 // package's lockfile parser owns the real field-level contract; here we
 // only assert the renderer sent an object, so unknown/forward-compat
@@ -562,6 +661,17 @@ export const installLocalMode = (): void => {
     }
     return getLocalAssistantStatus(lockfilePaths, assistantId);
   });
+
+  ipc(
+    "vellum:localMode:readAssistantAvatar",
+    assistantIdArgs,
+    ([assistantId]): LocalReadAssistantAvatarResult => {
+      if (!assistantId) {
+        return { ok: false, error: "Missing assistantId" };
+      }
+      return readAssistantAvatar(lockfilePaths, assistantId);
+    },
+  );
 
   ipc(
     "vellum:localMode:guardianToken",

--- a/packages/ipc-contract/src/bridge.ts
+++ b/packages/ipc-contract/src/bridge.ts
@@ -107,6 +107,22 @@ export type LocalListDevicesResult =
 export type LocalRevokeDeviceResult =
   { ok: true } | { ok: false; error: string };
 
+/**
+ * A local assistant's avatar as read off its workspace by the host. `null`
+ * covers every "nothing to show" case (no entry, no workspace, no avatar,
+ * unreadable files); only malformed arguments produce `ok: false`.
+ */
+export type LocalAssistantAvatar =
+  | {
+      kind: "character";
+      traits: { bodyShape: string; eyeStyle: string; color: string };
+    }
+  | { kind: "image"; imageBase64: string };
+
+export type LocalReadAssistantAvatarResult =
+  | { ok: true; avatar: LocalAssistantAvatar | null }
+  | { ok: false; error: string };
+
 export interface VellumBridge {
   platform: "electron";
   hostOS?: ElectronHostOS;
@@ -287,6 +303,13 @@ export interface VellumBridge {
       | { ok: true; accessToken: string }
       | { ok: false; status: number; error: string }
     >;
+    /**
+     * Read a local assistant's avatar straight off its workspace, so the
+     * chooser can render it even while that assistant is asleep.
+     */
+    readAssistantAvatar(
+      assistantId: string,
+    ): Promise<LocalReadAssistantAvatarResult>;
   };
   menu: {
     setPlatformSession(has: boolean): Promise<void>;

--- a/packages/ipc-contract/src/channels.ts
+++ b/packages/ipc-contract/src/channels.ts
@@ -92,6 +92,8 @@ export const LOCAL_MODE_WAKE = "vellum:localMode:wake";
 export const LOCAL_MODE_UPGRADE = "vellum:localMode:upgrade";
 export const LOCAL_MODE_STATUS = "vellum:localMode:status";
 export const LOCAL_MODE_GUARDIAN_TOKEN = "vellum:localMode:guardianToken";
+export const LOCAL_MODE_READ_ASSISTANT_AVATAR =
+  "vellum:localMode:readAssistantAvatar";
 
 // Menu
 export const MENU_SET_PLATFORM_SESSION = "vellum:menu:setPlatformSession";

--- a/packages/ipc-contract/src/index.ts
+++ b/packages/ipc-contract/src/index.ts
@@ -13,9 +13,11 @@ export * from "./types";
 export * from "./schemas";
 export {
   type ElectronHostOS,
+  type LocalAssistantAvatar,
   type LocalConnectImportResult,
   type LocalListDevicesResult,
   type LocalPairedDeviceRecord,
+  type LocalReadAssistantAvatarResult,
   type LocalRevokeDeviceResult,
   type LocalUpgradeOptions,
   type LocalWakeOptions,

--- a/packages/local-mode/src/__tests__/status.test.ts
+++ b/packages/local-mode/src/__tests__/status.test.ts
@@ -4,7 +4,7 @@ import { createServer, type Server } from "node:http";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-import { getLocalAssistantStatus } from "../status";
+import { getLocalAssistantStatus, resolveLockfileInstanceDir } from "../status";
 
 let tempDir: string;
 let lockfilePath: string;
@@ -225,5 +225,35 @@ describe("getLocalAssistantStatus", () => {
         error: "Local assistant not found",
       },
     );
+  });
+});
+
+describe("resolveLockfileInstanceDir", () => {
+  test("reads the instance dir from the parsed entry", () => {
+    writeLocalLockfile();
+    expect(resolveLockfileInstanceDir([lockfilePath], "local-1")).toBe(
+      instanceDir,
+    );
+  });
+
+  test("honors legacy top-level baseDataDir", () => {
+    writeLockfile({ assistantId: "local-1", baseDataDir: instanceDir });
+    expect(resolveLockfileInstanceDir([lockfilePath], "local-1")).toBe(
+      instanceDir,
+    );
+  });
+
+  test("stops when the authoritative lockfile is unreadable", () => {
+    const legacyPath = path.join(tempDir, "legacy.json");
+    writeFileSync(lockfilePath, "{ not json");
+    writeFileSync(
+      legacyPath,
+      JSON.stringify({
+        assistants: [{ assistantId: "local-1", baseDataDir: instanceDir }],
+      }),
+    );
+    expect(
+      resolveLockfileInstanceDir([lockfilePath, legacyPath], "local-1"),
+    ).toBeUndefined();
   });
 });

--- a/packages/local-mode/src/__tests__/status.test.ts
+++ b/packages/local-mode/src/__tests__/status.test.ts
@@ -256,4 +256,18 @@ describe("resolveLockfileInstanceDir", () => {
       resolveLockfileInstanceDir([lockfilePath, legacyPath], "local-1"),
     ).toBeUndefined();
   });
+
+  test("empty authoritative lockfile never falls through to a legacy file", () => {
+    const legacyPath = path.join(tempDir, "legacy.json");
+    writeFileSync(lockfilePath, "");
+    writeFileSync(
+      legacyPath,
+      JSON.stringify({
+        assistants: [{ assistantId: "local-1", baseDataDir: instanceDir }],
+      }),
+    );
+    expect(
+      resolveLockfileInstanceDir([lockfilePath, legacyPath], "local-1"),
+    ).toBeUndefined();
+  });
 });

--- a/packages/local-mode/src/index.ts
+++ b/packages/local-mode/src/index.ts
@@ -72,7 +72,7 @@ export type {
 } from "./devices";
 export { runUpgrade, isValidReleaseVersion } from "./upgrade";
 export type { UpgradeOptions, UpgradeResult } from "./upgrade";
-export { getLocalAssistantStatus } from "./status";
+export { getLocalAssistantStatus, resolveLockfileInstanceDir } from "./status";
 export type {
   LocalAssistantRuntimeState,
   LocalAssistantStatusResult,

--- a/packages/local-mode/src/lockfile.test.ts
+++ b/packages/local-mode/src/lockfile.test.ts
@@ -41,6 +41,7 @@ describe("getLockfileData", () => {
     expect(result).toEqual({
       ok: true,
       data: { assistants: [], activeAssistant: null },
+      raw: { assistants: [], activeAssistant: null },
     });
   });
 

--- a/packages/local-mode/src/lockfile.ts
+++ b/packages/local-mode/src/lockfile.ts
@@ -9,8 +9,10 @@ import {
 import { withLockfileLock } from "./lockfile-lock";
 import { stripSensitiveFields } from "./util";
 
+/** `raw` is the authoritative file's parsed JSON (unknown fields intact). */
 export type LockfileResult =
-  { ok: true; data: Lockfile } | { ok: false; status: number; error?: string };
+  | { ok: true; data: Lockfile; raw: Record<string, unknown> }
+  | { ok: false; status: number; error?: string };
 
 export function getLockfileData(lockfilePaths: string[]): LockfileResult {
   let raw: string | undefined;
@@ -26,7 +28,8 @@ export function getLockfileData(lockfilePaths: string[]): LockfileResult {
   }
 
   if (!raw) {
-    return { ok: true, data: { assistants: [], activeAssistant: null } };
+    const empty = { assistants: [], activeAssistant: null };
+    return { ok: true, data: empty, raw: empty };
   }
 
   let data: Record<string, unknown>;
@@ -36,7 +39,7 @@ export function getLockfileData(lockfilePaths: string[]): LockfileResult {
     return { ok: false, status: 500 };
   }
   stripSensitiveFields(data);
-  return { ok: true, data: parseLockfile(data) };
+  return { ok: true, data: parseLockfile(data), raw: data };
 }
 
 /**

--- a/packages/local-mode/src/status.ts
+++ b/packages/local-mode/src/status.ts
@@ -261,6 +261,42 @@ function findRawAssistant(
   return null;
 }
 
+// Legacy entries persisted the directory as top-level `baseDataDir`.
+function lockfileInstanceDir(
+  entry: LockfileAssistant | undefined,
+  rawEntry: Record<string, unknown> | null,
+): string | undefined {
+  const rawResources = isRecord(rawEntry?.resources)
+    ? rawEntry.resources
+    : undefined;
+  return firstString(
+    entry?.resources?.instanceDir,
+    rawResources?.instanceDir,
+    rawEntry?.baseDataDir,
+  );
+}
+
+/**
+ * The persisted instance directory for a lockfile entry, honoring legacy
+ * `baseDataDir` entries the parsed contract drops. Undefined when the entry
+ * is missing or records no directory.
+ */
+export function resolveLockfileInstanceDir(
+  lockfilePaths: string[],
+  assistantId: string,
+): string | undefined {
+  const result = getLockfileData(lockfilePaths);
+  const entry = result.ok
+    ? result.data.assistants.find(
+        (assistant) => assistant.assistantId === assistantId,
+      )
+    : undefined;
+  return lockfileInstanceDir(
+    entry,
+    findRawAssistant(lockfilePaths, assistantId),
+  );
+}
+
 function resolveStatusResources(
   entry: LockfileAssistant,
   rawEntry: Record<string, unknown> | null,
@@ -271,11 +307,8 @@ function resolveStatusResources(
     : undefined;
   const ports = defaultPorts(env);
   const instanceDir =
-    firstString(
-      entry.resources?.instanceDir,
-      rawResources?.instanceDir,
-      rawEntry?.baseDataDir,
-    ) ?? defaultInstanceDir(env, entry.assistantId);
+    lockfileInstanceDir(entry, rawEntry) ??
+    defaultInstanceDir(env, entry.assistantId);
   return {
     instanceDir,
     daemonPort:

--- a/packages/local-mode/src/status.ts
+++ b/packages/local-mode/src/status.ts
@@ -286,11 +286,12 @@ export function resolveLockfileInstanceDir(
   assistantId: string,
 ): string | undefined {
   const result = getLockfileData(lockfilePaths);
-  const entry = result.ok
-    ? result.data.assistants.find(
-        (assistant) => assistant.assistantId === assistantId,
-      )
-    : undefined;
+  if (!result.ok) {
+    return undefined;
+  }
+  const entry = result.data.assistants.find(
+    (assistant) => assistant.assistantId === assistantId,
+  );
   return lockfileInstanceDir(
     entry,
     findRawAssistant(lockfilePaths, assistantId),

--- a/packages/local-mode/src/status.ts
+++ b/packages/local-mode/src/status.ts
@@ -129,7 +129,10 @@ function httpHealthCheck(port: number): Promise<boolean> {
 }
 
 type DaemonReadyzClassification =
-  "ready" | "migrating" | "failed" | "no_answer";
+  | "ready"
+  | "migrating"
+  | "failed"
+  | "no_answer";
 
 /**
  * Classify the daemon's DB migration readiness from the `/readyz` BODY.
@@ -240,25 +243,16 @@ function firstNumber(...values: unknown[]): number | undefined {
   return undefined;
 }
 
+// Raw entry from the same authoritative file the parsed data came from.
 function findRawAssistant(
-  lockfilePaths: string[],
+  raw: Record<string, unknown>,
   assistantId: string,
 ): Record<string, unknown> | null {
-  for (const candidate of lockfilePaths) {
-    let data: unknown;
-    try {
-      data = JSON.parse(readFileSync(candidate, "utf-8"));
-    } catch {
-      continue;
-    }
-    if (!isRecord(data) || !Array.isArray(data.assistants)) return null;
-    const entry = data.assistants.find(
-      (assistant) =>
-        isRecord(assistant) && assistant.assistantId === assistantId,
-    );
-    return isRecord(entry) ? entry : null;
-  }
-  return null;
+  if (!Array.isArray(raw.assistants)) return null;
+  const entry = raw.assistants.find(
+    (assistant) => isRecord(assistant) && assistant.assistantId === assistantId,
+  );
+  return isRecord(entry) ? entry : null;
 }
 
 // Legacy entries persisted the directory as top-level `baseDataDir`.
@@ -292,10 +286,7 @@ export function resolveLockfileInstanceDir(
   const entry = result.data.assistants.find(
     (assistant) => assistant.assistantId === assistantId,
   );
-  return lockfileInstanceDir(
-    entry,
-    findRawAssistant(lockfilePaths, assistantId),
-  );
+  return lockfileInstanceDir(entry, findRawAssistant(result.raw, assistantId));
 }
 
 function resolveStatusResources(
@@ -450,7 +441,7 @@ export async function getLocalAssistantStatus(
 
   return runtimeStatusForEntry(
     entry,
-    findRawAssistant(lockfilePaths, assistantId),
+    findRawAssistant(result.raw, assistantId),
     env,
   );
 }


### PR DESCRIPTION
## Summary
- Add `VellumBridge.localMode.readAssistantAvatar(assistantId)` to the IPC contract (`LocalAssistantAvatar` / `LocalReadAssistantAvatarResult` types, `LOCAL_MODE_READ_ASSISTANT_AVATAR` channel constant) plus the renderer passthrough in `local-mode-bridge.ts`.
- Implement the Electron host handler: finds the lockfile entry's `resources.instanceDir` and reads `<instanceDir>/.vellum/workspace/data/avatar/`, so a sleeping sibling assistant still gets an avatar in the chooser.
- Resolution mirrors the daemon (`avatar-manifest.ts`): `avatar.json` first (character -> traits, image -> base64 PNG, none -> null); a missing, corrupt, or partial manifest falls back to traits-first legacy inference, so a character build that also wrote its raster never reads as an image.
- Image read is capped at 5 MB via `statSync`; every fs failure resolves `{ ok: true, avatar: null }`. Only a missing `assistantId` yields `{ ok: false }`. Registered through the existing origin-checked `ipc.ts` registrar with zod-validated args.
- 12 handler tests: manifest character (with raster present), manifest image, manifest none, legacy traits-over-PNG, PNG-only, empty dir, missing entry, missing instanceDir, oversized image, corrupt manifest fallback, partial manifest fallback, missing id.

Part of plan: chooser-assistant-avatars.md (PR 4 of 11)