### PR TITLE
web: retry paired platform-id probes after a miss

### DIFF
--- a/clients/web/src/hooks/use-chooser-row-avatar.ts
+++ b/clients/web/src/hooks/use-chooser-row-avatar.ts
@@ -224,7 +224,10 @@ function usePlatformLookupId(
     queryKey: pairedPlatformIdQueryKey(row.id, row.runtimeUrl),
     queryFn: () => resolvePairedAssistantPlatformId(row.id),
     enabled: needsPairedResolve && hasPlatformSession,
-    staleTime: Infinity,
+    // A miss goes stale so a later mount or resume probes again.
+    staleTime: (query) =>
+      query.state.data ? Infinity : EMPTY_AVATAR_STALE_TIME_MS,
+    refetchOnWindowFocus: (query) => !query.state.data,
     retry: false,
   });
   if (row.platformAssistantId) {

--- a/clients/web/src/lib/paired-platform-identity.test.ts
+++ b/clients/web/src/lib/paired-platform-identity.test.ts
@@ -87,16 +87,24 @@ describe("resolvePairedAssistantPlatformId", () => {
     expect(updateLockfileAssistant).toHaveBeenCalledTimes(1);
   });
 
-  test("caches a miss so an unreachable daemon is not re-asked", async () => {
-    fetchPlatformStatus.mockResolvedValue(null);
+  test("a miss is not cached, so a recovered daemon is asked again", async () => {
+    fetchPlatformStatus.mockResolvedValueOnce(null);
     await expect(
       resolvePairedAssistantPlatformId("paired-remote"),
     ).resolves.toBeNull();
-    await expect(
-      resolvePairedAssistantPlatformId("paired-remote"),
-    ).resolves.toBeNull();
-    expect(fetchPlatformStatus).toHaveBeenCalledTimes(1);
     expect(updateLockfileAssistant).not.toHaveBeenCalled();
+    await expect(
+      resolvePairedAssistantPlatformId("paired-remote"),
+    ).resolves.toBe(UUID);
+    expect(fetchPlatformStatus).toHaveBeenCalledTimes(2);
+  });
+
+  test("concurrent asks share one in-flight probe", async () => {
+    await Promise.all([
+      resolvePairedAssistantPlatformId("paired-remote"),
+      resolvePairedAssistantPlatformId("paired-remote"),
+    ]);
+    expect(fetchPlatformStatus).toHaveBeenCalledTimes(1);
   });
 
   test("returns the persisted id without a daemon read", async () => {

--- a/clients/web/src/lib/paired-platform-identity.ts
+++ b/clients/web/src/lib/paired-platform-identity.ts
@@ -6,9 +6,10 @@ import {
 } from "@/lib/local-mode";
 
 /**
- * One attempt per paired target per session; a miss (unreachable,
- * unregistered) is cached too. Keyed by gateway URL as well as id so a
- * same-name re-pair to another gateway probes again.
+ * One resolved UUID per paired target per session. A miss (unreachable,
+ * not yet registered) is evicted so the next ask probes again. Keyed by
+ * gateway URL as well as id so a same-name re-pair to another gateway
+ * probes again.
  */
 const pairedPlatformIdCache = new Map<string, Promise<string | null>>();
 
@@ -39,7 +40,12 @@ export function resolvePairedAssistantPlatformId(
   if (cached) {
     return cached;
   }
-  const promise = fetchAndPersistPairedPlatformId(assistantId);
+  const promise = fetchAndPersistPairedPlatformId(assistantId).then((id) => {
+    if (id === null) {
+      pairedPlatformIdCache.delete(key);
+    }
+    return id;
+  });
   pairedPlatformIdCache.set(key, promise);
   return promise;
 }


### PR DESCRIPTION
## Summary
- The paired platform-id resolver no longer caches a null result; only resolved UUIDs stay cached for the session, and concurrent asks still share one in-flight probe.
- The chooser row's lookup query goes stale after a miss (60 s) and refetches on window focus, so an assistant that was unreachable or not yet registered gets its synced avatar on the next mount or resume.

Addresses the cycle-4 P2 on #41549.