### PR TITLE
feat(windows): implement computer-use drag and open_app

### DIFF
--- a/assistant/src/config/bundled-skills/computer-use/TOOLS.json
+++ b/assistant/src/config/bundled-skills/computer-use/TOOLS.json
@@ -198,7 +198,7 @@
       },
       "executor": "tools/computer-use-drag.ts",
       "execution_target": "host",
-      "supported_client_os": ["macos"]
+      "supported_client_os": ["macos", "windows"]
     },
     {
       "name": "computer_use_wait",
@@ -251,7 +251,7 @@
       },
       "executor": "tools/computer-use-open-app.ts",
       "execution_target": "host",
-      "supported_client_os": ["macos"]
+      "supported_client_os": ["macos", "windows"]
     },
     {
       "name": "computer_use_run_applescript",

--- a/assistant/src/tools/computer-use/definitions.ts
+++ b/assistant/src/tools/computer-use/definitions.ts
@@ -224,7 +224,7 @@ export const computerUseDragTool = {
   category: "computer-use",
   defaultRiskLevel: RiskLevel.Low,
   executionTarget: "host",
-  supportedClientOs: ["macos"],
+  supportedClientOs: ["macos", "windows"],
 
   input_schema: {
     type: "object",
@@ -317,7 +317,7 @@ export const computerUseOpenAppTool = {
   category: "computer-use",
   defaultRiskLevel: RiskLevel.Low,
   executionTarget: "host",
-  supportedClientOs: ["macos"],
+  supportedClientOs: ["macos", "windows"],
 
   input_schema: {
     type: "object",

--- a/clients/windows/native/Vellum.WindowsHelper.Tests/InputControllerTests.cs
+++ b/clients/windows/native/Vellum.WindowsHelper.Tests/InputControllerTests.cs
@@ -86,7 +86,7 @@ public static class InputControllerTests
         };
         Check(AppLauncher.FindMatch(apps, "chrome", "Google Chrome") == "chrome.lnk", "app alias match");
         Check(AppLauncher.FindMatch(apps, "slack", "slack") == "slack.lnk", "app exact beats prefix");
-        Check(AppLauncher.FindMatch(apps, "sla", "sla") == "slack-beta.lnk", "app unique prefix");
+        Check(AppLauncher.FindMatch(apps, "goog", "goog") == "chrome.lnk", "app unique prefix");
         Check(AppLauncher.FindMatch(apps, "zoom", "zoom") is null, "app missing");
         try
         {

--- a/clients/windows/native/Vellum.WindowsHelper.Tests/InputControllerTests.cs
+++ b/clients/windows/native/Vellum.WindowsHelper.Tests/InputControllerTests.cs
@@ -69,6 +69,19 @@ public static class InputControllerTests
         Check(InputController.MapAction("computer_use_screenshot", null).Type == "observe", "screenshot observes");
         Check(InputController.MapAction("computer_use_press_key", null).Type == "key", "press_key");
 
+        // Drag carries a destination by coordinates or element id.
+        using var dragInput = JsonDocument.Parse("{\"element_id\":1,\"to_x\":50,\"to_y\":60}");
+        var drag = InputController.MapAction("computer_use_drag", dragInput.RootElement);
+        Check(drag.Type == "drag" && drag.ElementId == 1 && drag.ToX == 50 && drag.ToY == 60, "drag mapping");
+
+        // App names resolve through aliases and Start Menu shortcut stems.
+        Check(AppLauncher.Resolve("vscode") == "Visual Studio Code", "app alias");
+        var shortcuts = new[] { @"C:\sm\Google Chrome.lnk", @"C:\sm\Slack Beta.lnk", @"C:\sm\Slack.lnk" };
+        Check(AppLauncher.FindShortcut(shortcuts, "chrome", "Google Chrome") == shortcuts[0], "shortcut alias");
+        Check(AppLauncher.FindShortcut(shortcuts, "slack", "slack") == shortcuts[2], "shortcut exact beats prefix");
+        Check(AppLauncher.FindShortcut(shortcuts, "sla", "sla") == shortcuts[1], "shortcut prefix");
+        Check(AppLauncher.FindShortcut(shortcuts, "zoom", "zoom") is null, "shortcut missing");
+
         var module = new InputController();
 
         // An unrecognized tool reports an unsupported action instead of ending
@@ -87,6 +100,16 @@ public static class InputControllerTests
         CheckContains(
             await InvokeAsync(module, "conv-element", "computer_use_click", "{\"element_id\":3}"),
             "was not found", "unknown element");
+
+        // Drag resolves both endpoints; a missing destination fails before input.
+        var dragResolved = await InputController.ResolveElementCoordinatesAsync(
+            new CuAction("drag", X: 1, Y: 2, ToElementId: 7),
+            new FakeObservationSource(new CuPoint(40, 60)),
+            CancellationToken.None);
+        Check(dragResolved.ToX == 40 && dragResolved.ToY == 60, "drag destination resolves");
+        CheckContains(
+            await InvokeAsync(module, "conv-drag", "computer_use_drag", "{\"x\":1,\"y\":2}"),
+            "Destination coordinates", "drag needs destination");
 
         var resolved = await InputController.ResolveElementCoordinatesAsync(
             new CuAction("click", ElementId: 7),

--- a/clients/windows/native/Vellum.WindowsHelper.Tests/InputControllerTests.cs
+++ b/clients/windows/native/Vellum.WindowsHelper.Tests/InputControllerTests.cs
@@ -76,11 +76,27 @@ public static class InputControllerTests
 
         // App names resolve through aliases and Start Menu shortcut stems.
         Check(AppLauncher.Resolve("vscode") == "Visual Studio Code", "app alias");
-        var shortcuts = new[] { @"C:\sm\Google Chrome.lnk", @"C:\sm\Slack Beta.lnk", @"C:\sm\Slack.lnk" };
-        Check(AppLauncher.FindShortcut(shortcuts, "chrome", "Google Chrome") == shortcuts[0], "shortcut alias");
-        Check(AppLauncher.FindShortcut(shortcuts, "slack", "slack") == shortcuts[2], "shortcut exact beats prefix");
-        Check(AppLauncher.FindShortcut(shortcuts, "sla", "sla") == shortcuts[1], "shortcut prefix");
-        Check(AppLauncher.FindShortcut(shortcuts, "zoom", "zoom") is null, "shortcut missing");
+        var apps = new[]
+        {
+            new AppLauncher.AppEntry("Google Chrome", "chrome.lnk"),
+            new AppLauncher.AppEntry("Slack Beta", "slack-beta.lnk"),
+            new AppLauncher.AppEntry("Slack", "slack.lnk"),
+            new AppLauncher.AppEntry("Visual Studio Code", "code.lnk"),
+            new AppLauncher.AppEntry("Visual Studio Installer", "vsi.lnk"),
+        };
+        Check(AppLauncher.FindMatch(apps, "chrome", "Google Chrome") == "chrome.lnk", "app alias match");
+        Check(AppLauncher.FindMatch(apps, "slack", "slack") == "slack.lnk", "app exact beats prefix");
+        Check(AppLauncher.FindMatch(apps, "sla", "sla") == "slack-beta.lnk", "app unique prefix");
+        Check(AppLauncher.FindMatch(apps, "zoom", "zoom") is null, "app missing");
+        try
+        {
+            AppLauncher.FindMatch(apps, "Visual Studio", "Visual Studio");
+            throw new Exception("Ambiguous prefix was accepted");
+        }
+        catch (InvalidOperationException err)
+        {
+            Check(err.Message.Contains("Visual Studio Installer", StringComparison.Ordinal), "app ambiguous prefix");
+        }
 
         var module = new InputController();
 

--- a/clients/windows/native/Vellum.WindowsHelper/Modules/ActionVerifier.cs
+++ b/clients/windows/native/Vellum.WindowsHelper/Modules/ActionVerifier.cs
@@ -10,6 +10,7 @@ public sealed record CuAction(
     string Type,
     double? X = null, double? Y = null,
     long? ElementId = null,
+    double? ToX = null, double? ToY = null, long? ToElementId = null,
     string? Text = null, string? Key = null,
     string? ScrollDirection = null, int? ScrollAmount = null,
     int? WaitDurationMs = null, string? AppName = null, string? Script = null);
@@ -141,7 +142,7 @@ public sealed class ActionVerifier(int maxSteps = 50)
                 _ => false,
             };
         }
-        return a.X == b.X && a.Y == b.Y;
+        return a.X == b.X && a.Y == b.Y && a.ToX == b.ToX && a.ToY == b.ToY;
     }
 }
 

--- a/clients/windows/native/Vellum.WindowsHelper/Modules/AppLauncher.cs
+++ b/clients/windows/native/Vellum.WindowsHelper/Modules/AppLauncher.cs
@@ -105,8 +105,7 @@ public static partial class AppLauncher
             return $"switched to {resolved}";
         }
 
-        var target = FindMatch(StartMenuShortcuts(), name, resolved)
-            ?? FindMatch(AppsFolderEntries(), name, resolved)
+        var target = FindMatch(StartMenuShortcuts().Concat(AppsFolderEntries()), name, resolved)
             ?? (ShellCommands.TryGetValue(resolved, out var command) ? command : resolved);
         try
         {
@@ -122,9 +121,9 @@ public static partial class AppLauncher
     }
 
     // Brings forward the first visible top-level window whose process name or
-    // title matches; a minimized window is restored first. A found window counts
-    // as activated even if foreground-lock rules reject the switch, so a live
-    // app is never relaunched into a duplicate instance.
+    // title matches; a minimized window is restored first. A live window that
+    // foreground-lock rules refuse to raise is an error, never a relaunch or a
+    // silent success.
     private static bool ActivateRunning(string name, string resolved)
     {
         foreach (var process in Process.GetProcesses())
@@ -139,7 +138,11 @@ public static partial class AppLauncher
                 {
                     _ = ShowWindow(process.MainWindowHandle, 9); // SW_RESTORE
                 }
-                _ = SetForegroundWindow(process.MainWindowHandle);
+                if (!SetForegroundWindow(process.MainWindowHandle))
+                {
+                    throw new InvalidOperationException(
+                        $"{resolved} is running but Windows refused to bring it to the foreground");
+                }
                 return true;
             }
         }

