### PR TITLE
fix(web): forward marketing attribution on native auth flows

### DIFF
--- a/clients/web/src/runtime/native-auth.test.ts
+++ b/clients/web/src/runtime/native-auth.test.ts
@@ -1,21 +1,68 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-
 import {
-  clearCheckoutIntent,
-  readCheckoutIntent,
-  saveCheckoutIntent,
-} from "@/lib/billing/checkout-intent";
-import { nativeAuthErrorDetail } from "@/domains/account/native-auth-error";
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  test,
+} from "bun:test";
 
-import { ONBOARDED_HATCH_AGE_MS } from "@/domains/onboarding/onboarded-assistant";
-import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
-import { routes } from "@/utils/routes";
+type StartAuthOptions = {
+  baseURL: string;
+  loginHint?: string;
+  intent?: string;
+  attribution?: Record<string, string>;
+  postAuthDestination: string;
+};
 
-import {
+let nativePlatform = false;
+let platform = "web";
+
+const startAuth = mock(async (_options: StartAuthOptions) => ({
+  sessionToken: "session-token",
+}));
+const readInstallReferrer = mock(
+  async (): Promise<{ referrer?: string }> => ({}),
+);
+
+const nativePlugins: Record<string, unknown> = {
+  NativeAuth: { startAuth, consumeRestoredAuth: async () => ({}) },
+  InstallReferrer: { read: readInstallReferrer },
+};
+
+mock.module("@capacitor/core", () => ({
+  Capacitor: {
+    isNativePlatform: () => nativePlatform,
+    getPlatform: () => platform,
+  },
+  registerPlugin: (name: string) => nativePlugins[name] ?? {},
+}));
+
+// `completeNativeLogin` polls the session endpoint before navigating. Answer
+// "authenticated" immediately so the native tests don't sit through the
+// backoff or reach the network.
+mock.module("@/lib/auth/allauth-client", () => ({
+  getSession: async () => ({ ok: true, data: { user: { id: "user-1" } } }),
+}));
+
+const {
   clearStaleNativeCheckoutStash,
   resolveNativePostAuthDestination,
   startAuthFlow,
-} from "./native-auth";
+} = await import("./native-auth");
+const { clearCheckoutIntent, readCheckoutIntent, saveCheckoutIntent } =
+  await import("@/lib/billing/checkout-intent");
+const { nativeAuthErrorDetail } = await import(
+  "@/domains/account/native-auth-error"
+);
+const { ONBOARDED_HATCH_AGE_MS } = await import(
+  "@/domains/onboarding/onboarded-assistant"
+);
+const { useResolvedAssistantsStore } = await import(
+  "@/stores/resolved-assistants-store"
+);
+const { routes } = await import("@/utils/routes");
 
 describe("resolveNativePostAuthDestination", () => {
   beforeEach(() => {
@@ -209,5 +256,184 @@ describe("clearStaleNativeCheckoutStash", () => {
       kind: "package",
       packageKey: "super",
     });
+  });
+});
+
+describe("startAuthFlow attribution on native", () => {
+  const INSTALL_REFERRER_KEY = "device:install_referrer";
+  const originalLocation = Object.getOwnPropertyDescriptor(window, "location");
+
+  /**
+   * Swap in a plain `location`: happy-dom would try to navigate on the `href`
+   * assignment that ends the flow, and a plain object lets the test read back
+   * the destination that was chosen.
+   */
+  function setLocation(search: string): void {
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      writable: true,
+      value: {
+        protocol: "https:",
+        host: "app.vellum.ai",
+        search,
+        href: "https://app.vellum.ai/account/signup",
+      },
+    });
+  }
+
+  function lastStartAuthOptions(): StartAuthOptions {
+    const options = startAuth.mock.calls.at(-1)?.[0];
+    if (!options) {
+      throw new Error("startAuth was never called");
+    }
+    return options;
+  }
+
+  async function runSignup(): Promise<void> {
+    await startAuthFlow("workos", "/account/provider/callback", {
+      intent: "signup",
+      returnTo: "/assistant/home",
+    });
+  }
+
+  beforeEach(() => {
+    nativePlatform = true;
+    platform = "android";
+    localStorage.clear();
+    sessionStorage.clear();
+    clearCheckoutIntent();
+    useResolvedAssistantsStore.setState({ assistants: [] });
+    // Keep `completeNativeLogin`'s biometric branch out of the way; it is
+    // opt-out, so an unset preference would reach the secure-storage plugin.
+    localStorage.setItem("device:biometric_enabled", "false");
+    mock.clearAllMocks();
+    startAuth.mockResolvedValue({ sessionToken: "session-token" });
+    readInstallReferrer.mockResolvedValue({});
+    setLocation("");
+  });
+
+  afterEach(() => {
+    nativePlatform = false;
+    platform = "web";
+    useResolvedAssistantsStore.setState({ assistants: [] });
+  });
+
+  afterAll(() => {
+    if (originalLocation) {
+      Object.defineProperty(window, "location", originalLocation);
+    }
+  });
+
+  test("forwards the allowlisted URL params to the shell", async () => {
+    setLocation("?utm_source=newsletter&utm_campaign=spring&not_a_param=x");
+
+    await runSignup();
+
+    expect(startAuth).toHaveBeenCalledTimes(1);
+    expect(lastStartAuthOptions().attribution).toEqual({
+      utm_source: "newsletter",
+      utm_campaign: "spring",
+    });
+    // A live URL source short-circuits the install-referrer bridge entirely.
+    expect(readInstallReferrer).not.toHaveBeenCalled();
+  });
+
+  test("captures and forwards the Play install referrer when the URL has none", async () => {
+    readInstallReferrer.mockResolvedValueOnce({
+      referrer: "utm_source=google-play&utm_medium=organic&anid=admob",
+    });
+
+    await runSignup();
+
+    expect(readInstallReferrer).toHaveBeenCalledTimes(1);
+    expect(lastStartAuthOptions().attribution).toEqual({
+      utm_source: "google-play",
+      utm_medium: "organic",
+    });
+  });
+
+  test("omits attribution entirely when neither source has any", async () => {
+    await runSignup();
+
+    const options = lastStartAuthOptions();
+    expect(Object.keys(options).sort()).toEqual([
+      "baseURL",
+      "intent",
+      "postAuthDestination",
+    ]);
+    expect(options).toEqual({
+      baseURL: "https://app.vellum.ai",
+      intent: "signup",
+      postAuthDestination: "/assistant/onboarding/privacy",
+    });
+  });
+
+  test("sends one source, never a merge of both", async () => {
+    setLocation("?utm_source=newsletter");
+    localStorage.setItem(
+      INSTALL_REFERRER_KEY,
+      "utm_source=google-play&utm_medium=organic&gclid=abc123",
+    );
+
+    await runSignup();
+
+    // The platform stores a row as one coherent source, so the stored
+    // referrer's fields must not be spliced into the URL's.
+    expect(lastStartAuthOptions().attribution).toEqual({
+      utm_source: "newsletter",
+    });
+  });
+
+  test("an explicit attribution option outranks both discovered sources", async () => {
+    setLocation("?utm_source=newsletter");
+    localStorage.setItem(INSTALL_REFERRER_KEY, "utm_source=google-play");
+
+    await startAuthFlow("workos", "/account/provider/callback", {
+      intent: "signup",
+      returnTo: "/assistant/home",
+      attribution: { utm_source: "explicit" },
+    });
+
+    expect(lastStartAuthOptions().attribution).toEqual({
+      utm_source: "explicit",
+    });
+  });
+
+  test("clears the stored referrer once the session is real", async () => {
+    localStorage.setItem(INSTALL_REFERRER_KEY, "utm_source=google-play");
+
+    await runSignup();
+
+    expect(lastStartAuthOptions().attribution).toEqual({
+      utm_source: "google-play",
+    });
+    expect(localStorage.getItem(INSTALL_REFERRER_KEY)).toBeNull();
+    expect(window.location.href).toBe("/assistant/onboarding/privacy");
+  });
+
+  test("leaves the stored referrer in place when native auth fails", async () => {
+    localStorage.setItem(INSTALL_REFERRER_KEY, "utm_source=google-play");
+    startAuth.mockRejectedValueOnce(
+      Object.assign(new Error("auth failed"), { code: "AUTH_FAILED" }),
+    );
+
+    await expect(runSignup()).rejects.toThrow("auth failed");
+
+    expect(localStorage.getItem(INSTALL_REFERRER_KEY)).toBe(
+      "utm_source=google-play",
+    );
+  });
+
+  test("leaves the stored referrer in place when the user cancels", async () => {
+    localStorage.setItem(INSTALL_REFERRER_KEY, "utm_source=google-play");
+    startAuth.mockRejectedValueOnce(
+      Object.assign(new Error("cancelled"), { code: "USER_CANCELLED" }),
+    );
+
+    await runSignup();
+
+    expect(localStorage.getItem(INSTALL_REFERRER_KEY)).toBe(
+      "utm_source=google-play",
+    );
   });
 });

