### PR TITLE
feat(web): show which features run a different speech-to-text provider

### DIFF
--- a/clients/web/src/components/speech/stt-role-overrides.test.ts
+++ b/clients/web/src/components/speech/stt-role-overrides.test.ts
@@ -11,8 +11,9 @@ import { sttRoleOverrideEntries } from "@/components/speech/stt-role-overrides";
 
 describe("sttRoleOverrideEntries", () => {
   test("an assistant with no roles field reports nothing", () => {
-    // Also the pre-JARVIS-1640 daemon: the field is absent, so the section
-    // does not render, which is the feature-off state.
+    // An assistant that does not serve the field at all reports no entries,
+    // so the section does not render. That absence IS the compatibility
+    // story: there is no version gate behind it.
     expect(sttRoleOverrideEntries({ provider: "vellum" })).toEqual([]);
     expect(sttRoleOverrideEntries(undefined)).toEqual([]);
   });

--- a/clients/web/src/components/speech/stt-role-overrides.test.ts
+++ b/clients/web/src/components/speech/stt-role-overrides.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Which `services.stt.roles` entries count as a divergence worth showing.
+ *
+ * The comparison is the whole behaviour of the section: a role that resolves
+ * to the global selection is not an override, and a role naming a different
+ * model family on the same provider is.
+ */
+import { describe, expect, test } from "bun:test";
+
+import { sttRoleOverrideEntries } from "@/components/speech/stt-role-overrides";
+
+describe("sttRoleOverrideEntries", () => {
+  test("an assistant with no roles field reports nothing", () => {
+    // Also the pre-JARVIS-1640 daemon: the field is absent, so the section
+    // does not render, which is the feature-off state.
+    expect(sttRoleOverrideEntries({ provider: "vellum" })).toEqual([]);
+    expect(sttRoleOverrideEntries(undefined)).toEqual([]);
+  });
+
+  test("a role naming the global provider is not an override", () => {
+    expect(
+      sttRoleOverrideEntries({
+        provider: "deepgram",
+        roles: { liveVoice: { provider: "deepgram" } },
+      }),
+    ).toEqual([]);
+  });
+
+  test("a role on another provider is an override", () => {
+    expect(
+      sttRoleOverrideEntries({
+        provider: "openai-whisper",
+        roles: { dictation: { provider: "deepgram" } },
+      }),
+    ).toEqual([{ role: "dictation", provider: "deepgram" }]);
+  });
+
+  test("a different model family on the same provider is an override", () => {
+    // The case managed defaulting produces: live voice on Flux while the
+    // global stays on the base family. Comparing providers alone would call
+    // this identical and hide the one divergence that matters.
+    expect(
+      sttRoleOverrideEntries({
+        provider: "vellum",
+        providers: { vellum: { model: "nova-3" } },
+        roles: { liveVoice: { provider: "vellum", model: "flux" } },
+      }),
+    ).toEqual([{ role: "liveVoice", provider: "vellum", model: "flux" }]);
+  });
+
+  test("a role repeating the global's own family is not an override", () => {
+    expect(
+      sttRoleOverrideEntries({
+        provider: "vellum",
+        providers: { vellum: { model: "flux" } },
+        roles: { liveVoice: { provider: "vellum", model: "flux" } },
+      }),
+    ).toEqual([]);
+  });
+
+  test("reports every diverging role", () => {
+    const entries = sttRoleOverrideEntries({
+      provider: "vellum",
+      roles: {
+        liveVoice: { provider: "vellum", model: "flux" },
+        batch: { provider: "vellum" },
+        telephony: { provider: "deepgram" },
+      },
+    });
+
+    expect(entries.map((e) => e.role).sort()).toEqual([
+      "liveVoice",
+      "telephony",
+    ]);
+  });
+
+  test("a malformed role entry is skipped rather than rendered blank", () => {
+    expect(
+      sttRoleOverrideEntries({
+        provider: "vellum",
+        roles: { liveVoice: {}, batch: undefined },
+      }),
+    ).toEqual([]);
+  });
+});

--- a/clients/web/src/components/speech/stt-role-overrides.tsx
+++ b/clients/web/src/components/speech/stt-role-overrides.tsx
@@ -190,6 +190,12 @@ export function SttRoleOverrides({ assistantId }: { assistantId: string }) {
               <Button
                 variant="ghost"
                 size="compact"
+                // Sibling text does not reach a button's accessible name, so
+                // several rows would otherwise offer a screen reader a column
+                // of buttons all called "Reset".
+                aria-label={t("sttRoleOverrides.clearAria", {
+                  feature: labelKey ? t(labelKey) : entry.role,
+                })}
                 // Ghost resolves to `--content-default`, which reads louder
                 // than the provider it sits beside. The value is what the row
                 // exists to report; this is only the way out of it.

--- a/clients/web/src/components/speech/stt-role-overrides.tsx
+++ b/clients/web/src/components/speech/stt-role-overrides.tsx
@@ -1,0 +1,184 @@
+/**
+ * The consumers running an STT provider other than `services.stt.provider`.
+ *
+ * `services.stt.roles` lets one consumer diverge from the global provider,
+ * and managed-speech defaulting can write one without the user asking (live
+ * voice moves to Flux while batch and telephony stay behind). The provider
+ * form above shows only the global, so without this the divergence that
+ * config exists to make visible would be legible only in the daemon log.
+ *
+ * Read-only compatibility: an assistant predating `services.stt.roles` omits
+ * the field, so `entries` is empty and the section does not render, which is
+ * exactly the feature-off state. The reset write is reachable only from a row,
+ * and a row exists only where a daemon wrote a role, so it cannot reach an
+ * assistant that would not understand it. That structural gate is why there is
+ * no `MIN_VERSION` here: a version gate would have to name an unreleased
+ * version, which reads as unsupported on same-source self-hosted daemons that
+ * report the last released version while running this code.
+ */
+
+import { useState } from "react";
+
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+
+import {
+  configGetOptions,
+  configGetQueryKey,
+  sttProvidersGetOptions,
+} from "@/generated/daemon/@tanstack/react-query.gen";
+import { configPatch } from "@/generated/daemon/sdk.gen";
+import { useIsOrgReady } from "@/hooks/use-is-org-ready";
+import { useTranslation } from "@/i18n";
+import { Button } from "@vellumai/design-library/components/button";
+import { toast } from "@vellumai/design-library/components/toast";
+
+/** A `services.stt.roles.<role>` entry: a provider and optional family. */
+interface SttRoleSelection {
+  provider?: string;
+  model?: string;
+}
+
+/** The shape this component reads out of the `services.stt` config block. */
+export interface SttConfigShape {
+  provider?: string;
+  providers?: Record<string, { model?: string } | undefined>;
+  roles?: Record<string, SttRoleSelection | undefined>;
+}
+
+/** A consumer whose provider differs from the global one. */
+export interface SttRoleOverrideEntry {
+  role: string;
+  provider: string;
+  model?: string;
+}
+
+/**
+ * The roles that resolve to something other than the global selection.
+ *
+ * Compares the pair, not the provider alone: `{deepgram, flux}` and plain
+ * `deepgram` are different transcribers with different capabilities, and a
+ * role naming the family the global already uses is not a divergence worth
+ * showing.
+ */
+export function sttRoleOverrideEntries(
+  stt: SttConfigShape | undefined,
+): SttRoleOverrideEntry[] {
+  const roles = stt?.roles;
+  if (!roles) {
+    return [];
+  }
+  const globalProvider = stt?.provider;
+  const globalModel = globalProvider
+    ? stt?.providers?.[globalProvider]?.model
+    : undefined;
+
+  const entries: SttRoleOverrideEntry[] = [];
+  for (const [role, selection] of Object.entries(roles)) {
+    const provider = selection?.provider;
+    if (!provider) {
+      continue;
+    }
+    if (provider === globalProvider && selection?.model === globalModel) {
+      continue;
+    }
+    entries.push({
+      role,
+      provider,
+      ...(selection?.model !== undefined ? { model: selection.model } : {}),
+    });
+  }
+  return entries;
+}
+
+export function SttRoleOverrides({ assistantId }: { assistantId: string }) {
+  const { t } = useTranslation("settings");
+  const queryClient = useQueryClient();
+  const isOrgReady = useIsOrgReady();
+  const [clearing, setClearing] = useState<string | null>(null);
+
+  const { data: daemonConfig } = useQuery({
+    ...configGetOptions({ path: { assistant_id: assistantId } }),
+    enabled: isOrgReady,
+    staleTime: 30_000,
+  });
+  // `services.stt` falls under the ConfigGetResponse index signature
+  // (`unknown`), so narrow it explicitly, as the provider form does.
+  const stt = daemonConfig?.services?.stt as SttConfigShape | undefined;
+  const entries = sttRoleOverrideEntries(stt);
+
+  // Display names for the base providers. Variant rows are filtered out of
+  // this endpoint (they are selected through a model family, not offered as
+  // providers), so the family is rendered from the role's own pair.
+  const { data: catalog } = useQuery({
+    ...sttProvidersGetOptions({ path: { assistant_id: assistantId } }),
+    enabled: isOrgReady && entries.length > 0,
+    staleTime: 5 * 60_000,
+  });
+
+  if (entries.length === 0) {
+    return null;
+  }
+
+  const displayNameFor = (provider: string): string =>
+    catalog?.providers?.find((p) => p.id === provider)?.displayName ?? provider;
+
+  const clearRole = async (role: string) => {
+    setClearing(role);
+    try {
+      const { response } = await configPatch({
+        path: { assistant_id: assistantId },
+        // `null` deletes the key through the daemon's deep-merge, which is
+        // what returns this consumer to the global provider. Writing the
+        // global's value instead would pin it, and it would stop following
+        // a later change to the global.
+        body: { services: { stt: { roles: { [role]: null } } } },
+        throwOnError: false,
+      });
+      if (!response?.ok) {
+        throw new Error(String(response?.status ?? ""));
+      }
+      await queryClient.invalidateQueries({
+        queryKey: configGetQueryKey({ path: { assistant_id: assistantId } }),
+      });
+    } catch {
+      toast.error(t("sttRoleOverrides.clearFailed"));
+    } finally {
+      setClearing(null);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <span className="text-body-small-default text-[var(--content-tertiary)]">
+        {t("sttRoleOverrides.title")}
+      </span>
+      <ul className="flex flex-col gap-1">
+        {entries.map((entry) => (
+          <li
+            key={entry.role}
+            className="flex items-center gap-3 rounded-md border border-[var(--border-subtle)] bg-[var(--surface-sunken)] px-3 py-2"
+          >
+            <span className="min-w-0 flex-1 truncate text-body-medium-lighter text-[var(--content-default)]">
+              {t(`sttRoleOverrides.role.${entry.role}`, {
+                defaultValue: entry.role,
+              })}
+            </span>
+            <span className="min-w-0 truncate text-body-small-default text-[var(--content-tertiary)]">
+              {entry.model
+                ? `${displayNameFor(entry.provider)} · ${entry.model}`
+                : displayNameFor(entry.provider)}
+            </span>
+            <Button
+              variant="ghost"
+              size="compact"
+              disabled={clearing === entry.role}
+              onClick={() => void clearRole(entry.role)}
+            >
+              {t("sttRoleOverrides.clear")}
+            </Button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/clients/web/src/components/speech/stt-role-overrides.tsx
+++ b/clients/web/src/components/speech/stt-role-overrides.tsx
@@ -166,7 +166,7 @@ export function SttRoleOverrides({ assistantId }: { assistantId: string }) {
   };
 
   return (
-    <div className="flex flex-col gap-2">
+    <div className="mt-1 flex flex-col gap-2 border-t border-[var(--border-subtle)] pt-4">
       <span className="text-body-small-default text-[var(--content-tertiary)]">
         {t("sttRoleOverrides.title")}
       </span>
@@ -177,12 +177,12 @@ export function SttRoleOverrides({ assistantId }: { assistantId: string }) {
           return (
             <li
               key={entry.role}
-              className="flex items-center gap-3 rounded-md border border-[var(--border-subtle)] bg-[var(--surface-sunken)] px-3 py-2"
+              className="flex items-center gap-4 rounded-md border border-[var(--border-subtle)] bg-[var(--surface-sunken)] px-3 py-2"
             >
               <span className="min-w-0 flex-1 truncate text-body-medium-lighter text-[var(--content-default)]">
                 {labelKey ? t(labelKey) : entry.role}
               </span>
-              <span className="min-w-0 truncate text-body-small-default text-[var(--content-tertiary)]">
+              <span className="min-w-0 truncate text-body-small-default text-[var(--content-default)]">
                 {entry.model
                   ? `${displayNameFor(entry.provider)} · ${entry.model}`
                   : displayNameFor(entry.provider)}
@@ -190,6 +190,10 @@ export function SttRoleOverrides({ assistantId }: { assistantId: string }) {
               <Button
                 variant="ghost"
                 size="compact"
+                // Ghost resolves to `--content-default`, which reads louder
+                // than the provider it sits beside. The value is what the row
+                // exists to report; this is only the way out of it.
+                className="[--vbtn-fg:var(--content-tertiary)]"
                 disabled={clearing === entry.role}
                 onClick={() => void clearRole(entry.role)}
               >

--- a/clients/web/src/components/speech/stt-role-overrides.tsx
+++ b/clients/web/src/components/speech/stt-role-overrides.tsx
@@ -45,6 +45,24 @@ export interface SttConfigShape {
   roles?: Record<string, SttRoleSelection | undefined>;
 }
 
+/**
+ * The label key for each role, written out per role rather than built from the
+ * role id.
+ *
+ * The catalog guard (`i18n/catalogs.test.ts`) decides a key is dead copy by
+ * searching source text for it quoted, so a key assembled from a template
+ * literal reads as unreferenced and the five role labels would be deleted as
+ * orphans. Writing them out also means a role the daemon adds later renders
+ * its raw id instead of a missing-key placeholder.
+ */
+const ROLE_LABEL_KEYS = {
+  batch: "sttRoleOverrides.role.batch",
+  dictation: "sttRoleOverrides.role.dictation",
+  liveVoice: "sttRoleOverrides.role.liveVoice",
+  telephony: "sttRoleOverrides.role.telephony",
+  watch: "sttRoleOverrides.role.watch",
+} as const;
+
 /** A consumer whose provider differs from the global one. */
 export interface SttRoleOverrideEntry {
   role: string;
@@ -153,31 +171,33 @@ export function SttRoleOverrides({ assistantId }: { assistantId: string }) {
         {t("sttRoleOverrides.title")}
       </span>
       <ul className="flex flex-col gap-1">
-        {entries.map((entry) => (
-          <li
-            key={entry.role}
-            className="flex items-center gap-3 rounded-md border border-[var(--border-subtle)] bg-[var(--surface-sunken)] px-3 py-2"
-          >
-            <span className="min-w-0 flex-1 truncate text-body-medium-lighter text-[var(--content-default)]">
-              {t(`sttRoleOverrides.role.${entry.role}`, {
-                defaultValue: entry.role,
-              })}
-            </span>
-            <span className="min-w-0 truncate text-body-small-default text-[var(--content-tertiary)]">
-              {entry.model
-                ? `${displayNameFor(entry.provider)} · ${entry.model}`
-                : displayNameFor(entry.provider)}
-            </span>
-            <Button
-              variant="ghost"
-              size="compact"
-              disabled={clearing === entry.role}
-              onClick={() => void clearRole(entry.role)}
+        {entries.map((entry) => {
+          const labelKey =
+            ROLE_LABEL_KEYS[entry.role as keyof typeof ROLE_LABEL_KEYS];
+          return (
+            <li
+              key={entry.role}
+              className="flex items-center gap-3 rounded-md border border-[var(--border-subtle)] bg-[var(--surface-sunken)] px-3 py-2"
             >
-              {t("sttRoleOverrides.clear")}
-            </Button>
-          </li>
-        ))}
+              <span className="min-w-0 flex-1 truncate text-body-medium-lighter text-[var(--content-default)]">
+                {labelKey ? t(labelKey) : entry.role}
+              </span>
+              <span className="min-w-0 truncate text-body-small-default text-[var(--content-tertiary)]">
+                {entry.model
+                  ? `${displayNameFor(entry.provider)} · ${entry.model}`
+                  : displayNameFor(entry.provider)}
+              </span>
+              <Button
+                variant="ghost"
+                size="compact"
+                disabled={clearing === entry.role}
+                onClick={() => void clearRole(entry.role)}
+              >
+                {t("sttRoleOverrides.clear")}
+              </Button>
+            </li>
+          );
+        })}
       </ul>
     </div>
   );

--- a/clients/web/src/domains/settings/ai/speech-to-text-card.tsx
+++ b/clients/web/src/domains/settings/ai/speech-to-text-card.tsx
@@ -4,12 +4,15 @@
  * first-run card, which renders it bare inside its own modal.
  */
 
+import { useActiveAssistantId } from "@/assistant/use-active-assistant-id";
 import { ByoServiceCard } from "@/components/byo-service-card";
 import { SttProviderForm } from "@/components/speech/stt-provider-form";
+import { SttRoleOverrides } from "@/components/speech/stt-role-overrides";
 import { useTranslation } from "@/i18n";
 
 export function SpeechToTextCard() {
   const { t } = useTranslation("settings");
+  const assistantId = useActiveAssistantId();
 
   return (
     <ByoServiceCard
@@ -17,6 +20,11 @@ export function SpeechToTextCard() {
       subtitle={t("speechToTextCard.subtitle")}
     >
       <SttProviderForm />
+      {/* Only the settings card carries this. The live-voice first-run modal
+          renders the form bare to get someone speaking, and a consumer that
+          diverges from the global is a thing to review later, not a decision
+          to make mid-setup. */}
+      <SttRoleOverrides assistantId={assistantId} />
     </ByoServiceCard>
   );
 }

--- a/clients/web/src/i18n/locales/en/settings.json
+++ b/clients/web/src/i18n/locales/en/settings.json
@@ -1854,6 +1854,18 @@
     "subtitle": "Configure how your assistant transcribes speech",
     "title": "Speech-to-Text"
   },
+  "sttRoleOverrides": {
+    "clear": "Reset",
+    "clearFailed": "Could not reset",
+    "role": {
+      "batch": "File transcription",
+      "dictation": "Dictation",
+      "liveVoice": "Live voice",
+      "telephony": "Phone calls",
+      "watch": "Watch"
+    },
+    "title": "Per feature"
+  },
   "systemTasksSection": {
     "consolidationName": "Consolidation",
     "consolidationPausedHelper": "Memory is off, so consolidation is paused.",

--- a/clients/web/src/i18n/locales/en/settings.json
+++ b/clients/web/src/i18n/locales/en/settings.json
@@ -1856,6 +1856,7 @@
   },
   "sttRoleOverrides": {
     "clear": "Reset",
+    "clearAria": "Reset {feature}",
     "clearFailed": "Could not reset",
     "role": {
       "batch": "File transcription",

--- a/clients/web/src/i18n/locales/es/settings.json
+++ b/clients/web/src/i18n/locales/es/settings.json
@@ -1854,6 +1854,19 @@
     "subtitle": "Configura cómo tu asistente transcribe el habla",
     "title": "Voz a texto"
   },
+  "sttRoleOverrides": {
+    "clear": "Restablecer",
+    "clearAria": "Restablecer {feature}",
+    "clearFailed": "No se pudo restablecer",
+    "role": {
+      "batch": "Transcripción de archivos",
+      "dictation": "Dictado",
+      "liveVoice": "Voz en vivo",
+      "telephony": "Llamadas",
+      "watch": "Observación"
+    },
+    "title": "Por función"
+  },
   "systemTasksSection": {
     "consolidationName": "Consolidación",
     "consolidationPausedHelper": "La memoria está desactivada, así que la consolidación está en pausa.",

--- a/clients/web/src/i18n/locales/ru/settings.json
+++ b/clients/web/src/i18n/locales/ru/settings.json
@@ -1853,6 +1853,19 @@
     "subtitle": "Настройка того, как ассистент слышит слова",
     "title": "Речь в текст"
   },
+  "sttRoleOverrides": {
+    "clear": "Сбросить",
+    "clearAria": "Сбросить: {feature}",
+    "clearFailed": "Не удалось сбросить",
+    "role": {
+      "batch": "Транскрипция файлов",
+      "dictation": "Диктовка",
+      "liveVoice": "Голосовой режим",
+      "telephony": "Звонки",
+      "watch": "Наблюдение"
+    },
+    "title": "По функциям"
+  },
   "systemTasksSection": {
     "consolidationName": "Консолидация",
     "consolidationPausedHelper": "Память выключена, поэтому консолидация на паузе.",


### PR DESCRIPTION
Base is `main`, not the JARVIS-1640 stack. This is web-only, compiles independently, and renders nothing until a daemon writes `services.stt.roles`, so it is safe to merge in any order relative to #41402 / #41476 / #41477. It only becomes visible once those land.

## Problem

`services.stt.roles` lets one consumer diverge from `services.stt.provider`, and managed-speech defaulting can write one on the user's behalf (#41476). The Speech-to-Text card shows only the global provider, so a live-voice session moved to Flux while batch and telephony stayed behind was legible from the daemon log and nowhere else. That is the opposite of what the roles config is for: it exists to make a silent substitution visible.

## Change

The card lists the consumers whose provider differs from the global, each with what it actually runs and a reset.

Reset deletes the key (`null` through the daemon's deep-merge) rather than writing the global's current value, so the consumer keeps following a later change to the global instead of being pinned to today's.

Two details worth calling out:

- **Divergence compares the whole pair, not the provider.** Live voice on `vellum` running `flux` against a global `vellum` on the base family is precisely the case this exists to surface, and comparing providers alone would call it identical and hide it.
- **The family is rendered from the role's own pair.** `GET /v1/stt/providers` filters out model-family rows (`variantOf !== undefined`), because a provider picker must not offer them as separate providers, so there is no `Vellum (Flux)` display name to look up. The row composes the base provider's display name with the family the role names.

## Compatibility

No version gate, deliberately. An assistant predating `services.stt.roles` omits the field, so the list is empty and the section does not render, which is exactly the feature-off state the doc's exemption describes. The reset write is reachable only from a row, and a row exists only where a daemon wrote a role, so it cannot reach an assistant that would not understand it. A `MIN_VERSION` here would have to name an unreleased version, which reads as unsupported on the same-source self-hosted daemons that report the last released version while running this code (`BACKWARDS_COMPAT.md`, "When a gate is unnecessary").

## Design library

Uses `Button` and `toast` from `@vellumai/design-library`; the row is a plain `li` with existing surface/border tokens rather than a new primitive, matching the card's sibling rows.

## Tests

Seven cases over the pure divergence function: the absent-field (old daemon) case, a role repeating the global, a different provider, a different family on the same provider, a role repeating the global's own family, multiple roles, and a malformed entry.

Closes JARVIS-1647

🤖 Generated with [Claude Code](https://claude.com/claude-code)