### PR TITLE
fix(schedule): alert once per failure cause, not twice per failing schedule

### DIFF
--- a/assistant/src/__tests__/llm-resolver.test.ts
+++ b/assistant/src/__tests__/llm-resolver.test.ts
@@ -909,6 +909,25 @@ describe("mix profiles", () => {
     ).toBeUndefined();
   });
 
+  test("resolveSingleRouteProfileKey honors the dispatch resolvability predicate", () => {
+    // A pin whose provider dispatch cannot resolve (e.g. a force-deleted
+    // connection) must not be claimed as a scope: selection falls through to
+    // the active mix exactly as dispatch does, which then refuses to name a
+    // route.
+    expect(
+      resolveSingleRouteProfileKey("mainAgent", mixLlm, {
+        overrideProfile: "a",
+        isResolvableProvider: () => false,
+      }),
+    ).toBeUndefined();
+    expect(
+      resolveSingleRouteProfileKey("mainAgent", mixLlm, {
+        overrideProfile: "a",
+        isResolvableProvider: () => true,
+      }),
+    ).toBe("a");
+  });
+
   test("all dereference spots in a turn agree for the same seed", () => {
     // mainAgent (mix as activeProfile) and a non-main call site resolving the
     // same mix as its call-site profile must pick the same arm when given the

--- a/assistant/src/__tests__/llm-resolver.test.ts
+++ b/assistant/src/__tests__/llm-resolver.test.ts
@@ -9,6 +9,7 @@ import {
   resolveCallSiteConfigWithProfile,
   resolveDefaultProfileKey,
   resolveEffectiveProfileKey,
+  resolveSingleRouteProfileKey,
 } from "../config/llm-resolver.js";
 import { type LLMCallSite, LLMSchema } from "../config/schemas/llm.js";
 import { resolveModelIntent } from "../providers/model-intents.js";
@@ -887,6 +888,25 @@ describe("mix profiles", () => {
     expect(resolved.config.model).toBe(
       selectedArms[0] === "a" ? "model-a" : "model-b",
     );
+  });
+
+  test("resolveSingleRouteProfileKey names standard winners and refuses mixes", () => {
+    // The mix's arm is picked per conversation and can differ from any
+    // post-hoc recomputation, so the outer mix key must never be used as a
+    // single-route attribution scope.
+    expect(resolveSingleRouteProfileKey("mainAgent", mixLlm)).toBeUndefined();
+    expect(
+      resolveSingleRouteProfileKey("mainAgent", mixLlm, {
+        overrideProfile: "a",
+      }),
+    ).toBe("a");
+    // An unusable override falls through to the active mix, which still
+    // refuses to name a route.
+    expect(
+      resolveSingleRouteProfileKey("mainAgent", mixLlm, {
+        overrideProfile: "no-such-profile",
+      }),
+    ).toBeUndefined();
   });
 
   test("all dereference spots in a turn agree for the same seed", () => {

--- a/assistant/src/__tests__/llm-resolver.test.ts
+++ b/assistant/src/__tests__/llm-resolver.test.ts
@@ -913,19 +913,34 @@ describe("mix profiles", () => {
     // A pin whose provider dispatch cannot resolve (e.g. a force-deleted
     // connection) must not be claimed as a scope: selection falls through to
     // the active mix exactly as dispatch does, which then refuses to name a
-    // route.
+    // route. Without the predicate the stale pin still wins the chain, which
+    // is why scope callers must pass dispatch's predicate.
+    const staleLlm = LLMSchema.parse({
+      profiles: {
+        a: { provider: "anthropic", model: "model-a" },
+        b: { provider: "anthropic", model: "model-b" },
+        stale: { provider: "openai", model: "model-s" },
+        ab: {
+          mix: [
+            { profile: "a", weight: 1 },
+            { profile: "b", weight: 1 },
+          ],
+        },
+      },
+      activeProfile: "ab",
+    });
+    const openaiForceDeleted = (provider: string) => provider !== "openai";
     expect(
-      resolveSingleRouteProfileKey("mainAgent", mixLlm, {
-        overrideProfile: "a",
-        isResolvableProvider: () => false,
+      resolveSingleRouteProfileKey("mainAgent", staleLlm, {
+        overrideProfile: "stale",
+        isResolvableProvider: openaiForceDeleted,
       }),
     ).toBeUndefined();
     expect(
-      resolveSingleRouteProfileKey("mainAgent", mixLlm, {
-        overrideProfile: "a",
-        isResolvableProvider: () => true,
+      resolveSingleRouteProfileKey("mainAgent", staleLlm, {
+        overrideProfile: "stale",
       }),
-    ).toBe("a");
+    ).toBe("stale");
   });
 
   test("all dereference spots in a turn agree for the same seed", () => {

--- a/assistant/src/__tests__/schedule-retry.test.ts
+++ b/assistant/src/__tests__/schedule-retry.test.ts
@@ -540,12 +540,64 @@ describe("execute-mode failure notifications", () => {
     expect(alert.sourceEventName).toBe("activity.failed");
     expect(alert.sourceContextId).toBe(schedule.id);
     expect(alert.dedupeKey).toMatch(
-      /^activity-failed:cause:PROVIDER_BILLING:\d{4}-\d{2}-\d{2}$/,
+      /^activity-failed:cause:PROVIDER_BILLING:default:\d{4}-\d{2}-\d{2}$/,
     );
     expect(alert.contextPayload).toMatchObject({
       jobName: "schedule:Billing victim",
       errorKind: "model_provider",
     });
+  });
+
+  test("schedules on different profiles alert separately for the same cause", async () => {
+    // Two provider connections can fail for the same class of reason with
+    // different remedies; schedule A's alert must not suppress schedule B's.
+    const emitted: Array<Record<string, unknown>> = [];
+    emitNotificationSignalImpl = async (payload) => {
+      emitted.push(payload as Record<string, unknown>);
+    };
+    runnerFailureClassification = {
+      errorKind: "model_provider",
+      failureCode: "PROVIDER_INVALID_KEY",
+    };
+
+    const scheduleA = await createSchedule({
+      name: "Profile A victim",
+      cronExpression: "0 * * * *",
+      message: "do work",
+      syntax: "cron",
+      maxRetries: 1,
+      retryBackoffMs: 1000,
+      inferenceProfile: "profile-a",
+    });
+    const scheduleB = await createSchedule({
+      name: "Profile B victim",
+      cronExpression: "0 * * * *",
+      message: "do work",
+      syntax: "cron",
+      maxRetries: 1,
+      retryBackoffMs: 1000,
+      inferenceProfile: "profile-b",
+    });
+    forceScheduleDue(scheduleA.id);
+    forceScheduleDue(scheduleB.id);
+
+    scheduler = startScheduler(async () => {
+      throw new Error("provider rejected the key");
+    });
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    forceScheduleDue(scheduleA.id);
+    forceScheduleDue(scheduleB.id);
+    await scheduler.runOnce();
+    scheduler.stop();
+
+    expect(emitted).toHaveLength(2);
+    const keys = emitted.map((signal) => signal.dedupeKey as string).sort();
+    expect(keys[0]).toMatch(
+      /^activity-failed:cause:PROVIDER_INVALID_KEY:profile-a:\d{4}-\d{2}-\d{2}$/,
+    );
+    expect(keys[1]).toMatch(
+      /^activity-failed:cause:PROVIDER_INVALID_KEY:profile-b:\d{4}-\d{2}-\d{2}$/,
+    );
   });
 
   test("a cause-less failure keys the exhaustion alert per schedule", async () => {

--- a/assistant/src/__tests__/schedule-retry.test.ts
+++ b/assistant/src/__tests__/schedule-retry.test.ts
@@ -10,12 +10,23 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 let injectedProcessMessageForRunner:
   | ((conversationId: string, message: string) => Promise<unknown>)
   | null = null;
+// Options of every mocked `runBackgroundJob` call, for asserting what the
+// scheduler asked of the runner (e.g. that per-attempt failure emissions are
+// suppressed in favor of the retries-exhausted alert).
+const runnerCalls: Array<Record<string, unknown>> = [];
+// When set, a failing mocked run reports this classification instead of the
+// default generic exception, letting a test drive the cause-keyed alert path.
+let runnerFailureClassification: {
+  errorKind: "timeout" | "model_provider" | "exception";
+  failureCode?: string;
+} | null = null;
 mock.module("../runtime/background-job-runner.js", () => ({
   runBackgroundJob: async (opts: {
     jobName: string;
     prompt: string;
     onConversationCreated?: (conversationId: string) => void;
   }) => {
+    runnerCalls.push(opts as unknown as Record<string, unknown>);
     const conversationId = `mock-conv-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     opts.onConversationCreated?.(conversationId);
     try {
@@ -29,7 +40,7 @@ mock.module("../runtime/background-job-runner.js", () => ({
         conversationId,
         ok: false,
         error,
-        errorKind: "exception" as const,
+        ...(runnerFailureClassification ?? { errorKind: "exception" as const }),
       };
     }
   },
@@ -466,6 +477,113 @@ describe("scheduler retry integration", () => {
   });
 });
 
+// ── Execute-mode failure notifications ────────────────────────────────
+
+describe("execute-mode failure notifications", () => {
+  let scheduler: SchedulerHandle;
+
+  beforeEach(() => {
+    emitNotificationSignalImpl = async () => {};
+    runnerCalls.length = 0;
+    runnerFailureClassification = null;
+    const db = getDb();
+    db.run("DELETE FROM cron_runs");
+    db.run("DELETE FROM cron_jobs");
+  });
+
+  afterEach(() => {
+    scheduler?.stop();
+    runnerFailureClassification = null;
+  });
+
+  test("a failing schedule alerts once, at exhaustion, keyed on the failure cause", async () => {
+    const emitted: Array<Record<string, unknown>> = [];
+    emitNotificationSignalImpl = async (payload) => {
+      emitted.push(payload as Record<string, unknown>);
+    };
+    runnerFailureClassification = {
+      errorKind: "model_provider",
+      failureCode: "PROVIDER_BILLING",
+    };
+
+    const schedule = await createSchedule({
+      name: "Billing victim",
+      cronExpression: "0 * * * *",
+      message: "do work",
+      syntax: "cron",
+      maxRetries: 1,
+      retryBackoffMs: 1000,
+    });
+    forceScheduleDue(schedule.id);
+
+    scheduler = startScheduler(async () => {
+      throw new Error("PROVIDER_BILLING: Agent turn failed.");
+    });
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    // First failure: a retry is pending, so nothing is user-visible yet, and
+    // the scheduler told the runner to keep its per-attempt emission quiet.
+    expect(emitted).toHaveLength(0);
+    expect(runnerCalls.length).toBeGreaterThanOrEqual(1);
+    for (const call of runnerCalls) {
+      expect(call.suppressFailureNotifications).toBe(true);
+    }
+
+    // Second failure exhausts retries (maxRetries: 1) and fires the single
+    // alert, deduped on the classified cause rather than the schedule.
+    forceScheduleDue(schedule.id);
+    await scheduler.runOnce();
+    scheduler.stop();
+
+    expect(emitted).toHaveLength(1);
+    const alert = emitted[0];
+    expect(alert.sourceEventName).toBe("activity.failed");
+    expect(alert.sourceContextId).toBe(schedule.id);
+    expect(alert.dedupeKey).toMatch(
+      /^activity-failed:cause:PROVIDER_BILLING:\d{4}-\d{2}-\d{2}$/,
+    );
+    expect(alert.contextPayload).toMatchObject({
+      jobName: "schedule:Billing victim",
+      errorKind: "model_provider",
+    });
+  });
+
+  test("a cause-less failure keys the exhaustion alert per schedule", async () => {
+    const emitted: Array<Record<string, unknown>> = [];
+    emitNotificationSignalImpl = async (payload) => {
+      emitted.push(payload as Record<string, unknown>);
+    };
+
+    const schedule = await createSchedule({
+      name: "Crashing job",
+      cronExpression: "0 * * * *",
+      message: "do work",
+      syntax: "cron",
+      maxRetries: 1,
+      retryBackoffMs: 1000,
+    });
+    forceScheduleDue(schedule.id);
+
+    scheduler = startScheduler(async () => {
+      throw new Error("boom");
+    });
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    forceScheduleDue(schedule.id);
+    await scheduler.runOnce();
+    scheduler.stop();
+
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0].dedupeKey).toMatch(
+      new RegExp(
+        `^activity-failed:schedule:${schedule.id}:\\d{4}-\\d{2}-\\d{2}$`,
+      ),
+    );
+    expect(emitted[0].contextPayload).toMatchObject({
+      errorKind: "exception",
+    });
+  });
+});
+
 // ── Crash recovery ────────────────────────────────────────────────────
 
 describe("crash recovery", () => {
@@ -667,7 +785,6 @@ describe("scheduler-recovery equivalence", () => {
     await applyRetryDecision({
       job: jobB,
       isOneShot: false,
-      errorMsg: "fail",
       decision,
       scheduleRetry,
       failOneShotPermanently: () => {},
@@ -747,7 +864,6 @@ describe("scheduler-recovery equivalence", () => {
     await applyRetryDecision({
       job: jobB1,
       isOneShot: true,
-      errorMsg: "fail",
       decision: decision1,
       scheduleRetry,
       failOneShotPermanently: (id: string) => {
@@ -774,7 +890,6 @@ describe("scheduler-recovery equivalence", () => {
     await applyRetryDecision({
       job: jobB2,
       isOneShot: true,
-      errorMsg: "fail",
       decision: decision2,
       scheduleRetry,
       failOneShotPermanently: (id: string) => {

--- a/assistant/src/__tests__/schedule-retry.test.ts
+++ b/assistant/src/__tests__/schedule-retry.test.ts
@@ -573,7 +573,7 @@ describe("execute-mode failure notifications", () => {
       syntax: "cron",
       maxRetries: 1,
       retryBackoffMs: 1000,
-      inferenceProfile: "profile-a",
+      inferenceProfile: "cost-optimized",
     });
     const scheduleB = await createSchedule({
       name: "Profile B victim",
@@ -582,7 +582,7 @@ describe("execute-mode failure notifications", () => {
       syntax: "cron",
       maxRetries: 1,
       retryBackoffMs: 1000,
-      inferenceProfile: "profile-b",
+      inferenceProfile: "balanced",
     });
     forceScheduleDue(scheduleA.id);
     forceScheduleDue(scheduleB.id);
@@ -599,10 +599,10 @@ describe("execute-mode failure notifications", () => {
     expect(emitted).toHaveLength(2);
     const keys = emitted.map((signal) => signal.dedupeKey as string).sort();
     expect(keys[0]).toMatch(
-      /^activity-failed:cause:PROVIDER_INVALID_KEY:profile-a:\d{4}-\d{2}-\d{2}$/,
+      /^activity-failed:cause:PROVIDER_INVALID_KEY:balanced:\d{4}-\d{2}-\d{2}$/,
     );
     expect(keys[1]).toMatch(
-      /^activity-failed:cause:PROVIDER_INVALID_KEY:profile-b:\d{4}-\d{2}-\d{2}$/,
+      /^activity-failed:cause:PROVIDER_INVALID_KEY:cost-optimized:\d{4}-\d{2}-\d{2}$/,
     );
   });
 

--- a/assistant/src/__tests__/schedule-retry.test.ts
+++ b/assistant/src/__tests__/schedule-retry.test.ts
@@ -539,8 +539,13 @@ describe("execute-mode failure notifications", () => {
     const alert = emitted[0];
     expect(alert.sourceEventName).toBe("activity.failed");
     expect(alert.sourceContextId).toBe(schedule.id);
+    // Schedules always resolve a concrete inference profile at creation, and
+    // that profile is the alert's provider scope.
+    const scope = schedule.inferenceProfile ?? "default";
     expect(alert.dedupeKey).toMatch(
-      /^activity-failed:cause:PROVIDER_BILLING:default:\d{4}-\d{2}-\d{2}$/,
+      new RegExp(
+        `^activity-failed:cause:PROVIDER_BILLING:${scope}:\\d{4}-\\d{2}-\\d{2}$`,
+      ),
     );
     expect(alert.contextPayload).toMatchObject({
       jobName: "schedule:Billing victim",

--- a/assistant/src/__tests__/schedule-retry.test.ts
+++ b/assistant/src/__tests__/schedule-retry.test.ts
@@ -539,9 +539,10 @@ describe("execute-mode failure notifications", () => {
     const alert = emitted[0];
     expect(alert.sourceEventName).toBe("activity.failed");
     expect(alert.sourceContextId).toBe(schedule.id);
-    // Schedules always resolve a concrete inference profile at creation, and
-    // that profile is the alert's provider scope.
-    const scope = schedule.inferenceProfile ?? "default";
+    // Schedules snapshot a concrete inference profile at creation, and that
+    // profile is the alert's provider scope.
+    const scope = schedule.inferenceProfile;
+    expect(scope).toBeTruthy();
     expect(alert.dedupeKey).toMatch(
       new RegExp(
         `^activity-failed:cause:PROVIDER_BILLING:${scope}:\\d{4}-\\d{2}-\\d{2}$`,

--- a/assistant/src/__tests__/scheduler-reuse-conversation.test.ts
+++ b/assistant/src/__tests__/scheduler-reuse-conversation.test.ts
@@ -456,7 +456,7 @@ describe("scheduler talk-mode runner option propagation", () => {
     runBackgroundJobBootstrapFails = false;
   });
 
-  test("talk-mode propagates conversationType=scheduled, scheduleJobId, and quiet=>suppressFailureNotifications", async () => {
+  test("talk-mode propagates conversationType=scheduled and scheduleJobId", async () => {
     const rruleExpr = buildEveryMinuteRrule();
     const schedule = await createSchedule({
       name: "Quiet Talk Mode",
@@ -475,10 +475,12 @@ describe("scheduler talk-mode runner option propagation", () => {
     expect(opts.conversationType).toBe("scheduled");
     expect(opts.scheduleJobId).toBe(schedule.id);
     expect(opts.groupId).toBe("system:scheduled");
-    expect(opts.suppressFailureNotifications).toBe(true);
   });
 
-  test("talk-mode without quiet leaves suppressFailureNotifications=false", async () => {
+  test("talk-mode always suppresses the runner's per-attempt failure emission", async () => {
+    // The retry policy owns the single user-facing alert for a failing
+    // schedule (fired once, at exhaustion), so the runner must stay quiet
+    // per attempt whether or not the schedule itself is quiet.
     const rruleExpr = buildEveryMinuteRrule();
     const schedule = await createSchedule({
       name: "Loud Talk Mode",
@@ -493,9 +495,7 @@ describe("scheduler talk-mode runner option propagation", () => {
     await runDueSchedulesOnce();
 
     expect(runBackgroundJobOptions).toHaveLength(1);
-    expect(runBackgroundJobOptions[0]!.suppressFailureNotifications).toBe(
-      false,
-    );
+    expect(runBackgroundJobOptions[0]!.suppressFailureNotifications).toBe(true);
   });
 
   test("talk-mode bootstrap failure writes sentinel conversationId, not empty string", async () => {

--- a/assistant/src/config/llm-resolver.ts
+++ b/assistant/src/config/llm-resolver.ts
@@ -644,6 +644,30 @@ export function resolveEffectiveProfileKey(
 }
 
 /**
+ * Returns the winning profile key only when it identifies a single provider
+ * route: one profile whose own provider/model fragment serves every call it
+ * wins. A mix winner returns `undefined` on purpose. Its arm is picked per
+ * conversation from a seed (or `Math.random()` unseeded), so a caller
+ * recomputing after the fact cannot know which arm actually ran, and arms can
+ * span providers, so the outer mix key would put one label on what are
+ * several provider routes. Use this where attribution must not claim a
+ * broader scope than the route that ran (e.g. failure-notification dedupe);
+ * `undefined` means "no single route can be named", and callers fall back to
+ * their narrower key.
+ */
+export function resolveSingleRouteProfileKey(
+  callSite: LLMCallSite,
+  llm: z.infer<typeof LLMSchema>,
+  opts: ResolveCallSiteOpts = {},
+): string | undefined {
+  const name = selectWinningProfile(callSite, llm, opts).profileName;
+  if (name == null) {
+    return undefined;
+  }
+  return providerAwareEntry(llm, name)?.mix == null ? name : undefined;
+}
+
+/**
  * Stable non-null identity for profileless configs. Callers should prefer real
  * profile keys first; when no named profile applies, the resolved model id is
  * the only model-selection identifier available.

--- a/assistant/src/notifications/__tests__/activity-failed-dedupe.test.ts
+++ b/assistant/src/notifications/__tests__/activity-failed-dedupe.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test";
+
+import { activityFailedDedupeKey } from "../activity-failed-dedupe.js";
+
+describe("activityFailedDedupeKey", () => {
+  test("a failure code keys on the cause, whatever the job", () => {
+    const heartbeat = activityFailedDedupeKey({
+      jobName: "heartbeat",
+      errorKind: "model_provider",
+      failureCode: "PROVIDER_BILLING",
+    });
+    const schedule = activityFailedDedupeKey({
+      jobName: "schedule:job-123",
+      errorKind: "model_provider",
+      failureCode: "PROVIDER_BILLING",
+    });
+    expect(heartbeat).toBe(schedule);
+    expect(heartbeat).toMatch(
+      /^activity-failed:cause:PROVIDER_BILLING:\d{4}-\d{2}-\d{2}$/,
+    );
+  });
+
+  test("distinct failure codes stay distinct", () => {
+    const billing = activityFailedDedupeKey({
+      jobName: "job",
+      errorKind: "model_provider",
+      failureCode: "PROVIDER_BILLING",
+    });
+    const key = activityFailedDedupeKey({
+      jobName: "job",
+      errorKind: "model_provider",
+      failureCode: "MANAGED_KEY_INVALID",
+    });
+    expect(billing).not.toBe(key);
+  });
+
+  test("code-less provider failures share the model_provider cause key", () => {
+    const a = activityFailedDedupeKey({
+      jobName: "watcher-a",
+      errorKind: "model_provider",
+    });
+    const b = activityFailedDedupeKey({
+      jobName: "watcher-b",
+      errorKind: "model_provider",
+    });
+    expect(a).toBe(b);
+    expect(a).toMatch(
+      /^activity-failed:cause:model_provider:\d{4}-\d{2}-\d{2}$/,
+    );
+  });
+
+  test("job-specific failures key per job", () => {
+    const timeoutA = activityFailedDedupeKey({
+      jobName: "job-a",
+      errorKind: "timeout",
+    });
+    const timeoutB = activityFailedDedupeKey({
+      jobName: "job-b",
+      errorKind: "timeout",
+    });
+    const exceptionA = activityFailedDedupeKey({
+      jobName: "job-a",
+      errorKind: "exception",
+    });
+    expect(timeoutA).toMatch(/^activity-failed:job-a:\d{4}-\d{2}-\d{2}$/);
+    expect(timeoutA).not.toBe(timeoutB);
+    expect(exceptionA).toMatch(/^activity-failed:job-a:\d{4}-\d{2}-\d{2}$/);
+  });
+});

--- a/assistant/src/notifications/__tests__/activity-failed-dedupe.test.ts
+++ b/assistant/src/notifications/__tests__/activity-failed-dedupe.test.ts
@@ -8,16 +8,29 @@ describe("activityFailedDedupeKey", () => {
       jobName: "heartbeat",
       errorKind: "model_provider",
       failureCode: "PROVIDER_BILLING",
+      providerScope: "balanced",
     });
     const schedule = activityFailedDedupeKey({
       jobName: "schedule:job-123",
       errorKind: "model_provider",
       failureCode: "PROVIDER_BILLING",
+      providerScope: "balanced",
     });
     expect(heartbeat).toBe(schedule);
     expect(heartbeat).toMatch(
-      /^activity-failed:cause:PROVIDER_BILLING:default:\d{4}-\d{2}-\d{2}$/,
+      /^activity-failed:cause:PROVIDER_BILLING:balanced:\d{4}-\d{2}-\d{2}$/,
     );
+  });
+
+  test("a provider-scoped code without a scope keys per job", () => {
+    // A caller that cannot name the provider route its failure hit must not
+    // collapse with other routes' failures; per-job is the safe fallback.
+    const key = activityFailedDedupeKey({
+      jobName: "job-a",
+      errorKind: "model_provider",
+      failureCode: "PROVIDER_BILLING",
+    });
+    expect(key).toMatch(/^activity-failed:job-a:\d{4}-\d{2}-\d{2}$/);
   });
 
   test("the same code in different provider scopes stays distinct", () => {
@@ -89,34 +102,43 @@ describe("activityFailedDedupeKey", () => {
       jobName: "job",
       errorKind: "model_provider",
       failureCode: "PROVIDER_BILLING",
+      providerScope: "balanced",
     });
     const key = activityFailedDedupeKey({
       jobName: "job",
       errorKind: "model_provider",
       failureCode: "MANAGED_KEY_INVALID",
+      providerScope: "balanced",
     });
     expect(billing).not.toBe(key);
   });
 
-  test("code-less provider failures share the model_provider cause key", () => {
+  test("code-less provider failures share the cause key within one scope", () => {
     const a = activityFailedDedupeKey({
       jobName: "watcher-a",
       errorKind: "model_provider",
+      providerScope: "balanced",
     });
     const b = activityFailedDedupeKey({
       jobName: "watcher-b",
       errorKind: "model_provider",
+      providerScope: "balanced",
     });
     expect(a).toBe(b);
     expect(a).toMatch(
-      /^activity-failed:cause:model_provider:default:\d{4}-\d{2}-\d{2}$/,
+      /^activity-failed:cause:model_provider:balanced:\d{4}-\d{2}-\d{2}$/,
     );
-    const scoped = activityFailedDedupeKey({
+    const otherScope = activityFailedDedupeKey({
       jobName: "watcher-a",
       errorKind: "model_provider",
       providerScope: "profile-a",
     });
-    expect(scoped).not.toBe(a);
+    expect(otherScope).not.toBe(a);
+    const scopeless = activityFailedDedupeKey({
+      jobName: "watcher-a",
+      errorKind: "model_provider",
+    });
+    expect(scopeless).toMatch(/^activity-failed:watcher-a:\d{4}-\d{2}-\d{2}$/);
   });
 
   test("job-specific failures key per job", () => {

--- a/assistant/src/notifications/__tests__/activity-failed-dedupe.test.ts
+++ b/assistant/src/notifications/__tests__/activity-failed-dedupe.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from "bun:test";
 import { activityFailedDedupeKey } from "../activity-failed-dedupe.js";
 
 describe("activityFailedDedupeKey", () => {
-  test("a failure code keys on the cause, whatever the job", () => {
+  test("a provider-scoped code collapses across jobs within one scope", () => {
     const heartbeat = activityFailedDedupeKey({
       jobName: "heartbeat",
       errorKind: "model_provider",
@@ -16,7 +16,47 @@ describe("activityFailedDedupeKey", () => {
     });
     expect(heartbeat).toBe(schedule);
     expect(heartbeat).toMatch(
-      /^activity-failed:cause:PROVIDER_BILLING:\d{4}-\d{2}-\d{2}$/,
+      /^activity-failed:cause:PROVIDER_BILLING:default:\d{4}-\d{2}-\d{2}$/,
+    );
+  });
+
+  test("the same code in different provider scopes stays distinct", () => {
+    // Two provider connections can fail for the same class of reason with
+    // different remedies; the first notification must not hide the second.
+    const profileA = activityFailedDedupeKey({
+      jobName: "schedule:job-a",
+      errorKind: "model_provider",
+      failureCode: "PROVIDER_INVALID_KEY",
+      providerScope: "profile-a",
+    });
+    const profileB = activityFailedDedupeKey({
+      jobName: "schedule:job-b",
+      errorKind: "model_provider",
+      failureCode: "PROVIDER_INVALID_KEY",
+      providerScope: "profile-b",
+    });
+    expect(profileA).not.toBe(profileB);
+    expect(profileA).toMatch(
+      /^activity-failed:cause:PROVIDER_INVALID_KEY:profile-a:\d{4}-\d{2}-\d{2}$/,
+    );
+  });
+
+  test("a workspace-wide code collapses regardless of provider scope", () => {
+    const a = activityFailedDedupeKey({
+      jobName: "job-a",
+      errorKind: "model_provider",
+      failureCode: "MANAGED_KEY_INVALID",
+      providerScope: "profile-a",
+    });
+    const b = activityFailedDedupeKey({
+      jobName: "job-b",
+      errorKind: "model_provider",
+      failureCode: "MANAGED_KEY_INVALID",
+      providerScope: "profile-b",
+    });
+    expect(a).toBe(b);
+    expect(a).toMatch(
+      /^activity-failed:cause:MANAGED_KEY_INVALID:\d{4}-\d{2}-\d{2}$/,
     );
   });
 
@@ -69,8 +109,14 @@ describe("activityFailedDedupeKey", () => {
     });
     expect(a).toBe(b);
     expect(a).toMatch(
-      /^activity-failed:cause:model_provider:\d{4}-\d{2}-\d{2}$/,
+      /^activity-failed:cause:model_provider:default:\d{4}-\d{2}-\d{2}$/,
     );
+    const scoped = activityFailedDedupeKey({
+      jobName: "watcher-a",
+      errorKind: "model_provider",
+      providerScope: "profile-a",
+    });
+    expect(scoped).not.toBe(a);
   });
 
   test("job-specific failures key per job", () => {

--- a/assistant/src/notifications/__tests__/activity-failed-dedupe.test.ts
+++ b/assistant/src/notifications/__tests__/activity-failed-dedupe.test.ts
@@ -20,6 +20,30 @@ describe("activityFailedDedupeKey", () => {
     );
   });
 
+  test("job-specific failure codes key per job, not on the cause", () => {
+    const a = activityFailedDedupeKey({
+      jobName: "job-a",
+      errorKind: "model_provider",
+      failureCode: "CONTEXT_TOO_LARGE",
+    });
+    const b = activityFailedDedupeKey({
+      jobName: "job-b",
+      errorKind: "model_provider",
+      failureCode: "CONTEXT_TOO_LARGE",
+    });
+    expect(a).toMatch(/^activity-failed:job-a:\d{4}-\d{2}-\d{2}$/);
+    expect(a).not.toBe(b);
+  });
+
+  test("unknown failure codes default to the per-job key", () => {
+    const key = activityFailedDedupeKey({
+      jobName: "job-a",
+      errorKind: "model_provider",
+      failureCode: "SOME_FUTURE_CODE",
+    });
+    expect(key).toMatch(/^activity-failed:job-a:\d{4}-\d{2}-\d{2}$/);
+  });
+
   test("distinct failure codes stay distinct", () => {
     const billing = activityFailedDedupeKey({
       jobName: "job",

--- a/assistant/src/notifications/activity-failed-dedupe.ts
+++ b/assistant/src/notifications/activity-failed-dedupe.ts
@@ -53,9 +53,10 @@ const PROVIDER_SCOPED_FAILURE_CODES = new Set<string>([
  * another's.
  *
  * `providerScope` is the inference-profile key the failing call actually
- * resolved through (the runner derives it via `resolveEffectiveProfileKey`;
- * schedules pass their snapshotted pin). Callers that cannot name a
- * trustworthy scope omit it, and provider-scoped failures then key per job:
+ * resolved through, and only when that key names a single provider route
+ * (both producers derive it via `resolveSingleRouteProfileKey`; a mix
+ * winner has no single route). Callers that cannot name a trustworthy scope
+ * omit it, and provider-scoped failures then key per job:
  * an extra notification is recoverable, while a false collapse across two
  * provider routes hides a failure whose remedy differs. The profile is a
  * transitional stand-in for the provider connection the failure actually hit:

--- a/assistant/src/notifications/activity-failed-dedupe.ts
+++ b/assistant/src/notifications/activity-failed-dedupe.ts
@@ -2,44 +2,65 @@ import type { ConversationErrorCode } from "../api/events/conversation-error.js"
 import type { BackgroundJobErrorKind } from "../runtime/background-job-runner.js";
 
 /**
- * Failure codes that describe the environment rather than the failing job:
- * every job they hit shares one root cause and one remedy (add credits, fix
- * the key, free disk, wait out the provider), so their notifications collapse
- * across jobs.
+ * Failure codes whose cause is the whole workspace: the managed route and the
+ * local machine exist once, so every job they hit shares one root cause and
+ * one remedy, whatever provider or profile the job used. These collapse into
+ * a single notification per cause per UTC day.
  *
- * Codes NOT listed here key per job on purpose. A code like
+ * Typed against {@link ConversationErrorCode} so a renamed code fails the
+ * build here instead of silently un-collapsing.
+ */
+const WORKSPACE_WIDE_FAILURE_CODES = new Set<string>([
+  "MANAGED_KEY_INVALID",
+  "MANAGED_USAGE_LIMIT",
+  "DISK_SPACE_CRITICAL",
+] satisfies ConversationErrorCode[]);
+
+/**
+ * Failure codes whose cause is one provider account or connection: a billing
+ * lapse, a rejected key, a rate limit, an outage. One workspace can hold
+ * several provider connections with independent remedies, so these collapse
+ * only within a provider scope (see {@link activityFailedDedupeKey}), never
+ * across scopes where the first failure would hide a second one that needs a
+ * different fix.
+ *
+ * Codes in NEITHER set key per job on purpose. A code like
  * `CONTEXT_TOO_LARGE` or `MAX_TOKENS_REACHED` names a defect in one job's own
  * prompt or output, and collapsing it would hide a second job's unrelated
  * failure behind the first's notification. Unknown or future codes default to
  * per-job for the same reason: an extra notification is recoverable, a hidden
  * one is not.
- *
- * Typed against {@link ConversationErrorCode} so a renamed code fails the
- * build here instead of silently un-collapsing.
  */
-const ENVIRONMENT_WIDE_FAILURE_CODES = new Set<string>([
+const PROVIDER_SCOPED_FAILURE_CODES = new Set<string>([
   "PROVIDER_BILLING",
-  "MANAGED_KEY_INVALID",
-  "MANAGED_USAGE_LIMIT",
   "PROVIDER_NOT_CONFIGURED",
   "PROVIDER_INVALID_KEY",
   "PROVIDER_RATE_LIMIT",
   "PROVIDER_OVERLOADED",
   "PROVIDER_NETWORK",
   "PROVIDER_API",
-  "DISK_SPACE_CRITICAL",
 ] satisfies ConversationErrorCode[]);
 
 /**
  * Dedupe key for a background-job failure notification.
  *
- * Environment-wide failures (a billing lapse, a revoked managed key, a
- * provider outage) share one root cause across every job they hit, so they
- * key on the cause and collapse into a single notification per UTC day,
- * however many jobs fail. Job-specific failures (timeouts, generic
- * exceptions, and codes outside {@link ENVIRONMENT_WIDE_FAILURE_CODES}) keep
- * the per-job key so one job's failure cannot swallow the visibility of
+ * Workspace-wide failures collapse into one notification per cause per UTC
+ * day, however many jobs fail. Provider-scoped failures collapse within one
+ * provider scope per day, so two provider connections failing for the same
+ * class of reason still surface separately (their remedies differ).
+ * Job-specific failures (timeouts, generic exceptions, and unlisted codes)
+ * keep the per-job key so one job's failure cannot swallow the visibility of
  * another's.
+ *
+ * `providerScope` is the inference profile the job resolved against
+ * (`"default"` for the workspace's active profile). The profile is a
+ * transitional stand-in for the provider connection the failure actually hit:
+ * one profile resolves to one connection at a time, so scoping by profile can
+ * split one incident across profiles that share a connection (an extra
+ * notification, recoverable) but cannot merge two connections' incidents (a
+ * hidden failure, not recoverable). Once the turn boundary carries the
+ * classified `connectionName` (today it keeps only the code), this scope
+ * should become the connection itself.
  *
  * Shared by every `activity.failed` producer that reports a classified
  * background failure (the background-job runner, and the scheduler's
@@ -50,15 +71,21 @@ export function activityFailedDedupeKey(args: {
   jobName: string;
   errorKind: BackgroundJobErrorKind;
   failureCode?: string;
+  providerScope?: string;
 }): string {
   const day = new Date().toISOString().slice(0, 10);
+  const scope = args.providerScope ?? "default";
   if (args.failureCode) {
-    return ENVIRONMENT_WIDE_FAILURE_CODES.has(args.failureCode)
-      ? `activity-failed:cause:${args.failureCode}:${day}`
-      : `activity-failed:${args.jobName}:${day}`;
+    if (WORKSPACE_WIDE_FAILURE_CODES.has(args.failureCode)) {
+      return `activity-failed:cause:${args.failureCode}:${day}`;
+    }
+    if (PROVIDER_SCOPED_FAILURE_CODES.has(args.failureCode)) {
+      return `activity-failed:cause:${args.failureCode}:${scope}:${day}`;
+    }
+    return `activity-failed:${args.jobName}:${day}`;
   }
   if (args.errorKind === "model_provider") {
-    return `activity-failed:cause:model_provider:${day}`;
+    return `activity-failed:cause:model_provider:${scope}:${day}`;
   }
   return `activity-failed:${args.jobName}:${day}`;
 }

--- a/assistant/src/notifications/activity-failed-dedupe.ts
+++ b/assistant/src/notifications/activity-failed-dedupe.ts
@@ -1,13 +1,44 @@
+import type { ConversationErrorCode } from "../api/events/conversation-error.js";
 import type { BackgroundJobErrorKind } from "../runtime/background-job-runner.js";
+
+/**
+ * Failure codes that describe the environment rather than the failing job:
+ * every job they hit shares one root cause and one remedy (add credits, fix
+ * the key, free disk, wait out the provider), so their notifications collapse
+ * across jobs.
+ *
+ * Codes NOT listed here key per job on purpose. A code like
+ * `CONTEXT_TOO_LARGE` or `MAX_TOKENS_REACHED` names a defect in one job's own
+ * prompt or output, and collapsing it would hide a second job's unrelated
+ * failure behind the first's notification. Unknown or future codes default to
+ * per-job for the same reason: an extra notification is recoverable, a hidden
+ * one is not.
+ *
+ * Typed against {@link ConversationErrorCode} so a renamed code fails the
+ * build here instead of silently un-collapsing.
+ */
+const ENVIRONMENT_WIDE_FAILURE_CODES = new Set<string>([
+  "PROVIDER_BILLING",
+  "MANAGED_KEY_INVALID",
+  "MANAGED_USAGE_LIMIT",
+  "PROVIDER_NOT_CONFIGURED",
+  "PROVIDER_INVALID_KEY",
+  "PROVIDER_RATE_LIMIT",
+  "PROVIDER_OVERLOADED",
+  "PROVIDER_NETWORK",
+  "PROVIDER_API",
+  "DISK_SPACE_CRITICAL",
+] satisfies ConversationErrorCode[]);
 
 /**
  * Dedupe key for a background-job failure notification.
  *
- * Provider-level failures (a billing lapse, a revoked managed key, a provider
- * outage) share one root cause across every job they hit, so they key on the
- * cause and collapse into a single notification per UTC day, however many
- * jobs fail. Job-specific failures (timeouts, generic exceptions) keep the
- * per-job key so one job's failure cannot swallow the visibility of
+ * Environment-wide failures (a billing lapse, a revoked managed key, a
+ * provider outage) share one root cause across every job they hit, so they
+ * key on the cause and collapse into a single notification per UTC day,
+ * however many jobs fail. Job-specific failures (timeouts, generic
+ * exceptions, and codes outside {@link ENVIRONMENT_WIDE_FAILURE_CODES}) keep
+ * the per-job key so one job's failure cannot swallow the visibility of
  * another's.
  *
  * Shared by every `activity.failed` producer that reports a classified
@@ -22,7 +53,9 @@ export function activityFailedDedupeKey(args: {
 }): string {
   const day = new Date().toISOString().slice(0, 10);
   if (args.failureCode) {
-    return `activity-failed:cause:${args.failureCode}:${day}`;
+    return ENVIRONMENT_WIDE_FAILURE_CODES.has(args.failureCode)
+      ? `activity-failed:cause:${args.failureCode}:${day}`
+      : `activity-failed:${args.jobName}:${day}`;
   }
   if (args.errorKind === "model_provider") {
     return `activity-failed:cause:model_provider:${day}`;

--- a/assistant/src/notifications/activity-failed-dedupe.ts
+++ b/assistant/src/notifications/activity-failed-dedupe.ts
@@ -52,15 +52,18 @@ const PROVIDER_SCOPED_FAILURE_CODES = new Set<string>([
  * keep the per-job key so one job's failure cannot swallow the visibility of
  * another's.
  *
- * `providerScope` is the inference profile the job resolved against
- * (`"default"` for the workspace's active profile). The profile is a
+ * `providerScope` is the inference-profile key the failing call actually
+ * resolved through (the runner derives it via `resolveEffectiveProfileKey`;
+ * schedules pass their snapshotted pin). Callers that cannot name a
+ * trustworthy scope omit it, and provider-scoped failures then key per job:
+ * an extra notification is recoverable, while a false collapse across two
+ * provider routes hides a failure whose remedy differs. The profile is a
  * transitional stand-in for the provider connection the failure actually hit:
  * one profile resolves to one connection at a time, so scoping by profile can
- * split one incident across profiles that share a connection (an extra
- * notification, recoverable) but cannot merge two connections' incidents (a
- * hidden failure, not recoverable). Once the turn boundary carries the
- * classified `connectionName` (today it keeps only the code), this scope
- * should become the connection itself.
+ * split one incident across profiles that share a connection but cannot merge
+ * two connections' incidents. Once the turn boundary carries the classified
+ * `connectionName` (today it keeps only the code), this scope should become
+ * the connection itself.
  *
  * Shared by every `activity.failed` producer that reports a classified
  * background failure (the background-job runner, and the scheduler's
@@ -74,17 +77,17 @@ export function activityFailedDedupeKey(args: {
   providerScope?: string;
 }): string {
   const day = new Date().toISOString().slice(0, 10);
-  const scope = args.providerScope ?? "default";
+  const scope = args.providerScope;
   if (args.failureCode) {
     if (WORKSPACE_WIDE_FAILURE_CODES.has(args.failureCode)) {
       return `activity-failed:cause:${args.failureCode}:${day}`;
     }
-    if (PROVIDER_SCOPED_FAILURE_CODES.has(args.failureCode)) {
+    if (PROVIDER_SCOPED_FAILURE_CODES.has(args.failureCode) && scope) {
       return `activity-failed:cause:${args.failureCode}:${scope}:${day}`;
     }
     return `activity-failed:${args.jobName}:${day}`;
   }
-  if (args.errorKind === "model_provider") {
+  if (args.errorKind === "model_provider" && scope) {
     return `activity-failed:cause:model_provider:${scope}:${day}`;
   }
   return `activity-failed:${args.jobName}:${day}`;

--- a/assistant/src/notifications/activity-failed-dedupe.ts
+++ b/assistant/src/notifications/activity-failed-dedupe.ts
@@ -1,0 +1,31 @@
+import type { BackgroundJobErrorKind } from "../runtime/background-job-runner.js";
+
+/**
+ * Dedupe key for a background-job failure notification.
+ *
+ * Provider-level failures (a billing lapse, a revoked managed key, a provider
+ * outage) share one root cause across every job they hit, so they key on the
+ * cause and collapse into a single notification per UTC day, however many
+ * jobs fail. Job-specific failures (timeouts, generic exceptions) keep the
+ * per-job key so one job's failure cannot swallow the visibility of
+ * another's.
+ *
+ * Shared by every `activity.failed` producer that reports a classified
+ * background failure (the background-job runner, and the scheduler's
+ * retries-exhausted alert), so a schedule exhausting on the same cause as an
+ * already-reported job failure does not produce a second notification.
+ */
+export function activityFailedDedupeKey(args: {
+  jobName: string;
+  errorKind: BackgroundJobErrorKind;
+  failureCode?: string;
+}): string {
+  const day = new Date().toISOString().slice(0, 10);
+  if (args.failureCode) {
+    return `activity-failed:cause:${args.failureCode}:${day}`;
+  }
+  if (args.errorKind === "model_provider") {
+    return `activity-failed:cause:model_provider:${day}`;
+  }
+  return `activity-failed:${args.jobName}:${day}`;
+}

--- a/assistant/src/runtime/__tests__/background-job-runner.test.ts
+++ b/assistant/src/runtime/__tests__/background-job-runner.test.ts
@@ -286,24 +286,25 @@ describe("runBackgroundJob", () => {
       (emitCalls[0].contextPayload as { errorKind: string }).errorKind,
     ).toBe("model_provider");
     // A provider-scoped failure code keys the notification on the cause and
-    // the provider scope, not the job, so every job failing on the same code
-    // against the same profile collapses into one notification per UTC day.
+    // the resolved provider scope, not the job. `heartbeatAgent` resolves the
+    // cost-optimized default profile, so every job failing on this code
+    // through that route collapses into one notification per UTC day.
     expect(emitCalls[0].dedupeKey as string).toMatch(
-      /^activity-failed:cause:PROVIDER_BILLING:default:\d{4}-\d{2}-\d{2}$/,
+      /^activity-failed:cause:PROVIDER_BILLING:cost-optimized:\d{4}-\d{2}-\d{2}$/,
     );
   });
 
-  test("overrideProfile scopes the cause-keyed dedupe", async () => {
+  test("a usable overrideProfile scopes the cause-keyed dedupe", async () => {
     processMessageImpl = async () => ({
       messageId: "msg-failed-turn",
       turnFailure: { failureCode: "PROVIDER_BILLING" },
     });
 
-    await runBackgroundJob(baseOpts({ overrideProfile: "profile-a" }));
+    await runBackgroundJob(baseOpts({ overrideProfile: "balanced" }));
 
     expect(emitCalls).toHaveLength(1);
     expect(emitCalls[0].dedupeKey as string).toMatch(
-      /^activity-failed:cause:PROVIDER_BILLING:profile-a:\d{4}-\d{2}-\d{2}$/,
+      /^activity-failed:cause:PROVIDER_BILLING:balanced:\d{4}-\d{2}-\d{2}$/,
     );
   });
 
@@ -336,7 +337,7 @@ describe("runBackgroundJob", () => {
     expect(result.errorKind).toBe("model_provider");
     expect(emitCalls).toHaveLength(1);
     expect(emitCalls[0].dedupeKey as string).toMatch(
-      /^activity-failed:cause:model_provider:default:\d{4}-\d{2}-\d{2}$/,
+      /^activity-failed:cause:model_provider:cost-optimized:\d{4}-\d{2}-\d{2}$/,
     );
   });
 

--- a/assistant/src/runtime/__tests__/background-job-runner.test.ts
+++ b/assistant/src/runtime/__tests__/background-job-runner.test.ts
@@ -285,6 +285,27 @@ describe("runBackgroundJob", () => {
     expect(
       (emitCalls[0].contextPayload as { errorKind: string }).errorKind,
     ).toBe("model_provider");
+    // A classified failure code keys the notification on the cause, not the
+    // job, so every job failing on the same code collapses into one
+    // notification per UTC day.
+    expect(emitCalls[0].dedupeKey as string).toMatch(
+      /^activity-failed:cause:provider_error:\d{4}-\d{2}-\d{2}$/,
+    );
+  });
+
+  test("code-less provider failure dedupes on the shared model_provider cause", async () => {
+    processMessageImpl = async () => {
+      throw new Error("provider returned 401");
+    };
+
+    const result = await runBackgroundJob(baseOpts());
+
+    expect(result.ok).toBe(false);
+    expect(result.errorKind).toBe("model_provider");
+    expect(emitCalls).toHaveLength(1);
+    expect(emitCalls[0].dedupeKey as string).toMatch(
+      /^activity-failed:cause:model_provider:\d{4}-\d{2}-\d{2}$/,
+    );
   });
 
   test("timeout: returns ok=false with errorKind=timeout and emits activity.failed", async () => {
@@ -301,6 +322,10 @@ describe("runBackgroundJob", () => {
     expect(
       (emitCalls[0].contextPayload as { errorKind: string }).errorKind,
     ).toBe("timeout");
+    // A timeout is job-specific, so it keeps the per-job dedupe key.
+    expect(emitCalls[0].dedupeKey as string).toMatch(
+      /^activity-failed:test-job:\d{4}-\d{2}-\d{2}$/,
+    );
   });
 
   test("suppressFailureNotifications: failure returns ok=false but emits nothing", async () => {

--- a/assistant/src/runtime/__tests__/background-job-runner.test.ts
+++ b/assistant/src/runtime/__tests__/background-job-runner.test.ts
@@ -267,29 +267,47 @@ describe("runBackgroundJob", () => {
     // `turnFailure`. The runner must surface this as a failure, not ok=true.
     processMessageImpl = async () => ({
       messageId: "msg-failed-turn",
-      turnFailure: { failureCode: "provider_error" },
+      turnFailure: { failureCode: "PROVIDER_BILLING" },
     });
 
     const result = await runBackgroundJob(baseOpts());
 
     expect(result.ok).toBe(false);
     expect(result.errorKind).toBe("model_provider");
-    expect(result.error?.message).toContain("provider_error");
+    expect(result.error?.message).toContain("PROVIDER_BILLING");
     expect(result.conversationId).toBe(STUB_CONVERSATION_ID);
     // The stable classified code rides the result so callers can branch on
     // the failure class without parsing the error message.
-    expect(result.failureCode).toBe("provider_error");
+    expect(result.failureCode).toBe("PROVIDER_BILLING");
 
     expect(emitCalls).toHaveLength(1);
     expect(emitCalls[0].sourceEventName).toBe("activity.failed");
     expect(
       (emitCalls[0].contextPayload as { errorKind: string }).errorKind,
     ).toBe("model_provider");
-    // A classified failure code keys the notification on the cause, not the
-    // job, so every job failing on the same code collapses into one
+    // An environment-wide failure code keys the notification on the cause,
+    // not the job, so every job failing on the same code collapses into one
     // notification per UTC day.
     expect(emitCalls[0].dedupeKey as string).toMatch(
-      /^activity-failed:cause:provider_error:\d{4}-\d{2}-\d{2}$/,
+      /^activity-failed:cause:PROVIDER_BILLING:\d{4}-\d{2}-\d{2}$/,
+    );
+  });
+
+  test("job-specific failure code keeps the per-job dedupe key", async () => {
+    // CONTEXT_TOO_LARGE names a defect in this job's own prompt; collapsing
+    // it across jobs would hide a second job's unrelated failure.
+    processMessageImpl = async () => ({
+      messageId: "msg-failed-turn",
+      turnFailure: { failureCode: "CONTEXT_TOO_LARGE" },
+    });
+
+    const result = await runBackgroundJob(baseOpts());
+
+    expect(result.ok).toBe(false);
+    expect(result.failureCode).toBe("CONTEXT_TOO_LARGE");
+    expect(emitCalls).toHaveLength(1);
+    expect(emitCalls[0].dedupeKey as string).toMatch(
+      /^activity-failed:test-job:\d{4}-\d{2}-\d{2}$/,
     );
   });
 

--- a/assistant/src/runtime/__tests__/background-job-runner.test.ts
+++ b/assistant/src/runtime/__tests__/background-job-runner.test.ts
@@ -285,11 +285,25 @@ describe("runBackgroundJob", () => {
     expect(
       (emitCalls[0].contextPayload as { errorKind: string }).errorKind,
     ).toBe("model_provider");
-    // An environment-wide failure code keys the notification on the cause,
-    // not the job, so every job failing on the same code collapses into one
-    // notification per UTC day.
+    // A provider-scoped failure code keys the notification on the cause and
+    // the provider scope, not the job, so every job failing on the same code
+    // against the same profile collapses into one notification per UTC day.
     expect(emitCalls[0].dedupeKey as string).toMatch(
-      /^activity-failed:cause:PROVIDER_BILLING:\d{4}-\d{2}-\d{2}$/,
+      /^activity-failed:cause:PROVIDER_BILLING:default:\d{4}-\d{2}-\d{2}$/,
+    );
+  });
+
+  test("overrideProfile scopes the cause-keyed dedupe", async () => {
+    processMessageImpl = async () => ({
+      messageId: "msg-failed-turn",
+      turnFailure: { failureCode: "PROVIDER_BILLING" },
+    });
+
+    await runBackgroundJob(baseOpts({ overrideProfile: "profile-a" }));
+
+    expect(emitCalls).toHaveLength(1);
+    expect(emitCalls[0].dedupeKey as string).toMatch(
+      /^activity-failed:cause:PROVIDER_BILLING:profile-a:\d{4}-\d{2}-\d{2}$/,
     );
   });
 
@@ -322,7 +336,7 @@ describe("runBackgroundJob", () => {
     expect(result.errorKind).toBe("model_provider");
     expect(emitCalls).toHaveLength(1);
     expect(emitCalls[0].dedupeKey as string).toMatch(
-      /^activity-failed:cause:model_provider:\d{4}-\d{2}-\d{2}$/,
+      /^activity-failed:cause:model_provider:default:\d{4}-\d{2}-\d{2}$/,
     );
   });
 

--- a/assistant/src/runtime/background-job-runner.ts
+++ b/assistant/src/runtime/background-job-runner.ts
@@ -30,6 +30,7 @@ import type { AttentionHints } from "../notifications/signal.js";
 import { bootstrapConversation } from "../persistence/conversation-bootstrap.js";
 import { addMessage } from "../persistence/conversation-crud.js";
 import type { TitleOrigin } from "../persistence/conversation-title-service.js";
+import { dispatchProviderResolvable } from "../providers/provider-resolvability.js";
 import { getLogger } from "../util/logger.js";
 import { hasReceivedUserMessage } from "./pre-first-message-gate.js";
 
@@ -415,11 +416,13 @@ export async function runBackgroundJob(
       };
       // The provider scope is the profile key the resolver actually used for
       // this call site (the override when usable, else the site's own
-      // winner), so failures on different provider routes cannot collapse
-      // into one notification. A mix winner, no named winner, or a config
-      // read failing on this path all yield no scope, and the key falls back
-      // to per-job: a mix's arm is picked per conversation and can span
-      // providers, so no single route can be named for it after the fact.
+      // winner), resolved with the same provider-resolvability predicate
+      // dispatch uses, so this recomputation cannot accept a profile that
+      // dispatch rejected (e.g. a pin whose connection was force-deleted).
+      // A mix winner, no named winner, or a config read failing on this path
+      // all yield no scope, and the key falls back to per-job: a mix's arm
+      // is picked per conversation and can span providers, so no single
+      // route can be named for it after the fact.
       let providerScope: string | undefined;
       try {
         providerScope = resolveSingleRouteProfileKey(
@@ -429,6 +432,7 @@ export async function runBackgroundJob(
             ...(opts.overrideProfile
               ? { overrideProfile: opts.overrideProfile }
               : {}),
+            isResolvableProvider: dispatchProviderResolvable,
           },
         );
       } catch {

--- a/assistant/src/runtime/background-job-runner.ts
+++ b/assistant/src/runtime/background-job-runner.ts
@@ -22,6 +22,7 @@ import type { LLMCallSite } from "../config/schemas/llm.js";
 import { processMessage } from "../daemon/process-message.js";
 import type { SubagentToolGateMode } from "../daemon/tool-setup-types.js";
 import type { TrustContext } from "../daemon/trust-context-types.js";
+import { activityFailedDedupeKey } from "../notifications/activity-failed-dedupe.js";
 import { emitNotificationSignal } from "../notifications/emit-signal.js";
 import type { AttentionHints } from "../notifications/signal.js";
 import { bootstrapConversation } from "../persistence/conversation-bootstrap.js";
@@ -99,9 +100,9 @@ export interface RunBackgroundJobOptions {
   timeoutMs: number;
   /**
    * When true, failures do NOT emit an `activity.failed` notification.
-   * Use for jobs that own their own failure UX (e.g. heartbeat's alerter)
-   * or for "quiet" scheduled jobs that the user has explicitly asked to
-   * suppress notifications for.
+   * Use for jobs whose failure alerting is owned elsewhere: heartbeat's
+   * alerter banner, and the scheduler's retry policy (which alerts once,
+   * when retries are exhausted, instead of once per attempt).
    */
   suppressFailureNotifications?: boolean;
   /** Conversation grouping id. Defaults to `"system:background"`. */
@@ -410,12 +411,11 @@ export async function runBackgroundJob(
         isAsyncBackground: true,
         visibleInSourceNow: false,
       };
-      // Dedupe by jobName + UTC date so repeated failures of the same
-      // background job (e.g. a watcher whose credentials are revoked)
-      // collapse into a single home-feed entry per day rather than
-      // spamming on every tick.
-      const day = new Date().toISOString().slice(0, 10);
-      const dedupeKey = `activity-failed:${opts.jobName}:${day}`;
+      const dedupeKey = activityFailedDedupeKey({
+        jobName: opts.jobName,
+        errorKind,
+        ...(failureCode !== undefined ? { failureCode } : {}),
+      });
       emitNotificationSignal({
         sourceChannel: "assistant_tool",
         sourceContextId: conversationId,

--- a/assistant/src/runtime/background-job-runner.ts
+++ b/assistant/src/runtime/background-job-runner.ts
@@ -18,6 +18,8 @@
  * `suppressFailureNotifications`.
  */
 
+import { resolveEffectiveProfileKey } from "../config/llm-resolver.js";
+import { getConfig } from "../config/loader.js";
 import type { LLMCallSite } from "../config/schemas/llm.js";
 import { processMessage } from "../daemon/process-message.js";
 import type { SubagentToolGateMode } from "../daemon/tool-setup-types.js";
@@ -411,13 +413,30 @@ export async function runBackgroundJob(
         isAsyncBackground: true,
         visibleInSourceNow: false,
       };
+      // The provider scope is the profile key the resolver actually used for
+      // this call site (the override when usable, else the site's own
+      // winner), so failures on different provider routes cannot collapse
+      // into one notification. No named winner, or a config read failing on
+      // this path, yields no scope and the key falls back to per-job.
+      let providerScope: string | undefined;
+      try {
+        providerScope = resolveEffectiveProfileKey(
+          opts.callSite,
+          getConfig().llm,
+          {
+            ...(opts.overrideProfile
+              ? { overrideProfile: opts.overrideProfile }
+              : {}),
+          },
+        );
+      } catch {
+        providerScope = undefined;
+      }
       const dedupeKey = activityFailedDedupeKey({
         jobName: opts.jobName,
         errorKind,
         ...(failureCode !== undefined ? { failureCode } : {}),
-        ...(opts.overrideProfile !== undefined
-          ? { providerScope: opts.overrideProfile }
-          : {}),
+        ...(providerScope !== undefined ? { providerScope } : {}),
       });
       emitNotificationSignal({
         sourceChannel: "assistant_tool",

--- a/assistant/src/runtime/background-job-runner.ts
+++ b/assistant/src/runtime/background-job-runner.ts
@@ -18,7 +18,7 @@
  * `suppressFailureNotifications`.
  */
 
-import { resolveEffectiveProfileKey } from "../config/llm-resolver.js";
+import { resolveSingleRouteProfileKey } from "../config/llm-resolver.js";
 import { getConfig } from "../config/loader.js";
 import type { LLMCallSite } from "../config/schemas/llm.js";
 import { processMessage } from "../daemon/process-message.js";
@@ -416,11 +416,13 @@ export async function runBackgroundJob(
       // The provider scope is the profile key the resolver actually used for
       // this call site (the override when usable, else the site's own
       // winner), so failures on different provider routes cannot collapse
-      // into one notification. No named winner, or a config read failing on
-      // this path, yields no scope and the key falls back to per-job.
+      // into one notification. A mix winner, no named winner, or a config
+      // read failing on this path all yield no scope, and the key falls back
+      // to per-job: a mix's arm is picked per conversation and can span
+      // providers, so no single route can be named for it after the fact.
       let providerScope: string | undefined;
       try {
-        providerScope = resolveEffectiveProfileKey(
+        providerScope = resolveSingleRouteProfileKey(
           opts.callSite,
           getConfig().llm,
           {

--- a/assistant/src/runtime/background-job-runner.ts
+++ b/assistant/src/runtime/background-job-runner.ts
@@ -415,6 +415,9 @@ export async function runBackgroundJob(
         jobName: opts.jobName,
         errorKind,
         ...(failureCode !== undefined ? { failureCode } : {}),
+        ...(opts.overrideProfile !== undefined
+          ? { providerScope: opts.overrideProfile }
+          : {}),
       });
       emitNotificationSignal({
         sourceChannel: "assistant_tool",

--- a/assistant/src/schedule/retry-policy.ts
+++ b/assistant/src/schedule/retry-policy.ts
@@ -41,15 +41,19 @@ export function decideRetry(
 export async function applyRetryDecision(params: {
   job: RetryPolicyJob;
   isOneShot: boolean;
-  errorMsg: string;
   decision: RetryDecision;
   scheduleRetry: (id: string, nextRetryAt: number) => void | Promise<void>;
   failOneShotPermanently: (id: string) => void | Promise<void>;
   resetRetryCount: (id: string) => void | Promise<void>;
-  emitAlert: (title: string, summary: string, dedupKey: string) => void;
+  /**
+   * Fired exactly once, when retries are exhausted. This is the single
+   * user-facing alert for a failed schedule (per-attempt failures are
+   * retried silently), and the caller owns its content and dedupe key.
+   */
+  emitAlert: () => void;
   log: Logger;
 }): Promise<void> {
-  const { job, isOneShot, errorMsg, decision } = params;
+  const { job, isOneShot, decision } = params;
 
   if (decision.action === "retry") {
     await params.scheduleRetry(job.id, decision.nextRetryAt);
@@ -69,11 +73,7 @@ export async function applyRetryDecision(params: {
     } else {
       await params.resetRetryCount(job.id);
     }
-    params.emitAlert(
-      `${job.name}: Retries exhausted`,
-      `Failed after ${job.retryCount + 1} attempt(s): ${errorMsg}`,
-      `schedule-retries-exhausted:${job.id}:${Date.now()}`,
-    );
+    params.emitAlert();
     params.log.warn(
       { jobId: job.id, name: job.name, attempts: job.retryCount + 1 },
       "Schedule retries exhausted",

--- a/assistant/src/schedule/schedule-recovery.ts
+++ b/assistant/src/schedule/schedule-recovery.ts
@@ -52,7 +52,6 @@ export async function recoverStaleSchedules(): Promise<number> {
       await applyRetryDecision({
         job,
         isOneShot,
-        errorMsg,
         decision,
         scheduleRetry,
         failOneShotPermanently,

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -13,6 +13,7 @@ import { emitNotificationSignal } from "../notifications/emit-signal.js";
 import { getConversation } from "../persistence/conversation-crud.js";
 import { isLifecycleQuiesced } from "../persistence/lifecycle-quiesce.js";
 import { invalidateAssistantInferredItemsForConversation } from "../plugins/defaults/memory/task-memory-cleanup.js";
+import { dispatchProviderResolvable } from "../providers/provider-resolvability.js";
 import { wakeAgentForOpportunity } from "../runtime/agent-wake.js";
 import { broadcastMessage } from "../runtime/assistant-event-hub.js";
 import {
@@ -275,6 +276,9 @@ function resolveScheduleProviderScope(job: ScheduleJob): string | undefined {
       ...(job.inferenceProfile
         ? { overrideProfile: job.inferenceProfile }
         : {}),
+      // Dispatch's own resolvability predicate, so a stale pin dispatch
+      // rejected (force-deleted connection) is not accepted as the scope.
+      isResolvableProvider: dispatchProviderResolvable,
     });
   } catch {
     return undefined;

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -252,6 +252,9 @@ async function handleExecutionFailure(params: {
         ...(params.failureCode !== undefined
           ? { failureCode: params.failureCode }
           : {}),
+        ...(params.job.inferenceProfile != null
+          ? { providerScope: params.job.inferenceProfile }
+          : {}),
       }),
     log,
   });
@@ -1081,6 +1084,7 @@ function emitScheduleActivityFailed(args: {
   errorMessage: string;
   errorKind: BackgroundJobErrorKind;
   failureCode?: string;
+  providerScope?: string;
 }): void {
   emitNotificationSignal({
     sourceChannel: "scheduler",
@@ -1091,6 +1095,9 @@ function emitScheduleActivityFailed(args: {
       errorKind: args.errorKind,
       ...(args.failureCode !== undefined
         ? { failureCode: args.failureCode }
+        : {}),
+      ...(args.providerScope !== undefined
+        ? { providerScope: args.providerScope }
         : {}),
     }),
     contextPayload: {

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -7,13 +7,17 @@ import {
 } from "../daemon/disk-pressure-background-gate.js";
 import { processMessage } from "../daemon/process-message.js";
 import { INTERNAL_GUARDIAN_TRUST_CONTEXT } from "../daemon/trust-context.js";
+import { activityFailedDedupeKey } from "../notifications/activity-failed-dedupe.js";
 import { emitNotificationSignal } from "../notifications/emit-signal.js";
 import { getConversation } from "../persistence/conversation-crud.js";
 import { isLifecycleQuiesced } from "../persistence/lifecycle-quiesce.js";
 import { invalidateAssistantInferredItemsForConversation } from "../plugins/defaults/memory/task-memory-cleanup.js";
 import { wakeAgentForOpportunity } from "../runtime/agent-wake.js";
 import { broadcastMessage } from "../runtime/assistant-event-hub.js";
-import { runBackgroundJob } from "../runtime/background-job-runner.js";
+import {
+  type BackgroundJobErrorKind,
+  runBackgroundJob,
+} from "../runtime/background-job-runner.js";
 import { publishConversationListChanged } from "../runtime/sync/resource-sync-events.js";
 import { runSequencesOnce } from "../sequence/engine.js";
 import type { TurnFailure } from "../telemetry/turn-outcome.js";
@@ -223,22 +227,31 @@ async function handleExecutionFailure(params: {
   job: ScheduleJob;
   errorMsg: string;
   isOneShot: boolean;
+  /**
+   * Classified failure cause from the runner, when the failing path had one.
+   * Keys the exhaustion alert's dedupe so same-cause failures across jobs
+   * collapse; absent means a generic exception, which keys per schedule.
+   */
+  errorKind?: BackgroundJobErrorKind;
+  failureCode?: string;
 }): Promise<void> {
   const decision = decideRetry(params.job);
   await applyRetryDecision({
     job: params.job,
     isOneShot: params.isOneShot,
-    errorMsg: params.errorMsg,
     decision,
     scheduleRetry,
     failOneShotPermanently,
     resetRetryCount,
-    emitAlert: (_title, _summary, dedupKey) =>
+    emitAlert: () =>
       emitScheduleActivityFailed({
         jobId: params.job.id,
         jobName: params.job.name,
         errorMessage: params.errorMsg,
-        dedupKey,
+        errorKind: params.errorKind ?? "exception",
+        ...(params.failureCode !== undefined
+          ? { failureCode: params.failureCode }
+          : {}),
       }),
     log,
   });
@@ -896,6 +909,8 @@ export async function runDueSchedulesOnce(
     let conversationId: string;
     let ok: boolean;
     let errorMsg: string | undefined;
+    let errorKind: BackgroundJobErrorKind | undefined;
+    let failureCode: string | undefined;
     const conversationReused = reusedConversationId != null;
     let runConversationId = reusedConversationId;
     const runId = await createScheduleRun(job.id, reusedConversationId);
@@ -929,17 +944,20 @@ export async function runDueSchedulesOnce(
         if (turnFailure) {
           ok = false;
           errorMsg = describeTurnFailure(turnFailure);
+          errorKind = "model_provider";
+          failureCode = turnFailure.failureCode;
         } else {
           ok = true;
         }
       } catch (err) {
         ok = false;
         errorMsg = err instanceof Error ? err.message : String(err);
+        errorKind = "exception";
       }
     } else {
-      // Fresh-bootstrap path: route through the shared runner so failures
-      // surface via `activity.failed` and we get the standard timeout +
-      // error-classification policy applied to every background producer.
+      // Fresh-bootstrap path: route through the shared runner for the
+      // standard timeout + error-classification policy applied to every
+      // background producer.
       // The runner fires `onConversationCreated` synchronously after bootstrap
       // (before `processMessage` starts) so the macOS sidebar gets the new
       // conversation immediately rather than after the up-to-30-min job ends.
@@ -962,7 +980,12 @@ export async function runDueSchedulesOnce(
         groupId: resolveScheduleConversationGroupId(job),
         conversationType: "scheduled",
         scheduleJobId: job.id,
-        suppressFailureNotifications: job.quiet === true,
+        // The retry policy owns the single user-facing alert for a failing
+        // schedule (fired once, when retries are exhausted). Letting the
+        // runner also emit per attempt would notify for failures that a
+        // retry may yet recover, and pair every exhaustion alert with a
+        // duplicate.
+        suppressFailureNotifications: true,
         onConversationCreated: async (newConversationId) => {
           runConversationId = newConversationId;
           await setScheduleRunConversationId(runId, newConversationId);
@@ -988,6 +1011,8 @@ export async function runDueSchedulesOnce(
       }
       ok = result.ok;
       errorMsg = result.error?.message;
+      errorKind = result.errorKind;
+      failureCode = result.failureCode;
     }
 
     if (ok) {
@@ -1016,6 +1041,8 @@ export async function runDueSchedulesOnce(
         job,
         errorMsg: errorMsg ?? "Schedule run failed",
         isOneShot,
+        ...(errorKind !== undefined ? { errorKind } : {}),
+        ...(failureCode !== undefined ? { failureCode } : {}),
       });
 
       // Only skip invalidation when the conversation was *actually* reused,
@@ -1042,25 +1069,34 @@ export async function runDueSchedulesOnce(
 
 /**
  * Emit an `activity.failed` notification for a schedule whose retries have
- * been exhausted. Fires once when the retry policy has given up, so the
- * dedupeKey caller is the per-attempt key passed in by `applyRetryDecision`
- * (already includes the job id and a timestamp).
+ * been exhausted. Fires once when the retry policy has given up. The dedupe
+ * key comes from the shared cause-first derivation, so every schedule (and
+ * background job) failing for the same classified cause on the same UTC day
+ * collapses into one notification, and cause-less failures collapse per
+ * schedule per day.
  */
 function emitScheduleActivityFailed(args: {
   jobId: string;
   jobName: string;
   errorMessage: string;
-  dedupKey: string;
+  errorKind: BackgroundJobErrorKind;
+  failureCode?: string;
 }): void {
   emitNotificationSignal({
     sourceChannel: "scheduler",
     sourceContextId: args.jobId,
     sourceEventName: "activity.failed",
-    dedupeKey: args.dedupKey,
+    dedupeKey: activityFailedDedupeKey({
+      jobName: `schedule:${args.jobId}`,
+      errorKind: args.errorKind,
+      ...(args.failureCode !== undefined
+        ? { failureCode: args.failureCode }
+        : {}),
+    }),
     contextPayload: {
       jobName: `schedule:${args.jobName}`,
       errorMessage: args.errorMessage,
-      errorKind: "exception",
+      errorKind: args.errorKind,
     },
     attentionHints: {
       requiresAction: false,

--- a/assistant/src/schedule/scheduler.ts
+++ b/assistant/src/schedule/scheduler.ts
@@ -1,4 +1,5 @@
 import { refreshBackgroundWakeIntent } from "../background-wake/publisher.js";
+import { resolveSingleRouteProfileKey } from "../config/llm-resolver.js";
 import { getConfig } from "../config/loader.js";
 import {
   checkDiskPressureBackgroundGate,
@@ -243,7 +244,8 @@ async function handleExecutionFailure(params: {
     scheduleRetry,
     failOneShotPermanently,
     resetRetryCount,
-    emitAlert: () =>
+    emitAlert: () => {
+      const providerScope = resolveScheduleProviderScope(params.job);
       emitScheduleActivityFailed({
         jobId: params.job.id,
         jobName: params.job.name,
@@ -252,12 +254,31 @@ async function handleExecutionFailure(params: {
         ...(params.failureCode !== undefined
           ? { failureCode: params.failureCode }
           : {}),
-        ...(params.job.inferenceProfile != null
-          ? { providerScope: params.job.inferenceProfile }
-          : {}),
-      }),
+        ...(providerScope !== undefined ? { providerScope } : {}),
+      });
+    },
     log,
   });
+}
+
+/**
+ * The provider scope a schedule's failing runs resolved through: its pinned
+ * profile when that names a single provider route, else the route the
+ * mainAgent winner actually served (a deleted pin falls through to it). A
+ * mix pin, no named winner, or an unreadable config yield no scope, so the
+ * exhaustion alert keys per schedule rather than claiming one scope for
+ * arms that can span providers.
+ */
+function resolveScheduleProviderScope(job: ScheduleJob): string | undefined {
+  try {
+    return resolveSingleRouteProfileKey("mainAgent", getConfig().llm, {
+      ...(job.inferenceProfile
+        ? { overrideProfile: job.inferenceProfile }
+        : {}),
+    });
+  } catch {
+    return undefined;
+  }
 }
 
 /** The running scheduler, retained so shutdown can stop it. */


### PR DESCRIPTION
Part of LUM-3464 (kept open as the tracking ticket for the post-revamp consolidation work).

## TL;DR

A schedule that failed produced two notifications (one per attempt from the background-job runner, plus one at retry exhaustion under a timestamped dedupe key that could never collapse), and every job hit by the same provider outage notified separately. Now: the retry policy owns the single alert for a failing schedule, fired once when retries are exhausted, and failure notifications dedupe on the failure cause, so one billing outage is one notification per day, however many jobs it takes down.

## What changes for the user

| Scenario | Before | After |
| --- | --- | --- |
| One schedule fails (retries exhaust) | 2 notifications: an immediate one titled with the raw schedule UUID, then a second ~6 minutes later | 1 notification, at exhaustion, with the human-readable schedule name |
| Overnight credits outage hits 4 schedules | 8 notifications, all saying the same thing | 1 notification per day for the shared cause (PROVIDER_BILLING) per provider profile |
| Schedules and other background jobs (watchers, heartbeat wake) fail on the same provider cause | One notification per job | They share the one cause-keyed notification |
| A job times out or crashes on its own bug | One notification per job per day | Unchanged: still one per job per day, so unrelated failures stay individually visible |
| Transient schedule failure that a retry recovers | An immediate failure notification even though the retry succeeded | No notification |

## How

- `activityFailedDedupeKey` (new, `notifications/activity-failed-dedupe.ts`) is the single derivation for `activity.failed` dedupe keys, with two allowlists typed against the canonical `ConversationErrorCode` enum. Workspace-wide causes (managed key/usage, disk) collapse globally: `activity-failed:cause:<code>:<day>`. Provider-scoped causes (billing, key/config, rate limit, overload, network, API) and code-less `model_provider` failures collapse only within a provider scope: `activity-failed:cause:<code>:<scope>:<day>`. Both producers derive the scope with `resolveSingleRouteProfileKey` (the same single-winner chain the LLM call resolves through, so heartbeat keys on cost-optimized, watchers on the main-agent winner, a usable override or schedule pin on itself), which names a scope only when the winner is a single provider route: a mix winner, a deleted pin's fallback, no named winner, or an unreadable config all decline, and the failure keys per job rather than claiming a fabricated or multi-route scope. Two provider routes failing for the same class of reason therefore always surface separately. Everything else, including job-scoped codes like `CONTEXT_TOO_LARGE` and any unknown code, keeps the per-job daily key so one job's defect cannot hide another's. The profile scope is documented as a transitional stand-in for the classified `connectionName`, which the turn boundary does not carry yet. Both the runner and the scheduler's exhaustion alert use it, so a schedule exhausting on the same cause as an already-reported job failure dedupes against it.
- The scheduler passes `suppressFailureNotifications: true` to `runBackgroundJob` unconditionally: per-attempt failures are retried silently and the retry policy alerts once, at exhaustion. This also fixes the raw-UUID title, since the surviving alert uses the schedule's name.
- `applyRetryDecision`'s `emitAlert` callback no longer fabricates a title, summary, and timestamped dedupe key that its only caller discarded (the timestamped key was the reason exhaustion alerts never deduped). It is now a plain exhaustion signal; the scheduler owns the alert's content and key.
- The scheduler threads the runner's classified `errorKind`/`failureCode` into the exhaustion alert (both dispatch paths, including conversation reuse), replacing the hardcoded `errorKind: "exception"`.

## Why it's safe

- `tsc`, eslint, and prettier are clean; new unit tests cover the key derivation, the runner's cause-keyed emission, and the scheduler's exhaust-once-then-alert flow end to end (local test execution is hook-blocked in this environment, so please read CI for the suite result).
- The dedupe mechanism is unchanged (the existing UNIQUE index on `notification_events.dedupe_key`); only the key contents changed, and the day component still bounds every collapse window to one UTC day.
- Nothing parses these keys back: readers of the pipeline (copy composer, decision engine, home feed) key off `sourceEventName`/`contextPayload`, which keep their shapes. The one payload change is that the exhaustion alert now reports the real `errorKind` instead of always `"exception"`, and the copy composer renders that field verbatim.
- Quiet schedules behave exactly as before: their per-attempt emission was already suppressed, and they still alert at exhaustion.
- The other four schedule modes (notify, script, wake, workflow) already alerted only at exhaustion; they pick up the per-schedule daily dedupe (previously their exhaustion alerts never deduped) and are otherwise untouched.

## Relationship to #41295

The notifications revamp (#41295) rebuilds this machinery around runs and a System health counter and retires `activity.failed`. This is a deliberate interim fix on main for the live notification-spam incidents (LUM-3464 has the verified analysis); if the revamp lands later and reworks these seams, that rework cost was accepted when scoping this change.

## Deferred, and why

- Accumulating the affected job list into one editable notification body ("5 jobs failed due to PROVIDER_BILLING: ..."): needs the in-place edit mechanism, which is the machinery #41295 replaces, so it belongs in the post-revamp follow-up tracked on LUM-3464. Until then the consolidated notification carries the first failing job's details.
- The memory substrate sweep job emits `activity.failed` directly with a hardcoded generic error kind and no classification, so a provider outage still yields one extra notification per day from it. Converging it means adding error classification there, out of scope for this fix.
- `quiet: true` schedules still alert at retry exhaustion (pre-existing behavior, preserved here). Whether quiet should also silence the exhaustion alert is a semantics question deliberately not answered in this PR; system-created deferred wakes are quiet, and silencing their permanent failures could hide real breakage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
