### PR TITLE
fix(local-mode): clamp remote-controlled pairing cadence and stop burning codes on collisions

### DIFF
--- a/cli/src/__tests__/connect-import.test.ts
+++ b/cli/src/__tests__/connect-import.test.ts
@@ -506,7 +506,8 @@ describe("connect import", () => {
     expect(out).toContain("USAGE:");
   });
 
-  test("two pairings against the same host do not collide", async () => {
+  test("re-pairing the same host with no --name updates one entry", async () => {
+    const outcomes: string[] = [];
     const ids: string[] = [];
     for (const token of ["tok1", "tok2"]) {
       process.argv = ["bun", "vellum", "connect", "import", PAIRING_LINK];
@@ -517,17 +518,19 @@ describe("connect import", () => {
       } finally {
         restore();
       }
-      const match = logs.join("\n").match(/paired assistant '([^']+)'/);
+      const match = logs.join("\n").match(/(\w+) paired assistant '([^']+)'/);
       expect(match).not.toBeNull();
-      ids.push(match![1]);
+      outcomes.push(match![1]);
+      ids.push(match![2]);
     }
 
-    // A fresh device id per pairing, so the local ids differ and neither
-    // contains a path separator.
-    expect(ids[0]).not.toBe(ids[1]);
+    // The default id keys on the assistant's address, which survives the fresh
+    // device id every attempt mints, so the second pairing replaces the first
+    // rather than stranding it in the lockfile.
+    expect(ids[0]).toBe(ids[1]);
     expect(ids[0]).not.toContain("/");
-    expect(loadGuardianToken(ids[0])?.accessToken).toBe("tok1");
-    expect(loadGuardianToken(ids[1])?.accessToken).toBe("tok2");
+    expect(outcomes).toEqual(["Imported", "Updated"]);
+    expect(loadGuardianToken(ids[0])?.accessToken).toBe("tok2");
   });
 
   test("re-importing under the same --name updates in place", async () => {

--- a/packages/local-mode/src/__tests__/pair.test.ts
+++ b/packages/local-mode/src/__tests__/pair.test.ts
@@ -90,12 +90,27 @@ const credentials = (
   ...overrides,
 });
 
+/** The nameless id the default credentials' gateway host derives. */
+const DEFAULT_PAIRED_ID = "paired-10-0-0-5-7830";
+
 /** A syntactically valid JWT whose `exp` is 2030-01-01T00:00:00Z. */
 const JWT_EXP_S = 1893456000;
 const jwtWithExp = `h.${Buffer.from(JSON.stringify({ exp: JWT_EXP_S })).toString("base64")}.s`;
 
 const json = (status: number, body: unknown): Response =>
   new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+
+/**
+ * A reply whose JSON is written out literally, so a value `JSON.stringify`
+ * cannot express reaches the parser exactly as a remote sends it. `1e400`
+ * parses back as Infinity, which is how a hostile or broken assistant names an
+ * unbounded cadence.
+ */
+const rawJson = (status: number, text: string): Response =>
+  new Response(text, {
     status,
     headers: { "Content-Type": "application/json" },
   });
@@ -182,7 +197,7 @@ describe("pairAssistant", () => {
     if (!result.ok) {
       return;
     }
-    expect(result.assistantId).toBe("paired-dev-aaa");
+    expect(result.assistantId).toBe(DEFAULT_PAIRED_ID);
     expect(result.updated).toBe(false);
     expect(result.accessOnly).toBe(true);
 
@@ -191,7 +206,7 @@ describe("pairAssistant", () => {
     const onDisk = readLockfileFromDisk();
     const entry = (onDisk.assistants as Array<Record<string, unknown>>)[0]!;
     expect(entry).toEqual({
-      assistantId: "paired-dev-aaa",
+      assistantId: DEFAULT_PAIRED_ID,
       name: "paired (10.0.0.5:7830)",
       runtimeUrl: "http://10.0.0.5:7830",
       cloud: "paired",
@@ -209,7 +224,7 @@ describe("pairAssistant", () => {
     // Importing never reassigns the active assistant.
     expect(onDisk.activeAssistant ?? null).toBeNull();
 
-    const tokenPath = guardianTokenPath(configDir, "paired-dev-aaa");
+    const tokenPath = guardianTokenPath(configDir, DEFAULT_PAIRED_ID);
     const raw = fs.readFileSync(tokenPath, "utf-8");
     expect(raw.endsWith("\n")).toBe(true);
     const token = JSON.parse(raw) as Record<string, unknown>;
@@ -250,7 +265,7 @@ describe("pairAssistant", () => {
     });
     expect(result.ok).toBe(true);
 
-    const token = readGuardianToken("paired-dev-exp");
+    const token = readGuardianToken(DEFAULT_PAIRED_ID);
     const dayMs = 24 * 60 * 60 * 1000;
     expect(token.accessTokenExpiresAt as number).toBeGreaterThanOrEqual(
       before + dayMs,
@@ -276,7 +291,7 @@ describe("pairAssistant", () => {
       return;
     }
     expect(result.accessOnly).toBe(false);
-    const token = readGuardianToken("paired-dev-refresh");
+    const token = readGuardianToken("paired-gw-example-com");
     expect(token.refreshToken).toBe("refresh-tok");
     expect(token.refreshTokenExpiresAt).toBe("2027-01-01T00:00:00.000Z");
     expect(token.refreshAfter).toBe("2026-07-01T00:00:00.000Z");
@@ -293,9 +308,9 @@ describe("pairAssistant", () => {
     });
 
     expect(result.ok).toBe(true);
-    expect(readGuardianToken("paired-dev-num").refreshTokenExpiresAt).toBe(
-      1893456000000,
-    );
+    expect(
+      readGuardianToken("paired-gw-example-com").refreshTokenExpiresAt,
+    ).toBe(1893456000000);
   });
 
   test("refuses loopback gateway URLs so a pairing can't alias local services", () => {
@@ -327,9 +342,23 @@ describe("pairAssistant", () => {
     }
     // Nothing was written for any refused pairing.
     expect(fs.existsSync(lockfilePath)).toBe(false);
-    expect(fs.existsSync(guardianTokenPath(configDir, "paired-dev-loop"))).toBe(
-      false,
-    );
+    expect(fs.existsSync(path.join(configDir, "assistants"))).toBe(false);
+  });
+
+  test("a loopback refusal points at an address that can still work", () => {
+    // Private-network literals are refused before a pairing is ever minted, so
+    // advice to retry with a LAN address would send the user into a guaranteed
+    // second failure.
+    const result = pairAssistant([lockfilePath], configDir, {
+      credentials: credentials({ gatewayUrl: "http://localhost:7830" }),
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      return;
+    }
+    expect(result.error).toContain("tunnel or public https address");
+    expect(result.error).not.toContain("LAN");
   });
 
   test("a non-loopback plaintext http gateway is access-only even with a refresh token", () => {
@@ -383,7 +412,7 @@ describe("pairAssistant", () => {
     expect(fs.existsSync(lockfilePath)).toBe(false);
   });
 
-  test("a malicious deviceId is slugified out of the path", () => {
+  test("the derived id is path-safe whatever the deviceId carries", () => {
     const result = pairAssistant([lockfilePath], configDir, {
       credentials: credentials({ deviceId: "-/../../tmp/x" }),
     });
@@ -392,16 +421,17 @@ describe("pairAssistant", () => {
     if (!result.ok) {
       return;
     }
-    expect(result.assistantId).not.toContain("/");
-    expect(result.assistantId).not.toContain("..");
+    // The id keys on the gateway host, so an untrusted deviceId never reaches
+    // the token path at all.
+    expect(result.assistantId).toBe(DEFAULT_PAIRED_ID);
     expect(
       fs.existsSync(guardianTokenPath(configDir, result.assistantId)),
     ).toBe(true);
   });
 
-  test("a missing deviceId falls back to a random path-safe id", () => {
+  test("a gatewayUrl with no host falls back to a random path-safe id", () => {
     const result = pairAssistant([lockfilePath], configDir, {
-      credentials: credentials({ deviceId: undefined }),
+      credentials: credentials({ gatewayUrl: "mailto:ops@example.com" }),
     });
 
     expect(result.ok).toBe(true);
@@ -409,6 +439,56 @@ describe("pairAssistant", () => {
       return;
     }
     expect(result.assistantId).toMatch(/^paired-[A-Za-z0-9_-]{21}$/);
+  });
+
+  test("re-pairing with no name updates the entry instead of adding another", () => {
+    // Every attempt mints a fresh device id, so keying the default id on it
+    // would strand the previous pairing in the lockfile (and its guardian
+    // token on disk) every time a user re-paired the same assistant.
+    const first = pairAssistant([lockfilePath], configDir, {
+      credentials: credentials({ deviceId: "dev-one", token: "t1" }),
+    });
+    expect(first.ok).toBe(true);
+    if (!first.ok) {
+      return;
+    }
+    expect(first.updated).toBe(false);
+
+    const second = pairAssistant([lockfilePath], configDir, {
+      credentials: credentials({ deviceId: "dev-two", token: "t2" }),
+    });
+
+    expect(second.ok).toBe(true);
+    if (!second.ok) {
+      return;
+    }
+    expect(second.assistantId).toBe(first.assistantId);
+    expect(second.updated).toBe(true);
+
+    const assistants = readLockfileFromDisk().assistants as Array<
+      Record<string, unknown>
+    >;
+    expect(assistants).toHaveLength(1);
+    // One credential on disk, holding the newest pairing's device.
+    expect(fs.readdirSync(path.join(configDir, "assistants"))).toEqual([
+      DEFAULT_PAIRED_ID,
+    ]);
+    const token = readGuardianToken(DEFAULT_PAIRED_ID);
+    expect(token.accessToken).toBe("t2");
+    expect(token.deviceId).toBe("dev-two");
+  });
+
+  test("a --name still wins over the gateway-derived default", () => {
+    const result = pairAssistant([lockfilePath], configDir, {
+      credentials: credentials(),
+      name: "Desk",
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    expect(result.assistantId).toBe("desk");
   });
 
   test("refuses to clobber an existing non-paired assistant", () => {
@@ -445,9 +525,10 @@ describe("pairAssistant", () => {
     expect(fs.existsSync(guardianTokenPath(configDir, "desk"))).toBe(false);
   });
 
-  test("re-importing over an existing paired entry updates it in place", () => {
+  test("re-importing under the same name updates it in place, address and all", () => {
     const first = pairAssistant([lockfilePath], configDir, {
       credentials: credentials({ deviceId: "dev-re", token: "t1" }),
+      name: "desk",
     });
     expect(first.ok).toBe(true);
 
@@ -457,6 +538,7 @@ describe("pairAssistant", () => {
         token: "t2",
         gatewayUrl: "https://new.example.com",
       }),
+      name: "desk",
     });
 
     expect(second.ok).toBe(true);
@@ -469,7 +551,7 @@ describe("pairAssistant", () => {
     >;
     expect(assistants).toHaveLength(1);
     expect(assistants[0]!.runtimeUrl).toBe("https://new.example.com");
-    expect(readGuardianToken("paired-dev-re").accessToken).toBe("t2");
+    expect(readGuardianToken("desk").accessToken).toBe("t2");
   });
 
   test("deletes the just-written token when the lockfile write fails", () => {
@@ -478,7 +560,7 @@ describe("pairAssistant", () => {
     // has already been written.
     const notADir = path.join(tmpDir, "not-a-dir");
     fs.writeFileSync(notADir, "");
-    const tokenPath = guardianTokenPath(configDir, "paired-dev-aaa");
+    const tokenPath = guardianTokenPath(configDir, DEFAULT_PAIRED_ID);
 
     const result = pairAssistant(
       [path.join(notADir, "lockfile.json")],
@@ -497,7 +579,7 @@ describe("pairAssistant", () => {
       credentials: credentials({ deviceId: "dev-re", token: "t1" }),
     });
     expect(first.ok).toBe(true);
-    const tokenPath = guardianTokenPath(configDir, "paired-dev-re");
+    const tokenPath = guardianTokenPath(configDir, DEFAULT_PAIRED_ID);
     const priorContents = fs.readFileSync(tokenPath, "utf-8");
 
     // Reads fall back to the real lockfile (so the existing entry is found
@@ -626,6 +708,61 @@ describe("pairingStart", () => {
     expect(JSON.stringify(started)).not.toContain("device-code-abc");
   });
 
+  test("clamps the poll cadence a challenge names", async () => {
+    // The address is user-pasted, so the assistant answering it is untrusted:
+    // a caller turns this straight into a wait, and an unbounded one either
+    // parks the attempt forever or overflows a timer and spins.
+    const cadences: Array<[string, number]> = [
+      ["1e400", 5],
+      ["-1e400", 5],
+      ["null", 5],
+      ["0", 5],
+      ["86400", 60],
+      // A sub-second cadence the gateway is free to name is honored.
+      ["0.01", 0.01],
+      ["3", 3],
+    ];
+    for (const [literal, expected] of cadences) {
+      respond = () =>
+        rawJson(
+          200,
+          `{"deviceCode":"device-code-abc","userCode":"ABCD-EFGH",` +
+            `"expiresAt":"${new Date(Date.now() + 600_000).toISOString()}",` +
+            `"intervalSeconds":${literal}}`,
+        );
+
+      const started = await pairingStart("https://gw.example.com");
+
+      expect(started.ok).toBe(true);
+      if (!started.ok) {
+        continue;
+      }
+      expect(started.intervalSeconds).toBe(expected);
+    }
+  });
+
+  test("bounds the session by the code TTL, not by the instant the assistant reports", async () => {
+    respond = () =>
+      json(
+        200,
+        challengeBody({
+          expiresAt: new Date(Date.now() + 400 * 86_400_000).toISOString(),
+        }),
+      );
+
+    const started = await pairingStart("https://gw.example.com");
+
+    expect(started.ok).toBe(true);
+    if (!started.ok) {
+      return;
+    }
+    // A remote naming a further instant cannot buy itself a longer session.
+    expect(new Date(started.expiresAt).getTime()).toBeLessThanOrEqual(
+      Date.now() + 10 * 60_000,
+    );
+    expect(new Date(started.expiresAt).getTime()).toBeGreaterThan(Date.now());
+  });
+
   test("a challenge response missing its codes is a gateway failure", async () => {
     respond = () => json(200, { verificationUri: "https://gw.example.com" });
 
@@ -715,6 +852,10 @@ describe("pairingStart", () => {
     const cases: Array<[string, string]> = [
       ["http://localhost:7830", "loopback"],
       ["https://127.0.0.1", "loopback"],
+      // The reserved `.localhost` namespace resolves to loopback, and a
+      // trailing DNS root dot names the same host.
+      ["https://foo.localhost", "loopback"],
+      ["https://localhost.", "loopback"],
       ["https://10.0.0.1", "private-address"],
       ["https://192.168.1.5", "private-address"],
       // The cloud instance metadata endpoint, the classic blind-SSRF target.
@@ -770,6 +911,39 @@ describe("pairingStart", () => {
     }
     expect(started.error).toContain("too long");
     expect(fetchCalls).toHaveLength(0);
+  });
+});
+
+describe("loopback refusals agree across the pairing path", () => {
+  // One predicate backs both entry points, so an address class can never be
+  // refused by the one the user pasted into and accepted by the one an import
+  // goes through.
+  test.each([
+    ["https://localhost", "bare localhost"],
+    ["https://foo.localhost", "reserved .localhost namespace"],
+    ["https://a.b.localhost.", "absolute .localhost namespace"],
+    ["https://localhost.", "absolute localhost name"],
+    ["https://127.0.0.1.", "absolute IPv4 loopback literal"],
+    ["https://[::1]", "IPv6 loopback"],
+    ["https://0.0.0.0", "IPv4 wildcard bind"],
+  ])("refuses %s (%s) at both entry points", async (address) => {
+    const started = await pairingStart(address);
+    expect(started.ok).toBe(false);
+    if (started.ok) {
+      return;
+    }
+    expect(started.reason).toBe("invalid-address");
+    expect(started.rejection).toBe("loopback");
+
+    const imported = pairAssistant([lockfilePath], configDir, {
+      credentials: credentials({ gatewayUrl: address }),
+    });
+    expect(imported.ok).toBe(false);
+    if (imported.ok) {
+      return;
+    }
+    expect(imported.status).toBe(422);
+    expect(imported.error).toContain("non-loopback");
   });
 });
 
@@ -864,6 +1038,147 @@ describe("pairingPoll", () => {
       return;
     }
     expect(imported.status).toBe("imported");
+  });
+
+  test("a 202 may shorten the deadline but never extend it", async () => {
+    const started = await pairingStart(
+      "https://gw.example.com/assistant/pair#device_code=device-code-abc",
+    );
+    expect(started.ok).toBe(true);
+    if (!started.ok) {
+      return;
+    }
+    const openedAtMs = new Date(started.expiresAt).getTime();
+
+    // A remote that keeps naming a fresh expiry would otherwise hold the
+    // session open on its own TTL rather than the code's.
+    respond = () =>
+      json(
+        202,
+        pendingBody({
+          expiresAt: new Date(Date.now() + 365 * 86_400_000).toISOString(),
+        }),
+      );
+    const extended = await pairingPoll([lockfilePath], configDir, {
+      handle: started.handle,
+    });
+    expect(extended.ok).toBe(true);
+    if (!extended.ok || extended.status !== "pending") {
+      return;
+    }
+    expect(new Date(extended.expiresAt).getTime()).toBe(openedAtMs);
+
+    // Shortening is the gateway's to do: the code may be revoked early.
+    const sooner = new Date(Date.now() + 30_000).toISOString();
+    respond = () => json(202, pendingBody({ expiresAt: sooner }));
+    const shortened = await pairingPoll([lockfilePath], configDir, {
+      handle: started.handle,
+    });
+    expect(shortened.ok).toBe(true);
+    if (!shortened.ok || shortened.status !== "pending") {
+      return;
+    }
+    expect(shortened.expiresAt).toBe(sooner);
+  });
+
+  test("clamps the poll cadence a pending reply names", async () => {
+    for (const [literal, expected] of [
+      ["1e400", 5],
+      ["86400", 60],
+      ["0.01", 0.01],
+      ["7", 7],
+    ] as Array<[string, number]>) {
+      respond = () =>
+        rawJson(
+          202,
+          `{"status":"pending",` +
+            `"expiresAt":"${new Date(Date.now() + 300_000).toISOString()}",` +
+            `"intervalSeconds":${literal}}`,
+        );
+      const handle = await startFromLink();
+
+      const pending = await pairingPoll([lockfilePath], configDir, { handle });
+
+      expect(pending.ok).toBe(true);
+      if (!pending.ok || pending.status !== "pending") {
+        continue;
+      }
+      expect(pending.intervalSeconds).toBe(expected);
+    }
+  });
+
+  test("a colliding name is refused before the one-time code is spent", async () => {
+    writeLockfile({
+      assistants: [
+        {
+          assistantId: "desk",
+          cloud: "local",
+          runtimeUrl: "http://127.0.0.1:7830",
+        },
+      ],
+      activeAssistant: "desk",
+    });
+    respond = () => json(200, approvedBody());
+    const handle = await startFromLink();
+
+    const refused = await pairingPoll([lockfilePath], configDir, {
+      handle,
+      name: "desk",
+    });
+
+    expect(refused.ok).toBe(false);
+    if (refused.ok) {
+      return;
+    }
+    expect(refused.reason).toBe("import");
+    expect(refused.status).toBe(409);
+    // The exchange never went out, so the code is still exchangeable and the
+    // user does not need a fresh pairing link.
+    expect(fetchCalls).toHaveLength(0);
+
+    // The very same session completes once the caller picks a free name.
+    const imported = await pairingPoll([lockfilePath], configDir, {
+      handle,
+      name: "spare",
+    });
+    expect(imported.ok).toBe(true);
+    if (!imported.ok || imported.status !== "imported") {
+      return;
+    }
+    expect(imported.assistantId).toBe("spare");
+    expect(fetchCalls).toHaveLength(1);
+  });
+
+  test("re-pairing the same assistant with no name updates its entry", async () => {
+    // Each attempt mints its own device id, so a default id keyed on that
+    // would register a second entry (and a second guardian token) for the
+    // assistant the user was told to re-pair.
+    respond = () => json(200, approvedBody({ accessToken: "acc-1" }));
+    const first = await pairingPoll([lockfilePath], configDir, {
+      handle: await startFromLink(),
+    });
+    expect(first.ok).toBe(true);
+    if (!first.ok || first.status !== "imported") {
+      return;
+    }
+    expect(first.updated).toBe(false);
+
+    respond = () => json(200, approvedBody({ accessToken: "acc-2" }));
+    const second = await pairingPoll([lockfilePath], configDir, {
+      handle: await startFromLink(),
+    });
+
+    expect(second.ok).toBe(true);
+    if (!second.ok || second.status !== "imported") {
+      return;
+    }
+    expect(second.assistantId).toBe(first.assistantId);
+    expect(second.updated).toBe(true);
+    expect(readLockfileFromDisk().assistants).toHaveLength(1);
+    expect(fs.readdirSync(path.join(configDir, "assistants"))).toEqual([
+      first.assistantId,
+    ]);
+    expect(readGuardianToken(first.assistantId).accessToken).toBe("acc-2");
   });
 
   test("records the platform the caller names, defaulting to desktop", async () => {
@@ -1466,7 +1781,7 @@ describe("connectImport", () => {
 
     expect(result).toEqual({
       ok: true,
-      assistantId: "paired-dev-nn",
+      assistantId: "paired-gw-example-com",
       updated: false,
       accessOnly: true,
     });

--- a/packages/local-mode/src/guardian-token.ts
+++ b/packages/local-mode/src/guardian-token.ts
@@ -2,6 +2,8 @@ import { spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 
+import { isLoopbackPublicUrl } from "@vellumai/service-contracts/remote-web-pairing";
+
 import { guardianTokenPath, resolveConfigDirPaths } from "./config";
 import type { CliInvocation } from "./util";
 
@@ -61,44 +63,23 @@ export function saveGuardianToken(
  * wherever the configured URL points. This guard targets the
  * plaintext-interception vector.
  */
-function isLoopbackHostname(hostname: string): boolean {
-  // Strip URL brackets so IPv6 forms compare on the bare address.
-  const h = hostname.toLowerCase().replace(/^\[|\]$/g, "");
-  return (
-    h === "localhost" ||
-    h === "::1" ||
-    h === "0:0:0:0:0:0:0:1" ||
-    /^127(?:\.\d{1,3}){3}$/.test(h) ||
-    // Wildcard hosts reach a local listener when dialed (0.0.0.0 / ::), so
-    // they count as local for both the refresh-channel and pairing guards.
-    h === "0.0.0.0" ||
-    h === "0" ||
-    h === "::" ||
-    h === "0:0:0:0:0:0:0:0" ||
-    // IPv4-mapped loopback and wildcard, in dotted and hex encodings.
-    /^(?:0:0:0:0:0|:):ffff:127(?:\.\d{1,3}){3}$/.test(h) ||
-    /^(?:0:0:0:0:0|:):ffff:7f[0-9a-f]{2}:[0-9a-f]{1,4}$/.test(h) ||
-    /^(?:0:0:0:0:0|:):ffff:0\.0\.0\.0$/.test(h) ||
-    /^(?:0:0:0:0:0|:):ffff:0:0$/.test(h)
-  );
-}
-
 export function isConfidentialRefreshUrl(gatewayUrl: string): boolean {
   try {
-    const url = new URL(gatewayUrl);
-    return url.protocol === "https:" || isLoopbackHostname(url.hostname);
+    return (
+      new URL(gatewayUrl).protocol === "https:" || isLoopbackUrl(gatewayUrl)
+    );
   } catch {
     return false;
   }
 }
 
-/** Whether a URL's host is loopback; false for unparseable URLs. */
+/**
+ * Whether a URL's host is loopback; false for unparseable URLs. Delegates to
+ * the shared pairing predicate so this package's guards and the address checks
+ * in `@vellumai/service-contracts` judge a host by the same rules.
+ */
 export function isLoopbackUrl(url: string): boolean {
-  try {
-    return isLoopbackHostname(new URL(url).hostname);
-  } catch {
-    return false;
-  }
+  return isLoopbackPublicUrl(url);
 }
 
 function isAccessTokenExpired(data: GuardianTokenData): boolean {

--- a/packages/local-mode/src/pair.ts
+++ b/packages/local-mode/src/pair.ts
@@ -93,14 +93,28 @@ export type PairRefusal = Extract<PairResult, { ok: false }>;
 
 /**
  * The local id a pairing registers under: a `--name` slug, or
- * `paired-<deviceId>` (deviceId is unique per pairing). Never the remote
- * assistantId, which is typically "self" and would collide across hosts. The
- * deviceId may be untrusted and is used as a path component by
- * `saveGuardianToken`, so it MUST be slugified (no `../` traversal); it falls
- * back to a random id when it sanitizes to empty.
+ * `paired-<gateway host>`. The HOST keys the default because it is what stays
+ * the same across re-pairings of one assistant, so a second pairing lands on
+ * the existing entry instead of adding another; the device id is minted fresh
+ * per attempt and would strand every previous pairing in the lockfile. Never
+ * the remote assistantId, which is typically "self" and would collide across
+ * hosts.
+ *
+ * The id is a path component for `saveGuardianToken`, so it is always
+ * slugified (no `../` traversal) and falls back to a random id when it
+ * sanitizes to empty.
  */
-function derivePairedAssistantId(name?: string, deviceId?: string): string {
-  return name ? slugify(name) : `paired-${slugify(deviceId ?? "") || nanoid()}`;
+function derivePairedAssistantId(name?: string, gatewayUrl?: string): string {
+  if (name) {
+    return slugify(name);
+  }
+  let host = "";
+  try {
+    host = new URL(gatewayUrl ?? "").host;
+  } catch {
+    /* an unparseable URL names no host, so the random id below applies */
+  }
+  return `paired-${slugify(host) || nanoid()}`;
 }
 
 /** The raw lockfile entry already holding `localId`, if any. */
@@ -145,25 +159,48 @@ function refusePairedAssistantId(
   return null;
 }
 
+/** Where a pairing would land locally, and whether it may. */
+interface PairedDestination {
+  localId: string;
+  /** The raw lockfile entry already holding `localId`, if any. */
+  existing: Record<string, unknown> | undefined;
+  /** Why the id cannot be used, or null when it is free. */
+  refusal: PairRefusal | null;
+}
+
+/**
+ * The single derivation-plus-refusal every pairing caller runs, so a
+ * pre-check and the registration it precedes cannot drift apart.
+ *
+ * A pre-check is not a reservation: another process can claim the id in
+ * between. It closes the common case; the check inside `pairAssistant` is
+ * still what guarantees the id.
+ */
+function resolvePairedDestination(
+  lockfilePaths: string[],
+  name: string | undefined,
+  gatewayUrl?: string,
+): PairedDestination {
+  const localId = derivePairedAssistantId(name, gatewayUrl);
+  const existing = findRawAssistant(lockfilePaths, localId);
+  return {
+    localId,
+    existing,
+    refusal: refusePairedAssistantId(localId, existing),
+  };
+}
+
 /**
  * The refusal {@link pairAssistant} would return for a `--name`, or null when
  * the name is usable. Lets a caller reject a colliding name BEFORE spending a
  * one-time pairing code, which the gateway records a device for even when the
  * local write then fails.
- *
- * This is a pre-check, not a reservation: another process can claim the id
- * between here and the import. It closes the common case; the real check
- * inside `pairAssistant` is still what guarantees the id.
  */
 export function checkPairedAssistantName(
   lockfilePaths: string[],
   name: string,
 ): PairRefusal | null {
-  const localId = derivePairedAssistantId(name);
-  return refusePairedAssistantId(
-    localId,
-    findRawAssistant(lockfilePaths, localId),
-  );
+  return resolvePairedDestination(lockfilePaths, name).refusal;
 }
 
 /**
@@ -203,13 +240,15 @@ export function pairAssistant(
       status: 422,
       error:
         "A paired assistant needs a non-loopback gateway URL; run `vellum pair` " +
-        "with --url pointing at a tunnel or LAN address.",
+        "with --url pointing at a tunnel or public https address.",
     };
   }
 
-  const localId = derivePairedAssistantId(name, credentials.deviceId);
-  const existing = findRawAssistant(lockfilePaths, localId);
-  const refusal = refusePairedAssistantId(localId, existing);
+  const { localId, existing, refusal } = resolvePairedDestination(
+    lockfilePaths,
+    name,
+    credentials.gatewayUrl,
+  );
   if (refusal) {
     return refusal;
   }
@@ -322,6 +361,15 @@ const MAX_PAIRING_ADDRESS_LENGTH = 2 * 1024;
 
 /** Poll cadence used until the gateway names its own. */
 const DEFAULT_PAIRING_POLL_INTERVAL_SECONDS = 5;
+
+/**
+ * Caps the cadence the assistant at a pasted address may set. That address is
+ * untrusted and callers turn the cadence straight into a wait, so an absurd
+ * interval parks the attempt forever, and one past `2**31-1` ms overflows a
+ * `setTimeout` into a tight loop against that host. The gateway's own cadence
+ * is 5s, so this is generous.
+ */
+const MAX_PAIRING_POLL_INTERVAL_SECONDS = 60;
 
 /** Caps how long a single pairing request may occupy the caller. */
 const PAIRING_REQUEST_TIMEOUT_MS = 15_000;
@@ -728,7 +776,11 @@ function usableRefreshExpiry(value: unknown): value is string | number {
   return Number.isFinite(parsed) && parsed > 0;
 }
 
-/** An ISO instant as epoch ms, or `fallback` when it isn't one. */
+/**
+ * An ISO instant as epoch ms, or `fallback` when it isn't one. `Date.parse`
+ * answers NaN for an unparseable or out-of-range date, so the result is always
+ * a real instant; how far out it may sit is the caller's to bound.
+ */
 function instantMs(value: unknown, fallback: number): number {
   if (typeof value !== "string") {
     return fallback;
@@ -737,8 +789,27 @@ function instantMs(value: unknown, fallback: number): number {
   return Number.isFinite(parsed) ? parsed : fallback;
 }
 
+/**
+ * A session deadline the remote named, which may only move EARLIER than
+ * `ceilingMs`. A remote that keeps reporting a fresh expiry would otherwise
+ * hold a session open indefinitely, on its own TTL rather than the one the
+ * pairing code was minted with.
+ */
+function clampedDeadlineMs(value: unknown, ceilingMs: number): number {
+  return Math.min(instantMs(value, ceilingMs), ceilingMs);
+}
+
+/**
+ * A remote-named cadence in seconds, capped at
+ * {@link MAX_PAIRING_POLL_INTERVAL_SECONDS}. Non-finite values fall back:
+ * JSON.parse reads `1e400` as Infinity, which a caller turns into a wait that
+ * never ends or a timeout that overflows and fires immediately.
+ */
 function positiveSeconds(value: unknown, fallback: number): number {
-  return typeof value === "number" && value > 0 ? value : fallback;
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return fallback;
+  }
+  return Math.min(value, MAX_PAIRING_POLL_INTERVAL_SECONDS);
 }
 
 function openPairingSession(
@@ -828,7 +899,10 @@ export async function pairingStart(
       publicBaseUrl: parsed.publicBaseUrl,
       deviceCode: challenge.deviceCode,
       deviceId,
-      expiresAtMs: instantMs(
+      // A challenge expires somewhere inside the code's own TTL, so that TTL
+      // is the ceiling: a remote naming a further instant cannot buy itself a
+      // longer-lived session.
+      expiresAtMs: clampedDeadlineMs(
         challenge.expiresAt,
         Date.now() + REMOTE_WEB_PAIRING_CODE_TTL_MS,
       ),
@@ -875,6 +949,27 @@ export async function pairingPoll(
     return expiredCode();
   }
 
+  const localName = typeof name === "string" && name ? name : undefined;
+  // Refuse a destination this machine cannot register BEFORE the exchange.
+  // The device code is one-time and the gateway records a device the moment it
+  // is spent, so a collision found after the exchange burns the code and costs
+  // the user a fresh pairing link. Nothing is spent here: the code is
+  // untouched and the session stays pollable, so correcting the name and
+  // polling again completes the same attempt.
+  const { refusal } = resolvePairedDestination(
+    lockfilePaths,
+    localName,
+    session.publicBaseUrl,
+  );
+  if (refusal) {
+    return {
+      ok: false,
+      reason: "import",
+      status: refusal.status,
+      error: refusal.error,
+    };
+  }
+
   const posted = await postPairingRequest(
     session.publicBaseUrl,
     PAIRING_TOKEN_PATH,
@@ -909,7 +1004,10 @@ export async function pairingPoll(
   if (posted.status === 202) {
     const pending =
       posted.body as Partial<RemoteWebPairingTokenPendingResponse> | null;
-    session.expiresAtMs = instantMs(pending?.expiresAt, session.expiresAtMs);
+    session.expiresAtMs = clampedDeadlineMs(
+      pending?.expiresAt,
+      session.expiresAtMs,
+    );
     session.intervalSeconds = positiveSeconds(
       pending?.intervalSeconds,
       session.intervalSeconds,
@@ -956,7 +1054,7 @@ export async function pairingPoll(
       refreshTokenExpiresAt: approved.refreshTokenExpiresAt,
       refreshAfter: approved.refreshAfter,
     },
-    name: typeof name === "string" && name ? name : undefined,
+    name: localName,
   });
   if (!result.ok) {
     return {
@@ -1001,9 +1099,12 @@ export function pairingCancel(handle: unknown): boolean {
 
 // ── Legacy base64 bundle import ─────────────────────────────────────────────
 //
-// The pre-pairing-link import path, still reached by the Electron IPC channel,
-// the CLI dev-server route, and the Vite middleware. It shares `pairAssistant`
-// with the pairing-session flow above and adds only base64 decoding.
+// The pre-pairing-link import path. Its one caller is `vellum connect import`
+// (cli/src/commands/connect/import.ts), which falls back to it for a bundle
+// minted by a host on the previous release; nothing mints bundles any more, so
+// this section goes once that release is out of support. It shares
+// `pairAssistant` with the pairing-session flow above and adds only base64
+// decoding.
 
 /** Bounds what an untrusted bundle import can make a host buffer and decode. */
 const MAX_BUNDLE_LENGTH = 64 * 1024;

--- a/packages/service-contracts/src/__tests__/remote-web-pairing.test.ts
+++ b/packages/service-contracts/src/__tests__/remote-web-pairing.test.ts
@@ -150,7 +150,6 @@ describe("resolvePublicBaseUrl private-address containment", () => {
   });
 
   test.each([
-    "https://0.0.0.0",
     "https://10.0.0.1",
     "https://169.254.169.254",
     "https://172.20.3.4",
@@ -163,6 +162,22 @@ describe("resolvePublicBaseUrl private-address containment", () => {
     expect(resolvePublicBaseUrl(raw)).toEqual({
       ok: false,
       reason: "private-address",
+    });
+  });
+
+  // A wildcard bind reaches a listener on the machine that dials it, so it
+  // gets the more specific loopback reason and the "points back at this
+  // machine" guidance that goes with it.
+  test.each([
+    ["https://0.0.0.0", "IPv4 wildcard"],
+    ["https://[::]", "IPv6 wildcard"],
+    ["https://[::ffff:0.0.0.0]", "IPv4-mapped wildcard"],
+    ["https://[::ffff:127.0.0.1]", "IPv4-mapped loopback"],
+  ])("reports %s (%s) as loopback", (raw) => {
+    expect(isLoopbackPublicUrl(raw)).toBe(true);
+    expect(resolvePublicBaseUrl(raw)).toEqual({
+      ok: false,
+      reason: "loopback",
     });
   });
 

--- a/packages/service-contracts/src/remote-web-pairing.ts
+++ b/packages/service-contracts/src/remote-web-pairing.ts
@@ -314,24 +314,46 @@ export function tunnelProviderWebsiteName(url: string): string | null {
 }
 
 /**
- * A loopback URL: the whole reserved `localhost` namespace (RFC 6761, so
- * `foo.localhost` counts), `[::1]`, or `127.x.x.x`. A pairing link that encodes
- * a loopback address is unreachable from the scanning device, and a host that
- * POSTs to one is calling a service on its own machine.
+ * A URL that reaches a listener on the machine dialing it: the whole reserved
+ * `localhost` namespace (RFC 6761, so `foo.localhost` counts), `127.x.x.x`,
+ * `[::1]`, and the wildcard binds `0.0.0.0` / `[::]`, in their dotted, hex,
+ * and IPv4-mapped spellings. A pairing link that encodes one is unreachable
+ * from the scanning device, and a host that POSTs to one is calling a service
+ * on its own machine.
+ *
+ * This is the one loopback predicate the whole pairing path reads (the pasted
+ * address, and the gatewayUrl an import registers), so the same address class
+ * can never be refused by one entry point and accepted by another.
  */
 export function isLoopbackPublicUrl(url: string): boolean {
+  let hostname: string;
   try {
-    // WHATWG URL canonicalizes hostnames, so IPv6 loopback is always "[::1]".
-    const hostname = hostnameWithoutRootDot(new URL(url).hostname);
-    return (
-      hostname === "localhost" ||
-      hostname.endsWith(".localhost") ||
-      hostname === "[::1]" ||
-      /^127(?:\.\d{1,3}){3}$/.test(hostname)
-    );
+    // WHATWG URL canonicalizes hostnames: IPv6 loopback is always "[::1]", a
+    // bare "0" is "0.0.0.0", and encoded IPv4 literals become dotted quads.
+    hostname = hostnameWithoutRootDot(new URL(url).hostname);
   } catch {
     return false;
   }
+  // Strip URL brackets so IPv6 literals compare on the bare address.
+  const host = hostname.replace(/^\[|\]$/g, "");
+  return (
+    host === "localhost" ||
+    host.endsWith(".localhost") ||
+    host === "::1" ||
+    host === "0:0:0:0:0:0:0:1" ||
+    /^127(?:\.\d{1,3}){3}$/.test(host) ||
+    // A wildcard host reaches a local listener when dialed, so it counts as
+    // local for the pairing and refresh-channel guards alike.
+    host === "0.0.0.0" ||
+    host === "0" ||
+    host === "::" ||
+    host === "0:0:0:0:0:0:0:0" ||
+    // IPv4-mapped loopback and wildcard, in dotted and hex encodings.
+    /^(?:0:0:0:0:0|:):ffff:127(?:\.\d{1,3}){3}$/.test(host) ||
+    /^(?:0:0:0:0:0|:):ffff:7f[0-9a-f]{2}:[0-9a-f]{1,4}$/.test(host) ||
+    /^(?:0:0:0:0:0|:):ffff:0\.0\.0\.0$/.test(host) ||
+    /^(?:0:0:0:0:0|:):ffff:0:0$/.test(host)
+  );
 }
 
 /** Canonical dotted-quad as its four octets, or null when it is not one. */


### PR DESCRIPTION
## Summary
- Clamps the poll interval and the session deadline so a hostile or broken assistant cannot hang an attempt or spin it into a tight loop.
- Checks the destination name before the exchange, so a collision no longer spends the one-time device code.
- Keys the default paired id on the assistant's address, so re-pairing updates the entry instead of accumulating a duplicate.
- Unifies the two divergent loopback predicates and corrects advice that now always fails.

Found by self-review of plan zesty-wandering-nygaard.md.