### PR TITLE
web: cache last-seen assistant avatars in IndexedDB for offline chooser rows

### DIFF
--- a/clients/web/src/assistant/avatar-api.test.ts
+++ b/clients/web/src/assistant/avatar-api.test.ts
@@ -22,13 +22,21 @@ import { isAvatarState } from "@/types/avatar";
 
 import {
   fetchAvatarImageUrl,
+  fetchAvatarImageUrlResult,
   fetchAvatarState,
+  fetchCharacterTraitsResult,
   uploadAvatarImage,
 } from "./avatar-api";
 
+const CHARACTER_TRAITS = {
+  bodyShape: "round",
+  eyeStyle: "happy",
+  color: "#123456",
+};
+
 const CHARACTER_STATE: AvatarState = {
   kind: "character",
-  traits: { bodyShape: "round", eyeStyle: "happy", color: "#123456" },
+  traits: CHARACTER_TRAITS,
   source: "builder",
   image: null,
 };
@@ -233,6 +241,81 @@ describe("fetchAvatarImageUrl", () => {
     ) as typeof client.get;
 
     expect(await fetchAvatarImageUrl("asst-1")).toBeNull();
+  });
+});
+
+describe("fetchAvatarImageUrlResult", () => {
+  test("a 404 is absent, an authoritative answer", async () => {
+    stubGet({
+      data: undefined,
+      error: { detail: "missing" },
+      response: errorResponse(404),
+    });
+
+    expect(await fetchAvatarImageUrlResult("asst-1")).toEqual({
+      status: "absent",
+    });
+  });
+
+  test("any other non-2xx is failed", async () => {
+    stubGet({
+      data: undefined,
+      error: { detail: "boom" },
+      response: errorResponse(502),
+    });
+
+    expect(await fetchAvatarImageUrlResult("asst-1")).toEqual({
+      status: "failed",
+    });
+  });
+
+  test("a transport throw is failed", async () => {
+    client.get = mock(() =>
+      Promise.reject(new Error("network down")),
+    ) as typeof client.get;
+
+    expect(await fetchAvatarImageUrlResult("asst-1")).toEqual({
+      status: "failed",
+    });
+  });
+});
+
+describe("fetchCharacterTraitsResult", () => {
+  test("a 404 is absent while a 5xx is failed", async () => {
+    stubGet({ data: undefined, error: {}, response: errorResponse(404) });
+    expect(await fetchCharacterTraitsResult("asst-1")).toEqual({
+      status: "absent",
+    });
+
+    stubGet({ data: undefined, error: {}, response: errorResponse(500) });
+    expect(await fetchCharacterTraitsResult("asst-1")).toEqual({
+      status: "failed",
+    });
+  });
+
+  test("a sidecar that does not parse as traits is absent", async () => {
+    stubGet({
+      data: { content: "not json" },
+      error: undefined,
+      response: okResponse(),
+    });
+
+    expect(await fetchCharacterTraitsResult("asst-1")).toEqual({
+      status: "absent",
+    });
+  });
+
+  test("a valid sidecar is found", async () => {
+    stubGet({
+      data: { content: JSON.stringify(CHARACTER_TRAITS) },
+      error: undefined,
+      response: okResponse(),
+    });
+
+    expect(await fetchCharacterTraitsResult("asst-1")).toEqual({
+      status: "found",
+      value: CHARACTER_TRAITS,
+    });
   });
 });
 

--- a/clients/web/src/assistant/avatar-api.ts
+++ b/clients/web/src/assistant/avatar-api.ts
@@ -68,9 +68,30 @@ export async function fetchCharacterComponents(
   }
 }
 
