### PR TITLE
refactor(gateway): consolidate device identity capping and typing

### DIFF
--- a/gateway/src/auth/guardian-bootstrap.ts
+++ b/gateway/src/auth/guardian-bootstrap.ts
@@ -662,6 +662,23 @@ export interface DeviceIdentityInput {
   clientReportedName?: string | null;
 }
 
+/** Cap a device identity's free-text fields to their stored max lengths. */
+function capIdentity(identity?: DeviceIdentityInput): {
+  pairingUserAgent: string | null;
+  clientReportedName: string | null;
+} {
+  return {
+    pairingUserAgent: capDeviceIdentityText(
+      identity?.pairingUserAgent,
+      MAX_PAIRING_USER_AGENT_CHARS,
+    ),
+    clientReportedName: capDeviceIdentityText(
+      identity?.clientReportedName,
+      MAX_CLIENT_REPORTED_NAME_CHARS,
+    ),
+  };
+}
+
 /**
  * Mint a JWT access token and persist its hash in the gateway DB.
  */
@@ -695,14 +712,7 @@ function mintAccessToken(
       guardianPrincipalId,
       hashedDeviceId,
       platform,
-      pairingUserAgent: capDeviceIdentityText(
-        identity?.pairingUserAgent,
-        MAX_PAIRING_USER_AGENT_CHARS,
-      ),
-      clientReportedName: capDeviceIdentityText(
-        identity?.clientReportedName,
-        MAX_CLIENT_REPORTED_NAME_CHARS,
-      ),
+      ...capIdentity(identity),
       status: "active",
       issuedAt: now,
       expiresAt,
@@ -744,14 +754,7 @@ function mintRefreshToken(
       guardianPrincipalId,
       hashedDeviceId,
       platform,
-      pairingUserAgent: capDeviceIdentityText(
-        identity?.pairingUserAgent,
-        MAX_PAIRING_USER_AGENT_CHARS,
-      ),
-      clientReportedName: capDeviceIdentityText(
-        identity?.clientReportedName,
-        MAX_CLIENT_REPORTED_NAME_CHARS,
-      ),
+      ...capIdentity(identity),
       status: "active",
       issuedAt: now,
       absoluteExpiresAt,

--- a/gateway/src/auth/guardian-refresh.ts
+++ b/gateway/src/auth/guardian-refresh.ts
@@ -19,6 +19,7 @@ import {
   ACCESS_TOKEN_TTL_SECONDS,
   REFRESH_AFTER_FRACTION,
   REFRESH_INACTIVITY_TTL_MS,
+  type DeviceIdentityInput,
 } from "./guardian-bootstrap.js";
 import { guardianIntegrityState } from "./guardian-integrity.js";
 import { CURRENT_POLICY_EPOCH } from "./policy.js";
@@ -137,8 +138,7 @@ function mintAccessToken(
   guardianPrincipalId: string,
   hashedDeviceId: string,
   platform: string,
-  pairingUserAgent: string | null,
-  clientReportedName: string | null,
+  identity: DeviceIdentityInput,
 ): { token: string; expiresAt: number } {
   const externalAssistantId = getExternalAssistantId();
   const sub = `actor:${externalAssistantId}:${guardianPrincipalId}`;
@@ -163,8 +163,8 @@ function mintAccessToken(
       guardianPrincipalId,
       hashedDeviceId,
       platform,
-      pairingUserAgent,
-      clientReportedName,
+      pairingUserAgent: identity.pairingUserAgent,
+      clientReportedName: identity.clientReportedName,
       status: "active",
       issuedAt: now,
       expiresAt,
@@ -180,8 +180,7 @@ function mintRefreshTokenInFamily(params: {
   guardianPrincipalId: string;
   hashedDeviceId: string;
   platform: string;
-  pairingUserAgent: string | null;
-  clientReportedName: string | null;
+  identity: DeviceIdentityInput;
   familyId: string;
   absoluteExpiresAt: number;
   browserRefreshCookiePath?: string;
@@ -204,8 +203,8 @@ function mintRefreshTokenInFamily(params: {
       guardianPrincipalId: params.guardianPrincipalId,
       hashedDeviceId: params.hashedDeviceId,
       platform: params.platform,
-      pairingUserAgent: params.pairingUserAgent,
-      clientReportedName: params.clientReportedName,
+      pairingUserAgent: params.identity.pairingUserAgent,
+      clientReportedName: params.identity.clientReportedName,
       status: "active",
       issuedAt: now,
       absoluteExpiresAt: params.absoluteExpiresAt,
@@ -292,20 +291,23 @@ function rotateRefreshTokenRecord(
       record.hashedDeviceId,
     );
 
+    const identity: DeviceIdentityInput = {
+      pairingUserAgent: record.pairingUserAgent,
+      clientReportedName: record.clientReportedName,
+    };
+
     const access = mintAccessToken(
       record.guardianPrincipalId,
       record.hashedDeviceId,
       record.platform,
-      record.pairingUserAgent,
-      record.clientReportedName,
+      identity,
     );
 
     const refresh = mintRefreshTokenInFamily({
       guardianPrincipalId: record.guardianPrincipalId,
       hashedDeviceId: record.hashedDeviceId,
       platform: record.platform,
-      pairingUserAgent: record.pairingUserAgent,
-      clientReportedName: record.clientReportedName,
+      identity,
       familyId: record.familyId,
       absoluteExpiresAt: record.absoluteExpiresAt,
       browserRefreshCookiePath: record.browserRefreshCookiePath ?? undefined,


### PR DESCRIPTION
## Summary
Fixes two code-quality gaps identified during plan review for paired-device-names.md.

- guardian-bootstrap.ts: factored the duplicated identity-capping block (used identically in mintAccessToken and mintRefreshToken) into a single capIdentity helper.
- guardian-refresh.ts: its private mintAccessToken and mintRefreshTokenInFamily now accept a single identity: DeviceIdentityInput parameter (imported from guardian-bootstrap.ts) instead of two loose parameters, matching the convention already established in guardian-bootstrap.ts. Pure signature refactor, no behavior change: rotation still does not re-cap already-stored values.