### PR TITLE
feat(ios): forward marketing attribution on the provider-token exchange

### DIFF
--- a/.github/workflows/ci-main-ios.yaml
+++ b/.github/workflows/ci-main-ios.yaml
@@ -78,6 +78,21 @@ jobs:
       - name: Select Xcode 26.2
         run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
 
+      - name: Unit tests
+        working-directory: clients/ios/App
+        # The `AppTests` bundle links none of the app targets, so this costs
+        # seconds rather than a second full build. The simulator is picked at
+        # runtime: the runner image's device names follow whichever iOS
+        # runtime ships with Xcode.
+        run: |
+          simulator=$(xcrun simctl list devices available --json \
+            | jq -er '[.devices[][] | select(.name | startswith("iPhone"))][0].udid')
+          xcodebuild test \
+            -project App.xcodeproj \
+            -scheme AppTests \
+            -destination "platform=iOS Simulator,id=$simulator" \
+            CODE_SIGNING_ALLOWED=NO
+
       - name: Build (unsigned)
         working-directory: clients/ios/App
         # Unsigned so the check needs no repository secrets. Signing and

--- a/.github/workflows/ci-main-ios.yaml
+++ b/.github/workflows/ci-main-ios.yaml
@@ -14,6 +14,10 @@ on:
       # component library.
       - 'assistant/src/avatar/**'
       - 'clients/android/app/src/main/res/**'
+      # Both native shells embed the web layer's marketing attribution
+      # allowlist; the same drift tests pin the two copies to it.
+      - 'clients/android/app/src/main/java/ai/vellum/assistant/Attribution.java'
+      - 'clients/web/src/domains/account/social-auth.ts'
       - 'clients/web/capacitor.config.ts'
       - 'clients/web/package.json'
       - '.github/workflows/ci-main-ios.yaml'
@@ -53,10 +57,11 @@ jobs:
         working-directory: clients/web
         run: bun install --frozen-lockfile --filter=@vellumai/web
 
-      - name: Check app icon geometry drift
+      - name: Check drift guards
         working-directory: clients/ios
         # Asserts the icon assets still embed the avatar library's eye
-        # geometry verbatim. Runs from `clients/ios` because the repo-root
+        # geometry, and that both native shells still embed the web layer's
+        # attribution allowlist. Runs from `clients/ios` because the repo-root
         # `test-preload.ts` rejects a root `bun test`.
         run: bun test scripts/__tests__/
 

--- a/.github/workflows/pr-ios.yaml
+++ b/.github/workflows/pr-ios.yaml
@@ -13,6 +13,10 @@ on:
       # component library.
       - 'assistant/src/avatar/**'
       - 'clients/android/app/src/main/res/**'
+      # Both native shells embed the web layer's marketing attribution
+      # allowlist; the same drift tests pin the two copies to it.
+      - 'clients/android/app/src/main/java/ai/vellum/assistant/Attribution.java'
+      - 'clients/web/src/domains/account/social-auth.ts'
       - 'clients/web/capacitor.config.ts'
       - 'clients/web/package.json'
       - '.github/workflows/pr-ios.yaml'
@@ -50,10 +54,11 @@ jobs:
         working-directory: clients/web
         run: bun install --frozen-lockfile --filter=@vellumai/web
 
-      - name: Check app icon geometry drift
+      - name: Check drift guards
         working-directory: clients/ios
         # Asserts the icon assets still embed the avatar library's eye
-        # geometry verbatim. Runs from `clients/ios` because the repo-root
+        # geometry, and that both native shells still embed the web layer's
+        # attribution allowlist. Runs from `clients/ios` because the repo-root
         # `test-preload.ts` rejects a root `bun test`.
         run: bun test scripts/__tests__/
 

--- a/.github/workflows/pr-ios.yaml
+++ b/.github/workflows/pr-ios.yaml
@@ -75,6 +75,21 @@ jobs:
       - name: Select Xcode 26.2
         run: sudo xcode-select -s /Applications/Xcode_26.2.app/Contents/Developer
 
