### PR TITLE
web: carry avatar_url on ResolvedAssistant and use it for platform chooser rows

### DIFF
--- a/clients/web/src/components/avatar/chooser-avatar-chip.tsx
+++ b/clients/web/src/components/avatar/chooser-avatar-chip.tsx
@@ -25,6 +25,8 @@ export interface ChooserAvatarChipProps {
   className?: string;
   /** Hide from assistive tech when a sibling already names the row. */
   decorative?: boolean;
+  /** Fires when `imageUrl` fails to load. */
+  onImageError?: () => void;
 }
 
 export function ChooserAvatarChip({
@@ -34,6 +36,7 @@ export function ChooserAvatarChip({
   fallback,
   className,
   decorative = false,
+  onImageError,
 }: ChooserAvatarChipProps) {
   const { t } = useTranslation();
   const components = useBundledAvatarComponents();
@@ -72,6 +75,7 @@ export function ChooserAvatarChip({
         height={size}
         className={`rounded-full object-cover ${className ?? ""}`.trim()}
         style={{ width: size, height: size, flexShrink: 0 }}
+        onError={onImageError}
       />
     );
   }

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.test.tsx
@@ -274,8 +274,10 @@ mock.module("@/domains/onboarding/components/add-remote-origin-dialog", () => ({
 
 const forgetAssistantAvatarMock = mock((_qc: unknown, _id: string) => {});
 const useChooserRowAvatarMock: Partial<typeof UseChooserRowAvatarModule> = {
-  useChooserRowAvatar: (assistant) =>
-    rowAvatars.get(assistant.id) ?? { traits: null, imageUrl: null },
+  useChooserRowAvatar: (assistant) => ({
+    onImageError: () => {},
+    ...(rowAvatars.get(assistant.id) ?? { traits: null, imageUrl: null }),
+  }),
   forgetAssistantAvatar: forgetAssistantAvatarMock,
 };
 mock.module("@/hooks/use-chooser-row-avatar", () => useChooserRowAvatarMock);
@@ -295,7 +297,10 @@ const chooserAvatarChipMock: Partial<typeof ChooserAvatarChipModule> = {
       fallback
     ),
 };
-mock.module("@/components/avatar/chooser-avatar-chip", () => chooserAvatarChipMock);
+mock.module(
+  "@/components/avatar/chooser-avatar-chip",
+  () => chooserAvatarChipMock,
+);
 
 mock.module("@/components/onboarding-layout", () => ({
   OnboardingLayout: ({ children }: { children: ReactNode }) => children,
@@ -1693,8 +1698,12 @@ describe("SelectAssistantScreen assistant avatars", () => {
     });
     render(<SelectAssistantScreen />);
     expect(screen.getByRole("radio", { name: /^Office Mac/ })).toBeTruthy();
-    expect(screen.queryByRole("radio", { name: /Assistant avatar/ })).toBeNull();
-    expect(screen.getByTestId("chooser-avatar-chip").getAttribute("alt")).toBe("");
+    expect(
+      screen.queryByRole("radio", { name: /Assistant avatar/ }),
+    ).toBeNull();
+    expect(screen.getByTestId("chooser-avatar-chip").getAttribute("alt")).toBe(
+      "",
+    );
   });
 
   test("a row with no avatar keeps its glyph", () => {

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
@@ -1176,7 +1176,7 @@ function AssistantCard({
 }) {
   const { t } = useTranslation("onboarding");
   const label = assistantLabel(assistant);
-  const { traits, imageUrl } = useChooserRowAvatar(assistant);
+  const { traits, imageUrl, onImageError } = useChooserRowAvatar(assistant);
   const glyph = assistant.isPaired ? (
     <Link2 className="h-5 w-5" />
   ) : assistant.isLocal ? (
@@ -1192,6 +1192,7 @@ function AssistantCard({
           imageUrl={imageUrl}
           fallback={glyph}
           decorative
+          onImageError={onImageError}
         />
       }
       title={label}

--- a/clients/web/src/hooks/use-assistant-resource-sync.test.tsx
+++ b/clients/web/src/hooks/use-assistant-resource-sync.test.tsx
@@ -33,6 +33,7 @@ import { SYNC_TAGS } from "@/lib/sync/types";
 import type { SyncChangedEvent } from "@/lib/sync/types";
 import { __resetForTesting, publish } from "@/lib/event-bus";
 import { getClientId } from "@/lib/telemetry/client-identity";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 
 function createWrapper(queryClient: QueryClient) {
   return function Wrapper({ children }: { children: ReactNode }) {
@@ -294,8 +295,7 @@ describe("useAssistantResourceSync", () => {
   test("invalidates app list queries on apps:list sync tag", async () => {
     const queryClient = freshQueryClient();
     let predicate:
-      | ((query: { queryKey: readonly unknown[] }) => boolean)
-      | undefined;
+      ((query: { queryKey: readonly unknown[] }) => boolean) | undefined;
     queryClient.invalidateQueries = ((arg: unknown) => {
       predicate = (
         arg as {
@@ -727,8 +727,7 @@ describe("useAssistantResourceSync", () => {
   test("invalidates home-feed query on home_feed_updated", async () => {
     const queryClient = freshQueryClient();
     let predicate:
-      | ((query: { queryKey: readonly unknown[] }) => boolean)
-      | undefined;
+      ((query: { queryKey: readonly unknown[] }) => boolean) | undefined;
     queryClient.invalidateQueries = ((arg: unknown) => {
       predicate = (
         arg as {
@@ -852,6 +851,41 @@ describe("useAssistantResourceSync", () => {
         },
       ]);
     });
+  });
+
+  test("avatar change events clear the row's synced avatarUrl; the reconnect sweep does not", async () => {
+    const seed = () =>
+      useResolvedAssistantsStore.setState({
+        assistants: [
+          {
+            id: "asst-1",
+            isLocal: false,
+            isPlatformHosted: true,
+            isPaired: false,
+            avatarUrl: "https://cdn.example/a.png",
+          },
+        ],
+      });
+    const avatarUrl = () =>
+      useResolvedAssistantsStore.getState().assistants[0]?.avatarUrl;
+    const queryClient = freshQueryClient();
+    queryClient.invalidateQueries = mock(() => Promise.resolve()) as never;
+    renderHook(() => useAssistantResourceSync("asst-1", true), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    seed();
+    emit({ type: "avatar_updated" } as unknown as AssistantEvent);
+    await waitFor(() => expect(avatarUrl()).toBeNull());
+
+    seed();
+    emit(syncEvent([SYNC_TAGS.assistantAvatar]) as unknown as AssistantEvent);
+    await waitFor(() => expect(avatarUrl()).toBeNull());
+
+    seed();
+    publish("sse.opened", { assistantId: "asst-1", cause: "error" });
+    await flushReconnectSweep();
+    expect(avatarUrl()).toBe("https://cdn.example/a.png");
   });
 
   test("invalidates avatar query on avatar_updated event", async () => {

--- a/clients/web/src/hooks/use-assistant-resource-sync.ts
+++ b/clients/web/src/hooks/use-assistant-resource-sync.ts
@@ -48,6 +48,7 @@ import { chooserRowAvatarQueryKeyPrefix } from "@/hooks/use-chooser-row-avatar";
 import { useBusSubscription } from "@/hooks/use-bus-subscription";
 import { getClientId } from "@/lib/telemetry/client-identity";
 import { SYNC_TAGS } from "@/lib/sync/types";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 
 /**
  * A reconnect can flap: error, reopen, error, reopen. Collapse a burst into
@@ -111,7 +112,7 @@ export function useAssistantResourceSync(
         for (const tag of event.tags) {
           switch (tag) {
             case SYNC_TAGS.assistantAvatar:
-              invalidateAvatarQueries(queryClient, assistantId);
+              onAvatarChanged(queryClient, assistantId);
               break;
             case SYNC_TAGS.assistantIdentity:
               void queryClient.invalidateQueries({
@@ -215,7 +216,7 @@ export function useAssistantResourceSync(
         return;
 
       case "avatar_updated":
-        invalidateAvatarQueries(queryClient, assistantId);
+        onAvatarChanged(queryClient, assistantId);
         return;
     }
   });
@@ -235,6 +236,17 @@ export function useAssistantResourceSync(
       refreshAssistantResources(queryClient, assistantId);
     }, RECONNECT_SWEEP_DEBOUNCE_MS);
   });
+}
+
+/**
+ * An avatar change on the connected assistant. Beyond the query sweep, drops
+ * the row's synced `avatarUrl`: the platform copy lags the live change, and
+ * while set it keeps the chooser's live/cache paths disabled. The reconnect
+ * sweep does not do this, since nothing is known to have changed there.
+ */
+function onAvatarChanged(queryClient: QueryClient, assistantId: string): void {
+  useResolvedAssistantsStore.getState().clearAvatarUrl(assistantId);
+  invalidateAvatarQueries(queryClient, assistantId);
 }
 
 /** The canonical avatar cache plus every chooser row variant for the same id. */

--- a/clients/web/src/hooks/use-chooser-row-avatar.test.tsx
+++ b/clients/web/src/hooks/use-chooser-row-avatar.test.tsx
@@ -19,7 +19,7 @@ import {
   test,
 } from "bun:test";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 
 import type * as AvatarApi from "@/assistant/avatar-api";
 import type * as AvatarLastSeenCache from "@/lib/avatar-last-seen-cache";
@@ -228,6 +228,7 @@ afterEach(() => {
   setSystemTime();
   revokeObjectURL.mockClear();
   useResolvedAssistantsStore.getState().setActiveAssistantId(null);
+  useResolvedAssistantsStore.setState({ assistants: [] });
   useAssistantIdentityStore.getState().clearIdentity();
   fetchAvatarState.mockReset();
   fetchAvatarImageUrlResult.mockReset();
@@ -291,7 +292,7 @@ describe("useChooserRowAvatar", () => {
         { wrapper: createWrapper() },
       );
       await settle();
-      expect(result.current).toEqual({ traits: null, imageUrl: null });
+      expect(result.current).toMatchObject({ traits: null, imageUrl: null });
       expect(sdkCallCount()).toBe(0);
     },
   );
@@ -307,7 +308,7 @@ describe("useChooserRowAvatar", () => {
         { wrapper: createWrapper() },
       );
       await settle();
-      expect(result.current).toEqual({ traits: null, imageUrl: null });
+      expect(result.current).toMatchObject({ traits: null, imageUrl: null });
       expect(sdkCallCount()).toBe(0);
     },
   );
@@ -346,7 +347,10 @@ describe("useChooserRowAvatar", () => {
         { wrapper: createWrapper() },
       );
       await settle();
-      expect(result.current).toEqual({ traits: null, imageUrl: SYNCED_URL });
+      expect(result.current).toMatchObject({
+        traits: null,
+        imageUrl: SYNCED_URL,
+      });
       expect(sdkCallCount()).toBe(0);
       expect(readLastSeenAvatar).not.toHaveBeenCalled();
     });
@@ -391,7 +395,63 @@ describe("useChooserRowAvatar", () => {
         { wrapper: createWrapper() },
       );
       await settle();
-      expect(result.current).toEqual({ traits: null, imageUrl: null });
+      expect(result.current).toMatchObject({ traits: null, imageUrl: null });
+    });
+
+    test("persisting the connected row's live avatar drops its synced avatarUrl", async () => {
+      const row = platformRow("active", { avatarUrl: SYNCED_URL });
+      useResolvedAssistantsStore.setState({ assistants: [row] });
+      renderHook(() => useChooserRowAvatar(row), { wrapper: createWrapper() });
+      await waitFor(() => {
+        expect(writeLastSeenAvatar).toHaveBeenCalledTimes(1);
+      });
+      await waitFor(() => {
+        expect(
+          useResolvedAssistantsStore.getState().assistants[0]?.avatarUrl,
+        ).toBeNull();
+      });
+    });
+
+    test("a synced image that fails to load falls back to the cached avatar", async () => {
+      readLastSeenAvatar.mockResolvedValue({ kind: "character", traits });
+      const { result } = renderHook(
+        () =>
+          useChooserRowAvatar(platformRow("other", { avatarUrl: SYNCED_URL })),
+        { wrapper: createWrapper() },
+      );
+      await settle();
+      expect(result.current.imageUrl).toBe(SYNCED_URL);
+      expect(readLastSeenAvatar).not.toHaveBeenCalled();
+
+      act(() => result.current.onImageError());
+
+      await waitFor(() => {
+        expect(result.current.traits).toEqual(traits);
+      });
+      expect(result.current.imageUrl).toBeNull();
+      expect(readLastSeenAvatar).toHaveBeenCalledWith("other");
+    });
+
+    test("a fresh avatarUrl after a load failure is tried again", async () => {
+      // No other source applies, so only the synced URL can render.
+      localClient = true;
+      const NEXT_URL = "https://cdn.example/avatars/other-2.png";
+      const { result, rerender } = renderHook(
+        ({ url }: { url: string }) =>
+          useChooserRowAvatar(platformRow("other", { avatarUrl: url })),
+        { wrapper: createWrapper(), initialProps: { url: SYNCED_URL } },
+      );
+      await settle();
+      act(() => result.current.onImageError());
+      await waitFor(() => {
+        expect(result.current.imageUrl).toBeNull();
+      });
+
+      rerender({ url: NEXT_URL });
+
+      await waitFor(() => {
+        expect(result.current.imageUrl).toBe(NEXT_URL);
+      });
     });
 
     test("a null avatarUrl falls through to the proxy fetch", async () => {
@@ -413,7 +473,7 @@ describe("useChooserRowAvatar", () => {
       { wrapper: createWrapper() },
     );
     await settle();
-    expect(result.current).toEqual({ traits: null, imageUrl: null });
+    expect(result.current).toMatchObject({ traits: null, imageUrl: null });
     expect(sdkCallCount()).toBe(0);
 
     orgReady = true;
@@ -534,7 +594,7 @@ describe("useChooserRowAvatar", () => {
       expect(fetchAvatarState).toHaveBeenCalledTimes(1);
     });
     await settle();
-    expect(result.current).toEqual({ traits: null, imageUrl: null });
+    expect(result.current).toMatchObject({ traits: null, imageUrl: null });
   });
 
   test("re-keys on a version change so an upgraded row switches paths", async () => {
@@ -592,7 +652,10 @@ describe("useChooserRowAvatar", () => {
       expect(fetchCharacterTraitsResult).toHaveBeenCalledTimes(1);
     });
     await settle();
-    expect(first.result.current).toEqual({ traits: null, imageUrl: null });
+    expect(first.result.current).toMatchObject({
+      traits: null,
+      imageUrl: null,
+    });
     first.unmount();
 
     setSystemTime(new Date(Date.now() + A_MINUTE_LATER));
@@ -747,7 +810,7 @@ describe("useChooserRowAvatar", () => {
         );
       });
       await settle();
-      expect(result.current).toEqual({ traits: null, imageUrl: null });
+      expect(result.current).toMatchObject({ traits: null, imageUrl: null });
       expect(writeLastSeenAvatar).not.toHaveBeenCalled();
     });
 
@@ -771,7 +834,7 @@ describe("useChooserRowAvatar", () => {
       actualLastSeenCache.lastSeenAvatarGenerations.claim("other");
       resolveHost({ ok: true, avatar: null });
       await settle();
-      expect(result.current).toEqual({ traits: null, imageUrl: null });
+      expect(result.current).toMatchObject({ traits: null, imageUrl: null });
       expect(deleteLastSeenAvatar).not.toHaveBeenCalled();
     });
 
@@ -807,7 +870,7 @@ describe("useChooserRowAvatar", () => {
         expect(readAssistantAvatarHost).toHaveBeenCalledTimes(1);
       });
       await settle();
-      expect(result.current).toEqual({ traits: null, imageUrl: null });
+      expect(result.current).toMatchObject({ traits: null, imageUrl: null });
     });
 
     test("issues no host call when the host is unavailable", async () => {
@@ -819,7 +882,7 @@ describe("useChooserRowAvatar", () => {
         },
       );
       await settle();
-      expect(result.current).toEqual({ traits: null, imageUrl: null });
+      expect(result.current).toMatchObject({ traits: null, imageUrl: null });
       expect(readAssistantAvatarHost).not.toHaveBeenCalled();
     });
 
@@ -948,11 +1011,9 @@ describe("useChooserRowAvatar", () => {
 
       // bun:test has no fake timers to fire React Query's interval, so pin
       // the polling contract on the live query instead of a remount.
-      const hostQuery = queryClient
-        .getQueryCache()
-        .find({
-          queryKey: [...chooserRowAvatarQueryKeyPrefix("other"), "host"],
-        });
+      const hostQuery = queryClient.getQueryCache().find({
+        queryKey: [...chooserRowAvatarQueryKeyPrefix("other"), "host"],
+      });
       const observerOptions = hostQuery?.observers[0]?.options;
       expect(observerOptions?.refetchInterval).toBe(60_000);
       expect(observerOptions?.refetchIntervalInBackground).toBe(false);
@@ -1161,7 +1222,7 @@ describe("useChooserRowAvatar", () => {
         );
       });
       expect(writeLastSeenAvatar).not.toHaveBeenCalled();
-      expect(result.current).toEqual({ traits: null, imageUrl: null });
+      expect(result.current).toMatchObject({ traits: null, imageUrl: null });
     });
 
     test("an unreachable legacy row keeps its cached avatar and does not evict it", async () => {
@@ -1482,7 +1543,7 @@ describe("useChooserRowAvatar", () => {
         expect(readLastSeenAvatar).toHaveBeenCalledTimes(1);
       });
       await settle();
-      expect(result.current).toEqual({ traits: null, imageUrl: null });
+      expect(result.current).toMatchObject({ traits: null, imageUrl: null });
     });
   });
 });

--- a/clients/web/src/hooks/use-chooser-row-avatar.test.tsx
+++ b/clients/web/src/hooks/use-chooser-row-avatar.test.tsx
@@ -312,6 +312,100 @@ describe("useChooserRowAvatar", () => {
     },
   );
 
+  describe("synced platform avatarUrl", () => {
+    const SYNCED_URL = "https://cdn.example/avatars/other.png";
+
+    test.each([
+      ["local client", () => (localClient = true)],
+      ["remote-gateway mode", () => (remoteGatewayMode = true)],
+      ["gateway auth", () => (gatewayAuthEnabled = true)],
+    ])(
+      "renders a non-connected platform row's avatarUrl under %s with zero SDK calls",
+      async (_l, arrange) => {
+        arrange();
+        const { result } = renderHook(
+          () =>
+            useChooserRowAvatar(
+              platformRow("other", { avatarUrl: SYNCED_URL }),
+            ),
+          { wrapper: createWrapper() },
+        );
+        await waitFor(() => {
+          expect(result.current.imageUrl).toBe(SYNCED_URL);
+        });
+        expect(result.current.traits).toBeNull();
+        await settle();
+        expect(sdkCallCount()).toBe(0);
+      },
+    );
+
+    test("skips the platform-proxy fetch in pure cloud mode", async () => {
+      const { result } = renderHook(
+        () =>
+          useChooserRowAvatar(platformRow("other", { avatarUrl: SYNCED_URL })),
+        { wrapper: createWrapper() },
+      );
+      await settle();
+      expect(result.current).toEqual({ traits: null, imageUrl: SYNCED_URL });
+      expect(sdkCallCount()).toBe(0);
+      expect(readLastSeenAvatar).not.toHaveBeenCalled();
+    });
+
+    test("connected row prefers its live read over avatarUrl", async () => {
+      const { result } = renderHook(
+        () =>
+          useChooserRowAvatar(platformRow("active", { avatarUrl: SYNCED_URL })),
+        { wrapper: createWrapper() },
+      );
+      await waitFor(() => {
+        expect(result.current.traits).toEqual(traits);
+      });
+      expect(result.current.imageUrl).toBeNull();
+    });
+
+    test("connected row falls back to avatarUrl when it is unreachable", async () => {
+      fetchAvatarState.mockRejectedValue(new Error("offline"));
+      fetchCharacterComponents.mockRejectedValue(new Error("offline"));
+      readLastSeenAvatar.mockResolvedValue({ kind: "character", traits });
+      const { result } = renderHook(
+        () =>
+          useChooserRowAvatar(platformRow("active", { avatarUrl: SYNCED_URL })),
+        { wrapper: createWrapper() },
+      );
+      // The live read retries once (1s backoff) before it settles.
+      await waitFor(
+        () => {
+          expect(result.current.imageUrl).toBe(SYNCED_URL);
+        },
+        { timeout: 3000 },
+      );
+      expect(result.current.traits).toBeNull();
+      expect(readLastSeenAvatar).not.toHaveBeenCalled();
+    });
+
+    test("a conclusive live none on the connected row outranks avatarUrl", async () => {
+      fetchAvatarState.mockResolvedValue(noneState);
+      const { result } = renderHook(
+        () =>
+          useChooserRowAvatar(platformRow("active", { avatarUrl: SYNCED_URL })),
+        { wrapper: createWrapper() },
+      );
+      await settle();
+      expect(result.current).toEqual({ traits: null, imageUrl: null });
+    });
+
+    test("a null avatarUrl falls through to the proxy fetch", async () => {
+      const { result } = renderHook(
+        () => useChooserRowAvatar(platformRow("other", { avatarUrl: null })),
+        { wrapper: createWrapper() },
+      );
+      await waitFor(() => {
+        expect(result.current.traits).toEqual(traits);
+      });
+      expect(fetchAvatarState).toHaveBeenCalledWith("other");
+    });
+  });
+
   test("waits for org readiness before the first platform-proxy fetch", async () => {
     orgReady = false;
     const { result, rerender } = renderHook(
@@ -826,10 +920,9 @@ describe("useChooserRowAvatar", () => {
       });
       first.unmount();
 
-      const second = renderHook(
-        () => useChooserRowAvatar(localRow("other")),
-        { wrapper },
-      );
+      const second = renderHook(() => useChooserRowAvatar(localRow("other")), {
+        wrapper,
+      });
       await waitFor(() => {
         expect(second.result.current.traits).toEqual(traits);
       });
@@ -857,7 +950,9 @@ describe("useChooserRowAvatar", () => {
       // the polling contract on the live query instead of a remount.
       const hostQuery = queryClient
         .getQueryCache()
-        .find({ queryKey: [...chooserRowAvatarQueryKeyPrefix("other"), "host"] });
+        .find({
+          queryKey: [...chooserRowAvatarQueryKeyPrefix("other"), "host"],
+        });
       const observerOptions = hostQuery?.observers[0]?.options;
       expect(observerOptions?.refetchInterval).toBe(60_000);
       expect(observerOptions?.refetchIntervalInBackground).toBe(false);
@@ -884,10 +979,9 @@ describe("useChooserRowAvatar", () => {
         ok: true,
         avatar: { kind: "character", traits: updated },
       });
-      const second = renderHook(
-        () => useChooserRowAvatar(localRow("other")),
-        { wrapper },
-      );
+      const second = renderHook(() => useChooserRowAvatar(localRow("other")), {
+        wrapper,
+      });
       await waitFor(() => {
         expect(second.result.current.traits).toEqual(updated);
       });

--- a/clients/web/src/hooks/use-chooser-row-avatar.test.tsx
+++ b/clients/web/src/hooks/use-chooser-row-avatar.test.tsx
@@ -22,6 +22,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 
 import type * as AvatarApi from "@/assistant/avatar-api";
+import { publish } from "@/lib/event-bus";
 import type * as AvatarLastSeenCache from "@/lib/avatar-last-seen-cache";
 import type { LocalReadAssistantAvatarResult } from "@vellumai/ipc-contract";
 import type * as LocalModeHost from "@/runtime/local-mode-host";
@@ -451,6 +452,26 @@ describe("useChooserRowAvatar", () => {
 
       await waitFor(() => {
         expect(result.current.imageUrl).toBe(NEXT_URL);
+      });
+    });
+
+    test("a failed synced URL is tried again on app.resume", async () => {
+      localClient = true;
+      const { result } = renderHook(
+        () =>
+          useChooserRowAvatar(platformRow("other", { avatarUrl: SYNCED_URL })),
+        { wrapper: createWrapper() },
+      );
+      await settle();
+      act(() => result.current.onImageError());
+      await waitFor(() => {
+        expect(result.current.imageUrl).toBeNull();
+      });
+
+      act(() => publish("app.resume", { signal: "online" }));
+
+      await waitFor(() => {
+        expect(result.current.imageUrl).toBe(SYNCED_URL);
       });
     });
 

--- a/clients/web/src/hooks/use-chooser-row-avatar.ts
+++ b/clients/web/src/hooks/use-chooser-row-avatar.ts
@@ -277,14 +277,17 @@ async function readCachedRowAvatar(assistantId: string): Promise<AvatarRead> {
  * Avatar data for one chooser row, resolved through a precedence chain:
  * 1. The connected row reuses `useAssistantAvatar`'s cache, correct in every
  *    transport mode and never fetched twice.
- * 2. Other platform rows fetch per id through the platform proxy, only when
+ * 2. The platform's synced thumbnail (`assistant.avatarUrl`): a plain image
+ *    URL, so it renders in every mode with no daemon round-trip. It ranks
+ *    below 1 because the live read keeps a character avatar's SVG fidelity.
+ * 3. Other platform rows fetch per id through the platform proxy, only when
  *    {@link canFetchRowAvatarViaPlatformProxy} says the id is honored and the
  *    org store can supply the `Vellum-Organization-Id` header.
- * 3. Local rows (the connected one when unreachable, siblings even asleep)
+ * 4. Local rows (the connected one when unreachable, siblings even asleep)
  *    read their workspace through the host when one can serve it.
- * 4. The last-seen cache: whatever a live source last resolved for this id,
+ * 5. The last-seen cache: whatever a live source last resolved for this id,
  *    so a row keeps its avatar while the assistant is unreachable.
- * Only live sources (1 and 2) feed the cache, at fetch time (1 does so
+ * Only live sources (1 and 3) feed the cache, at fetch time (1 does so
  * inside `useAssistantAvatar`); a conclusive none from any source evicts it.
  * Anything else, including every failure, resolves to nulls: the row's glyph
  * fallback is the error state, a chooser row never surfaces an error.
@@ -296,6 +299,11 @@ export function useChooserRowAvatar(assistant: ResolvedAssistant): AvatarRead {
 
   const connected = useAssistantAvatar(isConnectedRow ? assistant.id : null);
 
+  const syncedAvatar: AvatarRead | null = assistant.avatarUrl
+    ? { traits: null, imageUrl: assistant.avatarUrl }
+    : null;
+  const hasSyncedAvatar = syncedAvatar !== null;
+
   const manifestSupport = rowManifestSupport(assistant);
   const rowQuery = useQuery<LegacyAvatarRead>({
     queryKey: chooserRowAvatarQueryKey(assistant.id, manifestSupport),
@@ -303,6 +311,7 @@ export function useChooserRowAvatar(assistant: ResolvedAssistant): AvatarRead {
       fetchRowAvatarGeneration(client, assistant, manifestSupport),
     enabled:
       !isConnectedRow &&
+      !hasSyncedAvatar &&
       isOrgReady &&
       canFetchRowAvatarViaPlatformProxy(assistant),
     staleTime: (query) =>
@@ -328,14 +337,17 @@ export function useChooserRowAvatar(assistant: ResolvedAssistant): AvatarRead {
   const showLive =
     liveConclusive || (live !== undefined && !isEmptyAvatar(live));
 
-  // The connected row only needs a host read once its live read has
-  // settled empty.
+  // The connected row only falls through once its live read has settled
+  // empty, so a loading row does not flash the thumbnail before the SVG.
   const liveSettledEmpty = !connected.isLoading && !showLive;
+  const showSynced = hasSyncedAvatar && (!isConnectedRow || liveSettledEmpty);
+
   const hostQuery = useQuery<LegacyAvatarRead>({
     queryKey: chooserRowAvatarHostQueryKey(assistant.id),
     queryFn: ({ client }) => readRowAvatarViaHost(client, assistant.id),
     enabled:
       canReadRowAvatarViaHost(assistant) &&
+      !hasSyncedAvatar &&
       (!isConnectedRow || liveSettledEmpty),
     staleTime: HOST_AVATAR_STALE_TIME_MS,
     // staleTime alone never refetches a chooser that stays mounted; the
@@ -353,7 +365,7 @@ export function useChooserRowAvatar(assistant: ResolvedAssistant): AvatarRead {
   const cacheQuery = useQuery<AvatarRead>({
     queryKey: chooserRowAvatarCacheQueryKey(assistant.id),
     queryFn: () => readCachedRowAvatar(assistant.id),
-    enabled: !showLive && !showHost,
+    enabled: !showLive && !hasSyncedAvatar && !showHost,
     staleTime: Infinity,
     structuralSharing: false,
     retry: false,
@@ -361,6 +373,9 @@ export function useChooserRowAvatar(assistant: ResolvedAssistant): AvatarRead {
 
   if (showLive) {
     return live ?? EMPTY_AVATAR;
+  }
+  if (showSynced) {
+    return syncedAvatar ?? EMPTY_AVATAR;
   }
   if (showHost) {
     return { traits: hostQuery.data.traits, imageUrl: hostQuery.data.imageUrl };

--- a/clients/web/src/hooks/use-chooser-row-avatar.ts
+++ b/clients/web/src/hooks/use-chooser-row-avatar.ts
@@ -1,3 +1,4 @@
+import { useCallback, useState } from "react";
 import { type QueryClient, useQuery } from "@tanstack/react-query";
 
 import { fetchAvatarState } from "@/assistant/avatar-api";
@@ -37,6 +38,14 @@ import {
 import type { AvatarRead } from "@/types/avatar";
 
 const QUERY_KEY_PREFIX = "chooserRowAvatar";
+
+export interface ChooserRowAvatar extends AvatarRead {
+  /**
+   * Wire to the rendered image's `onError`. A synced thumbnail that fails to
+   * load (offline, expired signed URL) re-enables the row's other sources.
+   */
+  onImageError: () => void;
+}
 
 type RowManifestSupport = "supported" | "unsupported" | "unknown";
 
@@ -289,18 +298,29 @@ async function readCachedRowAvatar(assistantId: string): Promise<AvatarRead> {
  *    so a row keeps its avatar while the assistant is unreachable.
  * Only live sources (1 and 3) feed the cache, at fetch time (1 does so
  * inside `useAssistantAvatar`); a conclusive none from any source evicts it.
+ * Persisting live evidence also drops the row's `avatarUrl`, so 2 never
+ * outranks a fresher local read. A synced URL that fails to load
+ * (`onImageError`) is set aside so 3 to 5 take over for that row.
  * Anything else, including every failure, resolves to nulls: the row's glyph
  * fallback is the error state, a chooser row never surfaces an error.
  */
-export function useChooserRowAvatar(assistant: ResolvedAssistant): AvatarRead {
+export function useChooserRowAvatar(
+  assistant: ResolvedAssistant,
+): ChooserRowAvatar {
   const activeAssistantId = useResolvedAssistantsStore.use.activeAssistantId();
   const isConnectedRow = assistant.id === activeAssistantId;
   const isOrgReady = useIsOrgReady();
 
   const connected = useAssistantAvatar(isConnectedRow ? assistant.id : null);
 
-  const syncedAvatar: AvatarRead | null = assistant.avatarUrl
-    ? { traits: null, imageUrl: assistant.avatarUrl }
+  // Keyed by URL so a reload that carries a new thumbnail retries it.
+  const [failedSyncedUrl, setFailedSyncedUrl] = useState<string | null>(null);
+  const syncedUrl =
+    assistant.avatarUrl && assistant.avatarUrl !== failedSyncedUrl
+      ? assistant.avatarUrl
+      : null;
+  const syncedAvatar: AvatarRead | null = syncedUrl
+    ? { traits: null, imageUrl: syncedUrl }
     : null;
   const hasSyncedAvatar = syncedAvatar !== null;
 
@@ -371,14 +391,18 @@ export function useChooserRowAvatar(assistant: ResolvedAssistant): AvatarRead {
     retry: false,
   });
 
-  if (showLive) {
-    return live ?? EMPTY_AVATAR;
-  }
-  if (showSynced) {
-    return syncedAvatar ?? EMPTY_AVATAR;
-  }
-  if (showHost) {
-    return { traits: hostQuery.data.traits, imageUrl: hostQuery.data.imageUrl };
-  }
-  return cacheQuery.data ?? EMPTY_AVATAR;
+  const onImageError = useCallback(() => {
+    if (showSynced) {
+      setFailedSyncedUrl(syncedUrl);
+    }
+  }, [showSynced, syncedUrl]);
+
+  const avatar: AvatarRead = showLive
+    ? (live ?? EMPTY_AVATAR)
+    : showSynced
+      ? (syncedAvatar ?? EMPTY_AVATAR)
+      : showHost
+        ? { traits: hostQuery.data.traits, imageUrl: hostQuery.data.imageUrl }
+        : (cacheQuery.data ?? EMPTY_AVATAR);
+  return { ...avatar, onImageError };
 }

--- a/clients/web/src/hooks/use-chooser-row-avatar.ts
+++ b/clients/web/src/hooks/use-chooser-row-avatar.ts
@@ -11,6 +11,7 @@ import {
   resolveAvatarFromState,
   useAssistantAvatar,
 } from "@/hooks/use-assistant-avatar";
+import { useBusSubscription } from "@/hooks/use-bus-subscription";
 import { useIsOrgReady } from "@/hooks/use-is-org-ready";
 import { isGatewayAuthEnabled } from "@/lib/auth/gateway-session";
 import {
@@ -300,7 +301,8 @@ async function readCachedRowAvatar(assistantId: string): Promise<AvatarRead> {
  * inside `useAssistantAvatar`); a conclusive none from any source evicts it.
  * Persisting live evidence also drops the row's `avatarUrl`, so 2 never
  * outranks a fresher local read. A synced URL that fails to load
- * (`onImageError`) is set aside so 3 to 5 take over for that row.
+ * (`onImageError`) is set aside so 3 to 5 take over for that row, until
+ * the next `app.resume` (network back, window foregrounded) retries it.
  * Anything else, including every failure, resolves to nulls: the row's glyph
  * fallback is the error state, a chooser row never surfaces an error.
  */
@@ -313,8 +315,10 @@ export function useChooserRowAvatar(
 
   const connected = useAssistantAvatar(isConnectedRow ? assistant.id : null);
 
-  // Keyed by URL so a reload that carries a new thumbnail retries it.
+  // Keyed by URL so a reload that carries a new thumbnail retries it; a
+  // resume retries the same URL, since the failure may have been offline.
   const [failedSyncedUrl, setFailedSyncedUrl] = useState<string | null>(null);
+  useBusSubscription("app.resume", () => setFailedSyncedUrl(null));
   const syncedUrl =
     assistant.avatarUrl && assistant.avatarUrl !== failedSyncedUrl
       ? assistant.avatarUrl

--- a/clients/web/src/lib/persist-last-seen-avatar.ts
+++ b/clients/web/src/lib/persist-last-seen-avatar.ts
@@ -5,6 +5,7 @@ import {
   lastSeenAvatarGenerations,
   writeLastSeenAvatar,
 } from "@/lib/avatar-last-seen-cache";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import type { AvatarRead } from "@/types/avatar";
 
 /** The chooser's query over the last-seen cache; invalidated after every persist. */
@@ -19,8 +20,10 @@ export function chooserRowAvatarCacheQueryKey(assistantId: string) {
  * read, not only while the chooser is mounted. Claims a persistence generation
  * up front so a blob read that resolves after a newer write or delete
  * (including a retire) commits nothing. Invalidates the chooser's cache query
- * once committed so a row that falls back later reads the fresh entry.
- * Best-effort like the cache: never throws.
+ * once committed so a row that falls back later reads the fresh entry, and
+ * drops the row's synced `avatarUrl`: live evidence outranks a thumbnail
+ * observed earlier, so the cache path wins until the next list load carries
+ * a newer URL. Best-effort like the cache: never throws.
  */
 export async function persistLastSeenAvatar(
   queryClient: QueryClient,
@@ -52,6 +55,7 @@ export async function persistLastSeenAvatar(
     // A blob that cannot be read back is simply not cached.
     return;
   }
+  useResolvedAssistantsStore.getState().clearAvatarUrl(assistantId);
   void queryClient.invalidateQueries({
     queryKey: chooserRowAvatarCacheQueryKey(assistantId),
   });

--- a/clients/web/src/stores/resolved-assistants-store.test.ts
+++ b/clients/web/src/stores/resolved-assistants-store.test.ts
@@ -97,6 +97,29 @@ describe("setFromLockfile", () => {
     expect(entry.releaseChannel).toBe("preview");
   });
 
+  it("preserves an API-seeded avatarUrl across a lockfile refresh", () => {
+    useResolvedAssistantsStore.setState({
+      assistants: [
+        {
+          id: "asst-platform",
+          isLocal: false,
+          isPlatformHosted: true,
+          isPaired: false,
+          avatarUrl: "https://cdn.example/a.png",
+        },
+      ],
+    });
+
+    useResolvedAssistantsStore.getState().setFromLockfile({
+      assistants: [platformAssistant],
+      activeAssistant: "asst-platform",
+    });
+
+    expect(useResolvedAssistantsStore.getState().assistants[0].avatarUrl).toBe(
+      "https://cdn.example/a.png",
+    );
+  });
+
   it("copies Bun-local fields for local entries", () => {
     const lockfile: Lockfile = {
       assistants: [localAssistant],
@@ -359,6 +382,31 @@ describe("setFromApi connectability", () => {
     expect(
       useResolvedAssistantsStore.getState().assistants[0].avatarUrl,
     ).toBeUndefined();
+  });
+
+  it("clearAvatarUrl nulls one row's avatarUrl and leaves the rest", () => {
+    useResolvedAssistantsStore
+      .getState()
+      .setFromApi([
+        apiEntry({ id: "asst-a", avatar_url: "https://cdn.example/a.png" }),
+        apiEntry({ id: "asst-b", avatar_url: "https://cdn.example/b.png" }),
+      ]);
+    const before = useResolvedAssistantsStore.getState().assistants;
+
+    useResolvedAssistantsStore.getState().clearAvatarUrl("asst-a");
+
+    const byId = new Map(
+      useResolvedAssistantsStore.getState().assistants.map((a) => [a.id, a]),
+    );
+    expect(byId.get("asst-a")?.avatarUrl).toBeNull();
+    expect(byId.get("asst-b")?.avatarUrl).toBe("https://cdn.example/b.png");
+
+    useResolvedAssistantsStore.getState().clearAvatarUrl("asst-a");
+    useResolvedAssistantsStore.getState().clearAvatarUrl("asst-missing");
+    expect(useResolvedAssistantsStore.getState().assistants).not.toBe(before);
+    expect(byId.get("asst-b")).toBe(
+      useResolvedAssistantsStore.getState().assistants[1],
+    );
   });
 
   it("drops a local registration with no ingress and no lockfile entry", () => {

--- a/clients/web/src/stores/resolved-assistants-store.test.ts
+++ b/clients/web/src/stores/resolved-assistants-store.test.ts
@@ -333,16 +333,41 @@ describe("setFromApi connectability", () => {
       created: "2026-01-01T00:00:00Z",
       is_local: false,
       ingress_url: null,
+      avatar_url: null,
       current_release_version: null,
       release_channel: "stable",
       ...overrides,
     }) as ApiAssistant;
 
+  it("carries the platform avatar_url and leaves lockfile entries without one", () => {
+    useResolvedAssistantsStore
+      .getState()
+      .setFromApi([
+        apiEntry({ id: "asst-cloud", avatar_url: "https://cdn.example/a.png" }),
+        apiEntry({ id: "asst-bare", avatar_url: null }),
+      ]);
+    const byId = new Map(
+      useResolvedAssistantsStore.getState().assistants.map((a) => [a.id, a]),
+    );
+    expect(byId.get("asst-cloud")?.avatarUrl).toBe("https://cdn.example/a.png");
+    expect(byId.get("asst-bare")?.avatarUrl).toBeNull();
+
+    useResolvedAssistantsStore.getState().setFromLockfile({
+      assistants: [localAssistant],
+      activeAssistant: "asst-local",
+    });
+    expect(
+      useResolvedAssistantsStore.getState().assistants[0].avatarUrl,
+    ).toBeUndefined();
+  });
+
   it("drops a local registration with no ingress and no lockfile entry", () => {
-    useResolvedAssistantsStore.getState().setFromApi([
-      apiEntry({ id: "asst-cloud" }),
-      apiEntry({ id: "asst-dead-local", is_local: true, ingress_url: null }),
-    ]);
+    useResolvedAssistantsStore
+      .getState()
+      .setFromApi([
+        apiEntry({ id: "asst-cloud" }),
+        apiEntry({ id: "asst-dead-local", is_local: true, ingress_url: null }),
+      ]);
 
     const assistants = useResolvedAssistantsStore.getState().assistants;
     expect(assistants.map((a) => a.id)).toEqual(["asst-cloud"]);
@@ -370,9 +395,11 @@ describe("setFromApi connectability", () => {
       activeAssistant: "asst-local",
     });
 
-    useResolvedAssistantsStore.getState().setFromApi([
-      apiEntry({ id: "asst-local", is_local: true, ingress_url: null }),
-    ]);
+    useResolvedAssistantsStore
+      .getState()
+      .setFromApi([
+        apiEntry({ id: "asst-local", is_local: true, ingress_url: null }),
+      ]);
 
     const entry = useResolvedAssistantsStore.getState().assistants[0];
     expect(entry.id).toBe("asst-local");

--- a/clients/web/src/stores/resolved-assistants-store.ts
+++ b/clients/web/src/stores/resolved-assistants-store.ts
@@ -60,6 +60,9 @@ export interface ResolvedAssistant {
    *  entries; only the API carries it. Null/undefined means the platform has
    *  no route to this assistant. */
   ingressUrl?: string | null;
+  /** Synced avatar thumbnail served by the platform; only the API carries
+   *  it. Null means the platform holds no avatar for this assistant. */
+  avatarUrl?: string | null;
   /** Owning org for platform entries; only the lockfile carries it, so
    *  API-sourced entries leave this undefined. */
   organizationId?: string;
@@ -187,6 +190,7 @@ const useResolvedAssistantsStoreBase = create<ResolvedAssistantsStore>(
               runtimeVersion: lockfileFields.runtimeVersion,
               runtimeUrl: lockfileFields.runtimeUrl,
               ingressUrl: a.ingress_url,
+              avatarUrl: a.avatar_url,
               currentReleaseVersion: a.current_release_version,
               releaseChannel: a.release_channel,
               isActiveLockfileAssistant:
@@ -211,6 +215,7 @@ const useResolvedAssistantsStoreBase = create<ResolvedAssistantsStore>(
           name: assistant.name,
           hatchedAt: assistant.created,
           ingressUrl: assistant.ingress_url,
+          avatarUrl: assistant.avatar_url,
           currentReleaseVersion: assistant.current_release_version,
           releaseChannel: assistant.release_channel,
           ...classifyApiEntry(

--- a/clients/web/src/stores/resolved-assistants-store.ts
+++ b/clients/web/src/stores/resolved-assistants-store.ts
@@ -123,6 +123,12 @@ interface ResolvedAssistantsActions {
    */
   markHydrated: () => void;
   upsertFromApi: (assistant: Assistant) => void;
+  /**
+   * Forget the synced thumbnail for one row. The platform copy lags a live
+   * avatar change, so callers drop it and let the live/cache paths render
+   * until the next API load carries the new URL.
+   */
+  clearAvatarUrl: (assistantId: string) => void;
   remove: (assistantId: string) => void;
   clear: () => void;
   setActiveAssistantId: (assistantId: string | null) => void;
@@ -145,12 +151,14 @@ const useResolvedAssistantsStoreBase = create<ResolvedAssistantsStore>(
       const existingById = new Map(
         get().assistants.map((assistant) => [assistant.id, assistant]),
       );
+      // The lockfile carries no platform metadata; keep what the API seeded.
       const assistants = lockfile.assistants.map((a) => ({
         id: a.assistantId,
         name: a.name,
         hatchedAt: a.hatchedAt,
         cloud: a.cloud,
         runtimeVersion: a.resources?.runtimeVersion,
+        avatarUrl: existingById.get(a.assistantId)?.avatarUrl,
         currentReleaseVersion: existingById.get(a.assistantId)
           ?.currentReleaseVersion,
         releaseChannel: existingById.get(a.assistantId)?.releaseChannel,
@@ -255,6 +263,17 @@ const useResolvedAssistantsStoreBase = create<ResolvedAssistantsStore>(
             },
           ],
         };
+      }),
+
+    clearAvatarUrl: (assistantId) =>
+      set((state) => {
+        const idx = state.assistants.findIndex((a) => a.id === assistantId);
+        if (idx < 0 || state.assistants[idx].avatarUrl == null) {
+          return state;
+        }
+        const next = [...state.assistants];
+        next[idx] = { ...next[idx], avatarUrl: null };
+        return { assistants: next };
       }),
 
     remove: (assistantId) =>


### PR DESCRIPTION
## Summary
- Add `avatarUrl?: string | null` to `ResolvedAssistant`, populated by `setFromApi` and `upsertFromApi` from the generated `Assistant.avatar_url`; lockfile-sourced entries leave it undefined.
- `useChooserRowAvatar` now ranks the synced thumbnail right after the connected row's live read: a plain `<img>` URL that renders in every mode (local, remote-gateway, gateway-auth, pure cloud) with zero daemon round-trips. When present it disables the platform-proxy fetch, the host disk read, and the IndexedDB cache read for that row.
- The connected row still prefers its live read (SVG fidelity for character avatars) and only falls through to `avatarUrl` once the live read has settled empty; a conclusive live none stays authoritative.
- Tests: store projection carries the field (API) and omits it (lockfile); hook renders `avatarUrl` for non-connected platform rows under every non-cloud mode with no SDK calls, skips the proxy fetch in cloud mode, prefers live data for the connected row, and falls back to `avatarUrl` when the connected row is unreachable.

Part of plan: chooser-assistant-avatars.md (PR 9 of 11); platform side landed in vellum-assistant-platform#10150, spec sync #41344