### PR TITLE
fix: expire the avatar sync key in-process, not only across restarts

### DIFF
--- a/assistant/src/platform/platform-patch-queue.test.ts
+++ b/assistant/src/platform/platform-patch-queue.test.ts
@@ -1,4 +1,11 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  setSystemTime,
+  test,
+} from "bun:test";
 
 let mockClient: {
   baseUrl: string;
@@ -11,7 +18,10 @@ mock.module("./client.js", () => ({
 }));
 
 import { getLogger } from "../util/logger.js";
-import { createPlatformPatchQueue } from "./platform-patch-queue.js";
+import {
+  createPlatformPatchQueue,
+  type SyncedKey,
+} from "./platform-patch-queue.js";
 
 interface Patch {
   path: string;
@@ -35,8 +45,9 @@ function makeClient(assistantId = "asst-1", baseUrl = "https://platform.a") {
 
 function makeQueue(
   opts: {
-    loadSyncedKey?: () => string | null;
-    saveSyncedKey?: (key: string) => void;
+    loadSyncedKey?: () => SyncedKey | null;
+    saveSyncedKey?: (synced: SyncedKey) => void;
+    maxAgeMs?: number;
   } = {},
 ) {
   return createPlatformPatchQueue<string | undefined>({
@@ -154,10 +165,13 @@ describe("createPlatformPatchQueue", () => {
   });
 
   test("seeds the dedup key from loadSyncedKey and saves each success", async () => {
-    const saved: string[] = [];
+    const saved: SyncedKey[] = [];
     const queue = makeQueue({
-      loadSyncedKey: () => "https://platform.a|asst-1|a",
-      saveSyncedKey: (key) => saved.push(key),
+      loadSyncedKey: () => ({
+        key: "https://platform.a|asst-1|a",
+        syncedAt: Date.now(),
+      }),
+      saveSyncedKey: (synced) => saved.push(synced),
     });
     queue.enqueue("a");
     await settle();
@@ -165,6 +179,62 @@ describe("createPlatformPatchQueue", () => {
     await settle();
 
     expect(patches.map((p) => p.body.value)).toEqual(["b"]);
-    expect(saved).toEqual(["https://platform.a|asst-1|b"]);
+    expect(saved).toEqual([
+      { key: "https://platform.a|asst-1|b", syncedAt: expect.any(Number) },
+    ]);
+  });
+
+  test("a matching key older than maxAgeMs re-sends in-process", async () => {
+    const saved: SyncedKey[] = [];
+    const queue = makeQueue({
+      maxAgeMs: 1000,
+      saveSyncedKey: (synced) => saved.push(synced),
+    });
+    const start = Date.now();
+    setSystemTime(new Date(start));
+    try {
+      queue.enqueue("a");
+      await settle();
+      setSystemTime(new Date(start + 999));
+      queue.enqueue("a");
+      await settle();
+      setSystemTime(new Date(start + 1000));
+      queue.enqueue("a");
+      await settle();
+      queue.enqueue("a");
+      await settle();
+    } finally {
+      setSystemTime();
+    }
+
+    expect(patches).toHaveLength(2);
+    expect(saved.map((s) => s.syncedAt)).toEqual([start, start + 1000]);
+  });
+
+  test("a seeded key older than maxAgeMs re-sends", async () => {
+    const queue = makeQueue({
+      maxAgeMs: 1000,
+      loadSyncedKey: () => ({
+        key: "https://platform.a|asst-1|a",
+        syncedAt: Date.now() - 1000,
+      }),
+    });
+    queue.enqueue("a");
+    await settle();
+
+    expect(patches).toHaveLength(1);
+  });
+
+  test("without maxAgeMs a matching key never expires", async () => {
+    const queue = makeQueue({
+      loadSyncedKey: () => ({
+        key: "https://platform.a|asst-1|a",
+        syncedAt: 0,
+      }),
+    });
+    queue.enqueue("a");
+    await settle();
+
+    expect(patches).toHaveLength(0);
   });
 });

--- a/assistant/src/platform/platform-patch-queue.ts
+++ b/assistant/src/platform/platform-patch-queue.ts
@@ -5,9 +5,11 @@
  * so rapid changes collapse into one PATCH carrying the newest payload and a
  * stale in-flight response cannot overwrite a newer value. The dedup key is
  * scoped to the platform destination (base URL + assistant id), so
- * re-registering elsewhere re-sends an unchanged payload. Best-effort: failures
- * are logged, never thrown, and leave the dedup key untouched so the next
- * enqueue retries.
+ * re-registering elsewhere re-sends an unchanged payload. With `maxAgeMs`, a
+ * key only dedups while its last success is younger than that, checked on
+ * every run so a long-lived process re-sends too. Best-effort: failures are
+ * logged, never thrown, and leave the dedup key untouched so the next enqueue
+ * retries.
  */
 
 import type { getLogger } from "../util/logger.js";
@@ -24,6 +26,13 @@ export interface PatchPayload {
   body: PatchBody | (() => Promise<PatchBody | undefined>);
 }
 
+export interface SyncedKey {
+  /** Destination-scoped dedup key of the last successful PATCH. */
+  key: string;
+  /** Epoch ms of that PATCH. */
+  syncedAt: number;
+}
+
 export interface PlatformPatchQueueOptions<T> {
   log: Logger;
   /** Names the synced thing in log lines, e.g. "avatar". */
@@ -33,9 +42,11 @@ export interface PlatformPatchQueueOptions<T> {
     input: T,
   ) => Promise<PatchPayload | undefined> | PatchPayload | undefined;
   /** Seeds the dedup key on first use (e.g. from disk). */
-  loadSyncedKey?: () => string | null;
-  /** Called after each successful PATCH with the destination-scoped key. */
-  saveSyncedKey?: (key: string) => void;
+  loadSyncedKey?: () => SyncedKey | null;
+  /** Called after each successful PATCH. */
+  saveSyncedKey?: (synced: SyncedKey) => void;
+  /** A matching key older than this re-sends; omit to never expire. */
+  maxAgeMs?: number;
 }
 
 export interface PlatformPatchQueue<T> {
@@ -45,8 +56,9 @@ export interface PlatformPatchQueue<T> {
 export function createPlatformPatchQueue<T = void>(
   options: PlatformPatchQueueOptions<T>,
 ): PlatformPatchQueue<T> {
-  const { log, label, buildPayload, loadSyncedKey, saveSyncedKey } = options;
-  let lastSyncedKey: string | null | undefined;
+  const { log, label, buildPayload, loadSyncedKey, saveSyncedKey, maxAgeMs } =
+    options;
+  let lastSynced: SyncedKey | null | undefined;
   let seq = 0;
   let pending: Promise<void> = Promise.resolve();
 
@@ -66,8 +78,11 @@ export function createPlatformPatchQueue<T = void>(
         return;
       }
       const key = `${client.baseUrl}|${assistantId}|${payload.key}`;
-      lastSyncedKey ??= loadSyncedKey?.() ?? null;
-      if (key === lastSyncedKey) {
+      lastSynced ??= loadSyncedKey?.() ?? null;
+      if (
+        lastSynced?.key === key &&
+        (maxAgeMs === undefined || Date.now() - lastSynced.syncedAt < maxAgeMs)
+      ) {
         return;
       }
       const body =
@@ -89,8 +104,8 @@ export function createPlatformPatchQueue<T = void>(
       );
 
       if (resp.ok) {
-        lastSyncedKey = key;
-        saveSyncedKey?.(key);
+        lastSynced = { key, syncedAt: Date.now() };
+        saveSyncedKey?.(lastSynced);
         log.info(
           { key: payload.key, assistantId },
           `Synced ${label} to platform`,

--- a/assistant/src/platform/sync-avatar.test.ts
+++ b/assistant/src/platform/sync-avatar.test.ts
@@ -9,7 +9,15 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
-import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterAll,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  setSystemTime,
+  test,
+} from "bun:test";
 
 import type { AvatarState } from "../avatar/avatar-manifest.js";
 
@@ -339,6 +347,33 @@ describe("syncAvatarToPlatform", () => {
     const refreshed = JSON.parse(readFileSync(syncStatePath, "utf-8"));
     expect(refreshed.key).toBe(stale.key);
     expect(refreshed.syncedAt).toBeGreaterThan(stale.syncedAt);
+  });
+
+  test("a key older than the TTL re-uploads without a restart", async () => {
+    const start = Date.now();
+    setSystemTime(new Date(start));
+    try {
+      syncAvatarToPlatform();
+      await settle();
+      setSystemTime(new Date(start + AVATAR_SYNC_KEY_TTL_MS - 1));
+      syncAvatarToPlatform();
+      await settle();
+      expect(patches).toHaveLength(1);
+
+      setSystemTime(new Date(start + AVATAR_SYNC_KEY_TTL_MS));
+      syncAvatarToPlatform();
+      await settle();
+      syncAvatarToPlatform();
+      await settle();
+    } finally {
+      setSystemTime();
+    }
+
+    expect(patches).toHaveLength(2);
+    expect(JSON.parse(readFileSync(syncStatePath, "utf-8"))).toEqual({
+      key: expect.stringMatching(/^https:\/\/platform\.a\|asst-1\|image:/),
+      syncedAt: start + AVATAR_SYNC_KEY_TTL_MS,
+    });
   });
 
   test("a corrupt persisted key re-uploads", async () => {

--- a/assistant/src/platform/sync-avatar.ts
+++ b/assistant/src/platform/sync-avatar.ts
@@ -9,9 +9,10 @@
  * syncs. The last synced key is persisted outside the workspace repo at
  * `<protected dir>/platform-sync/avatar.json` so a daemon restart does not
  * re-upload an unchanged raster and the record never dirties the workspace.
- * A persisted key older than `AVATAR_SYNC_KEY_TTL_MS` is ignored, so an
- * avatar lost server-side while id and base URL are unchanged is re-pushed
- * within a week (API-key auth cannot read the record to verify it).
+ * A synced key older than `AVATAR_SYNC_KEY_TTL_MS` no longer dedups, whether
+ * seeded from disk or set in-process, so an avatar lost server-side while id
+ * and base URL are unchanged is re-pushed within a week even by a daemon
+ * that never restarts (API-key auth cannot read the record to verify it).
  * `avatar_base64: null` is sent only when the avatar is actually removed; a
  * non-none avatar whose raster is missing (image PNG gone, character
  * re-render unavailable) is skipped so the platform keeps the last synced
@@ -34,6 +35,7 @@ import {
   createPlatformPatchQueue,
   type PatchPayload,
   type PlatformPatchQueue,
+  type SyncedKey,
 } from "./platform-patch-queue.js";
 
 const log = getLogger("sync-avatar");
@@ -64,6 +66,7 @@ export function syncAvatarToPlatform(): void {
     buildPayload,
     loadSyncedKey: readPersistedKey,
     saveSyncedKey: persistKey,
+    maxAgeMs: AVATAR_SYNC_KEY_TTL_MS,
   });
   queue.enqueue();
 }
@@ -72,8 +75,8 @@ function syncStatePath(): string {
   return join(getProtectedDir(), ...SYNC_STATE_SUBPATH);
 }
 
-/** Returns the persisted key, or null when missing, malformed, or expired. */
-function readPersistedKey(): string | null {
+/** Returns the persisted key, or null when missing or malformed. */
+function readPersistedKey(): SyncedKey | null {
   try {
     const parsed: unknown = JSON.parse(readFileSync(syncStatePath(), "utf-8"));
     const { key, syncedAt } = (parsed ?? {}) as {
@@ -83,18 +86,18 @@ function readPersistedKey(): string | null {
     if (typeof key !== "string" || typeof syncedAt !== "number") {
       return null;
     }
-    return Date.now() - syncedAt < AVATAR_SYNC_KEY_TTL_MS ? key : null;
+    return { key, syncedAt };
   } catch {
     return null;
   }
 }
 
-function persistKey(key: string): void {
+function persistKey(synced: SyncedKey): void {
   try {
     const path = syncStatePath();
     mkdirSync(dirname(path), { recursive: true });
     const tmpPath = `${path}.tmp.${process.pid}`;
-    writeFileSync(tmpPath, JSON.stringify({ key, syncedAt: Date.now() }));
+    writeFileSync(tmpPath, JSON.stringify(synced));
     renameSync(tmpPath, path);
   } catch (err) {
     log.warn({ err }, "Failed to persist avatar sync state");


### PR DESCRIPTION
## Summary
Fixes a gap identified during plan review (round 4) for chooser-assistant-avatars.md.

**Gap:** the 7-day TTL on the persisted avatar sync key was only evaluated when seeding from disk, so a long-running daemon never re-pushed.

**Fix:** `createPlatformPatchQueue` now tracks `{ key, syncedAt }` and takes an optional `maxAgeMs`; a key dedups only while its last 2xx is younger than that, checked on every run. Avatar sync passes `AVATAR_SYNC_KEY_TTL_MS`; identity passes nothing and never expires. The TTL check moved out of `readPersistedKey` so there is one implementation.

**Tests:** in-process expiry via `setSystemTime` (no reset) in both the queue and avatar suites, plus seeded-stale and never-expires queue cases; the restart TTL test is kept.