### PR TITLE
fix(credentials): mask secrets with a leading prefix

### DIFF
--- a/assistant/src/__tests__/credential-routes.test.ts
+++ b/assistant/src/__tests__/credential-routes.test.ts
@@ -749,10 +749,26 @@ describe("credentials routes", () => {
       expect(entry.service).toBe("vercel");
       expect(entry.field).toBe("api_token");
       expect(entry.hasSecret).toBe(true);
-      expect(entry.scrubbedValue).toBe("****alue");
+      expect(entry.scrubbedValue).toBe("supe****");
 
       // AND the raw secret never appears anywhere in the response
       expect(JSON.stringify(result)).not.toContain(SECRET_VALUE);
+    });
+
+    test("masked preview keeps a vendor token prefix", async () => {
+      const token = "cfat_000000000000000000000000000000000000abcd";
+      await setRoute!.handler({
+        body: {
+          service: "cloudflare",
+          field: "api_token",
+          value: token,
+        },
+      });
+
+      const result = (await listRoute!.handler({ body: {} })) as ListResponse;
+      expect(result.credentials).toHaveLength(1);
+      expect(result.credentials[0].scrubbedValue).toBe("cfat****");
+      expect(JSON.stringify(result)).not.toContain(token);
     });
 
     test("filters credentials by search substring", async () => {

--- a/assistant/src/cli/commands/credentials.help.ts
+++ b/assistant/src/cli/commands/credentials.help.ts
@@ -178,7 +178,7 @@ Arguments:
   id   (optional) Credential UUID for lookup by ID
 
 Shows everything known about a credential without revealing the secret value.
-The secret is masked to show only the last 4 characters (e.g. ****c123).
+The secret is masked to show only the first 4 characters (e.g. cfat****).
 
 Displayed fields include: label, creation/update timestamps, allowed tools,
 allowed domains, OAuth2 scopes, account info, and injection template count.

--- a/assistant/src/runtime/routes/credential-routes.ts
+++ b/assistant/src/runtime/routes/credential-routes.ts
@@ -72,7 +72,8 @@ function scrubSecret(secret: string | undefined): string {
   if (secret.length <= 4) {
     return "****";
   }
-  return "****" + secret.slice(-4);
+  // Keep the leading 4 characters so vendor prefixes stay visible.
+  return secret.slice(0, 4) + "****";
 }
 
 function safeGetConnectionByProvider(

--- a/clients/web/src/domains/settings/credentials/credential-row.tsx
+++ b/clients/web/src/domains/settings/credentials/credential-row.tsx
@@ -150,7 +150,7 @@ export function CredentialRow({
 // ---------------------------------------------------------------------------
 // CredentialValue — masked/revealed secret preview for a single stored
 // credential. Owns its own reveal + copy state so the row stays a thin
-// orchestrator. The masked preview (`****last4`) is rendered blurred until the
+// orchestrator. The masked preview (`first4****`) is rendered blurred until the
 // user reveals it, at which point the plaintext is fetched on demand via
 // `POST /v1/credentials/reveal` — the value is never held in the list query
 // cache, only in this component's transient state, and is dropped on re-hide.
@@ -193,7 +193,7 @@ function CredentialValue({
   // an upsert, so without this the stale plaintext from the previous value
   // would remain visible and copyable until the row remounts. Using
   // `updatedAt` (not `scrubbedValue`) avoids a false negative when the
-  // replacement masks to the same preview (e.g. same last four chars or any
+  // replacement masks to the same preview (e.g. same first four chars or any
   // value ≤ 4 chars where scrubSecret() returns "****").
   useEffect(() => {
     hide();
@@ -275,7 +275,7 @@ function CredentialValue({
         }
         // Prevent session-replay (LogRocket) from recording the credential
         // value. The attribute is always present so the masked preview
-        // (****last4) is also excluded, not just the revealed plaintext.
+        // (first4****) is also excluded, not just the revealed plaintext.
         // https://docs.logrocket.com/reference/dom#sanitizing-individual-elements
         data-private
         className={`min-w-0 truncate rounded-sm text-left transition-[filter,color] focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--border-focus)] ${


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan
Switch `assistant credentials list` / inspect masking from the last 4 characters to the first 4, so vendor token prefixes stay visible without revealing the secret.

`list` and `inspect` share `scrubSecret()`. This also updates the settings UI preview that consumes the same `scrubbedValue` field.

## Test plan
- `cd assistant && bun test src/__tests__/credential-routes.test.ts`

## CLI verb checklist
No new routes. Existing `credentials list` / `inspect` output shape is unchanged; only the mask format changes.

## Risk
Low. Masked previews change from `****last4` to `first4****`. Secrets of length 4 or less still render as `****`. The full secret is still never returned from list/inspect.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-256acf3e-37d6-4e07-82a2-8053e54db9ec?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-256acf3e-37d6-4e07-82a2-8053e54db9ec&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

