### PR TITLE
fix(memory): treat reference retrospective forks as having no copied prefix

### DIFF
--- a/assistant/src/__tests__/conversation-fork-referential.test.ts
+++ b/assistant/src/__tests__/conversation-fork-referential.test.ts
@@ -354,6 +354,63 @@ describe("referential forking", () => {
     expect(conversationIds()).toContain(source.id);
     expect(textOf(getMessages(source.id))).toHaveLength(4);
   });
+
+  test("loadRetrospectiveRunMessages attributes only owned rows on a reference fork", async () => {
+    const source = await seedSource("Launch");
+    setForkStrategy("reference");
+    const tip = getMessages(source.id).at(-1)!;
+    const fork = await forkConversationForRetrospective({
+      conversationId: source.id,
+      throughMessageId: tip.id,
+      conversationType: "background",
+      source: MEMORY_RETROSPECTIVE_FORK_SOURCE,
+    });
+
+    const instruction = await addMessage(
+      fork.id,
+      "user",
+      "review this conversation",
+      {
+        metadata: {
+          kind: MEMORY_RETROSPECTIVE_INSTRUCTION_KIND,
+          hidden: true,
+        },
+        skipIndexing: true,
+      },
+    );
+    const remember = await addMessage(fork.id, "assistant", "remembered a fact", {
+      skipIndexing: true,
+    });
+
+    const runRows = await loadRetrospectiveRunMessages(
+      fork.id,
+      MEMORY_RETROSPECTIVE_FORK_SOURCE,
+    );
+    expect(runRows?.map((m) => m.id)).toEqual([instruction.id, remember.id]);
+    expect(runRows?.every((m) => m.conversationId === fork.id)).toBe(true);
+  });
+
+  test("loadRetrospectiveRunMessages returns an empty owned tail on a reference fork with no run rows", async () => {
+    const source = await seedSource("Launch");
+    setForkStrategy("reference");
+    const tip = getMessages(source.id).at(-1)!;
+    const fork = await forkConversationForRetrospective({
+      conversationId: source.id,
+      throughMessageId: tip.id,
+      conversationType: "background",
+      source: MEMORY_RETROSPECTIVE_FORK_SOURCE,
+    });
+
+    // Lineage still presents the source prefix, but none of those rows are
+    // owned by the fork. Empty owned set is determined output, not
+    // indeterminate.
+    expect(getMessages(fork.id).length).toBeGreaterThan(0);
+    const runRows = await loadRetrospectiveRunMessages(
+      fork.id,
+      MEMORY_RETROSPECTIVE_FORK_SOURCE,
+    );
+    expect(runRows).toEqual([]);
+  });
 });
 
 describe("referential forking with unfinalized rows", () => {
@@ -420,62 +477,5 @@ describe("referential forking with unfinalized rows", () => {
       "here is a first pass",
       "tweak the timeline",
     ]);
-  });
-
-  test("loadRetrospectiveRunMessages attributes only owned rows on a reference fork", async () => {
-    const source = await seedSource("Launch");
-    setForkStrategy("reference");
-    const tip = getMessages(source.id).at(-1)!;
-    const fork = await forkConversationForRetrospective({
-      conversationId: source.id,
-      throughMessageId: tip.id,
-      conversationType: "background",
-      source: MEMORY_RETROSPECTIVE_FORK_SOURCE,
-    });
-
-    const instruction = await addMessage(
-      fork.id,
-      "user",
-      "review this conversation",
-      {
-        metadata: {
-          kind: MEMORY_RETROSPECTIVE_INSTRUCTION_KIND,
-          hidden: true,
-        },
-        skipIndexing: true,
-      },
-    );
-    const remember = await addMessage(fork.id, "assistant", "remembered a fact", {
-      skipIndexing: true,
-    });
-
-    const runRows = await loadRetrospectiveRunMessages(
-      fork.id,
-      MEMORY_RETROSPECTIVE_FORK_SOURCE,
-    );
-    expect(runRows?.map((m) => m.id)).toEqual([instruction.id, remember.id]);
-    expect(runRows?.every((m) => m.conversationId === fork.id)).toBe(true);
-  });
-
-  test("loadRetrospectiveRunMessages returns an empty owned tail on a reference fork with no run rows", async () => {
-    const source = await seedSource("Launch");
-    setForkStrategy("reference");
-    const tip = getMessages(source.id).at(-1)!;
-    const fork = await forkConversationForRetrospective({
-      conversationId: source.id,
-      throughMessageId: tip.id,
-      conversationType: "background",
-      source: MEMORY_RETROSPECTIVE_FORK_SOURCE,
-    });
-
-    // Lineage still presents the source prefix, but none of those rows are
-    // owned by the fork. Empty owned set is determined output, not
-    // indeterminate.
-    expect(getMessages(fork.id).length).toBeGreaterThan(0);
-    const runRows = await loadRetrospectiveRunMessages(
-      fork.id,
-      MEMORY_RETROSPECTIVE_FORK_SOURCE,
-    );
-    expect(runRows).toEqual([]);
   });
 });

