### PR TITLE
fix(web): Back from a chat-opened skill returns to the conversation (LUM-3433)

### DIFF
--- a/clients/web/src/domains/chat/components/chat-content-layout.tsx
+++ b/clients/web/src/domains/chat/components/chat-content-layout.tsx
@@ -11,7 +11,7 @@
  */
 
 import { lazy, useCallback, useEffect, type ReactNode } from "react";
-import { useNavigate } from "react-router";
+import { useLocation, useNavigate } from "react-router";
 import { Loader2 } from "lucide-react";
 import { AnimatedRightDrawer } from "@/domains/chat/components/animated-right-drawer";
 import { LazyBoundary } from "@/components/lazy-boundary";
@@ -38,6 +38,7 @@ import { notifyChannelSetupHandedOff } from "@/domains/chat/channel-setup-close-
 import { useEditApp } from "@/hooks/use-edit-app";
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { routes } from "@/utils/routes";
+import { skillDetailBackState } from "@/utils/skills";
 
 // Import thunks for the lazy panel chunks, shared by the React.lazy wrappers
 // below and the idle-prefetch effect. Once a thunk has run, the browser module
@@ -132,8 +133,7 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
   );
   const activeSkillDetailId = useViewerStore.use.activeSkillDetailId();
   const activeChannelSetup = useViewerStore.use.activeChannelSetup();
-  const activeChannelTranscript =
-    useViewerStore.use.activeChannelTranscript();
+  const activeChannelTranscript = useViewerStore.use.activeChannelTranscript();
 
   const isSharing = useDeployStore.use.isSharing();
   const isDeploying = useDeployStore.use.isDeploying();
@@ -141,6 +141,7 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
 
   const isMobile = useIsMobile();
   const navigate = useNavigate();
+  const location = useLocation();
   const editApp = useEditApp();
 
   // -------------------------------------------------------------------------
@@ -287,8 +288,10 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
       return;
     }
     useViewerStore.getState().closeSkillDetail();
-    navigate(routes.skills.detail(activeSkillDetailId));
-  }, [isMobile, mainView, activeSkillDetailId, navigate]);
+    navigate(routes.skills.detail(activeSkillDetailId), {
+      state: skillDetailBackState(location),
+    });
+  }, [isMobile, mainView, activeSkillDetailId, navigate, location]);
 
   // -------------------------------------------------------------------------
   // Escape closes whichever right-hand side panel is open (tool detail /
@@ -605,10 +608,7 @@ export function ChatContentLayout(props: ChatMainPanelProps) {
           onClose={onCloseChannelSetup}
         />
       );
