### PR TITLE
fix(windows): enable Check for Updates and Install CLI menu items

### DIFF
--- a/clients/windows/src/main/cli-path-flow.ts
+++ b/clients/windows/src/main/cli-path-flow.ts
@@ -1,9 +1,13 @@
 import path from "node:path";
 
+import { app, dialog } from "electron";
+
+import { WINDOWS_RELEASE_INFO } from "./app-config";
 import { provisionCliRuntime, resolveCliRuntimePaths } from "./cli-installer";
 import {
   installCliLauncher,
   resolveCliLauncherPaths,
+  type CliLauncherState,
   type RegistryRunner,
 } from "./cli-path-installer";
 
@@ -14,6 +18,19 @@ export interface CliPathFlowOptions {
   releaseChannel: string;
   version: string;
   registryRunner?: RegistryRunner;
+}
+
+/** Provisioning inputs for the running packaged app. */
+export function resolveCliPathFlowOptions(): CliPathFlowOptions {
+  return {
+    userDataDir: app.getPath("userData"),
+    resourcesDir: process.resourcesPath,
+    localAppData:
+      process.env.LOCALAPPDATA ??
+      path.join(app.getPath("home"), "AppData", "Local"),
+    releaseChannel: WINDOWS_RELEASE_INFO.releaseChannel,
+    version: app.getVersion(),
+  };
 }
 
 export function provisionCliForCurrentUser(options: CliPathFlowOptions) {
@@ -29,16 +46,83 @@ export function provisionCliForCurrentUser(options: CliPathFlowOptions) {
     resolveCliRuntimePaths(userDataDir, resourcesDir, version),
   );
   const sourcePath = path.join(runtime.installDir, "vellum.exe");
+  const paths = resolveCliLauncherPaths(localAppData, releaseChannel);
   const launcherState = installCliLauncher(
     sourcePath,
     version,
-    resolveCliLauncherPaths(localAppData, releaseChannel),
+    paths,
     registryRunner,
     { ownerId: resourcesDir },
   );
   return {
     installDir: runtime.installDir,
+    launcherPath: paths.executable,
     launcherState,
     reusedRuntime: runtime.reused,
   };
+}
+
+// Menu-triggered re-runs stack dialogs, so only one flow runs at a time.
+let flowInFlight = false;
+
+const errorMessage = (err: unknown): string =>
+  err instanceof Error ? err.message : "Unknown error";
+
+const installResultDialog = (
+  state: CliLauncherState,
+  launcherPath: string,
+): Electron.MessageBoxOptions => {
+  switch (state) {
+    case "installed":
+      return {
+        type: "info",
+        message: "Vellum CLI installed",
+        detail:
+          `The vellum command is installed at ${launcherPath}. ` +
+          'Open a new terminal and run "vellum".',
+      };
+    case "shadowed":
+      return {
+        type: "warning",
+        message: "Vellum CLI installed",
+        detail:
+          `The vellum command is installed at ${launcherPath}, but another ` +
+          '"vellum" earlier in your PATH will take precedence in your terminal.',
+      };
+    case "foreign":
+      return {
+        type: "warning",
+        message: "Vellum CLI not installed",
+        detail:
+          `A "vellum" file already exists at ${launcherPath} but wasn't ` +
+          "installed by Vellum, so it was left in place.",
+      };
+    default:
+      return {
+        type: "warning",
+        message: "Vellum CLI not installed",
+        detail: `The vellum command at ${launcherPath} could not be set up (${state}). Try again.`,
+      };
+  }
+};
+
+/**
+ * "Install vellum Command..." from the menu. Provisioning is idempotent, so
+ * this doubles as repair. Never throws; failures surface via showErrorBox.
+ */
+export async function runInstallCliCommandFlow(): Promise<void> {
+  if (flowInFlight) return;
+  flowInFlight = true;
+  try {
+    const { launcherState, launcherPath } = provisionCliForCurrentUser(
+      resolveCliPathFlowOptions(),
+    );
+    await dialog.showMessageBox(
+      installResultDialog(launcherState, launcherPath),
+    );
+  } catch (err) {
+    dialog.showErrorBox("Failed to install vellum command", errorMessage(err));
+  } finally {
+    flowInFlight = false;
+  }
 }

--- a/clients/windows/src/main/features/commands.ts
+++ b/clients/windows/src/main/features/commands.ts
@@ -19,6 +19,8 @@ import { installImageContextMenu } from "@vellumai/electron-desktop/image-contex
 import { installTextContextMenu } from "@vellumai/electron-desktop/text-context-menu";
 
 import { getRendererBase } from "../app-config";
+import { checkForUpdates } from "../auto-update";
+import { runInstallCliCommandFlow } from "../cli-path-flow";
 import { handle } from "../ipc.client";
 import log from "../logger";
 import { current, dispatchToMain, ensureVisible } from "../main-window";
