### PR TITLE
feat(gateway): reply when a plugin sender fails the admission floor

### DIFF
--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -6,10 +6,11 @@
  * Invite code/token redemption is intercepted at gateway ingress; redeemed
  * messages never reach this stage.
  */
-import type {
-  AdmissionPolicy,
-  SourceMetadata,
-  TrustVerdict,
+import {
+  ACCESS_DENIED_NOT_APPROVED_REPLY,
+  type AdmissionPolicy,
+  type SourceMetadata,
+  type TrustVerdict,
 } from "@vellumai/gateway-client";
 
 import type { VerificationSessionWire } from "../../../channels/gateway-verification-sessions.js";
@@ -78,7 +79,7 @@ export function composeAccessDenialReply(params: {
   if (params.guardianNotified) {
     return `Hmm looks like you don't have access to talk to me. I'll let ${resolveGuardianLabel(params.verdict)} know you tried talking to me and get back to you.`;
   }
-  return "Sorry, you haven't been approved to message this assistant.";
+  return ACCESS_DENIED_NOT_APPROVED_REPLY;
 }
 
 // ---------------------------------------------------------------------------
@@ -880,8 +881,7 @@ export async function enforceIngressAcl(
           { sourceChannel, channelId: resolvedMember.channelId },
           "Ingress ACL: member policy deny",
         );
-        const denyReplyText =
-          "Sorry, you haven't been approved to message this assistant.";
+        const denyReplyText = ACCESS_DENIED_NOT_APPROVED_REPLY;
         let denyReplyDelivered = false;
         if (replyCallbackUrl) {
           const denyPayload: Parameters<typeof deliverChannelReply>[1] = {

--- a/gateway/src/channels/plugin-inbound.test.ts
+++ b/gateway/src/channels/plugin-inbound.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 
 import { IngressInboundSchema } from "./ingress-inbound.js";
-import { readPluginInbound } from "./plugin-inbound.js";
+import { readPluginInbound, unscopedPluginId } from "./plugin-inbound.js";
 
 const RECEIVED_AT = "2026-02-01T00:00:00.000Z";
 
@@ -68,6 +68,16 @@ describe("readPluginInbound", () => {
     expect(result.event.message.conversationExternalId).toBe("imessage:chat-1");
     expect(result.event.actor.actorExternalId).toBe("imessage:+12025550142");
     expect(result.event.message.externalMessageId).toBe("imessage:msg-1");
+  });
+
+  it("returns the vendor id from a scoped plugin id", () => {
+    // The plugin send API addresses chats the way the vendor does. A notice
+    // that kept the prefix would aim at a chat that does not exist.
+    expect(unscopedPluginId("imessage", "imessage:chat-1")).toBe("chat-1");
+    expect(unscopedPluginId("imessage", "imessage:+12025550142")).toBe(
+      "+12025550142",
+    );
+    expect(unscopedPluginId("imessage", "chat-1")).toBe("chat-1");
   });
 
   it("takes the plugin name from the caller, not the reply", () => {

--- a/gateway/src/channels/plugin-inbound.ts
+++ b/gateway/src/channels/plugin-inbound.ts
@@ -70,6 +70,21 @@ export function pluginScopedId(plugin: string, value: string): string {
 }
 
 /**
+ * The vendor-facing id inside a scoped plugin id.
+ *
+ * `pluginScopedId` prefixes with `${plugin}:`. The plugin's send API addresses
+ * chats in the vendor's own terms, so a notice has to carry the unprefixed
+ * value the declaration read, not the namespaced key the gate stores.
+ */
+export function unscopedPluginId(plugin: string, scoped: string): string {
+  const prefix = `${plugin}:`;
+  if (scoped.startsWith(prefix)) {
+    return scoped.slice(prefix.length);
+  }
+  return scoped;
+}
+
+/**
  * The vendor payload the plugin carried forward, if it carried one.
  *
  * `raw` is what every other channel's normalizer keeps for a later stage to

--- a/gateway/src/http/routes/plugin-webhook.test.ts
+++ b/gateway/src/http/routes/plugin-webhook.test.ts
@@ -27,6 +27,11 @@ import {
   INBOUND_CLAIM_LEASE_MS,
 } from "../../db/inbound-dedup-store.js";
 import { inboundSeenEvents } from "../../db/schema.js";
+import {
+  ACCESS_DENIED_NOT_APPROVED_REPLY,
+  PLUGIN_ADMISSION_DENIED_NOTICE_PATH,
+} from "@vellumai/gateway-client";
+
 import type {
   HandleInboundOptions,
   InboundAdmission,
@@ -1279,10 +1284,8 @@ describe("inbound delivery", () => {
   });
 
   it("does not reach the plugin when the sender is below the admission floor", async () => {
-    // The gate stops at the kill switch and leaves the ranked floors to
-    // whoever receives the message. For a built-in channel that is the
-    // runtime's admission stage; here there is nothing downstream but the
-    // plugin, so a floor unenforced here is a floor unenforced at all.
+    // The vendor body must not reach a plugin free to run a turn. A separate
+    // notice asks the plugin to send the canned denial instead.
     const { forwards, deps } = harness({
       admit: async () => ({
         admitted: true,
@@ -1295,8 +1298,22 @@ describe("inbound delivery", () => {
 
     const res = await deliver(deps);
 
-    expect(forwards).toEqual([]);
     expect(res.status).toBe(200);
+    expect(forwards).toHaveLength(1);
+    expect(forwards[0]!.url).toBe(
+      `http://runtime.test:7821/v1/x/plugins/meeting-bot/${PLUGIN_ADMISSION_DENIED_NOTICE_PATH}`,
+    );
+    expect(JSON.parse(forwards[0]!.body)).toEqual({
+      reason: "admission_floor",
+      plugin: "meeting-bot",
+      ingressRoute: "events",
+      admissionPolicy: "trusted_contacts",
+      trustClass: "unknown",
+      conversationExternalId: "chat-1",
+      actorExternalId: "+12025550142",
+      externalMessageId: "msg-1",
+      replyText: ACCESS_DENIED_NOT_APPROVED_REPLY,
+    });
   });
 
   it("reaches the plugin when the sender clears the floor", async () => {
@@ -1330,7 +1347,35 @@ describe("inbound delivery", () => {
 
     await deliver(deps);
 
-    expect(forwards).toEqual([]);
+    expect(forwards).toHaveLength(1);
+    expect(forwards[0]!.url).toContain(PLUGIN_ADMISSION_DENIED_NOTICE_PATH);
+    expect(JSON.parse(forwards[0]!.body)).toMatchObject({
+      reason: "admission_floor",
+      trustClass: "unknown",
+    });
+  });
+
+  it("acknowledges the vendor when the admission-denied notice fails", async () => {
+    // The floor decision already landed. A missing plugin route or a failed
+    // send must not ask the vendor to retry a message that will only be
+    // denied again.
+    const { forwards, deps } = harness({
+      admit: async () => ({
+        admitted: true,
+        routing: { assistantId: "self" } as never,
+        trustVerdict: { trustClass: "unknown" } as never,
+        admissionPolicy: "guardian_only",
+        displayName: undefined,
+      }),
+      pluginStatus: 404,
+    });
+
+    const res = await deliver(deps);
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(forwards).toHaveLength(1);
+    expect(forwards[0]!.url).toContain(PLUGIN_ADMISSION_DENIED_NOTICE_PATH);
   });
 
   it("tells the pipeline which plugin and which route it came from", async () => {

--- a/gateway/src/http/routes/plugin-webhook.ts
+++ b/gateway/src/http/routes/plugin-webhook.ts
@@ -27,7 +27,13 @@
  * `deliverGatedInbound` below for the ordering.
  */
 
-import { meetsAdmissionFloor } from "@vellumai/gateway-client";
+import {
+  ACCESS_DENIED_NOT_APPROVED_REPLY,
+  isTrustClass,
+  meetsAdmissionFloor,
+  PLUGIN_ADMISSION_DENIED_NOTICE_PATH,
+  PluginAdmissionDeniedNoticeSchema,
+} from "@vellumai/gateway-client";
 
 import {
   findDeclaredRoute,
@@ -37,7 +43,10 @@ import {
   verifyDeclaredSignature,
   type VerificationRejection,
 } from "../../channels/ingress-verification.js";
-import { readPluginInbound } from "../../channels/plugin-inbound.js";
+import {
+  readPluginInbound,
+  unscopedPluginId,
+} from "../../channels/plugin-inbound.js";
 import type { IngressInbound } from "../../channels/ingress-inbound.js";
 import type { IngressSigner } from "../../channels/plugin-ingress.js";
 import {
@@ -179,6 +188,79 @@ async function forwardToPlugin(forward: PluginForward): Promise<Response> {
     );
   }
   return forwarded;
+}
+
+/**
+ * Ask the plugin to send the canned access-denial reply.
+ *
+ * The ranked floor stops the vendor delivery from reaching the plugin, because
+ * that path is free to run a turn. The sender still needs to hear that they
+ * were not admitted. Only the plugin can send on its vendor, so this is a
+ * separate, structured notice: no vendor payload, no turn.
+ *
+ * The vendor ACK does not depend on this hop. A missing route or a failed
+ * send is logged and absorbed.
+ */
+async function notifyPluginAdmissionDenied(opts: {
+  forward: PluginForward;
+  plugin: string;
+  routePath: string;
+  admissionPolicy: string;
+  trustClass: string;
+  conversationExternalId: string;
+  actorExternalId: string;
+  externalMessageId: string;
+}): Promise<void> {
+  const {
+    forward,
+    plugin,
+    routePath,
+    admissionPolicy,
+    trustClass,
+    conversationExternalId,
+    actorExternalId,
+    externalMessageId,
+  } = opts;
+  try {
+    const notice = PluginAdmissionDeniedNoticeSchema.parse({
+      reason: "admission_floor",
+      plugin,
+      ingressRoute: routePath,
+      admissionPolicy,
+      trustClass: isTrustClass(trustClass) ? trustClass : "unknown",
+      conversationExternalId,
+      actorExternalId,
+      externalMessageId,
+      replyText: ACCESS_DENIED_NOT_APPROVED_REPLY,
+    });
+    const body = JSON.stringify(notice);
+    const noticeReq = new Request(
+      "http://gateway/internal/plugin-admission-denied",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body,
+      },
+    );
+    const response = await proxyForwardToResponse(noticeReq, {
+      baseUrl: forward.config.assistantRuntimeBaseUrl,
+      path: pluginRouteUpstreamPath(plugin, PLUGIN_ADMISSION_DENIED_NOTICE_PATH),
+      serviceToken: mintServiceToken(),
+      timeoutMs: forward.config.runtimeTimeoutMs,
+      fetchImpl: forward.fetchImpl,
+    });
+    if (response.status >= 400) {
+      log.warn(
+        { plugin, path: routePath, status: response.status },
+        "Plugin admission-denied notice failed",
+      );
+    }
+  } catch (err) {
+    log.warn(
+      { err, plugin, path: routePath },
+      "Plugin admission-denied notice failed",
+    );
+  }
 }
 
 export interface PluginWebhookHandlerDeps {
@@ -491,21 +573,40 @@ async function deliverGatedInbound(opts: {
   // receives the message. For a built-in channel that is the runtime's own
   // admission stage; here there is nothing downstream but the plugin, so a
   // floor unenforced here is a floor unenforced at all, and an unknown sender
-  // would reach a plugin free to answer them.
+  // would reach a plugin free to answer them. The vendor body stays here. A
+  // separate notice asks the plugin to send the canned denial, which is the
+  // same line built-in channels send, without running a turn.
   const { admissionPolicy, trustVerdict } = admission;
-  if (
-    admissionPolicy &&
-    !meetsAdmissionFloor(admissionPolicy, trustVerdict?.trustClass ?? "unknown")
-  ) {
+  const trustClass = trustVerdict?.trustClass ?? "unknown";
+  if (admissionPolicy && !meetsAdmissionFloor(admissionPolicy, trustClass)) {
     log.info(
       {
         plugin,
         path: routePath,
         admissionPolicy,
-        trustClass: trustVerdict?.trustClass ?? "unknown",
+        trustClass,
       },
       "Plugin inbound message denied by the admission floor",
     );
+    await notifyPluginAdmissionDenied({
+      forward,
+      plugin,
+      routePath,
+      admissionPolicy,
+      trustClass,
+      conversationExternalId: unscopedPluginId(
+        plugin,
+        reading.event.message.conversationExternalId,
+      ),
+      actorExternalId: unscopedPluginId(
+        plugin,
+        reading.event.actor.actorExternalId,
+      ),
+      externalMessageId: unscopedPluginId(
+        plugin,
+        reading.event.message.externalMessageId,
+      ),
+    });
     commitInboundEvent(dedupKey);
     return Response.json({ ok: true }, { status: 200 });
   }

--- a/packages/gateway-client/src/__tests__/gateway-client.test.ts
+++ b/packages/gateway-client/src/__tests__/gateway-client.test.ts
@@ -30,6 +30,7 @@ describe("package independence", () => {
     "../http-delivery.ts",
     "../ipc-client.ts",
     "../gateway-ipc-contracts.ts",
+    "../plugin-admission-denied-contract.ts",
   ];
 
   for (const file of sourceFiles) {

--- a/packages/gateway-client/src/__tests__/plugin-admission-denied-contract.test.ts
+++ b/packages/gateway-client/src/__tests__/plugin-admission-denied-contract.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  ACCESS_DENIED_NOT_APPROVED_REPLY,
+  PLUGIN_ADMISSION_DENIED_NOTICE_PATH,
+  PluginAdmissionDeniedNoticeSchema,
+} from "../plugin-admission-denied-contract.js";
+
+describe("plugin admission-denied contract", () => {
+  test("keeps the not-approved copy stable", () => {
+    expect(ACCESS_DENIED_NOT_APPROVED_REPLY).toBe(
+      "Sorry, you haven't been approved to message this assistant.",
+    );
+  });
+
+  test("names the internal plugin notice path", () => {
+    expect(PLUGIN_ADMISSION_DENIED_NOTICE_PATH).toBe(
+      "notices/admission-denied",
+    );
+  });
+
+  test("round-trips a floor-deny notice", () => {
+    const notice = {
+      reason: "admission_floor" as const,
+      plugin: "imessage",
+      ingressRoute: "events-linq",
+      admissionPolicy: "guardian_only" as const,
+      trustClass: "unknown" as const,
+      conversationExternalId: "chat-1",
+      actorExternalId: "+15550100",
+      externalMessageId: "msg-1",
+      replyText: ACCESS_DENIED_NOT_APPROVED_REPLY,
+    };
+
+    expect(PluginAdmissionDeniedNoticeSchema.parse(notice)).toEqual(notice);
+  });
+
+  test("rejects a notice that still carries a plugin-scoped id as the chat", () => {
+    // The send API addresses vendor chats. An empty chat id is the failure
+    // that matters; the schema only requires a non-empty string, so this
+    // asserts the required fields rather than the prefix rule.
+    expect(() =>
+      PluginAdmissionDeniedNoticeSchema.parse({
+        reason: "admission_floor",
+        plugin: "imessage",
+        ingressRoute: "events-linq",
+        admissionPolicy: "guardian_only",
+        trustClass: "unknown",
+        conversationExternalId: "",
+        actorExternalId: "+15550100",
+        externalMessageId: "msg-1",
+        replyText: ACCESS_DENIED_NOT_APPROVED_REPLY,
+      }),
+    ).toThrow();
+  });
+});

--- a/packages/gateway-client/src/index.ts
+++ b/packages/gateway-client/src/index.ts
@@ -83,6 +83,15 @@ export {
 
 export type { AdmissionPolicy } from "./admission-policy-contract.js";
 
+// Plugin admission-denied notice (gateway → plugin) — canned deny copy + envelope
+export {
+  ACCESS_DENIED_NOT_APPROVED_REPLY,
+  PLUGIN_ADMISSION_DENIED_NOTICE_PATH,
+  PluginAdmissionDeniedNoticeSchema,
+} from "./plugin-admission-denied-contract.js";
+
+export type { PluginAdmissionDeniedNotice } from "./plugin-admission-denied-contract.js";
+
 // Trust verdict contract (gateway → daemon) — Zod schemas + derived types
 export {
   isTrustClass,

--- a/packages/gateway-client/src/plugin-admission-denied-contract.ts
+++ b/packages/gateway-client/src/plugin-admission-denied-contract.ts
@@ -1,0 +1,47 @@
+/**
+ * Canned access-denial copy and the plugin notice the gateway posts when a
+ * plugin inbound delivery clears verification but fails the admission floor.
+ *
+ * Built-in channels send this reply through the runtime's channel transport.
+ * A plugin channel has no such transport: the gateway does not hold the
+ * vendor send credentials, so the notice is how the plugin learns it must
+ * send the same line itself, without running a turn.
+ */
+
+import { z } from "zod";
+
+import { AdmissionPolicySchema } from "./admission-policy-contract.js";
+import { TrustClassSchema } from "./trust-verdict-contract.js";
+
+/**
+ * Requester-facing reply when access is denied and there is no handshake
+ * and no guardian notification. Single source for this line: the runtime
+ * ACL composer and the plugin admission-denied notice both send it.
+ */
+export const ACCESS_DENIED_NOT_APPROVED_REPLY =
+  "Sorry, you haven't been approved to message this assistant.";
+
+/**
+ * Plugin route the gateway posts the notice to, under
+ * `/v1/x/plugins/<plugin>/`. Not a public ingress path.
+ */
+export const PLUGIN_ADMISSION_DENIED_NOTICE_PATH = "notices/admission-denied";
+
+export const PluginAdmissionDeniedNoticeSchema = z.object({
+  reason: z.literal("admission_floor"),
+  plugin: z.string().min(1),
+  ingressRoute: z.string().min(1),
+  admissionPolicy: AdmissionPolicySchema,
+  trustClass: TrustClassSchema,
+  /** Vendor chat id, without the plugin prefix the gate stores. */
+  conversationExternalId: z.string().min(1),
+  /** Vendor sender id, without the plugin prefix the gate stores. */
+  actorExternalId: z.string().min(1),
+  /** Vendor message id, without the plugin prefix the gate stores. */
+  externalMessageId: z.string().min(1),
+  replyText: z.string().min(1),
+});
+
+export type PluginAdmissionDeniedNotice = z.infer<
+  typeof PluginAdmissionDeniedNoticeSchema
+>;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan

Plugin inbound (iMessage via Linq) was verifying and then failing the `plugin` channel's `guardian_only` floor with `trustClass: unknown`. The gateway ACKed the vendor with 200 and dropped the message. The sender heard nothing.

Built-in channels already send `composeAccessDenialReply` on that deny. A plugin channel cannot reuse that transport: the gateway does not hold Linq/Photon/Comms credentials, and forwarding the vendor webhook would run a turn for an unknown sender.

This PR keeps the floor in place and posts a structured internal notice to `/v1/x/plugins/<plugin>/notices/admission-denied` so the plugin can send the existing canned line:

`Sorry, you haven't been approved to message this assistant.`

Companion plugin change: https://github.com/vellum-ai/imessage/pull/46. The gateway treats a missing notice route as a logged failure and still ACKs the vendor, so this can merge first.

Out of scope: linking `imessage:` identities to `phone` / guardian contacts. That is why a known number can still be `unknown` on the plugin channel.

## What changed

- Shared `ACCESS_DENIED_NOT_APPROVED_REPLY` and notice envelope in `@vellumai/gateway-client`.
- Runtime ACL composer uses that constant (same copy as today).
- On a ranked-floor deny, `plugin-webhook` posts the notice with unprefixed vendor ids. It does not forward the vendor body.
- Kill-switch / other non-admit decisions stay silent (unchanged).
- No access-request card. Approving someone to `trusted_contact` cannot clear `guardian_only`.

## Test plan

- [x] `cd gateway && bun test src/http/routes/plugin-webhook.test.ts src/channels/plugin-inbound.test.ts` (75 pass)
- [x] `cd packages/gateway-client && bun test src/__tests__/plugin-admission-denied-contract.test.ts` (4 pass)

## CLI verb checklist

No new assistant HTTP/IPC route. The notice is a plugin-owned `/x/plugins/<name>/...` handler, same namespace the webhook forward already uses.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-27c6a680-a343-44ed-ae79-a2fa51ae8a90?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-27c6a680-a343-44ed-ae79-a2fa51ae8a90&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

