### PR TITLE
fix(assistant): commit live-voice turns on Flux's own end-of-turn by default

### DIFF
--- a/assistant/src/__tests__/config-schema.test.ts
+++ b/assistant/src/__tests__/config-schema.test.ts
@@ -959,7 +959,7 @@ describe("AssistantConfigSchema", () => {
         },
       },
       flux: {
-        turnEnd: { enabled: false },
+        turnEnd: { enabled: true },
         eotThreshold: 0.7,
         eotTimeoutMs: 5000,
       },
@@ -988,7 +988,7 @@ describe("AssistantConfigSchema", () => {
     expect(result.liveVoice.vad.maxTurnDurationMs).toBe(30000);
     expect(result.liveVoice.maxSessionDurationSeconds).toBe(900);
     // A partial liveVoice override leaves Flux turn-end disabled by default.
-    expect(result.liveVoice.flux.turnEnd.enabled).toBe(false);
+    expect(result.liveVoice.flux.turnEnd.enabled).toBe(true);
   });
 
   test("accepts a liveVoice.vad.bargeInMinSpeechMs of 0 (guard disabled)", () => {

--- a/assistant/src/config/schemas/__tests__/live-voice.test.ts
+++ b/assistant/src/config/schemas/__tests__/live-voice.test.ts
@@ -30,7 +30,7 @@ const FRONT_MODEL_DEFAULTS = {
 // is absent for a related reason: unset means the spoken language selects the
 // model, and pinning one overrides that.
 const FLUX_DEFAULTS = {
-  turnEnd: { enabled: false },
+  turnEnd: { enabled: true },
   eotThreshold: 0.7,
   eotTimeoutMs: 5_000,
 };
@@ -230,7 +230,7 @@ describe("LiveVoiceFrontModelConfigSchema", () => {
 });
 
 describe("LiveVoiceFluxConfigSchema", () => {
-  test("empty object parses to defaults, with turn-end off", () => {
+  test("empty object parses to defaults, with turn-end on", () => {
     expect(LiveVoiceFluxConfigSchema.parse({})).toEqual(FLUX_DEFAULTS);
   });
 
@@ -258,7 +258,7 @@ describe("LiveVoiceFluxConfigSchema", () => {
   test("partial overrides merge with defaults", () => {
     const parsed = LiveVoiceFluxConfigSchema.parse({ eotThreshold: 0.6 });
     expect(parsed.eotThreshold).toBe(0.6);
-    expect(parsed.turnEnd.enabled).toBe(false);
+    expect(parsed.turnEnd.enabled).toBe(true);
     expect(parsed.model).toBeUndefined();
     expect(parsed.eotTimeoutMs).toBe(5_000);
   });

--- a/assistant/src/config/schemas/live-voice.ts
+++ b/assistant/src/config/schemas/live-voice.ts
@@ -219,7 +219,14 @@ const LiveVoiceFluxTurnEndConfigSchema = z
   .object({
     enabled: z
       .boolean({ error: "liveVoice.flux.turnEnd.enabled must be a boolean" })
-      .default(false)
+      // On by default because it is the only reason to select Flux, and
+      // because off is not a neutral setting on this provider: managed Flux
+      // exposes no `finalizeUtterance` (Flux commits turns itself), so the
+      // session's persistence check falls through and it opens a socket per
+      // utterance, putting a full Deepgram handshake on every turn. Ignored
+      // by any provider that does not own its turn boundary, so the default
+      // reaches only the sessions it is about.
+      .default(true)
       .describe(
         "Commit the live-voice turn on Flux's EndOfTurn instead of the front-door [0] hold verdict. Requires the active STT provider to be running the flux model family (services.stt.providers.<provider>.model); ignored otherwise.",
       ),

--- a/assistant/src/live-voice/__tests__/live-voice-flux-turn-end.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-flux-turn-end.test.ts
@@ -277,6 +277,13 @@ const FLUX_ON = {
   eotTimeoutMs: 500,
 } as const satisfies Partial<LiveVoiceFluxConfig>;
 
+// Turn-end is on by schema default, so a session that must run the local
+// silence boundary has to say so. Naming it keeps those tests about the
+// boundary they exercise rather than about a default they no longer own.
+const FLUX_OFF = {
+  turnEnd: { enabled: false },
+} as const satisfies Partial<LiveVoiceFluxConfig>;
+
 describe("LiveVoiceSession Flux end-of-turn", () => {
   test("commits the turn on turn-end without an endpoint-decision leg", async () => {
     const { frames, session, transcribers, turnCalls } = createHarness({
@@ -331,6 +338,7 @@ describe("LiveVoiceSession Flux end-of-turn", () => {
 
   test("ignores turn-end when the flag is off and keeps the hold path", async () => {
     const { frames, session, transcribers, turnCalls } = createHarness({
+      fluxConfig: FLUX_OFF,
       startVoiceTurn: autoCompletingTurn(),
     });
 
@@ -420,8 +428,9 @@ describe("LiveVoiceSession Flux end-of-turn", () => {
 
   test("records the commit latency on the front-door path too, with no hold", async () => {
     const { frames, session, transcribers, turnCalls } = createHarness({
-      // No flux config: the latch is down and the local silence boundary owns
+      // Turn-end off: the latch is down and the local silence boundary owns
       // the commit, which is arm A of the measurement run.
+      fluxConfig: FLUX_OFF,
       silenceThresholdMs: 40,
       emitMetrics: true,
       startVoiceTurn: autoCompletingTurn(),
@@ -960,8 +969,8 @@ describe("LiveVoiceSession Flux end-of-turn during the STT dial", () => {
   test("never seeds the latch when the flag is off", async () => {
     const gate = createDialGate();
     const { frames, session, transcribers, turnCalls } = createHarness({
-      // No fluxConfig: `turnEnd.enabled` keeps its schema default of false
-      // while config still selects the flux model family.
+      // Turn-end explicitly off while config still selects the flux family.
+      fluxConfig: FLUX_OFF,
       silenceThresholdMs: 40,
       resolveGate: gate.promise,
       startVoiceTurn: autoCompletingTurn(),

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -362,7 +362,8 @@ export interface LiveVoiceSessionOptions {
   /**
    * Deepgram Flux turn-detection tuning. The production factory seeds this
    * from `liveVoice.flux` config when unset; absent fields fall back to the
-   * schema defaults, which leave `turnEnd.enabled` false.
+   * schema defaults, which leave `turnEnd.enabled` on. A test that needs the
+   * local silence boundary has to say so.
    */
   fluxConfig?: Partial<LiveVoiceFluxConfig>;
   /**


### PR DESCRIPTION
Top of the JARVIS-1640 stack (#41402 → #41476 → #41477 → this). GitHub retargets it as each base merges.

## Why this is the fix for JARVIS-1642

1642 was filed as "native Flux relay sessions die `upstream_error` after a few seconds." They were not dying. They were being closed, once per utterance, by us.

Managed Flux deliberately exposes no `finalizeUtterance` (Flux commits turns itself), so the live-voice session's persistence check

```ts
this.turnDetector && (typeof transcriber.finalizeUtterance === "function" || this.providerTurnEndActive)
```

rests entirely on `providerTurnEndActive`, which this flag gates. With the flag off it fell through, so each utterance got its own socket: dial, speak, `stop()`, which sends `CloseStream`, and Flux flushes and closes. The bare 1005 with no reason that velay logged was Flux answering our own request.

The comment three lines above that condition predicted the cost exactly: *"costs a socket per utterance, which drops the audio that arrives while the next one dials."*

## Measured

One conversation, nine replies over 43s, before and after flipping the flag on a live assistant:

| STT session | audio | |
| --- | --- | --- |
| 12:34:22 | 1.9s | flag off |
| 12:50:40 | 3.3s | flag off |
| 12:50:58 | 13.2s | flag off |
| **13:01:59** | **67.0s** | **flag on** |

One stream for the whole conversation instead of one per utterance, and the multi-second per-turn latency goes with it.

## Blast radius

The flag is ignored by any provider that does not own its turn boundary (`supportsProviderTurnDetection`), so the default reaches only Flux sessions. Flux itself remains opt-in, and anyone who selected it did so for turn detection, which the old default was working against.

## Tests

Three tests asserted the old default. They now name it explicitly through a `FLUX_OFF` constant, so they stay about the local silence boundary they exercise rather than about a default they no longer own. Schema-default assertions updated in `live-voice.test.ts` and `config-schema.test.ts`.

The matching velay change (classifying a client-requested close as `completed` rather than `upstream_error`) is a separate platform PR.

Closes JARVIS-1642

🤖 Generated with [Claude Code](https://claude.com/claude-code)