### PR TITLE
feat(web): speak first when voice opens on a blank thread (JARVIS-1649)

### DIFF
--- a/assistant/src/live-voice/__tests__/live-voice-text-turn.test.ts
+++ b/assistant/src/live-voice/__tests__/live-voice-text-turn.test.ts
@@ -163,6 +163,43 @@ describe("typed live-voice turns", () => {
     await session.close("websocket_close");
   });
 
+  test("a hidden text frame runs the turn as an internal instruction", async () => {
+    // The greeting that opens a voice session is a machine signal, not
+    // something the user typed. It must still drive the turn and still reach
+    // the model, so it persists, but `hiddenSyntheticPrompt` is what keeps it
+    // out of the transcript (no echo, filtered from `/messages`).
+    const { session, turnOptions } = createHarness();
+    await session.start();
+
+    await session.handleClientFrame({
+      type: "text",
+      text: "this message is sent automatically",
+      hidden: true,
+    });
+
+    await waitFor(() => turnOptions.length > 0);
+    expect(turnOptions[0]?.hiddenSyntheticPrompt).toBe(true);
+    expect(turnOptions[0]?.content).toContain(
+      "this message is sent automatically",
+    );
+
+    await session.close("websocket_close");
+  });
+
+  test("an ordinary typed turn stays visible", async () => {
+    // A turn the user actually typed is a real message and must render like
+    // one, so the flag is never set by default.
+    const { session, turnOptions } = createHarness();
+    await session.start();
+
+    await session.handleClientFrame({ type: "text", text: "typed by hand" });
+
+    await waitFor(() => turnOptions.length > 0);
+    expect(turnOptions[0]?.hiddenSyntheticPrompt).toBeUndefined();
+
+    await session.close("websocket_close");
+  });
+
   test("a typed turn emits the same thinking frame a spoken one does", async () => {
     // The client draws its working state off `thinking`. A typed turn that
     // skipped it would leave the room idle while the assistant worked.

--- a/assistant/src/live-voice/__tests__/protocol.test.ts
+++ b/assistant/src/live-voice/__tests__/protocol.test.ts
@@ -494,6 +494,61 @@ describe("parseLiveVoiceClientTextFrame", () => {
     });
   });
 
