### PR TITLE
daemon: best-effort sync of the avatar raster to the platform Assistant record

### DIFF
--- a/assistant/src/__tests__/avatar-identity-sync.test.ts
+++ b/assistant/src/__tests__/avatar-identity-sync.test.ts
@@ -1,4 +1,8 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
+
+mock.module("../platform/sync-avatar.js", () => ({
+  syncAvatarToPlatform: () => {},
+}));
 
 import type { AssistantEventEnvelope } from "../api/index.js";
 import { SYNC_TAGS } from "../daemon/message-types/sync.js";

--- a/assistant/src/__tests__/secret-routes-platform-proxy.test.ts
+++ b/assistant/src/__tests__/secret-routes-platform-proxy.test.ts
@@ -12,6 +12,9 @@ let secureKeyStore: Record<string, string | undefined> = {};
 const metadataUpserts: Array<{ service: string; field: string }> = [];
 const metadataDeletes: Array<{ service: string; field: string }> = [];
 let providerRefreshCalls = 0;
+let identitySyncCalls = 0;
+let avatarSyncCalls = 0;
+let failSecureKeyWrites = false;
 
 const PLATFORM_BASE_URL = "https://platform.example.com";
 const ASSISTANT_API_KEY_PATH = credentialKey("vellum", "assistant_api_key");
