### PR TITLE
fix(attribution): resolve attribution on every native entry and record referrer consumption

### DIFF
--- a/clients/android/app/src/main/java/ai/vellum/assistant/InstallReferrerPlugin.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/InstallReferrerPlugin.java
@@ -2,11 +2,14 @@ package ai.vellum.assistant;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.os.Handler;
+import android.os.Looper;
 import android.os.RemoteException;
 import com.android.installreferrer.api.InstallReferrerClient;
 import com.android.installreferrer.api.InstallReferrerStateListener;
 import com.android.installreferrer.api.ReferrerDetails;
 import com.getcapacitor.JSObject;
+import com.getcapacitor.Logger;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
@@ -17,27 +20,27 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * Exposes the Play Store install referrer, the only attribution a Play install
  * carries. {@code read} never rejects: an empty result is the answer when no
  * Play Store answers, so a sideloaded build takes the same path as a Play
- * install with no campaign.
+ * install with no campaign. Failures are logged, never reported: an absent or
+ * uncooperative Play Store is the normal state in development.
  */
 @CapacitorPlugin(name = "InstallReferrer")
 public class InstallReferrerPlugin extends Plugin {
     private static final String STATE_STORE = "install_referrer_state";
-    private static final String INSTALL_BEGIN_TIMESTAMP_KEY = "install_begin_timestamp";
     private static final String REFERRER_KEY = "referrer";
-    private static final String REFERRER_CLICK_TIMESTAMP_KEY = "referrer_click_timestamp";
     private static final String RESOLVED_KEY = "resolved";
+
+    /**
+     * Bound on the service bind. The web layer spends this value on the auth
+     * critical path, and a bind that connects but never calls back would
+     * otherwise leave the call unresolved for the life of the process.
+     */
+    private static final long BIND_TIMEOUT_MS = 5000L;
 
     @PluginMethod
     public void read(PluginCall call) {
         SharedPreferences store = stateStore();
         if (store.getBoolean(RESOLVED_KEY, false)) {
-            call.resolve(
-                payload(
-                    store.getString(REFERRER_KEY, ""),
-                    store.getLong(REFERRER_CLICK_TIMESTAMP_KEY, 0L),
-                    store.getLong(INSTALL_BEGIN_TIMESTAMP_KEY, 0L)
-                )
-            );
+            call.resolve(payload(store.getString(REFERRER_KEY, "")));
             return;
         }
 
@@ -45,6 +48,16 @@ public class InstallReferrerPlugin extends Plugin {
         // One connection can fire both setup-finished and service-disconnected,
         // and a call resolves once.
         final AtomicBoolean answered = new AtomicBoolean();
+        // A timed-out bind is transient, so it resolves empty without caching.
+        final Handler timeoutHandler = new Handler(Looper.getMainLooper());
+        timeoutHandler.postDelayed(
+            () -> {
+                if (!answered.getAndSet(true)) {
+                    finish(client, call, new JSObject(), timeoutHandler);
+                }
+            },
+            BIND_TIMEOUT_MS
+        );
         try {
             client.startConnection(
                 new InstallReferrerStateListener() {
@@ -57,23 +70,23 @@ public class InstallReferrerPlugin extends Plugin {
                         if (responseCode == InstallReferrerClient.InstallReferrerResponse.OK) {
                             result = readReferrer(client);
                         } else if (isTerminalStatus(responseCode)) {
-                            cache("", 0L, 0L);
+                            cache("");
                         }
-                        finish(client, call, result);
+                        finish(client, call, result, timeoutHandler);
                     }
 
                     @Override
                     public void onInstallReferrerServiceDisconnected() {
                         if (!answered.getAndSet(true)) {
-                            finish(client, call, new JSObject());
+                            finish(client, call, new JSObject(), timeoutHandler);
                         }
                     }
                 }
             );
         } catch (RuntimeException exception) {
-            NativeFailureGuard.record("Unable to bind the Play install referrer service", exception);
+            Logger.error("Unable to bind the Play install referrer service", exception);
             if (!answered.getAndSet(true)) {
-                finish(client, call, new JSObject());
+                finish(client, call, new JSObject(), timeoutHandler);
             }
         }
     }
@@ -95,27 +108,28 @@ public class InstallReferrerPlugin extends Plugin {
         try {
             details = client.getInstallReferrer();
         } catch (RemoteException | RuntimeException exception) {
-            NativeFailureGuard.record("Unable to read the Play install referrer", exception);
+            Logger.error("Unable to read the Play install referrer", exception);
             return new JSObject();
         }
         String referrer = details.getInstallReferrer();
-        long clickTimestamp = details.getReferrerClickTimestampSeconds();
-        long beginTimestamp = details.getInstallBeginTimestampSeconds();
-        cache(referrer, clickTimestamp, beginTimestamp);
-        return payload(referrer, clickTimestamp, beginTimestamp);
+        cache(referrer);
+        return payload(referrer);
     }
 
-    private void finish(InstallReferrerClient client, PluginCall call, JSObject result) {
-        NativeFailureGuard.run("Unable to close the Play install referrer connection", client::endConnection);
+    private void finish(InstallReferrerClient client, PluginCall call, JSObject result, Handler timeoutHandler) {
+        timeoutHandler.removeCallbacksAndMessages(null);
+        try {
+            client.endConnection();
+        } catch (RuntimeException exception) {
+            Logger.error("Unable to close the Play install referrer connection", exception);
+        }
         call.resolve(result);
     }
 
-    private void cache(String referrer, long clickTimestamp, long beginTimestamp) {
+    private void cache(String referrer) {
         stateStore()
             .edit()
             .putString(REFERRER_KEY, referrer == null ? "" : referrer)
-            .putLong(REFERRER_CLICK_TIMESTAMP_KEY, clickTimestamp)
-            .putLong(INSTALL_BEGIN_TIMESTAMP_KEY, beginTimestamp)
             .putBoolean(RESOLVED_KEY, true)
             .apply();
     }
@@ -124,14 +138,12 @@ public class InstallReferrerPlugin extends Plugin {
         return getContext().getSharedPreferences(STATE_STORE, Context.MODE_PRIVATE);
     }
 
-    private static JSObject payload(String referrer, long clickTimestamp, long beginTimestamp) {
+    private static JSObject payload(String referrer) {
         JSObject result = new JSObject();
         if (referrer == null || referrer.isEmpty()) {
             return result;
         }
         result.put("referrer", referrer);
-        result.put("referrerClickTimestampSeconds", clickTimestamp);
-        result.put("installBeginTimestampSeconds", beginTimestamp);
         return result;
     }
 }

--- a/clients/web/docs/CAPACITOR.md
+++ b/clients/web/docs/CAPACITOR.md
@@ -360,12 +360,13 @@ the web side is
 [`src/runtime/install-referrer.ts`](../src/runtime/install-referrer.ts). There
 is no iOS counterpart.
 
-- **`read()` never rejects.** It resolves
-  `{ referrer, referrerClickTimestampSeconds, installBeginTimestampSeconds }`
+- **`read()` never rejects, and always answers.** It resolves `{ referrer }`
   when Play answers with a referrer, and `{}` for every other outcome: no Play
   Store on the device, a Play Store that declines the bind, or a Play install
-  with no campaign. A rejection here would surface as an error on the auth
-  path, which is where the value is spent.
+  with no campaign. A bind that connects but never calls back is answered empty
+  by a timeout on each side (five seconds in the plugin, two in the web layer),
+  because the auth path that spends this value awaits the call. A rejection or
+  a hang here would surface as an error or a stuck sign-in button.
 - **The empty result is the answer.** There is no availability probe, for the
   same reason the voice bridge has none (§ "The skew rule"): a probe can itself
   be absent on an older shell, and `{}` is the only answer a caller could act
@@ -374,11 +375,21 @@ is no iOS counterpart.
 - **The shell caches the resolution, not its consumption.** A successful read
   and a status meaning this device's Play Store will never answer both land in
   the `install_referrer_state` preferences, so later launches skip the service
-  bind. A transient failure is left uncached, so a later launch retries.
+  bind. A transient failure, a timed-out bind included, is left uncached, so a
+  later launch retries.
 - **Consumption state belongs to the web layer.** The shell keeps answering
-  `read()` with the same value forever; the web layer captures it into device
-  storage once and drops it when a signup has spent it. Do not add a
-  "mark consumed" method to the bridge.
+  `read()` with the same value forever, so the spend has to be recorded where
+  the value is spent. The web layer captures the referrer into
+  `device:install_referrer` and empties that key once an auth flow has spent
+  it, keeping the key itself as the record: its presence, an empty value
+  included, is what stops a later signup on this device from re-reading the
+  bridge and inheriting the first user's campaign. Do not add a "mark consumed"
+  method to the bridge.
+- **Failures are logged, not reported.** The plugin logs through
+  `com.getcapacitor.Logger`, not `NativeFailureGuard`, whose reports the web
+  layer forwards to Sentry. A Play Store that is absent or declines the bind is
+  the normal path on every sideloaded, `dev`, and `staging` build, so a report
+  there is noise, not signal.
 - **No manifest permission.** The Play Install Referrer Library declares its
   own service binding, so `AndroidManifest.xml` needs no entry for this.
 

--- a/clients/web/src/lib/auth/session-cleanup.test.ts
+++ b/clients/web/src/lib/auth/session-cleanup.test.ts
@@ -132,6 +132,17 @@ describe("clearUserScopedStorage", () => {
     expect(localStorage.getItem("device:last_user_id")).toBe("user-123");
   });
 
+  test("preserves an emptied device: key", () => {
+    // A spent install referrer is recorded as an empty value under its
+    // `device:` key. Logout must leave the key in place: were it swept, the
+    // next signup on this device would re-read the shell's referrer.
+    localStorage.setItem("device:install_referrer", "");
+
+    clearUserScopedStorage();
+
+    expect(localStorage.getItem("device:install_referrer")).toBe("");
+  });
+
   test("automatically clears future vellum: keys without needing explicit registration", () => {
     localStorage.setItem("vellum:some-future-feature:asst-1", "data");
     localStorage.setItem("vellum:another-feature", "value");

--- a/clients/web/src/runtime/install-referrer.test.ts
+++ b/clients/web/src/runtime/install-referrer.test.ts
@@ -10,7 +10,7 @@ mock.module("@capacitor/core", () => ({
 
 const {
   captureInstallReferrer,
-  clearStoredInstallReferrer,
+  markInstallReferrerSpent,
   readStoredInstallReferrer,
 } = await import("./install-referrer");
 
@@ -85,13 +85,35 @@ test("reads the referrer at most once per install", async () => {
   await captureInstallReferrer();
   expect(read).toHaveBeenCalledTimes(1);
   expect(readStoredInstallReferrer()).toEqual({ utm_source: "newsletter" });
+});
 
-  clearStoredInstallReferrer();
+test("a spend does not re-arm the bridge", async () => {
+  read.mockResolvedValueOnce({ referrer: "utm_source=newsletter" });
+  await captureInstallReferrer();
+
+  markInstallReferrerSpent();
   expect(readStoredInstallReferrer()).toEqual({});
+  // The emptied key is the spend record, so the shell (which answers `read()`
+  // with the same referrer forever) is never asked again. Without it the next
+  // user to sign up on this device inherits the first user's campaign.
+  expect(localStorage.getItem(STORAGE_KEY)).toBe("");
+
+  read.mockResolvedValue({ referrer: "utm_source=newsletter" });
+  await captureInstallReferrer();
+  expect(read).toHaveBeenCalledTimes(1);
+  expect(readStoredInstallReferrer()).toEqual({});
+});
+
+test("a bridge that never answers stores nothing and stays retryable", async () => {
+  // A Play Store that binds without ever calling back would otherwise hold the
+  // auth flow that awaits this open forever.
+  read.mockImplementationOnce(
+    () => new Promise<{ referrer?: string }>(() => {}),
+  );
+  await captureInstallReferrer();
   expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
 
-  read.mockResolvedValueOnce({ referrer: "utm_source=retry" });
+  read.mockResolvedValueOnce({ referrer: "utm_source=newsletter" });
   await captureInstallReferrer();
-  expect(read).toHaveBeenCalledTimes(2);
-  expect(readStoredInstallReferrer()).toEqual({ utm_source: "retry" });
+  expect(readStoredInstallReferrer()).toEqual({ utm_source: "newsletter" });
 });

--- a/clients/web/src/runtime/install-referrer.ts
+++ b/clients/web/src/runtime/install-referrer.ts
@@ -4,9 +4,9 @@
  *
  * A user who taps a campaign link, lands in Play, and installs arrives in the
  * app with no URL params, so the referrer is the only attribution a Play
- * install carries. It is captured into device storage at startup and read back
- * when a signup posts attribution. Device scope is deliberate: the value
- * describes the physical install, not an account, so it survives logout.
+ * install carries. A native auth entry captures it into device storage on
+ * demand and spends it on the flow it posts. Device scope is deliberate: the
+ * value describes the physical install, not an account, so it survives logout.
  */
 
 import { Capacitor, registerPlugin } from "@capacitor/core";
@@ -14,43 +14,44 @@ import { Capacitor, registerPlugin } from "@capacitor/core";
 import { readAttributionParams } from "@/domains/account/social-auth";
 import {
   getDeviceSetting,
-  removeDeviceSetting,
+  hasDeviceSetting,
   setDeviceSetting,
 } from "@/utils/device-settings";
 
-type InstallReferrerResult = {
-  referrer?: string;
-  referrerClickTimestampSeconds?: number;
-  installBeginTimestampSeconds?: number;
-};
-
 interface InstallReferrerPlugin {
-  read(): Promise<InstallReferrerResult>;
+  read(): Promise<{ referrer?: string }>;
 }
 
 const InstallReferrer =
   registerPlugin<InstallReferrerPlugin>("InstallReferrer");
 
 /**
- * Read the Play install referrer once and persist its allowlisted params.
- * Safe to call on every startup: a stored value short-circuits the bridge.
+ * Bound on the bridge read. It sits on the auth critical path, so a Play
+ * Store that binds but never answers must not hold the sign-in button.
+ */
+const READ_TIMEOUT_MS = 2_000;
+
+/**
+ * Capture the Play install referrer into device storage, filtered to the
+ * allowlist. A missing plugin degrades to storing nothing, never an error
+ * (docs/CAPACITOR.md, "The skew rule").
  *
- * A missing plugin is an expected state, not an error. The shell ships on
- * Play's review cadence while this bundle goes live on every user's next
- * launch, so an older shell without the plugin is normal after any deploy
- * (docs/CAPACITOR.md, "The skew rule"). Nothing here reports to Sentry.
+ * The stored key's presence, an empty value included, is the record that this
+ * install's referrer has been asked for. The shell answers `read()` with the
+ * same value forever, so a spent referrer must never re-arm the bridge onto
+ * the next user to sign up here. A read that answers nothing stores nothing,
+ * leaving a later attempt free to retry.
  */
 export async function captureInstallReferrer(): Promise<void> {
   if (Capacitor.getPlatform() !== "android") {
     return;
   }
-  if (getDeviceSetting("installReferrer", "")) {
+  if (hasDeviceSetting("installReferrer")) {
     return;
   }
   try {
-    const { referrer } = await InstallReferrer.read();
     const attribution = new URLSearchParams(
-      readAttributionParams(referrer ?? ""),
+      readAttributionParams(await readReferrer()),
     ).toString();
     if (!attribution) {
       return;
@@ -58,6 +59,27 @@ export async function captureInstallReferrer(): Promise<void> {
     setDeviceSetting("installReferrer", attribution);
   } catch (error) {
     console.debug("[install-referrer] read unavailable:", error);
+  }
+}
+
+/** The shell's referrer, or `""` when it does not answer within the bound. */
+async function readReferrer(): Promise<string> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const { referrer } = await Promise.race([
+      InstallReferrer.read(),
+      new Promise<{ referrer?: string }>((resolve) => {
+        timer = setTimeout(() => {
+          console.debug(
+            `[install-referrer] read did not answer in ${READ_TIMEOUT_MS}ms`,
+          );
+          resolve({});
+        }, READ_TIMEOUT_MS);
+      }),
+    ]);
+    return referrer ?? "";
+  } finally {
+    clearTimeout(timer);
   }
 }
 
@@ -70,7 +92,11 @@ export function readStoredInstallReferrer(): Record<string, string> {
   return readAttributionParams(getDeviceSetting("installReferrer", ""));
 }
 
-/** Drop the captured referrer once it has been spent on a signup. */
-export function clearStoredInstallReferrer(): void {
-  removeDeviceSetting("installReferrer");
+/**
+ * Record that a native auth flow has spent the referrer. The emptied key stays
+ * behind as that record, so the next signup on this device starts
+ * unattributed instead of inheriting this install's campaign.
+ */
+export function markInstallReferrerSpent(): void {
+  setDeviceSetting("installReferrer", "");
 }

--- a/clients/web/src/runtime/native-auth.test.ts
+++ b/clients/web/src/runtime/native-auth.test.ts
@@ -50,6 +50,7 @@ const {
   clearStaleNativeCheckoutStash,
   resolveNativePostAuthDestination,
   startAuthFlow,
+  startNativeLogin,
 } = await import("./native-auth");
 const { clearCheckoutIntent, readCheckoutIntent, saveCheckoutIntent } =
   await import("@/lib/billing/checkout-intent");
@@ -399,7 +400,7 @@ describe("startAuthFlow attribution on native", () => {
     });
   });
 
-  test("clears the stored referrer once the session is real", async () => {
+  test("spends the stored referrer once the session is real", async () => {
     localStorage.setItem(INSTALL_REFERRER_KEY, "utm_source=google-play");
 
     await runSignup();
@@ -407,8 +408,37 @@ describe("startAuthFlow attribution on native", () => {
     expect(lastStartAuthOptions().attribution).toEqual({
       utm_source: "google-play",
     });
-    expect(localStorage.getItem(INSTALL_REFERRER_KEY)).toBeNull();
+    // Emptied, not removed: the key that remains is what keeps the shell from
+    // handing the same referrer to the next user who signs up here.
+    expect(localStorage.getItem(INSTALL_REFERRER_KEY)).toBe("");
     expect(window.location.href).toBe("/assistant/onboarding/privacy");
+  });
+
+  test("resolves attribution on the direct login entry too", async () => {
+    // `login-page.tsx` calls `startNativeLogin` itself, and it is the entry an
+    // unauthenticated fresh Play install actually reaches.
+    setLocation("?utm_source=newsletter&not_a_param=x");
+
+    await startNativeLogin({ returnTo: "/assistant/home" });
+
+    expect(lastStartAuthOptions().attribution).toEqual({
+      utm_source: "newsletter",
+    });
+  });
+
+  test("captures the install referrer on the direct login entry", async () => {
+    readInstallReferrer.mockResolvedValueOnce({
+      referrer: "utm_source=google-play&utm_medium=organic",
+    });
+
+    await startNativeLogin({ returnTo: "/assistant/home" });
+
+    expect(readInstallReferrer).toHaveBeenCalledTimes(1);
+    expect(lastStartAuthOptions().attribution).toEqual({
+      utm_source: "google-play",
+      utm_medium: "organic",
+    });
+    expect(localStorage.getItem(INSTALL_REFERRER_KEY)).toBe("");
   });
 
   test("leaves the stored referrer in place when native auth fails", async () => {

--- a/clients/web/src/runtime/native-auth.ts
+++ b/clients/web/src/runtime/native-auth.ts
@@ -18,7 +18,7 @@ import { setMenuPlatformSession } from "@/runtime/menu";
 import { primeElectronSessionToken } from "@/runtime/session-token";
 import {
   captureInstallReferrer,
-  clearStoredInstallReferrer,
+  markInstallReferrerSpent,
   readStoredInstallReferrer,
 } from "@/runtime/install-referrer";
 import {
@@ -134,6 +134,9 @@ export function useIsNativePlatform(): boolean {
  *
  * Throws on user cancellation (`USER_CANCELLED`) and any other error; the
  * caller decides whether to surface or swallow.
+ *
+ * `attribution` is an explicit override; absent it, this resolves the flow's
+ * attribution itself, so every native entry carries one.
  */
 export async function startNativeLogin(options?: {
   baseURL?: string;
@@ -149,6 +152,11 @@ export async function startNativeLogin(options?: {
   // resume checkout from privacy.
   clearStaleNativeCheckoutStash(options?.intent, options?.returnTo);
 
+  // Attribution resolves here for the same reason: the direct login form is
+  // the auth entry a fresh Play install reaches, and the install referrer is
+  // the only attribution such an install carries.
+  const attribution = await resolveNativeAttribution(options?.attribution);
+
   const baseURL = options?.baseURL ?? deriveAuthBaseURL();
   const destination = sanitizeReturnTo(
     options?.returnTo ?? null,
@@ -158,7 +166,7 @@ export async function startNativeLogin(options?: {
     baseURL,
     ...(options?.loginHint ? { loginHint: options.loginHint } : {}),
     ...(options?.intent ? { intent: options.intent } : {}),
-    ...(options?.attribution ? { attribution: options.attribution } : {}),
+    ...(attribution ? { attribution } : {}),
     postAuthDestination: destination,
   });
 
@@ -221,10 +229,10 @@ async function completeNativeLogin(
     await waitForNativeSessionCookie();
   }
 
-  // The referrer is spent: it rode this flow's `startAuth` call. Cleared on
+  // The referrer is spent: it rode this flow's `startAuth` call. Recorded on
   // login too, since we can't tell signup from login here and a retained value
   // would attach this install's campaign to the next user to sign up here.
-  clearStoredInstallReferrer();
+  markInstallReferrerSpent();
 
   // Persist the token in native secure storage for biometric session recovery.
   // Respects the user's opt-out preference; storeBiometricToken is also
@@ -378,9 +386,10 @@ export function clearStaleNativeCheckoutStash(
 /**
  * Attribution to hand the native shell, drawn from exactly one source.
  *
- * URL params win: they carry the user's current, explicit campaign context.
- * The Play install referrer is the fallback, and it is the only attribution a
- * Play install carries at all (such an install arrives with no URL params).
+ * A caller's override wins outright, then URL params: they carry the user's
+ * current, explicit campaign context. The Play install referrer is the
+ * fallback, and it is the only attribution a Play install carries at all (such
+ * an install arrives with no URL params).
  *
  * The two are never merged: `persist_attribution` on the platform stores a row
  * as one coherent unit from a single source, so it must not be handed fields
@@ -388,11 +397,11 @@ export function clearStaleNativeCheckoutStash(
  * the empty-row backfill guard.
  */
 async function resolveNativeAttribution(
-  attribution: Record<string, string> | undefined,
+  override: Record<string, string> | undefined,
 ): Promise<Record<string, string> | undefined> {
-  const fromUrl = attribution ?? readAttributionParams(window.location.search);
-  if (Object.keys(fromUrl).length > 0) {
-    return fromUrl;
+  const current = override ?? readAttributionParams(window.location.search);
+  if (Object.keys(current).length > 0) {
+    return current;
   }
   await captureInstallReferrer();
   const stored = readStoredInstallReferrer();
@@ -414,8 +423,7 @@ async function resolveNativeAttribution(
  * swallowed since it's a routine dismissal, and all other errors are
  * re-thrown for the caller to handle.
  *
- * The native and web paths both forward marketing attribution. Electron does
- * not: `window.vellum.auth.startOAuth` has no parameter for it yet.
+ * The native and web paths both forward marketing attribution.
  */
 export async function startAuthFlow(
   providerId: string,
@@ -424,7 +432,6 @@ export async function startAuthFlow(
 ): Promise<void> {
   if (isNativePlatform()) {
     try {
-      const attribution = await resolveNativeAttribution(options.attribution);
       await startNativeLogin({
         returnTo: resolveNativePostAuthDestination(
           options.intent,
@@ -432,7 +439,7 @@ export async function startAuthFlow(
         ),
         loginHint: options.loginHint,
         intent: options.intent,
-        attribution,
+        attribution: options.attribution,
       });
     } catch (err) {
       // Capacitor translates native `call.reject(msg, code)` into a

--- a/clients/web/src/utils/device-settings.ts
+++ b/clients/web/src/utils/device-settings.ts
@@ -17,7 +17,6 @@
  */
 
 import {
-  removeLocalSetting,
   setLocalBool,
   setLocalSetting,
   watchSetting,
@@ -58,7 +57,8 @@ const DEVICE_SETTINGS = {
   lastUserId: { key: "device:last_user_id" },
   // Allowlisted attribution parsed out of the Android Play install referrer,
   // stored as a query string. Describes the install, so it outlives any
-  // account that signs in on this device.
+  // account that signs in on this device. An empty value records that a native
+  // auth flow has spent it.
   installReferrer: { key: "device:install_referrer" },
 } as const satisfies Record<string, DeviceSettingEntry>;
 
@@ -89,9 +89,16 @@ export function setDeviceSetting(name: DeviceSettingName, value: string): void {
   setLocalSetting(DEVICE_SETTINGS[name].key, value);
 }
 
-/** Remove a device-scoped setting. Fires the `vellum:pref-changed` event for same-tab observers. */
-export function removeDeviceSetting(name: DeviceSettingName): void {
-  removeLocalSetting(DEVICE_SETTINGS[name].key);
+/** Whether a device-scoped setting is stored at all, an empty value included. */
+export function hasDeviceSetting(name: DeviceSettingName): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+  try {
+    return localStorage.getItem(DEVICE_SETTINGS[name].key) !== null;
+  } catch {
+    return false;
+  }
 }
 
 /** Read a boolean device setting. */


### PR DESCRIPTION
Self-review of the install-referrer attribution arc found four correctness gaps and two cleanups. This fixes all six on top of the feature branch.

**GAP 1 (critical): attribution never reached the wire on the real native entry point.** Attribution resolved only in `startAuthFlow`'s native branch, but a cold start on a fresh Play install lands on `/assistant` and is redirected to `/account/login`, whose `NativeLoginForm` calls `startNativeLogin` directly. That entry sent no attribution at all, so the Play install referrer never reached the platform. `resolveNativeAttribution` now runs inside `startNativeLogin`, beside the `clearStaleNativeCheckoutStash` call that was pushed down for the same bypass class; `startAuthFlow` passes only its explicit `options.attribution` through. Precedence is unchanged: explicit option, then URL params, then the stored install referrer, never a merge.

**GAP 2 (critical): consumption was never recorded, so the referrer leaked onto the next user.** The spend removed the device key, and capture treated an absent key as "not captured yet" and re-read the bridge, which by design answers with the same referrer forever. User B signing up on user A's device inherited A's campaign. The spend now writes an empty-string sentinel and capture gates on key presence rather than truthiness, so a spend is sticky. `device:`-prefixed keys are preserved by `session-cleanup.ts` regardless of value, covered by a new test there. `clearStoredInstallReferrer` is now `markInstallReferrerSpent`; the test that encoded the bug (asserting a second bridge read after a clear) is rewritten to assert a spend does not re-arm the bridge.

**GAP 3 (critical): the auth critical path awaited an unbounded native bridge call.** `InstallReferrerPlugin.read()` resolved its `PluginCall` only from setup-finished, service-disconnected, or the bind exception, so a bind that connects and never calls back left the JS promise pending forever: sign-in spins with no error and no Sentry event. Bounded on both sides. Web: `InstallReferrer.read()` races a two-second timeout resolving as "no referrer", following the `callBridge` pattern in `widget-snapshot.ts`; the timeout stores nothing, so a later launch retries. Android: a per-call `Handler` posts a five-second timeout that trips the existing `AtomicBoolean` guard and calls `finish(...)` with an empty `JSObject`, so the bind is torn down and the call resolves. The double-resolve guard and `endConnection()`-on-every-path behavior are intact, and a timeout is never cached.

**GAP 4: the plugin routed normal failures into Sentry.** `NativeFailureGuard.record` / `.run` enqueue into `NativeFailureReportStore`, which the web layer drains into `captureError`, contradicting this module's stated never-report invariant. Worst case was the `endConnection()` guard, which fires on the teardown path every non-Play device takes, the normal dev and staging path. The plugin now logs through `com.getcapacitor.Logger`, the same logger `NativeFailureGuard` itself uses for its log-only line.

**GAP 5 (cleanup): dead timestamp payload.** `referrerClickTimestampSeconds` and `installBeginTimestampSeconds` were read, cached under two dedicated SharedPreferences keys, put on the bridge result, declared in the TS type, and documented, with no reader anywhere. Dropped end to end; the cache is two keys and `payload()` is a `referrer`-only builder. The plugin unit test covers `isTerminalStatus` only and is unaffected.

**GAP 6 (cleanup): docs and comments describing things that do not exist.** The module header's "captured at startup" and "Safe to call on every startup" claims (there is no startup call site) now describe the lazy auth-time capture; the skew-rule re-derivation and the "Nothing here reports to Sentry" absence-note collapse to a one-line cross-reference; `startAuthFlow`'s "no parameter for it yet" Electron sentence is gone. `removeDeviceSetting` lost its only caller with GAP 2 and is replaced by `hasDeviceSetting`, the accessor GAP 2 needs.

`CAPACITOR.md` is corrected for the payload shape, the actual consumption scheme, the two timeouts, and the logging choice.

## Verification

- `bun test` on `install-referrer.test.ts` (8), `native-auth.test.ts` (23), `session-cleanup.test.ts` (12), `device-settings.test.ts` (7), `login-page.test.tsx` (22): all pass.
- `bun run typecheck` and `bun run lint` clean (lint: 0 errors, 15 pre-existing warnings in untouched files).
- Non-vacuous check: reverting the GAP 1 fix fails the two new direct-entry tests; reverting the GAP 2 presence gate to a truthiness gate fails "a spend does not re-arm the bridge". Both restored.
- Android JVM tests and lint run in CI; no JDK on this machine.