### PR TITLE
Remember an Android paired origin when the connect link arrives

### DIFF
--- a/clients/android/README.md
+++ b/clients/android/README.md
@@ -126,12 +126,14 @@ absent. Scanning a connect link switches the native shell to the validated
 server, opens `<server>/assistant/pair`, and keeps an existing server path
 prefix intact. Cold and warm app launches use the same route.
 
-The server, with its label, joins the remembered list as soon as the link is
-scanned, matching iOS, so the chooser can still offer it when the pairing page
-never loads. Only the active slot is deferred: it is written after that page
-loads, so a server that turns out to be unreachable never displaces the one
-already working. The one-time device code is kept out of app preferences and
-the generated Capacitor configuration. HTTPS is required except for `localhost`,
+A server the list does not already hold joins it, with its label, as soon as
+the link is scanned, matching iOS, so the chooser can still offer it when the
+pairing page never loads. What a scan alone cannot claim is deferred until that
+page loads: the active slot, so an unreachable server never displaces the one
+already working, and the label on a server already remembered, so an unpaired
+link cannot rename a card that an earlier pairing named. The one-time device
+code is kept out of app preferences and the generated Capacitor configuration.
+HTTPS is required except for `localhost`,
 `127.0.0.1`, and the Android emulator host alias `10.0.2.2`. Use `adb reverse`
 when a physical development device needs to reach a service through
 `localhost`.

--- a/clients/android/README.md
+++ b/clients/android/README.md
@@ -130,13 +130,13 @@ A server the list does not already hold joins it, with its label, as soon as
 the link is scanned, matching iOS, so the chooser can still offer it when the
 pairing page never loads. What a scan alone cannot claim is deferred until that
 page loads: the active slot, so an unreachable server never displaces the one
-already working, and the label on a server already remembered, so an unpaired
-link cannot rename a card that an earlier pairing named. The one-time device
-code is kept out of app preferences and the generated Capacitor configuration.
-HTTPS is required except for `localhost`,
-`127.0.0.1`, and the Android emulator host alias `10.0.2.2`. Use `adb reverse`
-when a physical development device needs to reach a service through
-`localhost`.
+already working, and any label a server is already remembered under, so an
+unpaired link can fill in a missing name but cannot rewrite one an earlier
+pairing established. The one-time device code is kept out of app preferences
+and the generated Capacitor configuration. HTTPS is required except for
+`localhost`, `127.0.0.1`, and the Android emulator host alias `10.0.2.2`. Use
+`adb reverse` when a physical development device needs to reach a service
+through `localhost`.
 
 Paired servers accumulate in a remembered list, stored as JSON `{name?, url}`
 entries in the same `self_hosted_server` SharedPreferences file as the active

--- a/clients/android/README.md
+++ b/clients/android/README.md
@@ -126,10 +126,12 @@ absent. Scanning a connect link switches the native shell to the validated
 server, opens `<server>/assistant/pair`, and keeps an existing server path
 prefix intact. Cold and warm app launches use the same route.
 
-Only the validated server base is saved after the pairing page loads; the
-same deferred write appends the server, with its label, to the remembered
-list. The one-time device code is kept out of app preferences and the
-generated Capacitor configuration. HTTPS is required except for `localhost`,
+The server, with its label, joins the remembered list as soon as the link is
+scanned, matching iOS, so the chooser can still offer it when the pairing page
+never loads. Only the active slot is deferred: it is written after that page
+loads, so a server that turns out to be unreachable never displaces the one
+already working. The one-time device code is kept out of app preferences and
+the generated Capacitor configuration. HTTPS is required except for `localhost`,
 `127.0.0.1`, and the Android emulator host alias `10.0.2.2`. Use `adb reverse`
 when a physical development device needs to reach a service through
 `localhost`.
@@ -157,9 +159,13 @@ If Android terminates the app before the pairing page loads, scan the connect
 link again. The shell intentionally does not save the one-time code for process
 restoration.
 
-If a saved or newly scanned server cannot load, the native recovery dialog can
-retry it or clear the saved server and return to Vellum Cloud. A failed new
-server is never promoted over the last server that loaded successfully.
+If a saved or newly scanned server cannot load, whether the connection is
+refused outright or a tunnel provider answers on the server's behalf with its
+own error page, the native recovery dialog offers Retry or Choose Assistant.
+Choose Assistant clears the active slot and recreates onto the Vellum Cloud
+chooser, which lists every remembered server including the one that just
+failed. A failed new server is never promoted over the last server that loaded
+successfully.
 
 ## Biometric Session Recovery
 

