### PR TITLE
feat(android): forward marketing attribution on the provider-token exchange

### DIFF
--- a/clients/android/app/src/main/java/ai/vellum/assistant/NativeAuthPlugin.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/NativeAuthPlugin.java
@@ -20,7 +20,9 @@ import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
 import java.util.Locale;
+import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.json.JSONException;
@@ -36,6 +38,7 @@ public class NativeAuthPlugin extends Plugin {
     private static final String AUTH_STATE_STORE = "native_auth_state";
     private static final String CONFIG_PATH = "/_allauth/app/v1/config";
     private static final long FLOW_MAX_AGE_MS = 10 * 60 * 1000L;
+    private static final String FLOW_ATTRIBUTION_KEY = "attribution";
     private static final String FLOW_BASE_URL_KEY = "base_url";
     private static final String FLOW_CLIENT_ID_KEY = "client_id";
     private static final String FLOW_CODE_VERIFIER_KEY = "code_verifier";
@@ -86,7 +89,8 @@ public class NativeAuthPlugin extends Plugin {
             baseURL,
             WorkOSAuth.generateBase64UrlToken(),
             WorkOSAuth.generateBase64UrlToken(),
-            sanitizePostAuthDestination(call.getString("postAuthDestination"))
+            sanitizePostAuthDestination(call.getString("postAuthDestination")),
+            readAttribution(call.getObject("attribution"))
         );
         replaceFlow(nextFlow);
 
@@ -296,7 +300,10 @@ public class NativeAuthPlugin extends Plugin {
                 String sessionResponse;
                 try {
                     sessionResponse = postJson(
-                        buildPlatformURL(expected.baseURL, PROVIDER_TOKEN_PATH),
+                        WorkOSAuth.withAttribution(
+                            buildPlatformURL(expected.baseURL, PROVIDER_TOKEN_PATH),
+                            expected.attribution
+                        ),
                         sessionBody
                     );
                 } catch (HttpException e) {
@@ -530,6 +537,7 @@ public class NativeAuthPlugin extends Plugin {
         return authStateStore()
             .edit()
             .clear()
+            .putString(FLOW_ATTRIBUTION_KEY, Attribution.toQuery(pendingFlow.attribution))
             .putString(FLOW_BASE_URL_KEY, pendingFlow.baseURL.toString())
             .putString(FLOW_CLIENT_ID_KEY, pendingFlow.clientId)
             .putString(FLOW_CODE_VERIFIER_KEY, pendingFlow.codeVerifier)
@@ -568,7 +576,8 @@ public class NativeAuthPlugin extends Plugin {
             baseURL,
             state,
             codeVerifier,
-            sanitizePostAuthDestination(store.getString(FLOW_DESTINATION_KEY, null))
+            sanitizePostAuthDestination(store.getString(FLOW_DESTINATION_KEY, null)),
+            Attribution.parseQuery(store.getString(FLOW_ATTRIBUTION_KEY, null))
         );
         restored.clientId = clientId;
         restored.browserLaunched = true;
@@ -581,6 +590,31 @@ public class NativeAuthPlugin extends Plugin {
 
     private void clearPendingFlow() {
         authStateStore().edit().clear().commit();
+    }
+
+    /**
+     * Allowlisted campaign attribution from a {@code startAuth} call. Unwrapped
+     * here so {@link Attribution} stays free of Capacitor and Android types, and
+     * so stays testable on the JVM.
+     */
+    private static Map<String, String> readAttribution(JSObject source) {
+        Map<String, String> fields = new LinkedHashMap<>();
+        if (source == null) {
+            return fields;
+        }
+        for (String key : Attribution.KEYS) {
+            String value = source.getString(key, "");
+            if (value.isEmpty()) {
+                continue;
+            }
+            fields.put(
+                key,
+                value.length() <= Attribution.VALUE_MAX_LENGTH
+                    ? value
+                    : value.substring(0, Attribution.VALUE_MAX_LENGTH)
+            );
+        }
+        return fields;
     }
 
     private static String sanitizePostAuthDestination(String value) {
@@ -630,18 +664,27 @@ public class NativeAuthPlugin extends Plugin {
         final String state;
         final String codeVerifier;
         final String postAuthDestination;
+        final Map<String, String> attribution;
 
         String clientId;
         boolean browserLaunched;
         boolean callbackReceived;
         long browserLaunchTimeMs;
 
-        AuthFlow(PluginCall call, Uri baseURL, String state, String codeVerifier, String postAuthDestination) {
+        AuthFlow(
+            PluginCall call,
+            Uri baseURL,
+            String state,
+            String codeVerifier,
+            String postAuthDestination,
+            Map<String, String> attribution
+        ) {
             this.call = call;
             this.baseURL = baseURL;
             this.state = state;
             this.codeVerifier = codeVerifier;
             this.postAuthDestination = postAuthDestination;
+            this.attribution = attribution;
         }
     }
 

--- a/clients/android/app/src/main/java/ai/vellum/assistant/WorkOSAuth.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/WorkOSAuth.java
@@ -2,10 +2,13 @@ package ai.vellum.assistant;
 
 import android.net.Uri;
 import android.util.Base64;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
+import java.util.Map;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -99,6 +102,24 @@ final class WorkOSAuth {
 
     static String accessToken(String authenticateBody) throws JSONException {
         return nonEmpty(new JSONObject(authenticateBody).optString("access_token", null));
+    }
+
+    /**
+     * {@code base} carrying {@code attribution} as its query, or {@code base}
+     * unchanged when there is nothing to carry.
+     *
+     * <p>Attribution rides the query string rather than the JSON body because
+     * allauth headless posts {@code application/json}, which leaves Django's
+     * {@code request.POST} empty; the platform reads these off {@code request.GET}
+     * even for a POST.
+     */
+    static URL withAttribution(URL base, Map<String, String> attribution)
+        throws MalformedURLException {
+        String query = Attribution.toQuery(attribution);
+        if (query.isEmpty()) {
+            return base;
+        }
+        return new URL(base + "?" + query);
     }
 
     static JSONObject providerTokenRequestBody(String clientId, String accessToken)

--- a/clients/android/app/src/test/java/ai/vellum/assistant/WorkOSAuthTest.java
+++ b/clients/android/app/src/test/java/ai/vellum/assistant/WorkOSAuthTest.java
@@ -1,0 +1,47 @@
+package ai.vellum.assistant;
+
+import static org.junit.Assert.assertEquals;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.Test;
+
+public class WorkOSAuthTest {
+    private static final String SESSION_URL =
+        "https://dev-assistant.vellum.ai/_allauth/app/v1/auth/provider/token";
+
+    @Test
+    public void appendsAttributionInAllowlistOrder() throws MalformedURLException {
+        Map<String, String> attribution = new LinkedHashMap<>();
+        attribution.put("gclid", "abc123");
+        attribution.put("utm_source", "google");
+
+        URL url = WorkOSAuth.withAttribution(new URL(SESSION_URL), attribution);
+
+        assertEquals(SESSION_URL + "?utm_source=google&gclid=abc123", url.toString());
+    }
+
+    @Test
+    public void leavesTheUrlUnchangedWithoutAttribution() throws MalformedURLException {
+        URL base = new URL(SESSION_URL);
+
+        assertEquals(SESSION_URL, WorkOSAuth.withAttribution(base, new LinkedHashMap<>()).toString());
+        assertEquals(SESSION_URL, WorkOSAuth.withAttribution(base, null).toString());
+    }
+
+    @Test
+    public void percentEncodesAttributionValues() throws MalformedURLException {
+        Map<String, String> attribution = new LinkedHashMap<>();
+        attribution.put("utm_campaign", "spring sale & more");
+        attribution.put("utm_term", "a=b#c");
+
+        URL url = WorkOSAuth.withAttribution(new URL(SESSION_URL), attribution);
+
+        assertEquals(
+            SESSION_URL + "?utm_campaign=spring+sale+%26+more&utm_term=a%3Db%23c",
+            url.toString()
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Native Android signups landed unattributed: the web bridge had nowhere to put campaign params, and the shell had nothing to carry them on. This is the Android receiving half.

- `startAuth` reads `call.getObject("attribution")` and unwraps it into a `Map<String, String>` in the plugin (allowlist from `Attribution.KEYS`, empty values skipped, values bounded by `Attribution.VALUE_MAX_LENGTH`). The unwrapping stays in `NativeAuthPlugin` so `Attribution` keeps its Capacitor-free, JVM-testable shape.
- The map rides on `AuthFlow` beside `clientId` / `codeVerifier` / `state`, and is persisted into the same `SharedPreferences` store the process-death restore path already uses (serialized with `Attribution.toQuery`, restored with `Attribution.parseQuery`). A restored login with no stored attribution degrades to no attribution, never to a failure.
- New `WorkOSAuth.withAttribution(URL, Map)` appends the already percent-encoded query to the provider/token URL, and returns the URL untouched when there is nothing to carry. No double-encoding, because `Attribution.toQuery` owns the encoding.

Query params rather than JSON body fields: allauth headless posts `application/json`, which leaves Django's `request.POST` empty, so the platform reads attribution off `request.GET` even for a POST. `providerTokenRequestBody` is unchanged; the body stays `{provider, process, token}`.

## Skew

An arbitrarily old Play shell can run an arbitrarily new web bundle, and vice versa. A `startAuth` call without `attribution` produces an empty map, an empty query, and byte-identical behavior to today.

## Testing

New `WorkOSAuthTest` covers the URL construction on the JVM: allowlist ordering, no `?` for an empty or null map, and percent-encoding of values containing `&`, `=`, `#`, and spaces. `./gradlew` cannot run on this machine (no JDK or Android SDK), so `:app:testDevDebugUnitTest` is verified in CI.

Part of plan: android-install-referrer-attribution.md (PR 3 of 7)