### PR TITLE
fix(web): render platform-aware shortcut labels on Windows

### DIFF
--- a/clients/web/src/components/command-palette/command-palette.test.tsx
+++ b/clients/web/src/components/command-palette/command-palette.test.tsx
@@ -1,6 +1,13 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import { cleanup, render, screen } from "@testing-library/react";
 
+// Shortcut hints follow the host OS; pin macOS so the glyph assertions below
+// hold on Linux CI runners too.
+Object.defineProperty(navigator, "platform", {
+  value: "MacIntel",
+  configurable: true,
+});
+
 import { viewportAxesStub } from "@/hooks/viewport-axes.test-helper";
 
 const isMobileRef = { value: false };

--- a/clients/web/src/components/command-palette/command-palette.test.tsx
+++ b/clients/web/src/components/command-palette/command-palette.test.tsx
@@ -7,7 +7,6 @@ Object.defineProperty(navigator, "platform", {
   value: "MacIntel",
   configurable: true,
 });
-
 import { viewportAxesStub } from "@/hooks/viewport-axes.test-helper";
 
 const isMobileRef = { value: false };

--- a/clients/web/src/components/command-palette/command-palette.tsx
+++ b/clients/web/src/components/command-palette/command-palette.tsx
@@ -1,4 +1,8 @@
-import { Button, Typography } from "@vellumai/design-library";
+import {
+  Button,
+  Typography,
+  formatAcceleratorHint,
+} from "@vellumai/design-library";
 import type { LucideIcon } from "lucide-react";
 import { Loader2, Search, X } from "lucide-react";
 import {
@@ -311,7 +315,7 @@ export const CommandPalette: FC<CommandPaletteProps> = ({
               : "shrink-0 rounded-md border border-[var(--border-base)] bg-[var(--surface-active)] px-1.5 py-0.5 text-label-small-default text-[var(--content-tertiary)]"
           }
         >
-          {t("commandPalette.shortcutHint")}
+          {formatAcceleratorHint("CmdOrCtrl+K")}
         </kbd>
       ) : null}
       {useMobileLayout ? (

--- a/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
@@ -13,6 +13,13 @@
  * `AssistantSideMenu`.
  */
 
+// Shortcut hints follow the host OS; pin macOS so the glyph assertions below
+// hold on Linux CI runners too.
+Object.defineProperty(navigator, "platform", {
+  value: "MacIntel",
+  configurable: true,
+});
+
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { act, cleanup, render, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -128,19 +135,16 @@ mock.module(
    own QueryClient per render, so a test has nothing to seed. */
 let pinnedAppsFixture: AppSummary[] = [];
 
-mock.module(
-  "@/hooks/use-pinned-apps",
-  (): Partial<typeof UsePinnedApps> => ({
-    usePinnedApps: () => ({
-      pinnedApps: pinnedAppsFixture,
-      pinnedAppIds: new Set(pinnedAppsFixture.map((app) => app.id)),
-      source: "daemon" as const,
-      togglePin: () => {},
-      unpin: () => {},
-      setColor: () => {},
-    }),
+mock.module("@/hooks/use-pinned-apps", (): Partial<typeof UsePinnedApps> => ({
+  usePinnedApps: () => ({
+    pinnedApps: pinnedAppsFixture,
+    pinnedAppIds: new Set(pinnedAppsFixture.map((app) => app.id)),
+    source: "daemon" as const,
+    togglePin: () => {},
+    unpin: () => {},
+    setColor: () => {},
   }),
-);
+}));
 
 // The assistant nav item reads the avatar through React Query; stub it so
 // static SSR rendering resolves without a QueryClient.
@@ -977,7 +981,9 @@ describe("AssistantSideMenu · overlay section card geometry", () => {
   test("the overlay card and its header carry the 44px pill geometry", () => {
     const container = document.createElement("div");
     container.innerHTML = renderMenu({
-      conversations: [makeConversation({ conversationId: "a", title: "Alpha" })],
+      conversations: [
+        makeConversation({ conversationId: "a", title: "Alpha" }),
+      ],
       variant: "overlay",
     });
 

--- a/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.test.tsx
@@ -13,13 +13,6 @@
  * `AssistantSideMenu`.
  */
 
-// Shortcut hints follow the host OS; pin macOS so the glyph assertions below
-// hold on Linux CI runners too.
-Object.defineProperty(navigator, "platform", {
-  value: "MacIntel",
-  configurable: true,
-});
-
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { act, cleanup, render, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
@@ -27,6 +20,12 @@ import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import * as reactRouter from "react-router";
 
+// Shortcut hints follow the host OS; pin macOS so the glyph assertions below
+// hold on Linux CI runners too.
+Object.defineProperty(navigator, "platform", {
+  value: "MacIntel",
+  configurable: true,
+});
 import {
   SIDEBAR_SECTION_MAX_HEIGHT,
   SIDEBAR_STACK_GAP,
@@ -135,16 +134,19 @@ mock.module(
    own QueryClient per render, so a test has nothing to seed. */
 let pinnedAppsFixture: AppSummary[] = [];
 
-mock.module("@/hooks/use-pinned-apps", (): Partial<typeof UsePinnedApps> => ({
-  usePinnedApps: () => ({
-    pinnedApps: pinnedAppsFixture,
-    pinnedAppIds: new Set(pinnedAppsFixture.map((app) => app.id)),
-    source: "daemon" as const,
-    togglePin: () => {},
-    unpin: () => {},
-    setColor: () => {},
+mock.module(
+  "@/hooks/use-pinned-apps",
+  (): Partial<typeof UsePinnedApps> => ({
+    usePinnedApps: () => ({
+      pinnedApps: pinnedAppsFixture,
+      pinnedAppIds: new Set(pinnedAppsFixture.map((app) => app.id)),
+      source: "daemon" as const,
+      togglePin: () => {},
+      unpin: () => {},
+      setColor: () => {},
+    }),
   }),
-}));
+);
 
 // The assistant nav item reads the avatar through React Query; stub it so
 // static SSR rendering resolves without a QueryClient.
@@ -981,9 +983,7 @@ describe("AssistantSideMenu · overlay section card geometry", () => {
   test("the overlay card and its header carry the 44px pill geometry", () => {
     const container = document.createElement("div");
     container.innerHTML = renderMenu({
-      conversations: [
-        makeConversation({ conversationId: "a", title: "Alpha" }),
-      ],
+      conversations: [makeConversation({ conversationId: "a", title: "Alpha" })],
       variant: "overlay",
     });
 

--- a/clients/web/src/domains/chat/components/assistant-side-menu.tsx
+++ b/clients/web/src/domains/chat/components/assistant-side-menu.tsx
@@ -1,3 +1,4 @@
+import { formatAcceleratorHint } from "@vellumai/design-library";
 import { Search, X } from "lucide-react";
 import {
   useCallback,
@@ -148,12 +149,15 @@ function SearchButton() {
   const handleClick = useCallback(() => {
     toggle();
   }, [toggle]);
+  const label = t("assistantSideMenu.searchShortcut", {
+    shortcut: formatAcceleratorHint("CmdOrCtrl+K"),
+  });
   return (
     <Button
       variant="ghost"
       iconOnly={<Search />}
-      aria-label={t("assistantSideMenu.searchShortcut")}
-      title={t("assistantSideMenu.searchShortcut")}
+      aria-label={label}
+      title={label}
       className={`pointer-events-auto ${NATIVE_MOBILE_BARE_ICON_BUTTON}`}
       onClick={handleClick}
     />

--- a/clients/web/src/domains/chat/hooks/command-palette-utils.ts
+++ b/clients/web/src/domains/chat/hooks/command-palette-utils.ts
@@ -14,6 +14,8 @@ import {
   SquarePen,
 } from "lucide-react";
 
+import { formatAcceleratorHint } from "@vellumai/design-library";
+
 import type { CommandPaletteSection } from "@/components/command-palette/command-palette";
 import type { GlobalSearchResponse } from "@/domains/chat/api/global-search";
 import { newChatShortcutHint } from "@/domains/chat/new-chat-shortcut";
@@ -36,13 +38,13 @@ export function buildActionsSection(
         id: "action-current-conversation",
         icon: Monitor,
         title: "Current Conversation",
-        shortcutHint: "⌘⇧N",
+        shortcutHint: formatAcceleratorHint("CmdOrCtrl+Shift+N"),
       },
       {
         id: "action-settings",
         icon: Settings,
         title: "Settings",
-        shortcutHint: "⌘,",
+        shortcutHint: formatAcceleratorHint("CmdOrCtrl+,"),
       },
       { id: "action-library", icon: LayoutGrid, title: "Library" },
       { id: "action-intelligence", icon: Globe, title: assistantName },

--- a/clients/web/src/domains/chat/new-chat-shortcut.test.ts
+++ b/clients/web/src/domains/chat/new-chat-shortcut.test.ts
@@ -2,13 +2,19 @@ import { afterEach, describe, expect, mock, test } from "bun:test";
 
 let electron = false;
 
+// Shortcut hints follow the host OS; pin macOS so the glyph assertions below
+// hold on Linux CI runners too.
+Object.defineProperty(navigator, "platform", {
+  value: "MacIntel",
+  configurable: true,
+});
+
 mock.module("@/runtime/is-electron", () => ({
   isElectron: () => electron,
 }));
 
-const { newChatAccelerator, newChatShortcutHint } = await import(
-  "@/domains/chat/new-chat-shortcut"
-);
+const { newChatAccelerator, newChatShortcutHint } =
+  await import("@/domains/chat/new-chat-shortcut");
 
 describe("newChatShortcutHint", () => {
   afterEach(() => {

--- a/clients/web/src/domains/chat/new-chat-shortcut.test.ts
+++ b/clients/web/src/domains/chat/new-chat-shortcut.test.ts
@@ -1,20 +1,20 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
 
-let electron = false;
-
 // Shortcut hints follow the host OS; pin macOS so the glyph assertions below
 // hold on Linux CI runners too.
 Object.defineProperty(navigator, "platform", {
   value: "MacIntel",
   configurable: true,
 });
+let electron = false;
 
 mock.module("@/runtime/is-electron", () => ({
   isElectron: () => electron,
 }));
 
-const { newChatAccelerator, newChatShortcutHint } =
-  await import("@/domains/chat/new-chat-shortcut");
+const { newChatAccelerator, newChatShortcutHint } = await import(
+  "@/domains/chat/new-chat-shortcut"
+);
 
 describe("newChatShortcutHint", () => {
   afterEach(() => {

--- a/clients/web/src/domains/chat/new-chat-shortcut.ts
+++ b/clients/web/src/domains/chat/new-chat-shortcut.ts
@@ -1,4 +1,4 @@
-import { parseAccelerator } from "@vellumai/design-library";
+import { formatAcceleratorHint } from "@vellumai/design-library";
 
 import { isElectron } from "@/runtime/is-electron";
 
@@ -22,7 +22,7 @@ export function newChatAccelerator(): string {
     : WEB_NEW_CHAT_ACCELERATOR;
 }
 
-/** Compact glyph form for tooltips and palette hints (`⌘N`, `⌘⇧O`). */
+/** Compact form for tooltips and palette hints (`⌘N` on macOS, `Ctrl+N` on Windows). */
 export function newChatShortcutHint(): string {
-  return parseAccelerator(newChatAccelerator()).join("");
+  return formatAcceleratorHint(newChatAccelerator());
 }

--- a/clients/web/src/i18n/locales/en/chat.json
+++ b/clients/web/src/i18n/locales/en/chat.json
@@ -94,7 +94,7 @@
     "bulkActionMembersFailed": "Couldn't load every conversation in this section. Try again.",
     "closeNavAria": "Close navigation",
     "navAria": "Assistant navigation",
-    "searchShortcut": "Search (⌘K)"
+    "searchShortcut": "Search ({shortcut})"
   },
   "assistantSwitcher": {
     "collapse": "Hide assistants",

--- a/clients/web/src/i18n/locales/en/common.json
+++ b/clients/web/src/i18n/locales/en/common.json
@@ -118,8 +118,7 @@
     "noResults": "No results",
     "placeholder": "Search conversations, memories…",
     "searchAriaLabel": "Search",
-    "searching": "Searching…",
-    "shortcutHint": "⌘K"
+    "searching": "Searching…"
   },
   "companionIntro": {
     "ariaLabel": "Introducing your companion",

--- a/clients/web/src/i18n/locales/es/chat.json
+++ b/clients/web/src/i18n/locales/es/chat.json
@@ -94,7 +94,7 @@
     "bulkActionMembersFailed": "No se pudieron cargar todas las conversaciones de esta sección. Inténtalo de nuevo.",
     "closeNavAria": "Cerrar navegación",
     "navAria": "Navegación del asistente",
-    "searchShortcut": "Buscar (⌘K)"
+    "searchShortcut": "Buscar ({shortcut})"
   },
   "assistantSwitcher": {
     "collapse": "Ocultar asistentes",

--- a/clients/web/src/i18n/locales/es/common.json
+++ b/clients/web/src/i18n/locales/es/common.json
@@ -118,8 +118,7 @@
     "noResults": "Sin resultados",
     "placeholder": "Buscar conversaciones, recuerdos…",
     "searchAriaLabel": "Buscar",
-    "searching": "Buscando…",
-    "shortcutHint": "⌘K"
+    "searching": "Buscando…"
   },
   "companionIntro": {
     "ariaLabel": "Te presento a tu compañero",

--- a/packages/design-library/src/components/shortcut-keys.stories.tsx
+++ b/packages/design-library/src/components/shortcut-keys.stories.tsx
@@ -7,6 +7,7 @@ const meta: Meta<typeof ShortcutKeys> = {
   component: ShortcutKeys,
   argTypes: {
     accelerator: { control: "text" },
+    platform: { control: "inline-radio", options: ["mac", "windows"] },
   },
 };
 
@@ -32,6 +33,10 @@ export const PunctuationKey: Story = {
 
 export const AllModifiers: Story = {
   args: { accelerator: "CmdOrCtrl+Control+Alt+Shift+K" },
+};
+
+export const Windows: Story = {
+  args: { accelerator: "CmdOrCtrl+Shift+N", platform: "windows" },
 };
 
 export const Gallery: Story = {

--- a/packages/design-library/src/components/shortcut-keys.test.tsx
+++ b/packages/design-library/src/components/shortcut-keys.test.tsx
@@ -2,7 +2,11 @@ import { describe, expect, test } from "bun:test";
 import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 
-import { ShortcutKeys, parseAccelerator } from "./shortcut-keys";
+import {
+  ShortcutKeys,
+  formatAcceleratorHint,
+  parseAccelerator,
+} from "./shortcut-keys";
 
 describe("parseAccelerator", () => {
   test("maps modifiers to macOS symbols", () => {
@@ -37,6 +41,34 @@ describe("parseAccelerator", () => {
   test("returns an empty array for an empty accelerator", () => {
     expect(parseAccelerator("")).toEqual([]);
   });
+
+  test("maps tokens to text labels on Windows", () => {
+    expect(parseAccelerator("CmdOrCtrl+Shift+N", "windows")).toEqual([
+      "Ctrl",
+      "Shift",
+      "N",
+    ]);
+    expect(parseAccelerator("Super+Alt+Escape", "windows")).toEqual([
+      "Win",
+      "Alt",
+      "Esc",
+    ]);
+    expect(parseAccelerator("Control+Up", "windows")).toEqual([
+      "Ctrl",
+      "\u2191",
+    ]);
+  });
+});
+
+describe("formatAcceleratorHint", () => {
+  test("runs glyphs together on mac and plus-joins labels on Windows", () => {
+    expect(formatAcceleratorHint("CmdOrCtrl+Shift+O", "mac")).toBe(
+      "\u2318\u21e7O",
+    );
+    expect(formatAcceleratorHint("CmdOrCtrl+Shift+O", "windows")).toBe(
+      "Ctrl+Shift+O",
+    );
+  });
 });
 
 describe("ShortcutKeys", () => {
@@ -47,6 +79,16 @@ describe("ShortcutKeys", () => {
     const caps = html.match(/<kbd/g) ?? [];
     expect(caps).toHaveLength(3);
     expect(html).toContain('data-slot="shortcut-keys"');
+  });
+
+  test("renders platform labels when asked", () => {
+    const html = renderToStaticMarkup(
+      createElement(ShortcutKeys, {
+        accelerator: "CmdOrCtrl+K",
+        platform: "windows",
+      }),
+    );
+    expect(html).toContain(">Ctrl<");
   });
 
   test("renders nothing for a disabled (empty) binding", () => {

--- a/packages/design-library/src/components/shortcut-keys.test.tsx
+++ b/packages/design-library/src/components/shortcut-keys.test.tsx
@@ -4,18 +4,19 @@ import { renderToStaticMarkup } from "react-dom/server";
 
 import {
   ShortcutKeys,
+  detectShortcutPlatform,
   formatAcceleratorHint,
   parseAccelerator,
 } from "./shortcut-keys";
 
 describe("parseAccelerator", () => {
   test("maps modifiers to macOS symbols", () => {
-    expect(parseAccelerator("CmdOrCtrl+Shift+N")).toEqual([
+    expect(parseAccelerator("CmdOrCtrl+Shift+N", "mac")).toEqual([
       "\u2318",
       "\u21e7",
       "N",
     ]);
-    expect(parseAccelerator("Command+Control+Alt+K")).toEqual([
+    expect(parseAccelerator("Command+Control+Alt+K", "mac")).toEqual([
       "\u2318",
       "\u2303",
       "\u2325",
@@ -24,22 +25,28 @@ describe("parseAccelerator", () => {
   });
 
   test("maps named keys to their glyphs", () => {
-    expect(parseAccelerator("CmdOrCtrl+Up")).toEqual(["\u2318", "\u2191"]);
-    expect(parseAccelerator("CmdOrCtrl+Down")).toEqual(["\u2318", "\u2193"]);
-    expect(parseAccelerator("Escape")).toEqual(["\u238b"]);
+    expect(parseAccelerator("CmdOrCtrl+Up", "mac")).toEqual([
+      "\u2318",
+      "\u2191",
+    ]);
+    expect(parseAccelerator("CmdOrCtrl+Down", "mac")).toEqual([
+      "\u2318",
+      "\u2193",
+    ]);
+    expect(parseAccelerator("Escape", "mac")).toEqual(["\u238b"]);
   });
 
   test("uppercases single-character keys", () => {
-    expect(parseAccelerator("CmdOrCtrl+a")).toEqual(["\u2318", "A"]);
+    expect(parseAccelerator("CmdOrCtrl+a", "mac")).toEqual(["\u2318", "A"]);
   });
 
   test("preserves a trailing plus as the literal plus key", () => {
-    expect(parseAccelerator("CmdOrCtrl+")).toEqual(["\u2318", "+"]);
-    expect(parseAccelerator("CmdOrCtrl+Plus")).toEqual(["\u2318", "+"]);
+    expect(parseAccelerator("CmdOrCtrl+", "mac")).toEqual(["\u2318", "+"]);
+    expect(parseAccelerator("CmdOrCtrl+Plus", "mac")).toEqual(["\u2318", "+"]);
   });
 
   test("returns an empty array for an empty accelerator", () => {
-    expect(parseAccelerator("")).toEqual([]);
+    expect(parseAccelerator("", "mac")).toEqual([]);
   });
 
   test("maps tokens to text labels on Windows", () => {
@@ -58,6 +65,34 @@ describe("parseAccelerator", () => {
       "\u2191",
     ]);
   });
+});
+
+describe("detectShortcutPlatform", () => {
+  const platforms: [string, ReturnType<typeof detectShortcutPlatform>][] = [
+    ["MacIntel", "mac"],
+    ["X11; Darwin arm64", "mac"],
+    ["iPhone", "mac"],
+    ["Win32", "windows"],
+    ["Linux x86_64", "windows"],
+    ["", "mac"],
+  ];
+  for (const [platform, expected] of platforms) {
+    test(`${JSON.stringify(platform)} resolves to ${expected}`, () => {
+      const original = navigator.platform;
+      Object.defineProperty(navigator, "platform", {
+        value: platform,
+        configurable: true,
+      });
+      try {
+        expect(detectShortcutPlatform()).toBe(expected);
+      } finally {
+        Object.defineProperty(navigator, "platform", {
+          value: original,
+          configurable: true,
+        });
+      }
+    });
+  }
 });
 
 describe("formatAcceleratorHint", () => {

--- a/packages/design-library/src/components/shortcut-keys.tsx
+++ b/packages/design-library/src/components/shortcut-keys.tsx
@@ -4,16 +4,40 @@ import { cn } from "../utils/cn";
 
 /**
  * Renders an Electron [`Accelerator`](https://www.electronjs.org/docs/latest/api/accelerator)
- * string as a row of macOS-style key caps (e.g. `"CmdOrCtrl+Shift+N"` →
- * ⌘ ⇧ N). Presentation-only: it does not capture or validate input, so it is
- * reusable anywhere a binding needs to be shown (Keyboard Shortcuts settings,
- * a future command palette, menu hints).
+ * string as a row of key caps (e.g. `"CmdOrCtrl+Shift+N"` renders ⌘ ⇧ N on
+ * macOS and Ctrl Shift N on Windows). Presentation-only: it does not capture
+ * or validate input, so it is reusable anywhere a binding needs to be shown
+ * (Keyboard Shortcuts settings, the command palette, menu hints).
  *
- * Modifier and named-key tokens are mapped to the symbols macOS uses; an empty
- * accelerator renders nothing, which callers use to show a "disabled" binding.
+ * Modifier and named-key tokens are mapped per platform; an empty accelerator
+ * renders nothing, which callers use to show a "disabled" binding.
  */
 
-const MODIFIER_SYMBOLS: Record<string, string> = {
+/** Which key-cap vocabulary to render: macOS glyphs or Windows text labels. */
+export type ShortcutPlatform = "mac" | "windows";
+
+/**
+ * Detect the shortcut vocabulary for the current host from `navigator`. Apple
+ * hosts (and unknown hosts, e.g. SSR or test DOMs) get glyphs; Windows and
+ * Linux get text labels. Electron renderers report the host OS here too, so
+ * this is correct inside the desktop apps.
+ */
+export const detectShortcutPlatform = (): ShortcutPlatform => {
+  if (typeof navigator === "undefined") {
+    return "mac";
+  }
+  const uaData = (
+    navigator as Navigator & { userAgentData?: { platform?: string } }
+  ).userAgentData;
+  const platform = (uaData?.platform || navigator.platform || "").toLowerCase();
+  // "darwin" contains "win", so rule out Apple hosts first.
+  if (/mac|darwin|iphone|ipad|ipod/.test(platform)) {
+    return "mac";
+  }
+  return /win|linux/.test(platform) ? "windows" : "mac";
+};
+
+const MAC_MODIFIER_SYMBOLS: Record<string, string> = {
   command: "\u2318",
   cmd: "\u2318",
   commandorcontrol: "\u2318",
@@ -28,7 +52,22 @@ const MODIFIER_SYMBOLS: Record<string, string> = {
   shift: "\u21e7",
 };
 
-const KEY_SYMBOLS: Record<string, string> = {
+const WINDOWS_MODIFIER_LABELS: Record<string, string> = {
+  command: "Win",
+  cmd: "Win",
+  commandorcontrol: "Ctrl",
+  cmdorctrl: "Ctrl",
+  super: "Win",
+  meta: "Win",
+  control: "Ctrl",
+  ctrl: "Ctrl",
+  alt: "Alt",
+  option: "Alt",
+  altgr: "AltGr",
+  shift: "Shift",
+};
+
+const MAC_KEY_SYMBOLS: Record<string, string> = {
   up: "\u2191",
   down: "\u2193",
   left: "\u2190",
@@ -46,6 +85,34 @@ const KEY_SYMBOLS: Record<string, string> = {
   home: "\u2196",
   end: "\u2198",
   plus: "+",
+};
+
+const WINDOWS_KEY_LABELS: Record<string, string> = {
+  up: "\u2191",
+  down: "\u2193",
+  left: "\u2190",
+  right: "\u2192",
+  return: "Enter",
+  enter: "Enter",
+  space: "Space",
+  backspace: "Backspace",
+  delete: "Del",
+  escape: "Esc",
+  esc: "Esc",
+  tab: "Tab",
+  pageup: "PgUp",
+  pagedown: "PgDn",
+  home: "Home",
+  end: "End",
+  plus: "+",
+};
+
+const TOKEN_MAPS: Record<
+  ShortcutPlatform,
+  { modifiers: Record<string, string>; keys: Record<string, string> }
+> = {
+  mac: { modifiers: MAC_MODIFIER_SYMBOLS, keys: MAC_KEY_SYMBOLS },
+  windows: { modifiers: WINDOWS_MODIFIER_LABELS, keys: WINDOWS_KEY_LABELS },
 };
 
 /**
@@ -67,33 +134,49 @@ const tokenize = (accelerator: string): string[] => {
   return tokens;
 };
 
-/** Convert one accelerator token to its display glyph. */
-const displayToken = (token: string): string => {
+/** Convert one accelerator token to its display label for a platform. */
+const displayToken = (token: string, platform: ShortcutPlatform): string => {
   const lower = token.toLowerCase();
-  return (
-    MODIFIER_SYMBOLS[lower] ?? KEY_SYMBOLS[lower] ?? token.toUpperCase()
-  );
+  const { modifiers, keys } = TOKEN_MAPS[platform];
+  return modifiers[lower] ?? keys[lower] ?? token.toUpperCase();
 };
 
 /**
- * Parse an Electron accelerator into the display glyphs for each key cap.
+ * Parse an Electron accelerator into the display label for each key cap.
  * Exported so non-visual consumers (tests, aria labels) can reuse the mapping.
+ * `platform` defaults to the detected host.
  */
-export const parseAccelerator = (accelerator: string): string[] =>
-  tokenize(accelerator).map(displayToken);
+export const parseAccelerator = (
+  accelerator: string,
+  platform: ShortcutPlatform = detectShortcutPlatform(),
+): string[] =>
+  tokenize(accelerator).map((token) => displayToken(token, platform));
+
+/**
+ * Compact inline form for tooltips and hints: glyphs run together on macOS
+ * (`⌘⇧N`), text labels are `+`-joined on Windows (`Ctrl+Shift+N`).
+ */
+export const formatAcceleratorHint = (
+  accelerator: string,
+  platform: ShortcutPlatform = detectShortcutPlatform(),
+): string =>
+  parseAccelerator(accelerator, platform).join(platform === "mac" ? "" : "+");
 
 export interface ShortcutKeysProps extends ComponentProps<"span"> {
   /** Electron accelerator string, e.g. `"CmdOrCtrl+Shift+N"`. */
   accelerator: string;
+  /** Key-cap vocabulary; defaults to the detected host. */
+  platform?: ShortcutPlatform;
 }
 
 export function ShortcutKeys({
   accelerator,
+  platform,
   className,
   ref,
   ...rest
 }: ShortcutKeysProps) {
-  const caps = parseAccelerator(accelerator);
+  const caps = parseAccelerator(accelerator, platform);
   return (
     <span
       {...rest}

--- a/packages/design-library/src/index.ts
+++ b/packages/design-library/src/index.ts
@@ -270,6 +270,8 @@ export {
 export { ListRow, type ListRowProps } from "./components/list-row";
 export {
   ShortcutKeys,
+  detectShortcutPlatform,
+  formatAcceleratorHint,
   parseAccelerator,
   type ShortcutKeysProps,
 } from "./components/shortcut-keys";


### PR DESCRIPTION
## Summary
- `ShortcutKeys` / `parseAccelerator` now take a `platform` (`mac` | `windows`) and default to `detectShortcutPlatform()`, which reads `navigator` (correct inside the Electron renderer on Windows). Windows renders text caps (Ctrl, Alt, Shift, Win, Esc, Enter...) instead of ⌘⌃⌥ glyphs.
- New `formatAcceleratorHint()` produces the compact hint form (`⌘⇧O` on mac, `Ctrl+Shift+O` on Windows); the command palette hints, the palette's ⌘K cap, the New Chat hint, and the sidebar Search tooltip/aria-label all route through it.
- The `⌘K` copy moved out of the i18n catalogs: `commandPalette.shortcutHint` is removed and `assistantSideMenu.searchShortcut` takes a `{shortcut}` interpolation.

## Original prompt
Part of a batch of Windows client parity fixes. Shortcut glyphs rendered as macOS ⌘⌃⌥ symbols everywhere on Windows (design-library shortcut-keys, command palette hints, the ⌘K string). The ask was to make rendering platform-aware using existing platform detection and sweep the client code for other hardcoded mac glyphs.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41425" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->