### PR TITLE
feat(companion): glow in the avatar's own colour and a slow bob

### DIFF
--- a/clients/web/src/components/companion-surface-page.test.tsx
+++ b/clients/web/src/components/companion-surface-page.test.tsx
@@ -41,6 +41,7 @@ const resetState = () => {
   STATE.watchEnabled = true;
   STATE.intro = null;
   STATE.assistantName = "Ziggy";
+  delete STATE.character;
 };
 
 /**
@@ -779,5 +780,105 @@ describe("the companion's own menu", () => {
     });
 
     expect(moveByMock).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * The glow is the assistant's own light, not the surface's.
+ *
+ * Before this, the resting colour came only from a running call, so a companion
+ * nobody was talking to glowed the component's teal whatever colour the
+ * assistant actually is.
+ */
+describe("the companion's accent colour", () => {
+  const CHARACTER = {
+    bodyShape: "blob",
+    eyeStyle: "curious",
+    color: "orange",
+  } as const;
+
+  /** A call running, carrying whatever accent the case is about. */
+  const listening = (accentHex: string): CompanionSurfaceState["call"] => ({
+    phase: "listening",
+    label: "Listening",
+    accentHex,
+    muted: false,
+    outputMuted: false,
+    detail: "",
+    approvalRequestId: "",
+    assistantName: "Ziggy",
+  });
+
+  /**
+   * The pill carries `--accent` in every phase; the glow only draws at rest.
+   *
+   * Awaited, because the state the colour comes from arrives after mount the
+   * way it does from main, so the first render is always the default.
+   */
+  const expectAccent = async (
+    container: HTMLElement,
+    hex: string,
+  ): Promise<void> => {
+    await waitFor(() => {
+      const pill = container.querySelector<HTMLElement>(".cursor-grab");
+      if (!pill) {
+        throw new Error("Expected the pill to render");
+      }
+      expect(pill.style.getPropertyValue("--accent").trim().toLowerCase()).toBe(
+        hex,
+      );
+    });
+  };
+
+  const expectGlow = async (
+    container: HTMLElement,
+    hex: string,
+  ): Promise<void> => {
+    await waitFor(() => {
+      const glow = container.querySelector<HTMLElement>(".companion-glow");
+      if (!glow) {
+        throw new Error("Expected the glow to render");
+      }
+      expect(glow.style.background.trim().toLowerCase()).toContain(hex);
+    });
+  };
+
+  test("resolves the character's palette colour with no call running", async () => {
+    STATE.character = { ...CHARACTER };
+    const { container } = render(<CompanionSurfacePage />);
+
+    await expectAccent(container, "#e9642f");
+    await expectGlow(container, "#e9642f");
+  });
+
+  test("lets a running call's accent win", async () => {
+    STATE.character = { ...CHARACTER };
+    STATE.call = listening("#123456");
+    const { container } = render(<CompanionSurfacePage />);
+
+    await expectAccent(container, "#123456");
+  });
+
+  /**
+   * The contract makes no promise the call's hex parses, and CSS drops an
+   * invalid custom property silently, so an unusable accent falls through to
+   * the character rather than being handed on.
+   */
+  test("ignores a call accent that is not a hex", async () => {
+    STATE.character = { ...CHARACTER };
+    STATE.call = listening("");
+    const { container } = render(<CompanionSurfacePage />);
+
+    await expectAccent(container, "#e9642f");
+  });
+
+  /**
+   * An uploaded image has no palette colour to resolve, so the component's own
+   * default is the last word rather than a colour guessed from nothing.
+   */
+  test("falls back to the component default without a character", async () => {
+    const { container } = render(<CompanionSurfacePage />);
+
+    await expectAccent(container, "#5eead4");
   });
 });

