### PR TITLE
web: cover lockfile-managed cloud rows and paired platform ids in the avatar lookup

### DIFF
--- a/clients/web/src/hooks/use-chooser-row-avatar.test.tsx
+++ b/clients/web/src/hooks/use-chooser-row-avatar.test.tsx
@@ -61,6 +61,14 @@ mock.module("@/hooks/use-is-org-ready", () => ({
   useIsOrgReady: () => orgReady,
 }));
 
+// A paired daemon registered under the row's own id, until a test says otherwise.
+const resolvePairedAssistantPlatformId = mock(
+  async (id: string): Promise<string | null> => id,
+);
+mock.module("@/lib/paired-platform-identity", () => ({
+  resolvePairedAssistantPlatformId,
+}));
+
 type HostAvatarResult = LocalReadAssistantAvatarResult;
 let hostAvailable = false;
 const readAssistantAvatarHost = mock(
@@ -279,6 +287,8 @@ afterEach(() => {
   readAssistantAvatarHost.mockReset();
   listAssistants.mockReset();
   listAssistants.mockResolvedValue({ ok: true, status: 200, data: [] });
+  resolvePairedAssistantPlatformId.mockReset();
+  resolvePairedAssistantPlatformId.mockImplementation(async (id) => id);
   useAuthStore.setState(initialAuthState, true);
   readAssistantAvatarHost.mockResolvedValue({ ok: true, avatar: null });
   readLastSeenAvatar.mockResolvedValue(null);
@@ -666,14 +676,100 @@ describe("useChooserRowAvatar", () => {
       expect(listAssistants).toHaveBeenCalledTimes(1);
     });
 
-    test("a pure platform row never uses the lookup", async () => {
-      const { result } = renderHook(
-        () => useChooserRowAvatar(platformRow("other")),
+    test("a paired row resolves its platform id from the paired daemon first", async () => {
+      resolvePairedAssistantPlatformId.mockResolvedValue("uuid-other");
+      listAssistants.mockResolvedValue({
+        ok: true,
+        status: 200,
+        data: [apiAssistant("uuid-other", LOOKUP_URL)],
+      });
+      const { result, rerender } = renderHook(
+        () => useChooserRowAvatar(pairedRow("other")),
         { wrapper: createWrapper() },
       );
+      await waitFor(() => {
+        expect(result.current.imageUrl).toBe(LOOKUP_URL);
+      });
+      rerender();
       await settle();
-      expect(result.current).toMatchObject({ traits: null, imageUrl: null });
+      expect(resolvePairedAssistantPlatformId).toHaveBeenCalledTimes(1);
+      expect(resolvePairedAssistantPlatformId).toHaveBeenCalledWith("other");
     });
+
+    test("a paired row that already carries its platform id skips the daemon", async () => {
+      listAssistants.mockResolvedValue({
+        ok: true,
+        status: 200,
+        data: [apiAssistant("uuid-other", LOOKUP_URL)],
+      });
+      const { result } = renderHook(
+        () =>
+          useChooserRowAvatar(
+            pairedRow("other", { platformAssistantId: "uuid-other" }),
+          ),
+        { wrapper: createWrapper() },
+      );
+      await waitFor(() => {
+        expect(result.current.imageUrl).toBe(LOOKUP_URL);
+      });
+      expect(resolvePairedAssistantPlatformId).not.toHaveBeenCalled();
+    });
+
+    test("a paired row with no resolvable platform id falls through to the cache", async () => {
+      resolvePairedAssistantPlatformId.mockResolvedValue(null);
+      readLastSeenAvatar.mockResolvedValue({ kind: "character", traits });
+      const { result } = renderHook(
+        () => useChooserRowAvatar(pairedRow("other")),
+        { wrapper: createWrapper() },
+      );
+      await waitFor(() => {
+        expect(result.current.traits).toEqual(traits);
+      });
+      expect(result.current.imageUrl).toBeNull();
+    });
+
+    test("a lockfile-managed platform row resolves through the lookup", async () => {
+      const { result } = renderHook(
+        () => useChooserRowAvatar(platformRow("other", { cloud: "vellum" })),
+        { wrapper: createWrapper() },
+      );
+      await waitFor(() => {
+        expect(result.current.imageUrl).toBe(LOOKUP_URL);
+      });
+      expect(resolvePairedAssistantPlatformId).not.toHaveBeenCalled();
+    });
+
+    test("a platform row that carries avatarUrl renders it, not the lookup", async () => {
+      const SYNCED = "https://cdn.example/avatars/other-api.png";
+      const { result } = renderHook(
+        () =>
+          useChooserRowAvatar(
+            platformRow("other", { cloud: "vellum", avatarUrl: SYNCED }),
+          ),
+        { wrapper: createWrapper() },
+      );
+      await waitFor(() => {
+        expect(result.current.imageUrl).toBe(SYNCED);
+      });
+    });
+
+    test.each([
+      ["pure cloud", () => (localClient = false)],
+      ["gateway auth", () => (gatewayAuthEnabled = true)],
+    ])(
+      "a platform row under %s never consults the map",
+      async (_l, arrange) => {
+        arrange();
+        const { result } = renderHook(
+          () => useChooserRowAvatar(platformRow("other", { cloud: "vellum" })),
+          { wrapper: createWrapper() },
+        );
+        await settle();
+        expect(result.current.imageUrl).not.toBe(LOOKUP_URL);
+        expect(listAssistants).not.toHaveBeenCalled();
+        expect(resolvePairedAssistantPlatformId).not.toHaveBeenCalled();
+      },
+    );
 
     test("a signed-out device keeps the glyph", async () => {
       useAuthStore.setState({ platformSession: "absent", user: null });
@@ -682,8 +778,9 @@ describe("useChooserRowAvatar", () => {
         { wrapper: createWrapper() },
       );
       await settle();
-      expect(result.current).toMatchObject({ traits: null, imageUrl: null });
+      expect(result.current.imageUrl).not.toBe(LOOKUP_URL);
       expect(listAssistants).not.toHaveBeenCalled();
+      expect(resolvePairedAssistantPlatformId).not.toHaveBeenCalled();
     });
 
     test("the connected row prefers its live read over the lookup", async () => {

--- a/clients/web/src/hooks/use-chooser-row-avatar.ts
+++ b/clients/web/src/hooks/use-chooser-row-avatar.ts
@@ -198,10 +198,11 @@ function canLookUpRowAvatarByPlatformId(row: ResolvedAssistant): boolean {
 }
 
 /** Under the row prefix so `forgetAssistantAvatar` drops it with the rest. */
-function pairedPlatformIdQueryKey(assistantId: string) {
+function pairedPlatformIdQueryKey(assistantId: string, runtimeUrl?: string) {
   return [
     ...chooserRowAvatarQueryKeyPrefix(assistantId),
     "platformId",
+    runtimeUrl ?? null,
   ] as const;
 }
 
@@ -220,7 +221,7 @@ function usePlatformLookupId(
   const needsPairedResolve =
     row.isPaired && !row.platformAssistantId && canLookUp;
   const pairedQuery = useQuery<string | null>({
-    queryKey: pairedPlatformIdQueryKey(row.id),
+    queryKey: pairedPlatformIdQueryKey(row.id, row.runtimeUrl),
     queryFn: () => resolvePairedAssistantPlatformId(row.id),
     enabled: needsPairedResolve && hasPlatformSession,
     staleTime: Infinity,

--- a/clients/web/src/hooks/use-chooser-row-avatar.ts
+++ b/clients/web/src/hooks/use-chooser-row-avatar.ts
@@ -13,7 +13,10 @@ import {
 } from "@/hooks/use-assistant-avatar";
 import { useBusSubscription } from "@/hooks/use-bus-subscription";
 import { useIsOrgReady } from "@/hooks/use-is-org-ready";
-import { usePlatformAvatarUrls } from "@/hooks/use-platform-avatar-urls";
+import {
+  isLockfileDrivenStore,
+  usePlatformAvatarUrls,
+} from "@/hooks/use-platform-avatar-urls";
 import { isGatewayAuthEnabled } from "@/lib/auth/gateway-session";
 import {
   deleteLastSeenAvatar,
@@ -24,6 +27,7 @@ import { trackBlobUrl } from "@/lib/blob-url-tracker";
 import { lastSeenAvatarGenerations } from "@/lib/avatar-last-seen-cache";
 import { createGenerationGuard } from "@/lib/generation-guard";
 import { isLocalClient, isRemoteGatewayMode } from "@/lib/local-mode";
+import { resolvePairedAssistantPlatformId } from "@/lib/paired-platform-identity";
 import {
   chooserRowAvatarCacheQueryKey,
   persistLastSeenAvatar,
@@ -33,9 +37,9 @@ import {
   canReadAvatarFromLocalHost,
   readAssistantAvatarHost,
 } from "@/runtime/local-mode-host";
+import { useHasPlatformSession } from "@/stores/auth-store";
 import {
   type ResolvedAssistant,
-  platformIdFor,
   useResolvedAssistantsStore,
 } from "@/stores/resolved-assistants-store";
 import type { AvatarRead } from "@/types/avatar";
@@ -182,13 +186,50 @@ function canReadRowAvatarViaHost(row: ResolvedAssistant): boolean {
 }
 
 /**
- * Whether `row` comes from the lockfile, where `avatarUrl` is never set and
- * the platform's thumbnail is only reachable by id through
- * {@link usePlatformAvatarUrls}. Paired rows share one id on both sides; a
- * local row's platform UUID is `platformAssistantId` (see {@link platformIdFor}).
+ * Whether `row` should consult {@link usePlatformAvatarUrls}: the store is
+ * lockfile-driven, so no row kind carries `avatarUrl` (platform-hosted rows
+ * included, since `reloadPlatformAssistants` skips the API write there) and
+ * the thumbnail is only reachable by platform id. A row that does carry one
+ * renders it directly. Pure cloud mode never gets here: the lookup query is
+ * disabled and the map stays empty.
  */
 function canLookUpRowAvatarByPlatformId(row: ResolvedAssistant): boolean {
-  return row.isPaired || row.cloud === "local";
+  return !row.avatarUrl && isLockfileDrivenStore();
+}
+
+/** Under the row prefix so `forgetAssistantAvatar` drops it with the rest. */
+function pairedPlatformIdQueryKey(assistantId: string) {
+  return [
+    ...chooserRowAvatarQueryKeyPrefix(assistantId),
+    "platformId",
+  ] as const;
+}
+
+/**
+ * The id to look `row` up by in the platform list. A platform-hosted row's
+ * `id` is its UUID; a local row's is `platformAssistantId`; a paired row's
+ * lockfile entry starts without one, so it is resolved lazily from the paired
+ * daemon and persisted (see {@link resolvePairedAssistantPlatformId}). Until
+ * that lands the row falls through to its other sources.
+ */
+function usePlatformLookupId(
+  row: ResolvedAssistant,
+  canLookUp: boolean,
+): string | null {
+  const hasPlatformSession = useHasPlatformSession();
+  const needsPairedResolve =
+    row.isPaired && !row.platformAssistantId && canLookUp;
+  const pairedQuery = useQuery<string | null>({
+    queryKey: pairedPlatformIdQueryKey(row.id),
+    queryFn: () => resolvePairedAssistantPlatformId(row.id),
+    enabled: needsPairedResolve && hasPlatformSession,
+    staleTime: Infinity,
+    retry: false,
+  });
+  if (row.platformAssistantId) {
+    return row.platformAssistantId;
+  }
+  return row.isPaired ? (pairedQuery.data ?? null) : row.id;
 }
 
 function conclusive(read: AvatarRead): LegacyAvatarRead {
@@ -307,9 +348,11 @@ async function readCachedRowAvatar(assistantId: string): Promise<AvatarRead> {
  *    org store can supply the `Vellum-Organization-Id` header.
  * 4. Local rows (the connected one when unreachable, siblings even asleep)
  *    read their workspace through the host when one can serve it.
- * 5. Paired and local rows look their id up in the platform list
- *    (`usePlatformAvatarUrls`): lockfile rows never carry `avatarUrl`, so
- *    this is how a logged-in desktop shows a sibling's synced thumbnail.
+ * 5. Every row without `avatarUrl` in a lockfile-driven mode looks its
+ *    platform id up in the platform list (`usePlatformAvatarUrls`): lockfile
+ *    rows never carry `avatarUrl`, so this is how a logged-in desktop shows a
+ *    sibling's synced thumbnail. A paired row first resolves its platform
+ *    UUID from the paired daemon (`usePlatformLookupId`).
  * 6. The last-seen cache: whatever a live source last resolved for this id,
  *    so a row keeps its avatar while the assistant is unreachable.
  * Only live sources (1 and 3) feed the cache, at fetch time (1 does so
@@ -405,9 +448,12 @@ export function useChooserRowAvatar(
     (hostConclusive || !isEmptyAvatar(hostQuery.data));
 
   const platformAvatarUrls = usePlatformAvatarUrls();
-  const lookupCandidate = canLookUpRowAvatarByPlatformId(assistant)
-    ? (platformAvatarUrls.get(platformIdFor(assistant)) ?? null)
-    : null;
+  const canLookUp = canLookUpRowAvatarByPlatformId(assistant);
+  const lookupId = usePlatformLookupId(assistant, canLookUp);
+  const lookupCandidate =
+    canLookUp && lookupId !== null
+      ? (platformAvatarUrls.get(lookupId) ?? null)
+      : null;
   const lookupUrl =
     lookupCandidate !== failedPlatformUrl ? lookupCandidate : null;
   // Waits out an in-flight host read so a row never flashes the thumbnail

--- a/clients/web/src/hooks/use-platform-avatar-urls.ts
+++ b/clients/web/src/hooks/use-platform-avatar-urls.ts
@@ -72,7 +72,7 @@ export function suppressPlatformAvatarUrl(
  * `avatarUrl` and the platform list is only reachable through a side query.
  * Gateway auth has no platform list at all.
  */
-function isLockfileDrivenStore(): boolean {
+export function isLockfileDrivenStore(): boolean {
   return (isLocalClient() || isRemoteGatewayMode()) && !isGatewayAuthEnabled();
 }
 

--- a/clients/web/src/lib/local-platform-identity.ts
+++ b/clients/web/src/lib/local-platform-identity.ts
@@ -602,7 +602,7 @@ function gatewayUrl(baseUrl: string, path: string): string {
   return url.toString();
 }
 
-function isUuid(value: string): boolean {
+export function isUuid(value: string): boolean {
   return UUID_RE.test(value);
 }
 

--- a/clients/web/src/lib/local-platform-identity.ts
+++ b/clients/web/src/lib/local-platform-identity.ts
@@ -338,8 +338,12 @@ async function ensureGatewayAccess(
   return { gatewayUrl, actorToken };
 }
 
-async function fetchPlatformStatus(
-  gateway: { gatewayUrl: string; actorToken: string },
+/**
+ * The daemon's `platform/status`, null on any failure. A null `actorToken`
+ * sends no bearer: the paired proxy's trusted host installs its own.
+ */
+export async function fetchPlatformStatus(
+  gateway: { gatewayUrl: string; actorToken: string | null },
   runtimeAssistantId: string,
 ): Promise<LocalPlatformStatus | null> {
   const url = gatewayUrl(
@@ -349,7 +353,9 @@ async function fetchPlatformStatus(
   const response = await fetch(url, {
     headers: {
       Accept: "application/json",
-      Authorization: `Bearer ${gateway.actorToken}`,
+      ...(gateway.actorToken && {
+        Authorization: `Bearer ${gateway.actorToken}`,
+      }),
     },
     credentials: "omit",
   }).catch(() => null);

--- a/clients/web/src/lib/paired-platform-identity.test.ts
+++ b/clients/web/src/lib/paired-platform-identity.test.ts
@@ -73,6 +73,13 @@ describe("resolvePairedAssistantPlatformId", () => {
     });
   });
 
+  test("a re-pair to another gateway probes again", async () => {
+    await resolvePairedAssistantPlatformId("paired-remote");
+    lockfileEntry = { ...pairedEntry, runtimeUrl: "https://new.example.com" };
+    await resolvePairedAssistantPlatformId("paired-remote");
+    expect(fetchPlatformStatus).toHaveBeenCalledTimes(2);
+  });
+
   test("resolves once per id per session", async () => {
     await resolvePairedAssistantPlatformId("paired-remote");
     await resolvePairedAssistantPlatformId("paired-remote");

--- a/clients/web/src/lib/paired-platform-identity.test.ts
+++ b/clients/web/src/lib/paired-platform-identity.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Tests for `resolvePairedAssistantPlatformId`: the paired-proxy status read,
+ * the lockfile persist, and the per-session cache (hits and misses alike).
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { LockfileAssistant } from "@/lib/local-mode";
+
+const UUID = "0f7c8b3e-2a41-4c1d-9b6e-1d2f3a4b5c6d";
+
+const pairedEntry: LockfileAssistant = {
+  assistantId: "paired-remote",
+  cloud: "paired",
+  runtimeUrl: "https://remote.example",
+  hatchedAt: "2024-01-01T00:00:00Z",
+};
+
+let lockfileEntry: LockfileAssistant | undefined = pairedEntry;
+let pairedGatewayUrl: string | undefined =
+  "/assistant/__gateway-paired/paired-remote";
+const updateLockfileAssistant = mock(async (_a: LockfileAssistant) => {});
+mock.module("@/lib/local-mode", () => ({
+  getLockfileAssistant: () => lockfileEntry,
+  getPairedGatewayUrl: () => pairedGatewayUrl,
+  updateLockfileAssistant,
+}));
+
+const fetchPlatformStatus = mock(
+  async (
+    _gateway: { gatewayUrl: string; actorToken: string | null },
+    _id: string,
+  ) => ({ assistantId: UUID }) as { assistantId: string | null } | null,
+);
+mock.module("@/lib/local-platform-identity", () => ({ fetchPlatformStatus }));
+
+const {
+  resetPairedPlatformIdentityCacheForTesting,
+  resolvePairedAssistantPlatformId,
+} = await import("@/lib/paired-platform-identity");
+
+beforeEach(() => {
+  lockfileEntry = pairedEntry;
+  pairedGatewayUrl = "/assistant/__gateway-paired/paired-remote";
+  fetchPlatformStatus.mockResolvedValue({ assistantId: UUID });
+  updateLockfileAssistant.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  resetPairedPlatformIdentityCacheForTesting();
+  fetchPlatformStatus.mockReset();
+  updateLockfileAssistant.mockReset();
+});
+
+describe("resolvePairedAssistantPlatformId", () => {
+  test("reads the paired daemon's status through the proxy and persists the UUID", async () => {
+    await expect(
+      resolvePairedAssistantPlatformId("paired-remote"),
+    ).resolves.toBe(UUID);
+    expect(fetchPlatformStatus).toHaveBeenCalledWith(
+      {
+        gatewayUrl: `${window.location.origin}/assistant/__gateway-paired/paired-remote`,
+        actorToken: null,
+      },
+      "paired-remote",
+    );
+    expect(updateLockfileAssistant).toHaveBeenCalledWith({
+      ...pairedEntry,
+      platformAssistantId: UUID,
+    });
+  });
+
+  test("resolves once per id per session", async () => {
+    await resolvePairedAssistantPlatformId("paired-remote");
+    await resolvePairedAssistantPlatformId("paired-remote");
+    expect(fetchPlatformStatus).toHaveBeenCalledTimes(1);
+    expect(updateLockfileAssistant).toHaveBeenCalledTimes(1);
+  });
+
+  test("caches a miss so an unreachable daemon is not re-asked", async () => {
+    fetchPlatformStatus.mockResolvedValue(null);
+    await expect(
+      resolvePairedAssistantPlatformId("paired-remote"),
+    ).resolves.toBeNull();
+    await expect(
+      resolvePairedAssistantPlatformId("paired-remote"),
+    ).resolves.toBeNull();
+    expect(fetchPlatformStatus).toHaveBeenCalledTimes(1);
+    expect(updateLockfileAssistant).not.toHaveBeenCalled();
+  });
+
+  test("returns the persisted id without a daemon read", async () => {
+    lockfileEntry = { ...pairedEntry, platformAssistantId: UUID };
+    await expect(
+      resolvePairedAssistantPlatformId("paired-remote"),
+    ).resolves.toBe(UUID);
+    expect(fetchPlatformStatus).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    ["no lockfile entry", () => (lockfileEntry = undefined)],
+    ["no usable paired proxy", () => (pairedGatewayUrl = undefined)],
+  ])("resolves null with %s", async (_l, arrange) => {
+    arrange();
+    await expect(
+      resolvePairedAssistantPlatformId("paired-remote"),
+    ).resolves.toBeNull();
+    expect(fetchPlatformStatus).not.toHaveBeenCalled();
+  });
+
+  test("rejects a status id that is not a UUID", async () => {
+    fetchPlatformStatus.mockResolvedValue({ assistantId: "self" });
+    await expect(
+      resolvePairedAssistantPlatformId("paired-remote"),
+    ).resolves.toBeNull();
+    expect(updateLockfileAssistant).not.toHaveBeenCalled();
+  });
+
+  test("a failed lockfile write still returns the UUID", async () => {
+    updateLockfileAssistant.mockRejectedValue(new Error("disk"));
+    await expect(
+      resolvePairedAssistantPlatformId("paired-remote"),
+    ).resolves.toBe(UUID);
+  });
+});

--- a/clients/web/src/lib/paired-platform-identity.test.ts
+++ b/clients/web/src/lib/paired-platform-identity.test.ts
@@ -147,6 +147,14 @@ describe("resolvePairedAssistantPlatformId", () => {
       "no longer paired",
       () => (lockfileEntry = { ...pairedEntry, cloud: "local" }),
     ],
+    [
+      "retargeted",
+      () =>
+        (lockfileEntry = {
+          ...pairedEntry,
+          runtimeUrl: "https://other.example",
+        }),
+    ],
   ])(
     "skips the write and resolves null when the entry is %s mid-request",
     async (_l, arrange) => {

--- a/clients/web/src/lib/paired-platform-identity.test.ts
+++ b/clients/web/src/lib/paired-platform-identity.test.ts
@@ -32,7 +32,10 @@ const fetchPlatformStatus = mock(
     _id: string,
   ) => ({ assistantId: UUID }) as { assistantId: string | null } | null,
 );
-mock.module("@/lib/local-platform-identity", () => ({ fetchPlatformStatus }));
+mock.module("@/lib/local-platform-identity", () => ({
+  fetchPlatformStatus,
+  isUuid: (value: string) => /^[0-9a-f-]{36}$/i.test(value),
+}));
 
 const {
   resetPairedPlatformIdentityCacheForTesting,
@@ -115,6 +118,41 @@ describe("resolvePairedAssistantPlatformId", () => {
     ).resolves.toBeNull();
     expect(updateLockfileAssistant).not.toHaveBeenCalled();
   });
+
+  test("a rename during the request keeps the new name and gains the UUID", async () => {
+    fetchPlatformStatus.mockImplementation(async () => {
+      lockfileEntry = { ...pairedEntry, name: "Renamed" };
+      return { assistantId: UUID };
+    });
+    await expect(
+      resolvePairedAssistantPlatformId("paired-remote"),
+    ).resolves.toBe(UUID);
+    expect(updateLockfileAssistant).toHaveBeenCalledWith({
+      ...pairedEntry,
+      name: "Renamed",
+      platformAssistantId: UUID,
+    });
+  });
+
+  test.each([
+    ["removed", () => (lockfileEntry = undefined)],
+    [
+      "no longer paired",
+      () => (lockfileEntry = { ...pairedEntry, cloud: "local" }),
+    ],
+  ])(
+    "skips the write and resolves null when the entry is %s mid-request",
+    async (_l, arrange) => {
+      fetchPlatformStatus.mockImplementation(async () => {
+        arrange();
+        return { assistantId: UUID };
+      });
+      await expect(
+        resolvePairedAssistantPlatformId("paired-remote"),
+      ).resolves.toBeNull();
+      expect(updateLockfileAssistant).not.toHaveBeenCalled();
+    },
+  );
 
   test("a failed lockfile write still returns the UUID", async () => {
     updateLockfileAssistant.mockRejectedValue(new Error("disk"));

--- a/clients/web/src/lib/paired-platform-identity.ts
+++ b/clients/web/src/lib/paired-platform-identity.ts
@@ -5,8 +5,16 @@ import {
   updateLockfileAssistant,
 } from "@/lib/local-mode";
 
-/** One attempt per paired id per session; a miss (unreachable, unregistered) is cached too. */
+/**
+ * One attempt per paired target per session; a miss (unreachable,
+ * unregistered) is cached too. Keyed by gateway URL as well as id so a
+ * same-name re-pair to another gateway probes again.
+ */
 const pairedPlatformIdCache = new Map<string, Promise<string | null>>();
+
+function pairedCacheKey(assistantId: string): string {
+  return `${assistantId}\n${getLockfileAssistant(assistantId)?.runtimeUrl ?? ""}`;
+}
 
 export function resetPairedPlatformIdentityCacheForTesting(): void {
   pairedPlatformIdCache.clear();
@@ -26,12 +34,13 @@ export function resetPairedPlatformIdentityCacheForTesting(): void {
 export function resolvePairedAssistantPlatformId(
   assistantId: string,
 ): Promise<string | null> {
-  const cached = pairedPlatformIdCache.get(assistantId);
+  const key = pairedCacheKey(assistantId);
+  const cached = pairedPlatformIdCache.get(key);
   if (cached) {
     return cached;
   }
   const promise = fetchAndPersistPairedPlatformId(assistantId);
-  pairedPlatformIdCache.set(assistantId, promise);
+  pairedPlatformIdCache.set(key, promise);
   return promise;
 }
 

--- a/clients/web/src/lib/paired-platform-identity.ts
+++ b/clients/web/src/lib/paired-platform-identity.ts
@@ -1,0 +1,69 @@
+import { fetchPlatformStatus } from "@/lib/local-platform-identity";
+import {
+  getLockfileAssistant,
+  getPairedGatewayUrl,
+  updateLockfileAssistant,
+} from "@/lib/local-mode";
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+/** One attempt per paired id per session; a miss (unreachable, unregistered) is cached too. */
+const pairedPlatformIdCache = new Map<string, Promise<string | null>>();
+
+export function resetPairedPlatformIdentityCacheForTesting(): void {
+  pairedPlatformIdCache.clear();
+}
+
+/**
+ * The platform UUID a paired assistant is registered under, or null.
+ *
+ * `pairAssistant` keys the lockfile entry by a local slug and the pairing
+ * reply carries no platform id, so the entry lacks `platformAssistantId`
+ * until something asks the paired daemon. Its `platform/status` route
+ * answers through the same-origin paired proxy (the host injects the
+ * guardian bearer, the gateway's runtime-proxy catch-all discards the id in
+ * the path), and the UUID is persisted to the entry so `setFromLockfile`
+ * carries it from then on. Never throws.
+ */
+export function resolvePairedAssistantPlatformId(
+  assistantId: string,
+): Promise<string | null> {
+  const cached = pairedPlatformIdCache.get(assistantId);
+  if (cached) {
+    return cached;
+  }
+  const promise = fetchAndPersistPairedPlatformId(assistantId);
+  pairedPlatformIdCache.set(assistantId, promise);
+  return promise;
+}
+
+async function fetchAndPersistPairedPlatformId(
+  assistantId: string,
+): Promise<string | null> {
+  const entry = getLockfileAssistant(assistantId);
+  if (!entry) {
+    return null;
+  }
+  if (entry.platformAssistantId) {
+    return entry.platformAssistantId;
+  }
+  const pairedUrl = getPairedGatewayUrl(entry);
+  if (!pairedUrl) {
+    return null;
+  }
+  const status = await fetchPlatformStatus(
+    { gatewayUrl: `${window.location.origin}${pairedUrl}`, actorToken: null },
+    assistantId,
+  );
+  const platformAssistantId = status?.assistantId ?? null;
+  if (!platformAssistantId || !UUID_RE.test(platformAssistantId)) {
+    return null;
+  }
+  try {
+    await updateLockfileAssistant({ ...entry, platformAssistantId });
+  } catch (error) {
+    console.warn("paired assistant platform lockfile update failed", error);
+  }
+  return platformAssistantId;
+}

--- a/clients/web/src/lib/paired-platform-identity.ts
+++ b/clients/web/src/lib/paired-platform-identity.ts
@@ -68,7 +68,11 @@ async function fetchAndPersistPairedPlatformId(
   }
   // Re-read: a rename or re-pair may have landed while the request was in flight.
   const current = getLockfileAssistant(assistantId);
-  if (!current || current.cloud !== "paired") {
+  if (
+    !current ||
+    current.cloud !== "paired" ||
+    current.runtimeUrl !== entry.runtimeUrl
+  ) {
     return null;
   }
   try {

--- a/clients/web/src/lib/paired-platform-identity.ts
+++ b/clients/web/src/lib/paired-platform-identity.ts
@@ -1,12 +1,9 @@
-import { fetchPlatformStatus } from "@/lib/local-platform-identity";
+import { fetchPlatformStatus, isUuid } from "@/lib/local-platform-identity";
 import {
   getLockfileAssistant,
   getPairedGatewayUrl,
   updateLockfileAssistant,
 } from "@/lib/local-mode";
-
-const UUID_RE =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 /** One attempt per paired id per session; a miss (unreachable, unregistered) is cached too. */
 const pairedPlatformIdCache = new Map<string, Promise<string | null>>();
@@ -57,11 +54,16 @@ async function fetchAndPersistPairedPlatformId(
     assistantId,
   );
   const platformAssistantId = status?.assistantId ?? null;
-  if (!platformAssistantId || !UUID_RE.test(platformAssistantId)) {
+  if (!platformAssistantId || !isUuid(platformAssistantId)) {
+    return null;
+  }
+  // Re-read: a rename or re-pair may have landed while the request was in flight.
+  const current = getLockfileAssistant(assistantId);
+  if (!current || current.cloud !== "paired") {
     return null;
   }
   try {
-    await updateLockfileAssistant({ ...entry, platformAssistantId });
+    await updateLockfileAssistant({ ...current, platformAssistantId });
   } catch (error) {
     console.warn("paired assistant platform lockfile update failed", error);
   }

--- a/packages/local-mode/src/__tests__/pair.test.ts
+++ b/packages/local-mode/src/__tests__/pair.test.ts
@@ -656,6 +656,36 @@ describe("pairAssistant", () => {
     expect(readGuardianToken("desk").accessToken).toBe("t2");
   });
 
+  test("re-pairing to a new gateway drops a cached platformAssistantId", () => {
+    const first = pairAssistant([lockfilePath], configDir, {
+      credentials: credentials({ deviceId: "dev-re", token: "t1" }),
+      name: "desk",
+    });
+    expect(first.ok).toBe(true);
+    const cached = readLockfileFromDisk();
+    (
+      cached.assistants as Array<Record<string, unknown>>
+    )[0]!.platformAssistantId = "11111111-1111-4111-8111-111111111111";
+    fs.writeFileSync(lockfilePath, JSON.stringify(cached, null, 2));
+
+    const second = pairAssistant([lockfilePath], configDir, {
+      credentials: credentials({
+        deviceId: "dev-re",
+        token: "t2",
+        gatewayUrl: "https://new.example.com",
+      }),
+      name: "desk",
+    });
+
+    expect(second.ok).toBe(true);
+    const assistants = readLockfileFromDisk().assistants as Array<
+      Record<string, unknown>
+    >;
+    expect(assistants).toHaveLength(1);
+    expect(assistants[0]!.runtimeUrl).toBe("https://new.example.com");
+    expect(assistants[0]!).not.toHaveProperty("platformAssistantId");
+  });
+
   test("deletes the just-written token when the lockfile write fails", () => {
     // A lockfile path whose parent is a regular file makes the write fail
     // deterministically (unlike chmod, which root ignores) after the token

--- a/packages/local-mode/src/pair.ts
+++ b/packages/local-mode/src/pair.ts
@@ -394,6 +394,10 @@ export function pairAssistant(
       // guard above).
       paired: true,
       species: "vellum",
+      // A re-pair may point at a different gateway, so the platform id the
+      // web resolver cached for the old target is dropped; the upsert merge
+      // would otherwise keep it and the resolver would never re-probe.
+      platformAssistantId: undefined,
     },
     undefined,
   );
@@ -694,8 +698,7 @@ type PairingPost =
   | { ok: false; failure: PairingFailure };
 
 type PairingBody =
-  | { ok: true; value: unknown }
-  | { ok: false; failure: PairingFailure };
+  { ok: true; value: unknown } | { ok: false; failure: PairingFailure };
 
 /**
  * The reply body as JSON, read under {@link MAX_PAIRING_RESPONSE_BYTES}. An


### PR DESCRIPTION
## Summary
- Paired rows (P1, `resolved-assistants-store.ts:76`): `pairAssistant` keys the lockfile entry by a local slug and the pairing reply carries no platform UUID, so `platformIdFor()` returned the slug and every paired-row lookup missed. New `lib/paired-platform-identity.ts` resolves the UUID lazily from the paired daemon's own `platform/status` through the same-origin paired proxy (the trusted host injects the guardian bearer; the gateway's runtime-proxy catch-all discards the assistant id in the path; `actor_client_v1` carries `settings.read`), persists it to the lockfile entry via `updateLockfileAssistant` so `setFromLockfile` carries it from then on, and caches one attempt per id per session (misses included). `fetchPlatformStatus` is exported with an optional bearer for reuse. The hook drives it from a `useQuery` keyed under the row prefix, gated on the lookup being live and a platform session existing.
- Lockfile-managed cloud rows (P1, `use-chooser-row-avatar.ts:191`): `syncPlatformAssistantsToLockfile` writes `cloud: "vellum"` entries and `reloadPlatformAssistants` skips the API store write in lockfile-driven modes, so those rows had no `avatarUrl` and were excluded from the lookup. The predicate is now "row lacks `avatarUrl` and the store is lockfile-driven" (`isLockfileDrivenStore`, exported from `use-platform-avatar-urls`), so a platform-hosted row's `id` (its UUID) consumes the map too. Pure cloud and gateway-auth modes stay disabled.
- Known edge: if the lockfile write fails the row still resolves through the query result, but the suppression helpers (`resolvePlatformAssistantId`) keep reading the slug until the next successful persist.

## Tests
- `paired-platform-identity.test.ts`: proxy URL + no bearer, lockfile persist, once-per-session (hit and miss), persisted-id short-circuit, no-entry / no-proxy, non-UUID rejection, failed write still returns the UUID.
- `use-chooser-row-avatar.test.tsx`: paired row resolves via the daemon then the map (one resolver call), a paired row carrying `platformAssistantId` skips the daemon, an unresolvable paired row falls through to the cache, a `cloud: "vellum"` lockfile row resolves through the map in local-client mode, a row with `avatarUrl` renders it instead, and pure-cloud / gateway-auth never consult the map or the resolver.

Addresses the two P1s on #41549.