### PR TITLE
fix: test hygiene sweep (generic names, present-tense comment, duplicate query)

### DIFF
--- a/clients/web/src/domains/settings/pair-device/paired-devices-section.test.tsx
+++ b/clients/web/src/domains/settings/pair-device/paired-devices-section.test.tsx
@@ -324,9 +324,9 @@ describe("PairedDevicesSection", () => {
   });
 
   test("a device with a client-reported name shows it verbatim, hash hidden but kept in the title", async () => {
-    await renderExpanded([device({ clientReportedName: "Noa's Laptop" })]);
+    await renderExpanded([device({ clientReportedName: "Alice's Laptop" })]);
 
-    const name = screen.getByText("Noa's Laptop");
+    const name = screen.getByText("Alice's Laptop");
     expect(name.getAttribute("title")).toBe(HASH_A);
     expect(screen.queryByText(HASH_A.slice(0, 12))).toBeNull();
   });
@@ -353,13 +353,13 @@ describe("PairedDevicesSection", () => {
   });
 
   test("the revoke confirmation leads with a client-reported name", async () => {
-    await renderExpanded([device({ clientReportedName: "Noa's Laptop" })]);
+    await renderExpanded([device({ clientReportedName: "Alice's Laptop" })]);
 
     fireEvent.click(screen.getByRole("button", { name: "Revoke" }));
 
     expect(
       screen.getByText(
-        new RegExp(`Noa's Laptop \\(${HASH_A.slice(0, 12)}\\)`),
+        new RegExp(`Alice's Laptop \\(${HASH_A.slice(0, 12)}\\)`),
       ),
     ).toBeTruthy();
   });

--- a/gateway/src/__tests__/devices.test.ts
+++ b/gateway/src/__tests__/devices.test.ts
@@ -216,38 +216,20 @@ describe("actorTokenRecords device identity columns", () => {
     seedActor({
       device: "device-identity-populated",
       pairingUserAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
-      clientReportedName: "Noa's MacBook Pro",
+      clientReportedName: "Alice's MacBook Pro",
     });
 
-    const row = getGatewayDb()
-      .select()
-      .from(actorTokenRecords)
-      .where(
-        eq(
-          actorTokenRecords.hashedDeviceId,
-          hashToken("device-identity-populated"),
-        ),
-      )
-      .get();
+    const row = actorRow("device-identity-populated");
     expect(row?.pairingUserAgent).toBe(
       "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
     );
-    expect(row?.clientReportedName).toBe("Noa's MacBook Pro");
+    expect(row?.clientReportedName).toBe("Alice's MacBook Pro");
   });
 
   test("leaves pairingUserAgent and clientReportedName null when omitted", () => {
     seedActor({ device: "device-identity-omitted" });
 
-    const row = getGatewayDb()
-      .select()
-      .from(actorTokenRecords)
-      .where(
-        eq(
-          actorTokenRecords.hashedDeviceId,
-          hashToken("device-identity-omitted"),
-        ),
-      )
-      .get();
+    const row = actorRow("device-identity-omitted");
     expect(row?.pairingUserAgent).toBeNull();
     expect(row?.clientReportedName).toBeNull();
   });
@@ -261,7 +243,7 @@ describe("mintAndRecordDeviceBoundTokenPair identity persistence", () => {
       platform: "cli",
       identity: {
         pairingUserAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
-        clientReportedName: "Noa's MacBook Pro",
+        clientReportedName: "Alice's MacBook Pro",
       },
     });
 
