### PR TITLE
Add the iOS Home Screen widgets to Storybook as replicas

### DIFF
--- a/clients/ios/App/VoiceActivity/Widgets/CatchUpWidget.swift
+++ b/clients/ios/App/VoiceActivity/Widgets/CatchUpWidget.swift
@@ -30,6 +30,10 @@ struct CatchUpWidget: Widget {
     }
 }
 
+// A Storybook replica copies this file's measurements and palette, at
+// `clients/web/src/components/ios-widget-previews/`. Nothing checks the two
+// against each other, so a change here wants a look there.
+
 /// Actions on the left, conversations on the right.
 ///
 /// The split is the point: the actions are always available and always in the

--- a/clients/ios/App/VoiceActivity/Widgets/QuickActionsWidget.swift
+++ b/clients/ios/App/VoiceActivity/Widgets/QuickActionsWidget.swift
@@ -37,6 +37,10 @@ struct QuickActionsWidget: Widget {
     }
 }
 
+// A Storybook replica copies this file's measurements and palette, at
+// `clients/web/src/components/ios-widget-previews/`. Nothing checks the two
+// against each other, so a change here wants a look there.
+
 /// The card: the two actions along the bottom, the assistant across the top,
 /// and the count beside it while something is waiting.
 ///

--- a/clients/ios/App/VoiceActivity/Widgets/StatusWidget.swift
+++ b/clients/ios/App/VoiceActivity/Widgets/StatusWidget.swift
@@ -33,6 +33,10 @@ struct StatusWidget: Widget {
     }
 }
 
+// A Storybook replica copies this file's measurements and palette, at
+// `clients/web/src/components/ios-widget-previews/`. Nothing checks the two
+// against each other, so a change here wants a look there.
+
 /// One card that swaps what it is for: a readout when the account has something
 /// waiting, a launcher when it does not.
 ///

--- a/clients/ios/App/VoiceActivity/Widgets/WidgetActionControls.swift
+++ b/clients/ios/App/VoiceActivity/Widgets/WidgetActionControls.swift
@@ -18,6 +18,10 @@ import WidgetKit
 // a translucent white, which survives the flattening as the same soft ground it
 // was drawn as.
 
+// A Storybook replica copies this file's measurements and palette, at
+// `clients/web/src/components/ios-widget-previews/`. Nothing checks the two
+// against each other, so a change here wants a look there.
+
 /// The grounds a control draws on once WidgetKit flattens the widget.
 ///
 /// White rather than the control's own color because only alpha survives the

--- a/clients/ios/App/VoiceActivity/Widgets/WidgetTheme.swift
+++ b/clients/ios/App/VoiceActivity/Widgets/WidgetTheme.swift
@@ -1,6 +1,10 @@
 import SwiftUI
 import UIKit
 
+// A Storybook replica copies this file's measurements and palette, at
+// `clients/web/src/components/ios-widget-previews/`. Nothing checks the two
+// against each other, so a change here wants a look there.
+
 /// The one palette the Vellum Home Screen widgets draw from.
 ///
 /// A widget renders in a process that never runs the SPA, so the CSS custom

