### PR TITLE
fix(cli): pin bun to 1.3.11 at every unpinned install site

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -275,6 +275,8 @@ jobs:
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: '1.3.11'
 
       # Hotfix releases can check out a pre-workspace tag (no root bun.lock);
       # those trees still install per package.

--- a/.github/workflows/pr-skills.yaml
+++ b/.github/workflows/pr-skills.yaml
@@ -120,6 +120,8 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: '1.3.11'
 
       - name: Run tests
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1042,6 +1042,8 @@ jobs:
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: '1.3.11'
 
       - name: Login to Docker Hub
         env:

--- a/cli/src/adapters/install.sh
+++ b/cli/src/adapters/install.sh
@@ -133,7 +133,8 @@ ensure_bun() {
     fi
 
     info "Installing bun..."
-    curl -fsSL https://bun.sh/install | bash
+    # Pinned — keep in sync with .tool-versions.
+    curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.11"
     export BUN_INSTALL="$HOME/.bun"
     export PATH="$BUN_INSTALL/bin:$PATH"
 

--- a/cli/src/adapters/install.sh
+++ b/cli/src/adapters/install.sh
@@ -133,7 +133,7 @@ ensure_bun() {
     fi
 
     info "Installing bun..."
-    # Pinned — keep in sync with .tool-versions.
+    # Pinned. Keep in sync with .tool-versions.
     curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.11"
     export BUN_INSTALL="$HOME/.bun"
     export PATH="$BUN_INSTALL/bin:$PATH"

--- a/cli/src/adapters/openclaw.ts
+++ b/cli/src/adapters/openclaw.ts
@@ -87,7 +87,8 @@ if ! command -v bun >/dev/null 2>&1; then
     echo "Installing unzip (required by bun)..."
     apt-get install -y unzip
   fi
-  curl -fsSL https://bun.sh/install | bash
+  # Pinned — keep in sync with .tool-versions.
+  curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.11"
   export BUN_INSTALL="\$HOME/.bun"
   export PATH="\$BUN_INSTALL/bin:\$PATH"
   echo "bun version: $(bun --version)"

--- a/cli/src/adapters/openclaw.ts
+++ b/cli/src/adapters/openclaw.ts
@@ -87,7 +87,7 @@ if ! command -v bun >/dev/null 2>&1; then
     echo "Installing unzip (required by bun)..."
     apt-get install -y unzip
   fi
-  # Pinned — keep in sync with .tool-versions.
+  # Pinned. Keep in sync with .tool-versions.
   curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.11"
   export BUN_INSTALL="\$HOME/.bun"
   export PATH="\$BUN_INSTALL/bin:\$PATH"

--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -550,7 +550,7 @@ function ensureBunInstalled(): void {
         installEnv[key] = process.env[key]!;
       }
     }
-    // Pinned — keep in sync with .tool-versions.
+    // Pinned. Keep in sync with .tool-versions.
     execSync('curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.11"', {
       stdio: "pipe",
       timeout: 60_000,

--- a/cli/src/lib/local.ts
+++ b/cli/src/lib/local.ts
@@ -550,7 +550,8 @@ function ensureBunInstalled(): void {
         installEnv[key] = process.env[key]!;
       }
     }
-    execSync("curl -fsSL https://bun.sh/install | bash", {
+    // Pinned — keep in sync with .tool-versions.
+    execSync('curl -fsSL https://bun.sh/install | bash -s "bun-v1.3.11"', {
       stdio: "pipe",
       timeout: 60_000,
       env: installEnv,


### PR DESCRIPTION
## Summary

- Pins bun to **1.3.11** at the six sites that previously installed *latest* bun: three that run on user machines (`cli/src/adapters/install.sh`, `cli/src/adapters/openclaw.ts`, `cli/src/lib/local.ts`) and three unpinned CI `setup-bun` steps (`create-release-branch.yml`, `pr-skills.yaml`, `release.yml:1044`). Every other bun pin in the repo was already 1.3.11, so this brings the stragglers in line with `AGENTS.md:57`.
- **Why:** bun 1.4.0 (current latest) hard-fails installing our published packages. `bun install -g vellum` dies with `Could not find package.json for "file:../packages/<name>"` for every internal `@vellumai/*` package. Our internal packages are unpublished and ship via `bundledDependencies`, with specs rewritten to inert `file:../packages/<name>` placeholders by `scripts/strip-bundled-field-from-tarball.mjs`. bun 1.3.x ignored those placeholders; bun 1.4.0 resolves them and fails. Verified: bun 1.3.11 and 1.3.12 install fine, bun 1.4.0 fails 5/5 against the real npmjs tarballs. npm is unaffected because its shrinkwrap marks the entries `"inBundle": true`.
- :warning: **This is a short-term hold, not the fix.** It only stops us from installing the broken bun onto user machines and CI runners. The published packages are still broken for anyone who brings their own bun 1.4 or newer. The durable fix (publishing the internal `@vellumai/*` packages and deleting the bundling entirely) is tracked separately.

## Why not just tell users to run `npm install -g vellum`

npm is not a viable fallback on these boxes. `cli/src/adapters/install.sh` provisions bun only: it installs git and unzip and never Node or npm, so on a fresh Debian image provisioned by our own installer, `npm` does not exist. `meta/bin/vellum.js` is also `#!/usr/bin/env bun`, so bun is both the installer and the runtime here. Nothing in this PR switches anything from bun to npm.

Note this also affects **self-upgrade**, not just fresh installs: `skills/self-upgrade/SKILL.md` and `cli/src/lib/stale-cli-hint.ts` both tell users to run `bun install -g vellum@latest`, which fails the same way under bun 1.4.

## Open question for the reviewer

`assistant/src/util/bun-runtime.ts:30` pins `BUN_VERSION = "1.2.0"` and downloads a bun binary at runtime. It is pinned, so bun 1.4.0 cannot reach it, but it disagrees with `AGENTS.md:57`, which requires every bun pin to share the same exact version. I deliberately left it alone: bumping the runtime-downloaded bun is a behavior change that deserves its own testing. Worth a follow-up.

## Verification

- `cli` typecheck clean. Full `cli` suite: 1073 pass, 0 fail (the one reported error is a local port-7830 conflict, unrelated).
- All three modified workflow files parse as YAML.
- No unpinned `bun.sh/install` invocation remains anywhere in the repo. All 96 `setup-bun` steps now carry `bun-version: '1.3.11'`.
- No tests or snapshots assert the changed script text.

## Note on the failing `Check catalog.json is up to date`

That check is failing for a reason unrelated to this PR. This branch touches no files under `skills/`. It only triggers the workflow because the `paths:` filter on `pr-skills.yaml` includes the workflow file itself, which this PR edits to add the bun pin.

`skills/catalog.json` on `main` is stale: `updatedAt` is derived from `git log -1 --format=%aI` per skill directory, and main's tip commit (98a42fcb4e) touched the whole `skills/` tree without regenerating the catalog. Regenerating locally produces a different value again (local resolves to 20:55:04Z, CI computed 19:48:41Z), so committing a regeneration from here would not reliably match what CI expects. This needs a separate fix on main by someone with that context rather than a speculative regeneration bundled into this PR.

## Original prompt

Investigating why `bun install -g vellum` failed on a fresh Debian 12 GCP VM, we traced it to bun 1.4.0 rather than anything environment-specific, and confirmed the published packages are broken for every bun 1.4 or newer. After evaluating several packaging fixes and finding that each traded one installer's correctness for another's, we chose to ship the short-term hold first: audit every place the repo installs bun or tells a user to install bun, and pin each unpinned one to the version we know is good. The packaging fix and the decision about publishing the internal packages are being handled separately.
