### PR TITLE
fix(web): recognize mobile Edge and Opera UA tokens in device-label

### DIFF
--- a/clients/web/src/domains/settings/pair-device/device-label.test.ts
+++ b/clients/web/src/domains/settings/pair-device/device-label.test.ts
@@ -51,6 +51,30 @@ describe("labelFromUserAgent", () => {
     ).toEqual({ browser: "Safari", os: "iPhone" });
   });
 
+  test("Edge on Android is not reported as Chrome", () => {
+    expect(
+      labelFromUserAgent(
+        "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Mobile Safari/537.36 EdgA/128.0.2739.42",
+      ),
+    ).toEqual({ browser: "Edge", os: "Android" });
+  });
+
+  test("Edge on iOS is not reported as Safari", () => {
+    expect(
+      labelFromUserAgent(
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 EdgiOS/128.2739.44 Mobile/15E148 Safari/604.1",
+      ),
+    ).toEqual({ browser: "Edge", os: "iPhone" });
+  });
+
+  test("Opera on iOS is not reported as Safari", () => {
+    expect(
+      labelFromUserAgent(
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 OPiOS/8.5.2.93674 Mobile/15E148 Safari/604.1",
+      ),
+    ).toEqual({ browser: "Opera", os: "iPhone" });
+  });
+
   test("Chrome on Android", () => {
     expect(
       labelFromUserAgent(

--- a/clients/web/src/domains/settings/pair-device/device-label.ts
+++ b/clients/web/src/domains/settings/pair-device/device-label.ts
@@ -43,10 +43,10 @@ function detectOS(userAgent: string): string | null {
 }
 
 function detectBrowser(userAgent: string): string | null {
-  if (/Edg\//.test(userAgent)) {
+  if (/Edg\/|EdgA\/|EdgiOS\//.test(userAgent)) {
     return "Edge";
   }
-  if (/OPR\//.test(userAgent)) {
+  if (/OPR\/|OPiOS\//.test(userAgent)) {
     return "Opera";
   }
   if (/Firefox\//.test(userAgent)) {


### PR DESCRIPTION
## Summary
Fixes a gap identified during plan review for paired-device-names.md.

**Gap:** detectBrowser in device-label.ts only checked desktop Edge (Edg/) and desktop Opera (OPR/) tokens. Mobile variants use different tokens (EdgA/ for Edge Android, EdgiOS/ for Edge iOS, OPiOS/ for Opera iOS), which fell through to a generic Chrome or Safari match, mislabeling the device.