### PR TITLE
fix(chat): stop the underfilled auto-fetch on no-progress pages

### DIFF
--- a/clients/web/src/domains/chat/transcript/transcript-scroll-utils.ts
+++ b/clients/web/src/domains/chat/transcript/transcript-scroll-utils.ts
@@ -92,6 +92,32 @@ export function haveSameItemKeys(
   return a.length === b.length && a.every((item, i) => item.key === b[i]?.key);
 }
 
+/**
+ * Whether a history-seeking user gesture should page in older history.
+ *
+ * An underfilled scroll element is pinned at scrollTop 0 and never fires
+ * `scroll`, so the scroll-handler load-older path is unreachable there and
+ * the no-progress guard (see {@link haveSameItemKeys}) has stopped the
+ * automatic chain. Gestures are the only remaining signal of intent, and
+ * each one pages in at most one fetch.
+ */
+export function shouldGestureLoadOlder(
+  metrics: ScrollMetrics,
+  flags: {
+    hasMore: boolean;
+    isLoadingOlder: boolean;
+    hasConversation: boolean;
+  },
+): boolean {
+  const underfilled = metrics.scrollHeight <= metrics.clientHeight;
+  return (
+    underfilled &&
+    flags.hasConversation &&
+    flags.hasMore &&
+    !flags.isLoadingOlder
+  );
+}
+
 /** Find the new index of a previously saved anchor key inside a refreshed
  *  items list. Returns -1 if the key is no longer present. */
 export function findAnchorIndex(

--- a/clients/web/src/domains/chat/transcript/transcript-scroll-utils.ts
+++ b/clients/web/src/domains/chat/transcript/transcript-scroll-utils.ts
@@ -73,6 +73,25 @@ export function classifyScrollPosition(
   return { distanceFromBottom, isPinned, showScrollToLatest, shouldLoadOlder };
 }
 
+/**
+ * Whether two item lists hold the same rows, compared by key.
+ *
+ * Guards the underfilled-viewport auto-fetch: transcript items are a
+ * projection of the loaded transcript (confirmation visibility and other
+ * filters can drop rows), so a fetched history page can change the items
+ * array's identity without changing its rows. An auto-fetch that re-fires on
+ * such a no-progress update would chain-load history the transcript will not
+ * show. Key equality is the right grain: a page that adds or removes any
+ * visible row changes the key sequence, while in-place updates to an
+ * existing row (streaming text) keep it.
+ */
+export function haveSameItemKeys(
+  a: readonly TranscriptItem[],
+  b: readonly TranscriptItem[],
+): boolean {
+  return a.length === b.length && a.every((item, i) => item.key === b[i]?.key);
+}
+
 /** Find the new index of a previously saved anchor key inside a refreshed
  *  items list. Returns -1 if the key is no longer present. */
 export function findAnchorIndex(

--- a/clients/web/src/domains/chat/transcript/use-transcript-scroll.test.ts
+++ b/clients/web/src/domains/chat/transcript/use-transcript-scroll.test.ts
@@ -21,6 +21,7 @@ import { describe, expect, mock, test } from "bun:test";
 import type { TranscriptItem } from "@/domains/chat/transcript/types";
 import {
   classifyScrollPosition,
+  haveSameItemKeys,
   decideItemsChangeAction,
   findAnchorIndex,
   findLatestUserAnchorKey,
@@ -705,5 +706,44 @@ describe("integration — items-effect dispatch on underfilled viewport", () => 
       onLoadOlder();
     }
     expect(onLoadOlder).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// haveSameItemKeys — the no-progress guard for the underfilled auto-fetch
+// ---------------------------------------------------------------------------
+
+describe("haveSameItemKeys", () => {
+  test("same rows in the same order compare equal", () => {
+    const prev = [makeMessage("m1"), makeMessage("m2")];
+    const next = [makeMessage("m1"), makeMessage("m2")];
+    expect(haveSameItemKeys(prev, next)).toBe(true);
+  });
+
+  test("an in-place update to a row (same key) still compares equal", () => {
+    // Streaming replaces the item object but keeps its key; the guard must
+    // not read that as progress.
+    const prev = [makeMessage("m1")];
+    const next = [makeMessage("m1")];
+    expect(prev[0]).not.toBe(next[0]);
+    expect(haveSameItemKeys(prev, next)).toBe(true);
+  });
+
+  test("a prepended row is progress", () => {
+    const prev = [makeMessage("m2")];
+    const next = [makeMessage("m1"), makeMessage("m2")];
+    expect(haveSameItemKeys(prev, next)).toBe(false);
+  });
+
+  test("a removed row is progress", () => {
+    const prev = [makeMessage("m1"), makeMessage("m2")];
+    const next = [makeMessage("m2")];
+    expect(haveSameItemKeys(prev, next)).toBe(false);
+  });
+
+  test("a replaced key at equal length is progress", () => {
+    const prev = [makeMessage("m1"), makeMessage("m2")];
+    const next = [makeMessage("m1"), makeMessage("m3")];
+    expect(haveSameItemKeys(prev, next)).toBe(false);
   });
 });

--- a/clients/web/src/domains/chat/transcript/use-transcript-scroll.test.ts
+++ b/clients/web/src/domains/chat/transcript/use-transcript-scroll.test.ts
@@ -22,6 +22,7 @@ import type { TranscriptItem } from "@/domains/chat/transcript/types";
 import {
   classifyScrollPosition,
   haveSameItemKeys,
+  shouldGestureLoadOlder,
   decideItemsChangeAction,
   findAnchorIndex,
   findLatestUserAnchorKey,
@@ -745,5 +746,47 @@ describe("haveSameItemKeys", () => {
     const prev = [makeMessage("m1"), makeMessage("m2")];
     const next = [makeMessage("m1"), makeMessage("m3")];
     expect(haveSameItemKeys(prev, next)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// shouldGestureLoadOlder — the underfilled-transcript gesture load path
+// ---------------------------------------------------------------------------
+
+describe("shouldGestureLoadOlder", () => {
+  const UNDERFILLED = { scrollTop: 0, scrollHeight: 400, clientHeight: 600 };
+  const READY = { hasMore: true, isLoadingOlder: false, hasConversation: true };
+
+  test("underfilled element with more history loads on a gesture", () => {
+    expect(shouldGestureLoadOlder(UNDERFILLED, READY)).toBe(true);
+  });
+
+  test("a scrollable element defers to the scroll handler", () => {
+    // Filled past the viewport: scroll events fire normally, so the gesture
+    // path stands down.
+    expect(
+      shouldGestureLoadOlder(
+        { scrollTop: 100, scrollHeight: 2_000, clientHeight: 600 },
+        READY,
+      ),
+    ).toBe(false);
+  });
+
+  test("no further history means no fetch", () => {
+    expect(
+      shouldGestureLoadOlder(UNDERFILLED, { ...READY, hasMore: false }),
+    ).toBe(false);
+  });
+
+  test("an in-flight load is not doubled", () => {
+    expect(
+      shouldGestureLoadOlder(UNDERFILLED, { ...READY, isLoadingOlder: true }),
+    ).toBe(false);
+  });
+
+  test("no conversation means no fetch", () => {
+    expect(
+      shouldGestureLoadOlder(UNDERFILLED, { ...READY, hasConversation: false }),
+    ).toBe(false);
   });
 });

--- a/clients/web/src/domains/chat/transcript/use-transcript-scroll.ts
+++ b/clients/web/src/domains/chat/transcript/use-transcript-scroll.ts
@@ -34,10 +34,11 @@ import {
 import { recordUpdate } from "@/lib/commit-pressure";
 import type { TranscriptItem } from "@/domains/chat/transcript/types";
 import {
-  type AnchorSnapshot,
   classifyScrollPosition,
   decideItemsChangeAction,
   findLatestUserAnchorKey,
+  haveSameItemKeys,
+  type AnchorSnapshot,
   type ScrollMetrics,
 } from "@/domains/chat/transcript/transcript-scroll-utils";
 
@@ -362,8 +363,16 @@ export function useTranscriptScroll(
       // from here. Skip the anchor save during auto-pin (resize observer re-pins).
       // Gate on the synchronous in-flight lock so a chain-load sequence
       // (response prepends → items change → effect re-runs near top) cannot
-      // double-fire on a single render cycle.
-      if (classification.shouldLoadOlder && !loadOlderInFlightRef.current) {
+      // double-fire on a single render cycle. Also gate on the item set
+      // actually having changed (see `haveSameItemKeys`): re-firing on a
+      // no-progress update would chain-load history the transcript will not
+      // show. A real user gesture still reaches load-older through the
+      // scroll handler.
+      if (
+        classification.shouldLoadOlder &&
+        !loadOlderInFlightRef.current &&
+        !haveSameItemKeys(prev, items)
+      ) {
         if (!shouldAutoPinRef.current) {
           const firstItem = items[0];
           if (firstItem) {

--- a/clients/web/src/domains/chat/transcript/use-transcript-scroll.ts
+++ b/clients/web/src/domains/chat/transcript/use-transcript-scroll.ts
@@ -38,6 +38,7 @@ import {
   decideItemsChangeAction,
   findLatestUserAnchorKey,
   haveSameItemKeys,
+  shouldGestureLoadOlder,
   type AnchorSnapshot,
   type ScrollMetrics,
 } from "@/domains/chat/transcript/transcript-scroll-utils";
@@ -366,8 +367,9 @@ export function useTranscriptScroll(
       // double-fire on a single render cycle. Also gate on the item set
       // actually having changed (see `haveSameItemKeys`): re-firing on a
       // no-progress update would chain-load history the transcript will not
-      // show. A real user gesture still reaches load-older through the
-      // scroll handler.
+      // show. A real user gesture still reaches load-older: through the
+      // scroll handler on a scrollable transcript, and through the gesture
+      // listeners on an underfilled one (which emits no scroll events).
       if (
         classification.shouldLoadOlder &&
         !loadOlderInFlightRef.current &&
@@ -517,21 +519,87 @@ export function useTranscriptScroll(
   // them. We listen on the scroll element rather than the scroll event
   // because the scroll event also fires from our own programmatic pins,
   // which would otherwise disengage their own window mid-pin.
+  //
+  // History-seeking gestures also page in older history when the element is
+  // underfilled: an underfilled element is pinned at scrollTop 0 and never
+  // fires `scroll`, so the scroll-handler load path cannot reach it, and the
+  // items-effect's no-progress guard has deliberately stopped the automatic
+  // chain. One fetch per gesture, gated by the same in-flight lock.
   // -----------------------------------------------------------------------
+  const maybeGestureLoadOlder = useCallback(() => {
+    const el = transcriptRef.current?.getScrollElement();
+    if (!el || loadOlderInFlightRef.current) {
+      return;
+    }
+    const latest = latestRef.current;
+    const wants = shouldGestureLoadOlder(
+      {
+        scrollTop: el.scrollTop,
+        scrollHeight: el.scrollHeight,
+        clientHeight: el.clientHeight,
+      },
+      {
+        hasMore: latest.hasMore,
+        isLoadingOlder: latest.isLoadingOlder,
+        hasConversation: latest.conversationId !== null,
+      },
+    );
+    if (wants) {
+      loadOlderInFlightRef.current = true;
+      latest.onLoadOlder();
+    }
+  }, [transcriptRef]);
+
+  const handleWheelGesture = useCallback(
+    (event: WheelEvent) => {
+      disengageAutoPin();
+      if (event.deltaY < 0) {
+        maybeGestureLoadOlder();
+      }
+    },
+    [disengageAutoPin, maybeGestureLoadOlder],
+  );
+  const handleTouchGesture = useCallback(() => {
+    disengageAutoPin();
+    // Touch direction is unknown without tracking the start point; any drag
+    // on an underfilled transcript reads as intent to see more.
+    maybeGestureLoadOlder();
+  }, [disengageAutoPin, maybeGestureLoadOlder]);
+  const handleKeyGesture = useCallback(
+    (event: KeyboardEvent) => {
+      disengageAutoPin();
+      if (
+        event.key === "ArrowUp" ||
+        event.key === "PageUp" ||
+        event.key === "Home"
+      ) {
+        maybeGestureLoadOlder();
+      }
+    },
+    [disengageAutoPin, maybeGestureLoadOlder],
+  );
+
   useEffect(() => {
     const el = transcriptRef.current?.getScrollElement() ?? null;
     if (!el) {
       return;
     }
-    el.addEventListener("wheel", disengageAutoPin, { passive: true });
-    el.addEventListener("touchmove", disengageAutoPin, { passive: true });
-    el.addEventListener("keydown", disengageAutoPin, { passive: true });
+    el.addEventListener("wheel", handleWheelGesture, { passive: true });
+    el.addEventListener("touchmove", handleTouchGesture, { passive: true });
+    el.addEventListener("keydown", handleKeyGesture, { passive: true });
     return () => {
-      el.removeEventListener("wheel", disengageAutoPin);
-      el.removeEventListener("touchmove", disengageAutoPin);
-      el.removeEventListener("keydown", disengageAutoPin);
+      el.removeEventListener("wheel", handleWheelGesture);
+      el.removeEventListener("touchmove", handleTouchGesture);
+      el.removeEventListener("keydown", handleKeyGesture);
     };
-  }, [conversationId, transcriptRef, disengageAutoPin, hasItems]);
+  }, [
+    conversationId,
+    transcriptRef,
+    handleWheelGesture,
+    handleTouchGesture,
+    handleKeyGesture,
+    hasItems,
+  ]);
 
   // -----------------------------------------------------------------------
   // Stable scroll handler. Reads latest props via the ref pattern.


### PR DESCRIPTION
## TL;DR

Fixes a chain-load hazard in the transcript's underfilled-viewport auto-pagination: when a fetched history page contains only rows the transcript's projection filters out, the items array changes identity without changing its rows, and the auto-fetch re-fires on that no-progress update. In a conversation where many consecutive pages are filtered, merely opening it can chain-load the full history into memory.

The auto-fetch is now gated on the item key sequence actually changing, via a new pure helper (`haveSameItemKeys`) in `transcript-scroll-utils.ts`, following the file's own architecture (load-bearing decisions live in pure, tested helpers; the hook stays thin wiring).

## Why this is safe

- Transcript items already are a filtered projection of the loaded transcript (confirmation visibility drops rows today), so the hazard predates any in-flight feature work; this hardens the shared machinery for the whole class. Extracted from #41516, where review surfaced it, because it applies to everyone independent of that PR's feature flag.
- Key equality is the right grain: any page that adds or removes a visible row changes the key sequence and still auto-fetches; in-place updates to an existing row (streaming text) keep their key and no longer count as progress, which was never a legitimate fetch trigger.
- History past a filtered stretch stays reachable, one page per gesture: scrollable transcripts keep the scroll-handler load path, and underfilled transcripts (which cannot emit scroll events) page in on history-seeking gestures (wheel-up, up keys, touch drag) via `shouldGestureLoadOlder`, gated by the same in-flight lock.
- Cold-load behavior is unchanged: the first items-effect run always sees a changed item set (the conversation-switch reset clears the previous list), so the initial underfill chain-fill still runs.

## What changes for users

| Before | After |
| --- | --- |
| A conversation whose older pages are entirely filtered from the transcript silently fetches every remaining history page in a loop | The transcript fetches one no-progress page, then waits for a real change or a user scroll gesture |
| All other pagination behavior | Unchanged |

## Coverage

`haveSameItemKeys` unit tests added to `use-transcript-scroll.test.ts` (equal sets, in-place same-key updates, prepend, removal, replaced key). Authored but not run locally; exact-head CI is the validation authority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41524" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