-    } else if (
-      mainView === "channel-transcript" &&
-      activeChannelTranscript
-    ) {
+    } else if (mainView === "channel-transcript" && activeChannelTranscript) {
       rightPanel = (
         <LazyBoundary>
           {/* Re-key per thread so switching conversations remounts the panel

--- a/clients/web/src/domains/chat/components/skill-detail-panel.test.tsx
+++ b/clients/web/src/domains/chat/components/skill-detail-panel.test.tsx
@@ -18,7 +18,13 @@
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 
 import type {
@@ -98,11 +104,14 @@ function skillQueryKey() {
   }).queryKey;
 }
 
-function renderPanel(client: QueryClient = makeQueryClient()): QueryClient {
+function renderPanel(
+  client: QueryClient = makeQueryClient(),
+  onClose: () => void = () => {},
+): QueryClient {
   render(
     <MemoryRouter>
       <QueryClientProvider client={client}>
-        <SkillDetailPanel skillId={SKILL_ID} onClose={() => {}} />
+        <SkillDetailPanel skillId={SKILL_ID} onClose={onClose} />
       </QueryClientProvider>
     </MemoryRouter>,
   );
@@ -169,5 +178,23 @@ describe("SkillDetailPanel skill query states", () => {
       expect(screen.getByText(ERROR_COPY)).toBeTruthy();
     });
     expect(screen.queryByText(SKILL_DESCRIPTION)).toBeNull();
+  });
+
+  test("Go to Skill closes the panel on hand-off to the dedicated page", async () => {
+    // The dedicated page supersedes the in-place panel. Leaving the panel's
+    // store state set would re-render it from stale state on the return trip
+    // to the conversation, as a dead drawer if the skill was removed there.
+    let closed = 0;
+    renderPanel(makeQueryClient(), () => {
+      closed += 1;
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(SKILL_DESCRIPTION)).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByText("Go to Skill"));
+
+    expect(closed).toBe(1);
   });
 });

--- a/clients/web/src/domains/chat/components/skill-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/skill-detail-panel.tsx
@@ -17,7 +17,7 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Brain, Loader2, MoreHorizontal, Trash2 } from "lucide-react";
 import { useState } from "react";
-import { useNavigate } from "react-router";
+import { useLocation, useNavigate } from "react-router";
 
 import { Button, Menu, Typography } from "@vellumai/design-library";
 
@@ -34,7 +34,11 @@ import { useSkillDetailFiles } from "@/hooks/use-skill-detail-files";
 import { captureError } from "@/lib/sentry/capture-error";
 import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import { routes } from "@/utils/routes";
-import { invalidateSkillsList, isRemovableSkill } from "@/utils/skills";
+import {
+  invalidateSkillsList,
+  isRemovableSkill,
+  skillDetailBackState,
+} from "@/utils/skills";
 
 interface SkillDetailPanelProps {
   skillId: string;
@@ -44,6 +48,7 @@ interface SkillDetailPanelProps {
 export function SkillDetailPanel({ skillId, onClose }: SkillDetailPanelProps) {
   const { t } = useTranslation("chat");
   const navigate = useNavigate();
+  const location = useLocation();
   const queryClient = useQueryClient();
   const assistantId = useResolvedAssistantsStore.use.activeAssistantId();
   const [confirmingRemoval, setConfirmingRemoval] = useState(false);
@@ -139,7 +144,13 @@ export function SkillDetailPanel({ skillId, onClose }: SkillDetailPanelProps) {
         }
         footer={
           <div className="flex justify-end">
-            <Button onClick={() => navigate(routes.skills.detail(skillId))}>
+            <Button
+              onClick={() =>
+                navigate(routes.skills.detail(skillId), {
+                  state: skillDetailBackState(location),
+                })
+              }
+            >
               {t("skillDetailPanel.goToSkill")}
             </Button>
           </div>

--- a/clients/web/src/domains/chat/components/skill-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/skill-detail-panel.tsx
@@ -146,11 +146,10 @@ export function SkillDetailPanel({ skillId, onClose }: SkillDetailPanelProps) {
           <div className="flex justify-end">
             <Button
               onClick={() => {
-                // The dedicated page supersedes the in-place panel, so close
-                // it on hand-off (matching the narrow-viewport redirect in
-                // chat-content-layout.tsx). Otherwise the return trip to the
-                // conversation re-renders the panel from stale store state,
-                // as a dead drawer if the skill was removed on the page.
+                // The dedicated page supersedes the in-place panel: close it
+                // on hand-off, or the backTo return trip re-renders it from
+                // stale viewer-store state (a dead drawer once the skill is
+                // removed on the page).
                 onClose();
                 navigate(routes.skills.detail(skillId), {
                   state: skillDetailBackState(location),

--- a/clients/web/src/domains/chat/components/skill-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/skill-detail-panel.tsx
@@ -145,11 +145,17 @@ export function SkillDetailPanel({ skillId, onClose }: SkillDetailPanelProps) {
         footer={
           <div className="flex justify-end">
             <Button
-              onClick={() =>
+              onClick={() => {
+                // The dedicated page supersedes the in-place panel, so close
+                // it on hand-off (matching the narrow-viewport redirect in
+                // chat-content-layout.tsx). Otherwise the return trip to the
+                // conversation re-renders the panel from stale store state,
+                // as a dead drawer if the skill was removed on the page.
+                onClose();
                 navigate(routes.skills.detail(skillId), {
                   state: skillDetailBackState(location),
-                })
-              }
+                });
+              }}
             >
               {t("skillDetailPanel.goToSkill")}
             </Button>

--- a/clients/web/src/domains/chat/components/skill-detail-panel.tsx
+++ b/clients/web/src/domains/chat/components/skill-detail-panel.tsx
@@ -146,10 +146,8 @@ export function SkillDetailPanel({ skillId, onClose }: SkillDetailPanelProps) {
           <div className="flex justify-end">
             <Button
               onClick={() => {
-                // The dedicated page supersedes the in-place panel: close it
-                // on hand-off, or the backTo return trip re-renders it from
-                // stale viewer-store state (a dead drawer once the skill is
-                // removed on the page).
+                // Close the in-place panel before handing off to the
+                // dedicated page, which supersedes it.
                 onClose();
                 navigate(routes.skills.detail(skillId), {
                   state: skillDetailBackState(location),

--- a/clients/web/src/domains/chat/components/surfaces/skill-created-card.test.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/skill-created-card.test.tsx
@@ -43,11 +43,15 @@ function makeSurface(overrides: Partial<Surface> = {}): Surface {
   };
 }
 
-/** Exposes the router's current URL so tests can assert navigation. */
+/** Exposes the router's current URL and state so tests can assert navigation. */
 function LocationProbe() {
   const location = useLocation();
+  const state = location.state as { backTo?: string } | null;
   return (
-    <div data-testid="location">{`${location.pathname}${location.search}`}</div>
+    <>
+      <div data-testid="location">{`${location.pathname}${location.search}`}</div>
+      <div data-testid="location-back-to">{state?.backTo ?? ""}</div>
+    </>
   );
 }
 
@@ -142,6 +146,11 @@ describe("SkillCreatedCard", () => {
 
     expect(getByTestId("location").textContent).toBe(
       "/assistant/skills/skill-2",
+    );
+    // The conversation's location rides along as router state so the detail
+    // page's back affordances return here instead of the Superpowers list.
+    expect(getByTestId("location-back-to").textContent).toBe(
+      "/assistant/conversations/conv-xyz",
     );
     // The panel path is not taken on mobile.
     expect(useViewerStore.getState().mainView).toBe("chat");

--- a/clients/web/src/domains/chat/components/surfaces/skill-created-card.tsx
+++ b/clients/web/src/domains/chat/components/surfaces/skill-created-card.tsx
@@ -1,5 +1,5 @@
 import { Brain } from "lucide-react";
-import { useNavigate } from "react-router";
+import { useLocation, useNavigate } from "react-router";
 
 import type { Surface } from "@/domains/chat/types/types";
 
@@ -11,6 +11,7 @@ import {
 import { useIsMobile } from "@/hooks/use-is-mobile";
 import { useViewerStore } from "@/stores/viewer-store";
 import { routes } from "@/utils/routes";
+import { skillDetailBackState } from "@/utils/skills";
 import { useTranslation } from "@/i18n";
 
 /**
@@ -69,6 +70,7 @@ function parseSkills(skills: unknown): SkillCardEntry[] {
 export function SkillCreatedCard({ surface, onAction }: SkillCreatedCardProps) {
   const { t } = useTranslation("chat");
   const navigate = useNavigate();
+  const location = useLocation();
   const isMobile = useIsMobile();
   const skills = parseSkills(surface.data.skills);
 
@@ -78,7 +80,9 @@ export function SkillCreatedCard({ surface, onAction }: SkillCreatedCardProps) {
   // chat-content-layout.tsx), so deep-link to the dedicated detail page.
   const handleView = (skillId: string) => {
     if (isMobile) {
-      navigate(routes.skills.detail(skillId));
+      navigate(routes.skills.detail(skillId), {
+        state: skillDetailBackState(location),
+      });
       return;
     }
     useViewerStore.getState().openSkillDetail(skillId);

--- a/clients/web/src/domains/intelligence/components/skills/skill-detail-mobile.tsx
+++ b/clients/web/src/domains/intelligence/components/skills/skill-detail-mobile.tsx
@@ -33,6 +33,12 @@ interface SkillDetailMobileProps {
   assistantId: string;
   skill: SkillInfo;
   onBack: () => void;
+  /**
+   * True when `onBack` returns to the conversation the skill was opened
+   * from (chat-origin `backTo` router state) rather than the skills list,
+   * so the back control announces where it actually lands.
+   */
+  backToConversation?: boolean;
   onInstall?: () => void;
   onRemove?: () => void;
   isInstalling?: boolean;
@@ -73,6 +79,7 @@ export function SkillDetailMobile({
   assistantId,
   skill,
   onBack,
+  backToConversation = false,
   onInstall,
   onRemove,
   isInstalling = false,
@@ -136,7 +143,11 @@ export function SkillDetailMobile({
           variant="ghost"
           iconOnly={<ArrowLeft aria-hidden />}
           expandOnMobile
-          aria-label={t("skillDetail.backToSkillsAriaLabel")}
+          aria-label={t(
+            backToConversation
+              ? "skillDetail.backToConversationAriaLabel"
+              : "skillDetail.backToSkillsAriaLabel",
+          )}
           onClick={onBack}
           className="max-md:bg-[var(--surface-active)]"
         />

--- a/clients/web/src/domains/intelligence/components/skills/skill-detail.tsx
+++ b/clients/web/src/domains/intelligence/components/skills/skill-detail.tsx
@@ -59,6 +59,12 @@ interface SkillDetailProps {
   tab: SkillDetailTab;
   onTabChange: (tab: SkillDetailTab) => void;
   onBack: () => void;
+  /**
+   * True when `onBack` returns to the conversation the skill was opened
+   * from (chat-origin `backTo` router state) rather than the skills list,
+   * so the back control announces where it actually lands.
+   */
+  backToConversation?: boolean;
   onInstall?: () => void;
   onRemove?: () => void;
   isInstalling?: boolean;
@@ -76,6 +82,7 @@ export function SkillDetail({
   tab,
   onTabChange,
   onBack,
+  backToConversation = false,
   onInstall,
   onRemove,
   isInstalling = false,
@@ -121,7 +128,11 @@ export function SkillDetail({
         type="button"
         variant="ghost"
         iconOnly={<ArrowLeft aria-hidden />}
-        aria-label={t("skillDetail.backToSkillsAriaLabel")}
+        aria-label={t(
+          backToConversation
+            ? "skillDetail.backToConversationAriaLabel"
+            : "skillDetail.backToSkillsAriaLabel",
+        )}
         onClick={onBack}
       />
       <div className="flex min-w-0 flex-1 flex-col gap-3 sm:flex-row sm:items-center">

--- a/clients/web/src/domains/intelligence/skill-detail-page.test.tsx
+++ b/clients/web/src/domains/intelligence/skill-detail-page.test.tsx
@@ -13,6 +13,9 @@
  *   instead of a false "Skill not found",
  * - the back button restores the My Superpowers list's query string passed
  *   as router state (search/filter/category survive detail navigation),
+ * - a chat origin passed as `backTo` router state wins over the list
+ *   fallback, so Back returns to the conversation the skill was opened
+ *   from (and a malformed value degrades to the list),
  * - the desktop Files/History tab rides `?tab=`: a `?tab=history` deep link
  *   opens on History, and a tab change writes the param back (deleting it
  *   for the default Files tab).
@@ -153,6 +156,15 @@ function SuperpowersListLanding() {
   return <div>Superpowers list at: [{location.search}]</div>;
 }
 
+// Sentinel at the conversation route so tests can prove a chat-origin back
+// navigation landed on the conversation it came from.
+function ConversationLanding() {
+  const location = useLocation();
+  return (
+    <div>Conversation at: [{`${location.pathname}${location.search}`}]</div>
+  );
+}
+
 // Sentinel beside the detail route so tests can prove what a tab change wrote
 // to the URL.
 function DetailSearchProbe() {
@@ -164,18 +176,27 @@ function renderDetail({
   skillId,
   search = "",
   listSearch,
+  backTo,
   client = makeQueryClient(),
 }: {
   skillId: string;
   /** Query string the detail route is entered with, e.g. `?tab=history`. */
   search?: string;
   listSearch?: string;
+  /** Chat-origin location passed as router state, e.g. a conversation URL. */
+  backTo?: string;
   client?: QueryClient;
 }): void {
   const entry = {
     pathname: `/assistant/skills/${skillId}`,
     search,
-    state: listSearch === undefined ? null : { listSearch },
+    state:
+      listSearch === undefined && backTo === undefined
+        ? null
+        : {
+            ...(listSearch === undefined ? null : { listSearch }),
+            ...(backTo === undefined ? null : { backTo }),
+          },
   };
   render(
     <MemoryRouter initialEntries={[entry]}>
@@ -193,6 +214,10 @@ function renderDetail({
           <Route
             path="/assistant/superpowers"
             element={<SuperpowersListLanding />}
+          />
+          <Route
+            path="/assistant/conversations/:conversationId"
+            element={<ConversationLanding />}
           />
         </Routes>
       </QueryClientProvider>
@@ -366,6 +391,69 @@ describe("SkillDetailPage back navigation", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Superpowers list at: []")).toBeTruthy();
+    });
+  });
+
+  test("back returns to the conversation passed as backTo router state", async () => {
+    renderDetail({
+      skillId: "skill-1",
+      backTo: "/assistant/conversations/conv-1?scrollToMessage=msg-9",
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Detail: Fresh Skill")).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByText("Back to skills"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          "Conversation at: [/assistant/conversations/conv-1?scrollToMessage=msg-9]",
+        ),
+      ).toBeTruthy();
+    });
+  });
+
+  test("a malformed backTo degrades to the list fallback", async () => {
+    // Router state never round-trips through the URL, but the page still
+    // refuses anything that could read as an external or scheme-relative
+    // destination.
+    renderDetail({ skillId: "skill-1", backTo: "//evil.example/phish" });
+
+    await waitFor(() => {
+      expect(screen.getByText("Detail: Fresh Skill")).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByText("Back to skills"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Superpowers list at: []")).toBeTruthy();
+    });
+  });
+
+  test("a tab change keeps the chat origin that Back restores", async () => {
+    // Tab changes replace the history entry and carry `location.state`
+    // forward, so the conversation origin has to survive the switch the
+    // same way the list search does.
+    renderDetail({
+      skillId: "skill-1",
+      backTo: "/assistant/conversations/conv-1",
+    });
+    await waitFor(() => {
+      expect(screen.getByText("Tab: files")).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByText("Open history"));
+    await waitFor(() => {
+      expect(screen.getByText("Tab: history")).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByText("Back to skills"));
+    await waitFor(() => {
+      expect(
+        screen.getByText("Conversation at: [/assistant/conversations/conv-1]"),
+      ).toBeTruthy();
     });
   });
 });

--- a/clients/web/src/domains/intelligence/skill-detail-page.test.tsx
+++ b/clients/web/src/domains/intelligence/skill-detail-page.test.tsx
@@ -99,10 +99,11 @@ mock.module(
   "@/domains/intelligence/components/skills/skill-detail",
   (): Partial<typeof SkillDetailModule> => ({
     parseSkillDetailTab,
-    SkillDetail: ({ skill, tab, onTabChange, onBack }) => (
+    SkillDetail: ({ skill, tab, onTabChange, onBack, backToConversation }) => (
       <div>
         <span>Detail: {skill.name}</span>
         <span>Tab: {tab}</span>
+        <span>BackDest: {backToConversation ? "conversation" : "skills"}</span>
         <button type="button" onClick={() => onTabChange("history")}>
           Open history
         </button>
@@ -403,6 +404,8 @@ describe("SkillDetailPage back navigation", () => {
     await waitFor(() => {
       expect(screen.getByText("Detail: Fresh Skill")).toBeTruthy();
     });
+    // The back control announces the conversation destination, not the list.
+    expect(screen.getByText("BackDest: conversation")).toBeTruthy();
 
     fireEvent.click(screen.getByText("Back to skills"));
 
@@ -411,6 +414,25 @@ describe("SkillDetailPage back navigation", () => {
         screen.getByText(
           "Conversation at: [/assistant/conversations/conv-1?scrollToMessage=msg-9]",
         ),
+      ).toBeTruthy();
+    });
+  });
+
+  test("the not-found exit is labelled for the conversation origin", async () => {
+    renderDetail({
+      skillId: "missing-skill",
+      backTo: "/assistant/conversations/conv-1",
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Skill not found")).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByText("Back to conversation"));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Conversation at: [/assistant/conversations/conv-1]"),
       ).toBeTruthy();
     });
   });

--- a/clients/web/src/domains/intelligence/skill-detail-page.tsx
+++ b/clients/web/src/domains/intelligence/skill-detail-page.tsx
@@ -213,7 +213,11 @@ export function SkillDetailPage() {
           leftIcon={<ArrowLeft aria-hidden />}
           onClick={handleBack}
         >
-          {t("skillDetailPage.backToSuperpowers")}
+          {t(
+            backTo
+              ? "skillDetailPage.backToConversation"
+              : "skillDetailPage.backToSuperpowers",
+          )}
         </Button>
       </SkillsStateCard>
     );
@@ -223,6 +227,7 @@ export function SkillDetailPage() {
     assistantId,
     skill,
     onBack: handleBack,
+    backToConversation: backTo !== null,
     onInstall: () => handleInstall(skill),
     onRemove: () => handleRemove(skill),
     isInstalling: isInstallingSkill(skill),

--- a/clients/web/src/domains/intelligence/skill-detail-page.tsx
+++ b/clients/web/src/domains/intelligence/skill-detail-page.tsx
@@ -127,7 +127,8 @@ export function SkillDetailPage() {
   }, [navigate, exitTarget]);
 
   // Register as the mobile back-swipe owner so a left-edge swipe navigates
-  // back to the skills list instead of opening the nav drawer (`ChatLayout`
+  // to the exit target (the origin conversation when `backTo` is present,
+  // otherwise the skills list) instead of opening the nav drawer (`ChatLayout`
   // only yields the edge while an owner is registered). The container ref is
   // threaded into `SkillDetailMobile`'s portaled overlay root — a page-level
   // wrapper wouldn't contain the overlay's DOM, so the drag transform would

--- a/clients/web/src/domains/intelligence/skill-detail-page.tsx
+++ b/clients/web/src/domains/intelligence/skill-detail-page.tsx
@@ -50,13 +50,28 @@ export function SkillDetailPage() {
   const isMobile = useIsMobile();
   const swipeContainerRef = useRef<HTMLDivElement>(null);
 
-  // The My Superpowers list passes its current query string
-  // (search/filter/category) as router state so the back button restores the
-  // same filtered view. Direct deep-links carry no state and fall back to
-  // the plain list.
-  const routerState = location.state as { listSearch?: unknown } | null;
+  // Two origins ride in as router state. The My Superpowers list passes its
+  // current query string (search/filter/category) as `listSearch` so the back
+  // button restores the same filtered view. Chat surfaces (the skill-created
+  // card, the panel's "Go to skill" button, and the narrow-viewport panel
+  // hand-off) pass their conversation location as `backTo` so every back
+  // affordance returns to the conversation the skill was opened from. Direct
+  // deep-links carry no state and fall back to the plain list.
+  const routerState = location.state as {
+    listSearch?: unknown;
+    backTo?: unknown;
+  } | null;
   const listSearch =
     typeof routerState?.listSearch === "string" ? routerState.listSearch : "";
+  // In-app pathname+search only. State never round-trips through the URL,
+  // but the guard keeps a malformed value from reading as an external or
+  // scheme-relative destination.
+  const backTo =
+    typeof routerState?.backTo === "string" &&
+    routerState.backTo.startsWith("/") &&
+    !routerState.backTo.startsWith("//")
+      ? routerState.backTo
+      : null;
 
   // The desktop view's Files/History tab rides `?tab=`, so an in-chat card
   // can link straight to a skill's history
@@ -94,12 +109,22 @@ export function SkillDetailPage() {
     refetchOnMount: "always",
   });
 
+  // Where leaving the page lands: the conversation the skill was opened
+  // from when the entry carried one, otherwise the (possibly filtered) list.
+  const exitTarget = backTo ?? `${routes.superpowers}${listSearch}`;
+
   const handleBack = useCallback(() => {
+    // Push, don't replace: the origin is a live page, so history stays
+    // walkable and browser Back can still reach this detail entry.
+    navigate(exitTarget);
+  }, [navigate, exitTarget]);
+
+  const handleRemovedExit = useCallback(() => {
     // Replace (rather than push) so browser Back doesn't bounce the user
-    // back to the detail entry — which may be a not-found page after the
-    // skill was removed via `onRemoved`.
-    navigate(`${routes.superpowers}${listSearch}`, { replace: true });
-  }, [navigate, listSearch]);
+    // back to this detail entry, a not-found page once the skill is
+    // removed.
+    navigate(exitTarget, { replace: true });
+  }, [navigate, exitTarget]);
 
   // Register as the mobile back-swipe owner so a left-edge swipe navigates
   // back to the skills list instead of opening the nav drawer (`ChatLayout`
@@ -114,9 +139,9 @@ export function SkillDetailPage() {
     onBack: handleBack,
     enabled: isMobile,
     navKey: pathname,
-    // Path only: the list's search params are carried by `handleBack` and
-    // play no part in matching the route branch to warm.
-    prefetchHref: routes.superpowers,
+    // Path only: the exit target's search params are carried by `handleBack`
+    // and play no part in matching the route branch to warm.
+    prefetchHref: exitTarget.split("?")[0] ?? exitTarget,
   });
 
   const {
@@ -127,7 +152,7 @@ export function SkillDetailPage() {
     skillPendingRemoval,
     confirmRemove,
     cancelRemove,
-  } = useSkillActions(assistantId, { onRemoved: handleBack });
+  } = useSkillActions(assistantId, { onRemoved: handleRemovedExit });
 
   const skills = skillsQuery.data;
   const skill = useMemo(

--- a/clients/web/src/i18n/locales/en/intelligence.json
+++ b/clients/web/src/i18n/locales/en/intelligence.json
@@ -279,6 +279,7 @@
     "workspace": "Workspace"
   },
   "skillDetail": {
+    "backToConversationAriaLabel": "Back to conversation",
     "backToSkillsAriaLabel": "Back to skills",
     "filesTab": "Files",
     "fileViewModeAriaLabel": "File view mode",
@@ -295,6 +296,7 @@
     "source": "Source"
   },
   "skillDetailPage": {
+    "backToConversation": "Back to conversation",
     "backToSuperpowers": "Back to My Superpowers",
     "notFoundSubtitle": "This skill may have been removed, or the link is out of date.",
     "notFoundTitle": "Skill not found"

--- a/clients/web/src/i18n/locales/es/intelligence.json
+++ b/clients/web/src/i18n/locales/es/intelligence.json
@@ -279,6 +279,7 @@
     "workspace": "Espacio de trabajo"
   },
   "skillDetail": {
+    "backToConversationAriaLabel": "Volver a la conversación",
     "backToSkillsAriaLabel": "Volver a las habilidades",
     "filesTab": "Archivos",
     "fileViewModeAriaLabel": "Modo de vista de archivo",
@@ -295,6 +296,7 @@
     "source": "Código"
   },
   "skillDetailPage": {
+    "backToConversation": "Volver a la conversación",
     "backToSuperpowers": "Volver a Mis superpoderes",
     "notFoundSubtitle": "Es posible que esta habilidad se haya eliminado, o que el enlace esté obsoleto.",
     "notFoundTitle": "Habilidad no encontrada"

--- a/clients/web/src/i18n/locales/ru/intelligence.json
+++ b/clients/web/src/i18n/locales/ru/intelligence.json
@@ -279,6 +279,7 @@
     "workspace": "Рабочая область"
   },
   "skillDetail": {
+    "backToConversationAriaLabel": "Назад к диалогу",
     "backToSkillsAriaLabel": "Назад к навыкам",
     "filesTab": "Файлы",
     "fileViewModeAriaLabel": "Режим просмотра файла",
@@ -295,6 +296,7 @@
     "source": "Код"
   },
   "skillDetailPage": {
+    "backToConversation": "Назад к диалогу",
     "backToSuperpowers": "Назад к моим суперсилам",
     "notFoundSubtitle": "Этот навык могли удалить, или ссылка устарела.",
     "notFoundTitle": "Навык не найден"

--- a/clients/web/src/utils/skills.test.ts
+++ b/clients/web/src/utils/skills.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+
+import { skillDetailBackState } from "@/utils/skills";
+
+describe("skillDetailBackState", () => {
+  test("serializes pathname, search, and hash", () => {
+    expect(
+      skillDetailBackState({
+        pathname: "/assistant/conversations/conv-1",
+        search: "?scrollToMessage=msg-9",
+        hash: "#top",
+      }),
+    ).toEqual({
+      backTo: "/assistant/conversations/conv-1?scrollToMessage=msg-9#top",
+    });
+  });
+
+  test("strips auto-send params so a return trip cannot re-send the prompt", () => {
+    // Relay callers keep `?prompt=&relay=` in the URL after dispatch
+    // (use-auto-send-effects.ts); a preserved copy in the return location
+    // would re-send on remount. Unrelated params survive.
+    expect(
+      skillDetailBackState({
+        pathname: "/assistant/conversations/conv-1",
+        search: "?prompt=do%20it%20again&relay=tok-1&scrollToMessage=msg-9",
+        hash: "",
+      }),
+    ).toEqual({
+      backTo: "/assistant/conversations/conv-1?scrollToMessage=msg-9",
+    });
+  });
+
+  test("drops the query separator when stripping empties the search", () => {
+    expect(
+      skillDetailBackState({
+        pathname: "/assistant/conversations/conv-1",
+        search: "?prompt=hello",
+        hash: "",
+      }),
+    ).toEqual({ backTo: "/assistant/conversations/conv-1" });
+  });
+});

--- a/clients/web/src/utils/skills.ts
+++ b/clients/web/src/utils/skills.ts
@@ -38,3 +38,19 @@ export function invalidateSkillsList(
     queryKey: skillsGetQueryKey({ path: { assistant_id: assistantId } }),
   });
 }
+
+/**
+ * Router state a chat surface attaches when opening the skill detail page
+ * (`routes.skills.detail`), so the page's back affordances return to the
+ * conversation the skill was opened from instead of the My Superpowers list.
+ *
+ * `skill-detail-page.tsx` is the one reader; it validates the value before
+ * trusting it, so deep links and stale history entries degrade to the list.
+ */
+export function skillDetailBackState(location: {
+  pathname: string;
+  search: string;
+  hash: string;
+}): { backTo: string } {
+  return { backTo: `${location.pathname}${location.search}${location.hash}` };
+}

--- a/clients/web/src/utils/skills.ts
+++ b/clients/web/src/utils/skills.ts
@@ -52,5 +52,15 @@ export function skillDetailBackState(location: {
   search: string;
   hash: string;
 }): { backTo: string } {
-  return { backTo: `${location.pathname}${location.search}${location.hash}` };
+  // `?prompt=` / `?relay=` are auto-send commands (use-auto-send-effects.ts).
+  // Relay callers deliberately keep them in the URL after dispatch, so a
+  // return trip would remount the chat view, reset its consumed-prompt ref,
+  // and send the prompt again. Strip them from the return location.
+  const params = new URLSearchParams(location.search);
+  params.delete("prompt");
+  params.delete("relay");
+  const search = params.toString();
+  return {
+    backTo: `${location.pathname}${search ? `?${search}` : ""}${location.hash}`,
+  };
 }


### PR DESCRIPTION
## Summary

- TL;DR: Back from a skill page opened in chat now returns to the conversation, not the My Superpowers list. The three chat entry points (the "I learned a new skill" card on mobile, the side panel's "Go to skill" button, and the narrow-viewport panel hand-off) attach the conversation's location as `backTo` router state through a shared `skillDetailBackState` helper; the page validates the value and keeps the list as the fallback for list origins and deep links.
- Back exits now push history instead of replacing it. The `replace: true` exit survives only on the removed-skill path that motivated it, so browser Back can never land on a removed skill's not-found page, and can no longer lose the conversation either.

Why this is safe: the list origin and deep-link flows are untouched (no `backTo` state means the exact previous fallback), the new state is validated before use (non-string, external-looking, or scheme-relative values degrade to the list), and the page-level test suite pins all four back flows: list search restore, plain-list fallback, conversation return, and malformed-state degradation.

## What changes for the user

| Flow | Before | After |
| --- | --- | --- |
| Tap the "I learned a new skill" card in chat, then Back | Dumped on the My Superpowers list; the conversation is hard to find again | Returns to the conversation |
| Left-edge swipe back on that page (mobile) | Superpowers list | The conversation |
| "Go to skill" from the chat side panel, then Back | Superpowers list | The conversation |
| Open a skill from the My Superpowers list, then Back | Filtered list restored | Unchanged |
| Open a skill by direct link, then Back | Plain list | Unchanged |
| Browser Back after using the in-page Back | Cannot return to the skill page (history entry was replaced) | Returns to the skill page |
| Remove the skill | Exits so Back cannot hit the dead page | Unchanged (still a replace-style exit, now to the origin) |

Fixes LUM-3433

## Original prompt

Work through the Activation Hub backlog quick wins one at a time. First up: LUM-3433, where tapping the skill-learned card in a conversation and pressing Back dumped the user in the Superpowers list because `handleBack` was hardcoded to the list with a history replace. The fix carries the chat origin in router state (the same mechanism the list already uses for its query string), returns there on Back, and keeps the replace-style exit only for the removed-skill case.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41545" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->