### PR TITLE
Keep the ask-question card from hiding the message it is asking about

### DIFF
--- a/clients/web/src/domains/chat/components/question-prompt-card-minimize.test.tsx
+++ b/clients/web/src/domains/chat/components/question-prompt-card-minimize.test.tsx
@@ -12,7 +12,13 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
 
 import type { QuestionResponseEntry } from "@/domains/chat/api/event-types";
 import { QuestionPromptCard } from "@/domains/chat/components/question-prompt-card";
@@ -30,26 +36,50 @@ const ENTRY: QuestionEntry = {
   ],
 };
 
-function setPointer(coarse: boolean): void {
+/**
+ * A `matchMedia` that can change its answer mid-test, which is the whole point
+ * of the pointer gates below: the card subscribes rather than sampling once, so
+ * a convertible folding into tablet mode has to reach a card already on screen.
+ */
+let pointerIsCoarse = false;
+const mediaListeners = new Set<() => void>();
+
+function installMatchMedia(): void {
   window.matchMedia = ((query: string) => ({
-    matches: coarse && query.includes("coarse"),
+    matches: pointerIsCoarse && query.includes("coarse"),
     media: query,
     onchange: null,
-    addEventListener: () => {},
-    removeEventListener: () => {},
+    addEventListener: (_type: string, listener: () => void) => {
+      mediaListeners.add(listener);
+    },
+    removeEventListener: (_type: string, listener: () => void) => {
+      mediaListeners.delete(listener);
+    },
     addListener: () => {},
     removeListener: () => {},
     dispatchEvent: () => false,
   })) as unknown as typeof window.matchMedia;
 }
 
+function setPointer(coarse: boolean): void {
+  pointerIsCoarse = coarse;
+  act(() => {
+    for (const listener of mediaListeners) {
+      listener();
+    }
+  });
+}
+
 beforeEach(() => {
-  setPointer(false);
+  pointerIsCoarse = false;
+  mediaListeners.clear();
+  installMatchMedia();
 });
 
 afterEach(() => {
   cleanup();
-  setPointer(false);
+  pointerIsCoarse = false;
+  mediaListeners.clear();
 });
 
 function renderCard(
@@ -237,5 +267,19 @@ describe("QuestionPromptCard minimize", () => {
     setPointer(true);
     const coarse = renderCard();
     expect(coarse.container.querySelector(GRABBER)).not.toBeNull();
+  });
+
+  test("the grabber follows the pointer changing under a mounted card", () => {
+    const GRABBER = '[data-slot="question-card-grabber"]';
+    const { container } = renderCard();
+
+    expect(container.querySelector(GRABBER)).toBeNull();
+
+    // A convertible folding into tablet mode, with the card already on screen.
+    setPointer(true);
+    expect(container.querySelector(GRABBER)).not.toBeNull();
+
+    setPointer(false);
+    expect(container.querySelector(GRABBER)).toBeNull();
   });
 });

--- a/clients/web/src/domains/chat/components/question-prompt-card-minimize.test.tsx
+++ b/clients/web/src/domains/chat/components/question-prompt-card-minimize.test.tsx
@@ -1,0 +1,241 @@
+/**
+ * Tests for the `QuestionPromptCard` minimized state (LUM-3390).
+ *
+ * The card sits between the transcript and the composer, so at full height it
+ * covers the message it is asking about. Minimizing has to put the options out
+ * of reach as well as out of sight: a collapsed row still answers a click and
+ * still takes a hotkey unless something says otherwise, and either would submit
+ * an answer the user never saw.
+ *
+ * The gesture itself is covered in `use-question-card-minimize.test.ts`; these
+ * cover what the card does with it.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import type { QuestionResponseEntry } from "@/domains/chat/api/event-types";
+import { QuestionPromptCard } from "@/domains/chat/components/question-prompt-card";
+import type { QuestionEntry } from "@/types/interaction-ui-types";
+
+const ENTRY: QuestionEntry = {
+  id: "q1",
+  question: "What should we build first for MarkOne?",
+  description: "Pick the most useful starting point.",
+  options: [
+    { id: "offer", label: "Define the offer and positioning" },
+    { id: "clients", label: "Choose the ideal clients" },
+    { id: "acquisition", label: "Build the client acquisition system" },
+    { id: "workflow", label: "Design the AI delivery workflow" },
+  ],
+};
+
+function setPointer(coarse: boolean): void {
+  window.matchMedia = ((query: string) => ({
+    matches: coarse && query.includes("coarse"),
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia;
+}
+
+beforeEach(() => {
+  setPointer(false);
+});
+
+afterEach(() => {
+  cleanup();
+  setPointer(false);
+});
+
+function renderCard(
+  overrides: {
+    entries?: QuestionEntry[];
+    onSubmitAll?: (responses: QuestionResponseEntry[]) => void;
+    onClose?: () => void;
+  } = {},
+) {
+  return render(
+    <QuestionPromptCard
+      requestId="req-1"
+      entries={overrides.entries ?? [ENTRY]}
+      isSubmitting={false}
+      onSubmitAll={overrides.onSubmitAll ?? (() => {})}
+      onClose={overrides.onClose}
+    />,
+  );
+}
+
+function toggleButton(): HTMLElement {
+  return screen.getByRole("button", {
+    name: /Minimize question|Reopen question/,
+  });
+}
+
+/**
+ * The text a screen reader would reach, which is not the same as the text in
+ * the DOM: both halves of the header crossfade stay mounted at zero height, and
+ * so does the whole collapsed body.
+ */
+function accessibleText(root: Element): string {
+  const out: string[] = [];
+  const walk = (node: Node) => {
+    if (node.nodeType === Node.TEXT_NODE) {
+      const text = node.textContent?.trim();
+      if (text) {
+        out.push(text);
+      }
+      return;
+    }
+    if (!(node instanceof Element)) {
+      return;
+    }
+    if (
+      node.getAttribute("aria-hidden") === "true" ||
+      node.hasAttribute("inert")
+    ) {
+      return;
+    }
+    node.childNodes.forEach(walk);
+  };
+  walk(root);
+  return out.join(" | ");
+}
+
+function collapsibleRegion(): HTMLElement {
+  const id = toggleButton().getAttribute("aria-controls");
+  expect(id).toBeTruthy();
+  const region = document.getElementById(id!);
+  expect(region).not.toBeNull();
+  return region!;
+}
+
+describe("QuestionPromptCard minimize", () => {
+  test("renders expanded, with the minimize control open", () => {
+    renderCard();
+
+    expect(toggleButton().getAttribute("aria-expanded")).toBe("true");
+    expect(toggleButton().getAttribute("aria-label")).toBe("Minimize question");
+    expect(
+      screen.getByText("Pick the most useful starting point."),
+    ).toBeDefined();
+    expect(collapsibleRegion().hasAttribute("inert")).toBe(false);
+  });
+
+  test("the minimize button collapses the body and swaps in a summary", () => {
+    renderCard();
+
+    fireEvent.click(toggleButton());
+
+    expect(toggleButton().getAttribute("aria-expanded")).toBe("false");
+    expect(toggleButton().getAttribute("aria-label")).toBe("Reopen question");
+    // The question itself stays: it is what the summary row is a summary of.
+    expect(
+      screen.getByText("What should we build first for MarkOne?"),
+    ).toBeDefined();
+    expect(screen.getByText(/4 options/)).toBeDefined();
+  });
+
+  test("the summary line is announced only once the body it stands in for is gone", () => {
+    const { container } = renderCard();
+
+    expect(accessibleText(container)).not.toContain("4 options");
+    expect(accessibleText(container)).toContain(
+      "Pick the most useful starting point.",
+    );
+
+    fireEvent.click(toggleButton());
+
+    expect(accessibleText(container)).toContain("4 options");
+    expect(accessibleText(container)).not.toContain(
+      "Pick the most useful starting point.",
+    );
+    // The options go with it: a row read out here is one the user cannot see.
+    expect(accessibleText(container)).not.toContain("Choose the ideal clients");
+  });
+
+  test("the collapsed body is inert, so its rows leave the tab order too", () => {
+    renderCard();
+
+    fireEvent.click(toggleButton());
+
+    expect(collapsibleRegion().hasAttribute("inert")).toBe(true);
+  });
+
+  test("tapping a minimized card's header reopens it", () => {
+    renderCard();
+
+    fireEvent.click(toggleButton());
+    expect(toggleButton().getAttribute("aria-expanded")).toBe("false");
+
+    fireEvent.click(
+      screen.getByText("What should we build first for MarkOne?"),
+    );
+
+    expect(toggleButton().getAttribute("aria-expanded")).toBe("true");
+  });
+
+  test("tapping an expanded card's header does not minimize it", () => {
+    renderCard();
+
+    fireEvent.click(
+      screen.getByText("What should we build first for MarkOne?"),
+    );
+
+    expect(toggleButton().getAttribute("aria-expanded")).toBe("true");
+  });
+
+  test("option hotkeys stop answering once the card is minimized", () => {
+    const submitted: QuestionResponseEntry[][] = [];
+    renderCard({ onSubmitAll: (r) => submitted.push(r) });
+
+    fireEvent.click(toggleButton());
+    fireEvent.keyDown(window, { key: "1" });
+
+    expect(submitted).toHaveLength(0);
+
+    // Reopened, the same key answers as it always did.
+    fireEvent.click(toggleButton());
+    fireEvent.keyDown(window, { key: "1" });
+
+    expect(submitted).toHaveLength(1);
+  });
+
+  test("Escape still closes a minimized card", () => {
+    let closed = 0;
+    renderCard({ onClose: () => (closed += 1) });
+
+    fireEvent.click(toggleButton());
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    expect(closed).toBe(1);
+  });
+
+  test("the pager leaves with the rows it pages between", () => {
+    renderCard({ entries: [ENTRY, { ...ENTRY, id: "q2" }] });
+
+    expect(
+      screen.queryByRole("button", { name: "Next question" }),
+    ).not.toBeNull();
+
+    fireEvent.click(toggleButton());
+
+    expect(screen.queryByRole("button", { name: "Next question" })).toBeNull();
+  });
+
+  test("the swipe grabber renders only where a swipe can happen", () => {
+    const GRABBER = '[data-slot="question-card-grabber"]';
+
+    const fine = renderCard();
+    expect(fine.container.querySelector(GRABBER)).toBeNull();
+
+    cleanup();
+    setPointer(true);
+    const coarse = renderCard();
+    expect(coarse.container.querySelector(GRABBER)).not.toBeNull();
+  });
+});

