### PR TITLE
feat(web): identify the signed-in user to Sentry (LUM-3471)

### DIFF
--- a/clients/web/src/lib/sentry/flavor-capacitor.ts
+++ b/clients/web/src/lib/sentry/flavor-capacitor.ts
@@ -78,4 +78,9 @@ export const capacitorFlavor: SentryFlavor = {
     const client = Capacitor.getClient();
     return client !== undefined && client.getOptions().enabled !== false;
   },
+  setUser(user) {
+    // `@sentry/capacitor` forwards the scope user to the native SDKs too,
+    // so native crash envelopes carry the same identity as JS events.
+    Capacitor.setUser(user);
+  },
 };

--- a/clients/web/src/lib/sentry/flavor-react.ts
+++ b/clients/web/src/lib/sentry/flavor-react.ts
@@ -22,4 +22,7 @@ export const reactFlavor: SentryFlavor = {
     const client = Sentry.getClient();
     return client !== undefined && client.getOptions().enabled !== false;
   },
+  setUser(user) {
+    Sentry.setUser(user);
+  },
 };

--- a/clients/web/src/lib/sentry/flavor.ts
+++ b/clients/web/src/lib/sentry/flavor.ts
@@ -18,6 +18,13 @@ export interface SentryFlavor {
   close(): Promise<void> | void;
   /** Whether an enabled client is currently installed. */
   getClientEnabled(): boolean;
+  /**
+   * Stamp the signed-in user on the SDK scope, or clear it with `null`.
+   * Dispatched per flavor because two `@sentry/core` copies exist in the
+   * dependency tree, so the scope `@sentry/react` writes is not
+   * guaranteed to be the one `@sentry/capacitor` reads.
+   */
+  setUser(user: { id: string } | null): void;
 }
 
 /**

--- a/clients/web/src/lib/sentry/sentry-control.test.ts
+++ b/clients/web/src/lib/sentry/sentry-control.test.ts
@@ -16,6 +16,7 @@ const flavor: SentryFlavor = {
   init: initMock,
   close: closeMock,
   getClientEnabled: () => clientEnabled,
+  setUser: () => {},
 };
 const selectSentryFlavorMock = mock(() => flavor);
 

--- a/clients/web/src/lib/sentry/sentry-control.test.ts
+++ b/clients/web/src/lib/sentry/sentry-control.test.ts
@@ -8,9 +8,20 @@ import type { SentryFlavor } from "@/lib/sentry/flavor";
 // Flavor seam — SDK access dispatches through selectSentryFlavor()
 // ---------------------------------------------------------------------------
 
-const initMock = mock((_options: BrowserOptions) => {});
+const callOrder: string[] = [];
+const initMock = mock((_options: BrowserOptions) => {
+  callOrder.push("init");
+});
 const closeMock = mock(() => {});
 let clientEnabled = false;
+
+const reapplySentryUserMock = mock(() => {
+  callOrder.push("reapplyUser");
+});
+mock.module("@/lib/sentry/user-sync", () => ({
+  reapplySentryUser: reapplySentryUserMock,
+  installSentryUserSync: () => () => {},
+}));
 
 const flavor: SentryFlavor = {
   init: initMock,
@@ -109,8 +120,10 @@ const { diagnosticsConsentGranted, diagnosticsReportingResolvedOff } =
 const OPTIONS: BrowserOptions = { dsn: "https://public@example.test/1" };
 
 beforeEach(() => {
+  callOrder.length = 0;
   initMock.mockClear();
   closeMock.mockClear();
+  reapplySentryUserMock.mockClear();
   selectSentryFlavorMock.mockClear();
   syncDiagnosticsToMainMock.mockReset();
   disableNativeFailureReportForwardingMock.mockClear();
@@ -236,6 +249,34 @@ describe("syncSentryClient", () => {
     expect(initMock).toHaveBeenCalledTimes(1);
     expect(initMock.mock.calls[0]![0]).toBe(OPTIONS);
     expect(closeMock).not.toHaveBeenCalled();
+  });
+
+  test("consent-off boot then opt-in: the late init re-stamps the identity", () => {
+    // Capacitor forwards scope users to the native SDK only for setUser
+    // calls made after init, so a boot-time stamp issued while consent was
+    // closed never reaches native crash envelopes. The identity must be
+    // reapplied after the client starts, not before.
+    deviceDiagnostics = false;
+    platformSession = "present";
+    clientEnabled = false;
+    syncSentryClient(OPTIONS);
+    expect(initMock).not.toHaveBeenCalled();
+    expect(reapplySentryUserMock).not.toHaveBeenCalled();
+
+    deviceDiagnostics = true;
+    syncSentryClient(OPTIONS);
+    expect(initMock).toHaveBeenCalledTimes(1);
+    expect(reapplySentryUserMock).toHaveBeenCalledTimes(1);
+    expect(callOrder).toEqual(["init", "reapplyUser"]);
+  });
+
+  test("an already-enabled client is not re-stamped", () => {
+    deviceDiagnostics = true;
+    platformSession = "present";
+    clientEnabled = true;
+    syncSentryClient(OPTIONS);
+    expect(initMock).not.toHaveBeenCalled();
+    expect(reapplySentryUserMock).not.toHaveBeenCalled();
   });
 
   test("does not re-init when a client is already enabled", () => {

--- a/clients/web/src/lib/sentry/sentry-control.ts
+++ b/clients/web/src/lib/sentry/sentry-control.ts
@@ -32,6 +32,7 @@ import { diagnosticsConsentGranted } from "@/lib/sentry/consent-gate";
 import { watchDeviceSetting } from "@/utils/device-settings";
 import { syncDiagnosticsToMain } from "@/runtime/diagnostics";
 import { disableNativeFailureReportForwarding } from "@/runtime/native-failure-reports";
+import { reapplySentryUser } from "@/lib/sentry/user-sync";
 import { useAuthStore } from "@/stores/auth-store";
 
 function tryInit(options: BrowserOptions): void {
@@ -40,6 +41,11 @@ function tryInit(options: BrowserOptions): void {
     return;
   }
   flavor.init(options);
+  // A late init (consent granted after boot) must re-stamp the identity:
+  // Capacitor forwards scope users to the native SDK only for setUser
+  // calls made after init, so the boot-time stamp never reaches native
+  // crash envelopes on its own. See `reapplySentryUser`.
+  reapplySentryUser();
 }
 
 function tryClose(): void {

--- a/clients/web/src/lib/sentry/sentry-init.test.ts
+++ b/clients/web/src/lib/sentry/sentry-init.test.ts
@@ -19,6 +19,9 @@ mock.module("@/lib/sentry/consent-gate", () => ({
 mock.module("@/runtime/diagnostics", () => ({
   syncDiagnosticsToMain: () => {},
 }));
+mock.module("@/lib/sentry/user-sync", () => ({
+  installSentryUserSync: () => () => {},
+}));
 mock.module("@/utils/device-settings", () => ({
   getDeviceBool: () => false,
   watchDeviceSetting: () => () => {},
@@ -102,7 +105,8 @@ describe("initSentry client_os tag", () => {
   function clientOsTag(): unknown {
     return (
       syncedOptions?.initialScope as
-        { tags?: Record<string, unknown> } | undefined
+        | { tags?: Record<string, unknown> }
+        | undefined
     )?.tags?.client_os;
   }
 
@@ -151,7 +155,8 @@ describe("initSentry commit-pressure enrichment", () => {
     );
 
     const pressure = sent?.contexts?.commit_pressure as
-      { updates: number; sources: Record<string, number> } | undefined;
+      | { updates: number; sources: Record<string, number> }
+      | undefined;
     expect(pressure?.updates).toBe(3);
     expect(pressure?.sources["smooth-stream"]).toBe(2);
   });

--- a/clients/web/src/lib/sentry/sentry-init.ts
+++ b/clients/web/src/lib/sentry/sentry-init.ts
@@ -7,6 +7,7 @@ import {
   installSentryControlListeners,
   syncSentryClient,
 } from "@/lib/sentry/sentry-control";
+import { installSentryUserSync } from "@/lib/sentry/user-sync";
 import { syncDiagnosticsToMain } from "@/runtime/diagnostics";
 import { sanitizeUrl } from "@/lib/sentry/url-sanitize";
 import { isElectron } from "@/runtime/is-electron";
@@ -194,5 +195,6 @@ export function initSentry(): void {
   };
   syncSentryClient(resolved);
   installSentryControlListeners(resolved);
+  installSentryUserSync();
   syncDiagnosticsToMain(diagnosticsConsentGranted());
 }

--- a/clients/web/src/lib/sentry/user-sync.test.ts
+++ b/clients/web/src/lib/sentry/user-sync.test.ts
@@ -25,7 +25,8 @@ mock.module(
   }),
 );
 
-const { installSentryUserSync } = await import("@/lib/sentry/user-sync");
+const { installSentryUserSync, reapplySentryUser } =
+  await import("@/lib/sentry/user-sync");
 const { useAuthStore } = await import("@/stores/auth-store");
 
 const PLATFORM_USER: AuthUser = {
@@ -100,6 +101,13 @@ describe("installSentryUserSync", () => {
       user: { ...PLATFORM_USER, id: PLATFORM_USER.username },
     });
     expect(setUserMock).toHaveBeenLastCalledWith(null);
+  });
+
+  test("reapplySentryUser re-stamps the current identity on demand", () => {
+    useAuthStore.setState({ user: PLATFORM_USER });
+    setUserMock.mockClear();
+    reapplySentryUser();
+    expect(setUserMock).toHaveBeenLastCalledWith({ id: "user-uuid-1" });
   });
 
   test("stops following after cleanup", () => {

--- a/clients/web/src/lib/sentry/user-sync.test.ts
+++ b/clients/web/src/lib/sentry/user-sync.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type * as Flavor from "@/lib/sentry/flavor";
+import type * as DeviceId from "@/runtime/device-id";
+import type { AuthUser } from "@/stores/auth-store";
+
+const setUserMock = mock((_user: { id: string } | null) => {});
+let deviceId: string | null = null;
+
+mock.module(
+  "@/lib/sentry/flavor",
+  (): Partial<typeof Flavor> => ({
+    selectSentryFlavor: () => ({
+      init: () => {},
+      close: () => {},
+      getClientEnabled: () => true,
+      setUser: setUserMock,
+    }),
+  }),
+);
+mock.module(
+  "@/runtime/device-id",
+  (): Partial<typeof DeviceId> => ({
+    getDeviceId: () => deviceId,
+  }),
+);
+
+const { installSentryUserSync } = await import("@/lib/sentry/user-sync");
+const { useAuthStore } = await import("@/stores/auth-store");
+
+const PLATFORM_USER: AuthUser = {
+  kind: "platform",
+  id: "user-uuid-1",
+  username: "ada",
+  email: "ada@example.com",
+  isStaff: false,
+  firstName: "Ada",
+  lastName: "L",
+};
+
+const LOCAL_USER: AuthUser = {
+  kind: "local",
+  id: "gateway-local",
+  username: "local",
+  email: null,
+  isStaff: false,
+  firstName: "",
+  lastName: "",
+};
+
+describe("installSentryUserSync", () => {
+  let cleanup: (() => void) | null = null;
+
+  beforeEach(() => {
+    cleanup?.();
+    cleanup = null;
+    setUserMock.mockClear();
+    deviceId = null;
+    useAuthStore.setState({ user: null });
+  });
+
+  test("stamps the platform account id and clears it on sign-out", () => {
+    useAuthStore.setState({ user: PLATFORM_USER });
+    cleanup = installSentryUserSync();
+    expect(setUserMock).toHaveBeenLastCalledWith({ id: "user-uuid-1" });
+
+    useAuthStore.setState({ user: null });
+    expect(setUserMock).toHaveBeenLastCalledWith(null);
+  });
+
+  test("follows a user who signs in after install", () => {
+    cleanup = installSentryUserSync();
+    expect(setUserMock).toHaveBeenLastCalledWith(null);
+
+    useAuthStore.setState({ user: PLATFORM_USER });
+    expect(setUserMock).toHaveBeenLastCalledWith({ id: "user-uuid-1" });
+  });
+
+  test("identifies local sessions by device id, not the shared synthetic id", () => {
+    deviceId = "device-abc";
+    useAuthStore.setState({ user: LOCAL_USER });
+    cleanup = installSentryUserSync();
+    expect(setUserMock).toHaveBeenLastCalledWith({ id: "device-abc" });
+  });
+
+  test("falls back to the synthetic id when no device id exists", () => {
+    useAuthStore.setState({ user: LOCAL_USER });
+    cleanup = installSentryUserSync();
+    expect(setUserMock).toHaveBeenLastCalledWith({ id: "gateway-local" });
+  });
+
+  test("stops following after cleanup", () => {
+    cleanup = installSentryUserSync();
+    setUserMock.mockClear();
+    cleanup();
+    cleanup = null;
+    useAuthStore.setState({ user: PLATFORM_USER });
+    expect(setUserMock).not.toHaveBeenCalled();
+  });
+});

--- a/clients/web/src/lib/sentry/user-sync.test.ts
+++ b/clients/web/src/lib/sentry/user-sync.test.ts
@@ -89,6 +89,19 @@ describe("installSentryUserSync", () => {
     expect(setUserMock).toHaveBeenLastCalledWith({ id: "gateway-local" });
   });
 
+  test("never identifies by the email or username fallback ids", () => {
+    useAuthStore.setState({
+      user: { ...PLATFORM_USER, id: PLATFORM_USER.email },
+    });
+    cleanup = installSentryUserSync();
+    expect(setUserMock).toHaveBeenLastCalledWith(null);
+
+    useAuthStore.setState({
+      user: { ...PLATFORM_USER, id: PLATFORM_USER.username },
+    });
+    expect(setUserMock).toHaveBeenLastCalledWith(null);
+  });
+
   test("stops following after cleanup", () => {
     cleanup = installSentryUserSync();
     setUserMock.mockClear();

--- a/clients/web/src/lib/sentry/user-sync.ts
+++ b/clients/web/src/lib/sentry/user-sync.ts
@@ -30,7 +30,15 @@ function toSentryUser(user: AuthUser | null): { id: string } | null {
     const id = deviceId ?? user.id;
     return id ? { id } : null;
   }
-  return user.id ? { id: user.id } : null;
+  // `resolveUserId` in the auth store falls back `id ?? email ?? username`
+  // when the session payload omits the account id. An identifier equal to
+  // either of those is PII whatever its provenance, so the session goes
+  // unidentified rather than identified by an email address.
+  const { id } = user;
+  if (!id || id === user.email || id === user.username) {
+    return null;
+  }
+  return { id };
 }
 
 /**

--- a/clients/web/src/lib/sentry/user-sync.ts
+++ b/clients/web/src/lib/sentry/user-sync.ts
@@ -1,0 +1,51 @@
+/**
+ * Mirrors the signed-in user into the Sentry scope so issues report how
+ * many distinct users they hit, the primary ranking signal for triage.
+ *
+ * Only a stable, non-PII identifier is sent: the platform account id for
+ * platform sessions, and the per-install device id for local gateway
+ * sessions (every local session shares the synthetic `gateway-local`
+ * account id, which would otherwise collapse all local users into one).
+ * Name and email stay out of the scope; Sentry's server-side scrubbing
+ * and the consent gate are unaffected.
+ *
+ * Consent is enforced by the client lifecycle, not here: `sentry-control`
+ * initializes a client only under the composed diagnostics gate, and a
+ * scope user without a client transmits nothing. Setting the scope before
+ * or after the client exists both work, so this module only has to track
+ * the auth store.
+ *
+ * Reference: https://docs.sentry.io/platforms/javascript/enriching-events/identify-user/
+ */
+import { selectSentryFlavor } from "@/lib/sentry/flavor";
+import { getDeviceId } from "@/runtime/device-id";
+import { type AuthUser, useAuthStore } from "@/stores/auth-store";
+
+function toSentryUser(user: AuthUser | null): { id: string } | null {
+  if (!user) {
+    return null;
+  }
+  if (user.kind === "local") {
+    const deviceId = getDeviceId();
+    const id = deviceId ?? user.id;
+    return id ? { id } : null;
+  }
+  return user.id ? { id: user.id } : null;
+}
+
+/**
+ * Stamp the current user and follow the auth store. Returns a cleanup
+ * function that stops following (the scope keeps its last value; sign-out
+ * itself flows through the subscription as `user: null`).
+ */
+export function installSentryUserSync(): () => void {
+  const apply = (user: AuthUser | null): void => {
+    selectSentryFlavor().setUser(toSentryUser(user));
+  };
+  apply(useAuthStore.getState().user);
+  return useAuthStore.subscribe((state, prevState) => {
+    if (state.user !== prevState.user) {
+      apply(state.user);
+    }
+  });
+}

