### PR TITLE
feat(web): capture the Android install referrer into device storage

### DIFF
--- a/clients/web/src/runtime/install-referrer.test.ts
+++ b/clients/web/src/runtime/install-referrer.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, expect, mock, test } from "bun:test";
+
+let platform = "android";
+const read = mock(async (): Promise<{ referrer?: string }> => ({}));
+
+mock.module("@capacitor/core", () => ({
+  Capacitor: { getPlatform: () => platform },
+  registerPlugin: () => ({ read }),
+}));
+
+const {
+  captureInstallReferrer,
+  clearStoredInstallReferrer,
+  readStoredInstallReferrer,
+} = await import("./install-referrer");
+
+const STORAGE_KEY = "device:install_referrer";
+
+beforeEach(() => {
+  platform = "android";
+  localStorage.clear();
+  mock.clearAllMocks();
+  read.mockResolvedValue({});
+});
+
+test("does not touch the bridge outside Android", async () => {
+  for (const other of ["web", "ios"]) {
+    platform = other;
+    await captureInstallReferrer();
+  }
+  expect(read).not.toHaveBeenCalled();
+  expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+});
+
+test("swallows a shell whose plugin predates this bundle", async () => {
+  read.mockRejectedValueOnce(
+    new Error('"InstallReferrer" plugin is not implemented on android'),
+  );
+  await captureInstallReferrer();
+  expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  expect(readStoredInstallReferrer()).toEqual({});
+});
+
+test("stores only allowlisted params from a campaign referrer", async () => {
+  read.mockResolvedValueOnce({
+    referrer:
+      "utm_source=newsletter&utm_medium=email&utm_campaign=spring&gclid=abc123&anid=admob&not_a_param=x",
+  });
+  await captureInstallReferrer();
+
+  expect(readStoredInstallReferrer()).toEqual({
+    utm_source: "newsletter",
+    utm_medium: "email",
+    utm_campaign: "spring",
+    gclid: "abc123",
+  });
+  const stored = localStorage.getItem(STORAGE_KEY) ?? "";
+  expect(stored).not.toContain("anid");
+  expect(stored).not.toContain("not_a_param");
+});
+
+test("stores the organic Play install signal", async () => {
+  read.mockResolvedValueOnce({
+    referrer: "utm_source=google-play&utm_medium=organic",
+  });
+  await captureInstallReferrer();
+  expect(readStoredInstallReferrer()).toEqual({
+    utm_source: "google-play",
+    utm_medium: "organic",
+  });
+});
+
+test("stores nothing when no allowlisted param survives", async () => {
+  for (const referrer of ["", "anid=admob&not_a_param=x", undefined]) {
+    localStorage.clear();
+    read.mockResolvedValueOnce({ referrer });
+    await captureInstallReferrer();
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  }
+});
+
+test("reads the referrer at most once per install", async () => {
+  read.mockResolvedValueOnce({ referrer: "utm_source=newsletter" });
+  await captureInstallReferrer();
+  await captureInstallReferrer();
+  expect(read).toHaveBeenCalledTimes(1);
+  expect(readStoredInstallReferrer()).toEqual({ utm_source: "newsletter" });
+
+  clearStoredInstallReferrer();
+  expect(readStoredInstallReferrer()).toEqual({});
+  expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+
+  read.mockResolvedValueOnce({ referrer: "utm_source=retry" });
+  await captureInstallReferrer();
+  expect(read).toHaveBeenCalledTimes(2);
+  expect(readStoredInstallReferrer()).toEqual({ utm_source: "retry" });
+});

--- a/clients/web/src/runtime/install-referrer.ts
+++ b/clients/web/src/runtime/install-referrer.ts
@@ -1,0 +1,76 @@
+/**
+ * JS side of the Android shell's `InstallReferrer` plugin, which reads the
+ * Play Store install referrer.
+ *
+ * A user who taps a campaign link, lands in Play, and installs arrives in the
+ * app with no URL params, so the referrer is the only attribution a Play
+ * install carries. It is captured into device storage at startup and read back
+ * when a signup posts attribution. Device scope is deliberate: the value
+ * describes the physical install, not an account, so it survives logout.
+ */
+
+import { Capacitor, registerPlugin } from "@capacitor/core";
+
+import { readAttributionParams } from "@/domains/account/social-auth";
+import {
+  getDeviceSetting,
+  removeDeviceSetting,
+  setDeviceSetting,
+} from "@/utils/device-settings";
+
+type InstallReferrerResult = {
+  referrer?: string;
+  referrerClickTimestampSeconds?: number;
+  installBeginTimestampSeconds?: number;
+};
+
+interface InstallReferrerPlugin {
+  read(): Promise<InstallReferrerResult>;
+}
+
+const InstallReferrer =
+  registerPlugin<InstallReferrerPlugin>("InstallReferrer");
+
+/**
+ * Read the Play install referrer once and persist its allowlisted params.
+ * Safe to call on every startup: a stored value short-circuits the bridge.
+ *
+ * A missing plugin is an expected state, not an error. The shell ships on
+ * Play's review cadence while this bundle goes live on every user's next
+ * launch, so an older shell without the plugin is normal after any deploy
+ * (docs/CAPACITOR.md, "The skew rule"). Nothing here reports to Sentry.
+ */
+export async function captureInstallReferrer(): Promise<void> {
+  if (Capacitor.getPlatform() !== "android") {
+    return;
+  }
+  if (getDeviceSetting("installReferrer", "")) {
+    return;
+  }
+  try {
+    const { referrer } = await InstallReferrer.read();
+    const attribution = new URLSearchParams(
+      readAttributionParams(referrer ?? ""),
+    ).toString();
+    if (!attribution) {
+      return;
+    }
+    setDeviceSetting("installReferrer", attribution);
+  } catch (error) {
+    console.debug("[install-referrer] read unavailable:", error);
+  }
+}
+
+/**
+ * Allowlisted attribution captured from the install referrer, or `{}` when
+ * this device has none. Re-filtered on read so a hand-edited or stale stored
+ * value can never widen what reaches the wire.
+ */
+export function readStoredInstallReferrer(): Record<string, string> {
+  return readAttributionParams(getDeviceSetting("installReferrer", ""));
+}
+
+/** Drop the captured referrer once it has been spent on a signup. */
+export function clearStoredInstallReferrer(): void {
+  removeDeviceSetting("installReferrer");
+}

