### PR TITLE
feat(companion): float the avatar beside the options pill

### DIFF
--- a/clients/macos/src/main/companion-window.test.ts
+++ b/clients/macos/src/main/companion-window.test.ts
@@ -243,9 +243,10 @@ const DROP_BELOW = GEOMETRY.dropBelow;
 // cases readable.
 const DISPLAY = { x: 0, width: 1440 };
 
-// The clearance the pill needs beyond the avatar's edge on the side it grows
-// into: the gap, then the widest body.
-const NEEDED = GEOMETRY.gap + GEOMETRY.maxBodyWidth;
+// The clearance the pill needs on the side it grows into, measured from the
+// avatar's centre the way the room on each side is: the avatar's half box, the
+// gap, then the widest body.
+const NEEDED = GEOMETRY.maxReach;
 
 describe("growthFor", () => {
   test("grows rightward with room to the right", () => {
@@ -272,15 +273,31 @@ describe("growthFor", () => {
   });
 
   /**
-   * The gap is part of the clearance, not slack the pill can be squeezed into.
-   * A test measured against the body alone would pass with the pill's leading
-   * edge already off the display.
+   * The gap and the avatar's half box are part of the clearance, not slack the
+   * pill can be squeezed into. A test measured against the body alone would
+   * pass with the pill's leading edge already off the display.
    */
-  test("counts the gap as room the pill needs", () => {
-    expect(NEEDED).toBe(GEOMETRY.maxBodyWidth + GEOMETRY.gap);
+  test("counts the gap and the half box as room the pill needs", () => {
+    expect(NEEDED).toBe(
+      GEOMETRY.avatarBox / 2 + GEOMETRY.gap + GEOMETRY.maxBodyWidth,
+    );
     expect(
       growthFor(DISPLAY.width - GEOMETRY.maxBodyWidth, DISPLAY, GEOMETRY),
     ).toBe("left");
+  });
+
+  /**
+   * The room is measured from the avatar's centre while the pill starts at the
+   * avatar's edge, so the half box is the difference between fitting and
+   * clipping. 340pt on the right clears the gap and the widest body and still
+   * cuts the controls off.
+   */
+  test("flips when only the avatar's half box is missing on the right", () => {
+    const centre = DISPLAY.width - 340;
+    expect(DISPLAY.width - centre).toBeGreaterThan(
+      GEOMETRY.gap + GEOMETRY.maxBodyWidth,
+    );
+    expect(growthFor(centre, DISPLAY, GEOMETRY)).toBe("left");
   });
 
   test("measures against the display's own origin, not the screen's", () => {
@@ -567,6 +584,7 @@ describe("geometryFor", () => {
     expect(small.avatarBox).toBe(44);
     expect(small.canvasWidth).toBe(748);
     expect(small.canvasHeight).toBe(338);
+    expect(small.maxReach).toBe(350);
   });
 
   /**
@@ -580,14 +598,11 @@ describe("geometryFor", () => {
       const pad =
         (COMPANION_BASE_CANVAS_PAD * geometry.avatarBox) /
         COMPANION_BASE_AVATAR_BOX;
+      expect(geometry.maxReach).toBe(
+        geometry.avatarBox / 2 + geometry.gap + geometry.maxBodyWidth,
+      );
       expect(geometry.canvasWidth).toBe(
-        Math.round(
-          2 *
-            (geometry.avatarBox / 2 +
-              geometry.gap +
-              geometry.maxBodyWidth +
-              pad),
-        ),
+        Math.round(2 * (geometry.maxReach + pad)),
       );
     }
   });
@@ -617,6 +632,7 @@ describe("geometryFor", () => {
     expect(large.dropBelow).toBe(small.dropBelow * scale);
     expect(large.gap).toBe(small.gap * scale);
     expect(large.maxBodyWidth).toBe(small.maxBodyWidth * scale);
+    expect(large.maxReach).toBe(small.maxReach * scale);
   });
 
   test("grows monotonically through the named steps", () => {

--- a/clients/macos/src/main/companion-window.test.ts
+++ b/clients/macos/src/main/companion-window.test.ts
@@ -1,7 +1,10 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 import {
+  COMPANION_BASE_AVATAR_BOX,
+  COMPANION_BASE_CANVAS_PAD,
   COMPANION_SIZES,
+  companionGapFor,
   type CompanionSurfaceState,
   type VellumCommand,
 } from "@vellumai/ipc-contract";
@@ -220,6 +223,16 @@ const START = {
 } as const;
 
 /**
+ * The size the placement cases are written against, which is the one the
+ * renderer's layout is authored at. Every other size is the same arithmetic
+ * scaled, which `geometryFor` has its own cases for.
+ */
+const GEOMETRY = geometryFor("small");
+const CANVAS_WIDTH = GEOMETRY.canvasWidth;
+const RISE_ABOVE = GEOMETRY.riseAbove;
+const DROP_BELOW = GEOMETRY.dropBelow;
+
+/**
  * The growth direction is the only rule in the companion window worth testing
  * without a window server: everything else is Electron plumbing. It decides
  * which way the pill unfurls out of the avatar, and getting it wrong runs the
@@ -230,8 +243,9 @@ const START = {
 // cases readable.
 const DISPLAY = { x: 0, width: 1440 };
 
-// 360 - 44: the clearance the body needs on the side it grows into.
-const NEEDED = 316;
+// The clearance the pill needs beyond the avatar's edge on the side it grows
+// into: the gap, then the widest body.
+const NEEDED = GEOMETRY.gap + GEOMETRY.maxBodyWidth;
 
 describe("growthFor", () => {
   test("grows rightward with room to the right", () => {
@@ -255,6 +269,18 @@ describe("growthFor", () => {
     expect(growthFor(DISPLAY.width - NEEDED + 1, DISPLAY, GEOMETRY)).toBe(
       "left",
     );
+  });
+
+  /**
+   * The gap is part of the clearance, not slack the pill can be squeezed into.
+   * A test measured against the body alone would pass with the pill's leading
+   * edge already off the display.
+   */
+  test("counts the gap as room the pill needs", () => {
+    expect(NEEDED).toBe(GEOMETRY.maxBodyWidth + GEOMETRY.gap);
+    expect(
+      growthFor(DISPLAY.width - GEOMETRY.maxBodyWidth, DISPLAY, GEOMETRY),
+    ).toBe("left");
   });
 
   test("measures against the display's own origin, not the screen's", () => {
@@ -284,16 +310,6 @@ describe("growthFor", () => {
  * somewhere the user can reach. A surface pushed off the display cannot be
  * dragged back, because there is nothing left on screen to grab.
  */
-
-/**
- * The size the placement cases are written against, which is the one the
- * renderer's layout is authored at. Every other size is the same arithmetic
- * scaled, which `geometryFor` has its own cases for.
- */
-const GEOMETRY = geometryFor("small");
-const CANVAS_WIDTH = GEOMETRY.canvasWidth;
-const RISE_ABOVE = GEOMETRY.riseAbove;
-const DROP_BELOW = GEOMETRY.dropBelow;
 
 /** A 1440x900 display with the menu bar taken off the top. */
 const WORK_AREA = { x: 0, y: 25, width: 1440, height: 875 };
@@ -549,8 +565,40 @@ describe("geometryFor", () => {
   test("draws `small` at the size the renderer's layout is authored at", () => {
     const small = geometryFor("small");
     expect(small.avatarBox).toBe(44);
-    expect(small.canvasWidth).toBe(724);
+    expect(small.canvasWidth).toBe(748);
     expect(small.canvasHeight).toBe(338);
+  });
+
+  /**
+   * What the width is actually for: the avatar's half box, the gap the pill
+   * hangs off it by, and the widest body, on both sides so main can flip the
+   * direction without resizing the window, plus the shadow's room.
+   */
+  test("holds the pill's whole reach on both sides of the avatar", () => {
+    for (const size of COMPANION_SIZES) {
+      const geometry = geometryFor(size);
+      const pad =
+        (COMPANION_BASE_CANVAS_PAD * geometry.avatarBox) /
+        COMPANION_BASE_AVATAR_BOX;
+      expect(geometry.canvasWidth).toBe(
+        Math.round(
+          2 *
+            (geometry.avatarBox / 2 +
+              geometry.gap +
+              geometry.maxBodyWidth +
+              pad),
+        ),
+      );
+    }
+  });
+
+  test("takes the gap from the contract rather than a copy of it", () => {
+    for (const size of COMPANION_SIZES) {
+      const geometry = geometryFor(size);
+      expect(geometry.gap).toBe(
+        companionGapFor(geometry.avatarBox, geometry.avatarBox),
+      );
+    }
   });
 
   /**
@@ -567,7 +615,8 @@ describe("geometryFor", () => {
     expect(large.canvasHeight).toBe(small.canvasHeight * scale);
     expect(large.riseAbove).toBe(small.riseAbove * scale);
     expect(large.dropBelow).toBe(small.dropBelow * scale);
-    expect(large.maxPillWidth).toBe(small.maxPillWidth * scale);
+    expect(large.gap).toBe(small.gap * scale);
+    expect(large.maxBodyWidth).toBe(small.maxBodyWidth * scale);
   });
 
   test("grows monotonically through the named steps", () => {

--- a/clients/macos/src/main/companion-window.ts
+++ b/clients/macos/src/main/companion-window.ts
@@ -175,6 +175,8 @@ export interface CompanionGeometry {
   gap: number;
   /** The widest the pill's body draws at this size, gap not included. */
   maxBodyWidth: number;
+  /** The pill's far edge at its widest, measured from the avatar's centre. */
+  maxReach: number;
 }
 
 /**
@@ -203,7 +205,8 @@ export const geometryFor = (size: CompanionSize): CompanionGeometry => {
   // The avatar holds its place and the pill hangs off one side of it across the
   // gap, so the reach is the avatar's half box, the gap, and the widest body.
   // The canvas has to hold it in whichever direction main later picks, so it is
-  // sized for both sides.
+  // sized for both sides, and `growthFor` picks that direction by the same
+  // number.
   const maxReach = avatarBox / 2 + gap + maxBodyWidth;
   const riseAbove = BASE_MAX_CARD_HEIGHT * scale - avatarBox / 2 + pad;
   // The invariant the renderer anchors by, at this size. Scaled rather than
@@ -217,6 +220,7 @@ export const geometryFor = (size: CompanionSize): CompanionGeometry => {
     dropBelow,
     gap,
     maxBodyWidth,
+    maxReach,
   };
 };
 
@@ -377,10 +381,12 @@ export const callOnUpdate = (
 /**
  * Which way the pill grows, from where the avatar actually sits.
  *
- * The pill needs the gap and its widest body of clearance beyond the avatar's
- * edge on the side it grows into. Rightward is the default and leftward is what
- * it flips to when the right edge is too close, so the avatar stays exactly
- * where the user put it instead of the controls running off the display.
+ * The room on each side is measured from the avatar's centre, so the clearance
+ * the pill needs is measured from there too: the avatar's half box, then the
+ * gap, then its widest body, which is {@link CompanionGeometry.maxReach}.
+ * Rightward is the default and leftward is what it flips to when the right edge
+ * is too close, so the avatar stays exactly where the user put it instead of
+ * the controls running off the display.
  *
  * A display too narrow for either direction still grows right, because the
  * clipping is then unavoidable and the user can drag the surface somewhere it
@@ -391,7 +397,7 @@ export const growthFor = (
   workArea: { x: number; width: number },
   geometry: CompanionGeometry,
 ): CompanionGrowth => {
-  const needed = geometry.gap + geometry.maxBodyWidth;
+  const needed = geometry.maxReach;
   const roomRight = workArea.x + workArea.width - avatarCentreX;
   const roomLeft = avatarCentreX - workArea.x;
   if (roomRight < needed && roomLeft >= needed) {

--- a/clients/macos/src/main/companion-window.ts
+++ b/clients/macos/src/main/companion-window.ts
@@ -13,6 +13,7 @@ import {
   COMPANION_SIZES,
   COMPANION_NEAR_EDGE,
   COMPANION_SIZE_BOXES,
+  companionGapFor,
   WATCH_FLAG,
   type CompanionCardGrowth,
   type CompanionGrowth,
@@ -126,14 +127,16 @@ const COMPANION_KIND = "companion";
 const COMPANION_ROUTE = "/floating/companion";
 
 /**
- * The widest the pill gets at {@link COMPANION_BASE_AVATAR_BOX}, matching
- * `FALLBACK_WIDTHS.call` in the renderer.
+ * The widest the pill's body gets at {@link COMPANION_BASE_AVATAR_BOX}, which
+ * is the ceiling every entry in the renderer's `FALLBACK_WIDTHS` stays under.
  *
- * A ceiling rather than a width: the pill measures its own content, so this is
- * what the canvas is sized to hold, and content wider than it is clipped by the
- * window. The call's approval row is the widest thing the surface renders.
+ * The body alone, because the avatar floats beside the pill rather than inside
+ * it: what the canvas has to hold on the growth side is the avatar's half box,
+ * the gap, and this. A ceiling rather than a width, since the pill measures its
+ * own content, and content wider than it is clipped by the window. The call's
+ * approval row is the widest thing the surface renders.
  */
-const BASE_MAX_PILL_WIDTH = 360;
+const BASE_MAX_BODY_WIDTH = 316;
 
 /**
  * The tallest the surface gets, which is the typing card.
@@ -146,7 +149,7 @@ const BASE_MAX_PILL_WIDTH = 360;
  * renderer and a canvas a few points short clips the top of the card off.
  *
  * Matched to `CompanionSurface`'s card in `companion-surface.tsx`, the way
- * {@link BASE_MAX_PILL_WIDTH} is matched to its widths.
+ * {@link BASE_MAX_BODY_WIDTH} is matched to its widths.
  */
 const BASE_MAX_CARD_HEIGHT = 290;
 
@@ -168,8 +171,10 @@ export interface CompanionGeometry {
   riseAbove: number;
   /** How much the other side needs: the avatar and its shadow, and no more. */
   dropBelow: number;
-  /** What {@link growthFor} measures the room against. */
-  maxPillWidth: number;
+  /** The room between the avatar's edge and the pill, at this size. */
+  gap: number;
+  /** The widest the pill's body draws at this size, gap not included. */
+  maxBodyWidth: number;
 }
 
 /**
@@ -193,11 +198,13 @@ export const geometryFor = (size: CompanionSize): CompanionGeometry => {
   const avatarBox = COMPANION_SIZE_BOXES[size];
   const scale = avatarBox / COMPANION_BASE_AVATAR_BOX;
   const pad = COMPANION_BASE_CANVAS_PAD * scale;
-  const maxPillWidth = BASE_MAX_PILL_WIDTH * scale;
-  // The avatar holds its place and the body runs off one side of it, so the
-  // reach is almost the pill's whole width. The canvas has to hold it in
-  // whichever direction main later picks, so it is sized for both sides.
-  const maxReach = maxPillWidth - avatarBox / 2;
+  const gap = companionGapFor(avatarBox, avatarBox);
+  const maxBodyWidth = BASE_MAX_BODY_WIDTH * scale;
+  // The avatar holds its place and the pill hangs off one side of it across the
+  // gap, so the reach is the avatar's half box, the gap, and the widest body.
+  // The canvas has to hold it in whichever direction main later picks, so it is
+  // sized for both sides.
+  const maxReach = avatarBox / 2 + gap + maxBodyWidth;
   const riseAbove = BASE_MAX_CARD_HEIGHT * scale - avatarBox / 2 + pad;
   // The invariant the renderer anchors by, at this size. Scaled rather than
   // recomputed, so the formula lives in one place for both processes.
@@ -208,7 +215,8 @@ export const geometryFor = (size: CompanionSize): CompanionGeometry => {
     canvasHeight: Math.round(riseAbove + dropBelow),
     riseAbove,
     dropBelow,
-    maxPillWidth,
+    gap,
+    maxBodyWidth,
   };
 };
 
@@ -369,10 +377,10 @@ export const callOnUpdate = (
 /**
  * Which way the pill grows, from where the avatar actually sits.
  *
- * The body needs `maxPillWidth - avatarBox` of clearance on the side it
- * grows into. Rightward is the default and leftward is what it flips to when
- * the right edge is too close, so the avatar stays exactly where the user put
- * it instead of the controls running off the display.
+ * The pill needs the gap and its widest body of clearance beyond the avatar's
+ * edge on the side it grows into. Rightward is the default and leftward is what
+ * it flips to when the right edge is too close, so the avatar stays exactly
+ * where the user put it instead of the controls running off the display.
  *
  * A display too narrow for either direction still grows right, because the
  * clipping is then unavoidable and the user can drag the surface somewhere it
@@ -383,7 +391,7 @@ export const growthFor = (
   workArea: { x: number; width: number },
   geometry: CompanionGeometry,
 ): CompanionGrowth => {
-  const needed = geometry.maxPillWidth - geometry.avatarBox;
+  const needed = geometry.gap + geometry.maxBodyWidth;
   const roomRight = workArea.x + workArea.width - avatarCentreX;
   const roomLeft = avatarCentreX - workArea.x;
   if (roomRight < needed && roomLeft >= needed) {

--- a/clients/web/src/components/companion-intro.tsx
+++ b/clients/web/src/components/companion-intro.tsx
@@ -1,6 +1,7 @@
 import {
   COMPANION_INTRO_BEATS,
   COMPANION_NEAR_EDGE,
+  companionGapFor,
 } from "@vellumai/ipc-contract";
 import type {
   CompanionIntroAction,
@@ -42,11 +43,16 @@ import type {
  * the main process for a card that is on screen once in an install's life.
  */
 
-/** Gap between the avatar's edge and the card, in base layout points. */
-const AVATAR_GAP = 12;
-
 /** The avatar's box the layout is authored at, as `CompanionSurface` has it. */
 const AVATAR_BOX = 44;
+
+/**
+ * The room between the avatar's edge and the card, which is the same room the
+ * surface leaves between the avatar and its pill. One number from the contract
+ * rather than one per neighbour, so everything hanging off the creature sits
+ * the same distance from it.
+ */
+const AVATAR_GAP = companionGapFor(AVATAR_BOX, AVATAR_BOX);
 
 /**
  * The card's width, fixed rather than measured.
@@ -54,9 +60,9 @@ const AVATAR_BOX = 44;
  * Prose has no natural width, so measuring would size the card to whichever
  * beat happened to say the most and change its shape as the run advanced. This
  * is the same bargain the typing card makes, and it fits the canvas at every
- * size: the window reaches `maxPillWidth - avatarBox / 2` past the avatar in
- * both directions (`geometryFor` in `companion-window.ts`), which is 338 at the
- * size this layout is authored at.
+ * size: the window reaches `avatarBox / 2 + gap + maxBodyWidth` past the avatar
+ * in both directions (`geometryFor` in `companion-window.ts`), which is 350 at
+ * the size this layout is authored at.
  */
 const CARD_WIDTH = 244;
 
@@ -181,10 +187,10 @@ export function CompanionIntro({
   const isLast = index === COMPANION_INTRO_BEATS.length - 1;
   const copy = INTRO_COPY_KEYS[beat];
 
-  // The pill's own horizontal anchoring, repeated rather than shared, because
-  // the card is a sibling of the pill and not inside it: it must not inherit
-  // the width that animates from beat to beat. Anchoring to the same edge is
-  // what makes the card and the pill read as one object being annotated.
+  // Hung off the avatar's own edge, which is the point the host positioned this
+  // window around and the point the pill is measured from too. Not off the
+  // pill: that box changes width from beat to beat as controls are spotlighted,
+  // and a card pinned to it would slide about while being read.
   const placement: CSSProperties =
     growth === "left"
       ? { right: "50%", marginRight: -(AVATAR_BOX / 2) }

--- a/clients/web/src/components/companion-surface-page.test.tsx
+++ b/clients/web/src/components/companion-surface-page.test.tsx
@@ -97,7 +97,8 @@ mock.module("@/runtime/desktop-voice-activity", () => ({
   sendVoiceActivityControl: () => undefined,
 }));
 
-const { CompanionSurfacePage } = await import("./companion-surface-page");
+const { CompanionSurfacePage, bridgeRect } =
+  await import("./companion-surface-page");
 
 afterEach(() => {
   cleanup();
@@ -119,62 +120,216 @@ const canvasOf = (container: HTMLElement): HTMLElement => {
   return canvas;
 };
 
-/**
- * The pill, pinned somewhere the hit-test can find it.
- *
- * The surface measures itself live, and nothing lays out in the test DOM, so
- * every rect would otherwise be zero and the pointer would never be over the
- * pill at all.
- */
-const pinPill = async (container: HTMLElement): Promise<HTMLElement> => {
-  const pill = await waitFor(() => {
-    const found = container.querySelector<HTMLElement>(".cursor-grab");
-    if (!found) {
-      throw new Error("Expected the pill to render");
-    }
-    return found;
-  });
-  pill.getBoundingClientRect = () =>
+/** A box the hit-test can read, which jsdom otherwise reports as all zeroes. */
+type Box = { left: number; right: number; top: number; bottom: number };
+
+const pin = (element: HTMLElement, box: Box): void => {
+  element.getBoundingClientRect = () =>
     ({
-      left: 100,
-      right: 144,
-      top: 100,
-      bottom: 144,
-      x: 100,
-      y: 100,
-      width: 44,
-      height: 44,
+      ...box,
+      x: box.left,
+      y: box.top,
+      width: box.right - box.left,
+      height: box.bottom - box.top,
       toJSON: () => ({}),
     }) as DOMRect;
-  return pill;
 };
 
-/** The avatar inside the pill, which is what a press "goes back to Vellum". */
-const avatarOf = (container: HTMLElement): HTMLElement => {
-  const avatar = container.querySelector<HTMLElement>(".place-items-center");
-  if (!avatar) {
-    throw new Error("Expected the avatar to render");
-  }
-  return avatar;
+/**
+ * The avatar and the pill, pinned somewhere the hit-test can find them.
+ *
+ * The surface measures itself live and nothing lays out in the test DOM, so
+ * every rect would otherwise be zero and the pointer would never be over any of
+ * it. Pinned as the surface draws them: the avatar's 44pt box, and the pill
+ * bottom-flush across a 12pt gap to its right.
+ */
+const pinSurface = async (
+  container: HTMLElement,
+): Promise<{ avatar: HTMLElement; pill: HTMLElement }> => {
+  const found = await waitFor(() => {
+    const avatar = container.querySelector<HTMLElement>(".size-11");
+    const pill = container.querySelector<HTMLElement>(
+      ".transition-\\[width\\]",
+    );
+    if (!avatar || !pill) {
+      throw new Error("Expected the surface to render");
+    }
+    return { avatar, pill };
+  });
+  pin(found.avatar, { left: 100, right: 144, top: 100, bottom: 144 });
+  pin(found.pill, { left: 156, right: 356, top: 100, bottom: 144 });
+  return found;
 };
+
+/**
+ * The surface is a union of rects, and this is the one nothing draws into.
+ *
+ * The avatar and the pill are separate elements with a gap between them, and
+ * the pointer crosses that gap on the way from the creature to the controls. A
+ * window that went click-through halfway would drop the press the user was
+ * travelling to make, and one that claimed the whole box around the pair would
+ * swallow desktop presses in the empty canvas above and below it.
+ */
+describe("the gap between the avatar and the pill", () => {
+  /**
+   * Whether the pill is open, read off the collapsed body's `inert`: the
+   * controls stay mounted at rest so they can be measured, so their presence
+   * says nothing and their being out of the tree says everything.
+   */
+  const closed = (container: HTMLElement): boolean =>
+    container.querySelector("[inert]") !== null;
+
+  /** Open the surface by putting the pointer on the creature. */
+  const open = async (container: HTMLElement): Promise<HTMLElement> => {
+    const canvas = canvasOf(container);
+    fireEvent.mouseMove(canvas, { clientX: 120, clientY: 120 });
+    await waitFor(() => {
+      if (closed(container)) {
+        throw new Error("Expected the pill to open");
+      }
+    });
+    return canvas;
+  };
+
+  test("keeps the window clickable while the pointer crosses it", async () => {
+    const { container } = render(<CompanionSurfacePage />);
+    await pinSurface(container);
+    const canvas = await open(container);
+
+    fireEvent.mouseMove(canvas, { clientX: 150, clientY: 122 });
+
+    expect(setInteractiveMock.mock.calls.at(-1)).toEqual([true]);
+  });
+
+  test("does not collapse the pill out from under the hand", async () => {
+    const { container } = render(<CompanionSurfacePage />);
+    await pinSurface(container);
+    const canvas = await open(container);
+
+    fireEvent.mouseMove(canvas, { clientX: 150, clientY: 122 });
+
+    expect(closed(container)).toBe(false);
+  });
+
+  test("carries the pointer on to the pill itself", async () => {
+    const { container } = render(<CompanionSurfacePage />);
+    await pinSurface(container);
+    const canvas = await open(container);
+
+    fireEvent.mouseMove(canvas, { clientX: 200, clientY: 122 });
+
+    expect(setInteractiveMock.mock.calls.at(-1)).toEqual([true]);
+    expect(closed(container)).toBe(false);
+  });
+
+  /**
+   * The bridge runs the pill's own height and no further, so a press aimed past
+   * it lands on whatever the user actually has behind the surface.
+   */
+  test("gives the desktop back above and below it", async () => {
+    for (const clientY of [90, 160]) {
+      const { container } = render(<CompanionSurfacePage />);
+      await pinSurface(container);
+      const canvas = await open(container);
+
+      fireEvent.mouseMove(canvas, { clientX: 150, clientY });
+
+      expect(setInteractiveMock.mock.calls.at(-1)).toEqual([false]);
+      cleanup();
+      setInteractiveMock.mockClear();
+    }
+  });
+
+  /** At rest there is no pill, and so nothing to bridge to. */
+  test("is not part of the surface while the pill is closed", async () => {
+    const { container } = render(<CompanionSurfacePage />);
+    await pinSurface(container);
+
+    fireEvent.mouseMove(canvasOf(container), { clientX: 150, clientY: 122 });
+
+    expect(setInteractiveMock).not.toHaveBeenCalledWith(true);
+    expect(closed(container)).toBe(true);
+  });
+});
+
+/**
+ * The strip itself, as arithmetic. The rects it is handed come from the DOM, so
+ * these are about the shape it makes of them: between the facing edges, and no
+ * taller than the pill.
+ */
+describe("bridgeRect", () => {
+  const AVATAR = { left: 100, right: 144, top: 100, bottom: 144 };
+
+  test("spans the facing edges when the pill grows rightward", () => {
+    const pill = { left: 156, right: 356, top: 100, bottom: 144 };
+    expect(bridgeRect(AVATAR, pill)).toEqual({
+      left: 144,
+      right: 156,
+      top: 100,
+      bottom: 144,
+    });
+  });
+
+  test("spans them the other way when it grows leftward", () => {
+    const pill = { left: -100, right: 88, top: 100, bottom: 144 };
+    expect(bridgeRect(AVATAR, pill)).toEqual({
+      left: 88,
+      right: 100,
+      top: 100,
+      bottom: 144,
+    });
+  });
+
+  /**
+   * The pill's height, never the avatar's. A strip as tall as a larger creature
+   * would claim the dead corners beside it, which is the bounding box this
+   * exists instead of.
+   */
+  test("takes the pill's height rather than a taller avatar's", () => {
+    const tall = { left: 100, right: 200, top: 40, bottom: 200 };
+    const pill = { left: 212, right: 412, top: 156, bottom: 200 };
+    expect(bridgeRect(tall, pill)).toEqual({
+      left: 200,
+      right: 212,
+      top: 156,
+      bottom: 200,
+    });
+  });
+
+  /** Overlapping rects have no gap between them, and an empty strip says so. */
+  test("is empty when the two overlap", () => {
+    const overlapping = { left: 120, right: 320, top: 100, bottom: 144 };
+    const bridge = bridgeRect(AVATAR, overlapping);
+    expect(bridge.left).toBeGreaterThan(bridge.right);
+  });
+});
 
 describe("dragging the companion surface", () => {
-  test("moves the window by the pointer's travel", async () => {
-    const { container } = render(<CompanionSurfacePage />);
-    const pill = await pinPill(container);
-    const canvas = canvasOf(container);
+  /**
+   * Both drawn halves are handles. The drag is a window move, so whichever the
+   * hand happens to land on takes the whole surface with it, and a creature
+   * that could not be grabbed would be the part users reach for first.
+   */
+  test("moves the window by the pointer's travel, from either half", async () => {
+    for (const half of ["avatar", "pill"] as const) {
+      const { container } = render(<CompanionSurfacePage />);
+      const pinned = await pinSurface(container);
+      const canvas = canvasOf(container);
 
-    fireEvent.mouseMove(canvas, { clientX: 120, clientY: 120 });
-    fireEvent.mouseDown(pill, { screenX: 500, screenY: 500 });
-    fireEvent.mouseMove(canvas, {
-      clientX: 120,
-      clientY: 120,
-      screenX: 530,
-      screenY: 520,
-      buttons: 1,
-    });
+      fireEvent.mouseMove(canvas, { clientX: 120, clientY: 120 });
+      fireEvent.mouseDown(pinned[half], { screenX: 500, screenY: 500 });
+      fireEvent.mouseMove(canvas, {
+        clientX: 120,
+        clientY: 120,
+        screenX: 530,
+        screenY: 520,
+        buttons: 1,
+      });
 
-    expect(moveByMock.mock.calls).toEqual([[30, 20]]);
+      expect(moveByMock.mock.calls).toEqual([[30, 20]]);
+      cleanup();
+      moveByMock.mockClear();
+    }
   });
 
   /**
@@ -184,7 +339,7 @@ describe("dragging the companion surface", () => {
    */
   test("ends a drag whose release landed outside the window", async () => {
     const { container } = render(<CompanionSurfacePage />);
-    const pill = await pinPill(container);
+    const { pill } = await pinSurface(container);
     const canvas = canvasOf(container);
 
     fireEvent.mouseMove(canvas, { clientX: 120, clientY: 120 });
@@ -213,7 +368,7 @@ describe("dragging the companion surface", () => {
 
   test("hit-tests again once the abandoned drag is dropped", async () => {
     const { container } = render(<CompanionSurfacePage />);
-    const pill = await pinPill(container);
+    const { pill } = await pinSurface(container);
     const canvas = canvasOf(container);
 
     fireEvent.mouseMove(canvas, { clientX: 120, clientY: 120 });
@@ -243,7 +398,7 @@ describe("dragging the companion surface", () => {
 
   test("a press that travelled is not a click on the avatar", async () => {
     const { container } = render(<CompanionSurfacePage />);
-    const pill = await pinPill(container);
+    const { avatar, pill } = await pinSurface(container);
     const canvas = canvasOf(container);
 
     fireEvent.mouseMove(canvas, { clientX: 120, clientY: 120 });
@@ -256,20 +411,20 @@ describe("dragging the companion surface", () => {
       buttons: 1,
     });
     fireEvent.mouseUp(canvas);
-    fireEvent.click(avatarOf(container));
+    fireEvent.click(avatar);
 
     expect(activateMock).not.toHaveBeenCalled();
   });
 
   test("a press that held still still goes back to Vellum", async () => {
     const { container } = render(<CompanionSurfacePage />);
-    const pill = await pinPill(container);
+    const { avatar, pill } = await pinSurface(container);
     const canvas = canvasOf(container);
 
     fireEvent.mouseMove(canvas, { clientX: 120, clientY: 120 });
     fireEvent.mouseDown(pill, { screenX: 500, screenY: 500 });
     fireEvent.mouseUp(canvas);
-    fireEvent.click(avatarOf(container));
+    fireEvent.click(avatar);
 
     expect(activateMock).toHaveBeenCalledTimes(1);
   });
@@ -294,7 +449,7 @@ describe("the working ring on the page", () => {
 
   test("stays dark when nothing is running", async () => {
     const { container } = render(<CompanionSurfacePage />);
-    await pinPill(container);
+    await pinSurface(container);
 
     expect(container.querySelector(".companion-working-ring")).toBeNull();
   });
@@ -320,7 +475,7 @@ describe("the watch session on the companion surface", () => {
 
   test("hands the press back to the window holding the session", async () => {
     const { container } = render(<CompanionSurfacePage />);
-    await pinPill(container);
+    await pinSurface(container);
     const canvas = canvasOf(container);
     fireEvent.mouseMove(canvas, { clientX: 120, clientY: 120 });
 
@@ -403,7 +558,7 @@ describe("the watch session on the companion surface", () => {
    */
   test("reads a state that says nothing about it as no session", async () => {
     const { container } = render(<CompanionSurfacePage />);
-    await pinPill(container);
+    await pinSurface(container);
     fireEvent.mouseMove(canvasOf(container), { clientX: 120, clientY: 120 });
 
     await waitFor(() => {
@@ -419,7 +574,7 @@ describe("the watch session on the companion surface", () => {
   test("keeps a way out of the session while the composer is open", async () => {
     STATE.watching = true;
     const { container } = render(<CompanionSurfacePage />);
-    await pinPill(container);
+    await pinSurface(container);
     fireEvent.mouseMove(canvasOf(container), { clientX: 120, clientY: 120 });
     fireEvent.click(
       await waitFor(() => {
@@ -463,26 +618,15 @@ describe("the companion's introduction", () => {
       }
       return found;
     });
-    // Well clear of the pill's box in `pinPill`, so a pointer on one is
-    // provably not on the other.
-    card.getBoundingClientRect = () =>
-      ({
-        left: 300,
-        right: 544,
-        top: 300,
-        bottom: 380,
-        x: 300,
-        y: 300,
-        width: 244,
-        height: 80,
-        toJSON: () => ({}),
-      }) as DOMRect;
+    // Well clear of the boxes `pinSurface` gives the avatar and the pill, so a
+    // pointer on one is provably not on the other.
+    pin(card, { left: 300, right: 544, top: 300, bottom: 380 });
     return card;
   };
 
   test("draws nothing while no run is due", async () => {
     const { container } = render(<CompanionSurfacePage />);
-    await pinPill(container);
+    await pinSurface(container);
     expect(container.querySelector('[role="group"]')).toBeNull();
   });
 
@@ -539,7 +683,7 @@ describe("the companion's introduction", () => {
   test("makes the window clickable while the pointer is on the card", async () => {
     STATE.intro = "meet";
     const { container } = render(<CompanionSurfacePage />);
-    await pinPill(container);
+    await pinSurface(container);
     await pinCard(container);
     const canvas = canvasOf(container);
 
@@ -556,7 +700,7 @@ describe("the companion's introduction", () => {
   test("does not read a pointer on the card as hovering the avatar", async () => {
     STATE.intro = "meet";
     const { container } = render(<CompanionSurfacePage />);
-    const pill = await pinPill(container);
+    const { pill } = await pinSurface(container);
     await pinCard(container);
     const canvas = canvasOf(container);
 
@@ -577,7 +721,7 @@ describe("the companion's introduction", () => {
   test("gives the desktop back when the run ends under the pointer", async () => {
     STATE.intro = "menu";
     const { container } = render(<CompanionSurfacePage />);
-    await pinPill(container);
+    await pinSurface(container);
     await pinCard(container);
     const canvas = canvasOf(container);
 
@@ -610,7 +754,7 @@ describe("the companion's introduction", () => {
       assistantName: "Ziggy",
     };
     const { container } = render(<CompanionSurfacePage />);
-    await pinPill(container);
+    await pinSurface(container);
     expect(container.querySelector('[role="group"]')).toBeNull();
   });
 
@@ -631,7 +775,7 @@ describe("the companion's introduction", () => {
       assistantName: "Ziggy",
     };
     const { container } = render(<CompanionSurfacePage />);
-    await pinPill(container);
+    await pinSurface(container);
     expect(container.querySelector('[role="group"]')).toBeNull();
 
     STATE.call = null;
@@ -655,7 +799,7 @@ describe("the Watch flag on the companion surface", () => {
 
   /** Open the pill, which is where the way into a session would be drawn. */
   const openPill = async (container: HTMLElement): Promise<void> => {
-    await pinPill(container);
+    await pinSurface(container);
     fireEvent.mouseMove(canvasOf(container), { clientX: 120, clientY: 120 });
     await waitFor(() => {
       if (!container.querySelector('button[aria-label="Talk"]')) {
@@ -697,7 +841,7 @@ describe("the Watch flag on the companion surface", () => {
     STATE.watchEnabled = false;
     STATE.watching = true;
     const { container } = render(<CompanionSurfacePage />);
-    await pinPill(container);
+    await pinSurface(container);
     fireEvent.mouseMove(canvasOf(container), { clientX: 120, clientY: 120 });
 
     const stop = await waitFor(() => {
@@ -721,13 +865,21 @@ describe("the Watch flag on the companion surface", () => {
  * press on the object itself is where a user reaches first.
  */
 describe("the companion's own menu", () => {
-  test("a right-click asks main to open it", async () => {
-    const { container } = render(<CompanionSurfacePage />);
-    const pill = await pinPill(container);
+  /**
+   * On the creature as much as on the pill: a user reaching for "make this go
+   * away" should not have to find the one of the two that carries the menu.
+   */
+  test("a right-click on either half asks main to open it", async () => {
+    for (const half of ["avatar", "pill"] as const) {
+      const { container } = render(<CompanionSurfacePage />);
+      const pinned = await pinSurface(container);
 
-    fireEvent.contextMenu(pill);
+      fireEvent.contextMenu(pinned[half]);
 
-    expect(contextMenuMock).toHaveBeenCalled();
+      expect(contextMenuMock).toHaveBeenCalled();
+      cleanup();
+      contextMenuMock.mockClear();
+    }
   });
 
   /**
@@ -743,7 +895,7 @@ describe("the companion's own menu", () => {
    */
   test("leaves the native text menu alone inside the composer", async () => {
     const { container } = render(<CompanionSurfacePage />);
-    const pill = await pinPill(container);
+    const { pill } = await pinSurface(container);
 
     // Open the composer, which is what puts a field on the card.
     const type = Array.from(pill.querySelectorAll("button")).find(
@@ -765,7 +917,7 @@ describe("the companion's own menu", () => {
 
   test("a right-press does not start a drag", async () => {
     const { container } = render(<CompanionSurfacePage />);
-    const pill = await pinPill(container);
+    const { pill } = await pinSurface(container);
     const canvas = canvasOf(container);
 
     fireEvent.mouseMove(canvas, { clientX: 120, clientY: 120 });
@@ -818,7 +970,9 @@ describe("the companion's accent colour", () => {
     hex: string,
   ): Promise<void> => {
     await waitFor(() => {
-      const pill = container.querySelector<HTMLElement>(".cursor-grab");
+      const pill = container.querySelector<HTMLElement>(
+        ".transition-\\[width\\]",
+      );
       if (!pill) {
         throw new Error("Expected the pill to render");
       }

--- a/clients/web/src/components/companion-surface-page.tsx
+++ b/clients/web/src/components/companion-surface-page.tsx
@@ -54,6 +54,45 @@ const DRAG_SLOP = 3;
  */
 const BASE_AVATAR_BOX = 44;
 
+/** As much of a rect as hit-testing a point against it needs. */
+type SurfaceRect = Pick<DOMRect, "left" | "right" | "top" | "bottom">;
+
+/**
+ * The gap between the avatar and the pill, as a rect of its own.
+ *
+ * **The surface is a union of rects, never the box around them.** The avatar
+ * and the pill are separate elements, and a bounding box over the pair would
+ * claim the empty canvas above and below the gap as well: a click-through
+ * window told it is interactive there swallows the presses meant for whatever
+ * is behind it, which is the failure every note in this file is about. So the
+ * gap is tested as exactly what it is, a strip between the two facing edges,
+ * running the pill's own height.
+ *
+ * It has to be part of the surface at all because the pointer crosses it on the
+ * way from the creature to the controls. A window that went click-through
+ * halfway would drop the press the user was travelling to make.
+ *
+ * Degenerate when the two overlap, which reads as no bridge at all: the strip's
+ * left edge lands past its right, and no point is inside it.
+ */
+export const bridgeRect = (
+  avatar: SurfaceRect,
+  pill: SurfaceRect,
+): SurfaceRect =>
+  pill.left >= avatar.right
+    ? {
+        left: avatar.right,
+        right: pill.left,
+        top: pill.top,
+        bottom: pill.bottom,
+      }
+    : {
+        left: pill.right,
+        right: avatar.left,
+        top: pill.top,
+        bottom: pill.bottom,
+      };
+
 /**
  * The companion surface inside its Electron canvas
  * (`clients/macos/src/main/companion-window.ts`).
@@ -134,6 +173,10 @@ export function CompanionSurfacePage() {
   // send the same instruction on every mouse-move.
   const interactiveRef = useRef(false);
   const pillRef = useRef<HTMLDivElement | null>(null);
+  // The creature's own box, hit-tested beside the pill rather than inside it:
+  // the two are siblings with a gap between them, and at rest the avatar is the
+  // only part of the surface drawn at all.
+  const avatarRef = useRef<HTMLDivElement | null>(null);
   // The introduction's card, hit-tested alongside the pill: it carries the only
   // two controls in the run, and a click-through window would drop presses on
   // them onto whatever is behind it.
@@ -273,15 +316,58 @@ export function CompanionSurfacePage() {
     setStarted(false);
   };
 
+  // **An open composer outranks everything, and a running call outranks the
+  // pointer.** The surface is otherwise a circle that only becomes a pill while
+  // it is being pointed at, and a live microphone that hides itself the moment
+  // the pointer leaves is a live microphone the user cannot see. So the call
+  // holds the pill open, and hovering it changes nothing: the controls it wants
+  // are already there.
+  //
+  // The composer sits above even that, because it is the one state holding
+  // something of the user's. A call starting from the app while a sentence is
+  // half-typed must not collapse the card and take the sentence with it.
+  //
+  // A watch session holds the pill open for the same reason the call does, and
+  // ranks below both: they are things the user is in the middle of, where this
+  // one runs beside whatever they are doing. Being outranked costs the session
+  // nothing, since the phase is only what the pill is drawing and the indicator
+  // reads `watching` instead.
+  //
+  // The summary of a finished session sits between the two: it outranks hover
+  // because it is a wait the user is owed an answer to and then a question
+  // waiting on one, and it is outranked by a session still recording, which is
+  // the one thing on this surface a user must always be able to see and stop.
+  // The introduction sits above the pointer and below everything the user is in
+  // the middle of. A beat that names a control has to have that control on
+  // screen to name, so it holds the pill open the way a call does; but a run
+  // still going when a call starts or the composer opens must give way, because
+  // those are the user's own business and this is a caption.
+  const introHeld = introPhase(intro);
+  const phase: CompanionSurfacePhase = typing
+    ? "typing"
+    : call !== null
+      ? "call"
+      : watching
+        ? "watching"
+        : watchRetro !== undefined
+          ? "summary"
+          : (introHeld ?? (hovered ? "hover" : "resting"));
+  const expanded = phase !== "resting";
+
   /**
-   * Hit-test the pointer against the pill on every move.
+   * Hit-test the pointer against the surface on every move.
    *
    * Not `mouseenter`: a click-through window delivers forwarded mouse-move and
    * little else, so entering and leaving have to be derived from coordinates.
    * `dictation-overlay-page.tsx` measures its stop button the same way for the
-   * same reason. The rect is read live rather than cached because the pill
+   * same reason. The rects are read live rather than cached because the pill
    * changes width as it expands, and a stale rect would collapse the surface
    * the moment it finished growing.
+   *
+   * **The surface is several rects, and the answer is their union.** The
+   * creature, the pill beside it, the strip of gap between them, and the
+   * introduction's card while it is drawn; see {@link bridgeRect} for why the
+   * box around them all is the wrong shape.
    */
   const onMouseMove = (event: MouseEvent<HTMLDivElement>) => {
     // **A drag whose release this window never saw ends here.**
@@ -325,71 +411,39 @@ export function CompanionSurfacePage() {
       return;
     }
     const pill = pillRef.current;
-    if (!pill) {
+    const avatar = avatarRef.current;
+    if (!pill || !avatar) {
       return;
     }
-    const within = (element: HTMLElement | null): boolean => {
-      if (!element) {
-        return false;
-      }
-      const rect = element.getBoundingClientRect();
-      return (
-        event.clientX >= rect.left &&
-        event.clientX <= rect.right &&
-        event.clientY >= rect.top &&
-        event.clientY <= rect.bottom
-      );
-    };
-    const onPill = within(pill);
+    const inside = (rect: SurfaceRect): boolean =>
+      event.clientX >= rect.left &&
+      event.clientX <= rect.right &&
+      event.clientY >= rect.top &&
+      event.clientY <= rect.bottom;
+    // Each box read once. Reading one forces layout, and this runs on every
+    // pixel of every mouse-move the host forwards.
+    const avatarRect = avatar.getBoundingClientRect();
+    const pillRect = pill.getBoundingClientRect();
+    const onAvatar = inside(avatarRect);
+    // The pill and the gap only count once there is a pill: at rest its box is
+    // nothing, and a rect of nothing beside the avatar is not somewhere a
+    // pointer can be.
+    const onPill = expanded && inside(pillRect);
+    const onBridge = expanded && inside(bridgeRect(avatarRect, pillRect));
     // The introduction's card is part of the surface for as long as it is
-    // drawn. Testing only the pill would leave the window click-through over
+    // drawn. Testing only the surface would leave the window click-through over
     // Next and Skip, so the presses meant to end the run would land on whatever
     // application is behind it instead.
-    const onIntro = within(introRef.current);
+    const introCard = introRef.current;
+    const onIntro =
+      introCard !== null && inside(introCard.getBoundingClientRect());
     // Hover is the creature noticing a hand on *it*, so the card does not feed
     // it: a pointer resting on a paragraph is not a pointer on the avatar, and
     // widening the eyes for it would be the surface reacting to the wrong
     // thing.
-    setHovered(onPill);
-    setInteractive(onPill || onIntro);
+    setHovered(onAvatar || onPill || onBridge);
+    setInteractive(onAvatar || onPill || onBridge || onIntro);
   };
-
-  // **An open composer outranks everything, and a running call outranks the
-  // pointer.** The surface is otherwise a circle that only becomes a pill while
-  // it is being pointed at, and a live microphone that hides itself the moment
-  // the pointer leaves is a live microphone the user cannot see. So the call
-  // holds the pill open, and hovering it changes nothing: the controls it wants
-  // are already there.
-  //
-  // The composer sits above even that, because it is the one state holding
-  // something of the user's. A call starting from the app while a sentence is
-  // half-typed must not collapse the card and take the sentence with it.
-  //
-  // A watch session holds the pill open for the same reason the call does, and
-  // ranks below both: they are things the user is in the middle of, where this
-  // one runs beside whatever they are doing. Being outranked costs the session
-  // nothing, since the phase is only what the pill is drawing and the indicator
-  // reads `watching` instead.
-  //
-  // The summary of a finished session sits between the two: it outranks hover
-  // because it is a wait the user is owed an answer to and then a question
-  // waiting on one, and it is outranked by a session still recording, which is
-  // the one thing on this surface a user must always be able to see and stop.
-  // The introduction sits above the pointer and below everything the user is in
-  // the middle of. A beat that names a control has to have that control on
-  // screen to name, so it holds the pill open the way a call does; but a run
-  // still going when a call starts or the composer opens must give way, because
-  // those are the user's own business and this is a caption.
-  const introHeld = introPhase(intro);
-  const phase: CompanionSurfacePhase = typing
-    ? "typing"
-    : call !== null
-      ? "call"
-      : watching
-        ? "watching"
-        : watchRetro !== undefined
-          ? "summary"
-          : (introHeld ?? (hovered ? "hover" : "resting"));
 
   // The avatar's own colour. A running call publishes one, and it wins: it is
   // the colour the call surfaces elsewhere are already tinted with. Outside a
@@ -532,6 +586,7 @@ export function CompanionSurfacePage() {
             )
           }
           rootRef={pillRef}
+          avatarRef={avatarRef}
           onSurfaceMouseDown={(event) => {
             // A right-click is a menu, not a grab. Left alone it would arm the
             // drag and then never be released by a `mouseup` this window sees,

--- a/clients/web/src/components/companion-surface.stories.tsx
+++ b/clients/web/src/components/companion-surface.stories.tsx
@@ -37,8 +37,8 @@ const DEMO_CALL: VoiceActivityState = {
 
 /**
  * A real assistant avatar, composed from the same bundled character components
- * the hatching screen uses, so what is on the pill is a genuine avatar rather
- * than a stand-in that happens to be round. Composed once at module scope: it
+ * the hatching screen uses, so what is beside the pill is a genuine avatar
+ * rather than a stand-in that happens to be round. Composed once at module scope: it
  * is a pure function of constants.
  */
 const EXAMPLE_AVATAR = `data:image/svg+xml;utf8,${encodeURIComponent(

--- a/clients/web/src/components/companion-surface.test.tsx
+++ b/clients/web/src/components/companion-surface.test.tsx
@@ -359,7 +359,7 @@ describe("the companion surface's custom avatar", () => {
 });
 
 /**
- * Where the avatar sits inside the canvas.
+ * Where the avatar sits inside the canvas, and where the pill hangs off it.
  *
  * The canvas is not symmetric about the avatar: the card's height is reserved
  * on whichever side it grows into, and only the avatar's own box and its shadow
@@ -368,26 +368,36 @@ describe("the companion surface's custom avatar", () => {
  * main flip the direction near the top of a display without the renderer
  * learning the canvas's height (JARVIS-1548).
  */
-/** The pill itself, which is also the surface's drag handle. */
+/** The pill, which is the one element on the surface whose width animates. */
 const surfaceOf = (container: HTMLElement): HTMLElement => {
-  const found = container.querySelector<HTMLElement>(".cursor-grab");
+  const found = container.querySelector<HTMLElement>(".transition-\\[width\\]");
   if (!found) {
     throw new Error("Expected the surface to render");
   }
   return found;
 };
 
+/** The avatar's own box, which is the point the host positions the window by. */
+const avatarOf = (container: HTMLElement): HTMLElement => {
+  const found = container.querySelector<HTMLElement>(".size-11");
+  if (!found) {
+    throw new Error("Expected the avatar to render");
+  }
+  return found;
+};
+
 describe("the companion surface's anchor in the canvas", () => {
-  test("hangs off the canvas's bottom edge while the card grows up", () => {
+  test("hangs the avatar off the canvas's bottom edge while the card grows up", () => {
     const { container } = render(<CompanionSurface phase="resting" />);
-    expect(surfaceOf(container).style.top).toBe("calc(100% - 46px)");
+    expect(avatarOf(container).style.top).toBe("calc(100% - 46px)");
+    expect(avatarOf(container).style.transform).toBe("translate(-50%, -50%)");
   });
 
-  test("sits against the canvas's top edge while the card grows down", () => {
+  test("sits the avatar against the canvas's top edge while the card grows down", () => {
     const { container } = render(
       <CompanionSurface phase="resting" cardGrowth="down" />,
     );
-    expect(surfaceOf(container).style.top).toBe("46px");
+    expect(avatarOf(container).style.top).toBe("46px");
   });
 
   test("grows up by default, which is where the surface normally lives", () => {
@@ -395,26 +405,47 @@ describe("the companion surface's anchor in the canvas", () => {
     const { container: explicit } = render(
       <CompanionSurface phase="resting" cardGrowth="up" />,
     );
-    expect(surfaceOf(container).style.top).toBe(surfaceOf(explicit).style.top);
+    expect(avatarOf(container).style.top).toBe(avatarOf(explicit).style.top);
   });
 
   /**
-   * The avatar's line is the fixed point in both directions. Growing up, the
-   * card's bottom row sits on it; growing down, its top row does. Either way
-   * the mascot is where it was before Type was pressed.
+   * The avatar's bottom line is the fixed point. The pill's bottom sits on it,
+   * which at this size puts the pill's own centre on the avatar's centre too,
+   * and the mascot never moves whichever way the pill or the card grows.
+   */
+  test("sits the pill's bottom on the avatar's bottom", () => {
+    const { container } = render(<CompanionSurface phase="hover" />);
+    // 46 from the canvas edge to the avatar's centre, 22 further to its bottom.
+    expect(surfaceOf(container).style.top).toBe("calc(100% - 24px)");
+    expect(surfaceOf(container).style.transform).toBe("translateY(-100%)");
+  });
+
+  test("keeps that line against the canvas's top edge too", () => {
+    const { container } = render(
+      <CompanionSurface phase="hover" cardGrowth="down" />,
+    );
+    expect(surfaceOf(container).style.top).toBe("68px");
+    expect(surfaceOf(container).style.transform).toBe("translateY(-100%)");
+  });
+
+  /**
+   * The composer row is the card's last child growing up and its first growing
+   * down, so the row's bottom is the avatar's bottom either way and the card
+   * hangs off it in whichever direction the host picked.
    */
   test("hangs the card off the avatar's line when it grows up", () => {
     const { container } = render(<CompanionSurface phase="typing" />);
-    expect(surfaceOf(container).style.transform).toBe(
-      "translateY(calc(-100% + 22px))",
-    );
+    expect(surfaceOf(container).style.top).toBe("calc(100% - 24px)");
+    expect(surfaceOf(container).style.transform).toBe("translateY(-100%)");
   });
 
   test("drops the card from the avatar's line when it grows down", () => {
     const { container } = render(
       <CompanionSurface phase="typing" cardGrowth="down" />,
     );
-    expect(surfaceOf(container).style.transform).toBe("translateY(-22px)");
+    // The row starts on the avatar's top line and the card falls away from it.
+    expect(surfaceOf(container).style.top).toBe("24px");
+    expect(surfaceOf(container).style.transform).toBe("none");
   });
 
   /**
@@ -436,13 +467,54 @@ describe("the companion surface's anchor in the canvas", () => {
     expect(className).not.toContain("flex-col-reverse");
   });
 
-  /** The pill is centred on the avatar's line whichever way the card would go. */
-  test("centres the resting pill on the avatar's line either way", () => {
+  /**
+   * The two are siblings with a gap between them, which is what the host's
+   * union hit-test is built on. A pill that contained the avatar would make a
+   * bounding box the honest answer and take the gap's dead corners with it.
+   */
+  test("draws the avatar beside the pill rather than inside it", () => {
+    const { container } = render(<CompanionSurface phase="hover" />);
+    expect(surfaceOf(container).contains(avatarOf(container))).toBe(false);
+    expect(avatarOf(container).parentElement).toBe(
+      surfaceOf(container).parentElement,
+    );
+  });
+
+  /** The pill's avatar-facing edge: the avatar's half box, then the gap. */
+  test("steps the pill off the avatar's edge by the gap", () => {
+    const { container } = render(<CompanionSurface phase="hover" />);
+    expect(surfaceOf(container).style.left).toBe("calc(50% + 34px)");
+  });
+
+  /**
+   * The property everything else here is in service of: the host positions the
+   * window by the creature, so the creature has to sit on the same point in
+   * every state the surface can be in.
+   */
+  test("keeps the avatar's own point in every phase", () => {
+    for (const phase of [
+      "resting",
+      "hover",
+      "watching",
+      "summary",
+      "call",
+      "typing",
+    ] as const) {
+      const { container } = render(<CompanionSurface phase={phase} />);
+      expect(avatarOf(container).style.left).toBe("50%");
+      expect(avatarOf(container).style.top).toBe("calc(100% - 46px)");
+      expect(avatarOf(container).style.transform).toBe("translate(-50%, -50%)");
+      cleanup();
+    }
+  });
+
+  test("keeps it whichever way the card would go", () => {
     for (const cardGrowth of ["up", "down"] as const) {
       const { container } = render(
         <CompanionSurface phase="resting" cardGrowth={cardGrowth} />,
       );
-      expect(surfaceOf(container).style.transform).toBe("translateY(-50%)");
+      expect(avatarOf(container).style.left).toBe("50%");
+      expect(avatarOf(container).style.transform).toBe("translate(-50%, -50%)");
       cleanup();
     }
   });
@@ -945,8 +1017,8 @@ describe("the summary a finished watch session leaves on the surface", () => {
 });
 
 describe("the companion surface's width ceiling", () => {
-  /** `BASE_MAX_PILL_WIDTH` in `clients/macos/src/main/companion-window.ts`. */
-  const CANVAS_CEILING = 360;
+  /** `BASE_MAX_BODY_WIDTH` in `clients/macos/src/main/companion-window.ts`. */
+  const CANVAS_CEILING = 316;
 
   test("holds for every phase", () => {
     const over = Object.entries(FALLBACK_WIDTHS).filter(
@@ -1016,78 +1088,55 @@ describe("the companion surface's capture indicator across phases", () => {
 });
 
 /**
- * Growing leftward is two halves, and the surface is only in the right place
- * when both happen.
+ * Growing leftward moves the pill and nothing else.
  *
  * Main positions the window by the *avatar's* centre and measures every later
  * drag, clamp and direction check from it. The renderer's half of that bargain
- * is to draw the avatar on the point the host aimed at: the surface anchors by
- * the edge the avatar is on, and the row the avatar sits in mirrors so the
- * avatar ends up against that edge.
- *
- * Anchoring without mirroring is the failure this covers. It draws the avatar
- * at the far end of the pill instead, up to a card's width from where main
- * believes it is, so the mascot teleports at the direction flip, the labels
- * sweep under a held pointer, and the point main hands presses to lands on a
- * control that refuses them. The surface reads as dead (JARVIS-1582).
+ * is to draw the avatar on the point the host aimed at, in both directions: the
+ * avatar keeps its place and the pill swaps which of its edges is pinned to the
+ * gap. A flip that moved the mascot instead would put it up to a card's width
+ * from where main believes it is, so it would teleport at the threshold, the
+ * labels would sweep under a held pointer, and the point main hands presses to
+ * would land on a control that refuses them. The surface reads as dead
+ * (JARVIS-1582).
  */
 describe("the companion surface growing leftward", () => {
-  /**
-   * The row the avatar is on, found through the avatar rather than by its own
-   * classes: it is the row's job to order the avatar, so the avatar is what
-   * says which row it is.
-   */
-  const avatarRowOf = (container: HTMLElement): HTMLElement => {
-    const avatar = container.querySelector<HTMLElement>(".size-11");
-    if (!avatar?.parentElement) {
-      throw new Error("Expected the avatar to render inside a row");
-    }
-    return avatar.parentElement;
-  };
-
-  test("mirrors the row the avatar is on", () => {
+  test("anchors the pill by its right edge, a gap off the avatar", () => {
     const { container } = render(
       <CompanionSurface phase="hover" growth="left" />,
     );
-    expect(avatarRowOf(container).className).toContain("flex-row-reverse");
+    expect(surfaceOf(container).style.right).toBe("calc(50% + 34px)");
+    expect(surfaceOf(container).style.left).toBe("");
   });
 
-  test("leaves that row alone growing the ordinary way", () => {
+  test("anchors it by its left edge growing the ordinary way", () => {
     const { container } = render(
       <CompanionSurface phase="hover" growth="right" />,
     );
-    expect(avatarRowOf(container).className).not.toContain("flex-row-reverse");
+    expect(surfaceOf(container).style.left).toBe("calc(50% + 34px)");
+    expect(surfaceOf(container).style.right).toBe("");
   });
 
   /**
-   * The card is anchored by the same edge as the pill and is eight times the
-   * avatar's width, so an unmirrored card puts the mascot further from where
-   * main is measuring than any other state.
+   * The card is anchored by the same edge as the pill and is seven times the
+   * avatar's width, so it is the state where a flip that moved the mascot would
+   * move it furthest.
    */
-  test("mirrors the card's row too", () => {
+  test("mirrors the card the same way", () => {
     const { container } = render(
       <CompanionSurface phase="typing" growth="left" />,
     );
-    expect(avatarRowOf(container).className).toContain("flex-row-reverse");
+    expect(surfaceOf(container).style.right).toBe("calc(50% + 34px)");
   });
 
-  /**
-   * The other half. The row is `INNER_GAP` narrower than the pill, because that
-   * gap is trailing space past the last control, so the row has to sit against
-   * the anchored end and leave the slack at the other.
-   */
-  test("holds the row against the edge the pill is anchored by", () => {
-    const { container } = render(
-      <CompanionSurface phase="hover" growth="left" />,
-    );
-    expect(surfaceOf(container).className).toContain("flex-row-reverse");
-  });
-
-  test("anchors the pill by its right edge", () => {
-    const { container } = render(
-      <CompanionSurface phase="hover" growth="left" />,
-    );
-    expect(surfaceOf(container).style.right).toBe("50%");
+  test("leaves the avatar on its own point either way", () => {
+    for (const growth of ["left", "right"] as const) {
+      const { container } = render(
+        <CompanionSurface phase="hover" growth={growth} />,
+      );
+      expect(avatarOf(container).style.left).toBe("50%");
+      cleanup();
+    }
   });
 });
 
@@ -1242,5 +1291,19 @@ describe("the resting avatar's idle motion", () => {
 
     const bob = container.querySelector<HTMLElement>(".companion-avatar-bob");
     expect(bob?.parentElement?.className).toContain("size-11");
+  });
+
+  /**
+   * The glow is the creature's own light and the creature is on screen in every
+   * phase, so it is lit in every phase. Nothing stacks under it: the pill is a
+   * separate shape a gap away rather than a body the halo would read as a
+   * second ring around.
+   */
+  test("glows in every phase, not only at rest", () => {
+    for (const phase of ["resting", "hover", "call", "typing"] as const) {
+      const { container } = render(<CompanionSurface phase={phase} />);
+      expect(container.querySelector(".companion-glow")).not.toBeNull();
+      cleanup();
+    }
   });
 });

--- a/clients/web/src/components/companion-surface.tsx
+++ b/clients/web/src/components/companion-surface.tsx
@@ -21,7 +21,7 @@ import type {
   Ref,
 } from "react";
 
-import { COMPANION_NEAR_EDGE } from "@vellumai/ipc-contract";
+import { COMPANION_NEAR_EDGE, companionGapFor } from "@vellumai/ipc-contract";
 import type {
   CompanionCharacter,
   CompanionTurn,
@@ -40,21 +40,24 @@ import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
 
 /**
  * The macOS companion surface (LUM-3086): the assistant's avatar floating from
- * app launch, expanding into a pill that carries the voice and type-chat
- * options, and expanding the same way while a call runs.
+ * app launch, with a pill carrying the voice and type-chat options unfurling
+ * beside it, and unfurling the same way while a call runs.
  *
- * **The mascot is the fixed point.** The body unfurls out of an avatar that
- * holds one x-position in every state, so the surface reads as one object
- * changing shape rather than a series of different objects, and the eye and the
- * cursor always have the same target to aim at. Placement is therefore a
- * position (`left: 50%` plus the avatar's own half-width) rather than a
- * transform, and only `width` animates.
+ * **Two elements, and the mascot is the fixed point.** The creature and the
+ * pill are siblings with {@link GAP} between them rather than one box holding
+ * the other. The avatar holds one point in the canvas in every state, which is
+ * the point the host positions this window around, so the surface reads as one
+ * object changing shape rather than a series of different objects and the eye
+ * and the cursor always have the same target to aim at. The pill hangs off it:
+ * its avatar-facing edge sits the avatar's half box plus the gap from that
+ * point, and its bottom edge sits on the avatar's bottom, so the two keep one
+ * baseline whatever the pill is carrying. Only the pill's `width` animates.
  *
- * **Growth needs clearance on the side it runs into**, `width - 44` of it:
- * 228px expanded and 316px at its widest. A circle parked against the right
- * edge does not have it, and unclamped the body would run straight off the
- * display with the controls the user was reaching for. So the surface flips and
- * grows the other way instead, the way a menu does, through {@link growth}.
+ * **Growth needs clearance on the side it runs into**: the gap, and then a body
+ * that reaches 316px at its widest. A circle parked against the right edge does
+ * not have it, and unclamped the pill would run straight off the display with
+ * the controls the user was reaching for. So the surface flips and grows the
+ * other way instead, the way a menu does, through {@link growth}.
  *
  * **Presentational only.** Phase comes from the caller, so this renders
  * identically in Storybook and in the Electron panel. Hover is a phase rather
@@ -172,11 +175,21 @@ const ASSISTANT_TURN_PHASES = new Set(["transcribing", "thinking", "speaking"]);
  */
 const WATCHING_RING_ACCENT = "#ff9f45";
 
-// The avatar is a fixed 44px disc in every state; only the body around it
+// The avatar is a fixed 44px disc in every state; only the pill beside it
 // changes. That is what makes this one surface expanding rather than three
 // surfaces that happen to share a colour, and it is the property to protect as
 // the states gain content.
 const AVATAR_BOX = 44;
+
+/**
+ * The room between the avatar's edge and the pill.
+ *
+ * Read from the contract rather than stated here, because main sizes the canvas
+ * to hold the same distance: what decides how wide the window has to be is the
+ * pill's reach past the avatar, and a second copy of the number is a pill drawn
+ * further out than the room main left for it.
+ */
+const GAP = companionGapFor(AVATAR_BOX, AVATAR_BOX);
 
 /**
  * The avatar artwork inside that box, which is inset by {@link INNER_GAP} on
@@ -203,19 +216,19 @@ const AVATAR_IMAGE = 28;
 const INNER_GAP = 8;
 
 /**
- * Widths to use until the content has been measured.
+ * Body widths to use until the content has been measured.
  *
- * The real width is the avatar plus whatever the body actually needs, measured
- * at runtime, because a fixed width is only ever right by accident: the pill
- * was 188pt against a body that wanted less, and `flex-1` piled the difference
- * up after the last control as dead space, so the right end sat further from
- * its content than the left did from the avatar.
+ * The body alone, since the avatar is a sibling of the pill rather than
+ * something inside it: the pill is as wide as its content, plus an
+ * {@link INNER_GAP} at either end, measured at runtime because a fixed width is
+ * only ever right by accident. A pill wider than its body leaves `flex-1` to
+ * pile the difference up after the last control as dead space.
  *
  * Measuring is also what makes the surface survive its own roadmap. Once
  * plugins contribute actions (LUM-3097) no hardcoded number can be correct, and
  * these become nothing but the value for the first frame.
  *
- * **Every entry stays at or under 360**, which is `BASE_MAX_PILL_WIDTH` in
+ * **Every entry stays at or under 316**, which is `BASE_MAX_BODY_WIDTH` in
  * `companion-window.ts`. The window is a fixed canvas sized once for the widest
  * state the surface has, so the ceiling is the host's rather than this file's:
  * a state that wanted more would be clipped by the window, and buying the room
@@ -223,23 +236,25 @@ const INNER_GAP = 8;
  * avoid.
  */
 export const FALLBACK_WIDTHS: Record<CompanionSurfacePhase, number> = {
-  resting: AVATAR_BOX,
+  // Nothing at all: at rest there is no pill, and its box goes with it.
+  resting: 0,
   // Three icon-only controls, which is the row as it is first drawn: the labels
   // are revealed one at a time under the pointer, and on the first frame there
   // is no pointer on any of them yet.
-  hover: 156,
+  hover: 112,
   // The same row of controls hover draws, since the session is run from it
   // rather than from a row of its own, plus the one word the running session
   // pins open on the control holding it.
-  watching: 195,
+  watching: 151,
   // Two labelled controls, both drawn: this row is a question waiting on an
   // answer rather than a set of ways in, so its words are not the pointer's to
   // reveal. That is what makes it wider than the idle row it stands in for.
-  summary: 264,
+  summary: 220,
   // The row with the stop control on it, which is the widest a call draws: a
   // watch session adds a fifth control to the four the call already has.
-  call: 332,
-  typing: 360,
+  call: 288,
+  // The card's body, which is {@link CARD_WIDTH} rather than anything measured.
+  typing: 316,
 };
 
 /**
@@ -250,7 +265,7 @@ export const FALLBACK_WIDTHS: Record<CompanionSurfacePhase, number> = {
  * measuring it would size the card to whatever the last turn happened to say
  * and reflow the whole surface on every message.
  */
-const CARD_WIDTH = 360;
+const CARD_WIDTH = 316;
 
 /**
  * The tallest the conversation gets before it scrolls.
@@ -323,11 +338,12 @@ export interface CompanionSurfaceProps {
    */
   onHoverStart?: () => void;
   /**
-   * Collapse. Wired to the whole surface rather than the avatar, because once
-   * expanded the pointer has to be able to travel from the avatar to the
-   * controls. Leaving on the avatar would collapse the pill out from under the
-   * hand reaching for it, and while resting the surface *is* the avatar, so
-   * the two agree exactly when it matters.
+   * Collapse. Wired to the group holding the avatar, the gap and the pill
+   * rather than to the avatar, because once expanded the pointer has to be able
+   * to travel across the gap to the controls. Leaving on the avatar would
+   * collapse the pill out from under the hand reaching for it, and while
+   * resting the avatar is all the group has drawn in it, so the two agree
+   * exactly when it matters.
    */
   onHoverEnd?: () => void;
   /** Which way the pill grows. See {@link CompanionSurfaceGrowth}. */
@@ -348,16 +364,28 @@ export interface CompanionSurfaceProps {
    */
   rootRef?: Ref<HTMLDivElement>;
   /**
-   * Begin a drag. Everything that is not a control is a handle, so this is
-   * wired to the surface and the controls stop the press from reaching it.
+   * The avatar's own element.
+   *
+   * Handed out for the reason {@link CompanionSurfaceProps.rootRef} is, and
+   * separately from it: the avatar and the pill are siblings with a gap between
+   * them, so the host hit-tests a union of their rects rather than one box. A
+   * box drawn around both would claim the empty canvas above and below the gap
+   * and swallow the presses landing there.
+   */
+  avatarRef?: Ref<HTMLDivElement>;
+  /**
+   * Begin a drag. Everything drawn that is not a control is a handle, so this
+   * is wired to the avatar and to the pill, and the controls stop the press
+   * from reaching it. The gap between the two is not a handle: there is nothing
+   * drawn in it to grab.
    */
   onSurfaceMouseDown?: (event: ReactMouseEvent<HTMLDivElement>) => void;
   /**
-   * Open the surface's own menu, which a right-click anywhere on it asks for.
+   * Open the surface's own menu, which a right-click on the avatar or the pill
+   * asks for.
    *
-   * On the whole surface rather than the avatar: at rest the two are the same
-   * box, and when expanded a user reaching for "make this go away" should not
-   * have to find the mascot inside the pill first.
+   * On both rather than on the avatar alone: a user reaching for "make this go
+   * away" should not have to find the mascot beside the pill first.
    */
   onSurfaceContextMenu?: (event: ReactMouseEvent<HTMLDivElement>) => void;
   /**
@@ -597,6 +625,7 @@ export function CompanionSurface({
   growth = "right",
   cardGrowth = "up",
   rootRef,
+  avatarRef,
   onSurfaceMouseDown,
   onSurfaceContextMenu,
   spotlight,
@@ -664,123 +693,82 @@ export function CompanionSurface({
     };
   }, [phase]);
 
-  // The avatar's 44pt box sits flush, because its image is already inset by
-  // `INNER_GAP` inside it. Only the trailing end needs the gap added, since the
-  // last control's own box ends where the body does.
+  // The body and the clearance at either end of it, and nothing else: the
+  // avatar has a box of its own beside the pill rather than a column inside it.
   const width = typing
     ? CARD_WIDTH
-    : AVATAR_BOX +
-      (!expanded
-        ? 0
-        : (contentWidth ?? FALLBACK_WIDTHS[phase] - AVATAR_BOX) + INNER_GAP);
+    : !expanded
+      ? 0
+      : (contentWidth ?? FALLBACK_WIDTHS[phase]) + 2 * INNER_GAP;
+
+  /**
+   * A line in the canvas, given how far it sits from the avatar's centre.
+   *
+   * The canvas is *not* symmetric about the avatar: the card's height is
+   * reserved on whichever side it grows into, so the avatar sits
+   * `COMPANION_NEAR_EDGE` from the other edge, and that edge is the one worth
+   * anchoring to. `100%` names the canvas without this side having to know how
+   * tall main made it.
+   */
+  const lineAt = (offset: number): string =>
+    cardGrowth === "up"
+      ? `calc(100% - ${COMPANION_NEAR_EDGE - offset}px)`
+      : `${COMPANION_NEAR_EDGE + offset}px`;
 
   // **The avatar never moves.** It holds one spot in the canvas, which is the
-  // spot the host positions this window around, and the body runs off one side
-  // of it. Growing from the pill's centre instead would slide the mascot to a
-  // different x-position in every state, so the surface would read as a series
-  // of different objects rather than one object changing shape, and the user's
-  // eye and cursor would have no fixed target to aim at.
+  // spot the host positions this window around, and the pill hangs off one side
+  // of it across the gap. Growing from the pill's centre instead would slide
+  // the mascot to a different x-position in every state, so the surface would
+  // read as a series of different objects rather than one object changing
+  // shape, and the user's eye and cursor would have no fixed target to aim at.
   //
-  // Each direction therefore fixes the avatar's own edge to the centre and lets
-  // the body run the other way: this anchors the surface by the edge the avatar
-  // is on, and the avatar's own row is mirrored below so the avatar ends up
-  // against that edge. Both halves are required. Anchoring by the right edge without
-  // mirroring puts the avatar at the far end of the pill, which is a different
-  // point from the one the host positioned the window by, and every drag,
-  // clamp and direction check main makes from then on is measured against a
-  // place the avatar is not.
+  // So each direction pins the pill's avatar-facing edge that far out from the
+  // centre and lets the body run the rest of the way: the pill is what moves
+  // when `growth` flips, and the creature the host measures every drag, clamp
+  // and direction check against is not.
   const placement: CSSProperties =
     growth === "left"
-      ? { right: "50%", marginRight: -(AVATAR_BOX / 2) }
-      : { left: "50%", marginLeft: -(AVATAR_BOX / 2) };
+      ? { right: `calc(50% + ${AVATAR_BOX / 2 + GAP}px)` }
+      : { left: `calc(50% + ${AVATAR_BOX / 2 + GAP}px)` };
 
-  // The vertical half of the same idea, against a canvas that is *not*
-  // symmetric about the avatar. The card's height is reserved on whichever side
-  // it grows into, so the avatar sits `COMPANION_NEAR_EDGE` from the other
-  // edge, and that edge is the one worth anchoring to: `100%` names the canvas
-  // without this side having to know how tall main made it.
-  const anchor: CSSProperties =
-    cardGrowth === "up"
-      ? { top: `calc(100% - ${COMPANION_NEAR_EDGE}px)` }
-      : { top: COMPANION_NEAR_EDGE };
+  // The card growing downward draws its composer row first, so the row starts
+  // on the avatar's top line and the card falls away from it; everything else
+  // hangs upward off the avatar's bottom line.
+  const dropsFromTheRow = typing && cardGrowth === "down";
 
   const style: CSSProperties = {
     width,
     ...placement,
-    ...anchor,
-    // The composer row holds the line the pill occupied and the conversation
-    // stacks off it, so the avatar never moves when Type is pressed and never
-    // moves again as turns arrive. Which way it stacks is the host's call:
-    // parked by the Dock a card growing down would grow off the bottom of the
-    // screen, and at the top of the display a card growing up has nowhere to be
-    // (see `CompanionSurfaceCardGrowth`).
-    transform: typing
-      ? cardGrowth === "up"
-        ? `translateY(calc(-100% + ${AVATAR_BOX / 2}px))`
-        : `translateY(-${AVATAR_BOX / 2}px)`
-      : "translateY(-50%)",
+    // **Bottom-flush with the avatar.** The pill's bottom edge sits on the
+    // avatar's, and the card keeps that line: its composer row is the column's
+    // last child growing up and its first growing down, so the row's bottom is
+    // the avatar's bottom either way and the mascot does not move when Type is
+    // pressed. Which way the card stacks is the host's call: parked by the Dock
+    // a card growing down would grow off the bottom of the screen, and at the
+    // top of the display a card growing up has nowhere to be (see
+    // `CompanionSurfaceCardGrowth`).
+    top: lineAt(dropsFromTheRow ? -(AVATAR_BOX / 2) : AVATAR_BOX / 2),
+    transform: dropsFromTheRow ? "none" : "translateY(-100%)",
     // Settles rather than overshoots. A surface on screen all day should not
     // bounce every time the pointer crosses it.
     transitionTimingFunction: "cubic-bezier(.2,.8,.2,1)",
     ["--accent" as string]: accentHex,
   };
 
-  return (
-    // A fragment, so the introduction's card is a sibling of the pill rather
-    // than a child of it. Inside, it would sit in the box whose width animates
-    // from state to state and be clipped by the pill's own rounding; beside it,
-    // both hang off the same fixed avatar position in the canvas.
+  /**
+   * The surface's edge, lit for something running and flared for each capture.
+   *
+   * Drawn around the avatar at rest and around the pill once there is one. The
+   * pill is nothing at rest, so the avatar is the only edge there is to light,
+   * and it is the state the ring most has to be legible in: the whole point is
+   * being readable from the corner of an eye while the user works elsewhere.
+   * Expanded, the pill is the surface's outline and takes it back.
+   */
+  const edge = (
     <>
-      {/* The whole surface is the drag handle. Controls opt out by stopping the
-        press, so everything that is not a button can be grabbed, which at rest
-        means the avatar and when expanded means the pill around the controls. */}
-      <div
-        className={`absolute cursor-grab transition-[width] duration-300 select-none will-change-[width] active:cursor-grabbing ${
-          typing
-            ? // The composer row is the column's last child, so a card growing
-              // downward reverses the column for the same reason a pill growing
-              // leftward reverses the row: the row that holds the avatar's line
-              // has to end up against the avatar, and the turns stack away from
-              // it.
-              `flex rounded-[22px] ${cardGrowth === "up" ? "flex-col" : "flex-col-reverse"}`
-            : "flex h-11 items-center rounded-full"
-        } ${
-          // Alignment, not ordering. The row is `INNER_GAP` narrower than the
-          // pill, because that gap is trailing space past the last control, so
-          // the row has to sit against the end the avatar is anchored to and
-          // leave the slack at the other. Reversing a one-item row is how a
-          // `flex-start` box puts its item at the far end. The card is a column
-          // whose row is stretched to its full width, so it needs no help.
-          growth === "left" && !typing ? "flex-row-reverse" : ""
-        }`}
-        style={style}
-        onMouseLeave={onHoverEnd}
-        onMouseDown={onSurfaceMouseDown}
-        onContextMenu={onSurfaceContextMenu}
-        ref={rootRef}
-      >
-        {/* The pill's body, which exists only once there is a pill. At rest the
-          surface is the avatar and nothing else: a dark disc with a border
-          drawn around a round avatar reads as a hard ring the avatar happens to
-          sit inside, and stacked under the glow it is two rings. Fading the
-          body in with the expansion also gives the avatar something to grow
-          out of. */}
-        <span
-          className={`absolute inset-0 border border-white/10 bg-[#17181b]/95 shadow-lg shadow-black/40 transition-opacity duration-200 ${
-            // Radius follows the same rule as the gap: the controls are 28pt so
-            // their radius is 14, and 8pt of clearance puts the outer radius at
-            // 22. A pill happens to reach that by being 44 tall; the card has to
-            // say it.
-            typing ? "rounded-[22px]" : "rounded-full"
-          }`}
-          style={{ opacity: expanded ? 1 : 0 }}
-          aria-hidden
-        />
-        {/* Something running, as a light travelling around the surface's edge.
-          Drawn over the body so it reads as the surface's own border in every
-          state, and outside it by a hair so it never crowds the avatar at rest,
-          which is the state it has to be legible in: the whole point is being
-          readable from the corner of an eye while the user works elsewhere.
+      {/* Something running, as a light travelling around the edge. Drawn over
+          the body so it reads as the surface's own border, and outside it by a
+          hair so it never crowds what it is drawn around.
 
           A turn burns it in the assistant's colour, a watch session in amber,
           and the session's ring is drawn in every phase rather than only the
@@ -788,125 +776,208 @@ export function CompanionSurface({
           true: the creature already carries the turn in its own pose, and a
           capture running with nothing drawn over it is the worse of the two
           failures. */}
-        {(assistantWorking || watching || summarizing) && (
-          <span
-            className={`companion-working-ring pointer-events-none absolute -inset-0.5 ${
-              typing ? "rounded-[24px]" : "rounded-full"
-            }`}
-            style={{
-              ["--companion-ring-accent" as string]: watching
-                ? WATCHING_RING_ACCENT
-                : accentHex,
-            }}
-            aria-hidden
-          />
-        )}
-        {/* One capture, as a single breath of light around the same edge.
-
-            The ring says a session is running, which is a state; this says the
-            screen was read just now, which is an event, and the two need
-            different treatments or the second is invisible inside the first. The
-            same edge rather than a mark of its own, because the edge is already
-            where the user looks for this surface's state and a capture is that
-            state doing something.
-
-            Keyed by the captures this surface has watched arrive, so each one
-            remounts the element and replays a one-shot animation. That is the
-            whole mechanism: a step is a read the runtime took and kept, and
-            there is no other way for this to fire. It cannot pulse in a gap, it
-            cannot pulse for a read that failed, timed out, or was cut off by the
-            session ending, because none of those advance the count, and it
-            cannot pulse for the count a reload handed it, because a first value
-            is a baseline rather than a step. */}
-        {watching && observedCaptures > 0 && (
-          <span
-            key={observedCaptures}
-            className={`companion-capture-pulse pointer-events-none absolute -inset-0.5 ${
-              typing ? "rounded-[24px]" : "rounded-full"
-            }`}
-            style={{
-              ["--companion-ring-accent" as string]: WATCHING_RING_ACCENT,
-            }}
-            aria-hidden
-          />
-        )}
-        {typing && turns.length > 0 && <RecentTurns turns={turns} />}
-        {/* The avatar's own row, and the half of the mirroring that orders it.
-          This row is the surface's only in-flow child, so it is the one place
-          the reversal has any ordering to do: reversing the surface around it
-          moves the row within the box and leaves the avatar wherever the row
-          put it. The avatar has to land against the edge `placement` anchored
-          by, since that edge is derived from the point the host positioned the
-          window by. True of the card as much as the pill, and the card is
-          anchored the same way with a card's width to be wrong by, so this
-          holds whether or not the composer is open. */}
-        <div
-          className={`relative flex h-11 shrink-0 items-center ${
-            growth === "left" ? "flex-row-reverse" : ""
+      {(assistantWorking || watching || summarizing) && (
+        <span
+          className={`companion-working-ring pointer-events-none absolute -inset-0.5 ${
+            typing ? "rounded-[24px]" : "rounded-full"
           }`}
+          style={{
+            ["--companion-ring-accent" as string]: watching
+              ? WATCHING_RING_ACCENT
+              : accentHex,
+          }}
+          aria-hidden
+        />
+      )}
+      {/* One capture, as a single breath of light around the same edge.
+
+          The ring says a session is running, which is a state; this says the
+          screen was read just now, which is an event, and the two need
+          different treatments or the second is invisible inside the first. The
+          same edge rather than a mark of its own, because the edge is already
+          where the user looks for this surface's state and a capture is that
+          state doing something.
+
+          Keyed by the captures this surface has watched arrive, so each one
+          remounts the element and replays a one-shot animation. That is the
+          whole mechanism: a step is a read the runtime took and kept, and
+          there is no other way for this to fire. It cannot pulse in a gap, it
+          cannot pulse for a read that failed, timed out, or was cut off by the
+          session ending, because none of those advance the count, and it
+          cannot pulse for the count a reload handed it, because a first value
+          is a baseline rather than a step. */}
+      {watching && observedCaptures > 0 && (
+        <span
+          key={observedCaptures}
+          className={`companion-capture-pulse pointer-events-none absolute -inset-0.5 ${
+            typing ? "rounded-[24px]" : "rounded-full"
+          }`}
+          style={{
+            ["--companion-ring-accent" as string]: WATCHING_RING_ACCENT,
+          }}
+          aria-hidden
+        />
+      )}
+    </>
+  );
+
+  return (
+    // A fragment, so the introduction's card is a sibling of the surface rather
+    // than a child of it. Inside, it would sit in the box whose width animates
+    // from state to state and be clipped by the pill's own rounding; beside it,
+    // both hang off the same fixed avatar position in the canvas.
+    <>
+      {/* The avatar, the pill, and the gap between them, as one group.
+
+        Its box is the whole canvas so the `50%` and `100%` its children anchor
+        by still name the canvas, and it takes no pointer of its own, so the
+        pointer is inside it exactly when it is on the avatar, the pill or the
+        bridge across the gap. Leaving the group is therefore leaving the whole
+        surface, which is what lets a hand travel from the creature to the
+        controls without the pill collapsing out from under it. */}
+      <div
+        className="pointer-events-none absolute inset-0"
+        onMouseLeave={onHoverEnd}
+      >
+        {/* The pill is a drag handle, as the avatar is. Controls opt out by
+          stopping the press, so everything on it that is not a button can be
+          grabbed. */}
+        <div
+          className={`pointer-events-auto absolute cursor-grab transition-[width] duration-300 select-none will-change-[width] active:cursor-grabbing ${
+            typing
+              ? // The composer row is the column's last child, so a card growing
+                // downward reverses the column: the row that holds the avatar's
+                // line has to stay on that line, and the turns stack away from
+                // it.
+                `flex rounded-[22px] ${cardGrowth === "up" ? "flex-col" : "flex-col-reverse"}`
+              : "flex h-11 items-center rounded-full"
+          }`}
+          style={style}
+          onMouseDown={onSurfaceMouseDown}
+          onContextMenu={onSurfaceContextMenu}
+          ref={rootRef}
         >
-          <Avatar
-            glow={glow && !expanded}
-            accentHex={accentHex}
-            avatarSrc={avatarSrc}
-            character={character}
-            attentive={hovered}
-            // The assistant's own turn. The creature stops blinking and holds a
-            // focused, morphing pose, which is the same treatment the chat avatar
-            // uses while a reply is streaming: one vocabulary for "it is working"
-            // wherever the user meets it.
-            busy={assistantWorking}
-            onMouseEnter={onHoverStart}
-            onClick={onAvatarClick}
+          {/* The pill's body, which exists only once there is a pill. At rest
+            there is nothing beside the avatar to draw, and fading the body in
+            as the width grows is what makes the pill unfurl out of the gap
+            rather than appear in it. */}
+          <span
+            className={`absolute inset-0 border border-white/10 bg-[#17181b]/95 shadow-lg shadow-black/40 transition-opacity duration-200 ${
+              // Radius follows the same rule as the gap: the controls are 28pt
+              // so their radius is 14, and 8pt of clearance puts the outer
+              // radius at 22. A pill happens to reach that by being 44 tall;
+              // the card has to say it.
+              typing ? "rounded-[22px]" : "rounded-full"
+            }`}
+            style={{ opacity: expanded ? 1 : 0 }}
+            aria-hidden
           />
-          {typing ? (
-            <Composer
-              assistantName={assistantName}
-              growth={growth}
-              watching={watching}
-              onSubmit={onSubmit}
-              onCancel={onCancelTyping}
-              onWatch={onWatch}
-            />
-          ) : (
-            <div
-              className="relative flex min-w-0 items-center gap-1 overflow-hidden transition-opacity duration-200"
-              ref={contentRef}
-              // Faded out is not gone: the body stays mounted while collapsed so
-              // it can be measured, which would otherwise leave its controls
-              // focusable and announced while nothing is drawn. `inert` takes
-              // them out of the tab order and the accessibility tree without
-              // taking them out of the DOM, so the measurement still works.
-              inert={!expanded}
-              style={{
-                opacity: expanded ? 1 : 0,
-                // Contents fade after the body has somewhere to put them, so
-                // nothing is ever drawn wider than the pill carrying it.
-                transitionDelay: expanded ? "120ms" : "0ms",
-              }}
-            >
-              {phase === "call" ? (
-                <CallBody
-                  call={call}
-                  watching={watching}
-                  onControl={onControl}
-                  onWatch={onWatch}
-                />
-              ) : phase === "summary" && watchRetro !== undefined ? (
-                <SummaryBody retro={watchRetro} onWatchRetro={onWatchRetro} />
-              ) : (
-                <IdleBody
-                  spotlight={spotlight}
-                  watching={watching}
-                  watchEnabled={watchEnabled}
-                  onTalk={onTalk}
-                  onType={onType}
-                  onWatch={onWatch}
-                />
-              )}
-            </div>
-          )}
+          {expanded && edge}
+          {typing && turns.length > 0 && <RecentTurns turns={turns} />}
+          {/* The pill's one in-flow row, and where the clearance at either end
+            lives. On the row rather than on the pill, so the pill's own box
+            goes to nothing at rest while the body inside it keeps being
+            measured. */}
+          <div
+            className="relative flex h-11 shrink-0 items-center"
+            style={{ paddingInline: INNER_GAP }}
+          >
+            {typing ? (
+              <Composer
+                assistantName={assistantName}
+                watching={watching}
+                onSubmit={onSubmit}
+                onCancel={onCancelTyping}
+                onWatch={onWatch}
+              />
+            ) : (
+              <div
+                className="relative flex min-w-0 items-center gap-1 overflow-hidden transition-opacity duration-200"
+                ref={contentRef}
+                // Faded out is not gone: the body stays mounted while collapsed
+                // so it can be measured, which would otherwise leave its
+                // controls focusable and announced while nothing is drawn.
+                // `inert` takes them out of the tab order and the accessibility
+                // tree without taking them out of the DOM, so the measurement
+                // still works.
+                inert={!expanded}
+                style={{
+                  opacity: expanded ? 1 : 0,
+                  // Contents fade after the body has somewhere to put them, so
+                  // nothing is ever drawn wider than the pill carrying it.
+                  transitionDelay: expanded ? "120ms" : "0ms",
+                }}
+              >
+                {phase === "call" ? (
+                  <CallBody
+                    call={call}
+                    watching={watching}
+                    onControl={onControl}
+                    onWatch={onWatch}
+                  />
+                ) : phase === "summary" && watchRetro !== undefined ? (
+                  <SummaryBody retro={watchRetro} onWatchRetro={onWatchRetro} />
+                ) : (
+                  <IdleBody
+                    spotlight={spotlight}
+                    watching={watching}
+                    watchEnabled={watchEnabled}
+                    onTalk={onTalk}
+                    onType={onType}
+                    onWatch={onWatch}
+                  />
+                )}
+              </div>
+            )}
+          </div>
         </div>
+        {/* The gap, as an element rather than empty canvas. Nothing is drawn in
+          it and nothing can be grabbed by it: it is here so a pointer crossing
+          from the creature to the controls stays inside the group and the pill
+          is not pulled out from under the hand halfway. The host hit-tests the
+          same span from the two rects (`bridgeRect` in
+          `companion-surface-page.tsx`), since a click-through window is told
+          about the pointer in coordinates rather than in elements. */}
+        {expanded && (
+          <span
+            className="pointer-events-auto absolute"
+            style={{
+              width: GAP,
+              height: AVATAR_BOX,
+              ...(growth === "left"
+                ? { right: `calc(50% + ${AVATAR_BOX / 2}px)` }
+                : { left: `calc(50% + ${AVATAR_BOX / 2}px)` }),
+              top: lineAt(0),
+              transform: "translateY(-50%)",
+            }}
+            aria-hidden
+          />
+        )}
+        {/* Drawn last so the glow, which falls off well past the creature,
+          lands over the pill's leading edge rather than under it. */}
+        <Avatar
+          glow={glow}
+          accentHex={accentHex}
+          avatarSrc={avatarSrc}
+          character={character}
+          attentive={hovered}
+          // The assistant's own turn. The creature stops blinking and holds a
+          // focused, morphing pose, which is the same treatment the chat avatar
+          // uses while a reply is streaming: one vocabulary for "it is working"
+          // wherever the user meets it.
+          busy={assistantWorking}
+          edge={expanded ? null : edge}
+          style={{
+            left: "50%",
+            top: lineAt(0),
+            transform: "translate(-50%, -50%)",
+          }}
+          elementRef={avatarRef}
+          onMouseEnter={onHoverStart}
+          onMouseDown={onSurfaceMouseDown}
+          onContextMenu={onSurfaceContextMenu}
+          onClick={onAvatarClick}
+        />
       </div>
       {intro}
     </>
@@ -1061,15 +1132,12 @@ function RecentTurns({ turns }: { turns: CompanionTurn[] }) {
  */
 function Composer({
   assistantName,
-  growth = "right",
   watching,
   onSubmit,
   onCancel,
   onWatch,
 }: {
   assistantName: string;
-  /** Which side the avatar sits on, so the padding can go on the other one. */
-  growth?: CompanionSurfaceGrowth;
   /**
    * Whether a watch session is running, so the card can carry the way to end
    * it. The card replaces the pill while it is open, and a session the user
@@ -1106,14 +1174,9 @@ function Composer({
   };
 
   return (
-    // The gap goes on the edge away from the avatar. The avatar's row reverses
-    // with `growth`, so a fixed side would put the whole gap between the field
-    // and the avatar and leave the text flush against the card's outer edge.
-    <div
-      className={`relative flex min-w-0 flex-1 items-center gap-1 ${
-        growth === "left" ? "pl-2" : "pr-2"
-      }`}
-    >
+    // Flush inside the row, which carries the clearance at both ends for the
+    // composer and the control rows alike.
+    <div className="relative flex min-w-0 flex-1 items-center gap-1">
       <input
         ref={inputRef}
         type="text"
@@ -1183,6 +1246,10 @@ function Composer({
 /**
  * The avatar, and the only part of the surface that arms the expansion.
  *
+ * Positioned on the point the host put the window around rather than laid out
+ * in the pill, which is what lets the pill change width and shape underneath
+ * without the creature moving a pixel.
+ *
  * The glow sits behind the image and is blurred well past it, so it falls off
  * into the desktop rather than ending on an edge. A halo sized to its own
  * source has nowhere to fall off and reads as a ring around the avatar rather
@@ -1192,7 +1259,9 @@ function Composer({
  * `transform` on its own `<svg>` for the breathe and the morph, and a second
  * animation on that node would silently replace one of them. Everything that
  * belongs to the creature rides inside the wrapper, glow included, so the light
- * travels with what is casting it.
+ * travels with what is casting it. The edge is outside it, because a ring
+ * saying the assistant is working belongs to the surface rather than to the
+ * creature's own idle motion.
  */
 function Avatar({
   glow,
@@ -1201,7 +1270,12 @@ function Avatar({
   character,
   busy = false,
   attentive = false,
+  edge,
+  style,
+  elementRef,
   onMouseEnter,
+  onMouseDown,
+  onContextMenu,
   onClick,
 }: {
   glow: boolean;
@@ -1210,7 +1284,16 @@ function Avatar({
   character?: CompanionCharacter;
   busy?: boolean;
   attentive?: boolean;
+  /**
+   * What the surface's edge is drawing, while the avatar is that edge. Null
+   * once there is a pill, which takes it back.
+   */
+  edge?: ReactNode;
+  style?: CSSProperties;
+  elementRef?: Ref<HTMLDivElement>;
   onMouseEnter?: () => void;
+  onMouseDown?: (event: ReactMouseEvent<HTMLDivElement>) => void;
+  onContextMenu?: (event: ReactMouseEvent<HTMLDivElement>) => void;
   onClick?: () => void;
 }) {
   // Belt and braces alongside the `prefers-reduced-motion` block beside the
@@ -1224,10 +1307,15 @@ function Avatar({
     // read as activating a control. `onClick` fires only for presses the caller
     // decided were not drags.
     <div
-      className="relative grid size-11 shrink-0 place-items-center"
+      className="pointer-events-auto absolute grid size-11 cursor-grab place-items-center active:cursor-grabbing"
+      style={style}
+      ref={elementRef}
       onMouseEnter={onMouseEnter}
+      onMouseDown={onMouseDown}
+      onContextMenu={onContextMenu}
       onClick={onClick}
     >
+      {edge}
       <div
         className="companion-avatar-bob relative grid place-items-center"
         style={{ animation: reduce ? "none" : undefined }}

--- a/packages/ipc-contract/src/types.ts
+++ b/packages/ipc-contract/src/types.ts
@@ -812,6 +812,39 @@ export const COMPANION_NEAR_EDGE =
   COMPANION_BASE_AVATAR_BOX / 2 + COMPANION_BASE_CANVAS_PAD;
 
 /**
+ * The room between the avatar's edge and the options pill beside it, at the
+ * base size.
+ *
+ * A gap rather than a shared edge. The avatar is a creature standing on the
+ * desktop and the pill is what it is holding out, so the two read as one
+ * surface by sitting near each other rather than by being fused into a single
+ * outline. It is also what gives the glow somewhere to fall off into, instead
+ * of ending against the pill's border.
+ */
+export const COMPANION_BASE_GAP = 12;
+
+/**
+ * That gap for a given pair of boxes.
+ *
+ * Scaled by the smaller of the two, because the gap is breathing room and the
+ * smaller object is the one that decides how much of it there is: a modest
+ * avatar beside an enormous pill wants the modest avatar's clearance, not the
+ * chasm the pill's own scale would ask for.
+ *
+ * Derived here rather than on each side of the bridge, for the reason
+ * {@link COMPANION_NEAR_EDGE} is: main sizes the canvas to hold the pill's
+ * reach past the avatar and the renderer positions the pill by the same
+ * distance, so two copies of this drifting is a pill drawn somewhere main did
+ * not leave room for.
+ */
+export const companionGapFor = (
+  avatarBox: number,
+  optionsBox: number,
+): number =>
+  (COMPANION_BASE_GAP * Math.min(avatarBox, optionsBox)) /
+  COMPANION_BASE_AVATAR_BOX;
+
+/**
  * The assistant's character, as the three trait ids it is composed from.
  *
  * Structurally the fields of the web layer's `CharacterTraits` that


### PR DESCRIPTION
## Summary
- The avatar and the options pill are separate elements with a gap; the avatar stays the fixed point and the pill sits bottom-flush beside it
- Contract gains COMPANION_BASE_GAP / companionGapFor; main's canvas and growth clearance include the gap
- Renderer hit-testing is a union of avatar, pill, bridge and intro rects, so the gap never leaves the window interactive over empty canvas

Part of plan: companion-avatar-restyle.md (PR 2 of 3)