--- a/clients/windows/native/Vellum.WindowsHelper/Modules/AppLauncher.cs
+++ b/clients/windows/native/Vellum.WindowsHelper/Modules/AppLauncher.cs
@@ -130,15 +130,24 @@ public static partial class AppLauncher
         {
             using (process)
             {
-                if (process.MainWindowHandle == IntPtr.Zero || !Matches(process, name, resolved))
+                IntPtr handle;
+                try
                 {
-                    continue;
+                    handle = process.MainWindowHandle;
+                    if (handle == IntPtr.Zero || !Matches(process, name, resolved))
+                    {
+                        continue;
+                    }
                 }
-                if (IsIconic(process.MainWindowHandle))
+                catch (Exception err) when (err is InvalidOperationException or System.ComponentModel.Win32Exception)
                 {
-                    _ = ShowWindow(process.MainWindowHandle, 9); // SW_RESTORE
+                    continue; // exited or inaccessible mid-enumeration
                 }
-                if (!SetForegroundWindow(process.MainWindowHandle))
+                if (IsIconic(handle))
+                {
+                    _ = ShowWindow(handle, 9); // SW_RESTORE
+                }
+                if (!SetForegroundWindow(handle))
                 {
                     throw new InvalidOperationException(
                         $"{resolved} is running but Windows refused to bring it to the foreground");
@@ -151,20 +160,11 @@ public static partial class AppLauncher
 
     private static bool Matches(Process process, string name, string resolved)
     {
-        string title;
-        try
-        {
-            title = process.MainWindowTitle;
-        }
-        catch (InvalidOperationException)
-        {
-            return false;
-        }
         var compact = resolved.Replace(" ", "", StringComparison.Ordinal);
         return process.ProcessName.Equals(compact, StringComparison.OrdinalIgnoreCase) ||
             process.ProcessName.Equals(name, StringComparison.OrdinalIgnoreCase) ||
-            title.Equals(resolved, StringComparison.OrdinalIgnoreCase) ||
-            title.EndsWith("- " + resolved, StringComparison.OrdinalIgnoreCase);
+            process.MainWindowTitle.Equals(resolved, StringComparison.OrdinalIgnoreCase) ||
+            process.MainWindowTitle.EndsWith("- " + resolved, StringComparison.OrdinalIgnoreCase);
     }
 
     [LibraryImport("user32.dll")]

--- a/clients/windows/native/Vellum.WindowsHelper/Modules/AppLauncher.cs
+++ b/clients/windows/native/Vellum.WindowsHelper/Modules/AppLauncher.cs
@@ -1,0 +1,136 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace Vellum.WindowsHelper.Modules;
+
+// Resolves a human app name the way the macOS helper does: activate a running
+// app first, then launch via Start Menu shortcuts, then shell execution.
+public static partial class AppLauncher
+{
+    private static readonly Dictionary<string, string> Aliases = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["chrome"] = "Google Chrome", ["vs code"] = "Visual Studio Code", ["vscode"] = "Visual Studio Code",
+        ["edge"] = "Microsoft Edge", ["word"] = "Word", ["excel"] = "Excel", ["powerpoint"] = "PowerPoint",
+        ["outlook"] = "Outlook", ["explorer"] = "File Explorer", ["file explorer"] = "File Explorer",
+        ["terminal"] = "Windows Terminal", ["cmd"] = "Command Prompt", ["notepad"] = "Notepad",
+    };
+
+    // Names that resolve straight to a shell command instead of a shortcut.
+    private static readonly Dictionary<string, string> ShellCommands = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["File Explorer"] = "explorer.exe", ["Command Prompt"] = "cmd.exe", ["Notepad"] = "notepad.exe",
+        ["Calculator"] = "calc.exe", ["Settings"] = "ms-settings:", ["Windows Terminal"] = "wt.exe",
+    };
+
+    public static string Resolve(string name) => Aliases.TryGetValue(name.Trim(), out var alias) ? alias : name.Trim();
+
+    // Case-insensitive match on a shortcut's file name, trying the resolved
+    // name and the raw name; an exact match beats a prefix match.
+    public static string? FindShortcut(IEnumerable<string> shortcutPaths, string name, string resolved)
+    {
+        string? prefix = null;
+        foreach (var path in shortcutPaths)
+        {
+            var stem = Path.GetFileNameWithoutExtension(path);
+            if (stem.Equals(resolved, StringComparison.OrdinalIgnoreCase) ||
+                stem.Equals(name, StringComparison.OrdinalIgnoreCase))
+            {
+                return path;
+            }
+            prefix ??= stem.StartsWith(resolved, StringComparison.OrdinalIgnoreCase) ? path : null;
+        }
+        return prefix;
+    }
+
+    public static IEnumerable<string> StartMenuShortcuts()
+    {
+        var roots = new[]
+        {
+            Environment.GetFolderPath(Environment.SpecialFolder.CommonStartMenu),
+            Environment.GetFolderPath(Environment.SpecialFolder.StartMenu),
+        };
+        var options = new EnumerationOptions { RecurseSubdirectories = true, IgnoreInaccessible = true };
+        return roots.Where(Directory.Exists).SelectMany(root => Directory.EnumerateFiles(root, "*.lnk", options));
+    }
+
+    public static async Task<string> OpenAsync(string name, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            throw new ArgumentException("open_app requires app_name");
+        }
+        var resolved = Resolve(name);
+
+        if (ActivateRunning(name, resolved))
+        {
+            await Task.Delay(300, cancellationToken);
+            return $"switched to {resolved}";
+        }
+
+        var target = FindShortcut(StartMenuShortcuts(), name, resolved)
+            ?? (ShellCommands.TryGetValue(resolved, out var command) ? command : resolved);
+        try
+        {
+            using var process = Process.Start(new ProcessStartInfo(target) { UseShellExecute = true })
+                ?? throw new InvalidOperationException($"Application not found: {name}");
+        }
+        catch (Exception err) when (err is System.ComponentModel.Win32Exception or FileNotFoundException)
+        {
+            throw new InvalidOperationException($"Application not found: {name}");
+        }
+        await Task.Delay(1_000, cancellationToken);
+        return $"opened {resolved}";
+    }
+
+    // Brings forward the first visible top-level window whose process name or
+    // title matches; a minimized window is restored first.
+    private static bool ActivateRunning(string name, string resolved)
+    {
+        foreach (var process in Process.GetProcesses())
+        {
+            using (process)
+            {
+                if (process.MainWindowHandle == IntPtr.Zero || !Matches(process, name, resolved))
+                {
+                    continue;
+                }
+                if (IsIconic(process.MainWindowHandle))
+                {
+                    _ = ShowWindow(process.MainWindowHandle, 9); // SW_RESTORE
+                }
+                return SetForegroundWindow(process.MainWindowHandle);
+            }
+        }
+        return false;
+    }
+
+    private static bool Matches(Process process, string name, string resolved)
+    {
+        string title;
+        try
+        {
+            title = process.MainWindowTitle;
+        }
+        catch (InvalidOperationException)
+        {
+            return false;
+        }
+        var compact = resolved.Replace(" ", "", StringComparison.Ordinal);
+        return process.ProcessName.Equals(compact, StringComparison.OrdinalIgnoreCase) ||
+            process.ProcessName.Equals(name, StringComparison.OrdinalIgnoreCase) ||
+            title.Equals(resolved, StringComparison.OrdinalIgnoreCase) ||
+            title.EndsWith("- " + resolved, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [LibraryImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool SetForegroundWindow(IntPtr hwnd);
+
+    [LibraryImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool ShowWindow(IntPtr hwnd, int command);
+
+    [LibraryImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool IsIconic(IntPtr hwnd);
+}

--- a/clients/windows/native/Vellum.WindowsHelper/Modules/AppLauncher.cs
+++ b/clients/windows/native/Vellum.WindowsHelper/Modules/AppLauncher.cs
@@ -24,25 +24,35 @@ public static partial class AppLauncher
 
     public static string Resolve(string name) => Aliases.TryGetValue(name.Trim(), out var alias) ? alias : name.Trim();
 
-    // Case-insensitive match on a shortcut's file name, trying the resolved
-    // name and the raw name; an exact match beats a prefix match.
-    public static string? FindShortcut(IEnumerable<string> shortcutPaths, string name, string resolved)
+    public sealed record AppEntry(string Name, string Target);
+
+    // Exact match on the resolved or raw name wins; otherwise a unique prefix
+    // match. Several prefix matches are ambiguous and reported, never guessed.
+    public static string? FindMatch(IEnumerable<AppEntry> entries, string name, string resolved)
     {
-        string? prefix = null;
-        foreach (var path in shortcutPaths)
+        var prefixes = new List<AppEntry>();
+        foreach (var entry in entries)
         {
-            var stem = Path.GetFileNameWithoutExtension(path);
-            if (stem.Equals(resolved, StringComparison.OrdinalIgnoreCase) ||
-                stem.Equals(name, StringComparison.OrdinalIgnoreCase))
+            if (entry.Name.Equals(resolved, StringComparison.OrdinalIgnoreCase) ||
+                entry.Name.Equals(name, StringComparison.OrdinalIgnoreCase))
             {
-                return path;
+                return entry.Target;
             }
-            prefix ??= stem.StartsWith(resolved, StringComparison.OrdinalIgnoreCase) ? path : null;
+            if (entry.Name.StartsWith(resolved, StringComparison.OrdinalIgnoreCase))
+            {
+                prefixes.Add(entry);
+            }
         }
-        return prefix;
+        return prefixes switch
+        {
+            [] => null,
+            [var only] => only.Target,
+            _ => throw new InvalidOperationException(
+                $"Ambiguous app name '{name}'; candidates: {string.Join(", ", prefixes.Select(e => e.Name).Distinct())}"),
+        };
     }
 
-    public static IEnumerable<string> StartMenuShortcuts()
+    public static IEnumerable<AppEntry> StartMenuShortcuts()
     {
         var roots = new[]
         {
@@ -50,7 +60,35 @@ public static partial class AppLauncher
             Environment.GetFolderPath(Environment.SpecialFolder.StartMenu),
         };
         var options = new EnumerationOptions { RecurseSubdirectories = true, IgnoreInaccessible = true };
-        return roots.Where(Directory.Exists).SelectMany(root => Directory.EnumerateFiles(root, "*.lnk", options));
+        return roots.Where(Directory.Exists)
+            .SelectMany(root => Directory.EnumerateFiles(root, "*.lnk", options))
+            .Select(path => new AppEntry(Path.GetFileNameWithoutExtension(path), path));
+    }
+
+    // Every Start-registered app, including MSIX/AppX packages that have no
+    // .lnk on disk. Item paths are AppUserModelIDs launchable via shell:AppsFolder.
+    public static IEnumerable<AppEntry> AppsFolderEntries()
+    {
+        var entries = new List<AppEntry>();
+        try
+        {
+            var shellType = Type.GetTypeFromProgID("Shell.Application");
+            if (shellType is null)
+            {
+                return entries;
+            }
+            dynamic shell = Activator.CreateInstance(shellType)!;
+            dynamic items = shell.NameSpace("shell:AppsFolder").Items();
+            for (var i = 0; i < (int)items.Count; i++)
+            {
+                dynamic item = items.Item(i);
+                entries.Add(new AppEntry((string)item.Name, $@"shell:AppsFolder\{(string)item.Path}"));
+            }
+        }
+        catch (Exception err) when (err is COMException or InvalidCastException or Microsoft.CSharp.RuntimeBinder.RuntimeBinderException)
+        {
+        }
+        return entries;
     }
 
     public static async Task<string> OpenAsync(string name, CancellationToken cancellationToken)
@@ -67,7 +105,8 @@ public static partial class AppLauncher
             return $"switched to {resolved}";
         }
 
-        var target = FindShortcut(StartMenuShortcuts(), name, resolved)
+        var target = FindMatch(StartMenuShortcuts(), name, resolved)
+            ?? FindMatch(AppsFolderEntries(), name, resolved)
             ?? (ShellCommands.TryGetValue(resolved, out var command) ? command : resolved);
         try
         {

--- a/clients/windows/native/Vellum.WindowsHelper/Modules/AppLauncher.cs
+++ b/clients/windows/native/Vellum.WindowsHelper/Modules/AppLauncher.cs
@@ -122,7 +122,9 @@ public static partial class AppLauncher
     }
 
     // Brings forward the first visible top-level window whose process name or
-    // title matches; a minimized window is restored first.
+    // title matches; a minimized window is restored first. A found window counts
+    // as activated even if foreground-lock rules reject the switch, so a live
+    // app is never relaunched into a duplicate instance.
     private static bool ActivateRunning(string name, string resolved)
     {
         foreach (var process in Process.GetProcesses())
@@ -137,7 +139,8 @@ public static partial class AppLauncher
                 {
                     _ = ShowWindow(process.MainWindowHandle, 9); // SW_RESTORE
                 }
-                return SetForegroundWindow(process.MainWindowHandle);
+                _ = SetForegroundWindow(process.MainWindowHandle);
+                return true;
             }
         }
         return false;

--- a/clients/windows/native/Vellum.WindowsHelper/Modules/InputController.cs
+++ b/clients/windows/native/Vellum.WindowsHelper/Modules/InputController.cs
@@ -203,6 +203,31 @@ internal static partial class NativeInput
         }
     }
 
+    // Press, interpolate the path with the button held, then release. The
+    // release is guaranteed so a failed move never leaves the button down.
+    public static async Task DragAsync(
+        double fromX, double fromY, double toX, double toY, CancellationToken cancellationToken)
+    {
+        const int steps = 10;
+        MoveTo(fromX, fromY);
+        await Task.Delay(30, cancellationToken);
+        Button("left", down: true);
+        try
+        {
+            await Task.Delay(50, cancellationToken);
+            for (var i = 1; i <= steps; i++)
+            {
+                var t = (double)i / steps;
+                MoveTo(fromX + (toX - fromX) * t, fromY + (toY - fromY) * t);
+                await Task.Delay(10, cancellationToken);
+            }
+        }
+        finally
+        {
+            Button("left", down: false);
+        }
+    }
+
     public static void TypeText(string text)
     {
         foreach (var (unit, isReturn) in KeyPlanner.PlanText(text))
@@ -279,10 +304,14 @@ public sealed class InputController : IRpcModule, IInputController
             return await Finish(null, error.Message);
         }
 
-        if (action.Type is "click" or "double_click" or "right_click" &&
+        if (action.Type is "click" or "double_click" or "right_click" or "drag" &&
             (action.X is null || action.Y is null))
         {
             return await Finish(null, "Coordinates or a valid element_id are required");
+        }
+        if (action.Type is "drag" && (action.ToX is null || action.ToY is null))
+        {
+            return await Finish(null, "Destination coordinates or a valid to_element_id are required");
         }
 
         var verdict = verifier.Verify(action);
@@ -312,36 +341,51 @@ public sealed class InputController : IRpcModule, IInputController
         CuAction action, ICuObservationSource? source, CancellationToken cancellationToken,
         string conversationId = "")
     {
-        if (action.Type is not ("click" or "double_click" or "right_click" or "scroll"))
+        if (action.Type is not ("click" or "double_click" or "right_click" or "scroll" or "drag"))
         {
             return action;
         }
-        if (action is { X: double x, Y: double y })
+        var from = await ResolvePointAsync(
+            action.X, action.Y, action.ElementId, source, cancellationToken, conversationId);
+        if (from is { } start)
         {
-            if (source is null)
+            action = action with { X = start.X, Y = start.Y };
+        }
+        if (action.Type is "drag")
+        {
+            var to = await ResolvePointAsync(
+                action.ToX, action.ToY, action.ToElementId, source, cancellationToken, conversationId);
+            if (to is { } end)
             {
-                return action;
+                action = action with { ToX = end.X, ToY = end.Y };
             }
-            var screenPoint = await source.TranslateScreenPointAsync(
-                conversationId, new CuPoint(x, y), cancellationToken);
-            return action with { X = screenPoint.X, Y = screenPoint.Y };
         }
-        if (action.ElementId is null)
+        return action;
+    }
+
+    // Explicit coordinates are translated into screen space; otherwise the
+    // element center is looked up. Null when neither is available.
+    private static async Task<CuPoint?> ResolvePointAsync(
+        double? x, double? y, long? elementId, ICuObservationSource? source,
+        CancellationToken cancellationToken, string conversationId)
+    {
+        if (x is double px && y is double py)
         {
-            return action;
+            return source is null
+                ? new CuPoint(px, py)
+                : await source.TranslateScreenPointAsync(conversationId, new CuPoint(px, py), cancellationToken);
+        }
+        if (elementId is null)
+        {
+            return null;
         }
         if (source is null)
         {
             throw new InvalidOperationException(
-                $"Element {action.ElementId} cannot be resolved because screen observation is unavailable");
+                $"Element {elementId} cannot be resolved because screen observation is unavailable");
         }
-        var elementPoint = await source.ResolveElementCenterAsync(action.ElementId.Value, cancellationToken);
-        if (elementPoint is null)
-        {
-            throw new InvalidOperationException(
-                $"Element {action.ElementId} was not found in the current window");
-        }
-        return action with { X = elementPoint.X, Y = elementPoint.Y };
+        return await source.ResolveElementCenterAsync(elementId.Value, cancellationToken)
+            ?? throw new InvalidOperationException($"Element {elementId} was not found in the current window");
     }
 
     private static async Task<string> ExecuteAsync(CuAction action, CancellationToken cancellationToken)
