### PR TITLE
web: look up platform avatar_url by id for paired and local chooser rows

### DIFF
--- a/clients/web/src/hooks/use-assistant-resource-sync.test.tsx
+++ b/clients/web/src/hooks/use-assistant-resource-sync.test.tsx
@@ -916,6 +916,38 @@ describe("useAssistantResourceSync", () => {
     expect(queryClient.getQueryState(key)?.fetchStatus).toBe("idle");
   });
 
+  test("avatar_updated drops the lookup entry under the row's platform id", async () => {
+    const queryClient = freshQueryClient();
+    queryClient.invalidateQueries = mock(() => Promise.resolve()) as never;
+    useResolvedAssistantsStore.setState({
+      assistants: [
+        {
+          id: "asst-1",
+          isLocal: true,
+          isPlatformHosted: false,
+          isPaired: false,
+          cloud: "local",
+          platformAssistantId: "uuid-1",
+        },
+      ],
+    });
+    const key = platformAvatarUrlsQueryKey("user-1", null);
+    queryClient.setQueryData(
+      key,
+      new Map([["uuid-1", "https://cdn.example/a.png"]]),
+    );
+    renderHook(() => useAssistantResourceSync("asst-1", true), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    emit({ type: "avatar_updated" } as unknown as AssistantEvent);
+    await waitFor(() => {
+      expect(
+        queryClient.getQueryData<Map<string, string>>(key)?.has("uuid-1"),
+      ).toBe(false);
+    });
+  });
+
   test("invalidates avatar query on avatar_updated event", async () => {
     const queryClient = freshQueryClient();
     const spy = mock(() => Promise.resolve());

--- a/clients/web/src/hooks/use-assistant-resource-sync.test.tsx
+++ b/clients/web/src/hooks/use-assistant-resource-sync.test.tsx
@@ -29,6 +29,7 @@ import { useAssistantResourceSync } from "@/hooks/use-assistant-resource-sync";
 import { assistantIdentityQueryKey } from "@/hooks/use-assistant-identity-init";
 import { avatarQueryKey } from "@/hooks/use-assistant-avatar";
 import { chooserRowAvatarQueryKeyPrefix } from "@/hooks/use-chooser-row-avatar";
+import { platformAvatarUrlsQueryKey } from "@/hooks/use-platform-avatar-urls";
 import { SYNC_TAGS } from "@/lib/sync/types";
 import type { SyncChangedEvent } from "@/lib/sync/types";
 import { __resetForTesting, publish } from "@/lib/event-bus";
@@ -886,6 +887,33 @@ describe("useAssistantResourceSync", () => {
     publish("sse.opened", { assistantId: "asst-1", cause: "error" });
     await flushReconnectSweep();
     expect(avatarUrl()).toBe("https://cdn.example/a.png");
+  });
+
+  test("avatar_updated drops the platform lookup entry without a refetch", async () => {
+    const queryClient = freshQueryClient();
+    queryClient.invalidateQueries = mock(() => Promise.resolve()) as never;
+    const key = platformAvatarUrlsQueryKey("user-1");
+    queryClient.setQueryData(
+      key,
+      new Map([
+        ["asst-1", "https://cdn.example/a.png"],
+        ["asst-2", "https://cdn.example/b.png"],
+      ]),
+    );
+    renderHook(() => useAssistantResourceSync("asst-1", true), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    emit({ type: "avatar_updated" } as unknown as AssistantEvent);
+    await waitFor(() => {
+      expect(
+        queryClient.getQueryData<Map<string, string>>(key)?.has("asst-1"),
+      ).toBe(false);
+    });
+    expect(
+      queryClient.getQueryData<Map<string, string>>(key)?.get("asst-2"),
+    ).toBe("https://cdn.example/b.png");
+    expect(queryClient.getQueryState(key)?.fetchStatus).toBe("idle");
   });
 
   test("invalidates avatar query on avatar_updated event", async () => {

--- a/clients/web/src/hooks/use-assistant-resource-sync.test.tsx
+++ b/clients/web/src/hooks/use-assistant-resource-sync.test.tsx
@@ -892,7 +892,7 @@ describe("useAssistantResourceSync", () => {
   test("avatar_updated drops the platform lookup entry without a refetch", async () => {
     const queryClient = freshQueryClient();
     queryClient.invalidateQueries = mock(() => Promise.resolve()) as never;
-    const key = platformAvatarUrlsQueryKey("user-1");
+    const key = platformAvatarUrlsQueryKey("user-1", null);
     queryClient.setQueryData(
       key,
       new Map([

--- a/clients/web/src/hooks/use-assistant-resource-sync.ts
+++ b/clients/web/src/hooks/use-assistant-resource-sync.ts
@@ -46,6 +46,7 @@ import {
 import { avatarQueryKey } from "@/hooks/use-assistant-avatar";
 import { chooserRowAvatarQueryKeyPrefix } from "@/hooks/use-chooser-row-avatar";
 import { useBusSubscription } from "@/hooks/use-bus-subscription";
+import { suppressPlatformAvatarUrl } from "@/hooks/use-platform-avatar-urls";
 import { getClientId } from "@/lib/telemetry/client-identity";
 import { SYNC_TAGS } from "@/lib/sync/types";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
@@ -240,12 +241,14 @@ export function useAssistantResourceSync(
 
 /**
  * An avatar change on the connected assistant. Beyond the query sweep, drops
- * the row's synced `avatarUrl`: the platform copy lags the live change, and
- * while set it keeps the chooser's live/cache paths disabled. The reconnect
- * sweep does not do this, since nothing is known to have changed there.
+ * the row's synced `avatarUrl` and platform lookup entry: the platform copy
+ * lags the live change, and while set it keeps the chooser's live/cache paths
+ * disabled. The reconnect sweep does not do this, since nothing is known to
+ * have changed there.
  */
 function onAvatarChanged(queryClient: QueryClient, assistantId: string): void {
   useResolvedAssistantsStore.getState().clearAvatarUrl(assistantId);
+  suppressPlatformAvatarUrl(queryClient, assistantId);
   invalidateAvatarQueries(queryClient, assistantId);
 }
 

--- a/clients/web/src/hooks/use-assistant-resource-sync.ts
+++ b/clients/web/src/hooks/use-assistant-resource-sync.ts
@@ -49,7 +49,10 @@ import { useBusSubscription } from "@/hooks/use-bus-subscription";
 import { suppressPlatformAvatarUrl } from "@/hooks/use-platform-avatar-urls";
 import { getClientId } from "@/lib/telemetry/client-identity";
 import { SYNC_TAGS } from "@/lib/sync/types";
-import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+import {
+  resolvePlatformAssistantId,
+  useResolvedAssistantsStore,
+} from "@/stores/resolved-assistants-store";
 
 /**
  * A reconnect can flap: error, reopen, error, reopen. Collapse a burst into
@@ -248,7 +251,10 @@ export function useAssistantResourceSync(
  */
 function onAvatarChanged(queryClient: QueryClient, assistantId: string): void {
   useResolvedAssistantsStore.getState().clearAvatarUrl(assistantId);
-  void suppressPlatformAvatarUrl(queryClient, assistantId);
+  suppressPlatformAvatarUrl(
+    queryClient,
+    resolvePlatformAssistantId(assistantId),
+  );
   invalidateAvatarQueries(queryClient, assistantId);
 }
 

--- a/clients/web/src/hooks/use-assistant-resource-sync.ts
+++ b/clients/web/src/hooks/use-assistant-resource-sync.ts
@@ -248,7 +248,7 @@ export function useAssistantResourceSync(
  */
 function onAvatarChanged(queryClient: QueryClient, assistantId: string): void {
   useResolvedAssistantsStore.getState().clearAvatarUrl(assistantId);
-  suppressPlatformAvatarUrl(queryClient, assistantId);
+  void suppressPlatformAvatarUrl(queryClient, assistantId);
   invalidateAvatarQueries(queryClient, assistantId);
 }
 

--- a/clients/web/src/hooks/use-chooser-row-avatar.test.tsx
+++ b/clients/web/src/hooks/use-chooser-row-avatar.test.tsx
@@ -602,7 +602,7 @@ describe("useChooserRowAvatar", () => {
       expect(
         queryClient
           .getQueryData<Map<string, string>>(
-            platformAvatarUrlsQueryKey("user-1"),
+            platformAvatarUrlsQueryKey("user-1", null),
           )
           ?.has("other"),
       ).toBe(false);

--- a/clients/web/src/hooks/use-chooser-row-avatar.test.tsx
+++ b/clients/web/src/hooks/use-chooser-row-avatar.test.tsx
@@ -568,6 +568,59 @@ describe("useChooserRowAvatar", () => {
       setState.mockRestore();
     });
 
+    test("a local row keyed by instance name resolves through its platform id", async () => {
+      listAssistants.mockResolvedValue({
+        ok: true,
+        status: 200,
+        data: [apiAssistant("uuid-other", LOOKUP_URL)],
+      });
+      const { result } = renderHook(
+        () =>
+          useChooserRowAvatar(
+            localRow("other", { platformAssistantId: "uuid-other" }),
+          ),
+        { wrapper: createWrapper() },
+      );
+      await waitFor(() => {
+        expect(result.current.imageUrl).toBe(LOOKUP_URL);
+      });
+    });
+
+    test("persisting live evidence by row id drops the platform id entry", async () => {
+      listAssistants.mockResolvedValue({
+        ok: true,
+        status: 200,
+        data: [apiAssistant("uuid-other", LOOKUP_URL)],
+      });
+      const row = localRow("other", { platformAssistantId: "uuid-other" });
+      useResolvedAssistantsStore.setState({ assistants: [row] });
+      const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      });
+      const { result } = renderHook(() => useChooserRowAvatar(row), {
+        wrapper: createWrapper(queryClient),
+      });
+      await waitFor(() => {
+        expect(result.current.imageUrl).toBe(LOOKUP_URL);
+      });
+
+      await persistLastSeenAvatar(queryClient, "other", {
+        traits,
+        imageUrl: null,
+      });
+
+      expect(
+        queryClient
+          .getQueryData<Map<string, string>>(
+            platformAvatarUrlsQueryKey("user-1", null),
+          )
+          ?.has("uuid-other"),
+      ).toBe(false);
+      await waitFor(() => {
+        expect(result.current.imageUrl).toBeNull();
+      });
+    });
+
     test("an id the platform does not list falls through to the cache", async () => {
       readLastSeenAvatar.mockResolvedValue({ kind: "character", traits });
       const { result } = renderHook(

--- a/clients/web/src/hooks/use-chooser-row-avatar.test.tsx
+++ b/clients/web/src/hooks/use-chooser-row-avatar.test.tsx
@@ -164,8 +164,10 @@ const {
 const { avatarQueryKey } = await import("@/hooks/use-assistant-avatar");
 
 const initialAuthState = useAuthStore.getState();
-const { chooserRowAvatarCacheQueryKey } =
+const { chooserRowAvatarCacheQueryKey, persistLastSeenAvatar } =
   await import("@/lib/persist-last-seen-avatar");
+const { platformAvatarUrlsQueryKey } =
+  await import("@/hooks/use-platform-avatar-urls");
 
 /** Past the window a bare avatar stays fresh for. */
 const A_MINUTE_LATER = 61_000;
@@ -572,6 +574,38 @@ describe("useChooserRowAvatar", () => {
         () => useChooserRowAvatar(pairedRow("unlisted")),
         { wrapper: createWrapper() },
       );
+      await waitFor(() => {
+        expect(result.current.traits).toEqual(traits);
+      });
+      expect(result.current.imageUrl).toBeNull();
+      expect(listAssistants).toHaveBeenCalledTimes(1);
+    });
+
+    test("persisting live evidence drops the lookup entry so the row falls through to the cache", async () => {
+      const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      });
+      const { result } = renderHook(
+        () => useChooserRowAvatar(pairedRow("other")),
+        { wrapper: createWrapper(queryClient) },
+      );
+      await waitFor(() => {
+        expect(result.current.imageUrl).toBe(LOOKUP_URL);
+      });
+
+      readLastSeenAvatar.mockResolvedValue({ kind: "character", traits });
+      await persistLastSeenAvatar(queryClient, "other", {
+        traits,
+        imageUrl: null,
+      });
+
+      expect(
+        queryClient
+          .getQueryData<Map<string, string>>(
+            platformAvatarUrlsQueryKey("user-1"),
+          )
+          ?.has("other"),
+      ).toBe(false);
       await waitFor(() => {
         expect(result.current.traits).toEqual(traits);
       });

--- a/clients/web/src/hooks/use-chooser-row-avatar.test.tsx
+++ b/clients/web/src/hooks/use-chooser-row-avatar.test.tsx
@@ -2,10 +2,11 @@
  * Tests for `useChooserRowAvatar`: the transport gate that decides whether a
  * per-row SDK fetch is addressable, connected-row delegation to
  * `useAssistantAvatar`, per-row manifest-vs-legacy path selection, the
- * host-bridge disk read for local rows, the last-seen cache as the final
- * fallback, and the failure-to-nulls contract. The resolved-assistants store
- * is real; the environment probes, the avatar API, the host bridge, and the
- * IndexedDB cache are mocked at the module boundary.
+ * host-bridge disk read for local rows, the platform id lookup for paired and
+ * local rows, the last-seen cache as the final fallback, and the
+ * failure-to-nulls contract. The resolved-assistants and auth stores are real;
+ * the environment probes, the avatar and assistants APIs, the host bridge, and
+ * the IndexedDB cache are mocked at the module boundary.
  */
 
 import type { ReactNode } from "react";
@@ -16,12 +17,15 @@ import {
   expect,
   mock,
   setSystemTime,
+  spyOn,
   test,
 } from "bun:test";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 
+import type * as AssistantApi from "@/assistant/api";
 import type * as AvatarApi from "@/assistant/avatar-api";
+import type { Assistant } from "@/generated/api";
 import { publish } from "@/lib/event-bus";
 import type * as AvatarLastSeenCache from "@/lib/avatar-last-seen-cache";
 import type { LocalReadAssistantAvatarResult } from "@vellumai/ipc-contract";
@@ -118,6 +122,16 @@ const avatarApiMock: Partial<typeof AvatarApi> = {
 };
 mock.module("@/assistant/avatar-api", () => avatarApiMock);
 
+const listAssistants = mock(
+  async (): Promise<AssistantApi.ListAssistantsResult> => ({
+    ok: true,
+    status: 200,
+    data: [],
+  }),
+);
+const actualApi = await import("@/assistant/api");
+mock.module("@/assistant/api", () => ({ ...actualApi, listAssistants }));
+
 type LastSeenAvatar = AvatarLastSeenCache.LastSeenAvatar;
 const actualLastSeenCache = await import("@/lib/avatar-last-seen-cache");
 const readLastSeenAvatar = mock(async () => null as LastSeenAvatar | null);
@@ -134,6 +148,7 @@ mock.module(
   }),
 );
 
+const { useAuthStore } = await import("@/stores/auth-store");
 const { useResolvedAssistantsStore } =
   await import("@/stores/resolved-assistants-store");
 const { useAssistantIdentityStore } =
@@ -147,6 +162,8 @@ const {
   useChooserRowAvatar,
 } = await import("@/hooks/use-chooser-row-avatar");
 const { avatarQueryKey } = await import("@/hooks/use-assistant-avatar");
+
+const initialAuthState = useAuthStore.getState();
 const { chooserRowAvatarCacheQueryKey } =
   await import("@/lib/persist-last-seen-avatar");
 
@@ -199,6 +216,25 @@ function createWrapper(
   };
 }
 
+/** A signed-in platform account on this device, the state a `vellum login` leaves. */
+function signInToPlatform(): void {
+  useAuthStore.setState({
+    platformSession: "present",
+    user: {
+      kind: "platform",
+      id: "user-1",
+      username: null,
+      email: null,
+      isStaff: false,
+      firstName: "",
+      lastName: "",
+    },
+  });
+}
+
+const apiAssistant = (id: string, avatar_url: string | null): Assistant =>
+  ({ id, avatar_url }) as Assistant;
+
 function sdkCallCount(): number {
   return (
     fetchAvatarState.mock.calls.length +
@@ -239,6 +275,9 @@ afterEach(() => {
   writeLastSeenAvatar.mockReset();
   deleteLastSeenAvatar.mockReset();
   readAssistantAvatarHost.mockReset();
+  listAssistants.mockReset();
+  listAssistants.mockResolvedValue({ ok: true, status: 200, data: [] });
+  useAuthStore.setState(initialAuthState, true);
   readAssistantAvatarHost.mockResolvedValue({ ok: true, avatar: null });
   readLastSeenAvatar.mockResolvedValue(null);
   fetchAvatarState.mockResolvedValue(characterState);
@@ -484,6 +523,162 @@ describe("useChooserRowAvatar", () => {
         expect(result.current.traits).toEqual(traits);
       });
       expect(fetchAvatarState).toHaveBeenCalledWith("other");
+    });
+  });
+
+  describe("platform id lookup", () => {
+    const LOOKUP_URL = "https://cdn.example/avatars/other-synced.png";
+    const pairedRow = (
+      id: string,
+      overrides: Partial<ResolvedAssistant> = {},
+    ) =>
+      platformRow(id, {
+        isPaired: true,
+        isPlatformHosted: false,
+        ...overrides,
+      });
+
+    beforeEach(() => {
+      localClient = true;
+      signInToPlatform();
+      listAssistants.mockResolvedValue({
+        ok: true,
+        status: 200,
+        data: [apiAssistant("other", LOOKUP_URL), apiAssistant("plain", null)],
+      });
+    });
+
+    test.each([
+      ["paired", pairedRow],
+      ["local", localRow],
+    ])("a %s row resolves its thumbnail by id", async (_l, row) => {
+      const setState = spyOn(useResolvedAssistantsStore, "setState");
+      const { result } = renderHook(() => useChooserRowAvatar(row("other")), {
+        wrapper: createWrapper(),
+      });
+      await waitFor(() => {
+        expect(result.current.imageUrl).toBe(LOOKUP_URL);
+      });
+      expect(result.current.traits).toBeNull();
+      await settle();
+      expect(sdkCallCount()).toBe(0);
+      expect(setState).not.toHaveBeenCalled();
+      setState.mockRestore();
+    });
+
+    test("an id the platform does not list falls through to the cache", async () => {
+      readLastSeenAvatar.mockResolvedValue({ kind: "character", traits });
+      const { result } = renderHook(
+        () => useChooserRowAvatar(pairedRow("unlisted")),
+        { wrapper: createWrapper() },
+      );
+      await waitFor(() => {
+        expect(result.current.traits).toEqual(traits);
+      });
+      expect(result.current.imageUrl).toBeNull();
+      expect(listAssistants).toHaveBeenCalledTimes(1);
+    });
+
+    test("a pure platform row never uses the lookup", async () => {
+      const { result } = renderHook(
+        () => useChooserRowAvatar(platformRow("other")),
+        { wrapper: createWrapper() },
+      );
+      await settle();
+      expect(result.current).toMatchObject({ traits: null, imageUrl: null });
+    });
+
+    test("a signed-out device keeps the glyph", async () => {
+      useAuthStore.setState({ platformSession: "absent", user: null });
+      const { result } = renderHook(
+        () => useChooserRowAvatar(pairedRow("other")),
+        { wrapper: createWrapper() },
+      );
+      await settle();
+      expect(result.current).toMatchObject({ traits: null, imageUrl: null });
+      expect(listAssistants).not.toHaveBeenCalled();
+    });
+
+    test("the connected row prefers its live read over the lookup", async () => {
+      const { result } = renderHook(
+        () => useChooserRowAvatar(pairedRow("active")),
+        { wrapper: createWrapper() },
+      );
+      await waitFor(() => {
+        expect(result.current.traits).toEqual(traits);
+      });
+      expect(result.current.imageUrl).toBeNull();
+    });
+
+    test("a host disk read outranks the lookup", async () => {
+      hostAvailable = true;
+      readAssistantAvatarHost.mockResolvedValue({
+        ok: true,
+        avatar: { kind: "character", traits },
+      });
+      const { result } = renderHook(
+        () => useChooserRowAvatar(localRow("other")),
+        { wrapper: createWrapper() },
+      );
+      await waitFor(() => {
+        expect(result.current.traits).toEqual(traits);
+      });
+      expect(result.current.imageUrl).toBeNull();
+    });
+
+    test("a lookup image that fails to load falls back to the cached avatar", async () => {
+      readLastSeenAvatar.mockResolvedValue({ kind: "character", traits });
+      const { result } = renderHook(
+        () => useChooserRowAvatar(pairedRow("other")),
+        { wrapper: createWrapper() },
+      );
+      await waitFor(() => {
+        expect(result.current.imageUrl).toBe(LOOKUP_URL);
+      });
+
+      act(() => result.current.onImageError());
+
+      await waitFor(() => {
+        expect(result.current.traits).toEqual(traits);
+      });
+      expect(result.current.imageUrl).toBeNull();
+    });
+
+    test("a failed lookup URL is tried again on app.resume", async () => {
+      const { result } = renderHook(
+        () => useChooserRowAvatar(pairedRow("other")),
+        { wrapper: createWrapper() },
+      );
+      await waitFor(() => {
+        expect(result.current.imageUrl).toBe(LOOKUP_URL);
+      });
+      act(() => result.current.onImageError());
+      await waitFor(() => {
+        expect(result.current.imageUrl).toBeNull();
+      });
+
+      act(() => publish("app.resume", { signal: "online" }));
+
+      await waitFor(() => {
+        expect(result.current.imageUrl).toBe(LOOKUP_URL);
+      });
+    });
+
+    test("one list call serves every row", async () => {
+      const wrapper = createWrapper();
+      const { result } = renderHook(
+        () => [
+          useChooserRowAvatar(pairedRow("other")),
+          useChooserRowAvatar(pairedRow("plain")),
+          useChooserRowAvatar(localRow("unlisted")),
+        ],
+        { wrapper },
+      );
+      await waitFor(() => {
+        expect(result.current[0]?.imageUrl).toBe(LOOKUP_URL);
+      });
+      await settle();
+      expect(listAssistants).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/clients/web/src/hooks/use-chooser-row-avatar.ts
+++ b/clients/web/src/hooks/use-chooser-row-avatar.ts
@@ -35,6 +35,7 @@ import {
 } from "@/runtime/local-mode-host";
 import {
   type ResolvedAssistant,
+  platformIdFor,
   useResolvedAssistantsStore,
 } from "@/stores/resolved-assistants-store";
 import type { AvatarRead } from "@/types/avatar";
@@ -183,8 +184,8 @@ function canReadRowAvatarViaHost(row: ResolvedAssistant): boolean {
 /**
  * Whether `row` comes from the lockfile, where `avatarUrl` is never set and
  * the platform's thumbnail is only reachable by id through
- * {@link usePlatformAvatarUrls}. Registered assistants share one id on both
- * sides, so the lookup keys straight off `row.id`.
+ * {@link usePlatformAvatarUrls}. Paired rows share one id on both sides; a
+ * local row's platform UUID is `platformAssistantId` (see {@link platformIdFor}).
  */
 function canLookUpRowAvatarByPlatformId(row: ResolvedAssistant): boolean {
   return row.isPaired || row.cloud === "local";
@@ -405,7 +406,7 @@ export function useChooserRowAvatar(
 
   const platformAvatarUrls = usePlatformAvatarUrls();
   const lookupCandidate = canLookUpRowAvatarByPlatformId(assistant)
-    ? (platformAvatarUrls.get(assistant.id) ?? null)
+    ? (platformAvatarUrls.get(platformIdFor(assistant)) ?? null)
     : null;
   const lookupUrl =
     lookupCandidate !== failedPlatformUrl ? lookupCandidate : null;

--- a/clients/web/src/hooks/use-chooser-row-avatar.ts
+++ b/clients/web/src/hooks/use-chooser-row-avatar.ts
@@ -13,6 +13,7 @@ import {
 } from "@/hooks/use-assistant-avatar";
 import { useBusSubscription } from "@/hooks/use-bus-subscription";
 import { useIsOrgReady } from "@/hooks/use-is-org-ready";
+import { usePlatformAvatarUrls } from "@/hooks/use-platform-avatar-urls";
 import { isGatewayAuthEnabled } from "@/lib/auth/gateway-session";
 import {
   deleteLastSeenAvatar,
@@ -42,8 +43,8 @@ const QUERY_KEY_PREFIX = "chooserRowAvatar";
 
 export interface ChooserRowAvatar extends AvatarRead {
   /**
-   * Wire to the rendered image's `onError`. A synced thumbnail that fails to
-   * load (offline, expired signed URL) re-enables the row's other sources.
+   * Wire to the rendered image's `onError`. A platform thumbnail that fails
+   * to load (offline, expired signed URL) re-enables the row's other sources.
    */
   onImageError: () => void;
 }
@@ -179,6 +180,16 @@ function canReadRowAvatarViaHost(row: ResolvedAssistant): boolean {
   return row.cloud === "local" && canReadAvatarFromLocalHost();
 }
 
+/**
+ * Whether `row` comes from the lockfile, where `avatarUrl` is never set and
+ * the platform's thumbnail is only reachable by id through
+ * {@link usePlatformAvatarUrls}. Registered assistants share one id on both
+ * sides, so the lookup keys straight off `row.id`.
+ */
+function canLookUpRowAvatarByPlatformId(row: ResolvedAssistant): boolean {
+  return row.isPaired || row.cloud === "local";
+}
+
 function conclusive(read: AvatarRead): LegacyAvatarRead {
   return { ...read, conclusive: true };
 }
@@ -295,14 +306,18 @@ async function readCachedRowAvatar(assistantId: string): Promise<AvatarRead> {
  *    org store can supply the `Vellum-Organization-Id` header.
  * 4. Local rows (the connected one when unreachable, siblings even asleep)
  *    read their workspace through the host when one can serve it.
- * 5. The last-seen cache: whatever a live source last resolved for this id,
+ * 5. Paired and local rows look their id up in the platform list
+ *    (`usePlatformAvatarUrls`): lockfile rows never carry `avatarUrl`, so
+ *    this is how a logged-in desktop shows a sibling's synced thumbnail.
+ * 6. The last-seen cache: whatever a live source last resolved for this id,
  *    so a row keeps its avatar while the assistant is unreachable.
  * Only live sources (1 and 3) feed the cache, at fetch time (1 does so
  * inside `useAssistantAvatar`); a conclusive none from any source evicts it.
  * Persisting live evidence also drops the row's `avatarUrl`, so 2 never
- * outranks a fresher local read. A synced URL that fails to load
- * (`onImageError`) is set aside so 3 to 5 take over for that row, until
- * the next `app.resume` (network back, window foregrounded) retries it.
+ * outranks a fresher local read. A platform URL (2 or 5) that fails to load
+ * (`onImageError`) is set aside so the sources below it take over for that
+ * row, until the next `app.resume` (network back, window foregrounded)
+ * retries it.
  * Anything else, including every failure, resolves to nulls: the row's glyph
  * fallback is the error state, a chooser row never surfaces an error.
  */
@@ -317,10 +332,12 @@ export function useChooserRowAvatar(
 
   // Keyed by URL so a reload that carries a new thumbnail retries it; a
   // resume retries the same URL, since the failure may have been offline.
-  const [failedSyncedUrl, setFailedSyncedUrl] = useState<string | null>(null);
-  useBusSubscription("app.resume", () => setFailedSyncedUrl(null));
+  const [failedPlatformUrl, setFailedPlatformUrl] = useState<string | null>(
+    null,
+  );
+  useBusSubscription("app.resume", () => setFailedPlatformUrl(null));
   const syncedUrl =
-    assistant.avatarUrl && assistant.avatarUrl !== failedSyncedUrl
+    assistant.avatarUrl && assistant.avatarUrl !== failedPlatformUrl
       ? assistant.avatarUrl
       : null;
   const syncedAvatar: AvatarRead | null = syncedUrl
@@ -386,10 +403,26 @@ export function useChooserRowAvatar(
     hostQuery.data !== undefined &&
     (hostConclusive || !isEmptyAvatar(hostQuery.data));
 
+  const platformAvatarUrls = usePlatformAvatarUrls();
+  const lookupCandidate = canLookUpRowAvatarByPlatformId(assistant)
+    ? (platformAvatarUrls.get(assistant.id) ?? null)
+    : null;
+  const lookupUrl =
+    lookupCandidate !== failedPlatformUrl ? lookupCandidate : null;
+  // Waits out an in-flight host read so a row never flashes the thumbnail
+  // before the disk snapshot replaces it.
+  const showLookup =
+    lookupUrl !== null &&
+    !showLive &&
+    !showSynced &&
+    !showHost &&
+    !hostQuery.isLoading &&
+    (!isConnectedRow || liveSettledEmpty);
+
   const cacheQuery = useQuery<AvatarRead>({
     queryKey: chooserRowAvatarCacheQueryKey(assistant.id),
     queryFn: () => readCachedRowAvatar(assistant.id),
-    enabled: !showLive && !hasSyncedAvatar && !showHost,
+    enabled: !showLive && !hasSyncedAvatar && !showHost && !showLookup,
     staleTime: Infinity,
     structuralSharing: false,
     retry: false,
@@ -397,9 +430,11 @@ export function useChooserRowAvatar(
 
   const onImageError = useCallback(() => {
     if (showSynced) {
-      setFailedSyncedUrl(syncedUrl);
+      setFailedPlatformUrl(syncedUrl);
+    } else if (showLookup) {
+      setFailedPlatformUrl(lookupUrl);
     }
-  }, [showSynced, syncedUrl]);
+  }, [showSynced, syncedUrl, showLookup, lookupUrl]);
 
   const avatar: AvatarRead = showLive
     ? (live ?? EMPTY_AVATAR)
@@ -407,6 +442,8 @@ export function useChooserRowAvatar(
       ? (syncedAvatar ?? EMPTY_AVATAR)
       : showHost
         ? { traits: hostQuery.data.traits, imageUrl: hostQuery.data.imageUrl }
-        : (cacheQuery.data ?? EMPTY_AVATAR);
+        : showLookup
+          ? { traits: null, imageUrl: lookupUrl }
+          : (cacheQuery.data ?? EMPTY_AVATAR);
   return { ...avatar, onImageError };
 }

--- a/clients/web/src/hooks/use-platform-avatar-urls.test.tsx
+++ b/clients/web/src/hooks/use-platform-avatar-urls.test.tsx
@@ -58,6 +58,7 @@ const { useResolvedAssistantsStore } =
   await import("@/stores/resolved-assistants-store");
 const {
   platformAvatarUrlsQueryKey,
+  resetPlatformAvatarUrlSuppressionsForTests,
   suppressPlatformAvatarUrl,
   usePlatformAvatarUrls,
 } = await import("@/hooks/use-platform-avatar-urls");
@@ -105,6 +106,7 @@ beforeEach(() => {
   remoteGatewayMode = false;
   gatewayAuthEnabled = false;
   orgReady = true;
+  resetPlatformAvatarUrlSuppressionsForTests();
   signIn();
   listAssistants.mockResolvedValue({
     ok: true,
@@ -257,6 +259,16 @@ describe("usePlatformAvatarUrls", () => {
 });
 
 describe("suppressPlatformAvatarUrl", () => {
+  function deferredList() {
+    let resolveList!: (value: AssistantApi.ListAssistantsResult) => void;
+    listAssistants.mockReturnValueOnce(
+      new Promise<AssistantApi.ListAssistantsResult>((resolve) => {
+        resolveList = resolve;
+      }),
+    );
+    return (data: Assistant[]) => resolveList({ ok: true, status: 200, data });
+  }
+
   test("drops the id from a cached map", async () => {
     const queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false } },
@@ -268,7 +280,7 @@ describe("suppressPlatformAvatarUrl", () => {
       expect(result.current.get("a")).toBe(WITH_AVATAR);
     });
 
-    await act(() => suppressPlatformAvatarUrl(queryClient, "a"));
+    act(() => suppressPlatformAvatarUrl(queryClient, "a"));
 
     await waitFor(() => {
       expect(result.current.has("a")).toBe(false);
@@ -276,13 +288,8 @@ describe("suppressPlatformAvatarUrl", () => {
     expect(listAssistants).toHaveBeenCalledTimes(1);
   });
 
-  test("a list in flight during suppression cannot land the stale url", async () => {
-    let resolveList!: (value: AssistantApi.ListAssistantsResult) => void;
-    listAssistants.mockReturnValueOnce(
-      new Promise<AssistantApi.ListAssistantsResult>((resolve) => {
-        resolveList = resolve;
-      }),
-    );
+  test("a list in flight during suppression lands its siblings without the stale url", async () => {
+    const resolveList = deferredList();
     const queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false } },
     });
@@ -293,19 +300,40 @@ describe("suppressPlatformAvatarUrl", () => {
       expect(listAssistants).toHaveBeenCalledTimes(1);
     });
 
-    await act(() => suppressPlatformAvatarUrl(queryClient, "a"));
-    resolveList({
-      ok: true,
-      status: 200,
-      data: [apiAssistant("a", WITH_AVATAR)],
-    });
-    await settle();
+    act(() => suppressPlatformAvatarUrl(queryClient, "a"));
+    resolveList([
+      apiAssistant("a", WITH_AVATAR),
+      apiAssistant("sibling", "https://cdn.example/avatars/sibling.png"),
+    ]);
 
+    await waitFor(() => {
+      expect(result.current.get("sibling")).toBe(
+        "https://cdn.example/avatars/sibling.png",
+      );
+    });
     expect(result.current.has("a")).toBe(false);
+    expect(listAssistants).toHaveBeenCalledTimes(1);
     expect(
       queryClient.getQueryState(platformAvatarUrlsQueryKey("user-1", null))
-        ?.fetchStatus,
-    ).toBe("idle");
+        ?.status,
+    ).toBe("success");
+  });
+
+  test("a list started after suppression carries the id again", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const { result } = renderHook(() => usePlatformAvatarUrls(), {
+      wrapper: createWrapper(queryClient),
+    });
+    await waitFor(() => {
+      expect(result.current.get("a")).toBe(WITH_AVATAR);
+    });
+
+    act(() => suppressPlatformAvatarUrl(queryClient, "a"));
+    await waitFor(() => {
+      expect(result.current.has("a")).toBe(false);
+    });
 
     await act(() =>
       queryClient.refetchQueries({ queryKey: ["platformAvatarUrls"] }),

--- a/clients/web/src/hooks/use-platform-avatar-urls.test.tsx
+++ b/clients/web/src/hooks/use-platform-avatar-urls.test.tsx
@@ -53,6 +53,7 @@ const actualApi = await import("@/assistant/api");
 mock.module("@/assistant/api", () => ({ ...actualApi, listAssistants }));
 
 const { useAuthStore } = await import("@/stores/auth-store");
+const { useOrganizationStore } = await import("@/stores/organization-store");
 const { useResolvedAssistantsStore } =
   await import("@/stores/resolved-assistants-store");
 const {
@@ -223,6 +224,23 @@ describe("usePlatformAvatarUrls", () => {
     });
   });
 
+  test("an organization switch gets a fresh list", async () => {
+    const wrapper = createWrapper();
+    const { result } = renderHook(() => usePlatformAvatarUrls(), { wrapper });
+    await waitFor(() => {
+      expect(result.current.get("a")).toBe(WITH_AVATAR);
+    });
+
+    act(() =>
+      useOrganizationStore.setState({ currentOrganizationId: "org-2" }),
+    );
+
+    await waitFor(() => {
+      expect(listAssistants).toHaveBeenCalledTimes(2);
+    });
+    useOrganizationStore.setState({ currentOrganizationId: null });
+  });
+
   test("never writes the resolved-assistants store", async () => {
     const setState = spyOn(useResolvedAssistantsStore, "setState");
     const before = useResolvedAssistantsStore.getState().assistants;
@@ -285,7 +303,7 @@ describe("suppressPlatformAvatarUrl", () => {
 
     expect(result.current.has("a")).toBe(false);
     expect(
-      queryClient.getQueryState(platformAvatarUrlsQueryKey("user-1"))
+      queryClient.getQueryState(platformAvatarUrlsQueryKey("user-1", null))
         ?.fetchStatus,
     ).toBe("idle");
 

--- a/clients/web/src/hooks/use-platform-avatar-urls.test.tsx
+++ b/clients/web/src/hooks/use-platform-avatar-urls.test.tsx
@@ -55,8 +55,11 @@ mock.module("@/assistant/api", () => ({ ...actualApi, listAssistants }));
 const { useAuthStore } = await import("@/stores/auth-store");
 const { useResolvedAssistantsStore } =
   await import("@/stores/resolved-assistants-store");
-const { usePlatformAvatarUrls } =
-  await import("@/hooks/use-platform-avatar-urls");
+const {
+  platformAvatarUrlsQueryKey,
+  suppressPlatformAvatarUrl,
+  usePlatformAvatarUrls,
+} = await import("@/hooks/use-platform-avatar-urls");
 
 const initialAuthState = useAuthStore.getState();
 
@@ -232,5 +235,67 @@ describe("usePlatformAvatarUrls", () => {
     expect(setState).not.toHaveBeenCalled();
     expect(useResolvedAssistantsStore.getState().assistants).toBe(before);
     setState.mockRestore();
+  });
+});
+
+describe("suppressPlatformAvatarUrl", () => {
+  test("drops the id from a cached map", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const { result } = renderHook(() => usePlatformAvatarUrls(), {
+      wrapper: createWrapper(queryClient),
+    });
+    await waitFor(() => {
+      expect(result.current.get("a")).toBe(WITH_AVATAR);
+    });
+
+    await act(() => suppressPlatformAvatarUrl(queryClient, "a"));
+
+    await waitFor(() => {
+      expect(result.current.has("a")).toBe(false);
+    });
+    expect(listAssistants).toHaveBeenCalledTimes(1);
+  });
+
+  test("a list in flight during suppression cannot land the stale url", async () => {
+    let resolveList!: (value: AssistantApi.ListAssistantsResult) => void;
+    listAssistants.mockReturnValueOnce(
+      new Promise<AssistantApi.ListAssistantsResult>((resolve) => {
+        resolveList = resolve;
+      }),
+    );
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const { result } = renderHook(() => usePlatformAvatarUrls(), {
+      wrapper: createWrapper(queryClient),
+    });
+    await waitFor(() => {
+      expect(listAssistants).toHaveBeenCalledTimes(1);
+    });
+
+    await act(() => suppressPlatformAvatarUrl(queryClient, "a"));
+    resolveList({
+      ok: true,
+      status: 200,
+      data: [apiAssistant("a", WITH_AVATAR)],
+    });
+    await settle();
+
+    expect(result.current.has("a")).toBe(false);
+    expect(
+      queryClient.getQueryState(platformAvatarUrlsQueryKey("user-1"))
+        ?.fetchStatus,
+    ).toBe("idle");
+
+    await act(() =>
+      queryClient.refetchQueries({ queryKey: ["platformAvatarUrls"] }),
+    );
+
+    expect(listAssistants).toHaveBeenCalledTimes(2);
+    await waitFor(() => {
+      expect(result.current.get("a")).toBe(WITH_AVATAR);
+    });
   });
 });

--- a/clients/web/src/hooks/use-platform-avatar-urls.test.tsx
+++ b/clients/web/src/hooks/use-platform-avatar-urls.test.tsx
@@ -1,0 +1,236 @@
+/**
+ * Tests for `usePlatformAvatarUrls`: the enable gate (live platform session
+ * in a lockfile-driven mode, org header ready), the id-to-url reduction, the
+ * failure-to-empty-map contract, one list call shared by every consumer, and
+ * the promise never to write the resolved-assistants store. The auth and
+ * resolved stores are real; the environment probes and the assistants API are
+ * mocked at the module boundary.
+ */
+
+import type { ReactNode } from "react";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  spyOn,
+  test,
+} from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+
+import type * as AssistantApi from "@/assistant/api";
+import type { Assistant } from "@/generated/api";
+
+const actualLocalMode = await import("@/lib/local-mode");
+let localClient = false;
+let remoteGatewayMode = false;
+mock.module("@/lib/local-mode", () => ({
+  ...actualLocalMode,
+  isLocalClient: () => localClient,
+  isRemoteGatewayMode: () => remoteGatewayMode,
+}));
+
+let gatewayAuthEnabled = false;
+mock.module("@/lib/auth/gateway-session", () => ({
+  isGatewayAuthEnabled: () => gatewayAuthEnabled,
+}));
+
+let orgReady = true;
+mock.module("@/hooks/use-is-org-ready", () => ({
+  useIsOrgReady: () => orgReady,
+}));
+
+const listAssistants = mock(
+  async (): Promise<AssistantApi.ListAssistantsResult> => ({
+    ok: true,
+    status: 200,
+    data: [],
+  }),
+);
+const actualApi = await import("@/assistant/api");
+mock.module("@/assistant/api", () => ({ ...actualApi, listAssistants }));
+
+const { useAuthStore } = await import("@/stores/auth-store");
+const { useResolvedAssistantsStore } =
+  await import("@/stores/resolved-assistants-store");
+const { usePlatformAvatarUrls } =
+  await import("@/hooks/use-platform-avatar-urls");
+
+const initialAuthState = useAuthStore.getState();
+
+const apiAssistant = (id: string, avatar_url: string | null): Assistant =>
+  ({ id, avatar_url }) as Assistant;
+
+const WITH_AVATAR = "https://cdn.example/avatars/a.png";
+
+function createWrapper(
+  queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  }),
+) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+async function settle(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 20));
+}
+
+function signIn(userId = "user-1"): void {
+  useAuthStore.setState({
+    platformSession: "present",
+    user: {
+      kind: "platform",
+      id: userId,
+      username: null,
+      email: null,
+      isStaff: false,
+      firstName: "",
+      lastName: "",
+    },
+  });
+}
+
+beforeEach(() => {
+  localClient = true;
+  remoteGatewayMode = false;
+  gatewayAuthEnabled = false;
+  orgReady = true;
+  signIn();
+  listAssistants.mockResolvedValue({
+    ok: true,
+    status: 200,
+    data: [
+      apiAssistant("a", WITH_AVATAR),
+      apiAssistant("b", null),
+      apiAssistant("c", ""),
+    ],
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  listAssistants.mockReset();
+  useAuthStore.setState(initialAuthState, true);
+});
+
+describe("usePlatformAvatarUrls", () => {
+  test.each([
+    ["local client", () => (localClient = true)],
+    [
+      "remote-gateway mode",
+      () => {
+        localClient = false;
+        remoteGatewayMode = true;
+      },
+    ],
+  ])("maps id to a non-empty avatar_url under %s", async (_l, arrange) => {
+    arrange();
+    const { result } = renderHook(() => usePlatformAvatarUrls(), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => {
+      expect(result.current.get("a")).toBe(WITH_AVATAR);
+    });
+    expect(result.current.has("b")).toBe(false);
+    expect(result.current.has("c")).toBe(false);
+    expect(listAssistants).toHaveBeenCalledTimes(1);
+  });
+
+  test.each([
+    [
+      "no live platform session",
+      () => useAuthStore.setState({ platformSession: "absent", user: null }),
+    ],
+    [
+      "an unsettled platform session",
+      () => useAuthStore.setState({ platformSession: "unknown" }),
+    ],
+    ["pure cloud mode", () => (localClient = false)],
+    ["gateway auth", () => (gatewayAuthEnabled = true)],
+    ["an unready org header", () => (orgReady = false)],
+  ])("stays idle with %s", async (_l, arrange) => {
+    arrange();
+    const { result } = renderHook(() => usePlatformAvatarUrls(), {
+      wrapper: createWrapper(),
+    });
+    await settle();
+    expect(result.current.size).toBe(0);
+    expect(listAssistants).not.toHaveBeenCalled();
+  });
+
+  test("a rejected list resolves to an empty map", async () => {
+    listAssistants.mockRejectedValue(new Error("offline"));
+    const { result } = renderHook(() => usePlatformAvatarUrls(), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => {
+      expect(listAssistants).toHaveBeenCalledTimes(1);
+    });
+    await settle();
+    expect(result.current.size).toBe(0);
+  });
+
+  test("a non-ok list resolves to an empty map", async () => {
+    listAssistants.mockResolvedValue({ ok: false, status: 500, error: {} });
+    const { result } = renderHook(() => usePlatformAvatarUrls(), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => {
+      expect(listAssistants).toHaveBeenCalledTimes(1);
+    });
+    await settle();
+    expect(result.current.size).toBe(0);
+  });
+
+  test("one list call serves every consumer in a stale window", async () => {
+    const wrapper = createWrapper();
+    const { result } = renderHook(
+      () => [
+        usePlatformAvatarUrls(),
+        usePlatformAvatarUrls(),
+        usePlatformAvatarUrls(),
+      ],
+      { wrapper },
+    );
+    await waitFor(() => {
+      expect(result.current[0]?.get("a")).toBe(WITH_AVATAR);
+    });
+    renderHook(() => usePlatformAvatarUrls(), { wrapper });
+    await settle();
+    expect(listAssistants).toHaveBeenCalledTimes(1);
+  });
+
+  test("a different user gets a fresh list", async () => {
+    const wrapper = createWrapper();
+    const { result } = renderHook(() => usePlatformAvatarUrls(), { wrapper });
+    await waitFor(() => {
+      expect(result.current.get("a")).toBe(WITH_AVATAR);
+    });
+
+    act(() => signIn("user-2"));
+
+    await waitFor(() => {
+      expect(listAssistants).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  test("never writes the resolved-assistants store", async () => {
+    const setState = spyOn(useResolvedAssistantsStore, "setState");
+    const before = useResolvedAssistantsStore.getState().assistants;
+    const { result } = renderHook(() => usePlatformAvatarUrls(), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => {
+      expect(result.current.get("a")).toBe(WITH_AVATAR);
+    });
+    expect(setState).not.toHaveBeenCalled();
+    expect(useResolvedAssistantsStore.getState().assistants).toBe(before);
+    setState.mockRestore();
+  });
+});

--- a/clients/web/src/hooks/use-platform-avatar-urls.ts
+++ b/clients/web/src/hooks/use-platform-avatar-urls.ts
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
+import { type QueryClient, useQuery } from "@tanstack/react-query";
 
 import { listAssistants } from "@/assistant/api";
 import { useIsOrgReady } from "@/hooks/use-is-org-ready";
@@ -16,6 +16,31 @@ export const PLATFORM_AVATAR_URLS_STALE_TIME_MS = 60_000;
 /** Keyed by user so a sign-out never serves another account's thumbnails. */
 export function platformAvatarUrlsQueryKey(userId: string | null) {
   return ["platformAvatarUrls", userId] as const;
+}
+
+const PLATFORM_AVATAR_URLS_KEY_PREFIX = ["platformAvatarUrls"] as const;
+
+/**
+ * Drops one id from every cached map without refetching. Mirrors the store's
+ * `clearAvatarUrl`: live evidence outranks a URL observed earlier, and the
+ * platform copy lags the daemon's async sync, so an immediate refetch would
+ * only re-serve the stale URL. The next stale-window refetch restores it.
+ */
+export function suppressPlatformAvatarUrl(
+  queryClient: QueryClient,
+  assistantId: string,
+): void {
+  queryClient.setQueriesData<PlatformAvatarUrls>(
+    { queryKey: PLATFORM_AVATAR_URLS_KEY_PREFIX },
+    (urls) => {
+      if (!urls?.has(assistantId)) {
+        return urls;
+      }
+      const next = new Map(urls);
+      next.delete(assistantId);
+      return next;
+    },
+  );
 }
 
 /**

--- a/clients/web/src/hooks/use-platform-avatar-urls.ts
+++ b/clients/web/src/hooks/use-platform-avatar-urls.ts
@@ -5,6 +5,7 @@ import { useIsOrgReady } from "@/hooks/use-is-org-ready";
 import { isGatewayAuthEnabled } from "@/lib/auth/gateway-session";
 import { isLocalClient, isRemoteGatewayMode } from "@/lib/local-mode";
 import { useAuthStore, useHasPlatformSession } from "@/stores/auth-store";
+import { useRequestOrganizationId } from "@/stores/organization-store";
 
 export type PlatformAvatarUrls = ReadonlyMap<string, string>;
 
@@ -13,9 +14,15 @@ const EMPTY_AVATAR_URLS: PlatformAvatarUrls = new Map();
 /** Matches the row-level avatar clocks so a re-synced thumbnail shows within a minute. */
 export const PLATFORM_AVATAR_URLS_STALE_TIME_MS = 60_000;
 
-/** Keyed by user so a sign-out never serves another account's thumbnails. */
-export function platformAvatarUrlsQueryKey(userId: string | null) {
-  return ["platformAvatarUrls", userId] as const;
+/**
+ * Keyed by user and organization: a sign-out never serves another account's
+ * thumbnails, and an org switch rescopes the list with the request header.
+ */
+export function platformAvatarUrlsQueryKey(
+  userId: string | null,
+  organizationId: string | null,
+) {
+  return ["platformAvatarUrls", userId, organizationId] as const;
 }
 
 const PLATFORM_AVATAR_URLS_KEY_PREFIX = ["platformAvatarUrls"] as const;
@@ -98,8 +105,9 @@ export function usePlatformAvatarUrls(): PlatformAvatarUrls {
   const hasPlatformSession = useHasPlatformSession();
   const userId = useAuthStore.use.user()?.id ?? null;
   const isOrgReady = useIsOrgReady();
+  const organizationId = useRequestOrganizationId();
   const query = useQuery<PlatformAvatarUrls>({
-    queryKey: platformAvatarUrlsQueryKey(userId),
+    queryKey: platformAvatarUrlsQueryKey(userId, organizationId),
     queryFn: fetchPlatformAvatarUrls,
     enabled: hasPlatformSession && isOrgReady && isLockfileDrivenStore(),
     staleTime: PLATFORM_AVATAR_URLS_STALE_TIME_MS,

--- a/clients/web/src/hooks/use-platform-avatar-urls.ts
+++ b/clients/web/src/hooks/use-platform-avatar-urls.ts
@@ -28,37 +28,40 @@ export function platformAvatarUrlsQueryKey(
 const PLATFORM_AVATAR_URLS_KEY_PREFIX = ["platformAvatarUrls"] as const;
 
 /**
- * Drops one id from every cached map without refetching. Mirrors the store's
- * `clearAvatarUrl`: live evidence outranks a URL observed earlier, and the
- * platform copy lags the daemon's async sync, so an immediate refetch would
- * only re-serve the stale URL. The next stale-window refetch restores it.
- * Also cancels an in-flight list so a response started before the change
- * cannot land the stale URL afterwards; the scrub runs again once the cancel
- * settles for a response that raced in first.
+ * Per-id tombstones stamped with the fetch generation current at suppression.
+ * A list fetch that started at or before the stamp omits the id when it
+ * lands; one that started after it is fresher than the suppression and
+ * carries the id again, clearing the tombstone.
  */
-export async function suppressPlatformAvatarUrl(
-  queryClient: QueryClient,
-  assistantId: string,
-): Promise<void> {
-  dropPlatformAvatarUrl(queryClient, assistantId);
-  await queryClient.cancelQueries({
-    queryKey: PLATFORM_AVATAR_URLS_KEY_PREFIX,
-  });
-  dropPlatformAvatarUrl(queryClient, assistantId);
+const suppressedPlatformIds = new Map<string, number>();
+let fetchGeneration = 0;
+
+export function resetPlatformAvatarUrlSuppressionsForTests(): void {
+  suppressedPlatformIds.clear();
+  fetchGeneration = 0;
 }
 
-function dropPlatformAvatarUrl(
+/**
+ * Drops one platform id from every cached map without refetching. Mirrors
+ * the store's `clearAvatarUrl`: live evidence outranks a URL observed
+ * earlier, and the platform copy lags the daemon's async sync, so an
+ * immediate refetch would only re-serve the stale URL. The next stale-window
+ * refetch restores it. A list in flight keeps its siblings and lands without
+ * this id (see the tombstones above); nothing is cancelled.
+ */
+export function suppressPlatformAvatarUrl(
   queryClient: QueryClient,
-  assistantId: string,
+  platformAssistantId: string,
 ): void {
+  suppressedPlatformIds.set(platformAssistantId, fetchGeneration);
   queryClient.setQueriesData<PlatformAvatarUrls>(
     { queryKey: PLATFORM_AVATAR_URLS_KEY_PREFIX },
     (urls) => {
-      if (!urls?.has(assistantId)) {
+      if (!urls?.has(platformAssistantId)) {
         return urls;
       }
       const next = new Map(urls);
-      next.delete(assistantId);
+      next.delete(platformAssistantId);
       return next;
     },
   );
@@ -75,6 +78,7 @@ function isLockfileDrivenStore(): boolean {
 
 /** Never throws: a chooser row falls back to its other sources, not an error. */
 async function fetchPlatformAvatarUrls(): Promise<PlatformAvatarUrls> {
+  const startGeneration = ++fetchGeneration;
   try {
     const result = await listAssistants();
     if (!result.ok) {
@@ -82,7 +86,10 @@ async function fetchPlatformAvatarUrls(): Promise<PlatformAvatarUrls> {
     }
     const urls = new Map<string, string>();
     for (const assistant of result.data) {
-      if (assistant.avatar_url) {
+      if (
+        assistant.avatar_url &&
+        !isSuppressed(assistant.id, startGeneration)
+      ) {
         urls.set(assistant.id, assistant.avatar_url);
       }
     }
@@ -90,6 +97,19 @@ async function fetchPlatformAvatarUrls(): Promise<PlatformAvatarUrls> {
   } catch {
     return EMPTY_AVATAR_URLS;
   }
+}
+
+/** Suppressed during or after this fetch; an older tombstone is stale and dropped. */
+function isSuppressed(platformAssistantId: string, startGeneration: number) {
+  const suppressedAt = suppressedPlatformIds.get(platformAssistantId);
+  if (suppressedAt === undefined) {
+    return false;
+  }
+  if (suppressedAt >= startGeneration) {
+    return true;
+  }
+  suppressedPlatformIds.delete(platformAssistantId);
+  return false;
 }
 
 /**

--- a/clients/web/src/hooks/use-platform-avatar-urls.ts
+++ b/clients/web/src/hooks/use-platform-avatar-urls.ts
@@ -1,0 +1,70 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { listAssistants } from "@/assistant/api";
+import { useIsOrgReady } from "@/hooks/use-is-org-ready";
+import { isGatewayAuthEnabled } from "@/lib/auth/gateway-session";
+import { isLocalClient, isRemoteGatewayMode } from "@/lib/local-mode";
+import { useAuthStore, useHasPlatformSession } from "@/stores/auth-store";
+
+export type PlatformAvatarUrls = ReadonlyMap<string, string>;
+
+const EMPTY_AVATAR_URLS: PlatformAvatarUrls = new Map();
+
+/** Matches the row-level avatar clocks so a re-synced thumbnail shows within a minute. */
+export const PLATFORM_AVATAR_URLS_STALE_TIME_MS = 60_000;
+
+/** Keyed by user so a sign-out never serves another account's thumbnails. */
+export function platformAvatarUrlsQueryKey(userId: string | null) {
+  return ["platformAvatarUrls", userId] as const;
+}
+
+/**
+ * Modes where the resolved store is lockfile-driven, so its rows never carry
+ * `avatarUrl` and the platform list is only reachable through a side query.
+ * Gateway auth has no platform list at all.
+ */
+function isLockfileDrivenStore(): boolean {
+  return (isLocalClient() || isRemoteGatewayMode()) && !isGatewayAuthEnabled();
+}
+
+/** Never throws: a chooser row falls back to its other sources, not an error. */
+async function fetchPlatformAvatarUrls(): Promise<PlatformAvatarUrls> {
+  try {
+    const result = await listAssistants();
+    if (!result.ok) {
+      return EMPTY_AVATAR_URLS;
+    }
+    const urls = new Map<string, string>();
+    for (const assistant of result.data) {
+      if (assistant.avatar_url) {
+        urls.set(assistant.id, assistant.avatar_url);
+      }
+    }
+    return urls;
+  } catch {
+    return EMPTY_AVATAR_URLS;
+  }
+}
+
+/**
+ * Platform `avatar_url` by assistant id, read-only. One shared query feeds
+ * every chooser row, so the list is fetched once per stale window however
+ * many rows mount. Enabled only when a live platform session exists in a
+ * lockfile-driven mode; elsewhere the resolved store already carries
+ * `avatarUrl` and this resolves to an empty map. Never writes the resolved
+ * store: `reloadPlatformAssistants` deliberately skips these modes so the
+ * API list cannot clobber lockfile rows, and this lookup keeps that contract.
+ */
+export function usePlatformAvatarUrls(): PlatformAvatarUrls {
+  const hasPlatformSession = useHasPlatformSession();
+  const userId = useAuthStore.use.user()?.id ?? null;
+  const isOrgReady = useIsOrgReady();
+  const query = useQuery<PlatformAvatarUrls>({
+    queryKey: platformAvatarUrlsQueryKey(userId),
+    queryFn: fetchPlatformAvatarUrls,
+    enabled: hasPlatformSession && isOrgReady && isLockfileDrivenStore(),
+    staleTime: PLATFORM_AVATAR_URLS_STALE_TIME_MS,
+    retry: false,
+  });
+  return query.data ?? EMPTY_AVATAR_URLS;
+}

--- a/clients/web/src/hooks/use-platform-avatar-urls.ts
+++ b/clients/web/src/hooks/use-platform-avatar-urls.ts
@@ -25,8 +25,22 @@ const PLATFORM_AVATAR_URLS_KEY_PREFIX = ["platformAvatarUrls"] as const;
  * `clearAvatarUrl`: live evidence outranks a URL observed earlier, and the
  * platform copy lags the daemon's async sync, so an immediate refetch would
  * only re-serve the stale URL. The next stale-window refetch restores it.
+ * Also cancels an in-flight list so a response started before the change
+ * cannot land the stale URL afterwards; the scrub runs again once the cancel
+ * settles for a response that raced in first.
  */
-export function suppressPlatformAvatarUrl(
+export async function suppressPlatformAvatarUrl(
+  queryClient: QueryClient,
+  assistantId: string,
+): Promise<void> {
+  dropPlatformAvatarUrl(queryClient, assistantId);
+  await queryClient.cancelQueries({
+    queryKey: PLATFORM_AVATAR_URLS_KEY_PREFIX,
+  });
+  dropPlatformAvatarUrl(queryClient, assistantId);
+}
+
+function dropPlatformAvatarUrl(
   queryClient: QueryClient,
   assistantId: string,
 ): void {

--- a/clients/web/src/lib/persist-last-seen-avatar.ts
+++ b/clients/web/src/lib/persist-last-seen-avatar.ts
@@ -57,7 +57,7 @@ export async function persistLastSeenAvatar(
     return;
   }
   useResolvedAssistantsStore.getState().clearAvatarUrl(assistantId);
-  suppressPlatformAvatarUrl(queryClient, assistantId);
+  void suppressPlatformAvatarUrl(queryClient, assistantId);
   void queryClient.invalidateQueries({
     queryKey: chooserRowAvatarCacheQueryKey(assistantId),
   });

--- a/clients/web/src/lib/persist-last-seen-avatar.ts
+++ b/clients/web/src/lib/persist-last-seen-avatar.ts
@@ -6,7 +6,10 @@ import {
   lastSeenAvatarGenerations,
   writeLastSeenAvatar,
 } from "@/lib/avatar-last-seen-cache";
-import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+import {
+  resolvePlatformAssistantId,
+  useResolvedAssistantsStore,
+} from "@/stores/resolved-assistants-store";
 import type { AvatarRead } from "@/types/avatar";
 
 /** The chooser's query over the last-seen cache; invalidated after every persist. */
@@ -57,7 +60,10 @@ export async function persistLastSeenAvatar(
     return;
   }
   useResolvedAssistantsStore.getState().clearAvatarUrl(assistantId);
-  void suppressPlatformAvatarUrl(queryClient, assistantId);
+  suppressPlatformAvatarUrl(
+    queryClient,
+    resolvePlatformAssistantId(assistantId),
+  );
   void queryClient.invalidateQueries({
     queryKey: chooserRowAvatarCacheQueryKey(assistantId),
   });

--- a/clients/web/src/lib/persist-last-seen-avatar.ts
+++ b/clients/web/src/lib/persist-last-seen-avatar.ts
@@ -1,5 +1,6 @@
 import type { QueryClient } from "@tanstack/react-query";
 
+import { suppressPlatformAvatarUrl } from "@/hooks/use-platform-avatar-urls";
 import {
   deleteLastSeenAvatar,
   lastSeenAvatarGenerations,
@@ -21,9 +22,9 @@ export function chooserRowAvatarCacheQueryKey(assistantId: string) {
  * up front so a blob read that resolves after a newer write or delete
  * (including a retire) commits nothing. Invalidates the chooser's cache query
  * once committed so a row that falls back later reads the fresh entry, and
- * drops the row's synced `avatarUrl`: live evidence outranks a thumbnail
- * observed earlier, so the cache path wins until the next list load carries
- * a newer URL. Best-effort like the cache: never throws.
+ * drops the row's synced `avatarUrl` and platform lookup entry: live evidence
+ * outranks a thumbnail observed earlier, so the cache path wins until the
+ * next list load carries a newer URL. Best-effort like the cache: never throws.
  */
 export async function persistLastSeenAvatar(
   queryClient: QueryClient,
@@ -56,6 +57,7 @@ export async function persistLastSeenAvatar(
     return;
   }
   useResolvedAssistantsStore.getState().clearAvatarUrl(assistantId);
+  suppressPlatformAvatarUrl(queryClient, assistantId);
   void queryClient.invalidateQueries({
     queryKey: chooserRowAvatarCacheQueryKey(assistantId),
   });

--- a/clients/web/src/stores/resolved-assistants-store.test.ts
+++ b/clients/web/src/stores/resolved-assistants-store.test.ts
@@ -136,6 +136,20 @@ describe("setFromLockfile", () => {
     expect(entry.isActiveLockfileAssistant).toBe(true);
   });
 
+  it("copies platformAssistantId for local entries", () => {
+    useResolvedAssistantsStore.getState().setFromLockfile({
+      assistants: [
+        { ...localAssistant, platformAssistantId: "uuid-local" },
+        platformAssistant,
+      ],
+      activeAssistant: "asst-local",
+    });
+
+    const [local, platform] = useResolvedAssistantsStore.getState().assistants;
+    expect(local.platformAssistantId).toBe("uuid-local");
+    expect(platform.platformAssistantId).toBeUndefined();
+  });
+
   it("marks local entries inactive when the lockfile active pointer differs", () => {
     const lockfile: Lockfile = {
       assistants: [localAssistant, otherLocalAssistant],

--- a/clients/web/src/stores/resolved-assistants-store.ts
+++ b/clients/web/src/stores/resolved-assistants-store.ts
@@ -66,6 +66,22 @@ export interface ResolvedAssistant {
   /** Owning org for platform entries; only the lockfile carries it, so
    *  API-sourced entries leave this undefined. */
   organizationId?: string;
+  /** Platform UUID for a locally hatched entry whose `id` is the instance
+   *  name; only the lockfile carries it. API rows are already keyed by UUID. */
+  platformAssistantId?: string;
+}
+
+/** The id the platform knows `a` by: the lockfile's registration for a local instance, else `a.id`. */
+export function platformIdFor(a: ResolvedAssistant): string {
+  return a.platformAssistantId ?? a.id;
+}
+
+/** {@link platformIdFor} by row id; an id not in the store is its own platform id. */
+export function resolvePlatformAssistantId(assistantId: string): string {
+  const row = useResolvedAssistantsStoreBase
+    .getState()
+    .assistants.find((a) => a.id === assistantId);
+  return row ? platformIdFor(row) : assistantId;
 }
 
 /**
@@ -168,6 +184,7 @@ const useResolvedAssistantsStoreBase = create<ResolvedAssistantsStore>(
         isPaired: isPairedAssistant(a),
         runtimeUrl: a.runtimeUrl,
         organizationId: a.organizationId,
+        platformAssistantId: a.platformAssistantId,
       }));
       set({ assistants, assistantsHydrated: true });
       // The lockfile carries every org's entries, so an id absent from it is
@@ -197,6 +214,7 @@ const useResolvedAssistantsStoreBase = create<ResolvedAssistantsStore>(
               cloud: lockfileFields.cloud,
               runtimeVersion: lockfileFields.runtimeVersion,
               runtimeUrl: lockfileFields.runtimeUrl,
+              platformAssistantId: lockfileFields.platformAssistantId,
               ingressUrl: a.ingress_url,
               avatarUrl: a.avatar_url,
               currentReleaseVersion: a.current_release_version,
@@ -241,6 +259,8 @@ const useResolvedAssistantsStoreBase = create<ResolvedAssistantsStore>(
             runtimeVersion:
               lockfileFields.runtimeVersion ?? prior.runtimeVersion,
             runtimeUrl: lockfileFields.runtimeUrl ?? prior.runtimeUrl,
+            platformAssistantId:
+              lockfileFields.platformAssistantId ?? prior.platformAssistantId,
             isActiveLockfileAssistant:
               lockfileFields.isActiveLockfileAssistant ??
               prior.isActiveLockfileAssistant,
@@ -258,6 +278,7 @@ const useResolvedAssistantsStoreBase = create<ResolvedAssistantsStore>(
               organizationId: lockfileFields.organizationId,
               runtimeVersion: lockfileFields.runtimeVersion,
               runtimeUrl: lockfileFields.runtimeUrl,
+              platformAssistantId: lockfileFields.platformAssistantId,
               isActiveLockfileAssistant:
                 lockfileFields.isActiveLockfileAssistant,
             },
@@ -351,6 +372,7 @@ function getLockfileFields(assistantId: string): {
   organizationId?: string;
   runtimeVersion?: string;
   runtimeUrl?: string;
+  platformAssistantId?: string;
   isPaired?: boolean;
   isActiveLockfileAssistant?: boolean;
 } {
@@ -364,6 +386,7 @@ function getLockfileFields(assistantId: string): {
     organizationId: entry?.organizationId,
     runtimeVersion: entry?.resources?.runtimeVersion,
     runtimeUrl: entry?.runtimeUrl,
+    platformAssistantId: entry?.platformAssistantId,
     isPaired: entry ? isPairedAssistant(entry) : undefined,
     isActiveLockfileAssistant: lockfile
       ? activeLockfileAssistantId === assistantId


### PR DESCRIPTION
## Summary
- Adds `usePlatformAvatarUrls`, a read-only React Query (`["platformAvatarUrls", userId]`, 60 s stale) that calls `listAssistants()` once per stale window and reduces it to a `Map<id, avatar_url>`. Enabled only with a live platform session in a lockfile-driven mode (local client or remote gateway, never gateway auth) once the org header is ready. Any failure resolves to an empty map; the resolved-assistants store is never written.
- `useChooserRowAvatar` uses the map for paired and `cloud: "local"` rows, ranked after the host disk read and before the last-seen cache. A lookup URL that fails to load is set aside like a synced `avatarUrl` (shared failed-URL state, cleared on `app.resume`), so the cache takes over instead of a broken image.
- Tests: new `use-platform-avatar-urls.test.tsx` (enable gate per mode/session/org, id reduction, rejected and non-ok lists, one call across consumers, per-user re-key, store-write spy) and a `platform id lookup` block in `use-chooser-row-avatar.test.tsx` (paired/local rows resolve, unlisted id falls through, pure platform row and signed-out device skip it, live read and host read outrank it, image-error fallback and resume retry, one list call across rows).

Part of plan: chooser-assistant-avatars.md (PR 10 of 11); builds on #41538