### PR TITLE
fix(mcp): start MCP tools at medium risk and let annotations move them one step

### DIFF
--- a/assistant/src/__tests__/mcp-cli.test.ts
+++ b/assistant/src/__tests__/mcp-cli.test.ts
@@ -438,12 +438,34 @@ describe("assistant mcp add", () => {
     expect(stderr).toContain("--url is required");
   });
 
-  test("defaults risk to high", async () => {
+  test("sends no risk when --risk is omitted, leaving the config default", async () => {
     const { exitCode } = await runMcpAdd("default-risk", [
       "-t",
       "sse",
       "-u",
       "https://example.com/sse",
+    ]);
+    expect(exitCode).toBe(0);
+
+    const addCall = mockCliIpcCallFn.mock.calls.find(
+      (c) => c[0] === "internal_mcp_add",
+    );
+    expect(addCall).toBeDefined();
+    const body = (addCall![1] as Record<string, unknown>).body as Record<
+      string,
+      unknown
+    >;
+    expect(body.risk).toBeUndefined();
+  });
+
+  test("forwards an explicit --risk", async () => {
+    const { exitCode } = await runMcpAdd("explicit-risk", [
+      "-t",
+      "sse",
+      "-u",
+      "https://example.com/sse",
+      "-r",
+      "high",
     ]);
     expect(exitCode).toBe(0);
 

--- a/assistant/src/__tests__/mcp-tool-annotations-risk.test.ts
+++ b/assistant/src/__tests__/mcp-tool-annotations-risk.test.ts
@@ -40,60 +40,66 @@ function serverConfig(defaultRiskLevel: ServerRisk) {
   };
 }
 
-function toolWithAnnotations(readOnlyHint?: boolean) {
+interface RiskAnnotations {
+  readOnlyHint?: boolean;
+  destructiveHint?: boolean;
+}
+
+function toolWithAnnotations(annotations?: RiskAnnotations) {
   return {
     name: "get-summary",
     description: "Read a summary",
     inputSchema: { type: "object", properties: {} },
-    ...(readOnlyHint === undefined ? {} : { annotations: { readOnlyHint } }),
+    ...(annotations === undefined ? {} : { annotations }),
   };
 }
 
-describe("MCP tool risk from readOnlyHint annotations", () => {
+describe("MCP tool risk from annotations", () => {
   const fakeManager = { callTool: jest.fn() } as never;
 
-  test("readOnlyHint true on a medium-risk server lowers risk to Low", () => {
-    const tool = createMcpTool(
-      toolWithAnnotations(true),
-      "fathom",
-      serverConfig("medium"),
+  function riskFor(server: ServerRisk, annotations?: RiskAnnotations) {
+    return createMcpTool(
+      toolWithAnnotations(annotations),
+      "server",
+      serverConfig(server),
       fakeManager,
-    );
+    ).defaultRiskLevel;
+  }
 
-    expect(tool.defaultRiskLevel).toBe(RiskLevel.Low);
+  test("no annotations keeps the server level", () => {
+    expect(riskFor("low")).toBe(RiskLevel.Low);
+    expect(riskFor("medium")).toBe(RiskLevel.Medium);
+    expect(riskFor("high")).toBe(RiskLevel.High);
   });
 
-  test("readOnlyHint true on a high-risk server leaves risk at High", () => {
-    const tool = createMcpTool(
-      toolWithAnnotations(true),
-      "untrusted",
-      serverConfig("high"),
-      fakeManager,
-    );
-
-    expect(tool.defaultRiskLevel).toBe(RiskLevel.High);
+  test("readOnlyHint steps down one level", () => {
+    expect(riskFor("high", { readOnlyHint: true })).toBe(RiskLevel.Medium);
+    expect(riskFor("medium", { readOnlyHint: true })).toBe(RiskLevel.Low);
   });
 
-  test("missing annotations keeps the server default risk", () => {
-    const tool = createMcpTool(
-      toolWithAnnotations(undefined),
-      "fathom",
-      serverConfig("medium"),
-      fakeManager,
-    );
-
-    expect(tool.defaultRiskLevel).toBe(RiskLevel.Medium);
+  test("readOnlyHint cannot step below low", () => {
+    expect(riskFor("low", { readOnlyHint: true })).toBe(RiskLevel.Low);
   });
 
-  test("readOnlyHint false on a low-risk server keeps risk at Low", () => {
-    const tool = createMcpTool(
-      toolWithAnnotations(false),
-      "trusted",
-      serverConfig("low"),
-      fakeManager,
-    );
+  test("destructiveHint steps up one level", () => {
+    expect(riskFor("low", { destructiveHint: true })).toBe(RiskLevel.Medium);
+    expect(riskFor("medium", { destructiveHint: true })).toBe(RiskLevel.High);
+  });
 
-    expect(tool.defaultRiskLevel).toBe(RiskLevel.Low);
+  test("destructiveHint cannot step above high", () => {
+    expect(riskFor("high", { destructiveHint: true })).toBe(RiskLevel.High);
+  });
+
+  test("destructiveHint wins when a server sends both", () => {
+    expect(
+      riskFor("medium", { readOnlyHint: true, destructiveHint: true }),
+    ).toBe(RiskLevel.High);
+  });
+
+  test("hints set to false leave the server level alone", () => {
+    expect(
+      riskFor("medium", { readOnlyHint: false, destructiveHint: false }),
+    ).toBe(RiskLevel.Medium);
   });
 });
 

--- a/assistant/src/__tests__/mcp-tool-annotations-risk.test.ts
+++ b/assistant/src/__tests__/mcp-tool-annotations-risk.test.ts
@@ -72,9 +72,12 @@ describe("MCP tool risk from annotations", () => {
     expect(riskFor("high")).toBe(RiskLevel.High);
   });
 
-  test("readOnlyHint steps down one level", () => {
-    expect(riskFor("high", { readOnlyHint: true })).toBe(RiskLevel.Medium);
+  test("readOnlyHint steps down from the medium default", () => {
     expect(riskFor("medium", { readOnlyHint: true })).toBe(RiskLevel.Low);
+  });
+
+  test("readOnlyHint cannot lower a server the user pinned to high", () => {
+    expect(riskFor("high", { readOnlyHint: true })).toBe(RiskLevel.High);
   });
 
   test("readOnlyHint cannot step below low", () => {

--- a/assistant/src/cli/commands/mcp.help.ts
+++ b/assistant/src/cli/commands/mcp.help.ts
@@ -97,8 +97,8 @@ Examples:
         },
         {
           flags: "-r, --risk <level>",
-          description: "Default risk level: low, medium, or high",
-          defaultValue: "high",
+          description:
+            "Risk level tools from this server start at: low, medium, or high",
         },
       ],
       helpText: `
@@ -110,9 +110,10 @@ Transport-specific requirements:
   sse               Requires --url pointing to the SSE endpoint
   streamable-http   Requires --url pointing to the HTTP endpoint
 
-The --risk flag sets the default risk level for all tools from this server
-(defaults to "high" if not specified). The server starts enabled unless
---disabled is passed.
+The --risk flag sets the risk level tools from this server start at. Omit it
+and the server tracks the shipped default, "medium". A tool's own MCP
+annotations move it one step from there: destructiveHint up, readOnlyHint
+down. The server starts enabled unless --disabled is passed.
 
 The --header (-H) flag adds custom HTTP headers to sse/streamable-http
 transports. Use it for Bearer Token or API Key authentication. The flag

--- a/assistant/src/cli/commands/mcp.ts
+++ b/assistant/src/cli/commands/mcp.ts
@@ -195,7 +195,7 @@ export function registerMcpCommand(program: Command): void {
               url?: string;
               command?: string;
               args?: string[];
-              risk: string;
+              risk?: string;
               header: string[];
               disabled?: boolean;
             },

--- a/assistant/src/config/schemas/mcp.ts
+++ b/assistant/src/config/schemas/mcp.ts
@@ -1,5 +1,13 @@
 import { z } from "zod";
 
+/**
+ * Risk level an MCP server's tools start at when its config entry does not
+ * name one. Callers that write or display a server entry must reference this
+ * rather than repeating a literal, so the level stays code-owned: an entry
+ * that omits the field picks up whatever this constant says on every load.
+ */
+export const DEFAULT_MCP_RISK_LEVEL = "medium";
+
 const McpStdioTransportSchema = z
   .object({
     type: z.literal("stdio"),
@@ -66,7 +74,7 @@ export const McpServerConfigSchema = z
       .enum(["low", "medium", "high"], {
         error: "mcp server defaultRiskLevel must be one of: low, medium, high",
       })
-      .default("medium")
+      .default(DEFAULT_MCP_RISK_LEVEL)
       .describe(
         "Risk level tools from this server start at (affects approval requirements). A tool's own MCP annotations move it one step from here: destructiveHint up, readOnlyHint down.",
       ),

--- a/assistant/src/config/schemas/mcp.ts
+++ b/assistant/src/config/schemas/mcp.ts
@@ -66,9 +66,9 @@ export const McpServerConfigSchema = z
       .enum(["low", "medium", "high"], {
         error: "mcp server defaultRiskLevel must be one of: low, medium, high",
       })
-      .default("high")
+      .default("medium")
       .describe(
-        "Default risk level assigned to tools from this server (affects approval requirements)",
+        "Risk level tools from this server start at (affects approval requirements). A tool's own MCP annotations move it one step from here: destructiveHint up, readOnlyHint down.",
       ),
     maxTools: z
       .number({ error: "mcp server maxTools must be a number" })

--- a/assistant/src/runtime/routes/__tests__/mcp-add-default-risk.test.ts
+++ b/assistant/src/runtime/routes/__tests__/mcp-add-default-risk.test.ts
@@ -1,0 +1,87 @@
+/**
+ * `internal_mcp_add` must not freeze a risk level into the entry it writes.
+ *
+ * The shipped default lives in `McpServerConfigSchema`, which parses
+ * `config.json` on every load. An entry that carries no `defaultRiskLevel`
+ * therefore tracks that default; one that carries an explicit level keeps it.
+ * Writing a level the caller never asked for would pin every added server to
+ * whatever the default happened to be on the day it was added.
+ */
+
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { McpServerConfigSchema } from "../../../config/schemas/mcp.js";
+import { BadRequestError } from "../errors.js";
+
+let raw: Record<string, unknown> = {};
+let saved: Record<string, unknown> | undefined;
+
+const actualLoader = await import("../../../config/loader.js");
+mock.module("../../../config/loader.js", () => ({
+  ...actualLoader,
+  loadRawConfig: () => raw,
+  saveRawConfig: (next: Record<string, unknown>) => {
+    saved = next;
+  },
+}));
+
+mock.module("../../../daemon/mcp-reload-service.js", () => ({
+  reloadMcpServers: async () => {},
+}));
+
+const { ROUTES } = await import("../mcp-auth-routes.js");
+
+const addRoute = ROUTES.find((r) => r.operationId === "internal_mcp_add")!;
+
+function addedEntry(): Record<string, unknown> {
+  const mcp = saved?.mcp as { servers: Record<string, unknown> };
+  return mcp.servers["srv"] as Record<string, unknown>;
+}
+
+describe("internal_mcp_add risk level", () => {
+  beforeEach(() => {
+    raw = {};
+    saved = undefined;
+  });
+
+  test("omits defaultRiskLevel when the caller names no risk", async () => {
+    await addRoute.handler({
+      body: {
+        name: "srv",
+        transportType: "streamable-http",
+        url: "https://example.com/mcp",
+      },
+    });
+
+    const entry = addedEntry();
+    expect(entry).not.toHaveProperty("defaultRiskLevel");
+    expect(McpServerConfigSchema.parse(entry).defaultRiskLevel).toBe("medium");
+  });
+
+  test("persists an explicit risk level", async () => {
+    await addRoute.handler({
+      body: {
+        name: "srv",
+        transportType: "streamable-http",
+        url: "https://example.com/mcp",
+        risk: "high",
+      },
+    });
+
+    expect(addedEntry().defaultRiskLevel).toBe("high");
+  });
+
+  test("rejects an unknown risk level", async () => {
+    await expect(
+      addRoute.handler({
+        body: {
+          name: "srv",
+          transportType: "streamable-http",
+          url: "https://example.com/mcp",
+          risk: "extreme",
+        },
+      }),
+    ).rejects.toThrow(BadRequestError);
+    expect(saved).toBeUndefined();
+  });
+});

--- a/assistant/src/runtime/routes/mcp-auth-routes.ts
+++ b/assistant/src/runtime/routes/mcp-auth-routes.ts
@@ -15,7 +15,11 @@
 import { z } from "zod";
 
 import { loadRawConfig, saveRawConfig } from "../../config/loader.js";
-import type { McpConfig, McpServerConfig } from "../../config/schemas/mcp.js";
+import {
+  DEFAULT_MCP_RISK_LEVEL,
+  type McpConfig,
+  type McpServerConfig,
+} from "../../config/schemas/mcp.js";
 import { estimateToolDefinitionTokens } from "../../context/token-estimator.js";
 import { reloadMcpServers } from "../../daemon/mcp-reload-service.js";
 import { McpClient } from "../../mcp/client.js";
@@ -312,7 +316,7 @@ async function handleMcpList(_args: {
         status,
         transport: safeTransport as McpServerEntry["transport"],
         enabled,
-        defaultRiskLevel: config.defaultRiskLevel ?? "high",
+        defaultRiskLevel: config.defaultRiskLevel ?? DEFAULT_MCP_RISK_LEVEL,
         hasOAuth,
         hasStaticAuth,
         authType,
@@ -551,10 +555,9 @@ async function handleMcpAdd({
   const { name, transportType, url, command, args, risk, disabled, headers } =
     parseBody(McpAddParams, body);
 
-  const riskLevel = risk ?? "high";
-  if (!["low", "medium", "high"].includes(riskLevel)) {
+  if (risk !== undefined && !["low", "medium", "high"].includes(risk)) {
     throw new BadRequestError(
-      `Invalid risk level: ${riskLevel}. Must be low, medium, or high`,
+      `Invalid risk level: ${risk}. Must be low, medium, or high`,
     );
   }
 
@@ -597,10 +600,13 @@ async function handleMcpAdd({
     );
   }
 
+  // Writing no `defaultRiskLevel` when the caller named none leaves the level
+  // to `McpServerConfigSchema`, so the entry tracks the shipped default
+  // instead of freezing whichever level was current on the day it was added.
   serverMap[name] = {
     transport,
     enabled: !disabled,
-    defaultRiskLevel: riskLevel,
+    ...(risk === undefined ? {} : { defaultRiskLevel: risk }),
   };
 
   // Store auth headers in credential store, not config

--- a/assistant/src/tools/mcp/mcp-tool-factory.ts
+++ b/assistant/src/tools/mcp/mcp-tool-factory.ts
@@ -46,17 +46,28 @@ function stepRisk(risk: RiskLevel, direction: -1 | 1): RiskLevel {
 /**
  * Resolve the risk level a tool carries.
  *
- * The server's configured level is the anchor. A tool's MCP annotations then
- * move it at most one step along {@link RISK_LADDER}:
+ * The server's configured level is the anchor, and a tool's own MCP
+ * annotations move it at most one step along {@link RISK_LADDER}.
  *
- * - `destructiveHint` steps up. Raising is the safe direction, so it applies
- *   whatever the server is set to.
- * - `readOnlyHint` steps down, and only one step. The hint is self-reported by
- *   the server, so a single step keeps a false claim from carrying a tool from
- *   the high ceiling all the way to auto-approval.
+ * `destructiveHint` steps up. Raising is the safe direction, so it applies at
+ * any server level.
+ *
+ * `readOnlyHint` steps down, and only from {@link RiskLevel.Medium}. Medium is
+ * the schema default, so a server sitting at High got there because the user
+ * put it there. A hint is self-reported by the server, and letting one lower a
+ * deliberately pinned server would hand a lying server the auto-approval the
+ * user withheld: under the Relaxed preset Medium carries no prompt at all. High
+ * is therefore the floor for downward hints.
  *
  * `destructiveHint` wins when a server sends both, since a tool that both reads
  * and destroys is a tool that destroys.
+ *
+ * The MCP spec defaults `destructiveHint` to true when it is absent. This
+ * deliberately does not, because the server's configured level already answers
+ * that question: choosing a level for a server is the user's statement about
+ * what its unlabeled tools are worth. Honoring the spec default instead would
+ * put every tool of every unannotated server back at High, which is the
+ * behavior this replaces.
  */
 function resolveRiskLevel(
   metadata: McpToolMetadata,
@@ -67,7 +78,7 @@ function resolveRiskLevel(
   if (annotations?.destructiveHint === true) {
     return stepRisk(serverRisk, 1);
   }
-  if (annotations?.readOnlyHint === true) {
+  if (annotations?.readOnlyHint === true && serverRisk === RiskLevel.Medium) {
     return stepRisk(serverRisk, -1);
   }
   return serverRisk;

--- a/assistant/src/tools/mcp/mcp-tool-factory.ts
+++ b/assistant/src/tools/mcp/mcp-tool-factory.ts
@@ -27,24 +27,48 @@ export interface McpToolMetadata {
   annotations?: McpToolAnnotations;
 }
 
+/** Risk levels ordered low to high, so a hint can step one place along it. */
+const RISK_LADDER: readonly RiskLevel[] = [
+  RiskLevel.Low,
+  RiskLevel.Medium,
+  RiskLevel.High,
+];
+
+function stepRisk(risk: RiskLevel, direction: -1 | 1): RiskLevel {
+  const index = RISK_LADDER.indexOf(risk);
+  if (index === -1) {
+    return risk;
+  }
+  const next = Math.min(Math.max(index + direction, 0), RISK_LADDER.length - 1);
+  return RISK_LADDER[next] ?? risk;
+}
+
 /**
  * Resolve the risk level a tool carries.
  *
- * `readOnlyHint` is self-reported by the server, so it only refines risk
- * downward and only for servers the user has already configured below the
- * high-trust ceiling. Servers left at the default "high" are unaffected, and
- * the hint never raises risk above the server default.
+ * The server's configured level is the anchor. A tool's MCP annotations then
+ * move it at most one step along {@link RISK_LADDER}:
+ *
+ * - `destructiveHint` steps up. Raising is the safe direction, so it applies
+ *   whatever the server is set to.
+ * - `readOnlyHint` steps down, and only one step. The hint is self-reported by
+ *   the server, so a single step keeps a false claim from carrying a tool from
+ *   the high ceiling all the way to auto-approval.
+ *
+ * `destructiveHint` wins when a server sends both, since a tool that both reads
+ * and destroys is a tool that destroys.
  */
 function resolveRiskLevel(
   metadata: McpToolMetadata,
   serverConfig: McpServerConfig,
 ): RiskLevel {
   const serverRisk = riskMap[serverConfig.defaultRiskLevel] ?? RiskLevel.High;
-  if (
-    metadata.annotations?.readOnlyHint === true &&
-    serverRisk !== RiskLevel.High
-  ) {
-    return RiskLevel.Low;
+  const annotations = metadata.annotations;
+  if (annotations?.destructiveHint === true) {
+    return stepRisk(serverRisk, 1);
+  }
+  if (annotations?.readOnlyHint === true) {
+    return stepRisk(serverRisk, -1);
   }
   return serverRisk;
 }

--- a/skills/catalog.json
+++ b/skills/catalog.json
@@ -184,7 +184,7 @@
         }
       },
       "compatibility": "Designed for Vellum personal assistants",
-      "updatedAt": "2026-08-26T15:06:39.000Z"
+      "updatedAt": "2026-08-26T16:13:57.000Z"
     },
     {
       "id": "doordash",
@@ -578,7 +578,7 @@
         }
       },
       "compatibility": "Works on both the Vellum desktop app (local daemon) and the Vellum web app (platform-hosted). Auth flow differs by environment.",
-      "updatedAt": "2026-06-12T18:05:36.000Z"
+      "updatedAt": "2026-08-27T04:08:20.000Z"
     },
     {
       "id": "meme-generator",
@@ -1356,7 +1356,7 @@
           ]
         }
       },
-      "updatedAt": "2026-08-26T00:47:45.000Z"
+      "updatedAt": "2026-08-26T23:11:05.000Z"
     },
     {
       "id": "watcher",

--- a/skills/mcp-setup/SKILL.md
+++ b/skills/mcp-setup/SKILL.md
@@ -113,7 +113,7 @@ Transport types:
 - `sse` — legacy remote servers
 - `stdio` — local process: use `-c <command>` and `-a <args...>` instead of `-u`
 
-Risk level (`-r`) controls approval prompts per tool call — `low` auto-approves, `high` always prompts (default: `high`).
+Risk level (`-r`) controls approval prompts per tool call: `low` auto-approves, `high` always prompts. Omit it and the server starts at `medium`, and a tool's own MCP annotations move it one step from there (`destructiveHint` up, `readOnlyHint` down).
 
 Examples:
 


### PR DESCRIPTION
Part of JARVIS-1631.

## The problem, from production data

Last 14 days, staff excluded, from `vellum-ai-prod.analytics.stg_telemetry__lifecycle`:

| tool | prompts | executions | prompt rate |
|---|---|---|---|
| mcp__lightpage__read_entry | 37 | 37 | **100%** |
| mcp__plaud__get_note | 45 | 46 | **97.8%** |
| mcp__unstructured-transform__check_job_status | 47 | 49 | **95.9%** |
| mcp__composio__COMPOSIO_MULTI_EXECUTE_TOOL | 68 | 76 | **89.5%** |
| mcp__cloudflare__execute | 37 | 79 | 46.8% |
| (for contrast) bash | 1351 | 354,000 | 0.38% |

MCP tools prompt on essentially every call. `bash` and `file_edit`, which are far more consequential, prompt on well under 1% of theirs.

The cause is a config default, not a bug in matching. Every MCP server starts at `defaultRiskLevel: "high"`, and nobody changes it. High auto-approves only under Full access, so every other preset prompts every time. `readOnlyHint` could have helped, but `resolveRiskLevel` only honored it when the server was *already* below high, so on a default install it never fired.

## The change

- `defaultRiskLevel` now defaults to `medium`. Relaxed auto-approves; Cautious still prompts.
- A tool's own MCP annotations move it one step from the server level: `destructiveHint` up, `readOnlyHint` down. `destructiveHint` wins when a server sends both.

So on a default install: an unannotated MCP tool is medium, a read-only one is low, and a destructive one is high.

## Security reasoning

Annotations are self-reported by the server, which is exactly the concern in **ATL-1240** (`readOnlyHint` can downgrade untrusted tool risk). Two properties contain it:

1. **The downgrade only applies from medium.** Medium is the new default, so a server sitting at high got there because the user pinned it. A `readOnlyHint` cannot move it: high is the floor for downward hints. Without that floor a lying server would win the auto-approval the user withheld, since medium carries no prompt under Relaxed.
2. **The upgrade is not capped by trust, because raising risk is the safe direction.** `destructiveHint` is honored wherever it appears.

This also slightly improves **ATL-1296** (plugin MCP tools auto-approved as low): a plugin server's tools still start at low, but a `destructiveHint` now lifts them to medium instead of being ignored.

@dvargasfuertes please review the risk change specifically. The security-relevant lines are `resolveRiskLevel` in `assistant/src/tools/mcp/mcp-tool-factory.ts` and the schema default in `assistant/src/config/schemas/mcp.ts`.

## Backwards compatibility

No migration needed. `defaultRiskLevel` is code-owned: it is parsed from `config.json` on every load through `McpServerConfigSchema` and never persisted as a resolved snapshot. Existing installs that never set the field pick up `medium` on upgrade, which is the intent. An install whose `config.json` does carry an explicit `"high"` keeps it.

## Tests

`assistant/src/__tests__/mcp-tool-annotations-risk.test.ts` covers every branch: no annotations at each server level, one step down, the floor at low, one step up, the ceiling at high, `destructiveHint` winning over `readOnlyHint`, and hints set to `false` changing nothing. 8 pass. `typecheck:fast` and `lint` clean.

## Out of scope

Trust rules still do not apply to MCP tools at all (JARVIS-1543), so an Allow decision on an MCP prompt buys nothing on the next call. That is tracked separately and is the other half of why these numbers are so high.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/vellum-ai/vellum-assistant/pull/41555" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

---

## Annotation audit: how well do real servers label their tools?

Live `tools/list` against each server (catalog read only, no tool was invoked).

| Server | Tools | `readOnlyHint` true | `destructiveHint` true | Verdict |
|---|---|---|---|---|
| **Linear** | 65 | 37 | 23 | Best labeled. Every `delete_*`, every mutating `save_*`, and `merge_diff` flag destructive; all 37 `get_*`/`list_*` flag read-only. Errs safe: `save_*` is destructive even when creating. |
| **Notion** | 28 | 14 | 3 | All 14 reads correctly flagged. No delete tool exists. Two under-flags: `notion-update-view` and `notion-move-pages` mutate in place but are `destructive:false`, so they stay at medium. |
| **Slack** | 19 | 12 | **1** | All 12 reads correct. But only `slack_update_canvas` flags destructive, so `slack_send_message`, `slack_schedule_message`, and `slack_create_conversation` stay at medium. Spec-correct (a send is additive, not destructive), but see below. |
| **Fathom** | — | — | — | Not assessed: not authenticated on this machine, and the vendor docs publish no tool list. Treat as unlabeled. |

**Known gap, flagged deliberately.** `destructiveHint` does not model irreversible *outbound* actions, so a Slack send lands at medium and goes ungated under Relaxed. This matches how the core `messaging_send` tool is already classified, so it is not a regression introduced here, but a hint alone will never catch it. Worth its own rule; not in this PR.

## Why this diverges from the MCP spec default

The spec defaults `destructiveHint` to `true` when absent. This code does not apply that default: honoring it would put every tool of every unannotated server back at High, which is exactly the behavior being replaced. The server's configured level already answers the question, since choosing a level for a server is the user's statement about what its unlabeled tools are worth.