--- a/clients/web/src/utils/device-settings.ts
+++ b/clients/web/src/utils/device-settings.ts
@@ -17,6 +17,7 @@
  */
 
 import {
+  removeLocalSetting,
   setLocalBool,
   setLocalSetting,
   watchSetting,
@@ -55,6 +56,10 @@ const DEVICE_SETTINGS = {
   mediaEmbedDomains: { key: "device:media_embed_domains" },
   dockBadgesEnabled: { key: "device:dock_badges_enabled" },
   lastUserId: { key: "device:last_user_id" },
+  // Allowlisted attribution parsed out of the Android Play install referrer,
+  // stored as a query string. Describes the install, so it outlives any
+  // account that signs in on this device.
+  installReferrer: { key: "device:install_referrer" },
 } as const satisfies Record<string, DeviceSettingEntry>;
 
 export type DeviceSettingName = keyof typeof DEVICE_SETTINGS;
@@ -82,6 +87,11 @@ export function getDeviceSetting(
 /** Write a device-scoped setting. Fires the `vellum:pref-changed` event for same-tab observers. */
 export function setDeviceSetting(name: DeviceSettingName, value: string): void {
   setLocalSetting(DEVICE_SETTINGS[name].key, value);
+}
+
+/** Remove a device-scoped setting. Fires the `vellum:pref-changed` event for same-tab observers. */
+export function removeDeviceSetting(name: DeviceSettingName): void {
+  removeLocalSetting(DEVICE_SETTINGS[name].key);
 }
 
 /** Read a boolean device setting. */


### PR DESCRIPTION
## Summary

Native Android signups land with no marketing attribution: a Play Store install carries no URL params, so a user who taps a campaign link, lands in Play, and installs arrives unattributed. Play exposes the campaign's referrer string once, through the Android shell's `InstallReferrer` plugin (added in PR 2 of this plan).

This PR adds the web layer that reads it and parks it in device storage, ready for PR 6 to spend on a native signup.

## What's here

- **`clients/web/src/runtime/install-referrer.ts`** (new)
  - `captureInstallReferrer()`: no-ops off Android, no-ops when a value is already stored, otherwise calls `InstallReferrer.read()`, filters the referrer through the attribution allowlist, and persists the surviving params as a query string. Idempotent and safe to call on every startup.
  - `readStoredInstallReferrer()`: parses the stored string back through the same allowlist, returning `{}` when absent. Re-filtering on read means a stale or hand-edited value can never widen what reaches the wire.
  - `clearStoredInstallReferrer()`: drops the key once it has been spent.
- **`clients/web/src/utils/device-settings.ts`**: adds the `installReferrer` registry entry (`device:install_referrer`, no legacy key, born post-migration) and a `removeDeviceSetting()` accessor alongside the existing typed getters and setters.
- **`clients/web/src/runtime/install-referrer.test.ts`** (new): 6 cases covering non-Android no-op, a rejecting (missing) plugin, allowlist filtering, the organic `utm_source=google-play` signal, all-unknown and empty referrers storing nothing, read-at-most-once, round-trip, and clear.

## Notes for review

- **No `captureError`, by design.** The Android shell ships on Play's review cadence while this bundle goes live on every user's next launch, so an older shell without the plugin is a normal state after any deploy. The read swallows everything to `console.debug` per the skew rule in `docs/CAPACITOR.md`. There is no availability probe either: a probe can itself be absent.
- **The allowlist is not redeclared.** The module reuses `readAttributionParams()` from `domains/account/social-auth.ts`, which already owns `ATTRIBUTION_PARAMS` and the per-value length cap. That is strictly DRY-er than exporting and re-looping over the constant, and it keeps one place to change when the backend allowlist moves.
- **Device scope is correct and needs no cleanup-list change.** Verified in `src/lib/auth/session-cleanup.ts`: `isUserScopedKey()` returns true only for the `vellum:` prefix or the legacy prefix list (`onboarding.`, `voice:`, `gw:`, `ff:client:`, `local:`, `integrations.`, `vellumDebug.`, `vellum_`). `device:install_referrer` matches none of them, so it survives logout automatically.
- **An organic Play install is a real signal.** It yields `utm_source=google-play&utm_medium=organic`, which survives the allowlist and is stored. Only a referrer with zero allowlisted keys stores nothing.
- The plugin Proxy never crosses an `async` return: `read()` is destructured inline at the call site per the lazy-import rule.

## Checks

`bun test src/runtime/install-referrer.test.ts` (6 pass), `bunx tsc --noEmit` clean, `bun run lint` 0 errors (the 15 warnings are pre-existing and in unrelated files).

Part of plan: android-install-referrer-attribution.md (PR 5 of 7)