@@ -62,7 +64,14 @@ const commandsFeature: CapabilityModule<DesktopCapabilityRegistry> = {
       },
       logger: log,
     });
-    installWindowsMenu({ handle, openAbout: openAboutWindow });
+    installWindowsMenu({
+      handle,
+      openAbout: openAboutWindow,
+      checkForUpdates,
+      installCli: () => {
+        void runInstallCliCommandFlow();
+      },
+    });
 
     app.on("web-contents-created", (_event, contents) => {
       installImageContextMenu(contents);

--- a/clients/windows/src/main/index.ts
+++ b/clients/windows/src/main/index.ts
@@ -40,7 +40,10 @@ import {
   usesAppProtocolRenderer,
 } from "./app-config";
 import { resolveAllowedOrigin } from "./app-origin.client";
-import { provisionCliForCurrentUser } from "./cli-path-flow";
+import {
+  provisionCliForCurrentUser,
+  resolveCliPathFlowOptions,
+} from "./cli-path-flow";
 import { installMainFeatures } from "./features";
 import { handleSync } from "./ipc.client";
 import log from "./logger";
@@ -264,15 +267,7 @@ app
     installCsp();
     if (app.isPackaged && process.platform === "win32") {
       try {
-        const result = provisionCliForCurrentUser({
-          userDataDir: app.getPath("userData"),
-          resourcesDir: process.resourcesPath,
-          localAppData:
-            process.env.LOCALAPPDATA ??
-            path.join(app.getPath("home"), "AppData", "Local"),
-          releaseChannel,
-          version: app.getVersion(),
-        });
+        const result = provisionCliForCurrentUser(resolveCliPathFlowOptions());
         if (["foreign", "shadowed"].includes(result.launcherState)) {
           log.warn(`[cli] Windows launcher is ${result.launcherState}`);
         }

--- a/clients/windows/src/main/menu.test.ts
+++ b/clients/windows/src/main/menu.test.ts
@@ -35,15 +35,18 @@ mock.module("electron", () => ({
 
 const { buildWindowsMenu, installWindowsMenu } = await import("./menu");
 
-const submenu = (label: string): Array<Record<string, unknown>> => {
-  const item = buildWindowsMenu({ openAbout: () => undefined }).find(
-    (entry) => entry.label === label,
-  );
+type MenuOptions = Parameters<typeof buildWindowsMenu>[0];
+
+const submenu = (
+  label: string,
+  options: MenuOptions = { openAbout: () => undefined },
+): Array<Record<string, unknown>> => {
+  const item = buildWindowsMenu(options).find((entry) => entry.label === label);
   return item?.submenu as Array<Record<string, unknown>>;
 };
 
-const enabled = (menu: string, label: string): unknown =>
-  submenu(menu).find((item) => item.label === label)?.enabled;
+const enabled = (menu: string, label: string, options?: MenuOptions): unknown =>
+  submenu(menu, options).find((item) => item.label === label)?.enabled;
 
 describe("buildWindowsMenu", () => {
   test("uses Windows roles and disables unavailable providers", () => {
@@ -51,6 +54,16 @@ describe("buildWindowsMenu", () => {
     expect(enabled("Help", "Check for Updates...")).toBe(false);
     expect(enabled("File", "Install vellum Command...")).toBe(false);
     expect(enabled("Window", "Pop Out Conversation")).toBe(false);
+  });
+
+  test("enables update and CLI items when handlers are provided", () => {
+    const options = {
+      openAbout: () => undefined,
+      checkForUpdates: () => undefined,
+      installCli: () => undefined,
+    };
+    expect(enabled("Help", "Check for Updates...", options)).toBe(true);
+    expect(enabled("File", "Install vellum Command...", options)).toBe(true);
   });
 
   test("dispatches committed commands to the focused window", () => {


### PR DESCRIPTION
## Summary
- Pass `checkForUpdates` and an `installCli` handler into `installWindowsMenu` so the packaged app's Help > Check for Updates and File > Install vellum Command items are no longer permanently disabled.
- Add `runInstallCliCommandFlow` to `clients/windows/src/main/cli-path-flow.ts`: re-runs the idempotent provisioner (so it doubles as repair), reports the launcher state via a message box, and surfaces failures with `showErrorBox`, mirroring the macOS flow. Startup provisioning in `index.ts` now shares `resolveCliPathFlowOptions`.
- Extend `menu.test.ts` to assert both items are enabled when handlers are passed.

## Original prompt
This came out of a Windows-vs-macOS parity audit on 2026-08-25. Maddie asked to open separate PRs for each P1 gap found; this one covers the disabled "Check for Updates" and "Install CLI" app menu items in the Windows Electron client, which were disabled because `commands.ts` never passed the handlers that `menu.ts` gates on.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41421" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->