### PR TITLE
fix: drop avatar query entries on removal, scope live persistence to the active assistant, persist at the source

### DIFF
--- a/clients/web/src/assistant/retire-service.test.ts
+++ b/clients/web/src/assistant/retire-service.test.ts
@@ -7,6 +7,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { QueryClient } from "@tanstack/react-query";
 
 // --- mutable mock state (set per test) --- //
 
@@ -48,10 +49,11 @@ mock.module("@/lib/local-mode", () => ({
   retireLocalAssistant: retireLocalAssistantMock,
   syncPlatformAssistantsToLockfile: syncPlatformAssistantsToLockfileMock,
 }));
-const releaseRowAvatarUrlsMock = mock((_id: string) => {});
+const forgetAssistantAvatarMock = mock((_qc: QueryClient, _id: string) => {});
 mock.module("@/hooks/use-chooser-row-avatar", () => ({
-  releaseRowAvatarUrls: releaseRowAvatarUrlsMock,
+  forgetAssistantAvatar: forgetAssistantAvatarMock,
 }));
+const queryClient = new QueryClient();
 mock.module("@/stores/organization-store", () => ({
   useOrganizationStore: {
     getState: () => ({ currentOrganizationId: "org-test" }),
@@ -132,7 +134,7 @@ beforeEach(() => {
   retireAssistantByIdMock.mockClear();
   listAssistantsMock.mockClear();
   retireLocalAssistantMock.mockClear();
-  releaseRowAvatarUrlsMock.mockClear();
+  forgetAssistantAvatarMock.mockClear();
   syncPlatformAssistantsToLockfileMock.mockClear();
   removeMock.mockClear();
   clearResearchSnapshotMock.mockClear();
@@ -149,12 +151,12 @@ describe("retireAssistant", () => {
     storeAssistants = [{ id: "p1" }];
 
     // WHEN retiring it
-    const outcome = await retireAssistant("p1");
+    const outcome = await retireAssistant(queryClient, "p1");
 
     // THEN the platform delete ran with that id and the local path did not
     expect(retireAssistantByIdMock).toHaveBeenCalledWith("p1");
     expect(retireLocalAssistantMock).not.toHaveBeenCalled();
-    expect(releaseRowAvatarUrlsMock).toHaveBeenCalledWith("p1");
+    expect(forgetAssistantAvatarMock).toHaveBeenCalledWith(queryClient, "p1");
     expect(outcome.ok).toBe(true);
     if (outcome.ok) {
       expect(outcome.nextRoute).toBe("/assistant/onboarding/privacy");
@@ -167,7 +169,7 @@ describe("retireAssistant", () => {
     storeAssistants = [{ id: "p1" }];
 
     // WHEN retiring it
-    const outcome = await retireAssistant("p1");
+    const outcome = await retireAssistant(queryClient, "p1");
 
     // THEN the saved onboarding journey is discarded — a later onboarding must
     // start at the form, not resume the retired assistant's run deep in the
@@ -183,7 +185,7 @@ describe("retireAssistant", () => {
     retireByIdResult = { ok: false, status: 500, error: { detail: "boom" } };
 
     // WHEN retiring it
-    const outcome = await retireAssistant("p1");
+    const outcome = await retireAssistant(queryClient, "p1");
 
     // THEN the journey survives — the assistant still exists.
     expect(outcome.ok).toBe(false);
@@ -197,7 +199,7 @@ describe("retireAssistant", () => {
     storeAssistants = [{ id: "l1" }];
 
     // WHEN retiring it
-    const outcome = await retireAssistant("l1");
+    const outcome = await retireAssistant(queryClient, "l1");
 
     // THEN the local retire ran and the platform path did not
     expect(retireLocalAssistantMock).toHaveBeenCalledWith("l1");
@@ -212,7 +214,7 @@ describe("retireAssistant", () => {
     storeAssistants = [{ id: "pr1" }];
 
     // WHEN retiring it
-    const outcome = await retireAssistant("pr1");
+    const outcome = await retireAssistant(queryClient, "pr1");
 
     // THEN the guard fails fast: neither retire path ran and nothing was
     // cleaned up (the assistant still exists on its host machine).
@@ -235,7 +237,7 @@ describe("retireAssistant", () => {
     storeAssistants = [{ id: "p1" }];
 
     // WHEN retiring the platform target
-    const outcome = await retireAssistant("p1");
+    const outcome = await retireAssistant(queryClient, "p1");
 
     // THEN it uses the platform delete (not local) and re-syncs the lockfile
     expect(retireAssistantByIdMock).toHaveBeenCalledWith("p1");
@@ -252,7 +254,7 @@ describe("retireAssistant", () => {
     storeAssistants = [{ id: "p1" }];
     retireByIdResult = { ok: false, status: 404, error: {} };
 
-    const outcome = await retireAssistant("p1");
+    const outcome = await retireAssistant(queryClient, "p1");
 
     expect(outcome.ok).toBe(true);
   });
@@ -262,7 +264,7 @@ describe("retireAssistant", () => {
     storeAssistants = [{ id: "p1" }];
     retireByIdResult = { ok: false, status: 500, error: { detail: "boom" } };
 
-    const outcome = await retireAssistant("p1");
+    const outcome = await retireAssistant(queryClient, "p1");
 
     expect(outcome.ok).toBe(false);
     if (!outcome.ok) {
@@ -278,7 +280,7 @@ describe("retireAssistant", () => {
     ];
     storeAssistants = [{ id: "l1" }, { id: "p1" }];
 
-    const outcome = await retireAssistant("l1");
+    const outcome = await retireAssistant(queryClient, "l1");
 
     expect(outcome.ok).toBe(true);
     if (outcome.ok) {
@@ -291,7 +293,7 @@ describe("retireAssistant", () => {
     lockfileAssistants = [{ assistantId: "l1", cloud: "local" }];
     storeAssistants = [{ id: "l1" }];
 
-    const outcome = await retireAssistant("l1");
+    const outcome = await retireAssistant(queryClient, "l1");
 
     expect(outcome.ok).toBe(true);
     if (outcome.ok) {

--- a/clients/web/src/assistant/retire-service.ts
+++ b/clients/web/src/assistant/retire-service.ts
@@ -1,6 +1,7 @@
+import type { QueryClient } from "@tanstack/react-query";
+
 import { listAssistants, retireAssistantById } from "@/assistant/api";
-import { releaseRowAvatarUrls } from "@/hooks/use-chooser-row-avatar";
-import { deleteLastSeenAvatar } from "@/lib/avatar-last-seen-cache";
+import { forgetAssistantAvatar } from "@/hooks/use-chooser-row-avatar";
 import {
   getLockfile,
   isLocalAssistant,
@@ -61,6 +62,7 @@ function getPostRetireRoute(): string {
  * `{ ok: false, error }`.
  */
 export async function retireAssistant(
+  queryClient: QueryClient,
   assistantId: string,
 ): Promise<RetireOutcome> {
   try {
@@ -114,8 +116,7 @@ export async function retireAssistant(
     }
 
     useResolvedAssistantsStore.getState().remove(assistantId);
-    void deleteLastSeenAvatar(assistantId);
-    releaseRowAvatarUrls(assistantId);
+    forgetAssistantAvatar(queryClient, assistantId);
     // Retiring ends any in-flight onboarding journey with it: drop the
     // research-onboarding resume snapshot so the next onboarding starts at the
     // form instead of resuming the retired assistant's run deep in the flow

--- a/clients/web/src/assistant/switch-service.test.ts
+++ b/clients/web/src/assistant/switch-service.test.ts
@@ -7,6 +7,7 @@
  */
 
 import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { QueryClient } from "@tanstack/react-query";
 
 // --- mutable mock state (set per test) --- //
 
@@ -45,14 +46,11 @@ mock.module("@/lib/local-mode", () => ({
   removePairedAssistantFromLockfile: removePairedFromLockfileMock,
 }));
 
-const deleteLastSeenAvatarMock = mock(async (_id: string) => {});
-mock.module("@/lib/avatar-last-seen-cache", () => ({
-  deleteLastSeenAvatar: deleteLastSeenAvatarMock,
-}));
-const releaseRowAvatarUrlsMock = mock((_id: string) => {});
+const forgetAssistantAvatarMock = mock((_qc: QueryClient, _id: string) => {});
 mock.module("@/hooks/use-chooser-row-avatar", () => ({
-  releaseRowAvatarUrls: releaseRowAvatarUrlsMock,
+  forgetAssistantAvatar: forgetAssistantAvatarMock,
 }));
+const queryClient = new QueryClient();
 
 const connectPairedAssistantMock = mock(async (_id: string) => {
   if (connectPairedShouldThrow) {
@@ -112,8 +110,7 @@ beforeEach(() => {
   connectPlatformAssistantMock.mockClear();
   setSelectedAssistantMock.mockClear();
   setActiveAssistantIdMock.mockClear();
-  deleteLastSeenAvatarMock.mockClear();
-  releaseRowAvatarUrlsMock.mockClear();
+  forgetAssistantAvatarMock.mockClear();
 });
 
 describe("switchToAssistant", () => {
@@ -261,11 +258,10 @@ describe("removePairedAssistant", () => {
     selectedAssistant = { assistantId: "pr1" };
     activeAssistantId = "pr1";
 
-    const outcome = await removePairedAssistant("pr1");
+    const outcome = await removePairedAssistant(queryClient, "pr1");
 
     expect(removePairedFromLockfileMock).toHaveBeenCalledWith("pr1");
-    expect(deleteLastSeenAvatarMock).toHaveBeenCalledWith("pr1");
-    expect(releaseRowAvatarUrlsMock).toHaveBeenCalledWith("pr1");
+    expect(forgetAssistantAvatarMock).toHaveBeenCalledWith(queryClient, "pr1");
     expect(setActiveAssistantIdMock).toHaveBeenCalledWith(null);
     expect(outcome.ok).toBe(true);
     if (outcome.ok) {
@@ -283,7 +279,7 @@ describe("removePairedAssistant", () => {
     selectedAssistant = { assistantId: "m1" };
     activeAssistantId = "m1";
 
-    const outcome = await removePairedAssistant("pr1");
+    const outcome = await removePairedAssistant(queryClient, "pr1");
 
     expect(setActiveAssistantIdMock).not.toHaveBeenCalled();
     expect(outcome.ok).toBe(true);
@@ -297,14 +293,13 @@ describe("removePairedAssistant", () => {
     activeAssistantId = "pr1";
     removeFromLockfileResult = { ok: false, error: "host says no" };
 
-    const outcome = await removePairedAssistant("pr1");
+    const outcome = await removePairedAssistant(queryClient, "pr1");
 
     expect(outcome.ok).toBe(false);
     if (!outcome.ok) {
       expect(outcome.error).toBe("host says no");
     }
-    expect(deleteLastSeenAvatarMock).not.toHaveBeenCalled();
-    expect(releaseRowAvatarUrlsMock).not.toHaveBeenCalled();
+    expect(forgetAssistantAvatarMock).not.toHaveBeenCalled();
     expect(setActiveAssistantIdMock).not.toHaveBeenCalled();
   });
 
@@ -315,7 +310,7 @@ describe("removePairedAssistant", () => {
       throw new Error("ipc channel gone");
     });
 
-    const outcome = await removePairedAssistant("pr1");
+    const outcome = await removePairedAssistant(queryClient, "pr1");
 
     expect(outcome.ok).toBe(false);
     if (!outcome.ok) {

--- a/clients/web/src/assistant/switch-service.ts
+++ b/clients/web/src/assistant/switch-service.ts
@@ -1,6 +1,7 @@
+import type { QueryClient } from "@tanstack/react-query";
+
 import { setSelectedAssistant } from "@/assistant/selection";
-import { releaseRowAvatarUrls } from "@/hooks/use-chooser-row-avatar";
-import { deleteLastSeenAvatar } from "@/lib/avatar-last-seen-cache";
+import { forgetAssistantAvatar } from "@/hooks/use-chooser-row-avatar";
 import {
   getLockfileAssistant,
   getSelectedAssistant,
@@ -97,6 +98,7 @@ export type RemovePairedOutcome =
  * should route to the chooser (`nextRoute`); otherwise stay put (`null`).
  */
 export async function removePairedAssistant(
+  queryClient: QueryClient,
   assistantId: string,
 ): Promise<RemovePairedOutcome> {
   const wasSelected = getSelectedAssistant()?.assistantId === assistantId;
@@ -110,8 +112,7 @@ export async function removePairedAssistant(
   if (!result.ok) {
     return { ok: false, error: result.error ?? "Failed to remove assistant." };
   }
-  void deleteLastSeenAvatar(assistantId);
-  releaseRowAvatarUrls(assistantId);
+  forgetAssistantAvatar(queryClient, assistantId);
   const resolvedStore = useResolvedAssistantsStore.getState();
   if (resolvedStore.activeAssistantId === assistantId) {
     resolvedStore.setActiveAssistantId(null);

--- a/clients/web/src/domains/chat/components/assistant-switcher.test.tsx
+++ b/clients/web/src/domains/chat/components/assistant-switcher.test.tsx
@@ -63,7 +63,9 @@ mock.module("@/lib/sentry/capture-error", () => ({
 }));
 
 let selfHostedIngressUrl: string | null = null;
+const actualSelfHostedConnection = await import("@/lib/self-hosted/connection");
 mock.module("@/lib/self-hosted/connection", () => ({
+  ...actualSelfHostedConnection,
   getSelfHostedIngressUrl: () => selfHostedIngressUrl,
 }));
 
@@ -73,7 +75,9 @@ const avatarCalls: Array<
     { supportsManifest?: boolean; enabled?: boolean } | undefined,
   ]
 > = [];
+const actualAssistantAvatar = await import("@/hooks/use-assistant-avatar");
 mock.module("@/hooks/use-assistant-avatar", () => ({
+  ...actualAssistantAvatar,
   useAssistantAvatar: (
     id: string | null,
     options?: { supportsManifest?: boolean; enabled?: boolean },

--- a/clients/web/src/domains/chat/components/assistant-switcher.tsx
+++ b/clients/web/src/domains/chat/components/assistant-switcher.tsx
@@ -24,9 +24,9 @@ import { switchToResolvedAssistant } from "@/assistant/switch-service";
 import { useSwitchableAssistants } from "@/assistant/use-switchable-assistants";
 import { AssistantNavItem } from "@/domains/chat/components/assistant-nav-item";
 import { AssistantSwitcherRow } from "@/domains/chat/components/assistant-switcher-row";
+import { canFetchRowAvatarViaPlatformProxy } from "@/hooks/use-chooser-row-avatar";
 import { versionSupportsAvatarStateManifest } from "@/lib/backwards-compat/avatar-state-manifest";
 import { captureError } from "@/lib/sentry/capture-error";
-import { getSelfHostedIngressUrl } from "@/lib/self-hosted/connection";
 import { useConversationStore } from "@/stores/conversation-store";
 import type { ResolvedAssistant } from "@/stores/resolved-assistants-store";
 import { routes } from "@/utils/routes";
@@ -202,17 +202,6 @@ export function AssistantSwitcher({
     </button>
   );
 
-  /* A sibling's avatar is only fetchable where the request can actually be
-     addressed to it: through the platform proxy, which routes by the id in
-     the path. With a self-hosted ingress active, the interceptor rewrites
-     every daemon request to that single gateway whatever id the path
-     carries, and it would answer with the ACTIVE assistant's avatar; a
-     local or paired sibling has no per-id platform route either. Those
-     rows keep the fallback avatar instead of showing a wrong one. */
-  const selfHostedActive = getSelfHostedIngressUrl() !== null;
-  const canFetchSiblingAvatar = (sibling: ResolvedAssistant) =>
-    sibling.isPlatformHosted && !selfHostedActive;
-
   const expansion = expanded ? (
     <div
       id={listId}
@@ -251,7 +240,7 @@ export function AssistantSwitcher({
               supportsAvatarManifest={versionSupportsAvatarStateManifest(
                 assistant.runtimeVersion ?? assistant.currentReleaseVersion,
               )}
-              avatarEnabled={canFetchSiblingAvatar(assistant)}
+              avatarEnabled={canFetchRowAvatarViaPlatformProxy(assistant)}
               onSelect={() => void handleSwitch(assistant)}
             />
           ))}

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.test.tsx
@@ -13,15 +13,16 @@ import {
   act,
   cleanup,
   fireEvent,
-  render,
+  render as renderWithoutProviders,
   screen,
   waitFor,
 } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { ReactNode } from "react";
 
 import type * as ChooserAvatarChipModule from "@/components/avatar/chooser-avatar-chip";
-import type { AvatarRead } from "@/hooks/use-assistant-avatar";
+import type { AvatarRead } from "@/types/avatar";
 import type * as UseChooserRowAvatarModule from "@/hooks/use-chooser-row-avatar";
 import type { RememberedOrigin } from "@/stores/remembered-origins-store";
 import type { ResolvedAssistant } from "@/stores/resolved-assistants-store";
@@ -259,7 +260,7 @@ mock.module("@/domains/onboarding/components/add-remote-origin-dialog", () => ({
 const useChooserRowAvatarMock: Partial<typeof UseChooserRowAvatarModule> = {
   useChooserRowAvatar: (assistant) =>
     rowAvatars.get(assistant.id) ?? { traits: null, imageUrl: null },
-  releaseRowAvatarUrls: () => {},
+  forgetAssistantAvatar: () => {},
 };
 mock.module("@/hooks/use-chooser-row-avatar", () => useChooserRowAvatarMock);
 
@@ -415,6 +416,19 @@ const { __resetConnectDialogForTesting, useConnectDialogStore } = await import(
 const { SelectAssistantScreen } = await import(
   "@/domains/onboarding/pages/select-assistant-screen"
 );
+
+/** The screen reads the query client for post-removal avatar cleanup. */
+function render(ui: ReactNode) {
+  const queryClient = new QueryClient();
+  const withProviders = (node: ReactNode) => (
+    <QueryClientProvider client={queryClient}>{node}</QueryClientProvider>
+  );
+  const result = renderWithoutProviders(withProviders(ui));
+  return {
+    ...result,
+    rerender: (node: ReactNode) => result.rerender(withProviders(node)),
+  };
+}
 
 // --- Helpers ------------------------------------------------------------------
 

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
@@ -8,6 +8,7 @@ import {
   Plus,
 } from "lucide-react";
 import { type ReactNode, useEffect, useRef, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate, useSearchParams } from "react-router";
 
 import { refreshPlatformAssistantsIfStale } from "@/assistant/platform-assistants-sync";
@@ -162,6 +163,7 @@ function withoutRegisterParams(params: URLSearchParams): URLSearchParams {
 export function SelectAssistantScreen() {
   const { t } = useTranslation("onboarding");
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const [searchParams, setSearchParams] = useSearchParams();
   const fromLogin = searchParams.get("fromLogin") === "1";
   const noAutoSkip = searchParams.get("noAutoSkip") === "1";
@@ -471,7 +473,7 @@ export function SelectAssistantScreen() {
     setRecoveryPending(true);
     setRecoveryError(null);
     try {
-      const outcome = await retireAssistant(recoveryAssistant.id);
+      const outcome = await retireAssistant(queryClient, recoveryAssistant.id);
       if (outcome.ok) {
         clearRecoveryState();
         void navigate(outcome.nextRoute, { replace: true });
@@ -503,7 +505,7 @@ export function SelectAssistantScreen() {
       // The shared service owns the paired sequence (lockfile removal plus
       // lifecycle active-id cleanup); its chooser-route outcome is ignored
       // because this screen is already the chooser.
-      const outcome = await removePairedAssistant(removeTarget.id);
+      const outcome = await removePairedAssistant(queryClient, removeTarget.id);
       if (outcome.ok) {
         removedThisVisitRef.current = true;
         setRemoveTarget(null);

--- a/clients/web/src/domains/settings/components/retire-assistant.tsx
+++ b/clients/web/src/domains/settings/components/retire-assistant.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "react-router";
 
 import { retireAssistant } from "@/assistant/retire-service";
@@ -14,12 +15,13 @@ interface RetireAssistantProps {
 export function RetireAssistant({ assistantId }: RetireAssistantProps) {
   const { t } = useTranslation("settings");
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [isPending, setIsPending] = useState(false);
 
   const handleRetire = async () => {
     setIsPending(true);
-    const outcome = await retireAssistant(assistantId);
+    const outcome = await retireAssistant(queryClient, assistantId);
     if (outcome.ok) {
       setConfirmOpen(false);
       navigate(outcome.nextRoute, { replace: true });

--- a/clients/web/src/domains/settings/teleport/use-teleport.ts
+++ b/clients/web/src/domains/settings/teleport/use-teleport.ts
@@ -9,6 +9,7 @@
  */
 
 import { type MutableRefObject, useCallback, useRef, useState } from "react";
+import { type QueryClient, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "react-router";
 
 import { getAssistantHealthz, hatchAssistant } from "@/assistant/api";
@@ -94,6 +95,7 @@ export interface TeleportController {
 
 export function useTeleport(): TeleportController {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const source = getSelectedAssistant();
   const destination = resolveDestination(source?.cloud);
 
@@ -144,13 +146,14 @@ export function useTeleport(): TeleportController {
       // pre-check would then reject because it already exists. Clean it up the
       // same way Cancel does.
       await cleanupFreshTarget(
+        queryClient,
         targetRef.current,
         originalRef.current,
         "teleport-execute-cleanup",
       );
       targetRef.current = null;
     }
-  }, [source, destination, setStep, setProgress]);
+  }, [source, destination, setStep, setProgress, queryClient]);
 
   const requestTeleport = useCallback(() => setConfirmOpen(true), []);
   const cancelConfirm = useCallback(() => setConfirmOpen(false), []);
@@ -210,7 +213,7 @@ export function useTeleport(): TeleportController {
       // `retireAssistant` (the retire service) also reconciles the lockfile +
       // resolved-assistants store, so the retired source stops being selectable.
       if (original) {
-        void retireAssistant(original.id).then((result) => {
+        void retireAssistant(queryClient, original.id).then((result) => {
           if (!result.ok) {
             captureError(new Error(result.error), {
               context: "teleport-retire-source",
@@ -222,7 +225,7 @@ export function useTeleport(): TeleportController {
       reset();
       void navigate(routes.assistant, { replace: true });
     })();
-  }, [navigate, reset]);
+  }, [navigate, reset, queryClient]);
 
   const cancelTeleport = useCallback(() => {
     const target = targetRef.current;
@@ -235,8 +238,13 @@ export function useTeleport(): TeleportController {
     targetRef.current = null;
     originalRef.current = null;
     setPhase({ kind: "idle" });
-    void cleanupFreshTarget(target, original, "teleport-cancel-retire-target");
-  }, []);
+    void cleanupFreshTarget(
+      queryClient,
+      target,
+      original,
+      "teleport-cancel-retire-target",
+    );
+  }, [queryClient]);
 
   return {
     destination,
@@ -457,12 +465,13 @@ async function resolveLocalTargetRuntimeVersion(
  * store so the target stops being selectable.
  */
 async function cleanupFreshTarget(
+  queryClient: QueryClient,
   target: AssistantRef | null,
   original: AssistantRef | null,
   context: string,
 ): Promise<void> {
   if (target?.createdFresh) {
-    const result = await retireAssistant(target.id);
+    const result = await retireAssistant(queryClient, target.id);
     if (!result.ok) {
       captureError(new Error(result.error), { context });
     }

--- a/clients/web/src/hooks/use-assistant-avatar.test.tsx
+++ b/clients/web/src/hooks/use-assistant-avatar.test.tsx
@@ -12,7 +12,9 @@ import type {
 } from "@/types/avatar";
 import { avatarQueryKey } from "@/hooks/use-assistant-avatar";
 import { MIN_VERSION } from "@/lib/backwards-compat/avatar-state-manifest";
+import { chooserRowAvatarCacheQueryKey } from "@/lib/persist-last-seen-avatar";
 import { useAssistantIdentityStore } from "@/stores/assistant-identity-store";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 
 const components: CharacterComponents = {
   bodyShapes: [
@@ -100,10 +102,11 @@ mock.module(
 
 const { useAssistantAvatar } = await import("@/hooks/use-assistant-avatar");
 
-function createWrapper() {
-  const queryClient = new QueryClient({
+function createWrapper(
+  queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
-  });
+  }),
+) {
 
   return function Wrapper({ children }: { children: ReactNode }) {
     return (
@@ -116,11 +119,13 @@ beforeEach(() => {
   // Default to a manifest-capable assistant so the `/avatar/state` path is
   // exercised; legacy-path tests override the version explicitly.
   useAssistantIdentityStore.getState().setIdentity("test-asst", MIN_VERSION);
+  useResolvedAssistantsStore.getState().setActiveAssistantId("asst-1");
 });
 
 afterEach(() => {
   cleanup();
   useAssistantIdentityStore.getState().clearIdentity();
+  useResolvedAssistantsStore.getState().setActiveAssistantId(null);
   fetchCharacterComponents.mockClear();
   fetchAvatarState.mockClear();
   fetchAvatarImageUrlResult.mockClear();
@@ -167,6 +172,37 @@ describe("useAssistantAvatar", () => {
         );
       });
       expect(writeLastSeenAvatar).not.toHaveBeenCalled();
+    });
+
+    test("a persist invalidates the chooser's cache query for that id", async () => {
+      fetchAvatarState.mockResolvedValueOnce(characterState);
+      const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      });
+      const cacheKey = chooserRowAvatarCacheQueryKey("asst-1");
+      queryClient.setQueryData(cacheKey, { traits: null, imageUrl: null });
+      renderHook(() => useAssistantAvatar("asst-1"), {
+        wrapper: createWrapper(queryClient),
+      });
+      await waitFor(() => {
+        expect(writeLastSeenAvatar).toHaveBeenCalledTimes(1);
+      });
+      await waitFor(() => {
+        expect(queryClient.getQueryState(cacheKey)?.isInvalidated).toBe(true);
+      });
+    });
+
+    test("a sibling's read never touches the cache, only the active assistant's does", async () => {
+      fetchAvatarState.mockResolvedValueOnce(characterState);
+      const { result } = renderHook(() => useAssistantAvatar("asst-2"), {
+        wrapper: createWrapper(),
+      });
+      await waitFor(() => {
+        expect(result.current.traits).toEqual(traits);
+      });
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      expect(writeLastSeenAvatar).not.toHaveBeenCalled();
+      expect(deleteLastSeenAvatar).not.toHaveBeenCalled();
     });
 
     test("an inconclusive read touches nothing", async () => {

--- a/clients/web/src/hooks/use-assistant-avatar.ts
+++ b/clients/web/src/hooks/use-assistant-avatar.ts
@@ -10,7 +10,9 @@ import {
 import { useSupportsAvatarStateManifest } from "@/lib/backwards-compat/avatar-state-manifest";
 import { trackBlobUrl } from "@/lib/blob-url-tracker";
 import { persistLastSeenAvatar } from "@/lib/persist-last-seen-avatar";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import type {
+  AvatarRead,
   AvatarState,
   CharacterComponents,
   CharacterTraits,
@@ -49,11 +51,6 @@ export interface AssistantAvatarOptions {
    * `canFetchRowAvatarViaPlatformProxy` in `use-chooser-row-avatar`).
    */
   enabled?: boolean;
-}
-
-export interface AvatarRead {
-  traits: CharacterTraits | null;
-  imageUrl: string | null;
 }
 
 /**
@@ -184,7 +181,7 @@ export function useAssistantAvatar(
 
   const { data, isLoading, isSuccess } = useQuery<AvatarData>({
     queryKey: [...avatarQueryKey(assistantId ?? ""), supportsManifest],
-    queryFn: async () => {
+    queryFn: async ({ client }) => {
       const id = assistantId!;
       const [components, { traits, imageUrl }] = await Promise.all([
         fetchCharacterComponents(id),
@@ -204,7 +201,11 @@ export function useAssistantAvatar(
       trackBlobUrl(activeBlobUrls, id, imageUrl);
       // A resolved read is conclusive (both paths throw otherwise), so it is
       // what the chooser falls back to once this assistant is unreachable.
-      void persistLastSeenAvatar(id, { traits, imageUrl });
+      // Only the active assistant's read is trusted here: a sibling behind a
+      // transport that ignores the id would cache the wrong avatar.
+      if (id === useResolvedAssistantsStore.getState().activeAssistantId) {
+        void persistLastSeenAvatar(client, id, { traits, imageUrl });
+      }
 
       return { components, traits, customImageUrl: imageUrl };
     },

--- a/clients/web/src/hooks/use-chooser-row-avatar.test.tsx
+++ b/clients/web/src/hooks/use-chooser-row-avatar.test.tsx
@@ -145,6 +145,9 @@ const {
   releaseRowAvatarUrls,
   useChooserRowAvatar,
 } = await import("@/hooks/use-chooser-row-avatar");
+const { avatarQueryKey } = await import("@/hooks/use-assistant-avatar");
+const { chooserRowAvatarCacheQueryKey } =
+  await import("@/lib/persist-last-seen-avatar");
 
 /** Past the window a bare avatar stays fresh for. */
 const A_MINUTE_LATER = 61_000;
@@ -787,10 +790,51 @@ describe("useChooserRowAvatar", () => {
         expect(cached.result.current.imageUrl).toBe("blob:cached-image");
       });
 
-      releaseRowAvatarUrls("other");
+      releaseRowAvatarUrls(new QueryClient(), "other");
 
       expect(revokeObjectURL).toHaveBeenCalledWith("blob:row-image");
       expect(revokeObjectURL).toHaveBeenCalledWith("blob:cached-image");
+    });
+
+    test("drops the query entries that held the revoked urls", async () => {
+      const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      });
+      queryClient.setQueryData(
+        [...chooserRowAvatarQueryKeyPrefix("other"), "supported"],
+        { traits: null, imageUrl: "blob:row-image", conclusive: true },
+      );
+      queryClient.setQueryData(chooserRowAvatarCacheQueryKey("other"), {
+        traits: null,
+        imageUrl: "blob:cached-image",
+      });
+      queryClient.setQueryData([...avatarQueryKey("other"), true], {
+        components: null,
+        traits: null,
+        customImageUrl: "blob:live-image",
+      });
+      queryClient.setQueryData(chooserRowAvatarCacheQueryKey("kept"), {
+        traits,
+        imageUrl: null,
+      });
+
+      releaseRowAvatarUrls(queryClient, "other");
+
+      expect(
+        queryClient.getQueryData([
+          ...chooserRowAvatarQueryKeyPrefix("other"),
+          "supported",
+        ]),
+      ).toBeUndefined();
+      expect(
+        queryClient.getQueryData(chooserRowAvatarCacheQueryKey("other")),
+      ).toBeUndefined();
+      expect(
+        queryClient.getQueryData([...avatarQueryKey("other"), true]),
+      ).toBeUndefined();
+      expect(
+        queryClient.getQueryData(chooserRowAvatarCacheQueryKey("kept")),
+      ).toBeDefined();
     });
   });
 
@@ -890,7 +934,7 @@ describe("useChooserRowAvatar", () => {
       expect(writeLastSeenAvatar).not.toHaveBeenCalled();
     });
 
-    test("a legacy row whose sidecars are both absent evicts the cache and shows the glyph", async () => {
+    test("a legacy row whose sidecars are both absent keeps its cached avatar (the proxy 404s for an asleep sibling)", async () => {
       readLastSeenAvatar.mockResolvedValue({ kind: "character", traits });
       const { result } = renderHook(
         () =>
@@ -900,14 +944,14 @@ describe("useChooserRowAvatar", () => {
         { wrapper: createWrapper() },
       );
       await waitFor(() => {
-        expect(deleteLastSeenAvatar).toHaveBeenCalledWith(
-          "other",
-          expect.any(Number),
-        );
+        expect(fetchCharacterTraitsResult).toHaveBeenCalledTimes(1);
       });
-      expect(fetchCharacterTraitsResult).toHaveBeenCalledTimes(1);
+      await waitFor(() => {
+        expect(result.current.traits).toEqual(traits);
+      });
+      await settle();
+      expect(deleteLastSeenAvatar).not.toHaveBeenCalled();
       expect(writeLastSeenAvatar).not.toHaveBeenCalled();
-      expect(result.current).toEqual({ traits: null, imageUrl: null });
     });
 
     test("a manifest image whose content fails keeps the cached image and does not evict it", async () => {

--- a/clients/web/src/hooks/use-chooser-row-avatar.ts
+++ b/clients/web/src/hooks/use-chooser-row-avatar.ts
@@ -1,10 +1,9 @@
-import { useEffect } from "react";
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { type QueryClient, useQuery } from "@tanstack/react-query";
 
 import { fetchAvatarState } from "@/assistant/avatar-api";
 import {
-  type AvatarRead,
   type LegacyAvatarRead,
+  avatarQueryKey,
   fetchAvatarViaManifest,
   readAvatarViaLegacyFiles,
   releaseAssistantAvatarUrl,
@@ -13,12 +12,18 @@ import {
 } from "@/hooks/use-assistant-avatar";
 import { useIsOrgReady } from "@/hooks/use-is-org-ready";
 import { isGatewayAuthEnabled } from "@/lib/auth/gateway-session";
-import { readLastSeenAvatar } from "@/lib/avatar-last-seen-cache";
+import {
+  deleteLastSeenAvatar,
+  readLastSeenAvatar,
+} from "@/lib/avatar-last-seen-cache";
 import { versionSupportsAvatarStateManifest } from "@/lib/backwards-compat/avatar-state-manifest";
 import { trackBlobUrl } from "@/lib/blob-url-tracker";
 import { createGenerationGuard } from "@/lib/generation-guard";
 import { isLocalClient, isRemoteGatewayMode } from "@/lib/local-mode";
-import { persistLastSeenAvatar } from "@/lib/persist-last-seen-avatar";
+import {
+  chooserRowAvatarCacheQueryKey,
+  persistLastSeenAvatar,
+} from "@/lib/persist-last-seen-avatar";
 import { getSelfHostedIngressUrl } from "@/lib/self-hosted/connection";
 import {
   canReadAvatarFromLocalHost,
@@ -28,9 +33,9 @@ import {
   type ResolvedAssistant,
   useResolvedAssistantsStore,
 } from "@/stores/resolved-assistants-store";
+import type { AvatarRead } from "@/types/avatar";
 
 const QUERY_KEY_PREFIX = "chooserRowAvatar";
-const CACHE_QUERY_KEY_PREFIX = "chooserRowAvatarCache";
 
 type RowManifestSupport = "supported" | "unsupported" | "unknown";
 
@@ -69,10 +74,6 @@ function chooserRowAvatarHostQueryKey(assistantId: string) {
   return [...chooserRowAvatarQueryKeyPrefix(assistantId), "host"] as const;
 }
 
-function chooserRowAvatarCacheQueryKey(assistantId: string) {
-  return [CACHE_QUERY_KEY_PREFIX, assistantId] as const;
-}
-
 const EMPTY_AVATAR: AvatarRead = { traits: null, imageUrl: null };
 
 /**
@@ -93,13 +94,33 @@ const fetchGenerations = createGenerationGuard();
 
 /**
  * Revoke every object URL held for a removed assistant, across this module's
- * maps and the live hook's. The query entries themselves are left to React
- * Query's garbage collection.
+ * maps and the live hook's, and drop the query entries that hold those
+ * (now dead) `blob:` strings, or re-pairing the same id within gcTime would
+ * render a revoked image.
  */
-export function releaseRowAvatarUrls(assistantId: string): void {
+export function releaseRowAvatarUrls(
+  queryClient: QueryClient,
+  assistantId: string,
+): void {
   trackBlobUrl(activeBlobUrls, assistantId, null);
   trackBlobUrl(cachedBlobUrls, assistantId, null);
   releaseAssistantAvatarUrl(assistantId);
+  for (const queryKey of [
+    chooserRowAvatarQueryKeyPrefix(assistantId),
+    chooserRowAvatarCacheQueryKey(assistantId),
+    avatarQueryKey(assistantId),
+  ]) {
+    queryClient.removeQueries({ queryKey });
+  }
+}
+
+/** Full avatar cleanup for an assistant leaving this device: cache entry, URLs, queries. */
+export function forgetAssistantAvatar(
+  queryClient: QueryClient,
+  assistantId: string,
+): void {
+  void deleteLastSeenAvatar(assistantId);
+  releaseRowAvatarUrls(queryClient, assistantId);
 }
 
 /**
@@ -143,9 +164,12 @@ function conclusive(read: AvatarRead): LegacyAvatarRead {
 
 /**
  * A data URL sidesteps blob lifecycle management for host-sourced bytes.
- * A successful read with no avatar is a conclusive none; `ok: false` is not.
+ * A successful read with no avatar is a conclusive none that evicts the
+ * last-seen entry; `ok: false` is not. Host-disk reads are durable, so a
+ * found avatar never feeds the cache.
  */
 async function readRowAvatarViaHost(
+  queryClient: QueryClient,
   assistantId: string,
 ): Promise<LegacyAvatarRead> {
   const result = await readAssistantAvatarHost(assistantId);
@@ -153,6 +177,7 @@ async function readRowAvatarViaHost(
     return { ...EMPTY_AVATAR, conclusive: false };
   }
   if (result.avatar === null) {
+    void persistLastSeenAvatar(queryClient, assistantId, EMPTY_AVATAR);
     return conclusive(EMPTY_AVATAR);
   }
   return conclusive(
@@ -167,12 +192,11 @@ async function readRowAvatarViaHost(
 
 /**
  * Manifest reads for runtimes known to serve `/avatar/state`; legacy sidecar
- * reads for runtimes known not to. An unknown version probes the manifest
- * first and falls back to the sidecars when the probe fails, but a failed
- * probe may also mean the runtime is unreachable (the platform proxy answers
- * 404 for an asleep sibling), so an empty fallback read is inconclusive
- * there. A manifest that promises an image whose content fails throws
- * (never a false "none").
+ * reads for runtimes known not to (an unknown version probes the manifest
+ * first). The platform proxy answers 404 for an asleep sibling, so two
+ * sidecar 404s cannot be told from an unreachable runtime: an empty sidecar
+ * read is inconclusive here. A manifest that promises an image whose
+ * content fails throws (never a false "none").
  */
 async function fetchRowAvatar(
   assistant: ResolvedAssistant,
@@ -186,19 +210,20 @@ async function fetchRowAvatar(
     if (state !== null) {
       return conclusive(await resolveAvatarFromState(assistant.id, state));
     }
-    const legacy = await readAvatarViaLegacyFiles(assistant.id);
-    return isEmptyAvatar(legacy) ? { ...legacy, conclusive: false } : legacy;
   }
-  return readAvatarViaLegacyFiles(assistant.id);
+  const legacy = await readAvatarViaLegacyFiles(assistant.id);
+  return isEmptyAvatar(legacy) ? { ...legacy, conclusive: false } : legacy;
 }
 
 /**
  * Runs one fetch generation for `assistant`. A re-key (manifest support
  * flipping) can start a newer fetch while this one is in flight; when the
  * older one finishes last it must not revoke the URL the newer query renders,
- * so it drops its own blob instead.
+ * so it drops its own blob instead. A conclusive read is what the row falls
+ * back to once the assistant is unreachable, so it feeds the last-seen cache.
  */
 async function fetchRowAvatarGeneration(
+  queryClient: QueryClient,
   assistant: ResolvedAssistant,
   manifestSupport: RowManifestSupport,
 ): Promise<LegacyAvatarRead> {
@@ -211,6 +236,9 @@ async function fetchRowAvatarGeneration(
     return { ...avatar, imageUrl: null };
   }
   trackBlobUrl(activeBlobUrls, assistant.id, avatar.imageUrl);
+  if (avatar.conclusive) {
+    void persistLastSeenAvatar(queryClient, assistant.id, avatar);
+  }
   return avatar;
 }
 
@@ -240,8 +268,8 @@ async function readCachedRowAvatar(assistantId: string): Promise<AvatarRead> {
  *    read their workspace through the host when one can serve it.
  * 4. The last-seen cache: whatever a live source last resolved for this id,
  *    so a row keeps its avatar while the assistant is unreachable.
- * Only live sources (1 and 2) feed the cache (1 does so inside
- * `useAssistantAvatar`); a conclusive none from any source evicts it.
+ * Only live sources (1 and 2) feed the cache, at fetch time (1 does so
+ * inside `useAssistantAvatar`); a conclusive none from any source evicts it.
  * Anything else, including every failure, resolves to nulls: the row's glyph
  * fallback is the error state, a chooser row never surfaces an error.
  */
@@ -249,14 +277,14 @@ export function useChooserRowAvatar(assistant: ResolvedAssistant): AvatarRead {
   const activeAssistantId = useResolvedAssistantsStore.use.activeAssistantId();
   const isConnectedRow = assistant.id === activeAssistantId;
   const isOrgReady = useIsOrgReady();
-  const queryClient = useQueryClient();
 
   const connected = useAssistantAvatar(isConnectedRow ? assistant.id : null);
 
   const manifestSupport = rowManifestSupport(assistant);
   const rowQuery = useQuery<LegacyAvatarRead>({
     queryKey: chooserRowAvatarQueryKey(assistant.id, manifestSupport),
-    queryFn: () => fetchRowAvatarGeneration(assistant, manifestSupport),
+    queryFn: ({ client }) =>
+      fetchRowAvatarGeneration(client, assistant, manifestSupport),
     enabled:
       !isConnectedRow &&
       isOrgReady &&
@@ -284,13 +312,12 @@ export function useChooserRowAvatar(assistant: ResolvedAssistant): AvatarRead {
   const showLive =
     liveConclusive || (live !== undefined && !isEmptyAvatar(live));
 
-  // Host-disk reads are durable, so they render directly and never feed the
-  // last-seen cache; a conclusive none still evicts a stale entry. The
-  // connected row only needs one once its live read has settled empty.
+  // The connected row only needs a host read once its live read has
+  // settled empty.
   const liveSettledEmpty = !connected.isLoading && !showLive;
   const hostQuery = useQuery<LegacyAvatarRead>({
     queryKey: chooserRowAvatarHostQueryKey(assistant.id),
-    queryFn: () => readRowAvatarViaHost(assistant.id),
+    queryFn: ({ client }) => readRowAvatarViaHost(client, assistant.id),
     enabled:
       canReadRowAvatarViaHost(assistant) &&
       (!isConnectedRow || liveSettledEmpty),
@@ -302,25 +329,6 @@ export function useChooserRowAvatar(assistant: ResolvedAssistant): AvatarRead {
     !showLive &&
     hostQuery.data !== undefined &&
     (hostConclusive || !isEmptyAvatar(hostQuery.data));
-  const hostNone = hostConclusive && isEmptyAvatar(hostQuery.data);
-
-  const rowConclusive = !isConnectedRow && liveConclusive;
-  const syncCache = rowConclusive || hostNone;
-  const syncTraits = rowConclusive ? (live?.traits ?? null) : null;
-  const syncImageUrl = rowConclusive ? (live?.imageUrl ?? null) : null;
-  useEffect(() => {
-    if (!syncCache) {
-      return;
-    }
-    void persistLastSeenAvatar(assistant.id, {
-      traits: syncTraits,
-      imageUrl: syncImageUrl,
-    }).then(() =>
-      queryClient.invalidateQueries({
-        queryKey: chooserRowAvatarCacheQueryKey(assistant.id),
-      }),
-    );
-  }, [assistant.id, syncCache, syncTraits, syncImageUrl, queryClient]);
 
   const cacheQuery = useQuery<AvatarRead>({
     queryKey: chooserRowAvatarCacheQueryKey(assistant.id),

--- a/clients/web/src/lib/persist-last-seen-avatar.ts
+++ b/clients/web/src/lib/persist-last-seen-avatar.ts
@@ -1,13 +1,15 @@
+import type { QueryClient } from "@tanstack/react-query";
+
 import {
   deleteLastSeenAvatar,
   lastSeenAvatarGenerations,
   writeLastSeenAvatar,
 } from "@/lib/avatar-last-seen-cache";
-import type { CharacterTraits } from "@/types/avatar";
+import type { AvatarRead } from "@/types/avatar";
 
-export interface LiveAvatarResolution {
-  traits: CharacterTraits | null;
-  imageUrl: string | null;
+/** The chooser's query over the last-seen cache; invalidated after every persist. */
+export function chooserRowAvatarCacheQueryKey(assistantId: string) {
+  return ["chooserRowAvatarCache", assistantId] as const;
 }
 
 /**
@@ -16,12 +18,14 @@ export interface LiveAvatarResolution {
  * and the chooser's per-row fetch) so the cache fills whenever an avatar is
  * read, not only while the chooser is mounted. Claims a persistence generation
  * up front so a blob read that resolves after a newer write or delete
- * (including a retire) commits nothing. Best-effort like the cache: never
- * throws.
+ * (including a retire) commits nothing. Invalidates the chooser's cache query
+ * once committed so a row that falls back later reads the fresh entry.
+ * Best-effort like the cache: never throws.
  */
 export async function persistLastSeenAvatar(
+  queryClient: QueryClient,
   assistantId: string,
-  avatar: LiveAvatarResolution,
+  avatar: AvatarRead,
 ): Promise<void> {
   const generation = lastSeenAvatarGenerations.claim(assistantId);
   try {
@@ -46,5 +50,9 @@ export async function persistLastSeenAvatar(
     }
   } catch {
     // A blob that cannot be read back is simply not cached.
+    return;
   }
+  void queryClient.invalidateQueries({
+    queryKey: chooserRowAvatarCacheQueryKey(assistantId),
+  });
 }

--- a/clients/web/src/root-layout.tsx
+++ b/clients/web/src/root-layout.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { Outlet, useLocation, useNavigate } from "react-router";
 
 import { ShareFeedbackModalLazy } from "@/components/share-feedback-modal-lazy";
@@ -127,6 +128,7 @@ export function RootLayout() {
 
   const location = useLocation();
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const sessionStatus = useAuthStore.use.sessionStatus();
   const isSessionInitializing = useIsSessionInitializing();
   const hasPlatformSession = useHasPlatformSession();
@@ -437,7 +439,7 @@ export function RootLayout() {
       return;
     }
     setRemovePairedPending(true);
-    const outcome = await removePairedAssistant(removePairedId);
+    const outcome = await removePairedAssistant(queryClient, removePairedId);
     setRemovePairedPending(false);
     setRemovePairedId(null);
     if (!outcome.ok) {
@@ -454,7 +456,7 @@ export function RootLayout() {
       return;
     }
     setRetirePending(true);
-    const outcome = await retireAssistant(retireId);
+    const outcome = await retireAssistant(queryClient, retireId);
     if (outcome.ok) {
       setRetireId(null);
       setRetirePending(false);

--- a/clients/web/src/types/avatar.ts
+++ b/clients/web/src/types/avatar.ts
@@ -37,6 +37,12 @@ export type CharacterComponents = CharacterComponentsResponse;
 
 export type CharacterTraits = NonNullable<AvatarStateResponse["traits"]>;
 
+/** A resolved avatar render mode: character traits, a custom image url, or neither. */
+export interface AvatarRead {
+  traits: CharacterTraits | null;
+  imageUrl: string | null;
+}
+
 export function isCharacterTraits(value: unknown): value is CharacterTraits {
   if (typeof value !== "object" || value === null) {
     return false;


### PR DESCRIPTION
## Summary
Fixes gaps identified during plan review (round 3) for chooser-assistant-avatars.md.

**Gaps:** removed assistants left query entries holding revoked blob URLs; useAssistantAvatar persisted for any id; chooser cache query not invalidated after a live persist; unsupported-version double-404 evicted the cache; effect-based persist scaffolding