### PR TITLE
fix: keep platform avatar on missing raster, scope identity dedup to destination, share readAvatarState

### DIFF
--- a/assistant/src/avatar/avatar-manifest.ts
+++ b/assistant/src/avatar/avatar-manifest.ts
@@ -146,3 +146,10 @@ export function deriveStateFromLegacyFiles(
       return { kind: "none", traits: null, source: null, image: null };
   }
 }
+
+/** Manifest first, legacy sidecars as fallback. Never persists. */
+export function readAvatarState(
+  avatarDir: string = getAvatarDir(),
+): AvatarState {
+  return readManifest(avatarDir) ?? deriveStateFromLegacyFiles(avatarDir);
+}

--- a/assistant/src/avatar/avatar-store.ts
+++ b/assistant/src/avatar/avatar-store.ts
@@ -18,6 +18,7 @@ import { join } from "node:path";
 import {
   AVATAR_IMAGE_FILENAME,
   AVATAR_MANIFEST_FILENAME,
+  AVATAR_TRAITS_FILENAME,
 } from "@vellumai/avatar-manifest";
 
 import { getLogger } from "../util/logger.js";
@@ -30,7 +31,6 @@ import {
 import {
   ASCII_FILENAME,
   type CharacterTraits,
-  TRAITS_FILENAME,
   type TraitsSyncResult,
   writeTraitsAndRenderAvatar,
 } from "./traits-png-sync.js";
@@ -77,7 +77,7 @@ export function setImage(pngBuffer: Buffer, source: AvatarSource): void {
   writeFileSync(pngTmp, pngBuffer);
   renameSync(pngTmp, pngPath);
 
-  rmSync(join(avatarDir, TRAITS_FILENAME), { force: true });
+  rmSync(join(avatarDir, AVATAR_TRAITS_FILENAME), { force: true });
   rmSync(join(avatarDir, ASCII_FILENAME), { force: true });
 
   writeManifest({
@@ -105,7 +105,7 @@ export function clearAvatar(): void {
   mkdirSync(avatarDir, { recursive: true });
 
   rmSync(join(avatarDir, AVATAR_IMAGE_FILENAME), { force: true });
-  rmSync(join(avatarDir, TRAITS_FILENAME), { force: true });
+  rmSync(join(avatarDir, AVATAR_TRAITS_FILENAME), { force: true });
   rmSync(join(avatarDir, ASCII_FILENAME), { force: true });
   rmSync(join(avatarDir, AVATAR_MANIFEST_FILENAME), { force: true });
 

--- a/assistant/src/avatar/ensure-raster.ts
+++ b/assistant/src/avatar/ensure-raster.ts
@@ -2,19 +2,10 @@ import { existsSync, readFileSync } from "node:fs";
 
 import { getLogger } from "../util/logger.js";
 import { getAvatarImagePath } from "../util/platform.js";
-import {
-  type AvatarState,
-  deriveStateFromLegacyFiles,
-  readManifest,
-} from "./avatar-manifest.js";
+import { type AvatarState, readAvatarState } from "./avatar-manifest.js";
 import { writeTraitsAndRenderAvatar } from "./traits-png-sync.js";
 
 const log = getLogger("ensure-raster");
-
-/** Manifest first, legacy sidecars as fallback. Never persists. */
-function readAvatarState(): AvatarState {
-  return readManifest() ?? deriveStateFromLegacyFiles();
-}
 
 function readPng(path: string): Buffer | null {
   try {

--- a/assistant/src/avatar/traits-png-sync.ts
+++ b/assistant/src/avatar/traits-png-sync.ts
@@ -17,9 +17,6 @@ import { isResvgAvailable } from "./resvg-lazy.js";
 
 const log = getLogger("traits-png-sync");
 
-/** Sidecar filename for the persisted character traits JSON. */
-export const TRAITS_FILENAME = AVATAR_TRAITS_FILENAME;
-
 /** Sidecar filename for the rendered ASCII art. */
 export const ASCII_FILENAME = "character-ascii.txt";
 
@@ -173,7 +170,7 @@ export function writeTraitsAndRenderAvatar(
   }
 
   const avatarDir = getAvatarDir();
-  const traitsPath = join(avatarDir, TRAITS_FILENAME);
+  const traitsPath = join(avatarDir, AVATAR_TRAITS_FILENAME);
 
   try {
     mkdirSync(avatarDir, { recursive: true });

--- a/assistant/src/platform/sync-avatar.test.ts
+++ b/assistant/src/platform/sync-avatar.test.ts
@@ -21,8 +21,7 @@ mock.module("./client.js", () => ({
 }));
 
 mock.module("../avatar/avatar-manifest.js", () => ({
-  readManifest: () => mockState,
-  deriveStateFromLegacyFiles: () => mockState,
+  readAvatarState: () => mockState,
   computeImageMeta: (path: string) => {
     const stats = statSync(path);
     return { updatedAt: "", etag: `${stats.size}:${stats.mtimeMs}` };
@@ -70,7 +69,12 @@ function imageState(etag: string): AvatarState {
   };
 }
 
-const NONE: AvatarState = { kind: "none", traits: null, source: null, image: null };
+const NONE: AvatarState = {
+  kind: "none",
+  traits: null,
+  source: null,
+  image: null,
+};
 
 interface Patch {
   path: string;
@@ -204,6 +208,32 @@ describe("syncAvatarToPlatform", () => {
     await settle();
 
     expect(patches[1].body).toEqual({ avatar_base64: null });
+  });
+
+  test("an image avatar with a missing PNG is skipped, not cleared", async () => {
+    syncAvatarToPlatform();
+    await settle();
+    mockRasterPath = null;
+    syncAvatarToPlatform();
+    await settle();
+
+    expect(patches).toHaveLength(1);
+  });
+
+  test("a character whose re-render failed is skipped, not cleared", async () => {
+    syncAvatarToPlatform();
+    await settle();
+    mockState = {
+      kind: "character",
+      traits: { bodyShape: "blob", eyeStyle: "curious", color: "green" },
+      source: null,
+      image: null,
+    };
+    mockRasterPath = null;
+    syncAvatarToPlatform();
+    await settle();
+
+    expect(patches).toHaveLength(1);
   });
 
   test("skips oversized rasters when resvg is unavailable", async () => {

--- a/assistant/src/platform/sync-avatar.ts
+++ b/assistant/src/platform/sync-avatar.ts
@@ -7,16 +7,18 @@
  * comes from the raster file itself, not the manifest, so a raster rewritten
  * in place (fs watcher path) still syncs, and is scoped to the platform
  * destination so re-registering to another assistant or base URL re-sends.
- * Best-effort: failures are logged, never
- * thrown, and leave the dedup key untouched so the next publish retries.
+ * `avatar_base64: null` is sent only when the avatar is actually removed; a
+ * non-none avatar whose raster is missing (image PNG gone, character re-render
+ * unavailable) is skipped so the platform keeps the last synced copy.
+ * Best-effort: failures are logged, never thrown, and leave the dedup key
+ * untouched so the next publish retries.
  */
 
 import { readFile } from "node:fs/promises";
 
 import {
   computeImageMeta,
-  deriveStateFromLegacyFiles,
-  readManifest,
+  readAvatarState,
 } from "../avatar/avatar-manifest.js";
 import { ensureAvatarRasterPath } from "../avatar/ensure-raster.js";
 import { getResvg, isResvgAvailable } from "../avatar/resvg-lazy.js";
@@ -50,11 +52,18 @@ export function syncAvatarToPlatform(): void {
   pending = pending.then(() => doSync(mySeq)).catch(() => {});
 }
 
-async function readRaster(): Promise<{ key: string; bytes: Buffer | null }> {
-  const state = readManifest() ?? deriveStateFromLegacyFiles();
+/** Returns undefined when a non-none avatar has no raster to send. */
+async function readRaster(): Promise<
+  { key: string; bytes: Buffer | null } | undefined
+> {
+  const state = readAvatarState();
+  if (state.kind === "none") {
+    return { key: NONE_KEY, bytes: null };
+  }
   const path = await ensureAvatarRasterPath(state);
   if (!path) {
-    return { key: NONE_KEY, bytes: null };
+    log.warn({ kind: state.kind }, "Avatar raster missing; skipping sync");
+    return undefined;
   }
   const { etag } = computeImageMeta(path);
   return { key: `${state.kind}:${etag}`, bytes: await readFile(path) };
@@ -100,7 +109,11 @@ async function doSync(requestSeq: number): Promise<void> {
       return;
     }
 
-    const { key: rasterKey, bytes } = await readRaster();
+    const raster = await readRaster();
+    if (!raster) {
+      return;
+    }
+    const { key: rasterKey, bytes } = raster;
     const key = `${client.baseUrl}|${assistantId}|${rasterKey}`;
     if (key === lastSyncedKey) {
       return;

--- a/assistant/src/platform/sync-identity.test.ts
+++ b/assistant/src/platform/sync-identity.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+let mockClient: {
+  baseUrl: string;
+  platformAssistantId: string;
+  fetch: (path: string, init: RequestInit) => Promise<Response>;
+} | null;
+
+mock.module("./client.js", () => ({
+  VellumPlatformClient: { create: async () => mockClient },
+}));
+
+import {
+  _resetSyncIdentityStateForTests,
+  syncIdentityNameToPlatform,
+} from "./sync-identity.js";
+
+interface Patch {
+  path: string;
+  body: { name: string };
+}
+
+let patches: Patch[];
+let respond: () => Response;
+
+function makeClient(assistantId = "asst-1", baseUrl = "https://platform.a") {
+  return {
+    baseUrl,
+    platformAssistantId: assistantId,
+    fetch: async (path: string, init: RequestInit) => {
+      patches.push({ path, body: JSON.parse(init.body as string) });
+      return respond();
+    },
+  };
+}
+
+async function settle(): Promise<void> {
+  for (let i = 0; i < 10; i++) {
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+describe("syncIdentityNameToPlatform", () => {
+  beforeEach(() => {
+    _resetSyncIdentityStateForTests();
+    patches = [];
+    respond = () => new Response("{}", { status: 200 });
+    mockClient = makeClient();
+  });
+
+  test("PATCHes the name once and dedups an unchanged name", async () => {
+    syncIdentityNameToPlatform("Ada");
+    await settle();
+    syncIdentityNameToPlatform("Ada");
+    await settle();
+
+    expect(patches).toEqual([
+      { path: "/v1/assistants/asst-1/", body: { name: "Ada" } },
+    ]);
+  });
+
+  test("re-registering to another assistant id re-sends the same name", async () => {
+    syncIdentityNameToPlatform("Ada");
+    await settle();
+    mockClient = makeClient("asst-2");
+    syncIdentityNameToPlatform("Ada");
+    await settle();
+    syncIdentityNameToPlatform("Ada");
+    await settle();
+
+    expect(patches.map((p) => p.path)).toEqual([
+      "/v1/assistants/asst-1/",
+      "/v1/assistants/asst-2/",
+    ]);
+  });
+
+  test("re-registering to another base URL re-sends the same name", async () => {
+    syncIdentityNameToPlatform("Ada");
+    await settle();
+    mockClient = makeClient("asst-1", "https://platform.b");
+    syncIdentityNameToPlatform("Ada");
+    await settle();
+
+    expect(patches).toHaveLength(2);
+  });
+
+  test("rapid changes collapse into one PATCH carrying the newest name", async () => {
+    syncIdentityNameToPlatform("Ada");
+    syncIdentityNameToPlatform("Bea");
+    syncIdentityNameToPlatform("Cy");
+    await settle();
+
+    expect(patches.map((p) => p.body.name)).toEqual(["Cy"]);
+  });
+
+  test("empty names and missing client or assistant id are no-ops", async () => {
+    syncIdentityNameToPlatform("");
+    mockClient = null;
+    syncIdentityNameToPlatform("Ada");
+    await settle();
+    mockClient = makeClient("");
+    syncIdentityNameToPlatform("Ada");
+    await settle();
+
+    expect(patches).toHaveLength(0);
+  });
+
+  test("a failed PATCH does not dedup the next attempt", async () => {
+    respond = () => new Response("nope", { status: 500 });
+    syncIdentityNameToPlatform("Ada");
+    await settle();
+    respond = () => new Response("{}", { status: 200 });
+    syncIdentityNameToPlatform("Ada");
+    await settle();
+    syncIdentityNameToPlatform("Ada");
+    await settle();
+
+    expect(patches).toHaveLength(2);
+  });
+});

--- a/assistant/src/platform/sync-identity.ts
+++ b/assistant/src/platform/sync-identity.ts
@@ -8,7 +8,9 @@
  *
  * Requests are serialized so that rapid name changes (A → B) never race:
  * only the most recently requested name is sent, and a stale in-flight
- * response cannot overwrite a newer value.
+ * response cannot overwrite a newer value. The dedup key is scoped to the
+ * platform destination (base URL + assistant id) so re-registering to
+ * another assistant re-sends an unchanged name.
  *
  * The sync is best-effort and fire-and-forget — network failures are
  * logged but never surface to callers.
@@ -23,22 +25,24 @@ import { VellumPlatformClient } from "./client.js";
 
 const log = getLogger("sync-identity");
 
-/** Track the last successfully synced name (used inside doSync to skip redundant PATCHes). */
-let lastSyncedName: string | null = null;
-
-/** Track the last requested name (used for dedup at enqueue time). */
-let lastRequestedName: string | null = null;
+/** `${baseUrl}|${assistantId}|${name}` of the last successful PATCH. */
+let lastSyncedKey: string | null = null;
 
 /**
  * Monotonically increasing sequence number.  Each call to
- * `syncIdentityNameToPlatform` bumps this; after a PATCH completes we
- * only update `lastSyncedName` when `seq` still matches, guaranteeing
- * the newest name always wins.
+ * `syncIdentityNameToPlatform` bumps this; a request whose seq is no longer
+ * current is skipped, guaranteeing the newest name always wins.
  */
 let seq = 0;
 
 /** Chain promise that serializes in-flight PATCH requests. */
 let pending: Promise<void> = Promise.resolve();
+
+export function _resetSyncIdentityStateForTests(): void {
+  lastSyncedKey = null;
+  seq = 0;
+  pending = Promise.resolve();
+}
 
 /**
  * Push the current assistant name to the platform `Assistant` record.
@@ -46,14 +50,12 @@ let pending: Promise<void> = Promise.resolve();
  * No-op when:
  * - The platform client cannot be created (not platform-hosted / missing creds).
  * - No assistant ID is configured.
- * - The name is empty or unchanged since the last request.
+ * - The name is empty or already synced to the same platform destination.
  */
 export function syncIdentityNameToPlatform(name: string): void {
-  if (!name || name === lastRequestedName) {
+  if (!name) {
     return;
   }
-
-  lastRequestedName = name;
 
   const mySeq = ++seq;
 
@@ -91,20 +93,14 @@ async function doSync(name: string, requestSeq: number): Promise<void> {
       return;
     }
 
-    // Re-check after awaiting the previous request in the chain.
-    if (name === lastSyncedName) {
-      return;
-    }
-
     const client = await VellumPlatformClient.create();
-    if (!client) {
-      clearRequestedIfLatest(requestSeq);
+    const assistantId = client?.platformAssistantId;
+    if (!client || !assistantId) {
       return;
     }
 
-    const assistantId = client.platformAssistantId;
-    if (!assistantId) {
-      clearRequestedIfLatest(requestSeq);
+    const key = `${client.baseUrl}|${assistantId}|${name}`;
+    if (key === lastSyncedKey) {
       return;
     }
 
@@ -119,15 +115,9 @@ async function doSync(name: string, requestSeq: number): Promise<void> {
     );
 
     if (resp.ok) {
-      // Only update cache if no newer request has been enqueued since we
-      // started this PATCH — prevents a slow response from overwriting a
-      // fresher value.
-      if (requestSeq === seq) {
-        lastSyncedName = name;
-      }
+      lastSyncedKey = key;
       log.info({ name, assistantId }, "Synced assistant name to platform");
     } else {
-      clearRequestedIfLatest(requestSeq);
       const text = await resp.text();
       log.warn(
         { status: resp.status, body: text, assistantId },
@@ -135,17 +125,6 @@ async function doSync(name: string, requestSeq: number): Promise<void> {
       );
     }
   } catch (err) {
-    clearRequestedIfLatest(requestSeq);
     log.warn({ err }, "Error syncing assistant name to platform");
-  }
-}
-
-/**
- * Reset `lastRequestedName` when the latest request failed, so that the
- * next call with the same name is allowed through instead of being deduped.
- */
-function clearRequestedIfLatest(requestSeq: number): void {
-  if (requestSeq === seq) {
-    lastRequestedName = lastSyncedName;
   }
 }

--- a/assistant/src/runtime/routes/avatar-routes.ts
+++ b/assistant/src/runtime/routes/avatar-routes.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 
+import { AVATAR_TRAITS_FILENAME } from "@vellumai/avatar-manifest";
 import { z } from "zod";
 
 import { renderCharacterAscii } from "../../avatar/ascii-renderer.js";
@@ -21,10 +22,7 @@ import {
   ensureAvatarRasterPath,
 } from "../../avatar/ensure-raster.js";
 import { updateIdentityAvatarSection } from "../../avatar/identity-avatar.js";
-import {
-  type CharacterTraits,
-  TRAITS_FILENAME,
-} from "../../avatar/traits-png-sync.js";
+import type { CharacterTraits } from "../../avatar/traits-png-sync.js";
 import { setPlatformBaseUrl } from "../../config/env.js";
 import { credentialKey } from "../../security/credential-key.js";
 import { getSecureKeyAsync } from "../../security/secure-keys.js";
@@ -311,7 +309,7 @@ function handleCharacterAscii({ queryParams, body }: RouteHandlerArgs) {
     );
   }
 
-  const traitsPath = join(getAvatarDir(), TRAITS_FILENAME);
+  const traitsPath = join(getAvatarDir(), AVATAR_TRAITS_FILENAME);
   if (!existsSync(traitsPath)) {
     throw new BadRequestError(
       "No native character set. Use 'assistant avatar character update' first.",


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for chooser-assistant-avatars.md.

**Gaps:** sync-avatar sent avatar_base64: null for non-none states with a missing raster; sync-identity dedup ignored the platform destination; duplicated readAvatarState; TRAITS_FILENAME alias