### PR TITLE
ci: run avatar-manifest checks and trigger consumers on its changes

### DIFF
--- a/.github/workflows/ci-main-avatar-manifest.yaml
+++ b/.github/workflows/ci-main-avatar-manifest.yaml
@@ -1,4 +1,4 @@
-name: CI Main Local Mode Checks
+name: CI Main Avatar Manifest Checks
 
 on:
   workflow_dispatch:
@@ -8,10 +8,8 @@ on:
       - 'package.json'
       - 'bun.lock'
       - 'patches/**'
-      - 'packages/local-mode/**'
-      - 'packages/environments/**'
       - 'packages/avatar-manifest/**'
-      - '.github/workflows/ci-main-local-mode.yaml'
+      - '.github/workflows/ci-main-avatar-manifest.yaml'
 
 jobs:
   checks:
@@ -20,7 +18,7 @@ jobs:
     timeout-minutes: 10
     defaults:
       run:
-        working-directory: packages/local-mode
+        working-directory: packages/avatar-manifest
 
     steps:
       - name: Checkout
@@ -32,7 +30,7 @@ jobs:
           bun-version: '1.3.11'
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile --filter=@vellumai/local-mode
+        run: bun install --frozen-lockfile --filter=@vellumai/avatar-manifest
 
       - name: Type check
         run: bun run typecheck

--- a/.github/workflows/ci-main-cli.yaml
+++ b/.github/workflows/ci-main-cli.yaml
@@ -11,6 +11,7 @@ on:
       - 'cli/**'
       - 'packages/local-mode/**'
       - 'packages/environments/**'
+      - 'packages/avatar-manifest/**'
       - '.github/workflows/ci-main-cli.yaml'
 
 jobs:

--- a/.github/workflows/ci-main-macos.yaml
+++ b/.github/workflows/ci-main-macos.yaml
@@ -13,6 +13,7 @@ on:
       - 'packages/native-sidecar/**'
       - 'packages/local-mode/**'
       - 'packages/environments/**'
+      - 'packages/avatar-manifest/**'
       - '.github/workflows/ci-main-macos.yaml'
 
 concurrency:

--- a/.github/workflows/ci-main-storybook.yaml
+++ b/.github/workflows/ci-main-storybook.yaml
@@ -13,6 +13,7 @@ on:
       - "clients/web/**"
       - "packages/local-mode/**"
       - "packages/environments/**"
+      - "packages/avatar-manifest/**"
       - ".github/workflows/ci-main-storybook.yaml"
 
 # Serialize per branch and cancel superseded runs so only the newest main

--- a/.github/workflows/ci-main-web.yaml
+++ b/.github/workflows/ci-main-web.yaml
@@ -16,6 +16,7 @@ on:
       - 'packages/design-library/**'
       - 'packages/local-mode/**'
       - 'packages/environments/**'
+      - 'packages/avatar-manifest/**'
       # The web LLM catalog parity test reads this file, so daemon-side catalog
       # regenerations must run the web tests too.
       - 'meta/llm-provider-catalog.json'

--- a/.github/workflows/pr-avatar-manifest.yaml
+++ b/.github/workflows/pr-avatar-manifest.yaml
@@ -1,26 +1,26 @@
-name: CI Main Local Mode Checks
+name: PR Avatar Manifest Checks
 
 on:
-  workflow_dispatch:
-  push:
-    branches: [main]
+  pull_request:
+    types: [synchronize, opened, reopened]
     paths:
       - 'package.json'
       - 'bun.lock'
       - 'patches/**'
-      - 'packages/local-mode/**'
-      - 'packages/environments/**'
       - 'packages/avatar-manifest/**'
-      - '.github/workflows/ci-main-local-mode.yaml'
+      - '.github/workflows/pr-avatar-manifest.yaml'
+
+concurrency:
+  group: pr-avatar-manifest-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   checks:
     name: Type Check & Test
     runs-on: ubuntu-latest
-    timeout-minutes: 10
     defaults:
       run:
-        working-directory: packages/local-mode
+        working-directory: packages/avatar-manifest
 
     steps:
       - name: Checkout
@@ -32,7 +32,7 @@ jobs:
           bun-version: '1.3.11'
 
       - name: Install dependencies
-        run: bun install --frozen-lockfile --filter=@vellumai/local-mode
+        run: bun install --frozen-lockfile --filter=@vellumai/avatar-manifest
 
       - name: Type check
         run: bun run typecheck

--- a/.github/workflows/pr-cli.yaml
+++ b/.github/workflows/pr-cli.yaml
@@ -10,6 +10,7 @@ on:
       - 'cli/**'
       - 'packages/local-mode/**'
       - 'packages/environments/**'
+      - 'packages/avatar-manifest/**'
       - '.github/workflows/pr-cli.yaml'
 
 concurrency:

--- a/.github/workflows/pr-macos.yaml
+++ b/.github/workflows/pr-macos.yaml
@@ -13,6 +13,7 @@ on:
       - 'packages/native-sidecar/**'
       - 'packages/local-mode/**'
       - 'packages/environments/**'
+      - 'packages/avatar-manifest/**'
       - '.github/workflows/pr-macos.yaml'
 
 concurrency:

--- a/.github/workflows/pr-web.yaml
+++ b/.github/workflows/pr-web.yaml
@@ -15,6 +15,7 @@ on:
       - 'packages/design-library/**'
       - 'packages/local-mode/**'
       - 'packages/environments/**'
+      - 'packages/avatar-manifest/**'
       # The web LLM catalog parity test reads this file, so daemon-side catalog
       # regenerations must run the web tests on the PR that introduces drift.
       - 'meta/llm-provider-catalog.json'


### PR DESCRIPTION
## Summary
Fixes gap identified during plan review for chooser-assistant-avatars.md.

**Gap:** packages/avatar-manifest had no CI and consumer workflows ignored it
**What was expected:** parity with packages/environments (own workflow + consumer path filters)
**What was found:** only pr-local-mode.yaml listed the path