--- a/clients/web/src/lib/sentry/user-sync.ts
+++ b/clients/web/src/lib/sentry/user-sync.ts
@@ -41,19 +41,33 @@ function toSentryUser(user: AuthUser | null): { id: string } | null {
   return { id };
 }
 
+function applyCurrentUser(): void {
+  selectSentryFlavor().setUser(toSentryUser(useAuthStore.getState().user));
+}
+
+/**
+ * Re-stamp the current identity on the active flavor. `sentry-control`
+ * calls this after every successful client initialization: on Capacitor,
+ * a `setUser` issued while consent was closed lands on the JS scope only,
+ * and `@sentry/capacitor` forwards scope users to the native SDK solely
+ * for calls made AFTER `init`; it does not replay the scope's stored
+ * user. Without the reapply, an opt-in after boot leaves native crash
+ * envelopes unidentified until the next auth transition.
+ */
+export function reapplySentryUser(): void {
+  applyCurrentUser();
+}
+
 /**
  * Stamp the current user and follow the auth store. Returns a cleanup
  * function that stops following (the scope keeps its last value; sign-out
  * itself flows through the subscription as `user: null`).
  */
 export function installSentryUserSync(): () => void {
-  const apply = (user: AuthUser | null): void => {
-    selectSentryFlavor().setUser(toSentryUser(user));
-  };
-  apply(useAuthStore.getState().user);
+  applyCurrentUser();
   return useAuthStore.subscribe((state, prevState) => {
     if (state.user !== prevState.user) {
-      apply(state.user);
+      applyCurrentUser();
     }
   });
 }