+      - name: Unit tests
+        working-directory: clients/ios/App
+        # The `AppTests` bundle links none of the app targets, so this costs
+        # seconds rather than a second full build. The simulator is picked at
+        # runtime: the runner image's device names follow whichever iOS
+        # runtime ships with Xcode.
+        run: |
+          simulator=$(xcrun simctl list devices available --json \
+            | jq -er '[.devices[][] | select(.name | startswith("iPhone"))][0].udid')
+          xcodebuild test \
+            -project App.xcodeproj \
+            -scheme AppTests \
+            -destination "platform=iOS Simulator,id=$simulator" \
+            CODE_SIGNING_ALLOWED=NO
+
       - name: Build (unsigned)
         working-directory: clients/ios/App
         # Unsigned so the check needs no repository secrets. Signing and

--- a/clients/ios/App/App/NativeAuthPlugin.swift
+++ b/clients/ios/App/App/NativeAuthPlugin.swift
@@ -102,8 +102,7 @@ public class NativeAuthPlugin: CAPPlugin, CAPBridgedPlugin {
 
         let loginHint = call.getString("loginHint")
         let intent = call.getString("intent")
-        // Absent on a web bundle that predates this, which must stay
-        // byte-identical on the wire.
+        // Optional: with no attribution the token request carries no query.
         let attribution = Attribution.fields(from: call.getObject("attribution"))
 
         guard let codeVerifier = WorkOSAuth.generateCodeVerifier() else {

--- a/clients/ios/App/App/NativeAuthPlugin.swift
+++ b/clients/ios/App/App/NativeAuthPlugin.swift
@@ -20,7 +20,8 @@ import UIKit
 /// 5. We verify `state`, exchange the code at
 ///    `user_management/authenticate` as a public client (no secret) for an
 ///    access token, then POST it to `/_allauth/app/v1/auth/provider/token`
-///    (`provider: "workos"`) to receive the platform session token.
+///    (`provider: "workos"`, campaign attribution on the query string)
+///    to receive the platform session token.
 /// 6. JS sets `document.cookie = "sessionid=<token>; ..."` and navigates;
 ///    the `AuthProvider` re-fetches `/_allauth/browser/v1/auth/session`
 ///    and the app is authenticated.
@@ -101,6 +102,9 @@ public class NativeAuthPlugin: CAPPlugin, CAPBridgedPlugin {
 
         let loginHint = call.getString("loginHint")
         let intent = call.getString("intent")
+        // Absent on a web bundle that predates this, which must stay
+        // byte-identical on the wire.
+        let attribution = Attribution.fields(from: call.getObject("attribution"))
 
         guard let codeVerifier = WorkOSAuth.generateCodeVerifier() else {
             // Same fail-closed rationale as `state`: no secure RNG, no PKCE.
@@ -143,6 +147,7 @@ public class NativeAuthPlugin: CAPPlugin, CAPBridgedPlugin {
                     baseURL: baseURL,
                     clientId: clientId,
                     codeVerifier: codeVerifier,
+                    attribution: attribution,
                     call: call
                 )
             }
@@ -158,6 +163,7 @@ public class NativeAuthPlugin: CAPPlugin, CAPBridgedPlugin {
         baseURL: URL,
         clientId: String,
         codeVerifier: String,
+        attribution: [String: String],
         call: CAPPluginCall
     ) {
         // Double-tap / concurrent call safety: cancel any in-flight session
@@ -229,7 +235,12 @@ public class NativeAuthPlugin: CAPPlugin, CAPBridgedPlugin {
                     self.reject(call, error)
                     return
                 }
-                self.exchangeForSession(baseURL: baseURL, clientId: clientId, accessToken: accessToken) { result in
+                self.exchangeForSession(
+                    baseURL: baseURL,
+                    clientId: clientId,
+                    accessToken: accessToken,
+                    attribution: attribution
+                ) { result in
                     switch result {
                     case .success(let sessionToken):
                         call.resolve(["sessionToken": sessionToken])
@@ -363,6 +374,7 @@ public class NativeAuthPlugin: CAPPlugin, CAPBridgedPlugin {
         baseURL: URL,
         clientId: String,
         accessToken: String,
+        attribution: [String: String],
         completion: @escaping (Result<String, AuthFlowError>) -> Void
     ) {
         var components = URLComponents()
@@ -370,6 +382,12 @@ public class NativeAuthPlugin: CAPPlugin, CAPBridgedPlugin {
         components.host = baseURL.host
         components.port = baseURL.port
         components.path = "/_allauth/app/v1/auth/provider/token"
+        // allauth headless takes a JSON body, so `request.POST` is empty on
+        // the platform side and attribution has to ride the query string.
+        let attributionQuery = Attribution.query(from: attribution)
+        if !attributionQuery.isEmpty {
+            components.percentEncodedQuery = attributionQuery
+        }
         guard let url = components.url,
               let body = WorkOSAuth.providerTokenRequestBody(clientId: clientId, accessToken: accessToken) else {
             completion(.failure(AuthFlowError(message: "Failed to build session exchange request")))

--- a/clients/ios/App/App/WorkOSAuth.swift
+++ b/clients/ios/App/App/WorkOSAuth.swift
@@ -242,9 +242,8 @@ enum Attribution {
     }
 
     /// Percent-encoded `key=value` pairs in ``keys`` order, or `""` when
-    /// nothing survives. Callers must leave the query untouched on `""` so a
-    /// call without attribution stays byte-identical to one from a shell that
-    /// predates this.
+    /// nothing survives. Callers leave the request query unset on `""`, so a
+    /// call without attribution carries no query string.
     static func query(from fields: [String: String]) -> String {
         keys.compactMap { key in
             guard let value = fields[key], !value.isEmpty else { return nil }

--- a/clients/ios/App/App/WorkOSAuth.swift
+++ b/clients/ios/App/App/WorkOSAuth.swift
@@ -190,3 +190,69 @@ enum WorkOSAuth {
         return value
     }
 }
+
+/// Marketing attribution carried from the web layer into the platform's
+/// provider-token exchange.
+///
+/// The native shell has no cookie jar the marketing site ever wrote to, so a
+/// signup started here arrives unattributed unless the web layer hands the
+/// campaign params across the bridge and we put them on the wire.
+///
+/// The allowlist and the truncation length mirror `ATTRIBUTION_PARAMS` and
+/// `ATTRIBUTION_VALUE_MAX_LENGTH` in
+/// `clients/web/src/domains/account/social-auth.ts` (the source of truth) and
+/// `Attribution.java` in the Android shell. All three must be changed together.
+enum Attribution {
+    static let keys: [String] = [
+        "utm_source",
+        "utm_medium",
+        "utm_campaign",
+        "utm_content",
+        "utm_term",
+        "gclid",
+        "gbraid",
+        "wbraid",
+        "msclkid",
+        "fbclid",
+        "ttclid",
+        "li_fat_id",
+        "twclid",
+    ]
+
+    /// The platform truncates per field independently; this only bounds what
+    /// we put on the wire.
+    static let valueMaxLength = 512
+
+    /// RFC 3986 unreserved characters. Everything else is percent-encoded so
+    /// Django's query parser cannot reinterpret it. `+` is the one that
+    /// bites: left raw, `parse_qsl` decodes it back as a space.
+    private static let unreserved = CharacterSet(charactersIn:
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~")
+
+    /// Allowlisted, non-empty, truncated fields from a raw bridge payload.
+    /// Anything else the caller sent is dropped.
+    static func fields(from raw: [String: Any]?) -> [String: String] {
+        guard let raw = raw else { return [:] }
+        var collected: [String: String] = [:]
+        for key in keys {
+            guard let value = raw[key] as? String, !value.isEmpty else { continue }
+            collected[key] = String(value.prefix(valueMaxLength))
+        }
+        return collected
+    }
+
+    /// Percent-encoded `key=value` pairs in ``keys`` order, or `""` when
+    /// nothing survives. Callers must leave the query untouched on `""` so a
+    /// call without attribution stays byte-identical to one from a shell that
+    /// predates this.
+    static func query(from fields: [String: String]) -> String {
+        keys.compactMap { key in
+            guard let value = fields[key], !value.isEmpty else { return nil }
+            return "\(encode(key))=\(encode(value))"
+        }.joined(separator: "&")
+    }
+
+    private static func encode(_ value: String) -> String {
+        value.addingPercentEncoding(withAllowedCharacters: unreserved) ?? value
+    }
+}

--- a/clients/ios/App/AppTests/WorkOSAuthTests.swift
+++ b/clients/ios/App/AppTests/WorkOSAuthTests.swift
@@ -1,0 +1,97 @@
+import XCTest
+
+/// Covers the pure `Attribution` helper in `App/WorkOSAuth.swift`, which the
+/// provider-token exchange uses to put campaign params on the wire.
+///
+/// Mirrors `AttributionTest.java` in the Android shell; the two allowlists and
+/// truncation lengths have to stay identical, so the drift a test would catch
+/// is the same drift on both platforms.
+final class AttributionTests: XCTestCase {
+    /// Character-for-character, in order, from `ATTRIBUTION_PARAMS` in
+    /// `clients/web/src/domains/account/social-auth.ts`.
+    func testAllowlistMatchesTheWebSourceOfTruth() {
+        XCTAssertEqual(Attribution.keys, [
+            "utm_source",
+            "utm_medium",
+            "utm_campaign",
+            "utm_content",
+            "utm_term",
+            "gclid",
+            "gbraid",
+            "wbraid",
+            "msclkid",
+            "fbclid",
+            "ttclid",
+            "li_fat_id",
+            "twclid",
+        ])
+        XCTAssertEqual(Attribution.valueMaxLength, 512)
+    }
+
+    func testFieldsKeepsOnlyAllowlistedKeys() {
+        let fields = Attribution.fields(from: [
+            "utm_source": "google",
+            "gclid": "abc123",
+            "callback_url": "https://evil.example",
+            "provider": "not-workos",
+        ])
+        XCTAssertEqual(fields, ["utm_source": "google", "gclid": "abc123"])
+    }
+
+    func testFieldsDropsEmptyAndNonStringValues() {
+        let fields = Attribution.fields(from: [
+            "utm_source": "",
+            "utm_medium": 42,
+            "utm_campaign": "spring",
+        ])
+        XCTAssertEqual(fields, ["utm_campaign": "spring"])
+    }
+
+    func testFieldsTruncatesToValueMaxLength() {
+        let long = String(repeating: "a", count: Attribution.valueMaxLength + 40)
+        let fields = Attribution.fields(from: ["utm_campaign": long])
+        XCTAssertEqual(fields["utm_campaign"]?.count, Attribution.valueMaxLength)
+    }
+
+    func testFieldsFromNilIsEmpty() {
+        XCTAssertEqual(Attribution.fields(from: nil), [:])
+        XCTAssertEqual(Attribution.fields(from: [:]), [:])
+    }
+
+    func testQueryEmitsInAllowlistOrder() {
+        let query = Attribution.query(from: [
+            "twclid": "tw",
+            "utm_medium": "cpc",
+            "utm_source": "google",
+        ])
+        XCTAssertEqual(query, "utm_source=google&utm_medium=cpc&twclid=tw")
+    }
+
+    func testQueryPercentEncodesReservedCharacters() {
+        let query = Attribution.query(from: ["utm_campaign": "spring sale&x=1+2/é"])
+        XCTAssertEqual(query, "utm_campaign=spring%20sale%26x%3D1%2B2%2F%C3%A9")
+    }
+
+    /// A `+` must survive as a literal plus: Django decodes an unencoded one
+    /// back to a space.
+    func testQueryRoundTripsThroughURLComponents() {
+        var components = URLComponents(string: "https://www.vellum.ai/x")!
+        components.percentEncodedQuery = Attribution.query(from: [
+            "utm_campaign": "spring sale",
+            "utm_term": "a+b",
+        ])
+        XCTAssertEqual(
+            components.queryItems,
+            [
+                URLQueryItem(name: "utm_campaign", value: "spring sale"),
+                URLQueryItem(name: "utm_term", value: "a+b"),
+            ]
+        )
+    }
+
+    func testQueryIsEmptyWhenNothingSurvives() {
+        XCTAssertEqual(Attribution.query(from: [:]), "")
+        XCTAssertEqual(Attribution.query(from: ["utm_source": ""]), "")
+        XCTAssertEqual(Attribution.query(from: ["unknown": "x"]), "")
+    }
+}

--- a/clients/ios/App/project.yml
+++ b/clients/ios/App/project.yml
@@ -206,3 +206,21 @@ targets:
     configFiles:
       Debug: App/Config/Extension-Dev.xcconfig
       Release: App/Config/Extension-Dev.xcconfig
+
+  # Logic-only unit tests for the framework-free helpers under `App/`.
+  # Sources are listed file by file rather than as the whole `App`
+  # directory, which is full of Capacitor plugins this host-less bundle
+  # cannot link. Keeps the suite to seconds, and to no app target.
+  AppTests:
+    type: bundle.unit-test
+    platform: iOS
+    sources:
+      - path: AppTests
+      - path: App/WorkOSAuth.swift
+    settings:
+      base:
+        GENERATE_INFOPLIST_FILE: "YES"
+        PRODUCT_BUNDLE_IDENTIFIER: ai.vellum.assistant.AppTests
+    scheme:
+      testTargets:
+        - AppTests

--- a/clients/ios/scripts/__tests__/attribution-allowlist.test.ts
+++ b/clients/ios/scripts/__tests__/attribution-allowlist.test.ts
@@ -56,7 +56,7 @@ function extractAllowlist(language: Language): string[] {
   const body = ALLOWLIST_DECLARATIONS[language].exec(read(language))?.[1];
   if (body === undefined) {
     throw new Error(
-      `${SOURCES[language]} no longer declares its attribution allowlist in the shape this guard parses`,
+      `${SOURCES[language]} does not declare its attribution allowlist in the shape this guard parses`,
     );
   }
   const keys = [...body.matchAll(/"([^"]*)"/g)].map((match) => match[1]);
@@ -72,7 +72,7 @@ function extractMaxLength(language: Language): number {
   const value = MAX_LENGTH_DECLARATIONS[language].exec(read(language))?.[1];
   if (value === undefined) {
     throw new Error(
-      `${SOURCES[language]} no longer declares its attribution truncation length in the shape this guard parses`,
+      `${SOURCES[language]} does not declare its attribution truncation length in the shape this guard parses`,
     );
   }
   return Number(value);

--- a/clients/ios/scripts/__tests__/attribution-allowlist.test.ts
+++ b/clients/ios/scripts/__tests__/attribution-allowlist.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Drift guard for the marketing attribution allowlist.
+ *
+ * `ATTRIBUTION_PARAMS` and `ATTRIBUTION_VALUE_MAX_LENGTH` in
+ * `clients/web/src/domains/account/social-auth.ts` are the source of truth for
+ * which campaign params reach the platform and how long each may be. Neither
+ * Swift nor Java can import TypeScript, so both native shells embed the list
+ * verbatim: `Attribution` in `clients/ios/App/App/WorkOSAuth.swift` and
+ * `Attribution` in
+ * `clients/android/app/src/main/java/ai/vellum/assistant/Attribution.java`.
+ * Without this test, a key added to the web contract would leave CI green
+ * while both shells silently dropped it.
+ *
+ * The TypeScript constants are read as source text rather than imported:
+ * `social-auth.ts` reaches `@/generated/...` through a CSRF helper, and that
+ * path alias has no tsconfig to resolve against from `clients/ios`, which is
+ * where the workflow runs `bun test`. Parsing all three files the same way
+ * keeps the comparison symmetric, and every extractor throws rather than
+ * yielding an empty list when a file stops matching its expected shape.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const REPO_ROOT = join(import.meta.dir, "../../../..");
+
+const SOURCES = {
+  typescript: join(REPO_ROOT, "clients/web/src/domains/account/social-auth.ts"),
+  swift: join(REPO_ROOT, "clients/ios/App/App/WorkOSAuth.swift"),
+  java: join(
+    REPO_ROOT,
+    "clients/android/app/src/main/java/ai/vellum/assistant/Attribution.java",
+  ),
+} as const;
+
+type Language = keyof typeof SOURCES;
+
+/** Declaration opener through the literal's body, captured in group 1. */
+const ALLOWLIST_DECLARATIONS: Record<Language, RegExp> = {
+  typescript: /\bconst\s+ATTRIBUTION_PARAMS\b[^=]*=\s*\[([^\]]*)\]/,
+  swift: /\bstatic\s+let\s+keys\b[^=]*=\s*\[([^\]]*)\]/,
+  java: /\bstatic\s+final\s+String\[\]\s+KEYS\s*=\s*\{([^}]*)\}/,
+};
+
+const MAX_LENGTH_DECLARATIONS: Record<Language, RegExp> = {
+  typescript: /\bconst\s+ATTRIBUTION_VALUE_MAX_LENGTH\b[^=]*=\s*(\d+)/,
+  swift: /\bstatic\s+let\s+valueMaxLength\b[^=]*=\s*(\d+)/,
+  java: /\bstatic\s+final\s+int\s+VALUE_MAX_LENGTH\s*=\s*(\d+)/,
+};
+
+function read(language: Language): string {
+  return readFileSync(SOURCES[language], "utf8");
+}
+
+function extractAllowlist(language: Language): string[] {
+  const body = ALLOWLIST_DECLARATIONS[language].exec(read(language))?.[1];
+  if (body === undefined) {
+    throw new Error(
+      `${SOURCES[language]} no longer declares its attribution allowlist in the shape this guard parses`,
+    );
+  }
+  const keys = [...body.matchAll(/"([^"]*)"/g)].map((match) => match[1]);
+  if (keys.length === 0) {
+    throw new Error(
+      `${SOURCES[language]} parsed an empty attribution allowlist`,
+    );
+  }
+  return keys;
+}
+
+function extractMaxLength(language: Language): number {
+  const value = MAX_LENGTH_DECLARATIONS[language].exec(read(language))?.[1];
+  if (value === undefined) {
+    throw new Error(
+      `${SOURCES[language]} no longer declares its attribution truncation length in the shape this guard parses`,
+    );
+  }
+  return Number(value);
+}
+
+describe("attribution allowlist", () => {
+  const expectedKeys = extractAllowlist("typescript");
+  const expectedMaxLength = extractMaxLength("typescript");
+
+  test("the web contract still looks like an allowlist", () => {
+    expect(expectedKeys).toContain("utm_source");
+    expect(new Set(expectedKeys).size).toBe(expectedKeys.length);
+    expect(expectedMaxLength).toBeGreaterThan(0);
+  });
+
+  for (const language of ["swift", "java"] as const) {
+    test(`the ${language} shell embeds the web allowlist in order`, () => {
+      expect(extractAllowlist(language)).toEqual(expectedKeys);
+    });
+
+    test(`the ${language} shell truncates at the web length`, () => {
+      expect(extractMaxLength(language)).toBe(expectedMaxLength);
+    });
+  }
+});


### PR DESCRIPTION
## What

Native (iOS) signups currently arrive with no marketing attribution at all. `NativeAuthPlugin.startAuth` has no parameter for it, and the shell's WebView cookie jar never loaded the marketing site, so the `vellum_utm` cookie fallback cannot rescue it either.

This adds the transport:

- **`Attribution` helper** in `WorkOSAuth.swift`: a `keys` allowlist character-for-character identical to `ATTRIBUTION_PARAMS` in `clients/web/src/domains/account/social-auth.ts` and in the same order, `valueMaxLength = 512` matching `ATTRIBUTION_VALUE_MAX_LENGTH`, `fields(from:)` to filter and truncate a raw bridge payload, and `query(from:)` to emit percent-encoded pairs in allowlist order.
- **`startAuth`** reads `call.getObject("attribution")` and carries the filtered fields on the same flow state that already holds `state` and the PKCE verifier.
- **`/_allauth/app/v1/auth/provider/token`** gets the query string appended when non-empty. allauth headless posts JSON, so `request.POST` is empty on the platform side and attribution has to ride `request.GET`. The JSON body is untouched.

Per `clients/AGENTS.md` ("keep their handling aligned"), the option name, the allowlist, and the truncation length match the Android shell exactly.

## Skew

An arbitrarily old App Store shell can run an arbitrarily new web bundle, and vice versa. `query(from:)` returns `""` when nothing survives and the caller then leaves `URLComponents.percentEncodedQuery` alone, so `startAuth` without `attribution` produces a byte-identical provider/token request to today's.

## Test infrastructure

The iOS target had no XCTest bundle at all, so the plan's unit tests needed one. `AppTests` is a host-less, logic-only `bundle.unit-test` target that lists its sources file by file (the whole `App` directory is full of Capacitor plugins it cannot link), and it links none of the three app targets. A `Unit tests` step runs it in both `pr-ios.yaml` and `ci-main-ios.yaml`, which the former's comment asks to change together. The simulator is picked at runtime rather than named, so the step does not break when the runner image's device names track a new Xcode.

Nine tests cover allowlist filtering, allowlist-order emission, percent-encoding (including `+`, which Django's `parse_qsl` would otherwise decode back as a space), 512-char truncation, and empty/nil input.

## Verification

The local simulator runtime is out of date, so `xcodebuild test` could not run here. Verified instead that the `AppTests` target builds standalone against `-sdk iphonesimulator`, and that all nine tests pass by compiling the same two files into a throwaway SwiftPM package. CI runs the real thing.

Part of plan: android-install-referrer-attribution.md (PR 4 of 7)