### PR TITLE
fix(windows): hide assistant worker console windows

### DIFF
--- a/assistant/src/monitoring/db-integrity-sample.ts
+++ b/assistant/src/monitoring/db-integrity-sample.ts
@@ -66,6 +66,7 @@ async function runCheckSubprocess(
   );
   const child = Bun.spawn({
     cmd: [...command, dbPath],
+    windowsHide: true,
     stdio: ["ignore", "pipe", "ignore"],
   });
   activeChild = child;

--- a/assistant/src/persistence/embeddings/embedding-local.ts
+++ b/assistant/src/persistence/embeddings/embedding-local.ts
@@ -438,6 +438,7 @@ export class LocalEmbeddingBackend implements EmbeddingBackend {
 
     const proc = Bun.spawn({
       cmd: [bunPath, "--smol", workerPath, this.model, modelCacheDir],
+      windowsHide: true,
       env: { ...workerMemoryEnv(), ...workerComputeEnv() },
       stdin: "pipe",
       stdout: "pipe",

--- a/assistant/src/persistence/embeddings/embedding-runtime-manager.ts
+++ b/assistant/src/persistence/embeddings/embedding-runtime-manager.ts
@@ -102,6 +102,7 @@ async function downloadAndExtract(
     // Extract tarball, stripping the leading "package/" directory
     const proc = Bun.spawn({
       cmd: ["tar", "xzf", tmpTar, "-C", targetDir, "--strip-components=1"],
+      windowsHide: true,
       stdout: "ignore",
       stderr: "pipe",
     });

--- a/assistant/src/plugins/defaults/memory/v2/rerank-local.ts
+++ b/assistant/src/plugins/defaults/memory/v2/rerank-local.ts
@@ -164,6 +164,7 @@ export class LocalRerankBackend {
         modelCacheDir,
         this.dtype,
       ],
+      windowsHide: true,
       env: { ...workerMemoryEnv(), ...workerComputeEnv() },
       stdin: "pipe",
       stdout: "pipe",


### PR DESCRIPTION
## Summary

- hide Windows console allocation for local embed, rerank, and database-integrity workers
- hide the embedding runtime extraction helper used during first-time setup

## Original prompt

The Windows desktop client was opening small terminal windows while using the local assistant, apparently when embed workers launched. The request was to fix the embed-worker path and audit adjacent assistant-owned subprocesses for the same visible-console behavior.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41415" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->