### PR TITLE
fix(cli): drop the Allowlist/Denylist approval options that strand the prompt

### DIFF
--- a/cli/src/components/DefaultMainScreen.tsx
+++ b/cli/src/components/DefaultMainScreen.tsx
@@ -163,12 +163,6 @@ interface SubmitDecisionResponse {
   accepted: boolean;
 }
 
-interface AddTrustRuleResponse {
-  accepted: boolean;
-}
-
-type TrustDecision = "always_allow" | "always_deny";
-
 interface HealthResponse {
   status: string;
   message?: string;
@@ -375,27 +369,6 @@ async function submitDecision(
   );
 }
 
-async function addTrustRule(
-  baseUrl: string,
-  assistantId: string,
-  requestId: string,
-  pattern: string,
-  scope: string,
-  decision: "allow" | "deny",
-  auth?: Record<string, string>,
-): Promise<AddTrustRuleResponse> {
-  return runtimeRequest<AddTrustRuleResponse>(
-    baseUrl,
-    assistantId,
-    "/trust-rules",
-    {
-      method: "POST",
-      body: JSON.stringify({ requestId, pattern, scope, decision }),
-    },
-    auth,
-  );
-}
-
 // ── SSE event types ─────────────────────────────────────────────
 interface SseEvent {
   type: string;
@@ -568,8 +541,6 @@ async function handleConfirmationPrompt(
     confirmation.toolName,
     confirmation.input,
   );
-  const allowlistOptions = confirmation.allowlistOptions ?? [];
-
   chatApp.addStatus(`\u250C ${confirmation.toolName}: ${preview}`);
   chatApp.addStatus(`\u2502 Risk: ${confirmation.riskLevel}`);
   if (confirmation.executionTarget) {
@@ -578,127 +549,12 @@ async function handleConfirmationPrompt(
   chatApp.addStatus("\u2514");
 
   const options = ["Allow once", "Deny once"];
-  if (
-    allowlistOptions.length > 0 &&
-    confirmation.persistentDecisionsAllowed !== false
-  ) {
-    options.push("Allowlist...", "Denylist...");
-  }
 
   const index = await chatApp.showSelection("Tool Approval", options);
 
   if (index === 0) {
     await submitDecision(baseUrl, assistantId, requestId, "allow", auth);
     chatApp.addStatus("\u2714 Allowed", "green");
-    return;
-  }
-  if (index === 2) {
-    await handlePatternSelection(
-      baseUrl,
-      assistantId,
-      requestId,
-      confirmation,
-      chatApp,
-      "always_allow",
-      auth,
-    );
-    return;
-  }
-  if (index === 3) {
-    await handlePatternSelection(
-      baseUrl,
-      assistantId,
-      requestId,
-      confirmation,
-      chatApp,
-      "always_deny",
-      auth,
-    );
-    return;
-  }
-
-  await submitDecision(baseUrl, assistantId, requestId, "deny", auth);
-  chatApp.addStatus("\u2718 Denied", "yellow");
-}
-
-async function handlePatternSelection(
-  baseUrl: string,
-  assistantId: string,
-  requestId: string,
-  confirmation: PendingConfirmation,
-  chatApp: ChatAppHandle,
-  trustDecision: TrustDecision,
-  auth?: Record<string, string>,
-): Promise<void> {
-  const allowlistOptions = confirmation.allowlistOptions ?? [];
-  const label = trustDecision === "always_deny" ? "Denylist" : "Allowlist";
-  const options = allowlistOptions.map((o) => o.label);
-
-  const index = await chatApp.showSelection(
-    `${label}: choose command pattern`,
-    options,
-  );
-
-  if (index >= 0 && index < allowlistOptions.length) {
-    const selectedPattern = allowlistOptions[index].pattern;
-    await handleScopeSelection(
-      baseUrl,
-      assistantId,
-      requestId,
-      confirmation,
-      chatApp,
-      selectedPattern,
-      trustDecision,
-      auth,
-    );
-    return;
-  }
-
-  await submitDecision(baseUrl, assistantId, requestId, "deny", auth);
-  chatApp.addStatus("\u2718 Denied", "yellow");
-}
-
-async function handleScopeSelection(
-  baseUrl: string,
-  assistantId: string,
-  requestId: string,
-  confirmation: PendingConfirmation,
-  chatApp: ChatAppHandle,
-  selectedPattern: string,
-  trustDecision: TrustDecision,
-  auth?: Record<string, string>,
-): Promise<void> {
-  const scopeOptions = confirmation.scopeOptions ?? [];
-  const label = trustDecision === "always_deny" ? "Denylist" : "Allowlist";
-  const options = scopeOptions.map((o) => o.label);
-
-  const index = await chatApp.showSelection(`${label}: choose scope`, options);
-
-  if (index >= 0 && index < scopeOptions.length) {
-    const ruleDecision = trustDecision === "always_deny" ? "deny" : "allow";
-    await addTrustRule(
-      baseUrl,
-      assistantId,
-      requestId,
-      selectedPattern,
-      scopeOptions[index].scope,
-      ruleDecision,
-      auth,
-    );
-    await submitDecision(
-      baseUrl,
-      assistantId,
-      requestId,
-      ruleDecision === "deny" ? "deny" : "allow",
-      auth,
-    );
-    const ruleLabel =
-      trustDecision === "always_deny" ? "Denylisted" : "Allowlisted";
-    const ruleColor = trustDecision === "always_deny" ? "yellow" : "green";
-    chatApp.addStatus(
-      `${trustDecision === "always_deny" ? "\u2718" : "\u2714"} ${ruleLabel}`,
-      ruleColor,
-    );
     return;
   }
 


### PR DESCRIPTION
Part of LUM-3467's standalone-bug sweep (third of the three broken always-allow surfaces, after #41506 and #41509).

## TL;DR

The CLI's Tool Approval menu offered "Allowlist..." / "Denylist..." options whose flow posts to `POST /v1/trust-rules` on the daemon — a route the daemon does not serve (its trust-rules surface is `GET` list and `POST suggest`). The 404 throws before the decision is ever submitted, so picking either option creates no rule, never answers the approval, and strands the prompt until it times out into a deny. This removes the two dead options and the 144 lines of selection flow behind them.

## What changes for the user

| Surface | Before | After |
| --- | --- | --- |
| CLI Tool Approval menu (when allowlist options exist) | Four options; picking "Allowlist..."/"Denylist..." silently 404s, skips the decision, and the tool call dies by timeout-deny | Two options, Allow once / Deny once, both of which work |

## Why this is safe

- Deletion-only: no option that worked is removed. The deleted flow has thrown on its first network call since the daemon route it targets was removed at trust-rules GA.
- The `allowlistOptions`/`scopeOptions`/`persistentDecisionsAllowed` fields stay on the CLI's confirmation types as wire mirrors of the SSE payload.
- Durable Always-Allow rules remain available through the web rule editor (backed by the gateway trust-rules API); re-surfacing them in the CLI belongs to the LUM-3467 consent redesign, which owns what scoped approval verbs should exist at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41510" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->