### PR TITLE
fix(assistant): keep languages Flux cannot serve off the Flux stand-in

### DIFF
--- a/assistant/src/__tests__/managed-speech-defaults.test.ts
+++ b/assistant/src/__tests__/managed-speech-defaults.test.ts
@@ -161,6 +161,49 @@ describe("maybeDefaultSpeechToManaged", () => {
     expect(sttCatalogKeyForRole(stt, "telephony")).toBe("vellum");
   });
 
+  test("a language Flux has no model for keeps live voice on nova-3", async () => {
+    // Korean is outside Flux's ten-language roster, so the relay would reject
+    // the dial. Standing in with Flux hands the speaker a dead mic rather
+    // than a worse transcriber.
+    mockManagedSpeechAvailable = true;
+    writeConfig({
+      services: {
+        stt: {
+          provider: "deepgram",
+          language: "ko",
+          providers: { deepgram: { model: "flux" } },
+        },
+        tts: { provider: "vellum" },
+      },
+    });
+
+    await maybeDefaultSpeechToManaged();
+
+    const stt = (readConfig().services as any).stt;
+    expect(stt.provider).toBe("vellum");
+    expect(stt.providers.vellum.model).toBe("nova-3");
+    expect(stt.roles).toBeUndefined();
+  });
+
+  test("a language Flux does serve still reaches the flux stand-in", async () => {
+    mockManagedSpeechAvailable = true;
+    writeConfig({
+      services: {
+        stt: {
+          provider: "deepgram",
+          language: "hi",
+          providers: { deepgram: { model: "flux" } },
+        },
+        tts: { provider: "vellum" },
+      },
+    });
+
+    await maybeDefaultSpeechToManaged();
+
+    const stt = (readConfig().services as any).stt;
+    expect(stt.roles.liveVoice).toEqual({ provider: "vellum", model: "flux" });
+  });
+
   test("a capability-preserving stand-in still writes the global provider", async () => {
     // Plain deepgram has no turn detection, so the stand-in is plain vellum,
     // which serves every role. That one belongs on the global, not a role.

--- a/assistant/src/config/managed-speech-defaults.ts
+++ b/assistant/src/config/managed-speech-defaults.ts
@@ -18,6 +18,7 @@
 
 import { ttsSecretResolves } from "../calls/telephony-tts-capability.js";
 import { managedSpeechAvailable } from "../platform/managed-speech.js";
+import { fluxModelForLanguage } from "../providers/speech-to-text/deepgram-flux-frames.js";
 import {
   baseModelFamilyFor,
   getProviderEntry,
@@ -84,8 +85,18 @@ async function ttsByokCredentialsResolve(provider: string): Promise<boolean> {
  * changing how it takes turns, which reads as "Flux is no better" rather than
  * as a missing credential. Match the capability instead.
  */
-function managedStandInFor(configured: SttProviderId): SttProviderId {
-  return supportsProviderTurnDetection(configured) ? "vellum-flux" : "vellum";
+function managedStandInFor(
+  configured: SttProviderId,
+  language: string | undefined,
+): SttProviderId {
+  if (!supportsProviderTurnDetection(configured)) {
+    return "vellum";
+  }
+  // Flux has a model for ten languages. Outside them the relay rejects the
+  // dial outright, so standing in with it would hand the speaker a mic that
+  // does not work at all rather than one that detects turns less well. The
+  // language is the one the resolver will actually send.
+  return fluxModelForLanguage(language) === null ? "vellum" : "vellum-flux";
 }
 
 /** The speech providers a runtime path uses, after managed-speech defaulting. */
@@ -124,7 +135,7 @@ export async function resolveEffectiveSpeechProviders(
   const stt =
     !isManagedSttProvider(configuredStt) &&
     !(await sttByokCredentialResolves(configuredStt))
-      ? managedStandInFor(configuredStt)
+      ? managedStandInFor(configuredStt, services.stt.language)
       : configuredStt;
 
   const tts =

--- a/assistant/src/providers/speech-to-text/__tests__/resolve.test.ts
+++ b/assistant/src/providers/speech-to-text/__tests__/resolve.test.ts
@@ -1185,6 +1185,28 @@ describe("vellum-flux managed resolution", () => {
 
     await expect(resolveBatchTranscriber()).rejects.toThrow(SttError);
   });
+
+  test("refuses a language Flux has no model for, like BYOK Flux", async () => {
+    // The relay rejects the dial for a language outside Flux's roster, which
+    // reaches the caller as an unexplained param error. Refusing here names
+    // the reason where it can be read.
+    mockVellumAvailable = true;
+    applyConfig({ provider: "vellum-flux", language: "ko" });
+
+    expect(await resolveStreamingTranscriber({ sampleRate: 16000 })).toBeNull();
+    expect(vellumFluxStreamCtorCalls).toHaveLength(0);
+  });
+
+  test("serves a language that is on the Flux roster", async () => {
+    mockVellumAvailable = true;
+    applyConfig({ provider: "vellum-flux", language: "hi" });
+
+    const transcriber = await resolveStreamingTranscriber({
+      sampleRate: 16000,
+    });
+
+    expect(transcriber?.providerId).toBe("vellum-flux");
+  });
 });
 
 describe("vellum managed resolution", () => {

--- a/assistant/src/providers/speech-to-text/resolve.ts
+++ b/assistant/src/providers/speech-to-text/resolve.ts
@@ -703,6 +703,20 @@ async function createStreamingTranscriber(
       if (!(await vellumManagedSpeechAvailable())) {
         return null;
       }
+      // The relay maps the language onto a Flux model and refuses the dial
+      // when there is none, so a language outside Flux's roster fails as a
+      // relay param error the caller cannot explain. Refuse here instead, on
+      // the same rule the BYOK twin above applies, so the reason is named
+      // where it can be read.
+      const { fluxModelForLanguage: managedFluxModelForLanguage } =
+        await import("./deepgram-flux-frames.js");
+      if (managedFluxModelForLanguage(options.language) === null) {
+        log.warn(
+          { providerId, language: options.language },
+          "Managed Flux has no model for the configured language; refusing rather than transcribing it as another",
+        );
+        return null;
+      }
       const { resolveSpeechRelayConnection } =
         await import("./vellum-speech-relay-connection.js");
       const connection = await resolveSpeechRelayConnection();


### PR DESCRIPTION
Stacked on #41476 (JARVIS-1645), which is itself stacked on #41402. GitHub retargets each as its base merges.

## Problem

Flux has a model for ten languages (`de en es fr hi it ja nl pt ru`); nova-3 serves roughly fifty. Outside that set the relay refuses the dial outright, so defaulting a managed speaker onto Flux would not give them a worse transcriber, it would give them a mic that does not work at all.

Managed Flux also had no language guard where BYOK Flux already has one: `deepgram-flux` refuses an unservable language in `resolveStreamingTranscriber`, but `vellum-flux` dialed straight into a relay param error the caller could not explain.

## Change

Two gates, matching what BYOK Flux already does:

- **Selection.** `managedStandInFor` consults the configured language, so the substitution never picks `vellum-flux` for a language it has no model for. Live voice stays on `vellum` and nova-3's roster.
- **Resolution.** `resolveStreamingTranscriber` refuses `vellum-flux` on such a language rather than dialing. This covers a role an operator sets by hand, not only one that defaulting chose.

The fallback is deliberately at selection time, not inside the relay. Resolving it where the role resolves keeps `config get` and the resolver logs honest about which provider is in force; a relay-side fallback would silently serve a provider the daemon believes it is not using, which is the substitution JARVIS-1640 exists to make visible.

The gate reads the language the resolver actually sends, so an unset language resolving to code-switching passes it.

## Tests

Two cases in `managed-speech-defaults.test.ts` (an unservable language keeps live voice on nova-3; a servable one still reaches the stand-in) and two in `resolve.test.ts` (managed Flux refuses `ko`, serves `hi`).

Closes JARVIS-1646

🤖 Generated with [Claude Code](https://claude.com/claude-code)