### PR TITLE
feat(web): run save-time validation on chat profile quick-add

### DIFF
--- a/clients/web/src/components/profile-quick-add-provider.test.tsx
+++ b/clients/web/src/components/profile-quick-add-provider.test.tsx
@@ -32,8 +32,9 @@ mock.module("@/stores/resolved-assistants-store", () => {
 
 // --- toast -------------------------------------------------------------------
 const toastSuccess = mock((_msg: string) => {});
+const toastWarning = mock((_msg: string) => {});
 mock.module("@vellumai/design-library/components/toast", () => ({
-  toast: { success: toastSuccess, error: () => {} },
+  toast: { success: toastSuccess, warning: toastWarning, error: () => {} },
 }));
 
 // --- ProfileEditorModal stub -------------------------------------------------
@@ -100,9 +101,19 @@ const configGetMock = mock(
     },
   }),
 );
+// The post-save probe. Mocked so a successful save never falls through to the
+// real HTTP client (which would dial a live daemon and run a billable probe).
+// Defaults to a passing check; the failed-check warning path is exercised in
+// the settings save-hook tests that own `probeSavedProfile`.
+const validateProfileMock = mock(
+  async (_opts: unknown): Promise<{ data: unknown }> => ({
+    data: { check: { ok: true } },
+  }),
+);
 mock.module("@/generated/daemon/sdk.gen", () => ({
   configGet: configGetMock,
   configPatch: configPatchMock,
+  inferenceProfilesByNameValidatePost: validateProfileMock,
 }));
 
 import {
@@ -146,6 +157,8 @@ beforeEach(() => {
   configPatchMock.mockClear();
   configGetMock.mockClear();
   configGetSetQueryDataMock.mockClear();
+  validateProfileMock.mockClear();
+  toastWarning.mockClear();
 });
 
 afterEach(() => {
@@ -192,6 +205,14 @@ describe("ProfileQuickAddProvider", () => {
       );
     });
     expect(screen.queryByTestId("modal-save-btn")).toBeNull();
+
+    // Fires the advisory post-save probe against the new profile.
+    await waitFor(() => {
+      expect(validateProfileMock).toHaveBeenCalledWith({
+        path: { assistant_id: "assistant-1", name: NEW_PROFILE_NAME },
+      });
+    });
+    expect(toastWarning).not.toHaveBeenCalled();
   });
 
   test("the save path reads the LATEST server config — appends to the server order, not the (stale/empty) opener input", async () => {
@@ -260,6 +281,8 @@ describe("ProfileQuickAddProvider", () => {
     expect(configPatchMock).not.toHaveBeenCalled();
     expect(toastSuccess).not.toHaveBeenCalled();
     expect(onCreated).not.toHaveBeenCalled();
+    // An aborted save must not probe a profile that was never written.
+    expect(validateProfileMock).not.toHaveBeenCalled();
     // The modal is still up, so the caller must not be told the flow is over.
     expect(onClosed).not.toHaveBeenCalled();
     expect(screen.getByTestId("modal-save-btn")).toBeTruthy();

--- a/clients/web/src/components/profile-quick-add-provider.tsx
+++ b/clients/web/src/components/profile-quick-add-provider.tsx
@@ -15,19 +15,19 @@
  * the feature-flag props, the create-persistence config PATCH, and the
  * success toast.
  *
- * The create-persistence here is a re-implementation, not a copy, of
- * the retired settings profile-save path: that code lived in the settings
- * domain and uses its `useDaemonConfigMutation` hook, which this provider
- * cannot import (`local/no-cross-domain-imports`). So it persists via the
- * generated SDK functions (`configGet`/`configPatch`), sources `profileOrder`
- * from a fresh authoritative server fetch (not a captured prop), and adds a
- * server-side duplicate-existence guard the modal does not have. See
- * `handleSave`.
+ * Persistence goes through the settings-owned `useLlmConfigPatch` mutation
+ * (allowed here — `local/no-cross-domain-imports` only restricts imports
+ * between peer domains, not from top-level dirs like this one), so the cache
+ * write and catalog invalidations match the settings save path. What differs
+ * from that path is create-flow hardening the modal's caller can't provide:
+ * `profileOrder` is sourced from a fresh authoritative server fetch (not a
+ * captured prop), and a server-side duplicate-existence guard rejects a name
+ * that already exists. See `handleSave`.
  *
  * `assistantId` and feature flags are read from top-level stores rather than
  * threaded through props, so the provider stays decoupled from any one domain.
  */
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import {
   createContext,
   useCallback,
@@ -41,11 +41,10 @@ import {
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import type { ProfilePatchEntryWritable } from "@/generated/daemon/types.gen";
 import { ProfileEditorModal } from "@/domains/settings/ai/profile-editor-modal";
-import { configGet, configPatch } from "@/generated/daemon/sdk.gen";
-import {
-  configGetSetQueryData,
-  inferenceProviderconnectionsGetOptions,
-} from "@/generated/daemon/@tanstack/react-query.gen";
+import { probeSavedProfile } from "@/domains/settings/ai/use-profile-save";
+import { useLlmConfigPatch } from "@/domains/settings/ai/use-llm-config-patch";
+import { configGet } from "@/generated/daemon/sdk.gen";
+import { inferenceProviderconnectionsGetOptions } from "@/generated/daemon/@tanstack/react-query.gen";
 import { useTranslation } from "@/i18n";
 import { toast } from "@vellumai/design-library/components/toast";
 
@@ -85,7 +84,7 @@ export function ProfileQuickAddProvider({ children }: { children: ReactNode }) {
   const { t } = useTranslation();
   const assistantId = useResolvedAssistantsStore.use.activeAssistantId();
 
-  const queryClient = useQueryClient();
+  const configMutation = useLlmConfigPatch(assistantId ?? "");
   const [isOpen, setIsOpen] = useState(false);
   const [existingNames, setExistingNames] = useState<string[]>([]);
   // Held in a ref so the modal's onSave closure always sees the latest caller
@@ -125,9 +124,9 @@ export function ProfileQuickAddProvider({ children }: { children: ReactNode }) {
   // Persist a freshly-created profile, then hand the name back to the caller.
   // Writes `llm.profiles[name]` plus an appended `profileOrder` in a single
   // config PATCH so the daemon records both the entry and its picker position.
-  // Uses generated SDK functions (`configGet`/`configPatch`) directly because
-  // this cross-domain provider can't import settings-domain hooks
-  // (`local/no-cross-domain-imports`).
+  // The PATCH goes through `useLlmConfigPatch`, whose onSuccess writes the
+  // merged config to the shared cache and invalidates the profile/call-site
+  // catalogs — same convergence as every settings-surface write.
   //
   // The order is computed from a FRESH server fetch rather than the
   // `profileOrder` captured when the modal opened. The caller may have opened
@@ -167,7 +166,7 @@ export function ProfileQuickAddProvider({ children }: { children: ReactNode }) {
         throw new Error(`A profile with the key "${name}" already exists.`);
       }
 
-      const patchResult = await configPatch({
+      await configMutation.mutateAsync({
         path: { assistant_id: assistantId },
         body: {
           llm: {
@@ -175,17 +174,7 @@ export function ProfileQuickAddProvider({ children }: { children: ReactNode }) {
             profileOrder: [...serverOrder, name],
           },
         },
-        throwOnError: true,
       });
-      // Write the PATCH response (full merged config) directly to the shared
-      // config query cache so all consumers see the new profile immediately.
-      if (patchResult.data) {
-        configGetSetQueryData(
-          queryClient,
-          { path: { assistant_id: assistantId } },
-          patchResult.data,
-        );
-      }
       // Hand back the display-name label alongside the key so the caller's
       // optimistic picker entry renders the Name immediately rather than
       // showing the key until the next config refetch. The create form derives
@@ -198,8 +187,9 @@ export function ProfileQuickAddProvider({ children }: { children: ReactNode }) {
       toast.success(
         t("profileQuickAddProvider.created", { name: label ?? name }),
       );
+      void probeSavedProfile(assistantId, name);
     },
-    [assistantId, queryClient, closePending, t],
+    [assistantId, configMutation, closePending, t],
   );
 
   const value = useMemo<ProfileQuickAddContextValue>(

--- a/clients/web/src/components/profile-quick-add-provider.tsx
+++ b/clients/web/src/components/profile-quick-add-provider.tsx
@@ -84,7 +84,7 @@ export function ProfileQuickAddProvider({ children }: { children: ReactNode }) {
   const { t } = useTranslation();
   const assistantId = useResolvedAssistantsStore.use.activeAssistantId();
 
-  const configMutation = useLlmConfigPatch(assistantId ?? "");
+  const configMutation = useLlmConfigPatch();
   const [isOpen, setIsOpen] = useState(false);
   const [existingNames, setExistingNames] = useState<string[]>([]);
   // Held in a ref so the modal's onSave closure always sees the latest caller

--- a/clients/web/src/domains/settings/ai/bulk-override-swap-modal.tsx
+++ b/clients/web/src/domains/settings/ai/bulk-override-swap-modal.tsx
@@ -76,7 +76,7 @@ export function BulkOverrideSwapModal({
   onApplied,
 }: BulkOverrideSwapModalProps) {
   const { t } = useTranslation("settings");
-  const configMutation = useLlmConfigPatch(assistantId);
+  const configMutation = useLlmConfigPatch();
   // Older assistants live-inherit blank profile fields, so a sparse profile
   // dispatches there and must not be filtered out of the target list.
   const requireOwnProviderAndModel = useSupportsCompleteProfileSnapshots();

--- a/clients/web/src/domains/settings/ai/overrides-detail-panel.tsx
+++ b/clients/web/src/domains/settings/ai/overrides-detail-panel.tsx
@@ -90,7 +90,7 @@ export function OverridesDetailPanel({
     [requireOwnProviderAndModel],
   );
 
-  const configMutation = useLlmConfigPatch(assistantId);
+  const configMutation = useLlmConfigPatch();
 
   const [search, setSearch] = useState("");
   const [saving, setSaving] = useState(false);

--- a/clients/web/src/domains/settings/ai/use-llm-config-patch.ts
+++ b/clients/web/src/domains/settings/ai/use-llm-config-patch.ts
@@ -16,10 +16,16 @@ import {
  * bulk swap) therefore converges on the same state regardless of which one
  * issued the write.
  */
-export function useLlmConfigPatch(assistantId: string) {
+export function useLlmConfigPatch() {
   const queryClient = useQueryClient();
   return useConfigPatchMutation({
-    onSuccess: (data) => {
+    // The assistant id comes from the mutation VARIABLES, not from a
+    // render-time prop: TanStack re-binds a pending mutation's options on
+    // rerender, so if the active assistant switches while a PATCH is in
+    // flight, a captured render-time id would file the old assistant's
+    // response under the new assistant's query key.
+    onSuccess: (data, variables) => {
+      const assistantId = variables.path.assistant_id;
       configGetSetQueryData(
         queryClient,
         { path: { assistant_id: assistantId } },

--- a/clients/web/src/domains/settings/ai/use-profile-actions.ts
+++ b/clients/web/src/domains/settings/ai/use-profile-actions.ts
@@ -50,7 +50,7 @@ export interface ProfileActions {
  * `makeActive`.
  */
 export function useProfileActions(assistantId: string): ProfileActions {
-  const configMutation = useLlmConfigPatch(assistantId);
+  const configMutation = useLlmConfigPatch();
   const queryClient = useQueryClient();
 
   // Make Default goes through the validated active-profile route on

--- a/clients/web/src/domains/settings/ai/use-profile-save.ts
+++ b/clients/web/src/domains/settings/ai/use-profile-save.ts
@@ -33,7 +33,7 @@ function toWritableEntry(entry: ProfileEntry): ProfilePatchEntryWritable {
  * transport error must not disturb the save flow, and a null check means the
  * daemon had no verdict to give.
  */
-async function probeSavedProfile(
+export async function probeSavedProfile(
   assistantId: string,
   name: string,
 ): Promise<void> {

--- a/clients/web/src/domains/settings/ai/use-profile-save.ts
+++ b/clients/web/src/domains/settings/ai/use-profile-save.ts
@@ -91,7 +91,7 @@ export function useProfileSave(
   assistantId: string,
   { onSaved }: { onSaved?: () => void } = {},
 ): ProfileSave {
-  const configMutation = useLlmConfigPatch(assistantId);
+  const configMutation = useLlmConfigPatch();
 
   const { data: config } = useQuery({
     ...configGetOptions({ path: { assistant_id: assistantId } }),


### PR DESCRIPTION
## Summary

The chat "+ New Profile" quick-add flow skipped the save-time validation the settings screen runs. This brings it to parity and cleans up the duplicated persistence plumbing:

- **Post-save live probe**: export `probeSavedProfile` from the settings save hook and fire it after the quick-add create persists, so a wrong model name or broken provider connection surfaces as a warning toast at save time instead of on the first chat message. Advisory and fire-and-forget, same as settings — an older daemon without the validate route stays silent.
- **Route the PATCH through `useLlmConfigPatch`** instead of raw `configPatch` + a hand-rolled `configGetSetQueryData` write. The hook's `onSuccess` also invalidates the effective-profile and call-site catalogs, which the manual path missed — previously a chat-created profile could show stale in settings until staleTime lapsed.
- **Fix stale comments** claiming `local/no-cross-domain-imports` blocks settings-hook imports here; the rule only restricts peer-domain imports, and this top-level provider already imports the settings modal.

The quick-add's create-flow hardening is intentionally kept: fresh server `configGet` for `profileOrder` sourcing and the server-side duplicate-name guard. The client-side budget check already applied to this flow via the shared `ProfileEditorModal`.

## Testing

- `bunx tsc --noEmit` clean
- `eslint` clean on both files (pre-commit hook)
- `bun test src/components/profile-quick-add-provider.test.tsx` — 8/8 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JKqJWBFqXvALTQ3qohmxzM
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41457" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->