### PR TITLE
fix(cli): retry repairable gateway refusals, matching the desktop classifier

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -562,6 +562,9 @@
     "packages/ipc-contract": {
       "name": "@vellumai/ipc-contract",
       "version": "0.0.1",
+      "dependencies": {
+        "@vellumai/service-contracts": "workspace:*",
+      },
       "devDependencies": {
         "@types/bun": "1.3.14",
         "typescript": "5.9.3",

--- a/cli/src/__tests__/connect-import.test.ts
+++ b/cli/src/__tests__/connect-import.test.ts
@@ -416,6 +416,43 @@ describe("connect import", () => {
     expect(loadGuardianToken("flaky-box")?.accessToken).toBe("acc-tok");
   });
 
+  test("retries a repairable gateway refusal and still imports", async () => {
+    process.argv = [
+      "bun",
+      "vellum",
+      "connect",
+      "import",
+      HOST,
+      "--name",
+      "repairing-box",
+    ];
+    let attempt = 0;
+    globalThis.fetch = (async (url: string) => {
+      if (url === CHALLENGE_URL) {
+        return jsonResponse(challengeBody());
+      }
+      attempt += 1;
+      // The gateway answers, but releases the code before a repairable
+      // failure, so the session stays pollable and the code is still good.
+      if (attempt === 1) {
+        return jsonResponse({ error: "guardian repair required" }, 503);
+      }
+      return jsonResponse(approvedBody());
+    }) as unknown as typeof fetch;
+    const { logs, restore } = captureLogs();
+    try {
+      await connectImport();
+    } finally {
+      restore();
+    }
+
+    expect(attempt).toBe(2);
+    expect(logs.join("\n")).toContain(
+      "Imported paired assistant 'repairing-box'",
+    );
+    expect(loadGuardianToken("repairing-box")?.accessToken).toBe("acc-tok");
+  });
+
   test("reports expiry once transient failures outlast the code", async () => {
     process.argv = ["bun", "vellum", "connect", "import", HOST];
     let exchanges = 0;

--- a/cli/src/commands/connect/import.ts
+++ b/cli/src/commands/connect/import.ts
@@ -15,9 +15,8 @@ import {
   pairingPoll,
   pairingStart,
   resolveConfigDir,
-  type PairingFailure,
-  type PairingFailureReason,
 } from "@vellumai/local-mode";
+import { isRetryablePairingReason } from "@vellumai/service-contracts/remote-web-pairing";
 
 import { extractFlag } from "../../lib/arg-utils.js";
 import { getLockfilePaths } from "../../lib/environments/paths.js";
@@ -59,33 +58,6 @@ EXAMPLES:
     vellum connect import https://your-assistant.ts.net
     vellum connect import https://your-assistant.ts.net --name desk
 `);
-}
-
-/**
- * Pairing failures worth another attempt. `unreachable` is the transport class
- * (a thrown fetch, a timeout, a refused redirect, a body that errored
- * mid-stream). `gateway-retryable` is a refusal the gateway answered but which
- * left the device code exchangeable, because the route releases the challenge
- * before a repairable failure. Local-mode keeps the session pollable for both,
- * so polling simply continues.
- *
- * Everything else is settled and ends the attempt. `invalid-address` and
- * `unknown-session` cannot resolve by waiting; `expired` and `import` mean the
- * one-time code is already spent; and `gateway` means the assistant answered
- * with something unusable (an over-cap body, or credentials this device cannot
- * persist) after spending the code, which is a definitive rejection.
- *
- * This set must stay in agreement with `RETRYABLE_PAIRING_REASONS` in
- * `clients/web/src/lib/local-mode.ts`, which classifies the same reasons for
- * the desktop dialog.
- */
-const RETRYABLE_PAIRING_REASONS: ReadonlySet<PairingFailureReason> = new Set([
-  "unreachable",
-  "gateway-retryable",
-]);
-
-function isRetryablePairingFailure(failure: PairingFailure): boolean {
-  return RETRYABLE_PAIRING_REASONS.has(failure.reason);
 }
 
 /** Caps a retry backoff so a long attempt still polls on a useful cadence. */
@@ -247,7 +219,10 @@ export async function connectImport(): Promise<void> {
       });
 
       if (!result.ok) {
-        if (!retryTransientFailures || !isRetryablePairingFailure(result)) {
+        if (
+          !retryTransientFailures ||
+          !isRetryablePairingReason(result.reason)
+        ) {
           console.error(formatImportFailure(result.status, result.error));
           process.exit(1);
         }

--- a/cli/src/commands/connect/import.ts
+++ b/cli/src/commands/connect/import.ts
@@ -62,20 +62,26 @@ EXAMPLES:
 }
 
 /**
- * Pairing failures worth another attempt: the assistant could not be reached
- * at all, which is the transport class (a thrown fetch, a timeout, a refused
- * redirect, a body that errored mid-stream). Local-mode leaves the session and
- * the device code untouched on those, so polling simply continues.
+ * Pairing failures worth another attempt. `unreachable` is the transport class
+ * (a thrown fetch, a timeout, a refused redirect, a body that errored
+ * mid-stream). `gateway-retryable` is a refusal the gateway answered but which
+ * left the device code exchangeable, because the route releases the challenge
+ * before a repairable failure. Local-mode keeps the session pollable for both,
+ * so polling simply continues.
  *
  * Everything else is settled and ends the attempt. `invalid-address` and
  * `unknown-session` cannot resolve by waiting; `expired` and `import` mean the
- * one-time code is already spent; and `gateway` means the assistant
- * ANSWERED with something unusable (an over-cap body, credentials this device
- * cannot persist, an unexpected status), which is a definitive rejection
- * rather than a dropped connection.
+ * one-time code is already spent; and `gateway` means the assistant answered
+ * with something unusable (an over-cap body, or credentials this device cannot
+ * persist) after spending the code, which is a definitive rejection.
+ *
+ * This set must stay in agreement with `RETRYABLE_PAIRING_REASONS` in
+ * `clients/web/src/lib/local-mode.ts`, which classifies the same reasons for
+ * the desktop dialog.
  */
 const RETRYABLE_PAIRING_REASONS: ReadonlySet<PairingFailureReason> = new Set([
   "unreachable",
+  "gateway-retryable",
 ]);
 
 function isRetryablePairingFailure(failure: PairingFailure): boolean {

--- a/clients/web/src/domains/onboarding/components/connect-assistant-dialog.test.tsx
+++ b/clients/web/src/domains/onboarding/components/connect-assistant-dialog.test.tsx
@@ -17,6 +17,10 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
+import {
+  isRetryablePairingReason,
+  type PairingFailureReason,
+} from "@vellumai/service-contracts/remote-web-pairing";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { ComponentProps, ReactNode } from "react";
 
@@ -31,15 +35,6 @@ type StartResult =
       intervalSeconds: number;
     }
   | { ok: false; error: string };
-
-type PairingFailureReason =
-  | "invalid-address"
-  | "unknown-session"
-  | "expired"
-  | "unreachable"
-  | "gateway-retryable"
-  | "gateway"
-  | "import";
 
 type PollResult =
   | { ok: true; status: "pending"; expiresAt: string; intervalSeconds: number }
@@ -76,15 +71,15 @@ const onImportedMock = mock((_assistantId: string) => {});
 
 // --- Mocks --------------------------------------------------------------------
 
-// Mirrors the real classifier, which is covered against every reason in
-// `src/lib/local-mode.test.ts`; restated here because this file replaces the
-// whole module rather than pulling its transport dependencies in.
+// This file replaces the whole module rather than pulling its transport
+// dependencies in, so the classifier is rebuilt from the shared reason table
+// the real one reads.
 mock.module("@/lib/local-mode", () => ({
   startAssistantPairing: startAssistantPairingMock,
   pollAssistantPairing: pollAssistantPairingMock,
   cancelAssistantPairing: cancelAssistantPairingMock,
   isRetryablePairingFailure: (failure: { reason?: PairingFailureReason }) =>
-    failure.reason === "unreachable" || failure.reason === "gateway-retryable",
+    isRetryablePairingReason(failure.reason),
 }));
 
 mock.module("@vellumai/design-library/components/button", () => ({

--- a/clients/web/src/lib/local-mode.ts
+++ b/clients/web/src/lib/local-mode.ts
@@ -3,6 +3,7 @@ import {
   isLoopbackGatewayCloud,
   isUsableRuntimeUrl,
 } from "@vellumai/local-mode/contract";
+import { isRetryablePairingReason } from "@vellumai/service-contracts/remote-web-pairing";
 
 import { getLocalSetting, setLocalSetting } from "@/utils/local-settings";
 import {
@@ -45,7 +46,6 @@ import type {
   LockfileAssistant,
   LocalAssistantResources,
   LocalPairingFailure,
-  LocalPairingFailureReason,
   LocalPairingPollResult,
   LocalPairingStartResult,
   LocalRetireResult,
@@ -507,37 +507,13 @@ export async function removePairedAssistantFromLockfile(
 const PAIRING_FALLBACK_ERROR = "Failed to connect to that assistant.";
 
 /**
- * Pairing failures worth another attempt, which are the two classes that leave
- * the device code exchangeable host-side:
- *
- * - `unreachable`, the transport class (a thrown fetch, a timeout, a refused
- *   redirect, a body that errored mid-stream). Nothing reached the assistant,
- *   so the session and the code are untouched.
- * - `gateway-retryable`, a non-200 the assistant answered with. The gateway
- *   releases the challenge on a repairable failure (a transient error, or the
- *   `GUARDIAN_REPAIR_REQUIRED` 503), so the same code stays exchangeable.
- *
- * Everything else is settled and ends the attempt. `invalid-address` and
- * `unknown-session` cannot resolve by waiting; `expired` and `import` mean the
- * one-time code is already spent; and `gateway` means the assistant answered
- * with something this device cannot use (an over-cap body, credentials it
- * cannot persist, a 200 that is not a pairing reply), past which the code is
- * spent rather than released.
- */
-const RETRYABLE_PAIRING_REASONS: ReadonlySet<LocalPairingFailureReason> =
-  new Set(["unreachable", "gateway-retryable"]);
-
-/**
- * Whether a refused pairing step is worth polling through. A host too old to
- * name a reason reads as settled, so an unlabelled failure ends the attempt
- * rather than spinning against a host that cannot say why it refused.
+ * Whether a refused pairing step is worth polling through, classified by the
+ * shared reason table so the dialog and `vellum connect import` cannot drift.
  */
 export function isRetryablePairingFailure(
   failure: LocalPairingFailure,
 ): boolean {
-  return (
-    failure.reason != null && RETRYABLE_PAIRING_REASONS.has(failure.reason)
-  );
+  return isRetryablePairingReason(failure.reason);
 }
 
 /**

--- a/packages/ipc-contract/package.json
+++ b/packages/ipc-contract/package.json
@@ -7,6 +7,9 @@
   "exports": {
     ".": "./src/index.ts"
   },
+  "dependencies": {
+    "@vellumai/service-contracts": "workspace:*"
+  },
   "peerDependencies": {
     "zod": ">=4.0.0"
   },

--- a/packages/ipc-contract/src/bridge.ts
+++ b/packages/ipc-contract/src/bridge.ts
@@ -15,6 +15,8 @@
  * interface; the renderer references the payload types (from `./types.ts`)
  * in its ambient declaration.
  */
+import type { PairingFailureReason } from "@vellumai/service-contracts/remote-web-pairing";
+
 import type {
   AppVersionInfo,
   AssistantStatus,
@@ -73,18 +75,13 @@ export interface LocalUpgradeOptions {
 export type ElectronHostOS = "macos" | "windows";
 
 /**
- * What a pairing step failed on, for callers picking recovery copy.
- * Structural duplicate of `@vellumai/local-mode`'s `PairingFailureReason`,
- * declared here for the same reason as {@link LocalPairedDeviceRecord}.
+ * What a pairing step failed on, for callers picking recovery copy. The
+ * bridge's name for `@vellumai/service-contracts`'s `PairingFailureReason`,
+ * which owns the union and the retryable classification read off it. That
+ * package is zod-only and environment-neutral, so the preload takes on nothing
+ * at runtime: this is a type-only import.
  */
-export type LocalPairingFailureReason =
-  | "invalid-address"
-  | "unknown-session"
-  | "expired"
-  | "unreachable"
-  | "gateway-retryable"
-  | "gateway"
-  | "import";
+export type LocalPairingFailureReason = PairingFailureReason;
 
 /** A refused pairing step. `error` is ready to display. */
 export interface LocalPairingFailure {

--- a/packages/local-mode/src/pair.ts
+++ b/packages/local-mode/src/pair.ts
@@ -6,6 +6,7 @@ import {
   REMOTE_WEB_PAIRING_CODE_TTL_MS,
   resolveRemoteWebPairingPlatform,
   tunnelProviderWebsiteName,
+  type PairingFailureReason,
   type PublicBaseUrlRejection,
   type RemoteWebPairingChallengeRequest,
   type RemoteWebPairingChallengeResponse,
@@ -335,28 +336,12 @@ const MAX_PAIRING_RESPONSE_BYTES = 64 * 1024;
 const PAIRING_CHALLENGE_PATH = "/v1/remote-web/pairing-challenge";
 const PAIRING_TOKEN_PATH = "/v1/remote-web/pairing-token";
 
-/** What a pairing attempt failed on, for callers picking recovery copy. */
-export type PairingFailureReason =
-  /** The pasted address is not a usable assistant address. */
-  | "invalid-address"
-  /** No live session for this handle: it was cancelled or never existed. */
-  | "unknown-session"
-  /** The device code expired, was denied, or was already spent. */
-  | "expired"
-  /** The assistant could not be reached. */
-  | "unreachable"
-  /**
-   * The assistant refused the request with a status that left the device code
-   * exchangeable, so the same session is worth another attempt.
-   */
-  | "gateway-retryable"
-  /**
-   * The assistant answered, but with a reply this device cannot use. The code
-   * behind it is spent or unknowable, so the attempt is settled.
-   */
-  | "gateway"
-  /** The credentials arrived, but registering them locally was refused. */
-  | "import";
+/**
+ * What a pairing attempt failed on. Defined by
+ * `@vellumai/service-contracts/remote-web-pairing`, which also owns the
+ * retryable classification every pairing surface reads.
+ */
+export type { PairingFailureReason };
 
 export interface PairingFailure {
   ok: false;

--- a/packages/service-contracts/src/__tests__/remote-web-pairing.test.ts
+++ b/packages/service-contracts/src/__tests__/remote-web-pairing.test.ts
@@ -4,9 +4,12 @@ import {
   buildRemoteWebPairingUrl,
   isLoopbackPublicUrl,
   isPrivateNetworkPublicUrl,
+  isRetryablePairingReason,
   parsePairingAddress,
   parseRemoteWebPairingParams,
   resolvePublicBaseUrl,
+  RETRYABLE_PAIRING_REASONS,
+  type PairingFailureReason,
   type PublicBaseUrlRejection,
 } from "../remote-web-pairing.js";
 
@@ -232,5 +235,53 @@ describe("resolvePublicBaseUrl localhost normalization", () => {
   ])("still resolves %s", (raw) => {
     expect(isLoopbackPublicUrl(raw)).toBe(false);
     expect(resolvePublicBaseUrl(raw)).toEqual({ ok: true, url: raw });
+  });
+});
+
+describe("isRetryablePairingReason", () => {
+  test.each([
+    // Nothing reached the assistant, so the session and code are untouched.
+    "unreachable",
+    // The assistant refused with a status that released the code.
+    "gateway-retryable",
+  ] as const)("%s is worth another attempt", (reason) => {
+    expect(isRetryablePairingReason(reason)).toBe(true);
+  });
+
+  test.each([
+    "invalid-address",
+    "unknown-session",
+    "expired",
+    // The assistant answered with something unusable, past which the code is
+    // spent rather than released.
+    "gateway",
+    "import",
+  ] as const)("%s settles the attempt", (reason) => {
+    expect(isRetryablePairingReason(reason)).toBe(false);
+  });
+
+  test("an absent reason settles the attempt", () => {
+    expect(isRetryablePairingReason(undefined)).toBe(false);
+    expect(isRetryablePairingReason(null)).toBe(false);
+  });
+
+  test("the exported set is exactly the reasons worth another attempt", () => {
+    const everyReason: PairingFailureReason[] = [
+      "invalid-address",
+      "unknown-session",
+      "expired",
+      "unreachable",
+      "gateway-retryable",
+      "gateway",
+      "import",
+    ];
+    expect(everyReason.filter(isRetryablePairingReason).sort()).toEqual([
+      "gateway-retryable",
+      "unreachable",
+    ]);
+    expect([...RETRYABLE_PAIRING_REASONS].sort()).toEqual([
+      "gateway-retryable",
+      "unreachable",
+    ]);
   });
 });

--- a/packages/service-contracts/src/remote-web-pairing.ts
+++ b/packages/service-contracts/src/remote-web-pairing.ts
@@ -619,3 +619,81 @@ export function parsePairingAddress(raw: string): ParsePairingAddressResult {
     deviceCode: parseRemoteWebPairingParams(raw).deviceCode,
   };
 }
+
+/**
+ * What a pairing attempt failed on, for callers picking recovery copy. Every
+ * pairing surface reports one of these: the host-side sessions in
+ * `@vellumai/local-mode`, the Electron bridge, the desktop connect dialog, and
+ * the `vellum connect import` CLI.
+ */
+export type PairingFailureReason =
+  /** The pasted address is not a usable assistant address. */
+  | "invalid-address"
+  /** No live session for this handle: it was cancelled or never existed. */
+  | "unknown-session"
+  /** The device code expired, was denied, or was already spent. */
+  | "expired"
+  /** The assistant could not be reached. */
+  | "unreachable"
+  /**
+   * The assistant refused the request with a status that left the device code
+   * exchangeable, so the same session is worth another attempt.
+   */
+  | "gateway-retryable"
+  /**
+   * The assistant answered, but with a reply this device cannot use. The code
+   * behind it is spent or unknowable, so the attempt is settled.
+   */
+  | "gateway"
+  /** The credentials arrived, but registering them locally was refused. */
+  | "import";
+
+/**
+ * Every reason, mapped to whether another attempt against the same session can
+ * still succeed. Two classes leave the device code exchangeable host-side:
+ *
+ * - `unreachable`, the transport class (a thrown fetch, a timeout, a refused
+ *   redirect, a body that errored mid-stream). Nothing reached the assistant,
+ *   so the session and the code are untouched.
+ * - `gateway-retryable`, a non-200 the assistant answered with. The gateway
+ *   releases the challenge before a repairable failure (a transient error, or
+ *   the `GUARDIAN_REPAIR_REQUIRED` 503), so the same code stays exchangeable.
+ *
+ * Everything else is settled and ends the attempt. `invalid-address` and
+ * `unknown-session` cannot resolve by waiting; `expired` and `import` mean the
+ * one-time code is already spent; and `gateway` means the assistant answered
+ * with something this device cannot use (an over-cap body, credentials it
+ * cannot persist, a 200 that is not a pairing reply), past which the code is
+ * spent rather than released.
+ *
+ * The `satisfies` clause keeps the map exhaustive, so a new reason does not
+ * compile until it is classified here.
+ */
+const PAIRING_REASON_RETRYABLE = {
+  "invalid-address": false,
+  "unknown-session": false,
+  expired: false,
+  unreachable: true,
+  "gateway-retryable": true,
+  gateway: false,
+  import: false,
+} satisfies Record<PairingFailureReason, boolean>;
+
+/** The reasons {@link isRetryablePairingReason} accepts. */
+export const RETRYABLE_PAIRING_REASONS: ReadonlySet<PairingFailureReason> =
+  new Set(
+    (Object.keys(PAIRING_REASON_RETRYABLE) as PairingFailureReason[]).filter(
+      (reason) => PAIRING_REASON_RETRYABLE[reason],
+    ),
+  );
+
+/**
+ * Whether a refused pairing step is worth another attempt. An unlabelled
+ * failure reads as settled, so a host too old to name a reason ends the
+ * attempt rather than being spun against until the code expires.
+ */
+export function isRetryablePairingReason(
+  reason: PairingFailureReason | null | undefined,
+): boolean {
+  return reason != null && RETRYABLE_PAIRING_REASONS.has(reason);
+}


### PR DESCRIPTION
## Summary
- `vellum connect import` now treats `gateway-retryable` as retryable, so a gateway refusal that left the device code exchangeable (a `GUARDIAN_REPAIR_REQUIRED` 503, say) keeps polling instead of ending the attempt.
- Brings the CLI's `RETRYABLE_PAIRING_REASONS` back into agreement with the desktop dialog's, which gained the new reason in #41408. The two branches were cut in parallel, so the CLI kept the pre-split set.
- Without this the CLI printed "Trying again may work" and then exited without trying again. The new test fails against the unpatched classifier with exactly that message.

Part of plan: zesty-wandering-nygaard.md (follow-up)