### PR TITLE
daemon: extract shared ensureAvatarRaster helper from the avatar/get re-render path

### DIFF
--- a/assistant/src/avatar/__tests__/ensure-raster.test.ts
+++ b/assistant/src/avatar/__tests__/ensure-raster.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Tests for ensureAvatarRaster.
+ *
+ * Character re-render routes through the native @resvg/resvg-js binding. As in
+ * avatar-store.test.ts, the re-render case branches on `isResvgAvailable()` so
+ * the suite is deterministic whether or not the binding is installed.
+ */
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { ensureAvatarRaster } from "../ensure-raster.js";
+import {
+  __resetResvgCacheForTests,
+  __setResvgCacheForTests,
+  isResvgAvailable,
+} from "../resvg-lazy.js";
+
+const VALID_TRAITS = { bodyShape: "blob", eyeStyle: "curious", color: "green" };
+
+const IMAGE_FILENAME = "avatar-image.png";
+const MANIFEST_FILENAME = "avatar.json";
+const NATIVE_RENDER_TEST_TIMEOUT_MS = 15_000;
+
+const FAKE_PNG = Buffer.from("not-really-a-png");
+
+describe("ensureAvatarRaster", () => {
+  let workspaceDir: string;
+  let avatarDir: string;
+  let prevWorkspaceDir: string | undefined;
+
+  beforeEach(() => {
+    workspaceDir = mkdtempSync(join(tmpdir(), "ensure-raster-test-"));
+    avatarDir = join(workspaceDir, "data", "avatar");
+    mkdirSync(avatarDir, { recursive: true });
+    prevWorkspaceDir = process.env.VELLUM_WORKSPACE_DIR;
+    process.env.VELLUM_WORKSPACE_DIR = workspaceDir;
+  });
+
+  afterEach(() => {
+    __resetResvgCacheForTests();
+    if (prevWorkspaceDir === undefined) {
+      delete process.env.VELLUM_WORKSPACE_DIR;
+    } else {
+      process.env.VELLUM_WORKSPACE_DIR = prevWorkspaceDir;
+    }
+    rmSync(workspaceDir, { recursive: true, force: true });
+  });
+
+  const writeManifestFile = (manifest: Record<string, unknown>) => {
+    writeFileSync(join(avatarDir, MANIFEST_FILENAME), JSON.stringify(manifest));
+  };
+
+  test("returns null for kind none", async () => {
+    writeManifestFile({
+      kind: "none",
+      traits: null,
+      source: null,
+      image: null,
+    });
+    expect(await ensureAvatarRaster()).toBeNull();
+  });
+
+  test("returns null with no manifest and no legacy files", async () => {
+    expect(await ensureAvatarRaster()).toBeNull();
+  });
+
+  test("returns the existing PNG bytes for an image avatar", async () => {
+    writeFileSync(join(avatarDir, IMAGE_FILENAME), FAKE_PNG);
+    writeManifestFile({
+      kind: "image",
+      traits: null,
+      source: "upload",
+      image: { updatedAt: new Date().toISOString(), etag: "0123456789abcdef" },
+    });
+    const raster = await ensureAvatarRaster();
+    expect(raster).not.toBeNull();
+    expect(raster!.equals(FAKE_PNG)).toBe(true);
+  });
+
+  test("returns the existing PNG for a character without re-rendering", async () => {
+    writeFileSync(join(avatarDir, IMAGE_FILENAME), FAKE_PNG);
+    writeManifestFile({
+      kind: "character",
+      traits: VALID_TRAITS,
+      source: "builder",
+      image: null,
+    });
+    // Force the unavailable path: a re-render attempt would return null.
+    __setResvgCacheForTests({ available: false, error: new Error("nope") });
+    const raster = await ensureAvatarRaster();
+    expect(raster).not.toBeNull();
+    expect(raster!.equals(FAKE_PNG)).toBe(true);
+  });
+
+  test("returns null for an image avatar whose PNG is missing", async () => {
+    writeManifestFile({
+      kind: "image",
+      traits: null,
+      source: "upload",
+      image: { updatedAt: new Date().toISOString(), etag: "0123456789abcdef" },
+    });
+    expect(await ensureAvatarRaster()).toBeNull();
+    expect(existsSync(join(avatarDir, IMAGE_FILENAME))).toBe(false);
+  });
+
+  test("returns null for a character when resvg is unavailable", async () => {
+    writeManifestFile({
+      kind: "character",
+      traits: VALID_TRAITS,
+      source: "builder",
+      image: null,
+    });
+    __setResvgCacheForTests({ available: false, error: new Error("nope") });
+    expect(await ensureAvatarRaster()).toBeNull();
+    expect(existsSync(join(avatarDir, IMAGE_FILENAME))).toBe(false);
+  });
+
+  test(
+    "re-renders a character whose PNG is missing",
+    async () => {
+      writeManifestFile({
+        kind: "character",
+        traits: VALID_TRAITS,
+        source: "builder",
+        image: null,
+      });
+      const raster = await ensureAvatarRaster();
+      if (!isResvgAvailable()) {
+        expect(raster).toBeNull();
+        return;
+      }
+      expect(raster).not.toBeNull();
+      expect(raster!.length).toBeGreaterThan(0);
+      // PNG magic bytes
+      expect(
+        raster!.subarray(0, 4).equals(Buffer.from([0x89, 0x50, 0x4e, 0x47])),
+      ).toBe(true);
+      expect(existsSync(join(avatarDir, IMAGE_FILENAME))).toBe(true);
+    },
+    NATIVE_RENDER_TEST_TIMEOUT_MS,
+  );
+
+  test("accepts an explicit state instead of reading the manifest", async () => {
+    writeFileSync(join(avatarDir, IMAGE_FILENAME), FAKE_PNG);
+    // No manifest on disk; explicit `none` wins over the legacy PNG.
+    expect(
+      await ensureAvatarRaster({
+        kind: "none",
+        traits: null,
+        source: null,
+        image: null,
+      }),
+    ).toBeNull();
+  });
+});