--- a/assistant/src/__tests__/conversation-fork-referential.test.ts
+++ b/assistant/src/__tests__/conversation-fork-referential.test.ts
@@ -38,6 +38,11 @@ import {
   memoryRetrospectiveState,
   messages,
 } from "../persistence/schema/index.js";
+import {
+  MEMORY_RETROSPECTIVE_FORK_SOURCE,
+  MEMORY_RETROSPECTIVE_INSTRUCTION_KIND,
+} from "../plugins/defaults/memory/memory-retrospective-constants.js";
+import { loadRetrospectiveRunMessages } from "../plugins/defaults/memory/memory-retrospective-fork-boundary.js";
 import { getWorkspaceConfigPath } from "../util/platform.js";
 
 await initializeDb();
@@ -415,5 +420,62 @@ describe("referential forking with unfinalized rows", () => {
       "here is a first pass",
       "tweak the timeline",
     ]);
+  });
+
+  test("loadRetrospectiveRunMessages attributes only owned rows on a reference fork", async () => {
+    const source = await seedSource("Launch");
+    setForkStrategy("reference");
+    const tip = getMessages(source.id).at(-1)!;
+    const fork = await forkConversationForRetrospective({
+      conversationId: source.id,
+      throughMessageId: tip.id,
+      conversationType: "background",
+      source: MEMORY_RETROSPECTIVE_FORK_SOURCE,
+    });
+
+    const instruction = await addMessage(
+      fork.id,
+      "user",
+      "review this conversation",
+      {
+        metadata: {
+          kind: MEMORY_RETROSPECTIVE_INSTRUCTION_KIND,
+          hidden: true,
+        },
+        skipIndexing: true,
+      },
+    );
+    const remember = await addMessage(fork.id, "assistant", "remembered a fact", {
+      skipIndexing: true,
+    });
+
+    const runRows = await loadRetrospectiveRunMessages(
+      fork.id,
+      MEMORY_RETROSPECTIVE_FORK_SOURCE,
+    );
+    expect(runRows?.map((m) => m.id)).toEqual([instruction.id, remember.id]);
+    expect(runRows?.every((m) => m.conversationId === fork.id)).toBe(true);
+  });
+
+  test("loadRetrospectiveRunMessages returns an empty owned tail on a reference fork with no run rows", async () => {
+    const source = await seedSource("Launch");
+    setForkStrategy("reference");
+    const tip = getMessages(source.id).at(-1)!;
+    const fork = await forkConversationForRetrospective({
+      conversationId: source.id,
+      throughMessageId: tip.id,
+      conversationType: "background",
+      source: MEMORY_RETROSPECTIVE_FORK_SOURCE,
+    });
+
+    // Lineage still presents the source prefix, but none of those rows are
+    // owned by the fork. Empty owned set is determined output, not
+    // indeterminate.
+    expect(getMessages(fork.id).length).toBeGreaterThan(0);
+    const runRows = await loadRetrospectiveRunMessages(
+      fork.id,
+      MEMORY_RETROSPECTIVE_FORK_SOURCE,
+    );
+    expect(runRows).toEqual([]);
   });
 });

--- a/assistant/src/__tests__/conversation-fork-referential.test.ts
+++ b/assistant/src/__tests__/conversation-fork-referential.test.ts
@@ -401,9 +401,9 @@ describe("referential forking", () => {
       source: MEMORY_RETROSPECTIVE_FORK_SOURCE,
     });
 
