### PR TITLE
fix: evict last-seen avatar on unpair, honor conclusive host none, tighten unknown-version eviction, consolidate hook helpers

### DIFF
--- a/clients/web/src/assistant/avatar-api.test.ts
+++ b/clients/web/src/assistant/avatar-api.test.ts
@@ -21,7 +21,6 @@ import type { AvatarState } from "@/types/avatar";
 import { isAvatarState } from "@/types/avatar";
 
 import {
-  fetchAvatarImageUrl,
   fetchAvatarImageUrlResult,
   fetchAvatarState,
   fetchCharacterTraitsResult,
@@ -190,7 +189,7 @@ describe("fetchAvatarState", () => {
   });
 });
 
-describe("fetchAvatarImageUrl", () => {
+describe("fetchAvatarImageUrlResult", () => {
   const originalCreateObjectURL = URL.createObjectURL;
 
   afterEach(() => {
@@ -209,7 +208,7 @@ describe("fetchAvatarImageUrl", () => {
       response: okResponse(),
     });
 
-    const result = await fetchAvatarImageUrl("asst-1");
+    const result = await fetchAvatarImageUrlResult("asst-1");
 
     // Regression guard: the image must be fetched through the daemon client
     // (the instance spied on here), not the platform `api` client. The latter
@@ -222,29 +221,9 @@ describe("fetchAvatarImageUrl", () => {
     expect(captured?.path).toEqual({ assistant_id: "asst-1" });
     expect(captured?.query).toEqual({ path: "data/avatar/avatar-image.png" });
     expect(captured?.parseAs).toBe("blob");
-    expect(result).toBe("blob:avatar");
+    expect(result).toEqual({ status: "found", value: "blob:avatar" });
   });
 
-  test("returns null on a non-2xx response", async () => {
-    stubGet({
-      data: undefined,
-      error: { detail: "boom" },
-      response: errorResponse(404),
-    });
-
-    expect(await fetchAvatarImageUrl("asst-1")).toBeNull();
-  });
-
-  test("returns null on a transport throw", async () => {
-    client.get = mock(() =>
-      Promise.reject(new Error("network down")),
-    ) as typeof client.get;
-
-    expect(await fetchAvatarImageUrl("asst-1")).toBeNull();
-  });
-});
-
-describe("fetchAvatarImageUrlResult", () => {
   test("a 404 is absent, an authoritative answer", async () => {
     stubGet({
       data: undefined,

--- a/clients/web/src/assistant/avatar-api.ts
+++ b/clients/web/src/assistant/avatar-api.ts
@@ -77,9 +77,6 @@ export type AvatarFileResult<T> =
   | { status: "absent" }
   | { status: "failed" };
 
-const ABSENT: AvatarFileResult<never> = { status: "absent" };
-const FAILED: AvatarFileResult<never> = { status: "failed" };
-
 function parseCharacterTraits(content: string): CharacterTraits | null {
   try {
     const parsed: unknown = JSON.parse(content);
@@ -100,16 +97,16 @@ export async function fetchCharacterTraitsResult(
     });
     assertHasResponse(response, error, "Failed to fetch character traits");
     if (response.status === 404) {
-      return ABSENT;
+      return { status: "absent" };
     }
     if (!response.ok || !data) {
-      return FAILED;
+      return { status: "failed" };
     }
     // A sidecar the daemon serves but cannot render is as good as missing.
     const traits = parseCharacterTraits(data.content);
-    return traits ? { status: "found", value: traits } : ABSENT;
+    return traits ? { status: "found", value: traits } : { status: "absent" };
   } catch {
-    return FAILED;
+    return { status: "failed" };
   }
 }
 
@@ -214,21 +211,13 @@ export async function fetchAvatarImageUrlResult(
     });
     assertHasResponse(response, error, "Failed to fetch avatar image");
     if (response.status === 404) {
-      return ABSENT;
+      return { status: "absent" };
     }
     if (!response.ok || !data) {
-      return FAILED;
+      return { status: "failed" };
     }
     return { status: "found", value: URL.createObjectURL(data) };
   } catch {
-    return FAILED;
+    return { status: "failed" };
   }
-}
-
-/** {@link fetchAvatarImageUrlResult} collapsed to a value; null for absent or failed. */
-export async function fetchAvatarImageUrl(
-  assistantId: string,
-): Promise<string | null> {
-  const result = await fetchAvatarImageUrlResult(assistantId);
-  return result.status === "found" ? result.value : null;
 }

--- a/clients/web/src/assistant/switch-service.test.ts
+++ b/clients/web/src/assistant/switch-service.test.ts
@@ -45,6 +45,11 @@ mock.module("@/lib/local-mode", () => ({
   removePairedAssistantFromLockfile: removePairedFromLockfileMock,
 }));
 
+const deleteLastSeenAvatarMock = mock(async (_id: string) => {});
+mock.module("@/lib/avatar-last-seen-cache", () => ({
+  deleteLastSeenAvatar: deleteLastSeenAvatarMock,
+}));
+
 const connectPairedAssistantMock = mock(async (_id: string) => {
   if (connectPairedShouldThrow) {
     throw new Error("guardian lease failed");
@@ -103,6 +108,7 @@ beforeEach(() => {
   connectPlatformAssistantMock.mockClear();
   setSelectedAssistantMock.mockClear();
   setActiveAssistantIdMock.mockClear();
+  deleteLastSeenAvatarMock.mockClear();
 });
 
 describe("switchToAssistant", () => {
@@ -253,6 +259,7 @@ describe("removePairedAssistant", () => {
     const outcome = await removePairedAssistant("pr1");
 
     expect(removePairedFromLockfileMock).toHaveBeenCalledWith("pr1");
+    expect(deleteLastSeenAvatarMock).toHaveBeenCalledWith("pr1");
     expect(setActiveAssistantIdMock).toHaveBeenCalledWith(null);
     expect(outcome.ok).toBe(true);
     if (outcome.ok) {
@@ -290,6 +297,7 @@ describe("removePairedAssistant", () => {
     if (!outcome.ok) {
       expect(outcome.error).toBe("host says no");
     }
+    expect(deleteLastSeenAvatarMock).not.toHaveBeenCalled();
     expect(setActiveAssistantIdMock).not.toHaveBeenCalled();
   });
 

--- a/clients/web/src/assistant/switch-service.ts
+++ b/clients/web/src/assistant/switch-service.ts
@@ -1,4 +1,5 @@
 import { setSelectedAssistant } from "@/assistant/selection";
+import { deleteLastSeenAvatar } from "@/lib/avatar-last-seen-cache";
 import {
   getLockfileAssistant,
   getSelectedAssistant,
@@ -108,6 +109,7 @@ export async function removePairedAssistant(
   if (!result.ok) {
     return { ok: false, error: result.error ?? "Failed to remove assistant." };
   }
+  void deleteLastSeenAvatar(assistantId);
   const resolvedStore = useResolvedAssistantsStore.getState();
   if (resolvedStore.activeAssistantId === assistantId) {
     resolvedStore.setActiveAssistantId(null);

--- a/clients/web/src/domains/chat/voice/voice-room/voice-avatar.test.tsx
+++ b/clients/web/src/domains/chat/voice/voice-room/voice-avatar.test.tsx
@@ -29,7 +29,6 @@ mock.module(
       customImageUrl: null,
       isLoading: false,
       isSuccess: true,
-      supportsManifest: true,
       invalidate: () => {},
     }),
   }),

--- a/clients/web/src/hooks/use-assistant-avatar.ts
+++ b/clients/web/src/hooks/use-assistant-avatar.ts
@@ -7,12 +7,13 @@ import {
   fetchAvatarImageUrlResult,
   fetchCharacterTraitsResult,
 } from "@/assistant/avatar-api";
+import { useSupportsAvatarStateManifest } from "@/lib/backwards-compat/avatar-state-manifest";
+import { trackBlobUrl } from "@/lib/blob-url-tracker";
 import type {
   AvatarState,
   CharacterComponents,
   CharacterTraits,
 } from "@/types/avatar";
-import { useSupportsAvatarStateManifest } from "@/lib/backwards-compat/avatar-state-manifest";
 
 export const AVATAR_QUERY_KEY_PREFIX = "assistantAvatar";
 
@@ -31,22 +32,15 @@ const activeBlobUrls = new Map<string, string>();
 
 export interface AssistantAvatarOptions {
   /**
-   * Per-assistant override for the avatar-state-manifest capability. The
-   * default gate reads the ACTIVE assistant's version, which is wrong for
-   * a sibling assistant on another runtime: a pre-manifest sibling would
-   * be asked for `/avatar/state` it doesn't serve and its avatar would
-   * collapse to the fallback. List surfaces resolve the sibling's own
-   * version (`versionSupportsAvatarStateManifest`) and pass it here;
-   * `undefined` keeps the active-assistant gate.
+   * Per-assistant manifest gate. The default reads the ACTIVE assistant's
+   * version, which is wrong for a sibling on another runtime; list surfaces
+   * resolve the sibling's own version and pass it here.
    */
   supportsManifest?: boolean;
   /**
-   * Skip the fetch entirely (`false`) and hand consumers the null avatar.
-   * For sibling assistants whose transport cannot be addressed
-   * independently: with a self-hosted ingress active, every daemon request
-   * is rewritten to that single gateway whatever assistant id the path
-   * carries, so a sibling fetch would return the ACTIVE assistant's
-   * avatar. Defaults to `true`.
+   * `false` skips the fetch and hands consumers the null avatar, for siblings
+   * whose transport cannot be addressed by id (see
+   * `canFetchRowAvatarViaPlatformProxy` in `use-chooser-row-avatar`).
    */
   enabled?: boolean;
 }
@@ -110,8 +104,8 @@ export async function fetchAvatarViaManifest(
 }
 
 /**
- * A legacy sidecar read plus whether it is authoritative: a found file is;
- * two 404s are a real bare avatar; any transport failure is inconclusive.
+ * A read plus whether it is authoritative. A found file or manifest answer
+ * is; two sidecar 404s are a real bare avatar; a transport failure is not.
  */
 export interface LegacyAvatarRead extends AvatarRead {
   conclusive: boolean;
@@ -201,15 +195,7 @@ export function useAssistantAvatar(
         throw new Error("Failed to fetch character components");
       }
 
-      const prev = activeBlobUrls.get(id);
-      if (prev && prev !== imageUrl) {
-        URL.revokeObjectURL(prev);
-      }
-      if (imageUrl) {
-        activeBlobUrls.set(id, imageUrl);
-      } else {
-        activeBlobUrls.delete(id);
-      }
+      trackBlobUrl(activeBlobUrls, id, imageUrl);
 
       return { components, traits, customImageUrl: imageUrl };
     },
@@ -237,7 +223,6 @@ export function useAssistantAvatar(
     customImageUrl: data?.customImageUrl ?? null,
     isLoading,
     isSuccess,
-    supportsManifest,
     invalidate,
   };
 }

--- a/clients/web/src/hooks/use-assistant-resource-sync.test.tsx
+++ b/clients/web/src/hooks/use-assistant-resource-sync.test.tsx
@@ -824,8 +824,13 @@ describe("useAssistantResourceSync", () => {
     emit(syncEvent([SYNC_TAGS.assistantAvatar]) as unknown as AssistantEvent);
     await waitFor(() => {
       expect(
-        sweepsFor(calls, chooserRowAvatarQueryKeyPrefix("asst-1")).length,
-      ).toBe(1);
+        sweepsFor(calls, chooserRowAvatarQueryKeyPrefix("asst-1")),
+      ).toEqual([
+        {
+          queryKey: chooserRowAvatarQueryKeyPrefix("asst-1"),
+          refetchType: "none",
+        },
+      ]);
     });
   });
 
@@ -839,8 +844,13 @@ describe("useAssistantResourceSync", () => {
     emit({ type: "avatar_updated" } as unknown as AssistantEvent);
     await waitFor(() => {
       expect(
-        sweepsFor(calls, chooserRowAvatarQueryKeyPrefix("asst-1")).length,
-      ).toBe(1);
+        sweepsFor(calls, chooserRowAvatarQueryKeyPrefix("asst-1")),
+      ).toEqual([
+        {
+          queryKey: chooserRowAvatarQueryKeyPrefix("asst-1"),
+          refetchType: "none",
+        },
+      ]);
     });
   });
 

--- a/clients/web/src/hooks/use-assistant-resource-sync.ts
+++ b/clients/web/src/hooks/use-assistant-resource-sync.ts
@@ -247,9 +247,11 @@ function invalidateAvatarQueries(
     queryKey: avatarQueryKey(assistantId),
     refetchType,
   });
+  // Chooser-row queries are disabled for the connected row, so this only
+  // marks them stale for when the user switches away and back.
   void queryClient.invalidateQueries({
     queryKey: chooserRowAvatarQueryKeyPrefix(assistantId),
-    refetchType,
+    refetchType: "none",
   });
 }
 

--- a/clients/web/src/hooks/use-chooser-row-avatar.test.tsx
+++ b/clients/web/src/hooks/use-chooser-row-avatar.test.tsx
@@ -614,11 +614,8 @@ describe("useChooserRowAvatar", () => {
       expect(result.current.traits).toBeNull();
     });
 
-    test.each([
-      ["a null avatar", { ok: true, avatar: null } as HostAvatarResult],
-      ["a failure", { ok: false, error: "nope" } as HostAvatarResult],
-    ])("%s falls through to the last-seen cache", async (_l, hostResult) => {
-      readAssistantAvatarHost.mockResolvedValue(hostResult);
+    test("a host failure falls through to the last-seen cache", async () => {
+      readAssistantAvatarHost.mockResolvedValue({ ok: false, error: "nope" });
       readLastSeenAvatar.mockResolvedValue({ kind: "character", traits });
       const { result } = renderHook(
         () => useChooserRowAvatar(localRow("other")),
@@ -631,6 +628,27 @@ describe("useChooserRowAvatar", () => {
       });
       expect(readAssistantAvatarHost).toHaveBeenCalledTimes(1);
       expect(readLastSeenAvatar).toHaveBeenCalledWith("other");
+      expect(deleteLastSeenAvatar).not.toHaveBeenCalled();
+    });
+
+    test("a host read with no avatar is conclusive: it evicts the cache and shows the glyph", async () => {
+      readAssistantAvatarHost.mockResolvedValue({ ok: true, avatar: null });
+      readLastSeenAvatar.mockResolvedValue({ kind: "character", traits });
+      const { result } = renderHook(
+        () => useChooserRowAvatar(localRow("other")),
+        {
+          wrapper: createWrapper(),
+        },
+      );
+      await waitFor(() => {
+        expect(deleteLastSeenAvatar).toHaveBeenCalledWith(
+          "other",
+          expect.any(Number),
+        );
+      });
+      await settle();
+      expect(result.current).toEqual({ traits: null, imageUrl: null });
+      expect(writeLastSeenAvatar).not.toHaveBeenCalled();
     });
 
     test("resolves to nulls when the host and the cache have nothing", async () => {
@@ -900,6 +918,52 @@ describe("useChooserRowAvatar", () => {
       });
       await settle();
       expect(deleteLastSeenAvatar).not.toHaveBeenCalled();
+    });
+
+    test("a version-unknown row whose probe failed keeps its cached avatar on a double 404", async () => {
+      fetchAvatarState.mockResolvedValue(null);
+      readLastSeenAvatar.mockResolvedValue({ kind: "character", traits });
+      const { result } = renderHook(
+        () =>
+          useChooserRowAvatar(
+            platformRow("other", {
+              runtimeVersion: undefined,
+              currentReleaseVersion: null,
+            }),
+          ),
+        { wrapper: createWrapper() },
+      );
+      await waitFor(() => {
+        expect(fetchCharacterTraitsResult).toHaveBeenCalledTimes(1);
+      });
+      await waitFor(() => {
+        expect(result.current.traits).toEqual(traits);
+      });
+      await settle();
+      expect(deleteLastSeenAvatar).not.toHaveBeenCalled();
+      expect(writeLastSeenAvatar).not.toHaveBeenCalled();
+    });
+
+    test("a version-unknown row whose probe failed still trusts a populated sidecar", async () => {
+      fetchAvatarState.mockResolvedValue(null);
+      fetchCharacterTraitsResult.mockResolvedValue(found(traits));
+      renderHook(
+        () =>
+          useChooserRowAvatar(
+            platformRow("other", {
+              runtimeVersion: undefined,
+              currentReleaseVersion: null,
+            }),
+          ),
+        { wrapper: createWrapper() },
+      );
+      await waitFor(() => {
+        expect(writeLastSeenAvatar).toHaveBeenCalledWith(
+          "other",
+          { kind: "character", traits },
+          expect.any(Number),
+        );
+      });
     });
 
     test("a populated legacy read still writes the cache", async () => {

--- a/clients/web/src/hooks/use-chooser-row-avatar.ts
+++ b/clients/web/src/hooks/use-chooser-row-avatar.ts
@@ -1,8 +1,14 @@
 import { useEffect } from "react";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  type QueryClient,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 
 import { fetchAvatarState } from "@/assistant/avatar-api";
 import {
+  type AvatarRead,
+  type LegacyAvatarRead,
   fetchAvatarViaManifest,
   readAvatarViaLegacyFiles,
   resolveAvatarFromState,
@@ -11,13 +17,14 @@ import {
 import { useIsOrgReady } from "@/hooks/use-is-org-ready";
 import { isGatewayAuthEnabled } from "@/lib/auth/gateway-session";
 import {
-  claimLastSeenAvatarGeneration,
   deleteLastSeenAvatar,
-  isLastSeenAvatarGenerationCurrent,
+  lastSeenAvatarGenerations,
   readLastSeenAvatar,
   writeLastSeenAvatar,
 } from "@/lib/avatar-last-seen-cache";
 import { versionSupportsAvatarStateManifest } from "@/lib/backwards-compat/avatar-state-manifest";
+import { trackBlobUrl } from "@/lib/blob-url-tracker";
+import { createGenerationGuard } from "@/lib/generation-guard";
 import { isLocalClient, isRemoteGatewayMode } from "@/lib/local-mode";
 import { getSelfHostedIngressUrl } from "@/lib/self-hosted/connection";
 import {
@@ -28,21 +35,17 @@ import {
   type ResolvedAssistant,
   useResolvedAssistantsStore,
 } from "@/stores/resolved-assistants-store";
-import type { CharacterTraits } from "@/types/avatar";
 
-export const CHOOSER_ROW_AVATAR_QUERY_KEY_PREFIX = "chooserRowAvatar";
-export const CHOOSER_ROW_AVATAR_CACHE_QUERY_KEY_PREFIX =
-  "chooserRowAvatarCache";
+const QUERY_KEY_PREFIX = "chooserRowAvatar";
+const CACHE_QUERY_KEY_PREFIX = "chooserRowAvatarCache";
 
-export type RowManifestSupport = "supported" | "unsupported" | "unknown";
+type RowManifestSupport = "supported" | "unsupported" | "unknown";
 
 /**
  * Tri-state manifest gate for a row's own runtime. Part of the query key so
  * a version change after an upgrade re-runs the fetch through the other path.
  */
-export function rowManifestSupport(
-  assistant: ResolvedAssistant,
-): RowManifestSupport {
+function rowManifestSupport(assistant: ResolvedAssistant): RowManifestSupport {
   const version =
     assistant.runtimeVersion ?? assistant.currentReleaseVersion ?? null;
   if (version === null) {
@@ -55,10 +58,10 @@ export function rowManifestSupport(
 
 /** Prefix matching every support-state variant of one row; use for invalidation. */
 export function chooserRowAvatarQueryKeyPrefix(assistantId: string) {
-  return [CHOOSER_ROW_AVATAR_QUERY_KEY_PREFIX, assistantId] as const;
+  return [QUERY_KEY_PREFIX, assistantId] as const;
 }
 
-export function chooserRowAvatarQueryKey(
+function chooserRowAvatarQueryKey(
   assistantId: string,
   manifestSupport: RowManifestSupport,
 ) {
@@ -69,31 +72,17 @@ export function chooserRowAvatarQueryKey(
 }
 
 /** Under the row prefix so the avatar-sync invalidation covers it too. */
-export function chooserRowAvatarHostQueryKey(assistantId: string) {
+function chooserRowAvatarHostQueryKey(assistantId: string) {
   return [...chooserRowAvatarQueryKeyPrefix(assistantId), "host"] as const;
 }
 
-export function chooserRowAvatarCacheQueryKey(assistantId: string) {
-  return [CHOOSER_ROW_AVATAR_CACHE_QUERY_KEY_PREFIX, assistantId] as const;
+function chooserRowAvatarCacheQueryKey(assistantId: string) {
+  return [CACHE_QUERY_KEY_PREFIX, assistantId] as const;
 }
 
-export interface ChooserRowAvatar {
-  traits: CharacterTraits | null;
-  imageUrl: string | null;
-}
+export type ChooserRowAvatar = AvatarRead;
 
-/**
- * A live read plus whether it is authoritative. The manifest answers
- * conclusively (including "none") or throws; a legacy sidecar read is
- * conclusive when it found a file or both files are absent (404), and
- * inconclusive on a transport failure. An inconclusive read never bypasses
- * or evicts the last-seen cache.
- */
-interface RowAvatarResult extends ChooserRowAvatar {
-  conclusive: boolean;
-}
-
-const EMPTY_AVATAR: ChooserRowAvatar = { traits: null, imageUrl: null };
+const EMPTY_AVATAR: AvatarRead = { traits: null, imageUrl: null };
 
 /**
  * A bare avatar is the state most likely to change soon (a fresh assistant
@@ -109,7 +98,7 @@ const activeBlobUrls = new Map<string, string>();
 const cachedBlobUrls = new Map<string, string>();
 
 /** Latest fetch generation per row; a superseded fetch must not touch the map. */
-const fetchGenerations = new Map<string, number>();
+const fetchGenerations = createGenerationGuard();
 
 /**
  * Whether a daemon SDK call for `row` actually reaches `row`'s runtime.
@@ -142,39 +131,46 @@ export function canFetchRowAvatarViaPlatformProxy(
  * assistant lives on this machine; docker and paired rows have no workspace
  * the host can read.
  */
-export function canReadRowAvatarViaHost(row: ResolvedAssistant): boolean {
+function canReadRowAvatarViaHost(row: ResolvedAssistant): boolean {
   return row.cloud === "local" && isLocalModeHostAvailable();
 }
 
 /**
  * A data URL sidesteps blob lifecycle management for host-sourced bytes.
- * Every "nothing to show" answer, including `ok: false`, resolves to nulls.
+ * A successful read with no avatar is a conclusive none; `ok: false` is not.
  */
 async function readRowAvatarViaHost(
   assistantId: string,
-): Promise<ChooserRowAvatar> {
+): Promise<LegacyAvatarRead> {
   const result = await readAssistantAvatarHost(assistantId);
-  if (!result.ok || result.avatar === null) {
-    return EMPTY_AVATAR;
+  if (!result.ok) {
+    return { ...EMPTY_AVATAR, conclusive: false };
+  }
+  if (result.avatar === null) {
+    return { ...EMPTY_AVATAR, conclusive: true };
   }
   return result.avatar.kind === "character"
-    ? { traits: result.avatar.traits, imageUrl: null }
+    ? { traits: result.avatar.traits, imageUrl: null, conclusive: true }
     : {
         traits: null,
         imageUrl: `data:image/png;base64,${result.avatar.imageBase64}`,
+        conclusive: true,
       };
 }
 
 /**
  * Manifest reads for runtimes known to serve `/avatar/state`; legacy sidecar
  * reads for runtimes known not to. An unknown version probes the manifest
- * first and falls back to the sidecars when the probe fails. A manifest that
- * promises an image whose content fails throws (never a false "none").
+ * first and falls back to the sidecars when the probe fails, but a failed
+ * probe may also mean the runtime is unreachable (the platform proxy answers
+ * 404 for an asleep sibling), so an empty fallback read is inconclusive
+ * there. A manifest that promises an image whose content fails throws
+ * (never a false "none").
  */
 async function fetchRowAvatar(
   assistant: ResolvedAssistant,
   manifestSupport: RowManifestSupport,
-): Promise<RowAvatarResult> {
+): Promise<LegacyAvatarRead> {
   if (manifestSupport === "supported") {
     return {
       ...(await fetchAvatarViaManifest(assistant.id)),
@@ -189,25 +185,10 @@ async function fetchRowAvatar(
         conclusive: true,
       };
     }
-    // Probe failed: the runtime is likely pre-manifest.
+    const legacy = await readAvatarViaLegacyFiles(assistant.id);
+    return isEmptyAvatar(legacy) ? { ...legacy, conclusive: false } : legacy;
   }
   return readAvatarViaLegacyFiles(assistant.id);
-}
-
-function trackBlobUrl(
-  urls: Map<string, string>,
-  assistantId: string,
-  imageUrl: string | null,
-): void {
-  const prev = urls.get(assistantId);
-  if (prev && prev !== imageUrl) {
-    URL.revokeObjectURL(prev);
-  }
-  if (imageUrl) {
-    urls.set(assistantId, imageUrl);
-  } else {
-    urls.delete(assistantId);
-  }
 }
 
 /**
@@ -219,11 +200,10 @@ function trackBlobUrl(
 async function fetchRowAvatarGeneration(
   assistant: ResolvedAssistant,
   manifestSupport: RowManifestSupport,
-): Promise<RowAvatarResult> {
-  const generation = (fetchGenerations.get(assistant.id) ?? 0) + 1;
-  fetchGenerations.set(assistant.id, generation);
+): Promise<LegacyAvatarRead> {
+  const generation = fetchGenerations.claim(assistant.id);
   const avatar = await fetchRowAvatar(assistant, manifestSupport);
-  if (fetchGenerations.get(assistant.id) !== generation) {
+  if (!fetchGenerations.isCurrent(assistant.id, generation)) {
     if (avatar.imageUrl) {
       URL.revokeObjectURL(avatar.imageUrl);
     }
@@ -233,26 +213,25 @@ async function fetchRowAvatarGeneration(
   return avatar;
 }
 
-function isEmptyAvatar(avatar: ChooserRowAvatar | undefined): boolean {
+function isEmptyAvatar(avatar: AvatarRead | undefined): boolean {
   return avatar !== undefined && !avatar.traits && !avatar.imageUrl;
 }
 
-// Last-seen cache (IndexedDB). Only LIVE sources feed it: the connected
-// row's `useAssistantAvatar` and the platform-proxy per-row fetch. Durable
-// sources (host disk, platform URLs) must never be written back here.
-
 /**
- * Claims a persistence generation up front so a blob read that resolves
- * after a newer write or delete (including a retire) commits nothing.
+ * Writes a conclusive resolution to the last-seen cache (IndexedDB); an
+ * empty avatar deletes the entry. Claims a persistence generation up front
+ * so a blob read that resolves after a newer write or delete (including a
+ * retire) commits nothing. Refreshes the cache query once committed.
  */
 async function persistLastSeenAvatar(
+  queryClient: QueryClient,
   assistantId: string,
-  avatar: ChooserRowAvatar,
+  avatar: AvatarRead,
 ): Promise<void> {
-  const generation = claimLastSeenAvatarGeneration(assistantId);
+  const generation = lastSeenAvatarGenerations.claim(assistantId);
   if (avatar.imageUrl) {
     const blob = await fetch(avatar.imageUrl).then((r) => r.blob());
-    if (!isLastSeenAvatarGenerationCurrent(assistantId, generation)) {
+    if (!lastSeenAvatarGenerations.isCurrent(assistantId, generation)) {
       return;
     }
     await writeLastSeenAvatar(assistantId, { kind: "image", blob }, generation);
@@ -265,11 +244,12 @@ async function persistLastSeenAvatar(
   } else {
     await deleteLastSeenAvatar(assistantId, generation);
   }
+  await queryClient.invalidateQueries({
+    queryKey: chooserRowAvatarCacheQueryKey(assistantId),
+  });
 }
 
-async function readCachedRowAvatar(
-  assistantId: string,
-): Promise<ChooserRowAvatar> {
+async function readCachedRowAvatar(assistantId: string): Promise<AvatarRead> {
   const cached = await readLastSeenAvatar(assistantId);
   const imageUrl =
     cached?.kind === "image" ? URL.createObjectURL(cached.blob) : null;
@@ -288,11 +268,13 @@ async function readCachedRowAvatar(
  *    {@link canFetchRowAvatarViaPlatformProxy} says the id is honored and the
  *    org store can supply the `Vellum-Organization-Id` header.
  * 3. Local rows (even asleep) read their workspace through the host bridge
- *    when {@link canReadRowAvatarViaHost} says one is available.
+ *    when one is available.
  * 4. The last-seen cache: whatever a live source last resolved for this id,
  *    so a row keeps its avatar while the assistant is unreachable.
- * Anything else, including every failure, resolves to nulls: the row's glyph
- * fallback is the error state, a chooser row never surfaces an error.
+ * Only live sources (1 and 2) feed the cache; a conclusive none from any
+ * source evicts it. Anything else, including every failure, resolves to
+ * nulls: the row's glyph fallback is the error state, a chooser row never
+ * surfaces an error.
  */
 export function useChooserRowAvatar(
   assistant: ResolvedAssistant,
@@ -305,7 +287,7 @@ export function useChooserRowAvatar(
   const connected = useAssistantAvatar(isConnectedRow ? assistant.id : null);
 
   const manifestSupport = rowManifestSupport(assistant);
-  const rowQuery = useQuery<RowAvatarResult>({
+  const rowQuery = useQuery<LegacyAvatarRead>({
     queryKey: chooserRowAvatarQueryKey(assistant.id, manifestSupport),
     queryFn: () => fetchRowAvatarGeneration(assistant, manifestSupport),
     enabled:
@@ -323,7 +305,7 @@ export function useChooserRowAvatar(
   // that cannot mistake a failure for a bare avatar (useAssistantAvatar
   // throws on every inconclusive read); on error React Query keeps prior
   // data, which is still worth rendering but not caching.
-  const live: ChooserRowAvatar | undefined = isConnectedRow
+  const live: AvatarRead | undefined = isConnectedRow
     ? { traits: connected.traits, imageUrl: connected.customImageUrl }
     : rowQuery.data && {
         traits: rowQuery.data.traits,
@@ -335,43 +317,39 @@ export function useChooserRowAvatar(
   const showLive =
     liveConclusive || (live !== undefined && !isEmptyAvatar(live));
 
-  const liveTraits = live?.traits ?? null;
-  const liveImageUrl = live?.imageUrl ?? null;
-  useEffect(() => {
-    if (!liveConclusive) {
-      return;
-    }
-    const assistantId = assistant.id;
-    void persistLastSeenAvatar(assistantId, {
-      traits: liveTraits,
-      imageUrl: liveImageUrl,
-    })
-      .then(() =>
-        queryClient.invalidateQueries({
-          queryKey: chooserRowAvatarCacheQueryKey(assistantId),
-        }),
-      )
-      .catch(() => {});
-  }, [assistant.id, liveConclusive, liveTraits, liveImageUrl, queryClient]);
-
   // Host-disk reads are durable, so they render directly and never feed the
-  // last-seen cache (the persist effect above is gated on `liveConclusive`).
-  const hostQuery = useQuery<ChooserRowAvatar>({
+  // last-seen cache; a conclusive none still evicts a stale entry.
+  const hostQuery = useQuery<LegacyAvatarRead>({
     queryKey: chooserRowAvatarHostQueryKey(assistant.id),
     queryFn: () => readRowAvatarViaHost(assistant.id),
     enabled: !isConnectedRow && canReadRowAvatarViaHost(assistant),
     staleTime: Infinity,
     retry: false,
   });
-  const host =
-    !showLive && hostQuery.data && !isEmptyAvatar(hostQuery.data)
-      ? hostQuery.data
-      : undefined;
+  const hostConclusive = hostQuery.isSuccess && hostQuery.data.conclusive;
+  const showHost =
+    !showLive &&
+    hostQuery.data !== undefined &&
+    (hostConclusive || !isEmptyAvatar(hostQuery.data));
+  const hostNone = hostConclusive && isEmptyAvatar(hostQuery.data);
 
-  const cacheQuery = useQuery<ChooserRowAvatar>({
+  const syncCache = liveConclusive || hostNone;
+  const syncTraits = liveConclusive ? (live?.traits ?? null) : null;
+  const syncImageUrl = liveConclusive ? (live?.imageUrl ?? null) : null;
+  useEffect(() => {
+    if (!syncCache) {
+      return;
+    }
+    void persistLastSeenAvatar(queryClient, assistant.id, {
+      traits: syncTraits,
+      imageUrl: syncImageUrl,
+    }).catch(() => {});
+  }, [assistant.id, syncCache, syncTraits, syncImageUrl, queryClient]);
+
+  const cacheQuery = useQuery<AvatarRead>({
     queryKey: chooserRowAvatarCacheQueryKey(assistant.id),
     queryFn: () => readCachedRowAvatar(assistant.id),
-    enabled: !showLive && host === undefined,
+    enabled: !showLive && !showHost,
     staleTime: Infinity,
     structuralSharing: false,
     retry: false,
@@ -380,8 +358,8 @@ export function useChooserRowAvatar(
   if (showLive) {
     return live ?? EMPTY_AVATAR;
   }
-  if (host) {
-    return host;
+  if (showHost) {
+    return { traits: hostQuery.data.traits, imageUrl: hostQuery.data.imageUrl };
   }
   return cacheQuery.data ?? EMPTY_AVATAR;
 }

--- a/clients/web/src/lib/avatar-last-seen-cache.test.ts
+++ b/clients/web/src/lib/avatar-last-seen-cache.test.ts
@@ -9,9 +9,8 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import type { CharacterTraits } from "@/types/avatar";
 
 import {
-  claimLastSeenAvatarGeneration,
   deleteLastSeenAvatar,
-  isLastSeenAvatarGenerationCurrent,
+  lastSeenAvatarGenerations,
   readLastSeenAvatar,
   writeLastSeenAvatar,
 } from "./avatar-last-seen-cache";
@@ -173,9 +172,9 @@ describe("avatar-last-seen-cache", () => {
 
     test("a write with a superseded generation commits nothing", async () => {
       installFakeIndexedDb();
-      const stale = claimLastSeenAvatarGeneration("a");
+      const stale = lastSeenAvatarGenerations.claim("a");
       await writeLastSeenAvatar("a", { kind: "character", traits });
-      expect(isLastSeenAvatarGenerationCurrent("a", stale)).toBe(false);
+      expect(lastSeenAvatarGenerations.isCurrent("a", stale)).toBe(false);
       await writeLastSeenAvatar(
         "a",
         { kind: "image", blob: new Blob() },
@@ -191,9 +190,9 @@ describe("avatar-last-seen-cache", () => {
 
     test("a plain delete supersedes an in-flight generation", async () => {
       installFakeIndexedDb();
-      const inFlight = claimLastSeenAvatarGeneration("a");
+      const inFlight = lastSeenAvatarGenerations.claim("a");
       await deleteLastSeenAvatar("a");
-      expect(isLastSeenAvatarGenerationCurrent("a", inFlight)).toBe(false);
+      expect(lastSeenAvatarGenerations.isCurrent("a", inFlight)).toBe(false);
     });
 
     test("a failed transaction is swallowed", async () => {

--- a/clients/web/src/lib/avatar-last-seen-cache.ts
+++ b/clients/web/src/lib/avatar-last-seen-cache.ts
@@ -1,3 +1,4 @@
+import { createGenerationGuard } from "@/lib/generation-guard";
 import { type CharacterTraits, isCharacterTraits } from "@/types/avatar";
 
 /**
@@ -82,32 +83,18 @@ export async function readLastSeenAvatar(
 }
 
 /**
- * Per-assistant persistence generation. Every write or delete claims the
- * next one; a caller that did async work before committing (e.g. reading a
- * blob) passes its claimed generation and is dropped if a newer operation
- * has claimed since, so the last-issued operation always wins.
+ * Persistence generations per assistant. A caller that does async work before
+ * committing (e.g. reading a blob) claims up front and passes its generation,
+ * so a newer write or delete issued meanwhile wins.
  */
-const generations = new Map<string, number>();
-
-export function claimLastSeenAvatarGeneration(assistantId: string): number {
-  const generation = (generations.get(assistantId) ?? 0) + 1;
-  generations.set(assistantId, generation);
-  return generation;
-}
-
-export function isLastSeenAvatarGenerationCurrent(
-  assistantId: string,
-  generation: number,
-): boolean {
-  return generations.get(assistantId) === generation;
-}
+export const lastSeenAvatarGenerations = createGenerationGuard();
 
 export async function writeLastSeenAvatar(
   assistantId: string,
   avatar: LastSeenAvatar,
-  generation = claimLastSeenAvatarGeneration(assistantId),
+  generation = lastSeenAvatarGenerations.claim(assistantId),
 ): Promise<void> {
-  if (!isLastSeenAvatarGenerationCurrent(assistantId, generation)) {
+  if (!lastSeenAvatarGenerations.isCurrent(assistantId, generation)) {
     return;
   }
   const record: StoredAvatar = {
@@ -120,9 +107,9 @@ export async function writeLastSeenAvatar(
 
 export async function deleteLastSeenAvatar(
   assistantId: string,
-  generation = claimLastSeenAvatarGeneration(assistantId),
+  generation = lastSeenAvatarGenerations.claim(assistantId),
 ): Promise<void> {
-  if (!isLastSeenAvatarGenerationCurrent(assistantId, generation)) {
+  if (!lastSeenAvatarGenerations.isCurrent(assistantId, generation)) {
     return;
   }
   await withStore("readwrite", (store) => store.delete(assistantId));

--- a/clients/web/src/lib/blob-url-tracker.ts
+++ b/clients/web/src/lib/blob-url-tracker.ts
@@ -1,0 +1,20 @@
+/**
+ * Records the object URL currently rendered for `key`, revoking the one it
+ * replaces. Each caller owns its own map so unrelated caches never revoke
+ * each other's URLs.
+ */
+export function trackBlobUrl(
+  urls: Map<string, string>,
+  key: string,
+  imageUrl: string | null,
+): void {
+  const prev = urls.get(key);
+  if (prev && prev !== imageUrl) {
+    URL.revokeObjectURL(prev);
+  }
+  if (imageUrl) {
+    urls.set(key, imageUrl);
+  } else {
+    urls.delete(key);
+  }
+}

--- a/clients/web/src/lib/generation-guard.ts
+++ b/clients/web/src/lib/generation-guard.ts
@@ -1,0 +1,23 @@
+/**
+ * Per-key monotonic generations. Every operation claims the next one; async
+ * work that started earlier checks `isCurrent` before committing, so the
+ * last-issued operation for a key always wins.
+ */
+export interface GenerationGuard {
+  claim(key: string): number;
+  isCurrent(key: string, generation: number): boolean;
+}
+
+export function createGenerationGuard(): GenerationGuard {
+  const generations = new Map<string, number>();
+  return {
+    claim(key) {
+      const generation = (generations.get(key) ?? 0) + 1;
+      generations.set(key, generation);
+      return generation;
+    },
+    isCurrent(key, generation) {
+      return generations.get(key) === generation;
+    },
+  };
+}


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review for chooser-assistant-avatars.md.

**Gaps:** unpair left IndexedDB residue; host none did not suppress the cache; unknown-version proxy 404 evicted the cache; unreachable chooser-row invalidation; duplicated blob/generation/result-type helpers and zero-caller exports