### PR TITLE
fix: report unreadable host avatar images as failures, thread plugin env into the avatar endpoint, trim exports

### DIFF
--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -57,6 +57,8 @@ The CLI is a generic lifecycle manager. It must **never** contain references to 
 
 Cross-package imports into `skills/` are forbidden. The CLI is distributed as an npm package; anything outside `cli/` is not included in the tarball and will fail to resolve at runtime.
 
+Workspace packages that `cli/src` never imports may still be listed in `package.json` `dependencies` and `bundledDependencies` when a bundled dependency depends on them (for example `@vellumai/avatar-manifest`, pulled in by `@vellumai/local-mode`); `bundledDependencies` only nests a `file:` dep when it is a direct dependency of the CLI.
+
 ## Boundary: No `.vellum/` directory access
 
 The CLI must **never** read from or write to the `.vellum/` directory (e.g. `~/.vellum/protected/`, `<instanceDir>/.vellum/`). That directory structure is an **assistant daemon / gateway implementation detail**. The CLI's job is to spawn those processes and pass configuration via environment variables — not to reach into their internal storage.

--- a/clients/web/vite-plugin-local-mode.test.ts
+++ b/clients/web/vite-plugin-local-mode.test.ts
@@ -13,6 +13,7 @@ import type { ViteDevServer, Connect } from "vite";
 import {
   AVATAR_IMAGE_FILENAME,
   AVATAR_MANIFEST_FILENAME,
+  AVATAR_TRAITS_FILENAME,
   resolveAvatarDir,
 } from "@vellumai/avatar-manifest";
 import * as actualLocalMode from "@vellumai/local-mode";
@@ -51,6 +52,7 @@ const env = {
   VELLUM_ENVIRONMENT: "production",
   VELLUM_LOCKFILE_DIR: tempDir,
   XDG_CONFIG_HOME: tempDir,
+  XDG_DATA_HOME: path.join(tempDir, "data-home"),
 };
 const configDir = path.join(tempDir, "vellum");
 const lockfilePath = path.join(tempDir, ".vellum.lock.json");
@@ -305,6 +307,43 @@ describe("avatar middleware", () => {
       ok: false,
       error: "Malformed assistant ID",
     });
