### PR TITLE
fix(oauth): remove unsupported Monday item scopes

### DIFF
--- a/assistant/src/oauth/__tests__/seed-providers-managed.test.ts
+++ b/assistant/src/oauth/__tests__/seed-providers-managed.test.ts
@@ -11,6 +11,24 @@ describe("PROVIDER_SEED_DATA managed mode wiring", () => {
     expect("github-oauth" in ServicesSchema.shape).toBe(true);
   });
 
+  test("monday only exposes scopes supported by its OAuth API", () => {
+    const monday = PROVIDER_SEED_DATA.monday;
+    expect(monday).toBeDefined();
+    expect(monday.defaultScopes).not.toContain("items:read");
+    expect(monday.defaultScopes).not.toContain("items:write");
+
+    const availableScopes = monday.availableScopes;
+    expect(Array.isArray(availableScopes)).toBe(true);
+    if (Array.isArray(availableScopes)) {
+      expect(availableScopes.map(({ scope }) => scope)).not.toContain(
+        "items:read",
+      );
+      expect(availableScopes.map(({ scope }) => scope)).not.toContain(
+        "items:write",
+      );
+    }
+  });
+
   test("google base URL is host-only so relative paths select the product", () => {
     // A host-only base URL (no product path) lets a relative request path pick
     // the Google product — Gmail (/gmail/v1/...), Calendar (/calendar/v3/...),

--- a/assistant/src/oauth/seed-providers.ts
+++ b/assistant/src/oauth/seed-providers.ts
@@ -714,8 +714,6 @@ export const PROVIDER_SEED_DATA: Record<
       "workspaces:read",
       "boards:read",
       "boards:write",
-      "items:read",
-      "items:write",
       "docs:read",
       "updates:read",
       "updates:write",
@@ -752,8 +750,6 @@ export const PROVIDER_SEED_DATA: Record<
       },
       { scope: "boards:read", description: "Read a user's board data" },
       { scope: "boards:write", description: "Modify a user's board data" },
-      { scope: "items:read", description: "Read a user's item data" },
-      { scope: "items:write", description: "Modify a user's item data" },
       { scope: "docs:read", description: "Read a user's docs" },
       { scope: "docs:write", description: "Modify a user's docs" },
       {


### PR DESCRIPTION
## What

Remove `items:read` and `items:write` from Monday OAuth `defaultScopes` and `availableScopes`. Monday item operations use board permissions, and the provider rejects those item-level scopes with `invalid_scope`.

This complements the managed-platform registry fix in vellum-ai/vellum-assistant-platform#10128; without the daemon-side change, managed connect still forwards the stale seeded defaults.

## Validation

- `bun test src/oauth/__tests__/seed-providers-managed.test.ts` (5 passed)
- `bunx eslint src/oauth/seed-providers.ts src/oauth/__tests__/seed-providers-managed.test.ts`
- `git diff --check`
- Full `bun run typecheck:fast` attempted; `tsgo` was SIGKILLed by the constrained validation container after the focused test passed, with no TypeScript diagnostic emitted.

## Rollout note

The provider seed is upserted on daemon startup, so assistants need a build containing this change and a restart before the corrected scopes are reflected locally.