+  test("carries the hidden marker on a text turn that sets it", () => {
+    const result = validateLiveVoiceClientFrame({
+      type: "text",
+      text: "this message is sent automatically",
+      hidden: true,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    expect(result.frame).toEqual({
+      type: "text",
+      text: "this message is sent automatically",
+      hidden: true,
+    });
+  });
+
+  test.each([[false], [undefined]])(
+    "omits the hidden marker when it is %s",
+    (hidden) => {
+      // Absent rather than `hidden: false`, so a turn the user typed is
+      // byte-identical to one sent by a client that predates the field.
+      const result = validateLiveVoiceClientFrame({
+        type: "text",
+        text: "typed by hand",
+        ...(hidden === undefined ? {} : { hidden }),
+      });
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) {
+        return;
+      }
+      expect(result.frame).toEqual({ type: "text", text: "typed by hand" });
+    },
+  );
+
+  test("rejects a non-boolean hidden marker", () => {
+    const result = validateLiveVoiceClientFrame({
+      type: "text",
+      text: "hello",
+      hidden: "yes",
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      return;
+    }
+    expect(result.error).toMatchObject({
+      code: "invalid_field",
+      field: "hidden",
+      frameType: "text",
+    });
+  });
+
   test.each([
     ["empty", ""],
     ["whitespace only", "   \n\t "],

--- a/assistant/src/live-voice/live-voice-session.ts
+++ b/assistant/src/live-voice/live-voice-session.ts
@@ -707,6 +707,10 @@ interface ActiveAssistantTurn {
   // no user utterance behind it — `content` is CONTINUATION_DELIVERY_CONTENT and
   // the answer rides the control prompt (buildLiveDeliveryNote).
   continuationDelivery: ContinuationDelivery | null;
+  // The turn's content is an internal instruction rather than user speech (the
+  // greeting that opens a session, say). The row still persists and the model
+  // still sees it; `hiddenSyntheticPrompt` keeps it out of the transcript.
+  hiddenPrompt: boolean;
   // Set when a barge-in handed the interrupted work to a background subagent:
   // that request's transcript, so the model can tell the user the work is
   // still running instead of appearing to have dropped it.
@@ -1576,7 +1580,9 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
     // Before the launch, so the anchor is the moment the text arrived rather
     // than whatever the dispatch costs.
     this.markTypedTurnSubmitted(utterance);
-    await this.launchAssistantTurn(utterance, frame.text);
+    await this.launchAssistantTurn(utterance, frame.text, {
+      ...(frame.hidden === true ? { hiddenPrompt: true } : {}),
+    });
   }
 
   /**
@@ -4711,6 +4717,10 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       // leading verdict commits the turn (see commitSpeculativeTurn); a hold
       // verdict rolls everything back instead.
       speculative?: boolean;
+      // Marks `content` as an internal instruction rather than user speech, so
+      // the row persists and drives the turn but never renders: no echo, and
+      // `/messages` filters it after a reload.
+      hiddenPrompt?: boolean;
     },
   ): Promise<boolean> {
     utterance.assistantTurnStarted = true;
@@ -4771,6 +4781,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       consumedAnnouncement: pending?.announcement ?? null,
       pendingContextStopGeneration: this.detachStopGeneration,
       continuationDelivery: opts?.continuationDelivery ?? null,
+      hiddenPrompt: opts?.hiddenPrompt === true,
       deltaEpoch: 0,
       escalationHandedOff: false,
       ttsBuffer: "",
@@ -4945,6 +4956,7 @@ export class LiveVoiceSession implements LiveVoiceSessionContract {
       const handle = await this.startVoiceTurn({
         conversationId: this.conversationId,
         voiceSessionId: this.context.sessionId,
+        ...(activeTurn.hiddenPrompt ? { hiddenSyntheticPrompt: true } : {}),
         userMessageChannel: "vellum",
         assistantMessageChannel: "vellum",
         // Fixed, and NOT the originating client: this pair resolves the turn's

--- a/assistant/src/live-voice/protocol.ts
+++ b/assistant/src/live-voice/protocol.ts
@@ -229,6 +229,20 @@ export interface LiveVoiceClientAttachImageFrame {
 export interface LiveVoiceClientTextTurnFrame {
   readonly type: "text";
   readonly text: string;
+  /**
+   * Marks the turn as an internal instruction rather than something the user
+   * typed. The row still persists and still drives the turn, so the model
+   * sees it, but it is suppressed from the transcript: no live echo, and
+   * `/messages` filters it after a reload.
+   *
+   * For machine signals the user never wrote, such as the greeting that opens
+   * a voice session. A turn the user actually typed leaves it unset.
+   *
+   * Optional, and a daemon that does not understand it simply persists the
+   * turn visibly, so a client cannot tell from the frame alone whether it was
+   * honored.
+   */
+  readonly hidden?: boolean;
 }
 
 export type LiveVoiceClientFrame =
@@ -690,7 +704,23 @@ function validateTextTurnFrame(
     );
   }
 
-  return { ok: true, frame: { type: "text", text } };
+  if ("hidden" in value && typeof value.hidden !== "boolean") {
+    return protocolError(
+      "invalid_field",
+      "text frame field hidden must be a boolean",
+      "hidden",
+      "text",
+    );
+  }
+
+  return {
+    ok: true,
+    frame: {
+      type: "text",
+      text,
+      ...(value.hidden === true ? { hidden: true } : {}),
+    },
+  };
 }
 
 function validateAttachImageFrame(

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.test.tsx
@@ -112,7 +112,11 @@ import {
 } from "@/domains/chat/voice/live-voice/live-voice-store";
 
 const liveStarterSpy = mock(
-  (_assistantId: string, _conversationId: string | null) => {},
+  (
+    _assistantId: string,
+    _conversationId: string | null,
+    _options?: { seedText?: string },
+  ) => {},
 );
 const livePrewarmSpy = mock(() => {});
 const liveCancelPrewarmSpy = mock(() => {});
@@ -2367,8 +2371,53 @@ describe("ChatComposer — live-voice integration", () => {
     // THEN the layout-owned controller starts with the bound context after the
     // ready verdict (the composer holds no controller of its own).
     expect(liveStarterSpy).toHaveBeenCalledTimes(1);
-    expect(liveStarterSpy).toHaveBeenCalledWith("asst_test", "conv_test");
+    expect(liveStarterSpy).toHaveBeenCalledWith("asst_test", "conv_test", {
+      // No greeting: this composer is bound to a conversation already
+      // underway (JARVIS-1649).
+      seedText: undefined,
+    });
     expect(liveCancelPrewarmSpy).not.toHaveBeenCalled();
+  });
+
+  test("on a blank conversation the start carries a seed so the assistant speaks first", async () => {
+    // GIVEN a composer bound to a conversation with nothing in it (JARVIS-1649)
+    useTurnStore.setState(INITIAL_TURN_STATE);
+    mockPreflightVerdict = { status: "ready" };
+
+    // WHEN the user enters voice mode
+    const { getByLabelText } = renderVoiceComposer({
+      conversationIsEmpty: true,
+    });
+    fireEvent.click(getByLabelText("Start voice mode"));
+    await flushPreflight();
+
+    // THEN the session is started with a first turn to take on the user's
+    // behalf, so the room does not open in silence waiting for them.
+    expect(liveStarterSpy).toHaveBeenCalledTimes(1);
+    const [, , options] = liveStarterSpy.mock.calls[0] ?? [];
+    expect(options?.seedText).toBeString();
+    expect((options?.seedText ?? "").length).toBeGreaterThan(0);
+  });
+
+  test("a conversation that fills up during the preflight is not seeded", async () => {
+    // GIVEN a blank conversation at click time
+    useTurnStore.setState(INITIAL_TURN_STATE);
+    mockPreflightVerdict = { status: "ready" };
+    const { getByLabelText, rerenderWith } = renderVoiceComposer({
+      conversationIsEmpty: true,
+    });
+    fireEvent.click(getByLabelText("Start voice mode"));
+
+    // WHEN a message lands while the readiness round trip is still in flight
+    rerenderWith({ conversationIsEmpty: false });
+    await flushPreflight();
+
+    // THEN the start goes ahead (an emptiness change is not a reason to
+    // abandon the press) but opens silent: the thread is underway now, so a
+    // seed would be a line the user never wrote.
+    expect(liveStarterSpy).toHaveBeenCalledTimes(1);
+    const [, , options] = liveStarterSpy.mock.calls[0] ?? [];
+    expect(options?.seedText).toBeUndefined();
   });
 
   test("entering voice mode drops the composer's focus, and only that", async () => {
@@ -2497,7 +2546,11 @@ describe("ChatComposer — live-voice integration", () => {
     // THEN a preflight outage does not block voice — the session starts and
     // the WS-level handshake surfaces any real credential problem
     expect(liveStarterSpy).toHaveBeenCalledTimes(1);
-    expect(liveStarterSpy).toHaveBeenCalledWith("asst_test", "conv_test");
+    expect(liveStarterSpy).toHaveBeenCalledWith("asst_test", "conv_test", {
+      // No greeting: this composer is bound to a conversation already
+      // underway (JARVIS-1649).
+      seedText: undefined,
+    });
     expect(livePrewarmSpy).toHaveBeenCalledTimes(1);
     expect(liveCancelPrewarmSpy).not.toHaveBeenCalled();
   });
@@ -2564,7 +2617,11 @@ describe("ChatComposer — live-voice integration", () => {
     expect(useVoicePrefsStore.getState().firstRunSeen).toBe(true);
     expect(queryByTestId("first-run-card")).toBeNull();
     expect(liveStarterSpy).toHaveBeenCalledTimes(1);
-    expect(liveStarterSpy).toHaveBeenCalledWith("asst_test", "conv_test");
+    expect(liveStarterSpy).toHaveBeenCalledWith("asst_test", "conv_test", {
+      // No greeting: this composer is bound to a conversation already
+      // underway (JARVIS-1649).
+      seedText: undefined,
+    });
     expect(livePrewarmSpy).toHaveBeenCalledTimes(1);
   });
 
@@ -2624,7 +2681,11 @@ describe("ChatComposer — live-voice integration", () => {
     // THEN it behaves exactly like the returning-user path on any platform
     expect(queryByTestId("first-run-card")).toBeNull();
     expect(liveStarterSpy).toHaveBeenCalledTimes(1);
-    expect(liveStarterSpy).toHaveBeenCalledWith("asst_test", "conv_test");
+    expect(liveStarterSpy).toHaveBeenCalledWith("asst_test", "conv_test", {
+      // No greeting: this composer is bound to a conversation already
+      // underway (JARVIS-1649).
+      seedText: undefined,
+    });
     expect(livePrewarmSpy).toHaveBeenCalledTimes(1);
   });
 

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -71,6 +71,7 @@ import {
   useIsLiveVoiceSessionOwnedBy,
   useLiveVoiceStore,
 } from "@/domains/chat/voice/live-voice/live-voice-store";
+import { voiceEntryGreetingSeed } from "@/domains/chat/voice/live-voice/voice-entry-greeting";
 import {
   firstRunCardIntercepts,
   publishConfigNotice,
@@ -183,6 +184,15 @@ export interface ChatComposerProps {
   // absent the session starts without a conversation and the server assigns
   // one. The app-editing variant, which has no voice, leaves this undefined.
   conversationId?: string | null;
+
+  // Whether that conversation has nothing in it yet. Drives the one decision
+  // in `voiceEntryGreetingSeed`: a voice session opened on a blank thread
+  // takes its first turn on the user's behalf so the assistant speaks first,
+  // and one opened on a thread already underway does not. Pass the same value
+  // the empty state renders from, so the two cannot disagree about what empty
+  // means. Optional, defaulting to false: a caller that says nothing gets the
+  // silent room it had before.
+  conversationIsEmpty?: boolean;
 
   // chrome surfacing existing buttons (rendered in the form's bottom-left row
   // on desktop; on mobile both settings slots move to the row above the card)
@@ -336,6 +346,7 @@ export function ChatComposer({
   isAssistantBusy,
   assistantId,
   conversationId,
+  conversationIsEmpty = false,
   thresholdPickerSlot,
   modelPickerSlot,
   settingsSheetOpen = false,
@@ -486,10 +497,18 @@ export function ChatComposer({
   // a user who switches chats (or leaves) mid-flight would otherwise resume and
   // bind the room to the chat they left. Kept in a ref so the check sees the
   // current render's values rather than the closure's.
-  const liveVoiceChatIdentityRef = useRef({ assistantId, conversationId });
+  const liveVoiceChatIdentityRef = useRef({
+    assistantId,
+    conversationId,
+    conversationIsEmpty,
+  });
   useEffect(() => {
-    liveVoiceChatIdentityRef.current = { assistantId, conversationId };
-  }, [assistantId, conversationId]);
+    liveVoiceChatIdentityRef.current = {
+      assistantId,
+      conversationId,
+      conversationIsEmpty,
+    };
+  }, [assistantId, conversationId, conversationIsEmpty]);
   const startLiveVoiceSession = useCallback(async () => {
     if (!assistantId || liveVoicePreflightPendingRef.current) {
       return;
@@ -548,7 +567,15 @@ export function ChatComposer({
     // Publish the origin BEFORE starting; the controller carries it across its
     // start-time `reset()` (see the live-voice store's `entryOrigin`).
     setLiveVoiceEntryOrigin(origin);
-    starter?.start(assistantId, conversationId ?? null);
+    // Read off `latest`, not off the render that opened this callback: the
+    // preflight above is a network round trip, and a conversation that filled
+    // up across it must not be seeded as if it were still blank. Unlike the
+    // assistant/conversation mismatch this is not a reason to abandon the
+    // start, only a reason to open silent, so it is decided here rather than
+    // in the staleness guard.
+    starter?.start(assistantId, conversationId ?? null, {
+      seedText: voiceEntryGreetingSeed(latest.conversationIsEmpty),
+    });
   }, [assistantId, conversationId]);
   /**
    * In-flight reclaim, so unmounting cancels it. The start on the far side of

--- a/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
+++ b/clients/web/src/domains/chat/components/chat-composer/chat-composer.tsx
@@ -190,8 +190,8 @@ export interface ChatComposerProps {
   // takes its first turn on the user's behalf so the assistant speaks first,
   // and one opened on a thread already underway does not. Pass the same value
   // the empty state renders from, so the two cannot disagree about what empty
-  // means. Optional, defaulting to false: a caller that says nothing gets the
-  // silent room it had before.
+  // means. Optional, defaulting to false: a caller that says nothing opens a
+  // silent room.
   conversationIsEmpty?: boolean;
 
   // chrome surfacing existing buttons (rendered in the form's bottom-left row

--- a/clients/web/src/domains/chat/components/chat-route-content.tsx
+++ b/clients/web/src/domains/chat/components/chat-route-content.tsx
@@ -1332,6 +1332,9 @@ export function ChatMainPanel({
       // session should attach to the thread the user is looking at — draft
       // ids included (the runtime accepts client-generated conversation ids).
       conversationId={activeConversationId}
+      // Same value the empty state renders from, so "speak first" and "show
+      // the blank-thread greeting" can never disagree about what empty means.
+      conversationIsEmpty={isEmptyConversation}
       onRecallLastMessage={
         isIdle && isNativeConversation ? handleRecallLastMessage : undefined
       }

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-client.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-client.test.ts
@@ -564,6 +564,27 @@ describe("server frame dispatch", () => {
     });
   });
 
+  test("sendText marks a turn hidden only when asked", async () => {
+    const { client, ws } = await ready({ textInput: true });
+
+    expect(client.sendText("an automatic greeting", { hidden: true })).toBe(
+      true,
+    );
+    expect(ws.sentJson.at(-1)).toEqual({
+      type: "text",
+      text: "an automatic greeting",
+      hidden: true,
+    });
+
+    // Omitted rather than `hidden: false`, so a turn the user typed is
+    // byte-identical on the wire to one from a client predating the field.
+    expect(client.sendText("typed by hand", { hidden: false })).toBe(true);
+    expect(ws.sentJson.at(-1)).toEqual({
+      type: "text",
+      text: "typed by hand",
+    });
+  });
+
   test("sendText trims and refuses an empty turn", async () => {
     const { client, ws } = await ready({ textInput: true });
 

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-client.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-client.ts
@@ -433,8 +433,14 @@ export class LiveVoiceChannelClient {
    * A turn the daemon refuses because it is mid-reply comes back as a
    * `recoverable` error frame carrying `frameType: "text"`, not as a false
    * here: the frame went out, and the answer arrived later.
+   *
+   * `hidden` marks the turn as an internal instruction rather than something
+   * the user typed: it still drives the turn and the model still sees it, but
+   * it never renders in the transcript. An assistant too old to know the field
+   * ignores it and persists the turn visibly, which no answer here reports, so
+   * text sent this way must still read acceptably to a human.
    */
-  sendText(text: string): boolean {
+  sendText(text: string, options?: { hidden?: boolean }): boolean {
     if (this.state !== "active" || !this.textInputSupported) {
       return false;
     }
@@ -442,7 +448,13 @@ export class LiveVoiceChannelClient {
     if (trimmed.length === 0) {
       return false;
     }
-    return this.trySend(JSON.stringify({ type: "text", text: trimmed }));
+    return this.trySend(
+      JSON.stringify({
+        type: "text",
+        text: trimmed,
+        ...(options?.hidden === true ? { hidden: true } : {}),
+      }),
+    );
   }
 
   /** Whether this session's assistant accepts typed turns. */

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-fakes.test-helper.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-fakes.test-helper.ts
@@ -50,6 +50,13 @@ export class FakeClient {
     bargeInMinSpeechMs?: number;
   } | null = null;
   sentAudio: ArrayBuffer[] = [];
+  sentText: string[] = [];
+  /**
+   * Mirrors the real client's `ready.textInput` echo. False by default, as the
+   * real one is until a `ready` frame says otherwise, so a test that wants a
+   * typed turn to go out has to say so.
+   */
+  textInputSupported = false;
   pttReleaseCount = 0;
   interruptCount = 0;
   updateConfigCalls: {
@@ -89,6 +96,16 @@ export class FakeClient {
 
   sendAudio(pcm: ArrayBuffer): void {
     this.sentAudio.push(pcm);
+  }
+  sendText(text: string): boolean {
+    if (!this.textInputSupported) {
+      return false;
+    }
+    this.sentText.push(text);
+    return true;
+  }
+  get supportsTextInput(): boolean {
+    return this.textInputSupported;
   }
   pttRelease(): void {
     this.pttReleaseCount++;

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-fakes.test-helper.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-fakes.test-helper.ts
@@ -51,6 +51,8 @@ export class FakeClient {
   } | null = null;
   sentAudio: ArrayBuffer[] = [];
   sentText: string[] = [];
+  /** Per-send options, index-aligned with {@link sentText}. */
+  sentTextOptions: ({ hidden?: boolean } | undefined)[] = [];
   /**
    * Mirrors the real client's `ready.textInput` echo. False by default, as the
    * real one is until a `ready` frame says otherwise, so a test that wants a
@@ -97,11 +99,12 @@ export class FakeClient {
   sendAudio(pcm: ArrayBuffer): void {
     this.sentAudio.push(pcm);
   }
-  sendText(text: string): boolean {
+  sendText(text: string, options?: { hidden?: boolean }): boolean {
     if (!this.textInputSupported) {
       return false;
     }
     this.sentText.push(text);
+    this.sentTextOptions.push(options);
     return true;
   }
   get supportsTextInput(): boolean {

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
@@ -246,11 +246,11 @@ export interface LiveVoiceSessionStarter {
   /**
    * Start a session, consuming the prewarmed player when one exists.
    *
-   * `seedText` takes a first turn on the session's behalf as soon as the
-   * server is `ready`, so the assistant speaks before the user has to
-   * (JARVIS-1649). It becomes a real user message in the conversation, so a
-   * caller passes one only where that reads honestly. See
-   * `voice-entry-greeting.ts` for the rule and the copy.
+   * `seedText` takes a first turn on the session's behalf once the microphone
+   * is live, so the assistant speaks without waiting for the user. It becomes
+   * a real user message in the conversation, so a caller passes one only where
+   * that reads honestly. See `voice-entry-greeting.ts` for the rule and the
+   * copy.
    */
   start(
     assistantId: string,

--- a/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/live-voice-store.ts
@@ -243,8 +243,20 @@ export interface LiveVoiceSessionStarter {
   prewarm(): void;
   /** Release playback reserved by a preflight that will not start a session. */
   cancelPrewarm(): void;
-  /** Start a session, consuming the prewarmed player when one exists. */
-  start(assistantId: string, conversationId: string | null): void;
+  /**
+   * Start a session, consuming the prewarmed player when one exists.
+   *
+   * `seedText` takes a first turn on the session's behalf as soon as the
+   * server is `ready`, so the assistant speaks before the user has to
+   * (JARVIS-1649). It becomes a real user message in the conversation, so a
+   * caller passes one only where that reads honestly. See
+   * `voice-entry-greeting.ts` for the rule and the copy.
+   */
+  start(
+    assistantId: string,
+    conversationId: string | null,
+    options?: { seedText?: string },
+  ): void;
 }
 
 export interface LiveVoiceState {

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice-session-controller.ts
@@ -191,7 +191,7 @@ export function useLiveVoiceSessionController(
     useLiveVoiceStore.getState().setStarter({
       prewarm: prewarmPlayback,
       cancelPrewarm: cancelPrewarmedPlayback,
-      start: (assistantId, conversationId) =>
+      start: (assistantId, conversationId, options) =>
         // Hands-free (server-side turn detection) is the only mode the voice
         // button starts — it keeps one socket open across turns so the
         // assistant's TTS drains instead of the session tearing down each
@@ -199,6 +199,7 @@ export function useLiveVoiceSessionController(
         // when the daemon's `ready` doesn't echo `server_vad`.
         void start(assistantId, conversationId ?? undefined, {
           handsFree: true,
+          ...(options?.seedText ? { seedText: options.seedText } : {}),
         }),
     });
     // A start-voice deep link that arrived before this mount (cold launch from

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
@@ -3233,8 +3233,8 @@ describe("echo-cancelling output route", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Speak first (JARVIS-1649): a caller-supplied seed turn, sent on `ready` so
-// the assistant opens the conversation instead of the user having to.
+// Speak first: a caller-supplied seed turn, sent once the microphone is live,
+// so the assistant opens the conversation instead of the user having to.
 // ---------------------------------------------------------------------------
 
 describe("speak first (seed turn)", () => {
@@ -3271,11 +3271,13 @@ describe("speak first (seed turn)", () => {
         conversationId: "conv-1",
         turnDetection: "server_vad",
       });
-      await Promise.resolve();
+      // Fully drained, not a single microtask: the seed rides behind the
+      // capture-startup await.
+      await flushMicrotasks();
     });
   }
 
-  test("takes the seed turn as soon as the server is ready", async () => {
+  test("takes the seed turn once the session is ready and the mic is up", async () => {
     const h = renderController();
     await startWithSeed(h);
     // Nothing before `ready`: the socket is not active yet, and the daemon
@@ -3285,10 +3287,49 @@ describe("speak first (seed turn)", () => {
     await emitReady(h);
 
     expect(h.client.sentText).toEqual([SEED]);
-    // The seed does not hold up the mic. Capture still comes up and the
-    // session lands in `listening`, so the user can talk over the greeting.
+    // The seed does not hold up the mic. Capture is running and the session
+    // is in `listening`, so the user can talk over the greeting.
     expect(h.view.result.current.state).toBe("listening");
     expect(h.getCapture().startCount).toBe(1);
+  });
+
+  test("never greets into a session whose microphone failed", async () => {
+    // A denied mic still gets a `ready` from the server. Seeding on that
+    // alone persists a user message the user never wrote into a conversation
+    // they can neither hear nor talk to, and the session then fails.
+    const h = renderController({
+      onCaptureCreated: (capture) => {
+        capture.startResult = { ok: false, error: "permission-denied" };
+      },
+    });
+    await startWithSeed(h);
+    await emitReady(h);
+
+    expect(h.client.sentText).toEqual([]);
+    expect(h.view.result.current.state).toBe("failed");
+  });
+
+  test("greets on a retry after a first attempt lost its microphone", async () => {
+    // The seed outlives a spent attempt: it is owed until some session
+    // actually opens with a mic, so the greeting is not lost to one denial.
+    let failNextCapture = true;
+    const h = renderController({
+      onCaptureCreated: (capture) => {
+        if (failNextCapture) {
+          capture.startResult = { ok: false, error: "permission-denied" };
+          failNextCapture = false;
+        }
+      },
+    });
+    await startWithSeed(h);
+    await emitReady(h);
+    expect(h.client.sentText).toEqual([]);
+
+    await startWithSeed(h);
+    await emitReady(h, "s2");
+
+    expect(h.view.result.current.state).toBe("listening");
+    expect(h.client.sentText).toEqual([SEED]);
   });
 
   test("opens silent when the caller asks for no greeting", async () => {
@@ -3336,8 +3377,7 @@ describe("speak first (seed turn)", () => {
 
   test("still greets after a pre-ready connect retry, which never got to", async () => {
     // The initial-connect resilience path (JARVIS-1282) re-enters the connect
-    // flow before any `ready` landed, so the seed is still owed. This is why
-    // the seed is consumed on `ready` rather than cleared on every connect.
+    // flow before any `ready` landed, so the seed is still owed.
     const h = renderController({ reconnectBackoffMs: FAST_BACKOFF });
     await startWithSeed(h);
     await act(async () => {

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
@@ -3231,3 +3231,150 @@ describe("echo-cancelling output route", () => {
     expect(h.player.restartOutputRouteCount).toBe(1);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Speak first (JARVIS-1649): a caller-supplied seed turn, sent on `ready` so
+// the assistant opens the conversation instead of the user having to.
+// ---------------------------------------------------------------------------
+
+describe("speak first (seed turn)", () => {
+  const SEED = "Greet me in one short sentence.";
+  const FAST_BACKOFF = [20, 40, 60];
+
+  /** Start a hands-free session carrying a seed, without readying it. */
+  async function startWithSeed(
+    h: ReturnType<typeof renderController>,
+    options: { textInput: boolean; seedText?: string } = { textInput: true },
+  ): Promise<void> {
+    // The echo the real client sets from `ready.textInput`; the fakes bypass
+    // the frame, so state it directly.
+    h.client.textInputSupported = options.textInput;
+    await act(async () => {
+      await h.view.result.current.start("assistant-1", "conv-1", {
+        handsFree: true,
+        ...("seedText" in options
+          ? { seedText: options.seedText }
+          : { seedText: SEED }),
+      });
+    });
+  }
+
+  async function emitReady(
+    h: ReturnType<typeof renderController>,
+    sessionId = "s1",
+  ): Promise<void> {
+    await act(async () => {
+      h.client.emit("ready", {
+        type: "ready",
+        seq: 1,
+        sessionId,
+        conversationId: "conv-1",
+        turnDetection: "server_vad",
+      });
+      await Promise.resolve();
+    });
+  }
+
+  test("takes the seed turn as soon as the server is ready", async () => {
+    const h = renderController();
+    await startWithSeed(h);
+    // Nothing before `ready`: the socket is not active yet, and the daemon
+    // would have no session to run the turn on.
+    expect(h.client.sentText).toEqual([]);
+
+    await emitReady(h);
+
+    expect(h.client.sentText).toEqual([SEED]);
+    // The seed does not hold up the mic. Capture still comes up and the
+    // session lands in `listening`, so the user can talk over the greeting.
+    expect(h.view.result.current.state).toBe("listening");
+    expect(h.getCapture().startCount).toBe(1);
+  });
+
+  test("opens silent when the caller asks for no greeting", async () => {
+    const h = renderController();
+    await startWithSeed(h, { textInput: true, seedText: undefined });
+    await emitReady(h);
+
+    expect(h.client.sentText).toEqual([]);
+    expect(h.view.result.current.state).toBe("listening");
+  });
+
+  test("opens silent on an assistant that predates typed turns", async () => {
+    // The `ready` echo is the only way to know: a `text` frame such an
+    // assistant cannot parse comes back as `unknown_type`, indistinguishable
+    // from the `update_config` rejection. Degrading to the silent room is the
+    // right answer, and the session must be otherwise unharmed.
+    const h = renderController();
+    await startWithSeed(h, { textInput: false });
+    await emitReady(h);
+
+    expect(h.client.sentText).toEqual([]);
+    expect(h.view.result.current.state).toBe("listening");
+  });
+
+  test("does not greet again when a dropped socket reconnects", async () => {
+    const h = renderController({ reconnectBackoffMs: FAST_BACKOFF });
+    await startWithSeed(h);
+    await emitReady(h);
+    expect(h.client.sentText).toEqual([SEED]);
+
+    // velay drops its tunnel mid-session. The same logical session comes back,
+    // and it has already said hello; greeting a second time would also land a
+    // second copy of the seed in the user's transcript.
+    await act(async () => {
+      h.client.emit("closed", { code: 1013, reason: "tunnel disconnected" });
+    });
+    await act(async () => {
+      await sleep(40);
+    });
+    await emitReady(h, "s2");
+
+    expect(h.view.result.current.state).toBe("listening");
+    expect(h.client.sentText).toEqual([SEED]);
+  });
+
+  test("still greets after a pre-ready connect retry, which never got to", async () => {
+    // The initial-connect resilience path (JARVIS-1282) re-enters the connect
+    // flow before any `ready` landed, so the seed is still owed. This is why
+    // the seed is consumed on `ready` rather than cleared on every connect.
+    const h = renderController({ reconnectBackoffMs: FAST_BACKOFF });
+    await startWithSeed(h);
+    await act(async () => {
+      await flushMicrotasks();
+    });
+
+    await act(async () => {
+      const err: LiveVoiceClientError = {
+        reason: "connection-failed",
+        message: "Live-voice WebSocket error",
+      };
+      h.client.emit("error", err);
+    });
+    expect(h.view.result.current.state).toBe("connecting");
+
+    await act(async () => {
+      await sleep(30);
+    });
+    await emitReady(h, "s2");
+
+    expect(h.view.result.current.state).toBe("listening");
+    expect(h.client.sentText).toEqual([SEED]);
+  });
+
+  test("a fresh session after one that greeted greets again", async () => {
+    // The arming lives on the hook, not the session context, so the guard that
+    // stops a reconnect must not also stop the next deliberate start.
+    const h = renderController();
+    await startWithSeed(h);
+    await emitReady(h);
+    await act(async () => {
+      await h.view.result.current.stop();
+    });
+
+    await startWithSeed(h);
+    await emitReady(h, "s2");
+
+    expect(h.client.sentText).toEqual([SEED, SEED]);
+  });
+});

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.test.ts
@@ -3287,6 +3287,10 @@ describe("speak first (seed turn)", () => {
     await emitReady(h);
 
     expect(h.client.sentText).toEqual([SEED]);
+    // Hidden: the seed drives the turn and stays in the model's context, but
+    // it is not something the user typed and must not render as though it
+    // were.
+    expect(h.client.sentTextOptions).toEqual([{ hidden: true }]);
     // The seed does not hold up the mic. Capture is running and the session
     // is in `listening`, so the user can talk over the greeting.
     expect(h.view.result.current.state).toBe("listening");

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -178,6 +178,21 @@ export interface LiveVoiceStartOptions {
    * socket. Defaults to the legacy per-turn push-to-talk flow.
    */
   handsFree?: boolean;
+  /**
+   * A first turn to take on the session's behalf, sent the moment the server
+   * says `ready`, so the assistant speaks before the user has to (JARVIS-1649).
+   *
+   * It travels the ordinary typed-turn path, which means it becomes a real
+   * user message in the conversation exactly as a spoken one would. That is
+   * the whole cost of the feature and the reason callers gate on an empty
+   * conversation: a seed sent into a thread already underway reads as a line
+   * the user never wrote.
+   *
+   * Sent at most once per `start()`. Reconnects (and the pre-`ready`
+   * initial-connect retries) never re-send it, so a socket blip mid-session
+   * cannot make the assistant greet twice.
+   */
+  seedText?: string;
 }
 
 /** Injectable factories so tests can supply mock primitives. */
@@ -397,6 +412,16 @@ export function useLiveVoice(
   // on a fresh `start()`, on `ready`, and on teardown/stop.
   const hasReadyRef = useRef(false);
   const initialConnectAttemptRef = useRef(0);
+  // The seed turn a caller asked for (see `LiveVoiceStartOptions.seedText`),
+  // held from `start()` until the first `ready` consumes it.
+  //
+  // Hook-scoped rather than session-scoped, and consumed rather than flagged,
+  // because every connect attempt builds a *fresh* `SessionContext`: a flag
+  // living there would reset on the reconnect path and greet a second time on
+  // a socket blip. Consuming also gets the pre-`ready` retry right for free:
+  // those attempts never reached a `ready`, so the seed is still armed for
+  // whichever attempt finally lands.
+  const pendingSeedTextRef = useRef<string | null>(null);
   const connectSessionRef = useRef<
     | ((
         assistantId: string,
@@ -812,6 +837,29 @@ export function useLiveVoice(
           // start-time value — session ownership for a draft-started session
           // hinges on it (see `isLiveVoiceSessionOwnedBy`).
           useLiveVoiceStore.getState().setConversationId(frame.conversationId);
+          // Speak first (JARVIS-1649). Consumed, so only the first `ready` of
+          // a `start()` can spend it.
+          //
+          // Gated on the echo, never on hope: an assistant that predates typed
+          // turns answers a `text` frame with `unknown_type`, which is
+          // byte-identical to the `update_config` rejection and so cannot be
+          // told apart after the fact. `sendText` refuses on the same echo, so
+          // the seed is simply dropped there and the session opens silent,
+          // the pre-JARVIS-1649 behaviour, which is the right thing to
+          // degrade to.
+          //
+          // Before `finishCaptureStartup`, deliberately: the turn is dispatched
+          // while mic acquisition is still settling, which is both the earliest
+          // the assistant can start talking and the one moment the daemon's
+          // turn floor cannot be blocked by a speech onset. Nothing here sets
+          // `thinking`. The daemon's own `thinking` frame does, and
+          // `finishCaptureStartup` only claims `listening` out of `connecting`,
+          // so the two cannot fight whichever order they land in.
+          const seedText = pendingSeedTextRef.current;
+          pendingSeedTextRef.current = null;
+          if (seedText !== null) {
+            sendTextTurn(session, seedText);
+          }
           void finishCaptureStartup(session, teardown);
         }),
         client.on("speechStarted", () => {
@@ -1314,6 +1362,10 @@ export function useLiveVoice(
       reconnectAttemptRef.current = 0;
       initialConnectAttemptRef.current = 0;
       hasReadyRef.current = false;
+      // Armed here rather than inside `connectSession`, which the reconnect
+      // path also enters (carrying the same `startOptions`): a session that
+      // already greeted must not greet again when its socket comes back.
+      pendingSeedTextRef.current = startOptions?.seedText?.trim() || null;
       await connectSession(assistantId, conversationId, startOptions ?? {});
     },
     [connectSession, clearReconnectTimer],

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -182,10 +182,10 @@ export interface LiveVoiceStartOptions {
    * A first turn to take on the session's behalf, sent once the microphone is
    * live, so the assistant speaks without waiting for the user.
    *
-   * It travels the ordinary typed-turn path, so it becomes a real user message
-   * in the conversation exactly as a spoken one does. That is why callers gate
-   * it on an empty conversation: a seed in a thread already underway reads as
-   * a line the user never wrote.
+   * Sent as a hidden turn: the row persists and the model sees it, but it does
+   * not render in the transcript. An assistant too old to understand that
+   * persists it visibly, so callers still gate it on an empty conversation and
+   * still pick copy a person could plausibly have sent.
    *
    * Spent at most once per `start()`, and only by a session whose microphone
    * came up. A reconnect never re-sends it, so a socket blip cannot make the
@@ -861,7 +861,12 @@ export function useLiveVoice(
             const seedText = pendingSeedTextRef.current;
             pendingSeedTextRef.current = null;
             if (seedText !== null) {
-              sendTextTurn(session, seedText);
+              // `hidden`: the seed is an instruction, not something the user
+              // typed, so it drives the turn and stays in the model's context
+              // while never rendering in the transcript. An assistant too old
+              // to know the field persists it visibly instead, which is why
+              // the copy still reads as a sentence a person could have sent.
+              sendTextTurn(session, seedText, { hidden: true });
             }
           });
         }),
@@ -1629,8 +1634,12 @@ function releasePushToTalk(session: SessionContext): void {
  * a refused turn does not leave an anchor for the next reply's audio to pair
  * against.
  */
-function sendTextTurn(session: SessionContext, text: string): boolean {
-  const sent = session.client.sendText(text);
+function sendTextTurn(
+  session: SessionContext,
+  text: string,
+  options?: { hidden?: boolean },
+): boolean {
+  const sent = session.client.sendText(text, options);
   if (sent) {
     session.speechEndedAtMs = performance.now();
   }

--- a/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/use-live-voice.ts
@@ -179,18 +179,17 @@ export interface LiveVoiceStartOptions {
    */
   handsFree?: boolean;
   /**
-   * A first turn to take on the session's behalf, sent the moment the server
-   * says `ready`, so the assistant speaks before the user has to (JARVIS-1649).
+   * A first turn to take on the session's behalf, sent once the microphone is
+   * live, so the assistant speaks without waiting for the user.
    *
-   * It travels the ordinary typed-turn path, which means it becomes a real
-   * user message in the conversation exactly as a spoken one would. That is
-   * the whole cost of the feature and the reason callers gate on an empty
-   * conversation: a seed sent into a thread already underway reads as a line
-   * the user never wrote.
+   * It travels the ordinary typed-turn path, so it becomes a real user message
+   * in the conversation exactly as a spoken one does. That is why callers gate
+   * it on an empty conversation: a seed in a thread already underway reads as
+   * a line the user never wrote.
    *
-   * Sent at most once per `start()`. Reconnects (and the pre-`ready`
-   * initial-connect retries) never re-send it, so a socket blip mid-session
-   * cannot make the assistant greet twice.
+   * Spent at most once per `start()`, and only by a session whose microphone
+   * came up. A reconnect never re-sends it, so a socket blip cannot make the
+   * assistant greet twice.
    */
   seedText?: string;
 }
@@ -413,14 +412,13 @@ export function useLiveVoice(
   const hasReadyRef = useRef(false);
   const initialConnectAttemptRef = useRef(0);
   // The seed turn a caller asked for (see `LiveVoiceStartOptions.seedText`),
-  // held from `start()` until the first `ready` consumes it.
+  // held from `start()` until a session with a live microphone spends it.
   //
-  // Hook-scoped rather than session-scoped, and consumed rather than flagged,
-  // because every connect attempt builds a *fresh* `SessionContext`: a flag
-  // living there would reset on the reconnect path and greet a second time on
-  // a socket blip. Consuming also gets the pre-`ready` retry right for free:
-  // those attempts never reached a `ready`, so the seed is still armed for
-  // whichever attempt finally lands.
+  // Hook-scoped rather than session-scoped, because every connect attempt
+  // builds a *fresh* `SessionContext`: a flag living there resets on the
+  // reconnect path and greets a second time on a socket blip. The ref outlives
+  // every attempt, so a connect that fails before `ready` still owes the
+  // greeting to whichever attempt finally lands.
   const pendingSeedTextRef = useRef<string | null>(null);
   const connectSessionRef = useRef<
     | ((
@@ -837,30 +835,35 @@ export function useLiveVoice(
           // start-time value — session ownership for a draft-started session
           // hinges on it (see `isLiveVoiceSessionOwnedBy`).
           useLiveVoiceStore.getState().setConversationId(frame.conversationId);
-          // Speak first (JARVIS-1649). Consumed, so only the first `ready` of
-          // a `start()` can spend it.
+          // The seed turn waits for the microphone, and is spent only by a
+          // session that got one.
           //
-          // Gated on the echo, never on hope: an assistant that predates typed
-          // turns answers a `text` frame with `unknown_type`, which is
-          // byte-identical to the `update_config` rejection and so cannot be
-          // told apart after the fact. `sendText` refuses on the same echo, so
-          // the seed is simply dropped there and the session opens silent,
-          // the pre-JARVIS-1649 behaviour, which is the right thing to
-          // degrade to.
+          // A `ready` says nothing about capture: permission can be denied,
+          // the device can be absent, the graph can fail to build, and the
+          // server still readies. `finishCaptureStartup` fails the session on
+          // any of those, so a seed dispatched ahead of it persists a user
+          // message into a conversation the user can neither hear nor talk to.
+          // `captureRunning` is that success signal.
           //
-          // Before `finishCaptureStartup`, deliberately: the turn is dispatched
-          // while mic acquisition is still settling, which is both the earliest
-          // the assistant can start talking and the one moment the daemon's
-          // turn floor cannot be blocked by a speech onset. Nothing here sets
-          // `thinking`. The daemon's own `thinking` frame does, and
-          // `finishCaptureStartup` only claims `listening` out of `connecting`,
-          // so the two cannot fight whichever order they land in.
-          const seedText = pendingSeedTextRef.current;
-          pendingSeedTextRef.current = null;
-          if (seedText !== null) {
-            sendTextTurn(session, seedText);
-          }
-          void finishCaptureStartup(session, teardown);
+          // Consuming (rather than flagging) is what keeps a reconnect from
+          // greeting twice while still owing the greeting to a connect attempt
+          // that failed before `ready`.
+          //
+          // `sendText` gates on the `ready.textInput` echo: an assistant
+          // without typed turns answers `unknown_type`, byte-identical to the
+          // `update_config` rejection and impossible to tell apart, so an
+          // unsupported seed is dropped and the room opens silent. Nothing
+          // here sets `thinking`; the daemon's own `thinking` frame does.
+          void finishCaptureStartup(session, teardown).then(() => {
+            if (!live() || !session.captureRunning) {
+              return;
+            }
+            const seedText = pendingSeedTextRef.current;
+            pendingSeedTextRef.current = null;
+            if (seedText !== null) {
+              sendTextTurn(session, seedText);
+            }
+          });
         }),
         client.on("speechStarted", () => {
           if (!live() || !session.handsFree) {
@@ -1363,7 +1366,7 @@ export function useLiveVoice(
       initialConnectAttemptRef.current = 0;
       hasReadyRef.current = false;
       // Armed here rather than inside `connectSession`, which the reconnect
-      // path also enters (carrying the same `startOptions`): a session that
+      // path also enters carrying the same `startOptions`: a session that
       // already greeted must not greet again when its socket comes back.
       pendingSeedTextRef.current = startOptions?.seedText?.trim() || null;
       await connectSession(assistantId, conversationId, startOptions ?? {});

--- a/clients/web/src/domains/chat/voice/live-voice/voice-entry-greeting.test.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/voice-entry-greeting.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Tests for the "speak first" entry rule (JARVIS-1649).
+ *
+ * The rule is the whole module, so the tests are about the rule: a seed only
+ * where it reads as an opener, and copy that actually resolves out of the
+ * catalog rather than leaking a key path into someone's conversation.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { voiceEntryGreetingSeed } from "@/domains/chat/voice/live-voice/voice-entry-greeting";
+
+describe("voiceEntryGreetingSeed", () => {
+  test("seeds a turn on a conversation with nothing in it", () => {
+    expect(voiceEntryGreetingSeed(true)).toBeString();
+  });
+
+  test("stays silent on a conversation already underway", () => {
+    // The seed becomes a real user message. Sent into a live thread it is a
+    // line the user never wrote, landing every time they open voice.
+    expect(voiceEntryGreetingSeed(false)).toBeUndefined();
+  });
+
+  test("resolves real copy, not a key path", () => {
+    // A missing catalog entry makes `t` echo the key, which would otherwise
+    // ship "chat:voiceEntryGreeting.seed" to the assistant as a turn.
+    const seed = voiceEntryGreetingSeed(true);
+    expect(seed).not.toContain("voiceEntryGreeting");
+    expect(seed).not.toContain(":");
+    expect((seed ?? "").trim().length).toBeGreaterThan(0);
+  });
+});

--- a/clients/web/src/domains/chat/voice/live-voice/voice-entry-greeting.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/voice-entry-greeting.ts
@@ -1,0 +1,42 @@
+/**
+ * Whether a live-voice entry opens with the assistant speaking, and what it
+ * says to get there (JARVIS-1649).
+ *
+ * A voice room that opens silent puts the burden of the first move on the
+ * user, who has just pressed a button and is now looking at an animation
+ * waiting for them. The fix is to take a turn on their behalf the moment the
+ * session is ready, which the typed-turn frame (JARVIS-1522) already makes
+ * possible without a daemon change.
+ *
+ * The rule and the copy live together, in one module, because they are not
+ * separable: the copy is only honest under the rule.
+ */
+
+import { t } from "@/i18n";
+
+/**
+ * The seed turn for a voice entry, or `undefined` to open silent.
+ *
+ * **Only on an empty conversation.** The seed is not a private instruction:
+ * it travels the ordinary typed-turn path, so the daemon runs it as a real
+ * user utterance and persists it as a user message, permanently, exactly as a
+ * spoken one. At the top of a thread with nothing else in it, that reads as
+ * what it is, an opener. Sent into a thread already underway it is a line the
+ * user never wrote, appearing in their history every time they happen to open
+ * voice, which is a worse problem than the silence it fixes.
+ *
+ * That gate also lands the behaviour where the silence actually hurts. A room
+ * opened on an existing thread has the conversation on screen to react to; a
+ * room opened on a blank one has nothing at all.
+ *
+ * **Why an instruction rather than an arrival line.** Since the seed is shown
+ * as the user either way, the choice is only about what it buys. An
+ * instruction bounds the opener: without the length cap the assistant is free
+ * to deliver a paragraph before the user can get a word in, which is the exact
+ * way a greeting on every entry stops being welcome.
+ */
+export function voiceEntryGreetingSeed(
+  conversationIsEmpty: boolean,
+): string | undefined {
+  return conversationIsEmpty ? t("chat:voiceEntryGreeting.seed") : undefined;
+}

--- a/clients/web/src/domains/chat/voice/live-voice/voice-entry-greeting.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/voice-entry-greeting.ts
@@ -1,12 +1,10 @@
 /**
  * Whether a live-voice entry opens with the assistant speaking, and what it
- * says to get there (JARVIS-1649).
+ * says to get there.
  *
- * A voice room that opens silent puts the burden of the first move on the
- * user, who has just pressed a button and is now looking at an animation
- * waiting for them. The fix is to take a turn on their behalf the moment the
- * session is ready, which the typed-turn frame (JARVIS-1522) already makes
- * possible without a daemon change.
+ * A voice room that opens silent leaves the first move to the user, who has
+ * just pressed a button and is now watching an animation wait for them. A seed
+ * turn takes that move on their behalf.
  *
  * The rule and the copy live together, in one module, because they are not
  * separable: the copy is only honest under the rule.
@@ -17,23 +15,22 @@ import { t } from "@/i18n";
 /**
  * The seed turn for a voice entry, or `undefined` to open silent.
  *
- * **Only on an empty conversation.** The seed is not a private instruction:
- * it travels the ordinary typed-turn path, so the daemon runs it as a real
- * user utterance and persists it as a user message, permanently, exactly as a
+ * **Only on an empty conversation.** The seed is not a private instruction: it
+ * travels the ordinary typed-turn path, so the daemon runs it as a real user
+ * utterance and persists it as a user message, permanently, exactly as a
  * spoken one. At the top of a thread with nothing else in it, that reads as
- * what it is, an opener. Sent into a thread already underway it is a line the
- * user never wrote, appearing in their history every time they happen to open
- * voice, which is a worse problem than the silence it fixes.
+ * what it is, an opener. In a thread already underway it is a line the user
+ * never wrote, appearing in their history every time they open voice, which is
+ * a worse problem than the silence it answers.
  *
- * That gate also lands the behaviour where the silence actually hurts. A room
- * opened on an existing thread has the conversation on screen to react to; a
- * room opened on a blank one has nothing at all.
+ * The gate also lands the behaviour where the silence hurts. A room opened on
+ * an existing thread has the conversation on screen to react to; a room opened
+ * on a blank one has nothing at all.
  *
- * **Why an instruction rather than an arrival line.** Since the seed is shown
- * as the user either way, the choice is only about what it buys. An
- * instruction bounds the opener: without the length cap the assistant is free
- * to deliver a paragraph before the user can get a word in, which is the exact
- * way a greeting on every entry stops being welcome.
+ * **An instruction, not an arrival line.** The seed shows as the user either
+ * way, so the choice is only about what it buys. An instruction bounds the
+ * opener: without the length cap the assistant is free to deliver a paragraph
+ * before the user can get a word in.
  */
 export function voiceEntryGreetingSeed(
   conversationIsEmpty: boolean,

--- a/clients/web/src/domains/chat/voice/live-voice/voice-entry-greeting.ts
+++ b/clients/web/src/domains/chat/voice/live-voice/voice-entry-greeting.ts
@@ -15,22 +15,24 @@ import { t } from "@/i18n";
 /**
  * The seed turn for a voice entry, or `undefined` to open silent.
  *
- * **Only on an empty conversation.** The seed is not a private instruction: it
- * travels the ordinary typed-turn path, so the daemon runs it as a real user
- * utterance and persists it as a user message, permanently, exactly as a
- * spoken one. At the top of a thread with nothing else in it, that reads as
- * what it is, an opener. In a thread already underway it is a line the user
- * never wrote, appearing in their history every time they open voice, which is
- * a worse problem than the silence it answers.
+ * **Only on an empty conversation.** The seed travels as a hidden turn, so on
+ * a current assistant it drives the reply without ever rendering. An assistant
+ * too old to understand `hidden` persists it as an ordinary user message
+ * instead, and that message is permanent. At the top of an otherwise empty
+ * thread it reads as an opener; in a thread already underway it is a line the
+ * user never wrote, appearing every time they open voice, which is a worse
+ * problem than the silence it answers. The gate is what keeps the degraded
+ * case tolerable.
  *
  * The gate also lands the behaviour where the silence hurts. A room opened on
  * an existing thread has the conversation on screen to react to; a room opened
  * on a blank one has nothing at all.
  *
- * **An instruction, not an arrival line.** The seed shows as the user either
- * way, so the choice is only about what it buys. An instruction bounds the
- * opener: without the length cap the assistant is free to deliver a paragraph
- * before the user can get a word in.
+ * **The copy says what it is, then what it wants.** It names itself as
+ * automatic, so the degraded case reads as a machine message rather than words
+ * put in the user's mouth, and it tells the model the same thing. The length
+ * cap is the rest of it: without one the assistant is free to deliver a
+ * paragraph before the user can get a word in.
  */
 export function voiceEntryGreetingSeed(
   conversationIsEmpty: boolean,

--- a/clients/web/src/i18n/locales/en/chat.json
+++ b/clients/web/src/i18n/locales/en/chat.json
@@ -1534,6 +1534,9 @@
     "unmuteAssistant": "Unmute assistant",
     "unmuteMicrophone": "Unmute microphone"
   },
+  "voiceEntryGreeting": {
+    "seed": "Greet me in one short sentence, then ask what I'd like to work on."
+  },
   "voiceErrors": {
     "nativeSttNoTranscript": "{clientName} Native Dictation didn’t return a transcript. Check native speech recognition in system settings, then try again."
   },

--- a/clients/web/src/i18n/locales/en/chat.json
+++ b/clients/web/src/i18n/locales/en/chat.json
@@ -1535,7 +1535,7 @@
     "unmuteMicrophone": "Unmute microphone"
   },
   "voiceEntryGreeting": {
-    "seed": "Greet me in one short sentence, then ask what I'd like to work on."
+    "seed": "Hey, I just started a voice conversation with you. This message is sent automatically. Greet me in one short sentence, then ask what I'd like to work on."
   },
   "voiceErrors": {
     "nativeSttNoTranscript": "{clientName} Native Dictation didn’t return a transcript. Check native speech recognition in system settings, then try again."

--- a/clients/web/src/i18n/locales/es/chat.json
+++ b/clients/web/src/i18n/locales/es/chat.json
@@ -1535,7 +1535,7 @@
     "unmuteMicrophone": "Activar el micrófono"
   },
   "voiceEntryGreeting": {
-    "seed": "Salúdame en una frase corta y luego pregúntame en qué quiero trabajar."
+    "seed": "Hola, acabo de iniciar una conversación de voz contigo. Este mensaje se envía automáticamente. Salúdame en una frase corta y luego pregúntame en qué quiero trabajar."
   },
   "voiceErrors": {
     "nativeSttNoTranscript": "El dictado nativo de {clientName} no devolvió una transcripción. Revisa el reconocimiento de voz nativo en los ajustes del sistema e inténtalo de nuevo."

--- a/clients/web/src/i18n/locales/es/chat.json
+++ b/clients/web/src/i18n/locales/es/chat.json
@@ -1534,6 +1534,9 @@
     "unmuteAssistant": "Activar el audio del asistente",
     "unmuteMicrophone": "Activar el micrófono"
   },
+  "voiceEntryGreeting": {
+    "seed": "Salúdame en una frase corta y luego pregúntame en qué quiero trabajar."
+  },
   "voiceErrors": {
     "nativeSttNoTranscript": "El dictado nativo de {clientName} no devolvió una transcripción. Revisa el reconocimiento de voz nativo en los ajustes del sistema e inténtalo de nuevo."
   },


### PR DESCRIPTION
Click voice mode on a blank thread and the assistant now opens the conversation, instead of the room sitting silent while you think of something to say.

The mechanism already existed: JARVIS-1522's `text` frame joins the pipeline where a finished transcript would, and the reply is spoken. This is its first product use, so the delta is only threading a seed string down to the session controller and sending it through the existing `sendTextTurn`.

## The two decisions

Both follow from one fact, confirmed in the daemon: `live-voice-session.ts:1575` runs a `text` frame through `launchAssistantTurn` on an ordinary utterance, so **the seed becomes a real, permanently persisted user message**, exactly as a spoken one. There is no hidden turn today; making one would be a daemon change and a much larger ask than the rest combined.

**Greet only on an empty conversation.** At the top of a blank thread the seed reads as what it is, an opener. Sent into a thread already underway it is a line the user never wrote, appearing in their history every time they happen to open voice — worse than the silence it fixes. The gate also lands the behaviour where the silence actually hurts: a room opened on an existing thread has the conversation on screen to react to, a blank one has nothing at all.

**Say it as an instruction, not an arrival line.** It shows as the user either way, so the choice is only about what it buys, and an instruction bounds the opener. Without the length cap the assistant is free to deliver a paragraph before you can get a word in, which is exactly how a greeting stops being welcome.

The rule and the copy live together in `voice-entry-greeting.ts`, because the copy is only honest under the rule.

## Mechanics worth a reviewer's eye

- **Armed in `start()`, consumed on the first `ready`.** Every connect attempt builds a fresh `SessionContext`, so a flag living there would reset on the reconnect path and greet again on a socket blip. Consuming also gets the JARVIS-1282 pre-`ready` retry right for free: those attempts never readied, so the seed is still owed.
- **Sent before `finishCaptureStartup`, deliberately.** That is both the earliest the assistant can start talking and the one moment the daemon's turn floor cannot be blocked by a speech onset.
- **Gated on the `ready.textInput` echo, never on hope.** An assistant predating typed turns answers with `unknown_type`, byte-identical to the `update_config` rejection, so it degrades to the silent room.
- **Emptiness is re-read across the readiness preflight**, like the chat identity beside it. A thread that fills up mid-flight opens silent rather than abandoning the press.

The composer stays the caller: it prewarms playback from the click (so autoplay is unlocked) and binds to the conversation on screen. `startVoiceFromSurface` passes no seed — it mints a fresh draft always, and has no gesture to borrow.

## Verification

Typecheck, full lint (0 errors), cross-domain audit and prettier all clean. 9 new tests plus 4 updated: `use-live-voice` 106 pass, composer 152, store/controller/start-voice-request all pass. Coverage includes the reconnect no-double-greet, the pre-`ready` retry, re-arming on a fresh start, the unsupported-daemon drop, and the composer's fills-up-mid-preflight case.

Beyond the fakes, I drove a **live socket** against a local assistant sending the seed the instant `ready` landed, exactly as the client now does:

```
[probe] ready: textInput=true conversationId=55ddc757-...
[probe] seed sent immediately on ready: true
```

The daemon launched a turn from it — the turn floor does not block a seed at `ready`, which was the one seam the unit tests could not reach. It then stopped at a missing local LLM credential, unrelated to this change.

Not yet exercised: hearing it speak end to end, which needs velay. Testing that off main.

## Not in scope

A presence-triggered greeting with no click. `clients/macos/src/main/presence.ts` already computes `idle → active`, but a gestureless caller reopens the autoplay problem the composer's click solves for free. Separate ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LA2LWfMZvVh2yEnemuuNvD