### PR TITLE
docs(permissions): make the admission and approvals comments tell the truth

### DIFF
--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -764,9 +764,10 @@ export async function handleChannelInbound({
   // re-verification challenge — §8.2). The gateway kill switch already
   // dropped `no_one` upstream, but the stage handles it defensively.
   //
-  // Internal channels (`vellum`, `platform`, `a2a`) short-circuit admit
-  // inside `enforceAdmissionPolicy` — defense in depth alongside the
-  // gateway's exempt-channel skip and the PUT-handler's 403.
+  // Exempt channels (`platform`, `a2a`) short-circuit admit inside
+  // `enforceAdmissionPolicy` — defense in depth alongside the gateway's
+  // exempt-channel skip and the PUT-handler's 403. `vellum` is hidden, not
+  // exempt: its floor is evaluated like any enforced channel's.
   //
   // Bootstrap deep-link: when ACL resolved a validated pending_bootstrap
   // session, skip the floor entirely. The bootstrap intercept stage below

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -765,7 +765,7 @@ export async function handleChannelInbound({
   // dropped `no_one` upstream, but the stage handles it defensively.
   //
   // Exempt channels (`platform`, `a2a`) short-circuit admit inside
-  // `enforceAdmissionPolicy` — defense in depth alongside the gateway's
+  // `enforceAdmissionPolicy`: defense in depth alongside the gateway's
   // exempt-channel skip and the PUT-handler's 403. `vellum` is hidden, not
   // exempt: its floor is evaluated like any enforced channel's.
   //

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -109,8 +109,10 @@ export interface AclEnforcementParams {
    * - `any_contact`: inactive `pending`/`unverified` members are passed
    *   through.
    *
-   * Passing this in avoids having ACL fire guardian notifications and canned
-   * replies for senders who will be admitted by the floor stage anyway.
+   * Passing this in keeps ACL from firing guardian notifications and canned
+   * replies for senders whose final answer belongs to the floor stage:
+   * admission under the permissive floors, or a `guardian_only` denial
+   * delivered without a misleading verification challenge.
    */
   effectiveAdmissionPolicy?: AdmissionPolicy;
   /**

--- a/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
+++ b/assistant/src/runtime/routes/inbound-stages/acl-enforcement.ts
@@ -99,12 +99,15 @@ export interface AclEnforcementParams {
   replyCallbackUrl: string | undefined;
   assistantId: string;
   /**
-   * Effective admission policy for this request (gateway floor resolved with
-   * any per-conversation override). When set, ACL skips its hard-deny paths
-   * when the policy is permissive enough:
+   * Effective admission policy for this request (the gateway's per-channel
+   * floor). When set, ACL skips its hard-deny paths when the policy makes
+   * the floor stage the right place to answer:
    * - `strangers`: non-members and inactive (non-blocked) members are passed
    *   through so the admission floor can emit the final verdict.
-   * - `any_contact`: inactive `pending` members are passed through.
+   * - `guardian_only`: non-members and inactive `pending`/`unverified`
+   *   members are passed through; the floor denies everyone below guardian.
+   * - `any_contact`: inactive `pending`/`unverified` members are passed
+   *   through.
    *
    * Passing this in avoids having ACL fire guardian notifications and canned
    * replies for senders who will be admitted by the floor stage anyway.

--- a/assistant/src/runtime/routes/inbound-stages/admission-policy.ts
+++ b/assistant/src/runtime/routes/inbound-stages/admission-policy.ts
@@ -7,7 +7,7 @@
  * floor (`sourceMetadata.admissionPolicy`); this stage compares the floor
  * to the resolved trust class's rank and either admits or denies.
  *
- * Deny semantics — see `wave-b-plan.md` §8.2:
+ * Deny semantics (the locked §8.2 decisions):
  *
  * - `shouldChallenge: true` when the policy is one that re-verification
  *   could lift past (`any_contact`, `strangers`). The caller fires the
@@ -66,7 +66,7 @@ export type AdmissionPolicyResult =
        * resolved trust class could clear the floor after verification.
        */
       shouldChallenge: boolean;
-      /** Effective policy that produced the deny (after override resolution). */
+      /** Policy that produced the deny. */
       effectivePolicy: AdmissionPolicy;
     };
 

--- a/clients/web/src/lib/channel-admission-policy/api.ts
+++ b/clients/web/src/lib/channel-admission-policy/api.ts
@@ -2,9 +2,9 @@
  * Per-channel inbound admission floor API
  * (gateway `/v1/assistants/{id}/channel-admission-policy/...`).
  *
- * Mirrors the Swift `ChannelAdmissionPolicyClient` in
- * `clients/shared/Network/ChannelAdmissionPolicyClient.swift` so naming
- * stays in lockstep across surfaces. Internal channels (platform/a2a) and
+ * Naming follows the gateway's admission-policy contract
+ * (`packages/gateway-client/src/admission-policy-contract.ts`) so the
+ * surfaces stay in lockstep. Internal channels (platform/a2a) and
  * hidden channels (vellum/whatsapp) are filtered client-side — the gateway is
  * already supposed to omit them from the list response, but we double-filter
  * so a future gateway regression can't leak them into the UI.

--- a/clients/web/src/lib/channel-admission-policy/types.ts
+++ b/clients/web/src/lib/channel-admission-policy/types.ts
@@ -1,7 +1,7 @@
 /**
  * Shared types for the per-channel admission policy. Mirrors
- * `gateway/src/db/admission-policy-store.ts` and the Swift
- * `ChannelAdmissionPolicy` types so cross-surface names stay in lockstep.
+ * `gateway/src/db/admission-policy-store.ts` so cross-surface names stay
+ * in lockstep.
  */
 
 export const ADMISSION_POLICY_VALUES = [

--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -289,7 +289,7 @@
       "scope": "assistant",
       "key": "channel-trust-floors",
       "label": "Channel Trust Floors",
-      "description": "Expose the Channel Trust Floors settings card (per-channel inbound admission policy) on the Privacy settings page. When off, the card is hidden and channels fall back to their default admission floors. On by default; disable to hide the card.",
+      "description": "Server-side switch for per-channel admission-floor enforcement: the gateway kill switch, the runtime floor stage, and the admission-policy reads all gate on it. On by default. Client UI visibility is version-gated, not flag-gated.",
       "defaultEnabled": true
     },
     {

--- a/clients/web/src/lib/feature-flags/feature-flag-registry.json
+++ b/clients/web/src/lib/feature-flags/feature-flag-registry.json
@@ -289,7 +289,7 @@
       "scope": "assistant",
       "key": "channel-trust-floors",
       "label": "Channel Trust Floors",
-      "description": "Server-side switch for per-channel admission-floor enforcement: the gateway kill switch, the runtime floor stage, and the admission-policy reads all gate on it. On by default. Client UI visibility is version-gated, not flag-gated.",
+      "description": "Server-side switch for admission-floor enforcement: the gateway kill switch, the runtime floor stage, and enforcement-time policy resolution gate on it. Configuration reads and writes stay available while it is off. On by default. Client UI visibility is version-gated, not flag-gated.",
       "defaultEnabled": true
     },
     {

--- a/gateway/src/db/admission-policy-store.ts
+++ b/gateway/src/db/admission-policy-store.ts
@@ -17,7 +17,7 @@ import { type ChannelId, isChannelId } from "../channels/types.js";
 /**
  * Per-channel inbound admission policy — ordered from most-restrictive
  * (`no_one`, hard kill switch) to most-permissive (`strangers`, admits any
- * sender). See plan section 2.3.
+ * sender).
  *
  * Vocabulary is centralized in `@vellumai/gateway-client` so the gateway
  * (storage + kill switch) and the runtime (admission stage) share one
@@ -35,7 +35,7 @@ export const VALID_ADMISSION_POLICY_VALUES: ReadonlySet<string> = new Set(
 /**
  * Read-side default applied when a channel has no row in the DB. Matches
  * today's effective semantics: guardian + active contacts admitted,
- * strangers denied. See plan section 2.2.
+ * strangers denied.
  */
 export const ADMISSION_POLICY_DEFAULT: AdmissionPolicy =
   ADMISSION_POLICY_DEFAULT_CONTRACT;
@@ -43,7 +43,7 @@ export const ADMISSION_POLICY_DEFAULT: AdmissionPolicy =
 /**
  * Minimum trust rank required for each policy. Higher rank = more trusted.
  * `no_one` is 5 — above the maximum guardian rank (4) — so no class is ever
- * admitted. See plan section 2.4 for the rank table (guardian=4,
+ * admitted. Rank table: guardian=4,
  * trusted_contact=3, unverified_contact=2, unknown=1; blocked/revoked=0).
  */
 export const ADMISSION_FLOOR: Record<AdmissionPolicy, number> =

--- a/gateway/src/handlers/handle-inbound.ts
+++ b/gateway/src/handlers/handle-inbound.ts
@@ -127,10 +127,12 @@ export async function admitInbound(
   // a `no_one` lockout would upgrade an actor on a channel the guardian has
   // explicitly turned off.
   //
-  // Defense in depth: the §8.1 exempt set (vellum/platform/a2a) skips this
-  // check so a guardian can never lock themselves out of the desktop client
-  // via the admission UI. The same exemption is enforced PUT-side in
-  // channel-admission-policy.ts and at the runtime admission stage.
+  // Defense in depth: the §8.1 exempt set (platform/a2a) skips this check.
+  // The same exemption is enforced PUT-side in channel-admission-policy.ts
+  // and at the runtime admission stage. `vellum` is hidden, not exempt: its
+  // floor stays enforced, and a guardian cannot lock themselves out of the
+  // desktop client because PUT 403s hidden channels and the seed re-pins
+  // `guardian_only`, which always admits the guardian.
   const admissionPolicy = resolveAdmissionPolicy(event.sourceChannel);
   if (admissionPolicy === "no_one") {
     log.info(

--- a/gateway/src/http/routes/channel-admission-policy.ts
+++ b/gateway/src/http/routes/channel-admission-policy.ts
@@ -3,8 +3,7 @@
  *
  * Mutations invalidate the in-memory admission policy cache so subsequent
  * `handle-inbound` evaluations see the new value within the same gateway
- * process (no restart). The cache is wired in P2 so the P3 admission gate
- * can read from it with no further infrastructure work.
+ * process (no restart).
  *
  * Mirrors the trust-rule routes — same zod / Response.json / error
  * conventions.

--- a/gateway/src/schema.ts
+++ b/gateway/src/schema.ts
@@ -3517,7 +3517,7 @@ export function buildSchema(): Record<string, unknown> {
         delete: {
           summary: "Delete a channel admission policy",
           description:
-            "Authenticated gateway endpoint that removes the admission policy for a single channel from the SQLite-backed store and invalidates the in-memory admission-policy cache. Internal channels (vellum/platform, vellum/a2a) are exempt from deletion per §8.1.",
+            "Authenticated gateway endpoint that removes the admission policy for a single channel from the SQLite-backed store and invalidates the in-memory admission-policy cache. Exempt channels (platform, a2a) and hidden channels (vellum, whatsapp) refuse deletion per §8.1.",
           operationId: "channelAdmissionPolicyDelete",
           security: [{ BearerAuth: [] }],
           parameters: [

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -289,7 +289,7 @@
       "scope": "assistant",
       "key": "channel-trust-floors",
       "label": "Channel Trust Floors",
-      "description": "Expose the Channel Trust Floors settings card (per-channel inbound admission policy) on the Privacy settings page. When off, the card is hidden and channels fall back to their default admission floors. On by default; disable to hide the card.",
+      "description": "Server-side switch for per-channel admission-floor enforcement: the gateway kill switch, the runtime floor stage, and the admission-policy reads all gate on it. On by default. Client UI visibility is version-gated, not flag-gated.",
       "defaultEnabled": true
     },
     {

--- a/meta/feature-flags/feature-flag-registry.json
+++ b/meta/feature-flags/feature-flag-registry.json
@@ -289,7 +289,7 @@
       "scope": "assistant",
       "key": "channel-trust-floors",
       "label": "Channel Trust Floors",
-      "description": "Server-side switch for per-channel admission-floor enforcement: the gateway kill switch, the runtime floor stage, and the admission-policy reads all gate on it. On by default. Client UI visibility is version-gated, not flag-gated.",
+      "description": "Server-side switch for admission-floor enforcement: the gateway kill switch, the runtime floor stage, and enforcement-time policy resolution gate on it. Configuration reads and writes stay available while it is off. On by default. Client UI visibility is version-gated, not flag-gated.",
       "defaultEnabled": true
     },
     {

--- a/packages/gateway-client/src/admission-policy-contract.ts
+++ b/packages/gateway-client/src/admission-policy-contract.ts
@@ -3,9 +3,9 @@
  *
  * Both the gateway (channel admission policy storage + kill switch) and the
  * runtime (admission-policy stage) consume these values. Keeping the type
- * here avoids the runtime importing from `gateway/src` and avoids the
- * vocabulary drift the plan §2.1 flags for the verification-purpose
- * `trustClass` enum.
+ * here avoids the runtime importing from `gateway/src` and keeps the
+ * vocabulary from drifting the way the verification-purpose `trustClass`
+ * enum once did.
  */
 
 import { z } from "zod";
@@ -15,7 +15,7 @@ import type { TrustClass } from "./trust-verdict-contract.js";
 /**
  * Per-channel inbound admission policy — ordered from most-restrictive
  * (`no_one`, hard kill switch) to most-permissive (`strangers`, admits any
- * sender). See `unverified-contact-role-plan.md` §2.3.
+ * sender).
  */
 export const ADMISSION_POLICY_VALUES = [
   "no_one",
@@ -32,14 +32,14 @@ export const AdmissionPolicySchema = z.enum(ADMISSION_POLICY_VALUES);
 /**
  * Read-side default applied when a channel has no row in the DB. Matches
  * today's effective semantics: guardian + active contacts admitted,
- * strangers denied. See plan §2.2.
+ * strangers denied.
  */
 export const ADMISSION_POLICY_DEFAULT: AdmissionPolicy = "trusted_contacts";
 
 /**
  * Minimum trust rank required for each policy. Higher rank = more trusted.
  * `no_one` is 5 — above the maximum guardian rank (4) — so no class is ever
- * admitted. See plan §2.4 for the rank table.
+ * admitted.
  */
 export const ADMISSION_FLOOR: Record<AdmissionPolicy, number> = {
   no_one: 5,

--- a/packages/gateway-client/src/admission-policy-contract.ts
+++ b/packages/gateway-client/src/admission-policy-contract.ts
@@ -3,9 +3,8 @@
  *
  * Both the gateway (channel admission policy storage + kill switch) and the
  * runtime (admission-policy stage) consume these values. Keeping the type
- * here avoids the runtime importing from `gateway/src` and keeps the
- * vocabulary from drifting the way the verification-purpose `trustClass`
- * enum once did.
+ * here avoids the runtime importing from `gateway/src` and keeps both
+ * sides on a single shared vocabulary.
  */
 
 import { z } from "zod";


### PR DESCRIPTION
Part of LUM-3467's standalone-bug sweep (the doc-drift inventory).

## TL;DR

Comments-and-descriptions-only sweep of the admission/permission stack, removing every statement the source-verified architecture mapping found to be false: a docstring for an override resolver that never shipped, an ACL doc block citing a per-conversation admission override that does not exist (while omitting the `guardian_only` bypass branches the code has), three comments calling `vellum` exempt when it is hidden-and-enforced (one in the published OpenAPI description, which also garbled the channel names), citations to two plan files never committed to the repo, a flag description for a settings card no code renders, references to a Swift client at a path that does not exist, and a P2/P3 rollout narration.

## Why this is safe

Zero behavior changes: every hunk is a comment, docstring, JSON description string, or OpenAPI description. All four touched packages typecheck; prettier clean. The §8.x decision labels are kept (they anchor to locked decisions recorded in commit history); only the dangling file references and false statements go.

## What changes for the user

Nothing at runtime. The published OpenAPI description for the admission-policy DELETE route now names the exempt/hidden channel sets correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41511" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->