### PR TITLE
Keep the default app icon's field color in dark mode

### DIFF
--- a/clients/ios/App/App/AppIcon-Dev.icon/icon.json
+++ b/clients/ios/App/App/AppIcon-Dev.icon/icon.json
@@ -1,7 +1,17 @@
 {
-  "fill": {
-    "solid": "display-p3:1.00000,0.53333,0.78824,1.00000"
-  },
+  "fill-specializations": [
+    {
+      "value": {
+        "solid": "display-p3:1.00000,0.53333,0.78824,1.00000"
+      }
+    },
+    {
+      "appearance": "dark",
+      "value": {
+        "solid": "display-p3:1.00000,0.53333,0.78824,1.00000"
+      }
+    }
+  ],
   "groups": [
     {
       "blend-mode": "normal",

--- a/clients/ios/App/App/AppIcon-Staging.icon/icon.json
+++ b/clients/ios/App/App/AppIcon-Staging.icon/icon.json
@@ -1,7 +1,17 @@
 {
-  "fill": {
-    "solid": "display-p3:0.91373,0.78824,0.10196,1.00000"
-  },
+  "fill-specializations": [
+    {
+      "value": {
+        "solid": "display-p3:0.91373,0.78824,0.10196,1.00000"
+      }
+    },
+    {
+      "appearance": "dark",
+      "value": {
+        "solid": "display-p3:0.91373,0.78824,0.10196,1.00000"
+      }
+    }
+  ],
   "groups": [
     {
       "blend-mode": "normal",

--- a/clients/ios/App/App/AppIcon.icon/icon.json
+++ b/clients/ios/App/App/AppIcon.icon/icon.json
@@ -1,7 +1,17 @@
 {
-  "fill": {
-    "solid": "display-p3:0.37749,0.60064,0.34581,1.00000"
-  },
+  "fill-specializations": [
+    {
+      "value": {
+        "solid": "display-p3:0.37749,0.60064,0.34581,1.00000"
+      }
+    },
+    {
+      "appearance": "dark",
+      "value": {
+        "solid": "display-p3:0.37749,0.60064,0.34581,1.00000"
+      }
+    }
+  ],
   "groups": [
     {
       "blend-mode": "normal",

--- a/clients/ios/scripts/__tests__/ios-app-icon-ground.test.ts
+++ b/clients/ios/scripts/__tests__/ios-app-icon-ground.test.ts
@@ -26,15 +26,38 @@ function readGround(xcconfig: string): string | undefined {
   return /^APP_ICON_GROUND\s*=\s*(.+)$/m.exec(contents)?.[1]?.trim();
 }
 
-function readIconFill(icon: string): string {
+interface FillSpecialization {
+  appearance?: string;
+  value: { solid: string };
+}
+
+function readFillSpecializations(icon: string): FillSpecialization[] {
   const contents = readFileSync(join(APP_DIR, icon, "icon.json"), "utf8");
-  return JSON.parse(contents).fill.solid;
+  return JSON.parse(contents)["fill-specializations"];
+}
+
+/** The bundle pins every appearance to one color, so any specialization does. */
+function readIconFill(icon: string): string {
+  const solids = new Set(
+    readFillSpecializations(icon).map(({ value }) => value.solid),
+  );
+  expect(solids.size).toBe(1);
+  return [...solids][0] as string;
 }
 
 describe("ios app icon ground", () => {
   for (const { xcconfig, icon } of TARGETS) {
     test(`${xcconfig} carries ${icon}'s own fill`, () => {
       expect(readGround(xcconfig)).toBe(readIconFill(icon));
+    });
+  }
+
+  for (const { icon } of TARGETS) {
+    test(`${icon} pins its dark appearance to the same fill`, () => {
+      const appearances = readFillSpecializations(icon).map(
+        ({ appearance }) => appearance,
+      );
+      expect(appearances).toContain("dark");
     });
   }
 


### PR DESCRIPTION
## What

The three Icon Composer bundles (`AppIcon.icon`, `AppIcon-Dev.icon`, `AppIcon-Staging.icon`) declared only a root-level `fill`, which Icon Composer treats as the light-appearance background. With no dark specialization, iOS substituted its own near-black field in dark appearance, so the home screen and the icon-change confirmation alert showed a black tile with white eyes instead of the environment's brand color (green / pink / yellow).

This pins the dark appearance to the exact same solid each bundle already used, via root-level `fill-specializations`. Each file keeps its own color string unchanged.

The eyes layer's own `fill-specializations` (`{"appearance": "dark", "value": "none"}`) is untouched, as are `groups` and `supported-platforms`.

## Consumer updates

`clients/ios/scripts/__tests__/ios-app-icon-ground.test.ts` read `JSON.parse(contents).fill.solid` to pin each extension target's `APP_ICON_GROUND` to the bundle it ships. It now reads `fill-specializations` and asserts every specialization carries the same solid, plus a new case asserting each bundle declares a `dark` specialization.

`clients/macos/scripts/generate-icon.sh` also reads a `json["fill"]`, but from its own bundles under `clients/macos/build-resources/icons/`, which are not touched here.

## Verification

Rendered every rendition with `ictool` at 256x256 for all three bundles, before (`origin/main`) and after, and compared pixels programmatically.

Background samples at (128,20), (20,128), (128,236), sRGB 8-bit:

| Bundle | Rendition | Before | After |
|---|---|---|---|
| AppIcon | Default | `77,155,81` / `77,155,80` / `77,155,80` | unchanged |
| AppIcon | **Dark** | `50,49,50` / `35,35,34` / `20,20,20` | **`77,155,81` / `77,155,80` / `77,155,80`** |
| AppIcon-Dev | Default | `255,128,204` / `255,128,203` / `255,127,203` | unchanged |
| AppIcon-Dev | **Dark** | `50,49,50` / `35,35,34` / `20,20,20` | **`255,128,204` / `255,128,203` / `255,127,203`** |
| AppIcon-Staging | Default | `240,199,0` / `240,199,0` / `239,199,0` | unchanged |
| AppIcon-Staging | **Dark** | `50,49,50` / `35,35,34` / `20,20,20` | **`240,199,0` / `240,199,0` / `239,199,0`** |

Dark now matches Default exactly at every background sample point in all three bundles; before, it was the system near-black gradient.

Whole-image diffs against the `origin/main` render:

- `Default`: `differing=0/65536 (0.00%)` for all three bundles, so the light icon is byte-identical.
- `TintedLight`, `TintedDark`, `ClearLight`, `ClearDark`: `differing=0/65536 (0.00%)` for all three bundles, so the tinted and clear renditions still render and are unchanged.
- `Dark`: 82-90% of pixels changed, which is the fix.

Drift tests:

```
$ cd clients/ios && bun test scripts/__tests__/ios-app-icon-ground.test.ts scripts/__tests__/ios-default-icon-geometry.test.ts
 11 pass
 0 fail
```

(`scripts/__tests__/generate-avatar-icons.test.ts` fails locally on a bare worktree with `Cannot find module '@vellumai/avatar-manifest'`; verified it fails identically on unmodified `origin/main`, so it is a missing-`node_modules` artifact, not a regression. CI installs deps before running it.)

## Manual QA

- [ ] Install a Dev build, switch the device to dark appearance, confirm the home screen icon is pink rather than black.
- [ ] Trigger an app-icon change and confirm the system confirmation alert previews the brand color.
- [ ] Spot-check Staging and Production builds the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)