### PR TITLE
feat(companion): reveal the idle row's verbs under the pointer (JARVIS-1644)

### DIFF
--- a/clients/web/src/components/companion-surface.test.tsx
+++ b/clients/web/src/components/companion-surface.test.tsx
@@ -449,6 +449,103 @@ describe("the companion surface's anchor in the canvas", () => {
 });
 
 /**
+ * The idle row's verbs, which are drawn one at a time under the pointer.
+ *
+ * **The behaviour is a stylesheet, so these hold its contract rather than its
+ * effect.** The reveal is `:hover` and not React state, because the host's
+ * window is click-through and the page derives its own hover from forwarded
+ * mouse-move rather than from `mouseenter`; CSS is the one hover mechanism that
+ * is known to work there, since the held-down background on these same buttons
+ * has always run on it. Nothing here renders Tailwind, so a case that fired a
+ * synthetic hover and read the text back would pass against a stylesheet that
+ * had been deleted. What is worth holding instead is the coupling: the word is
+ * marked hidden-until-hovered, the button is the `group` that variant resolves
+ * against, and the two cases that pin it open still pin it open.
+ */
+describe("the companion surface's revealed labels", () => {
+  const labelOf = (container: HTMLElement, name: string): HTMLElement | null =>
+    container.querySelector<HTMLElement>(
+      `button[aria-label="${name}"] span[data-label]`,
+    );
+
+  test("rests as icons, with no verb spelled out", () => {
+    const { container } = render(
+      <CompanionSurface phase="hover" watchEnabled />,
+    );
+    for (const name of ["Talk", "Type", "Teach"]) {
+      const label = labelOf(container, name);
+      expect(label?.getAttribute("data-label")).toBe("hover");
+      expect(label?.className).toContain("hidden");
+    }
+  });
+
+  /**
+   * The variant and the thing it resolves against, together. `group-hover:` on
+   * a button that is not a `group` is a word that never appears, and that is
+   * exactly the failure no rendered assertion in this file would catch.
+   */
+  test("reveals the verb under the pointer, from the button's own group", () => {
+    const { container } = render(<CompanionSurface phase="hover" />);
+    const talk = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Talk"]',
+    );
+    expect(talk?.className).toContain("group");
+    expect(labelOf(container, "Talk")?.className).toContain(
+      "group-hover:inline",
+    );
+  });
+
+  /**
+   * The reel has no pointer in the room, and the whole point of a spotlit frame
+   * is which control it is pointing at.
+   */
+  test("spells out the control the reel is pointing at", () => {
+    const { container } = render(
+      <CompanionSurface phase="hover" spotlight="talk" />,
+    );
+    expect(labelOf(container, "Talk")?.getAttribute("data-label")).toBe(
+      "pinned",
+    );
+    expect(labelOf(container, "Talk")?.className).not.toContain("hidden");
+    // And only that one: a frame pointing at both is pointing at neither.
+    expect(labelOf(container, "Type")?.getAttribute("data-label")).toBe(
+      "hover",
+    );
+  });
+
+  /**
+   * A running session is the one thing on this row the user has to be able to
+   * find without hunting, so its name stays on the surface rather than under
+   * the pointer.
+   */
+  test("keeps the running session's name drawn", () => {
+    const { container } = render(
+      <CompanionSurface phase="watching" watching watchEnabled />,
+    );
+    expect(labelOf(container, "Teach")?.getAttribute("data-label")).toBe(
+      "pinned",
+    );
+    expect(labelOf(container, "Teach")?.className).not.toContain("hidden");
+  });
+
+  /**
+   * The summary is a question waiting on an answer rather than a set of ways
+   * in, so its two answers are not the pointer's to reveal.
+   */
+  test("leaves the summary's answers spelled out", () => {
+    const { container } = render(
+      <CompanionSurface phase="summary" watchRetro="ready" />,
+    );
+    expect(labelOf(container, "Show summary")).toBeNull();
+    expect(
+      container.querySelector<HTMLButtonElement>(
+        'button[aria-label="Show summary"]',
+      )?.textContent,
+    ).toBe("Show summary");
+  });
+});
+
+/**
  * Watch, the third way in, and the session it toggles.
  *
  * One control for both edges: the surface draws a single button and the side
@@ -470,7 +567,13 @@ describe("the companion surface's Watch action", () => {
     const { container } = render(
       <CompanionSurface phase="hover" watchEnabled />,
     );
-    expect(watchOf(container).textContent).toBe("Teach");
+    // Third of the three, since this is the row's own ordering and the one a
+    // hand travelling out from the mascot crosses last.
+    expect(
+      [...container.querySelectorAll("button")].map((button) =>
+        button.getAttribute("aria-label"),
+      ),
+    ).toEqual(["Talk", "Type", "Teach"]);
   });
 
   test("reports the press", () => {

--- a/clients/web/src/components/companion-surface.test.tsx
+++ b/clients/web/src/components/companion-surface.test.tsx
@@ -457,8 +457,8 @@ describe("the companion surface's anchor in the canvas", () => {
  * mouse-move rather than from `mouseenter`; CSS is the one hover mechanism that
  * is known to work there, since the held-down background on these same buttons
  * has always run on it. Nothing here renders Tailwind, so a case that fired a
- * synthetic hover and read the text back would pass against a stylesheet that
- * had been deleted. What is worth holding instead is the coupling: the word is
+ * synthetic hover and read the text back passes with the stylesheet missing
+ * entirely. What is worth holding instead is the coupling: the word is
  * marked hidden-until-hovered, the button is the `group` that variant resolves
  * against, and the two cases that pin it open still pin it open.
  */

