### PR TITLE
Pin the approval-card edit as a cross-channel behavior

### DIFF
--- a/assistant/src/__tests__/approval-card-edit-inbound-handoff.test.ts
+++ b/assistant/src/__tests__/approval-card-edit-inbound-handoff.test.ts
@@ -1,0 +1,199 @@
+/**
+ * The inbound handoff of the approval-card message id, driven through the
+ * real handler.
+ *
+ * The companion suite (approval-card-edit.test.ts) pins the interception
+ * seam but injects `approvalMessageId` directly, so it stays green if the
+ * inbound handler stops reading `sourceMetadata.messageId` off the wire.
+ * This suite closes that gap: a Telegram button decision enters through
+ * `handleChannelInbound` exactly as the gateway forwards it, and the edit
+ * must address the message id the wire carried.
+ */
+import { beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+
+mock.module("../config/env.js", () => ({ isHttpAuthDisabled: () => true }));
+
+const _conversationMocks = new Map<string, unknown>();
+mock.module("../daemon/conversation-registry.js", () => ({
+  findConversation: (id: string) => _conversationMocks.get(id),
+}));
+
+mock.module("../runtime/local-actor-identity.js", () => ({
+  findLocalGuardianPrincipalId: async () => "vellum-principal-1",
+}));
+
+import type { TrustVerdict } from "@vellumai/gateway-client";
+
+import type { Conversation } from "../daemon/conversation.js";
+import * as providers from "../messaging/providers/index.js";
+import { getDb } from "../persistence/db-connection.js";
+import { initializeDb } from "../persistence/db-init.js";
+import * as pendingInteractions from "../runtime/pending-interactions.js";
+import {
+  handleChannelInbound,
+  setAdapterProcessMessage,
+} from "./helpers/channel-test-adapter.js";
+
+await initializeDb();
+
+const CHAT_ID = "chat-123";
+const GUARDIAN = "user-1";
+const BUTTON_MESSAGE_ID = "4242";
+const CALLBACK_URL = "https://gateway.test/deliver/telegram";
+
+function resetTables(): void {
+  const db = getDb();
+  db.run("DELETE FROM channel_inbound_events");
+  db.run("DELETE FROM conversation_keys");
+  db.run("DELETE FROM messages");
+  db.run("DELETE FROM conversations");
+  db.run("DELETE FROM external_conversation_bindings");
+  db.run("DELETE FROM contact_channels");
+  db.run("DELETE FROM contacts");
+}
+
+function guardianVerdict(): TrustVerdict {
+  return {
+    trustClass: "guardian",
+    canonicalSenderId: GUARDIAN,
+    contactId: "contact-1",
+    channelId: "channel-1",
+    type: "telegram",
+    address: GUARDIAN,
+    externalChatId: CHAT_ID,
+    status: "active",
+    policy: "allow",
+    guardianExternalUserId: GUARDIAN,
+    guardianDeliveryChatId: CHAT_ID,
+    guardianPrincipalId: "vellum-principal-1",
+  } satisfies TrustVerdict;
+}
+
+function makeInboundRequest(overrides: Record<string, unknown> = {}): Request {
+  return new Request("http://localhost/channels/inbound", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Gateway-Origin": "test-token",
+    },
+    body: JSON.stringify({
+      sourceChannel: "telegram",
+      interface: "telegram",
+      conversationExternalId: CHAT_ID,
+      externalMessageId: `msg-${Date.now()}-${Math.random()
+        .toString(36)
+        .slice(2, 8)}`,
+      content: "hello",
+      actorExternalId: GUARDIAN,
+      replyCallbackUrl: CALLBACK_URL,
+      sourceMetadata: { trustVerdict: guardianVerdict() },
+      ...overrides,
+    }),
+  });
+}
+
+function conversationIdFromInboundEvents(): string {
+  const rows = getDb()
+    .$client.prepare("SELECT conversation_id FROM channel_inbound_events")
+    .all() as Array<{ conversation_id: string }>;
+  expect(rows.length).toBeGreaterThan(0);
+  return rows[0].conversation_id;
+}
+
+function registerPendingInteraction(
+  requestId: string,
+  conversationId: string,
+): void {
+  const _mockSession = {
+    handleConfirmationResponse: mock(() => {}),
+    ensureActorScopedHistory: async () => {},
+  } as unknown as Conversation;
+  _conversationMocks.set(conversationId, _mockSession);
+
+  pendingInteractions.register(requestId, {
+    conversationId,
+    kind: "confirmation",
+    confirmationDetails: {
+      toolName: "execute_shell",
+      input: { command: "ls" },
+      riskLevel: "high",
+      allowlistOptions: [
+        { label: "test", description: "test", pattern: "test" },
+      ],
+      scopeOptions: [{ label: "everywhere", scope: "everywhere" }],
+    },
+  });
+}
+
+describe("approval-card edit: inbound message-id handoff", () => {
+  let editSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    resetTables();
+    pendingInteractions.clear();
+    _conversationMocks.clear();
+    setAdapterProcessMessage(undefined);
+    editSpy = spyOn(providers, "editChannelMessage").mockResolvedValue({
+      ok: true,
+    });
+  });
+
+  test("a Telegram button press edits the message id the wire carried", async () => {
+    // First inbound materializes the conversation the pending approval
+    // will hang off, the way a real approval prompt's conversation exists
+    // before its buttons are pressed.
+    const first = await handleChannelInbound(makeInboundRequest());
+    expect(((await first.json()) as { accepted?: boolean }).accepted).toBe(
+      true,
+    );
+    const conversationId = conversationIdFromInboundEvents();
+    registerPendingInteraction("req-handoff-1", conversationId);
+
+    // The gateway forwards a button press with the keyboard message's id on
+    // sourceMetadata.messageId; nothing in this request names the id any
+    // other way, so the edit below proves the handler read it off the wire.
+    const res = await handleChannelInbound(
+      makeInboundRequest({
+        content: "",
+        callbackData: "apr:req-handoff-1:approve_once",
+        sourceMetadata: {
+          trustVerdict: guardianVerdict(),
+          messageId: BUTTON_MESSAGE_ID,
+        },
+      }),
+    );
+    expect(res.status).toBe(200);
+
+    expect(editSpy).toHaveBeenCalledTimes(1);
+    const [callbackUrl, payload] = editSpy.mock.calls[0];
+    expect(callbackUrl).toBe(CALLBACK_URL);
+    expect(payload.chatId).toBe(CHAT_ID);
+    expect(payload.messageId).toBe(BUTTON_MESSAGE_ID);
+    expect(payload.text).toContain("Approved");
+
+    editSpy.mockRestore();
+  });
+
+  test("a button press whose wire carries no message id edits nothing", async () => {
+    // The inverse pin: the edit is driven by the wire's id and only by it.
+    const first = await handleChannelInbound(makeInboundRequest());
+    expect(((await first.json()) as { accepted?: boolean }).accepted).toBe(
+      true,
+    );
+    const conversationId = conversationIdFromInboundEvents();
+    registerPendingInteraction("req-handoff-2", conversationId);
+
+    const res = await handleChannelInbound(
+      makeInboundRequest({
+        content: "",
+        callbackData: "apr:req-handoff-2:approve_once",
+        sourceMetadata: { trustVerdict: guardianVerdict() },
+      }),
+    );
+    expect(res.status).toBe(200);
+
+    expect(editSpy).not.toHaveBeenCalled();
+
+    editSpy.mockRestore();
+  });
+});

