### PR TITLE
feat(windows): no-partials watchdog and server-STT fallback for dictation

### DIFF
--- a/clients/windows/native/Vellum.WindowsHelper.Tests/DictationServiceTests.cs
+++ b/clients/windows/native/Vellum.WindowsHelper.Tests/DictationServiceTests.cs
@@ -85,18 +85,23 @@ public static class DictationServiceTests
         Assert(events.Any(e => e.Method == "dictation.finalized" &&
             e.Json.Contains("final text", StringComparison.Ordinal)));
 
-        // Device loss mid-session surfaces dictation.error, not finalized.
+        // Device loss mid-tap-session surfaces dictation.error, not
+        // finalized, and moves the session to the server path.
         events.Clear();
         engine = new FakeEngine();
+        var server = new FakeEngine();
+        manager = new DictationSessionManager(
+            request => request.RequireOnDevice ? engine : server, Notify);
         Assert(Json(manager.SetPartials(true, false, 16000))
             .Contains("\"enabled\":true", StringComparison.Ordinal));
         engine.EmitFailure("audio device lost");
         Assert(events.Any(e => e.Method == "dictation.error" &&
-            e.Json.Contains("audio device lost", StringComparison.Ordinal)));
+            e.Json.Contains("audio device lost", StringComparison.Ordinal) &&
+            e.Json.Contains("\"willRetryServer\":true", StringComparison.Ordinal)));
         Assert(!events.Any(e => e.Method == "dictation.finalized"));
         Assert(SpinWait.SpinUntil(() => engine.Disposed, TimeSpan.FromSeconds(1)));
         manager.AppendAudio(Convert.ToBase64String(new byte[] { 3, 4 }));
-        Assert(engine.Chunks.Count == 0);
+        Assert(engine.Chunks.Count == 0 && server.Chunks.Count == 1);
 
         // A tap session that stays silent is retried once on the server
         // path; a session that spoke up is left alone.
@@ -149,6 +154,7 @@ public static class DictationServiceTests
         // Restarting cancels the replaced session: it is torn down and its
         // late events are dropped without a finalized transcript.
         events.Clear();
+        manager = new DictationSessionManager(_ => engine, Notify);
         var first = engine = new FakeEngine();
         manager.SetPartials(true, true, 16000);
         engine = new FakeEngine();

--- a/clients/windows/native/Vellum.WindowsHelper.Tests/DictationServiceTests.cs
+++ b/clients/windows/native/Vellum.WindowsHelper.Tests/DictationServiceTests.cs
@@ -103,6 +103,25 @@ public static class DictationServiceTests
         manager.AppendAudio(Convert.ToBase64String(new byte[] { 3, 4 }));
         Assert(engine.Chunks.Count == 0 && server.Chunks.Count == 1);
 
+        // A failure racing a graceful stop reports terminally instead of
+        // reopening the microphone on the server path.
+        events.Clear();
+        engine = new FakeEngine { FinalizeOnFinish = false };
+        var serverStarts = 0;
+        manager = new DictationSessionManager(
+            request =>
+            {
+                serverStarts += request.RequireOnDevice ? 0 : 1;
+                return engine;
+            },
+            Notify);
+        manager.SetPartials(true, false, 16000);
+        manager.SetPartials(false, false, 16000);
+        engine.EmitFailure("late failure");
+        Assert(events.Any(e => e.Method == "dictation.error" &&
+            e.Json.Contains("\"willRetryServer\":false", StringComparison.Ordinal)));
+        Assert(serverStarts == 0);
+
         // A tap session that stays silent is retried once on the server
         // path; a session that spoke up is left alone.
         events.Clear();

--- a/clients/windows/native/Vellum.WindowsHelper.Tests/DictationServiceTests.cs
+++ b/clients/windows/native/Vellum.WindowsHelper.Tests/DictationServiceTests.cs
@@ -187,10 +187,36 @@ public static class DictationServiceTests
         // A failed replacement reports a reason and settles the displaced owner.
         events.Clear();
         engine = new FakeEngine { StartError = new Exception("audio device unavailable") };
