### PR TITLE
feat(companion): size the avatar and the options pill independently

### DIFF
--- a/clients/macos/src/main/companion-window.test.ts
+++ b/clients/macos/src/main/companion-window.test.ts
@@ -3,8 +3,15 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 import {
   COMPANION_BASE_AVATAR_BOX,
   COMPANION_BASE_CANVAS_PAD,
+  COMPANION_BASE_CARD_HEIGHT,
+  COMPANION_NEAR_EDGE,
   COMPANION_SIZES,
+  COMPANION_SIZE_BOXES,
   companionGapFor,
+  companionPadFor,
+  companionScaleFor,
+  type CompanionSize,
+  type CompanionSizeAxis,
   type CompanionSurfaceState,
   type VellumCommand,
 } from "@vellumai/ipc-contract";
@@ -159,6 +166,7 @@ const {
   growthFor,
   cardGrowthFor,
   avatarOffsetFor,
+  companionContextMenuTemplate,
   geometryFor,
   placeCanvas,
   callOnUpdate,
@@ -227,7 +235,7 @@ const START = {
  * renderer's layout is authored at. Every other size is the same arithmetic
  * scaled, which `geometryFor` has its own cases for.
  */
-const GEOMETRY = geometryFor("small");
+const GEOMETRY = geometryFor("small", "small");
 const CANVAS_WIDTH = GEOMETRY.canvasWidth;
 const RISE_ABOVE = GEOMETRY.riseAbove;
 const DROP_BELOW = GEOMETRY.dropBelow;
@@ -580,8 +588,9 @@ describe("shouldShowCompanionSurface", () => {
  */
 describe("geometryFor", () => {
   test("draws `small` at the size the renderer's layout is authored at", () => {
-    const small = geometryFor("small");
+    const small = geometryFor("small", "small");
     expect(small.avatarBox).toBe(44);
+    expect(small.optionsBox).toBe(44);
     expect(small.canvasWidth).toBe(748);
     expect(small.canvasHeight).toBe(338);
     expect(small.maxReach).toBe(350);
@@ -594,7 +603,7 @@ describe("geometryFor", () => {
    */
   test("holds the pill's whole reach on both sides of the avatar", () => {
     for (const size of COMPANION_SIZES) {
-      const geometry = geometryFor(size);
+      const geometry = geometryFor(size, size);
       const pad =
         (COMPANION_BASE_CANVAS_PAD * geometry.avatarBox) /
         COMPANION_BASE_AVATAR_BOX;
@@ -609,7 +618,7 @@ describe("geometryFor", () => {
 
   test("takes the gap from the contract rather than a copy of it", () => {
     for (const size of COMPANION_SIZES) {
-      const geometry = geometryFor(size);
+      const geometry = geometryFor(size, size);
       expect(geometry.gap).toBe(
         companionGapFor(geometry.avatarBox, geometry.avatarBox),
       );
@@ -617,13 +626,41 @@ describe("geometryFor", () => {
   });
 
   /**
-   * The whole surface is one layout multiplied, so every length has to move
-   * together. A canvas that scaled while the pill's reach did not would clip
-   * the controls; the reverse would swallow clicks over empty desktop.
+   * The creature's box is the avatar axis's answer and nothing else's. It is
+   * what main clamps by, so a pill size leaking into it would move where the
+   * mascot is allowed to sit.
    */
-  test("scales every length by the same factor", () => {
-    const small = geometryFor("small");
-    const large = geometryFor("large");
+  test("takes the creature's box from the avatar axis alone", () => {
+    for (const options of COMPANION_SIZES) {
+      expect(geometryFor("large", options).avatarBox).toBe(
+        COMPANION_SIZE_BOXES.large,
+      );
+    }
+  });
+
+  /**
+   * Everything beside the creature is the options axis's answer: the pill's box
+   * and the widest body it draws, which is what the canvas's width is spent on.
+   */
+  test("takes the pill's box and its widest body from the options axis alone", () => {
+    for (const avatar of COMPANION_SIZES) {
+      const geometry = geometryFor(avatar, "large");
+      expect(geometry.optionsBox).toBe(COMPANION_SIZE_BOXES.large);
+      expect(geometry.maxBodyWidth).toBe(
+        geometryFor("large", "large").maxBodyWidth,
+      );
+    }
+  });
+
+  /**
+   * With one size on both axes the surface is still one layout multiplied, so
+   * every length moves together. A canvas that scaled while the pill's reach
+   * did not would clip the controls; the reverse would swallow clicks over
+   * empty desktop.
+   */
+  test("scales every length by the same factor when the axes agree", () => {
+    const small = geometryFor("small", "small");
+    const large = geometryFor("large", "large");
     const scale = large.avatarBox / small.avatarBox;
     expect(scale).toBe(2);
     expect(large.canvasWidth).toBe(small.canvasWidth * scale);
@@ -635,8 +672,28 @@ describe("geometryFor", () => {
     expect(large.maxReach).toBe(small.maxReach * scale);
   });
 
+  /**
+   * The two-box distances are the one-box ones wherever there is only one size,
+   * which is what makes the second axis a widening rather than a second
+   * geometry to keep in step.
+   */
+  test("reduces to the single-scale canvas when the axes agree", () => {
+    for (const size of COMPANION_SIZES) {
+      const geometry = geometryFor(size, size);
+      const scale = companionScaleFor(geometry.avatarBox);
+      expect(geometry.dropBelow).toBe(COMPANION_NEAR_EDGE * scale);
+      expect(geometry.riseAbove).toBe(
+        COMPANION_BASE_CARD_HEIGHT * scale -
+          geometry.avatarBox / 2 +
+          COMPANION_BASE_CANVAS_PAD * scale,
+      );
+    }
+  });
+
   test("grows monotonically through the named steps", () => {
-    const boxes = COMPANION_SIZES.map((size) => geometryFor(size).avatarBox);
+    const boxes = COMPANION_SIZES.map(
+      (size) => geometryFor(size, size).avatarBox,
+    );
     expect(boxes).toEqual([...boxes].sort((a, b) => a - b));
     expect(new Set(boxes).size).toBe(boxes.length);
   });
@@ -648,7 +705,7 @@ describe("geometryFor", () => {
    */
   test("gives every size a whole-point canvas", () => {
     for (const size of COMPANION_SIZES) {
-      const geometry = geometryFor(size);
+      const geometry = geometryFor(size, size);
       expect(Number.isInteger(geometry.canvasWidth)).toBe(true);
       expect(Number.isInteger(geometry.canvasHeight)).toBe(true);
     }
@@ -661,12 +718,217 @@ describe("geometryFor", () => {
    */
   test("keeps the canvas asymmetric about the avatar at every size", () => {
     for (const size of COMPANION_SIZES) {
-      const geometry = geometryFor(size);
+      const geometry = geometryFor(size, size);
       expect(geometry.dropBelow).toBeLessThan(geometry.riseAbove);
       expect(geometry.riseAbove + geometry.dropBelow).toBe(
         geometry.canvasHeight,
       );
     }
+  });
+});
+
+/**
+ * The canvas when the creature and the controls are sized apart, which is the
+ * shape the two axes exist for.
+ *
+ * Both sides of the avatar are sized for whichever card direction needs more,
+ * so main can still flip the direction by moving the window rather than
+ * rebuilding it. The cost is a few transparent points of slack in the direction
+ * that needed less, and what these cases hold is that the slack is never
+ * negative: a side short by a point clips the pill or the card.
+ */
+describe("geometryFor with the two axes apart", () => {
+  /** A creature far larger than the controls beside it, and the reverse. */
+  const BIG_CREATURE = geometryFor("huge", "small");
+  const BIG_OPTIONS = geometryFor("small", "huge");
+  const MIXED = [BIG_CREATURE, BIG_OPTIONS];
+
+  /**
+   * The near edge answers for both card directions at once. Growing up, the
+   * lowest thing drawn is the creature's own bottom; growing down, the pill
+   * stands on that same line and its top reaches a whole options box back up
+   * past it, over the head of a smaller creature.
+   */
+  test("clears the creature's bottom and the pill's top alike", () => {
+    for (const geometry of MIXED) {
+      const pad = companionPadFor(geometry.avatarBox, geometry.optionsBox);
+      expect(
+        geometry.dropBelow - geometry.avatarBox / 2,
+      ).toBeGreaterThanOrEqual(pad);
+      expect(
+        geometry.dropBelow + geometry.avatarBox / 2 - geometry.optionsBox,
+      ).toBeGreaterThanOrEqual(pad);
+    }
+  });
+
+  /**
+   * The far side, the same way. The card stands on the creature's bottom line
+   * and rises its whole height growing up; growing down its composer row holds
+   * that line and the rest of it falls away below.
+   */
+  test("clears the card in whichever direction it grows", () => {
+    for (const geometry of MIXED) {
+      const pad = companionPadFor(geometry.avatarBox, geometry.optionsBox);
+      const cardHeight =
+        COMPANION_BASE_CARD_HEIGHT * companionScaleFor(geometry.optionsBox);
+      expect(
+        geometry.riseAbove - (cardHeight - geometry.avatarBox / 2),
+      ).toBeGreaterThanOrEqual(pad);
+      expect(
+        geometry.riseAbove -
+          (geometry.avatarBox / 2 + cardHeight - geometry.optionsBox),
+      ).toBeGreaterThanOrEqual(pad);
+    }
+  });
+
+  test("spends the whole canvas on the two sides of the avatar", () => {
+    for (const geometry of MIXED) {
+      expect(geometry.riseAbove + geometry.dropBelow).toBe(
+        geometry.canvasHeight,
+      );
+      expect(geometry.dropBelow).toBeLessThan(geometry.riseAbove);
+      expect(Number.isInteger(geometry.canvasHeight)).toBe(true);
+    }
+  });
+
+  test("still holds the pill's reach on both sides of the avatar", () => {
+    for (const geometry of MIXED) {
+      const pad = companionPadFor(geometry.avatarBox, geometry.optionsBox);
+      expect(geometry.maxReach).toBe(
+        geometry.avatarBox / 2 + geometry.gap + geometry.maxBodyWidth,
+      );
+      expect(geometry.canvasWidth).toBe(
+        Math.round(2 * (geometry.maxReach + pad)),
+      );
+    }
+  });
+
+  /**
+   * The gap is breathing room, so the smaller of the two decides how much of it
+   * there is: a modest creature beside an enormous pill wants the creature's
+   * clearance rather than the chasm the pill's own scale would ask for.
+   */
+  test("takes the gap from the smaller of the two", () => {
+    expect(BIG_CREATURE.gap).toBe(geometryFor("small", "small").gap);
+    expect(BIG_OPTIONS.gap).toBe(BIG_CREATURE.gap);
+  });
+
+  test("flips the pill at the reach the options size asks for", () => {
+    expect(
+      growthFor(DISPLAY.width - BIG_CREATURE.maxReach, DISPLAY, BIG_CREATURE),
+    ).toBe("right");
+    expect(
+      growthFor(
+        DISPLAY.width - BIG_CREATURE.maxReach + 1,
+        DISPLAY,
+        BIG_CREATURE,
+      ),
+    ).toBe("left");
+  });
+
+  /**
+   * A display too narrow for the pill either way still grows the designed way,
+   * and an enormous options size beside a small creature is how a 1440pt
+   * display gets there.
+   */
+  test("still grows the designed way where neither side can hold the pill", () => {
+    expect(
+      growthFor(DISPLAY.width - BIG_OPTIONS.maxReach + 1, DISPLAY, BIG_OPTIONS),
+    ).toBe("right");
+  });
+});
+
+/**
+ * The menu a right-click on the surface pops, which is where a user actually
+ * reaches for the two things a floating avatar offers: a different size, and
+ * making it go away.
+ *
+ * The template rather than the menu: a menu is a native window, and what is
+ * worth stating is the wording, which step each axis is marked on, and that a
+ * press names the axis it was made under.
+ */
+describe("companionContextMenuTemplate", () => {
+  /** Only what a menu item is read for here, as `tray-model.test.ts` has it. */
+  type MenuItem = {
+    label?: string;
+    type?: string;
+    checked?: boolean;
+    click?: () => void;
+    submenu?: MenuItem[];
+  };
+
+  const build = (
+    current: Record<CompanionSizeAxis, CompanionSize> = {
+      avatar: "small",
+      options: "small",
+    },
+  ) => {
+    const picked: [CompanionSizeAxis, CompanionSize][] = [];
+    let hidden = false;
+    const items = companionContextMenuTemplate(current, {
+      setSize: (axis: CompanionSizeAxis, size: CompanionSize) => {
+        picked.push([axis, size]);
+      },
+      hide: () => {
+        hidden = true;
+      },
+    }) as MenuItem[];
+    return { items, picked, wasHidden: () => hidden };
+  };
+
+  test("offers the two axes under their own headings, then the way out", () => {
+    expect(build().items.map((item) => item.label ?? item.type)).toEqual([
+      "Avatar size",
+      "Options size",
+      "separator",
+      "Hide Companion",
+    ]);
+  });
+
+  test("offers every named step under each heading", () => {
+    for (const heading of build().items.slice(0, 2)) {
+      expect(heading.submenu?.map((item) => item.label)).toEqual([
+        "Small",
+        "Medium",
+        "Large",
+        "Huge",
+        "Ridiculous",
+      ]);
+      expect(heading.submenu?.every((item) => item.type === "radio")).toBe(
+        true,
+      );
+    }
+  });
+
+  /**
+   * The whole point of two menus: each one shows where its own axis is, and a
+   * user who has made the creature enormous and left the controls alone can see
+   * exactly that.
+   */
+  test("marks the step each axis is on, and only that one", () => {
+    const { items } = build({ avatar: "ridiculous", options: "medium" });
+    expect(
+      items[0]?.submenu?.filter((item) => item.checked).map((i) => i.label),
+    ).toEqual(["Ridiculous"]);
+    expect(
+      items[1]?.submenu?.filter((item) => item.checked).map((i) => i.label),
+    ).toEqual(["Medium"]);
+  });
+
+  test("a pick carries the axis it was made under", () => {
+    const menu = build();
+    menu.items[0]?.submenu?.[3]?.click?.();
+    menu.items[1]?.submenu?.[4]?.click?.();
+    expect(menu.picked).toEqual([
+      ["avatar", "huge"],
+      ["options", "ridiculous"],
+    ]);
+  });
+
+  test("the last item takes the surface away", () => {
+    const menu = build();
+    menu.items[3]?.click?.();
+    expect(menu.wasHidden()).toBe(true);
   });
 });
 
@@ -679,7 +941,7 @@ describe("geometryFor", () => {
  * the canvas, at whatever size.
  */
 describe("placing a larger companion", () => {
-  const LARGE = geometryFor("large");
+  const LARGE = geometryFor("large", "large");
 
   test("holds the avatar at the edges by its own box, not the canvas", () => {
     const placed = placeCanvas({ x: 9000, y: 500 }, WORK_AREA, LARGE);
@@ -715,6 +977,49 @@ describe("placing a larger companion", () => {
     expect(
       cardGrowthFor(WORK_AREA.y + LARGE.riseAbove - 1, WORK_AREA, LARGE),
     ).toBe("down");
+  });
+
+  /**
+   * The same rules with the two axes apart. The clamp binds on the creature,
+   * which is the avatar axis's answer, so an enormous pill beside a small
+   * creature must not hold that creature away from the edge, and an enormous
+   * creature beside a small pill must be held by its own whole box.
+   */
+  const BIG_CREATURE = geometryFor("huge", "small");
+  const BIG_OPTIONS = geometryFor("small", "huge");
+
+  test("holds a large creature at the edge by its own box", () => {
+    const placed = placeCanvas({ x: 9000, y: 500 }, WORK_AREA, BIG_CREATURE);
+    expect(centreOf(placed, BIG_CREATURE).x).toBe(
+      WORK_AREA.x + WORK_AREA.width - BIG_CREATURE.avatarBox / 2,
+    );
+  });
+
+  test("lets a small creature reach the edge beside an enormous pill", () => {
+    const placed = placeCanvas({ x: 9000, y: 500 }, WORK_AREA, BIG_OPTIONS);
+    expect(centreOf(placed, BIG_OPTIONS).x).toBe(
+      WORK_AREA.x + WORK_AREA.width - BIG_OPTIONS.avatarBox / 2,
+    );
+  });
+
+  test("never asks for an origin above the work area at either mix", () => {
+    for (const geometry of [BIG_CREATURE, BIG_OPTIONS]) {
+      for (const y of [-9000, 0, 25, 100, 400]) {
+        expect(
+          placeCanvas({ x: 700, y }, WORK_AREA, geometry).origin.y,
+        ).toBeGreaterThanOrEqual(WORK_AREA.y);
+      }
+    }
+  });
+
+  test("reaches the top, short by the near edge its own mix asks for", () => {
+    for (const geometry of [BIG_CREATURE, BIG_OPTIONS]) {
+      const centre = centreOf(
+        placeCanvas({ x: 700, y: -9000 }, WORK_AREA, geometry),
+        geometry,
+      );
+      expect(centre.y).toBe(WORK_AREA.y + geometry.dropBelow);
+    }
   });
 });
 

--- a/clients/macos/src/main/companion-window.ts
+++ b/clients/macos/src/main/companion-window.ts
@@ -14,8 +14,6 @@ import {
   voiceActivityStartSchema,
   COMPANION_INTRO_ACTIONS,
   COMPANION_INTRO_BEATS,
-  COMPANION_SIZE_AXES,
-  COMPANION_SIZES,
   COMPANION_SIZE_BOXES,
   companionCardSideFor,
   companionGapFor,
@@ -34,10 +32,7 @@ import {
   type VellumCommand,
   type VoiceActivityState,
 } from "@vellumai/ipc-contract";
-import {
-  COMPANION_SIZE_AXIS_LABELS,
-  COMPANION_SIZE_LABELS,
-} from "@vellumai/electron-desktop/companion-menu";
+import { companionSizeSubmenus } from "@vellumai/electron-desktop/companion-menu";
 import {
   onSettingChange,
   readSetting,
@@ -656,9 +651,9 @@ let installed = false;
  * is where people reach first.
  *
  * Built in main rather than in the renderer: a menu is a native window, and
- * main is the side that owns both the sizes and the visibility. The wording
- * comes from the tray's own tables, so the two menus cannot drift into
- * describing the same surface differently.
+ * main is the side that owns both the sizes and the visibility. The size
+ * pickers come from the same builder the tray reads, so the two menus cannot
+ * drift into describing the same surface differently.
  *
  * A pure template, separately from the press that pops it, because the menu
  * itself is a native window and what is worth stating is the wording and which
@@ -671,24 +666,10 @@ export const companionContextMenuTemplate = (
     hide: () => void;
   },
 ): MenuItemConstructorOptions[] => [
-  // A submenu per axis, since the creature and the controls beside it are
-  // sized separately and one picker could only ever move both.
-  //
-  // The steps sit under those headings rather than flat at the top level. A
-  // named submenu says what its five words are before it shows them, and leaves
-  // the top level short enough to read at a glance: two headings, and the one
-  // item that is not a size.
-  ...COMPANION_SIZE_AXES.map((axis) => ({
-    label: COMPANION_SIZE_AXIS_LABELS[axis],
-    submenu: COMPANION_SIZES.map((size) => ({
-      label: COMPANION_SIZE_LABELS[size],
-      type: "radio" as const,
-      checked: current[axis] === size,
-      click: () => {
-        actions.setSize(axis, size);
-      },
-    })),
-  })),
+  // The size pickers the tray offers too, from the one builder both read. They
+  // leave the top level short enough to read at a glance: two headings, and the
+  // one item that is not a size.
+  ...companionSizeSubmenus(current, actions.setSize),
   { type: "separator" as const },
   {
     // Named for what it does to the thing under the cursor. The tray's item is

--- a/clients/macos/src/main/companion-window.ts
+++ b/clients/macos/src/main/companion-window.ts
@@ -1,4 +1,10 @@
-import { BrowserWindow, Menu, screen, shell } from "electron";
+import {
+  BrowserWindow,
+  Menu,
+  screen,
+  shell,
+  type MenuItemConstructorOptions,
+} from "electron";
 import { z } from "zod";
 
 import {
@@ -6,14 +12,16 @@ import {
   voiceActivityContentSchema,
   voiceActivityControlSchema,
   voiceActivityStartSchema,
-  COMPANION_BASE_AVATAR_BOX,
-  COMPANION_BASE_CANVAS_PAD,
   COMPANION_INTRO_ACTIONS,
   COMPANION_INTRO_BEATS,
+  COMPANION_SIZE_AXES,
   COMPANION_SIZES,
-  COMPANION_NEAR_EDGE,
   COMPANION_SIZE_BOXES,
+  companionCardSideFor,
   companionGapFor,
+  companionNearEdgeFor,
+  companionPadFor,
+  companionScaleFor,
   WATCH_FLAG,
   type CompanionCardGrowth,
   type CompanionGrowth,
@@ -21,11 +29,15 @@ import {
   type CompanionIntroAction,
   type CompanionIntroBeat,
   type CompanionSize,
+  type CompanionSizeAxis,
   type CompanionSurfaceState,
   type VellumCommand,
   type VoiceActivityState,
 } from "@vellumai/ipc-contract";
-import { COMPANION_SIZE_LABELS } from "@vellumai/electron-desktop/companion-menu";
+import {
+  COMPANION_SIZE_AXIS_LABELS,
+  COMPANION_SIZE_LABELS,
+} from "@vellumai/electron-desktop/companion-menu";
 import {
   onSettingChange,
   readSetting,
@@ -127,65 +139,59 @@ const COMPANION_KIND = "companion";
 const COMPANION_ROUTE = "/floating/companion";
 
 /**
- * The widest the pill's body gets at {@link COMPANION_BASE_AVATAR_BOX}, which
- * is the ceiling every entry in the renderer's `FALLBACK_WIDTHS` stays under.
+ * The widest the pill's body gets at the size the surface's layout is authored
+ * at, which is the ceiling every entry in the renderer's `FALLBACK_WIDTHS`
+ * stays under.
  *
  * The body alone, because the avatar floats beside the pill rather than inside
  * it: what the canvas has to hold on the growth side is the avatar's half box,
- * the gap, and this. A ceiling rather than a width, since the pill measures its
- * own content, and content wider than it is clipped by the window. The call's
- * approval row is the widest thing the surface renders.
+ * the gap, and this at the options scale. A ceiling rather than a width, since
+ * the pill measures its own content, and content wider than it is clipped by
+ * the window. The call's approval row is the widest thing the surface renders.
  */
 const BASE_MAX_BODY_WIDTH = 316;
 
 /**
- * The tallest the surface gets, which is the typing card.
- *
- * Every other state is a pill exactly {@link COMPANION_BASE_AVATAR_BOX} tall. The card
- * stacks the conversation on top of that row, in a viewport that scrolls once
- * it is full, so the card has a ceiling rather than growing with the exchange:
- * the renderer's `TURNS_MAX_HEIGHT` (220) and its padding, over the composer.
- * Rounded up from what that comes to, because the text is laid out in the
- * renderer and a canvas a few points short clips the top of the card off.
- *
- * Matched to `CompanionSurface`'s card in `companion-surface.tsx`, the way
- * {@link BASE_MAX_BODY_WIDTH} is matched to its widths.
- */
-const BASE_MAX_CARD_HEIGHT = 290;
-
-/**
- * Everything the window's placement depends on, for one companion size.
+ * Everything the window's placement depends on, for one pair of companion
+ * sizes.
  *
  * A record rather than a set of module constants because the user picks the
- * size and the whole canvas follows it. Passed to the placement
+ * sizes and the whole canvas follows them. Passed to the placement
  * rules explicitly rather than read off the module, so they stay pure functions
  * of their inputs and every size is a case a test can state.
  */
 export interface CompanionGeometry {
-  /** The avatar's box, and the scale: this over {@link COMPANION_BASE_AVATAR_BOX}. */
+  /** The creature's box, which is the whole of its own scale. */
   avatarBox: number;
+  /**
+   * The pill's box, which is the scale of everything that is not the creature.
+   */
+  optionsBox: number;
   /** The canvas, sized to hold the largest state in either direction. */
   canvasWidth: number;
   canvasHeight: number;
   /** How much canvas the card's side of the avatar needs, shadow included. */
   riseAbove: number;
-  /** How much the other side needs: the avatar and its shadow, and no more. */
+  /**
+   * How much the other side needs: the avatar, whatever of the pill reaches
+   * back past it, and the shadow.
+   */
   dropBelow: number;
-  /** The room between the avatar's edge and the pill, at this size. */
+  /** The room between the avatar's edge and the pill, at these sizes. */
   gap: number;
-  /** The widest the pill's body draws at this size, gap not included. */
+  /** The widest the pill's body draws at this options size, gap not included. */
   maxBodyWidth: number;
   /** The pill's far edge at its widest, measured from the avatar's centre. */
   maxReach: number;
 }
 
 /**
- * The canvas for a named size.
+ * The canvas for a pair of named sizes.
  *
  * The asymmetry between {@link CompanionGeometry.riseAbove} and `dropBelow` is
  * the point of the shape. Sizing both sides for the card, which is what pinning
  * the avatar to the canvas's centre amounts to, spends the card's whole height
- * on a side that never draws anything taller than the avatar, and macOS
+ * on a side that never draws anything taller than the pill, and macOS
  * refuses a window origin above the top of the work area, so that spend is
  * exactly how far short of the top the avatar would stop.
  *
@@ -193,27 +199,34 @@ export interface CompanionGeometry {
  * the same bargain the width makes. A canvas that grew with the card would move
  * the window under the pointer mid-press and put the expansion back on the main
  * process, which is what the fixed canvas exists to avoid. It *is* resized when
- * the user picks a different size, which is a deliberate, one-off event rather
- * than something that happens mid-gesture.
+ * the user picks a different size on either axis, which is a deliberate,
+ * one-off event rather than something that happens mid-gesture.
  */
-export const geometryFor = (size: CompanionSize): CompanionGeometry => {
-  const avatarBox = COMPANION_SIZE_BOXES[size];
-  const scale = avatarBox / COMPANION_BASE_AVATAR_BOX;
-  const pad = COMPANION_BASE_CANVAS_PAD * scale;
-  const gap = companionGapFor(avatarBox, avatarBox);
-  const maxBodyWidth = BASE_MAX_BODY_WIDTH * scale;
+export const geometryFor = (
+  avatar: CompanionSize,
+  options: CompanionSize,
+): CompanionGeometry => {
+  const avatarBox = COMPANION_SIZE_BOXES[avatar];
+  const optionsBox = COMPANION_SIZE_BOXES[options];
+  const pad = companionPadFor(avatarBox, optionsBox);
+  const gap = companionGapFor(avatarBox, optionsBox);
+  const maxBodyWidth = BASE_MAX_BODY_WIDTH * companionScaleFor(optionsBox);
   // The avatar holds its place and the pill hangs off one side of it across the
   // gap, so the reach is the avatar's half box, the gap, and the widest body.
   // The canvas has to hold it in whichever direction main later picks, so it is
   // sized for both sides, and `growthFor` picks that direction by the same
   // number.
   const maxReach = avatarBox / 2 + gap + maxBodyWidth;
-  const riseAbove = BASE_MAX_CARD_HEIGHT * scale - avatarBox / 2 + pad;
-  // The invariant the renderer anchors by, at this size. Scaled rather than
-  // recomputed, so the formula lives in one place for both processes.
-  const dropBelow = COMPANION_NEAR_EDGE * scale;
+  // Both distances come from the contract, which is where the renderer reads
+  // them too: main places the window by them and the renderer anchors the
+  // surface by them, so a second copy of either is the avatar drawn somewhere
+  // main did not put it. Each already answers for both card directions, which
+  // is what lets a flip move the canvas rather than resize it.
+  const riseAbove = companionCardSideFor(avatarBox, optionsBox);
+  const dropBelow = companionNearEdgeFor(avatarBox, optionsBox);
   return {
     avatarBox,
+    optionsBox,
     canvasWidth: Math.round(maxReach * 2 + pad * 2),
     canvasHeight: Math.round(riseAbove + dropBelow),
     riseAbove,
@@ -246,7 +259,10 @@ let cardGrowth: CompanionCardGrowth = "up";
  * computed here is measured in, and reading the store on each mouse-move of a
  * drag would be a file read per frame.
  */
-let geometry: CompanionGeometry = geometryFor(readCompanionSize());
+let geometry: CompanionGeometry = geometryFor(
+  readCompanionSize("avatar"),
+  readCompanionSize("options"),
+);
 
 /**
  * The beat of the one-time introduction the surface is on, or `null` when it is
@@ -338,6 +354,7 @@ const currentState = (): CompanionSurfaceState => {
     growth,
     cardGrowth,
     avatarBox: geometry.avatarBox,
+    optionsBox: geometry.optionsBox,
     character: character === null ? undefined : character,
     avatarBase64: png === null ? undefined : png.toString("base64"),
     call,
@@ -629,6 +646,61 @@ export const dispatchWithoutRaising = (command: VellumCommand): void => {
 
 let installed = false;
 
+/**
+ * The surface's own menu, on a right-click.
+ *
+ * **Because the tray is the wrong place to look.** The two things a user
+ * wants from a floating avatar are to resize it and to make it go away, and
+ * both were otherwise reachable only from a menu-bar icon that says nothing
+ * about the thing they are actually looking at. A press on the object itself
+ * is where people reach first.
+ *
+ * Built in main rather than in the renderer: a menu is a native window, and
+ * main is the side that owns both the sizes and the visibility. The wording
+ * comes from the tray's own tables, so the two menus cannot drift into
+ * describing the same surface differently.
+ *
+ * A pure template, separately from the press that pops it, because the menu
+ * itself is a native window and what is worth stating is the wording and which
+ * radio is marked.
+ */
+export const companionContextMenuTemplate = (
+  current: Record<CompanionSizeAxis, CompanionSize>,
+  actions: {
+    setSize: (axis: CompanionSizeAxis, size: CompanionSize) => void;
+    hide: () => void;
+  },
+): MenuItemConstructorOptions[] => [
+  // A submenu per axis, since the creature and the controls beside it are
+  // sized separately and one picker could only ever move both.
+  //
+  // The steps sit under those headings rather than flat at the top level. A
+  // named submenu says what its five words are before it shows them, and leaves
+  // the top level short enough to read at a glance: two headings, and the one
+  // item that is not a size.
+  ...COMPANION_SIZE_AXES.map((axis) => ({
+    label: COMPANION_SIZE_AXIS_LABELS[axis],
+    submenu: COMPANION_SIZES.map((size) => ({
+      label: COMPANION_SIZE_LABELS[size],
+      type: "radio" as const,
+      checked: current[axis] === size,
+      click: () => {
+        actions.setSize(axis, size);
+      },
+    })),
+  })),
+  { type: "separator" as const },
+  {
+    // Named for what it does to the thing under the cursor. The tray's item is
+    // a checkbox because it is also the way back; here there is a surface in
+    // front of the user, so this only has to take it away.
+    label: "Hide Companion",
+    click: () => {
+      actions.hide();
+    },
+  },
+];
+
 export const installCompanionWindow = (): void => {
   if (installed) {
     return;
@@ -852,55 +924,25 @@ export const installCompanionWindow = (): void => {
     },
   );
 
-  /**
-   * The surface's own menu, on a right-click.
-   *
-   * **Because the tray is the wrong place to look.** The two things a user
-   * wants from a floating avatar are to resize it and to make it go away, and
-   * both were otherwise reachable only from a menu-bar icon that says nothing
-   * about the thing they are actually looking at. A press on the object itself
-   * is where people reach first.
-   *
-   * Built here rather than in the renderer: a menu is a native window, and main
-   * is the side that owns both the size and the visibility. The wording comes
-   * from the tray's own table, so the two menus cannot drift into describing
-   * the same surface differently.
-   */
   on("vellum:companion:contextMenu", z.tuple([]), () => {
     const win = getFloatingWindow(COMPANION_KIND);
     if (!win || win.isDestroyed()) {
       return;
     }
-    const current = readCompanionSize();
-    const menu = Menu.buildFromTemplate([
-      {
-        // The sizes sit under a heading rather than flat at the top level.
-        // Flat, the first thing a right-click offered was four words that only
-        // read as sizes once you had noticed they were sizes, and the one item
-        // that was not a size sat at the end of the same list. A named submenu
-        // says what the four are before it shows them, and leaves the top level
-        // short enough to read at a glance.
-        label: "Size",
-        submenu: COMPANION_SIZES.map((size) => ({
-          label: COMPANION_SIZE_LABELS[size],
-          type: "radio" as const,
-          checked: current === size,
-          click: () => {
-            setCompanionSurfaceSize(size);
-          },
-        })),
-      },
-      { type: "separator" as const },
-      {
-        // Named for what it does to the thing under the cursor. The tray's item
-        // is a checkbox because it is also the way back; here there is a
-        // surface in front of the user, so this only has to take it away.
-        label: "Hide Companion",
-        click: () => {
-          setCompanionSurfaceVisible(false);
+    const menu = Menu.buildFromTemplate(
+      companionContextMenuTemplate(
+        {
+          avatar: readCompanionSize("avatar"),
+          options: readCompanionSize("options"),
         },
-      },
-    ]);
+        {
+          setSize: setCompanionSurfaceSize,
+          hide: () => {
+            setCompanionSurfaceVisible(false);
+          },
+        },
+      ),
+    );
     menu.popup({ window: win });
   });
 
@@ -1159,9 +1201,13 @@ export const setCompanionSurfaceVisible = (visible: boolean): void => {
   closeCompanionWindow();
 };
 
-/** Which size the surface is currently drawn at, for the tray's radio items. */
-export const readCompanionSurfaceSize = (): CompanionSize =>
-  readCompanionSize();
+/**
+ * Which size one axis of the surface is currently drawn at, for the radio items
+ * in both menus that offer it.
+ */
+export const readCompanionSurfaceSize = (
+  axis: CompanionSizeAxis,
+): CompanionSize => readCompanionSize(axis);
 
 /**
  * Draw the surface at a different size, keeping the avatar where it is.
@@ -1177,10 +1223,21 @@ export const readCompanionSurfaceSize = (): CompanionSize =>
  * hundreds of points, and the user would watch the thing they were trying to
  * enlarge walk off across the desktop. So the centre is read in the old
  * geometry, and the window placed in the new one around the same point.
+ *
+ * Both axes take this same path. Sizing the options alone leaves the creature
+ * exactly as it was and still moves every edge around it: the pill's reach and
+ * the card's height are stated in the options size, so the canvas has to be
+ * built again for them.
  */
-export const setCompanionSurfaceSize = (size: CompanionSize): void => {
-  writeCompanionSize(size);
-  const next = geometryFor(size);
+export const setCompanionSurfaceSize = (
+  axis: CompanionSizeAxis,
+  size: CompanionSize,
+): void => {
+  writeCompanionSize(axis, size);
+  const next = geometryFor(
+    readCompanionSize("avatar"),
+    readCompanionSize("options"),
+  );
   const win = getFloatingWindow(COMPANION_KIND);
   if (!win || win.isDestroyed()) {
     geometry = next;

--- a/clients/web/src/components/companion-intro.tsx
+++ b/clients/web/src/components/companion-intro.tsx
@@ -1,7 +1,9 @@
 import {
+  COMPANION_BASE_AVATAR_BOX,
   COMPANION_INTRO_BEATS,
-  COMPANION_NEAR_EDGE,
   companionGapFor,
+  companionNearEdgeFor,
+  companionScaleFor,
 } from "@vellumai/ipc-contract";
 import type {
   CompanionIntroAction,
@@ -42,17 +44,6 @@ import type {
  * moving it, and moving it would have meant re-deciding growth and placement in
  * the main process for a card that is on screen once in an install's life.
  */
-
-/** The avatar's box the layout is authored at, as `CompanionSurface` has it. */
-const AVATAR_BOX = 44;
-
-/**
- * The room between the avatar's edge and the card, which is the same room the
- * surface leaves between the avatar and its pill. One number from the contract
- * rather than one per neighbour, so everything hanging off the creature sits
- * the same distance from it.
- */
-const AVATAR_GAP = companionGapFor(AVATAR_BOX, AVATAR_BOX);
 
 /**
  * The card's width, fixed rather than measured.
@@ -148,6 +139,16 @@ export interface CompanionIntroProps {
   growth?: CompanionSurfaceGrowth;
   /** Which side of the avatar has the canvas to hold the card. */
   cardGrowth?: CompanionSurfaceCardGrowth;
+  /**
+   * The creature's box and the pill's, in points, as `CompanionSurface` takes
+   * them.
+   *
+   * The card hangs off the creature's edge and steps off it by the same gap the
+   * pill does, so it needs the same two numbers the surface does. Defaulted to
+   * the size the layout is authored at, which is what Storybook draws.
+   */
+  avatarBox?: number;
+  optionsBox?: number;
   /** The assistant's avatar colour, for the progress dots. */
   accentHex?: string;
   /**
@@ -177,6 +178,8 @@ export function CompanionIntro({
   beat,
   growth = "right",
   cardGrowth = "up",
+  avatarBox = COMPANION_BASE_AVATAR_BOX,
+  optionsBox = COMPANION_BASE_AVATAR_BOX,
   accentHex,
   assistantName,
   cardRef,
@@ -187,14 +190,30 @@ export function CompanionIntro({
   const isLast = index === COMPANION_INTRO_BEATS.length - 1;
   const copy = INTRO_COPY_KEYS[beat];
 
+  // Every distance to the creature comes from the contract in points and is
+  // divided into the units this card is drawn in, which are the options scale
+  // the page's wrapper has already applied. The same conversion
+  // `CompanionSurface` makes, from the same helpers, so the card and the pill
+  // hang off the creature by exactly the same amount.
+  const inUnits = (points: number): number =>
+    points / companionScaleFor(optionsBox);
+  const avatarHalfUnits = inUnits(avatarBox / 2);
+  // The creature's half box and then the same room the surface leaves between
+  // the avatar and its pill, so everything hanging off the creature sits the
+  // same distance from it.
+  const stepOff = inUnits(
+    avatarBox / 2 + companionGapFor(avatarBox, optionsBox),
+  );
+  const nearEdgeUnits = inUnits(companionNearEdgeFor(avatarBox, optionsBox));
+
   // Hung off the avatar's own edge, which is the point the host positioned this
   // window around and the point the pill is measured from too. Not off the
   // pill: that box changes width from beat to beat as controls are spotlighted,
   // and a card pinned to it would slide about while being read.
   const placement: CSSProperties =
     growth === "left"
-      ? { right: "50%", marginRight: -(AVATAR_BOX / 2) }
-      : { left: "50%", marginLeft: -(AVATAR_BOX / 2) };
+      ? { right: "50%", marginRight: -avatarHalfUnits }
+      : { left: "50%", marginLeft: -avatarHalfUnits };
 
   // The vertical half: sit against the canvas edge the avatar is near, then
   // step off the avatar by its own half box plus the gap. `100%` names the
@@ -203,12 +222,12 @@ export function CompanionIntro({
   const anchor: CSSProperties =
     cardGrowth === "up"
       ? {
-          top: `calc(100% - ${COMPANION_NEAR_EDGE}px)`,
-          transform: `translateY(calc(-100% - ${AVATAR_BOX / 2 + AVATAR_GAP}px))`,
+          top: `calc(100% - ${nearEdgeUnits}px)`,
+          transform: `translateY(calc(-100% - ${stepOff}px))`,
         }
       : {
-          top: COMPANION_NEAR_EDGE,
-          transform: `translateY(${AVATAR_BOX / 2 + AVATAR_GAP}px)`,
+          top: nearEdgeUnits,
+          transform: `translateY(${stepOff}px)`,
         };
 
   return (

--- a/clients/web/src/components/companion-intro.tsx
+++ b/clients/web/src/components/companion-intro.tsx
@@ -1,9 +1,6 @@
 import {
   COMPANION_BASE_AVATAR_BOX,
   COMPANION_INTRO_BEATS,
-  companionGapFor,
-  companionNearEdgeFor,
-  companionScaleFor,
 } from "@vellumai/ipc-contract";
 import type {
   CompanionIntroAction,
@@ -13,6 +10,7 @@ import type { CSSProperties, Ref } from "react";
 
 import { useTranslation } from "@/i18n";
 
+import { companionLayoutFor } from "@/components/companion-layout";
 import type {
   CompanionSurfaceCardGrowth,
   CompanionSurfaceGrowth,
@@ -190,21 +188,18 @@ export function CompanionIntro({
   const isLast = index === COMPANION_INTRO_BEATS.length - 1;
   const copy = INTRO_COPY_KEYS[beat];
 
-  // Every distance to the creature comes from the contract in points and is
-  // divided into the units this card is drawn in, which are the options scale
-  // the page's wrapper has already applied. The same conversion
-  // `CompanionSurface` makes, from the same helpers, so the card and the pill
-  // hang off the creature by exactly the same amount.
-  const inUnits = (points: number): number =>
-    points / companionScaleFor(optionsBox);
-  const avatarHalfUnits = inUnits(avatarBox / 2);
+  // The same derivation `CompanionSurface` places the pill by, so the card and
+  // the pill hang off the creature by exactly the same amount.
+  const { inUnits, avatarHalf, gap, nearEdge } = companionLayoutFor(
+    avatarBox,
+    optionsBox,
+  );
+  const avatarHalfUnits = inUnits(avatarHalf);
   // The creature's half box and then the same room the surface leaves between
   // the avatar and its pill, so everything hanging off the creature sits the
   // same distance from it.
-  const stepOff = inUnits(
-    avatarBox / 2 + companionGapFor(avatarBox, optionsBox),
-  );
-  const nearEdgeUnits = inUnits(companionNearEdgeFor(avatarBox, optionsBox));
+  const stepOff = inUnits(avatarHalf + gap);
+  const nearEdgeUnits = inUnits(nearEdge);
 
   // Hung off the avatar's own edge, which is the point the host positioned this
   // window around and the point the pill is measured from too. Not off the

--- a/clients/web/src/components/companion-layout.test.ts
+++ b/clients/web/src/components/companion-layout.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+
+import { companionLayoutFor } from "./companion-layout";
+
+/**
+ * The one derivation the pill and the introduction card are both placed by.
+ *
+ * What is worth stating is the pair the layout is authored at coming out as the
+ * numbers the layout is written in, a mixed pair holding the same rules in the
+ * pill's units, and the conversion landing on the numbers CSS is handed rather
+ * than on their floating-point neighbours.
+ */
+describe("companionLayoutFor", () => {
+  /**
+   * The authored pair. Every length on the surface is stated at this size, so
+   * the layout has to reduce to itself here: the scale is one, the creature
+   * carries no difference of its own, and the distances are the points they
+   * were written as.
+   */
+  test("hands back the authored numbers when the two boxes agree", () => {
+    const layout = companionLayoutFor(44, 44);
+    expect(layout.scale).toBe(1);
+    expect(layout.avatarRel).toBe(1);
+    expect(layout.avatarHalf).toBe(22);
+    expect(layout.gap).toBe(12);
+    expect(layout.nearEdge).toBe(46);
+    expect(layout.inUnits(34)).toBe(34);
+  });
+
+  /**
+   * A small creature beside a large pill, read in the pill's units. The gap is
+   * the smaller box's, the creature is drawn at the ratio between the two, and
+   * every point distance is divided by the scale the wrapper has already
+   * applied.
+   */
+  test("states a mixed pair in the pill's units", () => {
+    const layout = companionLayoutFor(44, 110);
+    expect(layout.scale).toBe(2.5);
+    expect(layout.avatarRel).toBe(0.4);
+    expect(layout.avatarHalf).toBe(22);
+    expect(layout.gap).toBe(12);
+    expect(layout.nearEdge).toBe(148);
+    expect(layout.inUnits(34)).toBe(13.6);
+    expect(layout.inUnits(148)).toBe(59.2);
+  });
+
+  /**
+   * The conversion divides by the scale rather than multiplying by the base box
+   * over the pill's, because the numbers here are written straight into CSS.
+   * The other order comes out a float's width away, and `calc(50% +
+   * 13.600000000000001px)` is what the user would read in the inspector.
+   */
+  test("converts to the exact numbers CSS is handed", () => {
+    const layout = companionLayoutFor(44, 110);
+    expect(`${layout.inUnits(34)}`).toBe("13.6");
+    expect(`${layout.inUnits(148)}`).toBe("59.2");
+  });
+
+  /**
+   * The same rules the other way round: a creature larger than the pill keeps
+   * the smaller box's gap, and the canvas holds the creature's own half box
+   * plus a pad sized by the larger of the two.
+   */
+  test("keeps the smaller box's gap when the creature is the larger", () => {
+    const layout = companionLayoutFor(110, 44);
+    expect(layout.scale).toBe(1);
+    expect(layout.avatarRel).toBe(2.5);
+    expect(layout.avatarHalf).toBe(55);
+    expect(layout.gap).toBe(12);
+    expect(layout.nearEdge).toBe(115);
+    expect(layout.inUnits(67)).toBe(67);
+  });
+});

--- a/clients/web/src/components/companion-layout.ts
+++ b/clients/web/src/components/companion-layout.ts
@@ -1,0 +1,60 @@
+import {
+  companionGapFor,
+  companionNearEdgeFor,
+  companionScaleFor,
+} from "@vellumai/ipc-contract";
+
+/** The numbers everything on the companion surface is placed by. */
+export interface CompanionLayout {
+  /** The pill's box over the size the layout is authored at. */
+  scale: number;
+  /**
+   * What the creature carries itself: the difference between the two boxes,
+   * since the wrapper has spent the options one already.
+   */
+  avatarRel: number;
+  /** The creature's half box, in points. */
+  avatarHalf: number;
+  /** The room between the creature's edge and anything beside it, in points. */
+  gap: number;
+  /**
+   * How far the creature's centre sits from the canvas edge it is near, in
+   * points.
+   */
+  nearEdge: number;
+  /**
+   * A distance in points, in the units the layout is stated in.
+   *
+   * The one conversion, and the reason the distances above are held in points:
+   * the page's wrapper has already scaled the whole canvas by the options size,
+   * and the contract answers in points because that is what main sizes the
+   * window in. Dividing once at the end keeps the numbers that reach CSS as
+   * exact as the arithmetic that made them.
+   */
+  inUnits: (points: number) => number;
+}
+
+/**
+ * The surface's geometry for one pair of boxes.
+ *
+ * Derived here rather than in each component, because the pill and the
+ * introduction card both hang off the creature by these same distances:
+ * `CompanionSurface` steps the pill off the avatar's edge across the gap, and
+ * `CompanionIntro` steps its card off the same edge by the same amount. Two
+ * copies of this arithmetic drifting is a card placed somewhere other than
+ * beside the pill it describes.
+ */
+export function companionLayoutFor(
+  avatarBox: number,
+  optionsBox: number,
+): CompanionLayout {
+  const scale = companionScaleFor(optionsBox);
+  return {
+    scale,
+    avatarRel: avatarBox / optionsBox,
+    avatarHalf: avatarBox / 2,
+    gap: companionGapFor(avatarBox, optionsBox),
+    nearEdge: companionNearEdgeFor(avatarBox, optionsBox),
+    inUnits: (points: number): number => points / scale,
+  };
+}

--- a/clients/web/src/components/companion-surface-page.test.tsx
+++ b/clients/web/src/components/companion-surface-page.test.tsx
@@ -21,6 +21,7 @@ const STATE: CompanionSurfaceState = {
   growth: "right",
   cardGrowth: "up",
   avatarBox: 44,
+  optionsBox: 44,
   call: null,
   assistantName: "Ziggy",
   turns: [],
@@ -34,6 +35,8 @@ const STATE: CompanionSurfaceState = {
 
 /** Reset between cases, since `STATE` is what the mocked bridge hands back. */
 const resetState = () => {
+  STATE.avatarBox = 44;
+  STATE.optionsBox = 44;
   STATE.working = false;
   STATE.call = null;
   delete STATE.watching;
@@ -301,6 +304,96 @@ describe("bridgeRect", () => {
     const overlapping = { left: 120, right: 320, top: 100, bottom: 144 };
     const bridge = bridgeRect(AVATAR, overlapping);
     expect(bridge.left).toBeGreaterThan(bridge.right);
+  });
+});
+
+/**
+ * The two sizes, which are one choice each.
+ *
+ * The wrapper is scaled by the options size and the creature carries the
+ * difference between the two itself, which is what lets the pill's every length
+ * stay stated once. The hit-test needs nothing new for it, since it reads rects
+ * off the DOM after the transforms, and the case that proves it is the dead
+ * corner beside a creature far taller than the pill beside it.
+ */
+describe("the companion surface at two sizes", () => {
+  /** The wrapper the whole layout is drawn inside, scaled to the window. */
+  const wrapperOf = (container: HTMLElement): HTMLElement => {
+    const found = container.querySelector<HTMLElement>(".origin-top-left");
+    if (!found) {
+      throw new Error("Expected the scaled wrapper to render");
+    }
+    return found;
+  };
+
+  const avatarOf = (container: HTMLElement): HTMLElement | null =>
+    container.querySelector<HTMLElement>(".size-11");
+
+  test("scales the canvas by the options size rather than the creature's", async () => {
+    STATE.avatarBox = 44;
+    STATE.optionsBox = 110;
+    const { container } = render(<CompanionSurfacePage />);
+
+    await waitFor(() => {
+      expect(wrapperOf(container).style.transform).toBe("scale(2.5)");
+    });
+    expect(wrapperOf(container).style.width).toBe("40%");
+  });
+
+  test("leaves that canvas alone when only the creature grows", async () => {
+    STATE.avatarBox = 220;
+    STATE.optionsBox = 44;
+    const { container } = render(<CompanionSurfacePage />);
+
+    // The creature's own node is where the change lands, so waiting on it is
+    // waiting for the state to have arrived at all.
+    await waitFor(() => {
+      expect(avatarOf(container)?.style.transform).toBe(
+        "translate(-50%, -50%) scale(5)",
+      );
+    });
+    expect(wrapperOf(container).style.transform).toBe("scale(1)");
+  });
+
+  /**
+   * The dead corner: outside the creature's own box, above everything the pill
+   * occupies, and well inside the box drawn around the pair. A window that
+   * claimed it would swallow the presses meant for whatever the user actually
+   * has behind the surface, which is the failure every note in this file is
+   * about.
+   */
+  test("gives the desktop back beside a creature taller than the pill", async () => {
+    STATE.avatarBox = 110;
+    STATE.optionsBox = 44;
+    const { container } = render(<CompanionSurfacePage />);
+    const found = await waitFor(() => {
+      const avatar = container.querySelector<HTMLElement>(".size-11");
+      const pill = container.querySelector<HTMLElement>(
+        ".transition-\\[width\\]",
+      );
+      if (!avatar || !pill) {
+        throw new Error("Expected the surface to render");
+      }
+      return { avatar, pill };
+    });
+    // As the surface draws them at this pair: a 110pt creature, and the pill
+    // bottom-flush across the gap, 44pt tall in the creature's lower portion.
+    pin(found.avatar, { left: 100, right: 210, top: 100, bottom: 210 });
+    pin(found.pill, { left: 222, right: 422, top: 166, bottom: 210 });
+    const canvas = canvasOf(container);
+
+    // Open it from the creature, which is the only part drawn at rest.
+    fireEvent.mouseMove(canvas, { clientX: 150, clientY: 150 });
+    await waitFor(() => {
+      if (container.querySelector("[inert]") !== null) {
+        throw new Error("Expected the pill to open");
+      }
+    });
+    setInteractiveMock.mockClear();
+
+    fireEvent.mouseMove(canvas, { clientX: 216, clientY: 120 });
+
+    expect(setInteractiveMock.mock.calls.at(-1)).toEqual([false]);
   });
 });
 

--- a/clients/web/src/components/companion-surface-page.tsx
+++ b/clients/web/src/components/companion-surface-page.tsx
@@ -25,6 +25,10 @@ import {
   toggleCompanionWatch,
 } from "@/runtime/companion-surface";
 import { sendVoiceActivityControl } from "@/runtime/desktop-voice-activity";
+import {
+  COMPANION_BASE_AVATAR_BOX,
+  companionScaleFor,
+} from "@vellumai/ipc-contract";
 import type {
   CompanionCardGrowth,
   CompanionCharacter,
@@ -44,15 +48,6 @@ import type {
  * turn "take me back to Vellum" into a one-pixel nudge that does nothing.
  */
 const DRAG_SLOP = 3;
-
-/**
- * The avatar's box the surface's layout is authored at.
- *
- * Matches `BASE_AVATAR_BOX` in `companion-window.ts`. Main publishes the box it
- * actually sized the window for, and the ratio between the two is the scale:
- * one number, and the surface below is the same layout multiplied.
- */
-const BASE_AVATAR_BOX = 44;
 
 /** As much of a rect as hit-testing a point against it needs. */
 type SurfaceRect = Pick<DOMRect, "left" | "right" | "top" | "bottom">;
@@ -120,10 +115,11 @@ export function CompanionSurfacePage() {
   // to. Main's call: it owns the window position and is the only side that
   // knows how much room the display has above the surface.
   const [cardGrowth, setCardGrowth] = useState<CompanionCardGrowth>("up");
-  // The avatar's box in points, which is the surface's whole scale. Main sizes
-  // the window from it, so it arrives with the state rather than being a
-  // setting this window reads for itself.
-  const [avatarBox, setAvatarBox] = useState(BASE_AVATAR_BOX);
+  // The creature's box in points and the pill's, which are the surface's whole
+  // scale between them. Main sizes the window from both, so they arrive with
+  // the state rather than being settings this window reads for itself.
+  const [avatarBox, setAvatarBox] = useState(COMPANION_BASE_AVATAR_BOX);
+  const [optionsBox, setOptionsBox] = useState(COMPANION_BASE_AVATAR_BOX);
   const [avatarSrc, setAvatarSrc] = useState<string | undefined>();
   const [character, setCharacter] = useState<CompanionCharacter | undefined>();
   const [call, setCall] = useState<VoiceActivityState | null>(null);
@@ -197,6 +193,7 @@ export function CompanionSurfacePage() {
       setGrowth(state.growth);
       setCardGrowth(state.cardGrowth);
       setAvatarBox(state.avatarBox);
+      setOptionsBox(state.optionsBox);
       setAvatarSrc(
         state.avatarBase64 === undefined
           ? undefined
@@ -466,6 +463,10 @@ export function CompanionSurfacePage() {
     resolveAvatarAccentHex(null, character ?? null) ??
     undefined;
 
+  // The scale the whole canvas is drawn at, which is the options size over the
+  // size the layout is authored at.
+  const optionsScale = companionScaleFor(optionsBox);
+
   return (
     <div
       className="relative h-screen w-screen bg-transparent"
@@ -492,20 +493,30 @@ export function CompanionSurfacePage() {
           them in step with main's arithmetic, which is the drift this avoids
           rather than manages.
 
+          **The options size drives it, not the avatar's.** Almost every length
+          in the layout belongs to the pill, the card or the introduction, so
+          the wrapper is where the options scale is spent; the creature is one
+          element and carries the difference between the two boxes itself.
+
           Nothing else has to know. Hit-testing reads `getBoundingClientRect`,
           which is post-transform, and the drag is in screen deltas. */}
       <div
         className="absolute top-0 left-0 origin-top-left"
         style={{
-          width: `${(100 * BASE_AVATAR_BOX) / avatarBox}%`,
-          height: `${(100 * BASE_AVATAR_BOX) / avatarBox}%`,
-          transform: `scale(${avatarBox / BASE_AVATAR_BOX})`,
+          width: `${100 / optionsScale}%`,
+          height: `${100 / optionsScale}%`,
+          transform: `scale(${optionsScale})`,
         }}
       >
         <CompanionSurface
           phase={phase}
           growth={growth}
           cardGrowth={cardGrowth}
+          // The two boxes main sized the window for. The wrapper above has
+          // spent the options one already; the surface uses both to place the
+          // pill against a creature that may be a different size from it.
+          avatarBox={avatarBox}
+          optionsBox={optionsBox}
           avatarSrc={avatarSrc}
           character={character}
           // The creature notices the hand, in every state including mid-call.
@@ -574,6 +585,10 @@ export function CompanionSurfacePage() {
                 beat={intro}
                 growth={growth}
                 cardGrowth={cardGrowth}
+                // The card steps off the creature by the same gap the pill
+                // does, so it is given the same two boxes.
+                avatarBox={avatarBox}
+                optionsBox={optionsBox}
                 accentHex={accentHex}
                 // Same undefined-not-empty rule as the composer's placeholder
                 // above: the first beat introduces the creature by name, and

--- a/clients/web/src/components/companion-surface.stories.tsx
+++ b/clients/web/src/components/companion-surface.stories.tsx
@@ -14,6 +14,8 @@ import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
 import { composeSvg } from "@/utils/avatar-svg-compositor";
 import {
   COMPANION_INTRO_BEATS,
+  COMPANION_SIZE_BOXES,
+  COMPANION_SIZES,
   type CompanionIntroBeat,
   type VoiceActivityState,
 } from "@vellumai/ipc-contract";
@@ -73,6 +75,18 @@ const BACKDROPS = {
 
 type Backdrop = keyof typeof BACKDROPS;
 
+/**
+ * The five named steps, as the boxes the surface actually takes.
+ *
+ * The controls offer the names and hand over the numbers, because the names are
+ * what a user picks from a menu and the boxes are what the surface is drawn in.
+ * Both axes read from the same set: one vocabulary, two answers.
+ */
+const SIZE_OPTIONS = COMPANION_SIZES.map((size) => COMPANION_SIZE_BOXES[size]);
+const SIZE_LABELS: Record<number, string> = Object.fromEntries(
+  COMPANION_SIZES.map((size) => [COMPANION_SIZE_BOXES[size], size]),
+);
+
 type StoryArgs = React.ComponentProps<typeof CompanionSurface> & {
   backdrop: Backdrop;
   /**
@@ -108,6 +122,16 @@ const meta: Meta<StoryArgs> = {
     cardGrowth: {
       control: "inline-radio",
       options: ["up", "down"],
+    },
+    avatarBox: {
+      name: "avatarSize",
+      control: { type: "select", labels: SIZE_LABELS },
+      options: SIZE_OPTIONS,
+    },
+    optionsBox: {
+      name: "optionsSize",
+      control: { type: "select", labels: SIZE_LABELS },
+      options: SIZE_OPTIONS,
     },
     accentHex: { control: "color" },
     glow: { control: "boolean" },
@@ -212,6 +236,42 @@ export const TypingWhileWorking: Story = {
     working: true,
     assistantName: "Ziggy",
     turns: [{ role: "user", text: "what is on my calendar tomorrow?" }],
+  },
+};
+
+/**
+ * A creature far larger than the controls beside it, which is the pair the two
+ * size axes exist for.
+ *
+ * The pill keeps its authored size and the creature is scaled up around it, and
+ * the two still share a bottom line and a gap: the pill's avatar-facing edge is
+ * the creature's own visual edge plus that gap, which is the distance the host
+ * sizes the window by. There is no page wrapper here, so what these stories
+ * show is the *ratio* between the two rather than the points either would be
+ * drawn at on a desktop.
+ */
+export const BigAvatarSmallOptions: Story = {
+  args: {
+    phase: "hover",
+    hovered: true,
+    avatarBox: COMPANION_SIZE_BOXES.huge,
+    optionsBox: COMPANION_SIZE_BOXES.small,
+  },
+};
+
+/**
+ * The reverse: a modest creature beside controls sized well past it.
+ *
+ * The gap is the smaller of the two objects' clearance rather than the larger
+ * one's, so a small creature beside an enormous pill is not separated from it
+ * by a chasm.
+ */
+export const SmallAvatarBigOptions: Story = {
+  args: {
+    phase: "hover",
+    hovered: true,
+    avatarBox: COMPANION_SIZE_BOXES.small,
+    optionsBox: COMPANION_SIZE_BOXES.huge,
   },
 };
 

--- a/clients/web/src/components/companion-surface.test.tsx
+++ b/clients/web/src/components/companion-surface.test.tsx
@@ -521,6 +521,151 @@ describe("the companion surface's anchor in the canvas", () => {
 });
 
 /**
+ * The surface with the creature and the controls sized apart.
+ *
+ * The page's wrapper is scaled by the options size, so everything here is
+ * stated in those units and the creature carries the difference between the two
+ * boxes itself. What has to hold is that the pill still sits a gap off the
+ * creature's *visual* edge and still shares its bottom line, whichever of the
+ * two is the larger, because that edge and that line are what the host places
+ * the window by.
+ */
+describe("the companion surface at two sizes", () => {
+  /**
+   * The pair the layout is authored at, which every other case here is read
+   * against: it has to come out exactly where one size put it.
+   */
+  test("draws the authored pair exactly as a single size does", () => {
+    const { container } = render(
+      <CompanionSurface phase="hover" avatarBox={44} optionsBox={44} />,
+    );
+    expect(surfaceOf(container).style.left).toBe("calc(50% + 34px)");
+    expect(surfaceOf(container).style.top).toBe("calc(100% - 24px)");
+    expect(avatarOf(container).style.top).toBe("calc(100% - 46px)");
+    expect(avatarOf(container).style.transform).toBe("translate(-50%, -50%)");
+  });
+
+  /** 55 to a huge creature's edge, then the gap the smaller of the two earns. */
+  test("steps the pill off a larger creature's own edge", () => {
+    const { container } = render(
+      <CompanionSurface phase="hover" avatarBox={110} optionsBox={44} />,
+    );
+    expect(surfaceOf(container).style.left).toBe("calc(50% + 67px)");
+  });
+
+  /**
+   * The same rule the other way round, read in the pill's own units: 22 points
+   * to the creature's edge and 12 of gap, at a scale of two and a half.
+   */
+  test("steps it off a smaller creature by the same rule", () => {
+    const { container } = render(
+      <CompanionSurface phase="hover" avatarBox={44} optionsBox={110} />,
+    );
+    expect(surfaceOf(container).style.left).toBe("calc(50% + 13.6px)");
+  });
+
+  test("mirrors that step when the pill grows the other way", () => {
+    const { container } = render(
+      <CompanionSurface
+        phase="hover"
+        growth="left"
+        avatarBox={110}
+        optionsBox={44}
+      />,
+    );
+    expect(surfaceOf(container).style.right).toBe("calc(50% + 67px)");
+  });
+
+  /**
+   * Bottom-flush against a creature that is not the pill's size: the near edge
+   * is 115 at this pair and the creature's bottom is 55 in from its centre, so
+   * the pill's bottom lands 60 from the canvas edge.
+   */
+  test("keeps the pill's bottom on a larger creature's bottom", () => {
+    const { container } = render(
+      <CompanionSurface phase="hover" avatarBox={110} optionsBox={44} />,
+    );
+    expect(avatarOf(container).style.top).toBe("calc(100% - 115px)");
+    expect(surfaceOf(container).style.top).toBe("calc(100% - 60px)");
+    expect(surfaceOf(container).style.transform).toBe("translateY(-100%)");
+  });
+
+  test("keeps it on a smaller creature's bottom too", () => {
+    const { container } = render(
+      <CompanionSurface phase="hover" avatarBox={44} optionsBox={110} />,
+    );
+    expect(avatarOf(container).style.top).toBe("calc(100% - 59.2px)");
+    expect(surfaceOf(container).style.top).toBe("calc(100% - 50.4px)");
+    expect(surfaceOf(container).style.transform).toBe("translateY(-100%)");
+  });
+
+  test("anchors both against the canvas's top edge when the card grows down", () => {
+    const { container } = render(
+      <CompanionSurface
+        phase="hover"
+        cardGrowth="down"
+        avatarBox={110}
+        optionsBox={44}
+      />,
+    );
+    expect(avatarOf(container).style.top).toBe("115px");
+    expect(surfaceOf(container).style.top).toBe("170px");
+  });
+
+  /**
+   * The card growing downward starts on its composer row's top line, which is
+   * one options box above the creature's bottom whatever the creature's size.
+   */
+  test("drops the card from the composer row's own line", () => {
+    const { container } = render(
+      <CompanionSurface
+        phase="typing"
+        cardGrowth="down"
+        avatarBox={44}
+        optionsBox={110}
+      />,
+    );
+    expect(surfaceOf(container).style.top).toBe("24px");
+    expect(surfaceOf(container).style.transform).toBe("none");
+  });
+
+  /**
+   * The creature's own node carries the difference and nothing else does. It
+   * has to be that node rather than the wrapper below it, which owns the bob's
+   * `transform`: two transforms on one node leave one of them out.
+   */
+  test("scales the creature by the difference between the two boxes", () => {
+    const { container } = render(
+      <CompanionSurface phase="resting" avatarBox={110} optionsBox={44} />,
+    );
+    expect(avatarOf(container).style.transform).toBe(
+      "translate(-50%, -50%) scale(2.5)",
+    );
+    expect(
+      avatarOf(container).querySelector(".companion-avatar-bob"),
+    ).not.toBeNull();
+  });
+
+  test("scales it down the same way beside a larger pill", () => {
+    const { container } = render(
+      <CompanionSurface phase="resting" avatarBox={44} optionsBox={110} />,
+    );
+    expect(avatarOf(container).style.transform).toBe(
+      "translate(-50%, -50%) scale(0.4)",
+    );
+  });
+
+  /** With the two agreeing the wrapper has done all of it, at any size. */
+  test("leaves the creature unscaled when the two agree", () => {
+    const { container } = render(
+      <CompanionSurface phase="resting" avatarBox={110} optionsBox={110} />,
+    );
+    expect(avatarOf(container).style.transform).toBe("translate(-50%, -50%)");
+    expect(avatarOf(container).style.top).toBe("calc(100% - 46px)");
+  });
+});
+
+/**
  * The idle row's verbs, which are drawn one at a time under the pointer.
  *
  * **The behaviour is a stylesheet, so these hold its contract rather than its

--- a/clients/web/src/components/companion-surface.tsx
+++ b/clients/web/src/components/companion-surface.tsx
@@ -21,12 +21,7 @@ import type {
   Ref,
 } from "react";
 
-import {
-  COMPANION_BASE_AVATAR_BOX,
-  companionGapFor,
-  companionNearEdgeFor,
-  companionScaleFor,
-} from "@vellumai/ipc-contract";
+import { COMPANION_BASE_AVATAR_BOX } from "@vellumai/ipc-contract";
 import type {
   CompanionCharacter,
   CompanionTurn,
@@ -40,6 +35,7 @@ import { MarkdownMessage } from "@vellumai/design-library";
 import { openCompanionLink } from "@/runtime/companion-surface";
 
 import { AnimatedAvatar } from "@/components/avatar/animated-avatar";
+import { companionLayoutFor } from "@/components/companion-layout";
 import { useTranslation } from "@/i18n";
 import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
 
@@ -724,24 +720,13 @@ export function CompanionSurface({
       ? 0
       : (contentWidth ?? FALLBACK_WIDTHS[phase]) + 2 * INNER_GAP;
 
-  /**
-   * A distance in points, in the units this layout is stated in.
-   *
-   * The one conversion, and the reason the distances below are worked out in
-   * points first: the page's wrapper has already scaled the whole canvas by the
-   * options size, and the contract answers in points because that is what main
-   * sizes the window in. Dividing once at the end also keeps the numbers that
-   * reach CSS as exact as the arithmetic that made them.
-   */
-  const inUnits = (points: number): number =>
-    points / companionScaleFor(optionsBox);
-
-  // What the creature carries itself: the difference between the two boxes,
-  // since the wrapper has spent the options one already.
-  const avatarRel = avatarBox / optionsBox;
-  const avatarHalf = avatarBox / 2;
-  const gap = companionGapFor(avatarBox, optionsBox);
-  const nearEdge = companionNearEdgeFor(avatarBox, optionsBox);
+  // The distances everything below is placed by, in points, and the one
+  // conversion into the units this layout is stated in. Shared with
+  // `CompanionIntro`, whose card hangs off the same edge by the same amount.
+  const { inUnits, avatarRel, avatarHalf, gap, nearEdge } = companionLayoutFor(
+    avatarBox,
+    optionsBox,
+  );
 
   /**
    * A line in the canvas, given how far in points it sits from the avatar's

--- a/clients/web/src/components/companion-surface.tsx
+++ b/clients/web/src/components/companion-surface.tsx
@@ -21,7 +21,12 @@ import type {
   Ref,
 } from "react";
 
-import { COMPANION_NEAR_EDGE, companionGapFor } from "@vellumai/ipc-contract";
+import {
+  COMPANION_BASE_AVATAR_BOX,
+  companionGapFor,
+  companionNearEdgeFor,
+  companionScaleFor,
+} from "@vellumai/ipc-contract";
 import type {
   CompanionCharacter,
   CompanionTurn,
@@ -44,14 +49,22 @@ import { BUNDLED_COMPONENTS } from "@/utils/avatar-bundled-components";
  * beside it, and unfurling the same way while a call runs.
  *
  * **Two elements, and the mascot is the fixed point.** The creature and the
- * pill are siblings with {@link GAP} between them rather than one box holding
- * the other. The avatar holds one point in the canvas in every state, which is
- * the point the host positions this window around, so the surface reads as one
+ * pill are siblings with a gap between them rather than one box holding the
+ * other. The avatar holds one point in the canvas in every state, which is the
+ * point the host positions this window around, so the surface reads as one
  * object changing shape rather than a series of different objects and the eye
  * and the cursor always have the same target to aim at. The pill hangs off it:
  * its avatar-facing edge sits the avatar's half box plus the gap from that
  * point, and its bottom edge sits on the avatar's bottom, so the two keep one
  * baseline whatever the pill is carrying. Only the pill's `width` animates.
+ *
+ * **Two sizes, and the creature carries the difference.** The host publishes a
+ * box for the avatar and a box for the pill, and the page around this scales
+ * the whole canvas by the second, so every length below is stated once at the
+ * size the layout is authored at. The creature is scaled again inside that by
+ * the ratio between the two boxes, and the handful of distances measured from
+ * its edge (the gap, the near edge, its own half box) are worked out from the
+ * contract's helpers and divided back into these units.
  *
  * **Growth needs clearance on the side it runs into**: the gap, and then a body
  * that reaches 316px at its widest. A circle parked against the right edge does
@@ -175,21 +188,9 @@ const ASSISTANT_TURN_PHASES = new Set(["transcribing", "thinking", "speaking"]);
  */
 const WATCHING_RING_ACCENT = "#ff9f45";
 
-// The avatar is a fixed 44px disc in every state; only the pill beside it
-// changes. That is what makes this one surface expanding rather than three
-// surfaces that happen to share a colour, and it is the property to protect as
-// the states gain content.
-const AVATAR_BOX = 44;
-
-/**
- * The room between the avatar's edge and the pill.
- *
- * Read from the contract rather than stated here, because main sizes the canvas
- * to hold the same distance: what decides how wide the window has to be is the
- * pill's reach past the avatar, and a second copy of the number is a pill drawn
- * further out than the room main left for it.
- */
-const GAP = companionGapFor(AVATAR_BOX, AVATAR_BOX);
+// The box every length on this surface is stated in: the pill's own height, and
+// the creature's at the size the two agree on.
+const BASE_BOX = COMPANION_BASE_AVATAR_BOX;
 
 /**
  * The avatar artwork inside that box, which is inset by {@link INNER_GAP} on
@@ -348,6 +349,26 @@ export interface CompanionSurfaceProps {
   onHoverEnd?: () => void;
   /** Which way the pill grows. See {@link CompanionSurfaceGrowth}. */
   growth?: CompanionSurfaceGrowth;
+  /**
+   * The creature's box in points, which is the avatar's whole scale.
+   *
+   * Its own size rather than the surface's, because the two are chosen
+   * separately: a mascot big enough to read from across the room is not a pill
+   * that wide. Defaulted to the size the layout is authored at, which is what
+   * Storybook draws and what the host publishes for a surface nobody has
+   * resized.
+   */
+  avatarBox?: number;
+  /**
+   * The pill's box in points, which is the scale of everything that is not the
+   * creature.
+   *
+   * The page's wrapper is already scaled by this, so what it is for here is
+   * converting back: a distance the host and this side have to agree on is
+   * worked out in points from the contract's helpers and divided by this scale
+   * on its way into a style, so both ends are the same expression.
+   */
+  optionsBox?: number;
   /**
    * Which way the card grows, and with it which edge of the canvas the avatar
    * is anchored to. See {@link CompanionSurfaceCardGrowth}.
@@ -623,6 +644,8 @@ export function CompanionSurface({
   onHoverStart,
   onHoverEnd,
   growth = "right",
+  avatarBox = COMPANION_BASE_AVATAR_BOX,
+  optionsBox = COMPANION_BASE_AVATAR_BOX,
   cardGrowth = "up",
   rootRef,
   avatarRef,
@@ -702,18 +725,37 @@ export function CompanionSurface({
       : (contentWidth ?? FALLBACK_WIDTHS[phase]) + 2 * INNER_GAP;
 
   /**
-   * A line in the canvas, given how far it sits from the avatar's centre.
+   * A distance in points, in the units this layout is stated in.
+   *
+   * The one conversion, and the reason the distances below are worked out in
+   * points first: the page's wrapper has already scaled the whole canvas by the
+   * options size, and the contract answers in points because that is what main
+   * sizes the window in. Dividing once at the end also keeps the numbers that
+   * reach CSS as exact as the arithmetic that made them.
+   */
+  const inUnits = (points: number): number =>
+    points / companionScaleFor(optionsBox);
+
+  // What the creature carries itself: the difference between the two boxes,
+  // since the wrapper has spent the options one already.
+  const avatarRel = avatarBox / optionsBox;
+  const avatarHalf = avatarBox / 2;
+  const gap = companionGapFor(avatarBox, optionsBox);
+  const nearEdge = companionNearEdgeFor(avatarBox, optionsBox);
+
+  /**
+   * A line in the canvas, given how far in points it sits from the avatar's
+   * centre.
    *
    * The canvas is *not* symmetric about the avatar: the card's height is
-   * reserved on whichever side it grows into, so the avatar sits
-   * `COMPANION_NEAR_EDGE` from the other edge, and that edge is the one worth
-   * anchoring to. `100%` names the canvas without this side having to know how
-   * tall main made it.
+   * reserved on whichever side it grows into, so the avatar sits the near edge
+   * from the other one, and that edge is the one worth anchoring to. `100%`
+   * names the canvas without this side having to know how tall main made it.
    */
   const lineAt = (offset: number): string =>
     cardGrowth === "up"
-      ? `calc(100% - ${COMPANION_NEAR_EDGE - offset}px)`
-      : `${COMPANION_NEAR_EDGE + offset}px`;
+      ? `calc(100% - ${inUnits(nearEdge - offset)}px)`
+      : `${inUnits(nearEdge + offset)}px`;
 
   // **The avatar never moves.** It holds one spot in the canvas, which is the
   // spot the host positions this window around, and the pill hangs off one side
@@ -728,8 +770,8 @@ export function CompanionSurface({
   // and direction check against is not.
   const placement: CSSProperties =
     growth === "left"
-      ? { right: `calc(50% + ${AVATAR_BOX / 2 + GAP}px)` }
-      : { left: `calc(50% + ${AVATAR_BOX / 2 + GAP}px)` };
+      ? { right: `calc(50% + ${inUnits(avatarHalf + gap)}px)` }
+      : { left: `calc(50% + ${inUnits(avatarHalf + gap)}px)` };
 
   // The card growing downward draws its composer row first, so the row starts
   // on the avatar's top line and the card falls away from it; everything else
@@ -746,8 +788,9 @@ export function CompanionSurface({
     // pressed. Which way the card stacks is the host's call: parked by the Dock
     // a card growing down would grow off the bottom of the screen, and at the
     // top of the display a card growing up has nowhere to be (see
-    // `CompanionSurfaceCardGrowth`).
-    top: lineAt(dropsFromTheRow ? -(AVATAR_BOX / 2) : AVATAR_BOX / 2),
+    // `CompanionSurfaceCardGrowth`). The row is one options box tall, so a card
+    // growing downward starts exactly that far above the line.
+    top: lineAt(dropsFromTheRow ? avatarHalf - optionsBox : avatarHalf),
     transform: dropsFromTheRow ? "none" : "translateY(-100%)",
     // Settles rather than overshoots. A surface on screen all day should not
     // bounce every time the pointer crosses it.
@@ -942,13 +985,16 @@ export function CompanionSurface({
           <span
             className="pointer-events-auto absolute"
             style={{
-              width: GAP,
-              height: AVATAR_BOX,
+              width: inUnits(gap),
+              // The pill's own row, on the pill's own line: the strip is what
+              // the pointer crosses between the two, so it is as tall as what
+              // it leads to rather than as tall as the creature it leaves.
+              height: BASE_BOX,
               ...(growth === "left"
-                ? { right: `calc(50% + ${AVATAR_BOX / 2}px)` }
-                : { left: `calc(50% + ${AVATAR_BOX / 2}px)` }),
-              top: lineAt(0),
-              transform: "translateY(-50%)",
+                ? { right: `calc(50% + ${inUnits(avatarHalf)}px)` }
+                : { left: `calc(50% + ${inUnits(avatarHalf)}px)` }),
+              top: lineAt(avatarHalf),
+              transform: "translateY(-100%)",
             }}
             aria-hidden
           />
@@ -970,7 +1016,16 @@ export function CompanionSurface({
           style={{
             left: "50%",
             top: lineAt(0),
-            transform: "translate(-50%, -50%)",
+            // Centred on the point the host put the window around, then scaled
+            // about that centre by whatever the creature's own size asks for
+            // beyond the scale the page has already applied. Omitted where the
+            // two boxes agree, which is the surface every other length here is
+            // authored for. On this node rather than the one below it: the bob
+            // owns a `transform` of its own, and two transforms on one node
+            // silently leave one of them out.
+            transform: `translate(-50%, -50%)${
+              avatarRel === 1 ? "" : ` scale(${avatarRel})`
+            }`,
           }}
           elementRef={avatarRef}
           onMouseEnter={onHoverStart}

--- a/packages/electron-desktop/src/companion-menu.test.ts
+++ b/packages/electron-desktop/src/companion-menu.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "bun:test";
+import type { CompanionSize, CompanionSizeAxis } from "@vellumai/ipc-contract";
+
+import { companionSizeSubmenus } from "./companion-menu";
+
+/**
+ * The size pickers both companion menus draw, built once.
+ *
+ * The tray and the surface's own right-click read this builder, so what is
+ * worth stating here is what a menu is read for: the headings, the steps under
+ * them, which one is marked, and that a press carries the axis it was made
+ * under. The two callers then only have to state what is theirs, which is where
+ * the items sit and whether they stand down.
+ */
+describe("companionSizeSubmenus", () => {
+  /** Only what a menu item is read for here, as `tray-model.test.ts` has it. */
+  type MenuItem = {
+    label?: string;
+    enabled?: boolean;
+    type?: string;
+    checked?: boolean;
+    click?: () => void;
+    submenu?: MenuItem[];
+  };
+
+  const build = (
+    current: Record<CompanionSizeAxis, CompanionSize> = {
+      avatar: "small",
+      options: "small",
+    },
+    options?: { enabled?: boolean },
+  ) => {
+    const picked: [CompanionSizeAxis, CompanionSize][] = [];
+    const items = companionSizeSubmenus(
+      current,
+      (axis, size) => {
+        picked.push([axis, size]);
+      },
+      options,
+    ) as MenuItem[];
+    return { items, picked };
+  };
+
+  test("offers a heading for each thing that is sized", () => {
+    expect(build().items.map((item) => item.label)).toEqual([
+      "Avatar size",
+      "Options size",
+    ]);
+  });
+
+  test("offers every named step under each heading, as one radio group", () => {
+    for (const heading of build().items) {
+      expect(heading.submenu?.map((item) => item.label)).toEqual([
+        "Small",
+        "Medium",
+        "Large",
+        "Huge",
+        "Ridiculous",
+      ]);
+      expect(heading.submenu?.every((item) => item.type === "radio")).toBe(
+        true,
+      );
+    }
+  });
+
+  /**
+   * The whole point of two submenus: each shows where its own axis is, so a
+   * user who has made the creature enormous and left the controls alone can see
+   * exactly that.
+   */
+  test("marks the step each axis is on, and only that one", () => {
+    const { items } = build({ avatar: "ridiculous", options: "medium" });
+    expect(
+      items[0]?.submenu?.filter((item) => item.checked).map((i) => i.label),
+    ).toEqual(["Ridiculous"]);
+    expect(
+      items[1]?.submenu?.filter((item) => item.checked).map((i) => i.label),
+    ).toEqual(["Medium"]);
+  });
+
+  test("a pick carries the axis it was made under", () => {
+    const menu = build();
+    menu.items[0]?.submenu?.[3]?.click?.();
+    menu.items[1]?.submenu?.[4]?.click?.();
+    expect(menu.picked).toEqual([
+      ["avatar", "huge"],
+      ["options", "ridiculous"],
+    ]);
+  });
+
+  /**
+   * The headings stand down rather than disappear for the menu that also offers
+   * a way to hide the surface. Left to itself the builder hands back live items,
+   * which is what a menu drawn on the surface itself wants.
+   */
+  test("is enabled unless the caller says otherwise", () => {
+    expect(build().items.map((item) => item.enabled)).toEqual([true, true]);
+    expect(
+      build(undefined, { enabled: false }).items.map((item) => item.enabled),
+    ).toEqual([false, false]);
+  });
+});

--- a/packages/electron-desktop/src/companion-menu.ts
+++ b/packages/electron-desktop/src/companion-menu.ts
@@ -1,4 +1,11 @@
-import type { CompanionSize, CompanionSizeAxis } from "@vellumai/ipc-contract";
+import type { MenuItemConstructorOptions } from "electron";
+
+import {
+  COMPANION_SIZE_AXES,
+  COMPANION_SIZES,
+  type CompanionSize,
+  type CompanionSizeAxis,
+} from "@vellumai/ipc-contract";
 
 /**
  * Menu wording for each companion size.
@@ -8,12 +15,12 @@ import type { CompanionSize, CompanionSizeAxis } from "@vellumai/ipc-contract";
  * the labels: "88pt" means nothing next to a floating avatar, and the sizes are
  * meant to be picked by looking at the result.
  *
- * In a module of its own because two menus offer them now, the tray's and the
- * surface's own right-click, and those live in different packages. A user who
- * met "Large" in one place and "Big" in the other would reasonably wonder
- * whether they were setting the same thing.
+ * One table rather than a literal per menu, since the tray and the surface's
+ * own right-click both offer the steps. A user who met "Large" in one place and
+ * "Big" in the other would reasonably wonder whether they were setting the same
+ * thing.
  */
-export const COMPANION_SIZE_LABELS: Record<CompanionSize, string> = {
+const COMPANION_SIZE_LABELS: Record<CompanionSize, string> = {
   small: "Small",
   medium: "Medium",
   large: "Large",
@@ -33,7 +40,49 @@ export const COMPANION_SIZE_LABELS: Record<CompanionSize, string> = {
  * "Avatar size" in one place and "Creature size" in the other would reasonably
  * wonder whether they were setting the same thing.
  */
-export const COMPANION_SIZE_AXIS_LABELS: Record<CompanionSizeAxis, string> = {
+const COMPANION_SIZE_AXIS_LABELS: Record<CompanionSizeAxis, string> = {
   avatar: "Avatar size",
   options: "Options size",
 };
+
+/**
+ * The size pickers, as every menu that offers them draws them.
+ *
+ * One submenu per axis, since the creature and the controls beside it are sized
+ * separately and a single picker could only ever move both. The steps sit under
+ * those headings rather than flat: a named submenu says what its five words are
+ * before it shows them, and leaves the menu around it short enough to read at a
+ * glance.
+ *
+ * Named steps rather than a slider, because the avatar's box is not a style:
+ * the canvas, the pill's reach and the card's height are all derived from it,
+ * so a continuous scale would be a layout nobody had ever looked at. Radio
+ * items, since each axis is one choice and the menu has to show which step is
+ * in effect.
+ *
+ * Built here rather than in each menu, for the reason the wording above is: a
+ * later axis, label, checked state or click behaviour would otherwise reach the
+ * tray and leave the surface's own right-click describing the same setting
+ * differently.
+ *
+ * `enabled` is for the menu that offers the sizes beside a way to hide the
+ * surface: the items stand down rather than disappear while it is hidden, since
+ * they say the sizes are still something the companion has.
+ */
+export const companionSizeSubmenus = (
+  current: Record<CompanionSizeAxis, CompanionSize>,
+  pick: (axis: CompanionSizeAxis, size: CompanionSize) => void,
+  options?: { enabled?: boolean },
+): MenuItemConstructorOptions[] =>
+  COMPANION_SIZE_AXES.map((axis) => ({
+    label: COMPANION_SIZE_AXIS_LABELS[axis],
+    enabled: options?.enabled ?? true,
+    submenu: COMPANION_SIZES.map((size) => ({
+      label: COMPANION_SIZE_LABELS[size],
+      type: "radio" as const,
+      checked: current[axis] === size,
+      click: () => {
+        pick(axis, size);
+      },
+    })),
+  }));

--- a/packages/electron-desktop/src/companion-menu.ts
+++ b/packages/electron-desktop/src/companion-menu.ts
@@ -1,4 +1,4 @@
-import type { CompanionSize } from "@vellumai/ipc-contract";
+import type { CompanionSize, CompanionSizeAxis } from "@vellumai/ipc-contract";
 
 /**
  * Menu wording for each companion size.
@@ -19,4 +19,21 @@ export const COMPANION_SIZE_LABELS: Record<CompanionSize, string> = {
   large: "Large",
   huge: "Huge",
   ridiculous: "Ridiculous",
+};
+
+/**
+ * Menu wording for each of the two things a user sizes.
+ *
+ * Sentence case, and the noun first: the submenus sit among items that say what
+ * they act on ("Show Companion", "Hide Companion"), and a user scanning for the
+ * creature reads "Avatar" before they read "size".
+ *
+ * Here beside the steps themselves, and for the same reason: both menus that
+ * offer the sizes offer them under these two headings, and a user who met
+ * "Avatar size" in one place and "Creature size" in the other would reasonably
+ * wonder whether they were setting the same thing.
+ */
+export const COMPANION_SIZE_AXIS_LABELS: Record<CompanionSizeAxis, string> = {
+  avatar: "Avatar size",
+  options: "Options size",
 };

--- a/packages/electron-desktop/src/tray-model.test.ts
+++ b/packages/electron-desktop/src/tray-model.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import type { CompanionSize } from "@vellumai/ipc-contract";
+import type { CompanionSize, CompanionSizeAxis } from "@vellumai/ipc-contract";
 import type { Lockfile } from "@vellumai/local-mode/contract";
 
 // Tray stub: records constructions, event listeners, and image swaps.
@@ -99,8 +99,13 @@ let featureFlags: Record<string, boolean> | null = null;
 let companionSupported = true;
 let companionHidden = false;
 const setCompanionSurfaceVisibleMock = mock((_visible: boolean) => undefined);
-let companionSize: CompanionSize = "large";
-const setCompanionSizeMock = mock((_size: CompanionSize) => undefined);
+let companionSizes: Record<CompanionSizeAxis, CompanionSize> = {
+  avatar: "large",
+  options: "large",
+};
+const setCompanionSizeMock = mock(
+  (_axis: CompanionSizeAxis, _size: CompanionSize) => undefined,
+);
 
 const dispatchToMainMock = mock((_command: unknown) => undefined);
 
@@ -187,7 +192,7 @@ beforeEach(() => {
     onboardingActive: () => false,
     openComponentGallery: () => undefined,
     removePairedLabel: "Remove from this Mac\u2026",
-    companionSize: () => companionSize,
+    companionSize: (axis) => companionSizes[axis],
     setCompanionSize: setCompanionSizeMock,
     setCompanionVisible: setCompanionSurfaceVisibleMock,
   });
@@ -199,7 +204,7 @@ beforeEach(() => {
   featureFlags = null;
   companionSupported = true;
   companionHidden = false;
-  companionSize = "large";
+  companionSizes = { avatar: "large", options: "large" };
   setCompanionSurfaceVisibleMock.mockClear();
   setCompanionSizeMock.mockClear();
   dispatchToMainMock.mockClear();
@@ -565,15 +570,16 @@ describe("companion toggle", () => {
   };
 
   /**
-   * The size picker, which lives beside the toggle and is gated with it: with
-   * no surface there is nothing to size.
+   * The size pickers, which live beside the toggle and are gated with it: with
+   * no surface there is nothing to size. One per axis, since the creature and
+   * the controls beside it are sized separately.
    */
-  const popSizeItem = (): MenuItem | undefined => {
+  const popSizeItem = (label: string): MenuItem | undefined => {
     installTray(handlers);
     handlerFor(trays[0], "right-click")?.();
     const calls = buildFromTemplateMock.mock.calls;
     const template = calls[calls.length - 1]?.[0] as MenuItem[];
-    return template.find((i) => i.label === "Companion Size");
+    return template.find((i) => i.label === label);
   };
 
   test("renders as a checked checkbox while the surface is shown", () => {
@@ -598,47 +604,80 @@ describe("companion toggle", () => {
   });
 
   /**
+   * Two headings rather than one, because a single picker could only ever move
+   * both halves of the surface at once. The wording is the same table the
+   * surface's own right-click reads, so the two menus cannot describe the same
+   * choice differently.
+   */
+  test("offers a heading for each thing that is sized", () => {
+    installTray(handlers);
+    handlerFor(trays[0], "right-click")?.();
+    const calls = buildFromTemplateMock.mock.calls;
+    const template = calls[calls.length - 1]?.[0] as MenuItem[];
+    const headings = template
+      .map((i) => i.label)
+      .filter((label) => label === "Avatar size" || label === "Options size");
+    expect(headings).toEqual(["Avatar size", "Options size"]);
+  });
+
+  /**
    * Named steps rather than a slider (JARVIS-1549). The avatar's box is the
    * geometry both processes derive from, so the sizes are a fixed set of
    * layouts and the menu is where one is chosen.
    */
-  test("offers a size for each named step", () => {
-    expect(popSizeItem()?.submenu?.map((i) => i.label)).toEqual([
-      "Small",
-      "Medium",
-      "Large",
-      "Huge",
-      "Ridiculous",
-    ]);
+  test("offers a size for each named step, under both headings", () => {
+    for (const label of ["Avatar size", "Options size"]) {
+      expect(popSizeItem(label)?.submenu?.map((i) => i.label)).toEqual([
+        "Small",
+        "Medium",
+        "Large",
+        "Huge",
+        "Ridiculous",
+      ]);
+    }
   });
 
-  test("marks the size in effect, since radio items have to show one", () => {
-    companionSize = "medium";
-    const checked = popSizeItem()
-      ?.submenu?.filter((i) => i.checked)
-      .map((i) => i.label);
-    expect(checked).toEqual(["Medium"]);
+  test("marks the step each axis is on, since radio items have to show one", () => {
+    companionSizes = { avatar: "medium", options: "ridiculous" };
+    expect(
+      popSizeItem("Avatar size")
+        ?.submenu?.filter((i) => i.checked)
+        .map((i) => i.label),
+    ).toEqual(["Medium"]);
+    expect(
+      popSizeItem("Options size")
+        ?.submenu?.filter((i) => i.checked)
+        .map((i) => i.label),
+    ).toEqual(["Ridiculous"]);
   });
 
-  test("renders the sizes as one radio group", () => {
-    expect(popSizeItem()?.submenu?.every((i) => i.type === "radio")).toBe(true);
+  test("renders each heading's sizes as one radio group", () => {
+    for (const label of ["Avatar size", "Options size"]) {
+      expect(
+        popSizeItem(label)?.submenu?.every((i) => i.type === "radio"),
+      ).toBe(true);
+    }
   });
 
-  test("applies the size that was picked", () => {
-    popSizeItem()?.submenu?.[3]?.click?.({ checked: true });
-    expect(setCompanionSizeMock).toHaveBeenLastCalledWith("huge");
+  test("applies the size that was picked, to the axis it was picked under", () => {
+    popSizeItem("Avatar size")?.submenu?.[3]?.click?.({ checked: true });
+    expect(setCompanionSizeMock).toHaveBeenLastCalledWith("avatar", "huge");
+    popSizeItem("Options size")?.submenu?.[0]?.click?.({ checked: true });
+    expect(setCompanionSizeMock).toHaveBeenLastCalledWith("options", "small");
   });
 
   /**
-   * Disabled rather than dropped while the surface is hidden. The size is still
-   * something the companion has, and an item that comes and goes with the
-   * checkbox above it reads as a bug rather than as a state.
+   * Disabled rather than dropped while the surface is hidden. The sizes are
+   * still something the companion has, and items that came and went with the
+   * checkbox above them would read as a bug rather than as a state.
    */
   test("stands down while the surface is hidden, without disappearing", () => {
     companionHidden = true;
-    const item = popSizeItem();
-    expect(item).toBeDefined();
-    expect(item?.enabled).toBe(false);
+    for (const label of ["Avatar size", "Options size"]) {
+      const item = popSizeItem(label);
+      expect(item).toBeDefined();
+      expect(item?.enabled).toBe(false);
+    }
   });
 
   test("is absent entirely on a platform with no companion surface", () => {
@@ -647,7 +686,8 @@ describe("companion toggle", () => {
     handlerFor(trays[0], "right-click")?.();
     const calls = buildFromTemplateMock.mock.calls;
     const template = calls[calls.length - 1]?.[0] as MenuItem[];
-    expect(template.find((i) => i.label === "Companion Size")).toBeUndefined();
+    expect(template.find((i) => i.label === "Avatar size")).toBeUndefined();
+    expect(template.find((i) => i.label === "Options size")).toBeUndefined();
   });
 });
 

--- a/packages/electron-desktop/src/tray-model.ts
+++ b/packages/electron-desktop/src/tray-model.ts
@@ -13,8 +13,6 @@ import {
   type LockfileAssistant,
 } from "@vellumai/local-mode/contract";
 import {
-  COMPANION_SIZE_AXES,
-  COMPANION_SIZES,
   type CompanionSize,
   type CompanionSizeAxis,
   type VellumCommand,
@@ -31,10 +29,7 @@ import {
   type AssistantStatus,
 } from "./status";
 import { invalidateIconCache, statusFrames } from "./status-icon";
-import {
-  COMPANION_SIZE_AXIS_LABELS,
-  COMPANION_SIZE_LABELS,
-} from "./companion-menu";
+import { companionSizeSubmenus } from "./companion-menu";
 
 export type TrayMenuIcon =
   | "check"
@@ -379,30 +374,18 @@ const buildTrayMenu = (
               trayRuntime.setCompanionVisible(item.checked);
             },
           },
-          // One submenu per axis: the creature and the controls beside it are
-          // sized separately, and a single picker could only ever move both.
-          //
-          // Named steps rather than a slider, because the avatar's box is not a
-          // style: the canvas, the pill's reach and the card's height are all
-          // derived from it, so a continuous scale would be a layout nobody had
-          // ever looked at. Radio items, since each axis is one choice and the
-          // menu has to show which step is in effect.
-          //
-          // Disabled rather than hidden while the surface is hidden: the items
-          // say the sizes are still something the companion has, and items that
-          // came and went with the checkbox above them would read as a bug.
-          ...COMPANION_SIZE_AXES.map((axis) => ({
-            label: COMPANION_SIZE_AXIS_LABELS[axis],
-            enabled: !trayRuntime.companionHidden(),
-            submenu: COMPANION_SIZES.map((size) => ({
-              label: COMPANION_SIZE_LABELS[size],
-              type: "radio" as const,
-              checked: trayRuntime.companionSize(axis) === size,
-              click: () => {
-                trayRuntime.setCompanionSize(axis, size);
-              },
-            })),
-          })),
+          // The size pickers the surface's own right-click offers too, from the
+          // one builder both read. Disabled rather than hidden while the
+          // surface is: items that came and went with the checkbox above them
+          // would read as a bug.
+          ...companionSizeSubmenus(
+            {
+              avatar: trayRuntime.companionSize("avatar"),
+              options: trayRuntime.companionSize("options"),
+            },
+            trayRuntime.setCompanionSize,
+            { enabled: !trayRuntime.companionHidden() },
+          ),
         ]
       : []),
     { type: "separator" },

--- a/packages/electron-desktop/src/tray-model.ts
+++ b/packages/electron-desktop/src/tray-model.ts
@@ -13,8 +13,10 @@ import {
   type LockfileAssistant,
 } from "@vellumai/local-mode/contract";
 import {
+  COMPANION_SIZE_AXES,
   COMPANION_SIZES,
   type CompanionSize,
+  type CompanionSizeAxis,
   type VellumCommand,
 } from "@vellumai/ipc-contract";
 
@@ -29,7 +31,10 @@ import {
   type AssistantStatus,
 } from "./status";
 import { invalidateIconCache, statusFrames } from "./status-icon";
-import { COMPANION_SIZE_LABELS } from "./companion-menu";
+import {
+  COMPANION_SIZE_AXIS_LABELS,
+  COMPANION_SIZE_LABELS,
+} from "./companion-menu";
 
 export type TrayMenuIcon =
   | "check"
@@ -54,8 +59,8 @@ export interface TrayModelRuntime {
    */
   companionSupported: () => boolean;
   companionHidden: () => boolean;
-  /** Which named size the companion surface is drawn at. */
-  companionSize: () => CompanionSize;
+  /** Which named size one axis of the companion surface is drawn at. */
+  companionSize: (axis: CompanionSizeAxis) => CompanionSize;
   dispatch: (command: VellumCommand) => void;
   featureEnabled: (flag: string) => boolean;
   getLockfile: () => Lockfile;
@@ -64,7 +69,7 @@ export interface TrayModelRuntime {
   openComponentGallery: () => void;
   removePairedLabel: string;
   setCompanionVisible: (visible: boolean) => void;
-  setCompanionSize: (size: CompanionSize) => void;
+  setCompanionSize: (axis: CompanionSizeAxis, size: CompanionSize) => void;
 }
 
 let runtime: TrayModelRuntime | null = null;
@@ -374,27 +379,30 @@ const buildTrayMenu = (
               trayRuntime.setCompanionVisible(item.checked);
             },
           },
-          {
-            // Named steps rather than a slider, because the avatar's box is not
-            // a style: the canvas, the pill's reach and the card's height are
-            // all derived from it, so a continuous scale would be a layout
-            // nobody had ever looked at. Radio items, since the sizes are one
-            // choice and the menu has to show which one is in effect.
-            //
-            // Disabled rather than hidden while the surface is hidden: the item
-            // says the size is still something the companion has, and an item
-            // that comes and goes with the checkbox above it reads as a bug.
-            label: "Companion Size",
+          // One submenu per axis: the creature and the controls beside it are
+          // sized separately, and a single picker could only ever move both.
+          //
+          // Named steps rather than a slider, because the avatar's box is not a
+          // style: the canvas, the pill's reach and the card's height are all
+          // derived from it, so a continuous scale would be a layout nobody had
+          // ever looked at. Radio items, since each axis is one choice and the
+          // menu has to show which step is in effect.
+          //
+          // Disabled rather than hidden while the surface is hidden: the items
+          // say the sizes are still something the companion has, and items that
+          // came and went with the checkbox above them would read as a bug.
+          ...COMPANION_SIZE_AXES.map((axis) => ({
+            label: COMPANION_SIZE_AXIS_LABELS[axis],
             enabled: !trayRuntime.companionHidden(),
             submenu: COMPANION_SIZES.map((size) => ({
               label: COMPANION_SIZE_LABELS[size],
               type: "radio" as const,
-              checked: trayRuntime.companionSize() === size,
+              checked: trayRuntime.companionSize(axis) === size,
               click: () => {
-                trayRuntime.setCompanionSize(size);
+                trayRuntime.setCompanionSize(axis, size);
               },
             })),
-          },
+          })),
         ]
       : []),
     { type: "separator" },

--- a/packages/electron-desktop/src/window-state.test.ts
+++ b/packages/electron-desktop/src/window-state.test.ts
@@ -13,6 +13,9 @@ let savedWindows: Record<string, SavedState> = {};
 let savedOnboardingActive: boolean | undefined = undefined;
 let savedCompanionHidden: boolean | undefined = undefined;
 let savedCompanionIntroSeen: boolean | undefined = undefined;
+let savedCompanionSize: unknown = undefined;
+let savedCompanionAvatarSize: unknown = undefined;
+let savedCompanionOptionsSize: unknown = undefined;
 let savedTitleBarOverlay: unknown = undefined;
 let workArea = { x: 0, y: 0, width: 1920, height: 1080 };
 const storeSetMock = mock((_key: string, _value: unknown) => {});
@@ -30,6 +33,11 @@ mock.module("electron-store", () => ({
       if (key === "companionHidden") return savedCompanionHidden ?? fallback;
       if (key === "companionIntroSeen")
         return savedCompanionIntroSeen ?? fallback;
+      if (key === "companionSize") return savedCompanionSize ?? fallback;
+      if (key === "companionAvatarSize")
+        return savedCompanionAvatarSize ?? fallback;
+      if (key === "companionOptionsSize")
+        return savedCompanionOptionsSize ?? fallback;
       if (key === "titleBarOverlay") return savedTitleBarOverlay ?? fallback;
       if (key === "windows") return savedWindows;
       return fallback;
@@ -55,10 +63,12 @@ const {
   track,
   readCompanionHidden,
   readCompanionIntroSeen,
+  readCompanionSize,
   readOnboardingActive,
   readTitleBarOverlayTheme,
   writeCompanionHidden,
   writeCompanionIntroSeen,
+  writeCompanionSize,
   writeOnboardingActive,
   writeTitleBarOverlayTheme,
 } = await import("./window-state");
@@ -89,6 +99,9 @@ beforeEach(() => {
   savedOnboardingActive = undefined;
   savedCompanionHidden = undefined;
   savedCompanionIntroSeen = undefined;
+  savedCompanionSize = undefined;
+  savedCompanionAvatarSize = undefined;
+  savedCompanionOptionsSize = undefined;
   savedTitleBarOverlay = undefined;
   workArea = { x: 0, y: 0, width: 1920, height: 1080 };
   storeSetMock.mockClear();
@@ -373,6 +386,94 @@ describe("companion surface visibility flag", () => {
 
     writeCompanionHidden(true);
     expect(storeSetMock).toHaveBeenCalledWith("companionHidden", true);
+  });
+});
+
+/**
+ * The two sizes the companion surface is drawn at, which are one choice each
+ * and share a set of steps.
+ *
+ * The file is JSON a user can edit and another build can have written, and the
+ * values index a table of geometry, so what is worth stating is that only a
+ * step this build knows ever reaches the window, and that an install carrying
+ * only the single size a one-axis build writes is not resized under its user.
+ */
+describe("companion surface sizes", () => {
+  test("absent keys default to the shipped size on both axes", () => {
+    expect(readCompanionSize("avatar")).toBe("medium");
+    expect(readCompanionSize("options")).toBe("medium");
+  });
+
+  test("each axis reads its own key", () => {
+    savedCompanionAvatarSize = "ridiculous";
+    savedCompanionOptionsSize = "small";
+    expect(readCompanionSize("avatar")).toBe("ridiculous");
+    expect(readCompanionSize("options")).toBe("small");
+  });
+
+  /**
+   * Nobody is resized by the second axis arriving. Someone who picked `huge`
+   * from a menu that offered one size meant the thing they were looking at, so
+   * they get `huge` on both rather than the default on either.
+   */
+  test("falls back to the one size a single-axis build writes", () => {
+    savedCompanionSize = "huge";
+    expect(readCompanionSize("avatar")).toBe("huge");
+    expect(readCompanionSize("options")).toBe("huge");
+  });
+
+  test("an axis's own key wins over that fallback", () => {
+    savedCompanionSize = "huge";
+    savedCompanionOptionsSize = "small";
+    expect(readCompanionSize("avatar")).toBe("huge");
+    expect(readCompanionSize("options")).toBe("small");
+  });
+
+  test("a value this build does not know never reaches the window", () => {
+    savedCompanionAvatarSize = "gigantic";
+    savedCompanionSize = "enormous";
+    expect(readCompanionSize("avatar")).toBe("medium");
+  });
+
+  test("an unknown axis key still finds the shared fallback", () => {
+    savedCompanionAvatarSize = "gigantic";
+    savedCompanionSize = "large";
+    expect(readCompanionSize("avatar")).toBe("large");
+  });
+
+  test("writing one axis leaves the other alone", () => {
+    writeCompanionSize("avatar", "ridiculous");
+    expect(storeSetMock).toHaveBeenCalledWith(
+      "companionAvatarSize",
+      "ridiculous",
+    );
+    expect(storeSetMock).not.toHaveBeenCalledWith(
+      "companionOptionsSize",
+      "ridiculous",
+    );
+  });
+
+  test("writing skips persisting when the effective value is unchanged", () => {
+    savedCompanionOptionsSize = "large";
+    writeCompanionSize("options", "large");
+    expect(storeSetMock).not.toHaveBeenCalled();
+
+    writeCompanionSize("options", "small");
+    expect(storeSetMock).toHaveBeenCalledWith("companionOptionsSize", "small");
+  });
+
+  /**
+   * The shared key is read and never written. Writing it would hand a build
+   * that reads only that key one axis's answer for both, and turn a user sizing
+   * the pill alone into one whose creature changed too.
+   */
+  test("never writes the key the single-axis build reads", () => {
+    savedCompanionSize = "small";
+    writeCompanionSize("avatar", "ridiculous");
+    writeCompanionSize("options", "huge");
+    expect(
+      storeSetMock.mock.calls.some(([key]) => key === "companionSize"),
+    ).toBe(false);
   });
 });
 

--- a/packages/electron-desktop/src/window-state.test.ts
+++ b/packages/electron-desktop/src/window-state.test.ts
@@ -33,11 +33,15 @@ mock.module("electron-store", () => ({
       if (key === "companionHidden") return savedCompanionHidden ?? fallback;
       if (key === "companionIntroSeen")
         return savedCompanionIntroSeen ?? fallback;
-      if (key === "companionSize") return savedCompanionSize ?? fallback;
-      if (key === "companionAvatarSize")
+      if (key === "companionSize") {
+        return savedCompanionSize ?? fallback;
+      }
+      if (key === "companionAvatarSize") {
         return savedCompanionAvatarSize ?? fallback;
-      if (key === "companionOptionsSize")
+      }
+      if (key === "companionOptionsSize") {
         return savedCompanionOptionsSize ?? fallback;
+      }
       if (key === "titleBarOverlay") return savedTitleBarOverlay ?? fallback;
       if (key === "windows") return savedWindows;
       return fallback;

--- a/packages/electron-desktop/src/window-state.ts
+++ b/packages/electron-desktop/src/window-state.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_COMPANION_SIZE,
   titleBarOverlayThemeSchema,
   type CompanionSize,
+  type CompanionSizeAxis,
   type TitleBarOverlayTheme,
 } from "@vellumai/ipc-contract";
 
@@ -41,10 +42,17 @@ interface StoreSchema {
   // before any renderer loads. Optional: absent means shown, so the flag
   // records only the opt-out (see `readCompanionHidden`).
   companionHidden?: boolean;
-  // Which named size the companion surface is drawn at. A main-process concern
-  // for the same reason the opt-out is: the window is built at a size derived
-  // from this before any renderer loads. Optional: absent means the default
-  // (see `readCompanionSize`).
+  // Which named size the companion's avatar is drawn at, and which its options
+  // pill is. A main-process concern for the same reason the opt-out is: the
+  // window is built at a canvas derived from both before any renderer loads.
+  // Optional: absent means whatever `readCompanionSize` falls back to.
+  companionAvatarSize?: CompanionSize;
+  companionOptionsSize?: CompanionSize;
+  // The single size a build with one size axis records for the whole surface.
+  // Read only: `readCompanionSize` falls back to it for an axis with nothing of
+  // its own, so an install carrying only this comes up at the size it chose on
+  // both axes. Nothing writes it, and it stays in the schema so a build that
+  // reads it still finds what it left.
   companionSize?: CompanionSize;
   // Whether the companion's one-time introduction has run. Held here rather
   // than in the surface's renderer because that renderer reloads, and a run
@@ -117,20 +125,39 @@ export const writeCompanionHidden = (hidden: boolean): void => {
   store().set("companionHidden", hidden);
 };
 
-/**
- * Which named size the companion surface is drawn at.
- *
- * Validated on the way out rather than trusted. This file is a JSON store a
- * user can edit and an older build can have written, and the value indexes a
- * table of geometry, and an unknown one would size the window from `undefined`
- * put a canvas of `NaN` on screen.
- */
-export const readCompanionSize = (): CompanionSize => {
-  const stored = store().get("companionSize");
-  return stored !== undefined && COMPANION_SIZES.includes(stored)
-    ? stored
-    : DEFAULT_COMPANION_SIZE;
+/** Where each axis keeps its own chosen size. */
+const COMPANION_SIZE_KEYS: Record<
+  CompanionSizeAxis,
+  "companionAvatarSize" | "companionOptionsSize"
+> = {
+  avatar: "companionAvatarSize",
+  options: "companionOptionsSize",
 };
+
+/**
+ * A stored value if it is a size this build knows, and `null` otherwise.
+ *
+ * Validated rather than trusted. This file is a JSON store a user can edit and
+ * another build can have written, and the value indexes a table of geometry: an
+ * unknown one would size the window from `undefined` and put a canvas of `NaN`
+ * on screen.
+ */
+const knownSize = (stored: CompanionSize | undefined): CompanionSize | null =>
+  stored !== undefined && COMPANION_SIZES.includes(stored) ? stored : null;
+
+/**
+ * Which named size one axis of the companion surface is drawn at.
+ *
+ * The axis's own key first, then the single size a build with one size axis
+ * writes, then the default. That middle step is what keeps an install from
+ * being resized under its user: someone who picked `huge` from a menu offering
+ * one size meant the thing they were looking at, so they get `huge` on both
+ * axes rather than the default on either.
+ */
+export const readCompanionSize = (axis: CompanionSizeAxis): CompanionSize =>
+  knownSize(store().get(COMPANION_SIZE_KEYS[axis])) ??
+  knownSize(store().get("companionSize")) ??
+  DEFAULT_COMPANION_SIZE;
 
 /**
  * Whether the companion's one-time introduction has already run.
@@ -156,12 +183,22 @@ export const writeCompanionIntroSeen = (): void => {
   store().set("companionIntroSeen", true);
 };
 
-/** Persist the companion's size. No-op when unchanged, as the opt-out is. */
-export const writeCompanionSize = (size: CompanionSize): void => {
-  if (readCompanionSize() === size) {
+/**
+ * Persist one axis's size. No-op when the effective value is unchanged, as the
+ * opt-out is.
+ *
+ * Only ever the axis's own key. Writing the shared one as well would hand a
+ * build that reads only that key one axis's answer for both, and turn a user
+ * sizing the pill alone into one whose avatar changed too.
+ */
+export const writeCompanionSize = (
+  axis: CompanionSizeAxis,
+  size: CompanionSize,
+): void => {
+  if (readCompanionSize(axis) === size) {
     return;
   }
-  store().set("companionSize", size);
+  store().set(COMPANION_SIZE_KEYS[axis], size);
 };
 
 /**

--- a/packages/ipc-contract/src/types.ts
+++ b/packages/ipc-contract/src/types.ts
@@ -783,6 +783,23 @@ export const COMPANION_SIZE_BOXES: Record<CompanionSize, number> = {
 export const DEFAULT_COMPANION_SIZE: CompanionSize = "medium";
 
 /**
+ * The two things on the surface a user sizes, sized separately.
+ *
+ * The creature and the controls beside it are one object to look at and two
+ * things to want at different sizes: an avatar big enough to read from across
+ * the room does not mean a pill that wide, and a pill sized for its labels does
+ * not mean a mascot that small. Both axes take the same five steps
+ * ({@link COMPANION_SIZES}), so there is one vocabulary and two answers rather
+ * than two scales to learn.
+ *
+ * `avatar` sizes the creature, its glow and its bob. `options` sizes the pill,
+ * the typing card, the call's body and the introduction's card.
+ */
+export const COMPANION_SIZE_AXES = ["avatar", "options"] as const;
+
+export type CompanionSizeAxis = (typeof COMPANION_SIZE_AXES)[number];
+
+/**
  * The avatar's box the companion's layout is authored at, and the size every
  * other length in that layout is stated in.
  *
@@ -792,24 +809,26 @@ export const DEFAULT_COMPANION_SIZE: CompanionSize = "medium";
  */
 export const COMPANION_BASE_AVATAR_BOX = COMPANION_SIZE_BOXES.small;
 
-/** Room the pill's shadow paints outside its box, at the base size. */
+/**
+ * Room the pill's shadow and the avatar's glow paint outside their own boxes,
+ * at the base size.
+ */
 export const COMPANION_BASE_CANVAS_PAD = 24;
 
 /**
- * How far the avatar's centre sits from the canvas edge the card does *not*
- * grow into: its own half-box, plus the shadow's room.
+ * The tallest the surface draws at the base size, which is the typing card.
  *
- * **The cross-process invariant.** Main places the window by it and the
- * renderer anchors the avatar by it, so the two agreeing is what makes the
- * avatar appear where the window was put. Derived once here rather than on each
- * side, because two copies of this formula drifting is the avatar drawn
- * somewhere other than where main believes it is.
+ * Every other state is a pill exactly {@link COMPANION_BASE_AVATAR_BOX} tall.
+ * The card stacks the conversation above that row in a viewport that scrolls
+ * once it is full, so it has a ceiling rather than growing with the exchange,
+ * and this is that ceiling rounded up: the card's text is laid out in the
+ * renderer, and a canvas a few points short clips the top of it off.
  *
- * The far edge is however far away the canvas is, which neither side has to
- * state: `100%` names the canvas in the renderer, and main sizes it.
+ * Matched to `CompanionSurface`'s card, and held here rather than beside the
+ * placement rules because {@link companionCardSideFor} sizes the canvas from
+ * it.
  */
-export const COMPANION_NEAR_EDGE =
-  COMPANION_BASE_AVATAR_BOX / 2 + COMPANION_BASE_CANVAS_PAD;
+export const COMPANION_BASE_CARD_HEIGHT = 290;
 
 /**
  * The room between the avatar's edge and the options pill beside it, at the
@@ -824,6 +843,15 @@ export const COMPANION_NEAR_EDGE =
 export const COMPANION_BASE_GAP = 12;
 
 /**
+ * The scale a box is drawn at: the box over the size the layout is authored at.
+ *
+ * The one conversion from points into the units every length on the surface is
+ * stated in, so neither side of the bridge divides by the base box on its own.
+ */
+export const companionScaleFor = (box: number): number =>
+  box / COMPANION_BASE_AVATAR_BOX;
+
+/**
  * That gap for a given pair of boxes.
  *
  * Scaled by the smaller of the two, because the gap is breathing room and the
@@ -832,7 +860,7 @@ export const COMPANION_BASE_GAP = 12;
  * chasm the pill's own scale would ask for.
  *
  * Derived here rather than on each side of the bridge, for the reason
- * {@link COMPANION_NEAR_EDGE} is: main sizes the canvas to hold the pill's
+ * {@link companionNearEdgeFor} is: main sizes the canvas to hold the pill's
  * reach past the avatar and the renderer positions the pill by the same
  * distance, so two copies of this drifting is a pill drawn somewhere main did
  * not leave room for.
@@ -843,6 +871,91 @@ export const companionGapFor = (
 ): number =>
   (COMPANION_BASE_GAP * Math.min(avatarBox, optionsBox)) /
   COMPANION_BASE_AVATAR_BOX;
+
+/**
+ * The room the canvas keeps outside everything drawn into it, for a given pair
+ * of boxes.
+ *
+ * The larger of the two scales, because the pad holds two overflows and either
+ * one can be the bigger: the pill's shadow grows with the options size and the
+ * avatar's glow with the avatar's. Sizing it from the smaller would clip
+ * whichever of the two the user made large.
+ */
+export const companionPadFor = (
+  avatarBox: number,
+  optionsBox: number,
+): number =>
+  COMPANION_BASE_CANVAS_PAD *
+  Math.max(companionScaleFor(avatarBox), companionScaleFor(optionsBox));
+
+/**
+ * How far the avatar's centre sits from the canvas edge the card does *not*
+ * grow into, for a given pair of boxes.
+ *
+ * **The cross-process invariant.** Main places the window by it and the
+ * renderer anchors the avatar by it, so the two agreeing is what makes the
+ * avatar appear where the window was put. Derived once here rather than on each
+ * side, because two copies of this formula drifting is the avatar drawn
+ * somewhere other than where main believes it is.
+ *
+ * What has to clear that edge depends on which way the card grows, because the
+ * pill's bottom edge is the avatar's: growing up, the near side holds the
+ * avatar's own half box and nothing else; growing down, the pill stands on that
+ * line and reaches a whole options box back past it, which pokes above a
+ * smaller creature. The larger of the two is taken so the answer is the same
+ * either way, since a flip moves the canvas rather than resizing it, and a near
+ * edge that changed with the direction would shift the avatar by the
+ * difference.
+ *
+ * The far edge is {@link companionCardSideFor}, which the renderer never has to
+ * state: `100%` names the canvas there, and main sizes it.
+ */
+export const companionNearEdgeFor = (
+  avatarBox: number,
+  optionsBox: number,
+): number =>
+  Math.max(avatarBox / 2, optionsBox - avatarBox / 2) +
+  companionPadFor(avatarBox, optionsBox);
+
+/**
+ * How far the avatar's centre sits from the canvas edge the card *does* grow
+ * into, for a given pair of boxes.
+ *
+ * The far half of {@link companionNearEdgeFor}, taken over both growths for the
+ * same reason. Growing up, the card stands on the avatar's bottom line and
+ * rises its whole height from there; growing down, its composer row holds that
+ * line and the rest of the card falls away below it. The avatar's own half box
+ * is the floor under both, for a creature taller than the card beside it.
+ */
+export const companionCardSideFor = (
+  avatarBox: number,
+  optionsBox: number,
+): number => {
+  const scale = companionScaleFor(optionsBox);
+  return (
+    Math.max(
+      COMPANION_BASE_CARD_HEIGHT * scale - avatarBox / 2,
+      (COMPANION_BASE_CARD_HEIGHT - COMPANION_BASE_AVATAR_BOX) * scale +
+        avatarBox / 2,
+      avatarBox / 2,
+    ) + companionPadFor(avatarBox, optionsBox)
+  );
+};
+
+/**
+ * The near edge at the size the surface's layout is authored at.
+ *
+ * {@link companionNearEdgeFor} with both boxes at the base, which is what that
+ * helper comes to whenever the two sizes agree. A name of its own because it is
+ * the distance the whole layout is authored around, and because a helper that
+ * stopped reducing to it would be one that had quietly moved the avatar.
+ *
+ * Anything whose answer moves with either size calls the helper instead.
+ */
+export const COMPANION_NEAR_EDGE = companionNearEdgeFor(
+  COMPANION_BASE_AVATAR_BOX,
+  COMPANION_BASE_AVATAR_BOX,
+);
 
 /**
  * The assistant's character, as the three trait ids it is composed from.
@@ -1031,14 +1144,22 @@ export interface CompanionSurfaceState {
    */
   cardGrowth: CompanionCardGrowth;
   /**
-   * The avatar's box in points, which is the whole of the surface's scale.
+   * The avatar's box in points, which is the creature's whole scale.
    *
-   * One number rather than the named size, because the name is a lookup both
-   * sides would then have to hold the same copy of. Everything the surface
-   * draws derives from this, so the renderer scales itself by this over the
-   * size the layout is authored at. See {@link COMPANION_SIZE_BOXES}.
+   * Numbers rather than the named sizes, because a name is a lookup both sides
+   * would then have to hold the same copy of. See {@link COMPANION_SIZE_BOXES},
+   * and {@link COMPANION_SIZE_AXES} for why there are two of them.
    */
   avatarBox: number;
+  /**
+   * The pill's box in points, which is the scale of everything that is not the
+   * creature: the pill, the typing card, the call's body and the introduction.
+   *
+   * The renderer draws the surface at this over the size its layout is authored
+   * at and scales the creature inside that by the ratio between the two boxes,
+   * so every length beside the avatar stays stated once, at the base size.
+   */
+  optionsBox: number;
   /**
    * The assistant's display name, for the composer's placeholder.
    *


### PR DESCRIPTION
## Summary
- Two persisted sizes, avatar and options, over the same five steps; existing installs keep their legacy size on both axes
- Right-click and tray menus gain Avatar size / Options size submenus
- Contract helpers derive the gap, pad, near edge and card side for any pair of boxes; the page scales by options and the avatar by its own ratio, staying bottom-flush beside the pill

Part of plan: companion-avatar-restyle.md (PR 3 of 3)