### PR TITLE
fix(gateway): correct control-char and truncation ordering in capDeviceIdentityText

### DIFF
--- a/gateway/src/__tests__/device-identity-text.test.ts
+++ b/gateway/src/__tests__/device-identity-text.test.ts
@@ -27,15 +27,18 @@ describe("capDeviceIdentityText", () => {
 
   test("trims surrounding whitespace", () => {
     expect(
-      capDeviceIdentityText("  Noa's iPhone  ", MAX_CLIENT_REPORTED_NAME_CHARS),
-    ).toBe("Noa's iPhone");
+      capDeviceIdentityText(
+        "  Alice's iPhone  ",
+        MAX_CLIENT_REPORTED_NAME_CHARS,
+      ),
+    ).toBe("Alice's iPhone");
   });
 
   test("strips control characters including an embedded newline", () => {
-    const withNewline = "Noa's" + String.fromCharCode(10) + "iPhone";
+    const withNewline = "Alice's" + String.fromCharCode(10) + "iPhone";
     expect(
       capDeviceIdentityText(withNewline, MAX_CLIENT_REPORTED_NAME_CHARS),
-    ).toBe("Noa'siPhone");
+    ).toBe("Alice'siPhone");
   });
 
   test("strips an ESC control character", () => {
@@ -63,5 +66,59 @@ describe("capDeviceIdentityText", () => {
     expect(
       capDeviceIdentityText("Chrome on macOS", MAX_CLIENT_REPORTED_NAME_CHARS),
     ).toBe("Chrome on macOS");
+  });
+
+  test("control-character-only value becomes null, not an empty string", () => {
+    const result = capDeviceIdentityText(
+      String.fromCharCode(1),
+      MAX_CLIENT_REPORTED_NAME_CHARS,
+    );
+    expect(result).toBe(null);
+  });
+
+  test("whitespace surrounding control characters still becomes null", () => {
+    const value = "  " + String.fromCharCode(1) + "  ";
+    expect(capDeviceIdentityText(value, MAX_CLIENT_REPORTED_NAME_CHARS)).toBe(
+      null,
+    );
+  });
+
+  test("stripping control characters exposes whitespace that also gets trimmed", () => {
+    const value =
+      " " + String.fromCharCode(1) + " hello " + String.fromCharCode(1) + " ";
+    expect(capDeviceIdentityText(value, MAX_CLIENT_REPORTED_NAME_CHARS)).toBe(
+      "hello",
+    );
+  });
+
+  test("truncation at the char cap keeps a boundary surrogate pair whole rather than splitting it", () => {
+    const maxChars = MAX_CLIENT_REPORTED_NAME_CHARS;
+    const emoji = "\u{1F600}"; // surrogate pair: 2 UTF-16 code units, 1 code point
+    // maxChars - 1 plain ASCII chars, then the emoji, then more filler —
+    // so the emoji's surrogate pair straddles the UTF-16 code-unit offset
+    // `maxChars` (the boundary a naive .slice(0, maxChars) would cut at).
+    const value = "a".repeat(maxChars - 1) + emoji + "bbbb";
+    const result = capDeviceIdentityText(value, maxChars);
+    expect(result).not.toBe(null);
+    const safeResult = result ?? "";
+
+    // The result must be either the emoji included whole, or excluded
+    // entirely — never a lone unpaired surrogate.
+    const withEmoji = "a".repeat(maxChars - 1) + emoji;
+    const withoutEmoji = "a".repeat(maxChars);
+    expect(safeResult === withEmoji || safeResult === withoutEmoji).toBe(
+      true,
+    );
+
+    // Directly rule out an unpaired high or low surrogate anywhere in the
+    // result, regardless of which branch above it landed on.
+    const hasLoneHighSurrogate = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])/.test(
+      safeResult,
+    );
+    const hasLoneLowSurrogate = /(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(
+      safeResult,
+    );
+    expect(hasLoneHighSurrogate).toBe(false);
+    expect(hasLoneLowSurrogate).toBe(false);
   });
 });

--- a/gateway/src/auth/device-identity-text.ts
+++ b/gateway/src/auth/device-identity-text.ts
@@ -28,10 +28,12 @@ export function capDeviceIdentityText(
   if (value === null || value === undefined) {
     return null;
   }
-  const trimmed = value.trim();
+  const trimmed = stripControlChars(value).trim();
   if (trimmed === "") {
     return null;
   }
-  const stripped = stripControlChars(trimmed);
-  return stripped.slice(0, maxChars);
+  // Truncate by code point, not UTF-16 code unit, so an astral character
+  // (e.g. an emoji surrogate pair) at the boundary is kept or dropped
+  // whole rather than split into an unpaired surrogate.
+  return Array.from(trimmed).slice(0, maxChars).join("");
 }


### PR DESCRIPTION
## Summary
Fixes two correctness gaps identified during plan review for paired-device-names.md.

**Gap 1:** capDeviceIdentityText returned an empty string instead of null for input consisting solely of non-whitespace control characters, because the empty-check ran before control-character stripping. Now strips first, trims, then checks emptiness.

**Gap 2:** the final .slice(0, maxChars) truncation counted UTF-16 code units, which could split a surrogate pair (e.g. an emoji) in half at the boundary. Now truncates by code point.