--- a/assistant/src/__tests__/approval-card-edit.test.ts
+++ b/assistant/src/__tests__/approval-card-edit.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Approval-card editing after a button decision, across channels.
+ *
+ * The card edit is routed by the reply callback URL through the channel edit
+ * capability, so the same interception path serves every channel whose
+ * transport implements `edit`. These tests drive the Telegram shape end to
+ * end at this seam: the gateway forwards the id of the message holding the
+ * inline keyboard, and a decision or a stale press must edit exactly that
+ * message.
+ */
+import { beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+
+const _conversationMocks = new Map<string, unknown>();
+mock.module("../daemon/conversation-registry.js", () => ({
+  findConversation: (id: string) => _conversationMocks.get(id),
+}));
+
+let _anchorPrincipalId: string | undefined;
+mock.module("../runtime/local-actor-identity.js", () => ({
+  findLocalGuardianPrincipalId: async () => _anchorPrincipalId,
+}));
+
+import type { Conversation } from "../daemon/conversation.js";
+import * as providers from "../messaging/providers/index.js";
+import { initializeDb } from "../persistence/db-init.js";
+import * as gatewayClient from "../runtime/gateway-client.js";
+import * as pendingInteractions from "../runtime/pending-interactions.js";
+import { handleApprovalInterception } from "../runtime/routes/guardian-approval-interception.js";
+
+await initializeDb();
+
+const ASSISTANT_ID = "self";
+const CONVERSATION_ID = "conv-card-edit-1";
+const REQUESTER_CHAT = "5550100";
+const TELEGRAM_CALLBACK_URL = "https://gateway.test/deliver/telegram?chat=1";
+const BUTTON_MESSAGE_ID = "4242";
+
+function registerPendingInteraction(requestId: string): void {
+  const _mockSession = {
+    handleConfirmationResponse: mock(() => {}),
+    ensureActorScopedHistory: async () => {},
+  } as unknown as Conversation;
+  _conversationMocks.set(CONVERSATION_ID, _mockSession);
+
+  pendingInteractions.register(requestId, {
+    conversationId: CONVERSATION_ID,
+    kind: "confirmation",
+    confirmationDetails: {
+      toolName: "execute_shell",
+      input: { command: "ls" },
+      riskLevel: "high",
+      allowlistOptions: [
+        { label: "test", description: "test", pattern: "test" },
+      ],
+      scopeOptions: [{ label: "everywhere", scope: "everywhere" }],
+    },
+  });
+}
+
+function guardianParams(callbackData: string) {
+  return {
+    conversationId: CONVERSATION_ID,
+    callbackData,
+    content: "",
+    conversationExternalId: REQUESTER_CHAT,
+    sourceChannel: "telegram" as const,
+    actorExternalId: "guardian-user-1",
+    replyCallbackUrl: TELEGRAM_CALLBACK_URL,
+    trustCtx: {
+      sourceChannel: "telegram" as const,
+      trustClass: "guardian" as const,
+      requesterExternalUserId: "guardian-user-1",
+      guardianExternalUserId: "guardian-user-1",
+      guardianPrincipalId: "guardian-principal-1",
+    },
+    assistantId: ASSISTANT_ID,
+    approvalMessageId: BUTTON_MESSAGE_ID,
+  };
+}
+
+describe("approval card edit after a button decision", () => {
+  let editSpy: ReturnType<typeof spyOn>;
+  let deliverSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    pendingInteractions.clear();
+    _anchorPrincipalId = "guardian-principal-1";
+    editSpy = spyOn(providers, "editChannelMessage").mockResolvedValue({
+      ok: true,
+    });
+    deliverSpy = spyOn(gatewayClient, "deliverChannelReply").mockResolvedValue({
+      ok: true,
+    });
+  });
+
+  test("a Telegram approve button edits exactly the card message", async () => {
+    registerPendingInteraction("req-card-edit-approve");
+
+    const result = await handleApprovalInterception(
+      guardianParams("apr:req-card-edit-approve:approve_once"),
+    );
+
+    expect(result).toEqual({ handled: true, type: "decision_applied" });
+    expect(editSpy).toHaveBeenCalledTimes(1);
+    const [callbackUrl, payload] = editSpy.mock.calls[0];
+    expect(callbackUrl).toBe(TELEGRAM_CALLBACK_URL);
+    expect(payload.chatId).toBe(REQUESTER_CHAT);
+    expect(payload.messageId).toBe(BUTTON_MESSAGE_ID);
+    expect(payload.text).toContain("Approved");
+
+    editSpy.mockRestore();
+    deliverSpy.mockRestore();
+  });
+
+  test("a Telegram reject button edits the card to Denied", async () => {
+    registerPendingInteraction("req-card-edit-reject");
+
+    const result = await handleApprovalInterception(
+      guardianParams("apr:req-card-edit-reject:reject"),
+    );
+
+    expect(result).toEqual({ handled: true, type: "decision_applied" });
+    expect(editSpy).toHaveBeenCalledTimes(1);
+    const [, payload] = editSpy.mock.calls[0];
+    expect(payload.messageId).toBe(BUTTON_MESSAGE_ID);
+    expect(payload.text).toContain("Denied");
+
+    editSpy.mockRestore();
+    deliverSpy.mockRestore();
+  });
+
+  test("a stale Telegram button press marks the card resolved", async () => {
+    // Pending interaction exists, but the button belongs to a different,
+    // already-settled request: the card must lose its buttons rather than
+    // apply to the wrong interaction.
+    registerPendingInteraction("req-card-edit-live");
+
+    const result = await handleApprovalInterception(
+      guardianParams("apr:req-card-edit-settled:approve_once"),
+    );
+
+    expect(result).toEqual({ handled: true, type: "stale_ignored" });
+    expect(editSpy).toHaveBeenCalledTimes(1);
+    const [callbackUrl, payload] = editSpy.mock.calls[0];
+    expect(callbackUrl).toBe(TELEGRAM_CALLBACK_URL);
+    expect(payload.messageId).toBe(BUTTON_MESSAGE_ID);
+    expect(payload.text).toBe("This approval request has been resolved.");
+    expect(payload.emphasis).toBe("muted");
+
+    editSpy.mockRestore();
+    deliverSpy.mockRestore();
+  });
+});

