### PR TITLE
fix(web): guard the signup CTA against a double tap during auth start

### DIFF
--- a/clients/web/src/domains/account/components/signup-screen.test.tsx
+++ b/clients/web/src/domains/account/components/signup-screen.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * The sign-up screen's handoff to AuthKit: one flow at a time, and a failure
+ * that hands the screen back. The handoff is not instant, so a second
+ * activation would otherwise replace the flow already running, which the
+ * native plugin rejects as a failure the user never caused.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+
+import * as nativeAuth from "@/runtime/native-auth";
+
+/** Rejecters for the flows started so far, so each one stays pending. */
+const startedFlows: ((err: unknown) => void)[] = [];
+
+mock.module("@/runtime/native-auth", (): typeof nativeAuth => ({
+  ...nativeAuth,
+  startAuthFlow: () =>
+    new Promise<void>((_resolve, reject) => {
+      startedFlows.push(reject);
+    }),
+}));
+
+const { SignupScreen } = await import(
+  "@/domains/account/components/signup-screen"
+);
+
+const GENERIC_FAILURE = "Something went wrong. Please try again.";
+
+const continueButton = () => screen.getByText("Continue").closest("button");
+const signInButton = () => screen.getByText("Sign in").closest("button");
+
+describe("SignupScreen auth handoff", () => {
+  beforeEach(() => {
+    startedFlows.length = 0;
+    render(<SignupScreen returnTo={null} />);
+  });
+
+  afterEach(cleanup);
+
+  test("a second press cannot open a second flow", () => {
+    fireEvent.click(screen.getByText("Continue"));
+    fireEvent.click(screen.getByText("Continue"));
+
+    expect(startedFlows).toHaveLength(1);
+    expect(continueButton()?.disabled).toBe(true);
+  });
+
+  test("a pending signup blocks the sign-in link too", () => {
+    fireEvent.click(screen.getByText("Continue"));
+    fireEvent.click(screen.getByText("Sign in"));
+
+    expect(startedFlows).toHaveLength(1);
+    expect(signInButton()?.disabled).toBe(true);
+  });
+
+  test("the sign-in link holds the screen the same way", () => {
+    fireEvent.click(screen.getByText("Sign in"));
+    fireEvent.click(screen.getByText("Sign in"));
+    fireEvent.click(screen.getByText("Continue"));
+
+    expect(startedFlows).toHaveLength(1);
+    expect(continueButton()?.disabled).toBe(true);
+  });
+
+  test("a failed handoff hands the screen back", async () => {
+    fireEvent.click(screen.getByText("Continue"));
+    startedFlows[0]?.(new Error("handoff refused"));
+
+    await waitFor(() => {
+      expect(screen.getByText(GENERIC_FAILURE)).toBeTruthy();
+    });
+    expect(continueButton()?.disabled).toBe(false);
+
+    fireEvent.click(screen.getByText("Continue"));
+
+    expect(startedFlows).toHaveLength(2);
+    expect(screen.queryByText(GENERIC_FAILURE)).toBeNull();
+  });
+});

--- a/clients/web/src/domains/account/components/signup-screen.tsx
+++ b/clients/web/src/domains/account/components/signup-screen.tsx
@@ -42,31 +42,37 @@ export function SignupScreen({ returnTo }: SignupScreenProps) {
     [t],
   );
   const [error, setError] = useState<string | null>(null);
