### PR TITLE
fix(assistant): retry provider rate limits in the agent loop

### DIFF
--- a/assistant/src/__tests__/agent-loop-provider-error-recording.test.ts
+++ b/assistant/src/__tests__/agent-loop-provider-error-recording.test.ts
@@ -75,10 +75,9 @@ function makeThrowingProvider(
 describe("AgentLoop provider_error event emission", () => {
   test("emits provider_error with loop-level rawRequest when provider throws ProviderError", async () => {
     const thrown = new ProviderError(
-      "Anthropic API error (429): rate limited",
+      "Anthropic API error (400): invalid request",
       "anthropic",
-      429,
-      { retryAfterMs: 1500 },
+      400,
     );
     const { provider, calls } = makeThrowingProvider("anthropic", () => thrown);
 

--- a/assistant/src/__tests__/agent-loop-rate-limit-retry.test.ts
+++ b/assistant/src/__tests__/agent-loop-rate-limit-retry.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, test } from "bun:test";
+
+import type { AgentEvent } from "../agent/loop.js";
+import { AgentLoop } from "../agent/loop.js";
+import { DEFAULT_MAX_RETRIES } from "../daemon/conversation-rate-limit-retry.js";
+import type {
+  Message,
+  Provider,
+  ProviderResponse,
+  SendMessageOptions,
+} from "../providers/types.js";
+import { ProviderError } from "../util/errors.js";
+
+function rateLimitError(): ProviderError {
+  return new ProviderError(
+    "Anthropic API error (429): Too many requests",
+    "mock-provider",
+    429,
+    { reason: "rate_limited", retryAfterMs: 0 },
+  );
+}
+
+function textReply(text: string): ProviderResponse {
+  return {
+    content: [{ type: "text", text }],
+    model: "mock",
+    usage: { inputTokens: 1, outputTokens: 1 },
+    stopReason: "end_turn",
+  };
+}
+
+function runLoop(
+  provider: Provider,
+  options?: { signal?: AbortSignal },
+): Promise<{ events: AgentEvent[]; calls: number }> {
+  const events: AgentEvent[] = [];
+  let calls = 0;
+  const wrapped: Provider = {
+    name: provider.name,
+    async sendMessage(messages: Message[], sendOptions?: SendMessageOptions) {
+      calls++;
+      return provider.sendMessage(messages, sendOptions);
+    },
+  };
+  const loop = new AgentLoop({
+    provider: wrapped,
+    systemPrompt: "system",
+    conversationId: "conv-xyz",
+  });
+  return loop
+    .run({
+      requestId: "req-1",
+      messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+      onEvent: (event) => {
+        events.push(event);
+      },
+      trust: { sourceChannel: "vellum", trustClass: "unknown" },
+      ...(options?.signal ? { signal: options.signal } : {}),
+    })
+    .then(() => ({ events, calls }));
+}
+
+describe("AgentLoop rate-limit retries", () => {
+  test("retries a PROVIDER_RATE_LIMIT error and completes without an error event", async () => {
+    let attempts = 0;
+    const provider: Provider = {
+      name: "mock-provider",
+      async sendMessage() {
+        attempts++;
+        if (attempts === 1) {
+          throw rateLimitError();
+        }
+        return textReply("recovered");
+      },
+    };
+
+    const { events, calls } = await runLoop(provider);
+
+    expect(calls).toBe(2);
+    expect(events.some((event) => event.type === "error")).toBe(false);
+    expect(events.some((event) => event.type === "message_complete")).toBe(
+      true,
+    );
+  });
+
+  test("emits a terminal error after DEFAULT_MAX_RETRIES", async () => {
+    const provider: Provider = {
+      name: "mock-provider",
+      async sendMessage() {
+        throw rateLimitError();
+      },
+    };
+
+    const { events, calls } = await runLoop(provider);
+
+    expect(calls).toBe(1 + DEFAULT_MAX_RETRIES);
+    expect(events.filter((event) => event.type === "error")).toHaveLength(1);
+    const errorEvent = events.find((event) => event.type === "error");
+    expect(errorEvent?.type === "error" && errorEvent.error).toBeInstanceOf(
+      ProviderError,
+    );
+  });
+
+  test("does not retry when the abort signal is already active", async () => {
+    const controller = new AbortController();
+    const provider: Provider = {
+      name: "mock-provider",
+      async sendMessage() {
+        controller.abort();
+        throw rateLimitError();
+      },
+    };
+
+    const { events, calls } = await runLoop(provider, {
+      signal: controller.signal,
+    });
+
+    expect(calls).toBe(1);
+    expect(events.some((event) => event.type === "error")).toBe(false);
+  });
+
+  test("does not retry a retryable non-rate-limit provider error", async () => {
+    const provider: Provider = {
+      name: "mock-provider",
+      async sendMessage() {
+        throw new ProviderError(
+          "Anthropic API error (529): Overloaded",
+          "mock-provider",
+          529,
+          { reason: "overloaded", retryAfterMs: 0 },
+        );
+      },
+    };
+
+    const { events, calls } = await runLoop(provider);
+
+    expect(calls).toBe(1);
+    expect(events.some((event) => event.type === "error")).toBe(true);
+  });
+
+  test("aborts during the rate-limit backoff instead of emitting an error event", async () => {
+    const controller = new AbortController();
+    const provider: Provider = {
+      name: "mock-provider",
+      async sendMessage() {
+        throw new ProviderError(
+          "Anthropic API error (429): Too many requests",
+          "mock-provider",
+          429,
+          { reason: "rate_limited", retryAfterMs: 200 },
+        );
+      },
+    };
+
+    const events: AgentEvent[] = [];
+    const loop = new AgentLoop({
+      provider,
+      systemPrompt: "system",
+      conversationId: "conv-xyz",
+    });
+    const run = loop.run({
+      requestId: "req-1",
+      messages: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
+      onEvent: (event) => {
+        events.push(event);
+      },
+      trust: { sourceChannel: "vellum", trustClass: "unknown" },
+      signal: controller.signal,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    controller.abort();
+    await expect(run).rejects.toBeDefined();
+    expect(events.some((event) => event.type === "error")).toBe(false);
+  });
+});

--- a/assistant/src/__tests__/agent-loop.test.ts
+++ b/assistant/src/__tests__/agent-loop.test.ts
@@ -289,7 +289,7 @@ describe("AgentLoop", () => {
 
   // 5. Error handling — provider throws, verify error event and loop stops
   test("emits error event and stops when provider throws", async () => {
-    const error = new Error("API rate limit exceeded");
+    const error = new Error("unexpected provider crash");
     const provider: Provider = {
       name: "mock",
       async sendMessage(): Promise<ProviderResponse> {
@@ -318,7 +318,7 @@ describe("AgentLoop", () => {
     expect(errorEvents).toHaveLength(1);
     expect(
       (errorEvents[0] as { type: "error"; error: Error }).error.message,
-    ).toBe("API rate limit exceeded");
+    ).toBe("unexpected provider crash");
   });
 
   // 5b. Reactive context-overflow recovery

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -23,11 +23,11 @@ import { resetPluginRegistryAndRegisterDefaults } from "../plugins/defaults/inde
 import { registerPlugin } from "../plugins/registry.js";
 import type { Message, Provider, ToolDefinition } from "../providers/types.js";
 import { ContextOverflowError } from "../providers/types.js";
-import { ProviderError } from "../util/errors.js";
 import {
   resolveUsageAttribution,
   type UsageAttributionInput,
 } from "../usage/attribution.js";
+import { ProviderError } from "../util/errors.js";
 import { getWorkspaceDir } from "../util/platform.js";
 import { setConfig } from "./helpers/set-config.js";
 

--- a/assistant/src/__tests__/conversation-agent-loop.test.ts
+++ b/assistant/src/__tests__/conversation-agent-loop.test.ts
@@ -23,6 +23,7 @@ import { resetPluginRegistryAndRegisterDefaults } from "../plugins/defaults/inde
 import { registerPlugin } from "../plugins/registry.js";
 import type { Message, Provider, ToolDefinition } from "../providers/types.js";
 import { ContextOverflowError } from "../providers/types.js";
+import { ProviderError } from "../util/errors.js";
 import {
   resolveUsageAttribution,
   type UsageAttributionInput,
@@ -633,8 +634,35 @@ let mockConversationErrorClassification = {
 };
 
 mock.module("../daemon/conversation-error.js", () => ({
-  classifyConversationError: (_err: unknown, _ctx: unknown) =>
-    mockConversationErrorClassification,
+  classifyConversationError: (err: unknown, _ctx: unknown) => {
+    const reason =
+      err && typeof err === "object" && "reason" in err
+        ? (err as { reason?: string }).reason
+        : undefined;
+    const statusCode =
+      err && typeof err === "object" && "statusCode" in err
+        ? (err as { statusCode?: number }).statusCode
+        : undefined;
+    if (reason === "rate_limited" || statusCode === 429) {
+      return {
+        code: "PROVIDER_RATE_LIMIT",
+        userMessage:
+          "You are being rate limited by the AI provider. Please try again in a moment.",
+        retryable: true,
+        errorCategory: "rate_limit",
+      };
+    }
+    if (reason === "overloaded" || statusCode === 529) {
+      return {
+        code: "PROVIDER_OVERLOADED",
+        userMessage:
+          "The AI provider is temporarily overloaded. Please try again in a moment.",
+        retryable: true,
+        errorCategory: "provider_overloaded",
+      };
+    }
+    return mockConversationErrorClassification;
+  },
   isUserCancellation: (err: unknown, ctx: { aborted?: boolean }) => {
     if (!ctx.aborted) {
       return false;
@@ -2163,6 +2191,155 @@ describe("session-agent-loop", () => {
         );
         await new Promise((resolve) => setTimeout(resolve, 0));
       }
+    });
+  });
+
+  describe("provider rate-limit retries", () => {
+    function rateLimitError(): ProviderError {
+      return new ProviderError(
+        "Anthropic API error (429): Too many requests",
+        "anthropic",
+        429,
+        { reason: "rate_limited", retryAfterMs: 0 },
+      );
+    }
+
+    test("retries a PROVIDER_RATE_LIMIT error and completes without a terminal error", async () => {
+      const events: AssistantEvent[] = [];
+      let calls = 0;
+      const provider: Provider = {
+        name: "mock-provider",
+        async sendMessage() {
+          calls++;
+          if (calls === 1) {
+            throw rateLimitError();
+          }
+          return textResponse("recovered after rate limit");
+        },
+      };
+      const ctx = makeCtx({ loopProvider: provider });
+
+      await runAgentLoopImpl(ctx, "hi", "msg-1", (msg) => events.push(msg));
+
+      expect(calls).toBe(2);
+      expect(
+        events.find((event) => event.type === "conversation_error"),
+      ).toBeUndefined();
+      expect(ctx.isProcessing()).toBe(false);
+    });
+
+    test("emits a terminal PROVIDER_RATE_LIMIT error after DEFAULT_MAX_RETRIES", async () => {
+      const events: AssistantEvent[] = [];
+      let calls = 0;
+      const provider: Provider = {
+        name: "mock-provider",
+        async sendMessage() {
+          calls++;
+          throw rateLimitError();
+        },
+      };
+      const ctx = makeCtx({ loopProvider: provider });
+
+      await runAgentLoopImpl(ctx, "hi", "msg-1", (msg) => events.push(msg));
+
+      // 1 initial attempt + DEFAULT_MAX_RETRIES automatic retries
+      expect(calls).toBe(4);
+      expect(
+        events.find((event) => event.type === "conversation_error"),
+      ).toMatchObject({
+        type: "conversation_error",
+        code: "PROVIDER_RATE_LIMIT",
+        retryable: true,
+        errorCategory: "rate_limit",
+      });
+      expect(ctx.isProcessing()).toBe(false);
+    });
+
+    test("does not retry when the abort signal is already active", async () => {
+      const events: AssistantEvent[] = [];
+      const abortController = new AbortController();
+      let calls = 0;
+      const provider: Provider = {
+        name: "mock-provider",
+        async sendMessage() {
+          calls++;
+          abortController.abort();
+          throw rateLimitError();
+        },
+      };
+      const ctx = makeCtx({ loopProvider: provider, abortController });
+
+      await runAgentLoopImpl(ctx, "hi", "msg-1", (msg) => events.push(msg));
+
+      expect(calls).toBe(1);
+      expect(
+        events.find((event) => event.type === "generation_cancelled"),
+      ).toBeDefined();
+      expect(
+        events.find((event) => event.type === "conversation_error"),
+      ).toBeUndefined();
+    });
+
+    test("does not retry a retryable non-rate-limit provider error", async () => {
+      const events: AssistantEvent[] = [];
+      let calls = 0;
+      const provider: Provider = {
+        name: "mock-provider",
+        async sendMessage() {
+          calls++;
+          throw new ProviderError(
+            "Anthropic API error (529): Overloaded",
+            "anthropic",
+            529,
+            { reason: "overloaded", retryAfterMs: 0 },
+          );
+        },
+      };
+      const ctx = makeCtx({ loopProvider: provider });
+
+      await runAgentLoopImpl(ctx, "hi", "msg-1", (msg) => events.push(msg));
+
+      expect(calls).toBe(1);
+      expect(
+        events.find((event) => event.type === "conversation_error"),
+      ).toMatchObject({
+        type: "conversation_error",
+        code: "PROVIDER_OVERLOADED",
+      });
+    });
+
+    test("treats abort during the rate-limit backoff as a user cancellation", async () => {
+      const events: AssistantEvent[] = [];
+      const abortController = new AbortController();
+      let calls = 0;
+      const provider: Provider = {
+        name: "mock-provider",
+        async sendMessage() {
+          calls++;
+          throw new ProviderError(
+            "Anthropic API error (429): Too many requests",
+            "anthropic",
+            429,
+            { reason: "rate_limited", retryAfterMs: 200 },
+          );
+        },
+      };
+      const ctx = makeCtx({ loopProvider: provider, abortController });
+
+      const run = runAgentLoopImpl(ctx, "hi", "msg-1", (msg) =>
+        events.push(msg),
+      );
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      abortController.abort();
+      await run;
+
+      expect(calls).toBe(1);
+      expect(
+        events.find((event) => event.type === "generation_cancelled"),
+      ).toBeDefined();
+      expect(
+        events.find((event) => event.type === "conversation_error"),
+      ).toBeUndefined();
     });
   });
 

--- a/assistant/src/agent/loop.ts
+++ b/assistant/src/agent/loop.ts
@@ -10,6 +10,12 @@ import {
   getCalibrationProviderKey,
 } from "../context/token-estimator.js";
 import { spoolAndStubOversizedToolResults } from "../context/tool-result-spool.js";
+import { classifyConversationError } from "../daemon/conversation-error.js";
+import {
+  DEFAULT_MAX_RETRIES,
+  shouldRetryProviderRateLimit,
+  sleepForRateLimitRetry,
+} from "../daemon/conversation-rate-limit-retry.js";
 import type { ToolActivityMetadata } from "../daemon/message-types/web-activity.js";
 import { parseActualTokensFromError } from "../daemon/parse-actual-tokens-from-error.js";
 import type { TrustContext } from "../daemon/trust-context-types.js";
@@ -1089,6 +1095,10 @@ export class AgentLoop {
     // interruption means re-issuing is not getting through, so the error
     // surfaces instead of looping.
     let interruptedCallResumed = false;
+    // Automatic retries for classified PROVIDER_RATE_LIMIT errors. Separate
+    // from `postModelCallContinues` so a rate-limit wait does not consume
+    // image-recovery or history-repair budget.
+    let rateLimitRetries = 0;
     let lastLlmCallTime = 0;
     let exitReason: ExitReason | null = null;
     // Armed at the end of a tool-use iteration so the budget gate runs at the
@@ -2621,6 +2631,35 @@ export class AgentLoop {
               { turn: toolUseTurns, messageCount: history.length, err },
               "Model call died mid-generation, resuming the turn",
             );
+            continue;
+          }
+
+          const classified = classifyConversationError(error, {
+            phase: "agent_loop",
+            aborted: signal?.aborted,
+          });
+          if (
+            shouldRetryProviderRateLimit(classified, {
+              attempt: rateLimitRetries,
+              signal,
+            })
+          ) {
+            rlog.warn(
+              {
+                attempt: rateLimitRetries + 1,
+                maxRetries: DEFAULT_MAX_RETRIES,
+                code: classified.code,
+              },
+              "Rate limited by provider; retrying model call",
+            );
+            await sleepForRateLimitRetry(error, rateLimitRetries, signal);
+            if (signal?.aborted) {
+              throw (
+                signal.reason ??
+                new DOMException("The operation was aborted", "AbortError")
+              );
+            }
+            rateLimitRetries++;
             continue;
           }
         }

--- a/assistant/src/daemon/__tests__/conversation-rate-limit-retry.test.ts
+++ b/assistant/src/daemon/__tests__/conversation-rate-limit-retry.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, test } from "bun:test";
+
+import { ProviderError } from "../../util/errors.js";
+import type { ClassifiedConversationError } from "../conversation-error.js";
+import {
+  DEFAULT_MAX_RETRIES,
+  MAX_RATE_LIMIT_RETRY_DELAY_MS,
+  resolveRateLimitRetryDelay,
+  shouldRetryProviderRateLimit,
+  sleepForRateLimitRetry,
+} from "../conversation-rate-limit-retry.js";
+
+function rateLimitClassification(
+  overrides: Partial<ClassifiedConversationError> = {},
+): ClassifiedConversationError {
+  return {
+    code: "PROVIDER_RATE_LIMIT",
+    userMessage:
+      "You are being rate limited by the AI provider. Please try again in a moment.",
+    retryable: true,
+    errorCategory: "rate_limit",
+    ...overrides,
+  };
+}
+
+describe("shouldRetryProviderRateLimit", () => {
+  test("retries a retryable PROVIDER_RATE_LIMIT while budget remains", () => {
+    expect(
+      shouldRetryProviderRateLimit(rateLimitClassification(), { attempt: 0 }),
+    ).toBe(true);
+    expect(
+      shouldRetryProviderRateLimit(rateLimitClassification(), { attempt: 2 }),
+    ).toBe(true);
+  });
+
+  test("stops after DEFAULT_MAX_RETRIES attempts", () => {
+    expect(
+      shouldRetryProviderRateLimit(rateLimitClassification(), {
+        attempt: DEFAULT_MAX_RETRIES,
+      }),
+    ).toBe(false);
+    expect(
+      shouldRetryProviderRateLimit(rateLimitClassification(), {
+        attempt: DEFAULT_MAX_RETRIES + 1,
+      }),
+    ).toBe(false);
+  });
+
+  test("does not retry when the abort signal is already active", () => {
+    const controller = new AbortController();
+    controller.abort();
+    expect(
+      shouldRetryProviderRateLimit(rateLimitClassification(), {
+        attempt: 0,
+        signal: controller.signal,
+      }),
+    ).toBe(false);
+  });
+
+  test("does not retry a non-retryable rate-limit classification", () => {
+    expect(
+      shouldRetryProviderRateLimit(
+        rateLimitClassification({ retryable: false }),
+        { attempt: 0 },
+      ),
+    ).toBe(false);
+  });
+
+  test("does not retry managed usage limits or other retryable codes", () => {
+    expect(
+      shouldRetryProviderRateLimit(
+        rateLimitClassification({
+          code: "MANAGED_USAGE_LIMIT",
+          errorCategory: "managed_usage_limit",
+        }),
+        { attempt: 0 },
+      ),
+    ).toBe(false);
+    expect(
+      shouldRetryProviderRateLimit(
+        rateLimitClassification({
+          code: "PROVIDER_OVERLOADED",
+          errorCategory: "provider_overloaded",
+        }),
+        { attempt: 0 },
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("resolveRateLimitRetryDelay", () => {
+  test("honors ProviderError.retryAfterMs", () => {
+    const error = new ProviderError("rate limited", "anthropic", 429, {
+      reason: "rate_limited",
+      retryAfterMs: 12_000,
+    });
+    expect(resolveRateLimitRetryDelay(error, 0)).toBe(12_000);
+  });
+
+  test("extracts Retry-After from error.headers", () => {
+    const error = Object.assign(new Error("rate limited"), {
+      headers: { "retry-after": "8" },
+    });
+    expect(resolveRateLimitRetryDelay(error, 0)).toBe(8_000);
+  });
+
+  test("extracts Retry-After from the error cause headers", () => {
+    const cause = Object.assign(new Error("upstream 429"), {
+      headers: new Headers({ "retry-after": "5" }),
+    });
+    const error = new ProviderError("rate limited", "openai", 429, {
+      reason: "rate_limited",
+      cause,
+    });
+    expect(resolveRateLimitRetryDelay(error, 0)).toBe(5_000);
+  });
+
+  test("prefers stamped retryAfterMs over headers", () => {
+    const cause = Object.assign(new Error("upstream 429"), {
+      headers: { "retry-after": "5" },
+    });
+    const error = new ProviderError("rate limited", "openai", 429, {
+      reason: "rate_limited",
+      retryAfterMs: 1_500,
+      cause,
+    });
+    expect(resolveRateLimitRetryDelay(error, 0)).toBe(1_500);
+  });
+
+  test("falls back to exponential backoff when no Retry-After is present", () => {
+    const error = new ProviderError("rate limited", "anthropic", 429, {
+      reason: "rate_limited",
+    });
+    const delay = resolveRateLimitRetryDelay(error, 0);
+    // computeRetryDelay(0, 1000) = 500 + random * 500, in [500, 1000)
+    expect(delay).toBeGreaterThanOrEqual(500);
+    expect(delay).toBeLessThan(1_000);
+  });
+
+  test("caps pathological Retry-After values", () => {
+    const error = new ProviderError("rate limited", "anthropic", 429, {
+      reason: "rate_limited",
+      retryAfterMs: 3_600_000,
+    });
+    expect(resolveRateLimitRetryDelay(error, 0)).toBe(
+      MAX_RATE_LIMIT_RETRY_DELAY_MS,
+    );
+  });
+});
+
+describe("sleepForRateLimitRetry", () => {
+  test("resolves immediately when Retry-After is 0", async () => {
+    const error = new ProviderError("rate limited", "anthropic", 429, {
+      reason: "rate_limited",
+      retryAfterMs: 0,
+    });
+    const started = Date.now();
+    await sleepForRateLimitRetry(error, 0);
+    expect(Date.now() - started).toBeLessThan(50);
+  });
+
+  test("resolves early when the abort signal fires", async () => {
+    const controller = new AbortController();
+    const error = new ProviderError("rate limited", "anthropic", 429, {
+      reason: "rate_limited",
+      retryAfterMs: 5_000,
+    });
+    const sleep = sleepForRateLimitRetry(error, 0, controller.signal);
+    controller.abort();
+    const started = Date.now();
+    await sleep;
+    expect(Date.now() - started).toBeLessThan(50);
+  });
+});

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -109,14 +109,14 @@ import {
 } from "./conversation-error.js";
 import { raceWithTimeout } from "./conversation-media-retry.js";
 import {
+  clearConversationNotices,
+  drainConversationNotices,
+} from "./conversation-notices.js";
+import {
   DEFAULT_MAX_RETRIES,
   shouldRetryProviderRateLimit,
   sleepForRateLimitRetry,
 } from "./conversation-rate-limit-retry.js";
-import {
-  clearConversationNotices,
-  drainConversationNotices,
-} from "./conversation-notices.js";
 import {
   getSlackCompactionWatermarkForPrefix,
   loadSlackChronologicalContext,

--- a/assistant/src/daemon/conversation-agent-loop.ts
+++ b/assistant/src/daemon/conversation-agent-loop.ts
@@ -109,6 +109,11 @@ import {
 } from "./conversation-error.js";
 import { raceWithTimeout } from "./conversation-media-retry.js";
 import {
+  DEFAULT_MAX_RETRIES,
+  shouldRetryProviderRateLimit,
+  sleepForRateLimitRetry,
+} from "./conversation-rate-limit-retry.js";
+import {
   clearConversationNotices,
   drainConversationNotices,
 } from "./conversation-notices.js";
@@ -1351,7 +1356,51 @@ export async function runAgentLoopImpl(
       return history;
     };
 
-    const updatedHistory = await runAgentLoop(runMessages, true);
+    // Rate-limit retries wrap only the loop run so prompt-submit hooks,
+    // history repair, and the outer finally run once. Exhausted retries
+    // rethrow into the existing terminal `conversation_error` path.
+    let rateLimitRetries = 0;
+    let updatedHistory: Message[];
+    while (true) {
+      try {
+        updatedHistory = await runAgentLoop(runMessages, true);
+        break;
+      } catch (err) {
+        const classified = classifyConversationError(err, {
+          phase: "agent_loop",
+          aborted: abortController.signal.aborted,
+          ...turnErrorAttribution(),
+        });
+        if (
+          !shouldRetryProviderRateLimit(classified, {
+            attempt: rateLimitRetries,
+            signal: abortController.signal,
+          })
+        ) {
+          throw err;
+        }
+        rlog.warn(
+          {
+            attempt: rateLimitRetries + 1,
+            maxRetries: DEFAULT_MAX_RETRIES,
+            code: classified.code,
+          },
+          "Rate limited by provider; retrying agent loop",
+        );
+        await sleepForRateLimitRetry(
+          err,
+          rateLimitRetries,
+          abortController.signal,
+        );
+        if (abortController.signal.aborted) {
+          throw (
+            abortController.signal.reason ??
+            new DOMException("The operation was aborted", "AbortError")
+          );
+        }
+        rateLimitRetries++;
+      }
+    }
     // Generation is done streaming. Anything awaited between here and the
     // terminal SSE is what the user perceives as the gap between the last
     // token and the composer re-enabling, so keep that window minimal.

--- a/assistant/src/daemon/conversation-rate-limit-retry.ts
+++ b/assistant/src/daemon/conversation-rate-limit-retry.ts
@@ -1,0 +1,83 @@
+import { ProviderError } from "../util/errors.js";
+import {
+  abortableSleep,
+  computeRetryDelay,
+  DEFAULT_BASE_DELAY_MS,
+  DEFAULT_MAX_RETRIES,
+  extractRetryAfterMs,
+} from "../util/retry.js";
+import type { ClassifiedConversationError } from "./conversation-error.js";
+
+/**
+ * Cap server-suggested waits so a pathological Retry-After cannot stall a turn.
+ * Matches the provider-layer retry cap in `providers/retry.ts`.
+ */
+const MAX_RATE_LIMIT_RETRY_DELAY_MS = 60_000;
+
+/**
+ * Whether a classified agent-loop error should trigger an automatic
+ * rate-limit retry. Only `PROVIDER_RATE_LIMIT` with `retryable=true` is
+ * eligible, and only while the abort signal is idle and retry budget remains.
+ */
+export function shouldRetryProviderRateLimit(
+  classified: ClassifiedConversationError,
+  args: {
+    attempt: number;
+    signal?: AbortSignal;
+    maxRetries?: number;
+  },
+): boolean {
+  if (args.signal?.aborted) {
+    return false;
+  }
+  if (classified.code !== "PROVIDER_RATE_LIMIT" || !classified.retryable) {
+    return false;
+  }
+  const maxRetries = args.maxRetries ?? DEFAULT_MAX_RETRIES;
+  return args.attempt < maxRetries;
+}
+
+function headersFromUnknown(value: unknown): unknown {
+  if (!value || typeof value !== "object" || !("headers" in value)) {
+    return undefined;
+  }
+  return (value as { headers?: unknown }).headers;
+}
+
+/**
+ * Delay before the next rate-limit retry. Prefers a provider-stamped
+ * `retryAfterMs`, then a Retry-After header on the error or its cause,
+ * then exponential backoff with jitter.
+ */
+export function resolveRateLimitRetryDelay(
+  error: unknown,
+  attempt: number,
+): number {
+  const fromProvider =
+    error instanceof ProviderError ? error.retryAfterMs : undefined;
+  const fromHeaders = extractRetryAfterMs(headersFromUnknown(error));
+  const fromCause =
+    error instanceof Error
+      ? extractRetryAfterMs(headersFromUnknown(error.cause))
+      : undefined;
+  const retryAfterMs = fromProvider ?? fromHeaders ?? fromCause;
+  const delay =
+    retryAfterMs !== undefined
+      ? retryAfterMs
+      : computeRetryDelay(attempt, DEFAULT_BASE_DELAY_MS);
+  return Math.min(Math.max(0, delay), MAX_RATE_LIMIT_RETRY_DELAY_MS);
+}
+
+/**
+ * Wait out a rate-limit backoff, resolving early if `signal` aborts so the
+ * caller can treat it as a cancellation rather than a failed retry.
+ */
+export async function sleepForRateLimitRetry(
+  error: unknown,
+  attempt: number,
+  signal?: AbortSignal,
+): Promise<void> {
+  await abortableSleep(resolveRateLimitRetryDelay(error, attempt), signal);
+}
+
+export { DEFAULT_MAX_RETRIES, MAX_RATE_LIMIT_RETRY_DELAY_MS };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan
Provider 429s were classified as `PROVIDER_RATE_LIMIT` with `retryable=true`, then immediately emitted as a terminal `conversation_error`. That ended the turn and forced a manual retry, even though `computeRetryDelay`, `abortableSleep`, and `extractRetryAfterMs` already existed.

The live path is not the wrapper catch around `classifyConversationError`. `AgentLoop.run()` swallows provider failures, emits `{ type: "error" }`, and returns normally. Automatic retries therefore have to happen inside `AgentLoop` before that terminal error event. A wrapper around `runAgentLoop` remains as a backstop for thrown rate-limit errors.

## Summary
- Retry classified `PROVIDER_RATE_LIMIT` errors automatically, up to `DEFAULT_MAX_RETRIES` (3).
- Honor `ProviderError.retryAfterMs` or a Retry-After header, then fall back to exponential backoff with jitter. Cap the wait at 60s.
- Skip retry when the abort signal is already active. Abort during backoff is treated as a user cancellation.
- After retries are exhausted, emit the existing terminal `conversation_error`.
- Do not retry `MANAGED_USAGE_LIMIT` or `PROVIDER_OVERLOADED`.

## Test plan
- `cd assistant && bun test src/daemon/__tests__/conversation-rate-limit-retry.test.ts` (13 pass)
- `cd assistant && bun test src/__tests__/agent-loop-rate-limit-retry.test.ts` (5 pass)
- `cd assistant && bun test src/__tests__/conversation-agent-loop.test.ts --grep "provider rate-limit"` (5 pass)
- `cd assistant && bun test src/__tests__/conversation-agent-loop.test.ts` (93 pass)
- `cd assistant && bun test src/__tests__/agent-loop-provider-error-recording.test.ts` (4 pass)
- `cd assistant && bun run typecheck:fast` (pass)

## Risk
- Provider-layer retries already run before this path. A stubborn 429 can wait through both layers before the user sees an error.
- Pathological Retry-After values are capped at 60s, so a provider-suggested hour-long wait will not stall the turn that long.
- The wrapper retry around `runAgentLoop` is a backstop. Live 429s are recovered inside `AgentLoop`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9d034ade-00eb-4e71-b9d1-ce8f42a9baac?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9d034ade-00eb-4e71-b9d1-ce8f42a9baac&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

