### PR TITLE
fix(attribution): stop burning an install referrer the shell captured

### DIFF
--- a/clients/android/app/src/main/java/ai/vellum/assistant/InstallReferrerPlugin.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/InstallReferrerPlugin.java
@@ -30,11 +30,12 @@ public class InstallReferrerPlugin extends Plugin {
     private static final String RESOLVED_KEY = "resolved";
 
     /**
-     * Bound on the service bind. The web layer spends this value on the auth
-     * critical path, and a bind that connects but never calls back would
-     * otherwise leave the call unresolved for the life of the process.
+     * Bound on the service bind, and the only bound on this read: the web layer
+     * awaits the call on the auth critical path, ahead of the sign-in sheet. A
+     * bind that connects but never calls back resolves empty here, uncached, so
+     * a later launch retries.
      */
-    private static final long BIND_TIMEOUT_MS = 5000L;
+    private static final long BIND_TIMEOUT_MS = 2500L;
 
     @PluginMethod
     public void read(PluginCall call) {
@@ -48,7 +49,6 @@ public class InstallReferrerPlugin extends Plugin {
         // One connection can fire both setup-finished and service-disconnected,
         // and a call resolves once.
         final AtomicBoolean answered = new AtomicBoolean();
-        // A timed-out bind is transient, so it resolves empty without caching.
         final Handler timeoutHandler = new Handler(Looper.getMainLooper());
         timeoutHandler.postDelayed(
             () -> {

--- a/clients/web/docs/CAPACITOR.md
+++ b/clients/web/docs/CAPACITOR.md
@@ -364,9 +364,11 @@ is no iOS counterpart.
   when Play answers with a referrer, and `{}` for every other outcome: no Play
   Store on the device, a Play Store that declines the bind, or a Play install
   with no campaign. A bind that connects but never calls back is answered empty
-  by a timeout on each side (five seconds in the plugin, two in the web layer),
-  because the auth path that spends this value awaits the call. A rejection or
-  a hang here would surface as an error or a stuck sign-in button.
+  by the plugin's own `BIND_TIMEOUT_MS`, the only bound on this read: the auth
+  path that spends the value awaits the call, and a shorter bound in the web
+  layer would abandon a referrer the shell goes on to cache forever. A
+  rejection or a hang here would surface as an error or a stuck sign-in
+  button.
 - **The empty result is the answer.** There is no availability probe, for the
   same reason the voice bridge has none (§ "The skew rule"): a probe can itself
   be absent on an older shell, and `{}` is the only answer a caller could act
@@ -378,12 +380,9 @@ is no iOS counterpart.
   bind. A transient failure, a timed-out bind included, is left uncached, so a
   later launch retries.
 - **Consumption state belongs to the web layer.** The shell keeps answering
-  `read()` with the same value forever, so the spend has to be recorded where
-  the value is spent. The web layer captures the referrer into
-  `device:install_referrer` and empties that key once an auth flow has spent
-  it, keeping the key itself as the record: its presence, an empty value
-  included, is what stops a later signup on this device from re-reading the
-  bridge and inheriting the first user's campaign. Do not add a "mark consumed"
+  `read()` with the same value forever, so the spend is recorded where the
+  value is spent, under `device:install_referrer`; `markInstallReferrerSpent`
+  in `install-referrer.ts` carries the rules. Do not add a "mark consumed"
   method to the bridge.
 - **Failures are logged, not reported.** The plugin logs through
   `com.getcapacitor.Logger`, not `NativeFailureGuard`, whose reports the web

--- a/clients/web/src/lib/auth/session-cleanup.test.ts
+++ b/clients/web/src/lib/auth/session-cleanup.test.ts
@@ -132,17 +132,6 @@ describe("clearUserScopedStorage", () => {
     expect(localStorage.getItem("device:last_user_id")).toBe("user-123");
   });
 
-  test("preserves an emptied device: key", () => {
-    // A spent install referrer is recorded as an empty value under its
-    // `device:` key. Logout must leave the key in place: were it swept, the
-    // next signup on this device would re-read the shell's referrer.
-    localStorage.setItem("device:install_referrer", "");
-
-    clearUserScopedStorage();
-
-    expect(localStorage.getItem("device:install_referrer")).toBe("");
-  });
-
   test("automatically clears future vellum: keys without needing explicit registration", () => {
     localStorage.setItem("vellum:some-future-feature:asst-1", "data");
     localStorage.setItem("vellum:another-feature", "value");

--- a/clients/web/src/runtime/install-referrer.test.ts
+++ b/clients/web/src/runtime/install-referrer.test.ts
@@ -8,11 +8,8 @@ mock.module("@capacitor/core", () => ({
   registerPlugin: () => ({ read }),
 }));
 
-const {
-  captureInstallReferrer,
-  markInstallReferrerSpent,
-  readStoredInstallReferrer,
-} = await import("./install-referrer");
+const { captureInstallReferrer, markInstallReferrerSpent } =
+  await import("./install-referrer");
 
 const STORAGE_KEY = "device:install_referrer";
 
@@ -26,7 +23,7 @@ beforeEach(() => {
 test("does not touch the bridge outside Android", async () => {
   for (const other of ["web", "ios"]) {
     platform = other;
-    await captureInstallReferrer();
+    expect(await captureInstallReferrer()).toEqual({});
   }
   expect(read).not.toHaveBeenCalled();
   expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
@@ -36,19 +33,17 @@ test("swallows a shell whose plugin predates this bundle", async () => {
   read.mockRejectedValueOnce(
     new Error('"InstallReferrer" plugin is not implemented on android'),
   );
-  await captureInstallReferrer();
+  expect(await captureInstallReferrer()).toEqual({});
   expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
-  expect(readStoredInstallReferrer()).toEqual({});
 });
 
-test("stores only allowlisted params from a campaign referrer", async () => {
+test("returns and stores only allowlisted params from a campaign referrer", async () => {
   read.mockResolvedValueOnce({
     referrer:
       "utm_source=newsletter&utm_medium=email&utm_campaign=spring&gclid=abc123&anid=admob&not_a_param=x",
   });
-  await captureInstallReferrer();
 
-  expect(readStoredInstallReferrer()).toEqual({
+  expect(await captureInstallReferrer()).toEqual({
     utm_source: "newsletter",
     utm_medium: "email",
     utm_campaign: "spring",
@@ -63,8 +58,7 @@ test("stores the organic Play install signal", async () => {
   read.mockResolvedValueOnce({
     referrer: "utm_source=google-play&utm_medium=organic",
   });
-  await captureInstallReferrer();
-  expect(readStoredInstallReferrer()).toEqual({
+  expect(await captureInstallReferrer()).toEqual({
     utm_source: "google-play",
     utm_medium: "organic",
   });
@@ -74,17 +68,45 @@ test("stores nothing when no allowlisted param survives", async () => {
   for (const referrer of ["", "anid=admob&not_a_param=x", undefined]) {
     localStorage.clear();
     read.mockResolvedValueOnce({ referrer });
-    await captureInstallReferrer();
+    expect(await captureInstallReferrer()).toEqual({});
     expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
   }
+});
+
+test("returns a referrer whose storage write was rejected", async () => {
+  // Private mode and an exhausted quota reject the write; swapping the whole
+  // object is the only way happy-dom's storage refuses one.
+  const storage = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: {
+      getItem: () => null,
+      setItem: () => {
+        throw new Error("quota exceeded");
+      },
+    },
+  });
+  read.mockResolvedValueOnce({ referrer: "utm_source=newsletter" });
+  try {
+    expect(await captureInstallReferrer()).toEqual({
+      utm_source: "newsletter",
+    });
+  } finally {
+    if (storage) {
+      Object.defineProperty(globalThis, "localStorage", storage);
+    }
+  }
+  expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
 });
 
 test("reads the referrer at most once per install", async () => {
   read.mockResolvedValueOnce({ referrer: "utm_source=newsletter" });
   await captureInstallReferrer();
-  await captureInstallReferrer();
+
+  expect(await captureInstallReferrer()).toEqual({
+    utm_source: "newsletter",
+  });
   expect(read).toHaveBeenCalledTimes(1);
-  expect(readStoredInstallReferrer()).toEqual({ utm_source: "newsletter" });
 });
 
 test("a spend does not re-arm the bridge", async () => {
@@ -92,28 +114,20 @@ test("a spend does not re-arm the bridge", async () => {
   await captureInstallReferrer();
 
   markInstallReferrerSpent();
-  expect(readStoredInstallReferrer()).toEqual({});
-  // The emptied key is the spend record, so the shell (which answers `read()`
-  // with the same referrer forever) is never asked again. Without it the next
-  // user to sign up on this device inherits the first user's campaign.
   expect(localStorage.getItem(STORAGE_KEY)).toBe("");
 
   read.mockResolvedValue({ referrer: "utm_source=newsletter" });
-  await captureInstallReferrer();
+  expect(await captureInstallReferrer()).toEqual({});
   expect(read).toHaveBeenCalledTimes(1);
-  expect(readStoredInstallReferrer()).toEqual({});
 });
 
-test("a bridge that never answers stores nothing and stays retryable", async () => {
-  // A Play Store that binds without ever calling back would otherwise hold the
-  // auth flow that awaits this open forever.
-  read.mockImplementationOnce(
-    () => new Promise<{ referrer?: string }>(() => {}),
-  );
+test("a flow that captured nothing leaves the bridge retryable", async () => {
   await captureInstallReferrer();
+  markInstallReferrerSpent();
   expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
 
   read.mockResolvedValueOnce({ referrer: "utm_source=newsletter" });
-  await captureInstallReferrer();
-  expect(readStoredInstallReferrer()).toEqual({ utm_source: "newsletter" });
+  expect(await captureInstallReferrer()).toEqual({
+    utm_source: "newsletter",
+  });
 });

--- a/clients/web/src/runtime/install-referrer.ts
+++ b/clients/web/src/runtime/install-referrer.ts
@@ -26,77 +26,53 @@ const InstallReferrer =
   registerPlugin<InstallReferrerPlugin>("InstallReferrer");
 
 /**
- * Bound on the bridge read. It sits on the auth critical path, so a Play
- * Store that binds but never answers must not hold the sign-in button.
- */
-const READ_TIMEOUT_MS = 2_000;
-
-/**
- * Capture the Play install referrer into device storage, filtered to the
- * allowlist. A missing plugin degrades to storing nothing, never an error
- * (docs/CAPACITOR.md, "The skew rule").
+ * Allowlisted attribution from this install's Play referrer, captured into
+ * device storage on the way out and returned to the caller. `{}` on every
+ * other platform, on a shell whose plugin predates this bundle, and when the
+ * bridge answers nothing (docs/CAPACITOR.md, "The skew rule").
  *
- * The stored key's presence, an empty value included, is the record that this
- * install's referrer has been asked for. The shell answers `read()` with the
- * same value forever, so a spent referrer must never re-arm the bridge onto
- * the next user to sign up here. A read that answers nothing stores nothing,
- * leaving a later attempt free to retry.
+ * The shell bounds its own read and always answers, so this awaits it with no
+ * bound of its own; a shorter bound here would abandon a referrer the shell
+ * goes on to cache forever.
  */
-export async function captureInstallReferrer(): Promise<void> {
+export async function captureInstallReferrer(): Promise<
+  Record<string, string>
+> {
   if (Capacitor.getPlatform() !== "android") {
-    return;
+    return {};
   }
   if (hasDeviceSetting("installReferrer")) {
-    return;
+    // Re-filtered on read so a hand-edited or stale stored value can never
+    // widen what reaches the wire.
+    return readAttributionParams(getDeviceSetting("installReferrer", ""));
   }
   try {
-    const attribution = new URLSearchParams(
-      readAttributionParams(await readReferrer()),
-    ).toString();
-    if (!attribution) {
-      return;
+    const { referrer } = await InstallReferrer.read();
+    const attribution = readAttributionParams(referrer ?? "");
+    const captured = new URLSearchParams(attribution).toString();
+    if (captured) {
+      setDeviceSetting("installReferrer", captured);
     }
-    setDeviceSetting("installReferrer", attribution);
+    return attribution;
   } catch (error) {
     console.debug("[install-referrer] read unavailable:", error);
-  }
-}
-
-/** The shell's referrer, or `""` when it does not answer within the bound. */
-async function readReferrer(): Promise<string> {
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  try {
-    const { referrer } = await Promise.race([
-      InstallReferrer.read(),
-      new Promise<{ referrer?: string }>((resolve) => {
-        timer = setTimeout(() => {
-          console.debug(
-            `[install-referrer] read did not answer in ${READ_TIMEOUT_MS}ms`,
-          );
-          resolve({});
-        }, READ_TIMEOUT_MS);
-      }),
-    ]);
-    return referrer ?? "";
-  } finally {
-    clearTimeout(timer);
+    return {};
   }
 }
 
 /**
- * Allowlisted attribution captured from the install referrer, or `{}` when
- * this device has none. Re-filtered on read so a hand-edited or stale stored
- * value can never widen what reaches the wire.
- */
-export function readStoredInstallReferrer(): Record<string, string> {
-  return readAttributionParams(getDeviceSetting("installReferrer", ""));
-}
-
-/**
- * Record that a native auth flow has spent the referrer. The emptied key stays
- * behind as that record, so the next signup on this device starts
- * unattributed instead of inheriting this install's campaign.
+ * Record that a native auth flow has spent a captured referrer. The emptied
+ * key stays behind as that record: its presence, an empty value included, is
+ * what stops the next signup on this device from re-reading the bridge (the
+ * shell answers `read()` with the same value forever) and inheriting this
+ * install's campaign.
+ *
+ * A flow that captured nothing has nothing to spend, so it leaves the key
+ * absent and a later attempt free to retry.
  */
 export function markInstallReferrerSpent(): void {
+  if (getDeviceSetting("installReferrer", "") === "") {
+    return;
+  }
   setDeviceSetting("installReferrer", "");
 }

--- a/clients/web/src/runtime/native-auth.test.ts
+++ b/clients/web/src/runtime/native-auth.test.ts
@@ -408,8 +408,6 @@ describe("startAuthFlow attribution on native", () => {
     expect(lastStartAuthOptions().attribution).toEqual({
       utm_source: "google-play",
     });
-    // Emptied, not removed: the key that remains is what keeps the shell from
-    // handing the same referrer to the next user who signs up here.
     expect(localStorage.getItem(INSTALL_REFERRER_KEY)).toBe("");
     expect(window.location.href).toBe("/assistant/onboarding/privacy");
   });
@@ -439,6 +437,32 @@ describe("startAuthFlow attribution on native", () => {
       utm_medium: "organic",
     });
     expect(localStorage.getItem(INSTALL_REFERRER_KEY)).toBe("");
+  });
+
+  test("a login that captured no referrer leaves the next one retryable", async () => {
+    // The shell answered nothing here, so this login had nothing to spend and
+    // the next flow gets to ask again.
+    await runSignup();
+    expect(lastStartAuthOptions().attribution).toBeUndefined();
+    expect(localStorage.getItem(INSTALL_REFERRER_KEY)).toBeNull();
+
+    readInstallReferrer.mockResolvedValueOnce({
+      referrer: "utm_source=google-play&utm_medium=organic",
+    });
+    await runSignup();
+
+    expect(lastStartAuthOptions().attribution).toEqual({
+      utm_source: "google-play",
+      utm_medium: "organic",
+    });
+  });
+
+  test("an iOS login records no spend", async () => {
+    platform = "ios";
+
+    await runSignup();
+
+    expect(localStorage.getItem(INSTALL_REFERRER_KEY)).toBeNull();
   });
 
   test("leaves the stored referrer in place when native auth fails", async () => {

--- a/clients/web/src/runtime/native-auth.ts
+++ b/clients/web/src/runtime/native-auth.ts
@@ -19,7 +19,6 @@ import { primeElectronSessionToken } from "@/runtime/session-token";
 import {
   captureInstallReferrer,
   markInstallReferrerSpent,
-  readStoredInstallReferrer,
 } from "@/runtime/install-referrer";
 import {
   isBiometricEnabled,
@@ -229,9 +228,6 @@ async function completeNativeLogin(
     await waitForNativeSessionCookie();
   }
 
-  // The referrer is spent: it rode this flow's `startAuth` call. Recorded on
-  // login too, since we can't tell signup from login here and a retained value
-  // would attach this install's campaign to the next user to sign up here.
   markInstallReferrerSpent();
 
   // Persist the token in native secure storage for biometric session recovery.
@@ -403,9 +399,8 @@ async function resolveNativeAttribution(
   if (Object.keys(current).length > 0) {
     return current;
   }
-  await captureInstallReferrer();
-  const stored = readStoredInstallReferrer();
-  return Object.keys(stored).length > 0 ? stored : undefined;
+  const referrer = await captureInstallReferrer();
+  return Object.keys(referrer).length > 0 ? referrer : undefined;
 }
 
 /**
@@ -422,8 +417,6 @@ async function resolveNativeAttribution(
  * path, `USER_CANCELLED` (user tapped cancel on the auth sheet) is
  * swallowed since it's a routine dismissal, and all other errors are
  * re-thrown for the caller to handle.
- *
- * The native and web paths both forward marketing attribution.
  */
 export async function startAuthFlow(
   providerId: string,

--- a/clients/web/src/utils/device-settings.ts
+++ b/clients/web/src/utils/device-settings.ts
@@ -57,8 +57,7 @@ const DEVICE_SETTINGS = {
   lastUserId: { key: "device:last_user_id" },
   // Allowlisted attribution parsed out of the Android Play install referrer,
   // stored as a query string. Describes the install, so it outlives any
-  // account that signs in on this device. An empty value records that a native
-  // auth flow has spent it.
+  // account that signs in on this device.
   installReferrer: { key: "device:install_referrer" },
 } as const satisfies Record<string, DeviceSettingEntry>;
 


### PR DESCRIPTION
Second-round self-review remediation for the install-referrer arc. The previous
round left a defect that permanently destroys a campaign, plus four smaller
issues.

## The defect: two disagreeing read bounds plus an unconditional spend

The web layer raced `InstallReferrer.read()` against a 2s bound while the
plugin bound its own service bind at 5s. A Play bind answering between the two
made the plugin take its `OK` branch and durably cache the referrer with
`resolved = true`, while the web layer had already resolved `{}` and stored
nothing. `completeNativeLogin` then recorded a spend unconditionally, writing
`device:install_referrer = ""`, after which `captureInstallReferrer`
early-returned forever. The campaign was unreachable for the life of the install,
one SharedPreferences read away. The same trap swallowed the deliberately
uncached `SERVICE_UNAVAILABLE` / `SERVICE_DISCONNECTED` retries once any login
completed.

Both halves are fixed:

- **One bound, in the shell.** The web-side `Promise.race` is gone; the plugin
  always answers, so the web layer awaits it. `BIND_TIMEOUT_MS` drops from 5s
  to 2.5s because it now sits alone on the auth critical path ahead of the
  sign-in sheet. There is no shell carrying this plugin without the bind
  timeout, so nothing can hang here that a shorter web bound would have saved.
- **A spend records only what was there to spend.** `markInstallReferrerSpent`
  no-ops unless a non-empty captured value is stored. A flow that captured
  nothing leaves the key absent and retryable; a captured-and-spent one stays
  emptied, so a second user signing up on this device still cannot inherit the
  first user's campaign. The marker also stops being written on iOS, which has
  no referrer, and stops firing a `vellum:pref-changed` event on every
  successful native login.

Two further consequences fixed by the same gate: an Android login that used URL
attribution no longer burns an install referrer that was never read, and the
"stays retryable" test no longer asserts a sequence that cannot happen.

## Other fixes

- **A read that survives a failed write.** `captureInstallReferrer` returns the
  filtered `Record` instead of `void`, and `resolveNativeAttribution` uses that
  return value. `setLocalSetting` is best-effort and swallows quota and
  private-mode failures, so a successfully read referrer was being discarded
  when its write silently failed. This also drops `readAttributionParams` from
  three runs per native auth entry to at most two, and removes the localStorage
  round trip on a value written microseconds earlier.
- **A test that burned 2s of wall clock.** The "never answers" case awaited the
  real web bound. With no web bound it is gone; the suite drops from 2.19s to
  0.21s.
- **One invariant, one home.** The "an emptied key is the spend record"
  rationale lived in nine places. It now lives on `markInstallReferrerSpent`.
  CAPACITOR.md keeps the bridge contract and points at it; the inline copies in
  `install-referrer.test.ts`, `native-auth.test.ts`, and `device-settings.ts`
  are gone, as are two comments that restated the code beneath them (the
  `startAuthFlow` docstring's attribution line, and the duplicate between
  `BIND_TIMEOUT_MS`'s javadoc and the "A timed-out bind is transient" comment).
- **A redundant cleanup test.** `clearUserScopedStorage` is purely key-prefix
  based and never inspects values, and two existing tests already cover
  `device:` preservation, so "preserves an emptied `device:` key" is deleted.

## Verification

New tests fail against the pre-fix code and pass after:

- `a login that captured no referrer leaves the next one retryable` drives the
  real sequence, a login completing between two capture attempts. Before: the
  first login burns the key and the second flow forwards nothing. After: the
  second flow forwards the referrer.
- `an iOS login records no spend`. Before: the key is written as `""` on iOS.
- `a flow that captured nothing leaves the bridge retryable` in the
  install-referrer suite.
- `returns a referrer whose storage write was rejected` covers the discarded
  read, with the storage object swapped for one that throws.

`bun test` clean on `install-referrer`, `native-auth`, `session-cleanup`,
`device-settings`, and `social-auth`; `bun run typecheck` and `bun run lint`
clean (15 pre-existing warnings, 0 errors, none in touched files).

The Android change is a constant and comments only; no JDK here, so
`:app:testDevDebugUnitTest` runs in CI.