-        Assert(Json(manager.SetPartials(true, false, 16000))
+        Assert(Json(manager.SetPartials(true, true, 16000))
             .Contains("audio device unavailable", StringComparison.Ordinal));
         Assert(events.Any(e => e.Method == "dictation.error" &&
             e.Json.Contains("audio device unavailable", StringComparison.Ordinal)));
+
+        // A tap session whose on-device engine cannot start falls through
+        // to the server path; when that fails too the error is terminal.
+        events.Clear();
+        var noLanguagePack = new FakeEngine { StartError = new Exception("no recognizer") };
+        var fallback = new FakeEngine();
+        manager = new DictationSessionManager(
+            request => request.RequireOnDevice ? noLanguagePack : fallback, Notify);
+        Assert(Json(manager.SetPartials(true, false, 16000))
+            .Contains("\"enabled\":true", StringComparison.Ordinal));
+        Assert(noLanguagePack.Disposed);
+        Assert(events.Any(e => e.Method == "dictation.error" &&
+            e.Json.Contains("\"willRetryServer\":true", StringComparison.Ordinal)));
+        events.Clear();
+        manager = new DictationSessionManager(
+            request => request.RequireOnDevice
+                ? throw new DictationUnavailableException("no recognizer")
+                : throw new DictationUnavailableException("offline"),
+            Notify);
+        Assert(Json(manager.SetPartials(true, false, 16000))
+            .Contains("offline", StringComparison.Ordinal));
+        Assert(events.Count(e => e.Method == "dictation.error") == 2);
+        Assert(events.Any(e =>
+            e.Json.Contains("\"onDevice\":false", StringComparison.Ordinal) &&
+            e.Json.Contains("\"willRetryServer\":false", StringComparison.Ordinal)));
+        manager = new DictationSessionManager(_ => engine, Notify);
 
         // Whole-recording transcription uses an independent pushed-audio
         // engine, publishes its final text, and does not disturb streaming.

--- a/clients/windows/native/Vellum.WindowsHelper.Tests/DictationServiceTests.cs
+++ b/clients/windows/native/Vellum.WindowsHelper.Tests/DictationServiceTests.cs
@@ -10,6 +10,8 @@ public static class DictationServiceTests
     {
         public string Tap => "fake";
 
+        public bool HeardAudio => false;
+
         public bool Finished;
         public bool Cancelled;
         public bool Disposed;
@@ -95,6 +97,54 @@ public static class DictationServiceTests
         Assert(SpinWait.SpinUntil(() => engine.Disposed, TimeSpan.FromSeconds(1)));
         manager.AppendAudio(Convert.ToBase64String(new byte[] { 3, 4 }));
         Assert(engine.Chunks.Count == 0);
+
+        // A tap session that stays silent is retried once on the server
+        // path; a session that spoke up is left alone.
+        events.Clear();
+        var silent = new FakeEngine();
+        var online = new FakeEngine();
+        var requests = new List<DictationEngineRequest>();
+        manager = new DictationSessionManager(
+            request =>
+            {
+                requests.Add(request);
+                return request.RequireOnDevice ? silent : online;
+            },
+            Notify,
+            TimeSpan.FromMilliseconds(50));
+        manager.SetPartials(true, false, 16000);
+        Assert(SpinWait.SpinUntil(() => silent.Cancelled, TimeSpan.FromSeconds(2)));
+        Assert(events.Any(e => e.Method == "dictation.error" &&
+            e.Json.Contains("\"willRetryServer\":true", StringComparison.Ordinal)));
+        Assert(requests.Count == 2 && !requests[1].RequireOnDevice);
+        silent.EmitPartial("stale");
+        online.EmitPartial("server");
+        Assert(!events.Any(e => e.Json.Contains("stale", StringComparison.Ordinal)));
+        Assert(events.Any(e => e.Method == "dictation.partial" &&
+            e.Json.Contains("server", StringComparison.Ordinal)));
+
+        events.Clear();
+        var talkative = new FakeEngine();
+        manager = new DictationSessionManager(
+            _ => talkative, Notify, TimeSpan.FromMilliseconds(50));
+        manager.SetPartials(true, false, 16000);
+        talkative.EmitPartial("hi");
+        Thread.Sleep(150);
+        Assert(!talkative.Cancelled);
+        Assert(!events.Any(e => e.Method == "dictation.error"));
+
+        // Pushed-audio sessions never move to the server path, and an
+        // on-device failure there stays terminal.
+        events.Clear();
+        var pushed = new FakeEngine();
+        manager = new DictationSessionManager(
+            _ => pushed, Notify, TimeSpan.FromMilliseconds(50));
+        manager.SetPartials(true, true, 16000);
+        Thread.Sleep(150);
+        Assert(!pushed.Cancelled);
+        pushed.EmitFailure("gone");
+        Assert(events.Any(e => e.Method == "dictation.error" &&
+            e.Json.Contains("\"willRetryServer\":false", StringComparison.Ordinal)));
 
         // Restarting cancels the replaced session: it is torn down and its
         // late events are dropped without a finalized transcript.

--- a/clients/windows/native/Vellum.WindowsHelper/Modules/DictationService.cs
+++ b/clients/windows/native/Vellum.WindowsHelper/Modules/DictationService.cs
@@ -3,6 +3,7 @@ using System.Speech.AudioFormat;
 using System.Speech.Recognition;
 using System.Text.Json;
 using Vellum.WindowsHelper.Rpc;
+using Windows.Media.SpeechRecognition;
 
 namespace Vellum.WindowsHelper.Modules;
 
@@ -11,11 +12,17 @@ namespace Vellum.WindowsHelper.Modules;
 /// macOS helper. Audio is pushed by the renderer as base64 16 kHz mono
 /// Int16 LE PCM; without pushed audio the recognizer taps the system default
 /// input device. Audio and transcripts only ever live in memory.
+///
+/// Sessions start on-device (System.Speech). A tap session that stays
+/// silent, or whose recognizer dies, is retried once on the server path
+/// (WinRT online dictation), mirroring the macOS helper's watchdog.
 /// </summary>
 public sealed class DictationService : IRpcModule, IDictationSink
 {
     private readonly DictationSessionManager _manager = new(
-        request => new SystemSpeechEngine(request),
+        request => request.RequireOnDevice
+            ? new SystemSpeechEngine(request)
+            : new OnlineSpeechEngine(request),
         HelperNotifications.Emit);
 
     public string CapabilityId => "dictation";
@@ -54,12 +61,18 @@ public sealed class DictationService : IRpcModule, IDictationSink
 public sealed class DictationUnavailableException(string reason)
     : Exception(reason);
 
-public sealed record DictationEngineRequest(bool PushAudio, int SampleRate);
+public sealed record DictationEngineRequest(
+    bool PushAudio,
+    int SampleRate,
+    bool RequireOnDevice = true);
 
 /// <summary>Recognition engine seam so session behavior is testable.</summary>
 public interface IDictationEngine : IDisposable
 {
     string Tap { get; }
+
+    /// <summary>Whether the input carried speech-level audio so far.</summary>
+    bool HeardAudio { get; }
 
     event Action<string>? Partial;
     event Action<string>? Finalized;
@@ -77,16 +90,24 @@ public interface IDictationEngine : IDisposable
 /// </summary>
 public sealed class DictationSessionManager(
     Func<DictationEngineRequest, IDictationEngine> engineFactory,
-    Action<string, object> notify)
+    Action<string, object> notify,
+    TimeSpan? silentStartWatchdog = null)
 {
     private static readonly TimeSpan StreamingCompletionTimeout =
         TimeSpan.FromSeconds(3);
     private static readonly TimeSpan TranscriptionCompletionGrace =
         TimeSpan.FromSeconds(3);
+    // Matches the macOS helper: a pinned session with no partial, error or
+    // final by then is treated as hung.
+    private static readonly TimeSpan DefaultSilentStartWatchdog =
+        TimeSpan.FromSeconds(2.5);
 
+    private readonly TimeSpan _silentStartWatchdog =
+        silentStartWatchdog ?? DefaultSilentStartWatchdog;
     private readonly object _gate = new();
     private IDictationEngine? _engine;
     private int _generation;
+    private bool _sawActivity;
     private IDictationEngine? _transcriptionEngine;
     private int _transcriptionGeneration;
 
@@ -103,53 +124,127 @@ public sealed class DictationSessionManager(
             }
 
             CancelLocked();
-            var generation = ++_generation;
-            IDictationEngine engine;
-            try
-            {
-                engine = engineFactory(new DictationEngineRequest(pushAudio, sampleRate));
-            }
-            catch (DictationUnavailableException err)
-            {
-                NotifyStartFailure(err.Message);
-                return new { enabled = false, reason = err.Message };
-            }
-            engine.Partial += text => IfCurrent(generation, () =>
-                notify("dictation.partial", new { text }));
-            engine.Failed += message =>
-            {
-                ReleaseIfCurrent(generation, engine, () =>
-                    notify("dictation.error",
-                        new { message, onDevice = true, willRetryServer = false }));
-                _ = Task.Run(engine.Dispose);
-            };
-            engine.Finalized += text =>
-            {
-                ReleaseIfCurrent(generation, engine, () =>
-                    notify("dictation.finalized", new { text }));
-                _ = Task.Run(engine.Dispose);
-            };
-            _engine = engine;
-            try
-            {
-                engine.Start();
-            }
-            catch (Exception err)
-            {
-                if (ReferenceEquals(_engine, engine))
-                {
-                    _engine = null;
-                    engine.Dispose();
-                }
-                NotifyStartFailure(err.Message);
-                return new { enabled = false, reason = err.Message };
-            }
-            if (!ReferenceEquals(_engine, engine))
-            {
-                return new { enabled = false, reason = "recognition failed" };
-            }
-            return new { enabled = true, tap = engine.Tap };
+            return StartLocked(new DictationEngineRequest(pushAudio, sampleRate));
         }
+    }
+
+    private object StartLocked(DictationEngineRequest request)
+    {
+        var generation = ++_generation;
+        _sawActivity = false;
+        IDictationEngine engine;
+        try
+        {
+            engine = engineFactory(request);
+        }
+        catch (DictationUnavailableException err)
+        {
+            NotifyStartFailure(err.Message, request.RequireOnDevice);
+            return new { enabled = false, reason = err.Message };
+        }
+        // Only a tap session can move to the server path: the online
+        // engine cannot replay pushed PCM, and short push dictations settle
+        // through `dictation.transcribe` anyway.
+        var canRetryServer = request.RequireOnDevice && !request.PushAudio;
+        engine.Partial += text => IfCurrent(generation, () =>
+        {
+            _sawActivity = true;
+            notify("dictation.partial", new { text });
+        });
+        engine.Failed += message =>
+        {
+            ReleaseIfCurrent(generation, engine, () =>
+            {
+                _sawActivity = true;
+                notify("dictation.error", new
+                {
+                    message,
+                    onDevice = request.RequireOnDevice,
+                    willRetryServer = canRetryServer,
+                });
+                if (canRetryServer)
+                {
+                    RetryOnServerLocked(request);
+                }
+            });
+            _ = Task.Run(engine.Dispose);
+        };
+        engine.Finalized += text =>
+        {
+            ReleaseIfCurrent(generation, engine, () =>
+            {
+                _sawActivity = true;
+                notify("dictation.finalized", new { text });
+            });
+            _ = Task.Run(engine.Dispose);
+        };
+        _engine = engine;
+        try
+        {
+            engine.Start();
+        }
+        catch (Exception err)
+        {
+            if (ReferenceEquals(_engine, engine))
+            {
+                _engine = null;
+                engine.Dispose();
+            }
+            NotifyStartFailure(err.Message, request.RequireOnDevice);
+            return new { enabled = false, reason = err.Message };
+        }
+        if (!ReferenceEquals(_engine, engine))
+        {
+            // Failed synchronously during Start; a server retry may have
+            // already replaced it.
+            return _engine is null
+                ? new { enabled = false, reason = "recognition failed" }
+                : new { enabled = true, tap = _engine.Tap };
+        }
+        if (canRetryServer)
+        {
+            ScheduleSilentStartWatchdog(generation, engine, request);
+        }
+        return new { enabled = true, tap = engine.Tap };
+    }
+
+    /// <summary>
+    /// A pinned recognizer can hang without a partial or an error (missing
+    /// language pack, half-installed recognizer). Error-driven retry cannot
+    /// catch that, so a session still silent after the watchdog delay is
+    /// restarted on the server path.
+    /// </summary>
+    private void ScheduleSilentStartWatchdog(
+        int generation,
+        IDictationEngine engine,
+        DictationEngineRequest request)
+    {
+        _ = Task.Delay(_silentStartWatchdog).ContinueWith(_ =>
+        {
+            lock (_gate)
+            {
+                if (generation != _generation ||
+                    _sawActivity ||
+                    !ReferenceEquals(_engine, engine))
+                {
+                    return;
+                }
+                notify("dictation.error", new
+                {
+                    message =
+                        $"on-device recognition produced no output (heardAudio={engine.HeardAudio}, tap={engine.Tap}); retrying on the server path",
+                    onDevice = true,
+                    willRetryServer = true,
+                });
+                RetryOnServerLocked(request);
+            }
+        });
+    }
+
+    private void RetryOnServerLocked(DictationEngineRequest request)
+    {
+        CancelLocked();
+        StartLocked(request with { RequireOnDevice = false });
     }
 
     public object AppendAudio(string base64)
@@ -250,9 +345,9 @@ public sealed class DictationSessionManager(
         _transcriptionEngine = null;
     }
 
-    private void NotifyStartFailure(string message) =>
+    private void NotifyStartFailure(string message, bool onDevice) =>
         notify("dictation.error",
-            new { message, onDevice = true, willRetryServer = false });
+            new { message, onDevice, willRetryServer = false });
 
     private static TimeSpan TranscriptionCompletionTimeout(
         int pcmByteLength,
@@ -328,6 +423,7 @@ internal sealed class SystemSpeechEngine : IDictationEngine
     private string _committed = "";
     private bool _finishing;
     private bool _completed;
+    private volatile bool _heardAudio;
 
     public SystemSpeechEngine(DictationEngineRequest request)
     {
@@ -376,9 +472,18 @@ internal sealed class SystemSpeechEngine : IDictationEngine
             Partial?.Invoke(_committed);
         };
         _engine.RecognizeCompleted += (_, args) => Complete(args.Error?.Message);
+        _engine.AudioStateChanged += (_, args) =>
+        {
+            if (args.AudioState == AudioState.Speech)
+            {
+                _heardAudio = true;
+            }
+        };
     }
 
     public string Tap { get; }
+
+    public bool HeardAudio => _heardAudio;
 
     public event Action<string>? Partial;
     public event Action<string>? Finalized;
@@ -415,6 +520,138 @@ internal sealed class SystemSpeechEngine : IDictationEngine
         _pushStream?.Dispose();
         _engine.Dispose();
     }