+  });
+
+  test("an unreadable manifest image is a failure, not null", async () => {
+    fs.writeFileSync(
+      path.join(avatarDir, AVATAR_MANIFEST_FILENAME),
+      JSON.stringify({
+        kind: "image",
+        image: { updatedAt: "2026-01-01T00:00:00.000Z", etag: "abc" },
+      }),
+    );
+
+    expect(JSON.parse((await dispatch("/__local/avatar/asst-a")).body)).toEqual(
+      { ok: false, error: "avatar image unreadable" },
+    );
+  });
+
+  test("entry without an instanceDir resolves the default dir from the plugin env", async () => {
+    writeLockfile([{ assistantId: "asst-a", cloud: "local" }]);
+    const defaultAvatarDir = resolveAvatarDir(
+      path.join(
+        env.XDG_DATA_HOME,
+        "vellum",
+        "assistants",
+        "asst-a",
+        ".vellum",
+        "workspace",
+      ),
+    );
+    fs.mkdirSync(defaultAvatarDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(defaultAvatarDir, AVATAR_TRAITS_FILENAME),
+      JSON.stringify(traits),
+    );
+
+    expect(JSON.parse((await dispatch("/__local/avatar/asst-a")).body)).toEqual(
+      { ok: true, avatar: { kind: "character", traits } },
+    );
   });
 
   test("absent avatar and unknown assistant both resolve to null", async () => {

--- a/clients/web/vite-plugin-local-mode.ts
+++ b/clients/web/vite-plugin-local-mode.ts
@@ -120,7 +120,7 @@ export function localModePlugin(env: Record<string, string>): Plugin {
       server.middlewares.use(
         statusMiddleware(config.lockfilePaths, upgradingLocalAssistantIds),
       );
-      server.middlewares.use(avatarMiddleware(config.lockfilePaths));
+      server.middlewares.use(avatarMiddleware(config.lockfilePaths, env));
       server.middlewares.use(
         guardianTokenMiddleware(
           config.lockfilePaths,
@@ -941,7 +941,10 @@ function statusMiddleware(
   };
 }
 
-function avatarMiddleware(lockfilePaths: string[]): Connect.NextHandleFunction {
+function avatarMiddleware(
+  lockfilePaths: string[],
+  env: Record<string, string>,
+): Connect.NextHandleFunction {
   return (req, res, next) => {
     const match = req.url?.match(LOCAL_AVATAR_PATTERN);
     if (!match) {
@@ -971,7 +974,7 @@ function avatarMiddleware(lockfilePaths: string[]): Connect.NextHandleFunction {
     res.setHeader("Content-Type", "application/json");
     res.end(
       JSON.stringify(
-        readLockfileAssistantAvatar(lockfilePaths, assistantId, process.env),
+        readLockfileAssistantAvatar(lockfilePaths, assistantId, env),
       ),
     );
   };

--- a/packages/avatar-manifest/src/layout.ts
+++ b/packages/avatar-manifest/src/layout.ts
@@ -1,7 +1,7 @@
 import { join } from "node:path";
 
 /** Path segments of the avatar directory below the workspace directory. */
-export const AVATAR_DIR_SEGMENTS: readonly string[] = ["data", "avatar"];
+const AVATAR_DIR_SEGMENTS: readonly string[] = ["data", "avatar"];
 
 /** Avatar state manifest. */
 export const AVATAR_MANIFEST_FILENAME = "avatar.json";

--- a/packages/avatar-manifest/src/manifest.ts
+++ b/packages/avatar-manifest/src/manifest.ts
@@ -35,9 +35,7 @@ function isNonEmptyString(value: unknown): value is string {
 }
 
 /** Narrows an unknown value to valid CharacterTraits (presence check only). */
-export function isValidCharacterTraits(
-  value: unknown,
-): value is CharacterTraits {
+function isValidCharacterTraits(value: unknown): value is CharacterTraits {
   return (
     isRecord(value) &&
     isNonEmptyString(value.bodyShape) &&
@@ -47,9 +45,7 @@ export function isValidCharacterTraits(
 }
 
 /** Narrows an unknown value to valid AvatarImageMeta (presence check only). */
-export function isValidAvatarImageMeta(
-  value: unknown,
-): value is AvatarImageMeta {
+function isValidAvatarImageMeta(value: unknown): value is AvatarImageMeta {
   return (
     isRecord(value) &&
     isNonEmptyString(value.updatedAt) &&
@@ -85,7 +81,7 @@ export function parseAvatarManifest(value: unknown): AvatarState | null {
   };
 }
 
-export type LegacyAvatarDerivation =
+type LegacyAvatarDerivation =
   | { kind: "character"; traits: CharacterTraits }
   | { kind: "image" }
   | { kind: "none" };
@@ -106,7 +102,7 @@ export function deriveAvatarFromLegacyFiles(input: {
   return input.hasImage ? { kind: "image" } : { kind: "none" };
 }
 
-export type ResolvedAvatar =
+type ResolvedAvatar =
   | { kind: "character"; traits: CharacterTraits }
   | { kind: "image"; image: AvatarImageMeta | null }
   | { kind: "none" };

--- a/packages/electron-desktop/src/local-mode.test.ts
+++ b/packages/electron-desktop/src/local-mode.test.ts
@@ -1419,6 +1419,29 @@ describe("vellum:localMode:readAssistantAvatar handler", () => {
     }
   });
 
+  test("an unreadable manifest image surfaces as a failure over IPC", () => {
+    const avatarDir = path.join(
+      instanceDir,
+      ".vellum",
+      "workspace",
+      "data",
+      "avatar",
+    );
+    fs.mkdirSync(avatarDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(avatarDir, "avatar.json"),
+      JSON.stringify({
+        kind: "image",
+        image: { updatedAt: "2026-01-01T00:00:00.000Z", etag: "abc" },
+      }),
+    );
+
+    expect(readAssistantAvatar("asst-1")).toEqual({
+      ok: false,
+      error: "avatar image unreadable",
+    });
+  });
+
   test("missing assistantId is a structured error", () => {
     expect(readAssistantAvatar(undefined)).toEqual({
       ok: false,

--- a/packages/ipc-contract/src/bridge.ts
+++ b/packages/ipc-contract/src/bridge.ts
@@ -109,8 +109,8 @@ export type LocalRevokeDeviceResult =
 
 /**
  * A local assistant's avatar as read off its workspace by the host. `null`
- * covers every "nothing to show" case (no entry, no workspace, no avatar,
- * unreadable files); only malformed arguments produce `ok: false`.
+ * is a conclusive absence (no entry, no workspace, no avatar); malformed
+ * arguments and files the host cannot serve produce `ok: false`.
  */
 export type LocalAssistantAvatar =
   | {

--- a/packages/ipc-contract/src/index.ts
+++ b/packages/ipc-contract/src/index.ts
@@ -13,7 +13,6 @@ export * from "./types";
 export * from "./schemas";
 export {
   type ElectronHostOS,
-  type LocalAssistantAvatar,
   type LocalConnectImportResult,
   type LocalListDevicesResult,
   type LocalPairedDeviceRecord,

--- a/packages/local-mode/src/avatar.test.ts
+++ b/packages/local-mode/src/avatar.test.ts
@@ -3,12 +3,13 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { AVATAR_IMAGE_MAX_BYTES, readLockfileAssistantAvatar } from "./avatar";
+import { readLockfileAssistantAvatar } from "./avatar";
 
 describe("readLockfileAssistantAvatar", () => {
   const traits = { bodyShape: "round", eyeStyle: "dot", color: "#abc" };
   const imageMeta = { updatedAt: "2026-01-01T00:00:00.000Z", etag: "abc" };
   const png = Buffer.from("89504e470d0a1a0a", "hex");
+  const imageMaxBytes = 5 * 1024 * 1024;
   let tempDir: string;
   let lockfilePath: string;
   let instanceDir: string;
@@ -171,17 +172,14 @@ describe("readLockfileAssistantAvatar", () => {
     });
   });
 
-  test("oversized image yields null", () => {
+  test("oversized image is a failure, not a conclusive none", () => {
     writeAvatarFile(
       "avatar.json",
       JSON.stringify({ kind: "image", image: imageMeta }),
     );
-    writeAvatarFile(
-      "avatar-image.png",
-      Buffer.alloc(AVATAR_IMAGE_MAX_BYTES + 1),
-    );
+    writeAvatarFile("avatar-image.png", Buffer.alloc(imageMaxBytes + 1));
 
-    expect(read()).toEqual({ ok: true, avatar: null });
+    expect(read()).toEqual({ ok: false, error: "avatar image too large" });
   });
 
   test("image at exactly the cap is served", () => {
@@ -189,7 +187,7 @@ describe("readLockfileAssistantAvatar", () => {
       "avatar.json",
       JSON.stringify({ kind: "image", image: imageMeta }),
     );
-    const image = Buffer.alloc(AVATAR_IMAGE_MAX_BYTES);
+    const image = Buffer.alloc(imageMaxBytes);
     writeAvatarFile("avatar-image.png", image);
 
     expect(read()).toEqual({
@@ -198,14 +196,23 @@ describe("readLockfileAssistantAvatar", () => {
     });
   });
 
-  test("manifest image whose PNG is a directory yields null", () => {
+  test("manifest image whose PNG is a directory is a failure", () => {
     writeAvatarFile(
       "avatar.json",
       JSON.stringify({ kind: "image", image: imageMeta }),
     );
     fs.mkdirSync(path.join(avatarDir, "avatar-image.png"));
 
-    expect(read()).toEqual({ ok: true, avatar: null });
+    expect(read()).toEqual({ ok: false, error: "avatar image unreadable" });
+  });
+
+  test("manifest image whose PNG is missing is a failure", () => {
+    writeAvatarFile(
+      "avatar.json",
+      JSON.stringify({ kind: "image", image: imageMeta }),
+    );
+
+    expect(read()).toEqual({ ok: false, error: "avatar image unreadable" });
   });
 
   test("malformed manifest falls back to legacy inference", () => {

--- a/packages/local-mode/src/avatar.ts
+++ b/packages/local-mode/src/avatar.ts
@@ -9,34 +9,37 @@ import {
 import { resolveLockfileInstanceDir } from "./status";
 
 /**
- * A lockfile assistant's avatar as read off its workspace by a host. `null`
- * covers every "nothing to show" case (no entry, no workspace, no avatar,
- * unreadable or oversized files). Structurally identical to
+ * A lockfile assistant's avatar as read off its workspace by a host.
+ * `{ ok: true, avatar: null }` is a conclusive absence (no entry, no
+ * workspace, no avatar); a file the manifest points at but the host cannot
+ * serve (unreadable, oversized) is `ok: false` so callers keep their
+ * last-seen avatar. Structurally identical to
  * `LocalReadAssistantAvatarResult` in `@vellumai/ipc-contract`, which this
  * package cannot depend on; hosts return it straight over IPC/HTTP.
  */
-export type LockfileAssistantAvatar =
+type LockfileAssistantAvatar =
   | { kind: "character"; traits: CharacterTraits }
   | { kind: "image"; imageBase64: string };
 
-export type LockfileAssistantAvatarResult =
+type LockfileAssistantAvatarResult =
   | { ok: true; avatar: LockfileAssistantAvatar | null }
   | { ok: false; error: string };
 
-export const AVATAR_IMAGE_MAX_BYTES = 5 * 1024 * 1024;
+const AVATAR_IMAGE_MAX_BYTES = 5 * 1024 * 1024;
 
-function readAvatarImage(imagePath: string): LockfileAssistantAvatar | null {
+function readAvatarImage(imagePath: string): LockfileAssistantAvatarResult {
   try {
     const stats = fs.statSync(imagePath);
-    if (!stats.isFile() || stats.size > AVATAR_IMAGE_MAX_BYTES) {
-      return null;
+    if (!stats.isFile()) {
+      return { ok: false, error: "avatar image unreadable" };
     }
-    return {
-      kind: "image",
-      imageBase64: fs.readFileSync(imagePath).toString("base64"),
-    };
+    if (stats.size > AVATAR_IMAGE_MAX_BYTES) {
+      return { ok: false, error: "avatar image too large" };
+    }
+    const imageBase64 = fs.readFileSync(imagePath).toString("base64");
+    return { ok: true, avatar: { kind: "image", imageBase64 } };
   } catch {
-    return null;
+    return { ok: false, error: "avatar image unreadable" };
   }
 }
 
@@ -66,7 +69,7 @@ export function readLockfileAssistantAvatar(
     case "character":
       return { ok: true, avatar: { kind: "character", traits: avatar.traits } };
     case "image":
-      return { ok: true, avatar: readAvatarImage(avatar.imagePath) };
+      return readAvatarImage(avatar.imagePath);
     case "none":
       return { ok: true, avatar: null };
   }


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review (round 2) for chooser-assistant-avatars.md.

**Gaps:** host image read failures surfaced as a conclusive null (evicting the last-seen cache); vite avatar middleware used process.env instead of the plugin env; unused/test-only exports in local-mode, avatar-manifest, ipc-contract