-    // Lineage still presents the source prefix, but none of those rows are
-    // owned by the fork. Empty owned set is determined output, not
-    // indeterminate.
+    // Lineage still presents the source prefix (those rows keep the source
+    // conversationId). Empty owned set is determined output, not
+    // indeterminate, and does not need a conversation-row strategy lookup.
     expect(getMessages(fork.id).length).toBeGreaterThan(0);
     const runRows = await loadRetrospectiveRunMessages(
       fork.id,

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-fork-boundary.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-fork-boundary.ts
@@ -8,8 +8,9 @@
 // next run's dedup baseline). Lives in its own module so the sweep doesn't
 // have to import the job handler's full dependency graph.
 
-import { getMessages } from "@vellumai/plugin-api";
+import { getConversation, getMessages } from "@vellumai/plugin-api";
 
+import { isReferentialFork } from "../../../persistence/conversation-lineage.js";
 import { getLogger } from "./logging.js";
 import {
   MEMORY_RETROSPECTIVE_FORK_SOURCE,
@@ -76,21 +77,26 @@ function isRetrospectiveInstructionRow(metadata: string | null): boolean {
  * Load the messages a retrospective run produced itself, given the
  * retrospective conversation's `source` kind:
  *
- *   - **Fork-kind** rows carry the copied source prefix (the source's visible
- *     tail), so only the post-fork tail (messages strictly after the fork
- *     boundary) counts — scanning the whole row would attribute the source
- *     conversation's own turns to the retrospective. When no row carries a
- *     `forkSourceMessageId` stamp, the fork is run-authored end-to-end only
- *     if its first row is the run's own instruction message (the empty-prefix
- *     tail-only fork); a stampless fork WITHOUT a leading instruction row is
- *     indeterminate — attributing it would mine copied source tool calls as
- *     run output — and degrades to "produced none".
+ *   - **Fork-kind, referential** (`fork_strategy = "reference"`): the fork
+ *     copies no prefix. Inherited history is read through lineage and keeps
+ *     the source `conversationId`. Every row owned by the fork is the run's
+ *     own output, including when that set is empty.
+ *   - **Fork-kind, cloning**: rows carry the copied source prefix (the
+ *     source's visible tail), so only the post-fork tail (messages strictly
+ *     after the fork boundary) counts. Scanning the whole list would
+ *     attribute the source conversation's own turns to the retrospective.
+ *     When no row carries a `forkSourceMessageId` stamp, the fork is
+ *     run-authored end-to-end only if its first row is the run's own
+ *     instruction message (the empty-prefix tail-only fork). A stampless
+ *     fork WITHOUT a leading instruction row is indeterminate: attributing
+ *     it would mine copied source tool calls as run output, so the helper
+ *     degrades to "produced none".
  *   - **Legacy-kind** rows start empty, so every message is the run's own.
  *
  * Returns `null` when the run's output cannot be determined (message load
- * failure, or the indeterminate stampless shape above) — callers degrade
- * (empty dedup baseline / "no output"). Best-effort: failures are logged,
- * never thrown.
+ * failure, or the indeterminate stampless cloning shape above). Callers
+ * degrade (empty dedup baseline / "no output"). Best-effort: failures are
+ * logged, never thrown.
  */
 export async function loadRetrospectiveRunMessages(
   conversationId: string,
@@ -108,13 +114,28 @@ export async function loadRetrospectiveRunMessages(
   }
 
   if (source === MEMORY_RETROSPECTIVE_FORK_SOURCE) {
+    try {
+      const conversation = await getConversation(conversationId);
+      if (conversation && isReferentialFork(conversation)) {
+        // Referential forks copy nothing. Lineage-aware `getMessages` still
+        // returns the inherited source rows, which keep the source
+        // `conversationId`. Owned rows are the run.
+        return messages.filter((m) => m.conversationId === conversationId);
+      }
+    } catch (err) {
+      log.warn(
+        { err, retrospectiveConversationId: conversationId },
+        "memory-retrospective: failed to load retrospective conversation; falling back to copied-prefix boundary scan",
+      );
+    }
+
     const boundaryCreatedAt = findForkBoundaryCreatedAt(messages);
     if (boundaryCreatedAt == null) {
       if (messages.length === 0) {
         return messages;
       }
       if (isRetrospectiveInstructionRow(messages[0]?.metadata ?? null)) {
-        // Empty copied prefix — the run's instruction opens the conversation,
+        // Empty copied prefix. The run's instruction opens the conversation,
         // so every message is the run's own output.
         return messages;
       }

--- a/assistant/src/plugins/defaults/memory/memory-retrospective-fork-boundary.ts
+++ b/assistant/src/plugins/defaults/memory/memory-retrospective-fork-boundary.ts
@@ -8,9 +8,8 @@
 // next run's dedup baseline). Lives in its own module so the sweep doesn't
 // have to import the job handler's full dependency graph.
 
-import { getConversation, getMessages } from "@vellumai/plugin-api";
+import { getMessages } from "@vellumai/plugin-api";
 
-import { isReferentialFork } from "../../../persistence/conversation-lineage.js";
 import { getLogger } from "./logging.js";
 import {
   MEMORY_RETROSPECTIVE_FORK_SOURCE,
@@ -77,10 +76,11 @@ function isRetrospectiveInstructionRow(metadata: string | null): boolean {
  * Load the messages a retrospective run produced itself, given the
  * retrospective conversation's `source` kind:
  *
- *   - **Fork-kind, referential** (`fork_strategy = "reference"`): the fork
- *     copies no prefix. Inherited history is read through lineage and keeps
- *     the source `conversationId`. Every row owned by the fork is the run's
- *     own output, including when that set is empty.
+ *   - **Fork-kind, referential**: the fork copies no prefix. Inherited
+ *     history is read through lineage and keeps the source `conversationId`.
+ *     When no copied-row stamp is present, a mixed-ownership list is that
+ *     shape: rows owned by this conversation are the run, including when
+ *     that set is empty. No separate conversation-row lookup is required.
  *   - **Fork-kind, cloning**: rows carry the copied source prefix (the
  *     source's visible tail), so only the post-fork tail (messages strictly
  *     after the fork boundary) counts. Scanning the whole list would
@@ -88,9 +88,9 @@ function isRetrospectiveInstructionRow(metadata: string | null): boolean {
  *     When no row carries a `forkSourceMessageId` stamp, the fork is
  *     run-authored end-to-end only if its first row is the run's own
  *     instruction message (the empty-prefix tail-only fork). A stampless
- *     fork WITHOUT a leading instruction row is indeterminate: attributing
- *     it would mine copied source tool calls as run output, so the helper
- *     degrades to "produced none".
+ *     list where every row is owned by this conversation is the
+ *     indeterminate cloning shape: attributing it would mine copied source
+ *     tool calls as run output, so the helper degrades to "produced none".
  *   - **Legacy-kind** rows start empty, so every message is the run's own.
  *
  * Returns `null` when the run's output cannot be determined (message load
@@ -114,21 +114,6 @@ export async function loadRetrospectiveRunMessages(
   }
 
   if (source === MEMORY_RETROSPECTIVE_FORK_SOURCE) {
-    try {
-      const conversation = await getConversation(conversationId);
-      if (conversation && isReferentialFork(conversation)) {
-        // Referential forks copy nothing. Lineage-aware `getMessages` still
-        // returns the inherited source rows, which keep the source
-        // `conversationId`. Owned rows are the run.
-        return messages.filter((m) => m.conversationId === conversationId);
-      }
-    } catch (err) {
-      log.warn(
-        { err, retrospectiveConversationId: conversationId },
-        "memory-retrospective: failed to load retrospective conversation; falling back to copied-prefix boundary scan",
-      );
-    }
-
     const boundaryCreatedAt = findForkBoundaryCreatedAt(messages);
     if (boundaryCreatedAt == null) {
       if (messages.length === 0) {
@@ -138,6 +123,14 @@ export async function loadRetrospectiveRunMessages(
         // Empty copied prefix. The run's instruction opens the conversation,
         // so every message is the run's own output.
         return messages;
+      }
+      // Referential forks copy nothing. Lineage rows keep the source
+      // conversationId, so a mixed-ownership list is a reference fork and
+      // the owned rows are the run. A stampless list where every row is
+      // owned by this conversation is the indeterminate cloning shape.
+      const owned = messages.filter((m) => m.conversationId === conversationId);
+      if (owned.length < messages.length) {
+        return owned;
       }
       log.warn(
         { retrospectiveConversationId: conversationId },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan
`loadRetrospectiveRunMessages` assumed every fork-kind retrospective had a copied prefix stamped with `forkSourceMessageId`. `fork_strategy = "reference"` copies no rows. Lineage-aware `getMessages` still returns the inherited source history (those rows keep the source `conversationId`), so the helper treated a successful reference run as indeterminate and returned `null`.

A conversation-row `isReferentialFork` lookup is not required. The already-loaded message list carries ownership: a stampless mixed-ownership list is the reference shape, and the owned rows are the run.

## Summary
- When a fork-kind list has no copied-row stamps and some rows belong to another conversation, return the rows owned by the retrospective conversation (including an empty owned set).
- Leave the cloning stamp / leading-instruction path unchanged. A stampless list where every row is owned by this conversation is still the indeterminate cloning shape.
- No host import of `conversation-lineage` (plugin-import-boundary stays clean).

## Test plan
- `cd assistant && bun test src/__tests__/conversation-fork-referential.test.ts`
- `cd assistant && bun test src/__tests__/conversation-fork-retrospective.test.ts`
- Isolated `cd assistant && bun test src/plugins/defaults/memory/__tests__/memory-retrospective-job.test.ts`
- `cd assistant && bun test src/__tests__/plugin-import-boundary-guard.test.ts`

## Risk
Low. Cloning forks and mocked job stubs without mixed `conversationId`s keep the existing stamp scan. Empty owned tails return `[]` (produced none) instead of `null` (indeterminate).

No migrations, feature flags, or companion PRs.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a03da8-67cf-7922-8358-071529e12f23?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a03da8-67cf-7922-8358-071529e12f23&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

