### PR TITLE
fix(assistant): rebuild stale parents after in-flight subagents finish

### DIFF
--- a/assistant/src/__tests__/conversation-evictor.test.ts
+++ b/assistant/src/__tests__/conversation-evictor.test.ts
@@ -9,6 +9,13 @@ mock.module("../subagent/index.js", () => ({
   getSubagentManager: () => ({
     abortAllForParent: (id: string) => abortedParents.push(id),
     getChildrenOf: () => protectedChildren,
+    hasActiveChildren: () =>
+      protectedChildren.some(
+        (c) =>
+          c.status === "running" ||
+          c.status === "pending" ||
+          c.status === "awaiting_input",
+      ),
   }),
 }));
 
@@ -227,6 +234,18 @@ describe("ConversationEvictor", () => {
   describe("shouldProtect", () => {
     test("skips conversations with running or pending subagents", () => {
       protectedChildren = [{ status: "running" }];
+      const s1 = createMockSession();
+      sessions.set("a", s1);
+
+      const result = evictor.sweep();
+
+      expect(result.skipped).toBe(1);
+      expect(sessions.has("a")).toBe(true);
+      expect(s1.disposed).toBe(false);
+    });
+
+    test("skips conversations with awaiting_input subagents", () => {
+      protectedChildren = [{ status: "awaiting_input" }];
       const s1 = createMockSession();
       sessions.set("a", s1);
 

--- a/assistant/src/__tests__/evict-conversations-for-reload.test.ts
+++ b/assistant/src/__tests__/evict-conversations-for-reload.test.ts
@@ -5,13 +5,23 @@
  * same "not idle while a queue is pending" rule the periodic evictor applies
  * has to hold here: `isProcessing()` reads false in the window between a turn
  * releasing and its queued successor being dispatched.
+ *
+ * In-flight subagents are the other non-idle case: an async spawn leaves the
+ * parent idle between its own tool calls while children are still running, and
+ * reload must not abort those children.
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
+const abortedParents: string[] = [];
+const activeParents = new Set<string>();
+
 mock.module("../subagent/index.js", () => ({
   getSubagentManager: () => ({
-    abortAllForParent: () => {},
+    abortAllForParent: (id: string) => {
+      abortedParents.push(id);
+    },
     getChildrenOf: () => [],
+    hasActiveChildren: (id: string) => activeParents.has(id),
   }),
 }));
 
@@ -53,6 +63,8 @@ function register(
 describe("evictConversationsForReload", () => {
   beforeEach(() => {
     clearConversations();
+    abortedParents.length = 0;
+    activeParents.clear();
   });
 
   test("disposes an idle conversation", () => {
@@ -62,6 +74,7 @@ describe("evictConversationsForReload", () => {
 
     expect(idle.disposed).toBe(true);
     expect(findConversation("reload-idle")).toBeUndefined();
+    expect(abortedParents).toEqual(["reload-idle"]);
   });
 
   test("keeps a conversation with queued messages and marks it stale", () => {
@@ -76,6 +89,7 @@ describe("evictConversationsForReload", () => {
     expect(queued.disposed).toBe(false);
     expect(queued.markedStale).toBe(true);
     expect(findConversation("reload-queued")).toBeDefined();
+    expect(abortedParents).toEqual([]);
   });
 
   test("marks a mid-turn conversation stale instead of disposing it", () => {
@@ -86,5 +100,41 @@ describe("evictConversationsForReload", () => {
     expect(busy.disposed).toBe(false);
     expect(busy.markedStale).toBe(true);
     expect([...conversationIds()]).toEqual(["reload-busy"]);
+    expect(abortedParents).toEqual([]);
+  });
+
+  test("skips an idle parent with in-flight subagents", () => {
+    const parent = register("reload-with-children", {
+      processing: false,
+      queued: false,
+    });
+    activeParents.add("reload-with-children");
+
+    evictConversationsForReload();
+
+    expect(parent.disposed).toBe(false);
+    expect(parent.markedStale).toBe(false);
+    expect(findConversation("reload-with-children")).toBeDefined();
+    expect(abortedParents).toEqual([]);
+  });
+
+  test("still evicts other idle conversations when one parent is protected", () => {
+    const protectedParent = register("reload-protected", {
+      processing: false,
+      queued: false,
+    });
+    const idle = register("reload-unprotected", {
+      processing: false,
+      queued: false,
+    });
+    activeParents.add("reload-protected");
+
+    evictConversationsForReload();
+
+    expect(protectedParent.disposed).toBe(false);
+    expect(findConversation("reload-protected")).toBeDefined();
+    expect(idle.disposed).toBe(true);
+    expect(findConversation("reload-unprotected")).toBeUndefined();
+    expect(abortedParents).toEqual(["reload-unprotected"]);
   });
 });

--- a/assistant/src/__tests__/evict-conversations-for-reload.test.ts
+++ b/assistant/src/__tests__/evict-conversations-for-reload.test.ts
@@ -7,8 +7,9 @@
  * releasing and its queued successor being dispatched.
  *
  * In-flight subagents are the other non-idle case: an async spawn leaves the
- * parent idle between its own tool calls while children are still running, and
- * reload must not abort those children.
+ * parent idle between its own tool calls while children are still running.
+ * Reload marks that parent stale without aborting the children, then
+ * `getOrCreateConversation` rebuilds it once every child is terminal.
  */
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
@@ -32,7 +33,10 @@ import {
   findConversation,
   setConversation,
 } from "../daemon/conversation-registry.js";
-import { evictConversationsForReload } from "../daemon/conversation-store.js";
+import {
+  evictConversationsForReload,
+  getOrCreateConversation,
+} from "../daemon/conversation-store.js";
 
 interface FakeConversation {
   disposed: boolean;
@@ -41,7 +45,7 @@ interface FakeConversation {
 
 function register(
   id: string,
-  state: { processing: boolean; queued: boolean },
+  state: { processing: boolean; queued: boolean; stale?: boolean },
 ): FakeConversation {
   const fake: FakeConversation & Record<string, unknown> = {
     disposed: false,
@@ -49,6 +53,7 @@ function register(
     conversationId: id,
     isProcessing: () => state.processing,
     hasQueuedMessages: () => state.queued,
+    isStale: () => state.stale === true || fake.markedStale,
     dispose() {
       fake.disposed = true;
     },
@@ -103,7 +108,7 @@ describe("evictConversationsForReload", () => {
     expect(abortedParents).toEqual([]);
   });
 
-  test("skips an idle parent with in-flight subagents", () => {
+  test("marks an idle parent with in-flight subagents stale", () => {
     const parent = register("reload-with-children", {
       processing: false,
       queued: false,
@@ -113,7 +118,7 @@ describe("evictConversationsForReload", () => {
     evictConversationsForReload();
 
     expect(parent.disposed).toBe(false);
-    expect(parent.markedStale).toBe(false);
+    expect(parent.markedStale).toBe(true);
     expect(findConversation("reload-with-children")).toBeDefined();
     expect(abortedParents).toEqual([]);
   });
@@ -132,9 +137,42 @@ describe("evictConversationsForReload", () => {
     evictConversationsForReload();
 
     expect(protectedParent.disposed).toBe(false);
+    expect(protectedParent.markedStale).toBe(true);
     expect(findConversation("reload-protected")).toBeDefined();
     expect(idle.disposed).toBe(true);
     expect(findConversation("reload-unprotected")).toBeUndefined();
     expect(abortedParents).toEqual(["reload-unprotected"]);
+  });
+
+  test("defers stale rebuild while subagents are in flight", async () => {
+    const parent = register("stale-parent", {
+      processing: false,
+      queued: false,
+      stale: true,
+    });
+    activeParents.add("stale-parent");
+
+    const result = await getOrCreateConversation("stale-parent");
+
+    expect(result).toBe(parent);
+    expect(parent.disposed).toBe(false);
+    expect(abortedParents).toEqual([]);
+  });
+
+  test("rebuilds a stale parent once every child is terminal", async () => {
+    const parent = register("stale-parent", {
+      processing: false,
+      queued: false,
+      stale: true,
+    });
+
+    try {
+      await getOrCreateConversation("stale-parent");
+    } catch {
+      // Isolated test has no provider wiring; rebuild intent is abort + dispose.
+    }
+
+    expect(parent.disposed).toBe(true);
+    expect(abortedParents).toEqual(["stale-parent"]);
   });
 });

--- a/assistant/src/__tests__/subagent-manager-notify.test.ts
+++ b/assistant/src/__tests__/subagent-manager-notify.test.ts
@@ -533,6 +533,44 @@ describe("SubagentManager notifyParent (via runSubagent)", () => {
   });
 });
 
+describe("SubagentManager hasActiveChildren", () => {
+  test("is true for pending, running, and awaiting_input children", () => {
+    const manager = new SubagentManager();
+    injectFakeSubagent(
+      manager,
+      "sub-running",
+      makeState("sub-running", { status: "running" }),
+    );
+
+    expect(manager.hasActiveChildren("parent-sess-1")).toBe(true);
+
+    asInternals(manager).subagents.get("sub-running")!.state.status =
+      "awaiting_input";
+    expect(manager.hasActiveChildren("parent-sess-1")).toBe(true);
+
+    asInternals(manager).subagents.get("sub-running")!.state.status = "pending";
+    expect(manager.hasActiveChildren("parent-sess-1")).toBe(true);
+  });
+
+  test("is false when every child is terminal or the parent has none", () => {
+    const manager = new SubagentManager();
+    expect(manager.hasActiveChildren("parent-sess-1")).toBe(false);
+
+    injectFakeSubagent(
+      manager,
+      "sub-done",
+      makeState("sub-done", { status: "completed" }),
+    );
+    injectFakeSubagent(
+      manager,
+      "sub-aborted",
+      makeState("sub-aborted", { status: "aborted" }),
+    );
+
+    expect(manager.hasActiveChildren("parent-sess-1")).toBe(false);
+  });
+});
+
 describe("SubagentManager abortAllForParent", () => {
   test("aborts active children but keeps every child's state readable", () => {
     clearCaptured();

--- a/assistant/src/daemon/conversation-evictor.ts
+++ b/assistant/src/daemon/conversation-evictor.ts
@@ -74,11 +74,9 @@ export class ConversationEvictor {
     getSubagentManager().abortAllForParent(conversationId);
   }
 
-  /** Protect conversations with running or pending subagents from eviction. */
+  /** Protect conversations with in-flight subagents from eviction. */
   shouldProtect(conversationId: string): boolean {
-    return getSubagentManager()
-      .getChildrenOf(conversationId)
-      .some((c) => c.status === "running" || c.status === "pending");
+    return getSubagentManager().hasActiveChildren(conversationId);
   }
 
   /** Record an access for the given conversation (resets its idle clock). */

--- a/assistant/src/daemon/conversation-store.ts
+++ b/assistant/src/daemon/conversation-store.ts
@@ -402,7 +402,9 @@ export function clearAllActiveConversations(): number {
  * Evict in-memory conversations after a config/prompt/skills reload so the next
  * turn rebuilds them against the new config. Idle conversations are disposed and
  * dropped; busy ones are marked stale so they're rebuilt once their current turn
- * finishes. Also used when provider credentials change.
+ * finishes. Conversations with in-flight subagents are left in place so a
+ * reload does not abort those children. Also used when provider credentials
+ * change.
  */
 export function evictConversationsForReload(): void {
   const subagentManager = getSubagentManager();
@@ -413,6 +415,11 @@ export function evictConversationsForReload(): void {
     // would silently drop the queued messages, so mark it stale instead and
     // let it rebuild once the queue has run.
     if (!conversation.isProcessing() && !conversation.hasQueuedMessages()) {
+      // Same protection the TTL/LRU evictor applies: an idle parent still
+      // owns mid-task children, and aborting them here would kill that work.
+      if (subagentManager.hasActiveChildren(id)) {
+        continue;
+      }
       subagentManager.abortAllForParent(id);
       conversation.dispose();
       deleteConversation(id);

--- a/assistant/src/daemon/conversation-store.ts
+++ b/assistant/src/daemon/conversation-store.ts
@@ -147,6 +147,24 @@ function applyTransportMetadata(
 }
 
 /**
+ * True when dropping this in-memory instance would lose work that is still
+ * in flight: a live turn, a queued successor, or a child subagent.
+ */
+function hasInFlightWork(
+  conversation: {
+    isProcessing(): boolean;
+    hasQueuedMessages(): boolean;
+  },
+  conversationId: string,
+): boolean {
+  return (
+    conversation.isProcessing() ||
+    conversation.hasQueuedMessages() ||
+    getSubagentManager().hasActiveChildren(conversationId)
+  );
+}
+
+/**
  * Get or create an active conversation by ID.
  *
  * Handles provider setup, rate limiting, system prompt, memory policy,
@@ -184,18 +202,18 @@ export async function getOrCreateConversation(
   // messages live in memory on the instance being disposed, and the queue
   // drains via an async dispatch after the current turn releases, so
   // `isProcessing()` can read false while a queued turn is still pending:
-  // rebuilding in that gap would silently drop those messages. The conversation
-  // stays stale and is rebuilt on a later call.
+  // rebuilding in that gap would silently drop those messages. In-flight
+  // subagents are the same: the parent reads idle between its own tool calls
+  // while children still run, and rebuilding would abort them. The
+  // conversation stays stale and is rebuilt on a later call.
   if (
     !conversation ||
-    (conversation.isStale() &&
-      !conversation.isProcessing() &&
-      !conversation.hasQueuedMessages())
+    (conversation.isStale() && !hasInFlightWork(conversation, conversationId))
   ) {
     if (conversation) {
-      // Stale rebuild: the conversation id lives on, so abort in-flight
-      // children but keep terminal subagent results readable for the
-      // retention window.
+      // Stale rebuild: the conversation id lives on, so abort any children
+      // that raced into flight after the idle check and keep terminal
+      // subagent results readable for the retention window.
       getSubagentManager().abortAllForParent(conversationId);
       conversation.dispose();
     }
@@ -400,32 +418,22 @@ export function clearAllActiveConversations(): number {
 
 /**
  * Evict in-memory conversations after a config/prompt/skills reload so the next
- * turn rebuilds them against the new config. Idle conversations are disposed and
- * dropped; busy ones are marked stale so they're rebuilt once their current turn
- * finishes. Conversations with in-flight subagents are left in place so a
- * reload does not abort those children. Also used when provider credentials
+ * turn rebuilds them against the new config. Conversations with in-flight work
+ * (a live turn, a queued successor, or an active subagent) are marked stale
+ * and rebuilt by `getOrCreateConversation` once that work finishes. Idle
+ * conversations are disposed and dropped. Also used when provider credentials
  * change.
  */
 export function evictConversationsForReload(): void {
   const subagentManager = getSubagentManager();
   for (const [id, conversation] of conversationEntries()) {
-    // A conversation with queued messages is not idle: the queue drains via an
-    // async dispatch after the current turn releases, so `isProcessing()` can
-    // read false while a queued turn is still pending. Disposing in that gap
-    // would silently drop the queued messages, so mark it stale instead and
-    // let it rebuild once the queue has run.
-    if (!conversation.isProcessing() && !conversation.hasQueuedMessages()) {
-      // Same protection the TTL/LRU evictor applies: an idle parent still
-      // owns mid-task children, and aborting them here would kill that work.
-      if (subagentManager.hasActiveChildren(id)) {
-        continue;
-      }
-      subagentManager.abortAllForParent(id);
-      conversation.dispose();
-      deleteConversation(id);
-      removeFromEvictor(id);
-    } else {
+    if (hasInFlightWork(conversation, id)) {
       conversation.markStale();
+      continue;
     }
+    subagentManager.abortAllForParent(id);
+    conversation.dispose();
+    deleteConversation(id);
+    removeFromEvictor(id);
   }
 }

--- a/assistant/src/subagent/manager.ts
+++ b/assistant/src/subagent/manager.ts
@@ -1478,6 +1478,18 @@ export class SubagentManager {
       .filter((s): s is SubagentState => s !== undefined);
   }
 
+  /**
+   * True when this parent still has a child that is not terminal (`pending`,
+   * `running`, or `awaiting_input`). Idle-eviction and config-reload rebuild
+   * skip those parents so an otherwise-idle conversation does not abort
+   * mid-task children.
+   */
+  hasActiveChildren(parentConversationId: string): boolean {
+    return this.getChildrenOf(parentConversationId).some(
+      (child) => !TERMINAL_STATUSES.has(child.status),
+    );
+  }
+
   /** Total number of active (non-terminal) subagents. */
   get activeCount(): number {
     return [...this.subagents.values()].filter(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Prompt / plan

Follow-up to #41523. Codex asked that protected reload parents be scheduled for a later rebuild: skip-without-stale leaves the parent on its construction-time provider, tools, and prompt, so a credential rotation can poison the next parent turn.

## Summary
- Mark conversations with in-flight work (live turn, queued successor, or active subagent) stale on reload instead of leaving them untouched.
- Defer `getOrCreateConversation` stale rebuild until `hasInFlightWork` is false, so children are not aborted.
- Shared `hasInFlightWork` helper keeps the two paths aligned.

This branch includes #41523. Merge #41523 first if you want that change to land on its own, then rebase this PR. Merging this PR first lands both.

## Test plan
- [x] `cd assistant && bun test src/__tests__/evict-conversations-for-reload.test.ts`
- [x] `cd assistant && bun test src/__tests__/conversation-evictor.test.ts`
- [x] `cd assistant && bun test src/__tests__/subagent-manager-notify.test.ts`

49 tests passed locally (148 expect calls).

## Risk
- Low. Idle parents without children still evict immediately.
- A stale parent keeps serving its current instance until the next `getOrCreateConversation` after children finish (user send, wake, etc.). That is when the new config or credentials take effect.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be32a5d6-8bfa-4f51-932e-d5656a0f7c29?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be32a5d6-8bfa-4f51-932e-d5656a0f7c29&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

