### PR TITLE
fix(web): release the signup guard when a native auth flow is cancelled

### DIFF
--- a/clients/android/app/src/main/java/ai/vellum/assistant/InstallReferrerPlugin.java
+++ b/clients/android/app/src/main/java/ai/vellum/assistant/InstallReferrerPlugin.java
@@ -15,6 +15,7 @@ import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Exposes the Play Store install referrer, the only attribution a Play install
@@ -45,20 +46,24 @@ public class InstallReferrerPlugin extends Plugin {
             return;
         }
 
-        final InstallReferrerClient client = InstallReferrerClient.newBuilder(getContext()).build();
         // One connection can fire both setup-finished and service-disconnected,
         // and a call resolves once.
         final AtomicBoolean answered = new AtomicBoolean();
+        // The timeout is armed before the client is built, so a build that
+        // throws or hangs still leaves something to answer the call.
+        final AtomicReference<InstallReferrerClient> clientRef = new AtomicReference<>();
         final Handler timeoutHandler = new Handler(Looper.getMainLooper());
         timeoutHandler.postDelayed(
             () -> {
                 if (!answered.getAndSet(true)) {
-                    finish(client, call, new JSObject(), timeoutHandler);
+                    finish(clientRef.get(), call, new JSObject(), timeoutHandler);
                 }
             },
             BIND_TIMEOUT_MS
         );
         try {
+            final InstallReferrerClient client = InstallReferrerClient.newBuilder(getContext()).build();
+            clientRef.set(client);
             client.startConnection(
                 new InstallReferrerStateListener() {
                     @Override
@@ -66,13 +71,21 @@ public class InstallReferrerPlugin extends Plugin {
                         if (answered.getAndSet(true)) {
                             return;
                         }
+                        // The single-resolve guard is spent, so only this
+                        // branch can answer. Capacitor turns a throw here into
+                        // a log, never a rejection.
                         JSObject result = new JSObject();
-                        if (responseCode == InstallReferrerClient.InstallReferrerResponse.OK) {
-                            result = readReferrer(client);
-                        } else if (isTerminalStatus(responseCode)) {
-                            cache("");
+                        try {
+                            if (responseCode == InstallReferrerClient.InstallReferrerResponse.OK) {
+                                result = readReferrer(client);
+                            } else if (isTerminalStatus(responseCode)) {
+                                cache("");
+                            }
+                        } catch (RuntimeException exception) {
+                            Logger.error("Unable to resolve the Play install referrer", exception);
+                        } finally {
+                            finish(client, call, result, timeoutHandler);
                         }
-                        finish(client, call, result, timeoutHandler);
                     }
 
                     @Override
@@ -86,7 +99,7 @@ public class InstallReferrerPlugin extends Plugin {
         } catch (RuntimeException exception) {
             Logger.error("Unable to bind the Play install referrer service", exception);
             if (!answered.getAndSet(true)) {
-                finish(client, call, new JSObject(), timeoutHandler);
+                finish(clientRef.get(), call, new JSObject(), timeoutHandler);
             }
         }
     }
@@ -104,22 +117,26 @@ public class InstallReferrerPlugin extends Plugin {
     }
 
     private JSObject readReferrer(InstallReferrerClient client) {
-        ReferrerDetails details;
+        String referrer;
         try {
-            details = client.getInstallReferrer();
+            // A malfunctioning Play Store can hand back a null bundle.
+            ReferrerDetails details = client.getInstallReferrer();
+            referrer = details.getInstallReferrer();
         } catch (RemoteException | RuntimeException exception) {
             Logger.error("Unable to read the Play install referrer", exception);
             return new JSObject();
         }
-        String referrer = details.getInstallReferrer();
         cache(referrer);
         return payload(referrer);
     }
 
+    /** Resolves the call whatever happened, so nothing leaves it pending. */
     private void finish(InstallReferrerClient client, PluginCall call, JSObject result, Handler timeoutHandler) {
-        timeoutHandler.removeCallbacksAndMessages(null);
         try {
-            client.endConnection();
+            timeoutHandler.removeCallbacksAndMessages(null);
+            if (client != null) {
+                client.endConnection();
+            }
         } catch (RuntimeException exception) {
             Logger.error("Unable to close the Play install referrer connection", exception);
         }

--- a/clients/web/src/domains/account/components/signup-screen.test.tsx
+++ b/clients/web/src/domains/account/components/signup-screen.test.tsx
@@ -1,7 +1,7 @@
 /**
- * The sign-up screen's handoff to AuthKit: one flow at a time, and a failure
- * that hands the screen back. The handoff is not instant, so a second
- * activation would otherwise replace the flow already running, which the
+ * The sign-up screen's handoff to AuthKit: one flow at a time, and a screen
+ * handed back however that flow settles. The handoff is not instant, so a
+ * second activation would otherwise replace the flow already running, which the
  * native plugin rejects as a failure the user never caused.
  */
 
@@ -16,14 +16,17 @@ import {
 
 import * as nativeAuth from "@/runtime/native-auth";
 
-/** Rejecters for the flows started so far, so each one stays pending. */
-const startedFlows: ((err: unknown) => void)[] = [];
+/** Settlers for the flows started so far, so each one stays pending. */
+const startedFlows: {
+  resolve: () => void;
+  reject: (err: unknown) => void;
+}[] = [];
 
 mock.module("@/runtime/native-auth", (): typeof nativeAuth => ({
   ...nativeAuth,
   startAuthFlow: () =>
-    new Promise<void>((_resolve, reject) => {
-      startedFlows.push(reject);
+    new Promise<void>((resolve, reject) => {
+      startedFlows.push({ resolve, reject });
     }),
 }));
 
@@ -71,7 +74,7 @@ describe("SignupScreen auth handoff", () => {
 
   test("a failed handoff hands the screen back", async () => {
     fireEvent.click(screen.getByText("Continue"));
-    startedFlows[0]?.(new Error("handoff refused"));
+    startedFlows[0]?.reject(new Error("handoff refused"));
 
     await waitFor(() => {
       expect(screen.getByText(GENERIC_FAILURE)).toBeTruthy();
@@ -82,5 +85,22 @@ describe("SignupScreen auth handoff", () => {
 
     expect(startedFlows).toHaveLength(2);
     expect(screen.queryByText(GENERIC_FAILURE)).toBeNull();
+  });
+
+  test("a dismissed auth sheet hands the screen back", async () => {
+    fireEvent.click(screen.getByText("Continue"));
+    // A native cancellation is swallowed, so the flow resolves with the screen
+    // still up and nothing to report.
+    startedFlows[0]?.resolve();
+
+    await waitFor(() => {
+      expect(continueButton()?.disabled).toBe(false);
+    });
+    expect(signInButton()?.disabled).toBe(false);
+    expect(screen.queryByText(GENERIC_FAILURE)).toBeNull();
+
+    fireEvent.click(screen.getByText("Continue"));
+
+    expect(startedFlows).toHaveLength(2);
   });
 });

--- a/clients/web/src/domains/account/components/signup-screen.tsx
+++ b/clients/web/src/domains/account/components/signup-screen.tsx
@@ -45,11 +45,14 @@ export function SignupScreen({ returnTo }: SignupScreenProps) {
   const [pending, setPending] = useState(false);
 
   /**
-   * Hand off to AuthKit, holding the screen's controls until the flow lands. A
-   * native start resolves the flow's marketing attribution before the browser
+   * Hand off to AuthKit, holding the screen's controls until the flow settles.
+   * A native start resolves the flow's marketing attribution before the browser
    * auth surface opens, and a second start inside that gap replaces the first,
-   * which the plugin rejects as a failure the user never caused. A rejection
-   * hands the screen back.
+   * which the plugin rejects as a failure the user never caused.
+   *
+   * The controls come back however it settles. A flow that reached an account
+   * is already navigating away, and a dismissed auth sheet resolves with the
+   * screen still up, where these are the only controls on it.
    */
   const startFlow = (intent: "signup" | undefined, logLabel: string) => {
     setError(null);
@@ -58,11 +61,14 @@ export function SignupScreen({ returnTo }: SignupScreenProps) {
       PROVIDER_ID,
       buildProviderCallbackUrl(returnTo, { authIntent: intent }),
       { returnTo, intent },
-    ).catch((err) => {
-      console.error(logLabel, err);
-      setError(t("authErrors.genericFailure"));
-      setPending(false);
-    });
+    )
+      .catch((err) => {
+        console.error(logLabel, err);
+        setError(t("authErrors.genericFailure"));
+      })
+      .finally(() => {
+        setPending(false);
+      });
   };
 
   const start = () => {

--- a/clients/web/src/runtime/install-referrer.test.ts
+++ b/clients/web/src/runtime/install-referrer.test.ts
@@ -8,6 +8,7 @@ mock.module("@capacitor/core", () => ({
   registerPlugin: () => ({ read }),
 }));
 
+const { clearUserScopedStorage } = await import("@/lib/auth/session-cleanup");
 const { captureInstallReferrer, markInstallReferrerSpent } =
   await import("./install-referrer");
 
@@ -116,6 +117,21 @@ test("a spend does not re-arm the bridge", async () => {
   markInstallReferrerSpent();
   expect(localStorage.getItem(STORAGE_KEY)).toBe("");
 
+  read.mockResolvedValue({ referrer: "utm_source=newsletter" });
+  expect(await captureInstallReferrer()).toEqual({});
+  expect(read).toHaveBeenCalledTimes(1);
+});
+
+test("a logout leaves the spend record standing", async () => {
+  // The record is the emptied key itself, so a logout that swept device-scoped
+  // storage by value would re-arm the bridge for whoever signs in next.
+  read.mockResolvedValueOnce({ referrer: "utm_source=newsletter" });
+  await captureInstallReferrer();
+  markInstallReferrerSpent();
+
+  clearUserScopedStorage();
+
+  expect(localStorage.getItem(STORAGE_KEY)).toBe("");
   read.mockResolvedValue({ referrer: "utm_source=newsletter" });
   expect(await captureInstallReferrer()).toEqual({});
   expect(read).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
Three gaps from a third round of plan self-review.

## 1. The signup screen's pending guard never released on cancel (user-facing regression)

`SignupScreen.startFlow` set `pending` and cleared it only inside `.catch`. But `startAuthFlow` deliberately swallows `USER_CANCELLED` and **resolves** on the native path, and that path does not navigate. A user who tapped "Continue" (or "Sign in") on iOS or Android and then dismissed the AuthKit sheet was left with the CTA and the "Sign in" link both `disabled`, no error shown, and no other control on the screen. Stranded until they killed the app. Before the guard existed a cancel simply returned them to a working screen, so this was strictly a regression.

The fix releases the guard when the flow **settles**, via `.finally`, rather than only when it rejects.

Why that over making cancellation observable (a sentinel return from `startAuthFlow`): a sentinel changes a shared function's contract for one caller's benefit, and it would only cover cancellation. Resolving without navigating is not unique to cancellation. The Electron branch also resolves without navigating whenever `startOAuth` comes back with no `sessionToken`. Releasing on settle covers every such path at once, and clearing `pending` on the paths that *do* navigate is harmless because they are already unloading the page.

`signup-screen.test.tsx` previously exercised only the rejection path, which is why this slipped through. It now covers a flow that resolves with no navigation, and the mock hands back both settlers rather than just a rejecter.

## 2. The Android plugin could leave the JS promise unsettled

`InstallReferrerPlugin.read` had three escapes, and Capacitor converts none of them into a rejection: `Bridge.callPluginMethod` logs "Serious error executing plugin" and rethrows on the plugin task thread, so the JS promise never settles. With gap 1's guard, an unsettled promise also froze the signup screen.

- `onInstallReferrerSetupFinished` spent the single-resolve `AtomicBoolean` **before** doing the work, so anything that threw in between left the timeout runnable inert and `call.resolve` unreached. The body is now wrapped so `finish(...)` runs in a `finally`.
- `details.getInstallReferrer()` sat outside the `try` guarding `client.getInstallReferrer()`. A null bundle from a malfunctioning Play Store NPE'd there. It now sits inside.
- `InstallReferrerClient.newBuilder(getContext()).build()` sat before both the `postDelayed` and the `try`, so a builder failure escaped the method entirely. The timeout is now armed first and the build happens inside the outer `try`, so a build that throws **or hangs** still has something to answer the call. `finish` tolerates a null client for that window.

The single-resolve guard and the `endConnection()`-on-every-path behavior are preserved, and neither a timeout nor an error is cached as resolved.

## 3. Restored the test for the invariant the spend record rests on

The spend is recorded by **emptying** `device:install_referrer`, and `captureInstallReferrer` gates on key *presence*, so if logout ever swept empty `device:` values the bridge would silently re-arm for the next user on the device. An earlier round covered that in `session-cleanup.test.ts`; a later round deleted it as redundant with two prefix tests, leaving the contract enforced by nothing.

Coverage is restored in `install-referrer.test.ts` instead, where it reads as the real contract rather than a restatement of the prefix rule: capture, spend, `clearUserScopedStorage()`, then assert the key survives empty and a further capture neither returns attribution nor re-reads the bridge.