### PR TITLE
fix(assistant): keep in-flight subagents alive across config reload

### DIFF
--- a/assistant/src/__tests__/conversation-evictor.test.ts
+++ b/assistant/src/__tests__/conversation-evictor.test.ts
@@ -9,6 +9,13 @@ mock.module("../subagent/index.js", () => ({
   getSubagentManager: () => ({
     abortAllForParent: (id: string) => abortedParents.push(id),
     getChildrenOf: () => protectedChildren,
+    hasActiveChildren: () =>
+      protectedChildren.some(
+        (c) =>
+          c.status === "running" ||
+          c.status === "pending" ||
+          c.status === "awaiting_input",
+      ),
   }),
 }));
 
@@ -227,6 +234,18 @@ describe("ConversationEvictor", () => {
   describe("shouldProtect", () => {
     test("skips conversations with running or pending subagents", () => {
       protectedChildren = [{ status: "running" }];
+      const s1 = createMockSession();
+      sessions.set("a", s1);
+
+      const result = evictor.sweep();
+
+      expect(result.skipped).toBe(1);
+      expect(sessions.has("a")).toBe(true);
+      expect(s1.disposed).toBe(false);
+    });
+
+    test("skips conversations with awaiting_input subagents", () => {
+      protectedChildren = [{ status: "awaiting_input" }];
       const s1 = createMockSession();
       sessions.set("a", s1);
 

--- a/assistant/src/__tests__/evict-conversations-for-reload.test.ts
+++ b/assistant/src/__tests__/evict-conversations-for-reload.test.ts
@@ -5,13 +5,23 @@
  * same "not idle while a queue is pending" rule the periodic evictor applies
  * has to hold here: `isProcessing()` reads false in the window between a turn
  * releasing and its queued successor being dispatched.
+ *
+ * In-flight subagents are the other non-idle case: an async spawn leaves the
+ * parent idle between its own tool calls while children are still running, and
+ * reload must not abort those children.
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+const abortedParents: string[] = [];
+const activeParents = new Set<string>();
+
 mock.module("../subagent/index.js", () => ({
   getSubagentManager: () => ({
-    abortAllForParent: () => {},
+    abortAllForParent: (id: string) => {
+      abortedParents.push(id);
+    },
     getChildrenOf: () => [],
+    hasActiveChildren: (id: string) => activeParents.has(id),
   }),
 }));
 
@@ -53,6 +63,8 @@ function register(
 describe("evictConversationsForReload", () => {
   beforeEach(() => {
     clearConversations();
+    abortedParents.length = 0;
+    activeParents.clear();
   });
 
   test("disposes an idle conversation", () => {
@@ -62,6 +74,7 @@ describe("evictConversationsForReload", () => {
 
     expect(idle.disposed).toBe(true);
     expect(findConversation("reload-idle")).toBeUndefined();
+    expect(abortedParents).toEqual(["reload-idle"]);
   });
 
   test("keeps a conversation with queued messages and marks it stale", () => {
@@ -76,6 +89,7 @@ describe("evictConversationsForReload", () => {
     expect(queued.disposed).toBe(false);
     expect(queued.markedStale).toBe(true);
     expect(findConversation("reload-queued")).toBeDefined();
+    expect(abortedParents).toEqual([]);
   });
 
   test("marks a mid-turn conversation stale instead of disposing it", () => {
@@ -86,5 +100,41 @@ describe("evictConversationsForReload", () => {
     expect(busy.disposed).toBe(false);
     expect(busy.markedStale).toBe(true);
     expect([...conversationIds()]).toEqual(["reload-busy"]);
+    expect(abortedParents).toEqual([]);
+  });
+
+  test("skips an idle parent with in-flight subagents", () => {
+    const parent = register("reload-with-children", {
+      processing: false,
+      queued: false,
+    });
+    activeParents.add("reload-with-children");
+
+    evictConversationsForReload();
+
+    expect(parent.disposed).toBe(false);
+    expect(parent.markedStale).toBe(false);
+    expect(findConversation("reload-with-children")).toBeDefined();
+    expect(abortedParents).toEqual([]);
+  });
+
+  test("still evicts other idle conversations when one parent is protected", () => {
+    const protectedParent = register("reload-protected", {
+      processing: false,
+      queued: false,
+    });
+    const idle = register("reload-unprotected", {
+      processing: false,
+      queued: false,
+    });
+    activeParents.add("reload-protected");
+
+    evictConversationsForReload();
+
+    expect(protectedParent.disposed).toBe(false);
+    expect(findConversation("reload-protected")).toBeDefined();
+    expect(idle.disposed).toBe(true);
+    expect(findConversation("reload-unprotected")).toBeUndefined();
+    expect(abortedParents).toEqual(["reload-unprotected"]);
   });
 });

--- a/assistant/src/__tests__/subagent-manager-notify.test.ts
+++ b/assistant/src/__tests__/subagent-manager-notify.test.ts
@@ -533,6 +533,44 @@ describe("SubagentManager notifyParent (via runSubagent)", () => {
   });
 });
 
+describe("SubagentManager hasActiveChildren", () => {
+  test("is true for pending, running, and awaiting_input children", () => {
+    const manager = new SubagentManager();
+    injectFakeSubagent(
+      manager,
+      "sub-running",
+      makeState("sub-running", { status: "running" }),
+    );
+
+    expect(manager.hasActiveChildren("parent-sess-1")).toBe(true);
+
+    asInternals(manager).subagents.get("sub-running")!.state.status =
+      "awaiting_input";
+    expect(manager.hasActiveChildren("parent-sess-1")).toBe(true);
+
+    asInternals(manager).subagents.get("sub-running")!.state.status = "pending";
+    expect(manager.hasActiveChildren("parent-sess-1")).toBe(true);
+  });
+
+  test("is false when every child is terminal or the parent has none", () => {
+    const manager = new SubagentManager();
+    expect(manager.hasActiveChildren("parent-sess-1")).toBe(false);
+
+    injectFakeSubagent(
+      manager,
+      "sub-done",
+      makeState("sub-done", { status: "completed" }),
+    );
+    injectFakeSubagent(
+      manager,
+      "sub-aborted",
+      makeState("sub-aborted", { status: "aborted" }),
+    );
+
+    expect(manager.hasActiveChildren("parent-sess-1")).toBe(false);
+  });
+});
+
 describe("SubagentManager abortAllForParent", () => {
   test("aborts active children but keeps every child's state readable", () => {
     clearCaptured();

--- a/assistant/src/daemon/conversation-evictor.ts
+++ b/assistant/src/daemon/conversation-evictor.ts
@@ -74,11 +74,9 @@ export class ConversationEvictor {
     getSubagentManager().abortAllForParent(conversationId);
   }
 
-  /** Protect conversations with running or pending subagents from eviction. */
+  /** Protect conversations with in-flight subagents from eviction. */
   shouldProtect(conversationId: string): boolean {
-    return getSubagentManager()
-      .getChildrenOf(conversationId)
-      .some((c) => c.status === "running" || c.status === "pending");
+    return getSubagentManager().hasActiveChildren(conversationId);
   }
 
   /** Record an access for the given conversation (resets its idle clock). */

--- a/assistant/src/daemon/conversation-store.ts
+++ b/assistant/src/daemon/conversation-store.ts
@@ -402,7 +402,9 @@ export function clearAllActiveConversations(): number {
  * Evict in-memory conversations after a config/prompt/skills reload so the next
  * turn rebuilds them against the new config. Idle conversations are disposed and
  * dropped; busy ones are marked stale so they're rebuilt once their current turn
- * finishes. Also used when provider credentials change.
+ * finishes. Conversations with in-flight subagents are left in place so a
+ * reload does not abort those children. Also used when provider credentials
+ * change.
  */
 export function evictConversationsForReload(): void {
   const subagentManager = getSubagentManager();
@@ -413,6 +415,11 @@ export function evictConversationsForReload(): void {
     // would silently drop the queued messages, so mark it stale instead and
     // let it rebuild once the queue has run.
     if (!conversation.isProcessing() && !conversation.hasQueuedMessages()) {
+      // Same protection the TTL/LRU evictor applies: an idle parent still
+      // owns mid-task children, and aborting them here would kill that work.
+      if (subagentManager.hasActiveChildren(id)) {
+        continue;
+      }
       subagentManager.abortAllForParent(id);
       conversation.dispose();
       deleteConversation(id);

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -1478,6 +1478,18 @@ export class SubagentManager {
       .filter((s): s is SubagentState => s !== undefined);
   }
 
+  /**
+   * True when this parent still has a child that is not terminal (`pending`,
+   * `running`, or `awaiting_input`). Idle-eviction and config-reload rebuild
+   * skip those parents so an otherwise-idle conversation does not abort
+   * mid-task children.
+   */
+  hasActiveChildren(parentConversationId: string): boolean {
+    return this.getChildrenOf(parentConversationId).some(
+      (child) => !TERMINAL_STATUSES.has(child.status),
+    );
+  }
+
   /** Total number of active (non-terminal) subagents. */
   get activeCount(): number {
     return [...this.subagents.values()].filter(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan

A user reported that editing a watched workspace file (`SOUL.md`, `IDENTITY.md`, `config.json`, skill catalog files, `users/*.md`) while subagents are running aborts those subagents. The parent of an async spawn is idle between its own tool calls, so reload eviction treated it as disposable and called `abortAllForParent`.

The TTL/LRU evictor already skips parents with in-flight children via `shouldProtect`. Reload eviction did not.

## Summary
- Add `SubagentManager.hasActiveChildren()` as the shared in-flight-child check (`pending`, `running`, `awaiting_input`).
- Skip those parents in `evictConversationsForReload` instead of aborting and disposing them.
- Point the TTL/LRU evictor at the same helper so both paths stay aligned.

Out of scope: the agent-loop still labels every abort as "Cancelled by user". That is a separate labeling bug.

## Test plan
- [x] `cd assistant && bun test src/__tests__/evict-conversations-for-reload.test.ts`
- [x] `cd assistant && bun test src/__tests__/conversation-evictor.test.ts`
- [x] `cd assistant && bun test src/__tests__/subagent-manager-notify.test.ts`

All 47 tests across those files passed locally (142 expect calls).

## Risk
- Low. Idle parents without children still evict and rebuild against the new config.
- A parent that stays in memory because it has running children keeps its current system prompt until a later reload or idle eviction. That is the accepted tradeoff of skip-not-rebuild.
- Residual hole: a mid-turn parent is still marked stale on reload. If it is accessed again via `getOrCreateConversation` while children are still running, the stale-rebuild path still calls `abortAllForParent`. The reported case is the idle parent, which this PR covers.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be32a5d6-8bfa-4f51-932e-d5656a0f7c29?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be32a5d6-8bfa-4f51-932e-d5656a0f7c29&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

