### PR TITLE
fix(design-library): stop VirtualList from silently enabling follow-output (LUM-3466)

### DIFF
--- a/packages/design-library/src/components/virtual-list/virtual-list.test.tsx
+++ b/packages/design-library/src/components/virtual-list/virtual-list.test.tsx
@@ -25,8 +25,7 @@ describe("resolveFollowOutput", () => {
     // `false` exactly, not merely falsy: virtuoso applies every prop that is
     // present on the element, so an explicit `undefined` overrides its own
     // `false` default and its strict `!== false` checks then read it as
-    // follow-output ON. That pinned the sidebar sections to the bottom and
-    // made endReached drain every page on cold boot (LUM-3466).
+    // follow-output ON, pinning a growing list to the bottom.
     expect(resolveFollowOutput(undefined)).toBe(false);
     expect(resolveFollowOutput(false)).toBe(false);
   });

--- a/packages/design-library/src/components/virtual-list/virtual-list.test.tsx
+++ b/packages/design-library/src/components/virtual-list/virtual-list.test.tsx
@@ -21,9 +21,14 @@ import {
 } from "./virtual-list";
 
 describe("resolveFollowOutput", () => {
-  test("falsy values disable following", () => {
-    expect(resolveFollowOutput(undefined)).toBeUndefined();
-    expect(resolveFollowOutput(false)).toBeUndefined();
+  test("falsy values disable following with an explicit false, never undefined", () => {
+    // `false` exactly, not merely falsy: virtuoso applies every prop that is
+    // present on the element, so an explicit `undefined` overrides its own
+    // `false` default and its strict `!== false` checks then read it as
+    // follow-output ON. That pinned the sidebar sections to the bottom and
+    // made endReached drain every page on cold boot (LUM-3466).
+    expect(resolveFollowOutput(undefined)).toBe(false);
+    expect(resolveFollowOutput(false)).toBe(false);
   });
 
   test("true follows only while the user is already at the bottom", () => {

--- a/packages/design-library/src/components/virtual-list/virtual-list.tsx
+++ b/packages/design-library/src/components/virtual-list/virtual-list.tsx
@@ -98,21 +98,20 @@ const DEFAULT_AT_BOTTOM_THRESHOLD = 64;
  * callback returns a truthy follow mode only while the user is already at the
  * bottom, so streaming never yanks a user who has scrolled up back down.
  *
- * A falsy prop disables following by resolving to `false`, and it must be
- * `false`, never `undefined`. Virtuoso applies every prop that is *present*
- * (`"followOutput" in props`), so an explicit `undefined` overrides its own
- * `false` default, and its internal checks are all strict `!== false` /
- * truthiness tests that read `undefined` as follow-output ON: the list then
- * re-pins itself to the bottom whenever its size grows or its viewport
- * shrinks. In a list whose `endReached` loads more rows that is a
- * self-sustaining loop: append, auto-scroll to bottom, `endReached`, append
- * (LUM-3466, the sidebar draining every conversation and parking at the
- * oldest row on cold boot).
+ * A falsy prop resolves to an explicit `false`, never `undefined`. Virtuoso
+ * applies every prop that is present (`"followOutput" in props`), so an
+ * explicit `undefined` overrides its own `false` default, and its internal
+ * checks are strict `!== false` / truthiness tests that read `undefined` as
+ * follow-output ON: the list then re-pins itself to the bottom whenever its
+ * size grows or its viewport shrinks, and paired with an `endReached` that
+ * loads more rows that is a self-sustaining drain loop.
  */
 export function resolveFollowOutput(
   followOutput: VirtualListProps<unknown>["followOutput"],
 ): FollowOutput {
-  if (!followOutput) return false;
+  if (!followOutput) {
+    return false;
+  }
   const mode = followOutput === "smooth" ? "smooth" : true;
   return (isAtBottom: boolean) => (isAtBottom ? mode : false);
 }

--- a/packages/design-library/src/components/virtual-list/virtual-list.tsx
+++ b/packages/design-library/src/components/virtual-list/virtual-list.tsx
@@ -96,13 +96,23 @@ const DEFAULT_AT_BOTTOM_THRESHOLD = 64;
 /**
  * Map the scalar `followOutput` prop to virtuoso's callback form. The
  * callback returns a truthy follow mode only while the user is already at the
- * bottom, so streaming never yanks a user who has scrolled up back down. A
- * falsy prop disables following entirely (returns `undefined`).
+ * bottom, so streaming never yanks a user who has scrolled up back down.
+ *
+ * A falsy prop disables following by resolving to `false`, and it must be
+ * `false`, never `undefined`. Virtuoso applies every prop that is *present*
+ * (`"followOutput" in props`), so an explicit `undefined` overrides its own
+ * `false` default, and its internal checks are all strict `!== false` /
+ * truthiness tests that read `undefined` as follow-output ON: the list then
+ * re-pins itself to the bottom whenever its size grows or its viewport
+ * shrinks. In a list whose `endReached` loads more rows that is a
+ * self-sustaining loop: append, auto-scroll to bottom, `endReached`, append
+ * (LUM-3466, the sidebar draining every conversation and parking at the
+ * oldest row on cold boot).
  */
 export function resolveFollowOutput(
   followOutput: VirtualListProps<unknown>["followOutput"],
-): FollowOutput | undefined {
-  if (!followOutput) return undefined;
+): FollowOutput {
+  if (!followOutput) return false;
   const mode = followOutput === "smooth" ? "smooth" : true;
   return (isAtBottom: boolean) => (isAtBottom ? mode : false);
 }


### PR DESCRIPTION
## TL;DR

On a cold start (kill and reopen the app), every sidebar section silently ran react-virtuoso's follow-output ("stick to the bottom when content grows"), because `VirtualList` passed `followOutput={undefined}` and virtuoso treats a present-but-undefined prop as overriding its own `false` default. Combined with the windowed sections' `endReached` load-more, that made a self-sustaining loop: backfill a page, auto-scroll to the bottom, `endReached` fires, load the next page... until the whole conversation list had drained, with the sidebar left parked at the oldest chat. This is Marina's LUM-3466 repro on both desktop and mobile. The fix is resolving a falsy `followOutput` to an explicit `false`.

Fixes LUM-3466

## Root cause

- `resolveFollowOutput` mapped both "unset" and `false` to `undefined`, and `VirtualList` passes the result unconditionally.
- Virtuoso's optional-prop plumbing applies every prop that is **present** (`"prop" in props`), so the explicit `undefined` replaced its internal `false` default. This is the same trap the component already documents (and conditionally spreads around) for `overscan`/`increaseViewportBy`.
- Virtuoso's follow-output guards are strict `!== false` and truthiness checks (`atBottom && coerce(followOutput)` coerces `undefined` to `"auto"`), so `undefined` behaves as follow-output ON: re-pin to the bottom whenever the list grows while at the bottom, when a data refresh grows the size, or when the viewport shrinks.
- Cold boot is the one time a section list passes through a short-window state that virtuoso reads as "at bottom", which bootstraps the loop. A warm sidebar mounts long at scrollTop 0 and never follows, which is why this only shows after killing the app.
- The wrapper bug existed since VirtualList landed, but it was unreachable until the sidebar sections became windowed with `endReached`-driven load-more (LUM-2444); that gave the follow loop its fuel.

## Verification

- Reproduced in isolation: a bare `VirtualList` (no `followOutput` prop) whose `endReached` appends a page after a short delay pins itself to the bottom and drains page after page with zero user input, matching the Loom (viewport riding the bottom at load-more cadence, settling on the oldest rows).
- With this fix, the same setup does one mount-time backfill (the documented short-window behavior) and stays at the top; no auto-scroll, no loop.
- The unit test that had been asserting the buggy `undefined` now asserts `false`, with a comment explaining why `undefined` is not "off" for virtuoso.
- No consumer passes `followOutput` today (checked web + design library), so nothing relied on the accidental following; `false` is virtuoso's own default, and lists that do opt in are unchanged.

## Before / after

| | Before | After |
|---|---|---|
| Kill and reopen the app | Sidebar loads every conversation page by page on its own and ends up scrolled to the oldest chats | Sidebar loads one window per section and stays at the top |
| Scrolling a long section | List can yank back to the bottom when pages load or layout shifts | Scroll position stays where the user put it |
| Chat-style lists that opt into `followOutput` | Follows output while at the bottom | Unchanged |

## Notes

- The *other* half of "all the chats load": the foreground bucket query still drains every page on cold boot by design (the LUM-2409/LUM-2443/LUM-2444 arc; windowing the buckets is tracked there and in LUM-637). That is a known interim state and not what this PR changes; what users saw and reported here (the visible fill-in and the scroll-down) was the follow-output loop on the Chats section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
