### PR TITLE
fix: default instance dir for host avatar reads, guard dev-host id decode, trim package exports

### DIFF
--- a/clients/web/vite-plugin-local-mode.test.ts
+++ b/clients/web/vite-plugin-local-mode.test.ts
@@ -297,6 +297,16 @@ describe("avatar middleware", () => {
     });
   });
 
+  test("malformed percent-encoding is a 400", async () => {
+    const result = await dispatch("/__local/avatar/%E0%A4%A");
+
+    expect(result.status).toBe(400);
+    expect(JSON.parse(result.body)).toEqual({
+      ok: false,
+      error: "Malformed assistant ID",
+    });
+  });
+
   test("absent avatar and unknown assistant both resolve to null", async () => {
     expect(JSON.parse((await dispatch("/__local/avatar/asst-a")).body)).toEqual(
       { ok: true, avatar: null },

--- a/clients/web/vite-plugin-local-mode.ts
+++ b/clients/web/vite-plugin-local-mode.ts
@@ -958,11 +958,21 @@ function avatarMiddleware(lockfilePaths: string[]): Connect.NextHandleFunction {
       return;
     }
 
-    const assistantId = decodeURIComponent(match[1]!);
+    let assistantId: string;
+    try {
+      assistantId = decodeURIComponent(match[1]!);
+    } catch {
+      res.statusCode = 400;
+      res.setHeader("Content-Type", "application/json");
+      res.end(JSON.stringify({ ok: false, error: "Malformed assistant ID" }));
+      return;
+    }
     res.statusCode = 200;
     res.setHeader("Content-Type", "application/json");
     res.end(
-      JSON.stringify(readLockfileAssistantAvatar(lockfilePaths, assistantId)),
+      JSON.stringify(
+        readLockfileAssistantAvatar(lockfilePaths, assistantId, process.env),
+      ),
     );
   };
 }

--- a/packages/avatar-manifest/src/index.ts
+++ b/packages/avatar-manifest/src/index.ts
@@ -9,7 +9,6 @@
  * derivation here so they cannot disagree. Leaf package: node builtins only.
  */
 export {
-  AVATAR_DIR_SEGMENTS,
   AVATAR_IMAGE_FILENAME,
   AVATAR_MANIFEST_FILENAME,
   AVATAR_TRAITS_FILENAME,
@@ -17,10 +16,7 @@ export {
 } from "./layout.js";
 export {
   deriveAvatarFromLegacyFiles,
-  isValidAvatarImageMeta,
-  isValidCharacterTraits,
   parseAvatarManifest,
-  resolveAvatarFromFiles,
 } from "./manifest.js";
 export type {
   AvatarImageMeta,
@@ -28,8 +24,6 @@ export type {
   AvatarSource,
   AvatarState,
   CharacterTraits,
-  LegacyAvatarDerivation,
-  ResolvedAvatar,
 } from "./manifest.js";
 export { readWorkspaceAvatar } from "./read.js";
 export type { WorkspaceAvatar } from "./read.js";

--- a/packages/electron-desktop/src/local-mode.test.ts
+++ b/packages/electron-desktop/src/local-mode.test.ts
@@ -1377,6 +1377,48 @@ describe("vellum:localMode:readAssistantAvatar handler", () => {
     });
   });
 
+  test("entry without an instanceDir reads the default dir from process.env", () => {
+    const previousDataHome = process.env.XDG_DATA_HOME;
+    const dataHome = fs.mkdtempSync(path.join(os.tmpdir(), "vellum-data-"));
+    process.env.XDG_DATA_HOME = dataHome;
+    try {
+      fs.writeFileSync(
+        lockfilePath,
+        JSON.stringify({
+          assistants: [{ assistantId: "asst-1", cloud: "local" }],
+          activeAssistant: "asst-1",
+        }),
+      );
+      const avatarDir = path.join(
+        dataHome,
+        "vellum",
+        "assistants",
+        "asst-1",
+        ".vellum",
+        "workspace",
+        "data",
+        "avatar",
+      );
+      fs.mkdirSync(avatarDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(avatarDir, "character-traits.json"),
+        JSON.stringify(traits),
+      );
+
+      expect(readAssistantAvatar("asst-1")).toEqual({
+        ok: true,
+        avatar: { kind: "character", traits },
+      });
+    } finally {
+      if (previousDataHome === undefined) {
+        delete process.env.XDG_DATA_HOME;
+      } else {
+        process.env.XDG_DATA_HOME = previousDataHome;
+      }
+      fs.rmSync(dataHome, { recursive: true, force: true });
+    }
+  });
+
   test("missing assistantId is a structured error", () => {
     expect(readAssistantAvatar(undefined)).toEqual({
       ok: false,

--- a/packages/electron-desktop/src/local-mode.ts
+++ b/packages/electron-desktop/src/local-mode.ts
@@ -572,7 +572,11 @@ export const installLocalMode = (): void => {
       if (!assistantId) {
         return { ok: false, error: "Missing assistantId" };
       }
-      return readLockfileAssistantAvatar(lockfilePaths, assistantId);
+      return readLockfileAssistantAvatar(
+        lockfilePaths,
+        assistantId,
+        process.env,
+      );
     },
   );
 

--- a/packages/local-mode/src/__tests__/status.test.ts
+++ b/packages/local-mode/src/__tests__/status.test.ts
@@ -231,16 +231,37 @@ describe("getLocalAssistantStatus", () => {
 describe("resolveLockfileInstanceDir", () => {
   test("reads the instance dir from the parsed entry", () => {
     writeLocalLockfile();
-    expect(resolveLockfileInstanceDir([lockfilePath], "local-1")).toBe(
+    expect(resolveLockfileInstanceDir([lockfilePath], "local-1", {})).toBe(
       instanceDir,
     );
   });
 
   test("honors legacy top-level baseDataDir", () => {
     writeLockfile({ assistantId: "local-1", baseDataDir: instanceDir });
-    expect(resolveLockfileInstanceDir([lockfilePath], "local-1")).toBe(
+    expect(resolveLockfileInstanceDir([lockfilePath], "local-1", {})).toBe(
       instanceDir,
     );
+  });
+
+  test("falls back to the default instance dir for an entry without one", () => {
+    writeLockfile({ assistantId: "local-1", cloud: "local" });
+    const dataHome = path.join(tempDir, "data-home");
+    expect(
+      resolveLockfileInstanceDir([lockfilePath], "local-1", {
+        VELLUM_ENVIRONMENT: "production",
+        XDG_DATA_HOME: dataHome,
+      }),
+    ).toBe(path.join(dataHome, "vellum", "assistants", "local-1"));
+  });
+
+  test("is undefined for a missing entry", () => {
+    writeLocalLockfile();
+    expect(
+      resolveLockfileInstanceDir([lockfilePath], "local-2", {
+        VELLUM_ENVIRONMENT: "production",
+        XDG_DATA_HOME: tempDir,
+      }),
+    ).toBeUndefined();
   });
 
   test("stops when the authoritative lockfile is unreadable", () => {
@@ -253,7 +274,7 @@ describe("resolveLockfileInstanceDir", () => {
       }),
     );
     expect(
-      resolveLockfileInstanceDir([lockfilePath, legacyPath], "local-1"),
+      resolveLockfileInstanceDir([lockfilePath, legacyPath], "local-1", {}),
     ).toBeUndefined();
   });
 
@@ -267,7 +288,7 @@ describe("resolveLockfileInstanceDir", () => {
       }),
     );
     expect(
-      resolveLockfileInstanceDir([lockfilePath, legacyPath], "local-1"),
+      resolveLockfileInstanceDir([lockfilePath, legacyPath], "local-1", {}),
     ).toBeUndefined();
   });
 });

--- a/packages/local-mode/src/avatar.test.ts
+++ b/packages/local-mode/src/avatar.test.ts
@@ -14,8 +14,9 @@ describe("readLockfileAssistantAvatar", () => {
   let instanceDir: string;
   let avatarDir: string;
 
+  const env = { VELLUM_ENVIRONMENT: "production", XDG_DATA_HOME: "" };
   const read = (assistantId = "asst-1") =>
-    readLockfileAssistantAvatar([lockfilePath], assistantId);
+    readLockfileAssistantAvatar([lockfilePath], assistantId, env);
 
   const writeLockfileEntry = (
     resources?: Record<string, unknown>,
@@ -44,6 +45,7 @@ describe("readLockfileAssistantAvatar", () => {
 
   beforeEach(() => {
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "local-mode-avatar-"));
+    env.XDG_DATA_HOME = path.join(tempDir, "data-home");
     lockfilePath = path.join(tempDir, "lockfile.json");
     instanceDir = path.join(tempDir, "instance");
     avatarDir = path.join(
@@ -129,7 +131,31 @@ describe("readLockfileAssistantAvatar", () => {
     expect(read()).toEqual({ ok: true, avatar: null });
   });
 
-  test("entry without an instanceDir yields null", () => {
+  test("entry without an instanceDir reads the default instance dir", () => {
+    writeLockfileEntry({ gatewayPort: 1, daemonPort: 2 });
+    const defaultAvatarDir = path.join(
+      env.XDG_DATA_HOME,
+      "vellum",
+      "assistants",
+      "asst-1",
+      ".vellum",
+      "workspace",
+      "data",
+      "avatar",
+    );
+    fs.mkdirSync(defaultAvatarDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(defaultAvatarDir, "character-traits.json"),
+      JSON.stringify(traits),
+    );
+
+    expect(read()).toEqual({
+      ok: true,
+      avatar: { kind: "character", traits },
+    });
+  });
+
+  test("entry without an instanceDir and no default workspace yields null", () => {
     writeLockfileEntry({ gatewayPort: 1, daemonPort: 2 });
 
     expect(read()).toEqual({ ok: true, avatar: null });

--- a/packages/local-mode/src/avatar.ts
+++ b/packages/local-mode/src/avatar.ts
@@ -1,7 +1,10 @@
 import fs from "node:fs";
 import path from "node:path";
 
-import { readWorkspaceAvatar } from "@vellumai/avatar-manifest";
+import {
+  readWorkspaceAvatar,
+  type CharacterTraits,
+} from "@vellumai/avatar-manifest";
 
 import { resolveLockfileInstanceDir } from "./status";
 
@@ -13,10 +16,7 @@ import { resolveLockfileInstanceDir } from "./status";
  * package cannot depend on; hosts return it straight over IPC/HTTP.
  */
 export type LockfileAssistantAvatar =
-  | {
-      kind: "character";
-      traits: { bodyShape: string; eyeStyle: string; color: string };
-    }
+  | { kind: "character"; traits: CharacterTraits }
   | { kind: "image"; imageBase64: string };
 
 export type LockfileAssistantAvatarResult =
@@ -43,14 +43,19 @@ function readAvatarImage(imagePath: string): LockfileAssistantAvatar | null {
 /**
  * Read an assistant's avatar directly off disk via its lockfile instance dir,
  * so a sleeping sibling assistant still has an avatar in the chooser. Shared
- * by the Electron IPC handler, the Vite dev middleware, and the packaged CLI
- * `client` host so every host applies one size policy and one result shape.
+ * by the Electron IPC handler and the Vite dev middleware so every host
+ * applies one size policy and one result shape.
  */
 export function readLockfileAssistantAvatar(
   lockfilePaths: string[],
   assistantId: string,
+  env: Record<string, string | undefined>,
 ): LockfileAssistantAvatarResult {
-  const instanceDir = resolveLockfileInstanceDir(lockfilePaths, assistantId);
+  const instanceDir = resolveLockfileInstanceDir(
+    lockfilePaths,
+    assistantId,
+    env,
+  );
   if (!instanceDir) {
     return { ok: true, avatar: null };
   }

--- a/packages/local-mode/src/index.ts
+++ b/packages/local-mode/src/index.ts
@@ -72,12 +72,8 @@ export type {
 } from "./devices";
 export { runUpgrade, isValidReleaseVersion } from "./upgrade";
 export type { UpgradeOptions, UpgradeResult } from "./upgrade";
-export { getLocalAssistantStatus, resolveLockfileInstanceDir } from "./status";
-export { AVATAR_IMAGE_MAX_BYTES, readLockfileAssistantAvatar } from "./avatar";
-export type {
-  LockfileAssistantAvatar,
-  LockfileAssistantAvatarResult,
-} from "./avatar";
+export { getLocalAssistantStatus } from "./status";
+export { readLockfileAssistantAvatar } from "./avatar";
 export type {
   LocalAssistantRuntimeState,
   LocalAssistantStatusResult,

--- a/packages/local-mode/src/status.ts
+++ b/packages/local-mode/src/status.ts
@@ -271,13 +271,15 @@ function lockfileInstanceDir(
 }
 
 /**
- * The persisted instance directory for a lockfile entry, honoring legacy
- * `baseDataDir` entries the parsed contract drops. Undefined when the entry
- * is missing or records no directory.
+ * The instance directory for a lockfile entry: the persisted one (honoring
+ * legacy `baseDataDir` entries the parsed contract drops), else the default
+ * location status also falls back to. Undefined when the entry is missing or
+ * the authoritative lockfile is unreadable.
  */
 export function resolveLockfileInstanceDir(
   lockfilePaths: string[],
   assistantId: string,
+  env: Record<string, string | undefined>,
 ): string | undefined {
   const result = getLockfileData(lockfilePaths);
   if (!result.ok) {
@@ -286,7 +288,18 @@ export function resolveLockfileInstanceDir(
   const entry = result.data.assistants.find(
     (assistant) => assistant.assistantId === assistantId,
   );
-  return lockfileInstanceDir(entry, findRawAssistant(result.raw, assistantId));
+  const rawEntry = findRawAssistant(result.raw, assistantId);
+  if (!entry && !rawEntry) {
+    return undefined;
+  }
+  try {
+    return (
+      lockfileInstanceDir(entry, rawEntry) ??
+      defaultInstanceDir(env, assistantId)
+    );
+  } catch {
+    return undefined;
+  }
 }
 
 function resolveStatusResources(


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for chooser-assistant-avatars.md.

**Gaps:** resolveLockfileInstanceDir lacked the default-dir fallback status uses; vite avatar endpoint could throw on a malformed id; stale CLI docstring; duplicated traits shape and zero-caller exports in local-mode/avatar-manifest/ipc-contract