### PR TITLE
fix(web): voice hotkey matcher tolerates keydowns without a key (LUM-3469)

### DIFF
--- a/clients/web/src/utils/ptt-activator.test.ts
+++ b/clients/web/src/utils/ptt-activator.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+
+import { type PTTActivator, eventActivatesPTT } from "@/utils/ptt-activator";
+
+/**
+ * The matcher only reads `key` and the four modifier flags, so a plain
+ * object stands in for the event. `key: undefined` mirrors the trusted
+ * keydowns autofill and IME composition dispatch in production.
+ */
+function keydown(
+  key: string | undefined,
+  mods: Partial<
+    Pick<KeyboardEvent, "ctrlKey" | "altKey" | "shiftKey" | "metaKey">
+  > = {},
+): KeyboardEvent {
+  return {
+    key,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    metaKey: false,
+    ...mods,
+  } as KeyboardEvent;
+}
+
+const CTRL_SHIFT_V: PTTActivator = {
+  kind: "key",
+  label: "V",
+  modifiers: ["control", "shift"],
+};
+
+const CTRL_ONLY: PTTActivator = {
+  kind: "modifierOnly",
+  modifiers: ["control"],
+};
+
+describe("eventActivatesPTT", () => {
+  test("matches a key chord with its modifiers held", () => {
+    expect(
+      eventActivatesPTT(
+        keydown("v", { ctrlKey: true, shiftKey: true }),
+        CTRL_SHIFT_V,
+      ),
+    ).toBe(true);
+  });
+
+  test("rejects the key without its modifiers", () => {
+    expect(eventActivatesPTT(keydown("v"), CTRL_SHIFT_V)).toBe(false);
+  });
+
+  test("matches a modifier-only binding on the modifier keydown", () => {
+    expect(
+      eventActivatesPTT(keydown("Control", { ctrlKey: true }), CTRL_ONLY),
+    ).toBe(true);
+  });
+
+  test("rejects a keydown without a usable key instead of throwing", () => {
+    expect(eventActivatesPTT(keydown(undefined), CTRL_SHIFT_V)).toBe(false);
+    expect(
+      eventActivatesPTT(
+        keydown(undefined, { ctrlKey: true, shiftKey: true }),
+        CTRL_SHIFT_V,
+      ),
+    ).toBe(false);
+    expect(
+      eventActivatesPTT(keydown(undefined, { ctrlKey: true }), CTRL_ONLY),
+    ).toBe(false);
+  });
+
+  test("never matches when the activator is off", () => {
+    expect(eventActivatesPTT(keydown("v"), { kind: "off" })).toBe(false);
+  });
+});

--- a/clients/web/src/utils/ptt-activator.ts
+++ b/clients/web/src/utils/ptt-activator.ts
@@ -12,7 +12,11 @@
  */
 
 export type PTTModifier =
-  "function" | "control" | "shift" | "option" | "command";
+  | "function"
+  | "control"
+  | "shift"
+  | "option"
+  | "command";
 
 export interface PTTOff {
   kind: "off";
@@ -261,6 +265,12 @@ export function eventActivatesPTT(
   activator: PTTActivator,
 ): boolean {
   if (activator.kind === "off") {
+    return false;
+  }
+  // `KeyboardEvent.key` is typed `string`, but trusted keydowns from
+  // autofill, IME composition, and other synthetic dispatchers arrive
+  // with no key at all. An event with no usable key matches no binding.
+  if (typeof event.key !== "string") {
     return false;
   }
   if (activator.modifiers.includes("function")) {


### PR DESCRIPTION
Fixes LUM-3469.

## TL;DR

The global voice-mode hotkey listener crashed on keydowns that carry no `key` ([VELLUM-ASSISTANT-WEB-8N](https://vellum.sentry.io/issues/VELLUM-ASSISTANT-WEB-8N): `TypeError: Cannot read properties of undefined (reading 'length')` at `ptt-activator.ts`, 22 events since Aug 22, firing while users typed into inputs). The shared activator matcher now treats an event with no usable key as a non-match.

## Root cause

`eventActivatesPTT` trusts the platform type (`KeyboardEvent.key: string`), but trusted keydowns dispatched by autofill and IME composition arrive with `key === undefined` (the Sentry sample is a trusted keydown targeting an onboarding text input). The key-chord path dereferenced `event.key.length`; the modifier-only path only survived because `undefined === "Control"` happens to be false.

## Why this is safe

- The guard sits at the top of the one matcher every consumer routes through (push-to-talk hold and the voice-mode toggle), so both paths get the same rule; no call sites change.
- An event with no key could never legitimately match a binding, so the guard cannot suppress a real activation.
- The keyup path in `use-voice-mode-hotkey` already tolerates these events (`MODIFIER_BY_KEY[undefined]` misses and early-returns), so keydown and keyup now agree.
- New unit tests cover the regression shape (undefined key, with and without held modifiers) plus baseline chord and modifier-only matching.

## What changes for the user

| | Before | After |
|---|---|---|
| Typing into inputs with autofill/IME | Uncaught TypeError from the global keydown listener on affected keydowns | No error |
| Voice hotkey behavior | Unchanged for real key presses | Unchanged for real key presses |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41520" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->