### PR TITLE
ci(release): cut the second weekly release on Thursday instead of Friday

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -10,7 +10,7 @@ Cut a new release. Releases are a **two-step** process:
 1. **Branch cut → staging bake**: `create-release-branch.yml` computes the version from the bump type, deletes any stale `release/v<X.Y.Z>` branch, cuts a fresh one from `main` HEAD with the version-bump commit, and pushes it. That push triggers a `Release` run on the branch which is a **staging** deploy (push-triggered and main-dispatched `Release` runs are always staging).
 2. **Production**: dispatching `release.yml` **on the `release/v<X.Y.Z>` branch** runs the full production release — tag, GitHub Release, DMG sign/notarize/publish, npm packages, Docker Hub images, iOS TestFlight, platform dependency bump, and the merge-back of the release branch to `main`.
 
-The scheduled Tue/Thu 7:52am ET cut performs step 1 automatically; a human performs step 2 after the staging bake is green. A `release/v<X.Y.Z>` branch with no corresponding GitHub Release means a cut was never promoted — re-running step 1 refreshes it from current `main`.
+The scheduled Tue/Thu 7:52am ET cut performs step 1 automatically; a human performs step 2 after the staging bake is green. A `release/v<X.Y.Z>` branch with no corresponding GitHub Release means a cut was never promoted. Re-running step 1 refreshes it from current `main`.
 
 The user may pass `$ARGUMENTS` as the bump type for step 1: `patch`, `minor`, `major`, or `hotfix` (patch cut from the latest release tag's commit instead of `main`, pushed `[skip ci]` for manual cherry-picks). Default to `patch`.
 

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -10,7 +10,7 @@ Cut a new release. Releases are a **two-step** process:
 1. **Branch cut → staging bake**: `create-release-branch.yml` computes the version from the bump type, deletes any stale `release/v<X.Y.Z>` branch, cuts a fresh one from `main` HEAD with the version-bump commit, and pushes it. That push triggers a `Release` run on the branch which is a **staging** deploy (push-triggered and main-dispatched `Release` runs are always staging).
 2. **Production**: dispatching `release.yml` **on the `release/v<X.Y.Z>` branch** runs the full production release — tag, GitHub Release, DMG sign/notarize/publish, npm packages, Docker Hub images, iOS TestFlight, platform dependency bump, and the merge-back of the release branch to `main`.
 
-The scheduled Tue/Fri 8:52am ET cut performs step 1 automatically; a human performs step 2 after the staging bake is green. A `release/v<X.Y.Z>` branch with no corresponding GitHub Release means a cut was never promoted — re-running step 1 refreshes it from current `main`.
+The scheduled Tue/Thu 7:52am ET cut performs step 1 automatically; a human performs step 2 after the staging bake is green. A `release/v<X.Y.Z>` branch with no corresponding GitHub Release means a cut was never promoted — re-running step 1 refreshes it from current `main`.
 
 The user may pass `$ARGUMENTS` as the bump type for step 1: `patch`, `minor`, `major`, or `hotfix` (patch cut from the latest release tag's commit instead of `main`, pushed `[skip ci]` for manual cherry-picks). Default to `patch`.
 

--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -2,11 +2,11 @@ name: Create Release Branch
 
 on:
   schedule:
-    # Release at 7:52am ET every Tuesday and Friday. Two entries cover EDT
+    # Release at 7:52am ET every Tuesday and Thursday. Two entries cover EDT
     # (UTC-4) and EST (UTC-5); schedule-guard picks the one matching today's
     # offset and drops the other.
-    - cron: "52 11 * * 2,5"  # EDT: 7:52am ET
-    - cron: "52 12 * * 2,5"  # EST: 7:52am ET
+    - cron: "52 11 * * 2,4"  # EDT: 7:52am ET
+    - cron: "52 12 * * 2,4"  # EST: 7:52am ET
   workflow_dispatch:
     inputs:
       bump:
@@ -46,9 +46,9 @@ jobs:
           # start) stays correct even when GitHub delays the scheduled run.
           OFFSET=$(TZ=America/New_York date +%z)
           if [ "$OFFSET" = "-0400" ]; then
-            EXPECTED="52 11 * * 2,5"  # EDT: 7:52am ET = 11:52 UTC
+            EXPECTED="52 11 * * 2,4"  # EDT: 7:52am ET = 11:52 UTC
           else
-            EXPECTED="52 12 * * 2,5"  # EST: 7:52am ET = 12:52 UTC
+            EXPECTED="52 12 * * 2,4"  # EST: 7:52am ET = 12:52 UTC
           fi
           if [ "${{ github.event.schedule }}" != "$EXPECTED" ]; then
             echo "should-run=false" >> "$GITHUB_OUTPUT"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,7 @@ TestFlight builds are produced by the `release-ios.yaml` reusable workflow in th
 
 ## Cutting Releases
 
-**Never cut or promote a release automatically — always get explicit manual confirmation from the user first.** This applies to both release steps: dispatching `create-release-branch.yml` (branch cut + staging bake) and dispatching `release.yml` on a `release/v<X.Y.Z>` branch (production deploy). An explicit user request for the release in the current conversation counts as confirmation; otherwise ask and wait. Never dispatch either workflow as a side effect of other work (merging PRs, completing a plan, scheduled or autonomous agent runs), and standing authorizations (e.g. auto-merge) do not extend to releases. The scheduled Tue/Thu branch cut is the only sanctioned automation; production promotion is always a deliberate human action. Process details: `/release` (`.claude/skills/release/SKILL.md`).
+**Never cut or promote a release automatically. Always get explicit manual confirmation from the user first.** This applies to both release steps: dispatching `create-release-branch.yml` (branch cut + staging bake) and dispatching `release.yml` on a `release/v<X.Y.Z>` branch (production deploy). An explicit user request for the release in the current conversation counts as confirmation; otherwise ask and wait. Never dispatch either workflow as a side effect of other work (merging PRs, completing a plan, scheduled or autonomous agent runs), and standing authorizations (e.g. auto-merge) do not extend to releases. The scheduled Tue/Thu branch cut is the only sanctioned automation; production promotion is always a deliberate human action. Process details: `/release` (`.claude/skills/release/SKILL.md`).
 
 ## Testing
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,7 @@ TestFlight builds are produced by the `release-ios.yaml` reusable workflow in th
 
 ## Cutting Releases
 
-**Never cut or promote a release automatically — always get explicit manual confirmation from the user first.** This applies to both release steps: dispatching `create-release-branch.yml` (branch cut + staging bake) and dispatching `release.yml` on a `release/v<X.Y.Z>` branch (production deploy). An explicit user request for the release in the current conversation counts as confirmation; otherwise ask and wait. Never dispatch either workflow as a side effect of other work (merging PRs, completing a plan, scheduled or autonomous agent runs), and standing authorizations (e.g. auto-merge) do not extend to releases. The scheduled Tue/Fri branch cut is the only sanctioned automation; production promotion is always a deliberate human action. Process details: `/release` (`.claude/skills/release/SKILL.md`).
+**Never cut or promote a release automatically — always get explicit manual confirmation from the user first.** This applies to both release steps: dispatching `create-release-branch.yml` (branch cut + staging bake) and dispatching `release.yml` on a `release/v<X.Y.Z>` branch (production deploy). An explicit user request for the release in the current conversation counts as confirmation; otherwise ask and wait. Never dispatch either workflow as a side effect of other work (merging PRs, completing a plan, scheduled or autonomous agent runs), and standing authorizations (e.g. auto-merge) do not extend to releases. The scheduled Tue/Thu branch cut is the only sanctioned automation; production promotion is always a deliberate human action. Process details: `/release` (`.claude/skills/release/SKILL.md`).
 
 ## Testing
 

--- a/docs/internal-reference.md
+++ b/docs/internal-reference.md
@@ -602,7 +602,7 @@ Releases are cut using the `/release` Claude Code command and follow a two-step 
 Run `/release [patch|minor|major|hotfix]` in Claude Code. The command:
 
 1. Pulls the latest `main` branch and shows the commits the release will carry
-2. Dispatches `create-release-branch.yml` with the bump type. The workflow computes the version from the latest tag, deletes any stale `release/vX.Y.Z` branch, cuts a fresh one from `main` HEAD with the version-bump commit ("Release vX.Y.Z"), and pushes it — which triggers a **staging** `Release` run on the branch (push-triggered and main-dispatched `Release` runs are always staging; the scheduled Tue/Fri 8:52am ET cut is this same step)
+2. Dispatches `create-release-branch.yml` with the bump type. The workflow computes the version from the latest tag, deletes any stale `release/vX.Y.Z` branch, cuts a fresh one from `main` HEAD with the version-bump commit ("Release vX.Y.Z"), and pushes it, which triggers a **staging** `Release` run on the branch (push-triggered and main-dispatched `Release` runs are always staging; the scheduled Tue/Thu 7:52am ET cut is this same step)
 3. Waits for the staging bake to succeed — it is the CI bake for the exact release payload; a failure means fixing `main` and re-cutting
 4. Dispatches `release.yml` on `release/vX.Y.Z` — "manual dispatch on a release branch" is the **full production release**: tags `vX.Y.Z`, publishes npm packages, builds/signs/notarizes and publishes the macOS DMG, pushes Docker Hub images, uploads iOS to TestFlight, creates the GitHub Release, updates the `vellum-assistant-platform` dependency, and merges the release branch back to `main`
 


### PR DESCRIPTION
## Summary

- Moved the scheduled release branch cut from Tuesday/Friday to Tuesday/Thursday in `.github/workflows/create-release-branch.yml` (`2,5` -> `2,4` on both cron entries). Time of day is unchanged at 7:52am ET.
- Updated the matching `EXPECTED` strings in the `schedule-guard` job, which compares `github.event.schedule` byte-for-byte against the cron expressions. Leaving them on `2,5` would have made every scheduled run a no-op.
- Synced the three places that documented the old cadence: `AGENTS.md` (the release policy, which calls the scheduled cut the only sanctioned automation), `.claude/skills/release/SKILL.md`, and `docs/internal-reference.md`.
- The two skill/reference docs also stated 8:52am ET, which has been stale since #39401 moved the cron to 7:52am ET. Corrected alongside the weekday. Flagging it since it goes slightly beyond the weekday swap that was asked for.
- Recast the em-dash clauses on the doc lines this PR touches, per the repo rule that they be fixed on changed lines.

## Original prompt

The release GitHub Action currently fires twice a week, on Tuesdays and Fridays. Noa asked to keep the Tuesday cut as-is and move the second one from Friday to Thursday, leaving everything else about the schedule (time of day, EDT/EST double-entry handling) untouched.
