### PR TITLE
fix(assistant): scope a narrowing managed STT stand-in to the live-voice role

### DIFF
--- a/assistant/src/__tests__/managed-speech-defaults.test.ts
+++ b/assistant/src/__tests__/managed-speech-defaults.test.ts
@@ -27,6 +27,7 @@ mock.module("../calls/telephony-tts-capability.js", () => ({
 
 import { getConfig, invalidateConfigCache } from "../config/loader.js";
 import { maybeDefaultSpeechToManaged } from "../config/managed-speech-defaults.js";
+import { sttCatalogKeyForRole } from "../stt/roles.js";
 
 const WORKSPACE_DIR = process.env.VELLUM_WORKSPACE_DIR!;
 const CONFIG_PATH = join(WORKSPACE_DIR, "config.json");
@@ -113,6 +114,69 @@ describe("maybeDefaultSpeechToManaged", () => {
         tts: { provider: "vellum" },
       },
     });
+  });
+
+  test("a narrowing stand-in is written to the live-voice role, not the global", async () => {
+    // BYOK Flux with no key: the stand-in preserves turn detection, so it is
+    // vellum-flux, which streams and nothing else. Writing that globally is
+    // how batch transcription and telephony disappear for a managed user.
+    mockManagedSpeechAvailable = true;
+    writeConfig({
+      services: {
+        stt: {
+          provider: "deepgram",
+          providers: { deepgram: { model: "flux" } },
+        },
+        tts: { provider: "vellum" },
+      },
+    });
+
+    await maybeDefaultSpeechToManaged();
+
+    const stt = (readConfig().services as any).stt;
+    expect(stt.roles.liveVoice).toEqual({ provider: "vellum", model: "flux" });
+    // The other consumers land on the stand-in's base, which serves them all.
+    expect(stt.provider).toBe("vellum");
+    expect(stt.providers.vellum.model).toBe("nova-3");
+  });
+
+  test("the role write leaves batch and telephony on a provider that answers", async () => {
+    mockManagedSpeechAvailable = true;
+    writeConfig({
+      services: {
+        stt: {
+          provider: "deepgram",
+          providers: { deepgram: { model: "flux" } },
+        },
+        tts: { provider: "vellum" },
+      },
+    });
+
+    await maybeDefaultSpeechToManaged();
+
+    invalidateConfigCache();
+    const stt = getConfig().services.stt;
+    expect(sttCatalogKeyForRole(stt, "liveVoice")).toBe("vellum-flux");
+    expect(sttCatalogKeyForRole(stt, "batch")).toBe("vellum");
+    expect(sttCatalogKeyForRole(stt, "telephony")).toBe("vellum");
+  });
+
+  test("a capability-preserving stand-in still writes the global provider", async () => {
+    // Plain deepgram has no turn detection, so the stand-in is plain vellum,
+    // which serves every role. That one belongs on the global, not a role.
+    mockManagedSpeechAvailable = true;
+    writeConfig({
+      services: {
+        stt: { provider: "deepgram" },
+        tts: { provider: "vellum" },
+      },
+    });
+
+    await maybeDefaultSpeechToManaged();
+
+    const stt = (readConfig().services as any).stt;
+    expect(stt.provider).toBe("vellum");
+    expect(stt.roles).toBeUndefined();
   });
 
   test("never repoints an explicit BYOK provider with resolving credentials", async () => {

--- a/assistant/src/config/managed-speech-defaults.ts
+++ b/assistant/src/config/managed-speech-defaults.ts
@@ -27,7 +27,12 @@ import {
   supportsProviderTurnDetection,
 } from "../providers/speech-to-text/provider-catalog.js";
 import { sttProviderKeyResolves } from "../providers/speech-to-text/resolve.js";
-import { sttCatalogKeyForRole, type SttRole } from "../stt/roles.js";
+import {
+  STT_ROLES,
+  sttCatalogKeyForRole,
+  type SttRole,
+  sttRoleCapabilityGap,
+} from "../stt/roles.js";
 import type { SttProviderId } from "../stt/types.js";
 import { getCatalogProvider } from "../tts/provider-catalog.js";
 import type { TtsProviderId } from "../tts/types.js";
@@ -132,6 +137,48 @@ export async function resolveEffectiveSpeechProviders(
 }
 
 /**
+ * Whether a provider can serve every consumer, or only the one that chose it.
+ *
+ * `vellum` covers every boundary, so substituting it is safe everywhere. A
+ * narrowing row like `vellum-flux` streams and nothing else, and the roles it
+ * fails are exactly the consumers that must not be moved onto it.
+ */
+function servesEveryRole(provider: SttProviderId): boolean {
+  const selection = sttConfigForCatalogKey(provider);
+  return STT_ROLES.every(
+    (role) => sttRoleCapabilityGap(role, selection) === null,
+  );
+}
+
+/**
+ * The writes that put `selection` in force as the global provider.
+ *
+ * The family is always written, including the base one. Substituting away
+ * from a variant leaves its `model` behind otherwise, and the next load
+ * resolves straight back to the variant this substitution just rejected: the
+ * provider would read as plain vellum while running Flux, with batch and
+ * telephony quietly unavailable. A provider with no families has no name to
+ * write, and no variant to have left a stale value behind either.
+ */
+function globalSttUpdates(selection: {
+  provider: string;
+  model?: string | undefined;
+}): { path: string; provider: string }[] {
+  const updates = [
+    { path: "services.stt.provider", provider: selection.provider },
+  ];
+  const family =
+    selection.model ?? baseModelFamilyFor(selection.provider as SttProviderId);
+  if (family !== undefined) {
+    updates.push({
+      path: `services.stt.providers.${selection.provider}.model`,
+      provider: family,
+    });
+  }
+  return updates;
+}
+
+/**
  * Persist the effective speech providers resolved by
  * {@link resolveEffectiveSpeechProviders} whenever they differ from the
  * configured ones.
@@ -151,24 +198,30 @@ export async function maybeDefaultSpeechToManaged(): Promise<void> {
       // the pair that selects it. Writing the key itself would put an id the
       // schema rejects on disk, and an unparseable services block is how the
       // loader's salvage ladder ends up resetting the whole section.
-      const sttConfig = sttConfigForCatalogKey(effective.stt);
-      updates.push({
-        path: "services.stt.provider",
-        provider: sttConfig.provider,
-      });
-      // Always write the family, including the base one. Substituting away
-      // from a variant leaves its `model` behind otherwise, and the next load
-      // resolves straight back to the variant this substitution just
-      // rejected: the provider would read as plain vellum while running Flux,
-      // with batch and telephony quietly unavailable.
-      // A provider with no families has no name to write, and no variant to
-      // have left a stale value behind either.
-      const family = sttConfig.model ?? baseModelFamilyFor(sttConfig.provider);
-      if (family !== undefined) {
+      const standIn = sttConfigForCatalogKey(effective.stt);
+      if (servesEveryRole(effective.stt)) {
+        updates.push(...globalSttUpdates(standIn));
+      } else {
+        // A stand-in that cannot serve every consumer belongs to the one that
+        // chose it. Live voice is that consumer: provider turn detection is
+        // the only reason managedStandInFor reaches for a narrow row, and
+        // writing that row globally would take batch transcription and
+        // telephony from every other consumer in a single write.
         updates.push({
-          path: `services.stt.providers.${sttConfig.provider}.model`,
-          provider: family,
+          path: "services.stt.roles.liveVoice.provider",
+          provider: standIn.provider,
         });
+        if (standIn.model !== undefined) {
+          updates.push({
+            path: "services.stt.roles.liveVoice.model",
+            provider: standIn.model,
+          });
+        }
+        // The other consumers still need a provider that answers, and the
+        // narrow stand-in's own base is the managed row that serves them.
+        if (servesEveryRole(standIn.provider as SttProviderId)) {
+          updates.push(...globalSttUpdates({ provider: standIn.provider }));
+        }
       }
     }
     if (effective.tts !== services.tts.provider) {


### PR DESCRIPTION
Stacked on #41402 (JARVIS-1640), which introduces `services.stt.roles`. GitHub will retarget this to `main` when that merges.

## Problem

`maybeDefaultSpeechToManaged` resolves with no role and persists `services.stt.provider`, the global. That is correct while the managed stand-in is `vellum`, which serves every boundary. It becomes wrong the moment the stand-in can be `vellum-flux`: that row is `supportedBoundaries: ["daemon-streaming"]` and `telephonyMode: "none"`, so a single defaulting write would take batch transcription and telephony away from every managed user at once.

## Change

The write target follows capability:

- A stand-in that satisfies every role still writes the global, unchanged.
- One that does not is written to `services.stt.roles.liveVoice`. Live voice is the consumer that asked for it, since provider turn detection is the only reason `managedStandInFor` reaches for a narrow row.
- The other consumers are pointed at that row's own base (`vellum`), which does serve them, so nothing is stranded on a provider that cannot answer.

## What this does not do

It does not make managed live voice reach Flux. `managedStandInFor` still requires the configured provider to already do provider turn detection, so a managed user on plain `vellum` is unaffected. Flipping that is gated on JARVIS-1642.

## Tests

Three new cases in `managed-speech-defaults.test.ts` covering the narrowing write, the resulting per-role resolution (`liveVoice` -> `vellum-flux`, `batch`/`telephony` -> `vellum`), and the unchanged capability-preserving path. Verified non-vacuous: two fail when the capability branch is forced.

Closes JARVIS-1645

🤖 Generated with [Claude Code](https://claude.com/claude-code)