### PR TITLE
Settle the minimized ask-question card against its mock

### DIFF
--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -40,6 +40,7 @@ import {
   isDraftPastOneLine,
   shouldSubmitOnEnter,
 } from "@/domains/chat/components/chat-composer/chat-composer-utils";
+import { useInteractionStore } from "@/domains/chat/interaction-store";
 import { useQuoteReplyStore } from "@/domains/chat/quote-reply-store";
 
 // The two device-side axes are driven by stubbing `window.matchMedia`, not by
@@ -733,6 +734,7 @@ beforeEach(() => {
     stagedQuotes: [],
     replyBubble: null,
   });
+  useInteractionStore.setState({ pendingQuestion: null });
 });
 
 /**
@@ -1532,6 +1534,51 @@ describe("ChatComposer: a banner standing over the card", () => {
     expect(composerShell(container)?.hasAttribute("data-banner-above")).toBe(
       true,
     );
+  });
+
+  test("a pending question card takes the row down with it", async () => {
+    // GIVEN a standing row in an app shell
+    mockIsNativeMobile = true;
+    const { container } = renderPhoneComposer(SETTINGS_SLOTS);
+    expect(pillsRow(container)?.hasAttribute("hidden")).toBe(false);
+
+    // WHEN the agent raises a question, whose card docks in the same strip
+    await act(async () => {
+      useInteractionStore.setState({
+        pendingQuestion: {
+          requestId: "req-1",
+          entries: [{ id: "q1", question: "Which one?", options: [] }],
+        },
+      });
+    });
+
+    // THEN the row stands down, the way it does under a banner
+    expect(pillsRow(container)?.hasAttribute("hidden")).toBe(true);
+
+    // AND comes back once the question is answered
+    await act(async () => {
+      useInteractionStore.setState({ pendingQuestion: null });
+    });
+
+    expect(pillsRow(container)?.hasAttribute("hidden")).toBe(false);
+  });
+
+  test("focus does not buy the row back from a question card", () => {
+    // GIVEN a browser phone composer under a question card, where focus is
+    // normally what raises the row
+    useInteractionStore.setState({
+      pendingQuestion: {
+        requestId: "req-1",
+        entries: [{ id: "q1", question: "Which one?", options: [] }],
+      },
+    });
+    const { container } = renderPhoneComposer(SETTINGS_SLOTS);
+
+    // WHEN the user taps into it
+    fireEvent.focusIn(textareaOf(container));
+
+    // THEN the card still wins
+    expect(pillsRow(container)?.hasAttribute("hidden")).toBe(true);
   });
 
   test("a banner leaving gives the row back", async () => {

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -27,6 +27,7 @@ import {
   selectUploadingCount,
   useComposerStore,
 } from "@/domains/chat/composer-store";
+import { useHasPendingQuestion } from "@/domains/chat/interaction-store";
 import { useQuoteReplyStore } from "@/domains/chat/quote-reply-store";
 import { useComposerFocusWithin } from "@/domains/chat/hooks/use-composer-focus-within";
 import { ComposerDraftNotices } from "@/domains/chat/components/composer-draft-notices";
@@ -968,9 +969,16 @@ export function ChatComposer({
   // A banner docks to the card's top edge and takes the strip this row floats
   // in, so the row stands down while one is up rather than crowding it. The
   // avatar peeking over that same edge stands down with it (`ComposerPeek`).
+  //
+  // A pending question card lands in the same strip and stands the row down
+  // for the same reason, plus one of its own: the card is what the turn is
+  // waiting on, and the pills reach settings that are beside the point until
+  // it is answered.
+  const hasPendingQuestion = useHasPendingQuestion();
   const settingsPillsVisible =
     isMobileMainComposer &&
     !hasBannerAboveCard &&
+    !hasPendingQuestion &&
     (isNativeMobileShell || composerInUse);
   // The entrance belongs to the row that arrives with the keyboard. A row that
   // stands throughout has no arrival to animate, and the same animation there

--- a/clients/web/src/domains/chat/components/question-prompt-card-minimize.test.tsx
+++ b/clients/web/src/domains/chat/components/question-prompt-card-minimize.test.tsx
@@ -100,10 +100,18 @@ function renderCard(
   );
 }
 
+/**
+ * Whichever control currently carries the collapse state. Expanded that is the
+ * header chevron; minimized it is the summary itself, which is named by its own
+ * contents rather than a label, so `aria-expanded` is what identifies it in
+ * both states.
+ */
 function toggleButton(): HTMLElement {
-  return screen.getByRole("button", {
-    name: /Minimize question|Reopen question/,
-  });
+  const control = document.querySelector<HTMLElement>("[aria-expanded]");
+  if (!control) {
+    throw new Error("the card rendered no collapse control");
+  }
+  return control;
 }
 
 /**
@@ -162,7 +170,6 @@ describe("QuestionPromptCard minimize", () => {
     fireEvent.click(toggleButton());
 
     expect(toggleButton().getAttribute("aria-expanded")).toBe("false");
-    expect(toggleButton().getAttribute("aria-label")).toBe("Reopen question");
     // The question itself stays: it is what the summary row is a summary of.
     expect(
       screen.getByText("What should we build first for MarkOne?"),
@@ -281,6 +288,22 @@ describe("QuestionPromptCard minimize", () => {
     // What reopens the card is the summary itself, not a second chevron
     // pointing the other way.
     expect(toggleButton().tagName).not.toBe("BUTTON");
+  });
+
+  test("a minimized card is announced as the question it stands for", () => {
+    renderCard();
+
+    fireEvent.click(toggleButton());
+
+    // Descendants of a `role="button"` are flattened into its accessible name,
+    // so an `aria-label` here would trade the question and the option count for
+    // a generic phrase and a reader would lose both. Name-from-content is what
+    // keeps them, and it is the whole reason the label is absent.
+    expect(
+      screen.getByRole("button", {
+        name: /What should we build first for MarkOne\?.*4 options/,
+      }),
+    ).toBeDefined();
   });
 
   test("the keyboard reopens a minimized card", () => {

--- a/clients/web/src/domains/chat/components/question-prompt-card-minimize.test.tsx
+++ b/clients/web/src/domains/chat/components/question-prompt-card-minimize.test.tsx
@@ -144,6 +144,29 @@ function accessibleText(root: Element): string {
   return out.join(" | ");
 }
 
+/** The card's drag surface, which owns the touch handlers. */
+function dragSurface(): HTMLElement {
+  const el = document.querySelector<HTMLElement>(
+    '[data-slot="question-card-surface"]',
+  );
+  if (!el) {
+    throw new Error("the card rendered no drag surface");
+  }
+  return el;
+}
+
+/**
+ * A downward drag past the commit threshold, released. `MINIMIZE_COMMIT_PX` is
+ * 64, so 100px is comfortably a commit rather than a spring-back.
+ */
+function swipeDown(): void {
+  const surface = dragSurface();
+  const at = (clientY: number) => [{ identifier: 1, clientX: 0, clientY }];
+  fireEvent.touchStart(surface, { touches: at(200) });
+  fireEvent.touchMove(surface, { touches: at(300) });
+  fireEvent.touchEnd(surface, { changedTouches: at(300) });
+}
+
 function collapsibleRegion(): HTMLElement {
   const id = toggleButton().getAttribute("aria-controls");
   expect(id).toBeTruthy();
@@ -343,13 +366,39 @@ describe("QuestionPromptCard minimize", () => {
     expect(toggleButton().tagName).toBe("BUTTON");
   });
 
-  test("a card that opens minimized on its own does not pull focus", () => {
-    // The same guard the swipe relies on: focus moves only when the user
-    // activated one of the two controls, never when the state changed under a
-    // thumb that was not holding focus in the first place.
+  test("mounting does not pull focus into the card", () => {
     renderCard();
 
     expect(document.activeElement).toBe(document.body);
+  });
+
+  test("a swipe leaves focus where the user put it", () => {
+    // A thumb collapses the card while the free-text row holds focus. The
+    // gesture crosses the same state the chevron does, but focus is not its to
+    // move: it belongs to wherever the user left it.
+    setPointer(true);
+    renderCard();
+    screen.getByLabelText("Type a different answer").focus();
+
+    swipeDown();
+
+    expect(toggleButton().getAttribute("aria-expanded")).toBe("false");
+    expect(document.activeElement).not.toBe(toggleButton());
+  });
+
+  test("a swipe carries focus when it is the focused control being retired", () => {
+    // The hybrid keyboard-and-touch case: focus has been tabbed onto the
+    // chevron, and a thumb then swipes the card shut underneath it. The
+    // chevron unmounts, so focus has to land on what replaced it.
+    setPointer(true);
+    renderCard();
+    toggleButton().focus();
+    expect(document.activeElement).toBe(toggleButton());
+
+    swipeDown();
+
+    expect(toggleButton().getAttribute("aria-expanded")).toBe("false");
+    expect(document.activeElement).toBe(toggleButton());
   });
 
   test("the swipe grabber renders only where a swipe can happen", () => {

--- a/clients/web/src/domains/chat/components/question-prompt-card-minimize.test.tsx
+++ b/clients/web/src/domains/chat/components/question-prompt-card-minimize.test.tsx
@@ -257,6 +257,50 @@ describe("QuestionPromptCard minimize", () => {
     expect(screen.queryByRole("button", { name: "Next question" })).toBeNull();
   });
 
+  test("the position counter leaves with the pager it counts for", () => {
+    renderCard({ entries: [ENTRY, { ...ENTRY, id: "q2" }] });
+
+    expect(screen.getByText("1 of 2")).toBeDefined();
+
+    fireEvent.click(toggleButton());
+
+    expect(screen.queryByText("1 of 2")).toBeNull();
+  });
+
+  test("a minimized card keeps no chevron of its own", () => {
+    const { container } = renderCard({ onClose: () => {} });
+
+    fireEvent.click(toggleButton());
+
+    expect(
+      Array.from(container.querySelectorAll("button")).filter((button) => {
+        const label = button.getAttribute("aria-label");
+        return label === "Minimize question" || label === "Reopen question";
+      }),
+    ).toHaveLength(0);
+    // What reopens the card is the summary itself, not a second chevron
+    // pointing the other way.
+    expect(toggleButton().tagName).not.toBe("BUTTON");
+  });
+
+  test("the keyboard reopens a minimized card", () => {
+    renderCard();
+
+    fireEvent.click(toggleButton());
+    expect(toggleButton().getAttribute("aria-expanded")).toBe("false");
+
+    // The summary is a `role="button"` div, so it handles the keystrokes a
+    // real button would have taken care of on its own.
+    fireEvent.keyDown(toggleButton(), { key: "Enter" });
+
+    expect(toggleButton().getAttribute("aria-expanded")).toBe("true");
+
+    fireEvent.click(toggleButton());
+    fireEvent.keyDown(toggleButton(), { key: " " });
+
+    expect(toggleButton().getAttribute("aria-expanded")).toBe("true");
+  });
+
   test("the swipe grabber renders only where a swipe can happen", () => {
     const GRABBER = '[data-slot="question-card-grabber"]';
 

--- a/clients/web/src/domains/chat/components/question-prompt-card-minimize.test.tsx
+++ b/clients/web/src/domains/chat/components/question-prompt-card-minimize.test.tsx
@@ -324,6 +324,34 @@ describe("QuestionPromptCard minimize", () => {
     expect(toggleButton().getAttribute("aria-expanded")).toBe("true");
   });
 
+  test("focus follows the control that replaces the one it was on", () => {
+    renderCard();
+
+    const chevron = toggleButton();
+    chevron.focus();
+    fireEvent.click(chevron);
+
+    // The chevron has just unmounted. Left alone, focus would land on the
+    // document body and the next Tab would restart from the top of the page.
+    expect(document.activeElement).toBe(toggleButton());
+
+    fireEvent.keyDown(toggleButton(), { key: "Enter" });
+
+    // And back: the summary keeps the DOM node but loses its role and tab
+    // stop, so focus has to move to the chevron that took over from it.
+    expect(document.activeElement).toBe(toggleButton());
+    expect(toggleButton().tagName).toBe("BUTTON");
+  });
+
+  test("a card that opens minimized on its own does not pull focus", () => {
+    // The same guard the swipe relies on: focus moves only when the user
+    // activated one of the two controls, never when the state changed under a
+    // thumb that was not holding focus in the first place.
+    renderCard();
+
+    expect(document.activeElement).toBe(document.body);
+  });
+
   test("the swipe grabber renders only where a swipe can happen", () => {
     const GRABBER = '[data-slot="question-card-grabber"]';
 

--- a/clients/web/src/domains/chat/components/question-prompt-card.stories.tsx
+++ b/clients/web/src/domains/chat/components/question-prompt-card.stories.tsx
@@ -7,8 +7,17 @@
  * chevron, the swipe and the tap all land on the same transition, so it wants
  * to be played with rather than screenshotted. Open a story, use the chevron
  * in the header, and on a touch target drag the card down or flick it back up.
+ *
+ * The `Minimized*` stories start there instead, since that state is where the
+ * card is measured against the mock. They are set to the phone viewport, which
+ * is where the card is at its most cramped and where the collapse earns its
+ * keep. Note that a desktop browser reports a fine pointer at any width, so the
+ * swipe grabber stays away and the numeric hotkey badges stay on; open the
+ * story in a device-emulated frame, or on a real phone, to see the touch
+ * chrome.
  */
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { userEvent, within } from "storybook/test";
 
 import { QuestionPromptCard } from "@/domains/chat/components/question-prompt-card";
 import type { QuestionEntry } from "@/types/interaction-ui-types";
@@ -33,6 +42,23 @@ const CADENCE: QuestionEntry = {
     { id: "daily", label: "Every morning" },
     { id: "weekly", label: "Once a week" },
     { id: "never", label: "Only when something changes" },
+  ],
+};
+
+/**
+ * A question long enough to run past the one line the minimized header keeps,
+ * which is the shape the collapse actually ships in: the card docks above the
+ * composer with the question truncated to whatever the row has left.
+ */
+const LONG: QuestionEntry = {
+  id: "q3",
+  question:
+    "What's your preferred way to start the engagement, given how much of the positioning work is still open?",
+  description: "There is no wrong answer here.",
+  options: [
+    { id: "discovery", label: "A discovery call first" },
+    { id: "audit", label: "An audit of what exists" },
+    { id: "pilot", label: "A small paid pilot" },
   ],
 };
 
@@ -66,8 +92,9 @@ export const Expanded: Story = {
 };
 
 /**
- * A batch. The pager appears beside the counter, and both leave when the card
- * minimizes, since paging is an expanded-card action.
+ * A batch. The counter, the pager and the minimize chevron share the trailing
+ * cluster, and all three leave when the card minimizes, since every one of them
+ * acts on rows that are on screen.
  */
 export const Batched: Story = {
   args: { entries: [MARKONE, CADENCE] },
@@ -86,4 +113,46 @@ export const Submitting: Story = {
 /** No `onClose`, so the card renders without its X and Escape does nothing. */
 export const NotDismissible: Story = {
   args: { entries: [MARKONE], onClose: undefined },
+};
+
+/** Lands the story in the minimized state, which is otherwise a click away. */
+const minimizeCard: Story["play"] = async ({ canvasElement }) => {
+  const canvas = within(canvasElement);
+  await userEvent.click(
+    await canvas.findByRole("button", { name: "Minimize question" }),
+  );
+};
+
+/**
+ * The minimized card, at the width it docks above the composer on a phone. The
+ * question truncates to one line, the option count and the way back stand in
+ * for the body, and the only control left is the X: the chevron leaves with the
+ * rows it collapsed, and the summary itself is what reopens the card. Click it,
+ * or tab to it and press Enter.
+ */
+export const Minimized: Story = {
+  args: { entries: [LONG] },
+  globals: { viewport: { value: "sbMobile" } },
+  play: minimizeCard,
+};
+
+/**
+ * A minimized batch. The `1 of 2` counter is an expanded-card reading, so it
+ * leaves with the pager it counts for rather than sitting in a row that has
+ * nothing to page.
+ */
+export const MinimizedBatched: Story = {
+  args: { entries: [MARKONE, CADENCE] },
+  globals: { viewport: { value: "sbMobile" } },
+  play: minimizeCard,
+};
+
+/**
+ * The expanded card at phone width, to compare the two against each other: the
+ * counter, the pager and the one chevron all sit in the trailing cluster, and
+ * all of them go away together on the way down.
+ */
+export const BatchedOnAPhone: Story = {
+  args: { entries: [MARKONE, CADENCE] },
+  globals: { viewport: { value: "sbMobile" } },
 };

--- a/clients/web/src/domains/chat/components/question-prompt-card.tsx
+++ b/clients/web/src/domains/chat/components/question-prompt-card.tsx
@@ -91,9 +91,10 @@ export function QuestionPromptCard(props: QuestionPromptCardProps) {
  * At full height the card covers the assistant message the question is about,
  * which on a phone is most of what is left of the transcript (LUM-3390). The
  * header stays put and everything below it collapses to nothing, leaving the
- * question and an option count docked above the composer. Three ways in and
- * out, all driving the same state: the header's chevron, a vertical swipe
- * anywhere on the card, and a tap on a minimized card's header.
+ * question and an option count docked above the composer. Three ways through
+ * it, all driving the same state: the header's chevron minimizes, a vertical
+ * swipe anywhere on the card goes either way, and a minimized card reopens
+ * from its own header.
  *
  * `useQuestionCardMinimize` reduces all of that to one `progress` value, which
  * every moving part below reads. Mid-drag it tracks the finger; at rest it is
@@ -126,7 +127,19 @@ export function QuestionPromptBody({
   const collapsibleId = useId();
 
   const minimize = useQuestionCardMinimize();
-  const { isMinimized, progress, dragAttr } = minimize;
+  const { expand, isMinimized, progress, dragAttr } = minimize;
+
+  // `role="button"` buys the summary the click, not the keystrokes a real
+  // button would have handled for free.
+  const handleReopenKeyDown = useCallback(
+    (event: ReactKeyboardEvent<HTMLDivElement>) => {
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        expand();
+      }
+    },
+    [expand],
+  );
 
   const isBatched = entries.length > 1;
   const currentEntry = entries[currentIndex];
@@ -375,14 +388,29 @@ export function QuestionPromptBody({
           // Only where a drag can start: elsewhere this would take away the
           // ability to select the question text and give nothing back.
           isTouch && "select-none",
-          isMinimized && "cursor-pointer",
         )}
-        // A minimized card reopens from anywhere in its header, which is the
-        // whole card. Left off while expanded so the header's own buttons
-        // aren't shadowed by a handler that would undo them on the way up.
-        onClick={isMinimized ? minimize.expand : undefined}
       >
-        <div className="flex min-w-0 flex-1 flex-col">
+        <div
+          className={cn(
+            "flex min-w-0 flex-1 flex-col",
+            isMinimized && "cursor-pointer",
+          )}
+          // A minimized card carries no chevron of its own, so the summary is
+          // what reopens it, by tap and by keyboard alike. Role and tabindex
+          // rather than a real button because the close X sits in the same row
+          // and must not end up nested inside one. Left off while expanded so
+          // the header's own buttons aren't shadowed by a handler that would
+          // undo them on the way up.
+          role={isMinimized ? "button" : undefined}
+          tabIndex={isMinimized ? 0 : undefined}
+          aria-expanded={isMinimized ? false : undefined}
+          aria-controls={isMinimized ? collapsibleId : undefined}
+          aria-label={
+            isMinimized ? t("questionPromptCard.expandAria") : undefined
+          }
+          onClick={isMinimized ? expand : undefined}
+          onKeyDown={isMinimized ? handleReopenKeyDown : undefined}
+        >
           <Typography
             variant="body-medium-default"
             as="div"
@@ -438,28 +466,32 @@ export function QuestionPromptBody({
           </div>
         </div>
         <div className="flex shrink-0 items-center gap-1">
-          {isBatched && (
-            <Typography
-              variant="label-small-default"
-              as="span"
-              className="px-1 text-[color:var(--content-tertiary)]"
-            >
-              {t("questionPromptCard.position", {
-                current: currentIndex + 1,
-                total: entries.length,
-              })}
-            </Typography>
-          )}
           {!isMinimized && (
-            // Paging through a batch is an expanded-card action, so the pager
-            // leaves with the rows it pages between. It fades out over the
-            // first half of the collapse and unmounts once the state commits,
-            // by which point it is already invisible.
+            // Everything in here acts on rows that are on screen: the pager
+            // pages between them, the counter says which one is showing, and
+            // the chevron puts them away. So all three leave with the rows,
+            // fading out over the first half of the collapse and unmounting
+            // once the state commits, by which point they are already
+            // invisible. The chevron points down and stays there: reopening is
+            // the minimized header's job, and a second control rotated the
+            // other way would only duplicate it.
             <div
               className="question-card-motion flex items-center gap-1"
               style={{ opacity: expandedOpacity }}
               data-dragging={dragAttr}
             >
+              {isBatched && (
+                <Typography
+                  variant="label-small-default"
+                  as="span"
+                  className="px-1 text-[color:var(--content-tertiary)]"
+                >
+                  {t("questionPromptCard.position", {
+                    current: currentIndex + 1,
+                    total: entries.length,
+                  })}
+                </Typography>
+              )}
               <Button
                 variant="ghost"
                 size="compact"
@@ -476,27 +508,17 @@ export function QuestionPromptBody({
                 disabled={!canGoNext || isSubmitting}
                 aria-label={t("questionPromptCard.nextQuestionAria")}
               />
+              <Button
+                variant="ghost"
+                size="compact"
+                iconOnly={<ChevronDown />}
+                onClick={minimize.toggle}
+                aria-expanded
+                aria-controls={collapsibleId}
+                aria-label={t("questionPromptCard.minimizeAria")}
+              />
             </div>
           )}
-          <Button
-            variant="ghost"
-            size="compact"
-            iconOnly={
-              <ChevronDown
-                className="question-card-motion"
-                style={{ transform: `rotate(${(1 - progress) * 180}deg)` }}
-                data-dragging={dragAttr}
-              />
-            }
-            onClick={minimize.toggle}
-            aria-expanded={!isMinimized}
-            aria-controls={collapsibleId}
-            aria-label={
-              isMinimized
-                ? t("questionPromptCard.expandAria")
-                : t("questionPromptCard.minimizeAria")
-            }
-          />
           {onClose && (
             <Button
               variant="ghost"

--- a/clients/web/src/domains/chat/components/question-prompt-card.tsx
+++ b/clients/web/src/domains/chat/components/question-prompt-card.tsx
@@ -9,6 +9,7 @@ import {
 } from "lucide-react";
 import {
   type KeyboardEvent as ReactKeyboardEvent,
+  type TouchEvent as ReactTouchEvent,
   useCallback,
   useEffect,
   useId,
@@ -133,24 +134,46 @@ export function QuestionPromptBody({
   // chevron while expanded, the summary while minimized.
   const summaryRef = useRef<HTMLDivElement>(null);
   const chevronRef = useRef<HTMLButtonElement>(null);
-  // Whether the state last changed by activating one of those two, as opposed
-  // to a swipe or the first render. Only then does focus have somewhere it has
-  // to follow: crossing the state unmounts the chevron and strips the summary
-  // of its role and tab stop, so a keyboard user is left on the document body
-  // and the next Tab restarts from the top of the page. A swipe is a thumb
-  // that was never holding focus to begin with, and moving it there would take
-  // focus away from wherever the user actually left it.
-  const moveFocusRef = useRef(false);
+  // Whether the control that is about to be retired is the one holding focus.
+  // Crossing the state unmounts the chevron and strips the summary of its role
+  // and tab stop, so a keyboard user would be left on the document body with
+  // the next Tab restarting from the top of the page.
+  //
+  // Sampled up front rather than read in the effect below, which runs after the
+  // commit that already removed the chevron and sent focus to the body. And a
+  // sample rather than a flag saying "a control was activated", because the
+  // swipe crosses the same state without going through either control: a thumb
+  // that was not holding focus must not drag it out of wherever the user left
+  // it, and one that was must not lose it.
+  const controlHadFocusRef = useRef(false);
+
+  const sampleControlFocus = useCallback(() => {
+    const control = isMinimized ? summaryRef.current : chevronRef.current;
+    controlHadFocusRef.current =
+      control !== null && document.activeElement === control;
+  }, [isMinimized]);
 
   const handleMinimize = useCallback(() => {
-    moveFocusRef.current = true;
+    sampleControlFocus();
     toggle();
-  }, [toggle]);
+  }, [sampleControlFocus, toggle]);
 
   const handleReopen = useCallback(() => {
-    moveFocusRef.current = true;
+    sampleControlFocus();
     expand();
-  }, [expand]);
+  }, [sampleControlFocus, expand]);
+
+  // The third way across, and the only one that does not run through a control.
+  // Sampling on touch-start is early enough for any of them: the engine cannot
+  // commit before the finger has moved.
+  const { onTouchStart } = minimize.dragHandlers;
+  const handleCardTouchStart = useCallback(
+    (event: ReactTouchEvent) => {
+      sampleControlFocus();
+      onTouchStart(event);
+    },
+    [sampleControlFocus, onTouchStart],
+  );
 
   // `role="button"` buys the summary the click, not the keystrokes a real
   // button would have handled for free.
@@ -165,10 +188,10 @@ export function QuestionPromptBody({
   );
 
   useEffect(() => {
-    if (!moveFocusRef.current) {
+    if (!controlHadFocusRef.current) {
       return;
     }
-    moveFocusRef.current = false;
+    controlHadFocusRef.current = false;
     // The counterpart, which this same commit has just put on screen.
     const replacement = isMinimized ? summaryRef.current : chevronRef.current;
     replacement?.focus();
@@ -390,8 +413,9 @@ export function QuestionPromptBody({
       // `touchend`: the card would follow the finger and then snap back with
       // nothing committed. Zoom and horizontal panning are left alone, since
       // neither is a gesture the card wants.
+      data-slot="question-card-surface"
       className="relative flex flex-col p-4 [touch-action:pan-x_pinch-zoom]"
-      onTouchStart={minimize.dragHandlers.onTouchStart}
+      onTouchStart={handleCardTouchStart}
       onTouchMove={minimize.dragHandlers.onTouchMove}
       onTouchEnd={minimize.dragHandlers.onTouchEnd}
       onTouchCancel={minimize.dragHandlers.onTouchCancel}

--- a/clients/web/src/domains/chat/components/question-prompt-card.tsx
+++ b/clients/web/src/domains/chat/components/question-prompt-card.tsx
@@ -396,18 +396,27 @@ export function QuestionPromptBody({
             isMinimized && "cursor-pointer",
           )}
           // A minimized card carries no chevron of its own, so the summary is
-          // what reopens it, by tap and by keyboard alike. Role and tabindex
-          // rather than a real button because the close X sits in the same row
-          // and must not end up nested inside one. Left off while expanded so
-          // the header's own buttons aren't shadowed by a handler that would
-          // undo them on the way up.
+          // what reopens it, by tap and by keyboard alike. Left off while
+          // expanded, so the header's own buttons aren't shadowed by a handler
+          // that would undo them on the way up.
+          //
+          // Deliberately not `Button`, and deliberately unlabelled:
+          //
+          // - A real button would have to swap in at the state flip, and
+          //   changing the element type at this position remounts everything
+          //   under it. The two crossfading rows below are in there, and they
+          //   ease on `grid-template-rows`, which a fresh mount has no previous
+          //   value to interpolate from. The collapse would jump instead of
+          //   running.
+          // - A button's accessible name comes from its contents, and here the
+          //   contents are exactly what a reader should hear in place of the
+          //   body: the question, and the count of options behind it. An
+          //   `aria-label` would replace both with a generic phrase, since
+          //   descendants of `role="button"` are flattened into the name.
           role={isMinimized ? "button" : undefined}
           tabIndex={isMinimized ? 0 : undefined}
           aria-expanded={isMinimized ? false : undefined}
           aria-controls={isMinimized ? collapsibleId : undefined}
-          aria-label={
-            isMinimized ? t("questionPromptCard.expandAria") : undefined
-          }
           onClick={isMinimized ? expand : undefined}
           onKeyDown={isMinimized ? handleReopenKeyDown : undefined}
         >

--- a/clients/web/src/domains/chat/components/question-prompt-card.tsx
+++ b/clients/web/src/domains/chat/components/question-prompt-card.tsx
@@ -127,7 +127,30 @@ export function QuestionPromptBody({
   const collapsibleId = useId();
 
   const minimize = useQuestionCardMinimize();
-  const { expand, isMinimized, progress, dragAttr } = minimize;
+  const { expand, isMinimized, progress, dragAttr, toggle } = minimize;
+
+  // The two halves of the collapse control. Only one is ever on screen: the
+  // chevron while expanded, the summary while minimized.
+  const summaryRef = useRef<HTMLDivElement>(null);
+  const chevronRef = useRef<HTMLButtonElement>(null);
+  // Whether the state last changed by activating one of those two, as opposed
+  // to a swipe or the first render. Only then does focus have somewhere it has
+  // to follow: crossing the state unmounts the chevron and strips the summary
+  // of its role and tab stop, so a keyboard user is left on the document body
+  // and the next Tab restarts from the top of the page. A swipe is a thumb
+  // that was never holding focus to begin with, and moving it there would take
+  // focus away from wherever the user actually left it.
+  const moveFocusRef = useRef(false);
+
+  const handleMinimize = useCallback(() => {
+    moveFocusRef.current = true;
+    toggle();
+  }, [toggle]);
+
+  const handleReopen = useCallback(() => {
+    moveFocusRef.current = true;
+    expand();
+  }, [expand]);
 
   // `role="button"` buys the summary the click, not the keystrokes a real
   // button would have handled for free.
@@ -135,11 +158,21 @@ export function QuestionPromptBody({
     (event: ReactKeyboardEvent<HTMLDivElement>) => {
       if (event.key === "Enter" || event.key === " ") {
         event.preventDefault();
-        expand();
+        handleReopen();
       }
     },
-    [expand],
+    [handleReopen],
   );
+
+  useEffect(() => {
+    if (!moveFocusRef.current) {
+      return;
+    }
+    moveFocusRef.current = false;
+    // The counterpart, which this same commit has just put on screen.
+    const replacement = isMinimized ? summaryRef.current : chevronRef.current;
+    replacement?.focus();
+  }, [isMinimized]);
 
   const isBatched = entries.length > 1;
   const currentEntry = entries[currentIndex];
@@ -391,6 +424,7 @@ export function QuestionPromptBody({
         )}
       >
         <div
+          ref={summaryRef}
           className={cn(
             "flex min-w-0 flex-1 flex-col",
             isMinimized && "cursor-pointer",
@@ -417,7 +451,7 @@ export function QuestionPromptBody({
           tabIndex={isMinimized ? 0 : undefined}
           aria-expanded={isMinimized ? false : undefined}
           aria-controls={isMinimized ? collapsibleId : undefined}
-          onClick={isMinimized ? expand : undefined}
+          onClick={isMinimized ? handleReopen : undefined}
           onKeyDown={isMinimized ? handleReopenKeyDown : undefined}
         >
           <Typography
@@ -518,10 +552,11 @@ export function QuestionPromptBody({
                 aria-label={t("questionPromptCard.nextQuestionAria")}
               />
               <Button
+                ref={chevronRef}
                 variant="ghost"
                 size="compact"
                 iconOnly={<ChevronDown />}
-                onClick={minimize.toggle}
+                onClick={handleMinimize}
                 aria-expanded
                 aria-controls={collapsibleId}
                 aria-label={t("questionPromptCard.minimizeAria")}

--- a/clients/web/src/domains/chat/interaction-store.ts
+++ b/clients/web/src/domains/chat/interaction-store.ts
@@ -450,6 +450,15 @@ const useInteractionStoreBase = create<InteractionStore>()((set, get) => ({
 
 export const useInteractionStore = createSelectors(useInteractionStoreBase);
 
+/**
+ * Whether a question card is on screen. A boolean rather than the state
+ * itself, so a subscriber that only cares that one is up does not re-render
+ * every time its contents change.
+ */
+export function useHasPendingQuestion(): boolean {
+  return useInteractionStore((state) => state.pendingQuestion !== null);
+}
+
 /** Atomic per-kind subscription, so a card re-renders only for its own kind. */
 export function useSubmittingRequestId(kind: PromptKind): string | null {
   return useInteractionStore((state) => state.submittingByKind[kind]);

--- a/clients/web/src/i18n/locales/en/chat.json
+++ b/clients/web/src/i18n/locales/en/chat.json
@@ -1159,7 +1159,6 @@
   },
   "questionPromptCard": {
     "closeQuestionAria": "Close question",
-    "expandAria": "Reopen question",
     "minimizeAria": "Minimize question",
     "minimizedSummary": "{count, plural, one {# option} other {# options}} · Tap to reopen",
     "nextQuestionAria": "Next question",

--- a/clients/web/src/i18n/locales/es/chat.json
+++ b/clients/web/src/i18n/locales/es/chat.json
@@ -1159,7 +1159,6 @@
   },
   "questionPromptCard": {
     "closeQuestionAria": "Cerrar pregunta",
-    "expandAria": "Reabrir pregunta",
     "minimizeAria": "Minimizar pregunta",
     "minimizedSummary": "{count, plural, one {# opción} other {# opciones}} · Toca para reabrir",
     "nextQuestionAria": "Pregunta siguiente",


### PR DESCRIPTION
Follow-up to #41417 (LUM-3390). On a phone the minimized card carried three things the mock does not:

- the settings pills floating in the strip between the card and the composer,
- a `1 of N` counter in a row with nothing left to page,
- a chevron rotated 180° to point back up.

## What changed

**The pills stand down while a question is pending.** They float in the strip the card docks into, so this is the same rule that already takes them down under a banner, plus one of its own: they reach settings that are beside the point until the question is answered. A new `useHasPendingQuestion()` keeps the composer's subscription to a boolean, so a card whose contents change does not re-render it.

**The counter moved inside the expanded-only pager group.** It is an expanded-card reading, so it leaves with the pager it counts for rather than sitting in the collapsed row.

**The chevron joins them there and stops rotating.** It points down and minimizes, and nothing else. What reopens a minimized card is now its own summary, which picks up `role="button"`, a tab stop, Enter/Space, and the `aria-expanded` / `aria-controls` pair the chevron used to carry, so the keyboard way back in survives the chevron leaving. It is deliberately not a real `<button>`: the close X is its sibling in that row and must not end up nested inside one.

## Deliberate deviation

The mock puts a rounded-square reopen control on the **left** of the minimized card. There is no reopen chevron at all now, which is what was asked for. Happy to add the left-hand square as a follow-up if that is still wanted.

The counter and the chevron are gated on the minimized state only. Expanded still shows `1 of N` beside its pager and still shows the down chevron.

## Storybook

`Chat / QuestionPromptCard` gains three stories, so the collapsed state can be reviewed without a device:

- **Minimized** — the collapsed card at phone width, question truncated to one line
- **MinimizedBatched** — a collapsed 2-question batch, where the missing counter shows
- **BatchedOnAPhone** — the expanded card at the same width, to flip against it

Both `Minimized*` stories `play` the chevron on mount so they land collapsed. Caveat noted in the file: a desktop browser reports a fine pointer at any width, so the swipe grabber stays hidden and the numeric hotkey badges stay on. Device emulation or a real phone shows the touch chrome.

## Verification

- `bun run test:ci` — 1064 passed, 3 failed, all three the known pre-existing failures on `main` (`checkout-page`, `checkout-return-target`, `daily-reset-time` ICU `GMT` vs `GMT+0`)
- `bunx tsc --noEmit` and `eslint` clean
- 5 new tests: pills go down when a question is raised and come back when it clears; focus does not buy the row back from a card; the counter leaves with the pager; no chevron survives the collapse; Enter and Space reopen a minimized card
- Both new minimized stories verified rendering collapsed in a browser against a live Storybook

## Device QA outstanding

The swipe against the iOS keyboard and the reopen tap target on a real phone, carried over from #41417.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