--- a/assistant/src/avatar/__tests__/ensure-raster.test.ts
+++ b/assistant/src/avatar/__tests__/ensure-raster.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for ensureAvatarRaster.
+ * Tests for ensureAvatarRaster and ensureAvatarRasterPath.
  *
  * Character re-render routes through the native @resvg/resvg-js binding. As in
  * avatar-store.test.ts, the re-render case branches on `isResvgAvailable()` so
@@ -16,7 +16,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
-import { ensureAvatarRaster } from "../ensure-raster.js";
+import {
+  ensureAvatarRaster,
+  ensureAvatarRasterPath,
+} from "../ensure-raster.js";
 import {
   __resetResvgCacheForTests,
   __setResvgCacheForTests,
@@ -159,5 +162,79 @@ describe("ensureAvatarRaster", () => {
         image: null,
       }),
     ).toBeNull();
+  });
+
+  describe("ensureAvatarRasterPath", () => {
+    test("returns null for kind none", async () => {
+      writeFileSync(join(avatarDir, IMAGE_FILENAME), FAKE_PNG);
+      writeManifestFile({
+        kind: "none",
+        traits: null,
+        source: null,
+        image: null,
+      });
+      expect(await ensureAvatarRasterPath()).toBeNull();
+    });
+
+    test("returns the path of an existing PNG without reading it", async () => {
+      writeFileSync(join(avatarDir, IMAGE_FILENAME), FAKE_PNG);
+      writeManifestFile({
+        kind: "image",
+        traits: null,
+        source: "upload",
+        image: {
+          updatedAt: new Date().toISOString(),
+          etag: "0123456789abcdef",
+        },
+      });
+      expect(await ensureAvatarRasterPath()).toBe(
+        join(avatarDir, IMAGE_FILENAME),
+      );
+    });
+
+    test("returns null for an image avatar whose PNG is missing", async () => {
+      writeManifestFile({
+        kind: "image",
+        traits: null,
+        source: "upload",
+        image: {
+          updatedAt: new Date().toISOString(),
+          etag: "0123456789abcdef",
+        },
+      });
+      expect(await ensureAvatarRasterPath()).toBeNull();
+    });
+
+    test("returns null for a character when resvg is unavailable", async () => {
+      writeManifestFile({
+        kind: "character",
+        traits: VALID_TRAITS,
+        source: "builder",
+        image: null,
+      });
+      __setResvgCacheForTests({ available: false, error: new Error("nope") });
+      expect(await ensureAvatarRasterPath()).toBeNull();
+      expect(existsSync(join(avatarDir, IMAGE_FILENAME))).toBe(false);
+    });
+
+    test(
+      "re-renders a character whose PNG is missing and returns its path",
+      async () => {
+        writeManifestFile({
+          kind: "character",
+          traits: VALID_TRAITS,
+          source: "builder",
+          image: null,
+        });
+        const path = await ensureAvatarRasterPath();
+        if (!isResvgAvailable()) {
+          expect(path).toBeNull();
+          return;
+        }
+        expect(path).toBe(join(avatarDir, IMAGE_FILENAME));
+        expect(existsSync(path!)).toBe(true);
+      },
+      NATIVE_RENDER_TEST_TIMEOUT_MS,
+    );
   });
 });

