### PR TITLE
feat(web): tag SSE rescues with their trigger channel and turn age (LUM-3470)

### DIFF
--- a/clients/web/src/domains/chat/active-chat-view.tsx
+++ b/clients/web/src/domains/chat/active-chat-view.tsx
@@ -1,4 +1,3 @@
-
 import { useTranslation } from "@/i18n";
 /**
  * ActiveChatView — chat orchestration, mounted only when the assistant is usable.
@@ -427,7 +426,7 @@ export function ActiveChatView() {
     transcriptItemsRef,
     transcriptRef,
     uiContextRef,
-    reconcileActiveConversation,
+    reconcileActiveConversation: () => reconcileActiveConversation("debug"),
   });
 
   // Deep-link: ?message=<id> scrolls to and highlights that message (e.g. the

--- a/clients/web/src/domains/chat/hooks/use-event-stream-resume-reconcile.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-event-stream-resume-reconcile.test.tsx
@@ -7,6 +7,7 @@ import { resetReconnectCursor } from "@/lib/streaming/reconnect-cursor";
 import { __resetLocalSeqForTesting } from "@/lib/streaming/local-seq";
 
 import { useEventStream } from "@/domains/chat/hooks/use-event-stream";
+import type { ReconcileTrigger } from "@/domains/chat/hooks/use-message-reconciliation";
 
 function renderEventStream(params: {
   activeConversationId: string;
@@ -101,11 +102,13 @@ describe("useEventStream — sse.opened reconcile triggers", () => {
      * consumer's seq-gap detector, which only fires on a proven gap.
      */
     // GIVEN a mounted stream that records the reconcile's authoritative arg
