### PR TITLE
fix: share the platform PATCH queue and persist the last-synced avatar key across restarts

### DIFF
--- a/assistant/src/avatar/ensure-raster.ts
+++ b/assistant/src/avatar/ensure-raster.ts
@@ -7,17 +7,6 @@ import { writeTraitsAndRenderAvatar } from "./traits-png-sync.js";
 
 const log = getLogger("ensure-raster");
 
-function readPng(path: string): Buffer | null {
-  try {
-    return readFileSync(path);
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
-      return null;
-    }
-    throw err;
-  }
-}
-
 /**
  * Returns the on-disk path of the current avatar PNG, or null when there is
  * none. Never reads the raster bytes.
@@ -46,25 +35,32 @@ export async function ensureAvatarRasterPath(
 
   try {
     const result = writeTraitsAndRenderAvatar(state.traits);
-    if (!result.ok) {
-      log.warn({ reason: result.reason }, "Avatar raster re-render failed");
-      return null;
+    if (result.ok) {
+      return avatarPath;
     }
+    log.warn({ reason: result.reason }, "Avatar raster re-render failed");
   } catch (err) {
     log.warn({ err }, "Avatar raster re-render threw");
-    return null;
   }
-
-  return existsSync(avatarPath) ? avatarPath : null;
+  return null;
 }
 
 /**
- * Returns the PNG raster for the current avatar, or null when there is none.
- * Same existence and regeneration semantics as `ensureAvatarRasterPath`.
+ * Returns the PNG raster for the current avatar, or null when there is none
+ * or it cannot be read. Same regeneration semantics as
+ * `ensureAvatarRasterPath`.
  */
 export async function ensureAvatarRaster(
   state: AvatarState = readAvatarState(),
 ): Promise<Buffer | null> {
   const avatarPath = await ensureAvatarRasterPath(state);
-  return avatarPath ? readPng(avatarPath) : null;
+  if (!avatarPath) {
+    return null;
+  }
+  try {
+    return readFileSync(avatarPath);
+  } catch (err) {
+    log.warn({ err }, "Avatar raster read failed");
+    return null;
+  }
 }

