### PR TITLE
fix(cli): reject unknown flags in connect import instead of pairing against them

### DIFF
--- a/cli/src/__tests__/connect-import.test.ts
+++ b/cli/src/__tests__/connect-import.test.ts
@@ -506,6 +506,52 @@ describe("connect import", () => {
     expect(out).toContain("USAGE:");
   });
 
+  test("rejects an unknown --flag instead of pairing against it", async () => {
+    process.argv = ["bun", "vellum", "connect", "import", "--qr", HOST];
+    let fetched = false;
+    globalThis.fetch = (async () => {
+      fetched = true;
+      return jsonResponse({});
+    }) as unknown as typeof fetch;
+
+    const { exited, out } = await runExpectingExit();
+
+    // The flag is named and the CLI self-update path is offered. An address
+    // error would be a lie: the address was never the problem.
+    expect(exited).toBe(true);
+    expect(out).toContain("unknown option '--qr'");
+    expect(out).toContain("bun install -g vellum@latest");
+    expect(out).not.toContain("pairing link");
+    expect(fetched).toBe(false);
+  });
+
+  test("rejects an unknown --flag even alongside an address and --name", async () => {
+    process.argv = [
+      "bun",
+      "vellum",
+      "connect",
+      "import",
+      HOST,
+      "--name",
+      "guarded-box",
+      "--frobnicate",
+    ];
+    let fetched = false;
+    globalThis.fetch = (async () => {
+      fetched = true;
+      return jsonResponse({});
+    }) as unknown as typeof fetch;
+
+    const { exited, out } = await runExpectingExit();
+
+    // Known flags and a usable address never rescue an unknown one, and
+    // nothing is registered before the refusal.
+    expect(exited).toBe(true);
+    expect(out).toContain("unknown option '--frobnicate'");
+    expect(fetched).toBe(false);
+    expect(findAssistantByName("guarded-box")).toBeNull();
+  });
+
   test("two pairings against the same host do not collide", async () => {
     const ids: string[] = [];
     for (const token of ["tok1", "tok2"]) {

--- a/cli/src/commands/connect/import.ts
+++ b/cli/src/commands/connect/import.ts
@@ -21,6 +21,7 @@ import { isRetryablePairingReason } from "@vellumai/service-contracts/remote-web
 import { extractFlag } from "../../lib/arg-utils.js";
 import { getLockfilePaths } from "../../lib/environments/paths.js";
 import { getCurrentEnvironment } from "../../lib/environments/resolve.js";
+import { STALE_CLI_UPDATE_HINT } from "../../lib/stale-cli-hint.js";
 
 function printUsage(): void {
   console.log(`vellum connect import - Pair with an assistant running on another machine
@@ -140,6 +141,24 @@ export async function connectImport(): Promise<void> {
   }
 
   const [nameFlag, args] = extractFlag(rawArgs, "--name");
+
+  // Any `--`-prefixed token left after known-flag extraction is an option this
+  // CLI version doesn't support. Fail loud before any network call rather than
+  // letting it fall through: an unknown flag would otherwise be read as the
+  // address and reported as an unusable one, hiding the real mistake. Neither
+  // an https address nor a pairing link starts with `--`.
+  const unknownFlag = args.find((a) => a.startsWith("--"));
+  if (unknownFlag) {
+    console.error(`Error: unknown option '${unknownFlag}'.`);
+    console.error(
+      "Run `vellum connect import --help` to see available options.",
+    );
+    console.error(
+      `If this option is from newer docs, ${STALE_CLI_UPDATE_HINT}`,
+    );
+    process.exit(1);
+  }
+
   const address = args[0];
   if (!address) {
     console.error("Error: missing assistant address.");

--- a/packages/electron-desktop/src/deep-links.ts
+++ b/packages/electron-desktop/src/deep-links.ts
@@ -137,8 +137,9 @@ const ACCEPTED_SCHEMES = resolveAcceptedSchemes(currentEnv);
  *   - `vellum://connect?url=…&code=…` → `{ kind: "connect", … }`.
  *     The pair page's "Open in the Vellum app" button and
  *     `vellum pair --app` QR codes. `url` must parse as https
- *     (dropped otherwise); `code` (the device code) must match the
- *     base64url shape the gateway mints, and rides only alongside a
+ *     (dropped otherwise); `code` (the device code) is opaque, so it
+ *     is only bounded in length and refused when it carries
+ *     whitespace or control characters, and rides only alongside a
  *     usable base, since a code with nothing to exchange it against
  *     is inert. A `bundle` param comes from app versions whose
  *     connect dialog took a pasted pairing bundle: its presence sets


### PR DESCRIPTION
## Summary
- `vellum connect import` now fails loudly on an unknown flag rather than treating it as the address and reporting a confusing address error, matching the guard `vellum pair` already has.
- Corrects the deep-link JSDoc, which claimed the device code must be base64url while the regex it documents deliberately accepts any bounded opaque value.

Found by self-review of plan zesty-wandering-nygaard.md.