@@ -73,6 +76,9 @@ mock.module("../security/secure-keys.js", () => ({
     unreachable: false,
   }),
   setSecureKeyAsync: async (key: string, value: string) => {
+    if (failSecureKeyWrites) {
+      return false;
+    }
     secureKeyStore[key] = value;
     return true;
   },
@@ -97,6 +103,19 @@ mock.module("../tools/credentials/metadata-store.js", () => ({
 // to a no-op; its behavior is covered by boot-maintenance.test.ts.
 mock.module("../plugins/defaults/memory/substrate/boot-maintenance.js", () => ({
   maybeReseedCapabilitiesAfterManagedCredential: async () => {},
+}));
+
+// Live platform registration (`vellum login` against a running assistant)
+// must re-enqueue the name and avatar syncs that no-op'd at startup.
+mock.module("../platform/sync-identity.js", () => ({
+  syncWorkspaceIdentityToPlatform: () => {
+    identitySyncCalls++;
+  },
+}));
+mock.module("../platform/sync-avatar.js", () => ({
+  syncAvatarToPlatform: () => {
+    avatarSyncCalls++;
+  },
 }));
 
 // secret-routes evicts conversations after a credential change so the next turn
@@ -164,6 +183,9 @@ describe("secret routes managed proxy registry sync", () => {
     lastGeminiConstructorOpts = null;
     platformBaseUrlOverride = undefined;
     providerRefreshCalls = 0;
+    identitySyncCalls = 0;
+    avatarSyncCalls = 0;
+    failSecureKeyWrites = false;
     getDb()
       .delete(providerConnections)
       .where(eq(providerConnections.name, "openrouter-connection"))
@@ -299,6 +321,39 @@ describe("secret routes managed proxy registry sync", () => {
 
     // THEN the provider refresh does not run.
     expect(providerRefreshCalls).toBe(0);
+  });
+
+  test("storing a platform registration credential enqueues name and avatar syncs", async () => {
+    for (const name of [
+      "vellum:assistant_api_key",
+      "vellum:platform_assistant_id",
+      "vellum:platform_base_url",
+    ]) {
+      identitySyncCalls = 0;
+      avatarSyncCalls = 0;
+      await addCredential(name, "value");
+      expect(identitySyncCalls).toBe(1);
+      expect(avatarSyncCalls).toBe(1);
+    }
+  });
+
+  test("unrelated credentials do not enqueue platform syncs", async () => {
+    await addCredential("openrouter:api_key", "openrouter-key");
+    await addCredential("vellum:platform_user_id", "user-1");
+
+    expect(identitySyncCalls).toBe(0);
+    expect(avatarSyncCalls).toBe(0);
+  });
+
+  test("a failed platform credential write does not enqueue platform syncs", async () => {
+    failSecureKeyWrites = true;
+
+    await expect(
+      addCredential("vellum:platform_assistant_id", "asst-1"),
+    ).rejects.toThrow("Failed to store credential");
+
+    expect(identitySyncCalls).toBe(0);
+    expect(avatarSyncCalls).toBe(0);
   });
 
   test("storing vellum:platform_base_url sets override and triggers initializeProviders", async () => {

--- a/assistant/src/daemon/lifecycle.ts
+++ b/assistant/src/daemon/lifecycle.ts
@@ -32,6 +32,7 @@ import { maybeEnqueueLexicalBackfillOnUpgrade } from "../persistence/job-handler
 import { clearLifecycleQuiesce } from "../persistence/lifecycle-quiesce.js";
 import { isPlatformClientConfigured } from "../platform/client.js";
 import { startConsentRefresh } from "../platform/consent-cache.js";
+import { syncAvatarToPlatform } from "../platform/sync-avatar.js";
 import { syncWorkspaceIdentityToPlatform } from "../platform/sync-identity.js";
 import { ensurePromptFiles } from "../prompts/system-prompt.js";
 import { runProviderConnectionsBackfill } from "../providers/inference/backfill.js";
@@ -695,9 +696,10 @@ export async function runDaemon(): Promise<void> {
 
   // Initialize providers before Qdrant so HTTP routes can begin accepting
   // requests while Qdrant initializes, then best-effort sync the workspace
-  // identity name to the platform record.
+  // identity name and avatar to the platform record.
   await initializeProviders(config);
   syncWorkspaceIdentityToPlatform();
+  syncAvatarToPlatform();
 
   // Start the idle/LRU/memory-pressure sweep over the in-memory conversation
   // pool.

--- a/assistant/src/platform/sync-avatar.test.ts
+++ b/assistant/src/platform/sync-avatar.test.ts
@@ -8,6 +8,7 @@ import type { AvatarState } from "../avatar/avatar-manifest.js";
 let mockState: AvatarState;
 let mockRasterPath: string | null;
 let mockClient: {
+  baseUrl: string;
   platformAssistantId: string;
   fetch: (path: string, init: RequestInit) => Promise<Response>;
 } | null;
@@ -79,8 +80,9 @@ interface Patch {
 let patches: Patch[];
 let respond: () => Response;
 
-function makeClient(assistantId = "asst-1") {
+function makeClient(assistantId = "asst-1", baseUrl = "https://platform.a") {
   return {
+    baseUrl,
     platformAssistantId: assistantId,
     fetch: async (path: string, init: RequestInit) => {
       patches.push({ path, body: JSON.parse(init.body as string) });
@@ -144,6 +146,37 @@ describe("syncAvatarToPlatform", () => {
     expect(patches.map((p) => p.body.avatar_base64)).toEqual([
       Buffer.from("png-a").toString("base64"),
       Buffer.from("png-a-rewritten").toString("base64"),
+    ]);
+  });
+
+  test("re-registering to another assistant id re-sends the same raster", async () => {
+    syncAvatarToPlatform();
+    await settle();
+    mockClient = makeClient("asst-2");
+    syncAvatarToPlatform();
+    await settle();
+    syncAvatarToPlatform();
+    await settle();
+
+    expect(patches.map((p) => p.path)).toEqual([
+      "/v1/assistants/asst-1/",
+      "/v1/assistants/asst-2/",
+    ]);
+    expect(patches[1].body.avatar_base64).toBe(
+      Buffer.from("png-a").toString("base64"),
+    );
+  });
+
+  test("re-registering to another base URL re-sends the same raster", async () => {
+    syncAvatarToPlatform();
+    await settle();
+    mockClient = makeClient("asst-1", "https://platform.b");
+    syncAvatarToPlatform();
+    await settle();
+
+    expect(patches.map((p) => p.path)).toEqual([
+      "/v1/assistants/asst-1/",
+      "/v1/assistants/asst-1/",
     ]);
   });
 
@@ -240,6 +273,7 @@ describe("syncAvatarToPlatform", () => {
 
   test("a thrown fetch is swallowed and retried on the next publish", async () => {
     mockClient = {
+      baseUrl: "https://platform.a",
       platformAssistantId: "asst-1",
       fetch: async () => {
         throw new Error("boom");

--- a/assistant/src/platform/sync-avatar.test.ts
+++ b/assistant/src/platform/sync-avatar.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -22,7 +22,10 @@ mock.module("./client.js", () => ({
 mock.module("../avatar/avatar-manifest.js", () => ({
   readManifest: () => mockState,
   deriveStateFromLegacyFiles: () => mockState,
-  computeImageMeta: () => ({ updatedAt: "", etag: "stat-etag" }),
+  computeImageMeta: (path: string) => {
+    const stats = statSync(path);
+    return { updatedAt: "", etag: `${stats.size}:${stats.mtimeMs}` };
+  },
 }));
 
 mock.module("../avatar/ensure-raster.js", () => ({
@@ -121,13 +124,26 @@ describe("syncAvatarToPlatform", () => {
     syncAvatarToPlatform();
     await settle();
     mockState = imageState("etag-b");
-    mockRasterPath = writeRaster("b.png", Buffer.from("png-b"));
+    mockRasterPath = writeRaster("b.png", Buffer.from("png-bb"));
     syncAvatarToPlatform();
     await settle();
 
     expect(patches.map((p) => p.body.avatar_base64)).toEqual([
       Buffer.from("png-a").toString("base64"),
-      Buffer.from("png-b").toString("base64"),
+      Buffer.from("png-bb").toString("base64"),
+    ]);
+  });
+
+  test("a raster overwritten in place re-sends without a manifest change", async () => {
+    syncAvatarToPlatform();
+    await settle();
+    writeRaster("a.png", Buffer.from("png-a-rewritten"));
+    syncAvatarToPlatform();
+    await settle();
+
+    expect(patches.map((p) => p.body.avatar_base64)).toEqual([
+      Buffer.from("png-a").toString("base64"),
+      Buffer.from("png-a-rewritten").toString("base64"),
     ]);
   });
 

--- a/assistant/src/platform/sync-avatar.test.ts
+++ b/assistant/src/platform/sync-avatar.test.ts
@@ -1,0 +1,240 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { AvatarState } from "../avatar/avatar-manifest.js";
+
+let mockState: AvatarState;
+let mockRasterPath: string | null;
+let mockClient: {
+  platformAssistantId: string;
+  fetch: (path: string, init: RequestInit) => Promise<Response>;
+} | null;
+let mockResvgAvailable = false;
+let mockRenderedPng = Buffer.from("small");
+let rasterCalls = 0;
+
+mock.module("./client.js", () => ({
+  VellumPlatformClient: { create: async () => mockClient },
+}));
+
+mock.module("../avatar/avatar-manifest.js", () => ({
+  readManifest: () => mockState,
+  deriveStateFromLegacyFiles: () => mockState,
+  computeImageMeta: () => ({ updatedAt: "", etag: "stat-etag" }),
+}));
+
+mock.module("../avatar/ensure-raster.js", () => ({
+  ensureAvatarRasterPath: async () => {
+    rasterCalls += 1;
+    return mockRasterPath;
+  },
+}));
+
+mock.module("../avatar/resvg-lazy.js", () => ({
+  isResvgAvailable: () => mockResvgAvailable,
+  getResvg: () =>
+    class {
+      render() {
+        return { asPng: () => mockRenderedPng };
+      }
+    },
+}));
+
+import {
+  _resetSyncAvatarStateForTests,
+  MAX_AVATAR_UPLOAD_BYTES,
+  syncAvatarToPlatform,
+} from "./sync-avatar.js";
+
+const dir = mkdtempSync(join(tmpdir(), "sync-avatar-test-"));
+afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+function writeRaster(name: string, bytes: Buffer): string {
+  const path = join(dir, name);
+  writeFileSync(path, bytes);
+  return path;
+}
+
+function imageState(etag: string): AvatarState {
+  return {
+    kind: "image",
+    traits: null,
+    source: "upload",
+    image: { updatedAt: "2026-01-01T00:00:00.000Z", etag },
+  };
+}
+
+const NONE: AvatarState = { kind: "none", traits: null, source: null, image: null };
+
+interface Patch {
+  path: string;
+  body: { avatar_base64: string | null };
+}
+
+let patches: Patch[];
+let respond: () => Response;
+
+function makeClient(assistantId = "asst-1") {
+  return {
+    platformAssistantId: assistantId,
+    fetch: async (path: string, init: RequestInit) => {
+      patches.push({ path, body: JSON.parse(init.body as string) });
+      return respond();
+    },
+  };
+}
+
+async function settle(): Promise<void> {
+  for (let i = 0; i < 10; i++) {
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+describe("syncAvatarToPlatform", () => {
+  beforeEach(() => {
+    _resetSyncAvatarStateForTests();
+    patches = [];
+    rasterCalls = 0;
+    respond = () => new Response("{}", { status: 200 });
+    mockClient = makeClient();
+    mockResvgAvailable = false;
+    mockState = imageState("etag-a");
+    mockRasterPath = writeRaster("a.png", Buffer.from("png-a"));
+  });
+
+  test("PATCHes the base64 raster once and dedups an unchanged etag", async () => {
+    syncAvatarToPlatform();
+    await settle();
+    syncAvatarToPlatform();
+    await settle();
+
+    expect(patches).toHaveLength(1);
+    expect(patches[0].path).toBe("/v1/assistants/asst-1/");
+    expect(patches[0].body).toEqual({
+      avatar_base64: Buffer.from("png-a").toString("base64"),
+    });
+  });
+
+  test("a changed etag re-sends", async () => {
+    syncAvatarToPlatform();
+    await settle();
+    mockState = imageState("etag-b");
+    mockRasterPath = writeRaster("b.png", Buffer.from("png-b"));
+    syncAvatarToPlatform();
+    await settle();
+
+    expect(patches.map((p) => p.body.avatar_base64)).toEqual([
+      Buffer.from("png-a").toString("base64"),
+      Buffer.from("png-b").toString("base64"),
+    ]);
+  });
+
+  test("rapid changes collapse into one PATCH carrying the newest raster", async () => {
+    syncAvatarToPlatform();
+    syncAvatarToPlatform();
+    mockState = imageState("etag-c");
+    mockRasterPath = writeRaster("c.png", Buffer.from("png-c"));
+    syncAvatarToPlatform();
+    await settle();
+
+    expect(patches).toHaveLength(1);
+    expect(patches[0].body.avatar_base64).toBe(
+      Buffer.from("png-c").toString("base64"),
+    );
+    expect(rasterCalls).toBe(1);
+  });
+
+  test("removing the avatar sends avatar_base64: null", async () => {
+    syncAvatarToPlatform();
+    await settle();
+    mockState = NONE;
+    mockRasterPath = null;
+    syncAvatarToPlatform();
+    await settle();
+
+    expect(patches[1].body).toEqual({ avatar_base64: null });
+  });
+
+  test("skips oversized rasters when resvg is unavailable", async () => {
+    mockRasterPath = writeRaster(
+      "big.png",
+      Buffer.alloc(MAX_AVATAR_UPLOAD_BYTES + 1),
+    );
+    syncAvatarToPlatform();
+    await settle();
+
+    expect(patches).toHaveLength(0);
+  });
+
+  test("downscales oversized rasters through resvg", async () => {
+    mockResvgAvailable = true;
+    mockRenderedPng = Buffer.from("tiny");
+    mockRasterPath = writeRaster(
+      "big.png",
+      Buffer.alloc(MAX_AVATAR_UPLOAD_BYTES + 1),
+    );
+    syncAvatarToPlatform();
+    await settle();
+
+    expect(patches).toHaveLength(1);
+    expect(patches[0].body.avatar_base64).toBe(
+      Buffer.from("tiny").toString("base64"),
+    );
+  });
+
+  test("skips when the downscaled raster still exceeds the cap", async () => {
+    mockResvgAvailable = true;
+    mockRenderedPng = Buffer.alloc(MAX_AVATAR_UPLOAD_BYTES + 1);
+    mockRasterPath = writeRaster(
+      "big.png",
+      Buffer.alloc(MAX_AVATAR_UPLOAD_BYTES + 1),
+    );
+    syncAvatarToPlatform();
+    await settle();
+
+    expect(patches).toHaveLength(0);
+  });
+
+  test("no-op without a platform client or assistant id", async () => {
+    mockClient = null;
+    syncAvatarToPlatform();
+    await settle();
+    mockClient = makeClient("");
+    syncAvatarToPlatform();
+    await settle();
+
+    expect(patches).toHaveLength(0);
+    expect(rasterCalls).toBe(0);
+  });
+
+  test("a failed PATCH does not dedup the next attempt", async () => {
+    respond = () => new Response("nope", { status: 500 });
+    syncAvatarToPlatform();
+    await settle();
+    respond = () => new Response("{}", { status: 200 });
+    syncAvatarToPlatform();
+    await settle();
+    syncAvatarToPlatform();
+    await settle();
+
+    expect(patches).toHaveLength(2);
+  });
+
+  test("a thrown fetch is swallowed and retried on the next publish", async () => {
+    mockClient = {
+      platformAssistantId: "asst-1",
+      fetch: async () => {
+        throw new Error("boom");
+      },
+    };
+    syncAvatarToPlatform();
+    await settle();
+    mockClient = makeClient();
+    syncAvatarToPlatform();
+    await settle();
+
+    expect(patches).toHaveLength(1);
+  });
+});

--- a/assistant/src/platform/sync-avatar.ts
+++ b/assistant/src/platform/sync-avatar.ts
@@ -5,7 +5,9 @@
  * a sync. The current avatar state is read when the request runs, so rapid
  * changes collapse into one PATCH carrying the newest raster. The dedup key
  * comes from the raster file itself, not the manifest, so a raster rewritten
- * in place (fs watcher path) still syncs. Best-effort: failures are logged, never
+ * in place (fs watcher path) still syncs, and is scoped to the platform
+ * destination so re-registering to another assistant or base URL re-sends.
+ * Best-effort: failures are logged, never
  * thrown, and leave the dedup key untouched so the next publish retries.
  */
 
@@ -98,7 +100,8 @@ async function doSync(requestSeq: number): Promise<void> {
       return;
     }
 
-    const { key, bytes } = await readRaster();
+    const { key: rasterKey, bytes } = await readRaster();
+    const key = `${client.baseUrl}|${assistantId}|${rasterKey}`;
     if (key === lastSyncedKey) {
       return;
     }
@@ -134,7 +137,7 @@ async function doSync(requestSeq: number): Promise<void> {
 
     if (resp.ok) {
       lastSyncedKey = key;
-      log.info({ key, assistantId }, "Synced avatar to platform");
+      log.info({ key: rasterKey, assistantId }, "Synced avatar to platform");
     } else {
       const text = await resp.text();
       log.warn(

--- a/assistant/src/platform/sync-avatar.ts
+++ b/assistant/src/platform/sync-avatar.ts
@@ -1,0 +1,147 @@
+/**
+ * Sync the avatar raster to the platform Assistant record.
+ *
+ * Every avatar publish (routes and the fs watcher) and daemon startup enqueue
+ * a sync. The current avatar state is read when the request runs, so rapid
+ * changes collapse into one PATCH carrying the newest raster. A raster whose
+ * etag already synced is skipped. Best-effort: failures are logged, never
+ * thrown, and leave the dedup key untouched so the next publish retries.
+ */
+
+import { readFile } from "node:fs/promises";
+
+import {
+  computeImageMeta,
+  deriveStateFromLegacyFiles,
+  readManifest,
+} from "../avatar/avatar-manifest.js";
+import { ensureAvatarRasterPath } from "../avatar/ensure-raster.js";
+import { getResvg, isResvgAvailable } from "../avatar/resvg-lazy.js";
+import { getLogger } from "../util/logger.js";
+import { VellumPlatformClient } from "./client.js";
+
+const log = getLogger("sync-avatar");
+
+/** Largest raster sent as-is; bigger ones are downscaled first. */
+export const MAX_AVATAR_UPLOAD_BYTES = 256 * 1024;
+const DOWNSCALE_PX = 128;
+const NONE_KEY = "none";
+
+let lastSyncedKey: string | null = null;
+let seq = 0;
+let pending: Promise<void> = Promise.resolve();
+
+export function _resetSyncAvatarStateForTests(): void {
+  lastSyncedKey = null;
+  seq = 0;
+  pending = Promise.resolve();
+}
+
+/**
+ * Enqueue a best-effort push of the current avatar raster to the platform.
+ * No-op when the platform client cannot be created or no assistant id is
+ * configured, or when the raster's etag matches the last successful sync.
+ */
+export function syncAvatarToPlatform(): void {
+  const mySeq = ++seq;
+  pending = pending.then(() => doSync(mySeq)).catch(() => {});
+}
+
+async function readRaster(): Promise<{ key: string; bytes: Buffer | null }> {
+  const state = readManifest() ?? deriveStateFromLegacyFiles();
+  const path = await ensureAvatarRasterPath(state);
+  if (!path) {
+    return { key: NONE_KEY, bytes: null };
+  }
+  const etag = state.image?.etag ?? computeImageMeta(path).etag;
+  return { key: `${state.kind}:${etag}`, bytes: await readFile(path) };
+}
+
+function downscalePng(png: Buffer): Buffer | null {
+  if (!isResvgAvailable()) {
+    return null;
+  }
+  const href = `data:image/png;base64,${png.toString("base64")}`;
+  const svg =
+    `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" ` +
+    `width="${DOWNSCALE_PX}" height="${DOWNSCALE_PX}" viewBox="0 0 ${DOWNSCALE_PX} ${DOWNSCALE_PX}">` +
+    `<image width="${DOWNSCALE_PX}" height="${DOWNSCALE_PX}" preserveAspectRatio="xMidYMid meet" href="${href}" xlink:href="${href}"/></svg>`;
+  const Resvg = getResvg();
+  const resvg = new Resvg(svg, {
+    fitTo: { mode: "width", value: DOWNSCALE_PX },
+  });
+  return Buffer.from(resvg.render().asPng());
+}
+
+/** Returns the base64 payload, or undefined when the raster cannot fit the cap. */
+function encodeForUpload(bytes: Buffer): string | undefined {
+  let upload: Buffer | null = bytes;
+  if (upload.length > MAX_AVATAR_UPLOAD_BYTES) {
+    upload = downscalePng(upload);
+  }
+  if (!upload || upload.length > MAX_AVATAR_UPLOAD_BYTES) {
+    return undefined;
+  }
+  return upload.toString("base64");
+}
+
+async function doSync(requestSeq: number): Promise<void> {
+  try {
+    if (requestSeq !== seq) {
+      return;
+    }
+
+    const client = await VellumPlatformClient.create();
+    const assistantId = client?.platformAssistantId;
+    if (!client || !assistantId) {
+      return;
+    }
+
+    const { key, bytes } = await readRaster();
+    if (key === lastSyncedKey) {
+      return;
+    }
+
+    let avatarBase64: string | null = null;
+    if (bytes) {
+      const encoded = encodeForUpload(bytes);
+      if (encoded === undefined) {
+        log.warn(
+          { bytes: bytes.length, cap: MAX_AVATAR_UPLOAD_BYTES },
+          "Avatar raster exceeds upload cap and could not be downscaled; skipping sync",
+        );
+        return;
+      }
+      avatarBase64 = encoded;
+    }
+
+    // A newer publish superseded this one while the raster was read; it will
+    // carry the fresher state.
+    if (requestSeq !== seq) {
+      return;
+    }
+
+    const resp = await client.fetch(
+      `/v1/assistants/${encodeURIComponent(assistantId)}/`,
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ avatar_base64: avatarBase64 }),
+        signal: AbortSignal.timeout(15_000),
+      },
+    );
+
+    if (resp.ok) {
+      lastSyncedKey = key;
+      log.info({ key, assistantId }, "Synced avatar to platform");
+    } else {
+      const text = await resp.text();
+      log.warn(
+        { status: resp.status, body: text, assistantId },
+        "Failed to sync avatar to platform",
+      );
+    }
+  } catch (err) {
+    log.warn({ err }, "Error syncing avatar to platform");
+  }
+}

--- a/assistant/src/platform/sync-avatar.ts
+++ b/assistant/src/platform/sync-avatar.ts
@@ -3,8 +3,9 @@
  *
  * Every avatar publish (routes and the fs watcher) and daemon startup enqueue
  * a sync. The current avatar state is read when the request runs, so rapid
- * changes collapse into one PATCH carrying the newest raster. A raster whose
- * etag already synced is skipped. Best-effort: failures are logged, never
+ * changes collapse into one PATCH carrying the newest raster. The dedup key
+ * comes from the raster file itself, not the manifest, so a raster rewritten
+ * in place (fs watcher path) still syncs. Best-effort: failures are logged, never
  * thrown, and leave the dedup key untouched so the next publish retries.
  */
 
@@ -53,7 +54,7 @@ async function readRaster(): Promise<{ key: string; bytes: Buffer | null }> {
   if (!path) {
     return { key: NONE_KEY, bytes: null };
   }
-  const etag = state.image?.etag ?? computeImageMeta(path).etag;
+  const { etag } = computeImageMeta(path);
   return { key: `${state.kind}:${etag}`, bytes: await readFile(path) };
 }
 

--- a/assistant/src/runtime/routes/secret-routes.ts
+++ b/assistant/src/runtime/routes/secret-routes.ts
@@ -30,6 +30,8 @@ import {
   scrubStoredCredentialFromTranscripts,
 } from "../../daemon/credential-transcript-scrub.js";
 import { syncManualTokenConnection } from "../../oauth/manual-token-connection.js";
+import { syncAvatarToPlatform } from "../../platform/sync-avatar.js";
+import { syncWorkspaceIdentityToPlatform } from "../../platform/sync-identity.js";
 import { maybeReseedCapabilitiesAfterManagedCredential } from "../../plugins/defaults/memory/substrate/boot-maintenance.js";
 import { validateAnthropicApiKey } from "../../providers/anthropic/client.js";
 import { validateAtlasCloudApiKey } from "../../providers/atlascloud/client.js";
@@ -423,6 +425,11 @@ async function handleAddSecret({ body }: RouteHandlerArgs) {
         // defaulting; the hook no-ops until the connection is complete.
         // Detached — must not block the response.
         void maybeDefaultSpeechToManaged();
+        // Same last-write-wins shape: the startup syncs no-op before live
+        // registration, so re-enqueue them here. Both dedup and no-op until
+        // the client and assistant id exist.
+        syncWorkspaceIdentityToPlatform();
+        syncAvatarToPlatform();
       }
       log.info({ service, field }, "Credential added via HTTP");
       return { success: true, type, name };

--- a/assistant/src/runtime/sync/resource-sync-events.ts
+++ b/assistant/src/runtime/sync/resource-sync-events.ts
@@ -5,6 +5,7 @@ import {
   conversationMetadataSyncTag,
   SYNC_TAGS,
 } from "../../daemon/message-types/sync.js";
+import { syncAvatarToPlatform } from "../../platform/sync-avatar.js";
 import { getAvatarImagePath } from "../../util/platform.js";
 import { broadcastMessage } from "../assistant-event-hub.js";
 import { isStreamSeqStampingDisabled } from "../assistant-stream-state.js";
@@ -31,6 +32,7 @@ export function publishAvatarChanged(originClientId?: string): void {
     avatarPath: getAvatarImagePath(),
   });
   void publishSyncInvalidation([SYNC_TAGS.assistantAvatar], originClientId);
+  syncAvatarToPlatform();
 }
 
 export function publishIdentityChanged(


### PR DESCRIPTION
## Summary
- New `assistant/src/platform/sync-avatar.ts`: `syncAvatarToPlatform()` enqueues a serialized, best-effort PATCH of `/v1/assistants/{id}/` with `{ avatar_base64 }` (base64 PNG, or `null` when the avatar is removed). The current avatar state is read when the request runs, so rapid changes collapse into a single PATCH carrying the newest raster; a raster whose `kind:etag` key already synced is skipped. Failures are logged, never thrown, and leave the dedup key untouched so the next publish retries.
- Rasters over 256 KB are downscaled to 128px through resvg (PNG wrapped in an SVG `<image>`); when resvg is unavailable or the result still exceeds the cap the sync is skipped and the platform keeps its previous thumbnail.
- Uses `VellumPlatformClient.create()` and bails when it returns null or `platformAssistantId` is empty, so it works identically for platform-hosted and logged-in self-hosted assistants and is a silent no-op before `vellum login`.
- Hooked into `publishAvatarChanged` (covers every avatar route plus the config-watcher fs path) and a startup backfill in `lifecycle.ts` beside `syncWorkspaceIdentityToPlatform()`.
- Tests: etag dedup, changed-etag resend, newest-wins under rapid changes, clear-on-none, size-cap skip, resvg downscale, no-client/no-id no-op, failed PATCH and thrown fetch both retry. `avatar-identity-sync.test.ts` stubs the sync and still asserts exactly `["avatar_updated","sync_changed"]`.
- Skew: safe to merge before the platform `avatar_base64` field exists. DRF ignores unknown PATCH fields, so the request is a harmless no-op until the platform deploys, and the daemon-startup sync backfills the thumbnail afterwards.

Part of plan: chooser-assistant-avatars.md (PR 8 of 11)