### PR TITLE
fix: host fallback for the active local row, persist last-seen avatars from the live hook, release blob URLs on removal

### DIFF
--- a/clients/web/src/assistant/avatar-api.ts
+++ b/clients/web/src/assistant/avatar-api.ts
@@ -86,28 +86,41 @@ function parseCharacterTraits(content: string): CharacterTraits | null {
   }
 }
 
-export async function fetchCharacterTraitsResult(
-  assistantId: string,
-): Promise<AvatarFileResult<CharacterTraits>> {
+/** A sidecar the daemon serves but cannot be used (`parse` returns null) is as good as missing. */
+async function readAvatarFile<D, T>(
+  request: () => Promise<{ data?: D; error?: unknown; response?: Response }>,
+  failureMessage: string,
+  parse: (data: D) => T | null,
+): Promise<AvatarFileResult<T>> {
   try {
-    const { data, error, response } = await workspaceFileGet({
-      path: { assistant_id: assistantId },
-      query: { path: "data/avatar/character-traits.json" },
-      throwOnError: false,
-    });
-    assertHasResponse(response, error, "Failed to fetch character traits");
+    const { data, error, response } = await request();
+    assertHasResponse(response, error, failureMessage);
     if (response.status === 404) {
       return { status: "absent" };
     }
     if (!response.ok || !data) {
       return { status: "failed" };
     }
-    // A sidecar the daemon serves but cannot render is as good as missing.
-    const traits = parseCharacterTraits(data.content);
-    return traits ? { status: "found", value: traits } : { status: "absent" };
+    const value = parse(data);
+    return value ? { status: "found", value } : { status: "absent" };
   } catch {
     return { status: "failed" };
   }
+}
+
+export function fetchCharacterTraitsResult(
+  assistantId: string,
+): Promise<AvatarFileResult<CharacterTraits>> {
+  return readAvatarFile(
+    () =>
+      workspaceFileGet({
+        path: { assistant_id: assistantId },
+        query: { path: "data/avatar/character-traits.json" },
+        throwOnError: false,
+      }),
+    "Failed to fetch character traits",
+    (data) => parseCharacterTraits(data.content),
+  );
 }
 
 /** {@link fetchCharacterTraitsResult} collapsed to a value; null for absent or failed. */
@@ -199,25 +212,18 @@ async function uploadAvatarImageLegacy(
   return true;
 }
 
-export async function fetchAvatarImageUrlResult(
+export function fetchAvatarImageUrlResult(
   assistantId: string,
 ): Promise<AvatarFileResult<string>> {
-  try {
-    const { data, error, response } = await workspaceFileContentGet({
-      path: { assistant_id: assistantId },
-      query: { path: "data/avatar/avatar-image.png" },
-      parseAs: "blob",
-      throwOnError: false,
-    });
-    assertHasResponse(response, error, "Failed to fetch avatar image");
-    if (response.status === 404) {
-      return { status: "absent" };
-    }
-    if (!response.ok || !data) {
-      return { status: "failed" };
-    }
-    return { status: "found", value: URL.createObjectURL(data) };
-  } catch {
-    return { status: "failed" };
-  }
+  return readAvatarFile(
+    () =>
+      workspaceFileContentGet({
+        path: { assistant_id: assistantId },
+        query: { path: "data/avatar/avatar-image.png" },
+        parseAs: "blob",
+        throwOnError: false,
+      }),
+    "Failed to fetch avatar image",
+    (data) => URL.createObjectURL(data),
+  );
 }

--- a/clients/web/src/assistant/retire-service.test.ts
+++ b/clients/web/src/assistant/retire-service.test.ts
@@ -48,6 +48,10 @@ mock.module("@/lib/local-mode", () => ({
   retireLocalAssistant: retireLocalAssistantMock,
   syncPlatformAssistantsToLockfile: syncPlatformAssistantsToLockfileMock,
 }));
+const releaseRowAvatarUrlsMock = mock((_id: string) => {});
+mock.module("@/hooks/use-chooser-row-avatar", () => ({
+  releaseRowAvatarUrls: releaseRowAvatarUrlsMock,
+}));
 mock.module("@/stores/organization-store", () => ({
   useOrganizationStore: {
     getState: () => ({ currentOrganizationId: "org-test" }),
@@ -128,6 +132,7 @@ beforeEach(() => {
   retireAssistantByIdMock.mockClear();
   listAssistantsMock.mockClear();
   retireLocalAssistantMock.mockClear();
+  releaseRowAvatarUrlsMock.mockClear();
   syncPlatformAssistantsToLockfileMock.mockClear();
   removeMock.mockClear();
   clearResearchSnapshotMock.mockClear();
@@ -149,6 +154,7 @@ describe("retireAssistant", () => {
     // THEN the platform delete ran with that id and the local path did not
     expect(retireAssistantByIdMock).toHaveBeenCalledWith("p1");
     expect(retireLocalAssistantMock).not.toHaveBeenCalled();
+    expect(releaseRowAvatarUrlsMock).toHaveBeenCalledWith("p1");
     expect(outcome.ok).toBe(true);
     if (outcome.ok) {
       expect(outcome.nextRoute).toBe("/assistant/onboarding/privacy");

--- a/clients/web/src/assistant/retire-service.ts
+++ b/clients/web/src/assistant/retire-service.ts
@@ -1,4 +1,5 @@
 import { listAssistants, retireAssistantById } from "@/assistant/api";
+import { releaseRowAvatarUrls } from "@/hooks/use-chooser-row-avatar";
 import { deleteLastSeenAvatar } from "@/lib/avatar-last-seen-cache";
 import {
   getLockfile,
@@ -114,6 +115,7 @@ export async function retireAssistant(
 
     useResolvedAssistantsStore.getState().remove(assistantId);
     void deleteLastSeenAvatar(assistantId);
+    releaseRowAvatarUrls(assistantId);
     // Retiring ends any in-flight onboarding journey with it: drop the
     // research-onboarding resume snapshot so the next onboarding starts at the
     // form instead of resuming the retired assistant's run deep in the flow

--- a/clients/web/src/assistant/switch-service.test.ts
+++ b/clients/web/src/assistant/switch-service.test.ts
@@ -49,6 +49,10 @@ const deleteLastSeenAvatarMock = mock(async (_id: string) => {});
 mock.module("@/lib/avatar-last-seen-cache", () => ({
   deleteLastSeenAvatar: deleteLastSeenAvatarMock,
 }));
+const releaseRowAvatarUrlsMock = mock((_id: string) => {});
+mock.module("@/hooks/use-chooser-row-avatar", () => ({
+  releaseRowAvatarUrls: releaseRowAvatarUrlsMock,
+}));
 
 const connectPairedAssistantMock = mock(async (_id: string) => {
   if (connectPairedShouldThrow) {
@@ -109,6 +113,7 @@ beforeEach(() => {
   setSelectedAssistantMock.mockClear();
   setActiveAssistantIdMock.mockClear();
   deleteLastSeenAvatarMock.mockClear();
+  releaseRowAvatarUrlsMock.mockClear();
 });
 
 describe("switchToAssistant", () => {
@@ -260,6 +265,7 @@ describe("removePairedAssistant", () => {
 
     expect(removePairedFromLockfileMock).toHaveBeenCalledWith("pr1");
     expect(deleteLastSeenAvatarMock).toHaveBeenCalledWith("pr1");
+    expect(releaseRowAvatarUrlsMock).toHaveBeenCalledWith("pr1");
     expect(setActiveAssistantIdMock).toHaveBeenCalledWith(null);
     expect(outcome.ok).toBe(true);
     if (outcome.ok) {
@@ -298,6 +304,7 @@ describe("removePairedAssistant", () => {
       expect(outcome.error).toBe("host says no");
     }
     expect(deleteLastSeenAvatarMock).not.toHaveBeenCalled();
+    expect(releaseRowAvatarUrlsMock).not.toHaveBeenCalled();
     expect(setActiveAssistantIdMock).not.toHaveBeenCalled();
   });
 

--- a/clients/web/src/assistant/switch-service.ts
+++ b/clients/web/src/assistant/switch-service.ts
@@ -1,4 +1,5 @@
 import { setSelectedAssistant } from "@/assistant/selection";
+import { releaseRowAvatarUrls } from "@/hooks/use-chooser-row-avatar";
 import { deleteLastSeenAvatar } from "@/lib/avatar-last-seen-cache";
 import {
   getLockfileAssistant,
@@ -110,6 +111,7 @@ export async function removePairedAssistant(
     return { ok: false, error: result.error ?? "Failed to remove assistant." };
   }
   void deleteLastSeenAvatar(assistantId);
+  releaseRowAvatarUrls(assistantId);
   const resolvedStore = useResolvedAssistantsStore.getState();
   if (resolvedStore.activeAssistantId === assistantId) {
     resolvedStore.setActiveAssistantId(null);

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.test.tsx
@@ -21,6 +21,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { ReactNode } from "react";
 
 import type * as ChooserAvatarChipModule from "@/components/avatar/chooser-avatar-chip";
+import type { AvatarRead } from "@/hooks/use-assistant-avatar";
 import type * as UseChooserRowAvatarModule from "@/hooks/use-chooser-row-avatar";
 import type { RememberedOrigin } from "@/stores/remembered-origins-store";
 import type { ResolvedAssistant } from "@/stores/resolved-assistants-store";
@@ -90,7 +91,7 @@ const installNativeRememberedOriginsMock = mock(() => {});
 /** What the native shell reports as its baked Vellum Cloud origin, if any. */
 let nativeCloudOriginValue: string | null = null;
 /** Avatar data per assistant id; rows absent here resolve to nulls (glyph). */
-let rowAvatars = new Map<string, UseChooserRowAvatarModule.ChooserRowAvatar>();
+let rowAvatars = new Map<string, AvatarRead>();
 
 // Stands in for the real error class (the screen's `instanceof` check runs
 // against this mocked module's export).
@@ -258,6 +259,7 @@ mock.module("@/domains/onboarding/components/add-remote-origin-dialog", () => ({
 const useChooserRowAvatarMock: Partial<typeof UseChooserRowAvatarModule> = {
   useChooserRowAvatar: (assistant) =>
     rowAvatars.get(assistant.id) ?? { traits: null, imageUrl: null },
+  releaseRowAvatarUrls: () => {},
 };
 mock.module("@/hooks/use-chooser-row-avatar", () => useChooserRowAvatarMock);
 

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
@@ -1172,7 +1172,6 @@ function AssistantCard({
         <ChooserAvatarChip
           traits={traits}
           imageUrl={imageUrl}
-          size={48}
           fallback={glyph}
           decorative
         />

--- a/clients/web/src/hooks/use-assistant-avatar.test.tsx
+++ b/clients/web/src/hooks/use-assistant-avatar.test.tsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, renderHook, waitFor } from "@testing-library/react";
 
 import type { AvatarFileResult } from "@/assistant/avatar-api";
+import type * as AvatarLastSeenCache from "@/lib/avatar-last-seen-cache";
 import type {
   AvatarState,
   CharacterComponents,
@@ -83,6 +84,20 @@ mock.module("@/assistant/avatar-api", () => ({
   fetchCharacterTraitsResult,
 }));
 
+const actualLastSeenCache = await import("@/lib/avatar-last-seen-cache");
+const writeLastSeenAvatar = mock(
+  async (_id: string, _v: AvatarLastSeenCache.LastSeenAvatar) => {},
+);
+const deleteLastSeenAvatar = mock(async (_id: string) => {});
+mock.module(
+  "@/lib/avatar-last-seen-cache",
+  (): Partial<typeof AvatarLastSeenCache> => ({
+    ...actualLastSeenCache,
+    writeLastSeenAvatar,
+    deleteLastSeenAvatar,
+  }),
+);
+
 const { useAssistantAvatar } = await import("@/hooks/use-assistant-avatar");
 
 function createWrapper() {
@@ -110,6 +125,8 @@ afterEach(() => {
   fetchAvatarState.mockClear();
   fetchAvatarImageUrlResult.mockClear();
   fetchCharacterTraitsResult.mockClear();
+  writeLastSeenAvatar.mockClear();
+  deleteLastSeenAvatar.mockClear();
   fetchCharacterComponents.mockResolvedValue(components);
   fetchAvatarState.mockResolvedValue(noneState);
   fetchAvatarImageUrlResult.mockResolvedValue(ABSENT);
@@ -117,6 +134,56 @@ afterEach(() => {
 });
 
 describe("useAssistantAvatar", () => {
+  describe("last-seen cache", () => {
+    test("a resolved character avatar is persisted for the chooser's fallback", async () => {
+      fetchAvatarState.mockResolvedValueOnce(characterState);
+      const { result } = renderHook(() => useAssistantAvatar("asst-1"), {
+        wrapper: createWrapper(),
+      });
+      await waitFor(() => {
+        expect(result.current.traits).toEqual(traits);
+      });
+      await waitFor(() => {
+        expect(writeLastSeenAvatar).toHaveBeenCalledWith(
+          "asst-1",
+          { kind: "character", traits },
+          expect.any(Number),
+        );
+      });
+      expect(deleteLastSeenAvatar).not.toHaveBeenCalled();
+    });
+
+    test("a resolved none evicts the entry", async () => {
+      const { result } = renderHook(() => useAssistantAvatar("asst-1"), {
+        wrapper: createWrapper(),
+      });
+      await waitFor(() => {
+        expect(result.current.isSuccess).toBe(true);
+      });
+      await waitFor(() => {
+        expect(deleteLastSeenAvatar).toHaveBeenCalledWith(
+          "asst-1",
+          expect.any(Number),
+        );
+      });
+      expect(writeLastSeenAvatar).not.toHaveBeenCalled();
+    });
+
+    test("an inconclusive read touches nothing", async () => {
+      fetchAvatarState.mockResolvedValue(null);
+      const { result } = renderHook(() => useAssistantAvatar("asst-1"), {
+        wrapper: createWrapper(),
+      });
+      await waitFor(() => {
+        expect(fetchAvatarState).toHaveBeenCalled();
+      });
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      expect(result.current.isSuccess).toBe(false);
+      expect(writeLastSeenAvatar).not.toHaveBeenCalled();
+      expect(deleteLastSeenAvatar).not.toHaveBeenCalled();
+    });
+  });
+
   test("character kind exposes manifest traits and skips the image fetch", async () => {
     fetchAvatarState.mockResolvedValueOnce(characterState);
 

--- a/clients/web/src/hooks/use-assistant-avatar.ts
+++ b/clients/web/src/hooks/use-assistant-avatar.ts
@@ -9,6 +9,7 @@ import {
 } from "@/assistant/avatar-api";
 import { useSupportsAvatarStateManifest } from "@/lib/backwards-compat/avatar-state-manifest";
 import { trackBlobUrl } from "@/lib/blob-url-tracker";
+import { persistLastSeenAvatar } from "@/lib/persist-last-seen-avatar";
 import type {
   AvatarState,
   CharacterComponents,
@@ -29,6 +30,11 @@ export interface AvatarData {
 }
 
 const activeBlobUrls = new Map<string, string>();
+
+/** Revoke the object URL this hook holds for a removed assistant. */
+export function releaseAssistantAvatarUrl(assistantId: string): void {
+  trackBlobUrl(activeBlobUrls, assistantId, null);
+}
 
 export interface AssistantAvatarOptions {
   /**
@@ -196,6 +202,9 @@ export function useAssistantAvatar(
       }
 
       trackBlobUrl(activeBlobUrls, id, imageUrl);
+      // A resolved read is conclusive (both paths throw otherwise), so it is
+      // what the chooser falls back to once this assistant is unreachable.
+      void persistLastSeenAvatar(id, { traits, imageUrl });
 
       return { components, traits, customImageUrl: imageUrl };
     },

--- a/clients/web/src/hooks/use-chooser-row-avatar.test.tsx
+++ b/clients/web/src/hooks/use-chooser-row-avatar.test.tsx
@@ -65,7 +65,7 @@ const readAssistantAvatarHost = mock(
   }),
 );
 mock.module("@/runtime/local-mode-host", (): Partial<typeof LocalModeHost> => ({
-  isLocalModeHostAvailable: () => hostAvailable,
+  canReadAvatarFromLocalHost: () => hostAvailable,
   readAssistantAvatarHost,
 }));
 
@@ -140,11 +140,14 @@ const { useAssistantIdentityStore } =
 const { MIN_VERSION } =
   await import("@/lib/backwards-compat/avatar-state-manifest");
 const {
-  EMPTY_AVATAR_STALE_TIME_MS,
   canFetchRowAvatarViaPlatformProxy,
   chooserRowAvatarQueryKeyPrefix,
+  releaseRowAvatarUrls,
   useChooserRowAvatar,
 } = await import("@/hooks/use-chooser-row-avatar");
+
+/** Past the window a bare avatar stays fresh for. */
+const A_MINUTE_LATER = 61_000;
 
 const revokeObjectURL = mock((_url: string) => {});
 URL.revokeObjectURL = revokeObjectURL;
@@ -495,7 +498,7 @@ describe("useChooserRowAvatar", () => {
     expect(first.result.current).toEqual({ traits: null, imageUrl: null });
     first.unmount();
 
-    setSystemTime(new Date(Date.now() + EMPTY_AVATAR_STALE_TIME_MS + 1));
+    setSystemTime(new Date(Date.now() + A_MINUTE_LATER));
     fetchCharacterTraitsResult.mockResolvedValue(found(traits));
     const second = renderHook(() => useChooserRowAvatar(row), { wrapper });
     await waitFor(() => {
@@ -514,7 +517,7 @@ describe("useChooserRowAvatar", () => {
     });
     first.unmount();
 
-    setSystemTime(new Date(Date.now() + EMPTY_AVATAR_STALE_TIME_MS + 1));
+    setSystemTime(new Date(Date.now() + A_MINUTE_LATER));
     const second = renderHook(() => useChooserRowAvatar(row), { wrapper });
     await waitFor(() => {
       expect(second.result.current.traits).toEqual(traits);
@@ -703,8 +706,31 @@ describe("useChooserRowAvatar", () => {
       await waitFor(() => {
         expect(result.current.traits).toEqual(traits);
       });
+      await settle();
       expect(result.current.imageUrl).toBeNull();
       expect(readAssistantAvatarHost).not.toHaveBeenCalled();
+    });
+
+    test("the connected local row falls back to the host read when it is unreachable", async () => {
+      fetchAvatarState.mockResolvedValue(null);
+      const hostTraits = { ...traits, color: "sunset-orange" };
+      readAssistantAvatarHost.mockResolvedValue({
+        ok: true,
+        avatar: { kind: "character", traits: hostTraits },
+      });
+      const { result } = renderHook(
+        () => useChooserRowAvatar(localRow("active")),
+        { wrapper: createWrapper() },
+      );
+      // The live read retries once (1s backoff) before it settles.
+      await waitFor(
+        () => {
+          expect(result.current.traits).toEqual(hostTraits);
+        },
+        { timeout: 3000 },
+      );
+      expect(readAssistantAvatarHost).toHaveBeenCalledWith("active");
+      expect(writeLastSeenAvatar).not.toHaveBeenCalled();
     });
 
     test("invalidating the row prefix re-reads the host", async () => {
@@ -737,6 +763,34 @@ describe("useChooserRowAvatar", () => {
         expect(result.current.traits).toEqual(updated);
       });
       expect(readAssistantAvatarHost).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("releaseRowAvatarUrls", () => {
+    test("revokes the live and cached object urls held for a removed assistant", async () => {
+      fetchAvatarState.mockResolvedValue(imageState);
+      fetchAvatarImageUrlResult.mockResolvedValue(found("blob:row-image"));
+      const live = renderHook(() => useChooserRowAvatar(platformRow("other")), {
+        wrapper: createWrapper(),
+      });
+      await waitFor(() => {
+        expect(live.result.current.imageUrl).toBe("blob:row-image");
+      });
+      readLastSeenAvatar.mockResolvedValue({
+        kind: "image",
+        blob: new Blob(["png"]),
+      });
+      const cached = renderHook(() => useChooserRowAvatar(localRow("other")), {
+        wrapper: createWrapper(),
+      });
+      await waitFor(() => {
+        expect(cached.result.current.imageUrl).toBe("blob:cached-image");
+      });
+
+      releaseRowAvatarUrls("other");
+
+      expect(revokeObjectURL).toHaveBeenCalledWith("blob:row-image");
+      expect(revokeObjectURL).toHaveBeenCalledWith("blob:cached-image");
     });
   });
 

--- a/clients/web/src/hooks/use-chooser-row-avatar.ts
+++ b/clients/web/src/hooks/use-chooser-row-avatar.ts
@@ -1,9 +1,5 @@
 import { useEffect } from "react";
-import {
-  type QueryClient,
-  useQuery,
-  useQueryClient,
-} from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { fetchAvatarState } from "@/assistant/avatar-api";
 import {
@@ -11,24 +7,21 @@ import {
   type LegacyAvatarRead,
   fetchAvatarViaManifest,
   readAvatarViaLegacyFiles,
+  releaseAssistantAvatarUrl,
   resolveAvatarFromState,
   useAssistantAvatar,
 } from "@/hooks/use-assistant-avatar";
 import { useIsOrgReady } from "@/hooks/use-is-org-ready";
 import { isGatewayAuthEnabled } from "@/lib/auth/gateway-session";
-import {
-  deleteLastSeenAvatar,
-  lastSeenAvatarGenerations,
-  readLastSeenAvatar,
-  writeLastSeenAvatar,
-} from "@/lib/avatar-last-seen-cache";
+import { readLastSeenAvatar } from "@/lib/avatar-last-seen-cache";
 import { versionSupportsAvatarStateManifest } from "@/lib/backwards-compat/avatar-state-manifest";
 import { trackBlobUrl } from "@/lib/blob-url-tracker";
 import { createGenerationGuard } from "@/lib/generation-guard";
 import { isLocalClient, isRemoteGatewayMode } from "@/lib/local-mode";
+import { persistLastSeenAvatar } from "@/lib/persist-last-seen-avatar";
 import { getSelfHostedIngressUrl } from "@/lib/self-hosted/connection";
 import {
-  isLocalModeHostAvailable,
+  canReadAvatarFromLocalHost,
   readAssistantAvatarHost,
 } from "@/runtime/local-mode-host";
 import {
@@ -80,8 +73,6 @@ function chooserRowAvatarCacheQueryKey(assistantId: string) {
   return [CACHE_QUERY_KEY_PREFIX, assistantId] as const;
 }
 
-export type ChooserRowAvatar = AvatarRead;
-
 const EMPTY_AVATAR: AvatarRead = { traits: null, imageUrl: null };
 
 /**
@@ -89,7 +80,7 @@ const EMPTY_AVATAR: AvatarRead = { traits: null, imageUrl: null };
  * gets one during onboarding), and a legacy transport failure also lands
  * here. Let it go stale on a normal clock instead of pinning the glyph.
  */
-export const EMPTY_AVATAR_STALE_TIME_MS = 60_000;
+const EMPTY_AVATAR_STALE_TIME_MS = 60_000;
 
 /** Separate from `use-assistant-avatar`'s map so the two caches never revoke each other's URLs. */
 const activeBlobUrls = new Map<string, string>();
@@ -99,6 +90,17 @@ const cachedBlobUrls = new Map<string, string>();
 
 /** Latest fetch generation per row; a superseded fetch must not touch the map. */
 const fetchGenerations = createGenerationGuard();
+
+/**
+ * Revoke every object URL held for a removed assistant, across this module's
+ * maps and the live hook's. The query entries themselves are left to React
+ * Query's garbage collection.
+ */
+export function releaseRowAvatarUrls(assistantId: string): void {
+  trackBlobUrl(activeBlobUrls, assistantId, null);
+  trackBlobUrl(cachedBlobUrls, assistantId, null);
+  releaseAssistantAvatarUrl(assistantId);
+}
 
 /**
  * Whether a daemon SDK call for `row` actually reaches `row`'s runtime.
@@ -126,13 +128,17 @@ export function canFetchRowAvatarViaPlatformProxy(
 }
 
 /**
- * Whether the host bridge can read `row`'s avatar off its workspace on disk.
+ * Whether the host can read `row`'s avatar off its workspace on disk.
  * `cloud` is only ever set from the lockfile, so `"local"` means the
  * assistant lives on this machine; docker and paired rows have no workspace
  * the host can read.
  */
 function canReadRowAvatarViaHost(row: ResolvedAssistant): boolean {
-  return row.cloud === "local" && isLocalModeHostAvailable();
+  return row.cloud === "local" && canReadAvatarFromLocalHost();
+}
+
+function conclusive(read: AvatarRead): LegacyAvatarRead {
+  return { ...read, conclusive: true };
 }
 
 /**
@@ -147,15 +153,16 @@ async function readRowAvatarViaHost(
     return { ...EMPTY_AVATAR, conclusive: false };
   }
   if (result.avatar === null) {
-    return { ...EMPTY_AVATAR, conclusive: true };
+    return conclusive(EMPTY_AVATAR);
   }
-  return result.avatar.kind === "character"
-    ? { traits: result.avatar.traits, imageUrl: null, conclusive: true }
-    : {
-        traits: null,
-        imageUrl: `data:image/png;base64,${result.avatar.imageBase64}`,
-        conclusive: true,
-      };
+  return conclusive(
+    result.avatar.kind === "character"
+      ? { traits: result.avatar.traits, imageUrl: null }
+      : {
+          traits: null,
+          imageUrl: `data:image/png;base64,${result.avatar.imageBase64}`,
+        },
+  );
 }
 
 /**
@@ -172,18 +179,12 @@ async function fetchRowAvatar(
   manifestSupport: RowManifestSupport,
 ): Promise<LegacyAvatarRead> {
   if (manifestSupport === "supported") {
-    return {
-      ...(await fetchAvatarViaManifest(assistant.id)),
-      conclusive: true,
-    };
+    return conclusive(await fetchAvatarViaManifest(assistant.id));
   }
   if (manifestSupport === "unknown") {
     const state = await fetchAvatarState(assistant.id);
     if (state !== null) {
-      return {
-        ...(await resolveAvatarFromState(assistant.id, state)),
-        conclusive: true,
-      };
+      return conclusive(await resolveAvatarFromState(assistant.id, state));
     }
     const legacy = await readAvatarViaLegacyFiles(assistant.id);
     return isEmptyAvatar(legacy) ? { ...legacy, conclusive: false } : legacy;
@@ -217,38 +218,6 @@ function isEmptyAvatar(avatar: AvatarRead | undefined): boolean {
   return avatar !== undefined && !avatar.traits && !avatar.imageUrl;
 }
 
-/**
- * Writes a conclusive resolution to the last-seen cache (IndexedDB); an
- * empty avatar deletes the entry. Claims a persistence generation up front
- * so a blob read that resolves after a newer write or delete (including a
- * retire) commits nothing. Refreshes the cache query once committed.
- */
-async function persistLastSeenAvatar(
-  queryClient: QueryClient,
-  assistantId: string,
-  avatar: AvatarRead,
-): Promise<void> {
-  const generation = lastSeenAvatarGenerations.claim(assistantId);
-  if (avatar.imageUrl) {
-    const blob = await fetch(avatar.imageUrl).then((r) => r.blob());
-    if (!lastSeenAvatarGenerations.isCurrent(assistantId, generation)) {
-      return;
-    }
-    await writeLastSeenAvatar(assistantId, { kind: "image", blob }, generation);
-  } else if (avatar.traits) {
-    await writeLastSeenAvatar(
-      assistantId,
-      { kind: "character", traits: avatar.traits },
-      generation,
-    );
-  } else {
-    await deleteLastSeenAvatar(assistantId, generation);
-  }
-  await queryClient.invalidateQueries({
-    queryKey: chooserRowAvatarCacheQueryKey(assistantId),
-  });
-}
-
 async function readCachedRowAvatar(assistantId: string): Promise<AvatarRead> {
   const cached = await readLastSeenAvatar(assistantId);
   const imageUrl =
@@ -267,18 +236,16 @@ async function readCachedRowAvatar(assistantId: string): Promise<AvatarRead> {
  * 2. Other platform rows fetch per id through the platform proxy, only when
  *    {@link canFetchRowAvatarViaPlatformProxy} says the id is honored and the
  *    org store can supply the `Vellum-Organization-Id` header.
- * 3. Local rows (even asleep) read their workspace through the host bridge
- *    when one is available.
+ * 3. Local rows (the connected one when unreachable, siblings even asleep)
+ *    read their workspace through the host when one can serve it.
  * 4. The last-seen cache: whatever a live source last resolved for this id,
  *    so a row keeps its avatar while the assistant is unreachable.
- * Only live sources (1 and 2) feed the cache; a conclusive none from any
- * source evicts it. Anything else, including every failure, resolves to
- * nulls: the row's glyph fallback is the error state, a chooser row never
- * surfaces an error.
+ * Only live sources (1 and 2) feed the cache (1 does so inside
+ * `useAssistantAvatar`); a conclusive none from any source evicts it.
+ * Anything else, including every failure, resolves to nulls: the row's glyph
+ * fallback is the error state, a chooser row never surfaces an error.
  */
-export function useChooserRowAvatar(
-  assistant: ResolvedAssistant,
-): ChooserRowAvatar {
+export function useChooserRowAvatar(assistant: ResolvedAssistant): AvatarRead {
   const activeAssistantId = useResolvedAssistantsStore.use.activeAssistantId();
   const isConnectedRow = assistant.id === activeAssistantId;
   const isOrgReady = useIsOrgReady();
@@ -318,11 +285,15 @@ export function useChooserRowAvatar(
     liveConclusive || (live !== undefined && !isEmptyAvatar(live));
 
   // Host-disk reads are durable, so they render directly and never feed the
-  // last-seen cache; a conclusive none still evicts a stale entry.
+  // last-seen cache; a conclusive none still evicts a stale entry. The
+  // connected row only needs one once its live read has settled empty.
+  const liveSettledEmpty = !connected.isLoading && !showLive;
   const hostQuery = useQuery<LegacyAvatarRead>({
     queryKey: chooserRowAvatarHostQueryKey(assistant.id),
     queryFn: () => readRowAvatarViaHost(assistant.id),
-    enabled: !isConnectedRow && canReadRowAvatarViaHost(assistant),
+    enabled:
+      canReadRowAvatarViaHost(assistant) &&
+      (!isConnectedRow || liveSettledEmpty),
     staleTime: Infinity,
     retry: false,
   });
@@ -333,17 +304,22 @@ export function useChooserRowAvatar(
     (hostConclusive || !isEmptyAvatar(hostQuery.data));
   const hostNone = hostConclusive && isEmptyAvatar(hostQuery.data);
 
-  const syncCache = liveConclusive || hostNone;
-  const syncTraits = liveConclusive ? (live?.traits ?? null) : null;
-  const syncImageUrl = liveConclusive ? (live?.imageUrl ?? null) : null;
+  const rowConclusive = !isConnectedRow && liveConclusive;
+  const syncCache = rowConclusive || hostNone;
+  const syncTraits = rowConclusive ? (live?.traits ?? null) : null;
+  const syncImageUrl = rowConclusive ? (live?.imageUrl ?? null) : null;
   useEffect(() => {
     if (!syncCache) {
       return;
     }
-    void persistLastSeenAvatar(queryClient, assistant.id, {
+    void persistLastSeenAvatar(assistant.id, {
       traits: syncTraits,
       imageUrl: syncImageUrl,
-    }).catch(() => {});
+    }).then(() =>
+      queryClient.invalidateQueries({
+        queryKey: chooserRowAvatarCacheQueryKey(assistant.id),
+      }),
+    );
   }, [assistant.id, syncCache, syncTraits, syncImageUrl, queryClient]);
 
   const cacheQuery = useQuery<AvatarRead>({

--- a/clients/web/src/lib/persist-last-seen-avatar.ts
+++ b/clients/web/src/lib/persist-last-seen-avatar.ts
@@ -1,0 +1,50 @@
+import {
+  deleteLastSeenAvatar,
+  lastSeenAvatarGenerations,
+  writeLastSeenAvatar,
+} from "@/lib/avatar-last-seen-cache";
+import type { CharacterTraits } from "@/types/avatar";
+
+export interface LiveAvatarResolution {
+  traits: CharacterTraits | null;
+  imageUrl: string | null;
+}
+
+/**
+ * Writes a conclusive live resolution to the last-seen cache; an empty avatar
+ * deletes the entry. Shared by every live source (the active assistant's hook
+ * and the chooser's per-row fetch) so the cache fills whenever an avatar is
+ * read, not only while the chooser is mounted. Claims a persistence generation
+ * up front so a blob read that resolves after a newer write or delete
+ * (including a retire) commits nothing. Best-effort like the cache: never
+ * throws.
+ */
+export async function persistLastSeenAvatar(
+  assistantId: string,
+  avatar: LiveAvatarResolution,
+): Promise<void> {
+  const generation = lastSeenAvatarGenerations.claim(assistantId);
+  try {
+    if (avatar.imageUrl) {
+      const blob = await fetch(avatar.imageUrl).then((r) => r.blob());
+      if (!lastSeenAvatarGenerations.isCurrent(assistantId, generation)) {
+        return;
+      }
+      await writeLastSeenAvatar(
+        assistantId,
+        { kind: "image", blob },
+        generation,
+      );
+    } else if (avatar.traits) {
+      await writeLastSeenAvatar(
+        assistantId,
+        { kind: "character", traits: avatar.traits },
+        generation,
+      );
+    } else {
+      await deleteLastSeenAvatar(assistantId, generation);
+    }
+  } catch {
+    // A blob that cannot be read back is simply not cached.
+  }
+}

--- a/clients/web/src/runtime/local-mode-host.test.ts
+++ b/clients/web/src/runtime/local-mode-host.test.ts
@@ -24,6 +24,7 @@ const {
   readAssistantAvatarHost,
   fetchGuardianTokenHost,
   isLocalModeHostAvailable,
+  canReadAvatarFromLocalHost,
   requiresGuardianReprovision,
 } = await import("./local-mode-host");
 
@@ -40,8 +41,14 @@ beforeEach(() => {
   (window as WindowWithConfig).__VELLUM_CONFIG__ = {};
 });
 
+/** bun aliases `import.meta.env` to `process.env`, so this is the Vite dev flag. */
+function onViteDevHost() {
+  process.env.DEV = "true";
+}
+
 afterEach(() => {
   runningInElectron = false;
+  delete process.env.DEV;
   globalThis.fetch = realFetch;
   delete (window as { vellum?: unknown }).vellum;
   delete (window as WindowWithConfig).__VELLUM_CONFIG__;
@@ -761,6 +768,7 @@ describe("getLocalAssistantStatusHost", () => {
 
 describe("readAssistantAvatarHost", () => {
   test("web/dev host GETs the avatar middleware and returns its JSON", async () => {
+    onViteDevHost();
     const avatar = {
       kind: "character" as const,
       traits: { bodyShape: "round", eyeStyle: "dot", color: "#123456" },
@@ -809,6 +817,53 @@ describe("readAssistantAvatarHost", () => {
 
     expect(result.ok).toBe(false);
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  test("a rejected Electron bridge call resolves ok:false instead of throwing", async () => {
+    setElectronBridge({
+      readAssistantAvatar: mock(async () => {
+        throw new Error("ipc channel closed");
+      }),
+    });
+
+    expect(await readAssistantAvatarHost("a-1")).toEqual({
+      ok: false,
+      error: "Error: ipc channel closed",
+    });
+  });
+
+  test("the packaged CLI web host issues no request: it has no avatar endpoint", async () => {
+    const fetchMock = mock(async () => {
+      throw new Error("fetch must not run on the CLI host");
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await readAssistantAvatarHost("a-1");
+
+    expect(result.ok).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("canReadAvatarFromLocalHost", () => {
+  test("is true on the Electron host", () => {
+    runningInElectron = true;
+    expect(canReadAvatarFromLocalHost()).toBe(true);
+  });
+
+  test("is true on the Vite dev host", () => {
+    onViteDevHost();
+    expect(canReadAvatarFromLocalHost()).toBe(true);
+  });
+
+  test("is false on the packaged CLI web host", () => {
+    expect(canReadAvatarFromLocalHost()).toBe(false);
+  });
+
+  test("is false when no local-mode host is available", () => {
+    onViteDevHost();
+    delete (window as WindowWithConfig).__VELLUM_CONFIG__;
+    expect(canReadAvatarFromLocalHost()).toBe(false);
   });
 });
 
@@ -961,6 +1016,7 @@ describe("web/dev transport resilience", () => {
   });
 
   test("avatar returns a failure result instead of throwing on a non-JSON body", async () => {
+    onViteDevHost();
     globalThis.fetch = nonJsonResponse();
     const result = await readAssistantAvatarHost("a-1");
     expect(result.ok).toBe(false);

--- a/clients/web/src/runtime/local-mode-host.ts
+++ b/clients/web/src/runtime/local-mode-host.ts
@@ -172,6 +172,19 @@ export function isLocalModeHostAvailable(): boolean {
 }
 
 /**
+ * Whether this host serves `/assistant/__local/avatar/{id}`: the Electron main
+ * process and the Vite dev server do; the packaged `vellum client` web host
+ * deliberately does not (its `.vellum` boundary), and its SPA fallback would
+ * answer the request with HTML. `import.meta.env.DEV` is what separates the
+ * dev server from a served build.
+ */
+export function canReadAvatarFromLocalHost(): boolean {
+  return (
+    isLocalModeHostAvailable() && (isElectron() || Boolean(import.meta.env.DEV))
+  );
+}
+
+/**
  * POST a local-mode command and read back its `{ ok, ... }` result. Always
  * resolves, never throws: an unavailable host (no request sent) and a non-JSON
  * response both resolve to `{ ok: false }`.
@@ -604,7 +617,8 @@ export async function getLocalAssistantStatusHost(
  * process serves it behind `window.vellum.localMode.readAssistantAvatar`, the
  * Vite dev server behind `/assistant/__local/avatar/{id}`; both return the
  * ipc-contract shape. Never throws: an older Electron shell without the
- * channel and an unavailable dev host both resolve `{ ok: false }`.
+ * channel, a rejected bridge call, and a host that cannot serve the read
+ * ({@link canReadAvatarFromLocalHost}) all resolve `{ ok: false }`.
  */
 export async function readAssistantAvatarHost(
   assistantId: string,
@@ -617,9 +631,16 @@ export async function readAssistantAvatarHost(
         error: "Assistant avatars are not supported by this app version",
       };
     }
-    return readAssistantAvatar(assistantId);
+    try {
+      return await readAssistantAvatar(assistantId);
+    } catch (error) {
+      return { ok: false, error: String(error) };
+    }
   }
 
+  if (!canReadAvatarFromLocalHost()) {
+    return { ok: false, error: LOCAL_HOST_UNAVAILABLE_ERROR };
+  }
   return requestLocalCommand<LocalReadAssistantAvatarResult>(
     `/assistant/__local/avatar/${encodeURIComponent(assistantId)}`,
     { method: "GET" },


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review (round 2) for chooser-assistant-avatars.md.

**Gaps:** active local row had no host-disk fallback; last-seen cache was written only while the chooser was mounted; CLI-hosted web issued a dead host request; Electron host wrapper could reject; blob URLs leaked for removed assistants; small trims

## Details
- The connected local row now falls back to the host disk read once its live read settles empty (a healthy live read still wins and never issues the host read).
- `persistLastSeenAvatar` moved to `lib/persist-last-seen-avatar.ts`; `useAssistantAvatar` persists (or evicts on none) after every conclusive read, so the cache fills without the chooser mounted. The chooser no longer double-writes the connected row.
- `canReadAvatarFromLocalHost()` gates host avatar reads to Electron or the Vite dev host (`import.meta.env.DEV`); the packaged `vellum client --interface web` host has no avatar endpoint, so no request is issued there.
- Electron branch of `readAssistantAvatarHost` wraps the bridge call in try/catch.
- `releaseRowAvatarUrls(id)` revokes the live, cached, and `useAssistantAvatar` object URLs; called from retire and unpair beside `deleteLastSeenAvatar`.
- Trims: `ChooserRowAvatar` alias removed, `size={48}` dropped (chip default), `EMPTY_AVATAR_STALE_TIME_MS` un-exported, `conclusive()` helper, shared `readAvatarFile` skeleton in avatar-api.