--- a/assistant/src/avatar/ensure-raster.ts
+++ b/assistant/src/avatar/ensure-raster.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 
 import { getLogger } from "../util/logger.js";
 import { getAvatarImagePath } from "../util/platform.js";
@@ -28,7 +28,8 @@ function readPng(path: string): Buffer | null {
 }
 
 /**
- * Returns the PNG raster for the current avatar, or null when there is none.
+ * Returns the on-disk path of the current avatar PNG, or null when there is
+ * none. Never reads the raster bytes.
  *
  * Side-effect-free when the PNG already exists. A character whose PNG is
  * missing is re-rendered from its persisted traits (best-effort; null when
@@ -37,17 +38,19 @@ function readPng(path: string): Buffer | null {
  *
  * Callers that already hold the avatar state can pass it to skip the re-read.
  */
-export async function ensureAvatarRaster(
+export async function ensureAvatarRasterPath(
   state: AvatarState = readAvatarState(),
-): Promise<Buffer | null> {
+): Promise<string | null> {
   if (state.kind === "none") {
     return null;
   }
 
   const avatarPath = getAvatarImagePath();
-  const existing = readPng(avatarPath);
-  if (existing || state.kind !== "character" || !state.traits) {
-    return existing;
+  if (existsSync(avatarPath)) {
+    return avatarPath;
+  }
+  if (state.kind !== "character" || !state.traits) {
+    return null;
   }
 
   try {
@@ -61,5 +64,16 @@ export async function ensureAvatarRaster(
     return null;
   }
 
-  return readPng(avatarPath);
+  return existsSync(avatarPath) ? avatarPath : null;
+}
+
+/**
+ * Returns the PNG raster for the current avatar, or null when there is none.
+ * Same existence and regeneration semantics as `ensureAvatarRasterPath`.
+ */
+export async function ensureAvatarRaster(
+  state: AvatarState = readAvatarState(),
+): Promise<Buffer | null> {
+  const avatarPath = await ensureAvatarRasterPath(state);
+  return avatarPath ? readPng(avatarPath) : null;
 }

--- a/assistant/src/avatar/ensure-raster.ts
+++ b/assistant/src/avatar/ensure-raster.ts
@@ -1,0 +1,65 @@
+import { readFileSync } from "node:fs";
+
+import { getLogger } from "../util/logger.js";
+import { getAvatarImagePath } from "../util/platform.js";
+import {
+  type AvatarState,
+  deriveStateFromLegacyFiles,
+  readManifest,
+} from "./avatar-manifest.js";
+import { writeTraitsAndRenderAvatar } from "./traits-png-sync.js";
+
+const log = getLogger("ensure-raster");
+
+/** Manifest first, legacy sidecars as fallback. Never persists. */
+function readAvatarState(): AvatarState {
+  return readManifest() ?? deriveStateFromLegacyFiles();
+}
+
+function readPng(path: string): Buffer | null {
+  try {
+    return readFileSync(path);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+    throw err;
+  }
+}
+
+/**
+ * Returns the PNG raster for the current avatar, or null when there is none.
+ *
+ * Side-effect-free when the PNG already exists. A character whose PNG is
+ * missing is re-rendered from its persisted traits (best-effort; null when
+ * the native rasterizer is unavailable or the render fails). An image-kind
+ * avatar with a missing PNG cannot be recovered and yields null.
+ *
+ * Callers that already hold the avatar state can pass it to skip the re-read.
+ */
+export async function ensureAvatarRaster(
+  state: AvatarState = readAvatarState(),
+): Promise<Buffer | null> {
+  if (state.kind === "none") {
+    return null;
+  }
+
+  const avatarPath = getAvatarImagePath();
+  const existing = readPng(avatarPath);
+  if (existing || state.kind !== "character" || !state.traits) {
+    return existing;
+  }
+
+  try {
+    const result = writeTraitsAndRenderAvatar(state.traits);
+    if (!result.ok) {
+      log.warn({ reason: result.reason }, "Avatar raster re-render failed");
+      return null;
+    }
+  } catch (err) {
+    log.warn({ err }, "Avatar raster re-render threw");
+    return null;
+  }
+
+  return readPng(avatarPath);
+}

--- a/assistant/src/runtime/routes/__tests__/avatar-state-routes.test.ts
+++ b/assistant/src/runtime/routes/__tests__/avatar-state-routes.test.ts
@@ -464,7 +464,7 @@ describe("GET /avatar/get (manifest-driven precedence)", () => {
     base64?: string;
   }
 
-  test("returns the PNG for an image manifest", () => {
+  test("returns the PNG for an image manifest", async () => {
     writeFileSync(path(IMAGE_FILENAME), Buffer.from("png bytes"));
     const state: AvatarState = {
       kind: "image",
@@ -474,12 +474,12 @@ describe("GET /avatar/get (manifest-driven precedence)", () => {
     };
     writeManifest(state, avatarDir);
 
-    const result = getHandler("avatar_get")({}) as GetResult;
+    const result = (await getHandler("avatar_get")({})) as GetResult;
     expect(result.exists).toBe(true);
     expect(result.path).toBe(path(IMAGE_FILENAME));
   });
 
-  test("returns base64 for an image manifest when format=base64", () => {
+  test("returns base64 for an image manifest when format=base64", async () => {
     writeFileSync(path(IMAGE_FILENAME), Buffer.from("png bytes"));
     const state: AvatarState = {
       kind: "image",
@@ -489,15 +489,15 @@ describe("GET /avatar/get (manifest-driven precedence)", () => {
     };
     writeManifest(state, avatarDir);
 
-    const result = getHandler("avatar_get")({
+    const result = (await getHandler("avatar_get")({
       queryParams: { format: "base64" },
-    }) as GetResult;
+    })) as GetResult;
     expect(result.exists).toBe(true);
     expect(result.base64).toBe(Buffer.from("png bytes").toString("base64"));
     expect(result.path).toBeUndefined();
   });
 
-  test("returns the existing raster for a character manifest", () => {
+  test("returns the existing raster for a character manifest", async () => {
     // The builder writes the rendered PNG; assert the accessor returns it
     // without needing to re-render (the manifest says character).
     writeFileSync(path(IMAGE_FILENAME), Buffer.from("rendered character png"));
@@ -509,12 +509,12 @@ describe("GET /avatar/get (manifest-driven precedence)", () => {
     };
     writeManifest(state, avatarDir);
 
-    const result = getHandler("avatar_get")({}) as GetResult;
+    const result = (await getHandler("avatar_get")({})) as GetResult;
     expect(result.exists).toBe(true);
     expect(result.path).toBe(path(IMAGE_FILENAME));
   });
 
-  test("manifest precedence wins over file order: a character manifest is honored even when a PNG is present", () => {
+  test("manifest precedence wins over file order: a character manifest is honored even when a PNG is present", async () => {
     // Both a PNG and traits are on disk, but the manifest declares character.
     // The pre-manifest accessor was image-first; precedence is now the manifest.
     writeFileSync(path(IMAGE_FILENAME), Buffer.from("rendered character png"));
@@ -527,27 +527,27 @@ describe("GET /avatar/get (manifest-driven precedence)", () => {
     };
     writeManifest(state, avatarDir);
 
-    const result = getHandler("avatar_get")({}) as GetResult;
+    const result = (await getHandler("avatar_get")({})) as GetResult;
     expect(result.exists).toBe(true);
     expect(result.path).toBe(path(IMAGE_FILENAME));
   });
 
-  test("returns exists:false for a none manifest", () => {
+  test("returns exists:false for a none manifest", async () => {
     writeManifest(
       { kind: "none", traits: null, source: null, image: null },
       avatarDir,
     );
 
-    const result = getHandler("avatar_get")({}) as GetResult;
+    const result = (await getHandler("avatar_get")({})) as GetResult;
     expect(result.exists).toBe(false);
     expect(result.path).toBeUndefined();
   });
 
-  test("self-heals from legacy files when no manifest exists (image file) and persists the manifest", () => {
+  test("self-heals from legacy files when no manifest exists (image file) and persists the manifest", async () => {
     writeFileSync(path(IMAGE_FILENAME), Buffer.from("png bytes"));
     expect(existsSync(path(MANIFEST_FILENAME))).toBe(false);
 
-    const result = getHandler("avatar_get")({}) as GetResult;
+    const result = (await getHandler("avatar_get")({})) as GetResult;
     expect(result.exists).toBe(true);
     expect(result.path).toBe(path(IMAGE_FILENAME));
 
@@ -558,14 +558,14 @@ describe("GET /avatar/get (manifest-driven precedence)", () => {
     expect(persisted.kind).toBe("image");
   });
 
-  test("returns exists:false for an empty workspace (no manifest, no files)", () => {
-    const result = getHandler("avatar_get")({}) as GetResult;
+  test("returns exists:false for an empty workspace (no manifest, no files)", async () => {
+    const result = (await getHandler("avatar_get")({})) as GetResult;
     expect(result.exists).toBe(false);
   });
 
-  test("rejects an invalid format", () => {
-    expect(() =>
+  test("rejects an invalid format", async () => {
+    await expect(
       getHandler("avatar_get")({ queryParams: { format: "bmp" } }),
-    ).toThrow(/Invalid format/);
+    ).rejects.toThrow(/Invalid format/);
   });
 });

--- a/assistant/src/runtime/routes/avatar-routes.ts
+++ b/assistant/src/runtime/routes/avatar-routes.ts
@@ -16,11 +16,11 @@ import {
   setImage,
 } from "../../avatar/avatar-store.js";
 import { getCharacterComponents } from "../../avatar/character-components.js";
+import { ensureAvatarRaster } from "../../avatar/ensure-raster.js";
 import { updateIdentityAvatarSection } from "../../avatar/identity-avatar.js";
 import {
   type CharacterTraits,
   TRAITS_FILENAME,
-  writeTraitsAndRenderAvatar,
 } from "../../avatar/traits-png-sync.js";
 import { setPlatformBaseUrl } from "../../config/env.js";
 import { credentialKey } from "../../security/credential-key.js";
@@ -259,7 +259,7 @@ function handleRemoveAvatar({ headers }: RouteHandlerArgs) {
   return { ok: true, hadAvatar };
 }
 
-function handleGetAvatar({ queryParams, body }: RouteHandlerArgs) {
+async function handleGetAvatar({ queryParams, body }: RouteHandlerArgs) {
   const format = (queryParams?.format ??
     (body as Record<string, unknown>)?.format ??
     "path") as string;
@@ -281,27 +281,16 @@ function handleGetAvatar({ queryParams, body }: RouteHandlerArgs) {
     return { exists: false };
   }
 
-  const avatarPath = getAvatarImagePath();
-
-  // For a character, the rendered PNG normally already exists on disk. Keep the
-  // existing safety net: if it's missing, re-render it from the persisted traits
-  // so the accessor still returns a raster.
-  if (state.kind === "character" && !existsSync(avatarPath) && state.traits) {
-    try {
-      writeTraitsAndRenderAvatar(state.traits);
-    } catch {
-      // Best-effort
-    }
-  }
-
-  if (!existsSync(avatarPath)) {
+  // Re-renders a character whose PNG is missing (pre-existing GET side effect).
+  const raster = await ensureAvatarRaster(state);
+  if (!raster) {
     return { exists: false };
   }
 
   if (format === "path") {
-    return { exists: true, path: avatarPath };
+    return { exists: true, path: getAvatarImagePath() };
   }
-  return { exists: true, base64: readFileSync(avatarPath).toString("base64") };
+  return { exists: true, base64: raster.toString("base64") };
 }
 
 function handleCharacterAscii({ queryParams, body }: RouteHandlerArgs) {

--- a/assistant/src/runtime/routes/avatar-routes.ts
+++ b/assistant/src/runtime/routes/avatar-routes.ts
@@ -16,7 +16,10 @@ import {
   setImage,
 } from "../../avatar/avatar-store.js";
 import { getCharacterComponents } from "../../avatar/character-components.js";
-import { ensureAvatarRaster } from "../../avatar/ensure-raster.js";
+import {
+  ensureAvatarRaster,
+  ensureAvatarRasterPath,
+} from "../../avatar/ensure-raster.js";
 import { updateIdentityAvatarSection } from "../../avatar/identity-avatar.js";
 import {
   type CharacterTraits,
@@ -28,11 +31,7 @@ import { getSecureKeyAsync } from "../../security/secure-keys.js";
 import { detectMediaType } from "../../tools/shared/filesystem/image-read.js";
 import { generateAvatarImage } from "../../tools/system/avatar-generator.js";
 import { getLogger } from "../../util/logger.js";
-import {
-  getAvatarDir,
-  getAvatarImagePath,
-  getWorkspaceDir,
-} from "../../util/platform.js";
+import { getAvatarDir, getWorkspaceDir } from "../../util/platform.js";
 import { ACTOR_PRINCIPALS, LOCAL_PRINCIPALS } from "../auth/route-policy.js";
 import { publishAvatarChanged } from "../sync/resource-sync-events.js";
 import {
@@ -281,14 +280,15 @@ async function handleGetAvatar({ queryParams, body }: RouteHandlerArgs) {
     return { exists: false };
   }
 
-  // Re-renders a character whose PNG is missing (pre-existing GET side effect).
+  // A character whose PNG is missing is regenerated on read. Path mode never
+  // loads the raster bytes.
+  if (format === "path") {
+    const path = await ensureAvatarRasterPath(state);
+    return path ? { exists: true, path } : { exists: false };
+  }
   const raster = await ensureAvatarRaster(state);
   if (!raster) {
     return { exists: false };
-  }
-
-  if (format === "path") {
-    return { exists: true, path: getAvatarImagePath() };
   }
   return { exists: true, base64: raster.toString("base64") };
 }


### PR DESCRIPTION
## Summary
- Add `ensureAvatarRaster(state?)` in `assistant/src/avatar/ensure-raster.ts`: returns the current avatar PNG bytes, re-rendering a character from its persisted traits when the PNG is missing (null when the native resvg binding is unavailable or the render fails); `none` and image-kind-with-missing-PNG yield null. Side-effect-free when the raster already exists.
- Route `avatar/get` through the helper, replacing the route-local re-render. Behavior unchanged (the existing GET side effect is intentionally kept here and not spread to `avatar/state`).
- Tests for every branch, following the availability-branching pattern from `avatar-store.test.ts`; existing `avatar/get` route tests now await the (now async) handler.
- Verified the avatar suites pass both with the resvg binding present and with it mocked as unavailable.

Part of plan: chooser-assistant-avatars.md (PR 7 of 11)