### PR TITLE
web: add useChooserRowAvatar hook with mode-safe per-row avatar fetch

### DIFF
--- a/clients/web/src/hooks/use-assistant-avatar.ts
+++ b/clients/web/src/hooks/use-assistant-avatar.ts
@@ -53,7 +53,7 @@ export interface AssistantAvatarOptions {
  * Query keeps the previously cached avatar instead of blanking out — see
  * the `retry` / `staleTime` options below.
  */
-async function fetchAvatarViaManifest(
+export async function fetchAvatarViaManifest(
   assistantId: string,
 ): Promise<{ traits: CharacterTraits | null; imageUrl: string | null }> {
   const state = await fetchAvatarState(assistantId);
@@ -88,7 +88,7 @@ async function fetchAvatarViaManifest(
  * alive behind the version gate — see
  * `lib/backwards-compat/avatar-state-manifest.ts`.
  */
-async function fetchAvatarViaLegacyFiles(
+export async function fetchAvatarViaLegacyFiles(
   assistantId: string,
 ): Promise<{ traits: CharacterTraits | null; imageUrl: string | null }> {
   const imageUrl = await fetchAvatarImageUrl(assistantId);

--- a/clients/web/src/hooks/use-assistant-resource-sync.test.tsx
+++ b/clients/web/src/hooks/use-assistant-resource-sync.test.tsx
@@ -28,6 +28,7 @@ import type { AssistantEvent } from "@/types/event-types";
 import { useAssistantResourceSync } from "@/hooks/use-assistant-resource-sync";
 import { assistantIdentityQueryKey } from "@/hooks/use-assistant-identity-init";
 import { avatarQueryKey } from "@/hooks/use-assistant-avatar";
+import { chooserRowAvatarQueryKeyPrefix } from "@/hooks/use-chooser-row-avatar";
 import { SYNC_TAGS } from "@/lib/sync/types";
 import type { SyncChangedEvent } from "@/lib/sync/types";
 import { __resetForTesting, publish } from "@/lib/event-bus";
@@ -813,6 +814,36 @@ describe("useAssistantResourceSync", () => {
     });
   });
 
+  test("avatar sync tag also invalidates the chooser row cache by prefix", async () => {
+    const queryClient = freshQueryClient();
+    const calls: InvalidateCall[] = [];
+    queryClient.invalidateQueries = recordInvalidations(calls) as never;
+    renderHook(() => useAssistantResourceSync("asst-1", true), {
+      wrapper: createWrapper(queryClient),
+    });
+    emit(syncEvent([SYNC_TAGS.assistantAvatar]) as unknown as AssistantEvent);
+    await waitFor(() => {
+      expect(
+        sweepsFor(calls, chooserRowAvatarQueryKeyPrefix("asst-1")).length,
+      ).toBe(1);
+    });
+  });
+
+  test("avatar_updated also invalidates the chooser row cache by prefix", async () => {
+    const queryClient = freshQueryClient();
+    const calls: InvalidateCall[] = [];
+    queryClient.invalidateQueries = recordInvalidations(calls) as never;
+    renderHook(() => useAssistantResourceSync("asst-1", true), {
+      wrapper: createWrapper(queryClient),
+    });
+    emit({ type: "avatar_updated" } as unknown as AssistantEvent);
+    await waitFor(() => {
+      expect(
+        sweepsFor(calls, chooserRowAvatarQueryKeyPrefix("asst-1")).length,
+      ).toBe(1);
+    });
+  });
+
   test("invalidates avatar query on avatar_updated event", async () => {
     const queryClient = freshQueryClient();
     const spy = mock(() => Promise.resolve());
@@ -856,7 +887,7 @@ describe("useAssistantResourceSync", () => {
       },
     );
     emit(syncEvent([SYNC_TAGS.assistantAvatar]) as unknown as AssistantEvent);
-    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalled();
     spy.mockClear();
     rerender({ active: false });
     emit(syncEvent([SYNC_TAGS.assistantAvatar]) as unknown as AssistantEvent);

--- a/clients/web/src/hooks/use-assistant-resource-sync.ts
+++ b/clients/web/src/hooks/use-assistant-resource-sync.ts
@@ -44,6 +44,7 @@ import {
   soundsConfigGetQueryKey,
 } from "@/generated/daemon/@tanstack/react-query.gen";
 import { avatarQueryKey } from "@/hooks/use-assistant-avatar";
+import { chooserRowAvatarQueryKeyPrefix } from "@/hooks/use-chooser-row-avatar";
 import { useBusSubscription } from "@/hooks/use-bus-subscription";
 import { getClientId } from "@/lib/telemetry/client-identity";
 import { SYNC_TAGS } from "@/lib/sync/types";
@@ -110,9 +111,7 @@ export function useAssistantResourceSync(
         for (const tag of event.tags) {
           switch (tag) {
             case SYNC_TAGS.assistantAvatar:
-              void queryClient.invalidateQueries({
-                queryKey: avatarQueryKey(assistantId),
-              });
+              invalidateAvatarQueries(queryClient, assistantId);
               break;
             case SYNC_TAGS.assistantIdentity:
               void queryClient.invalidateQueries({
@@ -216,9 +215,7 @@ export function useAssistantResourceSync(
         return;
 
       case "avatar_updated":
-        void queryClient.invalidateQueries({
-          queryKey: avatarQueryKey(assistantId),
-        });
+        invalidateAvatarQueries(queryClient, assistantId);
         return;
     }
   });
@@ -237,6 +234,22 @@ export function useAssistantResourceSync(
       reconnectSweepTimerRef.current = null;
       refreshAssistantResources(queryClient, assistantId);
     }, RECONNECT_SWEEP_DEBOUNCE_MS);
+  });
+}
+
+/** The canonical avatar cache plus every chooser row variant for the same id. */
+function invalidateAvatarQueries(
+  queryClient: QueryClient,
+  assistantId: string,
+  refetchType?: "active" | "none",
+): void {
+  void queryClient.invalidateQueries({
+    queryKey: avatarQueryKey(assistantId),
+    refetchType,
+  });
+  void queryClient.invalidateQueries({
+    queryKey: chooserRowAvatarQueryKeyPrefix(assistantId),
+    refetchType,
   });
 }
 
@@ -272,10 +285,7 @@ function refreshAssistantResources(
     queryKey: configGetQueryKey(pathOpts),
     refetchType,
   });
-  void queryClient.invalidateQueries({
-    queryKey: avatarQueryKey(assistantId),
-    refetchType,
-  });
+  invalidateAvatarQueries(queryClient, assistantId, refetchType);
   invalidateMemoryQueries(queryClient, assistantId, refetchType);
   void queryClient.invalidateQueries({
     queryKey: soundsConfigGetQueryKey(pathOpts),

--- a/clients/web/src/hooks/use-chooser-row-avatar.test.tsx
+++ b/clients/web/src/hooks/use-chooser-row-avatar.test.tsx
@@ -326,6 +326,29 @@ describe("useChooserRowAvatar", () => {
     expect(result.current).toEqual({ traits: null, imageUrl: null });
   });
 
+  test("re-keys on a version change so an upgraded row switches paths", async () => {
+    fetchCharacterTraits.mockResolvedValue(traits);
+    const { result, rerender } = renderHook(
+      (version: string) =>
+        useChooserRowAvatar(platformRow("other", { runtimeVersion: version })),
+      { wrapper: createWrapper(), initialProps: "0.8.6" },
+    );
+    await waitFor(() => {
+      expect(result.current.traits).toEqual(traits);
+    });
+    expect(fetchAvatarState).not.toHaveBeenCalled();
+    expect(fetchCharacterTraits).toHaveBeenCalledTimes(1);
+
+    rerender(MIN_VERSION);
+    await waitFor(() => {
+      expect(fetchAvatarState).toHaveBeenCalledWith("other");
+    });
+    await waitFor(() => {
+      expect(result.current.traits).toEqual(traits);
+    });
+    expect(fetchCharacterTraits).toHaveBeenCalledTimes(1);
+  });
+
   test("keys the fetch per row id", async () => {
     const wrapper = createWrapper();
     const a = renderHook(() => useChooserRowAvatar(platformRow("a")), {

--- a/clients/web/src/hooks/use-chooser-row-avatar.test.tsx
+++ b/clients/web/src/hooks/use-chooser-row-avatar.test.tsx
@@ -38,6 +38,11 @@ mock.module("@/lib/self-hosted/connection", () => ({
   getSelfHostedIngressUrl: () => selfHostedIngressUrl,
 }));
 
+let orgReady = true;
+mock.module("@/hooks/use-is-org-ready", () => ({
+  useIsOrgReady: () => orgReady,
+}));
+
 const traits: CharacterTraits = {
   bodyShape: "brontosaurus",
   eyeStyle: "curious",
@@ -132,6 +137,7 @@ beforeEach(() => {
   remoteGatewayMode = false;
   gatewayAuthEnabled = false;
   selfHostedIngressUrl = null;
+  orgReady = true;
   useResolvedAssistantsStore.getState().setActiveAssistantId("active");
   // useAssistantAvatar gates its own path on the identity store's version.
   useAssistantIdentityStore.getState().setIdentity("active", MIN_VERSION);
@@ -217,6 +223,25 @@ describe("useChooserRowAvatar", () => {
       expect(sdkCallCount()).toBe(0);
     },
   );
+
+  test("waits for org readiness before the first platform-proxy fetch", async () => {
+    orgReady = false;
+    const { result, rerender } = renderHook(
+      () => useChooserRowAvatar(platformRow("other")),
+      { wrapper: createWrapper() },
+    );
+    await settle();
+    expect(result.current).toEqual({ traits: null, imageUrl: null });
+    expect(sdkCallCount()).toBe(0);
+
+    orgReady = true;
+    rerender();
+    await waitFor(() => {
+      expect(result.current.traits).toEqual(traits);
+    });
+    expect(fetchAvatarState).toHaveBeenCalledWith("other");
+    expect(fetchAvatarState).toHaveBeenCalledTimes(1);
+  });
 
   test("connected row delegates to useAssistantAvatar even when the gate is closed", async () => {
     localClient = true;

--- a/clients/web/src/hooks/use-chooser-row-avatar.test.tsx
+++ b/clients/web/src/hooks/use-chooser-row-avatar.test.tsx
@@ -7,7 +7,15 @@
  */
 
 import type { ReactNode } from "react";
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  setSystemTime,
+  test,
+} from "bun:test";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, renderHook, waitFor } from "@testing-library/react";
 
@@ -90,10 +98,14 @@ const { useAssistantIdentityStore } =
 const { MIN_VERSION } =
   await import("@/lib/backwards-compat/avatar-state-manifest");
 const {
+  EMPTY_AVATAR_STALE_TIME_MS,
   canFetchRowAvatarViaPlatformProxy,
   chooserRowAvatarQueryKeyPrefix,
   useChooserRowAvatar,
 } = await import("@/hooks/use-chooser-row-avatar");
+
+const revokeObjectURL = mock((_url: string) => {});
+URL.revokeObjectURL = revokeObjectURL;
 
 const platformRow = (
   id: string,
@@ -145,6 +157,8 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  setSystemTime();
+  revokeObjectURL.mockClear();
   useResolvedAssistantsStore.getState().setActiveAssistantId(null);
   useAssistantIdentityStore.getState().clearIdentity();
   fetchAvatarState.mockReset();
@@ -400,6 +414,77 @@ describe("useChooserRowAvatar", () => {
       expect(result.current.traits).toEqual(updated);
     });
     expect(fetchAvatarState).toHaveBeenCalledTimes(2);
+  });
+
+  test("an empty legacy result goes stale so a later mount refetches it", async () => {
+    const wrapper = createWrapper();
+    const row = platformRow("other", { runtimeVersion: "0.8.6" });
+    const first = renderHook(() => useChooserRowAvatar(row), { wrapper });
+    await waitFor(() => {
+      expect(fetchCharacterTraits).toHaveBeenCalledTimes(1);
+    });
+    await settle();
+    expect(first.result.current).toEqual({ traits: null, imageUrl: null });
+    first.unmount();
+
+    setSystemTime(new Date(Date.now() + EMPTY_AVATAR_STALE_TIME_MS + 1));
+    fetchCharacterTraits.mockResolvedValue(traits);
+    const second = renderHook(() => useChooserRowAvatar(row), { wrapper });
+    await waitFor(() => {
+      expect(second.result.current.traits).toEqual(traits);
+    });
+    expect(fetchCharacterTraits).toHaveBeenCalledTimes(2);
+  });
+
+  test("a populated legacy result stays cached past the empty stale window", async () => {
+    const wrapper = createWrapper();
+    const row = platformRow("other", { runtimeVersion: "0.8.6" });
+    fetchCharacterTraits.mockResolvedValue(traits);
+    const first = renderHook(() => useChooserRowAvatar(row), { wrapper });
+    await waitFor(() => {
+      expect(first.result.current.traits).toEqual(traits);
+    });
+    first.unmount();
+
+    setSystemTime(new Date(Date.now() + EMPTY_AVATAR_STALE_TIME_MS + 1));
+    const second = renderHook(() => useChooserRowAvatar(row), { wrapper });
+    await waitFor(() => {
+      expect(second.result.current.traits).toEqual(traits);
+    });
+    await settle();
+    expect(fetchCharacterTraits).toHaveBeenCalledTimes(1);
+  });
+
+  test("a superseded fetch that finishes last drops its own blob, not the current one", async () => {
+    let resolveOld: (url: string) => void = () => {};
+    const oldImage = new Promise<string | null>((resolve) => {
+      resolveOld = resolve;
+    });
+    fetchAvatarImageUrl.mockImplementationOnce(() => oldImage);
+    fetchAvatarImageUrl.mockResolvedValue("blob:new");
+    fetchAvatarState.mockResolvedValue(imageState);
+
+    const { result, rerender } = renderHook(
+      (version: string) =>
+        useChooserRowAvatar(platformRow("other", { runtimeVersion: version })),
+      { wrapper: createWrapper(), initialProps: "0.8.6" },
+    );
+    await waitFor(() => {
+      expect(fetchAvatarImageUrl).toHaveBeenCalledTimes(1);
+    });
+
+    rerender(MIN_VERSION);
+    await waitFor(() => {
+      expect(result.current.imageUrl).toBe("blob:new");
+    });
+
+    resolveOld("blob:old");
+    await waitFor(() => {
+      expect(revokeObjectURL).toHaveBeenCalledWith("blob:old");
+    });
+    await settle();
+    expect(revokeObjectURL).not.toHaveBeenCalledWith("blob:new");
+    expect(result.current.imageUrl).toBe("blob:new");
   });
 
   test("keys the fetch per row id", async () => {

--- a/clients/web/src/hooks/use-chooser-row-avatar.test.tsx
+++ b/clients/web/src/hooks/use-chooser-row-avatar.test.tsx
@@ -1,0 +1,345 @@
+/**
+ * Tests for `useChooserRowAvatar`: the transport gate that decides whether a
+ * per-row SDK fetch is addressable, connected-row delegation to
+ * `useAssistantAvatar`, per-row manifest-vs-legacy path selection, and the
+ * failure-to-nulls contract. The resolved-assistants store is real; the
+ * environment probes and the avatar API are mocked at the module boundary.
+ */
+
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, renderHook, waitFor } from "@testing-library/react";
+
+import type * as AvatarApi from "@/assistant/avatar-api";
+import type { ResolvedAssistant } from "@/stores/resolved-assistants-store";
+import type {
+  AvatarState,
+  CharacterComponents,
+  CharacterTraits,
+} from "@/types/avatar";
+
+const actualLocalMode = await import("@/lib/local-mode");
+let localClient = false;
+let remoteGatewayMode = false;
+mock.module("@/lib/local-mode", () => ({
+  ...actualLocalMode,
+  isLocalClient: () => localClient,
+  isRemoteGatewayMode: () => remoteGatewayMode,
+}));
+
+let gatewayAuthEnabled = false;
+mock.module("@/lib/auth/gateway-session", () => ({
+  isGatewayAuthEnabled: () => gatewayAuthEnabled,
+}));
+
+let selfHostedIngressUrl: string | null = null;
+mock.module("@/lib/self-hosted/connection", () => ({
+  getSelfHostedIngressUrl: () => selfHostedIngressUrl,
+}));
+
+const traits: CharacterTraits = {
+  bodyShape: "brontosaurus",
+  eyeStyle: "curious",
+  color: "cosmic-purple",
+};
+
+const components: CharacterComponents = {
+  bodyShapes: [],
+  eyeStyles: [],
+  colors: [],
+  faceCenterOverrides: [],
+};
+
+const characterState: AvatarState = {
+  kind: "character",
+  traits,
+  source: "builder",
+  image: { updatedAt: "2024-01-01T00:00:00Z", etag: "abc" },
+};
+
+const imageState: AvatarState = {
+  kind: "image",
+  traits: null,
+  source: "upload",
+  image: { updatedAt: "2024-01-01T00:00:00Z", etag: "def" },
+};
+
+const fetchAvatarState = mock(async () => characterState as AvatarState | null);
+const fetchAvatarImageUrl = mock(async () => null as string | null);
+const fetchCharacterTraits = mock(async () => null as CharacterTraits | null);
+const fetchCharacterComponents = mock(async () => components);
+
+const avatarApiMock: Partial<typeof AvatarApi> = {
+  fetchAvatarState,
+  fetchAvatarImageUrl,
+  fetchCharacterTraits,
+  fetchCharacterComponents,
+};
+mock.module("@/assistant/avatar-api", () => avatarApiMock);
+
+const { useResolvedAssistantsStore } =
+  await import("@/stores/resolved-assistants-store");
+const { useAssistantIdentityStore } =
+  await import("@/stores/assistant-identity-store");
+const { MIN_VERSION } =
+  await import("@/lib/backwards-compat/avatar-state-manifest");
+const { canFetchRowAvatarViaPlatformProxy, useChooserRowAvatar } =
+  await import("@/hooks/use-chooser-row-avatar");
+
+const platformRow = (
+  id: string,
+  overrides: Partial<ResolvedAssistant> = {},
+): ResolvedAssistant => ({
+  id,
+  isLocal: false,
+  isPlatformHosted: true,
+  isPaired: false,
+  runtimeVersion: "0.9.0",
+  ...overrides,
+});
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+function sdkCallCount(): number {
+  return (
+    fetchAvatarState.mock.calls.length +
+    fetchAvatarImageUrl.mock.calls.length +
+    fetchCharacterTraits.mock.calls.length +
+    fetchCharacterComponents.mock.calls.length
+  );
+}
+
+async function settle(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 20));
+}
+
+beforeEach(() => {
+  localClient = false;
+  remoteGatewayMode = false;
+  gatewayAuthEnabled = false;
+  selfHostedIngressUrl = null;
+  useResolvedAssistantsStore.getState().setActiveAssistantId("active");
+  // useAssistantAvatar gates its own path on the identity store's version.
+  useAssistantIdentityStore.getState().setIdentity("active", MIN_VERSION);
+});
+
+afterEach(() => {
+  cleanup();
+  useResolvedAssistantsStore.getState().setActiveAssistantId(null);
+  useAssistantIdentityStore.getState().clearIdentity();
+  fetchAvatarState.mockReset();
+  fetchAvatarImageUrl.mockReset();
+  fetchCharacterTraits.mockReset();
+  fetchCharacterComponents.mockReset();
+  fetchAvatarState.mockResolvedValue(characterState);
+  fetchAvatarImageUrl.mockResolvedValue(null);
+  fetchCharacterTraits.mockResolvedValue(null);
+  fetchCharacterComponents.mockResolvedValue(components);
+});
+
+describe("canFetchRowAvatarViaPlatformProxy", () => {
+  test("is open for a platform row in pure cloud mode", () => {
+    expect(canFetchRowAvatarViaPlatformProxy(platformRow("a"))).toBe(true);
+  });
+
+  test.each([
+    ["local client", () => (localClient = true)],
+    ["remote-gateway mode", () => (remoteGatewayMode = true)],
+    ["gateway auth", () => (gatewayAuthEnabled = true)],
+    [
+      "self-hosted ingress",
+      () => (selfHostedIngressUrl = "https://gw.example"),
+    ],
+  ])("is closed under %s", (_label, arrange) => {
+    arrange();
+    expect(canFetchRowAvatarViaPlatformProxy(platformRow("a"))).toBe(false);
+  });
+
+  test.each([
+    ["local", { isLocal: true, isPlatformHosted: false }],
+    ["paired", { isPaired: true, isPlatformHosted: false }],
+  ])("is closed for a %s row", (_label, overrides) => {
+    expect(canFetchRowAvatarViaPlatformProxy(platformRow("a", overrides))).toBe(
+      false,
+    );
+  });
+});
+
+describe("useChooserRowAvatar", () => {
+  test.each([
+    ["local client", () => (localClient = true)],
+    ["remote-gateway mode", () => (remoteGatewayMode = true)],
+    ["gateway auth", () => (gatewayAuthEnabled = true)],
+    [
+      "self-hosted ingress",
+      () => (selfHostedIngressUrl = "https://gw.example"),
+    ],
+  ])(
+    "issues zero SDK calls for a non-connected row under %s",
+    async (_l, arrange) => {
+      arrange();
+      const { result } = renderHook(
+        () => useChooserRowAvatar(platformRow("other")),
+        { wrapper: createWrapper() },
+      );
+      await settle();
+      expect(result.current).toEqual({ traits: null, imageUrl: null });
+      expect(sdkCallCount()).toBe(0);
+    },
+  );
+
+  test.each([
+    ["local", { isLocal: true, isPlatformHosted: false }],
+    ["paired", { isPaired: true, isPlatformHosted: false }],
+  ])(
+    "issues zero SDK calls for a non-connected %s row",
+    async (_l, overrides) => {
+      const { result } = renderHook(
+        () => useChooserRowAvatar(platformRow("other", overrides)),
+        { wrapper: createWrapper() },
+      );
+      await settle();
+      expect(result.current).toEqual({ traits: null, imageUrl: null });
+      expect(sdkCallCount()).toBe(0);
+    },
+  );
+
+  test("connected row delegates to useAssistantAvatar even when the gate is closed", async () => {
+    localClient = true;
+    const { result } = renderHook(
+      () => useChooserRowAvatar(platformRow("active", { isLocal: true })),
+      { wrapper: createWrapper() },
+    );
+    await waitFor(() => {
+      expect(result.current.traits).toEqual(traits);
+    });
+    expect(result.current.imageUrl).toBeNull();
+    // useAssistantAvatar's signature: components + state, no chooser fetch.
+    expect(fetchCharacterComponents).toHaveBeenCalledTimes(1);
+    expect(fetchAvatarState).toHaveBeenCalledTimes(1);
+  });
+
+  test("connected row reuses the useAssistantAvatar cache across consumers", async () => {
+    const wrapper = createWrapper();
+    const first = renderHook(() => useChooserRowAvatar(platformRow("active")), {
+      wrapper,
+    });
+    await waitFor(() => {
+      expect(first.result.current.traits).toEqual(traits);
+    });
+    const second = renderHook(
+      () => useChooserRowAvatar(platformRow("active")),
+      { wrapper },
+    );
+    await waitFor(() => {
+      expect(second.result.current.traits).toEqual(traits);
+    });
+    expect(fetchAvatarState).toHaveBeenCalledTimes(1);
+    expect(fetchCharacterComponents).toHaveBeenCalledTimes(1);
+  });
+
+  test("manifest-capable platform row reads /avatar/state and skips components", async () => {
+    const { result } = renderHook(
+      () => useChooserRowAvatar(platformRow("other")),
+      { wrapper: createWrapper() },
+    );
+    await waitFor(() => {
+      expect(result.current.traits).toEqual(traits);
+    });
+    expect(fetchAvatarState).toHaveBeenCalledWith("other");
+    expect(fetchCharacterComponents).not.toHaveBeenCalled();
+    expect(fetchAvatarImageUrl).not.toHaveBeenCalled();
+  });
+
+  test("image kind resolves the blob url", async () => {
+    fetchAvatarState.mockResolvedValue(imageState);
+    fetchAvatarImageUrl.mockResolvedValue("blob:row-image");
+    const { result } = renderHook(
+      () => useChooserRowAvatar(platformRow("other")),
+      { wrapper: createWrapper() },
+    );
+    await waitFor(() => {
+      expect(result.current.imageUrl).toBe("blob:row-image");
+    });
+    expect(result.current.traits).toBeNull();
+  });
+
+  test("pre-manifest platform row reads the legacy sidecars only", async () => {
+    fetchCharacterTraits.mockResolvedValue(traits);
+    const { result } = renderHook(
+      () =>
+        useChooserRowAvatar(
+          platformRow("other", {
+            runtimeVersion: undefined,
+            currentReleaseVersion: "0.8.6",
+          }),
+        ),
+      { wrapper: createWrapper() },
+    );
+    await waitFor(() => {
+      expect(result.current.traits).toEqual(traits);
+    });
+    expect(fetchAvatarState).not.toHaveBeenCalled();
+    expect(fetchAvatarImageUrl).toHaveBeenCalledWith("other");
+  });
+
+  test("unknown version probes the manifest, then falls back to sidecars", async () => {
+    fetchAvatarState.mockResolvedValue(null);
+    fetchAvatarImageUrl.mockResolvedValue("blob:legacy");
+    const { result } = renderHook(
+      () =>
+        useChooserRowAvatar(
+          platformRow("other", {
+            runtimeVersion: undefined,
+            currentReleaseVersion: null,
+          }),
+        ),
+      { wrapper: createWrapper() },
+    );
+    await waitFor(() => {
+      expect(result.current.imageUrl).toBe("blob:legacy");
+    });
+    expect(fetchAvatarState).toHaveBeenCalledTimes(1);
+    expect(fetchCharacterTraits).not.toHaveBeenCalled();
+  });
+
+  test("failures resolve to nulls, never an error", async () => {
+    fetchAvatarState.mockRejectedValue(new Error("boom"));
+    const { result } = renderHook(
+      () => useChooserRowAvatar(platformRow("other")),
+      { wrapper: createWrapper() },
+    );
+    await waitFor(() => {
+      expect(fetchAvatarState).toHaveBeenCalledTimes(1);
+    });
+    await settle();
+    expect(result.current).toEqual({ traits: null, imageUrl: null });
+  });
+
+  test("keys the fetch per row id", async () => {
+    const wrapper = createWrapper();
+    const a = renderHook(() => useChooserRowAvatar(platformRow("a")), {
+      wrapper,
+    });
+    const b = renderHook(() => useChooserRowAvatar(platformRow("b")), {
+      wrapper,
+    });
+    await waitFor(() => {
+      expect(a.result.current.traits).toEqual(traits);
+      expect(b.result.current.traits).toEqual(traits);
+    });
+    expect(fetchAvatarState).toHaveBeenCalledWith("a");
+    expect(fetchAvatarState).toHaveBeenCalledWith("b");
+    expect(fetchAvatarState).toHaveBeenCalledTimes(2);
+  });
+});

--- a/clients/web/src/hooks/use-chooser-row-avatar.test.tsx
+++ b/clients/web/src/hooks/use-chooser-row-avatar.test.tsx
@@ -84,8 +84,11 @@ const { useAssistantIdentityStore } =
   await import("@/stores/assistant-identity-store");
 const { MIN_VERSION } =
   await import("@/lib/backwards-compat/avatar-state-manifest");
-const { canFetchRowAvatarViaPlatformProxy, useChooserRowAvatar } =
-  await import("@/hooks/use-chooser-row-avatar");
+const {
+  canFetchRowAvatarViaPlatformProxy,
+  chooserRowAvatarQueryKeyPrefix,
+  useChooserRowAvatar,
+} = await import("@/hooks/use-chooser-row-avatar");
 
 const platformRow = (
   id: string,
@@ -99,10 +102,11 @@ const platformRow = (
   ...overrides,
 });
 
-function createWrapper() {
-  const queryClient = new QueryClient({
+function createWrapper(
+  queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
-  });
+  }),
+) {
   return function Wrapper({ children }: { children: ReactNode }) {
     return (
       <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
@@ -347,6 +351,30 @@ describe("useChooserRowAvatar", () => {
       expect(result.current.traits).toEqual(traits);
     });
     expect(fetchCharacterTraits).toHaveBeenCalledTimes(1);
+  });
+
+  test("invalidating the row prefix refetches past staleTime: Infinity", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const { result } = renderHook(
+      () => useChooserRowAvatar(platformRow("other")),
+      { wrapper: createWrapper(queryClient) },
+    );
+    await waitFor(() => {
+      expect(result.current.traits).toEqual(traits);
+    });
+    expect(fetchAvatarState).toHaveBeenCalledTimes(1);
+
+    const updated: CharacterTraits = { ...traits, color: "sunset-orange" };
+    fetchAvatarState.mockResolvedValue({ ...characterState, traits: updated });
+    await queryClient.invalidateQueries({
+      queryKey: chooserRowAvatarQueryKeyPrefix("other"),
+    });
+    await waitFor(() => {
+      expect(result.current.traits).toEqual(updated);
+    });
+    expect(fetchAvatarState).toHaveBeenCalledTimes(2);
   });
 
   test("keys the fetch per row id", async () => {

--- a/clients/web/src/hooks/use-chooser-row-avatar.ts
+++ b/clients/web/src/hooks/use-chooser-row-avatar.ts
@@ -36,13 +36,17 @@ export function rowManifestSupport(
     : "unsupported";
 }
 
+/** Prefix matching every support-state variant of one row; use for invalidation. */
+export function chooserRowAvatarQueryKeyPrefix(assistantId: string) {
+  return [CHOOSER_ROW_AVATAR_QUERY_KEY_PREFIX, assistantId] as const;
+}
+
 export function chooserRowAvatarQueryKey(
   assistantId: string,
   manifestSupport: RowManifestSupport,
 ) {
   return [
-    CHOOSER_ROW_AVATAR_QUERY_KEY_PREFIX,
-    assistantId,
+    ...chooserRowAvatarQueryKeyPrefix(assistantId),
     manifestSupport,
   ] as const;
 }

--- a/clients/web/src/hooks/use-chooser-row-avatar.ts
+++ b/clients/web/src/hooks/use-chooser-row-avatar.ts
@@ -17,8 +17,34 @@ import type { CharacterTraits } from "@/types/avatar";
 
 export const CHOOSER_ROW_AVATAR_QUERY_KEY_PREFIX = "chooserRowAvatar";
 
-export function chooserRowAvatarQueryKey(assistantId: string) {
-  return [CHOOSER_ROW_AVATAR_QUERY_KEY_PREFIX, assistantId] as const;
+export type RowManifestSupport = "supported" | "unsupported" | "unknown";
+
+/**
+ * Tri-state manifest gate for a row's own runtime. Part of the query key so
+ * a version change after an upgrade re-runs the fetch through the other path.
+ */
+export function rowManifestSupport(
+  assistant: ResolvedAssistant,
+): RowManifestSupport {
+  const version =
+    assistant.runtimeVersion ?? assistant.currentReleaseVersion ?? null;
+  if (version === null) {
+    return "unknown";
+  }
+  return versionSupportsAvatarStateManifest(version)
+    ? "supported"
+    : "unsupported";
+}
+
+export function chooserRowAvatarQueryKey(
+  assistantId: string,
+  manifestSupport: RowManifestSupport,
+) {
+  return [
+    CHOOSER_ROW_AVATAR_QUERY_KEY_PREFIX,
+    assistantId,
+    manifestSupport,
+  ] as const;
 }
 
 export interface ChooserRowAvatar {
@@ -63,13 +89,12 @@ export function canFetchRowAvatarViaPlatformProxy(
  */
 async function fetchRowAvatar(
   assistant: ResolvedAssistant,
+  manifestSupport: RowManifestSupport,
 ): Promise<ChooserRowAvatar> {
-  const version =
-    assistant.runtimeVersion ?? assistant.currentReleaseVersion ?? null;
-  if (versionSupportsAvatarStateManifest(version)) {
+  if (manifestSupport === "supported") {
     return fetchAvatarViaManifest(assistant.id);
   }
-  if (version === null) {
+  if (manifestSupport === "unknown") {
     try {
       return await fetchAvatarViaManifest(assistant.id);
     } catch {
@@ -108,10 +133,11 @@ export function useChooserRowAvatar(
 
   const connected = useAssistantAvatar(isConnectedRow ? assistant.id : null);
 
+  const manifestSupport = rowManifestSupport(assistant);
   const { data } = useQuery<ChooserRowAvatar>({
-    queryKey: chooserRowAvatarQueryKey(assistant.id),
+    queryKey: chooserRowAvatarQueryKey(assistant.id, manifestSupport),
     queryFn: async () => {
-      const avatar = await fetchRowAvatar(assistant);
+      const avatar = await fetchRowAvatar(assistant, manifestSupport);
       trackBlobUrl(assistant.id, avatar.imageUrl);
       return avatar;
     },

--- a/clients/web/src/hooks/use-chooser-row-avatar.ts
+++ b/clients/web/src/hooks/use-chooser-row-avatar.ts
@@ -1,0 +1,129 @@
+import { useQuery } from "@tanstack/react-query";
+
+import {
+  fetchAvatarViaLegacyFiles,
+  fetchAvatarViaManifest,
+  useAssistantAvatar,
+} from "@/hooks/use-assistant-avatar";
+import { isGatewayAuthEnabled } from "@/lib/auth/gateway-session";
+import { versionSupportsAvatarStateManifest } from "@/lib/backwards-compat/avatar-state-manifest";
+import { isLocalClient, isRemoteGatewayMode } from "@/lib/local-mode";
+import { getSelfHostedIngressUrl } from "@/lib/self-hosted/connection";
+import {
+  type ResolvedAssistant,
+  useResolvedAssistantsStore,
+} from "@/stores/resolved-assistants-store";
+import type { CharacterTraits } from "@/types/avatar";
+
+export const CHOOSER_ROW_AVATAR_QUERY_KEY_PREFIX = "chooserRowAvatar";
+
+export function chooserRowAvatarQueryKey(assistantId: string) {
+  return [CHOOSER_ROW_AVATAR_QUERY_KEY_PREFIX, assistantId] as const;
+}
+
+export interface ChooserRowAvatar {
+  traits: CharacterTraits | null;
+  imageUrl: string | null;
+}
+
+const EMPTY_AVATAR: ChooserRowAvatar = { traits: null, imageUrl: null };
+
+/** Separate from `use-assistant-avatar`'s map so the two caches never revoke each other's URLs. */
+const activeBlobUrls = new Map<string, string>();
+
+/**
+ * Whether a daemon SDK call for `row` actually reaches `row`'s runtime.
+ *
+ * The SDK targets `/v1/assistants/{id}/...`, and only the platform proxy
+ * routes by that id. Every other transport pins the request to ONE
+ * assistant regardless of the id in the path, so a fetch for a sibling
+ * row would answer with the connected assistant's avatar (or 404):
+ * - local / remote-gateway / gateway-auth clients talk to a single gateway;
+ * - a self-hosted ingress (`getSelfHostedIngressUrl()`) makes the request
+ *   interceptor rewrite every daemon call to that gateway, whose
+ *   runtime-proxy discards the id;
+ * - local and paired rows have no per-id platform route at all.
+ */
+export function canFetchRowAvatarViaPlatformProxy(
+  row: ResolvedAssistant,
+): boolean {
+  return (
+    !isLocalClient() &&
+    !isRemoteGatewayMode() &&
+    !isGatewayAuthEnabled() &&
+    getSelfHostedIngressUrl() === null &&
+    row.isPlatformHosted
+  );
+}
+
+/**
+ * Manifest reads for runtimes known to serve `/avatar/state`; legacy sidecar
+ * reads for runtimes known not to. An unknown version probes the manifest
+ * first and falls back to the sidecars when the probe fails.
+ */
+async function fetchRowAvatar(
+  assistant: ResolvedAssistant,
+): Promise<ChooserRowAvatar> {
+  const version =
+    assistant.runtimeVersion ?? assistant.currentReleaseVersion ?? null;
+  if (versionSupportsAvatarStateManifest(version)) {
+    return fetchAvatarViaManifest(assistant.id);
+  }
+  if (version === null) {
+    try {
+      return await fetchAvatarViaManifest(assistant.id);
+    } catch {
+      // Probe failed: the runtime is likely pre-manifest.
+    }
+  }
+  return fetchAvatarViaLegacyFiles(assistant.id);
+}
+
+function trackBlobUrl(assistantId: string, imageUrl: string | null): void {
+  const prev = activeBlobUrls.get(assistantId);
+  if (prev && prev !== imageUrl) {
+    URL.revokeObjectURL(prev);
+  }
+  if (imageUrl) {
+    activeBlobUrls.set(assistantId, imageUrl);
+  } else {
+    activeBlobUrls.delete(assistantId);
+  }
+}
+
+/**
+ * Avatar data for one chooser row, resolved through a precedence chain:
+ * 1. The connected row reuses `useAssistantAvatar`'s cache, correct in every
+ *    transport mode and never fetched twice.
+ * 2. Other platform rows fetch per id through the platform proxy, only when
+ *    {@link canFetchRowAvatarViaPlatformProxy} says the id is honored.
+ * Anything else, including every failure, resolves to nulls: the row's glyph
+ * fallback is the error state, a chooser row never surfaces an error.
+ */
+export function useChooserRowAvatar(
+  assistant: ResolvedAssistant,
+): ChooserRowAvatar {
+  const activeAssistantId = useResolvedAssistantsStore.use.activeAssistantId();
+  const isConnectedRow = assistant.id === activeAssistantId;
+
+  const connected = useAssistantAvatar(isConnectedRow ? assistant.id : null);
+
+  const { data } = useQuery<ChooserRowAvatar>({
+    queryKey: chooserRowAvatarQueryKey(assistant.id),
+    queryFn: async () => {
+      const avatar = await fetchRowAvatar(assistant);
+      trackBlobUrl(assistant.id, avatar.imageUrl);
+      return avatar;
+    },
+    enabled: !isConnectedRow && canFetchRowAvatarViaPlatformProxy(assistant),
+    staleTime: Infinity,
+    structuralSharing: false,
+    // A rejected query leaves `data` undefined, which reads as nulls below.
+    retry: 1,
+  });
+
+  if (isConnectedRow) {
+    return { traits: connected.traits, imageUrl: connected.customImageUrl };
+  }
+  return data ?? EMPTY_AVATAR;
+}

--- a/clients/web/src/hooks/use-chooser-row-avatar.ts
+++ b/clients/web/src/hooks/use-chooser-row-avatar.ts
@@ -59,8 +59,18 @@ export interface ChooserRowAvatar {
 
 const EMPTY_AVATAR: ChooserRowAvatar = { traits: null, imageUrl: null };
 
+/**
+ * The legacy sidecar path swallows read failures into nulls, so an empty
+ * result may be a transient error rather than a bare avatar. Let it go stale
+ * on a normal clock instead of pinning the glyph fallback forever.
+ */
+export const EMPTY_AVATAR_STALE_TIME_MS = 60_000;
+
 /** Separate from `use-assistant-avatar`'s map so the two caches never revoke each other's URLs. */
 const activeBlobUrls = new Map<string, string>();
+
+/** Latest fetch generation per row; a superseded fetch must not touch the map. */
+const fetchGenerations = new Map<string, number>();
 
 /**
  * Whether a daemon SDK call for `row` actually reaches `row`'s runtime.
@@ -122,6 +132,33 @@ function trackBlobUrl(assistantId: string, imageUrl: string | null): void {
 }
 
 /**
+ * Runs one fetch generation for `assistant`. A re-key (manifest support
+ * flipping) can start a newer fetch while this one is in flight; when the
+ * older one finishes last it must not revoke the URL the newer query renders,
+ * so it drops its own blob instead.
+ */
+async function fetchRowAvatarGeneration(
+  assistant: ResolvedAssistant,
+  manifestSupport: RowManifestSupport,
+): Promise<ChooserRowAvatar> {
+  const generation = (fetchGenerations.get(assistant.id) ?? 0) + 1;
+  fetchGenerations.set(assistant.id, generation);
+  const avatar = await fetchRowAvatar(assistant, manifestSupport);
+  if (fetchGenerations.get(assistant.id) !== generation) {
+    if (avatar.imageUrl) {
+      URL.revokeObjectURL(avatar.imageUrl);
+    }
+    return { traits: avatar.traits, imageUrl: null };
+  }
+  trackBlobUrl(assistant.id, avatar.imageUrl);
+  return avatar;
+}
+
+function isEmptyAvatar(avatar: ChooserRowAvatar | undefined): boolean {
+  return avatar !== undefined && !avatar.traits && !avatar.imageUrl;
+}
+
+/**
  * Avatar data for one chooser row, resolved through a precedence chain:
  * 1. The connected row reuses `useAssistantAvatar`'s cache, correct in every
  *    transport mode and never fetched twice.
@@ -143,16 +180,13 @@ export function useChooserRowAvatar(
   const manifestSupport = rowManifestSupport(assistant);
   const { data } = useQuery<ChooserRowAvatar>({
     queryKey: chooserRowAvatarQueryKey(assistant.id, manifestSupport),
-    queryFn: async () => {
-      const avatar = await fetchRowAvatar(assistant, manifestSupport);
-      trackBlobUrl(assistant.id, avatar.imageUrl);
-      return avatar;
-    },
+    queryFn: () => fetchRowAvatarGeneration(assistant, manifestSupport),
     enabled:
       !isConnectedRow &&
       isOrgReady &&
       canFetchRowAvatarViaPlatformProxy(assistant),
-    staleTime: Infinity,
+    staleTime: (query) =>
+      isEmptyAvatar(query.state.data) ? EMPTY_AVATAR_STALE_TIME_MS : Infinity,
     structuralSharing: false,
     // A rejected query leaves `data` undefined, which reads as nulls below.
     retry: 1,

--- a/clients/web/src/hooks/use-chooser-row-avatar.ts
+++ b/clients/web/src/hooks/use-chooser-row-avatar.ts
@@ -5,6 +5,7 @@ import {
   fetchAvatarViaManifest,
   useAssistantAvatar,
 } from "@/hooks/use-assistant-avatar";
+import { useIsOrgReady } from "@/hooks/use-is-org-ready";
 import { isGatewayAuthEnabled } from "@/lib/auth/gateway-session";
 import { versionSupportsAvatarStateManifest } from "@/lib/backwards-compat/avatar-state-manifest";
 import { isLocalClient, isRemoteGatewayMode } from "@/lib/local-mode";
@@ -125,7 +126,8 @@ function trackBlobUrl(assistantId: string, imageUrl: string | null): void {
  * 1. The connected row reuses `useAssistantAvatar`'s cache, correct in every
  *    transport mode and never fetched twice.
  * 2. Other platform rows fetch per id through the platform proxy, only when
- *    {@link canFetchRowAvatarViaPlatformProxy} says the id is honored.
+ *    {@link canFetchRowAvatarViaPlatformProxy} says the id is honored and the
+ *    org store can supply the `Vellum-Organization-Id` header.
  * Anything else, including every failure, resolves to nulls: the row's glyph
  * fallback is the error state, a chooser row never surfaces an error.
  */
@@ -134,6 +136,7 @@ export function useChooserRowAvatar(
 ): ChooserRowAvatar {
   const activeAssistantId = useResolvedAssistantsStore.use.activeAssistantId();
   const isConnectedRow = assistant.id === activeAssistantId;
+  const isOrgReady = useIsOrgReady();
 
   const connected = useAssistantAvatar(isConnectedRow ? assistant.id : null);
 
@@ -145,7 +148,10 @@ export function useChooserRowAvatar(
       trackBlobUrl(assistant.id, avatar.imageUrl);
       return avatar;
     },
-    enabled: !isConnectedRow && canFetchRowAvatarViaPlatformProxy(assistant),
+    enabled:
+      !isConnectedRow &&
+      isOrgReady &&
+      canFetchRowAvatarViaPlatformProxy(assistant),
     staleTime: Infinity,
     structuralSharing: false,
     // A rejected query leaves `data` undefined, which reads as nulls below.


### PR DESCRIPTION
## Summary
- Add `useChooserRowAvatar(assistant)` returning `{ traits, imageUrl }` for one chooser row, built as a precedence chain later PRs extend (host disk, platform avatarUrl, id map, IndexedDB cache).
- Export `canFetchRowAvatarViaPlatformProxy(row)`: a per-row SDK fetch is only addressable when the platform proxy routes by id, i.e. not local / remote-gateway / gateway-auth, no self-hosted ingress rewrite, and the row is platform-hosted. The hook issues zero SDK calls otherwise.
- Connected row delegates to `useAssistantAvatar` (correct in every mode, no duplicate fetch); other platform rows use a React Query keyed `["chooserRowAvatar", id]` with per-row manifest-vs-legacy gating via `versionSupportsAvatarStateManifest(row version)`, probing the manifest when the version is unknown. Failures resolve to nulls (glyph fallback is the error state).
- Export `fetchAvatarViaManifest` / `fetchAvatarViaLegacyFiles` from `use-assistant-avatar.ts` for reuse instead of duplicating them; own blob-URL map so the two caches never revoke each other.
- Tests: gate flips per mode flag and row kind, zero-call assertions, connected-row delegation and cache reuse, version-gated path selection, unknown-version probe fallback, failure to nulls, per-id keying.

Part of plan: chooser-assistant-avatars.md (PR 2 of 11)