--- a/clients/web/src/runtime/native-auth.ts
+++ b/clients/web/src/runtime/native-auth.ts
@@ -3,6 +3,7 @@ import { useSyncExternalStore } from "react";
 
 import {
   type ProviderRedirectOptions,
+  readAttributionParams,
   startProviderRedirect,
 } from "@/domains/account/social-auth";
 import { sanitizeReturnTo } from "@/domains/account/return-to";
@@ -15,6 +16,11 @@ import { isLocalClient } from "@/lib/local-mode";
 import { isElectron } from "@/runtime/is-electron";
 import { setMenuPlatformSession } from "@/runtime/menu";
 import { primeElectronSessionToken } from "@/runtime/session-token";
+import {
+  captureInstallReferrer,
+  clearStoredInstallReferrer,
+  readStoredInstallReferrer,
+} from "@/runtime/install-referrer";
 import {
   isBiometricEnabled,
   setBiometricEnabled,
@@ -42,6 +48,13 @@ interface NativeAuthPlugin {
     baseURL: string;
     loginHint?: string;
     intent?: string;
+    /**
+     * Allowlisted campaign params. The shell appends them as query params on
+     * its token POST: allauth headless posts JSON, so the platform reads
+     * attribution off `request.GET`. Omitted when empty, so a shell that
+     * predates this field sees an unchanged call.
+     */
+    attribution?: Record<string, string>;
     postAuthDestination: string;
   }): Promise<{ sessionToken: string }>;
   consumeRestoredAuth(): Promise<{
@@ -127,6 +140,7 @@ export async function startNativeLogin(options?: {
   returnTo?: string | null;
   loginHint?: string;
   intent?: string;
+  attribution?: Record<string, string>;
 }): Promise<void> {
   // Every native auth entry routes through the shared stale-stash cleanup. The
   // direct login form (`login-page.tsx`) calls this without going through
@@ -144,6 +158,7 @@ export async function startNativeLogin(options?: {
     baseURL,
     ...(options?.loginHint ? { loginHint: options.loginHint } : {}),
     ...(options?.intent ? { intent: options.intent } : {}),
+    ...(options?.attribution ? { attribution: options.attribution } : {}),
     postAuthDestination: destination,
   });
 
@@ -205,6 +220,11 @@ async function completeNativeLogin(
   if (isNativePlatform()) {
     await waitForNativeSessionCookie();
   }
+
+  // The referrer is spent: it rode this flow's `startAuth` call. Cleared on
+  // login too, since we can't tell signup from login here and a retained value
+  // would attach this install's campaign to the next user to sign up here.
+  clearStoredInstallReferrer();
 
   // Persist the token in native secure storage for biometric session recovery.
   // Respects the user's opt-out preference; storeBiometricToken is also
@@ -356,6 +376,30 @@ export function clearStaleNativeCheckoutStash(
 }
 
 /**
+ * Attribution to hand the native shell, drawn from exactly one source.
+ *
+ * URL params win: they carry the user's current, explicit campaign context.
+ * The Play install referrer is the fallback, and it is the only attribution a
+ * Play install carries at all (such an install arrives with no URL params).
+ *
+ * The two are never merged: `persist_attribution` on the platform stores a row
+ * as one coherent unit from a single source, so it must not be handed fields
+ * spliced from two. First touch across repeat signups is already held there by
+ * the empty-row backfill guard.
+ */
+async function resolveNativeAttribution(
+  attribution: Record<string, string> | undefined,
+): Promise<Record<string, string> | undefined> {
+  const fromUrl = attribution ?? readAttributionParams(window.location.search);
+  if (Object.keys(fromUrl).length > 0) {
+    return fromUrl;
+  }
+  await captureInstallReferrer();
+  const stored = readStoredInstallReferrer();
+  return Object.keys(stored).length > 0 ? stored : undefined;
+}
+
+/**
  * Unified auth-flow entry point that transparently chooses between the
  * native plugin path and the web form-POST path.
  *
@@ -369,6 +413,9 @@ export function clearStaleNativeCheckoutStash(
  * path, `USER_CANCELLED` (user tapped cancel on the auth sheet) is
  * swallowed since it's a routine dismissal, and all other errors are
  * re-thrown for the caller to handle.
+ *
+ * The native and web paths both forward marketing attribution. Electron does
+ * not: `window.vellum.auth.startOAuth` has no parameter for it yet.
  */
 export async function startAuthFlow(
   providerId: string,
@@ -377,6 +424,7 @@ export async function startAuthFlow(
 ): Promise<void> {
   if (isNativePlatform()) {
     try {
+      const attribution = await resolveNativeAttribution(options.attribution);
       await startNativeLogin({
         returnTo: resolveNativePostAuthDestination(
           options.intent,
@@ -384,6 +432,7 @@ export async function startAuthFlow(
         ),
         loginHint: options.loginHint,
         intent: options.intent,
+        attribution,
       });
     } catch (err) {
       // Capacitor translates native `call.reject(msg, code)` into a


### PR DESCRIPTION
## Why

Native (iOS + Android) signups land with no marketing attribution at all. `startAuthFlow`'s native branch computed `returnTo`, `loginHint`, and `intent` but dropped `options.attribution`, and `NativeAuthPlugin.startAuth` had no parameter to receive it. A Play install is worse still: it arrives with no URL params whatsoever, so the install referrer is the only attribution it ever carries.

This is the web half of the transport. The shell halves (PR 3 Android, PR 4 iOS) read `attribution` off the `startAuth` call and append it as query params on the `/_allauth/app/v1/auth/provider/token` POST, because allauth headless posts JSON and leaves `request.POST` empty, so the platform reads `request.GET`.

It is also the call site a Codex reviewer asked for on #41434: nothing called `captureInstallReferrer()` until now.

## What

- `NativeAuthPlugin.startAuth` and `startNativeLogin` both take an optional `attribution?: Record<string, string>`, spread in conditionally. With nothing to send, the call payload is byte-identical to today's, so a shell that predates the field is unaffected.
- New `resolveNativeAttribution()` picks **one** source: `options.attribution` or the current URL's allowlisted params if either yields a key, otherwise `captureInstallReferrer()` followed by `readStoredInstallReferrer()`.
- `completeNativeLogin()` clears the stored referrer once `waitForNativeSessionCookie()` confirms the session, before navigating.

## The two sources are never merged

`persist_attribution` on the platform treats a stored row as one coherent unit from a single source and must not be handed fields spliced from two, so a merged dict would violate that at the source. URL params win because they express the user's current, explicit campaign context; first touch across repeat signups is already protected server-side by the empty-row backfill guard.

Clearing happens on any successful native auth, not only signups: the client cannot tell signup from login at that point, and a retained referrer would otherwise attach this install's campaign to a different user signing up on the same device later. A failed or cancelled auth leaves the value in place for the next attempt.

## Out of scope

The Electron branch still does not forward attribution: `window.vellum.auth.startOAuth` has no parameter for it. That gap predates this change, needs a preload/main-process change on the desktop side, and is noted in the `startAuthFlow` docstring rather than fixed here. The web branch is untouched, since `startProviderRedirect` already forwards attribution.

## Testing

`native-auth.test.ts` now mocks the Capacitor bridge so the native branch is reachable, and covers: URL params forwarded, the Play referrer captured and forwarded when the URL has none, nothing sent when neither source has anything (asserted on the exact key set), one source never merged with the other, an explicit option outranking both, the stored referrer cleared on success, and left intact on both a thrown error and a user cancel. Each new assertion was verified to fail with the wiring removed.

`bun test` (native-auth, install-referrer, login-page, signup-page, social-auth), `bun run typecheck`, and `bun run lint` are clean.

Part of plan: android-install-referrer-attribution.md (PR 6 of 7)