### PR TITLE
fix(web): filter the iOS in-app-browser injected navigation bridge error (LUM-3472)

### DIFF
--- a/clients/web/src/lib/sentry/sentry-init.test.ts
+++ b/clients/web/src/lib/sentry/sentry-init.test.ts
@@ -209,18 +209,18 @@ describe("initSentry commit-pressure enrichment", () => {
   });
 });
 
-describe("initSentry cancellation ignoreErrors", () => {
-  // Sentry's inbound filter tests each pattern against the exception value
-  // and against `${type}: ${value}`, so both forms are checked here.
-  // Reference: https://docs.sentry.io/platforms/javascript/configuration/filtering/#using-ignore-errors
-  const matchesIgnoreErrors = (type: string, value: string): boolean => {
-    initSentry();
-    const patterns = (syncedOptions?.ignoreErrors ?? []).filter(
-      (p): p is RegExp => p instanceof RegExp,
-    );
-    return patterns.some((p) => p.test(value) || p.test(`${type}: ${value}`));
-  };
+// Sentry's inbound filter tests each pattern against the exception value
+// and against `${type}: ${value}`, so both forms are checked here.
+// Reference: https://docs.sentry.io/platforms/javascript/configuration/filtering/#using-ignore-errors
+const matchesIgnoreErrors = (type: string, value: string): boolean => {
+  initSentry();
+  const patterns = (syncedOptions?.ignoreErrors ?? []).filter(
+    (p): p is RegExp => p instanceof RegExp,
+  );
+  return patterns.some((p) => p.test(value) || p.test(`${type}: ${value}`));
+};
 
+describe("initSentry cancellation ignoreErrors", () => {
   test("filters cancellation rejections in every engine wording", () => {
     expect(
       matchesIgnoreErrors("AbortError", "signal is aborted without reason"),
@@ -261,5 +261,25 @@ describe("initSentry cancellation ignoreErrors", () => {
       matchesIgnoreErrors("ApiError", "signal is aborted without reason"),
     ).toBe(false);
     expect(matchesIgnoreErrors("ApiError", "CancelledError")).toBe(false);
+  });
+});
+
+describe("initSentry injected-script ignoreErrors", () => {
+  test("filters the iOS in-app-browser navigation bridge error", () => {
+    expect(
+      matchesIgnoreErrors(
+        "TypeError",
+        "undefined is not an object (evaluating 'window.webkit.messageHandlers.navigationPerformanceLoggerWithReply.postMessage')",
+      ),
+    ).toBe(true);
+  });
+
+  test("keeps first-party webkit bridge errors reportable", () => {
+    expect(
+      matchesIgnoreErrors(
+        "TypeError",
+        "undefined is not an object (evaluating 'window.webkit.messageHandlers.bridge.postMessage')",
+      ),
+    ).toBe(false);
   });
 });

--- a/clients/web/src/lib/sentry/sentry-init.ts
+++ b/clients/web/src/lib/sentry/sentry-init.ts
@@ -178,6 +178,15 @@ const options: BrowserOptions = {
     // operation was aborted.") stays reportable.
     /^AbortError:/, // any AbortError-typed DOMException, all engines
     /^Error: CancelledError$/, // TanStack Query's cancellation sentinel
+    // iOS in-app browsers (the Google and Facebook apps) inject script
+    // that bridges page navigation to their native shells through
+    // `window.webkit.messageHandlers.navigationPerformanceLoggerWithReply`.
+    // The bridge races the handler's registration, and the injected
+    // `setupIosCallbackHandler` then throws dereferencing it. Neither name
+    // exists anywhere in this repo, so the handler name is a precise
+    // injected-script signature rather than a message pattern our own
+    // errors could ever match (WEB-8Z).
+    /navigationPerformanceLoggerWithReply/,
   ],
   denyUrls: [
     // Browser-extension schemes.


### PR DESCRIPTION
Fixes LUM-3472.

## TL;DR

Filters the one provably third-party iOS in-app-browser error from Sentry: the Google/Facebook apps inject `setupIosCallbackHandler`, which races its own `window.webkit.messageHandlers.navigationPerformanceLoggerWithReply` registration and throws ([WEB-8Z](https://vellum.sentry.io/issues/7692787844)), firing the high-priority alert into #sentry-assistant-clients. Neither name exists anywhere in this repo, so the handler name is a precise injected-script signature, not a message pattern our own errors could match.

## Scope deliberately narrowed during verification

The ticket originally also covered [WEB-90](https://vellum.sentry.io/issues/VELLUM-ASSISTANT-WEB-90) (`RangeError: Maximum call stack size exceeded`, Google app on iOS). Verification killed that half: all five events are **one user, one session, one 3-minute burst**, and the crashing frames sit at columns far past our short source lines — inside a long minified inline-script line of the served page — so it could be our own Vite-minified `index.html` bootstrap interacting with the in-app browser's DOM wrappers rather than injected code. One user earns no filter, and blanket-filtering `RangeError` would hide real recursion bugs. It stays unfiltered and watched.

## Why this is safe

- One anchored substring pattern on a name that greps to zero hits in this repo; a first-party webkit bridge error (any other handler name) stays reportable, pinned by a new test.
- Depends on the `ignoreErrors` layout #41519 landed; the shared `matchesIgnoreErrors` test helper is hoisted to file scope rather than duplicated per describe.

## What changes for the user

| | Before | After |
|---|---|---|
| App behavior | Unchanged | Unchanged |
| #sentry-assistant-clients | High-priority alerts for Google/Facebook in-app browser injected-script throws | Those events never reach Sentry |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41535" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->