@@ -269,13 +251,13 @@ describe("mintAndRecordDeviceBoundTokenPair identity persistence", () => {
     expect(access?.pairingUserAgent).toBe(
       "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
     );
-    expect(access?.clientReportedName).toBe("Noa's MacBook Pro");
+    expect(access?.clientReportedName).toBe("Alice's MacBook Pro");
 
     const refresh = refreshRow("mint-device-with-identity");
     expect(refresh?.pairingUserAgent).toBe(
       "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
     );
-    expect(refresh?.clientReportedName).toBe("Noa's MacBook Pro");
+    expect(refresh?.clientReportedName).toBe("Alice's MacBook Pro");
   });
 
   test("writes null to both columns on both tables when identity is omitted", () => {
@@ -395,17 +377,17 @@ describe("/v1/pair clientReportedName", () => {
     const res = await handlePair(
       makeExtensionPairRequest({
         deviceId: "device-ext-name",
-        clientReportedName: "Noa's Chromebook",
+        clientReportedName: "Alice's Chromebook",
       }),
       LOOPBACK_IP,
     );
     expect(res.status).toBe(200);
 
     expect(actorRow("device-ext-name")?.clientReportedName).toBe(
-      "Noa's Chromebook",
+      "Alice's Chromebook",
     );
     expect(refreshRow("device-ext-name")?.clientReportedName).toBe(
-      "Noa's Chromebook",
+      "Alice's Chromebook",
     );
   });
 
@@ -413,17 +395,17 @@ describe("/v1/pair clientReportedName", () => {
     const res = await handlePair(
       makeCliPairRequest({
         deviceId: "device-cli-name",
-        clientReportedName: "Noa's MacBook Pro",
+        clientReportedName: "Alice's MacBook Pro",
       }),
       LOOPBACK_IP,
     );
     expect(res.status).toBe(200);
 
     expect(actorRow("device-cli-name")?.clientReportedName).toBe(
-      "Noa's MacBook Pro",
+      "Alice's MacBook Pro",
     );
     expect(refreshRow("device-cli-name")?.clientReportedName).toBe(
-      "Noa's MacBook Pro",
+      "Alice's MacBook Pro",
     );
   });
 
@@ -497,7 +479,7 @@ describe("GET /v1/devices", () => {
     seedActor({
       device: "device-A",
       pairingUserAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
-      clientReportedName: "Noa's MacBook Pro",
+      clientReportedName: "Alice's MacBook Pro",
       lastUsedAt: 1_700_000_000_000,
     });
     seedActor({ device: "device-B" });
@@ -518,7 +500,7 @@ describe("GET /v1/devices", () => {
     expect(a?.pairingUserAgent).toBe(
       "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)",
     );
-    expect(a?.clientReportedName).toBe("Noa's MacBook Pro");
+    expect(a?.clientReportedName).toBe("Alice's MacBook Pro");
     expect(a?.lastUsedAt).toBe(1_700_000_000_000);
 
     const b = body.devices.find(

--- a/gateway/src/__tests__/edge-auth.test.ts
+++ b/gateway/src/__tests__/edge-auth.test.ts
@@ -734,7 +734,7 @@ describe("handleCreateToken: derived actor-token identity carry-forward", () => 
     const sourceToken = mintSourceToken();
     seedSourceActorToken(sourceToken, {
       pairingUserAgent: "Vellum/1.2 (Macintosh; Intel Mac OS X 10_15_7)",
-      clientReportedName: "Noa's MacBook Pro",
+      clientReportedName: "Alice's MacBook Pro",
     });
 
     const res = await handleCreateToken(
@@ -748,7 +748,7 @@ describe("handleCreateToken: derived actor-token identity carry-forward", () => 
     expect(derived?.pairingUserAgent).toBe(
       "Vellum/1.2 (Macintosh; Intel Mac OS X 10_15_7)",
     );
-    expect(derived?.clientReportedName).toBe("Noa's MacBook Pro");
+    expect(derived?.clientReportedName).toBe("Alice's MacBook Pro");
   });
 
   test("a null-identity source row produces a derived row with nulls and does not throw", async () => {

--- a/gateway/src/__tests__/refresh-device-binding.test.ts
+++ b/gateway/src/__tests__/refresh-device-binding.test.ts
@@ -331,11 +331,10 @@ describe("rotateCredentials activity history", () => {
 });
 
 describe("rotateCredentials device identity carry-forward", () => {
-  // Regression for #41228: lastUsedAt lived on one table only and rotation
-  // reset it, costing two remediation rounds. pairingUserAgent and
-  // clientReportedName must survive rotation the same way platform does.
+  // pairingUserAgent and clientReportedName survive rotation the same way
+  // platform does.
   const USER_AGENT = "Vellum-CLI/1.2.3 (Macintosh; Darwin)";
-  const REPORTED_NAME = "Noa's MacBook Pro";
+  const REPORTED_NAME = "Alice's MacBook Pro";
 
   function findActorTokenRow(rawToken: string) {
     return getGatewayDb()

--- a/gateway/src/__tests__/remote-web-pairing-token.test.ts
+++ b/gateway/src/__tests__/remote-web-pairing-token.test.ts
@@ -752,7 +752,7 @@ describe("remote web pairing token exchange", () => {
 
   test("a missing deviceCode returns the deviceCode is required 400", async () => {
     const res = await handleRemoteWebPairingToken(
-      makeTokenRequest({ clientReportedName: "Noa's iPhone" }),
+      makeTokenRequest({ clientReportedName: "Alice's iPhone" }),
     );
 
     expect(res.status).toBe(400);
@@ -813,13 +813,13 @@ describe("remote web pairing token exchange", () => {
     const res = await handleRemoteWebPairingToken(
       makeTokenRequest({
         deviceCode: challenge.deviceCode,
-        clientReportedName: "Noa's iPhone",
+        clientReportedName: "Alice's iPhone",
       }),
     );
 
     expect(res.status).toBe(200);
-    expect(activeTokens()[0].clientReportedName).toBe("Noa's iPhone");
-    expect(activeRefreshTokens()[0].clientReportedName).toBe("Noa's iPhone");
+    expect(activeTokens()[0].clientReportedName).toBe("Alice's iPhone");
+    expect(activeRefreshTokens()[0].clientReportedName).toBe("Alice's iPhone");
   });
 
   test("a non-string clientReportedName still exchanges with the field null", async () => {

--- a/packages/local-mode/src/devices.test.ts
+++ b/packages/local-mode/src/devices.test.ts
@@ -50,7 +50,7 @@ describe("runDevicesList", () => {
               expiresAt: 2000,
               lastUsedAt: 1500,
               pairingUserAgent: "Vellum/1.0 iOS",
-              clientReportedName: "Noa's iPhone",
+              clientReportedName: "Alice's iPhone",
             },
           ],
         }),
@@ -68,7 +68,7 @@ describe("runDevicesList", () => {
           expiresAt: 2000,
           lastUsedAt: 1500,
           pairingUserAgent: "Vellum/1.0 iOS",
-          clientReportedName: "Noa's iPhone",
+          clientReportedName: "Alice's iPhone",
         },
       ],
     });


### PR DESCRIPTION
## Summary
Fixes three gaps identified during plan review for paired-device-names.md.

- Replaced a real personal name used in test fixtures across 6 files with generic placeholders, per AGENTS.md's Generic Examples policy.
- Rewrote a past-tense regression-history comment in refresh-device-binding.test.ts to present tense, per AGENTS.md's Code Comments policy.
- Replaced an inline duplicate DB query in devices.test.ts with the existing actorRow helper.