### PR TITLE
web: show assistant avatars on chooser cards with glyph fallback

### DIFF
--- a/clients/web/src/components/avatar/chooser-avatar-chip.test.tsx
+++ b/clients/web/src/components/avatar/chooser-avatar-chip.test.tsx
@@ -84,6 +84,29 @@ describe("ChooserAvatarChip", () => {
     expect(img?.style.width).toBe("48px");
   });
 
+  test("decorative hides the image and character from assistive tech", () => {
+    const { container, rerender } = render(
+      <ChooserAvatarChip
+        traits={null}
+        imageUrl="https://example.test/a.png"
+        fallback={fallback}
+        decorative
+      />,
+    );
+    expect(container.querySelector("img")?.getAttribute("alt")).toBe("");
+
+    rerender(
+      <ChooserAvatarChip
+        traits={TRAITS}
+        imageUrl={null}
+        fallback={fallback}
+        decorative
+      />,
+    );
+    const hidden = container.querySelector("[aria-hidden='true']");
+    expect(hidden?.querySelector("svg")).not.toBeNull();
+  });
+
   test("unknown trait ids fall through to the image", () => {
     const { container } = render(
       <ChooserAvatarChip

--- a/clients/web/src/components/avatar/chooser-avatar-chip.tsx
+++ b/clients/web/src/components/avatar/chooser-avatar-chip.tsx
@@ -23,6 +23,8 @@ export interface ChooserAvatarChipProps {
   /** Rendered when there is no avatar, or while the character chunk loads. */
   fallback: ReactNode;
   className?: string;
+  /** Hide from assistive tech when a sibling already names the row. */
+  decorative?: boolean;
 }
 
 export function ChooserAvatarChip({
@@ -31,6 +33,7 @@ export function ChooserAvatarChip({
   size = 48,
   fallback,
   className,
+  decorative = false,
 }: ChooserAvatarChipProps) {
   const { t } = useTranslation();
   const components = useBundledAvatarComponents();
@@ -46,7 +49,7 @@ export function ChooserAvatarChip({
       traits.color,
     );
     if (renderable) {
-      return (
+      const avatar = (
         <AvatarRenderer
           components={components}
           bodyShapeId={traits.bodyShape}
@@ -56,6 +59,7 @@ export function ChooserAvatarChip({
           className={className}
         />
       );
+      return decorative ? <span aria-hidden="true">{avatar}</span> : avatar;
     }
   }
 
@@ -63,7 +67,7 @@ export function ChooserAvatarChip({
     return (
       <img
         src={imageUrl}
-        alt={t("chooserAvatarChip.alt")}
+        alt={decorative ? "" : t("chooserAvatarChip.alt")}
         width={size}
         height={size}
         className={`rounded-full object-cover ${className ?? ""}`.trim()}

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.test.tsx
@@ -20,6 +20,8 @@ import {
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { ReactNode } from "react";
 
+import type * as ChooserAvatarChipModule from "@/components/avatar/chooser-avatar-chip";
+import type * as UseChooserRowAvatarModule from "@/hooks/use-chooser-row-avatar";
 import type { RememberedOrigin } from "@/stores/remembered-origins-store";
 import type { ResolvedAssistant } from "@/stores/resolved-assistants-store";
 
@@ -87,6 +89,8 @@ let isNativeMobileValue = false;
 const installNativeRememberedOriginsMock = mock(() => {});
 /** What the native shell reports as its baked Vellum Cloud origin, if any. */
 let nativeCloudOriginValue: string | null = null;
+/** Avatar data per assistant id; rows absent here resolve to nulls (glyph). */
+let rowAvatars = new Map<string, UseChooserRowAvatarModule.ChooserRowAvatar>();
 
 // Stands in for the real error class (the screen's `instanceof` check runs
 // against this mocked module's export).
@@ -250,6 +254,20 @@ mock.module("@/domains/onboarding/components/add-remote-origin-dialog", () => ({
       </div>
     ) : null,
 }));
+
+const useChooserRowAvatarMock: Partial<typeof UseChooserRowAvatarModule> = {
+  useChooserRowAvatar: (assistant) =>
+    rowAvatars.get(assistant.id) ?? { traits: null, imageUrl: null },
+};
+mock.module("@/hooks/use-chooser-row-avatar", () => useChooserRowAvatarMock);
+
+// The real chip lazily loads the character chunk; a marker keeps the suite
+// hermetic while still exercising the fallback branch.
+const chooserAvatarChipMock: Partial<typeof ChooserAvatarChipModule> = {
+  ChooserAvatarChip: ({ traits, imageUrl, fallback }) =>
+    traits || imageUrl ? <span data-testid="chooser-avatar-chip" /> : fallback,
+};
+mock.module("@/components/avatar/chooser-avatar-chip", () => chooserAvatarChipMock);
 
 mock.module("@/components/onboarding-layout", () => ({
   OnboardingLayout: ({ children }: { children: ReactNode }) => children,
@@ -493,6 +511,7 @@ beforeEach(() => {
   nativeSwitchToOriginMock.mockImplementation(async () => true);
   isNativeMobileValue = false;
   nativeCloudOriginValue = null;
+  rowAvatars = new Map();
   installNativeRememberedOriginsMock.mockClear();
   removePairedAssistantFromLockfileMock.mockClear();
   removePairedAssistantFromLockfileMock.mockImplementation(async () => ({
@@ -1553,6 +1572,27 @@ describe("SelectAssistantScreen local registrations on the platform hub", () => 
     await waitFor(() =>
       expect(refreshPlatformAssistantsIfStaleMock).toHaveBeenCalledTimes(1),
     );
+  });
+});
+
+describe("SelectAssistantScreen assistant avatars", () => {
+  test("a row with avatar data renders the chip in place of the glyph", () => {
+    assistantsValue = [makePlatformAssistant()];
+    rowAvatars.set(PLATFORM_ID, {
+      traits: { bodyShape: "round", eyeStyle: "dot", color: "blue" },
+      imageUrl: null,
+    });
+    render(<SelectAssistantScreen />);
+    expect(screen.getByTestId("chooser-avatar-chip")).toBeTruthy();
+    expect(document.querySelector("svg.lucide-cloud")).toBeNull();
+  });
+
+  test("a row with no avatar keeps its glyph", () => {
+    assistantsValue = [makePairedAssistant(), makeLocalAssistant()];
+    render(<SelectAssistantScreen />);
+    expect(screen.queryByTestId("chooser-avatar-chip")).toBeNull();
+    expect(document.querySelector("svg.lucide-link-2")).not.toBeNull();
+    expect(document.querySelector("svg.lucide-laptop")).not.toBeNull();
   });
 });
 

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.test.tsx
@@ -262,10 +262,19 @@ const useChooserRowAvatarMock: Partial<typeof UseChooserRowAvatarModule> = {
 mock.module("@/hooks/use-chooser-row-avatar", () => useChooserRowAvatarMock);
 
 // The real chip lazily loads the character chunk; a marker keeps the suite
-// hermetic while still exercising the fallback branch.
+// hermetic while still exercising the fallback branch. The img mirrors the
+// real chip's alt handling so accessible-name assertions stay meaningful.
 const chooserAvatarChipMock: Partial<typeof ChooserAvatarChipModule> = {
-  ChooserAvatarChip: ({ traits, imageUrl, fallback }) =>
-    traits || imageUrl ? <span data-testid="chooser-avatar-chip" /> : fallback,
+  ChooserAvatarChip: ({ traits, imageUrl, fallback, decorative }) =>
+    traits || imageUrl ? (
+      <img
+        data-testid="chooser-avatar-chip"
+        src={imageUrl ?? undefined}
+        alt={decorative ? "" : "Assistant avatar"}
+      />
+    ) : (
+      fallback
+    ),
 };
 mock.module("@/components/avatar/chooser-avatar-chip", () => chooserAvatarChipMock);
 
@@ -1585,6 +1594,18 @@ describe("SelectAssistantScreen assistant avatars", () => {
     render(<SelectAssistantScreen />);
     expect(screen.getByTestId("chooser-avatar-chip")).toBeTruthy();
     expect(document.querySelector("svg.lucide-cloud")).toBeNull();
+  });
+
+  test("an image-backed row's radio is named by its title, not the alt", () => {
+    assistantsValue = [makePairedAssistant(), makePlatformAssistant()];
+    rowAvatars.set(PAIRED_ID, {
+      traits: null,
+      imageUrl: "https://example.test/a.png",
+    });
+    render(<SelectAssistantScreen />);
+    expect(screen.getByRole("radio", { name: /^Office Mac/ })).toBeTruthy();
+    expect(screen.queryByRole("radio", { name: /Assistant avatar/ })).toBeNull();
+    expect(screen.getByTestId("chooser-avatar-chip").getAttribute("alt")).toBe("");
   });
 
   test("a row with no avatar keeps its glyph", () => {

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
@@ -18,6 +18,7 @@ import {
   removePairedAssistant,
   switchToResolvedAssistant,
 } from "@/assistant/switch-service";
+import { ChooserAvatarChip } from "@/components/avatar/chooser-avatar-chip";
 import { RemoveFromDeviceDialog } from "@/components/remove-from-device-dialog";
 import {
   clearGatewayToken,
@@ -35,6 +36,7 @@ import { ConnectRecoveryDialog } from "@/domains/onboarding/components/connect-r
 import { OnboardingLayout } from "@/components/onboarding-layout";
 import { handleRadioCardArrowNav } from "@/domains/onboarding/components/radio-card-nav";
 import { formatRelativeDate } from "@/utils/format-date";
+import { useChooserRowAvatar } from "@/hooks/use-chooser-row-avatar";
 import { useOnboardingLogin } from "@/hooks/use-onboarding-login";
 import { isElectron } from "@/runtime/is-electron";
 import {
@@ -1156,16 +1158,23 @@ function AssistantCard({
 }) {
   const { t } = useTranslation("onboarding");
   const label = assistantLabel(assistant);
+  const { traits, imageUrl } = useChooserRowAvatar(assistant);
+  const glyph = assistant.isPaired ? (
+    <Link2 className="h-5 w-5" />
+  ) : assistant.isLocal ? (
+    <Laptop className="h-5 w-5" />
+  ) : (
+    <Cloud className="h-5 w-5" />
+  );
   return (
     <ChooserCard
       icon={
-        assistant.isPaired ? (
-          <Link2 className="h-5 w-5" />
-        ) : assistant.isLocal ? (
-          <Laptop className="h-5 w-5" />
-        ) : (
-          <Cloud className="h-5 w-5" />
-        )
+        <ChooserAvatarChip
+          traits={traits}
+          imageUrl={imageUrl}
+          size={48}
+          fallback={glyph}
+        />
       }
       title={label}
       subtitle={assistantSubtitle(assistant, t)}

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
@@ -1174,6 +1174,7 @@ function AssistantCard({
           imageUrl={imageUrl}
           size={48}
           fallback={glyph}
+          decorative
         />
       }
       title={label}


### PR DESCRIPTION
## Summary
- `AssistantCard` now calls `useChooserRowAvatar(assistant)` and renders `ChooserAvatarChip` in the existing `ChooserCard` icon slot, keeping the `Link2`/`Laptop`/`Cloud` glyph as the chip's `fallback`
- The `h-12 w-12 rounded-[10px]` icon container is unchanged, so rows never reflow while avatars resolve; `RemoteOriginCard` keeps its Globe
- `select-assistant-screen.test.tsx` gains typed `Partial<typeof Module>` mocks for the hook (nulls by default) and the chip, plus tests for an avatar row and a glyph-fallback row

Part of plan: chooser-assistant-avatars.md (PR 3 of 11)