### PR TITLE
feat(web): tag the in-app Play Store link with an install referrer

### DIFF
--- a/clients/web/src/domains/settings/components/native-app-card.test.tsx
+++ b/clients/web/src/domains/settings/components/native-app-card.test.tsx
@@ -8,6 +8,8 @@ import {
 } from "bun:test";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 
+import { ANDROID_PLAY_STORE_URL } from "@/hooks/use-native-app-nudge";
+
 let iosWeb = false;
 let androidWeb = false;
 
@@ -72,7 +74,7 @@ describe("NativeAppCard", () => {
     fireEvent.click(screen.getByRole("button", { name: "Download" }));
 
     expect(open).toHaveBeenCalledWith(
-      "https://play.google.com/store/apps/details?id=ai.vellum.assistant",
+      ANDROID_PLAY_STORE_URL,
       "_blank",
       "noopener,noreferrer",
     );

--- a/clients/web/src/hooks/use-native-app-nudge.test.ts
+++ b/clients/web/src/hooks/use-native-app-nudge.test.ts
@@ -9,6 +9,7 @@ import {
 import { act, cleanup, renderHook } from "@testing-library/react";
 
 import {
+  ANDROID_PLAY_STORE_URL,
   getNativeAppPromotion,
   incrementNativeAppAssistantTurnsSeen,
   openNativeAppStore,
@@ -48,9 +49,18 @@ describe("Android promotion readiness", () => {
     expect(getNativeAppPromotion("android")).toEqual({
       platform: "android",
       appName: "Android",
-      storeUrl:
-        "https://play.google.com/store/apps/details?id=ai.vellum.assistant",
+      storeUrl: ANDROID_PLAY_STORE_URL,
     });
+  });
+
+  test("tags the listing with an install referrer", () => {
+    const url = new URL(ANDROID_PLAY_STORE_URL);
+
+    expect([...url.searchParams.keys()]).toEqual(["id", "referrer"]);
+    expect(url.searchParams.get("id")).toBe("ai.vellum.assistant");
+    expect(url.searchParams.get("referrer")).toBe(
+      "utm_source=vellum-app&utm_medium=in-app-nudge",
+    );
   });
 
   test("does not record a download when promotion is unavailable", () => {

--- a/clients/web/src/hooks/use-native-app-nudge.ts
+++ b/clients/web/src/hooks/use-native-app-nudge.ts
@@ -22,8 +22,14 @@ export const IOS_APP_STORE_URL =
   "https://apps.apple.com/us/app/vellum-assistant/id6759934423";
 
 const ANDROID_PACKAGE_ID = "ai.vellum.assistant";
-const ANDROID_PLAY_STORE_URL =
-  `https://play.google.com/store/apps/details?id=${ANDROID_PACKAGE_ID}`;
+
+/** Verbatim value Android's `getInstallReferrer()` returns after install. */
+const ANDROID_INSTALL_REFERRER =
+  "utm_source=vellum-app&utm_medium=in-app-nudge";
+
+export const ANDROID_PLAY_STORE_URL =
+  `https://play.google.com/store/apps/details?id=${ANDROID_PACKAGE_ID}` +
+  `&referrer=${encodeURIComponent(ANDROID_INSTALL_REFERRER)}`;
 
 const STORAGE_KEYS: Record<
   NativeAppPlatform,


### PR DESCRIPTION
## What

Appends an install referrer to the Play Store URL behind the in-app Android
nudge (the settings download card and the chat banner):

```
https://play.google.com/store/apps/details?id=ai.vellum.assistant&referrer=utm_source%3Dvellum-app%26utm_medium%3Din-app-nudge
```

The referrer is built from a named `ANDROID_INSTALL_REFERRER` constant and
encoded once with `encodeURIComponent`, so Play decodes it back to
`utm_source=vellum-app&utm_medium=in-app-nudge` and Android's
`getInstallReferrer()` returns that string verbatim.

`resolveAndroidPlayStoreUrl` already validated the `VITE_ANDROID_PLAY_STORE_URL`
env value against the expected listing shape and then returned the module
constant regardless, so the gating logic is unchanged. Only the constant it
returns moved.

## Scope, honestly

The value of this particular link is **Play Console acquisition reporting**, not
user attribution. Its audience is already signed in, so it will rarely produce a
`UserMarketingAttribution` row. Its practical use is as a dogfooding path to
verify the referrer pipeline end to end. The campaign links that actually matter
for acquisition live in the `vellum-website` repo and are not touched here.

## Tests

- New unit test asserts the emitted URL carries exactly the params `id` then
  `referrer`, that `id` is still `ai.vellum.assistant`, and that the decoded
  referrer value is `utm_source=vellum-app&utm_medium=in-app-nudge`.
- Existing assertions in `use-native-app-nudge.test.ts` and
  `native-app-card.test.tsx` that hardcoded the bare listing URL now compare
  against the exported constant. The env-var inputs in those tests stay the bare
  listing URL, since that is what the validation path receives.
- `bun test` (touched suites), `bun run typecheck`, and `bun run lint` are clean
  (lint reports only the 15 pre-existing `react-hooks/exhaustive-deps` warnings,
  0 errors).

Part of plan: android-install-referrer-attribution.md (PR 7 of 7)