--- a/clients/web/src/components/companion-surface-page.test.tsx
+++ b/clients/web/src/components/companion-surface-page.test.tsx
@@ -784,11 +784,9 @@ describe("the companion's own menu", () => {
 });
 
 /**
- * The glow is the assistant's own light, not the surface's.
- *
- * Before this, the resting colour came only from a running call, so a companion
- * nobody was talking to glowed the component's teal whatever colour the
- * assistant actually is.
+ * The glow is the assistant's own light, not the surface's: an idle companion
+ * with no call running glows its character's accent, and a running call's
+ * accent wins over it.
  */
 describe("the companion's accent colour", () => {
   const CHARACTER = {
@@ -812,8 +810,8 @@ describe("the companion's accent colour", () => {
   /**
    * The pill carries `--accent` in every phase; the glow only draws at rest.
    *
-   * Awaited, because the state the colour comes from arrives after mount the
-   * way it does from main, so the first render is always the default.
+   * Awaited, because the state the colour comes from arrives after mount, so
+   * the first render is always the default.
    */
   const expectAccent = async (
     container: HTMLElement,

--- a/clients/web/src/components/companion-surface-page.tsx
+++ b/clients/web/src/components/companion-surface-page.tsx
@@ -9,6 +9,7 @@ import {
   CompanionSurface,
   type CompanionSurfacePhase,
 } from "@/components/companion-surface";
+import { resolveAvatarAccentHex } from "@/hooks/use-avatar-accent-var";
 import {
   activateCompanionApp,
   answerCompanionWatchRetro,
@@ -390,15 +391,26 @@ export function CompanionSurfacePage() {
           ? "summary"
           : (introHeld ?? (hovered ? "hover" : "resting"));
 
-  // The avatar's own colour, which arrives with the session. It is `""` until
-  // the avatar resolves and the contract makes no promise it parses, so
-  // anything that is not an obvious `#RRGGBB` falls back to the component's
-  // default rather than being handed to CSS, where an invalid value silently
-  // drops the custom property and takes the glyph's colour with it.
-  const accentHex =
+  // The avatar's own colour. A running call publishes one, and it wins: it is
+  // the colour the call surfaces elsewhere are already tinted with. Outside a
+  // call the character's palette id resolves to the same hex the app draws the
+  // creature in, so the resting glow is the assistant's colour rather than the
+  // component's teal default.
+  //
+  // The call's hex is `""` until the avatar resolves and the contract makes no
+  // promise it parses, so anything that is not an obvious `#RRGGBB` falls
+  // through rather than being handed to CSS, where an invalid value silently
+  // drops the custom property and takes the glyph's colour with it. The
+  // resolver is handed `null` components on purpose: this window has no daemon
+  // query, so the bundled palette is the only one it can read.
+  const callAccentHex =
     call !== null && /^#[0-9a-f]{6}$/i.test(call.accentHex)
       ? call.accentHex
       : undefined;
+  const accentHex =
+    callAccentHex ??
+    resolveAvatarAccentHex(null, character ?? null) ??
+    undefined;
 
   return (
     <div

--- a/clients/web/src/components/companion-surface.stories.tsx
+++ b/clients/web/src/components/companion-surface.stories.tsx
@@ -164,6 +164,28 @@ export const Resting: Story = {
 };
 
 /**
+ * The same circle in an assistant's own colour, which is what the desktop
+ * actually shows: the glow is the character's palette hex, not the surface's
+ * teal default. Here to make the colour a thing that can be reviewed rather
+ * than something only a live call ever produced.
+ */
+export const RestingInItsOwnColour: Story = {
+  args: {
+    phase: "resting",
+    character: { bodyShape: "burst", eyeStyle: "curious", color: "orange" },
+    accentHex: "#E9642F",
+  },
+};
+
+/**
+ * An uploaded image instead of a composed creature. It has no palette colour to
+ * resolve, so this is the case the component's default accent exists for.
+ */
+export const RestingCustomImage: Story = {
+  args: { phase: "resting", character: undefined, avatarSrc: EXAMPLE_AVATAR },
+};
+
+/**
  * Resting, with a turn running somewhere the user is not looking.
  *
  * The state the working ring exists for: the assistant is doing something and

--- a/clients/web/src/components/companion-surface.stories.tsx
+++ b/clients/web/src/components/companion-surface.stories.tsx
@@ -166,8 +166,7 @@ export const Resting: Story = {
 /**
  * The same circle in an assistant's own colour, which is what the desktop
  * actually shows: the glow is the character's palette hex, not the surface's
- * teal default. Here to make the colour a thing that can be reviewed rather
- * than something only a live call ever produced.
+ * teal default. Here so the resting colour is reviewable without a live call.
  */
 export const RestingInItsOwnColour: Story = {
   args: {

--- a/clients/web/src/components/companion-surface.test.tsx
+++ b/clients/web/src/components/companion-surface.test.tsx
@@ -1196,3 +1196,51 @@ describe("the companion surface's text selection", () => {
     );
   });
 });
+
+/**
+ * The idle motion, which is two animations that must not become one.
+ *
+ * `AnimatedAvatar` owns `transform` on its own `<svg>` for the breathe and the
+ * morph, so the bob lives on a wrapper. Put both on one node and the browser
+ * silently keeps whichever declaration came last, and the loss is invisible in
+ * a screenshot.
+ */
+describe("the resting avatar's idle motion", () => {
+  test("bobs on a wrapper of its own, with the glow riding inside it", () => {
+    const { container } = render(
+      <CompanionSurface phase="resting" accentHex="#ff8800" />,
+    );
+
+    const bob = container.querySelector<HTMLElement>(".companion-avatar-bob");
+    expect(bob).not.toBeNull();
+
+    const glow = bob?.querySelector<HTMLElement>(".companion-glow");
+    expect(glow).not.toBeNull();
+    expect(glow?.className).not.toContain("animate-pulse");
+    expect(glow?.style.background.toLowerCase()).toContain("#ff8800");
+  });
+
+  /**
+   * The artwork keeps its own animated node under the wrapper, which is what
+   * makes the two transforms compose rather than replace each other.
+   */
+  test("leaves the artwork on a node below the bob", () => {
+    const { container } = render(
+      <CompanionSurface
+        phase="resting"
+        character={{ bodyShape: "blob", eyeStyle: "curious", color: "teal" }}
+      />,
+    );
+
+    const bob = container.querySelector<HTMLElement>(".companion-avatar-bob");
+    expect(bob?.querySelector("svg")).not.toBeNull();
+  });
+
+  /** The wrapper sits inside the avatar's box, which nothing else may move. */
+  test("keeps the avatar box as the wrapper's parent", () => {
+    const { container } = render(<CompanionSurface phase="resting" />);
+
+    const bob = container.querySelector<HTMLElement>(".companion-avatar-bob");
+    expect(bob?.parentElement?.className).toContain("size-11");
+  });
+});

--- a/clients/web/src/components/companion-surface.tsx
+++ b/clients/web/src/components/companion-surface.tsx
@@ -12,6 +12,7 @@ import {
   VolumeX,
   X,
 } from "lucide-react";
+import { useReducedMotion } from "motion/react";
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import type {
   CSSProperties,
@@ -1186,6 +1187,12 @@ function Composer({
  * into the desktop rather than ending on an edge. A halo sized to its own
  * source has nowhere to fall off and reads as a ring around the avatar rather
  * than as light coming off it.
+ *
+ * **The bob is a wrapper, not a class on the artwork.** `AnimatedAvatar` owns
+ * `transform` on its own `<svg>` for the breathe and the morph, and a second
+ * animation on that node would silently replace one of them. Everything that
+ * belongs to the creature rides inside the wrapper, glow included, so the light
+ * travels with what is casting it.
  */
 function Avatar({
   glow,
@@ -1206,6 +1213,11 @@ function Avatar({
   onMouseEnter?: () => void;
   onClick?: () => void;
 }) {
+  // Belt and braces alongside the `prefers-reduced-motion` block beside the
+  // keyframes: the class is what a stylesheet-only reader sees, this is what a
+  // reader of the component sees.
+  const reduce = useReducedMotion();
+
   return (
     // A div rather than a button even when it is pressable: it is the drag
     // handle for the whole surface, and the press that starts a drag must not
@@ -1216,51 +1228,59 @@ function Avatar({
       onMouseEnter={onMouseEnter}
       onClick={onClick}
     >
-      {glow && (
-        <span
-          className="absolute size-10 animate-pulse rounded-full blur-lg"
-          style={{ background: accentHex, opacity: 0.4 }}
-          aria-hidden
-        />
-      )}
-      {character !== undefined ? (
-        // The live creature, composed here rather than shipped as pixels. It
-        // blinks, twitches and breathes on its own, which is the whole reason
-        // the traits cross the bridge instead of a still.
-        <div className="relative drop-shadow-[0_1px_3px_rgba(0,0,0,0.55)]">
-          <AnimatedAvatar
-            components={BUNDLED_COMPONENTS}
-            traits={character}
-            size={AVATAR_IMAGE}
-            isAssistantBusy={busy}
-            attentive={attentive}
+      <div
+        className="companion-avatar-bob relative grid place-items-center"
+        style={{ animation: reduce ? "none" : undefined }}
+      >
+        {glow && (
+          <span
+            className="companion-glow absolute size-10 rounded-full blur-lg"
+            style={{
+              background: accentHex,
+              animation: reduce ? "none" : undefined,
+            }}
+            aria-hidden
           />
-        </div>
-      ) : avatarSrc === undefined ? (
-        // Until the avatar resolves, a disc in its colour. Same size, so
-        // nothing about the geometry moves when the image lands.
-        <span
-          className="relative size-7 rounded-full drop-shadow-[0_1px_3px_rgba(0,0,0,0.55)]"
-          style={{ background: accentHex }}
-          aria-hidden
-        />
-      ) : (
-        // A custom uploaded image, which has no traits to compose and so no
-        // eyes to animate.
-        //
-        // Undraggable, because the avatar is the surface's drag handle. An
-        // image is natively draggable, and the platform's own HTML5 image drag
-        // takes the pointer and ends the `mousemove` stream the surface's drag
-        // runs on, so pressing a custom avatar would move nothing where
-        // pressing a composed creature moves the window. WebKit honours the CSS
-        // on paths where it ignores the attribute, so both are needed.
-        <img
-          src={avatarSrc}
-          alt=""
-          draggable={false}
-          className="relative size-7 rounded-full object-contain drop-shadow-[0_1px_3px_rgba(0,0,0,0.55)] [-webkit-user-drag:none]"
-        />
-      )}
+        )}
+        {character !== undefined ? (
+          // The live creature, composed here rather than shipped as pixels. It
+          // blinks, twitches and breathes on its own, which is the whole reason
+          // the traits cross the bridge instead of a still.
+          <div className="relative drop-shadow-[0_1px_3px_rgba(0,0,0,0.55)]">
+            <AnimatedAvatar
+              components={BUNDLED_COMPONENTS}
+              traits={character}
+              size={AVATAR_IMAGE}
+              isAssistantBusy={busy}
+              attentive={attentive}
+            />
+          </div>
+        ) : avatarSrc === undefined ? (
+          // Until the avatar resolves, a disc in its colour. Same size, so
+          // nothing about the geometry moves when the image lands.
+          <span
+            className="relative size-7 rounded-full drop-shadow-[0_1px_3px_rgba(0,0,0,0.55)]"
+            style={{ background: accentHex }}
+            aria-hidden
+          />
+        ) : (
+          // A custom uploaded image, which has no traits to compose and so no
+          // eyes to animate.
+          //
+          // Undraggable, because the avatar is the surface's drag handle. An
+          // image is natively draggable, and the platform's own HTML5 image drag
+          // takes the pointer and ends the `mousemove` stream the surface's drag
+          // runs on, so pressing a custom avatar would move nothing where
+          // pressing a composed creature moves the window. WebKit honours the CSS
+          // on paths where it ignores the attribute, so both are needed.
+          <img
+            src={avatarSrc}
+            alt=""
+            draggable={false}
+            className="relative size-7 rounded-full object-contain drop-shadow-[0_1px_3px_rgba(0,0,0,0.55)] [-webkit-user-drag:none]"
+          />
+        )}
+      </div>
     </div>
   );
 }

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -248,8 +248,8 @@ html[data-page-transition="pop"]::view-transition-new(root) {
 
 /* Companion avatar bob: the creature lifting off its baseline and settling
    back, so a surface that otherwise only breathes reads as alive from across
-   the desk. One-directional on purpose: 0% is exactly where main placed the
-   avatar, and the lift is the only departure from it.
+   the desk. One-directional on purpose: 0% is the avatar's resting position,
+   and the lift is the only departure from it.
 
    It has to live on a wrapper of its own. `AnimatedAvatar` owns `transform` on
    its `<svg>` for the breathe and morph, and two animations on one node means
@@ -260,8 +260,8 @@ html[data-page-transition="pop"]::view-transition-new(root) {
 }
 
 /* The glow's breath, with both ends written out. Tailwind's `animate-pulse`
-   synthesises its 0%/100% from whatever opacity the element already has, which
-   made the swing 0.4 -> 0.5: a change nobody can see. */
+   synthesises its 0%/100% from whatever opacity the element already carries,
+   which on a glow this faint is a swing nobody can see. */
 @keyframes companion-glow-breathe {
   0%, 100% { opacity: 0.32; }
   50% { opacity: 0.5; }

--- a/clients/web/src/index.css
+++ b/clients/web/src/index.css
@@ -246,6 +246,48 @@ html[data-page-transition="pop"]::view-transition-new(root) {
   75% { transform: rotate(-0.86deg); }
 }
 
+/* Companion avatar bob: the creature lifting off its baseline and settling
+   back, so a surface that otherwise only breathes reads as alive from across
+   the desk. One-directional on purpose: 0% is exactly where main placed the
+   avatar, and the lift is the only departure from it.
+
+   It has to live on a wrapper of its own. `AnimatedAvatar` owns `transform` on
+   its `<svg>` for the breathe and morph, and two animations on one node means
+   one of them silently wins. */
+@keyframes companion-avatar-bob {
+  0%, 100% { transform: translateY(0); }
+  50% { transform: translateY(-3px); }
+}
+
+/* The glow's breath, with both ends written out. Tailwind's `animate-pulse`
+   synthesises its 0%/100% from whatever opacity the element already has, which
+   made the swing 0.4 -> 0.5: a change nobody can see. */
+@keyframes companion-glow-breathe {
+  0%, 100% { opacity: 0.32; }
+  50% { opacity: 0.5; }
+}
+
+.companion-avatar-bob {
+  animation: companion-avatar-bob 5s ease-in-out infinite;
+  will-change: transform;
+}
+
+.companion-glow {
+  /* Where the breath starts and where it is held when it cannot run. */
+  opacity: 0.32;
+  animation: companion-glow-breathe 4s ease-in-out infinite;
+}
+
+/* Held still rather than dropped: the glow is the avatar's own colour thrown
+   onto the desktop, so it stays lit at rest, and the creature keeps its
+   baseline rather than disappearing from it. */
+@media (prefers-reduced-motion: reduce) {
+  .companion-avatar-bob,
+  .companion-glow {
+    animation: none;
+  }
+}
+
 /* BusyIndicator — mirrors macOS VBusyIndicator. A filled circle pulsing in
  * opacity (1→0.3) and scale (1→0.85) over 1s easeInOut. Used in
  * ActivityRunCard for active/thinking phases. */


### PR DESCRIPTION
## Summary
- Resting glow now resolves from the character's palette colour (call accent still overrides)
- Slow one-directional bob on a wrapper around the avatar, reduced-motion guarded
- Glow breathe gets explicit keyframes and a reduced-motion guard

Part of plan: companion-avatar-restyle.md (PR 1 of 3)