### PR TITLE
fix: report an unreadable lockfile as a host avatar read failure

### DIFF
--- a/packages/electron-desktop/src/local-mode.test.ts
+++ b/packages/electron-desktop/src/local-mode.test.ts
@@ -1377,6 +1377,15 @@ describe("vellum:localMode:readAssistantAvatar handler", () => {
     });
   });
 
+  test("reports a corrupt lockfile as a failure, not a conclusive none", () => {
+    fs.writeFileSync(lockfilePath, "{ not json");
+
+    expect(readAssistantAvatar("asst-1")).toEqual({
+      ok: false,
+      error: "lockfile unreadable",
+    });
+  });
+
   test("entry without an instanceDir reads the default dir from process.env", () => {
     const previousDataHome = process.env.XDG_DATA_HOME;
     const dataHome = fs.mkdtempSync(path.join(os.tmpdir(), "vellum-data-"));

--- a/packages/local-mode/src/__tests__/status.test.ts
+++ b/packages/local-mode/src/__tests__/status.test.ts
@@ -231,16 +231,18 @@ describe("getLocalAssistantStatus", () => {
 describe("resolveLockfileInstanceDir", () => {
   test("reads the instance dir from the parsed entry", () => {
     writeLocalLockfile();
-    expect(resolveLockfileInstanceDir([lockfilePath], "local-1", {})).toBe(
+    expect(resolveLockfileInstanceDir([lockfilePath], "local-1", {})).toEqual({
+      ok: true,
       instanceDir,
-    );
+    });
   });
 
   test("honors legacy top-level baseDataDir", () => {
     writeLockfile({ assistantId: "local-1", baseDataDir: instanceDir });
-    expect(resolveLockfileInstanceDir([lockfilePath], "local-1", {})).toBe(
+    expect(resolveLockfileInstanceDir([lockfilePath], "local-1", {})).toEqual({
+      ok: true,
       instanceDir,
-    );
+    });
   });
 
   test("falls back to the default instance dir for an entry without one", () => {
@@ -251,20 +253,23 @@ describe("resolveLockfileInstanceDir", () => {
         VELLUM_ENVIRONMENT: "production",
         XDG_DATA_HOME: dataHome,
       }),
-    ).toBe(path.join(dataHome, "vellum", "assistants", "local-1"));
+    ).toEqual({
+      ok: true,
+      instanceDir: path.join(dataHome, "vellum", "assistants", "local-1"),
+    });
   });
 
-  test("is undefined for a missing entry", () => {
+  test("has no instance dir for a missing entry", () => {
     writeLocalLockfile();
     expect(
       resolveLockfileInstanceDir([lockfilePath], "local-2", {
         VELLUM_ENVIRONMENT: "production",
         XDG_DATA_HOME: tempDir,
       }),
-    ).toBeUndefined();
+    ).toEqual({ ok: true });
   });
 
-  test("stops when the authoritative lockfile is unreadable", () => {
+  test("fails when the authoritative lockfile is unreadable", () => {
     const legacyPath = path.join(tempDir, "legacy.json");
     writeFileSync(lockfilePath, "{ not json");
     writeFileSync(
@@ -275,7 +280,7 @@ describe("resolveLockfileInstanceDir", () => {
     );
     expect(
       resolveLockfileInstanceDir([lockfilePath, legacyPath], "local-1", {}),
-    ).toBeUndefined();
+    ).toEqual({ ok: false });
   });
 
   test("empty authoritative lockfile never falls through to a legacy file", () => {
@@ -289,6 +294,6 @@ describe("resolveLockfileInstanceDir", () => {
     );
     expect(
       resolveLockfileInstanceDir([lockfilePath, legacyPath], "local-1", {}),
-    ).toBeUndefined();
+    ).toEqual({ ok: true });
   });
 });

--- a/packages/local-mode/src/avatar.test.ts
+++ b/packages/local-mode/src/avatar.test.ts
@@ -132,6 +132,12 @@ describe("readLockfileAssistantAvatar", () => {
     expect(read()).toEqual({ ok: true, avatar: null });
   });
 
+  test("corrupt lockfile is a failure, not a conclusive none", () => {
+    fs.writeFileSync(lockfilePath, "{ not json");
+
+    expect(read()).toEqual({ ok: false, error: "lockfile unreadable" });
+  });
+
   test("entry without an instanceDir reads the default instance dir", () => {
     writeLockfileEntry({ gatewayPort: 1, daemonPort: 2 });
     const defaultAvatarDir = path.join(

--- a/packages/local-mode/src/avatar.ts
+++ b/packages/local-mode/src/avatar.ts
@@ -11,9 +11,9 @@ import { resolveLockfileInstanceDir } from "./status";
 /**
  * A lockfile assistant's avatar as read off its workspace by a host.
  * `{ ok: true, avatar: null }` is a conclusive absence (no entry, no
- * workspace, no avatar); a file the manifest points at but the host cannot
- * serve (unreadable, oversized) is `ok: false` so callers keep their
- * last-seen avatar. Structurally identical to
+ * workspace, no avatar); an unreadable lockfile, or a file the manifest
+ * points at but the host cannot serve (unreadable, oversized), is `ok: false`
+ * so callers keep their last-seen avatar. Structurally identical to
  * `LocalReadAssistantAvatarResult` in `@vellumai/ipc-contract`, which this
  * package cannot depend on; hosts return it straight over IPC/HTTP.
  */
@@ -54,16 +54,15 @@ export function readLockfileAssistantAvatar(
   assistantId: string,
   env: Record<string, string | undefined>,
 ): LockfileAssistantAvatarResult {
-  const instanceDir = resolveLockfileInstanceDir(
-    lockfilePaths,
-    assistantId,
-    env,
-  );
-  if (!instanceDir) {
+  const resolved = resolveLockfileInstanceDir(lockfilePaths, assistantId, env);
+  if (!resolved.ok) {
+    return { ok: false, error: "lockfile unreadable" };
+  }
+  if (!resolved.instanceDir) {
     return { ok: true, avatar: null };
   }
   const avatar = readWorkspaceAvatar(
-    path.join(instanceDir, ".vellum", "workspace"),
+    path.join(resolved.instanceDir, ".vellum", "workspace"),
   );
   switch (avatar.kind) {
     case "character":

--- a/packages/local-mode/src/status.ts
+++ b/packages/local-mode/src/status.ts
@@ -270,35 +270,42 @@ function lockfileInstanceDir(
   );
 }
 
+export type LockfileInstanceDirResult =
+  | { ok: true; instanceDir?: string }
+  | { ok: false };
+
 /**
  * The instance directory for a lockfile entry: the persisted one (honoring
  * legacy `baseDataDir` entries the parsed contract drops), else the default
- * location status also falls back to. Undefined when the entry is missing or
- * the authoritative lockfile is unreadable.
+ * location status also falls back to. `instanceDir` is undefined when the
+ * entry is missing; `ok: false` when the authoritative lockfile is unreadable,
+ * so callers can tell absence from a failed read.
  */
 export function resolveLockfileInstanceDir(
   lockfilePaths: string[],
   assistantId: string,
   env: Record<string, string | undefined>,
-): string | undefined {
+): LockfileInstanceDirResult {
   const result = getLockfileData(lockfilePaths);
   if (!result.ok) {
-    return undefined;
+    return { ok: false };
   }
   const entry = result.data.assistants.find(
     (assistant) => assistant.assistantId === assistantId,
   );
   const rawEntry = findRawAssistant(result.raw, assistantId);
   if (!entry && !rawEntry) {
-    return undefined;
+    return { ok: true };
   }
   try {
-    return (
-      lockfileInstanceDir(entry, rawEntry) ??
-      defaultInstanceDir(env, assistantId)
-    );
+    return {
+      ok: true,
+      instanceDir:
+        lockfileInstanceDir(entry, rawEntry) ??
+        defaultInstanceDir(env, assistantId),
+    };
   } catch {
-    return undefined;
+    return { ok: true };
   }
 }
 


### PR DESCRIPTION
## Summary
Fixes a gap identified during plan review (round 3) for chooser-assistant-avatars.md.

**Gap:** a corrupt lockfile produced a conclusive null host avatar, evicting the last-seen cache entry for an assistant the same lockfile listed a moment earlier.

**Fix:** `resolveLockfileInstanceDir` now returns `{ ok: true, instanceDir? } | { ok: false }` so a failed authoritative read is distinguishable from a missing entry; `readLockfileAssistantAvatar` maps `ok: false` to `{ ok: false, error: "lockfile unreadable" }` and keeps `{ ok: true, avatar: null }` for a genuinely missing entry / no workspace. `getLocalAssistantStatus` is unchanged.

Tests: local-mode `avatar.test.ts` + `status.test.ts` (corrupt lockfile case), electron-desktop IPC handler test.