-export async function fetchCharacterTraits(
+/**
+ * A workspace sidecar read that keeps "the file is not there" (a 404, an
+ * authoritative answer) apart from "the request failed" (inconclusive).
+ */
+export type AvatarFileResult<T> =
+  | { status: "found"; value: T }
+  | { status: "absent" }
+  | { status: "failed" };
+
+const ABSENT: AvatarFileResult<never> = { status: "absent" };
+const FAILED: AvatarFileResult<never> = { status: "failed" };
+
+function parseCharacterTraits(content: string): CharacterTraits | null {
+  try {
+    const parsed: unknown = JSON.parse(content);
+    return isCharacterTraits(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function fetchCharacterTraitsResult(
   assistantId: string,
-): Promise<CharacterTraits | null> {
+): Promise<AvatarFileResult<CharacterTraits>> {
   try {
     const { data, error, response } = await workspaceFileGet({
       path: { assistant_id: assistantId },
@@ -78,18 +99,26 @@ export async function fetchCharacterTraits(
       throwOnError: false,
     });
     assertHasResponse(response, error, "Failed to fetch character traits");
+    if (response.status === 404) {
+      return ABSENT;
+    }
     if (!response.ok || !data) {
-      return null;
+      return FAILED;
     }
-
-    const parsed: unknown = JSON.parse(data.content);
-    if (!isCharacterTraits(parsed)) {
-      return null;
-    }
-    return parsed;
+    // A sidecar the daemon serves but cannot render is as good as missing.
+    const traits = parseCharacterTraits(data.content);
+    return traits ? { status: "found", value: traits } : ABSENT;
   } catch {
-    return null;
+    return FAILED;
   }
+}
+
+/** {@link fetchCharacterTraitsResult} collapsed to a value; null for absent or failed. */
+export async function fetchCharacterTraits(
+  assistantId: string,
+): Promise<CharacterTraits | null> {
+  const result = await fetchCharacterTraitsResult(assistantId);
+  return result.status === "found" ? result.value : null;
 }
 
 export async function saveCharacterTraits(
@@ -173,9 +202,9 @@ async function uploadAvatarImageLegacy(
   return true;
 }
 
-export async function fetchAvatarImageUrl(
+export async function fetchAvatarImageUrlResult(
   assistantId: string,
-): Promise<string | null> {
+): Promise<AvatarFileResult<string>> {
   try {
     const { data, error, response } = await workspaceFileContentGet({
       path: { assistant_id: assistantId },
@@ -184,11 +213,22 @@ export async function fetchAvatarImageUrl(
       throwOnError: false,
     });
     assertHasResponse(response, error, "Failed to fetch avatar image");
-    if (!response.ok || !data) {
-      return null;
+    if (response.status === 404) {
+      return ABSENT;
     }
-    return URL.createObjectURL(data);
+    if (!response.ok || !data) {
+      return FAILED;
+    }
+    return { status: "found", value: URL.createObjectURL(data) };
   } catch {
-    return null;
+    return FAILED;
   }
+}
+
+/** {@link fetchAvatarImageUrlResult} collapsed to a value; null for absent or failed. */
+export async function fetchAvatarImageUrl(
+  assistantId: string,
+): Promise<string | null> {
+  const result = await fetchAvatarImageUrlResult(assistantId);
+  return result.status === "found" ? result.value : null;
 }

--- a/clients/web/src/assistant/retire-service.ts
+++ b/clients/web/src/assistant/retire-service.ts
@@ -1,4 +1,5 @@
 import { listAssistants, retireAssistantById } from "@/assistant/api";
+import { deleteLastSeenAvatar } from "@/lib/avatar-last-seen-cache";
 import {
   getLockfile,
   isLocalAssistant,
@@ -112,6 +113,7 @@ export async function retireAssistant(
     }
 
     useResolvedAssistantsStore.getState().remove(assistantId);
+    void deleteLastSeenAvatar(assistantId);
     // Retiring ends any in-flight onboarding journey with it: drop the
     // research-onboarding resume snapshot so the next onboarding starts at the
     // form instead of resuming the retired assistant's run deep in the flow

--- a/clients/web/src/domains/chat/voice/voice-room/voice-avatar.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-avatar.test.tsx
@@ -28,6 +28,7 @@ mock.module(
       traits: null,
       customImageUrl: null,
       isLoading: false,
+      isSuccess: true,
       invalidate: () => {},
     }),
   }),

--- a/clients/web/src/domains/chat/voice/voice-room/voice-avatar.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-avatar.test.tsx
@@ -29,6 +29,7 @@ mock.module(
       customImageUrl: null,
       isLoading: false,
       isSuccess: true,
+      supportsManifest: true,
       invalidate: () => {},
     }),
   }),

--- a/clients/web/src/hooks/use-assistant-avatar.test.tsx
+++ b/clients/web/src/hooks/use-assistant-avatar.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, renderHook, waitFor } from "@testing-library/react";
 
+import type { AvatarFileResult } from "@/assistant/avatar-api";
 import type {
   AvatarState,
   CharacterComponents,
@@ -62,14 +63,21 @@ const noneState: AvatarState = {
 
 const fetchCharacterComponents = mock(async () => components);
 const fetchAvatarState = mock(async () => noneState as AvatarState | null);
-const fetchAvatarImageUrl = mock(async () => null as string | null);
-const fetchCharacterTraits = mock(async () => null as CharacterTraits | null);
+const ABSENT: AvatarFileResult<never> = { status: "absent" };
+const FAILED: AvatarFileResult<never> = { status: "failed" };
+const found = <T,>(value: T): AvatarFileResult<T> => ({ status: "found", value });
+const fetchAvatarImageUrlResult = mock(
+  async () => ABSENT as AvatarFileResult<string>,
+);
+const fetchCharacterTraitsResult = mock(
+  async () => ABSENT as AvatarFileResult<CharacterTraits>,
+);
 
 mock.module("@/assistant/avatar-api", () => ({
   fetchCharacterComponents,
   fetchAvatarState,
-  fetchAvatarImageUrl,
-  fetchCharacterTraits,
+  fetchAvatarImageUrlResult,
+  fetchCharacterTraitsResult,
 }));
 
 const { useAssistantAvatar } = await import("@/hooks/use-assistant-avatar");
@@ -97,12 +105,12 @@ afterEach(() => {
   useAssistantIdentityStore.getState().clearIdentity();
   fetchCharacterComponents.mockClear();
   fetchAvatarState.mockClear();
-  fetchAvatarImageUrl.mockClear();
-  fetchCharacterTraits.mockClear();
+  fetchAvatarImageUrlResult.mockClear();
+  fetchCharacterTraitsResult.mockClear();
   fetchCharacterComponents.mockResolvedValue(components);
   fetchAvatarState.mockResolvedValue(noneState);
-  fetchAvatarImageUrl.mockResolvedValue(null);
-  fetchCharacterTraits.mockResolvedValue(null);
+  fetchAvatarImageUrlResult.mockResolvedValue(ABSENT);
+  fetchCharacterTraitsResult.mockResolvedValue(ABSENT);
 });
 
 describe("useAssistantAvatar", () => {
@@ -122,12 +130,12 @@ describe("useAssistantAvatar", () => {
     expect(result.current.customImageUrl).toBeNull();
     expect(fetchCharacterComponents).toHaveBeenCalledTimes(1);
     expect(fetchAvatarState).toHaveBeenCalledTimes(1);
-    expect(fetchAvatarImageUrl).not.toHaveBeenCalled();
+    expect(fetchAvatarImageUrlResult).not.toHaveBeenCalled();
   });
 
   test("image kind fetches the static image and leaves traits null", async () => {
     fetchAvatarState.mockResolvedValueOnce(imageState);
-    fetchAvatarImageUrl.mockResolvedValueOnce("blob:avatar-image");
+    fetchAvatarImageUrlResult.mockResolvedValueOnce(found("blob:avatar-image"));
 
     const { result } = renderHook(() => useAssistantAvatar("asst-1"), {
       wrapper: createWrapper(),
@@ -142,7 +150,7 @@ describe("useAssistantAvatar", () => {
     expect(result.current.traits).toBeNull();
     expect(fetchCharacterComponents).toHaveBeenCalledTimes(1);
     expect(fetchAvatarState).toHaveBeenCalledTimes(1);
-    expect(fetchAvatarImageUrl).toHaveBeenCalledTimes(1);
+    expect(fetchAvatarImageUrlResult).toHaveBeenCalledTimes(1);
   });
 
   test("none kind falls back with neither traits nor image", async () => {
@@ -159,7 +167,7 @@ describe("useAssistantAvatar", () => {
     expect(result.current.customImageUrl).toBeNull();
     expect(fetchCharacterComponents).toHaveBeenCalledTimes(1);
     expect(fetchAvatarState).toHaveBeenCalledTimes(1);
-    expect(fetchAvatarImageUrl).not.toHaveBeenCalled();
+    expect(fetchAvatarImageUrlResult).not.toHaveBeenCalled();
   });
 
   test("null state (transport failure) preserves the cached avatar instead of blanking", async () => {
@@ -267,7 +275,7 @@ describe("useAssistantAvatar", () => {
     // GIVEN the avatar state is an uploaded image
     fetchAvatarState.mockResolvedValue(imageState);
     // AND the image fetch succeeds
-    fetchAvatarImageUrl.mockResolvedValue("blob:avatar-image");
+    fetchAvatarImageUrlResult.mockResolvedValue(found("blob:avatar-image"));
     // AND the character-components endpoint fails
     fetchCharacterComponents.mockResolvedValue(
       null as unknown as CharacterComponents,
@@ -290,7 +298,7 @@ describe("useAssistantAvatar", () => {
 
   test("pre-manifest assistants infer character traits from the sidecar files", async () => {
     useAssistantIdentityStore.getState().setIdentity("test-asst", "0.8.6");
-    fetchCharacterTraits.mockResolvedValueOnce(traits);
+    fetchCharacterTraitsResult.mockResolvedValueOnce(found(traits));
 
     const { result } = renderHook(() => useAssistantAvatar("asst-1"), {
       wrapper: createWrapper(),
@@ -302,14 +310,14 @@ describe("useAssistantAvatar", () => {
 
     // Legacy path: no image ⇒ read traits sidecar, never touch `/avatar/state`.
     expect(result.current.customImageUrl).toBeNull();
-    expect(fetchAvatarImageUrl).toHaveBeenCalledTimes(1);
-    expect(fetchCharacterTraits).toHaveBeenCalledTimes(1);
+    expect(fetchAvatarImageUrlResult).toHaveBeenCalledTimes(1);
+    expect(fetchCharacterTraitsResult).toHaveBeenCalledTimes(1);
     expect(fetchAvatarState).not.toHaveBeenCalled();
   });
 
   test("pre-manifest assistants render a custom image and skip the traits fetch", async () => {
     useAssistantIdentityStore.getState().setIdentity("test-asst", "0.8.6");
-    fetchAvatarImageUrl.mockResolvedValueOnce("blob:legacy-image");
+    fetchAvatarImageUrlResult.mockResolvedValueOnce(found("blob:legacy-image"));
 
     const { result } = renderHook(() => useAssistantAvatar("asst-1"), {
       wrapper: createWrapper(),
@@ -321,7 +329,77 @@ describe("useAssistantAvatar", () => {
 
     // A custom image exists ⇒ traits are intentionally not fetched.
     expect(result.current.traits).toBeNull();
-    expect(fetchCharacterTraits).not.toHaveBeenCalled();
+    expect(fetchCharacterTraitsResult).not.toHaveBeenCalled();
     expect(fetchAvatarState).not.toHaveBeenCalled();
+  });
+
+  test("image content failure preserves the cached avatar instead of blanking", async () => {
+    fetchAvatarState.mockResolvedValue(imageState);
+    fetchAvatarImageUrlResult.mockResolvedValueOnce(found("blob:avatar-image"));
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    const first = renderHook(() => useAssistantAvatar("asst-1"), { wrapper });
+    await waitFor(() => {
+      expect(first.result.current.customImageUrl).toBe("blob:avatar-image");
+    });
+    first.unmount();
+
+    // The manifest still says image, but the content request fails.
+    fetchAvatarImageUrlResult.mockResolvedValue(FAILED);
+    await queryClient.invalidateQueries({ queryKey: avatarQueryKey("asst-1") });
+
+    const second = renderHook(() => useAssistantAvatar("asst-1"), { wrapper });
+    await waitFor(() => {
+      expect(fetchAvatarImageUrlResult).toHaveBeenCalledTimes(2);
+    });
+    expect(second.result.current.customImageUrl).toBe("blob:avatar-image");
+  });
+
+  test("pre-manifest assistants with both sidecars absent resolve to a bare avatar", async () => {
+    useAssistantIdentityStore.getState().setIdentity("test-asst", "0.8.6");
+
+    const { result } = renderHook(() => useAssistantAvatar("asst-1"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(result.current.traits).toBeNull();
+    expect(result.current.customImageUrl).toBeNull();
+  });
+
+  test("pre-manifest sidecar transport failure preserves the cached avatar", async () => {
+    useAssistantIdentityStore.getState().setIdentity("test-asst", "0.8.6");
+    fetchCharacterTraitsResult.mockResolvedValueOnce(found(traits));
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    const first = renderHook(() => useAssistantAvatar("asst-1"), { wrapper });
+    await waitFor(() => {
+      expect(first.result.current.traits).toEqual(traits);
+    });
+    first.unmount();
+
+    fetchAvatarImageUrlResult.mockResolvedValue(FAILED);
+    fetchCharacterTraitsResult.mockResolvedValue(FAILED);
+    await queryClient.invalidateQueries({ queryKey: avatarQueryKey("asst-1") });
+
+    const second = renderHook(() => useAssistantAvatar("asst-1"), { wrapper });
+    await waitFor(() => {
+      expect(fetchCharacterTraitsResult).toHaveBeenCalledTimes(2);
+    });
+    expect(second.result.current.traits).toEqual(traits);
   });
 });

--- a/clients/web/src/hooks/use-assistant-avatar.test.tsx
+++ b/clients/web/src/hooks/use-assistant-avatar.test.tsx
@@ -65,7 +65,10 @@ const fetchCharacterComponents = mock(async () => components);
 const fetchAvatarState = mock(async () => noneState as AvatarState | null);
 const ABSENT: AvatarFileResult<never> = { status: "absent" };
 const FAILED: AvatarFileResult<never> = { status: "failed" };
-const found = <T,>(value: T): AvatarFileResult<T> => ({ status: "found", value });
+const found = <T,>(value: T): AvatarFileResult<T> => ({
+  status: "found",
+  value,
+});
 const fetchAvatarImageUrlResult = mock(
   async () => ABSENT as AvatarFileResult<string>,
 );
@@ -375,6 +378,36 @@ describe("useAssistantAvatar", () => {
     expect(result.current.customImageUrl).toBeNull();
   });
 
+  test("pre-manifest image read failure is inconclusive even when traits load", async () => {
+    useAssistantIdentityStore.getState().setIdentity("test-asst", "0.8.6");
+    fetchAvatarImageUrlResult.mockResolvedValueOnce(found("blob:avatar-image"));
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    const first = renderHook(() => useAssistantAvatar("asst-1"), { wrapper });
+    await waitFor(() => {
+      expect(first.result.current.customImageUrl).toBe("blob:avatar-image");
+    });
+    first.unmount();
+
+    fetchAvatarImageUrlResult.mockResolvedValue(FAILED);
+    fetchCharacterTraitsResult.mockResolvedValue(found(traits));
+    await queryClient.invalidateQueries({ queryKey: avatarQueryKey("asst-1") });
+
+    const second = renderHook(() => useAssistantAvatar("asst-1"), { wrapper });
+    await waitFor(() => {
+      expect(fetchAvatarImageUrlResult).toHaveBeenCalledTimes(2);
+    });
+    expect(fetchCharacterTraitsResult).not.toHaveBeenCalled();
+    expect(second.result.current.customImageUrl).toBe("blob:avatar-image");
+    expect(second.result.current.traits).toBeNull();
+  });
+
   test("pre-manifest sidecar transport failure preserves the cached avatar", async () => {
     useAssistantIdentityStore.getState().setIdentity("test-asst", "0.8.6");
     fetchCharacterTraitsResult.mockResolvedValueOnce(found(traits));
@@ -398,7 +431,7 @@ describe("useAssistantAvatar", () => {
 
     const second = renderHook(() => useAssistantAvatar("asst-1"), { wrapper });
     await waitFor(() => {
-      expect(fetchCharacterTraitsResult).toHaveBeenCalledTimes(2);
+      expect(fetchAvatarImageUrlResult).toHaveBeenCalledTimes(2);
     });
     expect(second.result.current.traits).toEqual(traits);
   });

--- a/clients/web/src/hooks/use-assistant-avatar.ts
+++ b/clients/web/src/hooks/use-assistant-avatar.ts
@@ -175,6 +175,7 @@ export function useAssistantAvatar(
     customImageUrl: data?.customImageUrl ?? null,
     isLoading,
     isSuccess,
+    supportsManifest,
     invalidate,
   };
 }

--- a/clients/web/src/hooks/use-assistant-avatar.ts
+++ b/clients/web/src/hooks/use-assistant-avatar.ts
@@ -4,10 +4,14 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   fetchCharacterComponents,
   fetchAvatarState,
-  fetchAvatarImageUrl,
-  fetchCharacterTraits,
+  fetchAvatarImageUrlResult,
+  fetchCharacterTraitsResult,
 } from "@/assistant/avatar-api";
-import type { CharacterComponents, CharacterTraits } from "@/types/avatar";
+import type {
+  AvatarState,
+  CharacterComponents,
+  CharacterTraits,
+} from "@/types/avatar";
 import { useSupportsAvatarStateManifest } from "@/lib/backwards-compat/avatar-state-manifest";
 
 export const AVATAR_QUERY_KEY_PREFIX = "assistantAvatar";
@@ -47,6 +51,43 @@ export interface AssistantAvatarOptions {
   enabled?: boolean;
 }
 
+export interface AvatarRead {
+  traits: CharacterTraits | null;
+  imageUrl: string | null;
+}
+
+/**
+ * Resolve the render mode from an already-fetched `/avatar/state` manifest.
+ * Throws when the manifest promises an image whose content request fails,
+ * so React Query keeps the previously cached avatar instead of blanking out.
+ */
+export async function resolveAvatarFromState(
+  assistantId: string,
+  state: AvatarState,
+): Promise<AvatarRead> {
+  if (state.kind === "character") {
+    // Built/AI character: render the animated SVG from traits. The daemon
+    // also writes a derived avatar-image.png raster, but the web never
+    // uses it, so we skip the image fetch entirely.
+    return { traits: state.traits, imageUrl: null };
+  }
+  if (state.kind === "image") {
+    // Custom uploaded image: render the static circle. A 404 here means
+    // the image went away after the manifest was read; that is a real none.
+    const image = await fetchAvatarImageUrlResult(assistantId);
+    if (image.status === "failed") {
+      throw new Error("Failed to fetch avatar image");
+    }
+    return {
+      traits: null,
+      imageUrl: image.status === "found" ? image.value : null,
+    };
+  }
+  // kind === "none": both stay null, and ChatAvatar falls back to default
+  // components / the "V".
+  return { traits: null, imageUrl: null };
+}
+
 /**
  * Resolve the avatar render mode from the authoritative `/avatar/state`
  * manifest (assistants on `MIN_VERSION`+). Throws on a null state so React
@@ -55,7 +96,7 @@ export interface AssistantAvatarOptions {
  */
 export async function fetchAvatarViaManifest(
   assistantId: string,
-): Promise<{ traits: CharacterTraits | null; imageUrl: string | null }> {
+): Promise<AvatarRead> {
   const state = await fetchAvatarState(assistantId);
   if (state === null) {
     // `fetchAvatarState` returns null only on transport failure. Throw
@@ -65,20 +106,15 @@ export async function fetchAvatarViaManifest(
     // showing the last good avatar instead of blanking out to the "V".
     throw new Error("Failed to fetch avatar state");
   }
+  return resolveAvatarFromState(assistantId, state);
+}
 
-  if (state.kind === "character") {
-    // Built/AI character: render the animated SVG from traits. The daemon
-    // also writes a derived avatar-image.png raster, but the web never
-    // uses it, so we skip the image fetch entirely.
-    return { traits: state.traits, imageUrl: null };
-  }
-  if (state.kind === "image") {
-    // Custom uploaded image: render the static circle.
-    return { traits: null, imageUrl: await fetchAvatarImageUrl(assistantId) };
-  }
-  // kind === "none": both stay null, and ChatAvatar falls back to default
-  // components / the "V".
-  return { traits: null, imageUrl: null };
+/**
+ * A legacy sidecar read plus whether it is authoritative: a found file is;
+ * two 404s are a real bare avatar; any transport failure is inconclusive.
+ */
+export interface LegacyAvatarRead extends AvatarRead {
+  conclusive: boolean;
 }
 
 /**
@@ -88,15 +124,37 @@ export async function fetchAvatarViaManifest(
  * alive behind the version gate — see
  * `lib/backwards-compat/avatar-state-manifest.ts`.
  */
-export async function fetchAvatarViaLegacyFiles(
+export async function readAvatarViaLegacyFiles(
   assistantId: string,
-): Promise<{ traits: CharacterTraits | null; imageUrl: string | null }> {
-  const imageUrl = await fetchAvatarImageUrl(assistantId);
+): Promise<LegacyAvatarRead> {
+  const image = await fetchAvatarImageUrlResult(assistantId);
   // Skip the traits fetch when a custom image exists — the traits file is
   // intentionally deleted on the daemon side in that case, so requesting it
   // just generates 404s. `AvatarRenderer` only reads `traits` when there is
   // no `customImageUrl`.
-  const traits = imageUrl ? null : await fetchCharacterTraits(assistantId);
+  if (image.status === "found") {
+    return { traits: null, imageUrl: image.value, conclusive: true };
+  }
+  const traits = await fetchCharacterTraitsResult(assistantId);
+  if (traits.status === "found") {
+    return { traits: traits.value, imageUrl: null, conclusive: true };
+  }
+  return {
+    traits: null,
+    imageUrl: null,
+    conclusive: image.status === "absent" && traits.status === "absent",
+  };
+}
+
+/** {@link readAvatarViaLegacyFiles} that throws on an inconclusive read, like the manifest path. */
+export async function fetchAvatarViaLegacyFiles(
+  assistantId: string,
+): Promise<AvatarRead> {
+  const { traits, imageUrl, conclusive } =
+    await readAvatarViaLegacyFiles(assistantId);
+  if (!conclusive) {
+    throw new Error("Failed to fetch avatar sidecars");
+  }
   return { traits, imageUrl };
 }
 

--- a/clients/web/src/hooks/use-assistant-avatar.ts
+++ b/clients/web/src/hooks/use-assistant-avatar.ts
@@ -120,7 +120,7 @@ export function useAssistantAvatar(
   const activeSupportsManifest = useSupportsAvatarStateManifest();
   const supportsManifest = options?.supportsManifest ?? activeSupportsManifest;
 
-  const { data, isLoading } = useQuery<AvatarData>({
+  const { data, isLoading, isSuccess } = useQuery<AvatarData>({
     queryKey: [...avatarQueryKey(assistantId ?? ""), supportsManifest],
     queryFn: async () => {
       const id = assistantId!;
@@ -174,6 +174,7 @@ export function useAssistantAvatar(
     traits: data?.traits ?? null,
     customImageUrl: data?.customImageUrl ?? null,
     isLoading,
+    isSuccess,
     invalidate,
   };
 }

--- a/clients/web/src/hooks/use-assistant-avatar.ts
+++ b/clients/web/src/hooks/use-assistant-avatar.ts
@@ -135,6 +135,10 @@ export async function readAvatarViaLegacyFiles(
   if (image.status === "found") {
     return { traits: null, imageUrl: image.value, conclusive: true };
   }
+  if (image.status === "failed") {
+    // The image outranks traits, so an unread image leaves the outcome unknown.
+    return { traits: null, imageUrl: null, conclusive: false };
+  }
   const traits = await fetchCharacterTraitsResult(assistantId);
   if (traits.status === "found") {
     return { traits: traits.value, imageUrl: null, conclusive: true };
@@ -142,7 +146,7 @@ export async function readAvatarViaLegacyFiles(
   return {
     traits: null,
     imageUrl: null,
-    conclusive: image.status === "absent" && traits.status === "absent",
+    conclusive: traits.status === "absent",
   };
 }
 

--- a/clients/web/src/hooks/use-chooser-row-avatar.test.tsx
+++ b/clients/web/src/hooks/use-chooser-row-avatar.test.tsx
@@ -94,12 +94,15 @@ const avatarApiMock: Partial<typeof AvatarApi> = {
 mock.module("@/assistant/avatar-api", () => avatarApiMock);
 
 type LastSeenAvatar = AvatarLastSeenCache.LastSeenAvatar;
+const actualLastSeenCache = await import("@/lib/avatar-last-seen-cache");
 const readLastSeenAvatar = mock(async () => null as LastSeenAvatar | null);
 const writeLastSeenAvatar = mock(async (_id: string, _v: LastSeenAvatar) => {});
 const deleteLastSeenAvatar = mock(async (_id: string) => {});
+// The generation helpers stay real so the hook's write guard is exercised.
 mock.module(
   "@/lib/avatar-last-seen-cache",
   (): Partial<typeof AvatarLastSeenCache> => ({
+    ...actualLastSeenCache,
     readLastSeenAvatar,
     writeLastSeenAvatar,
     deleteLastSeenAvatar,
@@ -541,10 +544,11 @@ describe("useChooserRowAvatar", () => {
         expect(result.current.traits).toEqual(traits);
       });
       await waitFor(() => {
-        expect(writeLastSeenAvatar).toHaveBeenCalledWith("other", {
-          kind: "character",
-          traits,
-        });
+        expect(writeLastSeenAvatar).toHaveBeenCalledWith(
+          "other",
+          { kind: "character", traits },
+          expect.any(Number),
+        );
       });
       expect(deleteLastSeenAvatar).not.toHaveBeenCalled();
     });
@@ -579,10 +583,11 @@ describe("useChooserRowAvatar", () => {
         wrapper: createWrapper(),
       });
       await waitFor(() => {
-        expect(writeLastSeenAvatar).toHaveBeenCalledWith("active", {
-          kind: "character",
-          traits,
-        });
+        expect(writeLastSeenAvatar).toHaveBeenCalledWith(
+          "active",
+          { kind: "character", traits },
+          expect.any(Number),
+        );
       });
     });
 
@@ -593,10 +598,117 @@ describe("useChooserRowAvatar", () => {
         { wrapper: createWrapper() },
       );
       await waitFor(() => {
-        expect(deleteLastSeenAvatar).toHaveBeenCalledWith("other");
+        expect(deleteLastSeenAvatar).toHaveBeenCalledWith(
+          "other",
+          expect.any(Number),
+        );
       });
       expect(writeLastSeenAvatar).not.toHaveBeenCalled();
       expect(result.current).toEqual({ traits: null, imageUrl: null });
+    });
+
+    test("an unreachable legacy row keeps its cached avatar and does not evict it", async () => {
+      fetchAvatarImageUrl.mockResolvedValue(null);
+      fetchCharacterTraits.mockResolvedValue(null);
+      readLastSeenAvatar.mockResolvedValue({ kind: "character", traits });
+      const { result } = renderHook(
+        () =>
+          useChooserRowAvatar(
+            platformRow("other", { runtimeVersion: "0.8.6" }),
+          ),
+        { wrapper: createWrapper() },
+      );
+      await waitFor(() => {
+        expect(fetchCharacterTraits).toHaveBeenCalledTimes(1);
+      });
+      await waitFor(() => {
+        expect(result.current.traits).toEqual(traits);
+      });
+      await settle();
+      expect(result.current.traits).toEqual(traits);
+      expect(deleteLastSeenAvatar).not.toHaveBeenCalled();
+      expect(writeLastSeenAvatar).not.toHaveBeenCalled();
+    });
+
+    test("an unreachable version-unknown row keeps its cached avatar", async () => {
+      fetchAvatarState.mockResolvedValue(null);
+      readLastSeenAvatar.mockResolvedValue({ kind: "character", traits });
+      const { result } = renderHook(
+        () =>
+          useChooserRowAvatar(
+            platformRow("other", {
+              runtimeVersion: undefined,
+              currentReleaseVersion: null,
+            }),
+          ),
+        { wrapper: createWrapper() },
+      );
+      await waitFor(() => {
+        expect(result.current.traits).toEqual(traits);
+      });
+      await settle();
+      expect(deleteLastSeenAvatar).not.toHaveBeenCalled();
+    });
+
+    test("a populated legacy read still writes the cache", async () => {
+      fetchCharacterTraits.mockResolvedValue(traits);
+      renderHook(
+        () =>
+          useChooserRowAvatar(
+            platformRow("other", { runtimeVersion: "0.8.6" }),
+          ),
+        { wrapper: createWrapper() },
+      );
+      await waitFor(() => {
+        expect(writeLastSeenAvatar).toHaveBeenCalledWith(
+          "other",
+          { kind: "character", traits },
+          expect.any(Number),
+        );
+      });
+    });
+
+    test("an image write that resolves after a newer traits write commits nothing", async () => {
+      let resolveBlob: (r: Response) => void = () => {};
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = mock(
+        () => new Promise<Response>((resolve) => (resolveBlob = resolve)),
+      ) as unknown as typeof fetch;
+      try {
+        fetchAvatarState.mockResolvedValue(imageState);
+        fetchAvatarImageUrl.mockResolvedValue("blob:row-image");
+        const queryClient = new QueryClient({
+          defaultOptions: { queries: { retry: false } },
+        });
+        const { result } = renderHook(
+          () => useChooserRowAvatar(platformRow("other")),
+          { wrapper: createWrapper(queryClient) },
+        );
+        await waitFor(() => {
+          expect(globalThis.fetch).toHaveBeenCalledWith("blob:row-image");
+        });
+
+        fetchAvatarState.mockResolvedValue(characterState);
+        await queryClient.invalidateQueries({
+          queryKey: chooserRowAvatarQueryKeyPrefix("other"),
+        });
+        await waitFor(() => {
+          expect(result.current.traits).toEqual(traits);
+        });
+        await waitFor(() => {
+          expect(writeLastSeenAvatar).toHaveBeenCalledTimes(1);
+        });
+        expect(writeLastSeenAvatar.mock.calls[0]![1]).toEqual({
+          kind: "character",
+          traits,
+        });
+
+        resolveBlob(new Response(new Blob(["png"])));
+        await settle();
+        expect(writeLastSeenAvatar).toHaveBeenCalledTimes(1);
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
     });
 
     test("reads the cache as the final fallback when no live source applies", async () => {

--- a/clients/web/src/hooks/use-chooser-row-avatar.test.tsx
+++ b/clients/web/src/hooks/use-chooser-row-avatar.test.tsx
@@ -1,9 +1,10 @@
 /**
  * Tests for `useChooserRowAvatar`: the transport gate that decides whether a
  * per-row SDK fetch is addressable, connected-row delegation to
- * `useAssistantAvatar`, per-row manifest-vs-legacy path selection, and the
- * failure-to-nulls contract. The resolved-assistants store is real; the
- * environment probes and the avatar API are mocked at the module boundary.
+ * `useAssistantAvatar`, per-row manifest-vs-legacy path selection, the
+ * last-seen cache as the final fallback, and the failure-to-nulls contract.
+ * The resolved-assistants store is real; the environment probes, the avatar
+ * API, and the IndexedDB cache are mocked at the module boundary.
  */
 
 import type { ReactNode } from "react";
@@ -20,6 +21,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, renderHook, waitFor } from "@testing-library/react";
 
 import type * as AvatarApi from "@/assistant/avatar-api";
+import type * as AvatarLastSeenCache from "@/lib/avatar-last-seen-cache";
 import type { ResolvedAssistant } from "@/stores/resolved-assistants-store";
 import type {
   AvatarState,
@@ -91,6 +93,19 @@ const avatarApiMock: Partial<typeof AvatarApi> = {
 };
 mock.module("@/assistant/avatar-api", () => avatarApiMock);
 
+type LastSeenAvatar = AvatarLastSeenCache.LastSeenAvatar;
+const readLastSeenAvatar = mock(async () => null as LastSeenAvatar | null);
+const writeLastSeenAvatar = mock(async (_id: string, _v: LastSeenAvatar) => {});
+const deleteLastSeenAvatar = mock(async (_id: string) => {});
+mock.module(
+  "@/lib/avatar-last-seen-cache",
+  (): Partial<typeof AvatarLastSeenCache> => ({
+    readLastSeenAvatar,
+    writeLastSeenAvatar,
+    deleteLastSeenAvatar,
+  }),
+);
+
 const { useResolvedAssistantsStore } =
   await import("@/stores/resolved-assistants-store");
 const { useAssistantIdentityStore } =
@@ -106,6 +121,14 @@ const {
 
 const revokeObjectURL = mock((_url: string) => {});
 URL.revokeObjectURL = revokeObjectURL;
+URL.createObjectURL = () => "blob:cached-image";
+
+const noneState: AvatarState = {
+  kind: "none",
+  traits: null,
+  source: null,
+  image: null,
+};
 
 const platformRow = (
   id: string,
@@ -165,6 +188,10 @@ afterEach(() => {
   fetchAvatarImageUrl.mockReset();
   fetchCharacterTraits.mockReset();
   fetchCharacterComponents.mockReset();
+  readLastSeenAvatar.mockReset();
+  writeLastSeenAvatar.mockReset();
+  deleteLastSeenAvatar.mockReset();
+  readLastSeenAvatar.mockResolvedValue(null);
   fetchAvatarState.mockResolvedValue(characterState);
   fetchAvatarImageUrl.mockResolvedValue(null);
   fetchCharacterTraits.mockResolvedValue(null);
@@ -502,5 +529,160 @@ describe("useChooserRowAvatar", () => {
     expect(fetchAvatarState).toHaveBeenCalledWith("a");
     expect(fetchAvatarState).toHaveBeenCalledWith("b");
     expect(fetchAvatarState).toHaveBeenCalledTimes(2);
+  });
+
+  describe("last-seen cache", () => {
+    test("writes a character entry after a live platform-proxy resolution", async () => {
+      const { result } = renderHook(
+        () => useChooserRowAvatar(platformRow("other")),
+        { wrapper: createWrapper() },
+      );
+      await waitFor(() => {
+        expect(result.current.traits).toEqual(traits);
+      });
+      await waitFor(() => {
+        expect(writeLastSeenAvatar).toHaveBeenCalledWith("other", {
+          kind: "character",
+          traits,
+        });
+      });
+      expect(deleteLastSeenAvatar).not.toHaveBeenCalled();
+    });
+
+    test("writes an image entry as a Blob read back from the live blob url", async () => {
+      const blob = new Blob(["png"], { type: "image/png" });
+      const originalFetch = globalThis.fetch;
+      globalThis.fetch = mock(
+        async () => new Response(blob),
+      ) as unknown as typeof fetch;
+      try {
+        fetchAvatarState.mockResolvedValue(imageState);
+        fetchAvatarImageUrl.mockResolvedValue("blob:row-image");
+        renderHook(() => useChooserRowAvatar(platformRow("other")), {
+          wrapper: createWrapper(),
+        });
+        await waitFor(() => {
+          expect(writeLastSeenAvatar).toHaveBeenCalledTimes(1);
+        });
+        expect(globalThis.fetch).toHaveBeenCalledWith("blob:row-image");
+        const [id, entry] = writeLastSeenAvatar.mock.calls[0]!;
+        expect(id).toBe("other");
+        expect(entry.kind).toBe("image");
+        expect(entry.kind === "image" && (await entry.blob.text())).toBe("png");
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
+    test("writes the connected row's live avatar", async () => {
+      renderHook(() => useChooserRowAvatar(platformRow("active")), {
+        wrapper: createWrapper(),
+      });
+      await waitFor(() => {
+        expect(writeLastSeenAvatar).toHaveBeenCalledWith("active", {
+          kind: "character",
+          traits,
+        });
+      });
+    });
+
+    test("deletes the entry when a live source resolves kind none", async () => {
+      fetchAvatarState.mockResolvedValue(noneState);
+      const { result } = renderHook(
+        () => useChooserRowAvatar(platformRow("other")),
+        { wrapper: createWrapper() },
+      );
+      await waitFor(() => {
+        expect(deleteLastSeenAvatar).toHaveBeenCalledWith("other");
+      });
+      expect(writeLastSeenAvatar).not.toHaveBeenCalled();
+      expect(result.current).toEqual({ traits: null, imageUrl: null });
+    });
+
+    test("reads the cache as the final fallback when no live source applies", async () => {
+      localClient = true;
+      readLastSeenAvatar.mockResolvedValue({ kind: "character", traits });
+      const { result } = renderHook(
+        () => useChooserRowAvatar(platformRow("other", { isPaired: true })),
+        { wrapper: createWrapper() },
+      );
+      await waitFor(() => {
+        expect(result.current.traits).toEqual(traits);
+      });
+      expect(readLastSeenAvatar).toHaveBeenCalledWith("other");
+      expect(sdkCallCount()).toBe(0);
+    });
+
+    test("re-creates an object url from a cached image Blob", async () => {
+      localClient = true;
+      readLastSeenAvatar.mockResolvedValue({
+        kind: "image",
+        blob: new Blob(["png"]),
+      });
+      const { result } = renderHook(
+        () => useChooserRowAvatar(platformRow("other", { isPaired: true })),
+        { wrapper: createWrapper() },
+      );
+      await waitFor(() => {
+        expect(result.current.imageUrl).toBe("blob:cached-image");
+      });
+      expect(result.current.traits).toBeNull();
+    });
+
+    test("falls back to the cache when the live fetch fails", async () => {
+      fetchAvatarState.mockRejectedValue(new Error("boom"));
+      readLastSeenAvatar.mockResolvedValue({ kind: "character", traits });
+      const { result } = renderHook(
+        () => useChooserRowAvatar(platformRow("other")),
+        { wrapper: createWrapper() },
+      );
+      await waitFor(() => {
+        expect(result.current.traits).toEqual(traits);
+      });
+      expect(fetchAvatarState).toHaveBeenCalledTimes(1);
+    });
+
+    test("falls back to the cache for an unreachable connected row", async () => {
+      fetchAvatarState.mockRejectedValue(new Error("offline"));
+      fetchCharacterComponents.mockRejectedValue(new Error("offline"));
+      readLastSeenAvatar.mockResolvedValue({ kind: "character", traits });
+      const { result } = renderHook(
+        () => useChooserRowAvatar(platformRow("active")),
+        { wrapper: createWrapper() },
+      );
+      await waitFor(() => {
+        expect(result.current.traits).toEqual(traits);
+      });
+      expect(readLastSeenAvatar).toHaveBeenCalledWith("active");
+    });
+
+    test("never writes back data that came from the cache", async () => {
+      localClient = true;
+      readLastSeenAvatar.mockResolvedValue({ kind: "character", traits });
+      const { result } = renderHook(
+        () => useChooserRowAvatar(platformRow("other", { isPaired: true })),
+        { wrapper: createWrapper() },
+      );
+      await waitFor(() => {
+        expect(result.current.traits).toEqual(traits);
+      });
+      await settle();
+      expect(writeLastSeenAvatar).not.toHaveBeenCalled();
+      expect(deleteLastSeenAvatar).not.toHaveBeenCalled();
+    });
+
+    test("a cache read failure resolves to nulls", async () => {
+      localClient = true;
+      readLastSeenAvatar.mockRejectedValue(new Error("idb"));
+      const { result } = renderHook(
+        () => useChooserRowAvatar(platformRow("other", { isPaired: true })),
+        { wrapper: createWrapper() },
+      );
+      await waitFor(() => {
+        expect(readLastSeenAvatar).toHaveBeenCalledTimes(1);
+      });
+      await settle();
+      expect(result.current).toEqual({ traits: null, imageUrl: null });
+    });
   });
 });

--- a/clients/web/src/hooks/use-chooser-row-avatar.test.tsx
+++ b/clients/web/src/hooks/use-chooser-row-avatar.test.tsx
@@ -81,14 +81,22 @@ const imageState: AvatarState = {
 };
 
 const fetchAvatarState = mock(async () => characterState as AvatarState | null);
-const fetchAvatarImageUrl = mock(async () => null as string | null);
-const fetchCharacterTraits = mock(async () => null as CharacterTraits | null);
+type FileResult<T> = AvatarApi.AvatarFileResult<T>;
+const ABSENT: FileResult<never> = { status: "absent" };
+const FAILED: FileResult<never> = { status: "failed" };
+const found = <T,>(value: T): FileResult<T> => ({ status: "found", value });
+const fetchAvatarImageUrlResult = mock(
+  async () => ABSENT as FileResult<string>,
+);
+const fetchCharacterTraitsResult = mock(
+  async () => ABSENT as FileResult<CharacterTraits>,
+);
 const fetchCharacterComponents = mock(async () => components);
 
 const avatarApiMock: Partial<typeof AvatarApi> = {
   fetchAvatarState,
-  fetchAvatarImageUrl,
-  fetchCharacterTraits,
+  fetchAvatarImageUrlResult,
+  fetchCharacterTraitsResult,
   fetchCharacterComponents,
 };
 mock.module("@/assistant/avatar-api", () => avatarApiMock);
@@ -160,8 +168,8 @@ function createWrapper(
 function sdkCallCount(): number {
   return (
     fetchAvatarState.mock.calls.length +
-    fetchAvatarImageUrl.mock.calls.length +
-    fetchCharacterTraits.mock.calls.length +
+    fetchAvatarImageUrlResult.mock.calls.length +
+    fetchCharacterTraitsResult.mock.calls.length +
     fetchCharacterComponents.mock.calls.length
   );
 }
@@ -188,16 +196,16 @@ afterEach(() => {
   useResolvedAssistantsStore.getState().setActiveAssistantId(null);
   useAssistantIdentityStore.getState().clearIdentity();
   fetchAvatarState.mockReset();
-  fetchAvatarImageUrl.mockReset();
-  fetchCharacterTraits.mockReset();
+  fetchAvatarImageUrlResult.mockReset();
+  fetchCharacterTraitsResult.mockReset();
   fetchCharacterComponents.mockReset();
   readLastSeenAvatar.mockReset();
   writeLastSeenAvatar.mockReset();
   deleteLastSeenAvatar.mockReset();
   readLastSeenAvatar.mockResolvedValue(null);
   fetchAvatarState.mockResolvedValue(characterState);
-  fetchAvatarImageUrl.mockResolvedValue(null);
-  fetchCharacterTraits.mockResolvedValue(null);
+  fetchAvatarImageUrlResult.mockResolvedValue(ABSENT);
+  fetchCharacterTraitsResult.mockResolvedValue(ABSENT);
   fetchCharacterComponents.mockResolvedValue(components);
 });
 
@@ -331,12 +339,12 @@ describe("useChooserRowAvatar", () => {
     });
     expect(fetchAvatarState).toHaveBeenCalledWith("other");
     expect(fetchCharacterComponents).not.toHaveBeenCalled();
-    expect(fetchAvatarImageUrl).not.toHaveBeenCalled();
+    expect(fetchAvatarImageUrlResult).not.toHaveBeenCalled();
   });
 
   test("image kind resolves the blob url", async () => {
     fetchAvatarState.mockResolvedValue(imageState);
-    fetchAvatarImageUrl.mockResolvedValue("blob:row-image");
+    fetchAvatarImageUrlResult.mockResolvedValue(found("blob:row-image"));
     const { result } = renderHook(
       () => useChooserRowAvatar(platformRow("other")),
       { wrapper: createWrapper() },
@@ -348,7 +356,7 @@ describe("useChooserRowAvatar", () => {
   });
 
   test("pre-manifest platform row reads the legacy sidecars only", async () => {
-    fetchCharacterTraits.mockResolvedValue(traits);
+    fetchCharacterTraitsResult.mockResolvedValue(found(traits));
     const { result } = renderHook(
       () =>
         useChooserRowAvatar(
@@ -363,12 +371,12 @@ describe("useChooserRowAvatar", () => {
       expect(result.current.traits).toEqual(traits);
     });
     expect(fetchAvatarState).not.toHaveBeenCalled();
-    expect(fetchAvatarImageUrl).toHaveBeenCalledWith("other");
+    expect(fetchAvatarImageUrlResult).toHaveBeenCalledWith("other");
   });
 
   test("unknown version probes the manifest, then falls back to sidecars", async () => {
     fetchAvatarState.mockResolvedValue(null);
-    fetchAvatarImageUrl.mockResolvedValue("blob:legacy");
+    fetchAvatarImageUrlResult.mockResolvedValue(found("blob:legacy"));
     const { result } = renderHook(
       () =>
         useChooserRowAvatar(
@@ -383,7 +391,7 @@ describe("useChooserRowAvatar", () => {
       expect(result.current.imageUrl).toBe("blob:legacy");
     });
     expect(fetchAvatarState).toHaveBeenCalledTimes(1);
-    expect(fetchCharacterTraits).not.toHaveBeenCalled();
+    expect(fetchCharacterTraitsResult).not.toHaveBeenCalled();
   });
 
   test("failures resolve to nulls, never an error", async () => {
@@ -400,7 +408,7 @@ describe("useChooserRowAvatar", () => {
   });
 
   test("re-keys on a version change so an upgraded row switches paths", async () => {
-    fetchCharacterTraits.mockResolvedValue(traits);
+    fetchCharacterTraitsResult.mockResolvedValue(found(traits));
     const { result, rerender } = renderHook(
       (version: string) =>
         useChooserRowAvatar(platformRow("other", { runtimeVersion: version })),
@@ -410,7 +418,7 @@ describe("useChooserRowAvatar", () => {
       expect(result.current.traits).toEqual(traits);
     });
     expect(fetchAvatarState).not.toHaveBeenCalled();
-    expect(fetchCharacterTraits).toHaveBeenCalledTimes(1);
+    expect(fetchCharacterTraitsResult).toHaveBeenCalledTimes(1);
 
     rerender(MIN_VERSION);
     await waitFor(() => {
@@ -419,7 +427,7 @@ describe("useChooserRowAvatar", () => {
     await waitFor(() => {
       expect(result.current.traits).toEqual(traits);
     });
-    expect(fetchCharacterTraits).toHaveBeenCalledTimes(1);
+    expect(fetchCharacterTraitsResult).toHaveBeenCalledTimes(1);
   });
 
   test("invalidating the row prefix refetches past staleTime: Infinity", async () => {
@@ -451,25 +459,25 @@ describe("useChooserRowAvatar", () => {
     const row = platformRow("other", { runtimeVersion: "0.8.6" });
     const first = renderHook(() => useChooserRowAvatar(row), { wrapper });
     await waitFor(() => {
-      expect(fetchCharacterTraits).toHaveBeenCalledTimes(1);
+      expect(fetchCharacterTraitsResult).toHaveBeenCalledTimes(1);
     });
     await settle();
     expect(first.result.current).toEqual({ traits: null, imageUrl: null });
     first.unmount();
 
     setSystemTime(new Date(Date.now() + EMPTY_AVATAR_STALE_TIME_MS + 1));
-    fetchCharacterTraits.mockResolvedValue(traits);
+    fetchCharacterTraitsResult.mockResolvedValue(found(traits));
     const second = renderHook(() => useChooserRowAvatar(row), { wrapper });
     await waitFor(() => {
       expect(second.result.current.traits).toEqual(traits);
     });
-    expect(fetchCharacterTraits).toHaveBeenCalledTimes(2);
+    expect(fetchCharacterTraitsResult).toHaveBeenCalledTimes(2);
   });
 
   test("a populated legacy result stays cached past the empty stale window", async () => {
     const wrapper = createWrapper();
     const row = platformRow("other", { runtimeVersion: "0.8.6" });
-    fetchCharacterTraits.mockResolvedValue(traits);
+    fetchCharacterTraitsResult.mockResolvedValue(found(traits));
     const first = renderHook(() => useChooserRowAvatar(row), { wrapper });
     await waitFor(() => {
       expect(first.result.current.traits).toEqual(traits);
@@ -482,16 +490,16 @@ describe("useChooserRowAvatar", () => {
       expect(second.result.current.traits).toEqual(traits);
     });
     await settle();
-    expect(fetchCharacterTraits).toHaveBeenCalledTimes(1);
+    expect(fetchCharacterTraitsResult).toHaveBeenCalledTimes(1);
   });
 
   test("a superseded fetch that finishes last drops its own blob, not the current one", async () => {
-    let resolveOld: (url: string) => void = () => {};
-    const oldImage = new Promise<string | null>((resolve) => {
+    let resolveOld: (result: FileResult<string>) => void = () => {};
+    const oldImage = new Promise<FileResult<string>>((resolve) => {
       resolveOld = resolve;
     });
-    fetchAvatarImageUrl.mockImplementationOnce(() => oldImage);
-    fetchAvatarImageUrl.mockResolvedValue("blob:new");
+    fetchAvatarImageUrlResult.mockImplementationOnce(() => oldImage);
+    fetchAvatarImageUrlResult.mockResolvedValue(found("blob:new"));
     fetchAvatarState.mockResolvedValue(imageState);
 
     const { result, rerender } = renderHook(
@@ -500,7 +508,7 @@ describe("useChooserRowAvatar", () => {
       { wrapper: createWrapper(), initialProps: "0.8.6" },
     );
     await waitFor(() => {
-      expect(fetchAvatarImageUrl).toHaveBeenCalledTimes(1);
+      expect(fetchAvatarImageUrlResult).toHaveBeenCalledTimes(1);
     });
 
     rerender(MIN_VERSION);
@@ -508,7 +516,7 @@ describe("useChooserRowAvatar", () => {
       expect(result.current.imageUrl).toBe("blob:new");
     });
 
-    resolveOld("blob:old");
+    resolveOld(found("blob:old"));
     await waitFor(() => {
       expect(revokeObjectURL).toHaveBeenCalledWith("blob:old");
     });
@@ -561,7 +569,7 @@ describe("useChooserRowAvatar", () => {
       ) as unknown as typeof fetch;
       try {
         fetchAvatarState.mockResolvedValue(imageState);
-        fetchAvatarImageUrl.mockResolvedValue("blob:row-image");
+        fetchAvatarImageUrlResult.mockResolvedValue(found("blob:row-image"));
         renderHook(() => useChooserRowAvatar(platformRow("other")), {
           wrapper: createWrapper(),
         });
@@ -608,8 +616,8 @@ describe("useChooserRowAvatar", () => {
     });
 
     test("an unreachable legacy row keeps its cached avatar and does not evict it", async () => {
-      fetchAvatarImageUrl.mockResolvedValue(null);
-      fetchCharacterTraits.mockResolvedValue(null);
+      fetchAvatarImageUrlResult.mockResolvedValue(FAILED);
+      fetchCharacterTraitsResult.mockResolvedValue(FAILED);
       readLastSeenAvatar.mockResolvedValue({ kind: "character", traits });
       const { result } = renderHook(
         () =>
@@ -619,7 +627,7 @@ describe("useChooserRowAvatar", () => {
         { wrapper: createWrapper() },
       );
       await waitFor(() => {
-        expect(fetchCharacterTraits).toHaveBeenCalledTimes(1);
+        expect(fetchCharacterTraitsResult).toHaveBeenCalledTimes(1);
       });
       await waitFor(() => {
         expect(result.current.traits).toEqual(traits);
@@ -630,8 +638,72 @@ describe("useChooserRowAvatar", () => {
       expect(writeLastSeenAvatar).not.toHaveBeenCalled();
     });
 
+    test("a legacy row whose sidecars are both absent evicts the cache and shows the glyph", async () => {
+      readLastSeenAvatar.mockResolvedValue({ kind: "character", traits });
+      const { result } = renderHook(
+        () =>
+          useChooserRowAvatar(
+            platformRow("other", { runtimeVersion: "0.8.6" }),
+          ),
+        { wrapper: createWrapper() },
+      );
+      await waitFor(() => {
+        expect(deleteLastSeenAvatar).toHaveBeenCalledWith(
+          "other",
+          expect.any(Number),
+        );
+      });
+      expect(fetchCharacterTraitsResult).toHaveBeenCalledTimes(1);
+      expect(writeLastSeenAvatar).not.toHaveBeenCalled();
+      expect(result.current).toEqual({ traits: null, imageUrl: null });
+    });
+
+    test("a manifest image whose content fails keeps the cached image and does not evict it", async () => {
+      fetchAvatarState.mockResolvedValue(imageState);
+      fetchAvatarImageUrlResult.mockResolvedValue(FAILED);
+      readLastSeenAvatar.mockResolvedValue({
+        kind: "image",
+        blob: new Blob(["png"]),
+      });
+      const { result } = renderHook(
+        () => useChooserRowAvatar(platformRow("other")),
+        { wrapper: createWrapper() },
+      );
+      await waitFor(() => {
+        expect(result.current.imageUrl).toBe("blob:cached-image");
+      });
+      // The hook retries once before settling on the error.
+      await waitFor(() => {
+        expect(fetchAvatarImageUrlResult).toHaveBeenCalledTimes(2);
+      });
+      await settle();
+      expect(result.current.imageUrl).toBe("blob:cached-image");
+      expect(deleteLastSeenAvatar).not.toHaveBeenCalled();
+      expect(writeLastSeenAvatar).not.toHaveBeenCalled();
+    });
+
+    test("the connected row keeps its cached image when the manifest image content fails", async () => {
+      fetchAvatarState.mockResolvedValue(imageState);
+      fetchAvatarImageUrlResult.mockResolvedValue(FAILED);
+      readLastSeenAvatar.mockResolvedValue({
+        kind: "image",
+        blob: new Blob(["png"]),
+      });
+      const { result } = renderHook(
+        () => useChooserRowAvatar(platformRow("active")),
+        { wrapper: createWrapper() },
+      );
+      await waitFor(() => {
+        expect(result.current.imageUrl).toBe("blob:cached-image");
+      });
+      await settle();
+      expect(deleteLastSeenAvatar).not.toHaveBeenCalled();
+    });
+
     test("an unreachable version-unknown row keeps its cached avatar", async () => {
       fetchAvatarState.mockResolvedValue(null);
+      fetchAvatarImageUrlResult.mockResolvedValue(FAILED);
+      fetchCharacterTraitsResult.mockResolvedValue(FAILED);
       readLastSeenAvatar.mockResolvedValue({ kind: "character", traits });
       const { result } = renderHook(
         () =>
@@ -651,7 +723,7 @@ describe("useChooserRowAvatar", () => {
     });
 
     test("a populated legacy read still writes the cache", async () => {
-      fetchCharacterTraits.mockResolvedValue(traits);
+      fetchCharacterTraitsResult.mockResolvedValue(found(traits));
       renderHook(
         () =>
           useChooserRowAvatar(
@@ -676,7 +748,7 @@ describe("useChooserRowAvatar", () => {
       ) as unknown as typeof fetch;
       try {
         fetchAvatarState.mockResolvedValue(imageState);
-        fetchAvatarImageUrl.mockResolvedValue("blob:row-image");
+        fetchAvatarImageUrlResult.mockResolvedValue(found("blob:row-image"));
         const queryClient = new QueryClient({
           defaultOptions: { queries: { retry: false } },
         });

--- a/clients/web/src/hooks/use-chooser-row-avatar.test.tsx
+++ b/clients/web/src/hooks/use-chooser-row-avatar.test.tsx
@@ -627,7 +627,7 @@ describe("useChooserRowAvatar", () => {
         { wrapper: createWrapper() },
       );
       await waitFor(() => {
-        expect(fetchCharacterTraitsResult).toHaveBeenCalledTimes(1);
+        expect(fetchAvatarImageUrlResult).toHaveBeenCalledTimes(1);
       });
       await waitFor(() => {
         expect(result.current.traits).toEqual(traits);

--- a/clients/web/src/hooks/use-chooser-row-avatar.ts
+++ b/clients/web/src/hooks/use-chooser-row-avatar.ts
@@ -9,7 +9,9 @@ import {
 import { useIsOrgReady } from "@/hooks/use-is-org-ready";
 import { isGatewayAuthEnabled } from "@/lib/auth/gateway-session";
 import {
+  claimLastSeenAvatarGeneration,
   deleteLastSeenAvatar,
+  isLastSeenAvatarGenerationCurrent,
   readLastSeenAvatar,
   writeLastSeenAvatar,
 } from "@/lib/avatar-last-seen-cache";
@@ -69,6 +71,16 @@ export interface ChooserRowAvatar {
   imageUrl: string | null;
 }
 
+/**
+ * A live read plus whether it is authoritative. The manifest answers
+ * conclusively (including "none"); the legacy sidecar path swallows failures
+ * into nulls, so only a legacy read that found something is conclusive. An
+ * inconclusive read never bypasses or evicts the last-seen cache.
+ */
+interface RowAvatarResult extends ChooserRowAvatar {
+  conclusive: boolean;
+}
+
 const EMPTY_AVATAR: ChooserRowAvatar = { traits: null, imageUrl: null };
 
 /**
@@ -120,18 +132,25 @@ export function canFetchRowAvatarViaPlatformProxy(
 async function fetchRowAvatar(
   assistant: ResolvedAssistant,
   manifestSupport: RowManifestSupport,
-): Promise<ChooserRowAvatar> {
+): Promise<RowAvatarResult> {
   if (manifestSupport === "supported") {
-    return fetchAvatarViaManifest(assistant.id);
+    return {
+      ...(await fetchAvatarViaManifest(assistant.id)),
+      conclusive: true,
+    };
   }
   if (manifestSupport === "unknown") {
     try {
-      return await fetchAvatarViaManifest(assistant.id);
+      return {
+        ...(await fetchAvatarViaManifest(assistant.id)),
+        conclusive: true,
+      };
     } catch {
       // Probe failed: the runtime is likely pre-manifest.
     }
   }
-  return fetchAvatarViaLegacyFiles(assistant.id);
+  const legacy = await fetchAvatarViaLegacyFiles(assistant.id);
+  return { ...legacy, conclusive: !isEmptyAvatar(legacy) };
 }
 
 function trackBlobUrl(
@@ -159,7 +178,7 @@ function trackBlobUrl(
 async function fetchRowAvatarGeneration(
   assistant: ResolvedAssistant,
   manifestSupport: RowManifestSupport,
-): Promise<ChooserRowAvatar> {
+): Promise<RowAvatarResult> {
   const generation = (fetchGenerations.get(assistant.id) ?? 0) + 1;
   fetchGenerations.set(assistant.id, generation);
   const avatar = await fetchRowAvatar(assistant, manifestSupport);
@@ -167,7 +186,7 @@ async function fetchRowAvatarGeneration(
     if (avatar.imageUrl) {
       URL.revokeObjectURL(avatar.imageUrl);
     }
-    return { traits: avatar.traits, imageUrl: null };
+    return { ...avatar, imageUrl: null };
   }
   trackBlobUrl(activeBlobUrls, assistant.id, avatar.imageUrl);
   return avatar;
@@ -181,20 +200,29 @@ function isEmptyAvatar(avatar: ChooserRowAvatar | undefined): boolean {
 // row's `useAssistantAvatar` and the platform-proxy per-row fetch. Durable
 // sources (host disk, platform URLs) must never be written back here.
 
+/**
+ * Claims a persistence generation up front so a blob read that resolves
+ * after a newer write or delete (including a retire) commits nothing.
+ */
 async function persistLastSeenAvatar(
   assistantId: string,
   avatar: ChooserRowAvatar,
 ): Promise<void> {
+  const generation = claimLastSeenAvatarGeneration(assistantId);
   if (avatar.imageUrl) {
     const blob = await fetch(avatar.imageUrl).then((r) => r.blob());
-    await writeLastSeenAvatar(assistantId, { kind: "image", blob });
+    if (!isLastSeenAvatarGenerationCurrent(assistantId, generation)) {
+      return;
+    }
+    await writeLastSeenAvatar(assistantId, { kind: "image", blob }, generation);
   } else if (avatar.traits) {
-    await writeLastSeenAvatar(assistantId, {
-      kind: "character",
-      traits: avatar.traits,
-    });
+    await writeLastSeenAvatar(
+      assistantId,
+      { kind: "character", traits: avatar.traits },
+      generation,
+    );
   } else {
-    await deleteLastSeenAvatar(assistantId);
+    await deleteLastSeenAvatar(assistantId, generation);
   }
 }
 
@@ -234,7 +262,7 @@ export function useChooserRowAvatar(
   const connected = useAssistantAvatar(isConnectedRow ? assistant.id : null);
 
   const manifestSupport = rowManifestSupport(assistant);
-  const rowQuery = useQuery<ChooserRowAvatar>({
+  const rowQuery = useQuery<RowAvatarResult>({
     queryKey: chooserRowAvatarQueryKey(assistant.id, manifestSupport),
     queryFn: () => fetchRowAvatarGeneration(assistant, manifestSupport),
     enabled:
@@ -248,18 +276,26 @@ export function useChooserRowAvatar(
     retry: 1,
   });
 
-  // A live source is "settled" once its query succeeded; on error React
-  // Query keeps prior data, which is still worth rendering but not caching.
+  // A live source is conclusive once its query succeeded through a path
+  // that cannot mistake a failure for a bare avatar; on error React Query
+  // keeps prior data, which is still worth rendering but not caching.
   const live: ChooserRowAvatar | undefined = isConnectedRow
     ? { traits: connected.traits, imageUrl: connected.customImageUrl }
-    : rowQuery.data;
-  const liveSettled = isConnectedRow ? connected.isSuccess : rowQuery.isSuccess;
-  const showLive = liveSettled || (live !== undefined && !isEmptyAvatar(live));
+    : rowQuery.data && {
+        traits: rowQuery.data.traits,
+        imageUrl: rowQuery.data.imageUrl,
+      };
+  const liveConclusive = isConnectedRow
+    ? connected.isSuccess &&
+      (connected.supportsManifest || !isEmptyAvatar(live))
+    : rowQuery.isSuccess && rowQuery.data.conclusive;
+  const showLive =
+    liveConclusive || (live !== undefined && !isEmptyAvatar(live));
 
   const liveTraits = live?.traits ?? null;
   const liveImageUrl = live?.imageUrl ?? null;
   useEffect(() => {
-    if (!liveSettled) {
+    if (!liveConclusive) {
       return;
     }
     const assistantId = assistant.id;
@@ -273,7 +309,7 @@ export function useChooserRowAvatar(
         }),
       )
       .catch(() => {});
-  }, [assistant.id, liveSettled, liveTraits, liveImageUrl, queryClient]);
+  }, [assistant.id, liveConclusive, liveTraits, liveImageUrl, queryClient]);
 
   const cacheQuery = useQuery<ChooserRowAvatar>({
     queryKey: chooserRowAvatarCacheQueryKey(assistant.id),

--- a/clients/web/src/hooks/use-chooser-row-avatar.ts
+++ b/clients/web/src/hooks/use-chooser-row-avatar.ts
@@ -1,4 +1,5 @@
-import { useQuery } from "@tanstack/react-query";
+import { useEffect } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 
 import {
   fetchAvatarViaLegacyFiles,
@@ -7,6 +8,11 @@ import {
 } from "@/hooks/use-assistant-avatar";
 import { useIsOrgReady } from "@/hooks/use-is-org-ready";
 import { isGatewayAuthEnabled } from "@/lib/auth/gateway-session";
+import {
+  deleteLastSeenAvatar,
+  readLastSeenAvatar,
+  writeLastSeenAvatar,
+} from "@/lib/avatar-last-seen-cache";
 import { versionSupportsAvatarStateManifest } from "@/lib/backwards-compat/avatar-state-manifest";
 import { isLocalClient, isRemoteGatewayMode } from "@/lib/local-mode";
 import { getSelfHostedIngressUrl } from "@/lib/self-hosted/connection";
@@ -17,6 +23,8 @@ import {
 import type { CharacterTraits } from "@/types/avatar";
 
 export const CHOOSER_ROW_AVATAR_QUERY_KEY_PREFIX = "chooserRowAvatar";
+export const CHOOSER_ROW_AVATAR_CACHE_QUERY_KEY_PREFIX =
+  "chooserRowAvatarCache";
 
 export type RowManifestSupport = "supported" | "unsupported" | "unknown";
 
@@ -52,6 +60,10 @@ export function chooserRowAvatarQueryKey(
   ] as const;
 }
 
+export function chooserRowAvatarCacheQueryKey(assistantId: string) {
+  return [CHOOSER_ROW_AVATAR_CACHE_QUERY_KEY_PREFIX, assistantId] as const;
+}
+
 export interface ChooserRowAvatar {
   traits: CharacterTraits | null;
   imageUrl: string | null;
@@ -68,6 +80,9 @@ export const EMPTY_AVATAR_STALE_TIME_MS = 60_000;
 
 /** Separate from `use-assistant-avatar`'s map so the two caches never revoke each other's URLs. */
 const activeBlobUrls = new Map<string, string>();
+
+/** Object URLs minted from cached Blobs; kept apart so a live fetch never revokes a cached URL. */
+const cachedBlobUrls = new Map<string, string>();
 
 /** Latest fetch generation per row; a superseded fetch must not touch the map. */
 const fetchGenerations = new Map<string, number>();
@@ -119,15 +134,19 @@ async function fetchRowAvatar(
   return fetchAvatarViaLegacyFiles(assistant.id);
 }
 
-function trackBlobUrl(assistantId: string, imageUrl: string | null): void {
-  const prev = activeBlobUrls.get(assistantId);
+function trackBlobUrl(
+  urls: Map<string, string>,
+  assistantId: string,
+  imageUrl: string | null,
+): void {
+  const prev = urls.get(assistantId);
   if (prev && prev !== imageUrl) {
     URL.revokeObjectURL(prev);
   }
   if (imageUrl) {
-    activeBlobUrls.set(assistantId, imageUrl);
+    urls.set(assistantId, imageUrl);
   } else {
-    activeBlobUrls.delete(assistantId);
+    urls.delete(assistantId);
   }
 }
 
@@ -150,12 +169,46 @@ async function fetchRowAvatarGeneration(
     }
     return { traits: avatar.traits, imageUrl: null };
   }
-  trackBlobUrl(assistant.id, avatar.imageUrl);
+  trackBlobUrl(activeBlobUrls, assistant.id, avatar.imageUrl);
   return avatar;
 }
 
 function isEmptyAvatar(avatar: ChooserRowAvatar | undefined): boolean {
   return avatar !== undefined && !avatar.traits && !avatar.imageUrl;
+}
+
+// Last-seen cache (IndexedDB). Only LIVE sources feed it: the connected
+// row's `useAssistantAvatar` and the platform-proxy per-row fetch. Durable
+// sources (host disk, platform URLs) must never be written back here.
+
+async function persistLastSeenAvatar(
+  assistantId: string,
+  avatar: ChooserRowAvatar,
+): Promise<void> {
+  if (avatar.imageUrl) {
+    const blob = await fetch(avatar.imageUrl).then((r) => r.blob());
+    await writeLastSeenAvatar(assistantId, { kind: "image", blob });
+  } else if (avatar.traits) {
+    await writeLastSeenAvatar(assistantId, {
+      kind: "character",
+      traits: avatar.traits,
+    });
+  } else {
+    await deleteLastSeenAvatar(assistantId);
+  }
+}
+
+async function readCachedRowAvatar(
+  assistantId: string,
+): Promise<ChooserRowAvatar> {
+  const cached = await readLastSeenAvatar(assistantId);
+  const imageUrl =
+    cached?.kind === "image" ? URL.createObjectURL(cached.blob) : null;
+  trackBlobUrl(cachedBlobUrls, assistantId, imageUrl);
+  return {
+    traits: cached?.kind === "character" ? cached.traits : null,
+    imageUrl,
+  };
 }
 
 /**
@@ -165,6 +218,8 @@ function isEmptyAvatar(avatar: ChooserRowAvatar | undefined): boolean {
  * 2. Other platform rows fetch per id through the platform proxy, only when
  *    {@link canFetchRowAvatarViaPlatformProxy} says the id is honored and the
  *    org store can supply the `Vellum-Organization-Id` header.
+ * 3. The last-seen cache: whatever a live source last resolved for this id,
+ *    so a row keeps its avatar while the assistant is unreachable.
  * Anything else, including every failure, resolves to nulls: the row's glyph
  * fallback is the error state, a chooser row never surfaces an error.
  */
@@ -174,11 +229,12 @@ export function useChooserRowAvatar(
   const activeAssistantId = useResolvedAssistantsStore.use.activeAssistantId();
   const isConnectedRow = assistant.id === activeAssistantId;
   const isOrgReady = useIsOrgReady();
+  const queryClient = useQueryClient();
 
   const connected = useAssistantAvatar(isConnectedRow ? assistant.id : null);
 
   const manifestSupport = rowManifestSupport(assistant);
-  const { data } = useQuery<ChooserRowAvatar>({
+  const rowQuery = useQuery<ChooserRowAvatar>({
     queryKey: chooserRowAvatarQueryKey(assistant.id, manifestSupport),
     queryFn: () => fetchRowAvatarGeneration(assistant, manifestSupport),
     enabled:
@@ -192,8 +248,44 @@ export function useChooserRowAvatar(
     retry: 1,
   });
 
-  if (isConnectedRow) {
-    return { traits: connected.traits, imageUrl: connected.customImageUrl };
+  // A live source is "settled" once its query succeeded; on error React
+  // Query keeps prior data, which is still worth rendering but not caching.
+  const live: ChooserRowAvatar | undefined = isConnectedRow
+    ? { traits: connected.traits, imageUrl: connected.customImageUrl }
+    : rowQuery.data;
+  const liveSettled = isConnectedRow ? connected.isSuccess : rowQuery.isSuccess;
+  const showLive = liveSettled || (live !== undefined && !isEmptyAvatar(live));
+
+  const liveTraits = live?.traits ?? null;
+  const liveImageUrl = live?.imageUrl ?? null;
+  useEffect(() => {
+    if (!liveSettled) {
+      return;
+    }
+    const assistantId = assistant.id;
+    void persistLastSeenAvatar(assistantId, {
+      traits: liveTraits,
+      imageUrl: liveImageUrl,
+    })
+      .then(() =>
+        queryClient.invalidateQueries({
+          queryKey: chooserRowAvatarCacheQueryKey(assistantId),
+        }),
+      )
+      .catch(() => {});
+  }, [assistant.id, liveSettled, liveTraits, liveImageUrl, queryClient]);
+
+  const cacheQuery = useQuery<ChooserRowAvatar>({
+    queryKey: chooserRowAvatarCacheQueryKey(assistant.id),
+    queryFn: () => readCachedRowAvatar(assistant.id),
+    enabled: !showLive,
+    staleTime: Infinity,
+    structuralSharing: false,
+    retry: false,
+  });
+
+  if (showLive) {
+    return live ?? EMPTY_AVATAR;
   }
-  return data ?? EMPTY_AVATAR;
+  return cacheQuery.data ?? EMPTY_AVATAR;
 }

--- a/clients/web/src/hooks/use-chooser-row-avatar.ts
+++ b/clients/web/src/hooks/use-chooser-row-avatar.ts
@@ -1,9 +1,11 @@
 import { useEffect } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 
+import { fetchAvatarState } from "@/assistant/avatar-api";
 import {
-  fetchAvatarViaLegacyFiles,
   fetchAvatarViaManifest,
+  readAvatarViaLegacyFiles,
+  resolveAvatarFromState,
   useAssistantAvatar,
 } from "@/hooks/use-assistant-avatar";
 import { useIsOrgReady } from "@/hooks/use-is-org-ready";
@@ -73,9 +75,10 @@ export interface ChooserRowAvatar {
 
 /**
  * A live read plus whether it is authoritative. The manifest answers
- * conclusively (including "none"); the legacy sidecar path swallows failures
- * into nulls, so only a legacy read that found something is conclusive. An
- * inconclusive read never bypasses or evicts the last-seen cache.
+ * conclusively (including "none") or throws; a legacy sidecar read is
+ * conclusive when it found a file or both files are absent (404), and
+ * inconclusive on a transport failure. An inconclusive read never bypasses
+ * or evicts the last-seen cache.
  */
 interface RowAvatarResult extends ChooserRowAvatar {
   conclusive: boolean;
@@ -84,9 +87,9 @@ interface RowAvatarResult extends ChooserRowAvatar {
 const EMPTY_AVATAR: ChooserRowAvatar = { traits: null, imageUrl: null };
 
 /**
- * The legacy sidecar path swallows read failures into nulls, so an empty
- * result may be a transient error rather than a bare avatar. Let it go stale
- * on a normal clock instead of pinning the glyph fallback forever.
+ * A bare avatar is the state most likely to change soon (a fresh assistant
+ * gets one during onboarding), and a legacy transport failure also lands
+ * here. Let it go stale on a normal clock instead of pinning the glyph.
  */
 export const EMPTY_AVATAR_STALE_TIME_MS = 60_000;
 
@@ -127,7 +130,8 @@ export function canFetchRowAvatarViaPlatformProxy(
 /**
  * Manifest reads for runtimes known to serve `/avatar/state`; legacy sidecar
  * reads for runtimes known not to. An unknown version probes the manifest
- * first and falls back to the sidecars when the probe fails.
+ * first and falls back to the sidecars when the probe fails. A manifest that
+ * promises an image whose content fails throws (never a false "none").
  */
 async function fetchRowAvatar(
   assistant: ResolvedAssistant,
@@ -140,17 +144,16 @@ async function fetchRowAvatar(
     };
   }
   if (manifestSupport === "unknown") {
-    try {
+    const state = await fetchAvatarState(assistant.id);
+    if (state !== null) {
       return {
-        ...(await fetchAvatarViaManifest(assistant.id)),
+        ...(await resolveAvatarFromState(assistant.id, state)),
         conclusive: true,
       };
-    } catch {
-      // Probe failed: the runtime is likely pre-manifest.
     }
+    // Probe failed: the runtime is likely pre-manifest.
   }
-  const legacy = await fetchAvatarViaLegacyFiles(assistant.id);
-  return { ...legacy, conclusive: !isEmptyAvatar(legacy) };
+  return readAvatarViaLegacyFiles(assistant.id);
 }
 
 function trackBlobUrl(
@@ -277,8 +280,9 @@ export function useChooserRowAvatar(
   });
 
   // A live source is conclusive once its query succeeded through a path
-  // that cannot mistake a failure for a bare avatar; on error React Query
-  // keeps prior data, which is still worth rendering but not caching.
+  // that cannot mistake a failure for a bare avatar (useAssistantAvatar
+  // throws on every inconclusive read); on error React Query keeps prior
+  // data, which is still worth rendering but not caching.
   const live: ChooserRowAvatar | undefined = isConnectedRow
     ? { traits: connected.traits, imageUrl: connected.customImageUrl }
     : rowQuery.data && {
@@ -286,8 +290,7 @@ export function useChooserRowAvatar(
         imageUrl: rowQuery.data.imageUrl,
       };
   const liveConclusive = isConnectedRow
-    ? connected.isSuccess &&
-      (connected.supportsManifest || !isEmptyAvatar(live))
+    ? connected.isSuccess
     : rowQuery.isSuccess && rowQuery.data.conclusive;
   const showLive =
     liveConclusive || (live !== undefined && !isEmptyAvatar(live));

--- a/clients/web/src/lib/avatar-last-seen-cache.test.ts
+++ b/clients/web/src/lib/avatar-last-seen-cache.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Tests for the last-seen avatar cache: graceful degradation when the
+ * environment has no IndexedDB (happy-dom ships none), and round-trips of
+ * both record kinds against a minimal in-memory `indexedDB` fake.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import type { CharacterTraits } from "@/types/avatar";
+
+import {
+  deleteLastSeenAvatar,
+  readLastSeenAvatar,
+  writeLastSeenAvatar,
+} from "./avatar-last-seen-cache";
+
+const traits: CharacterTraits = {
+  bodyShape: "brontosaurus",
+  eyeStyle: "curious",
+  color: "cosmic-purple",
+};
+
+type Listener = (() => void) | null;
+
+class FakeRequest<T> {
+  result!: T;
+  error: DOMException | null = null;
+  onsuccess: Listener = null;
+  onerror: Listener = null;
+  onupgradeneeded: Listener = null;
+
+  settle(result: T): void {
+    this.result = result;
+    queueMicrotask(() => this.onsuccess?.());
+  }
+
+  fail(message: string): void {
+    this.error = new DOMException(message);
+    queueMicrotask(() => this.onerror?.());
+  }
+}
+
+/** Just enough of IDBFactory / IDBDatabase / IDBObjectStore for the cache module. */
+function installFakeIndexedDb(options: { failWrites?: boolean } = {}) {
+  const rows = new Map<string, unknown>();
+  const stores = new Set<string>();
+  const store = {
+    get: (key: string) => {
+      const request = new FakeRequest<unknown>();
+      request.settle(rows.get(key));
+      return request;
+    },
+    put: (value: { id: string }) => {
+      const request = new FakeRequest<string>();
+      if (options.failWrites) {
+        request.fail("write refused");
+      } else {
+        rows.set(value.id, value);
+        request.settle(value.id);
+      }
+      return request;
+    },
+    delete: (key: string) => {
+      const request = new FakeRequest<undefined>();
+      rows.delete(key);
+      request.settle(undefined);
+      return request;
+    },
+  };
+  const db = {
+    objectStoreNames: { contains: (name: string) => stores.has(name) },
+    createObjectStore: (name: string) => {
+      stores.add(name);
+    },
+    transaction: () => ({ objectStore: () => store }),
+    close: () => {},
+  };
+  const factory = {
+    open: () => {
+      const request = new FakeRequest<typeof db>();
+      request.result = db;
+      queueMicrotask(() => {
+        request.onupgradeneeded?.();
+        request.onsuccess?.();
+      });
+      return request;
+    },
+  };
+  Object.defineProperty(globalThis, "indexedDB", {
+    value: factory,
+    configurable: true,
+    writable: true,
+  });
+  return { rows, stores };
+}
+
+function uninstallFakeIndexedDb(): void {
+  Reflect.deleteProperty(globalThis, "indexedDB");
+}
+
+describe("avatar-last-seen-cache", () => {
+  describe("without IndexedDB", () => {
+    beforeEach(() => {
+      uninstallFakeIndexedDb();
+    });
+
+    test("read resolves null", async () => {
+      expect(await readLastSeenAvatar("a")).toBeNull();
+    });
+
+    test("write and delete resolve without throwing", async () => {
+      await expect(
+        writeLastSeenAvatar("a", { kind: "character", traits }),
+      ).resolves.toBeUndefined();
+      await expect(deleteLastSeenAvatar("a")).resolves.toBeUndefined();
+    });
+  });
+
+  describe("with IndexedDB", () => {
+    afterEach(() => {
+      uninstallFakeIndexedDb();
+    });
+
+    test("creates the store on first open", async () => {
+      const { stores } = installFakeIndexedDb();
+      await readLastSeenAvatar("a");
+      expect(stores.has("avatars")).toBe(true);
+    });
+
+    test("round-trips a character entry", async () => {
+      installFakeIndexedDb();
+      await writeLastSeenAvatar("a", { kind: "character", traits });
+      expect(await readLastSeenAvatar("a")).toEqual({
+        kind: "character",
+        traits,
+      });
+    });
+
+    test("round-trips an image entry as a Blob", async () => {
+      installFakeIndexedDb();
+      const blob = new Blob(["png"], { type: "image/png" });
+      await writeLastSeenAvatar("a", { kind: "image", blob });
+      const read = await readLastSeenAvatar("a");
+      expect(read?.kind).toBe("image");
+      expect(read?.kind === "image" && read.blob).toBe(blob);
+    });
+
+    test("stamps the record with the id and a timestamp", async () => {
+      const { rows } = installFakeIndexedDb();
+      await writeLastSeenAvatar("a", { kind: "character", traits });
+      expect(rows.get("a")).toMatchObject({
+        id: "a",
+        kind: "character",
+        updatedAt: expect.any(Number),
+      });
+    });
+
+    test("delete removes the entry", async () => {
+      installFakeIndexedDb();
+      await writeLastSeenAvatar("a", { kind: "character", traits });
+      await deleteLastSeenAvatar("a");
+      expect(await readLastSeenAvatar("a")).toBeNull();
+    });
+
+    test("read returns null for an unknown id and for a malformed record", async () => {
+      const { rows } = installFakeIndexedDb();
+      expect(await readLastSeenAvatar("missing")).toBeNull();
+      rows.set("bad", { id: "bad", kind: "character", traits: { nope: 1 } });
+      expect(await readLastSeenAvatar("bad")).toBeNull();
+    });
+
+    test("a failed transaction is swallowed", async () => {
+      installFakeIndexedDb({ failWrites: true });
+      await expect(
+        writeLastSeenAvatar("a", { kind: "character", traits }),
+      ).resolves.toBeUndefined();
+      expect(await readLastSeenAvatar("a")).toBeNull();
+    });
+  });
+});

--- a/clients/web/src/lib/avatar-last-seen-cache.test.ts
+++ b/clients/web/src/lib/avatar-last-seen-cache.test.ts
@@ -9,7 +9,9 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import type { CharacterTraits } from "@/types/avatar";
 
 import {
+  claimLastSeenAvatarGeneration,
   deleteLastSeenAvatar,
+  isLastSeenAvatarGenerationCurrent,
   readLastSeenAvatar,
   writeLastSeenAvatar,
 } from "./avatar-last-seen-cache";
@@ -167,6 +169,31 @@ describe("avatar-last-seen-cache", () => {
       expect(await readLastSeenAvatar("missing")).toBeNull();
       rows.set("bad", { id: "bad", kind: "character", traits: { nope: 1 } });
       expect(await readLastSeenAvatar("bad")).toBeNull();
+    });
+
+    test("a write with a superseded generation commits nothing", async () => {
+      installFakeIndexedDb();
+      const stale = claimLastSeenAvatarGeneration("a");
+      await writeLastSeenAvatar("a", { kind: "character", traits });
+      expect(isLastSeenAvatarGenerationCurrent("a", stale)).toBe(false);
+      await writeLastSeenAvatar(
+        "a",
+        { kind: "image", blob: new Blob() },
+        stale,
+      );
+      expect(await readLastSeenAvatar("a")).toEqual({
+        kind: "character",
+        traits,
+      });
+      await deleteLastSeenAvatar("a", stale);
+      expect(await readLastSeenAvatar("a")).not.toBeNull();
+    });
+
+    test("a plain delete supersedes an in-flight generation", async () => {
+      installFakeIndexedDb();
+      const inFlight = claimLastSeenAvatarGeneration("a");
+      await deleteLastSeenAvatar("a");
+      expect(isLastSeenAvatarGenerationCurrent("a", inFlight)).toBe(false);
     });
 
     test("a failed transaction is swallowed", async () => {

--- a/clients/web/src/lib/avatar-last-seen-cache.ts
+++ b/clients/web/src/lib/avatar-last-seen-cache.ts
@@ -81,10 +81,35 @@ export async function readLastSeenAvatar(
   return toLastSeenAvatar(record);
 }
 
+/**
+ * Per-assistant persistence generation. Every write or delete claims the
+ * next one; a caller that did async work before committing (e.g. reading a
+ * blob) passes its claimed generation and is dropped if a newer operation
+ * has claimed since, so the last-issued operation always wins.
+ */
+const generations = new Map<string, number>();
+
+export function claimLastSeenAvatarGeneration(assistantId: string): number {
+  const generation = (generations.get(assistantId) ?? 0) + 1;
+  generations.set(assistantId, generation);
+  return generation;
+}
+
+export function isLastSeenAvatarGenerationCurrent(
+  assistantId: string,
+  generation: number,
+): boolean {
+  return generations.get(assistantId) === generation;
+}
+
 export async function writeLastSeenAvatar(
   assistantId: string,
   avatar: LastSeenAvatar,
+  generation = claimLastSeenAvatarGeneration(assistantId),
 ): Promise<void> {
+  if (!isLastSeenAvatarGenerationCurrent(assistantId, generation)) {
+    return;
+  }
   const record: StoredAvatar = {
     ...avatar,
     id: assistantId,
@@ -93,6 +118,12 @@ export async function writeLastSeenAvatar(
   await withStore("readwrite", (store) => store.put(record));
 }
 
-export async function deleteLastSeenAvatar(assistantId: string): Promise<void> {
+export async function deleteLastSeenAvatar(
+  assistantId: string,
+  generation = claimLastSeenAvatarGeneration(assistantId),
+): Promise<void> {
+  if (!isLastSeenAvatarGenerationCurrent(assistantId, generation)) {
+    return;
+  }
   await withStore("readwrite", (store) => store.delete(assistantId));
 }

--- a/clients/web/src/lib/avatar-last-seen-cache.ts
+++ b/clients/web/src/lib/avatar-last-seen-cache.ts
@@ -1,0 +1,98 @@
+import { type CharacterTraits, isCharacterTraits } from "@/types/avatar";
+
+/**
+ * Last-seen avatar cache in IndexedDB, keyed by assistant id. Lets a chooser
+ * row keep showing an avatar it has rendered before while the assistant is
+ * unreachable and no live source can answer. Characters store their traits
+ * (the row re-renders the real SVG); images store the Blob itself, which is
+ * structured-clone safe, and the reader mints a fresh object URL.
+ *
+ * Every entry point is best-effort: no IndexedDB (private windows, tests),
+ * a blocked open, or a failed transaction all resolve to `null` / no-op.
+ */
+
+export type LastSeenAvatar =
+  | { kind: "character"; traits: CharacterTraits }
+  | { kind: "image"; blob: Blob };
+
+type StoredAvatar = LastSeenAvatar & { id: string; updatedAt: number };
+
+const DB_NAME = "vellum-avatar-cache";
+const DB_VERSION = 1;
+const STORE_NAME = "avatars";
+
+function requestToPromise<T>(request: IDBRequest<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+
+function openDatabase(): Promise<IDBDatabase> {
+  const factory = globalThis.indexedDB;
+  if (!factory) {
+    return Promise.reject(new Error("IndexedDB unavailable"));
+  }
+  const request = factory.open(DB_NAME, DB_VERSION);
+  request.onupgradeneeded = () => {
+    const db = request.result;
+    if (!db.objectStoreNames.contains(STORE_NAME)) {
+      db.createObjectStore(STORE_NAME, { keyPath: "id" });
+    }
+  };
+  return requestToPromise(request);
+}
+
+async function withStore<T>(
+  mode: IDBTransactionMode,
+  operation: (store: IDBObjectStore) => IDBRequest<T>,
+): Promise<T | null> {
+  try {
+    const db = await openDatabase();
+    try {
+      const store = db.transaction(STORE_NAME, mode).objectStore(STORE_NAME);
+      return await requestToPromise(operation(store));
+    } finally {
+      db.close();
+    }
+  } catch {
+    return null;
+  }
+}
+
+function toLastSeenAvatar(value: unknown): LastSeenAvatar | null {
+  if (typeof value !== "object" || value === null) {
+    return null;
+  }
+  const record = value as Partial<StoredAvatar>;
+  if (record.kind === "character" && isCharacterTraits(record.traits)) {
+    return { kind: "character", traits: record.traits };
+  }
+  if (record.kind === "image" && record.blob instanceof Blob) {
+    return { kind: "image", blob: record.blob };
+  }
+  return null;
+}
+
+export async function readLastSeenAvatar(
+  assistantId: string,
+): Promise<LastSeenAvatar | null> {
+  const record = await withStore("readonly", (store) => store.get(assistantId));
+  return toLastSeenAvatar(record);
+}
+
+export async function writeLastSeenAvatar(
+  assistantId: string,
+  avatar: LastSeenAvatar,
+): Promise<void> {
+  const record: StoredAvatar = {
+    ...avatar,
+    id: assistantId,
+    updatedAt: Date.now(),
+  };
+  await withStore("readwrite", (store) => store.put(record));
+}
+
+export async function deleteLastSeenAvatar(assistantId: string): Promise<void> {
+  await withStore("readwrite", (store) => store.delete(assistantId));
+}


### PR DESCRIPTION
## Summary
- Add `lib/avatar-last-seen-cache.ts`: a dependency-free IndexedDB module (`vellum-avatar-cache` / `avatars` store keyed by assistant id) storing character traits or the image Blob. Every call is best-effort and resolves to null / no-op when IndexedDB is missing or throws.
- `useChooserRowAvatar` gains a third precedence step: a `["chooserRowAvatarCache", id]` query read whenever no live source has resolved (gate closed, fetch failed, or still loading), minting a fresh object URL for cached Blobs in a separate blob map.
- Write path: once a live source settles (connected-row `useAssistantAvatar` or the platform-proxy per-row fetch), the result is persisted fire-and-forget; a `kind: none` resolution deletes the entry. A delimited seam marks where durable sources (host disk, platform URLs in later PRs) are excluded.
- `useAssistantAvatar` now also returns `isSuccess` so the connected row can distinguish a settled empty avatar from an error.
- Retire/unpair (`retire-service.ts`, the single `useResolvedAssistantsStore.remove` caller) evicts the cache entry.
- Tests: cache round-trips against a minimal in-memory `indexedDB` fake plus the no-IndexedDB path; hook tests for write on live resolution, delete on none, read as final fallback (incl. unreachable connected row), and never writing cache-sourced data.

Part of plan: chooser-assistant-avatars.md (PR 11 of 11)