### PR TITLE
fix(workers): start the conversation evictor in the schedule and memory workers

### DIFF
--- a/assistant/src/__tests__/plugin-import-boundary-guard.test.ts
+++ b/assistant/src/__tests__/plugin-import-boundary-guard.test.ts
@@ -173,6 +173,10 @@ const BASELINE: Record<string, readonly string[]> = {
     "../../../context/strip-injections.js",
     "../../../context/token-estimator.js",
     "../../../conversations/job-handlers/summarization.js",
+    // The standalone memory worker hosts real agent conversations, so its
+    // entry point starts the same eviction sweep the daemon starts at
+    // startup. No plugin-api equivalent.
+    "../../../daemon/conversation-evictor.js",
     "../../../daemon/date-context.js",
     "../../../daemon/disk-pressure-background-gate.js",
     "../../../daemon/embedding-reconcile.js",

--- a/assistant/src/plugins/defaults/memory/worker.ts
+++ b/assistant/src/plugins/defaults/memory/worker.ts
@@ -15,6 +15,7 @@ import { writeFileSync } from "node:fs";
 import { getConfig } from "../../../config/loader.js";
 import { isMemoryEnabled } from "../../../config/memory-v3-gate.js";
 import { rehydratePlatformCredentials } from "../../../config/platform-rehydration.js";
+import { startConversationEvictor } from "../../../daemon/conversation-evictor.js";
 import { resetDb } from "../../../persistence/db-connection.js";
 import {
   EMBEDDING_SHUTDOWN_BUDGET_MS,
@@ -83,6 +84,12 @@ async function main(): Promise<void> {
       "Failed to initialize tools in memory worker; continuing degraded",
     );
   }
+
+  // Sweep idle conversations out of the in-memory pool. The daemon starts
+  // this at startup; this process hosts conversations too (retrospective and
+  // consolidation passes), so without it every pass's conversation is
+  // retained for the process lifetime.
+  startConversationEvictor();
 
   let worker: ReturnType<typeof startMemoryJobsWorkerLoop> | null = null;
   let keepAlive: ReturnType<typeof setInterval> | null = null;

--- a/assistant/src/schedule/worker.ts
+++ b/assistant/src/schedule/worker.ts
@@ -15,6 +15,7 @@ import { writeFileSync } from "node:fs";
 
 import { getConfig } from "../config/loader.js";
 import { rehydratePlatformCredentials } from "../config/platform-rehydration.js";
+import { startConversationEvictor } from "../daemon/conversation-evictor.js";
 import { resetDb } from "../persistence/db-connection.js";
 import { registerWorkerPluginSurface } from "../plugins/worker-plugin-surface.js";
 import { disableStreamSeqStamping } from "../runtime/assistant-stream-state.js";
@@ -70,6 +71,11 @@ async function main(): Promise<void> {
       "Failed to initialize tools in schedule worker; continuing degraded",
     );
   }
+
+  // Sweep idle conversations out of the in-memory pool. The daemon starts
+  // this at startup; this process hosts conversations too, so without it
+  // every scheduled run's conversation is retained for the process lifetime.
+  startConversationEvictor();
 
   let stopped = false;
   let tickRunning = false;


### PR DESCRIPTION
## Summary
- Start the conversation eviction sweep in the schedule worker and memory jobs worker, matching the daemon's startup.
- Both processes host real agent conversations, but neither started the evictor, so every scheduled run / memory pass retained its conversation object in memory for the process lifetime. A reported instance grew the schedule worker to 3.2 GB RSS with a core pinned in GC under `bun --smol`.

## Original prompt
A user report showed the schedule worker at sustained 115% CPU and 3.2 GB RSS with a light schedule load. Investigation traced it to the in-memory conversation pool never being evicted in worker processes: the evictor is only started by daemon lifecycle. The ask was to start the evictor in both worker entrypoints, following their existing "the daemon does this at startup; this standalone process must do it itself" idiom, with concise comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)