--- a/assistant/src/platform/platform-patch-queue.test.ts
+++ b/assistant/src/platform/platform-patch-queue.test.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+let mockClient: {
+  baseUrl: string;
+  platformAssistantId: string;
+  fetch: (path: string, init: RequestInit) => Promise<Response>;
+} | null;
+
+mock.module("./client.js", () => ({
+  VellumPlatformClient: { create: async () => mockClient },
+}));
+
+import { getLogger } from "../util/logger.js";
+import { createPlatformPatchQueue } from "./platform-patch-queue.js";
+
+interface Patch {
+  path: string;
+  body: { value: string };
+}
+
+let patches: Patch[];
+let respond: () => Response;
+let builds: number;
+
+function makeClient(assistantId = "asst-1", baseUrl = "https://platform.a") {
+  return {
+    baseUrl,
+    platformAssistantId: assistantId,
+    fetch: async (path: string, init: RequestInit) => {
+      patches.push({ path, body: JSON.parse(init.body as string) });
+      return respond();
+    },
+  };
+}
+
+function makeQueue(
+  opts: {
+    loadSyncedKey?: () => string | null;
+    saveSyncedKey?: (key: string) => void;
+  } = {},
+) {
+  return createPlatformPatchQueue<string | undefined>({
+    log: getLogger("test"),
+    label: "value",
+    buildPayload: (value) => {
+      builds += 1;
+      return value === undefined ? undefined : { key: value, body: { value } };
+    },
+    ...opts,
+  });
+}
+
+async function settle(): Promise<void> {
+  for (let i = 0; i < 10; i++) {
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+describe("createPlatformPatchQueue", () => {
+  beforeEach(() => {
+    patches = [];
+    builds = 0;
+    respond = () => new Response("{}", { status: 200 });
+    mockClient = makeClient();
+  });
+
+  test("PATCHes once and dedups an unchanged key", async () => {
+    const queue = makeQueue();
+    queue.enqueue("a");
+    await settle();
+    queue.enqueue("a");
+    await settle();
+
+    expect(patches).toEqual([
+      { path: "/v1/assistants/asst-1/", body: { value: "a" } },
+    ]);
+  });
+
+  test("re-registering to another assistant id or base URL re-sends", async () => {
+    const queue = makeQueue();
+    queue.enqueue("a");
+    await settle();
+    mockClient = makeClient("asst-2");
+    queue.enqueue("a");
+    await settle();
+    mockClient = makeClient("asst-2", "https://platform.b");
+    queue.enqueue("a");
+    await settle();
+    queue.enqueue("a");
+    await settle();
+
+    expect(patches.map((p) => p.path)).toEqual([
+      "/v1/assistants/asst-1/",
+      "/v1/assistants/asst-2/",
+      "/v1/assistants/asst-2/",
+    ]);
+  });
+
+  test("rapid enqueues collapse into one PATCH carrying the newest payload", async () => {
+    const queue = makeQueue();
+    queue.enqueue("a");
+    queue.enqueue("b");
+    queue.enqueue("c");
+    await settle();
+
+    expect(patches.map((p) => p.body.value)).toEqual(["c"]);
+    expect(builds).toBe(1);
+  });
+
+  test("an undefined payload, missing client, or missing assistant id skips", async () => {
+    const queue = makeQueue();
+    queue.enqueue(undefined);
+    await settle();
+    mockClient = null;
+    queue.enqueue("a");
+    await settle();
+    mockClient = makeClient("");
+    queue.enqueue("a");
+    await settle();
+
+    expect(patches).toHaveLength(0);
+    expect(builds).toBe(1);
+  });
+
+  test("a failed PATCH does not dedup the next attempt", async () => {
+    const queue = makeQueue();
+    respond = () => new Response("nope", { status: 500 });
+    queue.enqueue("a");
+    await settle();
+    respond = () => new Response("{}", { status: 200 });
+    queue.enqueue("a");
+    await settle();
+    queue.enqueue("a");
+    await settle();
+
+    expect(patches).toHaveLength(2);
+  });
+
+  test("a thrown fetch is swallowed and retried on the next enqueue", async () => {
+    const queue = makeQueue();
+    mockClient = {
+      ...makeClient(),
+      fetch: async () => {
+        throw new Error("boom");
+      },
+    };
+    queue.enqueue("a");
+    await settle();
+    mockClient = makeClient();
+    queue.enqueue("a");
+    await settle();
+
+    expect(patches).toHaveLength(1);
+  });
+
+  test("seeds the dedup key from loadSyncedKey and saves each success", async () => {
+    const saved: string[] = [];
+    const queue = makeQueue({
+      loadSyncedKey: () => "https://platform.a|asst-1|a",
+      saveSyncedKey: (key) => saved.push(key),
+    });
+    queue.enqueue("a");
+    await settle();
+    queue.enqueue("b");
+    await settle();
+
+    expect(patches.map((p) => p.body.value)).toEqual(["b"]);
+    expect(saved).toEqual(["https://platform.a|asst-1|b"]);
+  });
+});

--- a/assistant/src/platform/platform-patch-queue.ts
+++ b/assistant/src/platform/platform-patch-queue.ts
@@ -1,0 +1,115 @@
+/**
+ * Serialized, deduplicated PATCH queue for the platform Assistant record.
+ *
+ * Each `enqueue` bumps a sequence number and chains onto the previous request,
+ * so rapid changes collapse into one PATCH carrying the newest payload and a
+ * stale in-flight response cannot overwrite a newer value. The dedup key is
+ * scoped to the platform destination (base URL + assistant id), so
+ * re-registering elsewhere re-sends an unchanged payload. Best-effort: failures
+ * are logged, never thrown, and leave the dedup key untouched so the next
+ * enqueue retries.
+ */
+
+import type { getLogger } from "../util/logger.js";
+import { VellumPlatformClient } from "./client.js";
+
+type Logger = ReturnType<typeof getLogger>;
+
+type PatchBody = Record<string, unknown>;
+
+export interface PatchPayload {
+  /** Identifies the payload content; equal keys are not re-sent. */
+  key: string;
+  /** A function runs only after the key passes dedup; undefined skips. */
+  body: PatchBody | (() => Promise<PatchBody | undefined>);
+}
+
+export interface PlatformPatchQueueOptions<T> {
+  log: Logger;
+  /** Names the synced thing in log lines, e.g. "avatar". */
+  label: string;
+  /** Returns undefined to skip the PATCH entirely. */
+  buildPayload: (
+    input: T,
+  ) => Promise<PatchPayload | undefined> | PatchPayload | undefined;
+  /** Seeds the dedup key on first use (e.g. from disk). */
+  loadSyncedKey?: () => string | null;
+  /** Called after each successful PATCH with the destination-scoped key. */
+  saveSyncedKey?: (key: string) => void;
+}
+
+export interface PlatformPatchQueue<T> {
+  enqueue: (input: T) => void;
+}
+
+export function createPlatformPatchQueue<T = void>(
+  options: PlatformPatchQueueOptions<T>,
+): PlatformPatchQueue<T> {
+  const { log, label, buildPayload, loadSyncedKey, saveSyncedKey } = options;
+  let lastSyncedKey: string | null | undefined;
+  let seq = 0;
+  let pending: Promise<void> = Promise.resolve();
+
+  async function run(input: T, requestSeq: number): Promise<void> {
+    try {
+      if (requestSeq !== seq) {
+        return;
+      }
+      const client = await VellumPlatformClient.create();
+      const assistantId = client?.platformAssistantId;
+      if (!client || !assistantId) {
+        return;
+      }
+
+      const payload = await buildPayload(input);
+      if (!payload || requestSeq !== seq) {
+        return;
+      }
+      const key = `${client.baseUrl}|${assistantId}|${payload.key}`;
+      lastSyncedKey ??= loadSyncedKey?.() ?? null;
+      if (key === lastSyncedKey) {
+        return;
+      }
+      const body =
+        typeof payload.body === "function"
+          ? await payload.body()
+          : payload.body;
+      if (!body || requestSeq !== seq) {
+        return;
+      }
+
+      const resp = await client.fetch(
+        `/v1/assistants/${encodeURIComponent(assistantId)}/`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+          signal: AbortSignal.timeout(15_000),
+        },
+      );
+
+      if (resp.ok) {
+        lastSyncedKey = key;
+        saveSyncedKey?.(key);
+        log.info(
+          { key: payload.key, assistantId },
+          `Synced ${label} to platform`,
+        );
+      } else {
+        log.warn(
+          { status: resp.status, body: await resp.text(), assistantId },
+          `Failed to sync ${label} to platform`,
+        );
+      }
+    } catch (err) {
+      log.warn({ err }, `Error syncing ${label} to platform`);
+    }
+  }
+
+  return {
+    enqueue(input: T): void {
+      const mySeq = ++seq;
+      pending = pending.then(() => run(input, mySeq)).catch(() => {});
+    },
+  };
+}

--- a/assistant/src/platform/sync-avatar.test.ts
+++ b/assistant/src/platform/sync-avatar.test.ts
@@ -1,4 +1,11 @@
-import { mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
@@ -47,12 +54,25 @@ mock.module("../avatar/resvg-lazy.js", () => ({
 
 import {
   _resetSyncAvatarStateForTests,
-  MAX_AVATAR_UPLOAD_BYTES,
   syncAvatarToPlatform,
 } from "./sync-avatar.js";
 
+/** Just over the 256 KB upload cap. */
+const OVERSIZED = Buffer.alloc(256 * 1024 + 1);
+
 const dir = mkdtempSync(join(tmpdir(), "sync-avatar-test-"));
-afterAll(() => rmSync(dir, { recursive: true, force: true }));
+const workspaceDir = join(dir, "workspace");
+const syncStatePath = join(workspaceDir, "data", "avatar", "avatar-sync.json");
+const prevWorkspaceDir = process.env.VELLUM_WORKSPACE_DIR;
+process.env.VELLUM_WORKSPACE_DIR = workspaceDir;
+afterAll(() => {
+  if (prevWorkspaceDir === undefined) {
+    delete process.env.VELLUM_WORKSPACE_DIR;
+  } else {
+    process.env.VELLUM_WORKSPACE_DIR = prevWorkspaceDir;
+  }
+  rmSync(dir, { recursive: true, force: true });
+});
 
 function writeRaster(name: string, bytes: Buffer): string {
   const path = join(dir, name);
@@ -103,6 +123,8 @@ async function settle(): Promise<void> {
 
 describe("syncAvatarToPlatform", () => {
   beforeEach(() => {
+    rmSync(workspaceDir, { recursive: true, force: true });
+    mkdirSync(join(workspaceDir, "data", "avatar"), { recursive: true });
     _resetSyncAvatarStateForTests();
     patches = [];
     rasterCalls = 0;
@@ -171,19 +193,6 @@ describe("syncAvatarToPlatform", () => {
     );
   });
 
-  test("re-registering to another base URL re-sends the same raster", async () => {
-    syncAvatarToPlatform();
-    await settle();
-    mockClient = makeClient("asst-1", "https://platform.b");
-    syncAvatarToPlatform();
-    await settle();
-
-    expect(patches.map((p) => p.path)).toEqual([
-      "/v1/assistants/asst-1/",
-      "/v1/assistants/asst-1/",
-    ]);
-  });
-
   test("rapid changes collapse into one PATCH carrying the newest raster", async () => {
     syncAvatarToPlatform();
     syncAvatarToPlatform();
@@ -237,10 +246,7 @@ describe("syncAvatarToPlatform", () => {
   });
 
   test("skips oversized rasters when resvg is unavailable", async () => {
-    mockRasterPath = writeRaster(
-      "big.png",
-      Buffer.alloc(MAX_AVATAR_UPLOAD_BYTES + 1),
-    );
+    mockRasterPath = writeRaster("big.png", OVERSIZED);
     syncAvatarToPlatform();
     await settle();
 
@@ -250,10 +256,7 @@ describe("syncAvatarToPlatform", () => {
   test("downscales oversized rasters through resvg", async () => {
     mockResvgAvailable = true;
     mockRenderedPng = Buffer.from("tiny");
-    mockRasterPath = writeRaster(
-      "big.png",
-      Buffer.alloc(MAX_AVATAR_UPLOAD_BYTES + 1),
-    );
+    mockRasterPath = writeRaster("big.png", OVERSIZED);
     syncAvatarToPlatform();
     await settle();
 
@@ -265,15 +268,58 @@ describe("syncAvatarToPlatform", () => {
 
   test("skips when the downscaled raster still exceeds the cap", async () => {
     mockResvgAvailable = true;
-    mockRenderedPng = Buffer.alloc(MAX_AVATAR_UPLOAD_BYTES + 1);
-    mockRasterPath = writeRaster(
-      "big.png",
-      Buffer.alloc(MAX_AVATAR_UPLOAD_BYTES + 1),
-    );
+    mockRenderedPng = OVERSIZED;
+    mockRasterPath = writeRaster("big.png", OVERSIZED);
     syncAvatarToPlatform();
     await settle();
 
     expect(patches).toHaveLength(0);
+  });
+
+  test("a restart with the same raster and destination does not re-upload", async () => {
+    syncAvatarToPlatform();
+    await settle();
+    expect(JSON.parse(readFileSync(syncStatePath, "utf-8"))).toEqual({
+      key: expect.stringMatching(/^https:\/\/platform\.a\|asst-1\|image:/),
+    });
+
+    _resetSyncAvatarStateForTests();
+    syncAvatarToPlatform();
+    await settle();
+
+    expect(patches).toHaveLength(1);
+  });
+
+  test("a restart re-uploads when the destination or raster changed", async () => {
+    syncAvatarToPlatform();
+    await settle();
+
+    _resetSyncAvatarStateForTests();
+    mockClient = makeClient("asst-2");
+    syncAvatarToPlatform();
+    await settle();
+
+    _resetSyncAvatarStateForTests();
+    writeRaster("a.png", Buffer.from("png-a-rewritten"));
+    syncAvatarToPlatform();
+    await settle();
+
+    expect(patches.map((p) => p.path)).toEqual([
+      "/v1/assistants/asst-1/",
+      "/v1/assistants/asst-2/",
+      "/v1/assistants/asst-2/",
+    ]);
+    expect(patches[2].body.avatar_base64).toBe(
+      Buffer.from("png-a-rewritten").toString("base64"),
+    );
+  });
+
+  test("a failed PATCH leaves the persisted key untouched", async () => {
+    respond = () => new Response("nope", { status: 500 });
+    syncAvatarToPlatform();
+    await settle();
+
+    expect(() => readFileSync(syncStatePath)).toThrow();
   });
 
   test("no-op without a platform client or assistant id", async () => {
@@ -286,35 +332,5 @@ describe("syncAvatarToPlatform", () => {
 
     expect(patches).toHaveLength(0);
     expect(rasterCalls).toBe(0);
-  });
-
-  test("a failed PATCH does not dedup the next attempt", async () => {
-    respond = () => new Response("nope", { status: 500 });
-    syncAvatarToPlatform();
-    await settle();
-    respond = () => new Response("{}", { status: 200 });
-    syncAvatarToPlatform();
-    await settle();
-    syncAvatarToPlatform();
-    await settle();
-
-    expect(patches).toHaveLength(2);
-  });
-
-  test("a thrown fetch is swallowed and retried on the next publish", async () => {
-    mockClient = {
-      baseUrl: "https://platform.a",
-      platformAssistantId: "asst-1",
-      fetch: async () => {
-        throw new Error("boom");
-      },
-    };
-    syncAvatarToPlatform();
-    await settle();
-    mockClient = makeClient();
-    syncAvatarToPlatform();
-    await settle();
-
-    expect(patches).toHaveLength(1);
   });
 });

--- a/assistant/src/platform/sync-avatar.ts
+++ b/assistant/src/platform/sync-avatar.ts
@@ -2,19 +2,20 @@
  * Sync the avatar raster to the platform Assistant record.
  *
  * Every avatar publish (routes and the fs watcher) and daemon startup enqueue
- * a sync. The current avatar state is read when the request runs, so rapid
- * changes collapse into one PATCH carrying the newest raster. The dedup key
- * comes from the raster file itself, not the manifest, so a raster rewritten
- * in place (fs watcher path) still syncs, and is scoped to the platform
- * destination so re-registering to another assistant or base URL re-sends.
- * `avatar_base64: null` is sent only when the avatar is actually removed; a
- * non-none avatar whose raster is missing (image PNG gone, character re-render
- * unavailable) is skipped so the platform keeps the last synced copy.
- * Best-effort: failures are logged, never thrown, and leave the dedup key
- * untouched so the next publish retries.
+ * a sync through the shared platform PATCH queue. The current avatar state is
+ * read when the request runs, so rapid changes collapse into one PATCH
+ * carrying the newest raster. The dedup key comes from the raster file itself,
+ * not the manifest, so a raster rewritten in place (fs watcher path) still
+ * syncs. The last synced key is persisted beside the manifest so a daemon
+ * restart does not re-upload an unchanged raster. `avatar_base64: null` is
+ * sent only when the avatar is actually removed; a non-none avatar whose
+ * raster is missing (image PNG gone, character re-render unavailable) is
+ * skipped so the platform keeps the last synced copy.
  */
 
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
+import { join } from "node:path";
 
 import {
   computeImageMeta,
@@ -23,23 +24,26 @@ import {
 import { ensureAvatarRasterPath } from "../avatar/ensure-raster.js";
 import { getResvg, isResvgAvailable } from "../avatar/resvg-lazy.js";
 import { getLogger } from "../util/logger.js";
-import { VellumPlatformClient } from "./client.js";
+import { getAvatarDir } from "../util/platform.js";
+import {
+  createPlatformPatchQueue,
+  type PatchPayload,
+  type PlatformPatchQueue,
+} from "./platform-patch-queue.js";
 
 const log = getLogger("sync-avatar");
 
 /** Largest raster sent as-is; bigger ones are downscaled first. */
-export const MAX_AVATAR_UPLOAD_BYTES = 256 * 1024;
+const MAX_AVATAR_UPLOAD_BYTES = 256 * 1024;
 const DOWNSCALE_PX = 128;
 const NONE_KEY = "none";
+const SYNC_STATE_FILENAME = "avatar-sync.json";
 
-let lastSyncedKey: string | null = null;
-let seq = 0;
-let pending: Promise<void> = Promise.resolve();
+let queue: PlatformPatchQueue<void> | null = null;
 
+/** Recreates the queue so the next sync re-seeds its dedup key from disk. */
 export function _resetSyncAvatarStateForTests(): void {
-  lastSyncedKey = null;
-  seq = 0;
-  pending = Promise.resolve();
+  queue = null;
 }
 
 /**
@@ -48,17 +52,43 @@ export function _resetSyncAvatarStateForTests(): void {
  * configured, or when the raster's etag matches the last successful sync.
  */
 export function syncAvatarToPlatform(): void {
-  const mySeq = ++seq;
-  pending = pending.then(() => doSync(mySeq)).catch(() => {});
+  queue ??= createPlatformPatchQueue({
+    log,
+    label: "avatar",
+    buildPayload,
+    loadSyncedKey: readPersistedKey,
+    saveSyncedKey: persistKey,
+  });
+  queue.enqueue();
 }
 
-/** Returns undefined when a non-none avatar has no raster to send. */
-async function readRaster(): Promise<
-  { key: string; bytes: Buffer | null } | undefined
-> {
+function syncStatePath(): string {
+  return join(getAvatarDir(), SYNC_STATE_FILENAME);
+}
+
+function readPersistedKey(): string | null {
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(syncStatePath(), "utf-8"));
+    const key = (parsed as { key?: unknown } | null)?.key;
+    return typeof key === "string" ? key : null;
+  } catch {
+    return null;
+  }
+}
+
+function persistKey(key: string): void {
+  try {
+    mkdirSync(getAvatarDir(), { recursive: true });
+    writeFileSync(syncStatePath(), JSON.stringify({ key }));
+  } catch (err) {
+    log.warn({ err }, "Failed to persist avatar sync state");
+  }
+}
+
+async function buildPayload(): Promise<PatchPayload | undefined> {
   const state = readAvatarState();
   if (state.kind === "none") {
-    return { key: NONE_KEY, bytes: null };
+    return { key: NONE_KEY, body: { avatar_base64: null } };
   }
   const path = await ensureAvatarRasterPath(state);
   if (!path) {
@@ -66,7 +96,21 @@ async function readRaster(): Promise<
     return undefined;
   }
   const { etag } = computeImageMeta(path);
-  return { key: `${state.kind}:${etag}`, bytes: await readFile(path) };
+  return {
+    key: `${state.kind}:${etag}`,
+    body: async () => {
+      const bytes = await readFile(path);
+      const encoded = encodeForUpload(bytes);
+      if (encoded === undefined) {
+        log.warn(
+          { bytes: bytes.length, cap: MAX_AVATAR_UPLOAD_BYTES },
+          "Avatar raster exceeds upload cap and could not be downscaled; skipping sync",
+        );
+        return undefined;
+      }
+      return { avatar_base64: encoded };
+    },
+  };
 }
 
 function downscalePng(png: Buffer): Buffer | null {
@@ -95,70 +139,4 @@ function encodeForUpload(bytes: Buffer): string | undefined {
     return undefined;
   }
   return upload.toString("base64");
-}
-
-async function doSync(requestSeq: number): Promise<void> {
-  try {
-    if (requestSeq !== seq) {
-      return;
-    }
-
-    const client = await VellumPlatformClient.create();
-    const assistantId = client?.platformAssistantId;
-    if (!client || !assistantId) {
-      return;
-    }
-
-    const raster = await readRaster();
-    if (!raster) {
-      return;
-    }
-    const { key: rasterKey, bytes } = raster;
-    const key = `${client.baseUrl}|${assistantId}|${rasterKey}`;
-    if (key === lastSyncedKey) {
-      return;
-    }
-
-    let avatarBase64: string | null = null;
-    if (bytes) {
-      const encoded = encodeForUpload(bytes);
-      if (encoded === undefined) {
-        log.warn(
-          { bytes: bytes.length, cap: MAX_AVATAR_UPLOAD_BYTES },
-          "Avatar raster exceeds upload cap and could not be downscaled; skipping sync",
-        );
-        return;
-      }
-      avatarBase64 = encoded;
-    }
-
-    // A newer publish superseded this one while the raster was read; it will
-    // carry the fresher state.
-    if (requestSeq !== seq) {
-      return;
-    }
-
-    const resp = await client.fetch(
-      `/v1/assistants/${encodeURIComponent(assistantId)}/`,
-      {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ avatar_base64: avatarBase64 }),
-        signal: AbortSignal.timeout(15_000),
-      },
-    );
-
-    if (resp.ok) {
-      lastSyncedKey = key;
-      log.info({ key: rasterKey, assistantId }, "Synced avatar to platform");
-    } else {
-      const text = await resp.text();
-      log.warn(
-        { status: resp.status, body: text, assistantId },
-        "Failed to sync avatar to platform",
-      );
-    }
-  } catch (err) {
-    log.warn({ err }, "Error syncing avatar to platform");
-  }
 }

--- a/assistant/src/platform/sync-identity.test.ts
+++ b/assistant/src/platform/sync-identity.test.ts
@@ -10,10 +10,7 @@ mock.module("./client.js", () => ({
   VellumPlatformClient: { create: async () => mockClient },
 }));
 
-import {
-  _resetSyncIdentityStateForTests,
-  syncIdentityNameToPlatform,
-} from "./sync-identity.js";
+import { syncIdentityNameToPlatform } from "./sync-identity.js";
 
 interface Patch {
   path: string;
@@ -21,15 +18,14 @@ interface Patch {
 }
 
 let patches: Patch[];
-let respond: () => Response;
 
-function makeClient(assistantId = "asst-1", baseUrl = "https://platform.a") {
+function makeClient(assistantId = "asst-1") {
   return {
-    baseUrl,
+    baseUrl: "https://platform.a",
     platformAssistantId: assistantId,
     fetch: async (path: string, init: RequestInit) => {
       patches.push({ path, body: JSON.parse(init.body as string) });
-      return respond();
+      return new Response("{}", { status: 200 });
     },
   };
 }
@@ -40,15 +36,15 @@ async function settle(): Promise<void> {
   }
 }
 
+// The module owns one queue, so names are unique per test to avoid dedup
+// across tests. Queue semantics are covered by platform-patch-queue.test.ts.
 describe("syncIdentityNameToPlatform", () => {
   beforeEach(() => {
-    _resetSyncIdentityStateForTests();
     patches = [];
-    respond = () => new Response("{}", { status: 200 });
     mockClient = makeClient();
   });
 
-  test("PATCHes the name once and dedups an unchanged name", async () => {
+  test("PATCHes the name and dedups an unchanged name", async () => {
     syncIdentityNameToPlatform("Ada");
     await settle();
     syncIdentityNameToPlatform("Ada");
@@ -59,62 +55,21 @@ describe("syncIdentityNameToPlatform", () => {
     ]);
   });
 
-  test("re-registering to another assistant id re-sends the same name", async () => {
-    syncIdentityNameToPlatform("Ada");
-    await settle();
-    mockClient = makeClient("asst-2");
-    syncIdentityNameToPlatform("Ada");
-    await settle();
-    syncIdentityNameToPlatform("Ada");
-    await settle();
-
-    expect(patches.map((p) => p.path)).toEqual([
-      "/v1/assistants/asst-1/",
-      "/v1/assistants/asst-2/",
-    ]);
-  });
-
-  test("re-registering to another base URL re-sends the same name", async () => {
-    syncIdentityNameToPlatform("Ada");
-    await settle();
-    mockClient = makeClient("asst-1", "https://platform.b");
-    syncIdentityNameToPlatform("Ada");
-    await settle();
-
-    expect(patches).toHaveLength(2);
-  });
-
   test("rapid changes collapse into one PATCH carrying the newest name", async () => {
-    syncIdentityNameToPlatform("Ada");
     syncIdentityNameToPlatform("Bea");
     syncIdentityNameToPlatform("Cy");
+    syncIdentityNameToPlatform("Dee");
     await settle();
 
-    expect(patches.map((p) => p.body.name)).toEqual(["Cy"]);
+    expect(patches.map((p) => p.body.name)).toEqual(["Dee"]);
   });
 
-  test("empty names and missing client or assistant id are no-ops", async () => {
+  test("empty names and a missing client are no-ops", async () => {
     syncIdentityNameToPlatform("");
     mockClient = null;
-    syncIdentityNameToPlatform("Ada");
-    await settle();
-    mockClient = makeClient("");
-    syncIdentityNameToPlatform("Ada");
+    syncIdentityNameToPlatform("Eve");
     await settle();
 
     expect(patches).toHaveLength(0);
-  });
-
-  test("a failed PATCH does not dedup the next attempt", async () => {
-    respond = () => new Response("nope", { status: 500 });
-    syncIdentityNameToPlatform("Ada");
-    await settle();
-    respond = () => new Response("{}", { status: 200 });
-    syncIdentityNameToPlatform("Ada");
-    await settle();
-    syncIdentityNameToPlatform("Ada");
-    await settle();
-
-    expect(patches).toHaveLength(2);
   });
 });

--- a/assistant/src/platform/sync-identity.ts
+++ b/assistant/src/platform/sync-identity.ts
@@ -2,18 +2,11 @@
  * Sync assistant identity fields to the platform Assistant record.
  *
  * When IDENTITY.md changes on disk the daemon broadcasts an
- * `identity_changed` event to connected clients.  This module hooks into
- * that same change signal and PATCHes the platform `Assistant` record so
- * the name (and, in future, other fields) stays in sync.
- *
- * Requests are serialized so that rapid name changes (A → B) never race:
- * only the most recently requested name is sent, and a stale in-flight
- * response cannot overwrite a newer value. The dedup key is scoped to the
- * platform destination (base URL + assistant id) so re-registering to
- * another assistant re-sends an unchanged name.
- *
- * The sync is best-effort and fire-and-forget — network failures are
- * logged but never surface to callers.
+ * `identity_changed` event to connected clients. This module hooks into that
+ * same change signal and PATCHes the platform `Assistant` record through the
+ * shared platform PATCH queue so the name stays in sync: rapid changes
+ * collapse to the newest name, and an unchanged name is not re-sent to the
+ * same platform destination.
  */
 
 import { existsSync, readFileSync } from "node:fs";
@@ -21,49 +14,27 @@ import { existsSync, readFileSync } from "node:fs";
 import { parseIdentityFields } from "../daemon/handlers/identity.js";
 import { getLogger } from "../util/logger.js";
 import { getWorkspacePromptPath } from "../util/platform.js";
-import { VellumPlatformClient } from "./client.js";
+import { createPlatformPatchQueue } from "./platform-patch-queue.js";
 
 const log = getLogger("sync-identity");
 
-/** `${baseUrl}|${assistantId}|${name}` of the last successful PATCH. */
-let lastSyncedKey: string | null = null;
-
-/**
- * Monotonically increasing sequence number.  Each call to
- * `syncIdentityNameToPlatform` bumps this; a request whose seq is no longer
- * current is skipped, guaranteeing the newest name always wins.
- */
-let seq = 0;
-
-/** Chain promise that serializes in-flight PATCH requests. */
-let pending: Promise<void> = Promise.resolve();
-
-export function _resetSyncIdentityStateForTests(): void {
-  lastSyncedKey = null;
-  seq = 0;
-  pending = Promise.resolve();
-}
+const queue = createPlatformPatchQueue<string>({
+  log,
+  label: "assistant name",
+  buildPayload: (name) => ({
+    key: name,
+    body: { name },
+  }),
+});
 
 /**
  * Push the current assistant name to the platform `Assistant` record.
- *
- * No-op when:
- * - The platform client cannot be created (not platform-hosted / missing creds).
- * - No assistant ID is configured.
- * - The name is empty or already synced to the same platform destination.
+ * Empty names are ignored.
  */
 export function syncIdentityNameToPlatform(name: string): void {
-  if (!name) {
-    return;
+  if (name) {
+    queue.enqueue(name);
   }
-
-  const mySeq = ++seq;
-
-  pending = pending
-    .then(() => doSync(name, mySeq))
-    .catch(() => {
-      // swallowed — doSync already logs internally
-    });
 }
 
 /**
@@ -83,48 +54,5 @@ export function syncWorkspaceIdentityToPlatform(): void {
     }
   } catch (err) {
     log.error({ err }, "Failed to sync identity to platform at startup");
-  }
-}
-
-async function doSync(name: string, requestSeq: number): Promise<void> {
-  try {
-    // A newer call has already been enqueued — skip this stale request.
-    if (requestSeq !== seq) {
-      return;
-    }
-
-    const client = await VellumPlatformClient.create();
-    const assistantId = client?.platformAssistantId;
-    if (!client || !assistantId) {
-      return;
-    }
-
-    const key = `${client.baseUrl}|${assistantId}|${name}`;
-    if (key === lastSyncedKey) {
-      return;
-    }
-
-    const resp = await client.fetch(
-      `/v1/assistants/${encodeURIComponent(assistantId)}/`,
-      {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name }),
-        signal: AbortSignal.timeout(15_000),
-      },
-    );
-
-    if (resp.ok) {
-      lastSyncedKey = key;
-      log.info({ name, assistantId }, "Synced assistant name to platform");
-    } else {
-      const text = await resp.text();
-      log.warn(
-        { status: resp.status, body: text, assistantId },
-        "Failed to sync assistant name to platform",
-      );
-    }
-  } catch (err) {
-    log.warn({ err }, "Error syncing assistant name to platform");
   }
 }


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review (round 2) for chooser-assistant-avatars.md.

**Gaps:** sync-avatar and sync-identity duplicated the serialized PATCH queue; every daemon restart re-uploaded the raster; ensure-raster double existence checks; test-only export

- New `platform/platform-patch-queue.ts`: `createPlatformPatchQueue({ log, label, buildPayload, loadSyncedKey?, saveSyncedKey? })` owns seq/pending/lastSyncedKey and the PATCH/log tail. `sync-avatar` and `sync-identity` are now thin payload logic; `_resetSyncIdentityStateForTests` is gone, `_resetSyncAvatarStateForTests` stays only to simulate a restart.
- Payload `body` may be a thunk that runs only after the key passes dedup, so an unchanged raster is never read or encoded.
- Avatar sync persists the last successful destination-scoped key in `<avatar dir>/avatar-sync.json` and seeds from it on first use; the fs watcher matches `AVATAR_IMAGE_FILENAME` exactly so the sidecar does not trigger `publishAvatarChanged`.
- `ensure-raster`: return the path directly on `result.ok`; single read with one catch.
- `MAX_AVATAR_UPLOAD_BYTES` un-exported; the test uses a literal just over 256 KB.