### PR DESCRIPTION
Fixes LUM-3471.

## TL;DR

Every issue in the `vellum-assistant-web` and `vellum-assistant-macos` Sentry projects shows **Users: 0** because the clients never identify the user, which makes impact-based triage impossible. A new `user-sync` module follows the auth store and stamps a stable, non-PII identifier on the Sentry scope, so issues start reporting how many distinct users they hit.

## Design

- **Identity**: the platform account id for platform sessions; the per-install device id for local gateway sessions (every local session shares the synthetic `gateway-local` account id, which would otherwise collapse all local users into one); `null` on sign-out. Name and email are never sent.
- **Seam**: `SentryFlavor` gains `setUser`, dispatched per flavor because two `@sentry/core` copies exist in the dependency tree, so the scope `@sentry/react` writes is not guaranteed to be the one `@sentry/capacitor` reads. The Capacitor implementation also forwards the identity to the native SDKs, so native crash envelopes carry it too.
- **Wiring**: `installSentryUserSync()` runs from `initSentry()` alongside the existing control listeners; it stamps the current user immediately and subscribes to the auth store's `user` slice.

## Why this is safe

- Consent posture is unchanged: `sentry-control` still gates the client lifecycle on the composed diagnostics gate, and a scope user without a client transmits nothing. Setting the scope before the client exists is well-defined in the SDK.
- Only an opaque id is attached; no PII fields. Server-side scrubbing and `beforeSend` gates are untouched.
- Unit tests cover: platform id stamped and cleared on sign-out, late sign-in, device-id identity for local sessions with the synthetic fallback, and unsubscription.

## What changes for the user

| | Before | After |
|---|---|---|
| App behavior | Unchanged | Unchanged |
| Sentry triage | Every issue shows Users: 0; ranking by impact impossible | Issues report distinct users hit; alerts and triage can rank by real impact |

## Deferred

The Electron **main-process** Sentry client (fatal `write EIO` / `ENOSPC` events) still reports without a user; bridging the renderer identity to the main process is a separate small change and is noted on LUM-3471.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41521" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->