### PR TITLE
feat(cli): speak assistant replies in the terminal (JARVIS-1638)

### DIFF
--- a/cli/src/commands/voice.ts
+++ b/cli/src/commands/voice.ts
@@ -41,11 +41,11 @@ OPTIONS:
     --help               Show this help
 
 DESCRIPTION:
-    Opens a live-voice session with no microphone. Each line you type is taken
-    as a turn (max ${MAX_TEXT_TURN_CHARS} characters) and the reply is streamed
-    back as text and spoken aloud.
+    Opens a live-voice session with no microphone. Each line you type is
+    taken as a turn and the reply is streamed back as text and spoken aloud.
+    A turn is at most ${MAX_TEXT_TURN_CHARS} characters.
 
-    Speech needs a PCM player on PATH: ffplay, play (sox), or aplay stream the
+    Speech needs a PCM player on PATH. ffplay, play (sox), or aplay stream the
     audio as it arrives; afplay (macOS) plays each reply once it is complete.
     With none of them installed the session still runs, printed but silent.
 
@@ -111,16 +111,24 @@ interface SessionDeps {
  * Drive one session to completion.
  *
  * Resolves when the socket closes, whether that is the user leaving or a
- * failure; the exit code is set on the way out rather than thrown, so a failed
+ * failure. The exit code is set on the way out rather than thrown, so a failed
  * session prints one line instead of a stack.
  */
 function runSession({ client, player, reference }: SessionDeps): Promise<void> {
   return new Promise<void>((resolve) => {
     let rl: Interface | null = null;
-    // True from the moment a turn is sent until its speech is done or
-    // cancelled. The daemon refuses a second turn while one is in flight, so
-    // the prompt is withheld for exactly as long.
+    // True from the moment a turn is sent until its reply has been spoken.
+    // The daemon refuses a second turn while one is in flight, so the prompt
+    // is withheld for exactly as long.
     let turnInFlight = false;
+    /**
+     * The in-flight turn's server-side id, once anything has named it.
+     *
+     * Lets a completion frame be matched to the turn it belongs to. Null while
+     * the turn is still anonymous, in which case a completion frame is taken
+     * at face value, which is what this did before ids were tracked at all.
+     */
+    let activeTurnId: string | null = null;
     // Whether anything of this turn's reply has been printed yet, so the
     // speaker label is written once rather than per delta.
     let replyStarted = false;
@@ -141,17 +149,37 @@ function runSession({ client, player, reference }: SessionDeps): Promise<void> {
       resolve();
     };
 
-    const endTurn = (): void => {
+    /** Hand the prompt back and let the user take another turn. */
+    const endTurn = (note?: string): void => {
+      // `finished` matters as much as `turnInFlight`: a session that closed
+      // while a `finish()` was still awaited resolves it through dispose(),
+      // and the prompt must not be redrawn under a closed interface.
+      if (!turnInFlight || finished) {
+        return;
+      }
       turnInFlight = false;
+      activeTurnId = null;
       replyStarted = false;
       lastActivity = "";
+      if (note) {
+        process.stdout.write(chalk.dim(note));
+      }
       process.stdout.write("\n");
+      rl?.resume();
       rl?.prompt();
     };
 
-    client.on("ready", (frame) => {
-      const speaking = describePlayback(player);
+    /**
+     * Whether a completion frame belongs to the turn currently in flight.
+     *
+     * A turn abandoned locally (Ctrl+C) leaves the prompt free while the
+     * daemon may still be winding down, so a late frame must not be allowed to
+     * end whatever turn came after it.
+     */
+    const completesActiveTurn = (turnId: string): boolean =>
+      turnInFlight && (activeTurnId === null || activeTurnId === turnId);
 
+    client.on("ready", (frame) => {
       if (!client.supportsTextInput) {
         // The `ready` echo is the only reliable signal. A daemon that predates
         // typed turns answers every `text` frame with `unknown_type`, so
@@ -165,13 +193,15 @@ function runSession({ client, player, reference }: SessionDeps): Promise<void> {
         return;
       }
 
-      console.log(chalk.dim(`Connected to ${reference} — ${speaking}.`));
+      console.log(
+        chalk.dim(`Connected to ${reference}. ${describePlayback(player)}.`),
+      );
       if (!client.hasAudioInput) {
         // Expected here rather than alarming: this client declared it can type,
         // which is what let the session open text-only instead of being refused.
         console.log(
           chalk.dim(
-            "Speech-to-text is not configured on this assistant; typed turns only.",
+            "Speech-to-text is not configured on this assistant, so typed turns only.",
           ),
         );
       }
@@ -185,7 +215,7 @@ function runSession({ client, player, reference }: SessionDeps): Promise<void> {
       rl = createInterface({
         input: process.stdin,
         output: process.stdout,
-        prompt: chalk.cyan("› "),
+        prompt: chalk.cyan("> "),
       });
 
       rl.on("line", (line) => {
@@ -204,29 +234,37 @@ function runSession({ client, player, reference }: SessionDeps): Promise<void> {
           return;
         }
         if (turnInFlight) {
-          console.error(chalk.yellow("Still replying — Ctrl+C to interrupt."));
+          console.error(chalk.yellow("Still replying. Ctrl+C to interrupt."));
           return;
         }
         if (!client.sendText(text)) {
           console.error(
-            chalk.yellow("Message not sent — the session is closed."),
+            chalk.yellow("Message not sent, the session is closed."),
           );
           return;
         }
         turnInFlight = true;
+        activeTurnId = null;
         // Withhold the prompt until the reply lands, so the next line the user
         // types is not composed against a turn the daemon would refuse.
         rl?.pause();
       });
 
       rl.on("SIGINT", () => {
-        if (turnInFlight) {
-          // Barge-in: the same thing speaking over the assistant does.
-          client.interrupt();
-          player?.stop();
+        if (!turnInFlight) {
+          client.end();
           return;
         }
-        client.end();
+        // Barge-in. The turn ends here rather than on a frame from the daemon,
+        // because a client `interrupt` is answered with neither `tts_done` nor
+        // `turn_cancelled`: the daemon's `interrupt()` cancels the turn through
+        // `cancelAssistantTurn`, `tts_done` is gated on the turn not being
+        // aborted, and `turn_cancelled` is only sent down the VAD barge-in
+        // path. Waiting for one would hang the prompt for the rest of the
+        // session.
+        client.interrupt();
+        player?.stop();
+        endTurn(" [interrupted]");
       });
 
       rl.on("close", () => {
@@ -239,19 +277,20 @@ function runSession({ client, player, reference }: SessionDeps): Promise<void> {
     });
 
     client.on("activity", (frame) => {
-      // Only worth showing while the turn is still silent — once text is
+      activeTurnId = frame.turnId;
+      // Only worth showing while the turn is still silent. Once text is
       // streaming, the reply itself is the better progress indicator.
       if (replyStarted || frame.label === "" || frame.label === lastActivity) {
         return;
       }
       lastActivity = frame.label;
-      console.log(chalk.dim(`  … ${frame.label}`));
+      console.log(chalk.dim(`  ... ${frame.label}`));
     });
 
     client.on("textDelta", (frame) => {
       if (!replyStarted) {
         replyStarted = true;
-        process.stdout.write(chalk.green("‹ "));
+        process.stdout.write(chalk.green("< "));
       }
       process.stdout.write(frame.text);
     });
@@ -263,21 +302,25 @@ function runSession({ client, player, reference }: SessionDeps): Promise<void> {
       player.write(Buffer.from(frame.dataBase64, "base64"), frame.sampleRate);
     });
 
-    client.on("turnDone", () => {
-      player?.finish();
-      if (turnInFlight) {
-        rl?.resume();
-        endTurn();
+    client.on("turnDone", (turnId) => {
+      if (!completesActiveTurn(turnId)) {
+        // Still drain the audio: the frame is stale for the prompt's purposes
+        // but the bytes are real and already queued.
+        void player?.finish();
+        return;
       }
+      // The turn is not over until the speaker is quiet. Handing the prompt
+      // back at the last byte instead would make Ctrl+C quit the session while
+      // the assistant is still talking, and let the next turn start a second
+      // player over the top of the first.
+      void player?.finish().then(() => endTurn());
     });
 
-    client.on("turnCancelled", () => {
+    client.on("turnCancelled", (turnId) => {
       // Audio still in flight belongs to a turn that no longer exists.
       player?.stop();
-      if (turnInFlight) {
-        process.stdout.write(chalk.dim(" [interrupted]"));
-        rl?.resume();
-        endTurn();
+      if (completesActiveTurn(turnId)) {
+        endTurn(" [interrupted]");
       }
     });
 
@@ -289,10 +332,8 @@ function runSession({ client, player, reference }: SessionDeps): Promise<void> {
             : `Turn not taken: ${message}`,
         ),
       );
-      if (turnInFlight) {
-        rl?.resume();
-        endTurn();
-      }
+      player?.stop();
+      endTurn();
     });
 
     client.on("warning", (message) => {
@@ -319,14 +360,14 @@ function runSession({ client, player, reference }: SessionDeps): Promise<void> {
  */
 function describePlayback(player: PcmPlayer | null): string {
   if (!player) {
-    return "audio off (--no-audio)";
+    return "Audio off (--no-audio)";
   }
   switch (player.mode) {
     case "streaming":
-      return `speaking via ${player.playerName}`;
+      return `Speaking via ${player.playerName}`;
     case "buffered":
-      return `speaking via ${player.playerName}, one reply at a time`;
+      return `Speaking via ${player.playerName}, one reply at a time`;
     case "silent":
-      return "silent — install ffplay, sox, or aplay to hear replies";
+      return "Silent: install ffplay, sox, or aplay to hear replies";
   }
 }

--- a/cli/src/commands/voice.ts
+++ b/cli/src/commands/voice.ts
@@ -1,0 +1,332 @@
+/**
+ * `vellum voice [assistant]`
+ *
+ * Type a turn in the terminal, hear the assistant speak the reply.
+ *
+ * A real live-voice session that never opens a microphone: each typed line
+ * goes out as a `text` frame and joins the pipeline where a finished
+ * transcript would have, so the answer streams back through the same turn
+ * runner, the same segmented text-to-speech, and the same barge-in as a spoken
+ * turn. Ctrl+C mid-reply cuts the assistant off exactly as speaking over it
+ * would.
+ */
+
+import { createInterface, type Interface } from "node:readline";
+
+import chalk from "chalk";
+
+import { parseAssistantTargetArg } from "../lib/assistant-target-args.js";
+import { CliLiveVoiceClient } from "../lib/live-voice/client.js";
+import {
+  LiveVoiceConnectionError,
+  resolveLiveVoiceConnection,
+} from "../lib/live-voice/connection.js";
+import { PcmPlayer } from "../lib/live-voice/pcm-player.js";
+import { MAX_TEXT_TURN_CHARS } from "../lib/live-voice/protocol.js";
+
+const VALUE_FLAGS = ["--conversation"] as const;
+
+function printUsage(): void {
+  console.log(`vellum voice - Talk to an assistant by typing; hear it answer
+
+USAGE:
+    vellum voice [assistant] [options]
+
+ARGUMENTS:
+    [assistant]    Instance name or ID (default: active assistant)
+
+OPTIONS:
+    --conversation <id>  Continue an existing conversation instead of starting one
+    --no-audio           Print replies without speaking them
+    --help               Show this help
+
+DESCRIPTION:
+    Opens a live-voice session with no microphone. Each line you type is taken
+    as a turn (max ${MAX_TEXT_TURN_CHARS} characters) and the reply is streamed
+    back as text and spoken aloud.
+
+    Speech needs a PCM player on PATH: ffplay, play (sox), or aplay stream the
+    audio as it arrives; afplay (macOS) plays each reply once it is complete.
+    With none of them installed the session still runs, printed but silent.
+
+    Ctrl+C interrupts the assistant mid-reply. Ctrl+D, or Ctrl+C when nothing
+    is being spoken, ends the session.
+
+    Local and self-hosted assistants only. Vellum cloud assistants authenticate
+    with a session token, which the voice endpoint does not accept.
+
+EXAMPLES:
+    vellum voice
+    vellum voice my-assistant
+    vellum voice my-assistant --no-audio
+    vellum voice --conversation conv_01H8XK3
+`);
+}
+
+export async function voice(): Promise<void> {
+  const args = process.argv.slice(3);
+  if (args.includes("--help") || args.includes("-h")) {
+    printUsage();
+    return;
+  }
+
+  const assistantArg = parseAssistantTargetArg(args, VALUE_FLAGS);
+  const conversationIdx = args.indexOf("--conversation");
+  const conversationId =
+    conversationIdx !== -1 ? args[conversationIdx + 1] : undefined;
+  if (conversationIdx !== -1 && !conversationId) {
+    console.error("Error: --conversation requires a conversation id.");
+    process.exit(1);
+  }
+  const audioEnabled = !args.includes("--no-audio");
+
+  let connection;
+  try {
+    connection = await resolveLiveVoiceConnection(assistantArg);
+  } catch (err) {
+    if (err instanceof LiveVoiceConnectionError) {
+      console.error(`Error: ${err.message}`);
+      process.exit(1);
+    }
+    throw err;
+  }
+
+  const player = audioEnabled ? new PcmPlayer() : null;
+  const client = new CliLiveVoiceClient({
+    url: connection.url,
+    token: connection.token,
+    ...(conversationId ? { conversationId } : {}),
+  });
+
+  await runSession({ client, player, reference: connection.reference });
+}
+
+interface SessionDeps {
+  client: CliLiveVoiceClient;
+  player: PcmPlayer | null;
+  reference: string;
+}
+
+/**
+ * Drive one session to completion.
+ *
+ * Resolves when the socket closes, whether that is the user leaving or a
+ * failure; the exit code is set on the way out rather than thrown, so a failed
+ * session prints one line instead of a stack.
+ */
+function runSession({ client, player, reference }: SessionDeps): Promise<void> {
+  return new Promise<void>((resolve) => {
+    let rl: Interface | null = null;
+    // True from the moment a turn is sent until its speech is done or
+    // cancelled. The daemon refuses a second turn while one is in flight, so
+    // the prompt is withheld for exactly as long.
+    let turnInFlight = false;
+    // Whether anything of this turn's reply has been printed yet, so the
+    // speaker label is written once rather than per delta.
+    let replyStarted = false;
+    let lastActivity = "";
+    let finished = false;
+
+    const finish = (error?: string): void => {
+      if (finished) {
+        return;
+      }
+      finished = true;
+      player?.dispose();
+      rl?.close();
+      if (error) {
+        console.error(`\n${chalk.red("Error:")} ${error}`);
+        process.exitCode = 1;
+      }
+      resolve();
+    };
+
+    const endTurn = (): void => {
+      turnInFlight = false;
+      replyStarted = false;
+      lastActivity = "";
+      process.stdout.write("\n");
+      rl?.prompt();
+    };
+
+    client.on("ready", (frame) => {
+      const speaking = describePlayback(player);
+
+      if (!client.supportsTextInput) {
+        // The `ready` echo is the only reliable signal. A daemon that predates
+        // typed turns answers every `text` frame with `unknown_type`, so
+        // opening the prompt anyway would give the user a session that
+        // silently swallows everything they type.
+        finish(
+          `${reference} does not accept typed turns. Upgrade it with ` +
+            `'vellum upgrade' and try again.`,
+        );
+        client.end();
+        return;
+      }
+
+      console.log(chalk.dim(`Connected to ${reference} — ${speaking}.`));
+      if (!client.hasAudioInput) {
+        // Expected here rather than alarming: this client declared it can type,
+        // which is what let the session open text-only instead of being refused.
+        console.log(
+          chalk.dim(
+            "Speech-to-text is not configured on this assistant; typed turns only.",
+          ),
+        );
+      }
+      console.log(
+        chalk.dim(
+          "Type a message and press enter. Ctrl+C interrupts, Ctrl+D exits.",
+        ),
+      );
+      console.log(`Conversation: ${chalk.dim(frame.conversationId)}\n`);
+
+      rl = createInterface({
+        input: process.stdin,
+        output: process.stdout,
+        prompt: chalk.cyan("› "),
+      });
+
+      rl.on("line", (line) => {
+        const text = line.trim();
+        if (text.length === 0) {
+          rl?.prompt();
+          return;
+        }
+        if (text.length > MAX_TEXT_TURN_CHARS) {
+          console.error(
+            chalk.yellow(
+              `Too long: ${text.length} characters, limit is ${MAX_TEXT_TURN_CHARS}.`,
+            ),
+          );
+          rl?.prompt();
+          return;
+        }
+        if (turnInFlight) {
+          console.error(chalk.yellow("Still replying — Ctrl+C to interrupt."));
+          return;
+        }
+        if (!client.sendText(text)) {
+          console.error(
+            chalk.yellow("Message not sent — the session is closed."),
+          );
+          return;
+        }
+        turnInFlight = true;
+        // Withhold the prompt until the reply lands, so the next line the user
+        // types is not composed against a turn the daemon would refuse.
+        rl?.pause();
+      });
+
+      rl.on("SIGINT", () => {
+        if (turnInFlight) {
+          // Barge-in: the same thing speaking over the assistant does.
+          client.interrupt();
+          player?.stop();
+          return;
+        }
+        client.end();
+      });
+
+      rl.on("close", () => {
+        // Ctrl+D at the prompt. `end()` is idempotent, so this is also the
+        // path taken when finish() closed the interface itself.
+        client.end();
+      });
+
+      rl.prompt();
+    });
+
+    client.on("activity", (frame) => {
+      // Only worth showing while the turn is still silent — once text is
+      // streaming, the reply itself is the better progress indicator.
+      if (replyStarted || frame.label === "" || frame.label === lastActivity) {
+        return;
+      }
+      lastActivity = frame.label;
+      console.log(chalk.dim(`  … ${frame.label}`));
+    });
+
+    client.on("textDelta", (frame) => {
+      if (!replyStarted) {
+        replyStarted = true;
+        process.stdout.write(chalk.green("‹ "));
+      }
+      process.stdout.write(frame.text);
+    });
+
+    client.on("audio", (frame) => {
+      if (!player) {
+        return;
+      }
+      player.write(Buffer.from(frame.dataBase64, "base64"), frame.sampleRate);
+    });
+
+    client.on("turnDone", () => {
+      player?.finish();
+      if (turnInFlight) {
+        rl?.resume();
+        endTurn();
+      }
+    });
+
+    client.on("turnCancelled", () => {
+      // Audio still in flight belongs to a turn that no longer exists.
+      player?.stop();
+      if (turnInFlight) {
+        process.stdout.write(chalk.dim(" [interrupted]"));
+        rl?.resume();
+        endTurn();
+      }
+    });
+
+    client.on("textTurnRejected", (reason, message) => {
+      console.error(
+        chalk.yellow(
+          reason === "unsupported"
+            ? `Typed turns are not supported by this assistant: ${message}`
+            : `Turn not taken: ${message}`,
+        ),
+      );
+      if (turnInFlight) {
+        rl?.resume();
+        endTurn();
+      }
+    });
+
+    client.on("warning", (message) => {
+      console.error(chalk.yellow(`Warning: ${message}`));
+    });
+
+    client.on("closed", (error) => {
+      if (!error) {
+        console.log(chalk.dim("\nSession ended."));
+      }
+      finish(error);
+    });
+
+    client.connect();
+  });
+}
+
+/**
+ * How this session will (or will not) speak, for the connection banner.
+ *
+ * The two silent cases are worth telling apart: a user who passed --no-audio
+ * knows why it is quiet, and a user who did not needs to be told that
+ * installing a player is what turns the sound on.
+ */
+function describePlayback(player: PcmPlayer | null): string {
+  if (!player) {
+    return "audio off (--no-audio)";
+  }
+  switch (player.mode) {
+    case "streaming":
+      return `speaking via ${player.playerName}`;
+    case "buffered":
+      return `speaking via ${player.playerName}, one reply at a time`;
+    case "silent":
+      return "silent — install ffplay, sox, or aplay to hear replies";
+  }
+}

--- a/cli/src/commands/voice.ts
+++ b/cli/src/commands/voice.ts
@@ -15,6 +15,7 @@ import { createInterface, type Interface } from "node:readline";
 
 import chalk from "chalk";
 
+import { extractValueFlag } from "../lib/arg-utils.js";
 import { parseAssistantTargetArg } from "../lib/assistant-target-args.js";
 import { CliLiveVoiceClient } from "../lib/live-voice/client.js";
 import {
@@ -23,8 +24,6 @@ import {
 } from "../lib/live-voice/connection.js";
 import { PcmPlayer } from "../lib/live-voice/pcm-player.js";
 import { MAX_TEXT_TURN_CHARS } from "../lib/live-voice/protocol.js";
-
-const VALUE_FLAGS = ["--conversation"] as const;
 
 function printUsage(): void {
   console.log(`vellum voice - Talk to an assistant by typing; hear it answer
@@ -70,14 +69,11 @@ export async function voice(): Promise<void> {
     return;
   }
 
-  const assistantArg = parseAssistantTargetArg(args, VALUE_FLAGS);
-  const conversationIdx = args.indexOf("--conversation");
-  const conversationId =
-    conversationIdx !== -1 ? args[conversationIdx + 1] : undefined;
-  if (conversationIdx !== -1 && !conversationId) {
-    console.error("Error: --conversation requires a conversation id.");
-    process.exit(1);
-  }
+  // Strips `--conversation <id>` from argv, rejecting a `-`-prefixed value:
+  // the daemon accepts any non-empty conversation id, so a swallowed option
+  // would open a conversation named after the flag it ate.
+  const conversationId = extractValueFlag(args, "conversation");
+  const assistantArg = parseAssistantTargetArg(args);
   const audioEnabled = !args.includes("--no-audio");
 
   let connection;
@@ -122,11 +118,12 @@ function runSession({ client, player, reference }: SessionDeps): Promise<void> {
     // is withheld for exactly as long.
     let turnInFlight = false;
     /**
-     * The in-flight turn's server-side id, once anything has named it.
+     * The in-flight turn's server-side id, once a frame has named it.
      *
-     * Lets a completion frame be matched to the turn it belongs to. Null while
-     * the turn is still anonymous, in which case a completion frame is taken
-     * at face value, which is what this did before ids were tracked at all.
+     * Matches a completion frame to the turn it belongs to, so one that
+     * arrives late cannot end a turn it does not describe. Null while the turn
+     * is still anonymous, in which case a completion frame is taken at face
+     * value: there is nothing to contradict it.
      */
     let activeTurnId: string | null = null;
     // Whether anything of this turn's reply has been printed yet, so the

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -37,6 +37,7 @@ import { tunnel } from "./commands/tunnel";
 import { unpair } from "./commands/unpair";
 import { upgrade } from "./commands/upgrade";
 import { use } from "./commands/use";
+import { voice } from "./commands/voice";
 import { wake } from "./commands/wake";
 import { workflows } from "./commands/workflows";
 import { resolveAssistant, setActiveAssistant } from "./lib/assistant-config";
@@ -76,6 +77,7 @@ const commands = {
   unpair,
   upgrade,
   use,
+  voice,
   wake,
   whoami,
   workflows,
@@ -131,6 +133,7 @@ function printHelp(): void {
   );
   console.log("  upgrade  Upgrade an assistant to a newer version");
   console.log("  use      Set the active assistant for commands");
+  console.log("  voice    Type to an assistant and hear it answer out loud");
   console.log("  wake     Start the assistant and gateway");
   console.log("  whoami   Show current logged-in user");
   console.log("  workflows Inspect and control workflow runs");

--- a/cli/src/lib/live-voice/client.test.ts
+++ b/cli/src/lib/live-voice/client.test.ts
@@ -1,0 +1,316 @@
+import { describe, expect, test } from "bun:test";
+
+import { CliLiveVoiceClient } from "./client.js";
+import { MAX_TEXT_TURN_CHARS } from "./protocol.js";
+
+/**
+ * Minimal stand-in for the WebSocket the client drives. Records what went out
+ * and lets a test push server frames in, so the version-skew rules can be
+ * exercised without a daemon.
+ */
+class FakeSocket {
+  static readonly OPEN = 1;
+  binaryType = "arraybuffer";
+  readyState = 0;
+  readonly sent: string[] = [];
+  closed = false;
+
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: unknown }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  onclose: ((event: { code: number; reason: string }) => void) | null = null;
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+
+  close(): void {
+    this.closed = true;
+  }
+
+  /** Complete the handshake and let the client send its `start` frame. */
+  open(): void {
+    this.readyState = FakeSocket.OPEN;
+    this.onopen?.();
+  }
+
+  /** Deliver one server frame. */
+  deliver(frame: unknown): void {
+    this.onmessage?.({ data: JSON.stringify(frame) });
+  }
+
+  sentFrames(): Record<string, unknown>[] {
+    return this.sent.map((raw) => JSON.parse(raw) as Record<string, unknown>);
+  }
+}
+
+function connected(): { client: CliLiveVoiceClient; socket: FakeSocket } {
+  const socket = new FakeSocket();
+  const client = new CliLiveVoiceClient({
+    url: "ws://127.0.0.1:7830/v1/live-voice",
+    token: "guardian-token",
+    webSocketFactory: () => socket as unknown as WebSocket,
+  });
+  client.connect();
+  socket.open();
+  return { client, socket };
+}
+
+const READY = {
+  type: "ready",
+  seq: 1,
+  sessionId: "sess_1",
+  conversationId: "conv_1",
+  textInput: true,
+};
+
+describe("start frame", () => {
+  test("declares textInput so a missing STT leg degrades instead of failing", () => {
+    const { socket } = connected();
+    const start = socket.sentFrames()[0]!;
+
+    expect(start.type).toBe("start");
+    // Load-bearing: without it the daemon refuses a session whose speech-to-text
+    // credential is missing, which is the case this client exists to survive.
+    expect(start.textInput).toBe(true);
+    expect(start.audio).toEqual({
+      mimeType: "audio/pcm",
+      sampleRate: 16000,
+      channels: 1,
+    });
+  });
+
+  test("carries a conversation id only when one was given", () => {
+    const socket = new FakeSocket();
+    const client = new CliLiveVoiceClient({
+      url: "ws://127.0.0.1:7830/v1/live-voice",
+      token: "guardian-token",
+      conversationId: "conv_resume",
+      webSocketFactory: () => socket as unknown as WebSocket,
+    });
+    client.connect();
+    socket.open();
+
+    expect(socket.sentFrames()[0]!.conversationId).toBe("conv_resume");
+    expect(connected().socket.sentFrames()[0]!).not.toHaveProperty(
+      "conversationId",
+    );
+  });
+});
+
+describe("typed turns", () => {
+  test("are refused until a ready frame echoes textInput", () => {
+    const { client, socket } = connected();
+
+    // Pre-ready: the session is not active yet.
+    expect(client.sendText("hello")).toBe(false);
+
+    socket.deliver(READY);
+    expect(client.supportsTextInput).toBe(true);
+    expect(client.sendText("hello")).toBe(true);
+    expect(socket.sentFrames().at(-1)).toEqual({ type: "text", text: "hello" });
+  });
+
+  test("are refused when ready omits textInput, rather than sent blind", () => {
+    const { client, socket } = connected();
+    // A daemon predating typed turns answers `text` with `unknown_type`, which
+    // is byte-identical to the `update_config` rejection — so absence of the
+    // echo has to mean "no", not "probably fine".
+    socket.deliver({ ...READY, textInput: undefined });
+
+    expect(client.supportsTextInput).toBe(false);
+    expect(client.sendText("hello")).toBe(false);
+    expect(socket.sentFrames().some((f) => f.type === "text")).toBe(false);
+  });
+
+  test("are trimmed, and empty or over-long text never reaches the socket", () => {
+    const { client, socket } = connected();
+    socket.deliver(READY);
+
+    expect(client.sendText("   ")).toBe(false);
+    expect(client.sendText("x".repeat(MAX_TEXT_TURN_CHARS + 1))).toBe(false);
+    expect(client.sendText("  spaced  ")).toBe(true);
+    expect(socket.sentFrames().at(-1)).toEqual({
+      type: "text",
+      text: "spaced",
+    });
+  });
+});
+
+describe("ready echoes", () => {
+  test("audioInput false opens a text-only session rather than failing it", () => {
+    const { client, socket } = connected();
+    let closedWith: string | undefined | "never" = "never";
+    client.on("closed", (error) => {
+      closedWith = error;
+    });
+
+    socket.deliver({ ...READY, audioInput: false });
+
+    expect(client.hasAudioInput).toBe(false);
+    expect(client.supportsTextInput).toBe(true);
+    expect(closedWith).toBe("never");
+  });
+
+  test("absent audioInput means the STT leg is live", () => {
+    const { client, socket } = connected();
+    socket.deliver(READY);
+    expect(client.hasAudioInput).toBe(true);
+  });
+});
+
+describe("error frames", () => {
+  test("a text-attributed rejection is reported, not treated as fatal", () => {
+    const { client, socket } = connected();
+    socket.deliver(READY);
+
+    const rejections: [string, string][] = [];
+    let closed = false;
+    client.on("textTurnRejected", (reason, message) =>
+      rejections.push([reason, message]),
+    );
+    client.on("closed", () => {
+      closed = true;
+    });
+
+    socket.deliver({
+      type: "error",
+      seq: 2,
+      code: "turn_in_progress",
+      message: "already replying",
+      recoverable: true,
+      frameType: "text",
+    });
+
+    expect(rejections).toEqual([["busy", "already replying"]]);
+    expect(closed).toBe(false);
+  });
+
+  test("unknown_type about a text frame reads as unsupported, not busy", () => {
+    const { client, socket } = connected();
+    socket.deliver(READY);
+
+    const rejections: [string, string][] = [];
+    client.on("textTurnRejected", (reason, message) =>
+      rejections.push([reason, message]),
+    );
+
+    socket.deliver({
+      type: "error",
+      seq: 2,
+      code: "unknown_type",
+      message: "unknown frame type",
+      frameType: "text",
+    });
+
+    expect(rejections[0]![0]).toBe("unsupported");
+  });
+
+  test("a recoverable error unrelated to a typed turn is a warning", () => {
+    const { client, socket } = connected();
+    socket.deliver(READY);
+
+    const warnings: string[] = [];
+    let closed = false;
+    client.on("warning", (message) => warnings.push(message));
+    client.on("closed", () => {
+      closed = true;
+    });
+
+    socket.deliver({
+      type: "error",
+      seq: 2,
+      code: "tts_failed",
+      message: "voice blip",
+      recoverable: true,
+    });
+
+    expect(warnings).toEqual(["voice blip"]);
+    expect(closed).toBe(false);
+  });
+
+  test("a non-recoverable error ends the session", () => {
+    const { client, socket } = connected();
+    socket.deliver(READY);
+
+    let closedWith: string | undefined;
+    client.on("closed", (error) => {
+      closedWith = error;
+    });
+
+    socket.deliver({
+      type: "error",
+      seq: 2,
+      code: "credentials_unavailable",
+      message: "no tts credential",
+    });
+
+    expect(closedWith).toBe("no tts credential");
+    expect(socket.closed).toBe(true);
+  });
+});
+
+describe("session lifecycle", () => {
+  test("busy ends the session naming the session already holding the floor", () => {
+    const { client, socket } = connected();
+    let closedWith: string | undefined;
+    client.on("closed", (error) => {
+      closedWith = error;
+    });
+
+    socket.deliver({ type: "busy", seq: 1, activeSessionId: "sess_other" });
+
+    expect(closedWith).toContain("sess_other");
+  });
+
+  test("a close before ready explains the likely credential rejection", () => {
+    const { client, socket } = connected();
+    let closedWith: string | undefined;
+    client.on("closed", (error) => {
+      closedWith = error;
+    });
+
+    socket.onclose?.({ code: 1008, reason: "" });
+
+    expect(closedWith).toContain("1008");
+    expect(closedWith).toContain("credential");
+  });
+
+  test("end sends the end frame once and is idempotent", () => {
+    const { client, socket } = connected();
+    socket.deliver(READY);
+
+    client.end();
+    client.end();
+
+    expect(socket.sentFrames().filter((f) => f.type === "end")).toHaveLength(1);
+    expect(socket.closed).toBe(true);
+  });
+
+  test("frames from a newer daemon are ignored, not fatal", () => {
+    const { client, socket } = connected();
+    socket.deliver(READY);
+    let closed = false;
+    client.on("closed", () => {
+      closed = true;
+    });
+
+    socket.deliver({ type: "some_future_frame", seq: 2 });
+    socket.onmessage?.({ data: "not json at all" });
+
+    expect(closed).toBe(false);
+    expect(client.sendText("still working")).toBe(true);
+  });
+});
+
+describe("interrupt", () => {
+  test("goes out only while a session is active", () => {
+    const { client, socket } = connected();
+    client.interrupt();
+    expect(socket.sentFrames().some((f) => f.type === "interrupt")).toBe(false);
+
+    socket.deliver(READY);
+    client.interrupt();
+    expect(socket.sentFrames().at(-1)).toEqual({ type: "interrupt" });
+  });
+});

--- a/cli/src/lib/live-voice/client.test.ts
+++ b/cli/src/lib/live-voice/client.test.ts
@@ -114,7 +114,7 @@ describe("typed turns", () => {
   test("are refused when ready omits textInput, rather than sent blind", () => {
     const { client, socket } = connected();
     // A daemon predating typed turns answers `text` with `unknown_type`, which
-    // is byte-identical to the `update_config` rejection — so absence of the
+    // is byte-identical to the `update_config` rejection, so absence of the
     // echo has to mean "no", not "probably fine".
     socket.deliver({ ...READY, textInput: undefined });
 

--- a/cli/src/lib/live-voice/client.ts
+++ b/cli/src/lib/live-voice/client.ts
@@ -1,0 +1,363 @@
+/**
+ * A live-voice client that never opens a microphone.
+ *
+ * One instance drives one session. It opens the gateway WebSocket, sends
+ * `start` with `textInput: true`, and from then on takes turns by typing them:
+ * a `text` frame joins the pipeline at the point speech-to-text would have
+ * handed over a finished transcript, so the reply streams back through the
+ * same turn runner, the same segmented TTS, and the same barge-in as a spoken
+ * one. Only the capture half is skipped.
+ *
+ * Modeled on `clients/web/src/domains/chat/voice/live-voice/live-voice-client.ts`
+ * and deliberately narrower: no audio upload, no push-to-talk, no mid-session
+ * config updates. After `end()` or a failure the instance is terminal.
+ */
+
+import {
+  LIVE_VOICE_AUDIO_FORMAT,
+  MAX_TEXT_TURN_CHARS,
+  parseServerFrame,
+  type LiveVoiceActivityFrame,
+  type LiveVoiceAssistantTextDeltaFrame,
+  type LiveVoiceReadyFrame,
+  type LiveVoiceStartFrame,
+  type LiveVoiceTtsAudioFrame,
+} from "./protocol.js";
+
+/** Fail the session if no `ready` frame arrives within this window. */
+const CONNECT_TIMEOUT_MS = 10_000;
+
+export interface LiveVoiceClientEvents {
+  /** The session is open. `textInput` says whether typed turns are accepted. */
+  ready(frame: LiveVoiceReadyFrame): void;
+  /** A chunk of the assistant's reply text, as the model produces it. */
+  textDelta(frame: LiveVoiceAssistantTextDeltaFrame): void;
+  /** A chunk of spoken audio. PCM16 mono at the frame's own sample rate. */
+  audio(frame: LiveVoiceTtsAudioFrame): void;
+  /** The turn's speech is fully sent. */
+  turnDone(turnId: string): void;
+  /** The turn was aborted; buffered audio for it must be dropped. */
+  turnCancelled(turnId: string): void;
+  /** A named piece of work the turn is doing ("" means idle again). */
+  activity(frame: LiveVoiceActivityFrame): void;
+  /** The daemon refused a typed turn. The session survives. */
+  textTurnRejected(reason: "unsupported" | "busy", message: string): void;
+  /** A recoverable mid-session error. The session survives. */
+  warning(message: string): void;
+  /** The session is over. `error` is set when it ended badly. */
+  closed(error?: string): void;
+}
+
+type EventName = keyof LiveVoiceClientEvents;
+
+export interface CliLiveVoiceClientOptions {
+  readonly url: string;
+  readonly token: string;
+  readonly conversationId?: string;
+  /** Override the socket factory (tests). */
+  readonly webSocketFactory?: (url: string, token: string) => WebSocket;
+  /** Override the connect timeout (tests). */
+  readonly connectTimeoutMs?: number;
+}
+
+type SessionState = "idle" | "connecting" | "active" | "closed";
+
+export class CliLiveVoiceClient {
+  private state: SessionState = "idle";
+  private ws: WebSocket | null = null;
+  private connectTimer: ReturnType<typeof setTimeout> | null = null;
+  private textInputSupported = false;
+  private audioInputLive = true;
+
+  private readonly options: CliLiveVoiceClientOptions;
+  private readonly listeners = new Map<
+    EventName,
+    Set<(...a: never[]) => void>
+  >();
+
+  constructor(options: CliLiveVoiceClientOptions) {
+    this.options = options;
+  }
+
+  on<E extends EventName>(event: E, handler: LiveVoiceClientEvents[E]): void {
+    const set = this.listeners.get(event) ?? new Set();
+    set.add(handler as (...a: never[]) => void);
+    this.listeners.set(event, set);
+  }
+
+  private emit<E extends EventName>(
+    event: E,
+    ...args: Parameters<LiveVoiceClientEvents[E]>
+  ): void {
+    for (const handler of this.listeners.get(event) ?? []) {
+      (handler as (...a: unknown[]) => void)(...args);
+    }
+  }
+
+  /** Whether this daemon accepts typed turns (set from the `ready` echo). */
+  get supportsTextInput(): boolean {
+    return this.textInputSupported;
+  }
+
+  /** Whether the session's speech-to-text leg came up. */
+  get hasAudioInput(): boolean {
+    return this.audioInputLive;
+  }
+
+  /**
+   * Open the socket. Resolves once it is opening; readiness arrives as the
+   * `ready` event, and failure as `closed` with an error.
+   */
+  connect(): void {
+    if (this.state !== "idle") {
+      return;
+    }
+    this.state = "connecting";
+
+    let ws: WebSocket;
+    try {
+      ws = this.options.webSocketFactory
+        ? this.options.webSocketFactory(this.options.url, this.options.token)
+        : openAuthenticatedSocket(this.options.url, this.options.token);
+    } catch (err) {
+      this.fail(
+        err instanceof Error
+          ? err.message
+          : "Failed to open the live-voice WebSocket",
+      );
+      return;
+    }
+    this.ws = ws;
+    ws.binaryType = "arraybuffer";
+    ws.onopen = () => this.handleOpen();
+    ws.onmessage = (event: MessageEvent) => this.handleMessage(event);
+    ws.onerror = () => this.fail("Live-voice WebSocket error");
+    ws.onclose = (event: CloseEvent) => this.handleClose(event);
+
+    this.connectTimer = setTimeout(() => {
+      if (this.state === "connecting") {
+        this.fail(
+          `Live-voice connection timed out after ${this.connectTimeoutMs()}ms`,
+        );
+      }
+    }, this.connectTimeoutMs());
+  }
+
+  /**
+   * Take a turn by typing it. Returns whether the frame went out.
+   *
+   * False means the turn was not taken at all and the caller must say so — the
+   * session is not active, the daemon predates typed turns, or the text is
+   * empty or over the cap. A turn the daemon *receives* but refuses (it is
+   * mid-reply) comes back later as `textTurnRejected`, not as false here.
+   */
+  sendText(text: string): boolean {
+    if (this.state !== "active" || !this.textInputSupported) {
+      return false;
+    }
+    const trimmed = text.trim();
+    if (trimmed.length === 0 || trimmed.length > MAX_TEXT_TURN_CHARS) {
+      return false;
+    }
+    return this.trySend(JSON.stringify({ type: "text", text: trimmed }));
+  }
+
+  /** Cut off the assistant mid-reply. */
+  interrupt(): void {
+    if (this.state !== "active") {
+      return;
+    }
+    this.trySend(JSON.stringify({ type: "interrupt" }));
+  }
+
+  /** End the session gracefully, then close the socket. Idempotent. */
+  end(): void {
+    if (this.state !== "connecting" && this.state !== "active") {
+      return;
+    }
+    // Best-effort: trySend no-ops unless the socket is OPEN, so a quick cancel
+    // during connect skips the (impossible) send and still closes cleanly.
+    this.trySend(JSON.stringify({ type: "end" }));
+    this.teardown();
+    this.emit("closed", undefined);
+  }
+
+  private connectTimeoutMs(): number {
+    return this.options.connectTimeoutMs ?? CONNECT_TIMEOUT_MS;
+  }
+
+  private handleOpen(): void {
+    if (this.state !== "connecting") {
+      return;
+    }
+    const start: LiveVoiceStartFrame = {
+      type: "start",
+      audio: LIVE_VOICE_AUDIO_FORMAT,
+      textInput: true,
+      ...(this.options.conversationId
+        ? { conversationId: this.options.conversationId }
+        : {}),
+    };
+    this.trySend(JSON.stringify(start));
+  }
+
+  private handleMessage(event: MessageEvent): void {
+    if (this.state === "closed") {
+      return;
+    }
+    // Every server payload is JSON text; binary is not part of the contract.
+    if (typeof event.data !== "string") {
+      return;
+    }
+    const frame = parseServerFrame(event.data);
+    switch (frame.type) {
+      case "ready": {
+        if (this.state !== "connecting") {
+          return;
+        }
+        this.clearConnectTimer();
+        this.state = "active";
+        this.textInputSupported = frame.textInput === true;
+        // Absent means yes: a daemon predating the field refuses any session it
+        // cannot transcribe, so every session it readies can hear.
+        this.audioInputLive = frame.audioInput !== false;
+        this.emit("ready", frame);
+        return;
+      }
+      case "busy":
+        this.fail(
+          "The assistant already has a voice session open " +
+            `(${frame.activeSessionId}).`,
+        );
+        return;
+      case "assistant_text_delta":
+        this.emit("textDelta", frame);
+        return;
+      case "tts_audio":
+        this.emit("audio", frame);
+        return;
+      case "tts_done":
+        this.emit("turnDone", frame.turnId);
+        return;
+      case "turn_cancelled":
+        this.emit("turnCancelled", frame.turnId);
+        return;
+      case "activity":
+        this.emit("activity", frame);
+        return;
+      case "thinking":
+        return;
+      case "error": {
+        // `frameType` names what the error is about. A typed turn's rejection
+        // must not be filed anywhere else: `unknown_type` here is
+        // byte-identical to the rejection an older daemon gives every optional
+        // frame, and a `recoverable` refusal is a busy assistant rather than a
+        // transient blip, so both would be misread by the generic paths below.
+        if (frame.frameType === "text") {
+          this.emit(
+            "textTurnRejected",
+            frame.code === "unknown_type" ? "unsupported" : "busy",
+            frame.message,
+          );
+          return;
+        }
+        if (frame.recoverable === true && this.state === "active") {
+          this.emit("warning", frame.message);
+          return;
+        }
+        this.fail(frame.message);
+        return;
+      }
+      case "unhandled":
+      case "malformed":
+        // Capture-side frames a mic-less session never acts on, and additions
+        // from a newer daemon. Ignoring them is what keeps protocol growth
+        // from breaking an older CLI.
+        return;
+    }
+  }
+
+  private handleClose(event: CloseEvent): void {
+    if (this.state === "closed") {
+      return;
+    }
+    if (this.state === "connecting") {
+      this.fail(closeReason(event));
+      return;
+    }
+    this.teardown();
+    this.emit("closed", undefined);
+  }
+
+  private trySend(data: string): boolean {
+    const ws = this.ws;
+    // Sending on a CONNECTING socket throws, so guard on readyState rather
+    // than on session state alone.
+    if (ws && ws.readyState === 1) {
+      ws.send(data);
+      return true;
+    }
+    return false;
+  }
+
+  private fail(message: string): void {
+    if (this.state === "closed") {
+      return;
+    }
+    this.teardown();
+    this.emit("closed", message);
+  }
+
+  private teardown(): void {
+    this.state = "closed";
+    this.clearConnectTimer();
+    const ws = this.ws;
+    this.ws = null;
+    if (ws) {
+      ws.onopen = null;
+      ws.onmessage = null;
+      ws.onerror = null;
+      ws.onclose = null;
+      ws.close();
+    }
+  }
+
+  private clearConnectTimer(): void {
+    if (this.connectTimer !== null) {
+      clearTimeout(this.connectTimer);
+      this.connectTimer = null;
+    }
+  }
+}
+
+/**
+ * Open the gateway socket with the guardian token in an `Authorization`
+ * header.
+ *
+ * The gateway takes the credential either as a header or as a `?token=` query
+ * parameter. The browser client has to use the query form — `WebSocket` there
+ * cannot set headers — but a CLI can, and should: a query parameter lands in
+ * process listings, shell history, and gateway access logs, and this token is
+ * the bound guardian's.
+ */
+function openAuthenticatedSocket(url: string, token: string): WebSocket {
+  return new WebSocket(url, {
+    headers: { Authorization: `Bearer ${token}` },
+  } as unknown as string[]) as WebSocket;
+}
+
+function closeReason(event: CloseEvent): string {
+  // 1008/1011 with no reason is what an upgrade rejected at the gateway looks
+  // like by the time it reaches a WebSocket client: the 401/403 body never
+  // survives the handshake. Name the likely cause rather than printing a bare
+  // numeric code the user cannot act on.
+  const detail = event.reason?.trim();
+  if (detail) {
+    return `Live-voice session closed before it opened: ${detail}`;
+  }
+  return (
+    "Live-voice session closed before it opened " +
+    `(code ${event.code}). The gateway may have rejected the credential — ` +
+    "try 'vellum wake' to lease a fresh one."
+  );
+}

--- a/cli/src/lib/live-voice/client.ts
+++ b/cli/src/lib/live-voice/client.ts
@@ -146,7 +146,7 @@ export class CliLiveVoiceClient {
   /**
    * Take a turn by typing it. Returns whether the frame went out.
    *
-   * False means the turn was not taken at all and the caller must say so — the
+   * False means the turn was not taken at all and the caller must say so: the
    * session is not active, the daemon predates typed turns, or the text is
    * empty or over the cap. A turn the daemon *receives* but refuses (it is
    * mid-reply) comes back later as `textTurnRejected`, not as false here.
@@ -335,8 +335,8 @@ export class CliLiveVoiceClient {
  * header.
  *
  * The gateway takes the credential either as a header or as a `?token=` query
- * parameter. The browser client has to use the query form — `WebSocket` there
- * cannot set headers — but a CLI can, and should: a query parameter lands in
+ * parameter. The browser client has to use the query form, because `WebSocket`
+ * there cannot set headers, but a CLI can and should: a query parameter lands in
  * process listings, shell history, and gateway access logs, and this token is
  * the bound guardian's.
  */
@@ -357,7 +357,7 @@ function closeReason(event: CloseEvent): string {
   }
   return (
     "Live-voice session closed before it opened " +
-    `(code ${event.code}). The gateway may have rejected the credential — ` +
+    `(code ${event.code}). The gateway may have rejected the credential: ` +
     "try 'vellum wake' to lease a fresh one."
   );
 }

--- a/cli/src/lib/live-voice/connection.ts
+++ b/cli/src/lib/live-voice/connection.ts
@@ -1,0 +1,133 @@
+/**
+ * Resolving the live-voice WebSocket URL and the credential to open it with.
+ *
+ * The endpoint is the **gateway's** `/v1/live-voice`, not the runtime's. That
+ * distinction is the whole of the auth story: the runtime's copy demands a
+ * gateway service token, which no client can mint, while the gateway's copy
+ * authenticates the caller and then mints that service token itself on the way
+ * upstream (`gateway/src/http/routes/live-voice-websocket.ts`).
+ *
+ * What the gateway wants is an actor edge JWT belonging to the *bound
+ * guardian* — live voice is a guardian-only surface, because the daemon stamps
+ * each voice turn with the guardian's trust context and the proxy replaces the
+ * caller's identity upstream, so the pin at the gateway is the only place a
+ * non-guardian can be stopped.
+ *
+ * The CLI already holds exactly that credential and has since it first paired:
+ * `leaseGuardianToken` POSTs `/v1/guardian/init`, which resolves the *vellum*
+ * guardian principal and mints an access token subject
+ * `actor:<assistantId>:<guardianPrincipalId>` — the same principal
+ * `findVellumGuardian()` returns on the other side of the check. So the pin
+ * passes by construction, and there is nothing new to provision here.
+ */
+
+import {
+  formatAssistantLookupError,
+  formatAssistantReference,
+  lookupAssistantByIdentifier,
+  resolveTargetAssistant,
+} from "../assistant-config.js";
+import {
+  guardianTokenDueForRenewal,
+  loadGuardianToken,
+  refreshGuardianToken,
+} from "../guardian-token.js";
+
+export interface LiveVoiceConnection {
+  /** `ws(s)://…/v1/live-voice` on the assistant's gateway. */
+  readonly url: string;
+  /** Guardian access token, sent as `Authorization: Bearer`. */
+  readonly token: string;
+  readonly assistantId: string;
+  /** `name (id)` when they differ, else the id — for user-facing output. */
+  readonly reference: string;
+}
+
+export class LiveVoiceConnectionError extends Error {}
+
+/**
+ * Resolve the target assistant, its gateway URL, and a usable guardian token.
+ *
+ * Refreshes the token when it is already due for renewal, so a long session
+ * does not open on a credential that expires mid-conversation. A token that is
+ * merely *rejected* is not refreshed here — that would disclose the long-lived
+ * refresh credential on demand — which matches how `AssistantClient` gates its
+ * own reactive refresh.
+ */
+export async function resolveLiveVoiceConnection(
+  assistantIdArg?: string,
+): Promise<LiveVoiceConnection> {
+  // An explicit target is looked up by id first and display name second, and
+  // an ambiguous display name is an error naming the candidates, per the
+  // package's assistant-targeting convention. With no target,
+  // `resolveTargetAssistant` applies the usual active/sole-entry fallback.
+  const entry = assistantIdArg
+    ? resolveNamedAssistant(assistantIdArg)
+    : resolveTargetAssistant();
+
+  // Platform-cloud assistants authenticate with a platform session token
+  // (`X-Session-Token`), and the live-voice upgrade accepts only an actor edge
+  // JWT or a velay attestation — neither of which the CLI has for a cloud
+  // instance. Say so plainly rather than opening a socket that 401s.
+  if (entry.cloud === "vellum") {
+    throw new LiveVoiceConnectionError(
+      `${formatAssistantReference(entry)} is a Vellum cloud assistant. ` +
+        "Voice sessions are supported for local and self-hosted assistants only.",
+    );
+  }
+
+  const baseUrl = (entry.localUrl || entry.runtimeUrl).replace(/\/+$/, "");
+  let parsed: URL;
+  try {
+    parsed = new URL(baseUrl);
+  } catch {
+    throw new LiveVoiceConnectionError(
+      `Assistant '${entry.assistantId}' has an unusable gateway URL: ${baseUrl}`,
+    );
+  }
+  parsed.protocol = parsed.protocol === "https:" ? "wss:" : "ws:";
+  parsed.pathname = "/v1/live-voice";
+
+  const token = await resolveGuardianAccessToken(entry.assistantId, baseUrl);
+  if (!token) {
+    throw new LiveVoiceConnectionError(
+      `No credential for '${entry.assistantId}'. Run 'vellum wake ` +
+        `${entry.assistantId}' to lease one.`,
+    );
+  }
+
+  return {
+    url: parsed.toString(),
+    token,
+    assistantId: entry.assistantId,
+    reference: formatAssistantReference(entry),
+  };
+}
+
+function resolveNamedAssistant(identifier: string) {
+  const result = lookupAssistantByIdentifier(identifier);
+  if (result.status !== "found") {
+    throw new LiveVoiceConnectionError(
+      formatAssistantLookupError(identifier, result),
+    );
+  }
+  return result.entry;
+}
+
+async function resolveGuardianAccessToken(
+  assistantId: string,
+  gatewayUrl: string,
+): Promise<string | undefined> {
+  const stored = loadGuardianToken(assistantId);
+  if (!stored?.accessToken) {
+    return undefined;
+  }
+  if (!guardianTokenDueForRenewal(stored)) {
+    return stored.accessToken;
+  }
+  const refreshed = await refreshGuardianToken(gatewayUrl, assistantId);
+  // A failed refresh is not fatal on its own: the stored token may still have
+  // life left (`refreshAfter` deliberately precedes expiry), so try it rather
+  // than refusing to open a session that would have worked.
+  return refreshed?.accessToken ?? stored.accessToken;
+}

--- a/cli/src/lib/live-voice/connection.ts
+++ b/cli/src/lib/live-voice/connection.ts
@@ -8,7 +8,7 @@
  * upstream (`gateway/src/http/routes/live-voice-websocket.ts`).
  *
  * What the gateway wants is an actor edge JWT belonging to the *bound
- * guardian* — live voice is a guardian-only surface, because the daemon stamps
+ * guardian*. Live voice is a guardian-only surface, because the daemon stamps
  * each voice turn with the guardian's trust context and the proxy replaces the
  * caller's identity upstream, so the pin at the gateway is the only place a
  * non-guardian can be stopped.
@@ -16,7 +16,7 @@
  * The CLI already holds exactly that credential and has since it first paired:
  * `leaseGuardianToken` POSTs `/v1/guardian/init`, which resolves the *vellum*
  * guardian principal and mints an access token subject
- * `actor:<assistantId>:<guardianPrincipalId>` — the same principal
+ * `actor:<assistantId>:<guardianPrincipalId>`, the same principal
  * `findVellumGuardian()` returns on the other side of the check. So the pin
  * passes by construction, and there is nothing new to provision here.
  */
@@ -39,7 +39,7 @@ export interface LiveVoiceConnection {
   /** Guardian access token, sent as `Authorization: Bearer`. */
   readonly token: string;
   readonly assistantId: string;
-  /** `name (id)` when they differ, else the id — for user-facing output. */
+  /** `name (id)` when they differ, else the id, for user-facing output. */
   readonly reference: string;
 }
 
@@ -50,9 +50,9 @@ export class LiveVoiceConnectionError extends Error {}
  *
  * Refreshes the token when it is already due for renewal, so a long session
  * does not open on a credential that expires mid-conversation. A token that is
- * merely *rejected* is not refreshed here — that would disclose the long-lived
- * refresh credential on demand — which matches how `AssistantClient` gates its
- * own reactive refresh.
+ * merely *rejected* is not refreshed here, because that would disclose the
+ * long-lived refresh credential on demand, which matches how `AssistantClient`
+ * gates its own reactive refresh.
  */
 export async function resolveLiveVoiceConnection(
   assistantIdArg?: string,
@@ -67,7 +67,7 @@ export async function resolveLiveVoiceConnection(
 
   // Platform-cloud assistants authenticate with a platform session token
   // (`X-Session-Token`), and the live-voice upgrade accepts only an actor edge
-  // JWT or a velay attestation — neither of which the CLI has for a cloud
+  // JWT or a velay attestation, neither of which the CLI has for a cloud
   // instance. Say so plainly rather than opening a socket that 401s.
   if (entry.cloud === "vellum") {
     throw new LiveVoiceConnectionError(

--- a/cli/src/lib/live-voice/pcm-player.test.ts
+++ b/cli/src/lib/live-voice/pcm-player.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "bun:test";
 
-import { wrapPcmAsWav } from "./pcm-player.js";
+import {
+  isOnPath,
+  PcmPlayer,
+  wrapPcmAsWav,
+  type PlayerCommand,
+} from "./pcm-player.js";
 
 describe("wrapPcmAsWav", () => {
   test("writes a canonical 44-byte mono PCM16 header for the given rate", () => {
@@ -24,5 +29,73 @@ describe("wrapPcmAsWav", () => {
   test("tracks the sample rate the frame declared, not a fixed one", () => {
     expect(wrapPcmAsWav(Buffer.alloc(2), 16000).readUInt32LE(24)).toBe(16000);
     expect(wrapPcmAsWav(Buffer.alloc(2), 44100).readUInt32LE(24)).toBe(44100);
+  });
+});
+
+describe("PcmPlayer playback lifetime", () => {
+  /** A player process whose lifetime a test controls. */
+  const sleeper = (seconds: number): PlayerCommand => ({
+    mode: "streaming",
+    name: "/bin/sh",
+    args: () => ["-c", `sleep ${seconds}`],
+  });
+
+  test("finish() waits for the player to exit, not for the last byte", async () => {
+    const player = new PcmPlayer(sleeper(0.4));
+    player.write(Buffer.alloc(64), 24000);
+    expect(player.isPlaying).toBe(true);
+
+    const started = performance.now();
+    await player.finish();
+    const elapsed = performance.now() - started;
+
+    // Handing the prompt back at the last byte would resolve immediately; the
+    // point of the await is that the speaker has actually gone quiet.
+    expect(elapsed).toBeGreaterThan(250);
+    expect(player.isPlaying).toBe(false);
+    player.dispose();
+  });
+
+  test("stop() cuts playback off and releases a pending finish()", async () => {
+    const player = new PcmPlayer(sleeper(5));
+    player.write(Buffer.alloc(64), 24000);
+
+    const started = performance.now();
+    const pending = player.finish();
+    player.stop();
+    await pending;
+
+    // A finish() that outlived its interrupt would wedge the prompt for the
+    // rest of the session, which is exactly the barge-in case.
+    expect(performance.now() - started).toBeLessThan(1000);
+    expect(player.isPlaying).toBe(false);
+    player.dispose();
+  });
+
+  test("finish() resolves immediately when there is no player", async () => {
+    const player = new PcmPlayer(null);
+    player.write(Buffer.alloc(64), 24000);
+    await player.finish();
+    expect(player.mode).toBe("silent");
+  });
+
+  test("a player that cannot be spawned does not wedge finish()", async () => {
+    const missing: PlayerCommand = {
+      mode: "streaming",
+      name: "definitely-not-a-real-player-binary",
+      args: () => [],
+    };
+    const player = new PcmPlayer(missing);
+    player.write(Buffer.alloc(64), 24000);
+    await player.finish();
+    expect(player.isPlaying).toBe(false);
+    player.dispose();
+  });
+});
+
+describe("isOnPath", () => {
+  test("finds a binary that exists and rejects one that does not", () => {
+    expect(isOnPath("sh")).toBe(true);
+    expect(isOnPath("definitely-not-a-real-binary-xyz")).toBe(false);
   });
 });

--- a/cli/src/lib/live-voice/pcm-player.test.ts
+++ b/cli/src/lib/live-voice/pcm-player.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+
+import { wrapPcmAsWav } from "./pcm-player.js";
+
+describe("wrapPcmAsWav", () => {
+  test("writes a canonical 44-byte mono PCM16 header for the given rate", () => {
+    const pcm = Buffer.alloc(160, 7);
+    const wav = wrapPcmAsWav(pcm, 24000);
+
+    expect(wav.length).toBe(44 + pcm.length);
+    expect(wav.subarray(0, 4).toString()).toBe("RIFF");
+    expect(wav.readUInt32LE(4)).toBe(36 + pcm.length);
+    expect(wav.subarray(8, 12).toString()).toBe("WAVE");
+    expect(wav.readUInt16LE(20)).toBe(1); // PCM
+    expect(wav.readUInt16LE(22)).toBe(1); // mono
+    expect(wav.readUInt32LE(24)).toBe(24000);
+    expect(wav.readUInt32LE(28)).toBe(48000); // byte rate = rate * 2
+    expect(wav.readUInt16LE(32)).toBe(2); // block align
+    expect(wav.readUInt16LE(34)).toBe(16); // bits per sample
+    expect(wav.readUInt32LE(40)).toBe(pcm.length);
+    expect(wav.subarray(44)).toEqual(pcm);
+  });
+
+  test("tracks the sample rate the frame declared, not a fixed one", () => {
+    expect(wrapPcmAsWav(Buffer.alloc(2), 16000).readUInt32LE(24)).toBe(16000);
+    expect(wrapPcmAsWav(Buffer.alloc(2), 44100).readUInt32LE(24)).toBe(44100);
+  });
+});

--- a/cli/src/lib/live-voice/pcm-player.ts
+++ b/cli/src/lib/live-voice/pcm-player.ts
@@ -2,7 +2,7 @@
  * Playing the assistant's voice out of a terminal.
  *
  * `tts_audio` frames carry PCM16 mono at a sample rate the frame states, which
- * needs no decoding — only somewhere to put it. There is no portable way to do
+ * needs no decoding, only somewhere to put it. There is no portable way to do
  * that from Node without a native addon, and a native addon is not an option
  * for a package distributed as an npm tarball, so this shells out to whichever
  * player the machine already has.
@@ -14,7 +14,7 @@
  *   a barge-in cuts it off mid-word. This is the real thing.
  * - **Buffered** (`afplay`): cannot read stdin, so the turn's audio is
  *   collected, wrapped in a WAV header, and played once the turn finishes.
- *   Kept because it is the only player that ships with macOS — without it the
+ *   Kept because it is the only player that ships with macOS. Without it the
  *   feature is silent on a stock Mac, which is most of them.
  *
  * With no player at all the session still runs; the reply is printed and never
@@ -22,8 +22,7 @@
  * someone would rather read the answer than not get one.
  */
 
-import { spawn, type ChildProcess } from "node:child_process";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawn, type ChildProcess } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -31,7 +30,7 @@ import { join } from "node:path";
 /** How a resolved player consumes audio. */
 export type PlaybackMode = "streaming" | "buffered" | "silent";
 
-interface PlayerCommand {
+export interface PlayerCommand {
   readonly mode: Exclude<PlaybackMode, "silent">;
   readonly name: string;
   /** Argv for a given sample rate. */
@@ -103,13 +102,22 @@ const PLAYERS: readonly PlayerCommand[] = [
   },
 ];
 
-function isOnPath(command: string): boolean {
+/**
+ * Whether a command resolves on this machine.
+ *
+ * Platform-split rather than one clever shell invocation: `command -v` is a
+ * POSIX shell builtin, and on Windows the spawned shell is `cmd.exe`, which
+ * has no such builtin. A single POSIX form there fails for every candidate and
+ * silently downgrades the session to text-only on a machine that has ffplay
+ * installed.
+ */
+export function isOnPath(command: string): boolean {
+  const [probe, args] =
+    process.platform === "win32"
+      ? ["where", [command]]
+      : ["/bin/sh", ["-c", `command -v ${command}`]];
   try {
-    execFileSync("command", ["-v", command], {
-      stdio: "ignore",
-      shell: true,
-      timeout: 2000,
-    });
+    execFileSync(probe, args, { stdio: "ignore", timeout: 2000 });
     return true;
   } catch {
     return false;
@@ -142,6 +150,13 @@ export class PcmPlayer {
   private pending: Buffer[] = [];
   private tempDir: string | null = null;
   private tempSeq = 0;
+  /**
+   * Resolvers for `finish()` callers still waiting on the current process.
+   * Held rather than resolved eagerly because "the bytes were handed over" and
+   * "the speaker went quiet" are different moments, and callers care about the
+   * second one.
+   */
+  private idleWaiters: (() => void)[] = [];
 
   constructor(player: PlayerCommand | null = resolvePlayer()) {
     this.player = player;
@@ -180,24 +195,42 @@ export class PcmPlayer {
   }
 
   /**
-   * The turn's audio is complete. Streaming players drain what is queued;
-   * buffered players play the whole turn now.
+   * The turn's audio is complete. Resolves when the machine actually stops
+   * making noise, not when the last byte is handed over.
+   *
+   * The distinction is the whole point. Closing a streaming player's stdin
+   * leaves seconds of audio still buffered inside it, and a buffered player
+   * has not even started yet at this moment. A caller that treated either as
+   * "done" would hand the prompt back while the assistant is still talking,
+   * so Ctrl+C would quit the session instead of interrupting, and the next
+   * turn would start a second player over the top of the first.
    */
-  finish(): void {
+  finish(): Promise<void> {
     if (!this.player) {
-      return;
+      return Promise.resolve();
     }
     if (this.player.mode === "buffered") {
       this.playBuffered();
-      return;
+    } else {
+      this.endStream();
     }
-    this.endStream();
+    if (!this.child) {
+      return Promise.resolve();
+    }
+    return new Promise<void>((resolve) => {
+      this.idleWaiters.push(resolve);
+    });
+  }
+
+  /** Whether audio is still playing. */
+  get isPlaying(): boolean {
+    return this.child !== null;
   }
 
   /**
    * Cut playback off immediately and drop anything not yet played. This is
-   * barge-in: `turn_cancelled` means the audio still in flight is for a turn
-   * that no longer exists, so draining it would be wrong.
+   * barge-in: an interrupted turn's audio is for a turn that no longer exists,
+   * so draining it would be wrong.
    */
   stop(): void {
     this.pending = [];
@@ -210,6 +243,7 @@ export class PcmPlayer {
       child.stdin?.destroy();
       child.kill("SIGKILL");
     }
+    this.releaseIdleWaiters();
   }
 
   /** Release the temp directory buffered playback used, if any. */
@@ -228,22 +262,15 @@ export class PcmPlayer {
     const child = spawn(this.player.name, this.player.args(sampleRate), {
       stdio: ["pipe", "ignore", "ignore"],
     });
-    // A player that dies mid-turn (or was never really there) must not take
-    // the session with it — EPIPE on the next write would be an unhandled
-    // error event otherwise.
-    child.on("error", () => this.stop());
-    child.stdin?.on("error", () => {});
-    this.child = child;
+    this.adopt(child);
     this.activeSampleRate = sampleRate;
   }
 
   private endStream(): void {
-    const child = this.child;
-    this.child = null;
-    this.activeSampleRate = null;
     // Closing stdin lets the player finish what is already queued and exit on
-    // its own; this is the ordinary end of a turn, not an interruption.
-    child?.stdin?.end();
+    // its own; this is the ordinary end of a turn, not an interruption. The
+    // process stays adopted so `finish()` can wait for it to actually exit.
+    this.child?.stdin?.end();
   }
 
   private playBuffered(): void {
@@ -260,22 +287,48 @@ export class PcmPlayer {
     const filePath = join(this.tempDir, `turn-${this.tempSeq++}.wav`);
     writeFileSync(filePath, wrapPcmAsWav(pcm, sampleRate));
 
-    const child = spawn(
-      this.player.name,
-      this.player.args(sampleRate, filePath),
-      {
+    this.adopt(
+      spawn(this.player.name, this.player.args(sampleRate, filePath), {
         stdio: "ignore",
-      },
+      }),
     );
-    child.on("error", () => {});
+  }
+
+  /**
+   * Take ownership of a player process and wire its exit back to whoever is
+   * waiting on `finish()`.
+   *
+   * A player that dies mid-turn, or was never really there, must not take the
+   * session with it: an unhandled `error` event would, and a `finish()` that
+   * never resolved would wedge the prompt just as surely.
+   */
+  private adopt(child: ChildProcess): void {
     this.child = child;
+    child.stdin?.on("error", () => {});
+    const settle = () => {
+      if (this.child === child) {
+        this.child = null;
+        this.activeSampleRate = null;
+      }
+      this.releaseIdleWaiters();
+    };
+    child.on("error", settle);
+    child.on("exit", settle);
+  }
+
+  private releaseIdleWaiters(): void {
+    const waiters = this.idleWaiters;
+    this.idleWaiters = [];
+    for (const resolve of waiters) {
+      resolve();
+    }
   }
 }
 
 /**
  * Wrap raw PCM16 mono in a 44-byte canonical WAV header.
  *
- * Only for the buffered path — a streaming player is told the format on its
+ * Only for the buffered path. A streaming player is told the format on its
  * command line and wants headerless bytes.
  */
 export function wrapPcmAsWav(pcm: Buffer, sampleRate: number): Buffer {

--- a/cli/src/lib/live-voice/pcm-player.ts
+++ b/cli/src/lib/live-voice/pcm-player.ts
@@ -1,0 +1,303 @@
+/**
+ * Playing the assistant's voice out of a terminal.
+ *
+ * `tts_audio` frames carry PCM16 mono at a sample rate the frame states, which
+ * needs no decoding — only somewhere to put it. There is no portable way to do
+ * that from Node without a native addon, and a native addon is not an option
+ * for a package distributed as an npm tarball, so this shells out to whichever
+ * player the machine already has.
+ *
+ * Two tiers, because they are genuinely different experiences:
+ *
+ * - **Streaming** (`ffplay`, `play`/sox, `aplay`): PCM is piped in as it
+ *   arrives, so the assistant starts speaking while it is still thinking, and
+ *   a barge-in cuts it off mid-word. This is the real thing.
+ * - **Buffered** (`afplay`): cannot read stdin, so the turn's audio is
+ *   collected, wrapped in a WAV header, and played once the turn finishes.
+ *   Kept because it is the only player that ships with macOS — without it the
+ *   feature is silent on a stock Mac, which is most of them.
+ *
+ * With no player at all the session still runs; the reply is printed and never
+ * spoken. That is a degradation worth having: a headless box is exactly where
+ * someone would rather read the answer than not get one.
+ */
+
+import { spawn, type ChildProcess } from "node:child_process";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/** How a resolved player consumes audio. */
+export type PlaybackMode = "streaming" | "buffered" | "silent";
+
+interface PlayerCommand {
+  readonly mode: Exclude<PlaybackMode, "silent">;
+  readonly name: string;
+  /** Argv for a given sample rate. */
+  readonly args: (sampleRate: number, filePath?: string) => string[];
+}
+
+/**
+ * Candidate players, best first.
+ *
+ * Order is by experience, not availability: a machine with both `ffplay` and
+ * `afplay` should stream rather than wait for the turn to end.
+ */
+const PLAYERS: readonly PlayerCommand[] = [
+  {
+    mode: "streaming",
+    name: "ffplay",
+    args: (sampleRate) => [
+      "-hide_banner",
+      "-loglevel",
+      "error",
+      "-nodisp",
+      "-autoexit",
+      "-f",
+      "s16le",
+      "-ar",
+      String(sampleRate),
+      "-ac",
+      "1",
+      "-i",
+      "pipe:0",
+    ],
+  },
+  {
+    mode: "streaming",
+    name: "play", // sox
+    args: (sampleRate) => [
+      "-q",
+      "-t",
+      "raw",
+      "-b",
+      "16",
+      "-e",
+      "signed-integer",
+      "-c",
+      "1",
+      "-r",
+      String(sampleRate),
+      "-",
+    ],
+  },
+  {
+    mode: "streaming",
+    name: "aplay", // alsa-utils
+    args: (sampleRate) => [
+      "-q",
+      "-f",
+      "S16_LE",
+      "-c",
+      "1",
+      "-r",
+      String(sampleRate),
+      "-",
+    ],
+  },
+  {
+    mode: "buffered",
+    name: "afplay", // macOS, stdin-incapable
+    args: (_sampleRate, filePath) => [filePath ?? ""],
+  },
+];
+
+function isOnPath(command: string): boolean {
+  try {
+    execFileSync("command", ["-v", command], {
+      stdio: "ignore",
+      shell: true,
+      timeout: 2000,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Pick the best available player, or null when the machine has none. */
+export function resolvePlayer(): PlayerCommand | null {
+  for (const player of PLAYERS) {
+    if (isOnPath(player.name)) {
+      return player;
+    }
+  }
+  return null;
+}
+
+/**
+ * Plays a turn's audio, one turn at a time.
+ *
+ * A turn is `write()`n chunk by chunk and closed with either `finish()` (let
+ * it drain) or `stop()` (cut it off now, for barge-in and Ctrl+C). Both are
+ * safe to call when nothing is playing.
+ */
+export class PcmPlayer {
+  private readonly player: PlayerCommand | null;
+  private child: ChildProcess | null = null;
+  /** Sample rate the running process was started for. */
+  private activeSampleRate: number | null = null;
+  /** Buffered-mode accumulator for the current turn. */
+  private pending: Buffer[] = [];
+  private tempDir: string | null = null;
+  private tempSeq = 0;
+
+  constructor(player: PlayerCommand | null = resolvePlayer()) {
+    this.player = player;
+  }
+
+  get mode(): PlaybackMode {
+    return this.player?.mode ?? "silent";
+  }
+
+  /** Name of the player in use, for the session banner. */
+  get playerName(): string | null {
+    return this.player?.name ?? null;
+  }
+
+  /** Queue one PCM16 chunk. */
+  write(pcm: Buffer, sampleRate: number): void {
+    if (!this.player) {
+      return;
+    }
+    if (this.player.mode === "buffered") {
+      this.activeSampleRate = sampleRate;
+      this.pending.push(pcm);
+      return;
+    }
+    // A sample-rate change mid-turn would be played at the wrong speed by an
+    // already-running process, so start a new one for it. In practice the rate
+    // is fixed per provider and this never fires within a turn; across turns
+    // (a voice change) it does.
+    if (this.child && this.activeSampleRate !== sampleRate) {
+      this.endStream();
+    }
+    if (!this.child) {
+      this.startStream(sampleRate);
+    }
+    this.child?.stdin?.write(pcm);
+  }
+
+  /**
+   * The turn's audio is complete. Streaming players drain what is queued;
+   * buffered players play the whole turn now.
+   */
+  finish(): void {
+    if (!this.player) {
+      return;
+    }
+    if (this.player.mode === "buffered") {
+      this.playBuffered();
+      return;
+    }
+    this.endStream();
+  }
+
+  /**
+   * Cut playback off immediately and drop anything not yet played. This is
+   * barge-in: `turn_cancelled` means the audio still in flight is for a turn
+   * that no longer exists, so draining it would be wrong.
+   */
+  stop(): void {
+    this.pending = [];
+    const child = this.child;
+    this.child = null;
+    this.activeSampleRate = null;
+    if (child) {
+      // Destroy stdin first: killing a player that is still being written to
+      // raises EPIPE on the next write instead of ending quietly.
+      child.stdin?.destroy();
+      child.kill("SIGKILL");
+    }
+  }
+
+  /** Release the temp directory buffered playback used, if any. */
+  dispose(): void {
+    this.stop();
+    if (this.tempDir) {
+      rmSync(this.tempDir, { recursive: true, force: true });
+      this.tempDir = null;
+    }
+  }
+
+  private startStream(sampleRate: number): void {
+    if (!this.player) {
+      return;
+    }
+    const child = spawn(this.player.name, this.player.args(sampleRate), {
+      stdio: ["pipe", "ignore", "ignore"],
+    });
+    // A player that dies mid-turn (or was never really there) must not take
+    // the session with it — EPIPE on the next write would be an unhandled
+    // error event otherwise.
+    child.on("error", () => this.stop());
+    child.stdin?.on("error", () => {});
+    this.child = child;
+    this.activeSampleRate = sampleRate;
+  }
+
+  private endStream(): void {
+    const child = this.child;
+    this.child = null;
+    this.activeSampleRate = null;
+    // Closing stdin lets the player finish what is already queued and exit on
+    // its own; this is the ordinary end of a turn, not an interruption.
+    child?.stdin?.end();
+  }
+
+  private playBuffered(): void {
+    if (!this.player || this.pending.length === 0) {
+      return;
+    }
+    const pcm = Buffer.concat(this.pending);
+    this.pending = [];
+    const sampleRate = this.activeSampleRate ?? 24000;
+
+    if (!this.tempDir) {
+      this.tempDir = mkdtempSync(join(tmpdir(), "vellum-voice-"));
+    }
+    const filePath = join(this.tempDir, `turn-${this.tempSeq++}.wav`);
+    writeFileSync(filePath, wrapPcmAsWav(pcm, sampleRate));
+
+    const child = spawn(
+      this.player.name,
+      this.player.args(sampleRate, filePath),
+      {
+        stdio: "ignore",
+      },
+    );
+    child.on("error", () => {});
+    this.child = child;
+  }
+}
+
+/**
+ * Wrap raw PCM16 mono in a 44-byte canonical WAV header.
+ *
+ * Only for the buffered path — a streaming player is told the format on its
+ * command line and wants headerless bytes.
+ */
+export function wrapPcmAsWav(pcm: Buffer, sampleRate: number): Buffer {
+  const channels = 1;
+  const bitsPerSample = 16;
+  const byteRate = (sampleRate * channels * bitsPerSample) / 8;
+  const blockAlign = (channels * bitsPerSample) / 8;
+
+  const header = Buffer.alloc(44);
+  header.write("RIFF", 0);
+  header.writeUInt32LE(36 + pcm.length, 4);
+  header.write("WAVE", 8);
+  header.write("fmt ", 12);
+  header.writeUInt32LE(16, 16); // PCM fmt chunk size
+  header.writeUInt16LE(1, 20); // format: PCM
+  header.writeUInt16LE(channels, 22);
+  header.writeUInt32LE(sampleRate, 24);
+  header.writeUInt32LE(byteRate, 28);
+  header.writeUInt16LE(blockAlign, 32);
+  header.writeUInt16LE(bitsPerSample, 34);
+  header.write("data", 36);
+  header.writeUInt32LE(pcm.length, 40);
+
+  return Buffer.concat([header, pcm]);
+}

--- a/cli/src/lib/live-voice/protocol.test.ts
+++ b/cli/src/lib/live-voice/protocol.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseServerFrame } from "./protocol.js";
+
+describe("parseServerFrame", () => {
+  test("returns a handled frame with its fields intact", () => {
+    const frame = parseServerFrame(
+      JSON.stringify({
+        type: "tts_audio",
+        seq: 4,
+        mimeType: "audio/pcm",
+        sampleRate: 24000,
+        dataBase64: "AAAA",
+      }),
+    );
+
+    expect(frame).toEqual({
+      type: "tts_audio",
+      seq: 4,
+      mimeType: "audio/pcm",
+      sampleRate: 24000,
+      dataBase64: "AAAA",
+    });
+  });
+
+  test("keeps fields a newer daemon adds to a known frame", () => {
+    const frame = parseServerFrame(
+      JSON.stringify({ type: "tts_done", seq: 5, turnId: "t1", extra: 1 }),
+    );
+    expect(frame).toHaveProperty("extra", 1);
+  });
+
+  test("names an unrecognized frame type rather than dropping it", () => {
+    expect(
+      parseServerFrame(JSON.stringify({ type: "stt_partial", seq: 2 })),
+    ).toEqual({ type: "unhandled", frameType: "stt_partial" });
+  });
+
+  test("never throws on malformed input", () => {
+    expect(parseServerFrame("{oops")).toEqual({
+      type: "malformed",
+      raw: "{oops",
+    });
+    expect(parseServerFrame("null")).toEqual({
+      type: "malformed",
+      raw: "null",
+    });
+    expect(parseServerFrame(JSON.stringify({ seq: 1 }))).toEqual({
+      type: "malformed",
+      raw: '{"seq":1}',
+    });
+  });
+});

--- a/cli/src/lib/live-voice/protocol.ts
+++ b/cli/src/lib/live-voice/protocol.ts
@@ -1,0 +1,193 @@
+/**
+ * Live-voice wire contract, as much of it as a microphone-less client needs.
+ *
+ * Ported from `assistant/src/live-voice/protocol.ts`, the same way
+ * `clients/web/src/domains/chat/voice/live-voice/protocol.ts` is: the CLI ships
+ * as an npm package and nothing outside `cli/` lands in the tarball, so the
+ * daemon's copy cannot be imported. Deliberately a subset rather than a full
+ * port — this client never captures audio, so the capture half of the protocol
+ * (`audio`, `ptt_release`, `speech_started`, `utterance_end`, the `stt_*`
+ * frames) is absent instead of present and unreachable.
+ *
+ * The one thing that must not drift is what goes *out*. Frames the daemon
+ * validates strictly are spelled out in full below; frames it sends are parsed
+ * leniently, so a newer daemon adding fields never breaks an older CLI.
+ */
+
+/**
+ * Capture format, declared on the `start` frame.
+ *
+ * A client with no microphone still has to state one: `audio` is required on
+ * the start frame, and the session sizes its transcriber against it whether or
+ * not a byte ever arrives. Mirrors the daemon's canonical
+ * `LIVE_VOICE_AUDIO_FORMAT`.
+ */
+export const LIVE_VOICE_AUDIO_FORMAT = {
+  mimeType: "audio/pcm",
+  sampleRate: 16000,
+  channels: 1,
+} as const;
+
+/** Longest typed turn the daemon accepts on a `text` frame. */
+export const MAX_TEXT_TURN_CHARS = 4_000;
+
+export interface LiveVoiceStartFrame {
+  readonly type: "start";
+  readonly audio: typeof LIVE_VOICE_AUDIO_FORMAT;
+  readonly conversationId?: string;
+  /**
+   * Always true from this client, and load-bearing rather than informational:
+   * it is what lets a session whose speech-to-text leg has no working
+   * credential open text-only (`ready.audioInput: false`) instead of being
+   * refused outright with `credentials_unavailable`. A CLI that cannot hear
+   * loses nothing — it was never going to listen.
+   */
+  readonly textInput: true;
+}
+
+export interface LiveVoiceTextFrame {
+  readonly type: "text";
+  readonly text: string;
+}
+
+/** Every server frame carries a monotonic sequence number. */
+interface ServerFrameBase {
+  readonly seq: number;
+}
+
+export interface LiveVoiceReadyFrame extends ServerFrameBase {
+  readonly type: "ready";
+  readonly sessionId: string;
+  readonly conversationId: string;
+  /**
+   * Whether this daemon takes `text` frames. Absent means no: a daemon
+   * predating typed turns answers each one with `unknown_type`, which is
+   * byte-identical to the `update_config` rejection, so the only safe read of
+   * silence is that typed turns are unavailable.
+   */
+  readonly textInput?: boolean;
+  /**
+   * Whether the speech-to-text leg is live. Absent means yes — an older daemon
+   * refuses any session it cannot transcribe, so every session it readies can
+   * hear. False is reachable only because this client declared `textInput`.
+   */
+  readonly audioInput?: boolean;
+}
+
+export interface LiveVoiceBusyFrame extends ServerFrameBase {
+  readonly type: "busy";
+  readonly activeSessionId: string;
+}
+
+export interface LiveVoiceAssistantTextDeltaFrame extends ServerFrameBase {
+  readonly type: "assistant_text_delta";
+  readonly text: string;
+}
+
+export interface LiveVoiceTtsAudioFrame extends ServerFrameBase {
+  readonly type: "tts_audio";
+  readonly mimeType: string;
+  readonly sampleRate: number;
+  readonly dataBase64: string;
+}
+
+export interface LiveVoiceTtsDoneFrame extends ServerFrameBase {
+  readonly type: "tts_done";
+  readonly turnId: string;
+}
+
+export interface LiveVoiceTurnCancelledFrame extends ServerFrameBase {
+  readonly type: "turn_cancelled";
+  readonly turnId: string;
+}
+
+export interface LiveVoiceThinkingFrame extends ServerFrameBase {
+  readonly type: "thinking";
+  readonly turnId?: string;
+}
+
+export interface LiveVoiceActivityFrame extends ServerFrameBase {
+  readonly type: "activity";
+  readonly turnId: string;
+  readonly label: string;
+}
+
+export interface LiveVoiceErrorFrame extends ServerFrameBase {
+  readonly type: "error";
+  readonly code: string;
+  readonly message: string;
+  readonly recoverable?: boolean;
+  /** Which client frame the error is about. Absent on older daemons. */
+  readonly frameType?: string;
+}
+
+/**
+ * A frame this build has no handling for — a newer daemon's addition, or one
+ * of the capture-side frames a microphone-less session never acts on.
+ * Surfaced as a type rather than dropped in the parser so the client can log
+ * it at debug level instead of silently swallowing protocol drift.
+ */
+export interface LiveVoiceUnhandledFrame {
+  readonly type: "unhandled";
+  readonly frameType: string;
+}
+
+/** A payload that did not parse as a server frame at all. */
+export interface LiveVoiceMalformedFrame {
+  readonly type: "malformed";
+  readonly raw: string;
+}
+
+export type LiveVoiceServerFrame =
+  | LiveVoiceReadyFrame
+  | LiveVoiceBusyFrame
+  | LiveVoiceAssistantTextDeltaFrame
+  | LiveVoiceTtsAudioFrame
+  | LiveVoiceTtsDoneFrame
+  | LiveVoiceTurnCancelledFrame
+  | LiveVoiceThinkingFrame
+  | LiveVoiceActivityFrame
+  | LiveVoiceErrorFrame
+  | LiveVoiceUnhandledFrame
+  | LiveVoiceMalformedFrame;
+
+/** Frame types this client acts on. Anything else becomes `unhandled`. */
+const HANDLED_FRAME_TYPES = new Set([
+  "ready",
+  "busy",
+  "assistant_text_delta",
+  "tts_audio",
+  "tts_done",
+  "turn_cancelled",
+  "thinking",
+  "activity",
+  "error",
+]);
+
+/**
+ * Parse one inbound server payload.
+ *
+ * Lenient by design: a frame whose type this build knows is returned as-is
+ * (extra fields ride along harmlessly), an unrecognized type becomes
+ * `unhandled`, and anything unparseable becomes `malformed`. Nothing here
+ * throws — a single bad frame must never take down a session.
+ */
+export function parseServerFrame(payload: string): LiveVoiceServerFrame {
+  let value: unknown;
+  try {
+    value = JSON.parse(payload);
+  } catch {
+    return { type: "malformed", raw: payload };
+  }
+  if (typeof value !== "object" || value === null) {
+    return { type: "malformed", raw: payload };
+  }
+  const frameType = (value as { type?: unknown }).type;
+  if (typeof frameType !== "string") {
+    return { type: "malformed", raw: payload };
+  }
+  if (!HANDLED_FRAME_TYPES.has(frameType)) {
+    return { type: "unhandled", frameType };
+  }
+  return value as LiveVoiceServerFrame;
+}

--- a/cli/src/lib/live-voice/protocol.ts
+++ b/cli/src/lib/live-voice/protocol.ts
@@ -5,7 +5,7 @@
  * `clients/web/src/domains/chat/voice/live-voice/protocol.ts` is: the CLI ships
  * as an npm package and nothing outside `cli/` lands in the tarball, so the
  * daemon's copy cannot be imported. Deliberately a subset rather than a full
- * port — this client never captures audio, so the capture half of the protocol
+ * port. This client never captures audio, so the capture half of the protocol
  * (`audio`, `ptt_release`, `speech_started`, `utterance_end`, the `stt_*`
  * frames) is absent instead of present and unreachable.
  *
@@ -40,7 +40,7 @@ export interface LiveVoiceStartFrame {
    * it is what lets a session whose speech-to-text leg has no working
    * credential open text-only (`ready.audioInput: false`) instead of being
    * refused outright with `credentials_unavailable`. A CLI that cannot hear
-   * loses nothing — it was never going to listen.
+   * loses nothing: it was never going to listen.
    */
   readonly textInput: true;
 }
@@ -67,7 +67,7 @@ export interface LiveVoiceReadyFrame extends ServerFrameBase {
    */
   readonly textInput?: boolean;
   /**
-   * Whether the speech-to-text leg is live. Absent means yes — an older daemon
+   * Whether the speech-to-text leg is live. Absent means yes, because an older daemon
    * refuses any session it cannot transcribe, so every session it readies can
    * hear. False is reachable only because this client declared `textInput`.
    */
@@ -122,7 +122,7 @@ export interface LiveVoiceErrorFrame extends ServerFrameBase {
 }
 
 /**
- * A frame this build has no handling for — a newer daemon's addition, or one
+ * A frame this build has no handling for: a newer daemon's addition, or one
  * of the capture-side frames a microphone-less session never acts on.
  * Surfaced as a type rather than dropped in the parser so the client can log
  * it at debug level instead of silently swallowing protocol drift.
@@ -170,7 +170,7 @@ const HANDLED_FRAME_TYPES = new Set([
  * Lenient by design: a frame whose type this build knows is returned as-is
  * (extra fields ride along harmlessly), an unrecognized type becomes
  * `unhandled`, and anything unparseable becomes `malformed`. Nothing here
- * throws — a single bad frame must never take down a session.
+ * throws, because a single bad frame must never take down a session.
  */
 export function parseServerFrame(payload: string): LiveVoiceServerFrame {
   let value: unknown;


### PR DESCRIPTION
`vellum voice [assistant]` opens a live-voice session that never opens a microphone. Each typed line goes out as a `text` frame and joins the pipeline where a finished transcript would have, so the reply comes back through the same turn runner, the same segmented TTS, and the same barge-in as a spoken turn. Ctrl+C mid-reply cuts the assistant off; Ctrl+D ends the session.

First consumer of the seam JARVIS-1522 shipped. Nothing user-facing sent a `text` frame until now.

Closes JARVIS-1638.

## Why the gateway, not the runtime

The socket goes to the **gateway's** `/v1/live-voice`. The runtime's copy demands a gateway service token, which no client can mint; the gateway's copy authenticates the caller and mints that token itself on the way upstream.

What it wants is an actor edge JWT belonging to the bound guardian, and the CLI has held exactly that since it first paired: `guardian/init` resolves the vellum guardian principal and mints `actor:<assistantId>:<guardianPrincipalId>`, the same principal `requireBoundGuardian` compares against. So there was nothing to provision, only the wrong host to stop dialing. The token rides an `Authorization` header rather than `?token=`; the browser client has to use the query form, but a query parameter lands in process listings and access logs, and this one is the guardian's.

## Version skew

Every send is gated on the `ready` echo. A daemon predating typed turns answers `text` with `unknown_type`, byte-identical to the rejection it gives every other optional frame, so an absent `textInput` has to mean no rather than probably-fine. `audioInput: false` is the other half: this client declares `textInput: true` on `start`, which is what lets a session with no speech-to-text credential open text-only instead of being refused outright with `credentials_unavailable`.

## Interrupts end locally

A client `interrupt` is answered with neither `tts_done` nor `turn_cancelled`. The daemon's `interrupt()` cancels through `cancelAssistantTurn`, `tts_done` is gated on the turn not being aborted, and `turn_cancelled` is only sent down the VAD barge-in path. So Ctrl+C settles the turn on the client, and completion frames are matched against the in-flight turn's id so a late one cannot land on the turn that came after it.

## Playback

Shells out, because a native audio addon is not an option for a package distributed as an npm tarball. `ffplay`, `sox`, or `aplay` stream PCM16 as it arrives, which is what makes barge-in feel like interrupting someone; `afplay` cannot read stdin so it plays each reply whole, and it is kept only because it is the one player that ships with macOS. With none of them present the session still runs, printed and silent.

A turn is not over until the player process exits. Handing the prompt back at the last byte would leave Ctrl+C quitting the session while the assistant is still talking, and let the next turn start a second player over the first.

## Scope

Local and self-hosted assistants. Cloud assistants are refused with a clear message rather than a 401, because they authenticate with a platform session token which this endpoint does not accept. Separate follow-up.

## Testing

- 27 unit tests: protocol parsing, start-frame shape, the `ready` gates, error-frame routing, playback lifetime (`finish()` outliving the last byte, `stop()` releasing a pending `finish()`, an unspawnable player not wedging it), path probing, and the WAV header. Typecheck and lint clean.
- Verified end-to-end against a local assistant: gateway auth, `start`, `ready` with `textInput: true`, typed turn dispatched, reply streamed and **spoken aloud**.
- Playback verified with real 24 kHz Deepgram speech through all three tiers, including `stop()` cutting a 5s clip off at 1.2s. macOS `afinfo` parses the generated WAV as `1 ch, 24000 Hz, Int16`.
- Cloud refusal verified against a `cloud: vellum` instance.

Pre-existing failures in `sleep.test.ts` and `flags.test.ts` reproduce identically on pristine `origin/main` (local lockfile state), untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011KY6Ss3R4ckRnxKJ2QyhPS