--- a/clients/android/app/src/main/java/ai/vellum/assistant/MainActivity.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/MainActivity.java
@@ -285,7 +285,16 @@ public class MainActivity extends BridgeActivity {
         String raw = intent.getDataString();
         intent.setData(null);
         setIntent(withoutData(intent));
-        return ConnectDeepLink.parse(raw, getString(R.string.vellum_auth_scheme));
+        ConnectDeepLink connect = ConnectDeepLink.parse(raw, getString(R.string.vellum_auth_scheme));
+        if (connect != null) {
+            // Remember the origin the moment the link arrives, as iOS does: a
+            // tunnel already down never reaches onPageFinished, so one recorded
+            // only on success is one the chooser can never offer back. The
+            // active slot stays deferred, keeping a server that fails to load
+            // from displacing the one already working.
+            SelfHostedServer.append(this, connect.server(), connect.name());
+        }
+        return connect;
     }
 
     private boolean isConnectIntent(Intent intent) {
@@ -340,6 +349,11 @@ public class MainActivity extends BridgeActivity {
         bridge.getWebView().loadUrl(appLink.toASCIIString());
     }
 
+    /**
+     * Promote the pending server once its pair page loads. Only the active slot
+     * really moves: {@link #consumeConnectIntent} already remembered the origin,
+     * so activate's re-append only refreshes the label.
+     */
     private void finishPendingConnect(String loadedUrl) {
         if (
             pendingConnect == null ||

--- a/clients/android/app/src/main/java/ai/vellum/assistant/MainActivity.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/MainActivity.java
@@ -289,10 +289,10 @@ public class MainActivity extends BridgeActivity {
         if (connect != null) {
             // Remember the origin the moment the link arrives, as iOS does: a
             // tunnel already down never reaches onPageFinished, so one recorded
-            // only on success is one the chooser can never offer back. The
-            // active slot stays deferred, keeping a server that fails to load
-            // from displacing the one already working.
-            SelfHostedServer.append(this, connect.server(), connect.name());
+            // only on success is one the chooser can never offer back. What
+            // pairing still has to earn stays deferred, so an unreachable server
+            // neither displaces the active one nor relabels a card it already has.
+            SelfHostedServer.appendIfAbsent(this, connect.server(), connect.name());
         }
         return connect;
     }
@@ -350,9 +350,9 @@ public class MainActivity extends BridgeActivity {
     }
 
     /**
-     * Promote the pending server once its pair page loads. Only the active slot
-     * really moves: {@link #consumeConnectIntent} already remembered the origin,
-     * so activate's re-append only refreshes the label.
+     * Promote the pending server once its pair page loads: the active slot, plus
+     * the label that {@link #consumeConnectIntent} withheld from an origin the
+     * list already knew.
      */
     private void finishPendingConnect(String loadedUrl) {
         if (

--- a/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServer.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServer.java
@@ -177,15 +177,15 @@ final class SelfHostedServer {
     }
 
     /**
-     * Remember an origin only when the list does not already hold it, leaving a
-     * known origin's label alone. A label carried by a link that has not paired
-     * yet is unverified, so it must not overwrite one a pairing earned.
+     * Remember an origin, filling in a label it does not have yet but never
+     * replacing one. A label carried by a link that has not paired is
+     * unverified, so it must not overwrite one a pairing earned.
      */
     static void appendIfAbsent(Store store, URI url, String name) {
         remember(store, url, name, false);
     }
 
-    private static void remember(Store store, URI url, String name, boolean relabel) {
+    private static void remember(Store store, URI url, String name, boolean replaceLabel) {
         synchronized (listLock) {
             List<Entry> entries = servers(store);
             String canonical = canonicalString(url);
@@ -193,11 +193,12 @@ final class SelfHostedServer {
             int index = indexOfUrl(entries, canonical);
             if (index < 0) {
                 entries.add(new Entry(label, canonical));
-            } else if (relabel && label != null) {
+            } else if (label != null && (replaceLabel || entries.get(index).name == null)) {
                 entries.set(index, new Entry(label, canonical));
-            } else {
-                return;
             }
+            // Persist even when the list is unchanged: servers() folds a legacy
+            // active URL in as a synthetic entry, and until that is written down
+            // the active slot is its only copy, so clearing the slot drops it.
             persist(store, entries);
         }
     }

--- a/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServer.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/SelfHostedServer.java
@@ -169,6 +169,23 @@ final class SelfHostedServer {
      * updates the label; a nameless re-append keeps the existing one.
      */
     static void append(Store store, URI url, String name) {
+        remember(store, url, name, true);
+    }
+
+    static void appendIfAbsent(Context context, URI url, String name) {
+        appendIfAbsent(new PreferencesStore(context), url, name);
+    }
+
+    /**
+     * Remember an origin only when the list does not already hold it, leaving a
+     * known origin's label alone. A label carried by a link that has not paired
+     * yet is unverified, so it must not overwrite one a pairing earned.
+     */
+    static void appendIfAbsent(Store store, URI url, String name) {
+        remember(store, url, name, false);
+    }
+
+    private static void remember(Store store, URI url, String name, boolean relabel) {
         synchronized (listLock) {
             List<Entry> entries = servers(store);
             String canonical = canonicalString(url);
@@ -176,8 +193,10 @@ final class SelfHostedServer {
             int index = indexOfUrl(entries, canonical);
             if (index < 0) {
                 entries.add(new Entry(label, canonical));
-            } else if (label != null) {
+            } else if (relabel && label != null) {
                 entries.set(index, new Entry(label, canonical));
+            } else {
+                return;
             }
             persist(store, entries);
         }

--- a/clients/android/app/src/test/java/ai/vellum/assistant/SelfHostedServerTest.java
+++ b/clients/android/app/src/test/java/ai/vellum/assistant/SelfHostedServerTest.java
@@ -196,7 +196,7 @@ public class SelfHostedServerTest {
     }
 
     @Test
-    public void appendIfAbsentAddsUnknownOriginsAndLeavesKnownLabelsAlone() {
+    public void appendIfAbsentAddsUnknownOriginsAndKeepsTheLabelAPairingEarned() {
         FakeStore store = new FakeStore();
         URI server = SelfHostedServer.validate("https://example.com:443/assistant-123/");
 
@@ -211,6 +211,21 @@ public class SelfHostedServerTest {
         servers = SelfHostedServer.servers(store);
         assertEquals(1, servers.size());
         assertEquals("Living Room", servers.get(0).name);
+    }
+
+    @Test
+    public void appendIfAbsentWritesDownALegacyActiveOriginSoClearingKeepsIt() {
+        FakeStore store = new FakeStore();
+        URI server = SelfHostedServer.validate("https://example.com/assistant-123");
+        SelfHostedServer.store(store, server);
+        assertNull(store.servers);
+
+        SelfHostedServer.appendIfAbsent(store, server, "Living Room");
+        SelfHostedServer.clear(store);
+
+        List<SelfHostedServer.Entry> servers = SelfHostedServer.servers(store);
+        assertEquals(1, servers.size());
+        assertEquals(new SelfHostedServer.Entry("Living Room", "https://example.com/assistant-123"), servers.get(0));
     }
 
     @Test

--- a/clients/android/app/src/test/java/ai/vellum/assistant/SelfHostedServerTest.java
+++ b/clients/android/app/src/test/java/ai/vellum/assistant/SelfHostedServerTest.java
@@ -196,6 +196,24 @@ public class SelfHostedServerTest {
     }
 
     @Test
+    public void appendIfAbsentAddsUnknownOriginsAndLeavesKnownLabelsAlone() {
+        FakeStore store = new FakeStore();
+        URI server = SelfHostedServer.validate("https://example.com:443/assistant-123/");
+
+        SelfHostedServer.appendIfAbsent(store, server, "Living Room");
+
+        List<SelfHostedServer.Entry> servers = SelfHostedServer.servers(store);
+        assertEquals(1, servers.size());
+        assertEquals(new SelfHostedServer.Entry("Living Room", "https://example.com/assistant-123"), servers.get(0));
+
+        SelfHostedServer.appendIfAbsent(store, SelfHostedServer.validate("https://example.com/assistant-123"), "Kitchen");
+
+        servers = SelfHostedServer.servers(store);
+        assertEquals(1, servers.size());
+        assertEquals("Living Room", servers.get(0).name);
+    }
+
+    @Test
     public void readingDropsInvalidEntriesAndDedupesPreCanonicalDuplicates() {
         FakeStore store = new FakeStore();
         store.servers =


### PR DESCRIPTION
## Summary

- Android now appends a connect deep link's origin to the remembered-server list the moment the link is parsed, matching what iOS has always done in `AppDelegate.handleConnectDeepLink`. Previously that append happened only in `finishPendingConnect()`, once the pair page had loaded successfully.
- The deferral had a hole that #41437 made reachable: pairing against an already-down tunnel never gets to `onPageFinished`, so the new **Choose Assistant** escape recreated onto the cloud chooser with the server the user had just scanned missing from the list, and recovering meant rescanning the QR.
- The active slot stays deferred on purpose, so this is parity for the remembered list only. Android still refuses to promote a server that never loaded over the one already working, which iOS cannot do because its cold-launch boot reads the slot `instanceDescriptor()` sees. `clients/android/README.md` now documents that split instead of the old "same deferred write", and its recovery-dialog paragraph is refreshed for the Retry / Choose Assistant buttons #41437 shipped.

## Original prompt

Follow-up to #41437, which gave the phone a way out when a paired assistant's tunnel is down. Codex left a P2 on that PR ([discussion r3863401565](https://github.com/vellum-ai/vellum-assistant/pull/41437#discussion_r3863401565)) noting that Android never records a pending connect server until pairing succeeds, so the escape hatch that PR added drops it. The ask was to address that latent feedback and bring Android pairing to parity with iOS.

## Verification

Not built locally: this machine has no JDK or Android SDK (`/usr/bin/javac` is the macOS stub with no runtime behind it), so the `android-checks` matrix is the first compile.

Device QA worth doing before this ships: scan a connect QR pointing at a tunnel that is already down, confirm the unreachable dialog appears, tap **Choose Assistant**, and confirm the scanned assistant is listed on the chooser rather than gone.