--- a/clients/web/src/components/ios-widget-previews/catch-up-widget-preview.tsx
+++ b/clients/web/src/components/ios-widget-previews/catch-up-widget-preview.tsx
@@ -1,0 +1,385 @@
+/* eslint-disable local/no-untranslated-strings --
+ * The literals here are not this app's copy. They reproduce strings hardcoded
+ * in the widgets' Swift, which ships in English only and never reads this app's
+ * catalogs: a widget renders in an extension process that does not run the SPA.
+ * Routing them through `t()` would assert a localization the widgets do not
+ * have, and would let a catalog edit silently drift the preview away from the
+ * card it is a picture of. The rule also reports the rgba style values below,
+ * which are not copy at all.
+ */
+/**
+ * The Catch Up widget: an action column, and the recent conversations beside
+ * it.
+ *
+ * Medium only, on a 339x161 canvas. Titles and group names are
+ * `.privacySensitive()` on the device, so iOS redacts them on a locked phone,
+ * which is what makes carrying titles into the snapshot defensible at all.
+ *
+ * @see clients/ios/App/VoiceActivity/Widgets/CatchUpWidget.swift
+ */
+
+import {
+  BubbleGlyph,
+  EllipsisGlyph,
+  VellumVGlyph,
+  WaveformGlyph,
+} from "./widget-glyphs";
+import { WidgetCard } from "./widget-card";
+import {
+  resolveColor,
+  softAccent,
+  widgetTheme,
+  type WidgetAppearance,
+} from "./widget-tokens";
+
+const CONTENT_MARGIN = 16;
+const ACTION_COLUMN_WIDTH = 71;
+const COLUMN_GAP = 14;
+const TILE_GAP = 7;
+const HEADER_TOP_INSET = 3;
+const HEADER_LEADING_INSET = 4;
+const HEADER_BOTTOM_GAP = 5;
+const MAX_ROWS = 3;
+const ROW_DESIGN_HEIGHT = 37;
+const ROW_LEADING_INSET = 8;
+const ROW_TEXT_TOP_INSET = 6;
+const ROW_GLYPH_SIZE = 12;
+const ROW_GLYPH_TEXT_GAP = 7;
+/** Where the glyph hangs, by whether the row carries a subtitle. */
+const GLYPH_TWO_LINE_TOP_INSET = 12.5;
+const GLYPH_TITLE_ONLY_TOP_INSET = 7;
+const TILE_CORNER_RADIUS = 12;
+const TILE_ICON_SIZE = 24;
+const TILE_LABEL_SIZE = 8;
+const FLATTENED_TILE_FILL = "rgba(255, 255, 255, 0.12)";
+
+export interface CatchUpConversation {
+  id: string;
+  title: string;
+  /** The group the conversation belongs to; omitted, the row is one line. */
+  subtitle?: string;
+  hasUnseen?: boolean;
+  isProcessing?: boolean;
+}
+
+export interface CatchUpWidgetPreviewProps {
+  scale?: number;
+  appearance?: WidgetAppearance;
+  conversations?: CatchUpConversation[];
+  accentHex?: string | null;
+  avatarImageUrl?: string | null;
+  /** A snapshot too old to be trusted about work in flight. */
+  isStale?: boolean;
+  flattened?: boolean;
+}
+
+export function CatchUpWidgetPreview({
+  scale = 1,
+  appearance = "light",
+  conversations = [],
+  accentHex = "#0E9B8B",
+  avatarImageUrl = null,
+  isStale = false,
+  flattened = false,
+}: CatchUpWidgetPreviewProps) {
+  const accent = softAccent(accentHex);
+  const rows = conversations.slice(0, MAX_ROWS);
+  const textPrimary = flattened
+    ? "#FFFFFF"
+    : resolveColor(widgetTheme.textPrimary, appearance);
+  const textSecondary = flattened
+    ? "rgba(255, 255, 255, 0.6)"
+    : resolveColor(widgetTheme.textSecondary, appearance);
+
+  // What the header leaves the rows, so three of them give back the two points
+  // the design's own rows overrun the content box by.
+  const listHeight =
+    161 * scale -
+    CONTENT_MARGIN * scale * 2 -
+    (HEADER_TOP_INSET + HEADER_BOTTOM_GAP + 12) * scale;
+  const rowHeight =
+    rows.length === 0
+      ? ROW_DESIGN_HEIGHT * scale
+      : Math.min(ROW_DESIGN_HEIGHT * scale, listHeight / rows.length);
+
+  return (
+    <WidgetCard
+      family="medium"
+      scale={scale}
+      appearance={appearance}
+      background={flattened ? "rgba(30, 30, 32, 1)" : widgetTheme.surface}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "flex-start",
+          gap: COLUMN_GAP * scale,
+          height: "100%",
+          padding: CONTENT_MARGIN * scale,
+          boxSizing: "border-box",
+        }}
+      >
+        <div
+          style={{
+            width: ACTION_COLUMN_WIDTH * scale,
+            display: "flex",
+            flexDirection: "column",
+            gap: TILE_GAP * scale,
+            height: "100%",
+          }}
+        >
+          <Tile
+            scale={scale}
+            label="New Chat"
+            fill={
+              flattened
+                ? FLATTENED_TILE_FILL
+                : resolveColor(accent.fill, appearance)
+            }
+            labelColor={textPrimary}
+            icon={
+              avatarImageUrl !== null ? (
+                <img
+                  src={avatarImageUrl}
+                  alt=""
+                  style={{
+                    width: TILE_ICON_SIZE * scale,
+                    height: TILE_ICON_SIZE * scale,
+                    borderRadius: "50%",
+                    objectFit: "cover",
+                    filter: flattened
+                      ? "grayscale(1) brightness(1.4)"
+                      : undefined,
+                  }}
+                />
+              ) : (
+                <VellumVGlyph
+                  size={TILE_ICON_SIZE * scale}
+                  color={
+                    flattened
+                      ? "#FFFFFF"
+                      : resolveColor(accent.onFill, appearance)
+                  }
+                />
+              )
+            }
+          />
+          <Tile
+            scale={scale}
+            label="Voice"
+            fill={
+              flattened
+                ? FLATTENED_TILE_FILL
+                : resolveColor(widgetTheme.voiceFill, appearance)
+            }
+            labelColor={textPrimary}
+            icon={
+              <WaveformGlyph
+                size={TILE_ICON_SIZE * scale}
+                color={textPrimary}
+              />
+            }
+          />
+        </div>
+
+        <div
+          style={{
+            flex: 1,
+            display: "flex",
+            flexDirection: "column",
+            height: "100%",
+            minWidth: 0,
+          }}
+        >
+          <span
+            style={{
+              fontSize: 10 * scale,
+              color: textSecondary,
+              paddingTop: HEADER_TOP_INSET * scale,
+              paddingLeft: HEADER_LEADING_INSET * scale,
+              paddingBottom: HEADER_BOTTOM_GAP * scale,
+            }}
+          >
+            Catch up:
+          </span>
+          {rows.length === 0 ? (
+            <span
+              style={{
+                fontSize: 11 * scale,
+                fontWeight: 500,
+                color: textSecondary,
+                paddingTop: 2 * scale,
+                paddingLeft: ROW_LEADING_INSET * scale,
+              }}
+            >
+              Open Vellum to see your recent chats.
+            </span>
+          ) : (
+            <div style={{ display: "flex", flexDirection: "column" }}>
+              {rows.map((conversation) => (
+                <Row
+                  key={conversation.id}
+                  conversation={conversation}
+                  height={rowHeight}
+                  scale={scale}
+                  appearance={appearance}
+                  isStale={isStale}
+                  flattened={flattened}
+                  textPrimary={textPrimary}
+                  textSecondary={textSecondary}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </WidgetCard>
+  );
+}
+
+function Row({
+  conversation,
+  height,
+  scale,
+  appearance,
+  isStale,
+  flattened,
+  textPrimary,
+  textSecondary,
+}: {
+  conversation: CatchUpConversation;
+  height: number;
+  scale: number;
+  appearance: WidgetAppearance;
+  isStale: boolean;
+  flattened: boolean;
+  textPrimary: string;
+  textSecondary: string;
+}) {
+  const subtitle = conversation.subtitle ?? null;
+  const glyphTopInset =
+    subtitle === null ? GLYPH_TITLE_ONLY_TOP_INSET : GLYPH_TWO_LINE_TOP_INSET;
+  // Working beats unread, and staleness beats working.
+  const working = conversation.isProcessing === true && !isStale;
+
+  return (
+    <div
+      style={{
+        height,
+        display: "flex",
+        alignItems: "flex-start",
+        gap: ROW_GLYPH_TEXT_GAP * scale,
+        paddingLeft: ROW_LEADING_INSET * scale,
+        overflow: "hidden",
+      }}
+    >
+      <span
+        style={{
+          width: ROW_GLYPH_SIZE * scale,
+          height: ROW_GLYPH_SIZE * scale,
+          marginTop: glyphTopInset * scale,
+          position: "relative",
+          display: "inline-flex",
+          flexShrink: 0,
+        }}
+      >
+        {working ? (
+          <EllipsisGlyph size={11 * scale} color={textSecondary} />
+        ) : (
+          <BubbleGlyph size={11 * scale} color={textPrimary} filled={false} />
+        )}
+        {!working && conversation.hasUnseen === true ? (
+          <span
+            style={{
+              position: "absolute",
+              top: -1 * scale,
+              right: -1 * scale,
+              width: 4 * scale,
+              height: 4 * scale,
+              borderRadius: "50%",
+              background: flattened
+                ? "#FFFFFF"
+                : resolveColor(widgetTheme.unseenIndicator, appearance),
+            }}
+          />
+        ) : null}
+      </span>
+      <span
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          gap: 2 * scale,
+          paddingTop: ROW_TEXT_TOP_INSET * scale,
+          minWidth: 0,
+        }}
+      >
+        <span
+          style={{
+            fontSize: 12 * scale,
+            fontWeight: 500,
+            color: textPrimary,
+            whiteSpace: "nowrap",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+          }}
+        >
+          {conversation.title}
+        </span>
+        {subtitle !== null ? (
+          <span
+            style={{
+              fontSize: 7 * scale,
+              fontWeight: 500,
+              color: textSecondary,
+              whiteSpace: "nowrap",
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+            }}
+          >
+            {subtitle}
+          </span>
+        ) : null}
+      </span>
+    </div>
+  );
+}
+
+function Tile({
+  scale,
+  label,
+  fill,
+  labelColor,
+  icon,
+}: {
+  scale: number;
+  label: string;
+  fill: string;
+  labelColor: string;
+  icon: React.ReactNode;
+}) {
+  return (
+    <div
+      style={{
+        flex: 1,
+        borderRadius: TILE_CORNER_RADIUS * scale,
+        background: fill,
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: 4 * scale,
+      }}
+    >
+      {icon}
+      <span
+        style={{
+          fontSize: TILE_LABEL_SIZE * scale,
+          fontWeight: 500,
+          color: labelColor,
+        }}
+      >
+        {label}
+      </span>
+    </div>
+  );
+}

--- a/clients/web/src/components/ios-widget-previews/catch-up-widget-preview.tsx
+++ b/clients/web/src/components/ios-widget-previews/catch-up-widget-preview.tsx
@@ -36,6 +36,7 @@ import {
   themeAccentHex,
   widgetTheme,
   type WidgetAppearance,
+  type WidgetAvatarKind,
 } from "./widget-tokens";
 
 const CONTENT_MARGIN = 16;
@@ -69,6 +70,9 @@ export interface CatchUpWidgetPreviewProps {
   scale?: number;
   appearance?: WidgetAppearance;
   conversations?: CatchUpConversation[];
+  /** See `QuickActionsWidgetPreviewProps`. The kind gates the accent; the
+   *  raster still rides the New Chat surface whatever the kind. */
+  avatarKind?: WidgetAvatarKind;
   accentHex?: string | null;
   avatarImageUrl?: string | null;
   /** A snapshot too old to be trusted about work in flight. */
@@ -80,12 +84,13 @@ export function CatchUpWidgetPreview({
   scale = 1,
   appearance = "light",
   conversations = [],
+  avatarKind = "character",
   accentHex = "#0E9B8B",
   avatarImageUrl = null,
   isStale = false,
   flattened = false,
 }: CatchUpWidgetPreviewProps) {
-  const accent = softAccent(themeAccentHex(accentHex, avatarImageUrl !== null));
+  const accent = softAccent(themeAccentHex(avatarKind, accentHex));
   const rows = conversations.slice(0, MAX_ROWS);
   const textPrimary = flattened
     ? "#FFFFFF"

--- a/clients/web/src/components/ios-widget-previews/catch-up-widget-preview.tsx
+++ b/clients/web/src/components/ios-widget-previews/catch-up-widget-preview.tsx
@@ -264,11 +264,7 @@ function Row({
   textPrimary: string;
   textSecondary: string;
 }) {
-  // `renderedSubtitle`: a group the producer sent as an empty string is a
-  // subtitle with nothing in it to draw, and the glyph's inset asks the same
-  // question, so the two answer from one place.
-  const rawSubtitle = conversation.subtitle ?? "";
-  const subtitle = rawSubtitle.length > 0 ? rawSubtitle : null;
+  const subtitle = conversation.subtitle ?? null;
   const glyphTopInset =
     subtitle === null ? GLYPH_TITLE_ONLY_TOP_INSET : GLYPH_TWO_LINE_TOP_INSET;
   // Working beats unread, and staleness beats working.

--- a/clients/web/src/components/ios-widget-previews/catch-up-widget-preview.tsx
+++ b/clients/web/src/components/ios-widget-previews/catch-up-widget-preview.tsx
@@ -33,6 +33,7 @@ import {
   FLATTENED_CARD_GROUND,
   resolveColor,
   softAccent,
+  themeAccentHex,
   widgetTheme,
   type WidgetAppearance,
 } from "./widget-tokens";
@@ -84,7 +85,7 @@ export function CatchUpWidgetPreview({
   isStale = false,
   flattened = false,
 }: CatchUpWidgetPreviewProps) {
-  const accent = softAccent(accentHex);
+  const accent = softAccent(themeAccentHex(accentHex, avatarImageUrl !== null));
   const rows = conversations.slice(0, MAX_ROWS);
   const textPrimary = flattened
     ? "#FFFFFF"

--- a/clients/web/src/components/ios-widget-previews/catch-up-widget-preview.tsx
+++ b/clients/web/src/components/ios-widget-previews/catch-up-widget-preview.tsx
@@ -24,6 +24,10 @@ import {
   VellumVGlyph,
   WaveformGlyph,
 } from "./widget-glyphs";
+import {
+  WidgetActionTile,
+  WIDGET_TILE_ICON_SIZE,
+} from "./widget-action-controls";
 import { WidgetCard } from "./widget-card";
 import {
   FLATTENED_CARD_GROUND,
@@ -49,9 +53,6 @@ const ROW_GLYPH_TEXT_GAP = 7;
 /** Where the glyph hangs, by whether the row carries a subtitle. */
 const GLYPH_TWO_LINE_TOP_INSET = 12.5;
 const GLYPH_TITLE_ONLY_TOP_INSET = 7;
-const TILE_CORNER_RADIUS = 12;
-const TILE_ICON_SIZE = 24;
-const TILE_LABEL_SIZE = 8;
 const FLATTENED_TILE_FILL = "rgba(255, 255, 255, 0.12)";
 
 export interface CatchUpConversation {
@@ -129,7 +130,7 @@ export function CatchUpWidgetPreview({
             height: "100%",
           }}
         >
-          <Tile
+          <WidgetActionTile
             scale={scale}
             label="New Chat"
             fill={
@@ -144,8 +145,8 @@ export function CatchUpWidgetPreview({
                   src={avatarImageUrl}
                   alt=""
                   style={{
-                    width: TILE_ICON_SIZE * scale,
-                    height: TILE_ICON_SIZE * scale,
+                    width: WIDGET_TILE_ICON_SIZE * scale,
+                    height: WIDGET_TILE_ICON_SIZE * scale,
                     borderRadius: "50%",
                     objectFit: "cover",
                     filter: flattened
@@ -155,7 +156,7 @@ export function CatchUpWidgetPreview({
                 />
               ) : (
                 <VellumVGlyph
-                  size={TILE_ICON_SIZE * scale}
+                  size={WIDGET_TILE_ICON_SIZE * scale}
                   color={
                     flattened
                       ? "#FFFFFF"
@@ -165,7 +166,7 @@ export function CatchUpWidgetPreview({
               )
             }
           />
-          <Tile
+          <WidgetActionTile
             scale={scale}
             label="Voice"
             fill={
@@ -176,7 +177,7 @@ export function CatchUpWidgetPreview({
             labelColor={textPrimary}
             icon={
               <WaveformGlyph
-                size={TILE_ICON_SIZE * scale}
+                size={WIDGET_TILE_ICON_SIZE * scale}
                 color={textPrimary}
               />
             }
@@ -257,7 +258,11 @@ function Row({
   textPrimary: string;
   textSecondary: string;
 }) {
-  const subtitle = conversation.subtitle ?? null;
+  // `renderedSubtitle`: a group the producer sent as an empty string is a
+  // subtitle with nothing in it to draw, and the glyph's inset asks the same
+  // question, so the two answer from one place.
+  const rawSubtitle = conversation.subtitle ?? "";
+  const subtitle = rawSubtitle.length > 0 ? rawSubtitle : null;
   const glyphTopInset =
     subtitle === null ? GLYPH_TITLE_ONLY_TOP_INSET : GLYPH_TWO_LINE_TOP_INSET;
   // Working beats unread, and staleness beats working.
@@ -340,46 +345,6 @@ function Row({
             {subtitle}
           </span>
         ) : null}
-      </span>
-    </div>
-  );
-}
-
-function Tile({
-  scale,
-  label,
-  fill,
-  labelColor,
-  icon,
-}: {
-  scale: number;
-  label: string;
-  fill: string;
-  labelColor: string;
-  icon: React.ReactNode;
-}) {
-  return (
-    <div
-      style={{
-        flex: 1,
-        borderRadius: TILE_CORNER_RADIUS * scale,
-        background: fill,
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "center",
-        justifyContent: "center",
-        gap: 4 * scale,
-      }}
-    >
-      {icon}
-      <span
-        style={{
-          fontSize: TILE_LABEL_SIZE * scale,
-          fontWeight: 500,
-          color: labelColor,
-        }}
-      >
-        {label}
       </span>
     </div>
   );

--- a/clients/web/src/components/ios-widget-previews/catch-up-widget-preview.tsx
+++ b/clients/web/src/components/ios-widget-previews/catch-up-widget-preview.tsx
@@ -26,6 +26,7 @@ import {
 } from "./widget-glyphs";
 import { WidgetCard } from "./widget-card";
 import {
+  FLATTENED_CARD_GROUND,
   resolveColor,
   softAccent,
   widgetTheme,
@@ -107,7 +108,7 @@ export function CatchUpWidgetPreview({
       family="medium"
       scale={scale}
       appearance={appearance}
-      background={flattened ? "rgba(30, 30, 32, 1)" : widgetTheme.surface}
+      background={flattened ? FLATTENED_CARD_GROUND : widgetTheme.surface}
     >
       <div
         style={{

--- a/clients/web/src/components/ios-widget-previews/ios-widget-previews.stories.tsx
+++ b/clients/web/src/components/ios-widget-previews/ios-widget-previews.stories.tsx
@@ -160,12 +160,17 @@ export const QuickActionsUnread: Story = {
 };
 
 /**
- * A custom photo replaces the eyes and is blurred under a scrim to become the
- * card, since an uploaded avatar carries no accent to tint with. The
- * accentless account falls back to the brand block.
+ * The three avatar kinds, which is what decides the treatment: a photo has no
+ * accent by design, so it replaces the eyes and is blurred under a scrim to
+ * become the card, while an account with no avatar at all falls back to the
+ * brand block.
+ *
+ * The character in the middle carries a face raster alongside its accent,
+ * which production payloads do. It keeps its accent and its eyes: presence of
+ * a raster is not what makes a card a photo card.
  */
 export const QuickActionsAvatars: Story = {
-  name: "Quick Actions / avatars",
+  name: "Quick Actions / avatar kinds",
   render: () => (
     <Appearances
       render={(appearance) => (
@@ -173,11 +178,38 @@ export const QuickActionsAvatars: Story = {
           <QuickActionsWidgetPreview
             appearance={appearance}
             unreadCount={5}
+            avatarKind="image"
             accentHex={null}
             avatarImageUrl={AVATAR_PHOTO}
           />
-          <QuickActionsWidgetPreview appearance={appearance} accentHex={null} />
+          <QuickActionsWidgetPreview
+            appearance={appearance}
+            unreadCount={5}
+            avatarKind="character"
+            accentHex="#0E9B8B"
+            avatarImageUrl={AVATAR_PHOTO}
+          />
+          <QuickActionsWidgetPreview
+            appearance={appearance}
+            avatarKind="none"
+            accentHex={null}
+          />
         </div>
+      )}
+    />
+  ),
+};
+
+/**
+ * A snapshot's ordinary `unreadCount: 0` is the quiet card, not a chip reading
+ * zero, so a consumer can hand the real count straight over.
+ */
+export const QuickActionsZeroUnread: Story = {
+  name: "Quick Actions / zero unread",
+  render: () => (
+    <Appearances
+      render={(appearance) => (
+        <QuickActionsWidgetPreview appearance={appearance} unreadCount={0} />
       )}
     />
   ),

--- a/clients/web/src/components/ios-widget-previews/ios-widget-previews.stories.tsx
+++ b/clients/web/src/components/ios-widget-previews/ios-widget-previews.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { CatchUpWidgetPreview } from "./catch-up-widget-preview";
+import { ReplicaNotice } from "./replica-notice";
 import { QuickActionsWidgetPreview } from "./quick-actions-widget-preview";
 import { StatusWidgetPreview } from "./status-widget-preview";
 import type { WidgetAppearance } from "./widget-tokens";
@@ -42,6 +43,16 @@ import type { WidgetAppearance } from "./widget-tokens";
 const meta = {
   title: "iOS Widgets/Home Screen",
   parameters: { layout: "centered" },
+  // Every canvas, not only the Docs tab: cards that look this much like the
+  // real thing are the ones worth labelling where they are looked at.
+  decorators: [
+    (Story) => (
+      <div>
+        <ReplicaNotice />
+        <Story />
+      </div>
+    ),
+  ],
 } satisfies Meta;
 
 export default meta;
@@ -235,6 +246,38 @@ export const StatusStates: Story = {
             appearance={appearance}
             unreadCount={3}
             inProgressCount={2}
+          />
+        </div>
+      )}
+    />
+  ),
+};
+
+/**
+ * What the small cards do once the snapshot is too old to be counting with.
+ *
+ * Quick Actions drops the chip and keeps the face, so the card is
+ * indistinguishable from a quiet one: the tally is a claim about now, which is
+ * exactly what a closed app cannot see, while whose assistant this is stays
+ * true. Status drops the readout entirely, because a lone "3 unread" also
+ * asserts nothing is running, and the launcher is the more useful true thing.
+ */
+export const StaleSnapshots: Story = {
+  name: "Stale snapshot",
+  render: () => (
+    <Appearances
+      render={(appearance) => (
+        <div style={{ display: "flex", gap: 12 }}>
+          <QuickActionsWidgetPreview
+            appearance={appearance}
+            unreadCount={3}
+            isStale
+          />
+          <StatusWidgetPreview
+            appearance={appearance}
+            unreadCount={3}
+            inProgressCount={2}
+            isStale
           />
         </div>
       )}

--- a/clients/web/src/components/ios-widget-previews/ios-widget-previews.stories.tsx
+++ b/clients/web/src/components/ios-widget-previews/ios-widget-previews.stories.tsx
@@ -1,0 +1,322 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { CatchUpWidgetPreview } from "./catch-up-widget-preview";
+import { QuickActionsWidgetPreview } from "./quick-actions-widget-preview";
+import { StatusWidgetPreview } from "./status-widget-preview";
+import type { WidgetAppearance } from "./widget-tokens";
+
+/**
+ * # iOS Home Screen widgets
+ *
+ * Replicas of the three WidgetKit widgets in
+ * `clients/ios/App/VoiceActivity/Widgets/`, so their states can be reviewed in
+ * a browser instead of a simulator.
+ *
+ * ## What this is not
+ *
+ * These are not the widgets. The widgets are SwiftUI compiled into an iOS app
+ * extension, and nothing renders SwiftUI in Storybook. What is here is a
+ * hand-maintained copy that reads its palette and geometry from constants
+ * transcribed out of the Swift, and it is worth exactly as much as that copy is
+ * current. Three specific gaps to keep in mind:
+ *
+ * - **The symbols are stand-ins.** The cards draw SF Symbols
+ *   (`camera.fill`, `waveform`, `bubble.left`, `ellipsis`) and the `VellumV`
+ *   asset, none of which exist in a browser. Everything else is an
+ *   approximation at the same nominal point size. The eyes are the exception:
+ *   they carry the same Bezier control points, and were checked against a
+ *   SwiftUI render of the real shapes at 8x, where the sclera and pupil ink
+ *   agree to 0.00pt on every edge.
+ * - **The type is not SF Pro off an Apple device.** The font stack falls
+ *   through to whatever the browser has, so line metrics drift. Judge layout
+ *   and weight here, not kerning.
+ * - **Flattened mode is imitated, not applied.** On a themed Home Screen
+ *   WidgetKit discards every color and redraws the widget in two monochrome
+ *   groups from each view's alpha. The `flattened` arg paints what that
+ *   *should* come out as. Only a device proves it.
+ *
+ * The authoritative previews are the `#Preview` blocks in the Swift, which
+ * render the real views in Xcode. Use these for design review and sharing; use
+ * those before believing anything.
+ */
+const meta = {
+  title: "iOS Widgets/Home Screen",
+  parameters: { layout: "centered" },
+} satisfies Meta;
+
+export default meta;
+
+const AVATAR_PHOTO =
+  "data:image/svg+xml;utf8," +
+  encodeURIComponent(
+    `<svg xmlns="http://www.w3.org/2000/svg" width="120" height="120">
+      <defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+        <stop offset="0%" stop-color="#F2994A"/><stop offset="100%" stop-color="#9B51E0"/>
+      </linearGradient></defs>
+      <rect width="120" height="120" fill="url(#g)"/>
+      <circle cx="60" cy="46" r="22" fill="#FFFFFF" fill-opacity="0.85"/>
+      <path d="M18 120c0-23 19-38 42-38s42 15 42 38Z" fill="#FFFFFF" fill-opacity="0.85"/>
+    </svg>`,
+  );
+
+const CONVERSATIONS = [
+  {
+    id: "1",
+    title: "Weekend Priority Sorting",
+    subtitle: "Recents",
+    hasUnseen: true,
+  },
+  {
+    id: "2",
+    title: "Q3 planning doc review",
+    subtitle: "Work",
+    isProcessing: true,
+  },
+  { id: "3", title: "Flight options to Lisbon", subtitle: "Travel" },
+];
+
+/**
+ * Both appearances side by side. A widget is drawn in whatever appearance the
+ * device is in, so every card carries a dark variant and neither is the
+ * default.
+ */
+function Appearances({
+  render,
+}: {
+  render: (appearance: WidgetAppearance) => React.ReactNode;
+}) {
+  return (
+    <div style={{ display: "flex", gap: 24, alignItems: "flex-start" }}>
+      {(["light", "dark"] as const).map((appearance) => (
+        <div
+          key={appearance}
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 8,
+            alignItems: "center",
+            padding: 20,
+            borderRadius: 20,
+            background: appearance === "light" ? "#E7E4DF" : "#2A2A2E",
+          }}
+        >
+          {render(appearance)}
+          <span
+            style={{
+              fontSize: 11,
+              color: appearance === "light" ? "#5A5A5A" : "#B0B0B0",
+            }}
+          >
+            {appearance}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+type Story = StoryObj;
+
+/**
+ * Nothing waiting. The face is the account's avatar rather than a
+ * notification, so the card wears it whatever the snapshot says, resting a
+ * nudge right of centre to lean into the glance the pupils already have.
+ */
+export const QuickActionsQuiet: Story = {
+  name: "Quick Actions / quiet",
+  render: () => (
+    <Appearances
+      render={(appearance) => (
+        <QuickActionsWidgetPreview appearance={appearance} />
+      )}
+    />
+  ),
+};
+
+/**
+ * With a count. The mark moves to the leading margin to leave the chip the
+ * other end of the row, and wide counts buy their width from the eyes rather
+ * than compressing the row.
+ *
+ * The chip is a tap target on the device: it runs `OpenConversationsIntent`
+ * and lands on the conversation list.
+ */
+export const QuickActionsUnread: Story = {
+  name: "Quick Actions / unread",
+  render: () => (
+    <Appearances
+      render={(appearance) => (
+        <div style={{ display: "flex", gap: 12 }}>
+          <QuickActionsWidgetPreview appearance={appearance} unreadCount={3} />
+          <QuickActionsWidgetPreview
+            appearance={appearance}
+            unreadCount={128}
+            accentHex="#F2C94C"
+          />
+        </div>
+      )}
+    />
+  ),
+};
+
+/**
+ * A custom photo replaces the eyes and is blurred under a scrim to become the
+ * card, since an uploaded avatar carries no accent to tint with. The
+ * accentless account falls back to the brand block.
+ */
+export const QuickActionsAvatars: Story = {
+  name: "Quick Actions / avatars",
+  render: () => (
+    <Appearances
+      render={(appearance) => (
+        <div style={{ display: "flex", gap: 12 }}>
+          <QuickActionsWidgetPreview
+            appearance={appearance}
+            unreadCount={5}
+            accentHex={null}
+            avatarImageUrl={AVATAR_PHOTO}
+          />
+          <QuickActionsWidgetPreview appearance={appearance} accentHex={null} />
+        </div>
+      )}
+    />
+  ),
+};
+
+/**
+ * The launcher and the readout. A count is worth the card only while there is
+ * a count, so the card flips rather than printing "All caught up." over two
+ * buttons.
+ *
+ * On the readout, the unread line is a tap target and the in-progress line
+ * deliberately is not: it counts turns still running, not replies waiting, so
+ * the conversation list is not where following it would go.
+ */
+export const StatusStates: Story = {
+  name: "Status / idle and active",
+  render: () => (
+    <Appearances
+      render={(appearance) => (
+        <div style={{ display: "flex", gap: 12 }}>
+          <StatusWidgetPreview appearance={appearance} />
+          <StatusWidgetPreview
+            appearance={appearance}
+            unreadCount={3}
+            inProgressCount={2}
+          />
+        </div>
+      )}
+    />
+  ),
+};
+
+/** Rows with a group, a turn in flight, and something unread. */
+export const CatchUpRows: Story = {
+  name: "Catch Up / rows",
+  render: () => (
+    <Appearances
+      render={(appearance) => (
+        <CatchUpWidgetPreview
+          appearance={appearance}
+          conversations={CONVERSATIONS}
+        />
+      )}
+    />
+  ),
+};
+
+/**
+ * A row with no group is one line, and its glyph moves up to meet the title.
+ * Beside it, the empty card: nothing synced and nothing to sync are the same
+ * thing to the person reading, and both end with opening the app.
+ */
+export const CatchUpEdges: Story = {
+  name: "Catch Up / single row and empty",
+  render: () => (
+    <Appearances
+      render={(appearance) => (
+        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+          <CatchUpWidgetPreview
+            appearance={appearance}
+            conversations={[{ id: "1", title: "Weekend Priority Sorting" }]}
+          />
+          <CatchUpWidgetPreview appearance={appearance} conversations={[]} />
+        </div>
+      )}
+    />
+  ),
+};
+
+/**
+ * A stale snapshot drops what it can no longer claim and keeps what stays
+ * true. The in-progress dots go, because nothing has confirmed that turn is
+ * still running; the unread dot stays, because a message that arrived stays
+ * unread until someone opens the app.
+ */
+export const CatchUpStale: Story = {
+  name: "Catch Up / stale",
+  render: () => (
+    <Appearances
+      render={(appearance) => (
+        <CatchUpWidgetPreview
+          appearance={appearance}
+          conversations={CONVERSATIONS}
+          isStale
+        />
+      )}
+    />
+  ),
+};
+
+/**
+ * What a themed Home Screen should come out as. WidgetKit throws away every
+ * color and redraws the widget in two monochrome groups from each view's
+ * alpha, so each control swaps to a translucent white and the pupil is punched
+ * out of the eye as a hole rather than painted on it.
+ *
+ * Imitated, not applied. Only a device proves this one.
+ */
+export const Flattened: Story = {
+  name: "Themed Home Screen (flattened)",
+  render: () => (
+    <div
+      style={{
+        display: "flex",
+        gap: 12,
+        flexWrap: "wrap",
+        maxWidth: 720,
+        padding: 20,
+        borderRadius: 20,
+        background: "#141416",
+      }}
+    >
+      <QuickActionsWidgetPreview appearance="dark" unreadCount={3} flattened />
+      <StatusWidgetPreview
+        appearance="dark"
+        unreadCount={3}
+        inProgressCount={2}
+        flattened
+      />
+      <CatchUpWidgetPreview
+        appearance="dark"
+        conversations={CONVERSATIONS}
+        flattened
+      />
+    </div>
+  ),
+};
+
+/**
+ * The cards at twice their design size, for looking at the geometry rather
+ * than the composition. Every measurement is multiplied by one scale factor,
+ * the way the real views multiply theirs.
+ */
+export const Magnified: Story = {
+  name: "Magnified (2x)",
+  render: () => (
+    <div style={{ display: "flex", gap: 24, flexWrap: "wrap", maxWidth: 900 }}>
+      <QuickActionsWidgetPreview scale={2} unreadCount={3} />
+      <StatusWidgetPreview scale={2} unreadCount={3} inProgressCount={2} />
+    </div>
+  ),
+};

--- a/clients/web/src/components/ios-widget-previews/quick-actions-widget-preview.tsx
+++ b/clients/web/src/components/ios-widget-previews/quick-actions-widget-preview.tsx
@@ -24,6 +24,7 @@ import {
   EYE_PAIR_ASPECT,
   WidgetAvatarEyes,
 } from "./widget-avatar-eyes";
+import { WidgetCircleAction } from "./widget-action-controls";
 import { WidgetCard } from "./widget-card";
 import { WidgetUnreadMark } from "./widget-unread-mark";
 import { SURFACE_GROUND } from "@/utils/avatar-tone";
@@ -205,7 +206,7 @@ export function QuickActionsWidgetPreview({
         )}
         <div style={{ flex: 1 }} />
         <div style={{ display: "flex", gap: CONTROL_GAP * scale }}>
-          <CircleAction
+          <WidgetCircleAction
             diameter={CONTROL_DIAMETER * scale}
             fill={controlFill}
             label="Take a photo"
@@ -214,8 +215,8 @@ export function QuickActionsWidgetPreview({
               size={CONTROL_DIAMETER * scale * 0.4}
               color={onSurface}
             />
-          </CircleAction>
-          <CircleAction
+          </WidgetCircleAction>
+          <WidgetCircleAction
             diameter={CONTROL_DIAMETER * scale}
             fill={controlFill}
             label="New voice conversation"
@@ -224,7 +225,7 @@ export function QuickActionsWidgetPreview({
               size={CONTROL_DIAMETER * scale * 0.4}
               color={onSurface}
             />
-          </CircleAction>
+          </WidgetCircleAction>
         </div>
       </div>
     </WidgetCard>
@@ -330,36 +331,6 @@ function UnreadChip({
       >
         {count > 99 ? "99+" : count}
       </span>
-    </div>
-  );
-}
-
-function CircleAction({
-  diameter,
-  fill,
-  label,
-  children,
-}: {
-  diameter: number;
-  fill: string;
-  label: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <div
-      role="img"
-      aria-label={label}
-      style={{
-        width: diameter,
-        height: diameter,
-        borderRadius: "50%",
-        background: fill,
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-      }}
-    >
-      {children}
     </div>
   );
 }

--- a/clients/web/src/components/ios-widget-previews/quick-actions-widget-preview.tsx
+++ b/clients/web/src/components/ios-widget-previews/quick-actions-widget-preview.tsx
@@ -85,6 +85,12 @@ export interface QuickActionsWidgetPreviewProps {
    * surfaces that show the whole avatar.
    */
   avatarImageUrl?: string | null;
+  /**
+   * Whether the snapshot behind this card is old enough that its count is a
+   * claim about an inbox from half an hour ago. The chip drops; the face does
+   * not, because whose assistant this is stays true.
+   */
+  isStale?: boolean;
   /** The system's monochrome modes: a themed Home Screen, StandBy, the lock screen. */
   flattened?: boolean;
 }
@@ -96,6 +102,7 @@ export function QuickActionsWidgetPreview({
   avatarKind = "character",
   accentHex = "#0E9B8B",
   avatarImageUrl = null,
+  isStale = false,
   flattened = false,
 }: QuickActionsWidgetPreviewProps) {
   const palette = avatarPalette(themeAccentHex(avatarKind, accentHex));
@@ -119,16 +126,18 @@ export function QuickActionsWidgetPreview({
       ? SURFACE_GROUND
       : resolveColor(palette.surface, appearance);
 
-  // `QuickActionsEntry.unreadCount`: nil unless something is actually waiting,
-  // so a snapshot's ordinary zero draws the quiet card rather than a `0` chip.
-  const chipCount = unreadCount !== null && unreadCount > 0 ? unreadCount : null;
+  // `QuickActionsEntry.unreadCount`: nil unless something is actually waiting
+  // and the snapshot is fresh enough to be counting. An ordinary zero draws the
+  // quiet card rather than a `0` chip, and a stale snapshot drops the tally
+  // while keeping the face: a count says how many are waiting NOW, which is
+  // exactly what a widget cannot see while the app is closed.
+  const chipCount =
+    !isStale && unreadCount !== null && unreadCount > 0 ? unreadCount : null;
   const contentWidth = 160 * scale - CONTENT_MARGIN * scale * 2;
   const markWidth =
     chipCount === null
       ? contentWidth
-      : contentWidth -
-        chipAllowance(chipCount, scale) -
-        MARK_CHIP_GAP * scale;
+      : contentWidth - chipAllowance(chipCount, scale) - MARK_CHIP_GAP * scale;
 
   return (
     <WidgetCard

--- a/clients/web/src/components/ios-widget-previews/quick-actions-widget-preview.tsx
+++ b/clients/web/src/components/ios-widget-previews/quick-actions-widget-preview.tsx
@@ -26,8 +26,11 @@ import {
 } from "./widget-avatar-eyes";
 import { WidgetCard } from "./widget-card";
 import { WidgetUnreadMark } from "./widget-unread-mark";
+import { SURFACE_GROUND } from "@/utils/avatar-tone";
+
 import {
   avatarPalette,
+  FLATTENED_CARD_GROUND,
   resolveColor,
   type WidgetAppearance,
 } from "./widget-tokens";
@@ -48,6 +51,11 @@ const FLATTENED_CIRCLE_FILL = "rgba(255, 255, 255, 0.14)";
 const CONTROL_FILL_ON_WHITE = 0.14;
 const CONTROL_FILL_ON_DARK = 0.1;
 const MARK_CHIP_GAP = 12;
+
+/** `BlurredAvatarBackground`: the card a custom photo makes. */
+const AVATAR_BLUR_RADIUS = 30;
+const AVATAR_BLUR_OVERSCAN = AVATAR_BLUR_RADIUS * 2;
+const AVATAR_SCRIM_OPACITY = 0.55;
 
 /** `chipAllowance(for:scale:)`: the width the chip needs at this count. */
 function chipAllowance(count: number, scale: number): number {
@@ -86,9 +94,15 @@ export function QuickActionsWidgetPreview({
         palette.controlFill(CONTROL_FILL_ON_WHITE, CONTROL_FILL_ON_DARK),
         appearance,
       );
+  // `QuickActionsCardBackground`: a photo avatar makes the card the blurred
+  // photo over its own near-black ground, not the accent, since an uploaded
+  // avatar carries no accent to tint with.
+  const hasPhotoCard = avatarImageUrl !== null && !flattened;
   const background = flattened
-    ? "rgba(30, 30, 32, 1)"
-    : resolveColor(palette.surface, appearance);
+    ? FLATTENED_CARD_GROUND
+    : hasPhotoCard
+      ? SURFACE_GROUND
+      : resolveColor(palette.surface, appearance);
 
   const contentWidth = 160 * scale - CONTENT_MARGIN * scale * 2;
   const markWidth =
@@ -105,18 +119,33 @@ export function QuickActionsWidgetPreview({
       appearance={appearance}
       background={background}
     >
-      {avatarImageUrl !== null && !flattened ? (
-        <div
-          style={{
-            position: "absolute",
-            inset: 0,
-            backgroundImage: `url(${avatarImageUrl})`,
-            backgroundSize: "cover",
-            backgroundPosition: "center",
-            filter: "blur(18px)",
-            transform: "scale(1.3)",
-          }}
-        />
+      {hasPhotoCard ? (
+        <>
+          {/* `BlurredAvatarBackground`: the blur samples transparency past the
+              layer's edge, so the photo grows beyond the card by twice the
+              radius per side and the clip trims the excess. Without that the
+              perimeter fades into the ground. */}
+          <div
+            style={{
+              position: "absolute",
+              inset: -AVATAR_BLUR_OVERSCAN * scale,
+              // Quoted: a data URI carries unencoded parentheses, which an
+              // unquoted `url()` reads as its own closing paren and drops the
+              // image entirely.
+              backgroundImage: `url("${avatarImageUrl}")`,
+              backgroundSize: "cover",
+              backgroundPosition: "center",
+              filter: `blur(${AVATAR_BLUR_RADIUS * scale}px)`,
+            }}
+          />
+          <div
+            style={{
+              position: "absolute",
+              inset: 0,
+              background: `rgba(0, 0, 0, ${AVATAR_SCRIM_OPACITY})`,
+            }}
+          />
+        </>
       ) : null}
       <div
         style={{
@@ -169,6 +198,7 @@ export function QuickActionsWidgetPreview({
               count={unreadCount}
               scale={scale}
               onSurface={onSurface}
+              appearance={appearance}
               flattened={flattened}
             />
           </div>
@@ -261,11 +291,13 @@ function UnreadChip({
   count,
   scale,
   onSurface,
+  appearance,
   flattened,
 }: {
   count: number;
   scale: number;
   onSurface: string;
+  appearance: WidgetAppearance;
   flattened: boolean;
 }) {
   return (
@@ -281,7 +313,13 @@ function UnreadChip({
         color: onSurface,
       }}
     >
-      <WidgetUnreadMark filled={false} size={16 * scale} color={onSurface} />
+      <WidgetUnreadMark
+        filled={false}
+        size={16 * scale}
+        color={onSurface}
+        appearance={appearance}
+        flattened={flattened}
+      />
       <span
         style={{
           fontSize: 16 * scale,

--- a/clients/web/src/components/ios-widget-previews/quick-actions-widget-preview.tsx
+++ b/clients/web/src/components/ios-widget-previews/quick-actions-widget-preview.tsx
@@ -1,0 +1,327 @@
+/* eslint-disable local/no-untranslated-strings --
+ * The literals here are not this app's copy. They reproduce strings hardcoded
+ * in the widgets' Swift, which ships in English only and never reads this app's
+ * catalogs: a widget renders in an extension process that does not run the SPA.
+ * Routing them through `t()` would assert a localization the widgets do not
+ * have, and would let a catalog edit silently drift the preview away from the
+ * card it is a picture of. The rule also reports the rgba style values below,
+ * which are not copy at all.
+ */
+/**
+ * The Quick Actions widget: the two most physical ways to start something, on
+ * a card painted in the assistant's own colors, plus the assistant looking up
+ * when something is waiting.
+ *
+ * Every measurement below is the constant of the same name in the Swift, on the
+ * same 160x161 design canvas.
+ *
+ * @see clients/ios/App/VoiceActivity/Widgets/QuickActionsWidget.swift
+ */
+
+import { CameraGlyph, WaveformGlyph } from "./widget-glyphs";
+import {
+  DEFAULT_EYE_HEIGHT,
+  EYE_PAIR_ASPECT,
+  WidgetAvatarEyes,
+} from "./widget-avatar-eyes";
+import { WidgetCard } from "./widget-card";
+import { WidgetUnreadMark } from "./widget-unread-mark";
+import {
+  avatarPalette,
+  resolveColor,
+  type WidgetAppearance,
+} from "./widget-tokens";
+
+const CONTENT_MARGIN = 16;
+const CONTROL_DIAMETER = 61;
+const CONTROL_GAP = 6;
+const AVATAR_IMAGE_SIZE = 44;
+const AVATAR_IMAGE_CORNER_RADIUS = 15;
+const MARK_INSET = 13;
+const MARK_LEADING_INSET = 2;
+/** How far right of centre the quiet mark rests, leaning into the glance. */
+const QUIET_MARK_CENTER_OFFSET = 11.5;
+const CHIP_HEIGHT = 31;
+const CHIP_FILL = "rgba(0, 0, 0, 0.10)";
+const FLATTENED_CHIP_FILL = "rgba(255, 255, 255, 0.12)";
+const FLATTENED_CIRCLE_FILL = "rgba(255, 255, 255, 0.14)";
+const CONTROL_FILL_ON_WHITE = 0.14;
+const CONTROL_FILL_ON_DARK = 0.1;
+const MARK_CHIP_GAP = 12;
+
+/** `chipAllowance(for:scale:)`: the width the chip needs at this count. */
+function chipAllowance(count: number, scale: number): number {
+  const glyphs = count > 99 ? 3 : String(count).length;
+  return (45 + 9.5 * glyphs) * scale;
+}
+
+export interface QuickActionsWidgetPreviewProps {
+  scale?: number;
+  appearance?: WidgetAppearance;
+  /** The count on the chip. `null` draws the quiet card. */
+  unreadCount?: number | null;
+  /** The avatar's accent, or `null` for the account with no avatar at all. */
+  accentHex?: string | null;
+  /** A custom photo, drawn in place of the eyes and blurred into the card. */
+  avatarImageUrl?: string | null;
+  /** The system's monochrome modes: a themed Home Screen, StandBy, the lock screen. */
+  flattened?: boolean;
+}
+
+export function QuickActionsWidgetPreview({
+  scale = 1,
+  appearance = "light",
+  unreadCount = null,
+  accentHex = "#0E9B8B",
+  avatarImageUrl = null,
+  flattened = false,
+}: QuickActionsWidgetPreviewProps) {
+  const palette = avatarPalette(accentHex);
+  const onSurface = flattened
+    ? "#FFFFFF"
+    : resolveColor(palette.onSurface, appearance);
+  const controlFill = flattened
+    ? FLATTENED_CIRCLE_FILL
+    : resolveColor(
+        palette.controlFill(CONTROL_FILL_ON_WHITE, CONTROL_FILL_ON_DARK),
+        appearance,
+      );
+  const background = flattened
+    ? "rgba(30, 30, 32, 1)"
+    : resolveColor(palette.surface, appearance);
+
+  const contentWidth = 160 * scale - CONTENT_MARGIN * scale * 2;
+  const markWidth =
+    unreadCount === null
+      ? contentWidth
+      : contentWidth -
+        chipAllowance(unreadCount, scale) -
+        MARK_CHIP_GAP * scale;
+
+  return (
+    <WidgetCard
+      family="small"
+      scale={scale}
+      appearance={appearance}
+      background={background}
+    >
+      {avatarImageUrl !== null && !flattened ? (
+        <div
+          style={{
+            position: "absolute",
+            inset: 0,
+            backgroundImage: `url(${avatarImageUrl})`,
+            backgroundSize: "cover",
+            backgroundPosition: "center",
+            filter: "blur(18px)",
+            transform: "scale(1.3)",
+          }}
+        />
+      ) : null}
+      <div
+        style={{
+          position: "relative",
+          display: "flex",
+          flexDirection: "column",
+          height: "100%",
+          padding: CONTENT_MARGIN * scale,
+          boxSizing: "border-box",
+        }}
+      >
+        {unreadCount === null ? (
+          <div
+            style={{
+              display: "flex",
+              justifyContent: "center",
+              paddingTop: MARK_INSET * scale,
+              transform: `translateX(${QUIET_MARK_CENTER_OFFSET * scale}px)`,
+            }}
+          >
+            <AvatarMark
+              eyeHeight={DEFAULT_EYE_HEIGHT * scale}
+              imageSize={AVATAR_IMAGE_SIZE * scale}
+              cornerRadius={AVATAR_IMAGE_CORNER_RADIUS * scale}
+              appearance={appearance}
+              avatarImageUrl={avatarImageUrl}
+              flattened={flattened}
+            />
+          </div>
+        ) : (
+          <div
+            style={{
+              display: "flex",
+              alignItems: "flex-start",
+              paddingTop: MARK_INSET * scale,
+            }}
+          >
+            <div style={{ paddingLeft: MARK_LEADING_INSET * scale }}>
+              <AvatarMark
+                eyeHeight={fittedEyeHeight(markWidth, scale)}
+                imageSize={fittedImageSize(markWidth, scale)}
+                cornerRadius={AVATAR_IMAGE_CORNER_RADIUS * scale}
+                appearance={appearance}
+                avatarImageUrl={avatarImageUrl}
+                flattened={flattened}
+              />
+            </div>
+            <div style={{ flex: 1 }} />
+            <UnreadChip
+              count={unreadCount}
+              scale={scale}
+              onSurface={onSurface}
+              flattened={flattened}
+            />
+          </div>
+        )}
+        <div style={{ flex: 1 }} />
+        <div style={{ display: "flex", gap: CONTROL_GAP * scale }}>
+          <CircleAction
+            diameter={CONTROL_DIAMETER * scale}
+            fill={controlFill}
+            label="Take a photo"
+          >
+            <CameraGlyph
+              size={CONTROL_DIAMETER * scale * 0.4}
+              color={onSurface}
+            />
+          </CircleAction>
+          <CircleAction
+            diameter={CONTROL_DIAMETER * scale}
+            fill={controlFill}
+            label="New voice conversation"
+          >
+            <WaveformGlyph
+              size={CONTROL_DIAMETER * scale * 0.4}
+              color={onSurface}
+            />
+          </CircleAction>
+        </div>
+      </div>
+    </WidgetCard>
+  );
+}
+
+/** `fittedEyeHeight(in:scale:)`: what the chip leaves the eyes. */
+function fittedEyeHeight(markWidth: number, scale: number): number {
+  const available = markWidth / EYE_PAIR_ASPECT;
+  return Math.min(DEFAULT_EYE_HEIGHT * scale, Math.max(24 * scale, available));
+}
+
+/** `fittedImageSize(in:scale:)`: the photo mark under the same constraint. */
+function fittedImageSize(markWidth: number, scale: number): number {
+  return Math.min(AVATAR_IMAGE_SIZE * scale, Math.max(24 * scale, markWidth));
+}
+
+function AvatarMark({
+  eyeHeight,
+  imageSize,
+  cornerRadius,
+  appearance,
+  avatarImageUrl,
+  flattened,
+}: {
+  eyeHeight: number;
+  imageSize: number;
+  cornerRadius: number;
+  appearance: WidgetAppearance;
+  avatarImageUrl: string | null;
+  flattened: boolean;
+}) {
+  if (avatarImageUrl !== null) {
+    return (
+      <img
+        src={avatarImageUrl}
+        alt=""
+        style={{
+          width: imageSize,
+          height: imageSize,
+          borderRadius: cornerRadius,
+          objectFit: "cover",
+          // `widgetAccentedRenderingMode(.accentedDesaturated)`.
+          filter: flattened ? "grayscale(1) brightness(1.4)" : undefined,
+        }}
+      />
+    );
+  }
+  return (
+    <WidgetAvatarEyes
+      eyeHeight={eyeHeight}
+      appearance={appearance}
+      flattened={flattened}
+    />
+  );
+}
+
+/**
+ * The chip is a tap target on the device, running `OpenConversationsIntent`.
+ * Rendered flat here: a preview has no app to open, and drawing a hover state
+ * the widget does not have would be a lie about the card.
+ */
+function UnreadChip({
+  count,
+  scale,
+  onSurface,
+  flattened,
+}: {
+  count: number;
+  scale: number;
+  onSurface: string;
+  flattened: boolean;
+}) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 5 * scale,
+        height: CHIP_HEIGHT * scale,
+        padding: `0 ${10 * scale}px`,
+        borderRadius: (CHIP_HEIGHT * scale) / 2,
+        background: flattened ? FLATTENED_CHIP_FILL : CHIP_FILL,
+        color: onSurface,
+      }}
+    >
+      <WidgetUnreadMark filled={false} size={16 * scale} color={onSurface} />
+      <span
+        style={{
+          fontSize: 16 * scale,
+          fontWeight: 500,
+          lineHeight: 1,
+          fontVariantNumeric: "tabular-nums",
+        }}
+      >
+        {count > 99 ? "99+" : count}
+      </span>
+    </div>
+  );
+}
+
+function CircleAction({
+  diameter,
+  fill,
+  label,
+  children,
+}: {
+  diameter: number;
+  fill: string;
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      role="img"
+      aria-label={label}
+      style={{
+        width: diameter,
+        height: diameter,
+        borderRadius: "50%",
+        background: fill,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/clients/web/src/components/ios-widget-previews/quick-actions-widget-preview.tsx
+++ b/clients/web/src/components/ios-widget-previews/quick-actions-widget-preview.tsx
@@ -33,6 +33,7 @@ import {
   avatarPalette,
   FLATTENED_CARD_GROUND,
   resolveColor,
+  themeAccentHex,
   type WidgetAppearance,
 } from "./widget-tokens";
 
@@ -85,7 +86,9 @@ export function QuickActionsWidgetPreview({
   avatarImageUrl = null,
   flattened = false,
 }: QuickActionsWidgetPreviewProps) {
-  const palette = avatarPalette(accentHex);
+  const palette = avatarPalette(
+    themeAccentHex(accentHex, avatarImageUrl !== null),
+  );
   const onSurface = flattened
     ? "#FFFFFF"
     : resolveColor(palette.onSurface, appearance);

--- a/clients/web/src/components/ios-widget-previews/quick-actions-widget-preview.tsx
+++ b/clients/web/src/components/ios-widget-previews/quick-actions-widget-preview.tsx
@@ -35,6 +35,7 @@ import {
   resolveColor,
   themeAccentHex,
   type WidgetAppearance,
+  type WidgetAvatarKind,
 } from "./widget-tokens";
 
 const CONTENT_MARGIN = 16;
@@ -70,9 +71,19 @@ export interface QuickActionsWidgetPreviewProps {
   appearance?: WidgetAppearance;
   /** The count on the chip. `null` draws the quiet card. */
   unreadCount?: number | null;
-  /** The avatar's accent, or `null` for the account with no avatar at all. */
+  /**
+   * Which of the three avatar treatments the card draws. The kind decides,
+   * never the presence of a raster: a character carries its accent and its
+   * encoded face together.
+   */
+  avatarKind?: WidgetAvatarKind;
+  /** The avatar's accent. Read only for a character; see `themeAccentHex`. */
   accentHex?: string | null;
-  /** A custom photo, drawn in place of the eyes and blurred into the card. */
+  /**
+   * The raster the snapshot carries. An `image` avatar draws it as the mark and
+   * blurs it into the card; a character keeps its eyes and leaves this to the
+   * surfaces that show the whole avatar.
+   */
   avatarImageUrl?: string | null;
   /** The system's monochrome modes: a themed Home Screen, StandBy, the lock screen. */
   flattened?: boolean;
@@ -82,13 +93,12 @@ export function QuickActionsWidgetPreview({
   scale = 1,
   appearance = "light",
   unreadCount = null,
+  avatarKind = "character",
   accentHex = "#0E9B8B",
   avatarImageUrl = null,
   flattened = false,
 }: QuickActionsWidgetPreviewProps) {
-  const palette = avatarPalette(
-    themeAccentHex(accentHex, avatarImageUrl !== null),
-  );
+  const palette = avatarPalette(themeAccentHex(avatarKind, accentHex));
   const onSurface = flattened
     ? "#FFFFFF"
     : resolveColor(palette.onSurface, appearance);
@@ -101,19 +111,23 @@ export function QuickActionsWidgetPreview({
   // `QuickActionsCardBackground`: a photo avatar makes the card the blurred
   // photo over its own near-black ground, not the accent, since an uploaded
   // avatar carries no accent to tint with.
-  const hasPhotoCard = avatarImageUrl !== null && !flattened;
+  const hasPhotoCard =
+    avatarKind === "image" && avatarImageUrl !== null && !flattened;
   const background = flattened
     ? FLATTENED_CARD_GROUND
     : hasPhotoCard
       ? SURFACE_GROUND
       : resolveColor(palette.surface, appearance);
 
+  // `QuickActionsEntry.unreadCount`: nil unless something is actually waiting,
+  // so a snapshot's ordinary zero draws the quiet card rather than a `0` chip.
+  const chipCount = unreadCount !== null && unreadCount > 0 ? unreadCount : null;
   const contentWidth = 160 * scale - CONTENT_MARGIN * scale * 2;
   const markWidth =
-    unreadCount === null
+    chipCount === null
       ? contentWidth
       : contentWidth -
-        chipAllowance(unreadCount, scale) -
+        chipAllowance(chipCount, scale) -
         MARK_CHIP_GAP * scale;
 
   return (
@@ -161,7 +175,7 @@ export function QuickActionsWidgetPreview({
           boxSizing: "border-box",
         }}
       >
-        {unreadCount === null ? (
+        {chipCount === null ? (
           <div
             style={{
               display: "flex",
@@ -175,6 +189,7 @@ export function QuickActionsWidgetPreview({
               imageSize={AVATAR_IMAGE_SIZE * scale}
               cornerRadius={AVATAR_IMAGE_CORNER_RADIUS * scale}
               appearance={appearance}
+              kind={avatarKind}
               avatarImageUrl={avatarImageUrl}
               flattened={flattened}
             />
@@ -193,13 +208,14 @@ export function QuickActionsWidgetPreview({
                 imageSize={fittedImageSize(markWidth, scale)}
                 cornerRadius={AVATAR_IMAGE_CORNER_RADIUS * scale}
                 appearance={appearance}
+                kind={avatarKind}
                 avatarImageUrl={avatarImageUrl}
                 flattened={flattened}
               />
             </div>
             <div style={{ flex: 1 }} />
             <UnreadChip
-              count={unreadCount}
+              count={chipCount}
               scale={scale}
               onSurface={onSurface}
               appearance={appearance}
@@ -251,6 +267,7 @@ function AvatarMark({
   imageSize,
   cornerRadius,
   appearance,
+  kind,
   avatarImageUrl,
   flattened,
 }: {
@@ -258,10 +275,11 @@ function AvatarMark({
   imageSize: number;
   cornerRadius: number;
   appearance: WidgetAppearance;
+  kind: WidgetAvatarKind;
   avatarImageUrl: string | null;
   flattened: boolean;
 }) {
-  if (avatarImageUrl !== null) {
+  if (kind === "image" && avatarImageUrl !== null) {
     return (
       <img
         src={avatarImageUrl}

--- a/clients/web/src/components/ios-widget-previews/replica-notice.tsx
+++ b/clients/web/src/components/ios-widget-previews/replica-notice.tsx
@@ -1,0 +1,46 @@
+/* eslint-disable local/no-untranslated-strings --
+ * Storybook chrome, not product copy. This renders only in a story canvas, is
+ * read by whoever is working on the widgets, and never ships in the app, so
+ * there is no user to translate it for and no catalog it belongs in. The
+ * neighbouring files carry their own, different exemption: theirs reproduce
+ * copy hardcoded in the Swift.
+ */
+/**
+ * The standing disclaimer above every widget story.
+ *
+ * The Docs tab carries the long version, but a person landing on a story
+ * canvas sees only the cards, and cards that look this much like the real
+ * thing are exactly the ones worth labelling. So the warning rides the canvas
+ * rather than the documentation.
+ *
+ * This is the one piece in this directory that is app chrome rather than a
+ * replica of native SwiftUI, so it is the one piece built from the design
+ * library.
+ */
+
+import { Notice } from "@vellumai/design-library";
+
+export function ReplicaNotice() {
+  return (
+    <Notice
+      tone="warning"
+      title="A replica, not the widget"
+      className="mb-4 max-w-[720px]"
+    >
+      <p>
+        The real widgets are SwiftUI compiled into an iOS app extension, and
+        nothing renders SwiftUI in Storybook. These are React copies, reading a
+        palette and geometry transcribed out of{" "}
+        <code>clients/ios/App/VoiceActivity/Widgets/</code>, and they are worth
+        exactly as much as that copy is current.
+      </p>
+      <p className="mt-2">
+        The eyes are exact, from the same Bezier control points. The SF Symbols
+        beside them are hand-drawn stand-ins, the type is not SF Pro off an
+        Apple device, and the themed Home Screen is painted rather than applied.
+        The <code>#Preview</code> blocks in the Swift render the real views and
+        are what to believe.
+      </p>
+    </Notice>
+  );
+}

--- a/clients/web/src/components/ios-widget-previews/status-widget-preview.tsx
+++ b/clients/web/src/components/ios-widget-previews/status-widget-preview.tsx
@@ -1,0 +1,402 @@
+/* eslint-disable local/no-untranslated-strings --
+ * The literals here are not this app's copy. They reproduce strings hardcoded
+ * in the widgets' Swift, which ships in English only and never reads this app's
+ * catalogs: a widget renders in an extension process that does not run the SPA.
+ * Routing them through `t()` would assert a localization the widgets do not
+ * have, and would let a catalog edit silently drift the preview away from the
+ * card it is a picture of. The rule also reports the rgba style values below,
+ * which are not copy at all.
+ */
+/**
+ * The Status widget, in the two states it has: what is waiting when something
+ * is, and the ways in when nothing is.
+ *
+ * A count is worth a small widget's card only while there is a count, so the
+ * card flips to a launcher rather than printing "All caught up." over two
+ * buttons. Both states sit on the same margins and the same two bands.
+ *
+ * @see clients/ios/App/VoiceActivity/Widgets/StatusWidget.swift
+ */
+
+import {
+  EllipsisGlyph,
+  CameraGlyph,
+  VellumVGlyph,
+  WaveformGlyph,
+} from "./widget-glyphs";
+import { WidgetCard } from "./widget-card";
+import { WidgetUnreadMark } from "./widget-unread-mark";
+import {
+  resolveColor,
+  softAccent,
+  widgetTheme,
+  type WidgetAppearance,
+} from "./widget-tokens";
+
+const CONTENT_MARGIN = 16;
+const CONTROL_HEIGHT = 61;
+const BAND_GAP = 7;
+const CIRCLE_GAP = 6;
+const TILE_GAP = 8;
+const COUNT_GAP = 16;
+const GLYPH_COLUMN_WIDTH = 17;
+const COUNT_GLYPH_GAP = 7;
+const COUNT_TEXT_SIZE = 14;
+const TILE_CORNER_RADIUS = 12;
+const TILE_ICON_SIZE = 24;
+const TILE_LABEL_SIZE = 8;
+const FLATTENED_TILE_FILL = "rgba(255, 255, 255, 0.12)";
+const FLATTENED_CIRCLE_FILL = "rgba(255, 255, 255, 0.14)";
+const FLATTENED_PILL_FILL = "rgba(255, 255, 255, 0.12)";
+
+export interface StatusWidgetPreviewProps {
+  scale?: number;
+  appearance?: WidgetAppearance;
+  unreadCount?: number;
+  inProgressCount?: number;
+  accentHex?: string | null;
+  avatarImageUrl?: string | null;
+  flattened?: boolean;
+}
+
+export function StatusWidgetPreview({
+  scale = 1,
+  appearance = "light",
+  unreadCount = 0,
+  inProgressCount = 0,
+  accentHex = "#0E9B8B",
+  avatarImageUrl = null,
+  flattened = false,
+}: StatusWidgetPreviewProps) {
+  const accent = softAccent(accentHex);
+  const isActive = unreadCount > 0 || inProgressCount > 0;
+  const control = CONTROL_HEIGHT * scale;
+  const textPrimary = flattened
+    ? "#FFFFFF"
+    : resolveColor(widgetTheme.textPrimary, appearance);
+
+  return (
+    <WidgetCard
+      family="small"
+      scale={scale}
+      appearance={appearance}
+      background={flattened ? "rgba(30, 30, 32, 1)" : widgetTheme.surface}
+    >
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          height: "100%",
+          padding: CONTENT_MARGIN * scale,
+          boxSizing: "border-box",
+        }}
+      >
+        {isActive ? (
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              gap: COUNT_GAP * scale,
+              alignItems: "flex-start",
+            }}
+          >
+            {unreadCount > 0 ? (
+              <CountLine
+                scale={scale}
+                text={`${unreadCount} unread`}
+                color={textPrimary}
+                glyph={
+                  <WidgetUnreadMark
+                    filled={false}
+                    size={16 * scale}
+                    color={textPrimary}
+                    appearance={appearance}
+                    flattened={flattened}
+                  />
+                }
+              />
+            ) : null}
+            {inProgressCount > 0 ? (
+              <CountLine
+                scale={scale}
+                text={`${inProgressCount} in progress`}
+                color={textPrimary}
+                glyph={
+                  <EllipsisGlyph
+                    size={16 * scale}
+                    color={
+                      flattened
+                        ? "rgba(255, 255, 255, 0.6)"
+                        : resolveColor(widgetTheme.textSecondary, appearance)
+                    }
+                  />
+                }
+              />
+            ) : null}
+          </div>
+        ) : (
+          <div style={{ display: "flex", gap: CIRCLE_GAP * scale }}>
+            <Circle
+              diameter={control}
+              fill={
+                flattened
+                  ? FLATTENED_CIRCLE_FILL
+                  : resolveColor(widgetTheme.voiceFill, appearance)
+              }
+              label="Take a photo"
+            >
+              <CameraGlyph size={control * 0.4} color={textPrimary} />
+            </Circle>
+            <Circle
+              diameter={control}
+              fill={
+                flattened
+                  ? FLATTENED_CIRCLE_FILL
+                  : resolveColor(widgetTheme.voiceFill, appearance)
+              }
+              label="New voice conversation"
+            >
+              <WaveformGlyph size={control * 0.4} color={textPrimary} />
+            </Circle>
+          </div>
+        )}
+        <div style={{ flex: 1, minHeight: BAND_GAP * scale }} />
+        {isActive ? (
+          <div
+            style={{ display: "flex", gap: TILE_GAP * scale, height: control }}
+          >
+            <Tile
+              scale={scale}
+              label="New Chat"
+              fill={
+                flattened
+                  ? FLATTENED_TILE_FILL
+                  : resolveColor(accent.fill, appearance)
+              }
+              labelColor={textPrimary}
+              icon={
+                avatarImageUrl !== null ? (
+                  <img
+                    src={avatarImageUrl}
+                    alt=""
+                    style={{
+                      width: TILE_ICON_SIZE * scale,
+                      height: TILE_ICON_SIZE * scale,
+                      borderRadius: "50%",
+                      objectFit: "cover",
+                      filter: flattened
+                        ? "grayscale(1) brightness(1.4)"
+                        : undefined,
+                    }}
+                  />
+                ) : (
+                  <VellumVGlyph
+                    size={TILE_ICON_SIZE * scale}
+                    color={
+                      flattened
+                        ? "#FFFFFF"
+                        : resolveColor(accent.onFill, appearance)
+                    }
+                  />
+                )
+              }
+            />
+            <Tile
+              scale={scale}
+              label="Voice"
+              fill={
+                flattened
+                  ? FLATTENED_TILE_FILL
+                  : resolveColor(widgetTheme.voiceFill, appearance)
+              }
+              labelColor={textPrimary}
+              icon={
+                <WaveformGlyph
+                  size={TILE_ICON_SIZE * scale}
+                  color={textPrimary}
+                />
+              }
+            />
+          </div>
+        ) : (
+          <ChatPill
+            scale={scale}
+            height={control}
+            fill={
+              flattened
+                ? FLATTENED_PILL_FILL
+                : resolveColor(accent.fill, appearance)
+            }
+            tint={
+              flattened ? "#FFFFFF" : resolveColor(accent.onFill, appearance)
+            }
+            avatarImageUrl={avatarImageUrl}
+            flattened={flattened}
+          />
+        )}
+      </div>
+    </WidgetCard>
+  );
+}
+
+function CountLine({
+  scale,
+  text,
+  color,
+  glyph,
+}: {
+  scale: number;
+  text: string;
+  color: string;
+  glyph: React.ReactNode;
+}) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: COUNT_GLYPH_GAP * scale,
+        width: "100%",
+      }}
+    >
+      <span
+        style={{
+          width: GLYPH_COLUMN_WIDTH * scale,
+          display: "inline-flex",
+          justifyContent: "flex-start",
+        }}
+      >
+        {glyph}
+      </span>
+      <span
+        style={{
+          fontSize: COUNT_TEXT_SIZE * scale,
+          fontWeight: 500,
+          color,
+          whiteSpace: "nowrap",
+        }}
+      >
+        {text}
+      </span>
+    </div>
+  );
+}
+
+function Circle({
+  diameter,
+  fill,
+  label,
+  children,
+}: {
+  diameter: number;
+  fill: string;
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      role="img"
+      aria-label={label}
+      style={{
+        width: diameter,
+        height: diameter,
+        borderRadius: "50%",
+        background: fill,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+function Tile({
+  scale,
+  label,
+  fill,
+  labelColor,
+  icon,
+}: {
+  scale: number;
+  label: string;
+  fill: string;
+  labelColor: string;
+  icon: React.ReactNode;
+}) {
+  return (
+    <div
+      style={{
+        flex: 1,
+        borderRadius: TILE_CORNER_RADIUS * scale,
+        background: fill,
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: 4 * scale,
+      }}
+    >
+      {icon}
+      <span
+        style={{
+          fontSize: TILE_LABEL_SIZE * scale,
+          fontWeight: 500,
+          color: labelColor,
+        }}
+      >
+        {label}
+      </span>
+    </div>
+  );
+}
+
+function ChatPill({
+  scale,
+  height,
+  fill,
+  tint,
+  avatarImageUrl,
+  flattened,
+}: {
+  scale: number;
+  height: number;
+  fill: string;
+  tint: string;
+  avatarImageUrl: string | null;
+  flattened: boolean;
+}) {
+  const iconSize = height * 0.4;
+  return (
+    <div
+      style={{
+        height,
+        borderRadius: height / 2,
+        background: fill,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: 6 * scale,
+        color: tint,
+      }}
+    >
+      {avatarImageUrl !== null ? (
+        <img
+          src={avatarImageUrl}
+          alt=""
+          style={{
+            width: iconSize,
+            height: iconSize,
+            borderRadius: "50%",
+            objectFit: "cover",
+            filter: flattened ? "grayscale(1) brightness(1.4)" : undefined,
+          }}
+        />
+      ) : (
+        <VellumVGlyph size={iconSize} color={tint} />
+      )}
+      <span style={{ fontSize: 15 * scale, fontWeight: 600 }}>Chat</span>
+    </div>
+  );
+}

--- a/clients/web/src/components/ios-widget-previews/status-widget-preview.tsx
+++ b/clients/web/src/components/ios-widget-previews/status-widget-preview.tsx
@@ -64,6 +64,12 @@ export interface StatusWidgetPreviewProps {
   avatarKind?: WidgetAvatarKind;
   accentHex?: string | null;
   avatarImageUrl?: string | null;
+  /**
+   * Whether the snapshot is too old to read as a status. A lone "2 unread" also
+   * asserts that nothing is running, which an aged snapshot cannot know, so the
+   * card falls back to the launcher rather than apologizing for its counts.
+   */
+  isStale?: boolean;
   flattened?: boolean;
 }
 
@@ -75,10 +81,12 @@ export function StatusWidgetPreview({
   avatarKind = "character",
   accentHex = "#0E9B8B",
   avatarImageUrl = null,
+  isStale = false,
   flattened = false,
 }: StatusWidgetPreviewProps) {
   const accent = softAccent(themeAccentHex(avatarKind, accentHex));
-  const isActive = unreadCount > 0 || inProgressCount > 0;
+  // `StatusWidgetView.isActive`: a stale snapshot has nothing to report.
+  const isActive = !isStale && (unreadCount > 0 || inProgressCount > 0);
   const control = CONTROL_HEIGHT * scale;
   const textPrimary = flattened
     ? "#FFFFFF"

--- a/clients/web/src/components/ios-widget-previews/status-widget-preview.tsx
+++ b/clients/web/src/components/ios-widget-previews/status-widget-preview.tsx
@@ -27,6 +27,7 @@ import {
 import { WidgetCard } from "./widget-card";
 import { WidgetUnreadMark } from "./widget-unread-mark";
 import {
+  FLATTENED_CARD_GROUND,
   resolveColor,
   softAccent,
   widgetTheme,
@@ -80,7 +81,7 @@ export function StatusWidgetPreview({
       family="small"
       scale={scale}
       appearance={appearance}
-      background={flattened ? "rgba(30, 30, 32, 1)" : widgetTheme.surface}
+      background={flattened ? FLATTENED_CARD_GROUND : widgetTheme.surface}
     >
       <div
         style={{

--- a/clients/web/src/components/ios-widget-previews/status-widget-preview.tsx
+++ b/clients/web/src/components/ios-widget-previews/status-widget-preview.tsx
@@ -38,6 +38,7 @@ import {
   themeAccentHex,
   widgetTheme,
   type WidgetAppearance,
+  type WidgetAvatarKind,
 } from "./widget-tokens";
 
 const CONTENT_MARGIN = 16;
@@ -58,6 +59,9 @@ export interface StatusWidgetPreviewProps {
   appearance?: WidgetAppearance;
   unreadCount?: number;
   inProgressCount?: number;
+  /** See `QuickActionsWidgetPreviewProps`. The kind gates the accent; the
+   *  raster still rides the New Chat surface whatever the kind. */
+  avatarKind?: WidgetAvatarKind;
   accentHex?: string | null;
   avatarImageUrl?: string | null;
   flattened?: boolean;
@@ -68,11 +72,12 @@ export function StatusWidgetPreview({
   appearance = "light",
   unreadCount = 0,
   inProgressCount = 0,
+  avatarKind = "character",
   accentHex = "#0E9B8B",
   avatarImageUrl = null,
   flattened = false,
 }: StatusWidgetPreviewProps) {
-  const accent = softAccent(themeAccentHex(accentHex, avatarImageUrl !== null));
+  const accent = softAccent(themeAccentHex(avatarKind, accentHex));
   const isActive = unreadCount > 0 || inProgressCount > 0;
   const control = CONTROL_HEIGHT * scale;
   const textPrimary = flattened

--- a/clients/web/src/components/ios-widget-previews/status-widget-preview.tsx
+++ b/clients/web/src/components/ios-widget-previews/status-widget-preview.tsx
@@ -35,6 +35,7 @@ import {
   FLATTENED_CARD_GROUND,
   resolveColor,
   softAccent,
+  themeAccentHex,
   widgetTheme,
   type WidgetAppearance,
 } from "./widget-tokens";
@@ -71,7 +72,7 @@ export function StatusWidgetPreview({
   avatarImageUrl = null,
   flattened = false,
 }: StatusWidgetPreviewProps) {
-  const accent = softAccent(accentHex);
+  const accent = softAccent(themeAccentHex(accentHex, avatarImageUrl !== null));
   const isActive = unreadCount > 0 || inProgressCount > 0;
   const control = CONTROL_HEIGHT * scale;
   const textPrimary = flattened

--- a/clients/web/src/components/ios-widget-previews/status-widget-preview.tsx
+++ b/clients/web/src/components/ios-widget-previews/status-widget-preview.tsx
@@ -24,6 +24,11 @@ import {
   VellumVGlyph,
   WaveformGlyph,
 } from "./widget-glyphs";
+import {
+  WidgetActionTile,
+  WidgetCircleAction,
+  WIDGET_TILE_ICON_SIZE,
+} from "./widget-action-controls";
 import { WidgetCard } from "./widget-card";
 import { WidgetUnreadMark } from "./widget-unread-mark";
 import {
@@ -43,9 +48,6 @@ const COUNT_GAP = 16;
 const GLYPH_COLUMN_WIDTH = 17;
 const COUNT_GLYPH_GAP = 7;
 const COUNT_TEXT_SIZE = 14;
-const TILE_CORNER_RADIUS = 12;
-const TILE_ICON_SIZE = 24;
-const TILE_LABEL_SIZE = 8;
 const FLATTENED_TILE_FILL = "rgba(255, 255, 255, 0.12)";
 const FLATTENED_CIRCLE_FILL = "rgba(255, 255, 255, 0.14)";
 const FLATTENED_PILL_FILL = "rgba(255, 255, 255, 0.12)";
@@ -137,7 +139,7 @@ export function StatusWidgetPreview({
           </div>
         ) : (
           <div style={{ display: "flex", gap: CIRCLE_GAP * scale }}>
-            <Circle
+            <WidgetCircleAction
               diameter={control}
               fill={
                 flattened
@@ -147,8 +149,8 @@ export function StatusWidgetPreview({
               label="Take a photo"
             >
               <CameraGlyph size={control * 0.4} color={textPrimary} />
-            </Circle>
-            <Circle
+            </WidgetCircleAction>
+            <WidgetCircleAction
               diameter={control}
               fill={
                 flattened
@@ -158,7 +160,7 @@ export function StatusWidgetPreview({
               label="New voice conversation"
             >
               <WaveformGlyph size={control * 0.4} color={textPrimary} />
-            </Circle>
+            </WidgetCircleAction>
           </div>
         )}
         <div style={{ flex: 1, minHeight: BAND_GAP * scale }} />
@@ -166,7 +168,7 @@ export function StatusWidgetPreview({
           <div
             style={{ display: "flex", gap: TILE_GAP * scale, height: control }}
           >
-            <Tile
+            <WidgetActionTile
               scale={scale}
               label="New Chat"
               fill={
@@ -181,8 +183,8 @@ export function StatusWidgetPreview({
                     src={avatarImageUrl}
                     alt=""
                     style={{
-                      width: TILE_ICON_SIZE * scale,
-                      height: TILE_ICON_SIZE * scale,
+                      width: WIDGET_TILE_ICON_SIZE * scale,
+                      height: WIDGET_TILE_ICON_SIZE * scale,
                       borderRadius: "50%",
                       objectFit: "cover",
                       filter: flattened
@@ -192,7 +194,7 @@ export function StatusWidgetPreview({
                   />
                 ) : (
                   <VellumVGlyph
-                    size={TILE_ICON_SIZE * scale}
+                    size={WIDGET_TILE_ICON_SIZE * scale}
                     color={
                       flattened
                         ? "#FFFFFF"
@@ -202,7 +204,7 @@ export function StatusWidgetPreview({
                 )
               }
             />
-            <Tile
+            <WidgetActionTile
               scale={scale}
               label="Voice"
               fill={
@@ -213,7 +215,7 @@ export function StatusWidgetPreview({
               labelColor={textPrimary}
               icon={
                 <WaveformGlyph
-                  size={TILE_ICON_SIZE * scale}
+                  size={WIDGET_TILE_ICON_SIZE * scale}
                   color={textPrimary}
                 />
               }
@@ -278,76 +280,6 @@ function CountLine({
         }}
       >
         {text}
-      </span>
-    </div>
-  );
-}
-
-function Circle({
-  diameter,
-  fill,
-  label,
-  children,
-}: {
-  diameter: number;
-  fill: string;
-  label: string;
-  children: React.ReactNode;
-}) {
-  return (
-    <div
-      role="img"
-      aria-label={label}
-      style={{
-        width: diameter,
-        height: diameter,
-        borderRadius: "50%",
-        background: fill,
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-      }}
-    >
-      {children}
-    </div>
-  );
-}
-
-function Tile({
-  scale,
-  label,
-  fill,
-  labelColor,
-  icon,
-}: {
-  scale: number;
-  label: string;
-  fill: string;
-  labelColor: string;
-  icon: React.ReactNode;
-}) {
-  return (
-    <div
-      style={{
-        flex: 1,
-        borderRadius: TILE_CORNER_RADIUS * scale,
-        background: fill,
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "center",
-        justifyContent: "center",
-        gap: 4 * scale,
-      }}
-    >
-      {icon}
-      <span
-        style={{
-          fontSize: TILE_LABEL_SIZE * scale,
-          fontWeight: 500,
-          color: labelColor,
-        }}
-      >
-        {label}
       </span>
     </div>
   );

--- a/clients/web/src/components/ios-widget-previews/widget-action-controls.tsx
+++ b/clients/web/src/components/ios-widget-previews/widget-action-controls.tsx
@@ -1,0 +1,99 @@
+/**
+ * The controls every card builds itself out of: the action tile, and the round
+ * one beside it.
+ *
+ * One implementation each, for the reason the Swift gives for collecting them
+ * in `WidgetActionControls.swift`: a control that lives in one widget's file is
+ * a control the next widget copies, and a fidelity correction then lands on one
+ * card and not the other.
+ *
+ * @see clients/ios/App/VoiceActivity/Widgets/WidgetActionControls.swift
+ */
+
+import type { ReactNode } from "react";
+
+/** `WidgetActionTile`: a corner tighter than the widget's own squircle. */
+const TILE_CORNER_RADIUS = 12;
+const TILE_ICON_SIZE = 24;
+const TILE_LABEL_SIZE = 8;
+const TILE_GLYPH_LABEL_GAP = 4;
+
+/** The tile's icon size, for callers sizing a glyph to hand in. */
+export const WIDGET_TILE_ICON_SIZE = TILE_ICON_SIZE;
+
+interface WidgetActionTileProps {
+  /** The owning card's ratio to the size it was designed at. */
+  scale: number;
+  label: string;
+  fill: string;
+  labelColor: string;
+  icon: ReactNode;
+}
+
+export function WidgetActionTile({
+  scale,
+  label,
+  fill,
+  labelColor,
+  icon,
+}: WidgetActionTileProps) {
+  return (
+    <div
+      style={{
+        flex: 1,
+        borderRadius: TILE_CORNER_RADIUS * scale,
+        background: fill,
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: TILE_GLYPH_LABEL_GAP * scale,
+      }}
+    >
+      {icon}
+      <span
+        style={{
+          fontSize: TILE_LABEL_SIZE * scale,
+          fontWeight: 500,
+          color: labelColor,
+        }}
+      >
+        {label}
+      </span>
+    </div>
+  );
+}
+
+interface WidgetCircleActionProps {
+  diameter: number;
+  fill: string;
+  /** What the control is for, since the glyph is its whole label. */
+  label: string;
+  children: ReactNode;
+}
+
+/** `CircleActionButton`: a round target with the glyph as its whole label. */
+export function WidgetCircleAction({
+  diameter,
+  fill,
+  label,
+  children,
+}: WidgetCircleActionProps) {
+  return (
+    <div
+      role="img"
+      aria-label={label}
+      style={{
+        width: diameter,
+        height: diameter,
+        borderRadius: "50%",
+        background: fill,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+      }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/clients/web/src/components/ios-widget-previews/widget-avatar-eyes.tsx
+++ b/clients/web/src/components/ios-widget-previews/widget-avatar-eyes.tsx
@@ -1,0 +1,130 @@
+/**
+ * The assistant's eyes, from the same control points the widget draws.
+ *
+ * Unlike the SF Symbols beside them these are exact: `AvatarEyeScleraShape` and
+ * `AvatarEyePupilShape` are hand-drawn Beziers in their own design boxes, and
+ * the numbers below are those control points transcribed one for one. The
+ * pupil fills most of the white and presses against its right edge, which is
+ * the whole trick: small centered dots read as punctuation, a heavy sideways
+ * pair reads as a face caught mid-glance.
+ *
+ * Everything is drawn in the eye's own 28x33 design box and scaled by the
+ * viewBox, so the ratios below read the same as the Swift's.
+ *
+ * @see clients/ios/App/VoiceActivity/Widgets/WidgetAvatarRendering.swift
+ */
+
+import { useId } from "react";
+
+import { widgetTheme, type WidgetAppearance } from "./widget-tokens";
+
+/** The eye's design box, and the pupil's. */
+const EYE_BOX = { width: 28, height: 33 };
+const PUPIL_BOX = { width: 18, height: 21 };
+
+/** `WidgetAvatarEyes`: every ratio below is a share of eye height. */
+const WIDTH_RATIO = EYE_BOX.width / EYE_BOX.height;
+const GAP_RATIO = 5 / 33;
+
+/** The pupil's drawn size and placement, in the eye's design box. */
+const PUPIL_WIDTH = 18;
+const PUPIL_HEIGHT = 21.5;
+const PUPIL_OFFSET_X = 9;
+const PUPIL_OFFSET_Y = 6.5;
+
+/** `WidgetAvatarEyes.defaultEyeHeight`. */
+export const DEFAULT_EYE_HEIGHT = 33;
+
+/** The pair's width as a share of its height, for callers that place it. */
+export const EYE_PAIR_ASPECT = 61 / 33;
+
+/** `AvatarEyeScleraShape`, in its 28x33 design box. */
+const SCLERA_PATH =
+  "M13.34 0.02C21.06 -0.41 27.61 6.61 27.98 15.71C28.36 24.80 22.41 32.53 14.69 32.98C6.96 33.43 0.39 26.40 0.02 17.30C-0.36 8.19 5.61 0.45 13.34 0.02Z";
+
+/** `AvatarEyePupilShape`, in its 18x21 design box. */
+const PUPIL_PATH =
+  "M7.77 0.10C12.70 -0.70 17.25 3.33 17.92 9.09C18.59 14.85 15.12 20.14 10.18 20.91C5.27 21.67 0.75 17.64 0.08 11.91C-0.58 6.17 2.85 0.89 7.77 0.10Z";
+
+/** Places the pupil in the eye's box at the size the eye draws it. */
+const PUPIL_TRANSFORM = `translate(${PUPIL_OFFSET_X} ${PUPIL_OFFSET_Y}) scale(${PUPIL_WIDTH / PUPIL_BOX.width} ${PUPIL_HEIGHT / PUPIL_BOX.height})`;
+
+interface WidgetAvatarEyesProps {
+  /** The one number the pair is sized from. */
+  eyeHeight?: number;
+  appearance: WidgetAppearance;
+  /**
+   * Whether the system has flattened the widget (a themed Home Screen, StandBy,
+   * the lock screen). Flattened, the pupil is punched out of the white as a
+   * hole rather than painted on it, because those modes discard every color and
+   * keep only alpha.
+   */
+  flattened?: boolean;
+}
+
+export function WidgetAvatarEyes({
+  eyeHeight = DEFAULT_EYE_HEIGHT,
+  appearance,
+  flattened = false,
+}: WidgetAvatarEyesProps) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        gap: eyeHeight * GAP_RATIO,
+        alignItems: "center",
+      }}
+      aria-hidden="true"
+    >
+      <Eye
+        eyeHeight={eyeHeight}
+        appearance={appearance}
+        flattened={flattened}
+      />
+      <Eye
+        eyeHeight={eyeHeight}
+        appearance={appearance}
+        flattened={flattened}
+      />
+    </div>
+  );
+}
+
+function Eye({
+  eyeHeight,
+  appearance,
+  flattened,
+}: Required<WidgetAvatarEyesProps>) {
+  const maskId = useId();
+  const sclera = flattened
+    ? "rgba(255, 255, 255, 0.75)"
+    : widgetTheme.avatarSclera[appearance];
+
+  return (
+    <svg
+      width={eyeHeight * WIDTH_RATIO}
+      height={eyeHeight}
+      viewBox={`0 0 ${EYE_BOX.width} ${EYE_BOX.height}`}
+      aria-hidden="true"
+    >
+      {flattened ? (
+        <mask id={maskId}>
+          <path d={SCLERA_PATH} fill="#FFFFFF" />
+          <g transform={PUPIL_TRANSFORM}>
+            <path d={PUPIL_PATH} fill="#000000" />
+          </g>
+        </mask>
+      ) : null}
+      <path
+        d={SCLERA_PATH}
+        fill={sclera}
+        mask={flattened ? `url(#${maskId})` : undefined}
+      />
+      {flattened ? null : (
+        <g transform={PUPIL_TRANSFORM}>
+          <path d={PUPIL_PATH} fill={widgetTheme.avatarPupil[appearance]} />
+        </g>
+      )}
+    </svg>
+  );
+}

--- a/clients/web/src/components/ios-widget-previews/widget-card.tsx
+++ b/clients/web/src/components/ios-widget-previews/widget-card.tsx
@@ -1,0 +1,62 @@
+/**
+ * The Home Screen tile a widget preview is drawn on: the design canvas, the
+ * system's corner, and the scale factor every measurement inside is multiplied
+ * by.
+ *
+ * The real views compute `scale = min(width / designWidth, height / designHeight)`
+ * and multiply every dimension and font by it, so a card renders at the design's
+ * proportions on every device rather than gaining margin on large phones and
+ * clipping on small ones. A preview scales the same way, from one arg.
+ */
+
+import type { ReactNode } from "react";
+
+import {
+  WIDGET_CORNER_RADIUS,
+  WIDGET_DESIGN_SIZE,
+  WIDGET_FONT_STACK,
+  resolveColor,
+  type WidgetAppearance,
+  type WidgetAppearanceColor,
+} from "./widget-tokens";
+
+interface WidgetCardProps {
+  family: keyof typeof WIDGET_DESIGN_SIZE;
+  /** Multiplier on the design size; 1 renders the card at its design pixels. */
+  scale: number;
+  appearance: WidgetAppearance;
+  /** `containerBackground`: the card behind everything, corner included. */
+  background: WidgetAppearanceColor | string;
+  children: ReactNode;
+}
+
+export function WidgetCard({
+  family,
+  scale,
+  appearance,
+  background,
+  children,
+}: WidgetCardProps) {
+  const design = WIDGET_DESIGN_SIZE[family];
+  return (
+    <div
+      style={{
+        width: design.width * scale,
+        height: design.height * scale,
+        borderRadius: WIDGET_CORNER_RADIUS * scale,
+        overflow: "hidden",
+        position: "relative",
+        background:
+          typeof background === "string"
+            ? background
+            : resolveColor(background, appearance),
+        fontFamily: WIDGET_FONT_STACK,
+        // The Home Screen's own drop shadow, so a white card still reads as a
+        // tile against a light Storybook canvas.
+        boxShadow: "0 4px 16px rgba(0, 0, 0, 0.12)",
+      }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/clients/web/src/components/ios-widget-previews/widget-glyphs.tsx
+++ b/clients/web/src/components/ios-widget-previews/widget-glyphs.tsx
@@ -1,0 +1,117 @@
+/**
+ * Stand-ins for the SF Symbols and the brand mark the widgets draw.
+ *
+ * The real cards use `Image(systemName:)` and the `VellumV` asset, neither of
+ * which exists in a browser. These are hand-drawn approximations at the same
+ * nominal point size, close enough to judge layout and weight by and not close
+ * enough to judge the symbols themselves; see the fidelity note in the stories.
+ *
+ * @see clients/ios/App/VoiceActivity/Widgets/WidgetActionControls.swift
+ */
+
+interface GlyphProps {
+  /** The point size the Swift passes to `.font(.system(size:))`. */
+  size: number;
+  color: string;
+}
+
+/** `camera.fill`. The lens is a hole, so the glyph reads on any fill. */
+export function CameraGlyph({ size, color }: GlyphProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill={color}
+      aria-hidden="true"
+    >
+      <path
+        fillRule="evenodd"
+        d="M9 3.6h6l1.1 1.9H19a2.4 2.4 0 0 1 2.4 2.4v9.6A2.4 2.4 0 0 1 19 19.9H5a2.4 2.4 0 0 1-2.4-2.4V7.9A2.4 2.4 0 0 1 5 5.5h2.9L9 3.6Zm3 5.5a3.6 3.6 0 1 0 0 7.2 3.6 3.6 0 0 0 0-7.2Z"
+      />
+    </svg>
+  );
+}
+
+/** `waveform` */
+export function WaveformGlyph({ size, color }: GlyphProps) {
+  const bars = [6, 12, 20, 12, 6];
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      fill={color}
+    >
+      {bars.map((height, index) => (
+        <rect
+          key={index}
+          x={2.6 + index * 4.6}
+          y={12 - height / 2}
+          width="2.2"
+          height={height}
+          rx="1.1"
+        />
+      ))}
+    </svg>
+  );
+}
+
+/**
+ * `bubble.left` / `bubble.left.fill`. The outline is what a white card draws
+ * and the fill is what a card painted in the assistant's color draws.
+ */
+export function BubbleGlyph({
+  size,
+  color,
+  filled,
+}: GlyphProps & { filled: boolean }) {
+  const d =
+    "M12 3.4c-4.9 0-8.9 3.1-8.9 7 0 2.2 1.3 4.2 3.3 5.5v3.4a.5.5 0 0 0 .8.4l3-2.2c.6.1 1.2.1 1.8.1 4.9 0 8.9-3.1 8.9-7s-4-7.2-8.9-7.2Z";
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      fill={filled ? color : "none"}
+      stroke={filled ? "none" : color}
+      strokeWidth={filled ? 0 : 1.7}
+    >
+      <path d={d} strokeLinejoin="round" />
+    </svg>
+  );
+}
+
+/** `ellipsis` */
+export function EllipsisGlyph({ size, color }: GlyphProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      fill={color}
+    >
+      <circle cx="5" cy="12" r="2.1" />
+      <circle cx="12" cy="12" r="2.1" />
+      <circle cx="19" cy="12" r="2.1" />
+    </svg>
+  );
+}
+
+/** The `VellumV` asset. */
+export function VellumVGlyph({ size, color }: GlyphProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      fill={color}
+    >
+      <path d="M4.4 5.2h3.5l4.1 11 4.1-11h3.5l-6 15.2H10.4L4.4 5.2Z" />
+    </svg>
+  );
+}

--- a/clients/web/src/components/ios-widget-previews/widget-tokens.ts
+++ b/clients/web/src/components/ios-widget-previews/widget-tokens.ts
@@ -12,8 +12,20 @@
  * Source of truth is the Swift, always. When the two disagree the Swift is
  * right and this file is stale.
  *
+ * The derived colors are NOT transcribed. `darkenHex`, `blendHex` and
+ * `contrastForeground` come from `@/utils/avatar-tone`, which the Swift names
+ * as its own source of truth (`UIColor.contrastingForeground` mirrors that
+ * file's `contrastForeground`, and `blendHex`/`darkenHex` mirror its
+ * namesakes). A second copy here would be a second copy that drifts, and its
+ * first victim would be the foreground: a YIQ-style brightness rule picks white
+ * on a mid-tone teal where the WCAG derivation both sides actually use picks
+ * dark.
+ *
  * @see clients/ios/App/VoiceActivity/Widgets/WidgetTheme.swift
+ * @see clients/ios/App/App/Shared/CSSHexColor.swift
  */
+
+import { blendHex, contrastForeground, darkenHex } from "@/utils/avatar-tone";
 
 /** A color that resolves from the appearance the widget is rendered in. */
 export interface WidgetAppearanceColor {
@@ -58,60 +70,20 @@ const DARK_SURFACE_FACTOR = 0.79;
 const SOFT_ACCENT_LIGHT_WASH = 0.105;
 const SOFT_ACCENT_DARK_WASH = 0.22;
 
-interface Rgb {
-  r: number;
-  g: number;
-  b: number;
-}
-
-function parseHex(hex: string): Rgb {
-  const value = hex.replace("#", "");
-  const full =
-    value.length === 3
-      ? value
-          .split("")
-          .map((c) => c + c)
-          .join("")
-      : value;
-  return {
-    r: Number.parseInt(full.slice(0, 2), 16),
-    g: Number.parseInt(full.slice(2, 4), 16),
-    b: Number.parseInt(full.slice(4, 6), 16),
-  };
-}
-
-function toHex({ r, g, b }: Rgb): string {
-  const channel = (n: number) =>
-    Math.max(0, Math.min(255, Math.round(n)))
-      .toString(16)
-      .padStart(2, "0");
-  return `#${channel(r)}${channel(g)}${channel(b)}`;
-}
-
-function darken(hex: string, factor: number): string {
-  const { r, g, b } = parseHex(hex);
-  return toHex({ r: r * factor, g: g * factor, b: b * factor });
-}
-
-function blend(base: string, overlay: string, alpha: number): string {
-  const a = parseHex(base);
-  const b = parseHex(overlay);
-  return toHex({
-    r: a.r + (b.r - a.r) * alpha,
-    g: a.g + (b.g - a.g) * alpha,
-    b: a.b + (b.b - a.b) * alpha,
-  });
-}
-
 /**
- * Relative luminance, the input to `UIColor.contrastingForeground`'s choice of
- * a foreground that survives the card it is drawn on. A yellow avatar and a
- * deep green one both have to produce a legible card, which a fixed white
- * cannot.
+ * `UIColor.contrastingForeground`'s two answers, which are
+ * `avatar-tone.ts`'s own `FG_DARK` / `FG_LIGHT`. Named here only so the fill
+ * weighting below can tell which one it was handed.
  */
-function isLight(hex: string): boolean {
-  const { r, g, b } = parseHex(hex);
-  return (0.299 * r + 0.587 * g + 0.114 * b) / 255 > 0.5;
+const FG_DARK = "#1A1A1A";
+
+function withAlpha(hex: string, alpha: number): string {
+  const m = /^#?([0-9a-f]{6})$/i.exec(hex);
+  if (m === null) {
+    return hex;
+  }
+  const n = Number.parseInt(m[1]!, 16);
+  return `rgba(${(n >> 16) & 0xff}, ${(n >> 8) & 0xff}, ${n & 0xff}, ${alpha})`;
 }
 
 /** `WidgetAvatarPalette`: the colors a card painted with an accent draws from. */
@@ -122,16 +94,13 @@ export interface WidgetAvatarPalette {
   controlFill: (onWhite: number, onDark: number) => WidgetAppearanceColor;
 }
 
-function withAlpha(hex: string, alpha: number): string {
-  const { r, g, b } = parseHex(hex);
-  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
-}
-
 export function avatarPalette(accentHex: string | null): WidgetAvatarPalette {
   if (accentHex === null) {
     return {
       surface: widgetTheme.brandCardSurface,
       onSurface: widgetTheme.onBrand,
+      // The brand card is a deep green in both appearances, so what sits on it
+      // is white in both, and a white wash is what lifts it.
       controlFill: (onWhite) => ({
         light: withAlpha("#FFFFFF", onWhite),
         dark: withAlpha("#FFFFFF", onWhite),
@@ -139,15 +108,18 @@ export function avatarPalette(accentHex: string | null): WidgetAvatarPalette {
     };
   }
   const light = accentHex;
-  const dark = darken(accentHex, DARK_SURFACE_FACTOR);
-  const lightOn = isLight(light) ? "#111417" : "#FFFFFF";
-  const darkOn = isLight(dark) ? "#111417" : "#FFFFFF";
+  const dark = darkenHex(accentHex, DARK_SURFACE_FACTOR);
+  const lightOn = contrastForeground(light);
+  const darkOn = contrastForeground(dark);
   return {
     surface: { light, dark },
     onSurface: { light: lightOn, dark: darkOn },
+    // `weighted(_:onWhite:onDark:)`: a white wash lifts a dark card further
+    // than a black wash deepens a light one, so the two weights differ and the
+    // foreground's own brightness picks between them.
     controlFill: (onWhite, onDark) => ({
-      light: withAlpha(lightOn, isLight(lightOn) ? onWhite : onDark),
-      dark: withAlpha(darkOn, isLight(darkOn) ? onWhite : onDark),
+      light: withAlpha(lightOn, lightOn === FG_DARK ? onDark : onWhite),
+      dark: withAlpha(darkOn, darkOn === FG_DARK ? onDark : onWhite),
     }),
   };
 }
@@ -164,12 +136,16 @@ export function softAccent(accentHex: string | null): WidgetSoftAccent {
   }
   return {
     fill: {
-      light: blend(
+      light: blendHex(
         widgetTheme.surface.light,
         accentHex,
         SOFT_ACCENT_LIGHT_WASH,
       ),
-      dark: blend(widgetTheme.surface.dark, accentHex, SOFT_ACCENT_DARK_WASH),
+      dark: blendHex(
+        widgetTheme.surface.dark,
+        accentHex,
+        SOFT_ACCENT_DARK_WASH,
+      ),
     },
     onFill: widgetTheme.textPrimary,
   };
@@ -184,6 +160,13 @@ export const WIDGET_DESIGN_SIZE = {
   small: { width: 160, height: 161 },
   medium: { width: 339, height: 161 },
 } as const;
+
+/**
+ * The ground a flattened card is composited over. The system supplies its own
+ * material on a themed Home Screen; this stands in for it so the
+ * translucent-white control fills have something to read against.
+ */
+export const FLATTENED_CARD_GROUND = "rgba(30, 30, 32, 1)";
 
 /**
  * The system draws a widget's corner, not the widget. Approximated here so the

--- a/clients/web/src/components/ios-widget-previews/widget-tokens.ts
+++ b/clients/web/src/components/ios-widget-previews/widget-tokens.ts
@@ -121,19 +121,31 @@ export function avatarPalette(accentHex: string | null): WidgetAvatarPalette {
 }
 
 /**
+ * `WidgetAvatarKind`: what a widget can do with the snapshot's avatar, as the
+ * three treatments it has rather than as the string the payload carries.
+ *
+ * The discriminator is the kind, never the presence of a raster: a character
+ * payload carries its accent AND its encoded face together, so "has an image"
+ * says nothing about which treatment the card wants.
+ */
+export type WidgetAvatarKind = "character" | "image" | "none";
+
+/**
  * `SnapshotEntry.themeAccentHex`: the accent a rendering themes itself with,
  * or `null` to keep the static tokens.
  *
  * The one owner of the rule that only a character avatar carries an accent: an
- * uploaded photo has none by design, so it drops any accent handed alongside
- * it. Both palettes below read the gate from here, so a card and the controls
- * on it cannot disagree about which accounts are themed.
+ * uploaded photo has none by design, an account with nothing synced has none to
+ * read, and any other kind keeps the static palette even if a malformed or
+ * newer-schema payload carries an accent alongside it. Both palettes below read
+ * the gate from here, so a card and the controls on it cannot disagree about
+ * which accounts are themed.
  */
 export function themeAccentHex(
+  kind: WidgetAvatarKind,
   accentHex: string | null,
-  hasPhotoAvatar: boolean,
 ): string | null {
-  return hasPhotoAvatar ? null : accentHex;
+  return kind === "character" ? accentHex : null;
 }
 
 /** `WidgetSoftAccent`: the pale card a New Chat surface sits on. */

--- a/clients/web/src/components/ios-widget-previews/widget-tokens.ts
+++ b/clients/web/src/components/ios-widget-previews/widget-tokens.ts
@@ -145,7 +145,47 @@ export function themeAccentHex(
   kind: WidgetAvatarKind,
   accentHex: string | null,
 ): string | null {
-  return kind === "character" ? accentHex : null;
+  if (kind !== "character" || accentHex === null) {
+    return null;
+  }
+  return canonicalAccentHex(accentHex);
+}
+
+/**
+ * `canonicalCSSHex`, narrowed to what a card surface can be.
+ *
+ * The Swift accepts `#RGB`, `#RRGGBB` and `#RRGGBBAA` with the `#` optional,
+ * and expands the short form before any palette derives anything from it. The
+ * shared derivations in `avatar-tone.ts` read `#RRGGBB` only and hand back
+ * their input untouched for anything else, so an accent arriving in one of the
+ * other spellings would silently skip the darkening, the wash and the contrast
+ * choice. Canonicalizing once, here, is what keeps the two sides agreeing on
+ * more than the spelling they happen to share.
+ *
+ * The alpha an 8-digit spelling carries is dropped rather than honored: what
+ * comes out is a card surface, and a translucent card is not one.
+ * `WidgetAvatarPalette` forces alpha on its light side for the same reason.
+ * Anything neither side can read returns `null`, so the caller falls back to
+ * its static palette exactly as the Swift's `guard` does.
+ */
+function canonicalAccentHex(raw: string): string | null {
+  let digits = raw.trim().toUpperCase();
+  if (digits.startsWith("#")) {
+    digits = digits.slice(1);
+  }
+  if (digits.length === 3) {
+    digits = digits
+      .split("")
+      .map((c) => c + c)
+      .join("");
+  }
+  if (digits.length !== 6 && digits.length !== 8) {
+    return null;
+  }
+  if (!/^[0-9A-F]+$/.test(digits)) {
+    return null;
+  }
+  return `#${digits.slice(0, 6)}`;
 }
 
 /** `WidgetSoftAccent`: the pale card a New Chat surface sits on. */

--- a/clients/web/src/components/ios-widget-previews/widget-tokens.ts
+++ b/clients/web/src/components/ios-widget-previews/widget-tokens.ts
@@ -1,0 +1,200 @@
+/**
+ * The Home Screen widgets' palette and design geometry, transcribed from the
+ * Swift that actually draws them.
+ *
+ * These are not app design tokens and must not be used by app code. A widget
+ * renders in an extension process that never runs this SPA, so it cannot read
+ * the CSS custom properties the product themes itself with; its palette is a
+ * set of literals in `WidgetTheme.swift`. This module mirrors those literals so
+ * the previews in this directory are worth looking at, and every value below
+ * names the Swift declaration it was copied from.
+ *
+ * Source of truth is the Swift, always. When the two disagree the Swift is
+ * right and this file is stale.
+ *
+ * @see clients/ios/App/VoiceActivity/Widgets/WidgetTheme.swift
+ */
+
+/** A color that resolves from the appearance the widget is rendered in. */
+export interface WidgetAppearanceColor {
+  light: string;
+  dark: string;
+}
+
+export type WidgetAppearance = "light" | "dark";
+
+export function resolveColor(
+  color: WidgetAppearanceColor,
+  appearance: WidgetAppearance,
+): string {
+  return color[appearance];
+}
+
+/** `WidgetTheme` in `WidgetTheme.swift`. */
+export const widgetTheme = {
+  surface: { light: "#FFFFFF", dark: "#1C1C1E" },
+  newChatFill: { light: "#E6F5F3", dark: "#123832" },
+  voiceFill: { light: "#F6F5F4", dark: "#2C2C2E" },
+  brand: { light: "#0E9B8B", dark: "#2FC1AE" },
+  textPrimary: { light: "#111417", dark: "#F2F2F7" },
+  textSecondary: { light: "#7C8894", dark: "#98A2AE" },
+  unseenIndicator: { light: "#FFB200", dark: "#FFC13D" },
+  brandCardSurface: { light: "#0E9B8B", dark: "#0B7A6E" },
+  /** Fixed in both appearances: the card under it is deep green either way. */
+  onBrand: { light: "#FFFFFF", dark: "#FFFFFF" },
+  /** Fixed: a face does not change color with the Home Screen behind it. */
+  avatarSclera: { light: "#F2F2F2", dark: "#F2F2F2" },
+  avatarPupil: { light: "#1A1A1A", dark: "#1A1A1A" },
+} satisfies Record<string, WidgetAppearanceColor>;
+
+/**
+ * `WidgetAvatarPalette.darkSurfaceFactor`: how far an accent is deepened for
+ * dark appearance, so a saturated card is not the brightest thing on a dark
+ * Home Screen.
+ */
+const DARK_SURFACE_FACTOR = 0.79;
+
+/** `WidgetSoftAccent`'s two washes: the accent's share of the card. */
+const SOFT_ACCENT_LIGHT_WASH = 0.105;
+const SOFT_ACCENT_DARK_WASH = 0.22;
+
+interface Rgb {
+  r: number;
+  g: number;
+  b: number;
+}
+
+function parseHex(hex: string): Rgb {
+  const value = hex.replace("#", "");
+  const full =
+    value.length === 3
+      ? value
+          .split("")
+          .map((c) => c + c)
+          .join("")
+      : value;
+  return {
+    r: Number.parseInt(full.slice(0, 2), 16),
+    g: Number.parseInt(full.slice(2, 4), 16),
+    b: Number.parseInt(full.slice(4, 6), 16),
+  };
+}
+
+function toHex({ r, g, b }: Rgb): string {
+  const channel = (n: number) =>
+    Math.max(0, Math.min(255, Math.round(n)))
+      .toString(16)
+      .padStart(2, "0");
+  return `#${channel(r)}${channel(g)}${channel(b)}`;
+}
+
+function darken(hex: string, factor: number): string {
+  const { r, g, b } = parseHex(hex);
+  return toHex({ r: r * factor, g: g * factor, b: b * factor });
+}
+
+function blend(base: string, overlay: string, alpha: number): string {
+  const a = parseHex(base);
+  const b = parseHex(overlay);
+  return toHex({
+    r: a.r + (b.r - a.r) * alpha,
+    g: a.g + (b.g - a.g) * alpha,
+    b: a.b + (b.b - a.b) * alpha,
+  });
+}
+
+/**
+ * Relative luminance, the input to `UIColor.contrastingForeground`'s choice of
+ * a foreground that survives the card it is drawn on. A yellow avatar and a
+ * deep green one both have to produce a legible card, which a fixed white
+ * cannot.
+ */
+function isLight(hex: string): boolean {
+  const { r, g, b } = parseHex(hex);
+  return (0.299 * r + 0.587 * g + 0.114 * b) / 255 > 0.5;
+}
+
+/** `WidgetAvatarPalette`: the colors a card painted with an accent draws from. */
+export interface WidgetAvatarPalette {
+  surface: WidgetAppearanceColor;
+  onSurface: WidgetAppearanceColor;
+  /** `controlFill(onWhite:onDark:)`, as an rgba string per appearance. */
+  controlFill: (onWhite: number, onDark: number) => WidgetAppearanceColor;
+}
+
+function withAlpha(hex: string, alpha: number): string {
+  const { r, g, b } = parseHex(hex);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+export function avatarPalette(accentHex: string | null): WidgetAvatarPalette {
+  if (accentHex === null) {
+    return {
+      surface: widgetTheme.brandCardSurface,
+      onSurface: widgetTheme.onBrand,
+      controlFill: (onWhite) => ({
+        light: withAlpha("#FFFFFF", onWhite),
+        dark: withAlpha("#FFFFFF", onWhite),
+      }),
+    };
+  }
+  const light = accentHex;
+  const dark = darken(accentHex, DARK_SURFACE_FACTOR);
+  const lightOn = isLight(light) ? "#111417" : "#FFFFFF";
+  const darkOn = isLight(dark) ? "#111417" : "#FFFFFF";
+  return {
+    surface: { light, dark },
+    onSurface: { light: lightOn, dark: darkOn },
+    controlFill: (onWhite, onDark) => ({
+      light: withAlpha(lightOn, isLight(lightOn) ? onWhite : onDark),
+      dark: withAlpha(darkOn, isLight(darkOn) ? onWhite : onDark),
+    }),
+  };
+}
+
+/** `WidgetSoftAccent`: the pale card a New Chat surface sits on. */
+export interface WidgetSoftAccent {
+  fill: WidgetAppearanceColor;
+  onFill: WidgetAppearanceColor;
+}
+
+export function softAccent(accentHex: string | null): WidgetSoftAccent {
+  if (accentHex === null) {
+    return { fill: widgetTheme.newChatFill, onFill: widgetTheme.brand };
+  }
+  return {
+    fill: {
+      light: blend(
+        widgetTheme.surface.light,
+        accentHex,
+        SOFT_ACCENT_LIGHT_WASH,
+      ),
+      dark: blend(widgetTheme.surface.dark, accentHex, SOFT_ACCENT_DARK_WASH),
+    },
+    onFill: widgetTheme.textPrimary,
+  };
+}
+
+/**
+ * The canvases each widget's measurements are designed on, so a preview can
+ * scale the way the real card does: every dimension is multiplied by the ratio
+ * between the rendered size and the design size.
+ */
+export const WIDGET_DESIGN_SIZE = {
+  small: { width: 160, height: 161 },
+  medium: { width: 339, height: 161 },
+} as const;
+
+/**
+ * The system draws a widget's corner, not the widget. Approximated here so the
+ * preview reads as a Home Screen tile rather than as a rectangle.
+ */
+export const WIDGET_CORNER_RADIUS = 24;
+
+/**
+ * SwiftUI's `.system(size:)` is SF Pro. Off an Apple platform the stack falls
+ * through to whatever the browser has, so metrics drift from the device; see
+ * the fidelity note in the stories.
+ */
+export const WIDGET_FONT_STACK =
+  '-apple-system, BlinkMacSystemFont, "SF Pro Text", "SF Pro Display", system-ui, sans-serif';

--- a/clients/web/src/components/ios-widget-previews/widget-tokens.ts
+++ b/clients/web/src/components/ios-widget-previews/widget-tokens.ts
@@ -120,6 +120,22 @@ export function avatarPalette(accentHex: string | null): WidgetAvatarPalette {
   };
 }
 
+/**
+ * `SnapshotEntry.themeAccentHex`: the accent a rendering themes itself with,
+ * or `null` to keep the static tokens.
+ *
+ * The one owner of the rule that only a character avatar carries an accent: an
+ * uploaded photo has none by design, so it drops any accent handed alongside
+ * it. Both palettes below read the gate from here, so a card and the controls
+ * on it cannot disagree about which accounts are themed.
+ */
+export function themeAccentHex(
+  accentHex: string | null,
+  hasPhotoAvatar: boolean,
+): string | null {
+  return hasPhotoAvatar ? null : accentHex;
+}
+
 /** `WidgetSoftAccent`: the pale card a New Chat surface sits on. */
 export interface WidgetSoftAccent {
   fill: WidgetAppearanceColor;

--- a/clients/web/src/components/ios-widget-previews/widget-tokens.ts
+++ b/clients/web/src/components/ios-widget-previews/widget-tokens.ts
@@ -12,14 +12,10 @@
  * Source of truth is the Swift, always. When the two disagree the Swift is
  * right and this file is stale.
  *
- * The derived colors are NOT transcribed. `darkenHex`, `blendHex` and
- * `contrastForeground` come from `@/utils/avatar-tone`, which the Swift names
- * as its own source of truth (`UIColor.contrastingForeground` mirrors that
- * file's `contrastForeground`, and `blendHex`/`darkenHex` mirror its
- * namesakes). A second copy here would be a second copy that drifts, and its
- * first victim would be the foreground: a YIQ-style brightness rule picks white
- * on a mid-tone teal where the WCAG derivation both sides actually use picks
- * dark.
+ * Only the literals are transcribed. The derivations come from
+ * `@/utils/avatar-tone`, which the Swift names as its own source of truth:
+ * `UIColor.contrastingForeground` mirrors that file's `contrastForeground`,
+ * and `blendHex` / `darkenHex` mirror its namesakes.
  *
  * @see clients/ios/App/VoiceActivity/Widgets/WidgetTheme.swift
  * @see clients/ios/App/App/Shared/CSSHexColor.swift
@@ -71,9 +67,9 @@ const SOFT_ACCENT_LIGHT_WASH = 0.105;
 const SOFT_ACCENT_DARK_WASH = 0.22;
 
 /**
- * `UIColor.contrastingForeground`'s two answers, which are
- * `avatar-tone.ts`'s own `FG_DARK` / `FG_LIGHT`. Named here only so the fill
- * weighting below can tell which one it was handed.
+ * `avatar-tone.ts`'s `FG_DARK`, the darker of the two answers
+ * `contrastForeground` gives. Named here so the fill weighting below can tell
+ * which one it was handed.
  */
 const FG_DARK = "#1A1A1A";
 

--- a/clients/web/src/components/ios-widget-previews/widget-tokens.ts
+++ b/clients/web/src/components/ios-widget-previews/widget-tokens.ts
@@ -145,47 +145,7 @@ export function themeAccentHex(
   kind: WidgetAvatarKind,
   accentHex: string | null,
 ): string | null {
-  if (kind !== "character" || accentHex === null) {
-    return null;
-  }
-  return canonicalAccentHex(accentHex);
-}
-
-/**
- * `canonicalCSSHex`, narrowed to what a card surface can be.
- *
- * The Swift accepts `#RGB`, `#RRGGBB` and `#RRGGBBAA` with the `#` optional,
- * and expands the short form before any palette derives anything from it. The
- * shared derivations in `avatar-tone.ts` read `#RRGGBB` only and hand back
- * their input untouched for anything else, so an accent arriving in one of the
- * other spellings would silently skip the darkening, the wash and the contrast
- * choice. Canonicalizing once, here, is what keeps the two sides agreeing on
- * more than the spelling they happen to share.
- *
- * The alpha an 8-digit spelling carries is dropped rather than honored: what
- * comes out is a card surface, and a translucent card is not one.
- * `WidgetAvatarPalette` forces alpha on its light side for the same reason.
- * Anything neither side can read returns `null`, so the caller falls back to
- * its static palette exactly as the Swift's `guard` does.
- */
-function canonicalAccentHex(raw: string): string | null {
-  let digits = raw.trim().toUpperCase();
-  if (digits.startsWith("#")) {
-    digits = digits.slice(1);
-  }
-  if (digits.length === 3) {
-    digits = digits
-      .split("")
-      .map((c) => c + c)
-      .join("");
-  }
-  if (digits.length !== 6 && digits.length !== 8) {
-    return null;
-  }
-  if (!/^[0-9A-F]+$/.test(digits)) {
-    return null;
-  }
-  return `#${digits.slice(0, 6)}`;
+  return kind === "character" ? accentHex : null;
 }
 
 /** `WidgetSoftAccent`: the pale card a New Chat surface sits on. */

--- a/clients/web/src/components/ios-widget-previews/widget-unread-mark.tsx
+++ b/clients/web/src/components/ios-widget-previews/widget-unread-mark.tsx
@@ -1,0 +1,59 @@
+/**
+ * The mark a widget says "something is waiting" with: a speech bubble wearing
+ * the unseen dot in its top-right corner.
+ *
+ * The dot rides the bubble's corner at the design's share of it, so the mark
+ * scales as one piece rather than drifting off the corner on a card rendered
+ * larger.
+ *
+ * @see clients/ios/App/VoiceActivity/Widgets/WidgetActionControls.swift
+ */
+
+import { BubbleGlyph } from "./widget-glyphs";
+import { widgetTheme, type WidgetAppearance } from "./widget-tokens";
+
+const DOT_DIAMETER_RATIO = 0.375;
+const DOT_NUDGE_RATIO = 0.0625;
+
+interface WidgetUnreadMarkProps {
+  /** A card painted in the assistant's color wants the filled bubble. */
+  filled: boolean;
+  size: number;
+  /** The bubble takes the color of whatever it is drawn on. */
+  color: string;
+  appearance?: WidgetAppearance;
+  /** Flattened, the dot is the mark's one accentable piece. */
+  flattened?: boolean;
+}
+
+export function WidgetUnreadMark({
+  filled,
+  size,
+  color,
+  appearance = "light",
+  flattened = false,
+}: WidgetUnreadMarkProps) {
+  const dot = size * DOT_DIAMETER_RATIO;
+  const nudge = size * DOT_NUDGE_RATIO;
+  return (
+    <span
+      style={{ position: "relative", display: "inline-flex", lineHeight: 0 }}
+      aria-hidden="true"
+    >
+      <BubbleGlyph size={size} color={color} filled={filled} />
+      <span
+        style={{
+          position: "absolute",
+          top: -nudge,
+          right: -nudge,
+          width: dot,
+          height: dot,
+          borderRadius: "50%",
+          background: flattened
+            ? "#FFFFFF"
+            : widgetTheme.unseenIndicator[appearance],
+        }}
+      />
+    </span>
+  );
+}


### PR DESCRIPTION
## Read this first

**These are not the widgets.** The widgets are SwiftUI compiled into an iOS app extension, and nothing renders SwiftUI in Storybook. What is here is a hand-maintained copy, worth exactly as much as that copy is current. The Swift stays the source of truth, and the `#Preview` blocks in it (16 across the three files) remain the only rendering that tells the truth.

I raised that trade-off before building this and the direction was to go ahead, so the mitigation is honesty rather than avoidance: the stories lead with what the replica cannot show, and every constant names the Swift declaration it came from.

## What is in it

`Storybook > iOS Widgets > Home Screen`, covering the states worth reviewing:

| Story | Covers |
| --- | --- |
| Quick Actions / quiet | the face with nothing waiting, resting right of centre |
| Quick Actions / unread | the chip, and a 3-digit count buying width from the eyes |
| Quick Actions / avatars | custom photo blurred into the card, and the accentless brand block |
| Status / idle and active | the launcher, and the readout it flips to |
| Catch Up / rows | a group, a turn in flight, something unread |
| Catch Up / single row and empty | the title-only glyph inset, and the empty prompt |
| Catch Up / stale | in-progress drops, unread survives |
| Themed Home Screen (flattened) | all three, monochrome |
| Magnified (2x) | the geometry rather than the composition |

Every card renders in both appearances side by side, because a widget is drawn in whatever appearance the device is in and neither is the default.

## Fidelity, stated precisely

- **The eyes are exact.** They carry the same Bezier control points as `AvatarEyeScleraShape` / `AvatarEyePupilShape`. I rendered the real SwiftUI shapes with `ImageRenderer` at 8x and diffed: the sclera and pupil ink bounding boxes agree to **0.00pt on every edge**, with 0.09% of pixels differing on the curve edges (antialiasing between CoreGraphics and Chrome).
- **The SF Symbols are stand-ins.** `camera.fill`, `waveform`, `bubble.left`, `ellipsis` and the `VellumV` asset do not exist in a browser. Hand-drawn at the same nominal point size: close enough for layout and weight, not for the symbols themselves.
- **The type is not SF Pro off an Apple device.** The stack falls through to whatever the browser has, so line metrics drift.
- **Flattened mode is imitated, not applied.** WidgetKit discards every color and redraws from each view's alpha; the `flattened` arg paints what that should come out as. Only a device proves it.

## Choices worth calling out

- **No design-library components.** The convention is design-system-first, and this is the case it does not cover: the cards reproduce native SwiftUI, so a design-library button would make them look like the app rather than like the widget. Inline styles for the same reason, driven by `widget-tokens.ts` where every value names its Swift declaration.
- **The i18n rule is disabled per file, with a reason in the disable.** The literals reproduce copy hardcoded in the Swift, which ships in English only and never reads this app's catalogs. Routing them through `t()` would assert a localization the widgets do not have, and would let a catalog edit drift the preview away from the card it is a picture of. (The rule also reports the rgba style values, which are not copy.)
- **Nothing in the app imports these.** They exist for the stories.

## Verification

- `bunx tsc --noEmit` and `eslint` clean; `prettier --check` clean.
- `bun run build-storybook` succeeds. It failed first on `MISSING_EXPORT` for generated SDK symbols, which was a stale `src/generated` after a branch switch, not this change; `bun run openapi-ts` fixed it and the symbol appeared.
- Rendered every story server-side and inspected the output.

## The drift risk, plainly

A reviewer who changes a constant in the Swift will not be told this file exists. If that becomes a problem, the next step is a comment in each Swift file naming its counterpart. I did not add it here because it is a second thing to keep current, and I would rather it be a deliberate follow-up than a reflex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)