### PR TITLE
fix: schedule the avatar re-upload when the synced key expires

### DIFF
--- a/assistant/src/platform/platform-patch-queue.test.ts
+++ b/assistant/src/platform/platform-patch-queue.test.ts
@@ -1,4 +1,5 @@
 import {
+  afterEach,
   beforeEach,
   describe,
   expect,
@@ -31,6 +32,7 @@ interface Patch {
 let patches: Patch[];
 let respond: () => Response;
 let builds: number;
+let queues: Array<{ dispose: () => void }>;
 
 function makeClient(assistantId = "asst-1", baseUrl = "https://platform.a") {
   return {
@@ -50,7 +52,7 @@ function makeQueue(
     maxAgeMs?: number;
   } = {},
 ) {
-  return createPlatformPatchQueue<string | undefined>({
+  const queue = createPlatformPatchQueue<string | undefined>({
     log: getLogger("test"),
     label: "value",
     buildPayload: (value) => {
@@ -59,6 +61,8 @@ function makeQueue(
     },
     ...opts,
   });
+  queues.push(queue);
+  return queue;
 }
 
 async function settle(): Promise<void> {
@@ -73,6 +77,13 @@ describe("createPlatformPatchQueue", () => {
     builds = 0;
     respond = () => new Response("{}", { status: 200 });
     mockClient = makeClient();
+    queues = [];
+  });
+
+  afterEach(() => {
+    for (const queue of queues) {
+      queue.dispose();
+    }
   });
 
   test("PATCHes once and dedups an unchanged key", async () => {
@@ -222,6 +233,40 @@ describe("createPlatformPatchQueue", () => {
     queue.enqueue("a");
     await settle();
 
+    expect(patches).toHaveLength(1);
+  });
+
+  test("re-sends at expiry with no enqueue call, and dispose cancels that", async () => {
+    const queue = makeQueue({ maxAgeMs: 300 });
+    queue.enqueue("a");
+    await settle();
+    expect(patches).toHaveLength(1);
+
+    await new Promise((r) => setTimeout(r, 300));
+    await settle();
+    expect(patches).toHaveLength(2);
+    expect(builds).toBe(2);
+
+    queue.dispose();
+    await new Promise((r) => setTimeout(r, 300));
+    await settle();
+    expect(patches).toHaveLength(2);
+  });
+
+  test("a seeded, still-fresh key arms the expiry re-send", async () => {
+    const queue = makeQueue({
+      maxAgeMs: 300,
+      loadSyncedKey: () => ({
+        key: "https://platform.a|asst-1|a",
+        syncedAt: Date.now(),
+      }),
+    });
+    queue.enqueue("a");
+    await settle();
+    expect(patches).toHaveLength(0);
+
+    await new Promise((r) => setTimeout(r, 300));
+    await settle();
     expect(patches).toHaveLength(1);
   });
 

--- a/assistant/src/platform/platform-patch-queue.ts
+++ b/assistant/src/platform/platform-patch-queue.ts
@@ -6,10 +6,10 @@
  * stale in-flight response cannot overwrite a newer value. The dedup key is
  * scoped to the platform destination (base URL + assistant id), so
  * re-registering elsewhere re-sends an unchanged payload. With `maxAgeMs`, a
- * key only dedups while its last success is younger than that, checked on
- * every run so a long-lived process re-sends too. Best-effort: failures are
- * logged, never thrown, and leave the dedup key untouched so the next enqueue
- * retries.
+ * key only dedups while its last success is younger than that, and an unref'd
+ * timer re-enqueues the last input at expiry so an idle long-lived process
+ * re-sends without any caller. Best-effort: failures are logged, never
+ * thrown, and leave the dedup key untouched so the next enqueue retries.
  */
 
 import type { getLogger } from "../util/logger.js";
@@ -45,12 +45,14 @@ export interface PlatformPatchQueueOptions<T> {
   loadSyncedKey?: () => SyncedKey | null;
   /** Called after each successful PATCH. */
   saveSyncedKey?: (synced: SyncedKey) => void;
-  /** A matching key older than this re-sends; omit to never expire. */
+  /** A matching key older than this re-sends, via a timer; omit to never expire. */
   maxAgeMs?: number;
 }
 
 export interface PlatformPatchQueue<T> {
   enqueue: (input: T) => void;
+  /** Cancels the expiry timer; queued requests still run. */
+  dispose: () => void;
 }
 
 export function createPlatformPatchQueue<T = void>(
@@ -61,6 +63,17 @@ export function createPlatformPatchQueue<T = void>(
   let lastSynced: SyncedKey | null | undefined;
   let seq = 0;
   let pending: Promise<void> = Promise.resolve();
+  let expiryTimer: ReturnType<typeof setTimeout> | undefined;
+
+  function armExpiry(input: T): void {
+    if (maxAgeMs === undefined || !lastSynced) {
+      return;
+    }
+    clearTimeout(expiryTimer);
+    const delay = Math.max(0, lastSynced.syncedAt + maxAgeMs - Date.now());
+    expiryTimer = setTimeout(() => enqueue(input), delay);
+    expiryTimer.unref?.();
+  }
 
   async function run(input: T, requestSeq: number): Promise<void> {
     try {
@@ -83,6 +96,7 @@ export function createPlatformPatchQueue<T = void>(
         lastSynced?.key === key &&
         (maxAgeMs === undefined || Date.now() - lastSynced.syncedAt < maxAgeMs)
       ) {
+        armExpiry(input);
         return;
       }
       const body =
@@ -106,6 +120,7 @@ export function createPlatformPatchQueue<T = void>(
       if (resp.ok) {
         lastSynced = { key, syncedAt: Date.now() };
         saveSyncedKey?.(lastSynced);
+        armExpiry(input);
         log.info(
           { key: payload.key, assistantId },
           `Synced ${label} to platform`,
@@ -121,10 +136,15 @@ export function createPlatformPatchQueue<T = void>(
     }
   }
 
+  function enqueue(input: T): void {
+    const mySeq = ++seq;
+    pending = pending.then(() => run(input, mySeq)).catch(() => {});
+  }
+
   return {
-    enqueue(input: T): void {
-      const mySeq = ++seq;
-      pending = pending.then(() => run(input, mySeq)).catch(() => {});
+    enqueue,
+    dispose(): void {
+      clearTimeout(expiryTimer);
     },
   };
 }

--- a/assistant/src/platform/sync-avatar.test.ts
+++ b/assistant/src/platform/sync-avatar.test.ts
@@ -16,6 +16,7 @@ import {
   expect,
   mock,
   setSystemTime,
+  spyOn,
   test,
 } from "bun:test";
 
@@ -374,6 +375,41 @@ describe("syncAvatarToPlatform", () => {
       key: expect.stringMatching(/^https:\/\/platform\.a\|asst-1\|image:/),
       syncedAt: start + AVATAR_SYNC_KEY_TTL_MS,
     });
+  });
+
+  test("arms an unref'd timer that re-uploads at the TTL without a caller", async () => {
+    const armed: Array<{ delay: number; fire: () => void }> = [];
+    const realSetTimeout = globalThis.setTimeout;
+    const spy = spyOn(globalThis, "setTimeout").mockImplementation(((
+      fn: () => void,
+      delay?: number,
+    ) => {
+      if (
+        delay !== undefined &&
+        delay > AVATAR_SYNC_KEY_TTL_MS - 1000 &&
+        delay <= AVATAR_SYNC_KEY_TTL_MS
+      ) {
+        armed.push({ delay, fire: fn });
+        return { unref: () => undefined } as unknown as NodeJS.Timeout;
+      }
+      return realSetTimeout(fn, delay);
+    }) as typeof setTimeout);
+    try {
+      syncAvatarToPlatform();
+      await settle();
+      expect(patches).toHaveLength(1);
+      expect(armed).toHaveLength(1);
+
+      setSystemTime(new Date(Date.now() + AVATAR_SYNC_KEY_TTL_MS));
+      armed[0]!.fire();
+      await settle();
+    } finally {
+      spy.mockRestore();
+      setSystemTime();
+    }
+
+    expect(patches).toHaveLength(2);
+    expect(armed).toHaveLength(2);
   });
 
   test("a corrupt persisted key re-uploads", async () => {

--- a/assistant/src/platform/sync-avatar.ts
+++ b/assistant/src/platform/sync-avatar.ts
@@ -9,10 +9,11 @@
  * syncs. The last synced key is persisted outside the workspace repo at
  * `<protected dir>/platform-sync/avatar.json` so a daemon restart does not
  * re-upload an unchanged raster and the record never dirties the workspace.
- * A synced key older than `AVATAR_SYNC_KEY_TTL_MS` no longer dedups, whether
- * seeded from disk or set in-process, so an avatar lost server-side while id
- * and base URL are unchanged is re-pushed within a week even by a daemon
- * that never restarts (API-key auth cannot read the record to verify it).
+ * A synced key older than `AVATAR_SYNC_KEY_TTL_MS` does not dedup, whether
+ * seeded from disk or set in-process, and the queue re-enqueues itself when
+ * the key expires, so an avatar lost server-side while id and base URL are
+ * unchanged is re-pushed within a week even by a daemon that never restarts
+ * (API-key auth cannot read the record to verify it).
  * `avatar_base64: null` is sent only when the avatar is actually removed; a
  * non-none avatar whose raster is missing (image PNG gone, character
  * re-render unavailable) is skipped so the platform keeps the last synced
@@ -51,6 +52,7 @@ let queue: PlatformPatchQueue<void> | null = null;
 
 /** Recreates the queue so the next sync re-seeds its dedup key from disk. */
 export function _resetSyncAvatarStateForTests(): void {
+  queue?.dispose();
   queue = null;
 }
 


### PR DESCRIPTION
## Summary
Fixes a gap identified during plan review (round 5) for chooser-assistant-avatars.md.

**Gap:** the sync-key TTL was only evaluated on enqueue, so an idle long-running daemon never re-pushed; the queue now arms an unref'd timer at expiry

CI skipped: GitHub Actions is degraded (queued/startup_failure across the org); local validation (4 test files, typecheck, eslint, prettier) is green.