--- a/clients/web/src/components/companion-surface.test.tsx
+++ b/clients/web/src/components/companion-surface.test.tsx
@@ -454,9 +454,9 @@ describe("the companion surface's anchor in the canvas", () => {
  * **The behaviour is a stylesheet, so these hold its contract rather than its
  * effect.** The reveal is `:hover` and not React state, because the host's
  * window is click-through and the page derives its own hover from forwarded
- * mouse-move rather than from `mouseenter`; CSS is the one hover mechanism that
- * is known to work there, since the held-down background on these same buttons
- * has always run on it. Nothing here renders Tailwind, so a case that fired a
+ * mouse-move rather than from `mouseenter`; CSS is the one hover mechanism
+ * known to work there, since the held-down background on these same buttons
+ * runs on it. Nothing here renders Tailwind, so a case that fired a
  * synthetic hover and read the text back passes with the stylesheet missing
  * entirely. What is worth holding instead is the coupling: the word is
  * marked hidden-until-hovered, the button is the `group` that variant resolves

--- a/clients/web/src/components/companion-surface.tsx
+++ b/clients/web/src/components/companion-surface.tsx
@@ -223,12 +223,17 @@ const INNER_GAP = 8;
  */
 export const FALLBACK_WIDTHS: Record<CompanionSurfacePhase, number> = {
   resting: AVATAR_BOX,
-  hover: 272,
+  // Three icon-only controls, which is the row as it is first drawn: the labels
+  // are revealed one at a time under the pointer, and on the first frame there
+  // is no pointer on any of them yet.
+  hover: 156,
   // The same row of controls hover draws, since the session is run from it
-  // rather than from a row of its own.
-  watching: 272,
-  // Two labelled controls where the idle row draws three, so narrower than the
-  // row it replaces and never wider than it.
+  // rather than from a row of its own, plus the one word the running session
+  // pins open on the control holding it.
+  watching: 195,
+  // Two labelled controls, both drawn: this row is a question waiting on an
+  // answer rather than a set of ways in, so its words are not the pointer's to
+  // reveal. Wider than the idle row it replaces for exactly that reason.
   summary: 264,
   // The row with the stop control on it, which is the widest a call draws: a
   // watch session adds a fifth control to the four the call already has.
@@ -1269,6 +1274,23 @@ function Avatar({
  * and the one where the assistant does the looking rather than the user the
  * saying. It is also the one that comes and goes: it is behind a flag of its
  * own, so the row is Talk and Type alone for anyone who does not have it.
+ *
+ * **The words are drawn one at a time, under the pointer.** This is the row a
+ * user meets by resting a hand near the mascot, which means it is drawn far
+ * more often than it is acted on, and three verbs spelled out at once made it a
+ * sentence being read at someone doing something else. Teach was the loudest of
+ * the three by being the least wanted: the flagged, occasional way in, drawn at
+ * the same weight as the two the row exists for.
+ *
+ * So the row rests as icons and each control says its own name when the pointer
+ * reaches it (`revealLabel`). The pill measures its contents, so it is a third
+ * of its old width at rest and grows by one word at a time, which is also what
+ * keeps the reveal legible: exactly one word is ever on the surface, and it is
+ * the one the hand is on.
+ *
+ * Nothing loses its name. `aria-label` was always the accessible name and is
+ * untouched, so a reader gets what it always got; what changed is only when a
+ * looking user is shown it.
  */
 function IdleBody({
   spotlight,
@@ -1293,14 +1315,14 @@ function IdleBody({
       <PillButton
         icon={<AudioLines className="size-4" />}
         label={t("companionSurface.talk")}
-        showLabel
+        revealLabel
         active={spotlight === "talk"}
         onClick={onTalk}
       />
       <PillButton
         icon={<Keyboard className="size-4" />}
         label={t("companionSurface.type")}
-        showLabel
+        revealLabel
         active={spotlight === "type"}
         onClick={onType}
       />
@@ -1309,6 +1331,12 @@ function IdleBody({
           rather than `active`, because this one is a state and not a look: a
           reader is told a session is running, where everything else this
           surface does about it is a colour they never receive.
+
+          It is also what keeps this control's word on the surface while the
+          rest of the row is icons: a running session is the one thing here the
+          user has to be able to find without hunting, and a name revealed only
+          under the pointer is one they would have to go looking for. `pressed`
+          pins it open, so the session names itself for as long as it runs.
 
           Absent entirely when Watch is not offered, rather than disabled: a
           user who cannot have the feature is not owed a control that explains
@@ -1325,7 +1353,7 @@ function IdleBody({
         <PillButton
           icon={<Eye className="size-4" />}
           label={t("companionSurface.teach")}
-          showLabel
+          revealLabel
           pressed={watching}
           onClick={onWatch}
         />
@@ -1614,6 +1642,7 @@ function PillButton({
   label,
   tone,
   showLabel = false,
+  revealLabel = false,
   active = false,
   pressed,
   onClick,
@@ -1622,6 +1651,24 @@ function PillButton({
   label: string;
   tone?: "positive" | "negative";
   showLabel?: boolean;
+  /**
+   * Draw the label while the pointer is on this control, and not otherwise.
+   *
+   * **CSS, deliberately, and this is the one place on the surface where that is
+   * not a matter of taste.** The host's window is click-through, so the page
+   * derives its own hover by hit-testing coordinates against the pill on every
+   * forwarded mouse-move rather than trusting `mouseenter`
+   * (`companion-surface-page.tsx`). A per-control reveal driven off React's
+   * mouse events would be betting on the events that page already decided it
+   * could not have. `:hover` is what the held-down background on this very
+   * button has always run on, so a reveal on the same mechanism works exactly
+   * where the rest of the control does.
+   *
+   * The pill measures its own contents, so a label appearing resizes this row
+   * and the surface grows to fit it on its own. Nothing here has to say how
+   * wide the word is.
+   */
+  revealLabel?: boolean;
   /** Drawn as though the pointer were on it. A look, not a state. */
   active?: boolean;
   /**
@@ -1636,20 +1683,34 @@ function PillButton({
   pressed?: boolean;
   onClick?: () => void;
 }) {
+  /**
+   * A revealed label held open with no pointer in the room.
+   *
+   * Both cases are ones where the word has to be readable without a hand on the
+   * control. `active` is the demo reel pointing at a control, and a control
+   * pointed at in a recording nobody can hover is one whose name has to be
+   * drawn. `pressed` is a control holding a session open, and the row's job
+   * then is to say which press ends it, which it cannot do as an icon the user
+   * would have to go looking under.
+   */
+  const pinned = active || pressed === true;
   return (
     <button
       type="button"
       aria-label={label}
       aria-pressed={pressed}
-      title={label}
+      // Only where the word is nowhere else. A tooltip over a control that
+      // reveals its own label on the same hover is the same word twice, a
+      // second later and a few pixels away.
+      title={showLabel || revealLabel ? undefined : label}
       onClick={onClick}
       // A press on a control is not the start of a drag. Without this the
       // surface would move under a click meant to activate something on it.
       onMouseDown={(event) => {
         event.stopPropagation();
       }}
-      className={`flex h-7 shrink-0 items-center gap-1.5 rounded-full px-2 text-[12px] transition-colors hover:bg-white/15 ${
-        active || pressed === true ? "bg-white/15" : ""
+      className={`group flex h-7 shrink-0 items-center gap-1.5 rounded-full px-2 text-[12px] transition-colors hover:bg-white/15 ${
+        pinned ? "bg-white/15" : ""
       } ${
         tone === "negative"
           ? "text-[#ff6b6b]"
@@ -1660,6 +1721,18 @@ function PillButton({
     >
       {icon}
       {showLabel && <span>{label}</span>}
+      {revealLabel && (
+        // `data-label` is the reveal's contract, and it is here because the
+        // behaviour itself is a stylesheet: a test running without Tailwind
+        // sees a span either way, so the attribute is the only honest way to
+        // hold that this word is hidden until the pointer arrives.
+        <span
+          data-label={pinned ? "pinned" : "hover"}
+          className={pinned ? "" : "hidden group-hover:inline"}
+        >
+          {label}
+        </span>
+      )}
     </button>
   );
 }

--- a/clients/web/src/components/companion-surface.tsx
+++ b/clients/web/src/components/companion-surface.tsx
@@ -233,7 +233,7 @@ export const FALLBACK_WIDTHS: Record<CompanionSurfacePhase, number> = {
   watching: 195,
   // Two labelled controls, both drawn: this row is a question waiting on an
   // answer rather than a set of ways in, so its words are not the pointer's to
-  // reveal. Wider than the idle row it replaces for exactly that reason.
+  // reveal. That is what makes it wider than the idle row it stands in for.
   summary: 264,
   // The row with the stop control on it, which is the widest a call draws: a
   // watch session adds a fifth control to the four the call already has.
@@ -1275,22 +1275,19 @@ function Avatar({
  * saying. It is also the one that comes and goes: it is behind a flag of its
  * own, so the row is Talk and Type alone for anyone who does not have it.
  *
- * **The words are drawn one at a time, under the pointer.** This is the row a
- * user meets by resting a hand near the mascot, which means it is drawn far
- * more often than it is acted on, and three verbs spelled out at once made it a
- * sentence being read at someone doing something else. Teach was the loudest of
- * the three by being the least wanted: the flagged, occasional way in, drawn at
- * the same weight as the two the row exists for.
+ * **The words are drawn one at a time, under the pointer** (`revealLabel`).
+ * This is the row a user meets by resting a hand near the mascot, so it is
+ * drawn far more often than it is acted on, and three verbs spelled out at once
+ * read as a sentence aimed at someone doing something else. Teach is the
+ * loudest of the three for being the least wanted: the flagged, occasional way
+ * in, at the same weight as the two the row exists for.
  *
- * So the row rests as icons and each control says its own name when the pointer
- * reaches it (`revealLabel`). The pill measures its contents, so it is a third
- * of its old width at rest and grows by one word at a time, which is also what
- * keeps the reveal legible: exactly one word is ever on the surface, and it is
- * the one the hand is on.
+ * Resting as icons keeps the pill to a third of the width its labels want, and
+ * revealing one at a time is what keeps the reveal legible: exactly one word is
+ * ever on the surface, and it is the one the hand is on.
  *
- * Nothing loses its name. `aria-label` was always the accessible name and is
- * untouched, so a reader gets what it always got; what changed is only when a
- * looking user is shown it.
+ * `aria-label` carries the name in every state, so a reader gets all three
+ * regardless of where the pointer is.
  */
 function IdleBody({
   spotlight,

--- a/clients/web/src/components/companion-surface.tsx
+++ b/clients/web/src/components/companion-surface.tsx
@@ -1656,10 +1656,10 @@ function PillButton({
    * derives its own hover by hit-testing coordinates against the pill on every
    * forwarded mouse-move rather than trusting `mouseenter`
    * (`companion-surface-page.tsx`). A per-control reveal driven off React's
-   * mouse events would be betting on the events that page already decided it
-   * could not have. `:hover` is what the held-down background on this very
-   * button has always run on, so a reveal on the same mechanism works exactly
-   * where the rest of the control does.
+   * mouse events would be betting on the events that page does not receive.
+   * The held-down background on this very button runs on
+   * `:hover`, so a reveal on the same mechanism works exactly where the rest of
+   * the control does.
    *
    * The pill measures its own contents, so a label appearing resizes this row
    * and the surface grows to fit it on its own. Nothing here has to say how


### PR DESCRIPTION
Closes JARVIS-1644.

The idle pill drew Talk, Type and Teach as icon and word all three at once. It is the row a user meets by resting a hand near the mascot, so it is drawn far more often than it is acted on, and three verbs spelled out at once made it a sentence being read at someone doing something else. Teach was the loudest of the three by being the least wanted: the flagged, occasional way in, drawn at the same weight as the two the row exists for.

The row now rests as icons and each control says its own name when the pointer reaches it.

| State | Pill width | Drawn |
|---|---|---|
| Idle | 156pt (was 272) | avatar, then three icons |
| Hover Talk | 183pt | `Talk` only |
| Hover Teach | 195pt | `Teach` only |
| Session running | 195pt | `Teach` pinned, held down, amber ring |

## Two cases keep a word on the surface with no hand on the control

`active` is the demo reel pointing at a control, and a control pointed at in a recording nobody can hover is one whose name has to be drawn — otherwise the intro tour's spotlight frames stop saying which control they are pointing at.

`pressed` is the running watch session. That row's job is to say which press ends it, which it cannot do as an icon the user would have to go looking under.

## The reveal is CSS, and that is not a matter of taste

The host's window is click-through, so `companion-surface-page.tsx` derives its own hover by hit-testing coordinates against the pill on every forwarded mouse-move rather than trusting `mouseenter` — its comment says so explicitly. A per-control reveal driven off React's mouse events would be betting on the events that page already decided it could not have. `:hover` is what the held-down background on these same buttons has always run on, so the reveal rides a mechanism already proven in that window.

The pill measures its own contents, so a label appearing resizes the row and the existing `ResizeObserver` plus `transition-[width]` handles the growth. No new measurement plumbing.

## Considered and rejected

A trailing chevron that discloses Teach. The pill is already a hover disclosure, and nesting a second one inside a hover-only surface means a hover-to-hover-to-click chain in a click-through window. It also collides with the invariant the file spells out as *"the exit outlives the door"*: a session running under a flag that has since been turned off still has to draw its stop control, so the chevron would need a state exception for exactly the case that matters most.

## Accessibility

Nothing loses its name. `aria-label` was always the accessible name and is untouched, so a reader gets what it always got; what changed is only when a looking user is shown it. The `title` tooltip goes from the controls that now reveal their own label, since a word repeated a second later by the same hover is the same word twice.

## Verification

Captured from Storybook against real Tailwind at every state: 156 at rest, 183 with Talk revealed, 195 with Teach, 195 with a session running. `FALLBACK_WIDTHS` is re-fitted to those measurements.

Worth knowing for anyone doing this again: `Input.dispatchMouseEvent` does **not** produce `:hover` in headless Chrome, which makes a working reveal look like a broken one. `CSS.forcePseudoState` is what actually holds the pseudo-state.

The previous `expect(watchOf(container).textContent).toBe("Teach")` was left passing but vacuous — nothing renders Tailwind under `bun test`, so it reads the same span whether or not the stylesheet exists. It is replaced by a `revealed labels` describe that holds the real contract: the word is marked hidden-until-hovered, the button is the `group` that variant resolves against, and both pinned cases still pin.

122 tests pass across `companion-surface.test.tsx` and `companion-surface-page.test.tsx`; typecheck, eslint and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JVwEyrMMqVRXvHYCyPLuV3
