### PR TITLE
Chooser assistant avatars: read platform avatar_url (plan PRs 9 and 10)

### DIFF
--- a/clients/web/src/components/avatar/chooser-avatar-chip.tsx
+++ b/clients/web/src/components/avatar/chooser-avatar-chip.tsx
@@ -25,6 +25,8 @@ export interface ChooserAvatarChipProps {
   className?: string;
   /** Hide from assistive tech when a sibling already names the row. */
   decorative?: boolean;
+  /** Fires when `imageUrl` fails to load. */
+  onImageError?: () => void;
 }
 
 export function ChooserAvatarChip({
@@ -34,6 +36,7 @@ export function ChooserAvatarChip({
   fallback,
   className,
   decorative = false,
+  onImageError,
 }: ChooserAvatarChipProps) {
   const { t } = useTranslation();
   const components = useBundledAvatarComponents();
@@ -72,6 +75,7 @@ export function ChooserAvatarChip({
         height={size}
         className={`rounded-full object-cover ${className ?? ""}`.trim()}
         style={{ width: size, height: size, flexShrink: 0 }}
+        onError={onImageError}
       />
     );
   }

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.test.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.test.tsx
@@ -274,8 +274,10 @@ mock.module("@/domains/onboarding/components/add-remote-origin-dialog", () => ({
 
 const forgetAssistantAvatarMock = mock((_qc: unknown, _id: string) => {});
 const useChooserRowAvatarMock: Partial<typeof UseChooserRowAvatarModule> = {
-  useChooserRowAvatar: (assistant) =>
-    rowAvatars.get(assistant.id) ?? { traits: null, imageUrl: null },
+  useChooserRowAvatar: (assistant) => ({
+    onImageError: () => {},
+    ...(rowAvatars.get(assistant.id) ?? { traits: null, imageUrl: null }),
+  }),
   forgetAssistantAvatar: forgetAssistantAvatarMock,
 };
 mock.module("@/hooks/use-chooser-row-avatar", () => useChooserRowAvatarMock);
@@ -295,7 +297,10 @@ const chooserAvatarChipMock: Partial<typeof ChooserAvatarChipModule> = {
       fallback
     ),
 };
-mock.module("@/components/avatar/chooser-avatar-chip", () => chooserAvatarChipMock);
+mock.module(
+  "@/components/avatar/chooser-avatar-chip",
+  () => chooserAvatarChipMock,
+);
 
 mock.module("@/components/onboarding-layout", () => ({
   OnboardingLayout: ({ children }: { children: ReactNode }) => children,
@@ -1693,8 +1698,12 @@ describe("SelectAssistantScreen assistant avatars", () => {
     });
     render(<SelectAssistantScreen />);
     expect(screen.getByRole("radio", { name: /^Office Mac/ })).toBeTruthy();
-    expect(screen.queryByRole("radio", { name: /Assistant avatar/ })).toBeNull();
-    expect(screen.getByTestId("chooser-avatar-chip").getAttribute("alt")).toBe("");
+    expect(
+      screen.queryByRole("radio", { name: /Assistant avatar/ }),
+    ).toBeNull();
+    expect(screen.getByTestId("chooser-avatar-chip").getAttribute("alt")).toBe(
+      "",
+    );
   });
 
   test("a row with no avatar keeps its glyph", () => {

--- a/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
+++ b/clients/web/src/domains/onboarding/pages/select-assistant-screen.tsx
@@ -1176,7 +1176,7 @@ function AssistantCard({
 }) {
   const { t } = useTranslation("onboarding");
   const label = assistantLabel(assistant);
-  const { traits, imageUrl } = useChooserRowAvatar(assistant);
+  const { traits, imageUrl, onImageError } = useChooserRowAvatar(assistant);
   const glyph = assistant.isPaired ? (
     <Link2 className="h-5 w-5" />
   ) : assistant.isLocal ? (
@@ -1192,6 +1192,7 @@ function AssistantCard({
           imageUrl={imageUrl}
           fallback={glyph}
           decorative
+          onImageError={onImageError}
         />
       }
       title={label}

--- a/clients/web/src/hooks/use-assistant-resource-sync.test.tsx
+++ b/clients/web/src/hooks/use-assistant-resource-sync.test.tsx
@@ -33,6 +33,7 @@ import { SYNC_TAGS } from "@/lib/sync/types";
 import type { SyncChangedEvent } from "@/lib/sync/types";
 import { __resetForTesting, publish } from "@/lib/event-bus";
 import { getClientId } from "@/lib/telemetry/client-identity";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 
 function createWrapper(queryClient: QueryClient) {
   return function Wrapper({ children }: { children: ReactNode }) {
@@ -294,8 +295,7 @@ describe("useAssistantResourceSync", () => {
   test("invalidates app list queries on apps:list sync tag", async () => {
     const queryClient = freshQueryClient();
     let predicate:
-      | ((query: { queryKey: readonly unknown[] }) => boolean)
-      | undefined;
+      ((query: { queryKey: readonly unknown[] }) => boolean) | undefined;
     queryClient.invalidateQueries = ((arg: unknown) => {
       predicate = (
         arg as {
@@ -727,8 +727,7 @@ describe("useAssistantResourceSync", () => {
   test("invalidates home-feed query on home_feed_updated", async () => {
     const queryClient = freshQueryClient();
     let predicate:
-      | ((query: { queryKey: readonly unknown[] }) => boolean)
-      | undefined;
+      ((query: { queryKey: readonly unknown[] }) => boolean) | undefined;
     queryClient.invalidateQueries = ((arg: unknown) => {
       predicate = (
         arg as {
@@ -852,6 +851,41 @@ describe("useAssistantResourceSync", () => {
         },
       ]);
     });
+  });
+
+  test("avatar change events clear the row's synced avatarUrl; the reconnect sweep does not", async () => {
+    const seed = () =>
+      useResolvedAssistantsStore.setState({
+        assistants: [
+          {
+            id: "asst-1",
+            isLocal: false,
+            isPlatformHosted: true,
+            isPaired: false,
+            avatarUrl: "https://cdn.example/a.png",
+          },
+        ],
+      });
+    const avatarUrl = () =>
+      useResolvedAssistantsStore.getState().assistants[0]?.avatarUrl;
+    const queryClient = freshQueryClient();
+    queryClient.invalidateQueries = mock(() => Promise.resolve()) as never;
+    renderHook(() => useAssistantResourceSync("asst-1", true), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    seed();
+    emit({ type: "avatar_updated" } as unknown as AssistantEvent);
+    await waitFor(() => expect(avatarUrl()).toBeNull());
+
+    seed();
+    emit(syncEvent([SYNC_TAGS.assistantAvatar]) as unknown as AssistantEvent);
+    await waitFor(() => expect(avatarUrl()).toBeNull());
+
+    seed();
+    publish("sse.opened", { assistantId: "asst-1", cause: "error" });
+    await flushReconnectSweep();
+    expect(avatarUrl()).toBe("https://cdn.example/a.png");
   });
 
   test("invalidates avatar query on avatar_updated event", async () => {

--- a/clients/web/src/hooks/use-assistant-resource-sync.test.tsx
+++ b/clients/web/src/hooks/use-assistant-resource-sync.test.tsx
@@ -29,6 +29,7 @@ import { useAssistantResourceSync } from "@/hooks/use-assistant-resource-sync";
 import { assistantIdentityQueryKey } from "@/hooks/use-assistant-identity-init";
 import { avatarQueryKey } from "@/hooks/use-assistant-avatar";
 import { chooserRowAvatarQueryKeyPrefix } from "@/hooks/use-chooser-row-avatar";
+import { platformAvatarUrlsQueryKey } from "@/hooks/use-platform-avatar-urls";
 import { SYNC_TAGS } from "@/lib/sync/types";
 import type { SyncChangedEvent } from "@/lib/sync/types";
 import { __resetForTesting, publish } from "@/lib/event-bus";
@@ -886,6 +887,65 @@ describe("useAssistantResourceSync", () => {
     publish("sse.opened", { assistantId: "asst-1", cause: "error" });
     await flushReconnectSweep();
     expect(avatarUrl()).toBe("https://cdn.example/a.png");
+  });
+
+  test("avatar_updated drops the platform lookup entry without a refetch", async () => {
+    const queryClient = freshQueryClient();
+    queryClient.invalidateQueries = mock(() => Promise.resolve()) as never;
+    const key = platformAvatarUrlsQueryKey("user-1", null);
+    queryClient.setQueryData(
+      key,
+      new Map([
+        ["asst-1", "https://cdn.example/a.png"],
+        ["asst-2", "https://cdn.example/b.png"],
+      ]),
+    );
+    renderHook(() => useAssistantResourceSync("asst-1", true), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    emit({ type: "avatar_updated" } as unknown as AssistantEvent);
+    await waitFor(() => {
+      expect(
+        queryClient.getQueryData<Map<string, string>>(key)?.has("asst-1"),
+      ).toBe(false);
+    });
+    expect(
+      queryClient.getQueryData<Map<string, string>>(key)?.get("asst-2"),
+    ).toBe("https://cdn.example/b.png");
+    expect(queryClient.getQueryState(key)?.fetchStatus).toBe("idle");
+  });
+
+  test("avatar_updated drops the lookup entry under the row's platform id", async () => {
+    const queryClient = freshQueryClient();
+    queryClient.invalidateQueries = mock(() => Promise.resolve()) as never;
+    useResolvedAssistantsStore.setState({
+      assistants: [
+        {
+          id: "asst-1",
+          isLocal: true,
+          isPlatformHosted: false,
+          isPaired: false,
+          cloud: "local",
+          platformAssistantId: "uuid-1",
+        },
+      ],
+    });
+    const key = platformAvatarUrlsQueryKey("user-1", null);
+    queryClient.setQueryData(
+      key,
+      new Map([["uuid-1", "https://cdn.example/a.png"]]),
+    );
+    renderHook(() => useAssistantResourceSync("asst-1", true), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    emit({ type: "avatar_updated" } as unknown as AssistantEvent);
+    await waitFor(() => {
+      expect(
+        queryClient.getQueryData<Map<string, string>>(key)?.has("uuid-1"),
+      ).toBe(false);
+    });
   });
 
   test("invalidates avatar query on avatar_updated event", async () => {

--- a/clients/web/src/hooks/use-assistant-resource-sync.ts
+++ b/clients/web/src/hooks/use-assistant-resource-sync.ts
@@ -48,6 +48,7 @@ import { chooserRowAvatarQueryKeyPrefix } from "@/hooks/use-chooser-row-avatar";
 import { useBusSubscription } from "@/hooks/use-bus-subscription";
 import { getClientId } from "@/lib/telemetry/client-identity";
 import { SYNC_TAGS } from "@/lib/sync/types";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 
 /**
  * A reconnect can flap: error, reopen, error, reopen. Collapse a burst into
@@ -111,7 +112,7 @@ export function useAssistantResourceSync(
         for (const tag of event.tags) {
           switch (tag) {
             case SYNC_TAGS.assistantAvatar:
-              invalidateAvatarQueries(queryClient, assistantId);
+              onAvatarChanged(queryClient, assistantId);
               break;
             case SYNC_TAGS.assistantIdentity:
               void queryClient.invalidateQueries({
@@ -215,7 +216,7 @@ export function useAssistantResourceSync(
         return;
 
       case "avatar_updated":
-        invalidateAvatarQueries(queryClient, assistantId);
+        onAvatarChanged(queryClient, assistantId);
         return;
     }
   });
@@ -235,6 +236,17 @@ export function useAssistantResourceSync(
       refreshAssistantResources(queryClient, assistantId);
     }, RECONNECT_SWEEP_DEBOUNCE_MS);
   });
+}
+
+/**
+ * An avatar change on the connected assistant. Beyond the query sweep, drops
+ * the row's synced `avatarUrl`: the platform copy lags the live change, and
+ * while set it keeps the chooser's live/cache paths disabled. The reconnect
+ * sweep does not do this, since nothing is known to have changed there.
+ */
+function onAvatarChanged(queryClient: QueryClient, assistantId: string): void {
+  useResolvedAssistantsStore.getState().clearAvatarUrl(assistantId);
+  invalidateAvatarQueries(queryClient, assistantId);
 }
 
 /** The canonical avatar cache plus every chooser row variant for the same id. */

--- a/clients/web/src/hooks/use-assistant-resource-sync.ts
+++ b/clients/web/src/hooks/use-assistant-resource-sync.ts
@@ -46,9 +46,13 @@ import {
 import { avatarQueryKey } from "@/hooks/use-assistant-avatar";
 import { chooserRowAvatarQueryKeyPrefix } from "@/hooks/use-chooser-row-avatar";
 import { useBusSubscription } from "@/hooks/use-bus-subscription";
+import { suppressPlatformAvatarUrl } from "@/hooks/use-platform-avatar-urls";
 import { getClientId } from "@/lib/telemetry/client-identity";
 import { SYNC_TAGS } from "@/lib/sync/types";
-import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+import {
+  resolvePlatformAssistantId,
+  useResolvedAssistantsStore,
+} from "@/stores/resolved-assistants-store";
 
 /**
  * A reconnect can flap: error, reopen, error, reopen. Collapse a burst into
@@ -240,12 +244,17 @@ export function useAssistantResourceSync(
 
 /**
  * An avatar change on the connected assistant. Beyond the query sweep, drops
- * the row's synced `avatarUrl`: the platform copy lags the live change, and
- * while set it keeps the chooser's live/cache paths disabled. The reconnect
- * sweep does not do this, since nothing is known to have changed there.
+ * the row's synced `avatarUrl` and platform lookup entry: the platform copy
+ * lags the live change, and while set it keeps the chooser's live/cache paths
+ * disabled. The reconnect sweep does not do this, since nothing is known to
+ * have changed there.
  */
 function onAvatarChanged(queryClient: QueryClient, assistantId: string): void {
   useResolvedAssistantsStore.getState().clearAvatarUrl(assistantId);
+  suppressPlatformAvatarUrl(
+    queryClient,
+    resolvePlatformAssistantId(assistantId),
+  );
   invalidateAvatarQueries(queryClient, assistantId);
 }
 

--- a/clients/web/src/hooks/use-chooser-row-avatar.test.tsx
+++ b/clients/web/src/hooks/use-chooser-row-avatar.test.tsx
@@ -19,9 +19,10 @@ import {
   test,
 } from "bun:test";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { cleanup, renderHook, waitFor } from "@testing-library/react";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 
 import type * as AvatarApi from "@/assistant/avatar-api";
+import { publish } from "@/lib/event-bus";
 import type * as AvatarLastSeenCache from "@/lib/avatar-last-seen-cache";
 import type { LocalReadAssistantAvatarResult } from "@vellumai/ipc-contract";
 import type * as LocalModeHost from "@/runtime/local-mode-host";
@@ -228,6 +229,7 @@ afterEach(() => {
   setSystemTime();
   revokeObjectURL.mockClear();
   useResolvedAssistantsStore.getState().setActiveAssistantId(null);
+  useResolvedAssistantsStore.setState({ assistants: [] });
   useAssistantIdentityStore.getState().clearIdentity();
   fetchAvatarState.mockReset();
   fetchAvatarImageUrlResult.mockReset();
@@ -291,7 +293,7 @@ describe("useChooserRowAvatar", () => {
         { wrapper: createWrapper() },
       );
       await settle();
-      expect(result.current).toEqual({ traits: null, imageUrl: null });
+      expect(result.current).toMatchObject({ traits: null, imageUrl: null });
       expect(sdkCallCount()).toBe(0);
     },
   );
@@ -307,10 +309,183 @@ describe("useChooserRowAvatar", () => {
         { wrapper: createWrapper() },
       );
       await settle();
-      expect(result.current).toEqual({ traits: null, imageUrl: null });
+      expect(result.current).toMatchObject({ traits: null, imageUrl: null });
       expect(sdkCallCount()).toBe(0);
     },
   );
+
+  describe("synced platform avatarUrl", () => {
+    const SYNCED_URL = "https://cdn.example/avatars/other.png";
+
+    test.each([
+      ["local client", () => (localClient = true)],
+      ["remote-gateway mode", () => (remoteGatewayMode = true)],
+      ["gateway auth", () => (gatewayAuthEnabled = true)],
+    ])(
+      "renders a non-connected platform row's avatarUrl under %s with zero SDK calls",
+      async (_l, arrange) => {
+        arrange();
+        const { result } = renderHook(
+          () =>
+            useChooserRowAvatar(
+              platformRow("other", { avatarUrl: SYNCED_URL }),
+            ),
+          { wrapper: createWrapper() },
+        );
+        await waitFor(() => {
+          expect(result.current.imageUrl).toBe(SYNCED_URL);
+        });
+        expect(result.current.traits).toBeNull();
+        await settle();
+        expect(sdkCallCount()).toBe(0);
+      },
+    );
+
+    test("skips the platform-proxy fetch in pure cloud mode", async () => {
+      const { result } = renderHook(
+        () =>
+          useChooserRowAvatar(platformRow("other", { avatarUrl: SYNCED_URL })),
+        { wrapper: createWrapper() },
+      );
+      await settle();
+      expect(result.current).toMatchObject({
+        traits: null,
+        imageUrl: SYNCED_URL,
+      });
+      expect(sdkCallCount()).toBe(0);
+      expect(readLastSeenAvatar).not.toHaveBeenCalled();
+    });
+
+    test("connected row prefers its live read over avatarUrl", async () => {
+      const { result } = renderHook(
+        () =>
+          useChooserRowAvatar(platformRow("active", { avatarUrl: SYNCED_URL })),
+        { wrapper: createWrapper() },
+      );
+      await waitFor(() => {
+        expect(result.current.traits).toEqual(traits);
+      });
+      expect(result.current.imageUrl).toBeNull();
+    });
+
+    test("connected row falls back to avatarUrl when it is unreachable", async () => {
+      fetchAvatarState.mockRejectedValue(new Error("offline"));
+      fetchCharacterComponents.mockRejectedValue(new Error("offline"));
+      readLastSeenAvatar.mockResolvedValue({ kind: "character", traits });
+      const { result } = renderHook(
+        () =>
+          useChooserRowAvatar(platformRow("active", { avatarUrl: SYNCED_URL })),
+        { wrapper: createWrapper() },
+      );
+      // The live read retries once (1s backoff) before it settles.
+      await waitFor(
+        () => {
+          expect(result.current.imageUrl).toBe(SYNCED_URL);
+        },
+        { timeout: 3000 },
+      );
+      expect(result.current.traits).toBeNull();
+      expect(readLastSeenAvatar).not.toHaveBeenCalled();
+    });
+
+    test("a conclusive live none on the connected row outranks avatarUrl", async () => {
+      fetchAvatarState.mockResolvedValue(noneState);
+      const { result } = renderHook(
+        () =>
+          useChooserRowAvatar(platformRow("active", { avatarUrl: SYNCED_URL })),
+        { wrapper: createWrapper() },
+      );
+      await settle();
+      expect(result.current).toMatchObject({ traits: null, imageUrl: null });
+    });
+
+    test("persisting the connected row's live avatar drops its synced avatarUrl", async () => {
+      const row = platformRow("active", { avatarUrl: SYNCED_URL });
+      useResolvedAssistantsStore.setState({ assistants: [row] });
+      renderHook(() => useChooserRowAvatar(row), { wrapper: createWrapper() });
+      await waitFor(() => {
+        expect(writeLastSeenAvatar).toHaveBeenCalledTimes(1);
+      });
+      await waitFor(() => {
+        expect(
+          useResolvedAssistantsStore.getState().assistants[0]?.avatarUrl,
+        ).toBeNull();
+      });
+    });
+
+    test("a synced image that fails to load falls back to the cached avatar", async () => {
+      readLastSeenAvatar.mockResolvedValue({ kind: "character", traits });
+      const { result } = renderHook(
+        () =>
+          useChooserRowAvatar(platformRow("other", { avatarUrl: SYNCED_URL })),
+        { wrapper: createWrapper() },
+      );
+      await settle();
+      expect(result.current.imageUrl).toBe(SYNCED_URL);
+      expect(readLastSeenAvatar).not.toHaveBeenCalled();
+
+      act(() => result.current.onImageError());
+
+      await waitFor(() => {
+        expect(result.current.traits).toEqual(traits);
+      });
+      expect(result.current.imageUrl).toBeNull();
+      expect(readLastSeenAvatar).toHaveBeenCalledWith("other");
+    });
+
+    test("a fresh avatarUrl after a load failure is tried again", async () => {
+      // No other source applies, so only the synced URL can render.
+      localClient = true;
+      const NEXT_URL = "https://cdn.example/avatars/other-2.png";
+      const { result, rerender } = renderHook(
+        ({ url }: { url: string }) =>
+          useChooserRowAvatar(platformRow("other", { avatarUrl: url })),
+        { wrapper: createWrapper(), initialProps: { url: SYNCED_URL } },
+      );
+      await settle();
+      act(() => result.current.onImageError());
+      await waitFor(() => {
+        expect(result.current.imageUrl).toBeNull();
+      });
+
+      rerender({ url: NEXT_URL });
+
+      await waitFor(() => {
+        expect(result.current.imageUrl).toBe(NEXT_URL);
+      });
+    });
+
+    test("a failed synced URL is tried again on app.resume", async () => {
+      localClient = true;
+      const { result } = renderHook(
+        () =>
+          useChooserRowAvatar(platformRow("other", { avatarUrl: SYNCED_URL })),
+        { wrapper: createWrapper() },
+      );
+      await settle();
+      act(() => result.current.onImageError());
+      await waitFor(() => {
+        expect(result.current.imageUrl).toBeNull();
+      });
+
+      act(() => publish("app.resume", { signal: "online" }));
+
+      await waitFor(() => {
+        expect(result.current.imageUrl).toBe(SYNCED_URL);
+      });
+    });
+
+    test("a null avatarUrl falls through to the proxy fetch", async () => {
+      const { result } = renderHook(
+        () => useChooserRowAvatar(platformRow("other", { avatarUrl: null })),
+        { wrapper: createWrapper() },
+      );
+      await waitFor(() => {
+        expect(result.current.traits).toEqual(traits);
+      });
+      expect(fetchAvatarState).toHaveBeenCalledWith("other");
+    });
+  });
 
   test("waits for org readiness before the first platform-proxy fetch", async () => {
     orgReady = false;
@@ -319,7 +494,7 @@ describe("useChooserRowAvatar", () => {
       { wrapper: createWrapper() },
     );
     await settle();
-    expect(result.current).toEqual({ traits: null, imageUrl: null });
+    expect(result.current).toMatchObject({ traits: null, imageUrl: null });
     expect(sdkCallCount()).toBe(0);
 
     orgReady = true;
@@ -440,7 +615,7 @@ describe("useChooserRowAvatar", () => {
       expect(fetchAvatarState).toHaveBeenCalledTimes(1);
     });
     await settle();
-    expect(result.current).toEqual({ traits: null, imageUrl: null });
+    expect(result.current).toMatchObject({ traits: null, imageUrl: null });
   });
 
   test("re-keys on a version change so an upgraded row switches paths", async () => {
@@ -498,7 +673,10 @@ describe("useChooserRowAvatar", () => {
       expect(fetchCharacterTraitsResult).toHaveBeenCalledTimes(1);
     });
     await settle();
-    expect(first.result.current).toEqual({ traits: null, imageUrl: null });
+    expect(first.result.current).toMatchObject({
+      traits: null,
+      imageUrl: null,
+    });
     first.unmount();
 
     setSystemTime(new Date(Date.now() + A_MINUTE_LATER));
@@ -653,7 +831,7 @@ describe("useChooserRowAvatar", () => {
         );
       });
       await settle();
-      expect(result.current).toEqual({ traits: null, imageUrl: null });
+      expect(result.current).toMatchObject({ traits: null, imageUrl: null });
       expect(writeLastSeenAvatar).not.toHaveBeenCalled();
     });
 
@@ -677,7 +855,7 @@ describe("useChooserRowAvatar", () => {
       actualLastSeenCache.lastSeenAvatarGenerations.claim("other");
       resolveHost({ ok: true, avatar: null });
       await settle();
-      expect(result.current).toEqual({ traits: null, imageUrl: null });
+      expect(result.current).toMatchObject({ traits: null, imageUrl: null });
       expect(deleteLastSeenAvatar).not.toHaveBeenCalled();
     });
 
@@ -713,7 +891,7 @@ describe("useChooserRowAvatar", () => {
         expect(readAssistantAvatarHost).toHaveBeenCalledTimes(1);
       });
       await settle();
-      expect(result.current).toEqual({ traits: null, imageUrl: null });
+      expect(result.current).toMatchObject({ traits: null, imageUrl: null });
     });
 
     test("issues no host call when the host is unavailable", async () => {
@@ -725,7 +903,7 @@ describe("useChooserRowAvatar", () => {
         },
       );
       await settle();
-      expect(result.current).toEqual({ traits: null, imageUrl: null });
+      expect(result.current).toMatchObject({ traits: null, imageUrl: null });
       expect(readAssistantAvatarHost).not.toHaveBeenCalled();
     });
 
@@ -826,10 +1004,9 @@ describe("useChooserRowAvatar", () => {
       });
       first.unmount();
 
-      const second = renderHook(
-        () => useChooserRowAvatar(localRow("other")),
-        { wrapper },
-      );
+      const second = renderHook(() => useChooserRowAvatar(localRow("other")), {
+        wrapper,
+      });
       await waitFor(() => {
         expect(second.result.current.traits).toEqual(traits);
       });
@@ -855,9 +1032,9 @@ describe("useChooserRowAvatar", () => {
 
       // bun:test has no fake timers to fire React Query's interval, so pin
       // the polling contract on the live query instead of a remount.
-      const hostQuery = queryClient
-        .getQueryCache()
-        .find({ queryKey: [...chooserRowAvatarQueryKeyPrefix("other"), "host"] });
+      const hostQuery = queryClient.getQueryCache().find({
+        queryKey: [...chooserRowAvatarQueryKeyPrefix("other"), "host"],
+      });
       const observerOptions = hostQuery?.observers[0]?.options;
       expect(observerOptions?.refetchInterval).toBe(60_000);
       expect(observerOptions?.refetchIntervalInBackground).toBe(false);
@@ -884,10 +1061,9 @@ describe("useChooserRowAvatar", () => {
         ok: true,
         avatar: { kind: "character", traits: updated },
       });
-      const second = renderHook(
-        () => useChooserRowAvatar(localRow("other")),
-        { wrapper },
-      );
+      const second = renderHook(() => useChooserRowAvatar(localRow("other")), {
+        wrapper,
+      });
       await waitFor(() => {
         expect(second.result.current.traits).toEqual(updated);
       });
@@ -1067,7 +1243,7 @@ describe("useChooserRowAvatar", () => {
         );
       });
       expect(writeLastSeenAvatar).not.toHaveBeenCalled();
-      expect(result.current).toEqual({ traits: null, imageUrl: null });
+      expect(result.current).toMatchObject({ traits: null, imageUrl: null });
     });
 
     test("an unreachable legacy row keeps its cached avatar and does not evict it", async () => {
@@ -1388,7 +1564,7 @@ describe("useChooserRowAvatar", () => {
         expect(readLastSeenAvatar).toHaveBeenCalledTimes(1);
       });
       await settle();
-      expect(result.current).toEqual({ traits: null, imageUrl: null });
+      expect(result.current).toMatchObject({ traits: null, imageUrl: null });
     });
   });
 });

--- a/clients/web/src/hooks/use-chooser-row-avatar.test.tsx
+++ b/clients/web/src/hooks/use-chooser-row-avatar.test.tsx
@@ -61,6 +61,14 @@ mock.module("@/hooks/use-is-org-ready", () => ({
   useIsOrgReady: () => orgReady,
 }));
 
+// A paired daemon registered under the row's own id, until a test says otherwise.
+const resolvePairedAssistantPlatformId = mock(
+  async (id: string): Promise<string | null> => id,
+);
+mock.module("@/lib/paired-platform-identity", () => ({
+  resolvePairedAssistantPlatformId,
+}));
+
 type HostAvatarResult = LocalReadAssistantAvatarResult;
 let hostAvailable = false;
 const readAssistantAvatarHost = mock(
@@ -279,6 +287,8 @@ afterEach(() => {
   readAssistantAvatarHost.mockReset();
   listAssistants.mockReset();
   listAssistants.mockResolvedValue({ ok: true, status: 200, data: [] });
+  resolvePairedAssistantPlatformId.mockReset();
+  resolvePairedAssistantPlatformId.mockImplementation(async (id) => id);
   useAuthStore.setState(initialAuthState, true);
   readAssistantAvatarHost.mockResolvedValue({ ok: true, avatar: null });
   readLastSeenAvatar.mockResolvedValue(null);
@@ -666,14 +676,100 @@ describe("useChooserRowAvatar", () => {
       expect(listAssistants).toHaveBeenCalledTimes(1);
     });
 
-    test("a pure platform row never uses the lookup", async () => {
-      const { result } = renderHook(
-        () => useChooserRowAvatar(platformRow("other")),
+    test("a paired row resolves its platform id from the paired daemon first", async () => {
+      resolvePairedAssistantPlatformId.mockResolvedValue("uuid-other");
+      listAssistants.mockResolvedValue({
+        ok: true,
+        status: 200,
+        data: [apiAssistant("uuid-other", LOOKUP_URL)],
+      });
+      const { result, rerender } = renderHook(
+        () => useChooserRowAvatar(pairedRow("other")),
         { wrapper: createWrapper() },
       );
+      await waitFor(() => {
+        expect(result.current.imageUrl).toBe(LOOKUP_URL);
+      });
+      rerender();
       await settle();
-      expect(result.current).toMatchObject({ traits: null, imageUrl: null });
+      expect(resolvePairedAssistantPlatformId).toHaveBeenCalledTimes(1);
+      expect(resolvePairedAssistantPlatformId).toHaveBeenCalledWith("other");
     });
+
+    test("a paired row that already carries its platform id skips the daemon", async () => {
+      listAssistants.mockResolvedValue({
+        ok: true,
+        status: 200,
+        data: [apiAssistant("uuid-other", LOOKUP_URL)],
+      });
+      const { result } = renderHook(
+        () =>
+          useChooserRowAvatar(
+            pairedRow("other", { platformAssistantId: "uuid-other" }),
+          ),
+        { wrapper: createWrapper() },
+      );
+      await waitFor(() => {
+        expect(result.current.imageUrl).toBe(LOOKUP_URL);
+      });
+      expect(resolvePairedAssistantPlatformId).not.toHaveBeenCalled();
+    });
+
+    test("a paired row with no resolvable platform id falls through to the cache", async () => {
+      resolvePairedAssistantPlatformId.mockResolvedValue(null);
+      readLastSeenAvatar.mockResolvedValue({ kind: "character", traits });
+      const { result } = renderHook(
+        () => useChooserRowAvatar(pairedRow("other")),
+        { wrapper: createWrapper() },
+      );
+      await waitFor(() => {
+        expect(result.current.traits).toEqual(traits);
+      });
+      expect(result.current.imageUrl).toBeNull();
+    });
+
+    test("a lockfile-managed platform row resolves through the lookup", async () => {
+      const { result } = renderHook(
+        () => useChooserRowAvatar(platformRow("other", { cloud: "vellum" })),
+        { wrapper: createWrapper() },
+      );
+      await waitFor(() => {
+        expect(result.current.imageUrl).toBe(LOOKUP_URL);
+      });
+      expect(resolvePairedAssistantPlatformId).not.toHaveBeenCalled();
+    });
+
+    test("a platform row that carries avatarUrl renders it, not the lookup", async () => {
+      const SYNCED = "https://cdn.example/avatars/other-api.png";
+      const { result } = renderHook(
+        () =>
+          useChooserRowAvatar(
+            platformRow("other", { cloud: "vellum", avatarUrl: SYNCED }),
+          ),
+        { wrapper: createWrapper() },
+      );
+      await waitFor(() => {
+        expect(result.current.imageUrl).toBe(SYNCED);
+      });
+    });
+
+    test.each([
+      ["pure cloud", () => (localClient = false)],
+      ["gateway auth", () => (gatewayAuthEnabled = true)],
+    ])(
+      "a platform row under %s never consults the map",
+      async (_l, arrange) => {
+        arrange();
+        const { result } = renderHook(
+          () => useChooserRowAvatar(platformRow("other", { cloud: "vellum" })),
+          { wrapper: createWrapper() },
+        );
+        await settle();
+        expect(result.current.imageUrl).not.toBe(LOOKUP_URL);
+        expect(listAssistants).not.toHaveBeenCalled();
+        expect(resolvePairedAssistantPlatformId).not.toHaveBeenCalled();
+      },
+    );
 
     test("a signed-out device keeps the glyph", async () => {
       useAuthStore.setState({ platformSession: "absent", user: null });
@@ -682,8 +778,9 @@ describe("useChooserRowAvatar", () => {
         { wrapper: createWrapper() },
       );
       await settle();
-      expect(result.current).toMatchObject({ traits: null, imageUrl: null });
+      expect(result.current.imageUrl).not.toBe(LOOKUP_URL);
       expect(listAssistants).not.toHaveBeenCalled();
+      expect(resolvePairedAssistantPlatformId).not.toHaveBeenCalled();
     });
 
     test("the connected row prefers its live read over the lookup", async () => {

--- a/clients/web/src/hooks/use-chooser-row-avatar.test.tsx
+++ b/clients/web/src/hooks/use-chooser-row-avatar.test.tsx
@@ -2,10 +2,11 @@
  * Tests for `useChooserRowAvatar`: the transport gate that decides whether a
  * per-row SDK fetch is addressable, connected-row delegation to
  * `useAssistantAvatar`, per-row manifest-vs-legacy path selection, the
- * host-bridge disk read for local rows, the last-seen cache as the final
- * fallback, and the failure-to-nulls contract. The resolved-assistants store
- * is real; the environment probes, the avatar API, the host bridge, and the
- * IndexedDB cache are mocked at the module boundary.
+ * host-bridge disk read for local rows, the platform id lookup for paired and
+ * local rows, the last-seen cache as the final fallback, and the
+ * failure-to-nulls contract. The resolved-assistants and auth stores are real;
+ * the environment probes, the avatar and assistants APIs, the host bridge, and
+ * the IndexedDB cache are mocked at the module boundary.
  */
 
 import type { ReactNode } from "react";
@@ -16,12 +17,15 @@ import {
   expect,
   mock,
   setSystemTime,
+  spyOn,
   test,
 } from "bun:test";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 
+import type * as AssistantApi from "@/assistant/api";
 import type * as AvatarApi from "@/assistant/avatar-api";
+import type { Assistant } from "@/generated/api";
 import { publish } from "@/lib/event-bus";
 import type * as AvatarLastSeenCache from "@/lib/avatar-last-seen-cache";
 import type { LocalReadAssistantAvatarResult } from "@vellumai/ipc-contract";
@@ -118,6 +122,16 @@ const avatarApiMock: Partial<typeof AvatarApi> = {
 };
 mock.module("@/assistant/avatar-api", () => avatarApiMock);
 
+const listAssistants = mock(
+  async (): Promise<AssistantApi.ListAssistantsResult> => ({
+    ok: true,
+    status: 200,
+    data: [],
+  }),
+);
+const actualApi = await import("@/assistant/api");
+mock.module("@/assistant/api", () => ({ ...actualApi, listAssistants }));
+
 type LastSeenAvatar = AvatarLastSeenCache.LastSeenAvatar;
 const actualLastSeenCache = await import("@/lib/avatar-last-seen-cache");
 const readLastSeenAvatar = mock(async () => null as LastSeenAvatar | null);
@@ -134,6 +148,7 @@ mock.module(
   }),
 );
 
+const { useAuthStore } = await import("@/stores/auth-store");
 const { useResolvedAssistantsStore } =
   await import("@/stores/resolved-assistants-store");
 const { useAssistantIdentityStore } =
@@ -147,8 +162,12 @@ const {
   useChooserRowAvatar,
 } = await import("@/hooks/use-chooser-row-avatar");
 const { avatarQueryKey } = await import("@/hooks/use-assistant-avatar");
-const { chooserRowAvatarCacheQueryKey } =
+
+const initialAuthState = useAuthStore.getState();
+const { chooserRowAvatarCacheQueryKey, persistLastSeenAvatar } =
   await import("@/lib/persist-last-seen-avatar");
+const { platformAvatarUrlsQueryKey } =
+  await import("@/hooks/use-platform-avatar-urls");
 
 /** Past the window a bare avatar stays fresh for. */
 const A_MINUTE_LATER = 61_000;
@@ -199,6 +218,25 @@ function createWrapper(
   };
 }
 
+/** A signed-in platform account on this device, the state a `vellum login` leaves. */
+function signInToPlatform(): void {
+  useAuthStore.setState({
+    platformSession: "present",
+    user: {
+      kind: "platform",
+      id: "user-1",
+      username: null,
+      email: null,
+      isStaff: false,
+      firstName: "",
+      lastName: "",
+    },
+  });
+}
+
+const apiAssistant = (id: string, avatar_url: string | null): Assistant =>
+  ({ id, avatar_url }) as Assistant;
+
 function sdkCallCount(): number {
   return (
     fetchAvatarState.mock.calls.length +
@@ -239,6 +277,9 @@ afterEach(() => {
   writeLastSeenAvatar.mockReset();
   deleteLastSeenAvatar.mockReset();
   readAssistantAvatarHost.mockReset();
+  listAssistants.mockReset();
+  listAssistants.mockResolvedValue({ ok: true, status: 200, data: [] });
+  useAuthStore.setState(initialAuthState, true);
   readAssistantAvatarHost.mockResolvedValue({ ok: true, avatar: null });
   readLastSeenAvatar.mockResolvedValue(null);
   fetchAvatarState.mockResolvedValue(characterState);
@@ -484,6 +525,247 @@ describe("useChooserRowAvatar", () => {
         expect(result.current.traits).toEqual(traits);
       });
       expect(fetchAvatarState).toHaveBeenCalledWith("other");
+    });
+  });
+
+  describe("platform id lookup", () => {
+    const LOOKUP_URL = "https://cdn.example/avatars/other-synced.png";
+    const pairedRow = (
+      id: string,
+      overrides: Partial<ResolvedAssistant> = {},
+    ) =>
+      platformRow(id, {
+        isPaired: true,
+        isPlatformHosted: false,
+        ...overrides,
+      });
+
+    beforeEach(() => {
+      localClient = true;
+      signInToPlatform();
+      listAssistants.mockResolvedValue({
+        ok: true,
+        status: 200,
+        data: [apiAssistant("other", LOOKUP_URL), apiAssistant("plain", null)],
+      });
+    });
+
+    test.each([
+      ["paired", pairedRow],
+      ["local", localRow],
+    ])("a %s row resolves its thumbnail by id", async (_l, row) => {
+      const setState = spyOn(useResolvedAssistantsStore, "setState");
+      const { result } = renderHook(() => useChooserRowAvatar(row("other")), {
+        wrapper: createWrapper(),
+      });
+      await waitFor(() => {
+        expect(result.current.imageUrl).toBe(LOOKUP_URL);
+      });
+      expect(result.current.traits).toBeNull();
+      await settle();
+      expect(sdkCallCount()).toBe(0);
+      expect(setState).not.toHaveBeenCalled();
+      setState.mockRestore();
+    });
+
+    test("a local row keyed by instance name resolves through its platform id", async () => {
+      listAssistants.mockResolvedValue({
+        ok: true,
+        status: 200,
+        data: [apiAssistant("uuid-other", LOOKUP_URL)],
+      });
+      const { result } = renderHook(
+        () =>
+          useChooserRowAvatar(
+            localRow("other", { platformAssistantId: "uuid-other" }),
+          ),
+        { wrapper: createWrapper() },
+      );
+      await waitFor(() => {
+        expect(result.current.imageUrl).toBe(LOOKUP_URL);
+      });
+    });
+
+    test("persisting live evidence by row id drops the platform id entry", async () => {
+      listAssistants.mockResolvedValue({
+        ok: true,
+        status: 200,
+        data: [apiAssistant("uuid-other", LOOKUP_URL)],
+      });
+      const row = localRow("other", { platformAssistantId: "uuid-other" });
+      useResolvedAssistantsStore.setState({ assistants: [row] });
+      const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      });
+      const { result } = renderHook(() => useChooserRowAvatar(row), {
+        wrapper: createWrapper(queryClient),
+      });
+      await waitFor(() => {
+        expect(result.current.imageUrl).toBe(LOOKUP_URL);
+      });
+
+      await persistLastSeenAvatar(queryClient, "other", {
+        traits,
+        imageUrl: null,
+      });
+
+      expect(
+        queryClient
+          .getQueryData<Map<string, string>>(
+            platformAvatarUrlsQueryKey("user-1", null),
+          )
+          ?.has("uuid-other"),
+      ).toBe(false);
+      await waitFor(() => {
+        expect(result.current.imageUrl).toBeNull();
+      });
+    });
+
+    test("an id the platform does not list falls through to the cache", async () => {
+      readLastSeenAvatar.mockResolvedValue({ kind: "character", traits });
+      const { result } = renderHook(
+        () => useChooserRowAvatar(pairedRow("unlisted")),
+        { wrapper: createWrapper() },
+      );
+      await waitFor(() => {
+        expect(result.current.traits).toEqual(traits);
+      });
+      expect(result.current.imageUrl).toBeNull();
+      expect(listAssistants).toHaveBeenCalledTimes(1);
+    });
+
+    test("persisting live evidence drops the lookup entry so the row falls through to the cache", async () => {
+      const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      });
+      const { result } = renderHook(
+        () => useChooserRowAvatar(pairedRow("other")),
+        { wrapper: createWrapper(queryClient) },
+      );
+      await waitFor(() => {
+        expect(result.current.imageUrl).toBe(LOOKUP_URL);
+      });
+
+      readLastSeenAvatar.mockResolvedValue({ kind: "character", traits });
+      await persistLastSeenAvatar(queryClient, "other", {
+        traits,
+        imageUrl: null,
+      });
+
+      expect(
+        queryClient
+          .getQueryData<Map<string, string>>(
+            platformAvatarUrlsQueryKey("user-1", null),
+          )
+          ?.has("other"),
+      ).toBe(false);
+      await waitFor(() => {
+        expect(result.current.traits).toEqual(traits);
+      });
+      expect(result.current.imageUrl).toBeNull();
+      expect(listAssistants).toHaveBeenCalledTimes(1);
+    });
+
+    test("a pure platform row never uses the lookup", async () => {
+      const { result } = renderHook(
+        () => useChooserRowAvatar(platformRow("other")),
+        { wrapper: createWrapper() },
+      );
+      await settle();
+      expect(result.current).toMatchObject({ traits: null, imageUrl: null });
+    });
+
+    test("a signed-out device keeps the glyph", async () => {
+      useAuthStore.setState({ platformSession: "absent", user: null });
+      const { result } = renderHook(
+        () => useChooserRowAvatar(pairedRow("other")),
+        { wrapper: createWrapper() },
+      );
+      await settle();
+      expect(result.current).toMatchObject({ traits: null, imageUrl: null });
+      expect(listAssistants).not.toHaveBeenCalled();
+    });
+
+    test("the connected row prefers its live read over the lookup", async () => {
+      const { result } = renderHook(
+        () => useChooserRowAvatar(pairedRow("active")),
+        { wrapper: createWrapper() },
+      );
+      await waitFor(() => {
+        expect(result.current.traits).toEqual(traits);
+      });
+      expect(result.current.imageUrl).toBeNull();
+    });
+
+    test("a host disk read outranks the lookup", async () => {
+      hostAvailable = true;
+      readAssistantAvatarHost.mockResolvedValue({
+        ok: true,
+        avatar: { kind: "character", traits },
+      });
+      const { result } = renderHook(
+        () => useChooserRowAvatar(localRow("other")),
+        { wrapper: createWrapper() },
+      );
+      await waitFor(() => {
+        expect(result.current.traits).toEqual(traits);
+      });
+      expect(result.current.imageUrl).toBeNull();
+    });
+
+    test("a lookup image that fails to load falls back to the cached avatar", async () => {
+      readLastSeenAvatar.mockResolvedValue({ kind: "character", traits });
+      const { result } = renderHook(
+        () => useChooserRowAvatar(pairedRow("other")),
+        { wrapper: createWrapper() },
+      );
+      await waitFor(() => {
+        expect(result.current.imageUrl).toBe(LOOKUP_URL);
+      });
+
+      act(() => result.current.onImageError());
+
+      await waitFor(() => {
+        expect(result.current.traits).toEqual(traits);
+      });
+      expect(result.current.imageUrl).toBeNull();
+    });
+
+    test("a failed lookup URL is tried again on app.resume", async () => {
+      const { result } = renderHook(
+        () => useChooserRowAvatar(pairedRow("other")),
+        { wrapper: createWrapper() },
+      );
+      await waitFor(() => {
+        expect(result.current.imageUrl).toBe(LOOKUP_URL);
+      });
+      act(() => result.current.onImageError());
+      await waitFor(() => {
+        expect(result.current.imageUrl).toBeNull();
+      });
+
+      act(() => publish("app.resume", { signal: "online" }));
+
+      await waitFor(() => {
+        expect(result.current.imageUrl).toBe(LOOKUP_URL);
+      });
+    });
+
+    test("one list call serves every row", async () => {
+      const wrapper = createWrapper();
+      const { result } = renderHook(
+        () => [
+          useChooserRowAvatar(pairedRow("other")),
+          useChooserRowAvatar(pairedRow("plain")),
+          useChooserRowAvatar(localRow("unlisted")),
+        ],
+        { wrapper },
+      );
+      await waitFor(() => {
+        expect(result.current[0]?.imageUrl).toBe(LOOKUP_URL);
+      });
+      await settle();
+      expect(listAssistants).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/clients/web/src/hooks/use-chooser-row-avatar.ts
+++ b/clients/web/src/hooks/use-chooser-row-avatar.ts
@@ -13,6 +13,7 @@ import {
 } from "@/hooks/use-assistant-avatar";
 import { useBusSubscription } from "@/hooks/use-bus-subscription";
 import { useIsOrgReady } from "@/hooks/use-is-org-ready";
+import { usePlatformAvatarUrls } from "@/hooks/use-platform-avatar-urls";
 import { isGatewayAuthEnabled } from "@/lib/auth/gateway-session";
 import {
   deleteLastSeenAvatar,
@@ -34,6 +35,7 @@ import {
 } from "@/runtime/local-mode-host";
 import {
   type ResolvedAssistant,
+  platformIdFor,
   useResolvedAssistantsStore,
 } from "@/stores/resolved-assistants-store";
 import type { AvatarRead } from "@/types/avatar";
@@ -42,8 +44,8 @@ const QUERY_KEY_PREFIX = "chooserRowAvatar";
 
 export interface ChooserRowAvatar extends AvatarRead {
   /**
-   * Wire to the rendered image's `onError`. A synced thumbnail that fails to
-   * load (offline, expired signed URL) re-enables the row's other sources.
+   * Wire to the rendered image's `onError`. A platform thumbnail that fails
+   * to load (offline, expired signed URL) re-enables the row's other sources.
    */
   onImageError: () => void;
 }
@@ -179,6 +181,16 @@ function canReadRowAvatarViaHost(row: ResolvedAssistant): boolean {
   return row.cloud === "local" && canReadAvatarFromLocalHost();
 }
 
+/**
+ * Whether `row` comes from the lockfile, where `avatarUrl` is never set and
+ * the platform's thumbnail is only reachable by id through
+ * {@link usePlatformAvatarUrls}. Paired rows share one id on both sides; a
+ * local row's platform UUID is `platformAssistantId` (see {@link platformIdFor}).
+ */
+function canLookUpRowAvatarByPlatformId(row: ResolvedAssistant): boolean {
+  return row.isPaired || row.cloud === "local";
+}
+
 function conclusive(read: AvatarRead): LegacyAvatarRead {
   return { ...read, conclusive: true };
 }
@@ -295,14 +307,18 @@ async function readCachedRowAvatar(assistantId: string): Promise<AvatarRead> {
  *    org store can supply the `Vellum-Organization-Id` header.
  * 4. Local rows (the connected one when unreachable, siblings even asleep)
  *    read their workspace through the host when one can serve it.
- * 5. The last-seen cache: whatever a live source last resolved for this id,
+ * 5. Paired and local rows look their id up in the platform list
+ *    (`usePlatformAvatarUrls`): lockfile rows never carry `avatarUrl`, so
+ *    this is how a logged-in desktop shows a sibling's synced thumbnail.
+ * 6. The last-seen cache: whatever a live source last resolved for this id,
  *    so a row keeps its avatar while the assistant is unreachable.
  * Only live sources (1 and 3) feed the cache, at fetch time (1 does so
  * inside `useAssistantAvatar`); a conclusive none from any source evicts it.
  * Persisting live evidence also drops the row's `avatarUrl`, so 2 never
- * outranks a fresher local read. A synced URL that fails to load
- * (`onImageError`) is set aside so 3 to 5 take over for that row, until
- * the next `app.resume` (network back, window foregrounded) retries it.
+ * outranks a fresher local read. A platform URL (2 or 5) that fails to load
+ * (`onImageError`) is set aside so the sources below it take over for that
+ * row, until the next `app.resume` (network back, window foregrounded)
+ * retries it.
  * Anything else, including every failure, resolves to nulls: the row's glyph
  * fallback is the error state, a chooser row never surfaces an error.
  */
@@ -317,10 +333,12 @@ export function useChooserRowAvatar(
 
   // Keyed by URL so a reload that carries a new thumbnail retries it; a
   // resume retries the same URL, since the failure may have been offline.
-  const [failedSyncedUrl, setFailedSyncedUrl] = useState<string | null>(null);
-  useBusSubscription("app.resume", () => setFailedSyncedUrl(null));
+  const [failedPlatformUrl, setFailedPlatformUrl] = useState<string | null>(
+    null,
+  );
+  useBusSubscription("app.resume", () => setFailedPlatformUrl(null));
   const syncedUrl =
-    assistant.avatarUrl && assistant.avatarUrl !== failedSyncedUrl
+    assistant.avatarUrl && assistant.avatarUrl !== failedPlatformUrl
       ? assistant.avatarUrl
       : null;
   const syncedAvatar: AvatarRead | null = syncedUrl
@@ -386,10 +404,26 @@ export function useChooserRowAvatar(
     hostQuery.data !== undefined &&
     (hostConclusive || !isEmptyAvatar(hostQuery.data));
 
+  const platformAvatarUrls = usePlatformAvatarUrls();
+  const lookupCandidate = canLookUpRowAvatarByPlatformId(assistant)
+    ? (platformAvatarUrls.get(platformIdFor(assistant)) ?? null)
+    : null;
+  const lookupUrl =
+    lookupCandidate !== failedPlatformUrl ? lookupCandidate : null;
+  // Waits out an in-flight host read so a row never flashes the thumbnail
+  // before the disk snapshot replaces it.
+  const showLookup =
+    lookupUrl !== null &&
+    !showLive &&
+    !showSynced &&
+    !showHost &&
+    !hostQuery.isLoading &&
+    (!isConnectedRow || liveSettledEmpty);
+
   const cacheQuery = useQuery<AvatarRead>({
     queryKey: chooserRowAvatarCacheQueryKey(assistant.id),
     queryFn: () => readCachedRowAvatar(assistant.id),
-    enabled: !showLive && !hasSyncedAvatar && !showHost,
+    enabled: !showLive && !hasSyncedAvatar && !showHost && !showLookup,
     staleTime: Infinity,
     structuralSharing: false,
     retry: false,
@@ -397,9 +431,11 @@ export function useChooserRowAvatar(
 
   const onImageError = useCallback(() => {
     if (showSynced) {
-      setFailedSyncedUrl(syncedUrl);
+      setFailedPlatformUrl(syncedUrl);
+    } else if (showLookup) {
+      setFailedPlatformUrl(lookupUrl);
     }
-  }, [showSynced, syncedUrl]);
+  }, [showSynced, syncedUrl, showLookup, lookupUrl]);
 
   const avatar: AvatarRead = showLive
     ? (live ?? EMPTY_AVATAR)
@@ -407,6 +443,8 @@ export function useChooserRowAvatar(
       ? (syncedAvatar ?? EMPTY_AVATAR)
       : showHost
         ? { traits: hostQuery.data.traits, imageUrl: hostQuery.data.imageUrl }
-        : (cacheQuery.data ?? EMPTY_AVATAR);
+        : showLookup
+          ? { traits: null, imageUrl: lookupUrl }
+          : (cacheQuery.data ?? EMPTY_AVATAR);
   return { ...avatar, onImageError };
 }

--- a/clients/web/src/hooks/use-chooser-row-avatar.ts
+++ b/clients/web/src/hooks/use-chooser-row-avatar.ts
@@ -224,7 +224,10 @@ function usePlatformLookupId(
     queryKey: pairedPlatformIdQueryKey(row.id, row.runtimeUrl),
     queryFn: () => resolvePairedAssistantPlatformId(row.id),
     enabled: needsPairedResolve && hasPlatformSession,
-    staleTime: Infinity,
+    // A miss goes stale so a later mount or resume probes again.
+    staleTime: (query) =>
+      query.state.data ? Infinity : EMPTY_AVATAR_STALE_TIME_MS,
+    refetchOnWindowFocus: (query) => !query.state.data,
     retry: false,
   });
   if (row.platformAssistantId) {

--- a/clients/web/src/hooks/use-chooser-row-avatar.ts
+++ b/clients/web/src/hooks/use-chooser-row-avatar.ts
@@ -1,3 +1,4 @@
+import { useCallback, useState } from "react";
 import { type QueryClient, useQuery } from "@tanstack/react-query";
 
 import { fetchAvatarState } from "@/assistant/avatar-api";
@@ -10,6 +11,7 @@ import {
   resolveAvatarFromState,
   useAssistantAvatar,
 } from "@/hooks/use-assistant-avatar";
+import { useBusSubscription } from "@/hooks/use-bus-subscription";
 import { useIsOrgReady } from "@/hooks/use-is-org-ready";
 import { isGatewayAuthEnabled } from "@/lib/auth/gateway-session";
 import {
@@ -37,6 +39,14 @@ import {
 import type { AvatarRead } from "@/types/avatar";
 
 const QUERY_KEY_PREFIX = "chooserRowAvatar";
+
+export interface ChooserRowAvatar extends AvatarRead {
+  /**
+   * Wire to the rendered image's `onError`. A synced thumbnail that fails to
+   * load (offline, expired signed URL) re-enables the row's other sources.
+   */
+  onImageError: () => void;
+}
 
 type RowManifestSupport = "supported" | "unsupported" | "unknown";
 
@@ -277,24 +287,46 @@ async function readCachedRowAvatar(assistantId: string): Promise<AvatarRead> {
  * Avatar data for one chooser row, resolved through a precedence chain:
  * 1. The connected row reuses `useAssistantAvatar`'s cache, correct in every
  *    transport mode and never fetched twice.
- * 2. Other platform rows fetch per id through the platform proxy, only when
+ * 2. The platform's synced thumbnail (`assistant.avatarUrl`): a plain image
+ *    URL, so it renders in every mode with no daemon round-trip. It ranks
+ *    below 1 because the live read keeps a character avatar's SVG fidelity.
+ * 3. Other platform rows fetch per id through the platform proxy, only when
  *    {@link canFetchRowAvatarViaPlatformProxy} says the id is honored and the
  *    org store can supply the `Vellum-Organization-Id` header.
- * 3. Local rows (the connected one when unreachable, siblings even asleep)
+ * 4. Local rows (the connected one when unreachable, siblings even asleep)
  *    read their workspace through the host when one can serve it.
- * 4. The last-seen cache: whatever a live source last resolved for this id,
+ * 5. The last-seen cache: whatever a live source last resolved for this id,
  *    so a row keeps its avatar while the assistant is unreachable.
- * Only live sources (1 and 2) feed the cache, at fetch time (1 does so
+ * Only live sources (1 and 3) feed the cache, at fetch time (1 does so
  * inside `useAssistantAvatar`); a conclusive none from any source evicts it.
+ * Persisting live evidence also drops the row's `avatarUrl`, so 2 never
+ * outranks a fresher local read. A synced URL that fails to load
+ * (`onImageError`) is set aside so 3 to 5 take over for that row, until
+ * the next `app.resume` (network back, window foregrounded) retries it.
  * Anything else, including every failure, resolves to nulls: the row's glyph
  * fallback is the error state, a chooser row never surfaces an error.
  */
-export function useChooserRowAvatar(assistant: ResolvedAssistant): AvatarRead {
+export function useChooserRowAvatar(
+  assistant: ResolvedAssistant,
+): ChooserRowAvatar {
   const activeAssistantId = useResolvedAssistantsStore.use.activeAssistantId();
   const isConnectedRow = assistant.id === activeAssistantId;
   const isOrgReady = useIsOrgReady();
 
   const connected = useAssistantAvatar(isConnectedRow ? assistant.id : null);
+
+  // Keyed by URL so a reload that carries a new thumbnail retries it; a
+  // resume retries the same URL, since the failure may have been offline.
+  const [failedSyncedUrl, setFailedSyncedUrl] = useState<string | null>(null);
+  useBusSubscription("app.resume", () => setFailedSyncedUrl(null));
+  const syncedUrl =
+    assistant.avatarUrl && assistant.avatarUrl !== failedSyncedUrl
+      ? assistant.avatarUrl
+      : null;
+  const syncedAvatar: AvatarRead | null = syncedUrl
+    ? { traits: null, imageUrl: syncedUrl }
+    : null;
+  const hasSyncedAvatar = syncedAvatar !== null;
 
   const manifestSupport = rowManifestSupport(assistant);
   const rowQuery = useQuery<LegacyAvatarRead>({
@@ -303,6 +335,7 @@ export function useChooserRowAvatar(assistant: ResolvedAssistant): AvatarRead {
       fetchRowAvatarGeneration(client, assistant, manifestSupport),
     enabled:
       !isConnectedRow &&
+      !hasSyncedAvatar &&
       isOrgReady &&
       canFetchRowAvatarViaPlatformProxy(assistant),
     staleTime: (query) =>
@@ -328,14 +361,17 @@ export function useChooserRowAvatar(assistant: ResolvedAssistant): AvatarRead {
   const showLive =
     liveConclusive || (live !== undefined && !isEmptyAvatar(live));
 
-  // The connected row only needs a host read once its live read has
-  // settled empty.
+  // The connected row only falls through once its live read has settled
+  // empty, so a loading row does not flash the thumbnail before the SVG.
   const liveSettledEmpty = !connected.isLoading && !showLive;
+  const showSynced = hasSyncedAvatar && (!isConnectedRow || liveSettledEmpty);
+
   const hostQuery = useQuery<LegacyAvatarRead>({
     queryKey: chooserRowAvatarHostQueryKey(assistant.id),
     queryFn: ({ client }) => readRowAvatarViaHost(client, assistant.id),
     enabled:
       canReadRowAvatarViaHost(assistant) &&
+      !hasSyncedAvatar &&
       (!isConnectedRow || liveSettledEmpty),
     staleTime: HOST_AVATAR_STALE_TIME_MS,
     // staleTime alone never refetches a chooser that stays mounted; the
@@ -353,17 +389,24 @@ export function useChooserRowAvatar(assistant: ResolvedAssistant): AvatarRead {
   const cacheQuery = useQuery<AvatarRead>({
     queryKey: chooserRowAvatarCacheQueryKey(assistant.id),
     queryFn: () => readCachedRowAvatar(assistant.id),
-    enabled: !showLive && !showHost,
+    enabled: !showLive && !hasSyncedAvatar && !showHost,
     staleTime: Infinity,
     structuralSharing: false,
     retry: false,
   });
 
-  if (showLive) {
-    return live ?? EMPTY_AVATAR;
-  }
-  if (showHost) {
-    return { traits: hostQuery.data.traits, imageUrl: hostQuery.data.imageUrl };
-  }
-  return cacheQuery.data ?? EMPTY_AVATAR;
+  const onImageError = useCallback(() => {
+    if (showSynced) {
+      setFailedSyncedUrl(syncedUrl);
+    }
+  }, [showSynced, syncedUrl]);
+
+  const avatar: AvatarRead = showLive
+    ? (live ?? EMPTY_AVATAR)
+    : showSynced
+      ? (syncedAvatar ?? EMPTY_AVATAR)
+      : showHost
+        ? { traits: hostQuery.data.traits, imageUrl: hostQuery.data.imageUrl }
+        : (cacheQuery.data ?? EMPTY_AVATAR);
+  return { ...avatar, onImageError };
 }

--- a/clients/web/src/hooks/use-chooser-row-avatar.ts
+++ b/clients/web/src/hooks/use-chooser-row-avatar.ts
@@ -13,7 +13,10 @@ import {
 } from "@/hooks/use-assistant-avatar";
 import { useBusSubscription } from "@/hooks/use-bus-subscription";
 import { useIsOrgReady } from "@/hooks/use-is-org-ready";
-import { usePlatformAvatarUrls } from "@/hooks/use-platform-avatar-urls";
+import {
+  isLockfileDrivenStore,
+  usePlatformAvatarUrls,
+} from "@/hooks/use-platform-avatar-urls";
 import { isGatewayAuthEnabled } from "@/lib/auth/gateway-session";
 import {
   deleteLastSeenAvatar,
@@ -24,6 +27,7 @@ import { trackBlobUrl } from "@/lib/blob-url-tracker";
 import { lastSeenAvatarGenerations } from "@/lib/avatar-last-seen-cache";
 import { createGenerationGuard } from "@/lib/generation-guard";
 import { isLocalClient, isRemoteGatewayMode } from "@/lib/local-mode";
+import { resolvePairedAssistantPlatformId } from "@/lib/paired-platform-identity";
 import {
   chooserRowAvatarCacheQueryKey,
   persistLastSeenAvatar,
@@ -33,9 +37,9 @@ import {
   canReadAvatarFromLocalHost,
   readAssistantAvatarHost,
 } from "@/runtime/local-mode-host";
+import { useHasPlatformSession } from "@/stores/auth-store";
 import {
   type ResolvedAssistant,
-  platformIdFor,
   useResolvedAssistantsStore,
 } from "@/stores/resolved-assistants-store";
 import type { AvatarRead } from "@/types/avatar";
@@ -182,13 +186,51 @@ function canReadRowAvatarViaHost(row: ResolvedAssistant): boolean {
 }
 
 /**
- * Whether `row` comes from the lockfile, where `avatarUrl` is never set and
- * the platform's thumbnail is only reachable by id through
- * {@link usePlatformAvatarUrls}. Paired rows share one id on both sides; a
- * local row's platform UUID is `platformAssistantId` (see {@link platformIdFor}).
+ * Whether `row` should consult {@link usePlatformAvatarUrls}: the store is
+ * lockfile-driven, so no row kind carries `avatarUrl` (platform-hosted rows
+ * included, since `reloadPlatformAssistants` skips the API write there) and
+ * the thumbnail is only reachable by platform id. A row that does carry one
+ * renders it directly. Pure cloud mode never gets here: the lookup query is
+ * disabled and the map stays empty.
  */
 function canLookUpRowAvatarByPlatformId(row: ResolvedAssistant): boolean {
-  return row.isPaired || row.cloud === "local";
+  return !row.avatarUrl && isLockfileDrivenStore();
+}
+
+/** Under the row prefix so `forgetAssistantAvatar` drops it with the rest. */
+function pairedPlatformIdQueryKey(assistantId: string, runtimeUrl?: string) {
+  return [
+    ...chooserRowAvatarQueryKeyPrefix(assistantId),
+    "platformId",
+    runtimeUrl ?? null,
+  ] as const;
+}
+
+/**
+ * The id to look `row` up by in the platform list. A platform-hosted row's
+ * `id` is its UUID; a local row's is `platformAssistantId`; a paired row's
+ * lockfile entry starts without one, so it is resolved lazily from the paired
+ * daemon and persisted (see {@link resolvePairedAssistantPlatformId}). Until
+ * that lands the row falls through to its other sources.
+ */
+function usePlatformLookupId(
+  row: ResolvedAssistant,
+  canLookUp: boolean,
+): string | null {
+  const hasPlatformSession = useHasPlatformSession();
+  const needsPairedResolve =
+    row.isPaired && !row.platformAssistantId && canLookUp;
+  const pairedQuery = useQuery<string | null>({
+    queryKey: pairedPlatformIdQueryKey(row.id, row.runtimeUrl),
+    queryFn: () => resolvePairedAssistantPlatformId(row.id),
+    enabled: needsPairedResolve && hasPlatformSession,
+    staleTime: Infinity,
+    retry: false,
+  });
+  if (row.platformAssistantId) {
+    return row.platformAssistantId;
+  }
+  return row.isPaired ? (pairedQuery.data ?? null) : row.id;
 }
 
 function conclusive(read: AvatarRead): LegacyAvatarRead {
@@ -307,9 +349,11 @@ async function readCachedRowAvatar(assistantId: string): Promise<AvatarRead> {
  *    org store can supply the `Vellum-Organization-Id` header.
  * 4. Local rows (the connected one when unreachable, siblings even asleep)
  *    read their workspace through the host when one can serve it.
- * 5. Paired and local rows look their id up in the platform list
- *    (`usePlatformAvatarUrls`): lockfile rows never carry `avatarUrl`, so
- *    this is how a logged-in desktop shows a sibling's synced thumbnail.
+ * 5. Every row without `avatarUrl` in a lockfile-driven mode looks its
+ *    platform id up in the platform list (`usePlatformAvatarUrls`): lockfile
+ *    rows never carry `avatarUrl`, so this is how a logged-in desktop shows a
+ *    sibling's synced thumbnail. A paired row first resolves its platform
+ *    UUID from the paired daemon (`usePlatformLookupId`).
  * 6. The last-seen cache: whatever a live source last resolved for this id,
  *    so a row keeps its avatar while the assistant is unreachable.
  * Only live sources (1 and 3) feed the cache, at fetch time (1 does so
@@ -405,9 +449,12 @@ export function useChooserRowAvatar(
     (hostConclusive || !isEmptyAvatar(hostQuery.data));
 
   const platformAvatarUrls = usePlatformAvatarUrls();
-  const lookupCandidate = canLookUpRowAvatarByPlatformId(assistant)
-    ? (platformAvatarUrls.get(platformIdFor(assistant)) ?? null)
-    : null;
+  const canLookUp = canLookUpRowAvatarByPlatformId(assistant);
+  const lookupId = usePlatformLookupId(assistant, canLookUp);
+  const lookupCandidate =
+    canLookUp && lookupId !== null
+      ? (platformAvatarUrls.get(lookupId) ?? null)
+      : null;
   const lookupUrl =
     lookupCandidate !== failedPlatformUrl ? lookupCandidate : null;
   // Waits out an in-flight host read so a row never flashes the thumbnail

--- a/clients/web/src/hooks/use-platform-avatar-urls.test.tsx
+++ b/clients/web/src/hooks/use-platform-avatar-urls.test.tsx
@@ -1,0 +1,347 @@
+/**
+ * Tests for `usePlatformAvatarUrls`: the enable gate (live platform session
+ * in a lockfile-driven mode, org header ready), the id-to-url reduction, the
+ * failure-to-empty-map contract, one list call shared by every consumer, and
+ * the promise never to write the resolved-assistants store. The auth and
+ * resolved stores are real; the environment probes and the assistants API are
+ * mocked at the module boundary.
+ */
+
+import type { ReactNode } from "react";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  mock,
+  spyOn,
+  test,
+} from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+
+import type * as AssistantApi from "@/assistant/api";
+import type { Assistant } from "@/generated/api";
+
+const actualLocalMode = await import("@/lib/local-mode");
+let localClient = false;
+let remoteGatewayMode = false;
+mock.module("@/lib/local-mode", () => ({
+  ...actualLocalMode,
+  isLocalClient: () => localClient,
+  isRemoteGatewayMode: () => remoteGatewayMode,
+}));
+
+let gatewayAuthEnabled = false;
+mock.module("@/lib/auth/gateway-session", () => ({
+  isGatewayAuthEnabled: () => gatewayAuthEnabled,
+}));
+
+let orgReady = true;
+mock.module("@/hooks/use-is-org-ready", () => ({
+  useIsOrgReady: () => orgReady,
+}));
+
+const listAssistants = mock(
+  async (): Promise<AssistantApi.ListAssistantsResult> => ({
+    ok: true,
+    status: 200,
+    data: [],
+  }),
+);
+const actualApi = await import("@/assistant/api");
+mock.module("@/assistant/api", () => ({ ...actualApi, listAssistants }));
+
+const { useAuthStore } = await import("@/stores/auth-store");
+const { useOrganizationStore } = await import("@/stores/organization-store");
+const { useResolvedAssistantsStore } =
+  await import("@/stores/resolved-assistants-store");
+const {
+  platformAvatarUrlsQueryKey,
+  resetPlatformAvatarUrlSuppressionsForTests,
+  suppressPlatformAvatarUrl,
+  usePlatformAvatarUrls,
+} = await import("@/hooks/use-platform-avatar-urls");
+
+const initialAuthState = useAuthStore.getState();
+
+const apiAssistant = (id: string, avatar_url: string | null): Assistant =>
+  ({ id, avatar_url }) as Assistant;
+
+const WITH_AVATAR = "https://cdn.example/avatars/a.png";
+
+function createWrapper(
+  queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  }),
+) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+async function settle(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 20));
+}
+
+function signIn(userId = "user-1"): void {
+  useAuthStore.setState({
+    platformSession: "present",
+    user: {
+      kind: "platform",
+      id: userId,
+      username: null,
+      email: null,
+      isStaff: false,
+      firstName: "",
+      lastName: "",
+    },
+  });
+}
+
+beforeEach(() => {
+  localClient = true;
+  remoteGatewayMode = false;
+  gatewayAuthEnabled = false;
+  orgReady = true;
+  resetPlatformAvatarUrlSuppressionsForTests();
+  signIn();
+  listAssistants.mockResolvedValue({
+    ok: true,
+    status: 200,
+    data: [
+      apiAssistant("a", WITH_AVATAR),
+      apiAssistant("b", null),
+      apiAssistant("c", ""),
+    ],
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  listAssistants.mockReset();
+  useAuthStore.setState(initialAuthState, true);
+});
+
+describe("usePlatformAvatarUrls", () => {
+  test.each([
+    ["local client", () => (localClient = true)],
+    [
+      "remote-gateway mode",
+      () => {
+        localClient = false;
+        remoteGatewayMode = true;
+      },
+    ],
+  ])("maps id to a non-empty avatar_url under %s", async (_l, arrange) => {
+    arrange();
+    const { result } = renderHook(() => usePlatformAvatarUrls(), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => {
+      expect(result.current.get("a")).toBe(WITH_AVATAR);
+    });
+    expect(result.current.has("b")).toBe(false);
+    expect(result.current.has("c")).toBe(false);
+    expect(listAssistants).toHaveBeenCalledTimes(1);
+  });
+
+  test.each([
+    [
+      "no live platform session",
+      () => useAuthStore.setState({ platformSession: "absent", user: null }),
+    ],
+    [
+      "an unsettled platform session",
+      () => useAuthStore.setState({ platformSession: "unknown" }),
+    ],
+    ["pure cloud mode", () => (localClient = false)],
+    ["gateway auth", () => (gatewayAuthEnabled = true)],
+    ["an unready org header", () => (orgReady = false)],
+  ])("stays idle with %s", async (_l, arrange) => {
+    arrange();
+    const { result } = renderHook(() => usePlatformAvatarUrls(), {
+      wrapper: createWrapper(),
+    });
+    await settle();
+    expect(result.current.size).toBe(0);
+    expect(listAssistants).not.toHaveBeenCalled();
+  });
+
+  test("a rejected list resolves to an empty map", async () => {
+    listAssistants.mockRejectedValue(new Error("offline"));
+    const { result } = renderHook(() => usePlatformAvatarUrls(), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => {
+      expect(listAssistants).toHaveBeenCalledTimes(1);
+    });
+    await settle();
+    expect(result.current.size).toBe(0);
+  });
+
+  test("a non-ok list resolves to an empty map", async () => {
+    listAssistants.mockResolvedValue({ ok: false, status: 500, error: {} });
+    const { result } = renderHook(() => usePlatformAvatarUrls(), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => {
+      expect(listAssistants).toHaveBeenCalledTimes(1);
+    });
+    await settle();
+    expect(result.current.size).toBe(0);
+  });
+
+  test("one list call serves every consumer in a stale window", async () => {
+    const wrapper = createWrapper();
+    const { result } = renderHook(
+      () => [
+        usePlatformAvatarUrls(),
+        usePlatformAvatarUrls(),
+        usePlatformAvatarUrls(),
+      ],
+      { wrapper },
+    );
+    await waitFor(() => {
+      expect(result.current[0]?.get("a")).toBe(WITH_AVATAR);
+    });
+    renderHook(() => usePlatformAvatarUrls(), { wrapper });
+    await settle();
+    expect(listAssistants).toHaveBeenCalledTimes(1);
+  });
+
+  test("a different user gets a fresh list", async () => {
+    const wrapper = createWrapper();
+    const { result } = renderHook(() => usePlatformAvatarUrls(), { wrapper });
+    await waitFor(() => {
+      expect(result.current.get("a")).toBe(WITH_AVATAR);
+    });
+
+    act(() => signIn("user-2"));
+
+    await waitFor(() => {
+      expect(listAssistants).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  test("an organization switch gets a fresh list", async () => {
+    const wrapper = createWrapper();
+    const { result } = renderHook(() => usePlatformAvatarUrls(), { wrapper });
+    await waitFor(() => {
+      expect(result.current.get("a")).toBe(WITH_AVATAR);
+    });
+
+    act(() =>
+      useOrganizationStore.setState({ currentOrganizationId: "org-2" }),
+    );
+
+    await waitFor(() => {
+      expect(listAssistants).toHaveBeenCalledTimes(2);
+    });
+    useOrganizationStore.setState({ currentOrganizationId: null });
+  });
+
+  test("never writes the resolved-assistants store", async () => {
+    const setState = spyOn(useResolvedAssistantsStore, "setState");
+    const before = useResolvedAssistantsStore.getState().assistants;
+    const { result } = renderHook(() => usePlatformAvatarUrls(), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => {
+      expect(result.current.get("a")).toBe(WITH_AVATAR);
+    });
+    expect(setState).not.toHaveBeenCalled();
+    expect(useResolvedAssistantsStore.getState().assistants).toBe(before);
+    setState.mockRestore();
+  });
+});
+
+describe("suppressPlatformAvatarUrl", () => {
+  function deferredList() {
+    let resolveList!: (value: AssistantApi.ListAssistantsResult) => void;
+    listAssistants.mockReturnValueOnce(
+      new Promise<AssistantApi.ListAssistantsResult>((resolve) => {
+        resolveList = resolve;
+      }),
+    );
+    return (data: Assistant[]) => resolveList({ ok: true, status: 200, data });
+  }
+
+  test("drops the id from a cached map", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const { result } = renderHook(() => usePlatformAvatarUrls(), {
+      wrapper: createWrapper(queryClient),
+    });
+    await waitFor(() => {
+      expect(result.current.get("a")).toBe(WITH_AVATAR);
+    });
+
+    act(() => suppressPlatformAvatarUrl(queryClient, "a"));
+
+    await waitFor(() => {
+      expect(result.current.has("a")).toBe(false);
+    });
+    expect(listAssistants).toHaveBeenCalledTimes(1);
+  });
+
+  test("a list in flight during suppression lands its siblings without the stale url", async () => {
+    const resolveList = deferredList();
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const { result } = renderHook(() => usePlatformAvatarUrls(), {
+      wrapper: createWrapper(queryClient),
+    });
+    await waitFor(() => {
+      expect(listAssistants).toHaveBeenCalledTimes(1);
+    });
+
+    act(() => suppressPlatformAvatarUrl(queryClient, "a"));
+    resolveList([
+      apiAssistant("a", WITH_AVATAR),
+      apiAssistant("sibling", "https://cdn.example/avatars/sibling.png"),
+    ]);
+
+    await waitFor(() => {
+      expect(result.current.get("sibling")).toBe(
+        "https://cdn.example/avatars/sibling.png",
+      );
+    });
+    expect(result.current.has("a")).toBe(false);
+    expect(listAssistants).toHaveBeenCalledTimes(1);
+    expect(
+      queryClient.getQueryState(platformAvatarUrlsQueryKey("user-1", null))
+        ?.status,
+    ).toBe("success");
+  });
+
+  test("a list started after suppression carries the id again", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const { result } = renderHook(() => usePlatformAvatarUrls(), {
+      wrapper: createWrapper(queryClient),
+    });
+    await waitFor(() => {
+      expect(result.current.get("a")).toBe(WITH_AVATAR);
+    });
+
+    act(() => suppressPlatformAvatarUrl(queryClient, "a"));
+    await waitFor(() => {
+      expect(result.current.has("a")).toBe(false);
+    });
+
+    await act(() =>
+      queryClient.refetchQueries({ queryKey: ["platformAvatarUrls"] }),
+    );
+
+    expect(listAssistants).toHaveBeenCalledTimes(2);
+    await waitFor(() => {
+      expect(result.current.get("a")).toBe(WITH_AVATAR);
+    });
+  });
+});

--- a/clients/web/src/hooks/use-platform-avatar-urls.ts
+++ b/clients/web/src/hooks/use-platform-avatar-urls.ts
@@ -1,0 +1,137 @@
+import { type QueryClient, useQuery } from "@tanstack/react-query";
+
+import { listAssistants } from "@/assistant/api";
+import { useIsOrgReady } from "@/hooks/use-is-org-ready";
+import { isGatewayAuthEnabled } from "@/lib/auth/gateway-session";
+import { isLocalClient, isRemoteGatewayMode } from "@/lib/local-mode";
+import { useAuthStore, useHasPlatformSession } from "@/stores/auth-store";
+import { useRequestOrganizationId } from "@/stores/organization-store";
+
+export type PlatformAvatarUrls = ReadonlyMap<string, string>;
+
+const EMPTY_AVATAR_URLS: PlatformAvatarUrls = new Map();
+
+/** Matches the row-level avatar clocks so a re-synced thumbnail shows within a minute. */
+export const PLATFORM_AVATAR_URLS_STALE_TIME_MS = 60_000;
+
+/**
+ * Keyed by user and organization: a sign-out never serves another account's
+ * thumbnails, and an org switch rescopes the list with the request header.
+ */
+export function platformAvatarUrlsQueryKey(
+  userId: string | null,
+  organizationId: string | null,
+) {
+  return ["platformAvatarUrls", userId, organizationId] as const;
+}
+
+const PLATFORM_AVATAR_URLS_KEY_PREFIX = ["platformAvatarUrls"] as const;
+
+/**
+ * Per-id tombstones stamped with the fetch generation current at suppression.
+ * A list fetch that started at or before the stamp omits the id when it
+ * lands; one that started after it is fresher than the suppression and
+ * carries the id again, clearing the tombstone.
+ */
+const suppressedPlatformIds = new Map<string, number>();
+let fetchGeneration = 0;
+
+export function resetPlatformAvatarUrlSuppressionsForTests(): void {
+  suppressedPlatformIds.clear();
+  fetchGeneration = 0;
+}
+
+/**
+ * Drops one platform id from every cached map without refetching. Mirrors
+ * the store's `clearAvatarUrl`: live evidence outranks a URL observed
+ * earlier, and the platform copy lags the daemon's async sync, so an
+ * immediate refetch would only re-serve the stale URL. The next stale-window
+ * refetch restores it. A list in flight keeps its siblings and lands without
+ * this id (see the tombstones above); nothing is cancelled.
+ */
+export function suppressPlatformAvatarUrl(
+  queryClient: QueryClient,
+  platformAssistantId: string,
+): void {
+  suppressedPlatformIds.set(platformAssistantId, fetchGeneration);
+  queryClient.setQueriesData<PlatformAvatarUrls>(
+    { queryKey: PLATFORM_AVATAR_URLS_KEY_PREFIX },
+    (urls) => {
+      if (!urls?.has(platformAssistantId)) {
+        return urls;
+      }
+      const next = new Map(urls);
+      next.delete(platformAssistantId);
+      return next;
+    },
+  );
+}
+
+/**
+ * Modes where the resolved store is lockfile-driven, so its rows never carry
+ * `avatarUrl` and the platform list is only reachable through a side query.
+ * Gateway auth has no platform list at all.
+ */
+function isLockfileDrivenStore(): boolean {
+  return (isLocalClient() || isRemoteGatewayMode()) && !isGatewayAuthEnabled();
+}
+
+/** Never throws: a chooser row falls back to its other sources, not an error. */
+async function fetchPlatformAvatarUrls(): Promise<PlatformAvatarUrls> {
+  const startGeneration = ++fetchGeneration;
+  try {
+    const result = await listAssistants();
+    if (!result.ok) {
+      return EMPTY_AVATAR_URLS;
+    }
+    const urls = new Map<string, string>();
+    for (const assistant of result.data) {
+      if (
+        assistant.avatar_url &&
+        !isSuppressed(assistant.id, startGeneration)
+      ) {
+        urls.set(assistant.id, assistant.avatar_url);
+      }
+    }
+    return urls;
+  } catch {
+    return EMPTY_AVATAR_URLS;
+  }
+}
+
+/** Suppressed during or after this fetch; an older tombstone is stale and dropped. */
+function isSuppressed(platformAssistantId: string, startGeneration: number) {
+  const suppressedAt = suppressedPlatformIds.get(platformAssistantId);
+  if (suppressedAt === undefined) {
+    return false;
+  }
+  if (suppressedAt >= startGeneration) {
+    return true;
+  }
+  suppressedPlatformIds.delete(platformAssistantId);
+  return false;
+}
+
+/**
+ * Platform `avatar_url` by assistant id, read-only. One shared query feeds
+ * every chooser row, so the list is fetched once per stale window however
+ * many rows mount. Enabled only when a live platform session exists in a
+ * lockfile-driven mode; elsewhere the resolved store already carries
+ * `avatarUrl` and this resolves to an empty map. Never writes the resolved
+ * store: `reloadPlatformAssistants` deliberately skips these modes so the
+ * API list cannot clobber lockfile rows, and this lookup keeps that contract.
+ */
+export function usePlatformAvatarUrls(): PlatformAvatarUrls {
+  const hasPlatformSession = useHasPlatformSession();
+  const userId = useAuthStore.use.user()?.id ?? null;
+  const isOrgReady = useIsOrgReady();
+  const organizationId = useRequestOrganizationId();
+  const query = useQuery<PlatformAvatarUrls>({
+    queryKey: platformAvatarUrlsQueryKey(userId, organizationId),
+    queryFn: fetchPlatformAvatarUrls,
+    enabled: hasPlatformSession && isOrgReady && isLockfileDrivenStore(),
+    staleTime: PLATFORM_AVATAR_URLS_STALE_TIME_MS,
+    retry: false,
+  });
+  return query.data ?? EMPTY_AVATAR_URLS;
+}

--- a/clients/web/src/hooks/use-platform-avatar-urls.ts
+++ b/clients/web/src/hooks/use-platform-avatar-urls.ts
@@ -72,7 +72,7 @@ export function suppressPlatformAvatarUrl(
  * `avatarUrl` and the platform list is only reachable through a side query.
  * Gateway auth has no platform list at all.
  */
-function isLockfileDrivenStore(): boolean {
+export function isLockfileDrivenStore(): boolean {
   return (isLocalClient() || isRemoteGatewayMode()) && !isGatewayAuthEnabled();
 }
 

--- a/clients/web/src/lib/local-platform-identity.ts
+++ b/clients/web/src/lib/local-platform-identity.ts
@@ -338,8 +338,12 @@ async function ensureGatewayAccess(
   return { gatewayUrl, actorToken };
 }
 
-async function fetchPlatformStatus(
-  gateway: { gatewayUrl: string; actorToken: string },
+/**
+ * The daemon's `platform/status`, null on any failure. A null `actorToken`
+ * sends no bearer: the paired proxy's trusted host installs its own.
+ */
+export async function fetchPlatformStatus(
+  gateway: { gatewayUrl: string; actorToken: string | null },
   runtimeAssistantId: string,
 ): Promise<LocalPlatformStatus | null> {
   const url = gatewayUrl(
@@ -349,7 +353,9 @@ async function fetchPlatformStatus(
   const response = await fetch(url, {
     headers: {
       Accept: "application/json",
-      Authorization: `Bearer ${gateway.actorToken}`,
+      ...(gateway.actorToken && {
+        Authorization: `Bearer ${gateway.actorToken}`,
+      }),
     },
     credentials: "omit",
   }).catch(() => null);
@@ -596,7 +602,7 @@ function gatewayUrl(baseUrl: string, path: string): string {
   return url.toString();
 }
 
-function isUuid(value: string): boolean {
+export function isUuid(value: string): boolean {
   return UUID_RE.test(value);
 }
 

--- a/clients/web/src/lib/paired-platform-identity.test.ts
+++ b/clients/web/src/lib/paired-platform-identity.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Tests for `resolvePairedAssistantPlatformId`: the paired-proxy status read,
+ * the lockfile persist, and the per-session cache (hits and misses alike).
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { LockfileAssistant } from "@/lib/local-mode";
+
+const UUID = "0f7c8b3e-2a41-4c1d-9b6e-1d2f3a4b5c6d";
+
+const pairedEntry: LockfileAssistant = {
+  assistantId: "paired-remote",
+  cloud: "paired",
+  runtimeUrl: "https://remote.example",
+  hatchedAt: "2024-01-01T00:00:00Z",
+};
+
+let lockfileEntry: LockfileAssistant | undefined = pairedEntry;
+let pairedGatewayUrl: string | undefined =
+  "/assistant/__gateway-paired/paired-remote";
+const updateLockfileAssistant = mock(async (_a: LockfileAssistant) => {});
+mock.module("@/lib/local-mode", () => ({
+  getLockfileAssistant: () => lockfileEntry,
+  getPairedGatewayUrl: () => pairedGatewayUrl,
+  updateLockfileAssistant,
+}));
+
+const fetchPlatformStatus = mock(
+  async (
+    _gateway: { gatewayUrl: string; actorToken: string | null },
+    _id: string,
+  ) => ({ assistantId: UUID }) as { assistantId: string | null } | null,
+);
+mock.module("@/lib/local-platform-identity", () => ({
+  fetchPlatformStatus,
+  isUuid: (value: string) => /^[0-9a-f-]{36}$/i.test(value),
+}));
+
+const {
+  resetPairedPlatformIdentityCacheForTesting,
+  resolvePairedAssistantPlatformId,
+} = await import("@/lib/paired-platform-identity");
+
+beforeEach(() => {
+  lockfileEntry = pairedEntry;
+  pairedGatewayUrl = "/assistant/__gateway-paired/paired-remote";
+  fetchPlatformStatus.mockResolvedValue({ assistantId: UUID });
+  updateLockfileAssistant.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  resetPairedPlatformIdentityCacheForTesting();
+  fetchPlatformStatus.mockReset();
+  updateLockfileAssistant.mockReset();
+});
+
+describe("resolvePairedAssistantPlatformId", () => {
+  test("reads the paired daemon's status through the proxy and persists the UUID", async () => {
+    await expect(
+      resolvePairedAssistantPlatformId("paired-remote"),
+    ).resolves.toBe(UUID);
+    expect(fetchPlatformStatus).toHaveBeenCalledWith(
+      {
+        gatewayUrl: `${window.location.origin}/assistant/__gateway-paired/paired-remote`,
+        actorToken: null,
+      },
+      "paired-remote",
+    );
+    expect(updateLockfileAssistant).toHaveBeenCalledWith({
+      ...pairedEntry,
+      platformAssistantId: UUID,
+    });
+  });
+
+  test("a re-pair to another gateway probes again", async () => {
+    await resolvePairedAssistantPlatformId("paired-remote");
+    lockfileEntry = { ...pairedEntry, runtimeUrl: "https://new.example.com" };
+    await resolvePairedAssistantPlatformId("paired-remote");
+    expect(fetchPlatformStatus).toHaveBeenCalledTimes(2);
+  });
+
+  test("resolves once per id per session", async () => {
+    await resolvePairedAssistantPlatformId("paired-remote");
+    await resolvePairedAssistantPlatformId("paired-remote");
+    expect(fetchPlatformStatus).toHaveBeenCalledTimes(1);
+    expect(updateLockfileAssistant).toHaveBeenCalledTimes(1);
+  });
+
+  test("caches a miss so an unreachable daemon is not re-asked", async () => {
+    fetchPlatformStatus.mockResolvedValue(null);
+    await expect(
+      resolvePairedAssistantPlatformId("paired-remote"),
+    ).resolves.toBeNull();
+    await expect(
+      resolvePairedAssistantPlatformId("paired-remote"),
+    ).resolves.toBeNull();
+    expect(fetchPlatformStatus).toHaveBeenCalledTimes(1);
+    expect(updateLockfileAssistant).not.toHaveBeenCalled();
+  });
+
+  test("returns the persisted id without a daemon read", async () => {
+    lockfileEntry = { ...pairedEntry, platformAssistantId: UUID };
+    await expect(
+      resolvePairedAssistantPlatformId("paired-remote"),
+    ).resolves.toBe(UUID);
+    expect(fetchPlatformStatus).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    ["no lockfile entry", () => (lockfileEntry = undefined)],
+    ["no usable paired proxy", () => (pairedGatewayUrl = undefined)],
+  ])("resolves null with %s", async (_l, arrange) => {
+    arrange();
+    await expect(
+      resolvePairedAssistantPlatformId("paired-remote"),
+    ).resolves.toBeNull();
+    expect(fetchPlatformStatus).not.toHaveBeenCalled();
+  });
+
+  test("rejects a status id that is not a UUID", async () => {
+    fetchPlatformStatus.mockResolvedValue({ assistantId: "self" });
+    await expect(
+      resolvePairedAssistantPlatformId("paired-remote"),
+    ).resolves.toBeNull();
+    expect(updateLockfileAssistant).not.toHaveBeenCalled();
+  });
+
+  test("a rename during the request keeps the new name and gains the UUID", async () => {
+    fetchPlatformStatus.mockImplementation(async () => {
+      lockfileEntry = { ...pairedEntry, name: "Renamed" };
+      return { assistantId: UUID };
+    });
+    await expect(
+      resolvePairedAssistantPlatformId("paired-remote"),
+    ).resolves.toBe(UUID);
+    expect(updateLockfileAssistant).toHaveBeenCalledWith({
+      ...pairedEntry,
+      name: "Renamed",
+      platformAssistantId: UUID,
+    });
+  });
+
+  test.each([
+    ["removed", () => (lockfileEntry = undefined)],
+    [
+      "no longer paired",
+      () => (lockfileEntry = { ...pairedEntry, cloud: "local" }),
+    ],
+    [
+      "retargeted",
+      () =>
+        (lockfileEntry = {
+          ...pairedEntry,
+          runtimeUrl: "https://other.example",
+        }),
+    ],
+  ])(
+    "skips the write and resolves null when the entry is %s mid-request",
+    async (_l, arrange) => {
+      fetchPlatformStatus.mockImplementation(async () => {
+        arrange();
+        return { assistantId: UUID };
+      });
+      await expect(
+        resolvePairedAssistantPlatformId("paired-remote"),
+      ).resolves.toBeNull();
+      expect(updateLockfileAssistant).not.toHaveBeenCalled();
+    },
+  );
+
+  test("a failed lockfile write still returns the UUID", async () => {
+    updateLockfileAssistant.mockRejectedValue(new Error("disk"));
+    await expect(
+      resolvePairedAssistantPlatformId("paired-remote"),
+    ).resolves.toBe(UUID);
+  });
+});

--- a/clients/web/src/lib/paired-platform-identity.test.ts
+++ b/clients/web/src/lib/paired-platform-identity.test.ts
@@ -87,16 +87,24 @@ describe("resolvePairedAssistantPlatformId", () => {
     expect(updateLockfileAssistant).toHaveBeenCalledTimes(1);
   });
 
-  test("caches a miss so an unreachable daemon is not re-asked", async () => {
-    fetchPlatformStatus.mockResolvedValue(null);
+  test("a miss is not cached, so a recovered daemon is asked again", async () => {
+    fetchPlatformStatus.mockResolvedValueOnce(null);
     await expect(
       resolvePairedAssistantPlatformId("paired-remote"),
     ).resolves.toBeNull();
-    await expect(
-      resolvePairedAssistantPlatformId("paired-remote"),
-    ).resolves.toBeNull();
-    expect(fetchPlatformStatus).toHaveBeenCalledTimes(1);
     expect(updateLockfileAssistant).not.toHaveBeenCalled();
+    await expect(
+      resolvePairedAssistantPlatformId("paired-remote"),
+    ).resolves.toBe(UUID);
+    expect(fetchPlatformStatus).toHaveBeenCalledTimes(2);
+  });
+
+  test("concurrent asks share one in-flight probe", async () => {
+    await Promise.all([
+      resolvePairedAssistantPlatformId("paired-remote"),
+      resolvePairedAssistantPlatformId("paired-remote"),
+    ]);
+    expect(fetchPlatformStatus).toHaveBeenCalledTimes(1);
   });
 
   test("returns the persisted id without a daemon read", async () => {

--- a/clients/web/src/lib/paired-platform-identity.ts
+++ b/clients/web/src/lib/paired-platform-identity.ts
@@ -1,0 +1,84 @@
+import { fetchPlatformStatus, isUuid } from "@/lib/local-platform-identity";
+import {
+  getLockfileAssistant,
+  getPairedGatewayUrl,
+  updateLockfileAssistant,
+} from "@/lib/local-mode";
+
+/**
+ * One attempt per paired target per session; a miss (unreachable,
+ * unregistered) is cached too. Keyed by gateway URL as well as id so a
+ * same-name re-pair to another gateway probes again.
+ */
+const pairedPlatformIdCache = new Map<string, Promise<string | null>>();
+
+function pairedCacheKey(assistantId: string): string {
+  return `${assistantId}\n${getLockfileAssistant(assistantId)?.runtimeUrl ?? ""}`;
+}
+
+export function resetPairedPlatformIdentityCacheForTesting(): void {
+  pairedPlatformIdCache.clear();
+}
+
+/**
+ * The platform UUID a paired assistant is registered under, or null.
+ *
+ * `pairAssistant` keys the lockfile entry by a local slug and the pairing
+ * reply carries no platform id, so the entry lacks `platformAssistantId`
+ * until something asks the paired daemon. Its `platform/status` route
+ * answers through the same-origin paired proxy (the host injects the
+ * guardian bearer, the gateway's runtime-proxy catch-all discards the id in
+ * the path), and the UUID is persisted to the entry so `setFromLockfile`
+ * carries it from then on. Never throws.
+ */
+export function resolvePairedAssistantPlatformId(
+  assistantId: string,
+): Promise<string | null> {
+  const key = pairedCacheKey(assistantId);
+  const cached = pairedPlatformIdCache.get(key);
+  if (cached) {
+    return cached;
+  }
+  const promise = fetchAndPersistPairedPlatformId(assistantId);
+  pairedPlatformIdCache.set(key, promise);
+  return promise;
+}
+
+async function fetchAndPersistPairedPlatformId(
+  assistantId: string,
+): Promise<string | null> {
+  const entry = getLockfileAssistant(assistantId);
+  if (!entry) {
+    return null;
+  }
+  if (entry.platformAssistantId) {
+    return entry.platformAssistantId;
+  }
+  const pairedUrl = getPairedGatewayUrl(entry);
+  if (!pairedUrl) {
+    return null;
+  }
+  const status = await fetchPlatformStatus(
+    { gatewayUrl: `${window.location.origin}${pairedUrl}`, actorToken: null },
+    assistantId,
+  );
+  const platformAssistantId = status?.assistantId ?? null;
+  if (!platformAssistantId || !isUuid(platformAssistantId)) {
+    return null;
+  }
+  // Re-read: a rename or re-pair may have landed while the request was in flight.
+  const current = getLockfileAssistant(assistantId);
+  if (
+    !current ||
+    current.cloud !== "paired" ||
+    current.runtimeUrl !== entry.runtimeUrl
+  ) {
+    return null;
+  }
+  try {
+    await updateLockfileAssistant({ ...current, platformAssistantId });
+  } catch (error) {
+    console.warn("paired assistant platform lockfile update failed", error);
+  }
+  return platformAssistantId;
+}

--- a/clients/web/src/lib/paired-platform-identity.ts
+++ b/clients/web/src/lib/paired-platform-identity.ts
@@ -6,9 +6,10 @@ import {
 } from "@/lib/local-mode";
 
 /**
- * One attempt per paired target per session; a miss (unreachable,
- * unregistered) is cached too. Keyed by gateway URL as well as id so a
- * same-name re-pair to another gateway probes again.
+ * One resolved UUID per paired target per session. A miss (unreachable,
+ * not yet registered) is evicted so the next ask probes again. Keyed by
+ * gateway URL as well as id so a same-name re-pair to another gateway
+ * probes again.
  */
 const pairedPlatformIdCache = new Map<string, Promise<string | null>>();
 
@@ -39,7 +40,12 @@ export function resolvePairedAssistantPlatformId(
   if (cached) {
     return cached;
   }
-  const promise = fetchAndPersistPairedPlatformId(assistantId);
+  const promise = fetchAndPersistPairedPlatformId(assistantId).then((id) => {
+    if (id === null) {
+      pairedPlatformIdCache.delete(key);
+    }
+    return id;
+  });
   pairedPlatformIdCache.set(key, promise);
   return promise;
 }

--- a/clients/web/src/lib/persist-last-seen-avatar.ts
+++ b/clients/web/src/lib/persist-last-seen-avatar.ts
@@ -5,6 +5,7 @@ import {
   lastSeenAvatarGenerations,
   writeLastSeenAvatar,
 } from "@/lib/avatar-last-seen-cache";
+import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
 import type { AvatarRead } from "@/types/avatar";
 
 /** The chooser's query over the last-seen cache; invalidated after every persist. */
@@ -19,8 +20,10 @@ export function chooserRowAvatarCacheQueryKey(assistantId: string) {
  * read, not only while the chooser is mounted. Claims a persistence generation
  * up front so a blob read that resolves after a newer write or delete
  * (including a retire) commits nothing. Invalidates the chooser's cache query
- * once committed so a row that falls back later reads the fresh entry.
- * Best-effort like the cache: never throws.
+ * once committed so a row that falls back later reads the fresh entry, and
+ * drops the row's synced `avatarUrl`: live evidence outranks a thumbnail
+ * observed earlier, so the cache path wins until the next list load carries
+ * a newer URL. Best-effort like the cache: never throws.
  */
 export async function persistLastSeenAvatar(
   queryClient: QueryClient,
@@ -52,6 +55,7 @@ export async function persistLastSeenAvatar(
     // A blob that cannot be read back is simply not cached.
     return;
   }
+  useResolvedAssistantsStore.getState().clearAvatarUrl(assistantId);
   void queryClient.invalidateQueries({
     queryKey: chooserRowAvatarCacheQueryKey(assistantId),
   });

--- a/clients/web/src/lib/persist-last-seen-avatar.ts
+++ b/clients/web/src/lib/persist-last-seen-avatar.ts
@@ -1,11 +1,15 @@
 import type { QueryClient } from "@tanstack/react-query";
 
+import { suppressPlatformAvatarUrl } from "@/hooks/use-platform-avatar-urls";
 import {
   deleteLastSeenAvatar,
   lastSeenAvatarGenerations,
   writeLastSeenAvatar,
 } from "@/lib/avatar-last-seen-cache";
-import { useResolvedAssistantsStore } from "@/stores/resolved-assistants-store";
+import {
+  resolvePlatformAssistantId,
+  useResolvedAssistantsStore,
+} from "@/stores/resolved-assistants-store";
 import type { AvatarRead } from "@/types/avatar";
 
 /** The chooser's query over the last-seen cache; invalidated after every persist. */
@@ -21,9 +25,9 @@ export function chooserRowAvatarCacheQueryKey(assistantId: string) {
  * up front so a blob read that resolves after a newer write or delete
  * (including a retire) commits nothing. Invalidates the chooser's cache query
  * once committed so a row that falls back later reads the fresh entry, and
- * drops the row's synced `avatarUrl`: live evidence outranks a thumbnail
- * observed earlier, so the cache path wins until the next list load carries
- * a newer URL. Best-effort like the cache: never throws.
+ * drops the row's synced `avatarUrl` and platform lookup entry: live evidence
+ * outranks a thumbnail observed earlier, so the cache path wins until the
+ * next list load carries a newer URL. Best-effort like the cache: never throws.
  */
 export async function persistLastSeenAvatar(
   queryClient: QueryClient,
@@ -56,6 +60,10 @@ export async function persistLastSeenAvatar(
     return;
   }
   useResolvedAssistantsStore.getState().clearAvatarUrl(assistantId);
+  suppressPlatformAvatarUrl(
+    queryClient,
+    resolvePlatformAssistantId(assistantId),
+  );
   void queryClient.invalidateQueries({
     queryKey: chooserRowAvatarCacheQueryKey(assistantId),
   });

--- a/clients/web/src/stores/resolved-assistants-store.test.ts
+++ b/clients/web/src/stores/resolved-assistants-store.test.ts
@@ -136,6 +136,20 @@ describe("setFromLockfile", () => {
     expect(entry.isActiveLockfileAssistant).toBe(true);
   });
 
+  it("copies platformAssistantId for local entries", () => {
+    useResolvedAssistantsStore.getState().setFromLockfile({
+      assistants: [
+        { ...localAssistant, platformAssistantId: "uuid-local" },
+        platformAssistant,
+      ],
+      activeAssistant: "asst-local",
+    });
+
+    const [local, platform] = useResolvedAssistantsStore.getState().assistants;
+    expect(local.platformAssistantId).toBe("uuid-local");
+    expect(platform.platformAssistantId).toBeUndefined();
+  });
+
   it("marks local entries inactive when the lockfile active pointer differs", () => {
     const lockfile: Lockfile = {
       assistants: [localAssistant, otherLocalAssistant],

--- a/clients/web/src/stores/resolved-assistants-store.test.ts
+++ b/clients/web/src/stores/resolved-assistants-store.test.ts
@@ -97,6 +97,29 @@ describe("setFromLockfile", () => {
     expect(entry.releaseChannel).toBe("preview");
   });
 
+  it("preserves an API-seeded avatarUrl across a lockfile refresh", () => {
+    useResolvedAssistantsStore.setState({
+      assistants: [
+        {
+          id: "asst-platform",
+          isLocal: false,
+          isPlatformHosted: true,
+          isPaired: false,
+          avatarUrl: "https://cdn.example/a.png",
+        },
+      ],
+    });
+
+    useResolvedAssistantsStore.getState().setFromLockfile({
+      assistants: [platformAssistant],
+      activeAssistant: "asst-platform",
+    });
+
+    expect(useResolvedAssistantsStore.getState().assistants[0].avatarUrl).toBe(
+      "https://cdn.example/a.png",
+    );
+  });
+
   it("copies Bun-local fields for local entries", () => {
     const lockfile: Lockfile = {
       assistants: [localAssistant],
@@ -333,16 +356,66 @@ describe("setFromApi connectability", () => {
       created: "2026-01-01T00:00:00Z",
       is_local: false,
       ingress_url: null,
+      avatar_url: null,
       current_release_version: null,
       release_channel: "stable",
       ...overrides,
     }) as ApiAssistant;
 
+  it("carries the platform avatar_url and leaves lockfile entries without one", () => {
+    useResolvedAssistantsStore
+      .getState()
+      .setFromApi([
+        apiEntry({ id: "asst-cloud", avatar_url: "https://cdn.example/a.png" }),
+        apiEntry({ id: "asst-bare", avatar_url: null }),
+      ]);
+    const byId = new Map(
+      useResolvedAssistantsStore.getState().assistants.map((a) => [a.id, a]),
+    );
+    expect(byId.get("asst-cloud")?.avatarUrl).toBe("https://cdn.example/a.png");
+    expect(byId.get("asst-bare")?.avatarUrl).toBeNull();
+
+    useResolvedAssistantsStore.getState().setFromLockfile({
+      assistants: [localAssistant],
+      activeAssistant: "asst-local",
+    });
+    expect(
+      useResolvedAssistantsStore.getState().assistants[0].avatarUrl,
+    ).toBeUndefined();
+  });
+
+  it("clearAvatarUrl nulls one row's avatarUrl and leaves the rest", () => {
+    useResolvedAssistantsStore
+      .getState()
+      .setFromApi([
+        apiEntry({ id: "asst-a", avatar_url: "https://cdn.example/a.png" }),
+        apiEntry({ id: "asst-b", avatar_url: "https://cdn.example/b.png" }),
+      ]);
+    const before = useResolvedAssistantsStore.getState().assistants;
+
+    useResolvedAssistantsStore.getState().clearAvatarUrl("asst-a");
+
+    const byId = new Map(
+      useResolvedAssistantsStore.getState().assistants.map((a) => [a.id, a]),
+    );
+    expect(byId.get("asst-a")?.avatarUrl).toBeNull();
+    expect(byId.get("asst-b")?.avatarUrl).toBe("https://cdn.example/b.png");
+
+    useResolvedAssistantsStore.getState().clearAvatarUrl("asst-a");
+    useResolvedAssistantsStore.getState().clearAvatarUrl("asst-missing");
+    expect(useResolvedAssistantsStore.getState().assistants).not.toBe(before);
+    expect(byId.get("asst-b")).toBe(
+      useResolvedAssistantsStore.getState().assistants[1],
+    );
+  });
+
   it("drops a local registration with no ingress and no lockfile entry", () => {
-    useResolvedAssistantsStore.getState().setFromApi([
-      apiEntry({ id: "asst-cloud" }),
-      apiEntry({ id: "asst-dead-local", is_local: true, ingress_url: null }),
-    ]);
+    useResolvedAssistantsStore
+      .getState()
+      .setFromApi([
+        apiEntry({ id: "asst-cloud" }),
+        apiEntry({ id: "asst-dead-local", is_local: true, ingress_url: null }),
+      ]);
 
     const assistants = useResolvedAssistantsStore.getState().assistants;
     expect(assistants.map((a) => a.id)).toEqual(["asst-cloud"]);
@@ -370,9 +443,11 @@ describe("setFromApi connectability", () => {
       activeAssistant: "asst-local",
     });
 
-    useResolvedAssistantsStore.getState().setFromApi([
-      apiEntry({ id: "asst-local", is_local: true, ingress_url: null }),
-    ]);
+    useResolvedAssistantsStore
+      .getState()
+      .setFromApi([
+        apiEntry({ id: "asst-local", is_local: true, ingress_url: null }),
+      ]);
 
     const entry = useResolvedAssistantsStore.getState().assistants[0];
     expect(entry.id).toBe("asst-local");

--- a/clients/web/src/stores/resolved-assistants-store.ts
+++ b/clients/web/src/stores/resolved-assistants-store.ts
@@ -60,6 +60,9 @@ export interface ResolvedAssistant {
    *  entries; only the API carries it. Null/undefined means the platform has
    *  no route to this assistant. */
   ingressUrl?: string | null;
+  /** Synced avatar thumbnail served by the platform; only the API carries
+   *  it. Null means the platform holds no avatar for this assistant. */
+  avatarUrl?: string | null;
   /** Owning org for platform entries; only the lockfile carries it, so
    *  API-sourced entries leave this undefined. */
   organizationId?: string;
@@ -120,6 +123,12 @@ interface ResolvedAssistantsActions {
    */
   markHydrated: () => void;
   upsertFromApi: (assistant: Assistant) => void;
+  /**
+   * Forget the synced thumbnail for one row. The platform copy lags a live
+   * avatar change, so callers drop it and let the live/cache paths render
+   * until the next API load carries the new URL.
+   */
+  clearAvatarUrl: (assistantId: string) => void;
   remove: (assistantId: string) => void;
   clear: () => void;
   setActiveAssistantId: (assistantId: string | null) => void;
@@ -142,12 +151,14 @@ const useResolvedAssistantsStoreBase = create<ResolvedAssistantsStore>(
       const existingById = new Map(
         get().assistants.map((assistant) => [assistant.id, assistant]),
       );
+      // The lockfile carries no platform metadata; keep what the API seeded.
       const assistants = lockfile.assistants.map((a) => ({
         id: a.assistantId,
         name: a.name,
         hatchedAt: a.hatchedAt,
         cloud: a.cloud,
         runtimeVersion: a.resources?.runtimeVersion,
+        avatarUrl: existingById.get(a.assistantId)?.avatarUrl,
         currentReleaseVersion: existingById.get(a.assistantId)
           ?.currentReleaseVersion,
         releaseChannel: existingById.get(a.assistantId)?.releaseChannel,
@@ -187,6 +198,7 @@ const useResolvedAssistantsStoreBase = create<ResolvedAssistantsStore>(
               runtimeVersion: lockfileFields.runtimeVersion,
               runtimeUrl: lockfileFields.runtimeUrl,
               ingressUrl: a.ingress_url,
+              avatarUrl: a.avatar_url,
               currentReleaseVersion: a.current_release_version,
               releaseChannel: a.release_channel,
               isActiveLockfileAssistant:
@@ -211,6 +223,7 @@ const useResolvedAssistantsStoreBase = create<ResolvedAssistantsStore>(
           name: assistant.name,
           hatchedAt: assistant.created,
           ingressUrl: assistant.ingress_url,
+          avatarUrl: assistant.avatar_url,
           currentReleaseVersion: assistant.current_release_version,
           releaseChannel: assistant.release_channel,
           ...classifyApiEntry(
@@ -250,6 +263,17 @@ const useResolvedAssistantsStoreBase = create<ResolvedAssistantsStore>(
             },
           ],
         };
+      }),
+
+    clearAvatarUrl: (assistantId) =>
+      set((state) => {
+        const idx = state.assistants.findIndex((a) => a.id === assistantId);
+        if (idx < 0 || state.assistants[idx].avatarUrl == null) {
+          return state;
+        }
+        const next = [...state.assistants];
+        next[idx] = { ...next[idx], avatarUrl: null };
+        return { assistants: next };
       }),
 
     remove: (assistantId) =>

--- a/clients/web/src/stores/resolved-assistants-store.ts
+++ b/clients/web/src/stores/resolved-assistants-store.ts
@@ -66,6 +66,22 @@ export interface ResolvedAssistant {
   /** Owning org for platform entries; only the lockfile carries it, so
    *  API-sourced entries leave this undefined. */
   organizationId?: string;
+  /** Platform UUID for a locally hatched entry whose `id` is the instance
+   *  name; only the lockfile carries it. API rows are already keyed by UUID. */
+  platformAssistantId?: string;
+}
+
+/** The id the platform knows `a` by: the lockfile's registration for a local instance, else `a.id`. */
+export function platformIdFor(a: ResolvedAssistant): string {
+  return a.platformAssistantId ?? a.id;
+}
+
+/** {@link platformIdFor} by row id; an id not in the store is its own platform id. */
+export function resolvePlatformAssistantId(assistantId: string): string {
+  const row = useResolvedAssistantsStoreBase
+    .getState()
+    .assistants.find((a) => a.id === assistantId);
+  return row ? platformIdFor(row) : assistantId;
 }
 
 /**
@@ -168,6 +184,7 @@ const useResolvedAssistantsStoreBase = create<ResolvedAssistantsStore>(
         isPaired: isPairedAssistant(a),
         runtimeUrl: a.runtimeUrl,
         organizationId: a.organizationId,
+        platformAssistantId: a.platformAssistantId,
       }));
       set({ assistants, assistantsHydrated: true });
       // The lockfile carries every org's entries, so an id absent from it is
@@ -197,6 +214,7 @@ const useResolvedAssistantsStoreBase = create<ResolvedAssistantsStore>(
               cloud: lockfileFields.cloud,
               runtimeVersion: lockfileFields.runtimeVersion,
               runtimeUrl: lockfileFields.runtimeUrl,
+              platformAssistantId: lockfileFields.platformAssistantId,
               ingressUrl: a.ingress_url,
               avatarUrl: a.avatar_url,
               currentReleaseVersion: a.current_release_version,
@@ -241,6 +259,8 @@ const useResolvedAssistantsStoreBase = create<ResolvedAssistantsStore>(
             runtimeVersion:
               lockfileFields.runtimeVersion ?? prior.runtimeVersion,
             runtimeUrl: lockfileFields.runtimeUrl ?? prior.runtimeUrl,
+            platformAssistantId:
+              lockfileFields.platformAssistantId ?? prior.platformAssistantId,
             isActiveLockfileAssistant:
               lockfileFields.isActiveLockfileAssistant ??
               prior.isActiveLockfileAssistant,
@@ -258,6 +278,7 @@ const useResolvedAssistantsStoreBase = create<ResolvedAssistantsStore>(
               organizationId: lockfileFields.organizationId,
               runtimeVersion: lockfileFields.runtimeVersion,
               runtimeUrl: lockfileFields.runtimeUrl,
+              platformAssistantId: lockfileFields.platformAssistantId,
               isActiveLockfileAssistant:
                 lockfileFields.isActiveLockfileAssistant,
             },
@@ -351,6 +372,7 @@ function getLockfileFields(assistantId: string): {
   organizationId?: string;
   runtimeVersion?: string;
   runtimeUrl?: string;
+  platformAssistantId?: string;
   isPaired?: boolean;
   isActiveLockfileAssistant?: boolean;
 } {
@@ -364,6 +386,7 @@ function getLockfileFields(assistantId: string): {
     organizationId: entry?.organizationId,
     runtimeVersion: entry?.resources?.runtimeVersion,
     runtimeUrl: entry?.runtimeUrl,
+    platformAssistantId: entry?.platformAssistantId,
     isPaired: entry ? isPairedAssistant(entry) : undefined,
     isActiveLockfileAssistant: lockfile
       ? activeLockfileAssistantId === assistantId

--- a/packages/local-mode/src/__tests__/pair.test.ts
+++ b/packages/local-mode/src/__tests__/pair.test.ts
@@ -656,6 +656,36 @@ describe("pairAssistant", () => {
     expect(readGuardianToken("desk").accessToken).toBe("t2");
   });
 
+  test("re-pairing to a new gateway drops a cached platformAssistantId", () => {
+    const first = pairAssistant([lockfilePath], configDir, {
+      credentials: credentials({ deviceId: "dev-re", token: "t1" }),
+      name: "desk",
+    });
+    expect(first.ok).toBe(true);
+    const cached = readLockfileFromDisk();
+    (
+      cached.assistants as Array<Record<string, unknown>>
+    )[0]!.platformAssistantId = "11111111-1111-4111-8111-111111111111";
+    fs.writeFileSync(lockfilePath, JSON.stringify(cached, null, 2));
+
+    const second = pairAssistant([lockfilePath], configDir, {
+      credentials: credentials({
+        deviceId: "dev-re",
+        token: "t2",
+        gatewayUrl: "https://new.example.com",
+      }),
+      name: "desk",
+    });
+
+    expect(second.ok).toBe(true);
+    const assistants = readLockfileFromDisk().assistants as Array<
+      Record<string, unknown>
+    >;
+    expect(assistants).toHaveLength(1);
+    expect(assistants[0]!.runtimeUrl).toBe("https://new.example.com");
+    expect(assistants[0]!).not.toHaveProperty("platformAssistantId");
+  });
+
   test("deletes the just-written token when the lockfile write fails", () => {
     // A lockfile path whose parent is a regular file makes the write fail
     // deterministically (unlike chmod, which root ignores) after the token

--- a/packages/local-mode/src/pair.ts
+++ b/packages/local-mode/src/pair.ts
@@ -394,6 +394,10 @@ export function pairAssistant(
       // guard above).
       paired: true,
       species: "vellum",
+      // A re-pair may point at a different gateway, so the platform id the
+      // web resolver cached for the old target is dropped; the upsert merge
+      // would otherwise keep it and the resolver would never re-probe.
+      platformAssistantId: undefined,
     },
     undefined,
   );
@@ -694,8 +698,7 @@ type PairingPost =
   | { ok: false; failure: PairingFailure };
 
 type PairingBody =
-  | { ok: true; value: unknown }
-  | { ok: false; failure: PairingFailure };
+  { ok: true; value: unknown } | { ok: false; failure: PairingFailure };
 
 /**
  * The reply body as JSON, read under {@link MAX_PAIRING_RESPONSE_BYTES}. An


### PR DESCRIPTION
## Summary

Read side of the chooser assistant avatars arc. The daemon already syncs avatars to the platform (#41467), the platform stores them and exposes `avatar_url` (vellum-assistant-platform#10150), and the spec sync landed in #41344. This branch makes the web chooser actually use that field.

- **PR 9 (#41538)**: `ResolvedAssistant.avatarUrl` populated from `Assistant.avatar_url`, preserved across lockfile refreshes, and used by `useChooserRowAvatar` as precedence step 2 (after the connected row's live data). Platform-hosted rows now show avatars in local/desktop modes with zero daemon round-trips. Local live evidence supersedes the synced URL (`clearAvatarUrl` on `avatar_updated` / sync invalidation / last-seen persist); a failed synced image falls back to cache and is retried on `app.resume`.
- **PR 10 (#41542)**: `usePlatformAvatarUrls()` read-only `listAssistants()` lookup (60 s stale window, one call per window) for lockfile-driven rows (paired + local) in local-client / remote-gateway modes; never writes the resolved store. Same supersede/fallback semantics as the synced URL, with per-id tombstones so an in-flight list cannot re-land a superseded URL. Local rows resolve through `platformAssistantId` (the lockfile instance id is not the platform UUID).

- **Fix PRs (#41551, #41553)**, from the two P1s Codex raised here: paired rows resolve their platform UUID lazily through the paired daemon's existing `platform/status` route (same-origin paired-gateway proxy, guardian bearer installed by the Electron forward) and persist it to the lockfile as `platformAssistantId`; a same-name re-pair clears it; probe misses are not cached and the lookup query goes stale after a miss. The lookup predicate is now "lockfile-driven store and the row has no `avatarUrl`", so lockfile-managed `cloud: "vellum"` rows in desktop mode are covered too.

Final precedence: connected-row live -> `avatarUrl` -> platform-proxy live (pure cloud) -> host disk read (local) -> platform id lookup (paired/local) -> IndexedDB last-seen -> nulls.

## Deferred (Codex P2s past the review-cycle limit, narrow races that self-heal on the next avatar event or list reload)

- Pure cloud: an assistants-list reload that overlaps platform replication right after an avatar change can restore the lagging `avatar_url` until the next reload.
- Switching assistants while the reconnect sweep's avatar refetch is in flight skips the last-seen persist, so the old synced thumbnail can win until the next change or reload.
- Lookup tombstone edge: an avatar change before the first list fetch records generation 0 and the first fetch (generation 1) drops it, so the platform's lagging URL can win once until the next change or reload.
- The platform list query has no foreground `refetchInterval`; a chooser that stays mounted with no focus change keeps a sibling's old thumbnail until remount or invalidation.
- `avatar_updated` for a paired row whose UUID has not been resolved yet suppresses by the local slug, not the UUID; self-heals once the resolver persists the UUID and the next change fires.
- `listAssistants()` reads only the first page; an org with more assistants than the page limit already truncates the chooser list itself, and the lookup inherits that. Fix belongs in the wrapper for both callers.

## QA

- Paired-row UUID resolution is verified by unit tests only; not exercised against a live paired daemon in this session.

- Desktop app: a paired assistant that has run `vellum login` shows its synced avatar; change the active assistant's avatar, switch away, the row updates.
- Pure cloud chooser unchanged except fewer per-row fetches.

Part of plan: chooser-assistant-avatars.md (PRs 9 and 10 of 11; the rest merged in #41467).