@@ -399,9 +443,14 @@ public sealed class InputController : IRpcModule, IInputController
                 // Structured unsupported result keeps the wire meaning intact.
                 throw new NotSupportedException(
                     "run_applescript is not supported on Windows; use click, type, and key actions instead");
-            case "drag" or "open_app":
-                // Drag pointer paths and app launching are not implemented.
-                throw new NotSupportedException($"{action.Type} is not yet available on Windows");
+            case "drag":
+            {
+                var (x, y, toX, toY) = (action.X!.Value, action.Y!.Value, action.ToX!.Value, action.ToY!.Value);
+                await NativeInput.DragAsync(x, y, toX, toY, cancellationToken);
+                return $"dragged from ({x}, {y}) to ({toX}, {toY})";
+            }
+            case "open_app":
+                return await AppLauncher.OpenAsync(action.AppName ?? "", cancellationToken);
             default:
                 throw new InvalidOperationException($"Unsupported action: {action.Type}");
         }
@@ -468,6 +517,9 @@ public sealed class InputController : IRpcModule, IInputController
             X: JsonInput.GetDouble(input, "x"),
             Y: JsonInput.GetDouble(input, "y"),
             ElementId: JsonInput.GetLong(input, "element_id"),
+            ToX: JsonInput.GetDouble(input, "to_x") ?? JsonInput.GetDouble(input, "toX"),
+            ToY: JsonInput.GetDouble(input, "to_y") ?? JsonInput.GetDouble(input, "toY"),
+            ToElementId: JsonInput.GetLong(input, "to_element_id") ?? JsonInput.GetLong(input, "toElementId"),
             Text: JsonInput.GetString(input, "text"),
             Key: JsonInput.GetString(input, "key"),
             ScrollDirection: JsonInput.GetString(input, "direction") ?? JsonInput.GetString(input, "scroll_direction"),


### PR DESCRIPTION
## Summary
- Implement `drag` in the Windows helper: move to the source, hold the left button, interpolate 10 steps to the destination via SendInput, and always release (mirrors the macOS helper's timing).
- Implement `open_app` via a new `AppLauncher`: activate a running app by process name or window title (restoring minimized windows), else launch a matching Start Menu shortcut, else shell-execute the name/alias.
- `CuAction` gains `ToX`/`ToY`/`ToElementId`; drag resolves both endpoints (element ids or coordinates) through the observation source. `computer_use_drag` and `computer_use_open_app` are now unhidden for `windows` in the daemon tool definitions and the bundled skill manifest.

## Original prompt
Part of a batch of Windows client parity fixes. Computer-use drag and open_app were unimplemented in InputController.cs and correctly hidden from the Windows tool schema; the ask was to implement both in the native helper, mirroring macOS semantics, and unhide them so the model can use them on Windows.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41424" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->