--- a/assistant/src/runtime/routes/guardian-approval-interception.ts
+++ b/assistant/src/runtime/routes/guardian-approval-interception.ts
@@ -45,7 +45,8 @@ export interface ApprovalInterceptionParams {
   assistantId: string;
   approvalCopyGenerator?: ApprovalCopyGenerator;
   approvalConversationGenerator?: ApprovalConversationGenerator;
-  /** Original approval message timestamp (Slack ts) for editing after resolution. */
+  /** Id of the channel message holding the approval buttons (Slack ts,
+   * Telegram message id), for editing the card after resolution. */
   approvalMessageId?: string;
 }
 
@@ -242,7 +243,7 @@ export async function handleApprovalInterception(
             "Callback request ID does not match any pending interaction, ignoring stale button press",
           );
 
-          // Edit the original Slack approval message to remove stale buttons
+          // Edit the original approval message to remove stale buttons
           if (approvalMessageId) {
             editStaleApprovalMessage({
               replyCallbackUrl,
@@ -260,8 +261,10 @@ export async function handleApprovalInterception(
       const result = await handleChannelDecision(conversationId, cbDecision);
 
       if (result.applied) {
-        // Edit the original Slack approval message to show the decision
-        // and remove stale action buttons.
+        // Edit the original approval message to show the decision and drop
+        // its action buttons. Routed by the callback URL through the channel
+        // edit capability; a transport without edit declines, so this is
+        // safe to attempt on every channel.
         if (approvalMessageId) {
           const decisionOutcome: "approved" | "denied" =
             cbDecision.action === "reject" ? "denied" : "approved";
@@ -276,7 +279,7 @@ export async function handleApprovalInterception(
           }).catch((err) => {
             log.error(
               { err, conversationId, messageTs: approvalMessageId },
-              "Failed to edit Slack approval message after decision",
+              "Failed to edit approval message after decision",
             );
           });
         }
@@ -287,8 +290,8 @@ export async function handleApprovalInterception(
       }
 
       // Race condition: request was already resolved between the stale check
-      // above and the decision attempt.
-      // Edit the original Slack approval message to remove stale buttons
+      // above and the decision attempt. Edit the original approval message to
+      // remove stale buttons
       if (approvalMessageId) {
         editStaleApprovalMessage({
           replyCallbackUrl,
@@ -368,7 +371,7 @@ export async function handleApprovalInterception(
 }
 
 // ---------------------------------------------------------------------------
-// Slack approval message edit helper
+// Approval message edit helper
 // ---------------------------------------------------------------------------
 
 /**
@@ -399,7 +402,7 @@ function editStaleApprovalMessage(params: {
         conversationId: params.conversationId,
         messageId: params.messageId,
       },
-      "Failed to edit stale Slack approval message",
+      "Failed to edit stale approval message",
     );
   });
 }

--- a/assistant/src/runtime/routes/inbound-message-handler.ts
+++ b/assistant/src/runtime/routes/inbound-message-handler.ts
@@ -1091,10 +1091,11 @@ export async function handleChannelInbound({
     !result.duplicate &&
     !guardianReplyResult.skipApprovalInterception
   ) {
-    // Extract the original approval message timestamp for Slack button
-    // cleanup. When a Slack block_actions payload is forwarded, the gateway
-    // sets sourceMetadata.messageId to the ts of the message containing
-    // the button. This lets us edit the message after resolution.
+    // The id of the message holding the approval buttons, for editing the
+    // card after resolution. The gateway sets sourceMetadata.messageId on
+    // every button-press forward: Slack's block_actions carry the ts of the
+    // message containing the button, Telegram's callback_query the id of the
+    // message the keyboard is attached to.
     const approvalMessageId =
       typeof sourceMetadata?.messageId === "string"
         ? sourceMetadata.messageId

--- a/gateway/src/telegram/normalize.test.ts
+++ b/gateway/src/telegram/normalize.test.ts
@@ -103,6 +103,17 @@ describe("normalizeTelegramUpdate — callback_query DM-only guard", () => {
     expect(result!.message.callbackData).toBe("apr:run1:approve");
   });
 
+  it("forwards the button message's id so the card can be edited later", () => {
+    // The approval-card edit after a decision addresses exactly the message
+    // holding the inline keyboard. Dropping this id would leave stale
+    // buttons on every decided card, silently: the daemon's interception
+    // reads it off sourceMetadata.messageId.
+    const result = normalizeTelegramUpdate(makeCallbackQueryPayload());
+
+    expect(result).not.toBeNull();
+    expect(result!.source.messageId).toBe("10");
+  });
+
   it("rejects callback_query from group chat", () => {
     const result = normalizeTelegramUpdate(
       makeCallbackQueryPayload({ chatType: "group" }),


### PR DESCRIPTION
## TL;DR

Stage 1 of LUM-3356, first item: the Telegram approval-card edit turned out to be fully wired already, so this PR delivers the missing half of "done": proof and truthful comments. A behavior suite drives the Telegram button shapes through the interception seam, and the comments that still described a Slack-only mechanism now state the channel-agnostic invariant.

## Why this is safe

- No behavior changes: every code edit is a comment. The card-edit path was already channel-agnostic (`approvalMessageId` from `sourceMetadata.messageId` for any channel; edits routed by callback URL through the channel `edit` capability, which declines when a transport lacks it).
- The chain was verified link by link before writing the tests: Telegram buttons carry `apr:<requestId>:<actionId>` matching `parseCallbackData`; the callback normalizer forwards the keyboard message's id; `handle-inbound` stamps it onto `sourceMetadata.messageId`; the transport's `edit` clears the inline keyboard as part of the revision.
- The new tests pin the invariants, not presence: an approve edits exactly the message holding the keyboard (id equality, not just "an edit happened"), a reject renders Denied, and a stale press strips the buttons instead of applying to the wrong pending interaction.
- LUM-3356 carries a dated correction recording that the blocker it named (`approvalMessageTs` computed Slack-only) no longer exists in this form.

## What changes for the user

| Before | After |
| --- | --- |
| Nothing user-visible changes in this PR | Same; it locks the Telegram approval-card edit behavior under test so a regression fails CI instead of silently leaving stale buttons |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41522" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->