### PR TITLE
Give the phone a way out when a paired assistant's tunnel is down

### DIFF
--- a/clients/android/app/src/main/java/ai/vellum/assistant/MainActivity.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/MainActivity.java
@@ -31,6 +31,17 @@ import org.json.JSONException;
 public class MainActivity extends BridgeActivity {
     private static final long LAUNCH_SCREEN_LOAD_FALLBACK_MS = 2_000;
     private static final long LAUNCH_SCREEN_TIMEOUT_MS = 15_000;
+
+    /**
+     * The way out of an origin that cannot be reached, as a route under the app
+     * entry: the baked Vellum Cloud origin serves the chooser whether or not
+     * the configured one is up, and the chooser lists every remembered origin,
+     * so the unreachable one is still one tap away once it recovers.
+     * {@code noAutoSkip} keeps it from connecting straight through a lone
+     * assistant. Mirrors the pairing page's cancel route.
+     */
+    private static final String CHOOSER_ROUTE_PATH = "select-assistant?noAutoSkip=1";
+
     private static ConnectDeepLink recreationConnect;
     private static String recreationRoutePath;
 
@@ -351,11 +362,24 @@ public class MainActivity extends BridgeActivity {
             return;
         }
 
+        // A dead tunnel answers with its provider's own error page, which
+        // offers no way back into the app; blanking it leaves this dialog as
+        // the whole error state, matching the iOS response cancellation. Sits
+        // below the guards so an unrelated failure keeps the WebView's own
+        // error page.
+        if (bridge != null) {
+            bridge.getWebView().loadUrl("about:blank");
+        }
+
         String host = effectiveServer.getHost();
         unreachableDialog = new AlertDialog.Builder(this)
-            .setMessage("Can't load " + host + ".")
+            .setTitle("Can't reach " + host)
+            .setMessage("The assistant may be offline or unreachable from this device.")
             .setPositiveButton("Retry", (dialog, which) -> retryServer())
-            .setNegativeButton("Use Vellum Cloud", (dialog, which) -> useVellumCloud())
+            .setNegativeButton("Choose Assistant", (dialog, which) -> openAssistantChooser())
+            // Dismissing without choosing would leave a blank page and no way
+            // out, which is the state this dialog exists to end.
+            .setCancelable(false)
             .setOnDismissListener(dialog -> unreachableDialog = null)
             .create();
         unreachableDialog.show();
@@ -371,10 +395,16 @@ public class MainActivity extends BridgeActivity {
         bridge.getWebView().loadUrl(destination);
     }
 
-    private void useVellumCloud() {
+    /**
+     * Leave the unreachable origin for the chooser on the baked Vellum Cloud
+     * origin, which is up whether or not the configured one is. Clearing unsets
+     * only the active slot, so the remembered list keeps the origin and the
+     * chooser offers it back once it recovers.
+     */
+    private void openAssistantChooser() {
         SelfHostedServer.clear(this);
         effectiveServer = null;
-        recreateForServerChange(null);
+        recreateForServerChange(CHOOSER_ROUTE_PATH);
     }
 
     /**

--- a/clients/ios/App/App/MyViewController.swift
+++ b/clients/ios/App/App/MyViewController.swift
@@ -486,13 +486,13 @@ extension MyViewController: WebViewNavigationFailureObserver {
     /// outside the configured base.
     ///
     /// The `SelfHostedServer.contains` check matters because the shell loads
-    /// other URLs into the same web view — most notably Universal Links via
-    /// `AppDelegate.navigateWebView`. Without it, an unrelated failure would
-    /// offer to clear a valid preference. Scoping to the base rather than its
-    /// host is what keeps that true for a base carrying a path prefix or a
-    /// nondefault port. The configured server's own failures (boot load,
-    /// foreground reload, the deferred connect pair-page load) all sit under
-    /// the base and still alert.
+    /// other URLs into the same web view, Universal Links through
+    /// `AppDelegate.navigateWebView` above all. Without it, an unrelated
+    /// failure would offer to clear a valid preference. Scoping to the base
+    /// rather than its host is what keeps that true for a base carrying a path
+    /// prefix or a nondefault port. The configured server's own failures (boot
+    /// load, foreground reload, the deferred connect pair-page load) all sit
+    /// under the base and still alert.
     ///
     /// Cancelling an error response in the proxy makes WebKit report a second,
     /// `WebKitErrorDomain` failure for the same load; the alert's own liveness

--- a/clients/ios/App/App/MyViewController.swift
+++ b/clients/ios/App/App/MyViewController.swift
@@ -78,9 +78,15 @@ class MyViewController: CAPBridgeViewController {
     private var navigationDelegateProxy: NavigationDelegateProxy?
 
     /// The live unreachable-server alert, so a second failure for the same load
-    /// does not stack another one. Weak: the presentation owns it, and the
-    /// reference going nil is what re-arms the alert for the next failure.
+    /// does not stack another one. Weak because the presentation owns it;
+    /// `disarmUnreachableAlert()` is what actually re-arms the guard, since the
+    /// reference outlives the alert's dismissal.
     private weak var unreachableAlert: UIAlertController?
+
+    /// How long to wait before re-offering the unreachable alert when a
+    /// presentation is still animating out. Comfortably longer than UIKit's
+    /// modal transition, and only ever reached on a failure.
+    private static let alertRetryDelay: TimeInterval = 0.5
 
     /// The full server URL the web view was last loaded against — the effective
     /// self-hosted override or the baked default. Foreground change detection
@@ -525,12 +531,26 @@ extension MyViewController: WebViewNavigationFailureObserver {
         return nil
     }
 
-    private func presentUnreachableAlert(for origin: URL) {
+    private func presentUnreachableAlert(for origin: URL, attemptsLeft: Int = 6) {
         DispatchQueue.main.async { [weak self] in
             guard let self,
                   self.viewIfLoaded?.window != nil,
                   self.unreachableAlert == nil
             else { return }
+
+            let presenter = self.topMostPresenter()
+            // A presentation still animating out refuses a new one. Come back
+            // for it rather than dropping the alert, which would strand the
+            // user on the cancelled document this alert exists to explain. The
+            // attempt budget only bounds a transition that never finishes;
+            // a real one clears in well under one delay.
+            guard presenter.presentedViewController == nil else {
+                guard attemptsLeft > 0 else { return }
+                DispatchQueue.main.asyncAfter(deadline: .now() + Self.alertRetryDelay) { [weak self] in
+                    self?.presentUnreachableAlert(for: origin, attemptsLeft: attemptsLeft - 1)
+                }
+                return
+            }
 
             let host = origin.host ?? origin.absoluteString
             let alert = UIAlertController(
@@ -539,15 +559,33 @@ extension MyViewController: WebViewNavigationFailureObserver {
                 preferredStyle: .alert
             )
             alert.addAction(UIAlertAction(title: "Retry", style: .default) { [weak self] _ in
-                self?.appliedServerURL = origin
-                self?.webView?.load(URLRequest(url: Self.appEntryURL(forBase: origin)))
+                guard let self else { return }
+                self.disarmUnreachableAlert()
+                self.appliedServerURL = origin
+                self.webView?.load(URLRequest(url: Self.appEntryURL(forBase: origin)))
             })
             alert.addAction(UIAlertAction(title: "Choose Assistant", style: .default) { [weak self] _ in
-                self?.openAssistantChooser()
+                guard let self else { return }
+                self.disarmUnreachableAlert()
+                self.openAssistantChooser()
             })
             self.unreachableAlert = alert
-            self.topMostPresenter().present(alert, animated: true)
+            presenter.present(alert, animated: true)
         }
+    }
+
+    /// Release the alert-liveness guard as the alert goes away, so the next
+    /// failure can raise a fresh one.
+    ///
+    /// This cannot wait for the weak reference to clear itself. An action
+    /// handler runs while its alert is still dismissing, so the reference is
+    /// very much alive at the moment Retry kicks off the next load, and a tunnel
+    /// edge that answers another 4xx before the animation ends would have its
+    /// replacement alert suppressed. The response is cancelled either way, so
+    /// that would leave a blank document and no remaining recourse, which is the
+    /// state this whole alert exists to prevent.
+    private func disarmUnreachableAlert() {
+        unreachableAlert = nil
     }
 
     /// Leave the unreachable origin for the chooser on the baked Vellum Cloud

--- a/clients/ios/App/App/MyViewController.swift
+++ b/clients/ios/App/App/MyViewController.swift
@@ -482,14 +482,17 @@ extension MyViewController: WebViewNavigationFailureObserver {
     /// main document fails to load, or comes back an HTTP error. A no-op when no
     /// override is active (the baked Vellum Cloud URL keeps its existing
     /// behavior), when the failure is a programmatic cancellation (e.g. a
-    /// superseding navigation), or when the failed navigation targeted some
-    /// other host.
+    /// superseding navigation), or when the failed navigation targeted anything
+    /// outside the configured base.
     ///
-    /// The host check matters because the shell loads other URLs into the same
-    /// web view — most notably Universal Links via `AppDelegate.navigateWebView`.
-    /// Without it, an unrelated failure would offer to clear a valid preference.
-    /// The configured server's own failures (boot load, foreground reload, the
-    /// deferred connect pair-page load — all to the configured host) still alert.
+    /// The `SelfHostedServer.contains` check matters because the shell loads
+    /// other URLs into the same web view — most notably Universal Links via
+    /// `AppDelegate.navigateWebView`. Without it, an unrelated failure would
+    /// offer to clear a valid preference. Scoping to the base rather than its
+    /// host is what keeps that true for a base carrying a path prefix or a
+    /// nondefault port. The configured server's own failures (boot load,
+    /// foreground reload, the deferred connect pair-page load) all sit under
+    /// the base and still alert.
     ///
     /// Cancelling an error response in the proxy makes WebKit report a second,
     /// `WebKitErrorDomain` failure for the same load; the alert's own liveness
@@ -500,8 +503,8 @@ extension MyViewController: WebViewNavigationFailureObserver {
         if nsError.domain == NSURLErrorDomain, nsError.code == NSURLErrorCancelled {
             return
         }
-        guard let failedHost = Self.failingURL(for: nsError)?.host?.lowercased(),
-              failedHost == configured.host?.lowercased()
+        guard let failedURL = Self.failingURL(for: nsError),
+              SelfHostedServer.contains(failedURL, base: configured)
         else {
             return
         }
@@ -631,8 +634,10 @@ final class NavigationDelegateProxy: NSObject, WKNavigationDelegate {
         target.webView(webView, decidePolicyFor: navigationAction, decisionHandler: decisionHandler)
     }
 
-    /// Refuse a main document the configured self-hosted origin answers with an
-    /// HTTP error, and report it as a load failure.
+    /// Refuse a main document the configured self-hosted base answers with an
+    /// HTTP error, and report it as a load failure. Scoped by
+    /// `SelfHostedServer.contains` for the same reason the failure observer is:
+    /// another path or port on the same host is not this server.
     ///
     /// A dead tunnel usually answers rather than refusing the connection: ngrok
     /// serves its own `ERR_NGROK_*` page with a 4xx, which is a perfectly good
@@ -653,8 +658,8 @@ final class NavigationDelegateProxy: NSObject, WKNavigationDelegate {
               let response = navigationResponse.response as? HTTPURLResponse,
               response.statusCode >= 400,
               let url = response.url,
-              let configuredHost = SelfHostedServer.configuredURL()?.host?.lowercased(),
-              url.host?.lowercased() == configuredHost
+              let configured = SelfHostedServer.configuredURL(),
+              SelfHostedServer.contains(url, base: configured)
         else {
             decisionHandler(.allow)
             return

--- a/clients/ios/App/App/MyViewController.swift
+++ b/clients/ios/App/App/MyViewController.swift
@@ -51,11 +51,19 @@ class MyViewController: CAPBridgeViewController {
     private static let textSelectionHandlerName = "vellumTextSelection"
     private static let surfaceOverlayHandlerName = "vellumSurfaceOverlay"
 
+    /// The way out of an origin that cannot be reached, as a route under the
+    /// app entry: the baked Vellum Cloud origin serves the chooser whether or
+    /// not the configured one is up, and the chooser lists every remembered
+    /// origin, so the unreachable one is still one tap away once it recovers.
+    /// `noAutoSkip` keeps it from connecting straight through a lone assistant.
+    /// Mirrors the pairing page's cancel route.
+    private static let chooserRoutePath = "select-assistant?noAutoSkip=1"
+
     // MARK: - Self-hosted server origin
 
     /// The baked Vellum Cloud URL from `capacitor.config.json`, captured before
-    /// any self-hosted override is applied so a cleared preference and the "Use
-    /// Vellum Cloud" fallback can always return here.
+    /// any self-hosted override is applied so a cleared preference and the
+    /// unreachable alert's "Choose Assistant" fallback can always return here.
     private var bakedServerURL: URL?
 
     /// The baked Vellum Cloud URL as a string, exposed for the
@@ -68,6 +76,11 @@ class MyViewController: CAPBridgeViewController {
     /// `navigationDelegate` weakly, so the proxy must be owned here to stay
     /// alive for the view controller's lifetime.
     private var navigationDelegateProxy: NavigationDelegateProxy?
+
+    /// The live unreachable-server alert, so a second failure for the same load
+    /// does not stack another one. Weak: the presentation owns it, and the
+    /// reference going nil is what re-arms the alert for the next failure.
+    private weak var unreachableAlert: UIAlertController?
 
     /// The full server URL the web view was last loaded against — the effective
     /// self-hosted override or the baked default. Foreground change detection
@@ -466,16 +479,21 @@ extension MyViewController: WKScriptMessageHandler {
 
 extension MyViewController: WebViewNavigationFailureObserver {
     /// Present a single native alert when the configured self-hosted server's
-    /// main document fails to load. A no-op when no override is active (the baked
-    /// Vellum Cloud URL keeps its existing behavior), when the failure is a
-    /// programmatic cancellation (e.g. a superseding navigation), or when the
-    /// failed navigation targeted some other host.
+    /// main document fails to load, or comes back an HTTP error. A no-op when no
+    /// override is active (the baked Vellum Cloud URL keeps its existing
+    /// behavior), when the failure is a programmatic cancellation (e.g. a
+    /// superseding navigation), or when the failed navigation targeted some
+    /// other host.
     ///
     /// The host check matters because the shell loads other URLs into the same
     /// web view — most notably Universal Links via `AppDelegate.navigateWebView`.
     /// Without it, an unrelated failure would offer to clear a valid preference.
     /// The configured server's own failures (boot load, foreground reload, the
     /// deferred connect pair-page load — all to the configured host) still alert.
+    ///
+    /// Cancelling an error response in the proxy makes WebKit report a second,
+    /// `WebKitErrorDomain` failure for the same load; the alert's own liveness
+    /// check collapses the pair into one alert.
     func webViewNavigationDidFail(_ error: Error) {
         guard let configured = SelfHostedServer.configuredURL() else { return }
         let nsError = error as NSError
@@ -492,7 +510,8 @@ extension MyViewController: WebViewNavigationFailureObserver {
 
     /// The URL whose load failed, read from the navigation error. Populated on
     /// the `NSURLErrorDomain` failures the unreachable alert cares about
-    /// (unreachable host, TLS, timeout).
+    /// (unreachable host, TLS, timeout) and on the synthesized HTTP-status
+    /// failure, which carries the same key.
     private static func failingURL(for error: NSError) -> URL? {
         if let url = error.userInfo[NSURLErrorFailingURLErrorKey] as? URL {
             return url
@@ -507,28 +526,45 @@ extension MyViewController: WebViewNavigationFailureObserver {
         DispatchQueue.main.async { [weak self] in
             guard let self,
                   self.viewIfLoaded?.window != nil,
-                  self.presentedViewController == nil
+                  self.unreachableAlert == nil
             else { return }
 
             let host = origin.host ?? origin.absoluteString
             let alert = UIAlertController(
-                title: nil,
-                message: "Can't reach \(host).",
+                title: "Can't reach \(host)",
+                message: "The assistant may be offline or unreachable from this device.",
                 preferredStyle: .alert
             )
             alert.addAction(UIAlertAction(title: "Retry", style: .default) { [weak self] _ in
                 self?.appliedServerURL = origin
                 self?.webView?.load(URLRequest(url: Self.appEntryURL(forBase: origin)))
             })
-            alert.addAction(UIAlertAction(title: "Use Vellum Cloud", style: .default) { [weak self] _ in
-                SelfHostedServer.clear()
-                if let baked = self?.bakedServerURL {
-                    self?.appliedServerURL = baked
-                    self?.webView?.load(URLRequest(url: Self.appEntryURL(forBase: baked)))
-                }
+            alert.addAction(UIAlertAction(title: "Choose Assistant", style: .default) { [weak self] _ in
+                self?.openAssistantChooser()
             })
-            self.present(alert, animated: true)
+            self.unreachableAlert = alert
+            self.topMostPresenter().present(alert, animated: true)
         }
+    }
+
+    /// Leave the unreachable origin for the chooser on the baked Vellum Cloud
+    /// origin. Clearing unsets only the active slot, so the remembered list
+    /// keeps the origin and the chooser offers it back once it recovers.
+    private func openAssistantChooser() {
+        SelfHostedServer.clear()
+        applyConfiguredOrigin(path: Self.chooserRoutePath)
+    }
+
+    /// The controller to present from. The shell presents its own sheets (the
+    /// camera, a share sheet) over this one, and presenting on a controller
+    /// that already has a presentation is a UIKit no-op, which would leave the
+    /// failure with no alert and the user with no way out.
+    private func topMostPresenter() -> UIViewController {
+        var presenter: UIViewController = self
+        while let presented = presenter.presentedViewController, !presented.isBeingDismissed {
+            presenter = presented
+        }
+        return presenter
     }
 }
 
@@ -552,7 +588,9 @@ protocol WebViewNavigationFailureObserver: AnyObject {
 ///     link) load in-app instead of being handed to Safari. The scope is exactly
 ///     the currently-configured host; everything else defers to Capacitor.
 ///  2. Main-document load failures are reported to `failureObserver` so the
-///     shell can show a native "can't reach server" alert.
+///     shell can show a native "can't reach server" alert. That covers both a
+///     navigation that fails outright and one the configured origin answers
+///     with an HTTP error.
 final class NavigationDelegateProxy: NSObject, WKNavigationDelegate {
     private weak var target: WebViewDelegationHandler?
     private weak var failureObserver: WebViewNavigationFailureObserver?
@@ -591,6 +629,48 @@ final class NavigationDelegateProxy: NSObject, WKNavigationDelegate {
             return
         }
         target.webView(webView, decidePolicyFor: navigationAction, decisionHandler: decisionHandler)
+    }
+
+    /// Refuse a main document the configured self-hosted origin answers with an
+    /// HTTP error, and report it as a load failure.
+    ///
+    /// A dead tunnel usually answers rather than refusing the connection: ngrok
+    /// serves its own `ERR_NGROK_*` page with a 4xx, which is a perfectly good
+    /// navigation as far as WebKit is concerned, so no `didFail` callback fires
+    /// and the provider's page renders with no way back to the app. Cancelling
+    /// keeps that page off screen, leaving the shell's own alert as the whole
+    /// error state. Android reaches the same alert via `onReceivedHttpError`.
+    ///
+    /// Capacitor's `WebViewDelegationHandler` does not implement this callback,
+    /// so nothing is forwarded; implementing it here does take the selector out
+    /// of the message forwarding above, so re-check that on a Capacitor upgrade.
+    func webView(
+        _ webView: WKWebView,
+        decidePolicyFor navigationResponse: WKNavigationResponse,
+        decisionHandler: @escaping (WKNavigationResponsePolicy) -> Void
+    ) {
+        guard navigationResponse.isForMainFrame,
+              let response = navigationResponse.response as? HTTPURLResponse,
+              response.statusCode >= 400,
+              let url = response.url,
+              let configuredHost = SelfHostedServer.configuredURL()?.host?.lowercased(),
+              url.host?.lowercased() == configuredHost
+        else {
+            decisionHandler(.allow)
+            return
+        }
+        decisionHandler(.cancel)
+        failureObserver?.webViewNavigationDidFail(Self.errorStatusFailure(for: url))
+    }
+
+    /// An HTTP error response as the kind of error `webViewNavigationDidFail`
+    /// already reads, so both failure shapes land on one alert path.
+    private static func errorStatusFailure(for url: URL) -> NSError {
+        return NSError(
+            domain: NSURLErrorDomain,
+            code: NSURLErrorBadServerResponse,
+            userInfo: [NSURLErrorFailingURLErrorKey: url]
+        )
     }
 
     // The force unwrap is part of the WKNavigationDelegate declaration.

--- a/clients/ios/App/App/SelfHostedServer.swift
+++ b/clients/ios/App/App/SelfHostedServer.swift
@@ -140,6 +140,60 @@ enum SelfHostedServer {
         return canonicalString(active) == canonicalString(url)
     }
 
+    /// Whether a URL falls inside a server base: same scheme, host and
+    /// effective port, with a path at or under the base's. The mirror of
+    /// Android's `SelfHostedServer.contains`, and the scope every "did the
+    /// configured server's own load fail?" check needs. Comparing hosts alone
+    /// would claim an unrelated URL on the same host, most plausibly a
+    /// Universal Link, whenever the base carries a path prefix or a nondefault
+    /// port.
+    static func contains(_ url: URL, base: URL) -> Bool {
+        let base = canonicalize(base)
+        let candidate = canonicalize(url)
+        guard base.scheme == candidate.scheme,
+              base.host == candidate.host,
+              base.port == candidate.port
+        else {
+            return false
+        }
+        // `canonicalize` collapses the https default port, so equal ports here
+        // are equal effective ports.
+        let basePath = comparablePath(base)
+        guard !basePath.isEmpty else {
+            return true
+        }
+        let candidatePath = comparablePath(candidate)
+        return candidatePath == basePath || candidatePath.hasPrefix(basePath + "/")
+    }
+
+    /// A canonicalized path as containment compares it: percent-escape hex
+    /// uppercased, since RFC 3986 makes it case-insensitive and `%2f` has to
+    /// match `%2F`. Comparison-only, like Android's `foldEscapeCase`; canonical
+    /// list identity keeps the original casing. Assumes a canonicalized URL, so
+    /// trailing slashes are already gone.
+    private static func comparablePath(_ canonical: URL) -> String {
+        let path = URLComponents(url: canonical, resolvingAgainstBaseURL: false)?
+            .percentEncodedPath ?? canonical.path
+        guard path != "/" else {
+            return ""
+        }
+        var folded = ""
+        folded.reserveCapacity(path.count)
+        var escapeDigits = 0
+        for character in path {
+            if escapeDigits > 0 {
+                folded.append(contentsOf: character.uppercased())
+                escapeDigits -= 1
+                continue
+            }
+            folded.append(character)
+            if character == "%" {
+                escapeDigits = 2
+            }
+        }
+        return folded
+    }
+
     /// Persist a validated origin under the shared defaults key.
     static func store(_ url: URL, defaults: UserDefaults = .standard) {
         setActive(url.absoluteString, defaults: defaults)

--- a/clients/ios/App/App/SelfHostedServer.swift
+++ b/clients/ios/App/App/SelfHostedServer.swift
@@ -33,7 +33,7 @@ import Foundation
 ///  1. `setActive`, so each in-app path inherits the drop without a call of its
 ///     own: the plugin's `switchTo`, `switchToPath` and `remove`, the `connect`
 ///     deep link on both a warm open and a cold launch, and the
-///     unreachable-server alert's "Use Vellum Cloud" fallback.
+///     unreachable-server alert's "Choose Assistant" fallback.
 ///  2. `MyViewController.reloadIfConfiguredOriginChanged()`, for the iOS
 ///     Settings pane, the one writer that goes straight to `UserDefaults`
 ///     behind this type's back while the app is running.


### PR DESCRIPTION
## Summary

- **iOS never noticed a dead tunnel.** `NavigationDelegateProxy` only watched `didFailProvisionalNavigation` / `didFail`, which are transport-level, but ngrok and Cloudflare terminate TLS at their own edge and *answer* when the agent is gone (404 `ERR_NGROK_3200`, 530 error 1033). WebKit treats that as a perfectly good navigation, so no failure callback fired and the provider's error page rendered with no Vellum UI and no way back. The proxy now implements `decidePolicyFor navigationResponse` and cancels a main-frame HTTP >= 400 from the configured self-hosted host, reporting it through the existing failure path. Android already caught this via `onReceivedHttpError`, but left the provider's page sitting behind the dialog.
- **Both shells' unreachable dialogs gained a "Choose Assistant" action**, replacing "Use Vellum Cloud". It clears the active slot and loads `select-assistant?noAutoSkip=1` on the baked Vellum Cloud origin, which is up whether or not the configured one is. Clearing unsets only the *active* server, so the remembered list keeps the origin and the chooser offers it back once it recovers. Mirrors the pairing page's cancel route.
- **Two smaller recourse fixes.** iOS deduped the alert on `presentedViewController == nil`, which silently dropped it whenever anything else was presented (stuck again), so it now dedupes on a weak reference to its own alert and presents from the top-most controller. Android blanks the failed document so the dialog is the whole error state, and the dialog is no longer cancelable, since dismissing it returned the user to exactly the state it exists to end.

## Provider coverage

| Provider | Assistant down | Caught by |
| --- | --- | --- |
| ngrok | edge answers 404 `ERR_NGROK_3200` | new response-policy path |
| Cloudflare Tunnel | edge answers 530 / error 1033 | new response-policy path |
| Tailscale Funnel, node offline | connection refused (SNI passthrough) | pre-existing transport path |
| Tailscale, node up + assistant down | `tailscale serve` returns 502 | new response-policy path |

Out of scope by design: a tunnel that dies *while* the SPA is already loaded stays with the web app's own reachability handling (`active-chat-view.tsx` "Connection lost"), where the in-SPA chooser still works because navigation is client-side.

## Testing

**Not built locally, and not QA'd on a device.** This machine's Xcode has no simulator runtime matching the 26.5 SDK, so `actool` fails on the VoiceActivity asset catalog before any Swift compiles, and there is no JDK or Android SDK here. `pr-ios.yaml` and `android-checks.yaml` are the first real builds for both platforms.

What was checked: the new Swift typechecks against the real iOS SDK in isolation, and the emitted ObjC header confirms the new method exports as `webView:decidePolicyForNavigationResponse:decisionHandler:`, the selector WebKit actually sends. `SelfHostedServerTest` already covers `appRoute(..., "select-assistant?noAutoSkip=1")`, the one string shared between the two platforms.

## Original prompt

Noa reported that on iOS (and likely Android), when the phone is paired to a local assistant and the tunnel is down (e.g. ngrok is not running), the app shows the tunnel provider's own error page with no recourse and no way for the user to exit that state. The ask was to detect this, show an error state of our own, and give it a button back to the Choose Assistant page. Scoped to the native mobile shells; not merged, per the convention that Noa merges to main manually.