+
+    private void Complete(string? error)
+    {
+        bool finishing;
+        lock (_gate)
+        {
+            if (_completed)
+            {
+                return;
+            }
+            _completed = true;
+            finishing = _finishing;
+        }
+        if (error is not null && !finishing)
+        {
+            Failed?.Invoke(error);
+            return;
+        }
+        Finalized?.Invoke(_committed);
+    }
+
+    private static string Combine(string committed, string next) =>
+        committed.Length == 0 ? next : $"{committed} {next}";
+}
+
+/// <summary>
+/// Server-path dictation through WinRT online recognition, used when the
+/// on-device session stays silent or dies. WinRT only listens on the
+/// system default input, so pushed PCM sessions cannot use it.
+/// </summary>
+internal sealed class OnlineSpeechEngine : IDictationEngine
+{
+    private readonly SpeechRecognizer _recognizer;
+    private readonly object _gate = new();
+    private string _committed = "";
+    private bool _finishing;
+    private bool _completed;
+
+    public OnlineSpeechEngine(DictationEngineRequest request)
+    {
+        if (request.PushAudio)
+        {
+            throw new DictationUnavailableException(
+                "online recognition only supports the system default input");
+        }
+        try
+        {
+            _recognizer = new SpeechRecognizer();
+            _recognizer.Constraints.Add(new SpeechRecognitionTopicConstraint(
+                SpeechRecognitionScenario.Dictation, "dictation"));
+            var compiled = _recognizer.CompileConstraintsAsync()
+                .AsTask().GetAwaiter().GetResult();
+            if (compiled.Status != SpeechRecognitionResultStatus.Success)
+            {
+                throw new InvalidOperationException(
+                    $"online recognition unavailable ({compiled.Status})");
+            }
+        }
+        catch (Exception err)
+        {
+            _recognizer?.Dispose();
+            throw new DictationUnavailableException(err.Message);
+        }
+        _recognizer.HypothesisGenerated += (_, args) =>
+            Partial?.Invoke(Combine(_committed, args.Hypothesis.Text));
+        _recognizer.ContinuousRecognitionSession.ResultGenerated += (_, args) =>
+        {
+            lock (_gate)
+            {
+                _committed = Combine(_committed, args.Result.Text);
+            }
+            Partial?.Invoke(_committed);
+        };
+        _recognizer.ContinuousRecognitionSession.Completed += (_, args) =>
+            Complete(args.Status == SpeechRecognitionResultStatus.Success
+                ? null
+                : args.Status.ToString());
+    }
+
+    public string Tap => "system default input (online)";
+
+    // The online session reports levels only through results.
+    public bool HeardAudio => _committed.Length > 0;
+
+    public event Action<string>? Partial;
+    public event Action<string>? Finalized;
+    public event Action<string>? Failed;
+
+    // Throws when the online speech privacy setting is off; the session
+    // manager reports it as a start failure.
+    public void Start() =>
+        _recognizer.ContinuousRecognitionSession.StartAsync()
+            .AsTask().GetAwaiter().GetResult();
+
+    public void Append(byte[] pcm)
+    {
+    }
+
+    public void Finish(TimeSpan completionTimeout)
+    {
+        lock (_gate)
+        {
+            _finishing = true;
+        }
+        try
+        {
+            _ = _recognizer.ContinuousRecognitionSession.StopAsync().AsTask();
+        }
+        catch (Exception)
+        {
+            // Session already ended; the guard below finalizes.
+        }
+        _ = Task.Delay(completionTimeout).ContinueWith(_ => Complete(null));
+    }
+
+    public void Cancel()
+    {
+        lock (_gate)
+        {
+            _completed = true;
+        }
+        try
+        {
+            _ = _recognizer.ContinuousRecognitionSession.CancelAsync().AsTask();
+        }
+        catch (Exception)
+        {
+            // Session never started.
+        }
+    }
+
+    public void Dispose() => _recognizer.Dispose();
 
     private void Complete(string? error)
     {

--- a/clients/windows/native/Vellum.WindowsHelper/Modules/DictationService.cs
+++ b/clients/windows/native/Vellum.WindowsHelper/Modules/DictationService.cs
@@ -133,6 +133,10 @@ public sealed class DictationSessionManager(
     {
         var generation = ++_generation;
         _sawActivity = false;
+        // Only a tap session can move to the server path: the online
+        // engine cannot replay pushed PCM, and short push dictations settle
+        // through `dictation.transcribe` anyway.
+        var canRetryServer = request.RequireOnDevice && !request.PushAudio;
         IDictationEngine engine;
         try
         {
@@ -140,13 +144,8 @@ public sealed class DictationSessionManager(
         }
         catch (DictationUnavailableException err)
         {
-            NotifyStartFailure(err.Message, request.RequireOnDevice);
-            return new { enabled = false, reason = err.Message };
+            return StartFailedLocked(err.Message, request, canRetryServer);
         }
-        // Only a tap session can move to the server path: the online
-        // engine cannot replay pushed PCM, and short push dictations settle
-        // through `dictation.transcribe` anyway.
-        var canRetryServer = request.RequireOnDevice && !request.PushAudio;
         engine.Partial += text => IfCurrent(generation, () =>
         {
             _sawActivity = true;
@@ -194,8 +193,7 @@ public sealed class DictationSessionManager(
                 _engine = null;
                 engine.Dispose();
             }
-            NotifyStartFailure(err.Message, request.RequireOnDevice);
-            return new { enabled = false, reason = err.Message };
+            return StartFailedLocked(err.Message, request, canRetryServer);
         }
         if (!ReferenceEquals(_engine, engine))
         {
@@ -249,6 +247,29 @@ public sealed class DictationSessionManager(
     {
         CancelLocked();
         StartLocked(request with { RequireOnDevice = false });
+    }
+
+    /// <summary>
+    /// A tap session whose on-device recognizer cannot even be built or
+    /// started (no language pack, denied device) tries the server path;
+    /// anything else is a terminal error.
+    /// </summary>
+    private object StartFailedLocked(
+        string message,
+        DictationEngineRequest request,
+        bool canRetryServer)
+    {
+        notify("dictation.error", new
+        {
+            message,
+            onDevice = request.RequireOnDevice,
+            willRetryServer = canRetryServer,
+        });
+        if (!canRetryServer)
+        {
+            return new { enabled = false, reason = message };
+        }
+        return StartLocked(request with { RequireOnDevice = false });
     }
 
     public object AppendAudio(string base64)
@@ -348,10 +369,6 @@ public sealed class DictationSessionManager(
         _transcriptionEngine?.Dispose();
         _transcriptionEngine = null;
     }
-
-    private void NotifyStartFailure(string message, bool onDevice) =>
-        notify("dictation.error",
-            new { message, onDevice, willRetryServer = false });
 
     private static TimeSpan TranscriptionCompletionTimeout(
         int pcmByteLength,
@@ -579,13 +596,6 @@ internal sealed class OnlineSpeechEngine : IDictationEngine
             _recognizer = new WinRtSpeechRecognizer();
             _recognizer.Constraints.Add(new SpeechRecognitionTopicConstraint(
                 SpeechRecognitionScenario.Dictation, "dictation"));
-            var compiled = _recognizer.CompileConstraintsAsync()
-                .AsTask().GetAwaiter().GetResult();
-            if (compiled.Status != SpeechRecognitionResultStatus.Success)
-            {
-                throw new InvalidOperationException(
-                    $"online recognition unavailable ({compiled.Status})");
-            }
         }
         catch (Exception err)
         {
@@ -617,11 +627,29 @@ internal sealed class OnlineSpeechEngine : IDictationEngine
     public event Action<string>? Finalized;
     public event Action<string>? Failed;
 
-    // Throws when the online speech privacy setting is off; the session
-    // manager reports it as a start failure.
-    public void Start() =>
-        _recognizer.ContinuousRecognitionSession.StartAsync()
-            .AsTask().GetAwaiter().GetResult();
+    // Compile and start off the caller's thread: the session manager
+    // holds its lock during Start, and the online path can stall on the
+    // network. Failures (offline, online speech privacy setting off)
+    // surface through `Failed`.
+    public void Start() => _ = StartAsync();
+
+    private async Task StartAsync()
+    {
+        try
+        {
+            var compiled = await _recognizer.CompileConstraintsAsync();
+            if (compiled.Status != SpeechRecognitionResultStatus.Success)
+            {
+                Complete($"online recognition unavailable ({compiled.Status})");
+                return;
+            }
+            await _recognizer.ContinuousRecognitionSession.StartAsync();
+        }
+        catch (Exception err)
+        {
+            Complete(err.Message);
+        }
+    }
 
     public void Append(byte[] pcm)
     {

--- a/clients/windows/native/Vellum.WindowsHelper/Modules/DictationService.cs
+++ b/clients/windows/native/Vellum.WindowsHelper/Modules/DictationService.cs
@@ -578,6 +578,8 @@ internal sealed class SystemSpeechEngine : IDictationEngine
 /// </summary>
 internal sealed class OnlineSpeechEngine : IDictationEngine
 {
+    private static readonly TimeSpan StartupTimeout = TimeSpan.FromSeconds(5);
+
     private readonly WinRtSpeechRecognizer _recognizer;
     private readonly object _gate = new();
     private string _committed = "";
@@ -627,28 +629,32 @@ internal sealed class OnlineSpeechEngine : IDictationEngine
     public event Action<string>? Finalized;
     public event Action<string>? Failed;
 
-    // Compile and start off the caller's thread: the session manager
-    // holds its lock during Start, and the online path can stall on the
-    // network. Failures (offline, online speech privacy setting off)
-    // surface through `Failed`.
-    public void Start() => _ = StartAsync();
+    // Startup is synchronous so `dictation.setPartials` only acknowledges
+    // a session that is really listening, but bounded: the session manager
+    // holds its lock meanwhile and the online path can stall on the
+    // network. Throws when offline or the online speech setting is off.
+    public void Start()
+    {
+        var startup = StartAsync();
+        var settled = Task.WhenAny(startup, Task.Delay(StartupTimeout))
+            .GetAwaiter().GetResult();
+        if (!ReferenceEquals(settled, startup))
+        {
+            Cancel();
+            throw new TimeoutException("online recognition did not start in time");
+        }
+        startup.GetAwaiter().GetResult();
+    }
 
     private async Task StartAsync()
     {
-        try
+        var compiled = await _recognizer.CompileConstraintsAsync();
+        if (compiled.Status != SpeechRecognitionResultStatus.Success)
         {
-            var compiled = await _recognizer.CompileConstraintsAsync();
-            if (compiled.Status != SpeechRecognitionResultStatus.Success)
-            {
-                Complete($"online recognition unavailable ({compiled.Status})");
-                return;
-            }
-            await _recognizer.ContinuousRecognitionSession.StartAsync();
+            throw new InvalidOperationException(
+                $"online recognition unavailable ({compiled.Status})");
         }
-        catch (Exception err)
-        {
-            Complete(err.Message);
-        }
+        await _recognizer.ContinuousRecognitionSession.StartAsync();
     }
 
     public void Append(byte[] pcm)

--- a/clients/windows/native/Vellum.WindowsHelper/Modules/DictationService.cs
+++ b/clients/windows/native/Vellum.WindowsHelper/Modules/DictationService.cs
@@ -154,16 +154,19 @@ public sealed class DictationSessionManager(
         });
         engine.Failed += message =>
         {
-            ReleaseIfCurrent(generation, engine, () =>
+            // A session already stopped by SetPartials(false) must not
+            // retry: that would reopen the microphone after the user let go.
+            ReleaseIfCurrent(generation, engine, wasActive =>
             {
                 _sawActivity = true;
+                var retry = canRetryServer && wasActive;
                 notify("dictation.error", new
                 {
                     message,
                     onDevice = request.RequireOnDevice,
-                    willRetryServer = canRetryServer,
+                    willRetryServer = retry,
                 });
-                if (canRetryServer)
+                if (retry)
                 {
                     RetryOnServerLocked(request);
                 }
@@ -172,7 +175,7 @@ public sealed class DictationSessionManager(
         };
         engine.Finalized += text =>
         {
-            ReleaseIfCurrent(generation, engine, () =>
+            ReleaseIfCurrent(generation, engine, _ =>
             {
                 _sawActivity = true;
                 notify("dictation.finalized", new { text });
@@ -372,10 +375,14 @@ public sealed class DictationSessionManager(
         }
     }
 
+    /// <summary>
+    /// Runs `action` for a same-generation callback, passing whether the
+    /// engine was still the active session (false after a graceful stop).
+    /// </summary>
     private void ReleaseIfCurrent(
         int generation,
         IDictationEngine engine,
-        Action action)
+        Action<bool> action)
     {
         lock (_gate)
         {
@@ -383,11 +390,12 @@ public sealed class DictationSessionManager(
             {
                 return;
             }
-            if (ReferenceEquals(_engine, engine))
+            var wasActive = ReferenceEquals(_engine, engine);
+            if (wasActive)
             {
                 _engine = null;
             }
-            action();
+            action(wasActive);
         }
     }
 

--- a/clients/windows/native/Vellum.WindowsHelper/Modules/DictationService.cs
+++ b/clients/windows/native/Vellum.WindowsHelper/Modules/DictationService.cs
@@ -4,6 +4,7 @@ using System.Speech.Recognition;
 using System.Text.Json;
 using Vellum.WindowsHelper.Rpc;
 using Windows.Media.SpeechRecognition;
+using WinRtSpeechRecognizer = Windows.Media.SpeechRecognition.SpeechRecognizer;
 
 namespace Vellum.WindowsHelper.Modules;
 
@@ -552,7 +553,7 @@ internal sealed class SystemSpeechEngine : IDictationEngine
 /// </summary>
 internal sealed class OnlineSpeechEngine : IDictationEngine
 {
-    private readonly SpeechRecognizer _recognizer;
+    private readonly WinRtSpeechRecognizer _recognizer;
     private readonly object _gate = new();
     private string _committed = "";
     private bool _finishing;
@@ -567,7 +568,7 @@ internal sealed class OnlineSpeechEngine : IDictationEngine
         }
         try
         {
-            _recognizer = new SpeechRecognizer();
+            _recognizer = new WinRtSpeechRecognizer();
             _recognizer.Constraints.Add(new SpeechRecognitionTopicConstraint(
                 SpeechRecognitionScenario.Dictation, "dictation"));
             var compiled = _recognizer.CompileConstraintsAsync()

--- a/clients/windows/src/main/dictation.test.ts
+++ b/clients/windows/src/main/dictation.test.ts
@@ -230,6 +230,27 @@ test("a terminal recognition error settles and clears the owner", async () => {
   expect(owner.send).toHaveBeenCalledTimes(1);
 });
 
+test("server-path retry keeps the streaming owner", async () => {
+  const owner = makeSender();
+  await handlers["vellum:helper:dictation:setPartials"]!(
+    [true, undefined, false],
+    { sender: owner },
+  );
+
+  fakeClient.notifications.get("dictation.error")!({
+    message: "no output",
+    onDevice: true,
+    willRetryServer: true,
+  });
+  expect(owner.send).not.toHaveBeenCalled();
+
+  fakeClient.notifications.get("dictation.partial")!({ text: "server" });
+  expect(owner.send).toHaveBeenCalledWith(
+    "vellum:helper:dictation:partial",
+    { text: "server" },
+  );
+});
+
 test("one-shot transcription routes independently from streaming", async () => {
   const recording = makeSender();
   const transcribing = makeSender();

--- a/clients/windows/src/main/features/dictation.ts
+++ b/clients/windows/src/main/features/dictation.ts
@@ -45,6 +45,11 @@ const DICTATION_TEXT_SCHEMA = z.object({ text: z.string() });
 const DICTATION_TRANSCRIBED_SCHEMA = DICTATION_TEXT_SCHEMA.extend({
   requestId: z.string(),
 });
+const DICTATION_ERROR_SCHEMA = z.object({
+  message: z.string(),
+  onDevice: z.boolean().optional(),
+  willRetryServer: z.boolean().optional(),
+});
 let clientFactory = (): NativeSidecarClient => getWindowsHelperClient();
 let client: NativeSidecarClient | null = null;
 const getClient = (): NativeSidecarClient => (client ??= clientFactory());
@@ -161,9 +166,16 @@ export const installDictation = (): void => {
   );
   helper.onNotification(
     "dictation.error",
-    z.object({ message: z.string() }),
+    DICTATION_ERROR_SCHEMA,
     (event) => {
-      log.warn(`[win-helper] dictation error: ${event.message}`);
+      log.warn(
+        `[win-helper] dictation error (onDevice=${event.onDevice ?? true}, retryServer=${event.willRetryServer ?? false}): ${event.message}`,
+      );
+      // The helper is restarting the session on the server path; the
+      // owner keeps streaming.
+      if (event.willRetryServer) {
+        return;
+      }
       dictationOwners
         .target()
         ?.send(HELPER_DICTATION_FINALIZED_EVENT, { text: "" });


### PR DESCRIPTION
## Summary
- Add a silent-start watchdog to the Windows helper's dictation session manager: a tap (non-pushed) session with no partial, error or final after 2.5s emits `dictation.error` with `willRetryServer: true` and restarts on the server path, mirroring the macOS helper. On-device recognizer failures in tap sessions retry the same way instead of being terminal.
- Add `OnlineSpeechEngine` (WinRT `Windows.Media.SpeechRecognition` online dictation) as the server-path engine; the legacy System.Speech engine stays the on-device default. `IDictationEngine` gains `HeardAudio` for the watchdog's field-debug message.
- Electron main now parses `onDevice`/`willRetryServer` on `dictation.error` and keeps the streaming owner alive while the helper retries, instead of finalizing with empty text.

## Original prompt
Part of a batch of Windows client parity PRs. Windows dictation had no no-partials watchdog (`willRetryServer` was always false), so a hung or dead System.Speech session never fell back to server STT the way the macOS helper does. Add the equivalent watchdog and server-path fallback around the existing engine without replacing System.Speech.

## Notes
- No dotnet toolchain on the authoring machine; the C# is exercised by the native-helper CI build and `DictationServiceTests` (new watchdog, no-retry-on-activity and no-retry-for-pushed-audio cases).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41427" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->