-    const reconcile = mock(async (_authoritative?: boolean) => ({
-      changed: false,
-      messagesAdded: 0,
-      assistantProgress: false,
-    }));
+    const reconcile = mock(
+      async (_trigger: ReconcileTrigger, _authoritative?: boolean) => ({
+        changed: false,
+        messagesAdded: 0,
+        assistantProgress: false,
+      }),
+    );
     renderEventStream({
       activeConversationId: "conv-A",
       reconcileActiveConversation: reconcile as never,
@@ -119,7 +122,8 @@ describe("useEventStream — sse.opened reconcile triggers", () => {
 
     // THEN the reopen reconcile is invoked without the authoritative flag
     expect(reconcile).toHaveBeenCalledTimes(1);
-    expect(reconcile.mock.calls[0]?.[0]).toBeFalsy();
+    expect(reconcile.mock.calls[0]?.[0]).toBe("reopen");
+    expect(reconcile.mock.calls[0]?.[1]).toBeFalsy();
   });
 
   test("a proven seq gap on the live stream heals authoritatively", async () => {
@@ -132,11 +136,13 @@ describe("useEventStream — sse.opened reconcile triggers", () => {
      * beginning, so this reconcile must run with the authoritative flag.
      */
     // GIVEN a mounted stream that records the reconcile's authoritative arg
-    const reconcile = mock(async (_authoritative?: boolean) => ({
-      changed: true,
-      messagesAdded: 1,
-      assistantProgress: true,
-    }));
+    const reconcile = mock(
+      async (_trigger: ReconcileTrigger, _authoritative?: boolean) => ({
+        changed: true,
+        messagesAdded: 1,
+        assistantProgress: true,
+      }),
+    );
     renderEventStream({
       activeConversationId: "conv-A",
       reconcileActiveConversation: reconcile as never,
@@ -170,7 +176,8 @@ describe("useEventStream — sse.opened reconcile triggers", () => {
 
     // THEN the gap heal reconcile runs with the authoritative flag set
     expect(reconcile).toHaveBeenCalledTimes(1);
-    expect(reconcile.mock.calls[0]?.[0]).toBe(true);
+    expect(reconcile.mock.calls[0]?.[0]).toBe("seq_gap");
+    expect(reconcile.mock.calls[0]?.[1]).toBe(true);
   });
 
   test("reconciles when the bus reopens after a reachability-driven retry", async () => {

--- a/clients/web/src/domains/chat/hooks/use-event-stream.ts
+++ b/clients/web/src/domains/chat/hooks/use-event-stream.ts
@@ -38,7 +38,10 @@ import { isSending, useTurnStore } from "@/domains/chat/turn-store";
 import { useBusSubscription } from "@/hooks/use-bus-subscription";
 import { recordLifecycleDiagnostic } from "@/lib/diagnostics";
 import type { EventStream } from "@/lib/streaming/stream-transport";
-import type { ReconcileActiveConversationResult } from "@/domains/chat/hooks/use-message-reconciliation";
+import type {
+  ReconcileActiveConversationResult,
+  ReconcileTrigger,
+} from "@/domains/chat/hooks/use-message-reconciliation";
 import type { AssistantEvent } from "@/types/event-types";
 import type { UseAssistantReachabilityResult } from "@/assistant/use-assistant-reachability";
 
@@ -56,6 +59,7 @@ export interface UseEventStreamParams {
   // Callbacks from useStreamEventHandler / useMessageReconciliation
   handleStreamEvent: (event: AssistantEvent, epoch: number) => void;
   reconcileActiveConversation: (
+    trigger: ReconcileTrigger,
     authoritative?: boolean,
   ) => Promise<ReconcileActiveConversationResult>;
   startReconciliationLoop: (epoch: number) => void;
@@ -227,7 +231,8 @@ export function useEventStream({
       // Seq-gap reconcile: a proven out-of-ring gap means the live suffix
       // is non-contiguous, so re-bootstrap authoritatively from the server
       // snapshot rather than keeping the holey local rows.
-      reconcileActive: () => reconcileActiveConversationRef.current(true),
+      reconcileActive: () =>
+        reconcileActiveConversationRef.current("seq_gap", true),
     });
   }, [
     assistantStateKind,
@@ -259,7 +264,7 @@ export function useEventStream({
       // keep-local rule protect the freshly streamed tail the debounced
       // `/messages` snapshot has not persisted yet. A genuine out-of-ring
       // gap is healed authoritatively by the consumer's seq-gap detector.
-      reconcileActive: () => reconcileActiveConversationRef.current(),
+      reconcileActive: () => reconcileActiveConversationRef.current("reopen"),
       startReconciliationLoop: (epoch) =>
         startReconciliationLoopRef.current(epoch),
     });

--- a/clients/web/src/domains/chat/hooks/use-message-lifecycle.ts
+++ b/clients/web/src/domains/chat/hooks/use-message-lifecycle.ts
@@ -21,7 +21,10 @@ import { getClientId } from "@/lib/telemetry/client-identity";
 import { parseConversationSyncTag } from "@/lib/sync/types";
 import { useConversationStore } from "@/stores/conversation-store";
 import type { UseAssistantReachabilityResult } from "@/assistant/use-assistant-reachability";
-import type { ReconcileActiveConversationResult } from "@/domains/chat/hooks/use-message-reconciliation";
+import type {
+  ReconcileActiveConversationResult,
+  ReconcileTrigger,
+} from "@/domains/chat/hooks/use-message-reconciliation";
 
 // ---------------------------------------------------------------------------
 // Params
@@ -44,7 +47,10 @@ export interface UseMessageLifecycleParams {
 export interface UseMessageLifecycleReturn {
   startReconciliationLoop: (epoch: number) => void;
   cancelReconciliation: () => void;
-  reconcileActiveConversation: () => Promise<ReconcileActiveConversationResult>;
+  reconcileActiveConversation: (
+    trigger: ReconcileTrigger,
+    authoritative?: boolean,
+  ) => Promise<ReconcileActiveConversationResult>;
 }
 
 // ---------------------------------------------------------------------------
@@ -135,7 +141,7 @@ export function useMessageLifecycle({
         parsed.resource === "messages" &&
         parsed.conversationId === currentActiveId
       ) {
-        void reconcileActiveConversation();
+        void reconcileActiveConversation("sync_tag");
         return;
       }
     }

--- a/clients/web/src/domains/chat/hooks/use-message-reconciliation.test.tsx
+++ b/clients/web/src/domains/chat/hooks/use-message-reconciliation.test.tsx
@@ -136,7 +136,7 @@ describe("useMessageReconciliation — server processing flag drives reseed", ()
     seedServerFetch(false);
     const { result, invalidateSpy } = renderReconciliation();
 
-    const outcome = await result.current.reconcileActiveConversation();
+    const outcome = await result.current.reconcileActiveConversation("reopen");
 
     expect(outcome.changed).toBe(false);
     // No content diff, but the server's `processing: false` must still trigger
@@ -149,7 +149,7 @@ describe("useMessageReconciliation — server processing flag drives reseed", ()
     seedServerFetch(true);
     const { result, invalidateSpy } = renderReconciliation();
 
-    await result.current.reconcileActiveConversation();
+    await result.current.reconcileActiveConversation("reopen");
 
     expect(invalidateSpy).not.toHaveBeenCalled();
   });
@@ -164,7 +164,7 @@ describe("useMessageReconciliation — server processing flag drives reseed", ()
     seedServerFetch(false);
     const { result, invalidateSpy } = renderReconciliation();
 
-    const outcome = await result.current.reconcileActiveConversation();
+    const outcome = await result.current.reconcileActiveConversation("reopen");
 
     expect(outcome.changed).toBe(false);
     expect(invalidateSpy).toHaveBeenCalledTimes(1);
@@ -176,7 +176,7 @@ describe("useMessageReconciliation — server processing flag drives reseed", ()
     seedServerFetch(false);
     const { result, invalidateSpy } = renderReconciliation();
 
-    await result.current.reconcileActiveConversation();
+    await result.current.reconcileActiveConversation("reopen");
 
     expect(invalidateSpy).not.toHaveBeenCalled();
   });
@@ -186,7 +186,7 @@ describe("useMessageReconciliation — server processing flag drives reseed", ()
     seedServerFetch(undefined);
     const { result, invalidateSpy } = renderReconciliation();
 
-    await result.current.reconcileActiveConversation();
+    await result.current.reconcileActiveConversation("reopen");
 
     expect(invalidateSpy).not.toHaveBeenCalled();
   });
@@ -203,7 +203,7 @@ describe("useMessageReconciliation — server event-tail catch-up", () => {
     });
 
     // WHEN the active conversation reconciles
-    await result.current.reconcileActiveConversation();
+    await result.current.reconcileActiveConversation("reopen");
 
     // THEN the tail was fetched from the snapshot's anchor ...
     const ingest = reconcileTrace.find((t) => t.step === "ingest-tail");

--- a/clients/web/src/domains/chat/hooks/use-message-reconciliation.ts
+++ b/clients/web/src/domains/chat/hooks/use-message-reconciliation.ts
@@ -8,8 +8,10 @@ import { useChatSessionStore } from "@/domains/chat/chat-session-store";
 import { useStreamStore } from "@/domains/chat/stream-store";
 import {
   bucketMessagesAdded,
+  bucketTurnAge,
   recordDiagnostic,
   resolvePlatformTag,
+  turnStartMsFromId,
 } from "@/lib/diagnostics";
 import { summarizeRuntimeMessages } from "@/domains/chat/utils/diagnostics";
 import type { DisplayMessage } from "@/domains/chat/types/types";
@@ -42,6 +44,26 @@ interface UseMessageReconciliationArgs {
   latestPageOldestTimestamp: number | null;
 }
 
+/**
+ * Which recovery channel asked for the reconcile. Carried onto the
+ * `sse_poll_reconciled_rescue` Sentry event so the fleet-wide signal says
+ * WHICH channel is doing the rescuing, not just that a rescue happened:
+ *
+ * - `"seq_gap"`: the SSE consumer proved an out-of-ring seq gap.
+ * - `"reopen"`: the stream reopened (visibility resume, reconnect) and the
+ *   post-reopen reconcile ran.
+ * - `"sync_tag"`: another client's `sync_changed` named this conversation's
+ *   messages.
+ * - `"poll"`: the below-events-tail-floor 5s polling loop.
+ * - `"debug"`: the debug API's manual reconcile.
+ */
+export type ReconcileTrigger =
+  | "seq_gap"
+  | "reopen"
+  | "sync_tag"
+  | "poll"
+  | "debug";
+
 /** Result of reconciling the active conversation against the server. */
 export interface ReconcileActiveConversationResult {
   /** The server snapshot carries content the local view does not yet show. */
@@ -68,6 +90,7 @@ interface UseMessageReconciliationReturn {
    *  regardless of whether the snapshot looks changed — set by reconnect
    *  reconciles, where the live suffix may be non-contiguous. */
   reconcileActiveConversation: (
+    trigger: ReconcileTrigger,
     authoritative?: boolean,
   ) => Promise<ReconcileActiveConversationResult>;
 }
@@ -254,6 +277,7 @@ export function useMessageReconciliation({
       snapshotConversationId: string,
       serverSeq: number | null,
       serverProcessing: boolean | undefined,
+      trigger: ReconcileTrigger,
       authoritative = false,
       issuedGeneration: number = getSeqGeneration(),
     ): ReconcileActiveConversationResult => {
@@ -318,11 +342,17 @@ export function useMessageReconciliation({
         // support bundles, biasing the sample toward broken-and-
         // noisy cases. See
         // https://docs.sentry.io/platforms/javascript/enriching-events/breadcrumbs/
+        // Turn age at rescue time, from the send stamp the turn id embeds.
+        // An upper bound on how long the user waited: it includes however
+        // long the turn legitimately ran before its terminal event was lost.
+        const turnStartMs = turnStartMsFromId(snapshotTurnId);
+        const turnAgeMs =
+          turnStartMs === null ? null : Date.now() - turnStartMs;
         Sentry.addBreadcrumb({
           category: "sse.terminal",
           level: "warning",
           message: "poll_reconciled_rescue",
-          data: { messagesAdded, turnId: snapshotTurnId },
+          data: { messagesAdded, turnId: snapshotTurnId, trigger },
         });
         Sentry.captureMessage("sse_poll_reconciled_rescue", {
           level: "warning",
@@ -330,8 +360,10 @@ export function useMessageReconciliation({
             context: "sse_terminal",
             platform: resolvePlatformTag(),
             messagesAddedBucket: bucketMessagesAdded(messagesAdded),
+            trigger,
+            turnAgeBucket: bucketTurnAge(turnAgeMs),
           },
-          extra: { messagesAdded, turnId: snapshotTurnId },
+          extra: { messagesAdded, turnId: snapshotTurnId, turnAgeMs },
         });
       }
 
@@ -342,6 +374,7 @@ export function useMessageReconciliation({
 
   const reconcileActiveConversation = useCallback(
     async (
+      trigger: ReconcileTrigger,
       authoritative = false,
     ): Promise<ReconcileActiveConversationResult> => {
       const empty: ReconcileActiveConversationResult = {
@@ -420,6 +453,7 @@ export function useMessageReconciliation({
           ctx.conversationId,
           serverSeq,
           serverProcessing,
+          trigger,
           authoritative,
           issuedGeneration,
         );
@@ -510,6 +544,7 @@ export function useMessageReconciliation({
               ctx.conversationId,
               serverSeq,
               serverProcessing,
+              "poll",
               // Poll-loop reconciles are never authoritative.
               false,
               issuedGeneration,

--- a/clients/web/src/domains/chat/hooks/use-message-reconciliation.ts
+++ b/clients/web/src/domains/chat/hooks/use-message-reconciliation.ts
@@ -11,8 +11,8 @@ import {
   bucketTurnAge,
   recordDiagnostic,
   resolvePlatformTag,
-  turnStartMsFromId,
 } from "@/lib/diagnostics";
+import { turnStartMsFromId } from "@/domains/chat/utils/send-message-utils";
 import { summarizeRuntimeMessages } from "@/domains/chat/utils/diagnostics";
 import type { DisplayMessage } from "@/domains/chat/types/types";
 import { recordLocalSeq } from "@/lib/streaming/local-seq";
@@ -277,10 +277,17 @@ export function useMessageReconciliation({
       snapshotConversationId: string,
       serverSeq: number | null,
       serverProcessing: boolean | undefined,
-      trigger: ReconcileTrigger,
-      authoritative = false,
-      issuedGeneration: number = getSeqGeneration(),
+      opts: {
+        trigger: ReconcileTrigger;
+        authoritative?: boolean;
+        issuedGeneration?: number;
+      },
     ): ReconcileActiveConversationResult => {
+      const {
+        trigger,
+        authoritative = false,
+        issuedGeneration = getSeqGeneration(),
+      } = opts;
       const { changed, assistantProgress, messagesAdded } =
         reconcileFromServerDetailed(
           serverMessages,
@@ -453,9 +460,7 @@ export function useMessageReconciliation({
           ctx.conversationId,
           serverSeq,
           serverProcessing,
-          trigger,
-          authoritative,
-          issuedGeneration,
+          { trigger, authoritative, issuedGeneration },
         );
       } catch (err) {
         // Re-throw so callers that await the result (e.g. the
@@ -544,10 +549,8 @@ export function useMessageReconciliation({
               ctx.conversationId,
               serverSeq,
               serverProcessing,
-              "poll",
               // Poll-loop reconciles are never authoritative.
-              false,
-              issuedGeneration,
+              { trigger: "poll", authoritative: false, issuedGeneration },
             );
 
             if (changed) {

--- a/clients/web/src/domains/chat/utils/send-message-utils.test.ts
+++ b/clients/web/src/domains/chat/utils/send-message-utils.test.ts
@@ -11,6 +11,7 @@ import {
   parsePendingSecretState,
   resolvePostError,
   shouldCleanupSupersededInteractions,
+  turnStartMsFromId,
 } from "@/domains/chat/utils/send-message-utils";
 
 // ---------------------------------------------------------------------------
@@ -392,5 +393,28 @@ describe("newTurnId", () => {
   it("generates unique IDs on successive calls", () => {
     const ids = new Set(Array.from({ length: 50 }, () => newTurnId()));
     expect(ids.size).toBe(50);
+  });
+});
+
+describe("turnStartMsFromId", () => {
+  it("extracts the send stamp newTurnId embeds", () => {
+    expect(turnStartMsFromId("turn-1787774471939-au3bcw")).toBe(1787774471939);
+  });
+
+  it("returns null for null and foreign id shapes", () => {
+    expect(turnStartMsFromId(null)).toBe(null);
+    expect(turnStartMsFromId("")).toBe(null);
+    expect(turnStartMsFromId("some-server-id")).toBe(null);
+    expect(turnStartMsFromId("turn-abc-xyz")).toBe(null);
+    // A short digit run is not an epoch-milliseconds stamp.
+    expect(turnStartMsFromId("turn-123-xyz")).toBe(null);
+  });
+
+  it("round-trips ids newTurnId generates", () => {
+    const before = Date.now();
+    const parsed = turnStartMsFromId(newTurnId());
+    expect(parsed).not.toBe(null);
+    expect(parsed!).toBeGreaterThanOrEqual(before);
+    expect(parsed!).toBeLessThanOrEqual(Date.now());
   });
 });

--- a/clients/web/src/domains/chat/utils/send-message-utils.ts
+++ b/clients/web/src/domains/chat/utils/send-message-utils.ts
@@ -256,3 +256,21 @@ export function parsePendingConfirmationData(
 export function newTurnId(): string {
   return `turn-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 }
+
+/**
+ * The milliseconds {@link newTurnId} embedded in a turn id, or null for any
+ * other shape. The embedded stamp is the send time, so `now - turnStartMs`
+ * bounds how long the turn ran before an observer (e.g. the silent-stall
+ * rescue) looked at it.
+ */
+export function turnStartMsFromId(turnId: string | null): number | null {
+  if (!turnId) {
+    return null;
+  }
+  const match = /^turn-(\d{10,})-/.exec(turnId);
+  if (!match) {
+    return null;
+  }
+  const ms = Number(match[1]);
+  return Number.isFinite(ms) ? ms : null;
+}

--- a/clients/web/src/lib/diagnostics.test.ts
+++ b/clients/web/src/lib/diagnostics.test.ts
@@ -1,10 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import {
-  bucketMessagesAdded,
-  bucketTurnAge,
-  turnStartMsFromId,
-} from "@/lib/diagnostics";
+import { bucketMessagesAdded, bucketTurnAge } from "@/lib/diagnostics";
 
 describe("bucketMessagesAdded", () => {
   // Buckets must stay low-cardinality so the values are aggregable
@@ -46,21 +42,6 @@ describe("bucketMessagesAdded", () => {
     expect(bucketMessagesAdded(Number.NaN)).toBe("0");
     expect(bucketMessagesAdded(Number.POSITIVE_INFINITY)).toBe("0");
     expect(bucketMessagesAdded(Number.NEGATIVE_INFINITY)).toBe("0");
-  });
-});
-
-describe("turnStartMsFromId", () => {
-  test("extracts the send stamp from a client turn id", () => {
-    expect(turnStartMsFromId("turn-1787774471939-au3bcw")).toBe(1787774471939);
-  });
-
-  test("returns null for null and foreign id shapes", () => {
-    expect(turnStartMsFromId(null)).toBe(null);
-    expect(turnStartMsFromId("")).toBe(null);
-    expect(turnStartMsFromId("some-server-id")).toBe(null);
-    expect(turnStartMsFromId("turn-abc-xyz")).toBe(null);
-    // A short digit run is not an epoch-milliseconds stamp.
-    expect(turnStartMsFromId("turn-123-xyz")).toBe(null);
   });
 });
 

--- a/clients/web/src/lib/diagnostics.test.ts
+++ b/clients/web/src/lib/diagnostics.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
-import { bucketMessagesAdded } from "@/lib/diagnostics";
+import {
+  bucketMessagesAdded,
+  bucketTurnAge,
+  turnStartMsFromId,
+} from "@/lib/diagnostics";
 
 describe("bucketMessagesAdded", () => {
   // Buckets must stay low-cardinality so the values are aggregable
@@ -42,5 +46,41 @@ describe("bucketMessagesAdded", () => {
     expect(bucketMessagesAdded(Number.NaN)).toBe("0");
     expect(bucketMessagesAdded(Number.POSITIVE_INFINITY)).toBe("0");
     expect(bucketMessagesAdded(Number.NEGATIVE_INFINITY)).toBe("0");
+  });
+});
+
+describe("turnStartMsFromId", () => {
+  test("extracts the send stamp from a client turn id", () => {
+    expect(turnStartMsFromId("turn-1787774471939-au3bcw")).toBe(1787774471939);
+  });
+
+  test("returns null for null and foreign id shapes", () => {
+    expect(turnStartMsFromId(null)).toBe(null);
+    expect(turnStartMsFromId("")).toBe(null);
+    expect(turnStartMsFromId("some-server-id")).toBe(null);
+    expect(turnStartMsFromId("turn-abc-xyz")).toBe(null);
+    // A short digit run is not an epoch-milliseconds stamp.
+    expect(turnStartMsFromId("turn-123-xyz")).toBe(null);
+  });
+});
+
+describe("bucketTurnAge", () => {
+  test("buckets ages into the tag bands", () => {
+    expect(bucketTurnAge(0)).toBe("<2s");
+    expect(bucketTurnAge(1_999)).toBe("<2s");
+    expect(bucketTurnAge(2_000)).toBe("2-5s");
+    expect(bucketTurnAge(4_999)).toBe("2-5s");
+    expect(bucketTurnAge(5_000)).toBe("5-15s");
+    expect(bucketTurnAge(14_999)).toBe("5-15s");
+    expect(bucketTurnAge(15_000)).toBe("15-60s");
+    expect(bucketTurnAge(59_999)).toBe("15-60s");
+    expect(bucketTurnAge(60_000)).toBe("60s+");
+  });
+
+  test("collapses unusable inputs to unknown rather than throwing", () => {
+    expect(bucketTurnAge(null)).toBe("unknown");
+    expect(bucketTurnAge(-1)).toBe("unknown");
+    expect(bucketTurnAge(Number.NaN)).toBe("unknown");
+    expect(bucketTurnAge(Number.POSITIVE_INFINITY)).toBe("unknown");
   });
 });

--- a/clients/web/src/lib/diagnostics.ts
+++ b/clients/web/src/lib/diagnostics.ts
@@ -240,24 +240,6 @@ export function bucketMessagesAdded(count: number): string {
   return "6+";
 }
 
-/**
- * The milliseconds embedded in a client turn id (`turn-<ms>-<suffix>`), or
- * null for any other shape. The embedded stamp is the send time, so
- * `now - turnStartMs` bounds how long the turn ran before an observer
- * (e.g. the silent-stall rescue) looked at it.
- */
-export function turnStartMsFromId(turnId: string | null): number | null {
-  if (!turnId) {
-    return null;
-  }
-  const match = /^turn-(\d{10,})-/.exec(turnId);
-  if (!match) {
-    return null;
-  }
-  const ms = Number(match[1]);
-  return Number.isFinite(ms) ? ms : null;
-}
-
 /** Bucket a turn's age at rescue time into a low-cardinality tag band. */
 export function bucketTurnAge(ageMs: number | null): string {
   if (ageMs === null || !Number.isFinite(ageMs) || ageMs < 0) {

--- a/clients/web/src/lib/diagnostics.ts
+++ b/clients/web/src/lib/diagnostics.ts
@@ -240,6 +240,44 @@ export function bucketMessagesAdded(count: number): string {
   return "6+";
 }
 
+/**
+ * The milliseconds embedded in a client turn id (`turn-<ms>-<suffix>`), or
+ * null for any other shape. The embedded stamp is the send time, so
+ * `now - turnStartMs` bounds how long the turn ran before an observer
+ * (e.g. the silent-stall rescue) looked at it.
+ */
+export function turnStartMsFromId(turnId: string | null): number | null {
+  if (!turnId) {
+    return null;
+  }
+  const match = /^turn-(\d{10,})-/.exec(turnId);
+  if (!match) {
+    return null;
+  }
+  const ms = Number(match[1]);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+/** Bucket a turn's age at rescue time into a low-cardinality tag band. */
+export function bucketTurnAge(ageMs: number | null): string {
+  if (ageMs === null || !Number.isFinite(ageMs) || ageMs < 0) {
+    return "unknown";
+  }
+  if (ageMs < 2_000) {
+    return "<2s";
+  }
+  if (ageMs < 5_000) {
+    return "2-5s";
+  }
+  if (ageMs < 15_000) {
+    return "5-15s";
+  }
+  if (ageMs < 60_000) {
+    return "15-60s";
+  }
+  return "60s+";
+}
+
 /** Count messages per role. */
 export function roleCounts(
   messages: Array<{ role: string }>,


### PR DESCRIPTION
Part of LUM-3470.

## TL;DR

The `sse_poll_reconciled_rescue` signal (11k events, ~80/day on web alone) cannot answer the question LUM-3470 asks, because it aggregates every rescue channel behind one name and records nothing about how long the user was stuck. This PR makes the signal answer it: every rescue now carries a `trigger` tag (`reopen` / `seq_gap` / `sync_tag` / `poll` / `debug`) and a `turnAgeBucket` tag, so next week's data discriminates the candidate loss modes.

## Investigation findings that motivated this

- Normalized against turn volume (BigQuery `telemetry.turn_raw`: ~14.8k turns/day in June vs ~18.6k/day in August), the rescue rate went ~0.51% to ~0.42% of turns; the June seq-gap rollout (#32948) helped modestly at best. Fleet-wide (web + macos + ios projects) rescues run ~136/day, ~0.7% of turns.
- 85% of rescues in the last 14 days recovered real messages (`messagesAddedBucket >= 1`), up from ~50% in June.
- On daemons at the events-tail floor there is **no 5s poll loop at all** — the signal's name is vestigial, and rescues come from whichever event-triggered reconcile noticed the stuck turn.
- Two sampled events' breadcrumb trails both show the same shape: visibility resume, SSE reopen, send, rescue 1-4 seconds after the POST, with the seq cursor advancing only via `events/tail` pulls. That points at the **reopen-after-visibility window not delivering the turn's events**, not at random mid-turn drops. Seq-gap detection is structurally blind to a dropped final event (no successor reveals the gap), which fits.
- Two breadcrumb trails are not a distribution, hence this instrumentation rather than a premature transport fix.

## Design

- `ReconcileTrigger` is a **required** parameter of `reconcileActiveConversation`, threaded from each entry point (SSE consumer seq-gap path, reconcile-on-reopen, sync-tag bus handler, legacy poll loop, debug API), so a future caller cannot silently report untagged.
- Turn age is parsed from the send stamp the client turn id already embeds (`turn-<ms>-<suffix>`) — zero new state; bucketed low-cardinality for tags with the raw ms in `extra`. Documented as an upper bound on the user's wait, since it includes the turn's legitimate run time.
- The Sentry event name is deliberately unchanged so the existing issue's history and alert rule stay continuous.

## Why this is safe

- Telemetry-only: no reconcile behavior, ordering, or authority changes; the trigger parameter is passed through and read exactly once, at the capture site.
- Type-checked exhaustively: every call site was forced to declare its channel by the compiler.
- New pure helpers (`turnStartMsFromId`, `bucketTurnAge`) are unit-tested including the never-throw degradation paths.

## What changes for the user

| | Before | After |
|---|---|---|
| App behavior | Unchanged | Unchanged |
| LUM-3470 diagnosability | Rescue events indistinguishable by channel; stuck duration unknown | Each rescue says which channel fired and how old the turn was |

## Next step (tracked on LUM-3470)

After ~a week of tagged data: if `trigger:reopen` with young turns dominates, the fix belongs in the reopen path (daemon replay from `lastSeenSeq` / subscription-establishment handshake, adjacent to LUM-3050); if `seq_gap`/`sync_tag` on old turns dominates, the loss is in live fan-out and the daemon side owns it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41525" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->