### PR TITLE
fix(windows): hotkey recorder modifiers and rebindable Quick Input shortcut

### DIFF
--- a/clients/web/src/domains/settings/keyboard-shortcuts/electron-accelerator.test.ts
+++ b/clients/web/src/domains/settings/keyboard-shortcuts/electron-accelerator.test.ts
@@ -51,6 +51,15 @@ describe("eventToAccelerator", () => {
     );
   });
 
+  it("maps Ctrl to CmdOrCtrl and the Windows key to Super on Windows", () => {
+    expect(
+      eventToAccelerator(keydown({ code: "KeyK", ctrlKey: true }), "windows"),
+    ).toBe("CmdOrCtrl+K");
+    expect(
+      eventToAccelerator(keydown({ code: "KeyK", metaKey: true }), "windows"),
+    ).toBe("Super+K");
+  });
+
   it("resolves arrows, digits, and punctuation from the physical code", () => {
     expect(
       eventToAccelerator(keydown({ code: "ArrowUp", metaKey: true })),

--- a/clients/web/src/domains/settings/keyboard-shortcuts/electron-accelerator.test.ts
+++ b/clients/web/src/domains/settings/keyboard-shortcuts/electron-accelerator.test.ts
@@ -121,4 +121,12 @@ describe("findConflict", () => {
     expect(clash?.key).toBe("find");
     expect(clash?.rebindable).toBe(false);
   });
+
+  it("treats a legacy Windows Control override as CmdOrCtrl", () => {
+    const catalog = [hotkey("newConversation", "Control+Shift+N")];
+    expect(
+      findConflict(catalog, "home", "CmdOrCtrl+Shift+N", "windows")?.key,
+    ).toBe("newConversation");
+    expect(findConflict(catalog, "home", "CmdOrCtrl+Shift+N")).toBeNull();
+  });
 });

--- a/clients/web/src/domains/settings/keyboard-shortcuts/electron-accelerator.ts
+++ b/clients/web/src/domains/settings/keyboard-shortcuts/electron-accelerator.ts
@@ -128,9 +128,9 @@ export const eventToAccelerator = (
 };
 
 /**
- * Modifier spellings Electron treats as the platform's primary modifier.
- * Legacy Windows overrides were recorded as `Control+...`, which Electron
- * binds identically to `CmdOrCtrl+...` there, so both must compare equal.
+ * Modifier spellings Electron binds to the same physical key as `CmdOrCtrl`
+ * on each host (Command on macOS, Control on Windows), so accelerators that
+ * differ only in that spelling are the same chord.
  */
 const PRIMARY_ALIASES: Record<ElectronHostOS, ReadonlySet<string>> = {
   macos: new Set(["Command", "Cmd", "CommandOrControl"]),

--- a/clients/web/src/domains/settings/keyboard-shortcuts/electron-accelerator.ts
+++ b/clients/web/src/domains/settings/keyboard-shortcuts/electron-accelerator.ts
@@ -128,6 +128,29 @@ export const eventToAccelerator = (
 };
 
 /**
+ * Modifier spellings Electron treats as the platform's primary modifier.
+ * Legacy Windows overrides were recorded as `Control+...`, which Electron
+ * binds identically to `CmdOrCtrl+...` there, so both must compare equal.
+ */
+const PRIMARY_ALIASES: Record<ElectronHostOS, ReadonlySet<string>> = {
+  macos: new Set(["Command", "Cmd", "CommandOrControl"]),
+  windows: new Set(["Control", "Ctrl", "CommandOrControl"]),
+};
+
+/** Canonical form of an accelerator for equality checks on `hostOS`. */
+export const normalizeAccelerator = (
+  accelerator: string,
+  hostOS: ElectronHostOS = "macos",
+): string => {
+  const aliases = PRIMARY_ALIASES[hostOS];
+  const parts = accelerator
+    .split("+")
+    .map((part) => (aliases.has(part) ? "CmdOrCtrl" : part));
+  const key = parts.pop() ?? "";
+  return [...new Set(parts)].sort().concat(key).join("+");
+};
+
+/**
  * The first command (other than `excludeKey`) already bound to `accelerator`,
  * or `null` when the accelerator is free. The catalog includes reserved,
  * non-rebindable commands (e.g. Find, Settings), so this also blocks binding
@@ -139,13 +162,18 @@ export const findConflict = (
   catalog: ResolvedHotkey[],
   excludeKey: string,
   accelerator: string,
+  hostOS: ElectronHostOS = "macos",
 ): ResolvedHotkey | null => {
   if (accelerator === "") {
     return null;
   }
+  const wanted = normalizeAccelerator(accelerator, hostOS);
   return (
     catalog.find(
-      (entry) => entry.key !== excludeKey && entry.accelerator === accelerator,
+      (entry) =>
+        entry.key !== excludeKey &&
+        entry.accelerator !== "" &&
+        normalizeAccelerator(entry.accelerator, hostOS) === wanted,
     ) ?? null
   );
 };

--- a/clients/web/src/domains/settings/keyboard-shortcuts/electron-accelerator.ts
+++ b/clients/web/src/domains/settings/keyboard-shortcuts/electron-accelerator.ts
@@ -1,4 +1,5 @@
 import type { ResolvedHotkey } from "@/runtime/hotkeys";
+import type { ElectronHostOS } from "@/runtime/platform-detection";
 
 /**
  * Converts a captured browser `KeyboardEvent` into an Electron
@@ -86,21 +87,35 @@ const mainKeyFromEvent = (event: KeyboardEvent): string | null => {
 /**
  * Build an Electron accelerator from a captured keydown, or `null` when the
  * event has no bindable key (e.g. a lone modifier press while the user is
- * still composing the chord). Command maps to `CmdOrCtrl` to match the
- * compiled defaults; the physical Control key maps to `Control`.
+ * still composing the chord). The host's primary modifier (Command on macOS,
+ * Ctrl on Windows) maps to `CmdOrCtrl` so a recorded chord compares equal to
+ * the compiled defaults; the other one maps to its literal Electron name
+ * (`Control` on macOS, `Super` for the Windows key).
  */
-export const eventToAccelerator = (event: KeyboardEvent): string | null => {
+export const eventToAccelerator = (
+  event: KeyboardEvent,
+  hostOS: ElectronHostOS = "macos",
+): string | null => {
   const key = mainKeyFromEvent(event);
   if (key === null) {
     return null;
   }
 
   const modifiers: string[] = [];
-  if (event.metaKey) {
-    modifiers.push("CmdOrCtrl");
-  }
-  if (event.ctrlKey) {
-    modifiers.push("Control");
+  if (hostOS === "windows") {
+    if (event.ctrlKey) {
+      modifiers.push("CmdOrCtrl");
+    }
+    if (event.metaKey) {
+      modifiers.push("Super");
+    }
+  } else {
+    if (event.metaKey) {
+      modifiers.push("CmdOrCtrl");
+    }
+    if (event.ctrlKey) {
+      modifiers.push("Control");
+    }
   }
   if (event.altKey) {
     modifiers.push("Alt");

--- a/clients/web/src/domains/settings/keyboard-shortcuts/use-hotkey-recorder.ts
+++ b/clients/web/src/domains/settings/keyboard-shortcuts/use-hotkey-recorder.ts
@@ -88,15 +88,13 @@ export function useHotkeyRecorder(options?: {
         return;
       }
 
-      const accelerator = eventToAccelerator(
-        event,
-        detectElectronHostOS() ?? "macos",
-      );
+      const hostOS = detectElectronHostOS() ?? "macos";
+      const accelerator = eventToAccelerator(event, hostOS);
       if (accelerator === null) {
         return;
       }
 
-      const clash = findConflict(catalog, recordingKey, accelerator);
+      const clash = findConflict(catalog, recordingKey, accelerator, hostOS);
       if (clash !== null) {
         setConflict({ key: recordingKey, label: clash.label });
         return;
@@ -136,7 +134,12 @@ export function useHotkeyRecorder(options?: {
       // blindly would resurrect that accelerator and shadow the other binding.
       const fallback =
         catalog.find((entry) => entry.key === key)?.defaultAccelerator ?? "";
-      const clash = findConflict(catalog, key, fallback);
+      const clash = findConflict(
+        catalog,
+        key,
+        fallback,
+        detectElectronHostOS() ?? "macos",
+      );
       if (clash !== null) {
         setRecordingKey(null);
         setConflict({ key, label: clash.label });

--- a/clients/web/src/domains/settings/keyboard-shortcuts/use-hotkey-recorder.ts
+++ b/clients/web/src/domains/settings/keyboard-shortcuts/use-hotkey-recorder.ts
@@ -6,6 +6,7 @@ import {
   setHotkey,
   type ResolvedHotkey,
 } from "@/runtime/hotkeys";
+import { detectElectronHostOS } from "@/runtime/platform-detection";
 
 import {
   eventToAccelerator,
@@ -87,7 +88,10 @@ export function useHotkeyRecorder(options?: {
         return;
       }
 
-      const accelerator = eventToAccelerator(event);
+      const accelerator = eventToAccelerator(
+        event,
+        detectElectronHostOS() ?? "macos",
+      );
       if (accelerator === null) {
         return;
       }

--- a/clients/windows/src/main/auxiliary-windows.test.ts
+++ b/clients/windows/src/main/auxiliary-windows.test.ts
@@ -80,7 +80,8 @@ const logWarn = mock(() => undefined);
 mock.module("electron", () => ({
   app: {
     isPackaged: false,
-    on: (event: string, listener: Listener) => appListeners.set(event, listener),
+    on: (event: string, listener: Listener) =>
+      appListeners.set(event, listener),
     off: (event: string) => appListeners.delete(event),
   },
   BrowserWindow: class {
@@ -130,6 +131,8 @@ mock.module("./logger", () => ({
 
 const { default: auxiliaryWindowsModule } =
   await import("./features/auxiliary-windows");
+const { toggleQuickInput } =
+  await import("@vellumai/electron-desktop/quick-input-window");
 beforeAll(() => {
   auxiliaryWindowsModule.install({} as never);
 });
@@ -164,7 +167,7 @@ describe("Windows auxiliary windows", () => {
 
   test("opens Quick Input from the Windows shortcut and closes on blur", () => {
     workArea = { x: 1600, y: 40, width: 1200, height: 800 };
-    shortcutListeners.get("Control+Shift+/")?.();
+    toggleQuickInput();
     const { options, window } = created[0]!;
     window.emit("ready-to-show");
     expect(options.browserWindow).toMatchObject({
@@ -264,7 +267,7 @@ describe("Windows auxiliary windows", () => {
 
   test("repositions transient windows after a display change", () => {
     handleListeners.get("vellum:commandPalette:open")?.([]);
-    shortcutListeners.get("Control+Shift+/")?.();
+    toggleQuickInput();
     onListeners.get("vellum:dictationOverlay:setState")?.([
       { kind: "recording", transcription: "" },
     ]);

--- a/clients/windows/src/main/features/auxiliary-windows.ts
+++ b/clients/windows/src/main/features/auxiliary-windows.ts
@@ -1,4 +1,4 @@
-import { app, globalShortcut, screen } from "electron";
+import { app, screen } from "electron";
 
 import {
   configureCommandPaletteWindow,
@@ -26,14 +26,10 @@ import {
   configureQuickInputWindow,
   installQuickInput,
   repositionQuickInputWindow,
-  toggleQuickInput,
 } from "@vellumai/electron-desktop/quick-input-window";
 
 import { getRendererBase } from "../app-config";
-import {
-  installEscapeMonitor,
-  setDictationRecording,
-} from "../escape-monitor";
+import { installEscapeMonitor, setDictationRecording } from "../escape-monitor";
 import { handle, on } from "../ipc.client";
 import log from "../logger";
 import { current, dispatchToMain, ensureVisible } from "../main-window";
@@ -82,10 +78,6 @@ const module: CapabilityModule<DesktopCapabilityRegistry> = {
     installQuickInput();
     installDictationOverlay({ onRecordingLifecycle: setDictationRecording });
     installPopoutWindows();
-
-    if (!globalShortcut.register("Control+Shift+/", toggleQuickInput)) {
-      log.warn("[auxiliary-windows] failed to register Quick Input shortcut");
-    }
 
     const repositionTransientWindows = (): void => {
       repositionCommandPaletteWindow();

--- a/clients/windows/src/main/features/commands.ts
+++ b/clients/windows/src/main/features/commands.ts
@@ -16,6 +16,7 @@ import {
 import { installGlobalShortcuts } from "@vellumai/electron-desktop/global-shortcuts";
 import { installHotkeysIpc } from "@vellumai/electron-desktop/hotkeys";
 import { installImageContextMenu } from "@vellumai/electron-desktop/image-context-menu";
+import { toggleQuickInput } from "@vellumai/electron-desktop/quick-input-window";
 import { installTextContextMenu } from "@vellumai/electron-desktop/text-context-menu";
 
 import { getRendererBase } from "../app-config";
@@ -43,6 +44,9 @@ const commandsFeature: CapabilityModule<DesktopCapabilityRegistry> = {
         globalHotkey: () => {
           void ensureVisible();
         },
+        // Bound here, not in auxiliary-windows, so the user's rebinding in
+        // Keyboard Shortcuts applies and the chord is registered once.
+        quickInput: toggleQuickInput,
         // Talk, from wherever the user is. `registerAll` skips a command with
         // no handler, so without this the binding would be offered in both
         // Keyboard Shortcuts and Voice settings, show as bound, and do

--- a/clients/windows/src/main/features/commands.ts
+++ b/clients/windows/src/main/features/commands.ts
@@ -44,8 +44,8 @@ const commandsFeature: CapabilityModule<DesktopCapabilityRegistry> = {
         globalHotkey: () => {
           void ensureVisible();
         },
-        // Bound here, not in auxiliary-windows, so the user's rebinding in
-        // Keyboard Shortcuts applies and the chord is registered once.
+        // Registered through installGlobalShortcuts so the Keyboard
+        // Shortcuts rebinding applies and the chord is bound exactly once.
         quickInput: toggleQuickInput,
         // Talk, from wherever the user is. `registerAll` skips a command with
         // no handler, so without this the binding would be offered in both


### PR DESCRIPTION
## Summary
- The Keyboard Shortcuts recorder now takes the host OS: on Windows Ctrl maps to `CmdOrCtrl` (matching the compiled defaults, so conflict detection works) and the Windows key maps to `Super`. macOS behavior is unchanged.
- Quick Input on Windows is no longer hardcoded to `Control+Shift+/` in `auxiliary-windows.ts`; it is registered via the shared `installGlobalShortcuts` `quickInput` handler, so rebinding in settings applies and the chord is registered exactly once.

## Original prompt
Part of a batch of Windows client parity fixes. The hotkey recorder mapped Ctrl to `Control` and Win to `CmdOrCtrl` on Windows, so conflict detection against the `CmdOrCtrl+` defaults silently failed. The Quick Input shortcut was hardcoded, ignored rebinding, and double-registered with the hotkeys module.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41422" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->