### PR TITLE
feat(android): expose the Play install referrer to the web layer

### DIFF
--- a/clients/android/app/build.gradle
+++ b/clients/android/app/build.gradle
@@ -149,6 +149,7 @@ dependencies {
     implementation "androidx.coordinatorlayout:coordinatorlayout:$androidxCoordinatorLayoutVersion"
     implementation "androidx.core:core:$androidxCoreVersion"
     implementation "androidx.core:core-splashscreen:$coreSplashScreenVersion"
+    implementation "com.android.installreferrer:installreferrer:$installReferrerVersion"
     implementation "com.google.firebase:firebase-messaging:$firebaseMessagingVersion"
     implementation project(':capacitor-android')
     testImplementation "junit:junit:$junitVersion"

--- a/clients/android/app/src/main/java/ai/vellum/assistant/InstallReferrerPlugin.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/InstallReferrerPlugin.java
@@ -1,0 +1,137 @@
+package ai.vellum.assistant;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.os.RemoteException;
+import com.android.installreferrer.api.InstallReferrerClient;
+import com.android.installreferrer.api.InstallReferrerStateListener;
+import com.android.installreferrer.api.ReferrerDetails;
+import com.getcapacitor.JSObject;
+import com.getcapacitor.Plugin;
+import com.getcapacitor.PluginCall;
+import com.getcapacitor.PluginMethod;
+import com.getcapacitor.annotation.CapacitorPlugin;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Exposes the Play Store install referrer, the only attribution a Play install
+ * carries. {@code read} never rejects: an empty result is the answer when no
+ * Play Store answers, so a sideloaded build takes the same path as a Play
+ * install with no campaign.
+ */
+@CapacitorPlugin(name = "InstallReferrer")
+public class InstallReferrerPlugin extends Plugin {
+    private static final String STATE_STORE = "install_referrer_state";
+    private static final String INSTALL_BEGIN_TIMESTAMP_KEY = "install_begin_timestamp";
+    private static final String REFERRER_KEY = "referrer";
+    private static final String REFERRER_CLICK_TIMESTAMP_KEY = "referrer_click_timestamp";
+    private static final String RESOLVED_KEY = "resolved";
+
+    @PluginMethod
+    public void read(PluginCall call) {
+        SharedPreferences store = stateStore();
+        if (store.getBoolean(RESOLVED_KEY, false)) {
+            call.resolve(
+                payload(
+                    store.getString(REFERRER_KEY, ""),
+                    store.getLong(REFERRER_CLICK_TIMESTAMP_KEY, 0L),
+                    store.getLong(INSTALL_BEGIN_TIMESTAMP_KEY, 0L)
+                )
+            );
+            return;
+        }
+
+        final InstallReferrerClient client = InstallReferrerClient.newBuilder(getContext()).build();
+        // One connection can fire both setup-finished and service-disconnected,
+        // and a call resolves once.
+        final AtomicBoolean answered = new AtomicBoolean();
+        try {
+            client.startConnection(
+                new InstallReferrerStateListener() {
+                    @Override
+                    public void onInstallReferrerSetupFinished(int responseCode) {
+                        if (answered.getAndSet(true)) {
+                            return;
+                        }
+                        JSObject result = new JSObject();
+                        if (responseCode == InstallReferrerClient.InstallReferrerResponse.OK) {
+                            result = readReferrer(client);
+                        } else if (isTerminalStatus(responseCode)) {
+                            cache("", 0L, 0L);
+                        }
+                        finish(client, call, result);
+                    }
+
+                    @Override
+                    public void onInstallReferrerServiceDisconnected() {
+                        if (!answered.getAndSet(true)) {
+                            finish(client, call, new JSObject());
+                        }
+                    }
+                }
+            );
+        } catch (RuntimeException exception) {
+            NativeFailureGuard.record("Unable to bind the Play install referrer service", exception);
+            if (!answered.getAndSet(true)) {
+                finish(client, call, new JSObject());
+            }
+        }
+    }
+
+    /**
+     * Whether a status means the Play Store on this device will never answer, so
+     * the miss is worth caching. Transient statuses stay uncached, leaving a
+     * later launch free to retry.
+     */
+    static boolean isTerminalStatus(int responseCode) {
+        return (
+            responseCode == InstallReferrerClient.InstallReferrerResponse.FEATURE_NOT_SUPPORTED ||
+            responseCode == InstallReferrerClient.InstallReferrerResponse.DEVELOPER_ERROR
+        );
+    }
+
+    private JSObject readReferrer(InstallReferrerClient client) {
+        ReferrerDetails details;
+        try {
+            details = client.getInstallReferrer();
+        } catch (RemoteException | RuntimeException exception) {
+            NativeFailureGuard.record("Unable to read the Play install referrer", exception);
+            return new JSObject();
+        }
+        String referrer = details.getInstallReferrer();
+        long clickTimestamp = details.getReferrerClickTimestampSeconds();
+        long beginTimestamp = details.getInstallBeginTimestampSeconds();
+        cache(referrer, clickTimestamp, beginTimestamp);
+        return payload(referrer, clickTimestamp, beginTimestamp);
+    }
+
+    private void finish(InstallReferrerClient client, PluginCall call, JSObject result) {
+        NativeFailureGuard.run("Unable to close the Play install referrer connection", client::endConnection);
+        call.resolve(result);
+    }
+
+    private void cache(String referrer, long clickTimestamp, long beginTimestamp) {
+        stateStore()
+            .edit()
+            .putString(REFERRER_KEY, referrer == null ? "" : referrer)
+            .putLong(REFERRER_CLICK_TIMESTAMP_KEY, clickTimestamp)
+            .putLong(INSTALL_BEGIN_TIMESTAMP_KEY, beginTimestamp)
+            .putBoolean(RESOLVED_KEY, true)
+            .apply();
+    }
+
+    private SharedPreferences stateStore() {
+        return getContext().getSharedPreferences(STATE_STORE, Context.MODE_PRIVATE);
+    }
+
+    private static JSObject payload(String referrer, long clickTimestamp, long beginTimestamp) {
+        JSObject result = new JSObject();
+        if (referrer == null || referrer.isEmpty()) {
+            return result;
+        }
+        result.put("referrer", referrer);
+        result.put("referrerClickTimestampSeconds", clickTimestamp);
+        result.put("installBeginTimestampSeconds", beginTimestamp);
+        return result;
+    }
+}

--- a/clients/android/app/src/main/java/ai/vellum/assistant/MainActivity.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/MainActivity.java
@@ -126,6 +126,7 @@ public class MainActivity extends BridgeActivity {
         registerPlugin(AndroidNotificationChannelsPlugin.class);
         registerPlugin(AndroidNotificationSettingsPlugin.class);
         registerPlugin(AndroidPushRegistrationPlugin.class);
+        registerPlugin(InstallReferrerPlugin.class);
         registerPlugin(VoiceAudioSessionPlugin.class);
         registerPlugin(VoiceLiveActivityPlugin.class);
         registerPlugin(SelfHostedServersPlugin.class);

--- a/clients/android/app/src/test/java/ai/vellum/assistant/InstallReferrerPluginTest.java
+++ b/clients/android/app/src/test/java/ai/vellum/assistant/InstallReferrerPluginTest.java
@@ -1,0 +1,26 @@
+package ai.vellum.assistant;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.android.installreferrer.api.InstallReferrerClient.InstallReferrerResponse;
+import org.junit.Test;
+
+public class InstallReferrerPluginTest {
+    @Test
+    public void unsupportedPlayStoresAreTerminal() {
+        assertTrue(InstallReferrerPlugin.isTerminalStatus(InstallReferrerResponse.FEATURE_NOT_SUPPORTED));
+        assertTrue(InstallReferrerPlugin.isTerminalStatus(InstallReferrerResponse.DEVELOPER_ERROR));
+    }
+
+    @Test
+    public void unavailableAndDisconnectedServicesAreRetryable() {
+        assertFalse(InstallReferrerPlugin.isTerminalStatus(InstallReferrerResponse.SERVICE_UNAVAILABLE));
+        assertFalse(InstallReferrerPlugin.isTerminalStatus(InstallReferrerResponse.SERVICE_DISCONNECTED));
+    }
+
+    @Test
+    public void successIsNotTerminal() {
+        assertFalse(InstallReferrerPlugin.isTerminalStatus(InstallReferrerResponse.OK));
+    }
+}

--- a/clients/android/variables.gradle
+++ b/clients/android/variables.gradle
@@ -15,4 +15,5 @@ ext {
     androidxEspressoCoreVersion = '3.7.0'
     cordovaAndroidVersion = '14.0.1'
     firebaseMessagingVersion = '25.0.1'
+    installReferrerVersion = '2.2'
 }

--- a/clients/web/docs/CAPACITOR.md
+++ b/clients/web/docs/CAPACITOR.md
@@ -350,6 +350,43 @@ Proxy.
 
 ---
 
+## Install referrer (`InstallReferrer`)
+
+A user who taps a campaign link, lands in Play, and installs arrives with no
+URL params, so the Play install referrer is the only attribution that install
+carries. The Android shell exposes it as the `InstallReferrer` plugin
+([`InstallReferrerPlugin.java`](../../../clients/android/app/src/main/java/ai/vellum/assistant/InstallReferrerPlugin.java));
+the web side is
+[`src/runtime/install-referrer.ts`](../src/runtime/install-referrer.ts). There
+is no iOS counterpart.
+
+- **`read()` never rejects.** It resolves
+  `{ referrer, referrerClickTimestampSeconds, installBeginTimestampSeconds }`
+  when Play answers with a referrer, and `{}` for every other outcome: no Play
+  Store on the device, a Play Store that declines the bind, or a Play install
+  with no campaign. A rejection here would surface as an error on the auth
+  path, which is where the value is spent.
+- **The empty result is the answer.** There is no availability probe, for the
+  same reason the voice bridge has none (§ "The skew rule"): a probe can itself
+  be absent on an older shell, and `{}` is the only answer a caller could act
+  on anyway. The `dev` and `staging` flavors carry an `applicationIdSuffix` and
+  are never Play-installed, so `{}` is the normal result in development.
+- **The shell caches the resolution, not its consumption.** A successful read
+  and a status meaning this device's Play Store will never answer both land in
+  the `install_referrer_state` preferences, so later launches skip the service
+  bind. A transient failure is left uncached, so a later launch retries.
+- **Consumption state belongs to the web layer.** The shell keeps answering
+  `read()` with the same value forever; the web layer captures it into device
+  storage once and drops it when a signup has spent it. Do not add a
+  "mark consumed" method to the bridge.
+- **No manifest permission.** The Play Install Referrer Library declares its
+  own service binding, so `AndroidManifest.xml` needs no entry for this.
+
+References:
+- Google Play: [Play Install Referrer Library](https://developer.android.com/google/play/installreferrer/library).
+
+---
+
 ## No JS height sync for auto-growing textareas
 
 Do not use JavaScript (`scrollHeight`, `offsetHeight`, `el.style.height = …`) to auto-resize `<textarea>` elements. iOS `WKWebView` re-dispatches native `input` events when it detects DOM geometry changes during input processing. In a controlled React component, JS height sync triggers `setState` → re-render → DOM mutation → re-fire, cascading until React hits its 50-update depth limit and throws `Maximum update depth exceeded`. Desktop browsers tolerate this pattern; iOS does not.


### PR DESCRIPTION
## Summary

Adds an Android-only `InstallReferrer` Capacitor plugin so the web layer can read the Play Store install referrer. A user who taps a campaign link, lands in Play, and installs arrives with no URL params, so the referrer is the only attribution a Play install carries.

`InstallReferrer.read()` resolves `{ referrer, referrerClickTimestampSeconds, installBeginTimestampSeconds }` when Play answers with a referrer, and `{}` in every other case. The key names match the contract already shipped in `clients/web/src/runtime/install-referrer.ts`.

## Never rejects

`read()` has no rejection path. The value is spent on the auth path, and a rejection there would surface as a login error on a sideloaded or non-Play build. The `dev` and `staging` flavors carry an `applicationIdSuffix` and are never Play-installed, so "no Play Store answers" is the normal path in development.

- `FEATURE_NOT_SUPPORTED` and `DEVELOPER_ERROR` are terminal: this device's Play Store will never answer, so an empty referrer is cached with `resolved = true` and later launches skip the service bind entirely.
- `SERVICE_UNAVAILABLE` and `onInstallReferrerServiceDisconnected` are transient: `{}` resolves without caching, so a later launch retries.
- A single-shot `AtomicBoolean` guards the listener, which can fire both `onInstallReferrerSetupFinished` and `onInstallReferrerServiceDisconnected` for one connection. `endConnection()` runs on every terminal path.

The status decision is extracted as a pure `static boolean isTerminalStatus(int)` and unit-tested against the `InstallReferrerClient.InstallReferrerResponse` constants.

## Dependency license (reviewer decision)

`com.android.installreferrer:installreferrer:2.2` ships under the [Android Software Development Kit License](https://developer.android.com/studio/terms), not Apache-2.0, so root `AGENTS.md` line 39 nominally wants explicit approval for it. Precedent already exists in this module: `com.google.firebase:firebase-messaging:25.0.1` is a current dependency under the same Google terms. Flagging it here rather than treating it as a blocker.

## No manifest permission

`AndroidManifest.xml` is untouched on purpose. The Play Install Referrer Library declares its own service binding, so there is no permission or `<queries>` entry to add.

## Test plan

- CI runs `:app:testDevDebugUnitTest` plus lint and bundle for all three flavors. This machine has no JDK or Android SDK, so the Java was reviewed by eye and verified in CI.
- On a device with no Play Store, `read()` resolves `{}`, and a second call does not bind the service again.

Part of plan: android-install-referrer-attribution.md (PR 2 of 7)