### PR TITLE
feat(android): add a pure attribution allowlist + query helper

### DIFF
--- a/clients/android/app/src/main/java/ai/vellum/assistant/Attribution.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/Attribution.java
@@ -1,0 +1,112 @@
+package ai.vellum.assistant;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/** Pure allowlist + query helpers for campaign attribution carried by the Android shell. */
+final class Attribution {
+    /**
+     * Source of truth: `ATTRIBUTION_PARAMS` in
+     * `clients/web/src/domains/account/social-auth.ts`. A key added there and
+     * not here is silently dropped on Android, so keep both lists identical.
+     */
+    static final String[] KEYS = {
+        "utm_source",
+        "utm_medium",
+        "utm_campaign",
+        "utm_content",
+        "utm_term",
+        "gclid",
+        "gbraid",
+        "wbraid",
+        "msclkid",
+        "fbclid",
+        "ttclid",
+        "li_fat_id",
+        "twclid",
+    };
+
+    /** Platform truncates per-field; this only bounds what we put on the wire. */
+    static final int VALUE_MAX_LENGTH = 512;
+
+    private Attribution() {}
+
+    /**
+     * Allowlisted fields of a raw `key=value&...` string, in the order they
+     * appear. Never null: a malformed pair is skipped so one garbage segment
+     * cannot discard the whole referrer.
+     */
+    static Map<String, String> parseQuery(String raw) {
+        Map<String, String> fields = new LinkedHashMap<>();
+        if (raw == null) {
+            return fields;
+        }
+        for (String pair : raw.split("&")) {
+            int separator = pair.indexOf('=');
+            if (separator <= 0) {
+                continue;
+            }
+            String key = decode(pair.substring(0, separator));
+            String value = decode(pair.substring(separator + 1));
+            if (key == null || value == null || value.isEmpty() || !isAllowed(key)) {
+                continue;
+            }
+            fields.put(key, truncate(value));
+        }
+        return fields;
+    }
+
+    /** Re-encodes `fields` as a query string in {@link #KEYS} order. */
+    static String toQuery(Map<String, String> fields) {
+        if (fields == null) {
+            return "";
+        }
+        StringBuilder query = new StringBuilder();
+        for (String key : KEYS) {
+            String value = fields.get(key);
+            if (value == null || value.isEmpty()) {
+                continue;
+            }
+            if (query.length() > 0) {
+                query.append('&');
+            }
+            query.append(encode(key)).append('=').append(encode(value));
+        }
+        return query.toString();
+    }
+
+    private static boolean isAllowed(String key) {
+        for (String allowed : KEYS) {
+            if (allowed.equals(key)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static String truncate(String value) {
+        return value.length() <= VALUE_MAX_LENGTH ? value : value.substring(0, VALUE_MAX_LENGTH);
+    }
+
+    private static String decode(String value) {
+        try {
+            return URLDecoder.decode(value, StandardCharsets.UTF_8.name());
+        } catch (IllegalArgumentException exception) {
+            return null;
+        } catch (UnsupportedEncodingException exception) {
+            throw new IllegalStateException("UTF-8 is unavailable", exception);
+        }
+    }
+
+    private static String encode(String value) {
+        try {
+            return URLEncoder.encode(value, StandardCharsets.UTF_8.name());
+        } catch (UnsupportedEncodingException exception) {
+            throw new IllegalStateException("UTF-8 is unavailable", exception);
+        }
+    }
+}

--- a/clients/android/app/src/test/java/ai/vellum/assistant/AttributionTest.java
+++ b/clients/android/app/src/test/java/ai/vellum/assistant/AttributionTest.java
@@ -1,0 +1,102 @@
+package ai.vellum.assistant;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.Test;
+
+public class AttributionTest {
+    @Test
+    public void parsesAWellFormedReferrer() {
+        Map<String, String> fields =
+            Attribution.parseQuery("utm_source=google&utm_medium=cpc&gclid=abc123");
+
+        assertEquals(3, fields.size());
+        assertEquals("google", fields.get("utm_source"));
+        assertEquals("cpc", fields.get("utm_medium"));
+        assertEquals("abc123", fields.get("gclid"));
+    }
+
+    @Test
+    public void decodesPercentEncodedKeysAndValues() {
+        Map<String, String> fields =
+            Attribution.parseQuery("utm_campaign=spring%20sale&utm%5Fterm=running+shoes");
+
+        assertEquals("spring sale", fields.get("utm_campaign"));
+        assertEquals("running shoes", fields.get("utm_term"));
+    }
+
+    @Test
+    public void dropsUnknownKeysAndEmptyValues() {
+        Map<String, String> fields = Attribution.parseQuery(
+            "utm_source=google&sessionToken=secret&ref=friend&utm_medium=&fbclid=fb-1"
+        );
+
+        assertEquals(2, fields.size());
+        assertEquals("google", fields.get("utm_source"));
+        assertEquals("fb-1", fields.get("fbclid"));
+    }
+
+    @Test
+    public void truncatesOverlongValues() {
+        String overlong = repeat('a', Attribution.VALUE_MAX_LENGTH + 88);
+
+        String value = Attribution.parseQuery("utm_campaign=" + overlong).get("utm_campaign");
+
+        assertEquals(Attribution.VALUE_MAX_LENGTH, value.length());
+        assertEquals(overlong.substring(0, Attribution.VALUE_MAX_LENGTH), value);
+    }
+
+    @Test
+    public void returnsAnEmptyMapForUnusableInput() {
+        assertTrue(Attribution.parseQuery(null).isEmpty());
+        assertTrue(Attribution.parseQuery("").isEmpty());
+        assertTrue(Attribution.parseQuery("   ").isEmpty());
+        assertTrue(Attribution.parseQuery("garbage").isEmpty());
+        assertTrue(Attribution.parseQuery("&&&").isEmpty());
+    }
+
+    @Test
+    public void keepsValidPairsBesideMalformedOnes() {
+        Map<String, String> fields = Attribution.parseQuery(
+            "=orphan&utm_source=google&utm_campaign=%ZZ&novalue&&gclid=abc123"
+        );
+
+        assertEquals(2, fields.size());
+        assertEquals("google", fields.get("utm_source"));
+        assertEquals("abc123", fields.get("gclid"));
+    }
+
+    @Test
+    public void toQueryRoundTripsThroughParseQuery() {
+        Map<String, String> fields = new LinkedHashMap<>();
+        fields.put("utm_source", "google");
+        fields.put("utm_campaign", "spring sale & more");
+        fields.put("li_fat_id", "li/123");
+
+        assertEquals(fields, Attribution.parseQuery(Attribution.toQuery(fields)));
+    }
+
+    @Test
+    public void toQueryEmitsInKeysOrderAndSkipsEmptyValues() {
+        Map<String, String> fields = new LinkedHashMap<>();
+        fields.put("twclid", "tw-1");
+        fields.put("utm_medium", "cpc");
+        fields.put("utm_source", "google");
+        fields.put("utm_term", "");
+
+        assertEquals("utm_source=google&utm_medium=cpc&twclid=tw-1", Attribution.toQuery(fields));
+        assertEquals("", Attribution.toQuery(new LinkedHashMap<String, String>()));
+        assertEquals("", Attribution.toQuery(null));
+    }
+
+    private static String repeat(char value, int count) {
+        StringBuilder builder = new StringBuilder(count);
+        for (int index = 0; index < count; index++) {
+            builder.append(value);
+        }
+        return builder.toString();
+    }
+}


### PR DESCRIPTION
## Summary

Adds `Attribution`, a pure (no `android.*` imports) helper for the Android shell that owns the campaign-attribution allowlist and the query parse/emit round trip. Nothing calls it yet; PR 2 (install referrer plugin) and PR 3 (native auth attribution) consume `KEYS`, `VALUE_MAX_LENGTH`, `parseQuery`, and `toQuery`.

- `KEYS` mirrors `ATTRIBUTION_PARAMS` in `clients/web/src/domains/account/social-auth.ts` character for character and in the same order, with a comment naming that file as the source of truth and flagging the drift risk.
- `VALUE_MAX_LENGTH` is 512, matching `ATTRIBUTION_VALUE_MAX_LENGTH`. The platform truncates per field independently, so this only bounds what goes on the wire.
- `parseQuery` splits on `&` then on the first `=`, URL-decodes both sides, keeps allowlisted keys with non-empty values, and truncates. It never throws and never returns null, including for null input. A malformed pair is skipped rather than discarding the whole referrer, so one garbage segment cannot cost us the attribution.
- `toQuery` emits in `KEYS` order regardless of insertion order, URL-encoding both sides and skipping empty values.

Decoding uses the `URLDecoder.decode(String, String)` overload (as `ConnectDeepLink` already does) rather than the `Charset` overload, which is API 33+ while the module's minSdk is 24.

## Testing

`AttributionTest` covers well-formed referrers, percent-encoded keys and values, unknown keys and empty values dropped, truncation at 512, null / empty / blank / `"garbage"` input returning an empty map, valid pairs surviving next to malformed ones, the `toQuery` round trip, and `KEYS`-order emission.

No JDK or Android SDK is installed in this environment, so `./gradlew :app:testDevDebugUnitTest` could not be run locally. The `Android Checks` workflow runs exactly that task on the dev flavor, plus lint on all three flavors.

Part of plan: android-install-referrer-attribution.md (PR 1 of 7)