### PR TITLE
Give every Contacts channel row a live action

### DIFF
--- a/clients/web/src/domains/contacts/components/assistant-channels-detail.test.tsx
+++ b/clients/web/src/domains/contacts/components/assistant-channels-detail.test.tsx
@@ -2,6 +2,8 @@ import { afterEach, describe, expect, test } from "bun:test";
 
 import { cleanup, fireEvent, render } from "@testing-library/react";
 
+import { MemoryRouter } from "react-router";
+
 import { AssistantChannelsDetail } from "@/domains/contacts/components/assistant-channels-detail";
 import type { AssistantChannelState } from "@/types/channel-types";
 
@@ -36,7 +38,11 @@ afterEach(() => {
 
 describe("assistant channels detail (contact card)", () => {
   test("the Contacts detail view renders the identity header card and Channels card", () => {
-    render(<AssistantChannelsDetail assistantName="Vex" channels={CHANNELS} />);
+    render(
+      <MemoryRouter>
+        <AssistantChannelsDetail assistantName="Vex" channels={CHANNELS} />
+      </MemoryRouter>,
+    );
     expect(document.body.textContent).toContain("Vex (Your Assistant)");
     expect(document.body.textContent).toContain("Channels");
     expect(document.body.textContent).toContain("Slack");
@@ -47,12 +53,14 @@ describe("assistant channels detail (contact card)", () => {
     // trust-floor dropdown, Slack cards, or channel list (those live in the
     // Channels tab).
     render(
-      <AssistantChannelsDetail
-        assistantName="Vex"
-        channels={CHANNELS}
-        onConnect={() => {}}
-        onDisconnect={() => {}}
-      />,
+      <MemoryRouter>
+        <AssistantChannelsDetail
+          assistantName="Vex"
+          channels={CHANNELS}
+          onConnect={() => {}}
+          onDisconnect={() => {}}
+        />
+      </MemoryRouter>,
     );
     expect(document.querySelector('[data-slot="tabs"]')).toBeNull();
     expect(document.body.textContent).not.toContain("Who can message");
@@ -78,22 +86,24 @@ describe("assistant channels detail (contact card)", () => {
     // away the only control that could actually change anything, while the
     // outage it is reporting clears itself in about forty seconds.
     render(
-      <AssistantChannelsDetail
-        assistantName="Vex"
-        channels={[
-          {
-            key: "slack",
-            status: "incomplete",
-            configured: true,
-            canDisconnect: true,
-            canManualEntry: true,
-            health: "failing",
-            address: "@vex",
-          },
-        ]}
-        onConnect={() => {}}
-        onDisconnect={() => {}}
-      />,
+      <MemoryRouter>
+        <AssistantChannelsDetail
+          assistantName="Vex"
+          channels={[
+            {
+              key: "slack",
+              status: "incomplete",
+              configured: true,
+              canDisconnect: true,
+              canManualEntry: true,
+              health: "failing",
+              address: "@vex",
+            },
+          ]}
+          onConnect={() => {}}
+          onDisconnect={() => {}}
+        />
+      </MemoryRouter>,
     );
 
     expect(document.body.textContent).toContain("@vex");
@@ -106,14 +116,49 @@ describe("assistant channels detail (contact card)", () => {
     expect(labels).not.toContain("Connect");
   });
 
+  test("a configured channel with no delete route offers Manage, not Disconnect", () => {
+    // No route means no one-click teardown exists (email; Discord below its
+    // config gate). The row must still lead somewhere: a Manage link to the
+    // channel's panel, and no danger button that could never be enabled.
+    render(
+      <MemoryRouter>
+        <AssistantChannelsDetail
+          assistantName="Vex"
+          channels={[
+            {
+              key: "discord",
+              status: "ready",
+              configured: true,
+              canDisconnect: false,
+              canManualEntry: false,
+              address: "@vex",
+            },
+          ]}
+          onConnect={() => {}}
+          onDisconnect={() => {}}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(document.body.textContent).not.toContain("Disconnect");
+    const manage = Array.from(document.querySelectorAll("a")).find(
+      (a) => a.textContent?.trim() === "Manage",
+    );
+    expect(manage?.getAttribute("href")).toBe(
+      "/assistant/channels?setup=discord",
+    );
+  });
+
   test("disconnecting from the contact card asks for confirmation first", () => {
     const disconnected: string[] = [];
     render(
-      <AssistantChannelsDetail
-        assistantName="Vex"
-        channels={CHANNELS}
-        onDisconnect={(key) => disconnected.push(key)}
-      />,
+      <MemoryRouter>
+        <AssistantChannelsDetail
+          assistantName="Vex"
+          channels={CHANNELS}
+          onDisconnect={(key) => disconnected.push(key)}
+        />
+      </MemoryRouter>,
     );
 
     const disconnectButton = Array.from(

--- a/clients/web/src/domains/contacts/components/assistant-contact-channels.tsx
+++ b/clients/web/src/domains/contacts/components/assistant-contact-channels.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import { Button } from "@vellumai/design-library/components/button";
 import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialog";
 
-import { useNavigate } from "react-router";
+import { Link } from "react-router";
 
 import { routes } from "@/utils/routes";
 import { useTranslation } from "@/i18n";
@@ -104,7 +104,6 @@ function ChannelRow({
   onDisconnect,
 }: ChannelRowProps) {
   const { t } = useTranslation("contacts");
-  const navigate = useNavigate();
   // Two axes, two decisions. `configured` owns the action and the address,
   // because a channel that is merely not delivering still has credentials
   // worth keeping and an address worth showing, and offering Connect would
@@ -154,13 +153,10 @@ function ChannelRow({
                 {pending ? t("actions.disconnecting") : t("actions.disconnect")}
               </Button>
             ) : (
-              <Button
-                variant="outlined"
-                onClick={() =>
-                  navigate(`${routes.channels}?setup=${channel.key}`)
-                }
-              >
-                {t("actions.manage")}
+              <Button variant="outlined" asChild>
+                <Link to={`${routes.channels}?setup=${channel.key}`}>
+                  {t("actions.manage")}
+                </Link>
               </Button>
             )}
           </>

--- a/clients/web/src/domains/contacts/components/assistant-contact-channels.tsx
+++ b/clients/web/src/domains/contacts/components/assistant-contact-channels.tsx
@@ -3,6 +3,9 @@ import { useState } from "react";
 import { Button } from "@vellumai/design-library/components/button";
 import { ConfirmDialog } from "@vellumai/design-library/components/confirm-dialog";
 
+import { useNavigate } from "react-router";
+
+import { routes } from "@/utils/routes";
 import { useTranslation } from "@/i18n";
 import type {
   AssistantChannelState,
@@ -101,6 +104,7 @@ function ChannelRow({
   onDisconnect,
 }: ChannelRowProps) {
   const { t } = useTranslation("contacts");
+  const navigate = useNavigate();
   // Two axes, two decisions. `configured` owns the action and the address,
   // because a channel that is merely not delivering still has credentials
   // worth keeping and an address worth showing, and offering Connect would
@@ -136,9 +140,11 @@ function ChannelRow({
               <Icon className="h-3 w-3" />
               {label}
             </span>
-            {/* No handler means no action exists for this row (email has no
-                disconnect route at all), so the button disappears rather than
-                sitting permanently disabled. */}
+            {/* No handler means no one-click disconnect exists for this row:
+                either the daemon predates the channel's delete route, or the
+                channel declares none because tearing it down is a multi-step
+                decision (email). The row links to the channel's panel, where
+                the real controls live, instead of a permanently dead button. */}
             {onDisconnect ? (
               <Button
                 variant="danger"
@@ -147,7 +153,16 @@ function ChannelRow({
               >
                 {pending ? t("actions.disconnecting") : t("actions.disconnect")}
               </Button>
-            ) : null}
+            ) : (
+              <Button
+                variant="outlined"
+                onClick={() =>
+                  navigate(`${routes.channels}?setup=${channel.key}`)
+                }
+              >
+                {t("actions.manage")}
+              </Button>
+            )}
           </>
         ) : onConnect ? (
           <Button variant="outlined" onClick={onConnect} disabled={pending}>

--- a/clients/web/src/domains/contacts/components/assistant-contact-channels.tsx
+++ b/clients/web/src/domains/contacts/components/assistant-contact-channels.tsx
@@ -136,23 +136,24 @@ function ChannelRow({
               <Icon className="h-3 w-3" />
               {label}
             </span>
-            <Button
-              variant="danger"
-              onClick={onDisconnect}
-              disabled={!onDisconnect || pending}
-            >
-              {pending ? t("actions.disconnecting") : t("actions.disconnect")}
-            </Button>
+            {/* No handler means no action exists for this row (email has no
+                disconnect route at all), so the button disappears rather than
+                sitting permanently disabled. */}
+            {onDisconnect ? (
+              <Button
+                variant="danger"
+                onClick={onDisconnect}
+                disabled={pending}
+              >
+                {pending ? t("actions.disconnecting") : t("actions.disconnect")}
+              </Button>
+            ) : null}
           </>
-        ) : (
-          <Button
-            variant="outlined"
-            onClick={onConnect}
-            disabled={!onConnect || pending}
-          >
+        ) : onConnect ? (
+          <Button variant="outlined" onClick={onConnect} disabled={pending}>
             {t("actions.connect")}
           </Button>
-        )}
+        ) : null}
       </div>
     </div>
   );

--- a/clients/web/src/i18n/locales/en/contacts.json
+++ b/clients/web/src/i18n/locales/en/contacts.json
@@ -8,6 +8,7 @@
     "deleting": "Deleting…",
     "connect": "Connect",
     "connecting": "Connecting…",
+    "manage": "Manage",
     "disconnect": "Disconnect",
     "disconnecting": "Disconnecting…",
     "cancel": "Cancel",

--- a/clients/web/src/i18n/locales/es/contacts.json
+++ b/clients/web/src/i18n/locales/es/contacts.json
@@ -8,6 +8,7 @@
     "deleting": "Eliminando…",
     "connect": "Conectar",
     "connecting": "Conectando…",
+    "manage": "Gestionar",
     "disconnect": "Desconectar",
     "disconnecting": "Desconectando…",
     "cancel": "Cancelar",

--- a/clients/web/src/i18n/locales/ru/contacts.json
+++ b/clients/web/src/i18n/locales/ru/contacts.json
@@ -8,6 +8,7 @@
     "deleting": "Удаление…",
     "connect": "Подключить",
     "connecting": "Подключение…",
+    "manage": "Настроить",
     "disconnect": "Отключить",
     "disconnecting": "Отключение…",
     "cancel": "Отмена",


### PR DESCRIPTION
## TL;DR

Contacts-page channel rows with no one-click disconnect now offer a Manage action that lands on that channel's panel on the Channels page, instead of rendering a permanently disabled Disconnect button.

## Why this is safe

- The row's Disconnect handler is withheld exactly when no delete route exists: Discord on a daemon below its config gate today, and email once it joins the Channels rail. Since #41348 gated the handler per-row, those rows showed a danger button that could never be enabled; that commit's stated intent was "no disconnect copy, so no disconnect button".
- A dead control was replaced with a real one, not just hidden: Manage navigates to `/assistant/channels?setup=<channel>`, which selects the channel's tab. For a configured channel the setup param only selects; the credential form renders solely in the disconnected branch, so the link cannot open a form over a connected channel.
- Rows with a working Disconnect are unchanged; the Connect side only hides when the parent passes no handler at all, which no current caller does.
- One component plus three locale files; typecheck and lint are clean.

## What changes for the user

| Before | After |
| --- | --- |
| A configured channel that cannot disconnect shows a permanently disabled Disconnect button | The row shows a Manage button that opens that channel's panel on the Channels page |
| Rows with a working Disconnect | Unchanged |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