-  const callbackUrl = buildProviderCallbackUrl(returnTo, {
-    authIntent: "signup",
-  });
+  const [pending, setPending] = useState(false);
+
+  /**
+   * Hand off to AuthKit, holding the screen's controls until the flow lands. A
+   * native start resolves the flow's marketing attribution before the browser
+   * auth surface opens, and a second start inside that gap replaces the first,
+   * which the plugin rejects as a failure the user never caused. A rejection
+   * hands the screen back.
+   */
+  const startFlow = (intent: "signup" | undefined, logLabel: string) => {
+    setError(null);
+    setPending(true);
+    startAuthFlow(
+      PROVIDER_ID,
+      buildProviderCallbackUrl(returnTo, { authIntent: intent }),
+      { returnTo, intent },
+    ).catch((err) => {
+      console.error(logLabel, err);
+      setError(t("authErrors.genericFailure"));
+      setPending(false);
+    });
+  };
 
   const start = () => {
-    setError(null);
-    startAuthFlow(PROVIDER_ID, callbackUrl, {
-      returnTo,
-      intent: "signup",
-    }).catch((err) => {
-      console.error("[signup] auth flow failed:", err);
-      setError(t("authErrors.genericFailure"));
-    });
+    startFlow("signup", "[signup] auth flow failed:");
   };
 
   // "Sign in" goes straight to AuthKit (login) rather than routing through the
   // /account/login redirect page, which would flash an extra "Redirecting…".
   const signIn = () => {
-    setError(null);
-    startAuthFlow(PROVIDER_ID, buildProviderCallbackUrl(returnTo), {
-      returnTo,
-    }).catch((err) => {
-      console.error("[signup] sign-in flow failed:", err);
-      setError(t("authErrors.genericFailure"));
-    });
+    startFlow(undefined, "[signup] sign-in flow failed:");
   };
 
   return (
@@ -79,7 +85,12 @@ export function SignupScreen({ returnTo }: SignupScreenProps) {
       <p className="signup__subtitle">{t("signupScreen.subtitle")}</p>
 
       <div className="signup__buttons">
-        <button type="button" className="signup__btn" onClick={start}>
+        <button
+          type="button"
+          className="signup__btn"
+          onClick={start}
+          disabled={pending}
+        >
           {t("signupScreen.continue")}
         </button>
       </div>
@@ -92,7 +103,12 @@ export function SignupScreen({ returnTo }: SignupScreenProps) {
           ns="account"
           components={{
             signIn: (
-              <button type="button" className="signup__link" onClick={signIn} />
+              <button
+                type="button"
+                className="signup__link"
+                onClick={signIn}
+                disabled={pending}
+              />
             ),
           }}
         />


### PR DESCRIPTION
## Summary

`SignupScreen`'s CTA was a plain `<button onClick={start}>` with no in-flight state. The handoff to AuthKit is not instant: a native start resolves the flow's marketing attribution before the browser auth surface opens, and on a first Android launch that can take up to about two seconds while the shell binds the Play Install Referrer service. Nothing on screen changed during that window, so a second tap issued a second `startAuth`. The Android plugin's `replaceFlow` then rejects the FIRST call with `AUTH_REPLACED` (`NativeAuthPlugin.java`), `startAuthFlow` only swallows `USER_CANCELLED`, and the screen's `.catch` rendered `authErrors.genericFailure`: a red error banner beside a flow that was proceeding normally.

## What changed

- `SignupScreen` holds a `pending` state and both controls that can start a flow (the Continue CTA and the "Sign in" link in the footer) go `disabled` while one is in flight. This is the same `loading` pattern `login-page.tsx` and `AuthWelcomeScreen` already use, and `.signup__btn:disabled` (opacity 0.6) was already in `signup.css` waiting for a consumer.
- A rejection releases the guard alongside the existing error message, so a genuine failure still lets the user retry. Success does not release it: the flow navigates the page away, exactly as on the login screen.
- The two near-identical handlers now share one `startFlow` helper. Their distinct console labels are preserved, so a bug report still says which control failed.

No change to `native-auth.ts`; the await window itself is being narrowed separately.

## Testing

New `signup-screen.test.tsx` holds `startAuthFlow` pending and asserts the guard in both directions (a second Continue press, Continue then Sign in, Sign in then Continue) plus the release on failure. Verified non-vacuous: deleting the two `disabled={pending}` lines fails 3 of the 4 tests, and deleting `setPending(false)` from the catch fails the fourth.

`bun test` on the new file and `signup-page.test.tsx` (16 pass), `bun run typecheck`, and `bun run lint` are all clean (0 errors; the 15 lint warnings are pre-existing in untouched files).