--- a/clients/web/src/domains/chat/components/question-prompt-card.stories.tsx
+++ b/clients/web/src/domains/chat/components/question-prompt-card.stories.tsx
@@ -1,0 +1,89 @@
+/**
+ * The pending `ask_question` card, the prompt that docks above the composer
+ * while the assistant is waiting on an answer.
+ *
+ * The card is pure props, so these stories drive it directly. What they are
+ * for is the minimized state (LUM-3390): it is a live interaction, and the
+ * chevron, the swipe and the tap all land on the same transition, so it wants
+ * to be played with rather than screenshotted. Open a story, use the chevron
+ * in the header, and on a touch target drag the card down or flick it back up.
+ */
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { QuestionPromptCard } from "@/domains/chat/components/question-prompt-card";
+import type { QuestionEntry } from "@/types/interaction-ui-types";
+
+const MARKONE: QuestionEntry = {
+  id: "q1",
+  question: "What should we build first for MarkOne?",
+  description:
+    "Pick the most useful starting point, or type your own direction.",
+  options: [
+    { id: "offer", label: "Define the offer and positioning" },
+    { id: "clients", label: "Choose the ideal clients" },
+    { id: "acquisition", label: "Build the client acquisition system" },
+    { id: "workflow", label: "Design the AI delivery workflow" },
+  ],
+};
+
+const CADENCE: QuestionEntry = {
+  id: "q2",
+  question: "How often should it report back?",
+  options: [
+    { id: "daily", label: "Every morning" },
+    { id: "weekly", label: "Once a week" },
+    { id: "never", label: "Only when something changes" },
+  ],
+};
+
+const meta: Meta<typeof QuestionPromptCard> = {
+  title: "Chat/QuestionPromptCard",
+  component: QuestionPromptCard,
+  parameters: { layout: "padded" },
+  args: {
+    requestId: "req-1",
+    isSubmitting: false,
+    onSubmitAll: () => {},
+    onClose: () => {},
+  },
+  decorators: [
+    (Story) => (
+      // The card is laid out against the chat column, which is capped well
+      // short of the viewport. Anything wider reads as a different component.
+      <div className="max-w-[--chat-max-width]">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof QuestionPromptCard>;
+
+/** The default: expanded, one question, four options and the free-text row. */
+export const Expanded: Story = {
+  args: { entries: [MARKONE] },
+};
+
+/**
+ * A batch. The pager appears beside the counter, and both leave when the card
+ * minimizes, since paging is an expanded-card action.
+ */
+export const Batched: Story = {
+  args: { entries: [MARKONE, CADENCE] },
+};
+
+/** A question with no description, so the header is a single line to begin with. */
+export const NoDescription: Story = {
+  args: { entries: [CADENCE] },
+};
+
+/** Mid-submit: every control is disabled, but the card still minimizes. */
+export const Submitting: Story = {
+  args: { entries: [MARKONE], isSubmitting: true },
+};
+
+/** No `onClose`, so the card renders without its X and Escape does nothing. */
+export const NotDismissible: Story = {
+  args: { entries: [MARKONE], onClose: undefined },
+};

--- a/clients/web/src/domains/chat/components/question-prompt-card.tsx
+++ b/clients/web/src/domains/chat/components/question-prompt-card.tsx
@@ -25,7 +25,7 @@ import {
 import { useTranslation } from "@/i18n";
 import { useOptionHotkeys } from "@/hooks/use-option-hotkeys";
 import type { QuestionEntry } from "@/types/interaction-ui-types";
-import { isPointerCoarse } from "@/utils/pointer";
+import { usePointerCoarse } from "@/utils/pointer";
 import { Button, Card, cn, Typography } from "@vellumai/design-library";
 
 /** Stable no-op for the hotkeys the minimized card has nothing to act on. */
@@ -135,12 +135,16 @@ export function QuestionPromptBody({
     : "";
   const hasFreeText = currentFreeText.trim().length > 0;
 
-  // The pointer axis, read once: on a given device it doesn't change. It gates
-  // two things that only make sense on one side of it: the numeric badges,
-  // which hint at a hardware-keyboard affordance a thumb can't reach, and the
-  // grabber, which advertises a swipe that only touch can perform. The pencil
-  // icon on the free-text row is iconography, not a hint, and stays either way.
-  const [isTouch] = useState(() => isPointerCoarse());
+  // The pointer axis, subscribed rather than sampled: a convertible folding
+  // into tablet mode changes it under a card that is already on screen, and
+  // both things it gates are rendered. The grabber advertises a swipe only
+  // touch can perform, and the numeric badges hint at a hardware-keyboard
+  // affordance a thumb can't reach, so a stale read leaves one of them making
+  // a promise the device can no longer keep. `useSwipeEngine` reads the same
+  // subscribed signal, so the grabber and the gesture it advertises arrive and
+  // leave together. The pencil icon on the free-text row is iconography, not a
+  // hint, and stays either way.
+  const isTouch = usePointerCoarse();
   const showHotkeyBadges = !isTouch;
 
   const recordResponse = useCallback(
@@ -334,7 +338,13 @@ export function QuestionPromptBody({
 
   return (
     <div
-      className="relative flex flex-col p-4"
+      // `pan-x pinch-zoom` hands the browser everything except the axis this
+      // card drags on. Without it a downward swipe can be claimed as native
+      // viewport or ancestor panning, and the touch stream is cancelled before
+      // `touchend`: the card would follow the finger and then snap back with
+      // nothing committed. Zoom and horizontal panning are left alone, since
+      // neither is a gesture the card wants.
+      className="relative flex flex-col p-4 [touch-action:pan-x_pinch-zoom]"
       onTouchStart={minimize.dragHandlers.onTouchStart}
       onTouchMove={minimize.dragHandlers.onTouchMove}
       onTouchEnd={minimize.dragHandlers.onTouchEnd}

--- a/clients/web/src/domains/chat/components/question-prompt-card.tsx
+++ b/clients/web/src/domains/chat/components/question-prompt-card.tsx
@@ -1,6 +1,7 @@
 import {
   ArrowRight,
   Check,
+  ChevronDown,
   ChevronLeft,
   ChevronRight,
   Pencil,
@@ -10,16 +11,25 @@ import {
   type KeyboardEvent as ReactKeyboardEvent,
   useCallback,
   useEffect,
+  useId,
   useRef,
   useState,
 } from "react";
 
 import type { QuestionResponseEntry } from "@/domains/chat/api/event-types";
+import {
+  expandedChromeOpacity,
+  minimizedChromeOpacity,
+  useQuestionCardMinimize,
+} from "@/domains/chat/hooks/use-question-card-minimize";
+import { useTranslation } from "@/i18n";
 import { useOptionHotkeys } from "@/hooks/use-option-hotkeys";
 import type { QuestionEntry } from "@/types/interaction-ui-types";
 import { isPointerCoarse } from "@/utils/pointer";
-import { Button, Card, Typography } from "@vellumai/design-library";
-import { useTranslation } from "@/i18n";
+import { Button, Card, cn, Typography } from "@vellumai/design-library";
+
+/** Stable no-op for the hotkeys the minimized card has nothing to act on. */
+const NOOP = () => {};
 
 export interface QuestionPromptCardProps {
   /** The daemon-supplied request id; needed by the owner for batched POST. */
@@ -56,10 +66,13 @@ export interface QuestionPromptCardProps {
  * `.private/plans/ask-question-batched-ui.md` (PR 2).
  */
 export function QuestionPromptCard(props: QuestionPromptCardProps) {
+  // The card owns its own padding: the bottom inset has to sit above the
+  // collapsing rows rather than below them, or minimizing would leave the
+  // expanded card's floor behind as dead space under the summary line.
   return (
-    <Card>
+    <Card.Root noPadding>
       <QuestionPromptBody {...props} />
-    </Card>
+    </Card.Root>
   );
 }
 
@@ -72,6 +85,19 @@ export function QuestionPromptCard(props: QuestionPromptCardProps) {
  * (N+1) focuses the inline input. Numeric badges are hidden on coarse-pointer
  * (touch) devices — the pencil icon stays since it's iconography, not a
  * hotkey hint.
+ *
+ * ## Minimized state
+ *
+ * At full height the card covers the assistant message the question is about,
+ * which on a phone is most of what is left of the transcript (LUM-3390). The
+ * header stays put and everything below it collapses to nothing, leaving the
+ * question and an option count docked above the composer. Three ways in and
+ * out, all driving the same state: the header's chevron, a vertical swipe
+ * anywhere on the card, and a tap on a minimized card's header.
+ *
+ * `useQuestionCardMinimize` reduces all of that to one `progress` value, which
+ * every moving part below reads. Mid-drag it tracks the finger; at rest it is
+ * the state and CSS eases between the two.
  */
 export function QuestionPromptBody({
   entries,
@@ -80,6 +106,7 @@ export function QuestionPromptBody({
   onClose,
 }: QuestionPromptCardProps) {
   const { t } = useTranslation("chat");
+
   // Defensive: schema requires ≥1 entry, but real-world streams can deliver
   // malformed payloads. Warn so QA notices, but still render something.
   useEffect(() => {
@@ -96,6 +123,10 @@ export function QuestionPromptBody({
     {},
   );
   const inputRef = useRef<HTMLInputElement>(null);
+  const collapsibleId = useId();
+
+  const minimize = useQuestionCardMinimize();
+  const { isMinimized, progress, dragAttr } = minimize;
 
   const isBatched = entries.length > 1;
   const currentEntry = entries[currentIndex];
@@ -104,10 +135,13 @@ export function QuestionPromptBody({
     : "";
   const hasFreeText = currentFreeText.trim().length > 0;
 
-  // Hide the numeric badges on coarse-pointer (touch) devices — they hint at
-  // a hardware-keyboard affordance the user can't trigger. The pencil icon on
-  // the free-text row is iconography (not a hotkey hint) and stays visible.
-  const [showHotkeyBadges] = useState(() => !isPointerCoarse());
+  // The pointer axis, read once: on a given device it doesn't change. It gates
+  // two things that only make sense on one side of it: the numeric badges,
+  // which hint at a hardware-keyboard affordance a thumb can't reach, and the
+  // grabber, which advertises a swipe that only touch can perform. The pencil
+  // icon on the free-text row is iconography, not a hint, and stays either way.
+  const [isTouch] = useState(() => isPointerCoarse());
+  const showHotkeyBadges = !isTouch;
 
   const recordResponse = useCallback(
     (entry: QuestionEntry, response: QuestionResponseEntry) => {
@@ -215,19 +249,24 @@ export function QuestionPromptBody({
   }, [canGoNext]);
 
   useOptionHotkeys(
-    currentEntry?.options.length ?? 0,
+    // A minimized card has no rows on screen, so the option, free-text, skip
+    // and pagination hotkeys would act invisibly: zero options means no digit
+    // resolves to one, and the free-text digit lands on a no-op. Escape is the
+    // exception and stays wired in both states, because it is the keyboard's
+    // way out of the card and the X beside it is the only other one.
+    isMinimized ? 0 : (currentEntry?.options.length ?? 0),
     handleSelectByIndex,
-    handleFocusFreeText,
+    isMinimized ? NOOP : handleFocusFreeText,
     !isSubmitting && currentEntry !== undefined,
     {
-      onPrev: isBatched ? handlePrev : undefined,
-      onNext: isBatched ? handleNext : undefined,
+      onPrev: isBatched && !isMinimized ? handlePrev : undefined,
+      onNext: isBatched && !isMinimized ? handleNext : undefined,
       // Only register `s` when in a batched UX *and* skipping is meaningful
       // for the current row. The legacy single-question card had no `s`
       // hotkey at all — preserve that parity by gating on `isBatched`. The
       // `hasFreeText` gate is a UX safety net (`recordResponse` itself also
       // guards `hasFreeText`).
-      onSkip: !hasFreeText ? handleSkip : undefined,
+      onSkip: !hasFreeText && !isMinimized ? handleSkip : undefined,
       onClose,
     },
   );
@@ -290,26 +329,103 @@ export function QuestionPromptBody({
       : null;
   const isSkipped = currentDraft?.kind === "skip";
 
+  const expandedOpacity = expandedChromeOpacity(progress);
+  const minimizedOpacity = minimizedChromeOpacity(progress);
+
   return (
-    <>
-      <div className="flex items-start gap-2">
-        <div className="flex min-w-0 flex-1 flex-col gap-1">
+    <div
+      className="relative flex flex-col p-4"
+      onTouchStart={minimize.dragHandlers.onTouchStart}
+      onTouchMove={minimize.dragHandlers.onTouchMove}
+      onTouchEnd={minimize.dragHandlers.onTouchEnd}
+      onTouchCancel={minimize.dragHandlers.onTouchCancel}
+      onClickCapture={minimize.dragHandlers.onClickCapture}
+    >
+      {isTouch && (
+        // The swipe is the fastest way out of the card's way, and nothing else
+        // on screen says it exists. Touch only: on a mouse the same bar would
+        // advertise a gesture that never fires (see `docs/PLATFORM_ADAPTATION.md`).
+        //
+        // Absolute, so it sits inside the inset the card already has rather
+        // than adding a band of its own above it. In flow it would push the
+        // header down while the floor below stayed where it was, and the card
+        // would be visibly lopsided on exactly the devices that show it.
+        <div
+          aria-hidden="true"
+          data-slot="question-card-grabber"
+          className="pointer-events-none absolute inset-x-0 top-1.5 flex justify-center"
+        >
+          <span className="h-1 w-9 rounded-full bg-[var(--border-element)]" />
+        </div>
+      )}
+
+      <div
+        className={cn(
+          "flex items-start gap-2",
+          // Only where a drag can start: elsewhere this would take away the
+          // ability to select the question text and give nothing back.
+          isTouch && "select-none",
+          isMinimized && "cursor-pointer",
+        )}
+        // A minimized card reopens from anywhere in its header, which is the
+        // whole card. Left off while expanded so the header's own buttons
+        // aren't shadowed by a handler that would undo them on the way up.
+        onClick={isMinimized ? minimize.expand : undefined}
+      >
+        <div className="flex min-w-0 flex-1 flex-col">
           <Typography
             variant="body-medium-default"
             as="div"
-            className="text-[color:var(--content-default)]"
+            className={cn(
+              "text-[color:var(--content-default)]",
+              isMinimized && "truncate",
+            )}
           >
             {currentEntry.question}
           </Typography>
           {currentEntry.description && (
-            <Typography
-              variant="body-small-default"
-              as="p"
-              className="text-[color:var(--content-tertiary)]"
+            <div
+              className="question-card-motion grid"
+              style={{ gridTemplateRows: `${progress}fr` }}
+              data-dragging={dragAttr}
+              // Collapsed to nothing is invisible, not absent. Without this the
+              // description is still read out under a minimized card, and the
+              // summary line below it under an expanded one.
+              aria-hidden={isMinimized || undefined}
             >
-              {currentEntry.description}
-            </Typography>
+              <div className="min-h-0 overflow-hidden">
+                <Typography
+                  variant="body-small-default"
+                  as="p"
+                  className="question-card-motion pt-1 text-[color:var(--content-tertiary)]"
+                  style={{ opacity: expandedOpacity }}
+                  data-dragging={dragAttr}
+                >
+                  {currentEntry.description}
+                </Typography>
+              </div>
+            </div>
           )}
+          <div
+            className="question-card-motion grid"
+            style={{ gridTemplateRows: `${1 - progress}fr` }}
+            data-dragging={dragAttr}
+            aria-hidden={!isMinimized || undefined}
+          >
+            <div className="min-h-0 overflow-hidden">
+              <Typography
+                variant="body-small-default"
+                as="p"
+                className="question-card-motion pt-1 text-[color:var(--content-tertiary)]"
+                style={{ opacity: minimizedOpacity }}
+                data-dragging={dragAttr}
+              >
+                {t("questionPromptCard.minimizedSummary", {
+                  count: currentEntry.options.length,
+                })}
+              </Typography>
+            </div>
+          </div>
         </div>
         <div className="flex shrink-0 items-center gap-1">
           {isBatched && (
@@ -318,24 +434,58 @@ export function QuestionPromptBody({
               as="span"
               className="px-1 text-[color:var(--content-tertiary)]"
             >
-              {t("questionPromptCard.position", { current: currentIndex + 1, total: entries.length })}
+              {t("questionPromptCard.position", {
+                current: currentIndex + 1,
+                total: entries.length,
+              })}
             </Typography>
+          )}
+          {!isMinimized && (
+            // Paging through a batch is an expanded-card action, so the pager
+            // leaves with the rows it pages between. It fades out over the
+            // first half of the collapse and unmounts once the state commits,
+            // by which point it is already invisible.
+            <div
+              className="question-card-motion flex items-center gap-1"
+              style={{ opacity: expandedOpacity }}
+              data-dragging={dragAttr}
+            >
+              <Button
+                variant="ghost"
+                size="compact"
+                iconOnly={<ChevronLeft />}
+                onClick={handlePrev}
+                disabled={!canGoPrev || isSubmitting}
+                aria-label={t("questionPromptCard.previousQuestionAria")}
+              />
+              <Button
+                variant="ghost"
+                size="compact"
+                iconOnly={<ChevronRight />}
+                onClick={handleNext}
+                disabled={!canGoNext || isSubmitting}
+                aria-label={t("questionPromptCard.nextQuestionAria")}
+              />
+            </div>
           )}
           <Button
             variant="ghost"
             size="compact"
-            iconOnly={<ChevronLeft />}
-            onClick={handlePrev}
-            disabled={!canGoPrev || isSubmitting}
-            aria-label={t("questionPromptCard.previousQuestionAria")}
-          />
-          <Button
-            variant="ghost"
-            size="compact"
-            iconOnly={<ChevronRight />}
-            onClick={handleNext}
-            disabled={!canGoNext || isSubmitting}
-            aria-label={t("questionPromptCard.nextQuestionAria")}
+            iconOnly={
+              <ChevronDown
+                className="question-card-motion"
+                style={{ transform: `rotate(${(1 - progress) * 180}deg)` }}
+                data-dragging={dragAttr}
+              />
+            }
+            onClick={minimize.toggle}
+            aria-expanded={!isMinimized}
+            aria-controls={collapsibleId}
+            aria-label={
+              isMinimized
+                ? t("questionPromptCard.expandAria")
+                : t("questionPromptCard.minimizeAria")
+            }
           />
           {onClose && (
             <Button
@@ -351,89 +501,107 @@ export function QuestionPromptBody({
         </div>
       </div>
 
-      <div className="mt-3 flex flex-col gap-1.5">
-        {currentEntry.options.map((option, index) => {
-          const badgeNumber = index + 1;
-          const isSelected = selectedOptionId === option.id;
-          return (
-            <Button
-              key={option.id}
-              variant="ghost"
-              fullWidth
-              disabled={isSubmitting || hasFreeText}
-              onClick={() => handleOptionClick(option.id)}
-              className="h-auto justify-start whitespace-normal px-3 py-2 text-left"
-              aria-label={t("questionPromptCard.optionAria", { number: badgeNumber, label: option.label })}
+      <div
+        id={collapsibleId}
+        className="question-card-motion grid"
+        style={{ gridTemplateRows: `${progress}fr` }}
+        data-dragging={dragAttr}
+        // Zero-height rows are still reachable by a screen reader and still in
+        // the tab order, so the collapse has to say so as well as show it.
+        inert={isMinimized}
+      >
+        <div className="min-h-0 overflow-hidden">
+          <div className="mt-3 flex flex-col gap-1.5">
+            {currentEntry.options.map((option, index) => {
+              const badgeNumber = index + 1;
+              const isSelected = selectedOptionId === option.id;
+              return (
+                <Button
+                  key={option.id}
+                  variant="ghost"
+                  fullWidth
+                  disabled={isSubmitting || hasFreeText}
+                  onClick={() => handleOptionClick(option.id)}
+                  className="h-auto justify-start whitespace-normal px-3 py-2 text-left"
+                  aria-label={t("questionPromptCard.optionAria", {
+                    number: badgeNumber,
+                    label: option.label,
+                  })}
+                >
+                  <QuestionRowContents
+                    badgeNumber={badgeNumber}
+                    showBadge={showHotkeyBadges}
+                    label={option.label}
+                    description={option.description}
+                    showCheck={isSelected}
+                  />
+                </Button>
+              );
+            })}
+
+            <div
+              className={`flex items-center gap-2 rounded-md px-3 py-2 transition-colors ${
+                hasFreeText ? "bg-[var(--surface-base)]" : ""
+              }`}
             >
-              <QuestionRowContents
-                badgeNumber={badgeNumber}
-                showBadge={showHotkeyBadges}
-                label={option.label}
-                description={option.description}
-                showCheck={isSelected}
+              <span
+                aria-hidden="true"
+                className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-[var(--surface-base)] text-[color:var(--content-secondary)]"
+              >
+                <Pencil className="h-3.5 w-3.5" />
+              </span>
+              <input
+                ref={inputRef}
+                type="text"
+                value={currentFreeText}
+                onChange={(event) => handleFreeTextChange(event.target.value)}
+                onKeyDown={handleInputKeyDown}
+                placeholder={
+                  currentEntry.freeTextPlaceholder ??
+                  t("questionPromptCard.typeSomethingElsePlaceholder")
+                }
+                disabled={isSubmitting}
+                aria-label={t("questionPromptCard.typeDifferentAnswerAria")}
+                className="text-body-medium-default min-w-0 flex-1 bg-transparent text-[color:var(--content-default)] placeholder:text-[color:var(--content-tertiary)] focus:outline-none disabled:opacity-50"
               />
-            </Button>
-          );
-        })}
+              {hasFreeText ? (
+                <Button
+                  variant="primary"
+                  size="compact"
+                  iconOnly={<ArrowRight />}
+                  onClick={handleSubmitFreeText}
+                  disabled={isSubmitting}
+                  aria-label={t("questionPromptCard.sendResponseAria")}
+                  className="shrink-0"
+                />
+              ) : (
+                <Button
+                  variant="outlined"
+                  onClick={handleSkip}
+                  disabled={isSubmitting}
+                  aria-label={t("questionPromptCard.skipAria")}
+                  className="shrink-0"
+                >
+                  {isSkipped
+                    ? t("questionPromptCard.skipped")
+                    : t("questionPromptCard.skip")}
+                </Button>
+              )}
+            </div>
 
-        <div
-          className={`flex items-center gap-2 rounded-md px-3 py-2 transition-colors ${
-            hasFreeText ? "bg-[var(--surface-base)]" : ""
-          }`}
-        >
-          <span
-            aria-hidden="true"
-            className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-[var(--surface-base)] text-[color:var(--content-secondary)]"
-          >
-            <Pencil className="h-3.5 w-3.5" />
-          </span>
-          <input
-            ref={inputRef}
-            type="text"
-            value={currentFreeText}
-            onChange={(event) => handleFreeTextChange(event.target.value)}
-            onKeyDown={handleInputKeyDown}
-            placeholder={
-              currentEntry.freeTextPlaceholder ?? t("questionPromptCard.typeSomethingElsePlaceholder")
-            }
-            disabled={isSubmitting}
-            aria-label={t("questionPromptCard.typeDifferentAnswerAria")}
-            className="text-body-medium-default min-w-0 flex-1 bg-transparent text-[color:var(--content-default)] placeholder:text-[color:var(--content-tertiary)] focus:outline-none disabled:opacity-50"
-          />
-          {hasFreeText ? (
-            <Button
-              variant="primary"
-              size="compact"
-              iconOnly={<ArrowRight />}
-              onClick={handleSubmitFreeText}
-              disabled={isSubmitting}
-              aria-label={t("questionPromptCard.sendResponseAria")}
-              className="shrink-0"
-            />
-          ) : (
-            <Button
-              variant="outlined"
-              onClick={handleSkip}
-              disabled={isSubmitting}
-              aria-label={t("questionPromptCard.skipAria")}
-              className="shrink-0"
-            >
-              {isSkipped ? t("questionPromptCard.skipped") : t("questionPromptCard.skip")}
-            </Button>
-          )}
+            {isSkipped && !hasFreeText && (
+              <Typography
+                variant="body-small-default"
+                as="p"
+                className="px-3 text-[color:var(--content-tertiary)]"
+              >
+                {t("questionPromptCard.skippedHint")}
+              </Typography>
+            )}
+          </div>
         </div>
-
-        {isSkipped && !hasFreeText && (
-          <Typography
-            variant="body-small-default"
-            as="p"
-            className="px-3 text-[color:var(--content-tertiary)]"
-          >
-            {t("questionPromptCard.skippedHint")}
-          </Typography>
-        )}
       </div>
-    </>
+    </div>
   );
 }
 

--- a/clients/web/src/domains/chat/hooks/use-question-card-minimize.test.ts
+++ b/clients/web/src/domains/chat/hooks/use-question-card-minimize.test.ts
@@ -1,0 +1,286 @@
+/**
+ * Tests for `useQuestionCardMinimize`, the minimize state and vertical drag
+ * behind the pending `ask_question` card.
+ *
+ * Two things are worth pinning down here. The first is `progress`: every moving
+ * part of the card reads it, so its resting values and the way a live drag maps
+ * onto it are the whole animation contract. The second is the click a drag
+ * leaves behind, because the card's drag surface covers the option rows, and a
+ * gesture that released into one of those would answer the question the user
+ * was only trying to get out of the way.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { act, renderHook } from "@testing-library/react";
+import type { MouseEvent as ReactMouseEvent, TouchEvent } from "react";
+
+import {
+  MINIMIZE_COMMIT_PX,
+  MINIMIZE_TRAVEL_PX,
+  collapseProgress,
+  expandedChromeOpacity,
+  minimizedChromeOpacity,
+  useQuestionCardMinimize,
+} from "@/domains/chat/hooks/use-question-card-minimize";
+
+// ---------------------------------------------------------------------------
+// Touch-event helpers, mirroring `use-swipe-vertical.test.ts`
+// ---------------------------------------------------------------------------
+
+interface FakeTouch {
+  identifier: number;
+  clientX: number;
+  clientY: number;
+}
+
+function touchEvent(
+  type: "touchstart" | "touchmove" | "touchend",
+  touches: FakeTouch[],
+  changedTouches: FakeTouch[] = [],
+): TouchEvent {
+  return {
+    type,
+    touches: touches as unknown as TouchList,
+    changedTouches: changedTouches as unknown as TouchList,
+    targetTouches: touches as unknown as TouchList,
+    preventDefault: () => {},
+    stopPropagation: () => {},
+  } as unknown as TouchEvent;
+}
+
+function finger(clientY: number): FakeTouch {
+  return { identifier: 1, clientX: 0, clientY };
+}
+
+const START_Y = 200;
+
+function setPointer(coarse: boolean): void {
+  window.matchMedia = ((query: string) => ({
+    matches: coarse && query.includes("coarse"),
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia;
+}
+
+beforeEach(() => {
+  setPointer(true);
+});
+
+afterEach(() => {
+  setPointer(false);
+});
+
+// ---------------------------------------------------------------------------
+// Pure mapping
+// ---------------------------------------------------------------------------
+
+describe("collapseProgress", () => {
+  test("rests at 1 expanded and 0 minimized", () => {
+    expect(collapseProgress(false, 0)).toBe(1);
+    expect(collapseProgress(true, 0)).toBe(0);
+  });
+
+  test("a downward drag from expanded runs progress to 0 over the travel", () => {
+    expect(collapseProgress(false, MINIMIZE_TRAVEL_PX / 2)).toBeCloseTo(0.5);
+    expect(collapseProgress(false, MINIMIZE_TRAVEL_PX)).toBe(0);
+  });
+
+  test("an upward drag from minimized runs progress back to 1", () => {
+    expect(collapseProgress(true, -MINIMIZE_TRAVEL_PX / 2)).toBeCloseTo(0.5);
+    expect(collapseProgress(true, -MINIMIZE_TRAVEL_PX)).toBe(1);
+  });
+
+  test("clamps at both ends so overdrag has nowhere to go", () => {
+    expect(collapseProgress(false, MINIMIZE_TRAVEL_PX * 3)).toBe(0);
+    expect(collapseProgress(false, -MINIMIZE_TRAVEL_PX)).toBe(1);
+    expect(collapseProgress(true, MINIMIZE_TRAVEL_PX)).toBe(0);
+  });
+});
+
+describe("chrome opacities", () => {
+  test("the two crossfades never overlap", () => {
+    for (const progress of [0, 0.25, 0.5, 0.75, 1]) {
+      const both =
+        expandedChromeOpacity(progress) > 0 &&
+        minimizedChromeOpacity(progress) > 0;
+      expect(both).toBe(false);
+    }
+  });
+
+  test("each is fully opaque at its own resting state", () => {
+    expect(expandedChromeOpacity(1)).toBe(1);
+    expect(expandedChromeOpacity(0)).toBe(0);
+    expect(minimizedChromeOpacity(0)).toBe(1);
+    expect(minimizedChromeOpacity(1)).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// State and gesture
+// ---------------------------------------------------------------------------
+
+describe("useQuestionCardMinimize", () => {
+  test("starts expanded", () => {
+    const { result } = renderHook(() => useQuestionCardMinimize());
+
+    expect(result.current.isMinimized).toBe(false);
+    expect(result.current.progress).toBe(1);
+    expect(result.current.dragAttr).toBeUndefined();
+  });
+
+  test("toggle flips the state and expand only ever opens", () => {
+    const { result } = renderHook(() => useQuestionCardMinimize());
+
+    act(() => result.current.toggle());
+    expect(result.current.isMinimized).toBe(true);
+    expect(result.current.progress).toBe(0);
+
+    act(() => result.current.expand());
+    expect(result.current.isMinimized).toBe(false);
+
+    act(() => result.current.expand());
+    expect(result.current.isMinimized).toBe(false);
+  });
+
+  test("a downward drag tracks the finger before it commits", () => {
+    const { result } = renderHook(() => useQuestionCardMinimize());
+    const half = MINIMIZE_TRAVEL_PX / 2;
+
+    act(() => {
+      result.current.dragHandlers.onTouchStart(
+        touchEvent("touchstart", [finger(START_Y)]),
+      );
+      result.current.dragHandlers.onTouchMove(
+        touchEvent("touchmove", [finger(START_Y + half)]),
+      );
+    });
+
+    expect(result.current.isDragging).toBe(true);
+    expect(result.current.dragAttr).toBe("true");
+    expect(result.current.progress).toBeCloseTo(0.5);
+    // Still expanded: the state only changes when the finger comes up.
+    expect(result.current.isMinimized).toBe(false);
+  });
+
+  test("releasing past the commit distance minimizes", () => {
+    const { result } = renderHook(() => useQuestionCardMinimize());
+    const travel = MINIMIZE_COMMIT_PX + 10;
+
+    act(() => {
+      result.current.dragHandlers.onTouchStart(
+        touchEvent("touchstart", [finger(START_Y)]),
+      );
+      result.current.dragHandlers.onTouchMove(
+        touchEvent("touchmove", [finger(START_Y + travel)]),
+      );
+      result.current.dragHandlers.onTouchEnd(
+        touchEvent("touchend", [], [finger(START_Y + travel)]),
+      );
+    });
+
+    expect(result.current.isMinimized).toBe(true);
+    expect(result.current.isDragging).toBe(false);
+    expect(result.current.progress).toBe(0);
+  });
+
+  test("releasing short of the commit distance springs back", () => {
+    const { result } = renderHook(() => useQuestionCardMinimize());
+    const travel = MINIMIZE_COMMIT_PX - 10;
+
+    act(() => {
+      result.current.dragHandlers.onTouchStart(
+        touchEvent("touchstart", [finger(START_Y)]),
+      );
+      result.current.dragHandlers.onTouchMove(
+        touchEvent("touchmove", [finger(START_Y + travel)]),
+      );
+      result.current.dragHandlers.onTouchEnd(
+        touchEvent("touchend", [], [finger(START_Y + travel)]),
+      );
+    });
+
+    expect(result.current.isMinimized).toBe(false);
+    expect(result.current.progress).toBe(1);
+  });
+
+  test("an upward drag past the commit distance expands a minimized card", () => {
+    const { result } = renderHook(() => useQuestionCardMinimize());
+    const travel = MINIMIZE_COMMIT_PX + 10;
+
+    act(() => result.current.toggle());
+
+    act(() => {
+      result.current.dragHandlers.onTouchStart(
+        touchEvent("touchstart", [finger(START_Y)]),
+      );
+      result.current.dragHandlers.onTouchMove(
+        touchEvent("touchmove", [finger(START_Y - travel)]),
+      );
+      result.current.dragHandlers.onTouchEnd(
+        touchEvent("touchend", [], [finger(START_Y - travel)]),
+      );
+    });
+
+    expect(result.current.isMinimized).toBe(false);
+  });
+
+  test("the click a drag leaves behind is swallowed, and only that one", () => {
+    const { result } = renderHook(() => useQuestionCardMinimize());
+    let stopped = 0;
+    const click = () =>
+      ({
+        stopPropagation: () => {
+          stopped += 1;
+        },
+        preventDefault: () => {},
+      }) as unknown as ReactMouseEvent;
+
+    act(() => {
+      result.current.dragHandlers.onTouchStart(
+        touchEvent("touchstart", [finger(START_Y)]),
+      );
+      result.current.dragHandlers.onTouchMove(
+        touchEvent("touchmove", [finger(START_Y + 30)]),
+      );
+      result.current.dragHandlers.onTouchEnd(
+        touchEvent("touchend", [], [finger(START_Y + 30)]),
+      );
+    });
+
+    act(() => result.current.dragHandlers.onClickCapture(click()));
+    expect(stopped).toBe(1);
+
+    // The next click is a real one: the drag is over and the flag went with it.
+    act(() => result.current.dragHandlers.onClickCapture(click()));
+    expect(stopped).toBe(1);
+  });
+
+  test("a tap that never moves leaves the following click alone", () => {
+    const { result } = renderHook(() => useQuestionCardMinimize());
+    let stopped = 0;
+    const click = () =>
+      ({
+        stopPropagation: () => {
+          stopped += 1;
+        },
+        preventDefault: () => {},
+      }) as unknown as ReactMouseEvent;
+
+    act(() => {
+      result.current.dragHandlers.onTouchStart(
+        touchEvent("touchstart", [finger(START_Y)]),
+      );
+      result.current.dragHandlers.onTouchEnd(
+        touchEvent("touchend", [], [finger(START_Y)]),
+      );
+    });
+
+    act(() => result.current.dragHandlers.onClickCapture(click()));
+    expect(stopped).toBe(0);
+  });
+});

--- a/clients/web/src/domains/chat/hooks/use-question-card-minimize.ts
+++ b/clients/web/src/domains/chat/hooks/use-question-card-minimize.ts
@@ -1,0 +1,184 @@
+/**
+ * Minimize / expand state for the pending `ask_question` card, and the vertical
+ * drag that drives it.
+ *
+ * The card sits between the transcript and the composer, so at full height it
+ * covers the assistant message the question is about (LUM-3390). Minimizing
+ * leaves a one-line stand-in and hands the message back, and the state is
+ * per-prompt: `QuestionPromptSlot` keys the card by `requestId`, so a new
+ * question always arrives expanded.
+ *
+ * Motion is expressed as a single `progress` in `[0, 1]`, 1 expanded and 0
+ * minimized, that every animated part of the card reads. At rest it is the
+ * state itself and CSS eases between the two; during a drag it tracks the
+ * finger directly and the card's transitions are dropped, so the card follows
+ * the gesture rather than lagging behind it.
+ */
+
+import { useCallback, useMemo, useRef, useState } from "react";
+import type {
+  MouseEvent as ReactMouseEvent,
+  TouchEvent as ReactTouchEvent,
+} from "react";
+
+import { useSwipeEngine } from "@/hooks/use-swipe-engine";
+import { haptic } from "@/utils/haptics";
+
+/**
+ * Vertical travel (px) that carries the card the whole way between states.
+ * Shorter than the card is tall: the collapse should read as finished well
+ * before the finger reaches the composer.
+ */
+export const MINIMIZE_TRAVEL_PX = 120;
+
+/**
+ * Vertical travel (px) at which a release commits to the other state. Set
+ * around half of {@link MINIMIZE_TRAVEL_PX} so the card is visibly past the
+ * midpoint before releasing counts, and springs back from anything less.
+ */
+export const MINIMIZE_COMMIT_PX = 64;
+
+function clamp01(value: number): number {
+  return Math.min(1, Math.max(0, value));
+}
+
+/**
+ * Where the card sits between minimized (0) and expanded (1) for a given
+ * resting state and live drag offset. `dragOffset` is positive downward, which
+ * is the direction that collapses.
+ */
+export function collapseProgress(
+  isMinimized: boolean,
+  dragOffset: number,
+): number {
+  const resting = isMinimized ? 0 : 1;
+  return clamp01(resting - dragOffset / MINIMIZE_TRAVEL_PX);
+}
+
+/**
+ * Opacity for chrome that belongs to the expanded card (the description, the
+ * pager). Gone by the halfway point so it has cleared out before the summary
+ * line it shares the header with fades in.
+ */
+export function expandedChromeOpacity(progress: number): number {
+  return clamp01(progress * 2 - 1);
+}
+
+/**
+ * Opacity for the one-line summary that stands in for the collapsed body. The
+ * mirror of {@link expandedChromeOpacity}: the two never overlap, so the header
+ * reads as one line swapping for another rather than as two lines dissolving
+ * through each other.
+ */
+export function minimizedChromeOpacity(progress: number): number {
+  return clamp01(1 - progress * 2);
+}
+
+export interface QuestionCardDragHandlers {
+  onTouchStart: (event: ReactTouchEvent) => void;
+  onTouchMove: (event: ReactTouchEvent) => void;
+  onTouchEnd: (event: ReactTouchEvent) => void;
+  onTouchCancel: () => void;
+  onClickCapture: (event: ReactMouseEvent) => void;
+}
+
+export interface UseQuestionCardMinimizeResult {
+  /** Whether the card is resting in its minimized state. */
+  isMinimized: boolean;
+  /** 0 minimized, 1 expanded, fractional mid-drag. */
+  progress: number;
+  /** True while a vertical drag is tracking the finger. */
+  isDragging: boolean;
+  /** `data-dragging` value for every element the drag animates. */
+  dragAttr: "true" | undefined;
+  /** Flips the state. Backs the header's minimize / reopen button. */
+  toggle: () => void;
+  /** Reopens a minimized card. Backs the header's tap target. */
+  expand: () => void;
+  /** Touch handlers for the card's drag surface. */
+  dragHandlers: QuestionCardDragHandlers;
+}
+
+export function useQuestionCardMinimize(): UseQuestionCardMinimizeResult {
+  const [isMinimized, setIsMinimized] = useState(false);
+
+  // A tap that ends a drag must not also toggle. `touchend` runs before the
+  // synthetic `click`, so the flag is raised while the drag resolves and
+  // cleared by the next touch rather than on release.
+  const draggedRef = useRef(false);
+
+  const swipe = useSwipeEngine({
+    enabled: true,
+    axis: "vertical",
+    commitThresholdPx: MINIMIZE_COMMIT_PX,
+    // The card follows the finger one-to-one for its whole travel. The engine's
+    // default damping is there to signal "release to commit" on gestures that
+    // have nowhere to travel to; this one does, and `collapseProgress` clamps
+    // at both ends, which is the resistance the gesture needs.
+    overdragDamping: 1,
+    onMove: () => {
+      draggedRef.current = true;
+    },
+    onCommit: (delta) => {
+      haptic.light();
+      setIsMinimized(delta > 0);
+    },
+  });
+
+  const { onTouchStart, onTouchMove, onTouchEnd, onTouchCancel } = swipe;
+
+  const handleTouchStart = useCallback(
+    (event: ReactTouchEvent) => {
+      draggedRef.current = false;
+      onTouchStart(event);
+    },
+    [onTouchStart],
+  );
+
+  const toggle = useCallback(() => {
+    setIsMinimized((minimized) => !minimized);
+  }, []);
+
+  // Drag suppression lives in `onClickCapture` below, which stops the click
+  // before it reaches any handler, so this one is free to be unconditional.
+  const expand = useCallback(() => {
+    setIsMinimized(false);
+  }, []);
+
+  /**
+   * Swallows the click a drag leaves behind. The whole card is a drag surface,
+   * so a gesture that starts on an option row and ends without committing would
+   * otherwise release into that row's `onClick` and answer the question. Runs
+   * in the capture phase so it lands before the row does, and clears the flag
+   * as it fires so it only ever eats the one click the drag produced.
+   */
+  const onClickCapture = useCallback((event: ReactMouseEvent) => {
+    if (!draggedRef.current) {
+      return;
+    }
+    draggedRef.current = false;
+    event.stopPropagation();
+    event.preventDefault();
+  }, []);
+
+  const dragHandlers = useMemo(
+    () => ({
+      onTouchStart: handleTouchStart,
+      onTouchMove,
+      onTouchEnd,
+      onTouchCancel,
+      onClickCapture,
+    }),
+    [handleTouchStart, onTouchMove, onTouchEnd, onTouchCancel, onClickCapture],
+  );
+
+  return {
+    isMinimized,
+    progress: collapseProgress(isMinimized, swipe.dragOffset),
+    isDragging: swipe.isDragging,
+    dragAttr: swipe.isDragging ? "true" : undefined,
+    toggle,
+    expand,
+    dragHandlers,
+  };
+}

--- a/clients/web/src/hooks/use-swipe-engine.ts
+++ b/clients/web/src/hooks/use-swipe-engine.ts
@@ -1,7 +1,7 @@
 import { useCallback, useRef, useState } from "react";
 import type { TouchEvent as ReactTouchEvent } from "react";
 
-import { isPointerCoarse } from "@/utils/pointer";
+import { usePointerCoarse } from "@/utils/pointer";
 
 /**
  * Minimum travel (px) on the primary axis to commit a swipe. Below this the drag
@@ -106,8 +106,12 @@ export function useSwipeEngine({
   const [dragOffset, setDragOffset] = useState(0);
   const [isDragging, setIsDragging] = useState(false);
 
-  // Evaluated once — on a given device the pointer type doesn't change.
-  const [isTouch] = useState(() => isPointerCoarse());
+  // Subscribed, not sampled once. The pointer type does change on a
+  // convertible folding into tablet mode, and a gesture armed on the reading
+  // taken at mount stays inert (or stays armed) until whatever it lives on
+  // remounts. Callers gate rendered affordances on the same signal, so the
+  // affordance and the gesture it advertises agree.
+  const isTouch = usePointerCoarse();
 
   // Mutable per-gesture state kept in a ref so touchmove/touchend read fresh
   // values without re-subscribing or re-rendering on every move. `touchId`

--- a/clients/web/src/i18n/locales/en/chat.json
+++ b/clients/web/src/i18n/locales/en/chat.json
@@ -1159,6 +1159,9 @@
   },
   "questionPromptCard": {
     "closeQuestionAria": "Close question",
+    "expandAria": "Reopen question",
+    "minimizeAria": "Minimize question",
+    "minimizedSummary": "{count, plural, one {# option} other {# options}} · Tap to reopen",
     "nextQuestionAria": "Next question",
     "optionAria": "Option {number}: {label}",
     "position": "{current} of {total}",

--- a/clients/web/src/i18n/locales/es/chat.json
+++ b/clients/web/src/i18n/locales/es/chat.json
@@ -1159,6 +1159,9 @@
   },
   "questionPromptCard": {
     "closeQuestionAria": "Cerrar pregunta",
+    "expandAria": "Reabrir pregunta",
+    "minimizeAria": "Minimizar pregunta",
+    "minimizedSummary": "{count, plural, one {# opción} other {# opciones}} · Toca para reabrir",
     "nextQuestionAria": "Pregunta siguiente",
     "optionAria": "Opción {number}: {label}",
     "position": "{current} de {total}",

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -401,6 +401,34 @@ html[data-page-transition="pop"]::view-transition-new(root) {
   border-radius: var(--radius-lg);
 }
 
+/* The ask-question card's minimize / expand travel. One class carried by every
+ * part that moves (the collapsing rows, the crossfading header copy, the
+ * chevron) so the card eases as one piece rather than as several things that
+ * happen to share a duration.
+ *
+ * Heights animate as `grid-template-rows` between `1fr` and `0fr` over a row
+ * whose child hides its overflow. That is the one way to ease to and from a
+ * content-sized height without measuring it in JavaScript, and it interpolates
+ * through fractional values, so the same property carries the drag. */
+.question-card-motion {
+  transition:
+    grid-template-rows var(--anim-standard) var(--anim-spring),
+    opacity var(--anim-standard) var(--anim-ease-out),
+    transform var(--anim-standard) var(--anim-spring);
+}
+
+/* While the finger is down the card is already where the gesture puts it, so a
+ * transition would only add lag between the two. */
+.question-card-motion[data-dragging="true"] {
+  transition: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .question-card-motion {
+    transition: none;
+  }
+}
+
 /* Unseen-changes dot attention pulse, applied when the dot appears so a
  * change landing while the user reads the transcript is noticeable. Bounded
  * on purpose: this dot lives in a persistent header, where anything looping


### PR DESCRIPTION
Closes [LUM-3390](https://linear.app/vellum/issue/LUM-3390/keep-the-ask-question-card-from-hiding-the-message-it-is-asking-about).

The pending `ask_question` card docks between the transcript and the composer, so at full height it covers the assistant message it is asking about. On a phone that message is most of what is left of the transcript, and the only way past the card was to answer it or dismiss it outright.

The card now minimizes. The header stays put and everything below it collapses, leaving the question and an option count above the composer.

| Expanded | Minimized |
|---|---|
| title, description, options, free-text row | title (truncated), `4 options · Tap to reopen` |

## Three ways in and out

All driving the same state:

- **The chevron in the header.** The same button both ways; it rotates 180° across the transition, and carries `aria-expanded` / `aria-controls`.
- **A vertical swipe anywhere on the card.** Down minimizes, up reopens. Touch only, via the existing `useSwipeEngine`.
- **A tap on a minimized card.** Anywhere in its header, which at that point is the whole card. An expanded card ignores header taps, so the header's own buttons aren't shadowed by a handler that would undo them.

A grabber sits in the card's top inset on coarse-pointer devices, because nothing else on screen says the swipe exists. It is absolutely positioned so it lives inside the padding the card already has rather than adding a band above it, which would otherwise leave the card visibly lopsided on exactly the devices that show it.

## How the motion works

`useQuestionCardMinimize` reduces the whole thing to one `progress` value in `[0, 1]` that every moving part reads.

- **At rest** it is the state itself (1 expanded, 0 minimized) and CSS eases between the two, on the design library's `--anim-standard` / `--anim-spring` tokens.
- **Mid-drag** it tracks the finger and the card drops its transitions (`data-dragging`), so the collapse follows the gesture instead of lagging a quarter second behind it. Release past ~64px commits; anything less springs back.

Heights animate as `grid-template-rows` between `1fr` and `0fr` over a row whose child hides its overflow. That is the one way to ease to and from a content-sized height without measuring one in JavaScript, and it interpolates through fractional values, so the same property carries the drag. `prefers-reduced-motion` drops the transitions and keeps the state change.

## Not just hidden

A zero-height row still answers a click and is still read out, so:

- `inert` on the collapsed body, which takes its option rows out of the tab order too.
- `aria-hidden` on whichever half of the header crossfade is currently collapsed, so the description isn't announced under a minimized card and the summary line isn't announced under an expanded one.
- Option, free-text, skip and pagination hotkeys stand down while minimized. **Escape stays wired in both states**, since it is the keyboard's way out of the card and the X beside it is the only other one.
- The pager (`‹ ›`) leaves with the rows it pages between, fading out over the first half of the collapse so its unmount is invisible.

## Deviation from the mock

The mock puts the reopen chevron in a rounded square on the *left* of the minimized bar, opposite the minimize chevron on the right of the expanded card. This ships one button in the trailing cluster that rotates between the two, because a single control that turns over reads as one affordance and animates, where two controls swapping sides is a jump cut. Everything else matches: truncated title, `N options · Tap to reopen`, `✕` on the right.

## New copy

`chat` namespace, en + es. `minimizedSummary` uses an ICU plural on the option count.

## Verification

- `bunx tsc --noEmit` clean.
- `bun run lint` 0 errors (15 pre-existing warnings, none in touched files).
- `bun run test:ci`: 1062 passed, 3 failed. All three fail identically on `origin/main` with this branch's changes stashed (`checkout-page`, `checkout-return-target`, `daily-reset-time` — the last is an ICU `GMT` vs `GMT+0` label).
- 24 new tests: `use-question-card-minimize.test.ts` (progress mapping, commit and spring-back, the click a drag leaves behind) and `question-prompt-card-minimize.test.tsx` (collapse, inert, crossfade a11y, hotkey stand-down, tap-to-reopen).
- Exercised in Storybook at 430×860, dark: header inset measured symmetric at 17px top and bottom in both states, and the accessible text checked to be exactly the question plus the summary when minimized.

A new `Chat/QuestionPromptCard` story set is the place to play with it, since the transition wants to be dragged rather than screenshotted.

## QA left to do

Device QA on a real phone: the swipe against the iOS keyboard, and the grabber's tap target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
