### PR TITLE
fix(security): stop offering trust-rule directory scopes the engine cannot honor

### DIFF
--- a/clients/web/src/domains/chat/components/chat-rule-editor-modal.tsx
+++ b/clients/web/src/domains/chat/components/chat-rule-editor-modal.tsx
@@ -1,12 +1,15 @@
 /**
  * In-chat trust rule editor modal.
  *
- * Mirrors the macOS `RuleEditorModal` — a focused dialog for creating or
- * editing a trust rule directly from the chat transcript. Supports:
- * - Create mode: pattern selection, directory scope, risk level picker
- * - Edit mode: locked existing pattern, "Save As New" for narrower scope
+ * A focused dialog for creating or editing a trust rule directly from the
+ * chat transcript. Supports:
+ * - Create mode: pattern selection and risk level picker
+ * - Edit mode: locked existing pattern, "Save As New" for a narrower pattern
  * - LLM suggestion pre-population with `hasUserInteracted` guard
  * - Suggestion annotation in edit mode ("Suggested: {risk}")
+ *
+ * Rules apply workspace-wide: the engine matches on (tool, pattern) only, so
+ * the editor offers no directory scoping and the gateway rejects any.
  *
  * Rendered by `ChatMainPanel` when `showRuleEditor` is `true`. Driven by
  * `RuleEditorContext` from `rule-editor-store`.
@@ -267,11 +270,6 @@ export function ChatRuleEditorModal({
     context.riskLevel,
   );
 
-  const directoryScopeFiltered = context.directoryScopeOptions.filter(
-    (opt) => opt.scope !== "everywhere",
-  );
-  const [selectedDirScopeIndex, setSelectedDirScopeIndex] = useState(-1);
-
   // Tracks whether user has manually interacted with the form.
   // Prevents a late-arriving LLM suggestion from overwriting user choices.
   const [hasUserInteracted, setHasUserInteracted] = useState(false);
@@ -325,15 +323,6 @@ export function ChatRuleEditorModal({
           setSelectedPatternIndex(matchIdx);
         }
       }
-      // Apply suggestion directory scope in edit mode.
-      if (suggestion?.scope && suggestion.scope !== "everywhere") {
-        const matchIdx = directoryScopeFiltered.findIndex(
-          (o) => o.scope === suggestion.scope,
-        );
-        if (matchIdx >= 0) {
-          setSelectedDirScopeIndex(matchIdx);
-        }
-      }
     } else if (suggestion) {
       // Create mode with suggestion.
       if (suggestion.risk) {
@@ -348,14 +337,6 @@ export function ChatRuleEditorModal({
           (matchIdx >= 0 && isSingleOption)
         ) {
           setSelectedPatternIndex(matchIdx);
-        }
-      }
-      if (suggestion.scope && suggestion.scope !== "everywhere") {
-        const matchIdx = directoryScopeFiltered.findIndex(
-          (o) => o.scope === suggestion.scope,
-        );
-        if (matchIdx >= 0) {
-          setSelectedDirScopeIndex(matchIdx);
         }
       }
     } else {
@@ -373,7 +354,6 @@ export function ChatRuleEditorModal({
     effectiveOptions,
     isSingleOption,
     narrowerOptions,
-    directoryScopeFiltered,
     context.riskLevel,
     generalizationOffset,
   ]);
@@ -382,16 +362,6 @@ export function ChatRuleEditorModal({
     setHasUserInteracted(true);
     setter();
   }, []);
-
-  const resolvedScope = useCallback(() => {
-    if (
-      selectedDirScopeIndex >= 0 &&
-      selectedDirScopeIndex < directoryScopeFiltered.length
-    ) {
-      return directoryScopeFiltered[selectedDirScopeIndex].scope;
-    }
-    return "everywhere";
-  }, [selectedDirScopeIndex, directoryScopeFiltered]);
 
   const canSave =
     !isSaving &&
@@ -408,7 +378,6 @@ export function ChatRuleEditorModal({
         toolName: context.toolName,
         pattern: existingRule.pattern,
         riskLevel: selectedRiskLevel,
-        scope: "everywhere",
       });
     } else {
       const selectedOption = effectiveOptions[selectedPatternIndex];
@@ -416,7 +385,6 @@ export function ChatRuleEditorModal({
         toolName: context.toolName,
         pattern: selectedOption.pattern,
         riskLevel: selectedRiskLevel,
-        scope: resolvedScope(),
       });
     }
   }, [
@@ -427,7 +395,6 @@ export function ChatRuleEditorModal({
     context.toolName,
     selectedPatternIndex,
     selectedRiskLevel,
-    resolvedScope,
     onSave,
   ]);
 
@@ -440,7 +407,6 @@ export function ChatRuleEditorModal({
       toolName: context.toolName,
       pattern: selectedOption.pattern,
       riskLevel: selectedRiskLevel,
-      scope: resolvedScope(),
     });
   }, [
     onSaveAsNew,
@@ -448,7 +414,6 @@ export function ChatRuleEditorModal({
     selectedPatternIndex,
     context.toolName,
     selectedRiskLevel,
-    resolvedScope,
   ]);
 
   const riskHint = getRiskToleranceHint(selectedRiskLevel) ?? "";
@@ -474,7 +439,9 @@ export function ChatRuleEditorModal({
       <Modal.Content size="sm" hideCloseButton>
         <Modal.Header>
           <Modal.Title>
-            {isEditMode ? t("chatRuleEditorModal.editTitle") : t("chatRuleEditorModal.createTitle")}
+            {isEditMode
+              ? t("chatRuleEditorModal.editTitle")
+              : t("chatRuleEditorModal.createTitle")}
           </Modal.Title>
           <Modal.Description>
             {t("chatRuleEditorModal.description")}
@@ -511,7 +478,9 @@ export function ChatRuleEditorModal({
 
             {/* Apply to — pattern options */}
             <section className="flex flex-col gap-2">
