### PR TITLE
fix(windows): build preview handler in pack and add pack:debug

### DIFF
--- a/clients/windows/README.md
+++ b/clients/windows/README.md
@@ -111,13 +111,16 @@ This builds the local `clients/web` source, serves it from Electron's
 ## Packaging
 
 ```bash
-bun run build:web   # builds clients/web into resources/web-dist
-bun run pack        # electron-vite build + electron-builder --win (NSIS)
+bun run pack        # runtime + native helper + preview handler + electron-vite build + electron-builder --win (NSIS)
+bun run pack:debug  # same, with Chrome DevTools enabled in the packaged app
 ```
 
-Local and CI packs are unsigned. `bun run pack` skips the Explorer preview
-handler, which `.github/workflows/windows-package-smoke.yaml` builds before
-packaging and then install-, launch-, and uninstall-tests.
+`pack` builds every bundled resource (`build:runtime`, `build:native-helper`,
+`build:preview-handler`) before `electron-builder`, so the Explorer preview
+handler DLL that `electron-builder.config.cjs` requires is always present.
+Local and CI packs are unsigned. `.github/workflows/windows-package-smoke.yaml`
+runs the same steps per architecture, then install-, launch-, and
+uninstall-tests the installer.
 
 ## Release
 

--- a/clients/windows/package.json
+++ b/clients/windows/package.json
@@ -23,7 +23,8 @@
     "test:native-helper": "bun scripts/build-native-helper.ts --test",
     "test:preview-handler": "bun scripts/build-preview-handler.ts --test-architecture && bun scripts/build-preview-handler.ts --native-test",
     "build:web": "cd ../web && bun install && bun run openapi-ts && bun run build && cd ../windows && mkdir -p resources && rm -rf resources/web-dist && cp -R ../web/dist resources/web-dist",
-    "pack": "bun run build:runtime && bun run build:native-helper && bun run build && electron-builder --win --config electron-builder.config.cjs --publish never"
+    "pack": "bun run build:runtime && bun run build:native-helper && bun run build:preview-handler && bun run build && electron-builder --win --config electron-builder.config.cjs --publish never",
+    "pack:debug": "VELLUM_ENABLE_CHROME_DEVTOOLS=true bun run pack"
   },
   "devDependencies": {
     "@types/bun": "1.3.14",


### PR DESCRIPTION
## Summary
- `bun run pack` in `clients/windows` now runs `build:preview-handler` before `electron-builder`, since `electron-builder.config.cjs` and `scripts/after-pack.ts` require `resources/preview-handler/Vellum.PreviewHandler.dll` and a bare pack failed without it
- Add `pack:debug` (sets `VELLUM_ENABLE_CHROME_DEVTOOLS=true`), mirroring the macOS script
- Fix the README packaging section, which claimed pack skips the preview handler; workflows keep calling steps individually because they pass `--arch` per step

## Original prompt
This came out of a Windows-vs-macOS parity audit on 2026-08-25. Maddie asked for separate PRs for each P1 gap; this one covers the broken Windows pack script (missing preview handler build, no pack:debug, stale README).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41419" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->