### PR TITLE
Add vellum-outcome-gate

### DIFF
--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -527,7 +527,7 @@
       "license": "MIT",
       "icon": "⚓"
     },
-    {
+       {
       "name": "octolens",
       "source": {
         "source": "github",
@@ -538,6 +538,19 @@
       "category": "growth",
       "homepage": "https://github.com/vellum-ai/octolens",
       "license": "MIT"
+    },
+    {
+      "name": "vellum-outcome-gate",
+      "source": {
+        "source": "github",
+        "repo": "jsfranklin221/vellum-outcome-gate",
+        "ref": "d94a6ea1dcbd9ce36decda7cd90afa485c6abb0d"
+      },
+      "description": "Check delivered work against explicit acceptance criteria before payment or another consequential action. Returns what passed, what failed, what was earned, and a signed Outcome Receipt through the Spoolis API, with a keyless sandbox for demos.",
+      "category": "finance",
+      "homepage": "https://github.com/jsfranklin221/vellum-outcome-gate",
+      "license": "MIT",
+      "icon": "🚦"
     }
   ]
 }

--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -544,7 +544,7 @@
       "source": {
         "source": "github",
         "repo": "jsfranklin221/vellum-outcome-gate",
-        "ref": "d94a6ea1dcbd9ce36decda7cd90afa485c6abb0d"
+        "ref": "ed5104d8bed5636e56990aee4ec830378f93b9da"
       },
       "description": "Check delivered work against explicit acceptance criteria before payment or another consequential action. Returns what passed, what failed, what was earned, and a signed Outcome Receipt through the Spoolis API, with a keyless sandbox for demos.",
       "category": "finance",

--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -540,15 +540,15 @@
       "license": "MIT"
     },
     {
-      "name": "vellum-outcome-gate",
+      "name": "spoolis-outcome-gate",
       "source": {
         "source": "github",
-        "repo": "jsfranklin221/vellum-outcome-gate",
-        "ref": "ed5104d8bed5636e56990aee4ec830378f93b9da"
+        "repo": "jsfranklin221/spoolis-outcome-gate",
+        "ref": "64d088f48fbaea925c9930dccf1b7a823b71e994"
       },
       "description": "Check delivered work against explicit acceptance criteria before payment or another consequential action. Returns what passed, what failed, what was earned, and a signed Outcome Receipt through the Spoolis API, with a keyless sandbox for demos.",
       "category": "finance",
-      "homepage": "https://github.com/jsfranklin221/vellum-outcome-gate",
+      "homepage": "https://github.com/jsfranklin221/spoolis-outcome-gate",
       "license": "MIT",
       "icon": "🚦"
     }

--- a/plugins/marketplace.json
+++ b/plugins/marketplace.json
@@ -527,7 +527,7 @@
       "license": "MIT",
       "icon": "⚓"
     },
-       {
+    {
       "name": "octolens",
       "source": {
         "source": "github",


### PR DESCRIPTION
Adds vellum-outcome-gate, an outcome gate for consequential actions. It checks delivered work against explicit acceptance criteria through the public Spoolis API and returns what passed, what failed, what was earned, and a signed Outcome Receipt.

Notes for review: the plugin calls the public Spoolis API, supports a keyless sandbox for demos, does not move money, and makes no affiliation claim with Vellum or Natural. The API key, when used, is stored only through the host credential prompt via the bundled setup skill; the committed mcp.json is endpoint-only.