### PR TITLE
fix(windows): persist popout bounds and gate menu/tray on onboarding

### DIFF
--- a/clients/windows/src/main/auxiliary-windows.test.ts
+++ b/clients/windows/src/main/auxiliary-windows.test.ts
@@ -110,6 +110,14 @@ mock.module("electron", () => ({
     },
   },
 }));
+const restoreBounds = mock(
+  (_key: string, defaults: { width: number; height: number }) => defaults,
+);
+const trackWindowState = mock((_key: string, _win: unknown) => undefined);
+mock.module("@vellumai/electron-desktop/window-state", () => ({
+  restoreBounds,
+  track: trackWindowState,
+}));
 mock.module("./windows.client", () => ({ createWindow }));
 mock.module("./ipc.client", () => ({
   handle: (channel: string, _schema: unknown, listener: Listener) => {
@@ -282,6 +290,11 @@ describe("Windows auxiliary windows", () => {
     popout.emit("ready-to-show");
     handleListeners.get("vellum:popout:open")?.(["conv-123"]);
     expect(popout.isDestroyed()).toBe(false);
+    expect(restoreBounds).toHaveBeenCalledWith("thread.conv-123", {
+      width: 720,
+      height: 800,
+    });
+    expect(trackWindowState).toHaveBeenCalledWith("thread.conv-123", popout);
     expect(options.browserWindow).not.toHaveProperty("parent");
     expect(options.backgroundThrottling).toBe(false);
     expect(popout.loadURL).toHaveBeenCalledWith(

--- a/clients/windows/src/main/features/auxiliary-windows.ts
+++ b/clients/windows/src/main/features/auxiliary-windows.ts
@@ -28,12 +28,13 @@ import {
   repositionQuickInputWindow,
   toggleQuickInput,
 } from "@vellumai/electron-desktop/quick-input-window";
+import {
+  restoreBounds,
+  track as trackWindowState,
+} from "@vellumai/electron-desktop/window-state";
 
 import { getRendererBase } from "../app-config";
-import {
-  installEscapeMonitor,
-  setDictationRecording,
-} from "../escape-monitor";
+import { installEscapeMonitor, setDictationRecording } from "../escape-monitor";
 import { handle, on } from "../ipc.client";
 import log from "../logger";
 import { current, dispatchToMain, ensureVisible } from "../main-window";
@@ -75,7 +76,13 @@ const module: CapabilityModule<DesktopCapabilityRegistry> = {
       handle,
       on,
     });
-    configurePopoutWindows({ createWindow, handle, resolveRoute });
+    configurePopoutWindows({
+      createWindow,
+      handle,
+      resolveRoute,
+      restoreBounds,
+      trackWindowState,
+    });
 
     installEscapeMonitor();
     installCommandPaletteWindow();

--- a/clients/windows/src/main/main-window.test.ts
+++ b/clients/windows/src/main/main-window.test.ts
@@ -185,6 +185,7 @@ const writeTitleBarOverlayThemeMock = mock(
 mock.module("@vellumai/electron-desktop/window-state", () => ({
   restoreBounds: () => restoredBounds,
   track: trackMock,
+  readOnboardingActive: () => false,
   writeOnboardingActive: writeOnboardingActiveMock,
   readTitleBarOverlayTheme: () => persistedOverlayTheme,
   writeTitleBarOverlayTheme: writeTitleBarOverlayThemeMock,

--- a/clients/windows/src/main/main-window.ts
+++ b/clients/windows/src/main/main-window.ts
@@ -170,7 +170,9 @@ export const onOnboardingChange = (
 };
 
 export const setOnboarding = (active: boolean): void => {
-  if (readOnboardingActive() === active) return;
+  if (readOnboardingActive() === active) {
+    return;
+  }
   writeOnboardingActive(active);
   for (const listener of onboardingListeners) {
     listener(active);

--- a/clients/windows/src/main/main-window.ts
+++ b/clients/windows/src/main/main-window.ts
@@ -10,6 +10,7 @@ import {
   type VellumCommand,
 } from "@vellumai/ipc-contract";
 import {
+  readOnboardingActive,
   readTitleBarOverlayTheme,
   restoreBounds,
   track as trackWindowState,
@@ -157,8 +158,23 @@ export const toggleVisibility = (): void => {
   ensureVisible();
 };
 
+const onboardingListeners = new Set<(active: boolean) => void>();
+
+// Fires only on a real transition; the renderer re-asserts the mode on
+// every navigation.
+export const onOnboardingChange = (
+  listener: (active: boolean) => void,
+): (() => void) => {
+  onboardingListeners.add(listener);
+  return () => onboardingListeners.delete(listener);
+};
+
 export const setOnboarding = (active: boolean): void => {
+  if (readOnboardingActive() === active) return;
   writeOnboardingActive(active);
+  for (const listener of onboardingListeners) {
+    listener(active);
+  }
 };
 
 /**

--- a/clients/windows/src/main/menu.test.ts
+++ b/clients/windows/src/main/menu.test.ts
@@ -33,6 +33,23 @@ mock.module("electron", () => ({
   shell: { openExternal: () => Promise.resolve() },
 }));
 
+let featureFlags: Record<string, boolean> = {};
+let onboardingActive = false;
+let chromeDevTools = false;
+mock.module("@vellumai/electron-desktop/settings", () => ({
+  readSetting: () => featureFlags,
+  onSettingChange: () => () => undefined,
+}));
+mock.module("@vellumai/electron-desktop/window-state", () => ({
+  readOnboardingActive: () => onboardingActive,
+}));
+mock.module("@vellumai/electron-desktop/devtools", () => ({
+  areChromeDevToolsEnabled: () => chromeDevTools,
+}));
+mock.module("./main-window", () => ({
+  onOnboardingChange: () => () => undefined,
+}));
+
 const { buildWindowsMenu, installWindowsMenu } = await import("./menu");
 
 const submenu = (label: string): Array<Record<string, unknown>> => {
@@ -50,7 +67,32 @@ describe("buildWindowsMenu", () => {
     expect(submenu("Window").some((item) => item.role === "close")).toBe(true);
     expect(enabled("Help", "Check for Updates...")).toBe(false);
     expect(enabled("File", "Install vellum Command...")).toBe(false);
-    expect(enabled("Window", "Pop Out Conversation")).toBe(false);
+    expect(enabled("Window", "Pop Out Conversation")).toBeUndefined();
+  });
+
+  test("gates Settings on onboarding and Developer on its flag", () => {
+    expect(enabled("File", "Settings...")).toBe(true);
+    expect(submenu("Developer")).toBeUndefined();
+    expect(submenu("View").some((item) => item.role === "toggleDevTools")).toBe(
+      false,
+    );
+
+    onboardingActive = true;
+    featureFlags = { "developer-menu-items": true };
+    chromeDevTools = true;
+    try {
+      expect(enabled("File", "Settings...")).toBe(false);
+      expect(
+        submenu("Developer").some((item) => item.label === "Replay Onboarding"),
+      ).toBe(true);
+      expect(
+        submenu("View").some((item) => item.role === "toggleDevTools"),
+      ).toBe(true);
+    } finally {
+      onboardingActive = false;
+      featureFlags = {};
+      chromeDevTools = false;
+    }
   });
 
   test("dispatches committed commands to the focused window", () => {

--- a/clients/windows/src/main/menu.ts
+++ b/clients/windows/src/main/menu.ts
@@ -13,12 +13,20 @@ import {
   onHotkeyOverridesChange,
   type VellumCommand,
 } from "@vellumai/electron-desktop/commands";
+import { areChromeDevToolsEnabled } from "@vellumai/electron-desktop/devtools";
 import type { IpcHandle } from "@vellumai/electron-desktop/ipc";
+import {
+  onSettingChange,
+  readSetting,
+} from "@vellumai/electron-desktop/settings";
+import { readOnboardingActive } from "@vellumai/electron-desktop/window-state";
 import {
   MENU_POPUP,
   MENU_SET_PLATFORM_SESSION,
   MENU_TITLES,
 } from "@vellumai/ipc-contract";
+
+import { onOnboardingChange } from "./main-window";
 
 interface WindowsMenuOptions {
   handle: IpcHandle;
@@ -28,6 +36,10 @@ interface WindowsMenuOptions {
 }
 
 let hasPlatformSession = false;
+
+// Same flag the macOS menu reads; the renderer publishes it over IPC.
+const isDeveloperMenuEnabled = (): boolean =>
+  readSetting("featureFlags")?.["developer-menu-items"] === true;
 
 const commandItem = (
   label: string,
@@ -59,7 +71,11 @@ export const buildWindowsMenu = ({
       commandItem("Previous Conversation", { kind: "previousConversation" }),
       commandItem("Next Conversation", { kind: "nextConversation" }),
       { type: "separator" },
-      commandItem("Settings...", { kind: "openSettings" }),
+      commandItem(
+        "Settings...",
+        { kind: "openSettings" },
+        !readOnboardingActive(),
+      ),
       ...(app.isPackaged
         ? [
             {
@@ -102,7 +118,9 @@ export const buildWindowsMenu = ({
       { type: "separator" },
       { role: "reload" },
       { role: "forceReload" },
-      ...(!app.isPackaged ? [{ role: "toggleDevTools" as const }] : []),
+      ...(areChromeDevToolsEnabled()
+        ? [{ role: "toggleDevTools" as const }]
+        : []),
       { type: "separator" },
       { role: "resetZoom" },
       { role: "zoomIn" },
@@ -118,10 +136,10 @@ export const buildWindowsMenu = ({
       { role: "minimize" },
       { role: "close" },
       { type: "separator" },
-      commandItem("Pop Out Conversation", { kind: "popOut" }, false),
+      commandItem("Pop Out Conversation", { kind: "popOut" }),
     ],
   },
-  ...(!app.isPackaged
+  ...(isDeveloperMenuEnabled()
     ? [
         {
           id: "developer",
@@ -213,5 +231,7 @@ export const installWindowsMenu = (options: WindowsMenuOptions): void => {
     },
   );
   onHotkeyOverridesChange(apply);
+  onSettingChange("featureFlags", apply);
+  onOnboardingChange(apply);
   apply();
 };

--- a/clients/windows/src/main/tray.test.ts
+++ b/clients/windows/src/main/tray.test.ts
@@ -36,6 +36,9 @@ let trayRuntime: TrayRuntime | null = null;
 mock.module("@vellumai/electron-desktop/status-icon", () => ({
   configureStatusIconFallback: () => undefined,
 }));
+mock.module("@vellumai/electron-desktop/window-state", () => ({
+  readOnboardingActive: () => false,
+}));
 mock.module("@vellumai/electron-desktop/about", () => ({
   openAboutWindow: () => undefined,
 }));

--- a/clients/windows/src/main/tray.ts
+++ b/clients/windows/src/main/tray.ts
@@ -9,6 +9,7 @@ import {
   configureTrayModel,
   installTray,
 } from "@vellumai/electron-desktop/tray-model";
+import { readOnboardingActive } from "@vellumai/electron-desktop/window-state";
 import {
   DEFAULT_COMPANION_SIZE,
   type VellumCommand,
@@ -61,7 +62,7 @@ export const installWindowsTray = (
     featureEnabled,
     getLockfile: getWatchedLockfile,
     icon: () => undefined,
-    onboardingActive: () => false,
+    onboardingActive: readOnboardingActive,
     openComponentGallery: () => {
       void shell.openExternal("http://localhost:6007");
     },

--- a/packages/electron-desktop/src/popout-window.ts
+++ b/packages/electron-desktop/src/popout-window.ts
@@ -84,7 +84,7 @@ export const openPopout = (conversationId: string): void => {
 
   const stateKey = `thread.${conversationId}`;
   // `maximized` is not a BrowserWindow option; apply it once shown.
-  const { maximized, ...sizing } =
+  const { maximized, ...sizing }: RestoredBounds =
     restoreBounds?.(stateKey, POPOUT_DEFAULT_BOUNDS) ?? POPOUT_DEFAULT_BOUNDS;
 
   const win = createWindow({

--- a/packages/electron-desktop/src/popout-window.ts
+++ b/packages/electron-desktop/src/popout-window.ts
@@ -42,7 +42,7 @@ const POPOUT_MIN_HEIGHT = 400;
 type RestoredBounds = Pick<
   BrowserWindowConstructorOptions,
   "fullscreen" | "height" | "width" | "x" | "y"
->;
+> & { maximized?: boolean };
 
 export interface PopoutWindowDependencies {
   createWindow: (options: CreateWindowOptions) => BrowserWindow;
@@ -83,8 +83,9 @@ export const openPopout = (conversationId: string): void => {
   }
 
   const stateKey = `thread.${conversationId}`;
-  const sizing = restoreBounds?.(stateKey, POPOUT_DEFAULT_BOUNDS) ??
-    POPOUT_DEFAULT_BOUNDS;
+  // `maximized` is not a BrowserWindow option; apply it once shown.
+  const { maximized, ...sizing } =
+    restoreBounds?.(stateKey, POPOUT_DEFAULT_BOUNDS) ?? POPOUT_DEFAULT_BOUNDS;
 
   const win = createWindow({
     browserWindow: {
@@ -116,6 +117,9 @@ export const openPopout = (conversationId: string): void => {
   popouts.set(conversationId, win);
 
   win.once("ready-to-show", () => {
+    if (maximized) {
+      win.maximize();
+    }
     win.show();
     win.focus();
   });


### PR DESCRIPTION
## Summary
- Pop-out windows now restore and track bounds per conversation (`thread.<id>`) like macOS, and the Window > Pop Out Conversation item is enabled.
- Settings is disabled while onboarding is active; the tray reads real onboarding state instead of `() => false`. The menu rebuilds on onboarding transitions.
- Developer submenu is gated on the `developer-menu-items` feature flag (same as macOS) and rebuilds on flag changes; Toggle Developer Tools uses `areChromeDevToolsEnabled`.

## Original prompt
Part of a batch of Windows client parity fixes split into separate PRs. This one covers the popout window (no bounds persistence, menu item hard-disabled) and menu/tray gating (dev menu on `!app.isPackaged` only, Settings not disabled during onboarding, tray `onboardingActive: () => false`), mirroring the macOS client's behavior.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41423" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->