### PR TITLE
docs(cli): correct the connect import default-id help text

### DIFF
--- a/cli/src/commands/connect/import.ts
+++ b/cli/src/commands/connect/import.ts
@@ -51,8 +51,9 @@ ARGUMENTS:
 
 OPTIONS:
     --name <name>   Local name to register the assistant under, slugified for
-                    the id (default: paired-<deviceId>). An existing local
-                    assistant of that name is never overwritten.
+                    the id (default: paired-<assistant host>). An existing
+                    local assistant of that name is never overwritten;
+                    re-importing the same host updates its entry.
 
 EXAMPLES:
     vellum connect import "https://your-assistant.ts.net/assistant/pair#device_code=abc123"


### PR DESCRIPTION
## Summary
- `vellum connect import --help` still documented the default local id as `paired-<deviceId>`. It is now derived from the assistant's host, so the old text described a scheme that no longer exists.
- Also notes that re-importing the same host updates its entry rather than adding a second one, which is the behavior change that made the old text wrong.

Found by self-review of plan zesty-wandering-nygaard.md.