-              <SectionHeading>{t("chatRuleEditorModal.applyTo")}</SectionHeading>
+              <SectionHeading>
+                {t("chatRuleEditorModal.applyTo")}
+              </SectionHeading>
               {isEditMode && existingRule ? (
                 <>
                   {/* Edit mode: the existing rule pattern is locked */}
@@ -616,50 +585,11 @@ export function ChatRuleEditorModal({
               ) : null}
             </section>
 
-            {/* Where — directory scope, one card per option */}
-            {directoryScopeFiltered.length > 0 && (
-              <section className="flex flex-col gap-2">
-                <SectionHeading>{t("chatRuleEditorModal.where")}</SectionHeading>
-                <RadioGroup
-                  aria-label={t("chatRuleEditorModal.where")}
-                  className="gap-2"
-                  value={String(selectedDirScopeIndex)}
-                  onValueChange={(next) =>
-                    handleUserInteraction(() =>
-                      setSelectedDirScopeIndex(Number(next)),
-                    )
-                  }
-                >
-                  {directoryScopeFiltered.map((option, i) => (
-                    <OverlayCard
-                      key={option.scope}
-                      onClick={() =>
-                        handleUserInteraction(() => setSelectedDirScopeIndex(i))
-                      }
-                    >
-                      <Radio
-                        value={String(i)}
-                        label={<OptionLabel>{option.label}</OptionLabel>}
-                      />
-                    </OverlayCard>
-                  ))}
-                  <OverlayCard
-                    onClick={() =>
-                      handleUserInteraction(() => setSelectedDirScopeIndex(-1))
-                    }
-                  >
-                    <Radio
-                      value="-1"
-                      label={<OptionLabel>{t("chatRuleEditorModal.everywhere")}</OptionLabel>}
-                    />
-                  </OverlayCard>
-                </RadioGroup>
-              </section>
-            )}
-
             {/* Treat as — risk level picker */}
             <section className="flex flex-col gap-2">
-              <SectionHeading>{t("chatRuleEditorModal.treatAs")}</SectionHeading>
+              <SectionHeading>
+                {t("chatRuleEditorModal.treatAs")}
+              </SectionHeading>
               <SegmentControl<TrustRuleRisk>
                 ariaLabel={t("chatRuleEditorModal.treatAs")}
                 value={selectedRiskLevel}
@@ -682,7 +612,9 @@ export function ChatRuleEditorModal({
                   variant="label-medium-default"
                   className="capitalize text-[var(--content-tertiary)]"
                 >
-                  {t("chatRuleEditorModal.suggested", { risk: suggestion.risk })}
+                  {t("chatRuleEditorModal.suggested", {
+                    risk: suggestion.risk,
+                  })}
                 </Typography>
               )}
               {riskHint && (
@@ -720,7 +652,9 @@ export function ChatRuleEditorModal({
                 onClick={handleSave}
                 disabled={isSaving}
               >
-                {isSaving ? t("chatRuleEditorModal.saving") : t("chatRuleEditorModal.save")}
+                {isSaving
+                  ? t("chatRuleEditorModal.saving")
+                  : t("chatRuleEditorModal.save")}
               </Button>
             </>
           ) : (
@@ -733,7 +667,9 @@ export function ChatRuleEditorModal({
                 onClick={handleSave}
                 disabled={!canSave}
               >
-                {isSaving ? t("chatRuleEditorModal.saving") : t("chatRuleEditorModal.saveRule")}
+                {isSaving
+                  ? t("chatRuleEditorModal.saving")
+                  : t("chatRuleEditorModal.saveRule")}
               </Button>
             </>
           )}

--- a/clients/web/src/domains/chat/components/multi-activity-group/multi-activity-group.tsx
+++ b/clients/web/src/domains/chat/components/multi-activity-group/multi-activity-group.tsx
@@ -25,7 +25,6 @@ import { useToolCallCardDataFromItems } from "@/domains/chat/hooks/use-tool-call
 import type { ConfirmationDecision } from "@/types/event-types";
 import type {
   AllowlistOption,
-  DirectoryScopeOption,
   ScopeOption,
 } from "@/types/interaction-ui-types";
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
@@ -51,7 +50,6 @@ export interface MultiActivityGroupProps {
     input?: Record<string, unknown>;
     allowlistOptions: AllowlistOption[];
     scopeOptions: ScopeOption[];
-    directoryScopeOptions: DirectoryScopeOption[];
     matchedTrustRuleId?: string;
   }) => void;
   // Inline confirmation props (pass-through). Each chip renders its own card
@@ -505,7 +503,6 @@ function UnknownCommandNudge({
                   input: toolCall.input ?? {},
                   allowlistOptions: toolCall.riskAllowlistOptions ?? [],
                   scopeOptions: toolCall.scopeOptions ?? [],
-                  directoryScopeOptions: toolCall.riskDirectoryScopeOptions ?? [],
                 })
               }
               // typography: off-scale — inline link within body-small nudge

--- a/clients/web/src/domains/chat/components/tool-call-chip/tool-call-chip.tsx
+++ b/clients/web/src/domains/chat/components/tool-call-chip/tool-call-chip.tsx
@@ -46,7 +46,6 @@ import {
 import type { ConfirmationDecision } from "@/types/event-types";
 import type {
   AllowlistOption,
-  DirectoryScopeOption,
   ScopeOption,
 } from "@/types/interaction-ui-types";
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
@@ -68,7 +67,6 @@ export interface ToolCallChipProps {
     input: Record<string, unknown>;
     allowlistOptions: AllowlistOption[];
     scopeOptions: ScopeOption[];
-    directoryScopeOptions: DirectoryScopeOption[];
     matchedTrustRuleId?: string;
   }) => void;
   onConfirmationSubmit?: (
@@ -271,7 +269,9 @@ export function InlineConfirmationCard({
             // typography: off-scale — 11px tertiary disclosure per the Figma spec
             className="flex items-center gap-1 self-start text-[11px] font-medium text-[var(--content-tertiary)] transition-colors hover:text-[var(--content-secondary)]"
           >
-            {showDetails ? t("toolCallChip.hideDetails") : t("toolCallChip.showDetails")}
+            {showDetails
+              ? t("toolCallChip.hideDetails")
+              : t("toolCallChip.showDetails")}
             <ChevronDown
               className={`size-2.5 transition-transform ${showDetails ? "rotate-180" : ""}`}
             />
@@ -468,8 +468,6 @@ export function ToolCallChip({
                   input: toolCall.input,
                   allowlistOptions: toolCall.riskAllowlistOptions ?? [],
                   scopeOptions: toolCall.scopeOptions ?? [],
-                  directoryScopeOptions:
-                    toolCall.riskDirectoryScopeOptions ?? [],
                   matchedTrustRuleId: toolCall.matchedTrustRuleId,
                 });
               }}
@@ -524,7 +522,9 @@ export function ToolCallChip({
             <div className="mb-1.5 text-label-small-default uppercase tracking-wider text-[var(--content-tertiary)]">
               {t("toolCallChip.technicalDetails")}
             </div>
-            <div className="text-[var(--content-secondary)]">{t("toolCallChip.toolName")}</div>
+            <div className="text-[var(--content-secondary)]">
+              {t("toolCallChip.toolName")}
+            </div>
             <div className="text-[var(--content-secondary)]">
               {toolCall.name
                 .replace(/_/g, " ")

--- a/clients/web/src/domains/chat/confirmation-actions.ts
+++ b/clients/web/src/domains/chat/confirmation-actions.ts
@@ -303,7 +303,6 @@ export async function handleAllowAndCreateRule(
     riskLevel: toRiskLevel(snapshot.riskLevel),
     allowlistOptions: snapshot.allowlistOptions ?? [],
     scopeOptions: snapshot.scopeOptions ?? [],
-    directoryScopeOptions: snapshot.directoryScopeOptions ?? [],
     commandText: deriveCommandText(snapshot.input, snapshot.toolName ?? ""),
     commandDescription: snapshot.riskReason ?? snapshot.description ?? "",
   };
@@ -318,7 +317,6 @@ export async function handleAllowAndCreateRule(
       riskReason: snapshot.riskReason ?? snapshot.description,
       resolvedAllowlistOptions: snapshot.allowlistOptions ?? [],
       scopeOptions: snapshot.scopeOptions ?? [],
-      directoryScopeOptions: snapshot.directoryScopeOptions ?? [],
     });
   };
 

--- a/clients/web/src/domains/chat/rule-editor-actions.ts
+++ b/clients/web/src/domains/chat/rule-editor-actions.ts
@@ -32,7 +32,6 @@ import { toRiskLevel } from "@/domains/chat/utils/risk";
 import { submitConfirmation } from "@/domains/chat/api/interactions";
 import type {
   AllowlistOption,
-  DirectoryScopeOption,
   ScopeOption,
 } from "@/types/interaction-ui-types";
 import type { TrustRuleItem, TrustRuleRisk } from "@/types/trust-rules";
@@ -46,7 +45,6 @@ export interface TrustRulePayload {
   toolName: string;
   pattern: string;
   riskLevel: TrustRuleRisk;
-  scope: string;
 }
 
 /** Shape for `handleOpenRuleEditorForToolCall`'s argument. */
@@ -57,7 +55,6 @@ export interface ToolCallRuleContext {
   input?: Record<string, unknown>;
   allowlistOptions: AllowlistOption[];
   scopeOptions: ScopeOption[];
-  directoryScopeOptions: DirectoryScopeOption[];
   matchedTrustRuleId?: string;
 }
 
@@ -172,7 +169,7 @@ async function executeSaveRule(
         ctx.assistantId,
         context.requestId,
         "allow",
-        { selectedPattern: rule.pattern, selectedScope: rule.scope },
+        { selectedPattern: rule.pattern, selectedScope: "everywhere" },
       );
       if (!result.ok) {
         useRuleEditorStore.getState().dismissRuleEditor();
@@ -233,7 +230,6 @@ async function executeSaveRule(
         pattern: rule.pattern,
         risk: rule.riskLevel,
         description: `${rule.toolName} — ${rule.pattern}`,
-        scope: rule.scope,
       });
     }
   } catch (err) {
@@ -269,7 +265,6 @@ export function fireSuggestion(params: {
   riskReason?: string;
   resolvedAllowlistOptions: AllowlistOption[];
   scopeOptions: ScopeOption[];
-  directoryScopeOptions: DirectoryScopeOption[];
   existingRule?: TrustRuleItem;
 }): void {
   const abortController = useRuleEditorStore
@@ -295,10 +290,6 @@ export function fireSuggestion(params: {
           reasonDescription: params.riskReason ?? "",
         },
         scopeOptions: scopeOpts,
-        directoryScopeOptions: params.directoryScopeOptions.map((o) => ({
-          scope: o.scope,
-          label: o.label,
-        })),
         intent: "auto_approve",
         existingRule: params.existingRule
           ? {
@@ -345,7 +336,6 @@ export function handleOpenRuleEditorForToolCall(
     riskLevel: toRiskLevel(context.riskLevel),
     allowlistOptions: resolvedAllowlistOptions,
     scopeOptions: context.scopeOptions,
-    directoryScopeOptions: context.directoryScopeOptions,
     commandText: deriveCommandText(context.input, context.toolName),
     commandDescription: context.riskReason ?? "",
   };
@@ -385,7 +375,6 @@ export function handleOpenRuleEditorForToolCall(
       riskReason: context.riskReason,
       resolvedAllowlistOptions,
       scopeOptions: context.scopeOptions,
-      directoryScopeOptions: context.directoryScopeOptions,
       existingRule,
     });
   };

--- a/clients/web/src/domains/chat/rule-editor-store.ts
+++ b/clients/web/src/domains/chat/rule-editor-store.ts
@@ -19,7 +19,6 @@ import { create } from "zustand";
 import { createSelectors } from "@/utils/create-selectors";
 import type {
   AllowlistOption,
-  DirectoryScopeOption,
   ScopeOption,
 } from "@/types/interaction-ui-types";
 import type {
@@ -39,7 +38,6 @@ export interface RuleEditorContext {
   riskLevel: TrustRuleRisk;
   allowlistOptions: AllowlistOption[];
   scopeOptions: ScopeOption[];
-  directoryScopeOptions: DirectoryScopeOption[];
   commandText: string;
   commandDescription: string;
   existingRule?: TrustRuleItem;

--- a/clients/web/src/domains/chat/transcript/latest-turn-row.tsx
+++ b/clients/web/src/domains/chat/transcript/latest-turn-row.tsx
@@ -44,7 +44,6 @@ export interface LatestTurnRowProps {
     input?: Record<string, unknown>;
     allowlistOptions: import("@/types/interaction-ui-types").AllowlistOption[];
     scopeOptions: import("@/types/interaction-ui-types").ScopeOption[];
-    directoryScopeOptions: import("@/types/interaction-ui-types").DirectoryScopeOption[];
   }) => void;
   unknownNudgeToolCallIds?: Set<string>;
   onDismissUnknownNudge?: (toolCallId: string) => void;

--- a/clients/web/src/domains/chat/transcript/transcript-message-body-shared.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-message-body-shared.tsx
@@ -14,7 +14,6 @@ import { useEmojiLookup } from "@/domains/chat/components/chat-composer/emoji-ca
 import type { ConfirmationDecision } from "@/types/event-types";
 import type {
   AllowlistOption,
-  DirectoryScopeOption,
   ScopeOption,
 } from "@/types/interaction-ui-types";
 import type { ChatMessageToolCall } from "@/domains/chat/api/event-types";
@@ -27,7 +26,6 @@ export interface OpenRuleEditorContext {
   input?: Record<string, unknown>;
   allowlistOptions: AllowlistOption[];
   scopeOptions: ScopeOption[];
-  directoryScopeOptions: DirectoryScopeOption[];
 }
 
 /**

--- a/clients/web/src/domains/chat/transcript/transcript-row.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript-row.tsx
@@ -59,7 +59,6 @@ export interface TranscriptRowProps {
     input?: Record<string, unknown>;
     allowlistOptions: import("@/types/interaction-ui-types").AllowlistOption[];
     scopeOptions: import("@/types/interaction-ui-types").ScopeOption[];
-    directoryScopeOptions: import("@/types/interaction-ui-types").DirectoryScopeOption[];
   }) => void;
   unknownNudgeToolCallIds?: Set<string>;
   onDismissUnknownNudge?: (toolCallId: string) => void;

--- a/clients/web/src/domains/chat/transcript/transcript.tsx
+++ b/clients/web/src/domains/chat/transcript/transcript.tsx
@@ -71,7 +71,6 @@ export interface TranscriptProps {
     input?: Record<string, unknown>;
     allowlistOptions: import("@/types/interaction-ui-types").AllowlistOption[];
     scopeOptions: import("@/types/interaction-ui-types").ScopeOption[];
-    directoryScopeOptions: import("@/types/interaction-ui-types").DirectoryScopeOption[];
   }) => void;
   /** Set of tool-call ids that should display the "command not recognized"
    *  nudge below their chip. */

--- a/clients/web/src/domains/chat/utils/chat.ts
+++ b/clients/web/src/domains/chat/utils/chat.ts
@@ -542,7 +542,6 @@ export function toolCallToRuleContext(
     input: tc.input ?? {},
     allowlistOptions: tc.riskAllowlistOptions ?? [],
     scopeOptions: tc.scopeOptions ?? [],
-    directoryScopeOptions: tc.riskDirectoryScopeOptions ?? [],
     matchedTrustRuleId: tc.matchedTrustRuleId,
   };
 }

--- a/clients/web/src/i18n/locales/en/chat.json
+++ b/clients/web/src/i18n/locales/en/chat.json
@@ -327,7 +327,6 @@
     "createTitle": "Create Trust Rule",
     "description": "Matching tool calls take this rule's risk level, so your approval tolerance can auto-approve them.",
     "editTitle": "Edit Trust Rule",
-    "everywhere": "Everywhere",
     "narrowerScopeAria": "Narrower scope",
     "orNarrowScope": "Or narrow the scope:",
     "save": "Save",
@@ -335,8 +334,7 @@
     "saveRule": "Save Rule",
     "saving": "Saving…",
     "suggested": "Suggested: {risk}",
-    "treatAs": "Treat as",
-    "where": "Where"
+    "treatAs": "Treat as"
   },
   "choiceSurface": {
     "continue": "Continue",

--- a/clients/web/src/i18n/locales/es/chat.json
+++ b/clients/web/src/i18n/locales/es/chat.json
@@ -327,7 +327,6 @@
     "createTitle": "Crear regla de confianza",
     "description": "Las llamadas a herramientas que coincidan usan el nivel de riesgo de esta regla, para que tu tolerancia de aprobación pueda autoaprobarlas.",
     "editTitle": "Editar regla de confianza",
-    "everywhere": "En todas partes",
     "narrowerScopeAria": "Alcance más estrecho",
     "orNarrowScope": "O reduce el alcance:",
     "save": "Guardar",
@@ -335,8 +334,7 @@
     "saveRule": "Guardar regla",
     "saving": "Guardando…",
     "suggested": "Sugerido: {risk}",
-    "treatAs": "Tratar como",
-    "where": "Dónde"
+    "treatAs": "Tratar como"
   },
   "choiceSurface": {
     "continue": "Continuar",

--- a/gateway/openapi.json
+++ b/gateway/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Vellum Gateway API",
-    "version": "0.11.5",
+    "version": "0.11.6",
     "description": "Auto-generated OpenAPI specification for the Vellum Gateway HTTP endpoints."
   },
   "servers": [{ "url": "", "description": "Same-origin (gateway)" }],
@@ -1822,8 +1822,9 @@
                   },
                   "description": { "type": "string", "minLength": 1 },
                   "scope": {
-                    "description": "Directory scope selected in the rule editor. Accepted on the wire but not yet persisted by the gateway.",
-                    "type": "string"
+                    "description": "Compatibility field. Trust rules apply workspace-wide: the engine matches on (tool, pattern) only, so a narrower scope cannot be honored and any value other than \"everywhere\" is rejected rather than stored broader than the consent it records.",
+                    "type": "string",
+                    "const": "everywhere"
                   }
                 },
                 "required": ["tool", "pattern", "risk", "description"]

--- a/gateway/src/__tests__/trust-rules-routes.test.ts
+++ b/gateway/src/__tests__/trust-rules-routes.test.ts
@@ -34,7 +34,6 @@ beforeEach(async () => {
   await initGatewayDb();
   initTrustRuleCache();
   store = new TrustRuleStore();
-
 });
 
 afterEach(() => {
@@ -93,10 +92,7 @@ describe("GET /v1/trust-rules — list", () => {
     expect(defaults.length).toBeGreaterThan(0);
     store.update(defaults[0].id, { risk: "high" });
 
-    const reqModified = jsonRequest(
-      "http://localhost/v1/trust-rules",
-      "GET",
-    );
+    const reqModified = jsonRequest("http://localhost/v1/trust-rules", "GET");
     const resModified = await handler(reqModified);
     const bodyModified = (await resModified.json()) as {
       rules: Array<{ origin: string; userModified: boolean }>;
@@ -299,6 +295,40 @@ describe("POST /v1/trust-rules — create", () => {
 
     const body = (await res.json()) as { error: string };
     expect(body.error).toContain("risk");
+  });
+
+  test("rejects a narrowing scope rather than storing the rule wider than consented", async () => {
+    // The engine matches on (tool, pattern) only. A request scoped to a
+    // directory must fail loudly: accepting it would persist a rule that
+    // auto-approves everywhere while the user consented to one directory.
+    const handler = createTrustRulesCreateHandler();
+    const res = await handler(
+      jsonRequest("http://localhost/v1/trust-rules", "POST", {
+        tool: "bash",
+        pattern: "npm run *",
+        risk: "low",
+        description: "Allow npm scripts",
+        scope: "/Users/me/projects/app/**",
+      }),
+    );
+    expect(res.status).toBe(400);
+
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("workspace-wide");
+  });
+
+  test('accepts scope "everywhere", which matches what the store does (201)', async () => {
+    const handler = createTrustRulesCreateHandler();
+    const res = await handler(
+      jsonRequest("http://localhost/v1/trust-rules", "POST", {
+        tool: "bash",
+        pattern: "git status",
+        risk: "low",
+        description: "Allow git status",
+        scope: "everywhere",
+      }),
+    );
+    expect(res.status).toBe(201);
   });
 });
 

--- a/gateway/src/http/routes/trust-rules-routes.ts
+++ b/gateway/src/http/routes/trust-rules-routes.ts
@@ -38,10 +38,10 @@ const CreateTrustRuleRequestSchema = z.object({
   risk: TrustRuleRiskSchema,
   description: z.string().min(1),
   scope: z
-    .string()
+    .literal("everywhere")
     .optional()
     .describe(
-      "Directory scope selected in the rule editor. Accepted on the wire but not yet persisted by the gateway.",
+      'Compatibility field. Trust rules apply workspace-wide: the engine matches on (tool, pattern) only, so a narrower scope cannot be honored and any value other than "everywhere" is rejected rather than stored broader than the consent it records.',
     ),
 });
 

--- a/gateway/src/http/routes/trust-rules.ts
+++ b/gateway/src/http/routes/trust-rules.ts
@@ -156,7 +156,7 @@ export function createTrustRulesCreateHandler() {
       );
     }
 
-    const { tool, pattern, risk, description } = body as Record<
+    const { tool, pattern, risk, description, scope } = body as Record<
       string,
       unknown
     >;
@@ -182,6 +182,20 @@ export function createTrustRulesCreateHandler() {
     if (typeof description !== "string" || !description) {
       return Response.json(
         { error: '"description" must be a non-empty string' },
+        { status: 400 },
+      );
+    }
+    // The engine matches rules on (tool, pattern) only, so a directory scope
+    // cannot narrow one. Storing a scoped request anyway would persist a rule
+    // broader than the consent it records; refuse it instead. "everywhere"
+    // is the one value that means what the store does, so it stays accepted
+    // for clients that send it explicitly.
+    if (scope !== undefined && scope !== "everywhere") {
+      return Response.json(
+        {
+          error:
+            'Trust rules apply workspace-wide; "scope" cannot narrow one. Omit it or send "everywhere".',
+        },
         { status: 400 },
       );
     }


### PR DESCRIPTION
Fixes ATL-1339

## TL;DR

The rule editor offered a "Where" directory-scope picker, but the trust-rule engine matches on (tool, pattern) only: the gateway's own wire schema documented `scope` as "accepted on the wire but not yet persisted," and the create handler dropped it. A rule the user restricted to one directory silently auto-approved matching commands workspace-wide. This removes the unenforceable scope UI and makes the gateway reject any scope it cannot honor.

## What changes for the user

| Surface | Before | After |
| --- | --- | --- |
| Trust-rule editor ("Create/Edit Trust Rule" modal) | Offers a "Where" section with directory choices that have no effect: every rule applies workspace-wide regardless | No directory section; the editor offers exactly what the engine enforces (pattern + risk) |
| Gateway `POST /v1/trust-rules` | Accepts any `scope` string and silently ignores it | Rejects any scope other than `"everywhere"` with a 400 explaining rules apply workspace-wide (stale clients sending the `"everywhere"` default still succeed) |

## Why this is safe

- No enforcement behavior changes: rules matched on (tool, pattern) before and still do. The change removes a UI promise the engine never kept.
- The confirmation SSE payload keeps carrying `directoryScopeOptions` on the wire untouched; only the editor-context plumbing that fed the dead picker is trimmed (typed end to end, `tsc` clean).
- The gateway schema tightens to `z.literal("everywhere").optional()`, so the generated SDK and the published spec match the handler; new route tests cover both the rejection and the compatibility value.
- Restoring real directory scoping would be re-shipping the removed v3 scoped-matching feature (an 8-PR arc), squarely inside the consent-scoping redesign now tracked as LUM-3467; rejecting-loudly is the correct interim posture either way.

## Deferred

- The suggest endpoint (`/v1/trust-rules/suggest`) still accepts and computes directory-scope suggestions that no client consumes; trimming that is gateway-side LLM-prompt surface and rides with the LUM-3467 redesign.
- The confirmation card's separate rule-hint dead-end (approve-with-rule creates no rule) is the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41506" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->