### PR TITLE
fix: invalidate in-flight avatar fetches when an assistant is forgotten

### DIFF
--- a/clients/web/src/hooks/use-chooser-row-avatar.test.tsx
+++ b/clients/web/src/hooks/use-chooser-row-avatar.test.tsx
@@ -142,7 +142,7 @@ const { MIN_VERSION } =
 const {
   canFetchRowAvatarViaPlatformProxy,
   chooserRowAvatarQueryKeyPrefix,
-  releaseRowAvatarUrls,
+  forgetAssistantAvatar,
   useChooserRowAvatar,
 } = await import("@/hooks/use-chooser-row-avatar");
 const { avatarQueryKey } = await import("@/hooks/use-assistant-avatar");
@@ -769,7 +769,7 @@ describe("useChooserRowAvatar", () => {
     });
   });
 
-  describe("releaseRowAvatarUrls", () => {
+  describe("forgetAssistantAvatar", () => {
     test("revokes the live and cached object urls held for a removed assistant", async () => {
       fetchAvatarState.mockResolvedValue(imageState);
       fetchAvatarImageUrlResult.mockResolvedValue(found("blob:row-image"));
@@ -790,7 +790,7 @@ describe("useChooserRowAvatar", () => {
         expect(cached.result.current.imageUrl).toBe("blob:cached-image");
       });
 
-      releaseRowAvatarUrls(new QueryClient(), "other");
+      forgetAssistantAvatar(new QueryClient(), "other");
 
       expect(revokeObjectURL).toHaveBeenCalledWith("blob:row-image");
       expect(revokeObjectURL).toHaveBeenCalledWith("blob:cached-image");
@@ -818,7 +818,7 @@ describe("useChooserRowAvatar", () => {
         imageUrl: null,
       });
 
-      releaseRowAvatarUrls(queryClient, "other");
+      forgetAssistantAvatar(queryClient, "other");
 
       expect(
         queryClient.getQueryData([
@@ -835,6 +835,39 @@ describe("useChooserRowAvatar", () => {
       expect(
         queryClient.getQueryData(chooserRowAvatarCacheQueryKey("kept")),
       ).toBeDefined();
+    });
+
+    test("an in-flight row fetch that resolves afterwards drops its blob and writes nothing", async () => {
+      let resolveImage: (result: FileResult<string>) => void = () => {};
+      fetchAvatarImageUrlResult.mockImplementationOnce(
+        () =>
+          new Promise<FileResult<string>>((resolve) => {
+            resolveImage = resolve;
+          }),
+      );
+      fetchAvatarState.mockResolvedValue(imageState);
+      const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      });
+      renderHook(() => useChooserRowAvatar(platformRow("other")), {
+        wrapper: createWrapper(queryClient),
+      });
+      await waitFor(() => {
+        expect(fetchAvatarImageUrlResult).toHaveBeenCalledTimes(1);
+      });
+
+      forgetAssistantAvatar(queryClient, "other");
+      resolveImage(found("blob:late"));
+      await waitFor(() => {
+        expect(revokeObjectURL).toHaveBeenCalledWith("blob:late");
+      });
+      await settle();
+      expect(writeLastSeenAvatar).not.toHaveBeenCalled();
+
+      // Nothing was registered for the late blob: a second release has nothing to revoke.
+      revokeObjectURL.mockClear();
+      forgetAssistantAvatar(queryClient, "other");
+      expect(revokeObjectURL).not.toHaveBeenCalled();
     });
   });
 

--- a/clients/web/src/hooks/use-chooser-row-avatar.ts
+++ b/clients/web/src/hooks/use-chooser-row-avatar.ts
@@ -96,12 +96,14 @@ const fetchGenerations = createGenerationGuard();
  * Revoke every object URL held for a removed assistant, across this module's
  * maps and the live hook's, and drop the query entries that hold those
  * (now dead) `blob:` strings, or re-pairing the same id within gcTime would
- * render a revoked image.
+ * render a revoked image. Supersedes any in-flight row fetch so it drops its
+ * own blob instead of re-registering one and re-persisting the entry.
  */
-export function releaseRowAvatarUrls(
+function releaseRowAvatarUrls(
   queryClient: QueryClient,
   assistantId: string,
 ): void {
+  fetchGenerations.invalidate(assistantId);
   trackBlobUrl(activeBlobUrls, assistantId, null);
   trackBlobUrl(cachedBlobUrls, assistantId, null);
   releaseAssistantAvatarUrl(assistantId);

--- a/clients/web/src/lib/generation-guard.ts
+++ b/clients/web/src/lib/generation-guard.ts
@@ -6,18 +6,24 @@
 export interface GenerationGuard {
   claim(key: string): number;
   isCurrent(key: string, generation: number): boolean;
+  /** Supersede every in-flight operation for `key` without starting a new one. */
+  invalidate(key: string): void;
 }
 
 export function createGenerationGuard(): GenerationGuard {
   const generations = new Map<string, number>();
+  const claim = (key: string) => {
+    const generation = (generations.get(key) ?? 0) + 1;
+    generations.set(key, generation);
+    return generation;
+  };
   return {
-    claim(key) {
-      const generation = (generations.get(key) ?? 0) + 1;
-      generations.set(key, generation);
-      return generation;
-    },
+    claim,
     isCurrent(key, generation) {
       return generations.get(key) === generation;
+    },
+    invalidate(key) {
+      claim(key);
     },
   };
 }


### PR DESCRIPTION
## Summary
Fixes a gap identified during plan review (round 4) for chooser-assistant-avatars.md.

**Gap:** forgetAssistantAvatar did not advance the fetch generation, so an in-flight row fetch could re-register a blob URL and re-persist the just-deleted last-seen entry.

**Fix:** releaseRowAvatarUrls now claims a fresh fetch generation (new GenerationGuard.invalidate), so a fetch that resolves after the forget fails isCurrent, revokes its own blob, and skips persistLastSeenAvatar. releaseRowAvatarUrls is no longer exported; tests go through forgetAssistantAvatar. Adds a regression test for the late-resolving fetch.